### PR TITLE
Add event to signal when messaging is complete and modify .net logging

### DIFF
--- a/c-sharp/Program.cs
+++ b/c-sharp/Program.cs
@@ -12,6 +12,7 @@ public static class Program
     public static async Task Main()
     {
         Console.WriteLine("Paranext data provider starting up");
+        Thread.CurrentThread.Name = "Main";
 
         using PapiClient papi = new();
         try
@@ -36,6 +37,7 @@ public static class Program
 
             Console.WriteLine("Paranext data provider ready!");
             papi.BlockUntilMessageHandlingComplete();
+            Console.WriteLine("Paranext data provider message handling complete");
         }
         finally
         {


### PR DESCRIPTION
I moved all logging from `Console.Error` to just `Console` because I wasn't 100% sure that data written to `Console.Error` would show up in my logs in the same way as everything else, and I needed to know for sure I was seeing all the log messages.  Really we need to move to a proper logging framework anyway and away from Console, but that's for another time.

I opened a [discussion on StackOverflow](https://stackoverflow.com/questions/76575018/how-can-thread-join-in-net-return-before-the-thread-has-terminated) about this because I'm really baffled how this problem could have happened in the first place.  We'll see if anyone else has a bright idea about how this could have happened in the first place.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/271)
<!-- Reviewable:end -->
