### PR TITLE
Revert "disable macOS GHA builds (#871)"

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         dotnet_version: [8.0.x]
 
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         dotnet_version: [8.0.x]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, macos-latest, ubuntu-latest]
         dotnet_version: [8.0.x]
 
     steps:

--- a/c-sharp-tests/c-sharp-tests.csproj
+++ b/c-sharp-tests/c-sharp-tests.csproj
@@ -7,7 +7,6 @@
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
-    <PlatformTarget>x64</PlatformTarget>
     <RootNamespace>TestParanextDataProvider</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
This reverts commit d719195fb02c1111a310d9d1360524b116e6e01f.

This PR is to monitor the (assumed) GHA problem with macOS builds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/872)
<!-- Reviewable:end -->
