### PR TITLE
chore: auto-sort cspell.json words array on pre-commit

### DIFF
--- a/.erb/scripts/sort-cspell-words.js
+++ b/.erb/scripts/sort-cspell-words.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Sorts the "words" array in cspell.json alphabetically.
+// Uses regex replacement so JSONC comments elsewhere in the file are preserved.
+// Used as a lint-staged hook to enforce consistent ordering.
+
+const fs = require('fs');
+const path = require('path');
+
+const cspellPath = path.resolve(__dirname, '../../cspell.json');
+const content = fs.readFileSync(cspellPath, 'utf8');
+
+// Match the "words": [ ... ] block (words are plain strings, one per line, no comments)
+const wordsBlockRegex = /"words":\s*\[([^\]]*)\]/s;
+const match = content.match(wordsBlockRegex);
+
+if (!match) {
+  console.error('Could not find "words" array in cspell.json');
+  process.exit(1);
+}
+
+const wordsBlock = match[1];
+const words = [...wordsBlock.matchAll(/"([^"]+)"/g)].map((m) => m[1]);
+const sorted = [...new Set(words)].sort((a, b) => a.localeCompare(b));
+
+if (JSON.stringify(words) === JSON.stringify(sorted)) {
+  process.exit(0);
+}
+
+const indent = '    ';
+const sortedBlock = sorted.map((w) => `${indent}"${w}"`).join(',\n');
+const newContent = content.replace(wordsBlockRegex, `"words": [\n${sortedBlock}\n  ]`);
+
+fs.writeFileSync(cspellPath, newContent, 'utf8');
+console.log('Sorted words array in cspell.json');

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
       "prettier --parser json --write --ignore-path .prettierignorerun"
     ],
     "*.{cjs,js,jsx,ts,tsx}": ["prettier --write --ignore-path .prettierignorerun"],
-    "*.json": ["prettier --parser json --write --ignore-path .prettierignorerun"],
+    "!(cspell).json": ["prettier --parser json --write --ignore-path .prettierignorerun"],
     "*.{css,scss}": ["stylelint --fix --allow-empty-input"],
     "*.{html,md,yml}": ["prettier --single-quote --write --ignore-path .prettierignorerun"]
   },

--- a/package.json
+++ b/package.json
@@ -109,6 +109,10 @@
     "utils:unlink": "yalc remove @eten-tech-foundation/scripture-utilities && npm i --ignore-scripts"
   },
   "lint-staged": {
+    "cspell.json": [
+      "node .erb/scripts/sort-cspell-words.js",
+      "prettier --parser json --write --ignore-path .prettierignorerun"
+    ],
     "*.{cjs,js,jsx,ts,tsx}": ["prettier --write --ignore-path .prettierignorerun"],
     "*.json": ["prettier --parser json --write --ignore-path .prettierignorerun"],
     "*.{css,scss}": ["stylelint --fix --allow-empty-input"],


### PR DESCRIPTION
## Summary

- Adds `.erb/scripts/sort-cspell-words.js` — a Node script that sorts (and deduplicates) the `words` array in `cspell.json` alphabetically in place, preserving JSONC comments elsewhere in the file
- Wires it into `lint-staged` so it runs automatically whenever `cspell.json` is staged for a commit

## Motivation

During review of #2162, Devin caught that three newly added words (`dont`, `lucide`, `saroj`) were grouped together out of alphabetical order rather than inserted at their correct positions. Fixing this manually is error-prone and easy to miss — this hook makes the list self-maintaining.

## Test plan

- [x] Modify `cspell.json` with an out-of-order word, stage it, and run `git commit` — the words array should be sorted automatically before the commit lands
- [x] Confirm JSONC comments in the `overrides` section are preserved after the hook runs
- [x] Confirm duplicate words are removed if accidentally added

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2187)
<!-- Reviewable:end -->