### PR TITLE
#567: Turn on globbing in rimrafSync calls

### DIFF
--- a/.erb/scripts/clean.js
+++ b/.erb/scripts/clean.js
@@ -10,5 +10,5 @@ const foldersToRemove = [
 ];
 
 foldersToRemove.forEach((folder) => {
-  if (fs.existsSync(folder)) rimrafSync(folder);
+  if (fs.existsSync(folder)) rimrafSync(folder, { glob: true });
 });

--- a/.erb/scripts/clean.js
+++ b/.erb/scripts/clean.js
@@ -10,5 +10,5 @@ const foldersToRemove = [
 ];
 
 foldersToRemove.forEach((folder) => {
-  if (fs.existsSync(folder)) rimrafSync(folder, { glob: true });
+  if (fs.existsSync(folder)) rimrafSync(folder);
 });

--- a/.erb/scripts/delete-source-maps.js
+++ b/.erb/scripts/delete-source-maps.js
@@ -5,7 +5,7 @@ import webpackPaths from '../configs/webpack.paths';
 
 export default function deleteSourceMaps() {
   if (fs.existsSync(webpackPaths.distMainPath))
-    rimrafSync(path.join(webpackPaths.distMainPath, '*.js.map'));
+    rimrafSync(path.join(webpackPaths.distMainPath, '*.js.map'), { glob: true });
   if (fs.existsSync(webpackPaths.distRendererPath))
-    rimrafSync(path.join(webpackPaths.distRendererPath, '*.js.map'));
+    rimrafSync(path.join(webpackPaths.distRendererPath, '*.js.map'), { glob: true });
 }


### PR DESCRIPTION
Hoping this will prevent "Illegal characters in path" error. I'm not quite sure how to reliably reproduce the problem in order to know if this fixes it, and I don't know if the PR build will suffice to ensure that the problem is solved. I tried running the various workflow steps locally but ran into errors with npm run lint (possibly because I didn't know what to do to set USE_HARD_LINKS: false).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/696)
<!-- Reviewable:end -->
