### PR TITLE
Package on main

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -1,0 +1,108 @@
+name: Package
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      debug_enabled:
+        type: boolean
+        description: 'Run the build with tmate debugging enabled (https://github.com/marketplace/actions/debugging-with-tmate)'
+        required: false
+        default: false
+
+jobs:
+  publish:
+    name: Main on ${{ matrix.os }}, .Net ${{ matrix.dotnet_version }}, node ${{ matrix.node_version }}
+
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+        dotnet_version: [7.0.x]
+        node_version: [18.x]
+
+    steps:
+      - name: Checkout git repo
+        uses: actions/checkout@v3
+
+      - name: Install .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: ${{matrix.dotnet_version}}
+
+      - name: Install Node and NPM
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node_version }}
+          cache: npm
+
+      - name: Install and build
+        run: |
+          npm install
+          npm run build
+
+      - name: Update release version
+        run: |
+          COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
+          cd ./release/app
+          CURRENT_VERSION=$(node -pe "require('./package.json').version")
+          NEW_VERSION="${CURRENT_VERSION}-commit.${COMMIT_HASH}"
+          echo "Updating version from ${CURRENT_VERSION} to ${NEW_VERSION}"
+          npm version $NEW_VERSION
+
+      - name: dotnet build - Windows on macOS
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: npm run build:data-release:windows
+
+      - name: Publish releases - Windows and macOS
+        if: ${{ matrix.os == 'macos-latest' }}
+        # env:
+        #   # These values are used for auto updates signing
+        #   APPLE_ID: ${{ secrets.APPLE_ID }}
+        #   APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS }}
+        #   CSC_LINK: ${{ secrets.CSC_LINK }}
+        #   CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          npm exec electron-builder -- build --publish never --win --mac
+
+      - name: Publish releases - Linux
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        env:
+          # no hardlinks so dependencies are copied
+          USE_HARD_LINKS: false
+        run: |
+          npm exec electron-builder -- build --publish never --linux
+
+      - name: Upload macOS artifacts
+        if: ${{ matrix.os == 'macos-latest' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-macos
+          path: |
+            ./release/build/*.dmg
+
+      - name: Upload Windows artifacts
+        if: ${{ matrix.os == 'macos-latest' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-windows
+          path: |
+            ./release/build/*.exe
+            !./release/build/*Setup*.exe
+
+      - name: Upload Linux artifacts
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: app-linux
+          path: |
+            ./release/build/*.AppImage
+
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled }}
+        uses: mxschmitt/action-tmate@v3
+        with:
+          limit-access-to-actor: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   publish:
-    name: Publish on ${{ matrix.os }}, .Net ${{ matrix.dotnet_version }}, and node ${{ matrix.node_version }}
+    name: Release on ${{ matrix.os }}, .Net ${{ matrix.dotnet_version }}, node ${{ matrix.node_version }}
 
     runs-on: ${{ matrix.os }}
 
@@ -43,21 +43,11 @@ jobs:
           npm install
           npm run build
 
-      - name: Install DMG license
+      - name: dotnet build - Windows on macOS
         if: ${{ matrix.os == 'macos-latest' }}
-        run: npm install dmg-license
+        run: npm run build:data-release:windows
 
-      - name: dotnet build - MacOS and Windows
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: |
-          npm run build:data-release:windows
-          npm run build:data-release:macos
-
-      - name: dotnet build - Linux
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        run: npm run build:data-release:linux
-
-      - name: Publish releases - Windows and MacOS
+      - name: Publish releases - Windows and macOS
         # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
         if: ${{ matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   test:
-    name: Test on ${{ matrix.os }}, .Net ${{ matrix.dotnet_version }}, and node ${{ matrix.node_version }}
+    name: Build on ${{ matrix.os }}, .Net ${{ matrix.dotnet_version }}, node ${{ matrix.node_version }}
 
     runs-on: ${{ matrix.os }}
 

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -2,8 +2,8 @@
  * @see https://www.electron.build/configuration/configuration
  */
 {
-  productName: 'ParanextCore',
-  appId: 'org.paranext.ParanextCore',
+  productName: 'Platform.Bible',
+  appId: 'org.paranext.PlatformBible',
   asar: true,
   asarUnpack: '**\\*.{node,dll}',
   files: ['dist', 'node_modules', 'package.json'],

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "build:data-release": "run-script-os",
     "build:data-release:windows": "dotnet publish c-sharp/ParanextDataProvider.csproj -r win-x64 -o ./c-sharp/bin/Release/net7.0/publish/win-x64/",
     "build:data-release:linux": "dotnet publish c-sharp/ParanextDataProvider.csproj -r linux-x64 -o ./c-sharp/bin/Release/net7.0/publish/linux-x64/",
-    "build:data-release:macos": "dotnet publish c-sharp/ParanextDataProvider.csproj -r osx-x64 -o ./c-sharp/bin/Release/net7.0/publish/osx-x64/ && dotnet publish c-sharp/ParanextDataProvider.csproj -p:PublishProfile=FolderProfile -r osx-arm64 -o ./c-sharp/bin/Release/net7.0/publish/osx-arm64/",
+    "build:data-release:macos": "dotnet publish c-sharp/ParanextDataProvider.csproj -r osx-x64 -o ./c-sharp/bin/Release/net7.0/publish/osx-x64/ && dotnet publish c-sharp/ParanextDataProvider.csproj -r osx-arm64 -o ./c-sharp/bin/Release/net7.0/publish/osx-arm64/",
     "build:types": "cd lib/papi-dts && npm run build",
     "build:papi-components": "cd lib/papi-components && npm run build",
     "csharp:tool:restore": "cd c-sharp && dotnet tool restore",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "Paranext",
+  "name": "platform.bible",
   "version": "0.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "Paranext",
+      "name": "platform.bible",
       "version": "0.0.2",
       "hasInstallScript": true,
       "license": "MIT"

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,10 +1,10 @@
 {
-  "name": "Paranext",
+  "name": "platform.bible",
   "version": "0.0.2",
   "description": "Extensible Bible translation software",
   "license": "MIT",
   "author": {
-    "name": "Paranext",
+    "name": "Platform.Bible",
     "url": "https://github.com/paranext/"
   },
   "main": "./dist/main/main.js",


### PR DESCRIPTION
- Artifacts are split by OS to reduce download size since individual artifacts cannot be extracted.
- Only portable app artifacts are included which should be sufficient at this point.
- Artifacts are removed by GH after 90 days.
- App version has commit hash appended to easily link to code, e.g. Linux portable app is named: `Platform.Bible-0.0.2-commit.db8e8f9.AppImage`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/442)
<!-- Reviewable:end -->
