### PR TITLE
Add secret prevention: gitleaks pre-commit hook and .gitignore expansion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,16 @@ CLAUDE.md
 CLAUDE.md.backup
 
 .review
+
+# Secrets & credentials
+.env
+.env.*
+.env.local
+.env.*.local
+secrets/
+*.pem
+*.key
+*.pfx
+*.p12
+credentials.json
+service-account.json

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,39 @@
 #!/usr/bin/env sh
 
 # ============================================
+# Secret scanning (ALL branches)
+# ============================================
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo ""
+  echo "=========================================="
+  echo "ERROR: gitleaks is not installed"
+  echo "=========================================="
+  echo "gitleaks is required to prevent committing secrets to this public repository."
+  echo ""
+  echo "Install it:"
+  echo "  macOS:   brew install gitleaks"
+  echo "  Windows: winget install Gitleaks.Gitleaks"
+  echo "  Linux:   https://github.com/gitleaks/gitleaks/releases"
+  echo ""
+  echo "Then retry your commit."
+  echo "=========================================="
+  exit 1
+fi
+
+echo "Scanning for secrets..."
+if ! gitleaks git --pre-commit --staged --no-banner; then
+  echo ""
+  echo "=========================================="
+  echo "SECRET DETECTED — commit blocked"
+  echo "=========================================="
+  echo "Remove the secret from your staged files before committing."
+  echo "See above for the file and line number."
+  echo "=========================================="
+  exit 1
+fi
+echo "No secrets found"
+
+# ============================================
 # Standard hooks (ALL branches)
 # ============================================
 echo "Format and stylelint fixes..."


### PR DESCRIPTION
## Summary

- Add gitleaks secret scanning to the pre-commit hook (all branches). Commits are blocked if gitleaks is not installed or if secrets are detected in staged files.
- Expand `.gitignore` with common secret file patterns (`.env`, `*.pem`, `*.key`, `*.pfx`, `credentials.json`, etc.)

**Companion PR:** See ai-prompts PR for Claude rule and settings changes.

## Manual action required

- **GitHub repo settings**: Enable **Push Protection** under Settings > Code security and analysis > Secret scanning. This is a server-side safety net that blocks pushes containing known secret patterns.

## Test plan

- [ ] Stage a file containing `-----BEGIN RSA PRIVATE KEY-----` and verify the commit is blocked
- [ ] Temporarily rename `gitleaks` binary and verify commit shows install instructions and is blocked
- [ ] Create a `.env` file and verify `git status` ignores it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2201)
<!-- Reviewable:end -->
