### PR TITLE
PT-3295 remove dock expand button

### DIFF
--- a/src/renderer/components/docking/dock-layout-wrapper.component.scss
+++ b/src/renderer/components/docking/dock-layout-wrapper.component.scss
@@ -71,16 +71,36 @@
 
 // #region TAB-BAR //////////////////////////////////////////////
 /* tabs take all the space */
+
 .dock-layout .dock-panel.dock-style-platform-bible .dock-nav-list {
   flex-grow: 1;
 }
 
-/* overriding default style for the shadow indicating that not all tabs are shown */
-.dock-nav-more {
-  color: hsl(var(--foreground));
-  margin-right: 10px;
+.dock-nav-operations {
+  align-items: center;
+  gap: vars.$space--s;
+  padding-inline: vars.$space--s;
+  height: 100%;
 }
 
+.dock-nav-more {
+  color: hsl(var(--foreground));
+  height: 24px;
+  width: 32px;
+  border-radius: vars.$space--s;
+}
+
+.dock-nav-more:hover {
+  background-color: hsl(var(--muted-foreground));
+}
+
+.dock-nav-more > svg {
+  width: 1rem;
+  height: 1rem;
+  flex-shrink: 0;
+}
+
+/* overriding default style for the shadow indicating that not all tabs are shown */
 .dock-nav-more::after {
   box-shadow: inset -10px 0 8px -8px vars.$color--shadow;
 }
@@ -102,7 +122,7 @@
    * Remove the handle bar at the top of each dock-tab. Note: Now, the tab
    * group can only be grabbed by grabbing the intersection between two tabs
    */
-  padding-top: 0;
+  padding-top: unset;
   /*
    * For some reason, by default, the tabs are moved down one pixel. That
    * makes them blurry, so this removes that transform
@@ -303,5 +323,9 @@ $tab-bottom-rounding: vars.$space--s;
 }
 
 .dock-panel.dock-style-card .dock-extra-content {
-  height: 0; // absolutely positioned with 0 height, to avoid influencing anything else
+  // long selector needed for specificity
+  height: 30px;
+  min-width: 36px;
+  display: flex;
+  align-items: center;
 }

--- a/src/renderer/components/docking/dock-layout-wrapper.component.scss
+++ b/src/renderer/components/docking/dock-layout-wrapper.component.scss
@@ -3,6 +3,7 @@
 .dock {
   background-color: hsl(var(--background));
   color: hsl(var(--foreground));
+  container-type: size;
 }
 
 .dock-dropdown,
@@ -117,6 +118,7 @@
   background: vars.$color--inactive-tab;
   color: vars.$color--text;
   flex: 1 0 auto;
+  max-width: fit-content;
 }
 
 .dock-layout .dock-panel.dock-style-platform-bible .dock-tab.dock-tab-active {
@@ -130,9 +132,8 @@
 
 .dock-layout .dock-panel.dock-style-platform-bible .dock-tab > div {
   padding-inline-start: vars.$space--xs;
-  padding-inline-end: 26px;
-  padding-top: vars.$space--xs;
-  padding-bottom: vars.$space--xs;
+  padding-inline-end: clamp(2rem, 3rem, 10cqw);
+  padding-block: vars.$space--xs;
 }
 
 .dock-dropdown-menu-item .title {

--- a/src/renderer/components/docking/panel-extra-content.component.scss
+++ b/src/renderer/components/docking/panel-extra-content.component.scss
@@ -2,27 +2,14 @@
 
 // Base class for panel buttons with shared styles
 %panel-button-base {
-  height: 24px !important;
+  height: 24px;
   width: 32px;
-  margin: 4px 4px 4px 0;
-
-  background-color: transparent;
-  transition: background-color 0.5s ease;
 
   &:hover {
-    background-color: hsl(var(--muted-foreground)) !important;
+    background-color: hsl(var(--muted-foreground));
   }
 }
 
 .new-tab-button {
-  @extend %panel-button-base;
-  margin-left: -10px;
-}
-
-.maximize-button {
-  @extend %panel-button-base;
-}
-
-.close-tab-group-button {
   @extend %panel-button-base;
 }

--- a/src/renderer/components/docking/panel-extra-content.component.tsx
+++ b/src/renderer/components/docking/panel-extra-content.component.tsx
@@ -3,7 +3,6 @@ import { logger } from '@shared/services/logger.service';
 import { Plus } from 'lucide-react';
 import { Button } from 'platform-bible-react';
 import { PanelData } from 'rc-dock';
-import React from 'react';
 import './panel-extra-content.component.scss';
 
 interface PanelExtraContentProps {

--- a/src/renderer/components/docking/panel-extra-content.component.tsx
+++ b/src/renderer/components/docking/panel-extra-content.component.tsx
@@ -1,28 +1,19 @@
 import { sendCommand } from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
-import { Maximize2, Minimize2, Plus } from 'lucide-react';
 import { Button } from 'platform-bible-react';
-import { DockContext, PanelData } from 'rc-dock';
+import { PanelData } from 'rc-dock';
 import React from 'react';
 import './panel-extra-content.component.scss';
 
 interface PanelExtraContentProps {
   panelData: PanelData;
-  context: DockContext;
 }
 
 /**
  * Component that renders the extra content in the panel header, including the maximize/minimize
  * button and the new tab button
  */
-export function PanelExtraContent({ panelData, context }: PanelExtraContentProps) {
-  const handleMaximize = (e: React.MouseEvent) => {
-    // RC Dock needs null here
-    // eslint-disable-next-line no-null/no-null
-    context.dockMove(panelData, null, 'maximize');
-    e.stopPropagation();
-  };
-
+export function PanelExtraContent({ panelData }: PanelExtraContentProps) {
   const handleOpenNewTab = async (tabGroupId?: string) => {
     try {
       await sendCommand('platformGetResources.openNewTab', tabGroupId);
@@ -32,21 +23,13 @@ export function PanelExtraContent({ panelData, context }: PanelExtraContentProps
   };
 
   return (
-    <>
-      <Button
-        variant="ghost"
-        className="new-tab-button"
-        onClick={() => handleOpenNewTab(panelData.id)}
-      >
-        <Plus />
-      </Button>
-
-      {panelData.parent && panelData.parent.mode !== 'window' && (
-        <Button variant="ghost" className="maximize-button" onClick={handleMaximize}>
-          {panelData.parent.mode === 'maximize' ? <Minimize2 /> : <Maximize2 />}
-        </Button>
-      )}
-    </>
+    <Button
+      variant="ghost"
+      className="new-tab-button"
+      onClick={() => handleOpenNewTab(panelData.id)}
+    >
+      <Plus />
+    </Button>
   );
 }
 

--- a/src/renderer/components/docking/panel-extra-content.component.tsx
+++ b/src/renderer/components/docking/panel-extra-content.component.tsx
@@ -1,5 +1,6 @@
 import { sendCommand } from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
+import { Plus } from 'lucide-react';
 import { Button } from 'platform-bible-react';
 import { PanelData } from 'rc-dock';
 import React from 'react';

--- a/src/renderer/components/docking/platform-dock-layout-positioning.util.ts
+++ b/src/renderer/components/docking/platform-dock-layout-positioning.util.ts
@@ -8,6 +8,7 @@ import {
 } from '@shared/models/docking-framework.model';
 import cloneDeep from 'lodash/cloneDeep';
 import { FloatPosition, FloatSize, LayoutSize, TabGroup } from 'rc-dock';
+import { ChevronDown } from 'lucide-react';
 import { TabType } from './docking-framework-internal.model';
 import { PanelExtraContent } from './panel-extra-content.component';
 
@@ -31,8 +32,9 @@ export const GROUPS: { [key: string]: TabGroup } = {
     animated: false, // Don't animate tab transitions
     // TODO: Currently allowing newWindow crashes since electron doesn't seem to have window.open defined?
     // newWindow: true, // Allow floating windows to show in a native window
-    panelExtra: (panelData, context) => {
-      return createElement(PanelExtraContent, { panelData, context });
+    moreIcon: createElement(ChevronDown),
+    panelExtra: (panelData) => {
+      return createElement(PanelExtraContent, { panelData });
     },
   },
 };


### PR DESCRIPTION
* Eliminate the Expand TabGroup button (my vote)
* TabHeader `{ max-width: fit-content }`

Recent Discussion
https://ptb.discord.com/channels/1064938364597436416/1397490838883405875/1399805499230257223

Jira work item
https://paratextstudio.atlassian.net/browse/PT-3295

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1740)
<!-- Reviewable:end -->

## Before
Notice the expand icon button in on the right side of each tab header row and simple text '...' more button.
<img width="1333" height="1024" alt="Screenshot 2025-07-30 at 15 17 39" src="https://github.com/user-attachments/assets/6f14d2f9-3909-4685-8b59-60c6dbd58c33" />

## After
Observe no expand icon button and a chevron More icon button.
<img width="1333" height="1024" alt="Screenshot 2025-07-30 at 15 17 00" src="https://github.com/user-attachments/assets/8b3244f4-8812-41f0-ae80-4f6ec84c7e27" />

## What this PR doesn't attempt
* Position the New Tab button to the left, just after the tab headers.
* Vertically center the header row buttons.
* Put the maximize action button in a context menu.