### PR TITLE
Release label-blank marketing strings in package.json

### DIFF
--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,8 +1,8 @@
 {
   "name": "platform-bible",
   "version": "0.5.0-alpha.0",
-  "marketingVersion": "β1",
-  "marketingVersionMoniker": "Developer Preview",
+  "marketingVersion": "",
+  "marketingVersionMoniker": "",
   "description": "Extensible Bible translation software",
   "license": "MIT",
   "author": {

--- a/src/renderer/components/platform-bible-toolbar.tsx
+++ b/src/renderer/components/platform-bible-toolbar.tsx
@@ -104,7 +104,9 @@ export function PlatformBibleToolbar() {
   const [marketingVersion] = usePromise(
     useCallback(async () => {
       const marketingInfo = await app.getMarketingInfo();
-      return marketingInfo.marketingVersion.concat(' ', marketingInfo.marketingVersionMoniker);
+      return marketingInfo.marketingVersion.concat(
+        marketingInfo.marketingVersionMoniker ? ` ${marketingInfo.marketingVersionMoniker}` : '',
+      );
     }, []),
     'Marketing Version',
   );
@@ -125,21 +127,23 @@ export function PlatformBibleToolbar() {
       appMenuAreaChildren={<img width={24} height={24} src={`${logo}`} alt="Application Logo" />}
       configAreaChildren={
         <>
-          <TooltipProvider delayDuration={300}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Badge
-                  variant="ghost"
-                  className="tw-block tw-max-w-[150px] tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap tw-font-normal tw-shrink"
-                >
-                  {marketingVersion}
-                </Badge>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="tw-font-light">{marketingVersion}</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          {marketingVersion !== '' && (
+            <TooltipProvider delayDuration={300}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Badge
+                    variant="ghost"
+                    className="tw-block tw-max-w-[150px] tw-overflow-hidden tw-text-ellipsis tw-whitespace-nowrap tw-font-normal tw-shrink"
+                  >
+                    {marketingVersion}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="tw-font-light">{marketingVersion}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          )}
           {/* This is a placeholder for the actual user menu */}
           <TooltipProvider delayDuration={300}>
             <Tooltip>


### PR DESCRIPTION
The marketing strings are only supposed to have values on the release prep branch, blanking them out. Fixed the code to not show the `Badge` or tooltip if the marketing string equals empty string.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1585)
<!-- Reviewable:end -->
