### PR TITLE
feat: made it so that extension manager functions wait for reload

### DIFF
--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -867,11 +867,7 @@ async function installExtension(
   // Waits for the extensions to reload
   await waitForExtensionsReload();
   // Checks to make sure the extension is active
-  if (
-    ![...activeExtensions.values()].find(
-      (active) => active.info.name === extensionName && active.info.version === extensionVersion,
-    )
-  ) {
+  if (activeExtensions.get(extensionName)?.info.version !== extensionVersion) {
     throw new Error(`'${extensionName} ${extensionVersion}' failed to enable!`);
   }
 
@@ -890,11 +886,7 @@ async function enableExtension(extensionId: ExtensionIdentifier) {
   // Waits for the extensions to reload
   await waitForExtensionsReload();
   // Checks to make sure the extension is active
-  if (
-    ![...activeExtensions.values()].find(
-      (active) => active.info.name === extensionName && active.info.version === extensionVersion,
-    )
-  ) {
+  if (activeExtensions.get(extensionName)?.info.version !== extensionVersion) {
     throw new Error(`'${extensionName} ${extensionVersion}' failed to enable!`);
   }
 
@@ -913,11 +905,7 @@ async function disableExtension(extensionId: ExtensionIdentifier) {
   // Waits for the extensions to reload
   await waitForExtensionsReload();
   // Checks to make sure the extension is no longer active
-  if (
-    [...activeExtensions.values()].find(
-      (active) => active.info.name === extensionName && active.info.version === extensionVersion,
-    )
-  ) {
+  if (activeExtensions.get(extensionName)?.info.version === extensionVersion) {
     throw new Error(`'${extensionName} ${extensionVersion}' failed to disable!`);
   }
 


### PR DESCRIPTION
This PR tries to implement a feature where if you install/enable/disable an extension it will wait for the extension to reload and then confirm that the extension is installed/enabled/disabled (is in the `activeExtensions` map).