### PR TITLE
fix: `manageExtensions` provider correctly parses extension name on Windows

### DIFF
--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -612,7 +612,7 @@ function getExtensionUri(baseUri: string, extensionName: string, extensionVersio
 function extractExtensionDetailsFromFileNames(fileUris: string[]): ExtensionIdentifier[] {
   return fileUris.map((fileUri: string) => {
     // Splits by either a forward-slash or back-slash to support Windows as well
-    const fileName = fileUri.split(/\\|\//).pop();
+    const fileName = fileUri.split(path.sep).pop();
     if (!fileName?.endsWith('.zip')) throw new Error(`Not a ZIP file: ${fileName}`);
     const lastDashIndex = fileName.lastIndexOf('_');
     const extensionName = fileName.substring(0, lastDashIndex);

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -611,7 +611,8 @@ function getExtensionUri(baseUri: string, extensionName: string, extensionVersio
  */
 function extractExtensionDetailsFromFileNames(fileUris: string[]): ExtensionIdentifier[] {
   return fileUris.map((fileUri: string) => {
-    const fileName = fileUri.split('/').pop();
+    // Splits by either a forward-slash or back-slash to support Windows as well
+    const fileName = fileUri.split(/\\|\//).pop();
     if (!fileName?.endsWith('.zip')) throw new Error(`Not a ZIP file: ${fileName}`);
     const lastDashIndex = fileName.lastIndexOf('_');
     const extensionName = fileName.substring(0, lastDashIndex);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1040)
<!-- Reviewable:end -->
