### PR TITLE
Log unhandled exceptions and highlight module loading oddity

### DIFF
--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -10,9 +10,10 @@ import App from './app.component';
 import { cleanupOldWebViewState } from './services/web-view-state.service';
 import { blockWebSocketsToPapiNetwork } from './services/renderer-web-socket.service';
 
-window.onerror = (_, source?: string, lineno?: number, colno?: number, error?: Error) => {
-  logger.error(`Unhandled error in renderer from ${source}:${lineno}:${colno}, '${error}'`);
-};
+window.addEventListener('error', (errorEvent: ErrorEvent) => {
+  const { filename, lineno, colno, error } = errorEvent;
+  logger.error(`Unhandled error in renderer from ${filename}:${lineno}:${colno}, '${error}'`);
+});
 
 logger.info('Starting renderer');
 

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -10,6 +10,10 @@ import App from './app.component';
 import { cleanupOldWebViewState } from './services/web-view-state.service';
 import { blockWebSocketsToPapiNetwork } from './services/renderer-web-socket.service';
 
+window.onerror = (_, source?: string, lineno?: number, colno?: number, error?: Error) => {
+  logger.error(`Unhandled error in renderer from ${source}:${lineno}:${colno}, '${error}'`);
+};
+
 logger.info('Starting renderer');
 
 // This is a little different than Promise.all in that the error message will have all the reasons

--- a/src/shared/services/logger.service.ts
+++ b/src/shared/services/logger.service.ts
@@ -124,7 +124,7 @@ if (isClient()) {
         ),
       };
     });
-  if (isExtensionHost())
+  else if (isExtensionHost())
     // Add a tag for warnings so we can recognize them outside the process.
     log.hooks.push((message) => {
       const caller = identifyCaller();
@@ -136,6 +136,10 @@ if (isClient()) {
         ),
       };
     });
+  else {
+    // eslint-disable-next-line no-console
+    console.warn(chalk.yellow(`Unexpected process type: ${globalThis.processType}`));
+  }
 } else {
   log.initialize();
   log.transports.console.level = globalThis.logLevel;


### PR DESCRIPTION
Adding an unhandled exception handler in the renderer and logging the results is straightforward.  It is possible to overwrite methods on `console` to send exceptions normally just written to the console to our logger, too, but webpack's loading of modules in an uncontrolled order before `index.tsx` runs makes the results less than ideal.  Rather than mess with that too much I just added something to point out when the logger is initialized before `globalThis` is configured with things like process type.

If we want to send all console messages from the renderer to our main log, we'll need to do more work to sort through how to force webpack to run some specific code blocks in the renderer before performing general module loading.  Otherwise things written to the console by those modules won't dependably be sent to the main log, causing some confusing situations.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/703)
<!-- Reviewable:end -->
