### PR TITLE
ci(chromatic): Fix Chromatic workflow — CLI v16 flag conflict + project-token secret

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Run Chromatic
         uses: chromaui/action@v16
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN_10_POWER }}
           buildScriptName: storybook:build
           # onlyStoryFiles and onlyChanged are mutually exclusive in Chromatic CLI v16.
           # The story filter (from .chromatic-story-filter or the default) is what scopes

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -65,8 +65,11 @@ jobs:
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           buildScriptName: storybook:build
+          # onlyStoryFiles and onlyChanged are mutually exclusive in Chromatic CLI v16.
+          # The story filter (from .chromatic-story-filter or the default) is what scopes
+          # the review to the relevant feature; onlyChanged was redundant and caused the
+          # CLI to reject the flags combination.
           onlyStoryFiles: ${{ steps.story_filter.outputs.glob }}
-          onlyChanged: true
           exitZeroOnChanges: true
         env:
           CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}


### PR DESCRIPTION
## Summary

Two related fixes to `.github/workflows/chromatic.yml` so the Chromatic job on AI-branch PRs actually works and uploads to the right project. Both surfaced during the markers-checklist P3D.3 gate review (paranext-core PR #2219).

## Fixes

### 1. Drop `onlyChanged: true` — conflicts with `onlyStoryFiles` in CLI v16

Chromatic CLI v16 rejects the combination of `--only-changed` and `--only-story-files` with:
```
✖ You can only use one of --only-changed, --only-story-files
```

The workflow was passing both, so the job failed on every PR using a `.chromatic-story-filter` file (and would also fail on the default broad glob, since the workflow always sets both flags).

`onlyStoryFiles` already scopes the review to the relevant file set; `onlyChanged` was redundant. Dropped it and added a comment explaining why.

### 2. Use `CHROMATIC_PROJECT_TOKEN_10_POWER` secret

The previous `CHROMATIC_PROJECT_TOKEN` secret pointed to a Chromatic project used by other contributors / other purposes (appId `69dfa41711447a20f4150e60` — an orphaned, setup-incomplete project), not the repo's canonical Chromatic project (`69cced5e253bf364823cfb83`, the one with GitHub App integration).

Effect before fix: Chromatic job succeeded but uploaded to the wrong project, so the Storybook URL posted on the PR returned 404 and the dashboard showed no builds. The repo owner has created a new project-scoped secret `CHROMATIC_PROJECT_TOKEN_10_POWER` pointing at the correct project.

## Impact

- Restores functionality to the Chromatic workflow on all AI feature branches with the `storybook-review` label
- Uploads now land in the canonical project so the PR-posted URL resolves and the builds show up on the dashboard
- No change to review scope semantics (story files are still filtered to the relevant set)
- No change for contributors who use the old secret in other workflows (secret still exists; this workflow just uses a different one)

## Discovery

Found on the markers-checklist feature PR #2219. The Chromatic job failed twice, then succeeded but uploaded to the wrong project. Three pushes were needed to figure out the full picture:
1. Multi-line filter file (fixed on feature branch PR #2219, not part of this PR)
2. `--only-changed` / `--only-story-files` conflict (**this PR — fix 1**)
3. Token pointing to wrong project (**this PR — fix 2**)

Both workflow-file fixes are already committed on the feature branch (PR #2219) to unblock that feature's Chromatic run immediately. This PR applies the same fixes to `ai/main` so future features inherit them without re-committing.

## Test Plan

- [x] Chromatic workflow re-runs on the markers-checklist feature branch succeed once the secret-rename lands (token updated separately by repo owner in GitHub Settings → Secrets)
- [ ] No regression on Chromatic runs for features without `.chromatic-story-filter` (they'll use the default `extensions/src/**/*.stories.tsx` glob — still scoped, just broader)
- [ ] Builds show up on the correct Chromatic project dashboard (appId `69cced5e253bf364823cfb83`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2227)
<!-- Reviewable:end -->
