### PR TITLE
Prepare the resource viewer to be able to open resource projects

### DIFF
--- a/c-sharp/ParanextDataProvider.csproj
+++ b/c-sharp/ParanextDataProvider.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -19,6 +19,7 @@
     <PackageProjectUrl>https://github.com/paranext</PackageProjectUrl>
     <RepositoryUrl>https://github.com/paranext/paranext-core</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <UserSecretsId>1860f020-31dd-4eb4-81c4-323eb0cb3e48</UserSecretsId>
     <!-- Uncomment the following lines to help with debugging into .NET core
     <DebugType>portable</DebugType>
     <EmbedUntrackedSources>true</EmbedUntrackedSources>
@@ -27,16 +28,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ParatextData" Version="9.5.0.6" />
+    <PackageReference Include="icu.net" Version="2.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
+    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.1" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
     <PackageReference Include="ParatextChecks" Version="9.5.0.6" />
+    <PackageReference Include="ParatextData" Version="9.5.0.6" />
     <PackageReference Include="SIL.Core" Version="14.2.0-beta0009" />
     <PackageReference Include="SIL.Scripture" Version="14.2.0-beta0009" />
     <PackageReference Include="SIL.WritingSystems" Version="14.2.0-beta0009" />
     <PackageReference Include="StreamJsonRpc" Version="2.19.27" />
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="8.0.0" />
-    <PackageReference Include="icu.net" Version="2.10.0" />
-    <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.1" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
   </ItemGroup>
 
   <!--

--- a/c-sharp/ParatextUtils/ParatextGlobals.cs
+++ b/c-sharp/ParatextUtils/ParatextGlobals.cs
@@ -24,6 +24,9 @@ namespace Paranext.DataProvider.ParatextUtils
                 if (s_initialized)
                     return;
 
+                // Override a few key functions for ScrTextCollection static methods to work
+                ScrTextCollection.Implementation = new PlatformScrTextCollection();
+
                 // Required for the Paratext.Data.Encodings.StringEncoders static constructor
                 Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 

--- a/c-sharp/ParatextUtils/PlatformScrTextCollection.cs
+++ b/c-sharp/ParatextUtils/PlatformScrTextCollection.cs
@@ -1,0 +1,66 @@
+using Paranext.DataProvider.Projects.DigitalBibleLibrary;
+using Paratext.Data;
+using Paratext.Data.Users;
+using SIL.WritingSystems;
+
+namespace Paranext.DataProvider.ParatextUtils;
+
+/// <summary>
+/// Adapted from ParatextScrTextCollection
+/// </summary>
+public class PlatformScrTextCollection : ScrTextCollection
+{
+    // keep track of languages that weren't found in SLDR so we don't call over and over for the same bad code
+    private static readonly HashSet<string> s_sldrLookupFailed = [];
+
+    protected override ScrText CreateResourceProject(ProjectName name)
+    {
+        return new ResourceScrText(
+            name,
+            RegistrationInfo.DefaultUser,
+            new DblResourcePasswordProvider()
+        );
+    }
+
+    protected override ScrText CreateXmlResourceProject(ProjectName name)
+    {
+        return new XmlResourceScrText(
+            name,
+            RegistrationInfo.DefaultUser,
+            new DblResourcePasswordProvider()
+        );
+    }
+
+    protected override UnsupportedReason MigrateProjectIfNeeded(ScrText scrText)
+    {
+        return scrText.NeedsMigration
+            ? UnsupportedReason.CannotUpgrade
+            : UnsupportedReason.Supported;
+    }
+
+    protected override WritingSystemDefinition CreateWsDef(string languageId, bool allowSldr)
+    {
+        // only check SLDR if allowed for this call and all internet access is enabled - SLDR isn't set up to use proxy
+        WritingSystemDefinition? wsDef = null;
+        if (
+            allowSldr
+            && InternetAccess.Status == InternetUse.Enabled
+            && !s_sldrLookupFailed.Contains(languageId)
+        )
+        {
+            try
+            {
+                var sldrFactory = new SldrWritingSystemFactory();
+                sldrFactory.Create(languageId, out wsDef);
+            }
+            catch (Exception e)
+            {
+                // ignore any SLDR errors - there have been problems with entries on the server failing to parse.
+                // also the id being provided may not be valid
+                Console.WriteLine("Getting {0} from SLDR failed: {1}", languageId, e);
+                s_sldrLookupFailed.Add(languageId);
+            }
+        }
+        return wsDef!;
+    }
+}

--- a/c-sharp/Projects/DigitalBibleLibrary/DblResourcePasswordProvider.cs
+++ b/c-sharp/Projects/DigitalBibleLibrary/DblResourcePasswordProvider.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Configuration;
+using Paranext.DataProvider.Users;
+using Paratext.Data.ProjectFileAccess;
+using Paratext.Data.Users;
+using PtxUtils;
+
+namespace Paranext.DataProvider.Projects.DigitalBibleLibrary;
+
+/// <summary>
+/// Adapted from ParatextZippedResourcePasswordProvider
+/// </summary>
+internal class DblResourcePasswordProvider : IZippedResourcePasswordProvider
+{
+    private string? _cachedValue;
+
+    public string GetPassword()
+    {
+        if (!RegistrationInfo.DefaultUser.IsValid)
+        {
+            // Throwing an exception here is invisible to users because ParatextData swallows it
+            // Log the message instead in case it is helpful for someone troubleshooting
+            Console.WriteLine(RegistrationRequiredException.ExceptionMessage);
+            return "This is not the correct password";
+        }
+
+        IConfigurationRoot config = new ConfigurationBuilder()
+            .AddUserSecrets<DblResourcePasswordProvider>()
+            .Build();
+
+        // Run the following from the command line to set a config value (quotes are important):
+        //     dotnet user-secrets set "<secret name>" "<secret value>"
+        // DO NOT share the secret values, including checking in code, texts, emails, DMs, etc.
+        _cachedValue ??= StringUtils.DecryptStringFromBase64(
+            config["DblResourceBase64-DO-NOT-SHARE"] ?? "",
+            config["DblResourceHash-DO-NOT-SHARE"] ?? ""
+        );
+        return _cachedValue;
+    }
+}

--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -1,5 +1,6 @@
 using System.Xml;
 using Paranext.DataProvider.ParatextUtils;
+using Paranext.DataProvider.Users;
 using Paratext.Data;
 using Paratext.Data.Users;
 
@@ -116,7 +117,10 @@ internal class LocalParatextProjects
 
     public IEnumerable<ProjectDetails> GetAllProjectDetails()
     {
-        return GetScrTexts().Select(scrText => scrText.GetProjectDetails());
+        var allScrTexts = GetScrTexts();
+        if (!RegistrationInfo.DefaultUser.IsValid)
+            allScrTexts = allScrTexts.Where((scrText) => !scrText.IsResourceProject);
+        return allScrTexts.Select(scrText => scrText.GetProjectDetails());
     }
 
     public ProjectDetails GetProjectDetails(string projectId)
@@ -126,7 +130,10 @@ internal class LocalParatextProjects
 
     public static ScrText GetParatextProject(string projectId)
     {
-        return ScrTextCollection.GetById(HexId.FromStr(projectId));
+        var retVal = ScrTextCollection.GetById(HexId.FromStr(projectId));
+        if (retVal.IsResourceProject && !RegistrationInfo.DefaultUser.IsValid)
+            throw new RegistrationRequiredException();
+        return retVal;
     }
 
     public static List<string> GetParatextProjectInterfaces()

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -292,6 +292,11 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         if (paratextSettingName == ProjectSettingsNames.PT_NAME)
             return scrText.Name;
 
+        // Some resource projects are marked as editable in their settings, but we want to treat
+        // them as read-only projects
+        if (scrText.IsResourceProject && paratextSettingName == ProjectSettingsNames.PT_IS_EDITABLE)
+            return false;
+
         if (
             scrText.Settings.ParametersDictionary.TryGetValue(
                 paratextSettingName,
@@ -324,6 +329,8 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     public bool SetProjectSetting(string settingName, object? value)
     {
         var scrText = LocalParatextProjects.GetParatextProject(ProjectDetails.Metadata.Id);
+        if (scrText.IsResourceProject)
+            throw new Exception("Cannot change settings on resources");
 
         // If there is no Paratext setting for the name given, we'll create one lower down
         object? currentValue = null;

--- a/c-sharp/Users/ParatextRegistrationService.cs
+++ b/c-sharp/Users/ParatextRegistrationService.cs
@@ -41,6 +41,17 @@ internal class ParatextRegistrationService(PapiClient papiClient)
             "command:paratextRegistration.setParatextRegistrationData",
             SetParatextRegistrationData
         );
+        await PapiClient.RegisterRequestHandlerAsync(
+            "command:paratextRegistration.doesUserHaveValidRegistration",
+            () => RegistrationInfo.DefaultUser.IsValid
+        );
+
+        // Lookup localized strings where they may be needed by callers without access to PapiClient
+        RegistrationRequiredException.ExceptionMessage = LocalizationService.GetLocalizedString(
+            PapiClient,
+            "%paratextRegistration_exception_register_before_accessing_dbl_resources%",
+            RegistrationRequiredException.ExceptionMessage
+        );
     }
 
     #endregion

--- a/c-sharp/Users/RegistrationRequiredException.cs
+++ b/c-sharp/Users/RegistrationRequiredException.cs
@@ -1,0 +1,22 @@
+namespace Paranext.DataProvider.Users;
+
+/// <summary>
+/// Exception to inform callers that a valid Paratext registration is required before DBL resources can be opened
+/// </summary>
+public class RegistrationRequiredException : Exception
+{
+    /// <summary>
+    /// Exception to inform callers that a valid Paratext registration is required before DBL resources can be opened
+    /// </summary>
+    public RegistrationRequiredException()
+        : base(ExceptionMessage) { }
+
+    /// <summary>
+    /// Exception to inform callers that a valid Paratext registration is required before DBL resources can be opened
+    /// </summary>
+    public RegistrationRequiredException(string? customMessage = null)
+        : base(customMessage ?? ExceptionMessage) { }
+
+    public static string ExceptionMessage { get; set; } =
+        "You must provide a valid Paratext registration before opening resources from the Digital Bible Library.";
+}

--- a/cspell.json
+++ b/cspell.json
@@ -33,7 +33,7 @@
     "appdata",
     "asyncs",
     "autodocs",
-    "BBBCCCVVV",
+    "bbbcccvvv",
     "biblionexus",
     "camelcase",
     "consts",
@@ -51,7 +51,7 @@
     "iusfm",
     "iusj",
     "iusx",
-    "JSONRPCID",
+    "jsonrpcid",
     "localizable",
     "localstorage",
     "maximizable",
@@ -74,6 +74,7 @@
     "reserialized",
     "shadcn",
     "sillsdev",
+    "sldr",
     "sonner",
     "steenwyk",
     "stringifiable",
@@ -94,7 +95,7 @@
     "verseref",
     "versification",
     "vref",
-    "VSTHRD"
+    "vsthrd"
   ],
   "ignoreWords": [],
   "import": []

--- a/extensions/src/paratext-registration/contributions/localizedStrings.json
+++ b/extensions/src/paratext-registration/contributions/localizedStrings.json
@@ -21,6 +21,7 @@
       "%paratextRegistration_warning_invalid_registration%": "This registration code is not correct for this user.",
       "%paratextRegistration_webView_title%": "Paratext Registration Information",
       "%paratextRegistration_webView_tooltip%": "Enter your Paratext Registration Information into this form.",
+      "%paratextRegistration_exception_register_before_accessing_dbl_resources%": "You must provide a valid Paratext registration before opening resources from the Digital Bible Library.",
       "%settings_paratextRegistration_registration_internet_group_label%": "Paratext Registration and Internet Settings",
       "%settings_paratextRegistration_registration_internet_group_description%": "Settings related to the user's Paratext Registry connection and some internet access controls",
       "%settings_paratextRegistration_shouldShowOnStartup_label%": "Show Paratext Registration Web View on Startup",

--- a/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
+++ b/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
@@ -45,6 +45,12 @@ declare module 'papi-shared-types' {
     'paratextRegistration.setParatextRegistrationData': (
       newRegistrationData: RegistrationData,
     ) => Promise<void>;
+    /**
+     * Gets the validity status of the user's Paratext registration
+     *
+     * @returns True if the user has a valid Paratext registration, false otherwise
+     */
+    'command:paratextRegistration.doesUserHaveValidRegistration': () => Promise<boolean>;
   }
 
   export interface SettingTypes {

--- a/package-lock.json
+++ b/package-lock.json
@@ -612,7 +612,6 @@
       }
     },
     "extensions/src/paratext-registration": {
-      "name": "paranext-extension-template",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
@@ -25173,12 +25172,12 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/paranext-extension-template": {
-      "resolved": "extensions/src/paratext-registration",
-      "link": true
-    },
     "node_modules/paranext-extensions": {
       "resolved": "extensions",
+      "link": true
+    },
+    "node_modules/paratext-registration": {
+      "resolved": "extensions/src/paratext-registration",
       "link": true
     },
     "node_modules/parent-module": {
@@ -48962,65 +48961,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "paranext-extension-template": {
-      "version": "file:extensions/src/paratext-registration",
-      "requires": {
-        "@sillsdev/scripture": "^2.0.2",
-        "@swc/core": "^1.7.35",
-        "@tailwindcss/typography": "^0.5.15",
-        "@types/node": "^20.16.11",
-        "@types/react": "^18.3.11",
-        "@types/react-dom": "^18.3.1",
-        "@types/webpack": "^5.28.5",
-        "@typescript-eslint/eslint-plugin": "^6.21.0",
-        "@typescript-eslint/parser": "^6.21.0",
-        "autoprefixer": "^10.4.20",
-        "concurrently": "^9.0.1",
-        "copy-webpack-plugin": "^12.0.2",
-        "cross-env": "^7.0.3",
-        "css-loader": "^6.11.0",
-        "escape-string-regexp": "^5.0.0",
-        "eslint": "^8.57.1",
-        "eslint-config-airbnb-base": "^15.0.0",
-        "eslint-config-erb": "^4.1.0",
-        "eslint-import-resolver-typescript": "^3.6.3",
-        "eslint-plugin-compat": "^4.2.0",
-        "eslint-plugin-import": "^2.31.0",
-        "eslint-plugin-jest": "^27.9.0",
-        "eslint-plugin-jsx-a11y": "^6.10.0",
-        "eslint-plugin-no-null": "^1.0.2",
-        "eslint-plugin-no-type-assertion": "^1.3.0",
-        "eslint-plugin-promise": "^6.6.0",
-        "eslint-plugin-react": "^7.37.1",
-        "eslint-plugin-react-hooks": "^4.6.2",
-        "glob": "^10.4.5",
-        "lucide-react": "^0.452.0",
-        "papi-dts": "file:../../../lib/papi-dts",
-        "platform-bible-react": "file:../../../lib/platform-bible-react",
-        "platform-bible-utils": "file:../../../lib/platform-bible-utils",
-        "postcss": "^8.4.47",
-        "postcss-loader": "^8.1.1",
-        "prettier": "^3.3.3",
-        "prettier-plugin-jsdoc": "^1.3.0",
-        "sass": "^1.79.5",
-        "sass-loader": "^16.0.2",
-        "stylelint": "^16.10.0",
-        "stylelint-config-recommended": "^14.0.1",
-        "stylelint-config-sass-guidelines": "^12.1.0",
-        "stylelint-config-tailwindcss": "^0.0.7",
-        "swc-loader": "^0.2.6",
-        "tailwindcss": "^3.4.13",
-        "tailwindcss-animate": "^1.0.7",
-        "ts-node": "^10.9.2",
-        "tsconfig-paths": "^4.2.0",
-        "tsconfig-paths-webpack-plugin": "^4.1.0",
-        "typescript": "^5.4.5",
-        "webpack": "^5.95.0",
-        "webpack-cli": "^5.1.4",
-        "webpack-merge": "^6.0.1",
-        "zip-build": "^1.8.0"
-      }
-    },
     "paranext-extensions": {
       "version": "file:extensions",
       "requires": {
@@ -49125,6 +49065,65 @@
           "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
           "dev": true
         }
+      }
+    },
+    "paratext-registration": {
+      "version": "file:extensions/src/paratext-registration",
+      "requires": {
+        "@sillsdev/scripture": "^2.0.2",
+        "@swc/core": "^1.7.35",
+        "@tailwindcss/typography": "^0.5.15",
+        "@types/node": "^20.16.11",
+        "@types/react": "^18.3.11",
+        "@types/react-dom": "^18.3.1",
+        "@types/webpack": "^5.28.5",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
+        "autoprefixer": "^10.4.20",
+        "concurrently": "^9.0.1",
+        "copy-webpack-plugin": "^12.0.2",
+        "cross-env": "^7.0.3",
+        "css-loader": "^6.11.0",
+        "escape-string-regexp": "^5.0.0",
+        "eslint": "^8.57.1",
+        "eslint-config-airbnb-base": "^15.0.0",
+        "eslint-config-erb": "^4.1.0",
+        "eslint-import-resolver-typescript": "^3.6.3",
+        "eslint-plugin-compat": "^4.2.0",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jest": "^27.9.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-no-null": "^1.0.2",
+        "eslint-plugin-no-type-assertion": "^1.3.0",
+        "eslint-plugin-promise": "^6.6.0",
+        "eslint-plugin-react": "^7.37.1",
+        "eslint-plugin-react-hooks": "^4.6.2",
+        "glob": "^10.4.5",
+        "lucide-react": "^0.452.0",
+        "papi-dts": "file:../../../lib/papi-dts",
+        "platform-bible-react": "file:../../../lib/platform-bible-react",
+        "platform-bible-utils": "file:../../../lib/platform-bible-utils",
+        "postcss": "^8.4.47",
+        "postcss-loader": "^8.1.1",
+        "prettier": "^3.3.3",
+        "prettier-plugin-jsdoc": "^1.3.0",
+        "sass": "^1.79.5",
+        "sass-loader": "^16.0.2",
+        "stylelint": "^16.10.0",
+        "stylelint-config-recommended": "^14.0.1",
+        "stylelint-config-sass-guidelines": "^12.1.0",
+        "stylelint-config-tailwindcss": "^0.0.7",
+        "swc-loader": "^0.2.6",
+        "tailwindcss": "^3.4.13",
+        "tailwindcss-animate": "^1.0.7",
+        "ts-node": "^10.9.2",
+        "tsconfig-paths": "^4.2.0",
+        "tsconfig-paths-webpack-plugin": "^4.1.0",
+        "typescript": "^5.4.5",
+        "webpack": "^5.95.0",
+        "webpack-cli": "^5.1.4",
+        "webpack-merge": "^6.0.1",
+        "zip-build": "^1.8.0"
       }
     },
     "parent-module": {


### PR DESCRIPTION
This PR does everything except provide the correct password for accessing resources. I will add a patch for that to the P10S repo.

This PR includes 2 small cleanup things:
1) In addition to adding a new cspell entry, I updated a few to be lowercase per previous review discussions.
2) When I ran `npm install`, the `package-lock.json` file changed. I'm checking in the latest version of the lock file so that it matches up with `package.json`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1271)
<!-- Reviewable:end -->
