### PR TITLE
New Simple from v0 (from MagicPatterns)

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -2888,8 +2888,13 @@ declare module 'shared/models/docking-framework.model' {
   ) => Promise<void>;
   /** Properties related to the dock layout */
   export type PapiDockLayout = {
-    /** The rc-dock dock layout React element ref. Used to perform operations on the layout */
-    dockLayout: DockLayout;
+    /**
+     * The rc-dock dock layout React element ref. Used to perform operations on the layout.
+     *
+     * Only available in Power Mode (rc-dock based layout). Simple Mode does not use rc-dock. Prefer
+     * using the abstracted methods on this type instead of accessing this directly.
+     */
+    dockLayout?: DockLayout;
     /**
      * A ref to a function that runs when the layout changes. We set this ref to our
      * {@link onLayoutChange} function
@@ -3019,6 +3024,20 @@ declare module 'shared/models/docking-framework.model' {
      * @returns `true` if successfully found tab to update, `false` otherwise
      */
     focusTab: (tabId: string) => boolean;
+    /**
+     * Load a layout into the dock layout.
+     *
+     * @param layout The layout to load
+     */
+    loadLayout: (layout: LayoutBase) => void;
+    /**
+     * Find a tab in the layout by its ID or by a predicate function.
+     *
+     * @param idOrFilter The ID of the tab to find, or a function that returns true for the desired
+     *   tab
+     * @returns The tab info if found, or undefined
+     */
+    findTab: (idOrFilter: string | ((item: SavedTabInfo) => boolean)) => TabInfo | undefined;
     /**
      * The layout to use as the default layout if the dockLayout doesn't have a layout loaded.
      *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "paranext-core",
+  "name": "COPY-paranext-core",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/src/renderer/app.component.tsx
+++ b/src/renderer/app.component.tsx
@@ -1,15 +1,28 @@
 import { PlatformDockLayout } from '@renderer/components/docking/platform-dock-layout.component';
+import { SimpleModeLayout } from '@renderer/components/simple-mode/simple-mode-layout.component';
 import { TestContext } from '@renderer/context/papi-context/test.context';
+import { useSetting } from '@renderer/hooks/papi-hooks/use-setting.hook';
 import { Route, MemoryRouter as Router, Routes } from 'react-router-dom';
 import './app.component.scss';
 import { NotificationDisplay } from './components/notification-display';
 import { PlatformBibleToolbar } from './components/platform-bible-toolbar';
 
 function Main() {
+  const [interfaceMode] = useSetting('platform.interfaceMode', 'simple');
+
+  // Treat loading/error states as 'simple' (the default)
+  const isSimpleMode = interfaceMode !== 'power';
+
   return (
     <TestContext.Provider value="test">
-      <PlatformBibleToolbar />
-      <PlatformDockLayout />
+      {isSimpleMode ? (
+        <SimpleModeLayout />
+      ) : (
+        <>
+          <PlatformBibleToolbar />
+          <PlatformDockLayout />
+        </>
+      )}
       <NotificationDisplay />
     </TestContext.Provider>
   );

--- a/src/renderer/components/docking/platform-dock-layout.component.tsx
+++ b/src/renderer/components/docking/platform-dock-layout.component.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect } from 'react';
-import DockLayout from 'rc-dock';
+import DockLayout, { LayoutBase } from 'rc-dock';
 import { Filter } from 'rc-dock/lib/Algorithm';
 
 import {
@@ -98,6 +98,21 @@ export function PlatformDockLayout() {
       getTabInfoById: (tabId: string) =>
         getTabInfoById(dockLayoutRef.current, tabId, 'external getTabInfoById'),
       focusTab: (tabId: string) => focusTab(dockLayoutRef.current, tabId),
+      loadLayout: (layout: LayoutBase) => dockLayoutRef.current.loadLayout(layout),
+      findTab: (idOrFilter: string | ((item: SavedTabInfo) => boolean)) => {
+        const found = dockLayoutRef.current.find(
+          typeof idOrFilter === 'function'
+            ? // rc-dock's find expects (item) => boolean where item has 'data' etc.
+              // We adapt our SavedTabInfo predicate to work with rc-dock's items
+              // eslint-disable-next-line no-type-assertion/no-type-assertion
+              (item) => isTab(item) && idOrFilter(item as unknown as SavedTabInfo)
+            : idOrFilter,
+        );
+        if (!found) return undefined;
+        if (!isTab(found)) return undefined;
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        return found as unknown as TabInfo;
+      },
       testLayout,
     });
     return () => {

--- a/src/renderer/components/platform-bible-toolbar.tsx
+++ b/src/renderer/components/platform-bible-toolbar.tsx
@@ -1,21 +1,17 @@
 import logo from '@assets/icon.png';
 import { provideMenuData } from '@renderer/components/platform-bible-menu.data';
+import { UserProfileDropdown } from '@renderer/components/user-profile-dropdown.component';
 import {
-  useData,
-  useDataProvider,
   useLocalizedStrings,
   useScrollGroupScrRef,
   useRecentScriptureRefs,
 } from '@renderer/hooks/papi-hooks';
 import { app } from '@renderer/services/papi-frontend.service';
 import { availableScrollGroupIds } from '@renderer/services/scroll-group.service-host';
-import { localThemeService } from '@renderer/services/theme.service-host';
 import { handleMenuCommand } from '@shared/data/platform-bible-menu.commands';
 import { sendCommand } from '@shared/services/command.service';
-import { logger } from '@shared/services/logger.service';
 import { ScrollGroupScrRef } from '@shared/services/scroll-group.service-model';
-import { themeServiceDataProviderName } from '@shared/services/theme.service-model';
-import { CircleUserRound, HomeIcon, Moon, Network, Sun } from 'lucide-react';
+import { HomeIcon } from 'lucide-react';
 import {
   Badge,
   BookChapterControl,
@@ -30,26 +26,10 @@ import {
   TooltipTrigger,
   usePromise,
 } from 'platform-bible-react';
-import {
-  getErrorMessage,
-  getLocalizeKeysForScrollGroupIds,
-  isPlatformError,
-  LocalizeKey,
-  ScrollGroupId,
-  ThemeDefinitionExpanded,
-} from 'platform-bible-utils';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getLocalizeKeysForScrollGroupIds, LocalizeKey, ScrollGroupId } from 'platform-bible-utils';
+import { useCallback, useState } from 'react';
 
 const TOOLTIP_DELAY = 300;
-
-/** Placeholder theme to detect when we are loading */
-const DEFAULT_THEME_VALUE: ThemeDefinitionExpanded = {
-  themeFamilyId: '',
-  type: 'light',
-  id: 'light',
-  label: '%unused%',
-  cssVariables: {},
-};
 
 const scrollGroupIdLocalStorageKey = 'platform-bible-toolbar.scrollGroupId';
 
@@ -60,15 +40,7 @@ const availableScrollGroupIdsTop = availableScrollGroupIds.filter(
 
 const scrollGroupLocalizedStringKeys = getLocalizeKeysForScrollGroupIds(availableScrollGroupIdsTop);
 
-const LOCALIZED_STRING_KEYS: LocalizeKey[] = [
-  '%mainMenu_openParatextRegistration%',
-  '%mainMenu_openInternetSettings%',
-  '%mainMenu_openHome%',
-  '%toolbar_theme_change_to_light%',
-  '%toolbar_theme_change_to_dark%',
-  '%toolbar_theme_loading%',
-  '%toolbar_theme_loading_error%',
-];
+const LOCALIZED_STRING_KEYS: LocalizeKey[] = ['%mainMenu_openHome%'];
 
 export function PlatformBibleToolbar() {
   // Internal state tracker for scroll group in local storage
@@ -145,35 +117,6 @@ export function PlatformBibleToolbar() {
     'Marketing Version',
   );
 
-  const themeDataProvider = useDataProvider(themeServiceDataProviderName);
-
-  /** Get the theme on first load so we can show the right symbol on the toolbar */
-  const themeOnFirstLoad = useMemo(() => localThemeService.getCurrentThemeSync(), []);
-
-  const [theme, setTheme] = useData<typeof themeServiceDataProviderName>(
-    themeDataProvider,
-  ).CurrentTheme(undefined, DEFAULT_THEME_VALUE);
-
-  // Warn if the theme came back as a PlatformError. Will handle the PlatformError in the jsx too
-  useEffect(() => {
-    if (isPlatformError(theme))
-      logger.warn(`Error getting theme for toolbar button. ${getErrorMessage(theme)}`);
-  }, [theme]);
-
-  const isThemeLoadedNotError = theme !== DEFAULT_THEME_VALUE && !isPlatformError(theme);
-
-  let themeButtonTooltip = localizedStrings['%toolbar_theme_loading%'];
-  if (!isThemeLoadedNotError)
-    themeButtonTooltip = localizedStrings['%tooltip_theme_loading_error%'];
-  else if (theme.type === 'dark') {
-    themeButtonTooltip = localizedStrings['%toolbar_theme_change_to_light%'];
-  } else {
-    themeButtonTooltip = localizedStrings['%toolbar_theme_change_to_dark%'];
-  }
-
-  // Get the theme type from the first theme load or the current theme data, whichever is available
-  const themeTypeEffective = isThemeLoadedNotError ? theme.type : themeOnFirstLoad.type;
-
   return (
     <Toolbar
       menuData={menuData}
@@ -207,78 +150,7 @@ export function PlatformBibleToolbar() {
               </Tooltip>
             </TooltipProvider>
           )}
-          <TooltipProvider delayDuration={TOOLTIP_DELAY}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="pr-twp tw-h-8 tw-flex-shrink-0"
-                  onClick={() => {
-                    if (!isThemeLoadedNotError) return;
-
-                    const newThemeType = theme.type === 'dark' ? 'light' : 'dark';
-                    try {
-                      setTheme?.({ type: newThemeType });
-                    } catch (e) {
-                      logger.warn(
-                        `Toolbar caught an error while trying to set theme to ${newThemeType}: ${getErrorMessage(e)}`,
-                      );
-                    }
-                  }}
-                  disabled={!isThemeLoadedNotError}
-                >
-                  {themeTypeEffective === 'dark' ? <Moon /> : <Sun />}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="tw-font-light">{themeButtonTooltip}</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          {/* This is a placeholder for the actual user menu */}
-          <TooltipProvider delayDuration={TOOLTIP_DELAY}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="pr-twp tw-h-8 tw-flex-shrink-0"
-                  onClick={() => sendCommand('paratextRegistration.showInternetSettings')}
-                >
-                  <Network />
-                </Button>
-              </TooltipTrigger>
-              {localizedStrings['%mainMenu_openInternetSettings%'] && (
-                <TooltipContent>
-                  <p className="tw-font-light">
-                    {localizedStrings['%mainMenu_openInternetSettings%']}
-                  </p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-          <TooltipProvider delayDuration={TOOLTIP_DELAY}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="pr-twp tw-h-8 tw-flex-shrink-0"
-                  onClick={() => sendCommand('paratextRegistration.showParatextRegistration')}
-                >
-                  <CircleUserRound />
-                </Button>
-              </TooltipTrigger>
-              {localizedStrings['%mainMenu_openParatextRegistration%'] && (
-                <TooltipContent>
-                  <p className="tw-font-light">
-                    {localizedStrings['%mainMenu_openParatextRegistration%']}
-                  </p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
+          <UserProfileDropdown />
         </>
       }
     >

--- a/src/renderer/components/simple-mode/placeholder-tab.component.tsx
+++ b/src/renderer/components/simple-mode/placeholder-tab.component.tsx
@@ -1,0 +1,26 @@
+export type PlaceholderTabProps = {
+  tabName: string;
+};
+
+/** Placeholder content for tabs that don't have a real webview implementation yet */
+export function PlaceholderTab({ tabName }: PlaceholderTabProps) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100%',
+        width: '100%',
+        gap: 8,
+        color: 'var(--muted-foreground, #888)',
+      }}
+    >
+      <p style={{ fontSize: '1.1rem', fontWeight: 500 }}>{tabName}</p>
+      <p style={{ fontSize: '0.85rem' }}>Coming soon</p>
+    </div>
+  );
+}
+
+export default PlaceholderTab;

--- a/src/renderer/components/simple-mode/simple-mode-layout.component.scss
+++ b/src/renderer/components/simple-mode/simple-mode-layout.component.scss
@@ -10,6 +10,13 @@
   overflow: hidden;
   display: flex;
   position: relative;
+
+  /* Override sidebar's tw-h-svh (100svh) so it fits inside this container
+     instead of overflowing past the toolbar above. The sidebar wrapper div
+     has data-collapsible and its two child divs both use h-svh. */
+  [data-collapsible] > div {
+    height: 100% !important;
+  }
 }
 
 .simple-mode-inset {

--- a/src/renderer/components/simple-mode/simple-mode-layout.component.scss
+++ b/src/renderer/components/simple-mode/simple-mode-layout.component.scss
@@ -1,0 +1,116 @@
+.simple-mode-inset {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.simple-mode-panels {
+  flex: 1;
+  overflow: hidden;
+}
+
+.simple-mode-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  color: var(--muted-foreground, #888);
+  font-size: 1.1rem;
+}
+
+/* Panel component */
+.simple-mode-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+  border: 1px solid var(--border, #e5e7eb);
+  background: var(--background, #fff);
+}
+
+.simple-mode-panel-tabbar {
+  display: flex;
+  align-items: center;
+  height: 36px;
+  min-height: 36px;
+  border-bottom: 1px solid var(--border, #e5e7eb);
+  background: var(--muted, #f4f4f5);
+  padding: 0 4px;
+  gap: 2px;
+}
+
+.simple-mode-panel-tabs {
+  display: flex;
+  align-items: center;
+  flex: 1;
+  overflow-x: auto;
+  gap: 2px;
+
+  /* Hide scrollbar */
+  scrollbar-width: none;
+
+  &::-webkit-scrollbar {
+    display: none;
+  }
+}
+
+.simple-mode-panel-toolbar-end {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+  margin-left: auto;
+}
+
+.simple-mode-tab-button {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted-foreground, #71717a);
+  font-size: 0.8rem;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background-color 0.15s, color 0.15s;
+
+  &:hover {
+    background: var(--accent, #e4e4e7);
+    color: var(--accent-foreground, #18181b);
+  }
+}
+
+.simple-mode-tab-button-active {
+  background: var(--background, #fff);
+  color: var(--foreground, #09090b);
+  box-shadow: 0 1px 2px rgb(0 0 0 / 5%);
+}
+
+.simple-mode-tab-label {
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.simple-mode-panel-content {
+  flex: 1;
+  overflow: hidden;
+  position: relative;
+}
+
+.simple-mode-panel-tab-content {
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+}
+
+.simple-mode-panel-webview-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  color: var(--muted-foreground, #888);
+}

--- a/src/renderer/components/simple-mode/simple-mode-layout.component.scss
+++ b/src/renderer/components/simple-mode/simple-mode-layout.component.scss
@@ -1,12 +1,24 @@
-.simple-mode-inset {
+.simple-mode-root {
   display: flex;
   flex-direction: column;
   height: 100vh;
   overflow: hidden;
 }
 
-.simple-mode-panels {
+.simple-mode-body {
   flex: 1;
+  overflow: hidden;
+  display: flex;
+  position: relative;
+}
+
+.simple-mode-inset {
+  flex: 1;
+  overflow: hidden;
+}
+
+.simple-mode-panels {
+  height: 100%;
   overflow: hidden;
 }
 
@@ -74,7 +86,9 @@
   font-size: 0.8rem;
   cursor: pointer;
   white-space: nowrap;
-  transition: background-color 0.15s, color 0.15s;
+  transition:
+    background-color 0.15s,
+    color 0.15s;
 
   &:hover {
     background: var(--accent, #e4e4e7);

--- a/src/renderer/components/simple-mode/simple-mode-layout.component.tsx
+++ b/src/renderer/components/simple-mode/simple-mode-layout.component.tsx
@@ -1,0 +1,195 @@
+import { useCallback, useState } from 'react';
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+  Sidebar,
+  SidebarProvider,
+  SidebarInset,
+} from 'platform-bible-react';
+import { WorkflowSidebar } from '@renderer/components/simple-mode/workflow-sidebar.component';
+import { useSimpleModeDockLayout } from '@renderer/components/simple-mode/use-simple-mode-dock-layout.hook';
+import { SimpleModeToolbar } from '@renderer/components/simple-mode/simple-mode-toolbar.component';
+import { SimpleModePanel } from '@renderer/components/simple-mode/simple-mode-panel.component';
+import { TabMoveDropdown } from '@renderer/components/simple-mode/tab-move-dropdown.component';
+import {
+  SimpleTabDefinition,
+  SIMPLE_MODE_TABS,
+  getTabsForPanel,
+} from '@renderer/components/simple-mode/simple-mode-tab-config';
+import './simple-mode-layout.component.scss';
+
+/** IDs for the panels in simple mode */
+export type SimplePanelId = 'reference' | 'editor' | 'tools' | 'extra';
+
+/** Visibility state for each panel */
+export type PanelVisibility = Record<SimplePanelId, boolean>;
+
+/** Map of panel ID to list of tab IDs assigned to it */
+type PanelTabAssignments = Record<SimplePanelId, string[]>;
+
+/** Build default tab assignments from config */
+function getDefaultTabAssignments(): PanelTabAssignments {
+  return {
+    reference: getTabsForPanel('reference').map((t) => t.id),
+    editor: getTabsForPanel('editor').map((t) => t.id),
+    tools: getTabsForPanel('tools').map((t) => t.id),
+    extra: [],
+  };
+}
+
+/** Resolve tab IDs to tab definitions */
+function resolveTabDefs(tabIds: string[]): SimpleTabDefinition[] {
+  return tabIds
+    .map((id) => SIMPLE_MODE_TABS.find((t) => t.id === id))
+    .filter((t): t is SimpleTabDefinition => t !== undefined);
+}
+
+export function SimpleModeLayout() {
+  // Register Simple Mode's PapiDockLayout implementation with the webview service
+  useSimpleModeDockLayout();
+
+  const [panelVisibility, setPanelVisibility] = useState<PanelVisibility>({
+    reference: true,
+    editor: true,
+    tools: true,
+    extra: false,
+  });
+
+  const [tabAssignments, setTabAssignments] =
+    useState<PanelTabAssignments>(getDefaultTabAssignments);
+
+  const togglePanel = (panelId: SimplePanelId) => {
+    setPanelVisibility((prev) => ({ ...prev, [panelId]: !prev[panelId] }));
+  };
+
+  const showExtraPanel = () => {
+    setPanelVisibility((prev) => ({ ...prev, extra: true }));
+  };
+
+  const hideExtraPanel = useCallback(() => {
+    // Move all extra-panel tabs back to tools
+    setTabAssignments((prev) => ({
+      ...prev,
+      tools: [...prev.tools, ...prev.extra],
+      extra: [],
+    }));
+    setPanelVisibility((prev) => ({ ...prev, extra: false }));
+  }, []);
+
+  const moveTabToExtra = useCallback((tabId: string) => {
+    setTabAssignments((prev) => ({
+      ...prev,
+      tools: prev.tools.filter((id) => id !== tabId),
+      extra: [...prev.extra, tabId],
+    }));
+    // Auto-show extra panel if not visible
+    setPanelVisibility((prev) => ({ ...prev, extra: true }));
+  }, []);
+
+  const moveTabToTools = useCallback((tabId: string) => {
+    setTabAssignments((prev) => {
+      const newExtra = prev.extra.filter((id) => id !== tabId);
+      const newAssignments = {
+        ...prev,
+        tools: [...prev.tools, tabId],
+        extra: newExtra,
+      };
+      // Auto-close extra panel if it becomes empty
+      if (newExtra.length === 0) {
+        setPanelVisibility((p) => ({ ...p, extra: false }));
+      }
+      return newAssignments;
+    });
+  }, []);
+
+  const toolsTabs = resolveTabDefs(tabAssignments.tools);
+  const extraTabs = resolveTabDefs(tabAssignments.extra);
+
+  const visiblePanelCount = Object.values(panelVisibility).filter(Boolean).length;
+
+  /** Toolbar end content for the extra panel — ellipsis dropdown for moving tabs */
+  const extraPanelToolbarEnd = (
+    <TabMoveDropdown
+      toolsTabs={toolsTabs}
+      extraTabs={extraTabs}
+      isExtraPanelOpen={panelVisibility.extra}
+      onMoveToExtra={moveTabToExtra}
+      onMoveToTools={moveTabToTools}
+      variant="ellipsis"
+    />
+  );
+
+  return (
+    <SidebarProvider defaultOpen={false}>
+      <Sidebar collapsible="icon">
+        <WorkflowSidebar />
+      </Sidebar>
+      <SidebarInset className="simple-mode-inset">
+        <SimpleModeToolbar
+          panelVisibility={panelVisibility}
+          onTogglePanel={togglePanel}
+          onShowExtraPanel={showExtraPanel}
+          onHideExtraPanel={hideExtraPanel}
+          toolsTabs={toolsTabs}
+          extraTabs={extraTabs}
+          onMoveTabToExtra={moveTabToExtra}
+          onMoveTabToTools={moveTabToTools}
+        />
+        <div className="simple-mode-panels">
+          {visiblePanelCount === 0 ? (
+            <div className="simple-mode-empty">No panels visible</div>
+          ) : (
+            <ResizablePanelGroup direction="horizontal">
+              {panelVisibility.reference && (
+                <>
+                  <ResizablePanel defaultSize={25} minSize={10}>
+                    <SimpleModePanel
+                      panelId="reference"
+                      tabs={resolveTabDefs(tabAssignments.reference)}
+                    />
+                  </ResizablePanel>
+                  {(panelVisibility.editor || panelVisibility.tools || panelVisibility.extra) && (
+                    <ResizableHandle withHandle />
+                  )}
+                </>
+              )}
+              {panelVisibility.editor && (
+                <>
+                  <ResizablePanel defaultSize={35} minSize={10}>
+                    <SimpleModePanel
+                      panelId="editor"
+                      tabs={resolveTabDefs(tabAssignments.editor)}
+                    />
+                  </ResizablePanel>
+                  {(panelVisibility.tools || panelVisibility.extra) && (
+                    <ResizableHandle withHandle />
+                  )}
+                </>
+              )}
+              {panelVisibility.tools && (
+                <>
+                  <ResizablePanel defaultSize={panelVisibility.extra ? 25 : 40} minSize={10}>
+                    <SimpleModePanel panelId="tools" tabs={toolsTabs} />
+                  </ResizablePanel>
+                  {panelVisibility.extra && <ResizableHandle withHandle />}
+                </>
+              )}
+              {panelVisibility.extra && (
+                <ResizablePanel defaultSize={15} minSize={10}>
+                  <SimpleModePanel
+                    panelId="extra"
+                    tabs={extraTabs}
+                    toolbarEndContent={extraPanelToolbarEnd}
+                  />
+                </ResizablePanel>
+              )}
+            </ResizablePanelGroup>
+          )}
+        </div>
+      </SidebarInset>
+    </SidebarProvider>
+  );
+}
+
+export default SimpleModeLayout;

--- a/src/renderer/components/simple-mode/simple-mode-layout.component.tsx
+++ b/src/renderer/components/simple-mode/simple-mode-layout.component.tsx
@@ -17,6 +17,8 @@ import {
   SIMPLE_MODE_TABS,
   getTabsForPanel,
 } from '@renderer/components/simple-mode/simple-mode-tab-config';
+import WebView from '@renderer/components/web-view.component';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
 import './simple-mode-layout.component.scss';
 
 /** IDs for the panels in simple mode */
@@ -46,8 +48,9 @@ function resolveTabDefs(tabIds: string[]): SimpleTabDefinition[] {
 }
 
 export function SimpleModeLayout() {
-  // Register Simple Mode's PapiDockLayout implementation with the webview service
-  useSimpleModeDockLayout();
+  // Register Simple Mode's PapiDockLayout implementation with the webview service.
+  // Returns a reactive webViewMap and dialogWebViews for rendering.
+  const { webViewMap, dialogWebViews, closeDialog } = useSimpleModeDockLayout();
 
   const [panelVisibility, setPanelVisibility] = useState<PanelVisibility>({
     reference: true,
@@ -68,7 +71,6 @@ export function SimpleModeLayout() {
   };
 
   const hideExtraPanel = useCallback(() => {
-    // Move all extra-panel tabs back to tools
     setTabAssignments((prev) => ({
       ...prev,
       tools: [...prev.tools, ...prev.extra],
@@ -83,7 +85,6 @@ export function SimpleModeLayout() {
       tools: prev.tools.filter((id) => id !== tabId),
       extra: [...prev.extra, tabId],
     }));
-    // Auto-show extra panel if not visible
     setPanelVisibility((prev) => ({ ...prev, extra: true }));
   }, []);
 
@@ -95,7 +96,6 @@ export function SimpleModeLayout() {
         tools: [...prev.tools, tabId],
         extra: newExtra,
       };
-      // Auto-close extra panel if it becomes empty
       if (newExtra.length === 0) {
         setPanelVisibility((p) => ({ ...p, extra: false }));
       }
@@ -108,7 +108,6 @@ export function SimpleModeLayout() {
 
   const visiblePanelCount = Object.values(panelVisibility).filter(Boolean).length;
 
-  /** Toolbar end content for the extra panel — ellipsis dropdown for moving tabs */
   const extraPanelToolbarEnd = (
     <TabMoveDropdown
       toolsTabs={toolsTabs}
@@ -121,74 +120,107 @@ export function SimpleModeLayout() {
   );
 
   return (
-    <SidebarProvider defaultOpen={false}>
-      <Sidebar collapsible="icon">
-        <WorkflowSidebar />
-      </Sidebar>
-      <SidebarInset className="simple-mode-inset">
-        <SimpleModeToolbar
-          panelVisibility={panelVisibility}
-          onTogglePanel={togglePanel}
-          onShowExtraPanel={showExtraPanel}
-          onHideExtraPanel={hideExtraPanel}
-          toolsTabs={toolsTabs}
-          extraTabs={extraTabs}
-          onMoveTabToExtra={moveTabToExtra}
-          onMoveTabToTools={moveTabToTools}
-        />
-        <div className="simple-mode-panels">
-          {visiblePanelCount === 0 ? (
-            <div className="simple-mode-empty">No panels visible</div>
-          ) : (
-            <ResizablePanelGroup direction="horizontal">
-              {panelVisibility.reference && (
-                <>
-                  <ResizablePanel defaultSize={25} minSize={10}>
-                    <SimpleModePanel
-                      panelId="reference"
-                      tabs={resolveTabDefs(tabAssignments.reference)}
-                    />
-                  </ResizablePanel>
-                  {(panelVisibility.editor || panelVisibility.tools || panelVisibility.extra) && (
-                    <ResizableHandle withHandle />
+    <div className="simple-mode-root">
+      {/* Toolbar spans full width above sidebar */}
+      <SimpleModeToolbar
+        panelVisibility={panelVisibility}
+        onTogglePanel={togglePanel}
+        onShowExtraPanel={showExtraPanel}
+        onHideExtraPanel={hideExtraPanel}
+        toolsTabs={toolsTabs}
+        extraTabs={extraTabs}
+        onMoveTabToExtra={moveTabToExtra}
+        onMoveTabToTools={moveTabToTools}
+      />
+
+      {/* Sidebar + panels area below toolbar */}
+      <div className="simple-mode-body">
+        <SidebarProvider open={false} onOpenChange={() => {}}>
+          <Sidebar
+            collapsible="icon"
+            style={
+              {
+                '--sidebar-width-icon': '3.5rem',
+              } as React.CSSProperties
+            }
+          >
+            <WorkflowSidebar />
+          </Sidebar>
+          <SidebarInset className="simple-mode-inset">
+            <div className="simple-mode-panels">
+              {visiblePanelCount === 0 ? (
+                <div className="simple-mode-empty">No panels visible</div>
+              ) : (
+                <ResizablePanelGroup direction="horizontal">
+                  {panelVisibility.reference && (
+                    <>
+                      <ResizablePanel defaultSize={25} minSize={10}>
+                        <SimpleModePanel
+                          panelId="reference"
+                          tabs={resolveTabDefs(tabAssignments.reference)}
+                          webViewMap={webViewMap}
+                        />
+                      </ResizablePanel>
+                      {(panelVisibility.editor ||
+                        panelVisibility.tools ||
+                        panelVisibility.extra) && <ResizableHandle withHandle />}
+                    </>
                   )}
-                </>
-              )}
-              {panelVisibility.editor && (
-                <>
-                  <ResizablePanel defaultSize={35} minSize={10}>
-                    <SimpleModePanel
-                      panelId="editor"
-                      tabs={resolveTabDefs(tabAssignments.editor)}
-                    />
-                  </ResizablePanel>
-                  {(panelVisibility.tools || panelVisibility.extra) && (
-                    <ResizableHandle withHandle />
+                  {panelVisibility.editor && (
+                    <>
+                      <ResizablePanel defaultSize={35} minSize={10}>
+                        <SimpleModePanel
+                          panelId="editor"
+                          tabs={resolveTabDefs(tabAssignments.editor)}
+                          webViewMap={webViewMap}
+                        />
+                      </ResizablePanel>
+                      {(panelVisibility.tools || panelVisibility.extra) && (
+                        <ResizableHandle withHandle />
+                      )}
+                    </>
                   )}
-                </>
+                  {panelVisibility.tools && (
+                    <>
+                      <ResizablePanel defaultSize={panelVisibility.extra ? 25 : 40} minSize={10}>
+                        <SimpleModePanel panelId="tools" tabs={toolsTabs} webViewMap={webViewMap} />
+                      </ResizablePanel>
+                      {panelVisibility.extra && <ResizableHandle withHandle />}
+                    </>
+                  )}
+                  {panelVisibility.extra && (
+                    <ResizablePanel defaultSize={15} minSize={10}>
+                      <SimpleModePanel
+                        panelId="extra"
+                        tabs={extraTabs}
+                        toolbarEndContent={extraPanelToolbarEnd}
+                        webViewMap={webViewMap}
+                      />
+                    </ResizablePanel>
+                  )}
+                </ResizablePanelGroup>
               )}
-              {panelVisibility.tools && (
-                <>
-                  <ResizablePanel defaultSize={panelVisibility.extra ? 25 : 40} minSize={10}>
-                    <SimpleModePanel panelId="tools" tabs={toolsTabs} />
-                  </ResizablePanel>
-                  {panelVisibility.extra && <ResizableHandle withHandle />}
-                </>
-              )}
-              {panelVisibility.extra && (
-                <ResizablePanel defaultSize={15} minSize={10}>
-                  <SimpleModePanel
-                    panelId="extra"
-                    tabs={extraTabs}
-                    toolbarEndContent={extraPanelToolbarEnd}
-                  />
-                </ResizablePanel>
-              )}
-            </ResizablePanelGroup>
-          )}
-        </div>
-      </SidebarInset>
-    </SidebarProvider>
+            </div>
+          </SidebarInset>
+        </SidebarProvider>
+      </div>
+
+      {/* Float-type webviews rendered as centered blocking dialogs */}
+      {dialogWebViews.map((dialogWv) => (
+        <DialogPrimitive.Root
+          key={dialogWv.dialogId}
+          open
+          onOpenChange={() => closeDialog(dialogWv.dialogId)}
+        >
+          <DialogPrimitive.Portal>
+            <DialogPrimitive.Overlay className="tw-fixed tw-inset-0 tw-z-[200] tw-bg-black/50" />
+            <DialogPrimitive.Content className="tw-fixed tw-left-1/2 tw-top-1/2 tw-z-[201] tw--translate-x-1/2 tw--translate-y-1/2 tw-w-[600px] tw-h-[540px] tw-rounded-lg tw-border tw-bg-background tw-shadow-lg tw-overflow-hidden">
+              <WebView {...dialogWv} />
+            </DialogPrimitive.Content>
+          </DialogPrimitive.Portal>
+        </DialogPrimitive.Root>
+      ))}
+    </div>
   );
 }
 

--- a/src/renderer/components/simple-mode/simple-mode-layout.component.tsx
+++ b/src/renderer/components/simple-mode/simple-mode-layout.component.tsx
@@ -50,7 +50,7 @@ function resolveTabDefs(tabIds: string[]): SimpleTabDefinition[] {
 export function SimpleModeLayout() {
   // Register Simple Mode's PapiDockLayout implementation with the webview service.
   // Returns a reactive webViewMap and dialogWebViews for rendering.
-  const { webViewMap, dialogWebViews, closeDialog } = useSimpleModeDockLayout();
+  const { webViewMap, tabWebViewIds, dialogWebViews, closeDialog } = useSimpleModeDockLayout();
 
   const [panelVisibility, setPanelVisibility] = useState<PanelVisibility>({
     reference: true,
@@ -140,7 +140,7 @@ export function SimpleModeLayout() {
             collapsible="icon"
             style={
               {
-                '--sidebar-width-icon': '3.5rem',
+                '--sidebar-width-icon': '4rem',
               } as React.CSSProperties
             }
           >
@@ -159,6 +159,7 @@ export function SimpleModeLayout() {
                           panelId="reference"
                           tabs={resolveTabDefs(tabAssignments.reference)}
                           webViewMap={webViewMap}
+                          tabWebViewIds={tabWebViewIds}
                         />
                       </ResizablePanel>
                       {(panelVisibility.editor ||
@@ -173,6 +174,7 @@ export function SimpleModeLayout() {
                           panelId="editor"
                           tabs={resolveTabDefs(tabAssignments.editor)}
                           webViewMap={webViewMap}
+                          tabWebViewIds={tabWebViewIds}
                         />
                       </ResizablePanel>
                       {(panelVisibility.tools || panelVisibility.extra) && (
@@ -183,7 +185,12 @@ export function SimpleModeLayout() {
                   {panelVisibility.tools && (
                     <>
                       <ResizablePanel defaultSize={panelVisibility.extra ? 25 : 40} minSize={10}>
-                        <SimpleModePanel panelId="tools" tabs={toolsTabs} webViewMap={webViewMap} />
+                        <SimpleModePanel
+                          panelId="tools"
+                          tabs={toolsTabs}
+                          webViewMap={webViewMap}
+                          tabWebViewIds={tabWebViewIds}
+                        />
                       </ResizablePanel>
                       {panelVisibility.extra && <ResizableHandle withHandle />}
                     </>
@@ -195,6 +202,7 @@ export function SimpleModeLayout() {
                         tabs={extraTabs}
                         toolbarEndContent={extraPanelToolbarEnd}
                         webViewMap={webViewMap}
+                        tabWebViewIds={tabWebViewIds}
                       />
                     </ResizablePanel>
                   )}

--- a/src/renderer/components/simple-mode/simple-mode-panel.component.tsx
+++ b/src/renderer/components/simple-mode/simple-mode-panel.component.tsx
@@ -1,0 +1,88 @@
+import { Button, cn } from 'platform-bible-react';
+import { EllipsisVertical } from 'lucide-react';
+import { useState } from 'react';
+import { SimplePanelId } from './simple-mode-layout.component';
+import { SimpleTabDefinition, getTabsForPanel } from './simple-mode-tab-config';
+import { PlaceholderTab } from './placeholder-tab.component';
+
+export type SimpleModePanelProps = {
+  panelId: SimplePanelId;
+  /** Tabs assigned to this panel. If not provided, uses default tabs from config. */
+  tabs?: SimpleTabDefinition[];
+  /** Extra toolbar content to render on the right side of the tab bar */
+  toolbarEndContent?: React.ReactNode;
+};
+
+/**
+ * Generic panel component for Simple Mode.
+ *
+ * - Shows a tab bar only when the panel has 2+ tabs.
+ * - When a single tab is assigned, it fills the panel with no tab bar.
+ * - Uses `display: none` for inactive tabs to preserve iframe state.
+ */
+export function SimpleModePanel({
+  panelId,
+  tabs: tabsProp,
+  toolbarEndContent,
+}: SimpleModePanelProps) {
+  const tabs = tabsProp ?? getTabsForPanel(panelId);
+  const [activeTabId, setActiveTabId] = useState<string>(tabs[0]?.id ?? '');
+
+  const showTabBar = tabs.length > 1;
+
+  return (
+    <div className="simple-mode-panel">
+      {/* Tab bar — only shown when 2+ tabs */}
+      {showTabBar && (
+        <div className="simple-mode-panel-tabbar">
+          <div className="simple-mode-panel-tabs">
+            {tabs.map((tab) => {
+              const Icon = tab.icon;
+              const isActive = tab.id === activeTabId;
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  className={cn(
+                    'simple-mode-tab-button',
+                    isActive && 'simple-mode-tab-button-active',
+                  )}
+                  onClick={() => setActiveTabId(tab.id)}
+                  title={tab.label}
+                >
+                  <Icon className="tw-h-4 tw-w-4" />
+                  <span className="simple-mode-tab-label">{tab.label}</span>
+                </button>
+              );
+            })}
+          </div>
+          {toolbarEndContent && (
+            <div className="simple-mode-panel-toolbar-end">{toolbarEndContent}</div>
+          )}
+        </div>
+      )}
+
+      {/* Content area — all tabs rendered, inactive hidden via display:none */}
+      <div className="simple-mode-panel-content">
+        {tabs.map((tab) => (
+          <div
+            key={tab.id}
+            style={{ display: tab.id === activeTabId ? 'flex' : 'none' }}
+            className="simple-mode-panel-tab-content"
+          >
+            {tab.isPlaceholder ? (
+              <PlaceholderTab tabName={tab.label} />
+            ) : (
+              // Real webview content will be wired in Phase 7
+              <div className="simple-mode-panel-webview-placeholder">
+                <span>{tab.label}</span>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default SimpleModePanel;

--- a/src/renderer/components/simple-mode/simple-mode-panel.component.tsx
+++ b/src/renderer/components/simple-mode/simple-mode-panel.component.tsx
@@ -5,7 +5,7 @@ import WebView from '@renderer/components/web-view.component';
 import { SimplePanelId } from './simple-mode-layout.component';
 import { SimpleTabDefinition, getTabsForPanel } from './simple-mode-tab-config';
 import { PlaceholderTab } from './placeholder-tab.component';
-import { WebViewMap } from './use-simple-mode-dock-layout.hook';
+import { WebViewMap, TabWebViewIds } from './use-simple-mode-dock-layout.hook';
 
 export type SimpleModePanelProps = {
   panelId: SimplePanelId;
@@ -13,21 +13,11 @@ export type SimpleModePanelProps = {
   tabs?: SimpleTabDefinition[];
   /** Extra toolbar content to render on the right side of the tab bar */
   toolbarEndContent?: React.ReactNode;
-  /** Map of webViewId -> WebViewTabProps for rendering real webviews */
+  /** All webview definitions keyed by webview UUID */
   webViewMap: WebViewMap;
+  /** Maps simple-mode tab id -> webview UUID */
+  tabWebViewIds: TabWebViewIds;
 };
-
-/**
- * Find the first WebViewTabProps in the map whose webViewType matches the tab's webViewType.
- * Returns undefined if no match.
- */
-function findWebViewForTab(
-  tab: SimpleTabDefinition,
-  webViewMap: WebViewMap,
-): WebViewTabProps | undefined {
-  if (!tab.webViewType) return undefined;
-  return Object.values(webViewMap).find((wv) => wv.webViewType === tab.webViewType);
-}
 
 /**
  * Generic panel component for Simple Mode.
@@ -35,13 +25,14 @@ function findWebViewForTab(
  * - Shows a tab bar only when the panel has 2+ tabs.
  * - When a single tab is assigned, it fills the panel with no tab bar.
  * - Uses `display: none` for inactive tabs to preserve iframe state.
- * - Renders real WebView components for non-placeholder tabs that have a matching webview.
+ * - Renders real WebView components for non-placeholder tabs that have been opened.
  */
 export function SimpleModePanel({
   panelId,
   tabs: tabsProp,
   toolbarEndContent,
   webViewMap,
+  tabWebViewIds,
 }: SimpleModePanelProps) {
   const tabs = tabsProp ?? getTabsForPanel(panelId);
   const [activeTabId, setActiveTabId] = useState<string>(tabs[0]?.id ?? '');
@@ -50,7 +41,6 @@ export function SimpleModePanel({
 
   return (
     <div className="simple-mode-panel">
-      {/* Tab bar — only shown when 2+ tabs */}
       {showTabBar && (
         <div className="simple-mode-panel-tabbar">
           <div className="simple-mode-panel-tabs">
@@ -80,10 +70,14 @@ export function SimpleModePanel({
         </div>
       )}
 
-      {/* Content area — all tabs rendered, inactive hidden via display:none */}
       <div className="simple-mode-panel-content">
         {tabs.map((tab) => {
-          const webViewProps = findWebViewForTab(tab, webViewMap);
+          // Look up the webview UUID for this tab, then get the webview props
+          const webViewId = tabWebViewIds?.[tab.id];
+          const webViewProps: WebViewTabProps | undefined = webViewId
+            ? webViewMap[webViewId]
+            : undefined;
+
           return (
             <div
               key={tab.id}

--- a/src/renderer/components/simple-mode/simple-mode-panel.component.tsx
+++ b/src/renderer/components/simple-mode/simple-mode-panel.component.tsx
@@ -1,9 +1,11 @@
-import { Button, cn } from 'platform-bible-react';
-import { EllipsisVertical } from 'lucide-react';
+import { cn } from 'platform-bible-react';
 import { useState } from 'react';
+import { WebViewTabProps } from '@shared/models/docking-framework.model';
+import WebView from '@renderer/components/web-view.component';
 import { SimplePanelId } from './simple-mode-layout.component';
 import { SimpleTabDefinition, getTabsForPanel } from './simple-mode-tab-config';
 import { PlaceholderTab } from './placeholder-tab.component';
+import { WebViewMap } from './use-simple-mode-dock-layout.hook';
 
 export type SimpleModePanelProps = {
   panelId: SimplePanelId;
@@ -11,7 +13,21 @@ export type SimpleModePanelProps = {
   tabs?: SimpleTabDefinition[];
   /** Extra toolbar content to render on the right side of the tab bar */
   toolbarEndContent?: React.ReactNode;
+  /** Map of webViewId -> WebViewTabProps for rendering real webviews */
+  webViewMap: WebViewMap;
 };
+
+/**
+ * Find the first WebViewTabProps in the map whose webViewType matches the tab's webViewType.
+ * Returns undefined if no match.
+ */
+function findWebViewForTab(
+  tab: SimpleTabDefinition,
+  webViewMap: WebViewMap,
+): WebViewTabProps | undefined {
+  if (!tab.webViewType) return undefined;
+  return Object.values(webViewMap).find((wv) => wv.webViewType === tab.webViewType);
+}
 
 /**
  * Generic panel component for Simple Mode.
@@ -19,11 +35,13 @@ export type SimpleModePanelProps = {
  * - Shows a tab bar only when the panel has 2+ tabs.
  * - When a single tab is assigned, it fills the panel with no tab bar.
  * - Uses `display: none` for inactive tabs to preserve iframe state.
+ * - Renders real WebView components for non-placeholder tabs that have a matching webview.
  */
 export function SimpleModePanel({
   panelId,
   tabs: tabsProp,
   toolbarEndContent,
+  webViewMap,
 }: SimpleModePanelProps) {
   const tabs = tabsProp ?? getTabsForPanel(panelId);
   const [activeTabId, setActiveTabId] = useState<string>(tabs[0]?.id ?? '');
@@ -64,22 +82,26 @@ export function SimpleModePanel({
 
       {/* Content area — all tabs rendered, inactive hidden via display:none */}
       <div className="simple-mode-panel-content">
-        {tabs.map((tab) => (
-          <div
-            key={tab.id}
-            style={{ display: tab.id === activeTabId ? 'flex' : 'none' }}
-            className="simple-mode-panel-tab-content"
-          >
-            {tab.isPlaceholder ? (
-              <PlaceholderTab tabName={tab.label} />
-            ) : (
-              // Real webview content will be wired in Phase 7
-              <div className="simple-mode-panel-webview-placeholder">
-                <span>{tab.label}</span>
-              </div>
-            )}
-          </div>
-        ))}
+        {tabs.map((tab) => {
+          const webViewProps = findWebViewForTab(tab, webViewMap);
+          return (
+            <div
+              key={tab.id}
+              style={{ display: tab.id === activeTabId ? 'flex' : 'none' }}
+              className="simple-mode-panel-tab-content"
+            >
+              {tab.isPlaceholder ? (
+                <PlaceholderTab tabName={tab.label} />
+              ) : webViewProps ? (
+                <WebView {...webViewProps} />
+              ) : (
+                <div className="simple-mode-panel-webview-placeholder">
+                  <span>{tab.label} — loading...</span>
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     </div>
   );

--- a/src/renderer/components/simple-mode/simple-mode-tab-config.ts
+++ b/src/renderer/components/simple-mode/simple-mode-tab-config.ts
@@ -24,6 +24,8 @@ export type SimpleTabDefinition = {
   isPlaceholder: boolean;
   /** The default panel this tab belongs to */
   defaultPanel: SimplePanelId;
+  /** The webViewType to match against when a webview is opened by the platform */
+  webViewType?: string;
 };
 
 /**
@@ -40,6 +42,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: BookOpen,
     isPlaceholder: false,
     defaultPanel: 'reference',
+    webViewType: 'platformScriptureEditor.reactWebView',
   },
 
   // Editor panel — single tab, tab bar hidden
@@ -49,6 +52,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: PenLine,
     isPlaceholder: false,
     defaultPanel: 'editor',
+    webViewType: 'platformScriptureEditor.reactWebView',
   },
 
   // Tools/Resources panel — many tabs, tab bar shown
@@ -58,6 +62,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: BookOpenText,
     isPlaceholder: false,
     defaultPanel: 'tools',
+    webViewType: 'platformScriptureEditor.reactWebView',
   },
   {
     id: 'commentary',
@@ -65,6 +70,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: FileText,
     isPlaceholder: false,
     defaultPanel: 'tools',
+    webViewType: 'platformScriptureEditor.reactWebView',
   },
   {
     id: 'dictionary',
@@ -72,6 +78,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: LetterText,
     isPlaceholder: false,
     defaultPanel: 'tools',
+    webViewType: 'platformLexicalTools.dictionary',
   },
   {
     id: 'text-collection',
@@ -100,6 +107,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: Languages,
     isPlaceholder: false,
     defaultPanel: 'tools',
+    webViewType: 'platformScriptureEditor.reactWebView',
   },
   {
     id: 'comments',
@@ -107,6 +115,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: MessageSquare,
     isPlaceholder: false,
     defaultPanel: 'tools',
+    webViewType: 'legacyCommentManager.commentList',
   },
   {
     id: 'find',
@@ -114,6 +123,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: Search,
     isPlaceholder: false,
     defaultPanel: 'tools',
+    webViewType: 'platformScripture.find',
   },
   {
     id: 'ask-ai',

--- a/src/renderer/components/simple-mode/simple-mode-tab-config.ts
+++ b/src/renderer/components/simple-mode/simple-mode-tab-config.ts
@@ -1,0 +1,135 @@
+import { type LucideIcon } from 'lucide-react';
+import {
+  BookOpen,
+  PenLine,
+  Library,
+  FileText,
+  BookOpenText,
+  Languages,
+  MessageSquare,
+  Search,
+  Sparkles,
+  LayoutList,
+  GitCompareArrows,
+  LetterText,
+} from 'lucide-react';
+import { SimplePanelId } from './simple-mode-layout.component';
+
+/** Definition for a tab in Simple Mode */
+export type SimpleTabDefinition = {
+  id: string;
+  label: string;
+  icon: LucideIcon;
+  /** Whether this tab has a real webview or is a placeholder */
+  isPlaceholder: boolean;
+  /** The default panel this tab belongs to */
+  defaultPanel: SimplePanelId;
+};
+
+/**
+ * Tab definitions for Study & Draft workflow.
+ *
+ * Reference and Editor panels have 1 tab each (tab bar hidden). Tools panel has many tabs (tab bar
+ * shown).
+ */
+export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
+  // Reference panel — single tab, tab bar hidden
+  {
+    id: 'reference-text',
+    label: 'Reference Text',
+    icon: BookOpen,
+    isPlaceholder: false,
+    defaultPanel: 'reference',
+  },
+
+  // Editor panel — single tab, tab bar hidden
+  {
+    id: 'scripture-editor',
+    label: 'Scripture Editor',
+    icon: PenLine,
+    isPlaceholder: false,
+    defaultPanel: 'editor',
+  },
+
+  // Tools/Resources panel — many tabs, tab bar shown
+  {
+    id: 'bible-texts',
+    label: 'Bible Texts',
+    icon: BookOpenText,
+    isPlaceholder: false,
+    defaultPanel: 'tools',
+  },
+  {
+    id: 'commentary',
+    label: 'Commentary',
+    icon: FileText,
+    isPlaceholder: false,
+    defaultPanel: 'tools',
+  },
+  {
+    id: 'dictionary',
+    label: 'Dictionary',
+    icon: LetterText,
+    isPlaceholder: false,
+    defaultPanel: 'tools',
+  },
+  {
+    id: 'text-collection',
+    label: 'Text Collection',
+    icon: Library,
+    isPlaceholder: true,
+    defaultPanel: 'tools',
+  },
+  {
+    id: 'parallel-passages',
+    label: 'Parallel Passages',
+    icon: GitCompareArrows,
+    isPlaceholder: true,
+    defaultPanel: 'tools',
+  },
+  {
+    id: 'biblical-terms',
+    label: 'Biblical Terms',
+    icon: LayoutList,
+    isPlaceholder: true,
+    defaultPanel: 'tools',
+  },
+  {
+    id: 'source-language-tools',
+    label: 'Source Language Tools',
+    icon: Languages,
+    isPlaceholder: false,
+    defaultPanel: 'tools',
+  },
+  {
+    id: 'comments',
+    label: 'Comments',
+    icon: MessageSquare,
+    isPlaceholder: false,
+    defaultPanel: 'tools',
+  },
+  {
+    id: 'find',
+    label: 'Find',
+    icon: Search,
+    isPlaceholder: false,
+    defaultPanel: 'tools',
+  },
+  {
+    id: 'ask-ai',
+    label: 'Ask AI',
+    icon: Sparkles,
+    isPlaceholder: true,
+    defaultPanel: 'tools',
+  },
+];
+
+/** Get tabs for a specific panel */
+export function getTabsForPanel(panelId: SimplePanelId): SimpleTabDefinition[] {
+  return SIMPLE_MODE_TABS.filter((tab) => tab.defaultPanel === panelId);
+}
+
+/** Get a tab definition by its ID */
+export function getTabById(tabId: string): SimpleTabDefinition | undefined {
+  return SIMPLE_MODE_TABS.find((tab) => tab.id === tabId);
+}

--- a/src/renderer/components/simple-mode/simple-mode-tab-config.ts
+++ b/src/renderer/components/simple-mode/simple-mode-tab-config.ts
@@ -24,7 +24,7 @@ export type SimpleTabDefinition = {
   isPlaceholder: boolean;
   /** The default panel this tab belongs to */
   defaultPanel: SimplePanelId;
-  /** The webViewType to match against when a webview is opened by the platform */
+  /** The webViewType to open for this tab. Each tab with a webViewType gets its own instance. */
   webViewType?: string;
 };
 
@@ -42,7 +42,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: BookOpen,
     isPlaceholder: false,
     defaultPanel: 'reference',
-    webViewType: 'platformScriptureEditor.reactWebView',
+    webViewType: 'platformScriptureEditor.react',
   },
 
   // Editor panel — single tab, tab bar hidden
@@ -52,7 +52,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: PenLine,
     isPlaceholder: false,
     defaultPanel: 'editor',
-    webViewType: 'platformScriptureEditor.reactWebView',
+    webViewType: 'platformScriptureEditor.react',
   },
 
   // Tools/Resources panel — many tabs, tab bar shown
@@ -62,7 +62,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: BookOpenText,
     isPlaceholder: false,
     defaultPanel: 'tools',
-    webViewType: 'platformScriptureEditor.reactWebView',
+    webViewType: 'platformScriptureEditor.react',
   },
   {
     id: 'commentary',
@@ -70,7 +70,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: FileText,
     isPlaceholder: false,
     defaultPanel: 'tools',
-    webViewType: 'platformScriptureEditor.reactWebView',
+    webViewType: 'platformScriptureEditor.react',
   },
   {
     id: 'dictionary',
@@ -107,7 +107,7 @@ export const SIMPLE_MODE_TABS: SimpleTabDefinition[] = [
     icon: Languages,
     isPlaceholder: false,
     defaultPanel: 'tools',
-    webViewType: 'platformScriptureEditor.reactWebView',
+    webViewType: 'platformScriptureEditor.react',
   },
   {
     id: 'comments',

--- a/src/renderer/components/simple-mode/simple-mode-toolbar.component.tsx
+++ b/src/renderer/components/simple-mode/simple-mode-toolbar.component.tsx
@@ -6,7 +6,7 @@ import {
   Button,
   cn,
   getToolbarOSReservedSpaceClassName,
-  SidebarTrigger,
+  Toolbar,
   Tooltip,
   TooltipContent,
   TooltipProvider,
@@ -29,13 +29,9 @@ export type SimpleModeToolbarProps = {
   onTogglePanel: (panelId: SimplePanelId) => void;
   onShowExtraPanel: () => void;
   onHideExtraPanel: () => void;
-  /** Tabs currently in the tools panel */
   toolsTabs: SimpleTabDefinition[];
-  /** Tabs currently in the extra panel */
   extraTabs: SimpleTabDefinition[];
-  /** Move a tab to the extra panel */
   onMoveTabToExtra: (tabId: string) => void;
-  /** Move a tab back to tools */
   onMoveTabToTools: (tabId: string) => void;
 };
 
@@ -56,7 +52,6 @@ export function SimpleModeToolbar({
   onMoveTabToExtra,
   onMoveTabToTools,
 }: SimpleModeToolbarProps) {
-  // Scroll group / BCV control — same pattern as Power Mode toolbar
   const [scrollGroupIdInternal, setScrollGroupIdInternal] = useState<ScrollGroupId>(() =>
     JSON.parse(localStorage.getItem(scrollGroupIdLocalStorageKey) ?? '0'),
   );
@@ -77,7 +72,6 @@ export function SimpleModeToolbar({
 
   const { recentScriptureRefs, addRecentScriptureRef } = useRecentScriptureRefs();
 
-  // OS reserved space for window controls
   const [osPlatformToReserveSpaceFor] = usePromise(
     useCallback(async () => {
       const osPlatform: string | undefined = await sendCommand('platform.getOSPlatform');
@@ -91,128 +85,95 @@ export function SimpleModeToolbar({
 
   return (
     <TooltipProvider delayDuration={TOOLTIP_DELAY}>
-      <div
+      <Toolbar
         className={cn(
-          'simple-mode-toolbar',
+          'tw-h-12 tw-bg-transparent',
           getToolbarOSReservedSpaceClassName(osPlatformToReserveSpaceFor),
         )}
-        style={{
-          height: 48,
-          display: 'flex',
-          alignItems: 'center',
-          gap: 4,
-          padding: '0 8px',
-          borderBottom: '1px solid var(--border, #e5e7eb)',
-          // eslint-disable-next-line no-restricted-syntax
-          WebkitAppRegion: 'drag',
-        }}
-      >
-        {/* Sidebar trigger */}
-        <SidebarTrigger
-          className="tw-h-8 tw-w-8 tw-flex-shrink-0"
-          style={{
-            // eslint-disable-next-line no-restricted-syntax
-            WebkitAppRegion: 'no-drag',
-          }}
-        />
+        shouldUseAsAppDragArea
+        onSelectMenuItem={() => {}}
+        appMenuAreaChildren={
+          <>
+            <img width={24} height={24} src={`${logo}`} alt="Platform.Bible logo" />
+            <span
+              className="tw-font-semibold tw-text-sm tw-whitespace-nowrap"
+              style={{ userSelect: 'none' }}
+            >
+              Platform.Bible
+            </span>
+          </>
+        }
+        configAreaChildren={
+          <div className="tw-flex tw-items-center tw-gap-1">
+            {PANEL_TOGGLES.map(({ id, icon: Icon, label }) => (
+              <Tooltip key={id}>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant={panelVisibility[id] ? 'default' : 'ghost'}
+                    size="icon"
+                    className="tw-h-8 tw-w-8"
+                    onClick={() => onTogglePanel(id)}
+                  >
+                    <Icon className="tw-h-4 tw-w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="tw-font-light">
+                    {panelVisibility[id] ? `Hide ${label}` : `Show ${label}`}
+                  </p>
+                </TooltipContent>
+              </Tooltip>
+            ))}
 
-        {/* Logo */}
-        <img width={24} height={24} src={`${logo}`} alt="Platform.Bible logo" />
-        <span
-          className="tw-font-semibold tw-text-sm tw-whitespace-nowrap tw-mr-2"
-          style={{ userSelect: 'none' }}
-        >
-          Platform.Bible
-        </span>
+            {panelVisibility.extra ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="tw-h-8 tw-w-8"
+                    onClick={onHideExtraPanel}
+                  >
+                    <Minus className="tw-h-4 tw-w-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="tw-font-light">Close extra panel</p>
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <TabMoveDropdown
+                toolsTabs={toolsTabs}
+                extraTabs={extraTabs}
+                isExtraPanelOpen={panelVisibility.extra}
+                onMoveToExtra={onMoveTabToExtra}
+                onMoveToTools={onMoveTabToTools}
+                variant="plus"
+              />
+            )}
 
-        {/* BCV Control */}
-        <div
-          style={{
-            // eslint-disable-next-line no-restricted-syntax
-            WebkitAppRegion: 'no-drag',
-          }}
-        >
-          <BookChapterControl
-            scrRef={scrRef}
-            handleSubmit={setScrRef}
-            className="tw-w-80"
-            recentSearches={recentScriptureRefs}
-            onAddRecentSearch={addRecentScriptureRef}
-          />
-        </div>
-
-        {/* Spacer */}
-        <div className="tw-flex-1" />
-
-        {/* Layout toggle buttons */}
-        <div
-          className="tw-flex tw-items-center tw-gap-1"
-          style={{
-            // eslint-disable-next-line no-restricted-syntax
-            WebkitAppRegion: 'no-drag',
-          }}
-        >
-          {PANEL_TOGGLES.map(({ id, icon: Icon, label }) => (
-            <Tooltip key={id}>
-              <TooltipTrigger asChild>
-                <Button
-                  variant={panelVisibility[id] ? 'default' : 'ghost'}
-                  size="icon"
-                  className="tw-h-8 tw-w-8"
-                  onClick={() => onTogglePanel(id)}
-                >
-                  <Icon className="tw-h-4 tw-w-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="tw-font-light">
-                  {panelVisibility[id] ? `Hide ${label}` : `Show ${label}`}
-                </p>
-              </TooltipContent>
-            </Tooltip>
-          ))}
-
-          {/* Plus / Minus button for extra panel */}
-          {panelVisibility.extra ? (
             <Tooltip>
               <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="tw-h-8 tw-w-8"
-                  onClick={onHideExtraPanel}
-                >
-                  <Minus className="tw-h-4 tw-w-4" />
+                <Button variant="ghost" size="icon" className="tw-h-8 tw-w-8">
+                  <EllipsisVertical className="tw-h-4 tw-w-4" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
-                <p className="tw-font-light">Close extra panel</p>
+                <p className="tw-font-light">View options</p>
               </TooltipContent>
             </Tooltip>
-          ) : (
-            <TabMoveDropdown
-              toolsTabs={toolsTabs}
-              extraTabs={extraTabs}
-              isExtraPanelOpen={panelVisibility.extra}
-              onMoveToExtra={onMoveTabToExtra}
-              onMoveToTools={onMoveTabToTools}
-              variant="plus"
-            />
-          )}
-
-          {/* View options dropdown — placeholder */}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button variant="ghost" size="icon" className="tw-h-8 tw-w-8">
-                <EllipsisVertical className="tw-h-4 tw-w-4" />
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              <p className="tw-font-light">View options</p>
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      </div>
+          </div>
+        }
+      >
+        {/* Center: BCV control */}
+        <BookChapterControl
+          scrRef={scrRef}
+          handleSubmit={setScrRef}
+          className="tw-w-80"
+          recentSearches={recentScriptureRefs}
+          onAddRecentSearch={addRecentScriptureRef}
+        />
+      </Toolbar>
     </TooltipProvider>
   );
 }

--- a/src/renderer/components/simple-mode/simple-mode-toolbar.component.tsx
+++ b/src/renderer/components/simple-mode/simple-mode-toolbar.component.tsx
@@ -1,6 +1,7 @@
 import logo from '@assets/icon.png';
 import { useScrollGroupScrRef, useRecentScriptureRefs } from '@renderer/hooks/papi-hooks';
 import { sendCommand } from '@shared/services/command.service';
+import { logger } from '@shared/services/logger.service';
 import {
   BookChapterControl,
   Button,
@@ -15,7 +16,7 @@ import {
 } from 'platform-bible-react';
 import { ScrollGroupId } from 'platform-bible-utils';
 import { ScrollGroupScrRef } from '@shared/services/scroll-group.service-model';
-import { BookOpen, PenLine, Wrench, Minus, EllipsisVertical } from 'lucide-react';
+import { BookOpen, PenLine, Wrench, Minus, Settings2, ChevronDown } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { PanelVisibility, SimplePanelId } from './simple-mode-layout.component';
 import { SimpleTabDefinition } from './simple-mode-tab-config';
@@ -155,7 +156,7 @@ export function SimpleModeToolbar({
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button variant="ghost" size="icon" className="tw-h-8 tw-w-8">
-                  <EllipsisVertical className="tw-h-4 tw-w-4" />
+                  <Settings2 className="tw-h-4 tw-w-4" />
                 </Button>
               </TooltipTrigger>
               <TooltipContent>
@@ -165,7 +166,28 @@ export function SimpleModeToolbar({
           </div>
         }
       >
-        {/* Center: BCV control */}
+        {/* Center: project selector + BCV control */}
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              variant="outline"
+              className="tw-h-8 tw-gap-1 tw-text-sm tw-font-normal tw-max-w-[180px]"
+              onClick={async () => {
+                try {
+                  await sendCommand('platformScriptureEditor.openScriptureEditor', undefined);
+                } catch (e) {
+                  logger.warn(`Error opening project selector: ${e}`);
+                }
+              }}
+            >
+              <span className="tw-truncate">Select Project</span>
+              <ChevronDown className="tw-h-3.5 tw-w-3.5 tw-shrink-0 tw-opacity-50" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="tw-font-light">Open project</p>
+          </TooltipContent>
+        </Tooltip>
         <BookChapterControl
           scrRef={scrRef}
           handleSubmit={setScrRef}

--- a/src/renderer/components/simple-mode/simple-mode-toolbar.component.tsx
+++ b/src/renderer/components/simple-mode/simple-mode-toolbar.component.tsx
@@ -1,0 +1,220 @@
+import logo from '@assets/icon.png';
+import { useScrollGroupScrRef, useRecentScriptureRefs } from '@renderer/hooks/papi-hooks';
+import { sendCommand } from '@shared/services/command.service';
+import {
+  BookChapterControl,
+  Button,
+  cn,
+  getToolbarOSReservedSpaceClassName,
+  SidebarTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+  usePromise,
+} from 'platform-bible-react';
+import { ScrollGroupId } from 'platform-bible-utils';
+import { ScrollGroupScrRef } from '@shared/services/scroll-group.service-model';
+import { BookOpen, PenLine, Wrench, Minus, EllipsisVertical } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { PanelVisibility, SimplePanelId } from './simple-mode-layout.component';
+import { SimpleTabDefinition } from './simple-mode-tab-config';
+import { TabMoveDropdown } from './tab-move-dropdown.component';
+
+const TOOLTIP_DELAY = 300;
+const scrollGroupIdLocalStorageKey = 'simple-mode-toolbar.scrollGroupId';
+
+export type SimpleModeToolbarProps = {
+  panelVisibility: PanelVisibility;
+  onTogglePanel: (panelId: SimplePanelId) => void;
+  onShowExtraPanel: () => void;
+  onHideExtraPanel: () => void;
+  /** Tabs currently in the tools panel */
+  toolsTabs: SimpleTabDefinition[];
+  /** Tabs currently in the extra panel */
+  extraTabs: SimpleTabDefinition[];
+  /** Move a tab to the extra panel */
+  onMoveTabToExtra: (tabId: string) => void;
+  /** Move a tab back to tools */
+  onMoveTabToTools: (tabId: string) => void;
+};
+
+/** Layout toggle button config */
+const PANEL_TOGGLES: { id: SimplePanelId; icon: typeof BookOpen; label: string }[] = [
+  { id: 'reference', icon: BookOpen, label: 'Reference' },
+  { id: 'editor', icon: PenLine, label: 'Editor' },
+  { id: 'tools', icon: Wrench, label: 'Tools / Resources' },
+];
+
+export function SimpleModeToolbar({
+  panelVisibility,
+  onTogglePanel,
+  onShowExtraPanel,
+  onHideExtraPanel,
+  toolsTabs,
+  extraTabs,
+  onMoveTabToExtra,
+  onMoveTabToTools,
+}: SimpleModeToolbarProps) {
+  // Scroll group / BCV control — same pattern as Power Mode toolbar
+  const [scrollGroupIdInternal, setScrollGroupIdInternal] = useState<ScrollGroupId>(() =>
+    JSON.parse(localStorage.getItem(scrollGroupIdLocalStorageKey) ?? '0'),
+  );
+  const updateScrollGroupIdInternal = useCallback((newScrollGroupId: ScrollGroupScrRef) => {
+    if (typeof newScrollGroupId !== 'number')
+      throw new Error(
+        `Top Scroll Group ID cannot be anything but a number! Trying to set to ${newScrollGroupId}`,
+      );
+    setScrollGroupIdInternal(newScrollGroupId);
+    localStorage.setItem(scrollGroupIdLocalStorageKey, JSON.stringify(newScrollGroupId));
+    return true;
+  }, []);
+
+  const [scrRef, setScrRef] = useScrollGroupScrRef(
+    scrollGroupIdInternal,
+    updateScrollGroupIdInternal,
+  );
+
+  const { recentScriptureRefs, addRecentScriptureRef } = useRecentScriptureRefs();
+
+  // OS reserved space for window controls
+  const [osPlatformToReserveSpaceFor] = usePromise(
+    useCallback(async () => {
+      const osPlatform: string | undefined = await sendCommand('platform.getOSPlatform');
+      const isFullScreen: boolean = await sendCommand('platform.isFullScreen');
+      if (osPlatform === 'darwin' && isFullScreen) return undefined;
+      if (osPlatform === 'linux') return undefined;
+      return osPlatform;
+    }, []),
+    undefined,
+  );
+
+  return (
+    <TooltipProvider delayDuration={TOOLTIP_DELAY}>
+      <div
+        className={cn(
+          'simple-mode-toolbar',
+          getToolbarOSReservedSpaceClassName(osPlatformToReserveSpaceFor),
+        )}
+        style={{
+          height: 48,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+          padding: '0 8px',
+          borderBottom: '1px solid var(--border, #e5e7eb)',
+          // eslint-disable-next-line no-restricted-syntax
+          WebkitAppRegion: 'drag',
+        }}
+      >
+        {/* Sidebar trigger */}
+        <SidebarTrigger
+          className="tw-h-8 tw-w-8 tw-flex-shrink-0"
+          style={{
+            // eslint-disable-next-line no-restricted-syntax
+            WebkitAppRegion: 'no-drag',
+          }}
+        />
+
+        {/* Logo */}
+        <img width={24} height={24} src={`${logo}`} alt="Platform.Bible logo" />
+        <span
+          className="tw-font-semibold tw-text-sm tw-whitespace-nowrap tw-mr-2"
+          style={{ userSelect: 'none' }}
+        >
+          Platform.Bible
+        </span>
+
+        {/* BCV Control */}
+        <div
+          style={{
+            // eslint-disable-next-line no-restricted-syntax
+            WebkitAppRegion: 'no-drag',
+          }}
+        >
+          <BookChapterControl
+            scrRef={scrRef}
+            handleSubmit={setScrRef}
+            className="tw-w-80"
+            recentSearches={recentScriptureRefs}
+            onAddRecentSearch={addRecentScriptureRef}
+          />
+        </div>
+
+        {/* Spacer */}
+        <div className="tw-flex-1" />
+
+        {/* Layout toggle buttons */}
+        <div
+          className="tw-flex tw-items-center tw-gap-1"
+          style={{
+            // eslint-disable-next-line no-restricted-syntax
+            WebkitAppRegion: 'no-drag',
+          }}
+        >
+          {PANEL_TOGGLES.map(({ id, icon: Icon, label }) => (
+            <Tooltip key={id}>
+              <TooltipTrigger asChild>
+                <Button
+                  variant={panelVisibility[id] ? 'default' : 'ghost'}
+                  size="icon"
+                  className="tw-h-8 tw-w-8"
+                  onClick={() => onTogglePanel(id)}
+                >
+                  <Icon className="tw-h-4 tw-w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="tw-font-light">
+                  {panelVisibility[id] ? `Hide ${label}` : `Show ${label}`}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          ))}
+
+          {/* Plus / Minus button for extra panel */}
+          {panelVisibility.extra ? (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="tw-h-8 tw-w-8"
+                  onClick={onHideExtraPanel}
+                >
+                  <Minus className="tw-h-4 tw-w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="tw-font-light">Close extra panel</p>
+              </TooltipContent>
+            </Tooltip>
+          ) : (
+            <TabMoveDropdown
+              toolsTabs={toolsTabs}
+              extraTabs={extraTabs}
+              isExtraPanelOpen={panelVisibility.extra}
+              onMoveToExtra={onMoveTabToExtra}
+              onMoveToTools={onMoveTabToTools}
+              variant="plus"
+            />
+          )}
+
+          {/* View options dropdown — placeholder */}
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant="ghost" size="icon" className="tw-h-8 tw-w-8">
+                <EllipsisVertical className="tw-h-4 tw-w-4" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p className="tw-font-light">View options</p>
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}
+
+export default SimpleModeToolbar;

--- a/src/renderer/components/simple-mode/tab-move-dropdown.component.tsx
+++ b/src/renderer/components/simple-mode/tab-move-dropdown.component.tsx
@@ -1,0 +1,104 @@
+import { Button, Popover, PopoverContent, PopoverTrigger, Separator } from 'platform-bible-react';
+import { EllipsisVertical, Plus, ArrowRight, ArrowLeft } from 'lucide-react';
+import { SimpleTabDefinition } from './simple-mode-tab-config';
+
+export type TabMoveDropdownProps = {
+  /** Tabs currently in the tools panel that can be moved to the extra panel */
+  toolsTabs: SimpleTabDefinition[];
+  /** Tabs currently in the extra panel that can be moved back to tools */
+  extraTabs: SimpleTabDefinition[];
+  /** Whether the extra panel is currently visible */
+  isExtraPanelOpen: boolean;
+  /** Called when a tab should be moved to the extra panel */
+  onMoveToExtra: (tabId: string) => void;
+  /** Called when a tab should be moved back to the tools panel */
+  onMoveToTools: (tabId: string) => void;
+  /** The trigger element variant */
+  variant?: 'plus' | 'ellipsis';
+};
+
+/**
+ * Reusable dropdown for moving tabs between the tools panel and the extra panel.
+ *
+ * Used in three places:
+ *
+ * 1. Toolbar plus (+) button — lists tools tabs to move to a new extra panel
+ * 2. Extra panel toolbar ellipsis button — bidirectional move
+ * 3. Tools panel toolbar ellipsis button — bidirectional move when extra panel is open
+ */
+export function TabMoveDropdown({
+  toolsTabs,
+  extraTabs,
+  isExtraPanelOpen,
+  onMoveToExtra,
+  onMoveToTools,
+  variant = 'ellipsis',
+}: TabMoveDropdownProps) {
+  const TriggerIcon = variant === 'plus' ? Plus : EllipsisVertical;
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="icon" className="tw-h-8 tw-w-8">
+          <TriggerIcon className="tw-h-4 tw-w-4" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent side="bottom" align="end" className="tw-w-56 tw-p-2">
+        {/* Move to extra panel */}
+        {toolsTabs.length > 0 && (
+          <>
+            <p className="tw-text-xs tw-font-medium tw-text-muted-foreground tw-px-2 tw-py-1">
+              Move to extra panel
+            </p>
+            {toolsTabs.map((tab) => {
+              const Icon = tab.icon;
+              return (
+                <Button
+                  key={tab.id}
+                  variant="ghost"
+                  className="tw-w-full tw-justify-start tw-gap-2 tw-h-8 tw-text-sm"
+                  onClick={() => onMoveToExtra(tab.id)}
+                >
+                  <Icon className="tw-h-4 tw-w-4" />
+                  {tab.label}
+                  <ArrowRight className="tw-h-3 tw-w-3 tw-ml-auto tw-text-muted-foreground" />
+                </Button>
+              );
+            })}
+          </>
+        )}
+
+        {/* Move back to tools panel */}
+        {isExtraPanelOpen && extraTabs.length > 0 && (
+          <>
+            {toolsTabs.length > 0 && <Separator className="tw-my-1" />}
+            <p className="tw-text-xs tw-font-medium tw-text-muted-foreground tw-px-2 tw-py-1">
+              Move to tools panel
+            </p>
+            {extraTabs.map((tab) => {
+              const Icon = tab.icon;
+              return (
+                <Button
+                  key={tab.id}
+                  variant="ghost"
+                  className="tw-w-full tw-justify-start tw-gap-2 tw-h-8 tw-text-sm"
+                  onClick={() => onMoveToTools(tab.id)}
+                >
+                  <Icon className="tw-h-4 tw-w-4" />
+                  {tab.label}
+                  <ArrowLeft className="tw-h-3 tw-w-3 tw-ml-auto tw-text-muted-foreground" />
+                </Button>
+              );
+            })}
+          </>
+        )}
+
+        {toolsTabs.length === 0 && extraTabs.length === 0 && (
+          <p className="tw-text-xs tw-text-muted-foreground tw-px-2 tw-py-2">No tabs to move</p>
+        )}
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default TabMoveDropdown;

--- a/src/renderer/components/simple-mode/use-simple-mode-dock-layout.hook.ts
+++ b/src/renderer/components/simple-mode/use-simple-mode-dock-layout.hook.ts
@@ -1,4 +1,4 @@
-import { useRef, useEffect, useCallback } from 'react';
+import { useRef, useEffect, useState, useCallback } from 'react';
 import { LayoutBase } from 'rc-dock';
 import {
   SavedTabInfo,
@@ -52,7 +52,6 @@ class SimpleModeTabStore {
   getWebViewDefinition(webViewId: string): WebViewDefinition | undefined {
     const tab = this.tabs.get(webViewId);
     if (!tab) return undefined;
-    // The webview definition is stored as tab.data
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     return tab.data as WebViewDefinition | undefined;
   }
@@ -63,36 +62,68 @@ class SimpleModeTabStore {
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     const currentDef = tab.data as WebViewDefinition | undefined;
     if (!currentDef) return false;
-    // Merge update info into the definition
     tab.data = { ...currentDef, ...updateInfo };
     this.tabs.set(webViewId, tab);
     return true;
   }
 }
 
-/**
- * An empty layout for Simple Mode. Simple Mode does not use rc-dock's LayoutBase, but the interface
- * requires one.
- */
-const SIMPLE_MODE_EMPTY_LAYOUT: LayoutBase = {
-  dockbox: { mode: 'horizontal', children: [] },
+/** Reactive map of webViewId -> WebViewTabProps surfaced to the UI */
+export type WebViewMap = Record<string, WebViewTabProps>;
+
+/** Webviews that should be rendered as floating dialogs (from float-type layouts) */
+export type DialogWebView = WebViewTabProps & { dialogId: string };
+
+export type UseSimpleModeDockLayoutResult = {
+  webViewMap: WebViewMap;
+  /** Webviews that should be shown as centered blocking dialogs */
+  dialogWebViews: DialogWebView[];
+  /** Close/dismiss a dialog webview */
+  closeDialog: (dialogId: string) => void;
 };
 
 /**
  * Hook that creates a PapiDockLayout implementation for Simple Mode and registers it with the
  * web-view service on mount.
  *
- * Returns the tab store so the layout component can inspect registered webviews.
+ * Returns a reactive `webViewMap` so the layout can render real WebView components.
  */
-export function useSimpleModeDockLayout(): SimpleModeTabStore {
+export function useSimpleModeDockLayout(): UseSimpleModeDockLayoutResult {
   const storeRef = useRef(new SimpleModeTabStore());
   const onLayoutChangeRef = useRef<OnLayoutChangeRCDock | undefined>();
+  const [webViewMap, setWebViewMap] = useState<WebViewMap>({});
+  const [dialogWebViews, setDialogWebViews] = useState<DialogWebView[]>([]);
+
+  // Callback to update the reactive webview map when webviews are added/updated/removed
+  const notifyWebViewChange = useCallback((webView: WebViewTabProps) => {
+    setWebViewMap((prev) => ({
+      ...prev,
+      [webView.id]: webView,
+    }));
+  }, []);
+
+  const notifyWebViewRemove = useCallback((tabId: string) => {
+    setWebViewMap((prev) => {
+      const next = { ...prev };
+      delete next[tabId];
+      return next;
+    });
+  }, []);
+
+  const addDialogWebView = useCallback((webView: WebViewTabProps) => {
+    setDialogWebViews((prev) => [...prev, { ...webView, dialogId: webView.id }]);
+  }, []);
+
+  const closeDialog = useCallback((dialogId: string) => {
+    setDialogWebViews((prev) => prev.filter((d) => d.dialogId !== dialogId));
+    // Also remove from the store
+    storeRef.current.removeTab(dialogId);
+  }, []);
 
   useEffect(() => {
     const store = storeRef.current;
 
     const dockLayout: PapiDockLayout = {
-      // No rc-dock in Simple Mode
       dockLayout: undefined,
       onLayoutChangeRef,
 
@@ -103,11 +134,9 @@ export function useSimpleModeDockLayout(): SimpleModeTabStore {
       ): Layout | undefined => {
         const existingTab = store.getTab(savedTabInfo.id);
         if (existingTab) {
-          // Update existing tab
           store.addOrUpdateTab({ ...existingTab, ...savedTabInfo });
           return undefined;
         }
-        // Create new tab info (minimal — real content comes from webview system)
         const newTab: TabInfo = {
           ...savedTabInfo,
           tabTitle: savedTabInfo.id,
@@ -124,12 +153,12 @@ export function useSimpleModeDockLayout(): SimpleModeTabStore {
       ): Layout | undefined => {
         const existingTab = store.getTab(webView.id);
         if (existingTab) {
-          // Update existing webview
           store.addOrUpdateTab({
             ...existingTab,
             data: webView,
             tabTitle: webView.title ?? webView.webViewType,
           });
+          notifyWebViewChange(webView);
           return undefined;
         }
         const newTab: TabInfo = {
@@ -140,15 +169,23 @@ export function useSimpleModeDockLayout(): SimpleModeTabStore {
           content: undefined,
         };
         store.addOrUpdateTab(newTab);
+
+        // Float-type layouts should be rendered as centered dialogs in Simple Mode
+        if (layout.type === 'float') {
+          addDialogWebView(webView);
+        } else {
+          notifyWebViewChange(webView);
+        }
         return layout;
       },
 
       removeTabFromDock: (tabId: string): boolean => {
-        return store.removeTab(tabId);
+        const removed = store.removeTab(tabId);
+        if (removed) notifyWebViewRemove(tabId);
+        return removed;
       },
 
       floatTabById: (_tabId: string): void => {
-        // Simple Mode does not support floating tabs
         logger.debug('SimpleModeLayout: floatTabById is not supported in Simple Mode');
       },
 
@@ -173,24 +210,27 @@ export function useSimpleModeDockLayout(): SimpleModeTabStore {
         updateInfo: WebViewDefinitionUpdateInfo,
         _shouldBringToFront = false,
       ): boolean => {
-        return store.updateWebViewDefinition(webViewId, updateInfo);
+        const result = store.updateWebViewDefinition(webViewId, updateInfo);
+        if (result) {
+          const def = store.getWebViewDefinition(webViewId);
+          // eslint-disable-next-line no-type-assertion/no-type-assertion
+          if (def) notifyWebViewChange(def as WebViewTabProps);
+        }
+        return result;
       },
 
       getTabInfoByDirectionFromTab: (
         sourceTabId: string,
         _direction: DirectionFromTab,
       ): TabInfo | undefined => {
-        // Simple Mode has a flat list of tabs per panel — direction navigation is simplified
         const allTabs = store.getAllTabs();
         const sourceIndex = allTabs.findIndex((t) => t.id === sourceTabId);
         if (sourceIndex < 0) return undefined;
-        // Just return the next tab, wrapping around
         const nextIndex = (sourceIndex + 1) % allTabs.length;
         return allTabs[nextIndex];
       },
 
       getTabInfoByElement: (tabElement: Element): TabInfo | undefined => {
-        // Walk up the DOM to find the data-web-view-id attribute
         let el: Element | null = tabElement;
         while (el) {
           const webViewId = el.getAttribute('data-web-view-id');
@@ -206,15 +246,10 @@ export function useSimpleModeDockLayout(): SimpleModeTabStore {
 
       focusTab: (tabId: string): boolean => {
         const tab = store.getTab(tabId);
-        if (!tab) return false;
-        // In Simple Mode, focusing means the UI should activate this tab in its panel.
-        // The actual focus logic is handled by the React component state.
-        // For now, just return true to indicate the tab exists.
-        return true;
+        return !!tab;
       },
 
       loadLayout: (_layout: LayoutBase): void => {
-        // Simple Mode does not use rc-dock layouts
         logger.debug('SimpleModeLayout: loadLayout is a no-op in Simple Mode');
       },
 
@@ -229,7 +264,8 @@ export function useSimpleModeDockLayout(): SimpleModeTabStore {
     return () => {
       unsub();
     };
-  }, []);
+    // All callbacks are stable (useCallback with [])
+  }, [notifyWebViewChange, notifyWebViewRemove, addDialogWebView]);
 
-  return storeRef.current;
+  return { webViewMap, dialogWebViews, closeDialog };
 }

--- a/src/renderer/components/simple-mode/use-simple-mode-dock-layout.hook.ts
+++ b/src/renderer/components/simple-mode/use-simple-mode-dock-layout.hook.ts
@@ -10,16 +10,12 @@ import {
   PapiDockLayout,
 } from '@shared/models/docking-framework.model';
 import { WebViewDefinition, WebViewDefinitionUpdateInfo } from '@shared/models/web-view.model';
-import { registerDockLayout } from '@renderer/services/web-view.service-host';
+import { registerDockLayout, openWebView } from '@renderer/services/web-view.service-host';
 import { testLayout } from '@renderer/testing/test-layout.data';
 import { logger } from '@shared/services/logger.service';
+import { SIMPLE_MODE_TABS } from './simple-mode-tab-config';
 
-/**
- * Internal store for tabs managed by Simple Mode.
- *
- * Simple Mode does not use rc-dock, so we maintain our own map of tab info and webview definitions.
- * This satisfies the PapiDockLayout interface so the webview service continues to work.
- */
+/** Internal store for tabs managed by Simple Mode. */
 class SimpleModeTabStore {
   private tabs = new Map<string, TabInfo>();
 
@@ -68,14 +64,20 @@ class SimpleModeTabStore {
   }
 }
 
-/** Reactive map of webViewId -> WebViewTabProps surfaced to the UI */
+/** Reactive map of webViewId (UUID) -> WebViewTabProps */
 export type WebViewMap = Record<string, WebViewTabProps>;
 
-/** Webviews that should be rendered as floating dialogs (from float-type layouts) */
+/** Map of simpleTabId -> webViewId so panels know which webview to render for each tab */
+export type TabWebViewIds = Record<string, string>;
+
+/** Webviews that should be rendered as floating dialogs */
 export type DialogWebView = WebViewTabProps & { dialogId: string };
 
 export type UseSimpleModeDockLayoutResult = {
+  /** All webview definitions keyed by their UUID */
   webViewMap: WebViewMap;
+  /** Maps each simple-mode tab id to its opened webview UUID */
+  tabWebViewIds: TabWebViewIds;
   /** Webviews that should be shown as centered blocking dialogs */
   dialogWebViews: DialogWebView[];
   /** Close/dismiss a dialog webview */
@@ -83,18 +85,18 @@ export type UseSimpleModeDockLayoutResult = {
 };
 
 /**
- * Hook that creates a PapiDockLayout implementation for Simple Mode and registers it with the
- * web-view service on mount.
- *
- * Returns a reactive `webViewMap` so the layout can render real WebView components.
+ * Hook that creates a PapiDockLayout implementation for Simple Mode, registers it with the web-view
+ * service, and opens webviews for all non-placeholder tabs on mount.
  */
 export function useSimpleModeDockLayout(): UseSimpleModeDockLayoutResult {
   const storeRef = useRef(new SimpleModeTabStore());
   const onLayoutChangeRef = useRef<OnLayoutChangeRCDock | undefined>();
   const [webViewMap, setWebViewMap] = useState<WebViewMap>({});
+  const [tabWebViewIds, setTabWebViewIds] = useState<TabWebViewIds>({});
   const [dialogWebViews, setDialogWebViews] = useState<DialogWebView[]>([]);
+  /** Track which simple tab IDs we're currently opening webviews for, to avoid duplicates */
+  const openingTabsRef = useRef(new Set<string>());
 
-  // Callback to update the reactive webview map when webviews are added/updated/removed
   const notifyWebViewChange = useCallback((webView: WebViewTabProps) => {
     setWebViewMap((prev) => ({
       ...prev,
@@ -116,10 +118,10 @@ export function useSimpleModeDockLayout(): UseSimpleModeDockLayoutResult {
 
   const closeDialog = useCallback((dialogId: string) => {
     setDialogWebViews((prev) => prev.filter((d) => d.dialogId !== dialogId));
-    // Also remove from the store
     storeRef.current.removeTab(dialogId);
   }, []);
 
+  // Register the PapiDockLayout implementation
   useEffect(() => {
     const store = storeRef.current;
 
@@ -170,7 +172,6 @@ export function useSimpleModeDockLayout(): UseSimpleModeDockLayoutResult {
         };
         store.addOrUpdateTab(newTab);
 
-        // Float-type layouts should be rendered as centered dialogs in Simple Mode
         if (layout.type === 'float') {
           addDialogWebView(webView);
         } else {
@@ -261,11 +262,49 @@ export function useSimpleModeDockLayout(): UseSimpleModeDockLayoutResult {
     };
 
     const unsub = registerDockLayout(dockLayout);
+
+    // After registering, open webviews for all non-placeholder tabs
+    openWebViewsForTabs();
+
     return () => {
       unsub();
     };
-    // All callbacks are stable (useCallback with [])
-  }, [notifyWebViewChange, notifyWebViewRemove, addDialogWebView]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  return { webViewMap, dialogWebViews, closeDialog };
+  /**
+   * Opens a webview for each non-placeholder simple-mode tab that has a webViewType. Each tab gets
+   * its own webview instance. The mapping simpleTabId -> webViewId is stored in tabWebViewIds so
+   * panels can look up which WebView to render.
+   */
+  async function openWebViewsForTabs(): Promise<void> {
+    const tabsToOpen = SIMPLE_MODE_TABS.filter((t) => !t.isPlaceholder && t.webViewType);
+
+    for (const tab of tabsToOpen) {
+      if (openingTabsRef.current.has(tab.id)) continue;
+      openingTabsRef.current.add(tab.id);
+
+      try {
+        // Open the webview — this will trigger addWebViewToDock which populates webViewMap
+        const webViewId = await openWebView(
+          // eslint-disable-next-line no-type-assertion/no-type-assertion
+          tab.webViewType!,
+          { type: 'tab' },
+        );
+
+        if (webViewId) {
+          // Record the mapping: this simple tab ID uses this webview UUID
+          setTabWebViewIds((prev) => ({ ...prev, [tab.id]: webViewId }));
+        } else {
+          logger.warn(
+            `SimpleModeLayout: Failed to open webview for tab "${tab.id}" (type: ${tab.webViewType})`,
+          );
+        }
+      } catch (e) {
+        logger.warn(`SimpleModeLayout: Error opening webview for tab "${tab.id}": ${e}`);
+      }
+    }
+  }
+
+  return { webViewMap, tabWebViewIds, dialogWebViews, closeDialog };
 }

--- a/src/renderer/components/simple-mode/use-simple-mode-dock-layout.hook.ts
+++ b/src/renderer/components/simple-mode/use-simple-mode-dock-layout.hook.ts
@@ -1,0 +1,235 @@
+import { useRef, useEffect, useCallback } from 'react';
+import { LayoutBase } from 'rc-dock';
+import {
+  SavedTabInfo,
+  Layout,
+  OnLayoutChangeRCDock,
+  WebViewTabProps,
+  TabInfo,
+  DirectionFromTab,
+  PapiDockLayout,
+} from '@shared/models/docking-framework.model';
+import { WebViewDefinition, WebViewDefinitionUpdateInfo } from '@shared/models/web-view.model';
+import { registerDockLayout } from '@renderer/services/web-view.service-host';
+import { testLayout } from '@renderer/testing/test-layout.data';
+import { logger } from '@shared/services/logger.service';
+
+/**
+ * Internal store for tabs managed by Simple Mode.
+ *
+ * Simple Mode does not use rc-dock, so we maintain our own map of tab info and webview definitions.
+ * This satisfies the PapiDockLayout interface so the webview service continues to work.
+ */
+class SimpleModeTabStore {
+  private tabs = new Map<string, TabInfo>();
+
+  addOrUpdateTab(tabInfo: TabInfo): void {
+    this.tabs.set(tabInfo.id, tabInfo);
+  }
+
+  removeTab(tabId: string): boolean {
+    return this.tabs.delete(tabId);
+  }
+
+  getTab(tabId: string): TabInfo | undefined {
+    return this.tabs.get(tabId);
+  }
+
+  findTab(idOrFilter: string | ((item: SavedTabInfo) => boolean)): TabInfo | undefined {
+    if (typeof idOrFilter === 'string') {
+      return this.tabs.get(idOrFilter);
+    }
+    for (const tab of this.tabs.values()) {
+      if (idOrFilter(tab)) return tab;
+    }
+    return undefined;
+  }
+
+  getAllTabs(): TabInfo[] {
+    return [...this.tabs.values()];
+  }
+
+  getWebViewDefinition(webViewId: string): WebViewDefinition | undefined {
+    const tab = this.tabs.get(webViewId);
+    if (!tab) return undefined;
+    // The webview definition is stored as tab.data
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    return tab.data as WebViewDefinition | undefined;
+  }
+
+  updateWebViewDefinition(webViewId: string, updateInfo: WebViewDefinitionUpdateInfo): boolean {
+    const tab = this.tabs.get(webViewId);
+    if (!tab) return false;
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    const currentDef = tab.data as WebViewDefinition | undefined;
+    if (!currentDef) return false;
+    // Merge update info into the definition
+    tab.data = { ...currentDef, ...updateInfo };
+    this.tabs.set(webViewId, tab);
+    return true;
+  }
+}
+
+/**
+ * An empty layout for Simple Mode. Simple Mode does not use rc-dock's LayoutBase, but the interface
+ * requires one.
+ */
+const SIMPLE_MODE_EMPTY_LAYOUT: LayoutBase = {
+  dockbox: { mode: 'horizontal', children: [] },
+};
+
+/**
+ * Hook that creates a PapiDockLayout implementation for Simple Mode and registers it with the
+ * web-view service on mount.
+ *
+ * Returns the tab store so the layout component can inspect registered webviews.
+ */
+export function useSimpleModeDockLayout(): SimpleModeTabStore {
+  const storeRef = useRef(new SimpleModeTabStore());
+  const onLayoutChangeRef = useRef<OnLayoutChangeRCDock | undefined>();
+
+  useEffect(() => {
+    const store = storeRef.current;
+
+    const dockLayout: PapiDockLayout = {
+      // No rc-dock in Simple Mode
+      dockLayout: undefined,
+      onLayoutChangeRef,
+
+      addTabToDock: (
+        savedTabInfo: SavedTabInfo,
+        layout: Layout,
+        _shouldBringToFront = true,
+      ): Layout | undefined => {
+        const existingTab = store.getTab(savedTabInfo.id);
+        if (existingTab) {
+          // Update existing tab
+          store.addOrUpdateTab({ ...existingTab, ...savedTabInfo });
+          return undefined;
+        }
+        // Create new tab info (minimal — real content comes from webview system)
+        const newTab: TabInfo = {
+          ...savedTabInfo,
+          tabTitle: savedTabInfo.id,
+          content: undefined,
+        };
+        store.addOrUpdateTab(newTab);
+        return layout;
+      },
+
+      addWebViewToDock: (
+        webView: WebViewTabProps,
+        layout: Layout,
+        _shouldBringToFront = true,
+      ): Layout | undefined => {
+        const existingTab = store.getTab(webView.id);
+        if (existingTab) {
+          // Update existing webview
+          store.addOrUpdateTab({
+            ...existingTab,
+            data: webView,
+            tabTitle: webView.title ?? webView.webViewType,
+          });
+          return undefined;
+        }
+        const newTab: TabInfo = {
+          id: webView.id,
+          tabType: 'webView',
+          data: webView,
+          tabTitle: webView.title ?? webView.webViewType,
+          content: undefined,
+        };
+        store.addOrUpdateTab(newTab);
+        return layout;
+      },
+
+      removeTabFromDock: (tabId: string): boolean => {
+        return store.removeTab(tabId);
+      },
+
+      floatTabById: (_tabId: string): void => {
+        // Simple Mode does not support floating tabs
+        logger.debug('SimpleModeLayout: floatTabById is not supported in Simple Mode');
+      },
+
+      getWebViewDefinition: (webViewId: string): WebViewDefinition | undefined => {
+        return store.getWebViewDefinition(webViewId);
+      },
+
+      updateTabPartial: (
+        tabId: string,
+        partialTabInfo: Partial<TabInfo>,
+        _shouldBringToFront = false,
+      ): TabInfo | undefined => {
+        const tab = store.getTab(tabId);
+        if (!tab) return undefined;
+        const updated = { ...tab, ...partialTabInfo, id: tabId };
+        store.addOrUpdateTab(updated);
+        return updated;
+      },
+
+      updateWebViewDefinition: (
+        webViewId: string,
+        updateInfo: WebViewDefinitionUpdateInfo,
+        _shouldBringToFront = false,
+      ): boolean => {
+        return store.updateWebViewDefinition(webViewId, updateInfo);
+      },
+
+      getTabInfoByDirectionFromTab: (
+        sourceTabId: string,
+        _direction: DirectionFromTab,
+      ): TabInfo | undefined => {
+        // Simple Mode has a flat list of tabs per panel — direction navigation is simplified
+        const allTabs = store.getAllTabs();
+        const sourceIndex = allTabs.findIndex((t) => t.id === sourceTabId);
+        if (sourceIndex < 0) return undefined;
+        // Just return the next tab, wrapping around
+        const nextIndex = (sourceIndex + 1) % allTabs.length;
+        return allTabs[nextIndex];
+      },
+
+      getTabInfoByElement: (tabElement: Element): TabInfo | undefined => {
+        // Walk up the DOM to find the data-web-view-id attribute
+        let el: Element | null = tabElement;
+        while (el) {
+          const webViewId = el.getAttribute('data-web-view-id');
+          if (webViewId) return store.getTab(webViewId);
+          el = el.parentElement;
+        }
+        return undefined;
+      },
+
+      getTabInfoById: (tabId: string): TabInfo | undefined => {
+        return store.getTab(tabId);
+      },
+
+      focusTab: (tabId: string): boolean => {
+        const tab = store.getTab(tabId);
+        if (!tab) return false;
+        // In Simple Mode, focusing means the UI should activate this tab in its panel.
+        // The actual focus logic is handled by the React component state.
+        // For now, just return true to indicate the tab exists.
+        return true;
+      },
+
+      loadLayout: (_layout: LayoutBase): void => {
+        // Simple Mode does not use rc-dock layouts
+        logger.debug('SimpleModeLayout: loadLayout is a no-op in Simple Mode');
+      },
+
+      findTab: (idOrFilter: string | ((item: SavedTabInfo) => boolean)): TabInfo | undefined => {
+        return store.findTab(idOrFilter);
+      },
+
+      testLayout,
+    };
+
+    const unsub = registerDockLayout(dockLayout);
+    return () => {
+      unsub();
+    };
+  }, []);
+
+  return storeRef.current;
+}

--- a/src/renderer/components/simple-mode/workflow-sidebar.component.tsx
+++ b/src/renderer/components/simple-mode/workflow-sidebar.component.tsx
@@ -1,0 +1,76 @@
+import {
+  SidebarContent,
+  SidebarGroup,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarRail,
+  SidebarSeparator,
+} from 'platform-bible-react';
+import { PenLine, RefreshCw, HelpCircle, CircleUserRound } from 'lucide-react';
+import { UserProfileDropdown } from '@renderer/components/user-profile-dropdown.component';
+
+/**
+ * Sidebar content for Simple Mode.
+ *
+ * Renders inside the shadcn `Sidebar` shell provided by `simple-mode-layout.component.tsx`.
+ * Currently only implements the Study & Draft workflow. Sync and Help are visible but
+ * non-functional placeholders.
+ */
+export function WorkflowSidebar() {
+  return (
+    <>
+      <SidebarHeader className="tw-p-2">
+        {/* Could hold a collapsed logo or brand mark in the future */}
+      </SidebarHeader>
+      <SidebarContent>
+        <SidebarGroup>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton isActive tooltip="Study & Draft">
+                <PenLine />
+                <span>Study &amp; Draft</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
+        <SidebarSeparator />
+        <SidebarGroup>
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton tooltip="Sync" disabled>
+                <RefreshCw />
+                <span>Sync</span>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarGroup>
+      </SidebarContent>
+      <SidebarFooter>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuButton tooltip="Help" disabled>
+              <HelpCircle />
+              <span>Help</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
+          <SidebarMenuItem>
+            <UserProfileDropdown
+              trigger={
+                <SidebarMenuButton tooltip="Profile">
+                  <CircleUserRound />
+                  <span>Profile</span>
+                </SidebarMenuButton>
+              }
+            />
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarFooter>
+      <SidebarRail />
+    </>
+  );
+}
+
+export default WorkflowSidebar;

--- a/src/renderer/components/simple-mode/workflow-sidebar.component.tsx
+++ b/src/renderer/components/simple-mode/workflow-sidebar.component.tsx
@@ -10,7 +10,7 @@ import {
 import { PenLine, RefreshCw, HelpCircle, CircleUserRound } from 'lucide-react';
 import { UserProfileDropdown } from '@renderer/components/user-profile-dropdown.component';
 
-const ICON_CLASS = 'tw-h-6 tw-w-6';
+const ICON_CLASS = 'tw-h-7 tw-w-7';
 
 /**
  * Sidebar content for Simple Mode.

--- a/src/renderer/components/simple-mode/workflow-sidebar.component.tsx
+++ b/src/renderer/components/simple-mode/workflow-sidebar.component.tsx
@@ -5,33 +5,28 @@ import {
   SidebarMenuItem,
   SidebarMenuButton,
   SidebarFooter,
-  SidebarHeader,
-  SidebarRail,
   SidebarSeparator,
 } from 'platform-bible-react';
 import { PenLine, RefreshCw, HelpCircle, CircleUserRound } from 'lucide-react';
 import { UserProfileDropdown } from '@renderer/components/user-profile-dropdown.component';
 
+const ICON_CLASS = 'tw-h-6 tw-w-6';
+
 /**
  * Sidebar content for Simple Mode.
  *
- * Renders inside the shadcn `Sidebar` shell provided by `simple-mode-layout.component.tsx`.
- * Currently only implements the Study & Draft workflow. Sync and Help are visible but
- * non-functional placeholders.
+ * Always collapsed to icon-only state with large icons. Rendered below the toolbar. Only Study &
+ * Draft workflow is implemented. Sync and Help are non-functional placeholders.
  */
 export function WorkflowSidebar() {
   return (
     <>
-      <SidebarHeader className="tw-p-2">
-        {/* Could hold a collapsed logo or brand mark in the future */}
-      </SidebarHeader>
       <SidebarContent>
         <SidebarGroup>
           <SidebarMenu>
             <SidebarMenuItem>
-              <SidebarMenuButton isActive tooltip="Study & Draft">
-                <PenLine />
-                <span>Study &amp; Draft</span>
+              <SidebarMenuButton isActive tooltip="Study & Draft" className="tw-h-10">
+                <PenLine className={ICON_CLASS} />
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
@@ -40,9 +35,8 @@ export function WorkflowSidebar() {
         <SidebarGroup>
           <SidebarMenu>
             <SidebarMenuItem>
-              <SidebarMenuButton tooltip="Sync" disabled>
-                <RefreshCw />
-                <span>Sync</span>
+              <SidebarMenuButton tooltip="Sync" disabled className="tw-h-10">
+                <RefreshCw className={ICON_CLASS} />
               </SidebarMenuButton>
             </SidebarMenuItem>
           </SidebarMenu>
@@ -51,24 +45,22 @@ export function WorkflowSidebar() {
       <SidebarFooter>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuButton tooltip="Help" disabled>
-              <HelpCircle />
-              <span>Help</span>
+            <SidebarMenuButton tooltip="Help" disabled className="tw-h-10">
+              <HelpCircle className={ICON_CLASS} />
             </SidebarMenuButton>
           </SidebarMenuItem>
           <SidebarMenuItem>
             <UserProfileDropdown
+              side="right"
               trigger={
-                <SidebarMenuButton tooltip="Profile">
-                  <CircleUserRound />
-                  <span>Profile</span>
+                <SidebarMenuButton tooltip="Profile" className="tw-h-10">
+                  <CircleUserRound className={ICON_CLASS} />
                 </SidebarMenuButton>
               }
             />
           </SidebarMenuItem>
         </SidebarMenu>
       </SidebarFooter>
-      <SidebarRail />
     </>
   );
 }

--- a/src/renderer/components/user-profile-dropdown.component.tsx
+++ b/src/renderer/components/user-profile-dropdown.component.tsx
@@ -1,0 +1,162 @@
+import { useSetting } from '@renderer/hooks/papi-hooks/use-setting.hook';
+import { useData, useDataProvider } from '@renderer/hooks/papi-hooks';
+import { localThemeService } from '@renderer/services/theme.service-host';
+import { sendCommand } from '@shared/services/command.service';
+import { logger } from '@shared/services/logger.service';
+import { themeServiceDataProviderName } from '@shared/services/theme.service-model';
+import { CircleUserRound, Moon, Network, Sun, Monitor, ArrowRightLeft } from 'lucide-react';
+import {
+  Button,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Separator,
+  usePromise,
+} from 'platform-bible-react';
+import { getErrorMessage, isPlatformError, ThemeDefinitionExpanded } from 'platform-bible-utils';
+import { ReactNode, useCallback, useEffect, useMemo } from 'react';
+
+/** Placeholder theme to detect when we are loading */
+const DEFAULT_THEME_VALUE: ThemeDefinitionExpanded = {
+  themeFamilyId: '',
+  type: 'light',
+  id: 'light',
+  label: '%unused%',
+  cssVariables: {},
+};
+
+export type UserProfileDropdownProps = {
+  /** The trigger element. If not provided, a default CircleUserRound icon button is used. */
+  trigger?: ReactNode;
+};
+
+/**
+ * User Profile dropdown shared between Simple Mode (sidebar) and Power Mode (title bar).
+ *
+ * Contains: user info, mode switch, theme toggle, network settings, registration, language
+ * selector.
+ */
+export function UserProfileDropdown({ trigger }: UserProfileDropdownProps) {
+  // Interface mode
+  const [interfaceMode, setInterfaceMode] = useSetting('platform.interfaceMode', 'simple');
+  const isSimpleMode = interfaceMode !== 'power';
+
+  // Registration data
+  const [registrationData] = usePromise(
+    useCallback(async () => {
+      try {
+        const data = await sendCommand('paratextRegistration.getParatextRegistrationData');
+        return data;
+      } catch {
+        return undefined;
+      }
+    }, []),
+    undefined,
+  );
+
+  // Theme
+  const themeDataProvider = useDataProvider(themeServiceDataProviderName);
+  const themeOnFirstLoad = useMemo(() => localThemeService.getCurrentThemeSync(), []);
+  const [theme, setTheme] = useData<typeof themeServiceDataProviderName>(
+    themeDataProvider,
+  ).CurrentTheme(undefined, DEFAULT_THEME_VALUE);
+
+  useEffect(() => {
+    if (isPlatformError(theme))
+      logger.warn(`UserProfileDropdown: Error getting theme. ${getErrorMessage(theme)}`);
+  }, [theme]);
+
+  const isThemeLoaded = theme !== DEFAULT_THEME_VALUE && !isPlatformError(theme);
+  const themeType = isThemeLoaded ? theme.type : themeOnFirstLoad.type;
+
+  const toggleTheme = () => {
+    if (!isThemeLoaded) return;
+    const newType = theme.type === 'dark' ? 'light' : 'dark';
+    try {
+      setTheme?.({ type: newType });
+    } catch (e) {
+      logger.warn(`UserProfileDropdown: Error setting theme to ${newType}: ${getErrorMessage(e)}`);
+    }
+  };
+
+  // Extract display name from registration data
+  const userName =
+    registrationData && typeof registrationData === 'object' && 'name' in registrationData
+      ? String(registrationData.name)
+      : undefined;
+
+  const defaultTrigger = (
+    <Button variant="ghost" size="icon" className="tw-h-8 tw-w-8 tw-flex-shrink-0">
+      <CircleUserRound className="tw-h-5 tw-w-5" />
+    </Button>
+  );
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{trigger ?? defaultTrigger}</PopoverTrigger>
+      <PopoverContent side="right" align="end" className="tw-w-64">
+        {/* User info */}
+        <div className="tw-mb-3">
+          <div className="tw-flex tw-items-center tw-gap-2">
+            <CircleUserRound className="tw-h-8 tw-w-8 tw-text-muted-foreground" />
+            <div className="tw-flex-1 tw-min-w-0">
+              <p className="tw-text-sm tw-font-medium tw-truncate">
+                {userName ?? 'Not registered'}
+              </p>
+            </div>
+          </div>
+        </div>
+        <Separator className="tw-mb-2" />
+
+        {/* Mode switch */}
+        <Button
+          variant="ghost"
+          className="tw-w-full tw-justify-start tw-gap-2 tw-h-9"
+          onClick={() => setInterfaceMode(isSimpleMode ? 'power' : 'simple')}
+        >
+          <ArrowRightLeft className="tw-h-4 tw-w-4" />
+          Switch to {isSimpleMode ? 'Power' : 'Simple'} Mode
+        </Button>
+
+        {/* Theme toggle */}
+        <Button
+          variant="ghost"
+          className="tw-w-full tw-justify-start tw-gap-2 tw-h-9"
+          onClick={toggleTheme}
+          disabled={!isThemeLoaded}
+        >
+          {themeType === 'dark' ? (
+            <Sun className="tw-h-4 tw-w-4" />
+          ) : (
+            <Moon className="tw-h-4 tw-w-4" />
+          )}
+          {themeType === 'dark' ? 'Light theme' : 'Dark theme'}
+        </Button>
+
+        <Separator className="tw-my-2" />
+
+        {/* Network settings */}
+        <Button
+          variant="ghost"
+          className="tw-w-full tw-justify-start tw-gap-2 tw-h-9"
+          onClick={() => sendCommand('paratextRegistration.showInternetSettings')}
+        >
+          <Network className="tw-h-4 tw-w-4" />
+          Internet Settings
+        </Button>
+
+        {/* Registration */}
+        <Button
+          variant="ghost"
+          className="tw-w-full tw-justify-start tw-gap-2 tw-h-9"
+          onClick={() => sendCommand('paratextRegistration.showParatextRegistration')}
+        >
+          <Monitor className="tw-h-4 tw-w-4" />
+          Registration
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}
+
+export default UserProfileDropdown;

--- a/src/renderer/components/user-profile-dropdown.component.tsx
+++ b/src/renderer/components/user-profile-dropdown.component.tsx
@@ -4,13 +4,17 @@ import { localThemeService } from '@renderer/services/theme.service-host';
 import { sendCommand } from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
 import { themeServiceDataProviderName } from '@shared/services/theme.service-model';
-import { CircleUserRound, Moon, Network, Sun, Monitor, ArrowRightLeft } from 'lucide-react';
+import { CircleUserRound, Moon, Network, Sun, Monitor } from 'lucide-react';
 import {
   Button,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-  Separator,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  ToggleGroup,
+  ToggleGroupItem,
   usePromise,
 } from 'platform-bible-react';
 import { getErrorMessage, isPlatformError, ThemeDefinitionExpanded } from 'platform-bible-utils';
@@ -28,25 +32,25 @@ const DEFAULT_THEME_VALUE: ThemeDefinitionExpanded = {
 export type UserProfileDropdownProps = {
   /** The trigger element. If not provided, a default CircleUserRound icon button is used. */
   trigger?: ReactNode;
+  /** Which side the dropdown should open on. Defaults to 'bottom'. */
+  side?: 'bottom' | 'right';
 };
 
 /**
  * User Profile dropdown shared between Simple Mode (sidebar) and Power Mode (title bar).
  *
- * Contains: user info, mode switch, theme toggle, network settings, registration, language
- * selector.
+ * Contains: user info headline, registration, internet settings, mode switch toggle, theme toggle.
  */
-export function UserProfileDropdown({ trigger }: UserProfileDropdownProps) {
+export function UserProfileDropdown({ trigger, side = 'bottom' }: UserProfileDropdownProps) {
   // Interface mode
   const [interfaceMode, setInterfaceMode] = useSetting('platform.interfaceMode', 'simple');
   const isSimpleMode = interfaceMode !== 'power';
 
-  // Registration data
-  const [registrationData] = usePromise(
+  // Registration data — loaded on mount, won't flash "Not registered"
+  const [registrationData, isLoadingRegistration] = usePromise(
     useCallback(async () => {
       try {
-        const data = await sendCommand('paratextRegistration.getParatextRegistrationData');
-        return data;
+        return await sendCommand('paratextRegistration.getParatextRegistrationData');
       } catch {
         return undefined;
       }
@@ -69,17 +73,23 @@ export function UserProfileDropdown({ trigger }: UserProfileDropdownProps) {
   const isThemeLoaded = theme !== DEFAULT_THEME_VALUE && !isPlatformError(theme);
   const themeType = isThemeLoaded ? theme.type : themeOnFirstLoad.type;
 
-  const toggleTheme = () => {
-    if (!isThemeLoaded) return;
-    const newType = theme.type === 'dark' ? 'light' : 'dark';
+  const handleThemeChange = (value: string) => {
+    if (!isThemeLoaded || !value) return;
     try {
-      setTheme?.({ type: newType });
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      setTheme?.({ type: value as 'light' | 'dark' });
     } catch (e) {
-      logger.warn(`UserProfileDropdown: Error setting theme to ${newType}: ${getErrorMessage(e)}`);
+      logger.warn(`UserProfileDropdown: Error setting theme: ${getErrorMessage(e)}`);
     }
   };
 
-  // Extract display name from registration data
+  const handleModeChange = (value: string) => {
+    if (!value) return;
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    setInterfaceMode(value as 'simple' | 'power');
+  };
+
+  // Extract display name
   const userName =
     registrationData && typeof registrationData === 'object' && 'name' in registrationData
       ? String(registrationData.name)
@@ -92,70 +102,70 @@ export function UserProfileDropdown({ trigger }: UserProfileDropdownProps) {
   );
 
   return (
-    <Popover>
-      <PopoverTrigger asChild>{trigger ?? defaultTrigger}</PopoverTrigger>
-      <PopoverContent side="right" align="end" className="tw-w-64">
-        {/* User info */}
-        <div className="tw-mb-3">
-          <div className="tw-flex tw-items-center tw-gap-2">
-            <CircleUserRound className="tw-h-8 tw-w-8 tw-text-muted-foreground" />
-            <div className="tw-flex-1 tw-min-w-0">
-              <p className="tw-text-sm tw-font-medium tw-truncate">
-                {userName ?? 'Not registered'}
-              </p>
-            </div>
-          </div>
-        </div>
-        <Separator className="tw-mb-2" />
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>{trigger ?? defaultTrigger}</DropdownMenuTrigger>
+      <DropdownMenuContent side={side} align="end" className="tw-w-56">
+        {/* Username headline — shows nothing while loading */}
+        <DropdownMenuLabel className="tw-text-base tw-font-semibold">
+          {isLoadingRegistration ? '\u00A0' : (userName ?? 'Not registered')}
+        </DropdownMenuLabel>
 
-        {/* Mode switch */}
-        <Button
-          variant="ghost"
-          className="tw-w-full tw-justify-start tw-gap-2 tw-h-9"
-          onClick={() => setInterfaceMode(isSimpleMode ? 'power' : 'simple')}
-        >
-          <ArrowRightLeft className="tw-h-4 tw-w-4" />
-          Switch to {isSimpleMode ? 'Power' : 'Simple'} Mode
-        </Button>
-
-        {/* Theme toggle */}
-        <Button
-          variant="ghost"
-          className="tw-w-full tw-justify-start tw-gap-2 tw-h-9"
-          onClick={toggleTheme}
-          disabled={!isThemeLoaded}
-        >
-          {themeType === 'dark' ? (
-            <Sun className="tw-h-4 tw-w-4" />
-          ) : (
-            <Moon className="tw-h-4 tw-w-4" />
-          )}
-          {themeType === 'dark' ? 'Light theme' : 'Dark theme'}
-        </Button>
-
-        <Separator className="tw-my-2" />
-
-        {/* Network settings */}
-        <Button
-          variant="ghost"
-          className="tw-w-full tw-justify-start tw-gap-2 tw-h-9"
-          onClick={() => sendCommand('paratextRegistration.showInternetSettings')}
-        >
-          <Network className="tw-h-4 tw-w-4" />
-          Internet Settings
-        </Button>
-
-        {/* Registration */}
-        <Button
-          variant="ghost"
-          className="tw-w-full tw-justify-start tw-gap-2 tw-h-9"
+        {/* Registration & Internet Settings */}
+        <DropdownMenuItem
           onClick={() => sendCommand('paratextRegistration.showParatextRegistration')}
         >
-          <Monitor className="tw-h-4 tw-w-4" />
+          <Monitor className="tw-h-4 tw-w-4 tw-mr-2" />
           Registration
-        </Button>
-      </PopoverContent>
-    </Popover>
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => sendCommand('paratextRegistration.showInternetSettings')}>
+          <Network className="tw-h-4 tw-w-4 tw-mr-2" />
+          Internet Settings
+        </DropdownMenuItem>
+
+        <DropdownMenuSeparator />
+
+        {/* Mode switch — connected toggle buttons */}
+        <div className="tw-px-2 tw-py-1.5">
+          <p className="tw-text-xs tw-font-medium tw-text-muted-foreground tw-mb-1">
+            Interface Mode
+          </p>
+          <ToggleGroup
+            type="single"
+            value={isSimpleMode ? 'simple' : 'power'}
+            onValueChange={handleModeChange}
+            className="tw-w-full"
+          >
+            <ToggleGroupItem value="simple" className="tw-flex-1 tw-h-8 tw-text-xs">
+              Simple
+            </ToggleGroupItem>
+            <ToggleGroupItem value="power" className="tw-flex-1 tw-h-8 tw-text-xs">
+              Power
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+
+        {/* Theme toggle — connected toggle buttons */}
+        <div className="tw-px-2 tw-py-1.5">
+          <p className="tw-text-xs tw-font-medium tw-text-muted-foreground tw-mb-1">Theme</p>
+          <ToggleGroup
+            type="single"
+            value={themeType}
+            onValueChange={handleThemeChange}
+            className="tw-w-full"
+            disabled={!isThemeLoaded}
+          >
+            <ToggleGroupItem value="light" className="tw-flex-1 tw-h-8 tw-text-xs tw-gap-1">
+              <Sun className="tw-h-3.5 tw-w-3.5" />
+              Light
+            </ToggleGroupItem>
+            <ToggleGroupItem value="dark" className="tw-flex-1 tw-h-8 tw-text-xs tw-gap-1">
+              <Moon className="tw-h-3.5 tw-w-3.5" />
+              Dark
+            </ToggleGroupItem>
+          </ToggleGroup>
+        </div>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -641,7 +641,7 @@ async function loadLayout(layout?: LayoutBase): Promise<void> {
   const dockLayoutVar = await getDockLayout();
   const layoutToLoad = layout || getStorageValue(DOCK_LAYOUT_KEY, dockLayoutVar.testLayout);
 
-  dockLayoutVar.dockLayout.loadLayout(layoutToLoad);
+  dockLayoutVar.loadLayout(layoutToLoad);
   if (layout) {
     // A layout was provided, meaning this is a layout change. Since `dockLayout.loadLayout` doesn't
     // run `onLayoutChange`, we run it manually
@@ -1540,21 +1540,17 @@ export const openWebView = async (
   // Find existing webView if one exists and handle it if it does
   if (optionsDefaulted.existingId) {
     // Expect this to be a tab.
-    // eslint-disable-next-line no-type-assertion/no-type-assertion
-    const existingWebView = (await getDockLayout()).dockLayout.find(
+    const existingWebView = (await getDockLayout()).findTab(
       optionsDefaulted.existingId === '?'
         ? // If they provided '?', that means look for any webview with a matching webViewType
           (item) => {
-            // This is not a webview
-            if (!('data' in item)) return false;
-
-            // Find any webview with the specified webViewType. Type assert the unknown `data`.
+            // Find any webview with the specified webViewType
             // eslint-disable-next-line no-type-assertion/no-type-assertion
-            return (item.data as WebViewDefinition).webViewType === webViewType;
+            return (item.data as WebViewDefinition | undefined)?.webViewType === webViewType;
           }
         : // If they provided any other string, look for a webview with that ID
           optionsDefaulted.existingId,
-    ) as TabInfo | undefined;
+    );
 
     // If we found an existing WebView, handle it and return it
     if (existingWebView) {

--- a/src/shared/models/docking-framework.model.ts
+++ b/src/shared/models/docking-framework.model.ts
@@ -204,8 +204,13 @@ export type OnLayoutChangeRCDock = (
 
 /** Properties related to the dock layout */
 export type PapiDockLayout = {
-  /** The rc-dock dock layout React element ref. Used to perform operations on the layout */
-  dockLayout: DockLayout;
+  /**
+   * The rc-dock dock layout React element ref. Used to perform operations on the layout.
+   *
+   * Only available in Power Mode (rc-dock based layout). Simple Mode does not use rc-dock. Prefer
+   * using the abstracted methods on this type instead of accessing this directly.
+   */
+  dockLayout?: DockLayout;
   /**
    * A ref to a function that runs when the layout changes. We set this ref to our
    * {@link onLayoutChange} function
@@ -335,6 +340,20 @@ export type PapiDockLayout = {
    * @returns `true` if successfully found tab to update, `false` otherwise
    */
   focusTab: (tabId: string) => boolean;
+  /**
+   * Load a layout into the dock layout.
+   *
+   * @param layout The layout to load
+   */
+  loadLayout: (layout: LayoutBase) => void;
+  /**
+   * Find a tab in the layout by its ID or by a predicate function.
+   *
+   * @param idOrFilter The ID of the tab to find, or a function that returns true for the desired
+   *   tab
+   * @returns The tab info if found, or undefined
+   */
+  findTab: (idOrFilter: string | ((item: SavedTabInfo) => boolean)) => TabInfo | undefined;
   /**
    * The layout to use as the default layout if the dockLayout doesn't have a layout loaded.
    *


### PR DESCRIPTION
https://discord.com/channels/892072317436448768/1486302806217461781

<img width="1285" height="936" alt="image" src="https://github.com/user-attachments/assets/e364a8d8-60b6-4519-9a82-86c0e8a80a6c" />

The shadcn Sidebar uses tw-h-svh (100svh) on two inner divs, but in Simple Mode the sidebar is nested below the toolbar so 100svh extends past the container. Override with height: 100% on both divs via the data-collapsible attribute selector so the SidebarFooter (containing the profile dropdown) is visible.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2133)
<!-- Reviewable:end -->
