### PR TITLE
update editor

### DIFF
--- a/extensions/src/platform-scripture-editor/package.json
+++ b/extensions/src/platform-scripture-editor/package.json
@@ -35,7 +35,7 @@
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {
-    "@biblionexus-foundation/platform-editor": "^0.5.0",
+    "@biblionexus-foundation/platform-editor": "^0.5.1",
     "@biblionexus-foundation/scripture-utilities": "^0.0.3",
     "@swc/core": "^1.4.11",
     "@types/node": "^20.12.2",

--- a/extensions/src/platform-scripture-editor/src/_editor.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor.scss
@@ -48,14 +48,8 @@
   display: inline-block;
   pointer-events: none;
   margin-block-start: 1em;
-}
-
-.editor-input[dir="ltr"] ~ .editor-placeholder {
-  left: 10px;
-}
-
-.editor-input[dir="rtl"] ~ .editor-placeholder {
-  right: 10px;
+  margin-inline-start: calc(10px + 2.5vw);
+  width: fill-available;
 }
 
 .editor-text-bold {
@@ -712,13 +706,15 @@ button.toolbar-item.active i {
 }
 
 .toolbar .toolbar-item .text {
-  display: flex;
   line-height: 20px;
   vertical-align: middle;
   font-size: 14px;
   color: #777;
   text-overflow: ellipsis;
   overflow: hidden;
+  width: 170px;
+  white-space: nowrap;
+  display: inline-block;
   height: 20px;
   text-align: start;
   padding-right: 10px;

--- a/package-lock.json
+++ b/package-lock.json
@@ -451,7 +451,7 @@
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
-        "@biblionexus-foundation/platform-editor": "^0.5.0",
+        "@biblionexus-foundation/platform-editor": "^0.5.1",
         "@biblionexus-foundation/scripture-utilities": "^0.0.3",
         "@swc/core": "^1.4.11",
         "@types/node": "^20.12.2",
@@ -3356,9 +3356,9 @@
       "dev": true
     },
     "node_modules/@biblionexus-foundation/platform-editor": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.5.0.tgz",
-      "integrity": "sha512-F7rftqoR4KAPW8iP/BP7tYVsr0gaqJgxvezgbEHO1OHdMBfSgAu0+vXOYM+HAa7JZIvfBbM6bMSYnr+vjF/cSg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.5.1.tgz",
+      "integrity": "sha512-igx+FLC8ThTg5InEusDri2MGywFJEwstGn4vJs++kCEbe3VqHB75Dpezx7SEX3n7+MgAmzQt/kEYjQMsygNqzw==",
       "dev": true,
       "dependencies": {
         "@biblionexus-foundation/scripture-utilities": "^0.0.3",
@@ -33642,9 +33642,9 @@
       "dev": true
     },
     "@biblionexus-foundation/platform-editor": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.5.0.tgz",
-      "integrity": "sha512-F7rftqoR4KAPW8iP/BP7tYVsr0gaqJgxvezgbEHO1OHdMBfSgAu0+vXOYM+HAa7JZIvfBbM6bMSYnr+vjF/cSg==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.5.1.tgz",
+      "integrity": "sha512-igx+FLC8ThTg5InEusDri2MGywFJEwstGn4vJs++kCEbe3VqHB75Dpezx7SEX3n7+MgAmzQt/kEYjQMsygNqzw==",
       "dev": true,
       "requires": {
         "@biblionexus-foundation/scripture-utilities": "^0.0.3",
@@ -48459,7 +48459,7 @@
     "platform-scripture-editor": {
       "version": "file:extensions/src/platform-scripture-editor",
       "requires": {
-        "@biblionexus-foundation/platform-editor": "^0.5.0",
+        "@biblionexus-foundation/platform-editor": "^0.5.1",
         "@biblionexus-foundation/scripture-utilities": "^0.0.3",
         "@sillsdev/scripture": "^2.0.1",
         "@swc/core": "^1.4.11",


### PR DESCRIPTION
- fixes #1007 ignore backslash keypress and if contained in paste or drag
- fixes BiblioNexus-Foundation/scripture-editors#128 double-click selection ignores verse numbers and `<notes>`
- fixes BiblioNexus-Foundation/scripture-editors#126 improve toolbar block width

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1068)
<!-- Reviewable:end -->
