### PR TITLE
Fix production logger

### DIFF
--- a/.erb/configs/webpack.config.base.ts
+++ b/.erb/configs/webpack.config.base.ts
@@ -87,7 +87,8 @@ const configuration: webpack.Configuration = {
           default: // main
             exclude =
               resource.startsWith('@renderer') ||
-              /renderer\//.test(resource) ||
+              (/renderer\//.test(resource) &&
+                !resource.includes('electron-log-preload')) ||
               resource.startsWith('@extension-host') ||
               resource.includes('extension-host/') ||
               resource.startsWith('@client') ||


### PR DESCRIPTION
- allow `../renderer/electron-log-preload.js` to be bundled

There is probably a more generic way to do this but I don't know what that should be so for now this is fixing the immediate issue. One generic option might be `(/renderer\//.test(resource) && (resource.startsWith('./') || resource.startsWith('../')))` but there could be other issues like a developer might use a backslash or start with something else and backup or forward to a location that would effectively be in the renderer.