### PR TITLE
Add eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -55,6 +55,7 @@ module.exports = {
       'error',
       { functions: false, allowNamedExports: true, typedefs: false, ignoreTypeReferences: true },
     ],
+    '@typescript-eslint/no-unnecessary-type-assertion': 'error',
     'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': 'error',
     'no-useless-constructor': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -71,6 +71,7 @@ module.exports = {
     // Should use our logger anytime you want logs that persist. Otherwise use console only in testing
     'no-console': 'warn',
     'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
+    'no-type-assertion/no-type-assertion': 'error',
     'prettier/prettier': ['warn', { tabWidth: 2, trailingComma: 'all' }],
     'react/jsx-indent-props': ['warn', 2],
     'react/jsx-props-no-spreading': ['error', { custom: 'ignore' }],
@@ -88,7 +89,7 @@ module.exports = {
     tsconfigRootDir: __dirname,
     createDefaultProgram: true,
   },
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'no-type-assertion'],
   settings: {
     'import/resolver': {
       // See https://github.com/benmosher/eslint-plugin-import/issues/1396#issuecomment-575727774 for line below

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -45,7 +45,6 @@ module.exports = {
       },
     ],
     '@typescript-eslint/no-explicit-any': 'error',
-    '@typescript-eslint/no-non-null-assertion': 'error',
     'no-redeclare': 'off',
     '@typescript-eslint/no-redeclare': 'error',
     'no-shadow': 'off',

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -52,8 +52,8 @@ const config: StorybookConfig = {
           return mergeWithCustomize({
             customizeArray(wpModule: object[], rModule: object[], moduleKey: string) {
               if (moduleKey === 'rules') {
-                const wpRules = wpModule as RuleSetRule[];
-                const rRules = rModule as RuleSetRule[];
+                const wpRules: RuleSetRule[] = wpModule;
+                const rRules: RuleSetRule[] = rModule;
                 return [
                   ...wpRules.filter(
                     (rule) =>

--- a/extensions/src/hello-someone/hello-someone.ts
+++ b/extensions/src/hello-someone/hello-someone.ts
@@ -72,7 +72,7 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
    */
   getPerson<T extends boolean = true>(
     name: string,
-    // TODO: I don't actually know why this of type T rather than just a boolean?
+    // Assert the conditional type.
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     createIfDoesNotExist: T = true as T,
   ): T extends true ? Person : Person | undefined {

--- a/extensions/src/hello-someone/hello-someone.ts
+++ b/extensions/src/hello-someone/hello-someone.ts
@@ -72,11 +72,14 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
    */
   getPerson<T extends boolean = true>(
     name: string,
+    // TODO: I don't actually know why this of type T rather than just a boolean?
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     createIfDoesNotExist: T = true as T,
   ): T extends true ? Person : Person | undefined {
     const nameLower = name.toLowerCase();
     if (createIfDoesNotExist && !this.people[nameLower]) this.people[nameLower] = {};
     // Type assert because we know this person exists
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     return this.people[nameLower] as T extends true ? Person : Person | undefined;
   },
 
@@ -238,6 +241,8 @@ const peopleWebViewProvider: IWebViewProvider = {
     return {
       ...savedWebView,
       title: 'People',
+      // Can't use the enum value from a definition file so assert the type from the string literal.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       contentType: 'html' as WebViewContentType.HTML,
       content: helloSomeoneHtmlWebView,
     };

--- a/extensions/src/hello-world/hello-world.ts
+++ b/extensions/src/hello-world/hello-world.ts
@@ -34,6 +34,8 @@ const htmlWebViewProvider: IWebViewProviderWithType = {
     return {
       ...savedWebView,
       title: 'Hello World HTML',
+      // Can't use the enum value from a definition file so assert the type from the string literal.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       contentType: 'html' as WebViewContentType.HTML,
       content: helloWorldHtmlWebView,
     };

--- a/extensions/src/hello-world/web-views/hello-world.web-view.tsx
+++ b/extensions/src/hello-world/web-views/hello-world.web-view.tsx
@@ -97,6 +97,8 @@ globalThis.webViewComponent = function HelloWorld() {
       iconUrl: 'papi-extension://hello-world/assets/offline.svg',
       title: 'Select Hello World Project',
     }).current,
+    // Assert as string literal type rather than string type.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     'None' as DialogTypes['platform.selectProject']['responseType'],
   );
 
@@ -191,10 +193,7 @@ globalThis.webViewComponent = function HelloWorld() {
         <Switch /> {/* no label available */}
         <ComboBox title="Test Me" options={['option 1', 'option 2']} />
         <Slider /> {/* no label available */}
-        <RefSelector
-          scrRef={scrRef as ScriptureReference}
-          handleSubmit={(newScrRef) => setScrRef(newScrRef)}
-        />
+        <RefSelector scrRef={scrRef} handleSubmit={(newScrRef) => setScrRef(newScrRef)} />
         <Table<Row>
           columns={[
             {

--- a/extensions/src/hello-world/web-views/hello-world.web-view.tsx
+++ b/extensions/src/hello-world/web-views/hello-world.web-view.tsx
@@ -97,7 +97,7 @@ globalThis.webViewComponent = function HelloWorld() {
       iconUrl: 'papi-extension://hello-world/assets/offline.svg',
       title: 'Select Hello World Project',
     }).current,
-    // Assert as string literal type rather than string type.
+    // Assert as string type rather than string literal type.
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     'None' as DialogTypes['platform.selectProject']['responseType'],
   );

--- a/extensions/webpack/webpack.util.ts
+++ b/extensions/webpack/webpack.util.ts
@@ -70,13 +70,13 @@ export function getWebViewTempPath(
  */
 export async function getWebViewEntries(): Promise<webpack.EntryObject> {
   const tsxWebViews = await getWebViewTsxPaths();
-  const webViewEntries = Object.fromEntries(
+  const webViewEntries: webpack.EntryObject = Object.fromEntries(
     tsxWebViews.map((webViewPath) => [
       webViewPath,
       {
         import: webViewPath,
         filename: getWebViewTempPath(webViewPath),
-      } as webpack.EntryObject[string],
+      },
     ]),
   );
   return webViewEntries;
@@ -191,7 +191,7 @@ export function getMainEntries(extensions: ExtensionInfo[]): webpack.EntryObject
           library: {
             type: LIBRARY_TYPE,
           },
-        } as webpack.EntryObject[string],
+        },
       ]),
   );
   return mainEntries;
@@ -257,9 +257,9 @@ export async function getExtensions(): Promise<ExtensionInfo[]> {
         path.join(sourceFolder, extensionFolderName, 'manifest.json'),
         'utf8',
       );
-      const extensionManifest = Object.freeze({
+      const extensionManifest: Readonly<ExtensionManifest> = Object.freeze({
         // Note that this does not transform the main file .ts into .js unlike extension.service
-        ...(JSON.parse(extensionManifestJson) as ExtensionManifest),
+        ...JSON.parse(extensionManifestJson),
       });
 
       // Get main file path from the manifest and return extension info

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1057,8 +1057,10 @@ declare module 'shared/services/network.service' {
    * Register a local request handler to run on requests.
    * @param requestType the type of request on which to register the handler
    * @param handler function to register to run on requests
-   * @param handlerType type of handler function - indicates what type of parameters and what return type the handler has
-   * @returns promise that resolves if the request successfully registered and unsubscriber function to run to stop the passed-in function from handling requests
+   * @param handlerType type of handler function - indicates what type of parameters and what return
+   * type the handler has
+   * @returns promise that resolves if the request successfully registered and unsubscriber function
+   * to run to stop the passed-in function from handling requests
    */
   export function registerRequestHandler(
     requestType: SerializedRequestType,
@@ -1096,7 +1098,8 @@ declare module 'shared/services/network.service' {
    * Creates a function that is a request function with a baked requestType.
    * This is also nice because you get TypeScript type support using this function.
    * @param requestType requestType for request function
-   * @returns function to call with arguments of request that performs the request and resolves with the response contents
+   * @returns function to call with arguments of request that performs the request and resolves with
+   * the response contents
    */
   export const createRequestFunction: <TParam extends unknown[], TReturn>(
     requestType: SerializedRequestType,
@@ -2131,7 +2134,12 @@ declare module 'shared/services/web-view.service' {
    *
    * Not exposed on the papi
    */
-  export const addTab: (savedTabInfo: SavedTabInfo, layout: Layout) => Promise<Layout | undefined>;
+  export const addTab: <TData = unknown>(
+    savedTabInfo: SavedTabInfo & {
+      data?: TData | undefined;
+    },
+    layout: Layout,
+  ) => Promise<Layout | undefined>;
   /**
    * Creates a new web view or gets an existing one depending on if you request an existing one and
    * if the web view provider decides to give that existing one to you (it is up to the provider).
@@ -2442,6 +2450,7 @@ declare module 'shared/services/data-provider.service' {
   export default dataProviderService;
 }
 declare module 'shared/models/project-metadata.model' {
+  import { ProjectTypes } from 'papi-shared-types';
   /**
    * Low-level information describing a project that Platform.Bible directly manages and uses to load project data
    */
@@ -2461,7 +2470,7 @@ declare module 'shared/models/project-metadata.model' {
     /**
      * Indicates what sort of project this is which implies its data shape (e.g., what data streams should be available)
      */
-    projectType: string;
+    projectType: ProjectTypes;
   };
 }
 declare module 'shared/services/project-lookup.service-model' {
@@ -2801,7 +2810,8 @@ declare module 'shared/services/settings.service' {
   /**
    * Retrieves the value of the specified setting
    * @param key The string id of the setting for which the value is being retrieved
-   * @returns The value of the specified setting, parsed to an object. Returns `null` if setting is not present or no value is available
+   * @returns The value of the specified setting, parsed to an object. Returns `null` if setting is
+   * not present or no value is available
    */
   const getSetting: <SettingName extends keyof SettingTypes>(
     key: SettingName,
@@ -2809,14 +2819,16 @@ declare module 'shared/services/settings.service' {
   /**
    * Sets the value of the specified setting
    * @param key The string id of the setting for which the value is being retrieved
-   * @param newSetting The value that is to be stored. Setting the new value to `null` is the equivalent of deleting the setting
+   * @param newSetting The value that is to be stored. Setting the new value to `null` is the
+   * equivalent of deleting the setting
    */
   const setSetting: <SettingName extends keyof SettingTypes>(
     key: SettingName,
     newSetting: Nullable<SettingTypes[SettingName]>,
   ) => void;
   /**
-   * Subscribes to updates of the specified setting. Whenever the value of the setting changes, the callback function is executed.
+   * Subscribes to updates of the specified setting. Whenever the value of the setting changes, the
+   * callback function is executed.
    * @param key The string id of the setting for which the value is being subscribed to
    * @param callback The function that will be called whenever the specified setting is updated
    * @returns Unsubscriber that should be called whenever the subscription should be deleted

--- a/package-lock.json
+++ b/package-lock.json
@@ -86,6 +86,7 @@
         "eslint-plugin-import": "^2.28.1",
         "eslint-plugin-jest": "^27.2.3",
         "eslint-plugin-jsx-a11y": "^6.7.1",
+        "eslint-plugin-no-type-assertion": "^1.3.0",
         "eslint-plugin-promise": "^6.1.1",
         "eslint-plugin-react": "^7.33.2",
         "eslint-plugin-react-hooks": "^4.6.0",
@@ -204,13 +205,79 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.5",
-      "license": "MIT",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "dependencies": {
-        "@babel/highlight": "^7.22.5"
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/@babel/code-frame/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/code-frame/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@babel/compat-data": {
@@ -262,12 +329,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-      "integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.22.5",
+        "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -428,20 +495,22 @@
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
-      "version": "7.22.5",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -595,8 +664,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.22.5",
-      "license": "MIT",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -638,11 +708,12 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.5",
-      "license": "MIT",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "engines": {
@@ -651,7 +722,8 @@
     },
     "node_modules/@babel/highlight/node_modules/ansi-styles": {
       "version": "3.2.1",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -661,7 +733,8 @@
     },
     "node_modules/@babel/highlight/node_modules/chalk": {
       "version": "2.4.2",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -673,32 +746,37 @@
     },
     "node_modules/@babel/highlight/node_modules/color-convert": {
       "version": "1.9.3",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
       "dependencies": {
         "color-name": "1.1.3"
       }
     },
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
-      "license": "MIT"
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
       "engines": {
         "node": ">=0.8.0"
       }
     },
     "node_modules/@babel/highlight/node_modules/has-flag": {
       "version": "3.0.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
       "engines": {
         "node": ">=4"
       }
     },
     "node_modules/@babel/highlight/node_modules/supports-color": {
       "version": "5.5.0",
-      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dependencies": {
         "has-flag": "^3.0.0"
       },
@@ -707,9 +785,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -2319,32 +2397,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.22.5",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/parser": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-      "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dev": true,
       "dependencies": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.7",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.7",
-        "@babel/types": "^7.22.5",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       },
@@ -2353,12 +2432,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
-      "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -13824,6 +13903,19 @@
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-no-type-assertion": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-type-assertion/-/eslint-plugin-no-type-assertion-1.3.0.tgz",
+      "integrity": "sha512-04wuuIP5ptNzp969tTt0gf/Jsw4G0T5md2/nbgv3dRL/HySSNU7H4vIKNjkuno9T+6h2daj1T9Aki6bDgmXDEw==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0",
+        "yarn": "^1.13.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-prettier": {
@@ -26231,9 +26323,63 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.22.5",
+      "version": "7.22.13",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
+      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
       "requires": {
-        "@babel/highlight": "^7.22.5"
+        "@babel/highlight": "^7.22.13",
+        "chalk": "^2.4.2"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "@babel/compat-data": {
@@ -26274,12 +26420,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.22.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.9.tgz",
-      "integrity": "sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.0.tgz",
+      "integrity": "sha512-lN85QRR+5IbYrMWM6Y4pE/noaQtg4pNiqeNGX60eqOfo6gtEj6uw/JagelB8vVztSd7R6M5n1+PQkDbHbBRU4g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.22.5",
+        "@babel/types": "^7.23.0",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -26408,15 +26554,19 @@
       }
     },
     "@babel/helper-environment-visitor": {
-      "version": "7.22.5",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true
     },
     "@babel/helper-function-name": {
-      "version": "7.22.5",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "requires": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       }
     },
     "@babel/helper-hoist-variables": {
@@ -26516,7 +26666,9 @@
       "version": "7.22.5"
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.22.5"
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A=="
     },
     "@babel/helper-validator-option": {
       "version": "7.22.5",
@@ -26545,21 +26697,27 @@
       }
     },
     "@babel/highlight": {
-      "version": "7.22.5",
+      "version": "7.22.20",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
+      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
       "requires": {
-        "@babel/helper-validator-identifier": "^7.22.5",
-        "chalk": "^2.0.0",
+        "@babel/helper-validator-identifier": "^7.22.20",
+        "chalk": "^2.4.2",
         "js-tokens": "^4.0.0"
       },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "chalk": {
           "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -26568,21 +26726,31 @@
         },
         "color-convert": {
           "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
           "requires": {
             "color-name": "1.1.3"
           }
         },
         "color-name": {
-          "version": "1.1.3"
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
-          "version": "1.0.5"
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         },
         "has-flag": {
-          "version": "3.0.0"
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw=="
         },
         "supports-color": {
           "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
           "requires": {
             "has-flag": "^3.0.0"
           }
@@ -26590,9 +26758,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.22.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.7.tgz",
-      "integrity": "sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
+      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
       "dev": true
     },
     "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": {
@@ -27642,39 +27810,41 @@
       }
     },
     "@babel/template": {
-      "version": "7.22.5",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
+      "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/parser": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/code-frame": "^7.22.13",
+        "@babel/parser": "^7.22.15",
+        "@babel/types": "^7.22.15"
       }
     },
     "@babel/traverse": {
-      "version": "7.22.8",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.8.tgz",
-      "integrity": "sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==",
+      "version": "7.23.2",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+      "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.22.5",
-        "@babel/generator": "^7.22.7",
-        "@babel/helper-environment-visitor": "^7.22.5",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/code-frame": "^7.22.13",
+        "@babel/generator": "^7.23.0",
+        "@babel/helper-environment-visitor": "^7.22.20",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.7",
-        "@babel/types": "^7.22.5",
+        "@babel/parser": "^7.23.0",
+        "@babel/types": "^7.23.0",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.22.11",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.11.tgz",
-      "integrity": "sha512-siazHiGuZRz9aB9NpHy9GOs9xiQPKnMzgdr493iI1M67vRXpnEq8ZOOKzezC5q7zwuQ6sDhdSp4SD9ixKSqKZg==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.0.tgz",
+      "integrity": "sha512-0oIyUfKoI3mSqMvsxBdclDwxXKXAUA8v/apZbc+iSyARYou1o8ZGDxbUYyLFoW2arqS2jDGqJuZvv1d/io1axg==",
       "requires": {
         "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.5",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -35584,6 +35754,13 @@
           "dev": true
         }
       }
+    },
+    "eslint-plugin-no-type-assertion": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-type-assertion/-/eslint-plugin-no-type-assertion-1.3.0.tgz",
+      "integrity": "sha512-04wuuIP5ptNzp969tTt0gf/Jsw4G0T5md2/nbgv3dRL/HySSNU7H4vIKNjkuno9T+6h2daj1T9Aki6bDgmXDEw==",
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-prettier": {
       "version": "4.2.1",

--- a/package.json
+++ b/package.json
@@ -168,6 +168,7 @@
     "eslint-plugin-import": "^2.28.1",
     "eslint-plugin-jest": "^27.2.3",
     "eslint-plugin-jsx-a11y": "^6.7.1",
+    "eslint-plugin-no-type-assertion": "^1.3.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-react": "^7.33.2",
     "eslint-plugin-react-hooks": "^4.6.0",

--- a/src/client/services/client-network-connector.service.ts
+++ b/src/client/services/client-network-connector.service.ts
@@ -334,7 +334,7 @@ export default class ClientNetworkConnector implements INetworkConnector {
   private onMessage = (event: MessageEvent<string>, fromSelf = false) => {
     const data = fromSelf
       ? (event.data as unknown as Message)
-      : (JSON.parse(event.data as string) as Message);
+      : (JSON.parse(event.data) as Message);
 
     const emitter = this.messageEmitters.get(data.type);
     emitter?.emit(data);

--- a/src/client/services/client-network-connector.service.ts
+++ b/src/client/services/client-network-connector.service.ts
@@ -175,11 +175,10 @@ export default class ClientNetworkConnector implements INetworkConnector {
         this.webSocket.addEventListener('close', this.disconnect);
 
         // Remove event listeners and try connecting again
-        const retry = (e: Event) => {
-          const err = (e as Event & { error?: Error }).error;
+        const retry = (e: Event & { error?: Error }) => {
           logger.warn(
             `ClientNetworkConnector WebSocket did not connect on attempt ${attempts}. Trying again. Error: ${getErrorMessage(
-              err,
+              e.error,
             )}`,
           );
           if (this.webSocket) {
@@ -315,6 +314,8 @@ export default class ClientNetworkConnector implements INetworkConnector {
     ) {
       // This message is from us and for us. Handle the message as if we just received it
       this.onMessage(
+        // Fake enough of the message event to handle it.
+        /* eslint-disable no-type-assertion/no-type-assertion */
         {
           data: message as unknown as string,
         } as MessageEvent,
@@ -332,9 +333,9 @@ export default class ClientNetworkConnector implements INetworkConnector {
    * @param fromSelf whether this message is from this connector instead of from someone else
    */
   private onMessage = (event: MessageEvent<string>, fromSelf = false) => {
-    const data = fromSelf
-      ? (event.data as unknown as Message)
-      : (JSON.parse(event.data) as Message);
+    // Assert our specific message type.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    const data: Message = fromSelf ? (event.data as unknown as Message) : JSON.parse(event.data);
 
     const emitter = this.messageEmitters.get(data.type);
     emitter?.emit(data);

--- a/src/client/services/web-socket.factory.ts
+++ b/src/client/services/web-socket.factory.ts
@@ -13,7 +13,7 @@ import { IWebSocket } from './web-socket.interface';
 export const createWebSocket = async (url: string): Promise<IWebSocket> => {
   if (isRenderer()) {
     const Ws = (await import('@renderer/services/renderer-web-socket.model')).default;
-    return new Ws(url) as IWebSocket;
+    return new Ws(url);
   }
   const Ws = (await import('@extension-host/services/extension-host-web-socket.model')).default;
   return new Ws(url) as unknown as IWebSocket;

--- a/src/client/services/web-socket.factory.ts
+++ b/src/client/services/web-socket.factory.ts
@@ -1,5 +1,6 @@
 /**
- * Creates a WebSocket from the node ws library or from the browser WebSocket depending on if we're in node or browser
+ * Creates a WebSocket from the node ws library or from the browser WebSocket depending on if we're
+ * in node or browser.
  */
 
 import { isRenderer } from '@shared/utils/internal-util';
@@ -16,7 +17,8 @@ export const createWebSocket = async (url: string): Promise<IWebSocket> => {
     return new Ws(url);
   }
   const Ws = (await import('@extension-host/services/extension-host-web-socket.model')).default;
-  // Assert the return type.
+  // Assert the return type. Note: this web socket is missing the `dispatchEvent` property that the
+  // renderer type has.
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   return new Ws(url) as unknown as IWebSocket;
 };

--- a/src/client/services/web-socket.factory.ts
+++ b/src/client/services/web-socket.factory.ts
@@ -16,5 +16,7 @@ export const createWebSocket = async (url: string): Promise<IWebSocket> => {
     return new Ws(url);
   }
   const Ws = (await import('@extension-host/services/extension-host-web-socket.model')).default;
+  // Assert the return type.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   return new Ws(url) as unknown as IWebSocket;
 };

--- a/src/extension-host/extension-host.ts
+++ b/src/extension-host/extension-host.ts
@@ -47,6 +47,8 @@ networkService
     // Set up network commands
     await Promise.all(
       Object.entries(commandHandlers).map(async ([commandName, handler]) => {
+        // Re-assert type after passing through `map`.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
         await papi.commands.registerCommand(commandName as CommandNames, handler);
       }),
     );

--- a/src/extension-host/global-this.model.ts
+++ b/src/extension-host/global-this.model.ts
@@ -18,6 +18,8 @@ import { ProcessType } from '@shared/global-this.model';
 const isPackaged = getCommandLineSwitch(ARG_PACKAGED);
 const resourcesPath = getCommandLineArgument(ARG_RESOURCES_PATH) ?? 'resources://';
 const logLevel =
+  // Assert the extracted type.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   (getCommandLineArgument(ARG_LOG_LEVEL) as LogLevel) ?? (isPackaged ? 'error' : 'info');
 
 // #endregion

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -277,7 +277,7 @@ async function getExtensions(): Promise<ExtensionInfo[]> {
         // If main is null, having no JavaScript is intentional. Do not load this extension
         return settled.value.main !== null;
       })
-      // Assert the more specific type.
+      // Assert the fulfilled type since the unfulfilled ones have been filtered out.
       // eslint-disable-next-line no-type-assertion/no-type-assertion
       .map((fulfilled) => (fulfilled as PromiseFulfilledResult<ExtensionInfo>).value)
   );

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -106,7 +106,7 @@ let availableExtensions: ExtensionInfo[];
 
 /** Parse string extension manifest into an object and perform any transformations needed */
 function parseManifest(extensionManifestJson: string): ExtensionManifest {
-  const extensionManifest = JSON.parse(extensionManifestJson) as ExtensionManifest;
+  const extensionManifest: ExtensionManifest = JSON.parse(extensionManifestJson);
   if (extensionManifest.name.includes('..'))
     throw new Error('Extension name must not include `..`!');
   // Replace ts with js so people can list their source code ts name but run the transpiled js
@@ -242,37 +242,45 @@ async function unzipCompressedExtensionFile(zipUri: Uri): Promise<void> {
 async function getExtensions(): Promise<ExtensionInfo[]> {
   const extensionUris = await extensionUrisToLoad;
   return (
-    await Promise.allSettled(
-      extensionUris.map(async (extensionUri) => {
-        try {
-          const extensionManifestJson = await nodeFS.readFileText(
-            joinUriPaths(extensionUri, MANIFEST_FILE_NAME),
-          );
-          return Object.freeze({
-            ...parseManifest(extensionManifestJson),
-            dirUri: extensionUri,
-          }) as ExtensionInfo;
-        } catch (e) {
-          const error = new Error(`Extension folder ${extensionUri} failed to load. Reason: ${e}`);
-          logger.warn(error);
-          throw error;
-        }
-      }),
+    (
+      await Promise.allSettled(
+        extensionUris.map(async (extensionUri) => {
+          try {
+            const extensionManifestJson = await nodeFS.readFileText(
+              joinUriPaths(extensionUri, MANIFEST_FILE_NAME),
+            );
+            // Assert the return type after freeze.
+            // eslint-disable-next-line no-type-assertion/no-type-assertion
+            return Object.freeze({
+              ...parseManifest(extensionManifestJson),
+              dirUri: extensionUri,
+            }) as ExtensionInfo;
+          } catch (e) {
+            const error = new Error(
+              `Extension folder ${extensionUri} failed to load. Reason: ${e}`,
+            );
+            logger.warn(error);
+            throw error;
+          }
+        }),
+      )
     )
-  )
-    .filter((settled) => {
-      // Ignore failed to load manifest issues - already logged those issues
-      if (settled.status !== 'fulfilled') return false;
-      if ((settled.value.main as Partial<ExtensionManifest>) === undefined) {
-        logger.warn(
-          `Extension ${settled.value.name} failed to load. Must provide property \`main\` in \`manifest.json\`. If you do not have JavaScript code to run, provide \`"main": null\``,
-        );
-        return false;
-      }
-      // If main is null, having no JavaScript is intentional. Do not load this extension
-      return settled.value.main !== null;
-    })
-    .map((fulfilled) => (fulfilled as PromiseFulfilledResult<ExtensionInfo>).value);
+      .filter((settled) => {
+        // Ignore failed to load manifest issues - already logged those issues
+        if (settled.status !== 'fulfilled') return false;
+        if (settled.value.main === undefined) {
+          logger.warn(
+            `Extension ${settled.value.name} failed to load. Must provide property \`main\` in \`manifest.json\`. If you do not have JavaScript code to run, provide \`"main": null\``,
+          );
+          return false;
+        }
+        // If main is null, having no JavaScript is intentional. Do not load this extension
+        return settled.value.main !== null;
+      })
+      // Assert the more specific type.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      .map((fulfilled) => (fulfilled as PromiseFulfilledResult<ExtensionInfo>).value)
+  );
 }
 
 /**
@@ -306,8 +314,9 @@ function watchForExtensionChanges(extensions: ExtensionInfo[]): void {
  */
 async function activateExtension(extension: ExtensionInfo): Promise<ActiveExtension> {
   // Import the extension file. Tell webpack to ignore it because extension files are not in the
-  // bundle and should not be looked up in the bundle
+  // bundle and should not be looked up in the bundle. Assert a more ambiguous type.
   // DO NOT REMOVE THE webpackIgnore COMMENT. It is a webpack "Magic Comment" https://webpack.js.org/api/module-methods/#magic-comments
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   const extensionModuleAmbiguous = systemRequire(
     /* webpackIgnore: true */ getPathFromUri(extension.dirUri),
   ) as AmbiguousExtensionModule;
@@ -364,6 +373,8 @@ async function activateExtensions(extensions: ExtensionInfo[]): Promise<ActiveEx
   }));
 
   // Shim out require so extensions can use it only as prescribed.
+  // Assert the specific type.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   Module.prototype.require = ((moduleName: string) => {
     // Allow the extension to import papi and some other things
     if (moduleName === 'papi-backend') return papi;
@@ -410,6 +421,8 @@ async function activateExtensions(extensions: ExtensionInfo[]): Promise<ActiveEx
   };
 
   // Import the extensions and run their activate() functions
+  // Assert the type has been filtered for null.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   const extensionsActive = (
     await Promise.all(
       extensionsWithCheck.map((extensionWithCheck) =>

--- a/src/extension-host/services/papi-backend.service.ts
+++ b/src/extension-host/services/papi-backend.service.ts
@@ -32,6 +32,7 @@ import { DialogService } from '@shared/services/dialog.service-model';
 // 1) When adding new services here, consider whether they also belong in papi-frontend.service.ts.
 // 2) We need to provide type assertions for all members so they carry the JSDoc comments on the
 // papi.d.ts file so extension developers see the comments. Please add to all properties you add.
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 // 3) The "JSDOC DESTINATION" comments are there to provide anchors for JSDocs to be copied in.
 // Please add to all properties you add.
 const papi = {

--- a/src/extension-host/services/papi-backend.service.ts
+++ b/src/extension-host/services/papi-backend.service.ts
@@ -32,7 +32,7 @@ import { DialogService } from '@shared/services/dialog.service-model';
 // 1) When adding new services here, consider whether they also belong in papi-frontend.service.ts.
 // 2) We need to provide type assertions for all members so they carry the JSDoc comments on the
 // papi.d.ts file so extension developers see the comments. Please add to all properties you add.
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion, no-type-assertion/no-type-assertion */
 // 3) The "JSDOC DESTINATION" comments are there to provide anchors for JSDocs to be copied in.
 // Please add to all properties you add.
 const papi = {

--- a/src/main/global-this.model.ts
+++ b/src/main/global-this.model.ts
@@ -20,6 +20,8 @@ globalThis.processType = ProcessType.Main;
 globalThis.isPackaged = app.isPackaged;
 globalThis.resourcesPath = app.isPackaged ? process.resourcesPath : path.join(__dirname, '../../');
 globalThis.logLevel =
+  // Assert the extracted type.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   (getCommandLineArgument(ARG_LOG_LEVEL) as LogLevel) ?? (globalThis.isPackaged ? 'error' : 'info');
 
 // #endregion

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -220,7 +220,7 @@ async function main() {
 
   /** Map from ipc channel to handler function. Use with ipcRenderer.invoke */
   const ipcHandlers: {
-    [ipcChannel: string]: (
+    [ipcChannel: SerializedRequestType]: (
       event: IpcMainInvokeEvent,
       // We don't know the exact parameter types since ipc handlers can be anything
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -252,7 +252,11 @@ async function main() {
 
   Object.entries(ipcHandlers).forEach(([ipcHandle, handler]) => {
     networkService.registerRequestHandler(
+      // Re-assert type after passing through `forEach`.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       ipcHandle as SerializedRequestType,
+      // Handle with an empty event.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       async (...args: unknown[]) => handler({} as IpcMainInvokeEvent, ...args),
     );
   });
@@ -262,6 +266,8 @@ async function main() {
   // #region Register test command handlers
 
   Object.entries(commandHandlers).forEach(([commandName, handler]) => {
+    // Re-assert type after passing through `forEach`.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     commandService.registerCommand(commandName as CommandNames, handler);
   });
 

--- a/src/main/services/extension-asset-protocol.service.ts
+++ b/src/main/services/extension-asset-protocol.service.ts
@@ -32,6 +32,8 @@ function getMimeTypeForFileName(fileName: string): string {
   const dotIndex = fileName.lastIndexOf('.');
   if (dotIndex > 0) {
     const fileType: string = fileName.substring(dotIndex);
+    // Assert key type confirmed in check.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     if (fileType in knownMimeTypes) return knownMimeTypes[fileType as keyof typeof knownMimeTypes];
   }
 

--- a/src/main/services/server-network-connector.service.ts
+++ b/src/main/services/server-network-connector.service.ts
@@ -298,9 +298,12 @@ export default class ServerNetworkConnector implements INetworkConnector {
     if (this.connectorInfo.clientId === recipientId) {
       // This message is from us and for us. Handle the message as if we just received it
       this.onMessage(
+        // Fake enough of the message event to handle it.
+        /* eslint-disable no-type-assertion/no-type-assertion */
         {
           data: message as unknown as string,
         } as MessageEvent,
+        /* eslint-enable */
         true,
       );
     } else {
@@ -315,9 +318,11 @@ export default class ServerNetworkConnector implements INetworkConnector {
    * @param fromSelf whether this message is from this connector instead of from someone else
    */
   private onMessage = (event: MessageEvent, fromSelf = false) => {
-    const data = fromSelf
-      ? (event.data as unknown as Message)
-      : (JSON.parse(event.data as string) as Message);
+    const data: Message = fromSelf
+      ? // Assert our specific message type.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        (event.data as unknown as Message)
+      : JSON.parse(event.data.toString());
 
     // Make sure the client isn't impersonating another client
     // TODO: consider speeding up validation by passing in webSocket client id?

--- a/src/node/services/node-file-system.service.ts
+++ b/src/node/services/node-file-system.service.ts
@@ -96,7 +96,7 @@ export async function readDir(
 ): Promise<DirectoryEntries> {
   const stats = await getStats(uri);
   // Assert return type.
-  // TODO: this is covering up a potential bug. Make DirectoryEntries properties optional, remove this assert, and fix everything affected.
+  // TODO: this is covering up a potential bug. EITHER make DirectoryEntries properties optional, remove this assert, and fix everything affected. OR it might be better return empty arrays for each property like it does in L120.
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   if (!stats || !stats.isDirectory()) return {} as DirectoryEntries;
   const unfilteredDirEntries = await fs.promises.readdir(getPathFromUri(uri), {

--- a/src/node/services/node-file-system.service.ts
+++ b/src/node/services/node-file-system.service.ts
@@ -95,7 +95,10 @@ export async function readDir(
   entryFilter?: (entryName: string) => boolean,
 ): Promise<DirectoryEntries> {
   const stats = await getStats(uri);
-  if (!stats || !stats.isDirectory()) return <DirectoryEntries>{};
+  // Assert return type.
+  // TODO: this is covering up a potential bug. Make DirectoryEntries properties optional, remove this assert, and fix everything affected.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  if (!stats || !stats.isDirectory()) return {} as DirectoryEntries;
   const unfilteredDirEntries = await fs.promises.readdir(getPathFromUri(uri), {
     withFileTypes: true,
   });
@@ -119,6 +122,8 @@ export async function readDir(
     if (!entryMap.has(entryType)) entryMap.set(entryType, []);
   });
 
+  // Assert return type.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   return Object.freeze(Object.fromEntries(entryMap)) as DirectoryEntries;
 }
 

--- a/src/renderer/components/dialogs/dialog-base.data.ts
+++ b/src/renderer/components/dialogs/dialog-base.data.ts
@@ -170,7 +170,7 @@ const DIALOG_BASE: DialogDefinitionBase = {
       minHeight: this.minHeight,
       // dialogs must define their own Component. It will then be used in this default
       // implementation of `loadDialog`
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       content: createElement(this.Component!, {
         ...tabData,
         submitDialog: (data) => resolveDialogRequest(savedTabInfo.id, data),

--- a/src/renderer/components/dialogs/dialog-base.data.ts
+++ b/src/renderer/components/dialogs/dialog-base.data.ts
@@ -147,6 +147,8 @@ export function hookUpDialogService({
 const DIALOG_BASE: DialogDefinitionBase = {
   initialSize: DIALOG_DEFAULT_SIZE,
   loadDialog(savedTabInfo) {
+    // Assert the more specific type.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     const maybeTabData = savedTabInfo.data as DialogData | undefined;
     if (!maybeTabData || !maybeTabData.isDialog)
       logger.error(
@@ -156,6 +158,8 @@ const DIALOG_BASE: DialogDefinitionBase = {
           savedTabInfo,
         )}`,
       );
+    // Assert the more specific type.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     const tabData = maybeTabData as DialogData;
     return {
       ...savedTabInfo,
@@ -166,7 +170,7 @@ const DIALOG_BASE: DialogDefinitionBase = {
       minHeight: this.minHeight,
       // dialogs must define their own Component. It will then be used in this default
       // implementation of `loadDialog`
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
       content: createElement(this.Component!, {
         ...tabData,
         submitDialog: (data) => resolveDialogRequest(savedTabInfo.id, data),

--- a/src/renderer/components/dialogs/index.ts
+++ b/src/renderer/components/dialogs/index.ts
@@ -11,6 +11,8 @@ const DIALOGS: { [DialogTabType in DialogTabTypes]: DialogDefinition<DialogTabTy
 };
 
 /** All tab types for available dialogs */
+// Re-assert the type of keys.
+// eslint-disable-next-line no-type-assertion/no-type-assertion
 export const DIALOG_TAB_TYPES = Object.keys(DIALOGS) as DialogTabTypes[];
 
 export default DIALOGS;

--- a/src/renderer/components/docking/error-tab.component.tsx
+++ b/src/renderer/components/docking/error-tab.component.tsx
@@ -27,6 +27,8 @@ export const createErrorTab = (errorMessage: string): TabInfo => {
     content: <ErrorTab errorMessage={errorMessage} />,
     minWidth: 150,
     minHeight: 150,
+    // Assert the more specific type.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     data: {
       errorMessage,
     } as ErrorTabData,

--- a/src/renderer/components/docking/platform-dock-layout.component.test.ts
+++ b/src/renderer/components/docking/platform-dock-layout.component.test.ts
@@ -82,6 +82,7 @@ describe('Dock Layout Component', () => {
 
   describe('loadTab()', () => {
     it('should throw when no id', () => {
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       const savedTabInfoNoId = {} as SavedTabInfo;
 
       expect(() => loadTab(savedTabInfoNoId)).toThrow();
@@ -94,6 +95,7 @@ describe('Dock Layout Component', () => {
       const layout: Layout = { type: 'tab' };
 
       expect(() =>
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
         addTabToDock('this is wrong' as unknown as SavedTabInfo, layout, dockLayout),
       ).toThrow();
     });
@@ -103,6 +105,7 @@ describe('Dock Layout Component', () => {
   describe('addWebViewToDock()', () => {
     it('should throw when no id', () => {
       const dockLayout = instance(mockDockLayout);
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       const webView = {} as WebViewProps;
       const layout: Layout = { type: 'tab' };
 
@@ -114,6 +117,7 @@ describe('Dock Layout Component', () => {
       when(mockDockLayout.find(anything())).thenReturn(undefined);
       const dockLayout = instance(mockDockLayout);
       const webView: WebViewProps = { id: 'myId', webViewType: 'test', content: '' };
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       const layout = { type: 'wacked' } as unknown as FloatLayout;
 
       expect(() => addWebViewToDock(webView, layout, dockLayout)).toThrow();

--- a/src/renderer/components/docking/platform-dock-layout.component.tsx
+++ b/src/renderer/components/docking/platform-dock-layout.component.tsx
@@ -211,6 +211,8 @@ function saveTab(dockTabInfo: RCDockTabInfo): SavedTabInfo | undefined {
  * @returns `true` if its a tab or `false` otherwise.
  */
 function isTab(tab: PanelData | TabData | BoxData | undefined): tab is TabData {
+  // Assert the more specific type.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   if (!tab || (tab as TabData).title == null) return false;
   return true;
 }
@@ -239,7 +241,7 @@ export function getFloatPosition(
   layoutSize: LayoutSize,
 ): FloatPosition {
   // Defaults are added in `web-view.service.ts`.
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
   const { width, height } = layout.floatSize!;
 
   let { left, top } = previousPosition;
@@ -267,7 +269,8 @@ function findPreviousTab(dockLayout: DockLayout) {
     if (previousTab) return previousTab;
   }
   // We don't have a previous tab or we didn't find the one we thought we had. Just find the first
-  // available tab
+  // available tab. Assert the more specific type.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   return dockLayout.find((tabData) => isTab(tabData)) as TabData;
 }
 
@@ -337,7 +340,9 @@ export function addTabToDock(
       targetTab = findPreviousTab(dockLayout);
       if (targetTab) {
         if (previousTabId === undefined)
-          // The target tab is the first found tab, so just add this as a new panel on top
+          // The target tab is the first found tab, so just add this as a new panel on top.
+          // Assert the more specific type.
+          // eslint-disable-next-line no-type-assertion/no-type-assertion
           dockLayout.dockMove(tab, targetTab.parent as PanelData, 'top');
         // The target tab is a previously added tab, so add this as a tab next to it
         else dockLayout.dockMove(tab, targetTab, 'after-tab');
@@ -381,13 +386,14 @@ export function addTabToDock(
 
       dockLayout.dockMove(
         tab,
-        // Add to the parent of the found tab if we found a tab
+        // Add to the parent of the found tab if we found a tab. Assert the more specific type.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
         (targetTab?.parent as PanelData) ??
           // Otherwise find the first thing (the dock box) and add the tab to it
           dockLayout.find(() => true) ??
           null,
         // Defaults are added in `web-view.service.ts`.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
         updatedLayout.direction!,
       );
       break;
@@ -395,6 +401,7 @@ export function addTabToDock(
     default:
       // Type assert here because TypeScript thinks this layout is `never` because the switch has
       // covered all its options (if JS were statically typed, this `default` would never hit)
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       throw new LogError(`Unknown layoutType: '${(updatedLayout as Layout).type}'`);
   }
 
@@ -404,6 +411,8 @@ export function addTabToDock(
   // happen on startup
   if (tab.tabType === TAB_TYPE_ERROR)
     throw new LogError(
+      // Assert the more specific type.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       `Dock Layout created an error tab: ${(tab.data as ErrorTabData)?.errorMessage}`,
     );
 
@@ -437,7 +446,7 @@ export function addWebViewToDock(
 
 export default function PlatformDockLayout() {
   // This ref will always be defined
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
   const dockLayoutRef = useRef<DockLayout>(null!);
 
   /**
@@ -481,13 +490,17 @@ export default function PlatformDockLayout() {
       // Type assert `saveTab` as not returning `undefined` because rc-dock's types are wrong
       // Here, if `saveTab` returns `undefined` the tab is not saved
       // https://github.com/ticlo/rc-dock/blob/8b6481dca4b4dd07f89107d6f48b1831bbdf0470/src/Serializer.ts#L68
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       saveTab={saveTab as (dockTabInfo: RCDockTabInfo) => SavedTabInfo}
       onLayoutChange={(...args) => {
         const [, currentTabId, direction] = args;
         // If a dialog was closed, tell the dialog service
         if (currentTabId && direction === 'remove') {
+          // Assert the more specific type.
+          /* eslint-disable no-type-assertion/no-type-assertion */
           const removedTab = dockLayoutRef.current.find(currentTabId) as RCDockTabInfo;
           if ((removedTab.data as DialogData)?.isDialog && hasDialogRequest(currentTabId))
+            /* eslint-enable */
             resolveDialogRequest(currentTabId, null, false);
         }
 

--- a/src/renderer/components/docking/platform-dock-layout.component.tsx
+++ b/src/renderer/components/docking/platform-dock-layout.component.tsx
@@ -241,7 +241,7 @@ export function getFloatPosition(
   layoutSize: LayoutSize,
 ): FloatPosition {
   // Defaults are added in `web-view.service.ts`.
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   const { width, height } = layout.floatSize!;
 
   let { left, top } = previousPosition;
@@ -393,7 +393,7 @@ export function addTabToDock(
           dockLayout.find(() => true) ??
           null,
         // Defaults are added in `web-view.service.ts`.
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
         updatedLayout.direction!,
       );
       break;
@@ -446,7 +446,7 @@ export function addWebViewToDock(
 
 export default function PlatformDockLayout() {
   // This ref will always be defined
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   const dockLayoutRef = useRef<DockLayout>(null!);
 
   /**

--- a/src/renderer/components/platform-bible-menu.commands.tsx
+++ b/src/renderer/components/platform-bible-menu.commands.tsx
@@ -31,6 +31,8 @@ export function handleMenuCommand(command: Command) {
       logger.info(`TODO: display about'`);
       break;
     default:
+      // Assert the more specific type.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       commandService.sendCommand(command.command as CommandNames);
   }
 }

--- a/src/renderer/components/platform-bible-toolbar.tsx
+++ b/src/renderer/components/platform-bible-toolbar.tsx
@@ -18,7 +18,7 @@ export default function PlatformBibleToolbar() {
 
   return (
     <Toolbar className="toolbar" dataHandler={handleMenuData} commandHandler={handleMenuCommand}>
-      <RefSelector handleSubmit={handleReferenceChanged} scrRef={scrRef as ScriptureReference} />
+      <RefSelector handleSubmit={handleReferenceChanged} scrRef={scrRef} />
     </Toolbar>
   );
 }

--- a/src/renderer/components/projects/project-list.component.tsx
+++ b/src/renderer/components/projects/project-list.component.tsx
@@ -1,5 +1,6 @@
 import { List, ListItem, ListItemButton, ListItemText, ListSubheader } from '@mui/material';
 import { ProjectMetadata } from '@shared/models/project-metadata.model';
+import { ProjectTypes } from 'papi-shared-types';
 import { PropsWithChildren, useCallback } from 'react';
 
 export type Project = ProjectMetadata & {
@@ -22,6 +23,7 @@ export type Project = ProjectMetadata & {
  * @returns downloadable (and downloaded) project information
  */
 export function fetchProjects(): Project[] {
+  /* eslint-disable no-type-assertion/no-type-assertion */
   return [
     {
       id: 'project-1',
@@ -30,7 +32,7 @@ export function fetchProjects(): Project[] {
       isDownloadable: true,
       isDownloaded: false,
       storageType: 'test',
-      projectType: 'test',
+      projectType: 'test' as ProjectTypes,
     },
     {
       id: 'project-2',
@@ -39,7 +41,7 @@ export function fetchProjects(): Project[] {
       isDownloadable: false,
       isDownloaded: true,
       storageType: 'test',
-      projectType: 'test',
+      projectType: 'test' as ProjectTypes,
     },
     {
       id: 'project-3',
@@ -48,7 +50,7 @@ export function fetchProjects(): Project[] {
       isDownloadable: true,
       isDownloaded: false,
       storageType: 'test',
-      projectType: 'test',
+      projectType: 'test' as ProjectTypes,
     },
     {
       id: 'project-4',
@@ -57,7 +59,7 @@ export function fetchProjects(): Project[] {
       isDownloadable: false,
       isDownloaded: false,
       storageType: 'test',
-      projectType: 'test',
+      projectType: 'test' as ProjectTypes,
     },
     {
       id: 'project-5',
@@ -66,9 +68,10 @@ export function fetchProjects(): Project[] {
       isDownloadable: false,
       isDownloaded: true,
       storageType: 'test',
-      projectType: 'test',
+      projectType: 'test' as ProjectTypes,
     },
   ];
+  /* eslint-enable */
 }
 
 export type ProjectListProps = PropsWithChildren<{

--- a/src/renderer/components/run-basic-checks-dialog/basic-checks.component.tsx
+++ b/src/renderer/components/run-basic-checks-dialog/basic-checks.component.tsx
@@ -5,62 +5,62 @@ export type BasicCheck = {
   name: string;
 };
 
-export function fetchChecks() {
+export function fetchChecks(): BasicCheck[] {
   return [
     {
       name: 'Chapter/Verse Numbers',
-    } as BasicCheck,
+    },
     {
       name: 'Markers',
-    } as BasicCheck,
+    },
     {
       name: 'Characters (Combinations)',
-    } as BasicCheck,
+    },
     {
       name: 'Punctuation (Sequences)',
-    } as BasicCheck,
+    },
     {
       name: 'References',
-    } as BasicCheck,
+    },
     {
       name: 'Footnote Quotes',
-    } as BasicCheck,
+    },
     {
       name: 'Capitalization',
-    } as BasicCheck,
+    },
     {
       name: 'Repeated Words',
-    } as BasicCheck,
+    },
     {
       name: 'Unmatched Pairs of Punctuation',
-    } as BasicCheck,
+    },
     {
       name: 'Quotations',
-    } as BasicCheck,
+    },
     {
       name: 'Quotation types',
-    } as BasicCheck,
+    },
     {
       name: 'Numbers',
-    } as BasicCheck,
+    },
     {
       name: 'Another Example 1',
-    } as BasicCheck,
+    },
     {
       name: 'Another Example 2',
-    } as BasicCheck,
+    },
     {
       name: 'Another Example 3',
-    } as BasicCheck,
+    },
     {
       name: 'Another Example 4',
-    } as BasicCheck,
+    },
     {
       name: 'Another Example 5',
-    } as BasicCheck,
+    },
     {
       name: 'Another Example 6',
-    } as BasicCheck,
+    },
   ];
 }
 

--- a/src/renderer/components/settings-dialog/settings-tab.component.tsx
+++ b/src/renderer/components/settings-dialog/settings-tab.component.tsx
@@ -188,6 +188,7 @@ function InterfaceLanguageSetting({ setting, setSetting }: SettingProps<string>)
       value={setting}
       // Type asserting because combobox props aren't precise enough yet
       // Issue https://github.com/paranext/paranext-core/issues/560
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       onChange={(_e, v) => setSetting(v as string)}
       width={200}
     />
@@ -223,6 +224,7 @@ function ProxySettings({
           placeholder="0"
           value={setting.Port}
           // This is a mock component- But BUG here because this TextField can take strings but we are forcing it as a number
+          // eslint-disable-next-line no-type-assertion/no-type-assertion
           onChange={(e) => setSetting({ ...setting, Port: e.target.value as unknown as number })}
         />
         <TextField
@@ -249,6 +251,9 @@ function CheckboxSetting({ setting, setSetting }: SettingProps<boolean>) {
 
 // Example component of a platform setting
 function ComboboxSetting({ setting, setSetting }: SettingProps<string>) {
+  // Type asserting because combobox props aren't precise enough yet
+  // Issue https://github.com/paranext/paranext-core/issues/560
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   return <ComboBox value={setting} onChange={(_e, v) => setSetting(v as string)} width={200} />;
 }
 

--- a/src/renderer/components/web-view.component.tsx
+++ b/src/renderer/components/web-view.component.tsx
@@ -23,7 +23,7 @@ export function getTitle({ webViewType, title, contentType }: Partial<WebViewPro
 
 export default function WebView({ webViewType, content, title, contentType }: WebViewProps) {
   // This ref will always be defined
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   const iframeRef = useRef<HTMLIFrameElement>(null!);
 
   // TODO: We may be catching iframe exceptions moving forward by posting messages from the child

--- a/src/renderer/components/web-view.component.tsx
+++ b/src/renderer/components/web-view.component.tsx
@@ -23,7 +23,7 @@ export function getTitle({ webViewType, title, contentType }: Partial<WebViewPro
 
 export default function WebView({ webViewType, content, title, contentType }: WebViewProps) {
   // This ref will always be defined
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
   const iframeRef = useRef<HTMLIFrameElement>(null!);
 
   // TODO: We may be catching iframe exceptions moving forward by posting messages from the child
@@ -69,6 +69,7 @@ export function loadWebViewTab(savedTabInfo: SavedTabInfo): TabInfo {
   let data: WebViewProps;
   if (savedTabInfo.data) {
     // We need to make sure that the data is of the correct type
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     data = savedTabInfo.data as WebViewProps;
 
     if (savedTabInfo.id !== data.id) throw new Error('"id" does not match webView id.');
@@ -99,6 +100,8 @@ export function loadWebViewTab(savedTabInfo: SavedTabInfo): TabInfo {
 export function saveWebViewTab(tabInfo: TabInfo): SavedTabInfo {
   return {
     ...saveTabInfoBase(tabInfo),
+    // Assert what the unknown `data` type is.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     data: convertWebViewDefinitionToSaved(tabInfo.data as WebViewDefinition),
   };
 }

--- a/src/renderer/context/papi-context/test.context.ts
+++ b/src/renderer/context/papi-context/test.context.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
 // This should always be defined, so non-null the value
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
 const TestContext = createContext<string>(undefined!);
 export default TestContext;

--- a/src/renderer/context/papi-context/test.context.ts
+++ b/src/renderer/context/papi-context/test.context.ts
@@ -1,6 +1,6 @@
 import { createContext } from 'react';
 
 // This should always be defined, so non-null the value
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion, no-type-assertion/no-type-assertion
+// eslint-disable-next-line no-type-assertion/no-type-assertion
 const TestContext = createContext<string>(undefined!);
 export default TestContext;

--- a/src/renderer/hooks/hook-generators/create-use-data-hook.util.ts
+++ b/src/renderer/hooks/hook-generators/create-use-data-hook.util.ts
@@ -154,7 +154,7 @@ function createUseDataHook(
       const newHook = createUseDataHookForDataTypeInternal(prop);
 
       // Save the hook in the cache to be used later
-      useDataCachedHooks[prop as keyof typeof useDataCachedHooks] = newHook;
+      useDataCachedHooks[prop] = newHook;
 
       return newHook;
     },

--- a/src/renderer/hooks/papi-hooks/use-data-provider.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-data-provider.hook.ts
@@ -13,8 +13,10 @@ import createUseNetworkObjectHook from '@renderer/hooks/hook-generators/create-u
  * @type `T` - the type of data provider to return. Use `IDataProvider<TDataProviderDataTypes>`,
  *  specifying your own types, or provide a custom data provider type
  */
+
+// We don't know what type the data provider serves
+// eslint-disable-next-line no-type-assertion/no-type-assertion
 const useDataProvider = createUseNetworkObjectHook(dataProviderService.get) as <
-  // We don't know what type the data provider serves
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   T extends IDataProvider<any>,
 >(

--- a/src/renderer/hooks/papi-hooks/use-dialog-callback.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-dialog-callback.hook.ts
@@ -52,6 +52,7 @@ function useDialogCallback<
   // Since `defaultResponse` could be unspecified which is equivalent to `null`, we need to
   // type assert to tell TS that `null` will be part of `TResponse` if `defaultResponse` is not
   // specified but is not otherwise
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   defaultResponse: TResponse = null as TResponse,
 ): [TResponse, () => Promise<void>, string | undefined, boolean] {
   // Keep track of whether we're mounted so we don't run stuff after unmount
@@ -73,6 +74,7 @@ function useDialogCallback<
       try {
         // Looks like we need to type assert here because it can't tell this is a TResponse. It can
         // just tell that it is the dialog response type, which does not include undefined
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
         const dialogResponse = (await dialogService.showDialog(
           dialogType,
           options,

--- a/src/renderer/hooks/papi-hooks/use-project-data-provider.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data-provider.hook.ts
@@ -14,6 +14,9 @@ import IDataProvider from '@shared/models/data-provider.interface';
  * @ProjectType `ProjectType` - the project type for the project to use. The returned project data
  * provider will have the project data provider type associated with this project type.
  */
+
+// Assert to specific data type for this hook.
+// eslint-disable-next-line no-type-assertion/no-type-assertion
 const useProjectDataProvider = createUseNetworkObjectHook(
   papiFrontendProjectDataProviderService.getProjectDataProvider,
 ) as <ProjectType extends ProjectTypes>(

--- a/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
@@ -121,10 +121,13 @@ type UseProjectDataHook = {
  * @type `TDataType` - the specific data type on this project you want to use. Must match the data
  * type specified in `useProjectData.<data_type>`
  */
+// Assert the more general and more specific types.
+/* eslint-disable no-type-assertion/no-type-assertion */
 const useProjectData: UseProjectDataHook = createUseDataHook(
   useProjectDataProvider as (
     dataProviderSource: string | IDataProvider | undefined,
   ) => IDataProvider | undefined,
 ) as UseProjectDataHook;
+/* eslint-enable */
 
 export default useProjectData;

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -54,10 +54,12 @@ logger.info('Starting renderer');
 })();
 
 const container = document.getElementById('root');
-const root = createRoot(container as HTMLElement);
-root.render(<App />);
+if (container) {
+  const root = createRoot(container);
+  root.render(<App />);
 
-// This doesn't run if the renderer has an uncaught exception (which is a good thing)
-window.addEventListener('beforeunload', () => {
-  cleanupOldWebViewState();
-});
+  // This doesn't run if the renderer has an uncaught exception (which is a good thing)
+  window.addEventListener('beforeunload', () => {
+    cleanupOldWebViewState();
+  });
+}

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -54,12 +54,14 @@ logger.info('Starting renderer');
 })();
 
 const container = document.getElementById('root');
-if (container) {
-  const root = createRoot(container);
-  root.render(<App />);
-
-  // This doesn't run if the renderer has an uncaught exception (which is a good thing)
-  window.addEventListener('beforeunload', () => {
-    cleanupOldWebViewState();
-  });
+if (!container) {
+  throw new Error('Document root element not found!');
 }
+
+const root = createRoot(container);
+root.render(<App />);
+
+// This doesn't run if the renderer has an uncaught exception (which is a good thing)
+window.addEventListener('beforeunload', () => {
+  cleanupOldWebViewState();
+});

--- a/src/renderer/services/dialog.service-host.ts
+++ b/src/renderer/services/dialog.service-host.ts
@@ -169,11 +169,11 @@ async function showDialog<DialogTabType extends DialogTabTypes>(
 
   try {
     // Open dialog
-    await webViewService.addTab(
+    await webViewService.addTab<DialogData>(
       {
         id: dialogId,
         tabType: dialogType,
-        data: { ...options, isDialog: true } as DialogData,
+        data: { ...options, isDialog: true },
       },
       {
         type: 'float',

--- a/src/renderer/services/papi-frontend.service.ts
+++ b/src/renderer/services/papi-frontend.service.ts
@@ -28,7 +28,7 @@ import { DialogService } from '@shared/services/dialog.service-model';
 // 1) When adding new services here, consider whether they also belong in papi-backend.service.ts.
 // 2) We need to provide type assertions for all members so they carry the JSDoc comments on the
 // papi.d.ts file so extension developers see the comments. Please add to all properties you add.
-/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion, no-type-assertion/no-type-assertion */
 // 3) The "JSDOC DESTINATION" comments are there to provide anchors for JSDocs to be copied in.
 // Please add to all properties you add.
 const papi = {

--- a/src/renderer/services/papi-frontend.service.ts
+++ b/src/renderer/services/papi-frontend.service.ts
@@ -28,6 +28,7 @@ import { DialogService } from '@shared/services/dialog.service-model';
 // 1) When adding new services here, consider whether they also belong in papi-backend.service.ts.
 // 2) We need to provide type assertions for all members so they carry the JSDoc comments on the
 // papi.d.ts file so extension developers see the comments. Please add to all properties you add.
+/* eslint-disable @typescript-eslint/no-unnecessary-type-assertion */
 // 3) The "JSDOC DESTINATION" comments are there to provide anchors for JSDocs to be copied in.
 // Please add to all properties you add.
 const papi = {

--- a/src/renderer/services/web-view-state.service.ts
+++ b/src/renderer/services/web-view-state.service.ts
@@ -9,7 +9,7 @@ function loadIfNeeded(): void {
   const serializedState = localStorage.getItem(WEBVIEW_STATE_KEY);
   if (!serializedState) return;
 
-  const entries = JSON.parse(serializedState) as [[string, Record<string, string>]];
+  const entries: [[string, Record<string, string>]] = JSON.parse(serializedState);
   entries.forEach(([key, value]) => {
     if (key && value) stateMap.set(key, value);
   });
@@ -70,7 +70,7 @@ export function getWebViewStateById<T>(id: string, stateKey: string): T | undefi
   if (!id || !stateKey) throw new Error('id and stateKey must be provided to get webview state');
   const state: Record<string, string> = getRecord(id);
   const stateValue: string | undefined = state[stateKey];
-  return stateValue ? (JSON.parse(stateValue) as T) : undefined;
+  return stateValue ? JSON.parse(stateValue) : undefined;
 }
 
 /**

--- a/src/renderer/testing/test-layout.data.ts
+++ b/src/renderer/testing/test-layout.data.ts
@@ -13,6 +13,8 @@ import { TAB_TYPE_BASIC_LIST } from '@renderer/components/basic-list/basic-list.
 
 export const FIRST_TAB_ID = 'About';
 
+// Using `as` here simplifies type changes.
+/* eslint-disable no-type-assertion/no-type-assertion */
 const testLayout: LayoutBase = {
   dockbox: {
     mode: 'horizontal',
@@ -108,4 +110,5 @@ const testLayout: LayoutBase = {
     ],
   },
 };
+/* eslint-enable */
 export default testLayout;

--- a/src/shared/models/data-provider.model.ts
+++ b/src/shared/models/data-provider.model.ts
@@ -215,6 +215,8 @@ export function getDataProviderDataTypeFromFunctionName<
   const fnPrefix = dataProviderFunctionPrefixes.find((prefix) => fnName.startsWith(prefix));
   if (!fnPrefix) throw new Error(`${fnName} is not a data provider data type function`);
 
+  // Assert the expected return type.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   return fnName.substring(fnPrefix.length) as DataTypeNames<TDataTypes>;
 }
 

--- a/src/shared/models/papi-network-event-emitter.model.ts
+++ b/src/shared/models/papi-network-event-emitter.model.ts
@@ -48,6 +48,7 @@ export default class PapiNetworkEventEmitter<T> extends PapiEventEmitter<T> {
   override dispose = () => {
     const retVal = super.disposeFn();
     // TODO: Do we need to set networkSubscriber to undefined? Had to remove readonly from it to do this
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     this.networkSubscriber = undefined as unknown as PapiEventHandler<T>;
     this.networkDisposer();
     return retVal;

--- a/src/shared/models/project-metadata.model.ts
+++ b/src/shared/models/project-metadata.model.ts
@@ -1,3 +1,5 @@
+import { ProjectTypes } from 'papi-shared-types';
+
 /**
  * Low-level information describing a project that Platform.Bible directly manages and uses to load project data
  */
@@ -17,5 +19,5 @@ export type ProjectMetadata = {
   /**
    * Indicates what sort of project this is which implies its data shape (e.g., what data streams should be available)
    */
-  projectType: string;
+  projectType: ProjectTypes;
 };

--- a/src/shared/services/command.service.ts
+++ b/src/shared/services/command.service.ts
@@ -52,6 +52,8 @@ const sendCommandUnsafe = async <CommandName extends CommandNames>(
   commandName: CommandName,
   ...args: Parameters<CommandHandlers[CommandName]>
 ): Promise<Awaited<ReturnType<CommandHandlers[CommandName]>>> => {
+  // This type assertion is needed when the return type is unknown or when it's not Awaited<...>.
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
   return networkService.request(
     serializeRequestType(CATEGORY_COMMAND, commandName),
     ...args,

--- a/src/shared/services/command.service.ts
+++ b/src/shared/services/command.service.ts
@@ -53,7 +53,7 @@ const sendCommandUnsafe = async <CommandName extends CommandNames>(
   ...args: Parameters<CommandHandlers[CommandName]>
 ): Promise<Awaited<ReturnType<CommandHandlers[CommandName]>>> => {
   // This type assertion is needed when the return type is unknown or when it's not Awaited<...>.
-  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion, no-type-assertion/no-type-assertion
   return networkService.request(
     serializeRequestType(CATEGORY_COMMAND, commandName),
     ...args,
@@ -96,6 +96,8 @@ export const initialize = () => {
     if (isRenderer()) {
       // TODO: make a registerRequestHandlers function that we use here and in NetworkService.initialize?
       const unsubPromises = Object.entries(rendererCommandFunctions).map(([commandName, handler]) =>
+        // Re-assert type of `commandName` even though the type is actually a string ultimately.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
         registerCommandUnsafe(commandName as CommandNames, handler),
       );
 

--- a/src/shared/services/connection.service.ts
+++ b/src/shared/services/connection.service.ts
@@ -125,13 +125,14 @@ export const disconnect = () => {
 const handleInternalRequest: InternalRequestHandler = async <TParam, TReturn>(
   requestType: string,
   incomingRequest: InternalRequest<TParam>,
-) => {
+): Promise<InternalResponse<TReturn>> => {
   if (!requestHandler) throw new Error('Handling request without a requestHandler!');
 
   // Not sure if it's really responsible to put the whole incomingRequest in. Might want to destructure and just pass ComplexRequest members
   const response = await requestHandler<TParam, TReturn>(
     // We don't require requestType to be SerializedRequestType in this service, but they should all
     // be SerializedRequestType if they are all registered as such. Doesn't matter much to us here
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     requestType as SerializedRequestType,
     incomingRequest,
   );
@@ -140,7 +141,7 @@ const handleInternalRequest: InternalRequestHandler = async <TParam, TReturn>(
     senderId: clientId,
     requesterId: incomingRequest.senderId,
     requestId: incomingRequest.requestId,
-  } as InternalResponse<TReturn>;
+  };
 };
 
 /**

--- a/src/shared/services/data-provider.service.ts
+++ b/src/shared/services/data-provider.service.ts
@@ -306,7 +306,7 @@ function mapUpdateInstructionsToUpdateEvent<TDataTypes extends DataProviderDataT
   if (updateInstructions === '*') return updateInstructions;
   // If the update instructions are a string other than '*' (hopefully one of the data types), send
   // an update specifically for that data type
-  if (isString(updateInstructions)) return [updateInstructions as DataTypeNames<TDataTypes>];
+  if (isString(updateInstructions)) return [updateInstructions];
   if (Array.isArray(updateInstructions)) {
     // If the update instructions are a non-empty array, send it
     if (updateInstructions.length > 0) return updateInstructions;

--- a/src/shared/services/logger.service.ts
+++ b/src/shared/services/logger.service.ts
@@ -119,6 +119,7 @@ if (isClient()) {
             caller ? `${logLine} ${caller}` : `${logLine}`,
             getProcessType(),
             // Renderer sends back with log level of log. Not sure why it's not in the type
+            // eslint-disable-next-line no-type-assertion/no-type-assertion
             (message.level as LogLevel | 'log') === 'log' ? undefined : message.level,
           ),
         ),

--- a/src/shared/services/project-data-provider.service.ts
+++ b/src/shared/services/project-data-provider.service.ts
@@ -99,7 +99,7 @@ export async function getProjectDataProvider<ProjectType extends ProjectTypes>(
   projectId: string,
 ): Promise<ProjectDataProvider[ProjectType]> {
   const metadata = await projectLookupService.getMetadataForProject(projectId);
-  const projectType = metadata.projectType as keyof ProjectDataTypes;
+  const { projectType } = metadata;
   const pdpFactoryId: string = getProjectDataProviderFactoryId(projectType);
   const pdpFactory = await networkObjectService.get<ProjectDataProviderFactory<ProjectType>>(
     pdpFactoryId,

--- a/src/shared/services/settings.service.ts
+++ b/src/shared/services/settings.service.ts
@@ -13,7 +13,8 @@ const onDidUpdateSettingEmitters = new Map<
 /**
  * Retrieves the value of the specified setting
  * @param key The string id of the setting for which the value is being retrieved
- * @returns The value of the specified setting, parsed to an object. Returns `null` if setting is not present or no value is available
+ * @returns The value of the specified setting, parsed to an object. Returns `null` if setting is
+ * not present or no value is available
  */
 const getSetting = <SettingName extends SettingNames>(
   key: SettingName,
@@ -25,13 +26,16 @@ const getSetting = <SettingName extends SettingNames>(
 /**
  * Sets the value of the specified setting
  * @param key The string id of the setting for which the value is being retrieved
- * @param newSetting The value that is to be stored. Setting the new value to `null` is the equivalent of deleting the setting
+ * @param newSetting The value that is to be stored. Setting the new value to `null` is the
+ * equivalent of deleting the setting
  */
 const setSetting = <SettingName extends SettingNames>(
   key: SettingName,
   newSetting: Nullable<SettingTypes[SettingName]>,
 ) => {
   localStorage.setItem(key, JSON.stringify(newSetting));
+  // Assert type of the particular SettingName of the emitter.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   const emitter = onDidUpdateSettingEmitters.get(key) as
     | PapiEventEmitter<Nullable<SettingTypes[SettingName]>>
     | undefined;
@@ -39,7 +43,8 @@ const setSetting = <SettingName extends SettingNames>(
 };
 
 /**
- * Subscribes to updates of the specified setting. Whenever the value of the setting changes, the callback function is executed.
+ * Subscribes to updates of the specified setting. Whenever the value of the setting changes, the
+ * callback function is executed.
  * @param key The string id of the setting for which the value is being subscribed to
  * @param callback The function that will be called whenever the specified setting is updated
  * @returns Unsubscriber that should be called whenever the subscription should be deleted
@@ -48,11 +53,15 @@ const subscribeToSetting = <SettingName extends SettingNames>(
   key: SettingName,
   callback: (newSetting: Nullable<SettingTypes[SettingName]>) => void,
 ): Unsubscriber => {
+  // Assert type of the particular SettingName of the emitter.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   let emitter = onDidUpdateSettingEmitters.get(key) as
     | PapiEventEmitter<Nullable<SettingTypes[SettingName]>>
     | undefined;
   if (!emitter) {
     emitter = new PapiEventEmitter<Nullable<SettingTypes[SettingName]>>();
+    // Assert type of the general SettingTypes of the emitter.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     onDidUpdateSettingEmitters.set(key, emitter as PapiEventEmitter<Nullable<SettingTypes>>);
   }
   return emitter.subscribe(callback);

--- a/src/shared/services/web-view.service.ts
+++ b/src/shared/services/web-view.service.ts
@@ -364,8 +364,8 @@ export const removeTab = async (tabId: string): Promise<boolean> => {
  *
  * Not exposed on the papi
  */
-export const addTab = async (
-  savedTabInfo: SavedTabInfo,
+export const addTab = async <TData = unknown>(
+  savedTabInfo: SavedTabInfo & { data?: TData },
   layout: Layout,
 ): Promise<Layout | undefined> => {
   return (await papiDockLayoutVar.promise).addTabToDock(savedTabInfo, layout);
@@ -448,6 +448,8 @@ export const getWebView = async (
   let existingSavedWebView: SavedWebViewDefinition | undefined;
   // Look for existing webview
   if (optionsDefaulted.existingId) {
+    // Expect this to be a tab.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     const existingWebView = (await papiDockLayoutVar.promise).dockLayout.find(
       optionsDefaulted.existingId === '?'
         ? // If they provided '?', that means look for any webview with a matching webViewType
@@ -455,7 +457,8 @@ export const getWebView = async (
             // This is not a webview
             if (!('data' in item)) return false;
 
-            // Find any webview with the specified webViewType
+            // Find any webview with the specified webViewType. Type assert the unknown `data`.
+            // eslint-disable-next-line no-type-assertion/no-type-assertion
             return (item.data as WebViewDefinition).webViewType === webViewType;
           }
         : // If they provided any other string, look for a webview with that id
@@ -464,6 +467,8 @@ export const getWebView = async (
     if (existingWebView) {
       // We found the webview! Save it to send to the web view provider
       existingSavedWebView = convertWebViewDefinitionToSaved(
+        // Type assert the unknown `data`.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
         existingWebView.data as WebViewDefinition,
       );
       // Load the web view state since the web view provider doesn't have access to the data store
@@ -534,6 +539,8 @@ export const getWebView = async (
       specificSrcPolicy = "'unsafe-inline'";
       break;
     default: {
+      // Defaults to React webview definition.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       const reactWebView = webView as WebViewDefinitionReact;
 
       // Add the component as a script
@@ -674,6 +681,8 @@ function removeForbiddenElements(mutationList: MutationRecord[]) {
     m.addedNodes.forEach((node) => {
       if (node.nodeType !== Node.ELEMENT_NODE) return;
 
+      // This is an element node.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       const element = node as Element;
       const tag = element.tagName.toLowerCase();
 
@@ -762,6 +771,8 @@ export const initialize = () => {
       // Register built-in requests
       // TODO: make a registerRequestHandlers function that we use here and in NetworkService.initialize?
       const unsubPromises = Object.entries(rendererRequestHandlers).map(([requestType, handler]) =>
+        // Fix type after passing through the `map` function.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
         networkService.registerRequestHandler(requestType as SerializedRequestType, handler),
       );
 

--- a/src/shared/utils/papi-util.test.ts
+++ b/src/shared/utils/papi-util.test.ts
@@ -32,13 +32,16 @@ describe('PAPI Utils', () => {
   it('will throw on deserialize with no separator', () => {
     const CATEGORY = 'myCategory';
 
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     expect(() => deserializeRequestType(CATEGORY as SerializedRequestType)).toThrow();
   });
 
   it('will throw on serialize if either input is undefined or empty', () => {
     const CATEGORY = 'myCategory';
     const DIRECTIVE = 'myDirective';
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     const undefStr = undefined as unknown as string;
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     const nullStr = null as unknown as string;
 
     expect(() => serializeRequestType('', DIRECTIVE)).toThrow();

--- a/src/shared/utils/util.ts
+++ b/src/shared/utils/util.ts
@@ -45,6 +45,8 @@ export function isString(o: unknown): o is string {
 export function debounce<T extends (...args: any[]) => void>(fn: T, delay = 300): T {
   if (isString(fn)) throw new Error('Tried to debounce a string! Could be XSS');
   let timeout: ReturnType<typeof setTimeout>;
+  // Ensure the right return type.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   return ((...args) => {
     clearTimeout(timeout);
     timeout = setTimeout(() => fn(...args), delay);
@@ -90,6 +92,8 @@ function isErrorWithMessage(error: unknown): error is ErrorWithMessage {
     typeof error === 'object' &&
     error !== null &&
     'message' in error &&
+    // Type assert `error` to check it's `message`.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     typeof (error as Record<string, unknown>).message === 'string'
   );
 }

--- a/src/stories/table.stories.tsx
+++ b/src/stories/table.stories.tsx
@@ -497,6 +497,8 @@ export const MiscellaneousFunctions: Story = {
 
     onCopy: ({ sourceRow, sourceColumnKey }: TableCopyEvent<Row>) => {
       if (window.isSecureContext) {
+        // CopyEvent in `react-data-grid` should declare its property as `sourceColumnKey: keyof TRow`
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
         navigator.clipboard.writeText(sourceRow[sourceColumnKey as keyof Row]);
       }
     },
@@ -513,6 +515,8 @@ export const MiscellaneousFunctions: Story = {
         return targetRow;
       }
 
+      // CopyEvent in `react-data-grid` should declare its property as `sourceColumnKey: keyof TRow`
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       return { ...targetRow, [targetColumnKey]: sourceRow[sourceColumnKey as keyof Row] };
     },
   },


### PR DESCRIPTION
- add eslint rule no-unnecessary-type-assertion
- add eslint rule no-type-assertion
- remove no-non-null-assertion covered by no-non-null-assertion
- also wrapped some overlength comments

Note:
- Don't need a reason to excuse using `as` in tests since you often need to spoof data.
- Most changes are repetative adding of comments to excuse using `as`.
- Some changes remove the need for using `as`.
- One potential bug was found and noted a TODO.
- ~Another one marked as TODO as the reason is unclear why its needed at all.~

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/577)
<!-- Reviewable:end -->
