### PR TITLE
Explained checking out a released version's git ref for developing extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,11 +101,22 @@ dotnet --list-sdks
 
 ### Cloning and installing dependencies (all platforms)
 
-Clone the repo and install dependencies:
+Clone the repo:
 
 ```bash
 git clone https://github.com/paranext/paranext-core.git
 cd paranext-core
+```
+
+If you want to develop an extension for Platform.Bible, check out the Git reference (usually a [tag](https://github.com/paranext/paranext-core/tags)) corresponding to the version for which you want to develop your extension. We recommend you develop for the latest released version, _not_ `main`. Consult [the version table](https://github.com/paranext/paranext/wiki/Software-Version-Info) for more information. For example, if you want to develop your extension for version 0.3.0, run the following:
+
+```bash
+git checkout v0.3.0
+```
+
+Install dependencies:
+
+```bash
 npm install
 ```
 


### PR DESCRIPTION
We are changing guidance so extension developers should develop against specific versions from now on.

I plan to make this change also in `paranext` and `paratext-10-studio` when this gets in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1528)
<!-- Reviewable:end -->
