### PR TITLE
Add communication to web views (Web View Controllers and `postMessageToWebView`)

### DIFF
--- a/extensions/src/hello-world/src/main.ts
+++ b/extensions/src/hello-world/src/main.ts
@@ -1,4 +1,4 @@
-import papi, { logger } from '@papi/backend';
+import papi, { logger, WebViewFactory } from '@papi/backend';
 import type {
   ExecutionActivationContext,
   WebViewContentType,
@@ -8,7 +8,7 @@ import type {
   GetWebViewOptions,
 } from '@papi/core';
 import { PlatformEventEmitter } from 'platform-bible-utils';
-import type { HelloWorldEvent } from 'hello-world';
+import type { HelloWorldEvent, HelloWorldProjectWebViewController } from 'hello-world';
 import helloWorldReactWebView from './web-views/hello-world.web-view?inline';
 import helloWorldReactWebViewStyles from './web-views/hello-world.web-view.scss?inline';
 import helloWorldReactWebView2 from './web-views/hello-world-2.web-view?inline';
@@ -18,6 +18,7 @@ import HelloWorldProjectDataProviderEngineFactory from './models/hello-world-pro
 import helloWorldProjectWebView from './web-views/hello-world-project/hello-world-project.web-view?inline';
 import helloWorldProjectWebViewStyles from './web-views/hello-world-project/hello-world-project.web-view.scss?inline';
 import helloWorldProjectViewerWebView from './web-views/hello-world-project/hello-world-project-viewer.web-view?inline';
+import tailwindStyles from './tailwind.css?inline';
 import { HTML_COLOR_NAMES } from './util';
 import { HELLO_WORLD_PROJECT_INTERFACES } from './models/hello-world-project-data-provider-engine.model';
 import { checkDetails, createHelloCheck } from './checks';
@@ -93,18 +94,26 @@ const reactWebView2Provider: IWebViewProviderWithType = {
 
 // #region Hello World Project Web View, Command, etc.
 
-/** Simple web view provider that provides helloWorld project web views when papi requests them */
-const helloWorldProjectWebViewProvider: IWebViewProviderWithType = {
-  webViewType: 'helloWorld.projectWebView',
-  async getWebView(
-    savedWebView: SavedWebViewDefinition,
-    getWebViewOptions: HelloWorldProjectViewerOptions,
-  ): Promise<WebViewDefinition | undefined> {
-    if (savedWebView.webViewType !== this.webViewType)
-      throw new Error(
-        `${this.webViewType} provider received request to provide a ${savedWebView.webViewType} web view`,
-      );
+interface HelloWorldProjectOptions extends GetWebViewOptions {
+  /** The project ID this viewer should focus on */
+  projectId?: string;
+}
 
+const HELLO_WORLD_PROJECT_WEB_VIEW_TYPE = 'helloWorld.projectWebView';
+/** Simple web view provider that provides helloWorld project web views when papi requests them */
+class HelloWorldProjectWebViewFactory extends WebViewFactory<
+  typeof HELLO_WORLD_PROJECT_WEB_VIEW_TYPE
+> {
+  constructor() {
+    super(HELLO_WORLD_PROJECT_WEB_VIEW_TYPE);
+  }
+
+  // No need to use `this` and implementing an abstract method so can't be static
+  // eslint-disable-next-line class-methods-use-this
+  async getWebViewDefinition(
+    savedWebView: SavedWebViewDefinition,
+    getWebViewOptions: HelloWorldProjectOptions,
+  ): Promise<WebViewDefinition | undefined> {
     const projectId = getWebViewOptions.projectId || savedWebView.projectId || undefined;
     return {
       title: projectId
@@ -119,12 +128,37 @@ const helloWorldProjectWebViewProvider: IWebViewProviderWithType = {
       styles: helloWorldProjectWebViewStyles,
       projectId,
     };
-  },
-};
+  }
 
-interface HelloWorldProjectViewerOptions extends GetWebViewOptions {
-  projectId: string | undefined;
+  // No need to use `this` and implementing an abstract method so can't be static
+  // eslint-disable-next-line class-methods-use-this
+  async createWebViewController(
+    webViewDefinition: WebViewDefinition,
+    webViewNonce: string,
+  ): Promise<HelloWorldProjectWebViewController> {
+    return {
+      async focusName(name) {
+        try {
+          logger.info(
+            `Hello World Project Web View Controller ${webViewDefinition.id} received request to focus ${name}`,
+          );
+          await papi.webViewProviders.postMessageToWebView(webViewDefinition.id, webViewNonce, {
+            method: 'focusName',
+            name,
+          });
+          return true;
+        } catch (e) {
+          logger.warn(
+            `Hello World Project Web View Controller ${webViewDefinition.id} threw while running focusName! ${e}`,
+          );
+          return false;
+        }
+      },
+    };
+  }
 }
+
+const helloWorldProjectWebViewProvider = new HelloWorldProjectWebViewFactory();
 
 /**
  * Function to prompt for a project and open it in the hello world project web view. Registered as a
@@ -143,8 +177,12 @@ async function openHelloWorldProjectWebView(
   }
   if (!projectIdForWebView) return undefined;
 
-  const options: HelloWorldProjectViewerOptions = { projectId: projectIdForWebView };
-  return papi.webViews.getWebView(helloWorldProjectWebViewProvider.webViewType, undefined, options);
+  const options: HelloWorldProjectOptions = { projectId: projectIdForWebView };
+  return papi.webViews.openWebView(
+    helloWorldProjectWebViewProvider.webViewType,
+    undefined,
+    options,
+  );
 }
 
 // #endregion
@@ -155,6 +193,11 @@ function selectProjectToDelete(): Promise<string | undefined> {
     title: 'Delete Hello World Project',
     prompt: 'Please choose a project to delete:',
   });
+}
+
+interface HelloWorldProjectViewerOptions extends HelloWorldProjectOptions {
+  /** The id of the web view that opened this viewer if opened from a web view */
+  callerWebViewId?: string;
 }
 
 /**
@@ -184,8 +227,12 @@ const helloWorldProjectViewerProvider: IWebViewProviderWithType = {
         : 'Hello World Project Viewer',
       ...savedWebView,
       content: helloWorldProjectViewerWebView,
-      styles: helloWorldProjectWebViewStyles,
+      styles: tailwindStyles,
       projectId,
+      state: {
+        ...savedWebView.state,
+        callerWebViewId: getWebViewOptions.callerWebViewId || savedWebView.state?.callerWebViewId,
+      },
     };
   },
 };
@@ -275,7 +322,7 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     async (webViewId) => {
       let projectId: string | undefined;
       if (webViewId) {
-        const webViewDefinition = await papi.webViews.getSavedWebViewDefinition(webViewId);
+        const webViewDefinition = await papi.webViews.getOpenWebViewDefinition(webViewId);
         projectId = webViewDefinition?.projectId;
       }
       const projectIdToDelete = projectId ?? (await selectProjectToDelete());
@@ -293,7 +340,7 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     async (webViewId) => {
       let projectId: string | undefined;
       if (webViewId) {
-        const webViewDefinition = await papi.webViews.getSavedWebViewDefinition(webViewId);
+        const webViewDefinition = await papi.webViews.getOpenWebViewDefinition(webViewId);
         projectId = webViewDefinition?.projectId;
       }
       const projectIdForWebView =
@@ -306,10 +353,13 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
 
       if (!projectIdForWebView) return undefined;
 
-      const options: HelloWorldProjectViewerOptions = { projectId: projectIdForWebView };
-      return papi.webViews.getWebView(
+      const options: HelloWorldProjectViewerOptions = {
+        projectId: projectIdForWebView,
+        callerWebViewId: webViewId,
+      };
+      return papi.webViews.openWebView(
         helloWorldProjectViewerProvider.webViewType,
-        { type: 'float', position: 'center' },
+        { type: 'float', position: 'center', floatSize: { width: 480, height: 320 } },
         options,
       );
     },
@@ -369,17 +419,6 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     .fetch('https://www.example.com')
     .catch((e) => logger.error(`Could not get data from example.com! Reason: ${e}`));
 
-  const peopleDataProvider = await papi.dataProviders.get('helloSomeone.people');
-  if (peopleDataProvider) {
-    // Test subscribing to a data provider
-    const unsubGreetings = await peopleDataProvider.subscribeGreeting(
-      'Bill',
-      (billGreeting: string | undefined) => logger.debug(`Bill's greeting: ${billGreeting}`),
-    );
-
-    context.registrations.add(unsubGreetings);
-  }
-
   const checkPromise = papi.commands.sendCommand(
     'platformScripture.registerCheck',
     checkDetails,
@@ -416,6 +455,21 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
   papi.webViews.getWebView(htmlWebViewProvider.webViewType, undefined, { existingId: '?' });
   papi.webViews.getWebView(reactWebViewProvider.webViewType, undefined, { existingId: '?' });
   papi.webViews.getWebView(reactWebView2Provider.webViewType, undefined, { existingId: '?' });
+
+  try {
+    const peopleDataProvider = await papi.dataProviders.get('helloSomeone.people');
+    if (peopleDataProvider) {
+      // Test subscribing to a data provider
+      const unsubGreetings = await peopleDataProvider.subscribeGreeting(
+        'Bill',
+        (billGreeting: string | undefined) => logger.debug(`Bill's greeting: ${billGreeting}`),
+      );
+
+      context.registrations.add(unsubGreetings);
+    }
+  } catch (e) {
+    logger.error(`Hello world error! Could not get people data provider ${e}`);
+  }
 
   logger.info('Hello World is finished activating!');
 }

--- a/extensions/src/hello-world/src/main.ts
+++ b/extensions/src/hello-world/src/main.ts
@@ -380,27 +380,27 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     async (newValue) => HTML_COLOR_NAMES.includes(newValue),
   );
 
-  const helloWorldProjectWebViewProviderPromise = papi.webViewProviders.register(
+  const helloWorldProjectWebViewProviderPromise = papi.webViewProviders.registerWebViewProvider(
     helloWorldProjectWebViewProvider.webViewType,
     helloWorldProjectWebViewProvider,
   );
 
-  const helloWorldProjectViewerProviderPromise = papi.webViewProviders.register(
+  const helloWorldProjectViewerProviderPromise = papi.webViewProviders.registerWebViewProvider(
     helloWorldProjectViewerProvider.webViewType,
     helloWorldProjectViewerProvider,
   );
 
-  const htmlWebViewProviderPromise = papi.webViewProviders.register(
+  const htmlWebViewProviderPromise = papi.webViewProviders.registerWebViewProvider(
     htmlWebViewProvider.webViewType,
     htmlWebViewProvider,
   );
 
-  const reactWebViewProviderPromise = papi.webViewProviders.register(
+  const reactWebViewProviderPromise = papi.webViewProviders.registerWebViewProvider(
     reactWebViewProvider.webViewType,
     reactWebViewProvider,
   );
 
-  const reactWebView2ProviderPromise = papi.webViewProviders.register(
+  const reactWebView2ProviderPromise = papi.webViewProviders.registerWebViewProvider(
     reactWebView2Provider.webViewType,
     reactWebView2Provider,
   );

--- a/extensions/src/hello-world/src/types/hello-world.d.ts
+++ b/extensions/src/hello-world/src/types/hello-world.d.ts
@@ -1,6 +1,10 @@
 declare module 'hello-world' {
-  // @ts-ignore: TS2307 - Cannot find module '@papi/core' or its corresponding type declarations
-  import type { DataProviderDataType, MandatoryProjectDataTypes } from '@papi/core';
+  import type {
+    DataProviderDataType,
+    MandatoryProjectDataTypes,
+    NetworkableObject,
+    // @ts-ignore: TS2307 - Cannot find module '@papi/core' or its corresponding type declarations
+  } from '@papi/core';
   import type { IBaseProjectDataProvider } from 'papi-shared-types';
 
   export type HelloWorldProjectDataTypes = MandatoryProjectDataTypes & {
@@ -36,6 +40,16 @@ declare module 'hello-world' {
      */
     times: number;
   };
+
+  export type HelloWorldProjectWebViewController = NetworkableObject<{
+    /**
+     * Attempts to focus a specific name in the web view
+     *
+     * @returns `true` if the name is in the project associated with this web view; `false`
+     *   otherwise
+     */
+    focusName: (name: string) => Promise<boolean>;
+  }>;
 
   /** All html color names according to https://htmlcolorcodes.com/color-names/ */
   type HTMLColorNames =
@@ -183,7 +197,11 @@ declare module 'hello-world' {
 }
 
 declare module 'papi-shared-types' {
-  import type { IHelloWorldProjectDataProvider, HTMLColorNames } from 'hello-world';
+  import type {
+    IHelloWorldProjectDataProvider,
+    HelloWorldProjectWebViewController,
+    HTMLColorNames,
+  } from 'hello-world';
 
   export interface CommandHandlers {
     'helloWorld.helloWorld': () => string;
@@ -251,5 +269,9 @@ declare module 'papi-shared-types' {
      * name](https://htmlcolorcodes.com/color-names/))
      */
     'helloWorld.headerColor': HTMLColorNames;
+  }
+
+  export interface WebViewControllers {
+    'helloWorld.projectWebView': HelloWorldProjectWebViewController;
   }
 }

--- a/extensions/src/hello-world/src/web-views/hello-world-project/hello-world-project-viewer.web-view.tsx
+++ b/extensions/src/hello-world/src/web-views/hello-world-project/hello-world-project-viewer.web-view.tsx
@@ -1,26 +1,55 @@
 import { WebViewProps } from '@papi/core';
-import { useProjectData, useProjectSetting } from '@papi/frontend/react';
+import { useProjectData, useProjectSetting, useWebViewController } from '@papi/frontend/react';
+import { Button } from 'platform-bible-react';
 import { CSSProperties, useMemo } from 'react';
 
 const namesDefault: string[] = [];
 
-globalThis.webViewComponent = function HelloWorldProjectViewer({ projectId }: WebViewProps) {
+globalThis.webViewComponent = function HelloWorldProjectViewer({
+  projectId,
+  useWebViewState,
+}: WebViewProps) {
+  const [callerWebViewId] = useWebViewState<string | undefined>('callerWebViewId', undefined);
+
+  const callerWebViewController = useWebViewController(
+    'helloWorld.projectWebView',
+    callerWebViewId,
+  );
+
   const [names] = useProjectData('helloWorld', projectId).Names(undefined, namesDefault);
 
   const [headerSize] = useProjectSetting(projectId, 'helloWorld.headerSize', 15);
 
   const [headerColor] = useProjectSetting(projectId, 'helloWorld.headerColor', 'Black');
 
-  const headerStyle = useMemo<CSSProperties>(
-    () => ({ fontSize: `${headerSize}pt`, color: headerColor }),
-    [headerSize, headerColor],
-  );
+  const headerStyle = useMemo<CSSProperties>(() => {
+    const colorPropertyName = callerWebViewController ? 'backgroundColor' : 'color';
+    return { fontSize: `${headerSize}pt`, [colorPropertyName]: headerColor };
+  }, [callerWebViewController, headerSize, headerColor]);
 
   return (
-    <div className="top">
-      {names.map((name) => (
-        <div style={headerStyle}>Hello, {name}!</div>
-      ))}
+    <div className="tw-m-3 [&>*]:tw-mb-3">
+      {callerWebViewController && (
+        <div>Click a name to focus it on the Hello World Project web view!</div>
+      )}
+      {names.map((name) => {
+        const textContent = `Hello, ${name}!`;
+        return callerWebViewController ? (
+          <div key={name}>
+            <Button
+              className="tw-text-foreground"
+              style={headerStyle}
+              onClick={() => callerWebViewController?.focusName(name)}
+            >
+              {textContent}
+            </Button>
+          </div>
+        ) : (
+          <div key={name} style={headerStyle}>
+            {textContent}
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/extensions/src/hello-world/src/web-views/hello-world-project/hello-world-project.web-view.tsx
+++ b/extensions/src/hello-world/src/web-views/hello-world-project/hello-world-project.web-view.tsx
@@ -1,7 +1,7 @@
 import { WebViewProps } from '@papi/core';
 import { logger } from '@papi/frontend';
 import { useProjectData, useProjectDataProvider } from '@papi/frontend/react';
-import { useCallback } from 'react';
+import { useCallback, useEffect } from 'react';
 import useHelloWorldProjectSettings from './use-hello-world-project-settings.hook';
 import ProjectSettingsEditor from './project-settings-editor.component';
 
@@ -16,6 +16,28 @@ globalThis.webViewComponent = function HelloWorldProjectWebView({
   projectId,
   useWebViewState,
 }: WebViewProps) {
+  const [focusedName, setFocusedName] = useWebViewState('focusedName', '');
+
+  useEffect(() => {
+    const webViewMessageListener = ({ data: { method, name } }: MessageEvent) => {
+      switch (method) {
+        case 'focusName':
+          setFocusedName(focusedName === name ? '' : name);
+          break;
+        default:
+          // Unknown method name
+          logger.info(`Received event with unknown method ${method} and name ${name}`);
+          break;
+      }
+    };
+
+    window.addEventListener('message', webViewMessageListener);
+
+    return () => {
+      window.removeEventListener('message', webViewMessageListener);
+    };
+  }, [focusedName, setFocusedName]);
+
   const [max, setMax] = useWebViewState('max', 1);
 
   const pdp = useProjectDataProvider('helloWorld', projectId);
@@ -39,7 +61,7 @@ globalThis.webViewComponent = function HelloWorldProjectWebView({
   }, [pdp, currentName, setCurrentName]);
 
   const helloWorldProjectSettings = useHelloWorldProjectSettings(pdp);
-  const { headerStyle } = helloWorldProjectSettings;
+  const { headerStyle, headerColor } = helloWorldProjectSettings;
 
   return (
     <div className="top">
@@ -68,12 +90,16 @@ globalThis.webViewComponent = function HelloWorldProjectWebView({
       <div>
         Names:{' '}
         {names.map((name) => (
-          <span>
-            {name}
+          <span key={name}>
+            <span style={focusedName === name ? { backgroundColor: headerColor } : undefined}>
+              {name}
+            </span>
             <button
               type="button"
               className="remove-name-button"
-              onClick={() => pdp?.removeName(name)}
+              onClick={async () => {
+                if (await pdp?.removeName(name)) setFocusedName('');
+              }}
             >
               -
             </button>

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -147,7 +147,61 @@ declare module 'shared/models/web-view.model' {
     webViewType: WebViewType;
     /** Unique ID among webviews specific to this webview instance. */
     id: WebViewId;
-    /** The code for the WebView that papi puts into an iframe */
+    /**
+     * The content for the WebView that papi puts into an iframe. This field differs significantly
+     * depending on which `contentType` you use in your `WebViewDefinition` as described below. If you
+     * are using a React or HTML WebView, you will probably want to use a bundler to bundle your code
+     * together and provide it here.
+     * [`paranext-extension-template`](https://github.com/paranext/paranext-extension-template) is set
+     * up for this use case. Feel free to use it for your extension!
+     *
+     *     ---
+     *
+     * **For React WebViews (default):** string containing all the code you want to run in the iframe
+     * on the frontend. You should set a function component to `globalThis.webViewComponent` in this
+     * code.
+     *
+     * For example, you could pass the bundled output of the following code to as your React Web View
+     * `content`:
+     *
+     * ```tsx
+     * globalThis.webViewComponent = function MyWebView() {
+     *  return <div>Hello World!! This is my React WebView!</div>;
+     * }
+     * ```
+     *
+     * **For HTML WebViews:** string containing all the code you want to run in the iframe on the
+     * frontend. This should be a complete HTML document. Usually,
+     *
+     * For example, you could pass the following string as your HTML Web View `content`:
+     *
+     * ```html
+     * <html>
+     *   <head>
+     *     <style>
+     *       .title {
+     *         color: darkgreen;
+     *       }
+     *     </style>
+     *   </head>
+     *   <body>
+     *     <div class="title">Hello World!! This is my HTML Web View!</div>
+     *   </body>
+     * </html>
+     * ```
+     *
+     *     ---
+     *
+     * **For URL WebViews:** the url you want to load into the iframe on the frontend.
+     *
+     * Note: URL WebViews must have `papi-extension:` or `https:` urls.
+     *
+     * For example, you could pass the following string as your URL Web View `content`:
+     *
+     * ```plain
+     * https://example.com/
+     * ```
+     */
     content: string;
     /**
      * Url of image to show on the title bar of the tab
@@ -563,6 +617,7 @@ declare module 'shared/global-this.model' {
     UseWebViewScrollGroupScrRefHook,
     UseWebViewStateHook,
     WebViewDefinitionUpdateInfo,
+    WebViewId,
     WebViewProps,
   } from 'shared/models/web-view.model';
   /**
@@ -586,6 +641,8 @@ declare module 'shared/global-this.model' {
      * in WebView iframes.
      */
     var webViewComponent: FunctionComponent<WebViewProps>;
+    /** The id of the current web view. Only used in WebView iframes. */
+    var webViewId: WebViewId;
     /**
      *
      * A React hook for working with a state object tied to a webview. Returns a WebView state value and
@@ -2112,6 +2169,684 @@ declare module 'shared/models/extract-data-provider-data-types.model' {
             : never;
   export default ExtractDataProviderDataTypes;
 }
+declare module 'shared/models/web-view-provider.model' {
+  import {
+    GetWebViewOptions,
+    WebViewDefinition,
+    SavedWebViewDefinition,
+  } from 'shared/models/web-view.model';
+  import {
+    DisposableNetworkObject,
+    NetworkObject,
+    NetworkableObject,
+  } from 'shared/models/network-object.model';
+  /**
+   * An object associated with a specific `webViewType` that provides a {@link WebViewDefinition} when
+   * the PAPI wants to open a web view with that `webViewType`. An extension registers a web view
+   * provider with `papi.webViewProviders.register`.
+   *
+   * Web View Providers provide the contents of all web views in Platform.Bible.
+   *
+   * If you want to provide {@link WebViewControllers} to facilitate interaction between your web views
+   * and extensions, you can extend the abstract class {@link WebViewFactory} to make the process
+   * easier. Alternatively, if you want to manage web view controllers manually, you can register them
+   * in {@link IWebViewProvider.getWebView}.
+   */
+  export interface IWebViewProvider extends NetworkableObject {
+    /**
+     * Receives a {@link SavedWebViewDefinition} and fills it out into a full {@link WebViewDefinition},
+     * providing the contents of the web view and other properties that are important for displaying
+     * the web view.
+     *
+     * The PAPI calls this method as part of opening a new web view or (re)loading an existing web
+     * view. If you want to create {@link WebViewControllers} for the web views the PAPI creates from
+     * this method, you should register it using `papi.webViewProviders.registerWebViewController`
+     * before returning from this method (resolving the returned promise). The {@link WebViewFactory}
+     * abstract class handles this for you, so please consider extending it.
+     *
+     * @param savedWebViewDefinition The saved web view information from which to build a complete web
+     *   view definition. Filled out with all {@link SavedWebViewDefinition} properties of the existing
+     *   web view if an existing webview is being called for (matched by ID). Just provides the
+     *   minimal properties required on {@link SavedWebViewDefinition} if this is a new request or if
+     *   the web view with the existing ID was not found.
+     * @param getWebViewOptions Various options that affect what calling `papi.webViews.openWebView`
+     *   should do. When options are passed to `papi.webViews.openWebView`, some defaults are set up
+     *   on the options, then those options are passed directly through to this method. That way, if
+     *   you want to adjust what this method does based on the contents of the options passed to
+     *   `papi.WebViews.openWebView`, you can. You can even read other properties on these options if
+     *   someone passes options with other properties to `papi.webViews.openWebView`.
+     * @param webViewNonce Nonce used to perform privileged interactions with the web view created
+     *   from this method's returned {@link WebViewDefinition} such as
+     *   `papi.webViewProviders.postMessageToWebView`. The web view service generates this nonce and
+     *   sends it _only here_ to this web view provider that creates the web view with this id. It is
+     *   generally recommended that this web view provider not share this nonce with anyone else but
+     *   only use it within itself and in the web view controller created for this web view if
+     *   applicable (See `papi.webViewProviders.registerWebViewController`).
+     * @returns Full {@link WebViewDefinition} including the content and other important display
+     *   properties based on the {@link SavedWebViewDefinition} provided
+     */
+    getWebView(
+      savedWebViewDefinition: SavedWebViewDefinition,
+      getWebViewOptions: GetWebViewOptions,
+      webViewNonce: string,
+    ): Promise<WebViewDefinition | undefined>;
+  }
+  /**
+   * A web view provider that has been registered with the PAPI.
+   *
+   * This is what the papi gives on `webViewProviderService.get` (not exposed on the PAPI). Basically
+   * a layer over NetworkObject
+   *
+   * This type is internal to core and is not used by extensions
+   */
+  export interface IRegisteredWebViewProvider extends NetworkObject<IWebViewProvider> {}
+  /**
+   * A web view provider that has been registered with the PAPI and returned to the extension that
+   * registered it. It is able to be disposed with `dispose`.
+   *
+   * The PAPI returns this type from `papi.webViewProviders.register`.
+   */
+  export interface IDisposableWebViewProvider extends DisposableNetworkObject<IWebViewProvider> {}
+}
+declare module 'shared/models/network-object-status.service-model' {
+  import { NetworkObjectDetails } from 'shared/models/network-object.model';
+  export interface NetworkObjectStatusRemoteServiceType {
+    /**
+     * Get details about all available network objects
+     *
+     * @returns Object whose keys are the names of the network objects and whose values are the
+     *   {@link NetworkObjectDetails} for each network object
+     */
+    getAllNetworkObjectDetails: () => Promise<Record<string, NetworkObjectDetails>>;
+  }
+  /**
+   *
+   * Provides functions related to the set of available network objects
+   */
+  export interface NetworkObjectStatusServiceType extends NetworkObjectStatusRemoteServiceType {
+    /**
+     * Get a promise that resolves when a network object is registered or rejects if a timeout is hit
+     *
+     * @param objectDetailsToMatch Subset of object details on the network object to wait for.
+     *   Compared to object details using {@link isSubset}
+     * @param timeoutInMS Max duration to wait for the network object. If not provided, it will wait
+     *   indefinitely
+     * @returns Promise that either resolves to the {@link NetworkObjectDetails} for a network object
+     *   once the network object is registered, or rejects if a timeout is provided and the timeout is
+     *   reached before the network object is registered
+     */
+    waitForNetworkObject: (
+      objectDetailsToMatch: Partial<NetworkObjectDetails>,
+      timeoutInMS?: number,
+    ) => Promise<NetworkObjectDetails>;
+  }
+  export const networkObjectStatusServiceNetworkObjectName = 'NetworkObjectStatusService';
+}
+declare module 'shared/services/network-object-status.service' {
+  import { NetworkObjectStatusServiceType } from 'shared/models/network-object-status.service-model';
+  /**
+   *
+   * Provides functions related to the set of available network objects
+   */
+  const networkObjectStatusService: NetworkObjectStatusServiceType;
+  export default networkObjectStatusService;
+}
+declare module 'shared/models/docking-framework.model' {
+  import { MutableRefObject, ReactNode } from 'react';
+  import { DockLayout, DropDirection, LayoutBase } from 'rc-dock';
+  import { WebViewDefinition, WebViewDefinitionUpdateInfo } from 'shared/models/web-view.model';
+  import { LocalizeKey } from 'platform-bible-utils';
+  /**
+   * Saved information used to recreate a tab.
+   *
+   * - {@link TabLoader} loads this into {@link TabInfo}
+   * - {@link TabSaver} saves {@link TabInfo} into this
+   */
+  export type SavedTabInfo = {
+    /**
+     * Tab ID - a unique identifier that identifies this tab. If this tab is a WebView, this ID will
+     * match the `WebViewDefinition.id`
+     */
+    id: string;
+    /** Type of tab - indicates what kind of built-in tab this info represents */
+    tabType: string;
+    /** Data needed to load the tab */
+    data?: unknown;
+  };
+  /**
+   * Information that Paranext uses to create a tab in the dock layout.
+   *
+   * - {@link TabLoader} loads {@link SavedTabInfo} into this
+   * - {@link TabSaver} saves this into {@link SavedTabInfo}
+   */
+  export type TabInfo = SavedTabInfo & {
+    /**
+     * Url of image to show on the title bar of the tab
+     *
+     * Defaults to the software's standard logo.
+     */
+    tabIconUrl?: string;
+    /**
+     * Text to show (or a localizeKey that will automatically be localized) on the title bar of the
+     * tab
+     */
+    tabTitle: string | LocalizeKey;
+    /** Text to show when hovering over the title bar of the tab */
+    tabTooltip?: string;
+    /** Content to show inside the tab. */
+    content: ReactNode;
+    /** (optional) Minimum width that the tab can become in CSS `px` units */
+    minWidth?: number;
+    /** (optional) Minimum height that the tab can become in CSS `px` units */
+    minHeight?: number;
+  };
+  /**
+   * Function that takes a {@link SavedTabInfo} and creates a Paranext tab out of it. Each type of tab
+   * must provide a {@link TabLoader}.
+   *
+   * For now all tab creators must do their own data type verification
+   */
+  export type TabLoader = (savedTabInfo: SavedTabInfo) => TabInfo;
+  /**
+   * Function that takes a Paranext tab and creates a saved tab out of it. Each type of tab can
+   * provide a {@link TabSaver}. If they do not provide one, the properties added by `TabInfo` are
+   * stripped from TabInfo by `saveTabInfoBase` before saving (so it is just a {@link SavedTabInfo}).
+   *
+   * @param tabInfo The Paranext tab to save
+   * @returns The saved tab info for Paranext to persist. If `undefined`, does not save the tab
+   */
+  export type TabSaver = (tabInfo: TabInfo) => SavedTabInfo | undefined;
+  /** Information about a tab in a panel */
+  interface TabLayout {
+    type: 'tab';
+  }
+  /**
+   * Indicates where to display a floating window
+   *
+   * - `cascade` - place the window a bit below and to the right of the previously created floating
+   *   window
+   * - `center` - center the window in the dock layout
+   */
+  type FloatPosition = 'cascade' | 'center';
+  /** The dimensions for a floating tab in CSS `px` units */
+  export type FloatSize = {
+    width: number;
+    height: number;
+  };
+  /** Information about a floating window */
+  export interface FloatLayout {
+    type: 'float';
+    floatSize?: FloatSize;
+    /** Where to display the floating window. Defaults to `cascade` */
+    position?: FloatPosition;
+  }
+  export type PanelDirection =
+    | 'left'
+    | 'right'
+    | 'bottom'
+    | 'top'
+    | 'before-tab'
+    | 'after-tab'
+    | 'maximize'
+    | 'move'
+    | 'active'
+    | 'update';
+  /** Information about a panel */
+  interface PanelLayout {
+    type: 'panel';
+    direction?: PanelDirection;
+    /** If undefined, it will add in the `direction` relative to the previously added tab. */
+    targetTabId?: string;
+  }
+  /** Information about how a Paranext tab fits into the dock layout */
+  export type Layout = TabLayout | FloatLayout | PanelLayout;
+  /** Props that are passed to the web view tab component */
+  export type WebViewTabProps = WebViewDefinition;
+  /**
+   * Rc-dock's onLayoutChange prop made asynchronous with `webViewDefinition` added. The dock layout
+   * component calls this on the web view service when the layout changes.
+   *
+   * @param webViewDefinition The web view definition if the edit was on a web view; `undefined`
+   *   otherwise
+   * @returns Promise that resolves when finished doing things
+   */
+  export type OnLayoutChangeRCDock = (
+    newLayout: LayoutBase,
+    currentTabId?: string,
+    direction?: DropDirection,
+    webViewDefinition?: WebViewDefinition,
+  ) => Promise<void>;
+  /** Properties related to the dock layout */
+  export type PapiDockLayout = {
+    /** The rc-dock dock layout React element ref. Used to perform operations on the layout */
+    dockLayout: DockLayout;
+    /**
+     * A ref to a function that runs when the layout changes. We set this ref to our
+     * {@link onLayoutChange} function
+     */
+    onLayoutChangeRef: MutableRefObject<OnLayoutChangeRCDock | undefined>;
+    /**
+     * Add or update a tab in the layout
+     *
+     * @param savedTabInfo Info for tab to add or update
+     * @param layout Information about where to put a new tab
+     * @returns If tab added, final layout used to display the new tab. If existing tab updated,
+     *   `undefined`
+     */
+    addTabToDock: (savedTabInfo: SavedTabInfo, layout: Layout) => Layout | undefined;
+    /**
+     * Add or update a webview in the layout
+     *
+     * @param webView Web view to add or update
+     * @param layout Information about where to put a new webview
+     * @returns If WebView added, final layout used to display the new webView. If existing webView
+     *   updated, `undefined`
+     */
+    addWebViewToDock: (webView: WebViewTabProps, layout: Layout) => Layout | undefined;
+    /**
+     * Remove a tab in the layout
+     *
+     * @param tabId ID of the tab to remove
+     */
+    removeTabFromDock: (tabId: string) => boolean;
+    /**
+     * Gets the WebView definition for the web view with the specified ID
+     *
+     * @param webViewId The ID of the WebView whose web view definition to get
+     * @returns WebView definition with the specified ID or undefined if not found
+     */
+    getWebViewDefinition: (webViewId: string) => WebViewDefinition | undefined;
+    /**
+     * Updates the WebView with the specified ID with the specified properties
+     *
+     * @param webViewId The ID of the WebView to update
+     * @param updateInfo Properties to update on the WebView. Any unspecified properties will stay the
+     *   same
+     * @returns True if successfully found the WebView to update; false otherwise
+     */
+    updateWebViewDefinition: (
+      webViewId: string,
+      updateInfo: WebViewDefinitionUpdateInfo,
+    ) => boolean;
+    /**
+     * The layout to use as the default layout if the dockLayout doesn't have a layout loaded.
+     *
+     * TODO: This should be removed and the `testLayout` imported directly in this file once this
+     * service is refactored to split the code between processes. The only reason this is passed from
+     * `platform-dock-layout.component.tsx` is that we cannot import `testLayout` here since this
+     * service is currently all shared code. Refactor should happen in #203
+     */
+    testLayout: LayoutBase;
+  };
+}
+declare module 'shared/services/web-view.service-model' {
+  import {
+    GetWebViewOptions,
+    SavedWebViewDefinition,
+    WebViewId,
+    WebViewType,
+  } from 'shared/models/web-view.model';
+  import { Layout } from 'shared/models/docking-framework.model';
+  import { PlatformEvent } from 'platform-bible-utils';
+  import { WebViewControllers, WebViewControllerTypes } from 'papi-shared-types';
+  import { NetworkObject } from 'shared/models/network-object.model';
+  /**
+   *
+   * Service exposing various functions related to using webViews
+   *
+   * WebViews are iframes in the Platform.Bible UI into which extensions load frontend code, either
+   * HTML or React components.
+   */
+  export interface WebViewServiceType {
+    /** Event that emits with webView info when a webView is added */
+    onDidAddWebView: PlatformEvent<AddWebViewEvent>;
+    /** Event that emits with webView info when a webView is updated */
+    onDidUpdateWebView: PlatformEvent<UpdateWebViewEvent>;
+    /** Event that emits with webView info when a webView is closed */
+    onDidCloseWebView: PlatformEvent<CloseWebViewEvent>;
+    /** @deprecated 6 November 2024. Renamed to {@link openWebView}. */
+    getWebView: (
+      webViewType: WebViewType,
+      layout?: Layout,
+      options?: GetWebViewOptions,
+    ) => Promise<WebViewId | undefined>;
+    /**
+     * Creates a new web view or gets an existing one depending on if you request an existing one and
+     * if the web view provider decides to give that existing one to you (it is up to the provider).
+     *
+     * @param webViewType Type of WebView to create
+     * @param layout Information about where you want the web view to go. Defaults to adding as a tab
+     * @param options Options that affect what this function does. For example, you can provide an
+     *   existing web view ID to request an existing web view with that ID.
+     * @returns Promise that resolves to the ID of the webview we got or undefined if the provider did
+     *   not create a WebView for this request.
+     * @throws If something went wrong like the provider for the webViewType was not found
+     */
+    openWebView: (
+      webViewType: WebViewType,
+      layout?: Layout,
+      options?: GetWebViewOptions,
+    ) => Promise<WebViewId | undefined>;
+    /** @deprecated 6 November 2024. Renamed to {@link getOpenWebViewDefinition} */
+    getSavedWebViewDefinition(webViewId: string): Promise<SavedWebViewDefinition | undefined>;
+    /**
+     * Gets the saved properties on the WebView definition with the specified ID
+     *
+     * Note: this only returns a representation of the current web view definition, not the actual web
+     * view definition itself. Changing properties on the returned definition does not affect the
+     * actual web view definition. You can possibly change the actual web view definition by calling
+     * {@link WebViewServiceType.openWebView} with certain `options`, depending on what options the web
+     * view provider has made available.
+     *
+     * @param webViewId The ID of the WebView whose saved properties to get
+     * @returns Saved properties of the WebView definition with the specified ID or undefined if not
+     *   found
+     */
+    getOpenWebViewDefinition(webViewId: string): Promise<SavedWebViewDefinition | undefined>;
+    /**
+     * Get an existing web view controller for an open web view.
+     *
+     * A Web View Controller is a network object that represents a web view and whose methods
+     * facilitate communication between its associated web view and extensions that want to interact
+     * with it.
+     *
+     * Web View Controllers are registered on the web view provider service.
+     *
+     * @param webViewType Type of webview controller you expect to get. If the web view controller's
+     *   `webViewType` does not match this, an error will be thrown
+     * @param webViewId Id of web view for which to get the corresponding web view controller if one
+     *   exists
+     * @returns Web view controller with the given name if one exists, undefined otherwise
+     */
+    getWebViewController<WebViewType extends WebViewControllerTypes>(
+      webViewType: WebViewType,
+      webViewId: WebViewId,
+    ): Promise<NetworkObject<WebViewControllers[WebViewType]> | undefined>;
+  }
+  /** Get request type for posting a message to a web view */
+  export function getWebViewMessageRequestType(webViewId: WebViewId): `${string}:${string}`;
+  /**
+   * Type of function to receive messages sent to a web view.
+   *
+   * See `web-view-provider.service.ts`'s `postMessageToWebView` and `web-view.component` for
+   * information on this type
+   */
+  export type WebViewMessageRequestHandler = (
+    webViewNonce: string,
+    message: unknown,
+    targetOrigin?: string,
+  ) => Promise<void>;
+  /** Gets the id for the web view controller network object with the given name */
+  export const getWebViewControllerObjectId: (webViewId: string) => string;
+  /** Network object type for web view controllers */
+  export const WEB_VIEW_CONTROLLER_OBJECT_TYPE = 'webViewController';
+  export function getWebViewController<WebViewType extends WebViewControllerTypes>(
+    webViewType: WebViewType,
+    webViewId: WebViewId,
+  ): Promise<NetworkObject<WebViewControllers[WebViewType]> | undefined>;
+  /** Name to use when creating a network event that is fired when webViews are created */
+  export const EVENT_NAME_ON_DID_ADD_WEB_VIEW: `${string}:${string}`;
+  /** Event emitted when webViews are created */
+  export type AddWebViewEvent = {
+    webView: SavedWebViewDefinition;
+    layout: Layout;
+  };
+  /** Name to use when creating a network event that is fired when webViews are updated */
+  export const EVENT_NAME_ON_DID_UPDATE_WEB_VIEW: `${string}:${string}`;
+  /** Event emitted when webViews are updated */
+  export type UpdateWebViewEvent = {
+    webView: SavedWebViewDefinition;
+  };
+  /** Name to use when creating a network event that is fired when webViews are closed */
+  export const EVENT_NAME_ON_DID_CLOSE_WEB_VIEW: `${string}:${string}`;
+  /** Event emitted when webViews are closed */
+  export type CloseWebViewEvent = {
+    webView: SavedWebViewDefinition;
+  };
+  export const NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE = 'WebViewService';
+}
+declare module 'shared/services/web-view.service' {
+  import { WebViewServiceType } from 'shared/services/web-view.service-model';
+  const webViewService: WebViewServiceType;
+  export default webViewService;
+}
+declare module 'shared/services/web-view-provider.service' {
+  /**
+   * Handles registering web view providers and serving web views around the papi. Exposed on the
+   * papi.
+   */
+  import {
+    IDisposableWebViewProvider,
+    IWebViewProvider,
+    IRegisteredWebViewProvider,
+  } from 'shared/models/web-view-provider.model';
+  import { WebViewControllers, WebViewControllerTypes } from 'papi-shared-types';
+  import { DisposableNetworkObject } from 'shared/models/network-object.model';
+  import { WebViewId } from 'shared/models/web-view.model';
+  /** Sets up the service. Only runs once and always returns the same promise after that */
+  const initialize: () => Promise<void>;
+  /**
+   * Indicate if we are aware of an existing web view provider with the given type. If a web view
+   * provider with the given type is somewhere else on the network, this function won't tell you about
+   * it unless something else in the existing process is subscribed to it.
+   *
+   * @param webViewType Type of webView to check for
+   */
+  function hasKnownWebViewProvider(webViewType: string): boolean;
+  /**
+   * Register a web view provider to serve webViews for a specified type of webViews
+   *
+   * @param webViewType Type of web view to provide
+   * @param webViewProvider Object to register as a webView provider including control over disposing
+   *   of it.
+   *
+   *   WARNING: setting a webView provider mutates the provided object.
+   * @returns `webViewProvider` modified to be a network object and able to be disposed with `dispose`
+   */
+  function register(
+    webViewType: string,
+    webViewProvider: IWebViewProvider,
+  ): Promise<IDisposableWebViewProvider>;
+  /**
+   * Get a web view provider that has previously been set up
+   *
+   * @param webViewType Type of webview provider to get
+   * @returns Web view provider with the given name if one exists, undefined otherwise
+   */
+  function get(webViewType: string): Promise<IRegisteredWebViewProvider | undefined>;
+  /**
+   * Register a web view controller to represent a web view. It is expected that a web view provider
+   * calls this to register a web view controller for a web view that is being created. If a web view
+   * provider extends {@link WebViewFactory}, it will call this function automatically.
+   *
+   * A Web View Controller is a network object that represents a web view and whose methods facilitate
+   * communication between its associated web view and extensions that want to interact with it.
+   *
+   * You can get web view controllers with {@link webViewService.getWebViewController}.
+   *
+   * @param webViewType Type of web view for which you are providing this web view controller
+   * @param webViewId Id of web view for which to register the web view controller
+   * @param webViewController Object to register as a web view controller including control over
+   *   disposing of it. Note: the web view controller will be disposed automatically when the web view
+   *   is closed
+   *
+   *   WARNING: setting a web view controller mutates the provided object.
+   * @returns `webViewController` modified to be a network object
+   */
+  function registerWebViewController<WebViewType extends WebViewControllerTypes>(
+    webViewType: WebViewType,
+    webViewId: WebViewId,
+    webViewController: WebViewControllers[WebViewType],
+  ): Promise<DisposableNetworkObject<WebViewControllers[WebViewType]>>;
+  /**
+   * Sends a message to the specified web view. Expected to be used only by the
+   * {@link IWebViewProvider} that created the web view or the {@link WebViewControllers} that
+   * represents the web view created by the Web View Provider.
+   *
+   * [`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) is used to
+   * deliver the message to the web view iframe. The web view can use
+   * [`window.addEventListener("message",
+   * ...)`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#the_dispatched_event)
+   * in order to receive these messages.
+   *
+   * @param webViewId Id of the web view to which to send a message.
+   * @param webViewNonce Nonce used to perform privileged interactions with the web view. Pass in the
+   *   nonce the web view provider received from {@link IWebViewProvider.getWebView}'s `webViewNonce`
+   *   parameter or from {@link WebViewFactory.createWebViewController}'s `webViewNonce` parameter
+   * @param message Data to send to the web view. Can only send serializable information
+   * @param targetOrigin Expected origin of the web view. Does not send the message if the web view's
+   *   origin does not match. See [`postMessage`'s
+   *   `targetOrigin`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#targetorigin)
+   *   for more information. Defaults to same origin only (works automatically with React and HTML web
+   *   views)
+   */
+  function postMessageToWebView(
+    webViewId: WebViewId,
+    webViewNonce: string,
+    message: unknown,
+    targetOrigin?: string,
+  ): Promise<void>;
+  export interface WebViewProviderService {
+    initialize: typeof initialize;
+    hasKnown: typeof hasKnownWebViewProvider;
+    register: typeof register;
+    get: typeof get;
+    registerWebViewController: typeof registerWebViewController;
+    postMessageToWebView: typeof postMessageToWebView;
+  }
+  export interface PapiWebViewProviderService {
+    register: typeof register;
+    registerWebViewController: typeof registerWebViewController;
+    postMessageToWebView: typeof postMessageToWebView;
+  }
+  const webViewProviderService: WebViewProviderService;
+  /**
+   *
+   * Interface for registering webView providers
+   */
+  export const papiWebViewProviderService: PapiWebViewProviderService;
+  export default webViewProviderService;
+}
+declare module 'shared/models/web-view-factory.model' {
+  import { WebViewControllers, WebViewControllerTypes } from 'papi-shared-types';
+  import type { IWebViewProvider } from 'shared/models/web-view-provider.model';
+  import {
+    SavedWebViewDefinition,
+    GetWebViewOptions,
+    WebViewDefinition,
+  } from 'shared/models/web-view.model';
+  /**
+   *
+   * A partial implementation of {@link IWebViewProvider} that includes creating
+   * {@link WebViewControllers} for each web view served by the web view provider. This class handles
+   * registering, disposing, and making sure there is only one web view controller for each web view
+   * for you.
+   *
+   * You can create a new class extending this abstract class to create a web view provider that
+   * serves web views and web view controllers of a specific `webViewType` to facilitate interaction
+   * between those web views and other extensions. You can register it with the PAPI using
+   * `papi.webViewProviders.register`.
+   *
+   * If you want to change your existing `IWebViewProvider` from a plain object to extending this
+   * class, you will need to change your object's existing method named `getWebView`
+   * ({@link IWebViewProvider.getWebView}) to be named `getWebViewDefinition`
+   * ({@link WebViewFactory.getWebViewDefinition}), which is a drop-in replacement. You likely do NOT
+   * want to overwrite this class's `getWebView` because that will eliminate most of the benefits
+   * associated with using this class.
+   *
+   * @see {@link IWebViewProvider} for more information on extending this class.
+   */
+  export abstract class WebViewFactory<WebViewType extends WebViewControllerTypes>
+    implements IWebViewProvider
+  {
+    readonly webViewType: WebViewType;
+    private readonly webViewControllersMutexMap;
+    private readonly webViewControllersCleanupList;
+    private readonly webViewControllersById;
+    constructor(webViewType: WebViewType);
+    /**
+     * Receives a {@link SavedWebViewDefinition} and fills it out into a full {@link WebViewDefinition},
+     * providing the contents of the web view and other properties that are important for displaying
+     * the web view.
+     *
+     * WARNING: This method must NOT be overridden if you want any of the benefits of this class. You
+     * are probably looking for {@link WebViewFactory.getWebViewDefinition}.
+     *
+     * If you are transferring a web view provider using a plain object to extending this class, you
+     * should rename your existing `getWebView` to `getWebViewDefinition`.
+     */
+    getWebView(
+      savedWebViewDefinition: SavedWebViewDefinition,
+      getWebViewOptions: GetWebViewOptions,
+      webViewNonce: string,
+    ): Promise<WebViewDefinition | undefined>;
+    /** Disposes of all WVCs that were created by this provider */
+    dispose(): Promise<boolean>;
+    /**
+     * Receives a {@link SavedWebViewDefinition} and fills it out into a full {@link WebViewDefinition},
+     * providing the contents of the web view and other properties that are important for displaying
+     * the web view.
+     *
+     * {@link WebViewFactory} calls this as part of its {@link getWebView}, which is called by the PAPI
+     * as part of opening a new web view. It will also create a web view controller after running this
+     * if applicable.
+     *
+     * See {@link IWebViewProvider.getWebView} for more information on how this method works.
+     *
+     * @param savedWebViewDefinition The saved web view information from which to build a complete web
+     *   view definition. Filled out with all {@link SavedWebViewDefinition} properties of the existing
+     *   web view if an existing webview is being called for (matched by ID). Just provides the
+     *   minimal properties required on {@link SavedWebViewDefinition} if this is a new request or if
+     *   the web view with the existing ID was not found.
+     * @param getWebViewOptions Various options that affect what calling `papi.webViews.openWebView`
+     *   should do. When options are passed to `papi.webViews.openWebView`, some defaults are set up
+     *   on the options, then those options are passed directly through to this method. That way, if
+     *   you want to adjust what this method does based on the contents of the options passed to
+     *   `papi.WebViews.openWebView`, you can. You can even read other properties on these options if
+     *   someone passes options with other properties to `papi.webViews.openWebView`.
+     * @param webViewNonce Nonce used to perform privileged interactions with the web view created
+     *   from this method's returned {@link WebViewDefinition} such as
+     *   `papi.webViewProviders.postMessageToWebView`. The web view service generates this nonce and
+     *   sends it _only here_ to this web view provider that creates the web view with this id. It is
+     *   generally recommended that this web view provider not share this nonce with anyone else but
+     *   only use it within itself and in the web view controller created for this web view if
+     *   applicable (See `papi.webViewProviders.registerWebViewController`).
+     * @returns Full {@link WebViewDefinition} including the content and other important display
+     *   properties based on the {@link SavedWebViewDefinition} provided
+     */
+    abstract getWebViewDefinition(
+      savedWebViewDefinition: SavedWebViewDefinition,
+      getWebViewOptions: GetWebViewOptions,
+      webViewNonce: string,
+    ): Promise<WebViewDefinition | undefined>;
+    /**
+     * Creates a {@link WebViewController} that corresponds to the {@link WebViewDefinition} provided.
+     * {@link WebViewFactory} calls this as part of its {@link getWebView}. {@link WebViewFactory} will
+     * automatically register this controller with the web view provider service
+     * (`papi.webViewProviders.registerWebViewController`), run its `dispose` when the web view is
+     * closed or this `WebViewFactory` is disposed, and make sure just one web view controller is
+     * created for each web view.
+     *
+     * Alternatively, if you do not want to create web view controllers (or a controller for a
+     * specific web view), feel free to return `undefined` from this method.
+     *
+     * @param webViewDefinition The definition for the web view for which to create a web view
+     *   controller
+     * @param webViewNonce Nonce used to perform privileged interactions with the web view created
+     *   from the `webViewDefinition` parameter such as `papi.webViewProviders.postMessageToWebView`.
+     *   The web view service generates this nonce and sends it _only here_ to this web view provider
+     *   that creates the web view with this id. It is generally recommended that this web view
+     *   provider not share this nonce with anyone else but only use it within itself and here in the
+     *   web view controller created for this web view.
+     * @returns Web view controller for the web view with the `webViewDefinition` provided. Or
+     *   `undefined` if you do not want to create a web view controller for this web view.
+     */
+    abstract createWebViewController(
+      webViewDefinition: WebViewDefinition,
+      webViewNonce: string,
+    ): Promise<WebViewControllers[WebViewType]>;
+  }
+}
 declare module 'papi-shared-types' {
   import type { ScriptureReference, UnsubscriberAsync } from 'platform-bible-utils';
   import type {
@@ -2128,6 +2863,7 @@ declare module 'papi-shared-types' {
   import type { IDisposableDataProvider } from 'shared/models/data-provider.interface';
   import type IDataProvider from 'shared/models/data-provider.interface';
   import type ExtractDataProviderDataTypes from 'shared/models/extract-data-provider-data-types.model';
+  import type { NetworkableObject } from 'shared/models/network-object.model';
   /**
    * Function types for each command available on the papi. Each extension can extend this interface
    * to add commands that it registers on the papi with `papi.commands.registerCommand`.
@@ -2612,6 +3348,59 @@ declare module 'papi-shared-types' {
       DataProviders[DataProviderName]
     >;
   };
+  /**
+   * {@link NetworkableObject} types for each web view controller supported by PAPI. A Web View
+   * Controller is a network object that represents a web view and whose methods facilitate
+   * communication between its associated web view and extensions that want to interact with it.
+   * `WebViewControllers` can be created by {@link IWebViewProvider} of the same `webViewType`.
+   * Extensions can add web view controllers with corresponding `webViewType`s by adding details to
+   * their `.d.ts` file and registering a web view controller in their web view provider's
+   * `getWebView` function with `papi.webViewProviders.registerWebViewController`. If you want to
+   * create web view controllers, we recommend you create a class derived from the abstract class
+   * {@link WebViewFactory}, which automatically manage the lifecycle of the web view controllers for
+   * you.
+   *
+   * Note: The keys of this interface are the `webViewType`s for the web views associated with these
+   * web view controllers. They must consist of two strings separated by at least one period. We
+   * recommend one period and lower camel case in case we expand the api in the future to allow dot
+   * notation.
+   *
+   * An extension can extend this interface to add a type for the web view controller it registers
+   * by adding the following to its `.d.ts` file (in this example, we are adding the
+   * `'helloSomeone.peopleWebView'` web view controller type):
+   *
+   * @example
+   *
+   * ```typescript
+   * declare module 'papi-shared-types' {
+   *   export type PeopleWebViewController = NetworkableObject<{
+   *     setSelectedPerson(name: string): Promise<boolean>;
+   *     testRandomMethod(things: string): Promise<string>;
+   *   }>;
+   *
+   *   export interface WebViewControllers {
+   *     'helloSomeone.peopleWebView': PeopleWebViewController;
+   *   }
+   * }
+   * ```
+   */
+  interface WebViewControllers {
+    'platform.stuffWebView': NetworkableObject<{
+      doStuff(thing: string): Promise<boolean>;
+    }>;
+    'platform.placeholderWebView': NetworkableObject<{
+      runPlaceholderStuff(thing: string): Promise<boolean>;
+    }>;
+  }
+  /**
+   * `webViewType`s for each web view controller available on the papi.
+   *
+   * Automatically includes all extensions' web view controllers that are added to
+   * {@link WebViewControllers}.
+   *
+   * @example 'platform.placeholderWebView'
+   */
+  type WebViewControllerTypes = keyof WebViewControllers;
 }
 declare module 'shared/services/command.service' {
   import { UnsubscriberAsync } from 'platform-bible-utils';
@@ -2657,390 +3446,6 @@ declare module 'shared/services/command.service' {
    * other services and extensions that have registered commands.
    */
   export type moduleSummaryComments = {};
-}
-declare module 'shared/models/docking-framework.model' {
-  import { MutableRefObject, ReactNode } from 'react';
-  import { DockLayout, DropDirection, LayoutBase } from 'rc-dock';
-  import { WebViewDefinition, WebViewDefinitionUpdateInfo } from 'shared/models/web-view.model';
-  import { LocalizeKey } from 'platform-bible-utils';
-  /**
-   * Saved information used to recreate a tab.
-   *
-   * - {@link TabLoader} loads this into {@link TabInfo}
-   * - {@link TabSaver} saves {@link TabInfo} into this
-   */
-  export type SavedTabInfo = {
-    /**
-     * Tab ID - a unique identifier that identifies this tab. If this tab is a WebView, this ID will
-     * match the `WebViewDefinition.id`
-     */
-    id: string;
-    /** Type of tab - indicates what kind of built-in tab this info represents */
-    tabType: string;
-    /** Data needed to load the tab */
-    data?: unknown;
-  };
-  /**
-   * Information that Paranext uses to create a tab in the dock layout.
-   *
-   * - {@link TabLoader} loads {@link SavedTabInfo} into this
-   * - {@link TabSaver} saves this into {@link SavedTabInfo}
-   */
-  export type TabInfo = SavedTabInfo & {
-    /**
-     * Url of image to show on the title bar of the tab
-     *
-     * Defaults to the software's standard logo.
-     */
-    tabIconUrl?: string;
-    /**
-     * Text to show (or a localizeKey that will automatically be localized) on the title bar of the
-     * tab
-     */
-    tabTitle: string | LocalizeKey;
-    /** Text to show when hovering over the title bar of the tab */
-    tabTooltip?: string;
-    /** Content to show inside the tab. */
-    content: ReactNode;
-    /** (optional) Minimum width that the tab can become in CSS `px` units */
-    minWidth?: number;
-    /** (optional) Minimum height that the tab can become in CSS `px` units */
-    minHeight?: number;
-  };
-  /**
-   * Function that takes a {@link SavedTabInfo} and creates a Paranext tab out of it. Each type of tab
-   * must provide a {@link TabLoader}.
-   *
-   * For now all tab creators must do their own data type verification
-   */
-  export type TabLoader = (savedTabInfo: SavedTabInfo) => TabInfo;
-  /**
-   * Function that takes a Paranext tab and creates a saved tab out of it. Each type of tab can
-   * provide a {@link TabSaver}. If they do not provide one, the properties added by `TabInfo` are
-   * stripped from TabInfo by `saveTabInfoBase` before saving (so it is just a {@link SavedTabInfo}).
-   *
-   * @param tabInfo The Paranext tab to save
-   * @returns The saved tab info for Paranext to persist. If `undefined`, does not save the tab
-   */
-  export type TabSaver = (tabInfo: TabInfo) => SavedTabInfo | undefined;
-  /** Information about a tab in a panel */
-  interface TabLayout {
-    type: 'tab';
-  }
-  /**
-   * Indicates where to display a floating window
-   *
-   * - `cascade` - place the window a bit below and to the right of the previously created floating
-   *   window
-   * - `center` - center the window in the dock layout
-   */
-  type FloatPosition = 'cascade' | 'center';
-  /** The dimensions for a floating tab in CSS `px` units */
-  export type FloatSize = {
-    width: number;
-    height: number;
-  };
-  /** Information about a floating window */
-  export interface FloatLayout {
-    type: 'float';
-    floatSize?: FloatSize;
-    /** Where to display the floating window. Defaults to `cascade` */
-    position?: FloatPosition;
-  }
-  export type PanelDirection =
-    | 'left'
-    | 'right'
-    | 'bottom'
-    | 'top'
-    | 'before-tab'
-    | 'after-tab'
-    | 'maximize'
-    | 'move'
-    | 'active'
-    | 'update';
-  /** Information about a panel */
-  interface PanelLayout {
-    type: 'panel';
-    direction?: PanelDirection;
-    /** If undefined, it will add in the `direction` relative to the previously added tab. */
-    targetTabId?: string;
-  }
-  /** Information about how a Paranext tab fits into the dock layout */
-  export type Layout = TabLayout | FloatLayout | PanelLayout;
-  /** Props that are passed to the web view tab component */
-  export type WebViewTabProps = WebViewDefinition;
-  /** Rc-dock's onLayoutChange prop made asynchronous - resolves */
-  export type OnLayoutChangeRCDock = (
-    newLayout: LayoutBase,
-    currentTabId?: string,
-    direction?: DropDirection,
-  ) => Promise<void>;
-  /** Properties related to the dock layout */
-  export type PapiDockLayout = {
-    /** The rc-dock dock layout React element ref. Used to perform operations on the layout */
-    dockLayout: DockLayout;
-    /**
-     * A ref to a function that runs when the layout changes. We set this ref to our
-     * {@link onLayoutChange} function
-     */
-    onLayoutChangeRef: MutableRefObject<OnLayoutChangeRCDock | undefined>;
-    /**
-     * Add or update a tab in the layout
-     *
-     * @param savedTabInfo Info for tab to add or update
-     * @param layout Information about where to put a new tab
-     * @returns If tab added, final layout used to display the new tab. If existing tab updated,
-     *   `undefined`
-     */
-    addTabToDock: (savedTabInfo: SavedTabInfo, layout: Layout) => Layout | undefined;
-    /**
-     * Add or update a webview in the layout
-     *
-     * @param webView Web view to add or update
-     * @param layout Information about where to put a new webview
-     * @returns If WebView added, final layout used to display the new webView. If existing webView
-     *   updated, `undefined`
-     */
-    addWebViewToDock: (webView: WebViewTabProps, layout: Layout) => Layout | undefined;
-    /**
-     * Remove a tab in the layout
-     *
-     * @param tabId ID of the tab to remove
-     */
-    removeTabFromDock: (tabId: string) => boolean;
-    /**
-     * Gets the WebView definition for the web view with the specified ID
-     *
-     * @param webViewId The ID of the WebView whose web view definition to get
-     * @returns WebView definition with the specified ID or undefined if not found
-     */
-    getWebViewDefinition: (webViewId: string) => WebViewDefinition | undefined;
-    /**
-     * Updates the WebView with the specified ID with the specified properties
-     *
-     * @param webViewId The ID of the WebView to update
-     * @param updateInfo Properties to update on the WebView. Any unspecified properties will stay the
-     *   same
-     * @returns True if successfully found the WebView to update; false otherwise
-     */
-    updateWebViewDefinition: (
-      webViewId: string,
-      updateInfo: WebViewDefinitionUpdateInfo,
-    ) => boolean;
-    /**
-     * The layout to use as the default layout if the dockLayout doesn't have a layout loaded.
-     *
-     * TODO: This should be removed and the `testLayout` imported directly in this file once this
-     * service is refactored to split the code between processes. The only reason this is passed from
-     * `platform-dock-layout.component.tsx` is that we cannot import `testLayout` here since this
-     * service is currently all shared code. Refactor should happen in #203
-     */
-    testLayout: LayoutBase;
-  };
-}
-declare module 'shared/services/web-view.service-model' {
-  import {
-    GetWebViewOptions,
-    SavedWebViewDefinition,
-    WebViewId,
-    WebViewType,
-  } from 'shared/models/web-view.model';
-  import { Layout } from 'shared/models/docking-framework.model';
-  import { PlatformEvent } from 'platform-bible-utils';
-  /**
-   *
-   * Service exposing various functions related to using webViews
-   *
-   * WebViews are iframes in the Platform.Bible UI into which extensions load frontend code, either
-   * HTML or React components.
-   */
-  export interface WebViewServiceType {
-    /** Event that emits with webView info when a webView is added */
-    onDidAddWebView: PlatformEvent<AddWebViewEvent>;
-    /** Event that emits with webView info when a webView is updated */
-    onDidUpdateWebView: PlatformEvent<UpdateWebViewEvent>;
-    /**
-     * Creates a new web view or gets an existing one depending on if you request an existing one and
-     * if the web view provider decides to give that existing one to you (it is up to the provider).
-     *
-     * @param webViewType Type of WebView to create
-     * @param layout Information about where you want the web view to go. Defaults to adding as a tab
-     * @param options Options that affect what this function does. For example, you can provide an
-     *   existing web view ID to request an existing web view with that ID.
-     * @returns Promise that resolves to the ID of the webview we got or undefined if the provider did
-     *   not create a WebView for this request.
-     * @throws If something went wrong like the provider for the webViewType was not found
-     */
-    getWebView: (
-      webViewType: WebViewType,
-      layout?: Layout,
-      options?: GetWebViewOptions,
-    ) => Promise<WebViewId | undefined>;
-    /**
-     * Gets the saved properties on the WebView definition with the specified ID
-     *
-     * Note: this only returns a representation of the current web view definition, not the actual web
-     * view definition itself. Changing properties on the returned definition does not affect the
-     * actual web view definition. You can possibly change the actual web view definition by calling
-     * {@link WebViewServiceType.getWebView} with certain `options`, depending on what options the web
-     * view provider has made available.
-     *
-     * @param webViewId The ID of the WebView whose saved properties to get
-     * @returns Saved properties of the WebView definition with the specified ID or undefined if not
-     *   found
-     */
-    getSavedWebViewDefinition(webViewId: string): Promise<SavedWebViewDefinition | undefined>;
-  }
-  /** Name to use when creating a network event that is fired when webViews are created */
-  export const EVENT_NAME_ON_DID_ADD_WEB_VIEW: `${string}:${string}`;
-  /** Event emitted when webViews are created */
-  export type AddWebViewEvent = {
-    webView: SavedWebViewDefinition;
-    layout: Layout;
-  };
-  /** Name to use when creating a network event that is fired when webViews are updated */
-  export const EVENT_NAME_ON_DID_UPDATE_WEB_VIEW: `${string}:${string}`;
-  /** Event emitted when webViews are updated */
-  export type UpdateWebViewEvent = {
-    webView: SavedWebViewDefinition;
-  };
-  export const NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE = 'WebViewService';
-}
-declare module 'shared/models/network-object-status.service-model' {
-  import { NetworkObjectDetails } from 'shared/models/network-object.model';
-  export interface NetworkObjectStatusRemoteServiceType {
-    /**
-     * Get details about all available network objects
-     *
-     * @returns Object whose keys are the names of the network objects and whose values are the
-     *   {@link NetworkObjectDetails} for each network object
-     */
-    getAllNetworkObjectDetails: () => Promise<Record<string, NetworkObjectDetails>>;
-  }
-  /**
-   *
-   * Provides functions related to the set of available network objects
-   */
-  export interface NetworkObjectStatusServiceType extends NetworkObjectStatusRemoteServiceType {
-    /**
-     * Get a promise that resolves when a network object is registered or rejects if a timeout is hit
-     *
-     * @param objectDetailsToMatch Subset of object details on the network object to wait for.
-     *   Compared to object details using {@link isSubset}
-     * @param timeoutInMS Max duration to wait for the network object. If not provided, it will wait
-     *   indefinitely
-     * @returns Promise that either resolves to the {@link NetworkObjectDetails} for a network object
-     *   once the network object is registered, or rejects if a timeout is provided and the timeout is
-     *   reached before the network object is registered
-     */
-    waitForNetworkObject: (
-      objectDetailsToMatch: Partial<NetworkObjectDetails>,
-      timeoutInMS?: number,
-    ) => Promise<NetworkObjectDetails>;
-  }
-  export const networkObjectStatusServiceNetworkObjectName = 'NetworkObjectStatusService';
-}
-declare module 'shared/services/network-object-status.service' {
-  import { NetworkObjectStatusServiceType } from 'shared/models/network-object-status.service-model';
-  /**
-   *
-   * Provides functions related to the set of available network objects
-   */
-  const networkObjectStatusService: NetworkObjectStatusServiceType;
-  export default networkObjectStatusService;
-}
-declare module 'shared/services/web-view.service' {
-  import { WebViewServiceType } from 'shared/services/web-view.service-model';
-  const webViewService: WebViewServiceType;
-  export default webViewService;
-}
-declare module 'shared/models/web-view-provider.model' {
-  import {
-    GetWebViewOptions,
-    WebViewDefinition,
-    SavedWebViewDefinition,
-  } from 'shared/models/web-view.model';
-  import {
-    DisposableNetworkObject,
-    NetworkObject,
-    NetworkableObject,
-  } from 'shared/models/network-object.model';
-  import { CanHaveOnDidDispose } from 'platform-bible-utils';
-  export interface IWebViewProvider extends NetworkableObject {
-    /**
-     * @param savedWebView Filled out if an existing webview is being called for (matched by ID). Just
-     *   ID if this is a new request or if the web view with the existing ID was not found
-     * @param getWebViewOptions
-     */
-    getWebView(
-      savedWebView: SavedWebViewDefinition,
-      getWebViewOptions: GetWebViewOptions,
-    ): Promise<WebViewDefinition | undefined>;
-  }
-  export interface WebViewProvider
-    extends NetworkObject<NetworkableObject>,
-      CanHaveOnDidDispose<IWebViewProvider> {}
-  export interface DisposableWebViewProvider
-    extends DisposableNetworkObject<NetworkableObject>,
-      Omit<WebViewProvider, 'dispose'> {}
-}
-declare module 'shared/services/web-view-provider.service' {
-  /**
-   * Handles registering web view providers and serving web views around the papi. Exposed on the
-   * papi.
-   */
-  import {
-    DisposableWebViewProvider,
-    IWebViewProvider,
-    WebViewProvider,
-  } from 'shared/models/web-view-provider.model';
-  /** Sets up the service. Only runs once and always returns the same promise after that */
-  const initialize: () => Promise<void>;
-  /**
-   * Indicate if we are aware of an existing web view provider with the given type. If a web view
-   * provider with the given type is somewhere else on the network, this function won't tell you about
-   * it unless something else in the existing process is subscribed to it.
-   *
-   * @param webViewType Type of webView to check for
-   */
-  function hasKnown(webViewType: string): boolean;
-  /**
-   * Register a web view provider to serve webViews for a specified type of webViews
-   *
-   * @param webViewType Type of web view to provide
-   * @param webViewProvider Object to register as a webView provider including control over disposing
-   *   of it.
-   *
-   *   WARNING: setting a webView provider mutates the provided object.
-   * @returns `webViewProvider` modified to be a network object
-   */
-  function register(
-    webViewType: string,
-    webViewProvider: IWebViewProvider,
-  ): Promise<DisposableWebViewProvider>;
-  /**
-   * Get a web view provider that has previously been set up
-   *
-   * @param webViewType Type of webview provider to get
-   * @returns Web view provider with the given name if one exists, undefined otherwise
-   */
-  function get(webViewType: string): Promise<WebViewProvider | undefined>;
-  export interface WebViewProviderService {
-    initialize: typeof initialize;
-    hasKnown: typeof hasKnown;
-    register: typeof register;
-    get: typeof get;
-  }
-  export interface PapiWebViewProviderService {
-    register: typeof register;
-  }
-  const webViewProviderService: WebViewProviderService;
-  /**
-   *
-   * Interface for registering webView providers
-   */
-  export const papiWebViewProviderService: PapiWebViewProviderService;
-  export default webViewProviderService;
 }
 declare module 'shared/services/internet.service' {
   /** Our shim over fetch. Allows us to control internet access. */
@@ -5593,6 +5998,7 @@ declare module '@papi/core' {
   export type { WithNotifyUpdate } from 'shared/models/data-provider-engine.model';
   export type { default as IDataProviderEngine } from 'shared/models/data-provider-engine.model';
   export type { DialogOptions } from 'shared/models/dialog-options.model';
+  export type { NetworkableObject, NetworkObject } from 'shared/models/network-object.model';
   export type {
     ExtensionDataScope,
     MandatoryProjectDataTypes,
@@ -5626,7 +6032,10 @@ declare module '@papi/core' {
     WebViewDefinition,
     WebViewProps,
   } from 'shared/models/web-view.model';
-  export type { IWebViewProvider } from 'shared/models/web-view-provider.model';
+  export type {
+    IDisposableWebViewProvider,
+    IWebViewProvider,
+  } from 'shared/models/web-view-provider.model';
   export type {
     SimultaneousProjectSettingsChanges,
     ProjectSettingValidator,
@@ -5823,6 +6232,7 @@ declare module '@papi/backend' {
   import { NetworkObjectStatusServiceType } from 'shared/models/network-object-status.service-model';
   import { ISettingsService } from 'shared/services/settings.service-model';
   import { IProjectSettingsService } from 'shared/services/project-settings.service-model';
+  import { WebViewFactory as PapiWebViewFactory } from 'shared/models/web-view-factory.model';
   const papi: {
     /**
      *
@@ -5877,6 +6287,28 @@ declare module '@papi/backend' {
      * requirements.
      */
     LayeringProjectDataProviderEngineFactory: typeof PapiLayeringProjectDataProviderEngineFactory;
+    /**
+     *
+     * A partial implementation of {@link IWebViewProvider} that includes creating
+     * {@link WebViewControllers} for each web view served by the web view provider. This class handles
+     * registering, disposing, and making sure there is only one web view controller for each web view
+     * for you.
+     *
+     * You can create a new class extending this abstract class to create a web view provider that
+     * serves web views and web view controllers of a specific `webViewType` to facilitate interaction
+     * between those web views and other extensions. You can register it with the PAPI using
+     * `papi.webViewProviders.register`.
+     *
+     * If you want to change your existing `IWebViewProvider` from a plain object to extending this
+     * class, you will need to change your object's existing method named `getWebView`
+     * ({@link IWebViewProvider.getWebView}) to be named `getWebViewDefinition`
+     * ({@link WebViewFactory.getWebViewDefinition}), which is a drop-in replacement. You likely do NOT
+     * want to overwrite this class's `getWebView` because that will eliminate most of the benefits
+     * associated with using this class.
+     *
+     * @see {@link IWebViewProvider} for more information on extending this class.
+     */
+    WebViewFactory: typeof PapiWebViewFactory;
     /** This is just an alias for internet.fetch */
     fetch: typeof globalThis.fetch;
     /**
@@ -6058,6 +6490,28 @@ declare module '@papi/backend' {
    * requirements.
    */
   export const LayeringProjectDataProviderEngineFactory: typeof PapiLayeringProjectDataProviderEngineFactory;
+  /**
+   *
+   * A partial implementation of {@link IWebViewProvider} that includes creating
+   * {@link WebViewControllers} for each web view served by the web view provider. This class handles
+   * registering, disposing, and making sure there is only one web view controller for each web view
+   * for you.
+   *
+   * You can create a new class extending this abstract class to create a web view provider that
+   * serves web views and web view controllers of a specific `webViewType` to facilitate interaction
+   * between those web views and other extensions. You can register it with the PAPI using
+   * `papi.webViewProviders.register`.
+   *
+   * If you want to change your existing `IWebViewProvider` from a plain object to extending this
+   * class, you will need to change your object's existing method named `getWebView`
+   * ({@link IWebViewProvider.getWebView}) to be named `getWebViewDefinition`
+   * ({@link WebViewFactory.getWebViewDefinition}), which is a drop-in replacement. You likely do NOT
+   * want to overwrite this class's `getWebView` because that will eliminate most of the benefits
+   * associated with using this class.
+   *
+   * @see {@link IWebViewProvider} for more information on extending this class.
+   */
+  export const WebViewFactory: typeof PapiWebViewFactory;
   /** This is just an alias for internet.fetch */
   export const fetch: typeof globalThis.fetch;
   /**
@@ -6853,6 +7307,33 @@ declare module 'renderer/hooks/papi-hooks/use-localized-strings-hook' {
   ) => [localizedStrings: LocalizationData, isLoading: boolean];
   export default useLocalizedStrings;
 }
+declare module 'renderer/hooks/papi-hooks/use-web-view-controller.hook' {
+  import { WebViewControllers } from 'papi-shared-types';
+  import { NetworkObject } from 'shared/models/network-object.model';
+  import { WebViewId } from 'shared/models/web-view.model';
+  /**
+   * Gets a Web View Controller with specified provider name
+   *
+   * @param webViewType `webViewType` that the web view controller must support. The TypeScript type
+   *   for the returned web view controller will have the web view controller interface type
+   *   associated with this `webViewType`. If the web view controller does not implement this
+   *   `webViewType` (according to its metadata), an error will be thrown.
+   * @param webViewId Id of the web view for which to get the web view controller OR
+   *   `webViewController` (result of `useWebViewController`, if you want this hook to just return the
+   *   controller again)
+   * @param pdpFactoryId Optional ID of the PDP factory from which to get the Web View Controller if
+   *   the PDP factory supports this project id and project interface. If not provided, then look in
+   *   all available PDP factories for the given project ID.
+   * @returns `undefined` if the Web View Controller has not been retrieved, the requested Web View
+   *   Controller if it has been retrieved and is not disposed, and undefined again if the Web View
+   *   Controller is disposed
+   */
+  const useWebViewController: <WebViewType extends keyof WebViewControllers>(
+    webViewType: WebViewType,
+    webViewId: WebViewId | NetworkObject<WebViewControllers[WebViewType]> | undefined,
+  ) => NetworkObject<WebViewControllers[WebViewType]> | undefined;
+  export default useWebViewController;
+}
 declare module 'renderer/hooks/papi-hooks/index' {
   export { default as useDataProvider } from 'renderer/hooks/papi-hooks/use-data-provider.hook';
   export { default as useData } from 'renderer/hooks/papi-hooks/use-data.hook';
@@ -6864,6 +7345,7 @@ declare module 'renderer/hooks/papi-hooks/index' {
   export { default as useDialogCallback } from 'renderer/hooks/papi-hooks/use-dialog-callback.hook';
   export { default as useDataProviderMulti } from 'renderer/hooks/papi-hooks/use-data-provider-multi.hook';
   export { default as useLocalizedStrings } from 'renderer/hooks/papi-hooks/use-localized-strings-hook';
+  export { default as useWebViewController } from 'renderer/hooks/papi-hooks/use-web-view-controller.hook';
 }
 declare module '@papi/frontend/react' {
   export * from 'renderer/hooks/papi-hooks/index';

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -14,6 +14,13 @@ declare module 'papi-shared-types' {
   import type { IDisposableDataProvider } from '@shared/models/data-provider.interface';
   import type IDataProvider from '@shared/models/data-provider.interface';
   import type ExtractDataProviderDataTypes from '@shared/models/extract-data-provider-data-types.model';
+  import type { NetworkableObject } from '@shared/models/network-object.model';
+  // Used in JSDocs
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  import type { WebViewFactory } from '@shared/models/web-view-factory.model';
+  // Used in JSDocs
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  import type { IWebViewProvider } from '@shared/models/web-view-provider.model';
 
   // #region Commands
 
@@ -529,6 +536,59 @@ declare module 'papi-shared-types' {
       DataProviders[DataProviderName]
     >;
   };
+
+  /**
+   * {@link NetworkableObject} types for each web view controller supported by PAPI. A Web View
+   * Controller is a network object that represents a web view and whose methods facilitate
+   * communication between its associated web view and extensions that want to interact with it.
+   * `WebViewControllers` can be created by {@link IWebViewProvider} of the same `webViewType`.
+   * Extensions can add web view controllers with corresponding `webViewType`s by adding details to
+   * their `.d.ts` file and registering a web view controller in their web view provider's
+   * `getWebView` function with `papi.webViewProviders.registerWebViewController`. If you want to
+   * create web view controllers, we recommend you create a class derived from the abstract class
+   * {@link WebViewFactory}, which automatically manage the lifecycle of the web view controllers for
+   * you.
+   *
+   * Note: The keys of this interface are the `webViewType`s for the web views associated with these
+   * web view controllers. They must consist of two strings separated by at least one period. We
+   * recommend one period and lower camel case in case we expand the api in the future to allow dot
+   * notation.
+   *
+   * An extension can extend this interface to add a type for the web view controller it registers
+   * by adding the following to its `.d.ts` file (in this example, we are adding the
+   * `'helloSomeone.peopleWebView'` web view controller type):
+   *
+   * @example
+   *
+   * ```typescript
+   * declare module 'papi-shared-types' {
+   *   export type PeopleWebViewController = NetworkableObject<{
+   *     setSelectedPerson(name: string): Promise<boolean>;
+   *     testRandomMethod(things: string): Promise<string>;
+   *   }>;
+   *
+   *   export interface WebViewControllers {
+   *     'helloSomeone.peopleWebView': PeopleWebViewController;
+   *   }
+   * }
+   * ```
+   */
+  export interface WebViewControllers {
+    'platform.stuffWebView': NetworkableObject<{ doStuff(thing: string): Promise<boolean> }>;
+    'platform.placeholderWebView': NetworkableObject<{
+      runPlaceholderStuff(thing: string): Promise<boolean>;
+    }>;
+  }
+
+  /**
+   * `webViewType`s for each web view controller available on the papi.
+   *
+   * Automatically includes all extensions' web view controllers that are added to
+   * {@link WebViewControllers}.
+   *
+   * @example 'platform.placeholderWebView'
+   */
+  export type WebViewControllerTypes = keyof WebViewControllers;
 
   // #endregion
 }

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -489,6 +489,7 @@ declare module 'papi-shared-types' {
    * ```
    */
   export interface DataProviders {
+    // These are examples. Feel free to take them out if we actually need to provide real ones in core
     'platform.stuff': IDataProvider<StuffDataTypes>;
     'platform.placeholder': IDataProvider<PlaceholderDataTypes>;
   }
@@ -574,6 +575,7 @@ declare module 'papi-shared-types' {
    * ```
    */
   export interface WebViewControllers {
+    // These are examples. Feel free to take them out if we actually need to provide real ones in core
     'platform.stuffWebView': NetworkableObject<{ doStuff(thing: string): Promise<boolean> }>;
     'platform.placeholderWebView': NetworkableObject<{
       runPlaceholderStuff(thing: string): Promise<boolean>;

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -1206,9 +1206,13 @@ async function reloadExtensions(
   isReloading = false;
   if (shouldReload) {
     (async () => {
-      await platformBibleUtils.wait(RESTART_DELAY_MS);
-      shouldReload = false;
-      reloadExtensions(shouldDeactivateExtensions, shouldEmitDidReloadEvent);
+      try {
+        await platformBibleUtils.wait(RESTART_DELAY_MS);
+        shouldReload = false;
+        await reloadExtensions(shouldDeactivateExtensions, shouldEmitDidReloadEvent);
+      } catch (e) {
+        logger.error(`Subsequent reload after initial reload extensions failed! ${e}`);
+      }
     })();
   }
 

--- a/src/extension-host/services/papi-backend.service.ts
+++ b/src/extension-host/services/papi-backend.service.ts
@@ -46,6 +46,7 @@ import { ISettingsService } from '@shared/services/settings.service-model';
 import settingsService from '@shared/services/settings.service';
 import { IProjectSettingsService } from '@shared/services/project-settings.service-model';
 import projectSettingsService from '@shared/services/project-settings.service';
+import { WebViewFactory as PapiWebViewFactory } from '@shared/models/web-view-factory.model';
 
 // IMPORTANT NOTES:
 // 1) When adding new services here, consider whether they also belong in papi-frontend.service.ts.
@@ -65,6 +66,8 @@ const papi = {
   BaseProjectDataProviderEngine: PapiBaseProjectDataProviderEngine,
   /** JSDOC DESTINATION LayeringProjectDataProviderEngineFactory */
   LayeringProjectDataProviderEngineFactory: PapiLayeringProjectDataProviderEngineFactory,
+  /** JSDOC DESTINATION WebViewFactory */
+  WebViewFactory: PapiWebViewFactory,
 
   // Functions
   /** This is just an alias for internet.fetch */
@@ -130,6 +133,9 @@ Object.freeze(papi.BaseProjectDataProviderEngine);
 /** JSDOC DESTINATION LayeringProjectDataProviderEngineFactory */
 export const { LayeringProjectDataProviderEngineFactory } = papi;
 Object.freeze(papi.LayeringProjectDataProviderEngineFactory);
+/** JSDOC DESTINATION WebViewFactory */
+export const { WebViewFactory } = papi;
+Object.freeze(papi.WebViewFactory);
 /** This is just an alias for internet.fetch */
 export const { fetch } = papi;
 Object.freeze(papi.fetch);

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -393,9 +393,7 @@ async function main() {
 
 async function restartExtensionHost() {
   logger.info('Restarting extension host');
-  await extensionHostService.waitForClose(PROCESS_CLOSE_TIME_OUT);
-  logger.debug('Extension host closed, restarting now');
-  await extensionHostService.start();
+  await extensionHostService.restart(PROCESS_CLOSE_TIME_OUT);
 }
 
 (async () => {

--- a/src/main/services/extension-host.service.ts
+++ b/src/main/services/extension-host.service.ts
@@ -88,7 +88,6 @@ async function restartExtensionHost(maxWaitTimeInMS: number) {
   }
   // Tells nodemon to restart the process https://github.com/remy/nodemon/blob/HEAD/doc/events.md#using-nodemon-as-child-process
   extensionHost?.send('restart');
-  return undefined;
 }
 
 function hardKillExtensionHost() {

--- a/src/main/services/extension-host.service.ts
+++ b/src/main/services/extension-host.service.ts
@@ -80,6 +80,17 @@ async function waitForExtensionHost(maxWaitTimeInMS: number) {
   if (!didExit) logger.warn(`Extension host did not exit within ${maxWaitTimeInMS.toString()} ms`);
 }
 
+async function restartExtensionHost(maxWaitTimeInMS: number) {
+  if (globalThis.isPackaged) {
+    await waitForExtensionHost(maxWaitTimeInMS);
+    logger.debug('Extension host closed, restarting now');
+    return startExtensionHost();
+  }
+  // Tells nodemon to restart the process https://github.com/remy/nodemon/blob/HEAD/doc/events.md#using-nodemon-as-child-process
+  extensionHost?.send('restart');
+  return undefined;
+}
+
 function hardKillExtensionHost() {
   if (!extensionHost) return;
 
@@ -165,7 +176,7 @@ async function startExtensionHost() {
         ...sharedArgs,
       ],
       {
-        stdio: ['ignore', 'pipe', 'pipe'],
+        stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
         env: { ...process.env, NODE_ENV: 'development' },
       },
     );
@@ -198,6 +209,7 @@ const extensionHostService = {
   start: startExtensionHost,
   kill: hardKillExtensionHost,
   waitForClose: waitForExtensionHost,
+  restart: restartExtensionHost,
 };
 
 export default extensionHostService;

--- a/src/main/services/rpc-server.ts
+++ b/src/main/services/rpc-server.ts
@@ -189,8 +189,10 @@ export default class RpcServer implements IRpcHandler {
     this.removeEventListenersFromWebSocket();
     this.connectionStatus = ConnectionStatus.Disconnected;
     this.rpcHandlerByMethodName.forEach((handler, methodName) => {
+      if (handler !== this) return;
+
       logger.info(`Method '${methodName}' removed since websocket ${this.name} closed`);
-      if (handler === this) this.rpcHandlerByMethodName.delete(methodName);
+      this.rpcHandlerByMethodName.delete(methodName);
     });
   }
 

--- a/src/renderer/components/web-view.component.tsx
+++ b/src/renderer/components/web-view.component.tsx
@@ -11,7 +11,7 @@ import {
   WEBVIEW_IFRAME_SRCDOC_SANDBOX,
   IFRAME_SANDBOX_ALLOW_POPUPS,
   updateWebViewDefinitionSync,
-  getWebViewNonce,
+  isWebViewNonceCorrect,
 } from '@renderer/services/web-view.service-host';
 import logger from '@shared/services/logger.service';
 import {
@@ -81,22 +81,18 @@ export default function WebView({
     ),
     useCallback(
       ([webViewNonce, message, targetOrigin]: Parameters<WebViewMessageRequestHandler>) => {
-        if (webViewNonce !== getWebViewNonce(id))
+        if (!isWebViewNonceCorrect(id, webViewNonce))
           throw new Error(
             `Web View Component ${id} (type ${webViewType}) received a message with an invalid nonce!`,
           );
-        if (!iframeRef.current) {
-          logger.error(
+        if (!iframeRef.current)
+          throw new Error(
             `Web View Component ${id} (type ${webViewType}) received a message but could not route it to the iframe because its ref was not set!`,
           );
-          return;
-        }
-        if (!iframeRef.current.contentWindow) {
-          logger.error(
+        if (!iframeRef.current.contentWindow)
+          throw new Error(
             `Web View Component ${id} (type ${webViewType}) received a message but could not route it to the iframe because its contentWindow was falsy!`,
           );
-          return;
-        }
 
         iframeRef.current.contentWindow.postMessage(message, { targetOrigin });
       },

--- a/src/renderer/hooks/papi-hooks/index.ts
+++ b/src/renderer/hooks/papi-hooks/index.ts
@@ -8,3 +8,4 @@ export { default as useProjectSetting } from '@renderer/hooks/papi-hooks/use-pro
 export { default as useDialogCallback } from '@renderer/hooks/papi-hooks/use-dialog-callback.hook';
 export { default as useDataProviderMulti } from '@renderer/hooks/papi-hooks/use-data-provider-multi.hook';
 export { default as useLocalizedStrings } from '@renderer/hooks/papi-hooks/use-localized-strings-hook';
+export { default as useWebViewController } from '@renderer/hooks/papi-hooks/use-web-view-controller.hook';

--- a/src/renderer/hooks/papi-hooks/use-web-view-controller.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-web-view-controller.hook.ts
@@ -1,0 +1,55 @@
+import { WebViewControllerTypes, WebViewControllers } from 'papi-shared-types';
+import createUseNetworkObjectHook from '@renderer/hooks/hook-generators/create-use-network-object-hook.util';
+import { NetworkObject } from '@shared/models/network-object.model';
+import webViewService from '@shared/services/web-view.service';
+import { WebViewId } from '@shared/models/web-view.model';
+
+/**
+ * Takes the parameters passed into the hook and returns the `webViewId` associated with those
+ * parameters.
+ *
+ * @param webViewType `webViewType` that the web view controller must support. The TypeScript type
+ *   for the returned web view controller will have the web view controller interface type
+ *   associated with this `webViewType`. If the web view controller does not implement this
+ *   `webViewType` (according to its metadata), an error will be thrown.
+ * @param webViewId Id of the web view for which to get the web view controller OR
+ *   `webViewController` (result of `useWebViewController`, if you want this hook to just return the
+ *   controller again)
+ * @returns `webViewId` for getting the web view controller
+ */
+function mapParametersToWebViewId<WebViewType extends WebViewControllerTypes>(
+  _webViewType: WebViewType,
+  webViewId: WebViewId | NetworkObject<WebViewControllers[WebViewType]> | undefined,
+) {
+  return webViewId;
+}
+
+/**
+ * Gets a Web View Controller with specified provider name
+ *
+ * @param webViewType `webViewType` that the web view controller must support. The TypeScript type
+ *   for the returned web view controller will have the web view controller interface type
+ *   associated with this `webViewType`. If the web view controller does not implement this
+ *   `webViewType` (according to its metadata), an error will be thrown.
+ * @param webViewId Id of the web view for which to get the web view controller OR
+ *   `webViewController` (result of `useWebViewController`, if you want this hook to just return the
+ *   controller again)
+ * @param pdpFactoryId Optional ID of the PDP factory from which to get the Web View Controller if
+ *   the PDP factory supports this project id and project interface. If not provided, then look in
+ *   all available PDP factories for the given project ID.
+ * @returns `undefined` if the Web View Controller has not been retrieved, the requested Web View
+ *   Controller if it has been retrieved and is not disposed, and undefined again if the Web View
+ *   Controller is disposed
+ */
+
+// Assert to specific data type for this hook.
+// eslint-disable-next-line no-type-assertion/no-type-assertion
+const useWebViewController = createUseNetworkObjectHook(
+  webViewService.getWebViewController,
+  mapParametersToWebViewId,
+) as <WebViewType extends WebViewControllerTypes>(
+  webViewType: WebViewType,
+  webViewId: WebViewId | NetworkObject<WebViewControllers[WebViewType]> | undefined,
+) => NetworkObject<WebViewControllers[WebViewType]> | undefined;
+
+export default useWebViewController;

--- a/src/renderer/services/dialog.service-host.ts
+++ b/src/renderer/services/dialog.service-host.ts
@@ -88,7 +88,7 @@ export function resolveDialogRequest<TReturn>(
     // We're not awaiting closing it. Doesn't really matter right now if we do or don't successfully close it
     (async () => {
       try {
-        const didClose = await webViewService.removeTab(id);
+        const didClose = await webViewService.closeTab(id);
         if (!didClose)
           logger.error(
             `DialogService error: dialog ${id} that was resolved with data ${serialize(
@@ -132,7 +132,7 @@ export function rejectDialogRequest(id: string, message: string) {
   // We're not awaiting closing it. Doesn't really matter right now if we do or don't successfully close it
   (async () => {
     try {
-      const didClose = await webViewService.removeTab(id);
+      const didClose = await webViewService.closeTab(id);
       if (!didClose)
         logger.error(
           `DialogService error: dialog ${id} that was rejected with error message ${message} was not found in the dock layout in order to close. Please investigate`,

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -47,8 +47,11 @@ import LogError from '@shared/log-error.model';
 import memoizeOne from 'memoize-one';
 import {
   AddWebViewEvent,
+  CloseWebViewEvent,
   EVENT_NAME_ON_DID_ADD_WEB_VIEW,
+  EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
   EVENT_NAME_ON_DID_UPDATE_WEB_VIEW,
+  getWebViewController,
   NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
   UpdateWebViewEvent,
   WebViewServiceType,
@@ -82,6 +85,14 @@ const onDidUpdateWebViewEmitter = createNetworkEventEmitter<UpdateWebViewEvent>(
 
 /** Event that emits with webView info when a webView is added */
 export const onDidUpdateWebView = onDidUpdateWebViewEmitter.event;
+
+/** Emitter for when a webview is removed */
+const onDidCloseWebViewEmitter = createNetworkEventEmitter<CloseWebViewEvent>(
+  EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
+);
+
+/** Event that emits with webView info when a webView is removed */
+export const onDidCloseWebView = onDidCloseWebViewEmitter.event;
 
 /**
  * Alias for `window.open` because `window.open` is deleted to prevent web views from accessing it.
@@ -521,7 +532,15 @@ function setDockLayout(dockLayout: PapiDockLayout | undefined): void {
  * @param newLayout The changed layout to save.
  */
 // TODO: We could filter whether we need to save based on the `direction` argument. - IJH 2023-05-1
-const onLayoutChange: OnLayoutChangeRCDock = async (newLayout) => {
+const onLayoutChange: OnLayoutChangeRCDock = async (
+  newLayout,
+  _currentTabId,
+  direction,
+  webViewDefinition,
+) => {
+  if (direction === 'remove' && webViewDefinition)
+    onDidCloseWebViewEmitter.emit({ webView: convertWebViewDefinitionToSaved(webViewDefinition) });
+
   return saveLayout(newLayout);
 };
 
@@ -620,12 +639,12 @@ export const addTab = async <TData = unknown>(
 };
 
 /**
- * Remove a tab in the layout
+ * Closes a tab in the layout
  *
- * @param tabId ID of the tab to remove
- * @returns True if successfully found the tab to remove
+ * @param tabId ID of the tab to close
+ * @returns True if successfully found the tab to close
  */
-export const removeTab = async (tabId: string): Promise<boolean> => {
+export const closeTab = async (tabId: string): Promise<boolean> => {
   return (await getDockLayout()).removeTabFromDock(tabId);
 };
 
@@ -657,7 +676,7 @@ export function saveTabInfoBase(tabInfo: TabInfo): SavedTabInfo {
  * @throws If the papi dock layout has not been registered
  */
 export function updateWebViewDefinitionSync(
-  webViewId: string,
+  webViewId: WebViewId,
   webViewDefinitionUpdateInfo: WebViewDefinitionUpdateInfo,
 ): boolean {
   const didUpdateWebView = getDockLayoutSync().updateWebViewDefinition(
@@ -733,8 +752,8 @@ export function convertWebViewDefinitionToSaved(
 }
 
 /** Explanation in web-view.service-model.ts */
-async function getSavedWebViewDefinition(
-  webViewId: string,
+async function getOpenWebViewDefinition(
+  webViewId: WebViewId,
 ): Promise<SavedWebViewDefinition | undefined> {
   const webViewDefinition = (await getDockLayout()).getWebViewDefinition(webViewId);
   if (webViewDefinition === undefined) return undefined;
@@ -751,7 +770,7 @@ async function getSavedWebViewDefinition(
  * @throws If the papi dock layout has not been registered
  */
 export function getSavedWebViewDefinitionSync(
-  webViewId: string,
+  webViewId: WebViewId,
 ): SavedWebViewDefinition | undefined {
   const webViewDefinition = getDockLayoutSync().getWebViewDefinition(webViewId);
   if (webViewDefinition === undefined) return undefined;
@@ -774,14 +793,63 @@ function getWebViewOptionsDefaults(options: GetWebViewOptions): GetWebViewOption
 
 // #endregion
 
-// #region Set up global variables to use in `getWebView`'s `imports` below
+// #region webViewNonce
+
+/**
+ * Map of web view id to `webViewNonce` for that web view. `webViewNonce`s are used to perform
+ * privileged interactions with the web view such as `papi.webViewProviders.postMessageToWebView`.
+ * The web view service generates this nonce and sends it _only_ to the web view provider that
+ * creates the web view. It is generally recommended that this web view provider not share this
+ * nonce with anyone else but only use it within itself and in the web view controller created for
+ * this web view if applicable (See `papi.webViewProviders.registerWebViewController`)
+ */
+const webViewNoncesById = new Map<WebViewId, string>();
+
+/**
+ * Get an existing `webViewNonce` or generate one if one did not already exist.
+ *
+ * WARNING: DO NOT SHARE THIS VALUE. `webViewNonce`s are PRIVILEGED INFORMATION and are not to be
+ * shared except with the web view provider that creates a web view. See {@link webViewNoncesById}
+ * for more info.
+ */
+export function getWebViewNonce(id: WebViewId) {
+  const existingNonce = webViewNoncesById.get(id);
+
+  if (existingNonce) return existingNonce;
+
+  const nonce = newNonce();
+  webViewNoncesById.set(id, nonce);
+
+  return nonce;
+}
+
+/**
+ * Delete a web view nonce. Should be done when the web view is closed.
+ *
+ * @returns `true` if successfully deleted a nonce for this id; `false` if there was not a nonce for
+ *   this id
+ */
+function deleteWebViewNonce(id: WebViewId) {
+  return webViewNoncesById.delete(id);
+}
+
+onDidCloseWebView(({ webView: { id, webViewType } }) => {
+  if (!deleteWebViewNonce(id))
+    logger.warn(
+      `Tried to delete webViewNonce for web view with id ${id} (type ${webViewType}), but a nonce was not found. May not be an issue, but worth investigating`,
+    );
+});
+
+// #endregion
+
+// #region Set up global variables to use in `openWebView`'s `imports` below
 
 globalThis.getSavedWebViewDefinitionById = getSavedWebViewDefinitionSync;
 globalThis.updateWebViewDefinitionById = updateWebViewDefinitionSync;
 
 // #endregion
 
-// #region getWebView
+// #region openWebView
 
 /**
  * Creates a new web view or gets an existing one depending on if you request an existing one and if
@@ -795,7 +863,7 @@ globalThis.updateWebViewDefinitionById = updateWebViewDefinitionSync;
  *   not create a WebView for this request.
  * @throws If something went wrong like the provider for the webViewType was not found
  */
-export const getWebView = async (
+export const openWebView = async (
   webViewType: WebViewType,
   layout: Layout = { type: 'tab' },
   options: GetWebViewOptions = {},
@@ -853,10 +921,17 @@ export const getWebView = async (
   }
 
   // Create the new webview or load if it already existed
-  const webView = await webViewProvider.getWebView(existingSavedWebView, optionsDefaulted);
+  const webView = await webViewProvider.getWebView(
+    existingSavedWebView,
+    optionsDefaulted,
+    getWebViewNonce(existingSavedWebView.id),
+  );
 
   // The web view provider didn't want to create this web view
-  if (!webView) return undefined;
+  if (!webView) {
+    deleteWebViewNonce(existingSavedWebView.id);
+    return undefined;
+  }
 
   // Set up WebViewDefinition default values
   /** WebView.contentType is assumed to be React by default. Extensions can specify otherwise */
@@ -917,6 +992,7 @@ export const getWebView = async (
   var getWebViewStateById = window.parent.getWebViewStateById;
   var setWebViewStateById = window.parent.setWebViewStateById;
   var resetWebViewStateById = window.parent.resetWebViewStateById;
+  window.webViewId = '${webView.id}';
   window.getWebViewState = (stateKey, defaultValue) => { return getWebViewStateById('${webView.id}', stateKey, defaultValue) };
   window.setWebViewState = (stateKey, stateValue) => { setWebViewStateById('${webView.id}', stateKey, stateValue) };
   window.resetWebViewState = (stateKey) => { resetWebViewStateById('${webView.id}', stateKey) };
@@ -1300,13 +1376,17 @@ export const initialize = () => {
 const papiWebViewService: WebViewServiceType = {
   onDidAddWebView,
   onDidUpdateWebView,
-  getWebView,
-  getSavedWebViewDefinition,
+  onDidCloseWebView,
+  getWebView: openWebView,
+  openWebView,
+  getSavedWebViewDefinition: getOpenWebViewDefinition,
+  getOpenWebViewDefinition,
+  getWebViewController,
 };
 
-async function openProjectSettingsTab(webViewId: string): Promise<Layout | undefined> {
+async function openProjectSettingsTab(webViewId: WebViewId): Promise<Layout | undefined> {
   const settingsTabId = newGuid();
-  const projectIdFromWebView = (await getSavedWebViewDefinition(webViewId))?.projectId;
+  const projectIdFromWebView = (await getOpenWebViewDefinition(webViewId))?.projectId;
 
   if (!projectIdFromWebView) return undefined;
 

--- a/src/shared/global-this.model.ts
+++ b/src/shared/global-this.model.ts
@@ -7,6 +7,7 @@ import {
   UseWebViewScrollGroupScrRefHook,
   UseWebViewStateHook,
   WebViewDefinitionUpdateInfo,
+  WebViewId,
   WebViewProps,
 } from '@shared/models/web-view.model';
 
@@ -33,6 +34,8 @@ declare global {
    * in WebView iframes.
    */
   var webViewComponent: FunctionComponent<WebViewProps>;
+  /** The id of the current web view. Only used in WebView iframes. */
+  var webViewId: WebViewId;
   /** JSDOC DESTINATION UseWebViewStateHook */
   var useWebViewState: UseWebViewStateHook;
   /** JSDOC DESTINATION UseWebViewScrollGroupScrRefHook */

--- a/src/shared/models/docking-framework.model.ts
+++ b/src/shared/models/docking-framework.model.ts
@@ -123,6 +123,10 @@ export type WebViewTabProps = WebViewDefinition;
  * Rc-dock's onLayoutChange prop made asynchronous with `webViewDefinition` added. The dock layout
  * component calls this on the web view service when the layout changes.
  *
+ * @param newLayout The changed layout to save.
+ * @param currentTabId The tab being changed
+ * @param direction The direction the tab is being moved (or deleted or other things - RCDock uses
+ *   the word "direction" here loosely)
  * @param webViewDefinition The web view definition if the edit was on a web view; `undefined`
  *   otherwise
  * @returns Promise that resolves when finished doing things

--- a/src/shared/models/docking-framework.model.ts
+++ b/src/shared/models/docking-framework.model.ts
@@ -119,11 +119,19 @@ export type Layout = TabLayout | FloatLayout | PanelLayout;
 /** Props that are passed to the web view tab component */
 export type WebViewTabProps = WebViewDefinition;
 
-/** Rc-dock's onLayoutChange prop made asynchronous - resolves */
+/**
+ * Rc-dock's onLayoutChange prop made asynchronous with `webViewDefinition` added. The dock layout
+ * component calls this on the web view service when the layout changes.
+ *
+ * @param webViewDefinition The web view definition if the edit was on a web view; `undefined`
+ *   otherwise
+ * @returns Promise that resolves when finished doing things
+ */
 export type OnLayoutChangeRCDock = (
   newLayout: LayoutBase,
   currentTabId?: string,
   direction?: DropDirection,
+  webViewDefinition?: WebViewDefinition,
 ) => Promise<void>;
 
 /** Properties related to the dock layout */

--- a/src/shared/models/web-view-factory.model.ts
+++ b/src/shared/models/web-view-factory.model.ts
@@ -88,7 +88,7 @@ export abstract class WebViewFactory<WebViewType extends WebViewControllerTypes>
       if (!webViewDefinition) return webViewDefinition;
 
       if (webViewDefinition.id !== webViewId)
-        logger.warn(
+        throw new Error(
           `${this.webViewType} WebViewFactory changed web view id from ${webViewId} to ${webViewDefinition.id} while in getWebViewDefinition. This is not expected and could cause problems. Attempting to continue with new id.`,
         );
 

--- a/src/shared/models/web-view-factory.model.ts
+++ b/src/shared/models/web-view-factory.model.ts
@@ -1,0 +1,199 @@
+/* eslint-disable import/prefer-default-export */
+import { WebViewControllers, WebViewControllerTypes } from 'papi-shared-types';
+import type { IWebViewProvider } from '@shared/models/web-view-provider.model';
+import {
+  SavedWebViewDefinition,
+  GetWebViewOptions,
+  WebViewDefinition,
+} from '@shared/models/web-view.model';
+import { MutexMap, UnsubscriberAsyncList } from 'platform-bible-utils';
+import { DisposableNetworkObject } from '@shared/models/network-object.model';
+import webViewProviderService from '@shared/services/web-view-provider.service';
+import logger from '@shared/services/logger.service';
+import { overrideDispose } from '@shared/services/network-object.service';
+
+/**
+ * JSDOC SOURCE WebViewFactory
+ *
+ * A partial implementation of {@link IWebViewProvider} that includes creating
+ * {@link WebViewControllers} for each web view served by the web view provider. This class handles
+ * registering, disposing, and making sure there is only one web view controller for each web view
+ * for you.
+ *
+ * You can create a new class extending this abstract class to create a web view provider that
+ * serves web views and web view controllers of a specific `webViewType` to facilitate interaction
+ * between those web views and other extensions. You can register it with the PAPI using
+ * `papi.webViewProviders.register`.
+ *
+ * If you want to change your existing `IWebViewProvider` from a plain object to extending this
+ * class, you will need to change your object's existing method named `getWebView`
+ * ({@link IWebViewProvider.getWebView}) to be named `getWebViewDefinition`
+ * ({@link WebViewFactory.getWebViewDefinition}), which is a drop-in replacement. You likely do NOT
+ * want to overwrite this class's `getWebView` because that will eliminate most of the benefits
+ * associated with using this class.
+ *
+ * @see {@link IWebViewProvider} for more information on extending this class.
+ */
+export abstract class WebViewFactory<WebViewType extends WebViewControllerTypes>
+  implements IWebViewProvider
+{
+  private readonly webViewControllersMutexMap = new MutexMap();
+  private readonly webViewControllersCleanupList: UnsubscriberAsyncList;
+  private readonly webViewControllersById = new Map<
+    string,
+    DisposableNetworkObject<WebViewControllers[WebViewType]>
+  >();
+
+  constructor(readonly webViewType: WebViewType) {
+    this.webViewControllersCleanupList = new UnsubscriberAsyncList(
+      `WebViewFactory for webViewType ${webViewType}`,
+    );
+  }
+
+  /**
+   * Receives a {@link SavedWebViewDefinition} and fills it out into a full {@link WebViewDefinition},
+   * providing the contents of the web view and other properties that are important for displaying
+   * the web view.
+   *
+   * WARNING: This method must NOT be overridden if you want any of the benefits of this class. You
+   * are probably looking for {@link WebViewFactory.getWebViewDefinition}.
+   *
+   * If you are transferring a web view provider using a plain object to extending this class, you
+   * should rename your existing `getWebView` to `getWebViewDefinition`.
+   */
+  async getWebView(
+    savedWebViewDefinition: SavedWebViewDefinition,
+    getWebViewOptions: GetWebViewOptions,
+    webViewNonce: string,
+  ): Promise<WebViewDefinition | undefined> {
+    const webViewId = savedWebViewDefinition.id;
+    // Don't allow simultaneous gets to run for the same web view id as an easy way to make sure we
+    // don't create multiple of the same web view controller. Not really expecting this to happen,
+    // but it's good to be sure.
+    const lock = this.webViewControllersMutexMap.get(webViewId);
+    return lock.runExclusive(async () => {
+      if (this.webViewType !== savedWebViewDefinition.webViewType)
+        throw new Error(
+          `${this.webViewType} WebViewFactory received request to provide a ${savedWebViewDefinition.webViewType} web view`,
+        );
+
+      const webViewDefinition = await this.getWebViewDefinition(
+        savedWebViewDefinition,
+        getWebViewOptions,
+        webViewNonce,
+      );
+
+      // If the web view provider doesn't want to create a web view right now, don't create a web view
+      // controller
+      if (!webViewDefinition) return webViewDefinition;
+
+      if (webViewDefinition.id !== webViewId)
+        logger.warn(
+          `${this.webViewType} WebViewFactory changed web view id from ${webViewId} to ${webViewDefinition.id} while in getWebViewDefinition. This is not expected and could cause problems. Attempting to continue with new id.`,
+        );
+
+      // If there is already a web view controller for this web view (so the web view is reloading),
+      // return instead of creating a new web view controller
+      const existingWebViewController = this.webViewControllersById.get(webViewDefinition.id);
+      if (existingWebViewController) return webViewDefinition;
+
+      // Create the web view controller (implementation-dependent)
+      const unregisteredWebViewController = await this.createWebViewController(
+        webViewDefinition,
+        webViewNonce,
+      );
+
+      // Make sure the web view controller gets removed from this provider's map so we can create a
+      // new one later if needed for some reason
+      overrideDispose(unregisteredWebViewController, async () => {
+        if (!this.webViewControllersById.delete(webViewDefinition.id))
+          logger.warn(
+            `${this.webViewType} web view controller with id ${webViewDefinition.id} was not found in its WebViewFactory in order to remove from the map. This could cause issues with not creating a new web view controller if needed. Attempting to continue.`,
+          );
+        return true;
+      });
+
+      // Register the web view controller
+      const webViewController = await webViewProviderService.registerWebViewController(
+        this.webViewType,
+        webViewDefinition.id,
+        unregisteredWebViewController,
+      );
+
+      this.webViewControllersCleanupList.add(webViewController);
+      this.webViewControllersById.set(webViewDefinition.id, webViewController);
+
+      return webViewDefinition;
+    });
+  }
+
+  /** Disposes of all WVCs that were created by this provider */
+  async dispose(): Promise<boolean> {
+    return this.webViewControllersCleanupList.runAllUnsubscribers();
+  }
+
+  /**
+   * Receives a {@link SavedWebViewDefinition} and fills it out into a full {@link WebViewDefinition},
+   * providing the contents of the web view and other properties that are important for displaying
+   * the web view.
+   *
+   * {@link WebViewFactory} calls this as part of its {@link getWebView}, which is called by the PAPI
+   * as part of opening a new web view. It will also create a web view controller after running this
+   * if applicable.
+   *
+   * See {@link IWebViewProvider.getWebView} for more information on how this method works.
+   *
+   * @param savedWebViewDefinition The saved web view information from which to build a complete web
+   *   view definition. Filled out with all {@link SavedWebViewDefinition} properties of the existing
+   *   web view if an existing webview is being called for (matched by ID). Just provides the
+   *   minimal properties required on {@link SavedWebViewDefinition} if this is a new request or if
+   *   the web view with the existing ID was not found.
+   * @param getWebViewOptions Various options that affect what calling `papi.webViews.openWebView`
+   *   should do. When options are passed to `papi.webViews.openWebView`, some defaults are set up
+   *   on the options, then those options are passed directly through to this method. That way, if
+   *   you want to adjust what this method does based on the contents of the options passed to
+   *   `papi.WebViews.openWebView`, you can. You can even read other properties on these options if
+   *   someone passes options with other properties to `papi.webViews.openWebView`.
+   * @param webViewNonce Nonce used to perform privileged interactions with the web view created
+   *   from this method's returned {@link WebViewDefinition} such as
+   *   `papi.webViewProviders.postMessageToWebView`. The web view service generates this nonce and
+   *   sends it _only here_ to this web view provider that creates the web view with this id. It is
+   *   generally recommended that this web view provider not share this nonce with anyone else but
+   *   only use it within itself and in the web view controller created for this web view if
+   *   applicable (See `papi.webViewProviders.registerWebViewController`).
+   * @returns Full {@link WebViewDefinition} including the content and other important display
+   *   properties based on the {@link SavedWebViewDefinition} provided
+   */
+  abstract getWebViewDefinition(
+    savedWebViewDefinition: SavedWebViewDefinition,
+    getWebViewOptions: GetWebViewOptions,
+    webViewNonce: string,
+  ): Promise<WebViewDefinition | undefined>;
+
+  /**
+   * Creates a {@link WebViewController} that corresponds to the {@link WebViewDefinition} provided.
+   * {@link WebViewFactory} calls this as part of its {@link getWebView}. {@link WebViewFactory} will
+   * automatically register this controller with the web view provider service
+   * (`papi.webViewProviders.registerWebViewController`), run its `dispose` when the web view is
+   * closed or this `WebViewFactory` is disposed, and make sure just one web view controller is
+   * created for each web view.
+   *
+   * Alternatively, if you do not want to create web view controllers (or a controller for a
+   * specific web view), feel free to return `undefined` from this method.
+   *
+   * @param webViewDefinition The definition for the web view for which to create a web view
+   *   controller
+   * @param webViewNonce Nonce used to perform privileged interactions with the web view created
+   *   from the `webViewDefinition` parameter such as `papi.webViewProviders.postMessageToWebView`.
+   *   The web view service generates this nonce and sends it _only here_ to this web view provider
+   *   that creates the web view with this id. It is generally recommended that this web view
+   *   provider not share this nonce with anyone else but only use it within itself and here in the
+   *   web view controller created for this web view.
+   * @returns Web view controller for the web view with the `webViewDefinition` provided. Or
+   *   `undefined` if you do not want to create a web view controller for this web view.
+   */
+  abstract createWebViewController(
+    webViewDefinition: WebViewDefinition,
+    webViewNonce: string,
+  ): Promise<WebViewControllers[WebViewType]>;
+}

--- a/src/shared/models/web-view-provider.model.ts
+++ b/src/shared/models/web-view-provider.model.ts
@@ -8,28 +8,79 @@ import {
   NetworkObject,
   NetworkableObject,
 } from '@shared/models/network-object.model';
-import { CanHaveOnDidDispose } from 'platform-bible-utils';
+// Used in JSDocs
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { WebViewFactory } from '@shared/models/web-view-factory.model';
+// Used in JSDocs
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import type { WebViewControllers } from 'papi-shared-types';
 
-// What the developer registers
+/**
+ * An object associated with a specific `webViewType` that provides a {@link WebViewDefinition} when
+ * the PAPI wants to open a web view with that `webViewType`. An extension registers a web view
+ * provider with `papi.webViewProviders.register`.
+ *
+ * Web View Providers provide the contents of all web views in Platform.Bible.
+ *
+ * If you want to provide {@link WebViewControllers} to facilitate interaction between your web views
+ * and extensions, you can extend the abstract class {@link WebViewFactory} to make the process
+ * easier. Alternatively, if you want to manage web view controllers manually, you can register them
+ * in {@link IWebViewProvider.getWebView}.
+ */
 export interface IWebViewProvider extends NetworkableObject {
   /**
-   * @param savedWebView Filled out if an existing webview is being called for (matched by ID). Just
-   *   ID if this is a new request or if the web view with the existing ID was not found
-   * @param getWebViewOptions
+   * Receives a {@link SavedWebViewDefinition} and fills it out into a full {@link WebViewDefinition},
+   * providing the contents of the web view and other properties that are important for displaying
+   * the web view.
+   *
+   * The PAPI calls this method as part of opening a new web view or (re)loading an existing web
+   * view. If you want to create {@link WebViewControllers} for the web views the PAPI creates from
+   * this method, you should register it using `papi.webViewProviders.registerWebViewController`
+   * before returning from this method (resolving the returned promise). The {@link WebViewFactory}
+   * abstract class handles this for you, so please consider extending it.
+   *
+   * @param savedWebViewDefinition The saved web view information from which to build a complete web
+   *   view definition. Filled out with all {@link SavedWebViewDefinition} properties of the existing
+   *   web view if an existing webview is being called for (matched by ID). Just provides the
+   *   minimal properties required on {@link SavedWebViewDefinition} if this is a new request or if
+   *   the web view with the existing ID was not found.
+   * @param getWebViewOptions Various options that affect what calling `papi.webViews.openWebView`
+   *   should do. When options are passed to `papi.webViews.openWebView`, some defaults are set up
+   *   on the options, then those options are passed directly through to this method. That way, if
+   *   you want to adjust what this method does based on the contents of the options passed to
+   *   `papi.WebViews.openWebView`, you can. You can even read other properties on these options if
+   *   someone passes options with other properties to `papi.webViews.openWebView`.
+   * @param webViewNonce Nonce used to perform privileged interactions with the web view created
+   *   from this method's returned {@link WebViewDefinition} such as
+   *   `papi.webViewProviders.postMessageToWebView`. The web view service generates this nonce and
+   *   sends it _only here_ to this web view provider that creates the web view with this id. It is
+   *   generally recommended that this web view provider not share this nonce with anyone else but
+   *   only use it within itself and in the web view controller created for this web view if
+   *   applicable (See `papi.webViewProviders.registerWebViewController`).
+   * @returns Full {@link WebViewDefinition} including the content and other important display
+   *   properties based on the {@link SavedWebViewDefinition} provided
    */
   getWebView(
-    savedWebView: SavedWebViewDefinition,
+    savedWebViewDefinition: SavedWebViewDefinition,
     getWebViewOptions: GetWebViewOptions,
+    webViewNonce: string,
   ): Promise<WebViewDefinition | undefined>;
 }
 
-// What the papi gives on get. Basically a layer over NetworkObject
-export interface WebViewProvider
-  extends NetworkObject<NetworkableObject>,
-    CanHaveOnDidDispose<IWebViewProvider> {}
+/**
+ * A web view provider that has been registered with the PAPI.
+ *
+ * This is what the papi gives on `webViewProviderService.get` (not exposed on the PAPI). Basically
+ * a layer over NetworkObject
+ *
+ * This type is internal to core and is not used by extensions
+ */
+export interface IRegisteredWebViewProvider extends NetworkObject<IWebViewProvider> {}
 
-// What the papi returns on register. Basically a layer over DisposableNetworkObject
-export interface DisposableWebViewProvider
-  extends DisposableNetworkObject<NetworkableObject>,
-    // Need to omit dispose here because it is optional on WebViewProvider but is required on DisposableNetworkObject
-    Omit<WebViewProvider, 'dispose'> {}
+/**
+ * A web view provider that has been registered with the PAPI and returned to the extension that
+ * registered it. It is able to be disposed with `dispose`.
+ *
+ * The PAPI returns this type from `papi.webViewProviders.register`.
+ */
+export interface IDisposableWebViewProvider extends DisposableNetworkObject<IWebViewProvider> {}

--- a/src/shared/models/web-view.model.ts
+++ b/src/shared/models/web-view.model.ts
@@ -32,7 +32,61 @@ type WebViewDefinitionBase = {
   webViewType: WebViewType;
   /** Unique ID among webviews specific to this webview instance. */
   id: WebViewId;
-  /** The code for the WebView that papi puts into an iframe */
+  /**
+   * The content for the WebView that papi puts into an iframe. This field differs significantly
+   * depending on which `contentType` you use in your `WebViewDefinition` as described below. If you
+   * are using a React or HTML WebView, you will probably want to use a bundler to bundle your code
+   * together and provide it here.
+   * [`paranext-extension-template`](https://github.com/paranext/paranext-extension-template) is set
+   * up for this use case. Feel free to use it for your extension!
+   *
+   *     ---
+   *
+   * **For React WebViews (default):** string containing all the code you want to run in the iframe
+   * on the frontend. You should set a function component to `globalThis.webViewComponent` in this
+   * code.
+   *
+   * For example, you could pass the bundled output of the following code to as your React Web View
+   * `content`:
+   *
+   * ```tsx
+   * globalThis.webViewComponent = function MyWebView() {
+   *  return <div>Hello World!! This is my React WebView!</div>;
+   * }
+   * ```
+   *
+   * **For HTML WebViews:** string containing all the code you want to run in the iframe on the
+   * frontend. This should be a complete HTML document. Usually,
+   *
+   * For example, you could pass the following string as your HTML Web View `content`:
+   *
+   * ```html
+   * <html>
+   *   <head>
+   *     <style>
+   *       .title {
+   *         color: darkgreen;
+   *       }
+   *     </style>
+   *   </head>
+   *   <body>
+   *     <div class="title">Hello World!! This is my HTML Web View!</div>
+   *   </body>
+   * </html>
+   * ```
+   *
+   *     ---
+   *
+   * **For URL WebViews:** the url you want to load into the iframe on the frontend.
+   *
+   * Note: URL WebViews must have `papi-extension:` or `https:` urls.
+   *
+   * For example, you could pass the following string as your URL Web View `content`:
+   *
+   * ```plain
+   * https://example.com/
+   * ```
+   */
   content: string;
   /**
    * Url of image to show on the title bar of the tab

--- a/src/shared/services/papi-core.service.ts
+++ b/src/shared/services/papi-core.service.ts
@@ -25,6 +25,7 @@ export type {
 export type { WithNotifyUpdate } from '@shared/models/data-provider-engine.model';
 export type { default as IDataProviderEngine } from '@shared/models/data-provider-engine.model';
 export type { DialogOptions } from '@shared/models/dialog-options.model';
+export type { NetworkableObject, NetworkObject } from '@shared/models/network-object.model';
 export type {
   ExtensionDataScope,
   MandatoryProjectDataTypes,
@@ -58,7 +59,10 @@ export type {
   WebViewDefinition,
   WebViewProps,
 } from '@shared/models/web-view.model';
-export type { IWebViewProvider } from '@shared/models/web-view-provider.model';
+export type {
+  IDisposableWebViewProvider,
+  IWebViewProvider,
+} from '@shared/models/web-view-provider.model';
 export type {
   SimultaneousProjectSettingsChanges,
   ProjectSettingValidator,

--- a/src/shared/services/web-view-provider.service.ts
+++ b/src/shared/services/web-view-provider.service.ts
@@ -239,8 +239,8 @@ async function registerWebViewController<WebViewType extends WebViewControllerTy
   });
 
   if (webViewControllersById.has(webViewId))
-    logger.warn(
-      `Web view provider service is setting web view controller with id ${webViewId} (type ${webViewType}) in the map over an existing web view. This is not expected.`,
+    throw new Error(
+      `Web view provider service tried to set web view controller with id ${webViewId} (type ${webViewType}) in the map over an existing web view.`,
     );
   webViewControllersById.set(webViewId, disposableWebViewController);
 

--- a/src/shared/services/web-view-provider.service.ts
+++ b/src/shared/services/web-view-provider.service.ts
@@ -4,22 +4,58 @@
  */
 
 import {
-  DisposableWebViewProvider,
+  IDisposableWebViewProvider,
   IWebViewProvider,
-  WebViewProvider,
+  IRegisteredWebViewProvider,
 } from '@shared/models/web-view-provider.model';
-import networkObjectService from '@shared/services/network-object.service';
+import networkObjectService, { overrideDispose } from '@shared/services/network-object.service';
 import * as networkService from '@shared/services/network.service';
 import logger from '@shared/services/logger.service';
 import { isSerializable } from 'platform-bible-utils';
 import networkObjectStatusService from '@shared/services/network-object-status.service';
+import { WebViewControllers, WebViewControllerTypes } from 'papi-shared-types';
+import { DisposableNetworkObject } from '@shared/models/network-object.model';
+import webViewService from '@shared/services/web-view.service';
+import {
+  getWebViewControllerObjectId,
+  getWebViewMessageRequestType,
+  WEB_VIEW_CONTROLLER_OBJECT_TYPE,
+  WebViewMessageRequestHandler,
+} from '@shared/services/web-view.service-model';
+import { WebViewId } from '@shared/models/web-view.model';
 
-/** Suffix on network objects that indicates that the network object is a data provider */
+/** Suffix on network objects that indicates that the network object is a web view provider */
 const WEB_VIEW_PROVIDER_LABEL = 'webViewProvider';
 
-/** Gets the id for the web view network object with the given name */
+/** Gets the id for the web view provider network object with the given name */
 const getWebViewProviderObjectId = (webViewType: string) =>
   `${webViewType}-${WEB_VIEW_PROVIDER_LABEL}`;
+
+/** Network object type for web view providers */
+const WEB_VIEW_PROVIDER_OBJECT_TYPE = 'webViewProvider';
+
+/**
+ * Map of web view controllers by web view id. Used to dispose of web view controllers when their
+ * web view closes
+ */
+const webViewControllersById = new Map<
+  string,
+  DisposableNetworkObject<WebViewControllers[WebViewControllerTypes]>
+>();
+
+// Dispose of web view controllers when their associated web view is closed
+webViewService.onDidCloseWebView(async ({ webView }) => {
+  const webViewController = webViewControllersById.get(webView.id);
+  if (!webViewController) return;
+
+  try {
+    if (!(await webViewController.dispose())) throw new Error('dispose returned false!');
+  } catch (e) {
+    logger.warn(
+      `Web View Provider service failed to dispose of web view controller for id ${webView.id} (type ${webView.webViewType}) when the web view was closed! ${e}`,
+    );
+  }
+});
 
 /** Whether this service has finished setting up */
 let isInitialized = false;
@@ -50,7 +86,7 @@ const initialize = () => {
  *
  * @param webViewType Type of webView to check for
  */
-function hasKnown(webViewType: string): boolean {
+function hasKnownWebViewProvider(webViewType: string): boolean {
   return networkObjectService.hasKnown(getWebViewProviderObjectId(webViewType));
 }
 
@@ -62,15 +98,15 @@ function hasKnown(webViewType: string): boolean {
  *   of it.
  *
  *   WARNING: setting a webView provider mutates the provided object.
- * @returns `webViewProvider` modified to be a network object
+ * @returns `webViewProvider` modified to be a network object and able to be disposed with `dispose`
  */
 async function register(
   webViewType: string,
   webViewProvider: IWebViewProvider,
-): Promise<DisposableWebViewProvider> {
+): Promise<IDisposableWebViewProvider> {
   await initialize();
 
-  if (hasKnown(webViewType))
+  if (hasKnownWebViewProvider(webViewType))
     throw new Error(`WebView provider for WebView type ${webViewType} is already registered`);
 
   // Validate that the WebView provider has what it needs
@@ -99,9 +135,11 @@ async function register(
   const webViewProviderObjectId = getWebViewProviderObjectId(webViewType);
 
   // Set up the WebView provider to be a network object so other processes can use it
-  const disposableWebViewProvider: DisposableWebViewProvider = await networkObjectService.set(
+  const disposableWebViewProvider: IDisposableWebViewProvider = await networkObjectService.set(
     webViewProviderObjectId,
     webViewProvider,
+    WEB_VIEW_PROVIDER_OBJECT_TYPE,
+    { webViewType },
   );
 
   return disposableWebViewProvider;
@@ -113,7 +151,7 @@ async function register(
  * @param webViewType Type of webview provider to get
  * @returns Web view provider with the given name if one exists, undefined otherwise
  */
-async function get(webViewType: string): Promise<WebViewProvider | undefined> {
+async function get(webViewType: string): Promise<IRegisteredWebViewProvider | undefined> {
   await initialize();
 
   // Get the object id for this web view provider name
@@ -125,7 +163,8 @@ async function get(webViewType: string): Promise<WebViewProvider | undefined> {
     20000,
   );
 
-  const webViewProvider = await networkObjectService.get<WebViewProvider>(webViewProviderObjectId);
+  const webViewProvider =
+    await networkObjectService.get<IRegisteredWebViewProvider>(webViewProviderObjectId);
 
   if (!webViewProvider) {
     logger.info(`No WebView provider found for WebView type ${webViewType}`);
@@ -135,23 +174,133 @@ async function get(webViewType: string): Promise<WebViewProvider | undefined> {
   return webViewProvider;
 }
 
+/**
+ * Indicate if we are aware of an existing web view provider with the given type. If a web view
+ * provider with the given type is somewhere else on the network, this function won't tell you about
+ * it unless something else in the existing process is subscribed to it.
+ *
+ * @param webViewType Type of webView to check for
+ */
+function hasKnownWebViewController(webViewId: WebViewId): boolean {
+  return (
+    networkObjectService.hasKnown(getWebViewControllerObjectId(webViewId)) ||
+    webViewControllersById.has(webViewId)
+  );
+}
+
+/**
+ * Register a web view controller to represent a web view. It is expected that a web view provider
+ * calls this to register a web view controller for a web view that is being created. If a web view
+ * provider extends {@link WebViewFactory}, it will call this function automatically.
+ *
+ * A Web View Controller is a network object that represents a web view and whose methods facilitate
+ * communication between its associated web view and extensions that want to interact with it.
+ *
+ * You can get web view controllers with {@link webViewService.getWebViewController}.
+ *
+ * @param webViewType Type of web view for which you are providing this web view controller
+ * @param webViewId Id of web view for which to register the web view controller
+ * @param webViewController Object to register as a web view controller including control over
+ *   disposing of it. Note: the web view controller will be disposed automatically when the web view
+ *   is closed
+ *
+ *   WARNING: setting a web view controller mutates the provided object.
+ * @returns `webViewController` modified to be a network object
+ */
+async function registerWebViewController<WebViewType extends WebViewControllerTypes>(
+  webViewType: WebViewType,
+  webViewId: WebViewId,
+  webViewController: WebViewControllers[WebViewType],
+): Promise<DisposableNetworkObject<WebViewControllers[WebViewType]>> {
+  await initialize();
+
+  if (hasKnownWebViewController(webViewId))
+    throw new Error(
+      `WebView controller for WebView Id ${webViewId} (type ${webViewType}) is already registered`,
+    );
+
+  // Get the object id for this web view controller name
+  const webViewControllerObjectId = getWebViewControllerObjectId(webViewId);
+
+  // Set up the WebView Controller to be a network object so other processes can use it
+  const disposableWebViewController: DisposableNetworkObject<WebViewControllers[WebViewType]> =
+    await networkObjectService.set(
+      webViewControllerObjectId,
+      webViewController,
+      WEB_VIEW_CONTROLLER_OBJECT_TYPE,
+      { webViewType, webViewId },
+    );
+
+  overrideDispose(disposableWebViewController, async () => {
+    return webViewControllersById.delete(webViewId);
+  });
+
+  if (webViewControllersById.has(webViewId))
+    logger.warn(
+      `Web view provider service is setting web view controller with id ${webViewId} (type ${webViewType}) in the map over an existing web view. This is not expected.`,
+    );
+  webViewControllersById.set(webViewId, disposableWebViewController);
+
+  return disposableWebViewController;
+}
+
+/**
+ * Sends a message to the specified web view. Expected to be used only by the
+ * {@link IWebViewProvider} that created the web view or the {@link WebViewControllers} that
+ * represents the web view created by the Web View Provider.
+ *
+ * [`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) is used to
+ * deliver the message to the web view iframe. The web view can use
+ * [`window.addEventListener("message",
+ * ...)`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#the_dispatched_event)
+ * in order to receive these messages.
+ *
+ * @param webViewId Id of the web view to which to send a message.
+ * @param webViewNonce Nonce used to perform privileged interactions with the web view. Pass in the
+ *   nonce the web view provider received from {@link IWebViewProvider.getWebView}'s `webViewNonce`
+ *   parameter or from {@link WebViewFactory.createWebViewController}'s `webViewNonce` parameter
+ * @param message Data to send to the web view. Can only send serializable information
+ * @param targetOrigin Expected origin of the web view. Does not send the message if the web view's
+ *   origin does not match. See [`postMessage`'s
+ *   `targetOrigin`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage#targetorigin)
+ *   for more information. Defaults to same origin only (works automatically with React and HTML web
+ *   views)
+ */
+async function postMessageToWebView(
+  webViewId: WebViewId,
+  webViewNonce: string,
+  message: unknown,
+  targetOrigin?: string,
+): Promise<void> {
+  return networkService.request<
+    Parameters<WebViewMessageRequestHandler>,
+    ReturnType<WebViewMessageRequestHandler>
+  >(getWebViewMessageRequestType(webViewId), webViewNonce, message, targetOrigin);
+}
+
 // Declare interfaces for the objects we're exporting so that JSDoc comments propagate
 export interface WebViewProviderService {
   initialize: typeof initialize;
-  hasKnown: typeof hasKnown;
+  hasKnown: typeof hasKnownWebViewProvider;
   register: typeof register;
   get: typeof get;
+  registerWebViewController: typeof registerWebViewController;
+  postMessageToWebView: typeof postMessageToWebView;
 }
 
 export interface PapiWebViewProviderService {
   register: typeof register;
+  registerWebViewController: typeof registerWebViewController;
+  postMessageToWebView: typeof postMessageToWebView;
 }
 
 const webViewProviderService: WebViewProviderService = {
   initialize,
-  hasKnown,
+  hasKnown: hasKnownWebViewProvider,
   register,
   get,
+  registerWebViewController,
+  postMessageToWebView,
 };
 
 /**
@@ -161,6 +310,8 @@ const webViewProviderService: WebViewProviderService = {
  */
 export const papiWebViewProviderService: PapiWebViewProviderService = {
   register,
+  registerWebViewController,
+  postMessageToWebView,
 };
 
 export default webViewProviderService;

--- a/src/shared/services/web-view-provider.service.ts
+++ b/src/shared/services/web-view-provider.service.ts
@@ -100,7 +100,7 @@ function hasKnownWebViewProvider(webViewType: string): boolean {
  *   WARNING: setting a webView provider mutates the provided object.
  * @returns `webViewProvider` modified to be a network object and able to be disposed with `dispose`
  */
-async function register(
+async function registerWebViewProvider(
   webViewType: string,
   webViewProvider: IWebViewProvider,
 ): Promise<IDisposableWebViewProvider> {
@@ -151,7 +151,9 @@ async function register(
  * @param webViewType Type of webview provider to get
  * @returns Web view provider with the given name if one exists, undefined otherwise
  */
-async function get(webViewType: string): Promise<IRegisteredWebViewProvider | undefined> {
+async function getWebViewProvider(
+  webViewType: string,
+): Promise<IRegisteredWebViewProvider | undefined> {
   await initialize();
 
   // Get the object id for this web view provider name
@@ -175,11 +177,12 @@ async function get(webViewType: string): Promise<IRegisteredWebViewProvider | un
 }
 
 /**
- * Indicate if we are aware of an existing web view provider with the given type. If a web view
- * provider with the given type is somewhere else on the network, this function won't tell you about
- * it unless something else in the existing process is subscribed to it.
+ * Indicate if we are aware of an existing web view controller for the web view with the given id.
+ * If a web view controller for the web view with the given id is somewhere else on the network,
+ * this function won't tell you about it unless something else in the existing process is subscribed
+ * to it.
  *
- * @param webViewType Type of webView to check for
+ * @param webViewId Id of web view to check for a web view controller
  */
 function hasKnownWebViewController(webViewId: WebViewId): boolean {
   return (
@@ -281,24 +284,27 @@ async function postMessageToWebView(
 // Declare interfaces for the objects we're exporting so that JSDoc comments propagate
 export interface WebViewProviderService {
   initialize: typeof initialize;
-  hasKnown: typeof hasKnownWebViewProvider;
-  register: typeof register;
-  get: typeof get;
+  registerWebViewProvider: typeof registerWebViewProvider;
+  getWebViewProvider: typeof getWebViewProvider;
   registerWebViewController: typeof registerWebViewController;
   postMessageToWebView: typeof postMessageToWebView;
 }
 
 export interface PapiWebViewProviderService {
-  register: typeof register;
+  /** @deprecated 13 November 2024. Renamed to {@link registerWebViewProvider} */
+  // Split out the function declaration to avoid propagating the jsdoc and overwriting this deprecated message
+  register: (
+    ...args: Parameters<typeof registerWebViewProvider>
+  ) => ReturnType<typeof registerWebViewProvider>;
+  registerWebViewProvider: typeof registerWebViewProvider;
   registerWebViewController: typeof registerWebViewController;
   postMessageToWebView: typeof postMessageToWebView;
 }
 
 const webViewProviderService: WebViewProviderService = {
   initialize,
-  hasKnown: hasKnownWebViewProvider,
-  register,
-  get,
+  registerWebViewProvider,
+  getWebViewProvider,
   registerWebViewController,
   postMessageToWebView,
 };
@@ -306,10 +312,12 @@ const webViewProviderService: WebViewProviderService = {
 /**
  * JSDOC SOURCE papiWebViewProviderService
  *
- * Interface for registering webView providers
+ * Interface for registering webView providers, registering webView controllers, and performing
+ * privileged interactions with web views
  */
 export const papiWebViewProviderService: PapiWebViewProviderService = {
-  register,
+  register: registerWebViewProvider,
+  registerWebViewProvider,
   registerWebViewController,
   postMessageToWebView,
 };

--- a/src/shared/services/web-view.service-model.ts
+++ b/src/shared/services/web-view.service-model.ts
@@ -22,8 +22,11 @@ import logger from '@shared/services/logger.service';
  * HTML or React components.
  */
 export interface WebViewServiceType {
-  /** Event that emits with webView info when a webView is added */
-  onDidAddWebView: PlatformEvent<AddWebViewEvent>;
+  /** @deprecated 13 November 2024. Renamed to {@link onDidOpenWebView} */
+  onDidAddWebView: PlatformEvent<OpenWebViewEvent>;
+
+  /** Event that emits with webView info when a webView is created */
+  onDidOpenWebView: PlatformEvent<OpenWebViewEvent>;
 
   /** Event that emits with webView info when a webView is updated */
   onDidUpdateWebView: PlatformEvent<UpdateWebViewEvent>;
@@ -161,14 +164,20 @@ export async function getWebViewController<WebViewType extends WebViewController
   return webViewController;
 }
 
-/** Name to use when creating a network event that is fired when webViews are created */
+/** @deprecated 13 November 2024. Renamed to {@link EVENT_NAME_ON_DID_OPEN_WEB_VIEW} */
 export const EVENT_NAME_ON_DID_ADD_WEB_VIEW = serializeRequestType(
   CATEGORY_WEB_VIEW,
   'onDidAddWebView',
 );
 
+/** Name to use when creating a network event that is fired when webViews are created */
+export const EVENT_NAME_ON_DID_OPEN_WEB_VIEW = serializeRequestType(
+  CATEGORY_WEB_VIEW,
+  'onDidOpenWebView',
+);
+
 /** Event emitted when webViews are created */
-export type AddWebViewEvent = {
+export type OpenWebViewEvent = {
   webView: SavedWebViewDefinition;
   layout: Layout;
 };

--- a/src/shared/services/web-view.service-model.ts
+++ b/src/shared/services/web-view.service-model.ts
@@ -7,6 +7,11 @@ import {
 import { Layout } from '@shared/models/docking-framework.model';
 import { PlatformEvent } from 'platform-bible-utils';
 import { serializeRequestType } from '@shared/utils/util';
+import { WebViewControllers, WebViewControllerTypes } from 'papi-shared-types';
+import { NetworkObject } from '@shared/models/network-object.model';
+import networkObjectStatusService from '@shared/services/network-object-status.service';
+import networkObjectService from '@shared/services/network-object.service';
+import logger from '@shared/services/logger.service';
 
 /**
  * JSDOC SOURCE papiWebViewService
@@ -23,6 +28,16 @@ export interface WebViewServiceType {
   /** Event that emits with webView info when a webView is updated */
   onDidUpdateWebView: PlatformEvent<UpdateWebViewEvent>;
 
+  /** Event that emits with webView info when a webView is closed */
+  onDidCloseWebView: PlatformEvent<CloseWebViewEvent>;
+
+  /** @deprecated 6 November 2024. Renamed to {@link openWebView}. */
+  getWebView: (
+    webViewType: WebViewType,
+    layout?: Layout,
+    options?: GetWebViewOptions,
+  ) => Promise<WebViewId | undefined>;
+
   /**
    * Creates a new web view or gets an existing one depending on if you request an existing one and
    * if the web view provider decides to give that existing one to you (it is up to the provider).
@@ -35,29 +50,116 @@ export interface WebViewServiceType {
    *   not create a WebView for this request.
    * @throws If something went wrong like the provider for the webViewType was not found
    */
-  getWebView: (
+  openWebView: (
     webViewType: WebViewType,
     layout?: Layout,
     options?: GetWebViewOptions,
   ) => Promise<WebViewId | undefined>;
+
+  /** @deprecated 6 November 2024. Renamed to {@link getOpenWebViewDefinition} */
+  getSavedWebViewDefinition(webViewId: string): Promise<SavedWebViewDefinition | undefined>;
+
   /**
    * Gets the saved properties on the WebView definition with the specified ID
    *
    * Note: this only returns a representation of the current web view definition, not the actual web
    * view definition itself. Changing properties on the returned definition does not affect the
    * actual web view definition. You can possibly change the actual web view definition by calling
-   * {@link WebViewServiceType.getWebView} with certain `options`, depending on what options the web
+   * {@link WebViewServiceType.openWebView} with certain `options`, depending on what options the web
    * view provider has made available.
    *
    * @param webViewId The ID of the WebView whose saved properties to get
    * @returns Saved properties of the WebView definition with the specified ID or undefined if not
    *   found
    */
-  getSavedWebViewDefinition(webViewId: string): Promise<SavedWebViewDefinition | undefined>;
+  getOpenWebViewDefinition(webViewId: string): Promise<SavedWebViewDefinition | undefined>;
+
+  /**
+   * Get an existing web view controller for an open web view.
+   *
+   * A Web View Controller is a network object that represents a web view and whose methods
+   * facilitate communication between its associated web view and extensions that want to interact
+   * with it.
+   *
+   * Web View Controllers are registered on the web view provider service.
+   *
+   * @param webViewType Type of webview controller you expect to get. If the web view controller's
+   *   `webViewType` does not match this, an error will be thrown
+   * @param webViewId Id of web view for which to get the corresponding web view controller if one
+   *   exists
+   * @returns Web view controller with the given name if one exists, undefined otherwise
+   */
+  getWebViewController<WebViewType extends WebViewControllerTypes>(
+    webViewType: WebViewType,
+    webViewId: WebViewId,
+  ): Promise<NetworkObject<WebViewControllers[WebViewType]> | undefined>;
 }
 
 /** Prefix on requests that indicates that the request is related to webView operations */
 const CATEGORY_WEB_VIEW = 'webView';
+
+/** Suffix on network objects that indicates that the network object is a web view controller */
+const WEB_VIEW_CONTROLLER_LABEL = 'webViewController';
+
+/** Prefix on requests that indicate that the request is related to web view messages */
+const CATEGORY_WEB_VIEW_MESSAGE = 'webViewMessage';
+
+/** Get request type for posting a message to a web view */
+export function getWebViewMessageRequestType(webViewId: WebViewId) {
+  return serializeRequestType(CATEGORY_WEB_VIEW_MESSAGE, webViewId);
+}
+
+/**
+ * Type of function to receive messages sent to a web view.
+ *
+ * See `web-view-provider.service.ts`'s `postMessageToWebView` and `web-view.component` for
+ * information on this type
+ */
+export type WebViewMessageRequestHandler = (
+  webViewNonce: string,
+  message: unknown,
+  targetOrigin?: string,
+) => Promise<void>;
+
+/** Gets the id for the web view controller network object with the given name */
+export const getWebViewControllerObjectId = (webViewId: string) =>
+  `${WEB_VIEW_CONTROLLER_LABEL}${webViewId}`;
+
+/** Network object type for web view controllers */
+export const WEB_VIEW_CONTROLLER_OBJECT_TYPE = 'webViewController';
+
+// See `WebViewServiceType` for explanation
+export async function getWebViewController<WebViewType extends WebViewControllerTypes>(
+  webViewType: WebViewType,
+  webViewId: WebViewId,
+): Promise<NetworkObject<WebViewControllers[WebViewType]> | undefined> {
+  // Get the object id for this web view Controller name
+  const webViewControllerObjectId = getWebViewControllerObjectId(webViewId);
+
+  const webViewControllerDetails = await networkObjectStatusService.waitForNetworkObject(
+    { id: webViewControllerObjectId },
+    // Wait up to 20 seconds for the web view Controller to appear
+    20000,
+  );
+
+  if (
+    !webViewControllerDetails.attributes ||
+    webViewControllerDetails.attributes.webViewType !== webViewType
+  )
+    throw new Error(
+      `Found web view controller with network object id ${webViewControllerObjectId} for web view id ${webViewId}, but its type was not what was expected! Expected: ${webViewType}; received ${webViewControllerDetails.attributes?.webViewType}`,
+    );
+
+  const webViewController =
+    await networkObjectService.get<WebViewControllers[WebViewType]>(webViewControllerObjectId);
+
+  if (!webViewController) {
+    logger.info(`No WebView Controller found for WebView id ${webViewId} (type ${webViewType})`);
+    return undefined;
+  }
+
+  return webViewController;
+}
 
 /** Name to use when creating a network event that is fired when webViews are created */
 export const EVENT_NAME_ON_DID_ADD_WEB_VIEW = serializeRequestType(
@@ -79,6 +181,17 @@ export const EVENT_NAME_ON_DID_UPDATE_WEB_VIEW = serializeRequestType(
 
 /** Event emitted when webViews are updated */
 export type UpdateWebViewEvent = {
+  webView: SavedWebViewDefinition;
+};
+
+/** Name to use when creating a network event that is fired when webViews are closed */
+export const EVENT_NAME_ON_DID_CLOSE_WEB_VIEW = serializeRequestType(
+  CATEGORY_WEB_VIEW,
+  'onDidCloseWebView',
+);
+
+/** Event emitted when webViews are closed */
+export type CloseWebViewEvent = {
   webView: SavedWebViewDefinition;
 };
 

--- a/src/shared/services/web-view.service.ts
+++ b/src/shared/services/web-view.service.ts
@@ -3,10 +3,13 @@ import { getNetworkEvent } from '@shared/services/network.service';
 import {
   AddWebViewEvent,
   EVENT_NAME_ON_DID_ADD_WEB_VIEW,
+  EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
   EVENT_NAME_ON_DID_UPDATE_WEB_VIEW,
   NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
+  CloseWebViewEvent,
   UpdateWebViewEvent,
   WebViewServiceType,
+  getWebViewController,
 } from '@shared/services/web-view.service-model';
 import networkObjectService from '@shared/services/network-object.service';
 import networkObjectStatusService from './network-object-status.service';
@@ -17,6 +20,10 @@ const onDidAddWebView: PlatformEvent<AddWebViewEvent> = getNetworkEvent<AddWebVi
 
 const onDidUpdateWebView: PlatformEvent<UpdateWebViewEvent> = getNetworkEvent<UpdateWebViewEvent>(
   EVENT_NAME_ON_DID_UPDATE_WEB_VIEW,
+);
+
+const onDidCloseWebView: PlatformEvent<CloseWebViewEvent> = getNetworkEvent<CloseWebViewEvent>(
+  EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
 );
 
 let networkObject: WebViewServiceType;
@@ -59,6 +66,8 @@ const webViewService = createSyncProxyForAsyncObject<WebViewServiceType>(
   {
     onDidAddWebView,
     onDidUpdateWebView,
+    onDidCloseWebView,
+    getWebViewController,
   },
 );
 

--- a/src/shared/services/web-view.service.ts
+++ b/src/shared/services/web-view.service.ts
@@ -1,9 +1,9 @@
 import { PlatformEvent, createSyncProxyForAsyncObject } from 'platform-bible-utils';
 import { getNetworkEvent } from '@shared/services/network.service';
 import {
-  AddWebViewEvent,
-  EVENT_NAME_ON_DID_ADD_WEB_VIEW,
+  OpenWebViewEvent,
   EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
+  EVENT_NAME_ON_DID_OPEN_WEB_VIEW,
   EVENT_NAME_ON_DID_UPDATE_WEB_VIEW,
   NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
   CloseWebViewEvent,
@@ -14,8 +14,8 @@ import {
 import networkObjectService from '@shared/services/network-object.service';
 import networkObjectStatusService from './network-object-status.service';
 
-const onDidAddWebView: PlatformEvent<AddWebViewEvent> = getNetworkEvent<AddWebViewEvent>(
-  EVENT_NAME_ON_DID_ADD_WEB_VIEW,
+const onDidOpenWebView: PlatformEvent<OpenWebViewEvent> = getNetworkEvent<OpenWebViewEvent>(
+  EVENT_NAME_ON_DID_OPEN_WEB_VIEW,
 );
 
 const onDidUpdateWebView: PlatformEvent<UpdateWebViewEvent> = getNetworkEvent<UpdateWebViewEvent>(
@@ -64,7 +64,8 @@ const webViewService = createSyncProxyForAsyncObject<WebViewServiceType>(
     return networkObject;
   },
   {
-    onDidAddWebView,
+    onDidAddWebView: onDidOpenWebView,
+    onDidOpenWebView,
     onDidUpdateWebView,
     onDidCloseWebView,
     getWebViewController,


### PR DESCRIPTION
Resolves #1185 

- Web View Controllers are network objects create by Web View Providers that represent web views so other extensions can communicate with them,
- `WebViewFactory` is a new abstract class an extension can implement to combine a Web View Provider with Web View Controllers.
- `papi.webViewProviders.postMessageToWebView` is a new method for sending messages directly to web views. These are communicated via [`postMessage`](https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage) and can be received in the web view with `window.addEventListener('message', ...)`
  - This method is restricted to use only if you have the new `webViewNonce` which is given to the web view provider via a new third parameter in `IWebViewProvider.getWebView`
- Added aliases and deprecated some names for clearer method names in the web view service. See #1185 for more details
- Misc network fixes, logging adjustments, extension restarting fixes, etc.
  - Fixed extension host web socket not properly disconnecting on restart extension host
  - Made disconnecting client log only the method names that are being removed because they were registered to that client instead of listing all method names
- Added sample web view controllers for hello world project web views. The viewer created from a project web view uses the web view controller to communicate with the project web view.
- Added `papi.webViews.onDidCloseWebView`
- Added `useWebViewController` hook
- Added `globalThis.webViewId` on web views

Known Problems:
- useEventAsync has a bug with subscriptions such that it is causing problems with the web view message handler request when moving the web view and causing it to reload (might be the same reason `useData`'s `isLoading` doesn't work properly)
- Didn't enforce something.something on web view types

![image](https://github.com/user-attachments/assets/f8dafd14-9588-4d57-9baf-3bbc8ca48304)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1300)
<!-- Reviewable:end -->
