### PR TITLE
Update GitHub workflows and docs for snaps instead of AppImages

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -171,7 +171,7 @@ jobs:
         with:
           name: app-linux
           path: |
-            ./release/build/*.AppImage
+            ./release/build/*.snap
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -169,15 +169,33 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm exec electron-builder -- --publish always --mac
 
-      - name: Publish releases - Linux
+      - name: Publish releases to the snap store - Linux
         # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
         if: ${{ matrix.os == env.OS_LINUX && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
         env:
           # no hardlinks so dependencies are copied
           USE_HARD_LINKS: false
-          # This is used for uploading release assets to github
+          # This is used by electron-builder to prepare the release
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npm exec electron-builder -- --publish always --linux
+          # This is required to upload automatically to the snap store
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.LINUX_SNAP_STORE_CREDENTIALS }}
+        run: |
+          npm exec electron-builder -- --publish never --linux
+          snapcraft upload --release=edge ./release/build/*.snap
+          mkdir release/staged
+          mv release/build/*.snap release/staged
+
+      - name: Upload Linux artifacts to GitHub
+        # If the branch is labeled as a release version (e.g. "release/v1.2.3"),
+        if: ${{ matrix.os == env.OS_LINUX && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: 'Linux-PlatformBible-${{ steps.release_package_json.outputs.version }}'
+          path: release/staged
+          if-no-files-found: error
+          compression-level: 0
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session

--- a/README.md
+++ b/README.md
@@ -28,13 +28,15 @@ If you would still like to try it, you can [download early releases here on GitH
 
 ### Linux Users
 
-To use `.AppImage` files in Linux, [install FUSE](https://github.com/AppImage/AppImageKit/wiki/FUSE) (you only need to do this once), for example, on Ubuntu (>= 22.04):
+We produce [`snap` packages](<https://en.wikipedia.org/wiki/Snap_(software)>) available [on the snap store](https://snapcraft.io/platform-bible) for users to run our
+software on Linux. Once you have all the `snap` tools installed for your flavor of Linux, run `sudo snap install platform-bible` for our most recent stable build (none yet) or `sudo snap install platform-bible --channel=edge` for our most recent, pre-release build that has passed our limited, automated testing suite.
 
-```bash
-sudo apt install libfuse2
+To install a locally created `snap` package, run the following commands:
+
+```sh
+sudo snap install <path to snap file> --dangerous
+sudo snap connect platform-bible:dot-platform-bible
 ```
-
-Then simply [execute/run](https://github.com/AppImage/AppImageKit/wiki) the `.AppImage` file, which you can download from [Releases](https://github.com/paranext/paranext-core/releases).
 
 Some users may find that not everything works properly in Linux without some additional setup. Please see [How to set up Platform.Bible on Linux](https://github.com/paranext/paranext/wiki/How-to-set-up-Platform.Bible-on-Linux) for more information.
 

--- a/cspell.json
+++ b/cspell.json
@@ -78,6 +78,7 @@
     "shadcn",
     "sillsdev",
     "sldr",
+    "snapcraft",
     "sonner",
     "steenwyk",
     "stringifiable",

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -55,7 +55,7 @@
     ],
   },
   linux: {
-    target: ['AppImage', 'snap'],
+    target: ['snap'],
     category: 'Development',
     extraResources: [
       {


### PR DESCRIPTION
This removes `AppImage` building for Linux and adds some guidance for how to work with `snap` files. I also updated https://github.com/paranext/paranext/wiki/How-to-set-up-Platform.Bible-on-Linux and https://github.com/paranext/paranext/wiki/Troubleshooting-Guide#log-file-location based on how the `snap` files work.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1473)
<!-- Reviewable:end -->
