### PR TITLE
check trailing para space

### DIFF
--- a/lib/platform-bible-utils/src/scripture/scripture-util.test.ts
+++ b/lib/platform-bible-utils/src/scripture/scripture-util.test.ts
@@ -568,6 +568,40 @@ describe('areUsjContentsEqualExceptWhitespace', () => {
     expect(areUsjContentsEqualExceptWhitespace(usj2, usj1)).toBe(true);
   });
 
+  it('should return true for trailing space on last plain text in a para (no char at end)', () => {
+    const usj1: Usj = {
+      type: 'USJ',
+      version: '3.1',
+      content: [
+        {
+          type: 'para',
+          marker: 'p',
+          content: [
+            { type: 'verse', marker: 'v', number: '1', sid: 'GEN 1:1' },
+            'In the beginning God created the heavens and the earth.',
+          ],
+        },
+      ],
+    };
+    const usj2: Usj = {
+      type: 'USJ',
+      version: '3.1',
+      content: [
+        {
+          type: 'para',
+          marker: 'p',
+          content: [
+            { type: 'verse', marker: 'v', number: '1', sid: 'GEN 1:1' },
+            // Trailing space added by Paratext normalization
+            'In the beginning God created the heavens and the earth. ',
+          ],
+        },
+      ],
+    };
+    expect(areUsjContentsEqualExceptWhitespace(usj1, usj2)).toBe(true);
+    expect(areUsjContentsEqualExceptWhitespace(usj2, usj1)).toBe(true);
+  });
+
   it('should return false for space difference at the end of last in-line marker in the block', () => {
     const usj1: Usj = {
       type: 'USJ',


### PR DESCRIPTION
- check trailing para space doesn't cause a normalization issue
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/paranext/paranext-core/pull/2213" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2213)
<!-- Reviewable:end -->
