### PR TITLE
Revert the Node version change to fix electron builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -244,6 +244,6 @@
   },
   "workspaces": ["lib/*", "extensions", "extensions/src/*"],
   "volta": {
-    "node": "22.12.0"
+    "node": "20.18.0"
   }
 }


### PR DESCRIPTION
Only on Windows, the latest updates seem to break the `publish` step in our GitHub workflows. I think this started with the change that included updating Node, so trying to back this out to see if that fixes the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1388)
<!-- Reviewable:end -->
