### PR TITLE
remove cwd property from spawn and fork option apis

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5602,7 +5602,7 @@ declare module 'shared/models/create-process-privilege.model' {
     executionToken: ExtensionBasicData,
     command: string,
     args: readonly string[],
-    options: SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioPipe>,
+    options: Omit<SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioPipe>, 'cwd'>,
   ) => ChildProcessByStdio<Writable, Readable, Readable>;
   /**
    * Run {@link fork} to create a child process. The platform will automatically kill all child
@@ -5636,7 +5636,7 @@ declare module 'shared/models/create-process-privilege.model' {
     executionToken: ExtensionBasicData,
     modulePath: string,
     args?: readonly string[],
-    options?: ForkOptions,
+    options?: Omit<ForkOptions, 'cwd'>,
   ) => ChildProcess;
   /** Data about the operating system on which this process is running */
   export type OperatingSystemData = {

--- a/src/shared/models/create-process-privilege.model.ts
+++ b/src/shared/models/create-process-privilege.model.ts
@@ -58,7 +58,7 @@ export type PlatformSpawn = (
   executionToken: ExtensionBasicData,
   command: string,
   args: readonly string[],
-  options: SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioPipe>,
+  options: Omit<SpawnOptionsWithStdioTuple<StdioPipe, StdioPipe, StdioPipe>, 'cwd'>,
 ) => ChildProcessByStdio<Writable, Readable, Readable>;
 
 /**
@@ -93,7 +93,7 @@ export type PlatformFork = (
   executionToken: ExtensionBasicData,
   modulePath: string,
   args?: readonly string[],
-  options?: ForkOptions,
+  options?: Omit<ForkOptions, 'cwd'>,
 ) => ChildProcess;
 
 /** Data about the operating system on which this process is running */


### PR DESCRIPTION
I spent far too long trying to figure out why this didn't set the cwd:
```ts
  context.elevatedPrivileges.createProcess.spawn(
    context.executionToken,
    binaryPath,
    [],
    {stdio: [null, null, null], cwd: 'my-dir'}
  );
```

after finally looking at the source and noticing cwd was overriden, and then that there was a note on `PlatformSpawn` that said as much. Unfortunately the docs [here](https://github.com/paranext/paranext-core/blob/92180c2605fe3ab9e74373693b71b5d3b1d15c5f/lib/papi-dts/papi.d.ts#L5561C1-L5600C6) don't show up in vs code when hovering over `spawn`. After playing with the docs for a bit I couldn't figure out how to get the docs to show up when hovering over `spawn`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1654)
<!-- Reviewable:end -->
