### PR TITLE
Added `app://cache/extension-types` for extension type sharing

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4765,3 +4765,39 @@ declare module 'extension-host/extension-types/extension.interface' {
     deactivate?: UnsubscriberAsync;
   }
 }
+declare module 'extension-host/extension-types/extension-manifest.model' {
+  /** Information about an extension provided by the extension developer. */
+  export type ExtensionManifest = {
+    /** Name of the extension */
+    name: string;
+    /**
+     * Extension version - expected to be [semver](https://semver.org/) like `"0.1.3"`.
+     *
+     * Note: semver may become a hard requirement in the future, so we recommend using it now.
+     */
+    version: string;
+    /**
+     * Path to the JavaScript file to run in the extension host. Relative to the extension's root
+     * folder.
+     *
+     * Must be specified. Can be `null` if the extension does not have any JavaScript to run.
+     */
+    main: string | null;
+    /**
+     * Path to the TypeScript type definition file that describes this extension and its interactions
+     * on the PAPI. Relative to the extension's root folder.
+     *
+     * If not provided, Platform.Bible will look in the following locations:
+     *
+     * 1. `<extension_name>.d.ts`
+     * 2. `<extension_name><other_stuff>.d.ts`
+     * 3. `index.d.ts`
+     */
+    types?: string;
+    /**
+     * List of events that occur that should cause this extension to be activated. Not yet
+     * implemented.
+     */
+    activationEvents: string[];
+  };
+}

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4784,7 +4784,7 @@ declare module 'extension-host/extension-types/extension-manifest.model' {
      */
     main: string | null;
     /**
-     * Path to the TypeScript type definition file that describes this extension and its interactions
+     * Path to the TypeScript type declaration file that describes this extension and its interactions
      * on the PAPI. Relative to the extension's root folder.
      *
      * If not provided, Platform.Bible will look in the following locations:
@@ -4792,6 +4792,10 @@ declare module 'extension-host/extension-types/extension-manifest.model' {
      * 1. `<extension_name>.d.ts`
      * 2. `<extension_name><other_stuff>.d.ts`
      * 3. `index.d.ts`
+     *
+     * See [Extension Anatomy - Type Declaration
+     * Files](https://github.com/paranext/paranext-extension-template/wiki/Extension-Anatomy#type-declaration-files-dts)
+     * for more information about extension type declaration files.
      */
     types?: string;
     /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4290,7 +4290,7 @@ declare module 'node/utils/util' {
 }
 declare module 'node/services/node-file-system.service' {
   /** File system calls from Node */
-  import { BigIntStats } from 'fs';
+  import fs, { BigIntStats } from 'fs';
   import { Uri } from 'shared/data/file-system.model';
   /**
    * Read a text file
@@ -4314,6 +4314,21 @@ declare module 'node/services/node-file-system.service' {
    * @returns Promise that resolves after writing the file
    */
   export function writeFile(uri: Uri, fileContents: string | Buffer): Promise<void>;
+  /**
+   * Copies a file from one location to another. Creates the path to the destination if it does not
+   * exist
+   *
+   * @param sourceUri The location of the file to copy
+   * @param destinationUri The uri to the file to create as a copy of the source file
+   * @param mode Bitwise modifiers that affect how the copy works. See
+   *   [`fsPromises.copyFile`](https://nodejs.org/api/fs.html#fspromisescopyfilesrc-dest-mode) for
+   *   more information
+   */
+  export function copyFile(
+    sourceUri: Uri,
+    destinationUri: Uri,
+    mode?: Parameters<typeof fs.promises.copyFile>[2],
+  ): Promise<void>;
   /**
    * Delete a file if it exists
    *
@@ -4359,7 +4374,7 @@ declare module 'node/services/node-file-system.service' {
     entryFilter?: (entryName: string) => boolean,
   ): Promise<DirectoryEntries>;
   /**
-   * Create a directory in the file system
+   * Create a directory in the file system if it does not exist. Does not throw if it already exists.
    *
    * @param uri URI of directory
    * @returns Promise that resolves once the directory has been created

--- a/lib/papi-dts/tsconfig.json
+++ b/lib/papi-dts/tsconfig.json
@@ -24,7 +24,8 @@
     "../../src/renderer/services/papi-frontend.service.ts",
     "../../src/renderer/services/papi-frontend-react.service.ts",
     "../../src/extension-host/services/papi-backend.service.ts",
-    "../../src/extension-host/extension-types/extension.interface.ts"
+    "../../src/extension-host/extension-types/extension.interface.ts",
+    "../../src/extension-host/extension-types/extension-manifest.model.ts"
   ],
   "exclude": ["node_modules"],
   "ts-node": {

--- a/src/extension-host/extension-types/extension-manifest.model.ts
+++ b/src/extension-host/extension-types/extension-manifest.model.ts
@@ -16,7 +16,7 @@ export type ExtensionManifest = {
    */
   main: string | null;
   /**
-   * Path to the TypeScript type definition file that describes this extension and its interactions
+   * Path to the TypeScript type declaration file that describes this extension and its interactions
    * on the PAPI. Relative to the extension's root folder.
    *
    * If not provided, Platform.Bible will look in the following locations:
@@ -24,6 +24,10 @@ export type ExtensionManifest = {
    * 1. `<extension_name>.d.ts`
    * 2. `<extension_name><other_stuff>.d.ts`
    * 3. `index.d.ts`
+   *
+   * See [Extension Anatomy - Type Declaration
+   * Files](https://github.com/paranext/paranext-extension-template/wiki/Extension-Anatomy#type-declaration-files-dts)
+   * for more information about extension type declaration files.
    */
   types?: string;
   /**

--- a/src/extension-host/extension-types/extension-manifest.model.ts
+++ b/src/extension-host/extension-types/extension-manifest.model.ts
@@ -1,0 +1,34 @@
+/** Information about an extension provided by the extension developer. */
+export type ExtensionManifest = {
+  /** Name of the extension */
+  name: string;
+  /**
+   * Extension version - expected to be [semver](https://semver.org/) like `"0.1.3"`.
+   *
+   * Note: semver may become a hard requirement in the future, so we recommend using it now.
+   */
+  version: string;
+  /**
+   * Path to the JavaScript file to run in the extension host. Relative to the extension's root
+   * folder.
+   *
+   * Must be specified. Can be `null` if the extension does not have any JavaScript to run.
+   */
+  main: string | null;
+  /**
+   * Path to the TypeScript type definition file that describes this extension and its interactions
+   * on the PAPI. Relative to the extension's root folder.
+   *
+   * If not provided, Platform.Bible will look in the following locations:
+   *
+   * 1. `<extension_name>.d.ts`
+   * 2. `<extension_name><other_stuff>.d.ts`
+   * 3. `index.d.ts`
+   */
+  types?: string;
+  /**
+   * List of events that occur that should cause this extension to be activated. Not yet
+   * implemented.
+   */
+  activationEvents: string[];
+};

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -395,9 +395,9 @@ function createDtsInfoFromUri(declarationUri: Uri): DtsInfo {
 }
 
 /**
- * Caches type definition files for each extension. Gets the type definition file from each
+ * Caches type declaration files for each extension. Gets the type declaration file from each
  * extension and copies it to `extension-types/<extension_type_file_name_without_.d.ts>/index.d.ts`
- * because that is the path that works. If the extension's type definition file does not start with
+ * because that is the path that works. If the extension's type declaration file does not start with
  * `<extension_name>`, the folder created will be named `<extension_name>` instead of the name of
  * the extension type declaration file name.
  *
@@ -407,7 +407,7 @@ function createDtsInfoFromUri(declarationUri: Uri): DtsInfo {
  *
  * @param extensionInfos Extension info for extensions whose types to cache
  */
-async function cacheExtensionTypeDefinitions(extensionInfos: ExtensionInfo[]) {
+async function cacheExtensionTypeDeclarations(extensionInfos: ExtensionInfo[]) {
   return Promise.all(
     extensionInfos.map(async (extensionInfo) => {
       /** The default assumed name for the dts file including `.d.ts` */
@@ -746,12 +746,12 @@ async function reloadExtensions(shouldDeactivateExtensions: boolean): Promise<vo
   // Get a list of all extensions found
   const allExtensions = await getExtensions();
 
-  // Cache type definitions in development
+  // Cache type declarations in development
   if (!globalThis.isPackaged)
     try {
-      await cacheExtensionTypeDefinitions(allExtensions);
+      await cacheExtensionTypeDeclarations(allExtensions);
     } catch (e) {
-      logger.warn(`Could not cache extension type definitions: ${e}`);
+      logger.warn(`Could not cache extension type declarations: ${e}`);
     }
 
   // Save extensions that have JavaScript to run

--- a/src/node/services/node-file-system.service.ts
+++ b/src/node/services/node-file-system.service.ts
@@ -41,6 +41,28 @@ export async function writeFile(uri: Uri, fileContents: string | Buffer): Promis
 }
 
 /**
+ * Copies a file from one location to another. Creates the path to the destination if it does not
+ * exist
+ *
+ * @param sourceUri The location of the file to copy
+ * @param destinationUri The uri to the file to create as a copy of the source file
+ * @param mode Bitwise modifiers that affect how the copy works. See
+ *   [`fsPromises.copyFile`](https://nodejs.org/api/fs.html#fspromisescopyfilesrc-dest-mode) for
+ *   more information
+ */
+export async function copyFile(
+  sourceUri: Uri,
+  destinationUri: Uri,
+  mode?: Parameters<typeof fs.promises.copyFile>[2],
+) {
+  const filePathSource: string = getPathFromUri(sourceUri);
+  const filePathDest: string = getPathFromUri(destinationUri);
+  const destDirName: string = path.dirname(filePathDest);
+  await fs.promises.mkdir(destDirName, { recursive: true });
+  return fs.promises.copyFile(filePathSource, filePathDest, mode);
+}
+
+/**
  * Delete a file if it exists
  *
  * @param uri URI of file
@@ -147,7 +169,7 @@ export async function readDir(
 }
 
 /**
- * Create a directory in the file system
+ * Create a directory in the file system if it does not exist. Does not throw if it already exists.
  *
  * @param uri URI of directory
  * @returns Promise that resolves once the directory has been created


### PR DESCRIPTION
For an explanation of why I added `app://cache/extension-types` instead of using `app://cache/extensions`, see [my comment on issue 365](https://github.com/paranext/paranext-core/issues/365#issuecomment-1835237874).

Also added `app://installed-extensions` for an easy place to put extensions

Goes along with https://github.com/paranext/paranext-extension-template/pull/52

Relates to #365

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/659)
<!-- Reviewable:end -->
