### PR TITLE
Added paratext.bible extension menu strings, made editor fill width

### DIFF
--- a/assets/localization/eng.json
+++ b/assets/localization/eng.json
@@ -9,6 +9,8 @@
   "mainMenu_openHelloWorldProject": "Open Hello World Project",
   "mainMenu_openProject": "Open Project",
   "mainMenu_openResourceViewer": "Open Resource Viewer",
+  "mainMenu_openTextCollection": "Open Text Collection",
+  "mainMenu_openWordList": "Open Word List",
   "mainMenu_openVerseImageGenerator": "Open Verse Image Generator",
   "mainMenu_project": "Project",
   "mainMenu_settings": "Settings",

--- a/extensions/src/resource-viewer/src/_editor-overrides.scss
+++ b/extensions/src/resource-viewer/src/_editor-overrides.scss
@@ -1,6 +1,10 @@
 /* Platform.Bible image protocol overrides */
 /* stylelint-disable selector-no-qualifying-type */
 
+.editor-container {
+  max-width: none;
+}
+
 .link-editor div.link-edit {
   background-image: url('papi-extension://resource-viewer/assets/images/icons/pencil-fill.svg');
 }


### PR DESCRIPTION
https://github.com/paranext/paratext-bible-extensions/pull/12

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/818)
<!-- Reviewable:end -->
