### PR TITLE
PT-3404 Fix some data problems when saving comments

### DIFF
--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -203,6 +203,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         if (!CommentsEnabled)
             return false;
 
+        var scrText = LocalParatextProjects.GetParatextProject(ProjectDetails.Metadata.Id);
         bool madeChange = false;
         foreach (var ic in incomingComments)
         {
@@ -217,6 +218,8 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                 );
             if (thread.Comments.Find((c) => c.Id == ic.Id) != null)
                 continue;
+            // Override the user name with the value from ParatextData
+            ic.User = scrText.User.Name;
             _commentManager.AddComment(ic);
             _commentManager.SaveUser(ic.User, false);
             madeChange = true;

--- a/extensions/src/platform-scripture-editor/src/comments.ts
+++ b/extensions/src/platform-scripture-editor/src/comments.ts
@@ -119,6 +119,8 @@ export function convertEditorCommentsToLegacyComments(
   comments.forEach((editorComment) => {
     const commentDetails = getCommentDetails(usjRW, editorComment.id, verseLocation.book);
     if (!commentDetails) return;
+    const startVerseRef = commentDetails.start.verseRef;
+    const verseRef = `${startVerseRef.book} ${startVerseRef.chapterNum}:${startVerseRef.verse ?? startVerseRef.verseNum}`;
     if (editorComment.type === 'comment') {
       legacyComments.push({
         contents: editorComment.content,
@@ -132,7 +134,7 @@ export function convertEditorCommentsToLegacyComments(
         startPosition: commentDetails.start.offset,
         thread: editorComment.id,
         user: editorComment.author,
-        verseRef: commentDetails.start.verseRef.toString(),
+        verseRef,
       });
     } else {
       editorComment.comments.forEach((editorThreadComment) => {
@@ -148,7 +150,7 @@ export function convertEditorCommentsToLegacyComments(
           startPosition: commentDetails.start.offset,
           thread: editorComment.id,
           user: editorThreadComment.author,
-          verseRef: commentDetails.start.verseRef.toString(),
+          verseRef,
         });
       });
     }


### PR DESCRIPTION
As the code currently works, all comments get saved as being authored by "Scripture User" because that is the [default name used in the editor control](https://github.com/eten-tech-foundation/scripture-editors/blob/f8de8b04c67f427cf1b65ca53b4dd3225408c17b/packages/platform/src/marginal/comments/CommentPlugin.tsx#L684). This change overrides whatever name is provided with the name that ParatextData.dll knows. The comment author's name is used by ParatextData.dll to identify the file name where to store the comment.

Note that if the comment source uses a name other than the name known to ParatextData.dll, then the PDP is going to hand back different comment data which could force comments to fully reload depending on the UI implementation. Since we're redoing the UI for comments now, I don't want to get hung up on the current UI behavior (which is completely hidden for now without turning on an undocumented setting).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1855)
<!-- Reviewable:end -->
