### PR TITLE
Style data cells in punctuation inventory

### DIFF
--- a/extensions/src/platform-scripture/src/checks/inventories/punctuation-inventory.component.tsx
+++ b/extensions/src/platform-scripture/src/checks/inventories/punctuation-inventory.component.tsx
@@ -45,14 +45,27 @@ const createColumns = (
   onUnapprovedItemsChange: (items: string[]) => void,
 ): ColumnDef<InventoryTableData>[] => {
   return [
-    inventoryItemColumn(itemLabel),
+    {
+      ...inventoryItemColumn(itemLabel),
+      cell: ({ row }) => (
+        <div className="tw-text-lg tw-font-bold tw-font-mono tw-flex tw-justify-center">
+          {row.getValue('item')}
+        </div>
+      ),
+    },
     {
       accessorKey: 'unicodeValue',
       header: () => <Button variant="ghost">{unicodeValueLabel}</Button>,
-      cell: ({ row }) => {
-        const item: string = row.getValue('item');
-        return item.charCodeAt(0).toString(16).toUpperCase().padStart(4, '0');
-      },
+      //  Q: How to style the <td> and <th> directly?
+      cell: ({ row }) => (
+        <div className="tw-font-mono tw-flex tw-justify-center">
+          {(row.getValue('item') as string)
+            .charCodeAt(0)
+            .toString(16)
+            .toUpperCase()
+            .padStart(4, '0')}
+        </div>
+      ),
     },
     inventoryCountColumn(countLabel),
     inventoryStatusColumn(

--- a/extensions/src/platform-scripture/src/checks/inventories/punctuation-inventory.component.tsx
+++ b/extensions/src/platform-scripture/src/checks/inventories/punctuation-inventory.component.tsx
@@ -59,11 +59,7 @@ const createColumns = (
       //  Q: How to style the <td> and <th> directly?
       cell: ({ row }) => (
         <div className="tw-font-mono tw-flex tw-justify-center">
-          {(row.getValue('item') as string)
-            .charCodeAt(0)
-            .toString(16)
-            .toUpperCase()
-            .padStart(4, '0')}
+          {String(row.getValue('item')).charCodeAt(0).toString(16).toUpperCase().padStart(4, '0')}
         </div>
       ),
     },


### PR DESCRIPTION
Resolves https://paratextstudio.atlassian.net/browse/PT-3432
Resolves item #2 on [P10 Preview #2 Punchlist](https://docs.google.com/document/d/1I1rDvvHTWXARyI82NkCBhxnEF7b6puGET4f8NrdhIGw/edit?disco=AAABpzeSe_w)

> The punctuation characters are faint and hard to see in the UI.  They need to be more legible.  (the characters in the char inventory are just barely legible to me, markers inventory looks good.)

I wish I could have styled the data cells `<td>` and headers `<th>` directly, but the component is so abstracted—and I didn't see a renderer or `className`s passed on—that I don't see a way to do that.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1794)
<!-- Reviewable:end -->
