### PR TITLE
use `npm ci` in GHA

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -52,9 +52,9 @@ jobs:
           node-version: ${{ fromJson(steps.package_json.outputs.volta).node }}
           cache: npm
 
-      - name: Install and build
+      - name: Install packages and build
         run: |
-          npm install
+          npm ci
           npm run build
 
       - name: Update release version

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -25,9 +25,9 @@ jobs:
           node-version: ${{ fromJson(steps.package_json.outputs.volta).node }}
           cache: npm
 
-      - name: Install and build
+      - name: Install packages and build
         run: |
-          npm install
+          npm ci
           npm run build
 
       - name: Build documentation

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,9 +52,9 @@ jobs:
           node-version: ${{ fromJson(steps.package_json.outputs.volta).node }}
           cache: npm
 
-      - name: Install and build
+      - name: Install packages and build
         run: |
-          npm install
+          npm ci
           npm run build
 
       - name: Publish releases - Windows

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,8 +54,8 @@ jobs:
           node-version: ${{ fromJson(steps.package_json.outputs.volta).node }}
           cache: npm
 
-      - name: npm install
-        run: npm install
+      - name: Install packages
+        run: npm ci
 
       - name: Build
         run: npm run build


### PR DESCRIPTION
- identifies inconsistencies between `package.json` and `package-lock.json` before it reaches PT10S builds

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1274)
<!-- Reviewable:end -->
