### PR TITLE
Menu item to restart extension host

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -25,6 +25,7 @@ declare module 'papi-commands' {
     'test.echoRenderer': (message: string) => Promise<string>;
     'test.echoExtensionHost': (message: string) => Promise<string>;
     'test.throwError': (message: string) => void;
+    'platform.restartExtensionHost': () => Promise<void>;
     'platform.quit': () => Promise<void>;
     'test.addMany': (...nums: number[]) => number;
     'test.throwErrorExtensionHost': (message: string) => void;

--- a/src/declarations/papi-commands.ts
+++ b/src/declarations/papi-commands.ts
@@ -26,6 +26,7 @@ declare module 'papi-commands' {
     'test.echoRenderer': (message: string) => Promise<string>;
     'test.echoExtensionHost': (message: string) => Promise<string>;
     'test.throwError': (message: string) => void;
+    'platform.restartExtensionHost': () => Promise<void>;
     'platform.quit': () => Promise<void>;
     // These commands are provided in `extension-host.ts`. They are only here because I needed them to
     // use in other places, but building `papi-dts` wasn't working because it didn't see

--- a/src/main/services/dotnet-data-provider.service.ts
+++ b/src/main/services/dotnet-data-provider.service.ts
@@ -91,6 +91,6 @@ function startDotnetDataProvider() {
 const dotnetDataProvider = {
   start: startDotnetDataProvider,
   kill: killDotnetDataProvider,
-  wait: waitForDotnetDataProvider,
+  waitForClose: waitForDotnetDataProvider,
 };
 export default dotnetDataProvider;

--- a/src/main/services/extension-host.service.ts
+++ b/src/main/services/extension-host.service.ts
@@ -173,7 +173,7 @@ function startExtensionHost() {
 const extensionHostService = {
   start: startExtensionHost,
   kill: killExtensionHost,
-  wait: waitForExtensionHost,
+  waitForClose: waitForExtensionHost,
 };
 
 export default extensionHostService;

--- a/src/renderer/components/platform-bible-menu.tsx
+++ b/src/renderer/components/platform-bible-menu.tsx
@@ -5,10 +5,19 @@ import logger from 'electron-log';
 import './platform-bible-menu.css';
 
 export type PlatformMenuProps = {
+  isSupportAndDevelopment?: boolean;
   closeMenu: () => void;
 };
 
-export default function PlatformBibleMenu({ closeMenu }: PlatformMenuProps) {
+export default function PlatformBibleMenu({
+  isSupportAndDevelopment = false,
+  closeMenu,
+}: PlatformMenuProps) {
+  const onRestartExtensionHost = () => {
+    commandService.sendCommand('platform.restartExtensionHost');
+    closeMenu();
+  };
+
   const onExit = () => {
     commandService.sendCommand('platform.quit');
     closeMenu();
@@ -59,6 +68,11 @@ export default function PlatformBibleMenu({ closeMenu }: PlatformMenuProps) {
         >
           Settings...
         </MenuItem>
+        {isSupportAndDevelopment ? (
+          <MenuItem className="menu-item" isDense onClick={onRestartExtensionHost}>
+            Reload Extensions
+          </MenuItem>
+        ) : undefined}
         <MenuItem className="menu-item" isDense onClick={onExit}>
           Exit
         </MenuItem>

--- a/src/renderer/components/platform-bible-toolbar.tsx
+++ b/src/renderer/components/platform-bible-toolbar.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useCallback } from 'react';
+import { useState, useRef, useCallback, MouseEvent } from 'react';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import IconButton from '@mui/material/IconButton';
@@ -14,10 +14,24 @@ export default function PlatformBibleToolbar() {
   const toolbarRef = useRef<HTMLDivElement>(null);
 
   const [menuOpen, setMenuOpen] = useState(false);
+  const [hasShiftModifier, setHasShiftModifier] = useState(false);
 
   const handleMenuClose = useCallback(() => {
     if (menuOpen) setMenuOpen(false);
+    setHasShiftModifier(false);
   }, [menuOpen, setMenuOpen]);
+
+  const handleMenuButtonClick = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      setMenuOpen((prevIsOpen) => {
+        const isOpening = !prevIsOpen;
+        if (isOpening && e.shiftKey) setHasShiftModifier(true);
+        return isOpening;
+      });
+    },
+    [setMenuOpen, setHasShiftModifier],
+  );
 
   return (
     <AppBar position="static">
@@ -27,9 +41,7 @@ export default function PlatformBibleToolbar() {
           className="menuButton"
           color="inherit"
           aria-label="open drawer"
-          onClick={() => {
-            setMenuOpen((prev) => !prev);
-          }}
+          onClick={handleMenuButtonClick}
         >
           <MenuIcon />
         </IconButton>
@@ -45,7 +57,10 @@ export default function PlatformBibleToolbar() {
           onClose={handleMenuClose}
           PaperProps={{ style: { top: '40px', width: '95%', height: 'fit-content' } }}
         >
-          <PlatformBibleMenu closeMenu={handleMenuClose} />
+          <PlatformBibleMenu
+            closeMenu={handleMenuClose}
+            isSupportAndDevelopment={hasShiftModifier}
+          />
         </Drawer>
       </Toolbar>
     </AppBar>


### PR DESCRIPTION
First MVP step for #299.

1. In production, add the built new extension code to the `resources/extensions` folder. In development, add the built new extension code to the `extensions/dist` folder. If it's already there, modify it as needed.
2. In Platform.Bible, hold the shift key and click the main menu.
3. Click **Reload Extensions** to load the new extension:
![image](https://github.com/paranext/paranext-core/assets/5582153/08a5c9d7-ac94-4764-b759-797687dad47c)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/330)
<!-- Reviewable:end -->
