### PR TITLE
Fix publish-docs workflow

### DIFF
--- a/.github/assets/github-pages-index.html
+++ b/.github/assets/github-pages-index.html
@@ -3,33 +3,38 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;700&display=swap"
+    />
     <title>Platform.Bible API</title>
     <style>
       body {
-        font-family: 'Arial', sans-serif;
+        font-family: 'Roboto', sans-serif;
         margin: 40px;
         padding: 20px;
-        background-color: #f8f8f8;
+        background-color: #fcfcfc;
         text-align: center;
       }
 
       h1 {
-        color: #333;
+        color: #121212;
+        font-weight: 700;
       }
 
       a {
-        display: block;
-        margin: 20px 0;
+        display: inline-block;
+        margin: 20px 10px;
         padding: 10px;
-        background-color: #007bff;
-        color: #fff;
+        background-color: #a70e13;
+        color: #fcfcfc;
         text-decoration: none;
         border-radius: 5px;
         transition: background-color 0.3s ease;
       }
 
       a:hover {
-        background-color: #0056b3;
+        background-color: #830c14;
       }
     </style>
   </head>

--- a/.github/assets/github-pages-index.html
+++ b/.github/assets/github-pages-index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Platform.Bible API</title>
+    <style>
+      body {
+        font-family: 'Arial', sans-serif;
+        margin: 40px;
+        padding: 20px;
+        background-color: #f8f8f8;
+        text-align: center;
+      }
+
+      h1 {
+        color: #333;
+      }
+
+      a {
+        display: block;
+        margin: 20px 0;
+        padding: 10px;
+        background-color: #007bff;
+        color: #fff;
+        text-decoration: none;
+        border-radius: 5px;
+        transition: background-color 0.3s ease;
+      }
+
+      a:hover {
+        background-color: #0056b3;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Platform.Bible API</h1>
+    <a href="papi-components/index.html">Go to papi-components</a>
+    <a href="papi-dts/index.html">Go to papi-dts</a>
+  </body>
+</html>

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-publish-docs
 
 jobs:
   publish-docs:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install Node and NPM
         uses: actions/setup-node@v3
         with:
-          node-version: [18.x]
+          node-version: 18.x
           cache: npm
 
       - name: Install and build

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -26,15 +26,18 @@ jobs:
           npm run build
 
       - name: Build documentation
-        run: | # renaming the folders so that pages links at /{their name} instead of at /docs
+        run: | # need to specify --out so pages links at /{their name} instead of at /docs
           cd lib/papi-components
           npx typedoc --out papi-components
           cd ../papi-dts
           npx typedoc --out papi-dts
+          cd ../../
+          mkdir docs-for-pages
+          mv lib/papi-components/papi-components docs-for-pages
+          mv lib/papi-dts/papi-dts docs-for-pages
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.4
         with:
           branch: github-pages
-          folder: |
-            lib/papi-components/papi-components
+          folder: docs-for-pages

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -25,19 +25,12 @@ jobs:
           npm install
           npm run build
 
-      - name: Debug
-        run: |
-          pwd
-          ls -la
-
       - name: Build documentation
         run: | # renaming the folders so that pages links at /{their name} instead of at /docs
           cd lib/papi-components
-          npm run build:docs
-          mv docs papi-components
+          npx typedoc --out papi-components
           cd ../papi-dts
-          npm run build:docs
-          mv docs papi-dts
+          npx typedoc --out papi-dts
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.4

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-publish-docs
 
 jobs:
   publish-docs:
@@ -27,9 +28,9 @@ jobs:
       - name: Build documentation
         run: | # need to specify --out so pages links at /{their name} instead of at /docs
           cd lib/papi-components
-          npx typedoc --out papi-components
+          npm run build:docs -- --out papi-components
           cd ../papi-dts
-          npx typedoc --out papi-dts
+          npm run build:docs -- --out papi-dts
           cd ../../
           mkdir docs-for-pages
           mv lib/papi-components/papi-components docs-for-pages

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - fix-publish-docs
 
 jobs:
   publish-docs:
@@ -36,7 +35,7 @@ jobs:
           mv lib/papi-components/papi-components docs-for-pages
           mv lib/papi-dts/papi-dts docs-for-pages
 
-      - name: Add nojekyll
+      - name: Add nojekyll # needed so that HTML pages that start with _ do not cause 404
         run: touch docs-for-pages/.nojekyll
 
       - name: Add landing page

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-publish-docs
 
 jobs:
   publish-docs:

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -24,6 +24,11 @@ jobs:
           npm install
           npm run build
 
+      - name: Debug
+        run: |
+          pwd
+          ls -la
+
       - name: Build documentation
         run: | # renaming the folders so that pages links at /{their name} instead of at /docs
           cd lib/papi-components

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -9,10 +9,6 @@ jobs:
   publish-docs:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        node_version: [18.x]
-
     steps:
       - name: Checkout git repo
         uses: actions/checkout@v3
@@ -20,7 +16,7 @@ jobs:
       - name: Install Node and NPM
         uses: actions/setup-node@v3
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: [18.x]
           cache: npm
 
       - name: Install and build
@@ -30,10 +26,10 @@ jobs:
 
       - name: Build documentation
         run: | # renaming the folders so that pages links at /{their name} instead of at /docs
-          cd ~/lib/papi-components
+          cd lib/papi-components
           npm run build:docs
           mv docs papi-components
-          cd ~/lib/papi-dts
+          cd ../papi-dts
           npm run build:docs
           mv docs papi-dts
 

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - fix-publish-docs
 
 jobs:
   publish-docs:
@@ -34,6 +35,7 @@ jobs:
           mkdir docs-for-pages
           mv lib/papi-components/papi-components docs-for-pages
           mv lib/papi-dts/papi-dts docs-for-pages
+          touch docs-for-pages/.nojekyll
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.4

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -38,4 +38,3 @@ jobs:
           branch: github-pages
           folder: |
             lib/papi-components/papi-components
-            lib/papi-dts/papi-dts

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -40,7 +40,9 @@ jobs:
         run: touch docs-for-pages/.nojekyll
 
       - name: Add landing page
-        run: cp README.md docs-for-pages
+        run: |
+          cp .github/assets/github-pages-index.html docs-for-pages
+          mv docs-for-pages/github-pages-index.html docs-for-pages/index.html
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.4

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -35,7 +35,12 @@ jobs:
           mkdir docs-for-pages
           mv lib/papi-components/papi-components docs-for-pages
           mv lib/papi-dts/papi-dts docs-for-pages
-          touch docs-for-pages/.nojekyll
+
+      - name: Add nojekyll
+        run: touch docs-for-pages/.nojekyll
+
+      - name: Add landing page
+        run: cp README.md docs-for-pages
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@4.1.4

--- a/lib/papi-components/package.json
+++ b/lib/papi-components/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "start": "vite --host --open",
     "build:basic": "tsc && vite build && dts-bundle-generator --config ./dts-bundle-generator.config.ts",
-    "build:docs": "npx typedoc",
+    "build:docs": "typedoc",
     "build": "npm run build:basic && npm run lint-fix",
     "watch": "tsc && vite build --watch",
     "lint": "npm run lint:scripts && npm run lint:styles",

--- a/lib/papi-components/typedoc.json
+++ b/lib/papi-components/typedoc.json
@@ -1,7 +1,7 @@
 {
-  "entryPoints": ["src"],
-  "entryPointStrategy": "expand",
-  "exclude": ["src/index.ts"],
+  "entryPoints": ["src/index.ts"],
   "out": "docs",
   "tsconfig": "tsconfig.json",
+  "sort": ["kind", "alphabetical"],
+  "kindSortOrder": ["Function"]
 }

--- a/lib/papi-dts/package.json
+++ b/lib/papi-dts/package.json
@@ -26,7 +26,7 @@
   "main": "",
   "types": "papi.d.ts",
   "scripts": {
-    "build:docs": "npx typedoc",
+    "build:docs": "typedoc",
     "build": "tsc && prettier --write papi.d.ts && ts-node edit-papi-d-ts.ts",
     "build:clean": "rimraf papi.tsbuildinfo",
     "build:fresh": "npm run build:clean && npm run build",

--- a/lib/papi-dts/typedoc.json
+++ b/lib/papi-dts/typedoc.json
@@ -4,5 +4,5 @@
   "out": "docs",
   "readme": "README.md",
   "logLevel": "Verbose",
-  "sort": ["kind", "alphabetical", "instance-first"]
+  "sort": ["kind", "alphabetical"]
 }

--- a/lib/papi-dts/typedoc.json
+++ b/lib/papi-dts/typedoc.json
@@ -4,5 +4,5 @@
   "out": "docs",
   "readme": "README.md",
   "logLevel": "Verbose",
-  "sort": ["kind", "alphabetical"]
+  "sort": ["kind", "alphabetical", "instance-first"]
 }


### PR DESCRIPTION
Follow up to #666 
- Removed the matrix for `node_version`
- The deploy action didn't seem to like that I was giving it two folders, so I added to the build documentation and put the two subdirectories into one `docs-for-pages` directory.
- Add `.nojekyll` file so that HTML pages that start with _ will not return a 404
- Create `.github/assets` that holds a landing page: `github-pages-index.html`. The deploy action overwrites the `github-pages` branch with each deploy, so this page needs to be housed somewhere off of the `github-pages` branch
- Copy the landing page into `docs-for-pages` when deploying
- Use the build script with `--out` folder name to skip renaming step
- Remove `npx` from build scripts
- Fix `entryPoint` for papi-components

### Landing page:
![Screenshot 2023-12-06 at 10 57 57 AM](https://github.com/paranext/paranext-core/assets/135999578/339905ab-cb05-47b1-ad28-54a4a1ac5c08)

### `/papi-components`
![Screenshot 2023-12-06 at 10 54 02 AM](https://github.com/paranext/paranext-core/assets/135999578/34ebd190-3005-42ec-9e3d-056b58ffc383)

### `/papi-dts`
![Screenshot 2023-12-06 at 10 54 46 AM](https://github.com/paranext/paranext-core/assets/135999578/11a0b1f4-0bf5-44d5-961f-b0a740c8b97c)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/669)
<!-- Reviewable:end -->
