### PR TITLE
PT-2358: Normalize USFM coming from file and going to file

### DIFF
--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1201,10 +1201,10 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
 
     /// <summary>
     /// Copied from `ScrText.StandardizeCrLfsIfNecessary`. We need to do this when setting USFM
-    /// because we need to normalize USFM with CrLfs before we run `ScrText.PutText`, and we expect
+    /// because we need to normalize USFM with CR/LFs before we run `ScrText.PutText`, and we expect
     /// CR not to be present on the USFM received for setting.
     ///
-    /// Some programs (include cc which is used for mapin/mapout) strip out cr's.
+    /// Some programs (include cc which is used for mapin/mapout) strip out CRs.
     /// Put them back in if missing. Also terminates with CR/LF
     /// </summary>
     private static string StandardizeCrLfsIfNecessary(string text)

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1176,7 +1176,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
 
     public string GetBookUsfm(VerseRef verseRef)
     {
-        return GetFromScrText(
+        return GetUsfmFromScrText(
             verseRef,
             (ScrText scrText, VerseRef verseRef) => scrText.GetText(verseRef, false, true)
         );
@@ -1184,7 +1184,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
 
     public string GetChapterUsfm(VerseRef verseRef)
     {
-        return GetFromScrText(
+        return GetUsfmFromScrText(
             verseRef,
             (ScrText scrText, VerseRef verseRef) => scrText.GetText(verseRef, true, true)
         );
@@ -1192,17 +1192,57 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
 
     public string GetVerseUsfm(VerseRef verseRef)
     {
-        return GetFromScrText(
+        return GetUsfmFromScrText(
             verseRef,
             (ScrText scrText, VerseRef verseRef) =>
                 scrText.Parser.GetVerseUsfmText(FindMatchingVerseRefInScrText(verseRef, scrText))
         );
     }
 
+    /// <summary>
+    /// Copied from `ScrText.StandardizeCrLfsIfNecessary`. We need to do this when setting book USFM
+    /// because we do not go through `ScrText.PutText`, and we strip out CR.
+    ///
+    /// Some programs (include cc which is used for mapin/mapout) strip out cr's.
+    /// Put them back in if missing. Also terminates with CR/LF
+    /// </summary>
+    private static string StandardizeCrLfsIfNecessary(string text)
+    {
+        text = text.Replace("\r", "").Replace("\n", "\r\n");
+        if (!text.EndsWith("\r\n", StringComparison.Ordinal))
+            text = text + "\r\n";
+        return text;
+    }
+
+    /// <summary>
+    /// Strip out the carriage returns from a string. This should be run on all USFM text going out
+    /// from this class.
+    ///
+    /// We use just LF in Platform.Bible Scripture text so UsjReaderWriter can accurately convert
+    /// between USFM and USJ positions without knowing the USFM.
+    /// </summary>
+    /// <param name="text"></param>
+    /// <returns></returns>
+    private static string RemoveCarriageReturns(string text)
+    {
+        return text.Replace("\r", "");
+    }
+
     public bool SetBookUsfm(VerseRef verseRef, string data)
     {
         verseRef.ChapterNum = 0;
         var scrText = LocalParatextProjects.GetParatextProject(ProjectDetails.Metadata.Id);
+
+        // Make newlines have CRLF because Paratext 9.4 always does this regardless of operating
+        // system, and we want to match Paratext 9.4's whitespace.
+        // ScrText.PutText runs other private methods to standardize the text before saving to file
+        // as well. Maybe sometime we should see if we can get ScrText.PutBook created or something
+        // so we don't have to copy stuff here or have inconsistencies.
+        data = StandardizeCrLfsIfNecessary(data);
+        // Normalize the USFM before saving (note: this is now done twice when called from SetBookUsx,
+        // but that normalization is done before making sure everything is CRLF which does affect
+        // the normalization code, unfortunately. Could optimize)
+        data = UsfmToken.NormalizeUsfm(scrText, verseRef.BookNum, data);
 
         var isNewBook = false;
 
@@ -1232,6 +1272,15 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         try
         {
             var scrText = LocalParatextProjects.GetParatextProject(ProjectDetails.Metadata.Id);
+
+            // Make newlines have CRLF because Paratext 9.4 always does this regardless of operating
+            // system, and we want to match Paratext 9.4's whitespace.
+            data = StandardizeCrLfsIfNecessary(data);
+            // Normalize the USFM before saving (note: this is now done twice when called from SetChapterUsx,
+            // but that normalization is done before making sure everything is CRLF which does affect
+            // the normalization code, unfortunately. Could optimize)
+            data = UsfmToken.NormalizeUsfm(scrText, verseRef.BookNum, data);
+
             RunWithinLock(
                 WriteScope.EntireProject(scrText),
                 writeLock =>
@@ -1357,6 +1406,15 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
 
     #region Private helper methods
 
+    /// <summary>
+    /// Helper function to make it convenient to get text data from ScrText and normalize it so it
+    /// is ready to be used.
+    /// </summary>
+    /// <param name="verseRef">Verse reference at which to get the text data</param>
+    /// <param name="getTextFromScrText">Function to get the text from ScrText. If you want to get USFM from the ScrText, use `GetUsfmFromScrText` instead</param>
+    /// <returns></returns>
+    /// <exception cref="MissingBookException">If the requested book is missing in the ScrText</exception>
+    /// <exception cref="InvalidDataException">If the project was not found</exception>
     private string GetFromScrText(
         VerseRef verseRef,
         Func<ScrText, VerseRef, string> getTextFromScrText
@@ -1377,6 +1435,37 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                 $"Project with ID '{ProjectDetails.Metadata.Id}' was not found"
             );
         }
+    }
+
+    /// <summary>
+    /// Helper function to make it convenient to get USFM data from ScrText and normalize it so it
+    /// is ready to be used.
+    /// </summary>
+    /// <param name="verseRef">Verse reference at which to get the USFM data</param>
+    /// <param name="getTextFromScrText">Function to get the USFM from ScrText. If you want to get other kinds of text from the ScrText like USX, use `GetFromScrText` instead</param>
+    /// <returns></returns>
+    /// <exception cref="MissingBookException">If the requested book is missing in the ScrText</exception>
+    /// <exception cref="InvalidDataException">If the project was not found</exception>
+    private string GetUsfmFromScrText(
+        VerseRef verseRef,
+        Func<ScrText, VerseRef, string> getTextFromScrText
+    )
+    {
+        return GetFromScrText(
+            verseRef,
+            (scrText, verseRef) =>
+            {
+                // Always normalize the USFM and remove CR before giving it out. This way,
+                // UsjReaderWriter can accurately convert between USFM and USJ positions without knowing
+                // the USFM
+                var usfm = UsfmToken.NormalizeUsfm(
+                    scrText,
+                    verseRef.BookNum,
+                    getTextFromScrText(scrText, verseRef)
+                );
+                return RemoveCarriageReturns(usfm);
+            }
+        );
     }
 
     /// <summary>

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1200,8 +1200,9 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     }
 
     /// <summary>
-    /// Copied from `ScrText.StandardizeCrLfsIfNecessary`. We need to do this when setting book USFM
-    /// because we do not go through `ScrText.PutText`, and we strip out CR.
+    /// Copied from `ScrText.StandardizeCrLfsIfNecessary`. We need to do this when setting USFM
+    /// because we need to normalize USFM with CrLfs before we run `ScrText.PutText`, and we expect
+    /// CR not to be present on the USFM received for setting.
     ///
     /// Some programs (include cc which is used for mapin/mapout) strip out cr's.
     /// Put them back in if missing. Also terminates with CR/LF
@@ -1235,9 +1236,6 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
 
         // Make newlines have CRLF because Paratext 9.4 always does this regardless of operating
         // system, and we want to match Paratext 9.4's whitespace.
-        // ScrText.PutText runs other private methods to standardize the text before saving to file
-        // as well. Maybe sometime we should see if we can get ScrText.PutBook created or something
-        // so we don't have to copy stuff here or have inconsistencies.
         data = StandardizeCrLfsIfNecessary(data);
         // Normalize the USFM before saving (note: this is now done twice when called from SetBookUsx,
         // but that normalization is done before making sure everything is CRLF which does affect

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1358,7 +1358,10 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                     // This may happen if someone makes a whitespace change that gets normalized
                     // back to the same USFM
                     var currentUsfm = GetChapterUsfm(verseRef);
-                    if (currentUsfm == usfm)
+                    // We need to remove carriage returns from the new USFM before comparing
+                    // because GetChapterUsfm removes carriage returns but the normalized USFM
+                    // from the input USX appropriately has CRLFs for saving to file
+                    if (currentUsfm == RemoveCarriageReturns(usfm))
                     {
                         didChange = false;
                         return;

--- a/lib/platform-bible-utils/src/scripture/usj-reader-writer-test-data/testUSFM-2SA-1-locations.ts
+++ b/lib/platform-bible-utils/src/scripture/usj-reader-writer-test-data/testUSFM-2SA-1-locations.ts
@@ -609,31 +609,11 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
       },
     },
   },
-  {
-    usfmVerseLocation: {
-      verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 67,
-    },
-    usjContent: {
-      node: {
-        type: 'chapter',
-        marker: 'c',
-        number: '1',
-        altnumber: '1 ca',
-        pubnumber: '1 cp',
-        sid: '2SA 1',
-      },
-      documentLocation: {
-        jsonPath: "$.content[4]['number']",
-        propertyOffset: 2,
-      },
-    },
-  },
   // begin altnumber - first example of an attribute marker
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 68,
+      offset: 67,
     },
     usjContent: {
       node: {
@@ -653,7 +633,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 69,
+      offset: 68,
     },
     usjContent: {
       node: {
@@ -674,7 +654,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 70,
+      offset: 69,
     },
     usjContent: {
       node: {
@@ -695,7 +675,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 71,
+      offset: 70,
     },
     usjContent: {
       node: {
@@ -716,7 +696,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 72,
+      offset: 71,
     },
     usjContent: {
       node: {
@@ -736,7 +716,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 73,
+      offset: 72,
     },
     usjContent: {
       node: {
@@ -756,7 +736,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 74,
+      offset: 73,
     },
     usjContent: {
       node: {
@@ -776,7 +756,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 75,
+      offset: 74,
     },
     usjContent: {
       node: {
@@ -796,7 +776,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 76,
+      offset: 75,
     },
     usjContent: {
       node: {
@@ -817,7 +797,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 77,
+      offset: 76,
     },
     usjContent: {
       node: {
@@ -838,7 +818,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 78,
+      offset: 77,
     },
     usjContent: {
       node: {
@@ -859,7 +839,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 79,
+      offset: 78,
     },
     usjContent: {
       node: {
@@ -880,7 +860,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 80,
+      offset: 79,
     },
     usjContent: {
       node: {
@@ -902,7 +882,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 81,
+      offset: 80,
     },
     usjContent: {
       node: {
@@ -922,7 +902,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 82,
+      offset: 81,
     },
     usjContent: {
       node: {
@@ -943,7 +923,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 83,
+      offset: 82,
     },
     usjContent: {
       node: {
@@ -964,7 +944,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 84,
+      offset: 83,
     },
     usjContent: {
       node: {
@@ -985,7 +965,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 85,
+      offset: 84,
     },
     usjContent: {
       node: {
@@ -1005,7 +985,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 86,
+      offset: 85,
     },
     usjContent: {
       node: {
@@ -1025,7 +1005,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 87,
+      offset: 86,
     },
     usjContent: {
       node: {
@@ -1045,7 +1025,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 88,
+      offset: 87,
     },
     usjContent: {
       node: {
@@ -1065,7 +1045,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 89,
+      offset: 88,
     },
     usjContent: {
       node: {
@@ -1086,7 +1066,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 90,
+      offset: 89,
     },
     usjContent: {
       node: {
@@ -1102,7 +1082,7 @@ export const testUSFM2SaCh1Locations: LocationUsfmAndUsj[] = [
   {
     usfmVerseLocation: {
       verseRef: { book: '2SA', chapterNum: 1, verseNum: 0 },
-      offset: 196,
+      offset: 195,
     },
     usjContent: {
       node: {

--- a/lib/platform-bible-utils/src/scripture/usj-reader-writer-test-data/testUSFM-2SA-1.usfm
+++ b/lib/platform-bible-utils/src/scripture/usj-reader-writer-test-data/testUSFM-2SA-1.usfm
@@ -2,8 +2,7 @@
 \toc3 2Sam
 \toc2 2 Sam
 \toc1 2 Samuel
-\c 1
- \ca 1 ca\ca*
+\c 1 \ca 1 ca\ca*
 \cp 1 cp
 \s1 This chapter and the next two chapters have lots of challenging USFM test markers and such in them.
 \p

--- a/lib/platform-bible-utils/src/scripture/usj-reader-writer-test-data/testUSFM-2SA-2.usfm
+++ b/lib/platform-bible-utils/src/scripture/usj-reader-writer-test-data/testUSFM-2SA-2.usfm
@@ -1,5 +1,4 @@
-\c 2
- \ca 2 ca
+\c 2 \ca 2 ca
 \cp 2 cp \f + \fr 2.0 \ft For some reason, Paratext's backslash menu allows you to insert a note and nothing else in a cp marker. You can add \wj character markers\wj* inside the note.\f* more \wj cp\wj* text
 \p
 \v 1 Notice that this chapter's attribute marker ca does not apply to the chapter as the altnumber attribute because the ca is not closed and therefore has the closed="true" attribute. Because ca is not translated to an attribute, attribute marker cp also follows suit and is not translated into pubnumber. This prior separation of cp from the chapter marker allows Paratext 9.5 to understand that it should make cp an independent marker that may have other marker contents in it. But see chapter 3 in which Paratext 9.5 fails to recognize that cp should be an independent marker.

--- a/lib/platform-bible-utils/src/scripture/usj-reader-writer-test-data/testUSFM-2SA-3.usfm
+++ b/lib/platform-bible-utils/src/scripture/usj-reader-writer-test-data/testUSFM-2SA-3.usfm
@@ -1,5 +1,4 @@
-\c 3
- \ca 3 ca\ca*
+\c 3 \ca 3 ca\ca*
 \cp 3 cp \wj wj marker \wj*
 \p
 \v 1 Notice that this chapter's attribute marker ca properly applies to the chapter as the altnumber attribute. However, its attribute marker cp should not be translated into pubnumber because it has markers in it. But Paratext 9.5 does not realize cp should be its own marker and improperly applies the part of cp before any markers as the pubnumber and puts the rest of the contents after the chapter marker.

--- a/lib/platform-bible-utils/src/scripture/usj-reader-writer.test.ts
+++ b/lib/platform-bible-utils/src/scripture/usj-reader-writer.test.ts
@@ -115,8 +115,9 @@ const webMatthew5Usj: Usj = JSON.parse(readTestDataFile('web-matthew-5-section-h
  * TestUSFM 2 Samuel 1 in USFM. Output from Platform.Bible; had to change `\\"` to `"` to unescape
  * quotes then `\\r\\n` to `\n` to unescape newlines then `\\\\` to `\\` to unescape markers
  *
- * Note: this content was fed into Paratext 9 so its whitespace was normalized according to Paratext
- * 9's rules. We will deal with whitespace normalization issues later.
+ * Note: this content was normalized in Paratext 9 using `UsfmToken.NormalizeUsfm`, so its
+ * whitespace was normalized according to Paratext 9's rules. We will deal with whitespace
+ * normalization issues later.
  */
 const testUSFM2SACh1Usfm = readTestDataFile('testUSFM-2SA-1.usfm');
 
@@ -124,8 +125,9 @@ const testUSFM2SACh1Usfm = readTestDataFile('testUSFM-2SA-1.usfm');
  * TestUSFM 2 Samuel 2 in USFM. Output from Platform.Bible; had to change `\\"` to `"` to unescape
  * quotes then `\\r\\n` to `\n` to unescape newlines then `\\\\` to `\\` to unescape markers
  *
- * Note: this content was fed into Paratext 9 so its whitespace was normalized according to Paratext
- * 9's rules. We will deal with whitespace normalization issues later.
+ * Note: this content was normalized in Paratext 9 using `UsfmToken.NormalizeUsfm`, so its
+ * whitespace was normalized according to Paratext 9's rules. We will deal with whitespace
+ * normalization issues later.
  */
 const testUSFM2SACh2Usfm = readTestDataFile('testUSFM-2SA-2.usfm');
 
@@ -133,8 +135,9 @@ const testUSFM2SACh2Usfm = readTestDataFile('testUSFM-2SA-2.usfm');
  * TestUSFM 2 Samuel 3 in USFM. Output from Platform.Bible; had to change `\\"` to `"` to unescape
  * quotes then `\\r\\n` to `\n` to unescape newlines then `\\\\` to `\\` to unescape markers
  *
- * Note: this content was fed into Paratext 9 so its whitespace was normalized according to Paratext
- * 9's rules. We will deal with whitespace normalization issues later.
+ * Note: this content was normalized in Paratext 9 using `UsfmToken.NormalizeUsfm`, so its
+ * whitespace was normalized according to Paratext 9's rules. We will deal with whitespace
+ * normalization issues later.
  */
 const testUSFM2SACh3Usfm = readTestDataFile('testUSFM-2SA-3.usfm');
 

--- a/lib/platform-bible-utils/src/scripture/usj-reader-writer.ts
+++ b/lib/platform-bible-utils/src/scripture/usj-reader-writer.ts
@@ -2601,7 +2601,7 @@ export class UsjReaderWriter implements IUsjReaderWriter {
     let markerUsfmOutput;
     let markerFragmentsInfo: UsjFragmentInfoMinimal[];
 
-    const { markerNameOriginal, markerType, markerTypeInfo } = this.getInfoForMarker(
+    const { markerType, markerTypeInfo } = this.getInfoForMarker(
       'isClosingMarker' in marker ? marker.forMarker : marker,
     );
 
@@ -2660,26 +2660,6 @@ export class UsjReaderWriter implements IUsjReaderWriter {
         // If there's supposed to be a newline before the marker, it should eat the last space if
         // there is one (that last space gets turned into the newline in this format)
         usfmOutput = UsjReaderWriter.removeEndSpace(usfmOutput);
-      }
-    }
-
-    // Special case: `ca` after chapter marker needs a newline and space before in Paratext USFM for
-    // some reason
-    // Note that there is not a newline and space before `ca` after importing from USX in Paratext,
-    // so maybe we should just remove the newline and space in the PDP
-    if (this.markersMap.isSpaceAfterAttributeMarkersContent && markerNameOriginal === 'ca') {
-      // Find the last marker in the current USFM output
-      const lastMarkerBackslashIndex = usfmOutput.lastIndexOf('\\');
-      if (lastMarkerBackslashIndex >= 0) {
-        // We just want to know if it's a chapter marker, so we can just get two characters, c and space
-        const lastMarker = usfm.substring(
-          lastMarkerBackslashIndex + 1,
-          lastMarkerBackslashIndex + 3,
-        );
-        if (lastMarker === 'c ') {
-          usfmOutput = UsjReaderWriter.removeEndSpace(usfmOutput);
-          usfmOutput += '\n ';
-        }
       }
     }
 


### PR DESCRIPTION
Normalize when coming out from `ParatextProjectDataProvider` and when saving to file. This is a significant product-level change that has been approved by Todd, Glenn, and Mike Lothers. I will discuss with Karina once this is merged so she can document this change in the list of significant things to note about using Paratext 10 Studio.

Benefits:
- Files with non-normalized USFM will not be changed unless edited in Platform.Bible
- All the code that relies on USFM being normalized according to Paratext's rules (including `UsjReaderWriter` USFM location <-> USJ location transformation) will still work on all USFM served from `ParatextProjectDataProvider`
- Any project that uses USFM 2.0 will be transformed to USFM 3.0 (automatic transformation during normalization and transformed back to USFM 2.0 while saving to file), so no one has to deal with USFM 2.0

Drawbacks:
- If a team uses Platform.Bible and something else that does not normalize whitespace the way Paratext 9 does (including Paratext 9 in some cases as mentioned below) to edit their project, the USFM they edit in Platform.Bible will be normalized, meaning non-normalized whitespace will be removed.
  - John Wickberg knows of at least one team who uses Paratext 9 unformatted view, which preserves non-normalized whitespace. However, he mentioned it is worth considering removing this ability (meaning normalize the USFM even in the unformatted view) since it is not officially supported and does not work properly all the time. See [this discussion in Discord](https://discord.com/channels/892072317436448768/892072317885235261/1431337999030812805) for more information.
  - This should not affect teams who use the Paratext 9 standard view almost at all. Paratext 9 Standard view saves USFM to file almost exactly normalized already, so their files have essentially no risk of changing (and no risk of meaningful changes)
    - TJ knows of one case where the Paratext 9 standard view saves to file in a way that is not the same as how Paratext 9 normalizes, so this situation would cause churn: Paratext 9 standard view saves the `ca` marker with an extra newline before the space before the marker. This means S/Ring and editing a project with `ca` markers will cause this extra newline to pop in and out every time the team edits the same chapter in the two different tools. The following image gives an example of what this would look like (Paratext 9 normalized USFM and proposed Paratext 10 Studio USFM on the left; Paratext 9 Standard View USFM on the right):
<img width="868" height="174" alt="image" src="https://github.com/user-attachments/assets/59e820c6-54c1-4b7c-982d-cc9cd6278d17" />


## Follow-up needed when this merges: the Standard-view attribute-markers work

The Standard-view attribute-markers track (PT-4186; scripture-editors branch `sv/attribute-markers` + this repo's `sv/attribute-markers-core`) deliberately KEPT the `ca` newline-plus-space special case in `UsjReaderWriter.toUsfm()` — restored with its index/slice bug fixed and a comment documenting both writers (Paratext 9 Standard View saves `\c 1` + newline + ` \ca 2\ca*`; ParatextData's USX->USFM writes same-line). Pre-normalization, byte fidelity with Standard-View-saved files was the right call. Once THIS PR merges, that reasoning inverts: the PDP normalizes all USFM served and saved, the newline never survives anywhere in Platform.Bible, and the special case should be removed — exactly as this PR does.

Two follow-ups:

1. **Expect a merge conflict** between this PR and the attribute-markers branch in `lib/platform-bible-utils/src/scripture/usj-reader-writer.ts` (the special-case block, rewritten there) and in the 2SA testUSFM fixtures + `testUSFM-2SA-1-locations.ts` (restored there to the newline shape). Resolution: **this PR's removal wins** — delete the whole special-case block and take this PR's fixture/locations shapes.

2. **scripture-editors needs a corresponding PR** after this merges, because it vendors copies of the 2SA fixtures. Prompt for an AI chat to do that work (from `main`; it has no other context):

> In the scripture-editors repo, work from `main` on a new branch. Context: paranext-core PR #1896 ("PT-2358: Normalize USFM coming from file and going to file") merged. Among other things it removed the `ca` special case in paranext-core's `lib/platform-bible-utils/src/scripture/usj-reader-writer.ts` (which emitted a newline plus leading space before a `ca` marker following a chapter marker, matching Paratext 9 Standard View's save shape) and joined the `\c`/`\ca` lines in paranext-core's testUSFM 2SA fixtures to the normalized same-line form (`\c 1 \ca 1 ca\ca*`).
>
> scripture-editors vendors copies of those fixtures at `libs/shared/src/converters/usfm/testUsfmCorpus/` (per its README: the source of truth is paranext-core's `lib/platform-bible-utils/src/scripture/usj-reader-writer-test-data/`; re-copy when it changes). Your task:
>
> 1. Copy `testUSFM-2SA-1.usfm`, `testUSFM-2SA-2.usfm`, and `testUSFM-2SA-3.usfm` from a paranext-core checkout at or after the PR #1896 merge into `libs/shared/src/converters/usfm/testUsfmCorpus/`, overwriting. Copy, do not hand-edit. Do NOT touch the `.usj` oracle files: the two whitespace spellings parse to identical USJ (a line break before an attribute marker is structural whitespace to the tokenizer), so the oracles are unchanged.
> 2. Run the cross-oracle corpus: `env -u _VOLTA_TOOL_RECURSION pnpm nx test shared -- usfmFragmentToUsj.corpus`. It must stay at zero divergence with no skips. No tokenizer changes should be needed — the parser handles both spellings identically, and `libs/shared/src/converters/usfm/usfmFragmentToUsj.test.ts` has explicit pins for the chapter `\ca` fold across both a same-line space and a line break.
> 3. Check `libs/test-data/src/data/2sa.usj-locations.ts`: its `usfmVerseLocation` values are documentation-only cross-references ("not used in assertions") into paranext-core's locations table, which PR #1896 adjusted (the chapter-1 verse-0 offsets at and after the old `\c 1`/`\ca` line boundary shifted down by one). Update the affected offsets to match, or leave them with a note — but do not let them silently read as authoritative.
> 4. Run the full suites (`env -u _VOLTA_TOOL_RECURSION pnpm nx run-many -t test`) and lint/typecheck (`env -u _VOLTA_TOOL_RECURSION pnpm nx run-many -t lint typecheck`). Corpus suites stay at full count with zero new skips.
>
> Context you do not need to rediscover: the Standard-view editor's own display and settle machinery is agnostic to this change — it already displays chapter attribute runs on the chapter's own line, and nothing in scripture-editors ever emitted the newline shape; only the vendored fixture bytes carry it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/1896)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/paranext/paranext-core/pull/1896" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

