### PR TITLE
Move all of the test webviews and commands behind an env var

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -39,7 +39,8 @@
       "skipFiles": ["<node_internals>/**"],
       "env": {
         "MAIN_ARGS": "--inspect=5858 --remote-debugging-port=9223",
-        "IN_VSCODE": "true"
+        "IN_VSCODE": "true",
+        "DEV_NOISY": "false"
       }
     },
     {

--- a/extensions/src/hello-someone/manifest.json
+++ b/extensions/src/hello-someone/manifest.json
@@ -1,5 +1,5 @@
 {
-  "name": "hello-someone",
+  "name": "helloSomeone",
   "version": "0.0.1",
   "description": "Simple hello someone extension for Platform.Bible",
   "author": "Paranext",
@@ -10,8 +10,5 @@
   "settings": "contributions/settings.json",
   "projectSettings": "contributions/projectSettings.json",
   "localizedStrings": "contributions/localizedStrings.json",
-  "activationEvents": [
-    "onCommand:helloSomeone.helloSomeone",
-    "onCommand:helloSomeone.echoSomeoneRenderer"
-  ]
+  "activationEvents": ["onCommand:helloSomeone.helloSomeone"]
 }

--- a/extensions/src/hello-someone/src/main.ts
+++ b/extensions/src/hello-someone/src/main.ts
@@ -303,18 +303,6 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     },
   );
 
-  const echoSomeoneRendererPromise = papi.commands.registerCommand(
-    'helloSomeone.echoSomeoneRenderer',
-    async (message: string) => {
-      return `echoSomeoneRenderer: ${await papi.commands.sendCommand(
-        'test.addThree',
-        2,
-        4,
-        6,
-      )}! ${message}`;
-    },
-  );
-
   // Create a webview or get the existing webview if ours already exists
   // Note: here, we are storing a created webview's id when we create it, and using that id on
   // `existingId` to look specifically for the webview that we previously created if we have ever
@@ -355,7 +343,6 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     await peopleWebViewProviderPromise,
     await emotionTestWebViewProviderPromise,
     await helloSomeoneCommandPromise,
-    await echoSomeoneRendererPromise,
     papi.webViews.onDidAddWebView((addWebViewEvent) => {
       if (addWebViewEvent.webView.webViewType === peopleWebViewType)
         logger.info(

--- a/extensions/src/hello-someone/src/types/hello-someone.d.ts
+++ b/extensions/src/hello-someone/src/types/hello-someone.d.ts
@@ -29,7 +29,6 @@ declare module 'papi-shared-types' {
 
   export interface CommandHandlers {
     'helloSomeone.helloSomeone': (name: string) => string;
-    'helloSomeone.echoSomeoneRenderer': (message: string) => Promise<string>;
   }
 
   export interface DataProviders {

--- a/extensions/src/hello-world/contributions/settings.json
+++ b/extensions/src/hello-world/contributions/settings.json
@@ -2,7 +2,7 @@
   {
     "label": "%settings_hello_world_group1_label%",
     "properties": {
-      "hello-world.personName": {
+      "helloWorld.personName": {
         "label": "%settings_hello_world_personName_label%",
         "default": "Bill"
       }

--- a/extensions/src/hello-world/src/main.ts
+++ b/extensions/src/hello-world/src/main.ts
@@ -52,7 +52,7 @@ const reactWebViewProvider: IWebViewProviderWithType = {
         `${this.webViewType} provider received request to provide a ${savedWebView.webViewType} web view`,
       );
     return {
-      iconUrl: 'papi-extension://hello-world/assets/offline.svg',
+      iconUrl: 'papi-extension://helloWorld/assets/offline.svg',
       title: 'Hello World React',
       ...savedWebView,
       content: helloWorldReactWebView,
@@ -191,7 +191,7 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
   );
 
   const helloWorldPersonNamePromise = papi.settings.registerValidator(
-    'hello-world.personName',
+    'helloWorld.personName',
     async (newValue) => typeof newValue === 'string',
   );
 

--- a/extensions/src/hello-world/src/types/hello-world.d.ts
+++ b/extensions/src/hello-world/src/types/hello-world.d.ts
@@ -60,6 +60,6 @@ declare module 'papi-shared-types' {
 
   export interface SettingTypes {
     /** Selected Person's Name on Hello World Web View */
-    'hello-world.personName': string;
+    'helloWorld.personName': string;
   }
 }

--- a/extensions/src/hello-world/src/web-views/hello-world.web-view.html
+++ b/extensions/src/hello-world/src/web-views/hello-world.web-view.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html>
   <head>
     <style>
@@ -10,14 +10,12 @@
   <body>
     <div class="title">Hello World!!</div>
     <div><button id="hello-world" type="button">Hello World 0</button></div>
-    <div><button id="echo-renderer" type="button">Echo Renderer</button></div>
-    <div id="echo-renderer-output"></div>
     <div><button id="hello-someone" type="button">Hello Someone</button></div>
     <div id="hello-someone-output"></div>
     <div id="root"></div>
     <!-- Test the papi-extension protocol in a webView -->
     <img
-      src="papi-extension://quick-verse/assets/letter-q.png"
+      src="papi-extension://quickVerse/assets/letter-q.png"
       alt="Q icon"
       style="max-height: 25px; max-width: 25px"
     />
@@ -44,14 +42,6 @@
           useCallback(({ times }) => setClicks(times), []),
         );
 
-        const [echoResult] = usePromise(
-          useCallback(async () => {
-            await new Promise((resolve) => setTimeout(() => resolve(), 3000));
-            return papi.commands.sendCommand('test.echoRenderer', `From ${NAME}`);
-          }, []),
-          'retrieving',
-        );
-
         return createElement(
           'div',
           null,
@@ -71,7 +61,6 @@
               clicks,
             ),
           ),
-          createElement('div', null, echoResult),
         );
       }
 
@@ -100,25 +89,6 @@
             print(message);
           });
           updateHelloWorldClicks(helloWorldClicks + 1);
-        });
-
-        // Attach handler for echo-renderer
-        const echoRendererButton = document.getElementById('echo-renderer');
-        echoRendererButton.addEventListener('click', () =>
-          papi.commands
-            .sendCommand('test.echoRenderer', 'From Hello World WebView')
-            .then((message) => {
-              const echoRendererOutput = document.getElementById('echo-renderer-output');
-              echoRendererOutput.textContent = papi.utils.htmlEncode(message);
-              print(message);
-            }),
-        );
-        echoRendererButton.addEventListener('contextmenu', (e) => {
-          e.preventDefault();
-          const promises = new Array(10000);
-          for (let i = 0; i < 10000; i += 1)
-            promises[i] = papi.commands.sendCommand('echoRenderer', 'From Hello World WebView');
-          Promise.all(promises).then(() => print('Done'));
         });
 
         // Attach handler for hello-someone

--- a/extensions/src/hello-world/src/web-views/hello-world.web-view.html
+++ b/extensions/src/hello-world/src/web-views/hello-world.web-view.html
@@ -23,6 +23,7 @@
       // Test React component to render in the root
       const { createElement, useCallback, useState } = require('react');
       const { usePromise, useEvent } = require('platform-bible-react');
+      const { htmlEncode } = require('platform-bible-utils');
       const papi = require('@papi/frontend');
       const { logger } = require('@papi/frontend');
 
@@ -73,7 +74,7 @@
         function updateHelloWorldClicks(clicks) {
           helloWorldClicks = clicks;
           const helloWorldButton = document.getElementById('hello-world');
-          helloWorldButton.textContent = papi.utils.htmlEncode(`Hello World ${helloWorldClicks}`);
+          helloWorldButton.textContent = htmlEncode(`Hello World ${helloWorldClicks}`);
         }
 
         // Update the clicks when we are informed helloWorld has been run
@@ -98,7 +99,7 @@
             .sendCommand('helloSomeone.helloSomeone', "'Hello World WebView'")
             .then((message) => {
               const helloSomeoneOutput = document.getElementById('hello-someone-output');
-              helloSomeoneOutput.textContent = papi.utils.htmlEncode(message);
+              helloSomeoneOutput.textContent = htmlEncode(message);
               print(message);
             }),
         );

--- a/extensions/src/hello-world/src/web-views/hello-world.web-view.tsx
+++ b/extensions/src/hello-world/src/web-views/hello-world.web-view.tsx
@@ -89,16 +89,6 @@ globalThis.webViewComponent = function HelloWorld({
     updateWebViewDefinition({ title: `Hello World ${clicks}` });
   }, [getWebViewDefinitionUpdatableProperties, updateWebViewDefinition, clicks]);
 
-  const [echoResult] = usePromise(
-    useCallback(async () => {
-      // Not using the promise's resolved value
-      // eslint-disable-next-line no-promise-executor-return
-      await new Promise<void>((resolve) => setTimeout(() => resolve(), 3000));
-      return papi.commands.sendCommand('test.echoRenderer', `From ${NAME}`);
-    }, []),
-    'retrieving',
-  );
-
   const [project, setProject] = useWebViewState<string>('project', '');
 
   const currentRender = useRef(-1);
@@ -110,7 +100,7 @@ globalThis.webViewComponent = function HelloWorld({
     // testing below to make sure `useDialogCallback` returns the same callback every time
     {
       prompt: `Please select a Scripture project for Hello World WebView: (Render ${currentRender.current})`,
-      iconUrl: 'papi-extension://hello-world/assets/offline.svg',
+      iconUrl: 'papi-extension://helloWorld/assets/offline.svg',
       title: 'Select Hello World Project',
       maximumOpenDialogs: 2,
       // Test ref parameter properly getting latest value
@@ -158,7 +148,7 @@ globalThis.webViewComponent = function HelloWorld({
     useMemo(
       () => ({
         prompt: 'Please select one or more Scripture projects for Hello World WebView:',
-        iconUrl: 'papi-extension://hello-world/assets/offline.svg',
+        iconUrl: 'papi-extension://helloWorld/assets/offline.svg',
         title: 'Select List of Hello World Projects',
         selectedProjectIds: projects,
         includeProjectTypes: '^ParatextStandard$',
@@ -173,7 +163,7 @@ globalThis.webViewComponent = function HelloWorld({
     ),
   );
 
-  const [name, setNameInternal] = useSetting('hello-world.personName', 'Kathy');
+  const [name, setNameInternal] = useSetting('helloWorld.personName', 'Kathy');
 
   // Name used for display and editing in the input field while debouncing the actual setting change
   const [nameTemp, setNameTemp] = useState(name);
@@ -222,7 +212,7 @@ globalThis.webViewComponent = function HelloWorld({
   const [localizedString] = usePromise(
     useCallback(() => {
       return papi.localization.getLocalizedString({
-        localizeKey: 'submitButton',
+        localizeKey: '%submitButton%',
         locales: ['fr', 'en'],
       });
     }, []),
@@ -253,7 +243,6 @@ globalThis.webViewComponent = function HelloWorld({
           Hello World {clicks}
         </Button>
       </div>
-      <div>{echoResult}</div>
       <div>
         <Button
           onClick={() => {

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -441,6 +441,8 @@ declare module 'shared/global-this.model' {
      * ```
      */
     var updateWebViewDefinition: UpdateWebViewDefinition;
+    /** Indicates whether test code meant just for developers to see should be run */
+    var isNoisyDevModeEnabled: boolean;
   }
   /** Type of Paranext process */
   export enum ProcessType {
@@ -2242,7 +2244,6 @@ declare module 'papi-shared-types' {
    */
   interface CommandHandlers {
     'test.echo': (message: string) => string;
-    'test.echoRenderer': (message: string) => Promise<string>;
     'test.echoExtensionHost': (message: string) => Promise<string>;
     'test.throwError': (message: string) => void;
     'platform.restartExtensionHost': () => Promise<void>;
@@ -2591,14 +2592,6 @@ declare module 'papi-shared-types' {
 declare module 'shared/services/command.service' {
   import { UnsubscriberAsync } from 'platform-bible-utils';
   import { CommandHandlers, CommandNames } from 'papi-shared-types';
-  module 'papi-shared-types' {
-    interface CommandHandlers {
-      'test.addThree': typeof addThree;
-      'test.squareAndConcat': typeof squareAndConcat;
-    }
-  }
-  function addThree(a: number, b: number, c: number): Promise<number>;
-  function squareAndConcat(a: number, b: string): Promise<string>;
   /** Sets up the CommandService. Only runs once and always returns the same promise after that */
   export const initialize: () => Promise<void>;
   /** Send a command to the backend. */
@@ -4459,6 +4452,12 @@ declare module 'node/utils/util' {
    * @returns One uri that combines the uri and the paths in left-to-right order
    */
   export function joinUriPaths(uri: Uri, ...paths: string[]): Uri;
+  /**
+   * Determines if running in noisy dev mode
+   *
+   * @returns True if the process is running in noisy dev mode, false otherwise
+   */
+  export const isNoisyDevModeEnvVariableSet: () => boolean;
 }
 declare module 'node/services/node-file-system.service' {
   /** File system calls from Node */
@@ -5650,6 +5649,7 @@ declare module '@papi/frontend' {
    * WARNING: DO NOT IMPORT papi IN ANY FILE THAT papi IMPORTS AND EXPOSES.
    */
   import * as commandService from 'shared/services/command.service';
+  import * as papiUtil from 'platform-bible-utils';
   import { PapiNetworkService } from 'shared/services/network.service';
   import { WebViewServiceType } from 'shared/services/web-view.service-model';
   import { InternetService } from 'shared/services/internet.service';
@@ -5687,6 +5687,11 @@ declare module '@papi/frontend' {
      * other services and extensions that have registered commands.
      */
     commands: typeof commandService;
+    /**
+     *
+     * Miscellaneous utility functions and classes
+     */
+    utils: typeof papiUtil;
     /**
      *
      * Service exposing various functions related to using webViews
@@ -5774,6 +5779,11 @@ declare module '@papi/frontend' {
    * other services and extensions that have registered commands.
    */
   export const commands: typeof commandService;
+  /**
+   *
+   * Miscellaneous utility functions and classes
+   */
+  export const utils: typeof papiUtil;
   /**
    *
    * Service exposing various functions related to using webViews

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5649,7 +5649,6 @@ declare module '@papi/frontend' {
    * WARNING: DO NOT IMPORT papi IN ANY FILE THAT papi IMPORTS AND EXPOSES.
    */
   import * as commandService from 'shared/services/command.service';
-  import * as papiUtil from 'platform-bible-utils';
   import { PapiNetworkService } from 'shared/services/network.service';
   import { WebViewServiceType } from 'shared/services/web-view.service-model';
   import { InternetService } from 'shared/services/internet.service';
@@ -5687,11 +5686,6 @@ declare module '@papi/frontend' {
      * other services and extensions that have registered commands.
      */
     commands: typeof commandService;
-    /**
-     *
-     * Miscellaneous utility functions and classes
-     */
-    utils: typeof papiUtil;
     /**
      *
      * Service exposing various functions related to using webViews
@@ -5779,11 +5773,6 @@ declare module '@papi/frontend' {
    * other services and extensions that have registered commands.
    */
   export const commands: typeof commandService;
-  /**
-   *
-   * Miscellaneous utility functions and classes
-   */
-  export const utils: typeof papiUtil;
   /**
    *
    * Service exposing various functions related to using webViews

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -42,7 +42,6 @@ declare module 'papi-shared-types' {
     // These commands are provided in `main.ts`. They are only here because I needed them to use in
     // other places, but building `papi-dts` wasn't working because it didn't see `main.ts`
     'test.echo': (message: string) => string;
-    'test.echoRenderer': (message: string) => Promise<string>;
     'test.echoExtensionHost': (message: string) => Promise<string>;
     'test.throwError': (message: string) => void;
     'platform.restartExtensionHost': () => Promise<void>;

--- a/src/extension-host/global-this.model.ts
+++ b/src/extension-host/global-this.model.ts
@@ -8,6 +8,7 @@ import {
   getCommandLineSwitch,
 } from '@node/utils/command-line.util';
 import { ProcessType } from '@shared/global-this.model';
+import { isNoisyDevModeEnvVariableSet } from '@node/utils/util';
 
 // #region command-line arguments
 
@@ -18,6 +19,7 @@ const logLevel =
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   (getCommandLineArgument(COMMAND_LINE_ARGS.LogLevel) as LogLevel) ??
   (isPackaged ? 'error' : 'info');
+globalThis.isNoisyDevModeEnabled = isNoisyDevModeEnvVariableSet();
 
 // #endregion
 

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -44,6 +44,15 @@ import { projectSettingsDocumentCombiner } from './project-settings.service-host
 // eslint-disable-next-line camelcase, no-underscore-dangle
 declare const __non_webpack_require__: typeof require;
 
+/** These are names of extensions that should only be loaded if "noisy dev mode" is enabled */
+const TEST_EXTENSION_NAMES = [
+  'c-sharp-provider-test',
+  'evil',
+  'helloSomeone',
+  'helloWorld',
+  'quickVerse',
+];
+
 /**
  * Information about an extension and extra metadata about it that we generate
  *
@@ -383,6 +392,8 @@ async function getExtensions(): Promise<ExtensionInfo[]> {
         );
         return false;
       }
+      if (!globalThis.isNoisyDevModeEnabled && TEST_EXTENSION_NAMES.includes(settled.value.name))
+        return false;
       return true;
     })
     // Assert the fulfilled type since the unfulfilled ones have been filtered out.

--- a/src/main/global-this.model.ts
+++ b/src/main/global-this.model.ts
@@ -13,6 +13,7 @@ import { ProcessType } from '@shared/global-this.model';
 import { app } from 'electron';
 import { getCommandLineArgument, COMMAND_LINE_ARGS } from '@node/utils/command-line.util';
 import { LogLevel } from 'electron-log';
+import { isNoisyDevModeEnvVariableSet } from '@node/utils/util';
 
 // #region globalThis setup
 
@@ -24,6 +25,7 @@ globalThis.logLevel =
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   (getCommandLineArgument(COMMAND_LINE_ARGS.LogLevel) as LogLevel) ??
   (globalThis.isPackaged ? 'info' : 'debug');
+globalThis.isNoisyDevModeEnabled = isNoisyDevModeEnvVariableSet();
 
 // #endregion
 

--- a/src/node/utils/util.ts
+++ b/src/node/utils/util.ts
@@ -92,3 +92,11 @@ export function joinUriPaths(uri: Uri, ...paths: string[]): Uri {
   const { scheme, uriPath } = getPathInfoFromUri(uri);
   return `${scheme}${PROTOCOL_PART}${path.join(uriPath, ...paths)}`;
 }
+
+/**
+ * Determines if running in noisy dev mode
+ *
+ * @returns True if the process is running in noisy dev mode, false otherwise
+ */
+export const isNoisyDevModeEnvVariableSet = (): boolean =>
+  !!process.env.DEV_NOISY && process.env.DEV_NOISY === 'true';

--- a/src/renderer/components/docking/platform-dock-layout-storage.util.ts
+++ b/src/renderer/components/docking/platform-dock-layout-storage.util.ts
@@ -63,23 +63,39 @@ import createRCDockTabFromTabInfo from './platform-dock-tab.component';
 import { ErrorTabData, TAB_TYPE_ERROR, createErrorTab, saveErrorTab } from './error-tab.component';
 
 /** Tab loader functions for each Platform tab type */
-const tabLoaderMap = new Map<TabType, TabLoader>([
-  [TAB_TYPE_ABOUT, loadAboutTab],
-  [TAB_TYPE_BUTTONS, loadButtonsTab],
-  [TAB_TYPE_QUICK_VERSE_HERESY, loadQuickVerseHeresyTab],
-  [TAB_TYPE_TEST, loadTestTab],
-  [TAB_TYPE_WEBVIEW, loadWebViewTab],
-  [TAB_TYPE_DOWNLOAD_UPDATE_PROJECT_DIALOG, loadDownloadUpdateProjectTab],
-  [TAB_TYPE_EXTENSION_MANAGER, loadExtensionManagerTab],
-  [TAB_TYPE_SETTINGS_DIALOG, loadSettingsDialog],
-  [TAB_TYPE_RUN_BASIC_CHECKS, loadRunBasicChecksTab],
-  [TAB_TYPE_BASIC_LIST, loadBasicListTab],
-  ...Object.entries(DIALOGS).map(
-    ([dialogTabType, dialogDefinition]) =>
-      // The default implementation of `loadDialog` uses `this`, so bind it to the definition
-      [dialogTabType, dialogDefinition.loadDialog.bind(dialogDefinition)] as const,
-  ),
-]);
+let tabLoaderMap: Map<TabType, TabLoader>;
+if (globalThis.isNoisyDevModeEnabled) {
+  tabLoaderMap = new Map<TabType, TabLoader>([
+    [TAB_TYPE_ABOUT, loadAboutTab],
+    [TAB_TYPE_BUTTONS, loadButtonsTab],
+    [TAB_TYPE_QUICK_VERSE_HERESY, loadQuickVerseHeresyTab],
+    [TAB_TYPE_TEST, loadTestTab],
+    [TAB_TYPE_WEBVIEW, loadWebViewTab],
+    [TAB_TYPE_DOWNLOAD_UPDATE_PROJECT_DIALOG, loadDownloadUpdateProjectTab],
+    [TAB_TYPE_EXTENSION_MANAGER, loadExtensionManagerTab],
+    [TAB_TYPE_SETTINGS_DIALOG, loadSettingsDialog],
+    [TAB_TYPE_RUN_BASIC_CHECKS, loadRunBasicChecksTab],
+    [TAB_TYPE_BASIC_LIST, loadBasicListTab],
+    ...Object.entries(DIALOGS).map(
+      ([dialogTabType, dialogDefinition]) =>
+        // The default implementation of `loadDialog` uses `this`, so bind it to the definition
+        [dialogTabType, dialogDefinition.loadDialog.bind(dialogDefinition)] as const,
+    ),
+  ]);
+} else {
+  tabLoaderMap = new Map<TabType, TabLoader>([
+    [TAB_TYPE_ABOUT, loadAboutTab],
+    [TAB_TYPE_BUTTONS, loadButtonsTab],
+    [TAB_TYPE_WEBVIEW, loadWebViewTab],
+    [TAB_TYPE_DOWNLOAD_UPDATE_PROJECT_DIALOG, loadDownloadUpdateProjectTab],
+    [TAB_TYPE_EXTENSION_MANAGER, loadExtensionManagerTab],
+    ...Object.entries(DIALOGS).map(
+      ([dialogTabType, dialogDefinition]) =>
+        // The default implementation of `loadDialog` uses `this`, so bind it to the definition
+        [dialogTabType, dialogDefinition.loadDialog.bind(dialogDefinition)] as const,
+    ),
+  ]);
+}
 
 /** Tab saver functions for each Platform tab type that wants to override the default */
 const tabSaverMap = new Map<TabType, TabSaver>([

--- a/src/renderer/components/extension-manager/extension-manager-tab.component.tsx
+++ b/src/renderer/components/extension-manager/extension-manager-tab.component.tsx
@@ -64,7 +64,7 @@ export function fetchExtensions(): Extension[] {
       description: 'Example Bundled Extension',
       hasUpdateAvailable: false,
       isInstalled: false,
-      iconFilePath: 'papi-extension://quick-verse/assets/letter-q.png',
+      iconFilePath: 'papi-extension://quickVerse/assets/letter-q.png',
     },
   ];
 }

--- a/src/renderer/global-this.model.ts
+++ b/src/renderer/global-this.model.ts
@@ -18,6 +18,7 @@ import useWebViewState from '@renderer/hooks/use-web-view-state.hook';
 import * as papiReact from '@renderer/services/papi-frontend-react.service';
 import * as platformBibleReact from 'platform-bible-react';
 import * as platformBibleUtils from 'platform-bible-utils';
+import { DEV_MODE_RENDERER_INDICATOR } from '@shared/data/platform.data';
 
 // #region webpack DefinePlugin types setup - these should be from the renderer webpack DefinePlugin
 
@@ -113,5 +114,7 @@ globalThis.setWebViewStateById = setWebViewStateById;
 globalThis.resetWebViewStateById = resetWebViewStateById;
 // We store the hook reference because we need it to bind it to the webview's iframe 'window' context
 globalThis.useWebViewState = useWebViewState;
+// Check if the main process indicated noisy dev mode is enabled
+globalThis.isNoisyDevModeEnabled = global.location.search === DEV_MODE_RENDERER_INDICATOR;
 
 // #endregion

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -15,7 +15,7 @@ window.addEventListener('error', (errorEvent: ErrorEvent) => {
   logger.error(`Unhandled error in renderer from ${filename}:${lineno}:${colno}, '${error}'`);
 });
 
-logger.info('Starting renderer');
+logger.info(`Starting renderer${globalThis.isNoisyDevModeEnabled ? ' in noisy dev mode' : ''}`);
 
 // This is a little different than Promise.all in that the error message will have all the reasons
 // that all promises were rejected (if they didn't resolve).

--- a/src/renderer/services/papi-frontend.service.ts
+++ b/src/renderer/services/papi-frontend.service.ts
@@ -5,6 +5,7 @@
  */
 
 import * as commandService from '@shared/services/command.service';
+import * as papiUtil from 'platform-bible-utils';
 import papiLogger from '@shared/services/logger.service';
 import { papiNetworkService, PapiNetworkService } from '@shared/services/network.service';
 import { WebViewServiceType } from '@shared/services/web-view.service-model';
@@ -51,6 +52,12 @@ const papi = {
   // Services/modules
   /** JSDOC DESTINATION commandService */
   commands: commandService,
+  /**
+   * JSDOC SOURCE papiUtil
+   *
+   * Miscellaneous utility functions and classes
+   */
+  utils: papiUtil,
   /** JSDOC DESTINATION papiWebViewService */
   webViews: webViewService as WebViewServiceType,
   /** JSDOC DESTINATION dialogService */
@@ -102,6 +109,9 @@ Object.freeze(papi.XMLHttpRequest);
 /** JSDOC DESTINATION commandService */
 export const { commands } = papi;
 Object.freeze(papi.commands);
+/** JSDOC DESTINATION papiUtil */
+export const { utils } = papi;
+Object.freeze(papi.utils);
 /** JSDOC DESTINATION papiWebViewService */
 export const { webViews } = papi;
 Object.freeze(papi.webViews);

--- a/src/renderer/services/papi-frontend.service.ts
+++ b/src/renderer/services/papi-frontend.service.ts
@@ -5,7 +5,6 @@
  */
 
 import * as commandService from '@shared/services/command.service';
-import * as papiUtil from 'platform-bible-utils';
 import papiLogger from '@shared/services/logger.service';
 import { papiNetworkService, PapiNetworkService } from '@shared/services/network.service';
 import { WebViewServiceType } from '@shared/services/web-view.service-model';
@@ -52,12 +51,6 @@ const papi = {
   // Services/modules
   /** JSDOC DESTINATION commandService */
   commands: commandService,
-  /**
-   * JSDOC SOURCE papiUtil
-   *
-   * Miscellaneous utility functions and classes
-   */
-  utils: papiUtil,
   /** JSDOC DESTINATION papiWebViewService */
   webViews: webViewService as WebViewServiceType,
   /** JSDOC DESTINATION dialogService */
@@ -109,9 +102,6 @@ Object.freeze(papi.XMLHttpRequest);
 /** JSDOC DESTINATION commandService */
 export const { commands } = papi;
 Object.freeze(papi.commands);
-/** JSDOC DESTINATION papiUtil */
-export const { utils } = papi;
-Object.freeze(papi.utils);
 /** JSDOC DESTINATION papiWebViewService */
 export const { webViews } = papi;
 Object.freeze(papi.webViews);

--- a/src/renderer/testing/test-buttons-panel.component.tsx
+++ b/src/renderer/testing/test-buttons-panel.component.tsx
@@ -25,15 +25,7 @@ const addOne = async (num: number) => commandService.sendCommand('test.addOne', 
 
 const echo = commandService.createSendCommandFunction('test.echo');
 
-const echoRenderer = commandService.createSendCommandFunction('test.echoRenderer');
-
 const echoExtensionHost = commandService.createSendCommandFunction('test.echoExtensionHost');
-
-const echoSomeoneRenderer = commandService.createSendCommandFunction(
-  'helloSomeone.echoSomeoneRenderer',
-);
-
-const addThree = commandService.createSendCommandFunction('test.addThree');
 
 const addMany = commandService.createSendCommandFunction('test.addMany');
 
@@ -206,22 +198,6 @@ export default function TestButtonsPanel() {
           className="test-button"
           onClick={async () => {
             const start = performance.now();
-            const result = await runPromise(() => echoRenderer('Echo Renderer Stuff'));
-            logger.debug(
-              `command:test.echoRenderer '${result}' took ${performance.now() - start} ms`,
-            );
-          }}
-          onContextMenu={(e) => {
-            e.preventDefault();
-            executeMany(() => echoRenderer('Echo Renderer Stuff'));
-          }}
-        >
-          Echo Renderer
-        </Button>
-        <Button
-          className="test-button"
-          onClick={async () => {
-            const start = performance.now();
             const result = await runPromise(() => echoExtensionHost('Echo Extension Host Stuff'));
             logger.debug(
               `command:test.echoExtensionHost '${result}' took ${performance.now() - start} ms`,
@@ -233,40 +209,6 @@ export default function TestButtonsPanel() {
           }}
         >
           Echo Extension Host
-        </Button>
-        <Button
-          className="test-button"
-          onClick={async () => {
-            const start = performance.now();
-            const result = await runPromise(() =>
-              echoSomeoneRenderer('Echo Someone Renderer Stuff'),
-            );
-            logger.debug(
-              `command:helloSomeone.echoSomeoneRenderer '${result}' took ${
-                performance.now() - start
-              } ms`,
-            );
-          }}
-          onContextMenu={(e) => {
-            e.preventDefault();
-            executeMany(() => echoSomeoneRenderer('Echo Someone Renderer Stuff'));
-          }}
-        >
-          Echo Someone Renderer
-        </Button>
-        <Button
-          className="test-button"
-          onClick={async () => {
-            const start = performance.now();
-            const result = await runPromise(() => addThree(1, 2, 3));
-            logger.debug(`command:test.addThree ${result} took ${performance.now() - start} ms`);
-          }}
-          onContextMenu={(e) => {
-            e.preventDefault();
-            executeMany(() => addThree(1, 2, 3));
-          }}
-        >
-          AddThree (Renderer)
         </Button>
         <Button
           className="test-button"

--- a/src/renderer/testing/test-layout.data.ts
+++ b/src/renderer/testing/test-layout.data.ts
@@ -16,105 +16,122 @@ export const FIRST_TAB_ID = 'About';
 
 // Using `as` here simplifies type changes.
 /* eslint-disable no-type-assertion/no-type-assertion */
-const testLayout: LayoutBase = {
-  dockbox: {
-    mode: 'horizontal',
-    children: [
-      {
-        mode: 'vertical',
-        size: 250,
+const testLayout: LayoutBase = globalThis.isNoisyDevModeEnabled
+  ? {
+      dockbox: {
+        mode: 'horizontal',
         children: [
           {
-            tabs: [
-              { id: 'About', tabType: TAB_TYPE_ABOUT },
-              { id: 'Test Tab Two', tabType: TAB_TYPE_TEST },
-              { id: 'Test Tab One', tabType: TAB_TYPE_TEST },
+            mode: 'vertical',
+            size: 250,
+            children: [
               {
-                id: 'Lorem Ipsum',
-                tabType: TAB_TYPE_TEST,
-                data: { content: LOREM_IPSUM },
+                tabs: [
+                  { id: 'About', tabType: TAB_TYPE_ABOUT },
+                  { id: 'Test Tab Two', tabType: TAB_TYPE_TEST },
+                  { id: 'Test Tab One', tabType: TAB_TYPE_TEST },
+                  {
+                    id: 'Lorem Ipsum',
+                    tabType: TAB_TYPE_TEST,
+                    data: { content: LOREM_IPSUM },
+                  },
+                ] as SavedTabInfo[],
               },
-            ] as SavedTabInfo[],
+            ],
+          },
+          {
+            tabs: [{ id: 'Test Buttons', tabType: TAB_TYPE_BUTTONS }] as SavedTabInfo[],
+          },
+          {
+            tabs: [{ id: 'Basic List', tabType: TAB_TYPE_BASIC_LIST }] as SavedTabInfo[],
           },
         ],
       },
-      {
-        tabs: [{ id: 'Test Buttons', tabType: TAB_TYPE_BUTTONS }] as SavedTabInfo[],
-      },
-      {
-        tabs: [{ id: 'Basic List', tabType: TAB_TYPE_BASIC_LIST }] as SavedTabInfo[],
-      },
-    ],
-  },
-  floatbox: {
-    mode: 'float',
-    children: [
-      // {
-      //   tabs: [
-      //     { id: 'Test Quick Verse Heresy', tabType: TAB_TYPE_QUICK_VERSE_HERESY },
-      //   ] as SavedTabInfo[],
-      //   x: 300,
-      //   y: 170,
-      //   w: 320,
-      //   h: 190,
-      // },
-      // {
-      //   tabs: [
-      //     {
-      //       id: 'Download/Update Project Dialog',
-      //       tabType: TAB_TYPE_DOWNLOAD_UPDATE_PROJECT_DIALOG,
-      //     },
-      //   ] as SavedTabInfo[],
-      //   x: 350,
-      //   y: 170,
-      //   w: 320,
-      //   h: 190,
-      // },
-      // {
-      //   tabs: [
-      //     {
-      //       id: 'Open Multiple Projects Dialog',
-      //       tabType: TAB_TYPE_OPEN_MULTIPLE_PROJECTS_DIALOG,
-      //     },
-      //   ] as SavedTabInfo[],
-      //   x: 400,
-      //   y: 170,
-      //   w: 320,
-      //   h: 190,
-      // },
-      // {
-      //   tabs: [
-      //     {
-      //       id: 'Extension Toggle',
-      //       tabType: TAB_TYPE_EXTENSION_MANAGER,
-      //     },
-      //   ] as SavedTabInfo[],
-      //   x: 300,
-      //   y: 170,
-      //   w: 320,
-      //   h: 190,
-      // },
-      {
-        tabs: [{ id: 'Settings', tabType: TAB_TYPE_SETTINGS_DIALOG }] as SavedTabInfo[],
-        x: 300,
-        y: 170,
-        w: 600,
-        h: 400,
-      },
-      {
-        tabs: [
+      floatbox: {
+        mode: 'float',
+        children: [
+          // {
+          //   tabs: [
+          //     { id: 'Test Quick Verse Heresy', tabType: TAB_TYPE_QUICK_VERSE_HERESY },
+          //   ] as SavedTabInfo[],
+          //   x: 300,
+          //   y: 170,
+          //   w: 320,
+          //   h: 190,
+          // },
+          // {
+          //   tabs: [
+          //     {
+          //       id: 'Download/Update Project Dialog',
+          //       tabType: TAB_TYPE_DOWNLOAD_UPDATE_PROJECT_DIALOG,
+          //     },
+          //   ] as SavedTabInfo[],
+          //   x: 350,
+          //   y: 170,
+          //   w: 320,
+          //   h: 190,
+          // },
+          // {
+          //   tabs: [
+          //     {
+          //       id: 'Open Multiple Projects Dialog',
+          //       tabType: TAB_TYPE_OPEN_MULTIPLE_PROJECTS_DIALOG,
+          //     },
+          //   ] as SavedTabInfo[],
+          //   x: 400,
+          //   y: 170,
+          //   w: 320,
+          //   h: 190,
+          // },
+          // {
+          //   tabs: [
+          //     {
+          //       id: 'Extension Toggle',
+          //       tabType: TAB_TYPE_EXTENSION_MANAGER,
+          //     },
+          //   ] as SavedTabInfo[],
+          //   x: 300,
+          //   y: 170,
+          //   w: 320,
+          //   h: 190,
+          // },
           {
-            id: 'Run Basic Checks',
-            tabType: TAB_TYPE_RUN_BASIC_CHECKS,
+            tabs: [{ id: 'Settings', tabType: TAB_TYPE_SETTINGS_DIALOG }] as SavedTabInfo[],
+            x: 300,
+            y: 170,
+            w: 600,
+            h: 400,
           },
-        ] as SavedTabInfo[],
-        x: 300,
-        y: 170,
-        w: 320,
-        h: 190,
+          {
+            tabs: [
+              {
+                id: 'Run Basic Checks',
+                tabType: TAB_TYPE_RUN_BASIC_CHECKS,
+              },
+            ] as SavedTabInfo[],
+            x: 300,
+            y: 170,
+            w: 320,
+            h: 190,
+          },
+        ],
       },
-    ],
-  },
-};
+    }
+  : {
+      dockbox: {
+        mode: 'horizontal',
+        children: [
+          {
+            mode: 'vertical',
+            size: 250,
+            children: [
+              {
+                tabs: [{ id: 'About', tabType: TAB_TYPE_ABOUT }] as SavedTabInfo[],
+              },
+            ],
+          },
+        ],
+      },
+    };
 /* eslint-enable */
 export default testLayout;

--- a/src/renderer/testing/test-quick-verse-heresy-panel.component.tsx
+++ b/src/renderer/testing/test-quick-verse-heresy-panel.component.tsx
@@ -36,7 +36,7 @@ export function TestQuickVerseHeresyPanel() {
     <div className="buttons-panel">
       <div className="hello">
         <img
-          src="papi-extension://quick-verse/assets/letter-q.png"
+          src="papi-extension://quickVerse/assets/letter-q.png"
           alt="Q icon"
           style={{
             maxHeight: '40px',

--- a/src/shared/data/platform.data.ts
+++ b/src/shared/data/platform.data.ts
@@ -2,6 +2,7 @@
  * Namespace to use for features like commands, settings, etc. on the PAPI that are provided by
  * Platform.Bible core
  */
-// This does not represent this file but is just one thing to export from it
-// eslint-disable-next-line import/prefer-default-export
 export const PLATFORM_NAMESPACE = 'platform';
+
+/** Query string passed to the renderer when starting if it should enable noisy dev mode */
+export const DEV_MODE_RENDERER_INDICATOR = '?noisyDevMode';

--- a/src/shared/global-this.model.ts
+++ b/src/shared/global-this.model.ts
@@ -58,6 +58,8 @@ declare global {
   var getWebViewDefinitionUpdatableProperties: GetWebViewDefinitionUpdatableProperties;
   /** JSDOC DESTINATION UpdateWebViewDefinition */
   var updateWebViewDefinition: UpdateWebViewDefinition;
+  /** Indicates whether test code meant just for developers to see should be run */
+  var isNoisyDevModeEnabled: boolean;
 }
 /* eslint-enable */
 


### PR DESCRIPTION
Changes:
 - Move a lot of test code behind an environment variable called `DEV_NOISY`. Devs can set that environment variable to "true" to see the same test webviews and commands that existed previously.
 - Remove the commands named "test.addThree" and "test.squareAndConcat" that were registered inside of the renderer within the command service.  The command service was still organized in the old way where flags like `isRenderer` and `isClient` are sprinkled into the code, so although the service is in `shared`, it actually has non-shared portions. Removing these commands eliminates all of that non-shared code, so the command service is all truly now "shared".
 - Remove the commands named "test.echoRenderer" and "'helloSomeone.echoSomeoneRenderer" which just wrapped calls to "test.addThree" internally.
 - Fix several small bugs with some built-in extensions.
 
Note that you will want to clear local storage in the renderer when switching `DEV_NOISY` back and forth to see all webviews appropriately.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/886)
<!-- Reviewable:end -->
