### PR TITLE
Remove bg-white from toggle group in dictionary entry

### DIFF
--- a/extensions/src/platform-lexical-tools/src/components/dictionary/dictionary-entry-display.component.tsx
+++ b/extensions/src/platform-lexical-tools/src/components/dictionary/dictionary-entry-display.component.tsx
@@ -225,7 +225,7 @@ export function DictionaryEntryDisplay({
               <ToggleGroupItem
                 key={`${sense.lexicalReferenceTextId}-sense-${sense.id}`}
                 value={`${sense.lexicalReferenceTextId}-sense-${sense.id}`}
-                className="tw-flex tw-w-full tw-h-fit tw-flex-col tw-items-start tw-border tw-rounded-lg tw-shadow-sm tw-p-4 tw-bg-white tw-cursor-pointer data-[state=on]:tw-border-accent data-[state=on]:tw-shadow-md tw-transition-colors"
+                className="tw-flex tw-w-full tw-h-fit tw-flex-col tw-items-start tw-border tw-rounded-lg tw-shadow-sm tw-p-4 tw-cursor-pointer data-[state=on]:tw-border-accent data-[state=on]:tw-shadow-md tw-transition-colors"
               >
                 <div className="tw-flex tw-items-baseline tw-gap-2">
                   <span className="tw-font-bold tw-text-accent-foreground">{senseIndex + 1}</span>


### PR DESCRIPTION
There was a lingering `tw-bg-white` in the `ToggleGroupItem` in the dictionary entry which broke dark mode. 

<img width="770" height="597" alt="Screenshot 2025-08-28 at 9 10 12 AM" src="https://github.com/user-attachments/assets/4e59c632-e8b6-4b96-ae99-7583fbab77e1" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1804)
<!-- Reviewable:end -->
