### PR TITLE
chore: exclude platform-bible-react dist from Claude Code searches

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "permissions": {
+    "deny": ["Read(lib/platform-bible-react/dist/**)"]
+  }
+}

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,1 +1,0 @@
-lib/platform-bible-react/dist/

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,1 @@
+lib/platform-bible-react/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,8 @@ e2e-tests/test-results/
 e2e-tests/.dev-server.pid
 
 #claude
-.claude
+.claude/*
+!.claude/settings.json
 .claude.backup/
 .context
 c-sharp/CLAUDE.md


### PR DESCRIPTION
## What this does

Adds `.claude/settings.json` with a `permissions.deny` rule that blocks Claude Code agents from reading or searching `lib/platform-bible-react/dist/`.

Also updates `.gitignore` to track `.claude/settings.json` while keeping the rest of `.claude/` (personal settings, skills, etc.) local-only as before.

## Why

`lib/platform-bible-react/dist/` has to stay committed — I understand it can't go in `.gitignore` because downstream consumers depend on it being in the repo. That's fine and correct.

The problem is that when Claude Code agents do any kind of broad search — looking for a component, tracing an export, exploring the API surface — they naturally find and read the compiled dist files. Since dist is a bundle of the source, the agent ends up consuming a large amount of tokens re-reading content it already found in the actual source files, and it can get confused trying to reconcile compiled output with the original TypeScript. It's a noise problem, not a correctness problem.

Claude Code's `permissions.deny` solves this at the tool level: it prevents the `Read`, `Grep`, and `Glob` tools from ever surfacing files under that path.

## I defer to you

I don't expect anyone to have asked for this or to be immediately sold on it. Adding an AI tooling config file to the repo is a real decision that deserves scrutiny. Please push back if this doesn't fit how the team wants to manage the project. I'll happily close it.

A few things I want to be transparent about:
- `.claude/settings.json` is the *shared* Claude Code settings file (per Anthropic's documentation). Personal Claude Code settings live in `.claude/settings.local.json`, which was already gitignored. This PR only commits the shared part.
- If the team doesn't use Claude Code, this file is completely inert — it does nothing without the Claude Code CLI present.
- I'm sure the team *does* have opinions about what should be in a shared config. I'd love input.

## Testing

Testing involved trying to reproduce the problem this is meant to solve: confirming that without the deny rule, Claude agents do find and read the dist files, and that after adding it, they can't.

**Without the deny rule (initial state):**
- `Glob("lib/platform-bible-react/dist/**/*")` returned all 5 dist files.
- `Glob("**/*.d.ts")` included `lib/platform-bible-react/dist/index.d.ts` alongside legitimate source `.d.ts` files.

**After adding `.claude/settings.json`:**
- `Glob("lib/platform-bible-react/dist/**/*")` → `No files found`
- `Grep` targeting the dist directory → `Permission to read .../lib/platform-bible-react/dist has been denied.`

The deny rule took effect immediately within the same session (no restart needed). Both the path-specific search and a broad `*.d.ts` search confirmed the dist files are fully excluded.

🤖 Co-authored with [Claude Code](https://claude.ai/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2167)
<!-- Reviewable:end -->
