### PR TITLE
Close all processes together

### DIFF
--- a/extensions/lib/evil/evil.js
+++ b/extensions/lib/evil/evil.js
@@ -28,7 +28,7 @@ async function tryImports() {
 
   try {
     // This should always work because `fetch` is replaced with `papi.fetch`.
-    fetch('https://bible-api.com/1%20thessalonians+5:16');
+    await fetch('https://bible-api.com/1%20thessalonians+5:16');
     logger.info('Evil: fetch is working.');
   } catch (e) {
     logger.error(`Evil: Error on fetch! ${e}`);

--- a/src/extension-host/extension-host.ts
+++ b/src/extension-host/extension-host.ts
@@ -8,6 +8,7 @@ import logger from '@shared/services/logger.service';
 import networkObjectService from '@shared/services/network-object.service';
 import dataProviderService from '@shared/services/data-provider.service';
 import extensionAssetService from '@shared/services/extension-asset.service';
+import { getErrorMessage } from '@shared/utils/util';
 
 // #region Test logs
 
@@ -63,11 +64,15 @@ networkService
 (async () => {
   const testEH = await networkObjectService.set('test-extension-host', {
     getVerse: async () => {
-      const verse = await papi.fetch('https://bible-api.com/matthew+24:14');
-      const verseJson = await verse.json();
-      const results = `test-extension-host got verse: ${verseJson.text.replace(/\\n/g, '')}`;
-      logger.info(results);
-      return results;
+      try {
+        const verse = await papi.fetch('https://bible-api.com/matthew+24:14');
+        const verseJson = await verse.json();
+        const results = `test-extension-host got verse: ${verseJson.text.replace(/\\n/g, '')}`;
+        logger.info(results);
+        return results;
+      } catch (e) {
+        return getErrorMessage(e);
+      }
     },
   });
 


### PR DESCRIPTION
I'm not sure if this actually fixes the zombie processes issue, but this is my best guess. Let's try this for a while and see if we see the issue continue.

I tested by editing a React web view file while running the application. Doing this enough times causes an EPERM crash. I thought this would certainly show the problematic zombie processes, but it doesn't seem to be the case. It seems the zombie processes are related to webpacking the preload script.

Coded on the plane ✈️

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/246)
<!-- Reviewable:end -->
