### PR TITLE
update editor

### DIFF
--- a/extensions/src/platform-scripture-editor/package.json
+++ b/extensions/src/platform-scripture-editor/package.json
@@ -35,7 +35,7 @@
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {
-    "@biblionexus-foundation/platform-editor": "^0.5.1",
+    "@biblionexus-foundation/platform-editor": "^0.5.2",
     "@biblionexus-foundation/scripture-utilities": "^0.0.3",
     "@swc/core": "^1.4.11",
     "@types/node": "^20.12.2",

--- a/extensions/src/platform-scripture-editor/src/_editor.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor.scss
@@ -35,6 +35,9 @@
 
 .editor-input > p {
   direction: inherit;
+  margin-top: 0;
+  margin-bottom: 0;
+  line-height: 1.5;
 }
 
 .editor-placeholder {

--- a/extensions/src/platform-scripture-editor/src/_usj-nodes.scss
+++ b/extensions/src/platform-scripture-editor/src/_usj-nodes.scss
@@ -57,6 +57,7 @@
 /* ChapterNode, ImmutableChapterNode */
 
 .formatted-font .usfm_c {
+  display: block;
   font-weight: bold;
   font-size: 150%;
 }

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -42,10 +42,11 @@ function deepEqualAcrossIframes(a: unknown, b: unknown) {
   return JSON.stringify(a) === JSON.stringify(b);
 }
 
-function scrollToScrRef(scrRef: ScriptureReference) {
-  const verseElement = document.querySelector<HTMLElement>(
-    `.editor-container span[data-marker="v"][data-number="${scrRef.verseNum}"]`,
-  );
+function scrollToScrRef(scrRef: ScriptureReference): HTMLElement | undefined {
+  const verseElement =
+    document.querySelector<HTMLElement>(
+      `.editor-container span[data-marker="v"][data-number="${scrRef.verseNum}"]`,
+    ) ?? undefined;
 
   // Scroll if we find the verse or we're at the start of the chapter
   if (verseElement || scrRef.verseNum === 1) {
@@ -153,16 +154,14 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
       return () => {};
     }
 
-    // Using react's ref api which uses null, so we must use null
-    // eslint-disable-next-line no-null/no-null
-    let highlightedVerseElement: HTMLElement | null;
+    let highlightedVerseElement: HTMLElement | undefined;
 
     // Wait before scrolling to make sure there is time for the editor to load
     // TODO: hook into the editor and detect when it has loaded somehow
     const scrollTimeout = setTimeout(() => {
       // Scroll to and add a highlight to the current verse element
       highlightedVerseElement = scrollToScrRef(scrRef);
-      if (highlightedVerseElement) highlightedVerseElement.classList.add('highlighted');
+      highlightedVerseElement?.classList.add('highlighted');
 
       internallySetScrRefRef.current = undefined;
     }, EDITOR_LOAD_DELAY_TIME);
@@ -173,7 +172,7 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
       clearTimeout(scrollTimeout);
 
       // Remove highlight from the current verse element
-      if (highlightedVerseElement) highlightedVerseElement.classList.remove('highlighted');
+      highlightedVerseElement?.classList.remove('highlighted');
     };
   }, [scrRef]);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -451,7 +451,7 @@
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
-        "@biblionexus-foundation/platform-editor": "^0.5.1",
+        "@biblionexus-foundation/platform-editor": "^0.5.2",
         "@biblionexus-foundation/scripture-utilities": "^0.0.3",
         "@swc/core": "^1.4.11",
         "@types/node": "^20.12.2",
@@ -3356,9 +3356,9 @@
       "dev": true
     },
     "node_modules/@biblionexus-foundation/platform-editor": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.5.1.tgz",
-      "integrity": "sha512-igx+FLC8ThTg5InEusDri2MGywFJEwstGn4vJs++kCEbe3VqHB75Dpezx7SEX3n7+MgAmzQt/kEYjQMsygNqzw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.5.2.tgz",
+      "integrity": "sha512-6tPozykekZcrSD5RLQreSHBFeg+ds95YWs07QyhAvWAvh4lpRUFPMy2eeg+VIQ7tp/XshI/nbbr4DT0ly74S2A==",
       "dev": true,
       "dependencies": {
         "@biblionexus-foundation/scripture-utilities": "^0.0.3",
@@ -33642,9 +33642,9 @@
       "dev": true
     },
     "@biblionexus-foundation/platform-editor": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.5.1.tgz",
-      "integrity": "sha512-igx+FLC8ThTg5InEusDri2MGywFJEwstGn4vJs++kCEbe3VqHB75Dpezx7SEX3n7+MgAmzQt/kEYjQMsygNqzw==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.5.2.tgz",
+      "integrity": "sha512-6tPozykekZcrSD5RLQreSHBFeg+ds95YWs07QyhAvWAvh4lpRUFPMy2eeg+VIQ7tp/XshI/nbbr4DT0ly74S2A==",
       "dev": true,
       "requires": {
         "@biblionexus-foundation/scripture-utilities": "^0.0.3",
@@ -48459,7 +48459,7 @@
     "platform-scripture-editor": {
       "version": "file:extensions/src/platform-scripture-editor",
       "requires": {
-        "@biblionexus-foundation/platform-editor": "^0.5.1",
+        "@biblionexus-foundation/platform-editor": "^0.5.2",
         "@biblionexus-foundation/scripture-utilities": "^0.0.3",
         "@sillsdev/scripture": "^2.0.1",
         "@swc/core": "^1.4.11",


### PR DESCRIPTION
- fix USJ serialization when a marker is undefined
- add `<unmatched />` - displays an invalid unmatched node to the user, usually a closing marker without a corresponding opening marker
- improve `<para />` spacing

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1078)
<!-- Reviewable:end -->
