### PR TITLE
Style tab width

### DIFF
--- a/src/renderer/components/docking/dock-layout-wrapper.component.scss
+++ b/src/renderer/components/docking/dock-layout-wrapper.component.scss
@@ -3,6 +3,7 @@
 .dock {
   background-color: hsl(var(--background));
   color: hsl(var(--foreground));
+  container-type: size;
 }
 
 .dock-dropdown,
@@ -117,6 +118,7 @@
   background: vars.$color--inactive-tab;
   color: vars.$color--text;
   flex: 1 0 auto;
+  max-width: fit-content;
 }
 
 .dock-layout .dock-panel.dock-style-platform-bible .dock-tab.dock-tab-active {
@@ -130,9 +132,8 @@
 
 .dock-layout .dock-panel.dock-style-platform-bible .dock-tab > div {
   padding-inline-start: vars.$space--xs;
-  padding-inline-end: 26px;
-  padding-top: vars.$space--xs;
-  padding-bottom: vars.$space--xs;
+  padding-inline-end: clamp(2rem, 3rem, 10cqw);
+  padding-block: vars.$space--xs;
 }
 
 .dock-dropdown-menu-item .title {


### PR DESCRIPTION
* not too big,
* not too small, and
* adjusts to the content and dock widths

## Before
Observe that tabs take up as much space is available. Ignore the big green tab background color—that's not meaningful. 
<img width="1564" height="1056" alt="Screenshot 2025-07-30 at 12 23 57" src="https://github.com/user-attachments/assets/653dd44b-f830-48e4-9dc5-18779eb55939" />

## After
Observe that widths hug their content, with a little extra room that gets bigger if the toolbar is wider.
<img width="1564" height="1056" alt="Screenshot 2025-07-30 at 12 23 18" src="https://github.com/user-attachments/assets/8758523f-24d5-4ab5-b08b-947908b06789" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1738)
<!-- Reviewable:end -->
