### PR TITLE
Reworked ParatextStandard PDP to include USFM in data type names, wrote TypeScript types for potential Scripture and Project Note data

### DIFF
--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -16,10 +16,10 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         : base(name, papiClient, projectDetails)
     {
         _paratextPsi = paratextPsi;
-        Getters.Add("getBook", GetBook);
-        Getters.Add("getChapter", GetChapter);
-        Setters.Add("setChapter", SetChapter);
-        Getters.Add("getVerse", GetVerse);
+        Getters.Add("getBookUSFM", GetBookUSFM);
+        Getters.Add("getChapterUSFM", GetChapterUSFM);
+        Setters.Add("setChapterUSFM", SetChapterUSFM);
+        Getters.Add("getVerseUSFM", GetVerseUSFM);
     }
 
     protected override Task StartDataProvider()
@@ -61,23 +61,23 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         return _paratextPsi.SetProjectData(scope, data);
     }
 
-    private ResponseToRequest GetBook(string jsonString)
+    private ResponseToRequest GetBookUSFM(string jsonString)
     {
-        return Get(ParatextProjectStorageInterpreter.Book, jsonString);
+        return Get(ParatextProjectStorageInterpreter.BookUSFM, jsonString);
     }
 
-    private ResponseToRequest GetChapter(string jsonString)
+    private ResponseToRequest GetChapterUSFM(string jsonString)
     {
-        return Get(ParatextProjectStorageInterpreter.Chapter, jsonString);
+        return Get(ParatextProjectStorageInterpreter.ChapterUSFM, jsonString);
     }
 
-    private ResponseToRequest GetVerse(string jsonString)
+    private ResponseToRequest GetVerseUSFM(string jsonString)
     {
-        return Get(ParatextProjectStorageInterpreter.Verse, jsonString);
+        return Get(ParatextProjectStorageInterpreter.VerseUSFM, jsonString);
     }
 
-    private ResponseToRequest SetChapter(string dataQualifier, string data)
+    private ResponseToRequest SetChapterUSFM(string dataQualifier, string data)
     {
-        return Set(ParatextProjectStorageInterpreter.Chapter, dataQualifier, data);
+        return Set(ParatextProjectStorageInterpreter.ChapterUSFM, dataQualifier, data);
     }
 }

--- a/c-sharp/Projects/ParatextProjectStorageInterpreter.cs
+++ b/c-sharp/Projects/ParatextProjectStorageInterpreter.cs
@@ -9,9 +9,9 @@ namespace Paranext.DataProvider.Projects;
 
 internal class ParatextProjectStorageInterpreter : ProjectStorageInterpreter
 {
-    public const string Book = "BOOK";
-    public const string Chapter = "CHAPTER";
-    public const string Verse = "VERSE";
+    public const string BookUSFM = "BookUSFM";
+    public const string ChapterUSFM = "ChapterUSFM";
+    public const string VerseUSFM = "VerseUSFM";
 
     public ParatextProjectStorageInterpreter(PapiClient papiClient)
         : base(ProjectStorageType.ParatextFolders, new[] { ProjectType.Paratext }, papiClient) { }
@@ -84,17 +84,17 @@ internal class ParatextProjectStorageInterpreter : ProjectStorageInterpreter
         VerseRefConverter.TryCreateVerseRef(scope.DataQualifier, out var verseRef, out var error);
 
         var scrText = LocalProjects.GetParatextProject(scope.ProjectID);
-        return scope.DataType.ToUpperInvariant() switch
+        return scope.DataType switch
         {
-            Book
+            BookUSFM
                 => string.IsNullOrEmpty(error)
                     ? ResponseToRequest.Succeeded(scrText.GetText(verseRef, false, false))
                     : ResponseToRequest.Failed(error),
-            Chapter
+            ChapterUSFM
                 => string.IsNullOrEmpty(error)
                     ? ResponseToRequest.Succeeded(scrText.GetText(verseRef, true, false))
                     : ResponseToRequest.Failed(error),
-            Verse
+            VerseUSFM
                 => string.IsNullOrEmpty(error)
                     ? ResponseToRequest.Succeeded(scrText.Parser.GetVerseUsfmText(verseRef))
                     : ResponseToRequest.Failed(error),
@@ -115,9 +115,9 @@ internal class ParatextProjectStorageInterpreter : ProjectStorageInterpreter
         VerseRefConverter.TryCreateVerseRef(scope.DataQualifier, out var verseRef, out var error);
 
         var scrText = LocalProjects.GetParatextProject(scope.ProjectID);
-        switch (scope.DataType.ToUpperInvariant())
+        switch (scope.DataType)
         {
-            case Chapter:
+            case ChapterUSFM:
                 if (!string.IsNullOrEmpty(error))
                     return ResponseToRequest.Failed(error);
                 RunWithinLock(
@@ -134,7 +134,7 @@ internal class ParatextProjectStorageInterpreter : ProjectStorageInterpreter
                     }
                 );
                 // The value of returned string is case sensitive and cannot change unless data provider subscriptions change
-                return ResponseToRequest.Succeeded("Chapter");
+                return ResponseToRequest.Succeeded(ChapterUSFM);
             default:
                 return ResponseToRequest.Failed($"Unknown data type: {scope.DataType}");
         }

--- a/extensions/src/project-notes-data-provider/index.d.ts
+++ b/extensions/src/project-notes-data-provider/index.d.ts
@@ -13,7 +13,15 @@ declare module 'project-notes-data-provider' {
     Notes: DataProviderDataType<ProjectNotesSelector, ProjectNote[], never>;
   };
 
-  /** Data provider for manipulating project notes */
+  /**
+   * Data provider for manipulating project notes
+   *
+   * Modeled from Paratext 9 Plugin API's [GetNotes](https://github.com/ubsicap/paratext_demo_plugins/wiki/IProject#getnotes)
+   * and [AddNote](https://github.com/ubsicap/paratext_demo_plugins/wiki/IProject#addnote)
+   *
+   * WARNING: This is currently designed to match closely with Paratext 9's Notes API. Any changes
+   * must maintain backwards compatibility for the time being.
+   */
   export type ProjectNotesDataProvider = IDataProvider<ProjectNotesProviderDataTypes> & {
     /**
      * Adds a project note
@@ -179,6 +187,12 @@ declare module 'project-notes-data-provider' {
 
   /**
    * Data provider for manipulating project notes
+   *
+   * Modeled from Paratext 9 Plugin API's [GetNotes](https://github.com/ubsicap/paratext_demo_plugins/wiki/IProject#getnotes)
+   * and [AddNote](https://github.com/ubsicap/paratext_demo_plugins/wiki/IProject#addnote)
+   *
+   * WARNING: This is currently designed to match closely with Paratext 9's Notes API. Any changes
+   * must maintain backwards compatibility for the time being.
    *
    * This is a hand-written baked-out version of `ProjectNotesDataProvider` for ease of reading
    */

--- a/extensions/src/project-notes-data-provider/index.d.ts
+++ b/extensions/src/project-notes-data-provider/index.d.ts
@@ -1,0 +1,221 @@
+import { VerseRef } from '@sillsdev/scripture';
+import type {
+  DataProviderDataType,
+  DataProviderSubscriberOptions,
+} from 'shared/models/data-provider.model';
+import type IDataProvider from 'shared/models/data-provider.interface';
+import type { PapiEvent } from 'shared/models/papi-event.model';
+import type { Unsubscriber } from 'shared/utils/papi-util';
+
+declare module 'project-notes-data-provider' {
+  export type ProjectNotesProviderDataTypes = {
+    /** Get notes from the provider. `setNotes` is not available; please use `addNote` */
+    Notes: DataProviderDataType<ProjectNotesSelector, ProjectNote[], never>;
+  };
+
+  /** Data provider for manipulating project notes */
+  export type ProjectNotesDataProvider = IDataProvider<ProjectNotesProviderDataTypes> & {
+    /**
+     * Adds a project note
+     *
+     * @param anchor A selection in the Scripture text representing the "anchor" location of the note. Note that the `ScriptureTextSelection.SelectedText` is expected to begin and end at a word break; We will attempt to expand the selection if it is not.
+     * @param contentParagraphs One or more paragraphs of formatted text
+     * @param language The default language used in `contentParagraphs` (except where specified explicitly in a `FormattedString`).
+     * @param assignedUser User (if any) to whom the new note is to be assigned.
+     *
+     * @returns `ProjectNote` the newly added note
+     */
+    addNote(
+      anchor: ScriptureTextSelection,
+      contentParagraphs: CommentParagraph[],
+      language?: Language,
+      assignedUser?: UserInfo,
+    ): Promise<ProjectNote>;
+  };
+
+  /** An object representing a project note */
+  type ProjectNote = {
+    /** A selection in the Scripture text representing the "anchor" location of the note. */
+    anchor: ScriptureTextSelection;
+    /** Present in a note when it has been assigned to a particular user. */
+    assignedUser?: UserInfo;
+    /** The comments that comprise the note */
+    comments: Comment[];
+    /** Flag indicating whether all the comments of the note have been read by the current user. */
+    isRead: boolean;
+    /** Flag indicating whether this note is resolved. */
+    isResolved: boolean;
+    /** Present in a note when it has been assigned to reply-to a particular user. */
+    replyToUser?: UserInfo;
+  };
+
+  /** A selection in the Scripture text */
+  type ScriptureTextSelection = {
+    /** The raw USFM text following the SelectedText (typically the remainder of the verse represented by VerseRefEnd). */
+    afterContext: string;
+    /** The raw USFM text preceding the SelectedText (typically the entirety of the verse represented by VerseRefStart up to Offset). */
+    beforeContext: string;
+    /** The character offset (in the raw USFM data) starting from the point before the \v (i.e., the slash is the 0th character). */
+    offset: number;
+    /** The selected text represented by this object. Can be an empty string (representing an insertion point). */
+    selectedText: string;
+    /** The verse where the selection ends. */
+    verseRefEnd: VerseRef;
+    /** The verse where the selection starts. */
+    verseRefStart: VerseRef;
+  };
+
+  /** An object representing information about a user */
+  type UserInfo = {
+    /** Gets the registration name of the current user or an empty string if there is no registration information */
+    name: string;
+  };
+
+  /** An object representing a comment in a project note */
+  type Comment = {
+    /** User to whom a comment is/was assigned. */
+    assignedUser?: UserInfo;
+    /** User who authored this comment */
+    author: UserInfo;
+    /** The list of paragraphs making up the contents of this comment. */
+    contents: CommentParagraph[];
+    /** Date/time this comment was created */
+    created: Date;
+    /** The language used in the comment (except where specified explicitly in a FormattedString). */
+    language?: Language;
+  };
+
+  /**
+   * An object representing a language definition
+   *
+   * WARNING: SUBJECT TO CHANGE
+   */
+  type Language = {
+    /** Gets the default font. */
+    font?: Font;
+    /** Gets the IETF BCP-47 language tag. */
+    id: string;
+    /** Gets whether the language is displayed right-to-left. */
+    isRtoL: boolean;
+  };
+
+  /**
+   * Object representing a font
+   *
+   * WARNING: SUBJECT TO CHANGE
+   */
+  type Font = {
+    /** A comma-separated list of selected feature options for a Graphite font. REVIEW: Although Paratext does not seem to support selection of features for Open Type fonts, it's possible that existing LDML files may have this information and it could be used by Paratext (and therefore maybe passed on here). */
+    features?: string;
+    /** Name of the font family, which represents a group of fonts that have a similar font face. */
+    fontFamily?: string;
+    /** The language tag needed to tell a Graphite font which set of customized rules to use. */
+    language?: string;
+    /** The em-size measured in in points */
+    size?: number;
+  };
+
+  /**
+   * Object representing a paragraph in a comment
+   *
+   * WARNING: SUBJECT TO CHANGE DEPENDING ON HOW WE WANT TO MAKE RICH TEXT EDITING
+   */
+  type CommentParagraph = {
+    /** List of formatted text spans that make up the paragraph */
+    spans: FormattedString[];
+  };
+
+  /**
+   * A span of text that has formatting specified
+   *
+   * WARNING: SUBJECT TO CHANGE DEPENDING ON HOW WE WANT TO MAKE RICH TEXT EDITING
+   */
+  type FormattedString = {
+    /** The language in which the text is written. If null, the language is the Comment.Language of the owning comment. */
+    language?: Language;
+    /** Flags indicating the style */
+    style: Style;
+    /** The text of the string. Cannot be null or empty. */
+    text: string;
+  };
+
+  /**
+   * Indicates which styles are applied on a FormattedString.
+   *
+   * WARNING: SUBJECT TO CHANGE DEPENDING ON HOW WE WANT TO MAKE RICH TEXT EDITING
+   */
+  enum Style {
+    /** Includes bold formatting */
+    Bold = 0,
+    /** Includes italics formatting */
+    Italic = 1,
+    /** No special formatting */
+    Plain = 2,
+  }
+
+  /** Specifies which notes to retrieve from `ProjectNotesDataProvider.GetNotes` */
+  type ProjectNotesSelector = {
+    /** The project from which to get notes */
+    projectId: string;
+    /**
+     * Book number from which to retrieve notes. If not provided or 0, get notes from the entire project
+     *
+     * @default 0
+     */
+    bookNum?: number;
+    /**
+     * Chapter number from which to retrieve notes. If not provided or 0, get notes from the whole book
+     *
+     * @default 0
+     */
+    chapterNum?: number;
+    /**
+     * Whether or not to return only unresolved notes.
+     *
+     * @default false
+     */
+    shouldRetrieveOnlyUnresolved?: boolean;
+  };
+
+  /**
+   * Data provider for manipulating project notes
+   *
+   * This is a hand-written baked-out version of `ProjectNotesDataProvider` for ease of reading
+   */
+  type ProjectNotesDataProviderExpanded = {
+    /** Event emitted when this provider is disposed */
+    onDidDispose: PapiEvent<void>;
+    /** Get notes from the provider. `setNotes` is not available; please use `addNote` */
+    getNotes(notesSelector: ProjectNotesSelector): Promise<ProjectNote[]>;
+    /**
+     * Subscribe to run a callback function when notes are added
+     *
+     * @param notesSelector tells the provider what notes to listen for
+     * @param callback function to run with the updated notes for this selector
+     * @param options various options to adjust how the subscriber emits updates
+     *
+     * @returns unsubscriber function (run to unsubscribe from listening for updates)
+     */
+    subscribeNotes(
+      notesSelector: ProjectNotesSelector,
+      callback: (notes: ProjectNote[]) => void,
+      options?: DataProviderSubscriberOptions,
+    ): Unsubscriber;
+    /**
+     * Adds a project note
+     *
+     * @param anchor A selection in the Scripture text representing the "anchor" location of the note. Note that the `ScriptureTextSelection.SelectedText` is expected to begin and end at a word break; We will attempt to expand the selection if it is not.
+     * @param contentParagraphs One or more paragraphs of formatted text
+     * @param language The default language used in `contentParagraphs` (except where specified explicitly in a `FormattedString`).
+     * @param assignedUser User (if any) to whom the new note is to be assigned.
+     *
+     * @returns `ProjectNote` the newly added note
+     */
+    addNote(
+      anchor: ScriptureTextSelection,
+      contentParagraphs: CommentParagraph[],
+      language?: Language,
+      assignedUser?: UserInfo,
+    ): Promise<ProjectNote>;
+  };
+}

--- a/extensions/src/project-notes-data-provider/manifest.json
+++ b/extensions/src/project-notes-data-provider/manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "project-notes-data-provider",
+  "version": "0.0.1",
+  "description": "Project Notes Data Provider for Paranext - provided by C# data provider",
+  "author": "Paranext",
+  "license": "MIT",
+  "main": null,
+  "activationEvents": []
+}

--- a/extensions/src/usfm-data-provider/index.d.ts
+++ b/extensions/src/usfm-data-provider/index.d.ts
@@ -1,6 +1,15 @@
 import { VerseRef } from '@sillsdev/scripture';
-import type { DataProviderDataType } from 'shared/models/data-provider.model';
+import type {
+  DataProviderDataType,
+  DataProviderSubscriberOptions,
+  DataProviderUpdateInstructions,
+} from 'shared/models/data-provider.model';
 import type IDataProvider from 'shared/models/data-provider.interface';
+import type {
+  ExtensionDataScope,
+  MandatoryProjectDataType,
+} from 'shared/models/project-data-provider.model';
+import type { Unsubscriber } from 'shared/utils/papi-util';
 
 declare module 'usfm-data-provider' {
   export type UsfmProviderDataTypes = {
@@ -11,4 +20,320 @@ declare module 'usfm-data-provider' {
   };
 
   export type UsfmDataProvider = IDataProvider<UsfmProviderDataTypes>;
+}
+
+declare module 'papi-shared-types' {
+  /** This is not yet a complete list of the data types available from Paratext projects. */
+  export type ParatextStandardProjectDataTypes = MandatoryProjectDataType & {
+    /** Gets the "raw" USFM data for the specified book */
+    BookUSFM: DataProviderDataType<VerseRef, string | undefined, string>;
+    /** Gets the "raw" USFM data for the specified chapter */
+    ChapterUSFM: DataProviderDataType<VerseRef, string | undefined, string>;
+    /** Gets the "raw" USFM data for the specified verse */
+    VerseUSFM: DataProviderDataType<VerseRef, string | undefined, string>;
+    /**
+     * Gets the tokenized USJ data for the specified book
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     */
+    BookUSJ: DataProviderDataType<VerseRef, USJDocument | undefined, USJDocument>;
+    /**
+     * Gets the tokenized USJ data for the specified chapter
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     */
+    ChapterUSJ: DataProviderDataType<VerseRef, USJDocument | undefined, USJDocument>;
+    /**
+     * Gets the tokenized USJ data for the specified verse
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     */
+    VerseUSJ: DataProviderDataType<VerseRef, USJDocument | undefined, USJDocument>;
+  };
+
+  export interface ProjectDataTypes {
+    ParatextStandard: ParatextStandardProjectDataTypes;
+  }
+
+  /**
+   * Scripture data represented in JSON format. Transformation from USX
+   *
+   * [See more information here](https://github.com/paranext/paranext-core/issues/480#issuecomment-1751094148)
+   */
+  type USJDocument = {
+    /** The Scripture data serialization format used for this document */
+    type: 'USJ';
+    /** The USJ spec version */
+    version: '0.0.1-alpha.2';
+    /** Scripture contents laid out in a linear fashion */
+    content: MarkerContent[];
+  };
+
+  /** One piece of Scripture content. Can be a simple string or a marker and its contents */
+  type MarkerContent = string | MarkerObject;
+
+  /** A Scripture Marker and its contents */
+  type MarkerObject = {
+    /**
+     * The kind of node or element this is, corresponding to each marker in USFM or each node in USX
+     *
+     * Its format is `type:style`
+     *
+     * @example `para:p`, `verse:v`, `char:nd`
+     */
+    type: `${string}:${string}`;
+    /** This marker's contents laid out in a linear fashion */
+    content?: MarkerContent[];
+    /** Indicates the Book-chapter-verse value in the paragraph based structure */
+    sid?: string;
+    /** Chapter number or verse number */
+    number?: string;
+    /** The 3-letter book code in the id element */
+    code?: BookCode;
+    /** Alternate chapter number or verse number */
+    altnumber?: string;
+    /** Published character of chapter or verse */
+    pubnumber?: string;
+    /** Caller character for footnotes and cross-refs */
+    caller?: string;
+    /** Alignment of table cells */
+    align?: string;
+    /** Category of extended study bible sections */
+    category?: string;
+  };
+
+  /** Three-letter Scripture book code */
+  // prettier-ignore
+  type BookCode = "GEN" | "EXO" | "LEV" | "NUM" | "DEU" | "JOS" | "JDG" | "RUT" | "1SA" | "2SA" | "1KI" | "2KI" | "1CH" | "2CH" | "EZR" | "NEH" | "EST" | "JOB" | "PSA" | "PRO" | "ECC" | "SNG" | "ISA" | "JER" | "LAM" | "EZK" | "DAN" | "HOS" | "JOL" | "AMO" | "OBA" | "JON" | "MIC" | "NAM" | "HAB" | "ZEP" | "HAG" | "ZEC" | "MAL" | "MAT" | "MRK" | "LUK" | "JHN" | "ACT" | "ROM" | "1CO" | "2CO" | "GAL" | "EPH" | "PHP" | "COL" | "1TH" | "2TH" | "1TI" | "2TI" | "TIT" | "PHM" | "HEB" | "JAS" | "1PE" | "2PE" | "1JN" | "2JN" | "3JN" | "JUD" | "REV" | "TOB" | "JDT" | "ESG" | "WIS" | "SIR" | "BAR" | "LJE" | "S3Y" | "SUS" | "BEL" | "1MA" | "2MA" | "3MA" | "4MA" | "1ES" | "2ES" | "MAN" | "PS2" | "ODA" | "PSS" | "EZA" | "5EZ" | "6EZ" | "DAG" | "PS3" | "2BA" | "LBA" | "JUB" | "ENO" | "1MQ" | "2MQ" | "3MQ" | "REP" | "4BA" | "LAO" | "FRT" | "BAK" | "OTH" | "INT" | "CNC" | "GLO" | "TDX" | "NDX" | "XXA" | "XXB" | "XXC" | "XXD" | "XXE" | "XXF" | "XXG";
+
+  /**
+   * Provides project data for Paratext Scripture projects. One is created for each project that is used
+   *
+   * This is a hand-written baked-out version of `ParatextStandardProjectDataProvider` for ease of reading
+   */
+  type ParatextStandardProjectDataProviderExpanded = {
+    /** Gets the "raw" USFM data for the specified book */
+    getBookUSFM(verseRef: VerseRef): Promise<string | undefined>;
+    /** Sets the "raw" USFM data for the specified book */
+    setBookUSFM(
+      verseRef: VerseRef,
+      usfm: string,
+    ): Promise<DataProviderUpdateInstructions<ParatextStandardProjectDataTypes>>;
+    /**
+     * Subscribe to run a callback function when the "raw" USFM data is changed
+     *
+     * @param verseRef tells the provider what changes to listen for
+     * @param callback function to run with the updated USFM for this selector
+     * @param options various options to adjust how the subscriber emits updates
+     *
+     * @returns unsubscriber function (run to unsubscribe from listening for updates)
+     */
+    subscribeBookUSFM(
+      verseRef: VerseRef,
+      callback: (usfm: string | undefined) => void,
+      options?: DataProviderSubscriberOptions,
+    ): Unsubscriber;
+
+    /** Gets the "raw" USFM data for the specified chapter */
+    getChapterUSFM(verseRef: VerseRef): Promise<string | undefined>;
+    /** Sets the "raw" USFM data for the specified chapter */
+    setChapterUSFM(
+      verseRef: VerseRef,
+      usfm: string,
+    ): Promise<DataProviderUpdateInstructions<ParatextStandardProjectDataTypes>>;
+    /**
+     * Subscribe to run a callback function when the "raw" USFM data is changed
+     *
+     * @param verseRef tells the provider what changes to listen for
+     * @param callback function to run with the updated USFM for this selector
+     * @param options various options to adjust how the subscriber emits updates
+     *
+     * @returns unsubscriber function (run to unsubscribe from listening for updates)
+     */
+    subscribeChapterUSFM(
+      verseRef: VerseRef,
+      callback: (usfm: string | undefined) => void,
+      options?: DataProviderSubscriberOptions,
+    ): Unsubscriber;
+
+    /** Gets the "raw" USFM data for the specified verse */
+    getVerseUSFM(verseRef: VerseRef): Promise<string | undefined>;
+    /** Sets the "raw" USFM data for the specified verse */
+    setVerseUSFM(
+      verseRef: VerseRef,
+      usfm: string,
+    ): Promise<DataProviderUpdateInstructions<ParatextStandardProjectDataTypes>>;
+    /**
+     * Subscribe to run a callback function when the "raw" USFM data is changed
+     *
+     * @param verseRef tells the provider what changes to listen for
+     * @param callback function to run with the updated USFM for this selector
+     * @param options various options to adjust how the subscriber emits updates
+     *
+     * @returns unsubscriber function (run to unsubscribe from listening for updates)
+     */
+    subscribeVerseUSFM(
+      verseRef: VerseRef,
+      callback: (usfm: string | undefined) => void,
+      options?: DataProviderSubscriberOptions,
+    ): Unsubscriber;
+
+    /**
+     * Gets the tokenized USJ data for the specified book
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     */
+    getBookUSJ(verseRef: VerseRef): Promise<USJDocument | undefined>;
+    /**
+     * Sets the tokenized USJ data for the specified book
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     */
+    setBookUSJ(
+      verseRef: VerseRef,
+      usj: USJDocument,
+    ): Promise<DataProviderUpdateInstructions<ParatextStandardProjectDataTypes>>;
+    /**
+     * Subscribe to run a callback function when the tokenized USJ data is changed
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     *
+     * @param verseRef tells the provider what changes to listen for
+     * @param callback function to run with the updated USJ for this selector
+     * @param options various options to adjust how the subscriber emits updates
+     *
+     * @returns unsubscriber function (run to unsubscribe from listening for updates)
+     */
+    subscribeBookUSJ(
+      verseRef: VerseRef,
+      callback: (usj: USJDocument | undefined) => void,
+      options?: DataProviderSubscriberOptions,
+    ): Unsubscriber;
+
+    /**
+     * Gets the tokenized USJ data for the specified chapter
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     */
+    getChapterUSJ(verseRef: VerseRef): Promise<USJDocument | undefined>;
+    /**
+     * Sets the tokenized USJ data for the specified chapter
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     */
+    setChapterUSJ(
+      verseRef: VerseRef,
+      usj: USJDocument,
+    ): Promise<DataProviderUpdateInstructions<ParatextStandardProjectDataTypes>>;
+    /**
+     * Subscribe to run a callback function when the tokenized USJ data is changed
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     *
+     * @param verseRef tells the provider what changes to listen for
+     * @param callback function to run with the updated USJ for this selector
+     * @param options various options to adjust how the subscriber emits updates
+     *
+     * @returns unsubscriber function (run to unsubscribe from listening for updates)
+     */
+    subscribeChapterUSJ(
+      verseRef: VerseRef,
+      callback: (usj: USJDocument | undefined) => void,
+      options?: DataProviderSubscriberOptions,
+    ): Unsubscriber;
+
+    /**
+     * Gets the tokenized USJ data for the specified verse
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     */
+    getVerseUSJ(verseRef: VerseRef): Promise<USJDocument | undefined>;
+    /**
+     * Sets the tokenized USJ data for the specified verse
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     */
+    setVerseUSJ(
+      verseRef: VerseRef,
+      usj: USJDocument,
+    ): Promise<DataProviderUpdateInstructions<ParatextStandardProjectDataTypes>>;
+    /**
+     * Subscribe to run a callback function when the tokenized USJ data is changed
+     *
+     * WARNING: USJ is one of many possible tokenized formats that we may use, so this may change
+     * over time. Additionally, USJ is in very early stages of proposal, so it will likely also
+     * change over time.
+     *
+     * @param verseRef tells the provider what changes to listen for
+     * @param callback function to run with the updated USJ for this selector
+     * @param options various options to adjust how the subscriber emits updates
+     *
+     * @returns unsubscriber function (run to unsubscribe from listening for updates)
+     */
+    subscribeVerseUSJ(
+      verseRef: VerseRef,
+      callback: (usj: USJDocument | undefined) => void,
+      options?: DataProviderSubscriberOptions,
+    ): Unsubscriber;
+
+    /**
+     * Gets an extension's serialized project data (so the extension can provide and manipulate its project data)
+     *
+     * @param dataScope contains the name of the extension requesting the data and which data it is requesting
+     * @example `{ extensionName: 'biblicalTerms', dataQualifier: 'renderings' }`
+     *
+     * @returns promise that resolves to the requested extension project data
+     */
+    getExtensionData(dataScope: ExtensionDataScope): Promise<string | undefined>;
+    /**
+     * Sets an extension's serialized project data (so the extension can provide and manipulate its project data)
+     *
+     * @param dataScope contains the name of the extension requesting the data and which data it is requesting
+     * @example `{ extensionName: 'biblicalTerms', dataQualifier: 'renderings' }`
+     * @param extensionData the new project data for this extension
+     *
+     * @returns promise that resolves indicating which data types received updates
+     */
+    setExtensionData(
+      dataScope: ExtensionDataScope,
+      extensionData: string | undefined,
+    ): Promise<DataProviderUpdateInstructions<ParatextStandardProjectDataTypes>>;
+    /**
+     * Subscribe to run a callback function when an extension's serialized project data is changed
+     *
+     * @param dataScope contains the name of the extension requesting the data and which data it is requesting
+     * @example `{ extensionName: 'biblicalTerms', dataQualifier: 'renderings' }`
+     * @param callback function to run with the updated extension data for this selector
+     * @param options various options to adjust how the subscriber emits updates
+     *
+     * @returns unsubscriber function (run to unsubscribe from listening for updates)
+     */
+    subscribeExtensionData(
+      dataScope: ExtensionDataScope,
+      callback: (extensionData: string | undefined) => void,
+      options?: DataProviderSubscriberOptions,
+    ): Unsubscriber;
+  };
 }

--- a/extensions/src/usfm-data-provider/index.d.ts
+++ b/extensions/src/usfm-data-provider/index.d.ts
@@ -23,7 +23,11 @@ declare module 'usfm-data-provider' {
 }
 
 declare module 'papi-shared-types' {
-  /** This is not yet a complete list of the data types available from Paratext projects. */
+  /**
+   * Provides project data for Paratext Scripture projects.
+   *
+   * This is not yet a complete list of the data types available from Paratext projects.
+   */
   export type ParatextStandardProjectDataTypes = MandatoryProjectDataType & {
     /** Gets the "raw" USFM data for the specified book */
     BookUSFM: DataProviderDataType<VerseRef, string | undefined, string>;

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1514,7 +1514,6 @@ declare module 'papi-shared-types' {
   import { ScriptureReference } from 'papi-components';
   import type { DataProviderDataType } from 'shared/models/data-provider.model';
   import type { MandatoryProjectDataType } from 'shared/models/project-data-provider.model';
-  import { VerseRef } from '@sillsdev/scripture';
   /**
      * Function types for each command available on the papi. Each extension can extend this interface
      * to add commands that it registers on the papi.
@@ -1559,12 +1558,6 @@ declare module 'papi-shared-types' {
     placeholder: null;
   }
   type SettingNames = keyof SettingTypes;
-  /** This is not yet a complete list of the data types available from Paratext projects. */
-  type ParatextStandardProjectDataTypes = MandatoryProjectDataType & {
-    Book: DataProviderDataType<VerseRef, string | undefined, string>;
-    Chapter: DataProviderDataType<VerseRef, string | undefined, string>;
-    Verse: DataProviderDataType<VerseRef, string | undefined, string>;
-  };
   /** This is just a simple example so we have more than one. It's not intended to be real. */
   type NotesOnlyProjectDataTypes = MandatoryProjectDataType & {
     Notes: DataProviderDataType<string, string | undefined, string>;
@@ -1589,7 +1582,6 @@ declare module 'papi-shared-types' {
    * ```
    */
   interface ProjectDataTypes {
-    ParatextStandard: ParatextStandardProjectDataTypes;
     NotesOnly: NotesOnlyProjectDataTypes;
   }
   /**

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -2,7 +2,6 @@ declare module 'papi-shared-types' {
   import { ScriptureReference } from 'papi-components';
   import type { DataProviderDataType } from 'shared/models/data-provider.model';
   import type { MandatoryProjectDataType } from '@shared/models/project-data-provider.model';
-  import { VerseRef } from '@sillsdev/scripture';
 
   // TODO: Adding an index type removes type checking on the key :( How do we make sure extensions provide only functions?
   /**
@@ -61,13 +60,6 @@ declare module 'papi-shared-types' {
 
   export type SettingNames = keyof SettingTypes;
 
-  /** This is not yet a complete list of the data types available from Paratext projects. */
-  export type ParatextStandardProjectDataTypes = MandatoryProjectDataType & {
-    Book: DataProviderDataType<VerseRef, string | undefined, string>;
-    Chapter: DataProviderDataType<VerseRef, string | undefined, string>;
-    Verse: DataProviderDataType<VerseRef, string | undefined, string>;
-  };
-
   /** This is just a simple example so we have more than one. It's not intended to be real. */
   export type NotesOnlyProjectDataTypes = MandatoryProjectDataType & {
     Notes: DataProviderDataType<string, string | undefined, string>;
@@ -93,7 +85,6 @@ declare module 'papi-shared-types' {
    * ```
    */
   export interface ProjectDataTypes {
-    ParatextStandard: ParatextStandardProjectDataTypes;
     NotesOnly: NotesOnlyProjectDataTypes;
   }
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -321,12 +321,10 @@ async function main() {
   //  }
   /*
   setTimeout(async () => {
-    const paratextPdp = await getProjectDataProvider(
-      'b4c501ad2538989d6fb723518e92408406e232d3',
-      'ParatextStandard',
-      'paratextFolders',
+    const paratextPdp = await getProjectDataProvider<'ParatextStandard'>(
+      '32664dc3288a28df2e2bb75ded887fc8f17a15fb',
     );
-    const verse = await paratextPdp.getVerse(new VerseRef('JHN', '1', '1'));
+    const verse = await paratextPdp.getVerseUSFM(new VerseRef('JHN', '1', '1'));
     logger.info(`Got PDP data: ${verse}`);
     paratextPdp.setExtensionData(
       { extensionName: 'foo', dataQualifier: 'fooData' },


### PR DESCRIPTION
Related to #479, #480.

Quick and dirty proposed types for Scripture and Project Notes data providers so the Information Architecture group can read them and get an idea of what's going on. There are many outstanding questions on Project Notes as I essentially copied them straight from the PT9 plugin interface. We still don't know what tokenization of USFM we will use, so I started with USJ.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/538)
<!-- Reviewable:end -->
