### PR TITLE
Fix a bug where Home was looking at the wrong list of projects

### DIFF
--- a/extensions/src/platform-get-resources/src/home.component.tsx
+++ b/extensions/src/platform-get-resources/src/home.component.tsx
@@ -502,15 +502,14 @@ export function Home({
                 )}
               </div>
             )}
-            {filteredAndSortedProjects.length === 1 &&
-              filteredAndSortedProjects[0].name === 'WEB' && (
-                <div className="tw-flex tw-flex-col tw-gap-4 tw-items-center tw-w-auto">
-                  <p className="tw-text-muted-foreground tw-font-normal">
-                    {getStartedDescriptionText}
-                  </p>
-                  <Button onClick={onGetStarted}>{getStartedText}</Button>
-                </div>
-              )}
+            {mergedProjectInfo.length === 1 && mergedProjectInfo[0].name === 'WEB' && (
+              <div className="tw-flex tw-flex-col tw-gap-4 tw-items-center tw-w-auto">
+                <p className="tw-text-muted-foreground tw-font-normal">
+                  {getStartedDescriptionText}
+                </p>
+                <Button onClick={onGetStarted}>{getStartedText}</Button>
+              </div>
+            )}
           </div>
         </CardContent>
       )}


### PR DESCRIPTION
The button should show up only when WEB is the only project on your device, but Roopa found it also showed up when WEB was the only search result in the list