### PR TITLE
workflow: Fix ScrTextCollection pollution from empty-path DummyScrText

### DIFF
--- a/c-sharp-tests/DummyScrText.cs
+++ b/c-sharp-tests/DummyScrText.cs
@@ -21,7 +21,10 @@ namespace TestParanextDataProvider
                 new ProjectName
                 {
                     ShortName = projectDetails.Name,
-                    ProjectPath = projectDetails.HomeDirectory
+                    ProjectPath = EnsureNonEmptyHomeDirectory(
+                        projectDetails.HomeDirectory,
+                        projectDetails.Metadata.Id
+                    ),
                 },
                 RegistrationInfo.DefaultUser
             )
@@ -30,7 +33,10 @@ namespace TestParanextDataProvider
             projectName = new ProjectName
             {
                 ShortName = projectDetails.Name + _id,
-                ProjectPath = projectDetails.HomeDirectory
+                ProjectPath = EnsureNonEmptyHomeDirectory(
+                    projectDetails.HomeDirectory,
+                    projectDetails.Metadata.Id
+                ),
             };
 
             Settings.Editable = true;
@@ -49,13 +55,46 @@ namespace TestParanextDataProvider
         }
 
         public DummyScrText()
-            : this(
-                new ProjectDetails(
-                    "Dummy",
-                    new ProjectMetadata(HexId.CreateNew().ToString(), []),
-                    ""
-                )
-            ) { }
+            : this(CreateUniqueDummyDetails()) { }
+
+        /// <summary>
+        /// Build <see cref="ProjectDetails"/> with a unique, non-empty
+        /// <see cref="ProjectDetails.HomeDirectory"/> per invocation.
+        /// </summary>
+        /// <remarks>
+        /// Using an empty <c>HomeDirectory</c> causes multiple instances to
+        /// share the same <c>ProjectPath</c> on the resulting <c>ScrText</c>.
+        /// When several such instances are added to the global
+        /// <c>ScrTextCollection</c> via <c>FakeAddProject</c>, internal
+        /// path-indexed lookups inside
+        /// <c>ScrTextCollection.RefreshScrTextsInternal</c> fail a
+        /// <c>SingleOrDefault</c> call with "Sequence contains more than one
+        /// matching element" the next time <c>ParatextData.Initialize</c> is
+        /// called — even after the tests that added them have completed and
+        /// called <c>ScrTextCollection.Remove</c>. A unique non-empty path
+        /// per instance sidesteps the collision entirely.
+        /// </remarks>
+        private static ProjectDetails CreateUniqueDummyDetails()
+        {
+            var id = HexId.CreateNew().ToString();
+            return new ProjectDetails("Dummy", new ProjectMetadata(id, []), "testDirectory_" + id);
+        }
+
+        /// <summary>
+        /// Returns <paramref name="homeDirectory"/> when non-empty; otherwise
+        /// returns a unique fake path derived from <paramref name="id"/>.
+        /// </summary>
+        /// <remarks>
+        /// Idempotent: for a given <paramref name="id"/>, multiple calls with
+        /// an empty <paramref name="homeDirectory"/> return the same
+        /// substituted path, so the constructor's two invocations (for the
+        /// <c>base(...)</c> call and the field assignment) stay consistent.
+        /// Protects all callers of the parameterized constructor — not just
+        /// the parameterless overload — from the collision described on
+        /// <see cref="CreateUniqueDummyDetails"/>.
+        /// </remarks>
+        private static string EnsureNonEmptyHomeDirectory(string homeDirectory, string id) =>
+            string.IsNullOrEmpty(homeDirectory) ? "testDirectory_" + id : homeDirectory;
 
         protected override void Load(bool ignoreLoadErrors = false)
         {
@@ -74,7 +113,7 @@ namespace TestParanextDataProvider
                 {
                     FullName = "Test ScrText",
                     MinParatextDataVersion = ParatextInfo.MinSupportedParatextDataVersion,
-                    Guid = _id
+                    Guid = _id,
                 };
 
             return settings;

--- a/c-sharp-tests/DummyScrTextTests.cs
+++ b/c-sharp-tests/DummyScrTextTests.cs
@@ -1,0 +1,123 @@
+using System.Diagnostics.CodeAnalysis;
+using Paranext.DataProvider.Projects;
+using Paratext.Data;
+using PtxUtils;
+
+namespace TestParanextDataProvider
+{
+    /// <summary>
+    /// Regression guard for the <see cref="DummyScrText"/> constructor's
+    /// empty-<c>HomeDirectory</c> handling. Pins the invariant that every
+    /// <see cref="DummyScrText"/> has a non-empty, unique <c>ProjectPath</c>
+    /// even when the test author passes (or the parameterless constructor
+    /// builds) a <see cref="ProjectDetails"/> with an empty
+    /// <c>HomeDirectory</c>.
+    /// </summary>
+    /// <remarks>
+    /// Motivation: multiple <see cref="DummyScrText"/> instances that share
+    /// an empty <c>ProjectPath</c> collide inside
+    /// <c>ScrTextCollection.RefreshScrTextsInternal</c>'s path-indexed
+    /// <c>SingleOrDefault</c> lookup. The collision surfaces as
+    /// "Sequence contains more than one matching element" thrown from an
+    /// unrelated test's <c>ParatextData.Initialize</c> call long after the
+    /// polluting test has finished. If a future change reintroduces empty
+    /// <c>ProjectPath</c> on <see cref="DummyScrText"/>, this test fails and
+    /// names the invariant explicitly rather than leaving future maintainers
+    /// to rediscover the symptom through a full-suite run.
+    /// </remarks>
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    internal class DummyScrTextTests
+    {
+        [Test]
+        public void ParameterlessConstructor_ProducesNonEmptyProjectPath()
+        {
+            using var scrText = new DummyScrText();
+
+            Assert.That(
+                scrText.Directory,
+                Is.Not.Null.And.Not.Empty,
+                "DummyScrText() must produce a non-empty ProjectPath to avoid "
+                    + "ScrTextCollection path-indexed lookup collisions"
+            );
+        }
+
+        [Test]
+        public void ParameterlessConstructor_TwoInstances_HaveDistinctProjectPaths()
+        {
+            using var a = new DummyScrText();
+            using var b = new DummyScrText();
+
+            Assert.That(
+                a.Directory,
+                Is.Not.EqualTo(b.Directory),
+                "Distinct DummyScrText instances must have distinct ProjectPaths"
+            );
+        }
+
+        [Test]
+        public void ParameterizedConstructor_EmptyHomeDirectory_IsSubstituted()
+        {
+            var details = new ProjectDetails(
+                "Dummy",
+                new ProjectMetadata(HexId.CreateNew().ToString(), []),
+                ""
+            );
+
+            using var scrText = new DummyScrText(details);
+
+            Assert.That(
+                scrText.Directory,
+                Is.Not.Null.And.Not.Empty,
+                "DummyScrText(details with empty HomeDirectory) must substitute a "
+                    + "non-empty ProjectPath so that instances do not collide "
+                    + "inside ScrTextCollection's path-indexed lookups"
+            );
+        }
+
+        [Test]
+        public void ParameterizedConstructor_EmptyHomeDirectory_TwoInstances_HaveDistinctProjectPaths()
+        {
+            var detailsA = new ProjectDetails(
+                "DummyA",
+                new ProjectMetadata(HexId.CreateNew().ToString(), []),
+                ""
+            );
+            var detailsB = new ProjectDetails(
+                "DummyB",
+                new ProjectMetadata(HexId.CreateNew().ToString(), []),
+                ""
+            );
+
+            using var a = new DummyScrText(detailsA);
+            using var b = new DummyScrText(detailsB);
+
+            Assert.That(
+                a.Directory,
+                Is.Not.EqualTo(b.Directory),
+                "Two DummyScrTexts built from details that both have empty "
+                    + "HomeDirectory must still end up with distinct ProjectPaths"
+            );
+        }
+
+        [Test]
+        public void ParameterizedConstructor_NonEmptyHomeDirectory_IsPreserved()
+        {
+            const string explicitPath = "some/real/project/path";
+            var details = new ProjectDetails(
+                "Dummy",
+                new ProjectMetadata(HexId.CreateNew().ToString(), []),
+                explicitPath
+            );
+
+            using var scrText = new DummyScrText(details);
+
+            Assert.That(
+                scrText.Directory,
+                Is.EqualTo(explicitPath),
+                "Substitution must only apply to empty HomeDirectory; a caller "
+                    + "that supplies an explicit path must see it preserved"
+            );
+        }
+    }
+}

--- a/c-sharp-tests/PapiTestBase.cs
+++ b/c-sharp-tests/PapiTestBase.cs
@@ -45,16 +45,6 @@ namespace TestParanextDataProvider
             foreach (ScrText project in projects)
                 ScrTextCollection.Remove(project, false);
 
-            // Defensive full reset: ScrTextCollection.Remove does not fully
-            // clear ParatextData's path-indexed internal lookups. If a test
-            // added ScrTexts whose paths collide or otherwise confuse
-            // RefreshScrTextsInternal, subsequent calls to
-            // ParatextData.Initialize in unrelated tests can throw
-            // "Sequence contains more than one matching element". Re-initialize
-            // against FixtureSetup.TestFolderPath (which has no real project
-            // folders) to guarantee a clean state for the next test.
-            ParatextData.Initialize(FixtureSetup.TestFolderPath, false);
-
             _client?.Dispose();
         }
         #endregion

--- a/c-sharp-tests/PapiTestBase.cs
+++ b/c-sharp-tests/PapiTestBase.cs
@@ -45,6 +45,16 @@ namespace TestParanextDataProvider
             foreach (ScrText project in projects)
                 ScrTextCollection.Remove(project, false);
 
+            // Defensive full reset: ScrTextCollection.Remove does not fully
+            // clear ParatextData's path-indexed internal lookups. If a test
+            // added ScrTexts whose paths collide or otherwise confuse
+            // RefreshScrTextsInternal, subsequent calls to
+            // ParatextData.Initialize in unrelated tests can throw
+            // "Sequence contains more than one matching element". Re-initialize
+            // against FixtureSetup.TestFolderPath (which has no real project
+            // folders) to guarantee a clean state for the next test.
+            ParatextData.Initialize(FixtureSetup.TestFolderPath, false);
+
             _client?.Dispose();
         }
         #endregion


### PR DESCRIPTION
## Summary

Fixes a test-isolation bug in `DummyScrText` where adding instances with empty `HomeDirectory` to the global `ScrTextCollection` (via `FakeAddProject`) appears to leave path-indexed state that `ScrTextCollection.Remove(project, false)` does not fully clear. Subsequent calls to `ParatextData.Initialize` in unrelated tests throw `Sequence contains more than one matching element` inside `RefreshScrTextsInternal`.

> **Root-cause note**: we observed the failure signature and the empirical fix, but we did *not* read `ParatextData.dll` source to confirm the exact mechanism inside `RefreshScrTextsInternal`. Calling the root cause "path-indexed state not fully cleared on Remove" is the best explanation consistent with the observed behavior — if a reader of this PR has `ParatextData` source access and a different account, happy to update the description.

Observed on paranext-core#2220 (manage-books) CI: 8 pre-existing tests (`ParatextDataConnectionTests.LoadPackagedWEB_LoadsProject` + 7 parameterized cases of `LocalParatextProjectsTests.Initialize_SingleProject_ProjectIsRetrievable`) failed — none are modified by manage-books. All 8 share the same stack trace into `ScrTextCollection.<RefreshScrTextsInternal>b__11`.

Reproduces locally on the full suite in alphabetical order; `--filter` runs of individual test classes pass.

## Changes

### `c-sharp-tests/DummyScrText.cs` — the fix

The parameterless `DummyScrText()` constructor previously built a `ProjectDetails` with `HomeDirectory = ""`. Multiple such instances added to `ScrTextCollection` share an empty `ProjectPath`, triggering the `SingleOrDefault` collision.

- **Parameterless constructor** now delegates to a new `CreateUniqueDummyDetails()` helper that generates a fresh `HexId` and a per-instance path `"testDirectory_{id}"`.
- **Parameterized constructor** `DummyScrText(ProjectDetails)` now pipes `HomeDirectory` through a new `EnsureNonEmptyHomeDirectory` idempotent helper — if the caller passed `""`, a unique path derived from `Metadata.Id` is substituted. This protects per-feature helpers in downstream test classes (e.g. `CreateScrText` methods in the `ManageBooks` test files) that construct `DummyScrText(details)` with an empty `HomeDirectory`.

### `c-sharp-tests/DummyScrTextTests.cs` — new regression guard

Five tests pin the invariant so the next person who touches `DummyScrText` doesn't silently reintroduce the empty-path bug (which would only surface when the full suite runs in alphabetical order with certain feature tests present):

1. Parameterless constructor produces non-empty `ProjectPath`.
2. Parameterless produces distinct paths across instances.
3. Parameterized with empty `HomeDirectory` substitutes a non-empty path.
4. Parameterized with empty `HomeDirectory` on two instances produces distinct paths.
5. Parameterized with non-empty `HomeDirectory` preserves the caller-supplied path (no spurious substitution).

Verified: 4/5 fail cleanly when the `DummyScrText` fix is reverted, naming the invariant explicitly in the failure message.

## Revision history

An earlier iteration of this PR also added a defensive `ParatextData.Initialize` reset to `PapiTestBase.TestTearDown`. Post-hoc verification showed the `DummyScrText` fix alone makes the full suite pass (471/471 including the new regression tests), while the TearDown reset alone (without the `DummyScrText` fix) does not — so the reset was speculative and has been dropped per YAGNI. If a future test pattern surfaces a real need for a stronger per-test reset, it can be added then. See commit log for details.

## Verification

| Scenario | Result |
|---|---|
| `dotnet test` full suite (before any fix) | 458/466 pass (8 failures) |
| With `DummyScrText` fix only | **471/471 pass** (includes 5 regression tests) |
| With `DummyScrText` fix reverted (regression tests only) | 4/5 regression tests fail |
| Wall-clock time (before vs after) | ~2.58s vs ~2.58s — within measurement noise |

Local verification is **Linux-only**. Matrix CI (Ubuntu / macOS / Windows) on this branch is authoritative.

## Also on

This commit is currently also carried on `ai/feature/manage-books-rolf-03-11-2026` so that manage-books CI (paranext-core#2220) goes green immediately. Once this PR merges to `ai/main`, the feature branch's copy will be a no-op on squash-merge.

## AI Involvement

**Level**: generated

Diagnosis and fix generated by Claude Opus 4.7 via the AI porting workflow while investigating paranext-core#2220 CI failures. Human review requested before merge.

## Related

- Observed on: paranext/paranext-core#2220
- Related workflow gap: paranext/ai-prompts#192

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2221)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/paranext/paranext-core/pull/2221" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
