### PR TITLE
Link to .NET SDKv8 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,24 @@ We use encryption to keep your data safe, allowing access to keychain provides e
 
 ## Developer Install
 
-Set up pre-requisites for building:
+Set up pre-requisites, build, and run:
+
+1. Install the version of [`Node.js`](https://nodejs.org/) that matches the version specified in [`package.json`](https://github.com/paranext/paranext-core/blob/main/package.json#L249) at `volta.node`. We recommend using [Volta](#javascript-tool-manager).
+
+2. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
+
+   To check if `dotnet` is installed run:
+
+   ```bash
+   dotnet --version
+   # 8.0.412 [/usr/local/share/dotnet/sdk] (or some other directory)
+   dotnet --list-sdks
+   # 8.0.412 (or similar 8.* version)
+   ```
+
+3. Prerequisites for macOS or Linux (below).
+
+4. Clone, install, build, and run (below).
 
 ### Linux Development Pre-requisites
 
@@ -97,23 +114,6 @@ export DYLD_FALLBACK_LIBRARY_PATH="$HOME/lib:/usr/local/lib:/usr/lib:/opt/local/
 
 If you need to set environment variables like the above, consider adding them to
 your `.zprofile` so you don't have to remember to do it manually.
-
-### Development Prerequisites for All Platforms
-
-1. Install the version of [`Node.js`](https://nodejs.org/) that matches the version specified in [`package.json`](https://github.com/paranext/paranext-core/blob/main/package.json#L249) at `volta.node`. We recommend using [Volta](#javascript-tool-manager).
-
-2. Install [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
-
-   To check if `dotnet` is installed run:
-
-   ```bash
-   dotnet --version
-   # 8.0.412 [/usr/local/share/dotnet/sdk] (or some other directory)
-   dotnet --list-sdks
-   # 8.0.412 (or similar 8.* version)
-   ```
-
-3. Prerequisites for macOS or Linux (below).
 
 ### Cloning and installing dependencies (all platforms)
 


### PR DESCRIPTION
### Changes
- **Updated .NET 8 download link** to point directly to the .NET 8 download page instead of a more confusing general page (especially problematic for macOS users)
- **Formatting improvements** for better readability
- **Re-ordered installation instructions** for better clarity - moved "All Platforms" prerequisites to the top after discovering that developers were skipping over them when they appeared after platform-specific sections

### Context
Alex had the wrong version of .NET (v9) because the Microsoft documentation (previously linked) made no mention of how to get v8 SDK.

Usability issues identified during developer user research, where at least one user skipped critical setup steps due to the previous organization of the instructions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1743)
<!-- Reviewable:end -->
