### PR TITLE
PT-3148 In Linux snap install, allow electron `safeStorage` to work

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -133,6 +133,7 @@
       'home',
       'network',
       'opengl',
+      'password-manager-service',
       'pulseaudio',
       'unity7',
       'wayland',


### PR DESCRIPTION
We use Electron's `safeStorage` to access platform encryption services. However, if the application is installed via snap, then those services are inaccessible by default.

The way to make them reachable, is by specifying that we need the `password-manager-services` interface.

That is what this commit does.  But that is not sufficient: That interface also must be _connected_.

Therefore, after `snap install`, the user will still need to manually `snap connect paratext-10-studio:password-manager-services`, to explicitly allow the application access to the platform encryption services. This will be documented on Wiki page
[How to set up Platform.Bible on Linux](https://github.com/paranext/paranext/wiki/How-to-set-up-Platform.Bible-on-Linux).

That might change, if we go through the
[Process for aliases, auto-connections and tracks](https://snapcraft.io/docs/process-for-aliases-auto-connections-and-tracks#p-2164-auto-connection-request-considerations) successfully.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1761)
<!-- Reviewable:end -->
