### PR TITLE
Changed shutdown to properly wait for sub-processes to shutdown

### DIFF
--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -579,6 +579,11 @@ export const onDidClientDisconnect = onDidClientDisconnectEmitter.event;
 
 // #endregion
 
+/** Closes the network services gracefully */
+export const shutdown = () => {
+  connectionService.disconnect();
+};
+
 /** Sets up the NetworkService. Runs only once */
 export const initialize = () => {
   if (initializePromise) return initializePromise;

--- a/src/shared/services/web-view.service.ts
+++ b/src/shared/services/web-view.service.ts
@@ -9,7 +9,7 @@ import {
   serializeRequestType,
 } from '@shared/utils/papi-util';
 import * as commandService from '@shared/services/command.service';
-import { newGuid, newNonce } from '@shared/utils/util';
+import { newGuid, newNonce, wait } from '@shared/utils/util';
 // We need the papi here to pass it into WebViews. Don't use it anywhere else in this file
 // eslint-disable-next-line import/no-cycle
 import papi from '@shared/services/papi.service';
@@ -77,11 +77,6 @@ const getWebViewPapi = (webViewId: string) => {
 
 // #endregion
 
-const sleep = (ms: number) => {
-  // eslint-disable-next-line no-promise-executor-return
-  return new Promise((resolve) => setTimeout(resolve, ms));
-};
-
 /**
  * Adds a WebView and runs all event handlers who are listening to this event
  * @param webView full html document to set as the webview iframe contents. Can be shortened to just a string
@@ -100,7 +95,7 @@ export const addWebView = async (webView: WebViewContents) => {
         .catch(async (error) => {
           succeeded = false;
           if (attemptsRemaining === 1) throw error;
-          await sleep(1000);
+          await wait(1000);
         });
 
       if (succeeded) return undefined;

--- a/src/shared/utils/util.ts
+++ b/src/shared/utils/util.ts
@@ -123,3 +123,24 @@ function toErrorWithMessage(maybeError: unknown): ErrorWithMessage {
 export function getErrorMessage(error: unknown) {
   return toErrorWithMessage(error).message;
 }
+
+/**
+ * Asynchronously waits for the specified number of milliseconds.
+ * (wraps setTimeout in a promise)
+ */
+export function wait(ms: number) {
+  // eslint-disable-next-line no-promise-executor-return
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Runs the specified function and will timeout if it takes longer than the specified wait time
+ * @param fn The function to run
+ * @param maxWaitTimeInMS The maximum amount of time to wait for the function to resolve
+ * @returns Promise that resolves to the resolved value of the function or null if it
+ * ran longer than the specified wait time
+ */
+export function waitForDuration<TResult>(fn: () => Promise<TResult>, maxWaitTimeInMS: number) {
+  const timeout = wait(maxWaitTimeInMS).then(() => null);
+  return Promise.any([timeout, fn()]);
+}


### PR DESCRIPTION
#37 Changed shutdown to properly wait for sub-processes to shutdown first. Fixed processes being orphaned when hot-reloading or shutdown.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/155)
<!-- Reviewable:end -->
