### PR TITLE
Change logging for some things that print out a lot

### DIFF
--- a/c-sharp/PapiClient.cs
+++ b/c-sharp/PapiClient.cs
@@ -148,6 +148,9 @@ internal class PapiClient : IDisposable
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
 
+        if (_requestTimeout == timeout)
+            return;
+
         Console.WriteLine($"Request timeout set to {timeout.TotalMilliseconds}ms");
         _requestTimeout = timeout;
     }

--- a/src/shared/models/project-lookup.service-model.ts
+++ b/src/shared/models/project-lookup.service-model.ts
@@ -506,11 +506,7 @@ async function internalGetMetadataWithRetries(
     if (allProjectsMetadataArray.length > 0)
       logger.debug(
         `Finally found project metadata on retry ${retryTimes} around ${performance.now()} for ${JSON.stringify(options)}! ${JSON.stringify(
-          allProjectsMetadataArray.map((projectMetadata) => {
-            const projectMetadataStripped: Partial<ProjectMetadata> = projectMetadata;
-            delete projectMetadataStripped.projectInterfaces;
-            return projectMetadataStripped;
-          }),
+          allProjectsMetadataArray.map((projectMetadata) => projectMetadata.id),
         )}`,
       );
   }


### PR DESCRIPTION
The C# change makes the .NET process stop spamming when it is told the network timeout is the same value that it already has.

The project lookup change makes it just print out what project IDs were found instead of all details about the projects. I have about 16 projects and resources, and whenever one of the "retry" messages printed for me that it found projects, it was a huge block in the log file that was annoying to see and scroll past. For people with magnitudes more projects than me on their machine, I have to believe this would be a gigantic message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1760)
<!-- Reviewable:end -->
