### PR TITLE
Fix Scripture update events not causing data providers to re-fetch data

### DIFF
--- a/c-sharp-tests/Projects/ParatextDataProviderTests.cs
+++ b/c-sharp-tests/Projects/ParatextDataProviderTests.cs
@@ -39,7 +39,7 @@ namespace TestParanextDataProvider.Projects
             await provider.RegisterDataProvider();
 
             JsonElement serverMessage = CreateRequestMessage(function);
-            
+
             Enum<RequestType> requestType = new(PdpDataRequest);
             Message result = Client.FakeMessageFromServer(new MessageRequest(requestType, requesterId, serverMessage)).First();
 
@@ -66,7 +66,7 @@ namespace TestParanextDataProvider.Projects
 
             JsonElement serverMessage =
                 CreateRequestMessage(function, CreateVerseRefNode(bookNum, chapterNum, verseNum));
-            
+
             Enum<RequestType> requestType = new(PdpDataRequest);
             Message result = Client.FakeMessageFromServer(new MessageRequest(requestType, requesterId, serverMessage)).First();
 
@@ -132,7 +132,7 @@ namespace TestParanextDataProvider.Projects
             Enum<RequestType> requestType = new(PdpDataRequest);
             Message result = Client.FakeMessageFromServer(new MessageRequest(requestType, requesterId, serverMessage)).First();
 
-            VerifyResponse(result, null, requestType, requesterId, "ChapterUSX");
+            VerifyResponse(result, null, requestType, requesterId, ParatextProjectStorageInterpreter.AllScriptureDataTypes);
 
             // Verify the new text was saved to disk
             VerseRef reference = new(bookNum, chapterNum, verseNum, _scrText.Settings.Versification);
@@ -168,7 +168,7 @@ namespace TestParanextDataProvider.Projects
             Enum<RequestType> requestType = new(PdpDataRequest);
             Message result = Client.FakeMessageFromServer(new MessageRequest(requestType, requesterId, serverMessage)).First();
 
-            VerifyResponse(result, null, requestType, requesterId, "ChapterUSFM");
+            VerifyResponse(result, null, requestType, requesterId, ParatextProjectStorageInterpreter.AllScriptureDataTypes);
 
             // Verify the new text was saved to disk
             VerseRef reference = new(bookNum, chapterNum, verseNum, _scrText.Settings.Versification);

--- a/c-sharp/NetworkObjects/DataProvider.cs
+++ b/c-sharp/NetworkObjects/DataProvider.cs
@@ -12,15 +12,18 @@ namespace Paranext.DataProvider.NetworkObjects;
 internal abstract class DataProvider : NetworkObject
 {
     // This is an internal class because nothing else should be instantiating it directly
-    private class MessageEventDataUpdated : MessageEventGeneric<string>
+    private class MessageEventDataUpdated : MessageEventGeneric<dynamic>
     {
         // A parameterless constructor is required for serialization to work
         // ReSharper disable once UnusedMember.Local
         public MessageEventDataUpdated()
             : base(Enum<EventType>.Null) { }
 
-        public MessageEventDataUpdated(Enum<EventType> eventType, string dataScope)
-            : base(eventType, dataScope) { }
+        public MessageEventDataUpdated(Enum<EventType> eventType, dynamic dataScope)
+            // Must cast to (object) for C# to know which base constructor to use
+            // See https://stackoverflow.com/questions/8098981/why-do-i-get-this-compile-error-trying-to-call-a-base-constructor-method-that-ta
+            // for more info
+            : base(eventType, (object)dataScope) { }
     }
 
     private readonly Enum<EventType> _eventType;
@@ -76,37 +79,65 @@ internal abstract class DataProvider : NetworkObject
     }
 
     /// <summary>
-    /// Notify all processes on the network that this data provider has new data
+    /// Notify all processes on the network that this data provider has new data.
+    ///
+    /// This method transforms the data scope in the same way that `data-provider`service.ts`'s
+    /// `mapUpdateInstructionsToUpdateEvent` does
     /// </summary>
-    /// <param name="dataScope">Indicator of what data changed in the provider</param>
+    /// <param name="dataScope">Indicator of what data changed in the provider. Can be '*' for all
+    /// updates, a `string` to update one data type, or a `List<string>` of data types to update. If dataScope is null, nothing happens. </param>
     protected void SendDataUpdateEvent(dynamic? dataScope)
     {
-        string scopeString;
+        // The final computed data scope to send out in the update event. Based on dataScope
+        dynamic dataScopeResult;
 
         if ((dataScope is string s) && !string.IsNullOrWhiteSpace(s))
         {
-            // If we are returning "*", just pass it as a string.  Otherwise we have to provide a JSON list of strings.
+            // If we are returning "*", just pass it as a string.  Otherwise we have to provide a list of strings.
             // Presumably this will change as part of https://github.com/paranext/paranext-core/issues/443
-            scopeString = (s == "*") ? s : JsonConvert.SerializeObject(new List<string> { s });
+            dataScopeResult = (s == "*") ? s : new List<string> { s };
         }
-        else if (dataScope != null)
+        else if (dataScope is List<string> dataScopeList)
         {
-            try
+            if (dataScopeList.Count > 0)
+                dataScopeResult = dataScope;
+            // Empty list means no data type updates
+            else
             {
-                scopeString = JsonConvert.SerializeObject(dataScope);
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine($"Unable to send data update event: {ex}");
+                Console.WriteLine("Did not send data update event. dataScope is an empty list");
                 return;
             }
         }
         else
+        {
+            if (dataScope != null)
+                Console.WriteLine(
+                    "Did not send data update event. dataScope is not a string or list of strings"
+                );
             return;
+        }
+
+        // a string representation of the data scope result to use when finding an existing message
+        // for the event
+        string dataScopeKey;
+        if (dataScopeResult is string sR)
+            dataScopeKey = sR;
+        else if (dataScopeResult is List<string> dataScopeListR)
+            dataScopeKey = string.Join(',', dataScopeListR);
+        else
+        {
+            Console.WriteLine(
+                $"dataScopeResult {dataScopeResult} was not string or list of strings. Unable to send data update event"
+            );
+            return;
+        }
 
         var dataUpdateEventMessage = _updateEventsByScope.GetOrAdd(
-            scopeString,
-            (scope) => new MessageEventDataUpdated(_eventType, scope)
+            dataScopeKey,
+            (Func<string, dynamic, MessageEventDataUpdated>)(
+                (scope, result) => new MessageEventDataUpdated(_eventType, result)
+            ),
+            dataScopeResult
         );
         PapiClient.SendEvent(dataUpdateEventMessage);
     }

--- a/c-sharp/NetworkObjects/DataProvider.cs
+++ b/c-sharp/NetworkObjects/DataProvider.cs
@@ -134,6 +134,9 @@ internal abstract class DataProvider : NetworkObject
 
         var dataUpdateEventMessage = _updateEventsByScope.GetOrAdd(
             dataScopeKey,
+            // Must cast to specific function type because the anonymous lambda was not clear to the
+            // compiler. See https://stackoverflow.com/questions/43890447/cannot-use-a-lambda-expression-as-an-argument-to-a-dynamically-dispatched
+            // for more information
             (Func<string, dynamic, MessageEventDataUpdated>)(
                 (scope, result) => new MessageEventDataUpdated(_eventType, result)
             ),

--- a/c-sharp/Projects/ParatextProjectStorageInterpreter.cs
+++ b/c-sharp/Projects/ParatextProjectStorageInterpreter.cs
@@ -19,6 +19,16 @@ internal class ParatextProjectStorageInterpreter : ProjectStorageInterpreter
     public const string VerseUSFM = "VerseUSFM";
     public const string ChapterUSX = "ChapterUSX";
 
+    // All data types related to Scripture editing. Changes to any portion of Scripture should send
+    // out updates to all these data types
+    public static readonly List<string> AllScriptureDataTypes = new List<string>
+    {
+        BookUSFM,
+        ChapterUSFM,
+        VerseUSFM,
+        ChapterUSX
+    };
+
     private readonly LocalProjects _projects;
     #endregion
 
@@ -152,8 +162,8 @@ internal class ParatextProjectStorageInterpreter : ProjectStorageInterpreter
                         );
                     }
                 );
-                // The value of returned string is case sensitive and cannot change unless data provider subscriptions change
-                return ResponseToRequest.Succeeded(ChapterUSFM);
+                // The value of returned strings are case sensitive and cannot change unless data provider subscriptions change
+                return ResponseToRequest.Succeeded(AllScriptureDataTypes);
             case ChapterUSX:
                 if (!string.IsNullOrEmpty(error))
                     return ResponseToRequest.Failed(error);
@@ -284,7 +294,7 @@ internal class ParatextProjectStorageInterpreter : ProjectStorageInterpreter
             return ResponseToRequest.Failed(e.ToString());
         }
 
-        return ResponseToRequest.Succeeded(ChapterUSX);
+        return ResponseToRequest.Succeeded(AllScriptureDataTypes);
     }
 
     private static XmlDocument ConvertUsfmToUsx(ScrText scrText, string usfm, int bookNum)


### PR DESCRIPTION
Update events on C# were being double-serialized. As such, subscribers weren't receiving updates. Additionally, not all relevant data types were announced as updated.

Before, the update looked like this:
![image](https://github.com/paranext/paranext-core/assets/104016682/aa7e09be-2779-4a51-9a62-e65a6ecccb55)


Now, the update looks like this:
![image](https://github.com/paranext/paranext-core/assets/104016682/993a10c3-469e-44e2-affb-b23912a5772d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/644)
<!-- Reviewable:end -->
