### PR TITLE
docs: add AI-generated shadcn UI customizations reference

### DIFF
--- a/docs/superpowers/plans/2026-04-09-shadcn-customizations-command.md
+++ b/docs/superpowers/plans/2026-04-09-shadcn-customizations-command.md
@@ -1,0 +1,468 @@
+# Shadcn Customizations Command Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a `/shadcn-customizations` command and a `shadcn-customization-tracker` subagent that together analyze all shadcn components in `lib/platform-bible-react/src/components/shadcn-ui/` and produce a `CUSTOMIZATIONS.md` file documenting every customization made relative to the original boilerplate.
+
+**Architecture:** A Claude command file orchestrates parallel dispatch of a reusable agent — one per component file. Each agent reads the current file and its git history to produce a structured customization report. The command aggregates all reports into a single `CUSTOMIZATIONS.md`.
+
+**Tech Stack:** Claude agent/command markdown files, git (`--diff-filter=A`), paranext-core TypeScript/React codebase.
+
+---
+
+## File Map
+
+| File                              | Location                                                                                        | Action                                           |
+| --------------------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `shadcn-customization-tracker.md` | `/home/tj_co/source/repos/ai-prompts/ai-porting/.claude/agents/shadcn-customization-tracker.md` | Create                                           |
+| `shadcn-customizations.md`        | `/home/tj_co/source/repos/ai-prompts/ai-porting/.claude/commands/shadcn-customizations.md`      | Create                                           |
+| `CUSTOMIZATIONS.md`               | `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md` (paranext-core)           | Generated output — committed on a feature branch |
+
+**Note on symlinks:** `.claude/` in paranext-core is a symlink to `/home/tj_co/source/repos/ai-prompts/ai-porting/.claude/`. Write files directly to the ai-prompts path. After writing, verify the symlink is working: `ls /home/tj_co/source/repos/paranext-core/.claude/agents/shadcn-customization-tracker.md` should resolve.
+
+**Note on branching:** Two branches are needed:
+
+- **ai-prompts:** `ai/feature/shadcn-customizations-tj-04-09-2026` — for the agent and command files, PR targeting `ai/main` in `paranext/ai-prompts`
+- **paranext-core:** `ai/feature/shadcn-customizations-tj-04-09-2026` — for `CUSTOMIZATIONS.md`, PR targeting `ai/main` in `paranext/paranext-core`
+
+Never commit directly to `main` in either repo.
+
+---
+
+## Task 1: Create the `shadcn-customization-tracker` agent
+
+**Files:**
+
+- Create: `/home/tj_co/source/repos/ai-prompts/ai-porting/.claude/agents/shadcn-customization-tracker.md`
+
+- [ ] **Step 1: Create a new branch in ai-prompts**
+
+```bash
+cd /home/tj_co/source/repos/ai-prompts/ai-porting
+git fetch origin
+git checkout ai/main
+git pull origin ai/main
+git checkout -b ai/feature/shadcn-customizations-tj-04-09-2026
+```
+
+Expected: new branch created from latest `ai/main`.
+
+- [ ] **Step 2: Write the agent file**
+
+Write `/home/tj_co/source/repos/ai-prompts/ai-porting/.claude/agents/shadcn-customization-tracker.md` with this exact content:
+
+````markdown
+---
+name: shadcn-customization-tracker
+description: 'Analyzes a single shadcn component file in lib/platform-bible-react/src/components/shadcn-ui/ and reports all customizations made relative to the original boilerplate. Returns a structured markdown report for aggregation by the shadcn-customizations command. Input: a single file path relative to the paranext-core repo root.'
+allowed-tools: Bash, Read, Grep
+---
+
+# Shadcn Customization Tracker
+
+You analyze a single shadcn component file and produce a structured markdown report of all customizations made to it relative to the original boilerplate.
+
+## Input
+
+You will be given a single file path relative to the paranext-core repo root (e.g., `lib/platform-bible-react/src/components/shadcn-ui/button.tsx`). The repo root is `/home/tj_co/source/repos/paranext-core` (or resolve via `git rev-parse --show-toplevel` from anywhere inside the repo).
+
+## Algorithm
+
+### Step 1 — Read the current file
+
+Read the full file. As you read:
+
+- Collect every `// CUSTOM:` comment and the code it annotates (the line(s) immediately after)
+- Collect any other comments that clearly indicate customization intent (e.g. "CUSTOM JSDoc comments added", "Changed from X to Y", "Added for accessibility")
+- List every exported symbol (functions, interfaces, constants, types) for the TSDocs check
+- Identify all DOM-rendered components (see criteria below)
+
+**Identifying DOM-rendered components:** A component is DOM-rendered if it produces actual DOM output and could be used standalone. Criteria:
+
+- Prop types include an HTML element type directly: `HTMLDivElement`, `HTMLButtonElement`, `HTMLInputElement`, `HTMLSpanElement`, etc.
+- Prop types use `React.ComponentPropsWithoutRef<typeof SomePrimitive>`, `React.ComponentProps<...>`, or `React.HTMLAttributes<...>` — these wrap an underlying DOM element via a Radix primitive
+- Component is declared with `React.forwardRef<HTMLSomeElement, Props>(...)`
+- When uncertain: look at what the component renders — if it renders an HTML tag or a Radix primitive (`PopoverPrimitive.Content`, `DialogPrimitive.Content`, etc.), it is DOM-rendered
+
+**Not DOM-rendered:** compound root components that coordinate state without a DOM representation (e.g. `Popover`, `Dialog`, `DropdownMenu` roots); cva variant factories like `buttonVariants` (these are functions, not components).
+
+### Step 2 — Get boilerplate diff
+
+Run exactly:
+
+```bash
+REPO_ROOT=$(git -C /home/tj_co/source/repos/paranext-core rev-parse --show-toplevel)
+FILE="<the file path you were given, relative to repo root>"
+FIRST_ADD=$(git -C "$REPO_ROOT" log --diff-filter=A --oneline --follow -- "$FILE" | head -1 | awk '{print $1}')
+echo "Boilerplate baseline commit: $FIRST_ADD"
+git -C "$REPO_ROOT" diff "${FIRST_ADD}..HEAD" -- "$FILE"
+```
+
+**Why `--diff-filter=A | head -1`:** Finds only commits where the file was Added (not modified or renamed). `head -1` takes the most recent add — correct even if the file was deleted and re-added, because the most recent add is the last known boilerplate state.
+
+**Edge case — `$FIRST_ADD` is empty:** The file was introduced in a way git doesn't surface with `--diff-filter=A` (e.g., a squash-merge). Do NOT silently skip. In the Uncalled-out section, write:
+
+> ⚠️ Could not determine boilerplate baseline: no "add" commit found via `git log --diff-filter=A`. Uncalled-out customizations from git history are unavailable for this file.
+
+**Edge case — diff is empty (but `$FIRST_ADD` exists):** The file was added in its already-customized form and hasn't changed since. In the Uncalled-out section, write:
+
+> File appears unchanged since it was added to this repo (diff is empty). Either all customizations were already present at the time of the add commit, or no customizations have been made since.
+
+### Step 3 — Non-shadcn heuristic check
+
+Inspect the boilerplate state:
+
+```bash
+git -C "$REPO_ROOT" show "${FIRST_ADD}:${FILE}" | head -30
+```
+
+Check whether the boilerplate content includes recognizable shadcn patterns: imports from `@radix-ui`, use of `cva`, use of the `cn` utility. If none are present, inspect the commit message (`git -C "$REPO_ROOT" show --no-patch "$FIRST_ADD"`) and the file's overall structure before continuing.
+
+**Known limitation:** This heuristic only catches files that look nothing like shadcn. A custom component that uses the same conventions (radix, cva, cn) will pass the check even if it was never copied from the shadcn boilerplate. The check is a safety net, not a guarantee. If genuinely uncertain, skip with a note rather than produce a potentially misleading analysis.
+
+### Step 4 — Analyze uncalled-out changes
+
+Go through the diff line by line. For each changed section:
+
+1. Determine whether it is already documented by a `// CUSTOM:` comment or another custom-indicating comment in the current file
+2. If not documented: record it as an uncalled-out customization with:
+   - **Where**: which component, which element, prop, or class string
+   - **What**: what changed from the boilerplate to now
+   - **Why**: your best assessment of the purpose (note uncertainty if unsure)
+
+Be thorough. If in doubt about whether something should be listed, list it with a note that you weren't certain.
+
+### Step 5 — Return your report
+
+Return markdown in exactly this structure. Use `(none)` for empty sections, never leave them blank.
+
+```markdown
+## <filename.tsx>
+
+### Standard customizations
+
+- TSDocs: [✅ present on all exports / ❌ missing on: ExportA, ExportB]
+- DOM-rendered components:
+  - `ComponentName` → pr-twp ✅
+  - `OtherComponent` → pr-twp ❌
+  - `VariantFactory` — not DOM-rendered (cva variant factory, not a component)
+  - `RootComponent` — not DOM-rendered (compound root, coordinates state only)
+
+### Explicit `// CUSTOM:` customizations
+
+- **Where:** [exact location — component name, prop, class string, etc.]
+  **What:** [what was changed or added]
+  **Why:** [the explanation from the comment]
+
+### Other comment-indicated customizations
+
+- **Where:** [location]
+  **What:** [what was changed]
+  **Note:** [explanation from the comment]
+
+### Uncalled-out customizations (from git history)
+
+- **Where:** [location]
+  **What:** [what changed from boilerplate to current]
+  **Why:** [your assessment]
+  **Note:** [if uncertain, say so here]
+```
+
+**If you skip the file**, return:
+
+```markdown
+## <filename.tsx>
+
+⚠️ Skipped: [reason — e.g., "boilerplate state contains no shadcn patterns and commit message does not reference shadcn"]
+
+### Standard customizations
+
+⚠️ Skipped — see above
+
+### Explicit `// CUSTOM:` customizations
+
+⚠️ Skipped — see above
+
+### Other comment-indicated customizations
+
+⚠️ Skipped — see above
+
+### Uncalled-out customizations (from git history)
+
+⚠️ Skipped — see above
+```
+````
+
+- [ ] **Step 3: Verify the symlink resolves**
+
+```bash
+ls /home/tj_co/source/repos/paranext-core/.claude/agents/shadcn-customization-tracker.md
+```
+
+Expected: file listed (symlink resolves through to ai-prompts).
+
+- [ ] **Step 4: Commit the agent file**
+
+```bash
+cd /home/tj_co/source/repos/ai-prompts/ai-porting
+git add .claude/agents/shadcn-customization-tracker.md
+git commit -m "feat: add shadcn-customization-tracker agent"
+```
+
+---
+
+## Task 2: Test the agent on `button.tsx`
+
+No automated tests exist for Claude agents — validation is done by running the agent and inspecting output.
+
+- [ ] **Step 1: Dispatch the agent on `button.tsx`**
+
+Using the Agent tool, dispatch `shadcn-customization-tracker` with this prompt:
+
+```
+Analyze this file: lib/platform-bible-react/src/components/shadcn-ui/button.tsx
+```
+
+- [ ] **Step 2: Verify the output structure**
+
+The agent's response must contain:
+
+- `## button.tsx` heading
+- `### Standard customizations` with TSDocs status and DOM-rendered component list
+- `### Explicit // CUSTOM: customizations` section
+- `### Other comment-indicated customizations` section
+- `### Uncalled-out customizations (from git history)` section
+- The git command `git log --diff-filter=A` must have found commit `b96ee0fe3f` as `$FIRST_ADD`
+- The diff must show changes (tw- prefix, pr-twp, TSDocs additions, export keyword changes)
+
+Check against what we know about button.tsx from the brainstorming session:
+
+- TSDocs were added to `buttonVariants`, `ButtonProps`, and `Button`
+- `pr-twp` was added to the base class string in `buttonVariants`
+- Tailwind prefix changed from `pr-` to `tw-`
+- `export` keyword added inline; trailing `export { Button, buttonVariants }` removed
+- `import * as React` changed to `import React`
+- `tw-gap-2` and SVG classes added
+- `buttonVariants` was made exported (was internal in boilerplate)
+
+If output is missing key items or sections are malformed, note the issues and fix the agent file before continuing.
+
+- [ ] **Step 3: Fix agent if needed, re-run**
+
+If Step 2 reveals issues, edit the agent file and re-test until output is correct.
+
+---
+
+## Task 3: Create the `shadcn-customizations` command
+
+**Files:**
+
+- Create: `/home/tj_co/source/repos/ai-prompts/ai-porting/.claude/commands/shadcn-customizations.md`
+
+- [ ] **Step 1: Write the command file**
+
+Write `/home/tj_co/source/repos/ai-prompts/ai-porting/.claude/commands/shadcn-customizations.md` with this exact content:
+
+````markdown
+# Shadcn Customizations
+
+Analyze all shadcn component files in `lib/platform-bible-react/src/components/shadcn-ui/` and write a `CUSTOMIZATIONS.md` documenting every customization made relative to the original boilerplate.
+
+## Steps
+
+### Step 1 — List files
+
+```bash
+ls /home/tj_co/source/repos/paranext-core/lib/platform-bible-react/src/components/shadcn-ui/
+```
+
+Collect all filenames excluding `CUSTOMIZATIONS.md`. These are the files to analyze.
+
+### Step 2 — Dispatch agents in parallel
+
+For every file collected in Step 1, dispatch one `shadcn-customization-tracker` agent. Pass each agent a prompt like:
+
+```
+Analyze this file: lib/platform-bible-react/src/components/shadcn-ui/<filename>
+```
+
+Dispatch ALL agents in a **single message** so they run in parallel. Do not use worktree isolation — agents are read-only.
+
+### Step 3 — Assemble CUSTOMIZATIONS.md
+
+Once all agents return their reports, write `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md` (overwrite if it already exists).
+
+**Document structure:**
+
+#### Disclaimer and h1 heading (exact text)
+
+```
+> This file is AI-generated at specific times for use with updating shadcn components and may not reflect current code. It is retained for ease of reference only.
+
+# Shadcn UI Component Customizations
+```
+
+#### `## Standard Customizations`
+
+Build a single table from the `### Standard customizations` section of every agent report. Sort rows alphabetically by component filename.
+
+| Component | TSDocs on all exports? | DOM-rendered components |
+| --------- | ---------------------- | ----------------------- |
+
+- **TSDocs column:** ✅ if all exports have TSDocs; otherwise list the missing exports (e.g., `❌ missing: ButtonProps`)
+- **DOM-rendered components column:** list each DOM-rendered component with its `pr-twp` status (✅ or ❌). Components the agent identified as not DOM-rendered should NOT appear in this column. For skipped files: `⚠️ skipped — see note below`
+
+#### `## Per-Component Customizations`
+
+For each component (alphabetical order), emit a `### filename.tsx` section containing the agent's three non-standard sections, re-leveled from `###` to `####`:
+
+```markdown
+### filename.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+[content from agent]
+
+#### Other comment-indicated customizations
+
+[content from agent]
+
+#### Uncalled-out customizations (from git history)
+
+[content from agent]
+```
+
+If all three sections are `(none)`, replace with a single line:
+
+> No non-standard customizations.
+
+For skipped files, emit:
+
+```markdown
+### filename.tsx
+
+⚠️ Skipped: [reason from agent report]
+```
+````
+
+- [ ] **Step 2: Verify the symlink resolves**
+
+```bash
+ls /home/tj_co/source/repos/paranext-core/.claude/commands/shadcn-customizations.md
+```
+
+Expected: file listed.
+
+- [ ] **Step 3: Commit the command file**
+
+```bash
+cd /home/tj_co/source/repos/ai-prompts/ai-porting
+git add .claude/commands/shadcn-customizations.md
+git commit -m "feat: add shadcn-customizations command"
+```
+
+---
+
+## Task 4: Run the full command and produce CUSTOMIZATIONS.md
+
+- [ ] **Step 1: Run `/shadcn-customizations`**
+
+Invoke the `shadcn-customizations` command (either via the Skill tool or by following its instructions directly). This dispatches ~31 agents in parallel.
+
+- [ ] **Step 2: Verify CUSTOMIZATIONS.md structure**
+
+Check that the generated file at `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md`:
+
+- Starts with the disclaimer blockquote
+- Has a `## Standard Customizations` table with one row per component
+- Has a `## Per-Component Customizations` section with `### filename.tsx` entries sorted alphabetically
+- Each component entry uses `####` subheadings
+- Components with no non-standard customizations say "No non-standard customizations."
+- Any skipped files have a note in both sections
+
+Spot-check `button.tsx` and `popover.tsx` entries for accuracy against what we know.
+
+- [ ] **Step 3: Create a feature branch in paranext-core and commit CUSTOMIZATIONS.md**
+
+```bash
+cd /home/tj_co/source/repos/paranext-core
+git fetch origin
+git checkout ai/main
+git pull origin ai/main
+git checkout -b ai/feature/shadcn-customizations-tj-04-09-2026
+git add lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md
+git commit -m "docs: add AI-generated shadcn UI customizations reference"
+```
+
+---
+
+## Task 5: Open PR for agent and command in ai-prompts
+
+- [ ] **Step 1: Push the ai-prompts branch**
+
+```bash
+cd /home/tj_co/source/repos/ai-prompts/ai-porting
+git push -u origin ai/feature/shadcn-customizations-tj-04-09-2026
+```
+
+- [ ] **Step 2: Open PR targeting `ai/main` in `paranext/ai-prompts`**
+
+```bash
+cd /home/tj_co/source/repos/ai-prompts/ai-porting
+gh pr create \
+  --repo paranext/ai-prompts \
+  --base ai/main \
+  --head ai/feature/shadcn-customizations-tj-04-09-2026 \
+  --title "feat: add shadcn-customizations command and tracker agent" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `shadcn-customization-tracker` agent: analyzes a single shadcn component file and reports all customizations relative to the original boilerplate (explicit `// CUSTOM:` comments, other comments, and uncalled-out git-history changes)
+- Adds `shadcn-customizations` command: dispatches tracker agents in parallel for all files in `lib/platform-bible-react/src/components/shadcn-ui/` and aggregates into `CUSTOMIZATIONS.md`
+- Design spec: `docs/superpowers/specs/2026-04-09-shadcn-customizations-command-design.md`
+
+## Test plan
+
+- [ ] Agent tested manually on `button.tsx` — output verified against known customizations
+- [ ] Full command run against all 31 component files — `CUSTOMIZATIONS.md` produced and spot-checked
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Task 6: Open PR for CUSTOMIZATIONS.md in paranext-core
+
+- [ ] **Step 1: Push the paranext-core branch**
+
+```bash
+cd /home/tj_co/source/repos/paranext-core
+git push -u origin ai/feature/shadcn-customizations-tj-04-09-2026
+```
+
+- [ ] **Step 2: Open PR targeting `ai/main` in `paranext/paranext-core`**
+
+```bash
+cd /home/tj_co/source/repos/paranext-core
+gh pr create \
+  --repo paranext/paranext-core \
+  --base ai/main \
+  --head ai/feature/shadcn-customizations-tj-04-09-2026 \
+  --title "docs: add AI-generated shadcn UI customizations reference" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Adds `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md`: AI-generated snapshot of all customizations made to shadcn components relative to their original boilerplate, for use when upgrading to a new shadcn version
+- Generated by the `/shadcn-customizations` command (see ai-prompts PR for the command and agent)
+
+## Test plan
+
+- [ ] Spot-checked `button.tsx` and `popover.tsx` entries for accuracy
+- [ ] All 31 component files have entries in the Standard Customizations table
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-04-09-shadcn-customizations-command-design.md
+++ b/docs/superpowers/specs/2026-04-09-shadcn-customizations-command-design.md
@@ -1,0 +1,144 @@
+# Design: shadcn-customizations Command
+
+**Date:** 2026-04-09
+**Status:** Approved
+
+## Problem
+
+`lib/platform-bible-react/src/components/shadcn-ui/` contains shadcn component files that were copied from the shadcn boilerplate at various points in time and later customized in this repo. When upgrading to a new shadcn boilerplate in the future, there is no single place to look up what customizations need to be re-applied. This command creates that reference.
+
+## Goal
+
+A slash command that produces `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md` — a single document recording all customizations made to all shadcn components in this repo, organized to make re-applying them to a new boilerplate as straightforward as possible.
+
+## Deliverables
+
+1. **Command:** `.claude/commands/shadcn-customizations.md` (saved in the ai-prompts repo, symlinked into paranext-core)
+2. **Agent:** `.claude/agents/shadcn-customization-tracker.md` (same repo/symlink)
+3. **Output:** `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md` (in paranext-core)
+
+## Architecture
+
+**Option chosen: Command + standalone reusable subagent (Option A)**
+
+The command orchestrates; the agent does the per-file analysis. Agents run in parallel since they are read-only and don't need worktree isolation.
+
+## Command Design
+
+**File:** `.claude/commands/shadcn-customizations.md`
+
+### Steps
+
+1. List all files in `lib/platform-bible-react/src/components/shadcn-ui/` excluding `CUSTOMIZATIONS.md` itself
+2. Dispatch one `shadcn-customization-tracker` agent per file **in parallel** (no worktree isolation — agents are read-only)
+3. Collect all per-file reports
+4. Write `CUSTOMIZATIONS.md` (overwrite on each run)
+
+### CUSTOMIZATIONS.md Structure
+
+```
+> This file is AI-generated at specific times for use with updating shadcn components
+> and may not reflect current code. It is retained for ease of reference only.
+
+# Shadcn UI Component Customizations
+
+## Standard Customizations
+
+[Table covering all components:]
+| Component | TSDocs on all exports? | DOM-rendered components with pr-twp |
+|-----------|------------------------|--------------------------------------|
+| button.tsx | ✅ | Button ✅ |
+| popover.tsx | ✅ | PopoverContent ✅, Popover ❌ (not DOM-rendered) |
+...
+
+## Per-Component Customizations
+
+### button.tsx
+
+#### Explicit `// CUSTOM:` customizations
+...
+
+#### Other comment-indicated customizations
+...
+
+#### Uncalled-out customizations (from git history)
+...
+
+### popover.tsx
+...
+```
+
+Components with no non-standard customizations get a brief note: "No non-standard customizations."
+
+## Subagent Design
+
+**File:** `.claude/agents/shadcn-customization-tracker.md`
+**Tools:** `Bash`, `Read`, `Grep`
+**Input:** Single file path relative to repo root
+
+### Algorithm
+
+**Step 1 — Read current file**
+
+- Extract all `// CUSTOM:` comments with surrounding context
+- Extract any other comments that indicate customization intent
+- Identify all exported members (for TSDocs check)
+- Identify all DOM-rendered components (look for components whose prop types include HTML element types like `HTMLDivElement`, `HTMLButtonElement`, etc.)
+
+**Step 2 — Get boilerplate diff**
+
+```bash
+FIRST_ADD=$(git log --diff-filter=A --oneline --follow -- <file> | head -1 | awk '{print $1}')
+git diff ${FIRST_ADD}..HEAD -- <file>
+```
+
+The `--diff-filter=A` flag finds commits where the file was added (not just modified), and `head -1` selects the most recent such commit — correct even if the file was deleted and re-added.
+
+**Step 3 — Non-shadcn heuristic check**
+If the boilerplate state (content at `$FIRST_ADD`) shows no recognizable shadcn patterns (no radix-ui imports, no `cva`, no `cn` utility, no `@radix-ui` or similar), flag the file as possibly not a shadcn component and inspect the commit message and file structure more carefully. If genuinely uncertain after checking, skip with a note in the report.
+
+**Step 4 — Analyze diff for uncalled-out changes**
+Cross-reference changes found in the diff against the two comment-based lists. Only include changes in the "uncalled-out" list that are not already documented by a comment.
+
+**Step 5 — Return structured markdown report**
+
+### Output Format (per agent)
+
+```markdown
+## button.tsx
+
+### Standard customizations
+
+- TSDocs: [present on all exports / missing on: X, Y]
+- DOM-rendered components:
+  - Button: pr-twp ✅
+  - (buttonVariants is not DOM-rendered)
+
+### Explicit `// CUSTOM:` customizations
+
+- **Where:** `buttonVariants` base class string
+  **What:** Added `pr-twp` class
+  **Why:** Scoped preflight must apply to all rendered content
+
+### Other comment-indicated customizations
+
+(none)
+
+### Uncalled-out customizations (from git history)
+
+- **Where:** Import statement
+  **What:** Changed `import * as React from 'react'` → `import React from 'react'`
+  **Why:** Likely code style standardization (default import preferred)
+  **Note:** Uncertain — may be auto-applied by linter/formatter
+```
+
+## Key Design Decisions
+
+| Decision                                         | Rationale                                                                                                       |
+| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
+| Parallel agents, no worktree                     | Agents are read-only; worktrees would waste disk space unnecessarily                                            |
+| Most recent add commit for diff base             | Files may be deleted and re-added; `--diff-filter=A \| head -1` correctly identifies the last boilerplate state |
+| Standard customizations in one shared section    | Enables a single-glance audit of TSDocs and `pr-twp` coverage across all components                             |
+| Per-component sections for other customizations  | Makes it easy to look up "what changed in table.tsx?"                                                           |
+| Overwrite on each run                            | CUSTOMIZATIONS.md is a snapshot, not a changelog; the disclaimer communicates this                              |
+| Non-shadcn heuristic with skip-and-note fallback | Prevents false analysis when a file in the directory happens not to be a shadcn component                       |

--- a/docs/superpowers/specs/2026-04-09-shadcn-customizations-command-design.md
+++ b/docs/superpowers/specs/2026-04-09-shadcn-customizations-command-design.md
@@ -32,7 +32,24 @@ The command orchestrates; the agent does the per-file analysis. Agents run in pa
 1. List all files in `lib/platform-bible-react/src/components/shadcn-ui/` excluding `CUSTOMIZATIONS.md` itself
 2. Dispatch one `shadcn-customization-tracker` agent per file **in parallel** (no worktree isolation — agents are read-only)
 3. Collect all per-file reports
-4. Write `CUSTOMIZATIONS.md` (overwrite on each run)
+4. Assemble and write `CUSTOMIZATIONS.md` (overwrite on each run)
+
+### Assembling CUSTOMIZATIONS.md from per-file reports
+
+Each agent returns a structured markdown report with these sections:
+
+- `### Standard customizations` — a narrative block with TSDocs status and DOM-rendered component list
+- `### Explicit // CUSTOM: customizations`
+- `### Other comment-indicated customizations`
+- `### Uncalled-out customizations (from git history)`
+
+The command transforms these into the final document as follows:
+
+**Standard Customizations table:** Extract the standard customizations narrative from every agent report and collapse all of them into a single shared table at the top of CUSTOMIZATIONS.md. Each row represents one component file. The table columns are: Component, TSDocs on all exports?, DOM-rendered components (with pr-twp status per component).
+
+**Per-Component sections:** For each file's remaining three sections (explicit `// CUSTOM:`, other comment-indicated, uncalled-out), emit them under a `### filename.tsx` heading inside a `## Per-Component Customizations` section. The heading levels are re-leveled: agent uses `###` for subsections, final doc uses `####`.
+
+**Skipped files:** If an agent skips a file (non-shadcn determination), include a note in both the Standard Customizations table and the Per-Component Customizations section.
 
 ### CUSTOMIZATIONS.md Structure
 
@@ -44,11 +61,11 @@ The command orchestrates; the agent does the per-file analysis. Agents run in pa
 
 ## Standard Customizations
 
-[Table covering all components:]
-| Component | TSDocs on all exports? | DOM-rendered components with pr-twp |
-|-----------|------------------------|--------------------------------------|
+| Component | TSDocs on all exports? | DOM-rendered components |
+|-----------|------------------------|-------------------------|
 | button.tsx | ✅ | Button ✅ |
-| popover.tsx | ✅ | PopoverContent ✅, Popover ❌ (not DOM-rendered) |
+| popover.tsx | ✅ | PopoverContent ✅ |
+| sidebar.tsx | ⚠️ skipped — see note | ⚠️ skipped — see note |
 ...
 
 ## Per-Component Customizations
@@ -66,6 +83,10 @@ The command orchestrates; the agent does the per-file analysis. Agents run in pa
 
 ### popover.tsx
 ...
+
+### sidebar.tsx
+
+⚠️ Skipped: [reason why agent determined this may not be a standard shadcn component]
 ```
 
 Components with no non-standard customizations get a brief note: "No non-standard customizations."
@@ -83,26 +104,43 @@ Components with no non-standard customizations get a brief note: "No non-standar
 - Extract all `// CUSTOM:` comments with surrounding context
 - Extract any other comments that indicate customization intent
 - Identify all exported members (for TSDocs check)
-- Identify all DOM-rendered components (look for components whose prop types include HTML element types like `HTMLDivElement`, `HTMLButtonElement`, etc.)
+- Identify all DOM-rendered components — look for components that produce actual DOM output. Detection patterns:
+  - Prop types include HTML element types: `HTMLDivElement`, `HTMLButtonElement`, `HTMLInputElement`, etc.
+  - Prop types use `React.ComponentPropsWithoutRef<typeof SomePrimitive>`, `React.ComponentProps<...>`, or `React.HTMLAttributes<...>` — these wrap an underlying DOM element
+  - Component uses `React.forwardRef` with an HTML element ref type
+  - When unsure, look at what the component renders: if it renders an HTML tag or a Radix primitive that itself maps to a DOM element, it is DOM-rendered
 
 **Step 2 — Get boilerplate diff**
 
 ```bash
 FIRST_ADD=$(git log --diff-filter=A --oneline --follow -- <file> | head -1 | awk '{print $1}')
+```
+
+`--diff-filter=A` finds only commits where the file was Added (not modified). `head -1` takes the most recent such commit, which is correct even when a file has been deleted and re-added — the most recent add is the last known boilerplate state, which is the right diff base.
+
+**Edge case — no add commit found:** If `$FIRST_ADD` is empty (e.g., the file was introduced via a squash-merge that git doesn't surface with `--diff-filter=A`), the agent must not silently produce an empty diff. Instead, report in the "Uncalled-out customizations" section: "⚠️ Could not determine boilerplate baseline: no add commit found via `git log --diff-filter=A`. Uncalled-out customizations from git history are unavailable for this file."
+
+**Edge case — diff is empty:** If `$FIRST_ADD` is found but `git diff ${FIRST_ADD}..HEAD -- <file>` produces no output, it means the file was added in its already-customized form and has not changed since. Report: "File appears unchanged since it was added. Either all customizations were present at add time, or no customizations have been made."
+
+```bash
 git diff ${FIRST_ADD}..HEAD -- <file>
 ```
 
-The `--diff-filter=A` flag finds commits where the file was added (not just modified), and `head -1` selects the most recent such commit — correct even if the file was deleted and re-added.
-
 **Step 3 — Non-shadcn heuristic check**
-If the boilerplate state (content at `$FIRST_ADD`) shows no recognizable shadcn patterns (no radix-ui imports, no `cva`, no `cn` utility, no `@radix-ui` or similar), flag the file as possibly not a shadcn component and inspect the commit message and file structure more carefully. If genuinely uncertain after checking, skip with a note in the report.
+
+Check the boilerplate state (`git show ${FIRST_ADD}:<file>`) for recognizable shadcn patterns: imports from `@radix-ui`, use of `cva`, use of the `cn` utility, etc. If none are present, the file may not be a standard shadcn component — inspect the commit message and file structure more carefully before proceeding.
+
+**Important limitation:** This heuristic only catches files that look nothing like shadcn. Custom components that follow the same conventions (radix imports, cva, cn) will pass the check even if they were not copied from the boilerplate. This is a known limitation; the check is a safety net, not a guarantee. If genuinely uncertain after checking, skip with a note in the report rather than produce a potentially misleading analysis.
 
 **Step 4 — Analyze diff for uncalled-out changes**
+
 Cross-reference changes found in the diff against the two comment-based lists. Only include changes in the "uncalled-out" list that are not already documented by a comment.
 
 **Step 5 — Return structured markdown report**
 
 ### Output Format (per agent)
+
+The agent returns markdown with this structure (heading levels use `###` for sections, `####` not used at this level):
 
 ```markdown
 ## button.tsx
@@ -111,8 +149,8 @@ Cross-reference changes found in the diff against the two comment-based lists. O
 
 - TSDocs: [present on all exports / missing on: X, Y]
 - DOM-rendered components:
-  - Button: pr-twp ✅
-  - (buttonVariants is not DOM-rendered)
+  - `Button` → pr-twp ✅
+  - `buttonVariants` — not DOM-rendered (it is a cva variant factory, not a component)
 
 ### Explicit `// CUSTOM:` customizations
 
@@ -134,11 +172,14 @@ Cross-reference changes found in the diff against the two comment-based lists. O
 
 ## Key Design Decisions
 
-| Decision                                         | Rationale                                                                                                       |
-| ------------------------------------------------ | --------------------------------------------------------------------------------------------------------------- |
-| Parallel agents, no worktree                     | Agents are read-only; worktrees would waste disk space unnecessarily                                            |
-| Most recent add commit for diff base             | Files may be deleted and re-added; `--diff-filter=A \| head -1` correctly identifies the last boilerplate state |
-| Standard customizations in one shared section    | Enables a single-glance audit of TSDocs and `pr-twp` coverage across all components                             |
-| Per-component sections for other customizations  | Makes it easy to look up "what changed in table.tsx?"                                                           |
-| Overwrite on each run                            | CUSTOMIZATIONS.md is a snapshot, not a changelog; the disclaimer communicates this                              |
-| Non-shadcn heuristic with skip-and-note fallback | Prevents false analysis when a file in the directory happens not to be a shadcn component                       |
+| Decision                                                 | Rationale                                                                                                                                                                       |
+| -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Parallel agents, no worktree                             | Agents are read-only; worktrees would waste disk space unnecessarily                                                                                                            |
+| Most recent add commit for diff base                     | Files may be deleted and re-added; `--diff-filter=A \| head -1` selects the last boilerplate state, which is the correct diff base                                              |
+| Explicit empty-diff and no-add-commit handling           | Prevents silently missing customizations in edge cases                                                                                                                          |
+| Standard customizations in one shared section            | Enables a single-glance audit of TSDocs and `pr-twp` coverage across all components                                                                                             |
+| Per-component sections for other customizations          | Makes it easy to look up "what changed in table.tsx?"                                                                                                                           |
+| Command re-levels headings when assembling               | Agent uses `###` sections for its own output; the final doc promotes these to `####` under `### filename.tsx`                                                                   |
+| Overwrite on each run                                    | CUSTOMIZATIONS.md is a snapshot, not a changelog; the disclaimer communicates this                                                                                              |
+| Non-shadcn heuristic with skip-and-note fallback         | Prevents false analysis when a file in the directory happens not to be a shadcn component; limitation (custom shadcn-patterned files pass) is acknowledged                      |
+| DOM-rendered detection includes ComponentPropsWithoutRef | Many shadcn components wrap Radix primitives without direct HTML type references; checking forwardRef and ComponentPropsWithoutRef patterns is necessary for accurate detection |

--- a/lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md
+++ b/lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md
@@ -1,0 +1,1084 @@
+> This file is AI-generated at specific times for use with updating shadcn components and may not reflect current code. It is retained for ease of reference only.
+
+# Shadcn UI Component Customizations
+
+## Standard Customizations
+
+| Component | TSDocs on all exports? | DOM-rendered components |
+| --------- | ---------------------- | ----------------------- |
+| alert.tsx | ✅ | Alert ✅, AlertTitle ❌, AlertDescription ❌ |
+| avatar.tsx | ✅ | Avatar ✅, AvatarImage ✅, AvatarFallback ✅ |
+| badge.tsx | ✅ | Badge ✅ |
+| button-group.tsx | ❌ missing on: ButtonGroup, ButtonGroupText, ButtonGroupSeparator, buttonGroupVariants | ButtonGroup ✅, ButtonGroupText ❌, ButtonGroupSeparator ❌ |
+| button.tsx | ✅ | Button ✅ |
+| card.tsx | ✅ | Card ✅, CardHeader ✅, CardTitle ✅, CardDescription ✅, CardContent ✅, CardFooter ✅ |
+| checkbox.tsx | ✅ | Checkbox ✅ |
+| command.tsx | ✅ | Command ❌, CommandInput ❌, CommandList ❌, CommandEmpty ❌, CommandGroup ❌, CommandItem ❌, CommandShortcut ❌, CommandSeparator ❌ |
+| context-menu.tsx | ✅ | ContextMenuSubTrigger ✅, ContextMenuSubContent ✅, ContextMenuContent ✅, ContextMenuItem ✅, ContextMenuCheckboxItem ❌, ContextMenuRadioItem ❌, ContextMenuLabel ❌, ContextMenuSeparator ❌, ContextMenuShortcut ❌ |
+| dialog.tsx | ✅ | DialogOverlay ❌, DialogContent ✅, DialogHeader ❌, DialogFooter ❌, DialogTitle ❌, DialogDescription ❌ |
+| drawer.tsx | ✅ | DrawerOverlay ❌, DrawerContent ✅, DrawerHeader ❌, DrawerFooter ❌, DrawerTitle ❌, DrawerDescription ❌ |
+| dropdown-menu.tsx | ✅ | DropdownMenuSubTrigger ❌, DropdownMenuSubContent ✅, DropdownMenuContent ✅, DropdownMenuItem ❌, DropdownMenuCheckboxItem ❌, DropdownMenuRadioItem ❌, DropdownMenuLabel ❌, DropdownMenuSeparator ❌, DropdownMenuShortcut ❌ |
+| input.tsx | ✅ | Input ✅ |
+| label.tsx | ✅ | Label ✅ |
+| menubar.tsx | ❌ missing on all exports | Menubar ❌, MenubarTrigger ✅, MenubarSubTrigger ❌, MenubarSubContent ❌, MenubarContent ✅, MenubarItem ❌, MenubarCheckboxItem ❌, MenubarRadioItem ❌, MenubarLabel ❌, MenubarSeparator ❌, MenubarShortcut ❌ |
+| popover.tsx | ✅ | PopoverContent ✅ |
+| progress.tsx | ✅ | Progress ✅ |
+| radio-group.tsx | ✅ | RadioGroup ✅, RadioGroupItem ✅ |
+| resizable.tsx | ✅ | ResizablePanelGroup ❌, ResizableHandle ❌ |
+| select.tsx | ✅ | SelectTrigger ❌, SelectContent ✅, SelectLabel ❌, SelectItem ❌, SelectSeparator ❌, SelectScrollUpButton ❌, SelectScrollDownButton ❌ |
+| separator.tsx | ✅ | Separator ✅ |
+| sidebar.tsx | ✅ | SidebarProvider ✅, Sidebar ❌, SidebarTrigger ❌, SidebarRail ❌, SidebarInset ❌, SidebarInput ❌, SidebarHeader ❌, SidebarFooter ❌, SidebarSeparator ❌, SidebarContent ❌, SidebarGroup ❌, SidebarGroupLabel ❌, SidebarGroupAction ❌, SidebarGroupContent ❌, SidebarMenu ❌, SidebarMenuItem ❌, SidebarMenuButton ❌, SidebarMenuAction ❌, SidebarMenuBadge ❌, SidebarMenuSkeleton ❌, SidebarMenuSub ❌, SidebarMenuSubItem ❌, SidebarMenuSubButton ❌ |
+| skeleton.tsx | ✅ | Skeleton ✅ |
+| slider.tsx | ✅ | Slider ✅ |
+| sonner.tsx | ✅ | Sonner ❌ |
+| switch.tsx | ✅ | Switch ✅ |
+| table.tsx | ✅ | Table ✅, TableHeader ❌, TableBody ❌, TableFooter ❌, TableRow ❌, TableHead ❌, TableCell ❌, TableCaption ❌ |
+| tabs.tsx | ✅ | TabsList ✅, TabsTrigger ✅, TabsContent ✅ |
+| textarea.tsx | ✅ | Textarea ✅ |
+| toggle-group.tsx | ✅ | ToggleGroup ✅, ToggleGroupItem ❌ |
+| toggle.tsx | ❌ missing on: Toggle, toggleVariants | Toggle ✅ |
+| tooltip.tsx | ✅ | TooltipTrigger ❌, TooltipContent ✅ |
+
+## Per-Component Customizations
+
+### alert.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+- **Where:** `alertVariants` cva base string and destructive variant
+  **What:** Added `[&>img~*]:tw-pl-7 [&>img+div]:tw-translate-y-[-3px] [&>img]:tw-absolute [&>img]:tw-left-4 [&>img]:tw-top-4 [&>img]:tw-text-foreground` to base, and `[&>img]:tw-text-destructive` to destructive variant
+  **Why:** Copied all svg arbitrary selector variant classes as img variants so images (or svgs from file) can be used as icons. Implemented by TJ Couch, approved by Alex Mercado, 20 February 2025.
+
+- **Where:** `Alert` component className
+  **What:** Added `'pr-twp'`
+  **Why:** Tailwind prefix scoping (comment: `// CUSTOM`)
+
+#### Other comment-indicated customizations
+
+- **Where:** `AlertTitle` render output
+  **What:** Renders `{props.children}{' '}` explicitly (trailing space)
+  **Note:** Added because of JSX a11y heading-has-content rule (comment references the ESLint rule URL)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `alertVariants` cva class strings
+  **What:** Tailwind prefix changed from `pr-` to `tw-` throughout
+  **Why:** Project-wide prefix migration
+
+- **Where:** All component JSDoc
+  **What:** Added JSDoc comments (`/** The Alert displays... */`, `/** @inheritdoc Alert */`)
+  **Why:** Documentation standard
+
+---
+
+### avatar.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** All components
+  **What:** Added JSDoc comments
+  **Why:** Documentation standard
+
+- **Where:** `AvatarImage` className
+  **What:** `pr-twp` was added (not in shadcn boilerplate)
+  **Why:** Tailwind prefix scoping — typically only the root needs it, but this was applied to each sub-component
+
+---
+
+### badge.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `badgeVariants` cva base string
+  **What:** Added `pr-twp`
+  **Why:** Tailwind prefix scoping
+
+- **Where:** `badgeVariants` variants
+  **What:** Added `tw-border` to default, secondary, and destructive variants (boilerplate had `tw-border-transparent` without explicit `tw-border`)
+  **Why:** Explicit border rendering fix
+
+- **Where:** `badgeVariants` variants
+  **What:** Added new variants: `muted`, `blueIndicator`, `mutedIndicator`, `ghost`. Note: `ghost` variant appears to have a truncated class (`tw-text-mu` — possibly incomplete)
+  **Why:** Application-specific design needs
+
+- **Where:** `Badge` component
+  **What:** Converted from plain function to `React.forwardRef` with ref support; added `displayName`
+  **Why:** Consistency with other components; ref forwarding support
+
+- **Where:** `Badge` component className
+  **What:** `pr-twp` explicitly added to the div (in addition to it being in the cva base string)
+  **Why:** Belt-and-suspenders scoping; uncertain if intentional duplication
+
+---
+
+### button-group.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- File appears to have been added in its current form (diff from boilerplate commit to HEAD is empty). This may not be a standard shadcn component copied from a boilerplate — shadcn does not ship a ButtonGroup component. It uses `@radix-ui/react-slot` and `cva` following shadcn conventions. All customizations (if any) were present at the time the file was added to this repo.
+
+---
+
+### button.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `buttonVariants` cva base string
+  **What:** Added `pr-twp`, `tw-gap-2`, `[&_svg]:tw-pointer-events-none [&_svg]:tw-size-4 [&_svg]:tw-shrink-0`
+  **Why:** `pr-twp` for prefix scoping; gap and svg utilities are from newer shadcn versions or custom additions
+
+- **Where:** All Tailwind class strings
+  **What:** Changed from `pr-` prefix to `tw-` prefix throughout
+  **Why:** Project-wide prefix migration
+
+- **Where:** Import statement
+  **What:** Changed `import * as React from "react"` to `import React from 'react'`
+  **Why:** Import style standardization
+
+- **Where:** Exports
+  **What:** Changed from `export { Button, buttonVariants }` at bottom to inline `export const` on each declaration
+  **Why:** Export style preference
+
+---
+
+### card.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+- **Where:** `CardTitle` render output
+  **What:** Renders `{props.children}` explicitly
+  **Note:** Added because of JSX a11y heading-has-content rule (comment references the ESLint rule URL)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** All components
+  **What:** Added `pr-twp` to each component's className (not in shadcn boilerplate)
+  **Why:** Tailwind prefix scoping
+
+- **Where:** All Tailwind class strings
+  **What:** Prefix migrated from `pr-` to `tw-`
+  **Why:** Project-wide prefix migration
+
+- **Where:** All components
+  **What:** Added JSDoc comments
+  **Why:** Documentation standard
+
+---
+
+### checkbox.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** Root element className
+  **What:** Added `pr-twp`
+  **Why:** Tailwind prefix scoping
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+- **Where:** Import statement
+  **What:** Changed `import * as React` to `import React`
+  **Why:** Import style standardization
+
+- **Where:** Exports
+  **What:** Changed to `export const` and added `export default Checkbox`
+  **Why:** Export style preference
+
+---
+
+### command.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `CommandInput` wrapper div
+  **What:** Added `readDirection()` call and `dir={dir}` prop; changed `tw-mr-2` to `tw-me-2`
+  **Why:** RTL/bidirectional text support
+
+- **Where:** `CommandShortcut`
+  **What:** Changed `tw-ml-auto` to `tw-ms-auto`
+  **Why:** RTL support (logical property)
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+- **Where:** All components
+  **What:** Added JSDoc comments
+  **Why:** Documentation standard
+
+---
+
+### context-menu.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- File appears unchanged since it was added to this repo (diff is empty). Either all customizations were already present at the time of the add commit, or no customizations have been made since.
+
+---
+
+### dialog.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+- **Where:** File-level comment
+  **What:** `// CUSTOM JSDoc comments added to all components for documentation`
+  **Why:** Documentation standard — all JSDoc was intentionally added as a customization
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `DialogContent`
+  **What:** Added `readDirection()` and `dir={dir}` prop on `DialogPrimitive.Content`
+  **Why:** RTL support
+
+- **Where:** `DialogContent` close button
+  **What:** Close button position is now dynamic: `tw-right-4` for LTR, `tw-left-4` for RTL (boilerplate had hardcoded `tw-right-4`)
+  **Why:** RTL support
+
+- **Where:** `DialogHeader`
+  **What:** Changed `sm:tw-text-left` to `sm:tw-text-start`
+  **Why:** RTL support (logical property)
+
+- **Where:** `DialogOverlay`
+  **What:** Fixed broken class `pr-` (empty prefix artifact) that existed in boilerplate
+  **Why:** Bug fix
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+---
+
+### drawer.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+- **Where:** `DrawerContext` creation (top of file)
+  **What:** Added `DrawerContext` to manage drawer direction
+  **Why:** Propagates direction to child components
+
+- **Where:** `Drawer` component
+  **What:** Uses `DrawerContext` to provide direction to child components
+  **Why:** Direction-aware rendering
+
+- **Where:** `DrawerContentProps` interface
+  **What:** Extended `DrawerPrimitive.Content` props with additional `hideDrawerHandle` prop
+  **Why:** Allows consumers to hide the drag handle
+
+- **Where:** `DrawerContent` internal logic
+  **What:** `directionStyles` object maps direction to position classes; `handleStyles` object maps direction to handle position classes
+  **Why:** Direction-aware styling for different drawer positions
+
+- **Where:** `DrawerContent` className
+  **What:** Removed hardcoded bottom-only classes; added direction-aware `flex-col`/`flex-row`
+  **Why:** Support for drawers on all four sides
+
+- **Where:** `DrawerContent` render
+  **What:** Conditional handle rendering based on `direction` and `hideDrawerHandle` prop
+  **Why:** Direction-aware handle position and optional hiding
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `DrawerContent`
+  **What:** Added `hideDrawerHandle` prop (extends original API)
+  **Why:** Allows consumers to hide the drag handle
+
+- **Where:** All sub-component JSDoc
+  **What:** Added `@inheritdoc Drawer` comments
+  **Why:** Documentation standard
+
+---
+
+### dropdown-menu.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+- **Where:** `DropdownMenuProps` type
+  **What:** Added `variant` prop to support different styles
+  **Why:** Application-specific menu variant system
+
+- **Where:** `DropdownMenu` component
+  **What:** Wraps `DropdownMenuPrimitive.Root` with `MenuContext.Provider` to propagate variant
+  **Why:** Provides context to add variants to child items
+
+- **Where:** `DropdownMenuSubTrigger`, `DropdownMenuItem`, `DropdownMenuCheckboxItem`, `DropdownMenuRadioItem`
+  **What:** Use `useMenuContext()` and `menuVariants()` for variant-aware styling
+  **Why:** Context-driven variant application
+
+- **Where:** `DropdownMenuCheckboxItem`, `DropdownMenuRadioItem`
+  **What:** Added `dir={dir}` from `readDirection()`
+  **Why:** RTL support
+
+- **Where:** `DropdownMenuSubContent`
+  **What:** Wraps children in `<div dir={dir}>`
+  **Why:** RTL support
+
+- **Where:** `DropdownMenuContent`
+  **What:** Added `pr-twp` with comment: "adding pr-twp because the dropdown content is added to the dom as a sibling to the app root"
+  **Why:** Tailwind prefix scoping (content is portaled outside normal DOM tree)
+
+#### Other comment-indicated customizations
+
+- **Where:** `DropdownMenuContent`
+  **What:** TODO comment documents a known limitation: does not support `dir` prop for RTL scrollbar positioning
+  **Note:** Known shadcn bug; RTL scrollbar positioning not supported
+
+- **Where:** `DropdownMenuItem`
+  **What:** Comment: `// removed: tw-relative focus:tw-text-accent-foreground`
+  **Note:** Documents deliberately removed classes
+
+- **Where:** `DropdownMenuShortcut`
+  **What:** `eslint-disable` comment: "Shadcn UI pattern: spreading props onto the element is necessary to forward all HTML attributes"
+  **Note:** Intentional props spread pattern
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** Imports and new utilities
+  **What:** Added `MenuContext`, `MenuContextProps`, `menuVariants`, `useMenuContext` from `@/context/menu.context`; added `readDirection` from `@/utils/dir-helper.util`
+  **Why:** Variant system and RTL support
+
+- **Where:** All prop type exports
+  **What:** Explicit prop type interfaces exported (`DropdownMenuSubTriggerProps`, `DropdownMenuSubContentProps`, `DropdownMenuContentProps`, `DropdownMenuItemProps`, `DropdownMenuCheckboxItemProps`, `DropdownMenuRadioItemProps`, `DropdownMenuLabelProps`, `DropdownMenuSeparatorProps`, `DropdownMenuShortcutProps`). Boilerplate used inline types.
+  **Why:** Reusability and documentation
+
+- **Where:** `DropdownMenuCheckboxItem`, `DropdownMenuRadioItem` class strings
+  **What:** Changed `tw-pl-8 tw-pr-2` to `tw-pe-2 tw-ps-8`; indicator span uses `ltr:tw-left-2 rtl:tw-right-2`
+  **Why:** RTL support (logical properties)
+
+- **Where:** `DropdownMenuShortcut`
+  **What:** Changed `tw-ml-auto` to `tw-ms-auto`
+  **Why:** RTL support (logical property)
+
+- **Where:** Exports
+  **What:** Changed from bottom `export { ... }` to inline `export` on each declaration
+  **Why:** Export style preference
+
+- **Where:** File-level eslint directive
+  **What:** Removed `/* eslint-disable react/prop-types */`
+  **Why:** No longer needed
+
+---
+
+### input.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+- **Where:** `Input` component props spread
+  **What:** `eslint-disable` comment: "Shadcn UI pattern: spreading props onto the element is necessary to forward all HTML attributes"
+  **Note:** Intentional props spread pattern
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `Input` className
+  **What:** Added `pr-twp`; removed `tw-w-full` (input is no longer full-width by default); added `file:tw-text-foreground`
+  **Why:** Prefix scoping and styling adjustments
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+- **Where:** Import statement
+  **What:** Changed `import * as React` to `import React`
+  **Why:** Import style standardization
+
+- **Where:** Exports
+  **What:** Changed from `export { Input }` to `export const Input`
+  **Why:** Export style preference
+
+---
+
+### label.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `Label` className
+  **What:** Added `'pr-twp'` as first argument to `cn()` (boilerplate had `cn(labelVariants(), className)`)
+  **Why:** Tailwind prefix scoping
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+- **Where:** Code style
+  **What:** Changed from double-quoted, semicolon-free style to single-quoted with semicolons
+  **Why:** Code style standardization (Prettier config)
+
+- **Where:** Exports
+  **What:** Changed from `export { Label }` to `export const Label`
+  **Why:** Export style preference
+
+---
+
+### menubar.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+- **Where:** `Menubar` component
+  **What:** Wraps root with `MenuContext.Provider` to support variants
+  **Why:** Variant system (comment: `#region CUSTOM provide context to add variants`)
+
+- **Where:** `MenubarTrigger` className
+  **What:** Added `'pr-twp'`
+  **Why:** Tailwind prefix scoping (comment: `// CUSTOM`)
+
+- **Where:** `MenubarTrigger`, `MenubarSubTrigger`, `MenubarSubContent`, `MenubarContent`, `MenubarItem`, `MenubarCheckboxItem`, `MenubarRadioItem`
+  **What:** Use `useMenuContext()` and/or `menuVariants()` for variant-aware styling
+  **Why:** Context-driven variant application (comment: `// CUSTOM use context to add variants`)
+
+- **Where:** `MenubarContent` className
+  **What:** Added `'pr-twp'` to reset styles so that only shadcn styles are applied
+  **Why:** Tailwind prefix scoping for portaled content (comment: `// CUSTOM reset styles so that only shadcn styles are applied`)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** Imports
+  **What:** Added `MenuContext`, `MenuContextProps`, `menuVariants`, `useMenuContext` from `@/context/menu.context`
+  **Why:** Variant system
+
+- **Where:** `Menubar`
+  **What:** Added `variant` prop of type `MenuContextProps['variant']`
+  **Why:** Menu variant support
+
+- **Where:** `MenubarSubContent`, `MenubarContent`
+  **What:** Added conditional `'tw-bg-popover': context.variant === 'muted'` class
+  **Why:** Muted variant styling
+
+- **Where:** Export order
+  **What:** Exports reordered alphabetically
+  **Why:** Code organization
+
+---
+
+### popover.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+- **Where:** `PopoverContent` `style` prop
+  **What:** Uses `Z_INDEX_ABOVE_DOCK` shared constant via inline style instead of Tailwind `tw-z-50` class
+  **Why:** Consistent z-index management via shared constant (comment: `// CUSTOM z-index uses shared constant instead of default tw-z-50`)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `PopoverContent`
+  **What:** Added `readDirection()` and `dir={dir}` prop
+  **Why:** RTL support
+
+- **Where:** `PopoverContent`
+  **What:** Replaced `tw-z-50` class with `style={{ zIndex: Z_INDEX_ABOVE_DOCK, ...style }}`; added `style` to destructured props
+  **Why:** Consistent z-index management via shared constant
+
+- **Where:** Exports
+  **What:** Added `PopoverAnchor` (not in original boilerplate)
+  **Why:** Additional primitive re-export needed by consumers
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+---
+
+### progress.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** All
+  **What:** Added JSDoc comment
+  **Why:** Documentation standard
+
+---
+
+### radio-group.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `RadioGroup`
+  **What:** Added `readDirection()` and `dir={dir}` prop
+  **Why:** RTL support
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+- **Where:** All components
+  **What:** Added JSDoc comments
+  **Why:** Documentation standard
+
+---
+
+### resizable.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** All
+  **What:** Added JSDoc comments
+  **Why:** Documentation standard
+
+---
+
+### select.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+- **Where:** `selectTriggerVariants` base class string
+  **What:** Removed `tw-justify-between`; added `tw-gap-2`, `[&>span]:tw-flex-1`, `[&>span]:tw-text-start`
+  **Why:** Keeps chevron tight against text while allowing span to fill remaining space (comment: `// CUSTOM: Removed tw-justify-between. Added tw-gap-2, [&>span]:tw-flex-1, [&>span]:tw-text-start`)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `selectTriggerVariants`
+  **What:** Entirely new cva factory added with size variants (default, sm, lg, icon); boilerplate had inline classes directly on SelectTrigger
+  **Why:** Enables size variants matching button sizes
+
+- **Where:** `SelectTriggerProps`
+  **What:** New exported interface combining primitive props with `VariantProps<typeof selectTriggerVariants>`
+  **Why:** Type support for size variants
+
+- **Where:** `SelectTrigger`
+  **What:** Added `readDirection()` and `dir={dir}` prop
+  **Why:** RTL support
+
+- **Where:** `SelectContent`
+  **What:** Added `readDirection()` and wraps children in `<div dir={dir}>`
+  **Why:** RTL support
+
+- **Where:** `SelectItem` class strings
+  **What:** Changed `tw-pl-8 tw-pr-2` to `tw-pe-2 tw-ps-8`; indicator span changed `tw-left-2` to `tw-start-2`
+  **Why:** RTL support (logical properties)
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+---
+
+### separator.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `Separator` className
+  **What:** Added `pr-twp`
+  **Why:** Tailwind prefix scoping
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+- **Where:** Import statement
+  **What:** Changed `import * as React` to `import React`
+  **Why:** Import style standardization
+
+---
+
+### sidebar.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+- **Where:** Keyboard shortcut handler
+  **What:** `SIDEBAR_KEYBOARD_SHORTCUT` constant and `useEffect` keyboard handler commented out
+  **Why:** Pending discussion with UX about keyboard shortcuts (comment: `// CUSTOM: Commented this out pending a discussion with UX about keyboard shortcuts`)
+
+- **Where:** `SidebarContextProps`
+  **What:** `side` property moved from `Sidebar` props to `SidebarContextProps`
+  **Why:** Allows child components to flip the icon based on the side (comment: `// CUSTOM: this was moved from Sidebar to SidebarProvider to also be able to flip the icon based on the side`)
+
+- **Where:** `Sidebar` inner div
+  **What:** Changed `tw-fixed` to `tw-absolute`
+  **Why:** Scopes the sidebar inside its container rather than the viewport (comment: `// CUSTOM: Switched tw-fixed to tw-absolute here to scope the sidebar inside of its container`)
+
+- **Where:** `SidebarInset` and `SidebarProvider`
+  **What:** Removed `tw-min-h-svh`
+  **Why:** Removed minimum viewport height constraint (comment: `// CUSTOM: Removed tw-min-h-svh`)
+
+#### Other comment-indicated customizations
+
+- **Where:** Top-level file comment
+  **What:** Documents changes from original shadcn code: removed `useIsMobile`, `Sheet`, `SheetContent`, and cookie-setting parts
+  **Note:** Major structural changes from boilerplate documented at file level
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `SidebarProvider`
+  **What:** Removed `useIsMobile`, `openMobile`, `setOpenMobile`, `isMobile` state and props; removed mobile `Sheet` rendering path entirely
+  **Why:** Mobile sidebar not needed in Platform.Bible (Electron) context
+
+- **Where:** `SidebarProvider`
+  **What:** Removed cookie setting (`SIDEBAR_COOKIE_NAME`, `SIDEBAR_COOKIE_MAX_AGE`, `useCookies`)
+  **Why:** Cookies not used in Electron app
+
+- **Where:** `SidebarProvider`
+  **What:** Added `side` prop and `readDirection()` for RTL-aware side calculation
+  **Why:** RTL support and primary/secondary side naming
+
+- **Where:** `Sidebar`
+  **What:** Changed `side` prop values from `'left'|'right'` to `'primary'|'secondary'` using context; removed `side` prop from `Sidebar` (now on `SidebarProvider`)
+  **Why:** Logical direction naming for RTL support
+
+- **Where:** `SidebarTrigger`
+  **What:** Now shows `PanelLeft` or `PanelRight` icon based on `context.side`
+  **Why:** Visual indication matches sidebar side
+
+- **Where:** `SidebarRail`
+  **What:** Changed `data-side=left/right` references to `data-side=primary/secondary`
+  **Why:** Consistent with side renaming
+
+- **Where:** `SidebarMenuButton`
+  **What:** Removed `isMobile` from tooltip hidden condition
+  **Why:** Mobile path removed
+
+- **Where:** Removed imports
+  **What:** Removed `Sheet`, `SheetContent`, `useIsMobile` imports
+  **Why:** Mobile sidebar path removed
+
+- **Where:** Added import
+  **What:** Added `PanelRight` from lucide-react
+  **Why:** Needed for secondary-side trigger icon
+
+---
+
+### skeleton.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** All
+  **What:** Added JSDoc comment
+  **Why:** Documentation standard
+
+---
+
+### slider.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `Slider`
+  **What:** Added `readDirection()` and `dir={dir}` prop
+  **Why:** RTL support
+
+- **Where:** `Slider` className
+  **What:** Added `pr-twp`
+  **Why:** Tailwind prefix scoping
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+---
+
+### sonner.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+- **Where:** `sonner` export (toast function)
+  **What:** Re-export of the sonner toast function was added manually
+  **Note:** "The re-export of the sonner function was added manually"
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `Sonner` component
+  **What:** Removed `useTheme()` from `next-themes` and the `theme` prop on `Toaster`
+  **Why:** `next-themes` is not used in Platform.Bible
+
+- **Where:** `Sonner` className
+  **What:** Changed from `pr-toaster pr-group` to `tw-toaster tw-group`
+  **Why:** Prefix migration. Note: these are plain class names used by sonner's own CSS selectors, not Tailwind utilities.
+
+- **Where:** `Sonner` `toastOptions` classNames
+  **What:** Class names in `toastOptions` do NOT use `tw-` prefix (e.g., `group-[.toaster]:bg-background`)
+  **Why:** These classes are used by sonner's internal styling which expects unprefixed Tailwind class names — uncertain if this is intentional
+
+---
+
+### switch.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `Switch`
+  **What:** Added `readDirection()` with conditional thumb translation classes for LTR (`tw-translate-x-5`) vs RTL (`tw-translate-x-[-20px]`)
+  **Why:** RTL support — thumb needs to slide in opposite direction
+
+- **Where:** Switch Thumb className
+  **What:** Added `pr-twp` to Thumb (boilerplate did not have it on thumb)
+  **Why:** Tailwind prefix scoping
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+---
+
+### table.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+- **Where:** `Table` and `TableRow` refs
+  **What:** Use internal refs to manage keyboard navigation and Enter key behavior; sync internal ref to forwarded ref if provided
+  **Why:** Custom keyboard navigation system
+
+- **Where:** `Table` — MutationObserver
+  **What:** Forces `tabindex=-1` on all focusable elements within the table to prevent tab navigation
+  **Why:** Custom tab focus management
+
+- **Where:** `Table` — keydown handler
+  **What:** `handleKeyDownInTable` handles ArrowDown and Space keys
+  **Why:** Keyboard navigation
+
+- **Where:** `Table` element
+  **What:** `tabIndex={0}` makes table tabbable; `onKeyDown={handleKeyDownInTable}` enables keyboard behavior; `ref={tableRef}` for internal ref management
+  **Why:** Accessible keyboard navigation
+
+- **Where:** `Table` className
+  **What:** Added `tw-outline-none` (remove duplicate outline); added focus ring styles (`focus:tw-relative focus:tw-z-10 focus:tw-ring-2 ...`)
+  **Why:** Focus styling
+
+- **Where:** `Table` attributes
+  **What:** Added `aria-label="Table"` and `aria-labelledby="table-label"`
+  **Why:** Accessibility
+
+- **Where:** `useFocusableInRowKeyboardNavigation` hook (custom)
+  **What:** Manages keyboard navigation and Enter key behavior for focusable elements in a row
+  **Why:** Accessible row keyboard navigation
+
+- **Where:** `focusAdjacentFocusableElementInRow` function (custom)
+  **What:** Moves focus left or right to adjacent focusable items in the same row
+  **Why:** Keyboard navigation
+
+- **Where:** `focusAdjacentRow` function (custom)
+  **What:** Moves focus up or down to adjacent rows in the same table
+  **Why:** Keyboard navigation
+
+- **Where:** `TableRow` element
+  **What:** `tabIndex={-1}` makes row not tabbable directly; `onFocus` handler for focus-triggers-select behavior; focus ring styles and `tw-outline-none`
+  **Why:** Keyboard navigation and focus management
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `Table`
+  **What:** Added `stickyHeader` prop with conditional `tw-p-1` padding
+  **Why:** Support for sticky table headers
+
+- **Where:** `TableHeader`
+  **What:** Added `stickyHeader` prop with sticky positioning classes
+  **Why:** Sticky header support
+
+- **Where:** `TableRow`
+  **What:** Added `setFocusAlsoRunsSelect` prop and `onSelect` callback integration
+  **Why:** Custom selection-on-focus behavior
+
+- **Where:** Utility imports
+  **What:** Added `getFocusableElements` from `@/utils/focus.util`
+  **Why:** Keyboard navigation utility
+
+- **Where:** `TableHead` class strings
+  **What:** Changed `tw-text-left` to `tw-text-start`; `[&:has([role=checkbox])]:tw-pr-0` to `tw-pe-0`
+  **Why:** RTL support (logical properties)
+
+- **Where:** `TableCell` class strings
+  **What:** Changed `[&:has([role=checkbox])]:tw-pr-0` to `tw-pe-0`
+  **Why:** RTL support (logical properties)
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+- **Where:** File-level eslint directive
+  **What:** Removed `/* eslint-disable react/jsx-props-no-spreading */`
+  **Why:** No longer needed
+
+---
+
+### tabs.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `TabsList`
+  **What:** Added `readDirection()` and `dir={dir}` prop
+  **Why:** RTL support
+
+- **Where:** All components
+  **What:** Added `pr-twp` to className
+  **Why:** Tailwind prefix scoping
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+- **Where:** Exports
+  **What:** Changed from `export { Tabs, TabsList, TabsTrigger, TabsContent }` to inline `export const`
+  **Why:** Export style preference
+
+- **Where:** Types
+  **What:** Added `TabsListProps`, `TabsTriggerProps`, `TabsContentProps` explicit type exports
+  **Why:** Explicit type exports for consumers
+
+- **Where:** File-level eslint directive
+  **What:** Removed `/* eslint-disable react/prop-types */`
+  **Why:** No longer needed
+
+---
+
+### textarea.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** All
+  **What:** Added JSDoc comment
+  **Why:** Documentation standard
+
+---
+
+### toggle-group.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `ToggleGroup`
+  **What:** Added `readDirection()` and `dir={dir}` prop
+  **Why:** RTL support
+
+- **Where:** `ToggleGroup` className
+  **What:** Removed `pr-font-sans` class
+  **Why:** Font class not needed / handled elsewhere
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+- **Where:** All components
+  **What:** Added JSDoc comments
+  **Why:** Documentation standard
+
+---
+
+### toggle.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+(none)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `toggleVariants` base string
+  **What:** Removed `pr-font-sans` class
+  **Why:** Font class not needed / handled elsewhere
+
+- **Where:** All Tailwind class strings
+  **What:** Migrated from `pr-` to `tw-` prefix
+  **Why:** Project-wide prefix migration
+
+---
+
+### tooltip.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+- **Where:** `TooltipTrigger` component
+  **What:** Extended to accept `ButtonProps` and applies `buttonVariants` when `variant` is provided; allows TooltipTrigger to be styled as a button without nesting a Button inside it
+  **Why:** Avoids the need for a nested button inside the trigger (comment: `// CUSTOM: TooltipTrigger is a button, so allow to use the button variants`)
+
+- **Where:** `TooltipContent` `style` prop
+  **What:** Uses `Z_INDEX_ABOVE_DOCK` shared constant via inline style instead of Tailwind `tw-z-50` class
+  **Why:** Consistent z-index management via shared constant (comment: `// CUSTOM z-index uses shared constant instead of default tw-z-50`)
+
+#### Other comment-indicated customizations
+
+(none)
+
+#### Uncalled-out customizations (from git history)
+
+- **Where:** `TooltipTrigger`
+  **What:** Changed from simple re-export (`const TooltipTrigger = TooltipPrimitive.Trigger`) to a `forwardRef` component accepting `ButtonProps` and conditionally applying `buttonVariants`
+  **Why:** Allows TooltipTrigger to be styled as a button without nesting a Button inside it
+
+- **Where:** `TooltipContent`
+  **What:** Wrapped in `<TooltipPrimitive.Portal>` (boilerplate did not have Portal)
+  **Why:** Ensures tooltip renders in a portal to avoid clipping/z-index issues
+
+- **Where:** `TooltipContent`
+  **What:** Replaced `tw-z-50` class with `style={{ zIndex: Z_INDEX_ABOVE_DOCK, ...style }}`; added `style` to destructured props
+  **Why:** Consistent z-index management via shared constant
+
+- **Where:** Imports
+  **What:** Added `ButtonProps`, `buttonVariants` from button, and `Z_INDEX_ABOVE_DOCK` from z-index
+  **Why:** Needed for customizations above


### PR DESCRIPTION
## Summary

- Adds `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md`: AI-generated snapshot of all customizations made to shadcn components relative to their original boilerplate, for use when upgrading to a new shadcn version
- Also includes `docs/superpowers/specs/` and `docs/superpowers/plans/` for the shadcn-customizations command design
- Generated by the `/shadcn-customizations` command (see ai-prompts PR for the command and agent)

## Test plan

- [ ] Spot-checked `button.tsx` and `popover.tsx` entries for accuracy
- [ ] All 31 component files have entries in the Standard Customizations table

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/paranext/paranext-core/pull/2190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2190)
<!-- Reviewable:end -->
