### PR TITLE
improve linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,11 @@ module.exports = {
     // Rules in each section are generally in alphabetical order. However, several
     // `@typescript-eslint` rules require disabling the equivalent ESLint rule. So in these cases
     // each ESLint rule is turned off immediately above the corresponding `@typescript-eslint` rule.
-    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
+    'class-methods-use-this': 'off',
+    '@typescript-eslint/class-methods-use-this': [
+      'error',
+      { ignoreOverrideMethods: true, ignoreClassesThatImplementAnInterface: false },
+    ],
     '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
     'lines-between-class-members': 'off',
     '@typescript-eslint/lines-between-class-members': [
@@ -75,6 +79,7 @@ module.exports = {
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
     'comma-dangle': ['error', 'always-multiline'],
+    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
     indent: 'off',
     'jsx-a11y/label-has-associated-control': [
       'error',

--- a/extensions/.eslintrc.cjs
+++ b/extensions/.eslintrc.cjs
@@ -33,7 +33,11 @@ module.exports = {
     // Rules in each section are generally in alphabetical order. However, several
     // `@typescript-eslint` rules require disabling the equivalent ESLint rule. So in these cases
     // each ESLint rule is turned off immediately above the corresponding `@typescript-eslint` rule.
-    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
+    'class-methods-use-this': 'off',
+    '@typescript-eslint/class-methods-use-this': [
+      'error',
+      { ignoreOverrideMethods: true, ignoreClassesThatImplementAnInterface: false },
+    ],
     '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
     'lines-between-class-members': 'off',
     '@typescript-eslint/lines-between-class-members': [
@@ -76,6 +80,7 @@ module.exports = {
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
     'comma-dangle': ['error', 'always-multiline'],
+    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
     indent: 'off',
     'jsx-a11y/label-has-associated-control': [
       'error',

--- a/extensions/src/hello-someone/.eslintrc.js
+++ b/extensions/src/hello-someone/.eslintrc.js
@@ -33,7 +33,11 @@ module.exports = {
     // Rules in each section are generally in alphabetical order. However, several
     // `@typescript-eslint` rules require disabling the equivalent ESLint rule. So in these cases
     // each ESLint rule is turned off immediately above the corresponding `@typescript-eslint` rule.
-    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
+    'class-methods-use-this': 'off',
+    '@typescript-eslint/class-methods-use-this': [
+      'error',
+      { ignoreOverrideMethods: true, ignoreClassesThatImplementAnInterface: false },
+    ],
     '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
     'lines-between-class-members': 'off',
     '@typescript-eslint/lines-between-class-members': [
@@ -76,6 +80,7 @@ module.exports = {
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
     'comma-dangle': ['error', 'always-multiline'],
+    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
     indent: 'off',
     'jsx-a11y/label-has-associated-control': [
       'error',

--- a/extensions/src/hello-world/.eslintrc.js
+++ b/extensions/src/hello-world/.eslintrc.js
@@ -33,7 +33,11 @@ module.exports = {
     // Rules in each section are generally in alphabetical order. However, several
     // `@typescript-eslint` rules require disabling the equivalent ESLint rule. So in these cases
     // each ESLint rule is turned off immediately above the corresponding `@typescript-eslint` rule.
-    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
+    'class-methods-use-this': 'off',
+    '@typescript-eslint/class-methods-use-this': [
+      'error',
+      { ignoreOverrideMethods: true, ignoreClassesThatImplementAnInterface: false },
+    ],
     '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
     'lines-between-class-members': 'off',
     '@typescript-eslint/lines-between-class-members': [
@@ -76,6 +80,7 @@ module.exports = {
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
     'comma-dangle': ['error', 'always-multiline'],
+    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
     indent: 'off',
     'jsx-a11y/label-has-associated-control': [
       'error',

--- a/extensions/src/hello-world/src/checks.ts
+++ b/extensions/src/hello-world/src/checks.ts
@@ -35,7 +35,7 @@ class HelloCheck implements Check {
     return true;
   }
 
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   getCheckDetails(): CheckDetails {
     return checkDetails;
   }

--- a/extensions/src/hello-world/src/main.ts
+++ b/extensions/src/hello-world/src/main.ts
@@ -108,9 +108,7 @@ class HelloWorldProjectWebViewFactory extends WebViewFactory<
     super(HELLO_WORLD_PROJECT_WEB_VIEW_TYPE);
   }
 
-  // No need to use `this` and implementing an abstract method so can't be static
-  // eslint-disable-next-line class-methods-use-this
-  async getWebViewDefinition(
+  override async getWebViewDefinition(
     savedWebView: SavedWebViewDefinition,
     getWebViewOptions: HelloWorldProjectOptions,
   ): Promise<WebViewDefinition | undefined> {
@@ -130,9 +128,7 @@ class HelloWorldProjectWebViewFactory extends WebViewFactory<
     };
   }
 
-  // No need to use `this` and implementing an abstract method so can't be static
-  // eslint-disable-next-line class-methods-use-this
-  async createWebViewController(
+  override async createWebViewController(
     webViewDefinition: WebViewDefinition,
     webViewNonce: string,
   ): Promise<HelloWorldProjectWebViewController> {

--- a/extensions/src/hello-world/src/models/hello-world-project-data-provider-engine.model.ts
+++ b/extensions/src/hello-world/src/models/hello-world-project-data-provider-engine.model.ts
@@ -128,7 +128,8 @@ class HelloWorldProjectDataProviderEngine
     return newNumber;
   }
 
-  // eslint-disable-next-line class-methods-use-this
+  // Required method since this is a data provider engine
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setNames(): Promise<
     DataProviderUpdateInstructions<ProjectInterfaceDataTypes['helloWorld']>
   > {

--- a/extensions/src/legacy-comment-manager/.eslintrc.js
+++ b/extensions/src/legacy-comment-manager/.eslintrc.js
@@ -33,7 +33,11 @@ module.exports = {
     // Rules in each section are generally in alphabetical order. However, several
     // `@typescript-eslint` rules require disabling the equivalent ESLint rule. So in these cases
     // each ESLint rule is turned off immediately above the corresponding `@typescript-eslint` rule.
-    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
+    'class-methods-use-this': 'off',
+    '@typescript-eslint/class-methods-use-this': [
+      'error',
+      { ignoreOverrideMethods: true, ignoreClassesThatImplementAnInterface: false },
+    ],
     '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
     'lines-between-class-members': 'off',
     '@typescript-eslint/lines-between-class-members': [
@@ -76,6 +80,7 @@ module.exports = {
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
     'comma-dangle': ['error', 'always-multiline'],
+    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
     indent: 'off',
     'jsx-a11y/label-has-associated-control': [
       'error',

--- a/extensions/src/paratext-registration/.eslintrc.js
+++ b/extensions/src/paratext-registration/.eslintrc.js
@@ -33,7 +33,11 @@ module.exports = {
     // Rules in each section are generally in alphabetical order. However, several
     // `@typescript-eslint` rules require disabling the equivalent ESLint rule. So in these cases
     // each ESLint rule is turned off immediately above the corresponding `@typescript-eslint` rule.
-    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
+    'class-methods-use-this': 'off',
+    '@typescript-eslint/class-methods-use-this': [
+      'error',
+      { ignoreOverrideMethods: true, ignoreClassesThatImplementAnInterface: false },
+    ],
     '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
     'lines-between-class-members': 'off',
     '@typescript-eslint/lines-between-class-members': [
@@ -76,6 +80,7 @@ module.exports = {
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
     'comma-dangle': ['error', 'always-multiline'],
+    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
     indent: 'off',
     'jsx-a11y/label-has-associated-control': [
       'error',

--- a/extensions/src/paratext-registration/src/paratext-registration.web-view-provider.ts
+++ b/extensions/src/paratext-registration/src/paratext-registration.web-view-provider.ts
@@ -10,7 +10,7 @@ const tooltipKey = '%paratextRegistration_webView_tooltip%';
 
 export default class ParatextRegistrationWebViewProvider implements IWebViewProvider {
   // needs to be a class method, not static method
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async getWebView(savedWebView: SavedWebViewDefinition): Promise<WebViewDefinition | undefined> {
     if (savedWebView.webViewType !== paratextRegistrationWebViewType)
       throw new Error(

--- a/extensions/src/platform-scripture-editor/.eslintrc.js
+++ b/extensions/src/platform-scripture-editor/.eslintrc.js
@@ -33,7 +33,11 @@ module.exports = {
     // Rules in each section are generally in alphabetical order. However, several
     // `@typescript-eslint` rules require disabling the equivalent ESLint rule. So in these cases
     // each ESLint rule is turned off immediately above the corresponding `@typescript-eslint` rule.
-    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
+    'class-methods-use-this': 'off',
+    '@typescript-eslint/class-methods-use-this': [
+      'error',
+      { ignoreOverrideMethods: true, ignoreClassesThatImplementAnInterface: false },
+    ],
     '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
     'lines-between-class-members': 'off',
     '@typescript-eslint/lines-between-class-members': [
@@ -76,6 +80,7 @@ module.exports = {
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
     'comma-dangle': ['error', 'always-multiline'],
+    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
     indent: 'off',
     'jsx-a11y/label-has-associated-control': [
       'error',

--- a/extensions/src/platform-scripture/.eslintrc.js
+++ b/extensions/src/platform-scripture/.eslintrc.js
@@ -33,7 +33,11 @@ module.exports = {
     // Rules in each section are generally in alphabetical order. However, several
     // `@typescript-eslint` rules require disabling the equivalent ESLint rule. So in these cases
     // each ESLint rule is turned off immediately above the corresponding `@typescript-eslint` rule.
-    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
+    'class-methods-use-this': 'off',
+    '@typescript-eslint/class-methods-use-this': [
+      'error',
+      { ignoreOverrideMethods: true, ignoreClassesThatImplementAnInterface: false },
+    ],
     '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
     'lines-between-class-members': 'off',
     '@typescript-eslint/lines-between-class-members': [
@@ -76,6 +80,7 @@ module.exports = {
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
     'comma-dangle': ['error', 'always-multiline'],
+    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
     indent: 'off',
     'jsx-a11y/label-has-associated-control': [
       'error',

--- a/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
+++ b/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
@@ -26,7 +26,7 @@ class CheckDataProviderEngine
   lastRangesSet: CheckInputRange[] = [];
 
   // Required method since this is a data provider engine
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setAvailableChecks(): Promise<DataProviderUpdateInstructions<CheckRunnerDataTypes>> {
     throw new Error('setAvailableChecks disabled');
   }
@@ -46,7 +46,7 @@ class CheckDataProviderEngine
   }
 
   // Required method since this is a data provider engine
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setCheckResults(): Promise<DataProviderUpdateInstructions<CheckRunnerDataTypes>> {
     throw new Error('setCheckResults disabled');
   }

--- a/extensions/src/platform-scripture/src/checks/extension-host-check-runner.service.ts
+++ b/extensions/src/platform-scripture/src/checks/extension-host-check-runner.service.ts
@@ -72,7 +72,7 @@ class CheckRunnerEngine
   }
 
   // Because this is a data provider, we have to provide this method even though it always throws
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setAvailableChecks(): Promise<DataProviderUpdateInstructions<CheckRunnerDataTypes>> {
     throw new Error('setAvailableChecks disabled - use enableCheck and disableCheck');
   }
@@ -221,7 +221,7 @@ class CheckRunnerEngine
   }
 
   // Because this is a data provider, we have to provide this method even though it always throws
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setCheckResults(): Promise<DataProviderUpdateInstructions<CheckRunnerDataTypes>> {
     throw new Error('setCheckResults disabled');
   }

--- a/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-extender-pdpe.model.ts
+++ b/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-extender-pdpe.model.ts
@@ -156,7 +156,8 @@ class ScriptureExtenderProjectDataProviderEngine
     return false;
   }
 
-  // eslint-disable-next-line class-methods-use-this
+  // Because this is a data provider, we have to provide this method even though it always throws
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setVerseUSJ(): Promise<DataProviderUpdateInstructions<USJVerseProjectInterfaceDataTypes>> {
     throw new Error('Cannot call setVerseUSJ, use setChapterUSJ or setBookUSJ instead');
   }

--- a/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-extender-pdpef.model.ts
+++ b/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-extender-pdpef.model.ts
@@ -31,7 +31,7 @@ class ScriptureExtenderProjectDataProviderEngineFactory
   providedProjectInterfaces = SCRIPTURE_EXTENDER_PROJECT_INTERFACES;
 
   // Implementing an interface method, so can't be static
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async createProjectDataProviderEngine(
     projectId: string,
   ): Promise<IProjectDataProviderEngine<typeof SCRIPTURE_EXTENDER_PROJECT_INTERFACES>> {

--- a/extensions/src/quick-verse/.eslintrc.js
+++ b/extensions/src/quick-verse/.eslintrc.js
@@ -33,7 +33,11 @@ module.exports = {
     // Rules in each section are generally in alphabetical order. However, several
     // `@typescript-eslint` rules require disabling the equivalent ESLint rule. So in these cases
     // each ESLint rule is turned off immediately above the corresponding `@typescript-eslint` rule.
-    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
+    'class-methods-use-this': 'off',
+    '@typescript-eslint/class-methods-use-this': [
+      'error',
+      { ignoreOverrideMethods: true, ignoreClassesThatImplementAnInterface: false },
+    ],
     '@typescript-eslint/explicit-member-accessibility': ['error', { accessibility: 'no-public' }],
     'lines-between-class-members': 'off',
     '@typescript-eslint/lines-between-class-members': [
@@ -76,6 +80,7 @@ module.exports = {
     'no-useless-constructor': 'off',
     '@typescript-eslint/no-useless-constructor': 'error',
     'comma-dangle': ['error', 'always-multiline'],
+    'import/no-anonymous-default-export': ['error', { allowCallExpression: false }],
     indent: 'off',
     'jsx-a11y/label-has-associated-control': [
       'error',

--- a/extensions/src/quick-verse/src/main.ts
+++ b/extensions/src/quick-verse/src/main.ts
@@ -230,7 +230,7 @@ class QuickVerseDataProviderEngine
    * @returns False meaning do not update anything
    */
   // Does nothing, so we don't need to use `this`
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setChapter() {
     // We are not supporting setting chapters now, so don't update anything
     return false;

--- a/src/extension-host/services/localization.service-host.ts
+++ b/src/extension-host/services/localization.service-host.ts
@@ -243,7 +243,7 @@ class LocalizationDataProviderEngine
   implements IDataProviderEngine<LocalizationDataDataTypes>
 {
   // This method legitimately does not need to call anything else in this class as of now
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async getLocalizedString({ localizeKey, locales = [] }: LocalizationSelector) {
     const languages = locales.length > 0 ? [...locales] : await getDefaultLanguages();
 
@@ -300,13 +300,13 @@ class LocalizationDataProviderEngine
   }
 
   // Because this is a data provider, we have to provide this method even though it always throws
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setLocalizedString(): Promise<DataProviderUpdateInstructions<LocalizationDataDataTypes>> {
     throw new Error('setLocalizedString disabled');
   }
 
   // Because this is a data provider, we have to provide this method even though it always throws
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setLocalizedStrings(): Promise<DataProviderUpdateInstructions<LocalizationDataDataTypes>> {
     throw new Error('setLocalizedStrings disabled');
   }

--- a/src/extension-host/services/menu-data.service-host.ts
+++ b/src/extension-host/services/menu-data.service-host.ts
@@ -53,7 +53,7 @@ class MenuDataDataProviderEngine
   }
 
   // Because this is a data provider, we have to provide this method even though it always throws
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setMainMenu(): Promise<DataProviderUpdateInstructions<MenuDataDataTypes>> {
     throw new Error('setMainMenu disabled');
   }
@@ -68,7 +68,7 @@ class MenuDataDataProviderEngine
   }
 
   // Because this is a data provider, we have to provide this method even though it always throws
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setWebViewMenu(): Promise<DataProviderUpdateInstructions<MenuDataDataTypes>> {
     throw new Error('setWebViewMenu disabled');
   }

--- a/src/extension-host/services/settings.service-host.ts
+++ b/src/extension-host/services/settings.service-host.ts
@@ -138,9 +138,10 @@ class SettingDataProviderEngine
     );
   }
 
-  // eslint-disable-next-line class-methods-use-this
+  /* eslint-disable @typescript-eslint/class-methods-use-this */
   @dataProviders.decorators.ignore
   async getLocalizedSettingsContributionInfo(): Promise<
+    /* eslint-enable */
     LocalizedSettingsContributionInfo | undefined
   > {
     return settingsDocumentCombiner.getLocalizedSettingsContributionInfo();
@@ -174,7 +175,7 @@ class SettingDataProviderEngine
     return true;
   }
 
-  // eslint-disable-next-line class-methods-use-this
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async validateSetting<SettingName extends SettingNames>(
     key: SettingName,
     newValue: SettingTypes[SettingName],

--- a/src/shared/models/data-provider-engine.model.ts
+++ b/src/shared/models/data-provider-engine.model.ts
@@ -161,6 +161,6 @@ export abstract class DataProviderEngine<TDataTypes extends DataProviderDataType
   // @ts-expect-error ts(6133) `updateInstructions` is not used in this method, but we don't care
   // because we want inheriting classes to be able to get this method with Intellisense without
   // an underscore that indicates to TypeScript that we aren't using the parameter
-  // eslint-disable-next-line class-methods-use-this, @typescript-eslint/no-unused-vars
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this, @typescript-eslint/no-unused-vars
   notifyUpdate(updateInstructions?: DataProviderUpdateInstructions<TDataTypes>): void {}
 }

--- a/src/shared/utils/localized-strings-document-combiner.ts
+++ b/src/shared/utils/localized-strings-document-combiner.ts
@@ -87,14 +87,10 @@ export default class LocalizedStringsDocumentCombiner extends DocumentCombiner {
     ) as T extends string ? LanguageStrings | undefined : LocalizedStringDataContribution;
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override validateBaseDocument(baseDocument: JsonDocumentLike): void {
     performSchemaValidation(baseDocument, PLATFORM_NAMESPACE);
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override transformBaseDocumentAfterValidation(
     baseDocument: JsonDocumentLike,
   ): JsonDocumentLike {
@@ -105,14 +101,10 @@ export default class LocalizedStringsDocumentCombiner extends DocumentCombiner {
     );
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override validateContribution(_documentName: string, document: JsonDocumentLike): void {
     performSchemaValidation(document, PLATFORM_NAMESPACE);
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override transformContributionAfterValidation(
     _documentName: string,
     document: JsonDocumentLike,
@@ -124,8 +116,6 @@ export default class LocalizedStringsDocumentCombiner extends DocumentCombiner {
     );
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override validateOutput(output: JsonDocumentLike): void {
     performSchemaValidation(output, 'output');
   }

--- a/src/shared/utils/menu-document-combiner.ts
+++ b/src/shared/utils/menu-document-combiner.ts
@@ -276,8 +276,6 @@ export default class MenuDocumentCombiner extends DocumentCombiner {
     return retVal;
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override validateBaseDocument(baseDocument: JsonDocumentLike): void {
     // The starting document has to validate against the output schema, too
     performSchemaValidation(baseDocument, 'starting');
@@ -343,8 +341,6 @@ export default class MenuDocumentCombiner extends DocumentCombiner {
     // TODO: Validate that extensions only add to objects that are marked as extensible
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override validateOutput(output: JsonDocumentLike): void {
     performSchemaValidation(output, 'output');
     // Once the schema has been validated, we know the type should match
@@ -371,8 +367,6 @@ export default class MenuDocumentCombiner extends DocumentCombiner {
   }
 
   // Combine the webview menu defaults for any web views that indicate that is desired
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override transformFinalOutputBeforeValidation(
     finalOutput: JsonDocumentLike,
   ): JsonDocumentLike {

--- a/src/shared/utils/project-settings-document-combiner.ts
+++ b/src/shared/utils/project-settings-document-combiner.ts
@@ -93,8 +93,6 @@ export default class ProjectSettingsDocumentCombiner extends SettingsDocumentCom
     >;
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override performSchemaValidation(document: JsonDocumentLike, docType: string): void {
     performSchemaValidation(document, docType);
   }

--- a/src/shared/utils/settings-document-combiner-base.ts
+++ b/src/shared/utils/settings-document-combiner-base.ts
@@ -189,14 +189,10 @@ export default abstract class SettingsDocumentCombinerBase extends DocumentCombi
     return this.localizedOutputPromise;
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override validateBaseDocument(baseDocument: JsonDocumentLike): void {
     this.performSchemaValidation(baseDocument, PLATFORM_NAMESPACE);
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override transformBaseDocumentAfterValidation(
     baseDocument: JsonDocumentLike,
   ): JsonDocumentLike {
@@ -208,8 +204,6 @@ export default abstract class SettingsDocumentCombinerBase extends DocumentCombi
     );
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override validateContribution(documentName: string, document: JsonDocumentLike): void {
     // Make sure it is a SettingsContribution
     this.performSchemaValidation(document, documentName);
@@ -241,8 +235,6 @@ export default abstract class SettingsDocumentCombinerBase extends DocumentCombi
     );
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override transformContributionAfterValidation(
     documentName: string,
     document: JsonDocumentLike,
@@ -255,8 +247,6 @@ export default abstract class SettingsDocumentCombinerBase extends DocumentCombi
     );
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override validateOutput(): void {
     // We already validated input documents and built the output ourselves, so we don't have any more
     // validating to do. Unless someday we want to double check we have a properly formatted

--- a/src/shared/utils/settings-document-combiner.ts
+++ b/src/shared/utils/settings-document-combiner.ts
@@ -54,8 +54,6 @@ export default class SettingsDocumentCombiner extends SettingsDocumentCombinerBa
     return this.getLocalizedOutput();
   }
 
-  // We don't need `this` on this override method
-  // eslint-disable-next-line class-methods-use-this
   protected override performSchemaValidation(document: JsonDocumentLike, docType: string): void {
     performSchemaValidation(document, docType);
   }


### PR DESCRIPTION
- use the TS version of `class-methods-use-this` so we can ignore override methods.

> [!NOTE]
> - `import/no-anonymous-default-export` was moved to it's alphabetical location.
> - `ignoreClassesThatImplementAnInterface` is explicitly false as it will ignore ALL methods if a class implements an interface, not just the ones in the interface. Eslint exception comments will keep these intentional.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1306)
<!-- Reviewable:end -->
