### PR TITLE
Add "elevated privileges" to extensions and make managing extensions one

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4334,6 +4334,13 @@ declare module 'node/services/node-file-system.service' {
     mode?: Parameters<typeof fs.promises.copyFile>[2],
   ): Promise<void>;
   /**
+   * Moves a file from one location to another
+   *
+   * @param sourceUri The location of the file to move
+   * @param destinationUri The uri where the file should be moved
+   */
+  export function moveFile(sourceUri: Uri, destinationUri: Uri): Promise<void>;
+  /**
    * Delete a file if it exists
    *
    * @param uri URI of file
@@ -4405,6 +4412,19 @@ declare module 'node/utils/crypto-util' {
    * @returns Cryptographically secure, pseudo-randomly generated value encoded as a string
    */
   export function createNonce(encoding: 'base64url' | 'hex', numberOfBytes?: number): string;
+  /**
+   * Calculates the hash of a given data buffer
+   *
+   * @param hashAlgorithm Name of the hash algorithm to use, such as "sha512"
+   * @param encodingType String encoding to use for returning the binary hash value that is calculated
+   * @param buffer Raw data to be fed into the hash algorithm
+   * @returns String encoded value of the digest (https://csrc.nist.gov/glossary/term/hash_digest)
+   */
+  export function generateHashFromBuffer(
+    hashAlgorithm: string,
+    encodingType: 'base64' | 'base64url' | 'hex' | 'binary',
+    buffer: Buffer,
+  ): string;
 }
 declare module 'node/models/execution-token.model' {
   /** For now this is just for extensions, but maybe we will want to expand this in the future */
@@ -4762,15 +4782,93 @@ declare module 'shared/services/dialog.service' {
   const dialogService: DialogService;
   export default dialogService;
 }
+declare module 'shared/models/manage-extensions-privilege.model' {
+  /** Base64 encoded hash values */
+  export type HashValues = Partial<{
+    sha256: string;
+    sha512: string;
+  }>;
+  /** Represents an extension that can be enabled or disabled */
+  export type ExtensionIdentifier = {
+    extensionName: string;
+    extensionVersion: string;
+  };
+  /**
+   * Represents all extensions that are installed. Note that packaged extensions cannot be disabled,
+   * so they are implied to always be enabled.
+   */
+  export type InstalledExtensions = {
+    packaged: ExtensionIdentifier[];
+    enabled: ExtensionIdentifier[];
+    disabled: ExtensionIdentifier[];
+  };
+  /**
+   * Download an extension from a given URL and enable it
+   *
+   * @param extensionUrlToDownload URL to the extension ZIP file to download
+   * @param fileSize Expected size of the file
+   * @param fileHashes Hash value(s) of the file to download
+   * @returns Promise that resolves when the extension has been installed
+   */
+  export type InstallExtensionFunction = (
+    extensionUrlToDownload: string,
+    fileSize: number,
+    fileHashes: HashValues,
+  ) => Promise<void>;
+  /**
+   * Start running an extension that had been previously downloaded and disabled
+   *
+   * @param extensionIdentifier Details of the extension to enable
+   * @returns Promise that resolves when the extension has been enabled, throws if enabling fails
+   */
+  export type EnableExtensionFunction = (extensionIdentifier: ExtensionIdentifier) => Promise<void>;
+  /**
+   * Stop running an extension that had been previously downloaded and enabled
+   *
+   * @param extensionIdentifier Details of the extension to disable
+   * @returns Promise that resolves when the extension has been enabled, throws if enabling fails
+   */
+  export type DisableExtensionFunction = (
+    extensionIdentifier: ExtensionIdentifier,
+  ) => Promise<void>;
+  /** Get extension identifiers of all extensions on the system */
+  export type GetInstalledExtensionsFunction = () => Promise<InstalledExtensions>;
+  /** Functions needed to manage extensions */
+  export type ManageExtensions = {
+    /** Function to download an extension and enable it */
+    installExtension: InstallExtensionFunction;
+    /** Function to start running an extension that had been previously downloaded and disabled */
+    enableExtension: EnableExtensionFunction;
+    /** Function to stop running an extension that had been previously downloaded and enabled */
+    disableExtension: DisableExtensionFunction;
+    /** Function to retrieve details about all installed extensions */
+    getInstalledExtensions: GetInstalledExtensionsFunction;
+  };
+}
+declare module 'shared/models/elevated-privileges.model' {
+  import { ManageExtensions } from 'shared/models/manage-extensions-privilege.model';
+  /** String constants that are listed in an extension's manifest.json to state needed privileges */
+  export enum ElevatedPrivilegeNames {
+    manageExtensions = 'ManageExtensions',
+  }
+  /** Object that contains properties with special capabilities for extensions that required them */
+  export type ElevatedPrivileges = {
+    /** Functions that can be run to manage what extensions are running */
+    manageExtensions: ManageExtensions | undefined;
+  };
+}
 declare module 'extension-host/extension-types/extension-activation-context.model' {
   import { ExecutionToken } from 'node/models/execution-token.model';
   import { UnsubscriberAsyncList } from 'platform-bible-utils';
+  import { ElevatedPrivileges } from 'shared/models/elevated-privileges.model';
   /** An object of this type is passed into `activate()` for each extension during initialization */
   export type ExecutionActivationContext = {
     /** Canonical name of the extension */
     name: string;
     /** Used to save and load data from the storage service. */
     executionToken: ExecutionToken;
+    /** Special permissions required by an extension based on its manifest */
+    elevatedPrivileges: ElevatedPrivileges;
     /** Tracks all registrations made by an extension so they can be cleaned up when it is unloaded */
     registrations: UnsubscriberAsyncList;
   };
@@ -5884,6 +5982,8 @@ declare module 'extension-host/extension-types/extension-manifest.model' {
      * Must be specified. Can be an empty string if the extension does not have any JavaScript to run.
      */
     main: string;
+    /** List of special permissions required by the extension to work as intended */
+    elevatedPrivileges: string[];
     /**
      * Path to the TypeScript type declaration file that describes this extension and its interactions
      * on the PAPI. Relative to the extension's root folder.

--- a/src/extension-host/extension-types/extension-activation-context.model.ts
+++ b/src/extension-host/extension-types/extension-activation-context.model.ts
@@ -1,14 +1,28 @@
 import { ExecutionToken } from '@node/models/execution-token.model';
 import { UnsubscriberAsyncList } from 'platform-bible-utils';
-import { ElevatedPrivileges } from '@shared/models/elevated-privileges.model';
+import {
+  ElevatedPrivileges,
+  // Needed for documentation links to work
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  ElevatedPrivilegeNames,
+} from '@shared/models/elevated-privileges.model';
 
 /** An object of this type is passed into `activate()` for each extension during initialization */
 export type ExecutionActivationContext = {
   /** Canonical name of the extension */
   name: string;
-  /** Used to save and load data from the storage service. */
+  /** Used to save and load data by the storage service. */
   executionToken: ExecutionToken;
-  /** Special permissions required by an extension based on its manifest */
+  /**
+   * Objects that provide special capabilities required by an extension based on the
+   * `elevatedPrivileges` values listed in its manifest. For example, if an extension needs to be
+   * able to manage other extensions, then it should include `manageExtensions` in the
+   * `elevatedPrivileges` array in `manifest.json`. Then when the extension is activated this
+   * {@link ElevatedPrivileges} object will have the `manageExtensions` property set to an object
+   * with functions used to manage extensions.
+   *
+   * See {@link ElevatedPrivilegeNames} for the full list of elevated privileges available.
+   */
   elevatedPrivileges: ElevatedPrivileges;
   /** Tracks all registrations made by an extension so they can be cleaned up when it is unloaded */
   registrations: UnsubscriberAsyncList;

--- a/src/extension-host/extension-types/extension-activation-context.model.ts
+++ b/src/extension-host/extension-types/extension-activation-context.model.ts
@@ -1,5 +1,6 @@
 import { ExecutionToken } from '@node/models/execution-token.model';
 import { UnsubscriberAsyncList } from 'platform-bible-utils';
+import { ElevatedPrivileges } from '@shared/models/elevated-privileges.model';
 
 /** An object of this type is passed into `activate()` for each extension during initialization */
 export type ExecutionActivationContext = {
@@ -7,6 +8,8 @@ export type ExecutionActivationContext = {
   name: string;
   /** Used to save and load data from the storage service. */
   executionToken: ExecutionToken;
+  /** Special permissions required by an extension based on its manifest */
+  elevatedPrivileges: ElevatedPrivileges;
   /** Tracks all registrations made by an extension so they can be cleaned up when it is unloaded */
   registrations: UnsubscriberAsyncList;
 };

--- a/src/extension-host/extension-types/extension-manifest.model.ts
+++ b/src/extension-host/extension-types/extension-manifest.model.ts
@@ -15,6 +15,8 @@ export type ExtensionManifest = {
    * Must be specified. Can be an empty string if the extension does not have any JavaScript to run.
    */
   main: string;
+  /** List of special permissions required by the extension to work as intended */
+  elevatedPrivileges: string[];
   /**
    * Path to the TypeScript type declaration file that describes this extension and its interactions
    * on the PAPI. Relative to the extension's root folder.

--- a/src/extension-host/extension-types/extension-manifest.model.ts
+++ b/src/extension-host/extension-types/extension-manifest.model.ts
@@ -1,3 +1,5 @@
+import { ElevatedPrivilegeNames } from '@shared/models/elevated-privileges.model';
+
 /** Information about an extension provided by the extension developer. */
 export type ExtensionManifest = {
   /** Name of the extension */
@@ -16,7 +18,7 @@ export type ExtensionManifest = {
    */
   main: string;
   /** List of special permissions required by the extension to work as intended */
-  elevatedPrivileges: string[];
+  elevatedPrivileges: `${ElevatedPrivilegeNames}`[];
   /**
    * Path to the TypeScript type declaration file that describes this extension and its interactions
    * on the PAPI. Relative to the extension's root folder.

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -738,16 +738,19 @@ async function disableExtension(extensionId: ExtensionIdentifier) {
 
 async function getInstalledExtensions(): Promise<InstalledExtensions> {
   // "Enabled" extensions are all the ones in the "installed" directory
-  const installedExtensions = (
+  const installedExtensionZips = (
     await nodeFS.readDir(installedExtensionsUri, (uri) => uri?.toLowerCase().endsWith('zip'))
   ).file;
-  const enabled = extractExtensionDetailsFromFileNames(installedExtensions);
+  const enabled = extractExtensionDetailsFromFileNames(installedExtensionZips);
 
-  // "Disabled" extensions are all the ones in the "disabled" directory
-  const disabledExtensions = (
+  // "Disabled" extensions are all the ones in the "disabled" directory that aren't also "enabled"
+  const disabledExtensionZips = (
     await nodeFS.readDir(disabledExtensionsUri, (uri) => uri?.toLowerCase().endsWith('zip'))
   ).file;
-  const disabled = extractExtensionDetailsFromFileNames(disabledExtensions);
+  const disabled = extractExtensionDetailsFromFileNames(disabledExtensionZips).filter(
+    (disabledId) =>
+      !enabled.find((enabledId) => enabledId.extensionName === disabledId.extensionName),
+  );
 
   // "Packaged" extensions are all the running extensions that aren't "enabled"
   const packaged = [...activeExtensions.values()]

--- a/src/node/services/node-file-system.service.ts
+++ b/src/node/services/node-file-system.service.ts
@@ -65,6 +65,18 @@ export async function copyFile(
 }
 
 /**
+ * Moves a file from one location to another
+ *
+ * @param sourceUri The location of the file to move
+ * @param destinationUri The uri where the file should be moved
+ */
+export async function moveFile(sourceUri: Uri, destinationUri: Uri) {
+  const filePathSource: string = getPathFromUri(sourceUri);
+  const filePathDest: string = getPathFromUri(destinationUri);
+  await fs.promises.rename(filePathSource, filePathDest);
+}
+
+/**
  * Delete a file if it exists
  *
  * @param uri URI of file
@@ -72,7 +84,7 @@ export async function copyFile(
  */
 export async function deleteFile(uri: Uri): Promise<void> {
   const stats = await getStats(uri);
-  if (stats && stats.isFile()) await fs.promises.rm(getPathFromUri(uri));
+  if (stats?.isFile()) await fs.promises.rm(getPathFromUri(uri));
 }
 
 /**
@@ -140,7 +152,7 @@ export async function readDir(
   entryFilter?: (entryName: string) => boolean,
 ): Promise<DirectoryEntries> {
   const stats = await getStats(uri);
-  if (!stats || !stats.isDirectory())
+  if (!stats?.isDirectory())
     // Assert return type.
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     return Object.freeze(Object.fromEntries(fillMissingEntryTypeProperties())) as DirectoryEntries;
@@ -189,6 +201,6 @@ export async function createDir(uri: Uri): Promise<void> {
  */
 export async function deleteDir(uri: Uri): Promise<void> {
   const stats = await getStats(uri);
-  if (!stats || !stats.isDirectory()) return;
+  if (!stats?.isDirectory()) return;
   await fs.promises.rm(getPathFromUri(uri), { recursive: true, maxRetries: 1 });
 }

--- a/src/node/utils/crypto-util.test.ts
+++ b/src/node/utils/crypto-util.test.ts
@@ -1,4 +1,4 @@
-import { createUuid, createNonce } from './crypto-util';
+import { createUuid, createNonce, generateHashFromBuffer } from './crypto-util';
 
 test('createUuid returns a property formatted UUID', () => {
   const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[8-9a-b][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -64,3 +64,13 @@ function calculateEntropy(data: Uint8Array): number {
 
   return entropy;
 }
+
+test('hash algorithm works as expected', () => {
+  const buffer = Buffer.from('Hello, World!', 'utf-8');
+  const hashValue256 = generateHashFromBuffer('sha256', 'base64', buffer);
+  expect(hashValue256).toBe('3/1gIbsr1bCvZ2KQgJ7DpTGR3YHH9wpLKGiKNiGCmG8=');
+  const hashValue512 = generateHashFromBuffer('SHA-512', 'base64', buffer);
+  expect(hashValue512).toBe(
+    'N015SpXNz9izWZMYX++bo2jxYNja9DLQi6nx7R5avmzGkpHg+i/gAGpSVw7xjBne9OYXwzzlLvCm5fvjGMsDhw==',
+  );
+});

--- a/src/node/utils/crypto-util.ts
+++ b/src/node/utils/crypto-util.ts
@@ -19,3 +19,26 @@ export function createNonce(encoding: 'base64url' | 'hex', numberOfBytes: number
   const randomBytes = crypto.randomBytes(numberOfBytes);
   return randomBytes.toString(encoding);
 }
+
+/**
+ * Calculates the hash of a given data buffer
+ *
+ * @param hashAlgorithm Name of the hash algorithm to use, such as "sha512"
+ * @param encodingType String encoding to use for returning the binary hash value that is calculated
+ * @param buffer Raw data to be fed into the hash algorithm
+ * @returns String encoded value of the digest (https://csrc.nist.gov/glossary/term/hash_digest)
+ */
+export function generateHashFromBuffer(
+  hashAlgorithm: string,
+  encodingType: 'base64' | 'base64url' | 'hex' | 'binary',
+  buffer: Buffer,
+): string {
+  // Names of hash algorithms can vary based on the library used
+  // The 'crypto' module wants lowercase with no dashes according to the docs
+  const algorithm = crypto.getHashes().find((algo) => algo === hashAlgorithm)
+    ? hashAlgorithm
+    : hashAlgorithm.toLowerCase().replaceAll('-', '');
+  const hashAlgo = crypto.createHash(algorithm);
+  hashAlgo.update(buffer);
+  return hashAlgo.digest(encodingType);
+}

--- a/src/shared/models/elevated-privileges.model.ts
+++ b/src/shared/models/elevated-privileges.model.ts
@@ -1,0 +1,12 @@
+import { ManageExtensions } from '@shared/models/manage-extensions-privilege.model';
+
+/** String constants that are listed in an extension's manifest.json to state needed privileges */
+export enum ElevatedPrivilegeNames {
+  manageExtensions = 'ManageExtensions',
+}
+
+/** Object that contains properties with special capabilities for extensions that required them */
+export type ElevatedPrivileges = {
+  /** Functions that can be run to manage what extensions are running */
+  manageExtensions: ManageExtensions | undefined;
+};

--- a/src/shared/models/elevated-privileges.model.ts
+++ b/src/shared/models/elevated-privileges.model.ts
@@ -2,7 +2,7 @@ import { ManageExtensions } from '@shared/models/manage-extensions-privilege.mod
 
 /** String constants that are listed in an extension's manifest.json to state needed privileges */
 export enum ElevatedPrivilegeNames {
-  manageExtensions = 'ManageExtensions',
+  manageExtensions = 'manageExtensions',
 }
 
 /** Object that contains properties with special capabilities for extensions that required them */

--- a/src/shared/models/manage-extensions-privilege.model.ts
+++ b/src/shared/models/manage-extensions-privilege.model.ts
@@ -1,0 +1,66 @@
+/** Base64 encoded hash values */
+export type HashValues = Partial<{
+  sha256: string;
+  sha512: string;
+}>;
+
+/** Represents an extension that can be enabled or disabled */
+export type ExtensionIdentifier = {
+  extensionName: string;
+  extensionVersion: string;
+};
+
+/**
+ * Represents all extensions that are installed. Note that packaged extensions cannot be disabled,
+ * so they are implied to always be enabled.
+ */
+export type InstalledExtensions = {
+  packaged: ExtensionIdentifier[];
+  enabled: ExtensionIdentifier[];
+  disabled: ExtensionIdentifier[];
+};
+
+/**
+ * Download an extension from a given URL and enable it
+ *
+ * @param extensionUrlToDownload URL to the extension ZIP file to download
+ * @param fileSize Expected size of the file
+ * @param fileHashes Hash value(s) of the file to download
+ * @returns Promise that resolves when the extension has been installed
+ */
+export type InstallExtensionFunction = (
+  extensionUrlToDownload: string,
+  fileSize: number,
+  fileHashes: HashValues,
+) => Promise<void>;
+
+/**
+ * Start running an extension that had been previously downloaded and disabled
+ *
+ * @param extensionIdentifier Details of the extension to enable
+ * @returns Promise that resolves when the extension has been enabled, throws if enabling fails
+ */
+export type EnableExtensionFunction = (extensionIdentifier: ExtensionIdentifier) => Promise<void>;
+
+/**
+ * Stop running an extension that had been previously downloaded and enabled
+ *
+ * @param extensionIdentifier Details of the extension to disable
+ * @returns Promise that resolves when the extension has been enabled, throws if enabling fails
+ */
+export type DisableExtensionFunction = (extensionIdentifier: ExtensionIdentifier) => Promise<void>;
+
+/** Get extension identifiers of all extensions on the system */
+export type GetInstalledExtensionsFunction = () => Promise<InstalledExtensions>;
+
+/** Functions needed to manage extensions */
+export type ManageExtensions = {
+  /** Function to download an extension and enable it */
+  installExtension: InstallExtensionFunction;
+  /** Function to start running an extension that had been previously downloaded and disabled */
+  enableExtension: EnableExtensionFunction;
+  /** Function to stop running an extension that had been previously downloaded and enabled */
+  disableExtension: DisableExtensionFunction;
+  /** Function to retrieve details about all installed extensions */
+  getInstalledExtensions: GetInstalledExtensionsFunction;
+};

--- a/src/shared/models/manage-extensions-privilege.model.ts
+++ b/src/shared/models/manage-extensions-privilege.model.ts
@@ -15,8 +15,23 @@ export type ExtensionIdentifier = {
  * so they are implied to always be enabled.
  */
 export type InstalledExtensions = {
+  /**
+   * Extensions that are explicitly bundled to be part of the application. They cannot be disabled.
+   * At runtime no extensions can be added or removed from the set of packaged extensions.
+   */
   packaged: ExtensionIdentifier[];
+  /**
+   * Extensions that are running but can be dynamically disabled. At runtime extensions can be added
+   * or removed from the set of enabled extensions.
+   */
   enabled: ExtensionIdentifier[];
+  /**
+   * Extensions that are not running but can be dynamically enabled. At runtime extensions can be
+   * added or removed from the set of disabled extensions.
+   *
+   * The only difference between a disabled extension and an extension that isn't installed is that
+   * disabled extensions do not need to be downloaded again to run them.
+   */
   disabled: ExtensionIdentifier[];
 };
 
@@ -25,7 +40,10 @@ export type InstalledExtensions = {
  *
  * @param extensionUrlToDownload URL to the extension ZIP file to download
  * @param fileSize Expected size of the file
- * @param fileHashes Hash value(s) of the file to download
+ * @param fileHashes Hash value(s) of the file to download. Note that only one hash value may be
+ *   validated, but multiple hash values may be provided so the installer can choose any of them for
+ *   validation. For example, if you provide a sha256 hash value and a sha512 hash value, the
+ *   installer may only use the sha512 hash value for validation.
  * @returns Promise that resolves when the extension has been installed
  */
 export type InstallExtensionFunction = (


### PR DESCRIPTION
Adds the notion of "elevated privileges" for extensions to give them abilities if requested in their manifest. The first of these privileges gives extensions the right to manage new extensions via installing, enabling, and disabling them.

This is intended to resolve https://github.com/paranext/paranext-core/issues/965. Note that this doesn't add any events, though, because I think we're going to want to get a better sense of use cases before putting in events. This is kind of nuanced, and we want to make sure whatever events are added make sense. For example, the code that activates an extension after it is installed in asynchronous and not directly awaitable, so emitting an event than an extension is "installed" might be misleading if it isn't activated yet. Maybe we just want to add activation events instead of installation events? Anyway, the uncertainty is why I held off on adding anything.

Because all other extension management functions were grouped together, I put the function to enumerate extensions in the same group instead of putting it separately in PAPI as the ticket suggested. We can move it if desired, but it's not clear to me what the use case is of enumerating extensions if you can't do anything about it, and it's annoying to look in two very different places for functions related to extension management.

Elevated privilege strings/IDs for extensions are stored in `paranext-core/src/shared/models/elevated-privileges.model.ts`. I'm assuming as we add more privileges, they will be updated in the same file. Although all the code using these (for now) is in the extension host, I assumed this was a good place to share the types with extensions.

Once this is merged I can add something to the extension template to give more details on how to use this. The general idea is that you add the privilege string to `manifest.json` under the `elevatedPrivileges` property (which is an array of strings). If the extension host sees this, it will populate the `elevatedPrivileges` property in the `ExecutionActivationContext` when an extension is activated. The extension can use the functions given there to install, enable, disable, and enumerate extensions available in the system.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1012)
<!-- Reviewable:end -->
