### PR TITLE
update editor v0.7.10

### DIFF
--- a/extensions/src/legacy-comment-manager/package.json
+++ b/extensions/src/legacy-comment-manager/package.json
@@ -39,7 +39,7 @@
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {
-    "@biblionexus-foundation/scripture-utilities": "~0.0.8",
+    "@biblionexus-foundation/scripture-utilities": "~0.0.9",
     "@swc/core": "^1.10.18",
     "@tailwindcss/typography": "^0.5.16",
     "@types/node": "^20.17.10",

--- a/extensions/src/platform-scripture-editor/package.json
+++ b/extensions/src/platform-scripture-editor/package.json
@@ -39,8 +39,8 @@
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {
-    "@biblionexus-foundation/platform-editor": "~0.7.9",
-    "@biblionexus-foundation/scripture-utilities": "~0.0.8",
+    "@biblionexus-foundation/platform-editor": "~0.7.10",
+    "@biblionexus-foundation/scripture-utilities": "~0.0.9",
     "@swc/core": "^1.10.18",
     "@tailwindcss/typography": "^0.5.16",
     "@types/node": "^20.17.10",

--- a/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
@@ -35,7 +35,7 @@
 }
 
 // focus ring
-:focus-visible,
+:focus-visible:not(.editor-input),
 .CommentPlugin_CommentInputBox_Editor:focus {
   outline: 2px solid transparent;
   outline-offset: 2px;

--- a/extensions/src/platform-scripture-editor/src/_editor.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor.scss
@@ -15,6 +15,14 @@
   border-top-right-radius: 10px;
 }
 
+.editor-toolbar-container-readonly {
+  display: none;
+}
+
+.editor-toolbar-container-editable {
+  display: inline;
+}
+
 .editor-inner {
   background: #fff;
   position: relative;

--- a/extensions/src/platform-scripture/package.json
+++ b/extensions/src/platform-scripture/package.json
@@ -40,7 +40,7 @@
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {
-    "@biblionexus-foundation/scripture-utilities": "~0.0.8",
+    "@biblionexus-foundation/scripture-utilities": "~0.0.9",
     "@swc/core": "^1.10.18",
     "@tailwindcss/typography": "^0.5.16",
     "@types/jest": "^29.5.14",

--- a/lib/platform-bible-utils/package.json
+++ b/lib/platform-bible-utils/package.json
@@ -51,7 +51,7 @@
     "jsonpath-plus": "^10.3.0"
   },
   "devDependencies": {
-    "@biblionexus-foundation/scripture-utilities": "^0.0.8",
+    "@biblionexus-foundation/scripture-utilities": "~0.0.9",
     "@types/jest": "^29.5.14",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -459,7 +459,7 @@
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
-        "@biblionexus-foundation/scripture-utilities": "~0.0.8",
+        "@biblionexus-foundation/scripture-utilities": "~0.0.9",
         "@swc/core": "^1.10.18",
         "@tailwindcss/typography": "^0.5.16",
         "@types/node": "^20.17.10",
@@ -771,7 +771,7 @@
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
-        "@biblionexus-foundation/scripture-utilities": "~0.0.8",
+        "@biblionexus-foundation/scripture-utilities": "~0.0.9",
         "@swc/core": "^1.10.18",
         "@tailwindcss/typography": "^0.5.16",
         "@types/jest": "^29.5.14",
@@ -838,8 +838,8 @@
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
-        "@biblionexus-foundation/platform-editor": "~0.7.9",
-        "@biblionexus-foundation/scripture-utilities": "~0.0.8",
+        "@biblionexus-foundation/platform-editor": "~0.7.10",
+        "@biblionexus-foundation/scripture-utilities": "~0.0.9",
         "@swc/core": "^1.10.18",
         "@tailwindcss/typography": "^0.5.16",
         "@types/node": "^20.17.10",
@@ -1258,7 +1258,7 @@
         "jsonpath-plus": "^10.3.0"
       },
       "devDependencies": {
-        "@biblionexus-foundation/scripture-utilities": "^0.0.8",
+        "@biblionexus-foundation/scripture-utilities": "~0.0.9",
         "@types/jest": "^29.5.14",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
@@ -3313,21 +3313,21 @@
       "peer": true
     },
     "node_modules/@biblionexus-foundation/platform-editor": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.7.9.tgz",
-      "integrity": "sha512-43DADfrcL3rLCCdsSQ780KKoXsoNyMLPpZzYPnktNKqj6pX7KkPRRhOBrO2jPnwqZdYe76xnlc/6h9baHgR8Ag==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/platform-editor/-/platform-editor-0.7.10.tgz",
+      "integrity": "sha512-xFJJa9OQ2PtN2K1RN17fF3kyvrb3Sj2uyueUZDlClkdrFEg1fBLI49jdj3897ZwUYLKMAL4QZl9RP6UanJ5xKg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@biblionexus-foundation/scripture-utilities": "~0.0.8",
-        "@lexical/react": "^0.27.2",
-        "@lexical/selection": "^0.27.2",
-        "@lexical/text": "^0.27.2",
-        "@lexical/utils": "^0.27.2",
-        "@lexical/yjs": "^0.27.2",
+        "@biblionexus-foundation/scripture-utilities": "~0.0.9",
+        "@lexical/react": "^0.30.0",
+        "@lexical/selection": "^0.30.0",
+        "@lexical/text": "^0.30.0",
+        "@lexical/utils": "^0.30.0",
+        "@lexical/yjs": "^0.30.0",
         "@sillsdev/scripture": "^2.0.2",
         "fast-equals": "^5.2.2",
-        "lexical": "^0.27.2",
+        "lexical": "^0.30.0",
         "yjs": "^13.6.20"
       },
       "peerDependencies": {
@@ -3336,13 +3336,13 @@
       }
     },
     "node_modules/@biblionexus-foundation/scripture-utilities": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/scripture-utilities/-/scripture-utilities-0.0.8.tgz",
-      "integrity": "sha512-8SUblROnmag2rBrlTaGfeTpjMBUnj1bQNKJckkhH14EAclkRr/j3FfbMgvmp+H6pzRuzgVPgOLynOcoDcsmF/A==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@biblionexus-foundation/scripture-utilities/-/scripture-utilities-0.0.9.tgz",
+      "integrity": "sha512-lvRyVXTgvuZm6rYvckCrhgqp4bwJEbUP5c4flnq/IufsWvAsQilZz0RwHz+o56gNFn+JbabjFT88+4R8m4qa/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@xmldom/xmldom": "^0.9.7"
+        "@xmldom/xmldom": "^0.9.8"
       }
     },
     "node_modules/@biblionexus-foundation/scripture-utilities/node_modules/@xmldom/xmldom": {
@@ -5544,44 +5544,44 @@
       "dev": true
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.27.2.tgz",
-      "integrity": "sha512-rfnFYf8P0081IvPOJjE7fWJE+d/dz0Xdsw83uizY5X6HaLXFB/Qy1MrzEqWZnYnOpgi1snAuolZ5Rbg83SIlYA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.30.0.tgz",
+      "integrity": "sha512-taWQURtE6xF4Jy4I8teQw3+nVBVNO1r+9N9voXeivgwxSrAM40rjqQ/aZEKxWbwZtfkABDkCEArbVrqP0SkWcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.27.2",
-        "@lexical/list": "0.27.2",
-        "@lexical/selection": "0.27.2",
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/html": "0.30.0",
+        "@lexical/list": "0.30.0",
+        "@lexical/selection": "0.30.0",
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/code": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.27.2.tgz",
-      "integrity": "sha512-GoTy57CYoXvP1N+E9ptCJ47LQCAu67K/HQsjg0NmmtNbWlInk6Sa2V4pM1KePp6JAQapGpIlCoEyC3/KkrQ55g==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code/-/code-0.30.0.tgz",
+      "integrity": "sha512-OmA6Bmp3w9SMV25Hae1dLXtPNOdCgnzo1xy84K19U+dPP5iqXagwFq5oY/9PVOOI2wgaQHrz3C+7B4phDb9xaA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2",
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0",
         "prismjs": "^1.30.0"
       }
     },
     "node_modules/@lexical/devtools-core": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.27.2.tgz",
-      "integrity": "sha512-LAI7j9roS2i/lV/6Z4AAx2+EVOEnMVzLZFB6aQfSjRbZ9lzA8S17743OJUHRXyTvBWc5520ihhBybO0EfjTagw==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.30.0.tgz",
+      "integrity": "sha512-6vKEEIUym8pQ+tWt4VfRMOGE/dtfyPr9e1zPrAAV7Y/EdzK0AJYPPlw2Dt5Uqq9rposcIriqF4MkuFvy4UcZiQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.27.2",
-        "@lexical/link": "0.27.2",
-        "@lexical/mark": "0.27.2",
-        "@lexical/table": "0.27.2",
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/html": "0.30.0",
+        "@lexical/link": "0.30.0",
+        "@lexical/mark": "0.30.0",
+        "@lexical/table": "0.30.0",
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
@@ -5589,157 +5589,155 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.27.2.tgz",
-      "integrity": "sha512-0xI98esvgtJpVLJUADtvJ/yKk4kFFrn2h7GgzvihLXeVe+O149DONFSarB9yguDyvHUblKtfjB2BcJaeOIpouQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.30.0.tgz",
+      "integrity": "sha512-eikVYw1pIcFIOojn2mGlps59YcyT9ATd6UMIx/ivuscakrZeU7SZM/F6c75QPJXNOu1b2koOo+4Bb1GT6jixGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.27.2"
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.27.2.tgz",
-      "integrity": "sha512-BBwMT3rz/TlZZ6ZjkP5+Yj86ffufiktOBwry7kPDUqOMyTuTFEE58cmd4SXiYEs7yifrC6TenRmFZgBui7xpmQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.30.0.tgz",
+      "integrity": "sha512-gB3DobSdAc0YZUhlTT7ZAUr+6RRREQ3UWVC1twdtFvXXw1vyTUXH2gWTDp/ParwBZ16Lnrg8mxET8Nu/qD1PSw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/history": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.27.2.tgz",
-      "integrity": "sha512-5CihqjvlmXuiLZYpKZMfYISpVSSpUrs3jpC5XK0kAv0etUWyf2/JzY0BLfD2kb7x/tOrU7O+WptNNyl5WL3N5A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.30.0.tgz",
+      "integrity": "sha512-dxudthi94vSLQKXVq3LSwcOVkOmb2lvxoy7sCma513yJbrsn3fPLppR2Ynhl6aB9oPw675wSDrfsE6BG3U3+CA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/html": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.27.2.tgz",
-      "integrity": "sha512-6kPvrTxAE39jUhnbYMCenHVHXTlew9sBprniQu5iZSszMfcn/SDkqmHWi8//fhiLlcAa/p0vRDxaBYoQQf0r9A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.30.0.tgz",
+      "integrity": "sha512-GdegWO6RjJ7eE+yD3Z0X/OpT88SZjOs3DyQ0rgrZy3z7RPaFCbEEcq0M/NssJbKAB1XOFUsUFrnS7kZs1vJzGg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.27.2",
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/selection": "0.30.0",
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.27.2.tgz",
-      "integrity": "sha512-t+tMr1aEwy67D4+GU6XX78Dxllyu3xebYAlB5ANpnv0oV8PSxT8h6aHHVwj0a55a89NnSPTzpBhqtX0QO374+A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.30.0.tgz",
+      "integrity": "sha512-isD3PC0ywQIwbtekHYEvh7hDxcPz/cEr/AspYntYs08u5J0czhw3rpqnXWGauWaav5V9ExIkf1ZkGUFUI6bw5w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/list": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.27.2.tgz",
-      "integrity": "sha512-jE7e95ttO26Xtt322dnUwWSG7QgeAfBg3Ghyjd8ByGI5O5wmMgMgb3NCiSSRPBWOpt6PEeD5s5KjQKfMUCCuHQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.30.0.tgz",
+      "integrity": "sha512-WKnwH+Cg+j2I0EbaEyPHo8MPNyrqQV3W1NmH5Mf/iRxCq42z7NJxemhmRUxbqv8vsugACwBkh2RlkhekRXmUQQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/selection": "0.30.0",
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/mark": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.27.2.tgz",
-      "integrity": "sha512-6rTwfVuuFeiTy6MU8yY3nyBOe2KtcB1lL0zg8ygIRjSYsV2+HAVAUesDFnaCUHJ1qimj9pJB8fW+GU2ur8uGvQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.30.0.tgz",
+      "integrity": "sha512-dLFH6tJ2WQUSdo1Y2Jp81vRT8j48FjF75K5YLRsKD/UFxWEy+RFgRXsd0H/BuFkx/jPTXt6xe8CaIrZvek8mLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.27.2.tgz",
-      "integrity": "sha512-XbM/G0CPoH2BUAuKSRS5L2pAU1kreZDOH0Eh4DR2sLzosM48ZyRktgKAUwHItQPQ/in5hkH3Xd5D4RAtYWhKUA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.30.0.tgz",
+      "integrity": "sha512-GGddZs63k0wb3/fdL7JyBjiy8L1AIHuRKT68riWbKAcNL7rfMl3Uy5VnMkgV/5bN/2eUQijkGjxG+VxsR8RWbw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/code": "0.27.2",
-        "@lexical/link": "0.27.2",
-        "@lexical/list": "0.27.2",
-        "@lexical/rich-text": "0.27.2",
-        "@lexical/text": "0.27.2",
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/code": "0.30.0",
+        "@lexical/link": "0.30.0",
+        "@lexical/list": "0.30.0",
+        "@lexical/rich-text": "0.30.0",
+        "@lexical/text": "0.30.0",
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/offset": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.27.2.tgz",
-      "integrity": "sha512-li+NxLeU2IW7JKOr8pheS/7aGlU8sKThPEKDtM20d0drvMAo03ebu5X/wxmy1e4zWKbpH3dll/ocE+gGV9DcLA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.30.0.tgz",
+      "integrity": "sha512-sZFbZt5dVdtrdoYk79i13xBDs8/MHXw6CqmZNht85L7UdwiuzVqA3KTyaMe60Vrg6mfsKIVjghbpMOhspcuCrw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.27.2"
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.27.2.tgz",
-      "integrity": "sha512-vkKrZyes4/r73wH/t+X0HEsol4A9yxzALAnx8vyXCnw2s8zklQFi5ccf3fkwPG6cSKDl+zAO0elmSjhxOp5JfQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.30.0.tgz",
+      "integrity": "sha512-fvjWnhtPZLMS3qJ6HC6tZTOMmcfNmeRUkgXTas9bvWT8Yul+WLJ/fWjzwvBcqpKlvPQjRFOcDcrW8T/Rp7KPrg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.27.2"
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.27.2.tgz",
-      "integrity": "sha512-/EygmUMFsH9WVkXl1/IwKJfJJAQy2pnxPx+bYz97hTXqh9CHkzn0N81gxjquRAPZkemoE7UoZsAbaw07BH+8hA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.30.0.tgz",
+      "integrity": "sha512-jvxMMxFO3Yuj7evWsc33IGWfigU5A1KrJaIf6zv6GmYj0a7ZRkR1x6vJyc7AlgUM70sld+dozLdoynguQIlmrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.27.2",
-        "@lexical/selection": "0.27.2",
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/clipboard": "0.30.0",
+        "@lexical/selection": "0.30.0",
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/react": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.27.2.tgz",
-      "integrity": "sha512-azfF9kQ/LM47Gn0vV5xMkD2viEiAxmgRQQsDv8gOZcZY4CWtRth/uehW8nchmD4xIgK63LLjGRjYhShTufy0XA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.30.0.tgz",
+      "integrity": "sha512-fsb6voXzxHyP55lXdmnGhHMfxe6g/f+0NpmfPCkutOXYnY8UqKa86LLYl4Nrsi8HX8BRZfh1H0IjkzDG6EzVPw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.27.2",
-        "@lexical/code": "0.27.2",
-        "@lexical/devtools-core": "0.27.2",
-        "@lexical/dragon": "0.27.2",
-        "@lexical/hashtag": "0.27.2",
-        "@lexical/history": "0.27.2",
-        "@lexical/link": "0.27.2",
-        "@lexical/list": "0.27.2",
-        "@lexical/mark": "0.27.2",
-        "@lexical/markdown": "0.27.2",
-        "@lexical/overflow": "0.27.2",
-        "@lexical/plain-text": "0.27.2",
-        "@lexical/rich-text": "0.27.2",
-        "@lexical/selection": "0.27.2",
-        "@lexical/table": "0.27.2",
-        "@lexical/text": "0.27.2",
-        "@lexical/utils": "0.27.2",
-        "@lexical/yjs": "0.27.2",
-        "lexical": "0.27.2",
+        "@lexical/devtools-core": "0.30.0",
+        "@lexical/dragon": "0.30.0",
+        "@lexical/hashtag": "0.30.0",
+        "@lexical/history": "0.30.0",
+        "@lexical/link": "0.30.0",
+        "@lexical/list": "0.30.0",
+        "@lexical/mark": "0.30.0",
+        "@lexical/markdown": "0.30.0",
+        "@lexical/overflow": "0.30.0",
+        "@lexical/plain-text": "0.30.0",
+        "@lexical/rich-text": "0.30.0",
+        "@lexical/table": "0.30.0",
+        "@lexical/text": "0.30.0",
+        "@lexical/utils": "0.30.0",
+        "@lexical/yjs": "0.30.0",
+        "lexical": "0.30.0",
         "react-error-boundary": "^3.1.4"
       },
       "peerDependencies": {
@@ -5748,73 +5746,73 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.27.2.tgz",
-      "integrity": "sha512-naWwPNbEJAue/R0pmZwqnTVkv3V2rzgzz+C6/J5tMOvN1Osth8OL3UD6K8NQX8rjdnXe4soVoH8XsNhU0Jv10w==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.30.0.tgz",
+      "integrity": "sha512-oitOh5u68E5DBZt5VBZIaIeM/iNdt3mIDkGp2C259x81V/9KlSNB9c3rqdTKcs/A+Msw4j60FRhdmZcKQ9uYUA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.27.2",
-        "@lexical/selection": "0.27.2",
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/clipboard": "0.30.0",
+        "@lexical/selection": "0.30.0",
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/selection": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.27.2.tgz",
-      "integrity": "sha512-9AJOfw1zMQ3PqGpovEuy6NjfWck/9KzxNPzXoGRZlJRvPexgZirentPWRhLHF3DMtnOML1+GCpj+5LOAYN2XbQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.30.0.tgz",
+      "integrity": "sha512-Ys2XfSmIV/Irg6Xo663YtR4jozIv/7sDemArkEGHT0fxZn2py5qftowPF5IBqFYxKTigAdv5vVPwusBvAnLIEg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.27.2"
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/table": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.27.2.tgz",
-      "integrity": "sha512-6G3jj7EyweviX3/AEZOr/XBTIQN5QCkJcg1Zw3I9Ga0F+CCDM5aeJWRv4hultP1nOz1xtYCDnezhaPV1Gef9dA==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.30.0.tgz",
+      "integrity": "sha512-XPCIMIGnZLKTa5/4cP16bXbmzvMndPR273HNl7ZaF35ky7UjZxdj42HBbE7q9zw2zbRPDiO77EyhYA0p20cbdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.27.2",
-        "@lexical/utils": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/clipboard": "0.30.0",
+        "@lexical/utils": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/text": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.27.2.tgz",
-      "integrity": "sha512-Rx61l/Cbz2GGwZvtp56PMGB35X+VnZYhRlLJdZhQ+XTYbRmCTAh50mBcS3FzZrziq8vn07yEN/9FVb8HGTyN1A==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.30.0.tgz",
+      "integrity": "sha512-P0ptriFwwP/hoDpz/MoBbzHxrFHqh0kCGzASWUdRZ1zrU0yPvJ9vV/UNMhyolH7xx+eAGI1Yl+m74NlpGmXqTg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.27.2"
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.27.2.tgz",
-      "integrity": "sha512-tCEuKL5IXiJ12ZN/Ej37Q7PhcBntekLeQbGiYO4sgIAnR9qI6yYgVH7b1CC+Tf06UapUXjIDG0Uh5/u0W1+kOQ==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.30.0.tgz",
+      "integrity": "sha512-VJlAUhupCZmnbYYX3zMWovd4viu2guR01sAqKGbbOMbP+4rlaymixFbinvNPaRKDBloOARi+fpiveQFxnyr/Ew==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/list": "0.27.2",
-        "@lexical/selection": "0.27.2",
-        "@lexical/table": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/list": "0.30.0",
+        "@lexical/selection": "0.30.0",
+        "@lexical/table": "0.30.0",
+        "lexical": "0.30.0"
       }
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.27.2.tgz",
-      "integrity": "sha512-+twxPJNwN9VOe20dMKDbBfdZWCiTVM7RrezNZ984o8bJVx6dW80yM96zEyyQp1pmgi60lOYunKWD1B5/74Dq/w==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.30.0.tgz",
+      "integrity": "sha512-mWGFAGpUPz4JoSV+Y0cZOzOZJoMLbVb/enldxEbV0xX71BBVzD0c0vjPxuaIJ9MtNkRZdK3eOubj+B45iOECtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.27.2",
-        "@lexical/selection": "0.27.2",
-        "lexical": "0.27.2"
+        "@lexical/offset": "0.30.0",
+        "@lexical/selection": "0.30.0",
+        "lexical": "0.30.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
@@ -18407,9 +18405,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.7.tgz",
-      "integrity": "sha512-fgVY8AV7qU7z/MmXJ/rxwbrtQH4jBQ9m7kp3llF0liB7glmFeVZFBepQb32T3y8n8k2+AEYuMPCpinYW+/CuRA==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
+      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20885,16 +20883,16 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.27.2.tgz",
-      "integrity": "sha512-R255V+4VBqZmSMWeuMrCNHJZd3L+qBkYYFrxkiO3FLg/36HatZLUdZLRYx+fOMWeSddo0DP9EVl0GTZzNb7v0w==",
+      "version": "0.30.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.30.0.tgz",
+      "integrity": "sha512-6gxYeXaJiAcreJD0whCofvO0MuJmnWoIgIl1w7L5FTigfhnEohuCx2SoI/oywzfzXE9gzZnyr3rVvZrMItPL8A==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/lib0": {
-      "version": "0.2.99",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.99.tgz",
-      "integrity": "sha512-vwztYuUf1uf/1zQxfzRfO5yzfNKhTtgOByCruuiQQxWQXnPb8Itaube5ylofcV0oM0aKal9Mv+S1s1Ky0UYP1w==",
+      "version": "0.2.104",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.104.tgz",
+      "integrity": "sha512-1tqKRANSPTcjs/yjPoKh52oRM2u5AYdd8jie8sDiN8/5kpWWiQSHUGgtB4VEXLw1chVL3QPSPp8q9RWqzSn2FA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -31199,9 +31197,9 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.24",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.24.tgz",
-      "integrity": "sha512-xn/pYLTZa3uD1uDG8lpxfLRo5SR/rp0frdASOl2a71aYNvUXdWcLtVL91s2y7j+Q8ppmjZ9H3jsGVgoFMbT2VA==",
+      "version": "13.6.26",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.26.tgz",
+      "integrity": "sha512-wiARO3wixu7mtoRP5f7LqpUtsURP9SmNgXUt3RlnZg4qDuF7dUjthwIvwxIDmK55dPw4Wl4QdW5A3ag0atwu7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
- allow dynamic option changes except `viewOptions` & `nodeOptions`
- `viewOptions` & `nodeOptions` changes will reload the editor to preserve edits
- fix cursor moving when typing between empty verses in (implied) paras
- update lexical v0.30.0
- also remove focus ring from editor - was showing as thick black line below editor when focused
- also `npm audit fix`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1605)
<!-- Reviewable:end -->
