### PR TITLE
Added Verse Plain Text project interface

### DIFF
--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -32,7 +32,8 @@ internal class LocalParatextProjects
         ProjectInterfaces.USFM_VERSE,
         ProjectInterfaces.USX_BOOK,
         ProjectInterfaces.USX_CHAPTER,
-        ProjectInterfaces.USX_VERSE];
+        ProjectInterfaces.USX_VERSE,
+        ProjectInterfaces.PLAIN_TEXT_VERSE];
 
     public LocalParatextProjects()
     {

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -26,7 +26,8 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         ProjectDataType.VERSE_USFM,
         ProjectDataType.BOOK_USX,
         ProjectDataType.CHAPTER_USX,
-        ProjectDataType.VERSE_USX
+        ProjectDataType.VERSE_USX,
+        ProjectDataType.VERSE_PLAIN_TEXT,
     ];
 
     private readonly LocalParatextProjects _paratextProjects;
@@ -55,6 +56,8 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         Getters.Add("getChapterUSX", GetChapterUsx);
         Setters.Add("setChapterUSX", SetChapterUsx);
         Getters.Add("getVerseUSX", GetVerseUsx);
+
+        Getters.Add("getVersePlainText", GetVersePlainText);
 
         Getters.Add("getSetting", GetProjectSetting);
         Setters.Add("setSetting", SetProjectSetting);
@@ -525,6 +528,16 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
 
     #endregion
 
+    #region Plain Text
+
+    public ResponseToRequest GetVersePlainText(string jsonString)
+    {
+        return GetFromScrText(jsonString,
+            (ScrText scrText, VerseRef verseRef) => scrText.GetVerseText(verseRef));
+    }
+
+    #endregion
+
     #region Private helper methods
 
     private ResponseToRequest GetFromScrText(string verseRefJson, Func<ScrText, VerseRef, string> getTextFromScrText)
@@ -598,7 +611,9 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             ? allXmlData.Length
             : allXmlData.IndexOf(nextVerseNode.OuterXml, chapterIndex,
                 StringComparison.InvariantCulture);
-        return allXmlData.Substring(verseIndex, nextVerseIndex - verseIndex);
+
+        // Wrap the verse text in a usx element so it is a whole valid usx document
+        return $"<usx version=\"{scrText.Settings.UsfmVersion}\">{allXmlData.Substring(verseIndex, nextVerseIndex - verseIndex)}</usx>";
     }
 
     private static string VerseXPath(int chapterNum, int verseNum)

--- a/c-sharp/Projects/ProjectDataType.cs
+++ b/c-sharp/Projects/ProjectDataType.cs
@@ -9,4 +9,5 @@ public sealed class ProjectDataType
     public const string SETTING = "Setting";
     public const string VERSE_USFM = "VerseUSFM";
     public const string VERSE_USX = "VerseUSX";
+    public const string VERSE_PLAIN_TEXT = "VersePlainText";
 }

--- a/c-sharp/Projects/ProjectInterfaces.cs
+++ b/c-sharp/Projects/ProjectInterfaces.cs
@@ -16,4 +16,5 @@ public static class ProjectInterfaces
     public const string USX_BOOK = "platformScripture.USX_Book";
     public const string USX_CHAPTER = "platformScripture.USX_Chapter";
     public const string USX_VERSE = "platformScripture.USX_Verse";
+    public const string PLAIN_TEXT_VERSE = "platformScripture.PlainText_Verse";
 }

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -69,7 +69,7 @@ declare module 'platform-scripture' {
     ChapterUSJ: DataProviderDataType<VerseRef, Usj | undefined, Usj>;
   };
 
-  /** Provides Scripture data in USJ format by chapter */
+  /** Provides Scripture data in USJ format by verse */
   export type USJVerseProjectInterfaceDataTypes = {
     /**
      * Gets the data in USJ form for the specified verse
@@ -77,6 +77,18 @@ declare module 'platform-scripture' {
      * WARNING: USJ is in very early stages of proposal, so it will likely change over time.
      */
     VerseUSJ: DataProviderDataType<VerseRef, Usj | undefined, Usj>;
+  };
+
+  /**
+   * Provides Scripture data in plain text format by verse. Plain text does not include notes,
+   * figures, and other things that are not considered "verse text"
+   */
+  export type PlainTextVerseProjectInterfaceDataTypes = {
+    /**
+     * Gets the data in plain text form for the specified verse. Plain text does not include notes,
+     * figures, and other things that are not considered "verse text".
+     */
+    VersePlainText: DataProviderDataType<VerseRef, string | undefined, string>;
   };
 
   /**
@@ -411,6 +423,41 @@ declare module 'platform-scripture' {
       ): Promise<UnsubscriberAsync>;
     };
 
+  /**
+   * Provides Scripture data in plain text format by verse. Plain text does not include notes,
+   * figures, and other things that are not considered "verse text"
+   */
+  export type IPlainTextVerseProjectDataProvider =
+    IProjectDataProvider<PlainTextVerseProjectInterfaceDataTypes> & {
+      /**
+       * Gets the data in plain text form for the specified verse. Plain text does not include
+       * notes, figures, and other things that are not considered "verse text"
+       */
+      getVersePlainText(verseRef: VerseRef): Promise<Usj | undefined>;
+      /**
+       * Sets the data in plain text form for the specified verse. Plain text does not include
+       * notes, figures, and other things that are not considered "verse text"
+       */
+      setVersePlainText(
+        verseRef: VerseRef,
+        data: string,
+      ): Promise<DataProviderUpdateInstructions<PlainTextVerseProjectInterfaceDataTypes>>;
+      /**
+       * Subscribe to run a callback function when the plain text data is changed. Plain text does
+       * not include notes, figures, and other things that are not considered "verse text"
+       *
+       * @param verseRef Tells the provider what changes to listen for
+       * @param callback Function to run with the updated USJ for this selector
+       * @param options Various options to adjust how the subscriber emits updates
+       * @returns Unsubscriber function (run to unsubscribe from listening for updates)
+       */
+      subscribeVersePlainText(
+        verseRef: VerseRef,
+        callback: (usj: Usj | undefined) => void,
+        options?: DataProviderSubscriberOptions,
+      ): Promise<UnsubscriberAsync>;
+    };
+
   // #endregion
 
   // #region Check Data Types
@@ -624,6 +671,7 @@ declare module 'papi-shared-types' {
     IUSJBookProjectDataProvider,
     IUSJChapterProjectDataProvider,
     IUSJVerseProjectDataProvider,
+    IPlainTextVerseProjectDataProvider,
     ICheckAggregatorService,
     ICheckRunner,
     CheckDetails,
@@ -640,6 +688,7 @@ declare module 'papi-shared-types' {
     'platformScripture.USJ_Book': IUSJBookProjectDataProvider;
     'platformScripture.USJ_Chapter': IUSJChapterProjectDataProvider;
     'platformScripture.USJ_Verse': IUSJVerseProjectDataProvider;
+    'platformScripture.PlainText_Verse': IPlainTextVerseProjectDataProvider;
   }
 
   export interface DataProviders {

--- a/src/extension-host/data/menu.data.json
+++ b/src/extension-host/data/menu.data.json
@@ -26,20 +26,6 @@
     },
     "items": [
       {
-        "label": "%mainMenu_openProject%",
-        "localizeNotes": "Application main menu > Project > Open Project",
-        "group": "platform.projectProjects",
-        "order": 1,
-        "command": "platform.openProjectDialog"
-      },
-      {
-        "label": "%mainMenu_downloadSlashUpdateProject%",
-        "localizeNotes": "Application main menu > Project > Download/Update Project",
-        "group": "platform.projectProjects",
-        "order": 2,
-        "command": "platform.openDownloadUpdateProjectDialog"
-      },
-      {
         "label": "%mainMenu_downloadSlashInstallResources%",
         "localizeNotes": "Application main menu > Project > Download/Install Resources",
         "group": "platform.projectResources",


### PR DESCRIPTION
#1111 

Also wrapped verse USX in `usx` tag because previously it was just a snippet that didn't actually function as proper USX. Before, Verse USJ would return an empty USJ object. Now, it returns the verse in USJ as expected.

However, there is still a bug in the verse USX endpoint where the `ExtractVerseUSX` logic can't find combined verses because their verse display says for example `13-15` instead of saying 13, 14, or 15. As such, sometimes you get unexpected results like returning the rest of the chapter starting at the current verse if you try to get verse 12 with the example combined verse above. This would be unacceptable to come up during a demo, so I went with plain text for now. Reported at #1131

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1132)
<!-- Reviewable:end -->
