### PR TITLE
Fixed empty or mostly empty editor not sizing up to the size of its container

### DIFF
--- a/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
@@ -10,6 +10,7 @@
   color: hsl(var(--foreground));
   overflow-y: auto;
   flex-grow: 1;
+  margin: 0;
 
   // remove rounded top corners to look better in tabs
   .toolbar {

--- a/src/renderer/services/notification.service-host.ts
+++ b/src/renderer/services/notification.service-host.ts
@@ -8,6 +8,7 @@ import * as commandService from '@shared/services/command.service';
 import networkObjectService from '@shared/services/network-object.service';
 import { isLocalizeKey } from 'platform-bible-utils';
 import localizationService from '@shared/services/localization.service';
+import logger from '@shared/services/logger.service';
 
 const mapOfNotificationIdsToToastIds = new Map<string | number, string | number>();
 
@@ -16,6 +17,14 @@ async function localize(text: string): Promise<string> {
 }
 
 async function send(notification: PlatformNotification): Promise<string | number> {
+  let notificationString = '';
+  try {
+    notificationString = JSON.stringify(notification);
+  } catch (e) {
+    notificationString = '<error stringifying notification>';
+  }
+  logger.info(`Notification service host received notification: ${notificationString}`);
+
   const { message, severity, clickCommand, clickCommandLabel, notificationId } = notification;
   const localizedMessage = await localize(message);
   let toastId = notificationId ? mapOfNotificationIdsToToastIds.get(notificationId) : undefined;


### PR DESCRIPTION
Also logged every notification that comes through the notification service to make sure there is a record of what's happening.

Before:
![image](https://github.com/user-attachments/assets/164e85de-1373-4696-aa35-fd49182a1625)

After:

![image](https://github.com/user-attachments/assets/989b377c-c807-4cbd-91bf-1b9fd0402cb6)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1471)
<!-- Reviewable:end -->
