### PR TITLE
docs(readme): Add gitleaks to Developer Install prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,9 +77,21 @@ Set up pre-requisites, build, and run:
    # 8.0.412 (or similar 8.* version)
    ```
 
-3. Prerequisites for macOS or Linux (below).
+3. Install [`gitleaks`](https://github.com/gitleaks/gitleaks). The pre-commit hook runs `gitleaks` on staged files to block accidental secret commits — without it, every `git commit` fails.
 
-4. Clone, install, build, and run (below).
+   - **macOS**: `brew install gitleaks`
+   - **Windows**: `winget install Gitleaks.Gitleaks`
+   - **Linux**: download a prebuilt binary from the [releases page](https://github.com/gitleaks/gitleaks/releases) and place it on your `PATH` (e.g., `~/.local/bin/gitleaks`), or `sudo apt install gitleaks` on Ubuntu 24.04+.
+
+   To verify:
+
+   ```bash
+   gitleaks version
+   ```
+
+4. Prerequisites for macOS or Linux (below).
+
+5. Clone, install, build, and run (below).
 
 ### Linux Development Pre-requisites
 


### PR DESCRIPTION
## Summary

Adds `gitleaks` to the README Developer Install prerequisites so contributors know to install it before their first commit.

## Problem

PR #2201 introduced a pre-commit hook that runs `gitleaks` on staged files to block accidental secret commits. When `gitleaks` is not installed, the hook fails with a helpful error message pointing to install docs — but the repo's Developer Install section (README.md §"Developer Install") was never updated, so new contributors hit the blocking error before learning they need the tool.

## Change

Inserts `gitleaks` as step 3 of the Developer Install list (after Node.js and .NET 8 SDK), with install commands for macOS, Windows, and Linux, and a verification command. The pre-existing "Prerequisites for macOS or Linux" and "Clone, install, build, and run" steps are renumbered 4 and 5.

## Test Plan

- [x] `gitleaks version` prints `8.30.1` (or current version)
- [x] `git commit` succeeds when gitleaks is installed (verified by this PR's own commit)
- [ ] Reviewer: confirm the install instructions work on each platform

## Context

Discovered when a workflow branch's pre-commit hook blocked a cherry-pick onto `ai/main` because gitleaks was not installed locally. The hook was added without a corresponding docs update — this PR closes that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2217)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/paranext/paranext-core/pull/2217" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
