### PR TITLE
Add  hoisting ESLint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,9 @@ module.exports = {
     'erb',
     // https://github.com/storybookjs/eslint-plugin-storybook/blob/main/lib/configs/recommended.ts
     'plugin:storybook/recommended',
+    // Make sure this is last so it gets the chance to override other configs.
+    // See https://github.com/prettier/eslint-config-prettier and https://github.com/prettier/eslint-plugin-prettier
+    'plugin:prettier/recommended',
   ],
 
   rules: {
@@ -22,6 +25,9 @@ module.exports = {
 
     // #region Paranext rules
 
+    // Rules in each section are generally in alphabetical order. However, several
+    // `@typescript-eslint` rules require disabling the equivalent ESLint rule. So in these cases
+    // each ESLint rule is turned off immediately above the corresponding `@typescript-eslint` rule.
     'lines-between-class-members': 'off',
     '@typescript-eslint/lines-between-class-members': [
       'error',
@@ -35,6 +41,11 @@ module.exports = {
     '@typescript-eslint/no-redeclare': 'error',
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': 'error',
+    'no-use-before-define': 'off',
+    '@typescript-eslint/no-use-before-define': [
+      'error',
+      { functions: false, allowNamedExports: true, typedefs: false, ignoreTypeReferences: true },
+    ],
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'error',
     'comma-dangle': ['error', 'always-multiline'],
@@ -48,7 +59,6 @@ module.exports = {
     // Should use our logger anytime you want logs that persist. Otherwise use console only in testing
     'no-console': 'warn',
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
-    'no-use-before-define': 'off',
     'prettier/prettier': ['warn', { tabWidth: 2, trailingComma: 'all' }],
     'react/jsx-indent-props': ['warn', 2],
     'react/jsx-props-no-spreading': ['error', { custom: 'ignore' }],


### PR DESCRIPTION
- enable `@typescript-eslint/no-use-before-define` with some safe exceptions, e.g. it's always safe to call a function before its declaration since that will always be hoisted above the call
- also re-add `plugin:prettier/recommended` config overrides since we have another `extends` item for storybook

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/131)
<!-- Reviewable:end -->
