### PR TITLE
update editor

### DIFF
--- a/extensions/src/platform-scripture-editor/package.json
+++ b/extensions/src/platform-scripture-editor/package.json
@@ -38,7 +38,7 @@
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {
-    "@biblionexus-foundation/platform-editor": "~0.6.7",
+    "@biblionexus-foundation/platform-editor": "~0.7.0",
     "@biblionexus-foundation/scripture-utilities": "~0.0.7",
     "@swc/core": "^1.10.1",
     "@tailwindcss/typography": "^0.5.15",

--- a/extensions/src/platform-scripture-editor/src/_nodes-menu.scss
+++ b/extensions/src/platform-scripture-editor/src/_nodes-menu.scss
@@ -1,0 +1,74 @@
+/* stylelint-disable selector-no-qualifying-type */
+
+/* Floating Menu Styles */
+.floating-box:has(> .autocomplete-menu-container) {
+  background: #f1f1f1;
+  border: 1px solid #ccc;
+}
+
+.floating-box .autocomplete-menu-options {
+  display: block;
+  text-align: left;
+  width: fit-content;
+  overflow-x: clip;
+  text-overflow: ellipsis;
+  overflow-y: auto;
+  max-height: 200px;
+}
+
+.autocomplete-menu-options button {
+  background: transparent;
+  color: inherit;
+  display: grid;
+  grid-template-columns: min-content minmax(0, 90vw);
+  align-items: baseline;
+  max-width: 400px;
+  gap: 1rem;
+  width: 100%;
+  white-space: nowrap;
+  font-size: 0.9rem;
+  border-radius: 0;
+  border: 0;
+}
+
+.autocomplete-menu-options button[aria-selected='true'] {
+  background: rgb(0 0 0 / 5%);
+}
+
+.autocomplete-menu-options button.active {
+  background: rgb(189, 232, 255);
+}
+
+.autocomplete-menu-options button .description {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-wrap: nowrap;
+  white-space: nowrap;
+  text-align: right;
+  align-items: baseline;
+  font-size: 0.7rem;
+  opacity: 0.8;
+}
+
+.autocomplete-menu-container input[type='text'] {
+  width: auto;
+  padding: 0.5rem;
+  box-sizing: border-box;
+  background: #e9e9e9;
+  border: 0;
+  outline: none;
+  color: #222;
+  font-size: 1rem;
+  margin: 0.4rem;
+  border-radius: 0.2rem;
+  font-family: inherit;
+}
+
+.autocomplete-menu-container {
+  display: flex;
+  flex-direction: column;
+}
+
+.autocomplete-menu-container.inverse {
+  flex-direction: column-reverse;
+}

--- a/extensions/src/platform-scripture-editor/src/comments.ts
+++ b/extensions/src/platform-scripture-editor/src/comments.ts
@@ -2,14 +2,13 @@ import { Comments } from '@biblionexus-foundation/platform-editor';
 import { MarkerContent, MarkerObject, Usj } from '@biblionexus-foundation/scripture-utilities';
 import {
   CHAPTER_TYPE,
-  ScriptureReference,
   UsjContentLocation,
   UsjReaderWriter,
   VERSE_TYPE,
   VerseRefOffset,
 } from 'platform-bible-utils';
 import { LegacyComment } from 'legacy-comment-manager';
-import { Canon, VerseRef } from '@sillsdev/scripture';
+import { SerializedVerseRef, VerseRef } from '@sillsdev/scripture';
 import { logger } from '@papi/frontend';
 
 export const MILESTONE_START = 'zmsc-s';
@@ -113,15 +112,11 @@ function getCommentDetails(
 export function convertEditorCommentsToLegacyComments(
   comments: Comments,
   usjRW: UsjReaderWriter,
-  scrRef: ScriptureReference,
+  verseLocation: SerializedVerseRef,
 ): LegacyComment[] {
   const legacyComments: LegacyComment[] = [];
   comments.forEach((editorComment) => {
-    const commentDetails = getCommentDetails(
-      usjRW,
-      editorComment.id,
-      Canon.bookNumberToId(scrRef.bookNum),
-    );
+    const commentDetails = getCommentDetails(usjRW, editorComment.id, verseLocation.book);
     if (!commentDetails) return;
     if (editorComment.type === 'comment') {
       legacyComments.push({

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.scss
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.scss
@@ -2,6 +2,7 @@
 @use './commenting';
 @use './editor';
 @use './editor-overrides';
+@use './nodes-menu';
 
 body {
   background-color: hsl(var(--background));

--- a/extensions/src/platform-scripture-editor/src/types/@biblionexus-foundation__platform-editor.d.ts
+++ b/extensions/src/platform-scripture-editor/src/types/@biblionexus-foundation__platform-editor.d.ts
@@ -24,12 +24,18 @@ declare module 'shared-react/nodes/scripture/usj/ImmutableNoteCallerNode' {
   export const immutableNoteCallerNodeName = 'ImmutableNoteCallerNode';
 }
 
-declare module 'shared-react/plugins/logger-basic.model' {
+declare module 'shared/adaptors/logger-basic.model' {
   export type LoggerBasic = {
     error(message: string): void;
     warn(message: string): void;
     info(message: string): void;
   };
+}
+
+declare module 'shared/utils/get-marker-action.model' {
+  import { SerializedVerseRef } from '@sillsdev/scripture';
+
+  export type ScriptureReference = SerializedVerseRef;
 }
 
 declare module 'shared-react/plugins/text-direction.model' {

--- a/package-lock.json
+++ b/package-lock.json
@@ -797,7 +797,7 @@
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
-        "@biblionexus-foundation/platform-editor": "~0.6.7",
+        "@biblionexus-foundation/platform-editor": "~0.7.0",
         "@biblionexus-foundation/scripture-utilities": "~0.0.7",
         "@swc/core": "^1.10.1",
         "@tailwindcss/typography": "^0.5.15",
@@ -3660,21 +3660,21 @@
       "dev": true
     },
     "node_modules/@biblionexus-foundation/platform-editor": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.6.7.tgz",
-      "integrity": "sha512-NsDWSHFD2NQo8fAkD4cfcgQGLSmuyoklQIqHbbfzlqytt39Yi8fZp7B8fIg5YBWFl/0ybezPRPES4yXWB4ee7w==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.7.0.tgz",
+      "integrity": "sha512-uSkPJhbw4V9s7anGEP12xPNsTnm99sMIz7GIlrCvJIswQgILMkNhMpGr/KhTtbz+uBWNwSlYqDhPUPwfZsbxPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@biblionexus-foundation/scripture-utilities": "~0.0.6",
-        "@lexical/react": "^0.20.0",
-        "@lexical/selection": "^0.20.0",
-        "@lexical/text": "^0.20.0",
-        "@lexical/utils": "^0.20.0",
-        "@lexical/yjs": "^0.20.0",
+        "@biblionexus-foundation/scripture-utilities": "~0.0.7",
+        "@lexical/react": "^0.21.0",
+        "@lexical/selection": "^0.21.0",
+        "@lexical/text": "^0.21.0",
+        "@lexical/utils": "^0.21.0",
+        "@lexical/yjs": "^0.21.0",
         "@sillsdev/scripture": "^2.0.2",
         "fast-equals": "^5.0.1",
-        "lexical": "^0.20.0",
+        "lexical": "^0.21.0",
         "yjs": "^13.6.20"
       },
       "peerDependencies": {
@@ -5673,44 +5673,44 @@
       "dev": true
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.20.0.tgz",
-      "integrity": "sha512-oHmb9kSVHjeFCd2q8VrEXW22doUHMJ6cGXqo7Ican7Ljl4/9OgRWr+cq55yntoSaJfCrRYkTiZCLDejF2ciSiA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.21.0.tgz",
+      "integrity": "sha512-3lNMlMeUob9fcnRXGVieV/lmPbmet/SVWckNTOwzfKrZ/YW5HiiyJrWviLRVf50dGXTbmBGt7K/2pfPYvWCHFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.20.0",
-        "@lexical/list": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/html": "0.21.0",
+        "@lexical/list": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.20.0.tgz",
-      "integrity": "sha512-zFsVGuzIn4CQxEnlW4AG/Hq6cyATVZ4fZTxozE/f5oK4vDPvnY/goRxrzSuAMX73A/HRX3kTEzMDcm4taRM3Mg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.21.0.tgz",
+      "integrity": "sha512-E0DNSFu4I+LMn3ft+UT0Dbntc8ZKjIA0BJj6BDewm0qh3bir40YUf5DkI2lpiFNRF2OpcmmcIxakREeU6avqTA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0",
         "prismjs": "^1.27.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.20.0.tgz",
-      "integrity": "sha512-/CnL+Dfpzw4koy2BTdUICkvrCkMIYG8Y73KB/S1Bt5UzJpD+PV300puWJ0NvUvAj24H78r73jxvK2QUG67Tdaw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.21.0.tgz",
+      "integrity": "sha512-csK41CmRLZbKNV5pT4fUn5RzdPjU5PoWR8EqaS9kiyayhDg2zEnuPtvUYWanLfCLH9A2oOfbEsGxjMctAySlJw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.20.0",
-        "@lexical/link": "0.20.0",
-        "@lexical/mark": "0.20.0",
-        "@lexical/table": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/html": "0.21.0",
+        "@lexical/link": "0.21.0",
+        "@lexical/mark": "0.21.0",
+        "@lexical/table": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -5718,157 +5718,157 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.20.0.tgz",
-      "integrity": "sha512-3DAHF8mSKiPZtXCqu2P8ynSwS3fGXzg4G/V0lXNjBxhmozjzUzWZRWIWtmTlWdEu9GXsoyeM3agcaxyDPJJwkA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.21.0.tgz",
+      "integrity": "sha512-ahTCaOtRFNauEzplN1qVuPjyGAlDd+XcVM5FQCdxVh/1DvqmBxEJRVuCBqatzUUVb89jRBekYUcEdnY9iNjvEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.20.0"
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.20.0.tgz",
-      "integrity": "sha512-ldOP/d9tA6V9qvLyr3mRYkcYY5ySOHJ2BFOW/jZPxQcj6lWafS8Lk7XdMUpHHDjRpY2Hizsi5MHJkIqFglYXbw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.21.0.tgz",
+      "integrity": "sha512-O4dxcZNq1Xm45HLoRifbGAYvQkg3qLoBc6ibmHnDqZL5mQDsufnH6QEKWfgDtrvp9++3iqsSC+TE7VzWIvA7ww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.20.0.tgz",
-      "integrity": "sha512-dXtIS31BU6RmLX2KwLAi1EgGl+USeyi+rshh19azACXHPFqONZgPd2t21LOLSFn7C1/W+cSp/kqVDlQVbZUZRA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.21.0.tgz",
+      "integrity": "sha512-Sv2sici2NnAfHYHYRSjjS139MDT8fHP6PlYM2hVr+17dOg7/fJl22VBLRgQ7/+jLtAPxQjID69jvaMlOvt4Oog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.20.0.tgz",
-      "integrity": "sha512-ob7QHkEv+mhaZjlurDj90UmEyN9G4rzBPR5QV42PLnu1qMSviMEdI5V3a5/A5aFf/FDDQ+0GAgWBFnA/MEDczQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.21.0.tgz",
+      "integrity": "sha512-UGahVsGz8OD7Ya39qwquE+JPStTxCw/uaQrnUNorCM7owtPidO2H+tsilAB3A1GK3ksFGdHeEjBjG0Gf7gOg+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/selection": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.20.0.tgz",
-      "integrity": "sha512-zicDcfgRZPRFZ8WOZv5er0Aqkde+i7QoFVkLQD4dNLLORjoMSJOISJH6VEdjBl3k7QJTxbfrt+xT5d/ZsAN5GA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.21.0.tgz",
+      "integrity": "sha512-/coktIyRXg8rXz/7uxXsSEfSQYxPIx8CmignAXWYhcyYtCWA0fD2mhEhWwVvHH9ofNzvidclRPYKUnrmUm3z3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.20.0.tgz",
-      "integrity": "sha512-ufSse8ui3ooUe0HA/yF/9STrG8wYhIDLMRhELOw80GFCkPJaxs6yRvjfmJooH5IC88rpUJ5XXFFiZKfGxEZLEw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.21.0.tgz",
+      "integrity": "sha512-WItGlwwNJCS8b6SO1QPKzArShmD+OXQkLbhBcAh+EfpnkvmCW5T5LqY+OfIRmEN1dhDOnwqCY7mXkivWO8o5tw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.20.0.tgz",
-      "integrity": "sha512-1P2izmkgZ4VDp+49rWO1KfWivL5aA30y5kkYbFZ/CS05fgbO7ogMjLSajpz+RN/zzW79v3q4YfikrMgaD23InA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.21.0.tgz",
+      "integrity": "sha512-2x/LoHDYPOkZbKHz4qLFWsPywjRv9KggTOtmRazmaNRUG0FpkImJwUbbaKjWQXeESVGpzfL3qNFSAmCWthsc4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.20.0.tgz",
-      "integrity": "sha512-ZoGsECejp9z6MEvc8l81b1h1aWbB3sTq6xOFeUTbDL5vKpA67z5CmQQLi0uZWrygrbO9dSE3Q/JGcodUrczxbw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.21.0.tgz",
+      "integrity": "sha512-XCQCyW5ujK0xR6evV8sF0hv/MRUA//kIrB2JiyF12tLQyjLRNEXO+0IKastWnMKSaDdJMKjzgd+4PiummYs7uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.20.0",
-        "@lexical/link": "0.20.0",
-        "@lexical/list": "0.20.0",
-        "@lexical/rich-text": "0.20.0",
-        "@lexical/text": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/code": "0.21.0",
+        "@lexical/link": "0.21.0",
+        "@lexical/list": "0.21.0",
+        "@lexical/rich-text": "0.21.0",
+        "@lexical/text": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.20.0.tgz",
-      "integrity": "sha512-VMhxsxxDGnpVw0jgC8UlDf0Q2RHIHbS49uZgs3l9nP+O+G8s3b76Ta4Tb+iJOK2FY6874/TcQMbSuXGhfpQk8A==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.21.0.tgz",
+      "integrity": "sha512-UR0wHg+XXbq++6aeUPdU0K41xhUDBYzX+AeiqU9bZ7yoOq4grvKD8KBr5tARCSYTy0yvQnL1ddSO12TrP/98Lg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.20.0"
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.20.0.tgz",
-      "integrity": "sha512-z4lElzLm1FVifc7bzBZN4VNKeTuwygpyHQvCJVWXzF2Kbvex43PEYMi8u4A83idVqbmzbyBLASwUJS0voLoPLw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.21.0.tgz",
+      "integrity": "sha512-93P+d1mbvaJvZF8KK2pG22GuS2pHLtyC7N3GBfkbyAIb7TL/rYs47iR+eADJ4iNY680lylJ4Sl/AEnWvlY7hAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.20.0"
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.20.0.tgz",
-      "integrity": "sha512-LvoC+9mm2Im1iO8GgtgaqSfW0T3mIE5GQl1xGxbVNdANmtHmBgRAJn2KfQm1XHZP6zydLRMhZkzC+jfInh2yfQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.21.0.tgz",
+      "integrity": "sha512-r4CsAknBD7qGYSE5fPdjpJ6EjfvzHbDtuCeKciL9muiswQhw4HeJrT1qb/QUIY+072uvXTgCgmjUmkbYnxKyPA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/clipboard": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.20.0.tgz",
-      "integrity": "sha512-5QbN5AFtZ9efXxU/M01ADhUZgthR0e8WKi5K/w5EPpWtYFDPQnUte3rKUjYJ7uwG1iwcvaCpuMbxJjHQ+i6pDQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.21.0.tgz",
+      "integrity": "sha512-tKwx8EoNkBBKOZf8c10QfyDImH87+XUI1QDL8KXt+Lb8E4ho7g1jAjoEirNEn9gMBj33K4l2qVdbe3XmPAdpMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.20.0",
-        "@lexical/code": "0.20.0",
-        "@lexical/devtools-core": "0.20.0",
-        "@lexical/dragon": "0.20.0",
-        "@lexical/hashtag": "0.20.0",
-        "@lexical/history": "0.20.0",
-        "@lexical/link": "0.20.0",
-        "@lexical/list": "0.20.0",
-        "@lexical/mark": "0.20.0",
-        "@lexical/markdown": "0.20.0",
-        "@lexical/overflow": "0.20.0",
-        "@lexical/plain-text": "0.20.0",
-        "@lexical/rich-text": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "@lexical/table": "0.20.0",
-        "@lexical/text": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "@lexical/yjs": "0.20.0",
-        "lexical": "0.20.0",
+        "@lexical/clipboard": "0.21.0",
+        "@lexical/code": "0.21.0",
+        "@lexical/devtools-core": "0.21.0",
+        "@lexical/dragon": "0.21.0",
+        "@lexical/hashtag": "0.21.0",
+        "@lexical/history": "0.21.0",
+        "@lexical/link": "0.21.0",
+        "@lexical/list": "0.21.0",
+        "@lexical/mark": "0.21.0",
+        "@lexical/markdown": "0.21.0",
+        "@lexical/overflow": "0.21.0",
+        "@lexical/plain-text": "0.21.0",
+        "@lexical/rich-text": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "@lexical/table": "0.21.0",
+        "@lexical/text": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "@lexical/yjs": "0.21.0",
+        "lexical": "0.21.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -5877,73 +5877,73 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.20.0.tgz",
-      "integrity": "sha512-BR1pACdMA+Ymef0f5EN1y+9yP8w7S+9MgmBP1yjr3w4KdqRnfSaGWyxwcHU8eA+zu16QfivpB6501VJ90YeuXw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.21.0.tgz",
+      "integrity": "sha512-+pvEKUneEkGfWOSTl9jU58N9knePilMLxxOtppCAcgnaCdilOh3n5YyRppXhvmprUe0JaTseCMoik2LP51G/JA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/clipboard": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.20.0.tgz",
-      "integrity": "sha512-YnkH5UCMNN/em95or/6uwAV31vcENh1Roj+JOg5KD+gJuA7VGdDCy0vZl/o0+1badXozeZ2VRxXNC6JSK7T4+A==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.21.0.tgz",
+      "integrity": "sha512-4u53bc8zlPPF0rnHjsGQExQ1St8NafsDd70/t1FMw7yvoMtUsKdH7+ap00esLkJOMv45unJD7UOzKRqU1X0sEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.20.0"
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.20.0.tgz",
-      "integrity": "sha512-qHuK2rvQUoQDx62YpvJE3Ev4yK9kjRFo79IDBapxrhoXg/wCGQOjMBzVD3G5PWkhyl/GDnww80GwYjLloQLQzg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.21.0.tgz",
+      "integrity": "sha512-JhylAWcf4qKD4FmxMUt3YzH5zg2+baBr4+/haLZL7178hMvUzJwGIiWk+3hD3phzmW3WrP49uFXzM7DMSCkE8w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/clipboard": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.20.0.tgz",
-      "integrity": "sha512-Fu64i5CIlEOlgucSdp9XFqB2XqoRsw4at76n93+6RF4+LgGDnu4nLXQVCVxNmLcGyh2WgczuTpnk5P2mHNAIUA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.21.0.tgz",
+      "integrity": "sha512-ceB4fhYejCoR8ID4uIs0sO/VyQoayRjrRWTIEMvOcQtwUkcyciKRhY0A7f2wVeq/MFStd+ajLLjy4WKYK5zUnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.20.0"
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.20.0.tgz",
-      "integrity": "sha512-sXIa2nowrNxY8VcjjuxZbJ/HovIql8bmInNaxBR03JAYfqMiL5I5/dYgjOQJV49NJnuR1uTY2GwVxVTXCTFUCw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.21.0.tgz",
+      "integrity": "sha512-YzsNOAiLkCy6R3DuP18gtseDrzgx+30lFyqRvp5M7mckeYgQElwdfG5biNFDLv7BM9GjSzgU5Cunjycsx6Sjqg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "@lexical/table": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/list": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "@lexical/table": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.20.0.tgz",
-      "integrity": "sha512-TiHNhu2VkhXN69V+fXVS3xjOQ6aLnheQUGwOAhuFkDPL3VLCb0yl2Mgydpayn+3Grwii4ZBHcF7oCC84GiU5bw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.21.0.tgz",
+      "integrity": "sha512-AtPhC3pJ92CHz3dWoniSky7+MSK2WSd0xijc76I2qbTeXyeuFfYyhR6gWMg4knuY9Wz3vo9/+dXGdbQIPD8efw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/offset": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "lexical": "0.21.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -21128,16 +21128,16 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.20.0.tgz",
-      "integrity": "sha512-lJEHLFACXqRf3u/VlIOu9T7MJ51O4la92uOBwiS9Sx+juDK3Nrru5Vgl1aUirV1qK8XEM3h6Org2HcrsrzZ3ZA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.21.0.tgz",
+      "integrity": "sha512-Dxc5SCG4kB+wF+Rh55ism3SuecOKeOtCtGHFGKd6pj2QKVojtjkxGTQPMt7//2z5rMSue4R+hmRM0pCEZflupA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.98",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.98.tgz",
-      "integrity": "sha512-XteTiNO0qEXqqweWx+b21p/fBnNHUA1NwAtJNJek1oPrewEZs2uiT4gWivHKr9GqCjDPAhchz0UQO8NwU3bBNA==",
+      "version": "0.2.99",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
+      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -31535,13 +31535,13 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.20",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.20.tgz",
-      "integrity": "sha512-Z2YZI+SYqK7XdWlloI3lhMiKnCdFCVC4PchpdO+mCYwtiTwncjUbnRK9R1JmkNfdmHyDXuWN3ibJAt0wsqTbLQ==",
+      "version": "13.6.23",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
+      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lib0": "^0.2.98"
+        "lib0": "^0.2.99"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -32957,20 +32957,20 @@
       "dev": true
     },
     "@biblionexus-foundation/platform-editor": {
-      "version": "0.6.7",
-      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.6.7.tgz",
-      "integrity": "sha512-NsDWSHFD2NQo8fAkD4cfcgQGLSmuyoklQIqHbbfzlqytt39Yi8fZp7B8fIg5YBWFl/0ybezPRPES4yXWB4ee7w==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.7.0.tgz",
+      "integrity": "sha512-uSkPJhbw4V9s7anGEP12xPNsTnm99sMIz7GIlrCvJIswQgILMkNhMpGr/KhTtbz+uBWNwSlYqDhPUPwfZsbxPg==",
       "dev": true,
       "requires": {
-        "@biblionexus-foundation/scripture-utilities": "~0.0.6",
-        "@lexical/react": "^0.20.0",
-        "@lexical/selection": "^0.20.0",
-        "@lexical/text": "^0.20.0",
-        "@lexical/utils": "^0.20.0",
-        "@lexical/yjs": "^0.20.0",
+        "@biblionexus-foundation/scripture-utilities": "~0.0.7",
+        "@lexical/react": "^0.21.0",
+        "@lexical/selection": "^0.21.0",
+        "@lexical/text": "^0.21.0",
+        "@lexical/utils": "^0.21.0",
+        "@lexical/yjs": "^0.21.0",
         "@sillsdev/scripture": "^2.0.2",
         "fast-equals": "^5.0.1",
-        "lexical": "^0.20.0",
+        "lexical": "^0.21.0",
         "yjs": "^13.6.20"
       }
     },
@@ -34307,248 +34307,248 @@
       "dev": true
     },
     "@lexical/clipboard": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.20.0.tgz",
-      "integrity": "sha512-oHmb9kSVHjeFCd2q8VrEXW22doUHMJ6cGXqo7Ican7Ljl4/9OgRWr+cq55yntoSaJfCrRYkTiZCLDejF2ciSiA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.21.0.tgz",
+      "integrity": "sha512-3lNMlMeUob9fcnRXGVieV/lmPbmet/SVWckNTOwzfKrZ/YW5HiiyJrWviLRVf50dGXTbmBGt7K/2pfPYvWCHFA==",
       "dev": true,
       "requires": {
-        "@lexical/html": "0.20.0",
-        "@lexical/list": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/html": "0.21.0",
+        "@lexical/list": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/code": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.20.0.tgz",
-      "integrity": "sha512-zFsVGuzIn4CQxEnlW4AG/Hq6cyATVZ4fZTxozE/f5oK4vDPvnY/goRxrzSuAMX73A/HRX3kTEzMDcm4taRM3Mg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.21.0.tgz",
+      "integrity": "sha512-E0DNSFu4I+LMn3ft+UT0Dbntc8ZKjIA0BJj6BDewm0qh3bir40YUf5DkI2lpiFNRF2OpcmmcIxakREeU6avqTA==",
       "dev": true,
       "requires": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0",
         "prismjs": "^1.27.0"
       }
     },
     "@lexical/devtools-core": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.20.0.tgz",
-      "integrity": "sha512-/CnL+Dfpzw4koy2BTdUICkvrCkMIYG8Y73KB/S1Bt5UzJpD+PV300puWJ0NvUvAj24H78r73jxvK2QUG67Tdaw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.21.0.tgz",
+      "integrity": "sha512-csK41CmRLZbKNV5pT4fUn5RzdPjU5PoWR8EqaS9kiyayhDg2zEnuPtvUYWanLfCLH9A2oOfbEsGxjMctAySlJw==",
       "dev": true,
       "requires": {
-        "@lexical/html": "0.20.0",
-        "@lexical/link": "0.20.0",
-        "@lexical/mark": "0.20.0",
-        "@lexical/table": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/html": "0.21.0",
+        "@lexical/link": "0.21.0",
+        "@lexical/mark": "0.21.0",
+        "@lexical/table": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/dragon": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.20.0.tgz",
-      "integrity": "sha512-3DAHF8mSKiPZtXCqu2P8ynSwS3fGXzg4G/V0lXNjBxhmozjzUzWZRWIWtmTlWdEu9GXsoyeM3agcaxyDPJJwkA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.21.0.tgz",
+      "integrity": "sha512-ahTCaOtRFNauEzplN1qVuPjyGAlDd+XcVM5FQCdxVh/1DvqmBxEJRVuCBqatzUUVb89jRBekYUcEdnY9iNjvEQ==",
       "dev": true,
       "requires": {
-        "lexical": "0.20.0"
+        "lexical": "0.21.0"
       }
     },
     "@lexical/hashtag": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.20.0.tgz",
-      "integrity": "sha512-ldOP/d9tA6V9qvLyr3mRYkcYY5ySOHJ2BFOW/jZPxQcj6lWafS8Lk7XdMUpHHDjRpY2Hizsi5MHJkIqFglYXbw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.21.0.tgz",
+      "integrity": "sha512-O4dxcZNq1Xm45HLoRifbGAYvQkg3qLoBc6ibmHnDqZL5mQDsufnH6QEKWfgDtrvp9++3iqsSC+TE7VzWIvA7ww==",
       "dev": true,
       "requires": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/history": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.20.0.tgz",
-      "integrity": "sha512-dXtIS31BU6RmLX2KwLAi1EgGl+USeyi+rshh19azACXHPFqONZgPd2t21LOLSFn7C1/W+cSp/kqVDlQVbZUZRA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.21.0.tgz",
+      "integrity": "sha512-Sv2sici2NnAfHYHYRSjjS139MDT8fHP6PlYM2hVr+17dOg7/fJl22VBLRgQ7/+jLtAPxQjID69jvaMlOvt4Oog==",
       "dev": true,
       "requires": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/html": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.20.0.tgz",
-      "integrity": "sha512-ob7QHkEv+mhaZjlurDj90UmEyN9G4rzBPR5QV42PLnu1qMSviMEdI5V3a5/A5aFf/FDDQ+0GAgWBFnA/MEDczQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.21.0.tgz",
+      "integrity": "sha512-UGahVsGz8OD7Ya39qwquE+JPStTxCw/uaQrnUNorCM7owtPidO2H+tsilAB3A1GK3ksFGdHeEjBjG0Gf7gOg+Q==",
       "dev": true,
       "requires": {
-        "@lexical/selection": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/selection": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/link": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.20.0.tgz",
-      "integrity": "sha512-zicDcfgRZPRFZ8WOZv5er0Aqkde+i7QoFVkLQD4dNLLORjoMSJOISJH6VEdjBl3k7QJTxbfrt+xT5d/ZsAN5GA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.21.0.tgz",
+      "integrity": "sha512-/coktIyRXg8rXz/7uxXsSEfSQYxPIx8CmignAXWYhcyYtCWA0fD2mhEhWwVvHH9ofNzvidclRPYKUnrmUm3z3Q==",
       "dev": true,
       "requires": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/list": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.20.0.tgz",
-      "integrity": "sha512-ufSse8ui3ooUe0HA/yF/9STrG8wYhIDLMRhELOw80GFCkPJaxs6yRvjfmJooH5IC88rpUJ5XXFFiZKfGxEZLEw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.21.0.tgz",
+      "integrity": "sha512-WItGlwwNJCS8b6SO1QPKzArShmD+OXQkLbhBcAh+EfpnkvmCW5T5LqY+OfIRmEN1dhDOnwqCY7mXkivWO8o5tw==",
       "dev": true,
       "requires": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/mark": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.20.0.tgz",
-      "integrity": "sha512-1P2izmkgZ4VDp+49rWO1KfWivL5aA30y5kkYbFZ/CS05fgbO7ogMjLSajpz+RN/zzW79v3q4YfikrMgaD23InA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.21.0.tgz",
+      "integrity": "sha512-2x/LoHDYPOkZbKHz4qLFWsPywjRv9KggTOtmRazmaNRUG0FpkImJwUbbaKjWQXeESVGpzfL3qNFSAmCWthsc4g==",
       "dev": true,
       "requires": {
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/markdown": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.20.0.tgz",
-      "integrity": "sha512-ZoGsECejp9z6MEvc8l81b1h1aWbB3sTq6xOFeUTbDL5vKpA67z5CmQQLi0uZWrygrbO9dSE3Q/JGcodUrczxbw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.21.0.tgz",
+      "integrity": "sha512-XCQCyW5ujK0xR6evV8sF0hv/MRUA//kIrB2JiyF12tLQyjLRNEXO+0IKastWnMKSaDdJMKjzgd+4PiummYs7uA==",
       "dev": true,
       "requires": {
-        "@lexical/code": "0.20.0",
-        "@lexical/link": "0.20.0",
-        "@lexical/list": "0.20.0",
-        "@lexical/rich-text": "0.20.0",
-        "@lexical/text": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/code": "0.21.0",
+        "@lexical/link": "0.21.0",
+        "@lexical/list": "0.21.0",
+        "@lexical/rich-text": "0.21.0",
+        "@lexical/text": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/offset": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.20.0.tgz",
-      "integrity": "sha512-VMhxsxxDGnpVw0jgC8UlDf0Q2RHIHbS49uZgs3l9nP+O+G8s3b76Ta4Tb+iJOK2FY6874/TcQMbSuXGhfpQk8A==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.21.0.tgz",
+      "integrity": "sha512-UR0wHg+XXbq++6aeUPdU0K41xhUDBYzX+AeiqU9bZ7yoOq4grvKD8KBr5tARCSYTy0yvQnL1ddSO12TrP/98Lg==",
       "dev": true,
       "requires": {
-        "lexical": "0.20.0"
+        "lexical": "0.21.0"
       }
     },
     "@lexical/overflow": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.20.0.tgz",
-      "integrity": "sha512-z4lElzLm1FVifc7bzBZN4VNKeTuwygpyHQvCJVWXzF2Kbvex43PEYMi8u4A83idVqbmzbyBLASwUJS0voLoPLw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.21.0.tgz",
+      "integrity": "sha512-93P+d1mbvaJvZF8KK2pG22GuS2pHLtyC7N3GBfkbyAIb7TL/rYs47iR+eADJ4iNY680lylJ4Sl/AEnWvlY7hAg==",
       "dev": true,
       "requires": {
-        "lexical": "0.20.0"
+        "lexical": "0.21.0"
       }
     },
     "@lexical/plain-text": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.20.0.tgz",
-      "integrity": "sha512-LvoC+9mm2Im1iO8GgtgaqSfW0T3mIE5GQl1xGxbVNdANmtHmBgRAJn2KfQm1XHZP6zydLRMhZkzC+jfInh2yfQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.21.0.tgz",
+      "integrity": "sha512-r4CsAknBD7qGYSE5fPdjpJ6EjfvzHbDtuCeKciL9muiswQhw4HeJrT1qb/QUIY+072uvXTgCgmjUmkbYnxKyPA==",
       "dev": true,
       "requires": {
-        "@lexical/clipboard": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/clipboard": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/react": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.20.0.tgz",
-      "integrity": "sha512-5QbN5AFtZ9efXxU/M01ADhUZgthR0e8WKi5K/w5EPpWtYFDPQnUte3rKUjYJ7uwG1iwcvaCpuMbxJjHQ+i6pDQ==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.21.0.tgz",
+      "integrity": "sha512-tKwx8EoNkBBKOZf8c10QfyDImH87+XUI1QDL8KXt+Lb8E4ho7g1jAjoEirNEn9gMBj33K4l2qVdbe3XmPAdpMQ==",
       "dev": true,
       "requires": {
-        "@lexical/clipboard": "0.20.0",
-        "@lexical/code": "0.20.0",
-        "@lexical/devtools-core": "0.20.0",
-        "@lexical/dragon": "0.20.0",
-        "@lexical/hashtag": "0.20.0",
-        "@lexical/history": "0.20.0",
-        "@lexical/link": "0.20.0",
-        "@lexical/list": "0.20.0",
-        "@lexical/mark": "0.20.0",
-        "@lexical/markdown": "0.20.0",
-        "@lexical/overflow": "0.20.0",
-        "@lexical/plain-text": "0.20.0",
-        "@lexical/rich-text": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "@lexical/table": "0.20.0",
-        "@lexical/text": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "@lexical/yjs": "0.20.0",
-        "lexical": "0.20.0",
+        "@lexical/clipboard": "0.21.0",
+        "@lexical/code": "0.21.0",
+        "@lexical/devtools-core": "0.21.0",
+        "@lexical/dragon": "0.21.0",
+        "@lexical/hashtag": "0.21.0",
+        "@lexical/history": "0.21.0",
+        "@lexical/link": "0.21.0",
+        "@lexical/list": "0.21.0",
+        "@lexical/mark": "0.21.0",
+        "@lexical/markdown": "0.21.0",
+        "@lexical/overflow": "0.21.0",
+        "@lexical/plain-text": "0.21.0",
+        "@lexical/rich-text": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "@lexical/table": "0.21.0",
+        "@lexical/text": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "@lexical/yjs": "0.21.0",
+        "lexical": "0.21.0",
         "react-error-boundary": "^3.1.4"
       }
     },
     "@lexical/rich-text": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.20.0.tgz",
-      "integrity": "sha512-BR1pACdMA+Ymef0f5EN1y+9yP8w7S+9MgmBP1yjr3w4KdqRnfSaGWyxwcHU8eA+zu16QfivpB6501VJ90YeuXw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.21.0.tgz",
+      "integrity": "sha512-+pvEKUneEkGfWOSTl9jU58N9knePilMLxxOtppCAcgnaCdilOh3n5YyRppXhvmprUe0JaTseCMoik2LP51G/JA==",
       "dev": true,
       "requires": {
-        "@lexical/clipboard": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/clipboard": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/selection": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.20.0.tgz",
-      "integrity": "sha512-YnkH5UCMNN/em95or/6uwAV31vcENh1Roj+JOg5KD+gJuA7VGdDCy0vZl/o0+1badXozeZ2VRxXNC6JSK7T4+A==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.21.0.tgz",
+      "integrity": "sha512-4u53bc8zlPPF0rnHjsGQExQ1St8NafsDd70/t1FMw7yvoMtUsKdH7+ap00esLkJOMv45unJD7UOzKRqU1X0sEA==",
       "dev": true,
       "requires": {
-        "lexical": "0.20.0"
+        "lexical": "0.21.0"
       }
     },
     "@lexical/table": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.20.0.tgz",
-      "integrity": "sha512-qHuK2rvQUoQDx62YpvJE3Ev4yK9kjRFo79IDBapxrhoXg/wCGQOjMBzVD3G5PWkhyl/GDnww80GwYjLloQLQzg==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.21.0.tgz",
+      "integrity": "sha512-JhylAWcf4qKD4FmxMUt3YzH5zg2+baBr4+/haLZL7178hMvUzJwGIiWk+3hD3phzmW3WrP49uFXzM7DMSCkE8w==",
       "dev": true,
       "requires": {
-        "@lexical/clipboard": "0.20.0",
-        "@lexical/utils": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/clipboard": "0.21.0",
+        "@lexical/utils": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/text": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.20.0.tgz",
-      "integrity": "sha512-Fu64i5CIlEOlgucSdp9XFqB2XqoRsw4at76n93+6RF4+LgGDnu4nLXQVCVxNmLcGyh2WgczuTpnk5P2mHNAIUA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.21.0.tgz",
+      "integrity": "sha512-ceB4fhYejCoR8ID4uIs0sO/VyQoayRjrRWTIEMvOcQtwUkcyciKRhY0A7f2wVeq/MFStd+ajLLjy4WKYK5zUnA==",
       "dev": true,
       "requires": {
-        "lexical": "0.20.0"
+        "lexical": "0.21.0"
       }
     },
     "@lexical/utils": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.20.0.tgz",
-      "integrity": "sha512-sXIa2nowrNxY8VcjjuxZbJ/HovIql8bmInNaxBR03JAYfqMiL5I5/dYgjOQJV49NJnuR1uTY2GwVxVTXCTFUCw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.21.0.tgz",
+      "integrity": "sha512-YzsNOAiLkCy6R3DuP18gtseDrzgx+30lFyqRvp5M7mckeYgQElwdfG5biNFDLv7BM9GjSzgU5Cunjycsx6Sjqg==",
       "dev": true,
       "requires": {
-        "@lexical/list": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "@lexical/table": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/list": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "@lexical/table": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@lexical/yjs": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.20.0.tgz",
-      "integrity": "sha512-TiHNhu2VkhXN69V+fXVS3xjOQ6aLnheQUGwOAhuFkDPL3VLCb0yl2Mgydpayn+3Grwii4ZBHcF7oCC84GiU5bw==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.21.0.tgz",
+      "integrity": "sha512-AtPhC3pJ92CHz3dWoniSky7+MSK2WSd0xijc76I2qbTeXyeuFfYyhR6gWMg4knuY9Wz3vo9/+dXGdbQIPD8efw==",
       "dev": true,
       "requires": {
-        "@lexical/offset": "0.20.0",
-        "@lexical/selection": "0.20.0",
-        "lexical": "0.20.0"
+        "@lexical/offset": "0.21.0",
+        "@lexical/selection": "0.21.0",
+        "lexical": "0.21.0"
       }
     },
     "@malept/cross-spawn-promise": {
@@ -44853,15 +44853,15 @@
       }
     },
     "lexical": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.20.0.tgz",
-      "integrity": "sha512-lJEHLFACXqRf3u/VlIOu9T7MJ51O4la92uOBwiS9Sx+juDK3Nrru5Vgl1aUirV1qK8XEM3h6Org2HcrsrzZ3ZA==",
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.21.0.tgz",
+      "integrity": "sha512-Dxc5SCG4kB+wF+Rh55ism3SuecOKeOtCtGHFGKd6pj2QKVojtjkxGTQPMt7//2z5rMSue4R+hmRM0pCEZflupA==",
       "dev": true
     },
     "lib0": {
-      "version": "0.2.98",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.98.tgz",
-      "integrity": "sha512-XteTiNO0qEXqqweWx+b21p/fBnNHUA1NwAtJNJek1oPrewEZs2uiT4gWivHKr9GqCjDPAhchz0UQO8NwU3bBNA==",
+      "version": "0.2.99",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
+      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
       "dev": true,
       "requires": {
         "isomorphic.js": "^0.2.4"
@@ -47267,7 +47267,7 @@
     "platform-scripture-editor": {
       "version": "file:extensions/src/platform-scripture-editor",
       "requires": {
-        "@biblionexus-foundation/platform-editor": "~0.6.7",
+        "@biblionexus-foundation/platform-editor": "~0.7.0",
         "@biblionexus-foundation/scripture-utilities": "~0.0.7",
         "@sillsdev/scripture": "^2.0.2",
         "@swc/core": "^1.10.1",
@@ -52338,12 +52338,12 @@
       }
     },
     "yjs": {
-      "version": "13.6.20",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.20.tgz",
-      "integrity": "sha512-Z2YZI+SYqK7XdWlloI3lhMiKnCdFCVC4PchpdO+mCYwtiTwncjUbnRK9R1JmkNfdmHyDXuWN3ibJAt0wsqTbLQ==",
+      "version": "13.6.23",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.23.tgz",
+      "integrity": "sha512-ExtnT5WIOVpkL56bhLeisG/N5c4fmzKn4k0ROVfJa5TY2QHbH7F0Wu2T5ZhR7ErsFWQEFafyrnSI8TPKVF9Few==",
       "dev": true,
       "requires": {
-        "lib0": "^0.2.98"
+        "lib0": "^0.2.99"
       }
     },
     "yn": {


### PR DESCRIPTION
- fix pasting with tab characters BiblioNexus-Foundation/scripture-editors#213
- fix cursor jumping BiblioNexus-Foundation/scripture-editors#217
- fix undo/redo BiblioNexus-Foundation/scripture-editors#212
- improve USX/J/FM v3.1 compatibility
- add insert marker menu (trigger on backslash)
- can only edit 'b' ParaNode if it already contains text.
- 'b' marker no longer selectable in block menu
- use `SerializedVerseRef` type for `ScriptureReference`. Use in the BC control needs updating also

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1437)
<!-- Reviewable:end -->
