### PR TITLE
fix twMerge to use our prefix

### DIFF
--- a/lib/platform-bible-react/src/utils/shadcn-ui.util.ts
+++ b/lib/platform-bible-react/src/utils/shadcn-ui.util.ts
@@ -1,8 +1,10 @@
 import { type ClassValue, clsx } from 'clsx';
-import { twMerge } from 'tailwind-merge';
+import { extendTailwindMerge } from 'tailwind-merge';
+
+const twMergeCustom = extendTailwindMerge({prefix: 'pr-'});
 
 // shadcn/ui uses this export in its boilerplate code
 // eslint-disable-next-line import/prefer-default-export
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
+  return twMergeCustom(clsx(inputs));
 }


### PR DESCRIPTION
This will fix class duplication when trying to overwrite a class from a component.

Thank you @tjcouch-sil 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/999)
<!-- Reviewable:end -->
