### PR TITLE
Better serialize error messages in RPC handling

### DIFF
--- a/src/client/services/rpc-client.ts
+++ b/src/client/services/rpc-client.ts
@@ -23,7 +23,7 @@ import {
   WEBSOCKET_PORT,
 } from '@shared/data/rpc.model';
 import { createWebSocket } from '@client/services/web-socket.factory';
-import { AsyncVariable, Mutex, MutexMap } from 'platform-bible-utils';
+import { AsyncVariable, getErrorMessage, Mutex, MutexMap } from 'platform-bible-utils';
 import { bindClassMethods, SerializedRequestType } from '@shared/utils/util';
 import { SingleMethodDocumentation } from '@shared/models/openrpc.model';
 
@@ -98,7 +98,7 @@ export default class RpcClient implements IRpcMethodRegistrar {
         this.connectionStatus = ConnectionStatus.Connected;
         logger.info(`Websocket connected to ${this.ws.url}`);
       } catch (error) {
-        RpcClient.handleError(`RPC client connection error: ${JSON.stringify(error)}`, this.ws);
+        RpcClient.handleError(`RPC client connection error: ${getErrorMessage(error)}`, this.ws);
         this.removeEventListenersFromWebSocket();
         this.connectionStatus = ConnectionStatus.Disconnected;
         this.ws = undefined;

--- a/src/main/services/rpc-server.ts
+++ b/src/main/services/rpc-server.ts
@@ -26,6 +26,7 @@ import {
 } from '@shared/data/rpc.model';
 import { bindClassMethods, SerializedRequestType } from '@shared/utils/util';
 import { SingleMethodDocumentation } from '@shared/models/openrpc.model';
+import { getErrorMessage } from 'platform-bible-utils';
 
 type PropagateEventMethod = <T>(source: RpcServer, eventType: string, event: T) => void;
 
@@ -209,7 +210,7 @@ export default class RpcServer implements IRpcHandler {
       this.processMessage(deserializeMessage(ev.data));
     } catch (error) {
       this.handleError(
-        `Error processing JSONRPC message (${ev.data}): ${JSON.stringify(error)}`,
+        `Error processing JSONRPC message (${ev.data}): ${getErrorMessage(error)}`,
         error,
       );
     }
@@ -239,7 +240,7 @@ export default class RpcServer implements IRpcHandler {
               : createErrorResponse(response.error.message, response.error.code, request.id);
           sendPayloadToWebSocket(this.ws, payload);
         } catch (error) {
-          this.handleError(`Error handling request: ${JSON.stringify(error)}`, request);
+          this.handleError(`Error handling request: ${getErrorMessage(error)}`, request);
         }
       });
       await Promise.all(promises);


### PR DESCRIPTION
When looking at some log output from Roopa I noticed that we weren't always logging errors properly. Switching to one of our utility functions to try to handle this better.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1442)
<!-- Reviewable:end -->
