### PR TITLE
Add a few elevated privilege types to @papi/core

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5401,6 +5401,8 @@ declare module '@papi/core' {
   export default core;
   export type { ExecutionActivationContext } from 'extension-host/extension-types/extension-activation-context.model';
   export type { ExecutionToken } from 'node/models/execution-token.model';
+  export type { ElevatedPrivileges } from 'shared/models/elevated-privileges.model';
+  export type { ManageExtensions } from 'shared/models/manage-extensions-privilege.model';
   export type { DialogTypes } from 'renderer/components/dialogs/dialog-definition.model';
   export type { UseDialogCallbackOptions } from 'renderer/hooks/papi-hooks/use-dialog-callback.hook';
   export type {

--- a/src/shared/services/papi-core.service.ts
+++ b/src/shared/services/papi-core.service.ts
@@ -4,6 +4,8 @@ export default core;
 
 export type { ExecutionActivationContext } from '@extension-host/extension-types/extension-activation-context.model';
 export type { ExecutionToken } from '@node/models/execution-token.model';
+export type { ElevatedPrivileges } from '@shared/models/elevated-privileges.model';
+export type { ManageExtensions } from '@shared/models/manage-extensions-privilege.model';
 export type { DialogTypes } from '@renderer/components/dialogs/dialog-definition.model';
 export type { UseDialogCallbackOptions } from '@renderer/hooks/papi-hooks/use-dialog-callback.hook';
 export type {


### PR DESCRIPTION
Roopa was asking about adding the elevated privilege types to `@papi/core`. We talked through that they aren't strictly necessary since they can be accessed through the activation context object, but it might be handy for extension developers to access some of the types. So here they are.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1021)
<!-- Reviewable:end -->
