### PR TITLE
Fix error message from React about synchronous unmount

### DIFF
--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -1226,10 +1226,29 @@ async function openOrReloadWebView(
 
                 renderRoot();
 
-                window.addEventListener('unload', () => {
-                  root.unmount();
-                  unsubscribeUpdateWebView();
-                });
+                // React warns if you synchronously unmount a root while another render is in progress.
+                // The unload event can fire while React is still in the middle of processing an update
+                // (e.g., due to a late arriving onDidUpdateWebView event). Defer the unmount to the next
+                // macrotask so React can finish any in-flight render first.
+                let didScheduleUnmount = false;
+                function scheduleDeferredUnmount() {
+                  if (didScheduleUnmount) return;
+                  didScheduleUnmount = true;
+                  setTimeout(() => {
+                    try {
+                      root.unmount();
+                    } catch (e) {
+                      // Ignore: iframe is likely already being torn down
+                    }
+                    try {
+                      unsubscribeUpdateWebView();
+                    } catch (e) {
+                      // Ignore
+                    }
+                  }, 0);
+                }
+
+                window.addEventListener('unload', scheduleDeferredUnmount);
               }
 
               if (document.readyState === 'loading')


### PR DESCRIPTION
This should fix errors like the following that print every time a webview is closed:
```
Warning: Attempted to synchronously unmount a root while React was already rendering. React cannot finish unmounting the root until the current render has completed, which may lead to a race condition.%s
    at div
    at DockBox (http://localhost:1212/renderer.dev.js:24664:9)
    at div
    at DockLayout (http://localhost:1212/renderer.dev.js:25212:9)
    at DockLayoutWrapper (http://localhost:1212/renderer.dev.js:81430:106)
    at PlatformDockLayout (http://localhost:1212/renderer.dev.js:82853:72)
    at Main
    at RenderedRoute (http://localhost:1212/renderer.dev.js:71581:5)
    at Routes (http://localhost:1212/renderer.dev.js:72315:5)
    at Router (http://localhost:1212/renderer.dev.js:72249:15)
    at MemoryRouter (http://localhost:1212/renderer.dev.js:72143:5)
    at App [at file:///home/lyonsm/paranext-core/.erb/dll/main.bundle.dev.js:5414:24]
```