### PR TITLE
Make platformScriptureEditor.edit column extensible

### DIFF
--- a/extensions/src/platform-scripture-editor/contributions/menus.json
+++ b/extensions/src/platform-scripture-editor/contributions/menus.json
@@ -11,7 +11,8 @@
         "columns": {
           "platformScriptureEditor.edit": {
             "label": "%webView_platformScriptureEditor_edit%",
-            "order": 2
+            "order": 2,
+            "isExtensible": true
           },
           "platformScriptureEditor.options": {
             "label": "%webView_platformScriptureEditor_options%",


### PR DESCRIPTION
Make it possible for extensions to add a menu group to the Scripture Editor

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1716)
<!-- Reviewable:end -->
