### PR TITLE
Fix potential bug on early return

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -3623,7 +3623,8 @@ declare module 'node/services/node-file-system.service' {
    * Get stats about the file or directory. Note that BigInts are used instead of ints to avoid.
    * https://en.wikipedia.org/wiki/Year_2038_problem
    * @param uri URI of file or directory
-   * @returns Promise that resolves to object of type https://nodejs.org/api/fs.html#class-fsstats if file or directory exists, undefined if it doesn't
+   * @returns Promise that resolves to object of type https://nodejs.org/api/fs.html#class-fsstats if
+   *  file or directory exists, undefined if it doesn't
    */
   export function getStats(uri: Uri): Promise<BigIntStats | undefined>;
   /**
@@ -3643,10 +3644,10 @@ declare module 'node/services/node-file-system.service' {
     [entryType in EntryType]: Uri[];
   }>;
   /**
-   * Reads a directory and returns lists of entries in the directory by entry type
-   * @param uri URI of directory
-   * @param entryFilter function to filter out entries in the directory based on their names
-   * @returns map of entry type to list of uris for each entry in the directory with that type
+   * Reads a directory and returns lists of entries in the directory by entry type.
+   * @param uri - URI of directory.
+   * @param entryFilter - function to filter out entries in the directory based on their names.
+   * @returns map of entry type to list of uris for each entry in the directory with that type.
    */
   export function readDir(
     uri: Uri,

--- a/src/node/services/node-file-system.service.ts
+++ b/src/node/services/node-file-system.service.ts
@@ -53,7 +53,8 @@ export async function deleteFile(uri: Uri): Promise<void> {
  * Get stats about the file or directory. Note that BigInts are used instead of ints to avoid.
  * https://en.wikipedia.org/wiki/Year_2038_problem
  * @param uri URI of file or directory
- * @returns Promise that resolves to object of type https://nodejs.org/api/fs.html#class-fsstats if file or directory exists, undefined if it doesn't
+ * @returns Promise that resolves to object of type https://nodejs.org/api/fs.html#class-fsstats if
+ *  file or directory exists, undefined if it doesn't
  */
 export async function getStats(uri: Uri): Promise<BigIntStats | undefined> {
   try {
@@ -85,20 +86,35 @@ export type DirectoryEntries = Readonly<{
 }>;
 
 /**
- * Reads a directory and returns lists of entries in the directory by entry type
- * @param uri URI of directory
- * @param entryFilter function to filter out entries in the directory based on their names
- * @returns map of entry type to list of uris for each entry in the directory with that type
+ * Fill in each missing EntryType with an empty array.
+ * @param entryMap - map of Uris to entry type. Defaults to empty map.
+ * @returns updated entryMap with missing properties filled with empty arrays.
+ */
+function fillMissingEntryTypeProperties(
+  entryMap: Map<EntryType, Uri[]> = new Map(),
+): Map<EntryType, Uri[]> {
+  Object.values(EntryType).forEach((entryType) => {
+    if (!entryMap.has(entryType)) entryMap.set(entryType, []);
+  });
+  return entryMap;
+}
+
+/**
+ * Reads a directory and returns lists of entries in the directory by entry type.
+ * @param uri - URI of directory.
+ * @param entryFilter - function to filter out entries in the directory based on their names.
+ * @returns map of entry type to list of uris for each entry in the directory with that type.
  */
 export async function readDir(
   uri: Uri,
   entryFilter?: (entryName: string) => boolean,
 ): Promise<DirectoryEntries> {
   const stats = await getStats(uri);
-  // Assert return type.
-  // TODO: this is covering up a potential bug. EITHER make DirectoryEntries properties optional, remove this assert, and fix everything affected. OR it might be better return empty arrays for each property like it does in L120.
-  // eslint-disable-next-line no-type-assertion/no-type-assertion
-  if (!stats || !stats.isDirectory()) return {} as DirectoryEntries;
+  if (!stats || !stats.isDirectory())
+    // Assert return type.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    return Object.freeze(Object.fromEntries(fillMissingEntryTypeProperties())) as DirectoryEntries;
+
   const unfilteredDirEntries = await fs.promises.readdir(getPathFromUri(uri), {
     withFileTypes: true,
   });
@@ -107,7 +123,7 @@ export async function readDir(
     : unfilteredDirEntries;
 
   // Group each entry by EntryType
-  const entryMap = groupBy(
+  const entryMap: Map<EntryType, Uri[]> = groupBy(
     dirEntries,
     (dirEntry): EntryType => {
       if (dirEntry.isFile()) return EntryType.File;
@@ -117,10 +133,7 @@ export async function readDir(
     (dirent) => joinUriPaths(uri, dirent.name),
   );
 
-  // Fill in each missing EntryType with an empty array
-  Object.values(EntryType).forEach((entryType) => {
-    if (!entryMap.has(entryType)) entryMap.set(entryType, []);
-  });
+  fillMissingEntryTypeProperties(entryMap);
 
   // Assert return type.
   // eslint-disable-next-line no-type-assertion/no-type-assertion


### PR DESCRIPTION
- this was found when adding eslint rule for `as` PR #577.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/580)
<!-- Reviewable:end -->
