### PR TITLE
Update ICU version on macOS to 76.1

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install icu4c on macOS
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
-          sudo port -v install icu @74.2_0 +universal
+          sudo port -v install icu @76.1_0 +universal
 
       - name: Fixup loader paths for icu4c
         if: ${{ matrix.os == 'macos-latest' }}
@@ -43,7 +43,7 @@ jobs:
         # For example, libicuuc (shortened to "uc") depends on libicudata (shortened to "data")
         # Dependencies can be seen by running "dyld_info -dependents /path/to/something.dylib"
         run: |
-          ICU_VERSION=74
+          ICU_VERSION=76
           LIB_DEPENDENCIES="
           i18n data
           i18n uc

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install icu4c on macOS
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
-          sudo port -v install icu @74.2_0 +universal
+          sudo port -v install icu @76.1_0 +universal
 
       - name: Fixup loader paths for icu4c
         if: ${{ matrix.os == 'macos-latest' }}
@@ -43,7 +43,7 @@ jobs:
         # For example, libicuuc (shortened to "uc") depends on libicudata (shortened to "data")
         # Dependencies can be seen by running "dyld_info -dependents /path/to/something.dylib"
         run: |
-          ICU_VERSION=74
+          ICU_VERSION=76
           LIB_DEPENDENCIES="
           i18n data
           i18n uc

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install icu4c on macOS
         if: ${{ matrix.os == 'macos-latest' }}
         run: |
-          sudo port -v install icu @74.2_0 +universal
+          sudo port -v install icu @76.1_0 +universal
 
       - name: Fixup loader paths for icu4c
         if: ${{ matrix.os == 'macos-latest' }}
@@ -46,7 +46,7 @@ jobs:
         # For example, libicuuc (shortened to "uc") depends on libicudata (shortened to "data")
         # Dependencies can be seen by running "dyld_info -dependents /path/to/something.dylib"
         run: |
-          ICU_VERSION=74
+          ICU_VERSION=76
           LIB_DEPENDENCIES="
           i18n data
           i18n uc


### PR DESCRIPTION
ICU 74.2 is no longer available on MacPorts. Moving to version 76.1 as the error message indicates it is the latest version. Per https://github.com/unicode-org/icu/releases, this is the latest version as of Oct 2024.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1416)
<!-- Reviewable:end -->
