### PR TITLE
PT-3921 follow-up: Fix typedoc cross-package link warnings

### DIFF
--- a/lib/platform-bible-react/src/components/advanced/comment-list/comment-list.types.ts
+++ b/lib/platform-bible-react/src/components/advanced/comment-list/comment-list.types.ts
@@ -55,9 +55,8 @@ export interface CommentListProps {
   /**
    * Comment threads to render. The component filters out threads where all comments are deleted,
    * but does not deduplicate threads. Callers are responsible for pre-filtering (e.g. excluding
-   * {@link LegacyCommentThread.isSpellingNote} and {@link LegacyCommentThread.isBTNote} threads,
-   * which belong in Wordlist and Biblical Terms respectively) and for deduplicating threads with
-   * repeated IDs before passing them in.
+   * `isSpellingNote` and `isBTNote` threads, which belong in Wordlist and Biblical Terms
+   * respectively) and for deduplicating threads with repeated IDs before passing them in.
    */
   threads: LegacyCommentThread[];
   /** Name of the current user, retrieved from the current user's Paratext Registry user information */


### PR DESCRIPTION
## Summary

Hotfix for the **Publish documentation** GitHub Action that started failing on `main` after PR #2204 (PT-3921) merged: https://github.com/paranext/paranext-core/actions/runs/24670739323/job/72146199841

## Root cause

PR #2204 added JSDoc links in `comment-list.types.ts` that reference members of `LegacyCommentThread`:

```ts
/**
 * ...excluding {@link LegacyCommentThread.isSpellingNote} and {@link LegacyCommentThread.isBTNote} threads...
 */
threads: LegacyCommentThread[];
```

`LegacyCommentThread` is exported from `platform-bible-utils`, but the `publish-docs` workflow runs `typedoc` separately for each package. TypeDoc can't resolve member links into a sibling package, so both links emitted warnings. `typedoc.json` has `treatWarningsAsErrors: true` (and `validation.invalidLink: true`), so each warning becomes exit code 4.

## Fix

Replace the `{@link ...}` references with plain backtick code spans (`` `isSpellingNote` ``, `` `isBTNote` ``). Semantically equivalent for readers, and typedoc no longer tries to resolve them. Verified locally: `cd lib/platform-bible-react && npm run build:docs` now succeeds.

Katherine's unmerged branch `pt-3878-assign-new-comment-to-previous-assignee` already applies the same fix as a review-feedback change, so this should rebase cleanly.

## AI Involvement

**Level**: assisted

- Root-cause analysis and fix drafted with Claude Code; human (Rolf) reviewed and authored the PR.

## Testing

- [x] `npm run build:docs` passes locally in `lib/platform-bible-react`
- [ ] `publish-docs` workflow passes once merged

## Risk Level

Low — JSDoc comment text only, no runtime or type changes.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/paranext/paranext-core/pull/2214" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2214)
<!-- Reviewable:end -->
