### PR TITLE
258 replace bible api with usfm

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ dotnet tool restore
 dotnet csharpier .
 ```
 
+## Thanks
+
+Some important decisions in this project were inspired by the work done in [Visual Studio Code](https://code.visualstudio.com/api). Thanks VS Code developers for some great ideas!
+
 ## License
 
 MIT © [SIL International](https://www.sil.org/)

--- a/extensions/lib/evil/evil.js
+++ b/extensions/lib/evil/evil.js
@@ -28,7 +28,7 @@ async function tryImports() {
 
   try {
     // This should always work because `fetch` is replaced with `papi.fetch`.
-    await fetch('https://bible-api.com/1%20thessalonians+5:16');
+    await fetch('https://www.example.com');
     logger.info('Evil: fetch is working.');
   } catch (e) {
     logger.error(`Evil: Error on fetch! ${e}`);
@@ -60,9 +60,8 @@ async function tryImports() {
 
   try {
     // This should always work.
-    const verse = await papi.fetch('https://bible-api.com/1%20thessalonians+5:16');
-    const verseJson = await verse.json();
-    logger.info(`Evil: could papi.fetch verse 1TH 5:16 "${verseJson.text.replace(/\n/g, '')}"`);
+    const genericFetch = await (await papi.fetch('https://www.example.com')).text();
+    logger.info(`Evil: could papi.fetch example.com "${genericFetch.substring(0, 100)}"`);
   } catch (e) {
     logger.error(`Evil: Error on papi.fetch! ${e}`);
   }

--- a/extensions/lib/hello-world/hello-world.ts
+++ b/extensions/lib/hello-world/hello-world.ts
@@ -82,10 +82,8 @@ export async function activate(): Promise<UnsubscriberAsync> {
   ];
 
   papi
-    .fetch('https://bible-api.com/matthew+24:14')
-    .then((res) => res.json())
-    .then((scr) => logger.info(scr.text.replace(/\n/g, '')))
-    .catch((e) => logger.error(`Could not get Scripture from bible-api! Reason: ${e}`));
+    .fetch('https://www.example.com')
+    .catch((e) => logger.error(`Could not get data from example.com! Reason: ${e}`));
 
   // Create webviews or get an existing webview if one already exists for this type
   // Note: here, we are using `existingId: '?'` to indicate we do not want to create a new webview

--- a/extensions/lib/hello-world/hello-world.web-view.ejs
+++ b/extensions/lib/hello-world/hello-world.web-view.ejs
@@ -34,10 +34,8 @@
 
       // Test fetching
       papi
-        .fetch('https://bible-api.com/matthew+24:14')
-        .then((res) => res.json())
-        .then((scr) => logger.info(scr.text.replace(/\\n/g, '')))
-        .catch((e) => logger.error(`Could not get Scripture from bible-api! Reason: ${e}`));
+        .fetch('https://www.example.com', { mode: 'no-cors' })
+        .catch((e) => logger.error(`Could not get data from example.com! Reason: ${e}`));
 
       function HelloWorld() {
         const [myState, setMyState] = useState(0);
@@ -123,10 +121,8 @@
 
         // Test fetching
         papi
-          .fetch('https://bible-api.com/matthew+24:14')
-          .then((res) => res.json())
-          .then((scr) => logger.info(scr.text.replace(/\\n/g, '')))
-          .catch((e) => logger.error(`Could not get Scripture from bible-api! Reason: ${e}`));
+          .fetch('https://www.example.com', { mode: 'no-cors' })
+          .catch((e) => logger.error(`Could not get data from example.com! Reason: ${e}`));
       });
 
       //# sourceURL=hello-world.web-view.ejs

--- a/extensions/lib/hello-world/hello-world.web-view.tsx
+++ b/extensions/lib/hello-world/hello-world.web-view.tsx
@@ -44,10 +44,8 @@ const initializeRows = (): Row[] => {
 
 // Test fetching
 papi
-  .fetch('https://bible-api.com/matthew+24:14')
-  .then((res) => res.json())
-  .then((scr) => logger.info(scr.text.replace(/\\n/g, '')))
-  .catch((e) => logger.error(`Could not get Scripture from bible-api! Reason: ${e}`));
+  .fetch('https://www.example.com', { mode: 'no-cors' })
+  .catch((e) => logger.error(`Could not get data from example.com! Reason: ${e}`));
 
 globalThis.webViewComponent = function HelloWorld() {
   const test = useContext(TestContext) || "Context didn't work!! :(";
@@ -117,10 +115,8 @@ globalThis.webViewComponent = function HelloWorld() {
             logger.info(`${NAME} Button clicked!`);
             setMyState((myStateCurrent) => myStateCurrent + 1);
             papi
-              .fetch('https://bible-api.com/matthew+24:14')
-              .then((res) => res.json())
-              .then((scr) => logger.info(`Got it! ${scr.text.replace(/\\n/g, '')}`))
-              .catch((e) => logger.error(`Could not get Scripture from bible-api! Reason: ${e}`));
+              .fetch('https://example.com', { mode: 'no-cors' })
+              .catch((e) => logger.error(`Could not get data from example.com! Reason: ${e}`));
           }}
         >
           Hello World Button {myState}

--- a/src/extension-host/extension-host.ts
+++ b/src/extension-host/extension-host.ts
@@ -65,12 +65,12 @@ networkService
   const testEH = await networkObjectService.set('test-extension-host', {
     getVerse: async () => {
       try {
-        const verse = await papi.fetch('https://bible-api.com/matthew+24:14');
-        const verseJson = await verse.json();
-        const results = `test-extension-host got verse: ${verseJson.text.replace(/\\n/g, '')}`;
+        const exampleData = await (await papi.fetch('https://www.example.com')).text();
+        const results = `test-extension-host got data: ${exampleData.substring(0, 100)}`;
         logger.info(results);
         return results;
       } catch (e) {
+        logger.error(`test-extension-host.getVerse() threw ${e}`);
         return getErrorMessage(e);
       }
     },

--- a/src/renderer/testing/test-buttons-panel.component.tsx
+++ b/src/renderer/testing/test-buttons-panel.component.tsx
@@ -133,7 +133,7 @@ export default function TestButtonsPanel() {
     ),
   );
 
-  const [verseRef, setVerseRef] = useState<string>('John 11:35');
+  const [verseRef, setVerseRef] = useState<string>('Jhn 11:35');
   // Displayed verse ref while debouncing the actual verse ref
   const [verseRefIntermediate, setVerseRefIntermediate] = useState<string>(verseRef);
   const setVerseRefDebounced = useMemo(

--- a/src/renderer/testing/test-quick-verse-heresy-panel.component.tsx
+++ b/src/renderer/testing/test-quick-verse-heresy-panel.component.tsx
@@ -9,7 +9,7 @@ import { TextField } from 'papi-components';
 export const TAB_TYPE_QUICK_VERSE_HERESY = 'quick-verse-heresy';
 
 export function TestQuickVerseHeresyPanel() {
-  const [verseRef, setVerseRef] = useState<string>('John 11:35');
+  const [verseRef, setVerseRef] = useState<string>('Jhn 11:35');
   // Displayed verse ref while debouncing the actual verse ref
   const [verseRefIntermediate, setVerseRefIntermediate] = useState<string>(verseRef);
   const setVerseRefDebounced = useMemo(


### PR DESCRIPTION
This removes all usage of bible-api.com from our project.  Where we used it to load scripture we now use the USFM data provider.  Where we used it as a "random" target for `fetch` calls we now use `example.com`.

It's worthwhile to note that the ParatextData USFM loader doesn't use full English book names but instead has 3 letter names/IDs for each book.  No effort was made to translate full English names to the 3 letter ones for now.  I am assuming that other controls will do that mapping and pass down what ParatextData is expecting.  If we want the USFM data provider to work from more names, we can follow up with another commit to add more functionality at the data provider level inside of C#.

I tacked on the change to `README.md` as part of this PR.