### PR TITLE
Enable webviews to change their title and icon url

### DIFF
--- a/c-sharp/NetworkObjects/UsfmDataProvider.cs
+++ b/c-sharp/NetworkObjects/UsfmDataProvider.cs
@@ -97,7 +97,7 @@ internal class UsfmDataProvider : DataProvider
 
     private string GetUsxForBook(VerseRef vref)
     {
-        XmlDocument usx = ConvertUsfmToUsx(GetUsfm(vref.BookNum, -1), vref.BookNum);
+        XmlDocument usx = ConvertUsfmToUsx(GetUsfm(vref.BookNum), vref.BookNum);
         string contents = usx.OuterXml ?? string.Empty;
         return contents;
     }
@@ -127,11 +127,10 @@ internal class UsfmDataProvider : DataProvider
     /// <param name="bookNum">The book for which to get USFM</param>
     /// <param name="chapterNum">The chapter for which to get USFM or -1 for the whole book</param>
     /// <returns>USFM</returns>
-    private string GetUsfm(int bookNum, int chapterNum = -1)
+    private string GetUsfm(int bookNum, int? chapterNum = null)
     {
-        VerseRef vref =
-            new(bookNum, chapterNum == -1 ? 0 : chapterNum, 0, _scrText!.Settings.Versification);
+        VerseRef vref = new(bookNum, chapterNum ?? 0, 0, _scrText!.Settings.Versification);
         ScrText projectToUse = _scrText!.GetJoinedText(bookNum);
-        return projectToUse.GetText(vref, chapterNum >= 0, true);
+        return projectToUse.GetText(vref, chapterNum.HasValue, true);
     }
 }

--- a/c-sharp/NetworkObjects/UsfmDataProvider.cs
+++ b/c-sharp/NetworkObjects/UsfmDataProvider.cs
@@ -125,7 +125,7 @@ internal class UsfmDataProvider : DataProvider
     /// Gets USFM for a book or chapter.
     /// </summary>
     /// <param name="bookNum">The book for which to get USFM</param>
-    /// <param name="chapterNum">The chapter for which to get USFM or -1 for the whole book</param>
+    /// <param name="chapterNum">The chapter for which to get USFM. Do not specify or specify `null` for the whole book</param>
     /// <returns>USFM</returns>
     private string GetUsfm(int bookNum, int? chapterNum = null)
     {

--- a/c-sharp/NetworkObjects/UsfmDataProvider.cs
+++ b/c-sharp/NetworkObjects/UsfmDataProvider.cs
@@ -43,6 +43,7 @@ internal class UsfmDataProvider : DataProvider
                 "getBookNames" => GetBookNames(),
                 "getChapter" => GetChapter(args[0]!.ToJsonString()),
                 "getChapterUsx" => GetChapterUsx(args[0]!.ToJsonString()),
+                "getBookUsx" => GetBookUsx(args[0]!.ToJsonString()),
                 "getVerse" => GetVerse(args[0]!.ToJsonString()),
                 _ => ResponseToRequest.Failed($"Unexpected function: {functionName}")
             };
@@ -69,7 +70,14 @@ internal class UsfmDataProvider : DataProvider
     private ResponseToRequest GetChapterUsx(string args)
     {
         return VerseRefConverter.TryCreateVerseRef(args, out var verseRef, out string errorMsg)
-            ? ResponseToRequest.Succeeded(GetUsx(verseRef))
+            ? ResponseToRequest.Succeeded(GetUsxForChapter(verseRef))
+            : ResponseToRequest.Failed(errorMsg);
+    }
+
+    private ResponseToRequest GetBookUsx(string args)
+    {
+        return VerseRefConverter.TryCreateVerseRef(args, out var verseRef, out string errorMsg)
+            ? ResponseToRequest.Succeeded(GetUsxForBook(verseRef))
             : ResponseToRequest.Failed(errorMsg);
     }
 
@@ -80,16 +88,18 @@ internal class UsfmDataProvider : DataProvider
             : ResponseToRequest.Failed(errorMsg);
     }
 
-    public string GetUsx(VerseRef vref)
+    private string GetUsxForChapter(VerseRef vref)
     {
-        XmlDocument usx = GetUsxForChapter(vref.BookNum, vref.ChapterNum);
+        XmlDocument usx = ConvertUsfmToUsx(GetUsfm(vref.BookNum, vref.ChapterNum), vref.BookNum);
         string contents = usx.OuterXml ?? string.Empty;
         return contents;
     }
 
-    private XmlDocument GetUsxForChapter(int bookNum, int chapterNum)
+    private string GetUsxForBook(VerseRef vref)
     {
-        return ConvertUsfmToUsx(GetUsfmForChapter(bookNum, chapterNum), bookNum);
+        XmlDocument usx = ConvertUsfmToUsx(GetUsfm(vref.BookNum, -1), vref.BookNum);
+        string contents = usx.OuterXml ?? string.Empty;
+        return contents;
     }
 
     /// <summary>
@@ -111,10 +121,17 @@ internal class UsfmDataProvider : DataProvider
         return doc;
     }
 
-    private string GetUsfmForChapter(int bookNum, int chapterNum)
+    /// <summary>
+    /// Gets USFM for a book or chapter.
+    /// </summary>
+    /// <param name="bookNum">The book for which to get USFM</param>
+    /// <param name="chapterNum">The chapter for which to get USFM or -1 for the whole book</param>
+    /// <returns>USFM</returns>
+    private string GetUsfm(int bookNum, int chapterNum = -1)
     {
-        VerseRef vref = new(bookNum, chapterNum, 0, _scrText!.Settings.Versification);
+        VerseRef vref =
+            new(bookNum, chapterNum == -1 ? 0 : chapterNum, 0, _scrText!.Settings.Versification);
         ScrText projectToUse = _scrText!.GetJoinedText(bookNum);
-        return projectToUse.GetText(vref, true, true);
+        return projectToUse.GetText(vref, chapterNum >= 0, true);
     }
 }

--- a/extensions/src/hello-world/hello-world.ts
+++ b/extensions/src/hello-world/hello-world.ts
@@ -53,9 +53,9 @@ const reactWebViewProvider: IWebViewProviderWithType = {
         `${this.webViewType} provider received request to provide a ${savedWebView.webViewType} web view`,
       );
     return {
-      ...savedWebView,
       iconUrl: 'papi-extension://hello-world/assets/offline.svg',
       title: 'Hello World React',
+      ...savedWebView,
       content: helloWorldReactWebView,
       styles: helloWorldReactWebViewStyles,
       state: {

--- a/extensions/src/hello-world/web-views/hello-world.web-view.tsx
+++ b/extensions/src/hello-world/web-views/hello-world.web-view.tsx
@@ -14,9 +14,10 @@ import {
 import type { QuickVerseDataTypes } from 'quick-verse';
 import type { PeopleDataProvider, PeopleDataTypes } from 'hello-someone';
 import type { UsfmProviderDataTypes } from 'usfm-data-provider';
-import { Key, useCallback, useContext, useMemo, useRef, useState } from 'react';
+import { Key, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import type { HelloWorldEvent } from 'hello-world';
 import type { DialogTypes } from 'renderer/components/dialogs/dialog-definition.model';
+import type { WebViewProps } from 'shared/data/web-view.model';
 import Clock from './components/clock.component';
 
 type Row = {
@@ -57,10 +58,14 @@ papi
   .fetch('https://www.example.com', { mode: 'no-cors' })
   .catch((e) => logger.error(`Could not get data from example.com! Reason: ${e}`));
 
-globalThis.webViewComponent = function HelloWorld() {
+globalThis.webViewComponent = function HelloWorld({
+  useWebViewState,
+  getWebViewDefinitionUpdatableProperties,
+  updateWebViewDefinition,
+}: WebViewProps) {
   const test = useContext(TestContext) || "Context didn't work!! :(";
 
-  const [clicks, setClicks] = globalThis.useWebViewState<number>('clicks', 0);
+  const [clicks, setClicks] = useWebViewState<number>('clicks', 0);
   const [rows, setRows] = useState(initializeRows());
   const [selectedRows, setSelectedRows] = useState(new Set<Key>());
   const [scrRef, setScrRef] = useSetting('platform.verseRef', defaultScrRef);
@@ -79,6 +84,13 @@ globalThis.webViewComponent = function HelloWorld() {
       [clicks, setClicks],
     ),
   );
+
+  useEffect(() => {
+    logger.log(
+      `Hello World WebView previous title: ${getWebViewDefinitionUpdatableProperties()?.title}`,
+    );
+    updateWebViewDefinition({ title: `Hello World ${clicks}` });
+  }, [getWebViewDefinitionUpdatableProperties, updateWebViewDefinition, clicks]);
 
   const [echoResult] = usePromise(
     useCallback(async () => {

--- a/extensions/src/usfm-data-provider/index.d.ts
+++ b/extensions/src/usfm-data-provider/index.d.ts
@@ -16,6 +16,7 @@ declare module 'usfm-data-provider' {
     BookNames: DataProviderDataType<boolean, string[], never>;
     Chapter: DataProviderDataType<VerseRef, string | undefined, never>;
     ChapterUsx: DataProviderDataType<VerseRef, string | undefined, never>;
+    BookUsx: DataProviderDataType<VerseRef, string | undefined, never>;
     Verse: DataProviderDataType<VerseRef, string | undefined, never>;
   };
 

--- a/src/renderer/components/docking/platform-dock-layout.component.test.ts
+++ b/src/renderer/components/docking/platform-dock-layout.component.test.ts
@@ -16,7 +16,7 @@ jest.mock(
 
 import DockLayout, { FloatPosition } from 'rc-dock';
 import { anything, instance, mock, verify, when } from 'ts-mockito';
-import { FloatLayout, Layout, SavedTabInfo, WebViewProps } from '@shared/data/web-view.model';
+import { FloatLayout, Layout, SavedTabInfo, WebViewTabProps } from '@shared/data/web-view.model';
 import {
   addTabToDock,
   addWebViewToDock,
@@ -106,7 +106,7 @@ describe('Dock Layout Component', () => {
     it('should throw when no id', () => {
       const dockLayout = instance(mockDockLayout);
       // eslint-disable-next-line no-type-assertion/no-type-assertion
-      const webView = {} as WebViewProps;
+      const webView = {} as WebViewTabProps;
       const layout: Layout = { type: 'tab' };
 
       expect(() => addWebViewToDock(webView, layout, dockLayout)).toThrow();
@@ -116,7 +116,7 @@ describe('Dock Layout Component', () => {
       // Ensure this is an add (rather than an update).
       when(mockDockLayout.find(anything())).thenReturn(undefined);
       const dockLayout = instance(mockDockLayout);
-      const webView: WebViewProps = { id: 'myId', webViewType: 'test', content: '' };
+      const webView: WebViewTabProps = { id: 'myId', webViewType: 'test', content: '' };
       // eslint-disable-next-line no-type-assertion/no-type-assertion
       const layout = { type: 'wacked' } as unknown as FloatLayout;
 
@@ -131,7 +131,7 @@ describe('Dock Layout Component', () => {
       // Ensure this is an add (rather than an update).
       when(mockDockLayout.find(anything())).thenReturn(undefined);
       const dockLayout = instance(mockDockLayout);
-      const webView: WebViewProps = { id: 'myId', webViewType: 'test', content: '' };
+      const webView: WebViewTabProps = { id: 'myId', webViewType: 'test', content: '' };
       const layout: Layout = { type: 'panel', direction: 'top', targetTabId: 'unknownTabId' };
 
       expect(() => addWebViewToDock(webView, layout, dockLayout)).toThrow();

--- a/src/renderer/components/web-view.component.test.ts
+++ b/src/renderer/components/web-view.component.test.ts
@@ -1,11 +1,11 @@
-import { WebViewContentType, WebViewProps } from '../../shared/data/web-view.model';
+import { WebViewContentType, WebViewTabProps } from '../../shared/data/web-view.model';
 import { getTitle } from './web-view.component';
 
 describe('WebView Component', () => {
   describe('getTitle', () => {
     it('can get title when title is defined', () => {
       const title = 'MyTitle';
-      const props: WebViewProps = {
+      const props: WebViewTabProps = {
         id: '',
         webViewType: '',
         content: '',
@@ -18,7 +18,7 @@ describe('WebView Component', () => {
     it('can get title when title is undefined but webViewType exists', () => {
       const webViewType = 'my-webview';
       const title = `${webViewType} Web View`;
-      const props: WebViewProps = {
+      const props: WebViewTabProps = {
         id: '',
         webViewType,
         content: '',
@@ -30,7 +30,7 @@ describe('WebView Component', () => {
     it('can get title when title is undefined and webViewType is empty but contentType exists', () => {
       const contentType = WebViewContentType.HTML;
       const title = `${contentType} Web View`;
-      const props: WebViewProps = {
+      const props: WebViewTabProps = {
         id: '',
         webViewType: '',
         content: '',

--- a/src/renderer/global-this.model.ts
+++ b/src/renderer/global-this.model.ts
@@ -14,7 +14,7 @@ import {
   getWebViewStateById,
   setWebViewStateById,
 } from '@renderer/services/web-view-state.service';
-import useWebViewState from '@renderer/hooks/use-webview-state';
+import useWebViewState from '@renderer/hooks/use-webview-state.hook';
 
 // #region webpack DefinePlugin types setup - these should be from the renderer webpack DefinePlugin
 
@@ -79,7 +79,7 @@ globalThis.resourcesPath = 'resources://';
 // TODO: support command-line logLevel in renderer
 globalThis.logLevel = globalThis.isPackaged ? 'error' : 'info';
 
-// Note: these items are used in `src\shared\services\web-view.service.ts`. Putting them here breaks
+// Note: these items are used in `@shared\services\web-view.service.ts`. Putting them here breaks
 // the circular dependency since `papi` uses the webview service.
 globalThis.papi = papi;
 globalThis.React = React;

--- a/src/renderer/hooks/papi-hooks/use-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-data.hook.ts
@@ -33,7 +33,7 @@ import createUseDataHook, {
  * example, `useData.Verse<QuickVerseDataTypes, 'Verse'>` lets you subscribe to verses from a data
  * provider that serves `QuickVerseDataTypes`.
  *
- * ＠example When subscribing to JHN 11:35 on the `'quickVerse.quickVerse'` data provider, we need
+ * *＠example* When subscribing to JHN 11:35 on the `'quickVerse.quickVerse'` data provider, we need
  * to tell the useData.Verse hook what types we are using, so we use the `QuickVerseDataTypes` data
  * types and specify that we are using the `'Verse'` data type as follows:
  * ```typescript
@@ -44,27 +44,28 @@ import createUseDataHook, {
  * );
  * ```
  *
- * ＠param `dataProviderSource` string name of data provider to get OR dataProvider (result of useDataProvider if you
+ * *＠param* `dataProviderSource` string name of data provider to get OR dataProvider (result of useDataProvider if you
  * want to consolidate and only get the data provider once)
  *
- * ＠param `selector` tells the provider what data this listener is listening for
+ * *＠param* `selector` tells the provider what data this listener is listening for
  *
- * ＠param `defaultValue` the initial value to return while first awaiting the data
+ * *＠param* `defaultValue` the initial value to return while first awaiting the data
  *
  *    WARNING: MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not be updated every render
  *
- * ＠param `subscriberOptions` various options to adjust how the subscriber emits updates
+ * *＠param* `subscriberOptions` various options to adjust how the subscriber emits updates
  *
  *    WARNING: If provided, MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not be updated every render
- * ＠returns `[data, setData, isLoading]`
+ *
+ * *＠returns* `[data, setData, isLoading]`
  *  - `data`: the current value for the data from the data provider with the specified data type and selector, either the defaultValue or the resolved data
  *  - `setData`: asynchronous function to request that the data provider update the data at this data type and selector. Returns true if successful.
  *    Note that this function does not update the data. The data provider sends out an update to this subscription if it successfully updates data.
  *  - `isLoading`: whether the data with the data type and selector is awaiting retrieval from the data provider
  *
- * ＠type `TDataTypes` - the data provider data types served by the data provider whose data to use.
+ * *＠type* `TDataTypes` - the data provider data types served by the data provider whose data to use.
  *
- * ＠type `TDataType` - the specific data type on this data provider that you want to use. Must match
+ * *＠type* `TDataType` - the specific data type on this data provider that you want to use. Must match
  * the data type specified in `useData.<data_type>`
  */
 const useData: UseDataHook = createUseDataHook(useDataProvider);

--- a/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
@@ -79,7 +79,7 @@ type UseProjectDataHook = {
  * lets you subscribe to verse USFM from a project data provider for the `ParatextStandard`
  * `projectType`.
  *
- * ＠example When subscribing to JHN 11:35 Verse USFM info on a `ParatextStandard` project with
+ * *＠example* When subscribing to JHN 11:35 Verse USFM info on a `ParatextStandard` project with
  * projectId `32664dc3288a28df2e2bb75ded887fc8f17a15fb`, we need to tell the
  * `useProjectData.VerseUSFM` hook what types we are using, so we specify the project data types as
  * `ProjectDataTypes['ParatextStandard']` and specify that we are using the `'VerseUSFM'` data type
@@ -92,20 +92,21 @@ type UseProjectDataHook = {
  * );
  * ```
  *
- * ＠param `projectDataProviderSource` string name of the id of the project to get OR
+ * *＠param* `projectDataProviderSource` string name of the id of the project to get OR
  * projectDataProvider (result of useProjectDataProvider if you
  * want to consolidate and only get the project data provider once)
  *
- * ＠param `selector` tells the provider what data this listener is listening for
+ * *＠param* `selector` tells the provider what data this listener is listening for
  *
- * ＠param `defaultValue` the initial value to return while first awaiting the data
+ * *＠param* `defaultValue` the initial value to return while first awaiting the data
  *
  *    WARNING: MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not be updated every render
  *
- * ＠param `subscriberOptions` various options to adjust how the subscriber emits updates
+ * *＠param* `subscriberOptions` various options to adjust how the subscriber emits updates
  *
  *    WARNING: If provided, MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not be updated every render
- * ＠returns `[data, setData, isLoading]`
+ *
+ * *＠returns* `[data, setData, isLoading]`
  *  - `data`: the current value for the data from the project data provider for the specified
  *    project id with the specified data type and selector, either the defaultValue or the resolved
  *    data
@@ -116,9 +117,10 @@ type UseProjectDataHook = {
  *  - `isLoading`: whether the data with the data type and selector is awaiting retrieval from the
  *    project data provider for this project id
  *
- * @type `TProjectDataTypes` - the project data types associated with the `projectType` used. You
+ * *＠type* `TProjectDataTypes` - the project data types associated with the `projectType` used. You
  * can specify this type with `ProjectDataTypes['<project_type>']`
- * @type `TDataType` - the specific data type on this project you want to use. Must match the data
+ *
+ * *＠type* `TDataType` - the specific data type on this project you want to use. Must match the data
  * type specified in `useProjectData.<data_type>`
  */
 // Assert the more general and more specific types.

--- a/src/renderer/hooks/use-webview-state.hook.ts
+++ b/src/renderer/hooks/use-webview-state.hook.ts
@@ -1,7 +1,7 @@
 import { useState, useEffect, Dispatch, SetStateAction } from 'react';
 
 // We don't add this to PAPI directly like other hooks because `this` has to be bound to a web view's iframe context
-/** See src/shared/global-this.model.ts for normal hook documentation */
+/** See `web-view.model.ts` for normal hook documentation */
 export default function useWebViewState<T>(
   this: {
     getWebViewState: (stateKey: string) => T | undefined;

--- a/src/shared/data/web-view.model.ts
+++ b/src/shared/data/web-view.model.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { Dispatch, ReactNode, SetStateAction } from 'react';
 
 /**
  * Saved information used to recreate a tab.
@@ -138,8 +138,99 @@ export type SavedWebViewDefinition =
     ) &
       Pick<WebViewDefinitionBase, 'id' | 'webViewType'>;
 
-/** Props that are passed to the web view component */
-export type WebViewProps = WebViewDefinition;
+/** Props that are passed to the web view tab component */
+export type WebViewTabProps = WebViewDefinition;
+
+/**
+ * The properties on a WebViewDefinition that may be updated when that webview is already displayed
+ */
+// To allow more properties to be updated, add them in
+// `web-view.service.ts` -> `getUpdatablePropertiesFromWebViewDefinition`
+export type WebViewDefinitionUpdatableProperties = Pick<WebViewDefinitionBase, 'iconUrl' | 'title'>;
+
+/**
+ * WebViewDefinition properties for updating a WebView that is already displayed. Any unspecified
+ * properties will stay the same
+ */
+// To allow more properties to be updated, add them in
+// `web-view.service.ts` -> `getUpdatablePropertiesFromWebViewDefinition`
+export type WebViewDefinitionUpdateInfo = Partial<WebViewDefinitionUpdatableProperties>;
+
+// This hook is found in `use-webview-state.hook.ts`
+// Note: the following comment uses ＠, not the actual @ character, to hackily provide @param and
+// such on this type. It seem that, for some reason, JSDoc does not carry these annotations on
+// destructured members of object types, so using WebViewProps as
+// `{ useWebViewState }: WebViewProps` was not carrying the annotations out to the new
+// `useWebViewState` variable. One day, this may work, so we can fix this JSDoc back to using real @
+/** JSDOC SOURCE UseWebViewStateHook
+ * A React hook for working with a state object tied to a webview.
+ *
+ * Only used in WebView iframes.
+ *
+ * *＠param* `stateKey` Key of the state value to use. The webview state holds a unique value per key.
+ *
+ * NOTE: `stateKey` needs to be a constant string, not something that could change during execution.
+ *
+ * *＠param* `defaultStateValue` Value to use if the web view state didn't contain a value for the
+ * given 'stateKey'
+ *
+ * *＠returns* `[stateValue, setStateValue]`
+ *  - `stateValue`: the current value for the web view state at the key specified or
+ *    `defaultStateValue` if a state was not found
+ *  - `setStateValue`: function to use to update the web view state value at the key specified
+ *
+ * *＠example*
+ * ```typescript
+ * const [lastPersonSeen, setLastPersonSeen] = useWebViewState('lastSeen', 'No one');
+ * ```
+ */
+export type UseWebViewStateHook = <T>(
+  stateKey: string,
+  defaultStateValue: NonNullable<T>,
+) => [webViewState: NonNullable<T>, setWebViewState: Dispatch<SetStateAction<NonNullable<T>>>];
+
+// Note: the following comment uses ＠, not the actual @ character, to hackily provide @param and
+// such on this type. It seem that, for some reason, JSDoc does not carry these annotations on
+// destructured members of object types. See comment above UseWebViewStateHook for more info.
+/** JSDOC SOURCE GetWebViewDefinitionUpdatableProperties
+ * Gets the updatable properties on this WebView's WebView definition
+ *
+ * *＠returns* updatable properties this WebView's WebView definition or undefined if not found for
+ * some reason
+ */
+export type GetWebViewDefinitionUpdatableProperties = () =>
+  | WebViewDefinitionUpdatableProperties
+  | undefined;
+
+// Note: the following comment uses ＠, not the actual @ character, to hackily provide @param and
+// such on this type. It seem that, for some reason, JSDoc does not carry these annotations on
+// destructured members of object types. See comment above UseWebViewStateHook for more info.
+/** JSDOC SOURCE UpdateWebViewDefinition
+ * Updates this WebView with the specified properties
+ *
+ * *＠param* `updateInfo` properties to update on the WebView. Any unspecified
+ * properties will stay the same
+ *
+ * *＠returns* true if successfully found the WebView to update; false otherwise
+ *
+ * *＠example*
+ * ```typescript
+ * updateWebViewDefinition({ title: `Hello ${name}`});
+ * ```
+ */
+export type UpdateWebViewDefinition = (updateInfo: WebViewDefinitionUpdateInfo) => boolean;
+
+/**
+ * Props that are passed into the web view itself inside the iframe in the web view tab component
+ */
+export type WebViewProps = {
+  /** JSDOC DESTINATION UseWebViewStateHook */
+  useWebViewState: UseWebViewStateHook;
+  /** JSDOC DESTINATION GetWebViewDefinitionUpdatableProperties */
+  getWebViewDefinitionUpdatableProperties: GetWebViewDefinitionUpdatableProperties;
+  /** JSDOC DESTINATION UpdateWebViewDefinition */
+  updateWebViewDefinition: UpdateWebViewDefinition;
+};
 
 /** Information about a tab in a panel */
 interface TabLayout {

--- a/src/shared/global-this.model.ts
+++ b/src/shared/global-this.model.ts
@@ -2,7 +2,15 @@
 /* eslint-disable no-var */
 
 import { LogLevel } from 'electron-log';
-import { FunctionComponent, Dispatch, SetStateAction } from 'react';
+import { FunctionComponent } from 'react';
+import {
+  GetWebViewDefinitionUpdatableProperties,
+  UpdateWebViewDefinition,
+  UseWebViewStateHook,
+  WebViewDefinitionUpdatableProperties,
+  WebViewDefinitionUpdateInfo,
+  WebViewProps,
+} from '@shared/data/web-view.model';
 
 /**
  * Variables that are defined in global scope. These must be defined in main.ts (main), index.ts (renderer), and extension-host.ts (extension host)
@@ -23,20 +31,9 @@ declare global {
    * A function that each React WebView extension must provide for Paranext to display it.
    * Only used in WebView iframes.
    */
-  var webViewComponent: FunctionComponent;
-  /**
-   * A React hook for working with a state object tied to a webview.
-   * Only used in WebView iframes.
-   * @param stateKey Key of the state value to use. The webview state holds a unique value per key.
-   * NOTE: `stateKey` needs to be a constant string, not something that could change during execution.
-   * @param defaultStateValue Value to use if the web view state didn't contain a value for the given 'stateKey'
-   * @returns string holding the state value and a function to use to update the state value
-   * @example const [lastPersonSeen, setLastPersonSeen] = useWebViewState('lastSeen');
-   */
-  var useWebViewState: <T>(
-    stateKey: string,
-    defaultStateValue: NonNullable<T>,
-  ) => [webViewState: NonNullable<T>, setWebViewState: Dispatch<SetStateAction<NonNullable<T>>>];
+  var webViewComponent: FunctionComponent<WebViewProps>;
+  /** JSDOC DESTINATION UseWebViewStateHook */
+  var useWebViewState: UseWebViewStateHook;
   /**
    * Retrieve the value from web view state with the given 'stateKey', if it exists.
    */
@@ -45,6 +42,21 @@ declare global {
    * Set the value for a given key in the web view state.
    */
   var setWebViewState: <T>(stateKey: string, stateValue: NonNullable<T>) => void;
+  // Web view "by id" functions are used in the default imports for each webview in web-view.service.ts
+  // but probably wouldn't be used in a webview
+  // TODO: Find a way to move this to `@renderer/global-this.model.ts` without causing an error on
+  // building papi.d.ts
+  var getWebViewDefinitionUpdatablePropertiesById: (
+    webViewId: string,
+  ) => WebViewDefinitionUpdatableProperties | undefined;
+  var updateWebViewDefinitionById: (
+    webViewId: string,
+    webViewDefinitionUpdateInfo: WebViewDefinitionUpdateInfo,
+  ) => boolean;
+  /** JSDOC DESTINATION GetWebViewDefinitionUpdatableProperties */
+  var getWebViewDefinitionUpdatableProperties: GetWebViewDefinitionUpdatableProperties;
+  /** JSDOC DESTINATION UpdateWebViewDefinition */
+  var updateWebViewDefinition: UpdateWebViewDefinition;
 }
 
 /** Type of Paranext process */

--- a/src/shared/services/web-view.service.ts
+++ b/src/shared/services/web-view.service.ts
@@ -21,12 +21,14 @@ import {
   TabInfo,
   WebViewDefinitionReact,
   WebViewContentType,
-  WebViewProps,
+  WebViewTabProps,
   WebViewType,
   WebViewId,
   GetWebViewOptions,
   WebViewDefinition,
   SavedWebViewDefinition,
+  WebViewDefinitionUpdateInfo,
+  WebViewDefinitionUpdatableProperties,
 } from '@shared/data/web-view.model';
 import * as networkService from '@shared/services/network.service';
 import webViewProviderService from '@shared/services/web-view-provider.service';
@@ -69,12 +71,30 @@ type PapiDockLayout = {
    * @returns If WebView added, final layout used to display the new webView. If existing webView
    *   updated, `undefined`
    */
-  addWebViewToDock: (webView: WebViewProps, layout: Layout) => Layout | undefined;
+  addWebViewToDock: (webView: WebViewTabProps, layout: Layout) => Layout | undefined;
   /**
    * Remove a tab in the layout
    * @param tabId id of the tab to remove
    */
   removeTabFromDock: (tabId: string) => boolean;
+  /**
+   * Gets the WebView definition for the web view with the specified id
+   *
+   * @param webViewId the id of the WebView whose web view definition to get
+   *
+   * @returns WebView definition with the specified id or undefined if not found
+   */
+  getWebViewDefinition: (webViewId: string) => WebViewDefinition | undefined;
+  /**
+   * Updates the WebView with the specified id with the specified properties
+   *
+   * @param webViewId the id of the WebView to update
+   * @param updateInfo properties to update on the WebView. Any unspecified
+   * properties will stay the same
+   *
+   * @returns true if successfully found the WebView to update; false otherwise
+   */
+  updateWebViewDefinition: (webViewId: string, updateInfo: WebViewDefinitionUpdateInfo) => boolean;
   /**
    * The layout to use as the default layout if the dockLayout doesn't have a layout loaded.
    *
@@ -184,14 +204,84 @@ const onDidAddWebViewEmitter = createNetworkEventEmitter<AddWebViewEvent>(
 export const onDidAddWebView = onDidAddWebViewEmitter.event;
 
 /**
- * Variable that will hold the rc-dock dock layout along with a couple other props. This is
- * populated by `platform-dock-layout.component.tsx` registering its dock layout with this service,
- * allowing this service to manage layouts and such.
+ * WARNING: DO NOT USE THIS VARIABLE DIRECTLY. USE `getDockLayout()`
+ *
+ * Asynchronously accessed variable that will hold the rc-dock dock layout along with a couple other
+ * props. This is populated by `platform-dock-layout.component.tsx` registering its dock layout with
+ * this service, allowing this service to manage layouts and such.
  *
  * WARNING: YOU CAN ONLY USE THIS VARIABLE IN THE RENDERER. Also please do not save this
  * variable out anywhere because it can change, invalidating the old one (see `registerDockLayout`)
  */
 let papiDockLayoutVar = createDockLayoutAsyncVar();
+/**
+ * WARNING: DO NOT USE THIS VARIABLE DIRECTLY. USE `getDockLayoutSync()`
+ *
+ * Synchronously accessed variable that will hold the rc-dock dock layout along with a couple other
+ * props. This is populated by `platform-dock-layout.component.tsx` registering its dock layout with
+ * this service, allowing this service to manage layouts and such.
+ *
+ * WARNING: YOU CAN ONLY USE THIS VARIABLE IN THE RENDERER. Also please do not save this
+ * variable out anywhere because it can change, invalidating the old one (see `registerDockLayout`)
+ */
+let papiDockLayoutVarSync: PapiDockLayout | undefined;
+/**
+ * Set the papi dock layout (async and sync). Resolves `getDockLayout()` calls.
+ *
+ * This should very likely only be used in `registerDockLayout`.
+ *
+ * @param dockLayout the papi dock layout to set or undefined to reset the dock layout
+ *
+ * WARNING: YOU CAN ONLY USE THIS FUNCTION IN THE RENDERER.
+ */
+function setDockLayout(dockLayout: PapiDockLayout | undefined): void {
+  if (dockLayout === undefined) {
+    // Create a new async var to empty out the dock layout only if the dock layout was previously
+    // set. That way, async callers to the dock layout who are awaiting a resolved value don't get
+    // lost or rejected needlessly
+    // TODO: Would creating a new async var create any problems...? I guess only if someone saves
+    // dockLayoutVar somewhere else
+    if (papiDockLayoutVar.hasSettled) papiDockLayoutVar = createDockLayoutAsyncVar();
+    papiDockLayoutVarSync = undefined;
+  } else {
+    // Set the dock layout as the promise var. Throws if already resolved
+    papiDockLayoutVar.resolveToValue(dockLayout, true);
+    if (papiDockLayoutVarSync)
+      throw new Error(
+        'WebView Service error: papiDockLayoutVarSync is already set when trying to set it!',
+      );
+    papiDockLayoutVarSync = dockLayout;
+  }
+}
+/**
+ * Get the papi dock layout promise. It will resolve to the papi dock layout when it is registered.
+ *
+ * WARNING: YOU CAN ONLY USE THIS FUNCTION IN THE RENDERER. Also please do not save the returned
+ * variable out anywhere because it can change, invalidating the old one (see `registerDockLayout`)
+ *
+ * @returns promise that resolves to the papi dock layout
+ */
+function getDockLayout(): Promise<PapiDockLayout> {
+  return papiDockLayoutVar.promise;
+}
+/**
+ * Get the papi dock layout synchronously *assuming* it has been registered. This should be safe to
+ * assume if you are accessing this from inside a tab's code
+ *
+ * WARNING: YOU CAN ONLY USE THIS FUNCTION IN THE RENDERER. Also please do not save the returned
+ * variable out anywhere because it can change, invalidating the old one (see `registerDockLayout`)
+ *
+ * @returns the papi dock layout
+ *
+ * @throws if the papi dock layout has not been registered
+ */
+function getDockLayoutSync(): PapiDockLayout {
+  if (!papiDockLayoutVarSync)
+    throw new Error(
+      'WebView Service error: Dock layout was requested synchronously, but the dock layout has not been registered!',
+    );
+  return papiDockLayoutVarSync;
+}
 
 // #region functions related to the dock layout
 
@@ -203,7 +293,7 @@ let papiDockLayoutVar = createDockLayoutAsyncVar();
 export function saveTabInfoBase(tabInfo: TabInfo): SavedTabInfo {
   // We don't need to use the other properties, but we need to remove them
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { tabTitle, content, minWidth, minHeight, ...savedTabInfo } = tabInfo;
+  const { tabTitle, tabIconUrl, content, minWidth, minHeight, ...savedTabInfo } = tabInfo;
   return savedTabInfo;
 }
 
@@ -276,7 +366,7 @@ async function saveLayout(layout: LayoutBase): Promise<void> {
  * WARNING: YOU CAN ONLY USE THIS FUNCTION IN THE RENDERER
  */
 async function loadLayout(layout?: LayoutBase): Promise<void> {
-  const dockLayoutVar = await papiDockLayoutVar.promise;
+  const dockLayoutVar = await getDockLayout();
   const layoutToLoad = layout || getStorageValue(DOCK_LAYOUT_KEY, dockLayoutVar.testLayout);
 
   dockLayoutVar.dockLayout.loadLayout(layoutToLoad);
@@ -301,8 +391,7 @@ export function registerDockLayout(dockLayout: PapiDockLayout): Unsubscriber {
   // Save the current async var so we know if it changed before we unsubscribed
   const currentPapiDockLayoutVar = papiDockLayoutVar;
 
-  // Set the dock layout as the promise var. Throws if already resolved
-  papiDockLayoutVar.resolveToValue(dockLayout, true);
+  setDockLayout(dockLayout);
 
   // TODO: Strange pattern that we are setting a ref to a service function. Investigate changing
   // this pattern in some way. Maybe just export `onLayoutChange`?
@@ -319,9 +408,7 @@ export function registerDockLayout(dockLayout: PapiDockLayout): Unsubscriber {
     if (papiDockLayoutVar !== currentPapiDockLayoutVar)
       throw new Error('Tried to unregister an old dock layout');
 
-    // Create a new async var to empty out the dock layout
-    // TODO: Would this create any problems...? I guess only if we save dockLayoutVar somewhere else
-    papiDockLayoutVar = createDockLayoutAsyncVar();
+    setDockLayout(undefined);
 
     return true;
   };
@@ -349,7 +436,7 @@ function getWebViewOptionsDefaults(options: GetWebViewOptions): GetWebViewOption
  * Not exposed on the papi
  */
 export const removeTab = async (tabId: string): Promise<boolean> => {
-  return (await papiDockLayoutVar.promise).removeTabFromDock(tabId);
+  return (await getDockLayout()).removeTabFromDock(tabId);
 };
 
 /**
@@ -368,8 +455,109 @@ export const addTab = async <TData = unknown>(
   savedTabInfo: SavedTabInfo & { data?: TData },
   layout: Layout,
 ): Promise<Layout | undefined> => {
-  return (await papiDockLayoutVar.promise).addTabToDock(savedTabInfo, layout);
+  return (await getDockLayout()).addTabToDock(savedTabInfo, layout);
 };
+
+/**
+ * Get just the updatable properties of a web view definition
+ * @param webViewDefinition web view definition or update info to get updatable properties from
+ * @returns updatable properties of the web view definition
+ *
+ * Not exposed on the papi
+ */
+export function getUpdatablePropertiesFromWebViewDefinition(
+  webViewDefinition:
+    | SavedWebViewDefinition
+    | WebViewDefinition
+    | WebViewDefinitionUpdatableProperties
+    | WebViewDefinitionUpdateInfo,
+): WebViewDefinitionUpdatableProperties {
+  // Make sure we're only including the specific properties we allow updates on
+  const { iconUrl, title } = webViewDefinition;
+  return { iconUrl, title };
+}
+
+/**
+ * Merges web view definition updates into a web view definition. Does not modify the original
+ * web view definition but returns a new object.
+ * @param webViewDefinition web view definition to merge into
+ * @param updateInfo updates to merge into the web view definition
+ * @returns new copy of web view definition with updates applied
+ *
+ * Not exposed on the papi
+ */
+export function mergeUpdatablePropertiesIntoWebViewDefinition<T extends SavedWebViewDefinition>(
+  webViewDefinition: T,
+  updateInfo: WebViewDefinitionUpdateInfo,
+): T {
+  const webViewUpdate = getUpdatablePropertiesFromWebViewDefinition(updateInfo);
+  // If update properties aren't specified, keep the original values
+  const mergedProperties = Object.fromEntries(
+    Object.entries(webViewUpdate).map(([key, value]) => [
+      key,
+      // Reminding TypeScript that key is from entries of updatable properties
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      value || webViewDefinition[key as keyof WebViewDefinitionUpdatableProperties],
+    ]),
+  );
+  return {
+    ...webViewDefinition,
+    ...mergedProperties,
+  };
+}
+
+/**
+ * Gets the updatable properties on the WebView definition with the specified id
+ *
+ * @param webViewId the id of the WebView whose updatable properties to get
+ *
+ * @returns updatable properties of the WebView definition with the specified id or undefined if
+ * not found
+ *
+ * @throws if the papi dock layout has not been registered
+ *
+ * WARNING: YOU CAN ONLY USE THIS FUNCTION IN THE RENDERER
+ *
+ * Not exposed on the papi
+ */
+export function getWebViewDefinitionUpdatablePropertiesSync(
+  webViewId: string,
+): WebViewDefinitionUpdatableProperties | undefined {
+  const webViewDefinition = getDockLayoutSync().getWebViewDefinition(webViewId);
+  if (webViewDefinition === undefined) return undefined;
+
+  return getUpdatablePropertiesFromWebViewDefinition(webViewDefinition);
+}
+
+/**
+ * Updates the WebView with the specified id with the specified properties
+ *
+ * @param webViewId the id of the WebView to update
+ * @param webViewDefinitionUpdateInfo properties to update on the WebView. Any unspecified
+ * properties will stay the same
+ *
+ * @returns true if successfully found the WebView to update; false otherwise
+ *
+ * @throws if the papi dock layout has not been registered
+ *
+ * WARNING: YOU CAN ONLY USE THIS FUNCTION IN THE RENDERER
+ *
+ * Not exposed on the papi
+ */
+export function updateWebViewDefinitionSync(
+  webViewId: string,
+  webViewDefinitionUpdateInfo: WebViewDefinitionUpdateInfo,
+): boolean {
+  return getDockLayoutSync().updateWebViewDefinition(webViewId, webViewDefinitionUpdateInfo);
+}
+
+// #region Set up global variables to use in `getWebView`'s `imports` below
+
+globalThis.getWebViewDefinitionUpdatablePropertiesById =
+  getWebViewDefinitionUpdatablePropertiesSync;
+globalThis.updateWebViewDefinitionById = updateWebViewDefinitionSync;
+
+// #endregion
 
 /**
  * Creates a new web view or gets an existing one depending on if you request an existing one and
@@ -450,7 +638,7 @@ export const getWebView = async (
   if (optionsDefaulted.existingId) {
     // Expect this to be a tab.
     // eslint-disable-next-line no-type-assertion/no-type-assertion
-    const existingWebView = (await papiDockLayoutVar.promise).dockLayout.find(
+    const existingWebView = (await getDockLayout()).dockLayout.find(
       optionsDefaulted.existingId === '?'
         ? // If they provided '?', that means look for any webview with a matching webViewType
           (item) => {
@@ -499,7 +687,14 @@ export const getWebView = async (
   // `webViewRequire`, `getWebViewStateById`, and `setWebViewStateById` below are defined in `src\renderer\global-this.model.ts`
   // `useWebViewState` below is defined in `src\shared\global-this.model.ts`
   // We have to bind `useWebViewState` to the current `window` context because calls within PAPI don't have access to a webview's `window` context
-  /** String that sets up 'import' statements in the webview to pull in libraries and clear out internet access and such */
+  /**
+   * String that sets up 'import' statements in the webview to pull in libraries and clear out internet access and such
+   *
+   * WARNING: `window.top` is not deletable as a security feature (websites need to know if they are
+   * running embedded in an iframe), so the child iframes are NOT isolated from their parents. We
+   * perform a number of tasks to mitigate this issue, but it would be very nice to find a way to
+   * properly delete `window.top`
+   */
   const imports = `
   var papi = window.parent.papi;
   var React = window.parent.React;
@@ -514,6 +709,10 @@ export const getWebView = async (
   window.getWebViewState = (stateKey) => { return getWebViewStateById('${webView.id}', stateKey) };
   window.setWebViewState = (stateKey, stateValue) => { setWebViewStateById('${webView.id}', stateKey, stateValue) };
   window.useWebViewState = window.parent.useWebViewState.bind(window);
+  var getWebViewDefinitionUpdatablePropertiesById = window.parent.getWebViewDefinitionUpdatablePropertiesById;
+  window.getWebViewDefinitionUpdatableProperties = () => { return getWebViewDefinitionUpdatablePropertiesById('${webView.id}')}
+  var updateWebViewDefinitionById = window.parent.updateWebViewDefinitionById;
+  window.updateWebViewDefinition = (webViewDefinitionUpdateInfo) => { return updateWebViewDefinitionById('${webView.id}', webViewDefinitionUpdateInfo)}
   window.fetch = papi.fetch;
   delete window.parent;
   delete window.top;
@@ -523,6 +722,10 @@ export const getWebView = async (
   `;
 
   /** Nonce used to allow scripts and styles to run */
+  // TODO: Generating nonces every time causes webviews to rerender every time `getWebView` is used
+  // on an existing webview such as when the extension host is restarted. Should we save webview
+  // nonces so the `content` can be the same and not have to rerender?
+  // Or this could solve the problem as well https://github.com/paranext/paranext-core/issues/282
   const srcNonce = newNonce();
 
   // Build the contents of the iframe
@@ -565,7 +768,15 @@ export const getWebView = async (
               function initializeReact() {
                 const container = document.getElementById('root');
                 const root = createRoot(container);
-                root.render(React.createElement(globalThis.webViewComponent, null));
+
+                // Set up WebViewProps to pass into the WebView component
+                const webViewProps = {
+                  useWebViewState: window.useWebViewState,
+                  getWebViewDefinitionUpdatableProperties: window.getWebViewDefinitionUpdatableProperties,
+                  updateWebViewDefinition: window.updateWebViewDefinition,
+                };
+
+                root.render(React.createElement(globalThis.webViewComponent, webViewProps));
               }
 
               if (document.readyState === 'loading')
@@ -642,13 +853,13 @@ export const getWebView = async (
     ${imports}
     </script>${webViewContent.substring(headEnd + 1)}`;
 
-  const updatedWebView: WebViewProps = {
+  const updatedWebView: WebViewTabProps = {
     ...webView,
     contentType,
     content: webViewContent,
   };
 
-  const updatedLayout = (await papiDockLayoutVar.promise).addWebViewToDock(updatedWebView, layout);
+  const updatedLayout = (await getDockLayout()).addWebViewToDock(updatedWebView, layout);
 
   // If we received a layout (meaning it created a new webview instead of updating an existing one),
   // inform web view consumers that we added a new web view


### PR DESCRIPTION
Refactored how React webviews work a bit so a few `WebViewProps` are now passed in for ease of access:
- useWebViewState
- updateWebViewDefinition
- getWebViewDefinitionUpdatableProperties

Also added `getBookUsx` to the USFM data provider to get data for Ira.

Subscribing to updates to the webview definition was split into #581 since that did not seem particularly valuable at this time.

Resolves #445

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/583)
<!-- Reviewable:end -->
