### PR TITLE
Added verse image generator localized string

### DIFF
--- a/assets/localization/eng.json
+++ b/assets/localization/eng.json
@@ -9,6 +9,7 @@
   "mainMenu_openHelloWorldProject": "Open Hello World Project",
   "mainMenu_openProject": "Open Project",
   "mainMenu_openResourceViewer": "Open Resource Viewer",
+  "mainMenu_openVerseImageGenerator": "Open Verse Image Generator",
   "mainMenu_project": "Project",
   "mainMenu_settings": "Settings",
   "mainMenu_visitSupportBible": "Visit Support.Bible",


### PR DESCRIPTION
Since we throw errors when localized strings are missing and we haven't implemented #740, this is the only way to add a menu item for the https://github.com/tjcouch-sil/platform-bible-extension-verse-image-generator extension without breaking everything 😬

Good thing json was intended to be a configuration language and properly supports adding comments so we can explain this in the localization file /s

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/800)
<!-- Reviewable:end -->
