### PR TITLE
Modify Linux builds to produce snap packages

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -1,5 +1,12 @@
 name: Package
 
+# Make sure these match with the matrix.os values below
+env:
+  OS_WINDOWS: windows-latest
+  OS_MACOS: macos-latest
+  # The Ubuntu version must align with the "core" version in electron-builder.json5
+  OS_LINUX: ubuntu-22.04
+
 on:
   push:
     branches: [main]
@@ -19,12 +26,13 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        # Make sure these match with the env values above
+        os: [windows-latest, macos-latest, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:
       - name: Install MacPorts
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         uses: melusina-org/setup-macports@v1
 
       - name: Update MacPorts ports tree
@@ -34,17 +42,17 @@ jobs:
           sudo port sync
 
       - name: Install loader tools on macOS
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         run: |
           sudo port -v install ld64
 
       - name: Install icu4c on macOS
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         run: |
           sudo port -v install icu @76.1_0 +universal
 
       - name: Fixup loader paths for icu4c
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         # LIB_DEPENDENCIES are of the form "<ICU lib short name> <dependency as ICU lib short name>"
         # For example, libicuuc (shortened to "uc") depends on libicudata (shortened to "data")
         # Dependencies can be seen by running "dyld_info -dependents /path/to/something.dylib"
@@ -63,6 +71,23 @@ jobs:
             set -- $line
             sudo install_name_tool -change "/opt/local/lib/libicu$2.$ICU_VERSION.dylib" "@loader_path/libicu$2.$ICU_VERSION.dylib" "/opt/local/lib/libicu$1.$ICU_VERSION.dylib"
           done <<< "$LIB_DEPENDENCIES"
+
+      - name: Install snap tools on Linux
+        if: ${{ matrix.os == env.OS_LINUX }}
+        run: |
+          sudo apt update
+          sudo apt install -y snapd
+          sudo snap install snapcraft --classic
+          sudo snap install lxd
+          sudo snap refresh lxd
+          sudo lxd init --auto
+          # Add the current user to the lxd group
+          getent group lxd | grep -qwF "$USER" || sudo usermod -aG lxd "$USER"
+          newgrp lxd
+          # Force the socket to be usable by the current user
+          sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
+          # https://github.com/canonical/action-build/blob/master/src/tools.ts#L54
+          sudo iptables -P FORWARD ACCEPT
 
       - name: Checkout git repo
         uses: actions/checkout@v4
@@ -100,12 +125,12 @@ jobs:
           npm --no-git-tag-version version $NEW_VERSION
 
       - name: Publish releases - Windows
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == env.OS_WINDOWS }}
         run: |
           npm exec electron-builder -- build --publish never --win
 
       - name: Publish releases - macOS
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         # env:
         #   # These values are used for auto updates signing
         #   APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -116,7 +141,7 @@ jobs:
           npm exec electron-builder -- build --publish never --mac
 
       - name: Publish releases - Linux
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == env.OS_LINUX }}
         env:
           # no hardlinks so dependencies are copied
           USE_HARD_LINKS: false
@@ -124,7 +149,7 @@ jobs:
           npm exec electron-builder -- build --publish never --linux
 
       - name: Upload Windows artifacts
-        if: ${{ matrix.os == 'windows-latest' }}
+        if: ${{ matrix.os == env.OS_WINDOWS }}
         uses: actions/upload-artifact@v4
         with:
           name: app-windows
@@ -133,7 +158,7 @@ jobs:
             !./release/build/*Setup*.exe
 
       - name: Upload macOS artifacts
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         uses: actions/upload-artifact@v4
         with:
           name: app-macos
@@ -141,7 +166,7 @@ jobs:
             ./release/build/*.dmg
 
       - name: Upload Linux artifacts
-        if: ${{ matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.os == env.OS_LINUX }}
         uses: actions/upload-artifact@v4
         with:
           name: app-linux

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,12 @@
 name: Publish
 
+# Make sure these match with the matrix.os values below
+env:
+  OS_WINDOWS: windows-latest
+  OS_MACOS: macos-latest
+  # The Ubuntu version must align with the "core" version in electron-builder.json5
+  OS_LINUX: ubuntu-22.04
+
 on:
   push:
     branches: [release/*]
@@ -19,12 +26,13 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        # Make sure these match with the env values above
+        os: [windows-latest, macos-latest, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:
       - name: Install MacPorts
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         uses: melusina-org/setup-macports@v1
 
       - name: Update MacPorts ports tree
@@ -34,17 +42,17 @@ jobs:
           sudo port sync
 
       - name: Install loader tools on macOS
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         run: |
           sudo port -v install ld64
 
       - name: Install icu4c on macOS
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         run: |
           sudo port -v install icu @76.1_0 +universal
 
       - name: Fixup loader paths for icu4c
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         # LIB_DEPENDENCIES are of the form "<ICU lib short name> <dependency as ICU lib short name>"
         # For example, libicuuc (shortened to "uc") depends on libicudata (shortened to "data")
         # Dependencies can be seen by running "dyld_info -dependents /path/to/something.dylib"
@@ -63,6 +71,23 @@ jobs:
             set -- $line
             sudo install_name_tool -change "/opt/local/lib/libicu$2.$ICU_VERSION.dylib" "@loader_path/libicu$2.$ICU_VERSION.dylib" "/opt/local/lib/libicu$1.$ICU_VERSION.dylib"
           done <<< "$LIB_DEPENDENCIES"
+
+      - name: Install snap tools on Linux
+        if: ${{ matrix.os == env.OS_LINUX }}
+        run: |
+          sudo apt update
+          sudo apt install -y snapd
+          sudo snap install snapcraft --classic
+          sudo snap install lxd
+          sudo snap refresh lxd
+          sudo lxd init --auto
+          # Add the current user to the lxd group
+          getent group lxd | grep -qwF "$USER" || sudo usermod -aG lxd "$USER"
+          newgrp lxd
+          # Force the socket to be usable by the current user
+          sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
+          # https://github.com/canonical/action-build/blob/master/src/tools.ts#L54
+          sudo iptables -P FORWARD ACCEPT
 
       - name: Checkout git repo
         uses: actions/checkout@v4
@@ -91,7 +116,7 @@ jobs:
 
       - name: Publish releases - Windows
         # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
-        if: ${{ matrix.os == 'windows-latest' && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
+        if: ${{ matrix.os == env.OS_WINDOWS && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
         env:
           # This is used for uploading release assets to github
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -99,7 +124,7 @@ jobs:
 
       - name: Publish releases - macOS
         # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
-        if: ${{ matrix.os == 'macos-latest' && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
+        if: ${{ matrix.os == env.OS_MACOS && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
         env:
           # The APPLE_* values are used for auto updates signing
           # APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASS }}
@@ -113,7 +138,7 @@ jobs:
 
       - name: Publish releases - Linux
         # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
-        if: ${{ matrix.os == 'ubuntu-latest' && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
+        if: ${{ matrix.os == env.OS_LINUX && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
         env:
           # no hardlinks so dependencies are copied
           USE_HARD_LINKS: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,12 @@
 name: Test
 
+# Make sure these match with the matrix.os values below
+env:
+  OS_WINDOWS: windows-latest
+  OS_MACOS: macos-latest
+  # The Ubuntu version must align with the "core" version in electron-builder.json5
+  OS_LINUX: ubuntu-22.04
+
 on:
   push:
     branches: ['main']
@@ -22,12 +29,13 @@ jobs:
 
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        # Make sure these match with the env values above
+        os: [windows-latest, macos-latest, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:
       - name: Install MacPorts
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         uses: melusina-org/setup-macports@v1
 
       - name: Update MacPorts ports tree
@@ -37,17 +45,17 @@ jobs:
           sudo port sync
 
       - name: Install loader tools on macOS
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         run: |
           sudo port -v install ld64
 
       - name: Install icu4c on macOS
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         run: |
           sudo port -v install icu @76.1_0 +universal
 
       - name: Fixup loader paths for icu4c
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         # LIB_DEPENDENCIES are of the form "<ICU lib short name> <dependency as ICU lib short name>"
         # For example, libicuuc (shortened to "uc") depends on libicudata (shortened to "data")
         # Dependencies can be seen by running "dyld_info -dependents /path/to/something.dylib"
@@ -66,6 +74,23 @@ jobs:
             set -- $line
             sudo install_name_tool -change "/opt/local/lib/libicu$2.$ICU_VERSION.dylib" "@loader_path/libicu$2.$ICU_VERSION.dylib" "/opt/local/lib/libicu$1.$ICU_VERSION.dylib"
           done <<< "$LIB_DEPENDENCIES"
+
+      - name: Install snap tools on Linux
+        if: ${{ matrix.os == env.OS_LINUX }}
+        run: |
+          sudo apt update
+          sudo apt install -y snapd
+          sudo snap install snapcraft --classic
+          sudo snap install lxd
+          sudo snap refresh lxd
+          sudo lxd init --auto
+          # Add the current user to the lxd group
+          getent group lxd | grep -qwF "$USER" || sudo usermod -aG lxd "$USER"
+          newgrp lxd
+          # Force the socket to be usable by the current user
+          sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
+          # https://github.com/canonical/action-build/blob/master/src/tools.ts#L54
+          sudo iptables -P FORWARD ACCEPT
 
       - name: Check out Git repository
         uses: actions/checkout@v4

--- a/c-sharp/ParanextDataProvider.csproj
+++ b/c-sharp/ParanextDataProvider.csproj
@@ -34,9 +34,9 @@
     <PackageReference Include="Microsoft.ICU.ICU4C.Runtime" Version="72.1.0.3" Condition="$([MSBuild]::IsOsPlatform('Windows'))" />
     <PackageReference Include="ParatextChecks" Version="9.5.0.9" />
     <PackageReference Include="ParatextData" Version="9.5.0.9" />
-    <PackageReference Include="SIL.Core" Version="15.0.0" />
-    <PackageReference Include="SIL.Scripture" Version="15.0.0" />
-    <PackageReference Include="SIL.WritingSystems" Version="15.0.0" />
+    <PackageReference Include="SIL.Core" Version="16.0.0-beta0031" />
+    <PackageReference Include="SIL.Scripture" Version="16.0.0-beta0031" />
+    <PackageReference Include="SIL.WritingSystems" Version="16.0.0-beta0031" />
     <PackageReference Include="StreamJsonRpc" Version="2.20.20" />
     <PackageReference Include="System.Net.WebSockets" Version="4.3.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.1" />
@@ -64,6 +64,24 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+
+  <!-- This assumes that icu4c libs are installed under "/usr/lib/x86_64-linux-gnu" on Linux. -->
+  <ItemGroup>
+    <Content Include="/usr/lib/x86_64-linux-gnu/libicu*.so.??" Exclude="/usr/lib/x86_64-linux-gnu/libicutest*;/usr/lib/x86_64-linux-gnu/libicutu*" Condition="$([MSBuild]::IsOsPlatform('Linux'))">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <!--
+    Workaround for .NET bug: https://github.com/dotnet/runtime/issues/57784
+    We also set the environment variable DOTNET_LTTNG to 0 to disable LTTng tracing in the snap.
+    We're copying the approach from https://github.com/jellyfin/jellyfin/pull/11008/files.
+    -->
+  <Target Name="DeleteClrTracePointProvider" Condition="$([MSBuild]::IsOsPlatform('Linux'))" AfterTargets="Publish">
+    <Message Text="Deleting libcoreclrtraceptprovider.so"/>
+    <Delete Files="$(OutDir)libcoreclrtraceptprovider.so" />
+    <Delete Files="$(PublishDir)libcoreclrtraceptprovider.so" />
+  </Target>
 
   <ItemGroup>
     <Content Include="assets\**\*.*">

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -55,277 +55,12 @@
     ],
   },
   linux: {
-    target: ['AppImage'],
+    target: ['AppImage', 'snap'],
     category: 'Development',
     extraResources: [
       {
         from: './c-sharp/bin/Release/net8.0/publish/linux-x64/',
         to: './dotnet/',
-      },
-    ],
-    extraFiles: [
-      // Package SO files are listed below and grouped according to packages as: libnss3 libasound2 libgbm1 libgl1 libgtk-3-0
-
-      // libnss3 package
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libnss3.so',
-        to: 'usr/lib/libnss3.so',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libnssutil3.so',
-        to: 'usr/lib/libnssutil3.so',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libsmime3.so',
-        to: 'usr/lib/libsmime3.so',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libssl3.so',
-        to: 'usr/lib/libssl3.so',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/nss/libfreebl3.so',
-        to: 'usr/lib/nss/libfreebl3.so',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/nss/libfreeblpriv3.so',
-        to: 'usr/lib/nss/libfreeblpriv3.so',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/nss/libnssckbi.so',
-        to: 'usr/lib/nss/libnssckbi.so',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/nss/libnssdbm3.so',
-        to: 'usr/lib/nss/libnssdbm3.so',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/nss/libsoftokn3.so',
-        to: 'usr/lib/nss/libsoftokn3.so',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libnspr4.so',
-        to: 'usr/lib/libnspr4.so',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libplc4.so',
-        to: 'usr/lib/libplc4.so',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libplds4.so',
-        to: 'usr/lib/libplds4.so',
-      },
-      // libasound2 package
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libasound.so.2',
-        to: 'usr/lib/libasound.so.2',
-      },
-      // libgbm1 package
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libgbm.so.1',
-        to: 'usr/lib/libgbm.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libwayland-server.so.0',
-        to: 'usr/lib/libwayland-server.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libexpat.so.1',
-        to: 'usr/lib/libexpat.so.1',
-      },
-      // libgl1 package
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libGL.so.1',
-        to: 'usr/lib/libGL.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libGLdispatch.so.0',
-        to: 'usr/lib/libGLdispatch.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libGLX.so.0',
-        to: 'usr/lib/libGLX.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libGLX_mesa.so.0',
-        to: 'usr/lib/libGLX_mesa.so.0',
-      },
-      // libgtk-3-0 package
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libgtk-3.so.0',
-        to: 'usr/lib/libgtk-3.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libatk-1.0.so.0',
-        to: 'usr/lib/libatk-1.0.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libatk-bridge-2.0.so.0',
-        to: 'usr/lib/libatk-bridge-2.0.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libatspi.so.0',
-        to: 'usr/lib/libatspi.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libcups.so.2',
-        to: 'usr/lib/libcups.so.2',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libavahi-common.so.3',
-        to: 'usr/lib/libavahi-common.so.3',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libavahi-client.so.3',
-        to: 'usr/lib/libavahi-client.so.3',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libpango-1.0.so.0',
-        to: 'usr/lib/libpango-1.0.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libcairo.so.2',
-        to: 'usr/lib/libcairo.so.2',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libXcomposite.so.1',
-        to: 'usr/lib/libXcomposite.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libXdamage.so.1',
-        to: 'usr/lib/libXdamage.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libXfixes.so.3',
-        to: 'usr/lib/libXfixes.so.3',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libXrandr.so.2',
-        to: 'usr/lib/libXrandr.so.2',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libxkbcommon.so.0',
-        to: 'usr/lib/libxkbcommon.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libgdk-3.so.0',
-        to: 'usr/lib/libgdk-3.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libpangocairo-1.0.so.0',
-        to: 'usr/lib/libpangocairo-1.0.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libXi.so.6',
-        to: 'usr/lib/libXi.so.6',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libcairo-gobject.so.2',
-        to: 'usr/lib/libcairo-gobject.so.2',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libgdk_pixbuf-2.0.so.0',
-        to: 'usr/lib/libgdk_pixbuf-2.0.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libepoxy.so.0',
-        to: 'usr/lib/libepoxy.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libpangoft2-1.0.so.0',
-        to: 'usr/lib/libpangoft2-1.0.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libharfbuzz.so.0',
-        to: 'usr/lib/libharfbuzz.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libfontconfig.so.1',
-        to: 'usr/lib/libfontconfig.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libthai.so.0',
-        to: 'usr/lib/libthai.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libpixman-1.so.0',
-        to: 'usr/lib/libpixman-1.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libfreetype.so.6',
-        to: 'usr/lib/libfreetype.so.6',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libxcb.so.1',
-        to: 'usr/lib/libxcb.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libxcb-shm.so.0',
-        to: 'usr/lib/libxcb-shm.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libxcb-render.so.0',
-        to: 'usr/lib/libxcb-render.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libXrender.so.1',
-        to: 'usr/lib/libXrender.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libXinerama.so.1',
-        to: 'usr/lib/libXinerama.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libXcursor.so.1',
-        to: 'usr/lib/libXcursor.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libwayland-cursor.so.0',
-        to: 'usr/lib/libwayland-cursor.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libwayland-egl.so.1',
-        to: 'usr/lib/libwayland-egl.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libwayland-client.so.0',
-        to: 'usr/lib/libwayland-client.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libjpeg.so.8',
-        to: 'usr/lib/libjpeg.so.8',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libgraphite2.so.3',
-        to: 'usr/lib/libgraphite2.so.3',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libdatrie.so.1',
-        to: 'usr/lib/libdatrie.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libX11-xcb.so.1',
-        to: 'usr/lib/libX11-xcb.so.1',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libdl.so.2',
-        to: 'usr/lib/libdl.so.2',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libpthread.so.0',
-        to: 'usr/lib/libpthread.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libglib-2.0.so.0',
-        to: 'usr/lib/libglib-2.0.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libgobject-2.0.so.0',
-        to: 'usr/lib/libgobject-2.0.so.0',
-      },
-      {
-        from: '/usr/lib/x86_64-linux-gnu/libgio-2.0.so.0',
-        to: 'usr/lib/libgio-2.0.so.0',
       },
     ],
   },
@@ -339,5 +74,60 @@
     provider: 'github',
     owner: 'paranext',
     repo: 'paranext-core',
+  },
+  snap: {
+    // The base version needs to align with the Ubuntu runners in the GitHub Actions workflows.
+    // Some things are built in the host OS, and some are built in the snap environment. If they
+    // don't match, there will likely be compatibility issues.
+    base: 'core22',
+    category: 'Development',
+    environment: {
+      // We copy the ICU libraries to the .NET app directory to avoid snap confinement issues
+      // We need to allow the ICU libraries to load their dependencies from the same directory
+      LD_LIBRARY_PATH: '$LD_LIBRARY_PATH:.',
+      // Workaround for .NET bug: https://github.com/dotnet/runtime/issues/57784
+      DOTNET_LTTNG: '0',
+      // Snap changes $HOME, but we want the original home directory for compatibility reasons
+      HOME: '$SNAP_REAL_HOME',
+      // Snap confinement prevents writing to `/var/lock` which GlobalMutex normally requires
+      SIL_CORE_MAKE_GLOBAL_MUTEX_LOCAL_ONLY: 'true',
+    },
+    // Change from "devel" to "stable" when it's ready to be published on the snap store
+    grade: 'devel',
+    stagePackages: [
+      'libappindicator3-1',
+      'libasound2',
+      'libdrm2',
+      'libdrm-nouveau2',
+      'libgbm1',
+      'libgl1',
+      'libgtk-3-0',
+      'libnspr4',
+      'libnss3',
+      'libsecret-1-0',
+      'libtinfo5',
+      'libxss1',
+    ],
+    plugs: [
+      'audio-playback',
+      'browser-support',
+      'desktop',
+      'desktop-legacy',
+      'gsettings',
+      'home',
+      'network',
+      'opengl',
+      'pulseaudio',
+      'unity7',
+      'wayland',
+      'x11',
+      {
+        'dot-platform-bible': {
+          interface: 'personal-files',
+          read: ['$HOME/.platform.bible'],
+          write: ['$HOME/.platform.bible'],
+        },
+      },
+    ],
   },
 }


### PR DESCRIPTION
I think we may want to disable AppImage files once we confirm that snaps are working for people because the technologies are different enough that we might have a hard time tracking and fixing bugs that happen in just one vs the other. For now, though, this is just adding `snap` as an option to align with some other software in the Paratext ecosystem (e.g., Paratext Lite).

The PT10 repo will need additional changes once this has been merged in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1449)
<!-- Reviewable:end -->
