### PR TITLE
feat: Add flexible macOS app installer script

### DIFF
--- a/.erb/scripts/install_unsigned_macos_build.sh
+++ b/.erb/scripts/install_unsigned_macos_build.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# Script to install arm64 app from app-macos*.zip file
+# Extract, install, codesign, and run the application
+# Supports both Paratext 10 Studio and Platform.Bible apps
+#
+# Usage:
+#   ./install_unsigned_macos_build.sh                    # Use ~/Downloads (default)
+#   ./install_unsigned_macos_build.sh /path/to/folder    # Search for app-macos*.zip in folder
+#   ./install_unsigned_macos_build.sh /path/to/file.zip  # Use specific zip file
+
+set -e  # Exit on any error
+
+# Show usage if help is requested
+if [[ "$1" == "-h" || "$1" == "--help" ]]; then
+    echo "Usage: $0 [path]"
+    echo "  path: Optional path to directory or zip file"
+    echo "        If directory: searches for most recent app-macos*.zip"
+    echo "        If file: uses that specific zip file"
+    echo "        If not specified: defaults to ~/Downloads"
+    exit 0
+fi
+
+echo "Starting app installation process..."
+
+# Define variables
+TEMP_DIR="/tmp/app_install_$$"
+DMG_PATTERN="*arm64*.dmg"
+
+# Find the zip file based on provided path or default
+SEARCH_PATH="${1:-$HOME/Downloads}"  # Use first argument or default to ~/Downloads
+
+# Determine if the path is a file or directory and find the zip file
+if [ -f "$SEARCH_PATH" ]; then
+    # Path is a file - use it directly
+    if [[ "$SEARCH_PATH" == *.zip ]]; then
+        ZIP_FILE="$SEARCH_PATH"
+        echo "Using specified zip file: $(basename "$ZIP_FILE")"
+    else
+        echo "Error: Specified file '$SEARCH_PATH' is not a zip file!"
+        exit 1
+    fi
+elif [ -d "$SEARCH_PATH" ]; then
+    # Path is a directory - search for app-macos*.zip files
+    echo "Looking for app-macos*.zip files in $SEARCH_PATH..."
+    ZIP_FILE=$(ls -t "$SEARCH_PATH/app-macos"*.zip 2>/dev/null | head -1)
+    
+    if [ -z "$ZIP_FILE" ]; then
+        echo "Error: No app-macos*.zip file found in $SEARCH_PATH!"
+        echo "Available zip files in $SEARCH_PATH:"
+        ls -la "$SEARCH_PATH/"*.zip 2>/dev/null || echo "No zip files found"
+        exit 1
+    fi
+else
+    echo "Error: Path '$SEARCH_PATH' does not exist!"
+    exit 1
+fi
+
+echo "Found most recent file: $(basename "$ZIP_FILE")"
+
+# Create temporary directory
+mkdir -p "$TEMP_DIR"
+echo "Created temporary directory: $TEMP_DIR"
+
+# Extract zip file
+echo "Extracting zip file..."
+unzip -q "$ZIP_FILE" -d "$TEMP_DIR"
+
+# Find the arm64 DMG file
+DMG_FILE=$(find "$TEMP_DIR" -name "$DMG_PATTERN" -type f | head -1)
+if [ -z "$DMG_FILE" ]; then
+    echo "Error: No arm64 DMG file found in the zip!"
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+echo "Found arm64 DMG: $(basename "$DMG_FILE")"
+
+# Mount the DMG
+echo "Mounting DMG..."
+MOUNT_OUTPUT=$(hdiutil attach "$DMG_FILE" -nobrowse)
+MOUNT_POINT=$(echo "$MOUNT_OUTPUT" | grep '/Volumes/' | sed 's/.*\t//')
+if [ -z "$MOUNT_POINT" ]; then
+    echo "Error: Failed to mount DMG file"
+    echo "hdiutil output: $MOUNT_OUTPUT"
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+echo "Mounted at: $MOUNT_POINT"
+
+# Find the .app in the mounted volume
+APP_PATH=$(find "$MOUNT_POINT" -name "*.app" -type d | head -1)
+if [ -z "$APP_PATH" ]; then
+    echo "Error: No .app found in the mounted DMG"
+    hdiutil detach "$MOUNT_POINT" -quiet
+    rm -rf "$TEMP_DIR"
+    exit 1
+fi
+
+APP_NAME=$(basename "$APP_PATH")
+echo "Found app: $APP_NAME"
+
+# Remove existing app if it exists
+if [ -d "/Applications/$APP_NAME" ]; then
+    echo "Removing existing app..."
+    rm -rf "/Applications/$APP_NAME"
+fi
+
+# Copy app to Applications
+echo "Installing app to /Applications..."
+cp -R "$APP_PATH" "/Applications/"
+
+# Unmount the DMG
+echo "Unmounting DMG..."
+hdiutil detach "$MOUNT_POINT" -quiet
+
+# Clean up temporary directory
+rm -rf "$TEMP_DIR"
+
+# Remove quarantine attribute to avoid Gatekeeper issues
+echo "Removing quarantine attribute..."
+xattr -dr com.apple.quarantine "/Applications/$APP_NAME" 2>/dev/null || true
+
+# Codesign the app
+echo "Code signing the application..."
+codesign --deep --force --sign - "/Applications/$APP_NAME"
+
+if [ $? -eq 0 ]; then
+    echo "✅ Code signing successful!"
+else
+    echo "❌ Code signing failed!"
+    exit 1
+fi
+
+# Add to Gatekeeper approval (this will prompt for admin password if needed)
+echo "Adding app to Gatekeeper approval..."
+spctl --add "/Applications/$APP_NAME" 2>/dev/null || echo "Note: Could not add to spctl (may require admin privileges)"
+
+# Verify the app is properly installed
+if [ -d "/Applications/$APP_NAME" ]; then
+    echo "✅ App successfully installed at /Applications/$APP_NAME"
+else
+    echo "❌ App installation failed!"
+    exit 1
+fi
+
+# Run the application
+echo "Launching the application..."
+open "/Applications/$APP_NAME"
+
+if [ $? -eq 0 ]; then
+    echo "✅ Application launched successfully!"
+else
+    echo "❌ Failed to launch application!"
+    exit 1
+fi
+
+echo "🎉 Installation and launch completed successfully!"
+

--- a/.erb/scripts/install_unsigned_macos_build.sh
+++ b/.erb/scripts/install_unsigned_macos_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Script to install Apple Silicone (arm64) or Intel (x86_64) app from app-macos*.zip file
+# Script to install Apple Silicon (arm64) or Intel (x86_64) app from app-macos*.zip file
 # Extract, install, codesign, and run the application
 # Supports both Paratext 10 Studio and Platform.Bible apps
 #
@@ -10,7 +10,7 @@
 #   ./install_unsigned_macos_build.sh /path/to/file.zip  # Use specific zip file
 #
 # Expected pathnames:
-# - For Apple Silicone (arm64) architecture: DMG files should include "arm64" in their names (e.g., app-arm64.dmg).
+# - For Apple Silicon (arm64) architecture: DMG files should include "arm64" in their names (e.g., app-arm64.dmg).
 # - For Intel (x86_64) architecture: DMG files should exclude "arm64" in their names (e.g., app.dmg).
 
 set -e  # Exit on any error
@@ -24,7 +24,7 @@ if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     echo "        If not specified: defaults to ~/Downloads"
     echo ""
     echo "Expected pathnames:"
-    echo "  - For Apple Silicone (arm64) architecture: DMG files should include 'arm64' in their names (e.g., app-arm64.dmg)."
+    echo "  - For Apple Silicon (arm64) architecture: DMG files should include 'arm64' in their names (e.g., app-arm64.dmg)."
     echo "  - For Intel (x86_64) architecture: DMG files should exclude 'arm64' in their names (e.g., app.dmg)."
     exit 0
 fi

--- a/.erb/scripts/install_unsigned_macos_build.sh
+++ b/.erb/scripts/install_unsigned_macos_build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Script to install arm64 app from app-macos*.zip file
+# Script to install Apple Silicone (arm64) or Intel (x86_64) app from app-macos*.zip file
 # Extract, install, codesign, and run the application
 # Supports both Paratext 10 Studio and Platform.Bible apps
 #
@@ -8,6 +8,10 @@
 #   ./install_unsigned_macos_build.sh                    # Use ~/Downloads (default)
 #   ./install_unsigned_macos_build.sh /path/to/folder    # Search for app-macos*.zip in folder
 #   ./install_unsigned_macos_build.sh /path/to/file.zip  # Use specific zip file
+#
+# Expected pathnames:
+# - For Apple Silicone (arm64) architecture: DMG files should include "arm64" in their names (e.g., app-arm64.dmg).
+# - For Intel (x86_64) architecture: DMG files should exclude "arm64" in their names (e.g., app.dmg).
 
 set -e  # Exit on any error
 
@@ -18,6 +22,10 @@ if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     echo "        If directory: searches for most recent app-macos*.zip"
     echo "        If file: uses that specific zip file"
     echo "        If not specified: defaults to ~/Downloads"
+    echo ""
+    echo "Expected pathnames:"
+    echo "  - For Apple Silicone (arm64) architecture: DMG files should include 'arm64' in their names (e.g., app-arm64.dmg)."
+    echo "  - For Intel (x86_64) architecture: DMG files should exclude 'arm64' in their names (e.g., app.dmg)."
     exit 0
 fi
 
@@ -25,7 +33,6 @@ echo "Starting app installation process..."
 
 # Define variables
 TEMP_DIR="/tmp/app_install_$$"
-DMG_PATTERN="*arm64*.dmg"
 
 # Find the zip file based on provided path or default
 SEARCH_PATH="${1:-$HOME/Downloads}"  # Use first argument or default to ~/Downloads
@@ -77,10 +84,10 @@ if [ "$ARCH" = "arm64" ]; then
     exit 1
   fi
 else
-  echo "Detected Intel (x86_64). Looking for non-arm64 DMG..."
+  echo "Detected Intel (x86_64). Looking for Intel (non-arm64) DMG..."
   DMG_FILE=$(find "$TEMP_DIR" -name "*.dmg" ! -name "*arm64*.dmg" -type f | head -1)
   if [ -z "$DMG_FILE" ]; then
-    echo "Error: No non-arm64 DMG file found in the zip!"
+    echo "Error: No Intel (non-arm64 DMG) file found in the zip!"
     rm -rf "$TEMP_DIR"
     exit 1
   fi


### PR DESCRIPTION
## Summary

This PR adds a macOS app installer script (`install_unsigned_macos_build.sh`) that streamlines the installation process for unsigned development builds of both Paratext 10 Studio and Platform.Bible applications.

## 🚀 Features

- **Two apps**: Automatically identifies and installs both Paratext 10 Studio and Platform.Bible apps
- **Pattern matching**: Uses arm64 DMG pattern to find the correct architecture builds

### Flexible Path Options
- **Default behavior**: Searches ~/Downloads for most recent app-macos zip files
- **Custom directory**: Search specified directory for app-macos zip files
- **Specific file**: Install exact zip file specified
- **Help**: Show usage instructions with --help flag

### Smart File Handling
- **Numbered duplicates**: Handles app-macos (1).zip, app-macos (2).zip, etc. automatically
- **Most recent download**: Uses ls -t to find the newest file when multiple exist
- **Validation**: Checks file existence, zip format, and directory structure

### macOS Security 
- **Quarantine removal**: Strips quarantine attributes to prevent Gatekeeper warnings
- **Code signing**: Applies ad-hoc signatures using codesign
- **Gatekeeper approval**: Attempts to add apps to system policy control

### Installation Process
1. **Extract**: Unzips archive to temporary directory
2. **Mount**: Attaches arm64 DMG file using hdiutil
3. **Install**: Copies .app bundle to /Applications (removes existing version first)
4. **Secure**: Removes quarantine and applies code signature
5. **Launch**: Opens the application automatically
6. **Cleanup**: Removes temporary files and unmounts DMG

## 🛡️ Error Handling

- Path validation (file/directory existence)
- Zip file format verification
- DMG mounting failure detection
- App bundle discovery in mounted volumes
- Code signing verification
- Installation success confirmation

## 🧪 Testing

The script has been thoroughly tested with:
- ✅ Paratext 10 Studio builds
- ✅ Platform.Bible builds
- ✅ Multiple file scenarios (numbered duplicates)
- ✅ All path option variations
- ✅ Error conditions and edge cases
- ✅ macOS Gatekeeper bypass functionality
- ✅ Apple Silicon ❌ NOT Intel x86

## 🎯 Benefits

- **Developer productivity**: One-command installation of development builds on macOS

## 🔧 Technical Details

- **Platform**: macOS-specific (uses hdiutil, codesign, xattr)
- **Dependencies**: Standard macOS utilities, no additional installations required
- **Location**: .erb/scripts/install_unsigned_macos_build.sh

This script reduces the friction involved in testing unsigned development builds by automating the installation workflow while compensating for macOS security requirements.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1653)
<!-- Reviewable:end -->
