### PR TITLE
Fix settings validation bug introduced with JSON-RPC change

### DIFF
--- a/c-sharp-tests/DummyPapiClient.cs
+++ b/c-sharp-tests/DummyPapiClient.cs
@@ -6,24 +6,7 @@ namespace TestParanextDataProvider
     [ExcludeFromCodeCoverage]
     internal class DummyPapiClient : PapiClient
     {
-        private readonly Dictionary<
-            string,
-            List<(string newValue, string oldValue)>
-        > _validSettings = [];
         private readonly Queue<(string eventType, object? eventParameters)> _sentEvents = [];
-
-        public void AddSettingValueToTreatAsValid(
-            string pbSettingName,
-            string newValue,
-            string oldValue
-        )
-        {
-            if (!_validSettings.TryGetValue(pbSettingName, out var values))
-            {
-                _validSettings[pbSettingName] = values = [];
-            }
-            values.Add((newValue, oldValue));
-        }
 
         #region Overrides of PapiClient
 

--- a/c-sharp-tests/Services/SettingsServiceTests.cs
+++ b/c-sharp-tests/Services/SettingsServiceTests.cs
@@ -1,0 +1,52 @@
+using System.Diagnostics.CodeAnalysis;
+using TestParanextDataProvider;
+
+namespace Paranext.DataProvider.Services.Tests;
+
+[ExcludeFromCodeCoverage]
+public class SettingsServiceTests
+{
+    #region Member variables
+    // Both of these will be non-null when the test runs
+    private DummyPapiClient _client = null!;
+    private DummySettingsService _settingsService = null!;
+    #endregion
+
+    #region Test setup/teardown
+    [SetUp]
+    public virtual async Task TestSetupAsync()
+    {
+        _client = new DummyPapiClient();
+        _settingsService = new DummySettingsService(_client);
+        await _settingsService.RegisterDataProviderAsync();
+    }
+
+    [TearDown]
+    public virtual void TestTearDown()
+    {
+        _client.Dispose();
+    }
+    #endregion
+
+    [TestCase()]
+    public void GetSettingValue_Boolean_ReturnsValue()
+    {
+        var settingKey = "isTest";
+        var settingValue = true;
+        _settingsService.AddSettingValue(settingKey, settingValue);
+
+        var retrievedSettingValue = SettingsService.GetSetting<bool>(_client, settingKey);
+        Assert.That(retrievedSettingValue, Is.EqualTo(settingValue));
+    }
+
+    [TestCase()]
+    public void GetSettingValue_Integer_ReturnsValue()
+    {
+        var settingKey = "testNum";
+        var settingValue = 15;
+        _settingsService.AddSettingValue(settingKey, settingValue);
+
+        var retrievedSettingValue = SettingsService.GetSetting<int>(_client, settingKey);
+        Assert.That(retrievedSettingValue, Is.EqualTo(settingValue));
+    }
+}

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -326,16 +326,15 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         var scrText = LocalParatextProjects.GetParatextProject(ProjectDetails.Metadata.Id);
 
         // If there is no Paratext setting for the name given, we'll create one lower down
-        string currentValueJson = string.Empty;
+        object? currentValue = null;
         try
         {
-            currentValueJson = GetProjectSetting(settingName).SerializeToJson();
+            currentValue = GetProjectSetting(settingName);
         }
         catch (Exception) { }
 
         // Make sure the value we're planning to set is valid
-        string? newJson = value == null ? string.Empty : value.SerializeToJson();
-        if (!ProjectSettingsService.IsValid(PapiClient, newJson, currentValueJson, settingName, ""))
+        if (!ProjectSettingsService.IsValid(PapiClient, value, currentValue, settingName, ""))
             throw new InvalidDataException($"Validation failed for {settingName}");
 
         // Figure out which setting name to use

--- a/c-sharp/Services/ProjectSettingsService.cs
+++ b/c-sharp/Services/ProjectSettingsService.cs
@@ -30,17 +30,17 @@ namespace Paranext.DataProvider.Services
         /// <returns><c>true</c> if change is valid, <c>false</c> otherwise</returns>
         public static bool IsValid(
             PapiClient papiClient,
-            string newValueJson,
-            string currentValueJson,
+            object? newValue,
+            object? currentValue,
             string key,
-            string allChangesJson
+            object? allChanges
         )
         {
             string description = $"ProjectSettingService.IsValid for {key}";
             return ThreadingUtils.GetTaskResult(
                     papiClient.SendRequestAsync<bool?>(
                         SERVICE_IS_VALID,
-                        [key, newValueJson, currentValueJson, allChangesJson]
+                        [key, newValue, currentValue, allChanges]
                     ),
                     description,
                     ThreadingUtils.DefaultTimeout

--- a/src/extension-host/services/project-settings.service-host.ts
+++ b/src/extension-host/services/project-settings.service-host.ts
@@ -61,16 +61,12 @@ async function isValid<ProjectSettingName extends ProjectSettingNames>(
     // If key exists in coreProjectSettingsValidators but there is no validator, let the change go through
     return true;
   }
+  const requestType = serializeRequestType(CATEGORY_EXTENSION_PROJECT_SETTING_VALIDATOR, key);
   try {
-    return await networkService.request(
-      serializeRequestType(CATEGORY_EXTENSION_PROJECT_SETTING_VALIDATOR, key),
-      newValue,
-      currentValue,
-      allChanges ?? {},
-    );
+    return await networkService.request(requestType, newValue, currentValue, allChanges ?? {});
   } catch (error) {
     // If there is no validator just let the change go through
-    const missingValidatorMsg = `No handler was found to process the request of type`;
+    const missingValidatorMsg = `'${requestType}' not found`;
     if (includes(`${error}`, missingValidatorMsg)) return true;
     throw error;
   }

--- a/src/extension-host/services/settings.service-host.ts
+++ b/src/extension-host/services/settings.service-host.ts
@@ -187,16 +187,12 @@ class SettingDataProviderEngine
       // If there is no validator just let the change go through
       return true;
     }
+    const requestType = serializeRequestType(CATEGORY_EXTENSION_SETTING_VALIDATOR, key);
     try {
-      return await networkService.request(
-        serializeRequestType(CATEGORY_EXTENSION_SETTING_VALIDATOR, key),
-        newValue,
-        currentValue,
-        allChanges ?? {},
-      );
+      return await networkService.request(requestType, newValue, currentValue, allChanges ?? {});
     } catch (error) {
       // If there is no validator just let the change go through
-      const missingValidatorMsg = `No handler was found to process the request of type`;
+      const missingValidatorMsg = `'${requestType}' not found`;
       if (includes(`${error}`, missingValidatorMsg)) return true;
       throw error;
     }


### PR DESCRIPTION
I'm also adding back a couple of settings-related tests. They wouldn't have caught this bug, but it is good to get a few more of the tests re-created.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1259)
<!-- Reviewable:end -->
