### PR TITLE
fix character inventory button style

### DIFF
--- a/extensions/src/platform-scripture/src/character-inventory.component.tsx
+++ b/extensions/src/platform-scripture/src/character-inventory.component.tsx
@@ -30,7 +30,7 @@ const createColumns = (
   inventoryItemColumn(itemLabel),
   {
     accessorKey: 'unicodeValue',
-    header: () => <Button>{unicodeValueLabel}</Button>,
+    header: () => <Button variant="ghost">{unicodeValueLabel}</Button>,
     cell: ({ row }) => {
       const item: string = row.getValue('item');
       return item.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0');


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1059)
<!-- Reviewable:end -->

before
![Screenshot 2024-08-08 180316](https://github.com/user-attachments/assets/0c549417-da2d-46d3-b24c-f6f671e13848)

after
![Screenshot 2024-08-08 180358](https://github.com/user-attachments/assets/c8535de2-2e02-4e09-b00d-d1db07802997)
