### PR TITLE
Make subscription persistent in checks side panel

### DIFF
--- a/extensions/src/platform-scripture/src/checks-side-panel.web-view-provider.ts
+++ b/extensions/src/platform-scripture/src/checks-side-panel.web-view-provider.ts
@@ -8,7 +8,6 @@ import {
 import papi from '@papi/backend';
 import checksSidePanelWebView from './checks-side-panel.web-view?inline';
 import tailwindStyles from './tailwind.css?inline';
-// import checkAggregatorService from './checks/check-aggregator.service';
 
 export const checksSidePanelWebViewType = 'platformScripture.checksSidePanel';
 

--- a/extensions/src/platform-scripture/src/checks-side-panel.web-view-provider.ts
+++ b/extensions/src/platform-scripture/src/checks-side-panel.web-view-provider.ts
@@ -8,12 +8,12 @@ import {
 import papi from '@papi/backend';
 import checksSidePanelWebView from './checks-side-panel.web-view?inline';
 import tailwindStyles from './tailwind.css?inline';
+// import checkAggregatorService from './checks/check-aggregator.service';
 
 export const checksSidePanelWebViewType = 'platformScripture.checksSidePanel';
 
 export interface ChecksSidePanelWebViewOptions extends GetWebViewOptions {
   projectId: string | undefined;
-  subscriptionId: string | undefined;
   editorScrollGroupId: ScrollGroupScrRef | undefined;
 }
 
@@ -38,8 +38,6 @@ export default class ChecksSidePanelWebViewProvider implements IWebViewProvider 
       scrollGroupScrRef: getWebViewOptions.editorScrollGroupId,
       state: {
         ...savedWebView.state,
-        subscriptionId: getWebViewOptions.subscriptionId ?? savedWebView.state?.subscriptionId,
-        scope: savedWebView.state?.scope,
       },
     };
   }

--- a/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
+++ b/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
@@ -58,17 +58,6 @@ global.webViewComponent = function ChecksSidePanelWebView({
   const checkAggregator = useDataProvider('platformScripture.checkAggregator');
 
   useEffect(() => {
-    // const validateSubscriptionId = async () => {
-    //   logger.info('Validating subscription ID');
-    //   const isIDValid = await checkAggregator?.validateSubscription(subscriptionId);
-    //   if (!isIDValid) {
-    //     await checkAggregator?.deleteSubscription(subscriptionId);
-    //     logger.info('Deleted subscription ID', subscriptionId);
-    //     const newSubscriptionId = await checkAggregator?.createSubscription();
-    //     setSubscriptionId(newSubscriptionId || '');
-    //     logger.info('Created subscription ID', newSubscriptionId);
-    //   }
-    // };
     const validateSubscriptionId = async () => {
       logger.info('Validating subscription ID');
       const isIDValid = await checkAggregator?.validateSubscription(subscriptionId);

--- a/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
+++ b/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
@@ -304,6 +304,11 @@ class CheckAggregatorDataProviderEngine
     return this.subscriptionsBySubscriptionId.delete(subscriptionId);
   }
 
+  async validateSubscription(subscriptionId: CheckSubscriptionId): Promise<boolean> {
+    const subscription = this.subscriptionsBySubscriptionId.get(subscriptionId);
+    return !!subscription;
+  }
+
   // #endregion
 
   // #region Helper methods

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -172,20 +172,12 @@ async function openChecksSidePanel(
     return undefined;
   }
 
-  const subscriptionId = await checkAggregatorService.serviceObject.createSubscription();
-
-  const options: ChecksSidePanelWebViewOptions = { projectId, subscriptionId, editorScrollGroupId };
+  const options: ChecksSidePanelWebViewOptions = { projectId, editorScrollGroupId };
   const sidePanelWebViewId = await papi.webViews.openWebView(
     checksSidePanelWebViewType,
     { type: 'panel', direction: 'right', targetTabId: tabIdFromWebViewId },
     options,
   );
-
-  papi.webViews.onDidCloseWebView(async ({ webView }) => {
-    if (webView.webViewType === checksSidePanelWebViewType && webView.id === sidePanelWebViewId) {
-      await checkAggregatorService.serviceObject.deleteSubscription(subscriptionId);
-    }
-  });
 
   return sidePanelWebViewId;
 }

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -732,6 +732,13 @@ declare module 'platform-scripture' {
      * @returns `true` if the subscription could be deleted, `false` otherwise
      */
     deleteSubscription: (subscriptionId: CheckSubscriptionId) => Promise<boolean>;
+    /**
+     * Validates the subscription with the given ID.
+     *
+     * @param subscriptionId - The ID of the subscription to validate.
+     * @returns `true` if the subscription is valid, `false` otherwise.
+     */
+    validateSubscription: (subscriptionId: CheckSubscriptionId) => Promise<boolean>;
   };
 
   /**


### PR DESCRIPTION
This satisfies PT-2138

Previously, because I was generating the subscription when the `openChecksSidePanel` function is called, if you refreshed or closed and reopened the app the side panel would get stuck "Loading" when really the subscription Id was no longer valid and we needed a new one. This solution creates subscriptions when an id is no longer valid, and deletes on un-mount.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1444)
<!-- Reviewable:end -->
