### PR TITLE
fix vertical tab ribbon + add more to preview app

### DIFF
--- a/lib/platform-bible-react/src/components/shadcn-ui/tabs-vertical.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/tabs-vertical.tsx
@@ -56,11 +56,7 @@ export const VerticalTabsTrigger = React.forwardRef<
       'overflow-clip pr-inline-flex pr-w-[116px] pr-cursor-pointer pr-items-center pr-justify-center pr-break-words pr-rounded-sm pr-border-0 pr-bg-muted pr-px-3 pr-py-1.5 pr-text-sm pr-font-medium pr-text-inherit pr-ring-offset-background pr-transition-all hover:pr-text-foreground focus-visible:pr-outline-none focus-visible:pr-ring-2 focus-visible:pr-ring-ring focus-visible:pr-ring-offset-2 disabled:pr-pointer-events-none disabled:pr-opacity-50 data-[state=active]:pr-bg-background data-[state=active]:pr-text-foreground data-[state=active]:pr-shadow-sm',
       className,
     )}
-  >
-    <div className="pr-flex pr-flex-col pr-justify-center">
-      <div>{props.value}</div>
-    </div>
-  </TabsPrimitive.Trigger>
+  />
 ));
 
 export const VerticalTabsContent = React.forwardRef<

--- a/lib/platform-bible-react/src/preview/components/compositions.component.tsx
+++ b/lib/platform-bible-react/src/preview/components/compositions.component.tsx
@@ -4,6 +4,7 @@ import ThemeToggle from '@/preview/theme-toggle.component';
 import {
   BookChapterControl,
   RefSelector,
+  SearchBar,
   VerticalTabs,
   VerticalTabsContent,
   VerticalTabsList,
@@ -22,9 +23,14 @@ function Compositions() {
   return (
     <VerticalTabs defaultValue="Book Chapter Control">
       <VerticalTabsList>
+        <VerticalTabsTrigger value="Search Bar">Search Bar</VerticalTabsTrigger>
         <VerticalTabsTrigger value="Book Chapter Control">Book Chapter Control</VerticalTabsTrigger>
         <VerticalTabsTrigger value="Theme Toggle">Theme Toggle</VerticalTabsTrigger>
       </VerticalTabsList>
+
+      <VerticalTabsContent value="Search Bar">
+        <SearchBar onSearch={() => {}} />
+      </VerticalTabsContent>
 
       <VerticalTabsContent value="Book Chapter Control">
         <RefSelector scrRef={scrRef} handleSubmit={setScrRef} />

--- a/lib/platform-bible-react/src/preview/components/examples.component.tsx
+++ b/lib/platform-bible-react/src/preview/components/examples.component.tsx
@@ -21,7 +21,8 @@ function Example() {
   return (
     <VerticalTabs defaultValue="Window">
       <VerticalTabsList>
-        <VerticalTabsTrigger value="Window">Window / Tab</VerticalTabsTrigger>
+        <VerticalTabsTrigger value="Window">Window or Tab</VerticalTabsTrigger>
+        <VerticalTabsTrigger value="Settings">Settings (n/a)</VerticalTabsTrigger>
       </VerticalTabsList>
 
       <VerticalTabsContent value="Window">


### PR DESCRIPTION
The fix of the ribbon enables to display all content that is passed to it (like the horizontal tab does) instead of outputting the the "value" property. Being able to do this is needed e.g. for localization or if you want to have non-label ui elements as a tab trigger.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/925)
<!-- Reviewable:end -->
