### PR TITLE
Resolved infinite loop between two layering PDPs, added new class to make resolving this easier

### DIFF
--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -32,7 +32,7 @@ export async function activate(context: ExecutionActivationContext) {
     papi.projectDataProviders.registerProjectDataProviderEngineFactory(
       SCRIPTURE_EXTENDER_PDPF_ID,
       SCRIPTURE_EXTENDER_PROJECT_INTERFACES,
-      new ScriptureExtenderProjectDataProviderEngineFactory(),
+      new ScriptureExtenderProjectDataProviderEngineFactory(SCRIPTURE_EXTENDER_PDPF_ID),
     );
 
   const includeProjectsCommandPromise = papi.commands.registerCommand(

--- a/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-extender-pdpef.model.ts
+++ b/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-extender-pdpef.model.ts
@@ -1,9 +1,5 @@
-import {
-  IProjectDataProviderEngine,
-  IProjectDataProviderEngineFactory,
-  ProjectMetadataWithoutFactoryInfo,
-} from '@papi/core';
-import papi from '@papi/backend';
+import { IProjectDataProviderEngine, IProjectDataProviderEngineFactory } from '@papi/core';
+import papi, { LayeringProjectDataProviderEngineFactory } from '@papi/backend';
 import { escapeStringRegexp } from 'platform-bible-utils';
 import ScriptureExtenderProjectDataProviderEngine, {
   SCRIPTURE_EXTENDER_OVERLAY_PROJECT_INTERFACES,
@@ -13,7 +9,6 @@ import ScriptureExtenderProjectDataProviderEngine, {
 
 /** PDP Factory ID for the Scripture Extender PDPF */
 export const SCRIPTURE_EXTENDER_PDPF_ID = 'platformScripture.scriptureExtenderPdpf';
-const SCRIPTURE_EXTENDER_PDPF_ID_REGEX_STRING = escapeStringRegexp(SCRIPTURE_EXTENDER_PDPF_ID);
 
 /** Regex strings for the project interfaces the Scripture Extender Layering PDPF layers over */
 const SCRIPTURE_EXTENDER_OVERLAY_PROJECT_INTERFACES_REGEX_STRINGS =
@@ -22,33 +17,12 @@ const SCRIPTURE_EXTENDER_OVERLAY_PROJECT_INTERFACES_REGEX_STRINGS =
   );
 
 class ScriptureExtenderProjectDataProviderEngineFactory
+  extends LayeringProjectDataProviderEngineFactory<typeof SCRIPTURE_EXTENDER_PROJECT_INTERFACES>
   implements IProjectDataProviderEngineFactory<typeof SCRIPTURE_EXTENDER_PROJECT_INTERFACES>
 {
-  // Implementing an interface method, so can't be static
-  // eslint-disable-next-line class-methods-use-this
-  async getAvailableProjects(): Promise<ProjectMetadataWithoutFactoryInfo[]> {
-    try {
-      const projectsToOverlayMetadata = await papi.projectLookup.getMetadataForAllProjects({
-        includeProjectInterfaces: SCRIPTURE_EXTENDER_OVERLAY_PROJECT_INTERFACES_REGEX_STRINGS,
-        // The `projectInterface`s we provide are excluded because we don't need to provide them
-        // again if they're already provided. Wrapped in another array so we only exclude projects
-        // that already serve all the `projectInterface`s we support
-        excludeProjectInterfaces: [SCRIPTURE_EXTENDER_PROJECT_INTERFACES],
-        excludePdpFactoryIds: SCRIPTURE_EXTENDER_PDPF_ID_REGEX_STRING,
-      });
-      return projectsToOverlayMetadata.map((projectMetadataToOverlay) => {
-        const projectMetadata: ProjectMetadataWithoutFactoryInfo & { pdpFactoryInfo?: unknown } =
-          projectMetadataToOverlay;
-        delete projectMetadata.pdpFactoryInfo;
-        projectMetadata.projectInterfaces = SCRIPTURE_EXTENDER_PROJECT_INTERFACES;
-        return projectMetadata;
-      });
-    } catch (e) {
-      throw new Error(
-        `${SCRIPTURE_EXTENDER_PDPF_ID} was not able to get metadata for projects to overlay. ${e}`,
-      );
-    }
-  }
+  projectInterfacesToLayerOver = SCRIPTURE_EXTENDER_OVERLAY_PROJECT_INTERFACES_REGEX_STRINGS;
+
+  providedProjectInterfaces = SCRIPTURE_EXTENDER_PROJECT_INTERFACES;
 
   // Implementing an interface method, so can't be static
   // eslint-disable-next-line class-methods-use-this

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -3817,7 +3817,9 @@ declare module 'shared/models/project-data-provider-engine-factory.model' {
    * {@link IBaseProjectDataProvider} and {@link ProjectDataProviderInterfaces} for more information.
    *
    * WARNING: For Layering PDPFs, `getAvailableProjects` has very specific requirements that
-   * **absolutely must** be met.
+   * **absolutely must** be met. Please see
+   * {@link IProjectDataProviderEngineFactory.getAvailableProjects} for more information on the
+   * requirements.
    *
    * To make creating a Layering PDPF easier, you can extend
    * {@link LayeringProjectDataProviderEngineFactory}, which automatically fulfills the special
@@ -3874,7 +3876,9 @@ declare module 'shared/models/project-data-provider-engine-factory.model' {
    * easier.
    *
    * Extending this class automatically fulfills the special requirements for Layering PDPfs, so we
-   * highly recommend extending this class.
+   * highly recommend extending this class. Please see
+   * {@link IProjectDataProviderEngineFactory.getAvailableProjects} for more information on the
+   * requirements.
    */
   export abstract class LayeringProjectDataProviderEngineFactory<
     SupportedProjectInterfaces extends ProjectInterfaces[],
@@ -5489,7 +5493,9 @@ declare module '@papi/backend' {
      * easier.
      *
      * Extending this class automatically fulfills the special requirements for Layering PDPfs, so we
-     * highly recommend extending this class.
+     * highly recommend extending this class. Please see
+     * {@link IProjectDataProviderEngineFactory.getAvailableProjects} for more information on the
+     * requirements.
      */
     LayeringProjectDataProviderEngineFactory: typeof PapiLayeringProjectDataProviderEngineFactory;
     /** This is just an alias for internet.fetch */
@@ -5629,7 +5635,9 @@ declare module '@papi/backend' {
    * easier.
    *
    * Extending this class automatically fulfills the special requirements for Layering PDPfs, so we
-   * highly recommend extending this class.
+   * highly recommend extending this class. Please see
+   * {@link IProjectDataProviderEngineFactory.getAvailableProjects} for more information on the
+   * requirements.
    */
   export const LayeringProjectDataProviderEngineFactory: typeof PapiLayeringProjectDataProviderEngineFactory;
   /** This is just an alias for internet.fetch */

--- a/src/extension-host/services/papi-backend.service.ts
+++ b/src/extension-host/services/papi-backend.service.ts
@@ -18,6 +18,7 @@ import dataProviderService, { DataProviderService } from '@shared/services/data-
 import { DataProviderEngine as PapiDataProviderEngine } from '@shared/models/data-provider-engine.model';
 import { ProjectDataProviderEngine as PapiProjectDataProviderEngine } from '@shared/models/project-data-provider-engine.model';
 import { BaseProjectDataProviderEngine as PapiBaseProjectDataProviderEngine } from '@shared/models/base-project-data-provider-engine.model';
+import { LayeringProjectDataProviderEngineFactory as PapiLayeringProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model';
 import {
   papiBackendProjectDataProviderService,
   PapiBackendProjectDataProviderService,
@@ -54,6 +55,8 @@ const papi = {
   ProjectDataProviderEngine: PapiProjectDataProviderEngine,
   /** JSDOC DESTINATION BaseProjectDataProviderEngine */
   BaseProjectDataProviderEngine: PapiBaseProjectDataProviderEngine,
+  /** JSDOC DESTINATION LayeringProjectDataProviderEngineFactory */
+  LayeringProjectDataProviderEngineFactory: PapiLayeringProjectDataProviderEngineFactory,
 
   // Functions
   /** This is just an alias for internet.fetch */
@@ -110,6 +113,9 @@ Object.freeze(papi.ProjectDataProviderEngine);
 /** JSDOC DESTINATION BaseProjectDataProviderEngine */
 export const { BaseProjectDataProviderEngine } = papi;
 Object.freeze(papi.BaseProjectDataProviderEngine);
+/** JSDOC DESTINATION LayeringProjectDataProviderEngineFactory */
+export const { LayeringProjectDataProviderEngineFactory } = papi;
+Object.freeze(papi.LayeringProjectDataProviderEngineFactory);
 /** This is just an alias for internet.fetch */
 export const { fetch } = papi;
 Object.freeze(papi.fetch);

--- a/src/renderer/components/dialogs/dialog-definition.model.ts
+++ b/src/renderer/components/dialogs/dialog-definition.model.ts
@@ -1,7 +1,7 @@
 import { DialogOptions } from '@shared/models/dialog-options.model';
 import { DialogDefinitionBase, DialogProps } from '@renderer/components/dialogs/dialog-base.data';
 import { ReactElement } from 'react';
-import { ProjectMetadataFilterOptions } from '@shared/models/project-lookup.service-model';
+import { ProjectMetadataFilterOptions } from '@shared/models/project-data-provider-factory.interface';
 
 /** The tabType for the select project dialog in `select-project.dialog.tsx` */
 export const SELECT_PROJECT_DIALOG_TYPE = 'platform.selectProject';

--- a/src/shared/models/project-data-provider-engine-factory.model.ts
+++ b/src/shared/models/project-data-provider-engine-factory.model.ts
@@ -25,7 +25,9 @@ import { escapeStringRegexp } from 'platform-bible-utils';
  * {@link IBaseProjectDataProvider} and {@link ProjectDataProviderInterfaces} for more information.
  *
  * WARNING: For Layering PDPFs, `getAvailableProjects` has very specific requirements that
- * **absolutely must** be met.
+ * **absolutely must** be met. Please see
+ * {@link IProjectDataProviderEngineFactory.getAvailableProjects} for more information on the
+ * requirements.
  *
  * To make creating a Layering PDPF easier, you can extend
  * {@link LayeringProjectDataProviderEngineFactory}, which automatically fulfills the special
@@ -60,7 +62,9 @@ export interface IProjectDataProviderEngineFactory<
  * easier.
  *
  * Extending this class automatically fulfills the special requirements for Layering PDPfs, so we
- * highly recommend extending this class.
+ * highly recommend extending this class. Please see
+ * {@link IProjectDataProviderEngineFactory.getAvailableProjects} for more information on the
+ * requirements.
  */
 export abstract class LayeringProjectDataProviderEngineFactory<
   SupportedProjectInterfaces extends ProjectInterfaces[],

--- a/src/shared/models/project-data-provider-engine-factory.model.ts
+++ b/src/shared/models/project-data-provider-engine-factory.model.ts
@@ -1,0 +1,149 @@
+import { ProjectInterfaces } from 'papi-shared-types';
+import { ProjectMetadataFilterOptions } from '@shared/models/project-data-provider-factory.interface';
+import { ProjectMetadataWithoutFactoryInfo } from '@shared/models/project-metadata.model';
+import { IProjectDataProviderEngine } from '@shared/models/project-data-provider-engine.model';
+import projectLookupService from '@shared/services/project-lookup.service';
+import { escapeStringRegexp } from 'platform-bible-utils';
+
+/**
+ * A factory object registered with the papi that creates a Project Data Provider Engine for each
+ * project with the factory's specified `projectInterface`s when the papi requests. Used by the papi
+ * to create {@link IProjectDataProviderEngine}s for a specific project and `projectInterface` when
+ * someone gets a project data provider with `papi.projectDataProviders.get`. When this factory
+ * object is registered with `papi.projectDataProviders.registerProjectDataProviderEngineFactory`,
+ * the papi creates a {@link ProjectDataProviderFactory} that layers over this engine to create
+ * {@link IProjectDataProvider}s.
+ *
+ * Project Data Provider Engine Factories create Project Data Provider Engines for specific
+ * `projectInterface`s. For each project id available on a Project Data Provider Factory, the
+ * factory that supports that project with some set of `projectInterface`s creates a new instance of
+ * a PDP with the supported `projectInterface`s.
+ *
+ * A PDP Factory can provide its own unique project ids (Base PDP Factory) or layer over other PDPFs
+ * and provide additional `projectInterface`s on those projects (Layering PDP Factory). Base PDP
+ * Factories must create PDPs that support the `platform.base` `projectInterface`. See
+ * {@link IBaseProjectDataProvider} and {@link ProjectDataProviderInterfaces} for more information.
+ *
+ * WARNING: For Layering PDPFs, `getAvailableProjects` has very specific requirements that
+ * **absolutely must** be met.
+ *
+ * To make creating a Layering PDPF easier, you can extend
+ * {@link LayeringProjectDataProviderEngineFactory}, which automatically fulfills the special
+ * requirements for Layering PDPFs. We highly recommend using it.
+ */
+export interface IProjectDataProviderEngineFactory<
+  SupportedProjectInterfaces extends ProjectInterfaces[],
+> {
+  /** JSDOC DESTINATION IProjectDataProviderFactoryGetAvailableProjects */
+  getAvailableProjects(
+    layeringFilters?: ProjectMetadataFilterOptions,
+  ): Promise<ProjectMetadataWithoutFactoryInfo[]>;
+  /**
+   * Create a {@link IProjectDataProviderEngine} for the project requested so the papi can create an
+   * {@link IProjectDataProvider} for the project. This project will have the same
+   * `projectInterface`s as this Project Data Provider Engine Factory
+   *
+   * @param projectId Id of the project for which to create a {@link IProjectDataProviderEngine}
+   * @returns A promise that resolves to a {@link IProjectDataProviderEngine} for the project passed
+   *   in
+   */
+  createProjectDataProviderEngine(
+    projectId: string,
+  ): Promise<IProjectDataProviderEngine<SupportedProjectInterfaces>>;
+}
+
+/**
+ * JSDOC SOURCE LayeringProjectDataProviderEngineFactory
+ *
+ * Abstract class with partial implementation of {@link IProjectDataProviderEngineFactory}
+ * specifically for Layering PDPFs. You can extend this class to make creating a Layering PDPF
+ * easier.
+ *
+ * Extending this class automatically fulfills the special requirements for Layering PDPfs, so we
+ * highly recommend extending this class.
+ */
+export abstract class LayeringProjectDataProviderEngineFactory<
+  SupportedProjectInterfaces extends ProjectInterfaces[],
+> {
+  /** Regex-escaped string of this `pdpfId`. */
+  protected pdpfIdRegexString: string;
+
+  /**
+   * String representation of `RegExp` pattern(s) to match against projects' `projectInterface`s
+   * (using the
+   * [`test`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test)
+   * function) to determine if they should be included in the available projects this Layering PDPF
+   * provides. This is used as {@link ProjectMetadataFilterOptions.includeProjectInterfaces} when
+   * determining what available projects this layering PDPF supports. You should list here all
+   * combinations of `projectInterface`s your Layering PDPs require to make sure this layering PDPF
+   * announces that it supports the right projects.
+   *
+   * See {@link ProjectMetadataFilterOptions.includeProjectInterfaces} for more information on how to
+   * use this field.
+   *
+   * @example
+   *
+   * ```typescript
+   * projectInterfacesToLayerOver: ['one', ['two', 'three']];
+   * ```
+   *
+   * This layering PDPF will announce that it supports projects whose `projectInterface`s fulfill at
+   * least one of the following conditions (At least one entry in the array must match) and will
+   * provide `providedProjectInterfaces` for those projects:
+   *
+   * - Include `one`
+   * - Include both `two` and `three`.
+   */
+  abstract projectInterfacesToLayerOver: undefined | string | (string | string[])[];
+  /**
+   * The list of `projectInterface`s that this layering PDPF provides on top of existing projects.
+   *
+   * @example
+   *
+   * ```typescript
+   * providedProjectInterfaces: ['four', 'five'];
+   * ```
+   *
+   * This layering PDPF will announce that its provides the `projectInterface`s `four` and `five`
+   * for projects that match `projectInterfacesToLayerOver`.
+   */
+  abstract providedProjectInterfaces: SupportedProjectInterfaces;
+
+  /** @param pdpfId The id of this Project Data Provider Factory */
+  constructor(public pdpfId: string) {
+    this.pdpfIdRegexString = escapeStringRegexp(pdpfId);
+  }
+
+  /**
+   * Implementation of {@link IProjectDataProviderEngineFactory.getAvailableProjects} that properly
+   * fulfills the requirements of the method for Layering PDPFs. Announces that this Layering PDPF
+   * provides the `providedProjectInterfaces` for projects that match
+   * `projectInterfacesToLayerOver`.
+   */
+  async getAvailableProjects(
+    layeringFilters?: ProjectMetadataFilterOptions,
+  ): Promise<ProjectMetadataWithoutFactoryInfo[]> {
+    try {
+      const filters = projectLookupService.mergeMetadataFilters(layeringFilters, {
+        // We want to layer over certain `projectInterface`s with our interfaces, so
+        // include them in the list of projects we provide
+        includeProjectInterfaces: this.projectInterfacesToLayerOver,
+        // Make sure this pdpf is excluded so it doesn't get into an infinite loop with itself. This
+        // is also done when the project lookup service calls this method, so this is a sanity
+        // check more than anything else.
+        excludePdpFactoryIds: this.pdpfIdRegexString,
+        // Do not exclude the `projectInterface`s that this layering PDP serves. If we
+        // did exclude them because they already exist, we would cancel out with
+        // duplicate layering PDPs, and neither would serve these interfaces at all
+      });
+      const projectsToOverlayMetadata =
+        await projectLookupService.getMetadataForAllProjects(filters);
+      return projectsToOverlayMetadata.map((projectMetadataToOverlay) => {
+        projectMetadataToOverlay.projectInterfaces = this.providedProjectInterfaces;
+        return projectMetadataToOverlay;
+      });
+    } catch (e) {
+      throw new Error(`${this.pdpfId} was not able to get metadata for projects to overlay. ${e}`);
+    }
+  }
+}

--- a/src/shared/models/project-data-provider-engine.model.ts
+++ b/src/shared/models/project-data-provider-engine.model.ts
@@ -1,49 +1,10 @@
 import { ProjectInterfaces, ProjectInterfaceDataTypes } from 'papi-shared-types';
 import IDataProviderEngine, { DataProviderEngine } from '@shared/models/data-provider-engine.model';
 import { DataProviderDataTypes } from '@shared/models/data-provider.model';
-import { ProjectMetadataWithoutFactoryInfo } from '@shared/models/project-metadata.model';
 import { UnionToIntersection } from 'platform-bible-utils';
-
-/**
- * A factory object registered with the papi that creates a Project Data Provider Engine for each
- * project with the factory's specified `projectInterface`s when the papi requests. Used by the papi
- * to create {@link IProjectDataProviderEngine}s for a specific project and `projectInterface` when
- * someone gets a project data provider with `papi.projectDataProviders.get`. When this factory
- * object is registered with `papi.projectDataProviders.registerProjectDataProviderEngineFactory`,
- * the papi creates a {@link ProjectDataProviderFactory} that layers over this engine to create
- * {@link IProjectDataProvider}s.
- *
- * Project Data Provider Engine Factories create Project Data Provider Engines for specific
- * `projectInterface`s. For each project id available on a Project Data Provider Factory, the
- * factory that supports that project with some set of `projectInterface`s creates a new instance of
- * a PDP with the supported `projectInterface`s.
- *
- * A PDP Factory can provide its own unique project ids (Base PDP Factory) or layer over other PDPFs
- * and provide additional `projectInterface`s on those projects (Layering PDP Factory). Base PDP
- * Factories must create PDPs that support the `platform.base` `projectInterface`. See
- * {@link IBaseProjectDataProvider} and {@link ProjectDataProviderInterfaces} for more information.
- */
-export interface IProjectDataProviderEngineFactory<
-  SupportedProjectInterfaces extends ProjectInterfaces[],
-> {
-  /**
-   * Get a list of metadata objects for all projects that can be the targets of PDPs created by this
-   * factory engine
-   */
-  getAvailableProjects(): Promise<ProjectMetadataWithoutFactoryInfo[]>;
-  /**
-   * Create a {@link IProjectDataProviderEngine} for the project requested so the papi can create an
-   * {@link IProjectDataProvider} for the project. This project will have the same
-   * `projectInterface`s as this Project Data Provider Engine Factory
-   *
-   * @param projectId Id of the project for which to create a {@link IProjectDataProviderEngine}
-   * @returns A promise that resolves to a {@link IProjectDataProviderEngine} for the project passed
-   *   in
-   */
-  createProjectDataProviderEngine(
-    projectId: string,
-  ): Promise<IProjectDataProviderEngine<SupportedProjectInterfaces>>;
-}
+// Referenced in JSDoc below
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { IProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model.ts';
 
 /**
  * The object to return from

--- a/src/shared/models/project-data-provider-factory.interface.ts
+++ b/src/shared/models/project-data-provider-factory.interface.ts
@@ -1,7 +1,14 @@
-import { Dispose } from 'platform-bible-utils';
+import { Dispose, ModifierProject } from 'platform-bible-utils';
 import { ProjectMetadataWithoutFactoryInfo } from './project-metadata.model';
 
 export const PDP_FACTORY_OBJECT_TYPE: string = 'pdpFactory';
+
+export type ProjectMetadataFilterOptions = ModifierProject & {
+  /** Project IDs to include */
+  includeProjectIds?: string | string[];
+  /** Project IDs to exclude */
+  excludeProjectIds?: string | string[];
+};
 
 /**
  * Network object that creates Project Data Providers of a specific set of `projectInterface`s as
@@ -15,8 +22,35 @@ export const PDP_FACTORY_OBJECT_TYPE: string = 'pdpFactory';
  * {@link IBaseProjectDataProvider} and {@link ProjectDataProviderInterfaces} for more information.
  */
 interface IProjectDataProviderFactory extends Dispose {
-  /** Get data about all projects that can be created by this PDP factory */
-  getAvailableProjects(): Promise<ProjectMetadataWithoutFactoryInfo[]>;
+  /**
+   * JSDOC SOURCE IProjectDataProviderFactoryGetAvailableProjects
+   *
+   * Get metadata about all projects that can be served by PDPs created by this PDP factory.
+   *
+   * If this is a Base PDP Factory, this method should return this PDP Factory's own unique project
+   * IDs.
+   *
+   * If this is a Layering PDP Factory, this method should call
+   * `papi.projectLookup.getMetadataForAllProjects` with some set of metadata filters in order to
+   * determine which projects it can layer over. The set of metadata filters relevant to this PDP
+   * Factory **absolutely must** be merged with the `layeringFilters` provided using
+   * `papi.projectLookup.mergeMetadataFilters`, or it will get into an infinite loop of calling
+   * other layering PDPs.
+   *
+   * WARNING: If this is a Layering PDP Factory, it **absolutely must** merge its metadata filters
+   * with `layeringFilters` provided using `papi.projectLookup.mergeMetadataFilters`! Otherwise you
+   * will cause an infinite loop that will break things.
+   *
+   * @param layeringFilters If applicable, filters used to prevent this Layering PDP Factory from
+   *   entering an infinite loop with another Layering PDP Factory. You **absolutely must** merge
+   *   these filters with your own filters using `papi.projectLookup.mergeMetadataFilters` when
+   *   calling `papi.projectLookup.getMetadataForAllProjects` inside this method. If you are not
+   *   calling `getMetadataForAllProjects` inside this method (likely if this is a Base PDPF), you
+   *   can safely ignore this parameter.
+   */
+  getAvailableProjects(
+    layeringFilters?: ProjectMetadataFilterOptions,
+  ): Promise<ProjectMetadataWithoutFactoryInfo[]>;
   /**
    * Returns the registered network object name of a PDP for the given project ID. Called by the
    * platform when someone uses the project data provider service to access a project's data.

--- a/src/shared/services/papi-core.service.ts
+++ b/src/shared/services/papi-core.service.ts
@@ -22,12 +22,13 @@ export type {
   ExtensionDataScope,
   MandatoryProjectDataTypes,
 } from '@shared/models/project-data-provider.model';
-export type {
-  IProjectDataProviderEngine,
-  IProjectDataProviderEngineFactory,
-} from '@shared/models/project-data-provider-engine.model';
+export type { IProjectDataProviderEngine } from '@shared/models/project-data-provider-engine.model';
+export type { IProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model.ts';
 export type { IBaseProjectDataProviderEngine } from '@shared/models/base-project-data-provider-engine.model';
-export type { default as IProjectDataProviderFactory } from '@shared/models/project-data-provider-factory.interface';
+export type {
+  default as IProjectDataProviderFactory,
+  ProjectMetadataFilterOptions,
+} from '@shared/models/project-data-provider-factory.interface';
 export type {
   ProjectDataProviderFactoryMetadataInfo,
   ProjectMetadata,

--- a/src/shared/services/project-data-provider.service.ts
+++ b/src/shared/services/project-data-provider.service.ts
@@ -3,10 +3,7 @@ import {
   ProjectInterfaceDataTypes,
   ProjectDataProviderInterfaces,
 } from 'papi-shared-types';
-import {
-  IProjectDataProviderEngineFactory,
-  IProjectDataProviderEngine,
-} from '@shared/models/project-data-provider-engine.model';
+import { IProjectDataProviderEngine } from '@shared/models/project-data-provider-engine.model';
 import networkObjectService from '@shared/services/network-object.service';
 import { getByType, registerEngineByType } from '@shared/services/data-provider.service';
 import { newNonce } from '@shared/utils/util';
@@ -18,11 +15,13 @@ import {
 } from 'platform-bible-utils';
 import IProjectDataProviderFactory, {
   PDP_FACTORY_OBJECT_TYPE,
+  ProjectMetadataFilterOptions,
 } from '@shared/models/project-data-provider-factory.interface';
 import projectLookupService from '@shared/services/project-lookup.service';
 import { ProjectMetadataWithoutFactoryInfo } from '@shared/models/project-metadata.model';
 import { PROJECT_INTERFACE_PLATFORM_BASE } from '@shared/models/project-data-provider.model';
 import { getPDPFactoryNetworkObjectNameFromId } from '@shared/models/project-lookup.service-model';
+import { IProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model';
 
 /**
  * Class that creates Project Data Providers of a specific set of `projectInterface`s. Layers over
@@ -55,12 +54,10 @@ class ProjectDataProviderFactory<SupportedProjectInterfaces extends ProjectInter
     this.pdpEngineFactory = pdpEngineFactory;
   }
 
-  /**
-   * Returns a list of metadata objects for all projects that can be the targets of PDPs created by
-   * this factory
-   */
-  getAvailableProjects(): Promise<ProjectMetadataWithoutFactoryInfo[]> {
-    return this.pdpEngineFactory.getAvailableProjects();
+  getAvailableProjects(
+    layeringFilters?: ProjectMetadataFilterOptions,
+  ): Promise<ProjectMetadataWithoutFactoryInfo[]> {
+    return this.pdpEngineFactory.getAvailableProjects(layeringFilters);
   }
 
   /** Disposes of all PDPs that were created by this PDP Factory */

--- a/src/shared/services/project-lookup.service.test.ts
+++ b/src/shared/services/project-lookup.service.test.ts
@@ -5,7 +5,7 @@ import {
   ProjectMetadataWithoutFactoryInfo,
 } from '@shared/models/project-metadata.model';
 import {
-  ProjectMetadataFilterOptions,
+  getPDPFactoryIdFromNetworkObjectName,
   getPDPFactoryNetworkObjectNameFromId,
   testingProjectLookupService,
 } from '@shared/models/project-lookup.service-model';
@@ -13,10 +13,12 @@ import networkObjectService from '@shared/services/network-object.service';
 import networkObjectStatusService from '@shared/services/network-object-status.service';
 import IProjectDataProviderFactory, {
   PDP_FACTORY_OBJECT_TYPE,
+  ProjectMetadataFilterOptions,
 } from '@shared/models/project-data-provider-factory.interface';
 import { NetworkObjectDetails } from '@shared/models/network-object.model';
 import { ProjectInterfaces } from 'papi-shared-types';
 import projectLookupService from '@shared/services/project-lookup.service';
+import { LayeringProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model';
 
 jest.mock('@shared/services/network-object.service', () => ({
   __esModule: true,
@@ -43,6 +45,307 @@ beforeEach(() => {
   networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() => {
     throw new Error(
       'networkObjectStatusService.getAllNetworkObjectDetails has no test implementation',
+    );
+  });
+});
+
+describe('Getting project metadata with Layering PDPs', () => {
+  const testProjectId = 'test-project';
+  const baseProjectInterfaces: ProjectInterfaces[] = ['platform.base', 'platform.placeholder'];
+  const layeringPDPInterfaces: { [pdpfName: string]: ProjectInterfaces[] } = {
+    [getPDPFactoryNetworkObjectNameFromId('layer-1')]: ['platformScripture.USJ_Chapter'],
+    [getPDPFactoryNetworkObjectNameFromId('layer-2')]: ['platformScripture.USX_Chapter'],
+    [getPDPFactoryNetworkObjectNameFromId('layer-3')]: ['platformScripture.USX_Chapter'],
+    [getPDPFactoryNetworkObjectNameFromId('meta-layer-3')]: ['platform.notesOnly'],
+    [getPDPFactoryNetworkObjectNameFromId('non-layer')]: [
+      'platformScripture.USFM_BookChapterVerse',
+    ],
+  };
+  function getIncludedPdpfIds(pdpfIds: string[]) {
+    return pdpfIds.filter(
+      (pdpfId) =>
+        !pdpfId.startsWith('non-') &&
+        (!pdpfId.startsWith('meta-') || pdpfIds.includes(pdpfId.substring('meta-'.length))),
+    );
+  }
+  function getAggregatedProjectInterfaces(pdpfIds: string[]) {
+    const interfaces = new Set([
+      ...baseProjectInterfaces,
+      ...getIncludedPdpfIds(pdpfIds)
+        .filter((pdpfId) => pdpfId !== 'base')
+        .flatMap(
+          (layeringPdpfId) =>
+            layeringPDPInterfaces[getPDPFactoryNetworkObjectNameFromId(layeringPdpfId)],
+        ),
+    ]);
+    return [...interfaces];
+  }
+  const testPDPFInfo: Record<string, Partial<NetworkObjectDetails>> = {
+    ...Object.fromEntries(
+      Object.entries(layeringPDPInterfaces).map(([pdpfName, projectInterfaces]) => [
+        pdpfName,
+        {
+          objectType: PDP_FACTORY_OBJECT_TYPE,
+          attributes: {
+            projectInterfaces,
+          },
+        },
+      ]),
+    ),
+    [getPDPFactoryNetworkObjectNameFromId('base')]: {
+      objectType: PDP_FACTORY_OBJECT_TYPE,
+      attributes: {
+        projectInterfaces: baseProjectInterfaces,
+      },
+    },
+    extraneous: {
+      objectType: 'not-a-pdpf',
+    },
+  };
+  function getTestPDPFInfoSubset(pdpfIds: string[]) {
+    return Object.fromEntries(
+      pdpfIds.map((pdpfId) => {
+        const pdpfName = getPDPFactoryNetworkObjectNameFromId(pdpfId);
+        return [pdpfName, testPDPFInfo[pdpfName]];
+      }),
+    );
+  }
+  const testPDPFs: Record<string, Partial<IProjectDataProviderFactory>> = {
+    ...Object.fromEntries(
+      Object.entries(layeringPDPInterfaces).map(([pdpfName, projectInterfaces]) => {
+        let projectInterfacesToLayerOver: string | (string | string[])[] = 'platform.placeholder';
+        const pdpfId = getPDPFactoryIdFromNetworkObjectName(pdpfName);
+        if (pdpfId.startsWith('non-'))
+          projectInterfacesToLayerOver = 'blah-does-not-match-anything';
+        else if (pdpfId.startsWith('meta-')) {
+          const layerOverPdpfId = pdpfId.substring('meta-'.length);
+          projectInterfacesToLayerOver =
+            layeringPDPInterfaces[getPDPFactoryNetworkObjectNameFromId(layerOverPdpfId)];
+        }
+        class LayeringPDP extends LayeringProjectDataProviderEngineFactory<
+          typeof projectInterfaces
+        > {
+          projectInterfacesToLayerOver = projectInterfacesToLayerOver;
+          providedProjectInterfaces = projectInterfaces;
+        }
+        return [pdpfName, new LayeringPDP(pdpfId)];
+      }),
+    ),
+    [getPDPFactoryNetworkObjectNameFromId('base')]: {
+      async getAvailableProjects(): Promise<ProjectMetadataWithoutFactoryInfo[]> {
+        return [
+          {
+            id: testProjectId,
+            projectInterfaces: baseProjectInterfaces,
+          },
+        ];
+      },
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a jest function :(
+    networkObjectService.get.mockImplementation(
+      (networkObjectId: string) => testPDPFs[networkObjectId],
+    );
+  });
+
+  it('should successfully get just the base metadata if that is the only pdpf available', async () => {
+    const pdpfIds = ['base'];
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a jest function :(
+    networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() =>
+      getTestPDPFInfoSubset(pdpfIds),
+    );
+
+    const projectsMetadata = await projectLookupService.getMetadataForAllProjects();
+
+    expect(projectsMetadata.length).toBe(1);
+
+    // Check project 1
+    const testProjectMetadataPossiblyUndefined = projectsMetadata.find(
+      (projectMetadata) => projectMetadata.id === testProjectId,
+    );
+    expect(testProjectMetadataPossiblyUndefined).toBeDefined();
+    const testProjectMetadata = testProjectMetadataPossiblyUndefined as ProjectMetadata;
+
+    // Should be provided by the right number of pdpfs
+    expect(Object.entries(testProjectMetadata.pdpFactoryInfo).length).toBe(
+      getIncludedPdpfIds(pdpfIds).length,
+    );
+
+    // `projectInterface`s should be a combination of all available `projectInterface`s
+    const correctProjectInterfaces = getAggregatedProjectInterfaces(pdpfIds);
+    expect(testProjectMetadata.projectInterfaces.length).toEqual(correctProjectInterfaces.length);
+    correctProjectInterfaces.forEach((projectInterface) =>
+      expect(testProjectMetadata.projectInterfaces).toContain(projectInterface),
+    );
+  });
+
+  it('should successfully get no projects if only a layering pdpf is available', async () => {
+    const pdpfIds = ['layer-1'];
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a jest function :(
+    networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() =>
+      getTestPDPFInfoSubset(pdpfIds),
+    );
+
+    const projectsMetadata = await projectLookupService.getMetadataForAllProjects();
+
+    expect(projectsMetadata.length).toBe(0);
+  });
+
+  it('should successfully get the base plus one layering metadata if there is just one layering pdpfs available', async () => {
+    const pdpfIds = ['base', 'layer-1'];
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a jest function :(
+    networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() =>
+      getTestPDPFInfoSubset(pdpfIds),
+    );
+
+    const projectsMetadata = await projectLookupService.getMetadataForAllProjects();
+
+    expect(projectsMetadata.length).toBe(1);
+
+    // Check project 1
+    const testProjectMetadataPossiblyUndefined = projectsMetadata.find(
+      (projectMetadata) => projectMetadata.id === testProjectId,
+    );
+    expect(testProjectMetadataPossiblyUndefined).toBeDefined();
+    const testProjectMetadata = testProjectMetadataPossiblyUndefined as ProjectMetadata;
+
+    // Should be provided by the right number of pdpfs
+    expect(Object.entries(testProjectMetadata.pdpFactoryInfo).length).toBe(
+      getIncludedPdpfIds(pdpfIds).length,
+    );
+
+    // `projectInterface`s should be a combination of all available `projectInterface`s
+    const correctProjectInterfaces = getAggregatedProjectInterfaces(pdpfIds);
+    expect(testProjectMetadata.projectInterfaces.length).toEqual(correctProjectInterfaces.length);
+    correctProjectInterfaces.forEach((projectInterface) =>
+      expect(testProjectMetadata.projectInterfaces).toContain(projectInterface),
+    );
+  });
+
+  it('should not cause an infinite loop of calling each other but should successfully get base and layering metadata with multiple layering pdpfs (as far as we can control)', async () => {
+    const pdpfIds = ['base', 'layer-1', 'layer-2'];
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a jest function :(
+    networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() =>
+      getTestPDPFInfoSubset(pdpfIds),
+    );
+
+    const projectsMetadata = await projectLookupService.getMetadataForAllProjects();
+
+    expect(projectsMetadata.length).toBe(1);
+
+    // Check project 1
+    const testProjectMetadataPossiblyUndefined = projectsMetadata.find(
+      (projectMetadata) => projectMetadata.id === testProjectId,
+    );
+    expect(testProjectMetadataPossiblyUndefined).toBeDefined();
+    const testProjectMetadata = testProjectMetadataPossiblyUndefined as ProjectMetadata;
+
+    // Should be provided by the right number of pdpfs
+    expect(Object.entries(testProjectMetadata.pdpFactoryInfo).length).toBe(
+      getIncludedPdpfIds(pdpfIds).length,
+    );
+
+    // `projectInterface`s should be a combination of all available `projectInterface`s
+    const correctProjectInterfaces = getAggregatedProjectInterfaces(pdpfIds);
+    expect(testProjectMetadata.projectInterfaces.length).toEqual(correctProjectInterfaces.length);
+    correctProjectInterfaces.forEach((projectInterface) =>
+      expect(testProjectMetadata.projectInterfaces).toContain(projectInterface),
+    );
+  });
+
+  it('should successfully get base and layering metadata with duplicate layering pdpfs', async () => {
+    const pdpfIds = ['base', 'layer-1', 'layer-2', 'layer-3'];
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a jest function :(
+    networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() =>
+      getTestPDPFInfoSubset(pdpfIds),
+    );
+
+    const projectsMetadata = await projectLookupService.getMetadataForAllProjects();
+
+    expect(projectsMetadata.length).toBe(1);
+
+    // Check project 1
+    const testProjectMetadataPossiblyUndefined = projectsMetadata.find(
+      (projectMetadata) => projectMetadata.id === testProjectId,
+    );
+    expect(testProjectMetadataPossiblyUndefined).toBeDefined();
+    const testProjectMetadata = testProjectMetadataPossiblyUndefined as ProjectMetadata;
+
+    // Should be provided by the right number of pdpfs
+    expect(Object.entries(testProjectMetadata.pdpFactoryInfo).length).toBe(
+      getIncludedPdpfIds(pdpfIds).length,
+    );
+
+    // `projectInterface`s should be a combination of all available `projectInterface`s
+    const correctProjectInterfaces = getAggregatedProjectInterfaces(pdpfIds);
+    expect(testProjectMetadata.projectInterfaces.length).toEqual(correctProjectInterfaces.length);
+    correctProjectInterfaces.forEach((projectInterface) =>
+      expect(testProjectMetadata.projectInterfaces).toContain(projectInterface),
+    );
+  });
+
+  it('should not get interfaces for non-matching layering pdpfs', async () => {
+    const pdpfIds = ['base', 'layer-1', 'non-layer', 'meta-layer-3'];
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a jest function :(
+    networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() =>
+      getTestPDPFInfoSubset(pdpfIds),
+    );
+
+    const projectsMetadata = await projectLookupService.getMetadataForAllProjects();
+
+    expect(projectsMetadata.length).toBe(1);
+
+    // Check project 1
+    const testProjectMetadataPossiblyUndefined = projectsMetadata.find(
+      (projectMetadata) => projectMetadata.id === testProjectId,
+    );
+    expect(testProjectMetadataPossiblyUndefined).toBeDefined();
+    const testProjectMetadata = testProjectMetadataPossiblyUndefined as ProjectMetadata;
+
+    // Should be provided by the right number of pdpfs
+    expect(Object.entries(testProjectMetadata.pdpFactoryInfo).length).toBe(
+      getIncludedPdpfIds(pdpfIds).length,
+    );
+
+    // `projectInterface`s should be a combination of all available `projectInterface`s
+    const correctProjectInterfaces = getAggregatedProjectInterfaces(pdpfIds);
+    expect(testProjectMetadata.projectInterfaces.length).toEqual(correctProjectInterfaces.length);
+    correctProjectInterfaces.forEach((projectInterface) =>
+      expect(testProjectMetadata.projectInterfaces).toContain(projectInterface),
+    );
+  });
+
+  it('should successfully get metadata for layering pdpfs that layer over layering pdpfs', async () => {
+    const pdpfIds = ['base', 'layer-1', 'layer-3', 'meta-layer-3'];
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a jest function :(
+    networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() =>
+      getTestPDPFInfoSubset(pdpfIds),
+    );
+
+    const projectsMetadata = await projectLookupService.getMetadataForAllProjects();
+
+    expect(projectsMetadata.length).toBe(1);
+
+    // Check project 1
+    const testProjectMetadataPossiblyUndefined = projectsMetadata.find(
+      (projectMetadata) => projectMetadata.id === testProjectId,
+    );
+    expect(testProjectMetadataPossiblyUndefined).toBeDefined();
+    const testProjectMetadata = testProjectMetadataPossiblyUndefined as ProjectMetadata;
+
+    // Should be provided by the right number of pdpfs
+    expect(Object.entries(testProjectMetadata.pdpFactoryInfo).length).toBe(
+      getIncludedPdpfIds(pdpfIds).length,
+    );
+
+    // `projectInterface`s should be a combination of all available `projectInterface`s
+    const correctProjectInterfaces = getAggregatedProjectInterfaces(pdpfIds);
+    expect(testProjectMetadata.projectInterfaces.length).toEqual(correctProjectInterfaces.length);
+    correctProjectInterfaces.forEach((projectInterface) =>
+      expect(testProjectMetadata.projectInterfaces).toContain(projectInterface),
     );
   });
 });
@@ -823,5 +1126,119 @@ describe('filterProjectsMetadata', () => {
     filteredMetadata = projectLookupService.filterProjectsMetadata(projectsMetadata, options);
 
     expect(filteredMetadata.length).toEqual(1);
+  });
+});
+
+describe('Merging metadata filters', () => {
+  it('properly keeps the filter minimal', () => {
+    let merged = projectLookupService.mergeMetadataFilters(undefined, undefined);
+    expect(merged).toEqual({});
+    merged = projectLookupService.mergeMetadataFilters({}, undefined);
+    expect(merged).toEqual({});
+    merged = projectLookupService.mergeMetadataFilters(undefined, {
+      extraneousProperty: 'blah',
+    } as ProjectMetadataFilterOptions);
+    expect(merged).toEqual({});
+  });
+
+  it('properly merges simple string filters', () => {
+    const merged = projectLookupService.mergeMetadataFilters(
+      {
+        excludePdpFactoryIds: 'blah0',
+        excludeProjectIds: 'blah1',
+        excludeProjectInterfaces: 'blah2',
+        includePdpFactoryIds: 'blah3',
+        includeProjectIds: 'blah4',
+        includeProjectInterfaces: 'blah5',
+      },
+      {
+        excludePdpFactoryIds: 'thing0',
+        excludeProjectIds: 'thing1',
+        excludeProjectInterfaces: 'thing2',
+        includePdpFactoryIds: 'thing3',
+        includeProjectIds: 'thing4',
+        includeProjectInterfaces: 'thing5',
+      },
+    );
+    expect(merged).toEqual({
+      excludePdpFactoryIds: ['blah0', 'thing0'],
+      excludeProjectIds: ['blah1', 'thing1'],
+      excludeProjectInterfaces: ['blah2', 'thing2'],
+      includePdpFactoryIds: ['blah3', 'thing3'],
+      includeProjectIds: ['blah4', 'thing4'],
+      includeProjectInterfaces: ['blah5', 'thing5'],
+    });
+  });
+
+  it('properly merges complex filters', () => {
+    const merged = projectLookupService.mergeMetadataFilters(
+      {
+        excludePdpFactoryIds: ['blah0', 'blah0.5'],
+        excludeProjectIds: ['blah1'],
+        excludeProjectInterfaces: ['blah2', ['blah2.5', 'blah2.6']],
+        includePdpFactoryIds: 'blah3',
+        includeProjectIds: ['blah4'],
+        includeProjectInterfaces: ['blah5', ['blah5.5', 'blah5.6']],
+      },
+      {
+        excludePdpFactoryIds: 'thing0',
+        excludeProjectIds: ['thing1'],
+        excludeProjectInterfaces: 'thing2',
+        includePdpFactoryIds: ['thing3'],
+        includeProjectIds: ['thing4', 'thing4.5'],
+        includeProjectInterfaces: [['thing5.5', 'thing5.6', 'thing5.7'], 'thing5'],
+      },
+    );
+    expect(merged).toEqual({
+      excludePdpFactoryIds: ['blah0', 'blah0.5', 'thing0'],
+      excludeProjectIds: ['blah1', 'thing1'],
+      excludeProjectInterfaces: ['blah2', ['blah2.5', 'blah2.6'], 'thing2'],
+      includePdpFactoryIds: ['blah3', 'thing3'],
+      includeProjectIds: ['blah4', 'thing4', 'thing4.5'],
+      includeProjectInterfaces: [
+        'blah5',
+        ['blah5.5', 'blah5.6'],
+        ['thing5.5', 'thing5.6', 'thing5.7'],
+        'thing5',
+      ],
+    });
+  });
+
+  it('properly merges filters with missing entries and de-dupes duplicates', () => {
+    const merged = projectLookupService.mergeMetadataFilters(
+      {
+        excludePdpFactoryIds: ['blah0', 'blah0.5'],
+        // excludeProjectIds
+        excludeProjectInterfaces: [
+          'blah2',
+          'blah2',
+          ['blah2.5', 'blah2.6'],
+          ['blah2.5', 'blah2.6'],
+        ],
+        includePdpFactoryIds: 'blah3',
+        // includeProjectIds
+        includeProjectInterfaces: ['blah5'],
+      },
+      {
+        // excludePdpFactoryIds
+        excludeProjectIds: 'thing1',
+        excludeProjectInterfaces: 'thing2',
+        includePdpFactoryIds: 'blah3',
+        includeProjectIds: ['thing4', 'thing4.5'],
+        includeProjectInterfaces: [['thing5.5', 'thing5.6', 'thing5.7'], 'blah5', 'thing5'],
+      },
+    );
+    expect(merged).toEqual({
+      excludePdpFactoryIds: ['blah0', 'blah0.5'],
+      // Wraps individual strings in an array, which is functionally equivalent
+      excludeProjectIds: ['thing1'],
+      // Does not properly look into arrays and deduplicate them at the moment. Would be nice to fix
+      // sometime, but it's not a high priority as they are functionally equivalent and this is
+      // probably rare
+      excludeProjectInterfaces: ['blah2', ['blah2.5', 'blah2.6'], ['blah2.5', 'blah2.6'], 'thing2'],
+      includePdpFactoryIds: ['blah3'],
+      includeProjectIds: ['thing4', 'thing4.5'],
+      includeProjectInterfaces: ['blah5', ['thing5.5', 'thing5.6', 'thing5.7'], 'thing5'],
+    });
   });
 });


### PR DESCRIPTION
[Breaking] Had to add a new requirement for layering PDPFs. Just extend from the class `LayeringProjectDataProviderEngineFactory` available on `@papi/backend` in order to fulfill this requirement automatically.
- Long explanation of the requirement: `getAvailableProjects` now receives a parameter which is some subset of the filtering options being used while calling `getAvailableProjects` on this PDPF. The subset of filtering options will primarily contain some set of PDPF ids to exclude from the search in order to avoid infinitely recurring calls to other layering PDPFs' `getAvailableProjects`. Base PDPFs can ignore that parameter, but layering PDPFs that call `papi.projectLookup.getMetadataForAllProjects` to get some set of existing project ids to layer over **absolutely must** now merge the filter options passed into `getAvailableProjects` into the filter options they use when calling `papi.projectLookup.getMetadataForAllProjects`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/944)
<!-- Reviewable:end -->
