### PR TITLE
PT-2261 rename binaries to include GitHub run IDs

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -114,16 +114,6 @@ jobs:
           npm ci
           npm run build
 
-      - name: Update release version
-        shell: bash
-        run: |
-          COMMIT_HASH=$(git rev-parse --short "$GITHUB_SHA")
-          cd ./release/app
-          CURRENT_VERSION=$(node -pe "require('./package.json').version")
-          NEW_VERSION="${CURRENT_VERSION}-commit.${COMMIT_HASH}"
-          echo "Updating version from ${CURRENT_VERSION} to ${NEW_VERSION}"
-          npm --no-git-tag-version version $NEW_VERSION
-
       - name: Publish releases - Windows
         if: ${{ matrix.os == env.OS_WINDOWS }}
         run: |
@@ -142,6 +132,17 @@ jobs:
         run: |
           npm exec electron-builder -- build --publish never --linux
 
+      - name: Rename Windows exe to include GitHub Action Run ID
+        if: ${{ matrix.os == env.OS_WINDOWS }}
+        run: |
+          Get-ChildItem -Path ./release/build/*.exe | ForEach-Object {
+            if (-not ($_.Name -like "*Setup*.exe")) {
+              $newName = "$($_.BaseName)-${{ github.run_id }}.exe"
+              Rename-Item -Path $_.FullName -NewName $newName
+              Write-Host "Renamed $($_.Name) to $newName"
+            }
+          }
+
       - name: Upload Windows artifacts
         if: ${{ matrix.os == env.OS_WINDOWS }}
         uses: actions/upload-artifact@v4
@@ -151,6 +152,15 @@ jobs:
             ./release/build/*.exe
             !./release/build/*Setup*.exe
 
+      - name: Rename macOS dmg to include GitHub Action Run ID
+        if: ${{ matrix.os == env.OS_MACOS }}
+        run: |
+          for file in ./release/build/*.dmg; do
+            newName="${file%.dmg}-${{ github.run_id }}.dmg"
+            mv "$file" "$newName"
+            echo "Renamed $file to $newName"
+          done
+
       - name: Upload macOS artifacts
         if: ${{ matrix.os == env.OS_MACOS }}
         uses: actions/upload-artifact@v4
@@ -158,6 +168,15 @@ jobs:
           name: app-macos
           path: |
             ./release/build/*.dmg
+
+      - name: Rename Linux snap to include GitHub Action Run ID
+        if: ${{ matrix.os == env.OS_LINUX }}
+        run: |
+          for file in ./release/build/*.snap; do
+            newName="${file%.snap}-${{ github.run_id }}.snap"
+            mv "$file" "$newName"
+            echo "Renamed $file to $newName"
+          done
 
       - name: Upload Linux artifacts
         if: ${{ matrix.os == env.OS_LINUX }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -168,6 +168,17 @@ jobs:
         run: |
           (gh api -X GET /repos/${{ github.repository }}/actions/artifacts --jq '.artifacts[] | select(.name == "app-windows-test" and .workflow_run.head_branch == "${{ github.ref_name }}") | .id') -split "`n" | ForEach-Object { gh api -X DELETE /repos/${{ github.repository }}/actions/artifacts/$_ }
 
+      - name: Rename Windows exe to include GitHub Action Run ID
+        if: ${{ matrix.os == env.OS_WINDOWS }}
+        run: |
+          Get-ChildItem -Path ./release/build/*.exe | ForEach-Object {
+            if (-not ($_.Name -like "*Setup*.exe")) {
+              $newName = "$($_.BaseName)-${{ github.run_id }}.exe"
+              Rename-Item -Path $_.FullName -NewName $newName
+              Write-Host "Renamed $($_.Name) to $newName"
+            }
+          }
+
       - name: Upload Windows artifacts
         if: ${{ matrix.os == env.OS_WINDOWS }}
         uses: actions/upload-artifact@v4
@@ -185,6 +196,15 @@ jobs:
         run: |
           gh api -X GET /repos/${{ github.repository }}/actions/artifacts --jq '.artifacts[] | select(.name == "app-macos-test" and .workflow_run.head_branch == "${{ github.ref_name }}") | .id' | xargs -I {} gh api -X DELETE /repos/${{ github.repository }}/actions/artifacts/{}
 
+      - name: Rename macOS dmg to include GitHub Action Run ID
+        if: ${{ matrix.os == env.OS_MACOS }}
+        run: |
+          for file in ./release/build/*.dmg; do
+            newName="${file%.dmg}-${{ github.run_id }}.dmg"
+            mv "$file" "$newName"
+            echo "Renamed $file to $newName"
+          done
+
       - name: Upload macOS artifacts
         if: ${{ matrix.os == env.OS_MACOS }}
         uses: actions/upload-artifact@v4
@@ -200,6 +220,15 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh api -X GET /repos/${{ github.repository }}/actions/artifacts --jq '.artifacts[] | select(.name == "app-linux-test" and .workflow_run.head_branch == "${{ github.ref_name }}") | .id' | xargs -I {} gh api -X DELETE /repos/${{ github.repository }}/actions/artifacts/{}
+
+      - name: Rename Linux snap to include GitHub Action Run ID
+        if: ${{ matrix.os == env.OS_LINUX }}
+        run: |
+          for file in ./release/build/*.snap; do
+            newName="${file%.snap}-${{ github.run_id }}.snap"
+            mv "$file" "$newName"
+            echo "Renamed $file to $newName"
+          done
 
       - name: Upload Linux artifacts
         if: ${{ matrix.os == env.OS_LINUX }}


### PR DESCRIPTION
This intentionally does not touch publishing workflows for "official" builds. This is only meant to help distinguish pre-release builds from each other when version numbers aren't changing.