### PR TITLE
Extensions using `papi-shared-types` to share other methods

### DIFF
--- a/extensions/src/hello-world/src/types/hello-world.d.ts
+++ b/extensions/src/hello-world/src/types/hello-world.d.ts
@@ -1,15 +1,4 @@
 declare module 'hello-world' {
-  /** Event containing information about `helloWorld` */
-  type HelloWorldEvent = {
-    /**
-     * How many times the `helloWorld` function has been run (called by `helloWorld.helloWorld`
-     * command)
-     */
-    times: number;
-  };
-}
-
-declare module 'papi-shared-types' {
   import type { DataProviderDataType, IDataProvider, MandatoryProjectDataType } from '@papi/core';
 
   export type MyProjectDataType = MandatoryProjectDataType & {
@@ -21,6 +10,19 @@ declare module 'papi-shared-types' {
   };
 
   export type MyProjectDataProvider = IDataProvider<MyProjectDataType> & MyProjectDataMethods;
+
+  /** Event containing information about `helloWorld` */
+  type HelloWorldEvent = {
+    /**
+     * How many times the `helloWorld` function has been run (called by `helloWorld.helloWorld`
+     * command)
+     */
+    times: number;
+  };
+}
+
+declare module 'papi-shared-types' {
+  import type { MyProjectDataProvider } from 'hello-world';
 
   export interface CommandHandlers {
     'helloWorld.helloWorld': () => string;

--- a/extensions/src/hello-world/src/types/hello-world.d.ts
+++ b/extensions/src/hello-world/src/types/hello-world.d.ts
@@ -1,5 +1,3 @@
-import type { DataProviderDataType, MandatoryProjectDataType } from '@papi/core';
-
 declare module 'hello-world' {
   /** Event containing information about `helloWorld` */
   type HelloWorldEvent = {
@@ -12,16 +10,24 @@ declare module 'hello-world' {
 }
 
 declare module 'papi-shared-types' {
-  export interface CommandHandlers {
-    'helloWorld.helloWorld': () => string;
-    'helloWorld.helloException': (message: string) => void;
-  }
+  import type { DataProviderDataType, IDataProvider, MandatoryProjectDataType } from '@papi/core';
 
   export type MyProjectDataType = MandatoryProjectDataType & {
     MyProjectData: DataProviderDataType<string, string, string>;
   };
 
-  export interface ProjectDataTypes {
-    MyExtensionProjectTypeName: MyProjectDataType;
+  export type MyProjectDataMethods = {
+    testRandomMethod(things: string): boolean;
+  };
+
+  export type MyProjectDataProvider = IDataProvider<MyProjectDataType> & MyProjectDataMethods;
+
+  export interface CommandHandlers {
+    'helloWorld.helloWorld': () => string;
+    'helloWorld.helloException': (message: string) => void;
+  }
+
+  export interface ProjectDataProviders {
+    'helloWorld.myExtensionProjectTypeName': MyProjectDataProvider;
   }
 }

--- a/extensions/src/usfm-data-provider/index.d.ts
+++ b/extensions/src/usfm-data-provider/index.d.ts
@@ -358,13 +358,15 @@ declare module 'usfm-data-provider' {
       options?: DataProviderSubscriberOptions,
     ): Unsubscriber;
   };
+
+  export type ParatextStandardProjectDataProvider = IDataProvider<ParatextStandardProjectDataTypes>;
 }
 
 declare module 'papi-shared-types' {
-  import type { ParatextStandardProjectDataTypes, UsfmDataProvider } from 'usfm-data-provider';
+  import type { ParatextStandardProjectDataProvider, UsfmDataProvider } from 'usfm-data-provider';
 
-  export interface ProjectDataTypes {
-    ParatextStandard: ParatextStandardProjectDataTypes;
+  export interface ProjectDataProviders {
+    ParatextStandard: ParatextStandardProjectDataProvider;
   }
 
   export interface DataProviders {

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -2504,7 +2504,7 @@ declare module 'papi-shared-types' {
    *   };
    *
    *   export interface ProjectDataProviders {
-   *     MyExtensionProjectTypeName: MyProjectDataType;
+   *     MyExtensionProjectTypeName: IDataProvider<MyProjectDataType>;
    *   }
    * }
    * ```
@@ -2523,8 +2523,8 @@ declare module 'papi-shared-types' {
    */
   type ProjectTypes = keyof ProjectDataProviders;
   /**
-   * `ProjectDataTypes` for each project data provider supported by PAPI. These are the data types
-   * served by each project data provider.
+   * `DataProviderDataTypes` for each project data provider supported by PAPI. These are the data
+   * types served by each project data provider.
    *
    * Automatically includes all extensions' project data providers that are added to
    * {@link ProjectDataProviders}.

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -69,38 +69,66 @@ declare module 'papi-shared-types' {
   };
 
   /**
-   * Data types for each project data provider supported by PAPI. Extensions can add more data types
-   * with corresponding project data provider IDs by adding details to their `.d.ts` file. Note that
-   * all project data types should extend `MandatoryProjectDataTypes` like the following example.
+   * `IDataProvider` types for each project data provider supported by PAPI. Extensions can add more
+   * project data providers with corresponding data provider IDs by adding details to their `.d.ts`
+   * file. Note that all project data types should extend `MandatoryProjectDataTypes` like the
+   * following example.
+   *
+   * Note: Project Data Provider names must consist of two string separated by at least one period.
+   * We recommend one period and lower camel case in case we expand the api in the future to allow
+   * dot notation.
+   *
+   * An extension can extend this interface to add types for the project data provider it registers
+   * by adding the following to its `.d.ts` file (in this example, we are adding the
+   * `MyExtensionProjectTypeName` data provider types):
    *
    * @example
    *
    * ```typescript
    * declare module 'papi-shared-types' {
-   *   export type MyProjectDataTypes = MandatoryProjectDataTypes & {
-   *     MyProjectData1: DataProviderDataType<string, string, string>;
-   *     MyProjectData2: DataProviderDataType<string, string, string>;
+   *   export type MyProjectDataType = MandatoryProjectDataType & {
+   *     MyProjectData: DataProviderDataType<string, string, string>;
    *   };
    *
-   *   export interface ProjectDataTypes {
-   *     MyExtensionProjectTypeName: MyProjectDataTypes;
+   *   export interface ProjectDataProviders {
+   *     MyExtensionProjectTypeName: MyProjectDataType;
    *   }
    * }
    * ```
    */
-  export interface ProjectDataTypes {
-    NotesOnly: NotesOnlyProjectDataTypes;
-    // With only one key in this interface, `papi.d.ts` was baking in the literal string when
-    // `ProjectTypes` was being used. Adding a placeholder key makes TypeScript generate `papi.d.ts`
-    // correctly. When we add another project data type, we can remove this placeholder.
-    placeholder: MandatoryProjectDataType;
+  export interface ProjectDataProviders {
+    'platform.notesOnly': IDataProvider<NotesOnlyProjectDataTypes & MandatoryProjectDataType>;
+    'platform.placeholder': IDataProvider<PlaceholderDataTypes & MandatoryProjectDataType>;
   }
 
   /**
-   * Identifiers for all project types supported by PAPI. These are not intended to correspond 1:1
-   * to the set of project types available in Paratext.
+   * Names for each project data provider available on the papi.
+   *
+   * Automatically includes all extensions' project data providers that are added to
+   * {@link ProjectDataProviders}.
+   *
+   * @example 'platform.placeholder'
    */
-  export type ProjectTypes = keyof ProjectDataTypes;
+  export type ProjectTypes = keyof ProjectDataProviders;
+
+  /**
+   * `ProjectDataTypes` for each project data provider supported by PAPI. These are the data types
+   * served by each project data provider.
+   *
+   * Automatically includes all extensions' project data providers that are added to
+   * {@link ProjectDataProviders}.
+   *
+   * @example
+   *
+   * ```typescript
+   * ProjectDataTypes['MyExtensionProjectTypeName'] => {
+   *     MyProjectData: DataProviderDataType<string, string, string>;
+   *   }
+   * ```
+   */
+  export type ProjectDataTypes = {
+    [ProjectType in ProjectTypes]: ExtractDataProviderDataTypes<ProjectDataProviders[ProjectType]>;
+  };
 
   type StuffDataTypes = { Stuff: DataProviderDataType<string, number, never> };
 

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -91,7 +91,7 @@ declare module 'papi-shared-types' {
    *   };
    *
    *   export interface ProjectDataProviders {
-   *     MyExtensionProjectTypeName: MyProjectDataType;
+   *     MyExtensionProjectTypeName: IDataProvider<MyProjectDataType>;
    *   }
    * }
    * ```
@@ -112,8 +112,8 @@ declare module 'papi-shared-types' {
   export type ProjectTypes = keyof ProjectDataProviders;
 
   /**
-   * `ProjectDataTypes` for each project data provider supported by PAPI. These are the data types
-   * served by each project data provider.
+   * `DataProviderDataTypes` for each project data provider supported by PAPI. These are the data
+   * types served by each project data provider.
    *
    * Automatically includes all extensions' project data providers that are added to
    * {@link ProjectDataProviders}.

--- a/src/renderer/hooks/papi-hooks/use-project-data-provider.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data-provider.hook.ts
@@ -1,7 +1,6 @@
 import { papiFrontendProjectDataProviderService } from '@shared/services/project-data-provider.service';
-import { ProjectTypes, ProjectDataTypes } from 'papi-shared-types';
+import { ProjectTypes, ProjectDataProviders } from 'papi-shared-types';
 import createUseNetworkObjectHook from '@renderer/hooks/hook-generators/create-use-network-object-hook.util';
-import IDataProvider from '@shared/models/data-provider.interface';
 
 /**
  * Takes the parameters passed into the hook and returns the `projectDataProviderSource` associated
@@ -18,7 +17,7 @@ import IDataProvider from '@shared/models/data-provider.interface';
  */
 function mapParametersToProjectDataProviderSource<ProjectType extends ProjectTypes>(
   _projectType: ProjectType,
-  projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+  projectDataProviderSource: string | ProjectDataProviders[ProjectType] | undefined,
 ) {
   return projectDataProviderSource;
 }
@@ -45,7 +44,7 @@ const useProjectDataProvider = createUseNetworkObjectHook(
   mapParametersToProjectDataProviderSource,
 ) as <ProjectType extends ProjectTypes>(
   projectType: ProjectType,
-  projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
-) => IDataProvider<ProjectDataTypes[ProjectType]> | undefined;
+  projectDataProviderSource: string | ProjectDataProviders[ProjectType] | undefined,
+) => ProjectDataProviders[ProjectType] | undefined;
 
 export default useProjectDataProvider;

--- a/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
@@ -5,7 +5,7 @@ import {
 } from '@shared/models/data-provider.model';
 import IDataProvider from '@shared/models/data-provider.interface';
 import useProjectDataProvider from '@renderer/hooks/papi-hooks/use-project-data-provider.hook';
-import { ProjectDataTypes, ProjectTypes } from 'papi-shared-types';
+import { ProjectDataProviders, ProjectDataTypes, ProjectTypes } from 'papi-shared-types';
 
 /**
  * React hook to use data from a project data provider
@@ -15,7 +15,7 @@ import { ProjectDataTypes, ProjectTypes } from 'papi-shared-types';
 type UseProjectDataHook = {
   <ProjectType extends ProjectTypes>(
     projectType: ProjectType,
-    projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+    projectDataProviderSource: string | ProjectDataProviders[ProjectType] | undefined,
   ): {
     [TDataType in keyof ProjectDataTypes[ProjectType]]: (
       // @ts-ignore TypeScript pretends it can't find `selector`, but it works just fine
@@ -45,7 +45,7 @@ type UseProjectDataHook = {
  * ```typescript
  * useProjectData<ProjectType extends ProjectTypes>(
  *     projectType: ProjectType,
- *     projectDataProviderSource: string | IDataProvider<ProjectDataTypes[ProjectType]> | undefined,
+ *     projectDataProviderSource: string | ProjectDataProviders[ProjectType] | undefined,
  *   ).DataType(
  *       selector: ProjectDataTypes[ProjectType][DataType]['selector'],
  *       defaultValue: ProjectDataTypes[ProjectType][DataType]['getData'],

--- a/src/shared/models/project-data-provider-engine.model.ts
+++ b/src/shared/models/project-data-provider-engine.model.ts
@@ -1,15 +1,9 @@
 import { ProjectTypes, ProjectDataTypes } from 'papi-shared-types';
-import type IDataProvider from '@shared/models/data-provider.interface';
 import type IDataProviderEngine from '@shared/models/data-provider-engine.model';
 
 /** All possible types for ProjectDataProviderEngines: IDataProviderEngine<ProjectDataType> */
 export type ProjectDataProviderEngineTypes = {
   [ProjectType in ProjectTypes]: IDataProviderEngine<ProjectDataTypes[ProjectType]>;
-};
-
-/** All possible types for ProjectDataProviders: IDataProvider<ProjectDataType> */
-export type ProjectDataProvider = {
-  [ProjectType in ProjectTypes]: IDataProvider<ProjectDataTypes[ProjectType]>;
 };
 
 export interface ProjectDataProviderEngineFactory<ProjectType extends ProjectTypes> {

--- a/src/shared/services/graphql.service.ts
+++ b/src/shared/services/graphql.service.ts
@@ -2,9 +2,9 @@ import { graphql, buildSchema } from 'graphql';
 import { VerseRef, ScrVers } from '@sillsdev/scripture';
 import projectLookupService from '@shared/services/project-lookup.service';
 import { ProjectMetadata } from '@shared/models/project-metadata.model';
-import { ProjectDataProvider } from '@shared/models/project-data-provider-engine.model';
 import { get } from '@shared/services/project-data-provider.service';
 import { serialize } from '@shared/utils/papi-util';
+import { ProjectDataProviders } from 'papi-shared-types';
 
 // TODO: figure out what to do with the schema. It's a baked in string just to get things rolling, not because it's optimal.
 const usfmSchema = buildSchema(`
@@ -54,13 +54,13 @@ function extractVerseRef(maybeVerseRef: MaybeVerseRef): VerseRef {
 
 // Caching some objects so we don't have to keep making network calls for every GraphQL query
 const projectMap = new Map<string, ProjectMetadata>();
-const paratextProjectMap = new Map<string, ProjectDataProvider['ParatextStandard']>();
+const paratextProjectMap = new Map<string, ProjectDataProviders['ParatextStandard']>();
 
 /** Transform the GraphQL inputs into objects we can work with */
 async function preparePdpCall(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   inputs: any,
-): Promise<{ pdp: ProjectDataProvider['ParatextStandard']; verseRef: VerseRef }> {
+): Promise<{ pdp: ProjectDataProviders['ParatextStandard']; verseRef: VerseRef }> {
   const { projectId, verseRef }: { projectId: string; verseRef: Object } = inputs;
   const parsedVerseRef = extractVerseRef(verseRef);
   const existingPdp = paratextProjectMap.get(projectId);

--- a/src/shared/services/project-data-provider.service.ts
+++ b/src/shared/services/project-data-provider.service.ts
@@ -1,6 +1,5 @@
-import { ProjectTypes, ProjectDataTypes } from 'papi-shared-types';
+import { ProjectTypes, ProjectDataTypes, ProjectDataProviders } from 'papi-shared-types';
 import {
-  ProjectDataProvider,
   ProjectDataProviderEngineTypes,
   ProjectDataProviderEngineFactory,
 } from '@shared/models/project-data-provider-engine.model';
@@ -109,7 +108,7 @@ export async function registerProjectDataProviderEngineFactory<ProjectType exten
 export async function get<ProjectType extends ProjectTypes>(
   projectType: ProjectType,
   projectId: string,
-): Promise<ProjectDataProvider[ProjectType]> {
+): Promise<ProjectDataProviders[ProjectType]> {
   const metadata = await projectLookupService.getMetadataForProject(projectId);
   const { projectType: projectTypeFromMetadata } = metadata;
   if (projectType && projectType !== projectTypeFromMetadata)
@@ -127,7 +126,7 @@ export async function get<ProjectType extends ProjectTypes>(
   // of the storageType. https://github.com/paranext/paranext-core/issues/367
   const { storageType } = metadata;
   const pdpId = await pdpFactory.getProjectDataProviderId(projectId, storageType);
-  const pdp = await getByType<ProjectDataProvider[ProjectType]>(pdpId);
+  const pdp = await getByType<ProjectDataProviders[ProjectType]>(pdpId);
   if (!pdp) throw new Error(`Cannot create project data provider for project ID ${projectId}`);
   return pdp;
 }


### PR DESCRIPTION
With these changes extensions can access methods other than the standard get/set/subscribe

Changes:
- Items on [this list](https://github.com/paranext/paranext-core/issues/517#issue-1922516773) included in the ticket
- Replaced use of `ProjectDataTypes` with `ProjectDataProviders` in `papi-shared-types` of hello world extension. 
- Replaced use of `ProjectDataTypes` with `ProjectDataProviders` in `papi-shared-types` of USFM data provider extension.
- Replace use of deleted `ProjectDataProvider` with `ProjectDataProviders` in `graphql.service.ts`


Currently investigating [macOS build failure](https://github.com/paranext/paranext-core/actions/runs/7452973446/job/20279487037?pr=699)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/699)
<!-- Reviewable:end -->
