### PR TITLE
Fix eslint running "forever"

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -32,3 +32,5 @@ npm-debug.log.*
 # https://github.com/eslint/eslint/issues/8429
 !.erb
 !.storybook
+
+storybook-static


### PR DESCRIPTION
- ignore storybook JS bundles

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/127)
<!-- Reviewable:end -->
