### PR TITLE
Fix filtering dictionary entries by search query

### DIFF
--- a/extensions/src/platform-lexical-tools/src/web-views/dictionary.web-view.tsx
+++ b/extensions/src/platform-lexical-tools/src/web-views/dictionary.web-view.tsx
@@ -82,10 +82,12 @@ globalThis.webViewComponent = function Dictionary({
       const matchesSearch =
         entry.lemma.toLowerCase().includes(search) ||
         entry.strongsCodes.some((code) => code.toLowerCase().includes(search)) ||
-        getFormatGlossesStringFromDictionaryEntrySenses(entry).toLowerCase().includes(search);
+        getFormatGlossesStringFromDictionaryEntrySenses(entry, scrRef)
+          .toLowerCase()
+          .includes(search);
       return matchesSearch;
     });
-  }, [entriesById, searchQuery, scope, scrRef.book, scrRef.chapterNum, scrRef.verseNum]);
+  }, [entriesById, searchQuery, scrRef, scope]);
 
   const onSelectOccurrence = useCallback(
     (scrRefOfOccurrence: SerializedVerseRef) => {


### PR DESCRIPTION
Roopa reported that when she searched the dictionary entries, more results come back than what matches the search query. I needed to pass the scrRef to the `getFormatGlossesStringFromDictionaryEntrySenses()` so that it can filter the senses by scrRef (similar to how we do in the filter by scrRef right above this) and get the appropriate matches.