### PR TITLE
Improve JSDoc divider

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -97,7 +97,7 @@ declare module 'shared/models/web-view.model' {
      * If you plan on embedding any iframes in your WebView, it is best practice to list only the host
      * values you need to function. The more you list, the higher the theoretical security risks.
      *
-     * ~-~
+     *     ---
      *
      * **For URL WebViews:** List of strings representing RegExp patterns (passed into [the RegExp
      * constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp))

--- a/src/shared/models/web-view.model.ts
+++ b/src/shared/models/web-view.model.ts
@@ -97,7 +97,7 @@ type WebViewDefinitionBase = {
    * If you plan on embedding any iframes in your WebView, it is best practice to list only the host
    * values you need to function. The more you list, the higher the theoretical security risks.
    *
-   * ~-~
+   *     ---
    *
    * **For URL WebViews:** List of strings representing RegExp patterns (passed into [the RegExp
    * constructor](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/RegExp))


### PR DESCRIPTION
- see https://github.com/hosseinmd/prettier-plugin-jsdoc/issues/216#issuecomment-1816858891
- still doesn't show as JSDoc divider

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/647)
<!-- Reviewable:end -->
