### PR TITLE
Added `DataProviders` shared interface for data providers

### DIFF
--- a/extensions/src/c-sharp-provider-test/index.d.ts
+++ b/extensions/src/c-sharp-provider-test/index.d.ts
@@ -1,16 +1,22 @@
-import type { DataProviderDataType } from 'shared/models/data-provider.model';
-import type IDataProvider from 'shared/models/data-provider.interface';
-
 declare module 'c-sharp-provider-test' {
+  import type { DataProviderDataType } from 'shared/models/data-provider.model';
+  import type IDataProvider from 'shared/models/data-provider.interface';
+
   type TimeDataTypes = {
-    TimeData: DataProviderDataType<undefined, string | undefined, never>;
+    Time: DataProviderDataType<undefined, string | undefined, never>;
   };
 
   export type TimeDataProvider = IDataProvider<TimeDataTypes>;
 }
 
 declare module 'papi-shared-types' {
+  import type { TimeDataProvider } from 'c-sharp-provider-test';
+
   export interface CommandHandlers {
     'test.addOne': (num: number) => number;
+  }
+
+  export interface DataProviders {
+    'current-time': TimeDataProvider;
   }
 }

--- a/extensions/src/hello-someone/hello-someone.d.ts
+++ b/extensions/src/hello-someone/hello-someone.d.ts
@@ -1,7 +1,7 @@
-import type IDataProvider from 'shared/models/data-provider.interface';
-import type { DataProviderDataType } from 'shared/models/data-provider.model';
-
 declare module 'hello-someone' {
+  import type IDataProvider from 'shared/models/data-provider.interface';
+  import type { DataProviderDataType } from 'shared/models/data-provider.model';
+
   export type Person = {
     greeting?: string;
     age?: number;
@@ -26,8 +26,14 @@ declare module 'hello-someone' {
 }
 
 declare module 'papi-shared-types' {
+  import type { PeopleDataProvider } from 'hello-someone';
+
   export interface CommandHandlers {
     'helloSomeone.helloSomeone': (name: string) => string;
     'helloSomeone.echoSomeoneRenderer': (message: string) => Promise<string>;
+  }
+
+  export interface DataProviders {
+    'helloSomeone.people': PeopleDataProvider;
   }
 }

--- a/extensions/src/hello-someone/hello-someone.ts
+++ b/extensions/src/hello-someone/hello-someone.ts
@@ -39,7 +39,7 @@ logger.info('Hello Someone is importing!');
  * - Cons
  *
  *   - Must specify all properties and methods in the object type
- *   - `papi.dataProvider.decorators.ignore` is difficult to apply to tell papi to ignore methods
+ *   - `@papi.dataProvider.decorators.ignore` is difficult to apply to tell papi to ignore methods
  *   - When using `this.notifyUpdate`, you must include the `WithNotifyUpdate` type and provide a
  *       placeholder `notifyUpdate` method
  *
@@ -99,8 +99,8 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
    *   Note: this method gets layered over so that you can run `this.setGreeting` inside this data
    *   provider engine, and it will send updates after returning.
    *
-   *   Note: this method is used when someone uses the `useData.Greeting` hook on the data provider
-   *   papi creates for this engine.
+   *   Note: this method is used when someone uses the `useData('helloSomeone.people').Greeting` hook
+   *   on the data provider papi creates for this engine.
    */
   async setGreeting(
     name: string,
@@ -122,8 +122,8 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
    * @param name Name of person
    * @returns Person's greeting or undefined
    *
-   *   Note: this method is used when someone uses the `useData.Greeting` hook or the
-   *   `subscribeGreeting` method on the data provider papi creates for this engine.
+   *   Note: this method is used when someone uses the `useData('helloSomeone.people').Greeting` hook
+   *   or the `subscribeGreeting` method on the data provider papi creates for this engine.
    */
   async getGreeting(name: string) {
     return this.getPerson(name, false)?.greeting;
@@ -140,8 +140,8 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
    *   Note: this method gets layered over so that you can run `this.setAge` inside this data provider
    *   engine, and it will send updates after returning.
    *
-   *   Note: this method is used when someone uses the `useData.Age` hook on the data provider papi
-   *   creates for this engine.
+   *   Note: this method is used when someone uses the `useData('helloSomeone.people').Age` hook on
+   *   the data provider papi creates for this engine.
    */
   async setAge(
     name: string,
@@ -163,8 +163,8 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
    * @param name Name of person
    * @returns Person's age or undefined
    *
-   *   Note: this method is used when someone uses the `useData.Age` hook or the `subscribeAge` method
-   *   on the data provider papi creates for this engine.
+   *   Note: this method is used when someone uses the `useData('helloSomeone.people').Age` hook or
+   *   the `subscribeAge` method on the data provider papi creates for this engine.
    */
   async getAge(name: string) {
     return this.getPerson(name, false)?.age;
@@ -263,7 +263,7 @@ const peopleWebViewProvider: IWebViewProvider = {
 export async function activate(context: ExecutionActivationContext): Promise<void> {
   logger.info('Hello Someone is activating!');
 
-  const peopleDataProviderPromise = papi.dataProvider.registerEngine<PeopleDataTypes>(
+  const peopleDataProviderPromise = papi.dataProvider.registerEngine(
     'helloSomeone.people',
     peopleDataProviderEngine,
   );

--- a/extensions/src/hello-world/hello-world.ts
+++ b/extensions/src/hello-world/hello-world.ts
@@ -5,7 +5,6 @@ import type {
   WebViewDefinition,
   SavedWebViewDefinition,
 } from 'shared/data/web-view.model';
-import type { PeopleDataProvider } from 'hello-someone';
 import type { IWebViewProvider } from 'shared/models/web-view-provider.model';
 import type PapiEventEmitter from 'shared/models/papi-event-emitter.model';
 import type { HelloWorldEvent } from 'hello-world';
@@ -141,7 +140,7 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
   papi.webViews.getWebView(reactWebViewProvider.webViewType, undefined, { existingId: '?' });
   papi.webViews.getWebView(reactWebView2Provider.webViewType, undefined, { existingId: '?' });
 
-  const peopleDataProvider = await papi.dataProvider.get<PeopleDataProvider>('helloSomeone.people');
+  const peopleDataProvider = await papi.dataProvider.get('helloSomeone.people');
 
   if (peopleDataProvider) {
     // Test subscribing to a data provider

--- a/extensions/src/hello-world/web-views/components/clock.component.tsx
+++ b/extensions/src/hello-world/web-views/components/clock.component.tsx
@@ -1,12 +1,7 @@
-import type { TimeDataTypes } from 'c-sharp-provider-test';
 import { useData } from 'papi-frontend/react';
 
 export default function Clock() {
-  const [currentTime] = useData.Time<TimeDataTypes, 'TimeData'>(
-    'current-time',
-    undefined,
-    'Loading current time',
-  );
+  const [currentTime] = useData('current-time').Time(undefined, 'Loading current time');
 
   return <div>{currentTime}</div>;
 }

--- a/extensions/src/hello-world/web-views/hello-world.web-view.tsx
+++ b/extensions/src/hello-world/web-views/hello-world.web-view.tsx
@@ -143,7 +143,7 @@ globalThis.webViewComponent = function HelloWorld({
     'Loading John 1:1...',
   );
 
-  const [currentProjectVerse] = useProjectData(project ?? undefined, 'ParatextStandard').VerseUSFM(
+  const [currentProjectVerse] = useProjectData('ParatextStandard', project ?? undefined).VerseUSFM(
     verseRef,
     'Loading Verse',
   );

--- a/extensions/src/hello-world/web-views/hello-world.web-view.tsx
+++ b/extensions/src/hello-world/web-views/hello-world.web-view.tsx
@@ -20,14 +20,10 @@ import {
   Table,
   ScriptureReference,
 } from 'papi-components';
-import type { QuickVerseDataTypes } from 'quick-verse';
-import type { PeopleDataProvider, PeopleDataTypes } from 'hello-someone';
-import type { UsfmProviderDataTypes } from 'usfm-data-provider';
 import { Key, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { HelloWorldEvent } from 'hello-world';
 import type { DialogTypes } from 'renderer/components/dialogs/dialog-definition.model';
 import type { WebViewProps } from 'shared/data/web-view.model';
-import { ProjectDataTypes } from 'papi-shared-types';
 import Clock from './components/clock.component';
 import Logo from '../assets/offline.svg';
 
@@ -112,8 +108,7 @@ globalThis.webViewComponent = function HelloWorld({
     }).current,
   );
 
-  const [latestVerseText] = useData.Verse<QuickVerseDataTypes, 'Verse'>(
-    'quickVerse.quickVerse',
+  const [latestVerseText] = useData('quickVerse.quickVerse').Verse(
     'latest',
     'Loading latest Scripture text...',
   );
@@ -132,32 +127,26 @@ globalThis.webViewComponent = function HelloWorld({
 
   const [name, setName] = useState('Bill');
 
-  const peopleDataProvider = useDataProvider<PeopleDataProvider>('helloSomeone.people');
+  const peopleDataProvider = useDataProvider('helloSomeone.people');
 
-  const [personGreeting] = useData.Greeting<PeopleDataTypes, 'Greeting'>(
-    'helloSomeone.people',
-    name,
-    'Greeting loading',
-  );
+  const [personGreeting] = useData('helloSomeone.people').Greeting(name, 'Greeting loading');
 
-  const [personAge] = useData.Age<PeopleDataTypes, 'Age'>('helloSomeone.people', name, -1);
+  const [personAge] = useData('helloSomeone.people').Age(name, -1);
 
-  const [psalm1] = useData.Chapter<UsfmProviderDataTypes, 'Chapter'>(
-    'usfm',
+  const [psalm1] = useData('usfm').Chapter(
     useMemo(() => new VerseRef('PSA', '1', '1', ScrVers.English), []),
     'Loading Psalm 1...',
   );
 
-  const [john11] = useData.Verse<UsfmProviderDataTypes, 'Verse'>(
-    'usfm',
+  const [john11] = useData('usfm').Verse(
     useMemo(() => new VerseRef('JHN 1:1'), []),
     'Loading John 1:1...',
   );
 
-  const [currentProjectVerse] = useProjectData.VerseUSFM<
-    ProjectDataTypes['ParatextStandard'],
-    'VerseUSFM'
-  >(project ?? undefined, verseRef, 'Loading Verse');
+  const [currentProjectVerse] = useProjectData(project ?? undefined, 'ParatextStandard').VerseUSFM(
+    verseRef,
+    'Loading Verse',
+  );
 
   return (
     <div>

--- a/extensions/src/quick-verse/quick-verse.d.ts
+++ b/extensions/src/quick-verse/quick-verse.d.ts
@@ -1,7 +1,7 @@
-import type { DataProviderDataType } from 'shared/models/data-provider.model';
-import type IDataProvider from 'shared/models/data-provider.interface';
-
 declare module 'quick-verse' {
+  import type { DataProviderDataType } from 'shared/models/data-provider.model';
+  import type IDataProvider from 'shared/models/data-provider.interface';
+
   export type QuickVerseSetData = string | { text: string; isHeresy: boolean };
 
   export type QuickVerseDataTypes = {
@@ -11,4 +11,12 @@ declare module 'quick-verse' {
   };
 
   export type QuickVerseDataProvider = IDataProvider<QuickVerseDataTypes>;
+}
+
+declare module 'papi-shared-types' {
+  import type { QuickVerseDataProvider } from 'quick-verse';
+
+  export interface DataProviders {
+    'quickVerse.quickVerse': QuickVerseDataProvider;
+  }
 }

--- a/extensions/src/quick-verse/quick-verse.ts
+++ b/extensions/src/quick-verse/quick-verse.ts
@@ -5,7 +5,6 @@ import type { ExecutionToken } from 'node/models/execution-token.model';
 import type IDataProviderEngine from 'shared/models/data-provider-engine.model';
 import type { QuickVerseDataTypes, QuickVerseSetData } from 'quick-verse';
 import type { DataProviderUpdateInstructions } from 'shared/models/data-provider.model';
-import type { UsfmDataProvider } from 'usfm-data-provider';
 
 logger.info('Quick Verse is importing!');
 
@@ -36,7 +35,7 @@ logger.info('Quick Verse is importing!');
  *
  *   - Can freely add properties and methods without specifying them in an extra type
  *   - Can use private methods (prefix with `#`) that are automatically ignored by papi
- *   - Can use @papi.dataProvider.decorators.ignore to tell papi to ignore methods
+ *   - Can use `@papi.dataProvider.decorators.ignore` to tell papi to ignore methods
  *   - Can extend `DataProviderEngine` so TypeScript will understand you can call `this.notifyUpdate`
  *       without specifying a `notifyUpdate` function
  *   - Can easily create multiple data providers from the same engine if you have two independent sets
@@ -66,7 +65,7 @@ class QuickVerseDataProviderEngine
   /** Latest updated verse reference */
   latestVerseRef = 'JHN 11:35';
 
-  usfmDataProviderPromise = papi.dataProvider.get<UsfmDataProvider>('usfm');
+  usfmDataProviderPromise = papi.dataProvider.get('usfm');
 
   /** Number of times any verse has been modified by a user this session */
   heresyCount = 0;
@@ -135,8 +134,8 @@ class QuickVerseDataProviderEngine
    *   Note: this method gets layered over so that you can run `this.setVerse` inside this data
    *   provider engine, and it will send updates after returning.
    *
-   *   Note: this method is used when someone uses the `useData.Verse` hook on the data provider papi
-   *   creates for this engine.
+   *   Note: this method is used when someone uses the `useData('quickVerse.quickVerse').Verse` hook
+   *   on the data provider papi creates for this engine.
    */
   async setVerse(verseRef: string, data: QuickVerseSetData) {
     return this.setInternal(verseRef, data);
@@ -154,8 +153,8 @@ class QuickVerseDataProviderEngine
    *   Note: this method gets layered over so that you can run `this.setHeresy` inside this data
    *   provider engine, and it will send updates after returning.
    *
-   *   Note: this method is used when someone uses the `useData.Heresy` hook on the data provider papi
-   *   creates for this engine.
+   *   Note: this method is used when someone uses the `useData('quickVerse.quickVerse').Heresy` hook
+   *   on the data provider papi creates for this engine.
    */
   async setHeresy(verseRef: string, verseText: string) {
     return this.setInternal(verseRef, { text: verseText, isHeresy: true });
@@ -167,8 +166,8 @@ class QuickVerseDataProviderEngine
    * @param verseRef Verse reference to get
    * @returns Verse contents at this reference
    *
-   *   Note: this method is used when someone uses the `useData.Verse` hook or the `subscribeVerse`
-   *   method on the data provider papi creates for this engine.
+   *   Note: this method is used when someone uses the `useData('quickVerse.quickVerse').Verse` hook
+   *   or the `subscribeVerse` method on the data provider papi creates for this engine.
    */
   getVerse = async (verseRef: string) => {
     // Just get notifications of updates with the 'notify' selector
@@ -212,8 +211,8 @@ class QuickVerseDataProviderEngine
    * @param verseRef Verse reference to get
    * @returns Verse contents at this reference
    *
-   *   Note: this method is used when someone uses the `useData.Heresy` hook or the `subscribeHeresy`
-   *   method on the data provider papi creates for this engine.
+   *   Note: this method is used when someone uses the `useData('quickVerse.quickVerse').Heresy` hook
+   *   or the `subscribeHeresy` method on the data provider papi creates for this engine.
    */
   async getHeresy(verseRef: string) {
     return this.getVerse(verseRef);
@@ -237,8 +236,8 @@ class QuickVerseDataProviderEngine
    *
    * @example To get the contents of John 3, you can use `getChapter(['John', 3])`.
    *
-   * Note: this method is used when someone uses the `useData.Chapter` hook or the
-   * `subscribeChapter` method on the data provider papi creates for this engine.
+   * Note: this method is used when someone uses the `useData('quickVerse.quickVerse').Chapter` hook
+   * or the `subscribeChapter` method on the data provider papi creates for this engine.
    *
    * @param chapterInfo Parameters for getting the chapter
    *
@@ -293,7 +292,7 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
   }
   engine.heresyCount = storedHeresyCount;
 
-  const quickVerseDataProvider = await papi.dataProvider.registerEngine<QuickVerseDataTypes>(
+  const quickVerseDataProvider = await papi.dataProvider.registerEngine(
     'quickVerse.quickVerse',
     engine,
   );

--- a/extensions/src/resource-viewer/resource-viewer.web-view.tsx
+++ b/extensions/src/resource-viewer/resource-viewer.web-view.tsx
@@ -161,7 +161,7 @@ globalThis.webViewComponent = function ResourceViewer({
 
   const [scrRef] = useSetting('platform.verseRef', defaultScrRef);
 
-  const [usx, setUsx] = useProjectData(projectId, 'ParatextStandard').ChapterUSX(
+  const [usx, setUsx] = useProjectData('ParatextStandard', projectId).ChapterUSX(
     useMemo(() => new VerseRef(scrRef.bookNum, scrRef.chapterNum, scrRef.verseNum), [scrRef]),
     'Loading Scripture...',
   );

--- a/extensions/src/resource-viewer/resource-viewer.web-view.tsx
+++ b/extensions/src/resource-viewer/resource-viewer.web-view.tsx
@@ -5,7 +5,6 @@ import { ScriptureReference } from 'papi-components';
 import { JSX, useMemo } from 'react';
 import UsxEditor from 'usxeditor';
 import type { WebViewProps } from 'shared/data/web-view.model';
-import { ProjectDataTypes } from 'papi-shared-types';
 
 /** Characteristics of a marker style */
 interface StyleInfo {
@@ -162,11 +161,7 @@ globalThis.webViewComponent = function ResourceViewer({
 
   const [scrRef] = useSetting('platform.verseRef', defaultScrRef);
 
-  const [usx, setUsx] = useProjectData.ChapterUSX<
-    ProjectDataTypes['ParatextStandard'],
-    'ChapterUSX'
-  >(
-    projectId,
+  const [usx, setUsx] = useProjectData(projectId, 'ParatextStandard').ChapterUSX(
     useMemo(() => new VerseRef(scrRef.bookNum, scrRef.chapterNum, scrRef.verseNum), [scrRef]),
     'Loading Scripture...',
   );

--- a/extensions/src/usfm-data-provider/index.d.ts
+++ b/extensions/src/usfm-data-provider/index.d.ts
@@ -1,17 +1,17 @@
-import { VerseRef } from '@sillsdev/scripture';
-import type {
-  DataProviderDataType,
-  DataProviderSubscriberOptions,
-  DataProviderUpdateInstructions,
-} from 'shared/models/data-provider.model';
-import type IDataProvider from 'shared/models/data-provider.interface';
-import type {
-  ExtensionDataScope,
-  MandatoryProjectDataType,
-} from 'shared/models/project-data-provider.model';
-import type { Unsubscriber } from 'shared/utils/papi-util';
-
 declare module 'usfm-data-provider' {
+  import { VerseRef } from '@sillsdev/scripture';
+  import type {
+    DataProviderDataType,
+    DataProviderSubscriberOptions,
+    DataProviderUpdateInstructions,
+  } from 'shared/models/data-provider.model';
+  import type IDataProvider from 'shared/models/data-provider.interface';
+  import type {
+    ExtensionDataScope,
+    MandatoryProjectDataType,
+  } from 'shared/models/project-data-provider.model';
+  import type { Unsubscriber } from 'shared/utils/papi-util';
+
   export type UsfmProviderDataTypes = {
     BookNames: DataProviderDataType<boolean, string[], never>;
     Chapter: DataProviderDataType<VerseRef, string | undefined, never>;
@@ -21,9 +21,7 @@ declare module 'usfm-data-provider' {
   };
 
   export type UsfmDataProvider = IDataProvider<UsfmProviderDataTypes>;
-}
 
-declare module 'papi-shared-types' {
   /**
    * Provides project data for Paratext Scripture projects.
    *
@@ -63,10 +61,6 @@ declare module 'papi-shared-types' {
      */
     VerseUSJ: DataProviderDataType<VerseRef, USJDocument | undefined, USJDocument>;
   };
-
-  export interface ProjectDataTypes {
-    ParatextStandard: ParatextStandardProjectDataTypes;
-  }
 
   /**
    * Scripture data represented in JSON format. Transformation from USX
@@ -366,4 +360,16 @@ declare module 'papi-shared-types' {
       options?: DataProviderSubscriberOptions,
     ): Unsubscriber;
   };
+}
+
+declare module 'papi-shared-types' {
+  import type { ParatextStandardProjectDataTypes, UsfmDataProvider } from 'usfm-data-provider';
+
+  export interface ProjectDataTypes {
+    ParatextStandard: ParatextStandardProjectDataTypes;
+  }
+
+  export interface DataProviders {
+    usfm: UsfmDataProvider;
+  }
 }

--- a/lib/papi-dts/edit-papi-d-ts.ts
+++ b/lib/papi-dts/edit-papi-d-ts.ts
@@ -16,16 +16,16 @@ let papiDTS = fs.readFileSync(PAPI_DTS_PATH, 'utf8');
 // Rename papi modules to 'papi-whatever' so extensions can import just 'papi-whatever'
 papiDTS = papiDTS
   .replace(
-    new RegExp(escapeStringRegexp('"renderer/services/papi-frontend.service"'), 'g'),
-    '"papi-frontend"',
+    new RegExp(escapeStringRegexp("'renderer/services/papi-frontend.service'"), 'g'),
+    "'papi-frontend'",
   )
   .replace(
-    new RegExp(escapeStringRegexp('"renderer/services/papi-frontend-react.service"'), 'g'),
-    '"papi-frontend/react"',
+    new RegExp(escapeStringRegexp("'renderer/services/papi-frontend-react.service'"), 'g'),
+    "'papi-frontend/react'",
   )
   .replace(
-    new RegExp(escapeStringRegexp('"extension-host/services/papi-backend.service"'), 'g'),
-    '"papi-backend"',
+    new RegExp(escapeStringRegexp("'extension-host/services/papi-backend.service'"), 'g'),
+    "'papi-backend'",
   );
 
 // #region Copy "JSDOC DESTINATION" blocks to "JSDOC SOURCE" blocks
@@ -94,6 +94,17 @@ papiDTS = papiDTS.replace(
 );
 
 // #endregion
+
+// Add ignore error messages to the `useData` and `useProjectData` signatures where TS pretends like
+// it doesn't know how to index the types but it works just fine
+papiDTS = papiDTS.replace(
+  /(?<!\/\/ @ts-expect-error.*)(\n(\s*).*DataProviderTypes\[DataProviderName\]\[TDataType\]\['(\w+)'\])/g,
+  "\n$2// @ts-expect-error TypeScript pretends it can't find `$3`, but it works just fine$1",
+);
+papiDTS = papiDTS.replace(
+  /(?<!\/\/ @ts-expect-error.*)(\n(\s*).*ProjectDataTypes\[ProjectType\]\[TDataType\]\['(\w+)'\])/g,
+  "\n$2// @ts-expect-error TypeScript pretends it can't find `$3`, but it works just fine$1",
+);
 
 // Fix all the path-aliased imports. For some reason, generating `papi.d.ts` removes the @ from path
 // aliases on module declarations and static imports but not on dynamic imports to other modules.

--- a/lib/papi-dts/package.json
+++ b/lib/papi-dts/package.json
@@ -26,7 +26,7 @@
   "main": "",
   "types": "papi.d.ts",
   "scripts": {
-    "build": "tsc && ts-node edit-papi-d-ts.ts && prettier --write papi.d.ts",
+    "build": "tsc && prettier --write papi.d.ts && ts-node edit-papi-d-ts.ts",
     "build:clean": "rimraf papi.tsbuildinfo",
     "build:fresh": "npm run build:clean && npm run build",
     "lint": "cross-env NODE_ENV=development eslint --ext .cjs,.js,.jsx,.ts,.tsx --cache .",

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -3929,13 +3929,17 @@ declare module 'renderer/hooks/papi-hooks/use-data.hook' {
       dataProviderSource: DataProviderName | DataProviders[DataProviderName] | undefined,
     ): {
       [TDataType in keyof DataProviderTypes[DataProviderName]]: (
+        // @ts-expect-error TypeScript pretends it can't find `selector`, but it works just fine
         selector: DataProviderTypes[DataProviderName][TDataType]['selector'],
+        // @ts-expect-error TypeScript pretends it can't find `getData`, but it works just fine
         defaultValue: DataProviderTypes[DataProviderName][TDataType]['getData'],
         subscriberOptions?: DataProviderSubscriberOptions,
       ) => [
+        // @ts-expect-error TypeScript pretends it can't find `getData`, but it works just fine
         DataProviderTypes[DataProviderName][TDataType]['getData'],
         (
           | ((
+              // @ts-expect-error TypeScript pretends it can't find `setData`, but it works just fine
               newData: DataProviderTypes[DataProviderName][TDataType]['setData'],
             ) => Promise<DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>>)
           | undefined
@@ -4081,13 +4085,17 @@ declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
       projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
     ): {
       [TDataType in keyof ProjectDataTypes[ProjectType]]: (
+        // @ts-expect-error TypeScript pretends it can't find `selector`, but it works just fine
         selector: ProjectDataTypes[ProjectType][TDataType]['selector'],
+        // @ts-expect-error TypeScript pretends it can't find `getData`, but it works just fine
         defaultValue: ProjectDataTypes[ProjectType][TDataType]['getData'],
         subscriberOptions?: DataProviderSubscriberOptions,
       ) => [
+        // @ts-expect-error TypeScript pretends it can't find `getData`, but it works just fine
         ProjectDataTypes[ProjectType][TDataType]['getData'],
         (
           | ((
+              // @ts-expect-error TypeScript pretends it can't find `setData`, but it works just fine
               newData: ProjectDataTypes[ProjectType][TDataType]['setData'],
             ) => Promise<DataProviderUpdateInstructions<ProjectDataTypes[ProjectType]>>)
           | undefined

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -3437,8 +3437,9 @@ declare module 'shared/services/project-data-provider.service' {
    * pdp.getVerse(new VerseRef('JHN', '1', '1'));
    * ```
    *
-   * @type `ProjectType` - The `projectType` of the project whose data to retrieve. Alternatively,
-   *   specify this as the second argument to this function for Intellisense support
+   * @type `ProjectType` - The `projectType` for the project to use. The returned project data
+   *   provider will have the project data provider type associated with this project type.
+   *   Alternatively, specify this as the second argument to this function for Intellisense support
    * @param projectId ID for the project to load
    * @param projectType Indicates what you expect the `projectType` to be for the project with the
    *   specified id. Currently, this does nothing but indicate to TypeScript what type the Project
@@ -4050,20 +4051,23 @@ declare module 'renderer/hooks/papi-hooks/use-project-data-provider.hook' {
   /**
    * Gets a project data provider with specified provider name
    *
+   * @type `ProjectType` - The `projectType` for the project to use. The returned project data
+   *   provider will have the project data provider type associated with this project type.
+   *   Alternatively, specify this as the second argument to this function for Intellisense support
    * @param projectDataProviderSource String name of the id of the project to get OR
    *   projectDataProvider (result of useProjectDataProvider, if you want this hook to just return the
    *   data provider again)
-   * @returns Undefined if the project data provider has not been retrieved, the requested project
+   * @param projectType Indicates what you expect the `projectType` to be for the project with the
+   *   specified id. Currently, this does nothing but indicate to TypeScript what type the Project
+   *   Data Provider is. This is an alternative way to specify the `ProjectType` generic type.
+   *   Optional.
+   * @returns `undefined` if the project data provider has not been retrieved, the requested project
    *   data provider if it has been retrieved and is not disposed, and undefined again if the project
    *   data provider is disposed
-   * @ProjectType `ProjectType` - the project type for the project to use. The returned project data
-   * provider will have the project data provider type associated with this project type.
    */
   const useProjectDataProvider: <ProjectType extends keyof ProjectDataTypes>(
-    projectDataProviderSource:
-      | ProjectType
-      | IDataProvider<ProjectDataTypes[ProjectType]>
-      | undefined,
+    projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+    projectType?: ProjectType | undefined,
   ) => IDataProvider<ProjectDataTypes[ProjectType]> | undefined;
   export default useProjectDataProvider;
 }

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -2186,19 +2186,246 @@ declare module 'shared/models/project-data-provider.model' {
     ExtensionData: DataProviderDataType<ExtensionDataScope, string | undefined, string>;
   };
 }
+declare module 'shared/models/data-provider.interface' {
+  import {
+    DataProviderDataTypes,
+    DataProviderGetters,
+    DataProviderSetters,
+    DataProviderSubscribers,
+  } from 'shared/models/data-provider.model';
+  import { Dispose, OnDidDispose } from 'shared/models/disposal.model';
+  /**
+   * An object on the papi that manages data and has methods for interacting with that data. Created
+   * by the papi and layers over an IDataProviderEngine provided by an extension. Returned from
+   * getting a data provider with dataProviderService.get.
+   *
+   * Note: each `set<data_type>` method has a corresponding `get<data_type>` and
+   * `subscribe<data_type>` method.
+   */
+  type IDataProvider<TDataTypes extends DataProviderDataTypes = DataProviderDataTypes> =
+    DataProviderSetters<TDataTypes> &
+      DataProviderGetters<TDataTypes> &
+      DataProviderSubscribers<TDataTypes> &
+      OnDidDispose;
+  export default IDataProvider;
+  /**
+   * A data provider that has control over disposing of it with dispose. Returned from registering a
+   * data provider (only the service that set it up should dispose of it) with
+   * dataProviderService.registerEngine
+   *
+   * @see IDataProvider
+   */
+  export type IDisposableDataProvider<TDataProvider extends IDataProvider<any>> = TDataProvider &
+    Dispose;
+}
+declare module 'shared/models/data-provider-engine.model' {
+  import {
+    DataProviderDataTypes,
+    DataProviderGetters,
+    DataProviderUpdateInstructions,
+    DataProviderSetters,
+  } from 'shared/models/data-provider.model';
+  import { NetworkableObject } from 'shared/models/network-object.model';
+  /**
+   *
+   * Method to run to send clients updates for a specific data type outside of the `set<data_type>`
+   * method. papi overwrites this function on the DataProviderEngine itself to emit an update after
+   * running the `notifyUpdate` method in the DataProviderEngine.
+   *
+   * @example To run `notifyUpdate` function so it updates the Verse and Heresy data types (in a data
+   * provider engine):
+   *
+   * ```typescript
+   * this.notifyUpdate(['Verse', 'Heresy']);
+   * ```
+   *
+   * @example You can log the manual updates in your data provider engine by specifying the following
+   * `notifyUpdate` function in the data provider engine:
+   *
+   * ```typescript
+   * notifyUpdate(updateInstructions) {
+   * papi.logger.info(updateInstructions);
+   * }
+   * ```
+   *
+   * Note: This function's return is treated the same as the return from `set<data_type>`
+   *
+   * @param updateInstructions Information that papi uses to interpret whether to send out updates.
+   *   Defaults to `'*'` (meaning send updates for all data types) if parameter `updateInstructions`
+   *   is not provided or is undefined. Otherwise returns `updateInstructions`. papi passes the
+   *   interpreted update value into this `notifyUpdate` function. For example, running
+   *   `this.notifyUpdate()` will call the data provider engine's `notifyUpdate` with
+   *   `updateInstructions` of `'*'`.
+   * @see DataProviderUpdateInstructions for more info on the `updateInstructions` parameter
+   *
+   * WARNING: Do not update a data type in its `get<data_type>` method (unless you make a base case)!
+   * It will create a destructive infinite loop.
+   */
+  export type DataProviderEngineNotifyUpdate<TDataTypes extends DataProviderDataTypes> = (
+    updateInstructions?: DataProviderUpdateInstructions<TDataTypes>,
+  ) => void;
+  /**
+   * Addon type for IDataProviderEngine to specify that there is a `notifyUpdate` method on the data
+   * provider engine. You do not need to specify this type unless you are creating an object that is
+   * to be registered as a data provider engine and you need to use `notifyUpdate`.
+   *
+   * @see DataProviderEngineNotifyUpdate for more information on `notifyUpdate`.
+   * @see IDataProviderEngine for more information on using this type.
+   */
+  export type WithNotifyUpdate<TDataTypes extends DataProviderDataTypes> = {
+    /**
+     *
+     * Method to run to send clients updates for a specific data type outside of the `set<data_type>`
+     * method. papi overwrites this function on the DataProviderEngine itself to emit an update after
+     * running the `notifyUpdate` method in the DataProviderEngine.
+     *
+     * @example To run `notifyUpdate` function so it updates the Verse and Heresy data types (in a data
+     * provider engine):
+     *
+     * ```typescript
+     * this.notifyUpdate(['Verse', 'Heresy']);
+     * ```
+     *
+     * @example You can log the manual updates in your data provider engine by specifying the following
+     * `notifyUpdate` function in the data provider engine:
+     *
+     * ```typescript
+     * notifyUpdate(updateInstructions) {
+     * papi.logger.info(updateInstructions);
+     * }
+     * ```
+     *
+     * Note: This function's return is treated the same as the return from `set<data_type>`
+     *
+     * @param updateInstructions Information that papi uses to interpret whether to send out updates.
+     *   Defaults to `'*'` (meaning send updates for all data types) if parameter `updateInstructions`
+     *   is not provided or is undefined. Otherwise returns `updateInstructions`. papi passes the
+     *   interpreted update value into this `notifyUpdate` function. For example, running
+     *   `this.notifyUpdate()` will call the data provider engine's `notifyUpdate` with
+     *   `updateInstructions` of `'*'`.
+     * @see DataProviderUpdateInstructions for more info on the `updateInstructions` parameter
+     *
+     * WARNING: Do not update a data type in its `get<data_type>` method (unless you make a base case)!
+     * It will create a destructive infinite loop.
+     */
+    notifyUpdate: DataProviderEngineNotifyUpdate<TDataTypes>;
+  };
+  /**
+   * The object to register with the DataProviderService to create a data provider. The
+   * DataProviderService creates an IDataProvider on the papi that layers over this engine, providing
+   * special functionality.
+   *
+   * @type TDataTypes - The data types that this data provider engine serves. For each data type
+   *   defined, the engine must have corresponding `get<data_type>` and `set<data_type> function`
+   *   functions.
+   * @see DataProviderDataTypes for information on how to make powerful types that work well with
+   * Intellisense.
+   *
+   * Note: papi creates a `notifyUpdate` function on the data provider engine if one is not provided, so it
+   * is not necessary to provide one in order to call `this.notifyUpdate`. However, TypeScript does
+   * not understand that papi will create one as you are writing your data provider engine, so you can
+   * avoid type errors with one of the following options:
+   *
+   * 1. If you are using an object or class to create a data provider engine, you can add a
+   * `notifyUpdate` function (and, with an object, add the WithNotifyUpdate type) to
+   * your data provider engine like so:
+   * ```typescript
+   * const myDPE: IDataProviderEngine<MyDataTypes> & WithNotifyUpdate<MyDataTypes> = {
+   *   notifyUpdate(updateInstructions) {},
+   *   ...
+   * }
+   * ```
+   * OR
+   * ```typescript
+   * class MyDPE implements IDataProviderEngine<MyDataTypes> {
+   *   notifyUpdate(updateInstructions?: DataProviderEngineNotifyUpdate<MyDataTypes>) {}
+   *   ...
+   * }
+   * ```
+   *
+   * 2. If you are using a class to create a data provider engine, you can extend the `DataProviderEngine`
+   * class, and it will provide `notifyUpdate` for you:
+   * ```typescript
+   * class MyDPE extends DataProviderEngine<MyDataTypes> implements IDataProviderEngine<MyDataTypes> {
+   *   ...
+   * }
+   * ```
+   */
+  type IDataProviderEngine<TDataTypes extends DataProviderDataTypes = DataProviderDataTypes> =
+    NetworkableObject &
+      /**
+       * Set of all `set<data_type>` methods that a data provider engine must provide according to its
+       * data types. papi overwrites this function on the DataProviderEngine itself to emit an update
+       * after running the defined `set<data_type>` method in the DataProviderEngine.
+       *
+       * Note: papi requires that each `set<data_type>` method has a corresponding `get<data_type>`
+       * method.
+       *
+       * Note: to make a data type read-only, you can always return false or throw from
+       * `set<data_type>`.
+       *
+       * WARNING: Do not run this recursively in its own `set<data_type>` method! It will create as
+       * many updates as you run `set<data_type>` methods.
+       *
+       * @see DataProviderSetter for more information
+       */
+      DataProviderSetters<TDataTypes> &
+      /**
+       * Set of all `get<data_type>` methods that a data provider engine must provide according to its
+       * data types. Run by the data provider on `get<data_type>`
+       *
+       * Note: papi requires that each `set<data_type>` method has a corresponding `get<data_type>`
+       * method.
+       *
+       * @see DataProviderGetter for more information
+       */
+      DataProviderGetters<TDataTypes> &
+      Partial<WithNotifyUpdate<TDataTypes>>;
+  export default IDataProviderEngine;
+}
+declare module 'shared/models/extract-data-provider-data-types.model' {
+  import IDataProviderEngine from 'shared/models/data-provider-engine.model';
+  import IDataProvider, { IDisposableDataProvider } from 'shared/models/data-provider.interface';
+  import DataProviderInternal from 'shared/models/data-provider.model';
+  /**
+   * Get the `DataProviderDataTypes` associated with the `IDataProvider` - essentially, returns
+   * `TDataTypes` from `IDataProvider<TDataTypes>`.
+   *
+   * Works with generic types `IDataProvider`, `DataProviderInternal`, `IDisposableDataProvider`, and
+   * `IDataProviderEngine` along with the `papi-shared-types` extensible interfaces `DataProviders`
+   * and `DisposableDataProviders`
+   */
+  type ExtractDataProviderDataTypes<TDataProvider> = TDataProvider extends IDataProvider<
+    infer TDataProviderDataTypes
+  >
+    ? TDataProviderDataTypes
+    : TDataProvider extends DataProviderInternal<infer TDataProviderDataTypes>
+    ? TDataProviderDataTypes
+    : TDataProvider extends IDisposableDataProvider<infer TDataProviderDataTypes>
+    ? TDataProviderDataTypes
+    : TDataProvider extends IDataProviderEngine<infer TDataProviderDataTypes>
+    ? TDataProviderDataTypes
+    : never;
+  export default ExtractDataProviderDataTypes;
+}
 declare module 'papi-shared-types' {
-  import { ScriptureReference } from 'papi-components';
+  import type { ScriptureReference } from 'papi-components';
   import type { DataProviderDataType } from 'shared/models/data-provider.model';
   import type { MandatoryProjectDataType } from 'shared/models/project-data-provider.model';
+  import type { IDisposableDataProvider } from 'shared/models/data-provider.interface';
+  import type IDataProvider from 'shared/models/data-provider.interface';
+  import type ExtractDataProviderDataTypes from 'shared/models/extract-data-provider-data-types.model';
   /**
    * Function types for each command available on the papi. Each extension can extend this interface
-   * to add commands that it registers on the papi.
+   * to add commands that it registers on the papi with `papi.commands.registerCommand`.
    *
    * Note: Command names must consist of two string separated by at least one period. We recommend
    * one period and lower camel case in case we expand the api in the future to allow dot notation.
    *
-   * @example An extension can extend this interface to add types for the commands it registers by
-   * adding the following to its `.d.ts` file:
+   * An extension can extend this interface to add types for the commands it registers by adding the
+   * following to its `.d.ts` file:
+   *
+   * @example
    *
    * ```typescript
    * declare module 'papi-shared-types' {
@@ -2220,11 +2447,9 @@ declare module 'papi-shared-types' {
     'test.throwErrorExtensionHost': (message: string) => void;
   }
   /**
-   * Names for each command available on the papi. Automatically includes all extensions' commands
-   * that are added to {@link CommandHandlers}.
+   * Names for each command available on the papi.
    *
-   * Note: Command names must consist of two string separated by at least one period. We recommend
-   * one period and lower camel case in case we expand the api in the future to allow dot notation.
+   * Automatically includes all extensions' commands that are added to {@link CommandHandlers}.
    *
    * @example 'platform.quit';
    */
@@ -2240,7 +2465,7 @@ declare module 'papi-shared-types' {
   };
   /**
    * Data types for each project data provider supported by PAPI. Extensions can add more data types
-   * with corresponding project data provider IDs by adding details to their `d.ts` file. Note that
+   * with corresponding project data provider IDs by adding details to their `.d.ts` file. Note that
    * all project data types should extend `MandatoryProjectDataTypes` like the following example.
    *
    * @example
@@ -2267,6 +2492,100 @@ declare module 'papi-shared-types' {
    * to the set of project types available in Paratext.
    */
   type ProjectTypes = keyof ProjectDataTypes;
+  type StuffDataTypes = {
+    Stuff: DataProviderDataType<string, number, never>;
+  };
+  type PlaceholderDataTypes = {
+    Placeholder: DataProviderDataType<
+      {
+        thing: number;
+      },
+      string[],
+      number
+    >;
+  };
+  /**
+   * `IDataProvider` types for each data provider supported by PAPI. Extensions can add more data
+   * providers with corresponding data provider IDs by adding details to their `.d.ts` file and
+   * registering a data provider engine in their `activate` function with
+   * `papi.dataProvider.registerEngine`.
+   *
+   * Note: Data Provider names must consist of two string separated by at least one period. We
+   * recommend one period and lower camel case in case we expand the api in the future to allow dot
+   * notation.
+   *
+   * An extension can extend this interface to add types for the data provider it registers by
+   * adding the following to its `.d.ts` file (in this example, we are adding the
+   * `'helloSomeone.people'` data provider types):
+   *
+   * @example
+   *
+   * ```typescript
+   * declare module 'papi-shared-types' {
+   *   export type PeopleDataTypes = {
+   *     Greeting: DataProviderDataType<string, string | undefined, string>;
+   *     Age: DataProviderDataType<string, number | undefined, number>;
+   *     People: DataProviderDataType<undefined, PeopleData, never>;
+   *   };
+   *
+   *   export type PeopleDataMethods = {
+   *     deletePerson(name: string): Promise<boolean>;
+   *     testRandomMethod(things: string): Promise<string>;
+   *   };
+   *
+   *   export type PeopleDataProvider = IDataProvider<PeopleDataTypes> & PeopleDataMethods;
+   *
+   *   export interface DataProviders {
+   *     'helloSomeone.people': PeopleDataProvider;
+   *   }
+   * }
+   * ```
+   */
+  interface DataProviders {
+    'platform.stuff': IDataProvider<StuffDataTypes>;
+    'platform.placeholder': IDataProvider<PlaceholderDataTypes>;
+  }
+  /**
+   * Names for each data provider available on the papi.
+   *
+   * Automatically includes all extensions' data providers that are added to {@link DataProviders}.
+   *
+   * @example 'platform.placeholder'
+   */
+  type DataProviderNames = keyof DataProviders;
+  /**
+   * `DataProviderDataTypes` for each data provider supported by PAPI. These are the data types
+   * served by each data provider.
+   *
+   * Automatically includes all extensions' data providers that are added to {@link DataProviders}.
+   *
+   * @example
+   *
+   * ```typescript
+   * DataProviderTypes['helloSomeone.people'] => {
+   *     Greeting: DataProviderDataType<string, string | undefined, string>;
+   *     Age: DataProviderDataType<string, number | undefined, number>;
+   *     People: DataProviderDataType<undefined, PeopleData, never>;
+   *   }
+   * ```
+   */
+  type DataProviderTypes = {
+    [DataProviderName in DataProviderNames]: ExtractDataProviderDataTypes<
+      DataProviders[DataProviderName]
+    >;
+  };
+  /**
+   * Disposable version of each data provider type supported by PAPI. These objects are only
+   * returned from `papi.dataProvider.registerEngine` - only the one who registers a data provider
+   * engine is allowed to dispose of the data provider.
+   *
+   * Automatically includes all extensions' data providers that are added to {@link DataProviders}.
+   */
+  type DisposableDataProviders = {
+    [DataProviderName in DataProviderNames]: IDisposableDataProvider<
+      DataProviders[DataProviderName]
+    >;
+  };
 }
 declare module 'shared/services/command.service' {
   import { UnsubscriberAsync } from 'shared/utils/papi-util';
@@ -2816,203 +3135,19 @@ declare module 'shared/services/internet.service' {
   const internetService: InternetService;
   export default internetService;
 }
-declare module 'shared/models/data-provider.interface' {
-  import DataProviderInternal, { DataProviderDataTypes } from 'shared/models/data-provider.model';
-  import { DisposableNetworkObject, NetworkObject } from 'shared/models/network-object.model';
-  /**
-   * An object on the papi that manages data and has methods for interacting with that data. Created
-   * by the papi and layers over an IDataProviderEngine provided by an extension. Returned from
-   * getting a data provider with dataProviderService.get.
-   *
-   * Note: each `set<data_type>` method has a corresponding `get<data_type>` and
-   * `subscribe<data_type>` method.
-   */
-  type IDataProvider<TDataTypes extends DataProviderDataTypes = DataProviderDataTypes> =
-    NetworkObject<DataProviderInternal<TDataTypes>>;
-  export default IDataProvider;
-  /**
-   * A data provider that has control over disposing of it with dispose. Returned from registering a
-   * data provider (only the service that set it up should dispose of it) with
-   * dataProviderService.registerEngine
-   *
-   * @see IDataProvider
-   */
-  export type IDisposableDataProvider<
-    TDataTypes extends DataProviderDataTypes = DataProviderDataTypes,
-  > = DisposableNetworkObject<Omit<IDataProvider<TDataTypes>, 'dispose'>>;
-}
-declare module 'shared/models/data-provider-engine.model' {
-  import {
-    DataProviderDataTypes,
-    DataProviderGetters,
-    DataProviderUpdateInstructions,
-    DataProviderSetters,
-  } from 'shared/models/data-provider.model';
-  import { NetworkableObject } from 'shared/models/network-object.model';
-  /**
-   *
-   * Method to run to send clients updates for a specific data type outside of the `set<data_type>`
-   * method. papi overwrites this function on the DataProviderEngine itself to emit an update after
-   * running the `notifyUpdate` method in the DataProviderEngine.
-   *
-   * @example To run `notifyUpdate` function so it updates the Verse and Heresy data types (in a data
-   * provider engine):
-   *
-   * ```typescript
-   * this.notifyUpdate(['Verse', 'Heresy']);
-   * ```
-   *
-   * @example You can log the manual updates in your data provider engine by specifying the following
-   * `notifyUpdate` function in the data provider engine:
-   *
-   * ```typescript
-   * notifyUpdate(updateInstructions) {
-   * papi.logger.info(updateInstructions);
-   * }
-   * ```
-   *
-   * Note: This function's return is treated the same as the return from `set<data_type>`
-   *
-   * @param updateInstructions Information that papi uses to interpret whether to send out updates.
-   *   Defaults to `'*'` (meaning send updates for all data types) if parameter `updateInstructions`
-   *   is not provided or is undefined. Otherwise returns `updateInstructions`. papi passes the
-   *   interpreted update value into this `notifyUpdate` function. For example, running
-   *   `this.notifyUpdate()` will call the data provider engine's `notifyUpdate` with
-   *   `updateInstructions` of `'*'`.
-   * @see DataProviderUpdateInstructions for more info on the `updateInstructions` parameter
-   *
-   * WARNING: Do not update a data type in its `get<data_type>` method (unless you make a base case)!
-   * It will create a destructive infinite loop.
-   */
-  export type DataProviderEngineNotifyUpdate<TDataTypes extends DataProviderDataTypes> = (
-    updateInstructions?: DataProviderUpdateInstructions<TDataTypes>,
-  ) => void;
-  /**
-   * Addon type for IDataProviderEngine to specify that there is a `notifyUpdate` method on the data
-   * provider engine. You do not need to specify this type unless you are creating an object that is
-   * to be registered as a data provider engine and you need to use `notifyUpdate`.
-   *
-   * @see DataProviderEngineNotifyUpdate for more information on `notifyUpdate`.
-   * @see IDataProviderEngine for more information on using this type.
-   */
-  export type WithNotifyUpdate<TDataTypes extends DataProviderDataTypes> = {
-    /**
-     *
-     * Method to run to send clients updates for a specific data type outside of the `set<data_type>`
-     * method. papi overwrites this function on the DataProviderEngine itself to emit an update after
-     * running the `notifyUpdate` method in the DataProviderEngine.
-     *
-     * @example To run `notifyUpdate` function so it updates the Verse and Heresy data types (in a data
-     * provider engine):
-     *
-     * ```typescript
-     * this.notifyUpdate(['Verse', 'Heresy']);
-     * ```
-     *
-     * @example You can log the manual updates in your data provider engine by specifying the following
-     * `notifyUpdate` function in the data provider engine:
-     *
-     * ```typescript
-     * notifyUpdate(updateInstructions) {
-     * papi.logger.info(updateInstructions);
-     * }
-     * ```
-     *
-     * Note: This function's return is treated the same as the return from `set<data_type>`
-     *
-     * @param updateInstructions Information that papi uses to interpret whether to send out updates.
-     *   Defaults to `'*'` (meaning send updates for all data types) if parameter `updateInstructions`
-     *   is not provided or is undefined. Otherwise returns `updateInstructions`. papi passes the
-     *   interpreted update value into this `notifyUpdate` function. For example, running
-     *   `this.notifyUpdate()` will call the data provider engine's `notifyUpdate` with
-     *   `updateInstructions` of `'*'`.
-     * @see DataProviderUpdateInstructions for more info on the `updateInstructions` parameter
-     *
-     * WARNING: Do not update a data type in its `get<data_type>` method (unless you make a base case)!
-     * It will create a destructive infinite loop.
-     */
-    notifyUpdate: DataProviderEngineNotifyUpdate<TDataTypes>;
-  };
-  /**
-   * The object to register with the DataProviderService to create a data provider. The
-   * DataProviderService creates an IDataProvider on the papi that layers over this engine, providing
-   * special functionality.
-   *
-   * @type TDataTypes - The data types that this data provider engine serves. For each data type
-   *   defined, the engine must have corresponding `get<data_type>` and `set<data_type> function`
-   *   functions.
-   * @see DataProviderDataTypes for information on how to make powerful types that work well with
-   * Intellisense.
-   *
-   * Note: papi creates a `notifyUpdate` function on the data provider engine if one is not provided, so it
-   * is not necessary to provide one in order to call `this.notifyUpdate`. However, TypeScript does
-   * not understand that papi will create one as you are writing your data provider engine, so you can
-   * avoid type errors with one of the following options:
-   *
-   * 1. If you are using an object or class to create a data provider engine, you can add a
-   * `notifyUpdate` function (and, with an object, add the WithNotifyUpdate type) to
-   * your data provider engine like so:
-   * ```typescript
-   * const myDPE: IDataProviderEngine<MyDataTypes> & WithNotifyUpdate<MyDataTypes> = {
-   *   notifyUpdate(updateInstructions) {},
-   *   ...
-   * }
-   * ```
-   * OR
-   * ```typescript
-   * class MyDPE implements IDataProviderEngine<MyDataTypes> {
-   *   notifyUpdate(updateInstructions?: DataProviderEngineNotifyUpdate<MyDataTypes>) {}
-   *   ...
-   * }
-   * ```
-   *
-   * 2. If you are using a class to create a data provider engine, you can extend the `DataProviderEngine`
-   * class, and it will provide `notifyUpdate` for you:
-   * ```typescript
-   * class MyDPE extends DataProviderEngine<MyDataTypes> implements IDataProviderEngine<MyDataTypes> {
-   *   ...
-   * }
-   * ```
-   */
-  type IDataProviderEngine<TDataTypes extends DataProviderDataTypes = DataProviderDataTypes> =
-    NetworkableObject &
-      /**
-       * Set of all `set<data_type>` methods that a data provider engine must provide according to its
-       * data types. papi overwrites this function on the DataProviderEngine itself to emit an update
-       * after running the defined `set<data_type>` method in the DataProviderEngine.
-       *
-       * Note: papi requires that each `set<data_type>` method has a corresponding `get<data_type>`
-       * method.
-       *
-       * Note: to make a data type read-only, you can always return false or throw from
-       * `set<data_type>`.
-       *
-       * WARNING: Do not run this recursively in its own `set<data_type>` method! It will create as
-       * many updates as you run `set<data_type>` methods.
-       *
-       * @see DataProviderSetter for more information
-       */
-      DataProviderSetters<TDataTypes> &
-      /**
-       * Set of all `get<data_type>` methods that a data provider engine must provide according to its
-       * data types. Run by the data provider on `get<data_type>`
-       *
-       * Note: papi requires that each `set<data_type>` method has a corresponding `get<data_type>`
-       * method.
-       *
-       * @see DataProviderGetter for more information
-       */
-      DataProviderGetters<TDataTypes> &
-      Partial<WithNotifyUpdate<TDataTypes>>;
-  export default IDataProviderEngine;
-}
 declare module 'shared/services/data-provider.service' {
   /** Handles registering data providers and serving data around the papi. Exposed on the papi. */
-  import IDataProvider, { IDisposableDataProvider } from 'shared/models/data-provider.interface';
   import { DataProviderDataTypes } from 'shared/models/data-provider.model';
   import IDataProviderEngine, {
     DataProviderEngineNotifyUpdate,
   } from 'shared/models/data-provider-engine.model';
+  import {
+    DataProviderNames,
+    DataProviderTypes,
+    DataProviders,
+    DisposableDataProviders,
+  } from 'papi-shared-types';
+  import IDataProvider, { IDisposableDataProvider } from 'shared/models/data-provider.interface';
   /**
    *
    * Abstract class that provides a placeholder `notifyUpdate` for data provider engine classes. If a
@@ -3099,10 +3234,6 @@ declare module 'shared/services/data-provider.service' {
    * Creates a data provider to be shared on the network layering over the provided data provider
    * engine.
    *
-   * @type `TSelector` - The type of selector used to get some data from this provider. A selector is
-   *   an object a caller provides to the data provider to tell the provider what subset of data it
-   *   wants. Note: A selector must be stringifiable.
-   * @type `TData` - The type of data provided by this data provider based on a provided selector
    * @param providerName Name this data provider should be called on the network
    * @param dataProviderEngine The object to layer over with a new data provider object
    *
@@ -3111,17 +3242,61 @@ declare module 'shared/services/data-provider.service' {
    * @returns The data provider including control over disposing of it. Note that this data provider
    *   is a new object distinct from the data provider engine passed in.
    */
-  function registerEngine<TDataTypes extends DataProviderDataTypes>(
+  function registerEngine<DataProviderName extends DataProviderNames>(
+    providerName: DataProviderName,
+    dataProviderEngine: IDataProviderEngine<DataProviderTypes[DataProviderName]>,
+  ): Promise<DisposableDataProviders[DataProviderName]>;
+  /**
+   * Create a mock local data provider object for connecting to the remote data provider
+   *
+   * @type `TDataTypes` - The data provider data types served by the data provider to create.
+   *
+   *   This is not exposed on the papi as it is a helper function to enable other services to layer over
+   *   this service and create their own subsets of data providers with other types than
+   *   `DataProviders` types using this function and {@link getByType}
+   * @param dataProviderObjectId Network object id corresponding to this data provider
+   * @param dataProviderContainer Container that holds a reference to the data provider so this
+   *   subscribe function can reference the data provider
+   * @param providerName Name this data provider should be called on the network
+   * @param dataProviderEngine The object to layer over with a new data provider object
+   *
+   *   WARNING: registering a dataProviderEngine mutates the provided object. Its `notifyUpdate` and
+   *   `set` methods are layered over to facilitate data provider subscriptions.
+   * @returns Local data provider object that represents a remote data provider
+   *
+   *   Creates a data provider to be shared on the network layering over the provided data provider
+   *   engine.
+   * @returns The data provider including control over disposing of it. Note that this data provider
+   *   is a new object distinct from the data provider engine passed in.
+   */
+  export function registerEngineByType<TDataTypes extends DataProviderDataTypes>(
     providerName: string,
     dataProviderEngine: IDataProviderEngine<TDataTypes>,
-  ): Promise<IDisposableDataProvider<TDataTypes>>;
+  ): Promise<IDisposableDataProvider<IDataProvider<TDataTypes>>>;
   /**
    * Get a data provider that has previously been set up
    *
    * @param providerName Name of the desired data provider
    * @returns The data provider with the given name if one exists, undefined otherwise
    */
-  function get<T extends IDataProvider<any>>(providerName: string): Promise<T | undefined>;
+  function get<DataProviderName extends DataProviderNames>(
+    providerName: DataProviderName,
+  ): Promise<DataProviders[DataProviderName] | undefined>;
+  /**
+   * Get a data provider that has previously been set up
+   *
+   * @type `T` - The type of data provider to get. Use `IDataProvider<TDataProviderDataTypes>`,
+   *   specifying your own types, or provide a custom data provider type
+   *
+   *   This is not exposed on the papi as it is a helper function to enable other services to layer over
+   *   this service and create their own subsets of data providers with other types than
+   *   `DataProviders` types using this function and {@link registerEngineByType}
+   * @param providerName Name of the desired data provider
+   * @returns The data provider with the given name if one exists, undefined otherwise
+   */
+  export function getByType<T extends IDataProvider<any>>(
+    providerName: string,
+  ): Promise<T | undefined>;
   export interface DataProviderService {
     hasKnown: typeof hasKnown;
     registerEngine: typeof registerEngine;
@@ -3188,16 +3363,14 @@ declare module 'shared/models/project-data-provider-engine.model' {
   import { ProjectTypes, ProjectDataTypes } from 'papi-shared-types';
   import type IDataProvider from 'shared/models/data-provider.interface';
   import type IDataProviderEngine from 'shared/models/data-provider-engine.model';
-  type IDataProviderEngineGeneric<T extends ProjectDataTypes> = {
-    [K in keyof T]: IDataProviderEngine<T[K]>;
-  };
   /** All possible types for ProjectDataProviderEngines: IDataProviderEngine<ProjectDataType> */
-  export type ProjectDataProviderEngineTypes = IDataProviderEngineGeneric<ProjectDataTypes>;
-  type IProjectDataProviderGeneric<T extends ProjectDataTypes> = {
-    [K in keyof T]: IDataProvider<T[K]>;
+  export type ProjectDataProviderEngineTypes = {
+    [ProjectType in ProjectTypes]: IDataProviderEngine<ProjectDataTypes[ProjectType]>;
   };
   /** All possible types for ProjectDataProviders: IDataProvider<ProjectDataType> */
-  export type ProjectDataProvider = IProjectDataProviderGeneric<ProjectDataTypes>;
+  export type ProjectDataProvider = {
+    [ProjectType in ProjectTypes]: IDataProvider<ProjectDataTypes[ProjectType]>;
+  };
   export interface ProjectDataProviderEngineFactory<ProjectType extends ProjectTypes> {
     createProjectDataProviderEngine(
       projectId: string,
@@ -3257,11 +3430,25 @@ declare module 'shared/services/project-data-provider.service' {
    * pdp.getVerse(new VerseRef('JHN', '1', '1'));
    * ```
    *
+   * @example
+   *
+   * ```typescript
+   * const pdp = await getProjectDataProvider('ProjectID12345', 'ParatextStandard');
+   * pdp.getVerse(new VerseRef('JHN', '1', '1'));
+   * ```
+   *
+   * @type `ProjectType` - The `projectType` of the project whose data to retrieve. Alternatively,
+   *   specify this as the second argument to this function for Intellisense support
    * @param projectId ID for the project to load
+   * @param projectType Indicates what you expect the `projectType` to be for the project with the
+   *   specified id. Currently, this does nothing but indicate to TypeScript what type the Project
+   *   Data Provider is. This is an alternative way to specify the `ProjectType` generic type.
+   *   Optional.
    * @returns Data provider with types that are associated with the given project type
    */
   export function getProjectDataProvider<ProjectType extends ProjectTypes>(
     projectId: string,
+    projectType?: ProjectType,
   ): Promise<ProjectDataProvider[ProjectType]>;
   export interface PapiBackendProjectDataProviderService {
     registerProjectDataProviderEngineFactory: typeof registerProjectDataProviderEngineFactory;
@@ -3644,7 +3831,7 @@ declare module 'renderer/hooks/hook-generators/create-use-network-object-hook.ut
   export default createUseNetworkObjectHook;
 }
 declare module 'renderer/hooks/papi-hooks/use-data-provider.hook' {
-  import IDataProvider from 'shared/models/data-provider.interface';
+  import { DataProviders } from 'papi-shared-types';
   /**
    * Gets a data provider with specified provider name
    *
@@ -3655,98 +3842,154 @@ declare module 'renderer/hooks/papi-hooks/use-data-provider.hook' {
    * @returns Undefined if the data provider has not been retrieved, data provider if it has been
    *   retrieved and is not disposed, and undefined again if the data provider is disposed
    */
-  const useDataProvider: <T extends IDataProvider<any>>(
-    dataProviderSource: string | T | undefined,
-  ) => T | undefined;
+  const useDataProvider: <DataProviderName extends keyof DataProviders>(
+    dataProviderSource: DataProviderName | DataProviders[DataProviderName] | undefined,
+  ) => DataProviders[DataProviderName] | undefined;
   export default useDataProvider;
 }
 declare module 'renderer/hooks/hook-generators/create-use-data-hook.util' {
   import {
-    DataProviderDataTypes,
     DataProviderSubscriberOptions,
     DataProviderUpdateInstructions,
   } from 'shared/models/data-provider.model';
   import IDataProvider from 'shared/models/data-provider.interface';
+  import ExtractDataProviderDataTypes from 'shared/models/extract-data-provider-data-types.model';
   /**
-   * Proxy object that provides hooks to use data provider data with various data types
+   * The final function called as part of the `useData` hook that is the actual React hook
    *
-   * @example `useData.Greeting<PeopleDataTypes, 'Greeting'>(...);`
-   *
-   * @type `TDataTypes` - The data provider data types served by the data provider whose data to use.
-   * @type `TDataType` - The specific data type on this data provider that you want to use. Must match
-   *   the data type specified in `useData.<data_type>`
+   * This is the `.Greeting(...)` part of `useData('helloSomeone.people').Greeting(...)`
    */
-  export type UseDataHook = {
-    [DataType in string]: <
-      TDataTypes extends DataProviderDataTypes,
-      TDataType extends keyof TDataTypes,
-    >(
-      dataProviderSource: string | IDataProvider<TDataTypes> | undefined,
-      selector: TDataTypes[TDataType]['selector'],
-      defaultValue: TDataTypes[TDataType]['getData'],
-      subscriberOptions?: DataProviderSubscriberOptions,
-    ) => [
-      TDataTypes[TDataType]['getData'],
-      (
-        | ((
-            newData: TDataTypes[TDataType]['setData'],
-          ) => Promise<DataProviderUpdateInstructions<TDataTypes>>)
-        | undefined
-      ),
-      boolean,
-    ];
+  type UseDataFunctionWithProviderType<
+    TDataProvider extends IDataProvider<any>,
+    TDataType extends keyof ExtractDataProviderDataTypes<TDataProvider>,
+  > = (
+    selector: ExtractDataProviderDataTypes<TDataProvider>[TDataType]['selector'],
+    defaultValue: ExtractDataProviderDataTypes<TDataProvider>[TDataType]['getData'],
+    subscriberOptions?: DataProviderSubscriberOptions,
+  ) => [
+    ExtractDataProviderDataTypes<TDataProvider>[TDataType]['getData'],
+    (
+      | ((
+          newData: ExtractDataProviderDataTypes<TDataProvider>[TDataType]['setData'],
+        ) => Promise<DataProviderUpdateInstructions<ExtractDataProviderDataTypes<TDataProvider>>>)
+      | undefined
+    ),
+    boolean,
+  ];
+  /**
+   * A proxy that serves the actual hooks for a single data provider
+   *
+   * This is the `useData('helloSomeone.people')` part of
+   * `useData('helloSomeone.people').Greeting(...)`
+   */
+  type UseDataProxy<TDataProvider extends IDataProvider<any>> = {
+    [TDataType in keyof ExtractDataProviderDataTypes<TDataProvider>]: UseDataFunctionWithProviderType<
+      TDataProvider,
+      TDataType
+    >;
   };
+  /**
+   * React hook to use data provider data with various data types
+   *
+   * @example `useData('helloSomeone.people').Greeting('Bill', 'Greeting loading')`
+   *
+   * @type `TDataProvider` - The type of data provider to get. Use
+   *   `IDataProvider<TDataProviderDataTypes>`, specifying your own types, or provide a custom data
+   *   provider type
+   */
+  type UseDataHookGeneric = {
+    <TDataProvider extends IDataProvider<any>>(
+      dataProviderSource: string | TDataProvider | undefined,
+    ): UseDataProxy<TDataProvider>;
+  };
+  /**
+   * Create a `useData(...).DataType(selector, defaultValue, options)` hook for a specific subset of
+   * data providers as supported by `useDataProviderHook`
+   *
+   * @param useDataProviderHook Hook that gets a data provider from a specific subset of data
+   *   providers
+   * @returns `useData` hook for getting data from a data provider
+   */
   function createUseDataHook(
     useDataProviderHook: (
       dataProviderSource: string | IDataProvider | undefined,
     ) => IDataProvider | undefined,
-  ): UseDataHook;
+  ): UseDataHookGeneric;
   export default createUseDataHook;
 }
 declare module 'renderer/hooks/papi-hooks/use-data.hook' {
-  import { UseDataHook } from 'renderer/hooks/hook-generators/create-use-data-hook.util';
+  import {
+    DataProviderSubscriberOptions,
+    DataProviderUpdateInstructions,
+  } from 'shared/models/data-provider.model';
+  import { DataProviderNames, DataProviderTypes, DataProviders } from 'papi-shared-types';
+  /**
+   * React hook to use data from a data provider
+   *
+   * @example `useData('helloSomeone.people').Greeting('Bill', 'Greeting loading')`
+   */
+  type UseDataHook = {
+    <DataProviderName extends DataProviderNames>(
+      dataProviderSource: DataProviderName | DataProviders[DataProviderName] | undefined,
+    ): {
+      [TDataType in keyof DataProviderTypes[DataProviderName]]: (
+        selector: DataProviderTypes[DataProviderName][TDataType]['selector'],
+        defaultValue: DataProviderTypes[DataProviderName][TDataType]['getData'],
+        subscriberOptions?: DataProviderSubscriberOptions,
+      ) => [
+        DataProviderTypes[DataProviderName][TDataType]['getData'],
+        (
+          | ((
+              newData: DataProviderTypes[DataProviderName][TDataType]['setData'],
+            ) => Promise<DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>>)
+          | undefined
+        ),
+        boolean,
+      ];
+    };
+  };
   /**
    * ```typescript
-   * useData.DataType<TDataTypes extends DataProviderDataTypes, TDataType extends keyof TDataTypes>(
-   *   dataProviderSource: string | IDataProvider<TDataTypes> | undefined,
-   *   selector: TDataTypes[TDataType]['selector'],
-   *   defaultValue: TDataTypes[TDataType]['getData'],
-   *   subscriberOptions?: DataProviderSubscriberOptions,
-   * ): [
-   *   TDataTypes[TDataType]['getData'],
-   *   (
-   *     | ((
-   *         newData: TDataTypes[TDataType]['setData'],
-   *       ) => Promise<DataProviderUpdateInstructions<TDataTypes>>)
-   *     | undefined
-   *   ),
-   *   boolean,
-   * ]
+   * useData<DataProviderName extends DataProviderNames>(
+   *     dataProviderSource: DataProviderName | DataProviders[DataProviderName] | undefined,
+   *   ).DataType(
+   *       selector: DataProviderTypes[DataProviderName][DataType]['selector'],
+   *       defaultValue: DataProviderTypes[DataProviderName][DataType]['getData'],
+   *       subscriberOptions?: DataProviderSubscriberOptions,
+   *     ) => [
+   *       DataProviderTypes[DataProviderName][DataType]['getData'],
+   *       (
+   *         | ((
+   *             newData: DataProviderTypes[DataProviderName][DataType]['setData'],
+   *           ) => Promise<DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>>)
+   *         | undefined
+   *       ),
+   *       boolean,
+   *     ]
    * ```
    *
-   * Special React hook that subscribes to run a callback on a data provider's data with specified
-   * selector on any data type that data provider serves.
+   * React hook to use data from a data provider. Subscribes to run a callback on a data provider's
+   * data with specified selector on the specified data type that data provider serves.
    *
-   * Usage: Specify the data type on the data provider with `useData.<data_type>` and use like any
-   * other React hook. Specify the generic types in order to receive type support from Intellisense.
-   * For example, `useData.Verse<QuickVerseDataTypes, 'Verse'>` lets you subscribe to verses from a
-   * data provider that serves `QuickVerseDataTypes`.
+   * Usage: Specify the data provider and the data type on the data provider with
+   * `useData('<data_provider>').<data_type>` and use like any other React hook.
    *
-   * _＠example_ When subscribing to JHN 11:35 on the `'quickVerse.quickVerse'` data provider, we need
-   * to tell the useData.Verse hook what types we are using, so we use the `QuickVerseDataTypes` data
-   * types and specify that we are using the `'Verse'` data type as follows:
+   * _＠example_ Subscribing to Verse data at JHN 11:35 on the `'quickVerse.quickVerse'` data provider:
    *
    * ```typescript
-   * const [verseText, setVerseText, verseTextIsLoading] = useData.Verse<
-   *   QuickVerseDataTypes,
-   *   'Verse'
-   * >('quickVerse.quickVerse', 'JHN 11:35', 'Verse text goes here');
+   * const [verseText, setVerseText, verseTextIsLoading] = useData('quickVerse.quickVerse').Verse(
+   *   'JHN 11:35',
+   *   'Verse text goes here',
+   * );
    * ```
    *
    * _＠param_ `dataProviderSource` string name of data provider to get OR dataProvider (result of
    * useDataProvider if you want to consolidate and only get the data provider once)
    *
    * _＠param_ `selector` tells the provider what data this listener is listening for
+   *
+   * WARNING: MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not be
+   * updated every render
    *
    * _＠param_ `defaultValue` the initial value to return while first awaiting the data
    *
@@ -3768,12 +4011,6 @@ declare module 'renderer/hooks/papi-hooks/use-data.hook' {
    *   data.
    * - `isLoading`: whether the data with the data type and selector is awaiting retrieval from the data
    *   provider
-   *
-   * _＠type_ `TDataTypes` - the data provider data types served by the data provider whose data to
-   * use.
-   *
-   * _＠type_ `TDataType` - the specific data type on this data provider that you want to use. Must
-   * match the data type specified in `useData.<data_type>`
    */
   const useData: UseDataHook;
   export default useData;
@@ -3823,21 +4060,26 @@ declare module 'renderer/hooks/papi-hooks/use-project-data-provider.hook' {
    * provider will have the project data provider type associated with this project type.
    */
   const useProjectDataProvider: <ProjectType extends keyof ProjectDataTypes>(
-    projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+    projectDataProviderSource:
+      | ProjectType
+      | IDataProvider<ProjectDataTypes[ProjectType]>
+      | undefined,
   ) => IDataProvider<ProjectDataTypes[ProjectType]> | undefined;
   export default useProjectDataProvider;
 }
 declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
   import {
-    DataProviderDataTypes,
     DataProviderSubscriberOptions,
     DataProviderUpdateInstructions,
   } from 'shared/models/data-provider.model';
   import IDataProvider from 'shared/models/data-provider.interface';
+  import { ProjectDataTypes, ProjectTypes } from 'papi-shared-types';
   /**
-   * Proxy object that provides hooks to use project data provider data with various data types
+   * React hook to use data from a project data provider
    *
    * @example `useProjectData.VerseUSFM<ProjectDataTypes['ParatextStandard'], 'VerseUSFM'>(...);`
+   *
+   * @example `useProjectData('<project_id>', 'ParatextStandard').VerseUSFM(...)`
    *
    * @type `TProjectDataTypes` - The project data types associated with the `projectType` used. You
    *   can specify this type with `ProjectDataTypes['<project_type>']`
@@ -3850,70 +4092,70 @@ declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
    *   because it refused to accept that `'selector'` was a valid member:
    *   `ProjectDataTypes[ProjectType][TDataType]['selector']`
    *
-   *   As such, this hook proxy actually has the same types as `UseDataHook` but with a couple of things
-   *   renamed for easier readability.
+   *   # As such, this hook proxy actually has the same types as `UseDataHook` but with a couple of things
+   *
+   *   Renamed for easier readability.
+   * @type `ProjectType` - The `projectType` of the project whose data to retrieve. Alternatively,
+   *   specify this as the second argument to the `useProjectData` function for Intellisense support
    */
   type UseProjectDataHook = {
-    [DataType in string]: <
-      TProjectDataTypes extends DataProviderDataTypes,
-      TDataType extends keyof TProjectDataTypes,
-    >(
-      projectDataProviderSource: string | IDataProvider<TProjectDataTypes> | undefined,
-      selector: TProjectDataTypes[TDataType]['selector'],
-      defaultValue: TProjectDataTypes[TDataType]['getData'],
-      subscriberOptions?: DataProviderSubscriberOptions,
-    ) => [
-      TProjectDataTypes[TDataType]['getData'],
-      (
-        | ((
-            newData: TProjectDataTypes[TDataType]['setData'],
-          ) => Promise<DataProviderUpdateInstructions<TProjectDataTypes>>)
-        | undefined
-      ),
-      boolean,
-    ];
+    <ProjectType extends ProjectTypes>(
+      projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+      projectType?: ProjectType,
+    ): {
+      [TDataType in keyof ProjectDataTypes[ProjectType]]: (
+        selector: ProjectDataTypes[ProjectType][TDataType]['selector'],
+        defaultValue: ProjectDataTypes[ProjectType][TDataType]['getData'],
+        subscriberOptions?: DataProviderSubscriberOptions,
+      ) => [
+        ProjectDataTypes[ProjectType][TDataType]['getData'],
+        (
+          | ((
+              newData: ProjectDataTypes[ProjectType][TDataType]['setData'],
+            ) => Promise<DataProviderUpdateInstructions<ProjectDataTypes[ProjectType]>>)
+          | undefined
+        ),
+        boolean,
+      ];
+    };
   };
   /**
    * ```typescript
-   * useProjectData.DataType<TProjectDataTypes extends DataProviderDataTypes, TDataType extends keyof TProjectDataTypes>(
-   *   projectDataProviderSource: string | IDataProvider<TProjectDataTypes> | undefined,
-   *   selector: TProjectDataTypes[TDataType]['selector'],
-   *   defaultValue: TProjectDataTypes[TDataType]['getData'],
-   *   subscriberOptions?: DataProviderSubscriberOptions,
-   * ): [
-   *   TProjectDataTypes[TDataType]['getData'],
-   *   (
-   *     | ((
-   *         newData: TProjectDataTypes[TDataType]['setData'],
-   *       ) => Promise<DataProviderUpdateInstructions<TProjectDataTypes>>)
-   *     | undefined
-   *   ),
-   *   boolean,
-   * ]
+   * useProjectData<ProjectType extends ProjectTypes>(
+   *     projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+   *     projectType?: ProjectType,
+   *   ).DataType(
+   *       selector: ProjectDataTypes[ProjectType][DataType]['selector'],
+   *       defaultValue: ProjectDataTypes[ProjectType][DataType]['getData'],
+   *       subscriberOptions?: DataProviderSubscriberOptions,
+   *     ) => [
+   *       ProjectDataTypes[ProjectType][DataType]['getData'],
+   *       (
+   *         | ((
+   *             newData: ProjectDataTypes[ProjectType][DataType]['setData'],
+   *           ) => Promise<DataProviderUpdateInstructions<ProjectDataTypes[ProjectType]>>)
+   *         | undefined
+   *       ),
+   *       boolean,
+   *     ]
    * ```
    *
-   * Special React hook that subscribes to run a callback on a project data provider's data with
-   * specified selector on any data type that the project data provider serves according to its
-   * projectType.
+   * React hook to use data from a project data provider. Subscribes to run a callback on a project
+   * data provider's data with specified selector on the specified data type that the project data
+   * provider serves according to its `projectType`.
    *
-   * Usage: Specify the data type on the project data provider with `useProjectData.<data_type>` and
-   * use like any other React hook. Specify the generic types in order to receive type support from
-   * Intellisense. For example, `useProjectData.VerseUSFM<ProjectDataTypes['ParatextStandard'],
-   * 'VerseUSFM'>` lets you subscribe to verse USFM from a project data provider for the
-   * `ParatextStandard` `projectType`.
+   * Usage: Specify the project id, the project type, and the data type on the project data provider
+   * with `useProjectData('<project_id>', '<project_type>').<data_type>` and use like any other React
+   * hook.
    *
-   * _＠example_ When subscribing to JHN 11:35 Verse USFM info on a `ParatextStandard` project with
-   * projectId `32664dc3288a28df2e2bb75ded887fc8f17a15fb`, we need to tell the
-   * `useProjectData.VerseUSFM` hook what types we are using, so we specify the project data types as
-   * `ProjectDataTypes['ParatextStandard']` and specify that we are using the `'VerseUSFM'` data type
-   * as follows:
+   * _＠example_ Subscribing to Verse USFM info at JHN 11:35 on a `ParatextStandard` project with
+   * projectId `32664dc3288a28df2e2bb75ded887fc8f17a15fb`:
    *
    * ```typescript
-   * const [verse, setVerse, verseIsLoading] = useProjectData.VerseUSFM<
-   *   ProjectDataTypes['ParatextStandard'],
-   *   'Verse'
-   * >(
+   * const [verse, setVerse, verseIsLoading] = useProjectData(
    *   '32664dc3288a28df2e2bb75ded887fc8f17a15fb',
+   *   'ParatextStandard',
+   * ).VerseUSFM(
    *   useMemo(() => new VerseRef('JHN', '11', '35', ScrVers.English), []),
    *   'Loading verse ',
    * );
@@ -3923,7 +4165,14 @@ declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
    * projectDataProvider (result of useProjectDataProvider if you want to consolidate and only get the
    * project data provider once)
    *
+   * _＠param_ `projectType` indicates what you expect the `projectType` to be for the project with the
+   * specified id. Currently, this does nothing but indicate to TypeScript what type the Project Data
+   * Provider is. This is an alternative way to specify the `ProjectType` generic type. Optional.
+   *
    * _＠param_ `selector` tells the provider what data this listener is listening for
+   *
+   * WARNING: MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not be
+   * updated every render
    *
    * _＠param_ `defaultValue` the initial value to return while first awaiting the data
    *
@@ -3937,20 +4186,8 @@ declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
    *
    * _＠returns_ `[data, setData, isLoading]`
    *
-   * - `data`: the current value for the data from the project data provider for the specified project
-   *   id with the specified data type and selector, either the defaultValue or the resolved data
-   * - `setData`: asynchronous function to request that the data provider for the specified project id
-   *   update the data at this data type and selector. Returns true if successful. Note that this
-   *   function does not update the data. The project data provider sends out an update to this
-   *   subscription if it successfully updates data.
-   * - `isLoading`: whether the data with the data type and selector is awaiting retrieval from the
-   *   project data provider for this project id
-   *
-   * _＠type_ `TProjectDataTypes` - the project data types associated with the `projectType` used. You
-   * can specify this type with `ProjectDataTypes['<project_type>']`
-   *
-   * _＠type_ `TDataType` - the specific data type on this project you want to use. Must match the data
-   * type specified in `useProjectData.<data_type>`
+   * _＠type_ `ProjectType` - the `projectType` of the project whose data to retrieve. Alternatively,
+   * specify this as the second argument to the `useProjectData` function for Intellisense support
    */
   const useProjectData: UseProjectDataHook;
   export default useProjectData;
@@ -4009,7 +4246,7 @@ declare module 'renderer/hooks/papi-hooks/use-dialog-callback.hook' {
   export default useDialogCallback;
 }
 declare module 'renderer/hooks/papi-hooks/use-data-provider-multi.hook' {
-  import IDataProvider from 'shared/models/data-provider.interface';
+  import { DataProviderNames, DataProviders } from 'papi-shared-types';
   /**
    * Gets an array of data providers based on an array of input sources
    *
@@ -4033,9 +4270,13 @@ declare module 'renderer/hooks/papi-hooks/use-data-provider-multi.hook' {
    *   not been retrieved or has been disposed, or (b) a data provider if it has been retrieved and is
    *   not disposed.
    */
-  function useDataProviderMulti<T extends IDataProvider<any>[]>(
-    dataProviderSources: (string | T[number] | undefined)[],
-  ): (T[number] | undefined)[];
+  function useDataProviderMulti<EachDataProviderName extends DataProviderNames[]>(
+    dataProviderSources: (
+      | EachDataProviderName[number]
+      | DataProviders[EachDataProviderName[number]]
+      | undefined
+    )[],
+  ): (DataProviders[EachDataProviderName[number]] | undefined)[];
   export default useDataProviderMulti;
 }
 declare module 'renderer/hooks/papi-hooks/index' {

--- a/src/client/services/client-network-connector.service.ts
+++ b/src/client/services/client-network-connector.service.ts
@@ -324,6 +324,7 @@ export default class ClientNetworkConnector implements INetworkConnector {
         {
           data: message as unknown as string,
         } as MessageEvent,
+        /* eslint-enable */
         true,
       );
     } else {

--- a/src/extension-host/services/papi-backend.service.ts
+++ b/src/extension-host/services/papi-backend.service.ts
@@ -77,6 +77,8 @@ const papi = {
   /** JSDOC DESTINATION extensionStorageService */
   storage: extensionStorageService as ExtensionStorageService,
 };
+/* eslint-enable */
+
 export default papi;
 
 // This is the destructured export, if you add to the PAPI you need to add to this

--- a/src/renderer/components/docking/platform-dock-layout.component.test.ts
+++ b/src/renderer/components/docking/platform-dock-layout.component.test.ts
@@ -23,6 +23,7 @@ import {
   getFloatPosition,
   loadTab,
 } from './platform-dock-layout.component';
+/* eslint-enable */
 
 describe('Dock Layout Component', () => {
   const mockDockLayout = mock(DockLayout);

--- a/src/renderer/components/run-basic-checks-dialog/run-basic-checks-tab.component.tsx
+++ b/src/renderer/components/run-basic-checks-dialog/run-basic-checks-tab.component.tsx
@@ -84,7 +84,7 @@ export default function RunBasicChecksTab({
     );
   };
 
-  const project = useProjectDataProvider(currentProjectId, 'ParatextStandard');
+  const project = useProjectDataProvider('ParatextStandard', currentProjectId);
 
   const [projectString] = usePromise(
     useMemo(() => {

--- a/src/renderer/components/run-basic-checks-dialog/run-basic-checks-tab.component.tsx
+++ b/src/renderer/components/run-basic-checks-dialog/run-basic-checks-tab.component.tsx
@@ -84,7 +84,7 @@ export default function RunBasicChecksTab({
     );
   };
 
-  const project = useProjectDataProvider<'ParatextStandard'>(currentProjectId);
+  const project = useProjectDataProvider(currentProjectId, 'ParatextStandard');
 
   const [projectString] = usePromise(
     useMemo(() => {

--- a/src/renderer/global-this.model.ts
+++ b/src/renderer/global-this.model.ts
@@ -60,8 +60,7 @@ type ReactDOMClientType = typeof ReactDOMClient;
 type SillsdevScriptureType = typeof SillsdevScripture;
 type WebViewRequire = typeof webViewRequire;
 
-/* eslint-disable vars-on-top */
-/* eslint-disable no-var */
+/* eslint-disable vars-on-top, no-var */
 declare global {
   var papi: Papi;
   var React: typeof React;

--- a/src/renderer/hooks/papi-hooks/use-data-provider-multi.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-data-provider-multi.hook.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
-import IDataProvider from '@shared/models/data-provider.interface';
 import { isString } from '@shared/utils/util';
 import dataProviderService from '@shared/services/data-provider.service';
 import logger from '@shared/services/logger.service';
+import { DataProviderNames, DataProviders } from 'papi-shared-types';
 
 /**
  * Gets an array of data providers based on an array of input sources
@@ -29,11 +29,18 @@ import logger from '@shared/services/logger.service';
  */
 // We don't know what types the data providers serve
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function useDataProviderMulti<T extends IDataProvider<any>[]>(
-  dataProviderSources: (string | T[number] | undefined)[],
-): (T[number] | undefined)[] {
-  type InputType = string | T[number] | undefined;
-  type OutputType = T[number] | undefined;
+function useDataProviderMulti<EachDataProviderName extends DataProviderNames[]>(
+  dataProviderSources: (
+    | EachDataProviderName[number]
+    | DataProviders[EachDataProviderName[number]]
+    | undefined
+  )[],
+): (DataProviders[EachDataProviderName[number]] | undefined)[] {
+  type InputType =
+    | EachDataProviderName[number]
+    | DataProviders[EachDataProviderName[number]]
+    | undefined;
+  type OutputType = DataProviders[EachDataProviderName[number]] | undefined;
 
   const [dataProviders, setDataProviders] = useState(() =>
     Array<OutputType>(dataProviderSources.length),

--- a/src/renderer/hooks/papi-hooks/use-data-provider.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-data-provider.hook.ts
@@ -1,6 +1,7 @@
 import dataProviderService from '@shared/services/data-provider.service';
-import IDataProvider from '@shared/models/data-provider.interface';
 import createUseNetworkObjectHook from '@renderer/hooks/hook-generators/create-use-network-object-hook.util';
+import { DataProviderNames, DataProviders } from 'papi-shared-types';
+import IDataProvider from '@shared/models/data-provider.interface';
 
 /**
  * Gets a data provider with specified provider name
@@ -13,13 +14,15 @@ import createUseNetworkObjectHook from '@renderer/hooks/hook-generators/create-u
  *   retrieved and is not disposed, and undefined again if the data provider is disposed
  */
 
-// We don't know what type the data provider serves
+// Assert to the specific data provider types for this hook
 // eslint-disable-next-line no-type-assertion/no-type-assertion
-const useDataProvider = createUseNetworkObjectHook(dataProviderService.get) as <
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  T extends IDataProvider<any>,
->(
-  dataProviderSource: string | T | undefined,
-) => T | undefined;
+const useDataProvider = createUseNetworkObjectHook(
+  // Type assert to more general function signature because the hook wants it to be more general.
+  // This is fine in this case since we're also casting the hook itself to the correct specific type
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  dataProviderService.get as (providerName: string) => Promise<IDataProvider | undefined>,
+) as <DataProviderName extends DataProviderNames>(
+  dataProviderSource: DataProviderName | DataProviders[DataProviderName] | undefined,
+) => DataProviders[DataProviderName] | undefined;
 
 export default useDataProvider;

--- a/src/renderer/hooks/papi-hooks/use-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-data.hook.ts
@@ -17,21 +17,17 @@ type UseDataHook = {
     dataProviderSource: DataProviderName | DataProviders[DataProviderName] | undefined,
   ): {
     [TDataType in keyof DataProviderTypes[DataProviderName]]: (
-      // @ts-expect-error For some reason, TypeScript pretends it can't find `selector`, but it
-      // works just fine
+      // @ts-expect-error TypeScript pretends it can't find `selector`, but it works just fine
       selector: DataProviderTypes[DataProviderName][TDataType]['selector'],
-      // @ts-expect-error For some reason, TypeScript pretends it can't find `getData`, but it
-      // works just fine
+      // @ts-expect-error TypeScript pretends it can't find `getData`, but it works just fine
       defaultValue: DataProviderTypes[DataProviderName][TDataType]['getData'],
       subscriberOptions?: DataProviderSubscriberOptions,
     ) => [
-      // @ts-expect-error For some reason, TypeScript pretends it can't find `getData`, but it
-      // works just fine
+      // @ts-expect-error TypeScript pretends it can't find `getData`, but it works just fine
       DataProviderTypes[DataProviderName][TDataType]['getData'],
       (
         | ((
-            // @ts-expect-error For some reason, TypeScript pretends it can't find `setData`, but it
-            // works just fine
+            // @ts-expect-error TypeScript pretends it can't find `setData`, but it works just fine
             newData: DataProviderTypes[DataProviderName][TDataType]['setData'],
           ) => Promise<DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>>)
         | undefined

--- a/src/renderer/hooks/papi-hooks/use-project-data-provider.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data-provider.hook.ts
@@ -6,14 +6,19 @@ import IDataProvider from '@shared/models/data-provider.interface';
 /**
  * Gets a project data provider with specified provider name
  *
+ * @type `ProjectType` - The `projectType` for the project to use. The returned project data
+ *   provider will have the project data provider type associated with this project type.
+ *   Alternatively, specify this as the second argument to this function for Intellisense support
  * @param projectDataProviderSource String name of the id of the project to get OR
  *   projectDataProvider (result of useProjectDataProvider, if you want this hook to just return the
  *   data provider again)
- * @returns Undefined if the project data provider has not been retrieved, the requested project
+ * @param projectType Indicates what you expect the `projectType` to be for the project with the
+ *   specified id. Currently, this does nothing but indicate to TypeScript what type the Project
+ *   Data Provider is. This is an alternative way to specify the `ProjectType` generic type.
+ *   Optional.
+ * @returns `undefined` if the project data provider has not been retrieved, the requested project
  *   data provider if it has been retrieved and is not disposed, and undefined again if the project
  *   data provider is disposed
- * @ProjectType `ProjectType` - the project type for the project to use. The returned project data
- * provider will have the project data provider type associated with this project type.
  */
 
 // Assert to specific data type for this hook.
@@ -21,7 +26,8 @@ import IDataProvider from '@shared/models/data-provider.interface';
 const useProjectDataProvider = createUseNetworkObjectHook(
   papiFrontendProjectDataProviderService.getProjectDataProvider,
 ) as <ProjectType extends ProjectTypes>(
-  projectDataProviderSource: ProjectType | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+  projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+  projectType?: ProjectType,
 ) => IDataProvider<ProjectDataTypes[ProjectType]> | undefined;
 
 export default useProjectDataProvider;

--- a/src/renderer/hooks/papi-hooks/use-project-data-provider.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data-provider.hook.ts
@@ -21,7 +21,7 @@ import IDataProvider from '@shared/models/data-provider.interface';
 const useProjectDataProvider = createUseNetworkObjectHook(
   papiFrontendProjectDataProviderService.getProjectDataProvider,
 ) as <ProjectType extends ProjectTypes>(
-  projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+  projectDataProviderSource: ProjectType | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
 ) => IDataProvider<ProjectDataTypes[ProjectType]> | undefined;
 
 export default useProjectDataProvider;

--- a/src/renderer/hooks/papi-hooks/use-project-data-provider.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data-provider.hook.ts
@@ -4,18 +4,35 @@ import createUseNetworkObjectHook from '@renderer/hooks/hook-generators/create-u
 import IDataProvider from '@shared/models/data-provider.interface';
 
 /**
- * Gets a project data provider with specified provider name
+ * Takes the parameters passed into the hook and returns the `projectDataProviderSource` associated
+ * with those parameters.
  *
- * @type `ProjectType` - The `projectType` for the project to use. The returned project data
- *   provider will have the project data provider type associated with this project type.
- *   Alternatively, specify this as the second argument to this function for Intellisense support
+ * @param projectType Indicates what you expect the `projectType` to be for the project with the
+ *   specified id. The TypeScript type for the returned project data provider will have the project
+ *   data provider type associated with this project type. If this argument does not match the
+ *   project's actual `projectType` (according to its metadata), a warning will be logged
  * @param projectDataProviderSource String name of the id of the project to get OR
  *   projectDataProvider (result of useProjectDataProvider, if you want this hook to just return the
  *   data provider again)
+ * @returns `projectDataProviderSource` for getting the project data provider
+ */
+function mapParametersToProjectDataProviderSource<ProjectType extends ProjectTypes>(
+  _projectType: ProjectType,
+  projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+) {
+  return projectDataProviderSource;
+}
+
+/**
+ * Gets a project data provider with specified provider name
+ *
  * @param projectType Indicates what you expect the `projectType` to be for the project with the
- *   specified id. Currently, this does nothing but indicate to TypeScript what type the Project
- *   Data Provider is. This is an alternative way to specify the `ProjectType` generic type.
- *   Optional.
+ *   specified id. The TypeScript type for the returned project data provider will have the project
+ *   data provider type associated with this project type. If this argument does not match the
+ *   project's actual `projectType` (according to its metadata), a warning will be logged
+ * @param projectDataProviderSource String name of the id of the project to get OR
+ *   projectDataProvider (result of useProjectDataProvider, if you want this hook to just return the
+ *   data provider again)
  * @returns `undefined` if the project data provider has not been retrieved, the requested project
  *   data provider if it has been retrieved and is not disposed, and undefined again if the project
  *   data provider is disposed
@@ -25,9 +42,10 @@ import IDataProvider from '@shared/models/data-provider.interface';
 // eslint-disable-next-line no-type-assertion/no-type-assertion
 const useProjectDataProvider = createUseNetworkObjectHook(
   papiFrontendProjectDataProviderService.getProjectDataProvider,
+  mapParametersToProjectDataProviderSource,
 ) as <ProjectType extends ProjectTypes>(
+  projectType: ProjectType,
   projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
-  projectType?: ProjectType,
 ) => IDataProvider<ProjectDataTypes[ProjectType]> | undefined;
 
 export default useProjectDataProvider;

--- a/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
@@ -1,16 +1,18 @@
 import createUseDataHook from '@renderer/hooks/hook-generators/create-use-data-hook.util';
 import {
-  DataProviderDataTypes,
   DataProviderSubscriberOptions,
   DataProviderUpdateInstructions,
 } from '@shared/models/data-provider.model';
 import IDataProvider from '@shared/models/data-provider.interface';
 import useProjectDataProvider from '@renderer/hooks/papi-hooks/use-project-data-provider.hook';
+import { ProjectDataTypes, ProjectTypes } from 'papi-shared-types';
 
 /**
- * Proxy object that provides hooks to use project data provider data with various data types
+ * React hook to use data from a project data provider
  *
  * @example `useProjectData.VerseUSFM<ProjectDataTypes['ParatextStandard'], 'VerseUSFM'>(...);`
+ *
+ * @example `useProjectData('<project_id>', 'ParatextStandard').VerseUSFM(...)`
  *
  * @type `TProjectDataTypes` - The project data types associated with the `projectType` used. You
  *   can specify this type with `ProjectDataTypes['<project_type>']`
@@ -23,28 +25,42 @@ import useProjectDataProvider from '@renderer/hooks/papi-hooks/use-project-data-
  *   because it refused to accept that `'selector'` was a valid member:
  *   `ProjectDataTypes[ProjectType][TDataType]['selector']`
  *
- *   As such, this hook proxy actually has the same types as `UseDataHook` but with a couple of things
- *   renamed for easier readability.
+ *   # As such, this hook proxy actually has the same types as `UseDataHook` but with a couple of things
+ *
+ *   Renamed for easier readability.
+ * @type `ProjectType` - The `projectType` of the project whose data to retrieve. Alternatively,
+ *   specify this as the second argument to the `useProjectData` function for Intellisense support
  */
 type UseProjectDataHook = {
-  [DataType in string]: <
-    TProjectDataTypes extends DataProviderDataTypes,
-    TDataType extends keyof TProjectDataTypes,
-  >(
-    projectDataProviderSource: string | IDataProvider<TProjectDataTypes> | undefined,
-    selector: TProjectDataTypes[TDataType]['selector'],
-    defaultValue: TProjectDataTypes[TDataType]['getData'],
-    subscriberOptions?: DataProviderSubscriberOptions,
-  ) => [
-    TProjectDataTypes[TDataType]['getData'],
-    (
-      | ((
-          newData: TProjectDataTypes[TDataType]['setData'],
-        ) => Promise<DataProviderUpdateInstructions<TProjectDataTypes>>)
-      | undefined
-    ),
-    boolean,
-  ];
+  // Here we do not use `ProjectType extends ProjectTypes` because `useProjectData<''>` Intellisense
+  // was not working to show the options. Whereas `useProjectData<ProjectDataTypes['']>` does
+  <ProjectType extends ProjectTypes>(
+    projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+    projectType?: ProjectType,
+  ): {
+    [TDataType in keyof ProjectDataTypes[ProjectType]]: (
+      // @ts-expect-error For some reason, TypeScript pretends it can't find `selector`, but it
+      // works just fine
+      selector: ProjectDataTypes[ProjectType][TDataType]['selector'],
+      // @ts-expect-error For some reason, TypeScript pretends it can't find `getData`, but it
+      // works just fine
+      defaultValue: ProjectDataTypes[ProjectType][TDataType]['getData'],
+      subscriberOptions?: DataProviderSubscriberOptions,
+    ) => [
+      // @ts-expect-error For some reason, TypeScript pretends it can't find `getData`, but it
+      // works just fine
+      ProjectDataTypes[ProjectType][TDataType]['getData'],
+      (
+        | ((
+            // @ts-expect-error For some reason, TypeScript pretends it can't find `setData`, but it
+            // works just fine
+            newData: ProjectDataTypes[ProjectType][TDataType]['setData'],
+          ) => Promise<DataProviderUpdateInstructions<ProjectDataTypes[ProjectType]>>)
+        | undefined
+      ),
+      boolean,
+    ];
+  };
 };
 
 // Note: the following comment uses ＠, not the actual @ character, to hackily provide @param and
@@ -52,45 +68,41 @@ type UseProjectDataHook = {
 // put this comment on an actual function, so we can fix the comments back to using real @
 /**
  * ```typescript
- * useProjectData.DataType<TProjectDataTypes extends DataProviderDataTypes, TDataType extends keyof TProjectDataTypes>(
- *   projectDataProviderSource: string | IDataProvider<TProjectDataTypes> | undefined,
- *   selector: TProjectDataTypes[TDataType]['selector'],
- *   defaultValue: TProjectDataTypes[TDataType]['getData'],
- *   subscriberOptions?: DataProviderSubscriberOptions,
- * ): [
- *   TProjectDataTypes[TDataType]['getData'],
- *   (
- *     | ((
- *         newData: TProjectDataTypes[TDataType]['setData'],
- *       ) => Promise<DataProviderUpdateInstructions<TProjectDataTypes>>)
- *     | undefined
- *   ),
- *   boolean,
- * ]
+ * useProjectData<ProjectType extends ProjectTypes>(
+ *     projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+ *     projectType?: ProjectType,
+ *   ).DataType(
+ *       selector: ProjectDataTypes[ProjectType][DataType]['selector'],
+ *       defaultValue: ProjectDataTypes[ProjectType][DataType]['getData'],
+ *       subscriberOptions?: DataProviderSubscriberOptions,
+ *     ) => [
+ *       ProjectDataTypes[ProjectType][DataType]['getData'],
+ *       (
+ *         | ((
+ *             newData: ProjectDataTypes[ProjectType][DataType]['setData'],
+ *           ) => Promise<DataProviderUpdateInstructions<ProjectDataTypes[ProjectType]>>)
+ *         | undefined
+ *       ),
+ *       boolean,
+ *     ]
  * ```
  *
- * Special React hook that subscribes to run a callback on a project data provider's data with
- * specified selector on any data type that the project data provider serves according to its
- * projectType.
+ * React hook to use data from a project data provider. Subscribes to run a callback on a project
+ * data provider's data with specified selector on the specified data type that the project data
+ * provider serves according to its `projectType`.
  *
- * Usage: Specify the data type on the project data provider with `useProjectData.<data_type>` and
- * use like any other React hook. Specify the generic types in order to receive type support from
- * Intellisense. For example, `useProjectData.VerseUSFM<ProjectDataTypes['ParatextStandard'],
- * 'VerseUSFM'>` lets you subscribe to verse USFM from a project data provider for the
- * `ParatextStandard` `projectType`.
+ * Usage: Specify the project id, the project type, and the data type on the project data provider
+ * with `useProjectData('<project_id>', '<project_type>').<data_type>` and use like any other React
+ * hook.
  *
- * _＠example_ When subscribing to JHN 11:35 Verse USFM info on a `ParatextStandard` project with
- * projectId `32664dc3288a28df2e2bb75ded887fc8f17a15fb`, we need to tell the
- * `useProjectData.VerseUSFM` hook what types we are using, so we specify the project data types as
- * `ProjectDataTypes['ParatextStandard']` and specify that we are using the `'VerseUSFM'` data type
- * as follows:
+ * _＠example_ Subscribing to Verse USFM info at JHN 11:35 on a `ParatextStandard` project with
+ * projectId `32664dc3288a28df2e2bb75ded887fc8f17a15fb`:
  *
  * ```typescript
- * const [verse, setVerse, verseIsLoading] = useProjectData.VerseUSFM<
- *   ProjectDataTypes['ParatextStandard'],
- *   'Verse'
- * >(
+ * const [verse, setVerse, verseIsLoading] = useProjectData(
  *   '32664dc3288a28df2e2bb75ded887fc8f17a15fb',
+ *   'ParatextStandard',
+ * ).VerseUSFM(
  *   useMemo(() => new VerseRef('JHN', '11', '35', ScrVers.English), []),
  *   'Loading verse ',
  * );
@@ -100,7 +112,14 @@ type UseProjectDataHook = {
  * projectDataProvider (result of useProjectDataProvider if you want to consolidate and only get the
  * project data provider once)
  *
+ * _＠param_ `projectType` indicates what you expect the `projectType` to be for the project with the
+ * specified id. Currently, this does nothing but indicate to TypeScript what type the Project Data
+ * Provider is. This is an alternative way to specify the `ProjectType` generic type. Optional.
+ *
  * _＠param_ `selector` tells the provider what data this listener is listening for
+ *
+ * WARNING: MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not be
+ * updated every render
  *
  * _＠param_ `defaultValue` the initial value to return while first awaiting the data
  *
@@ -114,24 +133,12 @@ type UseProjectDataHook = {
  *
  * _＠returns_ `[data, setData, isLoading]`
  *
- * - `data`: the current value for the data from the project data provider for the specified project
- *   id with the specified data type and selector, either the defaultValue or the resolved data
- * - `setData`: asynchronous function to request that the data provider for the specified project id
- *   update the data at this data type and selector. Returns true if successful. Note that this
- *   function does not update the data. The project data provider sends out an update to this
- *   subscription if it successfully updates data.
- * - `isLoading`: whether the data with the data type and selector is awaiting retrieval from the
- *   project data provider for this project id
- *
- * _＠type_ `TProjectDataTypes` - the project data types associated with the `projectType` used. You
- * can specify this type with `ProjectDataTypes['<project_type>']`
- *
- * _＠type_ `TDataType` - the specific data type on this project you want to use. Must match the data
- * type specified in `useProjectData.<data_type>`
+ * _＠type_ `ProjectType` - the `projectType` of the project whose data to retrieve. Alternatively,
+ * specify this as the second argument to the `useProjectData` function for Intellisense support
  */
 // Assert the more general and more specific types.
 /* eslint-disable no-type-assertion/no-type-assertion */
-const useProjectData: UseProjectDataHook = createUseDataHook(
+const useProjectData = createUseDataHook(
   useProjectDataProvider as (
     dataProviderSource: string | IDataProvider | undefined,
   ) => IDataProvider | undefined,

--- a/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
@@ -18,21 +18,17 @@ type UseProjectDataHook = {
     projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
   ): {
     [TDataType in keyof ProjectDataTypes[ProjectType]]: (
-      // @ts-expect-error For some reason, TypeScript pretends it can't find `selector`, but it
-      // works just fine
+      // @ts-expect-error TypeScript pretends it can't find `selector`, but it works just fine
       selector: ProjectDataTypes[ProjectType][TDataType]['selector'],
-      // @ts-expect-error For some reason, TypeScript pretends it can't find `getData`, but it
-      // works just fine
+      // @ts-expect-error TypeScript pretends it can't find `getData`, but it works just fine
       defaultValue: ProjectDataTypes[ProjectType][TDataType]['getData'],
       subscriberOptions?: DataProviderSubscriberOptions,
     ) => [
-      // @ts-expect-error For some reason, TypeScript pretends it can't find `getData`, but it
-      // works just fine
+      // @ts-expect-error TypeScript pretends it can't find `getData`, but it works just fine
       ProjectDataTypes[ProjectType][TDataType]['getData'],
       (
         | ((
-            // @ts-expect-error For some reason, TypeScript pretends it can't find `setData`, but it
-            // works just fine
+            // @ts-expect-error TypeScript pretends it can't find `setData`, but it works just fine
             newData: ProjectDataTypes[ProjectType][TDataType]['setData'],
           ) => Promise<DataProviderUpdateInstructions<ProjectDataTypes[ProjectType]>>)
         | undefined

--- a/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
@@ -10,33 +10,12 @@ import { ProjectDataTypes, ProjectTypes } from 'papi-shared-types';
 /**
  * React hook to use data from a project data provider
  *
- * @example `useProjectData.VerseUSFM<ProjectDataTypes['ParatextStandard'], 'VerseUSFM'>(...);`
- *
- * @example `useProjectData('<project_id>', 'ParatextStandard').VerseUSFM(...)`
- *
- * @type `TProjectDataTypes` - The project data types associated with the `projectType` used. You
- *   can specify this type with `ProjectDataTypes['<project_type>']`
- * @type `TDataType` - The specific data type on this project you want to use. Must match the data
- *   type specified in `useProjectData.<data_type>`
- *
- *   Unfortunately, accessing properties from the `DataProviderDataType`s in `ProjectDataTypes` did
- *   not work. Maybe TypeScript refuses to look at all properties in each member of
- *   `ProjectDataTypes` and tell that they're all `DataProviderDataType`s. So this did not work
- *   because it refused to accept that `'selector'` was a valid member:
- *   `ProjectDataTypes[ProjectType][TDataType]['selector']`
- *
- *   # As such, this hook proxy actually has the same types as `UseDataHook` but with a couple of things
- *
- *   Renamed for easier readability.
- * @type `ProjectType` - The `projectType` of the project whose data to retrieve. Alternatively,
- *   specify this as the second argument to the `useProjectData` function for Intellisense support
+ * @example `useProjectData('ParatextStandard', 'project id').VerseUSFM(...);`
  */
 type UseProjectDataHook = {
-  // Here we do not use `ProjectType extends ProjectTypes` because `useProjectData<''>` Intellisense
-  // was not working to show the options. Whereas `useProjectData<ProjectDataTypes['']>` does
   <ProjectType extends ProjectTypes>(
+    projectType: ProjectType,
     projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
-    projectType?: ProjectType,
   ): {
     [TDataType in keyof ProjectDataTypes[ProjectType]]: (
       // @ts-expect-error For some reason, TypeScript pretends it can't find `selector`, but it
@@ -69,8 +48,8 @@ type UseProjectDataHook = {
 /**
  * ```typescript
  * useProjectData<ProjectType extends ProjectTypes>(
+ *     projectType: ProjectType,
  *     projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
- *     projectType?: ProjectType,
  *   ).DataType(
  *       selector: ProjectDataTypes[ProjectType][DataType]['selector'],
  *       defaultValue: ProjectDataTypes[ProjectType][DataType]['getData'],
@@ -91,8 +70,8 @@ type UseProjectDataHook = {
  * data provider's data with specified selector on the specified data type that the project data
  * provider serves according to its `projectType`.
  *
- * Usage: Specify the project id, the project type, and the data type on the project data provider
- * with `useProjectData('<project_id>', '<project_type>').<data_type>` and use like any other React
+ * Usage: Specify the project type, the project id, and the data type on the project data provider
+ * with `useProjectData('<project_type>', '<project_id>').<data_type>` and use like any other React
  * hook.
  *
  * _＠example_ Subscribing to Verse USFM info at JHN 11:35 on a `ParatextStandard` project with
@@ -100,21 +79,22 @@ type UseProjectDataHook = {
  *
  * ```typescript
  * const [verse, setVerse, verseIsLoading] = useProjectData(
- *   '32664dc3288a28df2e2bb75ded887fc8f17a15fb',
  *   'ParatextStandard',
+ *   '32664dc3288a28df2e2bb75ded887fc8f17a15fb',
  * ).VerseUSFM(
  *   useMemo(() => new VerseRef('JHN', '11', '35', ScrVers.English), []),
  *   'Loading verse ',
  * );
  * ```
  *
- * _＠param_ `projectDataProviderSource` string name of the id of the project to get OR
+ * _＠param_ `projectType` Indicates what you expect the `projectType` to be for the project with the
+ * specified id. The TypeScript type for the returned project data provider will have the project
+ * data provider type associated with this project type. If this argument does not match the
+ * project's actual `projectType` (according to its metadata), a warning will be logged
+ *
+ * _＠param_ `projectDataProviderSource` String name of the id of the project to get OR
  * projectDataProvider (result of useProjectDataProvider if you want to consolidate and only get the
  * project data provider once)
- *
- * _＠param_ `projectType` indicates what you expect the `projectType` to be for the project with the
- * specified id. Currently, this does nothing but indicate to TypeScript what type the Project Data
- * Provider is. This is an alternative way to specify the `ProjectType` generic type. Optional.
  *
  * _＠param_ `selector` tells the provider what data this listener is listening for
  *
@@ -132,14 +112,12 @@ type UseProjectDataHook = {
  * must not be updated every render
  *
  * _＠returns_ `[data, setData, isLoading]`
- *
- * _＠type_ `ProjectType` - the `projectType` of the project whose data to retrieve. Alternatively,
- * specify this as the second argument to the `useProjectData` function for Intellisense support
  */
 // Assert the more general and more specific types.
 /* eslint-disable no-type-assertion/no-type-assertion */
 const useProjectData = createUseDataHook(
   useProjectDataProvider as (
+    projectType: ProjectTypes,
     dataProviderSource: string | IDataProvider | undefined,
   ) => IDataProvider | undefined,
 ) as UseProjectDataHook;

--- a/src/renderer/services/papi-frontend.service.ts
+++ b/src/renderer/services/papi-frontend.service.ts
@@ -71,6 +71,8 @@ const papi = {
   /** JSDOC DESTINATION settingsService */
   settings: settingsService as SettingsService,
 };
+/* eslint-enable */
+
 export default papi;
 
 // If you add to the PAPI you need to add to this

--- a/src/renderer/testing/test-buttons-panel.component.tsx
+++ b/src/renderer/testing/test-buttons-panel.component.tsx
@@ -9,8 +9,6 @@ import { SavedTabInfo, TabInfo } from '@shared/data/web-view.model';
 import useEvent from '@renderer/hooks/papi-hooks/use-event.hook';
 import useData from '@renderer/hooks/papi-hooks/use-data.hook';
 import useDataProvider from '@renderer/hooks/papi-hooks/use-data-provider.hook';
-import type { PeopleDataProvider } from 'hello-someone';
-import type { QuickVerseDataTypes } from 'quick-verse';
 
 export const TAB_TYPE_BUTTONS = 'buttons';
 
@@ -143,7 +141,7 @@ export default function TestButtonsPanel() {
 
   // Test a method on a data provider engine that isn't on the interface to see if you can actually do this
   const [hasTestedRandomMethod, setHasTestedRandomMethod] = useState(false);
-  const peopleDataProvider = useDataProvider<PeopleDataProvider>('helloSomeone.people');
+  const peopleDataProvider = useDataProvider('helloSomeone.people');
   if (!hasTestedRandomMethod && peopleDataProvider) {
     setHasTestedRandomMethod(true);
     (async () => {
@@ -167,8 +165,7 @@ export default function TestButtonsPanel() {
 
   // We need to tell the useData.Verse hook what types we are using, so we get the Verse data types
   // from the quick verse data types
-  const [verseText, setVerseText, verseTextIsLoading] = useData.Verse<QuickVerseDataTypes, 'Verse'>(
-    'quickVerse.quickVerse',
+  const [verseText, setVerseText, verseTextIsLoading] = useData('quickVerse.quickVerse').Verse(
     verseRef,
     'Verse text goes here',
   );

--- a/src/renderer/testing/test-quick-verse-heresy-panel.component.tsx
+++ b/src/renderer/testing/test-quick-verse-heresy-panel.component.tsx
@@ -3,7 +3,6 @@ import useData from '@renderer/hooks/papi-hooks/use-data.hook';
 import { SavedTabInfo, TabInfo } from '@shared/data/web-view.model';
 import { debounce } from '@shared/utils/util';
 import { useState, useMemo, useCallback } from 'react';
-import type { QuickVerseDataTypes } from 'quick-verse';
 import { TextField } from 'papi-components';
 
 export const TAB_TYPE_QUICK_VERSE_HERESY = 'quick-verse-heresy';
@@ -28,8 +27,7 @@ export function TestQuickVerseHeresyPanel() {
     [setVerseRefDebounced],
   );
 
-  const [heresyText, setHeresyText] = useData.Heresy<QuickVerseDataTypes, 'Heresy'>(
-    'quickVerse.quickVerse',
+  const [heresyText, setHeresyText] = useData('quickVerse.quickVerse').Heresy(
     verseRef,
     'Verse text goes here',
   );

--- a/src/shared/global-this.model.ts
+++ b/src/shared/global-this.model.ts
@@ -1,6 +1,3 @@
-/* eslint-disable vars-on-top */
-/* eslint-disable no-var */
-
 import { LogLevel } from 'electron-log';
 import { FunctionComponent } from 'react';
 import {
@@ -17,6 +14,7 @@ import {
  * (renderer), and extension-host.ts (extension host)
  */
 
+/* eslint-disable vars-on-top, no-var */
 declare global {
   /** Type of process this is. Helps with running specific code based on which process you're in */
   var processType: ProcessType;
@@ -56,6 +54,7 @@ declare global {
   /** JSDOC DESTINATION UpdateWebViewDefinition */
   var updateWebViewDefinition: UpdateWebViewDefinition;
 }
+/* eslint-enable */
 
 /** Type of Paranext process */
 // eslint-disable-next-line import/prefer-default-export

--- a/src/shared/models/data-provider-engine.model.ts
+++ b/src/shared/models/data-provider-engine.model.ts
@@ -100,6 +100,7 @@ export type WithNotifyUpdate<TDataTypes extends DataProviderDataTypes> = {
  * }
  * ```
  */
+// Try using DataProviderName here instead of TDataTypes?
 type IDataProviderEngine<TDataTypes extends DataProviderDataTypes = DataProviderDataTypes> =
   NetworkableObject &
     /**

--- a/src/shared/models/data-provider.interface.ts
+++ b/src/shared/models/data-provider.interface.ts
@@ -1,5 +1,10 @@
-import DataProviderInternal, { DataProviderDataTypes } from '@shared/models/data-provider.model';
-import { DisposableNetworkObject, NetworkObject } from '@shared/models/network-object.model';
+import {
+  DataProviderDataTypes,
+  DataProviderGetters,
+  DataProviderSetters,
+  DataProviderSubscribers,
+} from '@shared/models/data-provider.model';
+import { Dispose, OnDidDispose } from './disposal.model';
 
 /**
  * An object on the papi that manages data and has methods for interacting with that data. Created
@@ -9,9 +14,14 @@ import { DisposableNetworkObject, NetworkObject } from '@shared/models/network-o
  * Note: each `set<data_type>` method has a corresponding `get<data_type>` and
  * `subscribe<data_type>` method.
  */
-// Basically a layer over NetworkObject
+// Basically a layer over NetworkObject from DataProviderInternal.
+// Used to be `NetworkObject<DataProviderInternal<TDataTypes>>`, but it had problems with `infer`
+// See https://github.com/paranext/paranext-core/issues/318#issuecomment-1791317605 for more info
 type IDataProvider<TDataTypes extends DataProviderDataTypes = DataProviderDataTypes> =
-  NetworkObject<DataProviderInternal<TDataTypes>>;
+  DataProviderSetters<TDataTypes> &
+    DataProviderGetters<TDataTypes> &
+    DataProviderSubscribers<TDataTypes> &
+    OnDidDispose;
 
 export default IDataProvider;
 
@@ -23,8 +33,10 @@ export default IDataProvider;
  * @see IDataProvider
  */
 // Basically a layer over DisposableNetworkObject
-export type IDisposableDataProvider<
-  TDataTypes extends DataProviderDataTypes = DataProviderDataTypes,
-> =
-  // Need to omit dispose here because it is optional on IDataProvider but is required on DisposableNetworkObject
-  DisposableNetworkObject<Omit<IDataProvider<TDataTypes>, 'dispose'>>;
+// Used to be `DisposableNetworkObject<Omit<IDataProvider<TDataTypes>, 'dispose'>>`, , but it had
+// problems with `infer`. See https://github.com/paranext/paranext-core/issues/318#issuecomment-1791317605
+// for more info
+// Seems TypeScript doesn't like using a generic string to index DataProviderDataTypes
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type IDisposableDataProvider<TDataProvider extends IDataProvider<any>> = TDataProvider &
+  Dispose;

--- a/src/shared/models/extract-data-provider-data-types.model.ts
+++ b/src/shared/models/extract-data-provider-data-types.model.ts
@@ -1,0 +1,25 @@
+import IDataProviderEngine from '@shared/models/data-provider-engine.model';
+import IDataProvider, { IDisposableDataProvider } from '@shared/models/data-provider.interface';
+import DataProviderInternal from '@shared/models/data-provider.model';
+
+/**
+ * Get the `DataProviderDataTypes` associated with the `IDataProvider` - essentially, returns
+ * `TDataTypes` from `IDataProvider<TDataTypes>`.
+ *
+ * Works with generic types `IDataProvider`, `DataProviderInternal`, `IDisposableDataProvider`, and
+ * `IDataProviderEngine` along with the `papi-shared-types` extensible interfaces `DataProviders`
+ * and `DisposableDataProviders`
+ */
+type ExtractDataProviderDataTypes<TDataProvider> = TDataProvider extends IDataProvider<
+  infer TDataProviderDataTypes
+>
+  ? TDataProviderDataTypes
+  : TDataProvider extends DataProviderInternal<infer TDataProviderDataTypes>
+  ? TDataProviderDataTypes
+  : TDataProvider extends IDisposableDataProvider<infer TDataProviderDataTypes>
+  ? TDataProviderDataTypes
+  : TDataProvider extends IDataProviderEngine<infer TDataProviderDataTypes>
+  ? TDataProviderDataTypes
+  : never;
+
+export default ExtractDataProviderDataTypes;

--- a/src/shared/models/project-data-provider-engine.model.ts
+++ b/src/shared/models/project-data-provider-engine.model.ts
@@ -2,21 +2,15 @@ import { ProjectTypes, ProjectDataTypes } from 'papi-shared-types';
 import type IDataProvider from 'shared/models/data-provider.interface';
 import type IDataProviderEngine from 'shared/models/data-provider-engine.model';
 
-// This enforces all the keys match ProjectDataTypes
-type IDataProviderEngineGeneric<T extends ProjectDataTypes> = {
-  [K in keyof T]: IDataProviderEngine<T[K]>;
-};
-
 /** All possible types for ProjectDataProviderEngines: IDataProviderEngine<ProjectDataType> */
-export type ProjectDataProviderEngineTypes = IDataProviderEngineGeneric<ProjectDataTypes>;
-
-// This enforces all the keys match ProjectDataTypes
-type IProjectDataProviderGeneric<T extends ProjectDataTypes> = {
-  [K in keyof T]: IDataProvider<T[K]>;
+export type ProjectDataProviderEngineTypes = {
+  [ProjectType in ProjectTypes]: IDataProviderEngine<ProjectDataTypes[ProjectType]>;
 };
 
 /** All possible types for ProjectDataProviders: IDataProvider<ProjectDataType> */
-export type ProjectDataProvider = IProjectDataProviderGeneric<ProjectDataTypes>;
+export type ProjectDataProvider = {
+  [ProjectType in ProjectTypes]: IDataProvider<ProjectDataTypes[ProjectType]>;
+};
 
 export interface ProjectDataProviderEngineFactory<ProjectType extends ProjectTypes> {
   createProjectDataProviderEngine(

--- a/src/shared/services/project-data-provider.service.ts
+++ b/src/shared/services/project-data-provider.service.ts
@@ -90,36 +90,25 @@ export async function registerProjectDataProviderEngineFactory<ProjectType exten
 }
 
 /**
- * Get a Project Data Provider for the given project ID. For types to work properly, specify the
- * project type as a generic parameter.
+ * Get a Project Data Provider for the given project ID.
  *
  * @example
  *
  * ```typescript
- * const pdp = await getProjectDataProvider<'ParatextStandard'>('ProjectID12345');
+ * const pdp = await getProjectDataProvider('ParatextStandard', 'ProjectID12345');
  * pdp.getVerse(new VerseRef('JHN', '1', '1'));
  * ```
  *
- * @example
- *
- * ```typescript
- * const pdp = await getProjectDataProvider('ProjectID12345', 'ParatextStandard');
- * pdp.getVerse(new VerseRef('JHN', '1', '1'));
- * ```
- *
- * @type `ProjectType` - The `projectType` for the project to use. The returned project data
- *   provider will have the project data provider type associated with this project type.
- *   Alternatively, specify this as the second argument to this function for Intellisense support
- * @param projectId ID for the project to load
  * @param projectType Indicates what you expect the `projectType` to be for the project with the
- *   specified id. Currently, this does nothing but indicate to TypeScript what type the Project
- *   Data Provider is. This is an alternative way to specify the `ProjectType` generic type.
- *   Optional.
+ *   specified id. The TypeScript type for the returned project data provider will have the project
+ *   data provider type associated with this project type. If this argument does not match the
+ *   project's actual `projectType` (according to its metadata), a warning will be logged
+ * @param projectId ID for the project to load
  * @returns Data provider with types that are associated with the given project type
  */
 export async function getProjectDataProvider<ProjectType extends ProjectTypes>(
+  projectType: ProjectType,
   projectId: string,
-  projectType?: ProjectType,
 ): Promise<ProjectDataProvider[ProjectType]> {
   const metadata = await projectLookupService.getMetadataForProject(projectId);
   const { projectType: projectTypeFromMetadata } = metadata;

--- a/src/shared/services/project-data-provider.service.ts
+++ b/src/shared/services/project-data-provider.service.ts
@@ -107,8 +107,9 @@ export async function registerProjectDataProviderEngineFactory<ProjectType exten
  * pdp.getVerse(new VerseRef('JHN', '1', '1'));
  * ```
  *
- * @type `ProjectType` - The `projectType` of the project whose data to retrieve. Alternatively,
- *   specify this as the second argument to this function for Intellisense support
+ * @type `ProjectType` - The `projectType` for the project to use. The returned project data
+ *   provider will have the project data provider type associated with this project type.
+ *   Alternatively, specify this as the second argument to this function for Intellisense support
  * @param projectId ID for the project to load
  * @param projectType Indicates what you expect the `projectType` to be for the project with the
  *   specified id. Currently, this does nothing but indicate to TypeScript what type the Project


### PR DESCRIPTION
Now you don't need to get and specify a bunch of `IDataProvider`s and `DataProviderDataTypes` from other extensions in order to get the proper types for data providers.

`papi.dataProvider.get('data provider name')`
`useData('data provider name').DataType(selector, default, options)`
`useProjectData('project id', 'project type').DataType(selector, default, options)`

*Note: I may try to swap the parameters for `useProjectData` in a commit in a bit. The changes may be strange, though, so I may leave it in the end

Relates to #318

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/630)
<!-- Reviewable:end -->
