### PR TITLE
Allow WebViews to reuse IDs to reuse state

### DIFF
--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -1351,10 +1351,17 @@ export const openWebView = async (
 
   // We didn't find an existing web view with the ID, so we need to create a new one.
 
-  // We want to create a new webview, so create a placeholder with a new ID to pass to the WebViewProvider
-  const newWebViewDefinition = {
+  // If a specific ID was provided, use that; otherwise, generate a new one
+  const webViewId =
+    !optionsDefaulted.existingId || optionsDefaulted.existingId === '?'
+      ? newGuid()
+      : optionsDefaulted.existingId;
+
+  // We want to create a new webview, so create a placeholder to pass to the WebViewProvider
+  const newWebViewDefinition: SavedWebViewDefinition = {
     webViewType,
-    id: newGuid(),
+    id: webViewId,
+    state: getFullWebViewStateById(webViewId),
   };
 
   return openOrReloadWebView(newWebViewDefinition, layout, {


### PR DESCRIPTION
Rolf is using WebView state to save Find history, and there is no way for him to actually reuse the history once the tab is closed and reopened as the code currently stands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1669)
<!-- Reviewable:end -->
