### PR TITLE
PT-3279: opening find ui changes selected project, but preserves search term

### DIFF
--- a/extensions/src/platform-scripture/src/find.web-view.tsx
+++ b/extensions/src/platform-scripture/src/find.web-view.tsx
@@ -64,7 +64,7 @@ global.webViewComponent = function FindWebView({
   useWebViewState,
   useWebViewScrollGroupScrRef,
 }: WebViewProps) {
-  const [searchTerm, setSearchTerm] = useState<string>('');
+  const [searchTerm, setSearchTerm] = useWebViewState<string>('findSearchTerm ', '');
   const [submittedSearchTerm, setSubmittedSearchTerm] = useState<string | undefined>(undefined);
   const [scope, setScope] = useWebViewState<Scope>('findScope', 'book');
   const [submittedScope, setSubmittedScope] = useState<Scope | undefined>();

--- a/extensions/src/platform-scripture/src/find.web-view.tsx
+++ b/extensions/src/platform-scripture/src/find.web-view.tsx
@@ -64,7 +64,7 @@ global.webViewComponent = function FindWebView({
   useWebViewState,
   useWebViewScrollGroupScrRef,
 }: WebViewProps) {
-  const [searchTerm, setSearchTerm] = useWebViewState<string>('findSearchTerm ', '');
+  const [searchTerm, setSearchTerm] = useWebViewState<string>('findSearchTerm', '');
   const [submittedSearchTerm, setSubmittedSearchTerm] = useState<string | undefined>(undefined);
   const [scope, setScope] = useWebViewState<Scope>('findScope', 'book');
   const [submittedScope, setSubmittedScope] = useState<Scope | undefined>();


### PR DESCRIPTION
Made it so that when "Find" is called on a different project/resource, the find web view is reloaded with the updated project id. 
In addition, made it so that when the find web view is reloaded, the search term is preserved.

Fixes this issue here: https://paratextstudio.atlassian.net/browse/PT-3279

_Also, I accidentally pushed it to the branch I was previously working on, so the branch name is not accurate_ :facepalm:

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1771)
<!-- Reviewable:end -->
