### PR TITLE
Added note that registration stuff is shared with P9

### DIFF
--- a/extensions/src/paratext-registration/contributions/localizedStrings.json
+++ b/extensions/src/paratext-registration/contributions/localizedStrings.json
@@ -58,6 +58,7 @@
       "%paratextRegistration_description_internetUse_option_Disabled%": "Disable all Internet use",
       "%paratextRegistration_description_internetUse_option_ProxyOnly%": "Use a proxy",
       "%paratextRegistration_description_internetUse_option_VpnRequired%": "Disable Internet use in sensitive locations",
+      "%paratextRegistration_description_shared_with_paratext_9%": "Theses settings also apply to Paratext 9.",
       "%paratextRegistration_label_emailAddress%": "Email address",
       "%paratextRegistration_label_proxyHost%": "Host",
       "%paratextRegistration_label_proxyMode%": "Mode",

--- a/extensions/src/paratext-registration/src/paratext-registration.web-view.tsx
+++ b/extensions/src/paratext-registration/src/paratext-registration.web-view.tsx
@@ -150,6 +150,7 @@ const LOCALIZED_STRING_KEYS: LocalizeKey[] = [
   '%paratextRegistration_button_saveAndRestart%',
   '%paratextRegistration_description_internetUse_disclaimer%',
   ...INTERNET_USE_OPTIONS.map(getLocalizeKeyForInternetUse),
+  '%paratextRegistration_description_shared_with_paratext_9%',
   '%paratextRegistration_label_emailAddress%',
   '%paratextRegistration_label_proxyHost%',
   '%paratextRegistration_label_proxyMode%',
@@ -307,6 +308,9 @@ globalThis.webViewComponent = function ParatextRegistration({ useWebViewState }:
   return (
     <div className="tw-p-2 tw-flex tw-flex-col tw-justify-between tw-h-screen">
       <div>
+        <div className="tw-ms-2 tw-text-sm tw-text-muted-foreground">
+          {localizedStrings['%paratextRegistration_description_shared_with_paratext_9%']}
+        </div>
         <Grid>
           <span>{localizedStrings['%paratextRegistration_label_registrationName%']}</span>
           <Input value={name} disabled={isFormDisabled} onChange={(e) => setName(e.target.value)} />


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/ded67c96-8595-4b8b-9740-bb8f7dd38521)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1339)
<!-- Reviewable:end -->
