### PR TITLE
Fix getMetadataForProject being the only thing using project ids that is case-sensitive

### DIFF
--- a/src/extension-host/services/project-lookup.service-host.ts
+++ b/src/extension-host/services/project-lookup.service-host.ts
@@ -104,11 +104,12 @@ async function getMetadataForAllProjects(): Promise<ProjectMetadata[]> {
 
 async function getMetadataForProject(projectId: string): Promise<ProjectMetadata> {
   await initialize();
-  const existingValue = localProjects.get(projectId);
+  const idUpper = projectId.toUpperCase();
+  const existingValue = localProjects.get(idUpper);
   if (existingValue) return existingValue;
 
   // Try to load the project directly in case the files were copied after initialization
-  const newMetadata = await getProjectMetadata(projectId);
+  const newMetadata = await getProjectMetadata(idUpper);
   localProjects.set(newMetadata.id, newMetadata);
   return newMetadata;
 }


### PR DESCRIPTION
Fixes same project showing multiple times in Select Project dialog and elsewhere

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/589)
<!-- Reviewable:end -->
