### PR TITLE
overwrite editor styles to fit better into frames

### DIFF
--- a/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
@@ -5,7 +5,34 @@
 
 .editor-container {
   max-width: none;
-  margin-right: 16px;
+
+  .toolbar {
+    border-top-left-radius: 0;
+    border-top-right-radius: 0;
+  }
+}
+
+.toolbar-item.block-controls {
+  max-width: calc(100% - 140px);
+
+  .icon.block-marker.nb {
+    min-width: 20px;
+  }
+
+  .chevron-down {
+    min-width: 16px;
+  }
+}
+
+/* stylelint-disable-next-line selector-class-pattern */
+.CommentPlugin_CommentsPanel_Heading {
+  width: auto;
+}
+
+/* stylelint-disable-next-line selector-class-pattern */
+.CommentPlugin_AddCommentBox {
+  left: unset !important;
+  right: 0 !important;
 }
 
 /* stylelint-disable-next-line selector-class-pattern */

--- a/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
@@ -6,12 +6,15 @@
 .editor-container {
   max-width: none;
 
+  // remove rounded top corners to look better in tabs
   .toolbar {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
   }
 }
 
+// make the toolbar shrink and grow dynamically
+// work around https://github.com/BiblioNexus-Foundation/scripture-editors/issues/126
 .toolbar-item.block-controls {
   max-width: calc(100% - 140px);
 
@@ -24,11 +27,13 @@
   }
 }
 
+// work around https://github.com/BiblioNexus-Foundation/scripture-editors/issues/124
 /* stylelint-disable-next-line selector-class-pattern */
 .CommentPlugin_CommentsPanel_Heading {
   width: auto;
 }
 
+// work around https://github.com/BiblioNexus-Foundation/scripture-editors/issues/127
 /* stylelint-disable-next-line selector-class-pattern */
 .CommentPlugin_AddCommentBox {
   left: unset !important;

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.scss
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.scss
@@ -4,7 +4,8 @@
 @import './editor-overrides';
 
 body {
-  background-color: #eee;
+  background-color: #fff;
+  margin: 0;
 }
 
 // #region verse number highlight

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.scss
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.scss
@@ -4,7 +4,10 @@
 @import './editor-overrides';
 
 body {
+  // use the same color as the editor content - caution: long term this should be changed to support
+  // theming (e.g. dark mode)
   background-color: #fff;
+// remove margins added by the electron browser user-agent style sheet
   margin: 0;
 }
 


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/983)
<!-- Reviewable:end -->

![grafik](https://github.com/paranext/paranext-core/assets/141921979/e5f60902-fd26-4746-b355-e3454f85900a)
