### PR TITLE
Change macOS builds to produce universal binaries

### DIFF
--- a/c-sharp/ParanextDataProvider.csproj
+++ b/c-sharp/ParanextDataProvider.csproj
@@ -19,6 +19,8 @@
     <PackageProjectUrl>https://github.com/paranext</PackageProjectUrl>
     <RepositoryUrl>https://github.com/paranext/paranext-core</RepositoryUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <!-- To support macOS universal binaries, we need to build both architectures -->
+    <RuntimeIdentifiers Condition="$([MSBuild]::IsOsPlatform('OSX'))">osx-x64;osx-arm64</RuntimeIdentifiers>
     <UserSecretsId>1860f020-31dd-4eb4-81c4-323eb0cb3e48</UserSecretsId>
     <!-- Uncomment the following lines to help with debugging into .NET core
     <DebugType>portable</DebugType>
@@ -52,7 +54,7 @@
     </None>
   </ItemGroup>
 
-  <!-- This dectects the location of ICU libraries on the macOS system whether the user is using MacPorts or Homebrew. -->
+  <!-- This detects the location of ICU libraries on the macOS system whether the user is using MacPorts or Homebrew. -->
   <PropertyGroup>
     <!-- Check if MacPorts ICU exists -->
     <UseMacPortsICU Condition="Exists('/opt/local/lib/libicuuc.dylib')">true</UseMacPortsICU>

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -17,14 +17,26 @@
     notarize: false,
     target: {
       target: 'default',
-      arch: ['arm64', 'x64'],
+      arch: ['universal'],
     },
+    // Rather than creating a universal .NET build, we create one for each architecture
     extraResources: [
       {
-        from: './c-sharp/bin/Release/net8.0/publish/osx-${arch}/',
-        to: './dotnet/',
+        from: './c-sharp/bin/Release/net8.0/publish/osx-x64/',
+        to: './dotnet/osx-x64/',
+      },
+      {
+        from: './c-sharp/bin/Release/net8.0/publish/osx-arm64/',
+        to: './dotnet/osx-arm64/',
       },
     ],
+    // https://github.com/electron/universal?tab=readme-ov-file#skip-lipo-for-certain-binaries-in-your-universal-app
+    // The documentation for this option didn't seem to match the results when it was used.
+    // To not specify a global pattern match on everything would require listing every single .NET
+    // executable and DLL file in the app bundle. That isn't practical, so a global match is used.
+    // In addition to the .NET files, it also was unhappy about node native modules which were not
+    // stitched together using lipo beforehand. It's rather confusing why this option even exists.
+    x64ArchFiles: '**/*',
     type: 'distribution',
     hardenedRuntime: true,
     entitlements: 'assets/entitlements.mac.plist',

--- a/src/main/services/dotnet-data-provider.service.ts
+++ b/src/main/services/dotnet-data-provider.service.ts
@@ -100,7 +100,10 @@ function startDotnetDataProvider() {
   let options: SpawnOptionsWithoutStdio | undefined;
 
   if (globalThis.isPackaged) {
-    const dotnetPath: string = path.join(process.resourcesPath, 'dotnet');
+    let dotnetPath: string = path.join(process.resourcesPath, 'dotnet');
+    if (process.platform === 'darwin')
+      dotnetPath = path.join(dotnetPath, process.arch === 'arm64' ? 'osx-arm64' : 'osx-x64');
+
     if (process.platform === 'win32') {
       command = path.join(dotnetPath, 'ParanextDataProvider.exe');
       args = [];


### PR DESCRIPTION
I tested that builds produced by this run on a virtual ARM macOS machine and a virtual x86 macOS machine. The virtual machines aren't fast, but it worked.

Some important caveats:
- This breaks the `run-unsigned-build.macos.sh` script. The virtual machines where I ran the apps are slow and very hard to do development on, so I cheated for now by signing my test build that I ran on both. I assume the script should be updated to work with the new builds. (@merchako you are welcome to add a commit to this PR that fixes the script if you prefer to have it all go in together)
- This probably breaks building with homebrew since (I think) homebrew can't install universal versions of ICU libraries. We have to build the .NET application twice, once for x64 and once for arm. This is fine with our MacPorts libraries because those libraries themselves are universal builds, so they work with both architectures. If we can't get universal builds from homebrew, then I think the right approach would be to include some prebuild script that downloads both versions of the libraries from homebrew (if possible), use [`lipo`](https://ss64.com/mac/lipo.html) to combine the two libraries into a universal version, then update the `csproj` file to copy the universal version to the output directory when using homebrew.
- A universal build probably makes bundling Mercurial harder because we either need a universal version or we need to do something like I did with the .NET application where we bundle both and have a runtime check on which version to execute.

Since @jolierabideau is working on the Mercurial ticket now, I will let her decide when to merge this PR (i.e., before or after hers) even if this is approved shortly.