### PR TITLE
hide unimplemented check card menu entry

### DIFF
--- a/extensions/src/platform-scripture/src/checks/checks-side-panel/check-card.component.tsx
+++ b/extensions/src/platform-scripture/src/checks/checks-side-panel/check-card.component.tsx
@@ -140,7 +140,11 @@ function FocusedCheckDropdown({
           </span>
         </DropdownMenuItem>
         <DropdownMenuItem
-          className="tw-flex tw-flex-row"
+          /**
+           * This menu item is hidden until https://paratextstudio.atlassian.net/browse/PT-3309 gets
+           * implemented
+           */
+          className="tw-hidden"
           onClick={(e) => {
             e.stopPropagation();
             handleOpenSettingsAndInventories();


### PR DESCRIPTION
Hiding the "Open settings and inventories" menu entry on a Check card, as this is not implemented and needs UX to specify behavior first https://paratextstudio.atlassian.net/browse/PT-3309

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1688)
<!-- Reviewable:end -->
