### PR TITLE
Fixed slow startup problems

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4050,6 +4050,8 @@ declare module 'shared/models/project-lookup.service-model' {
   /** Local object of functions to run locally on each process as part of the project lookup service */
   export const projectLookupServiceBase: ProjectLookupServiceType;
   /**
+   * Gets project metadata from PDPFs filtered down by various filtering options
+   *
    * Note: If there are multiple PDPs available whose metadata matches the conditions provided by the
    * parameters, their project metadata will all be combined, so all available `projectInterface`s
    * provided by the PDP Factory with the matching id (or all PDP Factories if no id is specified) for
@@ -4111,6 +4113,7 @@ declare module 'shared/models/project-lookup.service-model' {
     internalGetMetadata: typeof internalGetMetadata;
     compareProjectDataProviderFactoryMetadataInfoMinimalMatch: typeof compareProjectDataProviderFactoryMetadataInfoMinimalMatch;
     transformGetMetadataForProjectParametersToFilter: typeof transformGetMetadataForProjectParametersToFilter;
+    LOAD_TIME_GRACE_PERIOD_MS: number;
   };
 }
 declare module 'shared/services/project-lookup.service' {

--- a/src/extension-host/services/contribution.service.ts
+++ b/src/extension-host/services/contribution.service.ts
@@ -1,0 +1,217 @@
+import { ExtensionManifest } from '@extension-host/extension-types/extension-manifest.model';
+import { AsyncVariable, JsonDocumentLike, Unsubscriber } from 'platform-bible-utils';
+import * as nodeFS from '@node/services/node-file-system.service';
+import { joinUriPaths } from '@node/utils/util';
+import logger from '@shared/services/logger.service';
+import SettingsDocumentCombiner from '@shared/utils/settings-document-combiner';
+import { platformSettings } from '@extension-host/data/core-settings-info.data';
+import MenuDocumentCombiner from '@shared/utils/menu-document-combiner';
+import menuDataObject from '@extension-host/data/menu.data.json';
+import ProjectSettingsDocumentCombiner from '@shared/utils/project-settings-document-combiner';
+import { platformProjectSettings } from '@extension-host/data/core-project-settings-info.data';
+import LocalizedStringsDocumentCombiner from '@shared/utils/localized-strings-document-combiner';
+
+// #region document combiners - manage the extension contributions. Services should layer over these
+
+/**
+ * Object that keeps track of all settings contributions in the platform. To listen to updates to
+ * the settings contributions, subscribe to its `onDidRebuild` event (consider debouncing as each
+ * contribution will trigger a rebuild).
+ *
+ * Keeping this object separate from the data provider and disabling the `set` calls in the data
+ * provider prevents random services from changing system settings contributions unexpectedly.
+ */
+export const settingsDocumentCombiner = new SettingsDocumentCombiner(platformSettings);
+/**
+ * Object that keeps track of all active menus in the platform. Call
+ * {@link MenuDataDataProviderEngine.rebuildMenus} in the service host after updating this object.
+ *
+ * Keeping this object separate from the data provider and disabling the `set` calls in the data
+ * provider prevents random services from changing system menus unexpectedly.
+ */
+export const menuDocumentCombiner = new MenuDocumentCombiner(menuDataObject);
+/**
+ * Object that keeps track of all project settings contributions in the platform. To listen to
+ * updates to the project settings contributions, subscribe to its `onDidRebuild` event (consider
+ * debouncing as each contribution will trigger a rebuild).
+ *
+ * Keeping this object separate from the network object prevents random services from changing
+ * system project settings contributions unexpectedly.
+ */
+export const projectSettingsDocumentCombiner = new ProjectSettingsDocumentCombiner(
+  platformProjectSettings,
+);
+/**
+ * Object that keeps track of all localized string contributions in the platform. To listen to
+ * updates to the localized string contributions, subscribe to its `onDidRebuild` event (consider
+ * debouncing as each contribution will trigger a rebuild).
+ *
+ * Keeping this object separate from the data provider and disabling the `set` calls in the data
+ * provider prevents random services from changing system localized string contributions
+ * unexpectedly.
+ */
+export const localizedStringsDocumentCombiner = new LocalizedStringsDocumentCombiner({});
+
+// #endregion
+
+const onDidResyncContributionsSubscriptions: (() => Promise<void>)[] = [];
+/**
+ * Event that runs asynchronous functions after extension contributions are finished being set up
+ * and after they are re-synced. Function calls are awaited
+ */
+export function onDidResyncContributions(callback: () => Promise<void>): Unsubscriber {
+  onDidResyncContributionsSubscriptions.push(callback);
+  return () => {
+    const callbackIndex = onDidResyncContributionsSubscriptions.indexOf(callback);
+    if (callbackIndex < 0) return false;
+    onDidResyncContributionsSubscriptions.splice(callbackIndex, 1);
+    return true;
+  };
+}
+
+let resyncContributionsCount = -1;
+function createNewResyncContributionsVariable() {
+  resyncContributionsCount += 1;
+  return new AsyncVariable<undefined>(`resyncContributions ${resyncContributionsCount}`, -1);
+}
+let resyncContributionsVariable = createNewResyncContributionsVariable();
+
+/**
+ * Returns a promise that resolves when the extension service is done resyncing contributions. If it
+ * has already set up contributions before and is not currently resyncing contributions, the promise
+ * will already be resolved.
+ *
+ * This should be used when attempting to access contribution information to ensure you aren't
+ * accessing incomplete or out-of-date contribution information
+ */
+export async function waitForResyncContributions() {
+  return resyncContributionsVariable.promise;
+}
+
+/** Clears extension contributions and re-adds them. Only call from `extension.service.ts`! */
+export async function resyncContributions(
+  extensionsToAdd: Readonly<ExtensionManifest & { dirUri: string }>[],
+) {
+  if (resyncContributionsVariable.hasSettled)
+    resyncContributionsVariable = createNewResyncContributionsVariable();
+
+  menuDocumentCombiner.deleteAllContributions();
+  settingsDocumentCombiner.deleteAllContributions();
+  projectSettingsDocumentCombiner.deleteAllContributions();
+  localizedStringsDocumentCombiner.deleteAllContributions();
+
+  // Load up all the extension contributions asynchronously
+  const extensionsContributions = await Promise.all(
+    extensionsToAdd.map(async (extension) => {
+      let localizedStringsDocument: JsonDocumentLike | undefined;
+      if (extension.localizedStrings) {
+        try {
+          // TODO: Provide a way to make sure extensions don't tell us to read files outside their dir
+          const localizedStringsJson = await nodeFS.readFileText(
+            joinUriPaths(extension.dirUri, extension.localizedStrings),
+          );
+          localizedStringsDocument = JSON.parse(localizedStringsJson);
+        } catch (error) {
+          logger.warn(
+            `Could not load localized strings contribution for ${extension.name}: ${error}`,
+          );
+        }
+      }
+      let menuDocument: JsonDocumentLike | undefined;
+      if (extension.menus) {
+        try {
+          // TODO: Provide a way to make sure extensions don't tell us to read files outside their dir
+          const menuJson = await nodeFS.readFileText(
+            joinUriPaths(extension.dirUri, extension.menus),
+          );
+          menuDocument = JSON.parse(menuJson);
+        } catch (error) {
+          logger.warn(`Could not load menu contribution for ${extension.name}: ${error}`);
+        }
+      }
+      let settingsDocument: JsonDocumentLike | undefined;
+      if (extension.settings) {
+        try {
+          // TODO: Provide a way to make sure extensions don't tell us to read files outside their dir
+          const settingsJson = await nodeFS.readFileText(
+            joinUriPaths(extension.dirUri, extension.settings),
+          );
+          settingsDocument = JSON.parse(settingsJson);
+        } catch (error) {
+          logger.warn(`Could not load settings contribution for ${extension.name}: ${error}`);
+        }
+      }
+      let projectSettingsDocument: JsonDocumentLike | undefined;
+      if (extension.projectSettings) {
+        try {
+          // TODO: Provide a way to make sure extensions don't tell us to read files outside their dir
+          const projectSettingsJson = await nodeFS.readFileText(
+            joinUriPaths(extension.dirUri, extension.projectSettings),
+          );
+          projectSettingsDocument = JSON.parse(projectSettingsJson);
+        } catch (error) {
+          logger.warn(
+            `Could not load project settings contribution for ${extension.name}: ${error}`,
+          );
+        }
+      }
+
+      return {
+        name: extension.name,
+        localizedStringsDocument,
+        menuDocument,
+        settingsDocument,
+        projectSettingsDocument,
+      };
+    }),
+  );
+
+  // Load contributions in the order in which the extensions are loaded
+  extensionsContributions.forEach(
+    ({
+      name,
+      localizedStringsDocument,
+      menuDocument,
+      settingsDocument,
+      projectSettingsDocument,
+    }) => {
+      if (localizedStringsDocument)
+        try {
+          localizedStringsDocumentCombiner.addOrUpdateContribution(name, localizedStringsDocument);
+        } catch (error) {
+          logger.warn(`Could not add localized strings contribution for ${name}: ${error}`);
+        }
+      if (menuDocument)
+        try {
+          menuDocumentCombiner.addOrUpdateContribution(name, menuDocument);
+        } catch (error) {
+          logger.warn(`Could not add menu contribution for ${name}: ${error}`);
+        }
+      if (settingsDocument)
+        try {
+          settingsDocumentCombiner.addOrUpdateContribution(name, settingsDocument);
+        } catch (error) {
+          logger.warn(`Could not add settings contribution for ${name}: ${error}`);
+        }
+      if (projectSettingsDocument)
+        try {
+          projectSettingsDocumentCombiner.addOrUpdateContribution(name, projectSettingsDocument);
+        } catch (error) {
+          logger.warn(`Could not add project settings contribution for ${name}: ${error}`);
+        }
+    },
+  );
+
+  resyncContributionsVariable.resolveToValue(undefined, true);
+
+  // Do things in response to finishing resyncing contributions
+  await Promise.all(
+    [...onDidResyncContributionsSubscriptions].map(async (callback, i) => {
+      try {
+        await callback();
+      } catch (e) {
+        logger.warn(`onDidResyncContributionsSubscriptions threw on callback ${i}! ${e}`);
+      }
+    }),
+  );
+}

--- a/src/extension-host/services/localization.service-host.test.ts
+++ b/src/extension-host/services/localization.service-host.test.ts
@@ -58,6 +58,11 @@ jest.mock('@shared/services/logger.service', () => ({
     warn: jest.fn(() => {}),
   },
 }));
+jest.mock('@extension-host/services/contribution.service', () => ({
+  ...jest.requireActual('@extension-host/services/contribution.service'),
+  // Don't actually wait because we're not syncing any contributions in these tests
+  waitForResyncContributions: async () => {},
+}));
 
 let localizationDataProviderEngine: Awaited<
   ReturnType<typeof testingLocalizationService.implementLocalizationDataProviderEngine>

--- a/src/extension-host/services/menu-data.service-host.ts
+++ b/src/extension-host/services/menu-data.service-host.ts
@@ -14,19 +14,10 @@ import {
   ReferencedItem,
   WebViewMenu,
   Localized,
+  Unsubscriber,
 } from 'platform-bible-utils';
-import menuDataObject from '@extension-host/data/menu.data.json';
 import logger from '@shared/services/logger.service';
-import MenuDocumentCombiner from '@shared/utils/menu-document-combiner';
-
-/**
- * Object that keeps track of all active menus in the platform. Call
- * {@link MenuDataDataProviderEngine.rebuildMenus} in the service host after updating this object.
- *
- * Keeping this object separate from the data provider and disabling the `set` calls in the data
- * provider prevents random services from changing system menus unexpectedly.
- */
-export const menuDocumentCombiner = new MenuDocumentCombiner(menuDataObject);
+import { menuDocumentCombiner, onDidResyncContributions } from './contribution.service';
 
 class MenuDataDataProviderEngine
   extends DataProviderEngine<MenuDataDataTypes>
@@ -34,10 +25,12 @@ class MenuDataDataProviderEngine
 {
   private mainMenu: Localized<MultiColumnMenu> = { groups: {}, items: [], columns: {} };
   private webViewMenusMap = new Map<ReferencedItem, Localized<WebViewMenu>>();
+  private unsubscribeOnDidResyncContributions: Unsubscriber | undefined;
 
   constructor(menuData: Localized<PlatformMenus>) {
     super();
     this.#loadAllMenuData(menuData);
+    onDidResyncContributions(() => this.rebuildMenus());
   }
 
   async rebuildMenus(): Promise<void> {
@@ -73,6 +66,15 @@ class MenuDataDataProviderEngine
     throw new Error('setWebViewMenu disabled');
   }
 
+  async dispose(): Promise<boolean> {
+    if (this.unsubscribeOnDidResyncContributions) {
+      const success = this.unsubscribeOnDidResyncContributions();
+      this.unsubscribeOnDidResyncContributions = undefined;
+      return success;
+    }
+    return true;
+  }
+
   #loadAllMenuData(menuData: Localized<PlatformMenus>): void {
     this.mainMenu = { groups: {}, items: [], columns: {} };
     this.webViewMenusMap.clear();
@@ -100,9 +102,13 @@ export async function initialize(): Promise<void> {
     initializationPromise = new Promise<void>((resolve, reject) => {
       const executor = async () => {
         try {
+          if (!menuDocumentCombiner.rawOutput)
+            throw new Error(
+              'Menu data service host initialization error: Menu Document Combiner output was null!',
+            );
           dataProvider = await dataProviderService.registerEngine(
             menuDataServiceProviderName,
-            new MenuDataDataProviderEngine(menuDataObject),
+            new MenuDataDataProviderEngine(menuDocumentCombiner.rawOutput),
           );
           resolve();
         } catch (error) {

--- a/src/extension-host/services/project-settings.service-host.test.ts
+++ b/src/extension-host/services/project-settings.service-host.test.ts
@@ -42,6 +42,11 @@ jest.mock('@shared/services/localization.service', () => ({
     },
   },
 }));
+jest.mock('@extension-host/services/contribution.service', () => ({
+  ...jest.requireActual('@extension-host/services/contribution.service'),
+  // Don't actually wait because we're not syncing any contributions in these tests
+  waitForResyncContributions: async () => {},
+}));
 
 describe('isValid', () => {
   it('should return true', async () => {

--- a/src/extension-host/services/settings.service-host.test.ts
+++ b/src/extension-host/services/settings.service-host.test.ts
@@ -70,6 +70,11 @@ jest.mock('@shared/services/localization.service', () => ({
     },
   },
 }));
+jest.mock('@extension-host/services/contribution.service', () => ({
+  ...jest.requireActual('@extension-host/services/contribution.service'),
+  // Don't actually wait because we're not syncing any contributions in these tests
+  waitForResyncContributions: async () => {},
+}));
 
 test('Get verseRef returns default value', async () => {
   const result = await settingsProviderEngine.get('platform.verseRef');

--- a/src/extension-host/services/settings.service-host.ts
+++ b/src/extension-host/services/settings.service-host.ts
@@ -13,10 +13,7 @@ import {
   settingsServiceDataProviderName,
   settingsServiceObjectToProxy,
 } from '@shared/services/settings.service-model';
-import {
-  coreSettingsValidators,
-  platformSettings,
-} from '@extension-host/data/core-settings-info.data';
+import { coreSettingsValidators } from '@extension-host/data/core-settings-info.data';
 import { SettingNames, SettingTypes } from 'papi-shared-types';
 import {
   Unsubscriber,
@@ -31,21 +28,13 @@ import {
 import { joinUriPaths } from '@node/utils/util';
 import * as nodeFS from '@node/services/node-file-system.service';
 import { serializeRequestType } from '@shared/utils/util';
-import SettingsDocumentCombiner from '@shared/utils/settings-document-combiner';
 import { LocalizedSettingsContributionInfo } from '@shared/utils/settings-document-combiner-base';
-import { dataProviders } from './papi-backend.service';
+import {
+  settingsDocumentCombiner,
+  waitForResyncContributions,
+} from '@extension-host/services/contribution.service';
 
 const SETTINGS_FILE_URI = joinUriPaths('data://', 'settings.json');
-
-/**
- * Object that keeps track of all settings contributions in the platform. To listen to updates to
- * the settings contributions, subscribe to its `onDidRebuild` event (consider debouncing as each
- * contribution will trigger a rebuild).
- *
- * Keeping this object separate from the data provider and disabling the `set` calls in the data
- * provider prevents random services from changing system settings contributions unexpectedly.
- */
-export const settingsDocumentCombiner = new SettingsDocumentCombiner(platformSettings);
 
 async function getSettingsDataFromFile() {
   const settingsFileExists = await nodeFS.getStats(SETTINGS_FILE_URI);
@@ -66,6 +55,7 @@ async function writeSettingsDataToFile(settingsData: Partial<AllSettingsData>) {
 async function getDefaultValueForKey<SettingName extends SettingNames>(
   key: SettingName,
 ): Promise<SettingTypes[SettingName]> {
+  await waitForResyncContributions();
   const settingInfo = settingsDocumentCombiner.getSettingsContributionInfo()?.settings[key];
   if (!settingInfo) {
     throw new Error(`No setting exists for key ${key}`);
@@ -139,11 +129,12 @@ class SettingDataProviderEngine
   }
 
   /* eslint-disable @typescript-eslint/class-methods-use-this */
-  @dataProviders.decorators.ignore
+  @dataProviderService.decorators.ignore
   async getLocalizedSettingsContributionInfo(): Promise<
     /* eslint-enable */
     LocalizedSettingsContributionInfo | undefined
   > {
+    await waitForResyncContributions();
     return settingsDocumentCombiner.getLocalizedSettingsContributionInfo();
   }
 

--- a/src/shared/models/project-lookup.service-model.ts
+++ b/src/shared/models/project-lookup.service-model.ts
@@ -19,6 +19,7 @@ import {
   slice,
   transformAndEnsureRegExpArray,
   transformAndEnsureRegExpRegExpArray,
+  wait,
 } from 'platform-bible-utils';
 
 export const NETWORK_OBJECT_NAME_PROJECT_LOOKUP_SERVICE = 'ProjectLookupService';
@@ -152,7 +153,7 @@ export const projectLookupServiceBase: ProjectLookupServiceType = {
   async getMetadataForAllProjects(
     options: ProjectMetadataFilterOptions = {},
   ): Promise<ProjectMetadata[]> {
-    return internalGetMetadata(options);
+    return internalGetMetadataWithRetries(options);
   },
   async getMetadataForProject(
     projectId: string,
@@ -196,7 +197,7 @@ export const projectLookupServiceBase: ProjectLookupServiceType = {
       }
     }
 
-    const metadata = await internalGetMetadata(
+    const metadata = await internalGetMetadataWithRetries(
       transformGetMetadataForProjectParametersToFilter(projectId, projectInterface, pdpFactoryId),
     );
 
@@ -335,6 +336,19 @@ export const projectLookupServiceBase: ProjectLookupServiceType = {
 // #region Project Lookup Service utility functions
 
 /**
+ * How long since start of the current process to count as time that the PDPFs possibly still
+ * haven't all started up
+ */
+const LOAD_TIME_GRACE_PERIOD_MS = 30 * 1000;
+/**
+ * How long to wait in-between attempts to get project metadata during the time since the current
+ * process started
+ */
+const GRACE_PERIOD_WAIT_TIME_MS = 1 * 1000;
+
+/**
+ * Gets project metadata from PDPFs filtered down by various filtering options
+ *
  * Note: If there are multiple PDPs available whose metadata matches the conditions provided by the
  * parameters, their project metadata will all be combined, so all available `projectInterface`s
  * provided by the PDP Factory with the matching id (or all PDP Factories if no id is specified) for
@@ -353,7 +367,7 @@ async function internalGetMetadata(
     excludePdpFactoryIds,
   } = ensurePopulatedMetadataFilter(options);
 
-  // Get all registered PDP factories
+  // Get all registered PDP factories and filter down to just the included ones
   const networkObjects = await networkObjectStatusService.getAllNetworkObjectDetails();
   const pdpFactoryIds = Object.keys(networkObjects)
     .filter((pdpfNetworkObjectName) => {
@@ -452,6 +466,50 @@ async function internalGetMetadata(
         includeProjectInterfaces,
         excludeProjectInterfaces,
       ),
+    );
+  }
+
+  return allProjectsMetadataArray;
+}
+
+/**
+ * Gets project metadata from PDPFs filtered down by various filtering options. If this process
+ * started recently and this finds no project metadata, waits a bit and tries again because it may
+ * be that not all PDPFs have started yet.
+ *
+ * Note: If there are multiple PDPs available whose metadata matches the conditions provided by the
+ * parameters, their project metadata will all be combined, so all available `projectInterface`s
+ * provided by the PDP Factory with the matching id (or all PDP Factories if no id is specified) for
+ * the project will be returned. If you need `projectInterface`s supported by specific PDP
+ * Factories, you can access it at {@link ProjectMetadata.pdpFactoryInfo}.
+ */
+async function internalGetMetadataWithRetries(
+  options: ProjectMetadataFilterOptions = {},
+): Promise<ProjectMetadata[]> {
+  let allProjectsMetadataArray: ProjectMetadata[] = await internalGetMetadata(options);
+
+  // If we're in the first little while of the process, there's a chance not all the PDPFs have
+  // loaded. Let's wait a bit and try again if we got no matching project metadata
+  let retryTimes = 0;
+  while (allProjectsMetadataArray.length === 0 && performance.now() < LOAD_TIME_GRACE_PERIOD_MS) {
+    logger.debug(
+      `Did not find any project metadata around ${performance.now()} for ${JSON.stringify(options)}. Will retry`,
+    );
+    // Intentionally stopping this method execution to wait some time
+    // eslint-disable-next-line no-await-in-loop
+    await wait(GRACE_PERIOD_WAIT_TIME_MS);
+    // Intentionally stopping this method execution to try getting project metadata again
+    // eslint-disable-next-line no-await-in-loop
+    allProjectsMetadataArray = await internalGetMetadata(options);
+    retryTimes += 1;
+    if (allProjectsMetadataArray.length > 0)
+      logger.debug(
+        `Finally found project metadata on retry ${retryTimes} around ${performance.now()} for ${JSON.stringify(options)}! ${JSON.stringify(allProjectsMetadataArray)}`,
+      );
+  }
+  if (allProjectsMetadataArray.length === 0) {
+    logger.warn(
+      `Did not find any project metadata${retryTimes > 0 ? ` on retry ${retryTimes}` : ''} for ${JSON.stringify(options)} after the grace period. If you expected to find projects for these filters, this probably indicates a problem. Maybe not all PDPFs loaded in time.`,
     );
   }
 
@@ -670,6 +728,7 @@ export const testingProjectLookupService = {
   internalGetMetadata,
   compareProjectDataProviderFactoryMetadataInfoMinimalMatch,
   transformGetMetadataForProjectParametersToFilter,
+  LOAD_TIME_GRACE_PERIOD_MS,
 };
 
 // #endregion

--- a/src/shared/services/project-lookup.service.test.ts
+++ b/src/shared/services/project-lookup.service.test.ts
@@ -36,6 +36,35 @@ jest.mock('@shared/services/network-object-status.service', () => ({
   },
 }));
 
+beforeAll(() => {
+  jest.useFakeTimers({
+    advanceTimers: true,
+    // Only fake performance.now()
+    doNotFake: [
+      'Date',
+      'hrtime',
+      'nextTick',
+      // 'performance',
+      'queueMicrotask',
+      'requestAnimationFrame',
+      'cancelAnimationFrame',
+      'requestIdleCallback',
+      'cancelIdleCallback',
+      'setImmediate',
+      'clearImmediate',
+      'setInterval',
+      'clearInterval',
+      'setTimeout',
+      'clearTimeout',
+    ],
+  });
+  jest.advanceTimersByTime(testingProjectLookupService.LOAD_TIME_GRACE_PERIOD_MS);
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
 beforeEach(() => {
   // @ts-expect-error ts(2339) TypeScript doesn't realize this is a jest function :(
   networkObjectService.get.mockImplementation(() => {


### PR DESCRIPTION
Resolves #1176 (hopefully)

- Made contribution-based services wait for extensions to load before giving out data where reasonably straight-forward to do (menu service especially didn't really get this benefit because it wasn't as simple as doing the others. But it is a data provider, so hopefully consumers will listen to updates and get the updated data anyway)
  - Fixes dotnet process getting settings before extensions load
- Added retry to getting project metadata if not found in process first 30 seconds
  - Fixes not seeing any projects when clicking menu item "Open Scripture Editor" before the dotnet process finishes loading

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1370)
<!-- Reviewable:end -->
