### PR TITLE
PT-3888: Fix book-with-data looks empty after navigating through non-existent book

### DIFF
--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -87,6 +87,7 @@ import {
   removeDecorations,
 } from './decorations.util';
 import { runOnFirstLoad, scrollToAnnotation, scrollToVerse } from './editor-dom.util';
+import { useEditorPdpSync } from './use-editor-pdp-sync.hook';
 import { FootnotesLayout } from './platform-scripture-editor-footnotes.component';
 import {
   availableScrollGroupIds,
@@ -1258,26 +1259,15 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
     [scrRef, webViewId],
   );
 
-  // Update the editor if a change comes in from the PDP
-  // Note: this will run every time we get data from the PDP whether or not it is different than it
-  // was previously. We need to know when data comes in so we can set
-  // `currentlyWritingUsjToPdp.current` to `false` appropriately
-  useEffect(() => {
-    if (!usjFromPdp || !editorRef.current) return;
-
-    // The PDP informed us of updates, so writing to it must be complete (if we were writing)
-    currentlyWritingUsjToPdp.current = false;
-
-    // If what the PDP provided is different than the last thing we sent to the PDP, assume the PDP
-    // has the best data. This could happen if the selected chapter changed or something other than
-    // the editor wrote to the PDP.
-    if (!areUsjContentsEqualExceptWhitespace(usjFromPdp, usjSentToPdp.current)) {
-      usjSentToPdp.current = usjFromPdp;
-      setEditorUsj.current(usjFromPdp);
-    }
-    // If the editor has updates that the PDP hasn't recorded, save them to the PDP
-    else saveUsjToPdpIfUpdated();
-  }, [saveUsjToPdpIfUpdated, usjFromPdp]);
+  // Sync editor content with PDP data and track write completion
+  useEditorPdpSync({
+    usjFromPdp,
+    editorRef,
+    usjSentToPdp,
+    setEditorUsj,
+    currentlyWritingUsjToPdp,
+    saveUsjToPdpIfUpdated,
+  });
 
   // On loading the first time, scroll the selected verse into view and set focus to the editor
   useEffect(() => {

--- a/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.test.ts
+++ b/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.test.ts
@@ -19,7 +19,7 @@ import { act, renderHook } from '@testing-library/react';
 import { Usj } from '@eten-tech-foundation/scripture-utilities';
 import { useRef } from 'react';
 import { describe, expect, it, vi } from 'vitest';
-import type { EditorHandle } from './use-editor-pdp-sync.hook';
+import type { EditorRef } from '@eten-tech-foundation/platform-editor';
 import { useEditorPdpSync } from './use-editor-pdp-sync.hook';
 
 // Empty USJ — returned by useProjectData while loading or when a book doesn't exist
@@ -48,7 +48,9 @@ describe('useEditorPdpSync', () => {
     const saveUsjToPdpIfUpdated = vi.fn();
 
     renderHook(() => {
-      const editorRef = useRef<EditorHandle | null>({ setUsj: setUsjSpy });
+      // EditorRef has many members; casting from a minimal stub is intentional in tests
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      const editorRef = useRef<EditorRef | null>({ setUsj: setUsjSpy } as unknown as EditorRef);
       const usjSentToPdp = useRef<Usj | undefined>(undefined);
       const setEditorUsj = useRef((usj: Usj) => setUsjSpy(usj));
       const currentlyWritingUsjToPdp = useRef(false);
@@ -76,9 +78,14 @@ describe('useEditorPdpSync', () => {
     const setUsjSpy = vi.fn();
     const saveUsjToPdpIfUpdated = vi.fn();
 
-    // Shared refs so rerenders observe the same state
-    const editorRef = { current: { setUsj: setUsjSpy } as EditorHandle | null };
-    const usjSentToPdp = { current: undefined as Usj | undefined };
+    // Plain objects instead of useRef so that state mutations are visible across rerenders without
+    // closure capture. useRef would re-create the ref on each render inside renderHook's callback.
+    const editorRef: { current: EditorRef | null } = {
+      // EditorRef has many members; casting from a minimal stub is intentional in tests
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      current: { setUsj: setUsjSpy } as unknown as EditorRef,
+    };
+    const usjSentToPdp: { current: Usj | undefined } = { current: undefined };
     const setEditorUsj = { current: (usj: Usj) => setUsjSpy(usj) };
     const currentlyWritingUsjToPdp = { current: false };
 
@@ -118,8 +125,12 @@ describe('useEditorPdpSync', () => {
     const saveUsjToPdpIfUpdated = vi.fn();
 
     // Shared refs that persist across rerenders, just like in the real component
-    const editorRef = { current: { setUsj: setUsjSpy } as EditorHandle | null };
-    const usjSentToPdp = { current: undefined as Usj | undefined };
+    const editorRef: { current: EditorRef | null } = {
+      // EditorRef has many members; casting from a minimal stub is intentional in tests
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      current: { setUsj: setUsjSpy } as unknown as EditorRef,
+    };
+    const usjSentToPdp: { current: Usj | undefined } = { current: undefined };
     const setEditorUsj = { current: (usj: Usj) => setUsjSpy(usj) };
     const currentlyWritingUsjToPdp = { current: false };
 
@@ -144,6 +155,7 @@ describe('useEditorPdpSync', () => {
 
     // Step 2: Navigate to non-existent 2KI — editor unmounts (editorRef.current = null) and
     // usjFromPdp becomes emptyUsj (the "book doesn't exist" state)
+    // eslint-disable-next-line no-null/no-null -- simulates React unmounting an element ref (which uses null)
     editorRef.current = null;
     act(() => rerender({ usjFromPdp: emptyUsj }));
 
@@ -152,7 +164,8 @@ describe('useEditorPdpSync', () => {
     expect(setUsjSpy).not.toHaveBeenCalled();
 
     // Step 3: Navigate back to LEV — same chapter data arrives and the editor remounts fresh
-    editorRef.current = { setUsj: setUsjSpy };
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    editorRef.current = { setUsj: setUsjSpy } as unknown as EditorRef;
     act(() => rerender({ usjFromPdp: levUsj }));
 
     // The fresh (empty) editor must receive its content even though the data hasn't changed

--- a/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.test.ts
+++ b/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.test.ts
@@ -1,0 +1,162 @@
+// @vitest-environment jsdom
+
+/**
+ * Regression tests for useEditorPdpSync.
+ *
+ * Bug: After navigating through a non-existent book and back to a previously-visited chapter, the
+ * editor showed "Enter some scripture…" (empty placeholder) instead of chapter content.
+ *
+ * Root cause: usjSentToPdp was not reset when the editor unmounted (editorRef.current === null). On
+ * returning to the same chapter, usjFromPdp matched the stale usjSentToPdp value, so the equality
+ * check skipped the setEditorUsj call and the fresh editor was never given its content.
+ *
+ * Fix: Reset usjSentToPdp to undefined when the editor is unmounted so the next PDP response always
+ * triggers setEditorUsj, regardless of whether the chapter data has changed.
+ */
+
+import '@testing-library/jest-dom';
+import { act, renderHook } from '@testing-library/react';
+import { Usj } from '@eten-tech-foundation/scripture-utilities';
+import { useRef } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type { EditorHandle } from './use-editor-pdp-sync.hook';
+import { useEditorPdpSync } from './use-editor-pdp-sync.hook';
+
+// Empty USJ — returned by useProjectData while loading or when a book doesn't exist
+// eslint-disable-next-line no-type-assertion/no-type-assertion
+const emptyUsj = { type: 'USJ', version: '3.0', content: [] } as unknown as Usj;
+
+// LEV chapter 14 with minimal content
+// eslint-disable-next-line no-type-assertion/no-type-assertion
+const levUsj = {
+  type: 'USJ',
+  version: '3.0',
+  content: [
+    { type: 'book', marker: 'id', code: 'LEV' },
+    { type: 'chapter', marker: 'c', number: '14' },
+    {
+      type: 'para',
+      marker: 'p',
+      content: [{ type: 'verse', marker: 'v', number: '2' }, 'This is the law of the leper.'],
+    },
+  ],
+} as unknown as Usj;
+
+describe('useEditorPdpSync', () => {
+  it('calls setEditorUsj when PDP data first arrives', () => {
+    const setUsjSpy = vi.fn();
+    const saveUsjToPdpIfUpdated = vi.fn();
+
+    renderHook(() => {
+      const editorRef = useRef<EditorHandle | null>({ setUsj: setUsjSpy });
+      const usjSentToPdp = useRef<Usj | undefined>(undefined);
+      const setEditorUsj = useRef((usj: Usj) => setUsjSpy(usj));
+      const currentlyWritingUsjToPdp = useRef(false);
+      useEditorPdpSync({
+        usjFromPdp: levUsj,
+        editorRef,
+        usjSentToPdp,
+        setEditorUsj,
+        currentlyWritingUsjToPdp,
+        saveUsjToPdpIfUpdated,
+      });
+    });
+
+    expect(setUsjSpy).toHaveBeenCalledOnce();
+    expect(setUsjSpy).toHaveBeenCalledWith(levUsj);
+    expect(saveUsjToPdpIfUpdated).not.toHaveBeenCalled();
+  });
+
+  it('does not call setEditorUsj again when the same chapter data re-arrives while the editor is mounted', () => {
+    // In the real component, useProjectData fires with whichUpdates:'*' so each PDP update
+    // produces a new object reference even when the content is unchanged. Simulate this by
+    // spreading levUsj to a new object with identical content.
+    const levUsjNewRef = { ...levUsj, content: [...levUsj.content] };
+
+    const setUsjSpy = vi.fn();
+    const saveUsjToPdpIfUpdated = vi.fn();
+
+    // Shared refs so rerenders observe the same state
+    const editorRef = { current: { setUsj: setUsjSpy } as EditorHandle | null };
+    const usjSentToPdp = { current: undefined as Usj | undefined };
+    const setEditorUsj = { current: (usj: Usj) => setUsjSpy(usj) };
+    const currentlyWritingUsjToPdp = { current: false };
+
+    const { rerender } = renderHook(
+      ({ usjFromPdp }: { usjFromPdp: Usj }) => {
+        useEditorPdpSync({
+          usjFromPdp,
+          editorRef,
+          usjSentToPdp,
+          setEditorUsj,
+          currentlyWritingUsjToPdp,
+          saveUsjToPdpIfUpdated,
+        });
+      },
+      { initialProps: { usjFromPdp: levUsj } },
+    );
+
+    setUsjSpy.mockClear();
+    saveUsjToPdpIfUpdated.mockClear();
+
+    // Same chapter content re-arrives as a new object reference (PDP subscription fired again)
+    act(() => rerender({ usjFromPdp: levUsjNewRef }));
+
+    expect(setUsjSpy).not.toHaveBeenCalled();
+    expect(saveUsjToPdpIfUpdated).toHaveBeenCalled();
+  });
+
+  it('calls setEditorUsj again after the editor unmounts and remounts with the same chapter data (regression: non-existent book navigation)', () => {
+    // Reproduces: LEV → 2KI (does not exist) → LEV
+    //
+    // After viewing 2KI (which sets editorRef.current = null and usjFromPdp = emptyUsj), the
+    // stale usjSentToPdp still holds LEV's content. When LEV data arrives again and the editor
+    // remounts, the equality check must fail so setEditorUsj is called to initialize the fresh
+    // empty editor. Without the fix, the check would pass and the editor would stay empty.
+
+    const setUsjSpy = vi.fn();
+    const saveUsjToPdpIfUpdated = vi.fn();
+
+    // Shared refs that persist across rerenders, just like in the real component
+    const editorRef = { current: { setUsj: setUsjSpy } as EditorHandle | null };
+    const usjSentToPdp = { current: undefined as Usj | undefined };
+    const setEditorUsj = { current: (usj: Usj) => setUsjSpy(usj) };
+    const currentlyWritingUsjToPdp = { current: false };
+
+    const { rerender } = renderHook(
+      ({ usjFromPdp }: { usjFromPdp: Usj }) => {
+        useEditorPdpSync({
+          usjFromPdp,
+          editorRef,
+          usjSentToPdp,
+          setEditorUsj,
+          currentlyWritingUsjToPdp,
+          saveUsjToPdpIfUpdated,
+        });
+      },
+      { initialProps: { usjFromPdp: levUsj } },
+    );
+
+    // Step 1: LEV loads — editor receives its content
+    expect(setUsjSpy).toHaveBeenCalledOnce();
+    expect(setUsjSpy).toHaveBeenCalledWith(levUsj);
+    setUsjSpy.mockClear();
+
+    // Step 2: Navigate to non-existent 2KI — editor unmounts (editorRef.current = null) and
+    // usjFromPdp becomes emptyUsj (the "book doesn't exist" state)
+    editorRef.current = null;
+    act(() => rerender({ usjFromPdp: emptyUsj }));
+
+    // usjSentToPdp must have been cleared so we know to re-initialize on next mount
+    expect(usjSentToPdp.current).toBeUndefined();
+    expect(setUsjSpy).not.toHaveBeenCalled();
+
+    // Step 3: Navigate back to LEV — same chapter data arrives and the editor remounts fresh
+    editorRef.current = { setUsj: setUsjSpy };
+    act(() => rerender({ usjFromPdp: levUsj }));
+
+    // The fresh (empty) editor must receive its content even though the data hasn't changed
+    expect(setUsjSpy).toHaveBeenCalledOnce();
+    expect(setUsjSpy).toHaveBeenCalledWith(levUsj);
+  });
+});

--- a/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.test.ts
+++ b/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.test.ts
@@ -25,11 +25,11 @@ import { useEditorPdpSync } from './use-editor-pdp-sync.hook';
 // Empty USJ — returned by useProjectData while loading or when a book doesn't exist
 const emptyUsj: Usj = { type: 'USJ', version: '3.1', content: [] };
 
-// LEV chapter 14 with minimal content
+// LEV chapter 14 with minimal content; casting from a minimal stub is intentional in tests
 // eslint-disable-next-line no-type-assertion/no-type-assertion
 const levUsj = {
   type: 'USJ',
-  version: '3.0',
+  version: '3.1',
   content: [
     { type: 'book', marker: 'id', code: 'LEV' },
     { type: 'chapter', marker: 'c', number: '14' },

--- a/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.test.ts
+++ b/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.test.ts
@@ -23,8 +23,7 @@ import type { EditorRef } from '@eten-tech-foundation/platform-editor';
 import { useEditorPdpSync } from './use-editor-pdp-sync.hook';
 
 // Empty USJ — returned by useProjectData while loading or when a book doesn't exist
-// eslint-disable-next-line no-type-assertion/no-type-assertion
-const emptyUsj = { type: 'USJ', version: '3.0', content: [] } as unknown as Usj;
+const emptyUsj: Usj = { type: 'USJ', version: '3.1', content: [] };
 
 // LEV chapter 14 with minimal content
 // eslint-disable-next-line no-type-assertion/no-type-assertion

--- a/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.test.ts
+++ b/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.test.ts
@@ -25,9 +25,8 @@ import { useEditorPdpSync } from './use-editor-pdp-sync.hook';
 // Empty USJ — returned by useProjectData while loading or when a book doesn't exist
 const emptyUsj: Usj = { type: 'USJ', version: '3.1', content: [] };
 
-// LEV chapter 14 with minimal content; casting from a minimal stub is intentional in tests
-// eslint-disable-next-line no-type-assertion/no-type-assertion
-const levUsj = {
+// LEV chapter 14 with minimal content
+const levUsj: Usj = {
   type: 'USJ',
   version: '3.1',
   content: [
@@ -39,7 +38,7 @@ const levUsj = {
       content: [{ type: 'verse', marker: 'v', number: '2' }, 'This is the law of the leper.'],
     },
   ],
-} as unknown as Usj;
+};
 
 describe('useEditorPdpSync', () => {
   it('calls setEditorUsj when PDP data first arrives', () => {

--- a/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.ts
+++ b/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.ts
@@ -1,10 +1,7 @@
+import type { EditorRef } from '@eten-tech-foundation/platform-editor';
 import { Usj } from '@eten-tech-foundation/scripture-utilities';
 import { areUsjContentsEqualExceptWhitespace } from 'platform-bible-utils';
-import { MutableRefObject, RefObject, useEffect } from 'react';
-
-export type EditorHandle = {
-  setUsj(usj: Usj): void;
-};
+import { MutableRefObject, useEffect } from 'react';
 
 /**
  * Synchronizes the editor's displayed content with data received from the PDP.
@@ -27,10 +24,10 @@ export function useEditorPdpSync({
   saveUsjToPdpIfUpdated,
 }: {
   usjFromPdp: Usj | undefined;
-  editorRef: MutableRefObject<EditorHandle | null>;
+  editorRef: MutableRefObject<EditorRef | null>;
   usjSentToPdp: MutableRefObject<Usj | undefined>;
   /** Stable ref whose `.current` is the function to call to update the editor's displayed content */
-  setEditorUsj: RefObject<(usj: Usj) => void>;
+  setEditorUsj: MutableRefObject<(usj: Usj) => void>;
   currentlyWritingUsjToPdp: MutableRefObject<boolean>;
   saveUsjToPdpIfUpdated: () => void;
 }): void {
@@ -50,9 +47,19 @@ export function useEditorPdpSync({
     // the editor wrote to the PDP.
     if (!areUsjContentsEqualExceptWhitespace(usjFromPdp, usjSentToPdp.current)) {
       usjSentToPdp.current = usjFromPdp;
-      setEditorUsj.current?.(usjFromPdp);
+      setEditorUsj.current(usjFromPdp);
     }
     // If the editor has updates that the PDP hasn't recorded, save them to the PDP
     else saveUsjToPdpIfUpdated();
-  }, [saveUsjToPdpIfUpdated, usjFromPdp]);
+  }, [
+    // usjFromPdp and saveUsjToPdpIfUpdated are the only deps that actually change and trigger
+    // re-runs. The refs below are stable (their identities never change), but are listed to
+    // satisfy the exhaustive-deps lint rule.
+    currentlyWritingUsjToPdp,
+    editorRef,
+    saveUsjToPdpIfUpdated,
+    setEditorUsj,
+    usjFromPdp,
+    usjSentToPdp,
+  ]);
 }

--- a/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.ts
+++ b/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.ts
@@ -1,0 +1,58 @@
+import { Usj } from '@eten-tech-foundation/scripture-utilities';
+import { areUsjContentsEqualExceptWhitespace } from 'platform-bible-utils';
+import { MutableRefObject, RefObject, useEffect } from 'react';
+
+export type EditorHandle = {
+  setUsj(usj: Usj): void;
+};
+
+/**
+ * Synchronizes the editor's displayed content with data received from the PDP.
+ *
+ * Runs on every PDP update (even ones with unchanged content) so we know when a write we initiated
+ * has completed and `currentlyWritingUsjToPdp` can be cleared.
+ *
+ * When the editor is unmounted (e.g. book doesn't exist or data is loading), `usjSentToPdp` is
+ * reset so that the editor is properly re-initialized with content when it remounts. Without this
+ * reset, returning to the same chapter after passing through a non-existent book would leave the
+ * fresh editor empty because the stale `usjSentToPdp` value would match the incoming PDP data and
+ * skip the `setEditorUsj` call.
+ */
+export function useEditorPdpSync({
+  usjFromPdp,
+  editorRef,
+  usjSentToPdp,
+  setEditorUsj,
+  currentlyWritingUsjToPdp,
+  saveUsjToPdpIfUpdated,
+}: {
+  usjFromPdp: Usj | undefined;
+  editorRef: MutableRefObject<EditorHandle | null>;
+  usjSentToPdp: MutableRefObject<Usj | undefined>;
+  /** Stable ref whose `.current` is the function to call to update the editor's displayed content */
+  setEditorUsj: RefObject<(usj: Usj) => void>;
+  currentlyWritingUsjToPdp: MutableRefObject<boolean>;
+  saveUsjToPdpIfUpdated: () => void;
+}): void {
+  useEffect(() => {
+    if (!usjFromPdp) return;
+    if (!editorRef.current) {
+      // Editor unmounted — reset so it re-initializes when it remounts (see JSDoc)
+      usjSentToPdp.current = undefined;
+      return;
+    }
+
+    // The PDP informed us of updates, so writing to it must be complete (if we were writing)
+    currentlyWritingUsjToPdp.current = false;
+
+    // If what the PDP provided is different than the last thing we sent to the PDP, assume the PDP
+    // has the best data. This could happen if the selected chapter changed or something other than
+    // the editor wrote to the PDP.
+    if (!areUsjContentsEqualExceptWhitespace(usjFromPdp, usjSentToPdp.current)) {
+      usjSentToPdp.current = usjFromPdp;
+      setEditorUsj.current?.(usjFromPdp);
+    }
+    // If the editor has updates that the PDP hasn't recorded, save them to the PDP
+    else saveUsjToPdpIfUpdated();
+  }, [saveUsjToPdpIfUpdated, usjFromPdp]);
+}

--- a/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.ts
+++ b/extensions/src/platform-scripture-editor/src/use-editor-pdp-sync.hook.ts
@@ -34,7 +34,7 @@ export function useEditorPdpSync({
   useEffect(() => {
     if (!usjFromPdp) return;
     if (!editorRef.current) {
-      // Editor unmounted — reset so it re-initializes when it remounts (see JSDoc)
+      // Editor unmounted — reset so it re-initializes when it remounts (see TSDoc)
       usjSentToPdp.current = undefined;
       return;
     }


### PR DESCRIPTION
https://paratextstudio.atlassian.net/browse/PT-3888

<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-3888-book-with-data-looks-empty

**Base**: origin/main

**Date**: 2026-04-16

**Review model**: Claude Sonnet 4.6

**Files changed**: 3

## Overview

This branch fixes a bug where navigating to a non-existent book and then back to a previously-viewed chapter left the editor showing the empty "Enter some scripture…" placeholder instead of the chapter content. The root cause was that `usjSentToPdp` was not reset when the editor unmounted (`editorRef.current === null`), so on returning to the same chapter the stale value matched the incoming PDP data and the `setEditorUsj` call was skipped.

The fix resets `usjSentToPdp.current` to `undefined` when the editor is unmounted, ensuring the next PDP response always re-initializes the fresh editor. As part of this change, the PDP sync `useEffect` was extracted from the large `platform-scripture-editor.web-view.tsx` into a dedicated `useEditorPdpSync` hook, making the logic independently testable. A regression test file covering the exact bug scenario (LEV → non-existent 2KI → LEV) was added alongside the hook.

## API Changes

None. All modifications are confined to `extensions/src/platform-scripture-editor/src/` and do not touch any public API surfaces (`lib/platform-bible-react/`, `lib/platform-bible-utils/`, `papi.d.ts`, or extension type declarations).

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **`use-editor-pdp-sync.hook.ts:53` — `setEditorUsj` typed as `RefObject` (nullable) with optional chain `?.`** _(fixed during review: changed parameter type to `MutableRefObject<(usj: Usj) => void>`, removed unused `RefObject` import, and dropped the optional chain — restoring the non-optional call that matched the original inline `useEffect` and the existing call at line 1134 of the web-view)_

- [x] **`use-editor-pdp-sync.hook.ts:5-7` — Local `EditorHandle` type duplicated `EditorRef` via structural typing; silent drift risk** _(fixed during review: removed `EditorHandle`, added `import type { EditorRef }` from `@eten-tech-foundation/platform-editor` — a type-only import with zero runtime cost. Tests updated to use `EditorRef` with `as unknown as EditorRef` casts on minimal mock objects, preserving the lightweight test setup.)_

Author confirmed the `RefObject` / `?.` choice was casual and was happy to change both. The `EditorHandle` local type was intentional for test dependency reasons; author agreed to `import type` as the solution that keeps tests light while eliminating the structural-typing ambiguity.

### Minor — Consider

- [x] **`use-editor-pdp-sync.hook.ts:57-64` — Stable refs in `useEffect` dep array listed without explanation** _(fixed during review: added a comment noting that only `usjFromPdp` and `saveUsjToPdpIfUpdated` actually trigger re-runs; the refs are listed only to satisfy the exhaustive-deps lint rule)_

- [x] **`use-editor-pdp-sync.hook.test.ts:80-84` — Plain object literals used instead of `useRef` for shared refs without explanation** _(fixed during review: added a comment explaining that plain objects are used so state mutations are visible across rerenders without closure capture)_

Author requested both comments be added.

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- The hook extraction cleanly separates the PDP-sync concern from the large web-view component, making it independently testable without altering any observable behavior for callers.
- The regression test file is exceptionally well-structured: the module-level JSDoc documents the bug, root cause, and fix, and the three tests cover all meaningful behavioral paths — initial load, re-arrival of unchanged data (same-content, new object reference), and re-initialization after unmount.
- The LEV → non-existent 2KI → LEV test directly reproduces the bug scenario that motivated the fix and is named clearly enough to serve as documentation.
- The `usjSentToPdp.current = undefined` reset on unmount addresses the bug with minimal surface area — no new state, no new effects.
- The hook's JSDoc explains both non-obvious behaviors: why the effect runs on every PDP update (not just differing ones) and why the unmount reset is necessary.
- No localization, UI, or template propagation concerns — a clean, focused change.

## Interview Notes

**Purpose**: Fix the bug where navigating through a non-existent book and back to a previously-viewed chapter shows an empty editor. The fix resets `usjSentToPdp` on editor unmount; the hook extraction was done to make the logic testable.

**Finding 1 (`RefObject` / `?.`)**: Author confirmed the optional chain was a casual choice with no particular reason behind it. Fixed during review.

**Finding 2 (`EditorHandle` vs `EditorRef`)**: The local `EditorHandle` type was intentional — author wanted to avoid pulling in the `@eten-tech-foundation/platform-editor` bundle (284KB) in tests. The `import type` solution (zero runtime cost, type-declarations only) satisfied both goals. Author agreed to the change.

**All findings were resolved during the review.** No unresolved items.

## In-Review Quality Check

Changes were made during the interview. Quality checks run after all fixes:

| Check                      | Result                                                                                                                      |
| -------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
| `npm run typecheck`        | PASS                                                                                                                        |
| `npm run lint`             | Fixed — auto-added explanatory comments above `eslint-disable-next-line` annotations on the `as unknown as EditorRef` casts |
| `npm run format`           | PASS                                                                                                                        |
| `npm test` (affected file) | PASS — 3/3 tests pass                                                                                                       |

## Questions researched

Q: **Confirm the `usjSentToPdp` reset condition**: the reset fires when `editorRef.current === null` (editor unmounted) — verify this is the right condition and that it doesn't fire in cases where the editor is temporarily null for other reasons.
A: editorRef.current === null **IS** reliable

React sets a ref.current to null only during the commit phase when the component truly unmounts from the tree — not during intermediate re-renders. If the Editorial component is in the tree and rendered, editorRef.current holds the instance. There is no "transient null" during re-renders.

The two cases where the editor is unmounted (and editorRef.current === null):

!bookExists — book not found error (renders a message, no editor)
!usjFromPdp || usjFromPdp === defaultUsj — data loading (renders spinner, no editor)
Both cases correctly cause editorRef.current = null, and resetting usjSentToPdp in both is the right behavior:

Book not found case: This is the exact bug scenario. Reset ensures re-initialization when navigating back.
Loading/defaultUsj case: Resetting is also correct — when real data arrives and the editor mounts, usjSentToPdp being undefined guarantees setEditorUsj is called.
Could the reset fire when the editor is mounted?

No. The hook fires because usjFromPdp changed. If usjFromPdp changes to a value that causes the editor to render, React will:

Render the editor component
Commit (setting editorRef.current = editorInstance)
Run effects
By the time the effect runs, editorRef.current is already set. There's no window where the editor is mounted but the ref is still null.

One edge case that's a non-issue here: if the Editorial component remounts due to a key change (without a usjFromPdp change), the hook wouldn't fire at all — so there's no false reset. The editor would need to be initialized through a different mechanism in that scenario, but that's unrelated to this condition.

Verdict: the condition is correct and tight. The only risk would be if something outside this hook set editorRef.current = null while the editor was still mounted, but that doesn't happen — React owns that ref lifecycle.

Q: **Hook parameter contract**: `setEditorUsj` is now typed as `MutableRefObject<(usj: Usj) => void>` (non-nullable `.current`) — confirm the caller always initializes this ref before mounting the hook.

A: **Confirmed**
The ref is initialized with an inline function at the point of useRef(...), well before the hook is mounted:

platform-scripture-editor.web-view.tsx:451-454

const setEditorUsj = useRef((usj: Usj) => {
editorRef.current?.setUsj(usj);
clearAnnotationInfo.current();
});
It's passed to the hook at line 1267 — after the useRef call — so .current is always a live function by the time useEditorPdpSync first runs. The non-nullable type matches reality: there is no window between ref creation and hook mount where .current could be undefined.

## Suggested Review Focus

Covered in the Questions Researched section.

<!-- review-paratext:summary:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/paranext/paranext-core/pull/2206" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2206)
<!-- Reviewable:end -->
