### PR TITLE
Select Scripture when you click a check result

### DIFF
--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -17,9 +17,16 @@ import { JSX, useCallback, useEffect, useMemo, useRef } from 'react';
 import type { WebViewProps } from '@papi/core';
 import { logger } from '@papi/frontend';
 import { useProjectData, useProjectSetting, useSetting } from '@papi/frontend/react';
-import { deepClone, ScriptureReference, UsjReaderWriter } from 'platform-bible-utils';
+import {
+  compareScrRefs,
+  deepClone,
+  ScriptureReference,
+  serialize,
+  UsjReaderWriter,
+} from 'platform-bible-utils';
 import { Button } from 'platform-bible-react';
 import { LegacyComment } from 'legacy-comment-manager';
+import { EditorWebViewMessage, SelectionRange } from 'platform-scripture-editor';
 import {
   convertEditorCommentsToLegacyComments,
   convertLegacyCommentsToEditorThreads,
@@ -83,7 +90,43 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
   // Using react's ref api which uses null, so we must use null
   // eslint-disable-next-line no-null/no-null
   const editorRef = useRef<EditorRef | MarginalRef | null>(null);
-  const [scrRef, setScrRefInternal] = useWebViewScrollGroupScrRef();
+  const [scrRef, setScrRefWithScroll] = useWebViewScrollGroupScrRef();
+
+  const nextSelectionRange = useRef<SelectionRange | undefined>(undefined);
+
+  // listen to messages from the web view controller
+  useEffect(() => {
+    const webViewMessageListener = ({
+      data: { method, scrRef: targetScrRef, range },
+    }: MessageEvent<EditorWebViewMessage>) => {
+      switch (method) {
+        case 'selectRange':
+          logger.debug(`selectRange targetScrRef ${serialize(targetScrRef)} ${serialize(range)}`);
+
+          if (compareScrRefs(scrRef, targetScrRef) !== 0) {
+            // Need to update scr ref, let the editor load the Scripture text at the new scrRef,
+            // and scroll to the new scrRef before setting the range. Set the nextSelectionRange
+            // which will set the range after a short wait time in a `useEffect` below
+            setScrRefWithScroll(targetScrRef);
+            nextSelectionRange.current = range;
+          }
+          // We're on the right scr ref. Go ahead and set the selection
+          else editorRef.current?.setSelection(range);
+
+          break;
+        default:
+          // Unknown method name
+          logger.debug(`Received event with unknown method ${method}`);
+          break;
+      }
+    };
+
+    window.addEventListener('message', webViewMessageListener);
+
+    return () => {
+      window.removeEventListener('message', webViewMessageListener);
+    };
+  }, [scrRef, setScrRefWithScroll]);
 
   const [commentsEnabled] = useSetting('platform.commentsEnabled', false);
 
@@ -93,12 +136,12 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
    */
   const internallySetScrRefRef = useRef<ScriptureReference | undefined>(undefined);
 
-  const setScrRef = useCallback(
+  const setScrRefNoScroll = useCallback(
     (newScrRef: ScriptureReference) => {
       internallySetScrRefRef.current = newScrRef;
-      return setScrRefInternal(newScrRef);
+      return setScrRefWithScroll(newScrRef);
     },
-    [setScrRefInternal],
+    [setScrRefWithScroll],
   );
 
   /**
@@ -273,7 +316,7 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
     }
   }, [usjFromPdp, scrRef]);
 
-  // Scroll the selected verse into view
+  // Scroll the selected verse and selection range into view
   useEffect(() => {
     // If we made this latest scrRef change, don't scroll
     if (
@@ -288,6 +331,11 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
 
     let highlightedVerseElement: HTMLElement | undefined;
 
+    // Queue up the next selection range to be set and clear it so we don't accidentally set the
+    // range to the wrong thing
+    const nextRange = nextSelectionRange.current;
+    nextSelectionRange.current = undefined;
+
     // Wait before scrolling to make sure there is time for the editor to load
     // TODO: hook into the editor and detect when it has loaded somehow
     const scrollTimeout = setTimeout(() => {
@@ -296,6 +344,9 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
       highlightedVerseElement?.classList.add('highlighted');
 
       internallySetScrRefRef.current = undefined;
+
+      // Set the selection if the selection was set to something as part of this scr ref change
+      if (nextRange) editorRef.current?.setSelection(nextRange);
     }, EDITOR_LOAD_DELAY_TIME);
 
     return () => {
@@ -327,7 +378,7 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
         <Editorial
           ref={editorRef}
           scrRef={scrRef}
-          onScrRefChange={setScrRef}
+          onScrRefChange={setScrRefNoScroll}
           options={options}
           logger={logger}
         />
@@ -342,7 +393,7 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
         <Marginal
           ref={editorRef}
           scrRef={scrRef}
-          onScrRefChange={setScrRef}
+          onScrRefChange={setScrRefNoScroll}
           onUsjChange={onUsjAndCommentsChange}
           onCommentChange={saveCommentsToPdp}
           options={options}
@@ -358,7 +409,7 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
       <Editorial
         ref={editorRef}
         scrRef={scrRef}
-        onScrRefChange={setScrRef}
+        onScrRefChange={setScrRefNoScroll}
         onUsjChange={saveUsjToPdp}
         options={options}
         logger={logger}

--- a/extensions/src/platform-scripture-editor/src/types/platform-scripture-editor.d.ts
+++ b/extensions/src/platform-scripture-editor/src/types/platform-scripture-editor.d.ts
@@ -1,6 +1,86 @@
-declare module 'platform-scripture-editor' {}
+declare module 'platform-scripture-editor' {
+  // Used in JSDocs
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  import type { CheckLocation } from 'platform-scripture';
+  // @ts-ignore: TS2307 - Cannot find module '@papi/core' or its corresponding type declarations
+  import type { NetworkableObject } from '@papi/core';
+  import type { ScriptureReference } from 'platform-bible-utils';
+
+  // #region copied from @biblionexus-foundation/platform-editor because they are not yet properly
+  // exported
+
+  type UsjLocation = {
+    jsonPath: string;
+    offset: number;
+  };
+
+  export type SelectionRange = {
+    start: UsjLocation;
+    end?: UsjLocation;
+  };
+
+  // #endregion
+
+  /** Messages sent to the editor web view */
+  export type EditorWebViewMessage = {
+    method: 'selectRange';
+    /** Goes to this Scripture Reference before setting the selection */
+    scrRef: ScriptureReference;
+    /** Endpoints of the selection. Should start at the same place as the scrRef */
+    range: SelectionRange;
+  };
+
+  /**
+   * Position in Scripture. See {@link CheckLocation} for more information as this is mostly a
+   * {@link CheckLocation} but using a `ScriptureReference` instead of a `VerseRef` since `VerseRef`
+   * doesn't travel across processes well
+   *
+   * Also added `bookNum` and `chapterNum` to the `jsonPath` result
+   */
+  export type ScriptureLocation =
+    | {
+        /** To which book this jsonPath is relative */
+        bookNum: number;
+        /** To which chapter this jsonPath is relative */
+        chapterNum: number;
+        /** JSONPath expression pointing to a location within USJ data */
+        jsonPath: string;
+        /**
+         * Offset to apply to the content inside of the property indicated by `jsonPath` to
+         * determine the start of the range.
+         *
+         * @example Given the following USJ, if the offset is 1, then this is pointing to the "a" in
+         * Matthew. If no offset is provided, then the entire object with type "para" is being
+         * pointed to.
+         *
+         * { "type": "para", "marker": "h", "content": [ "Matthew" ] }
+         */
+        offset?: number;
+      }
+    | {
+        /** Verse reference to a location with the document */
+        scrRef: ScriptureReference;
+        /** Offset to apply to start of the verse indicated by `verseRef` */
+        offset?: number;
+      };
+
+  /** A pair of Scripture positions that are either in USFM or USJ format */
+  export type ScriptureRange = {
+    /** Starting point where the check result applies in the document */
+    start: ScriptureLocation;
+    /** Ending point where the check result applies in the document */
+    end: ScriptureLocation;
+  };
+
+  export type PlatformScriptureEditorWebViewController = NetworkableObject<{
+    /** Set the current selection on the editor */
+    selectRange(range: ScriptureRange): Promise<void>;
+  }>;
+}
 
 declare module 'papi-shared-types' {
+  import type { PlatformScriptureEditorWebViewController } from 'platform-scripture-editor';
+
   export interface CommandHandlers {
     /**
      * Opens a new editor WebView and returns the WebView id
@@ -25,5 +105,9 @@ declare module 'papi-shared-types' {
     'platformScriptureEditor.openResourceViewer': (
       projectId?: string | undefined,
     ) => Promise<string | undefined>;
+  }
+
+  export interface WebViewControllers {
+    'platformScriptureEditor.react': PlatformScriptureEditorWebViewController;
   }
 }

--- a/extensions/src/platform-scripture/src/checking-results-list.web-view-provider.ts
+++ b/extensions/src/platform-scripture/src/checking-results-list.web-view-provider.ts
@@ -12,6 +12,8 @@ import checkingResultsListStyles from './checking-results-list.web-view.scss?inl
 export const checkResultsListWebViewType = 'platformScripture.checkingResults';
 
 export interface CheckResultsWebViewOptions extends GetWebViewOptions {
+  /** Id of the editor web view that opened this results list */
+  editorWebViewId?: string | undefined;
   projectId: string | undefined;
 }
 
@@ -69,6 +71,7 @@ export default class CheckResultsWebViewProvider implements IWebViewProvider {
       state: {
         ...savedWebView.state,
         webViewType: this.webViewType,
+        editorWebViewId: getWebViewOptions.editorWebViewId ?? savedWebView.state?.editorWebViewId,
       },
     };
   }

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -114,13 +114,16 @@ async function configureChecks(webViewId: string | undefined): Promise<string | 
 }
 
 async function showCheckResults(webViewId: string | undefined): Promise<string | undefined> {
+  let editorWebViewId: string | undefined;
   let projectId: string | undefined;
 
   logger.debug('Running checks');
 
   if (webViewId) {
-    const webViewDefinition = await papi.webViews.getSavedWebViewDefinition(webViewId);
+    const webViewDefinition = await papi.webViews.getOpenWebViewDefinition(webViewId);
     projectId = webViewDefinition?.projectId;
+    if (webViewDefinition?.webViewType === 'platformScriptureEditor.react')
+      editorWebViewId = webViewId;
   }
 
   if (!projectId) {
@@ -128,8 +131,8 @@ async function showCheckResults(webViewId: string | undefined): Promise<string |
     return undefined;
   }
 
-  const options: CheckResultsWebViewOptions = { projectId };
-  return papi.webViews.getWebView(checkResultsListWebViewType, { type: 'tab' }, options);
+  const options: CheckResultsWebViewOptions = { editorWebViewId, projectId };
+  return papi.webViews.openWebView(checkResultsListWebViewType, { type: 'tab' }, options);
 }
 
 export async function activate(context: ExecutionActivationContext) {


### PR DESCRIPTION
Resolves #454 

- Added `WebViewController`s for Scripture editors
  - One method `selectRange` that you pass USJ or USFM range specification, and it will select that location in the Scripture
- Converted Scripture editor `WebViewProvider` to `WebViewFactory`
- Set up check results list to call that web view controller on the editor from which it was opened

Known issues:
- Location offsets don't get converted quite properly from USFM to USJ
- Selection is really faint and hard to see. Also you can't really click into the editor without changing the selection

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1345)
<!-- Reviewable:end -->
