### PR TITLE
New Simple directly from MagicPatterns

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -2888,8 +2888,14 @@ declare module 'shared/models/docking-framework.model' {
   ) => Promise<void>;
   /** Properties related to the dock layout */
   export type PapiDockLayout = {
-    /** The rc-dock dock layout React element ref. Used to perform operations on the layout */
-    dockLayout: DockLayout;
+    /**
+     * The rc-dock dock layout React element ref. Used to perform operations on the layout.
+     *
+     * @deprecated Use the `find` and `loadLayout` methods on `PapiDockLayout` instead of accessing
+     *   the raw DockLayout. This property will be removed once all call sites are migrated. It may be
+     *   `undefined` in layout implementations that do not use rc-dock (e.g., Simple Mode).
+     */
+    dockLayout: DockLayout | undefined;
     /**
      * A ref to a function that runs when the layout changes. We set this ref to our
      * {@link onLayoutChange} function
@@ -3028,6 +3034,21 @@ declare module 'shared/models/docking-framework.model' {
      * service is currently all shared code. Refactor should happen in #203
      */
     testLayout: LayoutBase;
+    /**
+     * Find a tab by ID or by a predicate function. Replaces direct access to
+     * `dockLayout.dockLayout.find()`.
+     *
+     * @param idOrPredicate A tab ID string, or a predicate function that receives each item in the
+     *   layout and returns `true` for the desired match
+     * @returns The found tab info, or `undefined` if not found
+     */
+    find: (idOrPredicate: string | ((item: unknown) => boolean)) => TabInfo | undefined;
+    /**
+     * Load a layout into the dock. Replaces direct access to `dockLayout.dockLayout.loadLayout()`.
+     *
+     * @param layout The layout to load
+     */
+    loadLayout: (layout: LayoutBase) => void;
   };
 }
 declare module 'shared/services/web-view.service-model' {

--- a/src/renderer/app.component.tsx
+++ b/src/renderer/app.component.tsx
@@ -1,15 +1,25 @@
 import { PlatformDockLayout } from '@renderer/components/docking/platform-dock-layout.component';
+import { SimpleModeLayout } from '@renderer/components/simple-mode/simple-mode-layout.component';
 import { TestContext } from '@renderer/context/papi-context/test.context';
+import useSetting from '@renderer/hooks/papi-hooks/use-setting.hook';
 import { Route, MemoryRouter as Router, Routes } from 'react-router-dom';
 import './app.component.scss';
 import { NotificationDisplay } from './components/notification-display';
 import { PlatformBibleToolbar } from './components/platform-bible-toolbar';
 
 function Main() {
+  const [interfaceMode] = useSetting('platform.interfaceMode', 'simple');
+
   return (
     <TestContext.Provider value="test">
-      <PlatformBibleToolbar />
-      <PlatformDockLayout />
+      {interfaceMode === 'simple' ? (
+        <SimpleModeLayout />
+      ) : (
+        <>
+          <PlatformBibleToolbar />
+          <PlatformDockLayout />
+        </>
+      )}
       <NotificationDisplay />
     </TestContext.Provider>
   );

--- a/src/renderer/components/docking/platform-dock-layout.component.tsx
+++ b/src/renderer/components/docking/platform-dock-layout.component.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect } from 'react';
-import DockLayout from 'rc-dock';
+import DockLayout, { LayoutBase } from 'rc-dock';
 import { Filter } from 'rc-dock/lib/Algorithm';
 
 import {
@@ -99,6 +99,22 @@ export function PlatformDockLayout() {
         getTabInfoById(dockLayoutRef.current, tabId, 'external getTabInfoById'),
       focusTab: (tabId: string) => focusTab(dockLayoutRef.current, tabId),
       testLayout,
+      find: (idOrPredicate: string | ((item: unknown) => boolean)) => {
+        const result = dockLayoutRef.current.find(
+          // rc-dock's find accepts string | ((item) => boolean)
+          // eslint-disable-next-line no-type-assertion/no-type-assertion
+          idOrPredicate as Parameters<DockLayout['find']>[0],
+        );
+        if (result && isTab(result)) {
+          // We know tabs in the dock layout are RCDockTabInfo
+          // eslint-disable-next-line no-type-assertion/no-type-assertion
+          return result as RCDockTabInfo;
+        }
+        return undefined;
+      },
+      loadLayout: (layout: LayoutBase) => {
+        dockLayoutRef.current.loadLayout(layout);
+      },
     });
     return () => {
       unsub();

--- a/src/renderer/components/platform-bible-toolbar.tsx
+++ b/src/renderer/components/platform-bible-toolbar.tsx
@@ -1,21 +1,17 @@
 import logo from '@assets/icon.png';
 import { provideMenuData } from '@renderer/components/platform-bible-menu.data';
 import {
-  useData,
-  useDataProvider,
   useLocalizedStrings,
   useScrollGroupScrRef,
   useRecentScriptureRefs,
 } from '@renderer/hooks/papi-hooks';
 import { app } from '@renderer/services/papi-frontend.service';
 import { availableScrollGroupIds } from '@renderer/services/scroll-group.service-host';
-import { localThemeService } from '@renderer/services/theme.service-host';
 import { handleMenuCommand } from '@shared/data/platform-bible-menu.commands';
 import { sendCommand } from '@shared/services/command.service';
-import { logger } from '@shared/services/logger.service';
 import { ScrollGroupScrRef } from '@shared/services/scroll-group.service-model';
-import { themeServiceDataProviderName } from '@shared/services/theme.service-model';
-import { CircleUserRound, HomeIcon, Moon, Network, Sun } from 'lucide-react';
+import { HomeIcon } from 'lucide-react';
+import { UserProfileDropdown } from '@renderer/components/user-profile-dropdown.component';
 import {
   Badge,
   BookChapterControl,
@@ -30,26 +26,10 @@ import {
   TooltipTrigger,
   usePromise,
 } from 'platform-bible-react';
-import {
-  getErrorMessage,
-  getLocalizeKeysForScrollGroupIds,
-  isPlatformError,
-  LocalizeKey,
-  ScrollGroupId,
-  ThemeDefinitionExpanded,
-} from 'platform-bible-utils';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { getLocalizeKeysForScrollGroupIds, LocalizeKey, ScrollGroupId } from 'platform-bible-utils';
+import { useCallback, useState } from 'react';
 
 const TOOLTIP_DELAY = 300;
-
-/** Placeholder theme to detect when we are loading */
-const DEFAULT_THEME_VALUE: ThemeDefinitionExpanded = {
-  themeFamilyId: '',
-  type: 'light',
-  id: 'light',
-  label: '%unused%',
-  cssVariables: {},
-};
 
 const scrollGroupIdLocalStorageKey = 'platform-bible-toolbar.scrollGroupId';
 
@@ -60,15 +40,7 @@ const availableScrollGroupIdsTop = availableScrollGroupIds.filter(
 
 const scrollGroupLocalizedStringKeys = getLocalizeKeysForScrollGroupIds(availableScrollGroupIdsTop);
 
-const LOCALIZED_STRING_KEYS: LocalizeKey[] = [
-  '%mainMenu_openParatextRegistration%',
-  '%mainMenu_openInternetSettings%',
-  '%mainMenu_openHome%',
-  '%toolbar_theme_change_to_light%',
-  '%toolbar_theme_change_to_dark%',
-  '%toolbar_theme_loading%',
-  '%toolbar_theme_loading_error%',
-];
+const LOCALIZED_STRING_KEYS: LocalizeKey[] = ['%mainMenu_openHome%'];
 
 export function PlatformBibleToolbar() {
   // Internal state tracker for scroll group in local storage
@@ -145,35 +117,6 @@ export function PlatformBibleToolbar() {
     'Marketing Version',
   );
 
-  const themeDataProvider = useDataProvider(themeServiceDataProviderName);
-
-  /** Get the theme on first load so we can show the right symbol on the toolbar */
-  const themeOnFirstLoad = useMemo(() => localThemeService.getCurrentThemeSync(), []);
-
-  const [theme, setTheme] = useData<typeof themeServiceDataProviderName>(
-    themeDataProvider,
-  ).CurrentTheme(undefined, DEFAULT_THEME_VALUE);
-
-  // Warn if the theme came back as a PlatformError. Will handle the PlatformError in the jsx too
-  useEffect(() => {
-    if (isPlatformError(theme))
-      logger.warn(`Error getting theme for toolbar button. ${getErrorMessage(theme)}`);
-  }, [theme]);
-
-  const isThemeLoadedNotError = theme !== DEFAULT_THEME_VALUE && !isPlatformError(theme);
-
-  let themeButtonTooltip = localizedStrings['%toolbar_theme_loading%'];
-  if (!isThemeLoadedNotError)
-    themeButtonTooltip = localizedStrings['%tooltip_theme_loading_error%'];
-  else if (theme.type === 'dark') {
-    themeButtonTooltip = localizedStrings['%toolbar_theme_change_to_light%'];
-  } else {
-    themeButtonTooltip = localizedStrings['%toolbar_theme_change_to_dark%'];
-  }
-
-  // Get the theme type from the first theme load or the current theme data, whichever is available
-  const themeTypeEffective = isThemeLoadedNotError ? theme.type : themeOnFirstLoad.type;
-
   return (
     <Toolbar
       menuData={menuData}
@@ -207,78 +150,7 @@ export function PlatformBibleToolbar() {
               </Tooltip>
             </TooltipProvider>
           )}
-          <TooltipProvider delayDuration={TOOLTIP_DELAY}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="pr-twp tw-h-8 tw-flex-shrink-0"
-                  onClick={() => {
-                    if (!isThemeLoadedNotError) return;
-
-                    const newThemeType = theme.type === 'dark' ? 'light' : 'dark';
-                    try {
-                      setTheme?.({ type: newThemeType });
-                    } catch (e) {
-                      logger.warn(
-                        `Toolbar caught an error while trying to set theme to ${newThemeType}: ${getErrorMessage(e)}`,
-                      );
-                    }
-                  }}
-                  disabled={!isThemeLoadedNotError}
-                >
-                  {themeTypeEffective === 'dark' ? <Moon /> : <Sun />}
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>
-                <p className="tw-font-light">{themeButtonTooltip}</p>
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          {/* This is a placeholder for the actual user menu */}
-          <TooltipProvider delayDuration={TOOLTIP_DELAY}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="pr-twp tw-h-8 tw-flex-shrink-0"
-                  onClick={() => sendCommand('paratextRegistration.showInternetSettings')}
-                >
-                  <Network />
-                </Button>
-              </TooltipTrigger>
-              {localizedStrings['%mainMenu_openInternetSettings%'] && (
-                <TooltipContent>
-                  <p className="tw-font-light">
-                    {localizedStrings['%mainMenu_openInternetSettings%']}
-                  </p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-          <TooltipProvider delayDuration={TOOLTIP_DELAY}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="pr-twp tw-h-8 tw-flex-shrink-0"
-                  onClick={() => sendCommand('paratextRegistration.showParatextRegistration')}
-                >
-                  <CircleUserRound />
-                </Button>
-              </TooltipTrigger>
-              {localizedStrings['%mainMenu_openParatextRegistration%'] && (
-                <TooltipContent>
-                  <p className="tw-font-light">
-                    {localizedStrings['%mainMenu_openParatextRegistration%']}
-                  </p>
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
+          <UserProfileDropdown context="toolbar" />
         </>
       }
     >

--- a/src/renderer/components/simple-mode/extra-panel.component.tsx
+++ b/src/renderer/components/simple-mode/extra-panel.component.tsx
@@ -1,0 +1,64 @@
+/**
+ * Extra panel for Simple Mode — the optional 4th panel (leftmost when present). Has an ellipsis
+ * menu for choosing which tabs appear in this panel.
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import { WebViewDefinition } from '@shared/models/web-view.model';
+import type { TabItem } from './tab-config';
+import { ResourcesPanel } from './resources-panel.component';
+import { TabChooserDropdown } from './tab-chooser-dropdown.component';
+
+interface ExtraPanelProps {
+  tabArrangement: TabItem[];
+  onTabArrangementChange: (tabs: TabItem[]) => void;
+  webViewDefs?: Map<string, WebViewDefinition>;
+}
+
+export function ExtraPanel({
+  tabArrangement,
+  onTabArrangementChange,
+  webViewDefs,
+}: ExtraPanelProps) {
+  const [chooserOpen, setChooserOpen] = useState(false);
+
+  const extraTabs = useMemo(
+    () => tabArrangement.filter((t) => t.panel === 'extra'),
+    [tabArrangement],
+  );
+
+  const handleToggleExtraTab = useCallback(
+    (tabId: string) => {
+      const newArrangement = tabArrangement.map((tab) => {
+        if (tab.id !== tabId) return tab;
+        // Toggle between extra and its default panel (resources or tools)
+        return {
+          ...tab,
+          panel:
+            tab.panel === 'extra'
+              ? ((tab.group === 'scripture' ? 'resources' : 'tools') as TabItem['panel'])
+              : 'extra',
+        };
+      });
+      onTabArrangementChange(newArrangement);
+    },
+    [tabArrangement, onTabArrangementChange],
+  );
+
+  return (
+    <div className="tw-h-full tw-flex tw-flex-col tw-relative">
+      {/* Ellipsis button for tab chooser */}
+      <div className="tw-absolute tw-top-1 tw-right-1 tw-z-10">
+        <TabChooserDropdown
+          open={chooserOpen}
+          onOpenChange={setChooserOpen}
+          tabArrangement={tabArrangement}
+          onToggleExtraTab={handleToggleExtraTab}
+        />
+      </div>
+
+      {/* Tab bar and content */}
+      <ResourcesPanel tabs={extraTabs} panelRole="extra" webViewDefs={webViewDefs} />
+    </div>
+  );
+}

--- a/src/renderer/components/simple-mode/no-panels-placeholder.component.tsx
+++ b/src/renderer/components/simple-mode/no-panels-placeholder.component.tsx
@@ -1,0 +1,43 @@
+/** Shown when all panels are hidden in Simple Mode. Encourages the user to show a panel. */
+
+import type { PanelVisibility } from './simple-mode-layout.component';
+
+interface NoPanelsPlaceholderProps {
+  visibility: PanelVisibility;
+  onChange: (v: PanelVisibility) => void;
+}
+
+const PANEL_CARDS: { key: keyof PanelVisibility; label: string }[] = [
+  { key: 'reference', label: 'Reference' },
+  { key: 'editor', label: 'Editor' },
+  { key: 'resources', label: 'Resources & Tools' },
+];
+
+export function NoPanelsPlaceholder({ visibility, onChange }: NoPanelsPlaceholderProps) {
+  const togglePanel = (panel: keyof PanelVisibility) => {
+    onChange({ ...visibility, [panel]: true });
+  };
+
+  return (
+    <div className="tw-flex-1 tw-flex tw-flex-col tw-items-center tw-justify-center tw-gap-6 tw-bg-background">
+      <p className="tw-text-xs tw-text-muted-foreground tw-uppercase tw-tracking-widest tw-font-semibold">
+        Select a panel to display
+      </p>
+      <div className="tw-flex tw-items-end tw-gap-3">
+        {PANEL_CARDS.map((card) => (
+          <button
+            key={card.key}
+            type="button"
+            onClick={() => togglePanel(card.key)}
+            className="tw-flex tw-flex-col tw-items-center tw-gap-2 tw-group tw-cursor-pointer"
+          >
+            <div className="tw-w-16 tw-h-24 tw-rounded-md tw-border-2 tw-transition-all tw-flex tw-items-center tw-justify-center tw-border-border group-hover:tw-border-foreground/40 group-hover:tw-bg-muted" />
+            <span className="tw-text-[11px] tw-font-medium tw-transition-colors tw-text-muted-foreground group-hover:tw-text-foreground">
+              {card.label}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/simple-mode/panel-toggle-buttons.component.tsx
+++ b/src/renderer/components/simple-mode/panel-toggle-buttons.component.tsx
@@ -1,0 +1,231 @@
+/** Panel toggle buttons for Simple Mode toolbar. Includes +/- buttons for extra panel management. */
+
+import { useState, useRef, useEffect, useCallback } from 'react';
+import {
+  Button,
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from 'platform-bible-react';
+import type { PanelVisibility } from './simple-mode-layout.component';
+import type { TabItem } from './tab-config';
+import { getDefaultTabs } from './tab-config';
+import { TAB_GROUPS, type TabGroupId } from './tab-registry';
+
+const TOOLTIP_DELAY = 300;
+
+interface PanelToggleButtonsProps {
+  visibility: PanelVisibility;
+  onChange: (v: PanelVisibility) => void;
+  tabArrangement: TabItem[];
+  onTabArrangementChange: (tabs: TabItem[]) => void;
+}
+
+export function PanelToggleButtons({
+  visibility,
+  onChange,
+  tabArrangement,
+  onTabArrangementChange,
+}: PanelToggleButtonsProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedTabs, setSelectedTabs] = useState<Set<string>>(new Set());
+
+  const extraPanelExists = tabArrangement.some((t) => t.panel === 'extra');
+
+  const togglePanel = useCallback(
+    (panel: keyof PanelVisibility) => {
+      onChange({ ...visibility, [panel]: !visibility[panel] });
+    },
+    [visibility, onChange],
+  );
+
+  const handleCreateExtraPanel = useCallback(() => {
+    if (selectedTabs.size === 0) return;
+
+    const newArrangement = tabArrangement.map((tab) =>
+      selectedTabs.has(tab.id) ? { ...tab, panel: 'extra' as const } : tab,
+    );
+    onTabArrangementChange(newArrangement);
+    onChange({ ...visibility, extra: true });
+    setDialogOpen(false);
+    setSelectedTabs(new Set());
+  }, [selectedTabs, tabArrangement, onTabArrangementChange, onChange, visibility]);
+
+  const handleRemoveExtraPanel = useCallback(() => {
+    const defaults = getDefaultTabs();
+    const defaultMap = new Map(defaults.map((t) => [t.id, { panel: t.panel, visible: t.visible }]));
+
+    const newArrangement = tabArrangement.map((tab) => {
+      if (tab.panel !== 'extra') return tab;
+      const defaultInfo = defaultMap.get(tab.id);
+      if (defaultInfo) return { ...tab, panel: defaultInfo.panel };
+      return { ...tab, panel: 'tools' as const, visible: false };
+    });
+
+    onTabArrangementChange(newArrangement);
+    onChange({ ...visibility, extra: false });
+  }, [tabArrangement, onTabArrangementChange, onChange, visibility]);
+
+  const toggleTabSelection = useCallback((tabId: string) => {
+    setSelectedTabs((prev) => {
+      const next = new Set(prev);
+      if (next.has(tabId)) next.delete(tabId);
+      else next.add(tabId);
+      return next;
+    });
+  }, []);
+
+  // Build selectable tabs for the dialog, grouped by category
+  const selectableTabs = tabArrangement.filter(
+    (t) => t.visible && t.id !== 'reference', // reference stays in resources panel in Variant A
+  );
+  const scriptureGroupIds = new Set(TAB_GROUPS.scripture.tabIds);
+
+  const resourceTabs = selectableTabs.filter(
+    (t) => scriptureGroupIds.has(t.id) && t.id !== 'reference',
+  );
+  const toolTabs = selectableTabs.filter((t) => !scriptureGroupIds.has(t.id));
+
+  const baseButtons: { key: keyof PanelVisibility; tooltip: string }[] = [
+    { key: 'reference', tooltip: 'Reference' },
+    { key: 'editor', tooltip: 'Editor' },
+    { key: 'resources', tooltip: 'Resources & Tools' },
+  ];
+
+  const buttons =
+    extraPanelExists || visibility.extra
+      ? [{ key: 'extra' as keyof PanelVisibility, tooltip: 'Extra Panel' }, ...baseButtons]
+      : baseButtons;
+
+  return (
+    <div className="tw-flex tw-items-center tw-gap-0.5 tw-h-7">
+      {/* Plus button — add extra panel */}
+      {!extraPanelExists && !visibility.extra && (
+        <Popover open={dialogOpen} onOpenChange={setDialogOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="tw-h-full tw-w-4 tw-rounded-sm tw-transition-colors tw-cursor-pointer tw-bg-transparent tw-border tw-border-dashed tw-border-border hover:tw-border-foreground/50 tw-flex tw-items-center tw-justify-center tw-text-muted-foreground hover:tw-text-foreground tw-mr-1"
+              title="Add extra panel"
+            >
+              <span className="tw-text-[10px] tw-font-bold tw-leading-none">+</span>
+            </button>
+          </PopoverTrigger>
+          <PopoverContent className="tw-w-64 tw-p-0" align="start">
+            <div className="tw-p-3 tw-border-b tw-border-border tw-bg-muted">
+              <h3 className="tw-text-xs tw-font-bold">Add extra panel</h3>
+              <p className="tw-text-[10px] tw-text-muted-foreground tw-mt-0.5">
+                Select tabs to move to new panel
+              </p>
+            </div>
+
+            <div className="tw-max-h-64 tw-overflow-y-auto tw-p-2">
+              {resourceTabs.length > 0 && (
+                <TabGroup
+                  label="Resources"
+                  tabs={resourceTabs}
+                  selectedTabs={selectedTabs}
+                  onToggle={toggleTabSelection}
+                />
+              )}
+              {toolTabs.length > 0 && (
+                <TabGroup
+                  label="Tools"
+                  tabs={toolTabs}
+                  selectedTabs={selectedTabs}
+                  onToggle={toggleTabSelection}
+                />
+              )}
+            </div>
+
+            <div className="tw-p-2 tw-border-t tw-border-border tw-bg-muted">
+              <Button
+                onClick={handleCreateExtraPanel}
+                disabled={selectedTabs.size === 0}
+                size="sm"
+                className="tw-w-full tw-text-xs"
+              >
+                Move selected tabs to extra panel
+              </Button>
+            </div>
+          </PopoverContent>
+        </Popover>
+      )}
+
+      {/* Minus button — remove extra panel */}
+      {(extraPanelExists || visibility.extra) && (
+        <button
+          type="button"
+          onClick={handleRemoveExtraPanel}
+          className="tw-h-full tw-w-4 tw-rounded-sm tw-transition-colors tw-cursor-pointer tw-bg-transparent tw-border tw-border-dashed tw-border-border hover:tw-border-foreground/50 tw-flex tw-items-center tw-justify-center tw-text-muted-foreground hover:tw-text-foreground tw-mr-1"
+          title="Restore 3 panel layout"
+        >
+          <span className="tw-text-[10px] tw-font-bold tw-leading-none">-</span>
+        </button>
+      )}
+
+      {/* Panel toggle buttons */}
+      {buttons.map((btn) => {
+        const isActive = visibility[btn.key];
+        return (
+          <TooltipProvider key={btn.key} delayDuration={TOOLTIP_DELAY}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <button
+                  type="button"
+                  onClick={() => togglePanel(btn.key)}
+                  className={`tw-h-full tw-w-4 tw-rounded-sm tw-transition-colors tw-cursor-pointer ${isActive ? 'tw-bg-primary/20 tw-border tw-border-primary/50' : 'tw-bg-transparent tw-border tw-border-border hover:tw-border-foreground/50'}`}
+                  aria-label={`${isActive ? 'Hide' : 'Show'} ${btn.tooltip}`}
+                />
+              </TooltipTrigger>
+              <TooltipContent>
+                <p className="tw-font-light">
+                  {isActive ? 'Hide' : 'Show'} {btn.tooltip}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        );
+      })}
+    </div>
+  );
+}
+
+/** A group of checkboxes for tabs in the extra panel dialog. */
+function TabGroup({
+  label,
+  tabs,
+  selectedTabs,
+  onToggle,
+}: {
+  label: string;
+  tabs: TabItem[];
+  selectedTabs: Set<string>;
+  onToggle: (tabId: string) => void;
+}) {
+  return (
+    <div className="tw-mb-3">
+      <div className="tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-widest tw-text-muted-foreground tw-px-2 tw-mb-1">
+        {label}
+      </div>
+      {tabs.map((tab) => (
+        <label
+          key={tab.id}
+          className="tw-flex tw-items-center tw-gap-2 tw-px-2 tw-py-1.5 tw-rounded hover:tw-bg-muted tw-cursor-pointer"
+        >
+          <input
+            type="checkbox"
+            checked={selectedTabs.has(tab.id)}
+            onChange={() => onToggle(tab.id)}
+            className="tw-rounded tw-border-border"
+          />
+          <span className="tw-text-xs">{tab.label}</span>
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/components/simple-mode/placeholder-tab.component.tsx
+++ b/src/renderer/components/simple-mode/placeholder-tab.component.tsx
@@ -1,0 +1,58 @@
+/** Generic placeholder for unimplemented Simple Mode tabs. Shows tab name, icon, and "Coming soon". */
+
+import { getTabDef, type TabId } from './tab-registry';
+
+// Custom icon renderers for tabs without Lucide icons
+function AlephIcon({ className }: { className?: string }) {
+  return (
+    <span className={`tw-font-serif tw-text-lg tw-leading-none ${className ?? ''}`}>&#x05D0;</span>
+  );
+}
+
+function TriquetraIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      width="24"
+      height="24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+    >
+      <circle cx="12" cy="8" r="6" />
+      <circle cx="7" cy="16" r="6" />
+      <circle cx="17" cy="16" r="6" />
+    </svg>
+  );
+}
+
+interface PlaceholderTabProps {
+  tabId: string;
+}
+
+export function PlaceholderTab({ tabId }: PlaceholderTabProps) {
+  const tabDef = getTabDef(tabId);
+  const label = tabDef?.labelKey ?? tabId;
+
+  const renderIcon = () => {
+    if (tabDef?.customIcon === 'aleph') return <AlephIcon className="tw-text-muted-foreground" />;
+    if (tabDef?.customIcon === 'triquetra')
+      return <TriquetraIcon className="tw-w-8 tw-h-8 tw-text-muted-foreground" />;
+    if (tabDef?.icon) {
+      const Icon = tabDef.icon;
+      return <Icon className="tw-w-8 tw-h-8 tw-text-muted-foreground" />;
+    }
+    return undefined;
+  };
+
+  return (
+    <div className="tw-flex tw-flex-col tw-items-center tw-justify-center tw-h-full tw-gap-3 tw-bg-background">
+      {renderIcon()}
+      <div className="tw-text-sm tw-font-medium tw-text-muted-foreground">{label}</div>
+      <div className="tw-text-xs tw-text-muted-foreground/60">Coming soon</div>
+    </div>
+  );
+}
+
+export { AlephIcon, TriquetraIcon };

--- a/src/renderer/components/simple-mode/resources-panel.component.tsx
+++ b/src/renderer/components/simple-mode/resources-panel.component.tsx
@@ -1,0 +1,149 @@
+/**
+ * Resources/Tools panel for Simple Mode. Renders a grouped icon tab bar and content area. Content
+ * is either a real webview (display:none for inactive to preserve iframe state) or a placeholder.
+ */
+
+import { useState, useCallback, useMemo } from 'react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'platform-bible-react';
+import { WebViewDefinition } from '@shared/models/web-view.model';
+import { WebView } from '@renderer/components/web-view.component';
+import type { TabItem } from './tab-config';
+import { getTabDef, computeGroupDividerIndices } from './tab-registry';
+import { PlaceholderTab, AlephIcon, TriquetraIcon } from './placeholder-tab.component';
+
+const TOOLTIP_DELAY = 200;
+
+/** Tab-to-webview-type mapping for tabs that have real implementations. */
+const TAB_WEBVIEW_TYPES: Record<string, string> = {
+  reference: 'platformScriptureEditor.react',
+  bible: 'platformScriptureEditor.react',
+  source: 'platformScriptureEditor.react',
+  comments: 'legacyCommentManager.commentList',
+  search: 'platformScripture.find',
+  dictionary: 'platformLexicalTools.dictionary',
+};
+
+interface ResourcesPanelProps {
+  tabs: TabItem[];
+  panelRole: 'resources' | 'extra';
+  /** All webview definitions from the layout — used to render real webviews. */
+  webViewDefs?: Map<string, WebViewDefinition>;
+}
+
+export function ResourcesPanel({ tabs, panelRole, webViewDefs }: ResourcesPanelProps) {
+  const visibleTabs = useMemo(() => tabs.filter((t) => t.visible), [tabs]);
+  const [activeTabId, setActiveTabId] = useState<string>(() => visibleTabs[0]?.id ?? '');
+
+  const effectiveActiveTabId = useMemo(() => {
+    if (visibleTabs.some((t) => t.id === activeTabId)) return activeTabId;
+    return visibleTabs[0]?.id ?? '';
+  }, [activeTabId, visibleTabs]);
+
+  const tabIds = useMemo(() => visibleTabs.map((t) => t.id), [visibleTabs]);
+  const dividerIndices = useMemo(() => computeGroupDividerIndices(tabIds), [tabIds]);
+
+  const handleTabClick = useCallback((tabId: string) => {
+    setActiveTabId(tabId);
+  }, []);
+
+  if (visibleTabs.length === 0) {
+    return (
+      <div className="tw-h-full tw-flex tw-items-center tw-justify-center tw-text-xs tw-text-muted-foreground">
+        No tabs
+      </div>
+    );
+  }
+
+  const showTabBar = visibleTabs.length > 1;
+
+  return (
+    <div className="tw-h-full tw-flex tw-flex-col tw-overflow-hidden">
+      {showTabBar && (
+        <div className="tw-flex tw-items-center tw-h-8 tw-px-1 tw-gap-0.5 tw-border-b tw-border-border tw-bg-muted/50 tw-flex-shrink-0">
+          {visibleTabs.map((tab, index) => {
+            const isActive = tab.id === effectiveActiveTabId;
+            const tabDef = getTabDef(tab.id);
+            const showDivider = dividerIndices.has(index);
+
+            return (
+              <div key={tab.id} className="tw-flex tw-items-center">
+                <TooltipProvider delayDuration={TOOLTIP_DELAY}>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <button
+                        type="button"
+                        onClick={() => handleTabClick(tab.id)}
+                        className={`tw-flex tw-items-center tw-justify-center tw-w-7 tw-h-7 tw-rounded-md tw-transition-colors ${isActive ? 'tw-bg-primary/15 tw-text-primary' : 'tw-text-muted-foreground hover:tw-bg-muted hover:tw-text-foreground tw-cursor-pointer'}`}
+                        aria-label={tab.label}
+                      >
+                        <TabIcon tabDef={tabDef} size={16} />
+                      </button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p className="tw-font-light">{tab.label}</p>
+                    </TooltipContent>
+                  </Tooltip>
+                </TooltipProvider>
+                {showDivider && <div className="tw-w-px tw-h-4 tw-bg-border tw-mx-0.5" />}
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Content area — all tabs rendered, inactive hidden with display:none */}
+      <div className="tw-flex-1 tw-overflow-hidden tw-relative">
+        {visibleTabs.map((tab) => {
+          const isActive = tab.id === effectiveActiveTabId;
+          const hasWebViewType = tab.id in TAB_WEBVIEW_TYPES;
+
+          // Find a matching webview definition if one exists
+          let matchingDef: WebViewDefinition | undefined;
+          if (hasWebViewType && webViewDefs) {
+            const targetType = TAB_WEBVIEW_TYPES[tab.id];
+            for (const [, def] of webViewDefs) {
+              if (def.webViewType === targetType) {
+                matchingDef = def;
+                break;
+              }
+            }
+          }
+
+          return (
+            <div
+              key={tab.id}
+              style={{ display: isActive ? 'flex' : 'none' }}
+              className="tw-h-full tw-w-full tw-flex-col"
+            >
+              {matchingDef ? (
+                <WebView {...matchingDef} shouldShowToolbar={false} />
+              ) : hasWebViewType ? (
+                <div className="tw-flex-1 tw-flex tw-items-center tw-justify-center tw-text-xs tw-text-muted-foreground tw-bg-background">
+                  Loading {tab.label}...
+                </div>
+              ) : (
+                <PlaceholderTab tabId={tab.id} />
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function TabIcon({ tabDef, size }: { tabDef: ReturnType<typeof getTabDef>; size: number }) {
+  if (!tabDef) return <span>?</span>;
+
+  if (tabDef.customIcon === 'aleph') {
+    return <AlephIcon className="tw-text-[14px]" />;
+  }
+  if (tabDef.customIcon === 'triquetra') {
+    return <TriquetraIcon className={`tw-w-[${size}px] tw-h-[${size}px]`} />;
+  }
+  if (tabDef.icon) {
+    const Icon = tabDef.icon;
+    return <Icon style={{ width: size, height: size }} />;
+  }
+  return <span>?</span>;
+}

--- a/src/renderer/components/simple-mode/sidebar.component.tsx
+++ b/src/renderer/components/simple-mode/sidebar.component.tsx
@@ -1,0 +1,70 @@
+/** Simple Mode sidebar — shows Study & Draft workflow indicator, Help, and User Profile trigger. */
+
+import { PenLine, HelpCircle, CircleUser } from 'lucide-react';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'platform-bible-react';
+
+const TOOLTIP_DELAY = 300;
+
+interface SidebarProps {
+  onUserProfileClick: () => void;
+}
+
+export function Sidebar({ onUserProfileClick }: SidebarProps) {
+  return (
+    <div className="simple-mode-sidebar">
+      {/* Study & Draft — active workflow */}
+      <TooltipProvider delayDuration={TOOLTIP_DELAY}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="simple-mode-sidebar-btn simple-mode-sidebar-btn-active"
+              aria-label="Study & Draft"
+            >
+              <PenLine className="tw-w-5 tw-h-5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p className="tw-font-light">Study &amp; Draft</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+
+      {/* Spacer */}
+      <div className="tw-flex-1" />
+
+      {/* Help */}
+      <TooltipProvider delayDuration={TOOLTIP_DELAY}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button type="button" className="simple-mode-sidebar-btn" aria-label="Help">
+              <HelpCircle className="tw-w-5 tw-h-5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p className="tw-font-light">Help</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+
+      {/* User Profile */}
+      <TooltipProvider delayDuration={TOOLTIP_DELAY}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              className="simple-mode-sidebar-btn"
+              onClick={onUserProfileClick}
+              aria-label="User Profile"
+            >
+              <CircleUser className="tw-w-5 tw-h-5" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right">
+            <p className="tw-font-light">User Profile</p>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </div>
+  );
+}

--- a/src/renderer/components/simple-mode/simple-mode-layout.component.scss
+++ b/src/renderer/components/simple-mode/simple-mode-layout.component.scss
@@ -1,0 +1,137 @@
+.simple-mode-layout {
+  display: flex;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+
+.simple-mode-sidebar {
+  width: 48px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--sidebar-bg, #f5f4f1);
+  border-right: 1px solid var(--border-color, #e5e3de);
+  padding: 8px 0;
+  gap: 4px;
+}
+
+.simple-mode-sidebar-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary, #78716c);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: background-color 0.15s, color 0.15s;
+
+  &:hover {
+    background: var(--hover-bg, rgba(0, 0, 0, 0.06));
+    color: var(--text-primary, #44403c);
+  }
+}
+
+.simple-mode-sidebar-btn-active {
+  background: var(--accent-color, #c4956a);
+  color: white;
+
+  &:hover {
+    background: var(--accent-color-hover, #b5845c);
+    color: white;
+  }
+}
+
+.simple-mode-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.simple-mode-toolbar {
+  height: 40px;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border-color, #e5e3de);
+  background: var(--toolbar-bg, #faf9f6);
+  -webkit-app-region: drag;
+
+  /* All interactive children must opt out of drag */
+  > * {
+    -webkit-app-region: no-drag;
+  }
+}
+
+.simple-mode-toolbar-brand {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.simple-mode-toolbar-title {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.simple-mode-panels {
+  flex: 1;
+  overflow: hidden;
+}
+
+.simple-mode-panel {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.simple-mode-panel-placeholder {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  color: var(--text-secondary, #78716c);
+  background: var(--panel-bg, #fff);
+}
+
+.simple-mode-no-panels {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 16px;
+  background: var(--panel-bg, #faf9f6);
+
+  p {
+    font-size: 12px;
+    color: var(--text-secondary, #78716c);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-weight: 600;
+  }
+
+  button {
+    padding: 8px 16px;
+    font-size: 12px;
+    border: 1px solid var(--border-color, #e5e3de);
+    border-radius: 6px;
+    background: white;
+    cursor: pointer;
+
+    &:hover {
+      background: var(--hover-bg, #f5f4f1);
+    }
+  }
+}

--- a/src/renderer/components/simple-mode/simple-mode-layout.component.tsx
+++ b/src/renderer/components/simple-mode/simple-mode-layout.component.tsx
@@ -1,0 +1,343 @@
+import { useState, useMemo, useEffect, useRef, useCallback } from 'react';
+import { LayoutBase } from 'rc-dock';
+import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from 'platform-bible-react';
+import { WebViewDefinition, WebViewDefinitionUpdateInfo } from '@shared/models/web-view.model';
+import {
+  SavedTabInfo,
+  Layout,
+  OnLayoutChangeRCDock,
+  WebViewTabProps,
+  TabInfo,
+  DirectionFromTab,
+} from '@shared/models/docking-framework.model';
+import { PapiDockLayout } from '@shared/models/docking-framework.model';
+import { registerDockLayout, openWebView } from '@renderer/services/web-view.service-host';
+import { WebView, loadWebViewTab, TAB_TYPE_WEBVIEW } from '@renderer/components/web-view.component';
+import { logger } from '@shared/services/logger.service';
+import { Sidebar } from './sidebar.component';
+import { SimpleModeToolbar } from './simple-mode-toolbar.component';
+import { DEFAULT_VIEW_OPTIONS, type ViewOptions } from './view-options-dropdown.component';
+import { getDefaultTabs, type TabItem } from './tab-config';
+import { ResourcesPanel } from './resources-panel.component';
+import { ExtraPanel } from './extra-panel.component';
+import { NoPanelsPlaceholder } from './no-panels-placeholder.component';
+import './simple-mode-layout.component.scss';
+
+/** Panel visibility state for Simple Mode */
+export interface PanelVisibility {
+  reference: boolean;
+  editor: boolean;
+  resources: boolean;
+  extra?: boolean;
+}
+
+const DEFAULT_PANEL_VISIBILITY: PanelVisibility = {
+  reference: true,
+  editor: true,
+  resources: true,
+  extra: false,
+};
+
+/** Minimal empty layout for the testLayout property */
+const EMPTY_LAYOUT: LayoutBase = {
+  dockbox: { mode: 'horizontal', children: [] },
+};
+
+export function SimpleModeLayout() {
+  const [panelVisibility, setPanelVisibility] = useState<PanelVisibility>(DEFAULT_PANEL_VISIBILITY);
+  const [tabArrangement, setTabArrangement] = useState<TabItem[]>(() => getDefaultTabs());
+  const [viewOptions, setViewOptions] = useState<ViewOptions>(DEFAULT_VIEW_OPTIONS);
+
+  // WebView definitions stored by ID — populated when openWebView calls addWebViewToDock
+  const [webViewDefs, setWebViewDefs] = useState<Map<string, WebViewDefinition>>(new Map());
+
+  // Track which webview IDs are assigned to which fixed panel slots
+  const [referencePanelWebViewId, setReferencePanelWebViewId] = useState<string | undefined>();
+  const [editorPanelWebViewId, setEditorPanelWebViewId] = useState<string | undefined>();
+
+  // Ref for onLayoutChange callback from web-view.service-host
+  const onLayoutChangeRef = useRef<OnLayoutChangeRCDock | undefined>();
+
+  // Track whether we've opened the initial webviews
+  const hasOpenedInitialWebViews = useRef(false);
+
+  // ─── PapiDockLayout implementation ──────────────────────────────────────────
+
+  const addWebViewToDock = useCallback(
+    (webView: WebViewTabProps, layout: Layout, _shouldBringToFront?: boolean) => {
+      // Store the WebViewDefinition
+      setWebViewDefs((prev) => {
+        const next = new Map(prev);
+        next.set(webView.id, webView);
+        return next;
+      });
+
+      // Return the layout to indicate a new tab was added (not an update)
+      return layout;
+    },
+    [],
+  );
+
+  const addTabToDock = useCallback(
+    (savedTabInfo: SavedTabInfo, layout: Layout, _shouldBringToFront?: boolean) => {
+      if (savedTabInfo.tabType === TAB_TYPE_WEBVIEW && savedTabInfo.data) {
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        const webViewDef = savedTabInfo.data as WebViewDefinition;
+        setWebViewDefs((prev) => {
+          const next = new Map(prev);
+          next.set(webViewDef.id, webViewDef);
+          return next;
+        });
+      }
+      return layout;
+    },
+    [],
+  );
+
+  const removeTabFromDock = useCallback(
+    (tabId: string) => {
+      const had = webViewDefs.has(tabId);
+      if (had) {
+        setWebViewDefs((prev) => {
+          const next = new Map(prev);
+          next.delete(tabId);
+          return next;
+        });
+      }
+      return had;
+    },
+    [webViewDefs],
+  );
+
+  const getWebViewDefinition = useCallback(
+    (webViewId: string) => webViewDefs.get(webViewId),
+    [webViewDefs],
+  );
+
+  const getTabInfoById = useCallback(
+    (tabId: string): TabInfo | undefined => {
+      const def = webViewDefs.get(tabId);
+      if (!def) return undefined;
+      return loadWebViewTab({ id: tabId, tabType: TAB_TYPE_WEBVIEW, data: def });
+    },
+    [webViewDefs],
+  );
+
+  const focusTab = useCallback((tabId: string) => {
+    // Try to focus the iframe for this webview
+    const iframe = document.querySelector(
+      `[data-web-view-id="${tabId}"]`,
+    ) as HTMLIFrameElement | null;
+    if (iframe) {
+      iframe.focus();
+      return true;
+    }
+    return false;
+  }, []);
+
+  const updateWebViewDefinition = useCallback(
+    (webViewId: string, updateInfo: WebViewDefinitionUpdateInfo, _shouldBringToFront?: boolean) => {
+      const existing = webViewDefs.get(webViewId);
+      if (!existing) return false;
+      setWebViewDefs((prev) => {
+        const next = new Map(prev);
+        next.set(webViewId, { ...existing, ...updateInfo });
+        return next;
+      });
+      return true;
+    },
+    [webViewDefs],
+  );
+
+  const updateTabPartial = useCallback(
+    (tabId: string, partialTabInfo: Partial<TabInfo>, _shouldBringToFront?: boolean) => {
+      const info = getTabInfoById(tabId);
+      if (!info) return undefined;
+      return { ...info, ...partialTabInfo };
+    },
+    [getTabInfoById],
+  );
+
+  const find = useCallback(
+    (idOrPredicate: string | ((item: unknown) => boolean)) => {
+      if (typeof idOrPredicate === 'string') {
+        return getTabInfoById(idOrPredicate);
+      }
+      // Predicate search across all webview defs
+      for (const [id, def] of webViewDefs) {
+        const tabInfo = loadWebViewTab({ id, tabType: TAB_TYPE_WEBVIEW, data: def });
+        if (idOrPredicate(tabInfo)) return tabInfo;
+      }
+      return undefined;
+    },
+    [webViewDefs, getTabInfoById],
+  );
+
+  // ─── Register dock layout ──────────────────────────────────────────────────
+
+  useEffect(() => {
+    const papiDockLayout: PapiDockLayout = {
+      dockLayout: undefined,
+      onLayoutChangeRef,
+      addTabToDock,
+      addWebViewToDock,
+      removeTabFromDock,
+      floatTabById: () => {
+        // No-op: floating not supported in Simple Mode
+      },
+      getWebViewDefinition,
+      updateTabPartial,
+      updateWebViewDefinition,
+      getTabInfoByDirectionFromTab: (_sourceTabId: string, _direction: DirectionFromTab) => {
+        // Simple direction navigation — could be enhanced later
+        return undefined;
+      },
+      getTabInfoByElement: (_tabElement: Element) => {
+        // DOM-based tab lookup — could be enhanced later
+        return undefined;
+      },
+      getTabInfoById,
+      focusTab,
+      testLayout: EMPTY_LAYOUT,
+      find,
+      loadLayout: () => {
+        // No-op: Simple Mode layout is fixed
+      },
+    };
+
+    const unsub = registerDockLayout(papiDockLayout);
+
+    return () => {
+      unsub();
+    };
+    // We intentionally pass stable callbacks only. The functions close over the latest state via
+    // refs or setState updater functions.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ─── Open initial webviews ─────────────────────────────────────────────────
+
+  useEffect(() => {
+    if (hasOpenedInitialWebViews.current) return;
+    hasOpenedInitialWebViews.current = true;
+
+    (async () => {
+      try {
+        // Open reference panel webview (read-only scripture editor)
+        const refId = await openWebView('platformScriptureEditor.react', { type: 'tab' });
+        if (refId) setReferencePanelWebViewId(refId);
+
+        // Open editor panel webview (editable scripture editor)
+        const editorId = await openWebView('platformScriptureEditor.react', { type: 'tab' });
+        if (editorId) setEditorPanelWebViewId(editorId);
+      } catch (e) {
+        logger.error(`SimpleModeLayout: Failed to open initial webviews: ${e}`);
+      }
+    })();
+  }, []);
+
+  // ─── Derived state ─────────────────────────────────────────────────────────
+
+  const hasExtraPanel = panelVisibility.extra ?? false;
+  const visiblePanelCount =
+    (hasExtraPanel ? 1 : 0) +
+    (panelVisibility.reference ? 1 : 0) +
+    (panelVisibility.editor ? 1 : 0) +
+    (panelVisibility.resources ? 1 : 0);
+
+  const resourcesToolsTabs = useMemo(
+    () => tabArrangement.filter((t) => t.panel === 'resources' || t.panel === 'tools'),
+    [tabArrangement],
+  );
+
+  const referenceWebViewDef = referencePanelWebViewId
+    ? webViewDefs.get(referencePanelWebViewId)
+    : undefined;
+  const editorWebViewDef = editorPanelWebViewId ? webViewDefs.get(editorPanelWebViewId) : undefined;
+
+  // ─── Render ────────────────────────────────────────────────────────────────
+
+  return (
+    <div className="simple-mode-layout">
+      <Sidebar
+        onUserProfileClick={() => {
+          // TODO: Open UserProfileDropdown from sidebar
+        }}
+      />
+
+      <div className="simple-mode-main">
+        <SimpleModeToolbar
+          panelVisibility={panelVisibility}
+          onPanelVisibilityChange={setPanelVisibility}
+          tabArrangement={tabArrangement}
+          onTabArrangementChange={setTabArrangement}
+          viewOptions={viewOptions}
+          onViewOptionsChange={setViewOptions}
+        />
+
+        {visiblePanelCount === 0 ? (
+          <NoPanelsPlaceholder visibility={panelVisibility} onChange={setPanelVisibility} />
+        ) : (
+          <ResizablePanelGroup direction="horizontal" className="simple-mode-panels">
+            {hasExtraPanel && (
+              <>
+                <ResizablePanel defaultSize={20} minSize={10}>
+                  <ExtraPanel
+                    tabArrangement={tabArrangement}
+                    onTabArrangementChange={setTabArrangement}
+                    webViewDefs={webViewDefs}
+                  />
+                </ResizablePanel>
+                <ResizableHandle withHandle />
+              </>
+            )}
+
+            {panelVisibility.reference && (
+              <>
+                <ResizablePanel defaultSize={25} minSize={15}>
+                  <div className="simple-mode-panel simple-mode-panel-reference">
+                    {referenceWebViewDef ? (
+                      <WebView {...referenceWebViewDef} shouldShowToolbar={false} />
+                    ) : (
+                      <div className="simple-mode-panel-placeholder">Loading reference...</div>
+                    )}
+                  </div>
+                </ResizablePanel>
+                {(panelVisibility.editor || panelVisibility.resources) && (
+                  <ResizableHandle withHandle />
+                )}
+              </>
+            )}
+
+            {panelVisibility.editor && (
+              <>
+                <ResizablePanel defaultSize={35} minSize={15}>
+                  <div className="simple-mode-panel simple-mode-panel-editor">
+                    {editorWebViewDef ? (
+                      <WebView {...editorWebViewDef} shouldShowToolbar={false} />
+                    ) : (
+                      <div className="simple-mode-panel-placeholder">Loading editor...</div>
+                    )}
+                  </div>
+                </ResizablePanel>
+                {panelVisibility.resources && <ResizableHandle withHandle />}
+              </>
+            )}
+
+            {panelVisibility.resources && (
+              <ResizablePanel defaultSize={25} minSize={15}>
+                <ResourcesPanel
+                  tabs={resourcesToolsTabs}
+                  panelRole="resources"
+                  webViewDefs={webViewDefs}
+                />
+              </ResizablePanel>
+            )}
+          </ResizablePanelGroup>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default SimpleModeLayout;

--- a/src/renderer/components/simple-mode/simple-mode-toolbar.component.tsx
+++ b/src/renderer/components/simple-mode/simple-mode-toolbar.component.tsx
@@ -1,0 +1,160 @@
+/**
+ * Simple Mode toolbar — contains logo, project selector, BCV control, panel toggles, and view
+ * options.
+ */
+
+import logo from '@assets/icon.png';
+import { useScrollGroupScrRef, useRecentScriptureRefs } from '@renderer/hooks/papi-hooks';
+import { sendCommand } from '@shared/services/command.service';
+import { ScrollGroupScrRef } from '@shared/services/scroll-group.service-model';
+import { ChevronDown } from 'lucide-react';
+import {
+  BookChapterControl,
+  Button,
+  getToolbarOSReservedSpaceClassName,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  usePromise,
+} from 'platform-bible-react';
+import { useCallback, useState } from 'react';
+import type { PanelVisibility } from './simple-mode-layout.component';
+import type { TabItem } from './tab-config';
+import { PanelToggleButtons } from './panel-toggle-buttons.component';
+import {
+  ViewOptionsDropdown,
+  type ViewOptions,
+  DEFAULT_VIEW_OPTIONS,
+} from './view-options-dropdown.component';
+
+interface SimpleModeToolbarProps {
+  panelVisibility: PanelVisibility;
+  onPanelVisibilityChange: (v: PanelVisibility) => void;
+  tabArrangement: TabItem[];
+  onTabArrangementChange: (tabs: TabItem[]) => void;
+  viewOptions: ViewOptions;
+  onViewOptionsChange: (options: ViewOptions) => void;
+}
+
+export function SimpleModeToolbar({
+  panelVisibility,
+  onPanelVisibilityChange,
+  tabArrangement,
+  onTabArrangementChange,
+  viewOptions,
+  onViewOptionsChange,
+}: SimpleModeToolbarProps) {
+  // BCV control setup — same pattern as platform-bible-toolbar.tsx
+  const [scrollGroupIdInternal, setScrollGroupIdInternal] = useState<ScrollGroupScrRef>(0);
+  const updateScrollGroupIdInternal = useCallback((newScrollGroupId: ScrollGroupScrRef) => {
+    setScrollGroupIdInternal(newScrollGroupId);
+    return true;
+  }, []);
+
+  const [scrRef, setScrRef] = useScrollGroupScrRef(
+    scrollGroupIdInternal,
+    updateScrollGroupIdInternal,
+  );
+
+  const { recentScriptureRefs, addRecentScriptureRef } = useRecentScriptureRefs();
+
+  // OS platform for reserved space (macOS traffic lights)
+  const [osPlatformToReserveSpaceFor] = usePromise(
+    useCallback(async () => {
+      const osPlatform: string | undefined = await sendCommand('platform.getOSPlatform');
+      const isFullScreen: boolean = await sendCommand('platform.isFullScreen');
+      if (osPlatform === 'darwin' && isFullScreen) return undefined;
+      if (osPlatform === 'linux') return undefined;
+      return osPlatform;
+    }, []),
+    undefined,
+  );
+
+  // Project selector state (placeholder for now)
+  const [projectName, setProjectName] = useState('Select Project');
+  const [projectSelectorOpen, setProjectSelectorOpen] = useState(false);
+
+  const reservedSpaceClass = getToolbarOSReservedSpaceClassName(osPlatformToReserveSpaceFor);
+
+  return (
+    <div
+      className={`simple-mode-toolbar ${reservedSpaceClass ?? ''}`}
+      // eslint-disable-next-line jsx-a11y/no-noninteractive-element-to-interactive-role
+      role="toolbar"
+    >
+      {/* Logo + title */}
+      <div className="simple-mode-toolbar-brand">
+        <img width={20} height={20} src={`${logo}`} alt="Platform.Bible" />
+        <span className="simple-mode-toolbar-title">Platform.Bible</span>
+      </div>
+
+      {/* Project selector */}
+      <Popover open={projectSelectorOpen} onOpenChange={setProjectSelectorOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            size="sm"
+            className="tw-h-7 tw-gap-1 tw-text-xs tw-font-medium tw-max-w-[180px] tw-truncate"
+          >
+            <span className="tw-truncate">{projectName}</span>
+            <ChevronDown className="tw-w-3 tw-h-3 tw-flex-shrink-0" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="tw-w-56 tw-p-2" align="start">
+          <div className="tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-widest tw-text-muted-foreground tw-px-2 tw-mb-2">
+            Projects
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="tw-w-full tw-justify-start tw-text-xs"
+            onClick={() => {
+              setProjectSelectorOpen(false);
+              // TODO: Open project selector modal
+            }}
+          >
+            More projects...
+          </Button>
+          <div className="tw-mx-2 tw-my-1 tw-border-t tw-border-border" />
+          <Button
+            variant="ghost"
+            size="sm"
+            className="tw-w-full tw-justify-start tw-text-xs"
+            onClick={() => {
+              setProjectSelectorOpen(false);
+              // TODO: Open resource download dialog
+            }}
+          >
+            Download resource
+          </Button>
+        </PopoverContent>
+      </Popover>
+
+      {/* BCV control */}
+      <BookChapterControl
+        scrRef={scrRef}
+        handleSubmit={setScrRef}
+        className="tw-w-80"
+        recentSearches={recentScriptureRefs}
+        onAddRecentSearch={addRecentScriptureRef}
+      />
+
+      {/* Spacer */}
+      <div className="tw-flex-1" />
+
+      {/* Panel toggle buttons */}
+      <PanelToggleButtons
+        visibility={panelVisibility}
+        onChange={onPanelVisibilityChange}
+        tabArrangement={tabArrangement}
+        onTabArrangementChange={onTabArrangementChange}
+      />
+
+      {/* View options */}
+      <ViewOptionsDropdown options={viewOptions} onChange={onViewOptionsChange} />
+    </div>
+  );
+}
+
+export { DEFAULT_VIEW_OPTIONS };
+export type { ViewOptions };

--- a/src/renderer/components/simple-mode/tab-chooser-dropdown.component.tsx
+++ b/src/renderer/components/simple-mode/tab-chooser-dropdown.component.tsx
@@ -1,0 +1,101 @@
+/**
+ * Tab chooser dropdown — used by the extra panel's ellipsis menu to select which tabs appear in the
+ * extra panel vs the resources/tools panel.
+ */
+
+import { useMemo } from 'react';
+import { Popover, PopoverContent, PopoverTrigger } from 'platform-bible-react';
+import { MoreVertical } from 'lucide-react';
+import type { TabItem } from './tab-config';
+import { TAB_GROUPS } from './tab-registry';
+
+interface TabChooserDropdownProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  tabArrangement: TabItem[];
+  onToggleExtraTab: (tabId: string) => void;
+}
+
+export function TabChooserDropdown({
+  open,
+  onOpenChange,
+  tabArrangement,
+  onToggleExtraTab,
+}: TabChooserDropdownProps) {
+  const selectableTabs = useMemo(
+    () => tabArrangement.filter((t) => t.id !== 'reference' && !t.id.startsWith('__')),
+    [tabArrangement],
+  );
+
+  const scriptureGroupIds = useMemo(() => new Set(TAB_GROUPS.scripture.tabIds), []);
+
+  const groups = useMemo(() => {
+    const resourceTabs = selectableTabs.filter(
+      (t) => scriptureGroupIds.has(t.id) && t.id !== 'reference',
+    );
+    const toolTabs = selectableTabs.filter((t) => !scriptureGroupIds.has(t.id));
+
+    return [
+      { key: 'resources', label: 'Resources', tabs: resourceTabs },
+      { key: 'tools', label: 'Tools', tabs: toolTabs },
+    ].filter((g) => g.tabs.length > 0);
+  }, [selectableTabs, scriptureGroupIds]);
+
+  // Count non-extra tabs to prevent moving all tabs to extra
+  const nonExtraCount = selectableTabs.filter((t) => t.panel !== 'extra').length;
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="tw-p-1.5 tw-rounded-md tw-text-muted-foreground hover:tw-text-foreground hover:tw-bg-muted tw-transition-colors"
+          title="Choose extra panel tabs"
+        >
+          <MoreVertical className="tw-w-4 tw-h-4" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="tw-w-64 tw-p-0" align="end">
+        <div className="tw-p-3 tw-border-b tw-border-border tw-bg-muted">
+          <h3 className="tw-text-xs tw-font-bold">Choose extra panel tabs</h3>
+          <p className="tw-text-[10px] tw-text-muted-foreground tw-mt-0.5">
+            Select which tabs appear in this panel
+          </p>
+        </div>
+        <div className="tw-max-h-64 tw-overflow-y-auto tw-p-2">
+          {groups.map((group) => (
+            <div key={group.key} className="tw-mb-3 last:tw-mb-0">
+              <div className="tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-widest tw-text-muted-foreground tw-px-2 tw-mb-1">
+                {group.label}
+              </div>
+              {group.tabs.map((tab) => {
+                const isInExtra = tab.panel === 'extra';
+                const isLastNonExtra = !isInExtra && nonExtraCount <= 1;
+
+                return (
+                  <label
+                    key={tab.id}
+                    className={`tw-flex tw-items-center tw-gap-2 tw-px-2 tw-py-1.5 tw-rounded ${isLastNonExtra ? 'tw-opacity-50 tw-cursor-not-allowed' : 'hover:tw-bg-muted tw-cursor-pointer'}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={isInExtra}
+                      disabled={isLastNonExtra}
+                      onChange={() => !isLastNonExtra && onToggleExtraTab(tab.id)}
+                      className="tw-rounded tw-border-border"
+                    />
+                    <span
+                      className={`tw-text-xs ${isLastNonExtra ? 'tw-text-muted-foreground' : ''}`}
+                    >
+                      {tab.label}
+                    </span>
+                  </label>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/renderer/components/simple-mode/tab-config.ts
+++ b/src/renderer/components/simple-mode/tab-config.ts
@@ -1,0 +1,98 @@
+/**
+ * TAB CONFIGURATION — Default tab-to-panel assignments for Simple Mode (Study & Draft workflow).
+ *
+ * Defines which tabs appear on which panel by default. Only the Study & Draft workflow is
+ * implemented.
+ */
+
+import type { TabGroupId, TabId } from './tab-registry';
+import { getTabDef } from './tab-registry';
+
+// ─── TabItem — the runtime tab assignment used by panels ──────────────────────
+
+export type TabPanel = 'resources' | 'tools' | 'extra';
+
+export interface TabItem {
+  id: string;
+  label: string;
+  panel: TabPanel;
+  visible: boolean;
+  group: TabGroupId;
+}
+
+// ─── Per-tab assignment spec ──────────────────────────────────────────────────
+
+interface TabAssignment {
+  id: TabId;
+  panel: TabPanel;
+  visible: boolean;
+}
+
+/** Convert a TabAssignment to a full TabItem using the registry. */
+function toTabItem(a: TabAssignment): TabItem {
+  const def = getTabDef(a.id);
+  return {
+    id: a.id,
+    label: def?.labelKey ?? a.id,
+    panel: a.panel,
+    visible: a.visible,
+    group: def?.group ?? 'tools',
+  };
+}
+
+// ─── Study & Draft default tab assignments ────────────────────────────────────
+
+const STUDY_DRAFT_TABS: TabAssignment[] = [
+  // Scripture resources panel
+  { id: 'reference', panel: 'resources', visible: true },
+  { id: 'bible', panel: 'resources', visible: true },
+  { id: 'text-collection', panel: 'resources', visible: true },
+  { id: 'source', panel: 'resources', visible: true },
+  // Tools panel
+  { id: 'comments', panel: 'tools', visible: true },
+  { id: 'search', panel: 'tools', visible: true },
+  { id: 'dictionary', panel: 'tools', visible: true },
+  { id: 'terms', panel: 'tools', visible: true },
+  { id: 'parallel-passages', panel: 'tools', visible: true },
+  { id: 'ai', panel: 'tools', visible: true },
+];
+
+// ─── Public API ───────────────────────────────────────────────────────────────
+
+/** Get the default tab arrangement for Study & Draft. */
+export function getDefaultTabs(): TabItem[] {
+  return STUDY_DRAFT_TABS.map(toTabItem);
+}
+
+/** Get the set of tab IDs that are visible by default. */
+export function getDefaultVisibleIds(): Set<string> {
+  const defaults = getDefaultTabs();
+  return new Set(defaults.filter((t) => t.visible).map((t) => t.id));
+}
+
+/**
+ * Get tab metadata for a tab ID. Used when adding tabs dynamically (e.g., in the extra panel tab
+ * chooser).
+ */
+export function getTabMeta(tabId: string): { label: string; group: TabGroupId } {
+  const def = getTabDef(tabId);
+  if (def) {
+    return { label: def.labelKey, group: def.group };
+  }
+  return {
+    label: tabId.charAt(0).toUpperCase() + tabId.slice(1).replace(/-/g, ' '),
+    group: 'tools',
+  };
+}
+
+/** Resolve a complete TabItem from a tab ID and target panel. */
+export function resolveTabItem(tabId: string, panel: TabPanel, visible: boolean = true): TabItem {
+  const meta = getTabMeta(tabId);
+  return {
+    id: tabId,
+    label: meta.label,
+    panel,
+    visible,
+    group: meta.group,
+  };
+}

--- a/src/renderer/components/simple-mode/tab-registry.ts
+++ b/src/renderer/components/simple-mode/tab-registry.ts
@@ -1,0 +1,197 @@
+/**
+ * TAB REGISTRY — Single source of truth for all Simple Mode tab metadata.
+ *
+ * Every tab in Simple Mode is defined here exactly once. The registry provides tab IDs, labels,
+ * icons, and group membership used by the resources panel tab bar, the "add extra panel" dropdown,
+ * and the "choose extra panel tabs" dropdown.
+ */
+
+import {
+  BookOpenText,
+  BookOpen,
+  Library,
+  FileText,
+  BookA,
+  MessageSquare,
+  Search,
+  Sparkles,
+  GitCompare,
+  type LucideIcon,
+} from 'lucide-react';
+
+// ─── Tab Group definitions ────────────────────────────────────────────────────
+
+export type TabGroupId = 'scripture' | 'tools';
+
+/**
+ * Ordered list of tab group IDs. Determines the display order of groups when tabs from multiple
+ * groups appear in the same panel.
+ */
+export const TAB_GROUP_ORDER: TabGroupId[] = ['scripture', 'tools'];
+
+export interface TabGroupDef {
+  label: string;
+  tabIds: string[];
+}
+
+/**
+ * Tab groups with their ordered tab membership. The order of tabIds within each group determines
+ * the display order of tabs within that group.
+ */
+export const TAB_GROUPS: Record<TabGroupId, TabGroupDef> = {
+  scripture: {
+    label: 'Resources',
+    tabIds: ['reference', 'bible', 'text-collection', 'source'],
+  },
+  tools: {
+    label: 'Tools',
+    tabIds: ['comments', 'search', 'dictionary', 'terms', 'parallel-passages', 'ai'],
+  },
+};
+
+// ─── Tab ID type ──────────────────────────────────────────────────────────────
+
+export type TabId =
+  | 'reference'
+  | 'bible'
+  | 'text-collection'
+  | 'source'
+  | 'comments'
+  | 'search'
+  | 'dictionary'
+  | 'terms'
+  | 'parallel-passages'
+  | 'ai';
+
+// ─── Tab Definition ───────────────────────────────────────────────────────────
+
+export interface TabDefinition {
+  id: TabId;
+  labelKey: string;
+  group: TabGroupId;
+  /** Lucide icon component. Undefined for tabs that use custom rendering. */
+  icon?: LucideIcon;
+  /**
+   * When set, the tab uses a custom icon renderer instead of a Lucide icon. 'aleph' = Hebrew Aleph
+   * character, 'triquetra' = Triquetra SVG image.
+   */
+  customIcon?: 'aleph' | 'triquetra';
+}
+
+/**
+ * TAB_REGISTRY — Complete catalog of every tab in Simple Mode.
+ *
+ * Keyed by TabId. This is the ONLY place tab metadata is defined.
+ */
+export const TAB_REGISTRY: Record<TabId, TabDefinition> = {
+  // ── Scripture group ──
+  reference: {
+    id: 'reference',
+    labelKey: 'Reference Text',
+    group: 'scripture',
+    icon: BookOpenText,
+  },
+  bible: {
+    id: 'bible',
+    labelKey: 'Bible Texts',
+    group: 'scripture',
+    icon: BookOpen,
+  },
+  'text-collection': {
+    id: 'text-collection',
+    labelKey: 'Text Collection',
+    group: 'scripture',
+    icon: Library,
+  },
+  source: {
+    id: 'source',
+    labelKey: 'Source Language Tools',
+    group: 'scripture',
+    customIcon: 'aleph',
+  },
+
+  // ── Tools group ──
+  comments: {
+    id: 'comments',
+    labelKey: 'Comments',
+    group: 'tools',
+    icon: MessageSquare,
+  },
+  search: {
+    id: 'search',
+    labelKey: 'Find in texts',
+    group: 'tools',
+    icon: Search,
+  },
+  dictionary: {
+    id: 'dictionary',
+    labelKey: 'Dictionary',
+    group: 'tools',
+    icon: BookA,
+  },
+  terms: {
+    id: 'terms',
+    labelKey: 'Biblical Terms',
+    group: 'tools',
+    customIcon: 'triquetra',
+  },
+  'parallel-passages': {
+    id: 'parallel-passages',
+    labelKey: 'Parallel Passages',
+    group: 'tools',
+    icon: GitCompare,
+  },
+  ai: {
+    id: 'ai',
+    labelKey: 'Ask AI',
+    group: 'tools',
+    icon: Sparkles,
+  },
+};
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Get the TabDefinition for a given ID. Returns undefined if not found. */
+export function getTabDef(id: string): TabDefinition | undefined {
+  return TAB_REGISTRY[id as TabId];
+}
+
+/** Get the group for a tab ID. */
+export function getTabGroup(id: string): TabGroupId | undefined {
+  return getTabDef(id)?.group;
+}
+
+/** Get all tab IDs in display order (respecting group order and tab order within groups). */
+export function getAllTabIdsOrdered(): TabId[] {
+  const result: TabId[] = [];
+  for (const groupId of TAB_GROUP_ORDER) {
+    const group = TAB_GROUPS[groupId];
+    for (const tabId of group.tabIds) {
+      result.push(tabId as TabId);
+    }
+  }
+  return result;
+}
+
+/** Sort an array of tab IDs by the canonical order (group order → tab order within group). */
+export function sortTabIds(ids: string[]): string[] {
+  const ordered = getAllTabIdsOrdered();
+  const orderMap = new Map(ordered.map((id, i) => [id, i]));
+  return [...ids].sort((a, b) => (orderMap.get(a) ?? 999) - (orderMap.get(b) ?? 999));
+}
+
+/**
+ * Compute divider indices for a list of tabs — returns the set of indices after which a group
+ * divider should be rendered (i.e. the last tab before a group boundary).
+ */
+export function computeGroupDividerIndices(tabIds: string[]): Set<number> {
+  const indices = new Set<number>();
+  for (let i = 1; i < tabIds.length; i++) {
+    const prevGroup = getTabGroup(tabIds[i - 1]);
+    const currGroup = getTabGroup(tabIds[i]);
+    if (prevGroup && currGroup && prevGroup !== currGroup) {
+      indices.add(i - 1);
+    }
+  }
+  return indices;
+}

--- a/src/renderer/components/simple-mode/view-options-dropdown.component.tsx
+++ b/src/renderer/components/simple-mode/view-options-dropdown.component.tsx
@@ -1,0 +1,213 @@
+/** View options dropdown for Simple Mode toolbar. Contains editor and general view option toggles. */
+
+import { Settings2, ChevronDown } from 'lucide-react';
+import { Button, Popover, PopoverTrigger, PopoverContent } from 'platform-bible-react';
+import { useState, useCallback } from 'react';
+
+export type ToolbarPosition = 'hidden' | 'floating' | 'right';
+
+export interface ViewOptions {
+  showMarkers: boolean;
+  showGhostText: boolean;
+  showFootnotes: boolean;
+  highlightTerms: boolean;
+  toolbarPosition: ToolbarPosition;
+  verseNumberMode: 'superscript' | 'full-height';
+}
+
+export const DEFAULT_VIEW_OPTIONS: ViewOptions = {
+  showMarkers: true,
+  showGhostText: true,
+  showFootnotes: true,
+  highlightTerms: false,
+  toolbarPosition: 'right',
+  verseNumberMode: 'superscript',
+};
+
+interface ViewOptionsDropdownProps {
+  options: ViewOptions;
+  onChange: (options: ViewOptions) => void;
+}
+
+function ToggleRow({
+  label,
+  description,
+  value,
+  onToggle,
+}: {
+  label: string;
+  description?: string;
+  value: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      className="tw-w-full tw-flex tw-items-center tw-justify-between tw-px-3 tw-py-2 tw-text-left hover:tw-bg-muted tw-cursor-pointer tw-transition-colors"
+    >
+      <div className="tw-flex tw-flex-col tw-items-start">
+        <span className="tw-text-xs tw-font-medium">{label}</span>
+        {description && (
+          <span className="tw-text-[10px] tw-text-muted-foreground tw-leading-tight">
+            {description}
+          </span>
+        )}
+      </div>
+      <div
+        className={`tw-relative tw-w-7 tw-h-4 tw-rounded-full tw-flex-shrink-0 tw-ml-3 tw-transition-colors tw-duration-200 ${value ? 'tw-bg-primary' : 'tw-bg-muted-foreground/30'}`}
+      >
+        <div
+          className={`tw-absolute tw-top-0.5 tw-w-3 tw-h-3 tw-rounded-full tw-bg-background tw-shadow-sm tw-transition-all tw-duration-200 ${value ? 'tw-left-[14px]' : 'tw-left-[2px]'}`}
+        />
+      </div>
+    </button>
+  );
+}
+
+function ThreeWayToggle({
+  label,
+  options: toggleOptions,
+  value,
+  onChange,
+}: {
+  label: string;
+  options: { id: string; label: string }[];
+  value: string;
+  onChange: (value: string) => void;
+}) {
+  return (
+    <div className="tw-px-3 tw-py-2">
+      <div className="tw-text-xs tw-font-medium tw-mb-1.5">{label}</div>
+      <div className="tw-flex tw-rounded-lg tw-border tw-border-border tw-overflow-hidden">
+        {toggleOptions.map((opt, i) => {
+          const isActive = value === opt.id;
+          return (
+            <button
+              type="button"
+              key={opt.id}
+              onClick={() => onChange(opt.id)}
+              className={`tw-flex-1 tw-py-1.5 tw-text-[10px] tw-font-semibold tw-transition-all tw-duration-150 ${i > 0 ? 'tw-border-l tw-border-border' : ''} ${isActive ? 'tw-bg-primary tw-text-primary-foreground' : 'tw-bg-background tw-text-muted-foreground hover:tw-bg-muted tw-cursor-pointer'}`}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export function ViewOptionsDropdown({ options, onChange }: ViewOptionsDropdownProps) {
+  const [open, setOpen] = useState(false);
+
+  const toggle = useCallback(
+    (key: keyof Omit<ViewOptions, 'toolbarPosition' | 'verseNumberMode'>) => {
+      onChange({ ...options, [key]: !options[key] });
+    },
+    [options, onChange],
+  );
+
+  const handleToolbarPositionChange = useCallback(
+    (v: string) => {
+      onChange({ ...options, toolbarPosition: v as ToolbarPosition });
+    },
+    [options, onChange],
+  );
+
+  const handleMarkerPlaceholderChange = useCallback(
+    (mode: string) => {
+      if (mode === 'both') onChange({ ...options, showMarkers: true, showGhostText: true });
+      else if (mode === 'markers')
+        onChange({ ...options, showMarkers: true, showGhostText: false });
+      else if (mode === 'placeholder')
+        onChange({ ...options, showMarkers: false, showGhostText: true });
+    },
+    [options, onChange],
+  );
+
+  const markerPlaceholderValue =
+    options.showMarkers && options.showGhostText
+      ? 'both'
+      : options.showMarkers
+        ? 'markers'
+        : 'placeholder';
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button variant="ghost" size="sm" className="tw-h-7 tw-gap-1.5 tw-text-xs tw-font-medium">
+          <Settings2 className="tw-w-3.5 tw-h-3.5" />
+          <span>View</span>
+          <ChevronDown className="tw-w-3 tw-h-3" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="tw-w-[260px] tw-p-0" align="end">
+        {/* Editor section */}
+        <div className="tw-px-3 tw-py-1.5 tw-mb-0.5">
+          <span className="tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-widest tw-text-muted-foreground">
+            Editor
+          </span>
+        </div>
+
+        <ThreeWayToggle
+          label="Toolbar Position"
+          options={[
+            { id: 'hidden', label: 'Fixed' },
+            { id: 'floating', label: 'Floating' },
+            { id: 'right', label: 'Side' },
+          ]}
+          value={options.toolbarPosition}
+          onChange={handleToolbarPositionChange}
+        />
+
+        <ToggleRow
+          label="Key Terms (not implemented)"
+          description="Highlight key biblical terms in the editor"
+          value={options.highlightTerms}
+          onToggle={() => toggle('highlightTerms')}
+        />
+
+        <div className="tw-mx-3 tw-my-1.5 tw-border-t tw-border-border" />
+
+        {/* General View Options */}
+        <div className="tw-px-3 tw-py-1.5 tw-mb-0.5">
+          <span className="tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-widest tw-text-muted-foreground">
+            General View Options
+          </span>
+        </div>
+
+        <ThreeWayToggle
+          label="Show"
+          options={[
+            { id: 'markers', label: 'Markers' },
+            { id: 'both', label: 'Markers & Placeholder' },
+            { id: 'placeholder', label: 'Placeholder' },
+          ]}
+          value={markerPlaceholderValue}
+          onChange={handleMarkerPlaceholderChange}
+        />
+
+        <ToggleRow
+          label="Superscript verse numbers"
+          description="Use smaller superscript numbers instead of full-height"
+          value={options.verseNumberMode === 'superscript'}
+          onToggle={() =>
+            onChange({
+              ...options,
+              verseNumberMode:
+                options.verseNumberMode === 'superscript' ? 'full-height' : 'superscript',
+            })
+          }
+        />
+
+        <ToggleRow
+          label="Footnotes"
+          description="Show footnote panel below text"
+          value={options.showFootnotes}
+          onToggle={() => toggle('showFootnotes')}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/renderer/components/user-profile-dropdown.component.tsx
+++ b/src/renderer/components/user-profile-dropdown.component.tsx
@@ -1,0 +1,243 @@
+/**
+ * User Profile Dropdown — shared between Simple Mode (sidebar) and Power Mode (title bar).
+ *
+ * Contains: user info, mode switch, profile/registration, network settings, language, theme toggle.
+ * In Power Mode, this replaces the individual theme, network, and registration buttons.
+ */
+
+import { useData, useDataProvider } from '@renderer/hooks/papi-hooks';
+import useSetting from '@renderer/hooks/papi-hooks/use-setting.hook';
+import { localThemeService } from '@renderer/services/theme.service-host';
+import { sendCommand } from '@shared/services/command.service';
+import { logger } from '@shared/services/logger.service';
+import { themeServiceDataProviderName } from '@shared/services/theme.service-model';
+import {
+  BookOpen,
+  CircleUser,
+  Globe,
+  LayoutGrid,
+  Monitor,
+  Moon,
+  Network,
+  Sun,
+  User,
+} from 'lucide-react';
+import { Button, Popover, PopoverContent, PopoverTrigger, usePromise } from 'platform-bible-react';
+import { getErrorMessage, isPlatformError, ThemeDefinitionExpanded } from 'platform-bible-utils';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+const DEFAULT_THEME_VALUE: ThemeDefinitionExpanded = {
+  themeFamilyId: '',
+  type: 'light',
+  id: 'light',
+  label: '%unused%',
+  cssVariables: {},
+};
+
+interface UserProfileDropdownProps {
+  /** Where the dropdown trigger renders. Affects trigger button style. */
+  context?: 'sidebar' | 'toolbar';
+}
+
+export function UserProfileDropdown({ context = 'toolbar' }: UserProfileDropdownProps) {
+  const [open, setOpen] = useState(false);
+
+  // User registration data
+  const [registrationData] = usePromise(
+    useCallback(async () => sendCommand('paratextRegistration.getParatextRegistrationData'), []),
+    undefined,
+  );
+
+  // Interface mode
+  const [interfaceMode, setInterfaceMode] = useSetting('platform.interfaceMode', 'simple');
+
+  // Interface language
+  const [interfaceLanguage, setInterfaceLanguage] = useSetting('platform.interfaceLanguage', [
+    'en',
+  ]);
+
+  // Theme
+  const themeDataProvider = useDataProvider(themeServiceDataProviderName);
+  const themeOnFirstLoad = useMemo(() => localThemeService.getCurrentThemeSync(), []);
+  const [theme, setTheme] = useData<typeof themeServiceDataProviderName>(
+    themeDataProvider,
+  ).CurrentTheme(undefined, DEFAULT_THEME_VALUE);
+
+  useEffect(() => {
+    if (isPlatformError(theme))
+      logger.warn(`Error getting theme for profile dropdown. ${getErrorMessage(theme)}`);
+  }, [theme]);
+
+  const isThemeLoadedNotError = theme !== DEFAULT_THEME_VALUE && !isPlatformError(theme);
+  const themeTypeEffective = isThemeLoadedNotError ? theme.type : themeOnFirstLoad.type;
+
+  const handleThemeChange = useCallback(
+    (type: 'light' | 'dark') => {
+      try {
+        setTheme?.({ type });
+      } catch (e) {
+        logger.warn(`Profile dropdown error setting theme to ${type}: ${getErrorMessage(e)}`);
+      }
+    },
+    [setTheme],
+  );
+
+  // Display name from registration data
+  const userName =
+    registrationData && !isPlatformError(registrationData)
+      ? registrationData.name || 'User'
+      : 'User';
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        {context === 'sidebar' ? (
+          <button type="button" className="simple-mode-sidebar-btn" aria-label="User Profile">
+            <CircleUser className="tw-w-5 tw-h-5" />
+          </button>
+        ) : (
+          <Button variant="ghost" size="icon" className="pr-twp tw-h-8 tw-flex-shrink-0">
+            <CircleUser />
+          </Button>
+        )}
+      </PopoverTrigger>
+      <PopoverContent
+        className="tw-w-[280px] tw-p-0"
+        side={context === 'sidebar' ? 'right' : 'bottom'}
+        align={context === 'sidebar' ? 'end' : 'end'}
+      >
+        {/* User info */}
+        <div className="tw-px-4 tw-py-3 tw-border-b tw-border-border">
+          <div className="tw-flex tw-items-center tw-gap-3">
+            <div className="tw-p-2 tw-rounded-full tw-bg-muted">
+              <User className="tw-w-5 tw-h-5 tw-text-muted-foreground" />
+            </div>
+            <div>
+              <div className="tw-text-sm tw-font-medium">{userName}</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Mode switch */}
+        <div className="tw-p-2 tw-border-b tw-border-border">
+          <div className="tw-text-[10px] tw-font-bold tw-uppercase tw-tracking-widest tw-text-muted-foreground tw-px-2 tw-mb-2">
+            Interface Mode
+          </div>
+          <div className="tw-flex tw-gap-2">
+            <button
+              type="button"
+              onClick={() => setInterfaceMode('simple')}
+              className={`tw-flex-1 tw-flex tw-items-center tw-gap-2 tw-p-2.5 tw-rounded-lg tw-border tw-transition-all ${interfaceMode === 'simple' ? 'tw-border-primary tw-bg-primary/5' : 'tw-border-border hover:tw-border-foreground/30 hover:tw-bg-muted'}`}
+            >
+              <BookOpen
+                className={`tw-w-4 tw-h-4 ${interfaceMode === 'simple' ? 'tw-text-primary' : 'tw-text-muted-foreground'}`}
+              />
+              <div className="tw-text-left">
+                <div
+                  className={`tw-text-xs tw-font-semibold ${interfaceMode === 'simple' ? 'tw-text-primary' : ''}`}
+                >
+                  Simple
+                </div>
+              </div>
+            </button>
+            <button
+              type="button"
+              onClick={() => setInterfaceMode('power')}
+              className={`tw-flex-1 tw-flex tw-items-center tw-gap-2 tw-p-2.5 tw-rounded-lg tw-border tw-transition-all ${interfaceMode === 'power' ? 'tw-border-primary tw-bg-primary/5' : 'tw-border-border hover:tw-border-foreground/30 hover:tw-bg-muted'}`}
+            >
+              <LayoutGrid
+                className={`tw-w-4 tw-h-4 ${interfaceMode === 'power' ? 'tw-text-primary' : 'tw-text-muted-foreground'}`}
+              />
+              <div className="tw-text-left">
+                <div
+                  className={`tw-text-xs tw-font-semibold ${interfaceMode === 'power' ? 'tw-text-primary' : ''}`}
+                >
+                  Power
+                </div>
+              </div>
+            </button>
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="tw-p-1 tw-border-b tw-border-border">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="tw-w-full tw-justify-start tw-gap-2 tw-text-xs tw-h-8"
+            onClick={() => {
+              sendCommand('paratextRegistration.showParatextRegistration');
+              setOpen(false);
+            }}
+          >
+            <User className="tw-w-4 tw-h-4" />
+            Profile &amp; Registration
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="tw-w-full tw-justify-start tw-gap-2 tw-text-xs tw-h-8"
+            onClick={() => {
+              sendCommand('paratextRegistration.showInternetSettings');
+              setOpen(false);
+            }}
+          >
+            <Network className="tw-w-4 tw-h-4" />
+            Network Settings
+          </Button>
+        </div>
+
+        {/* Language selector */}
+        <div className="tw-px-4 tw-py-2 tw-flex tw-items-center tw-justify-between tw-border-b tw-border-border">
+          <span className="tw-text-sm tw-flex tw-items-center tw-gap-2">
+            <Globe className="tw-w-4 tw-h-4 tw-text-muted-foreground" /> Language
+          </span>
+          <div className="tw-flex tw-items-center tw-bg-muted tw-rounded-lg tw-p-0.5 tw-gap-0.5">
+            {[
+              { id: 'en', label: 'EN' },
+              { id: 'fr', label: 'FR' },
+              { id: 'es', label: 'ES' },
+            ].map(({ id, label }) => {
+              const isActive = Array.isArray(interfaceLanguage) && interfaceLanguage[0] === id;
+              return (
+                <button
+                  type="button"
+                  key={id}
+                  onClick={() => setInterfaceLanguage([id])}
+                  className={`tw-px-2 tw-py-1 tw-rounded-md tw-text-xs tw-font-medium tw-transition-all ${isActive ? 'tw-bg-background tw-shadow-sm' : 'tw-text-muted-foreground hover:tw-text-foreground hover:tw-bg-background/50'}`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Appearance / Theme toggle */}
+        <div className="tw-px-4 tw-py-2 tw-flex tw-items-center tw-justify-between">
+          <span className="tw-text-sm">Appearance</span>
+          <div className="tw-flex tw-items-center tw-bg-muted tw-rounded-lg tw-p-0.5 tw-gap-0.5">
+            {[
+              { id: 'light', Icon: Sun, label: 'Light' },
+              { id: 'dark', Icon: Moon, label: 'Dark' },
+            ].map(({ id, Icon, label }) => {
+              const isActive = themeTypeEffective === id;
+              return (
+                <button
+                  type="button"
+                  key={id}
+                  onClick={() => handleThemeChange(id as 'light' | 'dark')}
+                  disabled={!isThemeLoadedNotError}
+                  title={label}
+                  className={`tw-p-1.5 tw-rounded-md tw-transition-all ${isActive ? 'tw-bg-background tw-shadow-sm' : 'tw-text-muted-foreground hover:tw-text-foreground hover:tw-bg-background/50'}`}
+                >
+                  <Icon className="tw-w-3.5 tw-h-3.5" />
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -641,7 +641,7 @@ async function loadLayout(layout?: LayoutBase): Promise<void> {
   const dockLayoutVar = await getDockLayout();
   const layoutToLoad = layout || getStorageValue(DOCK_LAYOUT_KEY, dockLayoutVar.testLayout);
 
-  dockLayoutVar.dockLayout.loadLayout(layoutToLoad);
+  dockLayoutVar.loadLayout(layoutToLoad);
   if (layout) {
     // A layout was provided, meaning this is a layout change. Since `dockLayout.loadLayout` doesn't
     // run `onLayoutChange`, we run it manually
@@ -1539,22 +1539,24 @@ export const openWebView = async (
 
   // Find existing webView if one exists and handle it if it does
   if (optionsDefaulted.existingId) {
-    // Expect this to be a tab.
-    // eslint-disable-next-line no-type-assertion/no-type-assertion
-    const existingWebView = (await getDockLayout()).dockLayout.find(
+    const existingWebView = (await getDockLayout()).find(
       optionsDefaulted.existingId === '?'
         ? // If they provided '?', that means look for any webview with a matching webViewType
-          (item) => {
-            // This is not a webview
-            if (!('data' in item)) return false;
+          (item: unknown) => {
+            if (!item || typeof item !== 'object') return false;
 
-            // Find any webview with the specified webViewType. Type assert the unknown `data`.
+            // This is not a webview - no data property
             // eslint-disable-next-line no-type-assertion/no-type-assertion
-            return (item.data as WebViewDefinition).webViewType === webViewType;
+            const itemObj = item as { data?: unknown };
+            if (!itemObj.data) return false;
+
+            // Find any webview with the specified webViewType
+            // eslint-disable-next-line no-type-assertion/no-type-assertion
+            return (itemObj.data as WebViewDefinition).webViewType === webViewType;
           }
         : // If they provided any other string, look for a webview with that ID
           optionsDefaulted.existingId,
-    ) as TabInfo | undefined;
+    );
 
     // If we found an existing WebView, handle it and return it
     if (existingWebView) {

--- a/src/shared/models/docking-framework.model.ts
+++ b/src/shared/models/docking-framework.model.ts
@@ -204,8 +204,14 @@ export type OnLayoutChangeRCDock = (
 
 /** Properties related to the dock layout */
 export type PapiDockLayout = {
-  /** The rc-dock dock layout React element ref. Used to perform operations on the layout */
-  dockLayout: DockLayout;
+  /**
+   * The rc-dock dock layout React element ref. Used to perform operations on the layout.
+   *
+   * @deprecated Use the `find` and `loadLayout` methods on `PapiDockLayout` instead of accessing
+   *   the raw DockLayout. This property will be removed once all call sites are migrated. It may be
+   *   `undefined` in layout implementations that do not use rc-dock (e.g., Simple Mode).
+   */
+  dockLayout: DockLayout | undefined;
   /**
    * A ref to a function that runs when the layout changes. We set this ref to our
    * {@link onLayoutChange} function
@@ -344,4 +350,19 @@ export type PapiDockLayout = {
    * service is currently all shared code. Refactor should happen in #203
    */
   testLayout: LayoutBase;
+  /**
+   * Find a tab by ID or by a predicate function. Replaces direct access to
+   * `dockLayout.dockLayout.find()`.
+   *
+   * @param idOrPredicate A tab ID string, or a predicate function that receives each item in the
+   *   layout and returns `true` for the desired match
+   * @returns The found tab info, or `undefined` if not found
+   */
+  find: (idOrPredicate: string | ((item: unknown) => boolean)) => TabInfo | undefined;
+  /**
+   * Load a layout into the dock. Replaces direct access to `dockLayout.dockLayout.loadLayout()`.
+   *
+   * @param layout The layout to load
+   */
+  loadLayout: (layout: LayoutBase) => void;
 };


### PR DESCRIPTION
https://discord.com/channels/892072317436448768/1486342666424680610

<img width="1283" height="934" alt="image" src="https://github.com/user-attachments/assets/cef324f3-644e-49ba-9717-98fe5959c13a" />

Implement Simple Mode (Variant A) as an alternative to the existing Power Mode docking layout. Controlled by the `platform.interfaceMode` setting ('simple' | 'power').

- Refactor PapiDockLayout interface to be layout-engine-agnostic (add find/loadLayout methods, deprecate direct dockLayout access)
- Add SimpleModeLayout with shadcn resizable panels (Reference, Editor, Resources/Tools
  + optional Extra panel)
- Add tab registry and configuration for Study & Draft workflow
- Add toolbar with project selector, BCV control, panel toggles, view options dropdown
- Add sidebar with Study & Draft workflow indicator
- Add shared UserProfileDropdown (mode switch, theme, language, registration, network) used in both Simple Mode sidebar and Power Mode title bar (replaces 3 individual buttons)
- Add resources panel with grouped icon tab bar and tab chooser for extra panel
- Wire webview infrastructure (PapiDockLayout implementation against internal state)
- Add placeholder components for unimplemented tabs

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2134)
<!-- Reviewable:end -->
