### PR TITLE
Fix Linux release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         node_version: [16.x]
-        os: [macos-latest]
+        os: [macos-latest, ubuntu-latest]
 
     steps:
       - name: Checkout git repo
@@ -28,12 +28,11 @@ jobs:
       - name: Install and build
         run: |
           npm install
-          npm run postinstall
           npm run build
 
-      - name: Publish releases
+      - name: Publish releases - Windows and MacOS
         # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
-        if: ${{ startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
+        if: ${{ matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
         env:
           # These values are used for auto updates signing
           # APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -43,4 +42,15 @@ jobs:
           # This is used for uploading release assets to github
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npm exec electron-builder -- --publish always --win --mac --linux
+          npm exec electron-builder -- --publish always --win --mac
+
+      - name: Publish releases - Linux
+        # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
+        if: ${{ matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
+        env:
+          # no hardlinks so dependencies are copied
+          USE_HARD_LINKS: false
+          # This is used for uploading release assets to github
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm exec electron-builder -- --publish always --linux

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: npm test
         env:
+          # no hardlinks so dependencies are copied
+          USE_HARD_LINKS: false
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm run package

--- a/README.md
+++ b/README.md
@@ -20,7 +20,25 @@ Backend webserver/extension host and frontend Electron client for Paranext
 
 This software is not yet ready for users. We'll update here with where you can install it when its ready.
 
+### Linux Users
+
+To use `.AppImage` files in Linux, [install FUSE](https://github.com/AppImage/AppImageKit/wiki/FUSE) (you only need to do this once), for example, on Ubuntu (>= 22.04):
+
+```bash
+sudo apt install libfuse2
+```
+
+Then simply [execute/run](https://github.com/AppImage/AppImageKit/wiki) the `.AppImage` file, which you can download from [Releases](releases).
+
 ## Developer Install
+
+Set up pre-requisites for building:
+
+### Linux Development Pre-requisites
+
+Add the system libraries needed for Electron, [Build Instructions (Linux)](https://www.electronjs.org/docs/latest/development/build-instructions-linux).
+
+### Cloning and installing dependencies (all platforms)
 
 Clone the repo and install dependencies:
 
@@ -61,17 +79,13 @@ npm run package
 8. Once the GitHub build **Action** has finished, it will add build artifact files to the draft release. Remove the `.blockmap` files and leave the `.yml` files and the installers and executable, e.g. `.exe` on Windows.
 9. Publish the release on GitHub.
 
-## Linux Development
-
-Add the system libraries needed for Electron, [Build Instructions (Linux)](https://www.electronjs.org/docs/latest/development/build-instructions-linux).
-
 ## Windows Development with WSL2
 
 On Windows, you can install [WSL](https://learn.microsoft.com/en-us/windows/wsl/) (Windows Subsystem for Linux) so you can test cross-platform compatibility on Linux (as well as Windows). You'll need to use a Linux distribution with WSL2 (rather than WSL1) so the X-Server windows can be opened for Electron.
 
 1. Here is how to [install Linux on Windows with WSL](https://learn.microsoft.com/en-us/windows/wsl/install).
 2. You'll want to follow that by setting up to use **VS Code**, **Git** and **NodeJS** with WSL. See the various [tutorials](https://learn.microsoft.com/en-us/windows/wsl/setup/environment).
-3. In the WSL distribution, add system libraries needed for Electron, see [Linux Development](#linux-development) above.
+3. In the WSL distribution, add system libraries needed for Electron, see [Linux Development Pre-requisites](#linux-development-pre-requisites) above.
 4. In the WSL distribution, clone the repo as described above under [Developer Install](#developer-install).
 
 You'll be running a copy of the repo in both Windows and WSL so make sure they are both up-to-date.

--- a/package.json
+++ b/package.json
@@ -231,6 +231,264 @@
       "target": [
         "AppImage"
       ],
+      "extraFiles": [
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libnss3.so",
+          "to": "usr/lib/libnss3.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libnssutil3.so",
+          "to": "usr/lib/libnssutil3.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libsmime3.so",
+          "to": "usr/lib/libsmime3.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libssl3.so",
+          "to": "usr/lib/libssl3.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/nss/libfreebl3.so",
+          "to": "usr/lib/nss/libfreebl3.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/nss/libfreeblpriv3.so",
+          "to": "usr/lib/nss/libfreeblpriv3.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/nss/libnssckbi.so",
+          "to": "usr/lib/nss/libnssckbi.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/nss/libnssdbm3.so",
+          "to": "usr/lib/nss/libnssdbm3.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/nss/libsoftokn3.so",
+          "to": "usr/lib/nss/libsoftokn3.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libnspr4.so",
+          "to": "usr/lib/libnspr4.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libplc4.so",
+          "to": "usr/lib/libplc4.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libplds4.so",
+          "to": "usr/lib/libplds4.so"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libasound.so.2",
+          "to": "usr/lib/libasound.so.2"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libgbm.so.1",
+          "to": "usr/lib/libgbm.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libwayland-server.so.0",
+          "to": "usr/lib/libwayland-server.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libexpat.so.1",
+          "to": "usr/lib/libexpat.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libGL.so.1",
+          "to": "usr/lib/libGL.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libGLdispatch.so.0",
+          "to": "usr/lib/libGLdispatch.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libGLX.so.0",
+          "to": "usr/lib/libGLX.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libGLX_mesa.so.0",
+          "to": "usr/lib/libGLX_mesa.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libgtk-3.so.0",
+          "to": "usr/lib/libgtk-3.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libatk-1.0.so.0",
+          "to": "usr/lib/libatk-1.0.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0",
+          "to": "usr/lib/libatk-bridge-2.0.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libatspi.so.0",
+          "to": "usr/lib/libatspi.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libcups.so.2",
+          "to": "usr/lib/libcups.so.2"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libavahi-common.so.3",
+          "to": "usr/lib/libavahi-common.so.3"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libavahi-client.so.3",
+          "to": "usr/lib/libavahi-client.so.3"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libpango-1.0.so.0",
+          "to": "usr/lib/libpango-1.0.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libcairo.so.2",
+          "to": "usr/lib/libcairo.so.2"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libXcomposite.so.1",
+          "to": "usr/lib/libXcomposite.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libXdamage.so.1",
+          "to": "usr/lib/libXdamage.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libXfixes.so.3",
+          "to": "usr/lib/libXfixes.so.3"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libXrandr.so.2",
+          "to": "usr/lib/libXrandr.so.2"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libxkbcommon.so.0",
+          "to": "usr/lib/libxkbcommon.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libgdk-3.so.0",
+          "to": "usr/lib/libgdk-3.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0",
+          "to": "usr/lib/libpangocairo-1.0.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libXi.so.6",
+          "to": "usr/lib/libXi.so.6"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libcairo-gobject.so.2",
+          "to": "usr/lib/libcairo-gobject.so.2"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0",
+          "to": "usr/lib/libgdk_pixbuf-2.0.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libepoxy.so.0",
+          "to": "usr/lib/libepoxy.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0",
+          "to": "usr/lib/libpangoft2-1.0.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libharfbuzz.so.0",
+          "to": "usr/lib/libharfbuzz.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libfontconfig.so.1",
+          "to": "usr/lib/libfontconfig.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libthai.so.0",
+          "to": "usr/lib/libthai.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libpixman-1.so.0",
+          "to": "usr/lib/libpixman-1.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libfreetype.so.6",
+          "to": "usr/lib/libfreetype.so.6"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libxcb.so.1",
+          "to": "usr/lib/libxcb.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libxcb-shm.so.0",
+          "to": "usr/lib/libxcb-shm.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libxcb-render.so.0",
+          "to": "usr/lib/libxcb-render.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libXrender.so.1",
+          "to": "usr/lib/libXrender.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libXinerama.so.1",
+          "to": "usr/lib/libXinerama.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libXcursor.so.1",
+          "to": "usr/lib/libXcursor.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libwayland-cursor.so.0",
+          "to": "usr/lib/libwayland-cursor.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libwayland-egl.so.1",
+          "to": "usr/lib/libwayland-egl.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libwayland-client.so.0",
+          "to": "usr/lib/libwayland-client.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libjpeg.so.8",
+          "to": "usr/lib/libjpeg.so.8"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libgraphite2.so.3",
+          "to": "usr/lib/libgraphite2.so.3"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libdatrie.so.1",
+          "to": "usr/lib/libdatrie.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libX11-xcb.so.1",
+          "to": "usr/lib/libX11-xcb.so.1"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libdl.so.2",
+          "to": "usr/lib/libdl.so.2"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libpthread.so.0",
+          "to": "usr/lib/libpthread.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0",
+          "to": "usr/lib/libglib-2.0.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0",
+          "to": "usr/lib/libgobject-2.0.so.0"
+        },
+        {
+          "from": "/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0",
+          "to": "usr/lib/libgio-2.0.so.0"
+        }
+      ],
       "category": "Development"
     },
     "directories": {


### PR DESCRIPTION
- add missing packages for Linux, 64 found so far
- similar to `sudo apt install libnss3 libasound2 libgbm1 libgl1 libgtk-3-0`
- this takes the `.AppImage` file from 87 MB to 98 MB

Fix GHA build
- on Linux, use no hardlinks so source dependency *.so files are copied to the build (rather than linked)

Separate Linux release
- since it needs .so files (not available on MacOS)