### PR TITLE
Removed API for adding Lexical Reference DB files from extensions

### DIFF
--- a/extensions/src/platform-lexical-tools/src/lexical-reference-text-manager.model.ts
+++ b/extensions/src/platform-lexical-tools/src/lexical-reference-text-manager.model.ts
@@ -16,12 +16,12 @@ import type {
   LexicalEntriesByOccurrence,
   LexicalReferenceSelector,
   LexicalReferenceText,
-  LexicalReferenceTextRegistrar,
   LexicalSensesById,
   LexicalSensesByOccurrence,
   Occurrence,
   Sense,
 } from 'platform-lexical-tools';
+import { LexicalReferenceTextRegistrar } from './lexical-reference-text-registrar.model';
 
 /**
  * Fake occurrence used to put items that don't have occurrences somewhere in the

--- a/extensions/src/platform-lexical-tools/src/lexical-reference-text-registrar.model.ts
+++ b/extensions/src/platform-lexical-tools/src/lexical-reference-text-registrar.model.ts
@@ -1,0 +1,31 @@
+// This class moved out of `platform-lexical-tools.d.ts` to avoid exposing this early API on the PAPI
+// It should probably be edited and moved back when we do https://paratextstudio.atlassian.net/browse/PT-3217
+
+/** Object that receives and handles lexical reference texts */
+export type LexicalReferenceTextRegistrar = {
+  /**
+   * Registers a lexical reference text to be used with lexical tools.
+   *
+   * Note: you do not have to run `unregisterLexicalReferenceText` unless you want to remove the
+   * data from the lexical service. The lexical service will automatically unregister everything on
+   * shutdown.
+   *
+   * Note: the guid returned is not cryptographically secure. It may be changed to be secure in the
+   * future.
+   *
+   * @param extensionFileUri - The file URL of the SQLite database. This can only be an extension
+   *   asset URI like `papi-extension://<extension-name>/assets/<path-to-asset>`. The SQLite
+   *   database must follow [the Lexical Reference Text SQL
+   *   schema](https://github.com/paranext/marble-tools/blob/main/sql/schema.sql)
+   * @returns A guid that can be used to unregister this lexical reference text
+   */
+  registerLexicalReferenceText(extensionFileUri: string): Promise<string>;
+  /**
+   * Unregisters a lexical reference text that was previously registered with
+   * `registerLexicalReferenceText`, removing its data from the lexical service.
+   *
+   * @param guid - The guid of the lexical reference text to close. Returned from
+   *   `registerLexicalReferenceText`
+   */
+  unregisterLexicalReferenceText(guid: string): Promise<void>;
+};

--- a/extensions/src/platform-lexical-tools/src/lexical-reference.service.ts
+++ b/extensions/src/platform-lexical-tools/src/lexical-reference.service.ts
@@ -4,7 +4,6 @@ import type {
   LexicalEntriesById,
   LexicalEntriesByOccurrence,
   LexicalReferenceSelector,
-  LexicalReferenceTextRegistrar,
   LexicalReferenceDataTypes,
   LexicalSensesByOccurrence,
   LexicalSensesById,
@@ -14,7 +13,7 @@ import { LexicalReferenceTextManager } from './lexical-reference-text-manager.mo
 
 export class LexicalReferenceService
   extends DataProviderEngine<LexicalReferenceDataTypes>
-  implements IDataProviderEngine<LexicalReferenceDataTypes>, LexicalReferenceTextRegistrar
+  implements IDataProviderEngine<LexicalReferenceDataTypes>
 {
   #changeLexicalReferenceTextsUnsubscriber: Unsubscriber;
 
@@ -25,16 +24,6 @@ export class LexicalReferenceService
       this.lexicalReferenceTextManager.onDidChangeLexicalReferenceTexts(() =>
         this.notifyUpdate('*'),
       );
-  }
-
-  async registerLexicalReferenceText(fileUri: string): Promise<string> {
-    return this.lexicalReferenceTextManager.registerLexicalReferenceText(fileUri);
-  }
-
-  async unregisterLexicalReferenceText(lexicalReferenceTextGuid: string): Promise<void> {
-    return this.lexicalReferenceTextManager.unregisterLexicalReferenceText(
-      lexicalReferenceTextGuid,
-    );
   }
 
   async getEntriesById(selector: LexicalReferenceSelector): Promise<LexicalEntriesById> {

--- a/extensions/src/platform-lexical-tools/src/main.ts
+++ b/extensions/src/platform-lexical-tools/src/main.ts
@@ -64,7 +64,7 @@ export async function activate(context: ExecutionActivationContext) {
     );
 
   const lexicalReferenceService = await lexicalReferenceServicePromise;
-  await lexicalReferenceService.registerLexicalReferenceText(
+  await lexicalReferenceTextManager.registerLexicalReferenceText(
     'papi-extension://platformLexicalTools/assets/lexical-db/lexical.db',
   );
 

--- a/extensions/src/platform-lexical-tools/src/types/platform-lexical-tools.d.ts
+++ b/extensions/src/platform-lexical-tools/src/types/platform-lexical-tools.d.ts
@@ -530,35 +530,6 @@ declare module 'platform-lexical-tools' {
     >;
   };
 
-  /** Object that receives and handles lexical reference texts */
-  export type LexicalReferenceTextRegistrar = {
-    /**
-     * Registers a lexical reference text to be used with lexical tools.
-     *
-     * Note: you do not have to run `unregisterLexicalReferenceText` unless you want to remove the
-     * data from the lexical service. The lexical service will automatically unregister everything
-     * on shutdown.
-     *
-     * Note: the guid returned is not cryptographically secure. It may be changed to be secure in
-     * the future.
-     *
-     * @param extensionFileUri - The file URL of the SQLite database. This can only be an extension
-     *   asset URI like `papi-extension://<extension-name>/assets/<path-to-asset>`. The SQLite
-     *   database must follow [the Lexical Reference Text SQL
-     *   schema](https://github.com/paranext/marble-tools/blob/main/sql/schema.sql)
-     * @returns A guid that can be used to unregister this lexical reference text
-     */
-    registerLexicalReferenceText(extensionFileUri: string): Promise<string>;
-    /**
-     * Unregisters a lexical reference text that was previously registered with
-     * `registerLexicalReferenceText`, removing its data from the lexical service.
-     *
-     * @param guid - The guid of the lexical reference text to close. Returned from
-     *   `registerLexicalReferenceText`
-     */
-    unregisterLexicalReferenceText(guid: string): Promise<void>;
-  };
-
   /**
    * Service that manages lexical reference text data like dictionaries, concordances, lexicons,
    * etc.
@@ -699,7 +670,7 @@ declare module 'platform-lexical-tools' {
       callback: (sensesByOccurrence: LexicalSensesByOccurrence | undefined | PlatformError) => void,
       options?: DataProviderSubscriberOptions,
     ): Promise<UnsubscriberAsync>;
-  } & LexicalReferenceTextRegistrar;
+  };
 
   // #endregion
 }


### PR DESCRIPTION
These methods exposed in https://paratextstudio.atlassian.net/browse/PT-3153 for other extensions to add lexical reference text files was only temporary as the DB files are supposed to be internal details.

This PR removes them in favor of avoiding adding bad API that we will have to break or revert later. Better to wait until we have the XML API rather than expose this dirty DB API.

We will add the XML API with https://paratextstudio.atlassian.net/browse/PT-3217