### PR TITLE
Fix lorem ipsum white space

### DIFF
--- a/src/renderer/app.component.scss
+++ b/src/renderer/app.component.scss
@@ -72,4 +72,5 @@ a:hover {
 .test-panel {
   margin: 0.5em;
   overflow-y: auto;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
Forgot to respect whitespace in lorem ipsum (for UX test)

![image](https://github.com/paranext/paranext-core/assets/104016682/2d73c6fc-4fef-41f6-9144-d98434a35fd5)
