### PR TITLE
Fix docs related to `npm install` when running the first time

### DIFF
--- a/lib/platform-bible-react/README.md
+++ b/lib/platform-bible-react/README.md
@@ -17,7 +17,7 @@ TODO:
 
 #### Setting up
 
-To set up the dev environment to build, you must run the following:
+To set up the dev environment to build, you must run the following from `paranext-core`:
 
 ```bash
 npm i

--- a/lib/platform-bible-utils/README.md
+++ b/lib/platform-bible-utils/README.md
@@ -17,7 +17,7 @@ TODO:
 
 #### Setting up
 
-To set up the dev environment to build, you must run the following:
+To set up the dev environment to build, you must run the following from `paranext-core`:
 
 ```bash
 npm i


### PR DESCRIPTION
David noticed that `npm install` doesn't work from the lib directories if it hasn't been run first from `paranext-core`. After the first time it works fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/892)
<!-- Reviewable:end -->
