### PR TITLE
PT-2335: Fix a flaw in allowing/denying check results

### DIFF
--- a/c-sharp-tests/Checks/CheckRunResultTests.cs
+++ b/c-sharp-tests/Checks/CheckRunResultTests.cs
@@ -33,7 +33,7 @@ public class CheckRunResultTests
         VerseRef vrefEnd1 = new("GEN 1:2");
         CheckLocation end1 = new(vrefEnd1, 5);
         CheckRunResult checkRunResult1 =
-            new("checkId", "resType", "projectId", "msg", "", false, vrefStart1, start1, end1);
+            new("checkId", "resType", "projectId", "msg", "", "", false, vrefStart1, start1, end1);
 
         VerseRef vrefStart2 = new(verseRefStart2);
         CheckLocation start2 = new(vrefStart2, offsetStart2);
@@ -45,6 +45,7 @@ public class CheckRunResultTests
                 checkResultType2,
                 projectId2,
                 message2,
+                "",
                 "",
                 isDenied2,
                 vrefStart2,

--- a/c-sharp/Checks/CheckRunResult.cs
+++ b/c-sharp/Checks/CheckRunResult.cs
@@ -12,7 +12,8 @@ public sealed record CheckRunResult(
     string CheckResultType,
     string ProjectId,
     string MessageFormatString,
-    string SelectedText,
+    string VerseText,
+    string ItemText,
     bool IsDenied,
     VerseRef VerseRef,
     CheckLocation Start,
@@ -28,7 +29,8 @@ public sealed record CheckRunResult(
             && CheckResultType == other.CheckResultType
             && ProjectId == other.ProjectId
             && MessageFormatString == other.MessageFormatString
-            && SelectedText == other.SelectedText
+            && VerseText == other.VerseText
+            && ItemText == other.ItemText
             && IsDenied == other.IsDenied
             && VerseRef.ToStringWithVersification() == other.VerseRef.ToStringWithVersification()
             && Start == other.Start
@@ -37,12 +39,15 @@ public sealed record CheckRunResult(
 
     public override int GetHashCode()
     {
+        // ItemText is intentionally omitted from the hash code calculation. Typically, ItemText is
+        // extracted from MessageFormatString, but if extraction fails, ItemText may be set to the entire
+        // message. Combine can only take up to 8 arguments.
         int hash = HashCode.Combine(
             CheckId,
             CheckResultType,
             ProjectId,
             MessageFormatString,
-            SelectedText,
+            VerseText,
             IsDenied,
             VerseRef,
             Start

--- a/c-sharp/Checks/CheckRunner.cs
+++ b/c-sharp/Checks/CheckRunner.cs
@@ -6,6 +6,7 @@ using Paratext.Checks;
 using Paratext.Data;
 using Paratext.Data.Checking;
 using Paratext.Data.ProjectFileAccess;
+using PtxUtils;
 using SIL.Scripture;
 
 namespace Paranext.DataProvider.Checks;
@@ -302,7 +303,7 @@ internal class CheckRunner : NetworkObjects.DataProvider
         string checkResultType,
         string projectId,
         VerseRef vRef,
-        string selectedText,
+        string itemText,
         string? _checkResultUniqueId
     )
     {
@@ -311,7 +312,7 @@ internal class CheckRunner : NetworkObjects.DataProvider
         lock (check.Lock)
         {
             var denials = GetOrCreateDenials(projectId);
-            denials.AddDenial(MessageId.UnknownUseMsgText, vRef, checkResultType, selectedText);
+            denials.AddDenial(new Enum<MessageId>(checkResultType), vRef, null, itemText);
             denials.Save();
             check.ResultsRecorder.PostProcessResults(null, denials, null);
             SendDataUpdateEvent(DATA_TYPE_CHECK_RESULTS, "Denied check result");
@@ -324,7 +325,7 @@ internal class CheckRunner : NetworkObjects.DataProvider
         string checkResultType,
         string projectId,
         VerseRef vRef,
-        string selectedText,
+        string itemText,
         string? _checkResultUniqueId
     )
     {
@@ -333,7 +334,7 @@ internal class CheckRunner : NetworkObjects.DataProvider
         lock (check.Lock)
         {
             var denials = GetOrCreateDenials(projectId);
-            denials.RemoveDenial(MessageId.UnknownUseMsgText, vRef, checkResultType, selectedText);
+            denials.RemoveDenial(new Enum<MessageId>(checkResultType), vRef, null, itemText);
             denials.Save();
             check.ResultsRecorder.PostProcessResults(null, denials, null);
             SendDataUpdateEvent(DATA_TYPE_CHECK_RESULTS, "Allowed check result");

--- a/extensions/src/hello-rock3/src/checks.ts
+++ b/extensions/src/hello-rock3/src/checks.ts
@@ -87,8 +87,9 @@ class HelloCheck implements Check {
         isDenied: false,
         projectId: this.targetProjectId ?? '',
         messageFormatString: 'Found the word "sheep"',
-        selectedText: 'sheep',
+        itemText: 'sheep',
         verseRef,
+        verseText: 'And lo, there were sheep in the field.',
         start: { verseRef, offset },
         end: {
           verseRef,

--- a/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
+++ b/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
@@ -197,14 +197,6 @@ global.webViewComponent = function ChecksSidePanelWebView({
     logger.info('Open check settings and inventories');
   }, []);
 
-  // Used messageFormatString because result.selectedText is the entire verse.
-  const writeCheckTitle = useCallback((result: CheckRunResult) => {
-    if (!result || !result.messageFormatString) return '';
-    const [, extractedWord] = result.messageFormatString.match(/\|\|(.*?)\|\|/) || [];
-
-    return `${result.verseRef.book} ${result.verseRef.chapterNum}:${result.verseRef.verseNum} ${extractedWord} ${extractedWord}`;
-  }, []);
-
   /**
    * Creates a unique identifier for a CheckRunResult, used to provide a unique key to the UI and to
    * track which check result is selected.
@@ -271,7 +263,7 @@ global.webViewComponent = function ChecksSidePanelWebView({
         result.checkResultType,
         projectId,
         result.verseRef,
-        result.selectedText,
+        result.itemText,
         result.checkResultUniqueId,
       );
 
@@ -289,7 +281,7 @@ global.webViewComponent = function ChecksSidePanelWebView({
         result.checkResultType,
         projectId,
         result.verseRef,
-        result.selectedText,
+        result.itemText,
         result.checkResultUniqueId,
       );
 
@@ -371,7 +363,7 @@ global.webViewComponent = function ChecksSidePanelWebView({
                 checkId={writeCheckId(result, index)}
                 isSelected={selectedCheckId === writeCheckId(result, index)}
                 handleSelectCheck={handleSelectCheck}
-                checkCardTitle={writeCheckTitle(result)}
+                checkCardTitle={`${result.verseRef.book} ${result.verseRef.chapterNum}:${result.verseRef.verseNum} ${result.itemText}`}
                 checkState={result.isDenied ? CheckStates.Denied : CheckStates.DefaultFailed}
                 handleDenyCheck={handleDenyCheck}
                 handleAllowCheck={handleAllowCheck}

--- a/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
+++ b/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
@@ -224,7 +224,7 @@ class CheckAggregatorDataProviderEngine
     checkResultType: string,
     projectId: string,
     verseRef: SerializedVerseRef,
-    selectedText: string,
+    itemText: string,
     checkResultUniqueId?: string,
   ): Promise<boolean> {
     const checkRunner = await this.findCheckRunnerForCheckId(checkId);
@@ -233,7 +233,7 @@ class CheckAggregatorDataProviderEngine
       checkResultType,
       projectId,
       verseRef,
-      selectedText,
+      itemText,
       checkResultUniqueId,
     );
     this.notifyUpdate('CheckResults');
@@ -245,7 +245,7 @@ class CheckAggregatorDataProviderEngine
     checkResultType: string,
     projectId: string,
     verseRef: SerializedVerseRef,
-    selectedText: string,
+    itemText: string,
     checkResultUniqueId?: string,
   ): Promise<boolean> {
     const checkRunner = await this.findCheckRunnerForCheckId(checkId);
@@ -254,7 +254,7 @@ class CheckAggregatorDataProviderEngine
       checkResultType,
       projectId,
       verseRef,
-      selectedText,
+      itemText,
       checkResultUniqueId,
     );
     this.notifyUpdate('CheckResults');

--- a/extensions/src/platform-scripture/src/checks/extension-host-check-runner.service.ts
+++ b/extensions/src/platform-scripture/src/checks/extension-host-check-runner.service.ts
@@ -240,14 +240,14 @@ class CheckRunnerEngine
     checkResultType: string,
     projectId: string,
     verseRef: SerializedVerseRef,
-    selectedText: string,
+    itemText: string,
     checkResultUniqueId?: string,
   ): Promise<boolean> {
     const deniedResults = await this.loadDeniedResults(projectId);
     const retVal = deniedResults.addResult({
       checkResultType,
       verseRef,
-      selectedText,
+      itemText,
       checkResultUniqueId,
     });
     if (retVal) await this.saveDeniedResults(projectId);
@@ -259,14 +259,14 @@ class CheckRunnerEngine
     checkResultType: string,
     projectId: string,
     verseRef: SerializedVerseRef,
-    selectedText: string,
+    itemText: string,
     checkResultUniqueId?: string,
   ): Promise<boolean> {
     const deniedResults = await this.loadDeniedResults(projectId);
     const retVal = deniedResults.removeResult({
       checkResultType,
       verseRef,
-      selectedText,
+      itemText,
       checkResultUniqueId,
     });
     if (retVal) await this.saveDeniedResults(projectId);

--- a/extensions/src/platform-scripture/src/checks/persisted-check-run-result.model.ts
+++ b/extensions/src/platform-scripture/src/checks/persisted-check-run-result.model.ts
@@ -8,7 +8,12 @@ export type PersistedCheckRunResult = {
   /** Single verse reference identifying where the check result occurred */
   verseRef: SerializedVerseRef;
   /** Project text that was selected in the check result */
-  selectedText: string;
+  verseText?: string;
+  /**
+   * The specific item (i.e. marker, word, punctuation character et cetera) that the result applies
+   * to. Is also present in `messageFormatString` to form a localizable message.
+   */
+  itemText: string;
   /** Distinct ID for this check result if it might occur more than once in a single verse */
   checkResultUniqueId?: string;
 };
@@ -67,7 +72,7 @@ export class PersistedCheckRunResults {
       return (
         existingResult.checkResultType === result.checkResultType &&
         existingResult.verseRef.verse === result.verseRef.verse &&
-        existingResult.selectedText === result.selectedText &&
+        existingResult.verseText === result.verseText &&
         existingResult.checkResultUniqueId === result.checkResultUniqueId
       );
     });
@@ -96,7 +101,7 @@ export class PersistedCheckRunResults {
       return (
         possibleMatch.checkResultType === result.checkResultType &&
         possibleMatch.verseRef.verse === result.verseRef.verse &&
-        possibleMatch.selectedText === result.selectedText &&
+        possibleMatch.verseText === result.verseText &&
         possibleMatch.checkResultUniqueId === result.checkResultUniqueId
       );
     });

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -857,7 +857,12 @@ declare module 'platform-scripture' {
     /** ID of the project evaluated by the check */
     projectId: string;
     /** Project text that was selected in the check result */
-    selectedText: string;
+    verseText: string;
+    /**
+     * The specific item (i.e. marker, word, punctuation character et cetera) that the result
+     * applies to. Is also used present in `messageFormatString` to form a localizable message.
+     */
+    itemText: string;
     /**
      * Format string or {@link LocalizeKey} of the format string to display regarding the range of
      * text referenced in this result. A format string should be of the form "... {arg1} ... {arg2}
@@ -930,7 +935,7 @@ declare module 'platform-scripture' {
       checkResultType: string,
       projectId: string,
       verseRef: SerializedVerseRef,
-      selectedText: string,
+      itemText: string,
       checkResultUniqueId?: string,
     ) => Promise<boolean>;
     /** Reverse the denial of one particular check result */
@@ -939,7 +944,7 @@ declare module 'platform-scripture' {
       checkResultType: string,
       projectId: string,
       verseRef: SerializedVerseRef,
-      selectedText: string,
+      itemText: string,
       checkResultUniqueId?: string,
     ) => Promise<boolean>;
   };


### PR DESCRIPTION
https://github.com/user-attachments/assets/ba6cb1a6-c7bc-449c-b4b2-403803ff0384

This issue originated because we provided incorrect data to the AddDenial and RemoveDenial functions in the PT9 code. Providing the correct data fixed the issue. Functionality has been checked for all available checks, and works for all of them except  the `Quotation` and `Quotation types` checks, as they require configuration, which is currently not available in PT10. A message about this is printed to the console when enabling the check.

```
  How PT10 used to store denials:
  <Denial ref="MAT 1:1" key="UnknownUseMsgText" message="RepeatedWord" />
  How PT9 stores denials, and we now do to:
  <Denial ref="MAT 1:1" key="RepeatedWord" text="bout" />
  <Denial ref="MAT 1:1" key="RepeatedWord" text="tell" />
  <Denial ref="MAT 1:2" key="RepeatedWord" text="had" />
  
  How PT10 now stores denials for all currently supported checks:
  (Note that many checks use many different keys. The list here is not exhaustive, but all keys are extracted from Enum<MessageId> in the PT9 code)
  // Characters check:  
  <Denial ref="GEN 3:1" key="MixedCapitalization" text="JShow" />
  <Denial ref="DEU 9:23" key="CapStyle_MarkerTextNotCapital" text="xo" />
  <Denial ref="DEU 6:20" key="FinalPuncSent_CapitalMissingAfterSent" text="?" />
  // Chapter/verse numbers:  
  <Denial ref="MAT 5:13" key="CV_VerseNumInHeading" text="#Verse number in heading" />
  <Denial ref="MAT 2:2" key="CV_VerseNumMissing" text="#Verses missing: 2:3-6" />
  <Denial ref="2JN 1:4" key="CV_VerseSegUnknown" text="#Unknown verse segment: I" />
  <Denial ref="2JN 1:3" key="CV_VerseNumMissing" text="#Verse missing: 1:4" />
  // Characters:
  <Denial ref="2JN 1:4I" key="Char_CharacterInvalid" text="I" />
  // Marker:
  <Denial ref="MAT 1:17" key="Mark_Unknown" text="#Unknown marker: \zmsc-s" />
  <Denial ref="MAT 1:17" key="Mark_UnmatchedEndMarker" text="#Closing marker does not have matching opening marker: \*" />
  <Denial ref="MAT 2:16" key="Mark_EmptyMarker" text="#Empty marker: \p" />
  <Denial ref="MAT 5:13" key="Mark_MarkerWrongPlace" text="#Marker cannot occur here: \v" />
  <Denial ref="PHM 1:21" key="Mark_MissingOriginRefUnexpected" text="#Most notes of this type have an origin reference" />
  // Unmatched pairs of punctuation:
  <Denial ref="EXO 9:24" key="Pair_PuncUnmatched" text="}" />
  // Numbers:
  <Denial ref="NEH 7:42" key="Num_FinalPuncInvalid" text="1,017.”" />
  <Denial ref="MAT 1:4" key="Num_PrefixInvalid" text="Tamar.1:3:" />
  // Markers missing final punctuation:
  <Denial ref="MAT 25:40" key="FinalPuncPara_ParaEndPuncMissing" text="#Punctuation missing at end of paragraph" />
  // Punctuation:
  <Denial ref="MAT 1:17" key="FinalPuncPara_ParaEndPuncMissing" text="#Punctuation missing at end of paragraph" />
  <Denial ref="MAT 1:0" key="Punc_Invalid" text=")_" />
  // Footnote quotes:
  <Denial ref="ACT 1:20" key="QuotText_QuoteNotInVerse" text="let anodda guy take his lead." />
  // Reference:
  <Denial ref="GEN 1:3" key="Ref_OriginInvalid" text="1:3: \xo*" />
  <Denial ref="NUM 20:28" key="Ref_ChapVerseSepInvalid" text=":" />
  // Repeated word:  
  <Denial ref="MAT 1:1" key="RepeatedWord" text="bout" />
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1839)
<!-- Reviewable:end -->
