### PR TITLE
PT-3361: fixed wrong use of `isDrawer` component property for non-drawer single dictionary item

### DIFF
--- a/extensions/src/platform-lexical-tools/src/web-views/dictionary.web-view.tsx
+++ b/extensions/src/platform-lexical-tools/src/web-views/dictionary.web-view.tsx
@@ -171,7 +171,7 @@ globalThis.webViewComponent = function Dictionary({
         <div ref={dictionaryEntryRef} className="tw-overflow-y-auto tw-p-4">
           <DictionaryEntryDisplay
             scriptureReferenceToFilterBy={scrRef}
-            isDrawer={!isWideScreen}
+            isDrawer={false}
             dictionaryEntry={allEntriesByScrRef[0]}
             onSelectOccurrence={onSelectOccurrence}
             onClickScrollToTop={scrollToTop}

--- a/extensions/src/platform-lexical-tools/src/web-views/dictionary.web-view.tsx
+++ b/extensions/src/platform-lexical-tools/src/web-views/dictionary.web-view.tsx
@@ -19,7 +19,6 @@ import {
   DICTIONARY_LOCALIZED_STRING_KEYS,
   DictionaryScope,
   getFormatGlossesStringFromDictionaryEntrySenses,
-  useIsWideScreen,
 } from '../utils/dictionary.utils';
 import { DictionaryList } from '../components/dictionary/dictionary-list.component';
 

--- a/extensions/src/platform-lexical-tools/src/web-views/dictionary.web-view.tsx
+++ b/extensions/src/platform-lexical-tools/src/web-views/dictionary.web-view.tsx
@@ -40,7 +40,6 @@ globalThis.webViewComponent = function Dictionary({
   const dictionaryEntryRef = useRef<HTMLDivElement>(null);
 
   const lexicalService = useDataProvider('platformLexicalTools.lexicalReferenceService');
-  const isWideScreen = useIsWideScreen();
 
   const scrollToTop = () => {
     dictionaryEntryRef.current?.scrollTo({ top: 0, behavior: 'smooth' });


### PR DESCRIPTION
Turns out this was a very simple fix. The `isDrawer` component property for the `DictionaryEntryDisplay` when there is a single dictionary entry should not depend on the `isWideScreen` because if there is a single dictionary entry in a "half screen" tab there is no `Drawer` parent component. There's only a parent `Drawer` component if there are multiple dictionary list entries being shown and you select a single dictionary list entry and the drawer is shown.

Fixes the issue described here: https://paratextstudio.atlassian.net/browse/PT-3361

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1768)
<!-- Reviewable:end -->
