### PR TITLE
Fix storybook build

### DIFF
--- a/lib/platform-bible-react/package.json
+++ b/lib/platform-bible-react/package.json
@@ -107,6 +107,7 @@
     "@chromatic-com/storybook": "^4.0.0",
     "@senojs/rollup-plugin-style-inject": "^0.2.3",
     "@storybook/addon-a11y": "9.0.17",
+    "@storybook/addon-docs": "9.0.17",
     "@storybook/addon-links": "9.0.17",
     "@storybook/addon-vitest": "9.0.17",
     "@storybook/react-vite": "9.0.17",

--- a/lib/platform-bible-react/src/stories/capitalization.mdx
+++ b/lib/platform-bible-react/src/stories/capitalization.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/addon-docs';
+import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Guidelines/Capitalization Rules" />
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1155,6 +1155,7 @@
         "@chromatic-com/storybook": "^4.0.0",
         "@senojs/rollup-plugin-style-inject": "^0.2.3",
         "@storybook/addon-a11y": "9.0.17",
+        "@storybook/addon-docs": "9.0.17",
         "@storybook/addon-links": "9.0.17",
         "@storybook/addon-vitest": "9.0.17",
         "@storybook/react-vite": "9.0.17",


### PR DESCRIPTION
Tested by running `npm run build:storybook -- --output-dir ../../docs-for-pages/platform-bible-react-storybook` from `lib/platform-bible-react` since that is the command that is failing in the GitHub workflow.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1789)
<!-- Reviewable:end -->
