### PR TITLE
PT-2362 Add a way to get all localizations to help extension devs

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5804,7 +5804,12 @@ declare module 'shared/services/localization.service-model' {
     DataProviderUpdateInstructions,
   } from 'shared/models/data-provider.model';
   import { LanguageInfo } from 'platform-bible-react';
-  import { LanguageStrings, LocalizeKey, OnDidDispose } from 'platform-bible-utils';
+  import {
+    LanguageStrings,
+    LocalizedStringDataContribution,
+    LocalizeKey,
+    OnDidDispose,
+  } from 'platform-bible-utils';
   export type LocalizationData = LanguageStrings;
   export type LocalizationSelector = {
     localizeKey: LocalizeKey;
@@ -5869,6 +5874,12 @@ declare module 'shared/services/localization.service-model' {
      * @returns All user-interface languages
      */
     getAvailableInterfaceLanguages: () => Promise<Record<string, LanguageInfo>>;
+    /**
+     * Get all localized string data currently loaded by the platform
+     *
+     * @returns All localized string data from all sources formatted a single, combined contribution
+     */
+    retrieveCurrentLocalizedStringData: () => Promise<LocalizedStringDataContribution>;
     /**
      * This data cannot be changed. Trying to use this setter this will always throw
      *

--- a/src/extension-host/services/localization.service-host.ts
+++ b/src/extension-host/services/localization.service-host.ts
@@ -325,6 +325,12 @@ class LocalizationDataProviderEngine
     return loadedLocales;
   }
 
+  // This method legitimately does not need to call anything else in this class as of now
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  async retrieveCurrentLocalizedStringData(): Promise<LocalizedStringDataContribution> {
+    return localizedStringsDocumentCombiner.getLocalizedStringData();
+  }
+
   // Because this is a data provider, we have to provide this method even though it always throws
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setLocalizedString(): Promise<DataProviderUpdateInstructions<LocalizationDataDataTypes>> {

--- a/src/shared/services/localization.service-model.ts
+++ b/src/shared/services/localization.service-model.ts
@@ -4,7 +4,12 @@ import {
   DataProviderUpdateInstructions,
 } from '@shared/models/data-provider.model';
 import { LanguageInfo } from 'platform-bible-react';
-import { LanguageStrings, LocalizeKey, OnDidDispose } from 'platform-bible-utils';
+import {
+  LanguageStrings,
+  LocalizedStringDataContribution,
+  LocalizeKey,
+  OnDidDispose,
+} from 'platform-bible-utils';
 
 export type LocalizationData = LanguageStrings;
 
@@ -65,6 +70,12 @@ export type ILocalizationService = {
    * @returns All user-interface languages
    */
   getAvailableInterfaceLanguages: () => Promise<Record<string, LanguageInfo>>;
+  /**
+   * Get all localized string data currently loaded by the platform
+   *
+   * @returns All localized string data from all sources formatted a single, combined contribution
+   */
+  retrieveCurrentLocalizedStringData: () => Promise<LocalizedStringDataContribution>;
   /**
    * This data cannot be changed. Trying to use this setter this will always throw
    *


### PR DESCRIPTION
As part of writing "How To" docs for extension developers, I realized it is probably too hard for extension developers to discover what strings they might want/need to localize to change strings in the UI. This adds a simple function they can call. Then I can direct them to use the developer docs link the application to call this method to retrieve the live localization data in their application.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1490)
<!-- Reviewable:end -->
