### PR TITLE
Fixed extensions using papi-dts in TypeScript 5.1

### DIFF
--- a/extensions/tsconfig.json
+++ b/extensions/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "typeRoots": ["./node_modules/@types", "./dist"],
+    "typeRoots": ["./node_modules/@types", "./dist", "../lib"],
     "types": ["papi-dts"],
     "paths": {
       "@extensions/*": ["./dist/*"]


### PR DESCRIPTION
After upgrading VSCode to 1.79.0, I saw that bundled extensions couldn't find `papi-dts`. I realized VSCode upgraded to TypeScript 5.1 in this update, which comes along with a breaking change to `typeRoots` that caused this issue: https://devblogs.microsoft.com/typescript/announcing-typescript-5-1/#explicit-typeroots-disables-upward-walks-for-node_modules-types

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/243)
<!-- Reviewable:end -->
