### PR TITLE
PT-2139: Update Home when Resources is updated

### DIFF
--- a/extensions/src/platform-get-resources/src/home.web-view.tsx
+++ b/extensions/src/platform-get-resources/src/home.web-view.tsx
@@ -1,5 +1,5 @@
 import papi, { logger } from '@papi/frontend';
-import { useDataProvider, useLocalizedStrings, useSetting } from '@papi/frontend/react';
+import { useData, useDataProvider, useLocalizedStrings, useSetting } from '@papi/frontend/react';
 import {
   BookOpen,
   ChevronDown,
@@ -136,6 +136,11 @@ globalThis.webViewComponent = function HomeDialog() {
 
     fetchAvailability();
   }, [dblResourcesProvider]);
+
+  const [resourcesList] = useData('platformGetResources.dblResourcesProvider').DblResources(
+    undefined,
+    [],
+  );
 
   const openResource = (projectId: string, isEditable: boolean) =>
     papi.commands.sendCommand(
@@ -302,7 +307,7 @@ globalThis.webViewComponent = function HomeDialog() {
       // Mark this promise as old and not to be used
       promiseIsCurrent = false;
     };
-  }, [isSendReceiveInProgress, excludePdpFactoryIdsInHome]);
+  }, [isSendReceiveInProgress, excludePdpFactoryIdsInHome, resourcesList]);
 
   const mergedProjectInfo: MergedProjectInfo[] = useMemo(() => {
     const newMergedProjectInfo: MergedProjectInfo[] = [];


### PR DESCRIPTION
I'ts a quick fix, but with the DBL being the only resource provider for now, it should do


https://github.com/user-attachments/assets/a847d418-187a-45cf-a148-ea8ea1667ce0



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1572)
<!-- Reviewable:end -->
