### PR TITLE
Improve PAPI imports

### DIFF
--- a/extensions/src/hello-someone/hello-someone.ts
+++ b/extensions/src/hello-someone/hello-someone.ts
@@ -1,4 +1,4 @@
-import papi from 'papi-backend';
+import papi, { logger } from 'papi-backend';
 import type { ExecutionActivationContext } from 'extension-host/extension-types/extension-activation-context.model';
 import type {
   WebViewContentType,
@@ -12,32 +12,35 @@ import type { WithNotifyUpdate } from 'shared/models/data-provider-engine.model'
 import type { IWebViewProvider } from 'shared/models/web-view-provider.model';
 import helloSomeoneHtmlWebView from './hello-someone.web-view.html?inline';
 
-const { logger } = papi;
 logger.info('Hello Someone is importing!');
 
 /**
  * Example data provider engine that provides information about people.
  *
  * It has three data types:
- *  - Greeting: a person's greeting
- *  - Age: a person's age
- *  - People: information about all the people associated with this engine
+ *
+ * - Greeting: a person's greeting
+ * - Age: a person's age
+ * - People: information about all the people associated with this engine
  *
  * For each data type, an engine needs a `get<data_type>` and a `set<data_type>`.
  *
- * papi will create a data provider that internally uses this engine. The data provider layers over
+ * Papi will create a data provider that internally uses this engine. The data provider layers over
  * this engine and adds functionality like `subscribe<data_type>` functions with automatic updates.
  *
  * This data provider engine is defined by an object, which we recommend starting with to get
  * comfortable with the data provider api because of the following pros and cons:
- *  - Pros
- *    - Intellisense works better (Ctrl+Space lists methods you need to implement)
- *    - Function parameter and return types are inferred - no need to specify types
- *  - Cons
- *    - Must specify all properties and methods in the object type
- *    - papi.dataProvider.decorators.ignore is difficult to apply to tell papi to ignore methods
- *    - When using `this.notifyUpdate`, you must include the `WithNotifyUpdate` type and provide a
- *      placeholder `notifyUpdate` method
+ *
+ * - Pros
+ *
+ *   - Intellisense works better (Ctrl+Space lists methods you need to implement)
+ *   - Function parameter and return types are inferred - no need to specify types
+ * - Cons
+ *
+ *   - Must specify all properties and methods in the object type
+ *   - Papi.dataProvider.decorators.ignore is difficult to apply to tell papi to ignore methods
+ *   - When using `this.notifyUpdate`, you must include the `WithNotifyUpdate` type and provide a
+ *       placeholder `notifyUpdate` method
  *
  * If you would like more advanced functionality, you can alternatively define a data provider
  * engine with a class. An example of this is found in `quick-verse.ts`.
@@ -59,16 +62,17 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
 
   /**
    * Get a person by name. By default, creates that person if they don't exist yet
-   * @param name name of person
-   * @param createIfDoesNotExist whether to create the person if they don't exist. Defaults to true
-   * @returns person according to the provided name or undefined if they don't exist and
-   * were not set to be created in this method.
    *
-   * Note: this method is named `getPerson`, which would normally mean papi would consider it to be
-   * a data type method and would fail to use this engine because it would expect a `setPerson` as
-   * well. However, we added the `ignore` decorator (the line immediately after defining this
-   * peopleDataProviderEngine object), so papi will not pick it up. Alternatively, you can name
-   * it anything that doesn't start with `get` like `_getPerson` or `internalGetPerson`.
+   * @param name Name of person
+   * @param createIfDoesNotExist Whether to create the person if they don't exist. Defaults to true
+   * @returns Person according to the provided name or undefined if they don't exist and were not
+   *   set to be created in this method.
+   *
+   *   Note: this method is named `getPerson`, which would normally mean papi would consider it to be
+   *   a data type method and would fail to use this engine because it would expect a `setPerson` as
+   *   well. However, we added the `ignore` decorator (the line immediately after defining this
+   *   peopleDataProviderEngine object), so papi will not pick it up. Alternatively, you can name it
+   *   anything that doesn't start with `get` like `_getPerson` or `internalGetPerson`.
    */
   getPerson<T extends boolean = true>(
     name: string,
@@ -85,16 +89,17 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
 
   /**
    * Sets a person's greeting, creating the person if they do not exist.
-   * @param name name of person
-   * @param greeting person's new greeting
-   * @returns update instructions for updating the Greeting and People data types because we want
-   * subscribers to either of these data types to update based on this change.
    *
-   * Note: this method gets layered over so that you can run `this.setGreeting` inside this data
-   * provider engine, and it will send updates after returning.
+   * @param name Name of person
+   * @param greeting Person's new greeting
+   * @returns Update instructions for updating the Greeting and People data types because we want
+   *   subscribers to either of these data types to update based on this change.
    *
-   * Note: this method is used when someone uses the `useData.Greeting` hook on the data
-   * provider papi creates for this engine.
+   *   Note: this method gets layered over so that you can run `this.setGreeting` inside this data
+   *   provider engine, and it will send updates after returning.
+   *
+   *   Note: this method is used when someone uses the `useData.Greeting` hook on the data provider
+   *   papi creates for this engine.
    */
   async setGreeting(
     name: string,
@@ -112,11 +117,12 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
 
   /**
    * Get a person's greeting
-   * @param name name of person
-   * @returns person's greeting or undefined
    *
-   * Note: this method is used when someone uses the `useData.Greeting` hook or the
-   * `subscribeGreeting` method on the data provider papi creates for this engine.
+   * @param name Name of person
+   * @returns Person's greeting or undefined
+   *
+   *   Note: this method is used when someone uses the `useData.Greeting` hook or the
+   *   `subscribeGreeting` method on the data provider papi creates for this engine.
    */
   async getGreeting(name: string) {
     return this.getPerson(name, false)?.greeting;
@@ -124,16 +130,17 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
 
   /**
    * Set's a person's age, creating the person if they do not exist.
-   * @param name name of person
-   * @param age person's new age
-   * @returns update instructions for updating the Age and People data types because we want
-   * subscribers to either of these data types to update based on this change.
    *
-   * Note: this method gets layered over so that you can run `this.setAge` inside this data
-   * provider engine, and it will send updates after returning.
+   * @param name Name of person
+   * @param age Person's new age
+   * @returns Update instructions for updating the Age and People data types because we want
+   *   subscribers to either of these data types to update based on this change.
    *
-   * Note: this method is used when someone uses the `useData.Age` hook on the data
-   * provider papi creates for this engine.
+   *   Note: this method gets layered over so that you can run `this.setAge` inside this data provider
+   *   engine, and it will send updates after returning.
+   *
+   *   Note: this method is used when someone uses the `useData.Age` hook on the data provider papi
+   *   creates for this engine.
    */
   async setAge(
     name: string,
@@ -151,11 +158,12 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
 
   /**
    * Get a person's age
-   * @param name name of person
-   * @returns person's age or undefined
    *
-   * Note: this method is used when someone uses the `useData.Age` hook or the
-   * `subscribeAge` method on the data provider papi creates for this engine.
+   * @param name Name of person
+   * @returns Person's age or undefined
+   *
+   *   Note: this method is used when someone uses the `useData.Age` hook or the `subscribeAge` method
+   *   on the data provider papi creates for this engine.
    */
   async getAge(name: string) {
     return this.getPerson(name, false)?.age;
@@ -166,13 +174,13 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
    * can run `this.notifyUpdate` inside this data provider engine, and it will send updates after
    * running.
    *
-   * @param updateInstructions information that papi uses to interpret whether to send out updates.
-   * papi passes the interpreted update value into this function. For example, running
-   * `this.notifyUpdate()` will call this `notifyUpdate` with `updateInstructions` of `'*'`.
+   * @param updateInstructions Information that papi uses to interpret whether to send out updates.
+   *   papi passes the interpreted update value into this function. For example, running
+   *   `this.notifyUpdate()` will call this `notifyUpdate` with `updateInstructions` of `'*'`.
    *
-   * Note: this method does not have to be provided here for it to work properly because it is
-   * layered over on the papi. The only thing you can do here that will affect the update is to
-   * throw an error.
+   *   Note: this method does not have to be provided here for it to work properly because it is
+   *   layered over on the papi. The only thing you can do here that will affect the update is to
+   *   throw an error.
    */
   notifyUpdate(updateInstructions) {
     logger.info(`people data provider engine ran notifyUpdate! ${updateInstructions}`);
@@ -181,7 +189,8 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
   /**
    * Does nothing (meaning the People data type is read-only). This method is provided to match with
    * `getPeople`.
-   * @returns false meaning do not update anything
+   *
+   * @returns False meaning do not update anything
    */
   async setPeople() {
     // Don't change everyone's greeting, you heathen!
@@ -190,7 +199,8 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
 
   /**
    * Gets information about all people in this data provider.
-   * @returns information about all people in this data provider
+   *
+   * @returns Information about all people in this data provider
    */
   async getPeople() {
     // WARNING: returning the object reference itself allows in-process consumers to edit this
@@ -200,11 +210,13 @@ const peopleDataProviderEngine: IDataProviderEngine<PeopleDataTypes> &
 
   /**
    * Deletes a person from this data provider.
-   * @param name name of person
-   * @returns true if deleted, false if did not exist
    *
-   * Note: this is an example of a data provider engine custom method. It uses `notifyUpdateAll` to
-   * inform subscribers that the data has changed because it is not in a `set<data_type>` function.
+   * @param name Name of person
+   * @returns True if deleted, false if did not exist
+   *
+   *   Note: this is an example of a data provider engine custom method. It uses `notifyUpdateAll` to
+   *   inform subscribers that the data has changed because it is not in a `set<data_type>`
+   *   function.
    */
   async deletePerson(name: string) {
     const person = this.getPerson(name, false);
@@ -229,9 +241,7 @@ papi.dataProvider.decorators.ignore(peopleDataProviderEngine.getPerson);
 const peopleWebViewType = 'helloSomeone.peopleViewer';
 const peopleWebViewIdKey = 'peopleWebViewId';
 
-/**
- * Simple web view provider that provides People web views when papi requests them
- */
+/** Simple web view provider that provides People web views when papi requests them */
 const peopleWebViewProvider: IWebViewProvider = {
   async getWebView(savedWebView: SavedWebViewDefinition): Promise<WebViewDefinition | undefined> {
     if (savedWebView.webViewType !== peopleWebViewType)

--- a/extensions/src/hello-world/hello-world.ts
+++ b/extensions/src/hello-world/hello-world.ts
@@ -1,4 +1,4 @@
-import papi from 'papi-backend';
+import papi, { logger } from 'papi-backend';
 import type { ExecutionActivationContext } from 'extension-host/extension-types/extension-activation-context.model';
 import type {
   WebViewContentType,
@@ -17,13 +17,9 @@ import helloWorldHtmlWebView from './web-views/hello-world.web-view.html?inline'
 
 type IWebViewProviderWithType = IWebViewProvider & { webViewType: string };
 
-const { logger } = papi;
-
 logger.info('Hello world is importing!');
 
-/**
- * Simple web view provider that provides sample html web views when papi requests them
- */
+/** Simple web view provider that provides sample html web views when papi requests them */
 const htmlWebViewProvider: IWebViewProviderWithType = {
   webViewType: 'helloWorld.html',
   async getWebView(savedWebView: SavedWebViewDefinition): Promise<WebViewDefinition | undefined> {
@@ -42,9 +38,7 @@ const htmlWebViewProvider: IWebViewProviderWithType = {
   },
 };
 
-/**
- * Simple web view provider that provides React web views when papi requests them
- */
+/** Simple web view provider that provides React web views when papi requests them */
 const reactWebViewProvider: IWebViewProviderWithType = {
   webViewType: 'helloWorld.react',
   async getWebView(savedWebView: SavedWebViewDefinition): Promise<WebViewDefinition | undefined> {
@@ -66,9 +60,7 @@ const reactWebViewProvider: IWebViewProviderWithType = {
   },
 };
 
-/**
- * Simple web view provider that provides other React web views when papi requests them
- */
+/** Simple web view provider that provides other React web views when papi requests them */
 const reactWebView2Provider: IWebViewProviderWithType = {
   webViewType: 'helloWorld.react2',
   async getWebView(savedWebView: SavedWebViewDefinition): Promise<WebViewDefinition | undefined> {

--- a/extensions/src/hello-world/web-views/components/clock.component.tsx
+++ b/extensions/src/hello-world/web-views/components/clock.component.tsx
@@ -1,11 +1,5 @@
 import type { TimeDataTypes } from 'c-sharp-provider-test';
-import papi from 'papi-frontend';
-
-const {
-  react: {
-    hooks: { useData },
-  },
-} = papi;
+import { useData } from 'papi-frontend/react';
 
 export default function Clock() {
   const [currentTime] = useData.Time<TimeDataTypes, 'TimeData'>(

--- a/extensions/src/hello-world/web-views/hello-world-2.web-view.tsx
+++ b/extensions/src/hello-world/web-views/hello-world-2.web-view.tsx
@@ -1,13 +1,8 @@
 import papi from 'papi-frontend';
+import { useEvent } from 'papi-frontend/react';
 import { useCallback, useState } from 'react';
 import { Button } from 'papi-components';
 import type { HelloWorldEvent } from 'hello-world';
-
-const {
-  react: {
-    hooks: { useEvent },
-  },
-} = papi;
 
 globalThis.webViewComponent = function HelloWorld2() {
   const [clicks, setClicks] = useState(0);

--- a/extensions/src/hello-world/web-views/hello-world.web-view.tsx
+++ b/extensions/src/hello-world/web-views/hello-world.web-view.tsx
@@ -1,5 +1,14 @@
 ﻿import { ScrVers, VerseRef } from '@sillsdev/scripture';
-import papi from 'papi-frontend';
+import papi, { logger } from 'papi-frontend';
+import {
+  useData,
+  useProjectData,
+  usePromise,
+  useEvent,
+  useSetting,
+  useDialogCallback,
+  useDataProvider,
+} from 'papi-frontend/react';
 import {
   Button,
   Checkbox,
@@ -14,7 +23,7 @@ import {
 import type { QuickVerseDataTypes } from 'quick-verse';
 import type { PeopleDataProvider, PeopleDataTypes } from 'hello-someone';
 import type { UsfmProviderDataTypes } from 'usfm-data-provider';
-import { Key, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { Key, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { HelloWorldEvent } from 'hello-world';
 import type { DialogTypes } from 'renderer/components/dialogs/dialog-definition.model';
 import type { WebViewProps } from 'shared/data/web-view.model';
@@ -27,22 +36,6 @@ type Row = {
   title: string;
   subtitle: string;
 };
-
-const {
-  react: {
-    context: { TestContext },
-    hooks: {
-      useData,
-      useDataProvider,
-      useProjectData,
-      usePromise,
-      useEvent,
-      useSetting,
-      useDialogCallback,
-    },
-  },
-  logger,
-} = papi;
 
 const NAME = 'Hello World React WebView';
 
@@ -73,8 +66,6 @@ globalThis.webViewComponent = function HelloWorld({
   getWebViewDefinitionUpdatableProperties,
   updateWebViewDefinition,
 }: WebViewProps) {
-  const test = useContext(TestContext) || "Context didn't work!! :(";
-
   const [clicks, setClicks] = useWebViewState<number>('clicks', 0);
   const [rows, setRows] = useState(initializeRows());
   const [selectedRows, setSelectedRows] = useState(new Set<Key>());
@@ -174,8 +165,8 @@ globalThis.webViewComponent = function HelloWorld({
         Hello World <span className="framework">React</span>
         {/**
          * Note: `Logo` here is inlined into this code as a `data:` url. This is here simply for
-         * demonstration purposes. Inlining as a `data:` url is generally not recommended. Rather,
-         * it is generally better to use `papi-extension:` to avoid unnecessary bloat
+         * demonstration purposes. Inlining as a `data:` url is generally not recommended. Rather, it is
+         * generally better to use `papi-extension:` to avoid unnecessary bloat
          */}
         <img width={16} height={16} src={`${Logo}`} alt="Hello World Logo" />
       </div>
@@ -192,7 +183,6 @@ globalThis.webViewComponent = function HelloWorld({
           Hello World {clicks}
         </Button>
       </div>
-      <div>{test}</div>
       <div>{echoResult}</div>
       <div>
         <Button

--- a/extensions/src/quick-verse/quick-verse.ts
+++ b/extensions/src/quick-verse/quick-verse.ts
@@ -1,5 +1,5 @@
 import { VerseRef } from '@sillsdev/scripture';
-import papi from 'papi-backend';
+import papi, { logger, DataProviderEngine } from 'papi-backend';
 import type { ExecutionActivationContext } from 'extension-host/extension-types/extension-activation-context.model';
 import type { ExecutionToken } from 'node/models/execution-token.model';
 import type IDataProviderEngine from 'shared/models/data-provider-engine.model';
@@ -7,46 +7,46 @@ import type { QuickVerseDataTypes, QuickVerseSetData } from 'quick-verse';
 import type { DataProviderUpdateInstructions } from 'shared/models/data-provider.model';
 import type { UsfmDataProvider } from 'usfm-data-provider';
 
-const {
-  logger,
-  dataProvider: { DataProviderEngine },
-} = papi;
-
 logger.info('Quick Verse is importing!');
 
 /**
  * Example data provider engine that provides easy access to Scripture from an internet API.
  *
  * It has three data types:
- *  - Verse: get a portion of Scripture by its reference. You can also change the Scripture at a
- *    reference, but you have to clarify that you are heretical because you really shouldn't change
- *    published Scriptures like this ;)
- *  - Heresy: get or set Scripture freely. It automatically marks the verse as heretical if changed
- *  - Chapter: get a whole chapter of Scripture by book name and chapter number. Read-only
- *    - This data type is provided to demonstrate a more complex selector - an array of typed
- *      values. This is one way to make a `get<data_type>` function that feels more like a normal
- *      function that has "multiple" parameters in its selector.
+ *
+ * - Verse: get a portion of Scripture by its reference. You can also change the Scripture at a
+ *   reference, but you have to clarify that you are heretical because you really shouldn't change
+ *   published Scriptures like this ;)
+ * - Heresy: get or set Scripture freely. It automatically marks the verse as heretical if changed
+ * - Chapter: get a whole chapter of Scripture by book name and chapter number. Read-only
+ *
+ *   - This data type is provided to demonstrate a more complex selector - an array of typed values.
+ *       This is one way to make a `get<data_type>` function that feels more like a normal function
+ *       that has "multiple" parameters in its selector.
  *
  * For each data type, an engine needs a `get<data_type>` and a `set<data_type>`.
  *
- * papi will create a data provider that internally uses this engine. The data provider layers over
+ * Papi will create a data provider that internally uses this engine. The data provider layers over
  * this engine and adds functionality like `subscribe<data_type>` functions with automatic updates.
  *
  * This data provider engine is defined by a class, which we recommend trying once you get
  * comfortable with the data provider api because of the following pros and cons:
- *  - Pros
- *    - Can freely add properties and methods without specifying them in an extra type
- *    - Can use private methods (prefix with `#`) that are automatically ignored by papi
- *    - Can use @papi.dataProvider.decorators.ignore to tell papi to ignore methods
- *    - Can extend `DataProviderEngine` so TypeScript will understand you can call
- * `this.notifyUpdate` without specifying a `notifyUpdate` function
- *    - Can easily create multiple data providers from the same engine if you have two independent
- *      sets of data or something
- *  - Cons
- *    - Intellisense does not tell you all the `set<data_type>` and `get<data_type>` methods you
- *      need to provide, so it is slightly more challenging to use. However, TypeScript still shows
- *      an error unless you have the right methods.
- *    - You must specify parameter and return types. They are not inferred
+ *
+ * - Pros
+ *
+ *   - Can freely add properties and methods without specifying them in an extra type
+ *   - Can use private methods (prefix with `#`) that are automatically ignored by papi
+ *   - Can use @papi.dataProvider.decorators.ignore to tell papi to ignore methods
+ *   - Can extend `DataProviderEngine` so TypeScript will understand you can call `this.notifyUpdate`
+ *       without specifying a `notifyUpdate` function
+ *   - Can easily create multiple data providers from the same engine if you have two independent sets
+ *       of data or something
+ * - Cons
+ *
+ *   - Intellisense does not tell you all the `set<data_type>` and `get<data_type>` methods you need to
+ *       provide, so it is slightly more challenging to use. However, TypeScript still shows an
+ *       error unless you have the right methods.
+ *   - You must specify parameter and return types. They are not inferred
  *
  * If you would like better Intellisense support to get familiar with the api, you can alternatively
  * define a data provider engine with an object. An example of this is found in `hello-someone.ts`.
@@ -56,9 +56,8 @@ class QuickVerseDataProviderEngine
   implements IDataProviderEngine<QuickVerseDataTypes>
 {
   /**
-   * Verses stored by the Data Provider.
-   * Keys are Scripture References.
-   * Values are { text: '<verse_text>', isChanged?: boolean }
+   * Verses stored by the Data Provider. Keys are Scripture References. Values are { text:
+   * '<verse_text>', isChanged?: boolean }
    */
   verses: { [scrRef: string]: { text: string; isChanged?: boolean } } = {};
 
@@ -70,7 +69,7 @@ class QuickVerseDataProviderEngine
   /** Number of times any verse has been modified by a user this session */
   heresyCount = 0;
 
-  /** @param heresyWarning string to prefix heretical data */
+  /** @param heresyWarning String to prefix heretical data */
   constructor(public heresyWarning: string) {
     // `DataProviderEngine`'s constructor currently does nothing, but TypeScript requires that we
     // call it.
@@ -82,15 +81,17 @@ class QuickVerseDataProviderEngine
   /**
    * Internal set method that doesn't send updates so we can update how we want from setVerse and
    * setHeresy
-   * @param selector string Scripture reference
-   * @param data Verse string, and you must inform us that you are a heretic
-   * @returns '*' - update instructions for updating all data types because we want
-   * subscribers to Verse and Heresy data types to update based on this change.
    *
-   * Note: this method is named `setInternal`, which would normally mean papi would consider it to
-   * be a data type method and would fail to use this engine because it would expect a `getInternal`
-   * as well. However, we added the `ignore` decorator, so papi will not pick it up. Alternatively,
-   * you can name it anything that doesn't start with `set` like `_setInternal` or `internalSet`.
+   * @param selector String Scripture reference
+   * @param data Verse string, and you must inform us that you are a heretic
+   * @returns '*' - update instructions for updating all data types because we want subscribers to
+   *   Verse and Heresy data types to update based on this change.
+   *
+   *   Note: this method is named `setInternal`, which would normally mean papi would consider it to
+   *   be a data type method and would fail to use this engine because it would expect a
+   *   `getInternal` as well. However, we added the `ignore` decorator, so papi will not pick it up.
+   *   Alternatively, you can name it anything that doesn't start with `set` like `_setInternal` or
+   *   `internalSet`.
    */
   @papi.dataProvider.decorators.ignore
   async setInternal(
@@ -121,17 +122,19 @@ class QuickVerseDataProviderEngine
   }
 
   /**
-   * Set a verse's text. You must manually specify that the verse contains heresy, or you cannot set.
-   * @param verseRef verse reference to change
+   * Set a verse's text. You must manually specify that the verse contains heresy, or you cannot
+   * set.
+   *
+   * @param verseRef Verse reference to change
    * @param data Verse string, and you must inform us that you are a heretic
-   * @returns '*' - update instructions for updating all data types because we want
-   * subscribers to Verse and Heresy data types to update based on this change.
+   * @returns '*' - update instructions for updating all data types because we want subscribers to
+   *   Verse and Heresy data types to update based on this change.
    *
-   * Note: this method gets layered over so that you can run `this.setVerse` inside this data
-   * provider engine, and it will send updates after returning.
+   *   Note: this method gets layered over so that you can run `this.setVerse` inside this data
+   *   provider engine, and it will send updates after returning.
    *
-   * Note: this method is used when someone uses the `useData.Verse` hook on the data
-   * provider papi creates for this engine.
+   *   Note: this method is used when someone uses the `useData.Verse` hook on the data provider papi
+   *   creates for this engine.
    */
   async setVerse(verseRef: string, data: QuickVerseSetData) {
     return this.setInternal(verseRef, data);
@@ -140,16 +143,17 @@ class QuickVerseDataProviderEngine
   /**
    * Set a verse's text. Using this function implies that you identify as heresy, so you do not have
    * to identify as heresy in any special way
-   * @param verseRef verse reference to change
-   * @param verseText text to update the verse to, you heretic
-   * @returns '*' - update instructions for updating all data types because we want
-   * subscribers to Verse and Heresy data types to update based on this change.
    *
-   * Note: this method gets layered over so that you can run `this.setHeresy` inside this data
-   * provider engine, and it will send updates after returning.
+   * @param verseRef Verse reference to change
+   * @param verseText Text to update the verse to, you heretic
+   * @returns '*' - update instructions for updating all data types because we want subscribers to
+   *   Verse and Heresy data types to update based on this change.
    *
-   * Note: this method is used when someone uses the `useData.Heresy` hook on the data
-   * provider papi creates for this engine.
+   *   Note: this method gets layered over so that you can run `this.setHeresy` inside this data
+   *   provider engine, and it will send updates after returning.
+   *
+   *   Note: this method is used when someone uses the `useData.Heresy` hook on the data provider papi
+   *   creates for this engine.
    */
   async setHeresy(verseRef: string, verseText: string) {
     return this.setInternal(verseRef, { text: verseText, isHeresy: true });
@@ -157,11 +161,12 @@ class QuickVerseDataProviderEngine
 
   /**
    * Get a verse by its reference
-   * @param verseRef verse reference to get
-   * @returns verse contents at this reference
    *
-   * Note: this method is used when someone uses the `useData.Verse` hook or the
-   * `subscribeVerse` method on the data provider papi creates for this engine.
+   * @param verseRef Verse reference to get
+   * @returns Verse contents at this reference
+   *
+   *   Note: this method is used when someone uses the `useData.Verse` hook or the `subscribeVerse`
+   *   method on the data provider papi creates for this engine.
    */
   getVerse = async (verseRef: string) => {
     // Just get notifications of updates with the 'notify' selector
@@ -199,13 +204,14 @@ class QuickVerseDataProviderEngine
   };
 
   /**
-   * Get a verse by its reference. Need to provide a get for every set, so we specify getHeresy here which does the same thing as
-   * getVerse.
-   * @param verseRef verse reference to get
-   * @returns verse contents at this reference
+   * Get a verse by its reference. Need to provide a get for every set, so we specify getHeresy here
+   * which does the same thing as getVerse.
    *
-   * Note: this method is used when someone uses the `useData.Heresy` hook or the
-   * `subscribeHeresy` method on the data provider papi creates for this engine.
+   * @param verseRef Verse reference to get
+   * @returns Verse contents at this reference
+   *
+   *   Note: this method is used when someone uses the `useData.Heresy` hook or the `subscribeHeresy`
+   *   method on the data provider papi creates for this engine.
    */
   async getHeresy(verseRef: string) {
     return this.getVerse(verseRef);
@@ -214,7 +220,8 @@ class QuickVerseDataProviderEngine
   /**
    * Does nothing (meaning the Chapter data type is read-only). This method is provided to match
    * with `getChapter`.
-   * @returns false meaning do not update anything
+   *
+   * @returns False meaning do not update anything
    */
   // Does nothing, so we don't need to use `this`
   // eslint-disable-next-line class-methods-use-this
@@ -226,20 +233,21 @@ class QuickVerseDataProviderEngine
   /**
    * Get a chapter by its book name and chapter number.
    *
-   * @param chapterInfo parameters for getting the chapter
-   *   - `book` - the name of the book like 'John'
-   *   - `chapter` - the chapter number
-   *
-   * @returns full contents of the chapter
-   *
-   * This function demonstrates one way to make a `get<data_type>` function that feels more like a
-   * normal function in that it has "multiple" parameters in its selector, which is an array of
-   * parameters. To use it, you have to wrap the parameters in an array.
-   *
    * @example To get the contents of John 3, you can use `getChapter(['John', 3])`.
    *
    * Note: this method is used when someone uses the `useData.Chapter` hook or the
    * `subscribeChapter` method on the data provider papi creates for this engine.
+   *
+   * @param chapterInfo Parameters for getting the chapter
+   *
+   *   - `book` - the name of the book like 'John'
+   *   - `chapter` - the chapter number
+   *
+   * @returns Full contents of the chapter
+   *
+   *   This function demonstrates one way to make a `get<data_type>` function that feels more like a
+   *   normal function in that it has "multiple" parameters in its selector, which is an array of
+   *   parameters. To use it, you have to wrap the parameters in an array.
    */
   async getChapter(chapterInfo: [book: string, chapter: number]) {
     const [book, chapter] = chapterInfo;
@@ -247,13 +255,15 @@ class QuickVerseDataProviderEngine
   }
 
   /**
-   * Private method that cannot be called on the network.
-   * Valid selectors:
+   * Private method that cannot be called on the network. Valid selectors:
+   *
    * - `'notify'` - informs the listener of any changes in quick verse text but does not carry data
-   * - `'latest'` - the latest-updated quick verse text including pulling a verse from the server and a heretic changing the verse
+   * - `'latest'` - the latest-updated quick verse text including pulling a verse from the server and
+   *   a heretic changing the verse
    * - Scripture Reference strings. Ex: `'Romans 1:16'`
-   * @param selector selector provided by user
-   * @returns selector for use internally
+   *
+   * @param selector Selector provided by user
+   * @returns Selector for use internally
    */
   #getSelector(selector: string) {
     const selectorL = selector.toLowerCase().trim();

--- a/extensions/src/resource-viewer/resource-viewer.ts
+++ b/extensions/src/resource-viewer/resource-viewer.ts
@@ -1,4 +1,4 @@
-﻿import papi from 'papi-backend';
+﻿import papi, { logger } from 'papi-backend';
 import type { IWebViewProvider } from 'shared/models/web-view-provider.model';
 import type { DialogOptions } from 'shared/models/dialog-options.model';
 import type {
@@ -10,8 +10,6 @@ import type { ExecutionActivationContext } from 'extension-host/extension-types/
 import resourceViewerWebView from './resource-viewer.web-view?inline';
 import resourceViewerWebViewStyles from './resource-viewer.web-view.scss?inline';
 
-const { logger } = papi;
-
 logger.info('Resource Viewer is importing!');
 
 const resourceWebViewType = 'resourceViewer.react';
@@ -21,7 +19,8 @@ interface ResourceViewerOptions extends GetWebViewOptions {
 }
 
 /**
- * Function to prompt for a project and open it in the resource viewer. Registered as a command handler.
+ * Function to prompt for a project and open it in the resource viewer. Registered as a command
+ * handler.
  */
 async function openResourceViewer(
   projectId: string | undefined,
@@ -43,9 +42,7 @@ async function openResourceViewer(
   return null;
 }
 
-/**
- * Simple web view provider that provides Resource web views when papi requests them
- */
+/** Simple web view provider that provides Resource web views when papi requests them */
 const resourceWebViewProvider: IWebViewProvider = {
   async getWebView(
     savedWebView: SavedWebViewDefinition,

--- a/extensions/src/resource-viewer/resource-viewer.web-view.tsx
+++ b/extensions/src/resource-viewer/resource-viewer.web-view.tsx
@@ -1,5 +1,6 @@
 import { VerseRef } from '@sillsdev/scripture';
-import papi from 'papi-frontend';
+import { logger } from 'papi-frontend';
+import { useProjectData, useSetting } from 'papi-frontend/react';
 import { ScriptureReference } from 'papi-components';
 import { JSX, useMemo } from 'react';
 import UsxEditor from 'usxeditor';
@@ -12,7 +13,10 @@ interface StyleInfo {
   style: string;
   /** Whether this marker style can be closed (e.g. \nd and \nd*). In-line styles only. */
   canClose?: boolean;
-  /** Whether this marker style only applies to the word following it (e.g. \v 2). In-line styles only. */
+  /**
+   * Whether this marker style only applies to the word following it (e.g. \v 2). In-line styles
+   * only.
+   */
   oneWord?: boolean;
 }
 
@@ -20,16 +24,12 @@ interface StyleInfo {
 interface ElementInfo {
   /** Whether the element should be considered within one line or should be a block of text */
   inline?: boolean;
-  /** Marker styles for this element. All marker styles should be unique. There should not be a marker style repeated between two elements. */
+  /**
+   * Marker styles for this element. All marker styles should be unique. There should not be a
+   * marker style repeated between two elements.
+   */
   validStyles?: StyleInfo[];
 }
-
-const {
-  react: {
-    hooks: { useProjectData, useSetting },
-  },
-  logger,
-} = papi;
 
 /** All available elements for use in slate editor */
 const editorElements: { [type: string]: ElementInfo } = {

--- a/extensions/webpack/webpack.config.base.ts
+++ b/extensions/webpack/webpack.config.base.ts
@@ -23,7 +23,7 @@ export const LIBRARY_TYPE: NonNullable<webpack.Configuration['externalsType']> =
 // Note: we do not want to do any chunking because neither webViews nor main can import dependencies
 // other than those listed in configBase.externals. Each webView must contain all its dependency
 // code, and main must contain all its dependency code.
-/** webpack configuration shared by webView building and main building */
+/** Webpack configuration shared by webView building and main building */
 const configBase: webpack.Configuration = {
   // The operating directory for webpack instead of current working directory
   context: rootDir,
@@ -44,6 +44,7 @@ const configBase: webpack.Configuration = {
     'react-dom',
     'react-dom/client',
     'papi-frontend',
+    'papi-frontend/react',
     'papi-backend',
     '@sillsdev/scripture',
   ],
@@ -86,9 +87,7 @@ const configBase: webpack.Configuration = {
         },
         exclude: /node_modules/,
       },
-      /**
-       * Import scss, sass, and css files as strings
-       */
+      /** Import scss, sass, and css files as strings */
       // https://webpack.js.org/loaders/sass-loader/#getting-started
       {
         test: /\.(sa|sc|c)ss$/,
@@ -101,7 +100,8 @@ const configBase: webpack.Configuration = {
           'sass-loader',
         ],
       },
-      /** Load images as data uris
+      /**
+       * Load images as data uris
        *
        * Note: it is generally advised to use the `papi-extension:` protocol to load assets
        */
@@ -120,9 +120,7 @@ const configBase: webpack.Configuration = {
         test: /\.(woff|woff2|eot|ttf|otf)$/i,
         type: 'asset/inline',
       },
-      /**
-       * Import files with no transformation as strings with "./file?raw"
-       */
+      /** Import files with no transformation as strings with "./file?raw" */
       // This must be the last rule in order to be applied before all other transformations
       // https://webpack.js.org/guides/asset-modules/#replacing-inline-loader-syntax
       {

--- a/lib/papi-dts/edit-papi-d-ts.ts
+++ b/lib/papi-dts/edit-papi-d-ts.ts
@@ -20,6 +20,10 @@ papiDTS = papiDTS
     '"papi-frontend"',
   )
   .replace(
+    new RegExp(escapeStringRegexp('"renderer/services/papi-frontend-react.service"'), 'g'),
+    '"papi-frontend/react"',
+  )
+  .replace(
     new RegExp(escapeStringRegexp('"extension-host/services/papi-backend.service"'), 'g'),
     '"papi-backend"',
   );

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -3273,18 +3273,264 @@ declare module 'shared/services/project-data-provider.service' {
     getProjectDataProvider: typeof getProjectDataProvider;
   };
 }
-declare module 'renderer/context/papi-context/test.context' {
-  const TestContext: import('react').Context<string>;
-  export default TestContext;
-}
-declare module 'renderer/context/papi-context/index' {
-  import TestContext from 'renderer/context/papi-context/test.context';
-  export interface PapiContext {
-    TestContext: typeof TestContext;
+declare module 'shared/services/settings.service' {
+  import { Unsubscriber } from 'shared/utils/papi-util';
+  import { SettingTypes } from 'papi-shared-types';
+  type Nullable<T> = T | null;
+  /**
+   * Retrieves the value of the specified setting
+   *
+   * @param key The string id of the setting for which the value is being retrieved
+   * @returns The value of the specified setting, parsed to an object. Returns `null` if setting is
+   *   not present or no value is available
+   */
+  const getSetting: <SettingName extends keyof SettingTypes>(
+    key: SettingName,
+  ) => Nullable<SettingTypes[SettingName]>;
+  /**
+   * Sets the value of the specified setting
+   *
+   * @param key The string id of the setting for which the value is being retrieved
+   * @param newSetting The value that is to be stored. Setting the new value to `null` is the
+   *   equivalent of deleting the setting
+   */
+  const setSetting: <SettingName extends keyof SettingTypes>(
+    key: SettingName,
+    newSetting: Nullable<SettingTypes[SettingName]>,
+  ) => void;
+  /**
+   * Subscribes to updates of the specified setting. Whenever the value of the setting changes, the
+   * callback function is executed.
+   *
+   * @param key The string id of the setting for which the value is being subscribed to
+   * @param callback The function that will be called whenever the specified setting is updated
+   * @returns Unsubscriber that should be called whenever the subscription should be deleted
+   */
+  const subscribeToSetting: <SettingName extends keyof SettingTypes>(
+    key: SettingName,
+    callback: (newSetting: Nullable<SettingTypes[SettingName]>) => void,
+  ) => Unsubscriber;
+  export interface SettingsService {
+    get: typeof getSetting;
+    set: typeof setSetting;
+    subscribe: typeof subscribeToSetting;
   }
-  /** All React contexts to be exposed on the papi */
-  const papiContext: PapiContext;
-  export default papiContext;
+  /** Service that allows to get and set settings in local storage */
+  const settingsService: SettingsService;
+  export default settingsService;
+}
+declare module 'shared/models/dialog-options.model' {
+  /** General options to adjust dialogs (created from `papi.dialogs`) */
+  export type DialogOptions = {
+    /** Dialog title to display in the header. Default depends on the dialog */
+    title?: string;
+    /** Url of dialog icon to display in the header. Default is Platform.Bible logo */
+    iconUrl?: string;
+    /** The message to show the user in the dialog. Default depends on the dialog */
+    prompt?: string;
+  };
+  /** Data in each tab that is a dialog. Added to DialogOptions in `dialog.service-host.ts` */
+  export type DialogData = DialogOptions & {
+    isDialog: true;
+  };
+}
+declare module 'renderer/components/dialogs/dialog-base.data' {
+  import { FloatSize, TabLoader, TabSaver } from 'shared/data/web-view.model';
+  import { DialogData } from 'shared/models/dialog-options.model';
+  import { ReactElement } from 'react';
+  /** Base type for DialogDefinition. Contains reasonable defaults for dialogs */
+  export type DialogDefinitionBase = Readonly<{
+    /** Overwritten in {@link DialogDefinition}. Must be specified by all DialogDefinitions */
+    tabType?: string;
+    /** Overwritten in {@link DialogDefinition}. Must be specified by all DialogDefinitions */
+    Component?: (props: DialogProps) => ReactElement;
+    /**
+     * The default icon for this dialog. This may be overridden by the `DialogOptions.iconUrl`
+     *
+     * Defaults to the Platform.Bible logo
+     */
+    defaultIconUrl?: string;
+    /**
+     * The default title for this dialog. This may be overridden by the `DialogOptions.title`
+     *
+     * Defaults to the DialogDefinition's `tabType`
+     */
+    defaultTitle?: string;
+    /** The width and height at which the dialog will be loaded in CSS `px` units */
+    initialSize: FloatSize;
+    /** The minimum width to which the dialog can be set in CSS `px` units */
+    minWidth?: number;
+    /** The minimum height to which the dialog can be set in CSS `px` units */
+    minHeight?: number;
+    /**
+     * The function used to load the dialog into the dock layout. Default uses the `Component` field
+     * and passes in the `DialogProps`
+     */
+    loadDialog: TabLoader;
+    /**
+     * The function used to save the dialog into the dock layout
+     *
+     * Default does not save the dialog as they cannot properly be restored yet.
+     *
+     * TODO: preserve requests between refreshes - save the dialog info in such a way that it works
+     * when loading again after refresh
+     */
+    saveDialog: TabSaver;
+  }>;
+  /** Props provided to the dialog component */
+  export type DialogProps<TData = unknown> = DialogData & {
+    /**
+     * Sends the data as a resolved response to the dialog request and closes the dialog
+     *
+     * @param data Data with which to resolve the request
+     */
+    submitDialog(data: TData): void;
+    /** Cancels the dialog request (resolves the response with `null`) and closes the dialog */
+    cancelDialog(): void;
+    /**
+     * Rejects the dialog request with the specified message and closes the dialog
+     *
+     * @param errorMessage Message to explain why the dialog request was rejected
+     */
+    rejectDialog(errorMessage: string): void;
+  };
+  /**
+   * Set the functionality of submitting and canceling dialogs. This should be called specifically
+   * by `dialog.service-host.ts` immediately on startup and by nothing else. This is only here to
+   * mitigate a dependency cycle
+   *
+   * @param dialogServiceFunctions Functions from the dialog service host for resolving and
+   *   rejecting dialogs
+   */
+  export function hookUpDialogService({
+    resolveDialogRequest: resolve,
+    rejectDialogRequest: reject,
+  }: {
+    resolveDialogRequest: (id: string, data: unknown | null) => void;
+    rejectDialogRequest: (id: string, message: string) => void;
+  }): void;
+  /**
+   * Static definition of a dialog that can be shown in Platform.Bible
+   *
+   * For good defaults, dialogs can include all the properties of this dialog. Dialogs must then
+   * specify `tabType` and `Component` in order to comply with `DialogDefinition`
+   *
+   * Note: this is not a class that can be inherited because all properties would be static but then
+   * we would not be able to use the default `loadDialog` because it would be using a static
+   * reference to a nonexistent `Component`. Instead of inheriting this as a class, any dialog
+   * definition can spread this `{ ...DIALOG_BASE }`
+   */
+  const DIALOG_BASE: DialogDefinitionBase;
+  export default DIALOG_BASE;
+}
+declare module 'renderer/components/dialogs/dialog-definition.model' {
+  import { DialogOptions } from 'shared/models/dialog-options.model';
+  import { DialogDefinitionBase, DialogProps } from 'renderer/components/dialogs/dialog-base.data';
+  import { ReactElement } from 'react';
+  /** The tabType for the select project dialog in `select-project.dialog.tsx` */
+  export const SELECT_PROJECT_DIALOG_TYPE = 'platform.selectProject';
+  /** The tabType for the select multiple projects dialog in `select-multiple-projects.dialog.tsx` */
+  export const SELECT_MULTIPLE_PROJECTS_DIALOG_TYPE = 'platform.selectMultipleProjects';
+  /** Options to provide when showing the Select Project dialog */
+  export type SelectProjectDialogOptions = DialogOptions & {
+    /** Project IDs to exclude from showing in the dialog */
+    excludeProjectIds?: string[];
+  };
+  /** Options to provide when showing the Select Multiple Project dialog */
+  export type SelectMultipleProjectsDialogOptions = DialogOptions & {
+    /** Project IDs to exclude from showing in the dialog */
+    excludeProjectIds?: string[];
+    /** Project IDs that should start selected in the dialog */
+    selectedProjectIds?: string[];
+  };
+  /**
+   * Mapped type for dialog functions to use in getting various types for dialogs
+   *
+   * Keys should be dialog names, and values should be {@link DialogDataTypes}
+   *
+   * If you add a dialog here, you must also add it on {@link DIALOGS}
+   */
+  export interface DialogTypes {
+    [SELECT_PROJECT_DIALOG_TYPE]: DialogDataTypes<SelectProjectDialogOptions, string>;
+    [SELECT_MULTIPLE_PROJECTS_DIALOG_TYPE]: DialogDataTypes<
+      SelectMultipleProjectsDialogOptions,
+      string[]
+    >;
+  }
+  /** Each type of dialog. These are the tab types used in the dock layout */
+  export type DialogTabTypes = keyof DialogTypes;
+  /** Types related to a specific dialog */
+  export type DialogDataTypes<TOptions extends DialogOptions, TReturnType> = {
+    /**
+     * The dialog options to specify when calling the dialog. Passed into `loadDialog` as
+     * SavedTabInfo.data
+     *
+     * The default implementation of `loadDialog` passes all the options down to the dialog
+     * component as props
+     */
+    options: TOptions;
+    /** The type of the response to the dialog request */
+    responseType: TReturnType;
+    /** Props provided to the dialog component */
+    props: DialogProps<TReturnType> & TOptions;
+  };
+  export type DialogDefinition<DialogTabType extends DialogTabTypes> = Readonly<
+    DialogDefinitionBase & {
+      /**
+       * Type of tab - indicates what kind of built-in dock layout tab this dialog definition
+       * represents
+       */
+      tabType: DialogTabType;
+      /**
+       * React component to render for this dialog
+       *
+       * This must be specified only if you do not overwrite the default `loadDialog`
+       *
+       * @param props Props that will be passed through from the dialog tab's data
+       * @returns React element to render
+       */
+      Component: (
+        props: DialogProps<DialogTypes[DialogTabType]['responseType']> &
+          DialogTypes[DialogTabType]['options'],
+      ) => ReactElement;
+    }
+  >;
+}
+declare module 'shared/services/dialog.service-model' {
+  import { DialogTabTypes, DialogTypes } from 'renderer/components/dialogs/dialog-definition.model';
+  import { DialogOptions } from 'shared/models/dialog-options.model';
+  /** Prompt the user for responses with dialogs */
+  export interface DialogService {
+    /**
+     * Shows a dialog to the user and prompts the user to respond
+     *
+     * @type `TReturn` - The type of data the dialog responds with
+     * @param dialogType The type of dialog to show the user
+     * @param options Various options for configuring the dialog that shows
+     * @returns Returns the user's response or `null` if the user cancels
+     *
+     *   Note: canceling responds with `null` instead of `undefined` so that the dialog definition can
+     *   use `undefined` as a meaningful value if desired.
+     */
+    showDialog<DialogTabType extends DialogTabTypes>(
+      dialogType: DialogTabType,
+      options?: DialogTypes[DialogTabType]['options'],
+    ): Promise<DialogTypes[DialogTabType]['responseType'] | null>;
+    /**
+     * Shows a select project dialog to the user and prompts the user to select a dialog
+     *
+     * @param options Various options for configuring the dialog that shows
+     * @returns Returns the user's selected project id or `null` if the user cancels
+     */
+    selectProject(options?: DialogOptions): Promise<string | null>;
+  }
+  /** Prefix on requests that indicates that the request is related to dialog operations */
+  export const CATEGORY_DIALOG = 'dialog';
+}
+declare module 'shared/services/dialog.service' {
+  import { DialogService } from 'shared/services/dialog.service-model';
+  const dialogService: DialogService;
+  export default dialogService;
 }
 declare module 'renderer/hooks/papi-hooks/use-promise.hook' {
   /**
@@ -3519,52 +3765,6 @@ declare module 'renderer/hooks/papi-hooks/use-data.hook' {
   const useData: UseDataHook;
   export default useData;
 }
-declare module 'shared/services/settings.service' {
-  import { Unsubscriber } from 'shared/utils/papi-util';
-  import { SettingTypes } from 'papi-shared-types';
-  type Nullable<T> = T | null;
-  /**
-   * Retrieves the value of the specified setting
-   *
-   * @param key The string id of the setting for which the value is being retrieved
-   * @returns The value of the specified setting, parsed to an object. Returns `null` if setting is
-   *   not present or no value is available
-   */
-  const getSetting: <SettingName extends keyof SettingTypes>(
-    key: SettingName,
-  ) => Nullable<SettingTypes[SettingName]>;
-  /**
-   * Sets the value of the specified setting
-   *
-   * @param key The string id of the setting for which the value is being retrieved
-   * @param newSetting The value that is to be stored. Setting the new value to `null` is the
-   *   equivalent of deleting the setting
-   */
-  const setSetting: <SettingName extends keyof SettingTypes>(
-    key: SettingName,
-    newSetting: Nullable<SettingTypes[SettingName]>,
-  ) => void;
-  /**
-   * Subscribes to updates of the specified setting. Whenever the value of the setting changes, the
-   * callback function is executed.
-   *
-   * @param key The string id of the setting for which the value is being subscribed to
-   * @param callback The function that will be called whenever the specified setting is updated
-   * @returns Unsubscriber that should be called whenever the subscription should be deleted
-   */
-  const subscribeToSetting: <SettingName extends keyof SettingTypes>(
-    key: SettingName,
-    callback: (newSetting: Nullable<SettingTypes[SettingName]>) => void,
-  ) => Unsubscriber;
-  export interface SettingsService {
-    get: typeof getSetting;
-    set: typeof setSetting;
-    subscribe: typeof subscribeToSetting;
-  }
-  /** Service that allows to get and set settings in local storage */
-  const settingsService: SettingsService;
-  export default settingsService;
-}
 declare module 'renderer/hooks/papi-hooks/use-setting.hook' {
   import { SettingTypes } from 'papi-shared-types';
   /**
@@ -3742,219 +3942,6 @@ declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
   const useProjectData: UseProjectDataHook;
   export default useProjectData;
 }
-declare module 'shared/models/dialog-options.model' {
-  /** General options to adjust dialogs (created from `papi.dialogs`) */
-  export type DialogOptions = {
-    /** Dialog title to display in the header. Default depends on the dialog */
-    title?: string;
-    /** Url of dialog icon to display in the header. Default is Platform.Bible logo */
-    iconUrl?: string;
-    /** The message to show the user in the dialog. Default depends on the dialog */
-    prompt?: string;
-  };
-  /** Data in each tab that is a dialog. Added to DialogOptions in `dialog.service-host.ts` */
-  export type DialogData = DialogOptions & {
-    isDialog: true;
-  };
-}
-declare module 'renderer/components/dialogs/dialog-base.data' {
-  import { FloatSize, TabLoader, TabSaver } from 'shared/data/web-view.model';
-  import { DialogData } from 'shared/models/dialog-options.model';
-  import { ReactElement } from 'react';
-  /** Base type for DialogDefinition. Contains reasonable defaults for dialogs */
-  export type DialogDefinitionBase = Readonly<{
-    /** Overwritten in {@link DialogDefinition}. Must be specified by all DialogDefinitions */
-    tabType?: string;
-    /** Overwritten in {@link DialogDefinition}. Must be specified by all DialogDefinitions */
-    Component?: (props: DialogProps) => ReactElement;
-    /**
-     * The default icon for this dialog. This may be overridden by the `DialogOptions.iconUrl`
-     *
-     * Defaults to the Platform.Bible logo
-     */
-    defaultIconUrl?: string;
-    /**
-     * The default title for this dialog. This may be overridden by the `DialogOptions.title`
-     *
-     * Defaults to the DialogDefinition's `tabType`
-     */
-    defaultTitle?: string;
-    /** The width and height at which the dialog will be loaded in CSS `px` units */
-    initialSize: FloatSize;
-    /** The minimum width to which the dialog can be set in CSS `px` units */
-    minWidth?: number;
-    /** The minimum height to which the dialog can be set in CSS `px` units */
-    minHeight?: number;
-    /**
-     * The function used to load the dialog into the dock layout. Default uses the `Component` field
-     * and passes in the `DialogProps`
-     */
-    loadDialog: TabLoader;
-    /**
-     * The function used to save the dialog into the dock layout
-     *
-     * Default does not save the dialog as they cannot properly be restored yet.
-     *
-     * TODO: preserve requests between refreshes - save the dialog info in such a way that it works
-     * when loading again after refresh
-     */
-    saveDialog: TabSaver;
-  }>;
-  /** Props provided to the dialog component */
-  export type DialogProps<TData = unknown> = DialogData & {
-    /**
-     * Sends the data as a resolved response to the dialog request and closes the dialog
-     *
-     * @param data Data with which to resolve the request
-     */
-    submitDialog(data: TData): void;
-    /** Cancels the dialog request (resolves the response with `null`) and closes the dialog */
-    cancelDialog(): void;
-    /**
-     * Rejects the dialog request with the specified message and closes the dialog
-     *
-     * @param errorMessage Message to explain why the dialog request was rejected
-     */
-    rejectDialog(errorMessage: string): void;
-  };
-  /**
-   * Set the functionality of submitting and canceling dialogs. This should be called specifically
-   * by `dialog.service-host.ts` immediately on startup and by nothing else. This is only here to
-   * mitigate a dependency cycle
-   *
-   * @param dialogServiceFunctions Functions from the dialog service host for resolving and
-   *   rejecting dialogs
-   */
-  export function hookUpDialogService({
-    resolveDialogRequest: resolve,
-    rejectDialogRequest: reject,
-  }: {
-    resolveDialogRequest: (id: string, data: unknown | null) => void;
-    rejectDialogRequest: (id: string, message: string) => void;
-  }): void;
-  /**
-   * Static definition of a dialog that can be shown in Platform.Bible
-   *
-   * For good defaults, dialogs can include all the properties of this dialog. Dialogs must then
-   * specify `tabType` and `Component` in order to comply with `DialogDefinition`
-   *
-   * Note: this is not a class that can be inherited because all properties would be static but then
-   * we would not be able to use the default `loadDialog` because it would be using a static
-   * reference to a nonexistent `Component`. Instead of inheriting this as a class, any dialog
-   * definition can spread this `{ ...DIALOG_BASE }`
-   */
-  const DIALOG_BASE: DialogDefinitionBase;
-  export default DIALOG_BASE;
-}
-declare module 'renderer/components/dialogs/dialog-definition.model' {
-  import { DialogOptions } from 'shared/models/dialog-options.model';
-  import { DialogDefinitionBase, DialogProps } from 'renderer/components/dialogs/dialog-base.data';
-  import { ReactElement } from 'react';
-  /** The tabType for the select project dialog in `select-project.dialog.tsx` */
-  export const SELECT_PROJECT_DIALOG_TYPE = 'platform.selectProject';
-  /** The tabType for the select multiple projects dialog in `select-multiple-projects.dialog.tsx` */
-  export const SELECT_MULTIPLE_PROJECTS_DIALOG_TYPE = 'platform.selectMultipleProjects';
-  /** Options to provide when showing the Select Project dialog */
-  export type SelectProjectDialogOptions = DialogOptions & {
-    /** Project IDs to exclude from showing in the dialog */
-    excludeProjectIds?: string[];
-  };
-  /** Options to provide when showing the Select Multiple Project dialog */
-  export type SelectMultipleProjectsDialogOptions = DialogOptions & {
-    /** Project IDs to exclude from showing in the dialog */
-    excludeProjectIds?: string[];
-    /** Project IDs that should start selected in the dialog */
-    selectedProjectIds?: string[];
-  };
-  /**
-   * Mapped type for dialog functions to use in getting various types for dialogs
-   *
-   * Keys should be dialog names, and values should be {@link DialogDataTypes}
-   *
-   * If you add a dialog here, you must also add it on {@link DIALOGS}
-   */
-  export interface DialogTypes {
-    [SELECT_PROJECT_DIALOG_TYPE]: DialogDataTypes<SelectProjectDialogOptions, string>;
-    [SELECT_MULTIPLE_PROJECTS_DIALOG_TYPE]: DialogDataTypes<
-      SelectMultipleProjectsDialogOptions,
-      string[]
-    >;
-  }
-  /** Each type of dialog. These are the tab types used in the dock layout */
-  export type DialogTabTypes = keyof DialogTypes;
-  /** Types related to a specific dialog */
-  export type DialogDataTypes<TOptions extends DialogOptions, TReturnType> = {
-    /**
-     * The dialog options to specify when calling the dialog. Passed into `loadDialog` as
-     * SavedTabInfo.data
-     *
-     * The default implementation of `loadDialog` passes all the options down to the dialog
-     * component as props
-     */
-    options: TOptions;
-    /** The type of the response to the dialog request */
-    responseType: TReturnType;
-    /** Props provided to the dialog component */
-    props: DialogProps<TReturnType> & TOptions;
-  };
-  export type DialogDefinition<DialogTabType extends DialogTabTypes> = Readonly<
-    DialogDefinitionBase & {
-      /**
-       * Type of tab - indicates what kind of built-in dock layout tab this dialog definition
-       * represents
-       */
-      tabType: DialogTabType;
-      /**
-       * React component to render for this dialog
-       *
-       * This must be specified only if you do not overwrite the default `loadDialog`
-       *
-       * @param props Props that will be passed through from the dialog tab's data
-       * @returns React element to render
-       */
-      Component: (
-        props: DialogProps<DialogTypes[DialogTabType]['responseType']> &
-          DialogTypes[DialogTabType]['options'],
-      ) => ReactElement;
-    }
-  >;
-}
-declare module 'shared/services/dialog.service-model' {
-  import { DialogTabTypes, DialogTypes } from 'renderer/components/dialogs/dialog-definition.model';
-  import { DialogOptions } from 'shared/models/dialog-options.model';
-  /** Prompt the user for responses with dialogs */
-  export interface DialogService {
-    /**
-     * Shows a dialog to the user and prompts the user to respond
-     *
-     * @type `TReturn` - The type of data the dialog responds with
-     * @param dialogType The type of dialog to show the user
-     * @param options Various options for configuring the dialog that shows
-     * @returns Returns the user's response or `null` if the user cancels
-     *
-     *   Note: canceling responds with `null` instead of `undefined` so that the dialog definition can
-     *   use `undefined` as a meaningful value if desired.
-     */
-    showDialog<DialogTabType extends DialogTabTypes>(
-      dialogType: DialogTabType,
-      options?: DialogTypes[DialogTabType]['options'],
-    ): Promise<DialogTypes[DialogTabType]['responseType'] | null>;
-    /**
-     * Shows a select project dialog to the user and prompts the user to select a dialog
-     *
-     * @param options Various options for configuring the dialog that shows
-     * @returns Returns the user's selected project id or `null` if the user cancels
-     */
-    selectProject(options?: DialogOptions): Promise<string | null>;
-  }
-  /** Prefix on requests that indicates that the request is related to dialog operations */
-  export const CATEGORY_DIALOG = 'dialog';
-}
-declare module 'shared/services/dialog.service' {
-  import { DialogService } from 'shared/services/dialog.service-model';
-  const dialogService: DialogService;
-  export default dialogService;
-}
 declare module 'renderer/hooks/papi-hooks/use-dialog-callback.hook' {
   import { DialogTabTypes, DialogTypes } from 'renderer/components/dialogs/dialog-definition.model';
   /**
@@ -4040,183 +4027,19 @@ declare module 'renderer/hooks/papi-hooks/use-data-provider-multi.hook' {
   export default useDataProviderMulti;
 }
 declare module 'renderer/hooks/papi-hooks/index' {
-  import usePromise from 'renderer/hooks/papi-hooks/use-promise.hook';
-  import useEvent from 'renderer/hooks/papi-hooks/use-event.hook';
-  import useEventAsync from 'renderer/hooks/papi-hooks/use-event-async.hook';
-  import useDataProvider from 'renderer/hooks/papi-hooks/use-data-provider.hook';
-  import useData from 'renderer/hooks/papi-hooks/use-data.hook';
-  import useSetting from 'renderer/hooks/papi-hooks/use-setting.hook';
-  import useProjectData from 'renderer/hooks/papi-hooks/use-project-data.hook';
-  import useProjectDataProvider from 'renderer/hooks/papi-hooks/use-project-data-provider.hook';
-  import useDialogCallback from 'renderer/hooks/papi-hooks/use-dialog-callback.hook';
-  import useDataProviderMulti from 'renderer/hooks/papi-hooks/use-data-provider-multi.hook';
-  export interface PapiHooks {
-    useDialogCallback: typeof useDialogCallback;
-    usePromise: typeof usePromise;
-    useEvent: typeof useEvent;
-    useEventAsync: typeof useEventAsync;
-    useProjectDataProvider: typeof useProjectDataProvider;
-    useDataProvider: typeof useDataProvider;
-    useDataProviderMulti: typeof useDataProviderMulti;
-    /**
-     * ```typescript
-     * useData.DataType<TDataTypes extends DataProviderDataTypes, TDataType extends keyof TDataTypes>(
-     *   dataProviderSource: string | IDataProvider<TDataTypes> | undefined,
-     *   selector: TDataTypes[TDataType]['selector'],
-     *   defaultValue: TDataTypes[TDataType]['getData'],
-     *   subscriberOptions?: DataProviderSubscriberOptions,
-     * ): [
-     *   TDataTypes[TDataType]['getData'],
-     *   (
-     *     | ((
-     *         newData: TDataTypes[TDataType]['setData'],
-     *       ) => Promise<DataProviderUpdateInstructions<TDataTypes>>)
-     *     | undefined
-     *   ),
-     *   boolean,
-     * ]
-     * ```
-     *
-     * Special React hook that subscribes to run a callback on a data provider's data with specified
-     * selector on any data type that data provider serves.
-     *
-     * Usage: Specify the data type on the data provider with `useData.<data_type>` and use like any
-     * other React hook. Specify the generic types in order to receive type support from
-     * Intellisense. For example, `useData.Verse<QuickVerseDataTypes, 'Verse'>` lets you subscribe
-     * to verses from a data provider that serves `QuickVerseDataTypes`.
-     *
-     * _＠example_ When subscribing to JHN 11:35 on the `'quickVerse.quickVerse'` data provider, we
-     * need to tell the useData.Verse hook what types we are using, so we use the
-     * `QuickVerseDataTypes` data types and specify that we are using the `'Verse'` data type as
-     * follows:
-     *
-     * ```typescript
-     * const [verseText, setVerseText, verseTextIsLoading] = useData.Verse<
-     *   QuickVerseDataTypes,
-     *   'Verse'
-     * >('quickVerse.quickVerse', 'JHN 11:35', 'Verse text goes here');
-     * ```
-     *
-     * _＠param_ `dataProviderSource` string name of data provider to get OR dataProvider (result of
-     * useDataProvider if you want to consolidate and only get the data provider once)
-     *
-     * _＠param_ `selector` tells the provider what data this listener is listening for
-     *
-     * _＠param_ `defaultValue` the initial value to return while first awaiting the data
-     *
-     * WARNING: MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not
-     * be updated every render
-     *
-     * _＠param_ `subscriberOptions` various options to adjust how the subscriber emits updates
-     *
-     * WARNING: If provided, MUST BE STABLE - const or wrapped in useState, useMemo, etc. The
-     * reference must not be updated every render
-     *
-     * _＠returns_ `[data, setData, isLoading]`
-     *
-     * - `data`: the current value for the data from the data provider with the specified data type
-     *   and selector, either the defaultValue or the resolved data
-     * - `setData`: asynchronous function to request that the data provider update the data at this
-     *   data type and selector. Returns true if successful. Note that this function does not update
-     *   the data. The data provider sends out an update to this subscription if it successfully
-     *   updates data.
-     * - `isLoading`: whether the data with the data type and selector is awaiting retrieval from the
-     *   data provider
-     *
-     * _＠type_ `TDataTypes` - the data provider data types served by the data provider whose data to
-     * use.
-     *
-     * _＠type_ `TDataType` - the specific data type on this data provider that you want to use. Must
-     * match the data type specified in `useData.<data_type>`
-     */
-    useData: typeof useData;
-    /**
-     * ```typescript
-     * useProjectData.DataType<TProjectDataTypes extends DataProviderDataTypes, TDataType extends keyof TProjectDataTypes>(
-     *   projectDataProviderSource: string | IDataProvider<TProjectDataTypes> | undefined,
-     *   selector: TProjectDataTypes[TDataType]['selector'],
-     *   defaultValue: TProjectDataTypes[TDataType]['getData'],
-     *   subscriberOptions?: DataProviderSubscriberOptions,
-     * ): [
-     *   TProjectDataTypes[TDataType]['getData'],
-     *   (
-     *     | ((
-     *         newData: TProjectDataTypes[TDataType]['setData'],
-     *       ) => Promise<DataProviderUpdateInstructions<TProjectDataTypes>>)
-     *     | undefined
-     *   ),
-     *   boolean,
-     * ]
-     * ```
-     *
-     * Special React hook that subscribes to run a callback on a project data provider's data with
-     * specified selector on any data type that the project data provider serves according to its
-     * projectType.
-     *
-     * Usage: Specify the data type on the project data provider with `useProjectData.<data_type>`
-     * and use like any other React hook. Specify the generic types in order to receive type support
-     * from Intellisense. For example,
-     * `useProjectData.VerseUSFM<ProjectDataTypes['ParatextStandard'], 'VerseUSFM'>` lets you
-     * subscribe to verse USFM from a project data provider for the `ParatextStandard`
-     * `projectType`.
-     *
-     * _＠example_ When subscribing to JHN 11:35 Verse USFM info on a `ParatextStandard` project with
-     * projectId `32664dc3288a28df2e2bb75ded887fc8f17a15fb`, we need to tell the
-     * `useProjectData.VerseUSFM` hook what types we are using, so we specify the project data types
-     * as `ProjectDataTypes['ParatextStandard']` and specify that we are using the `'VerseUSFM'`
-     * data type as follows:
-     *
-     * ```typescript
-     * const [verse, setVerse, verseIsLoading] = useProjectData.VerseUSFM<
-     *   ProjectDataTypes['ParatextStandard'],
-     *   'Verse'
-     * >(
-     *   '32664dc3288a28df2e2bb75ded887fc8f17a15fb',
-     *   useMemo(() => new VerseRef('JHN', '11', '35', ScrVers.English), []),
-     *   'Loading verse ',
-     * );
-     * ```
-     *
-     * _＠param_ `projectDataProviderSource` string name of the id of the project to get OR
-     * projectDataProvider (result of useProjectDataProvider if you want to consolidate and only get
-     * the project data provider once)
-     *
-     * _＠param_ `selector` tells the provider what data this listener is listening for
-     *
-     * _＠param_ `defaultValue` the initial value to return while first awaiting the data
-     *
-     * WARNING: MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not
-     * be updated every render
-     *
-     * _＠param_ `subscriberOptions` various options to adjust how the subscriber emits updates
-     *
-     * WARNING: If provided, MUST BE STABLE - const or wrapped in useState, useMemo, etc. The
-     * reference must not be updated every render
-     *
-     * _＠returns_ `[data, setData, isLoading]`
-     *
-     * - `data`: the current value for the data from the project data provider for the specified
-     *   project id with the specified data type and selector, either the defaultValue or the
-     *   resolved data
-     * - `setData`: asynchronous function to request that the data provider for the specified project
-     *   id update the data at this data type and selector. Returns true if successful. Note that
-     *   this function does not update the data. The project data provider sends out an update to
-     *   this subscription if it successfully updates data.
-     * - `isLoading`: whether the data with the data type and selector is awaiting retrieval from the
-     *   project data provider for this project id
-     *
-     * _＠type_ `TProjectDataTypes` - the project data types associated with the `projectType` used.
-     * You can specify this type with `ProjectDataTypes['<project_type>']`
-     *
-     * _＠type_ `TDataType` - the specific data type on this project you want to use. Must match the
-     * data type specified in `useProjectData.<data_type>`
-     */
-    useProjectData: typeof useProjectData;
-    useSetting: typeof useSetting;
-  }
-  /** All React hooks to be exposed on the papi */
-  const papiHooks: PapiHooks;
-  export default papiHooks;
+  export { default as usePromise } from 'renderer/hooks/papi-hooks/use-promise.hook';
+  export { default as useEvent } from 'renderer/hooks/papi-hooks/use-event.hook';
+  export { default as useEventAsync } from 'renderer/hooks/papi-hooks/use-event-async.hook';
+  export { default as useDataProvider } from 'renderer/hooks/papi-hooks/use-data-provider.hook';
+  export { default as useData } from 'renderer/hooks/papi-hooks/use-data.hook';
+  export { default as useSetting } from 'renderer/hooks/papi-hooks/use-setting.hook';
+  export { default as useProjectData } from 'renderer/hooks/papi-hooks/use-project-data.hook';
+  export { default as useProjectDataProvider } from 'renderer/hooks/papi-hooks/use-project-data-provider.hook';
+  export { default as useDialogCallback } from 'renderer/hooks/papi-hooks/use-dialog-callback.hook';
+  export { default as useDataProviderMulti } from 'renderer/hooks/papi-hooks/use-data-provider-multi.hook';
+}
+declare module 'papi-frontend/react' {
+  export * from 'renderer/hooks/papi-hooks/index';
 }
 declare module 'papi-frontend' {
   /**
@@ -4233,10 +4056,9 @@ declare module 'papi-frontend' {
   import { DataProviderService } from 'shared/services/data-provider.service';
   import { ProjectLookupServiceType } from 'shared/services/project-lookup.service-model';
   import { PapiFrontendProjectDataProviderService } from 'shared/services/project-data-provider.service';
-  import { PapiContext } from 'renderer/context/papi-context/index';
-  import { PapiHooks } from 'renderer/hooks/papi-hooks/index';
   import { SettingsService } from 'shared/services/settings.service';
   import { DialogService } from 'shared/services/dialog.service-model';
+  import * as papiReact from 'papi-frontend/react';
   const papi: {
     /**
      * Event manager - accepts subscriptions to an event and runs the subscription callbacks when
@@ -4247,7 +4069,7 @@ declare module 'papi-frontend' {
      */
     EventEmitter: typeof PapiEventEmitter;
     /** This is just an alias for internet.fetch */
-    fetch: typeof fetch;
+    fetch: typeof globalThis.fetch;
     /**
      * The command service allows you to exchange messages with other components in the platform.
      * You can register a command that other services and extensions can send you. You can send
@@ -4283,16 +4105,59 @@ declare module 'papi-frontend' {
     projectDataProvider: PapiFrontendProjectDataProviderService;
     /** Provides metadata for projects known by the platform */
     projectLookup: ProjectLookupServiceType;
-    react: {
-      /** All React contexts to be exposed on the papi */
-      context: PapiContext;
-      /** All React hooks to be exposed on the papi */
-      hooks: PapiHooks;
-    };
+    react: typeof papiReact;
     /** Service that allows to get and set settings in local storage */
     settings: SettingsService;
   };
   export default papi;
+  /**
+   * Event manager - accepts subscriptions to an event and runs the subscription callbacks when the
+   * event is emitted Use eventEmitter.event(callback) to subscribe to the event. Use
+   * eventEmitter.emit(event) to run the subscriptions. Generally, this EventEmitter should be
+   * private, and its event should be public. That way, the emitter is not publicized, but anyone
+   * can subscribe to the event.
+   */
+  export const EventEmitter: typeof PapiEventEmitter;
+  /** This is just an alias for internet.fetch */
+  export const fetch: typeof globalThis.fetch;
+  /**
+   * The command service allows you to exchange messages with other components in the platform. You
+   * can register a command that other services and extensions can send you. You can send commands
+   * to other services and extensions that have registered commands.
+   */
+  export const commands: typeof commandService;
+  /**
+   * PapiUtil is a collection of functions, objects, and types that are used as helpers in other
+   * services. Extensions should not use or rely on anything in papiUtil unless some other service
+   * requires it.
+   */
+  export const util: typeof papiUtil;
+  /**
+   * Service exposing various functions related to using webViews
+   *
+   * WebViews are iframes in the Platform.Bible UI into which extensions load frontend code, either
+   * HTML or React components.
+   */
+  export const webViews: PapiWebViewService;
+  /** Prompt the user for responses with dialogs */
+  export const dialogs: DialogService;
+  /** Service that provides a way to send and receive network events */
+  export const network: PapiNetworkService;
+  /** All extensions and services should use this logger to provide a unified output of logs */
+  export const logger: import('electron-log').MainLogger & {
+    default: import('electron-log').MainLogger;
+  };
+  /** Service that provides a way to call `fetch` since the original function is not available */
+  export const internet: InternetService;
+  /** Service that allows extensions to send and receive data to/from other extensions */
+  export const dataProvider: DataProviderService;
+  /** Service that registers and gets project data providers */
+  export const projectDataProvider: PapiFrontendProjectDataProviderService;
+  /** Provides metadata for projects known by the platform */
+  export const projectLookup: ProjectLookupServiceType;
+  export const react: typeof papiReact;
+  /** Service that allows to get and set settings in local storage */
+  export const settings: SettingsService;
   export type Papi = typeof papi;
 }
 declare module 'shared/data/file-system.model' {
@@ -4585,8 +4450,20 @@ declare module 'papi-backend' {
      * can subscribe to the event.
      */
     EventEmitter: typeof PapiEventEmitter;
+    /**
+     * Abstract class that provides a placeholder `notifyUpdate` for data provider engine classes.
+     * If a data provider engine class extends this class, it doesn't have to specify its own
+     * `notifyUpdate` function in order to use `notifyUpdate`.
+     *
+     * @see IDataProviderEngine for more information on extending this class.
+     */
+    DataProviderEngine: abstract new <
+      TDataTypes extends import('shared/models/data-provider.model').DataProviderDataTypes,
+    >() => {
+      notifyUpdate: import('shared/models/data-provider-engine.model').DataProviderEngineNotifyUpdate<TDataTypes>;
+    };
     /** This is just an alias for internet.fetch */
-    fetch: typeof fetch;
+    fetch: typeof globalThis.fetch;
     /**
      * The command service allows you to exchange messages with other components in the platform.
      * You can register a command that other services and extensions can send you. You can send
@@ -4632,6 +4509,71 @@ declare module 'papi-backend' {
     storage: ExtensionStorageService;
   };
   export default papi;
+  /**
+   * Event manager - accepts subscriptions to an event and runs the subscription callbacks when the
+   * event is emitted Use eventEmitter.event(callback) to subscribe to the event. Use
+   * eventEmitter.emit(event) to run the subscriptions. Generally, this EventEmitter should be
+   * private, and its event should be public. That way, the emitter is not publicized, but anyone
+   * can subscribe to the event.
+   */
+  export const EventEmitter: typeof PapiEventEmitter;
+  /**
+   * Abstract class that provides a placeholder `notifyUpdate` for data provider engine classes. If
+   * a data provider engine class extends this class, it doesn't have to specify its own
+   * `notifyUpdate` function in order to use `notifyUpdate`.
+   *
+   * @see IDataProviderEngine for more information on extending this class.
+   */
+  export const DataProviderEngine: abstract new <
+    TDataTypes extends import('shared/models/data-provider.model').DataProviderDataTypes,
+  >() => {
+    notifyUpdate: import('shared/models/data-provider-engine.model').DataProviderEngineNotifyUpdate<TDataTypes>;
+  };
+  /** This is just an alias for internet.fetch */
+  export const fetch: typeof globalThis.fetch;
+  /**
+   * The command service allows you to exchange messages with other components in the platform. You
+   * can register a command that other services and extensions can send you. You can send commands
+   * to other services and extensions that have registered commands.
+   */
+  export const commands: typeof commandService;
+  /**
+   * PapiUtil is a collection of functions, objects, and types that are used as helpers in other
+   * services. Extensions should not use or rely on anything in papiUtil unless some other service
+   * requires it.
+   */
+  export const util: typeof papiUtil;
+  /**
+   * Service exposing various functions related to using webViews
+   *
+   * WebViews are iframes in the Platform.Bible UI into which extensions load frontend code, either
+   * HTML or React components.
+   */
+  export const webViews: PapiWebViewService;
+  /** Interface for registering webView providers */
+  export const webViewProviders: PapiWebViewProviderService;
+  /** Prompt the user for responses with dialogs */
+  export const dialogs: DialogService;
+  /** Service that provides a way to send and receive network events */
+  export const network: PapiNetworkService;
+  /** All extensions and services should use this logger to provide a unified output of logs */
+  export const logger: import('electron-log').MainLogger & {
+    default: import('electron-log').MainLogger;
+  };
+  /** Service that provides a way to call `fetch` since the original function is not available */
+  export const internet: InternetService;
+  /** Service that allows extensions to send and receive data to/from other extensions */
+  export const dataProvider: DataProviderService;
+  /** Service that registers and gets project data providers */
+  export const projectDataProvider: PapiBackendProjectDataProviderService;
+  /** Provides metadata for projects known by the platform */
+  export const projectLookup: ProjectLookupServiceType;
+  /**
+   * This service provides extensions in the extension host the ability to read/write data based on
+   * the extension identity and current user (as identified by the OS). This service will not work
+   * within the renderer.
+   */
+  export const storage: ExtensionStorageService;
 }
 declare module 'extension-host/extension-types/extension-activation-context.model' {
   import { ExecutionToken } from 'node/models/execution-token.model';

--- a/lib/papi-dts/tsconfig.json
+++ b/lib/papi-dts/tsconfig.json
@@ -22,6 +22,7 @@
   "include": [
     "../../src/declarations/*",
     "../../src/renderer/services/papi-frontend.service.ts",
+    "../../src/renderer/services/papi-frontend-react.service.ts",
     "../../src/extension-host/services/papi-backend.service.ts",
     "../../src/extension-host/extension-types/extension.interface.ts"
   ],

--- a/src/extension-host/services/papi-backend.service.ts
+++ b/src/extension-host/services/papi-backend.service.ts
@@ -7,7 +7,7 @@
 import PapiEventEmitter from '@shared/models/papi-event-emitter.model';
 import * as commandService from '@shared/services/command.service';
 import * as papiUtil from '@shared/utils/papi-util';
-import logger from '@shared/services/logger.service';
+import papiLogger from '@shared/services/logger.service';
 import { papiNetworkService, PapiNetworkService } from '@shared/services/network.service';
 import { papiWebViewService, PapiWebViewService } from '@shared/services/web-view.service';
 import {
@@ -35,10 +35,13 @@ import { DialogService } from '@shared/services/dialog.service-model';
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion, no-type-assertion/no-type-assertion */
 // 3) The "JSDOC DESTINATION" comments are there to provide anchors for JSDocs to be copied in.
 // Please add to all properties you add.
+// 4) Anytime you add anything to PAPI also add it to the destructured export below
 const papi = {
   // Classes
   /** JSDOC DESTINATION PapiEventEmitter */
   EventEmitter: PapiEventEmitter,
+  /** JSDOC DESTINATION DataProviderEngine */
+  DataProviderEngine: dataProviderService.DataProviderEngine,
 
   // Functions
   /** This is just an alias for internet.fetch */
@@ -58,7 +61,7 @@ const papi = {
   /** JSDOC DESTINATION papiNetworkService */
   network: papiNetworkService as PapiNetworkService,
   /** JSDOC DESTINATION logger */
-  logger,
+  logger: papiLogger,
   /** JSDOC DESTINATION internetService */
   internet: internetService as InternetService,
   /** JSDOC DESTINATION dataProviderService */
@@ -72,3 +75,36 @@ const papi = {
   storage: extensionStorageService as ExtensionStorageService,
 };
 export default papi;
+
+// This is the destructured export, if you add to the PAPI you need to add to this
+
+/** JSDOC DESTINATION PapiEventEmitter */
+export const { EventEmitter } = papi;
+/** JSDOC DESTINATION DataProviderEngine */
+export const { DataProviderEngine } = papi;
+/** This is just an alias for internet.fetch */
+export const { fetch } = papi;
+/** JSDOC DESTINATION commandService */
+export const { commands } = papi;
+/** JSDOC DESTINATION papiUtil */
+export const { util } = papi;
+/** JSDOC DESTINATION papiWebViewService */
+export const { webViews } = papi;
+/** JSDOC DESTINATION papiWebViewProviderService */
+export const { webViewProviders } = papi;
+/** JSDOC DESTINATION dialogService */
+export const { dialogs } = papi;
+/** JSDOC DESTINATION papiNetworkService */
+export const { network } = papi;
+/** JSDOC DESTINATION logger */
+export const { logger } = papi;
+/** JSDOC DESTINATION internetService */
+export const { internet } = papi;
+/** JSDOC DESTINATION dataProviderService */
+export const { dataProvider } = papi;
+/** JSDOC DESTINATION papiBackendProjectDataProviderService */
+export const { projectDataProvider } = papi;
+/** JSDOC DESTINATION projectLookupService */
+export const { projectLookup } = papi;
+/** JSDOC DESTINATION extensionStorageService */
+export const { storage } = papi;

--- a/src/renderer/global-this.model.ts
+++ b/src/renderer/global-this.model.ts
@@ -13,6 +13,7 @@ import {
   setWebViewStateById,
 } from '@renderer/services/web-view-state.service';
 import useWebViewState from '@renderer/hooks/use-webview-state.hook';
+import * as papiReact from '@renderer/services/papi-frontend-react.service';
 
 // #region webpack DefinePlugin types setup - these should be from the renderer webpack DefinePlugin
 
@@ -28,6 +29,7 @@ declare const webpackRenderer: {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const moduleMap = new Map<string, any>();
 moduleMap.set('papi-frontend', papi);
+moduleMap.set('papi-frontend/react', papiReact);
 moduleMap.set('react', React);
 moduleMap.set('react/jsx-runtime', ReactJsxRuntime);
 moduleMap.set('react-dom', ReactDOM);

--- a/src/renderer/hooks/papi-hooks/index.ts
+++ b/src/renderer/hooks/papi-hooks/index.ts
@@ -1,46 +1,10 @@
-import usePromise from '@renderer/hooks/papi-hooks/use-promise.hook';
-import useEvent from '@renderer/hooks/papi-hooks/use-event.hook';
-import useEventAsync from '@renderer/hooks/papi-hooks/use-event-async.hook';
-import useDataProvider from '@renderer/hooks/papi-hooks/use-data-provider.hook';
-import useData from '@renderer/hooks/papi-hooks/use-data.hook';
-import useSetting from '@renderer/hooks/papi-hooks/use-setting.hook';
-import useProjectData from '@renderer/hooks/papi-hooks/use-project-data.hook';
-import useProjectDataProvider from '@renderer/hooks/papi-hooks/use-project-data-provider.hook';
-import useDialogCallback from '@renderer/hooks/papi-hooks/use-dialog-callback.hook';
-import useDataProviderMulti from '@renderer/hooks/papi-hooks/use-data-provider-multi.hook';
-
-// Declare an interface for the object we're exporting so that JSDoc comments propagate
-export interface PapiHooks {
-  useDialogCallback: typeof useDialogCallback;
-  usePromise: typeof usePromise;
-  useEvent: typeof useEvent;
-  useEventAsync: typeof useEventAsync;
-  useProjectDataProvider: typeof useProjectDataProvider;
-  useDataProvider: typeof useDataProvider;
-  useDataProviderMulti: typeof useDataProviderMulti;
-  /** JSDOC DESTINATION UseDataHook */
-  useData: typeof useData;
-  /** JSDOC DESTINATION UseProjectDataHook */
-  useProjectData: typeof useProjectData;
-  useSetting: typeof useSetting;
-}
-
-/**
- * JSDOC SOURCE papiHooks
- *
- * All React hooks to be exposed on the papi
- */
-const papiHooks: PapiHooks = {
-  useDialogCallback,
-  usePromise,
-  useEvent,
-  useEventAsync,
-  useProjectDataProvider,
-  useDataProvider,
-  useDataProviderMulti,
-  useData,
-  useProjectData,
-  useSetting,
-};
-
-export default papiHooks;
+export { default as usePromise } from '@renderer/hooks/papi-hooks/use-promise.hook';
+export { default as useEvent } from '@renderer/hooks/papi-hooks/use-event.hook';
+export { default as useEventAsync } from '@renderer/hooks/papi-hooks/use-event-async.hook';
+export { default as useDataProvider } from '@renderer/hooks/papi-hooks/use-data-provider.hook';
+export { default as useData } from '@renderer/hooks/papi-hooks/use-data.hook';
+export { default as useSetting } from '@renderer/hooks/papi-hooks/use-setting.hook';
+export { default as useProjectData } from '@renderer/hooks/papi-hooks/use-project-data.hook';
+export { default as useProjectDataProvider } from '@renderer/hooks/papi-hooks/use-project-data-provider.hook';
+export { default as useDialogCallback } from '@renderer/hooks/papi-hooks/use-dialog-callback.hook';
+export { default as useDataProviderMulti } from '@renderer/hooks/papi-hooks/use-data-provider-multi.hook';

--- a/src/renderer/hooks/papi-hooks/use-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-data.hook.ts
@@ -7,8 +7,6 @@ import createUseDataHook, {
 // such on this object. JSDoc does not usually allow these on the object. One day, we may be able to
 // put this comment on an actual function, so we can fix the comments back to using real @
 /**
- * JSDOC SOURCE UseDataHook
- *
  * ```typescript
  * useData.DataType<TDataTypes extends DataProviderDataTypes, TDataType extends keyof TDataTypes>(
  *   dataProviderSource: string | IDataProvider<TDataTypes> | undefined,

--- a/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
@@ -51,8 +51,6 @@ type UseProjectDataHook = {
 // such on this object. JSDoc does not usually allow these on the object. One day, we may be able to
 // put this comment on an actual function, so we can fix the comments back to using real @
 /**
- * JSDOC SOURCE UseProjectDataHook
- *
  * ```typescript
  * useProjectData.DataType<TProjectDataTypes extends DataProviderDataTypes, TDataType extends keyof TProjectDataTypes>(
  *   projectDataProviderSource: string | IDataProvider<TProjectDataTypes> | undefined,

--- a/src/renderer/services/papi-frontend-react.service.ts
+++ b/src/renderer/services/papi-frontend-react.service.ts
@@ -1,0 +1,1 @@
+export * from '@renderer/hooks/papi-hooks';

--- a/src/renderer/services/papi-frontend.service.ts
+++ b/src/renderer/services/papi-frontend.service.ts
@@ -7,7 +7,7 @@
 import PapiEventEmitter from '@shared/models/papi-event-emitter.model';
 import * as commandService from '@shared/services/command.service';
 import * as papiUtil from '@shared/utils/papi-util';
-import logger from '@shared/services/logger.service';
+import papiLogger from '@shared/services/logger.service';
 import { papiNetworkService, PapiNetworkService } from '@shared/services/network.service';
 import { papiWebViewService, PapiWebViewService } from '@shared/services/web-view.service';
 import internetService, { InternetService } from '@shared/services/internet.service';
@@ -18,11 +18,10 @@ import {
   papiFrontendProjectDataProviderService,
   PapiFrontendProjectDataProviderService,
 } from '@shared/services/project-data-provider.service';
-import papiContext, { PapiContext } from '@renderer/context/papi-context';
-import papiHooks, { PapiHooks } from '@renderer/hooks/papi-hooks';
 import settingsService, { SettingsService } from '@shared/services/settings.service';
 import dialogService from '@shared/services/dialog.service';
 import { DialogService } from '@shared/services/dialog.service-model';
+import * as papiReact from '@renderer/services/papi-frontend-react.service';
 
 // IMPORTANT NOTES:
 // 1) When adding new services here, consider whether they also belong in papi-backend.service.ts.
@@ -31,6 +30,7 @@ import { DialogService } from '@shared/services/dialog.service-model';
 /* eslint-disable @typescript-eslint/no-unnecessary-type-assertion, no-type-assertion/no-type-assertion */
 // 3) The "JSDOC DESTINATION" comments are there to provide anchors for JSDocs to be copied in.
 // Please add to all properties you add.
+// 4) Anytime you add anything to PAPI also add it to the destructured export below
 const papi = {
   // Classes
   /** JSDOC DESTINATION PapiEventEmitter */
@@ -52,7 +52,7 @@ const papi = {
   /** JSDOC DESTINATION papiNetworkService */
   network: papiNetworkService as PapiNetworkService,
   /** JSDOC DESTINATION logger */
-  logger,
+  logger: papiLogger,
   /** JSDOC DESTINATION internetService */
   internet: internetService as InternetService,
   /** JSDOC DESTINATION dataProviderService */
@@ -62,15 +62,42 @@ const papi = {
     papiFrontendProjectDataProviderService as PapiFrontendProjectDataProviderService,
   /** JSDOC DESTINATION projectLookupService */
   projectLookup: projectLookupService as ProjectLookupServiceType,
-  react: {
-    /** JSDOC DESTINATION papiContext */
-    context: papiContext as PapiContext,
-    /** JSDOC DESTINATION papiHooks */
-    hooks: papiHooks as PapiHooks,
-  },
+  /** JSDOC SOURCE papiReact */
+  react: papiReact,
   /** JSDOC DESTINATION settingsService */
   settings: settingsService as SettingsService,
 };
 export default papi;
+
+// If you add to the PAPI you need to add to this
+
+/** JSDOC DESTINATION PapiEventEmitter */
+export const { EventEmitter } = papi;
+/** This is just an alias for internet.fetch */
+export const { fetch } = papi;
+/** JSDOC DESTINATION commandService */
+export const { commands } = papi;
+/** JSDOC DESTINATION papiUtil */
+export const { util } = papi;
+/** JSDOC DESTINATION papiWebViewService */
+export const { webViews } = papi;
+/** JSDOC DESTINATION dialogService */
+export const { dialogs } = papi;
+/** JSDOC DESTINATION papiNetworkService */
+export const { network } = papi;
+/** JSDOC DESTINATION logger */
+export const { logger } = papi;
+/** JSDOC DESTINATION internetService */
+export const { internet } = papi;
+/** JSDOC DESTINATION dataProviderService */
+export const { dataProvider } = papi;
+/** JSDOC DESTINATION papiBackendProjectDataProviderService */
+export const { projectDataProvider } = papi;
+/** JSDOC DESTINATION projectLookupService */
+export const { projectLookup } = papi;
+/** JSDOC DESTINATION papiReact */
+export const { react } = papi;
+/** JSDOC DESTINATION settingsService */
+export const { settings } = papi;
 
 export type Papi = typeof papi;

--- a/src/shared/services/data-provider.service.ts
+++ b/src/shared/services/data-provider.service.ts
@@ -55,6 +55,8 @@ let isInitialized = false;
 let initializePromise: Promise<void> | undefined;
 
 /**
+ * JSDOC SOURCE DataProviderEngine
+ *
  * Abstract class that provides a placeholder `notifyUpdate` for data provider engine classes. If a
  * data provider engine class extends this class, it doesn't have to specify its own `notifyUpdate`
  * function in order to use `notifyUpdate`.


### PR DESCRIPTION
Add new import path in `src/renderer global-this`
Add new service for `papi-frontent-react.service` that exports all of the PAPI hooks
Switches all imports in core to the new

Export parts of PAPI individually in `papi-frontend` and `papi-backend` so they can be accessed without destructuring papi. Originally I had a destructured export instead of exporting each const, but when I commit the code I got the error: `Split 'const' declarations into multiple statements`. I tried to assert as a const, but got another error: `A 'const' assertions can only be applied to references to enum members, or string, number, boolean, array, or object literals.`