### PR TITLE
Remove errors about `navigate-to` since it was dropped

### DIFF
--- a/src/renderer/index.ejs
+++ b/src/renderer/index.ejs
@@ -91,9 +91,6 @@
         data: so they can load data urls
       form-action 'self' lets the form submit to us
         TODO: not sure if this is needed. If we can attach handlers to forms, we might be able to remove this
-      navigate-to 'none' prevents them from redirecting this iframe somewhere else
-        WARNING: This is experimental and does not work as of July 2023! It is here for future
-        compatibility in case they add support for it
     -->
     <meta
       http-equiv="Content-Security-Policy"
@@ -109,8 +106,7 @@
         img-src 'self' papi-extension: https: data:;
         media-src 'self' papi-extension: https: data:;
         font-src 'self' papi-extension: https: data:;
-        form-action 'self';
-        navigate-to 'none';"
+        form-action 'self';"
     />
     <title>Platform.Bible</title>
   </head>

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -1297,9 +1297,6 @@ async function openOrReloadWebView(
   // form-action 'self' lets the form submit to us
   //    TODO: not sure if this is needed. If we can attach handlers to forms, we can probably remove
   //    this
-  // navigate-to 'none' prevents them from redirecting this iframe somewhere else
-  //   WARNING: This is experimental and does not work as of July 2023! It is here for future
-  //   compatibility in case they add support for it
   const contentSecurityPolicy = `<meta http-equiv="Content-Security-Policy"
     content="
       default-src 'none';
@@ -1313,7 +1310,6 @@ async function openOrReloadWebView(
       media-src 'self' papi-extension: https: data:;
       font-src 'self' papi-extension: https: data:;
       form-action 'self';
-      navigate-to 'none';
     ">`;
 
   // Add some elements at the start of the head to give access to papi, CSP, styles, etc.


### PR DESCRIPTION
From https://content-security-policy.com/navigate-to/ -
```
Note that navigate-to is not currently implemented in browsers, and although it was part of the CSP 3 spec, it has since been removed.
```

Leaving `navigate-to` in our code is causing a bunch of errors like the following to be be logged:
```
[2025-08-08 14:43:31.904] [error] [rend] Unrecognized Content-Security-Policy directive 'navigate-to'. [at file:///home/lyonsm/paranext-core/.erb/dll/main.bundle.dev.js:5414:24]
```

We should remove it and only add it back if it gets added back to the CSP spec.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1759)
<!-- Reviewable:end -->
