### PR TITLE
Update dictionary title and add copyright information

### DIFF
--- a/extensions/src/platform-lexical-tools/contributions/localizedStrings.json
+++ b/extensions/src/platform-lexical-tools/contributions/localizedStrings.json
@@ -2,6 +2,9 @@
   "metadata": {
     "%platformLexicalTools_mainMenu_openHebGrkDictionary%": {
       "fallbackKey": "%platformLexicalTools_mainMenu_openDictionary%"
+    },
+    "%platformLexicalTools_dictionary_title_SDBHSDBG%": {
+      "fallbackKey": "%platformLexicalTools_dictionary_title%"
     }
   },
   "localizedStrings": {
@@ -21,11 +24,15 @@
       "%platformLexicalTools_dictionary_scopeSelector_section%": "Current Section",
       "%platformLexicalTools_dictionary_scopeSelector_verse%": "Current Verse",
       "%platformLexicalTools_dictionary_strongsCodeLabel%": "Strong's code",
+      "%platformLexicalTools_dictionary_sdbgCopyright%": "Semantic Dictionary of the Greek New Testament, based on Louw & Nida's Greek-English Lexicon of the New Testament, ©1988-2021 United Bible Societies.",
+      "%platformLexicalTools_dictionary_sdbhCopyright%": "Semantic Dictionary of Biblical Hebrew, edited by Reinier de Blois, with the assistance of Enio R. Mueller, ©2000-2025 United Bible Societies.",
       "%platformLexicalTools_dictionary_title%": "HEBGRK Dictionary",
+      "%platformLexicalTools_dictionary_title_sdbhSdbg%": "Dictionary: SDBH/SDBG",
       "%platformLexicalTools_dictionary_trackProjectDropdownLabel%": "Track Biblical Terms",
       "%platformLexicalTools_mainMenu_openDictionary%": "Open Dictionary",
-      "%platformLexicalTools_webViewMenu_openDictionary%": "Open Dictionary",
-      "%platformLexicalTools_mainMenu_openHebGrkDictionary%": "Open HEBGRK Dictionary"
+      "%platformLexicalTools_mainMenu_openDictionary_sdbhSdbg%": "Open Dictionary: SDBH/SDBG",
+      "%platformLexicalTools_mainMenu_openHebGrkDictionary%": "Open HEBGRK Dictionary",
+      "%platformLexicalTools_webViewMenu_openDictionary%": "Open Dictionary"
     }
   }
 }

--- a/extensions/src/platform-lexical-tools/contributions/menus.json
+++ b/extensions/src/platform-lexical-tools/contributions/menus.json
@@ -4,8 +4,8 @@
     "groups": {},
     "items": [
       {
-        "label": "%platformLexicalTools_mainMenu_openHebGrkDictionary%",
-        "localizeNotes": "Scripture Editor top menu > Project > HEBGRK Dictionary",
+        "label": "%platformLexicalTools_mainMenu_openDictionary_sdbhSdbg%",
+        "localizeNotes": "Scripture Editor top menu > Project > Dictionary: SDBH/SDBG",
         "group": "platform.projectResources",
         "order": 100,
         "command": "platformLexicalTools.openDictionary"

--- a/extensions/src/platform-lexical-tools/src/components/dictionary/dictionary-entry-display.component.tsx
+++ b/extensions/src/platform-lexical-tools/src/components/dictionary/dictionary-entry-display.component.tsx
@@ -181,6 +181,20 @@ export function DictionaryEntryDisplay({
             ))}
           </ul>
         </div>
+        {dictionaryEntry.lexicalReferenceTextId === 'SDBH' && (
+          <div className="tw-max-w-xs tw-pt-3">
+            <p className="tw-text-xs tw-text-muted-foreground">
+              {localizedStrings['%platformLexicalTools_dictionary_sdbhCopyright%']}
+            </p>
+          </div>
+        )}
+        {dictionaryEntry.lexicalReferenceTextId === 'SDBG' && (
+          <div className="tw-max-w-xs tw-pt-3">
+            <p className="tw-text-xs tw-text-muted-foreground">
+              {localizedStrings['%platformLexicalTools_dictionary_sdbgCopyright%']}
+            </p>
+          </div>
+        )}
       </div>
 
       <Separator className="tw-my-3" />

--- a/extensions/src/platform-lexical-tools/src/components/dictionary/domains-display.component.tsx
+++ b/extensions/src/platform-lexical-tools/src/components/dictionary/domains-display.component.tsx
@@ -23,8 +23,9 @@ type DomainsDisplayProps = {
 export function DomainsDisplay({ domains, domainText }: DomainsDisplayProps) {
   // Helper to choose icon based on taxonomy. Icons picked by UX. Only works with SDBH lexical reference text.
   const getDomainIcon = (taxonomy: string) => {
-    if (taxonomy === 'SDBH-Lexical') return <BookA className="tw-inline tw-mr-1 tw-h-3 tw-w-3" />;
-    if (taxonomy === 'SDBH-Contextual')
+    if (taxonomy === 'SDBH-Lexical' || taxonomy === 'SDBG-Lexical')
+      return <BookA className="tw-inline tw-mr-1 tw-h-3 tw-w-3" />;
+    if (taxonomy === 'SDBH-Contextual' || taxonomy === 'SDBG-Contextual')
       return <LandPlot className="tw-inline tw-mr-1 tw-h-3 tw-w-3" />;
     return <Box className="tw-inline tw-mr-1 tw-h-3 tw-w-3" />;
   };

--- a/extensions/src/platform-lexical-tools/src/main.ts
+++ b/extensions/src/platform-lexical-tools/src/main.ts
@@ -36,7 +36,7 @@ const dictionaryWebViewProvider: IWebViewProvider = {
 
     return {
       ...savedWebView,
-      title: '%platformLexicalTools_dictionary_title%',
+      title: '%platformLexicalTools_dictionary_title_sdbhSdbg%',
       content: dictionaryWebViewReact,
       styles: tailwindCssStyles,
       shouldShowToolbar: true,

--- a/extensions/src/platform-lexical-tools/src/utils/dictionary.utils.ts
+++ b/extensions/src/platform-lexical-tools/src/utils/dictionary.utils.ts
@@ -22,6 +22,8 @@ export const DICTIONARY_LOCALIZED_STRING_KEYS: LocalizeKey[] = [
   '%platformLexicalTools_dictionary_scopeSelector_section%',
   '%platformLexicalTools_dictionary_scopeSelector_verse%',
   '%platformLexicalTools_dictionary_strongsCodeLabel%',
+  '%platformLexicalTools_dictionary_sdbgCopyright%',
+  '%platformLexicalTools_dictionary_sdbhCopyright%',
   '%platformLexicalTools_dictionary_trackProjectDropdownLabel%',
 ];
 


### PR DESCRIPTION
- Update dictionary title to "Dictionary: SDBH/SDBG"
- Add copyright information based on `dictionaryEntry.lexicalReferenceTextId`
     - Text has same styles as the [check type in the check result in checks side panel](https://github.com/paranext/paranext-core/blob/f520fd2bf100409e80fdd221c5be91b59a95ab74/extensions/src/platform-scripture/src/checks/checks-side-panel/check-card.component.tsx#L179C7-L179C79). `tw-text-xs tw-text-muted-foreground`
- Edit `DomainsDisplay` so we show consistent icons for SDBG-Lexical and SDBH-Lexical, and SDBG-Contextual and SDBG-Lexical

## Questions
- How do I store the copyright strings? Currently they are pasted into a localized string.

<img width="691" height="487" alt="Screenshot 2025-08-27 at 9 37 36 AM" src="https://github.com/user-attachments/assets/5cc9865f-e6d9-4d08-a9bf-e2b73e2db337" />
<img width="949" height="453" alt="Screenshot 2025-08-27 at 9 32 40 AM" src="https://github.com/user-attachments/assets/e92e4e4b-ef44-491a-a162-4cb9d29ebb2c" />
<img width="949" height="453" alt="Screenshot 2025-08-27 at 9 32 28 AM" src="https://github.com/user-attachments/assets/2c791615-9d99-4ebc-9e31-206a94d578d9" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1800)
<!-- Reviewable:end -->
