### PR TITLE
Settings UI css improvement

### DIFF
--- a/src/renderer/components/settings-tabs/settings-tab.component.scss
+++ b/src/renderer/components/settings-tabs/settings-tab.component.scss
@@ -14,7 +14,7 @@
 }
 
 .sidebar-container {
-  overflow: hidden;
+  min-height: 100%;
 }
 
 .project-or-settings-list-container {

--- a/src/renderer/components/settings-tabs/settings-tab.component.scss
+++ b/src/renderer/components/settings-tabs/settings-tab.component.scss
@@ -14,6 +14,7 @@
 }
 
 .sidebar-container {
+  overflow: hidden;
   min-height: 100%;
 }
 


### PR DESCRIPTION

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1468)
<!-- Reviewable:end -->

I noticed a bug when watching the demo of the Settings UI in yesterday's sprint meetings.

When the height of the settings on the right side of the view would be less than 100% of the window, the height of the left side would be limited to that same height. Like this:

![image](https://github.com/user-attachments/assets/1c977a85-0567-486f-89ed-a5067d6200e4)

When the height  of the right side is larger than 100% of the window height, this would not be a problem:

![image](https://github.com/user-attachments/assets/1e7e1340-5d00-4456-a95d-bf7649b47d5a)

But now it's also fixed when the right side has a very limited height:

![image](https://github.com/user-attachments/assets/a8a48cf0-e621-4756-89ee-e2538fb4adec)

