### PR TITLE
Show `nav-operations`

### DIFF
--- a/src/renderer/components/docking/platform-dock-layout.component.css
+++ b/src/renderer/components/docking/platform-dock-layout.component.css
@@ -41,10 +41,6 @@
   border-left: 0;
 }
 
-.dock-layout .dock-panel.dock-style-platform-bible .dock-tab:nth-last-child(2) {
-  border-right: 0;
-}
-
 .dock-layout .dock-panel.dock-style-platform-bible .dock-nav {
   border-left: 1px solid #5c5c5c;
   border-right: 1px solid #5c5c5c;
@@ -108,7 +104,6 @@
   border-top: 0;
 }
 
-/* Hide tab group overflow button when the button is not needed */
-.dock-layout .dock-nav-operations-hidden {
-  display: none;
+.dock-panel.dock-style-card .dock-extra-content {
+  height: 30px;
 }

--- a/src/renderer/components/docking/platform-dock-layout.component.tsx
+++ b/src/renderer/components/docking/platform-dock-layout.component.tsx
@@ -96,7 +96,7 @@ const TAB_GROUP = 'card platform-bible';
 
 const groups: { [key: string]: TabGroup } = {
   [TAB_GROUP]: {
-    maximizable: false, // Don't allow groups of tabs to be maximized
+    maximizable: true, // Allow groups of tabs to be maximized
     floatable: true, // Allow tabs to be floated
     animated: false, // Don't animate tab transitions
     // TODO: Currently allowing newWindow crashes since electron doesn't seem to have window.open defined?


### PR DESCRIPTION
- allow tab group maximize:
  ![image](https://github.com/paranext/paranext-core/assets/5582153/0b04f648-f34b-4cd6-9ea5-aa5ab9ee30a6)

- This change also permanently fixes the flickering tab issue #66.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/633)
<!-- Reviewable:end -->
