### PR TITLE
PT-3169 update: Fix toolbar item clipping and focus ring issues

### DIFF
--- a/lib/platform-bible-react/src/components/advanced/tab-toolbar.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/tab-toolbar.component.tsx
@@ -54,7 +54,7 @@ export function TabToolbar({
   return (
     <div
       className={cn(
-        'tw-box-border tw-flex tw-h-12 tw-w-full tw-flex-row tw-items-center tw-justify-between tw-gap-2 tw-overflow-clip tw-border tw-px-4 tw-py-2 tw-text-foreground tw-@container/toolbar',
+        'tw-box-border tw-flex tw-h-12 tw-w-full tw-flex-row tw-items-start tw-justify-between tw-gap-2 tw-overflow-clip tw-border-b tw-border-border tw-px-4 tw-pt-2 tw-text-foreground tw-@container/toolbar',
         className,
       )}
       id={id}
@@ -65,7 +65,7 @@ export function TabToolbar({
           menuData={projectMenuData}
           tabLabel="Project"
           icon={<Menu />}
-          className="tw-h-full tw-w-8"
+          className="tw-h-8 tw-w-8"
         />
       )}
       <div className="tw-flex tw-h-full tw-shrink tw-grow-[2] tw-flex-row tw-flex-wrap tw-items-start tw-gap-2 tw-overflow-clip tw-@container/tab-toolbar-start">
@@ -81,7 +81,7 @@ export function TabToolbar({
             menuData={tabViewMenuData}
             tabLabel="View Info"
             icon={<EllipsisVertical />}
-            className="tw-h-full"
+            className="tw-h-8"
           />
         )}
         {endAreaChildren}

--- a/lib/platform-bible-react/src/components/advanced/tab-toolbar.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/tab-toolbar.component.tsx
@@ -54,35 +54,41 @@ export function TabToolbar({
   return (
     <div
       className={cn(
-        'tw-box-border tw-flex tw-h-12 tw-w-full tw-flex-row tw-items-start tw-justify-between tw-gap-2 tw-overflow-clip tw-border-b tw-border-border tw-px-4 tw-pt-2 tw-text-foreground tw-@container/toolbar',
+        'tw-box-border tw-flex tw-h-12 tw-w-full tw-flex-row tw-items-start tw-justify-between tw-overflow-clip tw-border-b tw-border-border tw-text-foreground tw-@container/toolbar *:tw-p-2',
         className,
       )}
       id={id}
     >
       {projectMenuData && (
-        <TabDropdownMenu
-          commandHandler={projectMenuCommandHandler}
-          menuData={projectMenuData}
-          tabLabel="Project"
-          icon={<Menu />}
-          className="tw-h-8 tw-w-8"
-        />
+        // div wrapper gets padding instead of the button
+        <div>
+          <TabDropdownMenu
+            commandHandler={projectMenuCommandHandler}
+            menuData={projectMenuData}
+            tabLabel="Project"
+            icon={<Menu />}
+            className="tw-h-8 tw-w-8"
+          />
+        </div>
       )}
-      <div className="tw-flex tw-h-full tw-shrink tw-grow-[2] tw-flex-row tw-flex-wrap tw-items-start tw-gap-2 tw-overflow-clip tw-@container/tab-toolbar-start">
+      <div className="tw-flex tw-shrink tw-grow-[2] tw-flex-row tw-flex-wrap tw-items-start tw-gap-2 tw-overflow-clip tw-@container/tab-toolbar-start">
         {startAreaChildren}
       </div>
-      <div className="tw-flex tw-h-full tw-shrink tw-basis-0 tw-flex-row tw-flex-wrap tw-items-start tw-justify-center tw-gap-2 tw-overflow-clip tw-@container/tab-toolbar-center @sm:tw-grow @sm:tw-basis-auto">
+      <div className="tw-flex tw-shrink tw-basis-0 tw-flex-row tw-flex-wrap tw-items-start tw-justify-center tw-gap-2 tw-overflow-clip tw-@container/tab-toolbar-center @sm:tw-grow @sm:tw-basis-auto">
         {centerAreaChildren}
       </div>
-      <div className="tw-flex tw-h-full tw-shrink tw-grow-[2] tw-flex-row-reverse tw-flex-wrap tw-items-start tw-gap-2 tw-overflow-clip tw-@container/tab-toolbar-end">
+      <div className="tw-flex tw-shrink tw-grow-[2] tw-flex-row-reverse tw-flex-wrap tw-items-start tw-gap-2 tw-overflow-clip tw-@container/tab-toolbar-end">
         {tabViewMenuData && (
-          <TabDropdownMenu
-            commandHandler={viewInfoMenuCommandHandler}
-            menuData={tabViewMenuData}
-            tabLabel="View Info"
-            icon={<EllipsisVertical />}
-            className="tw-h-8"
-          />
+          // div wrapper gets padding instead of the button
+          <div>
+            <TabDropdownMenu
+              commandHandler={viewInfoMenuCommandHandler}
+              menuData={tabViewMenuData}
+              tabLabel="View Info"
+              icon={<EllipsisVertical />}
+              className="tw-h-8"
+            />
+          </div>
         )}
         {endAreaChildren}
       </div>

--- a/src/renderer/components/web-view.component.css
+++ b/src/renderer/components/web-view.component.css
@@ -5,24 +5,6 @@
   flex-direction: column;
 }
 
-.web-view-tab-nav {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  flex-grow: 0;
-  flex-shrink: 0;
-  gap: 8px;
-  padding: 8px;
-  border-bottom: 1px solid hsl(var(--border));
-  width: 100%;
-  box-sizing: border-box;
-}
-
-/** Make the bcv control shrink instead of going offscreen */
-.web-view-tab-nav input {
-  width: 100%;
-}
-
 .web-view-scroll-group-selector {
   width: auto;
 }


### PR DESCRIPTION
## Problem
Toolbar items were getting clipped at the bottom in the app and Preview on macOS (issue not present in Storybook). Additionally, focus rings were being clipped due to inadequate spacing.

## Solution
•  Fixed vertical sizing: Changed from `tw-items-center` with variable item heights to `tw-items-start` with consistent manual item heights and top padding
•  Improved spacing distribution: Restructured spacing to prevent focus ring clipping
•  Removed padding and gaps from the main toolbar div
•  Added wrapper divs to menu trigger buttons  
•  Applied padding to individual toolbar div children
•  Removed unnecessary `tw-h-full` from slots
•  Cleaned up redundant CSS: Removed duplicate toolbar styling from external CSS files since the tab-toolbar component already includes these styles

## Changes
•  lib/platform-bible-react/src/components/advanced/tab-toolbar.component.tsx: Updated spacing and sizing logic
•  src/renderer/components/web-view.component.css: Removed redundant styles

## Testing
•  ✅ Verified toolbar items no longer clip on macOS app and Preview
•  ✅ Focus rings now display properly without clipping
•  ✅ Storybook didn't break
•  ❌ Not tested in Electron app

Fixes for PT-3169 (not a separate bug report)