### PR TITLE
Fixed BooksPresent setting sometimes being fewer than 123 characters because of how we were accessing it, fixed BooksPresent being settable

### DIFF
--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -290,6 +290,10 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         if (paratextSettingName == ProjectSettingsNames.PT_TEXT_DIRECTION)
             return scrText.RightToLeft ? "rtl" : "ltr";
 
+        // BooksPresent in Settings.xml isn't always 123 characters, but this way of getting it is always
+        if (paratextSettingName == ProjectSettingsNames.PT_BOOKS_PRESENT)
+            return scrText.BooksPresentSet.Books;
+
         if (
             scrText.Settings.ParametersDictionary.TryGetValue(
                 paratextSettingName,
@@ -349,6 +353,12 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         if (paratextSettingName == ProjectSettingsNames.PT_TEXT_DIRECTION)
             throw new Exception(
                 "Cannot set text direction this way. Must edit the language definition ldml file"
+            );
+
+        // BooksPresentSet is changed by adding and removing books, not setting the setting value
+        if (paratextSettingName == ProjectSettingsNames.PT_BOOKS_PRESENT)
+            throw new Exception(
+                "Cannot set BooksPresent this way. Must add or delete books in the project"
             );
 
         // Now actually write the setting


### PR DESCRIPTION
The way we were getting BooksPresent was giving the string directly from Settings.xml which apparently is not always the full 123 characters but [sometimes just a subset](https://discord.com/channels/1064938364597436416/1082713433524424734/1390247826440716379) (needs 0's appended at the end). Fixed by accessing using the proper way according to ParatextData.dll.

Adjusted based on [feedback from Paratext 9 team](https://discord.com/channels/892072317436448768/892072317885235261/1390331408513372212)
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1694)
<!-- Reviewable:end -->
