### PR TITLE
Allow the extension host to restart as many times as desired

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -30,6 +30,7 @@
     "hopkinson",
     "iframes",
     "iife",
+    "interprocess",
     "iusfm",
     "iusj",
     "iusx",

--- a/src/extension-host/extension-host.ts
+++ b/src/extension-host/extension-host.ts
@@ -7,18 +7,27 @@ import logger from '@shared/services/logger.service';
 import networkObjectService from '@shared/services/network-object.service';
 import dataProviderService from '@shared/services/data-provider.service';
 import extensionAssetService from '@shared/services/extension-asset.service';
-import { getErrorMessage, substring } from 'platform-bible-utils';
+import { getErrorMessage, isString, substring } from 'platform-bible-utils';
 import { CommandNames } from 'papi-shared-types';
 import { registerCommand } from '@shared/services/command.service';
 import { initialize as initializeMenuData } from '@extension-host/services/menu-data.service-host';
 import { initialize as initializeSettingsService } from '@extension-host/services/settings.service-host';
 import { startProjectSettingsService } from '@extension-host/services/project-settings.service-host';
 import { initialize as initializeLocalizationService } from '@extension-host/services/localization.service-host';
+import { gracefulShutdownMessage } from '@node/models/interprocess-messages.model';
 
 logger.info(
   `Starting extension-host${globalThis.isNoisyDevModeEnabled ? ' in noisy dev mode' : ''}`,
 );
 logger.info(`Extension host process.env.NODE_ENV = ${process.env.NODE_ENV}`);
+
+// Make a graceful way to tear down the process since Windows and POSIX operating systems handle it differently
+process.on('message', (message) => {
+  if (isString(message) && message === gracefulShutdownMessage) {
+    logger.info('Shutting down process due to graceful shutdown message');
+    process.exit();
+  }
+});
 
 // #region Services setup
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -368,7 +368,9 @@ async function main() {
 }
 
 async function restartExtensionHost() {
+  logger.info('Restarting extension host');
   await extensionHostService.waitForClose(PROCESS_CLOSE_TIME_OUT);
+  logger.debug('Extension host closed, restarting now');
   await extensionHostService.start();
 }
 

--- a/src/node/models/interprocess-messages.model.ts
+++ b/src/node/models/interprocess-messages.model.ts
@@ -1,0 +1,2 @@
+export const gracefulShutdownMessage = 'gracefulShutdown';
+export const heartbeatMessage = 'heartbeat';


### PR DESCRIPTION
Resolves #933 

The underlying cause of the bug was that `closePromise` was never recreated when the extension host was restarted. I took the opportunity to do a little more reworking, though, since what `kill` does is different on Windows and Linux/macOS, and I thought it might be good to have a graceful shutdown mechanism in place on all OSes. Unfortunately nodemon breaks this in dev, but the fallback to hard kill works on all OSes in dev, so it's fine.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1022)
<!-- Reviewable:end -->
