### PR TITLE
remove `JSX.Element` references

### DIFF
--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -13,7 +13,7 @@ import {
   Usj,
 } from '@biblionexus-foundation/scripture-utilities';
 import { Canon, SerializedVerseRef } from '@sillsdev/scripture';
-import { JSX, useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { WebViewProps } from '@papi/core';
 import papi, { logger } from '@papi/frontend';
 import {
@@ -129,7 +129,7 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
   projectId,
   useWebViewState,
   useWebViewScrollGroupScrRef,
-}: WebViewProps): JSX.Element {
+}: WebViewProps) {
   const [isReadOnly] = useWebViewState<boolean>('isReadOnly', true);
   const [decorations, setDecorations] = useWebViewState<EditorDecorations>(
     'decorations',

--- a/lib/platform-bible-react/src/components/advanced/extension-marketplace/more-info.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/extension-marketplace/more-info.component.tsx
@@ -26,8 +26,8 @@ interface MoreInfoProps {
  * number of downloads, languages, and links to the website and support
  *
  * @param MoreInfoProps
- * @returns {JSX.Element} - Returns the more info component that displays the category, number of
- *   downloads, languages, and links to the website and support
+ * @returns The more info component that displays the category, number of downloads, languages, and
+ *   links to the website and support
  */
 export function MoreInfo({
   id,

--- a/src/renderer/components/projects/project-list.component.tsx
+++ b/src/renderer/components/projects/project-list.component.tsx
@@ -1,7 +1,7 @@
 import { ProjectMetadata } from '@shared/models/project-metadata.model';
 import { Button, Checkbox, Label } from 'platform-bible-react';
 import { ProjectInterfaces } from 'papi-shared-types';
-import { PropsWithChildren, useCallback, JSX } from 'react';
+import { PropsWithChildren, useCallback } from 'react';
 import './project-list.component.scss';
 
 /** Project metadata and some display information */
@@ -120,7 +120,7 @@ export type ProjectListProps = PropsWithChildren<{
    * If multiselect is selected, then the array of selected project IDs is passed to control the
    * selected flag on ListItemButton
    */
-  selectedProjectIds?: string[] | undefined;
+  selectedProjectIds?: string[];
 
   /** Optional subheader */
   subheader?: string;
@@ -155,7 +155,7 @@ export function ProjectList({
     [isMultiselect, selectedProjectIds],
   );
 
-  const createListItemContents = (project: ProjectMetadataDisplay): JSX.Element => {
+  const createListItemContents = (project: ProjectMetadataDisplay) => {
     return (
       <Button variant="ghost" onClick={() => handleSelectProject(project.id)}>
         {isCheckable && (


### PR DESCRIPTION
- conforms to how other React components are declared
- this future proofs changes in React. E.g. this would be a problem if we ever upgraded to React v19 which changes components to returning `ReactElement`.
- also removed redundant `undefined` on optional property

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1729)
<!-- Reviewable:end -->
