### PR TITLE
Moved app dir to home/.platform.bible and restructured some files in there, named UnsubscriberAsyncLists

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,13 @@ module.exports = {
       { exceptAfterSingleLine: true, exceptAfterOverload: true },
     ],
     '@typescript-eslint/member-ordering': 'error',
+    'no-empty-function': 'off',
+    '@typescript-eslint/no-empty-function': [
+      'error',
+      {
+        allow: ['arrowFunctions', 'functions', 'methods'],
+      },
+    ],
     '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/no-non-null-assertion': 'error',
     'no-redeclare': 'off',
@@ -50,6 +57,8 @@ module.exports = {
     ],
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'error',
+    'no-useless-constructor': 'off',
+    '@typescript-eslint/no-useless-constructor': 'error',
     'comma-dangle': ['error', 'always-multiline'],
     indent: 'off',
     'jsx-a11y/label-has-associated-control': [

--- a/extensions/src/evil/evil.js
+++ b/extensions/src/evil/evil.js
@@ -165,6 +165,9 @@ async function activate(context) {
 
 function deactivate() {
   logger.info('Evil is deactivated.');
+  logger.error(
+    'Evil is purposely failing to deactivate as a test! You should see one more error soon after this. Only these two errors are expected.',
+  );
 }
 
 exports.activate = activate;

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -2542,8 +2542,11 @@ declare module 'node/utils/util' {
   export const RESOURCES_PROTOCOL: string;
   export function resolveHtmlPath(htmlFileName: string): string;
   /**
-   * Gets the platform-specific user appdata folder for this application
-   * Thanks to Luke at https://stackoverflow.com/a/26227660
+   * Gets the platform-specific user Platform.Bible folder for this application
+   *
+   * When running in development: `<repo_directory>/dev-appdata`
+   *
+   * When packaged: `<user_home_directory>/.platform.bible`
    */
   export const getAppDir: import('memoize-one').MemoizedFn<() => string>;
   /**
@@ -2834,7 +2837,9 @@ declare module 'extension-host/extension-types/unsubscriber-async-list' {
    * Simple collection for UnsubscriberAsync objects that also provides an easy way to run them.
    */
   export default class UnsubscriberAsyncList {
+    private name;
     readonly unsubscribers: Set<Unsubscriber | UnsubscriberAsync>;
+    constructor(name?: string);
     /**
      * Add unsubscribers to the list. Note that duplicates are not added twice.
      * @param unsubscribers - Objects that were returned from a registration process.

--- a/src/extension-host/extension-types/unsubscriber-async-list.ts
+++ b/src/extension-host/extension-types/unsubscriber-async-list.ts
@@ -8,6 +8,8 @@ import { Unsubscriber, UnsubscriberAsync } from '@shared/utils/papi-util';
 export default class UnsubscriberAsyncList {
   readonly unsubscribers = new Set<UnsubscriberAsync | Unsubscriber>();
 
+  constructor(private name = 'Anonymous') {}
+
   /**
    * Add unsubscribers to the list. Note that duplicates are not added twice.
    * @param unsubscribers - Objects that were returned from a registration process.
@@ -28,7 +30,8 @@ export default class UnsubscriberAsyncList {
     const results = await Promise.all(unsubs);
     this.unsubscribers.clear();
     return results.every((unsubscriberSucceeded, index) => {
-      if (!unsubscriberSucceeded) logger.debug(`Unsubscriber at index ${index} failed!`);
+      if (!unsubscriberSucceeded)
+        logger.error(`UnsubscriberAsyncList ${this.name}: Unsubscriber at index ${index} failed!`);
 
       return unsubscriberSucceeded;
     });

--- a/src/extension-host/services/extension-storage.service.ts
+++ b/src/extension-host/services/extension-storage.service.ts
@@ -67,7 +67,7 @@ function buildUserDataPath(token: ExecutionToken, key: string): string {
   // "the ability to use the encoding result as filename or URL address"
   const encodedKey: string = Buffer.from(key, 'utf-8').toString('base64url');
 
-  return joinUriPaths('app://', subDir, encodedKey);
+  return joinUriPaths('app://extensions', subDir, 'user-data', encodedKey);
 }
 
 // #endregion

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -3,7 +3,6 @@
  */
 
 import chokidar from 'chokidar';
-import * as os from 'os';
 import JSZip from 'jszip';
 import path from 'path';
 import { IExtension } from '@extension-host/extension-types/extension.interface';
@@ -91,11 +90,7 @@ const requireOriginal = Module.prototype.require;
 const systemRequire = globalThis.isPackaged ? __non_webpack_require__ : require;
 
 /** This is the location where we will store decompressed extension ZIP files */
-const userUnzippedExtensionsCacheUri: string = `${FILE_PROTOCOL}${path.join(
-  os.homedir(),
-  '.platform.bible',
-  'extensions',
-)}`;
+const userUnzippedExtensionsCacheUri: string = joinUriPaths('cache://extensions');
 
 /** Map of extension name to extension that is currently active and running */
 const activeExtensions = new Map<string, ActiveExtension>();
@@ -333,7 +328,7 @@ async function activateExtension(extension: ExtensionInfo): Promise<ActiveExtens
   const context: ExecutionActivationContext = {
     name: extension.name,
     executionToken,
-    registrations: new UnsubscriberAsyncList(),
+    registrations: new UnsubscriberAsyncList(extension.name),
   };
   Object.freeze(context);
 

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -90,7 +90,7 @@ const requireOriginal = Module.prototype.require;
 const systemRequire = globalThis.isPackaged ? __non_webpack_require__ : require;
 
 /** This is the location where we will store decompressed extension ZIP files */
-const userUnzippedExtensionsCacheUri: string = joinUriPaths('cache://extensions');
+const userUnzippedExtensionsCacheUri: Uri = 'cache://extensions';
 
 /** Map of extension name to extension that is currently active and running */
 const activeExtensions = new Map<string, ActiveExtension>();

--- a/src/shared/data/file-system.model.ts
+++ b/src/shared/data/file-system.model.ts
@@ -7,7 +7,10 @@
  * Has a scheme followed by :// followed by a relative path.
  * If no scheme is provided, the app scheme is used.
  * Available schemes are as follows:
- *  - app:// - goes to the app's data directory (platform-dependent)
+ *  - app:// - goes to the app's home directory and into `.platform.bible` (platform-dependent)
+ *  - cache:// - goes to the app's temporary file cache at `app://cache`
+ *  - data:// - goes to the app's data storage location at `app://data`
  *  - resources:// - goes to the resources directory installed in the app
+ *  - file:// - an absolute file path from root
  */
 export type Uri = string;


### PR DESCRIPTION
Breaking change update announcement:

### Directories that Platform.Bible uses have moved

We have moved some directories around under the hood:

1. The main app directory has moved (will refer to this as `app://` in following entries). By os:
  - Windows: `%appdata%/paranext-core` -> `%homepath%/.platform.bible`
  - Linux: `~/.local/share/paranext-core` -> `~/.platform.bible`
  - Mac: `~/Library/Preferences/paranext-core` -> `~/.platform.bible`
  - Note: in development, the app directory is always `paranext-core/dev-appdata`
2. Unzipped extensions `~/.platform.bible/extensions` -> `~/.platform.bible/cache/extensions`
3. Extension user storage `app://<extension_name>` -> `app://extensions/<extension_name>/user-data`
  - This means extension user storage has been reset 
5. Node localstorage (not renderer localstorage) `app://local-storage/<process_type>` -> `app://local-storage/<process_type>` (the old location to the new location. Still the same relative to what is considered the `app` directory)

Almost no one will notice any difference other than having multiple 'People' webviews pop up now because the user storage was reset. You can safely close them both (or the old one if you can tell the difference!), and only one will pop up moving forward. This change is probably most relevant to testing if they are using these directories in any way.

Thanks!


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/384)
<!-- Reviewable:end -->
