### PR TITLE
Enforce styles on tab group buttons

### DIFF
--- a/src/renderer/components/docking/panel-extra-content.component.scss
+++ b/src/renderer/components/docking/panel-extra-content.component.scss
@@ -2,7 +2,7 @@
 
 // Base class for panel buttons with shared styles
 %panel-button-base {
-  height: 22px;
+  height: 24px !important;
   width: 32px;
   margin: 4px 4px 4px 0;
 
@@ -10,7 +10,7 @@
   transition: background-color 0.5s ease;
 
   &:hover {
-    background-color: hsl(var(--muted-foreground));
+    background-color: hsl(var(--muted-foreground)) !important;
   }
 }
 


### PR DESCRIPTION
For some reasons these styles were overwritten by the default Tailwind classes as defined in the `Button` component in PBR in packaged builds. In a dev environment they did work properly.
Adding `!important` makes sure they are observed in packaged builds too

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1726)
<!-- Reviewable:end -->
