### PR TITLE
Fix macOS icu dylib loading problems when MacPorts is not installed

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -27,10 +27,36 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         uses: melusina-org/setup-macports@v1
 
+      - name: Install loader tools on macOS
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          sudo port -v install ld64
+
       - name: Install icu4c on macOS
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
-          sudo port -v install icu
+          sudo port -v install icu @74.2_0 +universal
+
+      - name: Fixup loader paths for icu4c
+        if: ${{ matrix.os == 'macos-latest' }}
+        # LIB_DEPENDENCIES are of the form "<ICU lib short name> <dependency as ICU lib short name>"
+        # For example, libicuuc (shortened to "uc") depends on libicudata (shortened to "data")
+        # Dependencies can be seen by running "dyld_info -dependents /path/to/something.dylib"
+        run: |
+          ICU_VERSION=74
+          LIB_DEPENDENCIES="
+          i18n data
+          i18n uc
+          io data
+          io i18n
+          io uc
+          uc data
+          "
+          LIB_DEPENDENCIES=$(echo "$LIB_DEPENDENCIES" | sed '/^$/d')
+          while IFS= read -r line; do
+            set -- $line
+            sudo install_name_tool -change "/opt/local/lib/libicu$2.$ICU_VERSION.dylib" "@loader_path/libicu$2.$ICU_VERSION.dylib" "/opt/local/lib/libicu$1.$ICU_VERSION.dylib"
+          done <<< "$LIB_DEPENDENCIES"
 
       - name: Checkout git repo
         uses: actions/checkout@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,10 +27,36 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         uses: melusina-org/setup-macports@v1
 
+      - name: Install loader tools on macOS
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          sudo port -v install ld64
+
       - name: Install icu4c on macOS
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
-          sudo port -v install icu
+          sudo port -v install icu @74.2_0 +universal
+
+      - name: Fixup loader paths for icu4c
+        if: ${{ matrix.os == 'macos-latest' }}
+        # LIB_DEPENDENCIES are of the form "<ICU lib short name> <dependency as ICU lib short name>"
+        # For example, libicuuc (shortened to "uc") depends on libicudata (shortened to "data")
+        # Dependencies can be seen by running "dyld_info -dependents /path/to/something.dylib"
+        run: |
+          ICU_VERSION=74
+          LIB_DEPENDENCIES="
+          i18n data
+          i18n uc
+          io data
+          io i18n
+          io uc
+          uc data
+          "
+          LIB_DEPENDENCIES=$(echo "$LIB_DEPENDENCIES" | sed '/^$/d')
+          while IFS= read -r line; do
+            set -- $line
+            sudo install_name_tool -change "/opt/local/lib/libicu$2.$ICU_VERSION.dylib" "@loader_path/libicu$2.$ICU_VERSION.dylib" "/opt/local/lib/libicu$1.$ICU_VERSION.dylib"
+          done <<< "$LIB_DEPENDENCIES"
 
       - name: Checkout git repo
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,36 @@ jobs:
         if: ${{ matrix.os == 'macos-latest' }}
         uses: melusina-org/setup-macports@v1
 
+      - name: Install loader tools on macOS
+        if: ${{ matrix.os == 'macos-latest' }}
+        run: |
+          sudo port -v install ld64
+
       - name: Install icu4c on macOS
         if: ${{ matrix.os == 'macos-latest' }}
-        run: sudo port -v install icu
+        run: |
+          sudo port -v install icu @74.2_0 +universal
+
+      - name: Fixup loader paths for icu4c
+        if: ${{ matrix.os == 'macos-latest' }}
+        # LIB_DEPENDENCIES are of the form "<ICU lib short name> <dependency as ICU lib short name>"
+        # For example, libicuuc (shortened to "uc") depends on libicudata (shortened to "data")
+        # Dependencies can be seen by running "dyld_info -dependents /path/to/something.dylib"
+        run: |
+          ICU_VERSION=74
+          LIB_DEPENDENCIES="
+          i18n data
+          i18n uc
+          io data
+          io i18n
+          io uc
+          uc data
+          "
+          LIB_DEPENDENCIES=$(echo "$LIB_DEPENDENCIES" | sed '/^$/d')
+          while IFS= read -r line; do
+            set -- $line
+            sudo install_name_tool -change "/opt/local/lib/libicu$2.$ICU_VERSION.dylib" "@loader_path/libicu$2.$ICU_VERSION.dylib" "/opt/local/lib/libicu$1.$ICU_VERSION.dylib"
+          done <<< "$LIB_DEPENDENCIES"
 
       - name: Check out Git repository
         uses: actions/checkout@v4

--- a/c-sharp/ParanextDataProvider.csproj
+++ b/c-sharp/ParanextDataProvider.csproj
@@ -28,7 +28,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="icu.net" Version="2.10.0" />
+    <PackageReference Include="icu.net" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.1" />
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.1" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
@@ -60,7 +60,7 @@
     by default.
     -->
   <ItemGroup>
-    <Content Include="/opt/local/lib/libicu*.??.dylib" Condition="$([MSBuild]::IsOsPlatform('macOS'))">
+    <Content Include="/opt/local/lib/libicu*.??.dylib" Exclude="/opt/local/lib/libicutest*.dylib;/opt/local/lib/libicutu*.dylib" Condition="$([MSBuild]::IsOsPlatform('macOS'))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/c-sharp/Program.cs
+++ b/c-sharp/Program.cs
@@ -16,6 +16,14 @@ public static class Program
         Console.WriteLine("Paranext data provider starting up");
         Thread.CurrentThread.Name = "Main";
 
+        // Turn on additional logging to help diagnose failures on macOS
+        if (OperatingSystem.IsMacOS())
+        {
+            System.Diagnostics.Trace.Listeners.Add(new System.Diagnostics.ConsoleTraceListener());
+            System.Diagnostics.Trace.AutoFlush = true;
+            System.Diagnostics.Trace.WriteLine("Trace logging enabled");
+        }
+
         using PapiClient papi = new();
         try
         {


### PR DESCRIPTION
To decipher the changes made:
1) We need to add `+universal` to the MacPorts install of icu libs or we only get libs matching the architecture of the build machine (i.e., x64 or arm64). That would leave one architecture always broken, and it would vary which is broken depending on whether an arm64 or x64 machine was used for building. Universal libraries are basically containers that contain 2 libraries, one for x64 and one for arm64. Our build process doesn't provide a simple way to build separately for different architectures, so including universal libraries is a simple fix even though it makes the download larger since you'll always include code that isn't for your architecture. Because I'm not sure if every build of ICU on MacPorts will include universal libs, I locked in the version number to one that does.
2) We need to fix up the loader paths embedded inside each `dylib` so it doesn't look for its dependent `dylibs` only in the path where they were on the machine used to build the ICU `dylib` files originally that we download from MacPorts. As it stands now, when you load one of the ICU `dylib`s, it always looks for its dependencies under `/opt/local/lib`. Unless the machine running Platform.Bible has ICU installed from MacPorts (which puts them under `/opt/local/lib`), then loading ICU `dylib`s will not work in P.B. Apple provides a tool (`install_name_tool`) that can rewrite locations inside of a library where to look for each dependency.
3) I updated the .NET copying of ICU libs to exclude two that are only meant for testing. They aren't needed in production, and we don't need them for our own testing, either. `icu.net` might use them, but P.B does not.
4) I updated the version of `icu.net` to one that includes trace logging if loading ICU libraries fails. I updated the .NET program to log that extra trace information to the console when running on macOS. I didn't add it for other OSes for now. We can always adjust that later easily.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1346)
<!-- Reviewable:end -->
