### PR TITLE
Fix instructions after a clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,10 @@ cd paranext-core
 npm install
 ```
 
-To build the declaration type file `papi.d.ts` for extensions to use, run the following:
+To build, run the following:
 
 ```bash
-npm run build:types
+npm run build
 ```
 
 ## Starting Development


### PR DESCRIPTION
- previously you could get this extension host error: `An unexpected error occurred while executing "object:platform.settingsServiceDataProvider-data.get" JSON-RPC method: Error: No setting exists for key platformScripture.includeMyParatext9Projects  at getDefaultValueForKey (C:\Users\Ira\src\paranext-core2\src\extension-host\services\settings.service-host.ts:61:11)`
- building before starting fixes this

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1436)
<!-- Reviewable:end -->
