### PR TITLE
Added Epic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/epic.md
+++ b/.github/ISSUE_TEMPLATE/epic.md
@@ -1,0 +1,13 @@
+---
+name: Epic
+about: Create a high-level goal to implement during a milestone (project management)
+title: ''
+labels: epic
+assignees: ''
+---
+
+**User Story**
+As a (insert role here), I want (insert epic name/summary here) so that (insert reason here for the epic).
+
+**Description**
+Describe the new epic in detail.


### PR DESCRIPTION
After discussion with Craig and Sebastian, we decided we want to try to make a temporary representation of the roadmap in GitHub while we wait on the following GitHub features hopefully to be released very soon (slated for Q2 2024):

[Hierarchy: Sub-issues · Issue #927 · github/roadmap](https://github.com/github/roadmap/issues/927)
[Issues: Issue Types · Issue #837 · github/roadmap](https://github.com/github/roadmap/issues/837)

We are making the following changes:
- New `epic` label - indicates that an issue is an epic
- New `Epic #` field - indicates which epic this issue is under
- New views
  - Roadmap - shows all epics
  - Epic Issues - shows all issues under an epic (change the query to whichever epic you're interested in looking at)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/966)
<!-- Reviewable:end -->
