### PR TITLE
Fix the production build for the .NET Data Provider

### DIFF
--- a/c-sharp/ParanextDataProvider.csproj
+++ b/c-sharp/ParanextDataProvider.csproj
@@ -32,6 +32,16 @@
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="68.2.0.9" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
   </ItemGroup>
 
+  <!--
+    IMPORTANT: The version number below should match the version from the icu.net PackageReference
+    For some reason, the .config file only copies inconsistently from the NuGet package without this explicit reference.
+  -->
+  <ItemGroup>
+    <None Update="$(NuGetPackageRoot)\icu.net\2.9.0\contentFiles\any\any\icu.net.dll.config">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
   <ItemGroup>
     <Content Include="assets\**\*.*">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/src/main/services/dotnet-data-provider.service.ts
+++ b/src/main/services/dotnet-data-provider.service.ts
@@ -1,4 +1,4 @@
-import { ChildProcessWithoutNullStreams, spawn } from 'child_process';
+import { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio, spawn } from 'child_process';
 import path from 'path';
 import logger, { formatLog } from '@shared/services/logger.service';
 import { waitForDuration } from '@shared/utils/util';
@@ -54,18 +54,21 @@ function startDotnetDataProvider() {
   // default values for development
   let command = 'dotnet';
   let args: string[] = ['watch', '--project', 'c-sharp/ParanextDataProvider.csproj'];
+  let options: SpawnOptionsWithoutStdio | undefined;
 
   if (process.env.NODE_ENV === 'production') {
+    const dotnetPath: string = path.join(process.resourcesPath, 'dotnet');
     if (process.platform === 'win32') {
-      command = path.join(process.resourcesPath, 'dotnet', 'ParanextDataProvider.exe');
+      command = path.join(dotnetPath, 'ParanextDataProvider.exe');
       args = [];
     } else {
-      command = path.join(process.resourcesPath, 'dotnet', 'ParanextDataProvider');
+      command = path.join(dotnetPath, 'ParanextDataProvider');
       args = [];
     }
+    options = { cwd: dotnetPath };
   }
 
-  dotnet = spawn(command, args);
+  dotnet = spawn(command, args, options);
 
   dotnet.stdout.on('data', logProcessInfo);
   dotnet.stderr.on('data', logProcessError);


### PR DESCRIPTION
There fixes 2 separate issues:
1. The current working directory in production was not set to the location of the executable, so relative paths were different in dev and prod.
2. The .config file for icu.net was not copying to the publish directory consistently.  Sometimes it copied, and sometimes it didn't.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/308)
<!-- Reviewable:end -->
