### PR TITLE
PT-2347 Add a way to get unlocalized menu data

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -6534,6 +6534,7 @@ declare module 'shared/services/menu-data.service-model' {
   }>;
   export type MenuDataDataTypes = {
     MainMenu: DataProviderDataType<undefined, Localized<MultiColumnMenu>, never>;
+    UnlocalizedMainMenu: DataProviderDataType<undefined, MultiColumnMenu, never>;
     WebViewMenu: DataProviderDataType<ReferencedItem, Localized<WebViewMenu>, never>;
   };
   module 'papi-shared-types' {
@@ -6550,25 +6551,25 @@ declare module 'shared/services/menu-data.service-model' {
     rebuildMenus(): Promise<void>;
     /**
      *
-     * Get menu content for the main menu
+     * Get localized menu content for the main menu
      *
      * @param mainMenuType Does not have to be defined
-     * @returns MultiColumnMenu object of main menu content
+     * @returns MultiColumnMenu object of localized main menu content
      */
-    getMainMenu(mainMenuType: undefined): Promise<MultiColumnMenu>;
+    getMainMenu(mainMenuType: undefined): Promise<Localized<MultiColumnMenu>>;
     /**
      *
-     * Get menu content for the main menu
+     * Get localized menu content for the main menu
      *
      * @param mainMenuType Does not have to be defined
-     * @returns MultiColumnMenu object of main menu content
+     * @returns MultiColumnMenu object of localized main menu content
      */
-    getMainMenu(): Promise<MultiColumnMenu>;
+    getMainMenu(): Promise<Localized<MultiColumnMenu>>;
     /**
      * This data cannot be changed. Trying to use this setter this will always throw
      *
      * @param mainMenuType Does not have to be defined
-     * @param value MultiColumnMenu object to set as the main menu
+     * @param value MultiColumnMenu object to set as the localized main menu
      * @returns Unsubscriber function
      */
     setMainMenu(
@@ -6576,10 +6577,10 @@ declare module 'shared/services/menu-data.service-model' {
       value: never,
     ): Promise<DataProviderUpdateInstructions<MenuDataDataTypes>>;
     /**
-     * Subscribe to run a callback function when the main menu data is changed
+     * Subscribe to run a callback function when the localized main menu data is changed
      *
      * @param mainMenuType Does not have to be defined
-     * @param callback Function to run with the updated menuContent for this selector
+     * @param callback Function to run with the updated localized menuContent for this selector
      * @param options Various options to adjust how the subscriber emits updates
      * @returns Unsubscriber function (run to unsubscribe from listening for updates)
      */
@@ -6589,12 +6590,52 @@ declare module 'shared/services/menu-data.service-model' {
       options?: DataProviderSubscriberOptions,
     ): Promise<UnsubscriberAsync>;
     /**
-     * Get menu content for a web view
+     *
+     * Get unlocalized menu content for the main menu
+     *
+     * @param mainMenuType Does not have to be defined
+     * @returns MultiColumnMenu object of unlocalized main menu content
+     */
+    getUnlocalizedMainMenu(mainMenuType: undefined): Promise<MultiColumnMenu>;
+    /**
+     *
+     * Get unlocalized menu content for the main menu
+     *
+     * @param mainMenuType Does not have to be defined
+     * @returns MultiColumnMenu object of unlocalized main menu content
+     */
+    getUnlocalizedMainMenu(): Promise<MultiColumnMenu>;
+    /**
+     * This data cannot be changed. Trying to use this setter this will always throw
+     *
+     * @param mainMenuType Does not have to be defined
+     * @param value MultiColumnMenu object to set as the unlocalized main menu
+     * @returns Unsubscriber function
+     */
+    setUnlocalizedMainMenu(
+      mainMenuType: undefined,
+      value: never,
+    ): Promise<DataProviderUpdateInstructions<MenuDataDataTypes>>;
+    /**
+     * Subscribe to run a callback function when the unlocalized main menu data is changed
+     *
+     * @param mainMenuType Does not have to be defined
+     * @param callback Function to run with the updated unlocalized menuContent for this selector
+     * @param options Various options to adjust how the subscriber emits updates
+     * @returns Unsubscriber function (run to unsubscribe from listening for updates)
+     */
+    subscribeUnlocalizedMainMenu(
+      mainMenuType: undefined,
+      callback: (menuContent: MultiColumnMenu) => void,
+      options?: DataProviderSubscriberOptions,
+    ): Promise<UnsubscriberAsync>;
+    /**
+     * Get localized menu content for a web view
      *
      * @param webViewType The type of webview for which a menu should be retrieved
      * @returns WebViewMenu object of web view menu content
      */
-    getWebViewMenu(webViewType: ReferencedItem): Promise<WebViewMenu>;
+    getWebViewMenu(webViewType: ReferencedItem): Promise<Localized<WebViewMenu>>;
     /**
      * This data cannot be changed. Trying to use this setter this will always throw
      *
@@ -6607,7 +6648,7 @@ declare module 'shared/services/menu-data.service-model' {
       value: never,
     ): Promise<DataProviderUpdateInstructions<MenuDataDataTypes>>;
     /**
-     * Subscribe to run a callback function when the web view menu data is changed
+     * Subscribe to run a callback function when the localized web view menu data is changed
      *
      * @param webViewType The type of webview for which a menu should be subscribed
      * @param callback Function to run with the updated menuContent for this selector

--- a/src/extension-host/services/menu-data.service-host.test.tsx
+++ b/src/extension-host/services/menu-data.service-host.test.tsx
@@ -203,3 +203,15 @@ test('Get web view menu data for videoExtension', async () => {
 test('Setting web view menu data throws', async () => {
   await expect(menuDataProviderEngine.setWebViewMenu()).rejects.toThrow('setWebViewMenu disabled');
 });
+
+// Add tests for unlocalized main menu data
+test('Get unlocalized main menu data', async () => {
+  const result = await menuDataProviderEngine.getUnlocalizedMainMenu();
+  expect(result).toEqual(MOCK_MENU_DATA.mainMenu);
+});
+
+test('Setting unlocalized main menu data throws', async () => {
+  await expect(menuDataProviderEngine.setUnlocalizedMainMenu()).rejects.toThrow(
+    'setUnlocalizedMainMenu disabled',
+  );
+});

--- a/src/extension-host/services/menu-data.service-host.ts
+++ b/src/extension-host/services/menu-data.service-host.ts
@@ -24,19 +24,26 @@ class MenuDataDataProviderEngine
   implements IDataProviderEngine<MenuDataDataTypes>
 {
   private mainMenu: Localized<MultiColumnMenu> = { groups: {}, items: [], columns: {} };
+  private unlocalizedMainMenu: MultiColumnMenu = { groups: {}, items: [], columns: {} };
   private webViewMenusMap = new Map<ReferencedItem, Localized<WebViewMenu>>();
   private unsubscribeOnDidResyncContributions: Unsubscriber | undefined;
 
-  constructor(menuData: Localized<PlatformMenus>) {
+  constructor(unlocalizedMenuData: PlatformMenus) {
     super();
-    this.#loadAllMenuData(menuData);
+    this.#loadAllMenuData(unlocalizedMenuData, unlocalizedMenuData);
     onDidResyncContributions(() => this.rebuildMenus());
   }
 
   async rebuildMenus(): Promise<void> {
     const currentMenus = await menuDocumentCombiner.getCurrentMenus();
-    if (!currentMenus || currentMenus.mainMenu === this.mainMenu) return;
-    this.#loadAllMenuData(currentMenus);
+    const rawMenus = menuDocumentCombiner.rawOutput;
+    if (
+      !currentMenus ||
+      !rawMenus ||
+      (currentMenus.mainMenu === this.mainMenu && rawMenus.mainMenu === this.unlocalizedMainMenu)
+    )
+      return;
+    this.#loadAllMenuData(rawMenus, currentMenus);
     this.notifyUpdate('*');
   }
 
@@ -49,6 +56,17 @@ class MenuDataDataProviderEngine
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
   async setMainMenu(): Promise<DataProviderUpdateInstructions<MenuDataDataTypes>> {
     throw new Error('setMainMenu disabled');
+  }
+
+  async getUnlocalizedMainMenu(): Promise<MultiColumnMenu> {
+    if (!this.unlocalizedMainMenu) throw new Error('Missing/invalid unlocalized main menu data');
+    return this.unlocalizedMainMenu;
+  }
+
+  // Because this is a data provider, we have to provide this method even though it always throws
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  async setUnlocalizedMainMenu(): Promise<DataProviderUpdateInstructions<MenuDataDataTypes>> {
+    throw new Error('setUnlocalizedMainMenu disabled');
   }
 
   async getWebViewMenu(webViewName: ReferencedItem): Promise<Localized<WebViewMenu>> {
@@ -75,12 +93,14 @@ class MenuDataDataProviderEngine
     return true;
   }
 
-  #loadAllMenuData(menuData: Localized<PlatformMenus>): void {
+  #loadAllMenuData(unlocalizedMainMenu: PlatformMenus, menuData: Localized<PlatformMenus>): void {
     this.mainMenu = { groups: {}, items: [], columns: {} };
+    this.unlocalizedMainMenu = { groups: {}, items: [], columns: {} };
     this.webViewMenusMap.clear();
 
     try {
       this.mainMenu = menuData.mainMenu;
+      this.unlocalizedMainMenu = unlocalizedMainMenu.mainMenu;
       const { webViewMenus } = menuData;
 
       Object.entries(webViewMenus).forEach(([webViewType, value]) => {
@@ -123,7 +143,7 @@ export async function initialize(): Promise<void> {
 
 /** This is an internal-only export for testing purposes and should not be used in development */
 export const testingMenuDataService = {
-  implementMenuDataDataProviderEngine: (dataObj: Localized<PlatformMenus>) => {
+  implementMenuDataDataProviderEngine: (dataObj: PlatformMenus) => {
     return new MenuDataDataProviderEngine(dataObj);
   },
 };

--- a/src/shared/services/menu-data.service-model.ts
+++ b/src/shared/services/menu-data.service-model.ts
@@ -28,6 +28,7 @@ export const menuDataServiceObjectToProxy = Object.freeze({
 // Data Type to initialize data provider engine with
 export type MenuDataDataTypes = {
   MainMenu: DataProviderDataType<undefined, Localized<MultiColumnMenu>, never>;
+  UnlocalizedMainMenu: DataProviderDataType<undefined, MultiColumnMenu, never>;
   WebViewMenu: DataProviderDataType<ReferencedItem, Localized<WebViewMenu>, never>;
 };
 
@@ -48,19 +49,19 @@ export type IMenuDataService = {
   /**
    * JSDOC SOURCE getMainMenu
    *
-   * Get menu content for the main menu
+   * Get localized menu content for the main menu
    *
    * @param mainMenuType Does not have to be defined
-   * @returns MultiColumnMenu object of main menu content
+   * @returns MultiColumnMenu object of localized main menu content
    */
-  getMainMenu(mainMenuType: undefined): Promise<MultiColumnMenu>;
+  getMainMenu(mainMenuType: undefined): Promise<Localized<MultiColumnMenu>>;
   /** JSDOC DESTINATION getMainMenu */
-  getMainMenu(): Promise<MultiColumnMenu>;
+  getMainMenu(): Promise<Localized<MultiColumnMenu>>;
   /**
    * This data cannot be changed. Trying to use this setter this will always throw
    *
    * @param mainMenuType Does not have to be defined
-   * @param value MultiColumnMenu object to set as the main menu
+   * @param value MultiColumnMenu object to set as the localized main menu
    * @returns Unsubscriber function
    */
   setMainMenu(
@@ -68,10 +69,10 @@ export type IMenuDataService = {
     value: never,
   ): Promise<DataProviderUpdateInstructions<MenuDataDataTypes>>;
   /**
-   * Subscribe to run a callback function when the main menu data is changed
+   * Subscribe to run a callback function when the localized main menu data is changed
    *
    * @param mainMenuType Does not have to be defined
-   * @param callback Function to run with the updated menuContent for this selector
+   * @param callback Function to run with the updated localized menuContent for this selector
    * @param options Various options to adjust how the subscriber emits updates
    * @returns Unsubscriber function (run to unsubscribe from listening for updates)
    */
@@ -81,12 +82,47 @@ export type IMenuDataService = {
     options?: DataProviderSubscriberOptions,
   ): Promise<UnsubscriberAsync>;
   /**
-   * Get menu content for a web view
+   * JSDOC SOURCE getUnlocalizedMainMenu
+   *
+   * Get unlocalized menu content for the main menu
+   *
+   * @param mainMenuType Does not have to be defined
+   * @returns MultiColumnMenu object of unlocalized main menu content
+   */
+  getUnlocalizedMainMenu(mainMenuType: undefined): Promise<MultiColumnMenu>;
+  /** JSDOC DESTINATION getUnlocalizedMainMenu */
+  getUnlocalizedMainMenu(): Promise<MultiColumnMenu>;
+  /**
+   * This data cannot be changed. Trying to use this setter this will always throw
+   *
+   * @param mainMenuType Does not have to be defined
+   * @param value MultiColumnMenu object to set as the unlocalized main menu
+   * @returns Unsubscriber function
+   */
+  setUnlocalizedMainMenu(
+    mainMenuType: undefined,
+    value: never,
+  ): Promise<DataProviderUpdateInstructions<MenuDataDataTypes>>;
+  /**
+   * Subscribe to run a callback function when the unlocalized main menu data is changed
+   *
+   * @param mainMenuType Does not have to be defined
+   * @param callback Function to run with the updated unlocalized menuContent for this selector
+   * @param options Various options to adjust how the subscriber emits updates
+   * @returns Unsubscriber function (run to unsubscribe from listening for updates)
+   */
+  subscribeUnlocalizedMainMenu(
+    mainMenuType: undefined,
+    callback: (menuContent: MultiColumnMenu) => void,
+    options?: DataProviderSubscriberOptions,
+  ): Promise<UnsubscriberAsync>;
+  /**
+   * Get localized menu content for a web view
    *
    * @param webViewType The type of webview for which a menu should be retrieved
    * @returns WebViewMenu object of web view menu content
    */
-  getWebViewMenu(webViewType: ReferencedItem): Promise<WebViewMenu>;
+  getWebViewMenu(webViewType: ReferencedItem): Promise<Localized<WebViewMenu>>;
   /**
    * This data cannot be changed. Trying to use this setter this will always throw
    *
@@ -99,7 +135,7 @@ export type IMenuDataService = {
     value: never,
   ): Promise<DataProviderUpdateInstructions<MenuDataDataTypes>>;
   /**
-   * Subscribe to run a callback function when the web view menu data is changed
+   * Subscribe to run a callback function when the localized web view menu data is changed
    *
    * @param webViewType The type of webview for which a menu should be subscribed
    * @param callback Function to run with the updated menuContent for this selector


### PR DESCRIPTION
macOS main menu code needs a data type on the menu data service to work with unlocalized menu items.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1516)
<!-- Reviewable:end -->
