### PR TITLE
Move usersnap X buttons

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -408,32 +408,6 @@ async function main() {
       }
     });
 
-    let isClosing = false;
-    mainWindow.on('close', async (event) => {
-      if (isClosing || process.platform === 'darwin') {
-        isClosing = false;
-        return;
-      }
-
-      // On Windows and Linux, we need to check if a Usersnap form is open before we close the window.
-      // On those platforms, the Usersnap close button directly overlaps the OS close button, so we
-      // must prevent the application from closing when a user is trying to close the Usersnap form.
-      event.preventDefault();
-
-      try {
-        const isFormOpen = await commandService.sendCommand('platform.isUsersnapFormCurrentlyOpen');
-        if (isFormOpen) {
-          await commandService.sendCommand('platform.closeOpenUsersnapForm');
-          return;
-        }
-      } catch (error) {
-        logger.warn(`Failed to check if usersnap form is open: ${getErrorMessage(error)}`);
-      }
-
-      isClosing = true;
-      mainWindow?.close();
-    });
-
     mainWindow.on('closed', () => {
       mainWindow = undefined;
     });

--- a/src/renderer/services/usersnap.service.ts
+++ b/src/renderer/services/usersnap.service.ts
@@ -20,6 +20,123 @@ export const USERSNAP_SPACE_API_KEY: string = '1cf2709b-3ff0-4cff-8952-a2d2bca75
 let globalUsersnapApi: SpaceApi | undefined;
 let isUsersnapFormOpen = false;
 let apiKeyOfOpenForm: string | undefined;
+let shadowRootStylingInterval: ReturnType<typeof setInterval> | undefined;
+
+/**
+ * MutationObserver to detect when Usersnap elements are added to the DOM This will attempt to find
+ * and style Usersnap shadow DOMs
+ */
+let usersnapDomObserver: MutationObserver | undefined;
+
+/** Searches for Usersnap shadow DOM elements and applies custom styles */
+function findAndStyleUsersnapShadowRoots(): boolean {
+  try {
+    const usersnapWidget = document.querySelector('us-widget');
+    if (!usersnapWidget) return false;
+
+    if (!usersnapWidget.shadowRoot) return false;
+
+    const closeButton = usersnapWidget.shadowRoot.querySelector<HTMLButtonElement>(
+      'button[title="Close annotation"]',
+    );
+
+    if (!closeButton) return false;
+
+    if (apiKeyOfOpenForm === USERSNAP_PROJECT_SUBMIT_IDEA_API_KEY) {
+      closeButton.style.top = 'unset';
+      closeButton.style.right = '22ch';
+      closeButton.style.height = '54px';
+      closeButton.style.bottom = '0';
+    } else if (apiKeyOfOpenForm === USERSNAP_PROJECT_REPORT_ISSUE_API_KEY) {
+      closeButton.remove();
+
+      const collapseButton = usersnapWidget.shadowRoot.querySelector<HTMLButtonElement>(
+        'button[aria-label="Collapse form"]',
+      );
+
+      if (!(collapseButton instanceof HTMLButtonElement)) return false;
+
+      const newCloseButton = collapseButton.cloneNode(true);
+
+      if (!(newCloseButton instanceof HTMLButtonElement)) return false;
+
+      collapseButton.style.right = '36px';
+
+      newCloseButton.setAttribute('aria-label', 'Close feedback form');
+      newCloseButton.innerHTML = '✕';
+      newCloseButton.style.display = 'flex';
+      newCloseButton.style.alignItems = 'center';
+      newCloseButton.style.justifyContent = 'center';
+      newCloseButton.style.color = '#FFFFFF99';
+      newCloseButton.style.fontSize = '.8rem';
+      newCloseButton.addEventListener('click', async () => {
+        await closeOpenUsersnapForm();
+      });
+
+      collapseButton.parentNode?.insertBefore(newCloseButton, collapseButton.nextSibling);
+    }
+
+    return true;
+  } catch (error) {
+    logger.warn('Failed to find Usersnap close button in shadow roots:', error);
+    return false;
+  }
+}
+
+/** Sets up the Usersnap DOM observer, but doesn't start it yet */
+function initializeUsersnapDomObserver(): void {
+  if (usersnapDomObserver) return;
+
+  usersnapDomObserver = new MutationObserver((mutations) => {
+    if (!isUsersnapFormOpen) return;
+
+    const shouldSearchForShadowRoots = mutations.some((mutation) => {
+      if (mutation.type !== 'childList') return false;
+      return Array.from(mutation.addedNodes).some((node) => {
+        if (node instanceof Element && node.nodeType === Node.ELEMENT_NODE && node.shadowRoot) {
+          return true;
+        }
+        return false;
+      });
+    });
+
+    if (shouldSearchForShadowRoots) {
+      const startTime = Date.now();
+      const maxDuration = 10000; // 10 seconds
+      shadowRootStylingInterval = setInterval(() => {
+        const success = findAndStyleUsersnapShadowRoots();
+        const elapsed = Date.now() - startTime;
+
+        if (success || elapsed >= maxDuration) {
+          if (!success) {
+            logger.warn('Timeout reached while waiting for Usersnap shadow DOM elements to appear');
+          }
+          clearInterval(shadowRootStylingInterval);
+          shadowRootStylingInterval = undefined;
+        }
+      }, 100);
+    }
+  });
+
+  logger.debug('Usersnap DOM observer initialized');
+}
+
+/** Starts the Usersnap DOM observer */
+function startUsersnapObserver(): void {
+  if (usersnapDomObserver) {
+    usersnapDomObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+    });
+  }
+}
+
+/** Disconnects the Usersnap DOM observer */
+function stopUsersnapObserver(): void {
+  if (usersnapDomObserver) {
+    usersnapDomObserver.disconnect();
+  }
+}
 
 /** Initializes the global UserSnap API instance */
 export async function initializeUsersnapApi() {
@@ -55,6 +172,8 @@ export async function initializeUsersnapApi() {
 
     isUsersnapFormOpen = true;
     apiKeyOfOpenForm = event.apiKey;
+
+    startUsersnapObserver();
   });
   api.on('beforeSubmit', async (event) => {
     event.api.setValue('custom', customData);
@@ -62,9 +181,18 @@ export async function initializeUsersnapApi() {
   api.on('close', () => {
     isUsersnapFormOpen = false;
     apiKeyOfOpenForm = undefined;
+
+    if (shadowRootStylingInterval) {
+      clearInterval(shadowRootStylingInterval);
+      shadowRootStylingInterval = undefined;
+    }
+
+    stopUsersnapObserver();
   });
 
   globalUsersnapApi = api;
+
+  initializeUsersnapDomObserver();
 }
 
 /**


### PR DESCRIPTION
This PR moves the `X` (close) buttons on the Usersnap forms so they don't appear in the top-right corner where the overlap the `X` (close) button of the Electron window.

For `Submit an idea`, the `X` button is now in the bottom-right area, next to the existing button

<img width="804" height="563" alt="image" src="https://github.com/user-attachments/assets/2ff9ca93-4331-4269-94b9-bb85d1d8a66b" />

For `Report an issue`, the large `X` button has been removed, and a new, smaller `X` button has been added on the form in the bottom-right corner

<img width="805" height="563" alt="image" src="https://github.com/user-attachments/assets/7e83f01b-9610-476c-920b-d7d36ca72e84" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1797)
<!-- Reviewable:end -->
