### PR TITLE
PT-3336: Remove spot colors and restyle — rc-dock only

### DIFF
--- a/src/renderer/components/docking/dock-layout-wrapper.component.scss
+++ b/src/renderer/components/docking/dock-layout-wrapper.component.scss
@@ -104,12 +104,14 @@ This file styles with SCSS because rc-dock doesn't give us good ways to render w
   background: none;
 }
 
-/* global dock layout styles */
+/* While dragging a tab, shows where it will go when user releases. */
 .dock-layout > .dock-drop-indicator {
-  /* darken(#a6c9ff, 40%) = #0055d9 */
-  border: solid 1px #0055d9;
-  box-shadow: inset 0 0 10px #0055d9;
-  background: #a6c9ff;
+  --ring-offset-width: 3px;
+  --ring-color: hsl(var(--ring));
+  opacity: 100%; // reset rc-dock
+  background: hsl(var(--primary) / 0.5);
+  box-shadow: 0 0 0 calc(3px + var(--ring-offset-width)) var(--ring-color, currentcolor); // copied from Shadcn focus ring
+  border-radius: var(--radius);
 }
 // #endregion GENERAL ///////////////////////////////////////////////////
 


### PR DESCRIPTION
Only fulfillls [PT-3336](https://paratextstudio.atlassian.net/browse/PT-3336) for the rc-dock files.

Use Shadcn CSS custom properties instead of color literals in the drag-and-drop drop indicator.

After:

https://github.com/user-attachments/assets/d2f9ba7e-817b-4b12-82ff-180fd9c47a11



[PT-3336]: https://paratextstudio.atlassian.net/browse/PT-3336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1826)
<!-- Reviewable:end -->
