### PR TITLE
Improve resiliance of network request registration and error messages

### DIFF
--- a/c-sharp-tests/PapiTestBase.cs
+++ b/c-sharp-tests/PapiTestBase.cs
@@ -82,7 +82,7 @@ namespace TestParanextDataProvider
         }
 
         /// <summary>
-        /// Creates fake project details to fake the existence of a project 
+        /// Creates fake project details to fake the existence of a project
         /// </summary>
         /// <seealso cref="DummyLocalProjects.FakeAddProject"/>
         protected static ProjectDetails CreateProjectDetails(string id, string name)
@@ -142,7 +142,7 @@ namespace TestParanextDataProvider
             }
 
             jsonBldr.Append("] }");
-            
+
             JsonDocument serverMessage = JsonDocument.Parse(jsonBldr.ToString());
             return serverMessage.RootElement.GetProperty("value");
         }
@@ -173,7 +173,7 @@ namespace TestParanextDataProvider
 
             Assert.That(usfm1, Is.EqualTo(usfm2));
         }
-        
+
         /// <summary>
         /// Asserts that the two snippets of USX are the same. This function normalizes both snippets
         /// to ensure maximum compatibility between them.
@@ -218,7 +218,7 @@ namespace TestParanextDataProvider
                 Assert.That(message.Type, Is.EqualTo(MessageType.Response));
 
                 MessageResponse response = (MessageResponse)message;
-                Assert.That(response.ErrorMessage, Is.EqualTo(expectedErrorMessage));
+                Assert.That(response.ErrorMessage, Does.Contain(expectedErrorMessage));
                 Assert.That(response.Success, Is.EqualTo(string.IsNullOrEmpty(expectedErrorMessage)));
                 Assert.That(response.RequestType, Is.EqualTo(expectedResponseType));
                 Assert.That(response.RequestId, Is.EqualTo(expectedRequestId));

--- a/c-sharp-tests/PapiTestBase.cs
+++ b/c-sharp-tests/PapiTestBase.cs
@@ -218,7 +218,7 @@ namespace TestParanextDataProvider
                 Assert.That(message.Type, Is.EqualTo(MessageType.Response));
 
                 MessageResponse response = (MessageResponse)message;
-                Assert.That(response.ErrorMessage, Does.Contain(expectedErrorMessage));
+                Assert.That(response.ErrorMessage ?? "", Does.Contain(expectedErrorMessage ?? ""));
                 Assert.That(response.Success, Is.EqualTo(string.IsNullOrEmpty(expectedErrorMessage)));
                 Assert.That(response.RequestType, Is.EqualTo(expectedResponseType));
                 Assert.That(response.RequestId, Is.EqualTo(expectedRequestId));

--- a/c-sharp/MessageTransports/PapiClient.cs
+++ b/c-sharp/MessageTransports/PapiClient.cs
@@ -199,7 +199,7 @@ internal class PapiClient : IDisposable
     public virtual async Task<bool> RegisterRequestHandler(
         Enum<RequestType> requestType,
         Func<dynamic, ResponseToRequest> requestHandler,
-        int responseTimeoutInMs = 1000
+        int responseTimeoutInMs = 5000
     )
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
@@ -245,7 +245,10 @@ internal class PapiClient : IDisposable
 
         var timeout = TimeSpan.FromMilliseconds(responseTimeoutInMs);
         if (!await IsTaskCompleted(registrationTask, timeout, _cancellationToken))
+        {
             Console.WriteLine($"No response when registering request type \"{requestType}\"");
+            registrationSource.TrySetCanceled();
+        }
 
         return registrationSucceeded;
     }

--- a/c-sharp/NetworkObjects/UsfmDataProvider.cs
+++ b/c-sharp/NetworkObjects/UsfmDataProvider.cs
@@ -53,7 +53,7 @@ internal class UsfmDataProvider : DataProvider
         catch (Exception e)
         {
             Console.Error.WriteLine(e.ToString());
-            return ResponseToRequest.Failed(e.Message);
+            return ResponseToRequest.Failed(e.ToString());
         }
     }
 
@@ -119,7 +119,7 @@ internal class UsfmDataProvider : DataProvider
         }
         catch (Exception e)
         {
-            return ResponseToRequest.Failed(e.Message);
+            return ResponseToRequest.Failed(e.ToString());
         }
 
         return ResponseToRequest.Succeeded();

--- a/c-sharp/Projects/ParatextProjectStorageInterpreter.cs
+++ b/c-sharp/Projects/ParatextProjectStorageInterpreter.cs
@@ -70,7 +70,7 @@ internal class ParatextProjectStorageInterpreter : ProjectStorageInterpreter
         }
         catch (Exception ex)
         {
-            return ResponseToRequest.Failed(ex.Message);
+            return ResponseToRequest.Failed(ex.ToString());
         }
 
         // TODO: Do something to actually create the Paratext part of the project
@@ -220,7 +220,7 @@ internal class ParatextProjectStorageInterpreter : ProjectStorageInterpreter
         }
         catch (Exception e)
         {
-            return ResponseToRequest.Failed(e.Message);
+            return ResponseToRequest.Failed(e.ToString());
         }
     }
     #endregion

--- a/c-sharp/Projects/ProjectDataProvider.cs
+++ b/c-sharp/Projects/ProjectDataProvider.cs
@@ -74,7 +74,7 @@ internal abstract class ProjectDataProvider : NetworkObjects.DataProvider
         catch (Exception e)
         {
             Console.Error.WriteLine(e.ToString());
-            return ResponseToRequest.Failed(e.Message);
+            return ResponseToRequest.Failed(e.ToString());
         }
     }
 
@@ -86,7 +86,7 @@ internal abstract class ProjectDataProvider : NetworkObjects.DataProvider
         }
         catch (Exception ex)
         {
-            return ResponseToRequest.Failed(ex.Message);
+            return ResponseToRequest.Failed(ex.ToString());
         }
     }
 
@@ -99,7 +99,7 @@ internal abstract class ProjectDataProvider : NetworkObjects.DataProvider
         }
         catch (Exception ex)
         {
-            return ResponseToRequest.Failed(ex.Message);
+            return ResponseToRequest.Failed(ex.ToString());
         }
     }
 

--- a/c-sharp/Projects/ProjectDataProviderFactory.cs
+++ b/c-sharp/Projects/ProjectDataProviderFactory.cs
@@ -62,7 +62,7 @@ internal abstract class ProjectDataProviderFactory : NetworkObject
         }
         catch (Exception e)
         {
-            return ResponseToRequest.Failed(e.Message);
+            return ResponseToRequest.Failed(e.ToString());
         }
     }
 


### PR DESCRIPTION
I'm applying some changes make to the tech demo branch back to main.

The most important change here is in `PapiClient.cs`.  If the network service doesn't respond to a request registration within the expected time, then we were causing an exception that hid what was going on.  I also increased the timeout (which we could decide to ditch entirely later if we want).

I changed several response error messages to include call stacks because just giving the exception message wasn't enough to easily track down the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/635)
<!-- Reviewable:end -->
