### PR TITLE
speed-up commit hook

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,18 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Verify no files changed after build
+        id: verify-changed-files
+        uses: tj-actions/verify-changed-files@v20
+
+      - name: Report file changes
+        if: steps.verify-changed-files.outputs.files_changed == 'true'
+        env:
+          CHANGED_FILES: ${{ steps.verify-changed-files.outputs.changed_files }}
+        run: |
+          echo "Error - changed files after build: $CHANGED_FILES"
+          exit 1
+
       - name: dotnet unit tests
         run: dotnet test c-sharp-tests/c-sharp-tests.csproj
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,14 +1,9 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-echo "Lint checking..."
-# generate papi.d.ts as part of lint:staged
+echo "Format and stylelint fixes..."
 npm run lint:staged
-echo "Lint check finished"
-
-echo "Type checking..."
-npm run typecheck
-echo "Type check finished"
+echo "Format and stylelint fixes finished"
 
 echo "If the following fails run npm run editor:unlink"
 npx yalc check

--- a/extensions/package.json
+++ b/extensions/package.json
@@ -28,7 +28,7 @@
     "update-from-templates": "tsx ./lib/update-from-templates.ts"
   },
   "lint-staged": {
-    "*.{cjs,js,jsx,ts,tsx}": ["prettier --write", "cross-env NODE_ENV=development eslint --cache"],
+    "*.{cjs,js,jsx,ts,tsx}": ["prettier --write"],
     "*.json": ["prettier --parser json --write"],
     "*.{css,scss}": ["stylelint --fix"],
     "*.{html,md,yml}": ["prettier --single-quote --write"]

--- a/lib/papi-dts/package.json
+++ b/lib/papi-dts/package.json
@@ -36,7 +36,7 @@
     "typecheck": "tsc -p ./tsconfig.lint.json"
   },
   "lint-staged": {
-    "*.{cjs,js,jsx,ts,tsx}": ["prettier --write", "cross-env NODE_ENV=development eslint --cache"],
+    "*.{cjs,js,jsx,ts,tsx}": ["prettier --write"],
     "*.json": ["prettier --parser json --write"],
     "*.{html,md,yml}": ["prettier --single-quote --write"]
   },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "lint": "cross-env NODE_OPTIONS=\"--max-old-space-size=4096\" npm run build:types && npm run lint:scripts && npm run lint:styles && cd lib/papi-dts && npm run lint && cd ../../extensions && npm run lint",
     "lint:config": "cross-env NODE_ENV=development eslint --print-config .eslintrc.js > .eslintConfig.json",
     "lint:scripts": "cross-env NODE_ENV=development eslint --ext .cjs,.js,.jsx,.ts,.tsx --cache .",
-    "lint:staged": "npm run build:types && lint-staged -q && cd lib/papi-dts && npm run lint:staged && cd ../../extensions && npm run lint:staged",
+    "lint:staged": "lint-staged -q && npm run lint:staged --workspaces --if-present",
     "lint:styles": "stylelint **/*.{css,scss}",
     "lint-fix": "npm run build:types && npm run lint-fix:scripts && npm run lint-fix:styles && cd lib/papi-dts && npm run lint-fix && cd ../../extensions && npm run lint-fix",
     "lint-fix:scripts": "prettier --write \"**/*.{ts,tsx,js,jsx,cjs}\" && npm run lint:scripts",
@@ -96,7 +96,7 @@
     "typecheck:platform-bible-utils": "cd lib/platform-bible-utils && npm run typecheck"
   },
   "lint-staged": {
-    "*.{cjs,js,jsx,ts,tsx}": ["prettier --write", "cross-env NODE_ENV=development eslint --cache"],
+    "*.{cjs,js,jsx,ts,tsx}": ["prettier --write"],
     "*.json": ["prettier --parser json --write"],
     "*.{css,scss}": ["stylelint --fix --allow-empty-input"],
     "*.{html,md,yml}": ["prettier --single-quote --write"]


### PR DESCRIPTION
- remove type checking and linting from commit hook. Only format and stylelint --fix (which actually modify files).
- check for file changes after build, e.g. `lib/papi.d.ts`

> [!NOTE]
> Hear is a build that fails (intentionally for testing) https://github.com/paranext/paranext-core/actions/runs/11847734071/job/33017994912?pr=1314

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1314)
<!-- Reviewable:end -->
