### PR TITLE
Fix Jest test fail on papi-components

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -18,6 +18,7 @@ const config: Config = {
     ...pathsToModuleNameMapper(compilerOptions.paths, {
       prefix: '<rootDir>/src',
     }),
+    '^papi-components$': '<rootDir>/node_modules/papi-components/dist/index.es.js',
   },
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {

--- a/src/__tests__/app.component.test.tsx
+++ b/src/__tests__/app.component.test.tsx
@@ -39,19 +39,6 @@ jest.mock('@renderer/components/docking/platform-dock-layout.component', () => (
   __esModule: true,
   default: /** ParanextDockLayout Mock */ () => undefined,
 }));
-// Mock all of the papi-components because they should test themselves
-jest.mock(
-  'papi-components',
-  () =>
-    new Proxy(
-      {},
-      {
-        get() {
-          return function MockComponent() {};
-        },
-      },
-    ),
-);
 
 describe('App', () => {
   it('should render', async () => {

--- a/src/__tests__/button.component.test.tsx
+++ b/src/__tests__/button.component.test.tsx
@@ -1,0 +1,20 @@
+import { render, fireEvent } from '@testing-library/react';
+import { Button } from 'papi-components';
+import '@testing-library/jest-dom/extend-expect';
+
+describe('Button', () => {
+  it('renders button text correctly', () => {
+    const buttonText = 'Click me';
+    const { getByText } = render(<Button>{buttonText}</Button>);
+    expect(getByText(buttonText)).toBeInTheDocument();
+  });
+
+  it('handles click event correctly', () => {
+    const handleClick = jest.fn();
+    const { getByText } = render(<Button onClick={handleClick}>Click me</Button>);
+
+    fireEvent.click(getByText('Click me'));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/components/docking/platform-dock-layout.component.test.ts
+++ b/src/renderer/components/docking/platform-dock-layout.component.test.ts
@@ -1,18 +1,5 @@
 /* eslint-disable import/first */
 jest.mock('../../../shared/services/logger.service');
-// Mock all of the papi-components because they should test themselves
-jest.mock(
-  'papi-components',
-  () =>
-    new Proxy(
-      {},
-      {
-        get() {
-          return function MockComponent() {};
-        },
-      },
-    ),
-);
 
 import DockLayout, { FloatPosition } from 'rc-dock';
 import { anything, instance, mock, verify, when } from 'ts-mockito';


### PR DESCRIPTION
- Added line to Jest `moduleNameMapper` which forces it to use the `index.es.js` instead of the default `index.cjs.js`.
- Removed the mocks for papi-components

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/684)
<!-- Reviewable:end -->
