### PR TITLE
Misc cleanup

### DIFF
--- a/extensions/quick-verse/manifest.json
+++ b/extensions/quick-verse/manifest.json
@@ -5,6 +5,5 @@
   "author": "TJ Couch",
   "license": "MIT",
   "main": "quick-verse.js",
-  "activationEvents": [
-  ]
+  "activationEvents": []
 }

--- a/src/__tests__/app.component.test.tsx
+++ b/src/__tests__/app.component.test.tsx
@@ -20,7 +20,7 @@ jest.mock('@shared/services/network.service', () => ({
   createNetworkEventEmitter: () => {
     return new PapiEventEmitter();
   },
-  papiExports: {
+  papiNetworkService: {
     createNetworkEventEmitter: () => {
       return new PapiEventEmitter();
     },

--- a/src/node/polyfills/local-storage.polyfill.ts
+++ b/src/node/polyfills/local-storage.polyfill.ts
@@ -3,8 +3,7 @@ import { LocalStorage } from 'node-localstorage';
 import path from 'path';
 
 /**
- * Polyfills LocalStorage into node so you can use localstorage just like in browser
- * @param isPackaged whether or not the app is packaged for production
+ * Polyfills LocalStorage into node so you can use localstorage just like in a browser
  */
 const polyfillLocalStorage = () => {
   if (typeof localStorage === 'undefined' || localStorage === null) {

--- a/src/renderer/hooks/papi-hooks/use-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-data.hook.ts
@@ -70,7 +70,7 @@ function useData<TSelector, TGetData, TSetData>(
   // Indicates if the data with the selector is awaiting retrieval from the data provider
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
-  // Wrap subscribe so we can call it as a normal PEvent in useEvent
+  // Wrap subscribe so we can call it as a normal PapiEvent in useEvent
   const wrappedSubscribeEvent: PapiEventAsync<TGetData> | undefined = useMemo(
     () =>
       dataProvider

--- a/src/renderer/hooks/papi-hooks/use-event-async.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-event-async.hook.ts
@@ -10,7 +10,7 @@ const noopUnsubscriber = () => false;
  * Adds an event handler to an asynchronously subscribing/unsubscribing event so the event handler runs when the event is emitted
  * @param event the asynchronously (un)subscribing event to subscribe to. Can be either a string or an Event
  *  - If event is a `string`, the network event associated with this type will automatically be used
- *  - If event is a `PEvent` or `PEventAsync`, that event will be used
+ *  - If event is a `PapiEvent` or `PapiEventAsync`, that event will be used
  *  - If event is undefined, the callback will not be subscribed. Useful if the event is not yet available for example
  * @param eventHandler the callback to run when the event is emitted
  *

--- a/src/renderer/hooks/papi-hooks/use-event.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-event.hook.ts
@@ -7,7 +7,7 @@ import { useEffect } from 'react';
  * Adds an event handler to an event so the event handler runs when the event is emitted
  * @param event the event to subscribe to. Can be either a string or an Event
  *  - If event is a `string`, the network event associated with this type will automatically be used
- *  - If event is a `PEvent`, that event will be used
+ *  - If event is a `PapiEvent`, that event will be used
  *  - If event is undefined, the callback will not be subscribed. Useful if the event is not yet available for example
  * @param eventHandler the callback to run when the event is emitted
  *

--- a/src/shared/models/papi-event.model.ts
+++ b/src/shared/models/papi-event.model.ts
@@ -11,7 +11,7 @@ export type PapiEventHandler<T> = (event: T) => void;
 export type PapiEvent<T> = (callback: PapiEventHandler<T>) => Unsubscriber;
 
 /**
- * A PEvent that subscribes asynchronously and resolves an asynchronous unsubscriber.
+ * A PapiEvent that subscribes asynchronously and resolves an asynchronous unsubscriber.
  *
  * Note: The callback itself is not asynchronous.
  */

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -736,7 +736,7 @@ export const createRequestFunction = <TParam extends Array<unknown>, TReturn>(
 };
 
 /** All the exports in this service that are to be exposed on the PAPI */
-export const papiExports = {
+export const papiNetworkService = {
   onDidClientConnect,
   onDidClientDisconnect,
   createNetworkEventEmitter,

--- a/src/shared/services/papi.service.ts
+++ b/src/shared/services/papi.service.ts
@@ -5,7 +5,7 @@
  */
 
 import * as commandService from '@shared/services/command.service';
-import { papiExports } from '@shared/services/network.service';
+import { papiNetworkService } from '@shared/services/network.service';
 import * as papiUtil from '@shared/utils/papi-util';
 // We need the WebViewService here to include on the papi, but WebViewService passes papi into WebViews
 // eslint-disable-next-line import/no-cycle
@@ -44,7 +44,7 @@ const papi = {
     context: papiContext,
     hooks: papiHooks,
   },
-  network: papiExports,
+  network: papiNetworkService,
   logger,
   internet: internetService,
   dataProvider: dataProviderService,


### PR DESCRIPTION
- remove non-existent `@param`
- `npm run prettier`
- `PEvent` renamed to `PapiEvent` in comments
- `papiExports` renamed to `papiNetworkService`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/152)
<!-- Reviewable:end -->
