### PR TITLE
Improve lint performance

### DIFF
--- a/extensions/package.json
+++ b/extensions/package.json
@@ -16,7 +16,7 @@
     "package:debug": "cross-env DEBUG_PROD=true npm run package",
     "build:types": "cd .. && npm run build:types",
     "start": "cd .. && npm start",
-    "lint": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx --cache",
     "lint:staged": "lint-staged -q"
   },
   "lint-staged": {

--- a/extensions/tsconfig.json
+++ b/extensions/tsconfig.json
@@ -41,6 +41,7 @@
     "noFallthroughCasesInSwitch": true
   },
   "include": ["src"],
+  "exclude": ["node_modules"],
   "ts-node": {
     // This allows us to use path aliases in ts-node
     "require": ["tsconfig-paths/register"],

--- a/lib/papi-components/package.json
+++ b/lib/papi-components/package.json
@@ -33,7 +33,7 @@
     "build:basic": "tsc && vite build && dts-bundle-generator --config ./dts-bundle-generator.config.ts",
     "build": "npm run build:basic && npm run format:scripts && npm run lint:scripts && npm run format:styles && npm run lint:styles",
     "watch": "tsc && vite build --watch",
-    "lint:scripts": "eslint . --ext .ts",
+    "lint:scripts": "eslint . --ext .ts,.tsx --cache",
     "postinstall": "cd ../.. && npm install --ignore-scripts",
     "lint:styles": "stylelint ./**/*.{css,scss}",
     "format:scripts": "prettier . --write",

--- a/lib/papi-dts/.eslintignore
+++ b/lib/papi-dts/.eslintignore
@@ -1,0 +1,2 @@
+# Dependency directory
+node_modules

--- a/lib/papi-dts/package.json
+++ b/lib/papi-dts/package.json
@@ -29,7 +29,7 @@
     "build": "tsc && ts-node edit-papi-d-ts.ts && prettier --write papi.d.ts",
     "build:clean": "rimraf papi.tsbuildinfo",
     "build:fresh": "npm run build:clean && npm run build",
-    "lint": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx",
+    "lint": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx --cache",
     "lint:staged": "lint-staged -q"
   },
   "lint-staged": {

--- a/lib/papi-dts/tsconfig.json
+++ b/lib/papi-dts/tsconfig.json
@@ -25,6 +25,7 @@
     "../../src/extension-host/services/papi-backend.service.ts",
     "../../src/extension-host/extension-types/extension.interface.ts"
   ],
+  "exclude": ["node_modules"],
   "ts-node": {
     "esm": true
   }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "build:papi-components": "cd lib/papi-components && npm run build",
     "csharp:tool:restore": "cd c-sharp && dotnet tool restore",
     "postinstall": "patch-package && ts-node .erb/scripts/check-native-dep.js && electron-builder install-app-deps && cd lib/papi-dts && npm install && cd ../../extensions && npm install && cd .. && cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.dev.dll.ts",
-    "lint": "npm run build:types && cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx && cd lib/papi-dts && npm run lint && cd ../../extensions && npm run lint",
+    "lint": "npm run build:types && cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx  --cache && cd lib/papi-dts && npm run lint && cd ../../extensions && npm run lint",
     "lint:config": "cross-env NODE_ENV=development eslint --print-config .eslintrc.js > .eslintConfig.json",
     "lint:staged": "npm run build:types && lint-staged -q && cd lib/papi-dts && npm run lint:staged && cd ../../extensions && npm run lint:staged",
     "package": "ts-node ./.erb/scripts/clean.js dist && npm run build && npm run build:extensions:production && electron-builder build --publish never",
@@ -72,7 +72,7 @@
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
     "start:data": "dotnet watch --project c-sharp/ParanextDataProvider.csproj",
     "stop": "ts-node stop-processes.mjs",
-    "test": "jest",
+    "test": "jest --silent",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
     "resolveJsonModule": true,
     "outDir": ".erb/dll"
   },
+  "include": ["src", "assets"],
   "exclude": [
     "node_modules",
     "test",


### PR DESCRIPTION
- after first run with cache subsequent runs are much faster
- followed https://duncanleung.com/why-slow-plugin-typescript-eslint-performance-issues/
- fix linting in `papi-components` to include TSX files
- also stop console logs in tests

This improved my no-changes lint speed from >90s to ~35s.

**Note:** strictly this should be on top of the PR #376 branch (since that fixes the 3 existing lint errors) but that PR is already approved for merging and this won't cause CI lint errors unless you change something in `papi-components`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/385)
<!-- Reviewable:end -->
