### PR TITLE
Dictionary: Attribution at bottom of entry

### DIFF
--- a/extensions/src/platform-lexical-tools/src/components/dictionary/dictionary-entry-display.component.tsx
+++ b/extensions/src/platform-lexical-tools/src/components/dictionary/dictionary-entry-display.component.tsx
@@ -153,7 +153,7 @@ export function DictionaryEntryDisplay({
   );
 
   return (
-    <div>
+    <>
       <BackToListButton
         dictionaryEntry={dictionaryEntry}
         isDrawer={isDrawer}
@@ -181,20 +181,6 @@ export function DictionaryEntryDisplay({
             ))}
           </ul>
         </div>
-        {dictionaryEntry.lexicalReferenceTextId === 'SDBH' && (
-          <div className="tw-max-w-xs tw-pt-3">
-            <p className="tw-text-xs tw-text-muted-foreground">
-              {localizedStrings['%platformLexicalTools_dictionary_sdbhCopyright%']}
-            </p>
-          </div>
-        )}
-        {dictionaryEntry.lexicalReferenceTextId === 'SDBG' && (
-          <div className="tw-max-w-xs tw-pt-3">
-            <p className="tw-text-xs tw-text-muted-foreground">
-              {localizedStrings['%platformLexicalTools_dictionary_sdbgCopyright%']}
-            </p>
-          </div>
-        )}
       </div>
 
       <Separator className="tw-my-3" />
@@ -293,6 +279,20 @@ export function DictionaryEntryDisplay({
             </li>
           ))}
         </ul>
+        {dictionaryEntry.lexicalReferenceTextId === 'SDBH' && (
+          <div className="tw-max-w-xs tw-pt-3 tw-mt-auto">
+            <p className="tw-text-xs tw-text-muted-foreground">
+              {localizedStrings['%platformLexicalTools_dictionary_sdbhCopyright%']}
+            </p>
+          </div>
+        )}
+        {dictionaryEntry.lexicalReferenceTextId === 'SDBG' && (
+          <div className="tw-max-w-xs tw-pt-3 tw-mt-auto">
+            <p className="tw-text-xs tw-text-muted-foreground">
+              {localizedStrings['%platformLexicalTools_dictionary_sdbgCopyright%']}
+            </p>
+          </div>
+        )}
         <Button
           variant="secondary"
           size="icon"
@@ -302,6 +302,6 @@ export function DictionaryEntryDisplay({
           <ChevronUpIcon />
         </Button>
       </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
UX follow-on to [PR 1800](https://github.com/paranext/paranext-core/pull/1800) put attribution at the bottom of a dictionary entry

Before
<img width="613" height="890" alt="Screenshot 2025-08-28 at 21 32 13" src="https://github.com/user-attachments/assets/7a20721b-4a7f-4856-a9e8-ef17a181a750" />

After

<img width="615" height="891" alt="Screenshot 2025-08-28 at 21 30 29" src="https://github.com/user-attachments/assets/4b111c17-743e-4ac2-b075-e48501251e24" />

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1811)
<!-- Reviewable:end -->
