### PR TITLE
Fixed menu being unavailable on first startup

### DIFF
--- a/src/renderer/components/platform-bible-toolbar.tsx
+++ b/src/renderer/components/platform-bible-toolbar.tsx
@@ -1,5 +1,7 @@
 import useSetting from '@renderer/hooks/papi-hooks/use-setting.hook';
+import logger from '@shared/services/logger.service';
 import { Toolbar, RefSelector, ScriptureReference, Button } from 'platform-bible-react';
+import { Localized, MultiColumnMenu } from 'platform-bible-utils';
 import { handleMenuCommand } from './platform-bible-menu.commands';
 import provideMenuData from './platform-bible-menu.data';
 
@@ -9,6 +11,22 @@ const defaultScrRef: ScriptureReference = {
   verseNum: 1,
 };
 
+/**
+ * Providing empty menu data if the software fails to load fully so we can shift click the menu and
+ * click Reload Extensions if it fails the first time
+ *
+ * @param isSupportAndDevelopment
+ * @returns
+ */
+async function getMenuData(isSupportAndDevelopment: boolean): Promise<Localized<MultiColumnMenu>> {
+  try {
+    return await provideMenuData(isSupportAndDevelopment);
+  } catch (e) {
+    logger.error(`Could not get platform-bible-toolbar menu data! ${e}`);
+    return { columns: {}, groups: {}, items: [] };
+  }
+}
+
 export default function PlatformBibleToolbar() {
   const [scrRef, setScrRef, resetScrRef] = useSetting('platform.verseRef', defaultScrRef);
 
@@ -17,7 +35,7 @@ export default function PlatformBibleToolbar() {
   };
 
   return (
-    <Toolbar className="toolbar" menuProvider={provideMenuData} commandHandler={handleMenuCommand}>
+    <Toolbar className="toolbar" menuProvider={getMenuData} commandHandler={handleMenuCommand}>
       <RefSelector handleSubmit={handleReferenceChanged} scrRef={scrRef} />
       <Button
         onClick={() => {


### PR DESCRIPTION
If your machine is too slow to get the renderer up before the extension host needs it, the hamburger menu will not show up because the renderer will then throw an exception trying to get the menu data from the backend. Then you can't shift+click to click Reload Extensions and fix the problem.

This allows you to shift+click to click Reload Extensions if the extension host is down and is not serving menu data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/804)
<!-- Reviewable:end -->
