### PR TITLE
Allow relative paths for `--extensions`

### DIFF
--- a/src/extension-host/extension-host.ts
+++ b/src/extension-host/extension-host.ts
@@ -1,7 +1,7 @@
 import '@extension-host/global-this.model';
 import { isClient } from '@shared/utils/internal-util';
 import * as networkService from '@shared/services/network.service';
-import * as ExtensionService from '@extension-host/services/extension.service';
+import * as extensionService from '@extension-host/services/extension.service';
 import papi from '@extension-host/services/papi-backend.service';
 import logger from '@shared/services/logger.service';
 import networkObjectService from '@shared/services/network-object.service';
@@ -54,7 +54,7 @@ networkService
     await extensionAssetService.initialize();
 
     // The extension service locks down importing other modules, so be careful what runs after it
-    await ExtensionService.initialize();
+    await extensionService.initialize();
 
     // TODO: Probably should return Promise.all of these registrations
     return undefined;

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -24,24 +24,6 @@ import executionTokenService from '@node/services/execution-token.service';
 import UnsubscriberAsyncList from '@extension-host/extension-types/unsubscriber-async-list';
 import { ExecutionActivationContext } from '@extension-host/extension-types/extension-activation-context.model';
 
-/**
- * Name of the file describing the extension and its capabilities. Provided by the extension
- * developer
- */
-const MANIFEST_FILE_NAME = 'manifest.json';
-
-/** Whether this service has finished setting up */
-let isInitialized = false;
-
-/** Promise that resolves when this service is finished initializing */
-let initializePromise: Promise<void> | undefined;
-
-/** Extensions that are available to us */
-let availableExtensions: ExtensionInfo[];
-
-/** Map of extension name to extension that is currently active and running */
-const activeExtensions = new Map<string, ActiveExtension>();
-
 /** Extension manifest before it is finalized and frozen */
 
 /**
@@ -85,6 +67,31 @@ type ActiveExtension = {
  */
 type AmbiguousExtensionModule = IExtension | { default: IExtension };
 
+/**
+ * Name of the file describing the extension and its capabilities. Provided by the extension
+ * developer
+ */
+const MANIFEST_FILE_NAME = 'manifest.json';
+
+/** This is the location where we will store decompressed extension ZIP files */
+const userUnzippedExtensionsCacheUri: string = `file://${path.join(
+  os.homedir(),
+  '.platform.bible',
+  'extensions',
+)}`;
+
+/** Map of extension name to extension that is currently active and running */
+const activeExtensions = new Map<string, ActiveExtension>();
+
+/** Whether this service has finished setting up */
+let isInitialized = false;
+
+/** Promise that resolves when this service is finished initializing */
+let initializePromise: Promise<void> | undefined;
+
+/** Extensions that are available to us */
+let availableExtensions: ExtensionInfo[];
+
 /** Parse string extension manifest into an object and perform any transformations needed */
 function parseManifest(extensionManifestJson: string) {
   const extensionManifest = JSON.parse(extensionManifestJson) as ExtensionManifest;
@@ -95,43 +102,37 @@ function parseManifest(extensionManifestJson: string) {
   return extensionManifest;
 }
 
-/** This is the location where we will store decompressed extension ZIP files */
-const userUnzippedExtensionsCacheUri: string = `file://${path.join(
-  os.homedir(),
-  '.platform.bible/extensions',
-)}`;
-
 /** Contents of `nodeFS.readDir()` for all parent folders of extensions
  *  This is expected to be a mixture of directories and ZIP files.
  */
-const extensionRootDirectoryContents = (async () => {
+async function extensionRootDirectoryContents() {
   return Promise.all(
     [
       `resources://extensions${globalThis.isPackaged ? '' : '/dist'}`,
       ...getCommandLineArgumentsGroup(ARG_EXTENSION_DIRS).map(
-        (extensionDirPath) => `file://${extensionDirPath}`,
+        (extensionDirPath) => `file://${path.resolve(extensionDirPath)}`,
       ),
     ].map((extensionUri) => nodeFS.readDir(extensionUri)),
   );
-})();
+}
 
 /** All of the URIs of ZIP files for extensions we want to load */
-const extensionZipUris: Promise<Uri[]> = (async () => {
-  return (await extensionRootDirectoryContents)
+async function extensionZipUris(): Promise<Uri[]> {
+  return (await extensionRootDirectoryContents())
     .flatMap((dirEntries) => dirEntries[nodeFS.EntryType.File])
     .filter((extensionFileUri) => extensionFileUri)
     .filter((extensionFileUri) => extensionFileUri.toLowerCase().endsWith('.zip'))
     .concat(
       getCommandLineArgumentsGroup(ARG_EXTENSIONS)
         .filter((extensionUri) => extensionUri.toLowerCase().endsWith('.zip'))
-        .map((extensionPath) => `file://${extensionPath}`),
+        .map((extensionPath) => `file://${path.resolve(extensionPath)}`),
     );
-})();
+}
 
 /** All of the URIs of extensions to load */
-const extensionUrisToLoad: Promise<Uri[]> = (async () => {
+async function extensionUrisToLoad(): Promise<Uri[]> {
   // Get all subdirectories for bundled extensions and command line ARG_EXTENSION_DIRS values
-  let extensionFolders: Uri[] = (await extensionRootDirectoryContents)
+  let extensionFolders: Uri[] = (await extensionRootDirectoryContents())
     .flatMap((dirEntries) => dirEntries[nodeFS.EntryType.Directory])
     .filter((extensionDirUri) => extensionDirUri);
 
@@ -142,7 +143,7 @@ const extensionUrisToLoad: Promise<Uri[]> = (async () => {
         const extensionFolder = extensionDirPath.endsWith(MANIFEST_FILE_NAME)
           ? extensionDirPath.slice(0, -MANIFEST_FILE_NAME.length)
           : extensionDirPath;
-        return `file://${extensionFolder}`;
+        return `file://${path.resolve(extensionFolder)}`;
       }),
     )
     .map(async (extensionFolder) => {
@@ -156,17 +157,17 @@ const extensionUrisToLoad: Promise<Uri[]> = (async () => {
 
   // Now add in the cache directories for all ZIP files
   return extensionFolders.concat(
-    (await extensionZipUris).map((zipUri) =>
+    (await extensionZipUris()).map((zipUri) =>
       joinUriPaths(userUnzippedExtensionsCacheUri, path.parse(zipUri).name),
     ),
   );
-})();
+}
 
 /** Process all ZIP file extensions we can find. It might be nice to store unzipped extensions
  *  in memory, but the ESM loader doesn't make that easy. Store them in the file system.
  */
 async function unzipCompressedExtensionFiles(): Promise<void> {
-  const zipUris = await extensionZipUris;
+  const zipUris = await extensionZipUris();
   await Promise.all(
     zipUris.map(async (zipUri) => {
       try {
@@ -224,8 +225,8 @@ async function unzipCompressedExtensionFile(zipUri: Uri): Promise<void> {
  * Get information for all the extensions present
  */
 // TODO: figure out if we can share this code with webpack.util.ts
-const getExtensions = async (): Promise<ExtensionInfo[]> => {
-  const extensionUris = await extensionUrisToLoad;
+async function getExtensions(): Promise<ExtensionInfo[]> {
+  const extensionUris = await extensionUrisToLoad();
   return (
     await Promise.allSettled(
       extensionUris.map(async (extensionUri) => {
@@ -258,7 +259,7 @@ const getExtensions = async (): Promise<ExtensionInfo[]> => {
       return settled.value.main !== null;
     })
     .map((fulfilled) => (fulfilled as PromiseFulfilledResult<ExtensionInfo>).value);
-};
+}
 
 /**
  * Loads an extension and runs its activate function.
@@ -269,10 +270,10 @@ const getExtensions = async (): Promise<ExtensionInfo[]> => {
  * @param extensionFilePath path to extension main file to import
  * @returns unsubscriber that deactivates the extension
  */
-const activateExtension = async (
+async function activateExtension(
   extension: ExtensionInfo,
   extensionFilePath: string,
-): Promise<ActiveExtension> => {
+): Promise<ActiveExtension> {
   // Import the extension file. Tell webpack to ignore it because extension files are not in the
   // bundle and should not be looked up in the bundle
   // DO NOT REMOVE THE webpackIgnore COMMENT. It is a webpack "Magic Comment" https://webpack.js.org/api/module-methods/#magic-comments
@@ -319,14 +320,14 @@ const activateExtension = async (
   };
   activeExtensions.set(extension.name, activeExtension);
   return activeExtension;
-};
+}
 
 /**
  * Load extensions and runs their activate functions.
  * @param extensions extension info for the extensions we want to activate
  * @returns unsubscriber that deactivates the extension
  */
-const activateExtensions = async (extensions: ExtensionInfo[]): Promise<ActiveExtension[]> => {
+async function activateExtensions(extensions: ExtensionInfo[]): Promise<ActiveExtension[]> {
   /** The path to each extension along with whether that extension has already been imported */
   const extensionsWithFiles = extensions.map((extension) => ({
     extension,
@@ -398,7 +399,7 @@ const activateExtensions = async (extensions: ExtensionInfo[]): Promise<ActiveEx
   ).filter((activeExtension) => activeExtension !== null) as ActiveExtension[];
 
   return extensionsActive;
-};
+}
 
 /**
  * Sets up the ExtensionService. Runs only once

--- a/src/renderer/components/platform-bible-menu.commands.tsx
+++ b/src/renderer/components/platform-bible-menu.commands.tsx
@@ -1,5 +1,5 @@
 import * as commandService from '@shared/services/command.service';
-import logger from 'electron-log';
+import logger from '@shared/services/logger.service';
 import './platform-bible-menu.css';
 import { Command } from 'papi-components';
 import { CommandNames } from 'papi-commands';


### PR DESCRIPTION
- also misc cleanup

To test in development, add ` --extensions ../paranext-extension-template/dist` (or similar) to the end of the **start:main** script in `package.json`. Otherwise build the app (`npm run package`) and test with that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/355)
<!-- Reviewable:end -->
