### PR TITLE
Removed mention of Node 18 in README because it is outdated

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ your `.zprofile` so you don't have to remember to do it manually.
 
 ### All Platforms Development Pre-requisites
 
-Install [`Node.js` version >=18.0.0](https://nodejs.org/) (18.0.0 or greater is required for using `fetch`). We recommend using [Volta](#javascript-tool-manager).
+Install the version of [`Node.js`](https://nodejs.org/) that matches the version specified in [`package.json`](https://github.com/paranext/paranext-core/blob/main/package.json#L249) at `volta.node`. We recommend using [Volta](#javascript-tool-manager).
 
 Install `dotnet` [.NET 8 SDK from here](https://learn.microsoft.com/en-us/dotnet/core/install/).
 


### PR DESCRIPTION
Pointed instead to package.json's volta.node

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1616)
<!-- Reviewable:end -->
