### PR TITLE
Pass through warnings from extension host

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -479,6 +479,7 @@ declare module 'shared/data/network-connector.model' {
 }
 declare module 'shared/services/logger.service' {
   import log from 'electron-log';
+  export const WARN_TAG = '<WARN>';
   /**
    * Format a string of a service message
    * @param message message from the service

--- a/src/extension-host/extension-host.ts
+++ b/src/extension-host/extension-host.ts
@@ -13,7 +13,6 @@ import extensionAssetService from '@shared/services/extension-asset.service';
 
 logger.info('Starting extension-host');
 logger.info(`Extension host is${isClient() ? '' : ' not'} client`);
-logger.info(`Extension host process.type = ${process.type}`);
 logger.info(`Extension host process.env.NODE_ENV = ${process.env.NODE_ENV}`);
 logger.warn('Extension host example warning');
 

--- a/src/main/services/extension-host.service.ts
+++ b/src/main/services/extension-host.service.ts
@@ -7,7 +7,7 @@ import {
   ARG_EXTENSIONS,
   getCommandLineArgumentsGroup,
 } from '@node/utils/command-line.util';
-import logger, { formatLog } from '@shared/services/logger.service';
+import logger, { formatLog, WARN_TAG } from '@shared/services/logger.service';
 import { waitForDuration } from '@shared/utils/util';
 import { ChildProcess, ChildProcessByStdio, fork, spawn } from 'child_process';
 import { app } from 'electron';
@@ -26,7 +26,11 @@ const closePromise: Promise<void> = new Promise<void>((resolve) => {
 
 // log functions for inside the extension host process
 function logProcessError(message: unknown) {
-  logger.error(formatLog(message?.toString() || '', EXTENSION_HOST_NAME, 'error'));
+  let msg = message?.toString() || '';
+  if (msg.includes(WARN_TAG)) {
+    msg = msg.split(WARN_TAG).join('');
+    logger.warn(formatLog(msg, EXTENSION_HOST_NAME, 'warning'));
+  } else logger.error(formatLog(msg, EXTENSION_HOST_NAME, 'error'));
 }
 function logProcessInfo(message: unknown) {
   logger.info(formatLog(message?.toString() || '', EXTENSION_HOST_NAME));


### PR DESCRIPTION
- also remove unused `process.type`

![image](https://github.com/paranext/paranext-core/assets/5582153/f1f9c8a4-c514-486a-a108-8f4c024543c2)

Before this was an error even though it was logged as a warning.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/214)
<!-- Reviewable:end -->
