### PR TITLE
Make platform-bible-react styles apply with higher priority than extension styles

### DIFF
--- a/lib/platform-bible-react/dist/index.cjs
+++ b/lib/platform-bible-react/dist/index.cjs
@@ -3743,5 +3743,5 @@ video:where(.pr-twp,.pr-twp *) {
 .banded-row[data-state='selected']:hover {
   cursor: default;
 }
-`,"top");
+`,"after-all");
 //# sourceMappingURL=index.cjs.map

--- a/lib/platform-bible-react/dist/index.js
+++ b/lib/platform-bible-react/dist/index.js
@@ -8585,7 +8585,7 @@ video:where(.pr-twp,.pr-twp *) {
 .banded-row[data-state='selected']:hover {
   cursor: default;
 }
-`, "top");
+`, "after-all");
 export {
   ho as Alert,
   fo as AlertDescription,

--- a/lib/platform-bible-react/vite.config.ts
+++ b/lib/platform-bible-react/vite.config.ts
@@ -11,7 +11,9 @@ const config = defineConfig({
     tsconfigPaths(),
     react(),
     styleInject({
-      insertAt: 'top',
+      // Insert the platform-bible-react styles after all other style tags so the color variables and
+      // tailwind classes from platform-bible-react override those from extensions for consistency
+      insertAt: 'after-all',
     }),
   ],
   build: {


### PR DESCRIPTION
Benefits:
- Makes it a bit clearer to extensions that they can't (or shouldn't, at least) change the theme colors in their extension code
- Makes it so theme changes apply on pulling from `paranext-core` instead of requiring updating from templates
- Makes theme color changes in PBR apply to the whole application so you can see how theme changes look immediately

Limitations:
- Does not overwrite extensions' bundled styles with Platform.Bible's included styles to make sure all theme colors and used tailwind styles are consistent. We plan to have Platform.Bible apply its PBR styles to the WebView iframe in order to achieve consistency.

Context https://discord.com/channels/1064938364597436416/1353538042836811866/1354868860930625728

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1507)
<!-- Reviewable:end -->
