### PR TITLE
Revised content security policy and added WebViewContentType.URL for url webviews

### DIFF
--- a/extensions/src/evil/assets/evil.web-view.html
+++ b/extensions/src/evil/assets/evil.web-view.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script>
+      try {
+        // Note: child iframes can always tell window !== window.top, but they cannot access stuff
+        // on window.top unless they are same origin
+        window.top.papi.logger.error(
+          '<<BAD>> EVIL WEB VIEW FILE HAS SAME ORIGIN ACCESS TO window.top AND LOGGED THIS ERROR THROUGH THE PAPI ON ITS OWN',
+        );
+      } catch (e) {
+        if (!e.toString().includes('cross-origin frame'))
+          console.warn(
+            `Evil web view file failed to reach parent, but it was not because it is cross-origin. Investigate! Error: ${e}`,
+          );
+        else {
+          // Good! This iframe is not considered to be same origin as parent
+          // No need to log good stuff unless we're testing
+          // console.log(`Evil: good error on attempting cross-origin access window.top: ${e}`)
+        }
+      }
+      try {
+        // Note: child iframes can always tell window !== window.parent, but they cannot access stuff
+        // on window.parent unless they are same origin
+        window.parent.papi.logger.error(
+          '<<BAD>> EVIL WEB VIEW FILE HAS SAME ORIGIN ACCESS TO window.parent AND LOGGED THIS ERROR THROUGH THE PAPI ON ITS OWN',
+        );
+      } catch (e) {
+        if (!e.toString().includes('cross-origin frame'))
+          console.warn(
+            `Evil web view file failed to reach parent, but it was not because it is cross-origin. Investigate! Error: ${e}`,
+          );
+        else {
+          // Good! This iframe is not considered to be same origin as parent
+          // No need to log good stuff unless we're testing
+          // console.log(`Evil: good error on attempting cross-origin access window.parent: ${e}`)
+        }
+      }
+
+      // Note: our CSP is independent of `index.ejs`'s, so we can run whatever scripts we want
+      eval('1 + 1');
+    </script>
+  </body>
+  <div>
+    This evil webview comes from a file! It is served at
+    `papi-extension:evil/assets/evil.web-view.html`. It is trying to do bad things. If you see an
+    error in the console like '&lt;&lt;BAD&gt;&gt; EVIL WEB VIEW FILE...', it did bad things. But if
+    you see this message without seeing errors like that, it probably wasn't able to do bad things!
+    :)
+  </div>
+</html>

--- a/extensions/src/evil/evil.js
+++ b/extensions/src/evil/evil.js
@@ -6,28 +6,75 @@ const papi = require('papi-backend');
 
 const { logger } = papi;
 
+// This is here because we can't bundle a webview in due to webpack not bundling the evil extension
 const EVIL_WEBVIEW = `
 <!DOCTYPE html>
 <html>
   <body>
     <script>
-      // Try to create an iframe with less strict sandboxing - allow-modals (better test than no
-      // sandboxing at all)
-      const unsandboxedId = "evil-unsandboxed-iframe";
-      const unsandboxedIFrame = window.top.document.createElement('iframe');
-      unsandboxedIFrame.id = unsandboxedId;
-      unsandboxedIFrame.srcdoc = \`<html><script>alert(
-        "<<BAD>> evil created a new iframe with sandbox 'allow-modals'!")<\\/script><body>This is
-        evil's new iframe with sandbox 'allow-modals'</body></html>\`;
-      unsandboxedIFrame.setAttribute('sandbox', 'allow-same-origin allow-scripts allow-modals');
+      // Try to create a src iframe on the parent window - this would let us escape our CSP
+      try {
+        // Try to create a \`src\` iframe with less strict sandboxing - allow-same-origin (not allowed
+        // on \`src\` iframes). Note we are also providing \`srcdoc\`, but browsers fall back to
+        // \`src\` if they do not support \`srcdoc\`, so any iframe with \`src\` specified is treated
+        // as a \`src\` iframe
+        const unsandboxedSrcId = "evil-unsandboxed-src-iframe";
+        const unsandboxedSrcIFrame = window.top.document.createElement('iframe');
+        unsandboxedSrcIFrame.id = unsandboxedSrcId;
+        unsandboxedSrcIFrame.src = "https://example.com/";
+        unsandboxedSrcIFrame.srcdoc = \`<html><body>&lt;&lt;BAD&gt;&gt; This is evil's new src iframe with sandbox
+        'allow-same-origin'. Please report this!</body></html>\`;
+        unsandboxedSrcIFrame.setAttribute('sandbox', 'allow-same-origin allow-scripts');
 
-      // If one of these evil iframes already existed, replace it. Otherwise create a new one
-      papi.logger.warn(
-        'Evil is trying to execute code with higher privileges as a test! You should see one more warning soon after this. Only these two warnings are expected.'
-      );
-      const oldIFrame = window.top.document.getElementById(unsandboxedId);
-      if (oldIFrame != null) oldIFrame.replaceWith(unsandboxedIFrame);
-      else window.top.document.body.appendChild(unsandboxedIFrame);
+        // We now have two layers preventing this iframe from being created. Uncomment this warning
+        // if you want to test the MutationObserver. But this iframe should be completely rejected
+        // by the monkey-patched document.createElement, so this warning is not needed at the moment
+        /* papi.logger.warn(
+          'Evil is trying to execute code with higher privileges as a test of src iframes! You should see three more warnings soon after this. Only these four warnings are expected.'
+        ); */
+
+        // If one of these evil src iframes already existed, replace it. Otherwise create a new one
+        const oldSrcIFrame = window.top.document.getElementById(unsandboxedSrcId);
+        if (oldSrcIFrame != null) oldSrcIFrame.replaceWith(unsandboxedSrcIFrame);
+        else window.top.document.body.appendChild(unsandboxedSrcIFrame);
+
+        papi.logger.error('<<BAD>> Evil successfully created a src iframe on the parent window!')
+      } catch (e) {
+        // No need to log good stuff unless we're testing
+        // papi.logger.info(\`Evil: Good error on creating src iframe outside its frame: \${e.message}\`);
+      }
+
+      // Try to create a srcdoc iframe on the parent window - this would let us escape our CSP
+      try {
+        // Try to create a \`srcdoc\` iframe with less strict sandboxing - allow-modals (better test than no
+        // sandboxing at all) - inside a div to make sure the MutationObserver is watching recursively
+        const unsandboxedId = "evil-unsandboxed-iframe-div";
+        const unsandboxedIFrameDiv = window.top.document.createElement('div');
+        unsandboxedIFrameDiv.id = unsandboxedId;
+        const unsandboxedIFrame = window.top.document.createElement('iframe');
+        unsandboxedIFrame.srcdoc = \`<html><script>alert(
+          "<<BAD>> evil created a new iframe with sandbox 'allow-modals'!")<\\/script><body>This is
+          evil's new iframe with sandbox 'allow-modals'</body></html>\`;
+        unsandboxedIFrame.setAttribute('sandbox', 'allow-same-origin allow-scripts allow-modals');
+        unsandboxedIFrameDiv.appendChild(unsandboxedIFrame);
+
+        // We now have two layers preventing this iframe from being created. Uncomment this warning
+        // if you want to test the MutationObserver. But this iframe should be completely rejected
+        // by the monkey-patched document.createElement, so this warning is not needed at the moment
+        /* papi.logger.warn(
+          'Evil is trying to execute code with higher privileges as a test of srcdoc iframes! You should see two more warnings soon after this. Only these four warnings (including the previous one) are expected.'
+        ); */
+
+        // If one of these evil iframes already existed, replace it. Otherwise create a new one
+        const oldIFrameDiv = window.top.document.getElementById(unsandboxedId);
+        if (oldIFrameDiv != null) oldIFrameDiv.replaceWith(unsandboxedIFrameDiv);
+        else window.top.document.body.appendChild(unsandboxedIFrameDiv);
+
+        papi.logger.error('<<BAD>> Evil successfully created a srcdoc iframe on the parent window!')
+      } catch (e) {
+        // No need to log good stuff unless we're testing
+        // papi.logger.info(\`Evil: Good error on creating srcdoc iframe outside its frame: \${e.message}\`);
+      }
 
       // Try to create a script outside the iframe that runs arbitrary code
       // This would mean iframes can break out of their sandboxing and CSP by executing code that
@@ -39,7 +86,20 @@ const EVIL_WEBVIEW = `
           "alert('<<BAD>> evil created a script outside its iframe');window.location = 'https://example.com'";
         window.top.document.body.appendChild(unsandboxedScript);
       } catch (e) {
-        papi.logger.info(\`Evil: Good error on creating script outside its frame: \${e.message}\`);
+        // No need to log good stuff unless we're testing
+        // papi.logger.info(\`Evil: Good error on creating script outside its frame: \${e.message}\`);
+      }
+
+      // Try to create an anchor outside the iframe that allows navigation
+      // This would mean iframes could create a link to navigate to a different page.
+      try {
+        const unsafeAnchor = window.top.document.createElement('a');
+        unsafeAnchor.href ='https://example.com';
+        unsafeAnchor.textContent = '<<BAD>> This link is from the evil webview!'
+        window.top.document.body.appendChild(unsafeAnchor);
+      } catch (e) {
+        // No need to log good stuff unless we're testing
+        // papi.logger.info(\`Evil: Good error on creating script outside its frame: \${e.message}\`);
       }
 
       // Try to create an image outside the iframe with arbitrary code execution in it
@@ -58,10 +118,15 @@ const EVIL_WEBVIEW = `
       //# sourceURL=evil.web-view.html
     </script>
     <div>
-      This evil webview is trying to do bad things. If you see a new iframe on the side of the
-      screen or see modals about evil, it did bad things. But if you see this message without seeing
-      modals, it probably wasn't able to do bad things! 🎉
+      This evil webview is trying to do bad things. If you see a new iframe or link on the side of
+      the screen or see modals about evil, it did bad things. But if you see this message without
+      seeing modals, it probably wasn't able to do bad things! 🎉
     </div>
+    <div>
+      Below, you should see an iframe with another evil webview code that also should fail to do bad
+      things:
+    </div>
+    <iframe src="papi-extension://evil/assets/evil.web-view.html" />
   </body>
 </html>
 `;
@@ -74,6 +139,21 @@ const evilWebViewProvider = {
       title: 'Evil',
       contentType: 'html',
       content: EVIL_WEBVIEW,
+      allowedFrameSources: ['papi-extension:'],
+    };
+  },
+};
+
+const evilFileWebViewProvider = {
+  webViewType: 'evil.evilFile',
+  async getWebView(savedWebView) {
+    return {
+      ...savedWebView,
+      title: 'Evil File',
+      contentType: 'url',
+      content: 'papi-extension://evil/assets/evil.web-view.html',
+      allowScripts: true,
+      allowedFrameSources: ['papi-extension://evil/.+'],
     };
   },
 };
@@ -86,7 +166,8 @@ async function tryImports() {
     const fs = require('fs');
     logger.error(`Evil: <<BAD>> Successfully imported fs! fs.readFileSync = ${fs.readFileSync}`);
   } catch (e) {
-    logger.info(`Evil: Good error on require fs: ${e.message}`);
+    // No need to log good stuff unless we're testing
+    // logger.info(`Evil: Good error on require fs: ${e.message}`);
   }
 
   try {
@@ -94,13 +175,15 @@ async function tryImports() {
     const https = require('https');
     logger.error(`Evil: <<BAD>> Successfully imported https! ${JSON.stringify(https)}`);
   } catch (e) {
-    logger.info(`Evil: Good error on require https: ${e.message}`);
+    // No need to log good stuff unless we're testing
+    // logger.info(`Evil: Good error on require https: ${e.message}`);
   }
 
   try {
     // This should always work because `fetch` is replaced with `papi.fetch`.
     await fetch('https://www.example.com');
-    logger.info('Evil: Good - fetch is working.');
+    // No need to log good stuff unless we're testing
+    // logger.info('Evil: Good - fetch is working.');
   } catch (e) {
     logger.error(`Evil: <<BAD>> error on fetch! ${e}`);
   }
@@ -111,7 +194,8 @@ async function tryImports() {
     const xhr = new XMLHttpRequest();
     logger.error(`Evil: <<BAD>> Successfully created an XMLHttpRequest!`);
   } catch (e) {
-    logger.info(`Evil: Good error on XMLHttpRequest! ${e}`);
+    // No need to log good stuff unless we're testing
+    // logger.info(`Evil: Good error on XMLHttpRequest! ${e}`);
   }
 
   try {
@@ -120,7 +204,8 @@ async function tryImports() {
     const webSocket = new WebSocket();
     logger.error(`Evil: <<BAD>> Successfully created a WebSocket!`);
   } catch (e) {
-    logger.info(`Evil: Good error on WebSocket! ${e}`);
+    // No need to log good stuff unless we're testing
+    // logger.info(`Evil: Good error on WebSocket! ${e}`);
   }
 
   try {
@@ -130,15 +215,17 @@ async function tryImports() {
       `Evil: <<BAD>> Successfully dynamically imported fs! fs.readFileSync = ${fs.readFileSync}`,
     );
   } catch (e) {
-    logger.info(`Evil: Good error on dynamic import! ${e.message}`);
+    // No need to log good stuff unless we're testing
+    // logger.info(`Evil: Good error on dynamic import! ${e.message}`);
   }
 
   try {
     // This should always work.
-    const genericFetch = await (await papi.fetch('https://www.example.com')).text();
-    logger.info(
+    /* const genericFetch =  */ await (await papi.fetch('https://www.example.com')).text();
+    // No need to log good stuff unless we're testing
+    /* logger.info(
       `Evil: Good success - could papi.fetch example.com "${genericFetch.substring(0, 100)}"`,
-    );
+    ); */
   } catch (e) {
     logger.error(`Evil: <<BAD>> error on papi.fetch! ${e}`);
   }
@@ -158,7 +245,14 @@ async function activate(context) {
   );
   papi.webViews.getWebView(evilWebViewProvider.webViewType, undefined, { existingId: '?' });
 
+  const evilFileWebViewProviderPromise = papi.webViewProviders.register(
+    evilFileWebViewProvider.webViewType,
+    evilFileWebViewProvider,
+  );
+  papi.webViews.getWebView(evilFileWebViewProvider.webViewType, undefined, { existingId: '?' });
+
   context.registrations.add(await evilWebViewProviderPromise);
+  context.registrations.add(await evilFileWebViewProviderPromise);
 
   logger.info('Evil is finished activating!');
 }

--- a/extensions/src/evil/evil.js
+++ b/extensions/src/evil/evil.js
@@ -114,6 +114,54 @@ const EVIL_WEBVIEW = `
       // window.top.document.body.appendChild(imgWithAttributeScript);
       */
 
+     // Try to create a modal through window.top.alert
+      try {
+        window.top.alert('<<BAD>> Evil could create a modal through window.top.alert!');
+      } catch (e) {
+        // No need to log good stuff unless we're testing
+        //papi.logger.info(\`Evil: Good error on running window.top.alert: \${e.message}\`);
+      }
+
+     // Try to create a modal through window.top.confirm
+      try {
+        window.top.confirm('<<BAD>> Evil could create a modal through window.top.confirm!');
+      } catch (e) {
+        // No need to log good stuff unless we're testing
+        //papi.logger.info(\`Evil: Good error on running window.top.confirm: \${e.message}\`);
+      }
+
+     // Try to create a modal through window.top.print
+      try {
+        window.top.print('<<BAD>> Evil could create a modal through window.top.print!');
+      } catch (e) {
+        // No need to log good stuff unless we're testing
+        //papi.logger.info(\`Evil: Good error on running window.top.print: \${e.message}\`);
+      }
+
+     // Try to create a modal through window.top.prompt
+      try {
+        window.top.prompt('<<BAD>> Evil could create a modal through window.top.prompt!');
+      } catch (e) {
+        // No need to log good stuff unless we're testing
+        //papi.logger.info(\`Evil: Good error on running window.top.prompt: \${e.message}\`);
+      }
+
+     // Try to create a popup through window.top.open
+      try {
+        window.top.open('<<BAD>> Evil could create a popup through window.top.open!');
+      } catch (e) {
+        // No need to log good stuff unless we're testing
+        //papi.logger.info(\`Evil: Good error on running window.top.open: \${e.message}\`);
+      }
+
+     // Try to create a popup through window.top.showModalDialog
+      try {
+        window.top.showModalDialog('<<BAD>> Evil could create a popup through window.top.showModalDialog!');
+      } catch (e) {
+        // No need to log good stuff unless we're testing
+        //papi.logger.info(\`Evil: Good error on running window.top.showModalDialog: \${e.message}\`);
+      }
+
       // Note: we are using this sourceURL in web-view.service.ts, so keep it up-to-date with this
       //# sourceURL=evil.web-view.html
     </script>
@@ -126,7 +174,13 @@ const EVIL_WEBVIEW = `
       Below, you should see an iframe with another evil webview code that also should fail to do bad
       things:
     </div>
-    <iframe src="papi-extension://evil/assets/evil.web-view.html" />
+    <iframe src="papi-extension://evil/assets/evil.web-view.html"></iframe>
+    <!--
+    Uncomment this to test that iframes within iframes are restricted by the sandbox of their parent
+    This is commented out because it causes a sandbox error to show up in the console, and we don't
+    want to distract people with it.
+    <iframe srcdoc="<!DOCTYPE html><html><body><script>try { window.top.location='https://example.com'; } catch (e) {}</script></body></html>"></iframe>
+    -->
   </body>
 </html>
 `;

--- a/extensions/src/hello-world/web-views/hello-world.web-view.tsx
+++ b/extensions/src/hello-world/web-views/hello-world.web-view.tsx
@@ -172,6 +172,11 @@ globalThis.webViewComponent = function HelloWorld({
     <div>
       <div className="title">
         Hello World <span className="framework">React</span>
+        {/**
+         * Note: `Logo` here is inlined into this code as a `data:` url. This is here simply for
+         * demonstration purposes. Inlining as a `data:` url is generally not recommended. Rather,
+         * it is generally better to use `papi-extension:` to avoid unnecessary bloat
+         */}
         <img width={16} height={16} src={`${Logo}`} alt="Hello World Logo" />
       </div>
       <div>

--- a/extensions/src/hello-world/web-views/hello-world.web-view.tsx
+++ b/extensions/src/hello-world/web-views/hello-world.web-view.tsx
@@ -20,6 +20,7 @@ import type { DialogTypes } from 'renderer/components/dialogs/dialog-definition.
 import type { WebViewProps } from 'shared/data/web-view.model';
 import { ProjectDataTypes } from 'papi-shared-types';
 import Clock from './components/clock.component';
+import Logo from '../assets/offline.svg';
 
 type Row = {
   id: string;
@@ -171,6 +172,7 @@ globalThis.webViewComponent = function HelloWorld({
     <div>
       <div className="title">
         Hello World <span className="framework">React</span>
+        <img width={16} height={16} src={`${Logo}`} alt="Hello World Logo" />
       </div>
       <div>
         <Button

--- a/extensions/src/webpack-env.d.ts
+++ b/extensions/src/webpack-env.d.ts
@@ -54,4 +54,112 @@ declare module '*.css' {
 
 // #endregion
 
+// #region images
+
+/**
+ * Load images as data uris
+ *
+ * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+ */
+declare module '*.png' {
+  const content: string;
+  export default content;
+}
+
+/**
+ * Load images as data uris
+ *
+ * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+ */
+declare module '*.svg' {
+  const content: string;
+  export default content;
+}
+
+/**
+ * Load images as data uris
+ *
+ * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+ */
+declare module '*.jpg' {
+  const content: string;
+  export default content;
+}
+
+/**
+ * Load images as data uris
+ *
+ * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+ */
+declare module '*.jpeg' {
+  const content: string;
+  export default content;
+}
+
+/**
+ * Load images as data uris
+ *
+ * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+ */
+declare module '*.gif' {
+  const content: string;
+  export default content;
+}
+
+// #endregion
+
+// #region fonts
+
+/**
+ * Load fonts as data uris
+ *
+ * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+ */
+declare module '*.woff' {
+  const content: string;
+  export default content;
+}
+
+/**
+ * Load fonts as data uris
+ *
+ * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+ */
+declare module '*.woff2' {
+  const content: string;
+  export default content;
+}
+
+/**
+ * Load fonts as data uris
+ *
+ * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+ */
+declare module '*.eot' {
+  const content: string;
+  export default content;
+}
+
+/**
+ * Load fonts as data uris
+ *
+ * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+ */
+declare module '*.ttf' {
+  const content: string;
+  export default content;
+}
+
+/**
+ * Load fonts as data uris
+ *
+ * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+ */
+declare module '*.otf' {
+  const content: string;
+  export default content;
+}
+
+// #endregion
+
 // #endregion

--- a/extensions/webpack/webpack.config.base.ts
+++ b/extensions/webpack/webpack.config.base.ts
@@ -101,6 +101,25 @@ const configBase: webpack.Configuration = {
           'sass-loader',
         ],
       },
+      /** Load images as data uris
+       *
+       * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+       */
+      // https://webpack.js.org/guides/asset-management/#loading-images
+      {
+        test: /\.(png|svg|jpg|jpeg|gif)$/i,
+        type: 'asset/inline',
+      },
+      /**
+       * Load fonts as data uris
+       *
+       * Note: it is generally advised to use the `papi-extension:` protocol to load assets
+       */
+      // https://webpack.js.org/guides/asset-management/#loading-fonts
+      {
+        test: /\.(woff|woff2|eot|ttf|otf)$/i,
+        type: 'asset/inline',
+      },
       /**
        * Import files with no transformation as strings with "./file?raw"
        */

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -127,11 +127,12 @@ declare module 'shared/data/web-view.model' {
      *
      * It is best practice to set this to `false` where possible.
      *
-     * Note: Until we have a message-passing APi for WebViews, there is currently no way to
+     * Note: Until we have a message-passing API for WebViews, there is currently no way to
      * interact with the platform via a WebView with `allowSameOrigin: false`.
      *
-     * WARNING: If your WebView accepts secure user input like passwords, you MUST set this to `false`
-     * or you will risk exposing that secure input to other extensions who could be phishing for it.
+     * WARNING: If your WebView accepts secure user input like passwords on HTML or React WebViews,
+     * you MUST set this to `false` or you will risk exposing that secure input to other extensions
+     * who could be phishing for it.
      */
     allowSameOrigin?: boolean;
     /**
@@ -2722,6 +2723,38 @@ declare module 'shared/models/data-provider-engine.model' {
    * @see IDataProviderEngine for more information on using this type.
    */
   export type WithNotifyUpdate<TDataTypes extends DataProviderDataTypes> = {
+    /**
+     * Method to run to send clients updates for a specific data type outside of the `set<data_type>` method.
+     * papi overwrites this function on the DataProviderEngine itself to emit an update after running
+     * the `notifyUpdate` method in the DataProviderEngine.
+     *
+     * @param updateInstructions information that papi uses to interpret whether to send out updates.
+     * Defaults to `'*'` (meaning send updates for all data types) if parameter `updateInstructions` is
+     * not provided or is undefined. Otherwise returns `updateInstructions`. papi passes the interpreted
+     * update value into this `notifyUpdate` function. For example, running `this.notifyUpdate()` will
+     * call the data provider engine's `notifyUpdate` with `updateInstructions` of `'*'`.
+     *
+     * @see DataProviderUpdateInstructions for more info on the `updateInstructions` parameter
+     *
+     * WARNING: Do not update a data type in its `get<data_type>` method (unless you make a base case)!
+     * It will create a destructive infinite loop.
+     *
+     * @example To run `notifyUpdate` function so it updates the Verse and Heresy data types
+     * (in a data provider engine):
+     * ```typescript
+     * this.notifyUpdate(['Verse', 'Heresy']);
+     * ```
+     *
+     * @example You can log the manual updates in your data provider engine by specifying the following
+     * `notifyUpdate` function in the data provider engine:
+     * ```typescript
+     * notifyUpdate(updateInstructions) {
+     *   papi.logger.info(updateInstructions);
+     * }
+     * ```
+     *
+     * Note: This function's return is treated the same as the return from `set<data_type>`
+     */
     notifyUpdate: DataProviderEngineNotifyUpdate<TDataTypes>;
   };
   /**

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -420,7 +420,8 @@ async function activateExtensions(extensions: ExtensionInfo[]): Promise<ActiveEx
   }) as typeof Module.prototype.require;
 
   // Delete ways to execute arbitrary code https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_eval_expressions
-  // Note: node does not allow strings in setTimeout, setInterval, or setImmediate https://nodejs.org/api/timers.html#scheduling-timers
+  // Note: node does not allow strings in setTimeout, setInterval, or setImmediate, so we don't need
+  // to monkey-patch them https://nodejs.org/api/timers.html#scheduling-timers
   // @ts-expect-error we want to remove eval because it can create code from strings
   // eslint-disable-next-line no-eval
   delete globalThis.eval;

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -419,6 +419,14 @@ async function activateExtensions(extensions: ExtensionInfo[]): Promise<ActiveEx
     throw new Error(message);
   }) as typeof Module.prototype.require;
 
+  // Delete ways to execute arbitrary code https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/script-src#unsafe_eval_expressions
+  // Note: node does not allow strings in setTimeout, setInterval, or setImmediate https://nodejs.org/api/timers.html#scheduling-timers
+  // @ts-expect-error we want to remove eval because it can create code from strings
+  // eslint-disable-next-line no-eval
+  delete globalThis.eval;
+  // @ts-expect-error we want to remove Function because it can create code from strings
+  delete globalThis.Function;
+
   // Replace fetch with papi.fetch.
   // eslint-disable-next-line no-global-assign
   globalThis.fetch = papi.fetch;

--- a/src/renderer/index.ejs
+++ b/src/renderer/index.ejs
@@ -14,13 +14,14 @@
 
       default-src 'none' so things can't happen unless we allow them
       script-src-elem allows script tags but not in-line attribute scripts. That way, we can remove
-        scripts we don't want using monkey-patched `document.createElement and not have to worry
+        scripts we don't want using monkey-patched `document.createElement` and not have to worry
         about in-line scripts
         'self' so scripts can be loaded from us
         'wasm-unsafe-eval' because webview iframes want to use wasm
-          TODO: PLEASE FIX - we need to remove this once we have webview iframe CSP separated from
-          this so we don't allow extensions to run wasm code in parent window. This may be an avenue
-          through which they can escape their iframe sandbox and do things like navigate the page paranext-core#89
+          TODO: we may want to remove this once we have webview iframe CSP separated from this so we
+          don't allow extensions to run wasm code in parent window. It does not seem to be so, but
+          this may be an avenue through which they can escape their iframe sandbox and do things
+          like navigate the page. Warrants further consideration paranext-core#89
         'unsafe-inline' because web view iframes use srcdoc right now, which inherits CSP from parent frames
           TODO: PLEASE FIX THIS - Move web views to be retrieved from the backend, and remove this. paranext-core#89
           The web views must pass as same origin in order to be able to use same-origin features
@@ -35,28 +36,27 @@
         papi-extension: so styles can be loaded from installed extensions
         'unsafe-inline' because that's how bundled libraries' styles are loaded in :( like MUI
       frame-src determines what iframes can be loaded
-          Note: WebViewContentType.HTML and WebViewContentType.React load in as `srcdoc` iframes with same origin and
-          our CSP (these `srcdoc` iframes inherit this CSP as well in addition to using the CSP
-          defined in `web-view.service.ts`) to prevent them from executing arbitrary code on our
-          origin. However, WebViewContentType.URL loads in as `src` iframes, so we cannot control
-          their CSP. As such, we must not allow them to be on the same origin. See the
-          MutationObserver in `web-view.service.ts` and `web-view.component.tsx` for the allowed
-          iframe `sandbox` attribute options on these WebViewContentTypes. Also note `blob:` urls
-          are considered same origin as parent, so NEVER list blob: here in `frame-src` CSP
         'self' so frame contents can be loaded from us - sort-of includes `srcdoc` iframes with
         extension webview code... `srcdoc` iframes are actually executed in the parent and then put
         in the iframe, so `frame-src` doesn't actually count for them. But the rest of the CSP does
         papi-extension: so extensions can load their bundled asset iframes as WebViewContentType.URL
         on different origin
         https: so extensions can load remote iframes as WebViewContentType.URL on different origin
-      We do not include `frame-ancestors 'self'` so only we can host iframes - it is ok for WebViews
-        with same origin to be able to create child iframes without our CSP and sandbox protection
-        because those child iframes would be on different origin and would only be able to do what
-        the extension developer allows them via message passing. `frame-ancestors` cannot be used in
-        a `meta` tag anyway, so we may need to try to deliver it in the headers for this request if
-        we ever change our minds on this point. For now, we are just preventing children from
-        creating iframes on the parent window with monkey-patch on `document.createElement` in
-        `web-view.service.ts`
+          Note: WebViewContentType.HTML and WebViewContentType.React load in as `srcdoc` iframes
+          with same origin and our CSP (these `srcdoc` iframes inherit this CSP as well in addition
+          to using the CSP defined in `web-view.service.ts`) and iframe sandbox to prevent them from
+          executing arbitrary code on our origin as best we can. However, WebViewContentType.URL
+          loads in as `src` iframes, so we cannot control their CSP. As such, we must not allow them
+          to be on the same origin. See the MutationObserver in `web-view.service.ts` and
+          `web-view.component.tsx` for the allowed iframe `sandbox` attribute options on these
+          WebViewContentTypes. Also note `blob:` urls are considered same origin as parent, so NEVER
+          list blob: here in `frame-src` CSP
+          Note: it is ok for WebViews with same origin in our CSP and sandbox to be able to create
+          child iframes without our CSP and sandbox protection because those child iframes would be
+          on different origin and would only be able to do what the extension developer allows them
+          via message passing and would have the same sandbox restrictions as the WebView.
+          TODO: wrap WebViewContentType.URL webviews in an iframe that's hosting their url and
+          remove `papi-extension:` and `https:` here when we fix webview code to be retrieved from the backend? paranext-core#89
       object-src 'none' to prevent insecure object and embed until we have a reason to use them
       worker-src 'self' so web workers can be loaded from us
       manifest-src 'self' so we can load our manifest

--- a/src/renderer/index.ejs
+++ b/src/renderer/index.ejs
@@ -5,6 +5,8 @@
     <!--
       Content-Security-Policy controls what resources the renderer can access.
 
+      Design decisions and guiding principles at https://github.com/paranext/paranext/wiki/Content-Security-Policy-Design
+
       DO NOT CHANGE THIS WITHOUT A SERIOUS REASON
 
       Please uncomment the image creation arbitrary code execution in `evil.js`'s WebView when you
@@ -12,23 +14,54 @@
 
       default-src 'none' so things can't happen unless we allow them
       script-src-elem allows script tags but not in-line attribute scripts. That way, we can remove
-        scripts we don't want using MutationObserver and not have to worry about in-line scripts
+        scripts we don't want using monkey-patched `document.createElement and not have to worry
+        about in-line scripts
         'self' so scripts can be loaded from us
-        papi-extension: so scripts can be loaded from installed extensions
+        'wasm-unsafe-eval' because webview iframes want to use wasm
+          TODO: PLEASE FIX - we need to remove this once we have webview iframe CSP separated from
+          this so we don't allow extensions to run wasm code in parent window. This may be an avenue
+          through which they can escape their iframe sandbox and do things like navigate the page paranext-core#89
         'unsafe-inline' because web view iframes use srcdoc right now, which inherits CSP from parent frames
           TODO: PLEASE FIX THIS - Move web views to be retrieved from the backend, and remove this. paranext-core#89
-        TODO: change to script-src-elem so in-line attribute scripts like event handlers don't run? If this is actually more secure. paranext-core#89
+          The web views must pass as same origin in order to be able to use same-origin features
+          like accessing the papi. `papi-extension:` protocol is considered to be origin `null`
+          We cannot solve this by using the same nonce on every webview because each HTML webview
+          will need to provide its own nonces to merge with ours. Not sure if it would be an issue
+          beyond that, though, assuming we don't provide a way to get the nonce from a script.
+        We do NOT list papi-extension: so scripts cannot be loaded from installed extensions without
+        being limited by our WebView iframe security
       style-src allows them to use style/link tags and style attributes on tags
         'self' so styles can be loaded from us
         papi-extension: so styles can be loaded from installed extensions
-        'unsafe-inline' because that's how our styles are currently loaded in by hot reloading
-          TODO: PLEASE FIX THIS IN PRODUCTION. paranext-core#89
-      frame-src 'self' so frame contents can be loaded from us
+        'unsafe-inline' because that's how bundled libraries' styles are loaded in :( like MUI
+      frame-src determines what iframes can be loaded
+          Note: WebViewContentType.HTML and WebViewContentType.React load in as `srcdoc` iframes with same origin and
+          our CSP (these `srcdoc` iframes inherit this CSP as well in addition to using the CSP
+          defined in `web-view.service.ts`) to prevent them from executing arbitrary code on our
+          origin. However, WebViewContentType.URL loads in as `src` iframes, so we cannot control
+          their CSP. As such, we must not allow them to be on the same origin. See the
+          MutationObserver in `web-view.service.ts` and `web-view.component.tsx` for the allowed
+          iframe `sandbox` attribute options on these WebViewContentTypes. Also note `blob:` urls
+          are considered same origin as parent, so NEVER list blob: here in `frame-src` CSP
+        'self' so frame contents can be loaded from us - sort-of includes `srcdoc` iframes with
+        extension webview code... `srcdoc` iframes are actually executed in the parent and then put
+        in the iframe, so `frame-src` doesn't actually count for them. But the rest of the CSP does
+        papi-extension: so extensions can load their bundled asset iframes as WebViewContentType.URL
+        on different origin
+        https: so extensions can load remote iframes as WebViewContentType.URL on different origin
+      We do not include `frame-ancestors 'self'` so only we can host iframes - it is ok for WebViews
+        with same origin to be able to create child iframes without our CSP and sandbox protection
+        because those child iframes would be on different origin and would only be able to do what
+        the extension developer allows them via message passing. `frame-ancestors` cannot be used in
+        a `meta` tag anyway, so we may need to try to deliver it in the headers for this request if
+        we ever change our minds on this point. For now, we are just preventing children from
+        creating iframes on the parent window with monkey-patch on `document.createElement` in
+        `web-view.service.ts`
       object-src 'none' to prevent insecure object and embed until we have a reason to use them
       worker-src 'self' so web workers can be loaded from us
       manifest-src 'self' so we can load our manifest
         TODO: What exactly does this do?
-      connect-src only communicate over the network as we allow
+      connect-src only communicate over the network through JS APIs as we allow
         'self' communicate with us
         https: communicate with secure networks
         ws: communicate with webSockets
@@ -36,15 +69,21 @@
       img-src load images
         'self' so images can be loaded from us
         papi-extension: so images can be loaded from installed extensions
-        https: so they can load images from us and over secure connections
+          TODO: remove this when we fix webview code to be retrieved from the backend? paranext-core#89
+        https: so they can load images over secure connections
+        data: so they can load data urls
       media-src load audio, video, etc
         'self' so media can be loaded from us
         papi-extension: so media can be loaded from installed extensions
+          TODO: remove this when we fix webview code to be retrieved from the backend? paranext-core#89
         https: so media can be loaded over secure connections
+        data: so they can load data urls
       font-src load fonts
         'self' so fonts can be loaded from us
         papi-extension: so fonts can be loaded from installed extensions
+          TODO: remove this when we fix webview code to be retrieved from the backend? paranext-core#89
         https: so fonts can be loaded over secure connections
+        data: so they can load data urls
       form-action 'self' lets the form submit to us
         TODO: not sure if this is needed. If we can attach handlers to forms, we might be able to remove this
       navigate-to 'none' prevents them from redirecting this iframe somewhere else
@@ -55,16 +94,16 @@
       http-equiv="Content-Security-Policy"
       content="
         default-src 'none';
-        script-src-elem 'self' papi-extension: 'unsafe-inline';
+        script-src-elem 'self' 'wasm-unsafe-eval' 'unsafe-inline';
         style-src 'self' papi-extension: 'unsafe-inline';
-        frame-src 'self';
+        frame-src 'self' papi-extension: https:;
         object-src 'none';
         worker-src 'self';
         manifest-src 'self';
         connect-src 'self' https: ws:;
-        img-src 'self' papi-extension: https:;
-        media-src 'self' papi-extension: https:;
-        font-src 'self' papi-extension: https:;
+        img-src 'self' papi-extension: https: data:;
+        media-src 'self' papi-extension: https: data:;
+        font-src 'self' papi-extension: https: data:;
         form-action 'self';
         navigate-to 'none';"
     />

--- a/src/shared/data/web-view.model.ts
+++ b/src/shared/data/web-view.model.ts
@@ -131,11 +131,12 @@ type WebViewDefinitionBase = {
    *
    * It is best practice to set this to `false` where possible.
    *
-   * Note: Until we have a message-passing APi for WebViews, there is currently no way to
+   * Note: Until we have a message-passing API for WebViews, there is currently no way to
    * interact with the platform via a WebView with `allowSameOrigin: false`.
    *
-   * WARNING: If your WebView accepts secure user input like passwords, you MUST set this to `false`
-   * or you will risk exposing that secure input to other extensions who could be phishing for it.
+   * WARNING: If your WebView accepts secure user input like passwords on HTML or React WebViews,
+   * you MUST set this to `false` or you will risk exposing that secure input to other extensions
+   * who could be phishing for it.
    */
   allowSameOrigin?: boolean;
   /**
@@ -147,8 +148,6 @@ type WebViewDefinitionBase = {
    * WARNING: Setting this to `true` increases the possibility of a security threat occurring. If it
    * is not necessary to run scripts in your WebView, you should set this to `false` to reduce risk.
    */
-  // This does not follow our normal pattern of naming booleans because it mirrors the
-  // `allow-scripts` iframe sandbox attribute value
   allowScripts?: boolean;
   /**
    * **For HTML and React WebViews:** List of [Host or scheme values](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy#hosts_values)

--- a/src/shared/models/data-provider-engine.model.ts
+++ b/src/shared/models/data-provider-engine.model.ts
@@ -6,7 +6,7 @@ import {
 } from '@shared/models/data-provider.model';
 import { NetworkableObject } from '@shared/models/network-object.model';
 
-/**
+/** JSDOC SOURCE DataProviderEngineNotifyUpdate
  * Method to run to send clients updates for a specific data type outside of the `set<data_type>` method.
  * papi overwrites this function on the DataProviderEngine itself to emit an update after running
  * the `notifyUpdate` method in the DataProviderEngine.
@@ -51,6 +51,7 @@ export type DataProviderEngineNotifyUpdate<TDataTypes extends DataProviderDataTy
  * @see IDataProviderEngine for more information on using this type.
  */
 export type WithNotifyUpdate<TDataTypes extends DataProviderDataTypes> = {
+  /** JSDOC DESTINATION DataProviderEngineNotifyUpdate */
   notifyUpdate: DataProviderEngineNotifyUpdate<TDataTypes>;
 };
 


### PR DESCRIPTION
Content Security Policy Design decisions and guiding principles at https://github.com/paranext/paranext/wiki/Content-Security-Policy-Design

- Prevent extension webviews from creating iframes and a number of other tags on parent document
- Fixed problem with MutationObserver where it wouldn't remove frames if they were added under another element
- Stopped logging good things from Evil so it doesn't clog up the log so much
- Prevent extension main files from executing arbitrary code through `eval` and `Function`
- webview iframe sandbox changes
  - Made `'allow-same-origin'` opt-out from `WebViewDefinition`
  - Made `'allow-scripts'` opt-out from `WebViewDefinition` for HTML and React WebViews, opt-in for URL WebViews
  - Allowed WebView iframes to request fullscreen
- CSP Changes
  - Allow WebAssembly
  - Allow extensions to create iframes whose urls may be in the WebViewDefinition's `allowedFrameSources` (restricted to only allow urls on `papi-extension:` and `https:` at most, but defaults to none)
  - Allow images, media, and fonts from `https:` and `data:`
- Added importing images and fonts as data urls in webpack

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/610)
<!-- Reviewable:end -->
