### PR TITLE
Fix `papi-components` install

### DIFF
--- a/lib/papi-components/package.json
+++ b/lib/papi-components/package.json
@@ -34,6 +34,7 @@
     "build": "npm run build:basic && npm run format:scripts && npm run lint:scripts && npm run format:styles && npm run lint:styles",
     "watch": "tsc && vite build --watch",
     "lint:scripts": "eslint . --ext .ts",
+    "postinstall": "cd ../.. && npm install --ignore-scripts",
     "lint:styles": "stylelint ./**/*.{css,scss}",
     "format:scripts": "prettier . --write",
     "format:styles": "stylelint ./**/*.{css,scss} --fix"

--- a/package-lock.json
+++ b/package-lock.json
@@ -120,6 +120,7 @@
     },
     "lib/papi-components": {
       "version": "0.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
         "@emotion/react": "^11.10.6",


### PR DESCRIPTION
- Run root `npm i` after *papi-components* `npm i` to ensure the app still runs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/287)
<!-- Reviewable:end -->
