### PR TITLE
PT-2973: Handle `PlatformError` in hooks and data provider subscribe …

### DIFF
--- a/extensions/src/hello-someone/src/hello-someone.web-view.html
+++ b/extensions/src/hello-someone/src/hello-someone.web-view.html
@@ -34,7 +34,12 @@
     <script>
       const papi = require('@papi/frontend');
       const { logger } = require('@papi/frontend');
-      const { htmlEncode, serialize } = require('platform-bible-utils');
+      const {
+        getErrorMessage,
+        htmlEncode,
+        isPlatformError,
+        serialize,
+      } = require('platform-bible-utils');
 
       function print(input) {
         logger.debug(input);
@@ -114,6 +119,10 @@
 
         // Update the 'people' display on load and on updates
         peopleDataProvider.subscribePeople(undefined, (people) => {
+          if (isPlatformError(people)) {
+            logger.warn(`subscribePeople received PlatformError: ${getErrorMessage(people)}`);
+            return;
+          }
           const peopleData = document.getElementById('people-data');
           const peopleString = serialize(people, undefined, 2);
           peopleData.textContent = htmlEncode(peopleString.replace(/"/g, '`'));

--- a/extensions/src/hello-world/src/main.ts
+++ b/extensions/src/hello-world/src/main.ts
@@ -7,7 +7,7 @@ import type {
   WebViewDefinition,
 } from '@papi/core';
 import type { HelloWorldEvent, HelloWorldProjectWebViewController } from 'hello-world';
-import { PlatformEventEmitter } from 'platform-bible-utils';
+import { getErrorMessage, isPlatformError, PlatformEventEmitter } from 'platform-bible-utils';
 import { checkDetails, createHelloCheck } from './checks';
 import { HelloWorldProjectDataProviderEngineFactory } from './models/hello-world-project-data-provider-engine-factory.model';
 import { HELLO_WORLD_PROJECT_INTERFACES } from './models/hello-world-project-data-provider-engine.model';
@@ -498,10 +498,15 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     const peopleDataProvider = await papi.dataProviders.get('helloSomeone.people');
     if (peopleDataProvider) {
       // Test subscribing to a data provider
-      const unsubGreetings = await peopleDataProvider.subscribeGreeting(
-        'Bill',
-        (billGreeting: string | undefined) => logger.debug(`Bill's greeting: ${billGreeting}`),
-      );
+      const unsubGreetings = await peopleDataProvider.subscribeGreeting('Bill', (billGreeting) => {
+        if (isPlatformError(billGreeting)) {
+          logger.warn(
+            `Hello world main Bill's greeting subscription threw! ${getErrorMessage(billGreeting)}`,
+          );
+          return;
+        }
+        logger.debug(`Bill's greeting: ${billGreeting}`);
+      });
 
       context.registrations.add(unsubGreetings);
     }

--- a/extensions/src/hello-world/src/web-views/hello-world-project/hello-world-project-viewer.web-view.tsx
+++ b/extensions/src/hello-world/src/web-views/hello-world-project/hello-world-project-viewer.web-view.tsx
@@ -1,7 +1,10 @@
 import { WebViewProps } from '@papi/core';
-import { useProjectData, useProjectSetting, useWebViewController } from '@papi/frontend/react';
+import { logger } from '@papi/frontend';
+import { useProjectData, useWebViewController } from '@papi/frontend/react';
 import { Button } from 'platform-bible-react';
+import { getErrorMessage, isPlatformError } from 'platform-bible-utils';
 import { CSSProperties, useMemo } from 'react';
+import { useHelloWorldProjectSettings } from './use-hello-world-project-settings.hook';
 
 const namesDefault: string[] = [];
 
@@ -16,11 +19,20 @@ globalThis.webViewComponent = function HelloWorldProjectViewer({
     callerWebViewId,
   );
 
-  const [names] = useProjectData('helloWorld', projectId).Names(undefined, namesDefault);
+  const [namesPossiblyError] = useProjectData('helloWorld', projectId).Names(
+    undefined,
+    namesDefault,
+  );
 
-  const [headerSize] = useProjectSetting(projectId, 'helloWorld.headerSize', 15);
+  const names = useMemo(() => {
+    if (isPlatformError(namesPossiblyError)) {
+      logger.warn(`Error getting names: ${getErrorMessage(namesPossiblyError)}`);
+      return namesDefault;
+    }
+    return namesPossiblyError;
+  }, [namesPossiblyError]);
 
-  const [headerColor] = useProjectSetting(projectId, 'helloWorld.headerColor', 'Black');
+  const { headerSize, headerColor } = useHelloWorldProjectSettings(projectId);
 
   const headerStyle = useMemo<CSSProperties>(() => {
     const colorPropertyName = callerWebViewController ? 'backgroundColor' : 'color';

--- a/extensions/src/hello-world/src/web-views/hello-world-project/use-hello-world-project-settings.hook.ts
+++ b/extensions/src/hello-world/src/web-views/hello-world-project/use-hello-world-project-settings.hook.ts
@@ -1,23 +1,44 @@
+import { logger } from '@papi/frontend';
 import { useProjectSetting } from '@papi/frontend/react';
 import type { IBaseProjectDataProvider } from 'papi-shared-types';
+import { getErrorMessage, isPlatformError } from 'platform-bible-utils';
 import { CSSProperties, useMemo } from 'react';
+
+const HEADER_SIZE_DEFAULT = 15;
+const HEADER_COLOR_DEFAULT = 'Black';
 
 export function useHelloWorldProjectSettings(
   // Any Base PDP type works. Without `any`, the DataProviderUpdateInstructions types are incompatible
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   projectDataProviderSource: string | IBaseProjectDataProvider<any> | undefined,
 ) {
-  const [headerSize, setHeaderSize, resetHeaderSize] = useProjectSetting(
+  const [headerSizePossiblyError, setHeaderSize, resetHeaderSize] = useProjectSetting(
     projectDataProviderSource,
     'helloWorld.headerSize',
-    15,
+    HEADER_SIZE_DEFAULT,
   );
 
-  const [headerColor, setHeaderColor, resetHeaderColor] = useProjectSetting(
+  const headerSize = useMemo(() => {
+    if (isPlatformError(headerSizePossiblyError)) {
+      logger.warn(`Error getting header size: ${getErrorMessage(headerSizePossiblyError)}`);
+      return HEADER_SIZE_DEFAULT;
+    }
+    return headerSizePossiblyError;
+  }, [headerSizePossiblyError]);
+
+  const [headerColorPossiblyError, setHeaderColor, resetHeaderColor] = useProjectSetting(
     projectDataProviderSource,
     'helloWorld.headerColor',
-    'Black',
+    HEADER_COLOR_DEFAULT,
   );
+
+  const headerColor = useMemo(() => {
+    if (isPlatformError(headerColorPossiblyError)) {
+      logger.warn(`Error getting header color: ${getErrorMessage(headerColorPossiblyError)}`);
+      return HEADER_COLOR_DEFAULT;
+    }
+    return headerColorPossiblyError;
+  }, [headerColorPossiblyError]);
 
   const headerStyle = useMemo<CSSProperties>(
     () => ({ fontSize: `${headerSize}pt`, color: headerColor }),

--- a/extensions/src/hello-world/src/web-views/hello-world.web-view.tsx
+++ b/extensions/src/hello-world/src/web-views/hello-world.web-view.tsx
@@ -21,7 +21,7 @@ import {
   TextField,
   useEvent,
 } from 'platform-bible-react';
-import { debounce, isPlatformError } from 'platform-bible-utils';
+import { debounce, getErrorMessage, isPlatformError } from 'platform-bible-utils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Logo from '../../assets/offline.svg';
 import { Clock } from './components/clock.component';
@@ -29,6 +29,8 @@ import { ProjectSettingsEditor } from './hello-world-project/project-settings-ed
 import { useHelloWorldProjectSettings } from './hello-world-project/use-hello-world-project-settings.hook';
 
 const NAME = 'Hello World React WebView';
+
+const defaultExcludePdpFactoryIds: string[] = [];
 
 // Test fetching
 papi
@@ -153,10 +155,21 @@ globalThis.webViewComponent = function HelloWorld({
   const currentRender = useRef(-1);
   currentRender.current += 1;
 
-  const [excludePdpFactoryIdsInHome] = useSetting(
+  const [excludePdpFactoryIdsPossiblyError] = useSetting(
     'platformGetResources.excludePdpFactoryIdsInHome',
-    useMemo(() => [], []),
+    defaultExcludePdpFactoryIds,
   );
+
+  const excludePdpFactoryIds = useMemo(() => {
+    if (isPlatformError(excludePdpFactoryIdsPossiblyError)) {
+      logger.warn(
+        'Failed to load setting: platformGetResources.excludePdpFactoryIdsInHome',
+        excludePdpFactoryIdsPossiblyError,
+      );
+      return defaultExcludePdpFactoryIds;
+    }
+    return excludePdpFactoryIdsPossiblyError;
+  }, [excludePdpFactoryIdsPossiblyError]);
 
   const showProjectDialog = useDialogCallback(
     'platform.selectProject',
@@ -171,7 +184,7 @@ globalThis.webViewComponent = function HelloWorld({
       currentRender: currentRender.current,
       optionsSource: 'hook',
       includeProjectInterfaces: ['platformScripture.USFM_Verse'],
-      excludePdpFactoryIds: excludePdpFactoryIdsInHome,
+      excludePdpFactoryIds,
     },
     useCallback(
       (selectedProject, _dialogType, { currentRender: dialogRender, optionsSource }) => {
@@ -228,14 +241,25 @@ globalThis.webViewComponent = function HelloWorld({
     ),
   );
 
-  const [name, setNameInternal] = useSetting('helloWorld.personName', 'Kathy');
+  const [namePossiblyError, setNameInternal] = useSetting('helloWorld.personName', 'Kathy');
 
-  // Name used for display and editing in the input field while debouncing the actual setting change
-  const [nameTemp, setNameTemp] = useState(name);
+  const name = useMemo(() => {
+    if (isPlatformError(namePossiblyError)) {
+      return '';
+    }
+    return namePossiblyError;
+  }, [namePossiblyError]);
+
+  const nameIsError = isPlatformError(name);
+
+  // Name used for display and editing in the input field while debouncing the actual setting change.
+  // Code should never try to use nameTemp for anything if nameIsError, but I'm setting the value to
+  // "ERR" just so it'll be more obvious if we do use it.
+  const [nameTemp, setNameTemp] = useState(!nameIsError ? name : 'ERR');
 
   useEffect(() => {
-    setNameTemp(name);
-  }, [name]);
+    if (!nameIsError) setNameTemp(name);
+  }, [name, nameIsError]);
 
   const debouncedSetName = useMemo(
     () =>
@@ -255,14 +279,24 @@ globalThis.webViewComponent = function HelloWorld({
 
   const peopleDataProvider = useDataProvider('helloSomeone.people');
 
-  const [personGreeting] = useData('helloSomeone.people').Greeting(name, localizedGreetingLoading);
+  const [personGreeting] = useData<'helloSomeone.people'>(
+    nameIsError ? undefined : 'helloSomeone.people',
+  ).Greeting(name, localizedGreetingLoading);
+  const [personAge] = useData<'helloSomeone.people'>(
+    nameIsError ? undefined : 'helloSomeone.people',
+  ).Age(name, -1);
 
-  const [personAge] = useData('helloSomeone.people').Age(name, -1);
-
-  const [currentProjectVerse] = useProjectData(
+  const [currentProjectVersePossiblyError] = useProjectData(
     'platformScripture.USFM_Verse',
     projectId ?? undefined,
   ).VerseUSFM(scrRef, localizedScriptureLoadingVerse);
+
+  const currentProjectVerse = useMemo(() => {
+    if (isPlatformError(currentProjectVersePossiblyError)) {
+      return getErrorMessage(currentProjectVersePossiblyError);
+    }
+    return currentProjectVersePossiblyError;
+  }, [currentProjectVersePossiblyError]);
 
   const helloWorldProjectSettings = useHelloWorldProjectSettings(projectId);
   const { headerStyle } = helloWorldProjectSettings;
@@ -365,12 +399,16 @@ globalThis.webViewComponent = function HelloWorld({
       </div>
       <div>{isPlatformError(latestVerseText) ? latestVerseText.message : latestVerseText}</div>
       <Clock />
-      <div>
-        <input value={nameTemp} onChange={(e) => setName(e.target.value)} />
-        <Button onClick={() => peopleDataProvider?.deletePerson(name)}>
-          {localizedDelete} {name}
-        </Button>
-      </div>
+      {nameIsError ? (
+        <div>{name.message}</div>
+      ) : (
+        <div>
+          <input value={nameTemp} onChange={(e) => setName(e.target.value)} />
+          <Button onClick={() => peopleDataProvider?.deletePerson(name)}>
+            {localizedDelete} {name}
+          </Button>
+        </div>
+      )}
       <div>{isPlatformError(personGreeting) ? personGreeting.message : personGreeting}</div>
       <div>{isPlatformError(personAge) ? personAge.message : personAge}</div>
       <br />

--- a/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
+++ b/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
@@ -6,7 +6,7 @@ declare module 'legacy-comment-manager' {
     // @ts-ignore: TS2307 - Cannot find module '@papi/core' or its corresponding type declarations
   } from '@papi/core';
   import type { IProjectDataProvider } from 'papi-shared-types';
-  import { UnsubscriberAsync } from 'platform-bible-utils';
+  import { PlatformError, UnsubscriberAsync } from 'platform-bible-utils';
 
   export type LegacyCommentSelector = {
     bookId: string;
@@ -62,13 +62,16 @@ declare module 'legacy-comment-manager' {
        * Subscribe to run a callback function when the comments data changes
        *
        * @param selector Tells the provider what changes to listen for (which comments)
-       * @param callback Function to run with the updated comments for this selector
+       * @param callback Function to run with the updated comments for this selector. If there is an
+       *   error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscribeComments(
         selector: LegacyCommentSelector,
-        callback: (comments: LegacyComment[]) => void,
+        callback: (comments: LegacyComment[] | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };

--- a/extensions/src/platform-scripture/src/inventory.web-view.tsx
+++ b/extensions/src/platform-scripture/src/inventory.web-view.tsx
@@ -4,11 +4,15 @@ import { Scope, usePromise, INVENTORY_STRING_KEYS } from 'platform-bible-react';
 import { useCallback, useMemo, useState } from 'react';
 import type { ProjectSettingTypes } from 'papi-shared-types';
 import { SerializedVerseRef } from '@sillsdev/scripture';
-import papi from '@papi/frontend';
+import papi, { logger } from '@papi/frontend';
+import { getErrorMessage, isPlatformError } from 'platform-bible-utils';
 import { CharacterInventory } from './checks/inventories/character-inventory.component';
 import { RepeatedWordsInventory } from './checks/inventories/repeated-words-inventory.component';
 import { MarkerInventory } from './checks/inventories/marker-inventory.component';
 import { PunctuationInventory } from './checks/inventories/punctuation-inventory.component';
+
+const VALID_ITEMS_DEFAULT = '';
+const INVALID_ITEMS_DEFAULT = '';
 
 /**
  * Get scripture text for the provided scope and reference for the specified projectId
@@ -90,8 +94,33 @@ global.webViewComponent = function InventoryWebView({
     useMemo(() => '', []),
   );
 
-  const [validItems, setValidItems] = useProjectSetting(projectId, validItemsSetting, '');
-  const [invalidItems, setInvalidItems] = useProjectSetting(projectId, invalidItemsSetting, '');
+  const [validItemsPossiblyError, setValidItems] = useProjectSetting(
+    projectId,
+    validItemsSetting,
+    VALID_ITEMS_DEFAULT,
+  );
+
+  const validItems = useMemo(() => {
+    if (isPlatformError(validItemsPossiblyError)) {
+      logger.warn(`Error getting valid items: ${getErrorMessage(validItemsPossiblyError)}`);
+      return VALID_ITEMS_DEFAULT;
+    }
+    return validItemsPossiblyError;
+  }, [validItemsPossiblyError]);
+
+  const [invalidItemsPossiblyError, setInvalidItems] = useProjectSetting(
+    projectId,
+    invalidItemsSetting,
+    INVALID_ITEMS_DEFAULT,
+  );
+
+  const invalidItems = useMemo(() => {
+    if (isPlatformError(invalidItemsPossiblyError)) {
+      logger.warn(`Error getting invalid items: ${getErrorMessage(invalidItemsPossiblyError)}`);
+      return INVALID_ITEMS_DEFAULT;
+    }
+    return invalidItemsPossiblyError;
+  }, [invalidItemsPossiblyError]);
 
   const validItemsArray = useMemo(() => validItems.split(' '), [validItems]);
   const invalidItemsArray = useMemo(() => invalidItems.split(' '), [invalidItems]);

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -9,7 +9,7 @@ declare module 'platform-scripture' {
     // @ts-ignore: TS2307 - Cannot find module '@papi/core' or its corresponding type declarations
   } from '@papi/core';
   import type { IProjectDataProvider } from 'papi-shared-types';
-  import { Dispose, LocalizeKey, UnsubscriberAsync } from 'platform-bible-utils';
+  import { Dispose, LocalizeKey, PlatformError, UnsubscriberAsync } from 'platform-bible-utils';
   import type { Usj } from '@biblionexus-foundation/scripture-utilities';
 
   // #region Project Interface Data Types
@@ -148,13 +148,16 @@ declare module 'platform-scripture' {
      *
      * @param dataScope Contains the name of the extension requesting the data and which data it is
      *   requesting
-     * @param callback Function to run with the updated extension data for this selector
+     * @param callback Function to run with the updated extension data for this selector. If there
+     *   is an error while retrieving the updated data, the function will run with a
+     *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this value
+     *   to check if it is an error.
      * @param options Various options to adjust how the subscriber emits updates
      * @returns Unsubscriber function (run to unsubscribe from listening for updates)
      */
     subscribeExtensionData(
       dataScope: ExtensionDataScope,
-      callback: (extensionData: string | undefined) => void,
+      callback: (extensionData: string | undefined | PlatformError) => void,
       options?: DataProviderSubscriberOptions,
     ): Promise<UnsubscriberAsync>;
   };
@@ -177,13 +180,16 @@ declare module 'platform-scripture' {
        * Subscribe to run a callback function when the "raw" USFM data is changed
        *
        * @param verseRef Tells the provider what changes to listen for
-       * @param callback Function to run with the updated USFM for this selector
+       * @param callback Function to run with the updated USFM for this selector. If there is an
+       *   error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscribeBookUSFM(
         verseRef: SerializedVerseRef,
-        callback: (usfm: string | undefined) => void,
+        callback: (usfm: string | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };
@@ -202,13 +208,16 @@ declare module 'platform-scripture' {
        * Subscribe to run a callback function when the "raw" USFM data is changed
        *
        * @param verseRef Tells the provider what changes to listen for
-       * @param callback Function to run with the updated USFM for this selector
+       * @param callback Function to run with the updated USFM for this selector. If there is an
+       *   error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscribeChapterUSFM(
         verseRef: SerializedVerseRef,
-        callback: (usfm: string | undefined) => void,
+        callback: (usfm: string | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };
@@ -227,13 +236,16 @@ declare module 'platform-scripture' {
        * Subscribe to run a callback function when the "raw" USFM data is changed
        *
        * @param verseRef Tells the provider what changes to listen for
-       * @param callback Function to run with the updated USFM for this selector
+       * @param callback Function to run with the updated USFM for this selector. If there is an
+       *   error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscribeVerseUSFM(
         verseRef: SerializedVerseRef,
-        callback: (usfm: string | undefined) => void,
+        callback: (usfm: string | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };
@@ -252,13 +264,16 @@ declare module 'platform-scripture' {
        * Subscribe to run a callback function when the "raw" USX data is changed
        *
        * @param verseRef Tells the provider what changes to listen for
-       * @param callback Function to run with the updated USX for this selector
+       * @param callback Function to run with the updated USX for this selector. If there is an
+       *   error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscribeBookUSX(
         verseRef: SerializedVerseRef,
-        callback: (usx: string | undefined) => void,
+        callback: (usx: string | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };
@@ -277,13 +292,16 @@ declare module 'platform-scripture' {
        * Subscribe to run a callback function when the USX data is changed
        *
        * @param verseRef Tells the provider what changes to listen for
-       * @param callback Function to run with the updated USX for this selector
+       * @param callback Function to run with the updated USX for this selector. If there is an
+       *   error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscribeChapterUSX(
         verseRef: SerializedVerseRef,
-        callback: (usx: string | undefined) => void,
+        callback: (usx: string | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };
@@ -302,13 +320,16 @@ declare module 'platform-scripture' {
        * Subscribe to run a callback function when the "raw" USX data is changed
        *
        * @param verseRef Tells the provider what changes to listen for
-       * @param callback Function to run with the updated USX for this selector
+       * @param callback Function to run with the updated USX for this selector. If there is an
+       *   error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscribeVerseUSX(
         verseRef: SerializedVerseRef,
-        callback: (usx: string | undefined) => void,
+        callback: (usx: string | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };
@@ -343,13 +364,16 @@ declare module 'platform-scripture' {
        * change over time.
        *
        * @param verseRef Tells the provider what changes to listen for
-       * @param callback Function to run with the updated USJ for this selector
+       * @param callback Function to run with the updated USJ for this selector. If there is an
+       *   error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscribeBookUSJ(
         verseRef: SerializedVerseRef,
-        callback: (usj: Usj | undefined) => void,
+        callback: (usj: Usj | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };
@@ -378,13 +402,16 @@ declare module 'platform-scripture' {
        * WARNING: USJ is in very early stages of proposal, so it will likely change over time.
        *
        * @param verseRef Tells the provider what changes to listen for
-       * @param callback Function to run with the updated USJ for this selector
+       * @param callback Function to run with the updated USJ for this selector. If there is an
+       *   error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscribeChapterUSJ(
         verseRef: SerializedVerseRef,
-        callback: (usj: Usj | undefined) => void,
+        callback: (usj: Usj | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };
@@ -419,13 +446,16 @@ declare module 'platform-scripture' {
        * change over time.
        *
        * @param verseRef Tells the provider what changes to listen for
-       * @param callback Function to run with the updated USJ for this selector
+       * @param callback Function to run with the updated USJ for this selector. If there is an
+       *   error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscribeVerseUSJ(
         verseRef: SerializedVerseRef,
-        callback: (usj: Usj | undefined) => void,
+        callback: (usj: Usj | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };
@@ -454,13 +484,16 @@ declare module 'platform-scripture' {
        * not include notes, figures, and other things that are not considered "verse text"
        *
        * @param verseRef Tells the provider what changes to listen for
-       * @param callback Function to run with the updated USJ for this selector
+       * @param callback Function to run with the updated USJ for this selector. If there is an
+       *   error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscribeVersePlainText(
         verseRef: SerializedVerseRef,
-        callback: (usj: Usj | undefined) => void,
+        callback: (usj: Usj | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };
@@ -482,13 +515,16 @@ declare module 'platform-scripture' {
        * Subscribe to run a callback function when marker info changed
        *
        * @param bookNum Tells the provider what changes to listen for
-       * @param callback Function to run with the updated marker info for this selector
+       * @param callback Function to run with the updated marker info for this selector. If there is
+       *   an error while retrieving the updated data, the function will run with a
+       *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+       *   value to check if it is an error.
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function (run to unsubscribe from listening for updates)
        */
       subscriberMarkerNames(
         bookNum: number,
-        callback: (markerNames: string[] | undefined) => void,
+        callback: (markerNames: string[] | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
     };

--- a/extensions/src/project-notes-data-provider/index.d.ts
+++ b/extensions/src/project-notes-data-provider/index.d.ts
@@ -5,7 +5,7 @@ import type {
   IDataProvider,
   // @ts-ignore: TS2307 - Cannot find module '@papi/core' or its corresponding type declarations
 } from '@papi/core';
-import { PlatformEvent, Unsubscriber } from 'platform-bible-utils';
+import { PlatformError, PlatformEvent, Unsubscriber } from 'platform-bible-utils';
 
 declare module 'project-notes-data-provider' {
   export type ProjectNotesProviderDataTypes = {
@@ -234,13 +234,16 @@ declare module 'project-notes-data-provider' {
      * Subscribe to run a callback function when notes are added
      *
      * @param notesSelector Tells the provider what notes to listen for
-     * @param callback Function to run with the updated notes for this selector
+     * @param callback Function to run with the updated notes for this selector. If there is an
+     *   error while retrieving the updated data, the function will run with a {@link PlatformError}
+     *   instead of the data. You can call {@link isPlatformError} on this value to check if it is an
+     *   error.
      * @param options Various options to adjust how the subscriber emits updates
      * @returns Unsubscriber function (run to unsubscribe from listening for updates)
      */
     subscribeNotes(
       notesSelector: ProjectNotesSelector,
-      callback: (notes: ProjectNote[]) => void,
+      callback: (notes: ProjectNote[] | PlatformError) => void,
       options?: DataProviderSubscriberOptions,
     ): Unsubscriber;
     /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1790,7 +1790,7 @@ declare module 'shared/models/network-object.model' {
   };
 }
 declare module 'shared/models/data-provider.model' {
-  import { UnsubscriberAsync, PlatformEventHandler } from 'platform-bible-utils';
+  import { UnsubscriberAsync, PlatformEventHandler, PlatformError } from 'platform-bible-utils';
   import { NetworkableObject } from 'shared/models/network-object.model';
   /** Various options to adjust how the data provider subscriber emits updates */
   export type DataProviderSubscriberOptions = {
@@ -1883,13 +1883,15 @@ declare module 'shared/models/data-provider.model' {
    * functionality off in the `options` parameter.
    *
    * @param selector Tells the provider what data this listener is listening for
-   * @param callback Function to run with the updated data for this selector
+   * @param callback Function to run with the updated data for this selector. If there is an error
+   *   while retrieving the updated data, the function will run with a {@link PlatformError} instead of
+   *   the data. You can call {@link isPlatformError} on this value to check if it is an error.
    * @param options Various options to adjust how the subscriber emits updates
    * @returns Unsubscriber to stop listening for updates
    */
   export type DataProviderSubscriber<TDataType extends DataProviderDataType> = (
     selector: TDataType['selector'],
-    callback: PlatformEventHandler<TDataType['getData']>,
+    callback: PlatformEventHandler<TDataType['getData'] | PlatformError>,
     options?: DataProviderSubscriberOptions,
   ) => Promise<UnsubscriberAsync>;
   /**
@@ -3070,7 +3072,7 @@ declare module 'shared/models/web-view-factory.model' {
   }
 }
 declare module 'papi-shared-types' {
-  import type { UnsubscriberAsync } from 'platform-bible-utils';
+  import type { PlatformError, UnsubscriberAsync } from 'platform-bible-utils';
   import type {
     DataProviderDataType,
     DataProviderDataTypes,
@@ -3390,13 +3392,16 @@ declare module 'papi-shared-types' {
          * turn this functionality off in the `options` parameter.
          *
          * @param key The string id of the project setting for which to listen to changes
-         * @param callback Function to run with the updated project setting value
+         * @param callback Function to run with the updated project setting value. If there is an
+         *   error while retrieving the updated data, the function will run with a
+         *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+         *   value to check if it is an error.
          * @param options Various options to adjust how the subscriber emits updates
          * @returns Unsubscriber to stop listening for updates
          */
         subscribeSetting: <ProjectSettingName extends ProjectSettingNames>(
           key: ProjectSettingName,
-          callback: (value: ProjectSettingTypes[ProjectSettingName]) => void,
+          callback: (value: ProjectSettingTypes[ProjectSettingName] | PlatformError) => void,
           options: DataProviderSubscriberOptions,
         ) => Promise<UnsubscriberAsync>;
       };
@@ -6100,7 +6105,7 @@ declare module 'shared/utils/settings-document-combiner-base' {
 }
 declare module 'shared/services/settings.service-model' {
   import { SettingNames, SettingTypes } from 'papi-shared-types';
-  import { OnDidDispose, UnsubscriberAsync } from 'platform-bible-utils';
+  import { OnDidDispose, PlatformError, UnsubscriberAsync } from 'platform-bible-utils';
   import { IDataProvider } from 'shared/models/data-provider.interface';
   import {
     DataProviderSubscriberOptions,
@@ -6221,13 +6226,16 @@ declare module 'shared/services/settings.service-model' {
      * callback function is executed.
      *
      * @param key The string id of the setting for which the value is being subscribed to
-     * @param callback The function that will be called whenever the specified setting is updated
+     * @param callback The function that will be called whenever the specified setting is updated. If
+     *   there is an error while retrieving the updated data, the function will run with a
+     *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this value
+     *   to check if it is an error.
      * @param options Various options to adjust how the subscriber emits updates
      * @returns Unsubscriber that should be called whenever the subscription should be deleted
      */
     subscribe<SettingName extends SettingNames>(
       key: SettingName,
-      callback: (newSetting: SettingTypes[SettingName]) => void,
+      callback: (newSetting: SettingTypes[SettingName] | PlatformError) => void,
       options?: DataProviderSubscriberOptions,
     ): Promise<UnsubscriberAsync>;
     /**
@@ -6455,7 +6463,7 @@ declare module '@papi/core' {
   export type { DialogTypes } from 'renderer/components/dialogs/dialog-definition.model';
   export type { UseDialogCallbackOptions } from 'renderer/hooks/papi-hooks/use-dialog-callback.hook';
   export type {
-    default as IDataProvider,
+    IDataProvider,
     IDisposableDataProvider,
   } from 'shared/models/data-provider.interface';
   export type {
@@ -6464,7 +6472,7 @@ declare module '@papi/core' {
     DataProviderSubscriberOptions,
   } from 'shared/models/data-provider.model';
   export type { WithNotifyUpdate } from 'shared/models/data-provider-engine.model';
-  export type { default as IDataProviderEngine } from 'shared/models/data-provider-engine.model';
+  export type { IDataProviderEngine } from 'shared/models/data-provider-engine.model';
   export type { DialogOptions } from 'shared/models/dialog-options.model';
   export type { NetworkableObject, NetworkObject } from 'shared/models/network-object.model';
   export type { PlatformNotification } from 'shared/models/notification.service-model';
@@ -6482,7 +6490,7 @@ declare module '@papi/core' {
   export type { IProjectDataProviderEngineFactory } from 'shared/models/project-data-provider-engine-factory.model';
   export type { IBaseProjectDataProviderEngine } from 'shared/models/base-project-data-provider-engine.model';
   export type {
-    default as IProjectDataProviderFactory,
+    IProjectDataProviderFactory,
     ProjectMetadataFilterOptions,
   } from 'shared/models/project-data-provider-factory.interface';
   export type {
@@ -6525,6 +6533,7 @@ declare module 'shared/services/menu-data.service-model' {
     ReferencedItem,
     WebViewMenu,
     Localized,
+    PlatformError,
   } from 'platform-bible-utils';
   import {
     DataProviderDataType,
@@ -6594,13 +6603,16 @@ declare module 'shared/services/menu-data.service-model' {
      * Subscribe to run a callback function when the localized main menu data is changed
      *
      * @param mainMenuType Does not have to be defined
-     * @param callback Function to run with the updated localized menuContent for this selector
+     * @param callback Function to run with the updated localized menuContent for this selector. If
+     *   there is an error while retrieving the updated data, the function will run with a
+     *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this value
+     *   to check if it is an error.
      * @param options Various options to adjust how the subscriber emits updates
      * @returns Unsubscriber function (run to unsubscribe from listening for updates)
      */
     subscribeMainMenu(
       mainMenuType: undefined,
-      callback: (menuContent: Localized<MultiColumnMenu>) => void,
+      callback: (menuContent: Localized<MultiColumnMenu> | PlatformError) => void,
       options?: DataProviderSubscriberOptions,
     ): Promise<UnsubscriberAsync>;
     /**
@@ -6634,13 +6646,16 @@ declare module 'shared/services/menu-data.service-model' {
      * Subscribe to run a callback function when the unlocalized main menu data is changed
      *
      * @param mainMenuType Does not have to be defined
-     * @param callback Function to run with the updated unlocalized menuContent for this selector
+     * @param callback Function to run with the updated unlocalized menuContent for this selector. If
+     *   there is an error while retrieving the updated data, the function will run with a
+     *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this value
+     *   to check if it is an error.
      * @param options Various options to adjust how the subscriber emits updates
      * @returns Unsubscriber function (run to unsubscribe from listening for updates)
      */
     subscribeUnlocalizedMainMenu(
       mainMenuType: undefined,
-      callback: (menuContent: MultiColumnMenu) => void,
+      callback: (menuContent: MultiColumnMenu | PlatformError) => void,
       options?: DataProviderSubscriberOptions,
     ): Promise<UnsubscriberAsync>;
     /**
@@ -6665,13 +6680,16 @@ declare module 'shared/services/menu-data.service-model' {
      * Subscribe to run a callback function when the localized web view menu data is changed
      *
      * @param webViewType The type of webview for which a menu should be subscribed
-     * @param callback Function to run with the updated menuContent for this selector
+     * @param callback Function to run with the updated menuContent for this selector. If there is an
+     *   error while retrieving the updated data, the function will run with a {@link PlatformError}
+     *   instead of the data. You can call {@link isPlatformError} on this value to check if it is an
+     *   error.
      * @param options Various options to adjust how the subscriber emits updates
      * @returns Unsubscriber function (run to unsubscribe from listening for updates)
      */
     subscribeWebViewMenu(
       webViewType: ReferencedItem,
-      callback: (menuContent: Localized<WebViewMenu>) => void,
+      callback: (menuContent: Localized<WebViewMenu> | PlatformError) => void,
       options?: DataProviderSubscriberOptions,
     ): Promise<UnsubscriberAsync>;
   } & OnDidDispose &
@@ -7435,6 +7453,7 @@ declare module 'renderer/hooks/hook-generators/create-use-data-hook.util' {
     DataProviderUpdateInstructions,
   } from 'shared/models/data-provider.model';
   import { IDataProvider } from 'shared/models/data-provider.interface';
+  import { PlatformError } from 'platform-bible-utils';
   import { ExtractDataProviderDataTypes } from 'shared/models/extract-data-provider-data-types.model';
   /**
    * The final function called as part of the `useData` hook that is the actual React hook
@@ -7449,7 +7468,7 @@ declare module 'renderer/hooks/hook-generators/create-use-data-hook.util' {
     defaultValue: ExtractDataProviderDataTypes<TDataProvider>[TDataType]['getData'],
     subscriberOptions?: DataProviderSubscriberOptions,
   ) => [
-    ExtractDataProviderDataTypes<TDataProvider>[TDataType]['getData'],
+    ExtractDataProviderDataTypes<TDataProvider>[TDataType]['getData'] | PlatformError,
     (
       | ((
           newData: ExtractDataProviderDataTypes<TDataProvider>[TDataType]['setData'],
@@ -7542,7 +7561,7 @@ declare module 'renderer/hooks/papi-hooks/use-data.hook' {
    *       defaultValue: DataProviderTypes[DataProviderName][DataType]['getData'],
    *       subscriberOptions?: DataProviderSubscriberOptions,
    *     ) => [
-   *       DataProviderTypes[DataProviderName][DataType]['getData'],
+   *       DataProviderTypes[DataProviderName][DataType]['getData'] | PlatformError,
    *       (
    *         | ((
    *             newData: DataProviderTypes[DataProviderName][DataType]['setData'],
@@ -7674,6 +7693,7 @@ declare module 'renderer/hooks/papi-hooks/use-scroll-group-scr-ref.hook' {
   export default useScrollGroupScrRef;
 }
 declare module 'renderer/hooks/papi-hooks/use-setting.hook' {
+  import { PlatformError } from 'platform-bible-utils';
   import {
     DataProviderSubscriberOptions,
     DataProviderUpdateInstructions,
@@ -7681,10 +7701,10 @@ declare module 'renderer/hooks/papi-hooks/use-setting.hook' {
   import { SettingDataTypes } from 'shared/services/settings.service-model';
   import { SettingTypes } from 'papi-shared-types';
   /**
-   * Gets, sets and resets a setting on the papi. Also notifies subscribers when the setting changes
+   * Gets, sets and resets a setting on the PAPI. Also notifies subscribers when the setting changes
    * and gets updated when the setting is changed by others.
    *
-   * @param key The string id that is used to identify the setting that will be stored on the papi
+   * @param key The string id that is used to identify the setting that will be stored on the PAPI
    *
    *   WARNING: MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not be
    *   updated every render
@@ -7697,8 +7717,8 @@ declare module 'renderer/hooks/papi-hooks/use-setting.hook' {
    *   until `dataProviderSource` or `selector` changes.
    * @returns `[setting, setSetting, resetSetting]`
    *
-   *   - `setting`: The current state of the setting, either `defaultState` or the stored state on the
-   *       papi, if any
+   *   - `setting`: The current state of the setting, either `defaultState`, the stored value, or a
+   *       `PlatformError` if loading the value fails. Use `isPlatformError()` to check.
    *   - `setSetting`: Function that updates the setting to a new value
    *   - `resetSetting`: Function that removes the setting and resets the value to `defaultState`
    *
@@ -7710,7 +7730,7 @@ declare module 'renderer/hooks/papi-hooks/use-setting.hook' {
     defaultState: SettingTypes[SettingName],
     subscriberOptions?: DataProviderSubscriberOptions,
   ) => [
-    setting: SettingTypes[SettingName],
+    setting: SettingTypes[SettingName] | PlatformError,
     setSetting: (
       newData: SettingTypes[SettingName],
     ) => Promise<DataProviderUpdateInstructions<SettingDataTypes>>,
@@ -7748,6 +7768,7 @@ declare module 'renderer/hooks/papi-hooks/use-project-data-provider.hook' {
   export default useProjectDataProvider;
 }
 declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
+  import { PlatformError } from 'platform-bible-utils';
   import {
     DataProviderSubscriberOptions,
     DataProviderUpdateInstructions,
@@ -7778,7 +7799,7 @@ declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
         subscriberOptions?: DataProviderSubscriberOptions,
       ) => [
         // @ts-ignore TypeScript pretends it can't find `getData`, but it works just fine
-        ProjectInterfaceDataTypes[ProjectInterface][TDataType]['getData'],
+        ProjectInterfaceDataTypes[ProjectInterface][TDataType]['getData'] | PlatformError,
         (
           | ((
               // @ts-ignore TypeScript pretends it can't find `setData`, but it works just fine
@@ -7802,7 +7823,7 @@ declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
    *       defaultValue: ProjectInterfaceDataTypes[ProjectInterface][DataType]['getData'],
    *       subscriberOptions?: DataProviderSubscriberOptions,
    *     ) => [
-   *       ProjectInterfaceDataTypes[ProjectInterface][DataType]['getData'],
+   *       ProjectInterfaceDataTypes[ProjectInterface][DataType]['getData'] | PlatformError,
    *       (
    *         | ((
    *             newData: ProjectInterfaceDataTypes[ProjectInterface][DataType]['setData'],
@@ -7861,7 +7882,9 @@ declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
    * _＠returns_ `[data, setData, isLoading]`
    *
    * - `data`: the current value for the data from the Project Data Provider with the specified data
-   *   type and selector, either the `defaultValue` or the resolved data
+   *   type and selector, either the `defaultValue`, the resolved data, or a {@link PlatformError} if
+   *   the project data provider throws an error. You can call {@link isPlatformError} on this value to
+   *   check if it is an error.
    * - `setData`: asynchronous function to request that the Project Data Provider update the data at
    *   this data type and selector. Returns `true` if successful. Note that this function does not
    *   update the data. The Project Data Provider sends out an update to this subscription if it
@@ -7873,6 +7896,7 @@ declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
   export default useProjectData;
 }
 declare module 'renderer/hooks/papi-hooks/use-project-setting.hook' {
+  import { PlatformError } from 'platform-bible-utils';
   import { DataProviderSubscriberOptions } from 'shared/models/data-provider.model';
   import { IBaseProjectDataProvider, ProjectSettingTypes } from 'papi-shared-types';
   /**
@@ -7901,7 +7925,9 @@ declare module 'renderer/hooks/papi-hooks/use-project-setting.hook' {
    * @returns `[setting, setSetting, resetSetting]`
    *
    *   - `setting`: the current value for the project setting from the Project Data Provider with the
-   *       specified key, either the `defaultValue` or the resolved setting value
+   *       specified key, either the `defaultValue`, the resolved setting value, or a
+   *       {@link PlatformError} if the Project Data Provider throws an error. You can call
+   *       {@link isPlatformError} on this value to check if it is an error.
    *   - `setSetting`: asynchronous function to request that the Project Data Provider update the project
    *       setting with the specified key. Returns `true` if successful. Note that this function does
    *       not update the data. The Project Data Provider sends out an update to this subscription if
@@ -7919,7 +7945,7 @@ declare module 'renderer/hooks/papi-hooks/use-project-setting.hook' {
     defaultValue: ProjectSettingTypes[ProjectSettingName],
     subscriberOptions?: DataProviderSubscriberOptions,
   ) => [
-    setting: ProjectSettingTypes[ProjectSettingName],
+    setting: ProjectSettingTypes[ProjectSettingName] | PlatformError,
     setSetting: ((newSetting: ProjectSettingTypes[ProjectSettingName]) => void) | undefined,
     resetSetting: (() => void) | undefined,
     isLoading: boolean,

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -1,5 +1,5 @@
 declare module 'papi-shared-types' {
-  import type { UnsubscriberAsync } from 'platform-bible-utils';
+  import type { PlatformError, UnsubscriberAsync } from 'platform-bible-utils';
   import type {
     DataProviderDataType,
     DataProviderDataTypes,
@@ -353,13 +353,16 @@ declare module 'papi-shared-types' {
          * turn this functionality off in the `options` parameter.
          *
          * @param key The string id of the project setting for which to listen to changes
-         * @param callback Function to run with the updated project setting value
+         * @param callback Function to run with the updated project setting value. If there is an
+         *   error while retrieving the updated data, the function will run with a
+         *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this
+         *   value to check if it is an error.
          * @param options Various options to adjust how the subscriber emits updates
          * @returns Unsubscriber to stop listening for updates
          */
         subscribeSetting: <ProjectSettingName extends ProjectSettingNames>(
           key: ProjectSettingName,
-          callback: (value: ProjectSettingTypes[ProjectSettingName]) => void,
+          callback: (value: ProjectSettingTypes[ProjectSettingName] | PlatformError) => void,
           options: DataProviderSubscriberOptions,
         ) => Promise<UnsubscriberAsync>;
       };

--- a/src/main/platform-macos-menubar.util.ts
+++ b/src/main/platform-macos-menubar.util.ts
@@ -6,6 +6,9 @@ import {
   Localized,
   GroupsInMultiColumnMenu,
   formatReplacementString,
+  PlatformError,
+  isPlatformError,
+  getErrorMessage,
 } from 'platform-bible-utils';
 import {
   macosMenubarObject,
@@ -32,9 +35,11 @@ import { handleMenuCommand } from '@shared/data/platform-bible-menu.commands';
 export async function subscribeCurrentMacosMenubar() {
   await menuDataService.subscribeUnlocalizedMainMenu(
     undefined,
-    async (menuContent: MultiColumnMenu) => {
+    async (menuContent: MultiColumnMenu | PlatformError) => {
       let currentMacosMenubarTemplate;
       try {
+        if (isPlatformError(menuContent))
+          throw new Error(`PlatformError: ${getErrorMessage(menuContent)}`);
         currentMacosMenubarTemplate = await translatePlatformMenuItemsAndCombine(menuContent);
       } catch (error) {
         logger.error(

--- a/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
@@ -20,8 +20,14 @@ import {
   TooltipTrigger,
   UiLanguageSelector,
 } from 'platform-bible-react';
-import { debounce, getErrorMessage, isPlatformError, LocalizeKey } from 'platform-bible-utils';
-import { ChangeEvent, useCallback, useMemo, useState } from 'react';
+import {
+  debounce,
+  getErrorMessage,
+  isPlatformError,
+  LocalizeKey,
+  PlatformError,
+} from 'platform-bible-utils';
+import { ChangeEvent, useCallback, useEffect, useMemo, useState } from 'react';
 import './settings.component.scss';
 
 /** Props shared between the user and project setting components */
@@ -55,7 +61,7 @@ export type ProjectSettingProps = BaseSettingProps<ProjectSettingNames, ProjectS
 
 /** Values from the useProjectSetting hook to manage the setting */
 type ProjectSettingsControls = {
-  setting: ProjectSettingValues;
+  setting: ProjectSettingValues | PlatformError;
   // Necessary for flexibility in handleChangeSetting, ProjectSettingValues and
   // UserSettingValues are not the same so it couldn't assign
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -71,7 +77,7 @@ export type OtherSettingProps = BaseSettingProps<SettingNames, OtherSettingValue
 
 /** Values from the useSetting hook to manage the setting */
 type OtherSettingsControls = {
-  setting: OtherSettingValues;
+  setting: OtherSettingValues | PlatformError;
   // Necessary for flexibility in handleChangeSetting, ProjectSettingValues and
   // UserSettingValues are not the same so it couldn't assign
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -159,6 +165,10 @@ export function Setting({
     defaultLanguages,
   );
   const [errorMessage, setErrorMessage] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    setErrorMessage(isPlatformError(setting) ? setting.message : undefined);
+  }, [setting]);
 
   const [localizedStrings] = useLocalizedStrings(useMemo(() => LOCALIZE_SETTING_KEYS, []));
 

--- a/src/renderer/components/web-view.component.tsx
+++ b/src/renderer/components/web-view.component.tsx
@@ -21,6 +21,8 @@ import {
   isLocalizeKey,
   serialize,
   getLocalizeKeysForScrollGroupIds,
+  isPlatformError,
+  getErrorMessage,
 } from 'platform-bible-utils';
 import { BookChapterControl, ScrollGroupSelector, useEvent } from 'platform-bible-react';
 import './web-view.component.css';
@@ -38,6 +40,8 @@ import {
 import { Canon } from '@sillsdev/scripture';
 
 export const TAB_TYPE_WEBVIEW = 'webView';
+
+const BOOKS_PRESENT_DEFAULT = '';
 
 const scrollGroupLocalizedStringKeys = getLocalizeKeysForScrollGroupIds(availableScrollGroupIds);
 
@@ -215,7 +219,19 @@ export function WebView({
 
   const [scrollGroupLocalizedStrings] = useLocalizedStrings(scrollGroupLocalizedStringKeys);
 
-  const [booksPresent] = useProjectSetting(projectId, 'platformScripture.booksPresent', '');
+  const [booksPresentPossiblyError] = useProjectSetting(
+    projectId,
+    'platformScripture.booksPresent',
+    BOOKS_PRESENT_DEFAULT,
+  );
+
+  const booksPresent = useMemo(() => {
+    if (isPlatformError(booksPresentPossiblyError)) {
+      logger.warn(`Error getting books present: ${getErrorMessage(booksPresentPossiblyError)}`);
+      return BOOKS_PRESENT_DEFAULT;
+    }
+    return booksPresentPossiblyError;
+  }, [booksPresentPossiblyError]);
 
   const fetchActiveBooks = () => {
     return Array.from(booksPresent).reduce((ids: string[], char, index) => {

--- a/src/renderer/hooks/hook-generators/create-use-data-hook.util.ts
+++ b/src/renderer/hooks/hook-generators/create-use-data-hook.util.ts
@@ -34,7 +34,7 @@ type UseDataFunctionWithProviderType<
   defaultValue: ExtractDataProviderDataTypes<TDataProvider>[TDataType]['getData'],
   subscriberOptions?: DataProviderSubscriberOptions,
 ) => [
-  ExtractDataProviderDataTypes<TDataProvider>[TDataType]['getData'],
+  ExtractDataProviderDataTypes<TDataProvider>[TDataType]['getData'] | PlatformError,
   (
     | ((
         newData: ExtractDataProviderDataTypes<TDataProvider>[TDataType]['setData'],
@@ -139,7 +139,9 @@ export function createUseDataHook<TUseDataProviderParams extends unknown[]>(
       subscriberOptionsRef.current = subscriberOptions;
 
       // The data from the data provider at this selector
-      const [data, setDataInternal] = useState<TDataTypes[TDataType]['getData']>(defaultValue);
+      const [data, setDataInternal] = useState<TDataTypes[TDataType]['getData'] | PlatformError>(
+        defaultValue,
+      );
 
       // Get the data provider for this data provider name
       const dataProvider = useDataProviderHook(...args);
@@ -149,11 +151,15 @@ export function createUseDataHook<TUseDataProviderParams extends unknown[]>(
 
       // Wrap subscribe so we can call it as a normal PapiEvent in useEvent
       const wrappedSubscribeEvent:
-        | PlatformEventAsync<TDataTypes[TDataType]['getData']>
+        | PlatformEventAsync<TDataTypes[TDataType]['getData'] | PlatformError>
         | undefined = useMemo(
         () =>
           dataProvider
-            ? async (eventCallback: PlatformEventHandler<TDataTypes[TDataType]['getData']>) => {
+            ? async (
+                eventCallback: PlatformEventHandler<
+                  TDataTypes[TDataType]['getData'] | PlatformError
+                >,
+              ) => {
                 const unsub =
                   // We need any here because for some reason IDataProvider loses its ability to
                   // index subscribe. Assert to specified generic type.
@@ -165,7 +171,7 @@ export function createUseDataHook<TUseDataProviderParams extends unknown[]>(
                   )(
                     /* eslint-enable */
                     selector,
-                    (subscriptionData: TDataTypes[TDataType]['getData']) => {
+                    (subscriptionData: TDataTypes[TDataType]['getData'] | PlatformError) => {
                       eventCallback(subscriptionData);
                       // When we receive updated data, mark that we are not loading
                       setIsLoading(false);

--- a/src/renderer/hooks/papi-hooks/use-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-data.hook.ts
@@ -25,7 +25,6 @@ type UseDataHook = {
       defaultValue: DataProviderTypes[DataProviderName][TDataType]['getData'],
       subscriberOptions?: DataProviderSubscriberOptions,
     ) => [
-      // Adding PlatformError to the return type since the data provider could throw an error
       // @ts-ignore TypeScript pretends it can't find `getData`, but it works just fine
       DataProviderTypes[DataProviderName][TDataType]['getData'] | PlatformError,
       (
@@ -52,7 +51,7 @@ type UseDataHook = {
  *       defaultValue: DataProviderTypes[DataProviderName][DataType]['getData'],
  *       subscriberOptions?: DataProviderSubscriberOptions,
  *     ) => [
- *       DataProviderTypes[DataProviderName][DataType]['getData'],
+ *       DataProviderTypes[DataProviderName][DataType]['getData'] | PlatformError,
  *       (
  *         | ((
  *             newData: DataProviderTypes[DataProviderName][DataType]['setData'],

--- a/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-data.hook.ts
@@ -1,3 +1,4 @@
+import { PlatformError } from 'platform-bible-utils';
 import { createUseDataHook } from '@renderer/hooks/hook-generators/create-use-data-hook.util';
 import { useProjectDataProvider } from '@renderer/hooks/papi-hooks/use-project-data-provider.hook';
 import { IDataProvider } from '@shared/models/data-provider.interface';
@@ -29,7 +30,7 @@ type UseProjectDataHook = {
       subscriberOptions?: DataProviderSubscriberOptions,
     ) => [
       // @ts-ignore TypeScript pretends it can't find `getData`, but it works just fine
-      ProjectInterfaceDataTypes[ProjectInterface][TDataType]['getData'],
+      ProjectInterfaceDataTypes[ProjectInterface][TDataType]['getData'] | PlatformError,
       (
         | ((
             // @ts-ignore TypeScript pretends it can't find `setData`, but it works just fine
@@ -55,7 +56,7 @@ type UseProjectDataHook = {
  *       defaultValue: ProjectInterfaceDataTypes[ProjectInterface][DataType]['getData'],
  *       subscriberOptions?: DataProviderSubscriberOptions,
  *     ) => [
- *       ProjectInterfaceDataTypes[ProjectInterface][DataType]['getData'],
+ *       ProjectInterfaceDataTypes[ProjectInterface][DataType]['getData'] | PlatformError,
  *       (
  *         | ((
  *             newData: ProjectInterfaceDataTypes[ProjectInterface][DataType]['setData'],
@@ -114,7 +115,9 @@ type UseProjectDataHook = {
  * _＠returns_ `[data, setData, isLoading]`
  *
  * - `data`: the current value for the data from the Project Data Provider with the specified data
- *   type and selector, either the `defaultValue` or the resolved data
+ *   type and selector, either the `defaultValue`, the resolved data, or a {@link PlatformError} if
+ *   the project data provider throws an error. You can call {@link isPlatformError} on this value to
+ *   check if it is an error.
  * - `setData`: asynchronous function to request that the Project Data Provider update the data at
  *   this data type and selector. Returns `true` if successful. Note that this function does not
  *   update the data. The Project Data Provider sends out an update to this subscription if it

--- a/src/renderer/hooks/papi-hooks/use-project-setting.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-setting.hook.ts
@@ -1,3 +1,4 @@
+import { PlatformError } from 'platform-bible-utils';
 import { useProjectDataProvider } from '@renderer/hooks/papi-hooks/use-project-data-provider.hook';
 import { useProjectData } from '@renderer/hooks/papi-hooks/use-project-data.hook';
 import {
@@ -41,7 +42,9 @@ import { useMemo } from 'react';
  * @returns `[setting, setSetting, resetSetting]`
  *
  *   - `setting`: the current value for the project setting from the Project Data Provider with the
- *       specified key, either the `defaultValue` or the resolved setting value
+ *       specified key, either the `defaultValue`, the resolved setting value, or a
+ *       {@link PlatformError} if the Project Data Provider throws an error. You can call
+ *       {@link isPlatformError} on this value to check if it is an error.
  *   - `setSetting`: asynchronous function to request that the Project Data Provider update the project
  *       setting with the specified key. Returns `true` if successful. Note that this function does
  *       not update the data. The Project Data Provider sends out an update to this subscription if
@@ -61,7 +64,7 @@ export const useProjectSetting = <ProjectSettingName extends ProjectSettingNames
   defaultValue: ProjectSettingTypes[ProjectSettingName],
   subscriberOptions?: DataProviderSubscriberOptions,
 ): [
-  setting: ProjectSettingTypes[ProjectSettingName],
+  setting: ProjectSettingTypes[ProjectSettingName] | PlatformError,
   setSetting: ((newSetting: ProjectSettingTypes[ProjectSettingName]) => void) | undefined,
   resetSetting: (() => void) | undefined,
   isLoading: boolean,
@@ -85,7 +88,7 @@ export const useProjectSetting = <ProjectSettingName extends ProjectSettingNames
         defaultValue: ProjectSettingTypes[ProjectSettingName],
         subscriberOptions?: DataProviderSubscriberOptions,
       ) => [
-        setting: ProjectSettingTypes[ProjectSettingName],
+        setting: ProjectSettingTypes[ProjectSettingName] | PlatformError,
         setSetting:
           | ((
               newData: ProjectSettingTypes[ProjectSettingName],

--- a/src/renderer/hooks/papi-hooks/use-setting.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-setting.hook.ts
@@ -1,3 +1,4 @@
+import { PlatformError } from 'platform-bible-utils';
 import { useData } from '@renderer/hooks/papi-hooks/use-data.hook';
 import {
   DataProviderSubscriberOptions,
@@ -9,10 +10,10 @@ import { SettingNames, SettingTypes } from 'papi-shared-types';
 import { useCallback } from 'react';
 
 /**
- * Gets, sets and resets a setting on the papi. Also notifies subscribers when the setting changes
+ * Gets, sets and resets a setting on the PAPI. Also notifies subscribers when the setting changes
  * and gets updated when the setting is changed by others.
  *
- * @param key The string id that is used to identify the setting that will be stored on the papi
+ * @param key The string id that is used to identify the setting that will be stored on the PAPI
  *
  *   WARNING: MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not be
  *   updated every render
@@ -25,8 +26,8 @@ import { useCallback } from 'react';
  *   until `dataProviderSource` or `selector` changes.
  * @returns `[setting, setSetting, resetSetting]`
  *
- *   - `setting`: The current state of the setting, either `defaultState` or the stored state on the
- *       papi, if any
+ *   - `setting`: The current state of the setting, either `defaultState`, the stored value, or a
+ *       `PlatformError` if loading the value fails. Use `isPlatformError()` to check.
  *   - `setSetting`: Function that updates the setting to a new value
  *   - `resetSetting`: Function that removes the setting and resets the value to `defaultState`
  *
@@ -38,7 +39,7 @@ export const useSetting = <SettingName extends SettingNames>(
   defaultState: SettingTypes[SettingName],
   subscriberOptions?: DataProviderSubscriberOptions,
 ): [
-  setting: SettingTypes[SettingName],
+  setting: SettingTypes[SettingName] | PlatformError,
   setSetting: (
     newData: SettingTypes[SettingName],
   ) => Promise<DataProviderUpdateInstructions<SettingDataTypes>>,
@@ -56,7 +57,7 @@ export const useSetting = <SettingName extends SettingNames>(
         defaultValue: SettingTypes[SettingName],
         subscriberOptions?: DataProviderSubscriberOptions,
       ) => [
-        setting: SettingTypes[SettingName],
+        setting: SettingTypes[SettingName] | PlatformError,
         setSetting: (
           newData: SettingTypes[SettingName],
         ) => Promise<DataProviderUpdateInstructions<SettingDataTypes>>,

--- a/src/renderer/services/scroll-group.service-host.ts
+++ b/src/renderer/services/scroll-group.service-host.ts
@@ -13,6 +13,7 @@ import {
   compareScrRefs,
   deepClone,
   deserialize,
+  isPlatformError,
   ScrollGroupId,
   serialize,
 } from 'platform-bible-utils';
@@ -142,6 +143,12 @@ export async function startScrollGroupService(): Promise<void> {
 
   // Keep scroll group 0 in sync with the verse ref setting for backwards compatibility
   await settingsService.subscribe('platform.verseRef', (newScrRef) => {
+    if (isPlatformError(newScrRef)) {
+      logger.warn(
+        `Scroll group service failed to get platform.verseRef setting to keep in sync! ${newScrRef}`,
+      );
+      return;
+    }
     setScrRefSync(0, newScrRef, false);
   });
 }

--- a/src/shared/models/data-provider.model.ts
+++ b/src/shared/models/data-provider.model.ts
@@ -4,6 +4,7 @@ import {
   PlatformEventHandler,
   substring,
   startsWith,
+  PlatformError,
 } from 'platform-bible-utils';
 import { NetworkableObject } from '@shared/models/network-object.model';
 
@@ -102,13 +103,15 @@ export type DataProviderGetter<TDataType extends DataProviderDataType> = (
  * functionality off in the `options` parameter.
  *
  * @param selector Tells the provider what data this listener is listening for
- * @param callback Function to run with the updated data for this selector
+ * @param callback Function to run with the updated data for this selector. If there is an error
+ *   while retrieving the updated data, the function will run with a {@link PlatformError} instead of
+ *   the data. You can call {@link isPlatformError} on this value to check if it is an error.
  * @param options Various options to adjust how the subscriber emits updates
  * @returns Unsubscriber to stop listening for updates
  */
 export type DataProviderSubscriber<TDataType extends DataProviderDataType> = (
   selector: TDataType['selector'],
-  callback: PlatformEventHandler<TDataType['getData']>,
+  callback: PlatformEventHandler<TDataType['getData'] | PlatformError>,
   options?: DataProviderSubscriberOptions,
 ) => Promise<UnsubscriberAsync>;
 

--- a/src/shared/services/menu-data.service-model.ts
+++ b/src/shared/services/menu-data.service-model.ts
@@ -5,6 +5,7 @@ import {
   ReferencedItem,
   WebViewMenu,
   Localized,
+  PlatformError,
 } from 'platform-bible-utils';
 import {
   DataProviderDataType,
@@ -72,13 +73,16 @@ export type IMenuDataService = {
    * Subscribe to run a callback function when the localized main menu data is changed
    *
    * @param mainMenuType Does not have to be defined
-   * @param callback Function to run with the updated localized menuContent for this selector
+   * @param callback Function to run with the updated localized menuContent for this selector. If
+   *   there is an error while retrieving the updated data, the function will run with a
+   *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this value
+   *   to check if it is an error.
    * @param options Various options to adjust how the subscriber emits updates
    * @returns Unsubscriber function (run to unsubscribe from listening for updates)
    */
   subscribeMainMenu(
     mainMenuType: undefined,
-    callback: (menuContent: Localized<MultiColumnMenu>) => void,
+    callback: (menuContent: Localized<MultiColumnMenu> | PlatformError) => void,
     options?: DataProviderSubscriberOptions,
   ): Promise<UnsubscriberAsync>;
   /**
@@ -107,13 +111,16 @@ export type IMenuDataService = {
    * Subscribe to run a callback function when the unlocalized main menu data is changed
    *
    * @param mainMenuType Does not have to be defined
-   * @param callback Function to run with the updated unlocalized menuContent for this selector
+   * @param callback Function to run with the updated unlocalized menuContent for this selector. If
+   *   there is an error while retrieving the updated data, the function will run with a
+   *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this value
+   *   to check if it is an error.
    * @param options Various options to adjust how the subscriber emits updates
    * @returns Unsubscriber function (run to unsubscribe from listening for updates)
    */
   subscribeUnlocalizedMainMenu(
     mainMenuType: undefined,
-    callback: (menuContent: MultiColumnMenu) => void,
+    callback: (menuContent: MultiColumnMenu | PlatformError) => void,
     options?: DataProviderSubscriberOptions,
   ): Promise<UnsubscriberAsync>;
   /**
@@ -138,13 +145,16 @@ export type IMenuDataService = {
    * Subscribe to run a callback function when the localized web view menu data is changed
    *
    * @param webViewType The type of webview for which a menu should be subscribed
-   * @param callback Function to run with the updated menuContent for this selector
+   * @param callback Function to run with the updated menuContent for this selector. If there is an
+   *   error while retrieving the updated data, the function will run with a {@link PlatformError}
+   *   instead of the data. You can call {@link isPlatformError} on this value to check if it is an
+   *   error.
    * @param options Various options to adjust how the subscriber emits updates
    * @returns Unsubscriber function (run to unsubscribe from listening for updates)
    */
   subscribeWebViewMenu(
     webViewType: ReferencedItem,
-    callback: (menuContent: Localized<WebViewMenu>) => void,
+    callback: (menuContent: Localized<WebViewMenu> | PlatformError) => void,
     options?: DataProviderSubscriberOptions,
   ): Promise<UnsubscriberAsync>;
 } & OnDidDispose &

--- a/src/shared/services/papi-core.service.ts
+++ b/src/shared/services/papi-core.service.ts
@@ -19,7 +19,7 @@ export type {
 export type { DialogTypes } from '@renderer/components/dialogs/dialog-definition.model';
 export type { UseDialogCallbackOptions } from '@renderer/hooks/papi-hooks/use-dialog-callback.hook';
 export type {
-  default as IDataProvider,
+  IDataProvider,
   IDisposableDataProvider,
 } from '@shared/models/data-provider.interface';
 export type {
@@ -28,7 +28,7 @@ export type {
   DataProviderSubscriberOptions,
 } from '@shared/models/data-provider.model';
 export type { WithNotifyUpdate } from '@shared/models/data-provider-engine.model';
-export type { default as IDataProviderEngine } from '@shared/models/data-provider-engine.model';
+export type { IDataProviderEngine } from '@shared/models/data-provider-engine.model';
 export type { DialogOptions } from '@shared/models/dialog-options.model';
 export type { NetworkableObject, NetworkObject } from '@shared/models/network-object.model';
 export type { PlatformNotification } from '@shared/models/notification.service-model';
@@ -46,7 +46,7 @@ export type { IProjectDataProviderEngine } from '@shared/models/project-data-pro
 export type { IProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model.ts';
 export type { IBaseProjectDataProviderEngine } from '@shared/models/base-project-data-provider-engine.model';
 export type {
-  default as IProjectDataProviderFactory,
+  IProjectDataProviderFactory,
   ProjectMetadataFilterOptions,
 } from '@shared/models/project-data-provider-factory.interface';
 export type {

--- a/src/shared/services/settings.service-model.ts
+++ b/src/shared/services/settings.service-model.ts
@@ -1,6 +1,6 @@
 import * as networkService from '@shared/services/network.service';
 import { SettingNames, SettingTypes } from 'papi-shared-types';
-import { OnDidDispose, UnsubscriberAsync } from 'platform-bible-utils';
+import { OnDidDispose, PlatformError, UnsubscriberAsync } from 'platform-bible-utils';
 import { serializeRequestType } from '@shared/utils/util';
 import { IDataProvider } from '@shared/models/data-provider.interface';
 import {
@@ -191,13 +191,16 @@ export type ISettingsService = {
    * callback function is executed.
    *
    * @param key The string id of the setting for which the value is being subscribed to
-   * @param callback The function that will be called whenever the specified setting is updated
+   * @param callback The function that will be called whenever the specified setting is updated. If
+   *   there is an error while retrieving the updated data, the function will run with a
+   *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this value
+   *   to check if it is an error.
    * @param options Various options to adjust how the subscriber emits updates
    * @returns Unsubscriber that should be called whenever the subscription should be deleted
    */
   subscribe<SettingName extends SettingNames>(
     key: SettingName,
-    callback: (newSetting: SettingTypes[SettingName]) => void,
+    callback: (newSetting: SettingTypes[SettingName] | PlatformError) => void,
     options?: DataProviderSubscriberOptions,
   ): Promise<UnsubscriberAsync>;
 


### PR DESCRIPTION
…(#1588)

* Fixed data provider subscribe to reflect PlatformError (#1575)

* PT-2973: Changed return type of useSetting hook to indicate that it can result in a PlatformError.

Changed uses of that hook to check for errors.

* PT-2973: handle platform error in hooks use project setting (#1586)

Fixed useProjectSEtting to reflect PlatformError

* PT-2973: Fixed useProjectData to reflect PlatformError (#1581)

Fixed useProjectData to reflect PlatformError

---------

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1589)
<!-- Reviewable:end -->
