### PR TITLE
full height active tab header

### DIFF
--- a/src/renderer/components/docking/dock-layout-wrapper.component.scss
+++ b/src/renderer/components/docking/dock-layout-wrapper.component.scss
@@ -204,7 +204,7 @@ This file styles with SCSS because rc-dock doesn't give us good ways to render w
 .dock-layout .dock-panel.dock-style-platform-bible .dock-nav-list {
   position: relative;
   gap: vars.$space--xs;
-  padding-top: var(--tab-header-to-content-gap);
+  padding-block-start: var(--tab-header-to-content-gap);
   height: var(--dock-tab-height);
 }
 
@@ -250,13 +250,13 @@ This file styles with SCSS because rc-dock doesn't give us good ways to render w
   border: unset;
 
   --dock-tab-height: 30px; // also from rc-dock
-  height: calc(var(--dock-tab-height) + 6px);
+  height: calc(var(--dock-tab-height) + var(--tab-header-to-content-gap));
 
   display: flex;
   align-items: center;
   flex: 1 0 auto;
   max-width: max-content;
-  background-color: transparent;
+  background-color: unset; // reset rc-dock color
 
   transition:
     background-color 0.1s,
@@ -276,7 +276,6 @@ This file styles with SCSS because rc-dock doesn't give us good ways to render w
   &.platform-dock-tab-window-focus {
     // TODO these two properties should get the same level of abstraction
     --tab-background: var(--tab-front-focus-within);
-    background-color: var(--tab-background);
     color: hsl(var(--primary-foreground));
 
     outline: none;
@@ -297,12 +296,14 @@ This file styles with SCSS because rc-dock doesn't give us good ways to render w
   }
 }
 
-.dock-layout .dock-panel.dock-style-platform-bible .dock-tab.dock-tab-active .dock-tab-btn {
-  background-color: transparent;
+.dock-layout
+  .dock-panel.dock-style-platform-bible
+  .dock-tab:not(.dock-tab-active)
+  .dock-tab-btn:hover {
+  background-color: var(--tab-highlight);
 }
 
 .dock-layout .dock-panel.dock-style-platform-bible .dock-tab .dock-tab-btn {
-  background-color: var(--tab-background);
   border-radius: var(--radius);
   padding: unset;
   box-sizing: border-box;


### PR DESCRIPTION
This change

- makes the active tab header full height, so that they horizontally align with other tab headers and controls on the tab group
- removes the 4px tab inset (keeps the overall 8px inset) to smoothen the "border" of the first tab when focused

before:
<img width="1612" height="1026" alt="Screenshot 2025-08-29 123322" src="https://github.com/user-attachments/assets/9e7313c7-abda-48d6-98a7-d72dfce33df4" />

after:
<img width="1613" height="1029" alt="Screenshot 2025-08-29 123205" src="https://github.com/user-attachments/assets/c5041305-846f-4390-bfa7-8ada0a063680" />

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1812)
<!-- Reviewable:end -->
