### PR TITLE
PT-3336 Replace spot color in Settings

### DIFF
--- a/src/renderer/components/settings-tabs/settings-components/settings.component.scss
+++ b/src/renderer/components/settings-tabs/settings-components/settings.component.scss
@@ -1,4 +1,6 @@
 .setting-container {
+  --spacing: 0.25rem;
+  gap: calc(var(--spacing) * 2); // tw-gap-2
   display: flex;
   flex-direction: column;
   width: 50%;
@@ -10,8 +12,7 @@
 }
 
 .error-label {
-  color: #dc2626;
-  padding-top: 1rem;
+  color: hsl(var(--destructive)); // tw-text-destructive
 }
 
 .loading-label {


### PR DESCRIPTION
Only fulfillls [PT-3336](https://paratextstudio.atlassian.net/browse/PT-3336) for Settings. Use Shadcn CSS custom properties instead of color literals in Settings.

Before:
<img width="1026" height="764" alt="Screenshot 2025-09-04 at 18 30 12" src="https://github.com/user-attachments/assets/8d34a5d1-4439-46f0-a269-4a28b1454999" />


After:
<img width="1026" height="764" alt="Screenshot 2025-09-04 at 18 29 37" src="https://github.com/user-attachments/assets/88d645f8-5548-428c-8863-dd4610b75fa6" />

[PT-3336]: https://paratextstudio.atlassian.net/browse/PT-3336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
