### PR TITLE
PT-1509 Implement signed MacOS installer

### DIFF
--- a/.erb/scripts/notarize.js
+++ b/.erb/scripts/notarize.js
@@ -16,10 +16,14 @@ exports.default = async function notarizeMacos(context) {
   }
 
   if (
-    !('APPLE_ID' in process.env && 'APPLE_ID_PASS' in process.env && 'APPLE_TEAM_ID' in process.env)
+    !(
+      'APPLE_ID' in process.env &&
+      'APPLE_APP_SPECIFIC_PASSWORD' in process.env &&
+      'APPLE_TEAM_ID' in process.env
+    )
   ) {
     console.warn(
-      'Skipping notarizing step. APPLE_ID, APPLE_ID_PASS, and APPLE_TEAM_ID env variables must be set',
+      'Skipping notarizing step. APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID env variables must be set',
     );
     return;
   }
@@ -31,7 +35,7 @@ exports.default = async function notarizeMacos(context) {
     appBundleId: build.appId,
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLE_ID,
-    appleIdPassword: process.env.APPLE_ID_PASS,
+    appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD,
     teamId: process.env.APPLE_TEAM_ID,
   });
 };

--- a/.erb/scripts/notarize.js
+++ b/.erb/scripts/notarize.js
@@ -5,6 +5,7 @@ const JSON5 = require('json5');
 const build = JSON5.parse(fs.readFileSync('./electron-builder.json5', 'utf8'));
 
 exports.default = async function notarizeMacos(context) {
+  console.log('Running custom notarize script');
   const { electronPlatformName, appOutDir } = context;
   if (electronPlatformName !== 'darwin') {
     return;

--- a/.erb/scripts/notarize.js
+++ b/.erb/scripts/notarize.js
@@ -5,7 +5,6 @@ const JSON5 = require('json5');
 const build = JSON5.parse(fs.readFileSync('./electron-builder.json5', 'utf8'));
 
 exports.default = async function notarizeMacos(context) {
-  console.log('Running custom notarize script');
   const { electronPlatformName, appOutDir } = context;
   if (electronPlatformName !== 'darwin') {
     return;

--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -139,13 +139,6 @@ jobs:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: |
-          echo "Checking environment variables..."
-          if [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ]; then echo "❌ APPLE_APP_SPECIFIC_PASSWORD is NOT set!"; else echo "✅ APPLE_APP_SPECIFIC_PASSWORD is set."; fi
-          if [ -z "$APPLE_ID" ]; then echo "❌ APPLE_ID is NOT set!"; else echo "✅ APPLE_ID is set."; fi
-          if [ -z "$APPLE_TEAM_ID" ]; then echo "❌ APPLE_TEAM_ID is NOT set!"; else echo "✅ APPLE_TEAM_ID is set."; fi
-          if [ -z "$CSC_LINK" ]; then echo "❌ CSC_LINK is NOT set!"; else echo "✅ CSC_LINK is set."; fi
-          if [ -z "$CSC_KEY_PASSWORD" ]; then echo "❌ CSC_KEY_PASSWORD is NOT set!"; else echo "✅ CSC_KEY_PASSWORD is set."; fi
-          if [ -z "$GH_TOKEN" ]; then echo "❌ GH_TOKEN is NOT set!"; else echo "✅ GH_TOKEN is set."; fi
           npm exec electron-builder -- build --publish never --mac
 
       - name: Publish releases - Linux

--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -131,13 +131,6 @@ jobs:
 
       - name: Publish releases - macOS
         if: ${{ matrix.os == env.OS_MACOS }}
-        env:
-          # These values are used for auto updates signing
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: |
           npm exec electron-builder -- build --publish never --mac
 

--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -131,12 +131,12 @@ jobs:
 
       - name: Publish releases - macOS
         if: ${{ matrix.os == env.OS_MACOS }}
-        # env:
-        #   # These values are used for auto updates signing
-        #   APPLE_ID: ${{ secrets.APPLE_ID }}
-        #   APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS }}
-        #   CSC_LINK: ${{ secrets.CSC_LINK }}
-        #   CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        env:
+          # These values are used for auto updates signing
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: |
           npm exec electron-builder -- build --publish never --mac
 
@@ -146,6 +146,13 @@ jobs:
           # no hardlinks so dependencies are copied
           USE_HARD_LINKS: false
         run: |
+          echo "Checking environment variables..."
+          if [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ]; then echo "❌ APPLE_APP_SPECIFIC_PASSWORD is NOT set!"; else echo "✅ APPLE_APP_SPECIFIC_PASSWORD is set."; fi
+          if [ -z "$APPLE_ID" ]; then echo "❌ APPLE_ID is NOT set!"; else echo "✅ APPLE_ID is set."; fi
+          if [ -z "$APPLE_TEAM_ID" ]; then echo "❌ APPLE_TEAM_ID is NOT set!"; else echo "✅ APPLE_TEAM_ID is set."; fi
+          if [ -z "$CSC_LINK" ]; then echo "❌ CSC_LINK is NOT set!"; else echo "✅ CSC_LINK is set."; fi
+          if [ -z "$CSC_KEY_PASSWORD" ]; then echo "❌ CSC_KEY_PASSWORD is NOT set!"; else echo "✅ CSC_KEY_PASSWORD is set."; fi
+          if [ -z "$GH_TOKEN" ]; then echo "❌ GH_TOKEN is NOT set!"; else echo "✅ GH_TOKEN is set."; fi
           npm exec electron-builder -- build --publish never --linux
 
       - name: Upload Windows artifacts

--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -138,6 +138,13 @@ jobs:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
         run: |
+          echo "Checking environment variables..."
+          if [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ]; then echo "❌ APPLE_APP_SPECIFIC_PASSWORD is NOT set!"; else echo "✅ APPLE_APP_SPECIFIC_PASSWORD is set."; fi
+          if [ -z "$APPLE_ID" ]; then echo "❌ APPLE_ID is NOT set!"; else echo "✅ APPLE_ID is set."; fi
+          if [ -z "$APPLE_TEAM_ID" ]; then echo "❌ APPLE_TEAM_ID is NOT set!"; else echo "✅ APPLE_TEAM_ID is set."; fi
+          if [ -z "$CSC_LINK" ]; then echo "❌ CSC_LINK is NOT set!"; else echo "✅ CSC_LINK is set."; fi
+          if [ -z "$CSC_KEY_PASSWORD" ]; then echo "❌ CSC_KEY_PASSWORD is NOT set!"; else echo "✅ CSC_KEY_PASSWORD is set."; fi
+          if [ -z "$GH_TOKEN" ]; then echo "❌ GH_TOKEN is NOT set!"; else echo "✅ GH_TOKEN is set."; fi
           npm exec electron-builder -- build --publish never --mac
 
       - name: Publish releases - Linux
@@ -146,13 +153,6 @@ jobs:
           # no hardlinks so dependencies are copied
           USE_HARD_LINKS: false
         run: |
-          echo "Checking environment variables..."
-          if [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ]; then echo "❌ APPLE_APP_SPECIFIC_PASSWORD is NOT set!"; else echo "✅ APPLE_APP_SPECIFIC_PASSWORD is set."; fi
-          if [ -z "$APPLE_ID" ]; then echo "❌ APPLE_ID is NOT set!"; else echo "✅ APPLE_ID is set."; fi
-          if [ -z "$APPLE_TEAM_ID" ]; then echo "❌ APPLE_TEAM_ID is NOT set!"; else echo "✅ APPLE_TEAM_ID is set."; fi
-          if [ -z "$CSC_LINK" ]; then echo "❌ CSC_LINK is NOT set!"; else echo "✅ CSC_LINK is set."; fi
-          if [ -z "$CSC_KEY_PASSWORD" ]; then echo "❌ CSC_KEY_PASSWORD is NOT set!"; else echo "✅ CSC_KEY_PASSWORD is set."; fi
-          if [ -z "$GH_TOKEN" ]; then echo "❌ GH_TOKEN is NOT set!"; else echo "✅ GH_TOKEN is set."; fi
           npm exec electron-builder -- build --publish never --linux
 
       - name: Upload Windows artifacts

--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -134,6 +134,7 @@ jobs:
         env:
           # These values are used for auto updates signing
           APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -160,11 +160,11 @@ jobs:
         if: ${{ matrix.os == env.OS_MACOS && startsWith(github.ref, 'refs/heads/release/v') && contains(github.ref, '.') }}
         env:
           # The APPLE_* values are used for auto updates signing
-          # APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_ID_PASS }}
-          # APPLE_ID: ${{ secrets.APPLE_ID }}
-          # APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          # CSC_LINK: ${{ secrets.CSC_LINK }}
-          # CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           # This is used for uploading release assets to github
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm exec electron-builder -- --publish always --mac

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -14,7 +14,7 @@
   files: ['dist', 'node_modules', 'package.json'],
   mac: {
     sign: '.erb/scripts/notarize.js',
-    notarize: false,
+    notarize: true,
     target: {
       target: 'default',
       arch: ['arm64', 'x64'],

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -2,11 +2,11 @@
  * @see https://www.electron.build/configuration/configuration
  */
 {
-  productName: 'Platform.Bible',
+  productName: 'Platform.Bible TEST 1',
   appId: 'org.paranext.PlatformBible',
   copyright: 'Copyright © 2017-2025 SIL Global and United Bible Societies',
   protocols: {
-    name: 'platform-bible',
+    name: 'Platform.Bible TEST 2',
     schemes: ['platform-bible'],
   },
   asar: true,
@@ -14,7 +14,7 @@
   files: ['dist', 'node_modules', 'package.json'],
   afterSign: '.erb/scripts/notarize.js',
   mac: {
-    notarize: true,
+    notarize: false,
     target: {
       target: 'default',
       arch: ['arm64', 'x64'],

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -14,7 +14,7 @@
   files: ['dist', 'node_modules', 'package.json'],
   afterSign: '.erb/scripts/notarize.js',
   mac: {
-    notarize: true,
+    notarize: false,
     target: {
       target: 'default',
       arch: ['arm64', 'x64'],

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -14,7 +14,7 @@
   files: ['dist', 'node_modules', 'package.json'],
   afterSign: '.erb/scripts/notarize.js',
   mac: {
-    notarize: false,
+    notarize: true,
     target: {
       target: 'default',
       arch: ['arm64', 'x64'],

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -6,7 +6,7 @@
   appId: 'org.paranext.PlatformBible',
   copyright: 'Copyright © 2017-2025 SIL Global and United Bible Societies',
   protocols: {
-    name: 'Platform.Bible',
+    name: 'platform-bible',
     schemes: ['platform-bible'],
   },
   asar: true,

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -12,8 +12,8 @@
   asar: true,
   asarUnpack: '**\\*.{node,dll}',
   files: ['dist', 'node_modules', 'package.json'],
-  afterSign: '.erb/scripts/notarize.js',
   mac: {
+    sign: '.erb/scripts/notarize.js',
     notarize: false,
     target: {
       target: 'default',

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -12,8 +12,8 @@
   asar: true,
   asarUnpack: '**\\*.{node,dll}',
   files: ['dist', 'node_modules', 'package.json'],
+  afterSign: '.erb/scripts/notarize.js',
   mac: {
-    sign: '.erb/scripts/notarize.js',
     notarize: true,
     target: {
       target: 'default',

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -12,8 +12,8 @@
   asar: true,
   asarUnpack: '**\\*.{node,dll}',
   files: ['dist', 'node_modules', 'package.json'],
+  afterSign: '.erb/scripts/notarize.js',
   mac: {
-    sign: '.erb/scripts/notarize.js',
     notarize: false,
     target: {
       target: 'default',
@@ -32,6 +32,7 @@
     gatekeeperAssess: false,
   },
   dmg: {
+    sign: false,
     contents: [
       {
         x: 130,

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -2,11 +2,11 @@
  * @see https://www.electron.build/configuration/configuration
  */
 {
-  productName: 'Platform.Bible TEST 1',
+  productName: 'Platform.Bible',
   appId: 'org.paranext.PlatformBible',
   copyright: 'Copyright © 2017-2025 SIL Global and United Bible Societies',
   protocols: {
-    name: 'Platform.Bible TEST 2',
+    name: 'Platform.Bible',
     schemes: ['platform-bible'],
   },
   asar: true,


### PR DESCRIPTION
### Changes
- Renamed `APPLE_ID_PASS` to `APPLE_APP_SPECIFIC_PASSWORD` because that is the variable name expected by electron builder. https://www.electron.build/mac#notarize 
- Uncomment the sections for Apple env variables in `package-main.yml` and `publish.yml`
- Set `dmg: { sign: false }` Following [section 4 of this tutorial](https://kilianvalkhof.com/2019/electron/notarizing-your-electron-application/)
- Use the `afterSign` hook to run the notarize script so that notarizing is happening after signing. Following [section 3 of this tutorial](https://kilianvalkhof.com/2019/electron/notarizing-your-electron-application/)

### Testing Mac build
1. Navigate to Github Actions > Package run (Probably not most recent run- https://github.com/paranext/paranext-core/actions/runs/13817640449)
2. Download the `app-macos` artifact
3. Open the `.dmg`
4. Move the app to `/Applications` folder
5. Run the app, should see the dialog pictured below (Previously it wouldn't let you open it, it said "Move to Trash").
6. Click "Open", the app should open and work as expected.

![Screenshot 2025-03-12 at 1 04 21 PM](https://github.com/user-attachments/assets/16bb83f8-a558-4bb7-a1a7-304011ec6e17)

I do see this dialog when I download any application from the Internet, and upon some research it seems like this is the expected response for a correctly signed app. In order for a user to not see this warning, they would need to disable Gatekeeper. https://stackoverflow.com/a/44258906 

### Questions or Concerns
- The package run takes around 16 minutes now. That is almost double what it was prior to my changes. From the tutorial (quote below) and google searching, it seems this is expected. https://github.com/paranext/paranext-core/actions/runs/13817640449/usage 
> Now for the actual notarization part. Electron developers (and anyone else that has an app, really) can use a tool called [Electron-notarize](https://github.com/electron-userland/electron-notarize), so install electron-notarize as a devDependency. This tools does everything: zips and uploads your apps to Apple’s servers, wait for the notarization to succeed, and then staples your app. Because this all happens asynchronously, it will add a significant amount of time to your build process. [From section 3 of this tutorial](https://kilianvalkhof.com/2019/electron/notarizing-your-electron-application/)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1479)
<!-- Reviewable:end -->
