### PR TITLE
Make resource viewer take whole webview width, prevent extension name '..'

### DIFF
--- a/extensions/src/resource-viewer/resource-viewer.ts
+++ b/extensions/src/resource-viewer/resource-viewer.ts
@@ -3,6 +3,7 @@ import type { IWebViewProvider } from 'shared/models/web-view-provider.model';
 import type { SavedWebViewDefinition, WebViewDefinition } from 'shared/data/web-view.model';
 import type { ExecutionActivationContext } from 'extension-host/extension-types/extension-activation-context.model';
 import resourceViewerWebView from './resource-viewer.web-view?inline';
+import resourceViewerWebViewStyles from './resource-viewer.web-view.scss?inline';
 
 const { logger } = papi;
 logger.info('Resource Viewer is importing!');
@@ -22,6 +23,7 @@ const resourceWebViewProvider: IWebViewProvider = {
       ...savedWebView,
       title: 'Resource Viewer',
       content: resourceViewerWebView,
+      styles: resourceViewerWebViewStyles,
     };
   },
 };

--- a/extensions/src/resource-viewer/resource-viewer.web-view.scss
+++ b/extensions/src/resource-viewer/resource-viewer.web-view.scss
@@ -1,0 +1,5 @@
+// This class is built into the `usxeditor` library. We just need to override it
+/* stylelint-disable-next-line selector-class-pattern */
+.usxEditor {
+  width: auto !important;
+}

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -107,6 +107,8 @@ let availableExtensions: ExtensionInfo[];
 /** Parse string extension manifest into an object and perform any transformations needed */
 function parseManifest(extensionManifestJson: string): ExtensionManifest {
   const extensionManifest = JSON.parse(extensionManifestJson) as ExtensionManifest;
+  if (extensionManifest.name.includes('..'))
+    throw new Error('Extension name must not include `..`!');
   // Replace ts with js so people can list their source code ts name but run the transpiled js
   if (extensionManifest.main && extensionManifest.main.toLowerCase().endsWith('.ts'))
     extensionManifest.main = `${extensionManifest.main.slice(0, -3)}.js`;


### PR DESCRIPTION
Prevented .. in extension name because the extension name is used in file system calls

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/426)
<!-- Reviewable:end -->
