### PR TITLE
Fix book scope filter not working in checks side panel

### DIFF
--- a/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
+++ b/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
@@ -124,8 +124,8 @@ global.webViewComponent = function ChecksSidePanelWebView({
       chapterNum: scrRef.chapterNum,
       verseNum: 1,
     };
-    const start = defaultScrRef;
-    const end = defaultScrRef;
+    const start = { ...defaultScrRef };
+    const end = { ...defaultScrRef };
 
     if (scope === CheckScopes.Book) {
       start.chapterNum = 1;


### PR DESCRIPTION
When I started console logging the values of start.chapterNum and end.chapterNum, I realized that they were both the same and they would be the value of whatever got set last (so only check results in the last chapter were displaying for book). I made shallow copies of defaultScrRef as ChatGPT suggested and that cleared up the problem.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1564)
<!-- Reviewable:end -->
