### PR TITLE
PT-3310: Implemented function to retrieve full extension data

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5882,17 +5882,30 @@ declare module 'shared/models/full-extension-data.model' {
    * visualization data that is useful for the extension marketplace
    */
   export type FullExtensionData = Readonly<
-    Omit<ExtensionManifest, 'name' | 'version'> & {
-      id: string;
-      currentVersion: string;
+    ExtensionManifest & {
+      /** Localized display name data used to visualize the extension name */
       displayName: LanguageStrings;
+      /** Localized short summary for the extension which is used as a sort of subtitle for extensions */
       shortSummary: LanguageStrings;
+      /** Localized descriptions for the extension to describe the functionality of the extension */
       description: LanguageStrings;
+      /** Extension icon object used to visualize the extension icon */
       icon: ExtensionIcon;
+      /** Locales that the extension supports which have been formatted to be in the BCP 47 format */
       locales: string[];
+      /** Supplied URL to find more information about the extension */
       moreInfoUrl: string;
+      /** Supplied URL to get support concerning the extension */
       supportUrl: string;
+      /**
+       * File size of the extension ZIP file for extension file validation. Can be `-1` if the
+       * extension ZIP could not be found.
+       */
       fileSize: number;
+      /**
+       * Generated hash codes for the extension ZIP file for extension file validation validation. Can
+       * be an empty object if the extension ZIP could not be found.
+       */
       hashcode: Record<string, string>;
     }
   >;

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5796,7 +5796,7 @@ declare module 'shared/models/create-process-privilege.model' {
     osData: OperatingSystemData;
   };
 }
-declare module 'shared/models/elevated-privileges-names.model' {
+declare module 'shared/models/elevated-privilege-names.model' {
   /** String constants that are listed in an extension's manifest.json to state needed privileges */
   export enum ElevatedPrivilegeNames {
     createProcess = 'createProcess',
@@ -5805,7 +5805,7 @@ declare module 'shared/models/elevated-privileges-names.model' {
   }
 }
 declare module 'extension-host/extension-types/extension-manifest.model' {
-  import { ElevatedPrivilegeNames } from 'shared/models/elevated-privileges-names.model';
+  import { ElevatedPrivilegeNames } from 'shared/models/elevated-privilege-names.model';
   /** Interface that stores the extension dependency information */
   export interface ExtensionDependency {
     /** Extension id of the given extension dependency */
@@ -5872,6 +5872,7 @@ declare module 'extension-host/extension-types/extension-manifest.model' {
 }
 declare module 'shared/models/manage-extensions-privilege.model' {
   import { ExtensionManifest } from 'extension-host/extension-types/extension-manifest.model';
+  import { LanguageStrings } from 'platform-bible-utils';
   /** Base64 encoded hash values */
   export type HashValues = Partial<{
     sha256: string;
@@ -5882,11 +5883,6 @@ declare module 'shared/models/manage-extensions-privilege.model' {
     extensionName: string;
     extensionVersion: string;
   };
-  /**
-   * Type storing localized strings for an extension field. Indexed by locale, values are localized
-   * strings in that language.
-   */
-  export type ExtensionLocalizedStrings = Record<string, string>;
   /** Interface that stores extension icon information */
   export interface ExtensionIcon {
     /** Path to the icon's file. Could be a URL */
@@ -5899,16 +5895,16 @@ declare module 'shared/models/manage-extensions-privilege.model' {
     isUrl: boolean;
   }
   /**
-   * Full image of the data of an extension including the additional extension marketplace
-   * visualization data
+   * Full set of descriptive metadata for an extension including the extension manifest and
+   * visualization data that is useful for the extension marketplace
    */
-  export type ExtensionData = Readonly<
+  export type FullExtensionData = Readonly<
     Omit<ExtensionManifest, 'name' | 'version'> & {
       id: string;
       currentVersion: string;
-      displayName: ExtensionLocalizedStrings;
-      shortSummary: ExtensionLocalizedStrings;
-      description: ExtensionLocalizedStrings;
+      displayName: LanguageStrings;
+      shortSummary: LanguageStrings;
+      description: LanguageStrings;
       icon: ExtensionIcon;
       locales: string[];
       moreInfoUrl: string;
@@ -5978,7 +5974,7 @@ declare module 'shared/models/manage-extensions-privilege.model' {
   /** Get full extension data for a specified list of extensions */
   export type GetExtensionsDataFunction = (
     extensionIds: ExtensionIdentifier[],
-  ) => Promise<ExtensionData[]>;
+  ) => Promise<FullExtensionData[]>;
   /** Functions needed to manage extensions */
   export type ManageExtensions = {
     /** Function to download an extension and enable it */

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5806,13 +5806,6 @@ declare module 'shared/models/elevated-privilege-names.model' {
 }
 declare module 'extension-host/extension-types/extension-manifest.model' {
   import { ElevatedPrivilegeNames } from 'shared/models/elevated-privilege-names.model';
-  /** Interface that stores the extension dependency information */
-  export interface ExtensionDependency {
-    /** Extension id of the given extension dependency */
-    id: string;
-    /** Version of the given extension dependency */
-    version: string;
-  }
   /** Information about an extension provided by the extension developer. */
   export type ExtensionManifest = {
     /** Name of the extension */
@@ -5863,26 +5856,16 @@ declare module 'extension-host/extension-types/extension-manifest.model' {
      */
     activationEvents: string[];
     /** List of extension dependencies required for this extension to work */
-    extensionDependencies?: ExtensionDependency[];
+    extensionDependencies?: Record<string, string>;
     /** Path to the JSON file that defines the display data this extension is adding */
     displayData?: string;
     /** Id of publisher who published this extension on the extension marketplace */
     publisher?: string;
   };
 }
-declare module 'shared/models/manage-extensions-privilege.model' {
+declare module 'shared/models/full-extension-data.model' {
   import { ExtensionManifest } from 'extension-host/extension-types/extension-manifest.model';
   import { LanguageStrings } from 'platform-bible-utils';
-  /** Base64 encoded hash values */
-  export type HashValues = Partial<{
-    sha256: string;
-    sha512: string;
-  }>;
-  /** Represents an extension that can be enabled or disabled */
-  export type ExtensionIdentifier = {
-    extensionName: string;
-    extensionVersion: string;
-  };
   /** Interface that stores extension icon information */
   export interface ExtensionIcon {
     /** Path to the icon's file. Could be a URL */
@@ -5913,6 +5896,19 @@ declare module 'shared/models/manage-extensions-privilege.model' {
       hashcode: Record<string, string>;
     }
   >;
+}
+declare module 'shared/models/manage-extensions-privilege.model' {
+  import { FullExtensionData } from 'shared/models/full-extension-data.model';
+  /** Base64 encoded hash values */
+  export type HashValues = Partial<{
+    sha256: string;
+    sha512: string;
+  }>;
+  /** Represents an extension that can be enabled or disabled */
+  export type ExtensionIdentifier = {
+    extensionName: string;
+    extensionVersion: string;
+  };
   /**
    * Represents all extensions that are installed. Note that packaged extensions cannot be disabled,
    * so they are implied to always be enabled.
@@ -5985,7 +5981,10 @@ declare module 'shared/models/manage-extensions-privilege.model' {
     disableExtension: DisableExtensionFunction;
     /** Function to retrieve details about all installed extensions */
     getInstalledExtensions: GetInstalledExtensionsFunction;
-    /** Function to retrieve full details about a list of installed or disabled extensions */
+    /**
+     * Function to retrieve descriptive metadata and visualization data for an extension. Useful for
+     * the extension marketplace.
+     */
     getExtensionsData: GetExtensionsDataFunction;
   };
 }

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5863,7 +5863,7 @@ declare module 'extension-host/extension-types/extension-manifest.model' {
      */
     activationEvents: string[];
     /** List of extension dependencies required for this extension to work */
-    extensionDependencies?: ExtensionDependency;
+    extensionDependencies?: ExtensionDependency[];
     /** Path to the JSON file that defines the display data this extension is adding */
     displayData?: string;
     /** Id of publisher who published this extension on the extension marketplace */
@@ -5902,10 +5902,6 @@ declare module 'shared/models/manage-extensions-privilege.model' {
    * Full image of the data of an extension including the additional extension marketplace
    * visualization data
    */
-  /**
-   * Full image of the data of an extension including the additional extension marketplace
-   * visualization data
-   */
   export type ExtensionData = Readonly<
     Omit<ExtensionManifest, 'name' | 'version'> & {
       id: string;
@@ -5918,7 +5914,7 @@ declare module 'shared/models/manage-extensions-privilege.model' {
       moreInfoUrl: string;
       supportUrl: string;
       fileSize: number;
-      hashcode: string;
+      hashcode: Record<string, string>;
     }
   >;
   /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5105,13 +5105,27 @@ declare module 'node/services/node-file-system.service' {
   /** File system calls from Node */
   import fs, { BigIntStats } from 'fs';
   import { Uri } from 'shared/data/file-system.model';
+  /** Type containing the buffer encoding strings for the `readFileText` function */
+  export type BufferEncoding =
+    | 'ascii'
+    | 'utf8'
+    | 'utf-8'
+    | 'utf16le'
+    | 'utf-16le'
+    | 'ucs2'
+    | 'ucs-2'
+    | 'base64'
+    | 'base64url'
+    | 'latin1'
+    | 'binary'
+    | 'hex';
   /**
    * Read a text file
    *
    * @param uri URI of file
    * @returns Promise that resolves to the contents of the file
    */
-  export function readFileText(uri: Uri): Promise<string>;
+  export function readFileText(uri: Uri, encoding?: BufferEncoding): Promise<string>;
   /**
    * Read a binary file
    *
@@ -5119,13 +5133,6 @@ declare module 'node/services/node-file-system.service' {
    * @returns Promise that resolves to the contents of the file
    */
   export function readFileBinary(uri: Uri): Promise<Buffer>;
-  /**
-   * Read a file and encode with Base 64
-   *
-   * @param uri URI of file
-   * @returns Promise that resolves to the contents of the file
-   */
-  export function readFileBase64(uri: Uri): Promise<string>;
   /**
    * Write data to a file
    *
@@ -5789,8 +5796,16 @@ declare module 'shared/models/create-process-privilege.model' {
     osData: OperatingSystemData;
   };
 }
+declare module 'shared/models/elevated-privileges-names.model' {
+  /** String constants that are listed in an extension's manifest.json to state needed privileges */
+  export enum ElevatedPrivilegeNames {
+    createProcess = 'createProcess',
+    manageExtensions = 'manageExtensions',
+    handleUri = 'handleUri',
+  }
+}
 declare module 'extension-host/extension-types/extension-manifest.model' {
-  import { ElevatedPrivilegeNames } from 'shared/models/elevated-privileges.model';
+  import { ElevatedPrivilegeNames } from 'shared/models/elevated-privileges-names.model';
   /** Interface that stores the extension dependency information */
   export interface ExtensionDependency {
     /** Extension id of the given extension dependency */
@@ -5883,6 +5898,10 @@ declare module 'shared/models/manage-extensions-privilege.model' {
     /** True if this icon was submitted as a URL, else false. */
     isUrl: boolean;
   }
+  /**
+   * Full image of the data of an extension including the additional extension marketplace
+   * visualization data
+   */
   /**
    * Full image of the data of an extension including the additional extension marketplace
    * visualization data
@@ -6033,15 +6052,9 @@ declare module 'shared/models/handle-uri-privilege.model' {
   };
 }
 declare module 'shared/models/elevated-privileges.model' {
-  import { CreateProcess } from 'shared/models/create-process-privilege.model';
-  import { ManageExtensions } from 'shared/models/manage-extensions-privilege.model';
-  import { HandleUri } from 'shared/models/handle-uri-privilege.model';
-  /** String constants that are listed in an extension's manifest.json to state needed privileges */
-  export enum ElevatedPrivilegeNames {
-    createProcess = 'createProcess',
-    manageExtensions = 'manageExtensions',
-    handleUri = 'handleUri',
-  }
+  import type { CreateProcess } from 'shared/models/create-process-privilege.model';
+  import type { ManageExtensions } from 'shared/models/manage-extensions-privilege.model';
+  import type { HandleUri } from 'shared/models/handle-uri-privilege.model';
   /** Object that contains properties with special capabilities for extensions that required them */
   export type ElevatedPrivileges = {
     /** Functions that can be run to start new processes */

--- a/src/extension-host/extension-types/display-data-contribution.model.ts
+++ b/src/extension-host/extension-types/display-data-contribution.model.ts
@@ -1,0 +1,31 @@
+/**
+ * Interface for the contents of an extension's localized display data.
+ *
+ * This data is pulled from an extension's `displayData.json` file. The path of that file is
+ * specified in the extension's `manifest.json` file.
+ */
+export interface DisplayDataContribution {
+  /** Path to the extension's icon file. */
+  icon: string;
+
+  /** URL to access more information about the extension, such as developer's website. */
+  moreInfoUrl: string;
+
+  /** URL to access a support page for this extension. */
+  supportUrl: string;
+
+  /** Localized strings, indexed by locale. */
+  localizedDisplayInfo: Record<string, LocalizedDisplayInfo>;
+}
+
+/** Interface for localized display data of an extension. */
+export interface LocalizedDisplayInfo {
+  /** Name of the extension to be displayed in user's language. */
+  displayName: string;
+
+  /** Short summary of the extension to be displayed in user's language. */
+  shortSummary: string;
+
+  /** Path to localized description file. */
+  description: string;
+}

--- a/src/extension-host/extension-types/extension-activation-context.model.ts
+++ b/src/extension-host/extension-types/extension-activation-context.model.ts
@@ -3,7 +3,7 @@ import { UnsubscriberAsyncList } from 'platform-bible-utils';
 import { ElevatedPrivileges } from '@shared/models/elevated-privileges.model';
 // Needed for documentation links to work
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { ElevatedPrivilegeNames } from '@shared/models/elevated-privileges-names.model';
+import { ElevatedPrivilegeNames } from '@shared/models/elevated-privilege-names.model';
 
 /** An object of this type is passed into `activate()` for each extension during initialization */
 export type ExecutionActivationContext = {

--- a/src/extension-host/extension-types/extension-activation-context.model.ts
+++ b/src/extension-host/extension-types/extension-activation-context.model.ts
@@ -1,11 +1,9 @@
 import { ExecutionToken } from '@node/models/execution-token.model';
 import { UnsubscriberAsyncList } from 'platform-bible-utils';
-import {
-  ElevatedPrivileges,
-  // Needed for documentation links to work
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  ElevatedPrivilegeNames,
-} from '@shared/models/elevated-privileges.model';
+import { ElevatedPrivileges } from '@shared/models/elevated-privileges.model';
+// Needed for documentation links to work
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { ElevatedPrivilegeNames } from '@shared/models/elevated-privileges-names.model';
 
 /** An object of this type is passed into `activate()` for each extension during initialization */
 export type ExecutionActivationContext = {

--- a/src/extension-host/extension-types/extension-info.model.ts
+++ b/src/extension-host/extension-types/extension-info.model.ts
@@ -1,0 +1,17 @@
+import { Uri } from '@shared/data/file-system.model';
+import { ExtensionManifest } from './extension-manifest.model';
+
+/**
+ * Information about an extension and extra metadata about it that we generate
+ *
+ * This is a transformed and frozen version of the extension's {@link ExtensionManifest}
+ */
+export type ExtensionInfo = Readonly<
+  ExtensionManifest & {
+    /**
+     * Uri to this extension's directory. Not provided in actual manifest, but added while parsing
+     * the manifest
+     */
+    dirUri: Uri;
+  }
+>;

--- a/src/extension-host/extension-types/extension-manifest.model.ts
+++ b/src/extension-host/extension-types/extension-manifest.model.ts
@@ -58,7 +58,7 @@ export type ExtensionManifest = {
    */
   activationEvents: string[];
   /** List of extension dependencies required for this extension to work */
-  extensionDependencies?: ExtensionDependency;
+  extensionDependencies?: ExtensionDependency[];
   /** Path to the JSON file that defines the display data this extension is adding */
   displayData?: string;
   /** Id of publisher who published this extension on the extension marketplace */

--- a/src/extension-host/extension-types/extension-manifest.model.ts
+++ b/src/extension-host/extension-types/extension-manifest.model.ts
@@ -1,5 +1,13 @@
 import { ElevatedPrivilegeNames } from '@shared/models/elevated-privileges.model';
 
+/** Interface that stores the extension dependency information */
+export interface ExtensionDependency {
+  /** Extension id of the given extension dependency */
+  id: string;
+  /** Version of the given extension dependency */
+  version: string;
+}
+
 /** Information about an extension provided by the extension developer. */
 export type ExtensionManifest = {
   /** Name of the extension */
@@ -49,6 +57,10 @@ export type ExtensionManifest = {
    * implemented.
    */
   activationEvents: string[];
+  /** List of extension dependencies required for this extension to work */
+  extensionDependencies?: ExtensionDependency;
+  /** Path to the JSON file that defines the display data this extension is adding */
+  displayData?: string;
   /** Id of publisher who published this extension on the extension marketplace */
   publisher?: string;
 };

--- a/src/extension-host/extension-types/extension-manifest.model.ts
+++ b/src/extension-host/extension-types/extension-manifest.model.ts
@@ -1,13 +1,5 @@
 import { ElevatedPrivilegeNames } from '@shared/models/elevated-privilege-names.model';
 
-/** Interface that stores the extension dependency information */
-export interface ExtensionDependency {
-  /** Extension id of the given extension dependency */
-  id: string;
-  /** Version of the given extension dependency */
-  version: string;
-}
-
 /** Information about an extension provided by the extension developer. */
 export type ExtensionManifest = {
   /** Name of the extension */
@@ -58,7 +50,7 @@ export type ExtensionManifest = {
    */
   activationEvents: string[];
   /** List of extension dependencies required for this extension to work */
-  extensionDependencies?: ExtensionDependency[];
+  extensionDependencies?: Record<string, string>;
   /** Path to the JSON file that defines the display data this extension is adding */
   displayData?: string;
   /** Id of publisher who published this extension on the extension marketplace */

--- a/src/extension-host/extension-types/extension-manifest.model.ts
+++ b/src/extension-host/extension-types/extension-manifest.model.ts
@@ -1,4 +1,4 @@
-import { ElevatedPrivilegeNames } from '@shared/models/elevated-privileges.model';
+import { ElevatedPrivilegeNames } from '@shared/models/elevated-privileges-names.model';
 
 /** Interface that stores the extension dependency information */
 export interface ExtensionDependency {

--- a/src/extension-host/extension-types/extension-manifest.model.ts
+++ b/src/extension-host/extension-types/extension-manifest.model.ts
@@ -1,4 +1,4 @@
-import { ElevatedPrivilegeNames } from '@shared/models/elevated-privileges-names.model';
+import { ElevatedPrivilegeNames } from '@shared/models/elevated-privilege-names.model';
 
 /** Interface that stores the extension dependency information */
 export interface ExtensionDependency {

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -978,6 +978,10 @@ async function readExtensionDataFromZip(extensionUri: string): Promise<Extension
 
           // And return the language key with its corresponding description
           return [locale, descriptionString];
+          // Need to be able to return something so returns undefined filtered out in the later lines
+          // eslint-disable-next-line no-else-return
+        } else {
+          return undefined;
         }
       }),
     );
@@ -1211,6 +1215,10 @@ async function getExtensionsData(extensions: ExtensionIdentifier[]): Promise<Ext
       if (await nodeFS.getStats(extensionUri)) {
         return readExtensionDataFromZip(extensionUri);
       }
+
+      // Need to be able to return something so returns undefined filtered out in the later lines
+      // eslint-disable-next-line no-else-return
+      return undefined;
     }),
   );
   return extensionsData.filter((value) => !!value);

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -876,9 +876,9 @@ async function parseExtensionData(
 
   // Generate zip file hash if the zip file was found
   let extensionBuffer: Buffer | undefined;
-  if (disabledExtensionStats) {
+  if (disabledExtensionStats !== undefined) {
     extensionBuffer = await nodeFS.readFileBinary(disabledExtensionUri);
-  } else if (enabledExtensionStats) {
+  } else if (enabledExtensionStats !== undefined) {
     extensionBuffer = await nodeFS.readFileBinary(enabledExtensionUri);
   }
   const hashcode = extensionBuffer
@@ -888,7 +888,7 @@ async function parseExtensionData(
   // Creates an object whose keys are the language abbreviations (en, fr, es, ...)
   // and values are the display names in those languages
   let displayName: ExtensionLocalizedStrings = {};
-  if (displayData) {
+  if (displayData !== undefined) {
     displayName = Object.fromEntries(
       Object.entries(displayData.localizedDisplayInfo).map(([locale, data]) => {
         return [locale, data.displayName];
@@ -899,7 +899,7 @@ async function parseExtensionData(
   // Creates an object whose keys are the language abbreviations (en, fr, es, ...)
   // and values are the summaries in those languages
   let shortSummary: ExtensionLocalizedStrings = {};
-  if (displayData) {
+  if (displayData !== undefined) {
     shortSummary = Object.fromEntries(
       Object.entries(displayData.localizedDisplayInfo).map(([locale, data]) => {
         return [locale, data.shortSummary];
@@ -909,7 +909,7 @@ async function parseExtensionData(
 
   // Converts any two-digit locales to three-digit locales
   let locales: string[] = [];
-  if (localizedStrings) {
+  if (localizedStrings !== undefined) {
     locales = Object.keys(localizedStrings.localizedStrings).map((locale) => locale);
   }
 

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -41,10 +41,8 @@ import {
 import { LogError } from '@shared/log-error.model';
 import { ExtensionManifest } from '@extension-host/extension-types/extension-manifest.model';
 import { PLATFORM_NAMESPACE } from '@shared/data/platform.data';
-import {
-  ElevatedPrivilegeNames,
-  ElevatedPrivileges,
-} from '@shared/models/elevated-privileges.model';
+import { ElevatedPrivileges } from '@shared/models/elevated-privileges.model';
+import { ElevatedPrivilegeNames } from '@shared/models/elevated-privileges-names.model';
 import { generateHashFromBuffer } from '@node/utils/crypto-util';
 import {
   ExtensionIdentifier,
@@ -1062,7 +1060,7 @@ async function readExtensionDataFromFolder(extensionInfo: ExtensionInfo): Promis
     icon = {
       filepath: displayData.icon,
       filetype: path.extname(fullIconFilepath).substring(1), // Remove the first `.` to just extract the file extension
-      data: isUrl ? '' : await nodeFS.readFileBase64(fullIconFilepath),
+      data: isUrl ? '' : await nodeFS.readFileText(fullIconFilepath, 'base64'),
       isUrl,
     };
   }

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -879,7 +879,7 @@ async function parseExtensionData(
   } else if (enabledExtensionStats !== undefined) {
     extensionBuffer = await nodeFS.readFileBinary(enabledExtensionUri);
   }
-  const hashcode = extensionBuffer
+  const sha512Hashcode = extensionBuffer
     ? generateHashFromBuffer('sha512', 'base64', extensionBuffer)
     : '';
 
@@ -924,7 +924,7 @@ async function parseExtensionData(
     moreInfoUrl: displayData?.moreInfoUrl ?? '',
     supportUrl: displayData?.supportUrl ?? '',
     fileSize: fileSize ?? -1,
-    hashcode,
+    hashcode: { sha512: sha512Hashcode },
   };
 }
 

--- a/src/extension-host/utils/extension-data.util.ts
+++ b/src/extension-host/utils/extension-data.util.ts
@@ -1,0 +1,342 @@
+import * as nodeFS from '@node/services/node-file-system.service';
+import { LanguageStrings, LocalizedStringDataContribution } from 'platform-bible-utils';
+import { ExtensionIcon, FullExtensionData } from '@shared/models/full-extension-data.model';
+import logger from '@shared/services/logger.service';
+import path from 'path';
+import { ExtensionManifest } from '@extension-host/extension-types/extension-manifest.model';
+import { DisplayDataContribution } from '@extension-host/extension-types/display-data-contribution.model';
+import JSZip from 'jszip';
+import { ExtensionInfo } from '@extension-host/extension-types/extension-info.model';
+import { joinUriPaths } from '@node/utils/util';
+import { generateHashFromBuffer } from '@node/utils/crypto-util';
+import { transformLocalizedStringDataToCanonicalLocales } from '@shared/utils/localized-strings-document-combiner';
+
+/**
+ * Name of the file describing the extension and its capabilities. Provided by the extension
+ * developer
+ */
+export const EXTENSION_MANIFEST_FILE_NAME = 'manifest.json';
+
+/**
+ * Returns a URI we can use with `nodeFS` calls that is an expected filename given a base URI,
+ * extension name, and extension version. This is not that useful for packaged extensions but is
+ * important for all other extensions, both enabled and disabled.
+ */
+export function getExtensionUri(
+  baseUri: string,
+  extensionName: string,
+  extensionVersion: string,
+): string {
+  return `${baseUri}/${extensionName}_${extensionVersion}.zip`;
+}
+
+async function parseExtensionData(
+  displayData: DisplayDataContribution | undefined,
+  localizedStrings: LocalizedStringDataContribution | undefined,
+  icon: ExtensionIcon,
+  description: LanguageStrings,
+  manifest: ExtensionManifest,
+  disabledExtensionsUri: string,
+  installedExtensionsUri: string,
+): Promise<FullExtensionData> {
+  // Gets the file size and hash from the local zip file
+  const disabledExtensionUri = getExtensionUri(
+    disabledExtensionsUri,
+    manifest.name,
+    manifest.version,
+  );
+  const enabledExtensionUri = getExtensionUri(
+    installedExtensionsUri,
+    manifest.name,
+    manifest.version,
+  );
+  // Find the file size of the installed extension zip file if found
+  const disabledExtensionStats = await nodeFS.getStats(disabledExtensionUri);
+  const enabledExtensionStats = await nodeFS.getStats(enabledExtensionUri);
+  const fileSize = Number(disabledExtensionStats?.size ?? enabledExtensionStats?.size ?? -1);
+
+  // Generate zip file hash if the zip file was found
+  let extensionBuffer: Buffer | undefined;
+  if (disabledExtensionStats !== undefined) {
+    extensionBuffer = await nodeFS.readFileBinary(disabledExtensionUri);
+  } else if (enabledExtensionStats !== undefined) {
+    extensionBuffer = await nodeFS.readFileBinary(enabledExtensionUri);
+  }
+  const sha512Hashcode = extensionBuffer
+    ? generateHashFromBuffer('sha512', 'base64', extensionBuffer)
+    : '';
+
+  // Creates an object whose keys are the language abbreviations (en, fr, es, ...)
+  // and values are the display names in those languages
+  let displayName: LanguageStrings = {};
+  if (displayData !== undefined) {
+    displayName = Object.fromEntries(
+      Object.entries(displayData.localizedDisplayInfo).map(([locale, data]) => {
+        return [locale, data.displayName];
+      }),
+    );
+  }
+
+  // Creates an object whose keys are the language abbreviations (en, fr, es, ...)
+  // and values are the summaries in those languages
+  let shortSummary: LanguageStrings = {};
+  if (displayData !== undefined) {
+    shortSummary = Object.fromEntries(
+      Object.entries(displayData.localizedDisplayInfo).map(([locale, data]) => {
+        return [locale, data.shortSummary];
+      }),
+    );
+  }
+
+  // Converts any two-digit locales to three-digit locales
+  let locales: string[] = [];
+  if (localizedStrings !== undefined) {
+    // First transforms the localized strings struct to canonical locales
+    const transformedLocalizedStrings =
+      transformLocalizedStringDataToCanonicalLocales(localizedStrings);
+    locales = Object.keys(transformedLocalizedStrings.localizedStrings ?? {});
+  }
+
+  // We can now create and return a struct containing the extracted data
+  return {
+    ...manifest,
+    id: manifest.name,
+    currentVersion: manifest.version,
+    displayName,
+    shortSummary,
+    description,
+    icon,
+    locales,
+    moreInfoUrl: displayData?.moreInfoUrl ?? '',
+    supportUrl: displayData?.supportUrl ?? '',
+    fileSize: fileSize ?? -1,
+    hashcode: { sha512: sha512Hashcode },
+  };
+}
+
+export async function readExtensionDataFromZip(
+  extensionUri: string,
+  disabledExtensionsUri: string,
+  installedExtensionsUri: string,
+): Promise<FullExtensionData | undefined> {
+  let zip: JSZip;
+  try {
+    const extensionZipData: Buffer = await nodeFS.readFileBinary(extensionUri);
+    zip = await JSZip.loadAsync(extensionZipData);
+  } catch {
+    return undefined;
+  }
+
+  const manifestFile = zip.file(EXTENSION_MANIFEST_FILE_NAME);
+  // If the manifest file does not exist then returns undefined since can't really get any more info
+  if (!manifestFile) {
+    return undefined;
+  }
+  // Need to assert type to be ExtensionManifest for the manifest.json
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  const manifest = JSON.parse(await manifestFile.async('string')) as ExtensionManifest;
+
+  // Extract the localized strings of extension info, to determine supported languages.
+  let localizedStrings: LocalizedStringDataContribution | undefined;
+  if (manifest.localizedStrings) {
+    const localizedStringsFile = zip.file(manifest.localizedStrings);
+    if (localizedStringsFile) {
+      try {
+        // Type assertion to appropriate form of the localized strings
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        localizedStrings = JSON.parse(
+          await localizedStringsFile.async('string'),
+        ) as LocalizedStringDataContribution;
+      } catch {
+        logger.warn(
+          `Could not read localized strings file '${manifest.localizedStrings}' for extension '${manifest.name}!'`,
+        );
+      }
+    }
+  }
+
+  // Extract the localized display data, for description/display name/summary/etc.
+  let displayData: DisplayDataContribution | undefined;
+  if (manifest.displayData) {
+    const displayDataFile = zip.file(manifest.displayData);
+    if (displayDataFile) {
+      try {
+        // Type assertion to appropriate form of the localized display data
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        displayData = JSON.parse(await displayDataFile.async('string')) as DisplayDataContribution;
+      } catch {
+        logger.warn(
+          `Could not read display data file '${manifest.displayData}' for extension '${manifest.name}!'`,
+        );
+      }
+    }
+  }
+
+  // Creates an object whose keys are the language abbreviations (en, fr, es, ...)
+  // and values are the contents of the files found in the locale's "description" field
+  let description: LanguageStrings = {};
+  if (displayData !== undefined) {
+    const resolvedDescriptionEntries = await Promise.all(
+      Object.entries(displayData.localizedDisplayInfo).map(async ([locale, data]) => {
+        const descriptionFile = zip.file(data.description);
+        if (descriptionFile) {
+          // Now we can read that description to a string
+          let descriptionString = '';
+          try {
+            descriptionString = await descriptionFile.async('string');
+          } catch {
+            logger.warn(
+              `Could not read '${locale}' description file '${data.description}' for extension '${manifest.name}!'`,
+            );
+            return undefined;
+          }
+          // Now we can read that description to a string
+
+          // And return the language key with its corresponding description
+          return [locale, descriptionString];
+          // Need to be able to return something so returns undefined filtered out in the later lines
+          // eslint-disable-next-line no-else-return
+        } else {
+          return undefined;
+        }
+      }),
+    );
+    description = Object.fromEntries(resolvedDescriptionEntries.filter((value) => !!value));
+  }
+
+  // Retrieves the extension icon
+  let icon: ExtensionIcon = { filepath: '', filetype: '', data: '', isUrl: false };
+  if (displayData?.icon) {
+    const isUrl = URL.canParse(displayData.icon);
+    const iconFile = zip.file(displayData.icon);
+    let iconData = '';
+    if (!isUrl && iconFile) {
+      try {
+        iconData = await iconFile.async('base64');
+      } catch {
+        logger.warn(
+          `Could not read icon file '${displayData.icon}' for extension '${manifest.name}!'`,
+        );
+      }
+    }
+
+    // Read the icon file into a buffer of bytes.
+    icon = {
+      filepath: displayData.icon,
+      filetype: path.extname(displayData.icon).substring(1), // Remove the first `.` to just extract the file extension
+      data: iconData,
+      isUrl,
+    };
+  }
+
+  return parseExtensionData(
+    displayData,
+    localizedStrings,
+    icon,
+    description,
+    manifest,
+    disabledExtensionsUri,
+    installedExtensionsUri,
+  );
+}
+
+export async function readExtensionDataFromFolder(
+  extensionInfo: ExtensionInfo,
+  disabledExtensionsUri: string,
+  installedExtensionsUri: string,
+): Promise<FullExtensionData> {
+  const folderUri = extensionInfo.dirUri;
+  // Extract the localized strings of extension info, to determine supported languages.
+  let localizedStrings: LocalizedStringDataContribution | undefined;
+  if (extensionInfo.localizedStrings) {
+    try {
+      // Type assertion to appropriate form of the localized strings
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      localizedStrings = JSON.parse(
+        await nodeFS.readFileText(joinUriPaths(folderUri, extensionInfo.localizedStrings)),
+      ) as LocalizedStringDataContribution;
+    } catch {
+      logger.warn(
+        `Could not read localized strings file '${extensionInfo.localizedStrings}' for extension '${extensionInfo.name}!'`,
+      );
+    }
+  }
+
+  // Extract the localized display data, for description/display name/summary/etc.
+  let displayData: DisplayDataContribution | undefined;
+  if (extensionInfo.displayData) {
+    try {
+      // Type assertion to appropriate form of the localized display data
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      displayData = JSON.parse(
+        await nodeFS.readFileText(joinUriPaths(folderUri, extensionInfo.displayData)),
+      ) as DisplayDataContribution;
+    } catch {
+      logger.warn(
+        `Could not read display data file '${extensionInfo.displayData}' for extension '${extensionInfo.name}!'`,
+      );
+    }
+  }
+
+  // Creates an object whose keys are the language abbreviations (en, fr, es, ...)
+  // and values are the contents of the files found in the locale's "description" field
+  let description: LanguageStrings = {};
+  if (displayData !== undefined) {
+    const resolvedDescriptionEntries = await Promise.all(
+      Object.entries(displayData.localizedDisplayInfo).map(async ([locale, data]) => {
+        // Construct the path to the description file
+        const descriptionPath = joinUriPaths(folderUri, data.description);
+
+        // Now we can read that description to a string
+        let descriptionString = '';
+        try {
+          descriptionString = await nodeFS.readFileText(descriptionPath);
+        } catch {
+          logger.warn(
+            `Could not read '${locale}' description file '${descriptionPath}' for extension '${extensionInfo.name}!'`,
+          );
+          return undefined;
+        }
+
+        // And return the language key with its corresponding description
+        return [locale, descriptionString];
+      }),
+    );
+    description = Object.fromEntries(resolvedDescriptionEntries.filter((value) => !!value));
+  }
+
+  // Retrieves the extension icon
+  let icon: ExtensionIcon = { filepath: '', filetype: '', data: '', isUrl: false };
+  if (displayData?.icon) {
+    const isUrl = URL.canParse(displayData.icon);
+    const fullIconFilepath = isUrl ? displayData.icon : joinUriPaths(folderUri, displayData.icon);
+    let iconData = '';
+    if (!isUrl) {
+      try {
+        iconData = await nodeFS.readFileText(fullIconFilepath, 'base64');
+      } catch {
+        logger.warn(
+          `Could not read icon file '${fullIconFilepath}' for extension '${extensionInfo.name}!'`,
+        );
+      }
+    }
+
+    // Read the icon file into a buffer of bytes.
+    icon = {
+      filepath: displayData.icon,
+      filetype: path.extname(fullIconFilepath).substring(1), // Remove the first `.` to just extract the file extension
+      data: isUrl ? '' : iconData,
+      isUrl,
+    };
+  }
+
+  return parseExtensionData(
+    displayData,
+    localizedStrings,
+    icon,
+    description,
+    extensionInfo,
+    disabledExtensionsUri,
+    installedExtensionsUri,
+  );
+}

--- a/src/extension-host/utils/extension-data.util.ts
+++ b/src/extension-host/utils/extension-data.util.ts
@@ -72,7 +72,7 @@ async function parseExtensionData(
   if (displayData !== undefined) {
     displayName = Object.fromEntries(
       Object.entries(displayData.localizedDisplayInfo).map(([locale, data]) => {
-        return [locale, data.displayName];
+        return [Intl.getCanonicalLocales(locale)[0], data.displayName];
       }),
     );
   }
@@ -83,7 +83,7 @@ async function parseExtensionData(
   if (displayData !== undefined) {
     shortSummary = Object.fromEntries(
       Object.entries(displayData.localizedDisplayInfo).map(([locale, data]) => {
-        return [locale, data.shortSummary];
+        return [Intl.getCanonicalLocales(locale)[0], data.shortSummary];
       }),
     );
   }
@@ -100,8 +100,6 @@ async function parseExtensionData(
   // We can now create and return a struct containing the extracted data
   return {
     ...manifest,
-    id: manifest.name,
-    currentVersion: manifest.version,
     displayName,
     shortSummary,
     description,
@@ -193,7 +191,7 @@ export async function readExtensionDataFromZip(
           // Now we can read that description to a string
 
           // And return the language key with its corresponding description
-          return [locale, descriptionString];
+          return [Intl.getCanonicalLocales(locale)[0], descriptionString];
           // Need to be able to return something so returns undefined filtered out in the later lines
           // eslint-disable-next-line no-else-return
         } else {
@@ -299,7 +297,7 @@ export async function readExtensionDataFromFolder(
         }
 
         // And return the language key with its corresponding description
-        return [locale, descriptionString];
+        return [Intl.getCanonicalLocales(locale)[0], descriptionString];
       }),
     );
     description = Object.fromEntries(resolvedDescriptionEntries.filter((value) => !!value));

--- a/src/node/services/node-file-system.service.ts
+++ b/src/node/services/node-file-system.service.ts
@@ -6,6 +6,21 @@ import { Uri } from '@shared/data/file-system.model';
 import { getPathFromUri, joinUriPaths } from '@node/utils/util';
 import { groupBy } from 'platform-bible-utils';
 
+/** Type containing the buffer encoding strings for the `readFileText` function */
+export type BufferEncoding =
+  | 'ascii'
+  | 'utf8'
+  | 'utf-8'
+  | 'utf16le'
+  | 'utf-16le'
+  | 'ucs2'
+  | 'ucs-2'
+  | 'base64'
+  | 'base64url'
+  | 'latin1'
+  | 'binary'
+  | 'hex';
+
 /**
  * Read a text file
  *
@@ -14,8 +29,8 @@ import { groupBy } from 'platform-bible-utils';
  */
 // TODO: Provide options or some other way to allow callers to the URI isn't pointing outside of
 // some expected location (e.g., an extension file's URI doesn't point outside of the extension dir)
-export async function readFileText(uri: Uri): Promise<string> {
-  return fs.promises.readFile(getPathFromUri(uri), 'utf8');
+export async function readFileText(uri: Uri, encoding: BufferEncoding = 'utf8'): Promise<string> {
+  return fs.promises.readFile(getPathFromUri(uri), encoding);
 }
 
 /**
@@ -26,16 +41,6 @@ export async function readFileText(uri: Uri): Promise<string> {
  */
 export async function readFileBinary(uri: Uri): Promise<Buffer> {
   return fs.promises.readFile(getPathFromUri(uri));
-}
-
-/**
- * Read a file and encode with Base 64
- *
- * @param uri URI of file
- * @returns Promise that resolves to the contents of the file
- */
-export async function readFileBase64(uri: Uri): Promise<string> {
-  return fs.promises.readFile(getPathFromUri(uri), { encoding: 'base64' });
 }
 
 /**

--- a/src/node/services/node-file-system.service.ts
+++ b/src/node/services/node-file-system.service.ts
@@ -29,6 +29,16 @@ export async function readFileBinary(uri: Uri): Promise<Buffer> {
 }
 
 /**
+ * Read a file and encode with Base 64
+ *
+ * @param uri URI of file
+ * @returns Promise that resolves to the contents of the file
+ */
+export async function readFileBase64(uri: Uri): Promise<string> {
+  return fs.promises.readFile(getPathFromUri(uri), { encoding: 'base64' });
+}
+
+/**
  * Write data to a file
  *
  * @param uri URI of file

--- a/src/shared/models/elevated-privilege-names.model.ts
+++ b/src/shared/models/elevated-privilege-names.model.ts
@@ -1,4 +1,4 @@
-// NOTE: This was moved to it's own type file to avoid circular dependencies:
+// NOTE: This was moved to its own type file to avoid circular dependencies:
 // `manage-extension-privilege.model.ts` > `extension-manifest.model.ts` > `elevated-privileges-names.model.ts`
 // > `manage-extension-privilege.model.ts`
 

--- a/src/shared/models/elevated-privileges-names.model.ts
+++ b/src/shared/models/elevated-privileges-names.model.ts
@@ -1,0 +1,10 @@
+// NOTE: This was moved to it's own type file to avoid circular dependencies:
+// `manage-extension-privilege.model.ts` > `extension-manifest.model.ts` > `elevated-privileges-names.model.ts`
+// > `manage-extension-privilege.model.ts`
+
+/** String constants that are listed in an extension's manifest.json to state needed privileges */
+export enum ElevatedPrivilegeNames {
+  createProcess = 'createProcess',
+  manageExtensions = 'manageExtensions',
+  handleUri = 'handleUri',
+}

--- a/src/shared/models/elevated-privileges.model.ts
+++ b/src/shared/models/elevated-privileges.model.ts
@@ -1,13 +1,6 @@
-import { CreateProcess } from '@shared/models/create-process-privilege.model';
-import { ManageExtensions } from '@shared/models/manage-extensions-privilege.model';
-import { HandleUri } from '@shared/models/handle-uri-privilege.model';
-
-/** String constants that are listed in an extension's manifest.json to state needed privileges */
-export enum ElevatedPrivilegeNames {
-  createProcess = 'createProcess',
-  manageExtensions = 'manageExtensions',
-  handleUri = 'handleUri',
-}
+import type { CreateProcess } from '@shared/models/create-process-privilege.model';
+import type { ManageExtensions } from '@shared/models/manage-extensions-privilege.model';
+import type { HandleUri } from '@shared/models/handle-uri-privilege.model';
 
 /** Object that contains properties with special capabilities for extensions that required them */
 export type ElevatedPrivileges = {

--- a/src/shared/models/full-extension-data.model.ts
+++ b/src/shared/models/full-extension-data.model.ts
@@ -33,9 +33,15 @@ export type FullExtensionData = Readonly<
     moreInfoUrl: string;
     /** Supplied URL to get support concerning the extension */
     supportUrl: string;
-    /** File size of the extension ZIP file for extension file validation */
+    /**
+     * File size of the extension ZIP file for extension file validation. Can be `-1` if the
+     * extension ZIP could not be found.
+     */
     fileSize: number;
-    /** Generated hash codes for the extension ZIP file for extension file validation validation */
+    /**
+     * Generated hash codes for the extension ZIP file for extension file validation validation. Can
+     * be an empty object if the extension ZIP could not be found.
+     */
     hashcode: Record<string, string>;
   }
 >;

--- a/src/shared/models/full-extension-data.model.ts
+++ b/src/shared/models/full-extension-data.model.ts
@@ -18,17 +18,24 @@ export interface ExtensionIcon {
  * visualization data that is useful for the extension marketplace
  */
 export type FullExtensionData = Readonly<
-  Omit<ExtensionManifest, 'name' | 'version'> & {
-    id: string;
-    currentVersion: string;
+  ExtensionManifest & {
+    /** Localized display name data used to visualize the extension name */
     displayName: LanguageStrings;
+    /** Localized short summary for the extension which is used as a sort of subtitle for extensions */
     shortSummary: LanguageStrings;
+    /** Localized descriptions for the extension to describe the functionality of the extension */
     description: LanguageStrings;
+    /** Extension icon object used to visualize the extension icon */
     icon: ExtensionIcon;
+    /** Locales that the extension supports which have been formatted to be in the BCP 47 format */
     locales: string[];
+    /** Supplied URL to find more information about the extension */
     moreInfoUrl: string;
+    /** Supplied URL to get support concerning the extension */
     supportUrl: string;
+    /** File size of the extension ZIP file for extension file validation */
     fileSize: number;
+    /** Generated hash codes for the extension ZIP file for extension file validation validation */
     hashcode: Record<string, string>;
   }
 >;

--- a/src/shared/models/full-extension-data.model.ts
+++ b/src/shared/models/full-extension-data.model.ts
@@ -1,0 +1,34 @@
+import { ExtensionManifest } from '@extension-host/extension-types/extension-manifest.model';
+import { LanguageStrings } from 'platform-bible-utils';
+
+/** Interface that stores extension icon information */
+export interface ExtensionIcon {
+  /** Path to the icon's file. Could be a URL */
+  filepath: string;
+  /** Icon file extension (png, svg, ...) */
+  filetype: string;
+  /** Raw binary data of the icon, intended to be encoded in a base64 string */
+  data: string;
+  /** True if this icon was submitted as a URL, else false. */
+  isUrl: boolean;
+}
+
+/**
+ * Full set of descriptive metadata for an extension including the extension manifest and
+ * visualization data that is useful for the extension marketplace
+ */
+export type FullExtensionData = Readonly<
+  Omit<ExtensionManifest, 'name' | 'version'> & {
+    id: string;
+    currentVersion: string;
+    displayName: LanguageStrings;
+    shortSummary: LanguageStrings;
+    description: LanguageStrings;
+    icon: ExtensionIcon;
+    locales: string[];
+    moreInfoUrl: string;
+    supportUrl: string;
+    fileSize: number;
+    hashcode: Record<string, string>;
+  }
+>;

--- a/src/shared/models/manage-extensions-privilege.model.ts
+++ b/src/shared/models/manage-extensions-privilege.model.ts
@@ -34,25 +34,6 @@ export interface ExtensionIcon {
  * Full image of the data of an extension including the additional extension marketplace
  * visualization data
  */
-// export interface ExtensionData {
-//   id: string;
-//   currentVersion: string;
-//   main: string;
-//   displayName: ExtensionLocalizedStrings;
-//   shortSummary: ExtensionLocalizedStrings;
-//   description: ExtensionLocalizedStrings;
-//   icon: ExtensionIcon;
-//   locales: string[];
-//   moreInfoUrl: string;
-//   supportUrl: string;
-//   fileSize: number;
-//   hashcode: string;
-// }
-
-/**
- * Full image of the data of an extension including the additional extension marketplace
- * visualization data
- */
 export type ExtensionData = Readonly<
   Omit<ExtensionManifest, 'name' | 'version'> & {
     id: string;
@@ -65,7 +46,7 @@ export type ExtensionData = Readonly<
     moreInfoUrl: string;
     supportUrl: string;
     fileSize: number;
-    hashcode: string;
+    hashcode: Record<string, string>;
   }
 >;
 

--- a/src/shared/models/manage-extensions-privilege.model.ts
+++ b/src/shared/models/manage-extensions-privilege.model.ts
@@ -1,5 +1,4 @@
-import { ExtensionManifest } from '@extension-host/extension-types/extension-manifest.model';
-import { LanguageStrings } from 'platform-bible-utils';
+import { FullExtensionData } from './full-extension-data.model';
 
 /** Base64 encoded hash values */
 export type HashValues = Partial<{
@@ -12,38 +11,6 @@ export type ExtensionIdentifier = {
   extensionName: string;
   extensionVersion: string;
 };
-
-/** Interface that stores extension icon information */
-export interface ExtensionIcon {
-  /** Path to the icon's file. Could be a URL */
-  filepath: string;
-  /** Icon file extension (png, svg, ...) */
-  filetype: string;
-  /** Raw binary data of the icon, intended to be encoded in a base64 string */
-  data: string;
-  /** True if this icon was submitted as a URL, else false. */
-  isUrl: boolean;
-}
-
-/**
- * Full set of descriptive metadata for an extension including the extension manifest and
- * visualization data that is useful for the extension marketplace
- */
-export type FullExtensionData = Readonly<
-  Omit<ExtensionManifest, 'name' | 'version'> & {
-    id: string;
-    currentVersion: string;
-    displayName: LanguageStrings;
-    shortSummary: LanguageStrings;
-    description: LanguageStrings;
-    icon: ExtensionIcon;
-    locales: string[];
-    moreInfoUrl: string;
-    supportUrl: string;
-    fileSize: number;
-    hashcode: Record<string, string>;
-  }
->;
 
 /**
  * Represents all extensions that are installed. Note that packaged extensions cannot be disabled,
@@ -121,6 +88,9 @@ export type ManageExtensions = {
   disableExtension: DisableExtensionFunction;
   /** Function to retrieve details about all installed extensions */
   getInstalledExtensions: GetInstalledExtensionsFunction;
-  /** Function to retrieve full details about a list of installed or disabled extensions */
+  /**
+   * Function to retrieve descriptive metadata and visualization data for an extension. Useful for
+   * the extension marketplace.
+   */
   getExtensionsData: GetExtensionsDataFunction;
 };

--- a/src/shared/models/manage-extensions-privilege.model.ts
+++ b/src/shared/models/manage-extensions-privilege.model.ts
@@ -34,6 +34,25 @@ export interface ExtensionIcon {
  * Full image of the data of an extension including the additional extension marketplace
  * visualization data
  */
+// export interface ExtensionData {
+//   id: string;
+//   currentVersion: string;
+//   main: string;
+//   displayName: ExtensionLocalizedStrings;
+//   shortSummary: ExtensionLocalizedStrings;
+//   description: ExtensionLocalizedStrings;
+//   icon: ExtensionIcon;
+//   locales: string[];
+//   moreInfoUrl: string;
+//   supportUrl: string;
+//   fileSize: number;
+//   hashcode: string;
+// }
+
+/**
+ * Full image of the data of an extension including the additional extension marketplace
+ * visualization data
+ */
 export type ExtensionData = Readonly<
   Omit<ExtensionManifest, 'name' | 'version'> & {
     id: string;

--- a/src/shared/models/manage-extensions-privilege.model.ts
+++ b/src/shared/models/manage-extensions-privilege.model.ts
@@ -1,3 +1,5 @@
+import { ExtensionManifest } from '@extension-host/extension-types/extension-manifest.model';
+
 /** Base64 encoded hash values */
 export type HashValues = Partial<{
   sha256: string;
@@ -9,6 +11,44 @@ export type ExtensionIdentifier = {
   extensionName: string;
   extensionVersion: string;
 };
+
+/**
+ * Type storing localized strings for an extension field. Indexed by locale, values are localized
+ * strings in that language.
+ */
+export type ExtensionLocalizedStrings = Record<string, string>;
+
+/** Interface that stores extension icon information */
+export interface ExtensionIcon {
+  /** Path to the icon's file. Could be a URL */
+  filepath: string;
+  /** Icon file extension (png, svg, ...) */
+  filetype: string;
+  /** Raw binary data of the icon, intended to be encoded in a base64 string */
+  data: string;
+  /** True if this icon was submitted as a URL, else false. */
+  isUrl: boolean;
+}
+
+/**
+ * Full image of the data of an extension including the additional extension marketplace
+ * visualization data
+ */
+export type ExtensionData = Readonly<
+  Omit<ExtensionManifest, 'name' | 'version'> & {
+    id: string;
+    currentVersion: string;
+    displayName: ExtensionLocalizedStrings;
+    shortSummary: ExtensionLocalizedStrings;
+    description: ExtensionLocalizedStrings;
+    icon: ExtensionIcon;
+    locales: string[];
+    moreInfoUrl: string;
+    supportUrl: string;
+    fileSize: number;
+    hashcode: string;
+  }
+>;
 
 /**
  * Represents all extensions that are installed. Note that packaged extensions cannot be disabled,
@@ -71,6 +111,11 @@ export type DisableExtensionFunction = (extensionIdentifier: ExtensionIdentifier
 /** Get extension identifiers of all extensions on the system */
 export type GetInstalledExtensionsFunction = () => Promise<InstalledExtensions>;
 
+/** Get full extension data for a specified list of extensions */
+export type GetExtensionsDataFunction = (
+  extensionIds: ExtensionIdentifier[],
+) => Promise<ExtensionData[]>;
+
 /** Functions needed to manage extensions */
 export type ManageExtensions = {
   /** Function to download an extension and enable it */
@@ -81,4 +126,6 @@ export type ManageExtensions = {
   disableExtension: DisableExtensionFunction;
   /** Function to retrieve details about all installed extensions */
   getInstalledExtensions: GetInstalledExtensionsFunction;
+  /** Function to retrieve full details about a list of installed or disabled extensions */
+  getExtensionsData: GetExtensionsDataFunction;
 };

--- a/src/shared/models/manage-extensions-privilege.model.ts
+++ b/src/shared/models/manage-extensions-privilege.model.ts
@@ -1,4 +1,5 @@
 import { ExtensionManifest } from '@extension-host/extension-types/extension-manifest.model';
+import { LanguageStrings } from 'platform-bible-utils';
 
 /** Base64 encoded hash values */
 export type HashValues = Partial<{
@@ -11,12 +12,6 @@ export type ExtensionIdentifier = {
   extensionName: string;
   extensionVersion: string;
 };
-
-/**
- * Type storing localized strings for an extension field. Indexed by locale, values are localized
- * strings in that language.
- */
-export type ExtensionLocalizedStrings = Record<string, string>;
 
 /** Interface that stores extension icon information */
 export interface ExtensionIcon {
@@ -31,16 +26,16 @@ export interface ExtensionIcon {
 }
 
 /**
- * Full image of the data of an extension including the additional extension marketplace
- * visualization data
+ * Full set of descriptive metadata for an extension including the extension manifest and
+ * visualization data that is useful for the extension marketplace
  */
-export type ExtensionData = Readonly<
+export type FullExtensionData = Readonly<
   Omit<ExtensionManifest, 'name' | 'version'> & {
     id: string;
     currentVersion: string;
-    displayName: ExtensionLocalizedStrings;
-    shortSummary: ExtensionLocalizedStrings;
-    description: ExtensionLocalizedStrings;
+    displayName: LanguageStrings;
+    shortSummary: LanguageStrings;
+    description: LanguageStrings;
     icon: ExtensionIcon;
     locales: string[];
     moreInfoUrl: string;
@@ -114,7 +109,7 @@ export type GetInstalledExtensionsFunction = () => Promise<InstalledExtensions>;
 /** Get full extension data for a specified list of extensions */
 export type GetExtensionsDataFunction = (
   extensionIds: ExtensionIdentifier[],
-) => Promise<ExtensionData[]>;
+) => Promise<FullExtensionData[]>;
 
 /** Functions needed to manage extensions */
 export type ManageExtensions = {

--- a/src/shared/utils/localized-strings-document-combiner.ts
+++ b/src/shared/utils/localized-strings-document-combiner.ts
@@ -29,7 +29,7 @@ function performSchemaValidation(document: JsonDocumentLike, docType: string): v
 }
 
 /** Modifies the input localized string contribution by canonizing the locales */
-function transformLocalizedStringDataToCanonicalLocales(
+export function transformLocalizedStringDataToCanonicalLocales(
   stringData: LocalizedStringDataContribution,
 ): LocalizedStringDataContribution {
   if (!stringData.localizedStrings) return stringData;


### PR DESCRIPTION
Implements a helper function to retrieve full extension data (particularly including the marketplace-like data) for a list of extensions.
This will be particularly used for fetching data about local extensions to be shown in the marketplace extension.

NOTE: I haven't fully tested to make sure this works but most of this is sort of a copy/past (with modifications for the different node libraries) of the code inside of [`marketplace-extension.ts`](https://github.com/paranext/extension-marketplace-services/blob/beb61994a7ff5689f1470ed4af65034612726387/marketplace-publishing-tool/src/lib/marketplace-extension.ts#L286) in the `marketplace-publishing-tool` project which we know already works. I just wanted to get the code out first to make sure the structure of the code looks good as there was a lot of code added.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1701)
<!-- Reviewable:end -->
