### PR TITLE
Design: SourceLanguageIndexList (ER, Dictionary)

### DIFF
--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -1,11 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
-import { Input } from '@/components/shadcn-ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/shadcn-ui/popover';
-import { ChevronRight, MoreHorizontal, X } from 'lucide-react';
+import { ArrowUp, ChevronRight, MoreHorizontal } from 'lucide-react';
 import { Z_INDEX_MODAL } from '@/components/z-index';
-import SourceLanguageIndexedList from './source-language-indexed-list.component';
 import type {
   ErDictionaryFilteredListProps,
   IndexedListItem,
@@ -13,16 +11,13 @@ import type {
 } from './source-language-indexed-list.types';
 
 /**
- * ER Dictionary list filtered by semantic domain with breadcrumb-based navigation.
+ * ER Dictionary list filtered by semantic domain with breadcrumb navigation.
  *
- * Header row: `[breadcrumb button (hugs content)] ......... [X Close]`
+ * Header row: `[breadcrumb button] ......... [↑ Back]`
  *
- * Breadcrumbs collapse dynamically without flicker. Collapse order: start hiding the 2nd-left item,
- * then continue inward until only `root > ... > leaf` remains, then also hide root.
- *
- * Clicking a breadcrumb segment opens the domain tree popover expanded/scrolled to **that** level.
- * The popover has a full-width search input that filters the tree (showing matches + all ancestors)
- * with character-level highlighting.
+ * Below the header: an inline list + detail layout (same pattern as the dictionary tab) where the
+ * list and detail are side-by-side flex children. All interactive elements (list items,
+ * breadcrumbs, back button, domain links) remain clickable while the detail panel is open.
  */
 export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   items,
@@ -40,36 +35,66 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
 }: ErDictionaryFilteredListProps<T>) {
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [clickedSegmentId, setClickedSegmentId] = useState<string | undefined>();
+  const [selectedId, setSelectedId] = useState<string | undefined>(selectedItemId);
+
+  // eslint-disable-next-line no-null/no-null
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [narrow, setNarrow] = useState(false);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return undefined;
+    const observer = new ResizeObserver(([entry]) => {
+      setNarrow((entry?.contentRect.width ?? 0) < 350);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
 
   const handleDomainSelect = useCallback(
     (path: SemanticDomain[]) => {
       onDomainChange(path);
       setPopoverOpen(false);
+      setSelectedId(undefined);
     },
     [onDomainChange],
   );
 
-  const handleBreadcrumbSegmentClick = (segmentDomainId: string) => {
-    setClickedSegmentId(segmentDomainId);
-    setPopoverOpen(true);
+  const handleBreadcrumbClick = (segmentId: string) => {
+    if (popoverOpen) {
+      // Close on re-click
+      setPopoverOpen(false);
+    } else {
+      setClickedSegmentId(segmentId);
+      setPopoverOpen(true);
+    }
   };
 
+  const selectedItem = items.find((item) => item.id === selectedId);
+  const handleItemClick = (item: T) => {
+    onItemClick?.(item);
+    setSelectedId(item.id === selectedId ? undefined : item.id);
+  };
+
+  const showSideBySide = selectedItem && !narrow;
+  const showFullDetail = selectedItem && narrow;
+
   return (
-    <div className={cn('tw-relative tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}>
-      {/* Header: breadcrumb button (hugs content) + Close button (right) */}
+    <div className={cn('tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}>
+      {/* Header: breadcrumb + back */}
       <div className="tw-flex tw-items-center tw-gap-1 tw-border-b tw-px-2 tw-py-1.5">
         <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
           <PopoverTrigger asChild>
             <div className="tw-min-w-0 tw-flex-1">
-              <BreadcrumbBar path={domainPath} onSegmentClick={handleBreadcrumbSegmentClick} />
+              <BreadcrumbBar path={domainPath} onSegmentClick={handleBreadcrumbClick} />
             </div>
           </PopoverTrigger>
           <PopoverContent
             align="start"
-            className="tw-w-[min(var(--radix-popover-trigger-width),400px)] tw-p-0"
+            className="tw-w-full tw-max-w-[400px] tw-p-0"
             style={{ zIndex: Z_INDEX_MODAL + 10 }}
           >
-            <DomainSearchTree
+            <DomainTree
               domains={allDomains}
               currentPath={domainPath}
               expandToId={clickedSegmentId}
@@ -80,43 +105,75 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
 
         {onClose && (
           <Button variant="ghost" size="sm" className="tw-shrink-0 tw-gap-1" onClick={onClose}>
-            <X className="tw-h-4 tw-w-4" />
-            Close
+            <ArrowUp className="tw-h-4 tw-w-4" />
+            Back
           </Button>
         )}
       </div>
 
-      {/* Dictionary list */}
-      <div className="tw-flex-1 tw-overflow-hidden">
-        <SourceLanguageIndexedList
-          items={items}
-          renderItem={renderItem}
-          renderDetailContent={renderDetailContent}
-          onItemClick={onItemClick}
-          selectedItemId={selectedItemId}
-          emptyStateMessage={emptyStateMessage}
-          isLoading={isLoading}
-          showSourceLanguage
-          showTransliteration
-          className="tw-h-full"
-        />
+      {/* Inline list + detail (same pattern as dictionary tab) */}
+      <div ref={containerRef} className="tw-relative tw-flex tw-flex-1 tw-overflow-hidden">
+        {!showFullDetail && (
+          <div
+            className={cn(
+              'tw-h-full',
+              showSideBySide
+                ? 'tw-w-1/3 tw-min-w-[120px] tw-overflow-hidden tw-border-r'
+                : 'tw-w-full tw-overflow-y-auto',
+            )}
+          >
+            {isLoading ? (
+              <div className="tw-p-4 tw-text-sm tw-text-muted-foreground">Loading...</div>
+            ) : items.length === 0 ? (
+              <div className="tw-p-4 tw-text-sm tw-text-muted-foreground">
+                {emptyStateMessage ?? 'No items found'}
+              </div>
+            ) : (
+              <ul role="listbox" className="tw-outline-none">
+                {items.map((item) => {
+                  const isSelected = selectedId === item.id;
+                  return (
+                    <li
+                      key={item.id}
+                      role="option"
+                      aria-selected={isSelected}
+                      onClick={() => handleItemClick(item)}
+                      className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
+                        'tw-bg-muted': isSelected,
+                        'hover:tw-bg-muted': !isSelected,
+                      })}
+                    >
+                      {renderItem ? (
+                        renderItem(item)
+                      ) : (
+                        <span className="tw-text-sm">{item.primaryText}</span>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        )}
+        {selectedItem && renderDetailContent && (
+          <div
+            className={cn(
+              'tw-overflow-y-auto tw-bg-background tw-p-4',
+              showFullDetail ? 'tw-w-full' : 'tw-w-2/3',
+            )}
+          >
+            {renderDetailContent(selectedItem, () => setSelectedId(undefined))}
+          </div>
+        )}
       </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// BreadcrumbBar: flicker-free dynamic collapse, individual segment hover
+// BreadcrumbBar: flicker-free collapse, no hover underline
 // ---------------------------------------------------------------------------
 
-/**
- * Renders the breadcrumb path as a button that hugs its content. Segments collapse dynamically via
- * CSS `overflow: hidden` and a `ResizeObserver` that checks a hidden measurement row. Collapse
- * order: hide the 2nd-left segment first, then 3rd, etc., until only `root > ... > leaf`. If still
- * too wide, also hide root, showing `... > leaf`.
- *
- * Each segment has its own hover underline (not all segments at once).
- */
 function BreadcrumbBar({
   path,
   onSegmentClick,
@@ -128,10 +185,6 @@ function BreadcrumbBar({
   const outerRef = useRef<HTMLDivElement>(null);
   // eslint-disable-next-line no-null/no-null
   const fullRef = useRef<HTMLDivElement>(null);
-
-  // Number of segments to hide, starting from the 2nd item (index 1).
-  // 0 = show all, 1 = hide index 1, 2 = hide index 1+2, ...
-  // If hideCount >= path.length - 1, we also hide root (show only "... > leaf").
   const [hideCount, setHideCount] = useState(0);
 
   useEffect(() => {
@@ -140,51 +193,45 @@ function BreadcrumbBar({
     if (!outer || !full) return undefined;
 
     const measure = () => {
-      // Measure the full (unhidden) breadcrumb width vs available width
       const available = outer.clientWidth;
-      const fullWidth = full.scrollWidth;
+      const segEls = Array.from(full.children) as HTMLElement[];
+      if (segEls.length === 0) return;
 
-      if (fullWidth <= available) {
+      // Check if everything fits (include some padding buffer)
+      const fullWidth = segEls.reduce((sum, el) => sum + el.offsetWidth, 0);
+      if (fullWidth <= available - 8) {
         setHideCount(0);
         return;
       }
 
-      // Measure individual segment widths from the hidden row
-      const segEls = Array.from(full.children) as HTMLElement[];
       const widths = segEls.map((el) => el.offsetWidth);
       const totalSegments = path.length;
+      const ellipsisWidth = 44; // chevron + dots + gaps
 
-      // Try hiding 1, 2, 3, ... segments from index 1 (keeping root + ellipsis + trailing)
-      // Ellipsis takes roughly the width of ChevronRight + MoreHorizontal icons
-      const ellipsisWidth = 40;
-
+      // Try hiding from index 1 inward. Always keep the last segment.
+      // When h < totalSegments - 1: show root + ellipsis + trailing (from h+1..end)
+      // When h >= totalSegments - 1: show ellipsis + last segment only
       for (let h = 1; h < totalSegments; h += 1) {
-        // Visible segments: root (index 0) + segments after the hidden range + ellipsis
-        // Hidden range: indices 1..h
         let visibleWidth = ellipsisWidth;
 
-        // Include root if h < totalSegments - 1 (i.e., we haven't hidden everything except leaf)
         if (h < totalSegments - 1) {
+          // Root is still visible
           visibleWidth += widths[0] ?? 0;
-        }
-
-        // Include trailing segments (from index h+1 to end)
-        for (let j = h + 1; j < totalSegments; j += 1) {
-          visibleWidth += widths[j] ?? 0;
-        }
-
-        // Always include the last segment (even if h reaches totalSegments - 1)
-        if (h >= totalSegments - 1) {
+          for (let j = h + 1; j < totalSegments; j += 1) {
+            visibleWidth += widths[j] ?? 0;
+          }
+        } else {
+          // Root hidden, only last segment + ellipsis
           visibleWidth += widths[totalSegments - 1] ?? 0;
         }
 
-        if (visibleWidth <= available) {
+        if (visibleWidth <= available - 8) {
           setHideCount(h);
           return;
         }
       }
 
-      // Everything hidden except leaf
+      // Cannot fit even ellipsis + last segment - show just last
       setHideCount(totalSegments - 1);
     };
 
@@ -199,7 +246,7 @@ function BreadcrumbBar({
 
   return (
     <div ref={outerRef} className="tw-overflow-hidden">
-      {/* Hidden measurement row (same content, no hiding, invisible) */}
+      {/* Hidden measurement row */}
       <div
         ref={fullRef}
         className="tw-pointer-events-none tw-invisible tw-absolute tw-flex tw-items-center tw-gap-0.5 tw-whitespace-nowrap"
@@ -208,95 +255,93 @@ function BreadcrumbBar({
         {path.map((d, i) => (
           <span key={d.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
             {i > 0 && <ChevronRight className="tw-h-3 tw-w-3" />}
-            <span className="tw-text-sm">{d.label}</span>
+            <span className="tw-px-1.5 tw-py-1 tw-text-sm">{d.label}</span>
           </span>
         ))}
       </div>
 
-      {/* Visible breadcrumbs (inline, hugging content) */}
-      <button
-        type="button"
-        className="tw-inline-flex tw-items-center tw-gap-0.5 tw-rounded tw-px-1.5 tw-py-1 tw-text-left hover:tw-bg-muted"
-        onClick={(e) => {
-          // If the click was on a specific segment span, that handler fires first.
-          // This is the fallback for clicking the button padding.
-          const lastDomain = path[path.length - 1];
-          if (lastDomain) onSegmentClick(lastDomain.id);
-          e.stopPropagation();
-        }}
-      >
-        {/* Root segment */}
+      {/* Visible breadcrumbs (inline, hugs content) */}
+      <span className="tw-inline-flex tw-items-center tw-gap-0.5 tw-rounded tw-text-left">
+        {/* Root */}
         {!hideRoot && path[0] && (
-          <span
-            className="tw-shrink-0 tw-cursor-pointer tw-text-sm hover:tw-underline"
-            onClick={(e) => {
-              e.stopPropagation();
-              onSegmentClick(path[0].id);
-            }}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter') {
-                e.stopPropagation();
-                onSegmentClick(path[0].id);
-              }
-            }}
-            role="button"
-            tabIndex={0}
-          >
-            {path[0].label}
-          </span>
+          <BreadcrumbSegment domain={path[0]} isLast={path.length === 1} onClick={onSegmentClick} />
         )}
 
         {/* Ellipsis */}
         {showEllipsis && (
           <>
-            <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+            {!hideRoot && (
+              <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+            )}
             <MoreHorizontal className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
           </>
         )}
 
         {/* Trailing visible segments */}
         {path.map((domain, idx) => {
-          // Skip root (handled above) and hidden segments
-          if (idx === 0) return undefined;
-          if (idx <= hideCount) return undefined;
-
+          if (idx === 0) return undefined; // root handled above
+          if (idx <= hideCount) return undefined; // hidden
           const isLast = idx === path.length - 1;
           return (
-            <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
-              <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
-              <span
-                className={cn(
-                  'tw-cursor-pointer tw-text-sm hover:tw-underline',
-                  isLast && 'tw-font-bold',
-                )}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSegmentClick(domain.id);
-                }}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') {
-                    e.stopPropagation();
-                    onSegmentClick(domain.id);
-                  }
-                }}
-                role="button"
-                tabIndex={0}
-              >
-                {domain.label}
-              </span>
-            </span>
+            <BreadcrumbSegment
+              key={domain.id}
+              domain={domain}
+              isLast={isLast}
+              onClick={onSegmentClick}
+              showChevron
+            />
           );
         })}
-      </button>
+      </span>
     </div>
   );
 }
 
+function BreadcrumbSegment({
+  domain,
+  isLast,
+  onClick,
+  showChevron = false,
+}: {
+  domain: SemanticDomain;
+  isLast: boolean;
+  onClick: (id: string) => void;
+  showChevron?: boolean;
+}) {
+  return (
+    <span className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
+      {showChevron && (
+        <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+      )}
+      <span
+        className={cn(
+          'tw-cursor-pointer tw-rounded tw-px-1.5 tw-py-1 tw-text-sm hover:tw-bg-muted',
+          isLast && 'tw-font-bold',
+        )}
+        onClick={(e) => {
+          e.stopPropagation();
+          onClick(domain.id);
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter') {
+            e.stopPropagation();
+            onClick(domain.id);
+          }
+        }}
+        role="button"
+        tabIndex={0}
+      >
+        {domain.label}
+      </span>
+    </span>
+  );
+}
+
 // ---------------------------------------------------------------------------
-// Domain search tree: filterable, expands to clicked segment
+// Domain tree popover (no search, simple expandable tree)
 // ---------------------------------------------------------------------------
 
-function DomainSearchTree({
+function DomainTree({
   domains,
   currentPath,
   expandToId,
@@ -307,70 +352,29 @@ function DomainSearchTree({
   expandToId?: string;
   onSelect: (path: SemanticDomain[]) => void;
 }) {
-  const [filter, setFilter] = useState('');
   // eslint-disable-next-line no-null/no-null
   const scrollTargetRef = useRef<HTMLButtonElement>(null);
 
-  // Scroll to the expand-target on mount
   useEffect(() => {
     requestAnimationFrame(() => {
       scrollTargetRef.current?.scrollIntoView({ block: 'center' });
     });
   }, [expandToId]);
 
-  const filterLower = filter.toLowerCase();
-
   return (
-    <div className="tw-flex tw-max-h-[300px] tw-flex-col">
-      <div className="tw-border-b tw-p-2">
-        <Input
-          placeholder="Search domains..."
-          value={filter}
-          onChange={(e) => setFilter(e.target.value)}
-          className="tw-h-8 tw-w-full tw-text-sm"
-          autoFocus
-        />
-      </div>
-      <div className="tw-flex-1 tw-overflow-y-auto tw-p-1">
-        <TreeNodeList
-          domains={domains}
-          currentPath={currentPath}
-          expandToId={expandToId}
-          onSelect={onSelect}
-          parentPath={[]}
-          filter={filterLower}
-          scrollTargetRef={scrollTargetRef}
-        />
-      </div>
+    <div className="tw-max-h-[500px] tw-overflow-y-auto tw-p-1">
+      <TreeNodeList
+        domains={domains}
+        currentPath={currentPath}
+        expandToId={expandToId}
+        onSelect={onSelect}
+        parentPath={[]}
+        scrollTargetRef={scrollTargetRef}
+      />
     </div>
   );
 }
 
-// ---------------------------------------------------------------------------
-// Tree rendering helpers
-// ---------------------------------------------------------------------------
-
-function domainMatchesFilter(domain: SemanticDomain, filter: string): boolean {
-  if (domain.label.toLowerCase().includes(filter)) return true;
-  return domain.children?.some((child) => domainMatchesFilter(child, filter)) ?? false;
-}
-
-function HighlightLabel({ label, filter }: { label: string; filter: string }) {
-  if (!filter) return <span>{label}</span>;
-  const idx = label.toLowerCase().indexOf(filter);
-  if (idx < 0) return <span>{label}</span>;
-  return (
-    <span>
-      {label.slice(0, idx)}
-      <mark className="tw-bg-yellow-200 tw-text-inherit dark:tw-bg-yellow-800">
-        {label.slice(idx, idx + filter.length)}
-      </mark>
-      {label.slice(idx + filter.length)}
-    </span>
-  );
-}
-
-/** Check if a domain or any ancestor/descendant has the given id */
 function isAncestorOf(domain: SemanticDomain, targetId: string): boolean {
   if (domain.id === targetId) return true;
   return domain.children?.some((child) => isAncestorOf(child, targetId)) ?? false;
@@ -382,7 +386,6 @@ function TreeNodeList({
   expandToId,
   onSelect,
   parentPath,
-  filter,
   scrollTargetRef,
 }: {
   domains: SemanticDomain[];
@@ -390,23 +393,18 @@ function TreeNodeList({
   expandToId?: string;
   onSelect: (path: SemanticDomain[]) => void;
   parentPath: SemanticDomain[];
-  filter: string;
   scrollTargetRef: React.RefObject<HTMLButtonElement>;
 }) {
   return (
     <ul className={cn('tw-space-y-0.5', { 'tw-ml-3': parentPath.length > 0 })}>
       {domains.map((domain) => {
-        if (filter && !domainMatchesFilter(domain, filter)) return undefined;
-
         const thisPath = [...parentPath, domain];
         const isSelected =
           currentPath.length > 0 && currentPath[currentPath.length - 1].id === domain.id;
         const hasChildren = domain.children && domain.children.length > 0;
-        // Expand if: filtering, on current path, or contains the expand target
-        const isOnCurrentPath = currentPath.some((d) => d.id === domain.id);
+        const isOnPath = currentPath.some((d) => d.id === domain.id);
         const containsTarget = expandToId ? isAncestorOf(domain, expandToId) : false;
-        const shouldStartExpanded = !!filter || isOnCurrentPath || containsTarget;
-        // Scroll target: the domain matching expandToId
+        const shouldExpand = isOnPath || containsTarget;
         const isScrollTarget = domain.id === expandToId;
 
         return (
@@ -416,11 +414,10 @@ function TreeNodeList({
             thisPath={thisPath}
             isSelected={isSelected}
             hasChildren={hasChildren ?? false}
-            defaultExpanded={shouldStartExpanded}
+            defaultExpanded={shouldExpand}
             currentPath={currentPath}
             expandToId={expandToId}
             onSelect={onSelect}
-            filter={filter}
             scrollTargetRef={scrollTargetRef}
             isScrollTarget={isScrollTarget}
           />
@@ -439,7 +436,6 @@ function TreeNode({
   currentPath,
   expandToId,
   onSelect,
-  filter,
   scrollTargetRef,
   isScrollTarget,
 }: {
@@ -451,7 +447,6 @@ function TreeNode({
   currentPath: SemanticDomain[];
   expandToId?: string;
   onSelect: (path: SemanticDomain[]) => void;
-  filter: string;
   scrollTargetRef: React.RefObject<HTMLButtonElement>;
   isScrollTarget: boolean;
 }) {
@@ -471,9 +466,7 @@ function TreeNode({
             onClick={() => setExpanded(!expanded)}
           >
             <ChevronRight
-              className={cn('tw-h-3 tw-w-3 tw-transition-transform', {
-                'tw-rotate-90': expanded,
-              })}
+              className={cn('tw-h-3 tw-w-3 tw-transition-transform', { 'tw-rotate-90': expanded })}
             />
           </button>
         ) : (
@@ -488,7 +481,7 @@ function TreeNode({
           )}
           onClick={() => onSelect(thisPath)}
         >
-          <HighlightLabel label={domain.label} filter={filter} />
+          {domain.label}
         </button>
       </div>
       {expanded && hasChildren && (
@@ -498,7 +491,6 @@ function TreeNode({
           expandToId={expandToId}
           onSelect={onSelect}
           parentPath={thisPath}
-          filter={filter}
           scrollTargetRef={scrollTargetRef}
         />
       )}

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import { ToggleGroup, ToggleGroupItem } from '@/components/shadcn-ui/toggle-group';
@@ -8,13 +8,18 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/shadcn-ui/dropdown-menu';
-import { ChevronRight, ChevronDown, X, List, FolderTree } from 'lucide-react';
+import { Drawer, DrawerClose, DrawerContent, DrawerTitle } from '@/components/shadcn-ui/drawer';
+import { ChevronRight, ChevronDown, List, FolderTree } from 'lucide-react';
+import { Z_INDEX_MODAL } from '@/components/z-index';
 import SourceLanguageIndexedList from './source-language-indexed-list.component';
 import type {
   ErDictionaryFilteredListProps,
   IndexedListItem,
   SemanticDomain,
 } from './source-language-indexed-list.types';
+
+/** Z-index that sits above the Dialog modal layer so dropdowns/drawers are visible */
+const Z_ABOVE_MODAL = Z_INDEX_MODAL + 10;
 
 /**
  * ER Dictionary list filtered by semantic domain with 2-level breadcrumb navigation.
@@ -23,14 +28,14 @@ import type {
  *
  * 1. **Breadcrumbs**: Always shows exactly 2 levels (`Category > Domain`). Both breadcrumb segments
  *    are interactive. In **dropdown mode** each opens a dropdown with siblings at that level. In
- *    **tree mode** each opens an inline tree panel within the component. When switching a category,
- *    the first child domain is auto-selected.
+ *    **tree mode** each opens a Drawer scoped to this component's bounding box showing the full
+ *    domain tree. When switching a category the first child domain is auto-selected.
  * 2. **Dictionary list**: A `SourceLanguageIndexedList` showing entries filtered to the selected
- *    domain. Clicking an entry shows a detail panel inline within the list area.
+ *    domain. Clicking an entry opens a detail Drawer scoped to the list area.
  * 3. **Navigation mode toggle**: Switch between dropdown and tree navigation.
  *
- * All panels (detail, tree) render **inside this component's bounding box**, never as full-page
- * overlays. Dropdown menus use Radix portals so they correctly layer on top of a parent Dialog.
+ * All drawers render inside this component's bounding box via the Drawer `container` prop. Dropdown
+ * menus use a z-index above `Z_INDEX_MODAL` so they layer correctly on top of a parent Dialog.
  *
  * Domains are always exactly 2 levels deep.
  */
@@ -51,6 +56,9 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   className,
 }: ErDictionaryFilteredListProps<T>) {
   const [treeOpen, setTreeOpen] = useState(false);
+  // ref.current expects null not undefined for div ref
+  // eslint-disable-next-line no-null/no-null
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Ensure we always have a level-2 domain; fall back to first child
   const effectiveLevel2 = selectedLevel2Domain ?? selectedLevel1Domain.children?.[0];
@@ -71,7 +79,10 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   const level2Siblings = selectedLevel1Domain.children ?? [];
 
   return (
-    <div className={cn('tw-relative tw-flex tw-h-full tw-flex-col', className)}>
+    <div
+      ref={containerRef}
+      className={cn('tw-relative tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}
+    >
       {/* Breadcrumbs - always 2 levels: Category > Domain */}
       <div className="tw-flex tw-items-center tw-gap-1 tw-border-b tw-px-3 tw-py-2">
         <nav
@@ -87,7 +98,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
                   <ChevronDown className="tw-h-3 tw-w-3" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="tw-z-[60]">
+              <DropdownMenuContent align="start" style={{ zIndex: Z_ABOVE_MODAL }}>
                 {allDomains.map((domain) => (
                   <DropdownMenuItem
                     key={domain.id}
@@ -122,7 +133,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
                   <ChevronDown className="tw-h-3 tw-w-3" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" className="tw-z-[60]">
+              <DropdownMenuContent align="start" style={{ zIndex: Z_ABOVE_MODAL }}>
                 {level2Siblings.map((domain) => (
                   <DropdownMenuItem
                     key={domain.id}
@@ -148,46 +159,20 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
         </nav>
       </div>
 
-      {/* Main content area: list OR tree panel (mutually exclusive, both inline) */}
-      <div className="tw-relative tw-flex-1 tw-overflow-hidden">
-        {treeOpen ? (
-          /* Inline tree panel - renders inside this container, not as a portal */
-          <div className="tw-absolute tw-inset-0 tw-z-10 tw-flex tw-flex-col tw-bg-background">
-            <div className="tw-flex tw-items-center tw-justify-between tw-border-b tw-px-3 tw-py-2">
-              <span className="tw-text-sm tw-font-semibold">Semantic Domains</span>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="tw-h-7 tw-w-7"
-                onClick={() => setTreeOpen(false)}
-              >
-                <X className="tw-h-4 tw-w-4" />
-              </Button>
-            </div>
-            <div className="tw-flex-1 tw-overflow-y-auto tw-p-2">
-              <DomainTreeView
-                domains={allDomains}
-                selectedLevel1Id={selectedLevel1Domain.id}
-                selectedLevel2Id={effectiveLevel2?.id}
-                onSelect={handleDomainSelectFromTree}
-              />
-            </div>
-          </div>
-        ) : (
-          /* Dictionary list with optional inline detail panel */
-          <SourceLanguageIndexedList
-            items={items}
-            renderItem={renderItem}
-            renderDetailContent={renderDetailContent}
-            onItemClick={onItemClick}
-            selectedItemId={selectedItemId}
-            emptyStateMessage={emptyStateMessage}
-            isLoading={isLoading}
-            showSourceLanguage
-            showTransliteration
-            className="tw-h-full"
-          />
-        )}
+      {/* Dictionary list with optional detail drawer (scoped to SourceLanguageIndexedList) */}
+      <div className="tw-flex-1 tw-overflow-hidden">
+        <SourceLanguageIndexedList
+          items={items}
+          renderItem={renderItem}
+          renderDetailContent={renderDetailContent}
+          onItemClick={onItemClick}
+          selectedItemId={selectedItemId}
+          emptyStateMessage={emptyStateMessage}
+          isLoading={isLoading}
+          showSourceLanguage
+          showTransliteration
+          className="tw-h-full"
+        />
       </div>
 
       {/* Navigation mode toggle at the bottom */}
@@ -217,11 +202,35 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
           </ToggleGroupItem>
         </ToggleGroup>
       </div>
+
+      {/* Domain tree Drawer - scoped to this component's bounding box */}
+      <Drawer direction="right" modal={false} open={treeOpen} onOpenChange={setTreeOpen}>
+        <DrawerContent container={containerRef.current} hideDrawerHandle className="tw-max-w-full">
+          <div className="tw-flex tw-h-full tw-flex-col">
+            <div className="tw-flex tw-items-center tw-justify-between tw-border-b tw-px-3 tw-py-2">
+              <DrawerTitle className="tw-text-sm tw-font-semibold">Semantic Domains</DrawerTitle>
+              <DrawerClose asChild>
+                <Button variant="outline" size="sm">
+                  Close
+                </Button>
+              </DrawerClose>
+            </div>
+            <div className="tw-flex-1 tw-overflow-y-auto tw-p-2">
+              <DomainTreeView
+                domains={allDomains}
+                selectedLevel1Id={selectedLevel1Domain.id}
+                selectedLevel2Id={effectiveLevel2?.id}
+                onSelect={handleDomainSelectFromTree}
+              />
+            </div>
+          </div>
+        </DrawerContent>
+      </Drawer>
     </div>
   );
 }
 
-/** Full 2-level domain tree rendered inline within the component */
+/** Full 2-level domain tree rendered inside the drawer */
 function DomainTreeView({
   domains,
   selectedLevel1Id,

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -1,7 +1,6 @@
 import { useRef, useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
-import { ToggleGroup, ToggleGroupItem } from '@/components/shadcn-ui/toggle-group';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -9,7 +8,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/shadcn-ui/dropdown-menu';
 import { Drawer, DrawerClose, DrawerContent, DrawerTitle } from '@/components/shadcn-ui/drawer';
-import { ChevronRight, ChevronDown, List, FolderTree } from 'lucide-react';
+import { ArrowLeft, ChevronDown, FolderTree } from 'lucide-react';
 import { Z_INDEX_MODAL } from '@/components/z-index';
 import SourceLanguageIndexedList from './source-language-indexed-list.component';
 import type {
@@ -18,24 +17,21 @@ import type {
   SemanticDomain,
 } from './source-language-indexed-list.types';
 
-/** Z-index that sits above the Dialog modal layer so dropdowns/drawers are visible */
+/** Z-index that sits above the Dialog modal layer so dropdowns are visible */
 const Z_ABOVE_MODAL = Z_INDEX_MODAL + 10;
 
 /**
  * ER Dictionary list filtered by semantic domain with 2-level breadcrumb navigation.
  *
- * Layout (top to bottom):
+ * Breadcrumb row layout: `[← back] [Category ▼] · [Domain ▼] ........... [🌳]`
  *
- * 1. **Breadcrumbs**: Always shows exactly 2 levels (`Category > Domain`). Both breadcrumb segments
- *    are interactive. In **dropdown mode** each opens a dropdown with siblings at that level. In
- *    **tree mode** each opens a Drawer scoped to this component's bounding box showing the full
- *    domain tree. When switching a category the first child domain is auto-selected.
- * 2. **Dictionary list**: A `SourceLanguageIndexedList` showing entries filtered to the selected
- *    domain. Clicking an entry opens a detail Drawer scoped to the list area.
- * 3. **Navigation mode toggle**: Switch between dropdown and tree navigation.
+ * - **Back arrow** (icon only, no text): navigates back when `onBack` is provided.
+ * - **Breadcrumbs** with dot separator: both segments are dropdowns showing siblings at that level.
+ *   When switching a category the first child domain is auto-selected.
+ * - **Tree button** (right-aligned): opens a scoped Drawer with the full 2-level domain tree.
  *
- * All drawers render inside this component's bounding box via the Drawer `container` prop. Dropdown
- * menus use a z-index above `Z_INDEX_MODAL` so they layer correctly on top of a parent Dialog.
+ * Below the breadcrumbs: a `SourceLanguageIndexedList` showing entries filtered to the selected
+ * domain. Clicking an entry opens a detail panel inline within the list area.
  *
  * Domains are always exactly 2 levels deep.
  */
@@ -51,8 +47,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   selectedLevel2Domain,
   allDomains,
   onDomainChange,
-  navigationMode,
-  onNavigationModeChange,
+  onBack,
   className,
 }: ErDictionaryFilteredListProps<T>) {
   const [treeOpen, setTreeOpen] = useState(false);
@@ -73,8 +68,6 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
     setTreeOpen(false);
   };
 
-  const openTreePanel = () => setTreeOpen(true);
-
   // Sibling domains at level 2 (children of the selected level 1)
   const level2Siblings = selectedLevel1Domain.children ?? [];
 
@@ -83,83 +76,94 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
       ref={containerRef}
       className={cn('tw-relative tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}
     >
-      {/* Breadcrumbs - always 2 levels: Category > Domain */}
-      <div className="tw-flex tw-items-center tw-gap-1 tw-border-b tw-px-3 tw-py-2">
+      {/* Breadcrumb row: [← back] [Category ▼] · [Domain ▼] ... [tree] */}
+      <div className="tw-flex tw-items-center tw-gap-1 tw-border-b tw-px-2 tw-py-1.5">
+        {/* Back arrow (icon only) */}
+        {onBack && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="tw-h-7 tw-w-7 tw-shrink-0"
+            onClick={onBack}
+            aria-label="Back to dictionary"
+          >
+            <ArrowLeft className="tw-h-4 tw-w-4" />
+          </Button>
+        )}
+
+        {/* Breadcrumbs with dot separator */}
         <nav
           aria-label="Semantic domain breadcrumbs"
-          className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1"
+          className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-0.5"
         >
-          {/* Level 1 breadcrumb (Category) */}
-          {navigationMode === 'dropdown' ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="ghost" className="tw-h-auto tw-gap-1 tw-p-1 tw-text-sm">
-                  {selectedLevel1Domain.label}
-                  <ChevronDown className="tw-h-3 tw-w-3" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" style={{ zIndex: Z_ABOVE_MODAL }}>
-                {allDomains.map((domain) => (
-                  <DropdownMenuItem
-                    key={domain.id}
-                    className={cn({
-                      'tw-font-medium': domain.id === selectedLevel1Domain.id,
-                    })}
-                    onClick={() => handleCategoryChange(domain)}
-                  >
-                    {domain.label}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : (
-            <Button variant="ghost" className="tw-h-auto tw-p-1 tw-text-sm" onClick={openTreePanel}>
-              {selectedLevel1Domain.label}
-            </Button>
-          )}
-
-          {/* Separator - always shown since we always have 2 levels */}
-          <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
-
-          {/* Level 2 breadcrumb (Domain) */}
-          {navigationMode === 'dropdown' ? (
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  className="tw-h-auto tw-gap-1 tw-p-1 tw-text-sm tw-font-medium"
+          {/* Level 1 (Category) dropdown */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" className="tw-h-auto tw-gap-1 tw-px-1.5 tw-py-0.5 tw-text-sm">
+                {selectedLevel1Domain.label}
+                <ChevronDown className="tw-h-3 tw-w-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" style={{ zIndex: Z_ABOVE_MODAL }}>
+              {allDomains.map((domain) => (
+                <DropdownMenuItem
+                  key={domain.id}
+                  className={cn({
+                    'tw-font-medium': domain.id === selectedLevel1Domain.id,
+                  })}
+                  onClick={() => handleCategoryChange(domain)}
                 >
-                  {effectiveLevel2?.label ?? 'All'}
-                  <ChevronDown className="tw-h-3 tw-w-3" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" style={{ zIndex: Z_ABOVE_MODAL }}>
-                {level2Siblings.map((domain) => (
-                  <DropdownMenuItem
-                    key={domain.id}
-                    className={cn({
-                      'tw-font-medium': domain.id === effectiveLevel2?.id,
-                    })}
-                    onClick={() => onDomainChange(selectedLevel1Domain, domain)}
-                  >
-                    {domain.label}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-          ) : (
-            <Button
-              variant="ghost"
-              className="tw-h-auto tw-p-1 tw-text-sm tw-font-medium"
-              onClick={openTreePanel}
-            >
-              {effectiveLevel2?.label ?? 'All'}
-            </Button>
-          )}
+                  {domain.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+
+          {/* Dot separator */}
+          <span className="tw-select-none tw-text-muted-foreground" aria-hidden>
+            &middot;
+          </span>
+
+          {/* Level 2 (Domain) dropdown */}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                className="tw-h-auto tw-gap-1 tw-px-1.5 tw-py-0.5 tw-text-sm tw-font-medium"
+              >
+                {effectiveLevel2?.label ?? 'All'}
+                <ChevronDown className="tw-h-3 tw-w-3" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" style={{ zIndex: Z_ABOVE_MODAL }}>
+              {level2Siblings.map((domain) => (
+                <DropdownMenuItem
+                  key={domain.id}
+                  className={cn({
+                    'tw-font-medium': domain.id === effectiveLevel2?.id,
+                  })}
+                  onClick={() => onDomainChange(selectedLevel1Domain, domain)}
+                >
+                  {domain.label}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
         </nav>
+
+        {/* Tree button (right-aligned) */}
+        <Button
+          variant="ghost"
+          size="icon"
+          className="tw-h-7 tw-w-7 tw-shrink-0"
+          onClick={() => setTreeOpen(true)}
+          aria-label="Browse domain tree"
+        >
+          <FolderTree className="tw-h-3.5 tw-w-3.5" />
+        </Button>
       </div>
 
-      {/* Dictionary list with optional detail drawer (scoped to SourceLanguageIndexedList) */}
+      {/* Dictionary list */}
       <div className="tw-flex-1 tw-overflow-hidden">
         <SourceLanguageIndexedList
           items={items}
@@ -175,35 +179,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
         />
       </div>
 
-      {/* Navigation mode toggle at the bottom */}
-      <div className="tw-flex tw-items-center tw-justify-end tw-border-t tw-px-3 tw-py-1.5">
-        <ToggleGroup
-          type="single"
-          value={navigationMode}
-          onValueChange={(value) => {
-            if (value === 'tree' || value === 'dropdown') {
-              onNavigationModeChange?.(value);
-            }
-          }}
-        >
-          <ToggleGroupItem
-            value="dropdown"
-            aria-label="Dropdown navigation"
-            className="tw-h-7 tw-w-7 tw-p-0"
-          >
-            <List className="tw-h-3.5 tw-w-3.5" />
-          </ToggleGroupItem>
-          <ToggleGroupItem
-            value="tree"
-            aria-label="Tree navigation"
-            className="tw-h-7 tw-w-7 tw-p-0"
-          >
-            <FolderTree className="tw-h-3.5 tw-w-3.5" />
-          </ToggleGroupItem>
-        </ToggleGroup>
-      </div>
-
-      {/* Domain tree Drawer - scoped to this component's bounding box */}
+      {/* Domain tree Drawer - scoped to this component */}
       <Drawer direction="right" modal={false} open={treeOpen} onOpenChange={setTreeOpen}>
         <DrawerContent
           container={containerRef.current}

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -151,7 +151,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
                 ref={listRef}
                 role="listbox"
                 tabIndex={0}
-                className="tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-ring"
+                className="tw-outline-none"
                 onKeyDown={handleListKeyDown}
               >
                 {items.map((item, idx) => {
@@ -163,7 +163,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
                       role="option"
                       aria-selected={isSelected}
                       onClick={() => {
-                        setFocusedIndex(idx);
+                        setFocusedIndex(-1);
                         selectItem(item);
                       }}
                       className={cn('tw-cursor-pointer tw-border-b tw-p-2', {

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -23,10 +23,9 @@ import type {
 /**
  * ER Dictionary list filtered by semantic domain with breadcrumb navigation.
  *
- * Each breadcrumb segment (including the ellipsis) is clickable and opens a DropdownMenu (modal)
- * aligned to that segment, showing the expandable domain tree with that segment's level expanded.
- * The DropdownMenu captures keyboard: arrow keys move through items, Tab cycles expand/collapse
- * buttons, Esc closes only the dropdown (not the parent drawer).
+ * Each breadcrumb segment opens a DropdownMenu with a keyboard-navigable domain tree. The list
+ * supports arrow-key navigation: in wide mode arrows immediately select items; in narrow mode
+ * arrows move focus and Enter/Space submits.
  */
 export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   items,
@@ -43,9 +42,12 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   className,
 }: ErDictionaryFilteredListProps<T>) {
   const [selectedId, setSelectedId] = useState<string | undefined>(selectedItemId);
+  const [focusedIndex, setFocusedIndex] = useState(-1);
 
   // eslint-disable-next-line no-null/no-null
   const containerRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line no-null/no-null
+  const listRef = useRef<HTMLUListElement>(null);
   const [narrow, setNarrow] = useState(false);
 
   useEffect(() => {
@@ -67,13 +69,46 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   );
 
   const selectedItem = items.find((item) => item.id === selectedId);
-  const handleItemClick = (item: T) => {
-    onItemClick?.(item);
-    setSelectedId(item.id === selectedId ? undefined : item.id);
-  };
-
   const showSideBySide = selectedItem && !narrow;
   const showFullDetail = selectedItem && narrow;
+
+  const selectItem = useCallback(
+    (item: T) => {
+      onItemClick?.(item);
+      setSelectedId(item.id === selectedId ? undefined : item.id);
+    },
+    [onItemClick, selectedId],
+  );
+
+  // List keyboard: arrow keys navigate, behavior depends on narrow/wide
+  const handleListKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (items.length === 0) return;
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = Math.min(focusedIndex + 1, items.length - 1);
+        setFocusedIndex(next);
+        if (!narrow) selectItem(items[next]);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const prev = Math.max(focusedIndex - 1, 0);
+        setFocusedIndex(prev);
+        if (!narrow) selectItem(items[prev]);
+      } else if ((e.key === 'Enter' || e.key === ' ') && narrow && focusedIndex >= 0) {
+        e.preventDefault();
+        selectItem(items[focusedIndex]);
+      }
+    },
+    [items, focusedIndex, narrow, selectItem],
+  );
+
+  // Scroll focused item into view
+  useEffect(() => {
+    if (focusedIndex < 0 || !listRef.current) return;
+    const li = listRef.current.children[focusedIndex] as HTMLElement | undefined;
+    li?.scrollIntoView({ block: 'nearest' });
+  }, [focusedIndex]);
 
   return (
     <div className={cn('tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}>
@@ -112,18 +147,29 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
                 {emptyStateMessage ?? 'No items found'}
               </div>
             ) : (
-              <ul role="listbox" className="tw-outline-none">
-                {items.map((item) => {
+              <ul
+                ref={listRef}
+                role="listbox"
+                tabIndex={0}
+                className="tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-ring"
+                onKeyDown={handleListKeyDown}
+              >
+                {items.map((item, idx) => {
                   const isSelected = selectedId === item.id;
+                  const isFocused = focusedIndex === idx;
                   return (
                     <li
                       key={item.id}
                       role="option"
                       aria-selected={isSelected}
-                      onClick={() => handleItemClick(item)}
+                      onClick={() => {
+                        setFocusedIndex(idx);
+                        selectItem(item);
+                      }}
                       className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
                         'tw-bg-muted': isSelected,
                         'hover:tw-bg-muted': !isSelected,
+                        'tw-ring-1 tw-ring-inset tw-ring-ring': isFocused && !isSelected,
                       })}
                     >
                       {renderItem ? (
@@ -222,7 +268,6 @@ function BreadcrumbBar({
       : path.slice(1, hideCount + 1)
     : [];
   const hiddenTooltip = hiddenSegments.map((d) => d.label).join(' > ');
-  // The expand target for the ellipsis dropdown: first hidden segment
   const ellipsisExpandId = hiddenSegments[0]?.id ?? path[0]?.id;
 
   return (
@@ -243,7 +288,6 @@ function BreadcrumbBar({
 
       {/* Visible breadcrumbs */}
       <div className="tw-inline-flex tw-items-center tw-gap-0.5">
-        {/* Root */}
         {!hideRoot && path[0] && (
           <SegmentDropdown
             label={path[0].label}
@@ -255,7 +299,6 @@ function BreadcrumbBar({
           />
         )}
 
-        {/* Ellipsis: clickable (opens dropdown) + tooltip (immediate) */}
         {showEllipsis && (
           <>
             {!hideRoot && (
@@ -284,7 +327,6 @@ function BreadcrumbBar({
           </>
         )}
 
-        {/* Trailing segments */}
         {path.map((domain, idx) => {
           if (idx === 0) return undefined;
           if (idx <= hideCount) return undefined;
@@ -309,7 +351,7 @@ function BreadcrumbBar({
 }
 
 // ---------------------------------------------------------------------------
-// SegmentDropdown: a breadcrumb segment that opens a DropdownMenu with domain tree
+// SegmentDropdown
 // ---------------------------------------------------------------------------
 
 function SegmentDropdown({
@@ -331,10 +373,13 @@ function SegmentDropdown({
 }) {
   const [open, setOpen] = useState(false);
 
-  const handleSelect = (newPath: SemanticDomain[]) => {
-    onDomainSelect(newPath);
-    setOpen(false);
-  };
+  const handleSelect = useCallback(
+    (newPath: SemanticDomain[]) => {
+      onDomainSelect(newPath);
+      setOpen(false);
+    },
+    [onDomainSelect],
+  );
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen} modal>
@@ -354,17 +399,24 @@ function SegmentDropdown({
         align="start"
         className="tw-max-h-[500px] tw-w-[300px] tw-overflow-y-auto tw-p-1"
         style={{ zIndex: Z_INDEX_MODAL + 10 }}
-        // Prevent Esc from propagating to the parent Drawer
         onEscapeKeyDown={(e) => {
           e.stopPropagation();
+          e.preventDefault();
           setOpen(false);
         }}
+        onKeyDown={(e) => {
+          // Prevent all keyboard events from reaching the parent Drawer
+          if (e.key === 'Escape') {
+            e.stopPropagation();
+          }
+        }}
       >
-        <DomainTreeContent
+        <TreeKeyboardContainer
           domains={allDomains}
           currentPath={currentPath}
           expandToId={expandToId}
           onSelect={handleSelect}
+          onClose={() => setOpen(false)}
         />
       </DropdownMenuContent>
     </DropdownMenu>
@@ -372,37 +424,91 @@ function SegmentDropdown({
 }
 
 // ---------------------------------------------------------------------------
-// Domain tree inside dropdown (proper keyboard: focusable buttons, Esc stops)
+// Tree with custom keyboard navigation
 // ---------------------------------------------------------------------------
 
-function DomainTreeContent({
+/**
+ * Wraps the domain tree and implements custom keyboard navigation:
+ *
+ * - ArrowDown / ArrowUp: move focus through all visible buttons (domain labels + expand/collapse)
+ * - Tab / Shift+Tab: same as arrow keys (cycle through buttons)
+ * - Enter / Space on a domain label: select it
+ * - Enter / Space on an expand/collapse button: toggle expand
+ * - Escape: close the dropdown (stops propagation so the parent drawer stays open)
+ */
+function TreeKeyboardContainer({
   domains,
   currentPath,
   expandToId,
   onSelect,
+  onClose,
 }: {
   domains: SemanticDomain[];
   currentPath: SemanticDomain[];
   expandToId: string;
   onSelect: (path: SemanticDomain[]) => void;
+  onClose: () => void;
 }) {
+  // eslint-disable-next-line no-null/no-null
+  const containerRef = useRef<HTMLDivElement>(null);
   // eslint-disable-next-line no-null/no-null
   const scrollRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     requestAnimationFrame(() => {
-      scrollRef.current?.scrollIntoView({ block: 'center' });
+      // Focus and scroll to the expand target
+      if (scrollRef.current) {
+        scrollRef.current.scrollIntoView({ block: 'center' });
+        scrollRef.current.focus();
+      }
     });
   }, [expandToId]);
 
+  const getFocusableButtons = (): HTMLButtonElement[] => {
+    if (!containerRef.current) return [];
+    return Array.from(containerRef.current.querySelectorAll('button'));
+  };
+
+  const moveFocus = (direction: 1 | -1) => {
+    const buttons = getFocusableButtons();
+    if (buttons.length === 0) return;
+    const currentIdx = buttons.indexOf(document.activeElement as HTMLButtonElement);
+    let nextIdx = currentIdx + direction;
+    if (nextIdx < 0) nextIdx = buttons.length - 1;
+    if (nextIdx >= buttons.length) nextIdx = 0;
+    buttons[nextIdx].focus();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    switch (e.key) {
+      case 'ArrowDown':
+        e.preventDefault();
+        e.stopPropagation();
+        moveFocus(1);
+        break;
+      case 'ArrowUp':
+        e.preventDefault();
+        e.stopPropagation();
+        moveFocus(-1);
+        break;
+      case 'Tab':
+        e.preventDefault();
+        e.stopPropagation();
+        moveFocus(e.shiftKey ? -1 : 1);
+        break;
+      case 'Escape':
+        e.preventDefault();
+        e.stopPropagation();
+        onClose();
+        break;
+      default:
+        break;
+    }
+  };
+
   return (
-    // Role="menu" wrapping div so arrow keys work natively via the DropdownMenu Radix primitive.
-    // We use onKeyDown at this level to trap Esc.
-    <div
-      onKeyDown={(e) => {
-        if (e.key === 'Escape') e.stopPropagation();
-      }}
-    >
+    // eslint-disable-next-line jsx-a11y/no-static-element-interactions
+    <div ref={containerRef} onKeyDown={handleKeyDown}>
       <TreeNodeList
         domains={domains}
         currentPath={currentPath}
@@ -502,12 +608,8 @@ function TreeNode({
         {hasChildren ? (
           <button
             type="button"
-            tabIndex={0}
             className="tw-flex tw-h-5 tw-w-5 tw-shrink-0 tw-items-center tw-justify-center tw-rounded hover:tw-bg-muted focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-ring"
-            onClick={(e) => {
-              e.stopPropagation();
-              setExpanded(!expanded);
-            }}
+            onClick={() => setExpanded(!expanded)}
           >
             <ChevronRight
               className={cn('tw-h-3 tw-w-3 tw-transition-transform', {
@@ -520,7 +622,6 @@ function TreeNode({
         )}
         <button
           type="button"
-          tabIndex={0}
           ref={isScrollTarget ? scrollRef : undefined}
           className={cn(
             'tw-flex-1 tw-rounded tw-px-1.5 tw-py-0.5 tw-text-left tw-text-sm focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-ring',

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -1,14 +1,15 @@
+import { useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import { ToggleGroup, ToggleGroupItem } from '@/components/shadcn-ui/toggle-group';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/shadcn-ui/select';
-import { ChevronRight, List, FolderTree } from 'lucide-react';
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/shadcn-ui/dropdown-menu';
+import { Drawer, DrawerClose, DrawerContent, DrawerTitle } from '@/components/shadcn-ui/drawer';
+import { ChevronRight, ChevronDown, List, FolderTree } from 'lucide-react';
 import SourceLanguageIndexedList from './source-language-indexed-list.component';
 import type {
   ErDictionaryFilteredListProps,
@@ -17,42 +18,180 @@ import type {
 } from './source-language-indexed-list.types';
 
 /**
- * ER Dictionary list filtered by semantic domain. Shows a breadcrumb trail for the domain hierarchy
- * and a toggle to switch between tree view (Option A) and dropdown view (Option B) for domain
- * navigation.
+ * ER Dictionary list filtered by semantic domain with 2-level breadcrumb navigation.
  *
- * Screen A from ui-alignment.md: Dictionary entries filtered by a selected semantic domain, with
- * breadcrumbs showing the domain path and the list below filtered to that domain.
+ * Layout (top to bottom):
+ *
+ * 1. **Breadcrumbs**: Always shows 2-level breadcrumbs (`Level 1 > Level 2`). Clicking a breadcrumb
+ *    opens either a dropdown (in dropdown mode) or a domain tree drawer (in tree mode) to switch
+ *    the domain.
+ * 2. **Dictionary list**: A `SourceLanguageIndexedList` showing entries filtered to the selected
+ *    domain. Clicking an entry opens a detail drawer.
+ * 3. **Navigation mode toggle**: Switch between dropdown and tree view for domain navigation.
+ *
+ * Domains are always exactly 2 levels deep.
  *
  * @example
  *
  * ```tsx
  * <ErDictionaryFilteredList
  *   items={filteredEntries}
- *   domainPath={[root, naturalWorld, animals]}
- *   navigationMode="tree"
+ *   selectedLevel1Domain={level1}
+ *   selectedLevel2Domain={level2}
+ *   allDomains={allDomains}
+ *   onDomainChange={handleDomainChange}
+ *   navigationMode="dropdown"
  *   onNavigationModeChange={setNavMode}
- *   onBreadcrumbClick={handleBreadcrumbClick}
- *   domainChildren={currentDomainChildren}
- *   onDomainSelect={handleDomainSelect}
+ *   renderDetailContent={(item, onClose) => <Detail entry={item} onBack={onClose} />}
  * />;
  * ```
  */
 export default function ErDictionaryFilteredList<T extends IndexedListItem>({
-  domainPath,
-  onBreadcrumbClick,
+  items,
+  renderItem,
+  renderDetailContent,
+  onItemClick,
+  selectedItemId,
+  emptyStateMessage,
+  isLoading,
+  selectedLevel1Domain,
+  selectedLevel2Domain,
+  allDomains,
+  onDomainChange,
   navigationMode,
   onNavigationModeChange,
-  domainChildren,
-  onDomainSelect,
   className,
-  ...listProps
 }: ErDictionaryFilteredListProps<T>) {
+  const [treeDrawerOpen, setTreeDrawerOpen] = useState(false);
+
+  const handleLevel1BreadcrumbClick = () => {
+    if (navigationMode === 'dropdown') {
+      // Dropdown opens via DropdownMenu component natively
+      return;
+    }
+    // Tree mode: open the domain tree drawer
+    setTreeDrawerOpen(true);
+  };
+
+  const handleLevel2BreadcrumbClick = () => {
+    if (navigationMode === 'dropdown') {
+      // Dropdown opens via DropdownMenu component natively
+      return;
+    }
+    // Tree mode: open the domain tree drawer
+    setTreeDrawerOpen(true);
+  };
+
+  const handleDomainSelectFromTree = (level1: SemanticDomain, level2?: SemanticDomain) => {
+    onDomainChange(level1, level2);
+    setTreeDrawerOpen(false);
+  };
+
+  // Sibling domains at level 1 (all top-level domains)
+  const level1Siblings = allDomains;
+
+  // Sibling domains at level 2 (children of the selected level 1)
+  const level2Siblings = selectedLevel1Domain.children ?? [];
+
   return (
     <div className={cn('tw-flex tw-h-full tw-flex-col', className)}>
-      {/* Header: Breadcrumb trail + navigation mode toggle */}
-      <div className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-border-b tw-px-3 tw-py-2">
-        <DomainBreadcrumbs domainPath={domainPath} onBreadcrumbClick={onBreadcrumbClick} />
+      {/* Breadcrumbs - always 2 levels */}
+      <div className="tw-flex tw-items-center tw-gap-1 tw-border-b tw-px-3 tw-py-2">
+        <nav
+          aria-label="Semantic domain breadcrumbs"
+          className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1"
+        >
+          {/* Level 1 breadcrumb */}
+          {navigationMode === 'dropdown' ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" className="tw-h-auto tw-gap-1 tw-p-1 tw-text-sm">
+                  {selectedLevel1Domain.label}
+                  <ChevronDown className="tw-h-3 tw-w-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start">
+                {level1Siblings.map((domain) => (
+                  <DropdownMenuItem
+                    key={domain.id}
+                    className={cn({
+                      'tw-font-medium': domain.id === selectedLevel1Domain.id,
+                    })}
+                    onClick={() => onDomainChange(domain)}
+                  >
+                    {domain.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <Button
+              variant="ghost"
+              className="tw-h-auto tw-p-1 tw-text-sm"
+              onClick={handleLevel1BreadcrumbClick}
+            >
+              {selectedLevel1Domain.label}
+            </Button>
+          )}
+
+          {/* Separator */}
+          {selectedLevel2Domain && (
+            <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+          )}
+
+          {/* Level 2 breadcrumb (if a level-2 domain is selected) */}
+          {selectedLevel2Domain &&
+            (navigationMode === 'dropdown' ? (
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="ghost" className="tw-h-auto tw-gap-1 tw-p-1 tw-text-sm">
+                    {selectedLevel2Domain.label}
+                    <ChevronDown className="tw-h-3 tw-w-3" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  {level2Siblings.map((domain) => (
+                    <DropdownMenuItem
+                      key={domain.id}
+                      className={cn({
+                        'tw-font-medium': domain.id === selectedLevel2Domain.id,
+                      })}
+                      onClick={() => onDomainChange(selectedLevel1Domain, domain)}
+                    >
+                      {domain.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            ) : (
+              <Button
+                variant="ghost"
+                className="tw-h-auto tw-p-1 tw-text-sm tw-font-medium"
+                onClick={handleLevel2BreadcrumbClick}
+              >
+                {selectedLevel2Domain.label}
+              </Button>
+            ))}
+        </nav>
+      </div>
+
+      {/* Dictionary list with optional detail drawer */}
+      <div className="tw-flex-1 tw-overflow-y-auto">
+        <SourceLanguageIndexedList
+          items={items}
+          renderItem={renderItem}
+          renderDetailContent={renderDetailContent}
+          onItemClick={onItemClick}
+          selectedItemId={selectedItemId}
+          emptyStateMessage={emptyStateMessage}
+          isLoading={isLoading}
+          showSourceLanguage
+          showTransliteration
+        />
+      </div>
+
+      {/* Navigation mode toggle at the bottom */}
+      <div className="tw-flex tw-items-center tw-justify-end tw-border-t tw-px-3 tw-py-1.5">
         <ToggleGroup
           type="single"
           value={navigationMode}
@@ -61,130 +200,94 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
               onNavigationModeChange?.(value);
             }
           }}
-          className="tw-shrink-0"
         >
-          <ToggleGroupItem value="tree" aria-label="Tree view" className="tw-h-8 tw-w-8 tw-p-0">
-            <FolderTree className="tw-h-4 tw-w-4" />
-          </ToggleGroupItem>
           <ToggleGroupItem
             value="dropdown"
-            aria-label="Dropdown view"
-            className="tw-h-8 tw-w-8 tw-p-0"
+            aria-label="Dropdown navigation"
+            className="tw-h-7 tw-w-7 tw-p-0"
           >
-            <List className="tw-h-4 tw-w-4" />
+            <List className="tw-h-3.5 tw-w-3.5" />
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            value="tree"
+            aria-label="Tree navigation"
+            className="tw-h-7 tw-w-7 tw-p-0"
+          >
+            <FolderTree className="tw-h-3.5 tw-w-3.5" />
           </ToggleGroupItem>
         </ToggleGroup>
       </div>
 
-      {/* Domain navigation area (tree or dropdown based on mode) */}
-      {domainChildren && domainChildren.length > 0 && (
-        <div className="tw-border-b tw-px-3 tw-py-2">
-          {navigationMode === 'dropdown' ? (
-            <DomainDropdown domains={domainChildren} onSelect={onDomainSelect} />
-          ) : (
-            <DomainTree domains={domainChildren} onSelect={onDomainSelect} />
-          )}
-        </div>
-      )}
-
-      {/* Filtered dictionary list */}
-      <div className="tw-flex-1 tw-overflow-y-auto">
-        <SourceLanguageIndexedList {...listProps} showSourceLanguage showTransliteration />
-      </div>
+      {/* Domain tree drawer (tree mode only) */}
+      <Drawer direction="right" open={treeDrawerOpen} onOpenChange={setTreeDrawerOpen}>
+        <DrawerContent hideDrawerHandle className="tw-max-w-sm">
+          <div className="tw-overflow-y-auto tw-p-4">
+            <DrawerTitle className="tw-mb-4">Semantic Domains</DrawerTitle>
+            <DomainTreeView
+              domains={allDomains}
+              selectedLevel1Id={selectedLevel1Domain.id}
+              selectedLevel2Id={selectedLevel2Domain?.id}
+              onSelect={handleDomainSelectFromTree}
+            />
+            <div className="tw-mt-4">
+              <DrawerClose asChild>
+                <Button variant="outline" className="tw-w-full">
+                  Close
+                </Button>
+              </DrawerClose>
+            </div>
+          </div>
+        </DrawerContent>
+      </Drawer>
     </div>
   );
 }
 
-/** Breadcrumb trail showing the domain hierarchy path */
-function DomainBreadcrumbs({
-  domainPath,
-  onBreadcrumbClick,
-}: {
-  domainPath: SemanticDomain[];
-  onBreadcrumbClick?: (domain: SemanticDomain) => void;
-}) {
-  return (
-    <nav
-      aria-label="Semantic domain breadcrumbs"
-      className="tw-flex tw-min-w-0 tw-items-center tw-gap-1 tw-overflow-x-auto"
-    >
-      {domainPath.map((domain, index) => {
-        const isLast = index === domainPath.length - 1;
-        return (
-          <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-1">
-            {isLast ? (
-              <span className="tw-text-sm tw-font-medium">{domain.label}</span>
-            ) : (
-              <>
-                <Button
-                  variant="link"
-                  className="tw-h-auto tw-p-0 tw-text-sm"
-                  onClick={() => onBreadcrumbClick?.(domain)}
-                >
-                  {domain.label}
-                </Button>
-                <ChevronRight className="tw-h-3 tw-w-3 tw-text-muted-foreground" />
-              </>
-            )}
-          </span>
-        );
-      })}
-    </nav>
-  );
-}
-
-/** Dropdown navigation showing sibling domains at the current level */
-function DomainDropdown({
+/** Full 2-level domain tree view shown inside the tree drawer */
+function DomainTreeView({
   domains,
+  selectedLevel1Id,
+  selectedLevel2Id,
   onSelect,
 }: {
   domains: SemanticDomain[];
-  onSelect?: (domain: SemanticDomain) => void;
+  selectedLevel1Id: string;
+  selectedLevel2Id?: string;
+  onSelect: (level1: SemanticDomain, level2?: SemanticDomain) => void;
 }) {
   return (
-    <Select
-      onValueChange={(value) => {
-        const domain = domains.find((d) => d.id === value);
-        if (domain) onSelect?.(domain);
-      }}
-    >
-      <SelectTrigger className="tw-w-full">
-        <SelectValue placeholder="Select a domain..." />
-      </SelectTrigger>
-      <SelectContent>
-        {domains.map((domain) => (
-          <SelectItem key={domain.id} value={domain.id}>
-            {domain.label}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-}
-
-/** Tree navigation showing the full hierarchy of child domains */
-function DomainTree({
-  domains,
-  onSelect,
-  level = 0,
-}: {
-  domains: SemanticDomain[];
-  onSelect?: (domain: SemanticDomain) => void;
-  level?: number;
-}) {
-  return (
-    <ul className={cn('tw-space-y-0.5', { 'tw-pl-4': level > 0 })}>
-      {domains.map((domain) => (
-        <li key={domain.id}>
+    <ul className="tw-space-y-1">
+      {domains.map((level1) => (
+        <li key={level1.id}>
           <Button
             variant="ghost"
-            className="tw-h-auto tw-w-full tw-justify-start tw-px-2 tw-py-1 tw-text-sm"
-            onClick={() => onSelect?.(domain)}
+            className={cn('tw-h-auto tw-w-full tw-justify-start tw-px-2 tw-py-1.5 tw-text-sm', {
+              'tw-bg-accent tw-font-medium': level1.id === selectedLevel1Id && !selectedLevel2Id,
+            })}
+            onClick={() => onSelect(level1)}
           >
-            {domain.label}
+            {level1.label}
           </Button>
-          {domain.children && domain.children.length > 0 && (
-            <DomainTree domains={domain.children} onSelect={onSelect} level={level + 1} />
+          {level1.children && level1.children.length > 0 && (
+            <ul className="tw-ml-4 tw-space-y-0.5">
+              {level1.children.map((level2) => (
+                <li key={level2.id}>
+                  <Button
+                    variant="ghost"
+                    className={cn(
+                      'tw-h-auto tw-w-full tw-justify-start tw-px-2 tw-py-1 tw-text-sm',
+                      {
+                        'tw-bg-accent tw-font-medium':
+                          level1.id === selectedLevel1Id && level2.id === selectedLevel2Id,
+                      },
+                    )}
+                    onClick={() => onSelect(level1, level2)}
+                  >
+                    {level2.label}
+                  </Button>
+                </li>
+              ))}
+            </ul>
           )}
         </li>
       ))}

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -558,24 +558,13 @@ function TreeKeyboardContainer({
   // eslint-disable-next-line no-null/no-null
   const scrollRef = useRef<HTMLButtonElement>(null);
 
+  // Scroll the selected node into view when the dropdown opens, but do not
+  // move focus there — the user can Tab in when they want to navigate.
   useEffect(() => {
-    const focusTarget = () => {
-      if (!scrollRef.current) return;
-      if (document.activeElement === scrollRef.current) return;
-      scrollRef.current.scrollIntoView({ block: 'center' });
-      scrollRef.current.focus();
-    };
-    // Multiple staggered attempts to win the race against Radix's
-    // RovingFocusGroup, which re-focuses the first menu item asynchronously.
-    // A single rAF isn't enough on subsequent opens when focus was previously
-    // on another SegmentDropdown's trigger.
-    const rafId = requestAnimationFrame(focusTarget);
-    const delays = [0, 50, 120, 220];
-    const timeoutIds = delays.map((delay) => window.setTimeout(focusTarget, delay));
-    return () => {
-      cancelAnimationFrame(rafId);
-      timeoutIds.forEach((id) => window.clearTimeout(id));
-    };
+    const id = requestAnimationFrame(() => {
+      scrollRef.current?.scrollIntoView({ block: 'center' });
+    });
+    return () => cancelAnimationFrame(id);
   }, [expandToId]);
 
   const getFocusableButtons = (): HTMLButtonElement[] => {
@@ -668,12 +657,15 @@ function TreeNodeList({
     <ul className={cn('tw-space-y-0.5', { 'tw-ml-3': parentPath.length > 0 })}>
       {domains.map((domain) => {
         const thisPath = [...parentPath, domain];
-        const isSelected =
-          currentPath.length > 0 && currentPath[currentPath.length - 1].id === domain.id;
+        // The clicked breadcrumb segment is the selected node in the tree —
+        // not the final segment of currentPath, which may be deeper than the
+        // segment the user clicked.
+        const isSelected = domain.id === expandToId;
         const hasChildren = domain.children && domain.children.length > 0;
-        const isOnPath = currentPath.some((d) => d.id === domain.id);
         const containsTarget = isAncestorOf(domain, expandToId);
-        const shouldExpand = isOnPath || containsTarget;
+        // Expand only strict ancestors of the clicked breadcrumb segment so
+        // the segment itself is visible but its children stay collapsed.
+        const shouldExpand = containsTarget && domain.id !== expandToId;
         const isScrollTarget = domain.id === expandToId;
 
         return (

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -1,7 +1,17 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
-import { Popover, PopoverContent, PopoverTrigger } from '@/components/shadcn-ui/popover';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from '@/components/shadcn-ui/dropdown-menu';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/shadcn-ui/tooltip';
 import { ArrowUp, ChevronRight, MoreHorizontal } from 'lucide-react';
 import { Z_INDEX_MODAL } from '@/components/z-index';
 import type {
@@ -13,11 +23,11 @@ import type {
 /**
  * ER Dictionary list filtered by semantic domain with breadcrumb navigation.
  *
- * Header row: `[breadcrumb button] ......... [↑ Back]`
+ * Each breadcrumb segment is clickable and opens a DropdownMenu (modal) aligned to that segment,
+ * showing the expandable domain tree with that segment's level expanded and highlighted.
  *
- * Below the header: an inline list + detail layout (same pattern as the dictionary tab) where the
- * list and detail are side-by-side flex children. All interactive elements (list items,
- * breadcrumbs, back button, domain links) remain clickable while the detail panel is open.
+ * Breadcrumbs collapse from the 2nd-left inward. The final collapse state is `... > leaf` (root is
+ * hidden). The ellipsis has a tooltip showing the hidden path segments.
  */
 export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   items,
@@ -33,8 +43,6 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   onClose,
   className,
 }: ErDictionaryFilteredListProps<T>) {
-  const [popoverOpen, setPopoverOpen] = useState(false);
-  const [clickedSegmentId, setClickedSegmentId] = useState<string | undefined>();
   const [selectedId, setSelectedId] = useState<string | undefined>(selectedItemId);
 
   // eslint-disable-next-line no-null/no-null
@@ -54,21 +62,10 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   const handleDomainSelect = useCallback(
     (path: SemanticDomain[]) => {
       onDomainChange(path);
-      setPopoverOpen(false);
       setSelectedId(undefined);
     },
     [onDomainChange],
   );
-
-  const handleBreadcrumbClick = (segmentId: string) => {
-    if (popoverOpen) {
-      // Close on re-click
-      setPopoverOpen(false);
-    } else {
-      setClickedSegmentId(segmentId);
-      setPopoverOpen(true);
-    }
-  };
 
   const selectedItem = items.find((item) => item.id === selectedId);
   const handleItemClick = (item: T) => {
@@ -81,27 +78,15 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
 
   return (
     <div className={cn('tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}>
-      {/* Header: breadcrumb + back */}
+      {/* Header: breadcrumbs + back */}
       <div className="tw-flex tw-items-center tw-gap-1 tw-border-b tw-px-2 tw-py-1.5">
-        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-          <PopoverTrigger asChild>
-            <div className="tw-min-w-0 tw-flex-1">
-              <BreadcrumbBar path={domainPath} onSegmentClick={handleBreadcrumbClick} />
-            </div>
-          </PopoverTrigger>
-          <PopoverContent
-            align="start"
-            className="tw-w-full tw-max-w-[400px] tw-p-0"
-            style={{ zIndex: Z_INDEX_MODAL + 10 }}
-          >
-            <DomainTree
-              domains={allDomains}
-              currentPath={domainPath}
-              expandToId={clickedSegmentId}
-              onSelect={handleDomainSelect}
-            />
-          </PopoverContent>
-        </Popover>
+        <div className="tw-min-w-0 tw-flex-1">
+          <BreadcrumbBar
+            path={domainPath}
+            allDomains={allDomains}
+            onDomainSelect={handleDomainSelect}
+          />
+        </div>
 
         {onClose && (
           <Button variant="ghost" size="sm" className="tw-shrink-0 tw-gap-1" onClick={onClose}>
@@ -111,7 +96,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
         )}
       </div>
 
-      {/* Inline list + detail (same pattern as dictionary tab) */}
+      {/* Inline list + detail */}
       <div ref={containerRef} className="tw-relative tw-flex tw-flex-1 tw-overflow-hidden">
         {!showFullDetail && (
           <div
@@ -171,15 +156,17 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
 }
 
 // ---------------------------------------------------------------------------
-// BreadcrumbBar: flicker-free collapse, no hover underline
+// BreadcrumbBar: flicker-free collapse, ellipsis tooltip, per-segment dropdown
 // ---------------------------------------------------------------------------
 
 function BreadcrumbBar({
   path,
-  onSegmentClick,
+  allDomains,
+  onDomainSelect,
 }: {
   path: SemanticDomain[];
-  onSegmentClick: (domainId: string) => void;
+  allDomains: SemanticDomain[];
+  onDomainSelect: (path: SemanticDomain[]) => void;
 }) {
   // eslint-disable-next-line no-null/no-null
   const outerRef = useRef<HTMLDivElement>(null);
@@ -197,41 +184,36 @@ function BreadcrumbBar({
       const segEls = Array.from(full.children) as HTMLElement[];
       if (segEls.length === 0) return;
 
-      // Check if everything fits (include some padding buffer)
       const fullWidth = segEls.reduce((sum, el) => sum + el.offsetWidth, 0);
-      if (fullWidth <= available - 8) {
+      if (fullWidth <= available - 4) {
         setHideCount(0);
         return;
       }
 
       const widths = segEls.map((el) => el.offsetWidth);
       const totalSegments = path.length;
-      const ellipsisWidth = 44; // chevron + dots + gaps
+      const ellipsisWidth = 44;
 
       // Try hiding from index 1 inward. Always keep the last segment.
-      // When h < totalSegments - 1: show root + ellipsis + trailing (from h+1..end)
-      // When h >= totalSegments - 1: show ellipsis + last segment only
+      // h < totalSegments - 1: show root + ... + trailing
+      // h >= totalSegments - 1: show ... + last only
       for (let h = 1; h < totalSegments; h += 1) {
         let visibleWidth = ellipsisWidth;
 
         if (h < totalSegments - 1) {
-          // Root is still visible
           visibleWidth += widths[0] ?? 0;
-          for (let j = h + 1; j < totalSegments; j += 1) {
-            visibleWidth += widths[j] ?? 0;
-          }
+          for (let j = h + 1; j < totalSegments; j += 1) visibleWidth += widths[j] ?? 0;
         } else {
-          // Root hidden, only last segment + ellipsis
+          // Only ellipsis + last segment
           visibleWidth += widths[totalSegments - 1] ?? 0;
         }
 
-        if (visibleWidth <= available - 8) {
+        if (visibleWidth <= available - 4) {
           setHideCount(h);
           return;
         }
       }
 
-      // Cannot fit even ellipsis + last segment - show just last
       setHideCount(totalSegments - 1);
     };
 
@@ -243,6 +225,14 @@ function BreadcrumbBar({
 
   const showEllipsis = hideCount > 0;
   const hideRoot = hideCount >= path.length - 1;
+
+  // Hidden path segments for the ellipsis tooltip
+  const hiddenSegments = showEllipsis
+    ? hideRoot
+      ? path.slice(0, -1)
+      : path.slice(1, hideCount + 1)
+    : [];
+  const hiddenTooltip = hiddenSegments.map((d) => d.label).join(' > ');
 
   return (
     <div ref={outerRef} className="tw-overflow-hidden">
@@ -260,140 +250,139 @@ function BreadcrumbBar({
         ))}
       </div>
 
-      {/* Visible breadcrumbs (inline, hugs content) */}
-      <span className="tw-inline-flex tw-items-center tw-gap-0.5 tw-rounded tw-text-left">
-        {/* Root */}
+      {/* Visible breadcrumbs */}
+      <div className="tw-inline-flex tw-items-center tw-gap-0.5">
+        {/* Root segment (hidden when fully collapsed) */}
         {!hideRoot && path[0] && (
-          <BreadcrumbSegment domain={path[0]} isLast={path.length === 1} onClick={onSegmentClick} />
+          <BreadcrumbSegmentDropdown
+            domain={path[0]}
+            isLast={path.length === 1}
+            allDomains={allDomains}
+            currentPath={path}
+            expandToId={path[0].id}
+            onDomainSelect={onDomainSelect}
+          />
         )}
 
-        {/* Ellipsis */}
+        {/* Ellipsis with tooltip */}
         {showEllipsis && (
           <>
             {!hideRoot && (
               <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
             )}
-            <MoreHorizontal className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <span className="tw-flex tw-shrink-0 tw-cursor-default tw-items-center">
+                    <MoreHorizontal className="tw-h-3 tw-w-3 tw-text-muted-foreground" />
+                  </span>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p className="tw-text-xs">{hiddenTooltip}</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
           </>
         )}
 
         {/* Trailing visible segments */}
         {path.map((domain, idx) => {
-          if (idx === 0) return undefined; // root handled above
-          if (idx <= hideCount) return undefined; // hidden
+          if (idx === 0) return undefined;
+          if (idx <= hideCount) return undefined;
           const isLast = idx === path.length - 1;
           return (
-            <BreadcrumbSegment
-              key={domain.id}
-              domain={domain}
-              isLast={isLast}
-              onClick={onSegmentClick}
-              showChevron
-            />
+            <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
+              <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+              <BreadcrumbSegmentDropdown
+                domain={domain}
+                isLast={isLast}
+                allDomains={allDomains}
+                currentPath={path}
+                expandToId={domain.id}
+                onDomainSelect={onDomainSelect}
+              />
+            </span>
           );
         })}
-      </span>
+      </div>
     </div>
   );
 }
 
-function BreadcrumbSegment({
+/** A single breadcrumb segment that opens a DropdownMenu with the domain tree */
+function BreadcrumbSegmentDropdown({
   domain,
   isLast,
-  onClick,
-  showChevron = false,
+  allDomains,
+  currentPath,
+  expandToId,
+  onDomainSelect,
 }: {
   domain: SemanticDomain;
   isLast: boolean;
-  onClick: (id: string) => void;
-  showChevron?: boolean;
-}) {
-  return (
-    <span className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
-      {showChevron && (
-        <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
-      )}
-      <span
-        className={cn(
-          'tw-cursor-pointer tw-rounded tw-px-1.5 tw-py-1 tw-text-sm hover:tw-bg-muted',
-          isLast && 'tw-font-bold',
-        )}
-        onClick={(e) => {
-          e.stopPropagation();
-          onClick(domain.id);
-        }}
-        onKeyDown={(e) => {
-          if (e.key === 'Enter') {
-            e.stopPropagation();
-            onClick(domain.id);
-          }
-        }}
-        role="button"
-        tabIndex={0}
-      >
-        {domain.label}
-      </span>
-    </span>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Domain tree popover (no search, simple expandable tree)
-// ---------------------------------------------------------------------------
-
-function DomainTree({
-  domains,
-  currentPath,
-  expandToId,
-  onSelect,
-}: {
-  domains: SemanticDomain[];
+  allDomains: SemanticDomain[];
   currentPath: SemanticDomain[];
-  expandToId?: string;
-  onSelect: (path: SemanticDomain[]) => void;
+  expandToId: string;
+  onDomainSelect: (path: SemanticDomain[]) => void;
 }) {
-  // eslint-disable-next-line no-null/no-null
-  const scrollTargetRef = useRef<HTMLButtonElement>(null);
+  const [open, setOpen] = useState(false);
 
-  useEffect(() => {
-    requestAnimationFrame(() => {
-      scrollTargetRef.current?.scrollIntoView({ block: 'center' });
-    });
-  }, [expandToId]);
+  const handleSelect = (newPath: SemanticDomain[]) => {
+    onDomainSelect(newPath);
+    setOpen(false);
+  };
 
   return (
-    <div className="tw-max-h-[500px] tw-overflow-y-auto tw-p-1">
-      <TreeNodeList
-        domains={domains}
-        currentPath={currentPath}
-        expandToId={expandToId}
-        onSelect={onSelect}
-        parentPath={[]}
-        scrollTargetRef={scrollTargetRef}
-      />
-    </div>
+    <DropdownMenu open={open} onOpenChange={setOpen} modal>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className={cn(
+            'tw-shrink-0 tw-cursor-pointer tw-rounded tw-px-1.5 tw-py-1 tw-text-sm hover:tw-bg-muted',
+            isLast && 'tw-font-bold',
+          )}
+        >
+          {domain.label}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        className="tw-max-h-[500px] tw-w-[300px] tw-overflow-y-auto tw-p-1"
+        style={{ zIndex: Z_INDEX_MODAL + 10 }}
+      >
+        <DomainTreeList
+          domains={allDomains}
+          currentPath={currentPath}
+          expandToId={expandToId}
+          onSelect={handleSelect}
+          parentPath={[]}
+        />
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Domain tree (rendered inside DropdownMenu)
+// ---------------------------------------------------------------------------
 
 function isAncestorOf(domain: SemanticDomain, targetId: string): boolean {
   if (domain.id === targetId) return true;
   return domain.children?.some((child) => isAncestorOf(child, targetId)) ?? false;
 }
 
-function TreeNodeList({
+function DomainTreeList({
   domains,
   currentPath,
   expandToId,
   onSelect,
   parentPath,
-  scrollTargetRef,
 }: {
   domains: SemanticDomain[];
   currentPath: SemanticDomain[];
-  expandToId?: string;
+  expandToId: string;
   onSelect: (path: SemanticDomain[]) => void;
   parentPath: SemanticDomain[];
-  scrollTargetRef: React.RefObject<HTMLButtonElement>;
 }) {
   return (
     <ul className={cn('tw-space-y-0.5', { 'tw-ml-3': parentPath.length > 0 })}>
@@ -403,12 +392,11 @@ function TreeNodeList({
           currentPath.length > 0 && currentPath[currentPath.length - 1].id === domain.id;
         const hasChildren = domain.children && domain.children.length > 0;
         const isOnPath = currentPath.some((d) => d.id === domain.id);
-        const containsTarget = expandToId ? isAncestorOf(domain, expandToId) : false;
+        const containsTarget = isAncestorOf(domain, expandToId);
         const shouldExpand = isOnPath || containsTarget;
-        const isScrollTarget = domain.id === expandToId;
 
         return (
-          <TreeNode
+          <DomainTreeNode
             key={domain.id}
             domain={domain}
             thisPath={thisPath}
@@ -418,8 +406,6 @@ function TreeNodeList({
             currentPath={currentPath}
             expandToId={expandToId}
             onSelect={onSelect}
-            scrollTargetRef={scrollTargetRef}
-            isScrollTarget={isScrollTarget}
           />
         );
       })}
@@ -427,7 +413,7 @@ function TreeNodeList({
   );
 }
 
-function TreeNode({
+function DomainTreeNode({
   domain,
   thisPath,
   isSelected,
@@ -436,8 +422,6 @@ function TreeNode({
   currentPath,
   expandToId,
   onSelect,
-  scrollTargetRef,
-  isScrollTarget,
 }: {
   domain: SemanticDomain;
   thisPath: SemanticDomain[];
@@ -445,10 +429,8 @@ function TreeNode({
   hasChildren: boolean;
   defaultExpanded: boolean;
   currentPath: SemanticDomain[];
-  expandToId?: string;
+  expandToId: string;
   onSelect: (path: SemanticDomain[]) => void;
-  scrollTargetRef: React.RefObject<HTMLButtonElement>;
-  isScrollTarget: boolean;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
 
@@ -463,10 +445,15 @@ function TreeNode({
           <button
             type="button"
             className="tw-flex tw-h-5 tw-w-5 tw-shrink-0 tw-items-center tw-justify-center tw-rounded hover:tw-bg-muted"
-            onClick={() => setExpanded(!expanded)}
+            onClick={(e) => {
+              e.stopPropagation();
+              setExpanded(!expanded);
+            }}
           >
             <ChevronRight
-              className={cn('tw-h-3 tw-w-3 tw-transition-transform', { 'tw-rotate-90': expanded })}
+              className={cn('tw-h-3 tw-w-3 tw-transition-transform', {
+                'tw-rotate-90': expanded,
+              })}
             />
           </button>
         ) : (
@@ -474,7 +461,6 @@ function TreeNode({
         )}
         <button
           type="button"
-          ref={isScrollTarget ? scrollTargetRef : undefined}
           className={cn(
             'tw-flex-1 tw-rounded tw-px-1.5 tw-py-0.5 tw-text-left tw-text-sm',
             isSelected ? 'tw-bg-accent tw-font-medium' : 'hover:tw-bg-muted',
@@ -485,13 +471,12 @@ function TreeNode({
         </button>
       </div>
       {expanded && hasChildren && (
-        <TreeNodeList
+        <DomainTreeList
           domains={domain.children!}
           currentPath={currentPath}
           expandToId={expandToId}
           onSelect={onSelect}
           parentPath={thisPath}
-          scrollTargetRef={scrollTargetRef}
         />
       )}
     </li>

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -60,6 +60,13 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
     return () => observer.disconnect();
   }, []);
 
+  // Focus the list on mount so the user can arrow-navigate immediately when
+  // the drawer / dialog opens. :focus-visible stays off because the last user
+  // input was a click (domain link / tab), which is the desired behavior.
+  useEffect(() => {
+    listRef.current?.focus();
+  }, []);
+
   const handleDomainSelect = useCallback(
     (path: SemanticDomain[]) => {
       onDomainChange(path);
@@ -171,7 +178,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
                 ref={listRef}
                 role="listbox"
                 tabIndex={0}
-                className="tw-outline-none"
+                className="tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-ring"
                 onKeyDown={handleListKeyDown}
               >
                 {items.map((item, idx) => {

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -82,31 +82,23 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
 
   // List keyboard: arrow keys navigate, behavior depends on narrow/wide.
   // First keypress starts from the selected item (or first/last if none selected).
+  // At the boundaries the list stays put (no wrap, no reselect).
   const handleListKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (items.length === 0) return;
       const selectedIdx = selectedId ? items.findIndex((i) => i.id === selectedId) : -1;
+      const startIdx = focusedIndex >= 0 ? focusedIndex : selectedIdx;
 
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        let next: number;
-        if (focusedIndex < 0) {
-          // First press: start at selected item, or first item
-          next = selectedIdx >= 0 ? Math.min(selectedIdx + 1, items.length - 1) : 0;
-        } else {
-          next = Math.min(focusedIndex + 1, items.length - 1);
-        }
+        const next = startIdx < 0 ? 0 : Math.min(startIdx + 1, items.length - 1);
+        if (next === focusedIndex) return;
         setFocusedIndex(next);
         if (!narrow) selectItem(items[next]);
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        let prev: number;
-        if (focusedIndex < 0) {
-          // First press: start at selected item, or last item
-          prev = selectedIdx >= 0 ? Math.max(selectedIdx - 1, 0) : items.length - 1;
-        } else {
-          prev = Math.max(focusedIndex - 1, 0);
-        }
+        const prev = startIdx < 0 ? items.length - 1 : Math.max(startIdx - 1, 0);
+        if (prev === focusedIndex) return;
         setFocusedIndex(prev);
         if (!narrow) selectItem(items[prev]);
       } else if ((e.key === 'Enter' || e.key === ' ') && narrow && focusedIndex >= 0) {
@@ -116,6 +108,20 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
     },
     [items, focusedIndex, narrow, selectItem, selectedId],
   );
+
+  // On close, restore focus to the list and set the focused index to the
+  // previously-selected item so ArrowUp/Down pick up from there.
+  const handleCloseDetail = useCallback(() => {
+    const closingId = selectedId;
+    setSelectedId(undefined);
+    if (closingId) {
+      const idx = items.findIndex((i) => i.id === closingId);
+      if (idx >= 0) setFocusedIndex(idx);
+      requestAnimationFrame(() => {
+        listRef.current?.focus();
+      });
+    }
+  }, [items, selectedId]);
 
   // Scroll focused item into view
   useEffect(() => {
@@ -205,7 +211,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
               showFullDetail ? 'tw-w-full' : 'tw-w-2/3',
             )}
           >
-            {renderDetailContent(selectedItem, () => setSelectedId(undefined))}
+            {renderDetailContent(selectedItem, handleCloseDetail)}
           </div>
         )}
       </div>
@@ -469,13 +475,22 @@ function TreeKeyboardContainer({
   const scrollRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
-    requestAnimationFrame(() => {
-      // Focus and scroll to the expand target
+    const focusTarget = () => {
       if (scrollRef.current) {
         scrollRef.current.scrollIntoView({ block: 'center' });
         scrollRef.current.focus();
       }
-    });
+    };
+    // rAF to run after initial paint
+    const rafId = requestAnimationFrame(focusTarget);
+    // Fallback to override Radix's RovingFocusGroup, which re-focuses the first
+    // item asynchronously after our rAF when focus was previously on an element
+    // outside the dropdown (e.g. the detail panel's Back button).
+    const timeoutId = window.setTimeout(focusTarget, 50);
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.clearTimeout(timeoutId);
+    };
   }, [expandToId]);
 
   const getFocusableButtons = (): HTMLButtonElement[] => {

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -23,11 +23,10 @@ import type {
 /**
  * ER Dictionary list filtered by semantic domain with breadcrumb navigation.
  *
- * Each breadcrumb segment is clickable and opens a DropdownMenu (modal) aligned to that segment,
- * showing the expandable domain tree with that segment's level expanded and highlighted.
- *
- * Breadcrumbs collapse from the 2nd-left inward. The final collapse state is `... > leaf` (root is
- * hidden). The ellipsis has a tooltip showing the hidden path segments.
+ * Each breadcrumb segment (including the ellipsis) is clickable and opens a DropdownMenu (modal)
+ * aligned to that segment, showing the expandable domain tree with that segment's level expanded.
+ * The DropdownMenu captures keyboard: arrow keys move through items, Tab cycles expand/collapse
+ * buttons, Esc closes only the dropdown (not the parent drawer).
  */
 export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   items,
@@ -87,7 +86,6 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
             onDomainSelect={handleDomainSelect}
           />
         </div>
-
         {onClose && (
           <Button variant="ghost" size="sm" className="tw-shrink-0 tw-gap-1" onClick={onClose}>
             <ArrowUp className="tw-h-4 tw-w-4" />
@@ -156,7 +154,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
 }
 
 // ---------------------------------------------------------------------------
-// BreadcrumbBar: flicker-free collapse, ellipsis tooltip, per-segment dropdown
+// BreadcrumbBar
 // ---------------------------------------------------------------------------
 
 function BreadcrumbBar({
@@ -194,26 +192,19 @@ function BreadcrumbBar({
       const totalSegments = path.length;
       const ellipsisWidth = 44;
 
-      // Try hiding from index 1 inward. Always keep the last segment.
-      // h < totalSegments - 1: show root + ... + trailing
-      // h >= totalSegments - 1: show ... + last only
       for (let h = 1; h < totalSegments; h += 1) {
         let visibleWidth = ellipsisWidth;
-
         if (h < totalSegments - 1) {
           visibleWidth += widths[0] ?? 0;
           for (let j = h + 1; j < totalSegments; j += 1) visibleWidth += widths[j] ?? 0;
         } else {
-          // Only ellipsis + last segment
           visibleWidth += widths[totalSegments - 1] ?? 0;
         }
-
         if (visibleWidth <= available - 4) {
           setHideCount(h);
           return;
         }
       }
-
       setHideCount(totalSegments - 1);
     };
 
@@ -225,14 +216,14 @@ function BreadcrumbBar({
 
   const showEllipsis = hideCount > 0;
   const hideRoot = hideCount >= path.length - 1;
-
-  // Hidden path segments for the ellipsis tooltip
   const hiddenSegments = showEllipsis
     ? hideRoot
       ? path.slice(0, -1)
       : path.slice(1, hideCount + 1)
     : [];
   const hiddenTooltip = hiddenSegments.map((d) => d.label).join(' > ');
+  // The expand target for the ellipsis dropdown: first hidden segment
+  const ellipsisExpandId = hiddenSegments[0]?.id ?? path[0]?.id;
 
   return (
     <div ref={outerRef} className="tw-overflow-hidden">
@@ -252,10 +243,10 @@ function BreadcrumbBar({
 
       {/* Visible breadcrumbs */}
       <div className="tw-inline-flex tw-items-center tw-gap-0.5">
-        {/* Root segment (hidden when fully collapsed) */}
+        {/* Root */}
         {!hideRoot && path[0] && (
-          <BreadcrumbSegmentDropdown
-            domain={path[0]}
+          <SegmentDropdown
+            label={path[0].label}
             isLast={path.length === 1}
             allDomains={allDomains}
             currentPath={path}
@@ -264,20 +255,28 @@ function BreadcrumbBar({
           />
         )}
 
-        {/* Ellipsis with tooltip */}
+        {/* Ellipsis: clickable (opens dropdown) + tooltip (immediate) */}
         {showEllipsis && (
           <>
             {!hideRoot && (
               <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
             )}
-            <TooltipProvider>
+            <TooltipProvider delayDuration={0}>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <span className="tw-flex tw-shrink-0 tw-cursor-default tw-items-center">
-                    <MoreHorizontal className="tw-h-3 tw-w-3 tw-text-muted-foreground" />
+                  <span>
+                    <SegmentDropdown
+                      label={<MoreHorizontal className="tw-h-3 tw-w-3" />}
+                      isLast={false}
+                      allDomains={allDomains}
+                      currentPath={path}
+                      expandToId={ellipsisExpandId ?? path[0]?.id ?? ''}
+                      onDomainSelect={onDomainSelect}
+                      isEllipsis
+                    />
                   </span>
                 </TooltipTrigger>
-                <TooltipContent>
+                <TooltipContent side="bottom">
                   <p className="tw-text-xs">{hiddenTooltip}</p>
                 </TooltipContent>
               </Tooltip>
@@ -285,7 +284,7 @@ function BreadcrumbBar({
           </>
         )}
 
-        {/* Trailing visible segments */}
+        {/* Trailing segments */}
         {path.map((domain, idx) => {
           if (idx === 0) return undefined;
           if (idx <= hideCount) return undefined;
@@ -293,8 +292,8 @@ function BreadcrumbBar({
           return (
             <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
               <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
-              <BreadcrumbSegmentDropdown
-                domain={domain}
+              <SegmentDropdown
+                label={domain.label}
                 isLast={isLast}
                 allDomains={allDomains}
                 currentPath={path}
@@ -309,21 +308,26 @@ function BreadcrumbBar({
   );
 }
 
-/** A single breadcrumb segment that opens a DropdownMenu with the domain tree */
-function BreadcrumbSegmentDropdown({
-  domain,
+// ---------------------------------------------------------------------------
+// SegmentDropdown: a breadcrumb segment that opens a DropdownMenu with domain tree
+// ---------------------------------------------------------------------------
+
+function SegmentDropdown({
+  label,
   isLast,
   allDomains,
   currentPath,
   expandToId,
   onDomainSelect,
+  isEllipsis = false,
 }: {
-  domain: SemanticDomain;
+  label: React.ReactNode;
   isLast: boolean;
   allDomains: SemanticDomain[];
   currentPath: SemanticDomain[];
   expandToId: string;
   onDomainSelect: (path: SemanticDomain[]) => void;
+  isEllipsis?: boolean;
 }) {
   const [open, setOpen] = useState(false);
 
@@ -338,24 +342,29 @@ function BreadcrumbSegmentDropdown({
         <button
           type="button"
           className={cn(
-            'tw-shrink-0 tw-cursor-pointer tw-rounded tw-px-1.5 tw-py-1 tw-text-sm hover:tw-bg-muted',
-            isLast && 'tw-font-bold',
+            'tw-shrink-0 tw-cursor-pointer tw-rounded tw-text-sm hover:tw-bg-muted',
+            isEllipsis ? 'tw-flex tw-items-center tw-px-1 tw-py-1' : 'tw-px-1.5 tw-py-1',
+            isLast && !isEllipsis && 'tw-font-bold',
           )}
         >
-          {domain.label}
+          {label}
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent
         align="start"
         className="tw-max-h-[500px] tw-w-[300px] tw-overflow-y-auto tw-p-1"
         style={{ zIndex: Z_INDEX_MODAL + 10 }}
+        // Prevent Esc from propagating to the parent Drawer
+        onEscapeKeyDown={(e) => {
+          e.stopPropagation();
+          setOpen(false);
+        }}
       >
-        <DomainTreeList
+        <DomainTreeContent
           domains={allDomains}
           currentPath={currentPath}
           expandToId={expandToId}
           onSelect={handleSelect}
-          parentPath={[]}
         />
       </DropdownMenuContent>
     </DropdownMenu>
@@ -363,26 +372,68 @@ function BreadcrumbSegmentDropdown({
 }
 
 // ---------------------------------------------------------------------------
-// Domain tree (rendered inside DropdownMenu)
+// Domain tree inside dropdown (proper keyboard: focusable buttons, Esc stops)
 // ---------------------------------------------------------------------------
+
+function DomainTreeContent({
+  domains,
+  currentPath,
+  expandToId,
+  onSelect,
+}: {
+  domains: SemanticDomain[];
+  currentPath: SemanticDomain[];
+  expandToId: string;
+  onSelect: (path: SemanticDomain[]) => void;
+}) {
+  // eslint-disable-next-line no-null/no-null
+  const scrollRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      scrollRef.current?.scrollIntoView({ block: 'center' });
+    });
+  }, [expandToId]);
+
+  return (
+    // Role="menu" wrapping div so arrow keys work natively via the DropdownMenu Radix primitive.
+    // We use onKeyDown at this level to trap Esc.
+    <div
+      onKeyDown={(e) => {
+        if (e.key === 'Escape') e.stopPropagation();
+      }}
+    >
+      <TreeNodeList
+        domains={domains}
+        currentPath={currentPath}
+        expandToId={expandToId}
+        onSelect={onSelect}
+        parentPath={[]}
+        scrollRef={scrollRef}
+      />
+    </div>
+  );
+}
 
 function isAncestorOf(domain: SemanticDomain, targetId: string): boolean {
   if (domain.id === targetId) return true;
   return domain.children?.some((child) => isAncestorOf(child, targetId)) ?? false;
 }
 
-function DomainTreeList({
+function TreeNodeList({
   domains,
   currentPath,
   expandToId,
   onSelect,
   parentPath,
+  scrollRef,
 }: {
   domains: SemanticDomain[];
   currentPath: SemanticDomain[];
   expandToId: string;
   onSelect: (path: SemanticDomain[]) => void;
   parentPath: SemanticDomain[];
+  scrollRef: React.RefObject<HTMLButtonElement>;
 }) {
   return (
     <ul className={cn('tw-space-y-0.5', { 'tw-ml-3': parentPath.length > 0 })}>
@@ -394,9 +445,10 @@ function DomainTreeList({
         const isOnPath = currentPath.some((d) => d.id === domain.id);
         const containsTarget = isAncestorOf(domain, expandToId);
         const shouldExpand = isOnPath || containsTarget;
+        const isScrollTarget = domain.id === expandToId;
 
         return (
-          <DomainTreeNode
+          <TreeNode
             key={domain.id}
             domain={domain}
             thisPath={thisPath}
@@ -406,6 +458,8 @@ function DomainTreeList({
             currentPath={currentPath}
             expandToId={expandToId}
             onSelect={onSelect}
+            scrollRef={scrollRef}
+            isScrollTarget={isScrollTarget}
           />
         );
       })}
@@ -413,7 +467,7 @@ function DomainTreeList({
   );
 }
 
-function DomainTreeNode({
+function TreeNode({
   domain,
   thisPath,
   isSelected,
@@ -422,6 +476,8 @@ function DomainTreeNode({
   currentPath,
   expandToId,
   onSelect,
+  scrollRef,
+  isScrollTarget,
 }: {
   domain: SemanticDomain;
   thisPath: SemanticDomain[];
@@ -431,6 +487,8 @@ function DomainTreeNode({
   currentPath: SemanticDomain[];
   expandToId: string;
   onSelect: (path: SemanticDomain[]) => void;
+  scrollRef: React.RefObject<HTMLButtonElement>;
+  isScrollTarget: boolean;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
 
@@ -444,7 +502,8 @@ function DomainTreeNode({
         {hasChildren ? (
           <button
             type="button"
-            className="tw-flex tw-h-5 tw-w-5 tw-shrink-0 tw-items-center tw-justify-center tw-rounded hover:tw-bg-muted"
+            tabIndex={0}
+            className="tw-flex tw-h-5 tw-w-5 tw-shrink-0 tw-items-center tw-justify-center tw-rounded hover:tw-bg-muted focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-ring"
             onClick={(e) => {
               e.stopPropagation();
               setExpanded(!expanded);
@@ -461,8 +520,10 @@ function DomainTreeNode({
         )}
         <button
           type="button"
+          tabIndex={0}
+          ref={isScrollTarget ? scrollRef : undefined}
           className={cn(
-            'tw-flex-1 tw-rounded tw-px-1.5 tw-py-0.5 tw-text-left tw-text-sm',
+            'tw-flex-1 tw-rounded tw-px-1.5 tw-py-0.5 tw-text-left tw-text-sm focus:tw-outline-none focus:tw-ring-1 focus:tw-ring-ring',
             isSelected ? 'tw-bg-accent tw-font-medium' : 'hover:tw-bg-muted',
           )}
           onClick={() => onSelect(thisPath)}
@@ -471,12 +532,13 @@ function DomainTreeNode({
         </button>
       </div>
       {expanded && hasChildren && (
-        <DomainTreeList
+        <TreeNodeList
           domains={domain.children!}
           currentPath={currentPath}
           expandToId={expandToId}
           onSelect={onSelect}
           parentPath={thisPath}
+          scrollRef={scrollRef}
         />
       )}
     </li>

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -8,8 +8,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/shadcn-ui/dropdown-menu';
-import { Drawer, DrawerClose, DrawerContent, DrawerTitle } from '@/components/shadcn-ui/drawer';
-import { ChevronRight, ChevronDown, List, FolderTree } from 'lucide-react';
+import { ChevronRight, ChevronDown, X, List, FolderTree } from 'lucide-react';
 import SourceLanguageIndexedList from './source-language-indexed-list.component';
 import type {
   ErDictionaryFilteredListProps,
@@ -22,29 +21,18 @@ import type {
  *
  * Layout (top to bottom):
  *
- * 1. **Breadcrumbs**: Always shows 2-level breadcrumbs (`Level 1 > Level 2`). Clicking a breadcrumb
- *    opens either a dropdown (in dropdown mode) or a domain tree drawer (in tree mode) to switch
- *    the domain.
+ * 1. **Breadcrumbs**: Always shows exactly 2 levels (`Category > Domain`). Both breadcrumb segments
+ *    are interactive. In **dropdown mode** each opens a dropdown with siblings at that level. In
+ *    **tree mode** each opens an inline tree panel within the component. When switching a category,
+ *    the first child domain is auto-selected.
  * 2. **Dictionary list**: A `SourceLanguageIndexedList` showing entries filtered to the selected
- *    domain. Clicking an entry opens a detail drawer.
- * 3. **Navigation mode toggle**: Switch between dropdown and tree view for domain navigation.
+ *    domain. Clicking an entry shows a detail panel inline within the list area.
+ * 3. **Navigation mode toggle**: Switch between dropdown and tree navigation.
+ *
+ * All panels (detail, tree) render **inside this component's bounding box**, never as full-page
+ * overlays. Dropdown menus use Radix portals so they correctly layer on top of a parent Dialog.
  *
  * Domains are always exactly 2 levels deep.
- *
- * @example
- *
- * ```tsx
- * <ErDictionaryFilteredList
- *   items={filteredEntries}
- *   selectedLevel1Domain={level1}
- *   selectedLevel2Domain={level2}
- *   allDomains={allDomains}
- *   onDomainChange={handleDomainChange}
- *   navigationMode="dropdown"
- *   onNavigationModeChange={setNavMode}
- *   renderDetailContent={(item, onClose) => <Detail entry={item} onBack={onClose} />}
- * />;
- * ```
  */
 export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   items,
@@ -62,46 +50,35 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   onNavigationModeChange,
   className,
 }: ErDictionaryFilteredListProps<T>) {
-  const [treeDrawerOpen, setTreeDrawerOpen] = useState(false);
+  const [treeOpen, setTreeOpen] = useState(false);
 
-  const handleLevel1BreadcrumbClick = () => {
-    if (navigationMode === 'dropdown') {
-      // Dropdown opens via DropdownMenu component natively
-      return;
-    }
-    // Tree mode: open the domain tree drawer
-    setTreeDrawerOpen(true);
-  };
+  // Ensure we always have a level-2 domain; fall back to first child
+  const effectiveLevel2 = selectedLevel2Domain ?? selectedLevel1Domain.children?.[0];
 
-  const handleLevel2BreadcrumbClick = () => {
-    if (navigationMode === 'dropdown') {
-      // Dropdown opens via DropdownMenu component natively
-      return;
-    }
-    // Tree mode: open the domain tree drawer
-    setTreeDrawerOpen(true);
+  const handleCategoryChange = (newLevel1: SemanticDomain) => {
+    // Auto-select the first child domain when switching categories
+    onDomainChange(newLevel1, newLevel1.children?.[0]);
   };
 
   const handleDomainSelectFromTree = (level1: SemanticDomain, level2?: SemanticDomain) => {
-    onDomainChange(level1, level2);
-    setTreeDrawerOpen(false);
+    onDomainChange(level1, level2 ?? level1.children?.[0]);
+    setTreeOpen(false);
   };
 
-  // Sibling domains at level 1 (all top-level domains)
-  const level1Siblings = allDomains;
+  const openTreePanel = () => setTreeOpen(true);
 
   // Sibling domains at level 2 (children of the selected level 1)
   const level2Siblings = selectedLevel1Domain.children ?? [];
 
   return (
-    <div className={cn('tw-flex tw-h-full tw-flex-col', className)}>
-      {/* Breadcrumbs - always 2 levels */}
+    <div className={cn('tw-relative tw-flex tw-h-full tw-flex-col', className)}>
+      {/* Breadcrumbs - always 2 levels: Category > Domain */}
       <div className="tw-flex tw-items-center tw-gap-1 tw-border-b tw-px-3 tw-py-2">
         <nav
           aria-label="Semantic domain breadcrumbs"
           className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1"
         >
-          {/* Level 1 breadcrumb */}
+          {/* Level 1 breadcrumb (Category) */}
           {navigationMode === 'dropdown' ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
@@ -110,14 +87,49 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
                   <ChevronDown className="tw-h-3 tw-w-3" />
                 </Button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="start">
-                {level1Siblings.map((domain) => (
+              <DropdownMenuContent align="start" className="tw-z-[60]">
+                {allDomains.map((domain) => (
                   <DropdownMenuItem
                     key={domain.id}
                     className={cn({
                       'tw-font-medium': domain.id === selectedLevel1Domain.id,
                     })}
-                    onClick={() => onDomainChange(domain)}
+                    onClick={() => handleCategoryChange(domain)}
+                  >
+                    {domain.label}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          ) : (
+            <Button variant="ghost" className="tw-h-auto tw-p-1 tw-text-sm" onClick={openTreePanel}>
+              {selectedLevel1Domain.label}
+            </Button>
+          )}
+
+          {/* Separator - always shown since we always have 2 levels */}
+          <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+
+          {/* Level 2 breadcrumb (Domain) */}
+          {navigationMode === 'dropdown' ? (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="tw-h-auto tw-gap-1 tw-p-1 tw-text-sm tw-font-medium"
+                >
+                  {effectiveLevel2?.label ?? 'All'}
+                  <ChevronDown className="tw-h-3 tw-w-3" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" className="tw-z-[60]">
+                {level2Siblings.map((domain) => (
+                  <DropdownMenuItem
+                    key={domain.id}
+                    className={cn({
+                      'tw-font-medium': domain.id === effectiveLevel2?.id,
+                    })}
+                    onClick={() => onDomainChange(selectedLevel1Domain, domain)}
                   >
                     {domain.label}
                   </DropdownMenuItem>
@@ -127,67 +139,55 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
           ) : (
             <Button
               variant="ghost"
-              className="tw-h-auto tw-p-1 tw-text-sm"
-              onClick={handleLevel1BreadcrumbClick}
+              className="tw-h-auto tw-p-1 tw-text-sm tw-font-medium"
+              onClick={openTreePanel}
             >
-              {selectedLevel1Domain.label}
+              {effectiveLevel2?.label ?? 'All'}
             </Button>
           )}
-
-          {/* Separator */}
-          {selectedLevel2Domain && (
-            <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
-          )}
-
-          {/* Level 2 breadcrumb (if a level-2 domain is selected) */}
-          {selectedLevel2Domain &&
-            (navigationMode === 'dropdown' ? (
-              <DropdownMenu>
-                <DropdownMenuTrigger asChild>
-                  <Button variant="ghost" className="tw-h-auto tw-gap-1 tw-p-1 tw-text-sm">
-                    {selectedLevel2Domain.label}
-                    <ChevronDown className="tw-h-3 tw-w-3" />
-                  </Button>
-                </DropdownMenuTrigger>
-                <DropdownMenuContent align="start">
-                  {level2Siblings.map((domain) => (
-                    <DropdownMenuItem
-                      key={domain.id}
-                      className={cn({
-                        'tw-font-medium': domain.id === selectedLevel2Domain.id,
-                      })}
-                      onClick={() => onDomainChange(selectedLevel1Domain, domain)}
-                    >
-                      {domain.label}
-                    </DropdownMenuItem>
-                  ))}
-                </DropdownMenuContent>
-              </DropdownMenu>
-            ) : (
-              <Button
-                variant="ghost"
-                className="tw-h-auto tw-p-1 tw-text-sm tw-font-medium"
-                onClick={handleLevel2BreadcrumbClick}
-              >
-                {selectedLevel2Domain.label}
-              </Button>
-            ))}
         </nav>
       </div>
 
-      {/* Dictionary list with optional detail drawer */}
-      <div className="tw-flex-1 tw-overflow-y-auto">
-        <SourceLanguageIndexedList
-          items={items}
-          renderItem={renderItem}
-          renderDetailContent={renderDetailContent}
-          onItemClick={onItemClick}
-          selectedItemId={selectedItemId}
-          emptyStateMessage={emptyStateMessage}
-          isLoading={isLoading}
-          showSourceLanguage
-          showTransliteration
-        />
+      {/* Main content area: list OR tree panel (mutually exclusive, both inline) */}
+      <div className="tw-relative tw-flex-1 tw-overflow-hidden">
+        {treeOpen ? (
+          /* Inline tree panel - renders inside this container, not as a portal */
+          <div className="tw-absolute tw-inset-0 tw-z-10 tw-flex tw-flex-col tw-bg-background">
+            <div className="tw-flex tw-items-center tw-justify-between tw-border-b tw-px-3 tw-py-2">
+              <span className="tw-text-sm tw-font-semibold">Semantic Domains</span>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="tw-h-7 tw-w-7"
+                onClick={() => setTreeOpen(false)}
+              >
+                <X className="tw-h-4 tw-w-4" />
+              </Button>
+            </div>
+            <div className="tw-flex-1 tw-overflow-y-auto tw-p-2">
+              <DomainTreeView
+                domains={allDomains}
+                selectedLevel1Id={selectedLevel1Domain.id}
+                selectedLevel2Id={effectiveLevel2?.id}
+                onSelect={handleDomainSelectFromTree}
+              />
+            </div>
+          </div>
+        ) : (
+          /* Dictionary list with optional inline detail panel */
+          <SourceLanguageIndexedList
+            items={items}
+            renderItem={renderItem}
+            renderDetailContent={renderDetailContent}
+            onItemClick={onItemClick}
+            selectedItemId={selectedItemId}
+            emptyStateMessage={emptyStateMessage}
+            isLoading={isLoading}
+            showSourceLanguage
+            showTransliteration
+            className="tw-h-full"
+          />
+        )}
       </div>
 
       {/* Navigation mode toggle at the bottom */}
@@ -217,33 +217,11 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
           </ToggleGroupItem>
         </ToggleGroup>
       </div>
-
-      {/* Domain tree drawer (tree mode only) */}
-      <Drawer direction="right" open={treeDrawerOpen} onOpenChange={setTreeDrawerOpen}>
-        <DrawerContent hideDrawerHandle className="tw-max-w-sm">
-          <div className="tw-overflow-y-auto tw-p-4">
-            <DrawerTitle className="tw-mb-4">Semantic Domains</DrawerTitle>
-            <DomainTreeView
-              domains={allDomains}
-              selectedLevel1Id={selectedLevel1Domain.id}
-              selectedLevel2Id={selectedLevel2Domain?.id}
-              onSelect={handleDomainSelectFromTree}
-            />
-            <div className="tw-mt-4">
-              <DrawerClose asChild>
-                <Button variant="outline" className="tw-w-full">
-                  Close
-                </Button>
-              </DrawerClose>
-            </div>
-          </div>
-        </DrawerContent>
-      </Drawer>
     </div>
   );
 }
 
-/** Full 2-level domain tree view shown inside the tree drawer */
+/** Full 2-level domain tree rendered inline within the component */
 function DomainTreeView({
   domains,
   selectedLevel1Id,
@@ -259,17 +237,15 @@ function DomainTreeView({
     <ul className="tw-space-y-1">
       {domains.map((level1) => (
         <li key={level1.id}>
-          <Button
-            variant="ghost"
-            className={cn('tw-h-auto tw-w-full tw-justify-start tw-px-2 tw-py-1.5 tw-text-sm', {
-              'tw-bg-accent tw-font-medium': level1.id === selectedLevel1Id && !selectedLevel2Id,
+          <span
+            className={cn('tw-block tw-px-2 tw-py-1.5 tw-text-sm tw-font-semibold', {
+              'tw-text-primary': level1.id === selectedLevel1Id,
             })}
-            onClick={() => onSelect(level1)}
           >
             {level1.label}
-          </Button>
+          </span>
           {level1.children && level1.children.length > 0 && (
-            <ul className="tw-ml-4 tw-space-y-0.5">
+            <ul className="tw-ml-3 tw-space-y-0.5">
               {level1.children.map((level2) => (
                 <li key={level2.id}>
                   <Button

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ReactNode, type RefObject, useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import {
@@ -6,6 +6,11 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from '@/components/shadcn-ui/dropdown-menu';
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from '@/components/shadcn-ui/resizable';
 import {
   Tooltip,
   TooltipContent,
@@ -19,6 +24,11 @@ import type {
   IndexedListItem,
   SemanticDomain,
 } from './source-language-indexed-list.types';
+
+/** Minimum width in pixels for the list panel when shown side-by-side with details. */
+const LIST_MIN_PX = 100;
+/** Minimum width in pixels for the detail panel when shown side-by-side with the list. */
+const DETAIL_MIN_PX = 150;
 
 /**
  * ER Dictionary list filtered by semantic domain with breadcrumb navigation.
@@ -49,16 +59,24 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   // eslint-disable-next-line no-null/no-null
   const listRef = useRef<HTMLUListElement>(null);
   const [narrow, setNarrow] = useState(false);
+  const [containerWidth, setContainerWidth] = useState(0);
 
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return undefined;
     const observer = new ResizeObserver(([entry]) => {
-      setNarrow((entry?.contentRect.width ?? 0) < 350);
+      const width = entry?.contentRect.width ?? 0;
+      setContainerWidth(width);
+      setNarrow(width < 350);
     });
     observer.observe(el);
     return () => observer.disconnect();
   }, []);
+
+  // react-resizable-panels only accepts percentages; convert the pixel minima
+  // to percentages based on the observed container width.
+  const listMinPct = containerWidth > 0 ? (LIST_MIN_PX / containerWidth) * 100 : 20;
+  const detailMinPct = containerWidth > 0 ? (DETAIL_MIN_PX / containerWidth) * 100 : 30;
 
   // Focus the list on mount so the user can arrow-navigate immediately when
   // the drawer / dialog opens. :focus-visible stays off because the last user
@@ -137,6 +155,64 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
     li?.scrollIntoView({ block: 'nearest' });
   }, [focusedIndex]);
 
+  // When detail opens in narrow (full-detail) mode the list is unmounted, so
+  // move focus to the Back button. In side-by-side mode focus stays on the
+  // list so repeated Up/Down arrows continue to work.
+  // eslint-disable-next-line no-null/no-null
+  const detailPanelRef = useRef<HTMLDivElement>(null);
+  useEffect(() => {
+    if (!narrow || !selectedId) return;
+    const back = detailPanelRef.current?.querySelector<HTMLButtonElement>('[data-back-to-list]');
+    back?.focus();
+  }, [narrow, selectedId]);
+
+  // Switching from list-only to side-by-side replaces the list's wrapper with
+  // a ResizablePanelGroup, which remounts the <ul> and drops keyboard focus.
+  // Re-focus it so repeated Up/Down after the first selection keep working.
+  const isSideBySide = !!showSideBySide;
+  useEffect(() => {
+    if (isSideBySide) listRef.current?.focus();
+  }, [isSideBySide]);
+
+  const listElement = isLoading ? (
+    <div className="tw-p-4 tw-text-sm tw-text-muted-foreground">Loading...</div>
+  ) : items.length === 0 ? (
+    <div className="tw-p-4 tw-text-sm tw-text-muted-foreground">
+      {emptyStateMessage ?? 'No items found'}
+    </div>
+  ) : (
+    <ul
+      ref={listRef}
+      role="listbox"
+      tabIndex={0}
+      className="tw-p-0.5 tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-ring"
+      onKeyDown={handleListKeyDown}
+    >
+      {items.map((item, idx) => {
+        const isSelected = selectedId === item.id;
+        const isFocused = focusedIndex === idx;
+        return (
+          <li
+            key={item.id}
+            role="option"
+            aria-selected={isSelected}
+            onClick={() => {
+              setFocusedIndex(-1);
+              selectItem(item);
+            }}
+            className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
+              'tw-bg-muted': isSelected,
+              'hover:tw-bg-muted': !isSelected,
+              'tw-ring-1 tw-ring-inset tw-ring-ring': isFocused && !isSelected,
+            })}
+          >
+            {renderItem ? renderItem(item) : <span className="tw-text-sm">{item.primaryText}</span>}
+          </li>
+        );
+      })}
+    </ul>
+  );
+
   return (
     <div className={cn('tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}>
       {/* Header: breadcrumbs + back */}
@@ -158,72 +234,71 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
 
       {/* Inline list + detail */}
       <div ref={containerRef} className="tw-relative tw-flex tw-flex-1 tw-overflow-hidden">
-        {!showFullDetail && (
-          <div
-            className={cn(
-              'tw-h-full',
-              showSideBySide
-                ? 'tw-w-1/3 tw-min-w-[120px] tw-overflow-hidden tw-border-r'
-                : 'tw-w-full tw-overflow-y-auto',
-            )}
-          >
-            {isLoading ? (
-              <div className="tw-p-4 tw-text-sm tw-text-muted-foreground">Loading...</div>
-            ) : items.length === 0 ? (
-              <div className="tw-p-4 tw-text-sm tw-text-muted-foreground">
-                {emptyStateMessage ?? 'No items found'}
-              </div>
-            ) : (
-              <ul
-                ref={listRef}
-                role="listbox"
-                tabIndex={0}
-                className="tw-p-0.5 tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-ring"
-                onKeyDown={handleListKeyDown}
-              >
-                {items.map((item, idx) => {
-                  const isSelected = selectedId === item.id;
-                  const isFocused = focusedIndex === idx;
-                  return (
-                    <li
-                      key={item.id}
-                      role="option"
-                      aria-selected={isSelected}
-                      onClick={() => {
-                        setFocusedIndex(-1);
-                        selectItem(item);
-                      }}
-                      className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
-                        'tw-bg-muted': isSelected,
-                        'hover:tw-bg-muted': !isSelected,
-                        'tw-ring-1 tw-ring-inset tw-ring-ring': isFocused && !isSelected,
-                      })}
-                    >
-                      {renderItem ? (
-                        renderItem(item)
-                      ) : (
-                        <span className="tw-text-sm">{item.primaryText}</span>
-                      )}
-                    </li>
-                  );
-                })}
-              </ul>
-            )}
-          </div>
-        )}
-        {selectedItem && renderDetailContent && (
-          <div
-            className={cn(
-              'tw-h-full tw-overflow-y-auto tw-bg-background tw-p-4',
-              showFullDetail ? 'tw-w-full' : 'tw-w-2/3',
-            )}
-          >
-            {renderDetailContent(selectedItem, handleCloseDetail)}
-          </div>
-        )}
+        {renderListAndDetail({
+          showSideBySide: !!showSideBySide,
+          showFullDetail: !!showFullDetail,
+          listElement,
+          detailElement:
+            selectedItem && renderDetailContent
+              ? renderDetailContent(selectedItem, handleCloseDetail)
+              : undefined,
+          listMinPct,
+          detailMinPct,
+          detailPanelRef,
+        })}
       </div>
     </div>
   );
+}
+
+/**
+ * Renders the list / detail area in one of three layouts (side-by-side with a draggable separator,
+ * full-detail in narrow mode, or list only). Extracted as a helper so the main component body
+ * avoids nested ternaries.
+ */
+function renderListAndDetail({
+  showSideBySide,
+  showFullDetail,
+  listElement,
+  detailElement,
+  listMinPct,
+  detailMinPct,
+  detailPanelRef,
+}: {
+  showSideBySide: boolean;
+  showFullDetail: boolean;
+  listElement: ReactNode;
+  detailElement: ReactNode;
+  listMinPct: number;
+  detailMinPct: number;
+  detailPanelRef: RefObject<HTMLDivElement>;
+}): ReactNode {
+  if (showSideBySide && detailElement !== undefined) {
+    return (
+      <ResizablePanelGroup direction="horizontal">
+        <ResizablePanel defaultSize={33.3333} minSize={listMinPct}>
+          <div className="tw-h-full tw-overflow-y-auto">{listElement}</div>
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel defaultSize={66.6667} minSize={detailMinPct}>
+          <div className="tw-h-full tw-overflow-y-auto tw-bg-background tw-p-4">
+            {detailElement}
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    );
+  }
+  if (showFullDetail && detailElement !== undefined) {
+    return (
+      <div
+        ref={detailPanelRef}
+        className="tw-h-full tw-w-full tw-overflow-y-auto tw-bg-background tw-p-4"
+      >
+        {detailElement}
+      </div>
+    );
+  }
+  return <div className="tw-h-full tw-w-full tw-overflow-y-auto">{listElement}</div>;
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -1,0 +1,193 @@
+import { cn } from '@/utils/shadcn-ui.util';
+import { Button } from '@/components/shadcn-ui/button';
+import { ToggleGroup, ToggleGroupItem } from '@/components/shadcn-ui/toggle-group';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/shadcn-ui/select';
+import { ChevronRight, List, FolderTree } from 'lucide-react';
+import SourceLanguageIndexedList from './source-language-indexed-list.component';
+import type {
+  ErDictionaryFilteredListProps,
+  IndexedListItem,
+  SemanticDomain,
+} from './source-language-indexed-list.types';
+
+/**
+ * ER Dictionary list filtered by semantic domain. Shows a breadcrumb trail for the domain hierarchy
+ * and a toggle to switch between tree view (Option A) and dropdown view (Option B) for domain
+ * navigation.
+ *
+ * Screen A from ui-alignment.md: Dictionary entries filtered by a selected semantic domain, with
+ * breadcrumbs showing the domain path and the list below filtered to that domain.
+ *
+ * @example
+ *
+ * ```tsx
+ * <ErDictionaryFilteredList
+ *   items={filteredEntries}
+ *   domainPath={[root, naturalWorld, animals]}
+ *   navigationMode="tree"
+ *   onNavigationModeChange={setNavMode}
+ *   onBreadcrumbClick={handleBreadcrumbClick}
+ *   domainChildren={currentDomainChildren}
+ *   onDomainSelect={handleDomainSelect}
+ * />;
+ * ```
+ */
+export default function ErDictionaryFilteredList<T extends IndexedListItem>({
+  domainPath,
+  onBreadcrumbClick,
+  navigationMode,
+  onNavigationModeChange,
+  domainChildren,
+  onDomainSelect,
+  className,
+  ...listProps
+}: ErDictionaryFilteredListProps<T>) {
+  return (
+    <div className={cn('tw-flex tw-h-full tw-flex-col', className)}>
+      {/* Header: Breadcrumb trail + navigation mode toggle */}
+      <div className="tw-flex tw-items-center tw-justify-between tw-gap-2 tw-border-b tw-px-3 tw-py-2">
+        <DomainBreadcrumbs domainPath={domainPath} onBreadcrumbClick={onBreadcrumbClick} />
+        <ToggleGroup
+          type="single"
+          value={navigationMode}
+          onValueChange={(value) => {
+            if (value === 'tree' || value === 'dropdown') {
+              onNavigationModeChange?.(value);
+            }
+          }}
+          className="tw-shrink-0"
+        >
+          <ToggleGroupItem value="tree" aria-label="Tree view" className="tw-h-8 tw-w-8 tw-p-0">
+            <FolderTree className="tw-h-4 tw-w-4" />
+          </ToggleGroupItem>
+          <ToggleGroupItem
+            value="dropdown"
+            aria-label="Dropdown view"
+            className="tw-h-8 tw-w-8 tw-p-0"
+          >
+            <List className="tw-h-4 tw-w-4" />
+          </ToggleGroupItem>
+        </ToggleGroup>
+      </div>
+
+      {/* Domain navigation area (tree or dropdown based on mode) */}
+      {domainChildren && domainChildren.length > 0 && (
+        <div className="tw-border-b tw-px-3 tw-py-2">
+          {navigationMode === 'dropdown' ? (
+            <DomainDropdown domains={domainChildren} onSelect={onDomainSelect} />
+          ) : (
+            <DomainTree domains={domainChildren} onSelect={onDomainSelect} />
+          )}
+        </div>
+      )}
+
+      {/* Filtered dictionary list */}
+      <div className="tw-flex-1 tw-overflow-y-auto">
+        <SourceLanguageIndexedList {...listProps} showSourceLanguage showTransliteration />
+      </div>
+    </div>
+  );
+}
+
+/** Breadcrumb trail showing the domain hierarchy path */
+function DomainBreadcrumbs({
+  domainPath,
+  onBreadcrumbClick,
+}: {
+  domainPath: SemanticDomain[];
+  onBreadcrumbClick?: (domain: SemanticDomain) => void;
+}) {
+  return (
+    <nav
+      aria-label="Semantic domain breadcrumbs"
+      className="tw-flex tw-min-w-0 tw-items-center tw-gap-1 tw-overflow-x-auto"
+    >
+      {domainPath.map((domain, index) => {
+        const isLast = index === domainPath.length - 1;
+        return (
+          <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-1">
+            {isLast ? (
+              <span className="tw-text-sm tw-font-medium">{domain.label}</span>
+            ) : (
+              <>
+                <Button
+                  variant="link"
+                  className="tw-h-auto tw-p-0 tw-text-sm"
+                  onClick={() => onBreadcrumbClick?.(domain)}
+                >
+                  {domain.label}
+                </Button>
+                <ChevronRight className="tw-h-3 tw-w-3 tw-text-muted-foreground" />
+              </>
+            )}
+          </span>
+        );
+      })}
+    </nav>
+  );
+}
+
+/** Dropdown navigation showing sibling domains at the current level */
+function DomainDropdown({
+  domains,
+  onSelect,
+}: {
+  domains: SemanticDomain[];
+  onSelect?: (domain: SemanticDomain) => void;
+}) {
+  return (
+    <Select
+      onValueChange={(value) => {
+        const domain = domains.find((d) => d.id === value);
+        if (domain) onSelect?.(domain);
+      }}
+    >
+      <SelectTrigger className="tw-w-full">
+        <SelectValue placeholder="Select a domain..." />
+      </SelectTrigger>
+      <SelectContent>
+        {domains.map((domain) => (
+          <SelectItem key={domain.id} value={domain.id}>
+            {domain.label}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+}
+
+/** Tree navigation showing the full hierarchy of child domains */
+function DomainTree({
+  domains,
+  onSelect,
+  level = 0,
+}: {
+  domains: SemanticDomain[];
+  onSelect?: (domain: SemanticDomain) => void;
+  level?: number;
+}) {
+  return (
+    <ul className={cn('tw-space-y-0.5', { 'tw-pl-4': level > 0 })}>
+      {domains.map((domain) => (
+        <li key={domain.id}>
+          <Button
+            variant="ghost"
+            className="tw-h-auto tw-w-full tw-justify-start tw-px-2 tw-py-1 tw-text-sm"
+            onClick={() => onSelect?.(domain)}
+          >
+            {domain.label}
+          </Button>
+          {domain.children && domain.children.length > 0 && (
+            <DomainTree domains={domain.children} onSelect={onSelect} level={level + 1} />
+          )}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -1,8 +1,10 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
-import { Drawer, DrawerClose, DrawerContent, DrawerTitle } from '@/components/shadcn-ui/drawer';
-import { ArrowLeft, ChevronRight, FolderTree } from 'lucide-react';
+import { Input } from '@/components/shadcn-ui/input';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/shadcn-ui/popover';
+import { ChevronRight, MoreHorizontal, X } from 'lucide-react';
+import { Z_INDEX_MODAL } from '@/components/z-index';
 import SourceLanguageIndexedList from './source-language-indexed-list.component';
 import type {
   ErDictionaryFilteredListProps,
@@ -11,15 +13,18 @@ import type {
 } from './source-language-indexed-list.types';
 
 /**
- * ER Dictionary list filtered by semantic domain with breadcrumb navigation (up to 5 levels).
+ * ER Dictionary list filtered by semantic domain with breadcrumb-based navigation.
  *
- * Breadcrumb row: `[← Back] ... > Level3 > Level4 > Level5 ......... [🌳]`
+ * **Breadcrumb bar**: A single clickable button showing the domain path left-aligned. When space is
+ * limited, intermediate segments collapse into an ellipsis (`...`) while the root ("Domain") and
+ * the deepest segments stay visible. The last segment is bold. Hovering a segment underlines it.
+ * Clicking the breadcrumb bar opens a popover with a searchable expandable domain tree (combobox
+ * pattern). The tree auto-expands to and scrolls to the currently selected domain. Filtering keeps
+ * ancestor nodes visible and highlights matching characters.
  *
- * Breadcrumbs truncate from the **left** with "..." when space is limited. The rightmost segments
- * are always visible. Clicking any breadcrumb segment navigates to that domain.
+ * **Close button**: An X button on the right to dismiss the filtered view.
  *
- * The tree button opens a **bottom Drawer** (scoped to this component) that fills the full height
- * of the container, showing the expandable domain tree.
+ * Below the header: a `SourceLanguageIndexedList` for the filtered entries.
  */
 export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   items,
@@ -32,81 +37,53 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   domainPath,
   allDomains,
   onDomainChange,
-  onBack,
+  onClose,
   className,
 }: ErDictionaryFilteredListProps<T>) {
-  const [treeOpen, setTreeOpen] = useState(false);
-  // ref.current expects null not undefined for div ref
-  // eslint-disable-next-line no-null/no-null
-  const containerRef = useRef<HTMLDivElement>(null);
+  const [popoverOpen, setPopoverOpen] = useState(false);
 
-  const handleTreeSelect = (path: SemanticDomain[]) => {
+  const handleDomainSelect = (path: SemanticDomain[]) => {
     onDomainChange(path);
-    setTreeOpen(false);
+    setPopoverOpen(false);
   };
 
   return (
-    <div
-      ref={containerRef}
-      className={cn('tw-relative tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}
-    >
-      {/* Breadcrumb row */}
+    <div className={cn('tw-relative tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}>
+      {/* Header: breadcrumb button + close */}
       <div className="tw-flex tw-items-center tw-gap-1 tw-border-b tw-px-2 tw-py-1.5">
-        {onBack && (
+        <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              className="tw-group tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1 tw-overflow-hidden tw-rounded tw-px-1.5 tw-py-1 tw-text-left hover:tw-bg-muted"
+            >
+              <BreadcrumbDisplay path={domainPath} />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            align="start"
+            className="tw-w-[var(--radix-popover-trigger-width)] tw-p-0"
+            style={{ zIndex: Z_INDEX_MODAL + 10 }}
+          >
+            <DomainSearchTree
+              domains={allDomains}
+              currentPath={domainPath}
+              onSelect={handleDomainSelect}
+            />
+          </PopoverContent>
+        </Popover>
+
+        {onClose && (
           <Button
             variant="ghost"
-            size="sm"
-            className="tw-shrink-0 tw-gap-1"
-            onClick={onBack}
-            aria-label="Back to dictionary"
+            size="icon"
+            className="tw-h-7 tw-w-7 tw-shrink-0"
+            onClick={onClose}
+            aria-label="Close filtered view"
           >
-            <ArrowLeft className="tw-h-4 tw-w-4" />
-            Back
+            <X className="tw-h-4 tw-w-4" />
           </Button>
         )}
-
-        <nav
-          aria-label="Domain breadcrumbs"
-          className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-overflow-hidden"
-          dir="rtl"
-        >
-          {/* Render breadcrumbs in reverse order so RTL + overflow clips from the LEFT (oldest
-              ancestors are clipped first, most-specific domain is always visible). The visual order
-              stays correct because each segment is forced back to LTR via dir="ltr". */}
-          <div className="tw-flex tw-flex-row-reverse tw-items-center tw-gap-0.5" dir="ltr">
-            {domainPath.map((domain, idx) => {
-              const isLast = idx === domainPath.length - 1;
-              return (
-                <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
-                  {idx > 0 && (
-                    <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
-                  )}
-                  {isLast ? (
-                    <span className="tw-text-sm tw-font-medium">{domain.label}</span>
-                  ) : (
-                    <Button
-                      variant="link"
-                      className="tw-h-auto tw-p-0 tw-text-sm"
-                      onClick={() => onDomainChange(domainPath.slice(0, idx + 1))}
-                    >
-                      {domain.label}
-                    </Button>
-                  )}
-                </span>
-              );
-            })}
-          </div>
-        </nav>
-
-        <Button
-          variant="ghost"
-          size="icon"
-          className="tw-h-7 tw-w-7 tw-shrink-0"
-          onClick={() => setTreeOpen(true)}
-          aria-label="Browse domain tree"
-        >
-          <FolderTree className="tw-h-3.5 tw-w-3.5" />
-        </Button>
       </div>
 
       {/* Dictionary list */}
@@ -124,86 +101,234 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
           className="tw-h-full"
         />
       </div>
-
-      {/* Domain tree bottom Drawer (fills full height of container) */}
-      <Drawer direction="bottom" modal={false} open={treeOpen} onOpenChange={setTreeOpen}>
-        <DrawerContent
-          container={containerRef.current}
-          hideDrawerHandle
-          className="tw-mt-0 tw-h-full tw-max-h-full tw-rounded-none"
-        >
-          <div className="tw-flex tw-h-full tw-flex-col">
-            <div className="tw-flex tw-items-center tw-justify-between tw-border-b tw-px-3 tw-py-2">
-              <DrawerTitle className="tw-text-sm tw-font-semibold">Semantic Domains</DrawerTitle>
-              <DrawerClose asChild>
-                <Button variant="outline" size="sm">
-                  Close
-                </Button>
-              </DrawerClose>
-            </div>
-            <div className="tw-flex-1 tw-overflow-y-auto tw-p-2">
-              <ExpandableTree
-                domains={allDomains}
-                currentPath={domainPath}
-                onSelect={handleTreeSelect}
-              />
-            </div>
-          </div>
-        </DrawerContent>
-      </Drawer>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Expandable tree (recursive, with chevron expand/collapse)
+// Breadcrumb display: left-aligned, ellipsis collapse, last item bold,
+// hover underlines individual segments
 // ---------------------------------------------------------------------------
 
-function ExpandableTree({
+function BreadcrumbDisplay({ path }: { path: SemanticDomain[] }) {
+  // ref.current expects null not undefined for div ref
+  // eslint-disable-next-line no-null/no-null
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [visibleCount, setVisibleCount] = useState(path.length);
+
+  // Measure which segments fit. Show root + ellipsis + trailing segments.
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return undefined;
+    const observer = new ResizeObserver(() => {
+      // Reset to try full path
+      setVisibleCount(path.length);
+      requestAnimationFrame(() => {
+        if (!el) return;
+        if (el.scrollWidth > el.clientWidth) {
+          // Binary search for how many trailing segments fit with ellipsis
+          let lo = 2;
+          let hi = path.length;
+          while (lo < hi) {
+            const mid = Math.ceil((lo + hi) / 2);
+            setVisibleCount(mid);
+            // We can't measure synchronously after setState, so use a simpler heuristic:
+            // just show fewer if overflowing
+            hi = mid - 1;
+          }
+          setVisibleCount(Math.max(2, lo));
+        }
+      });
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [path.length]);
+
+  // Always show root ("Domain" label). If collapsed, show root + ... + trailing segments.
+  const showEllipsis = visibleCount < path.length;
+  const rootItem = path[0];
+  const trailingItems = showEllipsis ? path.slice(-(visibleCount - 1)) : path.slice(1);
+
+  return (
+    <div ref={containerRef} className="tw-flex tw-items-center tw-gap-0.5 tw-overflow-hidden">
+      {rootItem && (
+        <span className="tw-shrink-0 tw-text-sm group-hover:tw-underline">{rootItem.label}</span>
+      )}
+      {showEllipsis && (
+        <>
+          <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+          <MoreHorizontal className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+        </>
+      )}
+      {trailingItems.map((domain, idx) => {
+        const isLast = idx === trailingItems.length - 1;
+        return (
+          <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
+            <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+            <span
+              className={cn('tw-text-sm group-hover:tw-underline', {
+                'tw-font-bold': isLast,
+              })}
+            >
+              {domain.label}
+            </span>
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Domain search tree: filterable tree inside a popover, with highlight and
+// ancestor retention
+// ---------------------------------------------------------------------------
+
+function DomainSearchTree({
   domains,
   currentPath,
   onSelect,
-  depth = 0,
 }: {
   domains: SemanticDomain[];
   currentPath: SemanticDomain[];
   onSelect: (path: SemanticDomain[]) => void;
-  depth?: number;
 }) {
+  const [filter, setFilter] = useState('');
+  // ref.current expects null not undefined for element ref
+  // eslint-disable-next-line no-null/no-null
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  // Scroll to current selection when opening
+  useEffect(() => {
+    requestAnimationFrame(() => {
+      selectedRef.current?.scrollIntoView({ block: 'center' });
+    });
+  }, []);
+
+  const filterLower = filter.toLowerCase();
+
   return (
-    <ul className={cn('tw-space-y-0.5', { 'tw-ml-4': depth > 0 })}>
-      {domains.map((domain) => (
-        <ExpandableTreeNode
-          key={domain.id}
-          domain={domain}
+    <div className="tw-flex tw-max-h-[300px] tw-flex-col">
+      <div className="tw-border-b tw-p-2">
+        <Input
+          placeholder="Search domains..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="tw-h-8 tw-text-sm"
+          autoFocus
+        />
+      </div>
+      <div className="tw-flex-1 tw-overflow-y-auto tw-p-1">
+        <FilterableTreeNodes
+          domains={domains}
           currentPath={currentPath}
           onSelect={onSelect}
-          depth={depth}
           parentPath={[]}
+          filter={filterLower}
+          selectedRef={selectedRef}
         />
-      ))}
+      </div>
+    </div>
+  );
+}
+
+/** Check if a domain or any descendant matches the filter */
+function domainMatchesFilter(domain: SemanticDomain, filter: string): boolean {
+  if (domain.label.toLowerCase().includes(filter)) return true;
+  return domain.children?.some((child) => domainMatchesFilter(child, filter)) ?? false;
+}
+
+/** Highlight matching characters in a label */
+function HighlightLabel({ label, filter }: { label: string; filter: string }) {
+  if (!filter) return <span>{label}</span>;
+  const idx = label.toLowerCase().indexOf(filter);
+  if (idx < 0) return <span>{label}</span>;
+  return (
+    <span>
+      {label.slice(0, idx)}
+      <mark className="tw-bg-yellow-200 tw-text-inherit dark:tw-bg-yellow-800">
+        {label.slice(idx, idx + filter.length)}
+      </mark>
+      {label.slice(idx + filter.length)}
+    </span>
+  );
+}
+
+function FilterableTreeNodes({
+  domains,
+  currentPath,
+  onSelect,
+  parentPath,
+  filter,
+  selectedRef,
+}: {
+  domains: SemanticDomain[];
+  currentPath: SemanticDomain[];
+  onSelect: (path: SemanticDomain[]) => void;
+  parentPath: SemanticDomain[];
+  filter: string;
+  selectedRef: React.RefObject<HTMLButtonElement>;
+}) {
+  return (
+    <ul className={cn('tw-space-y-0.5', { 'tw-ml-3': parentPath.length > 0 })}>
+      {domains.map((domain) => {
+        // When filtering, skip domains (and subtrees) that don't match
+        if (filter && !domainMatchesFilter(domain, filter)) return undefined;
+
+        const thisPath = [...parentPath, domain];
+        const isInCurrentPath = currentPath.some((d) => d.id === domain.id);
+        const isSelected =
+          currentPath.length > 0 && currentPath[currentPath.length - 1].id === domain.id;
+        const hasChildren = domain.children && domain.children.length > 0;
+        // Auto-expand: when filtering (show all matches), or when on current path
+        const shouldExpand = !!filter || isInCurrentPath;
+
+        return (
+          <FilterableTreeNode
+            key={domain.id}
+            domain={domain}
+            thisPath={thisPath}
+            isSelected={isSelected}
+            hasChildren={hasChildren ?? false}
+            defaultExpanded={shouldExpand}
+            currentPath={currentPath}
+            onSelect={onSelect}
+            filter={filter}
+            selectedRef={selectedRef}
+          />
+        );
+      })}
     </ul>
   );
 }
 
-function ExpandableTreeNode({
+function FilterableTreeNode({
   domain,
+  thisPath,
+  isSelected,
+  hasChildren,
+  defaultExpanded,
   currentPath,
   onSelect,
-  depth,
-  parentPath,
+  filter,
+  selectedRef,
 }: {
   domain: SemanticDomain;
+  thisPath: SemanticDomain[];
+  isSelected: boolean;
+  hasChildren: boolean;
+  defaultExpanded: boolean;
   currentPath: SemanticDomain[];
   onSelect: (path: SemanticDomain[]) => void;
-  depth: number;
-  parentPath: SemanticDomain[];
+  filter: string;
+  selectedRef: React.RefObject<HTMLButtonElement>;
 }) {
-  const thisPath = [...parentPath, domain];
-  const isInCurrentPath = currentPath.some((d) => d.id === domain.id);
-  const isSelected = currentPath.length > 0 && currentPath[currentPath.length - 1].id === domain.id;
-  const hasChildren = domain.children && domain.children.length > 0;
-  const [expanded, setExpanded] = useState(isInCurrentPath);
+  const [expanded, setExpanded] = useState(defaultExpanded);
+
+  // Re-expand when filter or path changes
+  useEffect(() => {
+    if (defaultExpanded) setExpanded(true);
+  }, [defaultExpanded]);
 
   return (
     <li>
@@ -211,43 +336,39 @@ function ExpandableTreeNode({
         {hasChildren ? (
           <button
             type="button"
-            className="tw-flex tw-h-6 tw-w-6 tw-shrink-0 tw-items-center tw-justify-center tw-rounded hover:tw-bg-muted"
+            className="tw-flex tw-h-5 tw-w-5 tw-shrink-0 tw-items-center tw-justify-center tw-rounded hover:tw-bg-muted"
             onClick={() => setExpanded(!expanded)}
           >
-            {expanded ? (
-              <ChevronRight className="tw-h-3.5 tw-w-3.5 tw-rotate-90 tw-transition-transform" />
-            ) : (
-              <ChevronRight className="tw-h-3.5 tw-w-3.5 tw-transition-transform" />
-            )}
+            <ChevronRight
+              className={cn('tw-h-3 tw-w-3 tw-transition-transform', {
+                'tw-rotate-90': expanded,
+              })}
+            />
           </button>
         ) : (
-          <span className="tw-w-6 tw-shrink-0" />
+          <span className="tw-w-5 tw-shrink-0" />
         )}
         <button
           type="button"
+          ref={isSelected ? selectedRef : undefined}
           className={cn(
-            'tw-flex-1 tw-rounded tw-px-2 tw-py-1 tw-text-left tw-text-sm',
+            'tw-flex-1 tw-rounded tw-px-1.5 tw-py-0.5 tw-text-left tw-text-sm',
             isSelected ? 'tw-bg-accent tw-font-medium' : 'hover:tw-bg-muted',
-            depth === 0 && 'tw-font-semibold',
           )}
           onClick={() => onSelect(thisPath)}
         >
-          {domain.label}
+          <HighlightLabel label={domain.label} filter={filter} />
         </button>
       </div>
       {expanded && hasChildren && (
-        <ul className="tw-ml-4 tw-space-y-0.5">
-          {domain.children?.map((child) => (
-            <ExpandableTreeNode
-              key={child.id}
-              domain={child}
-              currentPath={currentPath}
-              onSelect={onSelect}
-              depth={depth + 1}
-              parentPath={thisPath}
-            />
-          ))}
-        </ul>
+        <FilterableTreeNodes
+          domains={domain.children!}
+          currentPath={currentPath}
+          onSelect={onSelect}
+          parentPath={thisPath}
+          filter={filter}
+          selectedRef={selectedRef}
+        />
       )}
     </li>
   );

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -1,9 +1,9 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import { Input } from '@/components/shadcn-ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/shadcn-ui/popover';
-import { ChevronRight, MoreHorizontal, X } from 'lucide-react';
+import { ArrowUp, ChevronRight, MoreHorizontal } from 'lucide-react';
 import { Z_INDEX_MODAL } from '@/components/z-index';
 import SourceLanguageIndexedList from './source-language-indexed-list.component';
 import type {
@@ -15,16 +15,16 @@ import type {
 /**
  * ER Dictionary list filtered by semantic domain with breadcrumb-based navigation.
  *
- * **Breadcrumb bar**: A single clickable button showing the domain path left-aligned. When space is
- * limited, intermediate segments collapse into an ellipsis (`...`) while the root ("Domain") and
- * the deepest segments stay visible. The last segment is bold. Hovering a segment underlines it.
- * Clicking the breadcrumb bar opens a popover with a searchable expandable domain tree (combobox
- * pattern). The tree auto-expands to and scrolls to the currently selected domain. Filtering keeps
- * ancestor nodes visible and highlights matching characters.
+ * Header layout (top to bottom):
  *
- * **Close button**: An X button on the right to dismiss the filtered view.
+ * 1. "Back to dictionary" button with arrow-up icon to slide the drawer back down.
+ * 2. Breadcrumb bar: a single clickable button showing the domain path left-aligned. When space is
+ *    limited, intermediate segments collapse into an ellipsis while the root and deepest segments
+ *    stay visible. Last segment is bold. Clicking opens a popover with a searchable expandable
+ *    domain tree.
  *
- * Below the header: a `SourceLanguageIndexedList` for the filtered entries.
+ * The detail panel within `SourceLanguageIndexedList` does not block interaction with the list or
+ * header elements because it is rendered as an absolutely-positioned sibling, not a modal overlay.
  */
 export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   items,
@@ -42,20 +42,33 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
 }: ErDictionaryFilteredListProps<T>) {
   const [popoverOpen, setPopoverOpen] = useState(false);
 
-  const handleDomainSelect = (path: SemanticDomain[]) => {
-    onDomainChange(path);
-    setPopoverOpen(false);
-  };
+  const handleDomainSelect = useCallback(
+    (path: SemanticDomain[]) => {
+      onDomainChange(path);
+      setPopoverOpen(false);
+    },
+    [onDomainChange],
+  );
 
   return (
     <div className={cn('tw-relative tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}>
-      {/* Header: breadcrumb button + close */}
-      <div className="tw-flex tw-items-center tw-gap-1 tw-border-b tw-px-2 tw-py-1.5">
+      {/* "Back to dictionary" button */}
+      {onClose && (
+        <div className="tw-border-b tw-px-2 tw-py-1">
+          <Button variant="ghost" size="sm" className="tw-gap-1" onClick={onClose}>
+            <ArrowUp className="tw-h-4 tw-w-4" />
+            Back to dictionary
+          </Button>
+        </div>
+      )}
+
+      {/* Breadcrumb bar */}
+      <div className="tw-border-b tw-px-2 tw-py-1">
         <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
           <PopoverTrigger asChild>
             <button
               type="button"
-              className="tw-group tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-1 tw-overflow-hidden tw-rounded tw-px-1.5 tw-py-1 tw-text-left hover:tw-bg-muted"
+              className="tw-group tw-flex tw-w-full tw-min-w-0 tw-items-center tw-gap-1 tw-overflow-hidden tw-rounded tw-px-1.5 tw-py-1 tw-text-left hover:tw-bg-muted"
             >
               <BreadcrumbDisplay path={domainPath} />
             </button>
@@ -72,18 +85,6 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
             />
           </PopoverContent>
         </Popover>
-
-        {onClose && (
-          <Button
-            variant="ghost"
-            size="icon"
-            className="tw-h-7 tw-w-7 tw-shrink-0"
-            onClick={onClose}
-            aria-label="Close filtered view"
-          >
-            <X className="tw-h-4 tw-w-4" />
-          </Button>
-        )}
       </div>
 
       {/* Dictionary list */}
@@ -106,82 +107,126 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
 }
 
 // ---------------------------------------------------------------------------
-// Breadcrumb display: left-aligned, ellipsis collapse, last item bold,
-// hover underlines individual segments
+// Breadcrumb display: left-aligned, stable ellipsis (no flicker), last bold
 // ---------------------------------------------------------------------------
 
+/**
+ * Renders the breadcrumb path. Uses a hidden measurement pass to determine how many trailing
+ * segments fit before the component mounts visually, avoiding flicker. The root segment is always
+ * shown; intermediate ones collapse into an ellipsis (`...`) when the container is too narrow.
+ */
 function BreadcrumbDisplay({ path }: { path: SemanticDomain[] }) {
-  // ref.current expects null not undefined for div ref
   // eslint-disable-next-line no-null/no-null
   const containerRef = useRef<HTMLDivElement>(null);
-  const [visibleCount, setVisibleCount] = useState(path.length);
+  // eslint-disable-next-line no-null/no-null
+  const measureRef = useRef<HTMLDivElement>(null);
+  const [visibleFromEnd, setVisibleFromEnd] = useState(path.length);
 
-  // Measure which segments fit. Show root + ellipsis + trailing segments.
+  // Measure once after layout, synchronously before paint, to avoid flicker
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    const measure = measureRef.current;
+    if (!container || !measure) return;
+
+    const availableWidth = container.clientWidth;
+
+    // measureRef contains all segments rendered invisibly. We measure from the right:
+    // always keep the root, then try adding trailing segments + ellipsis until it overflows.
+    const segments = Array.from(measure.children) as HTMLElement[];
+    if (segments.length === 0) return;
+
+    // Full width of all segments
+    let totalWidth = 0;
+    for (const seg of segments) totalWidth += seg.scrollWidth;
+
+    if (totalWidth <= availableWidth) {
+      setVisibleFromEnd(path.length);
+      return;
+    }
+
+    // Root width + ellipsis (approx 32px for chevron+dots)
+    const rootWidth = segments[0].scrollWidth;
+    const ellipsisWidth = 32;
+    let budget = availableWidth - rootWidth - ellipsisWidth;
+    let count = 0;
+
+    // Count from the end how many fit
+    for (let i = segments.length - 1; i >= 1 && budget > 0; i -= 1) {
+      const segWidth = segments[i].scrollWidth;
+      if (segWidth > budget) break;
+      budget -= segWidth;
+      count += 1;
+    }
+
+    setVisibleFromEnd(Math.max(1, count) + 1); // +1 for root
+  }, [path]);
+
+  // Also re-measure on resize
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el) return undefined;
+    const container = containerRef.current;
+    if (!container) return undefined;
     const observer = new ResizeObserver(() => {
-      // Reset to try full path
-      setVisibleCount(path.length);
-      requestAnimationFrame(() => {
-        if (!el) return;
-        if (el.scrollWidth > el.clientWidth) {
-          // Binary search for how many trailing segments fit with ellipsis
-          let lo = 2;
-          let hi = path.length;
-          while (lo < hi) {
-            const mid = Math.ceil((lo + hi) / 2);
-            setVisibleCount(mid);
-            // We can't measure synchronously after setState, so use a simpler heuristic:
-            // just show fewer if overflowing
-            hi = mid - 1;
-          }
-          setVisibleCount(Math.max(2, lo));
-        }
-      });
+      // Re-run the layout effect by triggering a state update with the full count,
+      // then the layout effect will correct it synchronously before paint
+      setVisibleFromEnd(path.length);
     });
-    observer.observe(el);
+    observer.observe(container);
     return () => observer.disconnect();
   }, [path.length]);
 
-  // Always show root ("Domain" label). If collapsed, show root + ... + trailing segments.
-  const showEllipsis = visibleCount < path.length;
+  const showEllipsis = visibleFromEnd < path.length;
   const rootItem = path[0];
-  const trailingItems = showEllipsis ? path.slice(-(visibleCount - 1)) : path.slice(1);
+  const trailingItems = showEllipsis ? path.slice(-(visibleFromEnd - 1)) : path.slice(1);
 
   return (
-    <div ref={containerRef} className="tw-flex tw-items-center tw-gap-0.5 tw-overflow-hidden">
-      {rootItem && (
-        <span className="tw-shrink-0 tw-text-sm group-hover:tw-underline">{rootItem.label}</span>
-      )}
-      {showEllipsis && (
-        <>
-          <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
-          <MoreHorizontal className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
-        </>
-      )}
-      {trailingItems.map((domain, idx) => {
-        const isLast = idx === trailingItems.length - 1;
-        return (
+    <>
+      {/* Hidden measurement div: renders all segments invisibly to measure their widths */}
+      <div
+        ref={measureRef}
+        className="tw-pointer-events-none tw-invisible tw-absolute tw-flex tw-items-center tw-gap-0.5 tw-whitespace-nowrap"
+        aria-hidden
+      >
+        {path.map((domain, idx) => (
           <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
-            <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
-            <span
-              className={cn('tw-text-sm group-hover:tw-underline', {
-                'tw-font-bold': isLast,
-              })}
-            >
-              {domain.label}
-            </span>
+            {idx > 0 && <ChevronRight className="tw-h-3 tw-w-3" />}
+            <span className="tw-text-sm">{domain.label}</span>
           </span>
-        );
-      })}
-    </div>
+        ))}
+      </div>
+
+      {/* Visible breadcrumbs */}
+      <div ref={containerRef} className="tw-flex tw-items-center tw-gap-0.5 tw-overflow-hidden">
+        {rootItem && (
+          <span className="tw-shrink-0 tw-text-sm group-hover:tw-underline">{rootItem.label}</span>
+        )}
+        {showEllipsis && (
+          <>
+            <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+            <MoreHorizontal className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+          </>
+        )}
+        {trailingItems.map((domain, idx) => {
+          const isLast = idx === trailingItems.length - 1;
+          return (
+            <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
+              <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+              <span
+                className={cn('tw-text-sm group-hover:tw-underline', {
+                  'tw-font-bold': isLast,
+                })}
+              >
+                {domain.label}
+              </span>
+            </span>
+          );
+        })}
+      </div>
+    </>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Domain search tree: filterable tree inside a popover, with highlight and
-// ancestor retention
+// Domain search tree
 // ---------------------------------------------------------------------------
 
 function DomainSearchTree({
@@ -194,11 +239,9 @@ function DomainSearchTree({
   onSelect: (path: SemanticDomain[]) => void;
 }) {
   const [filter, setFilter] = useState('');
-  // ref.current expects null not undefined for element ref
   // eslint-disable-next-line no-null/no-null
   const selectedRef = useRef<HTMLButtonElement>(null);
 
-  // Scroll to current selection when opening
   useEffect(() => {
     requestAnimationFrame(() => {
       selectedRef.current?.scrollIntoView({ block: 'center' });
@@ -232,13 +275,11 @@ function DomainSearchTree({
   );
 }
 
-/** Check if a domain or any descendant matches the filter */
 function domainMatchesFilter(domain: SemanticDomain, filter: string): boolean {
   if (domain.label.toLowerCase().includes(filter)) return true;
   return domain.children?.some((child) => domainMatchesFilter(child, filter)) ?? false;
 }
 
-/** Highlight matching characters in a label */
 function HighlightLabel({ label, filter }: { label: string; filter: string }) {
   if (!filter) return <span>{label}</span>;
   const idx = label.toLowerCase().indexOf(filter);
@@ -272,7 +313,6 @@ function FilterableTreeNodes({
   return (
     <ul className={cn('tw-space-y-0.5', { 'tw-ml-3': parentPath.length > 0 })}>
       {domains.map((domain) => {
-        // When filtering, skip domains (and subtrees) that don't match
         if (filter && !domainMatchesFilter(domain, filter)) return undefined;
 
         const thisPath = [...parentPath, domain];
@@ -280,7 +320,6 @@ function FilterableTreeNodes({
         const isSelected =
           currentPath.length > 0 && currentPath[currentPath.length - 1].id === domain.id;
         const hasChildren = domain.children && domain.children.length > 0;
-        // Auto-expand: when filtering (show all matches), or when on current path
         const shouldExpand = !!filter || isInCurrentPath;
 
         return (
@@ -325,7 +364,6 @@ function FilterableTreeNode({
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
 
-  // Re-expand when filter or path changes
   useEffect(() => {
     if (defaultExpanded) setExpanded(true);
   }, [defaultExpanded]);

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -1,15 +1,8 @@
 import { useRef, useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/shadcn-ui/dropdown-menu';
 import { Drawer, DrawerClose, DrawerContent, DrawerTitle } from '@/components/shadcn-ui/drawer';
-import { ArrowLeft, ChevronDown, FolderTree } from 'lucide-react';
-import { Z_INDEX_MODAL } from '@/components/z-index';
+import { ArrowLeft, ChevronRight, FolderTree } from 'lucide-react';
 import SourceLanguageIndexedList from './source-language-indexed-list.component';
 import type {
   ErDictionaryFilteredListProps,
@@ -17,23 +10,16 @@ import type {
   SemanticDomain,
 } from './source-language-indexed-list.types';
 
-/** Z-index that sits above the Dialog modal layer so dropdowns are visible */
-const Z_ABOVE_MODAL = Z_INDEX_MODAL + 10;
-
 /**
- * ER Dictionary list filtered by semantic domain with 2-level breadcrumb navigation.
+ * ER Dictionary list filtered by semantic domain with breadcrumb navigation (up to 5 levels).
  *
- * Breadcrumb row layout: `[← back] [Category ▼] · [Domain ▼] ........... [🌳]`
+ * Breadcrumb row: `[← Back] ... > Level3 > Level4 > Level5 ......... [🌳]`
  *
- * - **Back arrow** (icon only, no text): navigates back when `onBack` is provided.
- * - **Breadcrumbs** with dot separator: both segments are dropdowns showing siblings at that level.
- *   When switching a category the first child domain is auto-selected.
- * - **Tree button** (right-aligned): opens a scoped Drawer with the full 2-level domain tree.
+ * Breadcrumbs truncate from the **left** with "..." when space is limited. The rightmost segments
+ * are always visible. Clicking any breadcrumb segment navigates to that domain.
  *
- * Below the breadcrumbs: a `SourceLanguageIndexedList` showing entries filtered to the selected
- * domain. Clicking an entry opens a detail panel inline within the list area.
- *
- * Domains are always exactly 2 levels deep.
+ * The tree button opens a **bottom Drawer** (scoped to this component) that fills the full height
+ * of the container, showing the expandable domain tree.
  */
 export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   items,
@@ -43,8 +29,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   selectedItemId,
   emptyStateMessage,
   isLoading,
-  selectedLevel1Domain,
-  selectedLevel2Domain,
+  domainPath,
   allDomains,
   onDomainChange,
   onBack,
@@ -55,103 +40,64 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   // eslint-disable-next-line no-null/no-null
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Ensure we always have a level-2 domain; fall back to first child
-  const effectiveLevel2 = selectedLevel2Domain ?? selectedLevel1Domain.children?.[0];
-
-  const handleCategoryChange = (newLevel1: SemanticDomain) => {
-    // Auto-select the first child domain when switching categories
-    onDomainChange(newLevel1, newLevel1.children?.[0]);
-  };
-
-  const handleDomainSelectFromTree = (level1: SemanticDomain, level2?: SemanticDomain) => {
-    onDomainChange(level1, level2 ?? level1.children?.[0]);
+  const handleTreeSelect = (path: SemanticDomain[]) => {
+    onDomainChange(path);
     setTreeOpen(false);
   };
-
-  // Sibling domains at level 2 (children of the selected level 1)
-  const level2Siblings = selectedLevel1Domain.children ?? [];
 
   return (
     <div
       ref={containerRef}
       className={cn('tw-relative tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}
     >
-      {/* Breadcrumb row: [← back] [Category ▼] · [Domain ▼] ... [tree] */}
+      {/* Breadcrumb row */}
       <div className="tw-flex tw-items-center tw-gap-1 tw-border-b tw-px-2 tw-py-1.5">
-        {/* Back arrow (icon only) */}
         {onBack && (
           <Button
             variant="ghost"
-            size="icon"
-            className="tw-h-7 tw-w-7 tw-shrink-0"
+            size="sm"
+            className="tw-shrink-0 tw-gap-1"
             onClick={onBack}
             aria-label="Back to dictionary"
           >
             <ArrowLeft className="tw-h-4 tw-w-4" />
+            Back
           </Button>
         )}
 
-        {/* Breadcrumbs with dot separator */}
         <nav
-          aria-label="Semantic domain breadcrumbs"
-          className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-gap-0.5"
+          aria-label="Domain breadcrumbs"
+          className="tw-flex tw-min-w-0 tw-flex-1 tw-items-center tw-overflow-hidden"
+          dir="rtl"
         >
-          {/* Level 1 (Category) dropdown */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" className="tw-h-auto tw-gap-1 tw-px-1.5 tw-py-0.5 tw-text-sm">
-                {selectedLevel1Domain.label}
-                <ChevronDown className="tw-h-3 tw-w-3" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" style={{ zIndex: Z_ABOVE_MODAL }}>
-              {allDomains.map((domain) => (
-                <DropdownMenuItem
-                  key={domain.id}
-                  className={cn({
-                    'tw-font-medium': domain.id === selectedLevel1Domain.id,
-                  })}
-                  onClick={() => handleCategoryChange(domain)}
-                >
-                  {domain.label}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-
-          {/* Dot separator */}
-          <span className="tw-select-none tw-text-muted-foreground" aria-hidden>
-            &middot;
-          </span>
-
-          {/* Level 2 (Domain) dropdown */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                className="tw-h-auto tw-gap-1 tw-px-1.5 tw-py-0.5 tw-text-sm tw-font-medium"
-              >
-                {effectiveLevel2?.label ?? 'All'}
-                <ChevronDown className="tw-h-3 tw-w-3" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" style={{ zIndex: Z_ABOVE_MODAL }}>
-              {level2Siblings.map((domain) => (
-                <DropdownMenuItem
-                  key={domain.id}
-                  className={cn({
-                    'tw-font-medium': domain.id === effectiveLevel2?.id,
-                  })}
-                  onClick={() => onDomainChange(selectedLevel1Domain, domain)}
-                >
-                  {domain.label}
-                </DropdownMenuItem>
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          {/* Render breadcrumbs in reverse order so RTL + overflow clips from the LEFT (oldest
+              ancestors are clipped first, most-specific domain is always visible). The visual order
+              stays correct because each segment is forced back to LTR via dir="ltr". */}
+          <div className="tw-flex tw-flex-row-reverse tw-items-center tw-gap-0.5" dir="ltr">
+            {domainPath.map((domain, idx) => {
+              const isLast = idx === domainPath.length - 1;
+              return (
+                <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
+                  {idx > 0 && (
+                    <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
+                  )}
+                  {isLast ? (
+                    <span className="tw-text-sm tw-font-medium">{domain.label}</span>
+                  ) : (
+                    <Button
+                      variant="link"
+                      className="tw-h-auto tw-p-0 tw-text-sm"
+                      onClick={() => onDomainChange(domainPath.slice(0, idx + 1))}
+                    >
+                      {domain.label}
+                    </Button>
+                  )}
+                </span>
+              );
+            })}
+          </div>
         </nav>
 
-        {/* Tree button (right-aligned) */}
         <Button
           variant="ghost"
           size="icon"
@@ -179,12 +125,12 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
         />
       </div>
 
-      {/* Domain tree Drawer - scoped to this component */}
-      <Drawer direction="right" modal={false} open={treeOpen} onOpenChange={setTreeOpen}>
+      {/* Domain tree bottom Drawer (fills full height of container) */}
+      <Drawer direction="bottom" modal={false} open={treeOpen} onOpenChange={setTreeOpen}>
         <DrawerContent
           container={containerRef.current}
           hideDrawerHandle
-          className="tw-ml-0 tw-w-4/5 tw-max-w-none tw-rounded-none"
+          className="tw-mt-0 tw-h-full tw-max-h-full tw-rounded-none"
         >
           <div className="tw-flex tw-h-full tw-flex-col">
             <div className="tw-flex tw-items-center tw-justify-between tw-border-b tw-px-3 tw-py-2">
@@ -196,11 +142,10 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
               </DrawerClose>
             </div>
             <div className="tw-flex-1 tw-overflow-y-auto tw-p-2">
-              <DomainTreeView
+              <ExpandableTree
                 domains={allDomains}
-                selectedLevel1Id={selectedLevel1Domain.id}
-                selectedLevel2Id={effectiveLevel2?.id}
-                onSelect={handleDomainSelectFromTree}
+                currentPath={domainPath}
+                onSelect={handleTreeSelect}
               />
             </div>
           </div>
@@ -210,52 +155,100 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   );
 }
 
-/** Full 2-level domain tree rendered inside the drawer */
-function DomainTreeView({
+// ---------------------------------------------------------------------------
+// Expandable tree (recursive, with chevron expand/collapse)
+// ---------------------------------------------------------------------------
+
+function ExpandableTree({
   domains,
-  selectedLevel1Id,
-  selectedLevel2Id,
+  currentPath,
   onSelect,
+  depth = 0,
 }: {
   domains: SemanticDomain[];
-  selectedLevel1Id: string;
-  selectedLevel2Id?: string;
-  onSelect: (level1: SemanticDomain, level2?: SemanticDomain) => void;
+  currentPath: SemanticDomain[];
+  onSelect: (path: SemanticDomain[]) => void;
+  depth?: number;
 }) {
   return (
-    <ul className="tw-space-y-1">
-      {domains.map((level1) => (
-        <li key={level1.id}>
-          <span
-            className={cn('tw-block tw-px-2 tw-py-1.5 tw-text-sm tw-font-semibold', {
-              'tw-text-primary': level1.id === selectedLevel1Id,
-            })}
-          >
-            {level1.label}
-          </span>
-          {level1.children && level1.children.length > 0 && (
-            <ul className="tw-ml-3 tw-space-y-0.5">
-              {level1.children.map((level2) => (
-                <li key={level2.id}>
-                  <Button
-                    variant="ghost"
-                    className={cn(
-                      'tw-h-auto tw-w-full tw-justify-start tw-px-2 tw-py-1 tw-text-sm',
-                      {
-                        'tw-bg-accent tw-font-medium':
-                          level1.id === selectedLevel1Id && level2.id === selectedLevel2Id,
-                      },
-                    )}
-                    onClick={() => onSelect(level1, level2)}
-                  >
-                    {level2.label}
-                  </Button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </li>
+    <ul className={cn('tw-space-y-0.5', { 'tw-ml-4': depth > 0 })}>
+      {domains.map((domain) => (
+        <ExpandableTreeNode
+          key={domain.id}
+          domain={domain}
+          currentPath={currentPath}
+          onSelect={onSelect}
+          depth={depth}
+          parentPath={[]}
+        />
       ))}
     </ul>
+  );
+}
+
+function ExpandableTreeNode({
+  domain,
+  currentPath,
+  onSelect,
+  depth,
+  parentPath,
+}: {
+  domain: SemanticDomain;
+  currentPath: SemanticDomain[];
+  onSelect: (path: SemanticDomain[]) => void;
+  depth: number;
+  parentPath: SemanticDomain[];
+}) {
+  const thisPath = [...parentPath, domain];
+  const isInCurrentPath = currentPath.some((d) => d.id === domain.id);
+  const isSelected = currentPath.length > 0 && currentPath[currentPath.length - 1].id === domain.id;
+  const hasChildren = domain.children && domain.children.length > 0;
+  const [expanded, setExpanded] = useState(isInCurrentPath);
+
+  return (
+    <li>
+      <div className="tw-flex tw-items-center tw-gap-0.5">
+        {hasChildren ? (
+          <button
+            type="button"
+            className="tw-flex tw-h-6 tw-w-6 tw-shrink-0 tw-items-center tw-justify-center tw-rounded hover:tw-bg-muted"
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded ? (
+              <ChevronRight className="tw-h-3.5 tw-w-3.5 tw-rotate-90 tw-transition-transform" />
+            ) : (
+              <ChevronRight className="tw-h-3.5 tw-w-3.5 tw-transition-transform" />
+            )}
+          </button>
+        ) : (
+          <span className="tw-w-6 tw-shrink-0" />
+        )}
+        <button
+          type="button"
+          className={cn(
+            'tw-flex-1 tw-rounded tw-px-2 tw-py-1 tw-text-left tw-text-sm',
+            isSelected ? 'tw-bg-accent tw-font-medium' : 'hover:tw-bg-muted',
+            depth === 0 && 'tw-font-semibold',
+          )}
+          onClick={() => onSelect(thisPath)}
+        >
+          {domain.label}
+        </button>
+      </div>
+      {expanded && hasChildren && (
+        <ul className="tw-ml-4 tw-space-y-0.5">
+          {domain.children?.map((child) => (
+            <ExpandableTreeNode
+              key={child.id}
+              domain={child}
+              currentPath={currentPath}
+              onSelect={onSelect}
+              depth={depth + 1}
+              parentPath={thisPath}
+            />
+          ))}
+        </ul>
+      )}
+    </li>
   );
 }

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -178,7 +178,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
                 ref={listRef}
                 role="listbox"
                 tabIndex={0}
-                className="tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-ring"
+                className="tw-p-0.5 tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-ring"
                 onKeyDown={handleListKeyDown}
               >
                 {items.map((item, idx) => {
@@ -356,8 +356,10 @@ function BreadcrumbBar({
 
         {path.map((domain, idx) => {
           if (idx === 0) return undefined;
-          if (idx <= hideCount) return undefined;
           const isLast = idx === path.length - 1;
+          // Always keep the last segment visible — the most collapsed state is
+          // "ellipsis > last item", never just an ellipsis on its own.
+          if (idx <= hideCount && !isLast) return undefined;
           return (
             <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
               <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -1,9 +1,9 @@
-import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import { Input } from '@/components/shadcn-ui/input';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/shadcn-ui/popover';
-import { ArrowUp, ChevronRight, MoreHorizontal } from 'lucide-react';
+import { ChevronRight, MoreHorizontal, X } from 'lucide-react';
 import { Z_INDEX_MODAL } from '@/components/z-index';
 import SourceLanguageIndexedList from './source-language-indexed-list.component';
 import type {
@@ -15,16 +15,14 @@ import type {
 /**
  * ER Dictionary list filtered by semantic domain with breadcrumb-based navigation.
  *
- * Header layout (top to bottom):
+ * Header row: `[breadcrumb button (hugs content)] ......... [X Close]`
  *
- * 1. "Back to dictionary" button with arrow-up icon to slide the drawer back down.
- * 2. Breadcrumb bar: a single clickable button showing the domain path left-aligned. When space is
- *    limited, intermediate segments collapse into an ellipsis while the root and deepest segments
- *    stay visible. Last segment is bold. Clicking opens a popover with a searchable expandable
- *    domain tree.
+ * Breadcrumbs collapse dynamically without flicker. Collapse order: start hiding the 2nd-left item,
+ * then continue inward until only `root > ... > leaf` remains, then also hide root.
  *
- * The detail panel within `SourceLanguageIndexedList` does not block interaction with the list or
- * header elements because it is rendered as an absolutely-positioned sibling, not a modal overlay.
+ * Clicking a breadcrumb segment opens the domain tree popover expanded/scrolled to **that** level.
+ * The popover has a full-width search input that filters the tree (showing matches + all ancestors)
+ * with character-level highlighting.
  */
 export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   items,
@@ -41,6 +39,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
   className,
 }: ErDictionaryFilteredListProps<T>) {
   const [popoverOpen, setPopoverOpen] = useState(false);
+  const [clickedSegmentId, setClickedSegmentId] = useState<string | undefined>();
 
   const handleDomainSelect = useCallback(
     (path: SemanticDomain[]) => {
@@ -50,41 +49,41 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
     [onDomainChange],
   );
 
+  const handleBreadcrumbSegmentClick = (segmentDomainId: string) => {
+    setClickedSegmentId(segmentDomainId);
+    setPopoverOpen(true);
+  };
+
   return (
     <div className={cn('tw-relative tw-flex tw-h-full tw-flex-col tw-overflow-hidden', className)}>
-      {/* "Back to dictionary" button */}
-      {onClose && (
-        <div className="tw-border-b tw-px-2 tw-py-1">
-          <Button variant="ghost" size="sm" className="tw-gap-1" onClick={onClose}>
-            <ArrowUp className="tw-h-4 tw-w-4" />
-            Back to dictionary
-          </Button>
-        </div>
-      )}
-
-      {/* Breadcrumb bar */}
-      <div className="tw-border-b tw-px-2 tw-py-1">
+      {/* Header: breadcrumb button (hugs content) + Close button (right) */}
+      <div className="tw-flex tw-items-center tw-gap-1 tw-border-b tw-px-2 tw-py-1.5">
         <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
           <PopoverTrigger asChild>
-            <button
-              type="button"
-              className="tw-group tw-flex tw-w-full tw-min-w-0 tw-items-center tw-gap-1 tw-overflow-hidden tw-rounded tw-px-1.5 tw-py-1 tw-text-left hover:tw-bg-muted"
-            >
-              <BreadcrumbDisplay path={domainPath} />
-            </button>
+            <div className="tw-min-w-0 tw-flex-1">
+              <BreadcrumbBar path={domainPath} onSegmentClick={handleBreadcrumbSegmentClick} />
+            </div>
           </PopoverTrigger>
           <PopoverContent
             align="start"
-            className="tw-w-[var(--radix-popover-trigger-width)] tw-p-0"
+            className="tw-w-[min(var(--radix-popover-trigger-width),400px)] tw-p-0"
             style={{ zIndex: Z_INDEX_MODAL + 10 }}
           >
             <DomainSearchTree
               domains={allDomains}
               currentPath={domainPath}
+              expandToId={clickedSegmentId}
               onSelect={handleDomainSelect}
             />
           </PopoverContent>
         </Popover>
+
+        {onClose && (
+          <Button variant="ghost" size="sm" className="tw-shrink-0 tw-gap-1" onClick={onClose}>
+            <X className="tw-h-4 tw-w-4" />
+            Close
+          </Button>
+        )}
       </div>
 
       {/* Dictionary list */}
@@ -107,146 +106,217 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
 }
 
 // ---------------------------------------------------------------------------
-// Breadcrumb display: left-aligned, stable ellipsis (no flicker), last bold
+// BreadcrumbBar: flicker-free dynamic collapse, individual segment hover
 // ---------------------------------------------------------------------------
 
 /**
- * Renders the breadcrumb path. Uses a hidden measurement pass to determine how many trailing
- * segments fit before the component mounts visually, avoiding flicker. The root segment is always
- * shown; intermediate ones collapse into an ellipsis (`...`) when the container is too narrow.
+ * Renders the breadcrumb path as a button that hugs its content. Segments collapse dynamically via
+ * CSS `overflow: hidden` and a `ResizeObserver` that checks a hidden measurement row. Collapse
+ * order: hide the 2nd-left segment first, then 3rd, etc., until only `root > ... > leaf`. If still
+ * too wide, also hide root, showing `... > leaf`.
+ *
+ * Each segment has its own hover underline (not all segments at once).
  */
-function BreadcrumbDisplay({ path }: { path: SemanticDomain[] }) {
+function BreadcrumbBar({
+  path,
+  onSegmentClick,
+}: {
+  path: SemanticDomain[];
+  onSegmentClick: (domainId: string) => void;
+}) {
   // eslint-disable-next-line no-null/no-null
-  const containerRef = useRef<HTMLDivElement>(null);
+  const outerRef = useRef<HTMLDivElement>(null);
   // eslint-disable-next-line no-null/no-null
-  const measureRef = useRef<HTMLDivElement>(null);
-  const [visibleFromEnd, setVisibleFromEnd] = useState(path.length);
+  const fullRef = useRef<HTMLDivElement>(null);
 
-  // Measure once after layout, synchronously before paint, to avoid flicker
-  useLayoutEffect(() => {
-    const container = containerRef.current;
-    const measure = measureRef.current;
-    if (!container || !measure) return;
+  // Number of segments to hide, starting from the 2nd item (index 1).
+  // 0 = show all, 1 = hide index 1, 2 = hide index 1+2, ...
+  // If hideCount >= path.length - 1, we also hide root (show only "... > leaf").
+  const [hideCount, setHideCount] = useState(0);
 
-    const availableWidth = container.clientWidth;
+  useEffect(() => {
+    const outer = outerRef.current;
+    const full = fullRef.current;
+    if (!outer || !full) return undefined;
 
-    // measureRef contains all segments rendered invisibly. We measure from the right:
-    // always keep the root, then try adding trailing segments + ellipsis until it overflows.
-    const segments = Array.from(measure.children) as HTMLElement[];
-    if (segments.length === 0) return;
+    const measure = () => {
+      // Measure the full (unhidden) breadcrumb width vs available width
+      const available = outer.clientWidth;
+      const fullWidth = full.scrollWidth;
 
-    // Full width of all segments
-    let totalWidth = 0;
-    for (const seg of segments) totalWidth += seg.scrollWidth;
+      if (fullWidth <= available) {
+        setHideCount(0);
+        return;
+      }
 
-    if (totalWidth <= availableWidth) {
-      setVisibleFromEnd(path.length);
-      return;
-    }
+      // Measure individual segment widths from the hidden row
+      const segEls = Array.from(full.children) as HTMLElement[];
+      const widths = segEls.map((el) => el.offsetWidth);
+      const totalSegments = path.length;
 
-    // Root width + ellipsis (approx 32px for chevron+dots)
-    const rootWidth = segments[0].scrollWidth;
-    const ellipsisWidth = 32;
-    let budget = availableWidth - rootWidth - ellipsisWidth;
-    let count = 0;
+      // Try hiding 1, 2, 3, ... segments from index 1 (keeping root + ellipsis + trailing)
+      // Ellipsis takes roughly the width of ChevronRight + MoreHorizontal icons
+      const ellipsisWidth = 40;
 
-    // Count from the end how many fit
-    for (let i = segments.length - 1; i >= 1 && budget > 0; i -= 1) {
-      const segWidth = segments[i].scrollWidth;
-      if (segWidth > budget) break;
-      budget -= segWidth;
-      count += 1;
-    }
+      for (let h = 1; h < totalSegments; h += 1) {
+        // Visible segments: root (index 0) + segments after the hidden range + ellipsis
+        // Hidden range: indices 1..h
+        let visibleWidth = ellipsisWidth;
 
-    setVisibleFromEnd(Math.max(1, count) + 1); // +1 for root
+        // Include root if h < totalSegments - 1 (i.e., we haven't hidden everything except leaf)
+        if (h < totalSegments - 1) {
+          visibleWidth += widths[0] ?? 0;
+        }
+
+        // Include trailing segments (from index h+1 to end)
+        for (let j = h + 1; j < totalSegments; j += 1) {
+          visibleWidth += widths[j] ?? 0;
+        }
+
+        // Always include the last segment (even if h reaches totalSegments - 1)
+        if (h >= totalSegments - 1) {
+          visibleWidth += widths[totalSegments - 1] ?? 0;
+        }
+
+        if (visibleWidth <= available) {
+          setHideCount(h);
+          return;
+        }
+      }
+
+      // Everything hidden except leaf
+      setHideCount(totalSegments - 1);
+    };
+
+    const observer = new ResizeObserver(measure);
+    observer.observe(outer);
+    measure();
+    return () => observer.disconnect();
   }, [path]);
 
-  // Also re-measure on resize
-  useEffect(() => {
-    const container = containerRef.current;
-    if (!container) return undefined;
-    const observer = new ResizeObserver(() => {
-      // Re-run the layout effect by triggering a state update with the full count,
-      // then the layout effect will correct it synchronously before paint
-      setVisibleFromEnd(path.length);
-    });
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, [path.length]);
-
-  const showEllipsis = visibleFromEnd < path.length;
-  const rootItem = path[0];
-  const trailingItems = showEllipsis ? path.slice(-(visibleFromEnd - 1)) : path.slice(1);
+  const showEllipsis = hideCount > 0;
+  const hideRoot = hideCount >= path.length - 1;
 
   return (
-    <>
-      {/* Hidden measurement div: renders all segments invisibly to measure their widths */}
+    <div ref={outerRef} className="tw-overflow-hidden">
+      {/* Hidden measurement row (same content, no hiding, invisible) */}
       <div
-        ref={measureRef}
+        ref={fullRef}
         className="tw-pointer-events-none tw-invisible tw-absolute tw-flex tw-items-center tw-gap-0.5 tw-whitespace-nowrap"
         aria-hidden
       >
-        {path.map((domain, idx) => (
-          <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
-            {idx > 0 && <ChevronRight className="tw-h-3 tw-w-3" />}
-            <span className="tw-text-sm">{domain.label}</span>
+        {path.map((d, i) => (
+          <span key={d.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
+            {i > 0 && <ChevronRight className="tw-h-3 tw-w-3" />}
+            <span className="tw-text-sm">{d.label}</span>
           </span>
         ))}
       </div>
 
-      {/* Visible breadcrumbs */}
-      <div ref={containerRef} className="tw-flex tw-items-center tw-gap-0.5 tw-overflow-hidden">
-        {rootItem && (
-          <span className="tw-shrink-0 tw-text-sm group-hover:tw-underline">{rootItem.label}</span>
+      {/* Visible breadcrumbs (inline, hugging content) */}
+      <button
+        type="button"
+        className="tw-inline-flex tw-items-center tw-gap-0.5 tw-rounded tw-px-1.5 tw-py-1 tw-text-left hover:tw-bg-muted"
+        onClick={(e) => {
+          // If the click was on a specific segment span, that handler fires first.
+          // This is the fallback for clicking the button padding.
+          const lastDomain = path[path.length - 1];
+          if (lastDomain) onSegmentClick(lastDomain.id);
+          e.stopPropagation();
+        }}
+      >
+        {/* Root segment */}
+        {!hideRoot && path[0] && (
+          <span
+            className="tw-shrink-0 tw-cursor-pointer tw-text-sm hover:tw-underline"
+            onClick={(e) => {
+              e.stopPropagation();
+              onSegmentClick(path[0].id);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.stopPropagation();
+                onSegmentClick(path[0].id);
+              }
+            }}
+            role="button"
+            tabIndex={0}
+          >
+            {path[0].label}
+          </span>
         )}
+
+        {/* Ellipsis */}
         {showEllipsis && (
           <>
             <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
             <MoreHorizontal className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
           </>
         )}
-        {trailingItems.map((domain, idx) => {
-          const isLast = idx === trailingItems.length - 1;
+
+        {/* Trailing visible segments */}
+        {path.map((domain, idx) => {
+          // Skip root (handled above) and hidden segments
+          if (idx === 0) return undefined;
+          if (idx <= hideCount) return undefined;
+
+          const isLast = idx === path.length - 1;
           return (
             <span key={domain.id} className="tw-flex tw-shrink-0 tw-items-center tw-gap-0.5">
               <ChevronRight className="tw-h-3 tw-w-3 tw-shrink-0 tw-text-muted-foreground" />
               <span
-                className={cn('tw-text-sm group-hover:tw-underline', {
-                  'tw-font-bold': isLast,
-                })}
+                className={cn(
+                  'tw-cursor-pointer tw-text-sm hover:tw-underline',
+                  isLast && 'tw-font-bold',
+                )}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onSegmentClick(domain.id);
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') {
+                    e.stopPropagation();
+                    onSegmentClick(domain.id);
+                  }
+                }}
+                role="button"
+                tabIndex={0}
               >
                 {domain.label}
               </span>
             </span>
           );
         })}
-      </div>
-    </>
+      </button>
+    </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Domain search tree
+// Domain search tree: filterable, expands to clicked segment
 // ---------------------------------------------------------------------------
 
 function DomainSearchTree({
   domains,
   currentPath,
+  expandToId,
   onSelect,
 }: {
   domains: SemanticDomain[];
   currentPath: SemanticDomain[];
+  expandToId?: string;
   onSelect: (path: SemanticDomain[]) => void;
 }) {
   const [filter, setFilter] = useState('');
   // eslint-disable-next-line no-null/no-null
-  const selectedRef = useRef<HTMLButtonElement>(null);
+  const scrollTargetRef = useRef<HTMLButtonElement>(null);
 
+  // Scroll to the expand-target on mount
   useEffect(() => {
     requestAnimationFrame(() => {
-      selectedRef.current?.scrollIntoView({ block: 'center' });
+      scrollTargetRef.current?.scrollIntoView({ block: 'center' });
     });
-  }, []);
+  }, [expandToId]);
 
   const filterLower = filter.toLowerCase();
 
@@ -257,23 +327,28 @@ function DomainSearchTree({
           placeholder="Search domains..."
           value={filter}
           onChange={(e) => setFilter(e.target.value)}
-          className="tw-h-8 tw-text-sm"
+          className="tw-h-8 tw-w-full tw-text-sm"
           autoFocus
         />
       </div>
       <div className="tw-flex-1 tw-overflow-y-auto tw-p-1">
-        <FilterableTreeNodes
+        <TreeNodeList
           domains={domains}
           currentPath={currentPath}
+          expandToId={expandToId}
           onSelect={onSelect}
           parentPath={[]}
           filter={filterLower}
-          selectedRef={selectedRef}
+          scrollTargetRef={scrollTargetRef}
         />
       </div>
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Tree rendering helpers
+// ---------------------------------------------------------------------------
 
 function domainMatchesFilter(domain: SemanticDomain, filter: string): boolean {
   if (domain.label.toLowerCase().includes(filter)) return true;
@@ -295,20 +370,28 @@ function HighlightLabel({ label, filter }: { label: string; filter: string }) {
   );
 }
 
-function FilterableTreeNodes({
+/** Check if a domain or any ancestor/descendant has the given id */
+function isAncestorOf(domain: SemanticDomain, targetId: string): boolean {
+  if (domain.id === targetId) return true;
+  return domain.children?.some((child) => isAncestorOf(child, targetId)) ?? false;
+}
+
+function TreeNodeList({
   domains,
   currentPath,
+  expandToId,
   onSelect,
   parentPath,
   filter,
-  selectedRef,
+  scrollTargetRef,
 }: {
   domains: SemanticDomain[];
   currentPath: SemanticDomain[];
+  expandToId?: string;
   onSelect: (path: SemanticDomain[]) => void;
   parentPath: SemanticDomain[];
   filter: string;
-  selectedRef: React.RefObject<HTMLButtonElement>;
+  scrollTargetRef: React.RefObject<HTMLButtonElement>;
 }) {
   return (
     <ul className={cn('tw-space-y-0.5', { 'tw-ml-3': parentPath.length > 0 })}>
@@ -316,24 +399,30 @@ function FilterableTreeNodes({
         if (filter && !domainMatchesFilter(domain, filter)) return undefined;
 
         const thisPath = [...parentPath, domain];
-        const isInCurrentPath = currentPath.some((d) => d.id === domain.id);
         const isSelected =
           currentPath.length > 0 && currentPath[currentPath.length - 1].id === domain.id;
         const hasChildren = domain.children && domain.children.length > 0;
-        const shouldExpand = !!filter || isInCurrentPath;
+        // Expand if: filtering, on current path, or contains the expand target
+        const isOnCurrentPath = currentPath.some((d) => d.id === domain.id);
+        const containsTarget = expandToId ? isAncestorOf(domain, expandToId) : false;
+        const shouldStartExpanded = !!filter || isOnCurrentPath || containsTarget;
+        // Scroll target: the domain matching expandToId
+        const isScrollTarget = domain.id === expandToId;
 
         return (
-          <FilterableTreeNode
+          <TreeNode
             key={domain.id}
             domain={domain}
             thisPath={thisPath}
             isSelected={isSelected}
             hasChildren={hasChildren ?? false}
-            defaultExpanded={shouldExpand}
+            defaultExpanded={shouldStartExpanded}
             currentPath={currentPath}
+            expandToId={expandToId}
             onSelect={onSelect}
             filter={filter}
-            selectedRef={selectedRef}
+            scrollTargetRef={scrollTargetRef}
+            isScrollTarget={isScrollTarget}
           />
         );
       })}
@@ -341,16 +430,18 @@ function FilterableTreeNodes({
   );
 }
 
-function FilterableTreeNode({
+function TreeNode({
   domain,
   thisPath,
   isSelected,
   hasChildren,
   defaultExpanded,
   currentPath,
+  expandToId,
   onSelect,
   filter,
-  selectedRef,
+  scrollTargetRef,
+  isScrollTarget,
 }: {
   domain: SemanticDomain;
   thisPath: SemanticDomain[];
@@ -358,9 +449,11 @@ function FilterableTreeNode({
   hasChildren: boolean;
   defaultExpanded: boolean;
   currentPath: SemanticDomain[];
+  expandToId?: string;
   onSelect: (path: SemanticDomain[]) => void;
   filter: string;
-  selectedRef: React.RefObject<HTMLButtonElement>;
+  scrollTargetRef: React.RefObject<HTMLButtonElement>;
+  isScrollTarget: boolean;
 }) {
   const [expanded, setExpanded] = useState(defaultExpanded);
 
@@ -388,7 +481,7 @@ function FilterableTreeNode({
         )}
         <button
           type="button"
-          ref={isSelected ? selectedRef : undefined}
+          ref={isScrollTarget ? scrollTargetRef : undefined}
           className={cn(
             'tw-flex-1 tw-rounded tw-px-1.5 tw-py-0.5 tw-text-left tw-text-sm',
             isSelected ? 'tw-bg-accent tw-font-medium' : 'hover:tw-bg-muted',
@@ -399,13 +492,14 @@ function FilterableTreeNode({
         </button>
       </div>
       {expanded && hasChildren && (
-        <FilterableTreeNodes
+        <TreeNodeList
           domains={domain.children!}
           currentPath={currentPath}
+          expandToId={expandToId}
           onSelect={onSelect}
           parentPath={thisPath}
           filter={filter}
-          selectedRef={selectedRef}
+          scrollTargetRef={scrollTargetRef}
         />
       )}
     </li>

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -207,7 +207,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
         {selectedItem && renderDetailContent && (
           <div
             className={cn(
-              'tw-overflow-y-auto tw-bg-background tw-p-4',
+              'tw-h-full tw-overflow-y-auto tw-bg-background tw-p-4',
               showFullDetail ? 'tw-w-full' : 'tw-w-2/3',
             )}
           >
@@ -476,20 +476,21 @@ function TreeKeyboardContainer({
 
   useEffect(() => {
     const focusTarget = () => {
-      if (scrollRef.current) {
-        scrollRef.current.scrollIntoView({ block: 'center' });
-        scrollRef.current.focus();
-      }
+      if (!scrollRef.current) return;
+      if (document.activeElement === scrollRef.current) return;
+      scrollRef.current.scrollIntoView({ block: 'center' });
+      scrollRef.current.focus();
     };
-    // rAF to run after initial paint
+    // Multiple staggered attempts to win the race against Radix's
+    // RovingFocusGroup, which re-focuses the first menu item asynchronously.
+    // A single rAF isn't enough on subsequent opens when focus was previously
+    // on another SegmentDropdown's trigger.
     const rafId = requestAnimationFrame(focusTarget);
-    // Fallback to override Radix's RovingFocusGroup, which re-focuses the first
-    // item asynchronously after our rAF when focus was previously on an element
-    // outside the dropdown (e.g. the detail panel's Back button).
-    const timeoutId = window.setTimeout(focusTarget, 50);
+    const delays = [0, 50, 120, 220];
+    const timeoutIds = delays.map((delay) => window.setTimeout(focusTarget, delay));
     return () => {
       cancelAnimationFrame(rafId);
-      window.clearTimeout(timeoutId);
+      timeoutIds.forEach((id) => window.clearTimeout(id));
     };
   }, [expandToId]);
 
@@ -513,21 +514,30 @@ function TreeKeyboardContainer({
       case 'ArrowDown':
         e.preventDefault();
         e.stopPropagation();
+        e.nativeEvent.stopImmediatePropagation();
         moveFocus(1);
         break;
       case 'ArrowUp':
         e.preventDefault();
         e.stopPropagation();
+        e.nativeEvent.stopImmediatePropagation();
         moveFocus(-1);
         break;
       case 'Tab':
+        // Stop native propagation so the surrounding drawer/dialog can't also
+        // process this keystroke (would otherwise move focus outside the
+        // dropdown or close the surrounding layer).
         e.preventDefault();
         e.stopPropagation();
+        e.nativeEvent.stopImmediatePropagation();
         moveFocus(e.shiftKey ? -1 : 1);
         break;
       case 'Escape':
+        // Same reasoning as Tab: prevent the ESC from bubbling out of the
+        // dropdown to document-level dismiss listeners on the drawer.
         e.preventDefault();
         e.stopPropagation();
+        e.nativeEvent.stopImmediatePropagation();
         onClose();
         break;
       default:

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -80,19 +80,33 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
     [onItemClick, selectedId],
   );
 
-  // List keyboard: arrow keys navigate, behavior depends on narrow/wide
+  // List keyboard: arrow keys navigate, behavior depends on narrow/wide.
+  // First keypress starts from the selected item (or first/last if none selected).
   const handleListKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (items.length === 0) return;
+      const selectedIdx = selectedId ? items.findIndex((i) => i.id === selectedId) : -1;
 
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        const next = Math.min(focusedIndex + 1, items.length - 1);
+        let next: number;
+        if (focusedIndex < 0) {
+          // First press: start at selected item, or first item
+          next = selectedIdx >= 0 ? Math.min(selectedIdx + 1, items.length - 1) : 0;
+        } else {
+          next = Math.min(focusedIndex + 1, items.length - 1);
+        }
         setFocusedIndex(next);
         if (!narrow) selectItem(items[next]);
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        const prev = Math.max(focusedIndex - 1, 0);
+        let prev: number;
+        if (focusedIndex < 0) {
+          // First press: start at selected item, or last item
+          prev = selectedIdx >= 0 ? Math.max(selectedIdx - 1, 0) : items.length - 1;
+        } else {
+          prev = Math.max(focusedIndex - 1, 0);
+        }
         setFocusedIndex(prev);
         if (!narrow) selectItem(items[prev]);
       } else if ((e.key === 'Enter' || e.key === ' ') && narrow && focusedIndex >= 0) {
@@ -100,7 +114,7 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
         selectItem(items[focusedIndex]);
       }
     },
-    [items, focusedIndex, narrow, selectItem],
+    [items, focusedIndex, narrow, selectItem, selectedId],
   );
 
   // Scroll focused item into view

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component.tsx
@@ -205,7 +205,11 @@ export default function ErDictionaryFilteredList<T extends IndexedListItem>({
 
       {/* Domain tree Drawer - scoped to this component's bounding box */}
       <Drawer direction="right" modal={false} open={treeOpen} onOpenChange={setTreeOpen}>
-        <DrawerContent container={containerRef.current} hideDrawerHandle className="tw-max-w-full">
+        <DrawerContent
+          container={containerRef.current}
+          hideDrawerHandle
+          className="tw-ml-0 tw-w-4/5 tw-max-w-none tw-rounded-none"
+        >
           <div className="tw-flex tw-h-full tw-flex-col">
             <div className="tw-flex tw-items-center tw-justify-between tw-border-b tw-px-3 tw-py-2">
               <DrawerTitle className="tw-text-sm tw-font-semibold">Semantic Domains</DrawerTitle>

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-dictionary-list.component.tsx
@@ -1,0 +1,116 @@
+import { cn } from '@/utils/shadcn-ui.util';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/shadcn-ui/tooltip';
+import { Separator } from '@/components/shadcn-ui/separator';
+import SourceLanguageIndexedList from './source-language-indexed-list.component';
+import type { ErDictionaryListProps, IndexedListItem } from './source-language-indexed-list.types';
+
+/**
+ * ER Dictionary list component. Wraps SourceLanguageIndexedList with dictionary-specific rendering
+ * showing both columns (resource term + source language term), occurrence count badges, gloss
+ * descriptions, and Strong's code badges.
+ *
+ * @example
+ *
+ * ```tsx
+ * <ErDictionaryList
+ *   items={dictionaryItems}
+ *   onItemClick={handleSelect}
+ *   showSourceLanguage
+ *   showTransliteration
+ *   getDescription={(item) => item.glosses}
+ *   getBadges={(item) => item.strongsCodes}
+ *   getOccurrenceCount={(item) => item.count}
+ * />;
+ * ```
+ */
+export default function ErDictionaryList<T extends IndexedListItem>({
+  getDescription,
+  getBadges,
+  getOccurrenceCount,
+  showSourceLanguage = true,
+  showTransliteration = true,
+  ...listProps
+}: ErDictionaryListProps<T>) {
+  return (
+    <SourceLanguageIndexedList
+      {...listProps}
+      showSourceLanguage={showSourceLanguage}
+      showTransliteration={showTransliteration}
+      renderItem={(item) => (
+        <ErDictionaryListItemContent
+          item={item}
+          showSourceLanguage={showSourceLanguage}
+          showTransliteration={showTransliteration}
+          description={getDescription?.(item)}
+          badges={getBadges?.(item)}
+          occurrenceCount={getOccurrenceCount?.(item)}
+        />
+      )}
+    />
+  );
+}
+
+function ErDictionaryListItemContent<T extends IndexedListItem>({
+  item,
+  showSourceLanguage,
+  showTransliteration,
+  description,
+  badges,
+  occurrenceCount,
+}: {
+  item: T;
+  showSourceLanguage: boolean;
+  showTransliteration: boolean;
+  description?: string;
+  badges?: string[];
+  occurrenceCount?: number;
+}) {
+  return (
+    <div className="tw-flex tw-w-full tw-flex-col tw-gap-0.5">
+      <div className="tw-flex tw-items-baseline tw-gap-2">
+        <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
+        {showSourceLanguage && item.sourceLanguageText && (
+          <span className="tw-text-sm tw-text-muted-foreground">
+            {item.sourceLanguageText}
+            {showTransliteration && item.transliteration && (
+              <span className="tw-ml-1">({item.transliteration})</span>
+            )}
+          </span>
+        )}
+        {occurrenceCount !== undefined && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="tw-ml-1 tw-cursor-help tw-rounded tw-bg-accent tw-px-1.5 tw-py-0.5 tw-text-xs">
+                  {occurrenceCount}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Occurrences</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </div>
+      <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden">
+        {description && (
+          <p className="tw-truncate tw-text-sm tw-text-muted-foreground">{description}</p>
+        )}
+        {badges?.map((badge) => (
+          <span
+            key={badge}
+            className={cn('tw-shrink-0 tw-rounded tw-bg-accent tw-px-1.5 tw-py-0.5 tw-text-xs')}
+          >
+            {badge}
+          </span>
+        ))}
+      </div>
+      <Separator className="tw-mt-1" />
+    </div>
+  );
+}

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-encyclopedia-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-encyclopedia-list.component.tsx
@@ -1,0 +1,53 @@
+import { Separator } from '@/components/shadcn-ui/separator';
+import SourceLanguageIndexedList from './source-language-indexed-list.component';
+import type {
+  EncyclopediaTeaser,
+  ErEncyclopediaListProps,
+} from './source-language-indexed-list.types';
+
+/**
+ * ER Encyclopedia list component. Wraps SourceLanguageIndexedList with encyclopedia-specific
+ * rendering showing article titles with teaser/summary text and source language terms.
+ *
+ * @example
+ *
+ * ```tsx
+ * <ErEncyclopediaList
+ *   items={encyclopediaItems}
+ *   onItemClick={handleSelect}
+ *   showSourceLanguage
+ * />;
+ * ```
+ */
+export default function ErEncyclopediaList<T extends EncyclopediaTeaser>({
+  showSourceLanguage = true,
+  showTransliteration = true,
+  ...listProps
+}: ErEncyclopediaListProps<T>) {
+  return (
+    <SourceLanguageIndexedList
+      {...listProps}
+      showSourceLanguage={showSourceLanguage}
+      showTransliteration={showTransliteration}
+      renderItem={(item) => (
+        <div className="tw-flex tw-w-full tw-flex-col tw-gap-0.5">
+          <div className="tw-flex tw-items-baseline tw-gap-2">
+            <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
+            {showSourceLanguage && item.sourceLanguageText && (
+              <span className="tw-text-sm tw-text-muted-foreground">
+                {item.sourceLanguageText}
+                {showTransliteration && item.transliteration && (
+                  <span className="tw-ml-1">({item.transliteration})</span>
+                )}
+              </span>
+            )}
+          </div>
+          {item.teaserText && (
+            <p className="tw-line-clamp-2 tw-text-xs tw-text-muted-foreground">{item.teaserText}</p>
+          )}
+          <Separator className="tw-mt-1" />
+        </div>
+      )}
+    />
+  );
+}

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-media-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/er-media-list.component.tsx
@@ -1,0 +1,67 @@
+import { Badge } from '@/components/shadcn-ui/badge';
+import { Separator } from '@/components/shadcn-ui/separator';
+import SourceLanguageIndexedList from './source-language-indexed-list.component';
+import type { ErMediaListProps, MediaItem } from './source-language-indexed-list.types';
+
+/**
+ * ER Media list component (images and maps). Wraps SourceLanguageIndexedList with the thumbnail
+ * variant, showing image previews alongside item titles, captions, and media type badges.
+ *
+ * @example
+ *
+ * ```tsx
+ * <ErMediaList items={mediaItems} onItemClick={handleSelect} showSourceLanguage />;
+ * ```
+ */
+export default function ErMediaList<T extends MediaItem>({
+  showSourceLanguage = true,
+  showTransliteration = false,
+  ...listProps
+}: ErMediaListProps<T>) {
+  return (
+    <SourceLanguageIndexedList
+      {...listProps}
+      variant="thumbnail"
+      showSourceLanguage={showSourceLanguage}
+      showTransliteration={showTransliteration}
+      renderItem={(item) => (
+        <div className="tw-flex tw-w-full tw-items-center tw-gap-3">
+          {item.thumbnailUrl && (
+            <img
+              src={item.thumbnailUrl}
+              alt={item.thumbnailAlt ?? item.primaryText}
+              className="tw-h-14 tw-w-14 tw-shrink-0 tw-rounded tw-object-cover"
+            />
+          )}
+          {!item.thumbnailUrl && (
+            <div className="tw-flex tw-h-14 tw-w-14 tw-shrink-0 tw-items-center tw-justify-center tw-rounded tw-bg-muted">
+              <span className="tw-text-xs tw-text-muted-foreground">
+                {item.mediaType === 'map' ? 'Map' : 'Img'}
+              </span>
+            </div>
+          )}
+          <div className="tw-flex tw-flex-1 tw-flex-col tw-gap-0.5 tw-overflow-hidden">
+            <div className="tw-flex tw-items-baseline tw-gap-2">
+              <span className="tw-truncate tw-text-sm tw-font-medium">{item.primaryText}</span>
+              <Badge variant="outline" className="tw-shrink-0 tw-text-xs">
+                {item.mediaType}
+              </Badge>
+            </div>
+            {showSourceLanguage && item.sourceLanguageText && (
+              <span className="tw-truncate tw-text-xs tw-text-muted-foreground">
+                {item.sourceLanguageText}
+                {showTransliteration && item.transliteration && (
+                  <span className="tw-ml-1">({item.transliteration})</span>
+                )}
+              </span>
+            )}
+            {item.caption && (
+              <p className="tw-truncate tw-text-xs tw-text-muted-foreground">{item.caption}</p>
+            )}
+          </div>
+          <Separator className="tw-absolute tw-bottom-0 tw-left-0 tw-right-0" />
+        </div>
+      )}
+    />
+  );
+}

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/lexical-dictionary-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/lexical-dictionary-list.component.tsx
@@ -1,0 +1,162 @@
+import { RefObject, useMemo } from 'react';
+import { cn } from '@/utils/shadcn-ui.util';
+import { useListbox, type ListboxOption } from '@/hooks/listbox-keyboard-navigation.hook';
+import { Separator } from '@/components/shadcn-ui/separator';
+import { Skeleton } from '@/components/shadcn-ui/skeleton';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/shadcn-ui/tooltip';
+import type {
+  LexicalDictionaryEntry,
+  LexicalDictionaryListProps,
+} from './source-language-indexed-list.types';
+
+/**
+ * Lexical Dictionary list component. Extracted from platform-lexical-tools extension dictionary
+ * list pattern. Displays dictionary entries with lemma, occurrence count badge, formatted glosses,
+ * and Strong's code badges. Uses keyboard navigation via `useListbox`.
+ *
+ * This is the shared version of
+ * `extensions/src/platform-lexical-tools/src/components/dictionary/dictionary-list-item.component.tsx`
+ * moved to platform-bible-react so it can be reused by both lexical tools and enhanced resources.
+ *
+ * @example
+ *
+ * ```tsx
+ * <LexicalDictionaryList
+ *   items={entries}
+ *   onItemClick={handleSelect}
+ *   selectedItemId={selectedId}
+ *   occurrenceCountLabel="Occurrences in chapter"
+ *   strongsCodeLabel="Strong's code"
+ * />;
+ * ```
+ */
+export default function LexicalDictionaryList<T extends LexicalDictionaryEntry>({
+  items,
+  onItemClick,
+  selectedItemId,
+  emptyStateMessage = 'No entries found',
+  isLoading = false,
+  onCharacterPress,
+  className,
+  occurrenceCountLabel = 'Occurrences',
+  strongsCodeLabel = "Strong's code",
+}: LexicalDictionaryListProps<T>) {
+  const options: ListboxOption[] = useMemo(() => items.map((item) => ({ id: item.id })), [items]);
+
+  const handleOptionSelect = (option: ListboxOption) => {
+    const clickedItem = items.find((item) => item.id === option.id);
+    if (clickedItem) onItemClick?.(clickedItem);
+  };
+
+  const { listboxRef, activeId, handleKeyDown } = useListbox({
+    options,
+    onOptionSelect: handleOptionSelect,
+    onCharacterPress,
+  });
+
+  if (isLoading) {
+    return (
+      <div className={cn('tw-flex tw-flex-col tw-gap-2 tw-p-2', className)}>
+        {Array.from({ length: 6 }, (_, i) => (
+          <Skeleton
+            // Loading skeleton placeholders don't have meaningful keys
+            // eslint-disable-next-line react/no-array-index-key
+            key={i}
+            className="tw-h-12 tw-w-full tw-rounded"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div
+        className={cn(
+          'tw-flex tw-items-center tw-justify-center tw-p-8 tw-text-sm tw-text-muted-foreground',
+          className,
+        )}
+      >
+        {emptyStateMessage}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('tw-overflow-y-auto tw-px-2 tw-py-2', className)}>
+      <ul
+        role="listbox"
+        tabIndex={0}
+        // useListbox returns a generic HTMLElement ref for flexibility across element types
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        ref={listboxRef as RefObject<HTMLUListElement>}
+        aria-activedescendant={activeId ?? undefined}
+        className="tw-outline-none focus:tw-ring-2 focus:tw-ring-ring focus:tw-ring-offset-1 focus:tw-ring-offset-background"
+        onKeyDown={handleKeyDown}
+      >
+        {items.map((entry) => {
+          const isSelected = selectedItemId === entry.id;
+          return (
+            <div key={entry.id}>
+              {/* Keyboard navigation is handled by the useListbox hook on the parent ul */}
+              {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
+              <li
+                role="option"
+                aria-selected={isSelected}
+                id={entry.id}
+                onClick={() => onItemClick?.(entry)}
+                className={cn(
+                  'tw-flex tw-flex-col tw-p-2 tw-outline-none focus:tw-ring-2 focus:tw-ring-ring focus:tw-ring-offset-1 focus:tw-ring-offset-background',
+                  {
+                    'tw-bg-muted': isSelected,
+                    'hover:tw-bg-muted': !isSelected,
+                  },
+                )}
+                tabIndex={-1}
+              >
+                <div className="tw-flex tw-items-baseline tw-gap-2">
+                  <span className="scripture-font tw-text-sm">{entry.primaryText}</span>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="tw-ml-1 tw-cursor-help tw-rounded tw-bg-accent tw-px-1.5 tw-py-0.5 tw-text-xs">
+                          {entry.occurrenceCount}
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        <p>{occurrenceCountLabel}</p>
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                </div>
+                <div className="tw-mt-0.5 tw-flex tw-items-center tw-gap-2 tw-overflow-hidden">
+                  <p className="tw-truncate tw-text-sm tw-text-muted-foreground">{entry.glosses}</p>
+                  {entry.strongsCodes.map((strongsCode) => (
+                    <TooltipProvider key={strongsCode}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span className="tw-ml-1 tw-shrink-0 tw-cursor-help tw-rounded tw-bg-accent tw-px-1.5 tw-py-0.5 tw-text-xs">
+                            {strongsCode}
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>{strongsCodeLabel}</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  ))}
+                </div>
+              </li>
+              <Separator />
+            </div>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
@@ -1,8 +1,9 @@
-import { RefObject, useMemo } from 'react';
+import { RefObject, useMemo, useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { useListbox, type ListboxOption } from '@/hooks/listbox-keyboard-navigation.hook';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Skeleton } from '@/components/shadcn-ui/skeleton';
+import { Drawer, DrawerContent, DrawerTrigger } from '@/components/shadcn-ui/drawer';
 import type {
   IndexedListItem,
   SourceLanguageIndexedListProps,
@@ -10,8 +11,12 @@ import type {
 
 /**
  * A shared list component for displaying source-language indexed items. Supports two-column layout
- * (resource term + source language term), keyboard navigation, text and thumbnail variants, and
- * loading/empty states.
+ * (resource term + source language term), keyboard navigation, text and thumbnail variants,
+ * loading/empty states, and an optional right-side detail drawer.
+ *
+ * When `renderDetailContent` is provided, clicking an item opens a right-side drawer with the
+ * detail content (extracted from the lexical dictionary extension pattern). When not provided,
+ * clicking an item just fires `onItemClick`.
  *
  * Used by Enhanced Resources (dictionary, encyclopedia, media) and lexical tools (dictionary).
  *
@@ -24,14 +29,18 @@ import type {
  *   selectedItemId={selectedId}
  *   showSourceLanguage
  *   showTransliteration
+ *   renderDetailContent={(item, onClose) => (
+ *     <DictionaryEntryDetail entry={item} onBack={onClose} />
+ *   )}
  * />;
  * ```
  */
 export default function SourceLanguageIndexedList<T extends IndexedListItem>({
   items,
   renderItem,
+  renderDetailContent,
   onItemClick,
-  selectedItemId,
+  selectedItemId: controlledSelectedId,
   emptyStateMessage = 'No items found',
   isLoading = false,
   variant = 'text',
@@ -40,11 +49,32 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
   onCharacterPress,
   className,
 }: SourceLanguageIndexedListProps<T>) {
+  const [drawerItemId, setDrawerItemId] = useState<string | undefined>();
+
+  // Use controlled selection if provided, otherwise use internal drawer state
+  const effectiveSelectedId = controlledSelectedId ?? drawerItemId;
+
+  const drawerItem = useMemo(
+    () => (drawerItemId ? items.find((item) => item.id === drawerItemId) : undefined),
+    [drawerItemId, items],
+  );
+
   const options: ListboxOption[] = useMemo(() => items.map((item) => ({ id: item.id })), [items]);
+
+  const handleItemSelect = (item: T) => {
+    onItemClick?.(item);
+    if (renderDetailContent) {
+      setDrawerItemId(item.id === drawerItemId ? undefined : item.id);
+    }
+  };
 
   const handleOptionSelect = (option: ListboxOption) => {
     const clickedItem = items.find((item) => item.id === option.id);
-    if (clickedItem) onItemClick?.(clickedItem);
+    if (clickedItem) handleItemSelect(clickedItem);
+  };
+
+  const handleCloseDrawer = () => {
+    setDrawerItemId(undefined);
   };
 
   const { listboxRef, activeId, handleKeyDown } = useListbox({
@@ -83,7 +113,7 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
     );
   }
 
-  return (
+  const listContent = (
     <div className={cn('tw-overflow-y-auto', className)}>
       <ul
         role="listbox"
@@ -96,7 +126,7 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
         onKeyDown={handleKeyDown}
       >
         {items.map((item) => {
-          const isSelected = selectedItemId === item.id;
+          const isSelected = effectiveSelectedId === item.id;
           return (
             <li
               key={item.id}
@@ -104,11 +134,11 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
               role="option"
               aria-selected={isSelected}
               tabIndex={-1}
-              onClick={() => onItemClick?.(item)}
+              onClick={() => handleItemSelect(item)}
               onKeyDown={(e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                   e.preventDefault();
-                  onItemClick?.(item);
+                  handleItemSelect(item);
                 }
               }}
               className={cn(
@@ -134,6 +164,27 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
         })}
       </ul>
     </div>
+  );
+
+  // If no detail content renderer, render just the list
+  if (!renderDetailContent) return listContent;
+
+  // With detail content: wrap in a Drawer that opens from the right
+  return (
+    <Drawer
+      direction="right"
+      open={drawerItem !== undefined}
+      onOpenChange={(open) => {
+        if (!open) handleCloseDrawer();
+      }}
+    >
+      <DrawerTrigger asChild>{listContent}</DrawerTrigger>
+      <DrawerContent hideDrawerHandle className="tw-max-w-xl">
+        <div className="tw-overflow-y-auto tw-p-4">
+          {drawerItem && renderDetailContent(drawerItem, handleCloseDrawer)}
+        </div>
+      </DrawerContent>
+    </Drawer>
   );
 }
 

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
@@ -80,15 +80,24 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
     if (clickedItem) handleItemSelect(clickedItem);
   };
 
-  const handleCloseDetail = () => {
-    setDrawerItemId(undefined);
-  };
-
-  const { listboxRef, activeId, handleKeyDown } = useListbox({
+  const { listboxRef, activeId, handleKeyDown, focusOption } = useListbox({
     options,
     onOptionSelect: handleOptionSelect,
     onCharacterPress,
   });
+
+  // On close, restore focus to the listbox so arrow keys navigate again
+  // starting from the previously-selected item.
+  const handleCloseDetail = () => {
+    const closingId = drawerItemId;
+    setDrawerItemId(undefined);
+    if (closingId) {
+      requestAnimationFrame(() => {
+        focusOption(closingId);
+        listboxRef.current?.focus();
+      });
+    }
+  };
 
   if (isLoading) {
     return (

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
@@ -3,6 +3,7 @@ import { cn } from '@/utils/shadcn-ui.util';
 import { useListbox, type ListboxOption } from '@/hooks/listbox-keyboard-navigation.hook';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Skeleton } from '@/components/shadcn-ui/skeleton';
+import { Drawer, DrawerContent, DrawerTrigger } from '@/components/shadcn-ui/drawer';
 import type {
   IndexedListItem,
   SourceLanguageIndexedListProps,
@@ -11,11 +12,11 @@ import type {
 /**
  * A shared list component for displaying source-language indexed items. Supports two-column layout
  * (resource term + source language term), keyboard navigation, text and thumbnail variants,
- * loading/empty states, and an optional inline detail panel.
+ * loading/empty states, and an optional detail drawer.
  *
- * When `renderDetailContent` is provided, clicking an item slides in a detail panel from the right
- * **within the component's own bounding box** (not a full-page overlay). This pattern is extracted
- * from the lexical dictionary extension's split-pane layout.
+ * When `renderDetailContent` is provided, clicking an item opens a right-side drawer **within the
+ * component's own bounding box** using the Drawer component with a scoped `container` prop. This
+ * pattern is extracted from the lexical dictionary extension's split-pane layout.
  *
  * Used by Enhanced Resources (dictionary, encyclopedia, media) and lexical tools (dictionary).
  *
@@ -51,7 +52,7 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
   const [drawerItemId, setDrawerItemId] = useState<string | undefined>();
   // ref.current expects null not undefined for div ref
   // eslint-disable-next-line no-null/no-null
-  const detailRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   // Use controlled selection if provided, otherwise use internal state
   const effectiveSelectedId = controlledSelectedId ?? drawerItemId;
@@ -66,10 +67,7 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
   const handleItemSelect = (item: T) => {
     onItemClick?.(item);
     if (renderDetailContent) {
-      const newId = item.id === drawerItemId ? undefined : item.id;
-      setDrawerItemId(newId);
-      // Scroll detail panel to top when opening a new entry
-      if (newId) detailRef.current?.scrollTo({ top: 0 });
+      setDrawerItemId(item.id === drawerItemId ? undefined : item.id);
     }
   };
 
@@ -118,76 +116,84 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
     );
   }
 
-  const hasDetail = renderDetailContent && drawerItem;
+  const listContent = (
+    <ul
+      role="listbox"
+      tabIndex={0}
+      // useListbox returns a generic HTMLElement ref for flexibility across element types
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      ref={listboxRef as RefObject<HTMLUListElement>}
+      aria-activedescendant={activeId ?? undefined}
+      className="tw-outline-none focus:tw-ring-2 focus:tw-ring-ring focus:tw-ring-offset-1 focus:tw-ring-offset-background"
+      onKeyDown={handleKeyDown}
+    >
+      {items.map((item) => {
+        const isSelected = effectiveSelectedId === item.id;
+        return (
+          <li
+            key={item.id}
+            id={item.id}
+            role="option"
+            aria-selected={isSelected}
+            tabIndex={-1}
+            onClick={() => handleItemSelect(item)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                handleItemSelect(item);
+              }
+            }}
+            className={cn(
+              'tw-flex tw-cursor-pointer tw-items-center tw-gap-3 tw-p-2 tw-outline-none',
+              {
+                'tw-bg-muted': isSelected,
+                'hover:tw-bg-muted': !isSelected,
+              },
+            )}
+          >
+            {renderItem ? (
+              renderItem(item)
+            ) : (
+              <DefaultListItemContent
+                item={item}
+                variant={variant}
+                showSourceLanguage={showSourceLanguage}
+                showTransliteration={showTransliteration}
+              />
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
 
   return (
-    <div className={cn('tw-relative tw-flex tw-h-full tw-overflow-hidden', className)}>
-      {/* List pane */}
-      <div
-        className={cn('tw-overflow-y-auto tw-transition-all tw-duration-200', {
-          'tw-w-full': !hasDetail,
-          'tw-w-0 tw-min-w-0 tw-overflow-hidden': hasDetail,
-        })}
-      >
-        <ul
-          role="listbox"
-          tabIndex={0}
-          // useListbox returns a generic HTMLElement ref for flexibility across element types
-          // eslint-disable-next-line no-type-assertion/no-type-assertion
-          ref={listboxRef as RefObject<HTMLUListElement>}
-          aria-activedescendant={activeId ?? undefined}
-          className="tw-outline-none focus:tw-ring-2 focus:tw-ring-ring focus:tw-ring-offset-1 focus:tw-ring-offset-background"
-          onKeyDown={handleKeyDown}
-        >
-          {items.map((item) => {
-            const isSelected = effectiveSelectedId === item.id;
-            return (
-              <li
-                key={item.id}
-                id={item.id}
-                role="option"
-                aria-selected={isSelected}
-                tabIndex={-1}
-                onClick={() => handleItemSelect(item)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter' || e.key === ' ') {
-                    e.preventDefault();
-                    handleItemSelect(item);
-                  }
-                }}
-                className={cn(
-                  'tw-flex tw-cursor-pointer tw-items-center tw-gap-3 tw-p-2 tw-outline-none',
-                  {
-                    'tw-bg-muted': isSelected,
-                    'hover:tw-bg-muted': !isSelected,
-                  },
-                )}
-              >
-                {renderItem ? (
-                  renderItem(item)
-                ) : (
-                  <DefaultListItemContent
-                    item={item}
-                    variant={variant}
-                    showSourceLanguage={showSourceLanguage}
-                    showTransliteration={showTransliteration}
-                  />
-                )}
-              </li>
-            );
-          })}
-        </ul>
+    <div ref={containerRef} className={cn('tw-relative tw-h-full tw-overflow-hidden', className)}>
+      <div className="tw-h-full tw-overflow-y-auto">
+        {renderDetailContent ? (
+          <Drawer
+            direction="right"
+            modal={false}
+            open={drawerItem !== undefined}
+            onOpenChange={(open) => {
+              if (!open) handleCloseDetail();
+            }}
+          >
+            <DrawerTrigger asChild>{listContent}</DrawerTrigger>
+            <DrawerContent
+              container={containerRef.current}
+              hideDrawerHandle
+              className="tw-max-w-full"
+            >
+              <div className="tw-h-full tw-overflow-y-auto tw-p-4">
+                {drawerItem && renderDetailContent(drawerItem, handleCloseDetail)}
+              </div>
+            </DrawerContent>
+          </Drawer>
+        ) : (
+          listContent
+        )}
       </div>
-
-      {/* Inline detail panel - renders within the component's bounding box */}
-      {hasDetail && (
-        <div
-          ref={detailRef}
-          className="tw-w-full tw-overflow-y-auto tw-border-l tw-bg-background tw-p-4"
-        >
-          {renderDetailContent(drawerItem, handleCloseDetail)}
-        </div>
-      )}
     </div>
   );
 }

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
@@ -1,0 +1,175 @@
+import { RefObject, useMemo } from 'react';
+import { cn } from '@/utils/shadcn-ui.util';
+import { useListbox, type ListboxOption } from '@/hooks/listbox-keyboard-navigation.hook';
+import { Separator } from '@/components/shadcn-ui/separator';
+import { Skeleton } from '@/components/shadcn-ui/skeleton';
+import type {
+  IndexedListItem,
+  SourceLanguageIndexedListProps,
+} from './source-language-indexed-list.types';
+
+/**
+ * A shared list component for displaying source-language indexed items. Supports two-column layout
+ * (resource term + source language term), keyboard navigation, text and thumbnail variants, and
+ * loading/empty states.
+ *
+ * Used by Enhanced Resources (dictionary, encyclopedia, media) and lexical tools (dictionary).
+ *
+ * @example
+ *
+ * ```tsx
+ * <SourceLanguageIndexedList
+ *   items={dictionaryItems}
+ *   onItemClick={handleItemClick}
+ *   selectedItemId={selectedId}
+ *   showSourceLanguage
+ *   showTransliteration
+ * />;
+ * ```
+ */
+export default function SourceLanguageIndexedList<T extends IndexedListItem>({
+  items,
+  renderItem,
+  onItemClick,
+  selectedItemId,
+  emptyStateMessage = 'No items found',
+  isLoading = false,
+  variant = 'text',
+  showSourceLanguage = false,
+  showTransliteration = false,
+  onCharacterPress,
+  className,
+}: SourceLanguageIndexedListProps<T>) {
+  const options: ListboxOption[] = useMemo(() => items.map((item) => ({ id: item.id })), [items]);
+
+  const handleOptionSelect = (option: ListboxOption) => {
+    const clickedItem = items.find((item) => item.id === option.id);
+    if (clickedItem) onItemClick?.(clickedItem);
+  };
+
+  const { listboxRef, activeId, handleKeyDown } = useListbox({
+    options,
+    onOptionSelect: handleOptionSelect,
+    onCharacterPress,
+  });
+
+  if (isLoading) {
+    return (
+      <div className={cn('tw-flex tw-flex-col tw-gap-2 tw-p-2', className)}>
+        {Array.from({ length: 6 }, (_, i) => (
+          <Skeleton
+            // Loading skeleton placeholders don't have meaningful keys
+            // eslint-disable-next-line react/no-array-index-key
+            key={i}
+            className={cn('tw-h-12 tw-w-full tw-rounded', {
+              'tw-h-20': variant === 'thumbnail',
+            })}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div
+        className={cn(
+          'tw-flex tw-items-center tw-justify-center tw-p-8 tw-text-sm tw-text-muted-foreground',
+          className,
+        )}
+      >
+        {emptyStateMessage}
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('tw-overflow-y-auto', className)}>
+      <ul
+        role="listbox"
+        tabIndex={0}
+        // useListbox returns a generic HTMLElement ref for flexibility across element types
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        ref={listboxRef as RefObject<HTMLUListElement>}
+        aria-activedescendant={activeId ?? undefined}
+        className="tw-outline-none focus:tw-ring-2 focus:tw-ring-ring focus:tw-ring-offset-1 focus:tw-ring-offset-background"
+        onKeyDown={handleKeyDown}
+      >
+        {items.map((item) => {
+          const isSelected = selectedItemId === item.id;
+          return (
+            <li
+              key={item.id}
+              id={item.id}
+              role="option"
+              aria-selected={isSelected}
+              tabIndex={-1}
+              onClick={() => onItemClick?.(item)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onItemClick?.(item);
+                }
+              }}
+              className={cn(
+                'tw-flex tw-cursor-pointer tw-items-center tw-gap-3 tw-p-2 tw-outline-none',
+                {
+                  'tw-bg-muted': isSelected,
+                  'hover:tw-bg-muted': !isSelected,
+                },
+              )}
+            >
+              {renderItem ? (
+                renderItem(item)
+              ) : (
+                <DefaultListItemContent
+                  item={item}
+                  variant={variant}
+                  showSourceLanguage={showSourceLanguage}
+                  showTransliteration={showTransliteration}
+                />
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </div>
+  );
+}
+
+/** Default rendering for a list item showing the two-column layout */
+function DefaultListItemContent<T extends IndexedListItem>({
+  item,
+  variant,
+  showSourceLanguage,
+  showTransliteration,
+}: {
+  item: T;
+  variant: 'text' | 'thumbnail';
+  showSourceLanguage: boolean;
+  showTransliteration: boolean;
+}) {
+  return (
+    <>
+      {variant === 'thumbnail' && item.thumbnailUrl && (
+        <img
+          src={item.thumbnailUrl}
+          alt={item.thumbnailAlt ?? item.primaryText}
+          className="tw-h-14 tw-w-14 tw-shrink-0 tw-rounded tw-object-cover"
+        />
+      )}
+      <div className="tw-flex tw-flex-1 tw-items-baseline tw-gap-4 tw-overflow-hidden">
+        <span className="tw-shrink-0 tw-truncate tw-text-sm">{item.primaryText}</span>
+        {showSourceLanguage && item.sourceLanguageText && (
+          <span className="tw-truncate tw-text-sm tw-text-muted-foreground">
+            {item.sourceLanguageText}
+            {showTransliteration && item.transliteration && (
+              <span className="tw-ml-1">({item.transliteration})</span>
+            )}
+          </span>
+        )}
+      </div>
+      <Separator className="tw-absolute tw-bottom-0 tw-left-0 tw-right-0" />
+    </>
+  );
+}

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
@@ -1,9 +1,8 @@
-import { RefObject, useMemo, useState } from 'react';
+import { RefObject, useMemo, useRef, useState } from 'react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { useListbox, type ListboxOption } from '@/hooks/listbox-keyboard-navigation.hook';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Skeleton } from '@/components/shadcn-ui/skeleton';
-import { Drawer, DrawerContent, DrawerTrigger } from '@/components/shadcn-ui/drawer';
 import type {
   IndexedListItem,
   SourceLanguageIndexedListProps,
@@ -12,11 +11,11 @@ import type {
 /**
  * A shared list component for displaying source-language indexed items. Supports two-column layout
  * (resource term + source language term), keyboard navigation, text and thumbnail variants,
- * loading/empty states, and an optional right-side detail drawer.
+ * loading/empty states, and an optional inline detail panel.
  *
- * When `renderDetailContent` is provided, clicking an item opens a right-side drawer with the
- * detail content (extracted from the lexical dictionary extension pattern). When not provided,
- * clicking an item just fires `onItemClick`.
+ * When `renderDetailContent` is provided, clicking an item slides in a detail panel from the right
+ * **within the component's own bounding box** (not a full-page overlay). This pattern is extracted
+ * from the lexical dictionary extension's split-pane layout.
  *
  * Used by Enhanced Resources (dictionary, encyclopedia, media) and lexical tools (dictionary).
  *
@@ -50,8 +49,11 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
   className,
 }: SourceLanguageIndexedListProps<T>) {
   const [drawerItemId, setDrawerItemId] = useState<string | undefined>();
+  // ref.current expects null not undefined for div ref
+  // eslint-disable-next-line no-null/no-null
+  const detailRef = useRef<HTMLDivElement>(null);
 
-  // Use controlled selection if provided, otherwise use internal drawer state
+  // Use controlled selection if provided, otherwise use internal state
   const effectiveSelectedId = controlledSelectedId ?? drawerItemId;
 
   const drawerItem = useMemo(
@@ -64,7 +66,10 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
   const handleItemSelect = (item: T) => {
     onItemClick?.(item);
     if (renderDetailContent) {
-      setDrawerItemId(item.id === drawerItemId ? undefined : item.id);
+      const newId = item.id === drawerItemId ? undefined : item.id;
+      setDrawerItemId(newId);
+      // Scroll detail panel to top when opening a new entry
+      if (newId) detailRef.current?.scrollTo({ top: 0 });
     }
   };
 
@@ -73,7 +78,7 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
     if (clickedItem) handleItemSelect(clickedItem);
   };
 
-  const handleCloseDrawer = () => {
+  const handleCloseDetail = () => {
     setDrawerItemId(undefined);
   };
 
@@ -113,78 +118,77 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
     );
   }
 
-  const listContent = (
-    <div className={cn('tw-overflow-y-auto', className)}>
-      <ul
-        role="listbox"
-        tabIndex={0}
-        // useListbox returns a generic HTMLElement ref for flexibility across element types
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        ref={listboxRef as RefObject<HTMLUListElement>}
-        aria-activedescendant={activeId ?? undefined}
-        className="tw-outline-none focus:tw-ring-2 focus:tw-ring-ring focus:tw-ring-offset-1 focus:tw-ring-offset-background"
-        onKeyDown={handleKeyDown}
-      >
-        {items.map((item) => {
-          const isSelected = effectiveSelectedId === item.id;
-          return (
-            <li
-              key={item.id}
-              id={item.id}
-              role="option"
-              aria-selected={isSelected}
-              tabIndex={-1}
-              onClick={() => handleItemSelect(item)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  handleItemSelect(item);
-                }
-              }}
-              className={cn(
-                'tw-flex tw-cursor-pointer tw-items-center tw-gap-3 tw-p-2 tw-outline-none',
-                {
-                  'tw-bg-muted': isSelected,
-                  'hover:tw-bg-muted': !isSelected,
-                },
-              )}
-            >
-              {renderItem ? (
-                renderItem(item)
-              ) : (
-                <DefaultListItemContent
-                  item={item}
-                  variant={variant}
-                  showSourceLanguage={showSourceLanguage}
-                  showTransliteration={showTransliteration}
-                />
-              )}
-            </li>
-          );
-        })}
-      </ul>
-    </div>
-  );
+  const hasDetail = renderDetailContent && drawerItem;
 
-  // If no detail content renderer, render just the list
-  if (!renderDetailContent) return listContent;
-
-  // With detail content: wrap in a Drawer that opens from the right
   return (
-    <Drawer
-      direction="right"
-      open={drawerItem !== undefined}
-      onOpenChange={(open) => {
-        if (!open) handleCloseDrawer();
-      }}
-    >
-      <DrawerTrigger asChild>{listContent}</DrawerTrigger>
-      <DrawerContent hideDrawerHandle className="tw-max-w-xl">
-        <div className="tw-overflow-y-auto tw-p-4">
-          {drawerItem && renderDetailContent(drawerItem, handleCloseDrawer)}
+    <div className={cn('tw-relative tw-flex tw-h-full tw-overflow-hidden', className)}>
+      {/* List pane */}
+      <div
+        className={cn('tw-overflow-y-auto tw-transition-all tw-duration-200', {
+          'tw-w-full': !hasDetail,
+          'tw-w-0 tw-min-w-0 tw-overflow-hidden': hasDetail,
+        })}
+      >
+        <ul
+          role="listbox"
+          tabIndex={0}
+          // useListbox returns a generic HTMLElement ref for flexibility across element types
+          // eslint-disable-next-line no-type-assertion/no-type-assertion
+          ref={listboxRef as RefObject<HTMLUListElement>}
+          aria-activedescendant={activeId ?? undefined}
+          className="tw-outline-none focus:tw-ring-2 focus:tw-ring-ring focus:tw-ring-offset-1 focus:tw-ring-offset-background"
+          onKeyDown={handleKeyDown}
+        >
+          {items.map((item) => {
+            const isSelected = effectiveSelectedId === item.id;
+            return (
+              <li
+                key={item.id}
+                id={item.id}
+                role="option"
+                aria-selected={isSelected}
+                tabIndex={-1}
+                onClick={() => handleItemSelect(item)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleItemSelect(item);
+                  }
+                }}
+                className={cn(
+                  'tw-flex tw-cursor-pointer tw-items-center tw-gap-3 tw-p-2 tw-outline-none',
+                  {
+                    'tw-bg-muted': isSelected,
+                    'hover:tw-bg-muted': !isSelected,
+                  },
+                )}
+              >
+                {renderItem ? (
+                  renderItem(item)
+                ) : (
+                  <DefaultListItemContent
+                    item={item}
+                    variant={variant}
+                    showSourceLanguage={showSourceLanguage}
+                    showTransliteration={showTransliteration}
+                  />
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      {/* Inline detail panel - renders within the component's bounding box */}
+      {hasDetail && (
+        <div
+          ref={detailRef}
+          className="tw-w-full tw-overflow-y-auto tw-border-l tw-bg-background tw-p-4"
+        >
+          {renderDetailContent(drawerItem, handleCloseDetail)}
         </div>
-      </DrawerContent>
-    </Drawer>
+      )}
+    </div>
   );
 }
 

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.component.tsx
@@ -3,7 +3,7 @@ import { cn } from '@/utils/shadcn-ui.util';
 import { useListbox, type ListboxOption } from '@/hooks/listbox-keyboard-navigation.hook';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Skeleton } from '@/components/shadcn-ui/skeleton';
-import { Drawer, DrawerContent, DrawerTrigger } from '@/components/shadcn-ui/drawer';
+import { Drawer, DrawerContent } from '@/components/shadcn-ui/drawer';
 import type {
   IndexedListItem,
   SourceLanguageIndexedListProps,
@@ -15,8 +15,10 @@ import type {
  * loading/empty states, and an optional detail drawer.
  *
  * When `renderDetailContent` is provided, clicking an item opens a right-side drawer **within the
- * component's own bounding box** using the Drawer component with a scoped `container` prop. This
- * pattern is extracted from the lexical dictionary extension's split-pane layout.
+ * component's own bounding box** using the Drawer component with a scoped `container` prop. The
+ * drawer opens to 4/5 of the available width. Clicking a different list item while the drawer is
+ * open swaps the content without requiring a close-then-reopen cycle. Clicking outside the drawer
+ * closes it while allowing the click to pass through to the underlying element.
  *
  * Used by Enhanced Resources (dictionary, encyclopedia, media) and lexical tools (dictionary).
  *
@@ -67,6 +69,8 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
   const handleItemSelect = (item: T) => {
     onItemClick?.(item);
     if (renderDetailContent) {
+      // Always set to the clicked item so the drawer stays open with new content.
+      // Clicking the already-selected item closes the drawer.
       setDrawerItemId(item.id === drawerItemId ? undefined : item.id);
     }
   };
@@ -169,31 +173,29 @@ export default function SourceLanguageIndexedList<T extends IndexedListItem>({
 
   return (
     <div ref={containerRef} className={cn('tw-relative tw-h-full tw-overflow-hidden', className)}>
-      <div className="tw-h-full tw-overflow-y-auto">
-        {renderDetailContent ? (
-          <Drawer
-            direction="right"
-            modal={false}
-            open={drawerItem !== undefined}
-            onOpenChange={(open) => {
-              if (!open) handleCloseDetail();
-            }}
+      <div className="tw-h-full tw-overflow-y-auto">{listContent}</div>
+
+      {/* Detail drawer - scoped to this component, 4/5 width, no overlay so clicks pass through */}
+      {renderDetailContent && (
+        <Drawer
+          direction="right"
+          modal={false}
+          open={drawerItem !== undefined}
+          onOpenChange={(open) => {
+            if (!open) handleCloseDetail();
+          }}
+        >
+          <DrawerContent
+            container={containerRef.current}
+            hideDrawerHandle
+            className="tw-ml-0 tw-w-4/5 tw-max-w-none tw-rounded-none"
           >
-            <DrawerTrigger asChild>{listContent}</DrawerTrigger>
-            <DrawerContent
-              container={containerRef.current}
-              hideDrawerHandle
-              className="tw-max-w-full"
-            >
-              <div className="tw-h-full tw-overflow-y-auto tw-p-4">
-                {drawerItem && renderDetailContent(drawerItem, handleCloseDetail)}
-              </div>
-            </DrawerContent>
-          </Drawer>
-        ) : (
-          listContent
-        )}
-      </div>
+            <div className="tw-h-full tw-overflow-y-auto tw-p-4">
+              {drawerItem && renderDetailContent(drawerItem, handleCloseDetail)}
+            </div>
+          </DrawerContent>
+        </Drawer>
+      )}
     </div>
   );
 }

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.types.ts
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.types.ts
@@ -72,13 +72,13 @@ export type ErDictionaryListProps<T extends IndexedListItem> = SourceLanguageInd
   getOccurrenceCount?: (item: T) => number;
 };
 
-/** A semantic domain in a 2-level hierarchy */
+/** A semantic domain in a hierarchical tree (up to 5 levels) */
 export type SemanticDomain = {
   /** Unique identifier for the domain */
   id: string;
   /** Display label for the domain */
   label: string;
-  /** Child domains (only top-level domains have children; domains are always 2 levels) */
+  /** Child domains */
   children?: SemanticDomain[];
 };
 
@@ -98,15 +98,13 @@ export type ErDictionaryFilteredListProps<T extends IndexedListItem> = {
   emptyStateMessage?: string;
   /** Whether items are currently being loaded */
   isLoading?: boolean;
-  /** The currently selected top-level domain (level 1) */
-  selectedLevel1Domain: SemanticDomain;
-  /** The currently selected child domain (level 2), or undefined if viewing all of level 1 */
-  selectedLevel2Domain?: SemanticDomain;
-  /** All top-level domains (for navigation) */
+  /** Breadcrumb path: array of domains from root to the currently selected domain */
+  domainPath: SemanticDomain[];
+  /** All top-level domains (root of the tree, for navigation) */
   allDomains: SemanticDomain[];
-  /** Callback when a different domain is selected via breadcrumb navigation */
-  onDomainChange: (level1: SemanticDomain, level2?: SemanticDomain) => void;
-  /** Callback for the back arrow button (left of breadcrumbs). When provided, renders a back arrow */
+  /** Callback when a different domain is selected. Receives the new full path. */
+  onDomainChange: (newPath: SemanticDomain[]) => void;
+  /** Callback for the back arrow button. When provided, renders a back button. */
   onBack?: () => void;
   /** Additional CSS class names */
   className?: string;

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.types.ts
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.types.ts
@@ -17,13 +17,32 @@ export type IndexedListItem = {
   thumbnailAlt?: string;
 };
 
+/** A domain associated with a dictionary entry, displayed as a clickable link */
+export type EntryDomain = {
+  /** Unique identifier for the domain */
+  id: string;
+  /** Display label for the domain */
+  label: string;
+  /** The taxonomy this domain belongs to (e.g., 'SDBH-Lexical', 'SDBG-Contextual') */
+  taxonomy?: string;
+  /** Domain code (e.g., '1.2.3') */
+  code?: string;
+  /** Parent domain for 2-level hierarchy (undefined if this is a top-level domain) */
+  parentId?: string;
+};
+
 /** Props for the SourceLanguageIndexedList component */
 export type SourceLanguageIndexedListProps<T extends IndexedListItem> = {
   /** Array of items to display in the list */
   items: T[];
-  /** Custom render function for each item. If not provided, the default two-column layout is used */
+  /** Custom render function for each list item row. If not provided, the default layout is used */
   renderItem?: (item: T) => ReactNode;
-  /** Callback when an item is clicked */
+  /**
+   * Render function for the detail content shown in a right-side drawer when an item is selected.
+   * If not provided, no drawer is shown and `onItemClick` fires directly.
+   */
+  renderDetailContent?: (item: T, onClose: () => void) => ReactNode;
+  /** Callback when an item is clicked (fires in addition to opening the drawer if both exist) */
   onItemClick?: (item: T) => void;
   /** ID of the currently selected item */
   selectedItemId?: string;
@@ -53,32 +72,47 @@ export type ErDictionaryListProps<T extends IndexedListItem> = SourceLanguageInd
   getOccurrenceCount?: (item: T) => number;
 };
 
-/** A single semantic domain in the hierarchy */
+/** A semantic domain in a 2-level hierarchy */
 export type SemanticDomain = {
   /** Unique identifier for the domain */
   id: string;
   /** Display label for the domain */
   label: string;
-  /** Child domains */
+  /** Child domains (only top-level domains have children; domains are always 2 levels) */
   children?: SemanticDomain[];
 };
 
 /** Props for the ER Dictionary Filtered by Type component */
-export type ErDictionaryFilteredListProps<T extends IndexedListItem> =
-  SourceLanguageIndexedListProps<T> & {
-    /** Domain breadcrumb path from root to the current domain */
-    domainPath: SemanticDomain[];
-    /** Callback when a breadcrumb item is clicked */
-    onBreadcrumbClick?: (domain: SemanticDomain) => void;
-    /** Navigation mode: 'tree' shows full hierarchy, 'dropdown' shows siblings at each level */
-    navigationMode: 'tree' | 'dropdown';
-    /** Callback to change the navigation mode */
-    onNavigationModeChange?: (mode: 'tree' | 'dropdown') => void;
-    /** Children of the currently selected domain (used in tree/dropdown views) */
-    domainChildren?: SemanticDomain[];
-    /** Callback when a domain in the tree/dropdown is selected */
-    onDomainSelect?: (domain: SemanticDomain) => void;
-  };
+export type ErDictionaryFilteredListProps<T extends IndexedListItem> = {
+  /** Items filtered to the currently selected domain */
+  items: T[];
+  /** Custom render function for each list item row */
+  renderItem?: (item: T) => ReactNode;
+  /** Render function for the detail content shown in a drawer when an entry is clicked */
+  renderDetailContent?: (item: T, onClose: () => void) => ReactNode;
+  /** Callback when an item is clicked */
+  onItemClick?: (item: T) => void;
+  /** ID of the currently selected item */
+  selectedItemId?: string;
+  /** Message to display when items array is empty */
+  emptyStateMessage?: string;
+  /** Whether items are currently being loaded */
+  isLoading?: boolean;
+  /** The currently selected top-level domain (level 1) */
+  selectedLevel1Domain: SemanticDomain;
+  /** The currently selected child domain (level 2), or undefined if viewing all of level 1 */
+  selectedLevel2Domain?: SemanticDomain;
+  /** All top-level domains (for navigation) */
+  allDomains: SemanticDomain[];
+  /** Callback when a different domain is selected via breadcrumb navigation */
+  onDomainChange: (level1: SemanticDomain, level2?: SemanticDomain) => void;
+  /** Navigation mode: 'tree' opens a drawer with full tree, 'dropdown' shows a dropdown on click */
+  navigationMode: 'tree' | 'dropdown';
+  /** Callback to change the navigation mode */
+  onNavigationModeChange?: (mode: 'tree' | 'dropdown') => void;
+  /** Additional CSS class names */
+  className?: string;
+};
 
 /** An encyclopedia article teaser */
 export type EncyclopediaTeaser = IndexedListItem & {
@@ -145,6 +179,7 @@ export const SOURCE_LANGUAGE_INDEXED_LIST_STRING_KEYS: LocalizeKey[] = [
   '%sourceLanguageIndexedList_filterByDomain%',
   '%sourceLanguageIndexedList_navigationModeTree%',
   '%sourceLanguageIndexedList_navigationModeDropdown%',
+  '%sourceLanguageIndexedList_backToList%',
 ];
 
 /** Localized strings type for the indexed list components */

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.types.ts
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.types.ts
@@ -106,10 +106,8 @@ export type ErDictionaryFilteredListProps<T extends IndexedListItem> = {
   allDomains: SemanticDomain[];
   /** Callback when a different domain is selected via breadcrumb navigation */
   onDomainChange: (level1: SemanticDomain, level2?: SemanticDomain) => void;
-  /** Navigation mode: 'tree' opens a drawer with full tree, 'dropdown' shows a dropdown on click */
-  navigationMode: 'tree' | 'dropdown';
-  /** Callback to change the navigation mode */
-  onNavigationModeChange?: (mode: 'tree' | 'dropdown') => void;
+  /** Callback for the back arrow button (left of breadcrumbs). When provided, renders a back arrow */
+  onBack?: () => void;
   /** Additional CSS class names */
   className?: string;
 };

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.types.ts
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.types.ts
@@ -1,0 +1,153 @@
+import { ReactNode } from 'react';
+import { LocalizeKey } from 'platform-bible-utils';
+
+/** Base item interface for items displayed in the SourceLanguageIndexedList */
+export type IndexedListItem = {
+  /** Unique identifier for the item */
+  id: string;
+  /** Primary display text (term in the resource) */
+  primaryText: string;
+  /** Secondary display text (term in source language) */
+  sourceLanguageText?: string;
+  /** Transliteration of the source language text */
+  transliteration?: string;
+  /** Optional thumbnail URL for the 'thumbnail' variant */
+  thumbnailUrl?: string;
+  /** Optional alt text for the thumbnail */
+  thumbnailAlt?: string;
+};
+
+/** Props for the SourceLanguageIndexedList component */
+export type SourceLanguageIndexedListProps<T extends IndexedListItem> = {
+  /** Array of items to display in the list */
+  items: T[];
+  /** Custom render function for each item. If not provided, the default two-column layout is used */
+  renderItem?: (item: T) => ReactNode;
+  /** Callback when an item is clicked */
+  onItemClick?: (item: T) => void;
+  /** ID of the currently selected item */
+  selectedItemId?: string;
+  /** Message to display when items array is empty */
+  emptyStateMessage?: string;
+  /** Whether items are currently being loaded */
+  isLoading?: boolean;
+  /** Display variant: 'text' for default text list, 'thumbnail' for media/maps with image preview */
+  variant?: 'text' | 'thumbnail';
+  /** Whether to show the source language column */
+  showSourceLanguage?: boolean;
+  /** Whether to show transliteration in brackets after source language text */
+  showTransliteration?: boolean;
+  /** Callback fired when user presses a character key (for type-ahead search) */
+  onCharacterPress?: (char: string) => void;
+  /** Additional CSS class names */
+  className?: string;
+};
+
+/** Props for the ER Dictionary list component */
+export type ErDictionaryListProps<T extends IndexedListItem> = SourceLanguageIndexedListProps<T> & {
+  /** Additional description text per item (e.g., glosses) */
+  getDescription?: (item: T) => string;
+  /** Additional badge texts per item (e.g., Strong's codes) */
+  getBadges?: (item: T) => string[];
+  /** Occurrence count per item */
+  getOccurrenceCount?: (item: T) => number;
+};
+
+/** A single semantic domain in the hierarchy */
+export type SemanticDomain = {
+  /** Unique identifier for the domain */
+  id: string;
+  /** Display label for the domain */
+  label: string;
+  /** Child domains */
+  children?: SemanticDomain[];
+};
+
+/** Props for the ER Dictionary Filtered by Type component */
+export type ErDictionaryFilteredListProps<T extends IndexedListItem> =
+  SourceLanguageIndexedListProps<T> & {
+    /** Domain breadcrumb path from root to the current domain */
+    domainPath: SemanticDomain[];
+    /** Callback when a breadcrumb item is clicked */
+    onBreadcrumbClick?: (domain: SemanticDomain) => void;
+    /** Navigation mode: 'tree' shows full hierarchy, 'dropdown' shows siblings at each level */
+    navigationMode: 'tree' | 'dropdown';
+    /** Callback to change the navigation mode */
+    onNavigationModeChange?: (mode: 'tree' | 'dropdown') => void;
+    /** Children of the currently selected domain (used in tree/dropdown views) */
+    domainChildren?: SemanticDomain[];
+    /** Callback when a domain in the tree/dropdown is selected */
+    onDomainSelect?: (domain: SemanticDomain) => void;
+  };
+
+/** An encyclopedia article teaser */
+export type EncyclopediaTeaser = IndexedListItem & {
+  /** Short teaser/summary text for the article */
+  teaserText?: string;
+};
+
+/** Props for the ER Encyclopedia list component */
+export type ErEncyclopediaListProps<T extends EncyclopediaTeaser> =
+  SourceLanguageIndexedListProps<T>;
+
+/** A media item (image or map) */
+export type MediaItem = IndexedListItem & {
+  /** Type of media */
+  mediaType: 'image' | 'map';
+  /** Caption or description for the media */
+  caption?: string;
+};
+
+/** Props for the ER Media list component */
+export type ErMediaListProps<T extends MediaItem> = Omit<
+  SourceLanguageIndexedListProps<T>,
+  'variant'
+>;
+
+/** A lexical dictionary entry for use in the shared LexicalDictionaryList */
+export type LexicalDictionaryEntry = IndexedListItem & {
+  /** Strong's codes for this entry */
+  strongsCodes: string[];
+  /** Formatted glosses string */
+  glosses: string;
+  /** Number of occurrences */
+  occurrenceCount: number;
+};
+
+/** Props for the Lexical Dictionary list component */
+export type LexicalDictionaryListProps<T extends LexicalDictionaryEntry> = {
+  /** Array of dictionary entries */
+  items: T[];
+  /** Callback when an item is clicked */
+  onItemClick?: (item: T) => void;
+  /** ID of the currently selected item */
+  selectedItemId?: string;
+  /** Message to display when items array is empty */
+  emptyStateMessage?: string;
+  /** Whether items are currently being loaded */
+  isLoading?: boolean;
+  /** Callback fired when user presses a character key */
+  onCharacterPress?: (char: string) => void;
+  /** Additional CSS class names */
+  className?: string;
+  /** Localized string for occurrence count tooltip */
+  occurrenceCountLabel?: string;
+  /** Localized string for Strong's code tooltip */
+  strongsCodeLabel?: string;
+};
+
+/** Localization string keys used by the indexed list components */
+export const SOURCE_LANGUAGE_INDEXED_LIST_STRING_KEYS: LocalizeKey[] = [
+  '%sourceLanguageIndexedList_emptyState%',
+  '%sourceLanguageIndexedList_loading%',
+  '%sourceLanguageIndexedList_occurrenceCount%',
+  '%sourceLanguageIndexedList_strongsCode%',
+  '%sourceLanguageIndexedList_filterByDomain%',
+  '%sourceLanguageIndexedList_navigationModeTree%',
+  '%sourceLanguageIndexedList_navigationModeDropdown%',
+];
+
+/** Localized strings type for the indexed list components */
+export type SourceLanguageIndexedListLocalizedStrings = {
+  [localizedKey in (typeof SOURCE_LANGUAGE_INDEXED_LIST_STRING_KEYS)[number]]?: string;
+};

--- a/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.types.ts
+++ b/lib/platform-bible-react/src/components/advanced/source-language-indexed-list/source-language-indexed-list.types.ts
@@ -104,8 +104,8 @@ export type ErDictionaryFilteredListProps<T extends IndexedListItem> = {
   allDomains: SemanticDomain[];
   /** Callback when a different domain is selected. Receives the new full path. */
   onDomainChange: (newPath: SemanticDomain[]) => void;
-  /** Callback for the back arrow button. When provided, renders a back button. */
-  onBack?: () => void;
+  /** Callback for the close (X) button. When provided, renders a close button on the right. */
+  onClose?: () => void;
   /** Additional CSS class names */
   className?: string;
 };

--- a/lib/platform-bible-react/src/components/shadcn-ui/drawer.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/drawer.tsx
@@ -61,15 +61,25 @@ interface DrawerContentProps
   extends React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content> {
   /** Optionally hide the drawer handle */
   hideDrawerHandle?: boolean;
+  /**
+   * When provided, the drawer portals into this element and uses absolute positioning so it stays
+   * within the container's bounding box. The container element must have `position: relative` and
+   * `overflow: hidden`. When omitted the drawer portals to `document.body` with fixed positioning
+   * (the default full-page behaviour).
+   */
+  container?: HTMLElement | null;
 }
 
 /** @inheritdoc Drawer */
 const DrawerContent = React.forwardRef<
   React.ElementRef<typeof DrawerPrimitive.Content>,
   DrawerContentProps
->(({ className, children, hideDrawerHandle = false, ...props }, ref) => {
+>(({ className, children, hideDrawerHandle = false, container, ...props }, ref) => {
   // CUSTOM: Use context to provide direction to child components
   const { direction = 'bottom' } = React.useContext(DrawerContext);
+
+  // CUSTOM: When container is set, use absolute positioning so the drawer stays inside its parent
+  const positionClass = container ? 'tw-absolute' : 'tw-fixed';
 
   // CUSTOM: Define positioning and styling based on direction
   const directionStyles = {
@@ -88,14 +98,15 @@ const DrawerContent = React.forwardRef<
   };
 
   return (
-    <DrawerPortal>
-      <DrawerOverlay />
+    <DrawerPortal container={container}>
+      <DrawerOverlay className={container ? 'tw-absolute' : undefined} />
       <DrawerPrimitive.Content
         ref={ref}
         className={cn(
           // CUSTOM: Change Tailwind CSS classes for styling
           // Removed tw-inset-x-0 tw-bottom-0 tw-mt-24 tw-rounded-t-[10px] tw-flex-col
-          'pr-twp tw-fixed tw-z-50 tw-flex tw-h-auto tw-border tw-bg-background',
+          'pr-twp tw-z-50 tw-flex tw-h-auto tw-border tw-bg-background',
+          positionClass,
           direction === 'bottom' || direction === 'top' ? 'tw-flex-col' : 'tw-flex-row',
           directionStyles[direction],
           className,

--- a/lib/platform-bible-react/src/components/shadcn-ui/drawer.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/drawer.tsx
@@ -81,12 +81,12 @@ const DrawerContent = React.forwardRef<
   // CUSTOM: When container is set, use absolute positioning so the drawer stays inside its parent
   const positionClass = container ? 'tw-absolute' : 'tw-fixed';
 
-  // CUSTOM: Define positioning and styling based on direction
+  // CUSTOM: Define positioning and styling based on direction (tw-rounded-lg = 8px)
   const directionStyles = {
-    bottom: 'tw-inset-x-0 tw-bottom-0 tw-mt-24 tw-rounded-t-[10px]',
-    top: 'tw-inset-x-0 tw-top-0 tw-mb-24 tw-rounded-b-[10px]',
-    left: 'tw-inset-y-0 tw-left-0 tw-mr-24 tw-rounded-r-[10px] tw-w-auto tw-max-w-sm',
-    right: 'tw-inset-y-0 tw-right-0 tw-ml-24 tw-rounded-l-[10px] tw-w-auto tw-max-w-sm',
+    bottom: 'tw-inset-x-0 tw-bottom-0 tw-mt-24 tw-rounded-t-lg',
+    top: 'tw-inset-x-0 tw-top-0 tw-mb-24 tw-rounded-b-lg',
+    left: 'tw-inset-y-0 tw-left-0 tw-mr-24 tw-rounded-r-lg tw-w-auto tw-max-w-sm',
+    right: 'tw-inset-y-0 tw-right-0 tw-ml-24 tw-rounded-l-lg tw-w-auto tw-max-w-sm',
   };
 
   // CUSTOM: Define handle styles for each direction

--- a/lib/platform-bible-react/src/components/shadcn-ui/drawer.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/drawer.tsx
@@ -99,7 +99,9 @@ const DrawerContent = React.forwardRef<
 
   return (
     <DrawerPortal container={container}>
-      <DrawerOverlay className={container ? 'tw-absolute' : undefined} />
+      {/* CUSTOM: Skip overlay for container-scoped drawers so clicks pass through to elements
+          underneath. The drawer is dismissed via vaul's built-in outside-click handling. */}
+      {!container && <DrawerOverlay />}
       <DrawerPrimitive.Content
         ref={ref}
         className={cn(

--- a/lib/platform-bible-react/src/components/shadcn-ui/drawer.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/drawer.tsx
@@ -81,12 +81,12 @@ const DrawerContent = React.forwardRef<
   // CUSTOM: When container is set, use absolute positioning so the drawer stays inside its parent
   const positionClass = container ? 'tw-absolute' : 'tw-fixed';
 
-  // CUSTOM: Define positioning and styling based on direction (tw-rounded-lg = 8px)
+  // CUSTOM: Define positioning and styling based on direction
   const directionStyles = {
-    bottom: 'tw-inset-x-0 tw-bottom-0 tw-mt-24 tw-rounded-t-lg',
-    top: 'tw-inset-x-0 tw-top-0 tw-mb-24 tw-rounded-b-lg',
-    left: 'tw-inset-y-0 tw-left-0 tw-mr-24 tw-rounded-r-lg tw-w-auto tw-max-w-sm',
-    right: 'tw-inset-y-0 tw-right-0 tw-ml-24 tw-rounded-l-lg tw-w-auto tw-max-w-sm',
+    bottom: 'tw-inset-x-0 tw-bottom-0 tw-mt-24 tw-rounded-t-[10px]',
+    top: 'tw-inset-x-0 tw-top-0 tw-mb-24 tw-rounded-b-[10px]',
+    left: 'tw-inset-y-0 tw-left-0 tw-mr-24 tw-rounded-r-[10px] tw-w-auto tw-max-w-sm',
+    right: 'tw-inset-y-0 tw-right-0 tw-ml-24 tw-rounded-l-[10px] tw-w-auto tw-max-w-sm',
   };
 
   // CUSTOM: Define handle styles for each direction

--- a/lib/platform-bible-react/src/index.ts
+++ b/lib/platform-bible-react/src/index.ts
@@ -148,6 +148,27 @@ export {
   type LanguageInfo,
   type UiLanguageSelectorProps,
 } from './components/advanced/ui-language-selector.component';
+export { default as SourceLanguageIndexedList } from './components/advanced/source-language-indexed-list/source-language-indexed-list.component';
+export type {
+  IndexedListItem,
+  SourceLanguageIndexedListProps,
+  ErDictionaryListProps,
+  ErDictionaryFilteredListProps,
+  ErEncyclopediaListProps,
+  ErMediaListProps,
+  LexicalDictionaryListProps,
+  SemanticDomain,
+  EncyclopediaTeaser,
+  MediaItem,
+  LexicalDictionaryEntry,
+  SourceLanguageIndexedListLocalizedStrings,
+} from './components/advanced/source-language-indexed-list/source-language-indexed-list.types';
+export { SOURCE_LANGUAGE_INDEXED_LIST_STRING_KEYS } from './components/advanced/source-language-indexed-list/source-language-indexed-list.types';
+export { default as ErDictionaryList } from './components/advanced/source-language-indexed-list/er-dictionary-list.component';
+export { default as ErDictionaryFilteredList } from './components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component';
+export { default as ErEncyclopediaList } from './components/advanced/source-language-indexed-list/er-encyclopedia-list.component';
+export { default as ErMediaList } from './components/advanced/source-language-indexed-list/er-media-list.component';
+export { default as LexicalDictionaryList } from './components/advanced/source-language-indexed-list/lexical-dictionary-list.component';
 
 export { default as ChapterRangeSelector } from './components/basics/chapter-range-selector.component';
 export type { ChapterRangeSelectorProps } from './components/basics/chapter-range-selector.component';

--- a/lib/platform-bible-react/src/index.ts
+++ b/lib/platform-bible-react/src/index.ts
@@ -151,6 +151,7 @@ export {
 export { default as SourceLanguageIndexedList } from './components/advanced/source-language-indexed-list/source-language-indexed-list.component';
 export type {
   IndexedListItem,
+  EntryDomain,
   SourceLanguageIndexedListProps,
   ErDictionaryListProps,
   ErDictionaryFilteredListProps,

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -456,7 +456,7 @@ function ErDictionaryDetail({
 }) {
   return (
     <div>
-      <Button onClick={onClose} variant="link" className="tw-mb-3 tw-h-auto tw-p-0">
+      <Button onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
         <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
         Back to list
       </Button>
@@ -522,7 +522,7 @@ function LexicalDetail({ item, onClose }: { item: LexicalEntryFull; onClose: () 
 
   return (
     <div>
-      <Button onClick={onClose} variant="link" className="tw-mb-3 tw-h-auto tw-p-0">
+      <Button onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
         <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
         Back to list
       </Button>
@@ -618,7 +618,7 @@ function LexicalDetail({ item, onClose }: { item: LexicalEntryFull; onClose: () 
 function EncyclopediaDetail({ item, onClose }: { item: EncyclopediaTeaser; onClose: () => void }) {
   return (
     <div>
-      <Button onClick={onClose} variant="link" className="tw-mb-3 tw-h-auto tw-p-0">
+      <Button onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
         <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
         Back to list
       </Button>
@@ -638,7 +638,7 @@ function EncyclopediaDetail({ item, onClose }: { item: EncyclopediaTeaser; onClo
 function MediaDetail({ item, onClose }: { item: MediaItem; onClose: () => void }) {
   return (
     <div>
-      <Button onClick={onClose} variant="link" className="tw-mb-3 tw-h-auto tw-p-0">
+      <Button onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
         <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
         Back to list
       </Button>
@@ -700,7 +700,7 @@ function InlineListDetail<T extends { id: string }>({
           className={cn(
             'tw-h-full',
             showSideBySide
-              ? 'tw-w-1/5 tw-min-w-[120px] tw-overflow-hidden tw-border-r'
+              ? 'tw-w-1/3 tw-min-w-[120px] tw-overflow-hidden tw-border-r'
               : 'tw-w-full tw-overflow-y-auto',
           )}
         >
@@ -730,7 +730,7 @@ function InlineListDetail<T extends { id: string }>({
         <div
           className={cn(
             'tw-overflow-y-auto tw-bg-background tw-p-4',
-            showFullDetail ? 'tw-w-full' : 'tw-w-4/5',
+            showFullDetail ? 'tw-w-full' : 'tw-w-2/3',
           )}
         >
           {renderDetail(selectedItem)}
@@ -834,16 +834,8 @@ export const AllErTabs: Story = {
       [resolveDomainPath],
     );
 
-    // Domain click from inside the filtered detail view: update the breadcrumb path and list
-    const handleDomainClickInFiltered = useCallback(
-      (_domain: EntryDomain, pathIds?: string[]) => {
-        if (pathIds) {
-          const path = resolveDomainPath(pathIds);
-          if (path.length > 0) setDomainPath(path);
-        }
-      },
-      [resolveDomainPath],
-    );
+    // Domain click from inside the filtered detail view reuses the same handler
+    const handleDomainClickInFiltered = handleDomainClick;
 
     return (
       <div className="tw-flex tw-h-[550px] tw-flex-col tw-rounded tw-border">
@@ -955,21 +947,11 @@ export const AllErTabs: Story = {
                 className="tw-mt-0 tw-h-full tw-max-h-full tw-rounded-none"
               >
                 {domainPath && (
-                  <ErDictionaryFilteredList
-                    items={sampleDictionaryItems}
+                  <DomainFilteredView
                     domainPath={domainPath}
-                    allDomains={sampleAllDomains}
                     onDomainChange={setDomainPath}
                     onClose={() => setDomainPath(undefined)}
-                    renderItem={(item) => <ErDictListItem item={item} />}
-                    renderDetailContent={(item, onCloseDetail) => (
-                      <ErDictionaryDetail
-                        item={item}
-                        onClose={onCloseDetail}
-                        onDomainClick={handleDomainClickInFiltered}
-                      />
-                    )}
-                    className="tw-h-full"
+                    onDomainClick={handleDomainClickInFiltered}
                   />
                 )}
               </DrawerContent>
@@ -1054,3 +1036,41 @@ export const DomainComboBoxAlternative: Story = {
     },
   },
 };
+
+// ---------------------------------------------------------------------------
+// Domain-filtered view used inside the bottom drawer in AllErTabs.
+// Uses InlineListDetail so the list, breadcrumbs, close button, and domain
+// links all remain interactive while the detail panel is open.
+// ---------------------------------------------------------------------------
+
+function DomainFilteredView({
+  domainPath,
+  onDomainChange,
+  onClose,
+  onDomainClick,
+}: {
+  domainPath: SemanticDomain[];
+  onDomainChange: (path: SemanticDomain[]) => void;
+  onClose: () => void;
+  onDomainClick: (domain: EntryDomain, pathIds?: string[]) => void;
+}) {
+  const [selectedItem, setSelectedItem] = useState<DictionaryEntryWithSenses | undefined>();
+
+  return (
+    <ErDictionaryFilteredList
+      items={sampleDictionaryItems}
+      domainPath={domainPath}
+      allDomains={sampleAllDomains}
+      onDomainChange={(newPath) => {
+        onDomainChange(newPath);
+        setSelectedItem(undefined);
+      }}
+      onClose={onClose}
+      renderItem={(item) => <ErDictListItem item={item} compact={!!selectedItem} />}
+      renderDetailContent={(item, onCloseDetail) => (
+        <ErDictionaryDetail item={item} onClose={onCloseDetail} onDomainClick={onDomainClick} />
+      )}
+      className="tw-h-full"
+    />
+  );
+}

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -677,7 +677,10 @@ function InlineListDetail<T extends { id: string }>({
 }) {
   // eslint-disable-next-line no-null/no-null
   const containerRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line no-null/no-null
+  const listRef = useRef<HTMLUListElement>(null);
   const [narrow, setNarrow] = useState(false);
+  const [focusedIdx, setFocusedIdx] = useState(-1);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -692,9 +695,40 @@ function InlineListDetail<T extends { id: string }>({
   const showSideBySide = selectedItem && !narrow;
   const showFullDetail = selectedItem && narrow;
 
+  // Keyboard navigation: arrows move focus, behavior depends on narrow/wide
+  const handleListKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (items.length === 0) return;
+
+      if (e.key === 'ArrowDown') {
+        e.preventDefault();
+        const next = Math.min(focusedIdx + 1, items.length - 1);
+        setFocusedIdx(next);
+        // Wide mode: immediately select to show details side-by-side
+        if (!narrow) onSelectItem(items[next]);
+      } else if (e.key === 'ArrowUp') {
+        e.preventDefault();
+        const prev = Math.max(focusedIdx - 1, 0);
+        setFocusedIdx(prev);
+        if (!narrow) onSelectItem(items[prev]);
+      } else if ((e.key === 'Enter' || e.key === ' ') && narrow && focusedIdx >= 0) {
+        // Narrow mode: Enter/Space submits the focused item
+        e.preventDefault();
+        onSelectItem(items[focusedIdx]);
+      }
+    },
+    [items, focusedIdx, narrow, onSelectItem],
+  );
+
+  // Scroll focused item into view
+  useEffect(() => {
+    if (focusedIdx < 0 || !listRef.current) return;
+    const li = listRef.current.children[focusedIdx] as HTMLElement | undefined;
+    li?.scrollIntoView({ block: 'nearest' });
+  }, [focusedIdx]);
+
   return (
     <div ref={containerRef} className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
-      {/* List pane: hidden overflow (no scroll) when detail is shown side-by-side, full-width scroll when alone */}
       {!showFullDetail && (
         <div
           className={cn(
@@ -704,18 +738,29 @@ function InlineListDetail<T extends { id: string }>({
               : 'tw-w-full tw-overflow-y-auto',
           )}
         >
-          <ul role="listbox" className="tw-outline-none">
-            {items.map((item) => {
+          <ul
+            ref={listRef}
+            role="listbox"
+            tabIndex={0}
+            className="tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-ring"
+            onKeyDown={handleListKeyDown}
+          >
+            {items.map((item, idx) => {
               const isSelected = selectedItem?.id === item.id;
+              const isFocused = focusedIdx === idx;
               return (
                 <li
                   key={item.id}
                   role="option"
                   aria-selected={isSelected}
-                  onClick={() => onSelectItem(isSelected ? undefined : item)}
+                  onClick={() => {
+                    setFocusedIdx(idx);
+                    onSelectItem(isSelected ? undefined : item);
+                  }}
                   className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
                     'tw-bg-muted': isSelected,
                     'hover:tw-bg-muted': !isSelected,
+                    'tw-ring-1 tw-ring-inset tw-ring-ring': isFocused && !isSelected,
                   })}
                 >
                   {renderListItem(item, !!selectedItem)}
@@ -725,7 +770,6 @@ function InlineListDetail<T extends { id: string }>({
           </ul>
         </div>
       )}
-      {/* Detail pane */}
       {selectedItem && (
         <div
           className={cn(
@@ -944,7 +988,7 @@ export const AllErTabs: Story = {
               <DrawerContent
                 container={tabContentRef.current}
                 hideDrawerHandle
-                className="tw-top-2 tw-h-full tw-max-h-full tw-rounded-t-lg"
+                className="tw-top-[0.5rem] tw-mt-0 tw-h-full tw-max-h-full tw-rounded-t-lg"
               >
                 {domainPath && (
                   <DomainFilteredView

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -646,19 +646,32 @@ function InlineListDetail<T extends { id: string }>({
   onSelectItem,
   renderListItem,
   renderDetail,
+  listRef: externalListRef,
 }: {
   items: T[];
   selectedItem: T | undefined;
   onSelectItem: (item: T | undefined) => void;
   renderListItem: (item: T, compact: boolean) => React.ReactNode;
   renderDetail: (item: T, onClose: () => void) => React.ReactNode;
+  /** Optional ref to the listbox <ul> element so the caller can focus it. */
+  listRef?: React.MutableRefObject<HTMLUListElement | null>;
 }) {
   // eslint-disable-next-line no-null/no-null
   const containerRef = useRef<HTMLDivElement>(null);
   // eslint-disable-next-line no-null/no-null
-  const listRef = useRef<HTMLUListElement>(null);
+  const internalListRef = useRef<HTMLUListElement>(null);
+  const listRef = externalListRef ?? internalListRef;
   const [narrow, setNarrow] = useState(false);
   const [focusedIdx, setFocusedIdx] = useState(-1);
+
+  // Focus the list on mount so tab-switches and initial renders land on the
+  // list (enabling immediate keyboard navigation).
+  useEffect(() => {
+    listRef.current?.focus();
+    // Only run once on mount. listRef is either the stable internal ref or the
+    // caller's ref; in both cases we don't want to re-focus on re-renders.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   useEffect(() => {
     const el = containerRef.current;
@@ -707,7 +720,7 @@ function InlineListDetail<T extends { id: string }>({
     if (focusedIdx < 0 || !listRef.current) return;
     const li = listRef.current.children[focusedIdx] as HTMLElement | undefined;
     li?.scrollIntoView({ block: 'nearest' });
-  }, [focusedIdx]);
+  }, [focusedIdx, listRef]);
 
   // On close, restore focus to the list starting from the last selected item.
   const handleCloseDetail = useCallback(() => {
@@ -720,7 +733,7 @@ function InlineListDetail<T extends { id: string }>({
         listRef.current?.focus();
       });
     }
-  }, [items, onSelectItem, selectedItem]);
+  }, [items, onSelectItem, selectedItem, listRef]);
 
   return (
     <div ref={containerRef} className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
@@ -737,7 +750,7 @@ function InlineListDetail<T extends { id: string }>({
             ref={listRef}
             role="listbox"
             tabIndex={0}
-            className="tw-outline-none"
+            className="tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-ring"
             onKeyDown={handleListKeyDown}
           >
             {items.map((item, idx) => {
@@ -853,6 +866,15 @@ export const AllErTabs: Story = {
     const [domainPath, setDomainPath] = useState<SemanticDomain[] | undefined>();
     // eslint-disable-next-line no-null/no-null
     const tabContentRef = useRef<HTMLDivElement>(null);
+    // Refs to each tab's listbox so we can programmatically refocus on tab
+    // click (including clicks on the currently active tab where no remount
+    // would otherwise happen).
+    // eslint-disable-next-line no-null/no-null
+    const dictListRef = useRef<HTMLUListElement | null>(null);
+    // eslint-disable-next-line no-null/no-null
+    const encListRef = useRef<HTMLUListElement | null>(null);
+    // eslint-disable-next-line no-null/no-null
+    const mediaListRef = useRef<HTMLUListElement | null>(null);
 
     const resolveDomainPath = useCallback((pathIds: string[]): SemanticDomain[] => {
       return pathIds.reduce<SemanticDomain[]>((acc, id) => {
@@ -876,6 +898,22 @@ export const AllErTabs: Story = {
     // Domain click from inside the filtered detail view reuses the same handler
     const handleDomainClickInFiltered = handleDomainClick;
 
+    // Close the drawer on ESC. An open popover inside the drawer uses
+    // `e.nativeEvent.stopImmediatePropagation()` in its own ESC handler, which
+    // stops the native event from reaching this document-level listener — so
+    // ESC inside an open popover only closes the popover.
+    useEffect(() => {
+      if (domainPath === undefined) return undefined;
+      const handleEsc = (e: KeyboardEvent) => {
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setDomainPath(undefined);
+        }
+      };
+      document.addEventListener('keydown', handleEsc);
+      return () => document.removeEventListener('keydown', handleEsc);
+    }, [domainPath]);
+
     return (
       <div className="tw-flex tw-h-[550px] tw-flex-col tw-rounded tw-border">
         <div className="tw-flex tw-border-b">
@@ -890,6 +928,14 @@ export const AllErTabs: Story = {
                 setSelectedEnc(undefined);
                 setSelectedMedia(undefined);
                 setDomainPath(undefined);
+                // Move focus to the active tab's list after the re-render.
+                // Works for both tab-switch (mount focus also handles this)
+                // and same-tab clicks (no remount, so we force focus here).
+                requestAnimationFrame(() => {
+                  if (tab === 'dictionary') dictListRef.current?.focus();
+                  else if (tab === 'encyclopedia') encListRef.current?.focus();
+                  else mediaListRef.current?.focus();
+                });
               }}
             >
               {tab}
@@ -902,6 +948,7 @@ export const AllErTabs: Story = {
               items={sampleDictionaryItems}
               selectedItem={selectedDict}
               onSelectItem={setSelectedDict}
+              listRef={dictListRef}
               renderListItem={(item, compact) => <ErDictListItem item={item} compact={compact} />}
               renderDetail={(item, onClose) => (
                 <ErDictionaryDetail
@@ -917,6 +964,7 @@ export const AllErTabs: Story = {
               items={sampleEncyclopediaItems}
               selectedItem={selectedEnc}
               onSelectItem={setSelectedEnc}
+              listRef={encListRef}
               renderListItem={(item) => (
                 <div className="tw-flex tw-flex-col tw-gap-0.5 tw-overflow-hidden">
                   <div className="tw-flex tw-items-baseline tw-gap-2 tw-overflow-hidden">
@@ -943,6 +991,7 @@ export const AllErTabs: Story = {
               items={sampleMediaItems}
               selectedItem={selectedMedia}
               onSelectItem={setSelectedMedia}
+              listRef={mediaListRef}
               renderListItem={(item) => (
                 <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden">
                   {item.thumbnailUrl && (
@@ -969,7 +1018,7 @@ export const AllErTabs: Story = {
           {/* Domain-filtered drawer — a custom absolute panel scoped to the tab
               content area, with a modal backdrop. Implemented directly (not via
               vaul) so tab switching above the drawer keeps working while open.
-              Clicking the visible backdrop strip (top-4) closes the drawer. */}
+              Clicking the visible backdrop strip closes the drawer. */}
           {activeTab === 'dictionary' && domainPath !== undefined && (
             <>
               {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
@@ -978,7 +1027,7 @@ export const AllErTabs: Story = {
                 onClick={() => setDomainPath(undefined)}
                 aria-hidden
               />
-              <div className="tw-absolute tw-inset-x-0 tw-bottom-0 tw-top-4 tw-z-50 tw-flex tw-flex-col tw-overflow-hidden tw-rounded-t-lg tw-border tw-bg-background tw-shadow-xl">
+              <div className="tw-absolute tw-bottom-0 tw-left-2 tw-right-2 tw-top-2 tw-z-50 tw-flex tw-flex-col tw-overflow-hidden tw-rounded-t-lg tw-border tw-bg-background tw-shadow-xl">
                 <DomainFilteredView
                   domainPath={domainPath}
                   onDomainChange={setDomainPath}

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -6,7 +6,6 @@ import { Button } from '@/components/shadcn-ui/button';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Badge } from '@/components/shadcn-ui/badge';
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/shadcn-ui/dialog';
-import { DrawerClose, DrawerTitle, DrawerDescription } from '@/components/shadcn-ui/drawer';
 import SourceLanguageIndexedList from '@/components/advanced/source-language-indexed-list/source-language-indexed-list.component';
 import ErDictionaryList from '@/components/advanced/source-language-indexed-list/er-dictionary-list.component';
 import ErDictionaryFilteredList from '@/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component';
@@ -335,7 +334,7 @@ const sampleLexicalEntries: LexicalDictionaryEntry[] = [
 // Shared detail content renderers (extracted from lexical dictionary pattern)
 // ---------------------------------------------------------------------------
 
-/** Renders detailed dictionary entry content inside the drawer */
+/** Renders detailed dictionary entry content inside the inline detail panel */
 function DictionaryDetailContent({
   item,
   onClose,
@@ -347,20 +346,16 @@ function DictionaryDetailContent({
 }) {
   return (
     <>
-      <DrawerClose asChild>
-        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
-          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
-          Back to list
-        </Button>
-      </DrawerClose>
+      <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
+        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+        Back to list
+      </Button>
 
       <div className="tw-mb-4">
         <div className="tw-flex tw-items-baseline tw-justify-between tw-gap-2">
           <span className="tw-flex tw-flex-row tw-items-baseline tw-gap-2">
-            <DrawerTitle className="tw-text-2xl tw-font-normal">{item.primaryText}</DrawerTitle>
-            <DrawerDescription className="tw-text-lg tw-text-muted-foreground">
-              {item.glosses}
-            </DrawerDescription>
+            <h2 className="tw-text-2xl tw-font-normal">{item.primaryText}</h2>
+            <span className="tw-text-lg tw-text-muted-foreground">{item.glosses}</span>
           </span>
           <ul className="tw-flex tw-flex-row tw-gap-1">
             {item.strongsCodes.map((code) => (
@@ -422,7 +417,7 @@ function DictionaryDetailContent({
   );
 }
 
-/** Renders detailed encyclopedia content inside the drawer */
+/** Renders detailed encyclopedia content inside the inline detail panel */
 function EncyclopediaDetailContent({
   item,
   onClose,
@@ -432,19 +427,17 @@ function EncyclopediaDetailContent({
 }) {
   return (
     <>
-      <DrawerClose asChild>
-        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
-          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
-          Back to list
-        </Button>
-      </DrawerClose>
+      <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
+        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+        Back to list
+      </Button>
 
-      <DrawerTitle className="tw-mb-1 tw-text-2xl tw-font-normal">{item.primaryText}</DrawerTitle>
+      <h2 className="tw-mb-1 tw-text-2xl tw-font-normal">{item.primaryText}</h2>
       {item.sourceLanguageText && (
-        <DrawerDescription className="tw-text-sm tw-text-muted-foreground">
+        <p className="tw-text-sm tw-text-muted-foreground">
           {item.sourceLanguageText}
           {item.transliteration && <span className="tw-ml-1">({item.transliteration})</span>}
-        </DrawerDescription>
+        </p>
       )}
 
       <Separator className="tw-my-3" />
@@ -456,24 +449,19 @@ function EncyclopediaDetailContent({
   );
 }
 
-/** Renders detailed media content inside the drawer */
+/** Renders detailed media content inside the inline detail panel */
 function MediaDetailContent({ item, onClose }: { item: MediaItem; onClose: () => void }) {
   return (
     <>
-      <DrawerClose asChild>
-        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
-          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
-          Back to list
-        </Button>
-      </DrawerClose>
+      <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
+        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+        Back to list
+      </Button>
 
       <div className="tw-mb-4 tw-flex tw-items-center tw-gap-2">
-        <DrawerTitle className="tw-text-xl tw-font-normal">{item.primaryText}</DrawerTitle>
+        <h2 className="tw-text-xl tw-font-normal">{item.primaryText}</h2>
         <Badge variant="outline">{item.mediaType}</Badge>
       </div>
-      <DrawerDescription className="tw-sr-only">
-        {item.caption ?? item.primaryText}
-      </DrawerDescription>
 
       {item.thumbnailUrl && (
         <img
@@ -536,7 +524,7 @@ export const Default: Story = {
     docs: {
       description: {
         story:
-          'Base SourceLanguageIndexedList without a detail drawer. Clicking items toggles selection only.',
+          'Base SourceLanguageIndexedList without a detail panel. Clicking items toggles selection only.',
       },
     },
   },
@@ -578,7 +566,7 @@ export const EmptyState: Story = {
 };
 
 /**
- * ER Dictionary list with detail drawer. Clicking an entry opens a right-side drawer showing the
+ * ER Dictionary list with detail panel. Clicking an entry opens a inline detail panel showing the
  * full entry details (glosses, Strong's codes, definition, domains as clickable links). Clicking a
  * domain link opens the "ER Dictionary Filtered by Type" dialog.
  */
@@ -623,7 +611,7 @@ export const ErDictionary: Story = {
           />
         </div>
 
-        {/* Dialog that opens when clicking a domain link in the detail drawer */}
+        {/* Dialog that opens when clicking a domain link in the detail panel */}
         <Dialog open={filteredDialogOpen} onOpenChange={setFilteredDialogOpen}>
           <DialogContent className="tw-flex tw-h-[500px] tw-max-w-lg tw-flex-col tw-p-0">
             <DialogTitle className="tw-px-4 tw-pt-4 tw-text-base tw-font-semibold">
@@ -661,7 +649,7 @@ export const ErDictionary: Story = {
     docs: {
       description: {
         story:
-          'ER Dictionary list with a detail drawer. Clicking an entry opens a right-side drawer with full details. Domain names in the detail view are clickable links that open the "ER Dictionary Filtered by Type" dialog.',
+          'ER Dictionary list with a detail panel. Clicking an entry opens a inline detail panel with full details. Domain names in the detail view are clickable links that open the "ER Dictionary Filtered by Type" dialog.',
       },
     },
   },
@@ -669,7 +657,7 @@ export const ErDictionary: Story = {
 
 /**
  * ER Dictionary filtered by semantic domain, shown in a Dialog. Features 2-level breadcrumbs,
- * dropdown/tree navigation toggle, and entry detail drawer.
+ * dropdown/tree navigation toggle, and entry detail panel.
  */
 export const ErDictionaryFilteredByType: Story = {
   render: () => {
@@ -714,13 +702,13 @@ export const ErDictionaryFilteredByType: Story = {
     docs: {
       description: {
         story:
-          'ER Dictionary filtered by semantic domain inside a Dialog. 2-level breadcrumbs at top; clicking them opens either a dropdown (dropdown mode) or a domain tree drawer (tree mode). Toggle between modes at the bottom. Clicking an entry opens a detail drawer.',
+          'ER Dictionary filtered by semantic domain inside a Dialog. 2-level breadcrumbs at top; clicking them opens either a dropdown (dropdown mode) or a domain tree drawer (tree mode). Toggle between modes at the bottom. Clicking an entry opens a detail panel.',
       },
     },
   },
 };
 
-/** ER Encyclopedia list with detail drawer showing article titles and teaser text. */
+/** ER Encyclopedia list with detail panel showing article titles and teaser text. */
 export const ErEncyclopedia: Story = {
   render: () => (
     <div className="tw-h-[500px] tw-rounded tw-border">
@@ -739,13 +727,13 @@ export const ErEncyclopedia: Story = {
     docs: {
       description: {
         story:
-          'ER Encyclopedia list with a detail drawer. Clicking an article opens the full article content in a right-side drawer.',
+          'ER Encyclopedia list with a detail panel. Clicking an article opens the full article content in a inline detail panel.',
       },
     },
   },
 };
 
-/** ER Media list (images and maps) with detail drawer showing image preview. */
+/** ER Media list (images and maps) with detail panel showing image preview. */
 export const ErMedia: Story = {
   render: () => (
     <div className="tw-h-[500px] tw-rounded tw-border">
@@ -765,7 +753,7 @@ export const ErMedia: Story = {
     docs: {
       description: {
         story:
-          'ER Media list with a detail drawer. Clicking an image or map opens a preview in a right-side drawer with zoom/pan support.',
+          'ER Media list with a detail panel. Clicking an image or map opens a preview in a inline detail panel with zoom/pan support.',
       },
     },
   },
@@ -922,7 +910,7 @@ export const AllErTabs: Story = {
     docs: {
       description: {
         story:
-          'All ER tabs combined with detail drawers and domain-filtered dialog. Dictionary entries open a detail drawer with clickable domain links. Clicking a domain opens the filtered dictionary dialog.',
+          'All ER tabs combined with detail panels and domain-filtered dialog. Dictionary entries open a detail panel with clickable domain links. Clicking a domain opens the filtered dictionary dialog.',
       },
     },
   },

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/shadcn-ui/button';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Badge } from '@/components/shadcn-ui/badge';
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/shadcn-ui/dialog';
+import { DrawerClose, DrawerTitle, DrawerDescription } from '@/components/shadcn-ui/drawer';
 import SourceLanguageIndexedList from '@/components/advanced/source-language-indexed-list/source-language-indexed-list.component';
 import ErDictionaryList from '@/components/advanced/source-language-indexed-list/er-dictionary-list.component';
 import ErDictionaryFilteredList from '@/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component';
@@ -334,7 +335,7 @@ const sampleLexicalEntries: LexicalDictionaryEntry[] = [
 // Shared detail content renderers (extracted from lexical dictionary pattern)
 // ---------------------------------------------------------------------------
 
-/** Renders detailed dictionary entry content inside the inline detail panel */
+/** Renders detailed dictionary entry content inside the scoped drawer */
 function DictionaryDetailContent({
   item,
   onClose,
@@ -346,16 +347,20 @@ function DictionaryDetailContent({
 }) {
   return (
     <>
-      <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
-        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
-        Back to list
-      </Button>
+      <DrawerClose asChild>
+        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
+          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+          Back to list
+        </Button>
+      </DrawerClose>
 
       <div className="tw-mb-4">
         <div className="tw-flex tw-items-baseline tw-justify-between tw-gap-2">
           <span className="tw-flex tw-flex-row tw-items-baseline tw-gap-2">
-            <h2 className="tw-text-2xl tw-font-normal">{item.primaryText}</h2>
-            <span className="tw-text-lg tw-text-muted-foreground">{item.glosses}</span>
+            <DrawerTitle className="tw-text-2xl tw-font-normal">{item.primaryText}</DrawerTitle>
+            <DrawerDescription className="tw-text-lg tw-text-muted-foreground">
+              {item.glosses}
+            </DrawerDescription>
           </span>
           <ul className="tw-flex tw-flex-row tw-gap-1">
             {item.strongsCodes.map((code) => (
@@ -417,7 +422,7 @@ function DictionaryDetailContent({
   );
 }
 
-/** Renders detailed encyclopedia content inside the inline detail panel */
+/** Renders detailed encyclopedia content inside the scoped drawer */
 function EncyclopediaDetailContent({
   item,
   onClose,
@@ -427,17 +432,19 @@ function EncyclopediaDetailContent({
 }) {
   return (
     <>
-      <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
-        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
-        Back to list
-      </Button>
+      <DrawerClose asChild>
+        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
+          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+          Back to list
+        </Button>
+      </DrawerClose>
 
-      <h2 className="tw-mb-1 tw-text-2xl tw-font-normal">{item.primaryText}</h2>
+      <DrawerTitle className="tw-mb-1 tw-text-2xl tw-font-normal">{item.primaryText}</DrawerTitle>
       {item.sourceLanguageText && (
-        <p className="tw-text-sm tw-text-muted-foreground">
+        <DrawerDescription className="tw-text-sm tw-text-muted-foreground">
           {item.sourceLanguageText}
           {item.transliteration && <span className="tw-ml-1">({item.transliteration})</span>}
-        </p>
+        </DrawerDescription>
       )}
 
       <Separator className="tw-my-3" />
@@ -449,19 +456,24 @@ function EncyclopediaDetailContent({
   );
 }
 
-/** Renders detailed media content inside the inline detail panel */
+/** Renders detailed media content inside the scoped drawer */
 function MediaDetailContent({ item, onClose }: { item: MediaItem; onClose: () => void }) {
   return (
     <>
-      <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
-        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
-        Back to list
-      </Button>
+      <DrawerClose asChild>
+        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
+          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+          Back to list
+        </Button>
+      </DrawerClose>
 
       <div className="tw-mb-4 tw-flex tw-items-center tw-gap-2">
-        <h2 className="tw-text-xl tw-font-normal">{item.primaryText}</h2>
+        <DrawerTitle className="tw-text-xl tw-font-normal">{item.primaryText}</DrawerTitle>
         <Badge variant="outline">{item.mediaType}</Badge>
       </div>
+      <DrawerDescription className="tw-sr-only">
+        {item.caption ?? item.primaryText}
+      </DrawerDescription>
 
       {item.thumbnailUrl && (
         <img

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -944,7 +944,7 @@ export const AllErTabs: Story = {
               <DrawerContent
                 container={tabContentRef.current}
                 hideDrawerHandle
-                className="tw-mt-0 tw-h-full tw-max-h-full tw-rounded-none"
+                className="tw-mt-2 tw-h-full tw-max-h-full"
               >
                 {domainPath && (
                   <DomainFilteredView

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -1,12 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ThemeProvider } from '@/storybook/theme-provider.component';
-import { ArrowLeft, ChevronDown, ChevronRight } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Badge } from '@/components/shadcn-ui/badge';
-import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/shadcn-ui/dialog';
+import ComboBox from '@/components/basics/combo-box.component';
+// Dialog/DialogContent/DialogTitle/DialogTrigger available from shadcn but not used in current stories
 import {
   Tooltip,
   TooltipContent,
@@ -14,6 +15,7 @@ import {
   TooltipTrigger,
 } from '@/components/shadcn-ui/tooltip';
 import SourceLanguageIndexedList from '@/components/advanced/source-language-indexed-list/source-language-indexed-list.component';
+import ErDictionaryFilteredList from '@/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component';
 import type {
   IndexedListItem,
   EncyclopediaTeaser,
@@ -24,7 +26,7 @@ import type {
 } from '@/components/advanced/source-language-indexed-list/source-language-indexed-list.types';
 
 // ---------------------------------------------------------------------------
-// Domain data (always 2 levels)
+// Domain data (5 levels deep)
 // ---------------------------------------------------------------------------
 
 const sampleAllDomains: SemanticDomain[] = [
@@ -32,7 +34,25 @@ const sampleAllDomains: SemanticDomain[] = [
     id: 'exist',
     label: 'Exist',
     children: [
-      { id: 'exist-create', label: 'Create' },
+      {
+        id: 'exist-create',
+        label: 'Create',
+        children: [
+          {
+            id: 'exist-create-divine',
+            label: 'Divine Creation',
+            children: [
+              {
+                id: 'exist-create-divine-world',
+                label: 'World & Cosmos',
+                children: [{ id: 'exist-create-divine-world-earth', label: 'Earth & Land' }],
+              },
+              { id: 'exist-create-divine-life', label: 'Living Beings' },
+            ],
+          },
+          { id: 'exist-create-human', label: 'Human Making' },
+        ],
+      },
       { id: 'exist-destroy', label: 'Destroy' },
       { id: 'exist-change', label: 'Change State' },
     ],
@@ -41,28 +61,54 @@ const sampleAllDomains: SemanticDomain[] = [
     id: 'happen',
     label: 'Happen',
     children: [
-      { id: 'happen-cause', label: 'Cause' },
+      {
+        id: 'happen-cause',
+        label: 'Cause',
+        children: [
+          { id: 'happen-cause-direct', label: 'Direct Causation' },
+          { id: 'happen-cause-indirect', label: 'Indirect Causation' },
+        ],
+      },
       { id: 'happen-prevent', label: 'Prevent' },
-    ],
-  },
-  {
-    id: 'social-relations',
-    label: 'Social Relations',
-    children: [
-      { id: 'family', label: 'Family' },
-      { id: 'authority', label: 'Authority & Leadership' },
-      { id: 'worship', label: 'Worship & Religion' },
     ],
   },
   {
     id: 'communication',
     label: 'Communication',
     children: [
-      { id: 'speak', label: 'Speak & Proclaim' },
+      {
+        id: 'speak',
+        label: 'Speak & Proclaim',
+        children: [
+          { id: 'speak-public', label: 'Public Speech' },
+          { id: 'speak-private', label: 'Private Speech' },
+        ],
+      },
       { id: 'write', label: 'Write & Inscribe' },
     ],
   },
 ];
+
+// ---------------------------------------------------------------------------
+// Flatten domains for combobox
+// ---------------------------------------------------------------------------
+
+type FlatDomain = { path: SemanticDomain[]; label: string };
+
+function flattenDomains(
+  domains: SemanticDomain[],
+  parentPath: SemanticDomain[] = [],
+): FlatDomain[] {
+  const result: FlatDomain[] = [];
+  for (const domain of domains) {
+    const path = [...parentPath, domain];
+    result.push({ path, label: path.map((d) => d.label).join(' > ') });
+    if (domain.children) {
+      result.push(...flattenDomains(domain.children, path));
+    }
+  }
+  return result;
+}
 
 // ---------------------------------------------------------------------------
 // Sense / entry types
@@ -74,6 +120,7 @@ type DictionarySense = {
   occurrenceCount: number;
   glosses: string;
   domain: EntryDomain;
+  domainPath?: string[];
 };
 
 type DictionaryEntryWithSenses = IndexedListItem & {
@@ -95,7 +142,7 @@ type LexicalEntryFull = LexicalDictionaryEntry & {
 };
 
 // ---------------------------------------------------------------------------
-// Sample ER dictionary items (longer words)
+// Sample ER dictionary items
 // ---------------------------------------------------------------------------
 
 const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
@@ -111,7 +158,14 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
           'causative action by which a deity brings to existence something that did not exist before.',
         occurrenceCount: 41,
         glosses: 'to create',
-        domain: { id: 'exist', label: 'Exist', code: '1.0' },
+        domain: { id: 'exist-create-divine-world-earth', label: 'Earth & Land', code: '1.0' },
+        domainPath: [
+          'exist',
+          'exist-create',
+          'exist-create-divine',
+          'exist-create-divine-world',
+          'exist-create-divine-world-earth',
+        ],
       },
       {
         number: 2,
@@ -119,7 +173,8 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
           'causative action by which a deity causes something to happen that did not happen before.',
         occurrenceCount: 7,
         glosses: 'to create (an event); to cause to happen',
-        domain: { id: 'happen', label: 'Happen', code: '2.0' },
+        domain: { id: 'happen-cause-direct', label: 'Direct Causation', code: '2.0' },
+        domainPath: ['happen', 'happen-cause', 'happen-cause-direct'],
       },
     ],
     totalOccurrences: 48,
@@ -135,14 +190,8 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
         definition: 'to utter words or speech; to communicate verbally.',
         occurrenceCount: 523,
         glosses: 'to say, to speak, to tell',
-        domain: { id: 'speak', label: 'Speak & Proclaim', parentId: 'communication', code: '4.1' },
-      },
-      {
-        number: 2,
-        definition: 'to think or intend within oneself.',
-        occurrenceCount: 34,
-        glosses: 'to say to oneself, to think',
-        domain: { id: 'happen-cause', label: 'Cause', parentId: 'happen', code: '2.1' },
+        domain: { id: 'speak-public', label: 'Public Speech', code: '4.1' },
+        domainPath: ['communication', 'speak', 'speak-public'],
       },
     ],
     totalOccurrences: 557,
@@ -158,7 +207,8 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
         definition: 'to bring something into being by forming, constructing, or producing.',
         occurrenceCount: 412,
         glosses: 'to make, to do, to produce',
-        domain: { id: 'exist-create', label: 'Create', parentId: 'exist', code: '1.1' },
+        domain: { id: 'exist-create-human', label: 'Human Making', code: '1.1' },
+        domainPath: ['exist', 'exist-create', 'exist-create-human'],
       },
     ],
     totalOccurrences: 412,
@@ -174,7 +224,8 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
         definition: 'to move on foot; to go or travel by walking.',
         occurrenceCount: 198,
         glosses: 'to walk, to go, to travel',
-        domain: { id: 'happen-cause', label: 'Cause', parentId: 'happen', code: '2.1' },
+        domain: { id: 'happen-cause-direct', label: 'Direct Causation', code: '2.1' },
+        domainPath: ['happen', 'happen-cause', 'happen-cause-direct'],
       },
     ],
     totalOccurrences: 198,
@@ -190,16 +241,13 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
         definition: 'to perceive sound with the ear; to listen attentively and respond.',
         occurrenceCount: 287,
         glosses: 'to hear, to listen, to obey',
-        domain: { id: 'speak', label: 'Speak & Proclaim', parentId: 'communication', code: '4.1' },
+        domain: { id: 'speak-public', label: 'Public Speech', code: '4.1' },
+        domainPath: ['communication', 'speak', 'speak-public'],
       },
     ],
     totalOccurrences: 287,
   },
 ];
-
-// ---------------------------------------------------------------------------
-// Sample encyclopedia items (longer words, with source language)
-// ---------------------------------------------------------------------------
 
 const sampleEncyclopediaItems: EncyclopediaTeaser[] = [
   {
@@ -207,24 +255,21 @@ const sampleEncyclopediaItems: EncyclopediaTeaser[] = [
     primaryText: 'Temple of Artemis at Ephesus',
     sourceLanguageText: '\u1F08\u03C1\u03C4\u03B5\u03BC\u03AF\u03C3\u03B9\u03BF\u03BD',
     transliteration: 'Artemision',
-    teaserText:
-      'One of the Seven Wonders of the Ancient World, dedicated to the Greek goddess Artemis.',
+    teaserText: 'One of the Seven Wonders of the Ancient World.',
   },
   {
     id: 'enc-2',
     primaryText: 'Corinthian Church Community',
-    sourceLanguageText:
-      '\u1F10\u03BA\u03BA\u03BB\u03B7\u03C3\u03AF\u03B1 \u039A\u03BF\u03C1\u03AF\u03BD\u03B8\u03BF\u03C5',
+    sourceLanguageText: '\u1F10\u03BA\u03BA\u03BB\u03B7\u03C3\u03AF\u03B1',
     transliteration: 'ekklesia Korinthou',
-    teaserText: 'The early Christian community in Corinth addressed in two Pauline epistles.',
+    teaserText: 'The early Christian community addressed in two Pauline epistles.',
   },
   {
     id: 'enc-3',
     primaryText: 'Rite of Baptismal Purification',
     sourceLanguageText: '\u03B2\u03AC\u03C0\u03C4\u03B9\u03C3\u03BC\u03B1',
     transliteration: 'baptisma',
-    teaserText:
-      'A rite of washing with water as a sign of religious purification and consecration.',
+    teaserText: 'A rite of washing with water as a sign of purification.',
   },
 ];
 
@@ -241,13 +286,9 @@ const sampleMediaItems: MediaItem[] = [
     primaryText: 'Theater at Ephesus',
     thumbnailUrl: 'https://placehold.co/200x200/e2e8f0/64748b?text=Photo',
     mediaType: 'image',
-    caption: 'The Great Theater, seating ~25,000 spectators',
+    caption: 'The Great Theater',
   },
 ];
-
-// ---------------------------------------------------------------------------
-// Sample lexical entries (full detail)
-// ---------------------------------------------------------------------------
 
 const sampleLexicalEntries: LexicalEntryFull[] = [
   {
@@ -260,14 +301,14 @@ const sampleLexicalEntries: LexicalEntryFull[] = [
     senses: [
       {
         id: 's1',
-        glosses: ['word', 'message', 'statement'],
-        definition: 'A meaningful unit of spoken or written language.',
+        glosses: ['word', 'message'],
+        definition: 'A meaningful unit of language.',
         domains: [{ taxonomy: 'SDBG-Lexical', code: '33.A', label: 'Communication' }],
       },
       {
         id: 's2',
         glosses: ['reason', 'account'],
-        definition: 'The rational faculty or principle; explanation.',
+        definition: 'The rational faculty.',
         domains: [{ taxonomy: 'SDBG-Contextual', code: '32.B', label: 'Thought' }],
       },
     ],
@@ -284,19 +325,12 @@ const sampleLexicalEntries: LexicalEntryFull[] = [
     senses: [
       {
         id: 's1',
-        glosses: ['God', 'the true God'],
-        definition: 'The supreme deity; the creator and ruler of the universe.',
+        glosses: ['God'],
+        definition: 'The supreme deity.',
         domains: [{ taxonomy: 'SDBG-Lexical', code: '12.A', label: 'Supernatural' }],
       },
     ],
-    chapterOccurrences: [
-      { ref: 'John 1:1' },
-      { ref: 'John 1:2' },
-      { ref: 'John 1:6' },
-      { ref: 'John 1:12' },
-      { ref: 'John 1:13' },
-      { ref: 'John 1:18' },
-    ],
+    chapterOccurrences: [{ ref: 'John 1:1' }, { ref: 'John 1:2' }, { ref: 'John 1:6' }],
     allOccurrences: Array.from({ length: 45 }, (_, i) => ({ ref: `Ref ${i + 1}` })),
   },
   {
@@ -309,19 +343,12 @@ const sampleLexicalEntries: LexicalEntryFull[] = [
     senses: [
       {
         id: 's1',
-        glosses: ['light', 'radiance', 'illumination'],
-        definition:
-          'Natural agent that makes things visible; figuratively, truth or understanding.',
+        glosses: ['light', 'radiance'],
+        definition: 'Natural agent that makes things visible.',
         domains: [{ taxonomy: 'SDBG-Lexical', code: '14.A', label: 'Physical' }],
       },
     ],
-    chapterOccurrences: [
-      { ref: 'John 1:4' },
-      { ref: 'John 1:5' },
-      { ref: 'John 1:7' },
-      { ref: 'John 1:8' },
-      { ref: 'John 1:9' },
-    ],
+    chapterOccurrences: [{ ref: 'John 1:4' }, { ref: 'John 1:5' }, { ref: 'John 1:7' }],
     allOccurrences: Array.from({ length: 9 }, (_, i) => ({ ref: `Ref ${i + 1}` })),
   },
   {
@@ -334,8 +361,8 @@ const sampleLexicalEntries: LexicalEntryFull[] = [
     senses: [
       {
         id: 's1',
-        glosses: ['life', 'living', 'existence'],
-        definition: 'The state of being alive; vitality. Often refers to eternal life.',
+        glosses: ['life', 'living'],
+        definition: 'The state of being alive.',
         domains: [{ taxonomy: 'SDBG-Lexical', code: '23.A', label: 'Physiological' }],
       },
     ],
@@ -345,10 +372,9 @@ const sampleLexicalEntries: LexicalEntryFull[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Shared list item renderers
+// List item renderers (always 2 lines, no wrap, no horizontal overflow)
 // ---------------------------------------------------------------------------
 
-/** ER dictionary list item - always 2 rows. Hides occurrence count when `compact`. */
 function ErDictListItem({
   item,
   compact = false,
@@ -358,10 +384,10 @@ function ErDictListItem({
 }) {
   const firstSense = item.senses[0];
   return (
-    <div className="tw-flex tw-w-full tw-flex-col tw-gap-0.5">
-      <div className="tw-flex tw-items-baseline tw-gap-2">
-        <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
-        <span className="tw-text-sm tw-text-muted-foreground">
+    <div className="tw-flex tw-w-full tw-flex-col tw-gap-0.5 tw-overflow-hidden">
+      <div className="tw-flex tw-items-baseline tw-gap-2 tw-overflow-hidden">
+        <span className="tw-shrink-0 tw-text-sm tw-font-medium">{item.primaryText}</span>
+        <span className="tw-truncate tw-text-sm tw-text-muted-foreground">
           {item.sourceLanguageText}
           {item.transliteration && <span className="tw-ml-1">({item.transliteration})</span>}
         </span>
@@ -379,12 +405,11 @@ function ErDictListItem({
   );
 }
 
-/** Lexical list item - same padding/border/hover style as ER dictionary */
 function LexicalListItem({ item, compact = false }: { item: LexicalEntryFull; compact?: boolean }) {
   return (
-    <div className="tw-flex tw-w-full tw-flex-col tw-gap-0.5">
-      <div className="tw-flex tw-items-baseline tw-gap-2">
-        <span className="scripture-font tw-text-sm">{item.primaryText}</span>
+    <div className="tw-flex tw-w-full tw-flex-col tw-gap-0.5 tw-overflow-hidden">
+      <div className="tw-flex tw-items-baseline tw-gap-2 tw-overflow-hidden">
+        <span className="scripture-font tw-shrink-0 tw-text-sm">{item.primaryText}</span>
         {!compact && (
           <TooltipProvider>
             <Tooltip>
@@ -417,10 +442,9 @@ function LexicalListItem({ item, compact = false }: { item: LexicalEntryFull; co
 }
 
 // ---------------------------------------------------------------------------
-// Detail content renderers
+// Detail renderers
 // ---------------------------------------------------------------------------
 
-/** ER Dictionary entry detail (PT9 screenshot layout) */
 function ErDictionaryDetail({
   item,
   onClose,
@@ -428,7 +452,7 @@ function ErDictionaryDetail({
 }: {
   item: DictionaryEntryWithSenses;
   onClose: () => void;
-  onDomainClick?: (domain: EntryDomain) => void;
+  onDomainClick?: (domain: EntryDomain, domainPath?: string[]) => void;
 }) {
   return (
     <div>
@@ -436,16 +460,14 @@ function ErDictionaryDetail({
         <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
         Back to list
       </Button>
-
       <div className="tw-mb-4">
-        <span className="tw-text-lg tw-font-normal">{item.sourceLanguageText}</span>
+        <span className="tw-text-lg">{item.sourceLanguageText}</span>
         {item.transliteration && (
           <span className="tw-ml-1 tw-text-base tw-text-muted-foreground">
             ({item.transliteration})
           </span>
         )}
       </div>
-
       <div className="tw-space-y-4">
         {item.senses.map((sense) => (
           <div key={sense.number} className="tw-pl-1">
@@ -462,7 +484,7 @@ function ErDictionaryDetail({
               <Button
                 variant="link"
                 className="tw-h-auto tw-p-0 tw-text-sm tw-italic tw-underline"
-                onClick={() => onDomainClick?.(sense.domain)}
+                onClick={() => onDomainClick?.(sense.domain, sense.domainPath)}
               >
                 {sense.domain.label}
               </Button>
@@ -470,7 +492,6 @@ function ErDictionaryDetail({
           </div>
         ))}
       </div>
-
       <Separator className="tw-my-3" />
       <p className="tw-text-sm">
         Occurrences in all books{' '}
@@ -480,15 +501,12 @@ function ErDictionaryDetail({
   );
 }
 
-/** Full lexical dictionary detail (matching platform-lexical-tools extension) */
 function LexicalDetail({ item, onClose }: { item: LexicalEntryFull; onClose: () => void }) {
   const [selectedSenseId, setSelectedSenseId] = useState<string | undefined>(
     item.senses.length === 1 ? item.senses[0].id : undefined,
   );
-  const [occurrenceView, setOccurrenceView] = useState<'chapter' | 'all'>('chapter');
-
-  const selectedSense = item.senses.find((s) => s.id === selectedSenseId);
-  const occurrences = occurrenceView === 'chapter' ? item.chapterOccurrences : item.allOccurrences;
+  const [occView, setOccView] = useState<'chapter' | 'all'>('chapter');
+  const occs = occView === 'chapter' ? item.chapterOccurrences : item.allOccurrences;
 
   return (
     <div>
@@ -496,112 +514,95 @@ function LexicalDetail({ item, onClose }: { item: LexicalEntryFull; onClose: () 
         <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
         Back to list
       </Button>
-
-      {/* Header */}
-      <div className="tw-mb-3">
-        <div className="tw-flex tw-items-baseline tw-justify-between tw-gap-2">
-          <span className="tw-flex tw-items-baseline tw-gap-2">
-            <span className="scripture-font tw-text-2xl tw-font-normal">{item.primaryText}</span>
-            <span className="tw-text-lg tw-text-muted-foreground">{item.glosses}</span>
-          </span>
-          <div className="tw-flex tw-gap-1">
-            {item.strongsCodes.map((code) => (
-              <span key={code} className="tw-rounded tw-bg-accent tw-px-2 tw-py-0.5 tw-text-sm">
-                {code}
-              </span>
-            ))}
-          </div>
+      <div className="tw-mb-3 tw-flex tw-items-baseline tw-justify-between tw-gap-2">
+        <span className="tw-flex tw-items-baseline tw-gap-2">
+          <span className="scripture-font tw-text-2xl">{item.primaryText}</span>
+          <span className="tw-text-lg tw-text-muted-foreground">{item.glosses}</span>
+        </span>
+        <div className="tw-flex tw-gap-1">
+          {item.strongsCodes.map((c) => (
+            <span key={c} className="tw-rounded tw-bg-accent tw-px-2 tw-py-0.5 tw-text-sm">
+              {c}
+            </span>
+          ))}
         </div>
       </div>
-
       <Separator className="tw-my-3" />
-
-      {/* Senses */}
-      <div className="tw-mb-4">
-        <h3 className="tw-mb-1 tw-font-semibold">Senses</h3>
-        <div className="tw-flex tw-flex-col tw-gap-3">
-          {item.senses.map((sense, idx) => (
-            <button
-              key={sense.id}
-              type="button"
-              onClick={() =>
-                setSelectedSenseId(selectedSenseId === sense.id ? undefined : sense.id)
-              }
-              className={cn(
-                'tw-flex tw-w-full tw-flex-col tw-items-start tw-rounded-lg tw-border tw-p-3 tw-text-left tw-shadow-sm tw-transition-colors',
-                selectedSenseId === sense.id
-                  ? 'tw-border-accent tw-shadow-md'
-                  : 'hover:tw-border-accent',
-              )}
-            >
-              <div className="tw-flex tw-items-baseline tw-gap-2">
-                <span className="tw-font-bold tw-text-accent-foreground">{idx + 1}</span>
-                <span className="tw-text-sm">{sense.glosses.join(', ')}</span>
+      <h3 className="tw-mb-1 tw-font-semibold">Senses</h3>
+      <div className="tw-flex tw-flex-col tw-gap-3">
+        {item.senses.map((sense, idx) => (
+          <button
+            key={sense.id}
+            type="button"
+            onClick={() => setSelectedSenseId(selectedSenseId === sense.id ? undefined : sense.id)}
+            className={cn(
+              'tw-flex tw-w-full tw-flex-col tw-items-start tw-rounded-lg tw-border tw-p-3 tw-text-left tw-shadow-sm tw-transition-colors',
+              selectedSenseId === sense.id
+                ? 'tw-border-accent tw-shadow-md'
+                : 'hover:tw-border-accent',
+            )}
+          >
+            <div className="tw-flex tw-items-baseline tw-gap-2">
+              <span className="tw-font-bold tw-text-accent-foreground">{idx + 1}</span>
+              <span className="tw-text-sm">{sense.glosses.join(', ')}</span>
+            </div>
+            {sense.definition && (
+              <p className="tw-mt-1 tw-text-sm tw-text-muted-foreground">{sense.definition}</p>
+            )}
+            {sense.domains.length > 0 && (
+              <div className="tw-mt-2 tw-flex tw-flex-wrap tw-gap-1">
+                {sense.domains.map((d) => (
+                  <span
+                    key={d.code}
+                    className="tw-rounded tw-bg-accent tw-px-2 tw-py-0.5 tw-text-xs"
+                  >
+                    {d.code} {d.label ?? ''}
+                  </span>
+                ))}
               </div>
-              {sense.definition && (
-                <p className="tw-mt-1 tw-text-sm tw-text-muted-foreground">{sense.definition}</p>
-              )}
-              {sense.domains.length > 0 && (
-                <div className="tw-mt-2 tw-flex tw-flex-wrap tw-gap-1">
-                  {sense.domains.map((d) => (
-                    <span
-                      key={d.code}
-                      className="tw-rounded tw-bg-accent tw-px-2 tw-py-0.5 tw-text-xs"
-                    >
-                      {d.code} {d.label ?? ''}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </button>
-          ))}
+            )}
+          </button>
+        ))}
+      </div>
+      <Separator className="tw-my-3" />
+      <div className="tw-mb-2 tw-flex tw-items-center tw-justify-between">
+        <h3 className="tw-font-semibold">Occurrences</h3>
+        <div className="tw-flex tw-rounded-md tw-border">
+          <button
+            type="button"
+            className={cn(
+              'tw-rounded-s-md tw-px-3 tw-py-1 tw-text-xs',
+              occView === 'chapter' ? 'tw-bg-accent' : 'hover:tw-bg-accent',
+            )}
+            onClick={() => setOccView('chapter')}
+          >
+            Chapter ({item.chapterOccurrences.length})
+          </button>
+          <button
+            type="button"
+            className={cn(
+              'tw-rounded-e-md tw-px-3 tw-py-1 tw-text-xs',
+              occView === 'all' ? 'tw-bg-accent' : 'hover:tw-bg-accent',
+            )}
+            onClick={() => setOccView('all')}
+          >
+            All ({item.allOccurrences.length})
+          </button>
         </div>
       </div>
-
-      {/* Occurrences with chapter/all toggle */}
-      <div>
-        <div className="tw-mb-2 tw-flex tw-items-center tw-justify-between">
-          <h3 className="tw-font-semibold">
-            {selectedSense ? `Occurrences for sense` : 'All occurrences'}
-          </h3>
-          <div className="tw-flex tw-items-center tw-gap-0 tw-rounded-md tw-border">
-            <button
-              type="button"
-              className={cn('tw-rounded-s-md tw-px-3 tw-py-1 tw-text-xs', {
-                'tw-bg-accent': occurrenceView === 'chapter',
-                'hover:tw-bg-accent': occurrenceView !== 'chapter',
-              })}
-              onClick={() => setOccurrenceView('chapter')}
-            >
-              Chapter ({item.chapterOccurrences.length})
-            </button>
-            <button
-              type="button"
-              className={cn('tw-rounded-e-md tw-px-3 tw-py-1 tw-text-xs', {
-                'tw-bg-accent': occurrenceView === 'all',
-                'hover:tw-bg-accent': occurrenceView !== 'all',
-              })}
-              onClick={() => setOccurrenceView('all')}
-            >
-              All ({item.allOccurrences.length})
-            </button>
-          </div>
-        </div>
-        <ul className="tw-list-inside tw-list-disc">
-          {occurrences.map((occ) => (
-            <li key={occ.ref} className="tw-py-0.5">
-              <Button variant="link" className="tw-h-auto tw-p-0">
-                {occ.ref}
-              </Button>
-            </li>
-          ))}
-        </ul>
-      </div>
+      <ul className="tw-list-inside tw-list-disc">
+        {occs.map((o) => (
+          <li key={o.ref} className="tw-py-0.5">
+            <Button variant="link" className="tw-h-auto tw-p-0">
+              {o.ref}
+            </Button>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }
 
-/** Encyclopedia detail */
 function EncyclopediaDetail({ item, onClose }: { item: EncyclopediaTeaser; onClose: () => void }) {
   return (
     <div>
@@ -609,7 +610,7 @@ function EncyclopediaDetail({ item, onClose }: { item: EncyclopediaTeaser; onClo
         <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
         Back to list
       </Button>
-      <h2 className="tw-mb-1 tw-text-xl tw-font-normal">{item.primaryText}</h2>
+      <h2 className="tw-mb-1 tw-text-xl">{item.primaryText}</h2>
       {item.sourceLanguageText && (
         <p className="tw-text-sm tw-text-muted-foreground">
           {item.sourceLanguageText}
@@ -622,7 +623,6 @@ function EncyclopediaDetail({ item, onClose }: { item: EncyclopediaTeaser; onClo
   );
 }
 
-/** Media detail */
 function MediaDetail({ item, onClose }: { item: MediaItem; onClose: () => void }) {
   return (
     <div>
@@ -631,7 +631,7 @@ function MediaDetail({ item, onClose }: { item: MediaItem; onClose: () => void }
         Back to list
       </Button>
       <div className="tw-mb-3 tw-flex tw-items-center tw-gap-2">
-        <h2 className="tw-text-lg tw-font-normal">{item.primaryText}</h2>
+        <h2 className="tw-text-lg">{item.primaryText}</h2>
         <Badge variant="outline">{item.mediaType}</Badge>
       </div>
       {item.thumbnailUrl && (
@@ -647,167 +647,80 @@ function MediaDetail({ item, onClose }: { item: MediaItem; onClose: () => void }
 }
 
 // ---------------------------------------------------------------------------
-// Domain tree dialog (expandable, scrolls to current)
+// Generic inline list+detail layout with responsive breakpoint
 // ---------------------------------------------------------------------------
 
-function DomainTreeDialog({
-  domains,
-  selectedLevel1Id,
-  selectedLevel2Id,
-  onSelect,
-  trigger,
-}: {
-  domains: SemanticDomain[];
-  selectedLevel1Id: string;
-  selectedLevel2Id?: string;
-  onSelect: (level1: SemanticDomain, level2?: SemanticDomain) => void;
-  trigger: React.ReactNode;
-}) {
-  const [open, setOpen] = useState(false);
-  const [expanded, setExpanded] = useState<Set<string>>(new Set([selectedLevel1Id]));
-  // ref.current expects null not undefined for element refs
-  // eslint-disable-next-line no-null/no-null
-  const selectedRef = useRef<HTMLButtonElement>(null);
-
-  const toggleExpand = (id: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(id)) next.delete(id);
-      else next.add(id);
-      return next;
-    });
-  };
-
-  // Expand the selected category and scroll to it when dialog opens
-  useEffect(() => {
-    if (open) {
-      setExpanded((prev) => new Set(prev).add(selectedLevel1Id));
-      // Defer scroll until DOM has rendered
-      requestAnimationFrame(() => {
-        selectedRef.current?.scrollIntoView({ block: 'center' });
-      });
-    }
-  }, [open, selectedLevel1Id]);
-
-  const handleSelect = useCallback(
-    (l1: SemanticDomain, l2?: SemanticDomain) => {
-      onSelect(l1, l2);
-      setOpen(false);
-    },
-    [onSelect],
-  );
-
-  return (
-    <Dialog open={open} onOpenChange={setOpen}>
-      <DialogTrigger asChild>{trigger}</DialogTrigger>
-      <DialogContent className="tw-flex tw-max-h-[70vh] tw-max-w-sm tw-flex-col tw-p-0">
-        <DialogTitle className="tw-px-4 tw-pt-4 tw-text-base tw-font-semibold">
-          Semantic Domains
-        </DialogTitle>
-        <div className="tw-flex-1 tw-overflow-y-auto tw-px-2 tw-pb-4">
-          <ul className="tw-space-y-0.5">
-            {domains.map((level1) => {
-              const isExpanded = expanded.has(level1.id);
-              return (
-                <li key={level1.id}>
-                  <button
-                    type="button"
-                    className="tw-flex tw-w-full tw-items-center tw-gap-1 tw-rounded tw-px-2 tw-py-1.5 tw-text-left tw-text-sm tw-font-semibold hover:tw-bg-muted"
-                    onClick={() => toggleExpand(level1.id)}
-                  >
-                    {isExpanded ? (
-                      <ChevronDown className="tw-h-4 tw-w-4 tw-shrink-0" />
-                    ) : (
-                      <ChevronRight className="tw-h-4 tw-w-4 tw-shrink-0" />
-                    )}
-                    {level1.label}
-                  </button>
-                  {isExpanded && level1.children && (
-                    <ul className="tw-ml-5 tw-space-y-0.5">
-                      {level1.children.map((level2) => {
-                        const isActive =
-                          level1.id === selectedLevel1Id && level2.id === selectedLevel2Id;
-                        return (
-                          <li key={level2.id}>
-                            <button
-                              type="button"
-                              ref={isActive ? selectedRef : undefined}
-                              className={cn(
-                                'tw-w-full tw-rounded tw-px-2 tw-py-1 tw-text-left tw-text-sm',
-                                isActive ? 'tw-bg-accent tw-font-medium' : 'hover:tw-bg-muted',
-                              )}
-                              onClick={() => handleSelect(level1, level2)}
-                            >
-                              {level2.label}
-                            </button>
-                          </li>
-                        );
-                      })}
-                    </ul>
-                  )}
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Shared inline list+detail layout
-// ---------------------------------------------------------------------------
-
-/** Generic inline list + detail pane. List hides overflow (no scroll) when detail is shown. */
 function InlineListDetail<T extends { id: string }>({
   items,
   selectedItem,
   onSelectItem,
   renderListItem,
   renderDetail,
-  listClassName,
 }: {
   items: T[];
   selectedItem: T | undefined;
   onSelectItem: (item: T | undefined) => void;
   renderListItem: (item: T, compact: boolean) => React.ReactNode;
   renderDetail: (item: T) => React.ReactNode;
-  listClassName?: string;
 }) {
+  // eslint-disable-next-line no-null/no-null
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [narrow, setNarrow] = useState(false);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return undefined;
+    const observer = new ResizeObserver(([entry]) => {
+      setNarrow((entry?.contentRect.width ?? 0) < 360);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, []);
+
+  const showSideBySide = selectedItem && !narrow;
+  const showFullDetail = selectedItem && narrow;
+
   return (
-    <div className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
-      <div
-        className={cn(
-          'tw-h-full',
-          selectedItem
-            ? 'tw-w-1/5 tw-min-w-[120px] tw-overflow-hidden tw-border-r'
-            : 'tw-w-full tw-overflow-y-auto',
-          listClassName,
-        )}
-      >
-        <ul role="listbox" className="tw-outline-none">
-          {items.map((item) => {
-            const isSelected = selectedItem?.id === item.id;
-            return (
-              <li
-                key={item.id}
-                role="option"
-                aria-selected={isSelected}
-                onClick={() => onSelectItem(isSelected ? undefined : item)}
-                className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
-                  'tw-bg-muted': isSelected,
-                  'hover:tw-bg-muted': !isSelected,
-                })}
-              >
-                {renderListItem(item, !!selectedItem)}
-              </li>
-            );
-          })}
-        </ul>
-      </div>
+    <div ref={containerRef} className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
+      {/* List pane: hidden overflow (no scroll) when detail is shown side-by-side, full-width scroll when alone */}
+      {!showFullDetail && (
+        <div
+          className={cn(
+            'tw-h-full',
+            showSideBySide
+              ? 'tw-w-1/5 tw-min-w-[120px] tw-overflow-hidden tw-border-r'
+              : 'tw-w-full tw-overflow-y-auto',
+          )}
+        >
+          <ul role="listbox" className="tw-outline-none">
+            {items.map((item) => {
+              const isSelected = selectedItem?.id === item.id;
+              return (
+                <li
+                  key={item.id}
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => onSelectItem(isSelected ? undefined : item)}
+                  className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
+                    'tw-bg-muted': isSelected,
+                    'hover:tw-bg-muted': !isSelected,
+                  })}
+                >
+                  {renderListItem(item, !!selectedItem)}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+      {/* Detail pane */}
       {selectedItem && (
-        <div className="tw-w-4/5 tw-overflow-y-auto tw-bg-background tw-p-4">
+        <div
+          className={cn(
+            'tw-overflow-y-auto tw-bg-background tw-p-4',
+            showFullDetail ? 'tw-w-full' : 'tw-w-4/5',
+          )}
+        >
           {renderDetail(selectedItem)}
         </div>
       )}
@@ -816,7 +729,7 @@ function InlineListDetail<T extends { id: string }>({
 }
 
 // ---------------------------------------------------------------------------
-// Story meta
+// Story meta (full width - no max-w-2xl constraint)
 // ---------------------------------------------------------------------------
 
 const meta: Meta<typeof SourceLanguageIndexedList> = {
@@ -826,7 +739,7 @@ const meta: Meta<typeof SourceLanguageIndexedList> = {
   decorators: [
     (Story) => (
       <ThemeProvider>
-        <div className="tw-max-w-2xl tw-p-4">
+        <div className="tw-p-4">
           <Story />
         </div>
       </ThemeProvider>
@@ -841,7 +754,6 @@ type Story = StoryObj<typeof SourceLanguageIndexedList>;
 // Stories
 // ---------------------------------------------------------------------------
 
-/** Base list without detail panel */
 export const Default: Story = {
   render: () => {
     const [selectedId, setSelectedId] = useState<string | undefined>();
@@ -866,7 +778,6 @@ export const Loading: Story = {
     </div>
   ),
 };
-
 export const EmptyState: Story = {
   render: () => (
     <div className="tw-h-[400px] tw-rounded tw-border">
@@ -876,37 +787,33 @@ export const EmptyState: Story = {
 };
 
 /**
- * All ER tabs with inline panel detail view and inline domain navigation. Dictionary entries open a
- * detail panel matching the PT9 screenshot layout. Domain links replace the dictionary view
- * inline.
+ * All ER tabs with inline panel + inline domain navigation. Domain links open a bottom drawer with
+ * 5-level breadcrumb navigation.
  */
 export const AllErTabs: Story = {
   render: () => {
     const [activeTab, setActiveTab] = useState<'dictionary' | 'encyclopedia' | 'media'>(
       'dictionary',
     );
-    const [selectedDictItem, setSelectedDictItem] = useState<
-      DictionaryEntryWithSenses | undefined
-    >();
-    const [selectedEncItem, setSelectedEncItem] = useState<EncyclopediaTeaser | undefined>();
-    const [selectedMediaItem, setSelectedMediaItem] = useState<MediaItem | undefined>();
-    const [activeDomain, setActiveDomain] = useState<
-      | {
-          level1: SemanticDomain;
-          level2?: SemanticDomain;
-        }
-      | undefined
-    >();
+    const [selectedDict, setSelectedDict] = useState<DictionaryEntryWithSenses | undefined>();
+    const [selectedEnc, setSelectedEnc] = useState<EncyclopediaTeaser | undefined>();
+    const [selectedMedia, setSelectedMedia] = useState<MediaItem | undefined>();
+    const [domainPath, setDomainPath] = useState<SemanticDomain[] | undefined>();
 
-    const handleDomainClick = (domain: EntryDomain) => {
-      const l1 = sampleAllDomains.find(
-        (d) => d.id === domain.id || d.children?.some((c) => c.id === domain.id),
-      );
-      if (l1) {
-        setActiveDomain({ level1: l1, level2: l1.children?.find((c) => c.id === domain.id) });
-        setSelectedDictItem(undefined);
+    const handleDomainClick = useCallback((_domain: EntryDomain, pathIds?: string[]) => {
+      if (pathIds) {
+        const path = pathIds.reduce<SemanticDomain[]>((acc, id) => {
+          const parent = acc.length === 0 ? sampleAllDomains : (acc[acc.length - 1].children ?? []);
+          const found = parent.find((d) => d.id === id);
+          if (found) acc.push(found);
+          return acc;
+        }, []);
+        if (path.length > 0) {
+          setDomainPath(path);
+          setSelectedDict(undefined);
+        }
       }
-    };
+    }, []);
 
     return (
       <div className="tw-flex tw-h-[550px] tw-flex-col tw-rounded tw-border">
@@ -915,59 +822,61 @@ export const AllErTabs: Story = {
             <button
               key={tab}
               type="button"
-              className={`tw-px-4 tw-py-2 tw-text-sm tw-capitalize ${
-                activeTab === tab
-                  ? 'tw-border-b-2 tw-border-primary tw-font-medium'
-                  : 'tw-text-muted-foreground hover:tw-text-foreground'
-              }`}
+              className={`tw-px-4 tw-py-2 tw-text-sm tw-capitalize ${activeTab === tab ? 'tw-border-b-2 tw-border-primary tw-font-medium' : 'tw-text-muted-foreground hover:tw-text-foreground'}`}
               onClick={() => {
                 setActiveTab(tab);
-                setSelectedDictItem(undefined);
-                setSelectedEncItem(undefined);
-                setSelectedMediaItem(undefined);
-                setActiveDomain(undefined);
+                setSelectedDict(undefined);
+                setSelectedEnc(undefined);
+                setSelectedMedia(undefined);
+                setDomainPath(undefined);
               }}
             >
               {tab}
             </button>
           ))}
         </div>
-
         <div className="tw-flex-1 tw-overflow-hidden">
-          {activeTab === 'dictionary' && !activeDomain && (
+          {activeTab === 'dictionary' && !domainPath && (
             <InlineListDetail
               items={sampleDictionaryItems}
-              selectedItem={selectedDictItem}
-              onSelectItem={setSelectedDictItem}
+              selectedItem={selectedDict}
+              onSelectItem={setSelectedDict}
               renderListItem={(item, compact) => <ErDictListItem item={item} compact={compact} />}
               renderDetail={(item) => (
                 <ErDictionaryDetail
                   item={item}
-                  onClose={() => setSelectedDictItem(undefined)}
+                  onClose={() => setSelectedDict(undefined)}
                   onDomainClick={handleDomainClick}
                 />
               )}
             />
           )}
-
-          {activeTab === 'dictionary' && activeDomain && (
-            <DomainFilteredInline
-              activeDomain={activeDomain}
-              onDomainChange={(l1, l2) => setActiveDomain({ level1: l1, level2: l2 })}
-              onBack={() => setActiveDomain(undefined)}
+          {activeTab === 'dictionary' && domainPath && (
+            <ErDictionaryFilteredList
+              items={sampleDictionaryItems}
+              domainPath={domainPath}
+              allDomains={sampleAllDomains}
+              onDomainChange={setDomainPath}
+              onBack={() => setDomainPath(undefined)}
+              renderItem={(item) => <ErDictListItem item={item} />}
+              renderDetailContent={(item, onClose) => (
+                <ErDictionaryDetail item={item} onClose={onClose} />
+              )}
+              className="tw-h-full"
             />
           )}
-
           {activeTab === 'encyclopedia' && (
             <InlineListDetail
               items={sampleEncyclopediaItems}
-              selectedItem={selectedEncItem}
-              onSelectItem={setSelectedEncItem}
+              selectedItem={selectedEnc}
+              onSelectItem={setSelectedEnc}
               renderListItem={(item) => (
-                <div className="tw-flex tw-flex-col tw-gap-0.5">
-                  <div className="tw-flex tw-items-baseline tw-gap-2">
-                    <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
-                    <span className="tw-text-sm tw-text-muted-foreground">
+                <div className="tw-flex tw-flex-col tw-gap-0.5 tw-overflow-hidden">
+                  <div className="tw-flex tw-items-baseline tw-gap-2 tw-overflow-hidden">
+                    <span className="tw-shrink-0 tw-text-sm tw-font-medium">
+                      {item.primaryText}
+                    </span>
+                    <span className="tw-truncate tw-text-sm tw-text-muted-foreground">
                       {item.sourceLanguageText}
                       {item.transliteration && (
                         <span className="tw-ml-1">({item.transliteration})</span>
@@ -980,27 +889,28 @@ export const AllErTabs: Story = {
                 </div>
               )}
               renderDetail={(item) => (
-                <EncyclopediaDetail item={item} onClose={() => setSelectedEncItem(undefined)} />
+                <EncyclopediaDetail item={item} onClose={() => setSelectedEnc(undefined)} />
               )}
             />
           )}
-
           {activeTab === 'media' && (
             <InlineListDetail
               items={sampleMediaItems}
-              selectedItem={selectedMediaItem}
-              onSelectItem={setSelectedMediaItem}
+              selectedItem={selectedMedia}
+              onSelectItem={setSelectedMedia}
               renderListItem={(item) => (
-                <div className="tw-flex tw-items-center tw-gap-2">
+                <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden">
                   {item.thumbnailUrl && (
                     <img
                       src={item.thumbnailUrl}
                       alt={item.primaryText}
-                      className="tw-h-10 tw-w-10 tw-rounded tw-object-cover"
+                      className="tw-h-10 tw-w-10 tw-shrink-0 tw-rounded tw-object-cover"
                     />
                   )}
-                  <div className="tw-flex tw-flex-col tw-gap-0.5">
-                    <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
+                  <div className="tw-flex tw-flex-col tw-gap-0.5 tw-overflow-hidden">
+                    <span className="tw-truncate tw-text-sm tw-font-medium">
+                      {item.primaryText}
+                    </span>
                     <Badge variant="outline" className="tw-w-fit tw-text-xs">
                       {item.mediaType}
                     </Badge>
@@ -1008,7 +918,7 @@ export const AllErTabs: Story = {
                 </div>
               )}
               renderDetail={(item) => (
-                <MediaDetail item={item} onClose={() => setSelectedMediaItem(undefined)} />
+                <MediaDetail item={item} onClose={() => setSelectedMedia(undefined)} />
               )}
             />
           )}
@@ -1018,13 +928,10 @@ export const AllErTabs: Story = {
   },
 };
 
-/**
- * Lexical extension dictionary with inline panel. Full detail view with senses, occurrence
- * chapter/all toggle, domains, and Strong's codes. List uses same styling as ER dictionary.
- */
+/** Lexical dictionary with full detail (senses, chapter/all occurrences, domains, Strong's codes). */
 export const LexicalDictionary: Story = {
   render: () => {
-    const [selectedItem, setSelectedItem] = useState<LexicalEntryFull | undefined>();
+    const [selected, setSelected] = useState<LexicalEntryFull | undefined>();
     return (
       <div className="tw-h-[550px] tw-rounded tw-border">
         <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
@@ -1033,11 +940,11 @@ export const LexicalDictionary: Story = {
         <div className="tw-h-[calc(100%-41px)]">
           <InlineListDetail
             items={sampleLexicalEntries}
-            selectedItem={selectedItem}
-            onSelectItem={setSelectedItem}
+            selectedItem={selected}
+            onSelectItem={setSelected}
             renderListItem={(item, compact) => <LexicalListItem item={item} compact={compact} />}
             renderDetail={(item) => (
-              <LexicalDetail item={item} onClose={() => setSelectedItem(undefined)} />
+              <LexicalDetail item={item} onClose={() => setSelected(undefined)} />
             )}
           />
         </div>
@@ -1046,78 +953,51 @@ export const LexicalDictionary: Story = {
   },
 };
 
-// ---------------------------------------------------------------------------
-// Helper: domain filtered inline view used within AllErTabs
-// ---------------------------------------------------------------------------
+/** Alternative: domain selection via ComboBox (searchable) instead of Dialog tree. */
+export const DomainComboBoxAlternative: Story = {
+  render: () => {
+    const flatDomains = useMemo(() => flattenDomains(sampleAllDomains), []);
+    const [selectedFlat, setSelectedFlat] = useState<FlatDomain>(flatDomains[0]);
+    const [selectedItem, setSelectedItem] = useState<DictionaryEntryWithSenses | undefined>();
 
-function DomainFilteredInline({
-  activeDomain,
-  onDomainChange,
-  onBack,
-}: {
-  activeDomain: { level1: SemanticDomain; level2?: SemanticDomain };
-  onDomainChange: (level1: SemanticDomain, level2?: SemanticDomain) => void;
-  onBack: () => void;
-}) {
-  const [selectedItem, setSelectedItem] = useState<DictionaryEntryWithSenses | undefined>();
-
-  const effectiveLevel2 = activeDomain.level2 ?? activeDomain.level1.children?.[0];
-  const domainLabel = effectiveLevel2
-    ? `${activeDomain.level1.label} \u00B7 ${effectiveLevel2.label}`
-    : activeDomain.level1.label;
-
-  const filteredItems = useMemo(
-    () =>
-      sampleDictionaryItems.filter((entry) =>
-        entry.senses.some(
-          (s) =>
-            s.domain.id === activeDomain.level1.id ||
-            s.domain.id === effectiveLevel2?.id ||
-            s.domain.parentId === activeDomain.level1.id,
-        ),
-      ),
-    [activeDomain.level1.id, effectiveLevel2?.id],
-  );
-
-  return (
-    <div className="tw-flex tw-h-full tw-flex-col">
-      {/* Header: [← Back] [domain dropdown centered] */}
-      <div className="tw-flex tw-items-center tw-gap-2 tw-border-b tw-px-2 tw-py-1.5">
-        <Button variant="ghost" size="sm" onClick={onBack} className="tw-shrink-0 tw-gap-1">
-          <ArrowLeft className="tw-h-4 tw-w-4" />
-          Back
-        </Button>
-        <div className="tw-flex tw-flex-1 tw-justify-center">
-          <DomainTreeDialog
-            domains={sampleAllDomains}
-            selectedLevel1Id={activeDomain.level1.id}
-            selectedLevel2Id={effectiveLevel2?.id}
-            onSelect={(l1, l2) => {
-              onDomainChange(l1, l2);
+    return (
+      <div className="tw-flex tw-h-[550px] tw-flex-col tw-rounded tw-border">
+        <div className="tw-flex tw-items-center tw-gap-2 tw-border-b tw-px-3 tw-py-2">
+          <span className="tw-shrink-0 tw-text-sm tw-font-semibold">Domain:</span>
+          <ComboBox
+            options={flatDomains}
+            value={selectedFlat}
+            onChange={(v) => {
+              setSelectedFlat(v);
               setSelectedItem(undefined);
             }}
-            trigger={
-              <Button variant="outline" className="tw-gap-1 tw-text-sm">
-                {domainLabel}
-                <ChevronDown className="tw-h-3 tw-w-3" />
-              </Button>
-            }
+            getOptionLabel={(o) => o.label}
+            textPlaceholder="Search domains..."
+            buttonPlaceholder="Select a domain"
+            buttonVariant="outline"
+            buttonClassName="tw-flex-1 tw-justify-start tw-text-sm"
+          />
+        </div>
+        <div className="tw-flex-1 tw-overflow-hidden">
+          <InlineListDetail
+            items={sampleDictionaryItems}
+            selectedItem={selectedItem}
+            onSelectItem={setSelectedItem}
+            renderListItem={(item, compact) => <ErDictListItem item={item} compact={compact} />}
+            renderDetail={(item) => (
+              <ErDictionaryDetail item={item} onClose={() => setSelectedItem(undefined)} />
+            )}
           />
         </div>
       </div>
-
-      {/* List + detail */}
-      <div className="tw-flex-1 tw-overflow-hidden">
-        <InlineListDetail
-          items={filteredItems}
-          selectedItem={selectedItem}
-          onSelectItem={setSelectedItem}
-          renderListItem={(item, compact) => <ErDictListItem item={item} compact={compact} />}
-          renderDetail={(item) => (
-            <ErDictionaryDetail item={item} onClose={() => setSelectedItem(undefined)} />
-          )}
-        />
-      </div>
-    </div>
-  );
-}
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Alternative domain selection using a searchable ComboBox instead of the tree dialog. Type to filter domains across all levels.',
+      },
+    },
+  },
+};

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -683,7 +683,7 @@ function InlineListDetail<T extends { id: string }>({
     const el = containerRef.current;
     if (!el) return undefined;
     const observer = new ResizeObserver(([entry]) => {
-      setNarrow((entry?.contentRect.width ?? 0) < 360);
+      setNarrow((entry?.contentRect.width ?? 0) < 500);
     });
     observer.observe(el);
     return () => observer.disconnect();

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -1,13 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ThemeProvider } from '@/storybook/theme-provider.component';
 import { ArrowLeft } from 'lucide-react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Badge } from '@/components/shadcn-ui/badge';
-import ComboBox from '@/components/basics/combo-box.component';
 import { Drawer, DrawerContent } from '@/components/shadcn-ui/drawer';
+import { Dialog, DialogContent, DialogTitle } from '@/components/shadcn-ui/dialog';
 import {
   Tooltip,
   TooltipContent,
@@ -88,27 +88,6 @@ const sampleAllDomains: SemanticDomain[] = [
     ],
   },
 ];
-
-// ---------------------------------------------------------------------------
-// Flatten domains for combobox
-// ---------------------------------------------------------------------------
-
-type FlatDomain = { path: SemanticDomain[]; label: string };
-
-function flattenDomains(
-  domains: SemanticDomain[],
-  parentPath: SemanticDomain[] = [],
-): FlatDomain[] {
-  const result: FlatDomain[] = [];
-  for (const domain of domains) {
-    const path = [...parentPath, domain];
-    result.push({ path, label: path.map((d) => d.label).join(' > ') });
-    if (domain.children) {
-      result.push(...flattenDomains(domain.children, path));
-    }
-  }
-  return result;
-}
 
 // ---------------------------------------------------------------------------
 // Sense / entry types
@@ -673,7 +652,7 @@ function InlineListDetail<T extends { id: string }>({
   selectedItem: T | undefined;
   onSelectItem: (item: T | undefined) => void;
   renderListItem: (item: T, compact: boolean) => React.ReactNode;
-  renderDetail: (item: T) => React.ReactNode;
+  renderDetail: (item: T, onClose: () => void) => React.ReactNode;
 }) {
   // eslint-disable-next-line no-null/no-null
   const containerRef = useRef<HTMLDivElement>(null);
@@ -697,29 +676,23 @@ function InlineListDetail<T extends { id: string }>({
 
   // Keyboard navigation: arrows move focus, behavior depends on narrow/wide.
   // First keypress starts from the selected item (or first/last if none).
+  // At the boundaries the list stays put (no wrap, no reselect).
   const handleListKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (items.length === 0) return;
       const selectedIdx = selectedItem ? items.findIndex((i) => i.id === selectedItem.id) : -1;
+      const startIdx = focusedIdx >= 0 ? focusedIdx : selectedIdx;
 
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        let next: number;
-        if (focusedIdx < 0) {
-          next = selectedIdx >= 0 ? Math.min(selectedIdx + 1, items.length - 1) : 0;
-        } else {
-          next = Math.min(focusedIdx + 1, items.length - 1);
-        }
+        const next = startIdx < 0 ? 0 : Math.min(startIdx + 1, items.length - 1);
+        if (next === focusedIdx) return;
         setFocusedIdx(next);
         if (!narrow) onSelectItem(items[next]);
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        let prev: number;
-        if (focusedIdx < 0) {
-          prev = selectedIdx >= 0 ? Math.max(selectedIdx - 1, 0) : items.length - 1;
-        } else {
-          prev = Math.max(focusedIdx - 1, 0);
-        }
+        const prev = startIdx < 0 ? items.length - 1 : Math.max(startIdx - 1, 0);
+        if (prev === focusedIdx) return;
         setFocusedIdx(prev);
         if (!narrow) onSelectItem(items[prev]);
       } else if ((e.key === 'Enter' || e.key === ' ') && narrow && focusedIdx >= 0) {
@@ -736,6 +709,19 @@ function InlineListDetail<T extends { id: string }>({
     const li = listRef.current.children[focusedIdx] as HTMLElement | undefined;
     li?.scrollIntoView({ block: 'nearest' });
   }, [focusedIdx]);
+
+  // On close, restore focus to the list starting from the last selected item.
+  const handleCloseDetail = useCallback(() => {
+    const closingId = selectedItem?.id;
+    onSelectItem(undefined);
+    if (closingId) {
+      const idx = items.findIndex((i) => i.id === closingId);
+      if (idx >= 0) setFocusedIdx(idx);
+      requestAnimationFrame(() => {
+        listRef.current?.focus();
+      });
+    }
+  }, [items, onSelectItem, selectedItem]);
 
   return (
     <div ref={containerRef} className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
@@ -787,7 +773,7 @@ function InlineListDetail<T extends { id: string }>({
             showFullDetail ? 'tw-w-full' : 'tw-w-2/3',
           )}
         >
-          {renderDetail(selectedItem)}
+          {renderDetail(selectedItem, handleCloseDetail)}
         </div>
       )}
     </div>
@@ -918,10 +904,10 @@ export const AllErTabs: Story = {
               selectedItem={selectedDict}
               onSelectItem={setSelectedDict}
               renderListItem={(item, compact) => <ErDictListItem item={item} compact={compact} />}
-              renderDetail={(item) => (
+              renderDetail={(item, onClose) => (
                 <ErDictionaryDetail
                   item={item}
-                  onClose={() => setSelectedDict(undefined)}
+                  onClose={onClose}
                   onDomainClick={handleDomainClick}
                 />
               )}
@@ -950,9 +936,7 @@ export const AllErTabs: Story = {
                   </span>
                 </div>
               )}
-              renderDetail={(item) => (
-                <EncyclopediaDetail item={item} onClose={() => setSelectedEnc(undefined)} />
-              )}
+              renderDetail={(item, onClose) => <EncyclopediaDetail item={item} onClose={onClose} />}
             />
           )}
           {activeTab === 'media' && (
@@ -979,17 +963,19 @@ export const AllErTabs: Story = {
                   </div>
                 </div>
               )}
-              renderDetail={(item) => (
-                <MediaDetail item={item} onClose={() => setSelectedMedia(undefined)} />
-              )}
+              renderDetail={(item, onClose) => <MediaDetail item={item} onClose={onClose} />}
             />
           )}
 
-          {/* Domain-filtered bottom Drawer (slides up, fills full tab height) */}
+          {/* Domain-filtered bottom Drawer (slides up, fills full tab height).
+              shouldScaleBackground={false} stops vaul from scaling the page
+              wrapper — otherwise the tab buttons above the drawer container
+              become uninteractive while the drawer is open. */}
           {activeTab === 'dictionary' && (
             <Drawer
               direction="bottom"
               modal={false}
+              shouldScaleBackground={false}
               open={domainPath !== undefined}
               onOpenChange={(open) => {
                 if (!open) setDomainPath(undefined);
@@ -998,7 +984,7 @@ export const AllErTabs: Story = {
               <DrawerContent
                 container={tabContentRef.current}
                 hideDrawerHandle
-                className="tw-top-[0.5rem] tw-mt-0 tw-h-full tw-max-h-full tw-rounded-t-lg"
+                className="tw-top-0.5 tw-mt-0 tw-h-full tw-max-h-full tw-rounded-t-lg"
               >
                 {domainPath && (
                   <DomainFilteredView
@@ -1032,9 +1018,7 @@ export const LexicalDictionary: Story = {
             selectedItem={selected}
             onSelectItem={setSelected}
             renderListItem={(item, compact) => <LexicalListItem item={item} compact={compact} />}
-            renderDetail={(item) => (
-              <LexicalDetail item={item} onClose={() => setSelected(undefined)} />
-            )}
+            renderDetail={(item, onClose) => <LexicalDetail item={item} onClose={onClose} />}
           />
         </div>
       </div>
@@ -1042,42 +1026,68 @@ export const LexicalDictionary: Story = {
   },
 };
 
-/** Alternative: domain selection via ComboBox (searchable) instead of Dialog tree. */
-export const DomainComboBoxAlternative: Story = {
+/**
+ * Alternative to AllErTabs: shows the domain-filtered view inside a centered modal Dialog instead
+ * of a bottom Drawer. Clicking a domain link inside an entry's detail opens the dialog.
+ */
+export const AllErTabsDialogVariant: Story = {
   render: () => {
-    const flatDomains = useMemo(() => flattenDomains(sampleAllDomains), []);
-    const [selectedFlat, setSelectedFlat] = useState<FlatDomain>(flatDomains[0]);
-    const [selectedItem, setSelectedItem] = useState<DictionaryEntryWithSenses | undefined>();
+    const [selectedDict, setSelectedDict] = useState<DictionaryEntryWithSenses | undefined>();
+    const [domainPath, setDomainPath] = useState<SemanticDomain[] | undefined>();
+
+    const resolveDomainPath = useCallback((pathIds: string[]): SemanticDomain[] => {
+      return pathIds.reduce<SemanticDomain[]>((acc, id) => {
+        const parent = acc.length === 0 ? sampleAllDomains : (acc[acc.length - 1].children ?? []);
+        const found = parent.find((d) => d.id === id);
+        if (found) acc.push(found);
+        return acc;
+      }, []);
+    }, []);
+
+    const handleDomainClick = useCallback(
+      (_domain: EntryDomain, pathIds?: string[]) => {
+        if (pathIds) {
+          const path = resolveDomainPath(pathIds);
+          if (path.length > 0) setDomainPath(path);
+        }
+      },
+      [resolveDomainPath],
+    );
 
     return (
       <div className="tw-flex tw-h-[550px] tw-flex-col tw-rounded tw-border">
-        <div className="tw-flex tw-items-center tw-gap-2 tw-border-b tw-px-3 tw-py-2">
-          <span className="tw-shrink-0 tw-text-sm tw-font-semibold">Domain:</span>
-          <ComboBox
-            options={flatDomains}
-            value={selectedFlat}
-            onChange={(v) => {
-              setSelectedFlat(v);
-              setSelectedItem(undefined);
-            }}
-            getOptionLabel={(o) => o.label}
-            textPlaceholder="Search domains..."
-            buttonPlaceholder="Select a domain"
-            buttonVariant="outline"
-            buttonClassName="tw-flex-1 tw-justify-start tw-text-sm"
-          />
-        </div>
+        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
+          Dictionary (Dialog variant)
+        </h3>
         <div className="tw-flex-1 tw-overflow-hidden">
           <InlineListDetail
             items={sampleDictionaryItems}
-            selectedItem={selectedItem}
-            onSelectItem={setSelectedItem}
+            selectedItem={selectedDict}
+            onSelectItem={setSelectedDict}
             renderListItem={(item, compact) => <ErDictListItem item={item} compact={compact} />}
-            renderDetail={(item) => (
-              <ErDictionaryDetail item={item} onClose={() => setSelectedItem(undefined)} />
+            renderDetail={(item, onClose) => (
+              <ErDictionaryDetail item={item} onClose={onClose} onDomainClick={handleDomainClick} />
             )}
           />
         </div>
+        <Dialog
+          open={domainPath !== undefined}
+          onOpenChange={(open) => {
+            if (!open) setDomainPath(undefined);
+          }}
+        >
+          <DialogContent className="tw-flex tw-h-[80vh] tw-max-h-[600px] tw-w-[90vw] tw-max-w-3xl tw-flex-col tw-overflow-hidden tw-p-0">
+            <DialogTitle className="tw-sr-only">Filtered dictionary</DialogTitle>
+            {domainPath && (
+              <DomainFilteredView
+                domainPath={domainPath}
+                onDomainChange={setDomainPath}
+                onClose={() => setDomainPath(undefined)}
+                onDomainClick={handleDomainClick}
+              />
+            )}
+          </DialogContent>
+        </Dialog>
       </div>
     );
   },
@@ -1085,7 +1095,7 @@ export const DomainComboBoxAlternative: Story = {
     docs: {
       description: {
         story:
-          'Alternative domain selection using a searchable ComboBox instead of the tree dialog. Type to filter domains across all levels.',
+          'Alternative to the bottom Drawer: the domain-filtered view is presented in a centered modal Dialog.',
       },
     },
   },

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -1,0 +1,627 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { ThemeProvider } from '@/storybook/theme-provider.component';
+import SourceLanguageIndexedList from '@/components/advanced/source-language-indexed-list/source-language-indexed-list.component';
+import ErDictionaryList from '@/components/advanced/source-language-indexed-list/er-dictionary-list.component';
+import ErDictionaryFilteredList from '@/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component';
+import ErEncyclopediaList from '@/components/advanced/source-language-indexed-list/er-encyclopedia-list.component';
+import ErMediaList from '@/components/advanced/source-language-indexed-list/er-media-list.component';
+import LexicalDictionaryList from '@/components/advanced/source-language-indexed-list/lexical-dictionary-list.component';
+import type {
+  IndexedListItem,
+  EncyclopediaTeaser,
+  MediaItem,
+  LexicalDictionaryEntry,
+  SemanticDomain,
+} from '@/components/advanced/source-language-indexed-list/source-language-indexed-list.types';
+
+// ---------------------------------------------------------------------------
+// Sample data
+// ---------------------------------------------------------------------------
+
+const sampleDictionaryItems: (IndexedListItem & {
+  glosses: string;
+  strongsCodes: string[];
+  occurrenceCount: number;
+})[] = [
+  {
+    id: 'entry-1',
+    primaryText: 'grace',
+    sourceLanguageText: '\u03C7\u03AC\u03C1\u03B9\u03C2',
+    transliteration: 'charis',
+    glosses: 'grace, favor, kindness',
+    strongsCodes: ['G5485'],
+    occurrenceCount: 12,
+  },
+  {
+    id: 'entry-2',
+    primaryText: 'faith',
+    sourceLanguageText: '\u03C0\u03AF\u03C3\u03C4\u03B9\u03C2',
+    transliteration: 'pistis',
+    glosses: 'faith, belief, trust',
+    strongsCodes: ['G4102'],
+    occurrenceCount: 8,
+  },
+  {
+    id: 'entry-3',
+    primaryText: 'love',
+    sourceLanguageText: '\u1F00\u03B3\u03AC\u03C0\u03B7',
+    transliteration: 'agape',
+    glosses: 'love, affection, goodwill',
+    strongsCodes: ['G26'],
+    occurrenceCount: 15,
+  },
+  {
+    id: 'entry-4',
+    primaryText: 'righteousness',
+    sourceLanguageText: '\u03B4\u03B9\u03BA\u03B1\u03B9\u03BF\u03C3\u03CD\u03BD\u03B7',
+    transliteration: 'dikaiosyne',
+    glosses: 'righteousness, justice',
+    strongsCodes: ['G1343'],
+    occurrenceCount: 5,
+  },
+  {
+    id: 'entry-5',
+    primaryText: 'salvation',
+    sourceLanguageText: '\u03C3\u03C9\u03C4\u03B7\u03C1\u03AF\u03B1',
+    transliteration: 'soteria',
+    glosses: 'salvation, deliverance, preservation',
+    strongsCodes: ['G4991'],
+    occurrenceCount: 3,
+  },
+  {
+    id: 'entry-6',
+    primaryText: 'glory',
+    sourceLanguageText: '\u03B4\u03CC\u03BE\u03B1',
+    transliteration: 'doxa',
+    glosses: 'glory, splendor, brightness',
+    strongsCodes: ['G1391'],
+    occurrenceCount: 7,
+  },
+];
+
+const sampleEncyclopediaItems: EncyclopediaTeaser[] = [
+  {
+    id: 'enc-1',
+    primaryText: 'Ephesus',
+    sourceLanguageText: '\u1F1C\u03C6\u03B5\u03C3\u03BF\u03C2',
+    transliteration: 'Ephesos',
+    teaserText:
+      'An ancient Greek city on the coast of Ionia, renowned for the Temple of Artemis. Paul spent about three years there establishing the early church.',
+  },
+  {
+    id: 'enc-2',
+    primaryText: 'Corinth',
+    sourceLanguageText: '\u039A\u03CC\u03C1\u03B9\u03BD\u03B8\u03BF\u03C2',
+    transliteration: 'Korinthos',
+    teaserText:
+      'A major Greek city-state located on the isthmus connecting the Peloponnese to mainland Greece. Paul wrote two epistles to the church there.',
+  },
+  {
+    id: 'enc-3',
+    primaryText: 'Baptism',
+    sourceLanguageText: '\u03B2\u03AC\u03C0\u03C4\u03B9\u03C3\u03BC\u03B1',
+    transliteration: 'baptisma',
+    teaserText:
+      'A rite of washing with water as a sign of religious purification and consecration. Central to Christian initiation.',
+  },
+  {
+    id: 'enc-4',
+    primaryText: 'Pharisees',
+    sourceLanguageText: '\u03A6\u03B1\u03C1\u03B9\u03C3\u03B1\u1FD6\u03BF\u03B9',
+    transliteration: 'Pharisaioi',
+    teaserText:
+      'A Jewish sect known for strict observance of the Torah and oral traditions. Frequently mentioned in the Gospels in dialogue with Jesus.',
+  },
+  {
+    id: 'enc-5',
+    primaryText: 'Covenant',
+    sourceLanguageText: '\u03B4\u03B9\u03B1\u03B8\u03AE\u03BA\u03B7',
+    transliteration: 'diatheke',
+    teaserText:
+      'A solemn agreement between God and his people. Key covenants include those with Abraham, Moses, and the New Covenant through Christ.',
+  },
+];
+
+const sampleMediaItems: MediaItem[] = [
+  {
+    id: 'media-1',
+    primaryText: 'Map of Ancient Ephesus',
+    sourceLanguageText: '\u1F1C\u03C6\u03B5\u03C3\u03BF\u03C2',
+    transliteration: 'Ephesos',
+    thumbnailUrl: 'https://placehold.co/200x200/e2e8f0/64748b?text=Map',
+    thumbnailAlt: 'Map of Ancient Ephesus',
+    mediaType: 'map',
+    caption: 'City plan showing the harbor, theater, and Temple of Artemis',
+  },
+  {
+    id: 'media-2',
+    primaryText: 'Theater at Ephesus',
+    sourceLanguageText: '\u03B8\u03AD\u03B1\u03C4\u03C1\u03BF\u03BD',
+    transliteration: 'theatron',
+    thumbnailUrl: 'https://placehold.co/200x200/e2e8f0/64748b?text=Photo',
+    thumbnailAlt: 'Photo of the ancient theater at Ephesus',
+    mediaType: 'image',
+    caption: 'The Great Theater, seating approximately 25,000 spectators',
+  },
+  {
+    id: 'media-3',
+    primaryText: "Paul's Missionary Journeys",
+    sourceLanguageText: '\u03BF\u03B4\u03BF\u03B9\u03C0\u03BF\u03C1\u03AF\u03B1',
+    transliteration: 'hodoiporia',
+    thumbnailUrl: 'https://placehold.co/200x200/e2e8f0/64748b?text=Map',
+    thumbnailAlt: "Map of Paul's missionary journeys",
+    mediaType: 'map',
+    caption: 'Routes of the first, second, and third missionary journeys',
+  },
+  {
+    id: 'media-4',
+    primaryText: 'Temple of Artemis',
+    sourceLanguageText: '\u0391\u03C1\u03C4\u03AD\u03BC\u03B9\u03C2',
+    transliteration: 'Artemis',
+    thumbnailUrl: 'https://placehold.co/200x200/e2e8f0/64748b?text=Photo',
+    thumbnailAlt: 'Artistic reconstruction of the Temple of Artemis',
+    mediaType: 'image',
+    caption: 'One of the Seven Wonders of the Ancient World',
+  },
+];
+
+const sampleLexicalEntries: LexicalDictionaryEntry[] = [
+  {
+    id: 'lex-1',
+    primaryText: '\u03BB\u03CC\u03B3\u03BF\u03C2',
+    sourceLanguageText: '\u03BB\u03CC\u03B3\u03BF\u03C2',
+    transliteration: 'logos',
+    strongsCodes: ['G3056'],
+    glosses: 'word, speech, message, reason',
+    occurrenceCount: 23,
+  },
+  {
+    id: 'lex-2',
+    primaryText: '\u03B8\u03B5\u03CC\u03C2',
+    sourceLanguageText: '\u03B8\u03B5\u03CC\u03C2',
+    transliteration: 'theos',
+    strongsCodes: ['G2316'],
+    glosses: 'God, god, deity',
+    occurrenceCount: 45,
+  },
+  {
+    id: 'lex-3',
+    primaryText: '\u03BA\u03CC\u03C3\u03BC\u03BF\u03C2',
+    sourceLanguageText: '\u03BA\u03CC\u03C3\u03BC\u03BF\u03C2',
+    transliteration: 'kosmos',
+    strongsCodes: ['G2889'],
+    glosses: 'world, universe, order',
+    occurrenceCount: 17,
+  },
+  {
+    id: 'lex-4',
+    primaryText: '\u03C6\u1FF6\u03C2',
+    sourceLanguageText: '\u03C6\u1FF6\u03C2',
+    transliteration: 'phos',
+    strongsCodes: ['G5457'],
+    glosses: 'light, radiance',
+    occurrenceCount: 9,
+  },
+  {
+    id: 'lex-5',
+    primaryText: '\u03C3\u03BA\u03BF\u03C4\u03AF\u03B1',
+    sourceLanguageText: '\u03C3\u03BA\u03BF\u03C4\u03AF\u03B1',
+    transliteration: 'skotia',
+    strongsCodes: ['G4653'],
+    glosses: 'darkness, gloom',
+    occurrenceCount: 4,
+  },
+  {
+    id: 'lex-6',
+    primaryText: '\u03B6\u03C9\u03AE',
+    sourceLanguageText: '\u03B6\u03C9\u03AE',
+    transliteration: 'zoe',
+    strongsCodes: ['G2222'],
+    glosses: 'life, living',
+    occurrenceCount: 11,
+  },
+  {
+    id: 'lex-7',
+    primaryText: '\u1F00\u03BB\u03AE\u03B8\u03B5\u03B9\u03B1',
+    sourceLanguageText: '\u1F00\u03BB\u03AE\u03B8\u03B5\u03B9\u03B1',
+    transliteration: 'aletheia',
+    strongsCodes: ['G225'],
+    glosses: 'truth, reality',
+    occurrenceCount: 6,
+  },
+];
+
+const sampleDomainPath: SemanticDomain[] = [
+  { id: 'root', label: 'All Domains' },
+  { id: 'natural-world', label: 'Natural World' },
+  { id: 'animals', label: 'Animals' },
+];
+
+const sampleDomainChildren: SemanticDomain[] = [
+  {
+    id: 'domestic',
+    label: 'Domestic Animals',
+    children: [
+      { id: 'cattle', label: 'Cattle' },
+      { id: 'sheep', label: 'Sheep & Goats' },
+      { id: 'donkeys', label: 'Donkeys' },
+    ],
+  },
+  {
+    id: 'wild',
+    label: 'Wild Animals',
+    children: [
+      { id: 'predators', label: 'Predators' },
+      { id: 'prey', label: 'Prey Animals' },
+    ],
+  },
+  { id: 'birds', label: 'Birds' },
+  { id: 'fish', label: 'Fish & Sea Creatures' },
+  { id: 'insects', label: 'Insects' },
+];
+
+const sampleFilteredItems: IndexedListItem[] = [
+  {
+    id: 'filtered-1',
+    primaryText: 'lamb',
+    sourceLanguageText: '\u1F00\u03BC\u03BD\u03CC\u03C2',
+    transliteration: 'amnos',
+  },
+  {
+    id: 'filtered-2',
+    primaryText: 'sheep',
+    sourceLanguageText: '\u03C0\u03C1\u03CC\u03B2\u03B1\u03C4\u03BF\u03BD',
+    transliteration: 'probaton',
+  },
+  {
+    id: 'filtered-3',
+    primaryText: 'goat',
+    sourceLanguageText: '\u03B1\u1F34\u03BE',
+    transliteration: 'aix',
+  },
+  {
+    id: 'filtered-4',
+    primaryText: 'ox',
+    sourceLanguageText: '\u03B2\u03BF\u1FE6\u03C2',
+    transliteration: 'bous',
+  },
+  {
+    id: 'filtered-5',
+    primaryText: 'donkey',
+    sourceLanguageText: '\u1F44\u03BD\u03BF\u03C2',
+    transliteration: 'onos',
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Story meta
+// ---------------------------------------------------------------------------
+
+const meta: Meta<typeof SourceLanguageIndexedList> = {
+  title: 'Advanced/SourceLanguageIndexedList',
+  component: SourceLanguageIndexedList,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <div className="tw-max-w-2xl tw-p-4">
+          <Story />
+        </div>
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SourceLanguageIndexedList>;
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** Base SourceLanguageIndexedList with default two-column layout */
+export const Default: Story = {
+  render: () => {
+    const [selectedId, setSelectedId] = useState<string | undefined>();
+
+    return (
+      <div className="tw-h-[400px] tw-rounded tw-border">
+        <SourceLanguageIndexedList
+          items={sampleDictionaryItems}
+          onItemClick={(item) => setSelectedId(item.id === selectedId ? undefined : item.id)}
+          selectedItemId={selectedId}
+          showSourceLanguage
+          showTransliteration
+        />
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Base SourceLanguageIndexedList component showing the default two-column layout with resource terms and source language terms.',
+      },
+    },
+  },
+};
+
+/** Loading state with skeleton placeholders */
+export const Loading: Story = {
+  render: () => (
+    <div className="tw-h-[400px] tw-rounded tw-border">
+      <SourceLanguageIndexedList items={[]} isLoading />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Loading state showing skeleton placeholders while data is being fetched.',
+      },
+    },
+  },
+};
+
+/** Empty state with custom message */
+export const EmptyState: Story = {
+  render: () => (
+    <div className="tw-h-[400px] tw-rounded tw-border">
+      <SourceLanguageIndexedList
+        items={[]}
+        emptyStateMessage="No dictionary entries found for this scope"
+      />
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Empty state shown when no items match the current filter or scope.',
+      },
+    },
+  },
+};
+
+/**
+ * ER Dictionary list showing both columns (resource term + source language), occurrence count
+ * badges, formatted glosses, and Strong's code badges.
+ */
+export const ErDictionary: Story = {
+  render: () => {
+    const [selectedId, setSelectedId] = useState<string | undefined>();
+
+    return (
+      <div className="tw-h-[500px] tw-rounded tw-border">
+        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">Dictionary</h3>
+        <ErDictionaryList
+          items={sampleDictionaryItems}
+          onItemClick={(item) => setSelectedId(item.id === selectedId ? undefined : item.id)}
+          selectedItemId={selectedId}
+          getDescription={(item) => item.glosses}
+          getBadges={(item) => item.strongsCodes}
+          getOccurrenceCount={(item) => item.occurrenceCount}
+        />
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "ER Dictionary list showing both columns with occurrence counts, glosses, and Strong's codes. Used in the Dictionary tab of the Enhanced Resources research pane.",
+      },
+    },
+  },
+};
+
+/**
+ * ER Dictionary filtered by semantic domain, showing breadcrumb navigation and a toggle to switch
+ * between tree view (Option A) and dropdown view (Option B) for domain navigation.
+ */
+export const ErDictionaryFilteredByType: Story = {
+  render: () => {
+    const [selectedId, setSelectedId] = useState<string | undefined>();
+    const [navMode, setNavMode] = useState<'tree' | 'dropdown'>('tree');
+    const [domainPath, setDomainPath] = useState<SemanticDomain[]>(sampleDomainPath);
+
+    const handleBreadcrumbClick = (domain: SemanticDomain) => {
+      const index = domainPath.findIndex((d) => d.id === domain.id);
+      if (index >= 0) {
+        setDomainPath(domainPath.slice(0, index + 1));
+      }
+    };
+
+    const handleDomainSelect = (domain: SemanticDomain) => {
+      setDomainPath([...domainPath, domain]);
+    };
+
+    return (
+      <div className="tw-h-[600px] tw-rounded tw-border">
+        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
+          Dictionary &mdash; Filtered by Semantic Domain
+        </h3>
+        <ErDictionaryFilteredList
+          items={sampleFilteredItems}
+          onItemClick={(item) => setSelectedId(item.id === selectedId ? undefined : item.id)}
+          selectedItemId={selectedId}
+          domainPath={domainPath}
+          onBreadcrumbClick={handleBreadcrumbClick}
+          navigationMode={navMode}
+          onNavigationModeChange={setNavMode}
+          domainChildren={sampleDomainChildren}
+          onDomainSelect={handleDomainSelect}
+          className="tw-h-full"
+        />
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Dictionary entries filtered by semantic domain. Shows breadcrumb trail for the domain hierarchy and a toggle to switch between tree view (Option A, showing nested hierarchy) and dropdown view (Option B, showing siblings at each level). Corresponds to Screen A from ui-alignment.md.',
+      },
+    },
+  },
+};
+
+/** ER Encyclopedia list showing article titles with teaser/summary text. */
+export const ErEncyclopedia: Story = {
+  render: () => {
+    const [selectedId, setSelectedId] = useState<string | undefined>();
+
+    return (
+      <div className="tw-h-[500px] tw-rounded tw-border">
+        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">Encyclopedia</h3>
+        <ErEncyclopediaList
+          items={sampleEncyclopediaItems}
+          onItemClick={(item) => setSelectedId(item.id === selectedId ? undefined : item.id)}
+          selectedItemId={selectedId}
+        />
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'ER Encyclopedia list showing article titles with teaser/summary text and source language terms. Used in the Encyclopedia tab of the Enhanced Resources research pane.',
+      },
+    },
+  },
+};
+
+/** ER Media list (images and maps) using the thumbnail variant with image previews. */
+export const ErMedia: Story = {
+  render: () => {
+    const [selectedId, setSelectedId] = useState<string | undefined>();
+
+    return (
+      <div className="tw-h-[500px] tw-rounded tw-border">
+        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
+          Media (Images &amp; Maps)
+        </h3>
+        <ErMediaList
+          items={sampleMediaItems}
+          onItemClick={(item) => setSelectedId(item.id === selectedId ? undefined : item.id)}
+          selectedItemId={selectedId}
+        />
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'ER Media list showing images and maps with thumbnail previews, media type badges, and captions. Used in the Media and Maps tabs of the Enhanced Resources research pane.',
+      },
+    },
+  },
+};
+
+/**
+ * Lexical extension dictionary list extracted from platform-lexical-tools. Shows entries with lemma
+ * text, occurrence count badges, formatted glosses, and Strong's code badges. Matches the existing
+ * dictionary list pattern from the lexical tools extension.
+ */
+export const LexicalDictionary: Story = {
+  render: () => {
+    const [selectedId, setSelectedId] = useState<string | undefined>();
+
+    return (
+      <div className="tw-h-[500px] tw-rounded tw-border">
+        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
+          Lexical Dictionary
+        </h3>
+        <LexicalDictionaryList
+          items={sampleLexicalEntries}
+          onItemClick={(item) => setSelectedId(item?.id === selectedId ? undefined : item?.id)}
+          selectedItemId={selectedId}
+          occurrenceCountLabel="Occurrences in chapter"
+          strongsCodeLabel="Strong's code"
+        />
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Lexical extension dictionary list extracted from platform-lexical-tools. Shows entries with source language lemma, occurrence count, glosses, and Strong's codes. This is the shared version of the existing dictionary list component.",
+      },
+    },
+  },
+};
+
+/** All ER tabs combined to show how the components work together in a research pane layout. */
+export const AllErTabs: Story = {
+  render: () => {
+    const [activeTab, setActiveTab] = useState<'dictionary' | 'encyclopedia' | 'media'>(
+      'dictionary',
+    );
+    const [selectedId, setSelectedId] = useState<string | undefined>();
+
+    const handleItemClick = (item: IndexedListItem) => {
+      setSelectedId(item.id === selectedId ? undefined : item.id);
+    };
+
+    return (
+      <div className="tw-flex tw-h-[500px] tw-flex-col tw-rounded tw-border">
+        <div className="tw-flex tw-border-b">
+          {(['dictionary', 'encyclopedia', 'media'] as const).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              className={`tw-px-4 tw-py-2 tw-text-sm tw-capitalize ${
+                activeTab === tab
+                  ? 'tw-border-b-2 tw-border-primary tw-font-medium'
+                  : 'tw-text-muted-foreground hover:tw-text-foreground'
+              }`}
+              onClick={() => {
+                setActiveTab(tab);
+                setSelectedId(undefined);
+              }}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+        <div className="tw-flex-1 tw-overflow-hidden">
+          {activeTab === 'dictionary' && (
+            <ErDictionaryList
+              items={sampleDictionaryItems}
+              onItemClick={handleItemClick}
+              selectedItemId={selectedId}
+              getDescription={(item) => item.glosses}
+              getBadges={(item) => item.strongsCodes}
+              getOccurrenceCount={(item) => item.occurrenceCount}
+            />
+          )}
+          {activeTab === 'encyclopedia' && (
+            <ErEncyclopediaList
+              items={sampleEncyclopediaItems}
+              onItemClick={handleItemClick}
+              selectedItemId={selectedId}
+            />
+          )}
+          {activeTab === 'media' && (
+            <ErMediaList
+              items={sampleMediaItems}
+              onItemClick={handleItemClick}
+              selectedItemId={selectedId}
+            />
+          )}
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'All ER research pane tabs combined to demonstrate how Dictionary, Encyclopedia, and Media lists work together in a tabbed layout, matching the Enhanced Resources research pane structure.',
+      },
+    },
+  },
+};

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -742,7 +742,7 @@ function InlineListDetail<T extends { id: string }>({
             ref={listRef}
             role="listbox"
             tabIndex={0}
-            className="tw-outline-none focus:tw-ring-1 focus:tw-ring-inset focus:tw-ring-ring"
+            className="tw-outline-none"
             onKeyDown={handleListKeyDown}
           >
             {items.map((item, idx) => {
@@ -754,7 +754,7 @@ function InlineListDetail<T extends { id: string }>({
                   role="option"
                   aria-selected={isSelected}
                   onClick={() => {
-                    setFocusedIdx(idx);
+                    setFocusedIdx(-1);
                     onSelectItem(isSelected ? undefined : item);
                   }}
                   className={cn('tw-cursor-pointer tw-border-b tw-p-2', {

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -695,29 +695,39 @@ function InlineListDetail<T extends { id: string }>({
   const showSideBySide = selectedItem && !narrow;
   const showFullDetail = selectedItem && narrow;
 
-  // Keyboard navigation: arrows move focus, behavior depends on narrow/wide
+  // Keyboard navigation: arrows move focus, behavior depends on narrow/wide.
+  // First keypress starts from the selected item (or first/last if none).
   const handleListKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (items.length === 0) return;
+      const selectedIdx = selectedItem ? items.findIndex((i) => i.id === selectedItem.id) : -1;
 
       if (e.key === 'ArrowDown') {
         e.preventDefault();
-        const next = Math.min(focusedIdx + 1, items.length - 1);
+        let next: number;
+        if (focusedIdx < 0) {
+          next = selectedIdx >= 0 ? Math.min(selectedIdx + 1, items.length - 1) : 0;
+        } else {
+          next = Math.min(focusedIdx + 1, items.length - 1);
+        }
         setFocusedIdx(next);
-        // Wide mode: immediately select to show details side-by-side
         if (!narrow) onSelectItem(items[next]);
       } else if (e.key === 'ArrowUp') {
         e.preventDefault();
-        const prev = Math.max(focusedIdx - 1, 0);
+        let prev: number;
+        if (focusedIdx < 0) {
+          prev = selectedIdx >= 0 ? Math.max(selectedIdx - 1, 0) : items.length - 1;
+        } else {
+          prev = Math.max(focusedIdx - 1, 0);
+        }
         setFocusedIdx(prev);
         if (!narrow) onSelectItem(items[prev]);
       } else if ((e.key === 'Enter' || e.key === ' ') && narrow && focusedIdx >= 0) {
-        // Narrow mode: Enter/Space submits the focused item
         e.preventDefault();
         onSelectItem(items[focusedIdx]);
       }
     },
-    [items, focusedIdx, narrow, onSelectItem],
+    [items, focusedIdx, narrow, onSelectItem, selectedItem],
   );
 
   // Scroll focused item into view

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -944,7 +944,7 @@ export const AllErTabs: Story = {
               <DrawerContent
                 container={tabContentRef.current}
                 hideDrawerHandle
-                className="tw-mt-2 tw-h-full tw-max-h-full"
+                className="tw-top-2 tw-h-full tw-max-h-full tw-rounded-t-lg"
               >
                 {domainPath && (
                   <DomainFilteredView

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { ThemeProvider } from '@/storybook/theme-provider.component';
 import { ArrowLeft } from 'lucide-react';
 import { cn } from '@/utils/shadcn-ui.util';
@@ -7,6 +7,11 @@ import { Button } from '@/components/shadcn-ui/button';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Badge } from '@/components/shadcn-ui/badge';
 import { Dialog, DialogContent, DialogTitle } from '@/components/shadcn-ui/dialog';
+import {
+  ResizableHandle,
+  ResizablePanel,
+  ResizablePanelGroup,
+} from '@/components/shadcn-ui/resizable';
 import {
   Tooltip,
   TooltipContent,
@@ -434,7 +439,7 @@ function ErDictionaryDetail({
 }) {
   return (
     <div>
-      <Button onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
+      <Button data-back-to-list onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
         <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
         Back to list
       </Button>
@@ -500,7 +505,7 @@ function LexicalDetail({ item, onClose }: { item: LexicalEntryFull; onClose: () 
 
   return (
     <div>
-      <Button onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
+      <Button data-back-to-list onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
         <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
         Back to list
       </Button>
@@ -596,7 +601,7 @@ function LexicalDetail({ item, onClose }: { item: LexicalEntryFull; onClose: () 
 function EncyclopediaDetail({ item, onClose }: { item: EncyclopediaTeaser; onClose: () => void }) {
   return (
     <div>
-      <Button onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
+      <Button data-back-to-list onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
         <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
         Back to list
       </Button>
@@ -616,7 +621,7 @@ function EncyclopediaDetail({ item, onClose }: { item: EncyclopediaTeaser; onClo
 function MediaDetail({ item, onClose }: { item: MediaItem; onClose: () => void }) {
   return (
     <div>
-      <Button onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
+      <Button data-back-to-list onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
         <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
         Back to list
       </Button>
@@ -673,11 +678,14 @@ function InlineListDetail<T extends { id: string }>({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const [containerWidth, setContainerWidth] = useState(0);
   useEffect(() => {
     const el = containerRef.current;
     if (!el) return undefined;
     const observer = new ResizeObserver(([entry]) => {
-      setNarrow((entry?.contentRect.width ?? 0) < 350);
+      const width = entry?.contentRect.width ?? 0;
+      setContainerWidth(width);
+      setNarrow(width < 350);
     });
     observer.observe(el);
     return () => observer.disconnect();
@@ -685,6 +693,11 @@ function InlineListDetail<T extends { id: string }>({
 
   const showSideBySide = selectedItem && !narrow;
   const showFullDetail = selectedItem && narrow;
+
+  // react-resizable-panels uses percentages; convert the pixel minima for the
+  // list (100px) and detail (150px) panels based on the observed container.
+  const listMinPct = containerWidth > 0 ? (100 / containerWidth) * 100 : 20;
+  const detailMinPct = containerWidth > 0 ? (150 / containerWidth) * 100 : 30;
 
   // Keyboard navigation: arrows move focus, behavior depends on narrow/wide.
   // First keypress starts from the selected item (or first/last if none).
@@ -735,59 +748,92 @@ function InlineListDetail<T extends { id: string }>({
     }
   }, [items, onSelectItem, selectedItem, listRef]);
 
+  // When detail opens in narrow (full-detail) mode the list is unmounted, so
+  // move focus to the Back button. In side-by-side mode focus stays on the
+  // list so repeated Up/Down arrows continue to work.
+  // eslint-disable-next-line no-null/no-null
+  const detailPanelRef = useRef<HTMLDivElement>(null);
+  const selectedItemId = selectedItem?.id;
+  useEffect(() => {
+    if (!narrow || !selectedItemId) return;
+    const back = detailPanelRef.current?.querySelector<HTMLButtonElement>('[data-back-to-list]');
+    back?.focus();
+  }, [narrow, selectedItemId]);
+
+  // Switching from list-only to side-by-side replaces the list's wrapper with
+  // a ResizablePanelGroup, which remounts the <ul> and drops keyboard focus.
+  // Re-focus it so repeated Up/Down after the first selection keep working.
+  const isSideBySide = !!showSideBySide;
+  useEffect(() => {
+    if (isSideBySide) listRef.current?.focus();
+  }, [isSideBySide, listRef]);
+
+  const listElement = (
+    <ul
+      ref={listRef}
+      role="listbox"
+      tabIndex={0}
+      className="tw-p-0.5 tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-ring"
+      onKeyDown={handleListKeyDown}
+    >
+      {items.map((item, idx) => {
+        const isSelected = selectedItem?.id === item.id;
+        const isFocused = focusedIdx === idx;
+        return (
+          <li
+            key={item.id}
+            role="option"
+            aria-selected={isSelected}
+            onClick={() => {
+              setFocusedIdx(-1);
+              onSelectItem(isSelected ? undefined : item);
+            }}
+            className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
+              'tw-bg-muted': isSelected,
+              'hover:tw-bg-muted': !isSelected,
+              'tw-ring-1 tw-ring-inset tw-ring-ring': isFocused && !isSelected,
+            })}
+          >
+            {renderListItem(item, !!selectedItem)}
+          </li>
+        );
+      })}
+    </ul>
+  );
+
+  const detailElement = selectedItem ? renderDetail(selectedItem, handleCloseDetail) : undefined;
+
+  let body: ReactNode;
+  if (showSideBySide && detailElement !== undefined) {
+    body = (
+      <ResizablePanelGroup direction="horizontal">
+        <ResizablePanel defaultSize={33.3333} minSize={listMinPct}>
+          <div className="tw-h-full tw-overflow-y-auto">{listElement}</div>
+        </ResizablePanel>
+        <ResizableHandle />
+        <ResizablePanel defaultSize={66.6667} minSize={detailMinPct}>
+          <div className="tw-h-full tw-overflow-y-auto tw-bg-background tw-p-4">
+            {detailElement}
+          </div>
+        </ResizablePanel>
+      </ResizablePanelGroup>
+    );
+  } else if (showFullDetail && detailElement !== undefined) {
+    body = (
+      <div
+        ref={detailPanelRef}
+        className="tw-h-full tw-w-full tw-overflow-y-auto tw-bg-background tw-p-4"
+      >
+        {detailElement}
+      </div>
+    );
+  } else {
+    body = <div className="tw-h-full tw-w-full tw-overflow-y-auto">{listElement}</div>;
+  }
+
   return (
     <div ref={containerRef} className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
-      {!showFullDetail && (
-        <div
-          className={cn(
-            'tw-h-full',
-            showSideBySide
-              ? 'tw-w-1/3 tw-min-w-[120px] tw-overflow-hidden tw-border-r'
-              : 'tw-w-full tw-overflow-y-auto',
-          )}
-        >
-          <ul
-            ref={listRef}
-            role="listbox"
-            tabIndex={0}
-            className="tw-p-0.5 tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-ring"
-            onKeyDown={handleListKeyDown}
-          >
-            {items.map((item, idx) => {
-              const isSelected = selectedItem?.id === item.id;
-              const isFocused = focusedIdx === idx;
-              return (
-                <li
-                  key={item.id}
-                  role="option"
-                  aria-selected={isSelected}
-                  onClick={() => {
-                    setFocusedIdx(-1);
-                    onSelectItem(isSelected ? undefined : item);
-                  }}
-                  className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
-                    'tw-bg-muted': isSelected,
-                    'hover:tw-bg-muted': !isSelected,
-                    'tw-ring-1 tw-ring-inset tw-ring-ring': isFocused && !isSelected,
-                  })}
-                >
-                  {renderListItem(item, !!selectedItem)}
-                </li>
-              );
-            })}
-          </ul>
-        </div>
-      )}
-      {selectedItem && (
-        <div
-          className={cn(
-            'tw-overflow-y-auto tw-bg-background tw-p-4',
-            showFullDetail ? 'tw-w-full' : 'tw-w-2/3',
-          )}
-        >
-          {renderDetail(selectedItem, handleCloseDetail)}
-        </div>
-      )}
+      {body}
     </div>
   );
 }

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -6,7 +6,6 @@ import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Badge } from '@/components/shadcn-ui/badge';
-import { Drawer, DrawerContent } from '@/components/shadcn-ui/drawer';
 import { Dialog, DialogContent, DialogTitle } from '@/components/shadcn-ui/dialog';
 import {
   Tooltip,
@@ -967,35 +966,27 @@ export const AllErTabs: Story = {
             />
           )}
 
-          {/* Domain-filtered bottom Drawer (slides up, fills full tab height).
-              shouldScaleBackground={false} stops vaul from scaling the page
-              wrapper — otherwise the tab buttons above the drawer container
-              become uninteractive while the drawer is open. */}
-          {activeTab === 'dictionary' && (
-            <Drawer
-              direction="bottom"
-              modal={false}
-              shouldScaleBackground={false}
-              open={domainPath !== undefined}
-              onOpenChange={(open) => {
-                if (!open) setDomainPath(undefined);
-              }}
-            >
-              <DrawerContent
-                container={tabContentRef.current}
-                hideDrawerHandle
-                className="tw-top-0.5 tw-mt-0 tw-h-full tw-max-h-full tw-rounded-t-lg"
-              >
-                {domainPath && (
-                  <DomainFilteredView
-                    domainPath={domainPath}
-                    onDomainChange={setDomainPath}
-                    onClose={() => setDomainPath(undefined)}
-                    onDomainClick={handleDomainClickInFiltered}
-                  />
-                )}
-              </DrawerContent>
-            </Drawer>
+          {/* Domain-filtered drawer — a custom absolute panel scoped to the tab
+              content area, with a modal backdrop. Implemented directly (not via
+              vaul) so tab switching above the drawer keeps working while open.
+              Clicking the visible backdrop strip (top-4) closes the drawer. */}
+          {activeTab === 'dictionary' && domainPath !== undefined && (
+            <>
+              {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+              <div
+                className="tw-absolute tw-inset-0 tw-z-40 tw-cursor-pointer tw-bg-black/50"
+                onClick={() => setDomainPath(undefined)}
+                aria-hidden
+              />
+              <div className="tw-absolute tw-inset-x-0 tw-bottom-0 tw-top-4 tw-z-50 tw-flex tw-flex-col tw-overflow-hidden tw-rounded-t-lg tw-border tw-bg-background tw-shadow-xl">
+                <DomainFilteredView
+                  domainPath={domainPath}
+                  onDomainChange={setDomainPath}
+                  onClose={() => setDomainPath(undefined)}
+                  onDomainClick={handleDomainClickInFiltered}
+                />
+              </div>
+            </>
           )}
         </div>
       </div>
@@ -1079,10 +1070,11 @@ export const AllErTabsDialogVariant: Story = {
           <DialogContent className="tw-flex tw-h-[80vh] tw-max-h-[600px] tw-w-[90vw] tw-max-w-3xl tw-flex-col tw-overflow-hidden tw-p-0">
             <DialogTitle className="tw-sr-only">Filtered dictionary</DialogTitle>
             {domainPath && (
+              // Dialog already provides a close button + ESC dismiss, so we do
+              // not pass onClose (which hides the in-header Back button).
               <DomainFilteredView
                 domainPath={domainPath}
                 onDomainChange={setDomainPath}
-                onClose={() => setDomainPath(undefined)}
                 onDomainClick={handleDomainClick}
               />
             )}
@@ -1115,7 +1107,8 @@ function DomainFilteredView({
 }: {
   domainPath: SemanticDomain[];
   onDomainChange: (path: SemanticDomain[]) => void;
-  onClose: () => void;
+  /** When omitted, the Back button in the filtered list header is hidden. */
+  onClose?: () => void;
   onDomainClick: (domain: EntryDomain, pathIds?: string[]) => void;
 }) {
   return (

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -1,12 +1,20 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { ThemeProvider } from '@/storybook/theme-provider.component';
-import { ArrowLeft } from 'lucide-react';
+import {
+  ArrowLeft,
+  ChevronLeft as ChevronLeftIcon,
+  ChevronRight as ChevronRightIcon,
+  Maximize2,
+  ZoomIn,
+  ZoomOut,
+} from 'lucide-react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Badge } from '@/components/shadcn-ui/badge';
 import { Dialog, DialogContent, DialogTitle } from '@/components/shadcn-ui/dialog';
+import { Drawer, DrawerContent, DrawerTitle } from '@/components/shadcn-ui/drawer';
 import {
   ResizableHandle,
   ResizablePanel,
@@ -618,7 +626,34 @@ function EncyclopediaDetail({ item, onClose }: { item: EncyclopediaTeaser; onClo
   );
 }
 
-function MediaDetail({ item, onClose }: { item: MediaItem; onClose: () => void }) {
+const ZOOM_MIN = 0.25;
+const ZOOM_MAX = 5;
+const ZOOM_STEP = 0.25;
+
+function MediaDetail({
+  item,
+  onClose,
+  onPrev,
+  onNext,
+}: {
+  item: MediaItem;
+  onClose: () => void;
+  onPrev?: () => void;
+  onNext?: () => void;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [zoom, setZoom] = useState(1);
+  const imageAlt = item.thumbnailAlt ?? item.primaryText;
+
+  // Reset zoom when navigating to a different item so the new image starts
+  // at fit-to-viewport scale.
+  useEffect(() => {
+    setZoom(1);
+  }, [item.id]);
+
+  const zoomIn = useCallback(() => setZoom((z) => Math.min(z + ZOOM_STEP, ZOOM_MAX)), []);
+  const zoomOut = useCallback(() => setZoom((z) => Math.max(z - ZOOM_STEP, ZOOM_MIN)), []);
+
   return (
     <div>
       <Button data-back-to-list onClick={onClose} variant="ghost" size="sm" className="tw-mb-3">
@@ -630,13 +665,116 @@ function MediaDetail({ item, onClose }: { item: MediaItem; onClose: () => void }
         <Badge variant="outline">{item.mediaType}</Badge>
       </div>
       {item.thumbnailUrl && (
-        <img
-          src={item.thumbnailUrl}
-          alt={item.thumbnailAlt ?? item.primaryText}
-          className="tw-mb-3 tw-w-full tw-rounded tw-object-contain"
-        />
+        <div className="tw-relative tw-mb-3">
+          <img
+            src={item.thumbnailUrl}
+            alt={imageAlt}
+            className="tw-w-full tw-rounded tw-object-contain"
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            size="icon"
+            onClick={() => setExpanded(true)}
+            aria-label="Expand image"
+            className="tw-absolute tw-right-2 tw-top-2 tw-h-8 tw-w-8 tw-bg-background/80 tw-shadow hover:tw-bg-background"
+          >
+            <Maximize2 className="tw-h-4 tw-w-4" />
+          </Button>
+        </div>
       )}
       {item.caption && <p className="tw-text-sm tw-text-muted-foreground">{item.caption}</p>}
+      {item.thumbnailUrl && (
+        <Dialog open={expanded} onOpenChange={setExpanded}>
+          <DialogContent className="tw-flex tw-max-h-[95vh] tw-w-[95vw] tw-max-w-[95vw] tw-flex-col tw-overflow-hidden tw-p-4">
+            <div className="tw-flex tw-items-center tw-gap-2">
+              <DialogTitle className="tw-flex-1 tw-truncate">{item.primaryText}</DialogTitle>
+              <TooltipProvider delayDuration={300}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={onPrev}
+                      disabled={!onPrev}
+                      aria-label="Previous item"
+                      className="tw-h-8 tw-w-8"
+                    >
+                      <ChevronLeftIcon className="tw-h-4 tw-w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Previous item</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={onNext}
+                      disabled={!onNext}
+                      aria-label="Next item"
+                      className="tw-h-8 tw-w-8"
+                    >
+                      <ChevronRightIcon className="tw-h-4 tw-w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Next item</TooltipContent>
+                </Tooltip>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={zoomOut}
+                      disabled={zoom <= ZOOM_MIN}
+                      aria-label="Zoom out"
+                      className="tw-h-8 tw-w-8"
+                    >
+                      <ZoomOut className="tw-h-4 tw-w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Zoom out</TooltipContent>
+                </Tooltip>
+                <span className="tw-w-12 tw-text-center tw-text-xs tw-tabular-nums tw-text-muted-foreground">
+                  {Math.round(zoom * 100)}%
+                </span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={zoomIn}
+                      disabled={zoom >= ZOOM_MAX}
+                      aria-label="Zoom in"
+                      className="tw-h-8 tw-w-8"
+                    >
+                      <ZoomIn className="tw-h-4 tw-w-4" />
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent>Zoom in</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+              {/* Spacer for the built-in DialogContent close (X) button */}
+              <div className="tw-w-8" />
+            </div>
+            <div className="tw-flex tw-flex-1 tw-items-center tw-justify-center tw-overflow-auto">
+              <img
+                src={item.thumbnailUrl}
+                alt={imageAlt}
+                style={{ transform: `scale(${zoom})`, transformOrigin: 'center center' }}
+                className="tw-max-h-full tw-max-w-full tw-object-contain tw-transition-transform"
+              />
+            </div>
+            {item.caption && (
+              <p className="tw-text-sm tw-text-muted-foreground">{item.caption}</p>
+            )}
+          </DialogContent>
+        </Dialog>
+      )}
     </div>
   );
 }
@@ -896,196 +1034,314 @@ export const EmptyState: Story = {
   ),
 };
 
+// ---------------------------------------------------------------------------
+// Shared AllErTabs layout: tabs + per-tab list/detail + pluggable domain overlay
+// ---------------------------------------------------------------------------
+
+type DomainOverlayProps = {
+  domainPath: SemanticDomain[] | undefined;
+  setDomainPath: (path: SemanticDomain[] | undefined) => void;
+  handleDomainClick: (domain: EntryDomain, pathIds?: string[]) => void;
+  tabContentRef: React.RefObject<HTMLDivElement>;
+  isDictionaryTab: boolean;
+};
+
+function AllErTabsLayout({ Overlay }: { Overlay: React.ComponentType<DomainOverlayProps> }) {
+  const [activeTab, setActiveTab] = useState<'dictionary' | 'encyclopedia' | 'media'>('dictionary');
+  const [selectedDict, setSelectedDict] = useState<DictionaryEntryWithSenses | undefined>();
+  const [selectedEnc, setSelectedEnc] = useState<EncyclopediaTeaser | undefined>();
+  const [selectedMedia, setSelectedMedia] = useState<MediaItem | undefined>();
+  const [domainPath, setDomainPath] = useState<SemanticDomain[] | undefined>();
+  // eslint-disable-next-line no-null/no-null
+  const tabContentRef = useRef<HTMLDivElement>(null);
+  // eslint-disable-next-line no-null/no-null
+  const dictListRef = useRef<HTMLUListElement | null>(null);
+  // eslint-disable-next-line no-null/no-null
+  const encListRef = useRef<HTMLUListElement | null>(null);
+  // eslint-disable-next-line no-null/no-null
+  const mediaListRef = useRef<HTMLUListElement | null>(null);
+
+  const resolveDomainPath = useCallback((pathIds: string[]): SemanticDomain[] => {
+    return pathIds.reduce<SemanticDomain[]>((acc, id) => {
+      const parent = acc.length === 0 ? sampleAllDomains : (acc[acc.length - 1].children ?? []);
+      const found = parent.find((d) => d.id === id);
+      if (found) acc.push(found);
+      return acc;
+    }, []);
+  }, []);
+
+  const handleDomainClick = useCallback(
+    (_domain: EntryDomain, pathIds?: string[]) => {
+      if (pathIds) {
+        const path = resolveDomainPath(pathIds);
+        if (path.length > 0) setDomainPath(path);
+      }
+    },
+    [resolveDomainPath],
+  );
+
+  return (
+    <div className="tw-flex tw-h-[550px] tw-flex-col tw-rounded tw-border">
+      <div className="tw-flex tw-border-b">
+        {(['dictionary', 'encyclopedia', 'media'] as const).map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            className={`tw-px-4 tw-py-2 tw-text-sm tw-capitalize ${activeTab === tab ? 'tw-border-b-2 tw-border-primary tw-font-medium' : 'tw-text-muted-foreground hover:tw-text-foreground'}`}
+            onClick={() => {
+              setActiveTab(tab);
+              setSelectedDict(undefined);
+              setSelectedEnc(undefined);
+              setSelectedMedia(undefined);
+              setDomainPath(undefined);
+              requestAnimationFrame(() => {
+                if (tab === 'dictionary') dictListRef.current?.focus();
+                else if (tab === 'encyclopedia') encListRef.current?.focus();
+                else mediaListRef.current?.focus();
+              });
+            }}
+          >
+            {tab}
+          </button>
+        ))}
+      </div>
+      <div ref={tabContentRef} className="tw-relative tw-flex-1 tw-overflow-hidden">
+        {activeTab === 'dictionary' && (
+          <InlineListDetail
+            items={sampleDictionaryItems}
+            selectedItem={selectedDict}
+            onSelectItem={setSelectedDict}
+            listRef={dictListRef}
+            renderListItem={(item, compact) => <ErDictListItem item={item} compact={compact} />}
+            renderDetail={(item, onClose) => (
+              <ErDictionaryDetail
+                item={item}
+                onClose={onClose}
+                onDomainClick={handleDomainClick}
+              />
+            )}
+          />
+        )}
+        {activeTab === 'encyclopedia' && (
+          <InlineListDetail
+            items={sampleEncyclopediaItems}
+            selectedItem={selectedEnc}
+            onSelectItem={setSelectedEnc}
+            listRef={encListRef}
+            renderListItem={(item) => (
+              <div className="tw-flex tw-flex-col tw-gap-0.5 tw-overflow-hidden">
+                <div className="tw-flex tw-items-baseline tw-gap-2 tw-overflow-hidden">
+                  <span className="tw-shrink-0 tw-text-sm tw-font-medium">{item.primaryText}</span>
+                  <span className="tw-truncate tw-text-sm tw-text-muted-foreground">
+                    {item.sourceLanguageText}
+                    {item.transliteration && (
+                      <span className="tw-ml-1">({item.transliteration})</span>
+                    )}
+                  </span>
+                </div>
+                <span className="tw-truncate tw-text-xs tw-text-muted-foreground">
+                  {item.teaserText}
+                </span>
+              </div>
+            )}
+            renderDetail={(item, onClose) => <EncyclopediaDetail item={item} onClose={onClose} />}
+          />
+        )}
+        {activeTab === 'media' && (
+          <InlineListDetail
+            items={sampleMediaItems}
+            selectedItem={selectedMedia}
+            onSelectItem={setSelectedMedia}
+            listRef={mediaListRef}
+            renderListItem={(item) => (
+              <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden">
+                {item.thumbnailUrl && (
+                  <img
+                    src={item.thumbnailUrl}
+                    alt={item.primaryText}
+                    className="tw-h-10 tw-w-10 tw-shrink-0 tw-rounded tw-object-cover"
+                  />
+                )}
+                <div className="tw-flex tw-flex-col tw-gap-0.5 tw-overflow-hidden">
+                  <span className="tw-truncate tw-text-sm tw-font-medium">{item.primaryText}</span>
+                  <Badge variant="outline" className="tw-w-fit tw-text-xs">
+                    {item.mediaType}
+                  </Badge>
+                </div>
+              </div>
+            )}
+            renderDetail={(item, onClose) => {
+              const idx = sampleMediaItems.findIndex((m) => m.id === item.id);
+              const onPrev =
+                idx > 0 ? () => setSelectedMedia(sampleMediaItems[idx - 1]) : undefined;
+              const onNext =
+                idx >= 0 && idx < sampleMediaItems.length - 1
+                  ? () => setSelectedMedia(sampleMediaItems[idx + 1])
+                  : undefined;
+              return (
+                <MediaDetail item={item} onClose={onClose} onPrev={onPrev} onNext={onNext} />
+              );
+            }}
+          />
+        )}
+        <Overlay
+          domainPath={domainPath}
+          setDomainPath={setDomainPath}
+          handleDomainClick={handleDomainClick}
+          tabContentRef={tabContentRef}
+          isDictionaryTab={activeTab === 'dictionary'}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Domain-overlay variants
+// ---------------------------------------------------------------------------
+
+/** Overlay variant: centered modal Dialog. ESC + close button are built-in. */
+function DialogDomainOverlay({
+  domainPath,
+  setDomainPath,
+  handleDomainClick,
+  isDictionaryTab,
+}: DomainOverlayProps) {
+  return (
+    <Dialog
+      open={isDictionaryTab && domainPath !== undefined}
+      onOpenChange={(open) => {
+        if (!open) setDomainPath(undefined);
+      }}
+    >
+      <DialogContent className="tw-flex tw-h-[80vh] tw-max-h-[600px] tw-w-[90vw] tw-max-w-3xl tw-flex-col tw-overflow-hidden tw-p-0">
+        <DialogTitle className="tw-sr-only">Filtered dictionary</DialogTitle>
+        {domainPath && (
+          <DomainFilteredView
+            domainPath={domainPath}
+            onDomainChange={setDomainPath}
+            onDomainClick={handleDomainClick}
+          />
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/** Overlay variant: shadcn (vaul) Drawer scoped to the tab content area. */
+function StandardDrawerDomainOverlay({
+  domainPath,
+  setDomainPath,
+  handleDomainClick,
+  tabContentRef,
+  isDictionaryTab,
+}: DomainOverlayProps) {
+  return (
+    <Drawer
+      open={isDictionaryTab && domainPath !== undefined}
+      onOpenChange={(open) => {
+        if (!open) setDomainPath(undefined);
+      }}
+      direction="bottom"
+    >
+      <DrawerContent
+        container={tabContentRef.current ?? undefined}
+        className="tw-h-[85%]"
+      >
+        <DrawerTitle className="tw-sr-only">Filtered dictionary</DrawerTitle>
+        {domainPath && (
+          <DomainFilteredView
+            domainPath={domainPath}
+            onDomainChange={setDomainPath}
+            onDomainClick={handleDomainClick}
+          />
+        )}
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
 /**
- * All ER tabs with inline panel detail views. Domain links open a bottom Drawer containing the
- * domain-filtered list with breadcrumb navigation. Interaction works while details are shown:
+ * Overlay variant: custom absolute panel (not vaul) so tab switching above the drawer keeps
+ * working while open. Clicking the visible backdrop strip closes the drawer.
+ */
+function CustomDrawerDomainOverlay({
+  domainPath,
+  setDomainPath,
+  handleDomainClick,
+  isDictionaryTab,
+}: DomainOverlayProps) {
+  // Close on ESC. An open popover inside the drawer uses
+  // `e.nativeEvent.stopImmediatePropagation()` in its own ESC handler, so ESC
+  // inside an open popover only closes the popover, not the drawer.
+  useEffect(() => {
+    if (domainPath === undefined) return undefined;
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        setDomainPath(undefined);
+      }
+    };
+    document.addEventListener('keydown', handleEsc);
+    return () => document.removeEventListener('keydown', handleEsc);
+  }, [domainPath, setDomainPath]);
+
+  if (!isDictionaryTab || domainPath === undefined) return undefined;
+  return (
+    <>
+      {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+      <div
+        className="tw-absolute tw-inset-0 tw-z-40 tw-cursor-pointer tw-bg-black/50"
+        onClick={() => setDomainPath(undefined)}
+        aria-hidden
+      />
+      <div className="tw-absolute tw-bottom-0 tw-left-2 tw-right-2 tw-top-2 tw-z-50 tw-flex tw-flex-col tw-overflow-hidden tw-rounded-t-lg tw-border tw-bg-background tw-shadow-xl">
+        <DomainFilteredView
+          domainPath={domainPath}
+          onDomainChange={setDomainPath}
+          onClose={() => setDomainPath(undefined)}
+          onDomainClick={handleDomainClick}
+        />
+      </div>
+    </>
+  );
+}
+
+/**
+ * All ER tabs with inline panel detail views. Domain links open a centered modal Dialog containing
+ * the domain-filtered list with breadcrumb navigation. Interaction works while details are shown:
  * selecting entries, clicking close, breadcrumbs, and domain links all remain functional.
  */
 export const AllErTabs: Story = {
-  render: () => {
-    const [activeTab, setActiveTab] = useState<'dictionary' | 'encyclopedia' | 'media'>(
-      'dictionary',
-    );
-    const [selectedDict, setSelectedDict] = useState<DictionaryEntryWithSenses | undefined>();
-    const [selectedEnc, setSelectedEnc] = useState<EncyclopediaTeaser | undefined>();
-    const [selectedMedia, setSelectedMedia] = useState<MediaItem | undefined>();
-    const [domainPath, setDomainPath] = useState<SemanticDomain[] | undefined>();
-    // eslint-disable-next-line no-null/no-null
-    const tabContentRef = useRef<HTMLDivElement>(null);
-    // Refs to each tab's listbox so we can programmatically refocus on tab
-    // click (including clicks on the currently active tab where no remount
-    // would otherwise happen).
-    // eslint-disable-next-line no-null/no-null
-    const dictListRef = useRef<HTMLUListElement | null>(null);
-    // eslint-disable-next-line no-null/no-null
-    const encListRef = useRef<HTMLUListElement | null>(null);
-    // eslint-disable-next-line no-null/no-null
-    const mediaListRef = useRef<HTMLUListElement | null>(null);
+  render: () => <AllErTabsLayout Overlay={DialogDomainOverlay} />,
+};
 
-    const resolveDomainPath = useCallback((pathIds: string[]): SemanticDomain[] => {
-      return pathIds.reduce<SemanticDomain[]>((acc, id) => {
-        const parent = acc.length === 0 ? sampleAllDomains : (acc[acc.length - 1].children ?? []);
-        const found = parent.find((d) => d.id === id);
-        if (found) acc.push(found);
-        return acc;
-      }, []);
-    }, []);
-
-    const handleDomainClick = useCallback(
-      (_domain: EntryDomain, pathIds?: string[]) => {
-        if (pathIds) {
-          const path = resolveDomainPath(pathIds);
-          if (path.length > 0) setDomainPath(path);
-        }
+/** Same as AllErTabs but the domain-filtered view appears in a bottom Drawer (shadcn / vaul). */
+export const AllErTabsDrawerVariant: Story = {
+  render: () => <AllErTabsLayout Overlay={StandardDrawerDomainOverlay} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Variant using the standard shadcn Drawer (vaul-based), scoped to the tab content area via the `container` prop.',
       },
-      [resolveDomainPath],
-    );
+    },
+  },
+};
 
-    // Domain click from inside the filtered detail view reuses the same handler
-    const handleDomainClickInFiltered = handleDomainClick;
-
-    // Close the drawer on ESC. An open popover inside the drawer uses
-    // `e.nativeEvent.stopImmediatePropagation()` in its own ESC handler, which
-    // stops the native event from reaching this document-level listener — so
-    // ESC inside an open popover only closes the popover.
-    useEffect(() => {
-      if (domainPath === undefined) return undefined;
-      const handleEsc = (e: KeyboardEvent) => {
-        if (e.key === 'Escape') {
-          e.preventDefault();
-          setDomainPath(undefined);
-        }
-      };
-      document.addEventListener('keydown', handleEsc);
-      return () => document.removeEventListener('keydown', handleEsc);
-    }, [domainPath]);
-
-    return (
-      <div className="tw-flex tw-h-[550px] tw-flex-col tw-rounded tw-border">
-        <div className="tw-flex tw-border-b">
-          {(['dictionary', 'encyclopedia', 'media'] as const).map((tab) => (
-            <button
-              key={tab}
-              type="button"
-              className={`tw-px-4 tw-py-2 tw-text-sm tw-capitalize ${activeTab === tab ? 'tw-border-b-2 tw-border-primary tw-font-medium' : 'tw-text-muted-foreground hover:tw-text-foreground'}`}
-              onClick={() => {
-                setActiveTab(tab);
-                setSelectedDict(undefined);
-                setSelectedEnc(undefined);
-                setSelectedMedia(undefined);
-                setDomainPath(undefined);
-                // Move focus to the active tab's list after the re-render.
-                // Works for both tab-switch (mount focus also handles this)
-                // and same-tab clicks (no remount, so we force focus here).
-                requestAnimationFrame(() => {
-                  if (tab === 'dictionary') dictListRef.current?.focus();
-                  else if (tab === 'encyclopedia') encListRef.current?.focus();
-                  else mediaListRef.current?.focus();
-                });
-              }}
-            >
-              {tab}
-            </button>
-          ))}
-        </div>
-        <div ref={tabContentRef} className="tw-relative tw-flex-1 tw-overflow-hidden">
-          {activeTab === 'dictionary' && (
-            <InlineListDetail
-              items={sampleDictionaryItems}
-              selectedItem={selectedDict}
-              onSelectItem={setSelectedDict}
-              listRef={dictListRef}
-              renderListItem={(item, compact) => <ErDictListItem item={item} compact={compact} />}
-              renderDetail={(item, onClose) => (
-                <ErDictionaryDetail
-                  item={item}
-                  onClose={onClose}
-                  onDomainClick={handleDomainClick}
-                />
-              )}
-            />
-          )}
-          {activeTab === 'encyclopedia' && (
-            <InlineListDetail
-              items={sampleEncyclopediaItems}
-              selectedItem={selectedEnc}
-              onSelectItem={setSelectedEnc}
-              listRef={encListRef}
-              renderListItem={(item) => (
-                <div className="tw-flex tw-flex-col tw-gap-0.5 tw-overflow-hidden">
-                  <div className="tw-flex tw-items-baseline tw-gap-2 tw-overflow-hidden">
-                    <span className="tw-shrink-0 tw-text-sm tw-font-medium">
-                      {item.primaryText}
-                    </span>
-                    <span className="tw-truncate tw-text-sm tw-text-muted-foreground">
-                      {item.sourceLanguageText}
-                      {item.transliteration && (
-                        <span className="tw-ml-1">({item.transliteration})</span>
-                      )}
-                    </span>
-                  </div>
-                  <span className="tw-truncate tw-text-xs tw-text-muted-foreground">
-                    {item.teaserText}
-                  </span>
-                </div>
-              )}
-              renderDetail={(item, onClose) => <EncyclopediaDetail item={item} onClose={onClose} />}
-            />
-          )}
-          {activeTab === 'media' && (
-            <InlineListDetail
-              items={sampleMediaItems}
-              selectedItem={selectedMedia}
-              onSelectItem={setSelectedMedia}
-              listRef={mediaListRef}
-              renderListItem={(item) => (
-                <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden">
-                  {item.thumbnailUrl && (
-                    <img
-                      src={item.thumbnailUrl}
-                      alt={item.primaryText}
-                      className="tw-h-10 tw-w-10 tw-shrink-0 tw-rounded tw-object-cover"
-                    />
-                  )}
-                  <div className="tw-flex tw-flex-col tw-gap-0.5 tw-overflow-hidden">
-                    <span className="tw-truncate tw-text-sm tw-font-medium">
-                      {item.primaryText}
-                    </span>
-                    <Badge variant="outline" className="tw-w-fit tw-text-xs">
-                      {item.mediaType}
-                    </Badge>
-                  </div>
-                </div>
-              )}
-              renderDetail={(item, onClose) => <MediaDetail item={item} onClose={onClose} />}
-            />
-          )}
-
-          {/* Domain-filtered drawer — a custom absolute panel scoped to the tab
-              content area, with a modal backdrop. Implemented directly (not via
-              vaul) so tab switching above the drawer keeps working while open.
-              Clicking the visible backdrop strip closes the drawer. */}
-          {activeTab === 'dictionary' && domainPath !== undefined && (
-            <>
-              {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
-              <div
-                className="tw-absolute tw-inset-0 tw-z-40 tw-cursor-pointer tw-bg-black/50"
-                onClick={() => setDomainPath(undefined)}
-                aria-hidden
-              />
-              <div className="tw-absolute tw-bottom-0 tw-left-2 tw-right-2 tw-top-2 tw-z-50 tw-flex tw-flex-col tw-overflow-hidden tw-rounded-t-lg tw-border tw-bg-background tw-shadow-xl">
-                <DomainFilteredView
-                  domainPath={domainPath}
-                  onDomainChange={setDomainPath}
-                  onClose={() => setDomainPath(undefined)}
-                  onDomainClick={handleDomainClickInFiltered}
-                />
-              </div>
-            </>
-          )}
-        </div>
-      </div>
-    );
+/**
+ * Same as AllErTabs but uses a custom absolute panel as the drawer. Implemented directly (not via
+ * vaul) so tab switching above the drawer keeps working while open.
+ */
+export const AllErTabsCustomDrawerVariant: Story = {
+  render: () => <AllErTabsLayout Overlay={CustomDrawerDomainOverlay} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Variant using a custom absolute panel (not vaul) so tab switching above the drawer keeps working while open.',
+      },
+    },
   },
 };
 

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -1,15 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import { ThemeProvider } from '@/storybook/theme-provider.component';
-import { ArrowLeft, BookA } from 'lucide-react';
+import { ArrowLeft } from 'lucide-react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Badge } from '@/components/shadcn-ui/badge';
-import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/shadcn-ui/dialog';
-import { DrawerClose, DrawerTitle, DrawerDescription } from '@/components/shadcn-ui/drawer';
 import SourceLanguageIndexedList from '@/components/advanced/source-language-indexed-list/source-language-indexed-list.component';
-import ErDictionaryList from '@/components/advanced/source-language-indexed-list/er-dictionary-list.component';
 import ErDictionaryFilteredList from '@/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component';
 import ErEncyclopediaList from '@/components/advanced/source-language-indexed-list/er-encyclopedia-list.component';
 import ErMediaList from '@/components/advanced/source-language-indexed-list/er-media-list.component';
@@ -24,26 +21,25 @@ import type {
 } from '@/components/advanced/source-language-indexed-list/source-language-indexed-list.types';
 
 // ---------------------------------------------------------------------------
-// Sample domain data (always 2 levels)
+// Domain data (always 2 levels)
 // ---------------------------------------------------------------------------
 
 const sampleAllDomains: SemanticDomain[] = [
   {
-    id: 'natural-world',
-    label: 'Natural World',
+    id: 'exist',
+    label: 'Exist',
     children: [
-      { id: 'animals', label: 'Animals' },
-      { id: 'plants', label: 'Plants' },
-      { id: 'weather', label: 'Weather & Climate' },
+      { id: 'exist-create', label: 'Create' },
+      { id: 'exist-destroy', label: 'Destroy' },
+      { id: 'exist-change', label: 'Change State' },
     ],
   },
   {
-    id: 'human-body',
-    label: 'Human Body',
+    id: 'happen',
+    label: 'Happen',
     children: [
-      { id: 'body-parts', label: 'Body Parts' },
-      { id: 'senses', label: 'Senses & Perception' },
-      { id: 'health', label: 'Health & Sickness' },
+      { id: 'happen-cause', label: 'Cause' },
+      { id: 'happen-prevent', label: 'Prevent' },
     ],
   },
   {
@@ -51,125 +47,142 @@ const sampleAllDomains: SemanticDomain[] = [
     label: 'Social Relations',
     children: [
       { id: 'family', label: 'Family' },
-      { id: 'authority', label: 'Authority & Leadership' },
-      { id: 'worship', label: 'Worship & Religion' },
+      { id: 'authority', label: 'Authority' },
+      { id: 'worship', label: 'Worship' },
     ],
   },
   {
-    id: 'abstract-concepts',
-    label: 'Abstract Concepts',
+    id: 'communication',
+    label: 'Communication',
     children: [
-      { id: 'time', label: 'Time' },
-      { id: 'quantity', label: 'Quantity & Number' },
-      { id: 'quality', label: 'Quality & Attributes' },
+      { id: 'speak', label: 'Speak' },
+      { id: 'write', label: 'Write' },
     ],
   },
 ];
 
 // ---------------------------------------------------------------------------
-// Dictionary entry type with domains for stories
+// Sense type for ER dictionary entries
 // ---------------------------------------------------------------------------
 
-type DictionaryEntryWithDomains = IndexedListItem & {
-  glosses: string;
-  strongsCodes: string[];
+type DictionarySense = {
+  number: number;
+  definition: string;
   occurrenceCount: number;
-  domains: EntryDomain[];
-  definition?: string;
+  glosses: string;
+  domain: EntryDomain;
+};
+
+type DictionaryEntryWithSenses = IndexedListItem & {
+  senses: DictionarySense[];
+  totalOccurrences: number;
 };
 
 // ---------------------------------------------------------------------------
-// Sample dictionary items
+// Sample ER dictionary items (matching the screenshot structure)
 // ---------------------------------------------------------------------------
 
-const sampleDictionaryItems: DictionaryEntryWithDomains[] = [
+const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
   {
-    id: 'entry-1',
-    primaryText: 'grace',
-    sourceLanguageText: '\u03C7\u03AC\u03C1\u03B9\u03C2',
-    transliteration: 'charis',
-    glosses: 'grace, favor, kindness',
-    strongsCodes: ['G5485'],
-    occurrenceCount: 12,
-    domains: [{ id: 'abstract-concepts', label: 'Abstract Concepts', code: '1.1' }],
-    definition:
-      'Unmerited divine favor or assistance given to humans for regeneration or sanctification.',
-  },
-  {
-    id: 'entry-2',
-    primaryText: 'faith',
-    sourceLanguageText: '\u03C0\u03AF\u03C3\u03C4\u03B9\u03C2',
-    transliteration: 'pistis',
-    glosses: 'faith, belief, trust',
-    strongsCodes: ['G4102'],
-    occurrenceCount: 8,
-    domains: [
-      { id: 'worship', label: 'Worship & Religion', parentId: 'social-relations', code: '3.3' },
-    ],
-    definition: 'Complete trust or confidence in something or someone; firm belief.',
-  },
-  {
-    id: 'entry-3',
-    primaryText: 'love',
-    sourceLanguageText: '\u1F00\u03B3\u03AC\u03C0\u03B7',
-    transliteration: 'agape',
-    glosses: 'love, affection, goodwill',
-    strongsCodes: ['G26'],
-    occurrenceCount: 15,
-    domains: [
+    id: 'entry-bara',
+    primaryText: 'create',
+    sourceLanguageText: '\u05D1\u05B8\u05BC\u05E8\u05B8\u05D0',
+    transliteration: 'br\u02BE',
+    senses: [
       {
-        id: 'social-relations',
-        label: 'Social Relations',
-        code: '3.0',
+        number: 1,
+        definition:
+          'causative action by which a deity brings to existence something that did not exist before.',
+        occurrenceCount: 41,
+        glosses: 'to create',
+        domain: { id: 'exist', label: 'Exist', code: '1.0' },
+      },
+      {
+        number: 2,
+        definition:
+          'causative action by which a deity causes something to happen that did not happen before.',
+        occurrenceCount: 7,
+        glosses: 'to create (an event); to cause to happen',
+        domain: { id: 'happen', label: 'Happen', code: '2.0' },
       },
     ],
-    definition:
-      'Unconditional love, especially the love of God for humanity and the love expected between believers.',
+    totalOccurrences: 48,
   },
   {
-    id: 'entry-4',
-    primaryText: 'righteousness',
-    sourceLanguageText: '\u03B4\u03B9\u03BA\u03B1\u03B9\u03BF\u03C3\u03CD\u03BD\u03B7',
-    transliteration: 'dikaiosyne',
-    glosses: 'righteousness, justice',
-    strongsCodes: ['G1343'],
-    occurrenceCount: 5,
-    domains: [
-      { id: 'quality', label: 'Quality & Attributes', parentId: 'abstract-concepts', code: '1.3' },
+    id: 'entry-amar',
+    primaryText: 'say',
+    sourceLanguageText: '\u05D0\u05B8\u05DE\u05B7\u05E8',
+    transliteration: '\u02BEmr',
+    senses: [
+      {
+        number: 1,
+        definition: 'to utter words or speech; to communicate verbally.',
+        occurrenceCount: 523,
+        glosses: 'to say, to speak, to tell',
+        domain: { id: 'speak', label: 'Speak', parentId: 'communication', code: '4.1' },
+      },
+      {
+        number: 2,
+        definition: 'to think or intend within oneself.',
+        occurrenceCount: 34,
+        glosses: 'to say to oneself, to think',
+        domain: { id: 'happen-cause', label: 'Cause', parentId: 'happen', code: '2.1' },
+      },
     ],
-    definition: 'The quality of being morally right or justifiable; conformity to divine law.',
+    totalOccurrences: 557,
   },
   {
-    id: 'entry-5',
-    primaryText: 'salvation',
-    sourceLanguageText: '\u03C3\u03C9\u03C4\u03B7\u03C1\u03AF\u03B1',
-    transliteration: 'soteria',
-    glosses: 'salvation, deliverance, preservation',
-    strongsCodes: ['G4991'],
-    occurrenceCount: 3,
-    domains: [
-      { id: 'worship', label: 'Worship & Religion', parentId: 'social-relations', code: '3.3' },
+    id: 'entry-asa',
+    primaryText: 'make',
+    sourceLanguageText: '\u05E2\u05B8\u05E9\u05B8\u05C2\u05D4',
+    transliteration: '\u02BF\u015Bh',
+    senses: [
+      {
+        number: 1,
+        definition: 'to bring something into being by forming, constructing, or producing.',
+        occurrenceCount: 412,
+        glosses: 'to make, to do, to produce',
+        domain: { id: 'exist-create', label: 'Create', parentId: 'exist', code: '1.1' },
+      },
     ],
-    definition: 'Deliverance from sin and its consequences, brought about by faith in Christ.',
+    totalOccurrences: 412,
   },
   {
-    id: 'entry-6',
-    primaryText: 'glory',
-    sourceLanguageText: '\u03B4\u03CC\u03BE\u03B1',
-    transliteration: 'doxa',
-    glosses: 'glory, splendor, brightness',
-    strongsCodes: ['G1391'],
-    occurrenceCount: 7,
-    domains: [
-      { id: 'quality', label: 'Quality & Attributes', parentId: 'abstract-concepts', code: '1.3' },
+    id: 'entry-halak',
+    primaryText: 'walk',
+    sourceLanguageText: '\u05D4\u05B8\u05DC\u05B7\u05DA\u05B0',
+    transliteration: 'hlk',
+    senses: [
+      {
+        number: 1,
+        definition: 'to move on foot; to go or travel by walking.',
+        occurrenceCount: 198,
+        glosses: 'to walk, to go, to travel',
+        domain: { id: 'happen-cause', label: 'Cause', parentId: 'happen', code: '2.1' },
+      },
     ],
-    definition:
-      'Great beauty, magnificence, or splendor. Often refers to the manifest presence and power of God.',
+    totalOccurrences: 198,
+  },
+  {
+    id: 'entry-shama',
+    primaryText: 'hear',
+    sourceLanguageText: '\u05E9\u05B8\u05C1\u05DE\u05B7\u05E2',
+    transliteration: '\u0161m\u02BF',
+    senses: [
+      {
+        number: 1,
+        definition: 'to perceive sound with the ear; to listen attentively.',
+        occurrenceCount: 287,
+        glosses: 'to hear, to listen, to obey',
+        domain: { id: 'speak', label: 'Speak', parentId: 'communication', code: '4.1' },
+      },
+    ],
+    totalOccurrences: 287,
   },
 ];
 
 // ---------------------------------------------------------------------------
-// Sample encyclopedia items
+// Sample encyclopedia / media / lexical data
 // ---------------------------------------------------------------------------
 
 const sampleEncyclopediaItems: EncyclopediaTeaser[] = [
@@ -178,8 +191,7 @@ const sampleEncyclopediaItems: EncyclopediaTeaser[] = [
     primaryText: 'Ephesus',
     sourceLanguageText: '\u1F1C\u03C6\u03B5\u03C3\u03BF\u03C2',
     transliteration: 'Ephesos',
-    teaserText:
-      'An ancient Greek city on the coast of Ionia, renowned for the Temple of Artemis. Paul spent about three years there establishing the early church.',
+    teaserText: 'An ancient Greek city on the coast of Ionia, renowned for the Temple of Artemis.',
   },
   {
     id: 'enc-2',
@@ -187,90 +199,39 @@ const sampleEncyclopediaItems: EncyclopediaTeaser[] = [
     sourceLanguageText: '\u039A\u03CC\u03C1\u03B9\u03BD\u03B8\u03BF\u03C2',
     transliteration: 'Korinthos',
     teaserText:
-      'A major Greek city-state located on the isthmus connecting the Peloponnese to mainland Greece. Paul wrote two epistles to the church there.',
+      'A major Greek city-state on the isthmus connecting the Peloponnese to mainland Greece.',
   },
   {
     id: 'enc-3',
     primaryText: 'Baptism',
     sourceLanguageText: '\u03B2\u03AC\u03C0\u03C4\u03B9\u03C3\u03BC\u03B1',
     transliteration: 'baptisma',
-    teaserText:
-      'A rite of washing with water as a sign of religious purification and consecration. Central to Christian initiation.',
-  },
-  {
-    id: 'enc-4',
-    primaryText: 'Pharisees',
-    sourceLanguageText: '\u03A6\u03B1\u03C1\u03B9\u03C3\u03B1\u1FD6\u03BF\u03B9',
-    transliteration: 'Pharisaioi',
-    teaserText:
-      'A Jewish sect known for strict observance of the Torah and oral traditions. Frequently mentioned in the Gospels in dialogue with Jesus.',
-  },
-  {
-    id: 'enc-5',
-    primaryText: 'Covenant',
-    sourceLanguageText: '\u03B4\u03B9\u03B1\u03B8\u03AE\u03BA\u03B7',
-    transliteration: 'diatheke',
-    teaserText:
-      'A solemn agreement between God and his people. Key covenants include those with Abraham, Moses, and the New Covenant through Christ.',
+    teaserText: 'A rite of washing with water as a sign of religious purification.',
   },
 ];
-
-// ---------------------------------------------------------------------------
-// Sample media items
-// ---------------------------------------------------------------------------
 
 const sampleMediaItems: MediaItem[] = [
   {
     id: 'media-1',
     primaryText: 'Map of Ancient Ephesus',
     sourceLanguageText: '\u1F1C\u03C6\u03B5\u03C3\u03BF\u03C2',
-    transliteration: 'Ephesos',
     thumbnailUrl: 'https://placehold.co/200x200/e2e8f0/64748b?text=Map',
-    thumbnailAlt: 'Map of Ancient Ephesus',
     mediaType: 'map',
-    caption: 'City plan showing the harbor, theater, and Temple of Artemis',
+    caption: 'City plan showing the harbor and Temple of Artemis',
   },
   {
     id: 'media-2',
     primaryText: 'Theater at Ephesus',
-    sourceLanguageText: '\u03B8\u03AD\u03B1\u03C4\u03C1\u03BF\u03BD',
-    transliteration: 'theatron',
     thumbnailUrl: 'https://placehold.co/200x200/e2e8f0/64748b?text=Photo',
-    thumbnailAlt: 'Photo of the ancient theater at Ephesus',
     mediaType: 'image',
-    caption: 'The Great Theater, seating approximately 25,000 spectators',
-  },
-  {
-    id: 'media-3',
-    primaryText: "Paul's Missionary Journeys",
-    sourceLanguageText: '\u03BF\u03B4\u03BF\u03B9\u03C0\u03BF\u03C1\u03AF\u03B1',
-    transliteration: 'hodoiporia',
-    thumbnailUrl: 'https://placehold.co/200x200/e2e8f0/64748b?text=Map',
-    thumbnailAlt: "Map of Paul's missionary journeys",
-    mediaType: 'map',
-    caption: 'Routes of the first, second, and third missionary journeys',
-  },
-  {
-    id: 'media-4',
-    primaryText: 'Temple of Artemis',
-    sourceLanguageText: '\u0391\u03C1\u03C4\u03AD\u03BC\u03B9\u03C2',
-    transliteration: 'Artemis',
-    thumbnailUrl: 'https://placehold.co/200x200/e2e8f0/64748b?text=Photo',
-    thumbnailAlt: 'Artistic reconstruction of the Temple of Artemis',
-    mediaType: 'image',
-    caption: 'One of the Seven Wonders of the Ancient World',
+    caption: 'The Great Theater, seating ~25,000 spectators',
   },
 ];
-
-// ---------------------------------------------------------------------------
-// Sample lexical entries
-// ---------------------------------------------------------------------------
 
 const sampleLexicalEntries: LexicalDictionaryEntry[] = [
   {
     id: 'lex-1',
     primaryText: '\u03BB\u03CC\u03B3\u03BF\u03C2',
-    sourceLanguageText: '\u03BB\u03CC\u03B3\u03BF\u03C2',
     transliteration: 'logos',
     strongsCodes: ['G3056'],
     glosses: 'word, speech, message, reason',
@@ -279,7 +240,6 @@ const sampleLexicalEntries: LexicalDictionaryEntry[] = [
   {
     id: 'lex-2',
     primaryText: '\u03B8\u03B5\u03CC\u03C2',
-    sourceLanguageText: '\u03B8\u03B5\u03CC\u03C2',
     transliteration: 'theos',
     strongsCodes: ['G2316'],
     glosses: 'God, god, deity',
@@ -288,7 +248,6 @@ const sampleLexicalEntries: LexicalDictionaryEntry[] = [
   {
     id: 'lex-3',
     primaryText: '\u03BA\u03CC\u03C3\u03BC\u03BF\u03C2',
-    sourceLanguageText: '\u03BA\u03CC\u03C3\u03BC\u03BF\u03C2',
     transliteration: 'kosmos',
     strongsCodes: ['G2889'],
     glosses: 'world, universe, order',
@@ -297,7 +256,6 @@ const sampleLexicalEntries: LexicalDictionaryEntry[] = [
   {
     id: 'lex-4',
     primaryText: '\u03C6\u1FF6\u03C2',
-    sourceLanguageText: '\u03C6\u1FF6\u03C2',
     transliteration: 'phos',
     strongsCodes: ['G5457'],
     glosses: 'light, radiance',
@@ -305,187 +263,180 @@ const sampleLexicalEntries: LexicalDictionaryEntry[] = [
   },
   {
     id: 'lex-5',
-    primaryText: '\u03C3\u03BA\u03BF\u03C4\u03AF\u03B1',
-    sourceLanguageText: '\u03C3\u03BA\u03BF\u03C4\u03AF\u03B1',
-    transliteration: 'skotia',
-    strongsCodes: ['G4653'],
-    glosses: 'darkness, gloom',
-    occurrenceCount: 4,
-  },
-  {
-    id: 'lex-6',
     primaryText: '\u03B6\u03C9\u03AE',
-    sourceLanguageText: '\u03B6\u03C9\u03AE',
     transliteration: 'zoe',
     strongsCodes: ['G2222'],
     glosses: 'life, living',
     occurrenceCount: 11,
   },
-  {
-    id: 'lex-7',
-    primaryText: '\u1F00\u03BB\u03AE\u03B8\u03B5\u03B9\u03B1',
-    sourceLanguageText: '\u1F00\u03BB\u03AE\u03B8\u03B5\u03B9\u03B1',
-    transliteration: 'aletheia',
-    strongsCodes: ['G225'],
-    glosses: 'truth, reality',
-    occurrenceCount: 6,
-  },
 ];
 
 // ---------------------------------------------------------------------------
-// Shared detail content renderers (extracted from lexical dictionary pattern)
+// Detail content renderers
 // ---------------------------------------------------------------------------
 
-/** Renders detailed dictionary entry content inside the scoped drawer */
-function DictionaryDetailContent({
+/** ER Dictionary entry detail - matches the PT9 screenshot layout with shadcn styling */
+function ErDictionaryDetail({
   item,
   onClose,
   onDomainClick,
 }: {
-  item: DictionaryEntryWithDomains;
+  item: DictionaryEntryWithSenses;
   onClose: () => void;
   onDomainClick?: (domain: EntryDomain) => void;
 }) {
   return (
-    <>
-      <DrawerClose asChild>
-        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
-          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
-          Back to list
-        </Button>
-      </DrawerClose>
+    <div>
+      <Button onClick={onClose} variant="link" className="tw-mb-3 tw-h-auto tw-p-0">
+        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+        Back to list
+      </Button>
 
+      {/* Header: source language text + transliteration */}
       <div className="tw-mb-4">
-        <div className="tw-flex tw-items-baseline tw-justify-between tw-gap-2">
-          <span className="tw-flex tw-flex-row tw-items-baseline tw-gap-2">
-            <DrawerTitle className="tw-text-2xl tw-font-normal">{item.primaryText}</DrawerTitle>
-            <DrawerDescription className="tw-text-lg tw-text-muted-foreground">
-              {item.glosses}
-            </DrawerDescription>
+        <span className="tw-text-lg tw-font-normal">{item.sourceLanguageText}</span>
+        {item.transliteration && (
+          <span className="tw-ml-1 tw-text-base tw-text-muted-foreground">
+            ({item.transliteration})
           </span>
-          <ul className="tw-flex tw-flex-row tw-gap-1">
-            {item.strongsCodes.map((code) => (
-              <li
-                key={code}
-                className="tw-ml-auto tw-rounded tw-bg-accent tw-px-2 tw-py-0.5 tw-text-sm"
-              >
-                {code}
-              </li>
-            ))}
-          </ul>
-        </div>
-        {item.sourceLanguageText && (
-          <p className="tw-mt-1 tw-text-sm tw-text-muted-foreground">
-            {item.sourceLanguageText}
-            {item.transliteration && <span className="tw-ml-1">({item.transliteration})</span>}
-          </p>
         )}
       </div>
 
-      <Separator className="tw-my-3" />
-
-      {item.definition && (
-        <div className="tw-mb-4">
-          <h3 className="tw-mb-1 tw-font-semibold">Definition</h3>
-          <p className="tw-text-sm tw-text-muted-foreground">{item.definition}</p>
-        </div>
-      )}
-
-      {/* Domains as clickable links */}
-      {item.domains.length > 0 && (
-        <div className="tw-mb-4">
-          <h3 className="tw-mb-2 tw-font-semibold">Domains</h3>
-          <div className="tw-flex tw-flex-wrap tw-gap-2">
-            {item.domains.map((domain) => (
+      {/* Senses */}
+      <div className="tw-space-y-4">
+        {item.senses.map((sense) => (
+          <div key={sense.number} className="tw-pl-1">
+            <p className="tw-text-sm">
+              <span className="tw-mr-2 tw-font-bold tw-text-primary">{sense.number}</span>
+              <span>{sense.definition}</span>
+              <span className="tw-ml-1 tw-text-muted-foreground">({sense.occurrenceCount})</span>
+            </p>
+            <p className="tw-mt-0.5 tw-pl-5 tw-text-sm tw-text-muted-foreground">
+              Glosses: <span className="tw-italic">{sense.glosses}</span>
+            </p>
+            <p className="tw-pl-5 tw-text-sm tw-text-muted-foreground">
+              Domain:{' '}
               <Button
-                key={domain.id}
-                variant="outline"
-                className="tw-h-auto tw-gap-1 tw-px-2 tw-py-1 tw-text-xs"
-                onClick={() => onDomainClick?.(domain)}
+                variant="link"
+                className="tw-h-auto tw-p-0 tw-text-sm tw-italic tw-underline"
+                onClick={() => onDomainClick?.(sense.domain)}
               >
-                <BookA className="tw-h-3 tw-w-3" />
-                {domain.label}
+                {sense.domain.label}
               </Button>
-            ))}
+            </p>
           </div>
-        </div>
-      )}
+        ))}
+      </div>
 
       <Separator className="tw-my-3" />
 
-      <div>
-        <h3 className="tw-mb-2 tw-font-semibold">Occurrences ({item.occurrenceCount})</h3>
-        <p className="tw-text-sm tw-text-muted-foreground">
-          Scripture references would appear here in the real application.
-        </p>
-      </div>
-    </>
+      {/* Occurrences */}
+      <p className="tw-text-sm">
+        Occurrences in all books{' '}
+        <span className="tw-text-muted-foreground">({item.totalOccurrences})</span>
+      </p>
+    </div>
   );
 }
 
-/** Renders detailed encyclopedia content inside the scoped drawer */
-function EncyclopediaDetailContent({
-  item,
-  onClose,
-}: {
-  item: EncyclopediaTeaser;
-  onClose: () => void;
-}) {
+/** Encyclopedia detail */
+function EncyclopediaDetail({ item, onClose }: { item: EncyclopediaTeaser; onClose: () => void }) {
   return (
-    <>
-      <DrawerClose asChild>
-        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
-          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
-          Back to list
-        </Button>
-      </DrawerClose>
-
-      <DrawerTitle className="tw-mb-1 tw-text-2xl tw-font-normal">{item.primaryText}</DrawerTitle>
+    <div>
+      <Button onClick={onClose} variant="link" className="tw-mb-3 tw-h-auto tw-p-0">
+        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+        Back to list
+      </Button>
+      <h2 className="tw-mb-1 tw-text-xl tw-font-normal">{item.primaryText}</h2>
       {item.sourceLanguageText && (
-        <DrawerDescription className="tw-text-sm tw-text-muted-foreground">
+        <p className="tw-text-sm tw-text-muted-foreground">
           {item.sourceLanguageText}
           {item.transliteration && <span className="tw-ml-1">({item.transliteration})</span>}
-        </DrawerDescription>
+        </p>
       )}
-
       <Separator className="tw-my-3" />
-
-      <p className="tw-text-sm">
-        {item.teaserText ?? 'Full article content would be displayed here in the real application.'}
-      </p>
-    </>
+      <p className="tw-text-sm">{item.teaserText}</p>
+    </div>
   );
 }
 
-/** Renders detailed media content inside the scoped drawer */
-function MediaDetailContent({ item, onClose }: { item: MediaItem; onClose: () => void }) {
+/** Media detail */
+function MediaDetail({ item, onClose }: { item: MediaItem; onClose: () => void }) {
   return (
-    <>
-      <DrawerClose asChild>
-        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
-          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
-          Back to list
-        </Button>
-      </DrawerClose>
-
-      <div className="tw-mb-4 tw-flex tw-items-center tw-gap-2">
-        <DrawerTitle className="tw-text-xl tw-font-normal">{item.primaryText}</DrawerTitle>
+    <div>
+      <Button onClick={onClose} variant="link" className="tw-mb-3 tw-h-auto tw-p-0">
+        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+        Back to list
+      </Button>
+      <div className="tw-mb-3 tw-flex tw-items-center tw-gap-2">
+        <h2 className="tw-text-lg tw-font-normal">{item.primaryText}</h2>
         <Badge variant="outline">{item.mediaType}</Badge>
       </div>
-      <DrawerDescription className="tw-sr-only">
-        {item.caption ?? item.primaryText}
-      </DrawerDescription>
-
       {item.thumbnailUrl && (
         <img
           src={item.thumbnailUrl}
           alt={item.thumbnailAlt ?? item.primaryText}
-          className="tw-mb-4 tw-w-full tw-rounded tw-object-contain"
+          className="tw-mb-3 tw-w-full tw-rounded tw-object-contain"
         />
       )}
-
       {item.caption && <p className="tw-text-sm tw-text-muted-foreground">{item.caption}</p>}
-    </>
+    </div>
+  );
+}
+
+/** Lexical dictionary detail (extracted from platform-lexical-tools pattern) */
+function LexicalDetail({ item, onClose }: { item: LexicalDictionaryEntry; onClose: () => void }) {
+  return (
+    <div>
+      <Button onClick={onClose} variant="link" className="tw-mb-3 tw-h-auto tw-p-0">
+        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+        Back to list
+      </Button>
+      <div className="tw-mb-3">
+        <span className="scripture-font tw-text-2xl tw-font-normal">{item.primaryText}</span>
+        <span className="tw-ml-2 tw-text-lg tw-text-muted-foreground">{item.glosses}</span>
+      </div>
+      <div className="tw-flex tw-gap-1">
+        {item.strongsCodes.map((code) => (
+          <span key={code} className="tw-rounded tw-bg-accent tw-px-2 tw-py-0.5 tw-text-sm">
+            {code}
+          </span>
+        ))}
+      </div>
+      <Separator className="tw-my-3" />
+      <p className="tw-text-sm">
+        Occurrences <span className="tw-text-muted-foreground">({item.occurrenceCount})</span>
+      </p>
+      <p className="tw-mt-2 tw-text-sm tw-text-muted-foreground">
+        Scripture references would appear here.
+      </p>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ER dictionary list item with full 2-row content (kept at this height always)
+// ---------------------------------------------------------------------------
+
+function ErDictionaryListItem({ item }: { item: DictionaryEntryWithSenses }) {
+  const firstSense = item.senses[0];
+  return (
+    <div className="tw-flex tw-w-full tw-flex-col tw-gap-0.5">
+      <div className="tw-flex tw-items-baseline tw-gap-2">
+        <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
+        <span className="tw-text-sm tw-text-muted-foreground">
+          {item.sourceLanguageText}
+          {item.transliteration && <span className="tw-ml-1">({item.transliteration})</span>}
+        </span>
+        <span className="tw-ml-auto tw-shrink-0 tw-rounded tw-bg-accent tw-px-1.5 tw-py-0.5 tw-text-xs">
+          {item.totalOccurrences}
+        </span>
+      </div>
+      <p className="tw-truncate tw-text-sm tw-text-muted-foreground">
+        {firstSense?.glosses}
+        {item.senses.length > 1 && ` (+${item.senses.length - 1} more)`}
+      </p>
+    </div>
   );
 }
 
@@ -520,7 +471,6 @@ type Story = StoryObj<typeof SourceLanguageIndexedList>;
 export const Default: Story = {
   render: () => {
     const [selectedId, setSelectedId] = useState<string | undefined>();
-
     return (
       <div className="tw-h-[400px] tw-rounded tw-border">
         <SourceLanguageIndexedList
@@ -537,477 +487,249 @@ export const Default: Story = {
     docs: {
       description: {
         story:
-          'Base SourceLanguageIndexedList without a detail panel. Clicking items toggles selection only.',
+          'Base SourceLanguageIndexedList without a detail panel. Clicking items toggles selection.',
       },
     },
   },
 };
 
-/** Loading state with skeleton placeholders */
+/** Loading state */
 export const Loading: Story = {
   render: () => (
     <div className="tw-h-[400px] tw-rounded tw-border">
       <SourceLanguageIndexedList items={[]} isLoading />
     </div>
   ),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Loading state showing skeleton placeholders while data is being fetched.',
-      },
-    },
-  },
 };
 
-/** Empty state with custom message */
+/** Empty state */
 export const EmptyState: Story = {
   render: () => (
     <div className="tw-h-[400px] tw-rounded tw-border">
-      <SourceLanguageIndexedList
-        items={[]}
-        emptyStateMessage="No dictionary entries found for this scope"
-      />
+      <SourceLanguageIndexedList items={[]} emptyStateMessage="No entries found for this scope" />
     </div>
   ),
-  parameters: {
-    docs: {
-      description: {
-        story: 'Empty state shown when no items match the current filter or scope.',
-      },
-    },
-  },
 };
 
 /**
- * ER Dictionary list with detail panel. Clicking an entry opens a inline detail panel showing the
- * full entry details (glosses, Strong's codes, definition, domains as clickable links). Clicking a
- * domain link opens the "ER Dictionary Filtered by Type" dialog.
+ * All ER tabs with inline panel detail view and inline domain navigation. This is the primary
+ * layout showing Dictionary, Encyclopedia, and Media tabs together. Clicking a domain link in the
+ * dictionary detail replaces the view inline with a back button.
  */
-export const ErDictionary: Story = {
-  render: () => {
-    const [filteredDialogOpen, setFilteredDialogOpen] = useState(false);
-    const [filteredDomainL1, setFilteredDomainL1] = useState(sampleAllDomains[0]);
-    const [filteredDomainL2, setFilteredDomainL2] = useState<SemanticDomain | undefined>();
-    const [navMode, setNavMode] = useState<'tree' | 'dropdown'>('dropdown');
-
-    const handleDomainClick = (domain: EntryDomain) => {
-      // Find the matching level-1 domain and optionally level-2
-      const l1 = sampleAllDomains.find(
-        (d) => d.id === domain.id || d.children?.some((c) => c.id === domain.id),
-      );
-      if (l1) {
-        setFilteredDomainL1(l1);
-        const l2 = l1.children?.find((c) => c.id === domain.id);
-        setFilteredDomainL2(l2);
-        setFilteredDialogOpen(true);
-      }
-    };
-
-    return (
-      <>
-        <div className="tw-h-[500px] tw-rounded tw-border">
-          <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">Dictionary</h3>
-          <ErDictionaryList
-            items={sampleDictionaryItems}
-            showSourceLanguage
-            showTransliteration
-            getDescription={(item) => item.glosses}
-            getBadges={(item) => item.strongsCodes}
-            getOccurrenceCount={(item) => item.occurrenceCount}
-            renderDetailContent={(item, onClose) => (
-              <DictionaryDetailContent
-                item={item}
-                onClose={onClose}
-                onDomainClick={handleDomainClick}
-              />
-            )}
-          />
-        </div>
-
-        {/* Dialog that opens when clicking a domain link in the detail panel */}
-        <Dialog open={filteredDialogOpen} onOpenChange={setFilteredDialogOpen}>
-          <DialogContent className="tw-flex tw-h-[500px] tw-max-w-lg tw-flex-col tw-p-0">
-            <DialogTitle className="tw-px-4 tw-pt-4 tw-text-base tw-font-semibold">
-              Dictionary by Domain
-            </DialogTitle>
-            <ErDictionaryFilteredList
-              items={sampleDictionaryItems.filter((entry) =>
-                entry.domains.some(
-                  (d) =>
-                    d.id === filteredDomainL1.id ||
-                    d.id === filteredDomainL2?.id ||
-                    d.parentId === filteredDomainL1.id,
-                ),
-              )}
-              selectedLevel1Domain={filteredDomainL1}
-              selectedLevel2Domain={filteredDomainL2}
-              allDomains={sampleAllDomains}
-              onDomainChange={(l1, l2) => {
-                setFilteredDomainL1(l1);
-                setFilteredDomainL2(l2);
-              }}
-              navigationMode={navMode}
-              onNavigationModeChange={setNavMode}
-              renderDetailContent={(item, onClose) => (
-                <DictionaryDetailContent item={item} onClose={onClose} />
-              )}
-              className="tw-min-h-0 tw-flex-1"
-            />
-          </DialogContent>
-        </Dialog>
-      </>
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'ER Dictionary list with a detail panel. Clicking an entry opens a inline detail panel with full details. Domain names in the detail view are clickable links that open the "ER Dictionary Filtered by Type" dialog.',
-      },
-    },
-  },
-};
-
-/**
- * ER Dictionary filtered by semantic domain, shown in a Dialog. Features 2-level breadcrumbs,
- * dropdown/tree navigation toggle, and entry detail panel.
- */
-export const ErDictionaryFilteredByType: Story = {
-  render: () => {
-    const [selectedL1, setSelectedL1] = useState(sampleAllDomains[0]);
-    const [selectedL2, setSelectedL2] = useState<SemanticDomain | undefined>(
-      sampleAllDomains[0].children?.[0],
-    );
-    const [navMode, setNavMode] = useState<'tree' | 'dropdown'>('dropdown');
-
-    const handleDomainChange = useCallback((l1: SemanticDomain, l2?: SemanticDomain) => {
-      setSelectedL1(l1);
-      setSelectedL2(l2);
-    }, []);
-
-    return (
-      <Dialog>
-        <DialogTrigger asChild>
-          <Button variant="outline">Open Dictionary by Domain</Button>
-        </DialogTrigger>
-        <DialogContent className="tw-flex tw-h-[550px] tw-max-w-lg tw-flex-col tw-p-0">
-          <DialogTitle className="tw-px-4 tw-pt-4 tw-text-base tw-font-semibold">
-            Dictionary by Semantic Domain
-          </DialogTitle>
-          <ErDictionaryFilteredList
-            items={sampleDictionaryItems}
-            selectedLevel1Domain={selectedL1}
-            selectedLevel2Domain={selectedL2}
-            allDomains={sampleAllDomains}
-            onDomainChange={handleDomainChange}
-            navigationMode={navMode}
-            onNavigationModeChange={setNavMode}
-            renderDetailContent={(item, onClose) => (
-              <DictionaryDetailContent item={item} onClose={onClose} />
-            )}
-            className="tw-min-h-0 tw-flex-1"
-          />
-        </DialogContent>
-      </Dialog>
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'ER Dictionary filtered by semantic domain inside a Dialog. 2-level breadcrumbs at top; clicking them opens either a dropdown (dropdown mode) or a domain tree drawer (tree mode). Toggle between modes at the bottom. Clicking an entry opens a detail panel.',
-      },
-    },
-  },
-};
-
-/** ER Encyclopedia list with detail panel showing article titles and teaser text. */
-export const ErEncyclopedia: Story = {
-  render: () => (
-    <div className="tw-h-[500px] tw-rounded tw-border">
-      <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">Encyclopedia</h3>
-      <ErEncyclopediaList
-        items={sampleEncyclopediaItems}
-        showSourceLanguage
-        showTransliteration
-        renderDetailContent={(item, onClose) => (
-          <EncyclopediaDetailContent item={item} onClose={onClose} />
-        )}
-      />
-    </div>
-  ),
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'ER Encyclopedia list with a detail panel. Clicking an article opens the full article content in a inline detail panel.',
-      },
-    },
-  },
-};
-
-/** ER Media list (images and maps) with detail panel showing image preview. */
-export const ErMedia: Story = {
-  render: () => (
-    <div className="tw-h-[500px] tw-rounded tw-border">
-      <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
-        Media (Images &amp; Maps)
-      </h3>
-      <ErMediaList
-        items={sampleMediaItems}
-        showSourceLanguage
-        renderDetailContent={(item, onClose) => (
-          <MediaDetailContent item={item} onClose={onClose} />
-        )}
-      />
-    </div>
-  ),
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'ER Media list with a detail panel. Clicking an image or map opens a preview in a inline detail panel with zoom/pan support.',
-      },
-    },
-  },
-};
-
-/**
- * Lexical extension dictionary list extracted from platform-lexical-tools. Shows entries with lemma
- * text, occurrence count badges, formatted glosses, and Strong's code badges.
- */
-export const LexicalDictionary: Story = {
-  render: () => {
-    const [selectedId, setSelectedId] = useState<string | undefined>();
-
-    return (
-      <div className="tw-h-[500px] tw-rounded tw-border">
-        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
-          Lexical Dictionary
-        </h3>
-        <LexicalDictionaryList
-          items={sampleLexicalEntries}
-          onItemClick={(item) => setSelectedId(item?.id === selectedId ? undefined : item?.id)}
-          selectedItemId={selectedId}
-          occurrenceCountLabel="Occurrences in chapter"
-          strongsCodeLabel="Strong's code"
-        />
-      </div>
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Lexical extension dictionary list extracted from platform-lexical-tools. Shows entries with source language lemma, occurrence count, glosses, and Strong's codes.",
-      },
-    },
-  },
-};
-
-/** All ER tabs combined to show how the components work together in a research pane layout. */
 export const AllErTabs: Story = {
   render: () => {
     const [activeTab, setActiveTab] = useState<'dictionary' | 'encyclopedia' | 'media'>(
       'dictionary',
     );
-    const [filteredDialogOpen, setFilteredDialogOpen] = useState(false);
-    const [filteredDomainL1, setFilteredDomainL1] = useState(sampleAllDomains[0]);
-    const [filteredDomainL2, setFilteredDomainL2] = useState<SemanticDomain | undefined>();
-    const [navMode, setNavMode] = useState<'tree' | 'dropdown'>('dropdown');
+    const [selectedDictItem, setSelectedDictItem] = useState<
+      DictionaryEntryWithSenses | undefined
+    >();
+    const [selectedEncItem, setSelectedEncItem] = useState<EncyclopediaTeaser | undefined>();
+    const [selectedMediaItem, setSelectedMediaItem] = useState<MediaItem | undefined>();
+
+    // Inline domain navigation state
+    const [activeDomain, setActiveDomain] = useState<
+      | {
+          level1: SemanticDomain;
+          level2?: SemanticDomain;
+        }
+      | undefined
+    >();
 
     const handleDomainClick = (domain: EntryDomain) => {
       const l1 = sampleAllDomains.find(
         (d) => d.id === domain.id || d.children?.some((c) => c.id === domain.id),
       );
       if (l1) {
-        setFilteredDomainL1(l1);
-        setFilteredDomainL2(l1.children?.find((c) => c.id === domain.id));
-        setFilteredDialogOpen(true);
+        setActiveDomain({ level1: l1, level2: l1.children?.find((c) => c.id === domain.id) });
+        setSelectedDictItem(undefined);
       }
     };
 
     return (
-      <>
-        <div className="tw-flex tw-h-[500px] tw-flex-col tw-rounded tw-border">
-          <div className="tw-flex tw-border-b">
-            {(['dictionary', 'encyclopedia', 'media'] as const).map((tab) => (
-              <button
-                key={tab}
-                type="button"
-                className={`tw-px-4 tw-py-2 tw-text-sm tw-capitalize ${
-                  activeTab === tab
-                    ? 'tw-border-b-2 tw-border-primary tw-font-medium'
-                    : 'tw-text-muted-foreground hover:tw-text-foreground'
-                }`}
-                onClick={() => setActiveTab(tab)}
-              >
-                {tab}
-              </button>
-            ))}
-          </div>
-          <div className="tw-flex-1 tw-overflow-hidden">
-            {activeTab === 'dictionary' && (
-              <ErDictionaryList
-                items={sampleDictionaryItems}
-                showSourceLanguage
-                showTransliteration
-                getDescription={(item) => item.glosses}
-                getBadges={(item) => item.strongsCodes}
-                getOccurrenceCount={(item) => item.occurrenceCount}
-                renderDetailContent={(item, onClose) => (
-                  <DictionaryDetailContent
-                    item={item}
-                    onClose={onClose}
-                    onDomainClick={handleDomainClick}
-                  />
-                )}
-              />
-            )}
-            {activeTab === 'encyclopedia' && (
-              <ErEncyclopediaList
-                items={sampleEncyclopediaItems}
-                showSourceLanguage
-                showTransliteration
-                renderDetailContent={(item, onClose) => (
-                  <EncyclopediaDetailContent item={item} onClose={onClose} />
-                )}
-              />
-            )}
-            {activeTab === 'media' && (
-              <ErMediaList
-                items={sampleMediaItems}
-                showSourceLanguage
-                renderDetailContent={(item, onClose) => (
-                  <MediaDetailContent item={item} onClose={onClose} />
-                )}
-              />
-            )}
-          </div>
+      <div className="tw-flex tw-h-[550px] tw-flex-col tw-rounded tw-border">
+        {/* Tabs */}
+        <div className="tw-flex tw-border-b">
+          {(['dictionary', 'encyclopedia', 'media'] as const).map((tab) => (
+            <button
+              key={tab}
+              type="button"
+              className={`tw-px-4 tw-py-2 tw-text-sm tw-capitalize ${
+                activeTab === tab
+                  ? 'tw-border-b-2 tw-border-primary tw-font-medium'
+                  : 'tw-text-muted-foreground hover:tw-text-foreground'
+              }`}
+              onClick={() => {
+                setActiveTab(tab);
+                setSelectedDictItem(undefined);
+                setSelectedEncItem(undefined);
+                setSelectedMediaItem(undefined);
+                setActiveDomain(undefined);
+              }}
+            >
+              {tab}
+            </button>
+          ))}
         </div>
 
-        <Dialog open={filteredDialogOpen} onOpenChange={setFilteredDialogOpen}>
-          <DialogContent className="tw-flex tw-h-[500px] tw-max-w-lg tw-flex-col tw-p-0">
-            <DialogTitle className="tw-px-4 tw-pt-4 tw-text-base tw-font-semibold">
-              Dictionary by Domain
-            </DialogTitle>
+        {/* Tab content */}
+        <div className="tw-flex-1 tw-overflow-hidden">
+          {activeTab === 'dictionary' && !activeDomain && (
+            <div className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
+              {/* List pane */}
+              <div
+                className={cn('tw-h-full tw-overflow-y-auto tw-border-r', {
+                  'tw-w-full': !selectedDictItem,
+                  'tw-w-1/5 tw-min-w-[120px]': !!selectedDictItem,
+                })}
+              >
+                <ul role="listbox" className="tw-outline-none">
+                  {sampleDictionaryItems.map((item) => {
+                    const isSelected = selectedDictItem?.id === item.id;
+                    return (
+                      <li
+                        key={item.id}
+                        role="option"
+                        aria-selected={isSelected}
+                        onClick={() => setSelectedDictItem(isSelected ? undefined : item)}
+                        className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
+                          'tw-bg-muted': isSelected,
+                          'hover:tw-bg-muted': !isSelected,
+                        })}
+                      >
+                        <ErDictionaryListItem item={item} />
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+              {/* Detail pane */}
+              {selectedDictItem && (
+                <div className="tw-w-4/5 tw-overflow-y-auto tw-bg-background tw-p-4">
+                  <ErDictionaryDetail
+                    item={selectedDictItem}
+                    onClose={() => setSelectedDictItem(undefined)}
+                    onDomainClick={handleDomainClick}
+                  />
+                </div>
+              )}
+            </div>
+          )}
+
+          {activeTab === 'dictionary' && activeDomain && (
             <ErDictionaryFilteredList
               items={sampleDictionaryItems.filter((entry) =>
-                entry.domains.some(
-                  (d) =>
-                    d.id === filteredDomainL1.id ||
-                    d.id === filteredDomainL2?.id ||
-                    d.parentId === filteredDomainL1.id,
+                entry.senses.some(
+                  (s) =>
+                    s.domain.id === activeDomain.level1.id ||
+                    s.domain.id === activeDomain.level2?.id ||
+                    s.domain.parentId === activeDomain.level1.id,
                 ),
               )}
-              selectedLevel1Domain={filteredDomainL1}
-              selectedLevel2Domain={filteredDomainL2}
+              selectedLevel1Domain={activeDomain.level1}
+              selectedLevel2Domain={activeDomain.level2}
               allDomains={sampleAllDomains}
-              onDomainChange={(l1, l2) => {
-                setFilteredDomainL1(l1);
-                setFilteredDomainL2(l2);
-              }}
-              navigationMode={navMode}
-              onNavigationModeChange={setNavMode}
+              onDomainChange={(l1, l2) => setActiveDomain({ level1: l1, level2: l2 })}
+              onBack={() => setActiveDomain(undefined)}
+              renderItem={(item) => <ErDictionaryListItem item={item} />}
               renderDetailContent={(item, onClose) => (
-                <DictionaryDetailContent item={item} onClose={onClose} />
+                <ErDictionaryDetail item={item} onClose={onClose} />
               )}
-              className="tw-min-h-0 tw-flex-1"
+              className="tw-h-full"
             />
-          </DialogContent>
-        </Dialog>
-      </>
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'All ER tabs combined with detail panels and domain-filtered dialog. Dictionary entries open a detail panel with clickable domain links. Clicking a domain opens the filtered dictionary dialog.',
-      },
-    },
-  },
-};
+          )}
 
-// ---------------------------------------------------------------------------
-// Alternative: Inline panel (flex layout, no Drawer)
-// ---------------------------------------------------------------------------
-
-/**
- * Alternative layout using an inline flex panel instead of a Drawer. The detail view renders as a
- * sibling div that takes 4/5 of the width while the list collapses. No portal or overlay involved.
- */
-export const InlinePanelAlternative: Story = {
-  render: () => {
-    const [selectedItem, setSelectedItem] = useState<DictionaryEntryWithDomains | undefined>();
-
-    return (
-      <div className="tw-h-[500px] tw-rounded tw-border">
-        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
-          Dictionary (Inline Panel Alternative)
-        </h3>
-        <div className="tw-relative tw-flex tw-h-[calc(100%-41px)] tw-overflow-hidden">
-          {/* List pane */}
-          <div
-            className={cn('tw-overflow-y-auto tw-transition-all tw-duration-200', {
-              'tw-w-full': !selectedItem,
-              'tw-w-1/5 tw-min-w-0': !!selectedItem,
-            })}
-          >
-            <ul role="listbox" className="tw-outline-none">
-              {sampleDictionaryItems.map((item) => {
-                const isSelected = selectedItem?.id === item.id;
-                return (
-                  <li
-                    key={item.id}
-                    role="option"
-                    aria-selected={isSelected}
-                    tabIndex={-1}
-                    onClick={() => setSelectedItem(isSelected ? undefined : item)}
-                    className={cn(
-                      'tw-flex tw-cursor-pointer tw-flex-col tw-gap-0.5 tw-border-b tw-p-2',
-                      {
-                        'tw-bg-muted': isSelected,
-                        'hover:tw-bg-muted': !isSelected,
-                      },
-                    )}
-                  >
-                    <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
-                    {!selectedItem && (
-                      <span className="tw-truncate tw-text-xs tw-text-muted-foreground">
-                        {item.glosses}
-                      </span>
-                    )}
-                  </li>
-                );
-              })}
-            </ul>
-          </div>
-
-          {/* Inline detail pane */}
-          {selectedItem && (
-            <div className="tw-w-4/5 tw-overflow-y-auto tw-border-l tw-bg-background tw-p-4">
-              <Button
-                onClick={() => setSelectedItem(undefined)}
-                className="tw-mb-4 tw-flex tw-items-center"
-                variant="link"
+          {activeTab === 'encyclopedia' && (
+            <div className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
+              <div
+                className={cn('tw-h-full tw-overflow-y-auto tw-border-r', {
+                  'tw-w-full': !selectedEncItem,
+                  'tw-w-1/5 tw-min-w-[120px]': !!selectedEncItem,
+                })}
               >
-                <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
-                Back to list
-              </Button>
-              <h2 className="tw-text-2xl tw-font-normal">{selectedItem.primaryText}</h2>
-              <p className="tw-text-lg tw-text-muted-foreground">{selectedItem.glosses}</p>
-              {selectedItem.sourceLanguageText && (
-                <p className="tw-mt-1 tw-text-sm tw-text-muted-foreground">
-                  {selectedItem.sourceLanguageText}
-                  {selectedItem.transliteration && (
-                    <span className="tw-ml-1">({selectedItem.transliteration})</span>
-                  )}
-                </p>
+                <ul role="listbox" className="tw-outline-none">
+                  {sampleEncyclopediaItems.map((item) => {
+                    const isSelected = selectedEncItem?.id === item.id;
+                    return (
+                      <li
+                        key={item.id}
+                        role="option"
+                        aria-selected={isSelected}
+                        onClick={() => setSelectedEncItem(isSelected ? undefined : item)}
+                        className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
+                          'tw-bg-muted': isSelected,
+                          'hover:tw-bg-muted': !isSelected,
+                        })}
+                      >
+                        <div className="tw-flex tw-flex-col tw-gap-0.5">
+                          <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
+                          <span className="tw-truncate tw-text-xs tw-text-muted-foreground">
+                            {item.teaserText}
+                          </span>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+              {selectedEncItem && (
+                <div className="tw-w-4/5 tw-overflow-y-auto tw-bg-background tw-p-4">
+                  <EncyclopediaDetail
+                    item={selectedEncItem}
+                    onClose={() => setSelectedEncItem(undefined)}
+                  />
+                </div>
               )}
-              <Separator className="tw-my-3" />
-              {selectedItem.definition && (
-                <p className="tw-text-sm tw-text-muted-foreground">{selectedItem.definition}</p>
+            </div>
+          )}
+
+          {activeTab === 'media' && (
+            <div className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
+              <div
+                className={cn('tw-h-full tw-overflow-y-auto tw-border-r', {
+                  'tw-w-full': !selectedMediaItem,
+                  'tw-w-1/5 tw-min-w-[120px]': !!selectedMediaItem,
+                })}
+              >
+                <ul role="listbox" className="tw-outline-none">
+                  {sampleMediaItems.map((item) => {
+                    const isSelected = selectedMediaItem?.id === item.id;
+                    return (
+                      <li
+                        key={item.id}
+                        role="option"
+                        aria-selected={isSelected}
+                        onClick={() => setSelectedMediaItem(isSelected ? undefined : item)}
+                        className={cn(
+                          'tw-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-border-b tw-p-2',
+                          { 'tw-bg-muted': isSelected, 'hover:tw-bg-muted': !isSelected },
+                        )}
+                      >
+                        {item.thumbnailUrl && (
+                          <img
+                            src={item.thumbnailUrl}
+                            alt={item.primaryText}
+                            className="tw-h-10 tw-w-10 tw-rounded tw-object-cover"
+                          />
+                        )}
+                        <div className="tw-flex tw-flex-col tw-gap-0.5">
+                          <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
+                          <Badge variant="outline" className="tw-w-fit tw-text-xs">
+                            {item.mediaType}
+                          </Badge>
+                        </div>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+              {selectedMediaItem && (
+                <div className="tw-w-4/5 tw-overflow-y-auto tw-bg-background tw-p-4">
+                  <MediaDetail
+                    item={selectedMediaItem}
+                    onClose={() => setSelectedMediaItem(undefined)}
+                  />
+                </div>
               )}
             </div>
           )}
@@ -1019,106 +741,37 @@ export const InlinePanelAlternative: Story = {
     docs: {
       description: {
         story:
-          'Alternative layout using an inline flex panel instead of a Drawer. The list shrinks to 1/5 width and the detail panel takes 4/5. No portal, overlay, or z-index concerns. Compare with the Drawer-based ErDictionary story.',
+          'All ER tabs combined with inline panel detail views and inline domain navigation. Dictionary entries open a detail panel matching the PT9 screenshot layout. Domain links replace the dictionary view inline with breadcrumb navigation and a back arrow.',
       },
     },
   },
 };
 
-// ---------------------------------------------------------------------------
-// Alternative: Inline domain navigation (no Dialog)
-// ---------------------------------------------------------------------------
-
-/**
- * Alternative to using a Dialog for domain-filtered navigation. Clicking a domain link in the
- * dictionary detail view replaces the current dictionary list with the filtered domain view inline.
- * A back button returns to the original list.
- */
-export const ErDictionaryInlineNavigation: Story = {
+/** ER Dictionary filtered by domain - standalone view with breadcrumbs, dropdowns, and tree */
+export const ErDictionaryFilteredByDomain: Story = {
   render: () => {
-    const [activeDomain, setActiveDomain] = useState<
-      | {
-          level1: SemanticDomain;
-          level2?: SemanticDomain;
-        }
-      | undefined
-    >();
-    const [navMode, setNavMode] = useState<'tree' | 'dropdown'>('dropdown');
-
-    const handleDomainClick = (domain: EntryDomain) => {
-      const l1 = sampleAllDomains.find(
-        (d) => d.id === domain.id || d.children?.some((c) => c.id === domain.id),
-      );
-      if (l1) {
-        const l2 = l1.children?.find((c) => c.id === domain.id);
-        setActiveDomain({ level1: l1, level2: l2 });
-      }
-    };
+    const [selectedL1, setSelectedL1] = useState(sampleAllDomains[0]);
+    const [selectedL2, setSelectedL2] = useState<SemanticDomain | undefined>(
+      sampleAllDomains[0].children?.[0],
+    );
 
     return (
       <div className="tw-h-[500px] tw-rounded tw-border">
-        {activeDomain ? (
-          /* Domain-filtered view (replaces the dictionary list) */
-          <>
-            <div className="tw-flex tw-items-center tw-gap-2 tw-border-b tw-px-3 tw-py-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setActiveDomain(undefined)}
-                className="tw-gap-1"
-              >
-                <ArrowLeft className="tw-h-4 tw-w-4" />
-                Back to Dictionary
-              </Button>
-              <span className="tw-text-sm tw-text-muted-foreground">
-                {activeDomain.level1.label}
-                {activeDomain.level2 && ` / ${activeDomain.level2.label}`}
-              </span>
-            </div>
-            <ErDictionaryFilteredList
-              items={sampleDictionaryItems.filter((entry) =>
-                entry.domains.some(
-                  (d) =>
-                    d.id === activeDomain.level1.id ||
-                    d.id === activeDomain.level2?.id ||
-                    d.parentId === activeDomain.level1.id,
-                ),
-              )}
-              selectedLevel1Domain={activeDomain.level1}
-              selectedLevel2Domain={activeDomain.level2}
-              allDomains={sampleAllDomains}
-              onDomainChange={(l1, l2) => setActiveDomain({ level1: l1, level2: l2 })}
-              navigationMode={navMode}
-              onNavigationModeChange={setNavMode}
-              renderDetailContent={(item, onClose) => (
-                <DictionaryDetailContent item={item} onClose={onClose} />
-              )}
-              className="tw-h-[calc(100%-45px)]"
-            />
-          </>
-        ) : (
-          /* Normal dictionary list */
-          <>
-            <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
-              Dictionary (Inline Navigation)
-            </h3>
-            <ErDictionaryList
-              items={sampleDictionaryItems}
-              showSourceLanguage
-              showTransliteration
-              getDescription={(item) => item.glosses}
-              getBadges={(item) => item.strongsCodes}
-              getOccurrenceCount={(item) => item.occurrenceCount}
-              renderDetailContent={(item, onClose) => (
-                <DictionaryDetailContent
-                  item={item}
-                  onClose={onClose}
-                  onDomainClick={handleDomainClick}
-                />
-              )}
-            />
-          </>
-        )}
+        <ErDictionaryFilteredList
+          items={sampleDictionaryItems}
+          selectedLevel1Domain={selectedL1}
+          selectedLevel2Domain={selectedL2}
+          allDomains={sampleAllDomains}
+          onDomainChange={(l1, l2) => {
+            setSelectedL1(l1);
+            setSelectedL2(l2);
+          }}
+          renderItem={(item) => <ErDictionaryListItem item={item} />}
+          renderDetailContent={(item, onClose) => (
+            <ErDictionaryDetail item={item} onClose={onClose} />
+          )}
+          className="tw-h-full"
+        />
       </div>
     );
   },
@@ -1126,8 +779,90 @@ export const ErDictionaryInlineNavigation: Story = {
     docs: {
       description: {
         story:
-          'Alternative to using a Dialog for domain navigation. Clicking a domain link in the detail view replaces the entire dictionary with the domain-filtered view inline. A back button returns to the original list. Compare with the Dialog-based ErDictionary story.',
+          'Dictionary filtered by semantic domain. Breadcrumbs use dot separator with dropdown navigation. Tree button (right-aligned) opens the full domain tree in a scoped drawer.',
       },
     },
   },
+};
+
+/**
+ * Lexical extension dictionary with inline panel detail view. Shows entries with source language
+ * lemma, occurrence count, glosses, and Strong's codes. Clicking an entry opens a detail panel.
+ */
+export const LexicalDictionary: Story = {
+  render: () => {
+    const [selectedItem, setSelectedItem] = useState<LexicalDictionaryEntry | undefined>();
+
+    return (
+      <div className="tw-h-[500px] tw-rounded tw-border">
+        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
+          Lexical Dictionary
+        </h3>
+        <div className="tw-relative tw-flex tw-h-[calc(100%-41px)] tw-overflow-hidden">
+          <div
+            className={cn('tw-h-full tw-overflow-y-auto', {
+              'tw-w-full': !selectedItem,
+              'tw-w-1/5 tw-min-w-[80px] tw-border-r': !!selectedItem,
+            })}
+          >
+            <LexicalDictionaryList
+              items={sampleLexicalEntries}
+              onItemClick={(item) =>
+                setSelectedItem(item.id === selectedItem?.id ? undefined : item)
+              }
+              selectedItemId={selectedItem?.id}
+              occurrenceCountLabel="Occurrences in chapter"
+              strongsCodeLabel="Strong's code"
+            />
+          </div>
+          {selectedItem && (
+            <div className="tw-w-4/5 tw-overflow-y-auto tw-bg-background tw-p-4">
+              <LexicalDetail item={selectedItem} onClose={() => setSelectedItem(undefined)} />
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Lexical extension dictionary with inline panel. Shows entries with source language lemma, occurrence count, glosses, and Strong's codes. Clicking an entry opens a detail panel extracted from the platform-lexical-tools extension.",
+      },
+    },
+  },
+};
+
+/** ER Encyclopedia list with inline panel */
+export const ErEncyclopedia: Story = {
+  render: () => (
+    <div className="tw-h-[500px] tw-rounded tw-border">
+      <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">Encyclopedia</h3>
+      <ErEncyclopediaList
+        items={sampleEncyclopediaItems}
+        showSourceLanguage
+        showTransliteration
+        renderDetailContent={(item, onClose) => (
+          <EncyclopediaDetail item={item} onClose={onClose} />
+        )}
+      />
+    </div>
+  ),
+};
+
+/** ER Media list with inline panel */
+export const ErMedia: Story = {
+  render: () => (
+    <div className="tw-h-[500px] tw-rounded tw-border">
+      <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
+        Media (Images &amp; Maps)
+      </h3>
+      <ErMediaList
+        items={sampleMediaItems}
+        showSourceLanguage
+        renderDetailContent={(item, onClose) => <MediaDetail item={item} onClose={onClose} />}
+      />
+    </div>
+  ),
 };

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -7,7 +7,7 @@ import { Button } from '@/components/shadcn-ui/button';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Badge } from '@/components/shadcn-ui/badge';
 import ComboBox from '@/components/basics/combo-box.component';
-// Dialog/DialogContent/DialogTitle/DialogTrigger available from shadcn but not used in current stories
+import { Drawer, DrawerContent } from '@/components/shadcn-ui/drawer';
 import {
   Tooltip,
   TooltipContent,
@@ -474,7 +474,13 @@ function ErDictionaryDetail({
             <p className="tw-text-sm">
               <span className="tw-mr-2 tw-font-bold tw-text-primary">{sense.number}</span>
               {sense.definition}{' '}
-              <span className="tw-text-muted-foreground">({sense.occurrenceCount})</span>
+              <button
+                type="button"
+                className="tw-cursor-pointer tw-text-muted-foreground tw-underline"
+                onClick={() => {}}
+              >
+                ({sense.occurrenceCount})
+              </button>
             </p>
             <p className="tw-mt-0.5 tw-pl-5 tw-text-sm tw-text-muted-foreground">
               Glosses: <span className="tw-italic">{sense.glosses}</span>
@@ -495,7 +501,13 @@ function ErDictionaryDetail({
       <Separator className="tw-my-3" />
       <p className="tw-text-sm">
         Occurrences in all books{' '}
-        <span className="tw-text-muted-foreground">({item.totalOccurrences})</span>
+        <button
+          type="button"
+          className="tw-cursor-pointer tw-text-muted-foreground tw-underline"
+          onClick={() => {}}
+        >
+          ({item.totalOccurrences})
+        </button>
       </p>
     </div>
   );
@@ -787,8 +799,9 @@ export const EmptyState: Story = {
 };
 
 /**
- * All ER tabs with inline panel + inline domain navigation. Domain links open a bottom drawer with
- * 5-level breadcrumb navigation.
+ * All ER tabs with inline panel detail views. Domain links open a bottom Drawer containing the
+ * domain-filtered list with breadcrumb navigation. Interaction works while details are shown:
+ * selecting entries, clicking close, breadcrumbs, and domain links all remain functional.
  */
 export const AllErTabs: Story = {
   render: () => {
@@ -799,21 +812,38 @@ export const AllErTabs: Story = {
     const [selectedEnc, setSelectedEnc] = useState<EncyclopediaTeaser | undefined>();
     const [selectedMedia, setSelectedMedia] = useState<MediaItem | undefined>();
     const [domainPath, setDomainPath] = useState<SemanticDomain[] | undefined>();
+    // eslint-disable-next-line no-null/no-null
+    const tabContentRef = useRef<HTMLDivElement>(null);
 
-    const handleDomainClick = useCallback((_domain: EntryDomain, pathIds?: string[]) => {
-      if (pathIds) {
-        const path = pathIds.reduce<SemanticDomain[]>((acc, id) => {
-          const parent = acc.length === 0 ? sampleAllDomains : (acc[acc.length - 1].children ?? []);
-          const found = parent.find((d) => d.id === id);
-          if (found) acc.push(found);
-          return acc;
-        }, []);
-        if (path.length > 0) {
-          setDomainPath(path);
-          setSelectedDict(undefined);
-        }
-      }
+    const resolveDomainPath = useCallback((pathIds: string[]): SemanticDomain[] => {
+      return pathIds.reduce<SemanticDomain[]>((acc, id) => {
+        const parent = acc.length === 0 ? sampleAllDomains : (acc[acc.length - 1].children ?? []);
+        const found = parent.find((d) => d.id === id);
+        if (found) acc.push(found);
+        return acc;
+      }, []);
     }, []);
+
+    const handleDomainClick = useCallback(
+      (_domain: EntryDomain, pathIds?: string[]) => {
+        if (pathIds) {
+          const path = resolveDomainPath(pathIds);
+          if (path.length > 0) setDomainPath(path);
+        }
+      },
+      [resolveDomainPath],
+    );
+
+    // Domain click from inside the filtered detail view: update the breadcrumb path and list
+    const handleDomainClickInFiltered = useCallback(
+      (_domain: EntryDomain, pathIds?: string[]) => {
+        if (pathIds) {
+          const path = resolveDomainPath(pathIds);
+          if (path.length > 0) setDomainPath(path);
+        }
+      },
+      [resolveDomainPath],
+    );
 
     return (
       <div className="tw-flex tw-h-[550px] tw-flex-col tw-rounded tw-border">
@@ -835,8 +865,8 @@ export const AllErTabs: Story = {
             </button>
           ))}
         </div>
-        <div className="tw-flex-1 tw-overflow-hidden">
-          {activeTab === 'dictionary' && !domainPath && (
+        <div ref={tabContentRef} className="tw-relative tw-flex-1 tw-overflow-hidden">
+          {activeTab === 'dictionary' && (
             <InlineListDetail
               items={sampleDictionaryItems}
               selectedItem={selectedDict}
@@ -849,20 +879,6 @@ export const AllErTabs: Story = {
                   onDomainClick={handleDomainClick}
                 />
               )}
-            />
-          )}
-          {activeTab === 'dictionary' && domainPath && (
-            <ErDictionaryFilteredList
-              items={sampleDictionaryItems}
-              domainPath={domainPath}
-              allDomains={sampleAllDomains}
-              onDomainChange={setDomainPath}
-              onBack={() => setDomainPath(undefined)}
-              renderItem={(item) => <ErDictListItem item={item} />}
-              renderDetailContent={(item, onClose) => (
-                <ErDictionaryDetail item={item} onClose={onClose} />
-              )}
-              className="tw-h-full"
             />
           )}
           {activeTab === 'encyclopedia' && (
@@ -921,6 +937,43 @@ export const AllErTabs: Story = {
                 <MediaDetail item={item} onClose={() => setSelectedMedia(undefined)} />
               )}
             />
+          )}
+
+          {/* Domain-filtered bottom Drawer (slides up, fills full tab height) */}
+          {activeTab === 'dictionary' && (
+            <Drawer
+              direction="bottom"
+              modal={false}
+              open={domainPath !== undefined}
+              onOpenChange={(open) => {
+                if (!open) setDomainPath(undefined);
+              }}
+            >
+              <DrawerContent
+                container={tabContentRef.current}
+                hideDrawerHandle
+                className="tw-mt-0 tw-h-full tw-max-h-full tw-rounded-none"
+              >
+                {domainPath && (
+                  <ErDictionaryFilteredList
+                    items={sampleDictionaryItems}
+                    domainPath={domainPath}
+                    allDomains={sampleAllDomains}
+                    onDomainChange={setDomainPath}
+                    onClose={() => setDomainPath(undefined)}
+                    renderItem={(item) => <ErDictListItem item={item} />}
+                    renderDetailContent={(item, onCloseDetail) => (
+                      <ErDictionaryDetail
+                        item={item}
+                        onClose={onCloseDetail}
+                        onDomainClick={handleDomainClickInFiltered}
+                      />
+                    )}
+                    className="tw-h-full"
+                  />
+                )}
+              </DrawerContent>
+            </Drawer>
           )}
         </div>
       </div>

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -1,16 +1,19 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ThemeProvider } from '@/storybook/theme-provider.component';
-import { ArrowLeft } from 'lucide-react';
+import { ArrowLeft, ChevronDown, ChevronRight } from 'lucide-react';
 import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Badge } from '@/components/shadcn-ui/badge';
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/shadcn-ui/dialog';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/shadcn-ui/tooltip';
 import SourceLanguageIndexedList from '@/components/advanced/source-language-indexed-list/source-language-indexed-list.component';
-import ErDictionaryFilteredList from '@/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component';
-import ErEncyclopediaList from '@/components/advanced/source-language-indexed-list/er-encyclopedia-list.component';
-import ErMediaList from '@/components/advanced/source-language-indexed-list/er-media-list.component';
-import LexicalDictionaryList from '@/components/advanced/source-language-indexed-list/lexical-dictionary-list.component';
 import type {
   IndexedListItem,
   EncyclopediaTeaser,
@@ -47,22 +50,22 @@ const sampleAllDomains: SemanticDomain[] = [
     label: 'Social Relations',
     children: [
       { id: 'family', label: 'Family' },
-      { id: 'authority', label: 'Authority' },
-      { id: 'worship', label: 'Worship' },
+      { id: 'authority', label: 'Authority & Leadership' },
+      { id: 'worship', label: 'Worship & Religion' },
     ],
   },
   {
     id: 'communication',
     label: 'Communication',
     children: [
-      { id: 'speak', label: 'Speak' },
-      { id: 'write', label: 'Write' },
+      { id: 'speak', label: 'Speak & Proclaim' },
+      { id: 'write', label: 'Write & Inscribe' },
     ],
   },
 ];
 
 // ---------------------------------------------------------------------------
-// Sense type for ER dictionary entries
+// Sense / entry types
 // ---------------------------------------------------------------------------
 
 type DictionarySense = {
@@ -78,14 +81,27 @@ type DictionaryEntryWithSenses = IndexedListItem & {
   totalOccurrences: number;
 };
 
+type LexicalSense = {
+  id: string;
+  glosses: string[];
+  definition?: string;
+  domains: { taxonomy: string; code: string; label?: string }[];
+};
+
+type LexicalEntryFull = LexicalDictionaryEntry & {
+  senses: LexicalSense[];
+  chapterOccurrences: { ref: string }[];
+  allOccurrences: { ref: string }[];
+};
+
 // ---------------------------------------------------------------------------
-// Sample ER dictionary items (matching the screenshot structure)
+// Sample ER dictionary items (longer words)
 // ---------------------------------------------------------------------------
 
 const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
   {
     id: 'entry-bara',
-    primaryText: 'create',
+    primaryText: 'create, bring forth',
     sourceLanguageText: '\u05D1\u05B8\u05BC\u05E8\u05B8\u05D0',
     transliteration: 'br\u02BE',
     senses: [
@@ -110,7 +126,7 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
   },
   {
     id: 'entry-amar',
-    primaryText: 'say',
+    primaryText: 'say, speak, declare',
     sourceLanguageText: '\u05D0\u05B8\u05DE\u05B7\u05E8',
     transliteration: '\u02BEmr',
     senses: [
@@ -119,7 +135,7 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
         definition: 'to utter words or speech; to communicate verbally.',
         occurrenceCount: 523,
         glosses: 'to say, to speak, to tell',
-        domain: { id: 'speak', label: 'Speak', parentId: 'communication', code: '4.1' },
+        domain: { id: 'speak', label: 'Speak & Proclaim', parentId: 'communication', code: '4.1' },
       },
       {
         number: 2,
@@ -133,7 +149,7 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
   },
   {
     id: 'entry-asa',
-    primaryText: 'make',
+    primaryText: 'make, produce, accomplish',
     sourceLanguageText: '\u05E2\u05B8\u05E9\u05B8\u05C2\u05D4',
     transliteration: '\u02BF\u015Bh',
     senses: [
@@ -149,7 +165,7 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
   },
   {
     id: 'entry-halak',
-    primaryText: 'walk',
+    primaryText: 'walk, journey, proceed',
     sourceLanguageText: '\u05D4\u05B8\u05DC\u05B7\u05DA\u05B0',
     transliteration: 'hlk',
     senses: [
@@ -165,16 +181,16 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
   },
   {
     id: 'entry-shama',
-    primaryText: 'hear',
+    primaryText: 'hear, listen, obey',
     sourceLanguageText: '\u05E9\u05B8\u05C1\u05DE\u05B7\u05E2',
     transliteration: '\u0161m\u02BF',
     senses: [
       {
         number: 1,
-        definition: 'to perceive sound with the ear; to listen attentively.',
+        definition: 'to perceive sound with the ear; to listen attentively and respond.',
         occurrenceCount: 287,
         glosses: 'to hear, to listen, to obey',
-        domain: { id: 'speak', label: 'Speak', parentId: 'communication', code: '4.1' },
+        domain: { id: 'speak', label: 'Speak & Proclaim', parentId: 'communication', code: '4.1' },
       },
     ],
     totalOccurrences: 287,
@@ -182,31 +198,33 @@ const sampleDictionaryItems: DictionaryEntryWithSenses[] = [
 ];
 
 // ---------------------------------------------------------------------------
-// Sample encyclopedia / media / lexical data
+// Sample encyclopedia items (longer words, with source language)
 // ---------------------------------------------------------------------------
 
 const sampleEncyclopediaItems: EncyclopediaTeaser[] = [
   {
     id: 'enc-1',
-    primaryText: 'Ephesus',
-    sourceLanguageText: '\u1F1C\u03C6\u03B5\u03C3\u03BF\u03C2',
-    transliteration: 'Ephesos',
-    teaserText: 'An ancient Greek city on the coast of Ionia, renowned for the Temple of Artemis.',
+    primaryText: 'Temple of Artemis at Ephesus',
+    sourceLanguageText: '\u1F08\u03C1\u03C4\u03B5\u03BC\u03AF\u03C3\u03B9\u03BF\u03BD',
+    transliteration: 'Artemision',
+    teaserText:
+      'One of the Seven Wonders of the Ancient World, dedicated to the Greek goddess Artemis.',
   },
   {
     id: 'enc-2',
-    primaryText: 'Corinth',
-    sourceLanguageText: '\u039A\u03CC\u03C1\u03B9\u03BD\u03B8\u03BF\u03C2',
-    transliteration: 'Korinthos',
-    teaserText:
-      'A major Greek city-state on the isthmus connecting the Peloponnese to mainland Greece.',
+    primaryText: 'Corinthian Church Community',
+    sourceLanguageText:
+      '\u1F10\u03BA\u03BA\u03BB\u03B7\u03C3\u03AF\u03B1 \u039A\u03BF\u03C1\u03AF\u03BD\u03B8\u03BF\u03C5',
+    transliteration: 'ekklesia Korinthou',
+    teaserText: 'The early Christian community in Corinth addressed in two Pauline epistles.',
   },
   {
     id: 'enc-3',
-    primaryText: 'Baptism',
+    primaryText: 'Rite of Baptismal Purification',
     sourceLanguageText: '\u03B2\u03AC\u03C0\u03C4\u03B9\u03C3\u03BC\u03B1',
     transliteration: 'baptisma',
-    teaserText: 'A rite of washing with water as a sign of religious purification.',
+    teaserText:
+      'A rite of washing with water as a sign of religious purification and consecration.',
   },
 ];
 
@@ -214,7 +232,6 @@ const sampleMediaItems: MediaItem[] = [
   {
     id: 'media-1',
     primaryText: 'Map of Ancient Ephesus',
-    sourceLanguageText: '\u1F1C\u03C6\u03B5\u03C3\u03BF\u03C2',
     thumbnailUrl: 'https://placehold.co/200x200/e2e8f0/64748b?text=Map',
     mediaType: 'map',
     caption: 'City plan showing the harbor and Temple of Artemis',
@@ -228,7 +245,11 @@ const sampleMediaItems: MediaItem[] = [
   },
 ];
 
-const sampleLexicalEntries: LexicalDictionaryEntry[] = [
+// ---------------------------------------------------------------------------
+// Sample lexical entries (full detail)
+// ---------------------------------------------------------------------------
+
+const sampleLexicalEntries: LexicalEntryFull[] = [
   {
     id: 'lex-1',
     primaryText: '\u03BB\u03CC\u03B3\u03BF\u03C2',
@@ -236,6 +257,22 @@ const sampleLexicalEntries: LexicalDictionaryEntry[] = [
     strongsCodes: ['G3056'],
     glosses: 'word, speech, message, reason',
     occurrenceCount: 23,
+    senses: [
+      {
+        id: 's1',
+        glosses: ['word', 'message', 'statement'],
+        definition: 'A meaningful unit of spoken or written language.',
+        domains: [{ taxonomy: 'SDBG-Lexical', code: '33.A', label: 'Communication' }],
+      },
+      {
+        id: 's2',
+        glosses: ['reason', 'account'],
+        definition: 'The rational faculty or principle; explanation.',
+        domains: [{ taxonomy: 'SDBG-Contextual', code: '32.B', label: 'Thought' }],
+      },
+    ],
+    chapterOccurrences: [{ ref: 'John 1:1' }, { ref: 'John 1:14' }],
+    allOccurrences: Array.from({ length: 23 }, (_, i) => ({ ref: `Ref ${i + 1}` })),
   },
   {
     id: 'lex-2',
@@ -244,38 +281,146 @@ const sampleLexicalEntries: LexicalDictionaryEntry[] = [
     strongsCodes: ['G2316'],
     glosses: 'God, god, deity',
     occurrenceCount: 45,
+    senses: [
+      {
+        id: 's1',
+        glosses: ['God', 'the true God'],
+        definition: 'The supreme deity; the creator and ruler of the universe.',
+        domains: [{ taxonomy: 'SDBG-Lexical', code: '12.A', label: 'Supernatural' }],
+      },
+    ],
+    chapterOccurrences: [
+      { ref: 'John 1:1' },
+      { ref: 'John 1:2' },
+      { ref: 'John 1:6' },
+      { ref: 'John 1:12' },
+      { ref: 'John 1:13' },
+      { ref: 'John 1:18' },
+    ],
+    allOccurrences: Array.from({ length: 45 }, (_, i) => ({ ref: `Ref ${i + 1}` })),
   },
   {
     id: 'lex-3',
-    primaryText: '\u03BA\u03CC\u03C3\u03BC\u03BF\u03C2',
-    transliteration: 'kosmos',
-    strongsCodes: ['G2889'],
-    glosses: 'world, universe, order',
-    occurrenceCount: 17,
-  },
-  {
-    id: 'lex-4',
     primaryText: '\u03C6\u1FF6\u03C2',
     transliteration: 'phos',
     strongsCodes: ['G5457'],
     glosses: 'light, radiance',
     occurrenceCount: 9,
+    senses: [
+      {
+        id: 's1',
+        glosses: ['light', 'radiance', 'illumination'],
+        definition:
+          'Natural agent that makes things visible; figuratively, truth or understanding.',
+        domains: [{ taxonomy: 'SDBG-Lexical', code: '14.A', label: 'Physical' }],
+      },
+    ],
+    chapterOccurrences: [
+      { ref: 'John 1:4' },
+      { ref: 'John 1:5' },
+      { ref: 'John 1:7' },
+      { ref: 'John 1:8' },
+      { ref: 'John 1:9' },
+    ],
+    allOccurrences: Array.from({ length: 9 }, (_, i) => ({ ref: `Ref ${i + 1}` })),
   },
   {
-    id: 'lex-5',
+    id: 'lex-4',
     primaryText: '\u03B6\u03C9\u03AE',
     transliteration: 'zoe',
     strongsCodes: ['G2222'],
     glosses: 'life, living',
     occurrenceCount: 11,
+    senses: [
+      {
+        id: 's1',
+        glosses: ['life', 'living', 'existence'],
+        definition: 'The state of being alive; vitality. Often refers to eternal life.',
+        domains: [{ taxonomy: 'SDBG-Lexical', code: '23.A', label: 'Physiological' }],
+      },
+    ],
+    chapterOccurrences: [{ ref: 'John 1:4' }],
+    allOccurrences: Array.from({ length: 11 }, (_, i) => ({ ref: `Ref ${i + 1}` })),
   },
 ];
+
+// ---------------------------------------------------------------------------
+// Shared list item renderers
+// ---------------------------------------------------------------------------
+
+/** ER dictionary list item - always 2 rows. Hides occurrence count when `compact`. */
+function ErDictListItem({
+  item,
+  compact = false,
+}: {
+  item: DictionaryEntryWithSenses;
+  compact?: boolean;
+}) {
+  const firstSense = item.senses[0];
+  return (
+    <div className="tw-flex tw-w-full tw-flex-col tw-gap-0.5">
+      <div className="tw-flex tw-items-baseline tw-gap-2">
+        <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
+        <span className="tw-text-sm tw-text-muted-foreground">
+          {item.sourceLanguageText}
+          {item.transliteration && <span className="tw-ml-1">({item.transliteration})</span>}
+        </span>
+        {!compact && (
+          <span className="tw-ml-auto tw-shrink-0 tw-rounded tw-bg-accent tw-px-1.5 tw-py-0.5 tw-text-xs">
+            {item.totalOccurrences}
+          </span>
+        )}
+      </div>
+      <p className="tw-truncate tw-text-sm tw-text-muted-foreground">
+        {firstSense?.glosses}
+        {item.senses.length > 1 && ` (+${item.senses.length - 1} more)`}
+      </p>
+    </div>
+  );
+}
+
+/** Lexical list item - same padding/border/hover style as ER dictionary */
+function LexicalListItem({ item, compact = false }: { item: LexicalEntryFull; compact?: boolean }) {
+  return (
+    <div className="tw-flex tw-w-full tw-flex-col tw-gap-0.5">
+      <div className="tw-flex tw-items-baseline tw-gap-2">
+        <span className="scripture-font tw-text-sm">{item.primaryText}</span>
+        {!compact && (
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="tw-ml-auto tw-shrink-0 tw-cursor-help tw-rounded tw-bg-accent tw-px-1.5 tw-py-0.5 tw-text-xs">
+                  {item.occurrenceCount}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Occurrences in chapter</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+      </div>
+      <div className="tw-flex tw-items-center tw-gap-2 tw-overflow-hidden">
+        <p className="tw-truncate tw-text-sm tw-text-muted-foreground">{item.glosses}</p>
+        {!compact &&
+          item.strongsCodes.map((code) => (
+            <span
+              key={code}
+              className="tw-shrink-0 tw-rounded tw-bg-accent tw-px-1.5 tw-py-0.5 tw-text-xs"
+            >
+              {code}
+            </span>
+          ))}
+      </div>
+    </div>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Detail content renderers
 // ---------------------------------------------------------------------------
 
-/** ER Dictionary entry detail - matches the PT9 screenshot layout with shadcn styling */
+/** ER Dictionary entry detail (PT9 screenshot layout) */
 function ErDictionaryDetail({
   item,
   onClose,
@@ -292,7 +437,6 @@ function ErDictionaryDetail({
         Back to list
       </Button>
 
-      {/* Header: source language text + transliteration */}
       <div className="tw-mb-4">
         <span className="tw-text-lg tw-font-normal">{item.sourceLanguageText}</span>
         {item.transliteration && (
@@ -302,14 +446,13 @@ function ErDictionaryDetail({
         )}
       </div>
 
-      {/* Senses */}
       <div className="tw-space-y-4">
         {item.senses.map((sense) => (
           <div key={sense.number} className="tw-pl-1">
             <p className="tw-text-sm">
               <span className="tw-mr-2 tw-font-bold tw-text-primary">{sense.number}</span>
-              <span>{sense.definition}</span>
-              <span className="tw-ml-1 tw-text-muted-foreground">({sense.occurrenceCount})</span>
+              {sense.definition}{' '}
+              <span className="tw-text-muted-foreground">({sense.occurrenceCount})</span>
             </p>
             <p className="tw-mt-0.5 tw-pl-5 tw-text-sm tw-text-muted-foreground">
               Glosses: <span className="tw-italic">{sense.glosses}</span>
@@ -329,12 +472,131 @@ function ErDictionaryDetail({
       </div>
 
       <Separator className="tw-my-3" />
-
-      {/* Occurrences */}
       <p className="tw-text-sm">
         Occurrences in all books{' '}
         <span className="tw-text-muted-foreground">({item.totalOccurrences})</span>
       </p>
+    </div>
+  );
+}
+
+/** Full lexical dictionary detail (matching platform-lexical-tools extension) */
+function LexicalDetail({ item, onClose }: { item: LexicalEntryFull; onClose: () => void }) {
+  const [selectedSenseId, setSelectedSenseId] = useState<string | undefined>(
+    item.senses.length === 1 ? item.senses[0].id : undefined,
+  );
+  const [occurrenceView, setOccurrenceView] = useState<'chapter' | 'all'>('chapter');
+
+  const selectedSense = item.senses.find((s) => s.id === selectedSenseId);
+  const occurrences = occurrenceView === 'chapter' ? item.chapterOccurrences : item.allOccurrences;
+
+  return (
+    <div>
+      <Button onClick={onClose} variant="link" className="tw-mb-3 tw-h-auto tw-p-0">
+        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+        Back to list
+      </Button>
+
+      {/* Header */}
+      <div className="tw-mb-3">
+        <div className="tw-flex tw-items-baseline tw-justify-between tw-gap-2">
+          <span className="tw-flex tw-items-baseline tw-gap-2">
+            <span className="scripture-font tw-text-2xl tw-font-normal">{item.primaryText}</span>
+            <span className="tw-text-lg tw-text-muted-foreground">{item.glosses}</span>
+          </span>
+          <div className="tw-flex tw-gap-1">
+            {item.strongsCodes.map((code) => (
+              <span key={code} className="tw-rounded tw-bg-accent tw-px-2 tw-py-0.5 tw-text-sm">
+                {code}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <Separator className="tw-my-3" />
+
+      {/* Senses */}
+      <div className="tw-mb-4">
+        <h3 className="tw-mb-1 tw-font-semibold">Senses</h3>
+        <div className="tw-flex tw-flex-col tw-gap-3">
+          {item.senses.map((sense, idx) => (
+            <button
+              key={sense.id}
+              type="button"
+              onClick={() =>
+                setSelectedSenseId(selectedSenseId === sense.id ? undefined : sense.id)
+              }
+              className={cn(
+                'tw-flex tw-w-full tw-flex-col tw-items-start tw-rounded-lg tw-border tw-p-3 tw-text-left tw-shadow-sm tw-transition-colors',
+                selectedSenseId === sense.id
+                  ? 'tw-border-accent tw-shadow-md'
+                  : 'hover:tw-border-accent',
+              )}
+            >
+              <div className="tw-flex tw-items-baseline tw-gap-2">
+                <span className="tw-font-bold tw-text-accent-foreground">{idx + 1}</span>
+                <span className="tw-text-sm">{sense.glosses.join(', ')}</span>
+              </div>
+              {sense.definition && (
+                <p className="tw-mt-1 tw-text-sm tw-text-muted-foreground">{sense.definition}</p>
+              )}
+              {sense.domains.length > 0 && (
+                <div className="tw-mt-2 tw-flex tw-flex-wrap tw-gap-1">
+                  {sense.domains.map((d) => (
+                    <span
+                      key={d.code}
+                      className="tw-rounded tw-bg-accent tw-px-2 tw-py-0.5 tw-text-xs"
+                    >
+                      {d.code} {d.label ?? ''}
+                    </span>
+                  ))}
+                </div>
+              )}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Occurrences with chapter/all toggle */}
+      <div>
+        <div className="tw-mb-2 tw-flex tw-items-center tw-justify-between">
+          <h3 className="tw-font-semibold">
+            {selectedSense ? `Occurrences for sense` : 'All occurrences'}
+          </h3>
+          <div className="tw-flex tw-items-center tw-gap-0 tw-rounded-md tw-border">
+            <button
+              type="button"
+              className={cn('tw-rounded-s-md tw-px-3 tw-py-1 tw-text-xs', {
+                'tw-bg-accent': occurrenceView === 'chapter',
+                'hover:tw-bg-accent': occurrenceView !== 'chapter',
+              })}
+              onClick={() => setOccurrenceView('chapter')}
+            >
+              Chapter ({item.chapterOccurrences.length})
+            </button>
+            <button
+              type="button"
+              className={cn('tw-rounded-e-md tw-px-3 tw-py-1 tw-text-xs', {
+                'tw-bg-accent': occurrenceView === 'all',
+                'hover:tw-bg-accent': occurrenceView !== 'all',
+              })}
+              onClick={() => setOccurrenceView('all')}
+            >
+              All ({item.allOccurrences.length})
+            </button>
+          </div>
+        </div>
+        <ul className="tw-list-inside tw-list-disc">
+          {occurrences.map((occ) => (
+            <li key={occ.ref} className="tw-py-0.5">
+              <Button variant="link" className="tw-h-auto tw-p-0">
+                {occ.ref}
+              </Button>
+            </li>
+          ))}
+        </ul>
+      </div>
     </div>
   );
 }
@@ -384,58 +646,171 @@ function MediaDetail({ item, onClose }: { item: MediaItem; onClose: () => void }
   );
 }
 
-/** Lexical dictionary detail (extracted from platform-lexical-tools pattern) */
-function LexicalDetail({ item, onClose }: { item: LexicalDictionaryEntry; onClose: () => void }) {
+// ---------------------------------------------------------------------------
+// Domain tree dialog (expandable, scrolls to current)
+// ---------------------------------------------------------------------------
+
+function DomainTreeDialog({
+  domains,
+  selectedLevel1Id,
+  selectedLevel2Id,
+  onSelect,
+  trigger,
+}: {
+  domains: SemanticDomain[];
+  selectedLevel1Id: string;
+  selectedLevel2Id?: string;
+  onSelect: (level1: SemanticDomain, level2?: SemanticDomain) => void;
+  trigger: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set([selectedLevel1Id]));
+  // ref.current expects null not undefined for element refs
+  // eslint-disable-next-line no-null/no-null
+  const selectedRef = useRef<HTMLButtonElement>(null);
+
+  const toggleExpand = (id: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  };
+
+  // Expand the selected category and scroll to it when dialog opens
+  useEffect(() => {
+    if (open) {
+      setExpanded((prev) => new Set(prev).add(selectedLevel1Id));
+      // Defer scroll until DOM has rendered
+      requestAnimationFrame(() => {
+        selectedRef.current?.scrollIntoView({ block: 'center' });
+      });
+    }
+  }, [open, selectedLevel1Id]);
+
+  const handleSelect = useCallback(
+    (l1: SemanticDomain, l2?: SemanticDomain) => {
+      onSelect(l1, l2);
+      setOpen(false);
+    },
+    [onSelect],
+  );
+
   return (
-    <div>
-      <Button onClick={onClose} variant="link" className="tw-mb-3 tw-h-auto tw-p-0">
-        <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
-        Back to list
-      </Button>
-      <div className="tw-mb-3">
-        <span className="scripture-font tw-text-2xl tw-font-normal">{item.primaryText}</span>
-        <span className="tw-ml-2 tw-text-lg tw-text-muted-foreground">{item.glosses}</span>
-      </div>
-      <div className="tw-flex tw-gap-1">
-        {item.strongsCodes.map((code) => (
-          <span key={code} className="tw-rounded tw-bg-accent tw-px-2 tw-py-0.5 tw-text-sm">
-            {code}
-          </span>
-        ))}
-      </div>
-      <Separator className="tw-my-3" />
-      <p className="tw-text-sm">
-        Occurrences <span className="tw-text-muted-foreground">({item.occurrenceCount})</span>
-      </p>
-      <p className="tw-mt-2 tw-text-sm tw-text-muted-foreground">
-        Scripture references would appear here.
-      </p>
-    </div>
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>{trigger}</DialogTrigger>
+      <DialogContent className="tw-flex tw-max-h-[70vh] tw-max-w-sm tw-flex-col tw-p-0">
+        <DialogTitle className="tw-px-4 tw-pt-4 tw-text-base tw-font-semibold">
+          Semantic Domains
+        </DialogTitle>
+        <div className="tw-flex-1 tw-overflow-y-auto tw-px-2 tw-pb-4">
+          <ul className="tw-space-y-0.5">
+            {domains.map((level1) => {
+              const isExpanded = expanded.has(level1.id);
+              return (
+                <li key={level1.id}>
+                  <button
+                    type="button"
+                    className="tw-flex tw-w-full tw-items-center tw-gap-1 tw-rounded tw-px-2 tw-py-1.5 tw-text-left tw-text-sm tw-font-semibold hover:tw-bg-muted"
+                    onClick={() => toggleExpand(level1.id)}
+                  >
+                    {isExpanded ? (
+                      <ChevronDown className="tw-h-4 tw-w-4 tw-shrink-0" />
+                    ) : (
+                      <ChevronRight className="tw-h-4 tw-w-4 tw-shrink-0" />
+                    )}
+                    {level1.label}
+                  </button>
+                  {isExpanded && level1.children && (
+                    <ul className="tw-ml-5 tw-space-y-0.5">
+                      {level1.children.map((level2) => {
+                        const isActive =
+                          level1.id === selectedLevel1Id && level2.id === selectedLevel2Id;
+                        return (
+                          <li key={level2.id}>
+                            <button
+                              type="button"
+                              ref={isActive ? selectedRef : undefined}
+                              className={cn(
+                                'tw-w-full tw-rounded tw-px-2 tw-py-1 tw-text-left tw-text-sm',
+                                isActive ? 'tw-bg-accent tw-font-medium' : 'hover:tw-bg-muted',
+                              )}
+                              onClick={() => handleSelect(level1, level2)}
+                            >
+                              {level2.label}
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 
 // ---------------------------------------------------------------------------
-// ER dictionary list item with full 2-row content (kept at this height always)
+// Shared inline list+detail layout
 // ---------------------------------------------------------------------------
 
-function ErDictionaryListItem({ item }: { item: DictionaryEntryWithSenses }) {
-  const firstSense = item.senses[0];
+/** Generic inline list + detail pane. List hides overflow (no scroll) when detail is shown. */
+function InlineListDetail<T extends { id: string }>({
+  items,
+  selectedItem,
+  onSelectItem,
+  renderListItem,
+  renderDetail,
+  listClassName,
+}: {
+  items: T[];
+  selectedItem: T | undefined;
+  onSelectItem: (item: T | undefined) => void;
+  renderListItem: (item: T, compact: boolean) => React.ReactNode;
+  renderDetail: (item: T) => React.ReactNode;
+  listClassName?: string;
+}) {
   return (
-    <div className="tw-flex tw-w-full tw-flex-col tw-gap-0.5">
-      <div className="tw-flex tw-items-baseline tw-gap-2">
-        <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
-        <span className="tw-text-sm tw-text-muted-foreground">
-          {item.sourceLanguageText}
-          {item.transliteration && <span className="tw-ml-1">({item.transliteration})</span>}
-        </span>
-        <span className="tw-ml-auto tw-shrink-0 tw-rounded tw-bg-accent tw-px-1.5 tw-py-0.5 tw-text-xs">
-          {item.totalOccurrences}
-        </span>
+    <div className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
+      <div
+        className={cn(
+          'tw-h-full',
+          selectedItem
+            ? 'tw-w-1/5 tw-min-w-[120px] tw-overflow-hidden tw-border-r'
+            : 'tw-w-full tw-overflow-y-auto',
+          listClassName,
+        )}
+      >
+        <ul role="listbox" className="tw-outline-none">
+          {items.map((item) => {
+            const isSelected = selectedItem?.id === item.id;
+            return (
+              <li
+                key={item.id}
+                role="option"
+                aria-selected={isSelected}
+                onClick={() => onSelectItem(isSelected ? undefined : item)}
+                className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
+                  'tw-bg-muted': isSelected,
+                  'hover:tw-bg-muted': !isSelected,
+                })}
+              >
+                {renderListItem(item, !!selectedItem)}
+              </li>
+            );
+          })}
+        </ul>
       </div>
-      <p className="tw-truncate tw-text-sm tw-text-muted-foreground">
-        {firstSense?.glosses}
-        {item.senses.length > 1 && ` (+${item.senses.length - 1} more)`}
-      </p>
+      {selectedItem && (
+        <div className="tw-w-4/5 tw-overflow-y-auto tw-bg-background tw-p-4">
+          {renderDetail(selectedItem)}
+        </div>
+      )}
     </div>
   );
 }
@@ -460,14 +835,13 @@ const meta: Meta<typeof SourceLanguageIndexedList> = {
 };
 
 export default meta;
-
 type Story = StoryObj<typeof SourceLanguageIndexedList>;
 
 // ---------------------------------------------------------------------------
 // Stories
 // ---------------------------------------------------------------------------
 
-/** Base SourceLanguageIndexedList with default two-column layout */
+/** Base list without detail panel */
 export const Default: Story = {
   render: () => {
     const [selectedId, setSelectedId] = useState<string | undefined>();
@@ -483,17 +857,8 @@ export const Default: Story = {
       </div>
     );
   },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Base SourceLanguageIndexedList without a detail panel. Clicking items toggles selection.',
-      },
-    },
-  },
 };
 
-/** Loading state */
 export const Loading: Story = {
   render: () => (
     <div className="tw-h-[400px] tw-rounded tw-border">
@@ -502,19 +867,18 @@ export const Loading: Story = {
   ),
 };
 
-/** Empty state */
 export const EmptyState: Story = {
   render: () => (
     <div className="tw-h-[400px] tw-rounded tw-border">
-      <SourceLanguageIndexedList items={[]} emptyStateMessage="No entries found for this scope" />
+      <SourceLanguageIndexedList items={[]} emptyStateMessage="No entries found" />
     </div>
   ),
 };
 
 /**
- * All ER tabs with inline panel detail view and inline domain navigation. This is the primary
- * layout showing Dictionary, Encyclopedia, and Media tabs together. Clicking a domain link in the
- * dictionary detail replaces the view inline with a back button.
+ * All ER tabs with inline panel detail view and inline domain navigation. Dictionary entries open a
+ * detail panel matching the PT9 screenshot layout. Domain links replace the dictionary view
+ * inline.
  */
 export const AllErTabs: Story = {
   render: () => {
@@ -526,8 +890,6 @@ export const AllErTabs: Story = {
     >();
     const [selectedEncItem, setSelectedEncItem] = useState<EncyclopediaTeaser | undefined>();
     const [selectedMediaItem, setSelectedMediaItem] = useState<MediaItem | undefined>();
-
-    // Inline domain navigation state
     const [activeDomain, setActiveDomain] = useState<
       | {
           level1: SemanticDomain;
@@ -548,7 +910,6 @@ export const AllErTabs: Story = {
 
     return (
       <div className="tw-flex tw-h-[550px] tw-flex-col tw-rounded tw-border">
-        {/* Tabs */}
         <div className="tw-flex tw-border-b">
           {(['dictionary', 'encyclopedia', 'media'] as const).map((tab) => (
             <button
@@ -572,297 +933,191 @@ export const AllErTabs: Story = {
           ))}
         </div>
 
-        {/* Tab content */}
         <div className="tw-flex-1 tw-overflow-hidden">
           {activeTab === 'dictionary' && !activeDomain && (
-            <div className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
-              {/* List pane */}
-              <div
-                className={cn('tw-h-full tw-overflow-y-auto tw-border-r', {
-                  'tw-w-full': !selectedDictItem,
-                  'tw-w-1/5 tw-min-w-[120px]': !!selectedDictItem,
-                })}
-              >
-                <ul role="listbox" className="tw-outline-none">
-                  {sampleDictionaryItems.map((item) => {
-                    const isSelected = selectedDictItem?.id === item.id;
-                    return (
-                      <li
-                        key={item.id}
-                        role="option"
-                        aria-selected={isSelected}
-                        onClick={() => setSelectedDictItem(isSelected ? undefined : item)}
-                        className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
-                          'tw-bg-muted': isSelected,
-                          'hover:tw-bg-muted': !isSelected,
-                        })}
-                      >
-                        <ErDictionaryListItem item={item} />
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-              {/* Detail pane */}
-              {selectedDictItem && (
-                <div className="tw-w-4/5 tw-overflow-y-auto tw-bg-background tw-p-4">
-                  <ErDictionaryDetail
-                    item={selectedDictItem}
-                    onClose={() => setSelectedDictItem(undefined)}
-                    onDomainClick={handleDomainClick}
-                  />
-                </div>
+            <InlineListDetail
+              items={sampleDictionaryItems}
+              selectedItem={selectedDictItem}
+              onSelectItem={setSelectedDictItem}
+              renderListItem={(item, compact) => <ErDictListItem item={item} compact={compact} />}
+              renderDetail={(item) => (
+                <ErDictionaryDetail
+                  item={item}
+                  onClose={() => setSelectedDictItem(undefined)}
+                  onDomainClick={handleDomainClick}
+                />
               )}
-            </div>
+            />
           )}
 
           {activeTab === 'dictionary' && activeDomain && (
-            <ErDictionaryFilteredList
-              items={sampleDictionaryItems.filter((entry) =>
-                entry.senses.some(
-                  (s) =>
-                    s.domain.id === activeDomain.level1.id ||
-                    s.domain.id === activeDomain.level2?.id ||
-                    s.domain.parentId === activeDomain.level1.id,
-                ),
-              )}
-              selectedLevel1Domain={activeDomain.level1}
-              selectedLevel2Domain={activeDomain.level2}
-              allDomains={sampleAllDomains}
+            <DomainFilteredInline
+              activeDomain={activeDomain}
               onDomainChange={(l1, l2) => setActiveDomain({ level1: l1, level2: l2 })}
               onBack={() => setActiveDomain(undefined)}
-              renderItem={(item) => <ErDictionaryListItem item={item} />}
-              renderDetailContent={(item, onClose) => (
-                <ErDictionaryDetail item={item} onClose={onClose} />
-              )}
-              className="tw-h-full"
             />
           )}
 
           {activeTab === 'encyclopedia' && (
-            <div className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
-              <div
-                className={cn('tw-h-full tw-overflow-y-auto tw-border-r', {
-                  'tw-w-full': !selectedEncItem,
-                  'tw-w-1/5 tw-min-w-[120px]': !!selectedEncItem,
-                })}
-              >
-                <ul role="listbox" className="tw-outline-none">
-                  {sampleEncyclopediaItems.map((item) => {
-                    const isSelected = selectedEncItem?.id === item.id;
-                    return (
-                      <li
-                        key={item.id}
-                        role="option"
-                        aria-selected={isSelected}
-                        onClick={() => setSelectedEncItem(isSelected ? undefined : item)}
-                        className={cn('tw-cursor-pointer tw-border-b tw-p-2', {
-                          'tw-bg-muted': isSelected,
-                          'hover:tw-bg-muted': !isSelected,
-                        })}
-                      >
-                        <div className="tw-flex tw-flex-col tw-gap-0.5">
-                          <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
-                          <span className="tw-truncate tw-text-xs tw-text-muted-foreground">
-                            {item.teaserText}
-                          </span>
-                        </div>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-              {selectedEncItem && (
-                <div className="tw-w-4/5 tw-overflow-y-auto tw-bg-background tw-p-4">
-                  <EncyclopediaDetail
-                    item={selectedEncItem}
-                    onClose={() => setSelectedEncItem(undefined)}
-                  />
+            <InlineListDetail
+              items={sampleEncyclopediaItems}
+              selectedItem={selectedEncItem}
+              onSelectItem={setSelectedEncItem}
+              renderListItem={(item) => (
+                <div className="tw-flex tw-flex-col tw-gap-0.5">
+                  <div className="tw-flex tw-items-baseline tw-gap-2">
+                    <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
+                    <span className="tw-text-sm tw-text-muted-foreground">
+                      {item.sourceLanguageText}
+                      {item.transliteration && (
+                        <span className="tw-ml-1">({item.transliteration})</span>
+                      )}
+                    </span>
+                  </div>
+                  <span className="tw-truncate tw-text-xs tw-text-muted-foreground">
+                    {item.teaserText}
+                  </span>
                 </div>
               )}
-            </div>
+              renderDetail={(item) => (
+                <EncyclopediaDetail item={item} onClose={() => setSelectedEncItem(undefined)} />
+              )}
+            />
           )}
 
           {activeTab === 'media' && (
-            <div className="tw-relative tw-flex tw-h-full tw-overflow-hidden">
-              <div
-                className={cn('tw-h-full tw-overflow-y-auto tw-border-r', {
-                  'tw-w-full': !selectedMediaItem,
-                  'tw-w-1/5 tw-min-w-[120px]': !!selectedMediaItem,
-                })}
-              >
-                <ul role="listbox" className="tw-outline-none">
-                  {sampleMediaItems.map((item) => {
-                    const isSelected = selectedMediaItem?.id === item.id;
-                    return (
-                      <li
-                        key={item.id}
-                        role="option"
-                        aria-selected={isSelected}
-                        onClick={() => setSelectedMediaItem(isSelected ? undefined : item)}
-                        className={cn(
-                          'tw-flex tw-cursor-pointer tw-items-center tw-gap-2 tw-border-b tw-p-2',
-                          { 'tw-bg-muted': isSelected, 'hover:tw-bg-muted': !isSelected },
-                        )}
-                      >
-                        {item.thumbnailUrl && (
-                          <img
-                            src={item.thumbnailUrl}
-                            alt={item.primaryText}
-                            className="tw-h-10 tw-w-10 tw-rounded tw-object-cover"
-                          />
-                        )}
-                        <div className="tw-flex tw-flex-col tw-gap-0.5">
-                          <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
-                          <Badge variant="outline" className="tw-w-fit tw-text-xs">
-                            {item.mediaType}
-                          </Badge>
-                        </div>
-                      </li>
-                    );
-                  })}
-                </ul>
-              </div>
-              {selectedMediaItem && (
-                <div className="tw-w-4/5 tw-overflow-y-auto tw-bg-background tw-p-4">
-                  <MediaDetail
-                    item={selectedMediaItem}
-                    onClose={() => setSelectedMediaItem(undefined)}
-                  />
+            <InlineListDetail
+              items={sampleMediaItems}
+              selectedItem={selectedMediaItem}
+              onSelectItem={setSelectedMediaItem}
+              renderListItem={(item) => (
+                <div className="tw-flex tw-items-center tw-gap-2">
+                  {item.thumbnailUrl && (
+                    <img
+                      src={item.thumbnailUrl}
+                      alt={item.primaryText}
+                      className="tw-h-10 tw-w-10 tw-rounded tw-object-cover"
+                    />
+                  )}
+                  <div className="tw-flex tw-flex-col tw-gap-0.5">
+                    <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
+                    <Badge variant="outline" className="tw-w-fit tw-text-xs">
+                      {item.mediaType}
+                    </Badge>
+                  </div>
                 </div>
               )}
-            </div>
+              renderDetail={(item) => (
+                <MediaDetail item={item} onClose={() => setSelectedMediaItem(undefined)} />
+              )}
+            />
           )}
         </div>
       </div>
     );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'All ER tabs combined with inline panel detail views and inline domain navigation. Dictionary entries open a detail panel matching the PT9 screenshot layout. Domain links replace the dictionary view inline with breadcrumb navigation and a back arrow.',
-      },
-    },
-  },
-};
-
-/** ER Dictionary filtered by domain - standalone view with breadcrumbs, dropdowns, and tree */
-export const ErDictionaryFilteredByDomain: Story = {
-  render: () => {
-    const [selectedL1, setSelectedL1] = useState(sampleAllDomains[0]);
-    const [selectedL2, setSelectedL2] = useState<SemanticDomain | undefined>(
-      sampleAllDomains[0].children?.[0],
-    );
-
-    return (
-      <div className="tw-h-[500px] tw-rounded tw-border">
-        <ErDictionaryFilteredList
-          items={sampleDictionaryItems}
-          selectedLevel1Domain={selectedL1}
-          selectedLevel2Domain={selectedL2}
-          allDomains={sampleAllDomains}
-          onDomainChange={(l1, l2) => {
-            setSelectedL1(l1);
-            setSelectedL2(l2);
-          }}
-          renderItem={(item) => <ErDictionaryListItem item={item} />}
-          renderDetailContent={(item, onClose) => (
-            <ErDictionaryDetail item={item} onClose={onClose} />
-          )}
-          className="tw-h-full"
-        />
-      </div>
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          'Dictionary filtered by semantic domain. Breadcrumbs use dot separator with dropdown navigation. Tree button (right-aligned) opens the full domain tree in a scoped drawer.',
-      },
-    },
   },
 };
 
 /**
- * Lexical extension dictionary with inline panel detail view. Shows entries with source language
- * lemma, occurrence count, glosses, and Strong's codes. Clicking an entry opens a detail panel.
+ * Lexical extension dictionary with inline panel. Full detail view with senses, occurrence
+ * chapter/all toggle, domains, and Strong's codes. List uses same styling as ER dictionary.
  */
 export const LexicalDictionary: Story = {
   render: () => {
-    const [selectedItem, setSelectedItem] = useState<LexicalDictionaryEntry | undefined>();
-
+    const [selectedItem, setSelectedItem] = useState<LexicalEntryFull | undefined>();
     return (
-      <div className="tw-h-[500px] tw-rounded tw-border">
+      <div className="tw-h-[550px] tw-rounded tw-border">
         <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
           Lexical Dictionary
         </h3>
-        <div className="tw-relative tw-flex tw-h-[calc(100%-41px)] tw-overflow-hidden">
-          <div
-            className={cn('tw-h-full tw-overflow-y-auto', {
-              'tw-w-full': !selectedItem,
-              'tw-w-1/5 tw-min-w-[80px] tw-border-r': !!selectedItem,
-            })}
-          >
-            <LexicalDictionaryList
-              items={sampleLexicalEntries}
-              onItemClick={(item) =>
-                setSelectedItem(item.id === selectedItem?.id ? undefined : item)
-              }
-              selectedItemId={selectedItem?.id}
-              occurrenceCountLabel="Occurrences in chapter"
-              strongsCodeLabel="Strong's code"
-            />
-          </div>
-          {selectedItem && (
-            <div className="tw-w-4/5 tw-overflow-y-auto tw-bg-background tw-p-4">
-              <LexicalDetail item={selectedItem} onClose={() => setSelectedItem(undefined)} />
-            </div>
-          )}
+        <div className="tw-h-[calc(100%-41px)]">
+          <InlineListDetail
+            items={sampleLexicalEntries}
+            selectedItem={selectedItem}
+            onSelectItem={setSelectedItem}
+            renderListItem={(item, compact) => <LexicalListItem item={item} compact={compact} />}
+            renderDetail={(item) => (
+              <LexicalDetail item={item} onClose={() => setSelectedItem(undefined)} />
+            )}
+          />
         </div>
       </div>
     );
   },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "Lexical extension dictionary with inline panel. Shows entries with source language lemma, occurrence count, glosses, and Strong's codes. Clicking an entry opens a detail panel extracted from the platform-lexical-tools extension.",
-      },
-    },
-  },
 };
 
-/** ER Encyclopedia list with inline panel */
-export const ErEncyclopedia: Story = {
-  render: () => (
-    <div className="tw-h-[500px] tw-rounded tw-border">
-      <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">Encyclopedia</h3>
-      <ErEncyclopediaList
-        items={sampleEncyclopediaItems}
-        showSourceLanguage
-        showTransliteration
-        renderDetailContent={(item, onClose) => (
-          <EncyclopediaDetail item={item} onClose={onClose} />
-        )}
-      />
-    </div>
-  ),
-};
+// ---------------------------------------------------------------------------
+// Helper: domain filtered inline view used within AllErTabs
+// ---------------------------------------------------------------------------
 
-/** ER Media list with inline panel */
-export const ErMedia: Story = {
-  render: () => (
-    <div className="tw-h-[500px] tw-rounded tw-border">
-      <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
-        Media (Images &amp; Maps)
-      </h3>
-      <ErMediaList
-        items={sampleMediaItems}
-        showSourceLanguage
-        renderDetailContent={(item, onClose) => <MediaDetail item={item} onClose={onClose} />}
-      />
+function DomainFilteredInline({
+  activeDomain,
+  onDomainChange,
+  onBack,
+}: {
+  activeDomain: { level1: SemanticDomain; level2?: SemanticDomain };
+  onDomainChange: (level1: SemanticDomain, level2?: SemanticDomain) => void;
+  onBack: () => void;
+}) {
+  const [selectedItem, setSelectedItem] = useState<DictionaryEntryWithSenses | undefined>();
+
+  const effectiveLevel2 = activeDomain.level2 ?? activeDomain.level1.children?.[0];
+  const domainLabel = effectiveLevel2
+    ? `${activeDomain.level1.label} \u00B7 ${effectiveLevel2.label}`
+    : activeDomain.level1.label;
+
+  const filteredItems = useMemo(
+    () =>
+      sampleDictionaryItems.filter((entry) =>
+        entry.senses.some(
+          (s) =>
+            s.domain.id === activeDomain.level1.id ||
+            s.domain.id === effectiveLevel2?.id ||
+            s.domain.parentId === activeDomain.level1.id,
+        ),
+      ),
+    [activeDomain.level1.id, effectiveLevel2?.id],
+  );
+
+  return (
+    <div className="tw-flex tw-h-full tw-flex-col">
+      {/* Header: [← Back] [domain dropdown centered] */}
+      <div className="tw-flex tw-items-center tw-gap-2 tw-border-b tw-px-2 tw-py-1.5">
+        <Button variant="ghost" size="sm" onClick={onBack} className="tw-shrink-0 tw-gap-1">
+          <ArrowLeft className="tw-h-4 tw-w-4" />
+          Back
+        </Button>
+        <div className="tw-flex tw-flex-1 tw-justify-center">
+          <DomainTreeDialog
+            domains={sampleAllDomains}
+            selectedLevel1Id={activeDomain.level1.id}
+            selectedLevel2Id={effectiveLevel2?.id}
+            onSelect={(l1, l2) => {
+              onDomainChange(l1, l2);
+              setSelectedItem(undefined);
+            }}
+            trigger={
+              <Button variant="outline" className="tw-gap-1 tw-text-sm">
+                {domainLabel}
+                <ChevronDown className="tw-h-3 tw-w-3" />
+              </Button>
+            }
+          />
+        </div>
+      </div>
+
+      {/* List + detail */}
+      <div className="tw-flex-1 tw-overflow-hidden">
+        <InlineListDetail
+          items={filteredItems}
+          selectedItem={selectedItem}
+          onSelectItem={setSelectedItem}
+          renderListItem={(item, compact) => <ErDictListItem item={item} compact={compact} />}
+          renderDetail={(item) => (
+            <ErDictionaryDetail item={item} onClose={() => setSelectedItem(undefined)} />
+          )}
+        />
+      </div>
     </div>
-  ),
-};
+  );
+}

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -1,6 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { useState } from 'react';
+import { useState, useCallback } from 'react';
 import { ThemeProvider } from '@/storybook/theme-provider.component';
+import { ArrowLeft, BookA } from 'lucide-react';
+import { Button } from '@/components/shadcn-ui/button';
+import { Separator } from '@/components/shadcn-ui/separator';
+import { Badge } from '@/components/shadcn-ui/badge';
+import { Dialog, DialogContent, DialogTitle, DialogTrigger } from '@/components/shadcn-ui/dialog';
+import { DrawerClose, DrawerTitle, DrawerDescription } from '@/components/shadcn-ui/drawer';
 import SourceLanguageIndexedList from '@/components/advanced/source-language-indexed-list/source-language-indexed-list.component';
 import ErDictionaryList from '@/components/advanced/source-language-indexed-list/er-dictionary-list.component';
 import ErDictionaryFilteredList from '@/components/advanced/source-language-indexed-list/er-dictionary-filtered-list.component';
@@ -13,17 +19,69 @@ import type {
   MediaItem,
   LexicalDictionaryEntry,
   SemanticDomain,
+  EntryDomain,
 } from '@/components/advanced/source-language-indexed-list/source-language-indexed-list.types';
 
 // ---------------------------------------------------------------------------
-// Sample data
+// Sample domain data (always 2 levels)
 // ---------------------------------------------------------------------------
 
-const sampleDictionaryItems: (IndexedListItem & {
+const sampleAllDomains: SemanticDomain[] = [
+  {
+    id: 'natural-world',
+    label: 'Natural World',
+    children: [
+      { id: 'animals', label: 'Animals' },
+      { id: 'plants', label: 'Plants' },
+      { id: 'weather', label: 'Weather & Climate' },
+    ],
+  },
+  {
+    id: 'human-body',
+    label: 'Human Body',
+    children: [
+      { id: 'body-parts', label: 'Body Parts' },
+      { id: 'senses', label: 'Senses & Perception' },
+      { id: 'health', label: 'Health & Sickness' },
+    ],
+  },
+  {
+    id: 'social-relations',
+    label: 'Social Relations',
+    children: [
+      { id: 'family', label: 'Family' },
+      { id: 'authority', label: 'Authority & Leadership' },
+      { id: 'worship', label: 'Worship & Religion' },
+    ],
+  },
+  {
+    id: 'abstract-concepts',
+    label: 'Abstract Concepts',
+    children: [
+      { id: 'time', label: 'Time' },
+      { id: 'quantity', label: 'Quantity & Number' },
+      { id: 'quality', label: 'Quality & Attributes' },
+    ],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Dictionary entry type with domains for stories
+// ---------------------------------------------------------------------------
+
+type DictionaryEntryWithDomains = IndexedListItem & {
   glosses: string;
   strongsCodes: string[];
   occurrenceCount: number;
-})[] = [
+  domains: EntryDomain[];
+  definition?: string;
+};
+
+// ---------------------------------------------------------------------------
+// Sample dictionary items
+// ---------------------------------------------------------------------------
+
+const sampleDictionaryItems: DictionaryEntryWithDomains[] = [
   {
     id: 'entry-1',
     primaryText: 'grace',
@@ -32,6 +90,9 @@ const sampleDictionaryItems: (IndexedListItem & {
     glosses: 'grace, favor, kindness',
     strongsCodes: ['G5485'],
     occurrenceCount: 12,
+    domains: [{ id: 'abstract-concepts', label: 'Abstract Concepts', code: '1.1' }],
+    definition:
+      'Unmerited divine favor or assistance given to humans for regeneration or sanctification.',
   },
   {
     id: 'entry-2',
@@ -41,6 +102,10 @@ const sampleDictionaryItems: (IndexedListItem & {
     glosses: 'faith, belief, trust',
     strongsCodes: ['G4102'],
     occurrenceCount: 8,
+    domains: [
+      { id: 'worship', label: 'Worship & Religion', parentId: 'social-relations', code: '3.3' },
+    ],
+    definition: 'Complete trust or confidence in something or someone; firm belief.',
   },
   {
     id: 'entry-3',
@@ -50,6 +115,15 @@ const sampleDictionaryItems: (IndexedListItem & {
     glosses: 'love, affection, goodwill',
     strongsCodes: ['G26'],
     occurrenceCount: 15,
+    domains: [
+      {
+        id: 'social-relations',
+        label: 'Social Relations',
+        code: '3.0',
+      },
+    ],
+    definition:
+      'Unconditional love, especially the love of God for humanity and the love expected between believers.',
   },
   {
     id: 'entry-4',
@@ -59,6 +133,10 @@ const sampleDictionaryItems: (IndexedListItem & {
     glosses: 'righteousness, justice',
     strongsCodes: ['G1343'],
     occurrenceCount: 5,
+    domains: [
+      { id: 'quality', label: 'Quality & Attributes', parentId: 'abstract-concepts', code: '1.3' },
+    ],
+    definition: 'The quality of being morally right or justifiable; conformity to divine law.',
   },
   {
     id: 'entry-5',
@@ -68,6 +146,10 @@ const sampleDictionaryItems: (IndexedListItem & {
     glosses: 'salvation, deliverance, preservation',
     strongsCodes: ['G4991'],
     occurrenceCount: 3,
+    domains: [
+      { id: 'worship', label: 'Worship & Religion', parentId: 'social-relations', code: '3.3' },
+    ],
+    definition: 'Deliverance from sin and its consequences, brought about by faith in Christ.',
   },
   {
     id: 'entry-6',
@@ -77,8 +159,17 @@ const sampleDictionaryItems: (IndexedListItem & {
     glosses: 'glory, splendor, brightness',
     strongsCodes: ['G1391'],
     occurrenceCount: 7,
+    domains: [
+      { id: 'quality', label: 'Quality & Attributes', parentId: 'abstract-concepts', code: '1.3' },
+    ],
+    definition:
+      'Great beauty, magnificence, or splendor. Often refers to the manifest presence and power of God.',
   },
 ];
+
+// ---------------------------------------------------------------------------
+// Sample encyclopedia items
+// ---------------------------------------------------------------------------
 
 const sampleEncyclopediaItems: EncyclopediaTeaser[] = [
   {
@@ -123,6 +214,10 @@ const sampleEncyclopediaItems: EncyclopediaTeaser[] = [
   },
 ];
 
+// ---------------------------------------------------------------------------
+// Sample media items
+// ---------------------------------------------------------------------------
+
 const sampleMediaItems: MediaItem[] = [
   {
     id: 'media-1',
@@ -165,6 +260,10 @@ const sampleMediaItems: MediaItem[] = [
     caption: 'One of the Seven Wonders of the Ancient World',
   },
 ];
+
+// ---------------------------------------------------------------------------
+// Sample lexical entries
+// ---------------------------------------------------------------------------
 
 const sampleLexicalEntries: LexicalDictionaryEntry[] = [
   {
@@ -232,67 +331,162 @@ const sampleLexicalEntries: LexicalDictionaryEntry[] = [
   },
 ];
 
-const sampleDomainPath: SemanticDomain[] = [
-  { id: 'root', label: 'All Domains' },
-  { id: 'natural-world', label: 'Natural World' },
-  { id: 'animals', label: 'Animals' },
-];
+// ---------------------------------------------------------------------------
+// Shared detail content renderers (extracted from lexical dictionary pattern)
+// ---------------------------------------------------------------------------
 
-const sampleDomainChildren: SemanticDomain[] = [
-  {
-    id: 'domestic',
-    label: 'Domestic Animals',
-    children: [
-      { id: 'cattle', label: 'Cattle' },
-      { id: 'sheep', label: 'Sheep & Goats' },
-      { id: 'donkeys', label: 'Donkeys' },
-    ],
-  },
-  {
-    id: 'wild',
-    label: 'Wild Animals',
-    children: [
-      { id: 'predators', label: 'Predators' },
-      { id: 'prey', label: 'Prey Animals' },
-    ],
-  },
-  { id: 'birds', label: 'Birds' },
-  { id: 'fish', label: 'Fish & Sea Creatures' },
-  { id: 'insects', label: 'Insects' },
-];
+/** Renders detailed dictionary entry content inside the drawer */
+function DictionaryDetailContent({
+  item,
+  onClose,
+  onDomainClick,
+}: {
+  item: DictionaryEntryWithDomains;
+  onClose: () => void;
+  onDomainClick?: (domain: EntryDomain) => void;
+}) {
+  return (
+    <>
+      <DrawerClose asChild>
+        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
+          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+          Back to list
+        </Button>
+      </DrawerClose>
 
-const sampleFilteredItems: IndexedListItem[] = [
-  {
-    id: 'filtered-1',
-    primaryText: 'lamb',
-    sourceLanguageText: '\u1F00\u03BC\u03BD\u03CC\u03C2',
-    transliteration: 'amnos',
-  },
-  {
-    id: 'filtered-2',
-    primaryText: 'sheep',
-    sourceLanguageText: '\u03C0\u03C1\u03CC\u03B2\u03B1\u03C4\u03BF\u03BD',
-    transliteration: 'probaton',
-  },
-  {
-    id: 'filtered-3',
-    primaryText: 'goat',
-    sourceLanguageText: '\u03B1\u1F34\u03BE',
-    transliteration: 'aix',
-  },
-  {
-    id: 'filtered-4',
-    primaryText: 'ox',
-    sourceLanguageText: '\u03B2\u03BF\u1FE6\u03C2',
-    transliteration: 'bous',
-  },
-  {
-    id: 'filtered-5',
-    primaryText: 'donkey',
-    sourceLanguageText: '\u1F44\u03BD\u03BF\u03C2',
-    transliteration: 'onos',
-  },
-];
+      <div className="tw-mb-4">
+        <div className="tw-flex tw-items-baseline tw-justify-between tw-gap-2">
+          <span className="tw-flex tw-flex-row tw-items-baseline tw-gap-2">
+            <DrawerTitle className="tw-text-2xl tw-font-normal">{item.primaryText}</DrawerTitle>
+            <DrawerDescription className="tw-text-lg tw-text-muted-foreground">
+              {item.glosses}
+            </DrawerDescription>
+          </span>
+          <ul className="tw-flex tw-flex-row tw-gap-1">
+            {item.strongsCodes.map((code) => (
+              <li
+                key={code}
+                className="tw-ml-auto tw-rounded tw-bg-accent tw-px-2 tw-py-0.5 tw-text-sm"
+              >
+                {code}
+              </li>
+            ))}
+          </ul>
+        </div>
+        {item.sourceLanguageText && (
+          <p className="tw-mt-1 tw-text-sm tw-text-muted-foreground">
+            {item.sourceLanguageText}
+            {item.transliteration && <span className="tw-ml-1">({item.transliteration})</span>}
+          </p>
+        )}
+      </div>
+
+      <Separator className="tw-my-3" />
+
+      {item.definition && (
+        <div className="tw-mb-4">
+          <h3 className="tw-mb-1 tw-font-semibold">Definition</h3>
+          <p className="tw-text-sm tw-text-muted-foreground">{item.definition}</p>
+        </div>
+      )}
+
+      {/* Domains as clickable links */}
+      {item.domains.length > 0 && (
+        <div className="tw-mb-4">
+          <h3 className="tw-mb-2 tw-font-semibold">Domains</h3>
+          <div className="tw-flex tw-flex-wrap tw-gap-2">
+            {item.domains.map((domain) => (
+              <Button
+                key={domain.id}
+                variant="outline"
+                className="tw-h-auto tw-gap-1 tw-px-2 tw-py-1 tw-text-xs"
+                onClick={() => onDomainClick?.(domain)}
+              >
+                <BookA className="tw-h-3 tw-w-3" />
+                {domain.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <Separator className="tw-my-3" />
+
+      <div>
+        <h3 className="tw-mb-2 tw-font-semibold">Occurrences ({item.occurrenceCount})</h3>
+        <p className="tw-text-sm tw-text-muted-foreground">
+          Scripture references would appear here in the real application.
+        </p>
+      </div>
+    </>
+  );
+}
+
+/** Renders detailed encyclopedia content inside the drawer */
+function EncyclopediaDetailContent({
+  item,
+  onClose,
+}: {
+  item: EncyclopediaTeaser;
+  onClose: () => void;
+}) {
+  return (
+    <>
+      <DrawerClose asChild>
+        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
+          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+          Back to list
+        </Button>
+      </DrawerClose>
+
+      <DrawerTitle className="tw-mb-1 tw-text-2xl tw-font-normal">{item.primaryText}</DrawerTitle>
+      {item.sourceLanguageText && (
+        <DrawerDescription className="tw-text-sm tw-text-muted-foreground">
+          {item.sourceLanguageText}
+          {item.transliteration && <span className="tw-ml-1">({item.transliteration})</span>}
+        </DrawerDescription>
+      )}
+
+      <Separator className="tw-my-3" />
+
+      <p className="tw-text-sm">
+        {item.teaserText ?? 'Full article content would be displayed here in the real application.'}
+      </p>
+    </>
+  );
+}
+
+/** Renders detailed media content inside the drawer */
+function MediaDetailContent({ item, onClose }: { item: MediaItem; onClose: () => void }) {
+  return (
+    <>
+      <DrawerClose asChild>
+        <Button onClick={onClose} className="tw-mb-4 tw-flex tw-items-center" variant="link">
+          <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+          Back to list
+        </Button>
+      </DrawerClose>
+
+      <div className="tw-mb-4 tw-flex tw-items-center tw-gap-2">
+        <DrawerTitle className="tw-text-xl tw-font-normal">{item.primaryText}</DrawerTitle>
+        <Badge variant="outline">{item.mediaType}</Badge>
+      </div>
+      <DrawerDescription className="tw-sr-only">
+        {item.caption ?? item.primaryText}
+      </DrawerDescription>
+
+      {item.thumbnailUrl && (
+        <img
+          src={item.thumbnailUrl}
+          alt={item.thumbnailAlt ?? item.primaryText}
+          className="tw-mb-4 tw-w-full tw-rounded tw-object-contain"
+        />
+      )}
+
+      {item.caption && <p className="tw-text-sm tw-text-muted-foreground">{item.caption}</p>}
+    </>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Story meta
@@ -342,7 +536,7 @@ export const Default: Story = {
     docs: {
       description: {
         story:
-          'Base SourceLanguageIndexedList component showing the default two-column layout with resource terms and source language terms.',
+          'Base SourceLanguageIndexedList without a detail drawer. Clicking items toggles selection only.',
       },
     },
   },
@@ -384,137 +578,194 @@ export const EmptyState: Story = {
 };
 
 /**
- * ER Dictionary list showing both columns (resource term + source language), occurrence count
- * badges, formatted glosses, and Strong's code badges.
+ * ER Dictionary list with detail drawer. Clicking an entry opens a right-side drawer showing the
+ * full entry details (glosses, Strong's codes, definition, domains as clickable links). Clicking a
+ * domain link opens the "ER Dictionary Filtered by Type" dialog.
  */
 export const ErDictionary: Story = {
   render: () => {
-    const [selectedId, setSelectedId] = useState<string | undefined>();
+    const [filteredDialogOpen, setFilteredDialogOpen] = useState(false);
+    const [filteredDomainL1, setFilteredDomainL1] = useState(sampleAllDomains[0]);
+    const [filteredDomainL2, setFilteredDomainL2] = useState<SemanticDomain | undefined>();
+    const [navMode, setNavMode] = useState<'tree' | 'dropdown'>('dropdown');
+
+    const handleDomainClick = (domain: EntryDomain) => {
+      // Find the matching level-1 domain and optionally level-2
+      const l1 = sampleAllDomains.find(
+        (d) => d.id === domain.id || d.children?.some((c) => c.id === domain.id),
+      );
+      if (l1) {
+        setFilteredDomainL1(l1);
+        const l2 = l1.children?.find((c) => c.id === domain.id);
+        setFilteredDomainL2(l2);
+        setFilteredDialogOpen(true);
+      }
+    };
 
     return (
-      <div className="tw-h-[500px] tw-rounded tw-border">
-        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">Dictionary</h3>
-        <ErDictionaryList
-          items={sampleDictionaryItems}
-          onItemClick={(item) => setSelectedId(item.id === selectedId ? undefined : item.id)}
-          selectedItemId={selectedId}
-          getDescription={(item) => item.glosses}
-          getBadges={(item) => item.strongsCodes}
-          getOccurrenceCount={(item) => item.occurrenceCount}
-        />
-      </div>
+      <>
+        <div className="tw-h-[500px] tw-rounded tw-border">
+          <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">Dictionary</h3>
+          <ErDictionaryList
+            items={sampleDictionaryItems}
+            showSourceLanguage
+            showTransliteration
+            getDescription={(item) => item.glosses}
+            getBadges={(item) => item.strongsCodes}
+            getOccurrenceCount={(item) => item.occurrenceCount}
+            renderDetailContent={(item, onClose) => (
+              <DictionaryDetailContent
+                item={item}
+                onClose={onClose}
+                onDomainClick={handleDomainClick}
+              />
+            )}
+          />
+        </div>
+
+        {/* Dialog that opens when clicking a domain link in the detail drawer */}
+        <Dialog open={filteredDialogOpen} onOpenChange={setFilteredDialogOpen}>
+          <DialogContent className="tw-flex tw-h-[500px] tw-max-w-lg tw-flex-col tw-p-0">
+            <DialogTitle className="tw-px-4 tw-pt-4 tw-text-base tw-font-semibold">
+              Dictionary by Domain
+            </DialogTitle>
+            <ErDictionaryFilteredList
+              items={sampleDictionaryItems.filter((entry) =>
+                entry.domains.some(
+                  (d) =>
+                    d.id === filteredDomainL1.id ||
+                    d.id === filteredDomainL2?.id ||
+                    d.parentId === filteredDomainL1.id,
+                ),
+              )}
+              selectedLevel1Domain={filteredDomainL1}
+              selectedLevel2Domain={filteredDomainL2}
+              allDomains={sampleAllDomains}
+              onDomainChange={(l1, l2) => {
+                setFilteredDomainL1(l1);
+                setFilteredDomainL2(l2);
+              }}
+              navigationMode={navMode}
+              onNavigationModeChange={setNavMode}
+              renderDetailContent={(item, onClose) => (
+                <DictionaryDetailContent item={item} onClose={onClose} />
+              )}
+              className="tw-min-h-0 tw-flex-1"
+            />
+          </DialogContent>
+        </Dialog>
+      </>
     );
   },
   parameters: {
     docs: {
       description: {
         story:
-          "ER Dictionary list showing both columns with occurrence counts, glosses, and Strong's codes. Used in the Dictionary tab of the Enhanced Resources research pane.",
+          'ER Dictionary list with a detail drawer. Clicking an entry opens a right-side drawer with full details. Domain names in the detail view are clickable links that open the "ER Dictionary Filtered by Type" dialog.',
       },
     },
   },
 };
 
 /**
- * ER Dictionary filtered by semantic domain, showing breadcrumb navigation and a toggle to switch
- * between tree view (Option A) and dropdown view (Option B) for domain navigation.
+ * ER Dictionary filtered by semantic domain, shown in a Dialog. Features 2-level breadcrumbs,
+ * dropdown/tree navigation toggle, and entry detail drawer.
  */
 export const ErDictionaryFilteredByType: Story = {
   render: () => {
-    const [selectedId, setSelectedId] = useState<string | undefined>();
-    const [navMode, setNavMode] = useState<'tree' | 'dropdown'>('tree');
-    const [domainPath, setDomainPath] = useState<SemanticDomain[]>(sampleDomainPath);
+    const [selectedL1, setSelectedL1] = useState(sampleAllDomains[0]);
+    const [selectedL2, setSelectedL2] = useState<SemanticDomain | undefined>(
+      sampleAllDomains[0].children?.[0],
+    );
+    const [navMode, setNavMode] = useState<'tree' | 'dropdown'>('dropdown');
 
-    const handleBreadcrumbClick = (domain: SemanticDomain) => {
-      const index = domainPath.findIndex((d) => d.id === domain.id);
-      if (index >= 0) {
-        setDomainPath(domainPath.slice(0, index + 1));
-      }
-    };
-
-    const handleDomainSelect = (domain: SemanticDomain) => {
-      setDomainPath([...domainPath, domain]);
-    };
+    const handleDomainChange = useCallback((l1: SemanticDomain, l2?: SemanticDomain) => {
+      setSelectedL1(l1);
+      setSelectedL2(l2);
+    }, []);
 
     return (
-      <div className="tw-h-[600px] tw-rounded tw-border">
-        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
-          Dictionary &mdash; Filtered by Semantic Domain
-        </h3>
-        <ErDictionaryFilteredList
-          items={sampleFilteredItems}
-          onItemClick={(item) => setSelectedId(item.id === selectedId ? undefined : item.id)}
-          selectedItemId={selectedId}
-          domainPath={domainPath}
-          onBreadcrumbClick={handleBreadcrumbClick}
-          navigationMode={navMode}
-          onNavigationModeChange={setNavMode}
-          domainChildren={sampleDomainChildren}
-          onDomainSelect={handleDomainSelect}
-          className="tw-h-full"
-        />
-      </div>
+      <Dialog>
+        <DialogTrigger asChild>
+          <Button variant="outline">Open Dictionary by Domain</Button>
+        </DialogTrigger>
+        <DialogContent className="tw-flex tw-h-[550px] tw-max-w-lg tw-flex-col tw-p-0">
+          <DialogTitle className="tw-px-4 tw-pt-4 tw-text-base tw-font-semibold">
+            Dictionary by Semantic Domain
+          </DialogTitle>
+          <ErDictionaryFilteredList
+            items={sampleDictionaryItems}
+            selectedLevel1Domain={selectedL1}
+            selectedLevel2Domain={selectedL2}
+            allDomains={sampleAllDomains}
+            onDomainChange={handleDomainChange}
+            navigationMode={navMode}
+            onNavigationModeChange={setNavMode}
+            renderDetailContent={(item, onClose) => (
+              <DictionaryDetailContent item={item} onClose={onClose} />
+            )}
+            className="tw-min-h-0 tw-flex-1"
+          />
+        </DialogContent>
+      </Dialog>
     );
   },
   parameters: {
     docs: {
       description: {
         story:
-          'Dictionary entries filtered by semantic domain. Shows breadcrumb trail for the domain hierarchy and a toggle to switch between tree view (Option A, showing nested hierarchy) and dropdown view (Option B, showing siblings at each level). Corresponds to Screen A from ui-alignment.md.',
+          'ER Dictionary filtered by semantic domain inside a Dialog. 2-level breadcrumbs at top; clicking them opens either a dropdown (dropdown mode) or a domain tree drawer (tree mode). Toggle between modes at the bottom. Clicking an entry opens a detail drawer.',
       },
     },
   },
 };
 
-/** ER Encyclopedia list showing article titles with teaser/summary text. */
+/** ER Encyclopedia list with detail drawer showing article titles and teaser text. */
 export const ErEncyclopedia: Story = {
-  render: () => {
-    const [selectedId, setSelectedId] = useState<string | undefined>();
-
-    return (
-      <div className="tw-h-[500px] tw-rounded tw-border">
-        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">Encyclopedia</h3>
-        <ErEncyclopediaList
-          items={sampleEncyclopediaItems}
-          onItemClick={(item) => setSelectedId(item.id === selectedId ? undefined : item.id)}
-          selectedItemId={selectedId}
-        />
-      </div>
-    );
-  },
+  render: () => (
+    <div className="tw-h-[500px] tw-rounded tw-border">
+      <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">Encyclopedia</h3>
+      <ErEncyclopediaList
+        items={sampleEncyclopediaItems}
+        showSourceLanguage
+        showTransliteration
+        renderDetailContent={(item, onClose) => (
+          <EncyclopediaDetailContent item={item} onClose={onClose} />
+        )}
+      />
+    </div>
+  ),
   parameters: {
     docs: {
       description: {
         story:
-          'ER Encyclopedia list showing article titles with teaser/summary text and source language terms. Used in the Encyclopedia tab of the Enhanced Resources research pane.',
+          'ER Encyclopedia list with a detail drawer. Clicking an article opens the full article content in a right-side drawer.',
       },
     },
   },
 };
 
-/** ER Media list (images and maps) using the thumbnail variant with image previews. */
+/** ER Media list (images and maps) with detail drawer showing image preview. */
 export const ErMedia: Story = {
-  render: () => {
-    const [selectedId, setSelectedId] = useState<string | undefined>();
-
-    return (
-      <div className="tw-h-[500px] tw-rounded tw-border">
-        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
-          Media (Images &amp; Maps)
-        </h3>
-        <ErMediaList
-          items={sampleMediaItems}
-          onItemClick={(item) => setSelectedId(item.id === selectedId ? undefined : item.id)}
-          selectedItemId={selectedId}
-        />
-      </div>
-    );
-  },
+  render: () => (
+    <div className="tw-h-[500px] tw-rounded tw-border">
+      <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
+        Media (Images &amp; Maps)
+      </h3>
+      <ErMediaList
+        items={sampleMediaItems}
+        showSourceLanguage
+        renderDetailContent={(item, onClose) => (
+          <MediaDetailContent item={item} onClose={onClose} />
+        )}
+      />
+    </div>
+  ),
   parameters: {
     docs: {
       description: {
         story:
-          'ER Media list showing images and maps with thumbnail previews, media type badges, and captions. Used in the Media and Maps tabs of the Enhanced Resources research pane.',
+          'ER Media list with a detail drawer. Clicking an image or map opens a preview in a right-side drawer with zoom/pan support.',
       },
     },
   },
@@ -522,8 +773,7 @@ export const ErMedia: Story = {
 
 /**
  * Lexical extension dictionary list extracted from platform-lexical-tools. Shows entries with lemma
- * text, occurrence count badges, formatted glosses, and Strong's code badges. Matches the existing
- * dictionary list pattern from the lexical tools extension.
+ * text, occurrence count badges, formatted glosses, and Strong's code badges.
  */
 export const LexicalDictionary: Story = {
   render: () => {
@@ -548,7 +798,7 @@ export const LexicalDictionary: Story = {
     docs: {
       description: {
         story:
-          "Lexical extension dictionary list extracted from platform-lexical-tools. Shows entries with source language lemma, occurrence count, glosses, and Strong's codes. This is the shared version of the existing dictionary list component.",
+          "Lexical extension dictionary list extracted from platform-lexical-tools. Shows entries with source language lemma, occurrence count, glosses, and Strong's codes.",
       },
     },
   },
@@ -560,67 +810,119 @@ export const AllErTabs: Story = {
     const [activeTab, setActiveTab] = useState<'dictionary' | 'encyclopedia' | 'media'>(
       'dictionary',
     );
-    const [selectedId, setSelectedId] = useState<string | undefined>();
+    const [filteredDialogOpen, setFilteredDialogOpen] = useState(false);
+    const [filteredDomainL1, setFilteredDomainL1] = useState(sampleAllDomains[0]);
+    const [filteredDomainL2, setFilteredDomainL2] = useState<SemanticDomain | undefined>();
+    const [navMode, setNavMode] = useState<'tree' | 'dropdown'>('dropdown');
 
-    const handleItemClick = (item: IndexedListItem) => {
-      setSelectedId(item.id === selectedId ? undefined : item.id);
+    const handleDomainClick = (domain: EntryDomain) => {
+      const l1 = sampleAllDomains.find(
+        (d) => d.id === domain.id || d.children?.some((c) => c.id === domain.id),
+      );
+      if (l1) {
+        setFilteredDomainL1(l1);
+        setFilteredDomainL2(l1.children?.find((c) => c.id === domain.id));
+        setFilteredDialogOpen(true);
+      }
     };
 
     return (
-      <div className="tw-flex tw-h-[500px] tw-flex-col tw-rounded tw-border">
-        <div className="tw-flex tw-border-b">
-          {(['dictionary', 'encyclopedia', 'media'] as const).map((tab) => (
-            <button
-              key={tab}
-              type="button"
-              className={`tw-px-4 tw-py-2 tw-text-sm tw-capitalize ${
-                activeTab === tab
-                  ? 'tw-border-b-2 tw-border-primary tw-font-medium'
-                  : 'tw-text-muted-foreground hover:tw-text-foreground'
-              }`}
-              onClick={() => {
-                setActiveTab(tab);
-                setSelectedId(undefined);
+      <>
+        <div className="tw-flex tw-h-[500px] tw-flex-col tw-rounded tw-border">
+          <div className="tw-flex tw-border-b">
+            {(['dictionary', 'encyclopedia', 'media'] as const).map((tab) => (
+              <button
+                key={tab}
+                type="button"
+                className={`tw-px-4 tw-py-2 tw-text-sm tw-capitalize ${
+                  activeTab === tab
+                    ? 'tw-border-b-2 tw-border-primary tw-font-medium'
+                    : 'tw-text-muted-foreground hover:tw-text-foreground'
+                }`}
+                onClick={() => setActiveTab(tab)}
+              >
+                {tab}
+              </button>
+            ))}
+          </div>
+          <div className="tw-flex-1 tw-overflow-hidden">
+            {activeTab === 'dictionary' && (
+              <ErDictionaryList
+                items={sampleDictionaryItems}
+                showSourceLanguage
+                showTransliteration
+                getDescription={(item) => item.glosses}
+                getBadges={(item) => item.strongsCodes}
+                getOccurrenceCount={(item) => item.occurrenceCount}
+                renderDetailContent={(item, onClose) => (
+                  <DictionaryDetailContent
+                    item={item}
+                    onClose={onClose}
+                    onDomainClick={handleDomainClick}
+                  />
+                )}
+              />
+            )}
+            {activeTab === 'encyclopedia' && (
+              <ErEncyclopediaList
+                items={sampleEncyclopediaItems}
+                showSourceLanguage
+                showTransliteration
+                renderDetailContent={(item, onClose) => (
+                  <EncyclopediaDetailContent item={item} onClose={onClose} />
+                )}
+              />
+            )}
+            {activeTab === 'media' && (
+              <ErMediaList
+                items={sampleMediaItems}
+                showSourceLanguage
+                renderDetailContent={(item, onClose) => (
+                  <MediaDetailContent item={item} onClose={onClose} />
+                )}
+              />
+            )}
+          </div>
+        </div>
+
+        <Dialog open={filteredDialogOpen} onOpenChange={setFilteredDialogOpen}>
+          <DialogContent className="tw-flex tw-h-[500px] tw-max-w-lg tw-flex-col tw-p-0">
+            <DialogTitle className="tw-px-4 tw-pt-4 tw-text-base tw-font-semibold">
+              Dictionary by Domain
+            </DialogTitle>
+            <ErDictionaryFilteredList
+              items={sampleDictionaryItems.filter((entry) =>
+                entry.domains.some(
+                  (d) =>
+                    d.id === filteredDomainL1.id ||
+                    d.id === filteredDomainL2?.id ||
+                    d.parentId === filteredDomainL1.id,
+                ),
+              )}
+              selectedLevel1Domain={filteredDomainL1}
+              selectedLevel2Domain={filteredDomainL2}
+              allDomains={sampleAllDomains}
+              onDomainChange={(l1, l2) => {
+                setFilteredDomainL1(l1);
+                setFilteredDomainL2(l2);
               }}
-            >
-              {tab}
-            </button>
-          ))}
-        </div>
-        <div className="tw-flex-1 tw-overflow-hidden">
-          {activeTab === 'dictionary' && (
-            <ErDictionaryList
-              items={sampleDictionaryItems}
-              onItemClick={handleItemClick}
-              selectedItemId={selectedId}
-              getDescription={(item) => item.glosses}
-              getBadges={(item) => item.strongsCodes}
-              getOccurrenceCount={(item) => item.occurrenceCount}
+              navigationMode={navMode}
+              onNavigationModeChange={setNavMode}
+              renderDetailContent={(item, onClose) => (
+                <DictionaryDetailContent item={item} onClose={onClose} />
+              )}
+              className="tw-min-h-0 tw-flex-1"
             />
-          )}
-          {activeTab === 'encyclopedia' && (
-            <ErEncyclopediaList
-              items={sampleEncyclopediaItems}
-              onItemClick={handleItemClick}
-              selectedItemId={selectedId}
-            />
-          )}
-          {activeTab === 'media' && (
-            <ErMediaList
-              items={sampleMediaItems}
-              onItemClick={handleItemClick}
-              selectedItemId={selectedId}
-            />
-          )}
-        </div>
-      </div>
+          </DialogContent>
+        </Dialog>
+      </>
     );
   },
   parameters: {
     docs: {
       description: {
         story:
-          'All ER research pane tabs combined to demonstrate how Dictionary, Encyclopedia, and Media lists work together in a tabbed layout, matching the Enhanced Resources research pane structure.',
+          'All ER tabs combined with detail drawers and domain-filtered dialog. Dictionary entries open a detail drawer with clickable domain links. Clicking a domain opens the filtered dictionary dialog.',
       },
     },
   },

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -683,7 +683,7 @@ function InlineListDetail<T extends { id: string }>({
     const el = containerRef.current;
     if (!el) return undefined;
     const observer = new ResizeObserver(([entry]) => {
-      setNarrow((entry?.contentRect.width ?? 0) < 500);
+      setNarrow((entry?.contentRect.width ?? 0) < 350);
     });
     observer.observe(el);
     return () => observer.disconnect();
@@ -1054,19 +1054,14 @@ function DomainFilteredView({
   onClose: () => void;
   onDomainClick: (domain: EntryDomain, pathIds?: string[]) => void;
 }) {
-  const [selectedItem, setSelectedItem] = useState<DictionaryEntryWithSenses | undefined>();
-
   return (
     <ErDictionaryFilteredList
       items={sampleDictionaryItems}
       domainPath={domainPath}
       allDomains={sampleAllDomains}
-      onDomainChange={(newPath) => {
-        onDomainChange(newPath);
-        setSelectedItem(undefined);
-      }}
+      onDomainChange={onDomainChange}
       onClose={onClose}
-      renderItem={(item) => <ErDictListItem item={item} compact={!!selectedItem} />}
+      renderItem={(item) => <ErDictListItem item={item} />}
       renderDetailContent={(item, onCloseDetail) => (
         <ErDictionaryDetail item={item} onClose={onCloseDetail} onDomainClick={onDomainClick} />
       )}

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -750,7 +750,7 @@ function InlineListDetail<T extends { id: string }>({
             ref={listRef}
             role="listbox"
             tabIndex={0}
-            className="tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-ring"
+            className="tw-p-0.5 tw-outline-none focus-visible:tw-ring-2 focus-visible:tw-ring-inset focus-visible:tw-ring-ring"
             onKeyDown={handleListKeyDown}
           >
             {items.map((item, idx) => {

--- a/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/source-language-indexed-list.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState, useCallback } from 'react';
 import { ThemeProvider } from '@/storybook/theme-provider.component';
 import { ArrowLeft, BookA } from 'lucide-react';
+import { cn } from '@/utils/shadcn-ui.util';
 import { Button } from '@/components/shadcn-ui/button';
 import { Separator } from '@/components/shadcn-ui/separator';
 import { Badge } from '@/components/shadcn-ui/badge';
@@ -923,6 +924,209 @@ export const AllErTabs: Story = {
       description: {
         story:
           'All ER tabs combined with detail panels and domain-filtered dialog. Dictionary entries open a detail panel with clickable domain links. Clicking a domain opens the filtered dictionary dialog.',
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Alternative: Inline panel (flex layout, no Drawer)
+// ---------------------------------------------------------------------------
+
+/**
+ * Alternative layout using an inline flex panel instead of a Drawer. The detail view renders as a
+ * sibling div that takes 4/5 of the width while the list collapses. No portal or overlay involved.
+ */
+export const InlinePanelAlternative: Story = {
+  render: () => {
+    const [selectedItem, setSelectedItem] = useState<DictionaryEntryWithDomains | undefined>();
+
+    return (
+      <div className="tw-h-[500px] tw-rounded tw-border">
+        <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
+          Dictionary (Inline Panel Alternative)
+        </h3>
+        <div className="tw-relative tw-flex tw-h-[calc(100%-41px)] tw-overflow-hidden">
+          {/* List pane */}
+          <div
+            className={cn('tw-overflow-y-auto tw-transition-all tw-duration-200', {
+              'tw-w-full': !selectedItem,
+              'tw-w-1/5 tw-min-w-0': !!selectedItem,
+            })}
+          >
+            <ul role="listbox" className="tw-outline-none">
+              {sampleDictionaryItems.map((item) => {
+                const isSelected = selectedItem?.id === item.id;
+                return (
+                  <li
+                    key={item.id}
+                    role="option"
+                    aria-selected={isSelected}
+                    tabIndex={-1}
+                    onClick={() => setSelectedItem(isSelected ? undefined : item)}
+                    className={cn(
+                      'tw-flex tw-cursor-pointer tw-flex-col tw-gap-0.5 tw-border-b tw-p-2',
+                      {
+                        'tw-bg-muted': isSelected,
+                        'hover:tw-bg-muted': !isSelected,
+                      },
+                    )}
+                  >
+                    <span className="tw-text-sm tw-font-medium">{item.primaryText}</span>
+                    {!selectedItem && (
+                      <span className="tw-truncate tw-text-xs tw-text-muted-foreground">
+                        {item.glosses}
+                      </span>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+
+          {/* Inline detail pane */}
+          {selectedItem && (
+            <div className="tw-w-4/5 tw-overflow-y-auto tw-border-l tw-bg-background tw-p-4">
+              <Button
+                onClick={() => setSelectedItem(undefined)}
+                className="tw-mb-4 tw-flex tw-items-center"
+                variant="link"
+              >
+                <ArrowLeft className="tw-mr-1 tw-h-4 tw-w-4" />
+                Back to list
+              </Button>
+              <h2 className="tw-text-2xl tw-font-normal">{selectedItem.primaryText}</h2>
+              <p className="tw-text-lg tw-text-muted-foreground">{selectedItem.glosses}</p>
+              {selectedItem.sourceLanguageText && (
+                <p className="tw-mt-1 tw-text-sm tw-text-muted-foreground">
+                  {selectedItem.sourceLanguageText}
+                  {selectedItem.transliteration && (
+                    <span className="tw-ml-1">({selectedItem.transliteration})</span>
+                  )}
+                </p>
+              )}
+              <Separator className="tw-my-3" />
+              {selectedItem.definition && (
+                <p className="tw-text-sm tw-text-muted-foreground">{selectedItem.definition}</p>
+              )}
+            </div>
+          )}
+        </div>
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Alternative layout using an inline flex panel instead of a Drawer. The list shrinks to 1/5 width and the detail panel takes 4/5. No portal, overlay, or z-index concerns. Compare with the Drawer-based ErDictionary story.',
+      },
+    },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Alternative: Inline domain navigation (no Dialog)
+// ---------------------------------------------------------------------------
+
+/**
+ * Alternative to using a Dialog for domain-filtered navigation. Clicking a domain link in the
+ * dictionary detail view replaces the current dictionary list with the filtered domain view inline.
+ * A back button returns to the original list.
+ */
+export const ErDictionaryInlineNavigation: Story = {
+  render: () => {
+    const [activeDomain, setActiveDomain] = useState<
+      | {
+          level1: SemanticDomain;
+          level2?: SemanticDomain;
+        }
+      | undefined
+    >();
+    const [navMode, setNavMode] = useState<'tree' | 'dropdown'>('dropdown');
+
+    const handleDomainClick = (domain: EntryDomain) => {
+      const l1 = sampleAllDomains.find(
+        (d) => d.id === domain.id || d.children?.some((c) => c.id === domain.id),
+      );
+      if (l1) {
+        const l2 = l1.children?.find((c) => c.id === domain.id);
+        setActiveDomain({ level1: l1, level2: l2 });
+      }
+    };
+
+    return (
+      <div className="tw-h-[500px] tw-rounded tw-border">
+        {activeDomain ? (
+          /* Domain-filtered view (replaces the dictionary list) */
+          <>
+            <div className="tw-flex tw-items-center tw-gap-2 tw-border-b tw-px-3 tw-py-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setActiveDomain(undefined)}
+                className="tw-gap-1"
+              >
+                <ArrowLeft className="tw-h-4 tw-w-4" />
+                Back to Dictionary
+              </Button>
+              <span className="tw-text-sm tw-text-muted-foreground">
+                {activeDomain.level1.label}
+                {activeDomain.level2 && ` / ${activeDomain.level2.label}`}
+              </span>
+            </div>
+            <ErDictionaryFilteredList
+              items={sampleDictionaryItems.filter((entry) =>
+                entry.domains.some(
+                  (d) =>
+                    d.id === activeDomain.level1.id ||
+                    d.id === activeDomain.level2?.id ||
+                    d.parentId === activeDomain.level1.id,
+                ),
+              )}
+              selectedLevel1Domain={activeDomain.level1}
+              selectedLevel2Domain={activeDomain.level2}
+              allDomains={sampleAllDomains}
+              onDomainChange={(l1, l2) => setActiveDomain({ level1: l1, level2: l2 })}
+              navigationMode={navMode}
+              onNavigationModeChange={setNavMode}
+              renderDetailContent={(item, onClose) => (
+                <DictionaryDetailContent item={item} onClose={onClose} />
+              )}
+              className="tw-h-[calc(100%-45px)]"
+            />
+          </>
+        ) : (
+          /* Normal dictionary list */
+          <>
+            <h3 className="tw-border-b tw-px-3 tw-py-2 tw-text-sm tw-font-semibold">
+              Dictionary (Inline Navigation)
+            </h3>
+            <ErDictionaryList
+              items={sampleDictionaryItems}
+              showSourceLanguage
+              showTransliteration
+              getDescription={(item) => item.glosses}
+              getBadges={(item) => item.strongsCodes}
+              getOccurrenceCount={(item) => item.occurrenceCount}
+              renderDetailContent={(item, onClose) => (
+                <DictionaryDetailContent
+                  item={item}
+                  onClose={onClose}
+                  onDomainClick={handleDomainClick}
+                />
+              )}
+            />
+          </>
+        )}
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Alternative to using a Dialog for domain navigation. Clicking a domain link in the detail view replaces the entire dictionary with the domain-filtered view inline. A back button returns to the original list. Compare with the Dialog-based ErDictionary story.',
       },
     },
   },


### PR DESCRIPTION
<details><summary>This a Design PR: </summary>

This component was coded together with Claude.
✅Behavior and look and feel of the story is as expected for now (improvements / changes possible)
🤔Code might not be as expected by a developer
This should be a good basis to make the code nice and use it.

---
</details>

Changes:
- New component: a list indexed by source language word (and optionally a rendering of this)
- Includes
    - breadcrumbs (for some reason not using the shadcn component)
    - a tree inside a dropdown
    - modification of the drawer component to fit into a dedicated container instead of app/frame-wide
    - 2 variants for the Filtered Dictionary List by Semantic Domain (Drawer / Dialog)

→ Try it [in Chromatic](https://www.chromatic.com/component?appId=69cced5e253bf364823cfb83&csfId=advanced-sourcelanguageindexedlist--all-er-tabs&buildNumber=7&k=69e8a582bb90476be276e549-1200px-interactive-true&h=5&b=-1)

<img width="1255" height="724" alt="image" src="https://github.com/user-attachments/assets/9126f94f-ac9a-47b1-b745-622ec1fa6e25" />

Breadcrumbs
<img width="336" height="101" alt="Screenshot 2026-04-22 124538" src="https://github.com/user-attachments/assets/e13c7d0c-5c89-4b61-8e75-f00911a711f1" />

Tree Popover
<img width="389" height="409" alt="image" src="https://github.com/user-attachments/assets/3fa9b799-ef1b-4e13-8bc0-82d49b023ef4" />

Variant A: Drawer
<img width="560" height="708" alt="image" src="https://github.com/user-attachments/assets/52108795-0441-4e5f-a28f-d76d929df9e9" />

Variant B: Dialog
<img width="605" height="846" alt="image" src="https://github.com/user-attachments/assets/bc8dff57-4a55-4725-89f0-0250c7d3e3dd" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2209)
<!-- Reviewable:end -->
