### PR TITLE
Allow extensions to use iframes from http://localhost:*

### DIFF
--- a/src/renderer/index.ejs
+++ b/src/renderer/index.ejs
@@ -97,7 +97,7 @@
         default-src 'none';
         script-src-elem 'self' 'wasm-unsafe-eval' 'unsafe-inline';
         style-src 'self' papi-extension: 'unsafe-inline';
-        frame-src 'self' papi-extension: https:;
+        frame-src 'self' papi-extension: https: http://localhost:*;
         object-src 'none';
         worker-src 'self';
         manifest-src 'self';

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -992,7 +992,10 @@ export const openWebView = async (
   let { allowedFrameSources } = webView;
   if (contentType !== WEB_VIEW_CONTENT_TYPE.URL && allowedFrameSources)
     allowedFrameSources = allowedFrameSources.filter(
-      (hostValue) => startsWith(hostValue, 'https:') || startsWith(hostValue, 'papi-extension:'),
+      (hostValue) =>
+        startsWith(hostValue, 'https:') ||
+        startsWith(hostValue, 'papi-extension:') ||
+        startsWith(hostValue, 'http://localhost:'),
     );
 
   // Validate the WebViewDefinition to make sure it is acceptable


### PR DESCRIPTION
Our FW Lite extension works by launching a web server locally and then showing a page from the server in an iframe. However since this is a local server there's no https certs and there's no need to be so I can't use the existing allowance for https.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1651)
<!-- Reviewable:end -->
