### PR TITLE
PT-3920: Make Tailwind fully functional in paranext-core's app build

### DIFF
--- a/.erb/configs/css-loaders.ts
+++ b/.erb/configs/css-loaders.ts
@@ -1,0 +1,42 @@
+/**
+ * Shared CSS loader chains for the renderer webpack configs.
+ *
+ * Both dev (`webpack.config.renderer.dev.ts`) and prod (`webpack.config.renderer.prod.ts`) process
+ * `.css` / `.scss` / `.sass` through the same four-loader pipeline (style-or-extract → css-loader →
+ * postcss-loader → sass-loader). The only per-environment difference is the first loader:
+ *
+ * - Dev: `'style-loader'` (injects styles into the DOM at runtime)
+ * - Prod: `MiniCssExtractPlugin.loader` (emits a separate .css file)
+ *
+ * `importLoaders: 2` tells css-loader that `postcss-loader` and `sass-loader` both run before it,
+ * so `@import`-ed files are processed through postcss (Tailwind) and sass as well.
+ *
+ * See docs/tailwind.md for the overall Tailwind architecture.
+ */
+
+import type { RuleSetUseItem } from 'webpack';
+
+/**
+ * Build the renderer CSS loader chain.
+ *
+ * @param firstLoader The first loader in the chain (webpack runs `use` right-to-left). Use
+ *   `'style-loader'` in dev, `MiniCssExtractPlugin.loader` in prod.
+ * @param modules Whether this rule is for CSS Modules (`*.module.css/.scss`). CSS Module rules
+ *   additionally enable `css-loader`'s `modules` option and source maps.
+ */
+export function buildRendererCssLoaders(
+  firstLoader: RuleSetUseItem,
+  { modules }: { modules: boolean },
+): RuleSetUseItem[] {
+  return [
+    firstLoader,
+    {
+      loader: 'css-loader',
+      options: modules
+        ? { modules: true, sourceMap: true, importLoaders: 2 }
+        : { importLoaders: 2 },
+    },
+    'postcss-loader',
+    'sass-loader',
+  ];
+}

--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -9,6 +9,7 @@ import { ChildProcess, execSync, spawn } from 'child_process';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import baseConfig from './webpack.config.base';
 import webpackPaths from './webpack.paths';
+import { buildRendererCssLoaders } from './css-loaders';
 import checkNodeEnv from '../scripts/check-node-env';
 
 // When an ESLint server is running, we can't set the NODE_ENV so we'll check if it's
@@ -60,35 +61,13 @@ const configuration: webpack.Configuration = {
       {
         test: /\.s?(c|a)ss$/,
         resourceQuery: { not: [/raw/] },
-        use: [
-          'style-loader',
-          {
-            loader: 'css-loader',
-            options: {
-              modules: true,
-              sourceMap: true,
-              // postcss-loader + sass-loader both run before css-loader resolves @imports
-              importLoaders: 2,
-            },
-          },
-          'postcss-loader',
-          'sass-loader',
-        ],
+        use: buildRendererCssLoaders('style-loader', { modules: true }),
         include: /\.module\.s?(c|a)ss$/,
       },
       {
         test: /\.s?css$/,
         resourceQuery: { not: [/raw/] },
-        use: [
-          'style-loader',
-          {
-            loader: 'css-loader',
-            // postcss-loader + sass-loader both run before css-loader resolves @imports
-            options: { importLoaders: 2 },
-          },
-          'postcss-loader',
-          'sass-loader',
-        ],
+        use: buildRendererCssLoaders('style-loader', { modules: false }),
         exclude: /\.module\.s?(c|a)ss$/,
       },
       // Fonts

--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -67,9 +67,11 @@ const configuration: webpack.Configuration = {
             options: {
               modules: true,
               sourceMap: true,
-              importLoaders: 1,
+              // postcss-loader + sass-loader both run before css-loader resolves @imports
+              importLoaders: 2,
             },
           },
+          'postcss-loader',
           'sass-loader',
         ],
         include: /\.module\.s?(c|a)ss$/,
@@ -77,7 +79,16 @@ const configuration: webpack.Configuration = {
       {
         test: /\.s?css$/,
         resourceQuery: { not: [/raw/] },
-        use: ['style-loader', 'css-loader', 'sass-loader'],
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            // postcss-loader + sass-loader both run before css-loader resolves @imports
+            options: { importLoaders: 2 },
+          },
+          'postcss-loader',
+          'sass-loader',
+        ],
         exclude: /\.module\.s?(c|a)ss$/,
       },
       // Fonts

--- a/.erb/configs/webpack.config.renderer.prod.ts
+++ b/.erb/configs/webpack.config.renderer.prod.ts
@@ -10,6 +10,7 @@ import { merge } from 'webpack-merge';
 import TerserPlugin from 'terser-webpack-plugin';
 import baseConfig from './webpack.config.base';
 import webpackPaths from './webpack.paths';
+import { buildRendererCssLoaders } from './css-loaders';
 import checkNodeEnv from '../scripts/check-node-env';
 import deleteSourceMaps from '../scripts/delete-source-maps';
 
@@ -51,35 +52,13 @@ const configuration: webpack.Configuration = {
       {
         test: /\.s?(a|c)ss$/,
         resourceQuery: { not: [/raw/] },
-        use: [
-          MiniCssExtractPlugin.loader,
-          {
-            loader: 'css-loader',
-            options: {
-              modules: true,
-              sourceMap: true,
-              // postcss-loader + sass-loader both run before css-loader resolves @imports
-              importLoaders: 2,
-            },
-          },
-          'postcss-loader',
-          'sass-loader',
-        ],
+        use: buildRendererCssLoaders(MiniCssExtractPlugin.loader, { modules: true }),
         include: /\.module\.s?(c|a)ss$/,
       },
       {
         test: /\.s?(a|c)ss$/,
         resourceQuery: { not: [/raw/] },
-        use: [
-          MiniCssExtractPlugin.loader,
-          {
-            loader: 'css-loader',
-            // postcss-loader + sass-loader both run before css-loader resolves @imports
-            options: { importLoaders: 2 },
-          },
-          'postcss-loader',
-          'sass-loader',
-        ],
+        use: buildRendererCssLoaders(MiniCssExtractPlugin.loader, { modules: false }),
         exclude: /\.module\.s?(c|a)ss$/,
       },
       // Fonts

--- a/.erb/configs/webpack.config.renderer.prod.ts
+++ b/.erb/configs/webpack.config.renderer.prod.ts
@@ -58,9 +58,11 @@ const configuration: webpack.Configuration = {
             options: {
               modules: true,
               sourceMap: true,
-              importLoaders: 1,
+              // postcss-loader + sass-loader both run before css-loader resolves @imports
+              importLoaders: 2,
             },
           },
+          'postcss-loader',
           'sass-loader',
         ],
         include: /\.module\.s?(c|a)ss$/,
@@ -68,7 +70,16 @@ const configuration: webpack.Configuration = {
       {
         test: /\.s?(a|c)ss$/,
         resourceQuery: { not: [/raw/] },
-        use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            // postcss-loader + sass-loader both run before css-loader resolves @imports
+            options: { importLoaders: 2 },
+          },
+          'postcss-loader',
+          'sass-loader',
+        ],
         exclude: /\.module\.s?(c|a)ss$/,
       },
       // Fonts

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -93,8 +93,8 @@ const config: StorybookConfig = {
               !!u &&
               typeof u === 'object' &&
               'options' in u &&
-              typeof u.options === 'object' &&
-              u.options !== null
+              u.options &&
+              typeof u.options === 'object'
                 ? u.options
                 : {};
             return {

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -42,19 +42,30 @@ const config: StorybookConfig = {
 
   // Merge StorybookWebpackConfig with our WebpackRendererConfig
   // See the current webpack configuration using npm run storybook -- --debug-webpack
-  // TODO: Make this work in production mode
   webpackFinal: async (webpackConfig, { configType }) => {
     const rendererConfig =
       configType === 'PRODUCTION'
-        ? // Storybook is a build tool so this will not affect anything
+        ? // Webpack configs must be loaded dynamically based on configType (PRODUCTION vs DEVELOPMENT)
           // eslint-disable-next-line global-require
           require('../.erb/configs/webpack.config.renderer.prod').default
         : // Storybook is a build tool so this will not affect anything
           // eslint-disable-next-line global-require
           require('../.erb/configs/webpack.config.renderer.dev').default;
-    // Remove configs that break stuff (https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config)
+    // Strip Electron-specific configs that conflict with Storybook's own webpack setup.
+    // devServer/entry/output are Electron-only; optimization/cache are managed by Storybook.
+    // See https://storybook.js.org/docs/react/builders/webpack#extending-storybooks-webpack-config
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { devServer, entry, output, ...rendererConfigSanitized } = rendererConfig;
+    const { devServer, entry, output, optimization, cache, ...rendererConfigSanitized } =
+      rendererConfig;
+
+    // Filter out plugins that conflict with Storybook's own plugins.
+    // HtmlWebpackPlugin causes Storybook 9's WebpackInjectMockerRuntimePlugin to
+    // emit mocker-runtime-injected.js twice (one per HtmlWebpackPlugin instance).
+    const conflictingPlugins = ['HtmlWebpackPlugin', 'BundleAnalyzerPlugin'];
+    rendererConfigSanitized.plugins = (rendererConfigSanitized.plugins || []).filter(
+      (plugin: { constructor?: { name?: string } }) =>
+        !conflictingPlugins.includes(plugin?.constructor?.name ?? ''),
+    );
 
     // Inject postcss-loader into the renderer's CSS rules for Storybook only.
     // postcss-loader is intentionally omitted from the shared renderer webpack configs so that

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -121,7 +121,12 @@ const config: StorybookConfig = {
           }
           return u;
         });
-        newUse.splice(cssIdx + 1, 0, 'postcss-loader');
+        newUse.splice(cssIdx + 1, 0, {
+          loader: 'postcss-loader',
+          options: {
+            postcssOptions: { config: join(__dirname, 'postcss.config.ts') },
+          },
+        });
         return { ...rule, use: newUse };
       });
     }

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -67,67 +67,28 @@ const config: StorybookConfig = {
         !conflictingPlugins.includes(plugin?.constructor?.name ?? ''),
     );
 
-    // Inject postcss-loader into the renderer's CSS rules for Storybook only.
-    // postcss-loader is intentionally omitted from the shared renderer webpack configs so that
-    // Tailwind CSS is not processed in the Electron app build — only in Storybook.
+    // Override the inherited postcss-loader's config path so Storybook uses
+    // .storybook/postcss.config.ts (which scans extensions and platform-bible-react source)
+    // rather than the root postcss.config.ts (app-scoped). postcss-loader is now supplied
+    // by the shared renderer webpack config, so we just need to point it at the right config.
+    // See docs/tailwind.md for the overall Tailwind architecture.
+    const storybookPostcssConfigPath = join(__dirname, 'postcss.config.ts');
     if (rendererConfigSanitized.module?.rules) {
       const rendererRules: RuleSetRule[] = rendererConfigSanitized.module.rules;
       rendererConfigSanitized.module.rules = rendererRules.map((rule) => {
         if (!rule || typeof rule !== 'object' || !Array.isArray(rule.use)) return rule;
-        const useArr = rule.use;
-        const cssIdx = useArr.findIndex(
-          (u) =>
-            u === 'css-loader' ||
-            (!!u &&
-              typeof u === 'object' &&
-              typeof u !== 'function' &&
-              'loader' in u &&
-              u.loader === 'css-loader'),
-        );
-        if (cssIdx < 0) return rule;
-        // Bump importLoaders by 1 so postcss-loader processes CSS @imports.
-        // Handles both the plain string form ('css-loader') and the object form ({ loader: 'css-loader', options: {...} }).
-        const newUse = useArr.map((u, i) => {
-          if (i !== cssIdx) return u;
-          // Plain string form: convert to object with importLoaders: 1
-          if (u === 'css-loader') {
-            return { loader: 'css-loader', options: { importLoaders: 1 } };
-          }
-          // Object form: bump existing importLoaders count
-          if (
-            !!u &&
-            typeof u === 'object' &&
-            typeof u !== 'function' &&
-            'options' in u &&
-            typeof u.options === 'object' &&
-            !!u.options &&
-            'importLoaders' in u.options &&
-            typeof u.options.importLoaders === 'number'
-          ) {
-            return { ...u, options: { ...u.options, importLoaders: u.options.importLoaders + 1 } };
-          }
-          // Object form without importLoaders: add importLoaders: 1
-          if (
-            !!u &&
-            typeof u === 'object' &&
-            typeof u !== 'function' &&
-            'loader' in u &&
-            u.loader === 'css-loader' &&
-            (!('options' in u) || typeof u.options !== 'function')
-          ) {
-            const existingOptions =
-              'options' in u && typeof u.options === 'object' ? (u.options ?? {}) : {};
-            return { ...u, options: { ...existingOptions, importLoaders: 1 } };
-          }
-          return u;
-        });
-        newUse.splice(cssIdx + 1, 0, {
-          loader: 'postcss-loader',
-          options: {
-            postcssOptions: { config: join(__dirname, 'postcss.config.ts') },
-          },
-        });
-        return { ...rule, use: newUse };
+        return {
+          ...rule,
+          use: rule.use.map((u) => {
+            if (u === 'postcss-loader') {
+              return {
+                loader: 'postcss-loader',
+                options: { postcssOptions: { config: storybookPostcssConfigPath } },
+              };
+            }
+            return u;
+          }),
+        };
       });
     }
 

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -73,6 +73,12 @@ const config: StorybookConfig = {
     // by the shared renderer webpack config, so we just need to point it at the right config.
     // See docs/tailwind.md for the overall Tailwind architecture.
     const storybookPostcssConfigPath = join(__dirname, 'postcss.config.ts');
+    // Matches both shapes the renderer webpack config could produce for postcss-loader:
+    // - bare string form: `'postcss-loader'`
+    // - object form: `{ loader: 'postcss-loader', ... }`
+    const isPostcssLoader = (u: unknown) =>
+      u === 'postcss-loader' ||
+      (!!u && typeof u === 'object' && 'loader' in u && u.loader === 'postcss-loader');
     if (rendererConfigSanitized.module?.rules) {
       const rendererRules: RuleSetRule[] = rendererConfigSanitized.module.rules;
       rendererConfigSanitized.module.rules = rendererRules.map((rule) => {
@@ -80,13 +86,24 @@ const config: StorybookConfig = {
         return {
           ...rule,
           use: rule.use.map((u) => {
-            if (u === 'postcss-loader') {
-              return {
-                loader: 'postcss-loader',
-                options: { postcssOptions: { config: storybookPostcssConfigPath } },
-              };
-            }
-            return u;
+            if (!isPostcssLoader(u)) return u;
+            // Preserve any existing options the renderer config may have set, then override
+            // the postcss config path.
+            const existingOptions =
+              !!u &&
+              typeof u === 'object' &&
+              'options' in u &&
+              typeof u.options === 'object' &&
+              u.options !== null
+                ? u.options
+                : {};
+            return {
+              loader: 'postcss-loader',
+              options: {
+                ...existingOptions,
+                postcssOptions: { config: storybookPostcssConfigPath },
+              },
+            };
           }),
         };
       });

--- a/.storybook/postcss.config.ts
+++ b/.storybook/postcss.config.ts
@@ -1,0 +1,13 @@
+// PostCSS configuration for Storybook. See docs/tailwind.md for the overall Tailwind
+// architecture. Storybook's webpackFinal points its postcss-loader at this file so Tailwind
+// uses `.storybook/tailwind.config.ts` (which scans core + extensions + platform-bible-react
+// source) rather than the root app-scoped config.
+import type { Config } from 'postcss-load-config';
+import tailwindcss from 'tailwindcss';
+import autoprefixer from 'autoprefixer';
+
+const config: Config = {
+  plugins: [tailwindcss({ config: './.storybook/tailwind.config.ts' }), autoprefixer()],
+};
+
+export default config;

--- a/.storybook/tailwind.config.ts
+++ b/.storybook/tailwind.config.ts
@@ -1,6 +1,21 @@
 import type { Config } from 'tailwindcss';
-// See docs/tailwind.md for what this config covers. Storybook pulls source files from core,
-// extensions, and platform-bible-react, so its Tailwind content globs scan all three trees.
+// See docs/tailwind.md for the overall Tailwind architecture.
+//
+// This config is Storybook-only. It scans three trees because Storybook pulls source files
+// directly from each (rather than consuming their built outputs):
+//   - ./src/**                          — paranext-core's own renderer stories/components
+//   - ./extensions/src/**               — bundled extension stories (until PT-3307 gives each
+//                                          extension its own Storybook)
+//   - ./lib/platform-bible-react/src/** — PBR source. .storybook/main.ts aliases the
+//                                          `platform-bible-react` and `@/…` imports to PBR
+//                                          source files rather than dist, which bypasses the
+//                                          style-inject that normally happens at runtime when
+//                                          consuming PBR's built bundle — so Storybook has to
+//                                          process PBR's Tailwind classes itself.
+//
+// The app's tailwind.config.ts at the repo root is app-scoped and only scans ./src/** — that
+// split was the purpose of PT-3920.
+//
 // Root imports from PBR (not the other way around) because PBR is shared externally and cannot
 // depend on this monorepo root.
 import libConfig from '../lib/platform-bible-react/tailwind.config';

--- a/.storybook/tailwind.config.ts
+++ b/.storybook/tailwind.config.ts
@@ -1,0 +1,22 @@
+import type { Config } from 'tailwindcss';
+// See docs/tailwind.md for what this config covers. Storybook pulls source files from core,
+// extensions, and platform-bible-react, so its Tailwind content globs scan all three trees.
+// Root imports from PBR (not the other way around) because PBR is shared externally and cannot
+// depend on this monorepo root.
+import libConfig from '../lib/platform-bible-react/tailwind.config';
+
+const config: Config = {
+  presets: [libConfig],
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}',
+    './extensions/src/**/*.{js,ts,jsx,tsx}',
+    './lib/platform-bible-react/src/**/*.{js,ts,jsx,tsx}',
+    './.storybook/**/*.{ts,tsx}',
+    // Ignore build artifacts and dependencies within extensions to avoid slow builds
+    '!./**/node_modules/**/*',
+    '!./**/temp-build/**/*',
+    '!./**/dist/**/*',
+  ],
+};
+
+export default config;

--- a/docs/plans/2026-04-16-tailwind-in-core.md
+++ b/docs/plans/2026-04-16-tailwind-in-core.md
@@ -1,0 +1,818 @@
+# Tailwind in paranext-core App Build Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire Tailwind into paranext-core's app webpack build so core's `tw-*` utilities are emitted from core's own source, ending the silent-failure dependency on PBR's compiled bundle.
+
+**Architecture:** Split the existing Storybook-only root `tailwind.config.ts` and `postcss.config.ts` into two config pairs — root configs become app-only (scan `src/**`), new `.storybook/*` configs scan core + extensions + PBR source. Add `postcss-loader` to the shared renderer webpack config so core's new `src/renderer/styles/tailwind.css` gets processed at app build time. Storybook inherits `postcss-loader` from the renderer config and only overrides which config file it resolves to. Utilities-only emission from core (no `@tailwind base;`) — preflight keeps coming from PBR under `.pr-twp`.
+
+**Tech Stack:** Tailwind 3 (already installed), PostCSS 8, `postcss-loader` 8, webpack 5, Storybook 9 (react-webpack5), TypeScript.
+
+**Spec:** `docs/specs/2026-04-16-tailwind-in-core-design.md`
+
+---
+
+## File Map
+
+| File                                           | Action | Purpose                                                                                                                                                                                                                               |
+| ---------------------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `.storybook/tailwind.config.ts`                | Create | Storybook-scoped Tailwind config. Scans core + extensions + PBR source. Extends PBR preset.                                                                                                                                           |
+| `.storybook/postcss.config.ts`                 | Create | Storybook-scoped PostCSS config. Points Tailwind plugin at `.storybook/tailwind.config.ts`.                                                                                                                                           |
+| `.storybook/main.ts`                           | Modify | Task 1: update the existing postcss-loader injection to pass `postcssOptions.config: '.storybook/postcss.config.ts'`. Task 3: remove the ~60-line injection entirely; replace with ~10-line override on the inherited postcss-loader. |
+| `tailwind.config.ts` (root)                    | Modify | Narrow `content` to `./src/**` only. Rewrite the "Storybook-only" and "PT-3920" comments.                                                                                                                                             |
+| `postcss.config.ts` (root)                     | Modify | Rewrite the "Storybook (not used by the Electron app build)" comment.                                                                                                                                                                 |
+| `.erb/configs/webpack.config.renderer.dev.ts`  | Modify | Add `postcss-loader` to both CSS rules; bump `importLoaders`.                                                                                                                                                                         |
+| `.erb/configs/webpack.config.renderer.prod.ts` | Modify | Same as dev.                                                                                                                                                                                                                          |
+| `src/renderer/styles/tailwind.css`             | Create | Core's Tailwind entry. Utilities-only: `@tailwind components; @tailwind utilities;`.                                                                                                                                                  |
+| `src/renderer/app.component.tsx`               | Modify | Side-effect import of `./styles/tailwind.css` next to the existing SCSS import.                                                                                                                                                       |
+| `docs/tailwind.md`                             | Create | Contributor-facing doc: where Tailwind runs, where configs live, how stories work, edge cases.                                                                                                                                        |
+
+No new dependencies; all packages already in root `package.json`.
+
+---
+
+## Task 1: Split the Storybook-scoped Tailwind/PostCSS configs out of the root files
+
+**Context:** Today the root `tailwind.config.ts` and `postcss.config.ts` are "for Storybook only" per their own comments (lines 1 and 9 of `tailwind.config.ts`; line 1 of `postcss.config.ts`). `.storybook/main.ts:59-115` injects `postcss-loader` into the renderer's CSS rules and that loader discovers the root `postcss.config.ts` by default. We create `.storybook`-local copies first so Storybook's build switches to them before Task 2 narrows the root files.
+
+**Files:**
+
+- Create: `.storybook/tailwind.config.ts`
+- Create: `.storybook/postcss.config.ts`
+- Modify: `.storybook/main.ts` (around current line 113, where `newUse.splice(cssIdx + 1, 0, 'postcss-loader');` is)
+
+- [ ] **Step 1: Record a pre-change baseline**
+
+```bash
+rm -rf storybook-static && npm run storybook:build > /tmp/sb-pre-task1.log 2>&1 && echo "baseline OK" && grep -cE "^\\./(src|extensions/src|lib/platform-bible-react/src)" storybook-static/index.json 2>/dev/null | head
+```
+
+Expected: `baseline OK`. Remember this baseline — Tasks 1–3 must not reduce it.
+
+- [ ] **Step 2: Create `.storybook/tailwind.config.ts`**
+
+Create this file with the following content:
+
+```ts
+import type { Config } from 'tailwindcss';
+// See docs/tailwind.md for what this config covers. Storybook pulls source files from core,
+// extensions, and platform-bible-react, so its Tailwind content globs scan all three trees.
+// Root imports from PBR (not the other way around) because PBR is shared externally and cannot
+// depend on this monorepo root.
+import libConfig from '../lib/platform-bible-react/tailwind.config';
+
+const config: Config = {
+  presets: [libConfig],
+  content: [
+    './src/**/*.{js,ts,jsx,tsx}',
+    './extensions/src/**/*.{js,ts,jsx,tsx}',
+    './lib/platform-bible-react/src/**/*.{js,ts,jsx,tsx}',
+    './.storybook/**/*.{ts,tsx}',
+    // Ignore build artifacts and dependencies within extensions to avoid slow builds
+    '!./**/node_modules/**/*',
+    '!./**/temp-build/**/*',
+    '!./**/dist/**/*',
+  ],
+};
+
+export default config;
+```
+
+Note that the `content` globs are still written **relative to the repo root**, not to `.storybook/`. Tailwind's content globs are resolved against `process.cwd()` (the repo root when Storybook runs), not relative to the config file's location. Keeping them root-relative preserves existing behaviour.
+
+- [ ] **Step 3: Create `.storybook/postcss.config.ts`**
+
+Create this file with the following content:
+
+```ts
+// PostCSS configuration for Storybook. See docs/tailwind.md for the overall Tailwind
+// architecture. Storybook's webpackFinal points its postcss-loader at this file so Tailwind
+// uses `.storybook/tailwind.config.ts` (which scans core + extensions + platform-bible-react
+// source) rather than the root app-scoped config.
+import type { Config } from 'postcss-load-config';
+import tailwindcss from 'tailwindcss';
+import autoprefixer from 'autoprefixer';
+
+const config: Config = {
+  plugins: [tailwindcss({ config: './.storybook/tailwind.config.ts' }), autoprefixer()],
+};
+
+export default config;
+```
+
+Passing `{ config: ... }` to the `tailwindcss` plugin explicitly pins the Tailwind config file so we don't rely on PostCSS's implicit config discovery (which searches upward from the CSS file's directory and would otherwise find the root `tailwind.config.ts`).
+
+- [ ] **Step 4: Point the Storybook postcss-loader at the new Storybook PostCSS config**
+
+Open `.storybook/main.ts`. Find this line (currently near line 113):
+
+```ts
+newUse.splice(cssIdx + 1, 0, 'postcss-loader');
+```
+
+Replace with:
+
+```ts
+newUse.splice(cssIdx + 1, 0, {
+  loader: 'postcss-loader',
+  options: {
+    postcssOptions: { config: join(__dirname, 'postcss.config.ts') },
+  },
+});
+```
+
+This makes the injected `postcss-loader` use `.storybook/postcss.config.ts` explicitly instead of walking up from the source file and finding the root `postcss.config.ts`.
+
+- [ ] **Step 5: Verify Storybook still builds against the new Storybook configs**
+
+```bash
+rm -rf storybook-static && npm run storybook:build > /tmp/sb-task1.log 2>&1; echo "exit=$?"; tail -3 /tmp/sb-task1.log
+```
+
+Expected: `exit=0`, final line `info => Output directory: /home/paratext/git/paranext-core/storybook-static`.
+
+Confirm core and extension story asset bundles are still present:
+
+```bash
+grep -l "./src/renderer/components/overlays/overlay-command-palette.stories" storybook-static/ -r | head -1
+grep -l "./extensions/src/platform-get-resources/src/home.stories" storybook-static/ -r | head -1
+```
+
+Expected: each returns at least one match (the story bundle was included).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .storybook/tailwind.config.ts .storybook/postcss.config.ts .storybook/main.ts
+git commit -m "refactor(storybook): move Storybook Tailwind/PostCSS configs into .storybook/
+
+Creates .storybook/tailwind.config.ts and .storybook/postcss.config.ts
+as copies of the root configs. Storybook's webpackFinal now points its
+injected postcss-loader at the local .storybook/postcss.config.ts so
+subsequent tasks can narrow the root configs to app-only content globs
+without affecting Storybook.
+
+Part of PT-3920."
+```
+
+---
+
+## Task 2: Narrow the root Tailwind/PostCSS configs to app-only
+
+**Context:** The root `tailwind.config.ts` and `postcss.config.ts` are now orphaned by Storybook (Task 1 switched Storybook to `.storybook/*`). Before Task 3 starts using them for the app build, narrow them down to only what the app cares about: core's own `src/**` and its own PostCSS plugin chain. Storybook must not regress — verify after.
+
+**Files:**
+
+- Modify: `tailwind.config.ts` (root)
+- Modify: `postcss.config.ts` (root)
+
+- [ ] **Step 1: Rewrite `tailwind.config.ts` (root)**
+
+Replace the entire file with:
+
+```ts
+import type { Config } from 'tailwindcss';
+// See docs/tailwind.md for the overall Tailwind architecture. This config is used by the
+// paranext-core Electron app webpack build to emit utilities from core's own source.
+// Storybook has its own config at .storybook/tailwind.config.ts that scans extensions and
+// platform-bible-react too.
+// Root imports from PBR (not the other way around) because PBR is shared externally and cannot
+// depend on this monorepo root.
+import libConfig from './lib/platform-bible-react/tailwind.config';
+
+const config: Config = {
+  presets: [libConfig],
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
+};
+
+export default config;
+```
+
+Note the deletions:
+
+- The old note block about "This tailwind config is for Storybook only" and the "When PT-3920 is implemented…" paragraph are gone — they no longer describe the file.
+- The `!./**/node_modules/**/*`, `!./**/temp-build/**/*`, `!./**/dist/**/*` exclusion globs are unnecessary here because `./src/**` doesn't match any of those (they live in `node_modules/`, `extensions/**/temp-build/`, and `**/dist/`, none of which are under `./src/`).
+- `./.storybook/**` is dropped from content because the Storybook config handles that.
+
+- [ ] **Step 2: Rewrite `postcss.config.ts` (root)**
+
+Replace the entire file with:
+
+```ts
+// PostCSS configuration for the paranext-core Electron app. See docs/tailwind.md for the overall
+// Tailwind architecture. Storybook has its own PostCSS config at .storybook/postcss.config.ts.
+import type { Config } from 'postcss-load-config';
+
+const config: Config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+
+export default config;
+```
+
+With no `{ config: ... }` arg on the `tailwindcss` plugin, PostCSS's default discovery walks up from the CSS file and finds `./tailwind.config.ts` at the repo root — which is what we want for the app build.
+
+- [ ] **Step 3: Verify Storybook still builds (root configs are now app-only but Storybook uses .storybook/)**
+
+```bash
+rm -rf storybook-static && npm run storybook:build > /tmp/sb-task2.log 2>&1; echo "exit=$?"; tail -3 /tmp/sb-task2.log
+```
+
+Expected: `exit=0`, successful output directory line. Storybook's own tailwind config still scans extensions and PBR, so its bundle is unaffected.
+
+- [ ] **Step 4: Sanity-check that extensions still have utilities in the Storybook bundle**
+
+```bash
+grep -rE "tw-flex|tw-grid|tw-px-" storybook-static/*.css storybook-static/*style*.css 2>/dev/null | head -3
+```
+
+Expected: at least one match (Tailwind utilities from extensions' `tw-*` usage are still emitted).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tailwind.config.ts postcss.config.ts
+git commit -m "refactor(tailwind): narrow root configs to app-only content globs
+
+The root tailwind.config.ts now scans only ./src/** — core's own
+renderer source. Extensions and platform-bible-react are no longer
+referenced because they have their own independent builds, and
+Storybook has switched to .storybook/tailwind.config.ts (previous
+commit).
+
+Removes the outdated note about the config being 'for Storybook only'
+and the PT-3920 forward-reference, which this PR resolves.
+
+Part of PT-3920."
+```
+
+---
+
+## Task 3: Add postcss-loader to the renderer webpack and simplify the Storybook monkey-patch
+
+**Context:** The app build's renderer webpack config (`webpack.config.renderer.dev.ts` and `.prod.ts`) currently has no PostCSS processing. Once we add it, the app processes Tailwind at build time. Storybook inherits the renderer config via its `webpackFinal`, so the ~60-line injection block becomes unnecessary — we only need a small override that re-points the inherited `postcss-loader` at `.storybook/postcss.config.ts`. Both changes happen together so there's no window where Storybook double-processes CSS.
+
+**Files:**
+
+- Modify: `.erb/configs/webpack.config.renderer.dev.ts` (CSS rules around lines 60–82)
+- Modify: `.erb/configs/webpack.config.renderer.prod.ts` (CSS rules around lines 51–73)
+- Modify: `.storybook/main.ts` (replace the whole `// Inject postcss-loader …` block from current lines 59–116)
+
+- [ ] **Step 1: Edit `.erb/configs/webpack.config.renderer.dev.ts`**
+
+Find the two CSS rules (currently lines 60–82):
+
+```ts
+      {
+        test: /\.s?(c|a)ss$/,
+        resourceQuery: { not: [/raw/] },
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              modules: true,
+              sourceMap: true,
+              importLoaders: 1,
+            },
+          },
+          'sass-loader',
+        ],
+        include: /\.module\.s?(c|a)ss$/,
+      },
+      {
+        test: /\.s?css$/,
+        resourceQuery: { not: [/raw/] },
+        use: ['style-loader', 'css-loader', 'sass-loader'],
+        exclude: /\.module\.s?(c|a)ss$/,
+      },
+```
+
+Replace with:
+
+```ts
+      {
+        test: /\.s?(c|a)ss$/,
+        resourceQuery: { not: [/raw/] },
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            options: {
+              modules: true,
+              sourceMap: true,
+              // postcss-loader + sass-loader both run before css-loader resolves @imports
+              importLoaders: 2,
+            },
+          },
+          'postcss-loader',
+          'sass-loader',
+        ],
+        include: /\.module\.s?(c|a)ss$/,
+      },
+      {
+        test: /\.s?css$/,
+        resourceQuery: { not: [/raw/] },
+        use: [
+          'style-loader',
+          {
+            loader: 'css-loader',
+            // postcss-loader + sass-loader both run before css-loader resolves @imports
+            options: { importLoaders: 2 },
+          },
+          'postcss-loader',
+          'sass-loader',
+        ],
+        exclude: /\.module\.s?(c|a)ss$/,
+      },
+```
+
+Two changes per rule: insert `'postcss-loader'` between `'css-loader'` and `'sass-loader'`, and bump `importLoaders` from 1 → 2 (modules rule) or 0 → 2 (non-modules rule — converted from plain string to object form).
+
+- [ ] **Step 2: Edit `.erb/configs/webpack.config.renderer.prod.ts`**
+
+Find the two CSS rules (currently lines 51–73):
+
+```ts
+      {
+        test: /\.s?(a|c)ss$/,
+        resourceQuery: { not: [/raw/] },
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              modules: true,
+              sourceMap: true,
+              importLoaders: 1,
+            },
+          },
+          'sass-loader',
+        ],
+        include: /\.module\.s?(c|a)ss$/,
+      },
+      {
+        test: /\.s?(a|c)ss$/,
+        resourceQuery: { not: [/raw/] },
+        use: [MiniCssExtractPlugin.loader, 'css-loader', 'sass-loader'],
+        exclude: /\.module\.s?(c|a)ss$/,
+      },
+```
+
+Replace with:
+
+```ts
+      {
+        test: /\.s?(a|c)ss$/,
+        resourceQuery: { not: [/raw/] },
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            options: {
+              modules: true,
+              sourceMap: true,
+              // postcss-loader + sass-loader both run before css-loader resolves @imports
+              importLoaders: 2,
+            },
+          },
+          'postcss-loader',
+          'sass-loader',
+        ],
+        include: /\.module\.s?(c|a)ss$/,
+      },
+      {
+        test: /\.s?(a|c)ss$/,
+        resourceQuery: { not: [/raw/] },
+        use: [
+          MiniCssExtractPlugin.loader,
+          {
+            loader: 'css-loader',
+            // postcss-loader + sass-loader both run before css-loader resolves @imports
+            options: { importLoaders: 2 },
+          },
+          'postcss-loader',
+          'sass-loader',
+        ],
+        exclude: /\.module\.s?(c|a)ss$/,
+      },
+```
+
+Same pattern as dev, with `MiniCssExtractPlugin.loader` in place of `'style-loader'`.
+
+- [ ] **Step 3: Replace the Storybook postcss-injection monkey-patch with a small config-path override**
+
+Open `.storybook/main.ts`. Find the whole injection block (currently lines 59–116) — everything starting from:
+
+```ts
+// Inject postcss-loader into the renderer's CSS rules for Storybook only.
+```
+
+through the closing `}` of:
+
+```ts
+      });
+    }
+```
+
+That is, the block that ends right before `// Add path mapping for platform-bible-react's @/ alias…`.
+
+Replace it with:
+
+```ts
+// Override the inherited postcss-loader's config path so Storybook uses
+// .storybook/postcss.config.ts (which scans extensions and platform-bible-react source)
+// rather than the root postcss.config.ts (app-scoped). postcss-loader is now supplied
+// by the shared renderer webpack config, so we just need to point it at the right config.
+// See docs/tailwind.md for the overall Tailwind architecture.
+const storybookPostcssConfigPath = join(__dirname, 'postcss.config.ts');
+if (rendererConfigSanitized.module?.rules) {
+  const rendererRules: RuleSetRule[] = rendererConfigSanitized.module.rules;
+  rendererConfigSanitized.module.rules = rendererRules.map((rule) => {
+    if (!rule || typeof rule !== 'object' || !Array.isArray(rule.use)) return rule;
+    return {
+      ...rule,
+      use: rule.use.map((u) => {
+        if (u === 'postcss-loader') {
+          return {
+            loader: 'postcss-loader',
+            options: { postcssOptions: { config: storybookPostcssConfigPath } },
+          };
+        }
+        return u;
+      }),
+    };
+  });
+}
+```
+
+- [ ] **Step 4: Run the app production build to verify it still compiles**
+
+```bash
+npm run build 2>&1 | tail -10; echo "exit=$?"
+```
+
+Expected: `exit=0`. No webpack errors. This is the first time the renderer config's CSS rules have postcss-loader in them, so any PostCSS misconfiguration surfaces here.
+
+- [ ] **Step 5: Verify Storybook still builds and output is unchanged in shape**
+
+```bash
+rm -rf storybook-static && npm run storybook:build > /tmp/sb-task3.log 2>&1; echo "exit=$?"; tail -3 /tmp/sb-task3.log
+```
+
+Expected: `exit=0`, `info => Output directory: …`.
+
+Confirm PBR and extension utilities are still in the Storybook bundle:
+
+```bash
+grep -rE "tw-flex|tw-grid" storybook-static/*.css 2>/dev/null | head -2
+```
+
+Expected: at least one match.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add .erb/configs/webpack.config.renderer.dev.ts .erb/configs/webpack.config.renderer.prod.ts .storybook/main.ts
+git commit -m "feat(tailwind): add postcss-loader to renderer webpack; simplify Storybook
+
+Adds postcss-loader to both CSS rules in the shared renderer webpack
+config (dev + prod), so the Electron app now processes Tailwind at
+build time. importLoaders is bumped so postcss-loader and sass-loader
+both re-run on any CSS resolved via @import.
+
+Storybook's webpackFinal now inherits postcss-loader from the renderer
+config. The previous ~60-line injection block is replaced by a ~15-line
+override that re-points the inherited postcss-loader at
+.storybook/postcss.config.ts.
+
+Part of PT-3920."
+```
+
+---
+
+## Task 4: Add core's Tailwind entry CSS and wire it into the renderer
+
+**Context:** The renderer webpack now processes CSS through PostCSS → Tailwind, but core doesn't have an entry file that actually triggers Tailwind's `@tailwind` directives. Add that file (utilities-only per spec §4) and import it as a side effect from the renderer's established style-import site, `src/renderer/app.component.tsx`.
+
+**Files:**
+
+- Create: `src/renderer/styles/tailwind.css`
+- Modify: `src/renderer/app.component.tsx` (near line 4, where `import './app.component.scss';` is)
+
+- [ ] **Step 1: Create `src/renderer/styles/tailwind.css`**
+
+```css
+/* Core's Tailwind entry for the paranext-core Electron app build.
+ * Utilities-only — preflight (base) is intentionally omitted.
+ * Preflight continues to come from platform-bible-react's runtime-injected CSS, scoped under
+ * .pr-twp. See docs/tailwind.md for the overall Tailwind architecture. */
+@tailwind components;
+@tailwind utilities;
+```
+
+No `@tailwind base;` directive — that matches the spec's utilities-only decision.
+
+- [ ] **Step 2: Check stylelint tolerates `@tailwind` directives**
+
+```bash
+npx stylelint src/renderer/styles/tailwind.css
+```
+
+Expected: exits 0 with no output, or at most warnings. If stylelint errors on `@tailwind` as an unknown at-rule, check whether `stylelint-config-tailwindcss` is extended in `.stylelintrc.*`. If not, add `"extends": ["stylelint-config-tailwindcss"]` to the stylelint config — the package is already in `package.json` (version `^0.0.7`).
+
+(If adding the extends is needed, include it in the Step 5 commit with a one-line commit-message bullet.)
+
+- [ ] **Step 3: Import the new entry from `src/renderer/app.component.tsx`**
+
+Open `src/renderer/app.component.tsx`. Find the existing SCSS import (currently near line 4):
+
+```ts
+import './app.component.scss';
+```
+
+Insert a new line right after it so Tailwind's utility classes load **last** in source order — Tailwind utilities are single-class (low specificity), so for any tie they must come after component CSS to win. This is the standard Tailwind-with-component-styles ordering.
+
+```ts
+import './app.component.scss';
+import './styles/tailwind.css';
+```
+
+- [ ] **Step 4: Build and verify Tailwind utilities are emitted**
+
+```bash
+npm run build 2>&1 | tail -5; echo "exit=$?"
+```
+
+Expected: `exit=0`.
+
+Sanity-check the emitted CSS for a utility that core uses but PBR's compiled CSS is unlikely to carry (pick one with the `!` modifier from `platform-bible-toolbar.tsx` usage, e.g. `tw-h-12`):
+
+```bash
+find release/app/dist/renderer -name "*.css" -exec grep -l "tw-h-12" {} + 2>/dev/null | head
+```
+
+Expected: at least one path prints.
+
+(If `release/app/dist/renderer` doesn't exist, use `find . -name "*.css" -path "*/dist*" -newer /tmp/sb-task3.log 2>/dev/null | head -5` to locate the actual output location emitted by `npm run build`.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/renderer/styles/tailwind.css src/renderer/app.component.tsx
+# If stylelint config was also adjusted in Step 2, include that file too.
+git commit -m "feat(tailwind): emit core Tailwind utilities from app build
+
+Adds src/renderer/styles/tailwind.css (utilities-only — no @tailwind
+base; directive) and imports it from src/renderer/app.component.tsx.
+Combined with the postcss-loader in the renderer webpack config,
+the paranext-core Electron app now emits its own Tailwind utilities
+from its own source. tw-* classes in core code no longer depend on
+incidental overlap with PBR's compiled bundle.
+
+Part of PT-3920."
+```
+
+---
+
+## Task 5: Runtime verification with a probe utility
+
+**Context:** The previous tasks compile and ship utilities in the bundle, but the real win is runtime rendering of a core-only class that PBR doesn't already emit. Add a temporary probe, run the app, confirm it renders, revert the probe.
+
+**Files:**
+
+- Temporary modify: `src/renderer/components/platform-bible-toolbar.tsx` (or any visible core component)
+
+- [ ] **Step 1: Add a probe**
+
+Pick a short-lived arbitrary-value utility class unlikely to appear anywhere else, e.g. `tw-rotate-[7.3deg]`. Open `src/renderer/components/platform-bible-toolbar.tsx`, find a visible top-level element with an existing `className`, and append the probe. For example, change:
+
+```tsx
+<SomeElement className="tw-h-12 tw-bg-transparent">
+```
+
+to:
+
+```tsx
+<SomeElement className="tw-h-12 tw-bg-transparent tw-rotate-[7.3deg]">
+```
+
+- [ ] **Step 2: Run the app and observe**
+
+Use the repo's standard dev startup (see `CLAUDE.md` → _Common Commands_ → _Development_). Once the app window renders, look at the toolbar — the probed element should be visibly rotated 7.3°.
+
+```bash
+./.erb/scripts/refresh.sh
+```
+
+If you can't run the app interactively in your environment, inspect the built CSS instead:
+
+```bash
+find release/app/dist/renderer -name "*.css" -exec grep -l "tw-rotate-\\[7\\.3deg\\]" {} + 2>/dev/null | head
+```
+
+Expected: at least one match (the arbitrary-value utility was detected by Tailwind's content scanner and emitted).
+
+- [ ] **Step 3: Revert the probe**
+
+Undo Step 1 so the probe is not committed:
+
+```bash
+git restore src/renderer/components/platform-bible-toolbar.tsx
+```
+
+Verify clean tree:
+
+```bash
+git diff --stat
+```
+
+Expected: no output (probe is gone).
+
+- [ ] **Step 4: No commit for this task**
+
+The probe was diagnostic only. Nothing to commit.
+
+---
+
+## Task 6: Add `docs/tailwind.md` and pointer comments
+
+**Context:** The spec requires a contributor-facing doc covering where Tailwind runs, where the configs live, how Storybook handles Tailwind, and when a story needs special setup. Tailwind config files already have one-line comments added in Tasks 1 and 2 (`See docs/tailwind.md …`); create the doc they point to.
+
+**Files:**
+
+- Create: `docs/tailwind.md`
+
+- [ ] **Step 1: Create `docs/tailwind.md`**
+
+```markdown
+# Tailwind in paranext-core
+
+This doc explains where Tailwind runs in paranext-core, which config file controls
+what, and how to author new stories that depend on Tailwind.
+
+## Where Tailwind runs
+
+| Context                              | Config                                                           | Scans                                                                                     | Emits                                                                                                          |
+| ------------------------------------ | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| paranext-core Electron app build     | `tailwind.config.ts` (root) + `postcss.config.ts` (root)         | `./src/**`                                                                                | Utilities-only (no preflight) — see "Why utilities-only" below                                                 |
+| paranext-core Storybook build        | `.storybook/tailwind.config.ts` + `.storybook/postcss.config.ts` | `./src/**`, `./extensions/src/**`, `./lib/platform-bible-react/src/**`, `./.storybook/**` | Utilities + scoped preflight (via the PBR preset's `scopedPreflightStyles({ cssSelector: '.pr-twp' })` plugin) |
+| `platform-bible-react`               | `lib/platform-bible-react/tailwind.config.ts`                    | `lib/platform-bible-react/src/**`                                                         | Utilities + scoped preflight, injected into the host document at runtime via its dist JS bundle                |
+| Each extension in `extensions/src/*` | `extensions/src/<ext>/tailwind.config.ts` + `postcss.config.ts`  | that extension's `src/**`                                                                 | Utilities + preflight, isolated by WebView (iframe)                                                            |
+
+Both core configs extend platform-bible-react's config via `presets: [libConfig]`,
+so theme tokens, the `tw-` class prefix, and the plugin list (`typography`,
+`tailwindcss-animate`, container queries, `scopedPreflightStyles`) are inherited.
+Only `content` differs between them.
+
+## Why utilities-only in the app build
+
+Core's `src/renderer/styles/tailwind.css` contains only
+`@tailwind components; @tailwind utilities;` — **not** `@tailwind base;`.
+Preflight for core continues to come from PBR's runtime-injected CSS, which is
+scoped under `.pr-twp`. Emitting preflight a second time from core would either
+duplicate rules under `.pr-twp` or leak global resets that clash with rc-dock,
+SCSS component stylesheets, and other non-Tailwind CSS. The goal of this setup
+is to emit missing utilities, not missing preflight.
+
+## Using Tailwind classes in core code
+
+Just use `tw-*` classes in core's renderer code — no additional setup. They're
+picked up by the content scanner in `tailwind.config.ts` and emitted as part of
+the app build.
+
+## Authoring a Storybook story that uses Tailwind
+
+Stories "just work" by default. The `.storybook` config scans core, extensions,
+and PBR source, so any `tw-*` class in a story file or the component under test
+gets emitted into the Storybook bundle. No per-story setup is required.
+
+## When you need something special or unexpected
+
+Reach for one of these patterns only when the default setup doesn't cover your
+case:
+
+- **Demoing a component _outside_ `.pr-twp` preflight scope.** Preflight in
+  Storybook is scoped under `.pr-twp` (applied in `.storybook/preview.ts`).
+  If you need to show what a component looks like _without_ preflight
+  (e.g. to check its base-style assumptions), wrap the story in a decorator
+  that renders the component outside any `.pr-twp` ancestor.
+- **Arbitrary-value classes built dynamically.** Tailwind's content scanner
+  looks for literal class strings in source. If you build a class name at
+  runtime (e.g. `` `tw-rotate-[${angle}deg]` ``), the scanner cannot see it and
+  won't emit the utility. Either safelist the pattern in the relevant
+  `tailwind.config.ts` or construct a finite set of literal class strings
+  the scanner can detect.
+- **Injecting an external stylesheet in a story.** If the story needs an
+  external CSS file (e.g. `rc-dock/dist/rc-dock.css` imported at the top of
+  the story), just add a plain `import` — Storybook's webpack config picks
+  up CSS imports the same way the app build does.
+
+## Tips
+
+- New `tw-*` class in core code isn't taking effect? Make sure you ran
+  `npm run build` after the code change (or restart the dev server) — the
+  Tailwind content scan runs at build time. Static analysis of class strings
+  is strict: no template literals or runtime concatenation.
+- Changed a `tailwind.config.ts` content glob and nothing happens? Restart
+  the build — webpack caches the compiled CSS.
+- Storybook rebuilds do more Tailwind work than the app build because the
+  Storybook config scans three trees (core + extensions + PBR). That's
+  expected; the app build uses the narrower root config and is faster.
+```
+
+- [ ] **Step 2: Verify the pointer comments in earlier tasks landed**
+
+```bash
+grep -l "docs/tailwind.md" tailwind.config.ts postcss.config.ts .storybook/tailwind.config.ts .storybook/postcss.config.ts .storybook/main.ts src/renderer/styles/tailwind.css
+```
+
+Expected: all six files print (each has a one-line `See docs/tailwind.md` or `See docs/tailwind.md for the overall Tailwind architecture` comment added in Tasks 1–4).
+
+If any file is missing the pointer, add it now as a one-line comment near the top of the file and include it in the Step 3 commit.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/tailwind.md
+git commit -m "docs(tailwind): add contributor guide for Tailwind in paranext-core
+
+Explains the four Tailwind contexts (app, Storybook, PBR, extensions),
+why core's app build emits utilities only (no @tailwind base;), how
+tw-* classes work in core code, how Storybook stories handle Tailwind
+by default, and the edge cases where a story needs extra setup.
+
+Pointer comments added to each Tailwind config file in earlier
+commits link here.
+
+Part of PT-3920."
+```
+
+---
+
+## Task 7: Push branch and open PR
+
+**Context:** Six commits on `pt-3920-tailwind-in-core` (one from each of Tasks 1–3, 4, 6, plus the spec commit from brainstorming). Push and open a PR targeting `main`.
+
+- [ ] **Step 1: Verify the commit history**
+
+```bash
+git log --oneline main..HEAD
+```
+
+Expected (in reverse-chronological order):
+
+```
+<sha> docs(tailwind): add contributor guide for Tailwind in paranext-core
+<sha> feat(tailwind): emit core Tailwind utilities from app build
+<sha> feat(tailwind): add postcss-loader to renderer webpack; simplify Storybook
+<sha> refactor(tailwind): narrow root configs to app-only content globs
+<sha> refactor(storybook): move Storybook Tailwind/PostCSS configs into .storybook/
+<sha> docs(pt-3920): add design spec for Tailwind in core app build
+```
+
+Six commits.
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin pt-3920-tailwind-in-core
+```
+
+Expected: exit 0; GitHub prints a PR-creation URL.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --base main --title "PT-3920: Make Tailwind fully functional in paranext-core's app build" --body "$(cat <<'EOF'
+## Summary
+- Wire Tailwind into the paranext-core Electron app webpack build so core's `tw-*` utility classes are emitted from core's own source.
+- Split the existing Storybook-only Tailwind/PostCSS configs into two config pairs — root configs are now app-only, `.storybook/tailwind.config.ts` + `.storybook/postcss.config.ts` are Storybook-only.
+- Simplify `.storybook/main.ts`: replaces a ~60-line `postcss-loader` injection with a ~15-line override that just re-points the inherited loader at the Storybook config.
+- Utilities-only emission from core — preflight keeps coming from PBR's runtime-injected CSS under `.pr-twp`.
+- New `docs/tailwind.md` explains the full Tailwind architecture for contributors.
+
+Full design: `docs/specs/2026-04-16-tailwind-in-core-design.md`
+Implementation plan: `docs/plans/2026-04-16-tailwind-in-core.md`
+
+## Test plan
+- [x] `npm run build` succeeds; renderer bundle emits `tw-*` utilities from core's own source.
+- [x] `npm run storybook:build` succeeds; output contains utilities from core + extensions + PBR source as before.
+- [x] A previously-silent utility (probe: `tw-rotate-[7.3deg]` on the toolbar) renders correctly in the running app.
+- [ ] `npm run storybook` (dev mode) starts and stories render with Tailwind styling.
+- [ ] Extension builds still produce their own Tailwind output (`npm run build` covers this).
+- [ ] `.storybook/main.ts` monkey-patch is gone; Storybook inherits postcss-loader from renderer webpack.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed to stdout.
+
+- [ ] **Step 4: Report PR URL to the user**
+
+Print the URL. Task complete.

--- a/docs/specs/2026-04-16-tailwind-in-core-design.md
+++ b/docs/specs/2026-04-16-tailwind-in-core-design.md
@@ -1,0 +1,180 @@
+# Make Tailwind fully functional in paranext-core's app build
+
+**Date:** 2026-04-16
+**Status:** Approved
+**Ticket:** PT-3920
+
+## Motivation
+
+Developers in paranext-core's main renderer use Tailwind utility classes
+(`tw-*`) throughout — 51 occurrences across files like
+`src/renderer/components/platform-bible-toolbar.tsx`. These classes only render
+correctly today by incidental overlap with utilities that platform-bible-react
+(PBR) happens to emit into its own compiled bundle. If core adds a `tw-*` class
+that PBR doesn't also use, it silently has no style — developers hit this as
+"the class doesn't work" and either add CSS hacks or drop the class.
+
+The user story:
+
+> As a developer I need the same classnames to be available all over Platform
+> so that I can develop UIs without the need for hacks.
+
+This spec eliminates the incidental-overlap dependency by wiring Tailwind into
+paranext-core's app build so it emits its own utilities for its own source.
+
+## Current state
+
+### How Tailwind flows today
+
+| Context                          | Tailwind processing? | How                                                                                                                                                                                                          |
+| -------------------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| PBR (`lib/platform-bible-react`) | ✅ Own build         | Emits scoped preflight (`.pr-twp`) + utilities; injected at runtime into the host document via PBR's dist `.js` bundle (no standalone `.css` file)                                                           |
+| Extensions (`extensions/src/*`)  | ✅ Own builds        | Each extension has its own `tailwind.config.ts` + `postcss.config.ts` + `tailwind.css`; emits unscoped preflight + utilities, isolated by WebView (iframe)                                                   |
+| Core app (`src/renderer/*`)      | ❌ **Not processed** | `postcss-loader` is intentionally omitted from `webpack.config.renderer.*`; core relies on PBR's runtime-injected CSS for any Tailwind classes it uses (works only when PBR also uses the same class)        |
+| Core Storybook                   | ✅ Via monkey-patch  | `.storybook/main.ts:59-115` injects `postcss-loader` into the renderer's CSS rules for Storybook only; root `tailwind.config.ts` and `postcss.config.ts` are Storybook-only (comments in those files say so) |
+
+### Symptom
+
+Any core-only `tw-*` class that PBR does not itself emit is missing from the
+rendered document's styles. Workaround patterns seen in the past include inline
+`<style>` blocks duplicating a subset of Tailwind rules (e.g. the inline CSS
+hack removed from `home.stories.tsx` in commit `a639bb1124`). Without this
+change, similar hacks will recur whenever a developer adds a new Tailwind class
+to core.
+
+### Ticket reference
+
+`tailwind.config.ts:15-18` explicitly marks PT-3920 as the ticket that splits
+app vs. Storybook Tailwind content globs:
+
+> When https://paratextstudio.atlassian.net/browse/PT-3920 is implemented, the
+> app's tailwind config will NOT need to include extensions or
+> lib/platform-bible-react since they will build their own tailwind files
+> independently, but they will need to continue to be included in Storybook's
+> config since Storybook still pulls in source files from those packages.
+
+## Design
+
+No new dependencies. All Tailwind/PostCSS packages (`tailwindcss`,
+`postcss-loader`, `autoprefixer`, `tailwindcss-animate`,
+`tailwindcss-scoped-preflight`, `@tailwindcss/typography`,
+`@tailwindcss/container-queries`) are already in root `package.json` (installed
+for Storybook's use).
+
+### 1. App build: add Tailwind processing to the renderer webpack
+
+- Add `postcss-loader` to the renderer's CSS loader chain in the shared
+  `.erb/configs/webpack.config.renderer.*` configs.
+- Add a new entry CSS file for core's Tailwind: `src/renderer/styles/tailwind.css`
+  (location chosen to match the existing `src/renderer/styles/` folder).
+- Contents of the entry CSS: `@tailwind components; @tailwind utilities;`
+  (no `@tailwind base;`) — **utilities-only**, per the preflight decision below.
+- Side-effect import from `src/renderer/app.component.tsx` (next to the
+  existing `import './app.component.scss';`). A plain (non-`?raw`) import
+  triggers webpack → postcss-loader → Tailwind. `app.component.tsx` is the
+  established site for non-raw renderer style imports.
+
+### 2. Config split — four files
+
+| File                            | Used by                 | Content globs                                                                             |
+| ------------------------------- | ----------------------- | ----------------------------------------------------------------------------------------- |
+| `tailwind.config.ts` (root)     | App build (new)         | `./src/**/*.{js,ts,jsx,tsx}` only                                                         |
+| `postcss.config.ts` (root)      | App build (new)         | references root `tailwind.config.ts`                                                      |
+| `.storybook/tailwind.config.ts` | Storybook build (moved) | `./src/**`, `./extensions/src/**`, `./lib/platform-bible-react/src/**`, `./.storybook/**` |
+| `.storybook/postcss.config.ts`  | Storybook build (moved) | references `.storybook/tailwind.config.ts`                                                |
+
+Both Tailwind configs extend PBR's config via `presets: [libConfig]` (where
+`libConfig` is imported from `./lib/platform-bible-react/tailwind.config`).
+This preserves the existing pattern: theme tokens, `tw-` prefix, plugins
+(`typography`, `tailwindCssAnimate`, container queries,
+`scopedPreflightStyles`) all come from PBR. Only `content` differs.
+
+Extensions' and PBR's own configs are not touched.
+
+### 3. Storybook wiring simplification
+
+Today `.storybook/main.ts:59-115` contains ~60 lines of webpack-merge logic
+that injects `postcss-loader` into the renderer config's CSS rules, because
+`postcss-loader` isn't in the shared renderer config. Once we add
+`postcss-loader` to the shared renderer config (Design §1), Storybook inherits
+it naturally.
+
+- **Remove** the injection monkey-patch from `.storybook/main.ts`.
+- **Add** a small override so Storybook's inherited `postcss-loader` uses
+  `.storybook/postcss.config.ts` (which references the Storybook-scoped
+  Tailwind config) instead of the root `postcss.config.ts` (which is
+  app-scoped and would only scan core).
+
+Expected size: ~10 lines, down from ~60.
+
+### 4. Preflight policy — utilities-only for core
+
+Core's own build emits **no** Tailwind base/preflight. Rationale:
+
+- PBR already emits scoped preflight under `.pr-twp` (via
+  `scopedPreflightStyles({ cssSelector: '.pr-twp' })` in its config) and
+  injects it at runtime via its dist bundle. Core continues to receive
+  preflight from PBR wherever `.pr-twp` is on the DOM.
+- Emitting preflight from core too would either double-emit the same rules
+  (if scoped under `.pr-twp`) or leak resets outside PBR trees (if unscoped,
+  colliding with rc-dock, SCSS files, etc.).
+- Core's gap today is missing _utilities_, not missing preflight. Fix only
+  what's broken.
+
+### 5. Documentation
+
+Note: on `main`, `.context/standards/` is a symlink into the `ai-prompts`
+repo — not part of the paranext-core tree. Docs need to live in the main
+tree. The convention we started in Task 1 uses `docs/specs/` and
+`docs/plans/`; extending with a short contributor-facing note keeps that
+convention growing.
+
+- **New file:** `docs/tailwind.md` (~50–100 lines) covering:
+  - Where Tailwind runs today (app build, Storybook, extensions, PBR) — a
+    short version of the table in "Current state".
+  - Where the two Tailwind configs live (`tailwind.config.ts` at root for
+    the app; `.storybook/tailwind.config.ts` for Storybook).
+  - How `tw-*` classes in core code just work — no special setup.
+  - How core stories just work — the Storybook config scans all source.
+  - **When you'd need something special/unexpected in a story** —
+    e.g. demoing a component _outside_ `.pr-twp` preflight scope, or
+    needing arbitrary-value classes that aren't detected by Tailwind's
+    content scanner, or injecting an external stylesheet.
+- **Pointer comments:** top of each Tailwind config file — a one-line
+  comment linking to `docs/tailwind.md` so future readers don't have to
+  guess which config does what.
+
+## Out of scope
+
+- Touching extensions' Tailwind/PostCSS setups.
+- Touching PBR's Tailwind config or its runtime style-injection.
+- Deleting the `home.stories.tsx` hack (already handled by commit
+  `a639bb1124`; scratched from the user story during brainstorming).
+- Switching core to emit its own preflight under `.pr-twp` or a new scope
+  (utilities-only was chosen; revisit only if a concrete preflight gap
+  surfaces).
+- Replacing Tailwind 3 with Tailwind 4.
+
+## Acceptance criteria
+
+1. `npm run build` succeeds; the renderer bundle includes core's emitted
+   utilities.
+2. `npm run storybook:build` still succeeds; Storybook uses the new
+   `.storybook/tailwind.config.ts` and scans core + extensions + PBR source
+   as before.
+3. `npm run storybook` (dev) still shows stories with proper Tailwind styling.
+4. In the running app, a `tw-*` utility used by core but **not** by PBR
+   renders correctly. Concrete check: introduce a temporary probe class in
+   core (e.g. `className="tw-rotate-[7deg]"` on a toolbar element) — it
+   applies the rotation. Revert the probe before merge.
+5. Root `tailwind.config.ts` no longer references `extensions/` or
+   `lib/platform-bible-react/` in its content globs; the updated
+   `.storybook/tailwind.config.ts` does.
+6. `.storybook/main.ts`'s ~60-line `postcss-loader` injection block is
+   removed; replaced by a small override (~10 lines) that points Storybook's
+   inherited `postcss-loader` at `.storybook/postcss.config.ts`.
+7. `tailwind.config.ts:15-18` comment referencing PT-3920 is removed or
+   updated (the "when PT-3920 is implemented" prediction no longer belongs
+   in the config once it's implemented).
+8. `docs/tailwind.md` added per Design §5; pointer comments at the top of
+   each Tailwind config file link to it.

--- a/docs/tailwind.md
+++ b/docs/tailwind.md
@@ -1,0 +1,73 @@
+# Tailwind in paranext-core
+
+This doc explains where Tailwind runs in paranext-core, which config file controls
+what, and how to author new stories that depend on Tailwind.
+
+## Where Tailwind runs
+
+| Context                              | Config                                                           | Scans                                                                                     | Emits                                                                                                          |
+| ------------------------------------ | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| paranext-core Electron app build     | `tailwind.config.ts` (root) + `postcss.config.ts` (root)         | `./src/**`                                                                                | Utilities-only (no preflight) — see "Why utilities-only" below                                                 |
+| paranext-core Storybook build        | `.storybook/tailwind.config.ts` + `.storybook/postcss.config.ts` | `./src/**`, `./extensions/src/**`, `./lib/platform-bible-react/src/**`, `./.storybook/**` | Utilities + scoped preflight (via the PBR preset's `scopedPreflightStyles({ cssSelector: '.pr-twp' })` plugin) |
+| `platform-bible-react`               | `lib/platform-bible-react/tailwind.config.ts`                    | `lib/platform-bible-react/src/**`                                                         | Utilities + scoped preflight, injected into the host document at runtime via its dist JS bundle                |
+| Each extension in `extensions/src/*` | `extensions/src/<ext>/tailwind.config.ts` + `postcss.config.ts`  | that extension's `src/**`                                                                 | Utilities + preflight, isolated by WebView (iframe)                                                            |
+
+Both core configs extend platform-bible-react's config via `presets: [libConfig]`,
+so theme tokens, the `tw-` class prefix, and the plugin list (`typography`,
+`tailwindcss-animate`, container queries, `scopedPreflightStyles`) are inherited.
+Only `content` differs between them.
+
+## Why utilities-only in the app build
+
+Core's `src/renderer/styles/tailwind.css` contains only
+`@tailwind components; @tailwind utilities;` — **not** `@tailwind base;`.
+Preflight for core continues to come from PBR's runtime-injected CSS, which is
+scoped under `.pr-twp`. Emitting preflight a second time from core would either
+duplicate rules under `.pr-twp` or leak global resets that clash with rc-dock,
+SCSS component stylesheets, and other non-Tailwind CSS. The goal of this setup
+is to emit missing utilities, not missing preflight.
+
+## Using Tailwind classes in core code
+
+Just use `tw-*` classes in core's renderer code — no additional setup. They're
+picked up by the content scanner in `tailwind.config.ts` and emitted as part of
+the app build.
+
+## Authoring a Storybook story that uses Tailwind
+
+Stories "just work" by default. The `.storybook` config scans core, extensions,
+and PBR source, so any `tw-*` class in a story file or the component under test
+gets emitted into the Storybook bundle. No per-story setup is required.
+
+## When you need something special or unexpected
+
+Reach for one of these patterns only when the default setup doesn't cover your
+case:
+
+- **Demoing a component _outside_ `.pr-twp` preflight scope.** Preflight in
+  Storybook is scoped under `.pr-twp` (applied in `.storybook/preview.ts`).
+  If you need to show what a component looks like _without_ preflight
+  (e.g. to check its base-style assumptions), wrap the story in a decorator
+  that renders the component outside any `.pr-twp` ancestor.
+- **Arbitrary-value classes built dynamically.** Tailwind's content scanner
+  looks for literal class strings in source. If you build a class name at
+  runtime (e.g. `` `tw-rotate-[${angle}deg]` ``), the scanner cannot see it and
+  won't emit the utility. Either safelist the pattern in the relevant
+  `tailwind.config.ts` or construct a finite set of literal class strings
+  the scanner can detect.
+- **Injecting an external stylesheet in a story.** If the story needs an
+  external CSS file (e.g. `rc-dock/dist/rc-dock.css` imported at the top of
+  the story), just add a plain `import` — Storybook's webpack config picks
+  up CSS imports the same way the app build does.
+
+## Tips
+
+- New `tw-*` class in core code isn't taking effect? Make sure you ran
+  `npm run build` after the code change (or restart the dev server) — the
+  Tailwind content scan runs at build time. Static analysis of class strings
+  is strict: no template literals or runtime concatenation.
+- Changed a `tailwind.config.ts` content glob and nothing happens? Restart
+  the build — webpack caches the compiled CSS.
+- Storybook rebuilds do more Tailwind work than the app build because the
+  Storybook config scans three trees (core + extensions + PBR). That's
+  expected; the app build uses the narrower root config and is faster.

--- a/postcss.config.ts
+++ b/postcss.config.ts
@@ -1,4 +1,5 @@
-// PostCSS configuration for Storybook (not used by the Electron app build)
+// PostCSS configuration for the paranext-core Electron app. See docs/tailwind.md for the overall
+// Tailwind architecture. Storybook has its own PostCSS config at .storybook/postcss.config.ts.
 import type { Config } from 'postcss-load-config';
 
 const config: Config = {

--- a/postcss.config.ts
+++ b/postcss.config.ts
@@ -2,6 +2,12 @@
 // Tailwind architecture. Storybook has its own PostCSS config at .storybook/postcss.config.ts.
 import type { Config } from 'postcss-load-config';
 
+// This config uses the object form of the `plugins` map — `tailwindcss` with no options means
+// PostCSS's default config discovery finds `./tailwind.config.ts` at the repo root. The Storybook
+// config at `.storybook/postcss.config.ts` uses the array form instead so it can pass
+// `{ config: '.storybook/tailwind.config.ts' }` to the tailwindcss plugin and override the default
+// discovery. The two shapes are functionally equivalent here; the difference is forced by that
+// need to pass options in the Storybook setup.
 const config: Config = {
   plugins: {
     tailwindcss: {},

--- a/src/renderer/app.component.tsx
+++ b/src/renderer/app.component.tsx
@@ -2,6 +2,7 @@ import { PlatformDockLayout } from '@renderer/components/docking/platform-dock-l
 import { TestContext } from '@renderer/context/papi-context/test.context';
 import { Route, MemoryRouter as Router, Routes } from 'react-router-dom';
 import './app.component.scss';
+import './styles/tailwind.css';
 import { NotificationDisplay } from './components/notification-display';
 import { OverlayHost } from './components/overlay-host.component';
 import { PlatformBibleToolbar } from './components/platform-bible-toolbar';

--- a/src/renderer/styles/tailwind.css
+++ b/src/renderer/styles/tailwind.css
@@ -1,0 +1,6 @@
+/* Core's Tailwind entry for the paranext-core Electron app build.
+ * Utilities-only — preflight (base) is intentionally omitted.
+ * Preflight continues to come from platform-bible-react's runtime-injected CSS, scoped under
+ * .pr-twp. See docs/tailwind.md for the overall Tailwind architecture. */
+@tailwind components;
+@tailwind utilities;

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,33 +1,15 @@
 import type { Config } from 'tailwindcss';
+// See docs/tailwind.md for the overall Tailwind architecture. This config is used by the
+// paranext-core Electron app webpack build to emit utilities from core's own source.
+// Storybook has its own config at .storybook/tailwind.config.ts that scans extensions and
+// platform-bible-react too.
 // Root imports from PBR (not the other way around) because PBR is shared externally and cannot
 // depend on this monorepo root.
 import libConfig from './lib/platform-bible-react/tailwind.config';
 
-// Use the library config as a Tailwind preset so its theme, plugins, and other settings are
-// deep-merged correctly. Only override content to cover the full monorepo including .storybook/.
-//
-// NOTE: This tailwind config is for Storybook only. It includes extension and platform-bible-react
-// source files because Storybook pulls them in directly (rather than using their built outputs).
-// .storybook/main.ts adds an alias to reroute PBR imports to source files rather than dist (which
-// bypasses the styleinject that happens in dist).
-// The preset's content paths (e.g. './src/**') resolve relative to the root project, NOT the
-// preset file, so PBR source must be listed explicitly here.
-// When https://paratextstudio.atlassian.net/browse/PT-3920 is implemented, the app's tailwind
-// config will NOT need to include extensions or lib/platform-bible-react since they will build
-// their own tailwind files independently, but they will need to continue to be included in
-// Storybook's config since Storybook still pulls in source files from those packages.
 const config: Config = {
   presets: [libConfig],
-  content: [
-    './src/**/*.{js,ts,jsx,tsx}',
-    './extensions/src/**/*.{js,ts,jsx,tsx}',
-    './lib/platform-bible-react/src/**/*.{js,ts,jsx,tsx}',
-    './.storybook/**/*.{ts,tsx}',
-    // Ignore build artifacts and dependencies within extensions to avoid slow builds
-    '!./**/node_modules/**/*',
-    '!./**/temp-build/**/*',
-    '!./**/dist/**/*',
-  ],
+  content: ['./src/**/*.{js,ts,jsx,tsx}'],
 };
 
 export default config;


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-3920-tailwind-in-core

**Base**: origin/main

**Date**: 2026-04-16

**Review model**: Claude Opus 4.7

**Files changed**: 13

## Overview

PT-3920 wires Tailwind processing into the paranext-core Electron app build so
core's `tw-*` utilities are emitted from core's own source rather than relying
on incidental overlap with `platform-bible-react` (PBR)'s runtime-injected CSS.
Before this PR, `postcss-loader` was intentionally omitted from the renderer
webpack config; any `tw-*` class core used that PBR didn't happen to also emit
rendered as nothing. This caused "the class doesn't work" confusion and invited
inline-CSS hacks (one of which was deleted earlier in commit `a639bb1124`).

The change is config-only: no runtime code paths are altered, no public API is
touched. `postcss-loader` is added to the shared renderer webpack config (dev +
prod), a new utilities-only `src/renderer/styles/tailwind.css` entry is
imported from `app.component.tsx`, and the existing root Tailwind/PostCSS
configs are split — root configs become app-only (scan `./src/**`), new
`.storybook/tailwind.config.ts` / `.storybook/postcss.config.ts` scan core +
extensions + PBR source for the Storybook build. The ~60-line `postcss-loader`
injection monkey-patch in `.storybook/main.ts` collapses to a ~15-line
override that re-points the now-inherited loader at the Storybook config path.
Core emits utilities only (no `@tailwind base;`) — preflight keeps coming from
PBR's `.pr-twp`-scoped CSS.

## API Changes

None. No files in `lib/platform-bible-react/`, `lib/platform-bible-utils/`,
`papi.d.ts` (`@papi/` modules), or extensions' type declaration files were
modified. All changes are confined to build configuration, Storybook
configuration, a new CSS entry file, a single `import` line in
`src/renderer/app.component.tsx`, and documentation under `docs/`.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **DRY: renderer webpack CSS loader arrays duplicated across `.erb/configs/webpack.config.renderer.{dev,prod}.ts`** _(fixed during review: extracted `buildRendererCssLoaders` into new `.erb/configs/css-loaders.ts`; dev and prod now differ only in the first-loader argument)_

[Author response: agreed the duplication was worth fixing since this PR widened it. Extracted the helper and verified both builds still succeed.]

### Minor — Consider

- [ ] ~~`docs/tailwind.md` placement: analyzer suggested `.context/standards/Tailwind-Guide.md` to match existing contributor-doc naming~~ _(on the `main` branch, `.context/` is a symlink into the `ai-prompts` repo and is not part of this repo's git tree. `docs/` is the only viable in-tree location for contributor docs.)_
- [ ] ~~Root and `.storybook` Tailwind configs are nearly identical — could share a base~~ _(the only shared line is `presets: [libConfig]`; any further abstraction would hide more than it saves. Current arrangement is explicit and readable.)_
- [x] **PostCSS plugin shape inconsistency between root (`{ tailwindcss: {}, autoprefixer: {} }` object form) and `.storybook` (`[tailwindcss({ config: '...' }), autoprefixer()]` array form)** _(fixed during review: added a 6-line comment to `postcss.config.ts` explaining why the shapes differ — the array form is required in Storybook to pass `{ config }` to the tailwindcss plugin; they are functionally equivalent otherwise.)_
- [ ] ~~Plugin-conflict filter in `.storybook/main.ts` only documents `HtmlWebpackPlugin` even though the array also includes `BundleAnalyzerPlugin`~~ _(that code was cherry-picked from PT-3921 where it has already been reviewed and merged to ai/main. Editing it here would create merge-conflict noise once PT-3921 lands. Raise on PT-3921 instead.)_
- [ ] ~~Stale "will not affect anything" comment on the DEV branch of the `require(renderer.dev)` ternary in `.storybook/main.ts` (PROD branch was updated in PT-3921 but DEV was not)~~ _(same cherry-pick; same reason to leave untouched.)_
- [ ] ~~Unusual-for-Tailwind omission of `@tailwind base;` in the app entry CSS~~ _(intentional and thoroughly documented both inline in `src/renderer/styles/tailwind.css` and in `docs/tailwind.md` §"Why utilities-only in the app build". No action needed.)_

[Author response: fixed finding #3 with an inline comment. Dismissed findings #1, #2, #4, #5, #6 for the reasons above.]

### Template Propagation

#### Shared Regions Modified

None. No changed file contains `#region shared with` markers.

#### Extension Config Changes

None. All changes are outside `extensions/`. The touched configs
(`.erb/configs/webpack.config.renderer.{dev,prod}.ts`, root `tailwind.config.ts`,
root `postcss.config.ts`, `.storybook/*`) are core app and Storybook
infrastructure — not extension configs.

## Positive Observations

- Purpose alignment is clean and verifiable — each commit stands on its own
  (split Storybook configs, narrow root configs, wire postcss-loader, add entry
  CSS, add docs, address review).
- `importLoaders: 2` bump is correct and commented at each site; good defense
  against future readers trimming what might look like an off-by-one.
- `isPostcssLoader` predicate in `.storybook/main.ts` (added during prior local
  review before `/review-paratext`) handles both bare-string and object-form
  `postcss-loader` entries, future-proofing against renderer-config shape
  changes.
- `src/renderer/styles/tailwind.css` is minimal (two directives) with a clear
  inline comment explaining why `@tailwind base;` is omitted — an easy detail
  for a future developer to "fix" without this guardrail.
- `docs/tailwind.md` gives future contributors a map of which config scans
  what, why preflight is omitted from the app build, and specifies the edge
  cases where a story needs special setup.
- `scopedPreflightStyles` plugin comes through the PBR preset, so the two new
  Storybook-scope Tailwind configs inherit scoped preflight without
  re-declaring it.
- No new dependencies introduced — every Tailwind/PostCSS package used was
  already installed for Storybook's sake.

## Interview Notes

**Stated purpose** (from command invocation): "Wire Tailwind into the
paranext-core Electron app build (PT-3920). Split root Tailwind/PostCSS configs
into app-only vs Storybook-only, add postcss-loader to renderer webpack, add
utilities-only src/renderer/styles/tailwind.css, simplify .storybook/main.ts
monkey-patch."

**Key decisions the author made:**

- **Utilities-only emission from core** (no `@tailwind base;`). Rationale:
  preflight already comes from PBR's runtime-injected CSS under `.pr-twp`;
  emitting a second preflight from core would either double-emit under
  `.pr-twp` or leak global resets that clash with rc-dock and SCSS component
  styles.
- **Keep both webpack aliases** (`platform-bible-react` → PBR source,
  `@` → `lib/platform-bible-react/src`) in `.storybook/main.ts`. The `@` alias
  is required transitively — when webpack compiles PBR source via the
  `platform-bible-react` alias, PBR's own internal imports use `@/…` paths.
- **Cherry-pick the Storybook production-build fix from PT-3921** (commit
  `103171132c`) rather than stacking PRs. Author acknowledged this as a
  temporary state; the cherry-picked commit will drop as a no-op once PT-3921
  merges and this branch is rebased onto `main`.
- **Added a new `docs/` convention** (`docs/specs/`, `docs/plans/`,
  `docs/tailwind.md`) since `.context/standards/` is a symlink into the
  ai-prompts repo on `main` and is not part of this repo's git tree.

**Author opted to skip the Step 3.3 design-understanding walkthrough.** For
the reviewer meeting, the key non-obvious point the walkthrough would have
covered is: **why Storybook still needs its own wider content globs** (scans
core + extensions + PBR source) even though the app build now processes
Tailwind natively. The answer is that Storybook consumes the three source
trees directly via webpack aliases (rather than each package's built output),
so its Tailwind scan must cover all three or utilities from imported code
won't be emitted. The new `.storybook/tailwind.config.ts` head-of-file comment
explains this inline.

**Runtime verification performed during the review** (Phase 4):

1. Re-added `tw-rotate-[7.3deg]` probe to the Platform.Bible toolbar.
2. Rebuilt and started the Electron app via `./refresh.sh`.
3. Via CDP/Playwright, queried the Toolbar DOM element: class list is
   `tw-border tw-px-4 tw-text-foreground tw-h-12 tw-bg-transparent tw-rotate-[7.3deg]`;
   computed transform is `matrix(0.991894, 0.127065, -0.127065, 0.991894, 0, 0)`
   — exactly `[cos(7.3°), sin(7.3°), -sin(7.3°), cos(7.3°)]`.
4. Reverted the probe.

This is end-to-end proof that a core-only Tailwind utility flows from source →
our new postcss/tailwind pipeline → compiled CSS → loaded renderer → applied
at runtime.

**Unresolved items:** none.

**Author does not understand:** nothing explicit — the author declined Step
3.3 rather than attempting an explanation, so the reviewer may want to cover
the Storybook content-glob rationale (above) in the meeting just to confirm
shared understanding.

**Additional context the author flagged:**

- This branch carries a cherry-picked copy of PT-3921's Storybook build fix
  (commit `103171132c`). It will rebase-drop once PT-3921 merges.
- Feedback items on the `.storybook/main.ts` cherry-picked block (the
  `BundleAnalyzerPlugin`-only-in-the-array and the "will not affect anything"
  stale comment) were intentionally left untouched in this PR; they belong on
  PT-3921's PR instead.

## In-Review Quality Check

All quality checks passed cleanly on the staged in-review changes:

- `npm run typecheck` — passed across all projects
- `npm run lint` — 0 errors, 0 warnings
- `npm run format` — no changes needed
- `npm test` — all test suites passed (1540+ tests across 156 files)

No auto-fixes were required. No unfixable failures.

## Suggested Review Focus

Prioritized areas for the author-reviewer meeting:

- [ ] **Confirm shared understanding of the Storybook-vs-app Tailwind split.**
      The app's Tailwind config now scans `./src/**` only; Storybook's new config
      scans core + extensions + PBR source. Why the asymmetry is needed: Storybook
      pulls those three trees directly from source (via webpack aliases that
      bypass PBR's runtime style-inject), so its Tailwind content globs must cover
      all three or classes in imported code won't be emitted. Author skipped the
      design walkthrough — worth confirming.
- [ ] **Confirm the utilities-only decision for core's entry CSS.** No
      `@tailwind base;` in `src/renderer/styles/tailwind.css`. Preflight continues
      to come from PBR's `.pr-twp` runtime injection. Rationale is in
      `docs/tailwind.md`. Reviewer should confirm they agree emitting preflight
      from core would create conflicts rather than resolving them.
- [ ] **Acknowledge the cherry-pick dependency on PT-3921.** Commit
      `103171132c` in this branch is a verbatim cherry-pick of the Storybook
      production-build fix from PT-3921 (#2204). Once PT-3921 merges to `main`,
      rebase this branch and the cherry-picked commit drops as a no-op. Two
      unrelated review findings on that block (stale DEV comment;
      `BundleAnalyzerPlugin` not documented) were intentionally left for PT-3921's
      PR.
- [ ] **Runtime verification evidence.** A `tw-rotate-[7.3deg]` probe on the
      Platform.Bible toolbar was confirmed via CDP at runtime: the rotation matrix
      on the rendered element matches `cos/sin(7.3°)` exactly. This verifies the
      full pipeline end-to-end.
- [ ] **DRY refactor introduced during review.** New
      `.erb/configs/css-loaders.ts` exports `buildRendererCssLoaders`; both
      renderer configs now differ only in which first-loader they pass (style vs
      MiniCssExtractPlugin). Sanity-check the helper signature and the comment at
      the top of the file.
<!-- review-paratext:summary:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/paranext/paranext-core/pull/2205" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2205)
<!-- Reviewable:end -->
