### PR TITLE
Fixed extension type discovery for papi-dts

### DIFF
--- a/extensions/lib/evil/package.json
+++ b/extensions/lib/evil/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Paranext extension that tries to break things!!1!!",
   "main": "evil.js",
+  "types": "evil.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/extensions/lib/hello-someone/package.json
+++ b/extensions/lib/hello-someone/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Simple hello someone extension for Paranext",
   "main": "hello-someone.js",
+  "types": "hello-someone.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/extensions/lib/hello-world/package.json
+++ b/extensions/lib/hello-world/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Simple hello world extension for Paranext",
   "main": "hello-world.js",
+  "types": "hello-world.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/extensions/lib/quick-verse/package.json
+++ b/extensions/lib/quick-verse/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "description": "Simple quick verse extension for Paranext",
   "main": "quick-verse.js",
+  "types": "quick-verse.d.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1370,7 +1370,7 @@ declare module 'shared/services/network-object.service' {
       id: string,
       createLocalObjectToProxy?: LocalObjectToProxyCreator<T> | undefined,
     ) => Promise<NetworkObject<T> | undefined>;
-    set: <T_1 extends NetworkableObject>(
+    set: <T_1 extends NetworkableObject<object>>(
       id: string,
       objectToShare: T_1,
     ) => Promise<DisposableNetworkObject<T_1>>;


### PR DESCRIPTION
It seems TypeScript doesn't like that I didn't explicitly spell out the types file though I thought I read in their documentation that it will try to infer it. Oh well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/262)
<!-- Reviewable:end -->
