### PR TITLE
PT-1640: Stop listening for changes to bundled extensions when in portable

### DIFF
--- a/src/main/services/extension-host.service.ts
+++ b/src/main/services/extension-host.service.ts
@@ -150,7 +150,13 @@ async function startExtensionHost() {
   if (app.isPackaged) {
     extensionHost = fork(
       path.join(__dirname, '../extension-host/extension-host.js'),
-      [commandLineArgumentsAliases[COMMAND_LINE_ARGS.Packaged][0], ...sharedArgs],
+      [
+        commandLineArgumentsAliases[COMMAND_LINE_ARGS.Packaged][0],
+        ...(process.env.PORTABLE_EXECUTABLE_FILE
+          ? [commandLineArgumentsAliases[COMMAND_LINE_ARGS.Portable][0]]
+          : []),
+        ...sharedArgs,
+      ],
       {
         stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
       },

--- a/src/node/utils/command-line.util.ts
+++ b/src/node/utils/command-line.util.ts
@@ -16,6 +16,8 @@ type CommandLineArgumentAliases = {
  * - ResourcesPath - Command-line argument that specifies the path to the resources folder
  * - Packaged - Command-line switch that specifies if the application is packaged. Only on
  *   extension-host
+ * - Portable - Command-line switch that specifies if the application is a windows portable app. Only
+ *   on extension-host
  */
 export enum COMMAND_LINE_ARGS {
   Extensions = 'extensions',
@@ -23,6 +25,7 @@ export enum COMMAND_LINE_ARGS {
   LogLevel = 'log_level',
   ResourcesPath = 'resources_path',
   Packaged = 'packaged',
+  Portable = 'portable',
 }
 
 /**
@@ -35,6 +38,7 @@ export const commandLineArgumentsAliases: CommandLineArgumentAliases = {
   [COMMAND_LINE_ARGS.LogLevel]: ['--logLevels', '--logLevel', '-l'],
   [COMMAND_LINE_ARGS.ResourcesPath]: ['--resourcesPath', '--resourcePath', '-r'],
   [COMMAND_LINE_ARGS.Packaged]: ['--packaged', '--isPackaged', '-p'],
+  [COMMAND_LINE_ARGS.Portable]: ['--portable'],
 };
 
 /** Get the index of the next command-line argument after the startIndex */


### PR DESCRIPTION
Stop listening for changes to bundled extensions and restarting when in portable since those will pretty much not be able to be changed
- Fixed uri redirect handling in portable not working because extensions restarted when the portable app was opened (because it unzipped, deleting the existing files and unzipping over them) by the redirect and therefore were not available to accept the redirect.

Relates to https://paratextstudio.atlassian.net/browse/PT-1640

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1434)
<!-- Reviewable:end -->
