### PR TITLE
PT-3234 Add extra protections for the requestTimeout setting

### DIFF
--- a/c-sharp/PapiClient.cs
+++ b/c-sharp/PapiClient.cs
@@ -151,6 +151,14 @@ internal class PapiClient : IDisposable
         if (_requestTimeout == timeout)
             return;
 
+        if (timeout < TimeSpan.Zero || timeout > TimeSpan.FromDays(1))
+        {
+            Console.WriteLine(
+                $"Timeout must be between 0 and 1 day. Tried to set it to {timeout.TotalMilliseconds}ms"
+            );
+            return;
+        }
+
         Console.WriteLine($"Request timeout set to {timeout.TotalMilliseconds}ms");
         _requestTimeout = timeout;
     }

--- a/src/extension-host/data/core-settings-info.data.ts
+++ b/src/extension-host/data/core-settings-info.data.ts
@@ -100,7 +100,8 @@ const booleanValidator: SettingValidator<'platform.commentsEnabled'> = async (
 const requestTimeoutValidator: SettingValidator<'platform.requestTimeout'> = async (
   newValue: number,
 ): Promise<boolean> => {
-  return typeof newValue === 'number' && newValue >= 0;
+  // The request timeout is in seconds. Keep it between 0 (disabled) and 1 day
+  return typeof newValue === 'number' && newValue >= 0 && newValue <= 60 * 60 * 24;
 };
 
 /** Info about all settings built into core. Does not contain info for extensions' settings */

--- a/src/shared/services/settings.service.ts
+++ b/src/shared/services/settings.service.ts
@@ -33,6 +33,13 @@ async function initialize(): Promise<void> {
                 );
                 return;
               }
+              // The request timeout is in seconds. Keep it between 0 (disabled) and 1 day
+              if (typeof newTimeout !== 'number' || newTimeout < 0 || newTimeout > 60 * 60 * 24) {
+                logger.warn(
+                  `Attempt to set an invalid value for platform.requestTimeout: ${newTimeout}.`,
+                );
+                return;
+              }
               networkService.setRequestTimeout(newTimeout);
             },
           );


### PR DESCRIPTION
The `platform.requestTimeout` setting is special in that it is used by pretty low-level code we have, and if it gets broken the whole platform might not work properly without manual modification of settings files.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1788)
<!-- Reviewable:end -->
