### PR TITLE
Fixed parsing verse in dotnet so it does not always use verse value which may be null

### DIFF
--- a/c-sharp-tests/PapiTestBase.cs
+++ b/c-sharp-tests/PapiTestBase.cs
@@ -134,6 +134,30 @@ namespace TestParanextDataProvider
         }
 
         /// <summary>
+        /// Creates JSON that represents a verse reference having the specified parameters in full
+        /// serialization.
+        ///
+        /// Includes the `verse: undefined` property from @sillsdev/scripture v2.0.0
+        /// https://github.com/sillsdev/scripture/blob/209054a89652ba9f6aec6bd142aba439cd952bc5/src/verse-ref.ts#L491
+        /// </summary>
+        protected static JsonNode CreateFullSerializationVerseRefNodev2_0_0(
+            string book,
+            int chapterNum,
+            int verseNum
+        )
+        {
+            var jsonObject = new JsonObject
+            {
+                ["book"] = book,
+                ["chapterNum"] = chapterNum,
+                ["verse"] = null,
+                ["verseNum"] = verseNum,
+                ["versificationStr"] = "English",
+            };
+            return jsonObject;
+        }
+
+        /// <summary>
         /// Creates a JSON string node with the specified data
         /// </summary>
         protected static JsonNode CreateJsonString(string data)

--- a/c-sharp/JsonUtils/VerseRefConverter.cs
+++ b/c-sharp/JsonUtils/VerseRefConverter.cs
@@ -82,9 +82,9 @@ namespace Paranext.DataProvider.JsonUtils
             }
             else if (parsedArgs.ContainsKey("chapterNum"))
             {
-                var verse = parsedArgs.ContainsKey("verse")
-                    ? parsedArgs["verse"]!.Value<string>()
-                    : parsedArgs["verseNum"]!.Value<int>().ToString();
+                var verse =
+                    (parsedArgs.ContainsKey("verse") ? parsedArgs["verse"]!.Value<string>() : null)
+                    ?? parsedArgs["verseNum"]!.Value<int>().ToString();
                 verseRef =
                     (versification != null)
                         ? new VerseRef(


### PR DESCRIPTION
This fixes `getVerseUSFM` returning `undefined`
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1010)
<!-- Reviewable:end -->
