### PR TITLE
Remove all lower level threading types and replace them with Task-based types

### DIFF
--- a/c-sharp/NetworkObjects/DataProvider.cs
+++ b/c-sharp/NetworkObjects/DataProvider.cs
@@ -43,10 +43,10 @@ namespace Paranext.DataProvider.NetworkObjects
         /// <summary>
         /// Register this data provider on the network so that other services can use it
         /// </summary>
-        public void RegisterDataProvider()
+        public async Task RegisterDataProvider()
         {
-            RegisterNetworkObject(DataProviderName, FunctionHandler);
-            StartDataProvider();
+            await RegisterNetworkObject(DataProviderName, FunctionHandler);
+            await StartDataProvider();
         }
 
         // An array of strings serialized as JSON will be sent here.
@@ -92,7 +92,7 @@ namespace Paranext.DataProvider.NetworkObjects
         /// <summary>
         /// Once a data provider has started, it should send out update events whenever its data changes.
         /// </summary>
-        protected abstract void StartDataProvider();
+        protected abstract Task StartDataProvider();
 
         /// <summary>
         /// Handle a request from a service using this data provider

--- a/c-sharp/NetworkObjects/NetworkObject.cs
+++ b/c-sharp/NetworkObjects/NetworkObject.cs
@@ -20,7 +20,7 @@ namespace Paranext.DataProvider.NetworkObjects
         /// <param name="networkObjectName">Services access this network object using this name</param>
         /// <param name="requestHandler">Function that will handle calls from services to this network object</param>
         /// <exception cref="Exception">Throws if the network object could not be registered properly</exception>
-        protected void RegisterNetworkObject(
+        protected async Task RegisterNetworkObject(
             string networkObjectName,
             Func<dynamic, ResponseToRequest> requestHandler
         )
@@ -29,10 +29,10 @@ namespace Paranext.DataProvider.NetworkObjects
             var getReqType = new Enum<RequestType>($"object:{networkObjectName}.get");
             var functionReqType = new Enum<RequestType>($"object:{networkObjectName}.function");
 
-            if (!PapiClient.RegisterRequestHandler(getReqType, HandleGet))
+            if (!await PapiClient.RegisterRequestHandler(getReqType, HandleGet))
                 throw new Exception($"Could not register GET for {networkObjectName}");
 
-            if (!PapiClient.RegisterRequestHandler(functionReqType, requestHandler))
+            if (!await PapiClient.RegisterRequestHandler(functionReqType, requestHandler))
                 throw new Exception($"Could not register FUNCTION for {networkObjectName}");
         }
 

--- a/c-sharp/NetworkObjects/TimeDataProvider.cs
+++ b/c-sharp/NetworkObjects/TimeDataProvider.cs
@@ -16,7 +16,7 @@ namespace Paranext.DataProvider.NetworkObjects
         public TimeDataProvider(PapiClient papiClient)
             : base("current-time", papiClient) { }
 
-        protected override void StartDataProvider()
+        protected override Task StartDataProvider()
         {
             _timer.Elapsed += (_, _) =>
             {
@@ -24,6 +24,7 @@ namespace Paranext.DataProvider.NetworkObjects
             };
             _timer.AutoReset = true;
             _timer.Enabled = true;
+            return Task.CompletedTask;
         }
 
         protected override ResponseToRequest HandleRequest(string functionName, JsonArray args)

--- a/c-sharp/NetworkObjects/UsfmDataProvider.cs
+++ b/c-sharp/NetworkObjects/UsfmDataProvider.cs
@@ -21,9 +21,10 @@ namespace Paranext.DataProvider.NetworkObjects
             ParatextGlobals.Initialize(dataFolderPath);
         }
 
-        protected override void StartDataProvider()
+        protected override Task StartDataProvider()
         {
             _scrText = ScrTextCollection.Find(_collectionName);
+            return Task.CompletedTask;
         }
 
         protected override ResponseToRequest HandleRequest(string functionName, JsonArray args)

--- a/c-sharp/Program.cs
+++ b/c-sharp/Program.cs
@@ -23,20 +23,20 @@ public static class Program
                 return;
             }
 
-            if (!papi.RegisterRequestHandler(RequestType.AddOne, RequestAddOne))
+            if (!await papi.RegisterRequestHandler(RequestType.AddOne, RequestAddOne))
             {
                 Console.WriteLine("Paranext data provider could not register request handler");
                 return;
             }
 
             var tdp = new TimeDataProvider(papi);
-            tdp.RegisterDataProvider();
+            await tdp.RegisterDataProvider();
 
             var sdp = new UsfmDataProvider(papi, "assets", "WEB");
-            sdp.RegisterDataProvider();
+            await sdp.RegisterDataProvider();
 
             Console.WriteLine("Paranext data provider ready!");
-            papi.BlockUntilMessageHandlingComplete();
+            await papi.MessageHandlingCompleteTask;
             Console.WriteLine("Paranext data provider message handling complete");
         }
         finally


### PR DESCRIPTION
I learned that async methods and dedicated threads don't play nicely together.  Dedicated threads can terminate unexpectedly even though the async methods will continue to run on other threads in the thread pool.  It's better to just move away from dedicated threads to avoid problems or confusion in the future.

In addition to moving away from dedicated threads, it seems there is some small risk of deadlocking by using blocking threading primitives in async methods.  So this PR also replaces `ManualResetEventSlim` with `TaskCompletionSource`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/272)
<!-- Reviewable:end -->
