### PR TITLE
fix C# project root folder paths

### DIFF
--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -285,8 +285,10 @@ internal class LocalParatextProjects
         // Add usfm.sty and Attribution.md
         foreach (string requiredFile in _requiredProjectRootFiles)
         {
-            var dest = Path.Join(ProjectRootFolder, requiredFile);
-            File.Copy(Path.Join("assets", requiredFile), dest, true);
+            string basePath = AppContext.BaseDirectory;
+            string sourcePath = Path.Combine(basePath, "assets", requiredFile);
+            string dest = Path.Join(ProjectRootFolder, requiredFile);
+            File.Copy(sourcePath, dest, true);
         }
     }
 


### PR DESCRIPTION
- previously it was copying from 'assets' in the repo root (wrong) rather than from 'c-sharp/assets' (correct) but only for one developer

Note I've tested this still works in a production build.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1435)
<!-- Reviewable:end -->
