### PR TITLE
update editor v0.7.9

### DIFF
--- a/extensions/src/platform-scripture-editor/package.json
+++ b/extensions/src/platform-scripture-editor/package.json
@@ -38,7 +38,7 @@
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {
-    "@biblionexus-foundation/platform-editor": "~0.7.7",
+    "@biblionexus-foundation/platform-editor": "~0.7.9",
     "@biblionexus-foundation/scripture-utilities": "~0.0.8",
     "@swc/core": "^1.10.18",
     "@tailwindcss/typography": "^0.5.16",

--- a/extensions/src/platform-scripture-editor/src/_usj-nodes.scss
+++ b/extensions/src/platform-scripture-editor/src/_usj-nodes.scss
@@ -2107,11 +2107,15 @@ body {
 }
 
 .editor-input {
-  counter-reset: caller 0;
+  counter-reset: caller;
+}
+
+.editor-input.reset-counters {
+  counter-reset: none;
 }
 
 .immutable-note-caller[data-caller='+'] {
-  counter-increment: caller 1;
+  counter-increment: caller;
 }
 
 .immutable-note-caller[data-caller='+'] > button::before {

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -152,9 +152,9 @@ class ScriptureEditorWebViewFactory extends WebViewFactory<typeof scriptureEdito
       );
 
     // We know that the projectId (if present in the state) will be a string.
-    const projectId = getWebViewOptions.projectId || savedWebView.projectId || undefined;
+    const projectId = getWebViewOptions.projectId ?? savedWebView.projectId ?? undefined;
     const isReadOnly = getWebViewOptions.isReadOnly || savedWebView.state?.isReadOnly;
-    let title = getWebViewOptions.options?.title || savedWebView.title;
+    let title = getWebViewOptions.options?.title ?? savedWebView.title;
     if (!title) {
       if (projectId) title = PROJECT_ID_TITLE_FORMAT_STRING_KEY;
       else title = isReadOnly ? RESOURCE_VIEWER_KEY : SCRIPTURE_EDITOR_KEY;
@@ -421,7 +421,7 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     },
   );
 
-  const scriptureEditorWebViewProviderPromise = papi.webViewProviders.register(
+  const scriptureEditorWebViewProviderPromise = papi.webViewProviders.registerWebViewProvider(
     scriptureEditorWebViewType,
     scriptureEditorWebViewProvider,
   );

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -81,9 +81,11 @@ function deepEqualAcrossIframes(a: unknown, b: unknown) {
 
 function scrollToVerse(verseLocation: SerializedVerseRef): HTMLElement | undefined {
   const verseElement =
-    document.querySelector<HTMLElement>(
-      `.editor-container span[data-marker="v"][data-number="${verseLocation.verseNum}"]`,
-    ) ?? undefined;
+    verseLocation.verseNum < 1
+      ? undefined
+      : (document.querySelector<HTMLElement>(
+          `.editor-container span[data-marker="v"][data-number*="${verseLocation.verseNum}"]`,
+        ) ?? undefined);
 
   const scrollContainerElement =
     document.querySelector<HTMLElement>('.editor-container') ?? undefined;

--- a/extensions/src/platform-scripture-editor/src/types/@biblionexus-foundation__platform-editor.d.ts
+++ b/extensions/src/platform-scripture-editor/src/types/@biblionexus-foundation__platform-editor.d.ts
@@ -45,7 +45,7 @@ declare module 'shared-react/nodes/scripture/usj/usj-node-options.model' {
   type OnClick = (event: SyntheticEvent) => void;
   const immutableNoteCallerNodeName = 'ImmutableNoteCallerNode';
 
-  export const MarkNodeName = 'MarkNode';
+  export const typedMarkNodeName = 'TypedMarkNode';
 
   export type AddMissingComments = (usjCommentIds: string[]) => void;
 
@@ -57,7 +57,7 @@ declare module 'shared-react/nodes/scripture/usj/usj-node-options.model' {
       /** Click handler method. */
       onClick?: OnClick;
     };
-    [MarkNodeName]?: {
+    [typedMarkNodeName]?: {
       /** Method to add missing comments. */
       addMissingComments?: AddMissingComments;
     };

--- a/package-lock.json
+++ b/package-lock.json
@@ -838,7 +838,7 @@
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
-        "@biblionexus-foundation/platform-editor": "~0.7.7",
+        "@biblionexus-foundation/platform-editor": "~0.7.9",
         "@biblionexus-foundation/scripture-utilities": "~0.0.8",
         "@swc/core": "^1.10.18",
         "@tailwindcss/typography": "^0.5.16",
@@ -3313,9 +3313,9 @@
       "peer": true
     },
     "node_modules/@biblionexus-foundation/platform-editor": {
-      "version": "0.7.7",
-      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.7.7.tgz",
-      "integrity": "sha512-YPuavEd+G2n5tn5XD+yCVLHtMsY/oaSbGcl8T+8aKn3gMErEyYrQSl7PVoFQkQmrtVUYA9kT4yXjs3uBPtb+aw==",
+      "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.7.9.tgz",
+      "integrity": "sha512-43DADfrcL3rLCCdsSQ780KKoXsoNyMLPpZzYPnktNKqj6pX7KkPRRhOBrO2jPnwqZdYe76xnlc/6h9baHgR8Ag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- when a note is removed, re-generate callers without scrolling the content-editable to the top
- selecting another verse in the range of this editor in another editor doesn't move the cursor already in the range in this editor.
- fix highlighting and scrolling for ranges and segments
- use `typeMarkNodeName` to complete earlier refactor