### PR TITLE
feat: add shadcn AlertDialog component to platform-bible-react

### DIFF
--- a/.erb/scripts/refresh.sh
+++ b/.erb/scripts/refresh.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Quick app refresh - stops, rebuilds, and restarts Platform.Bible with CDP enabled
+# This is a FAST operation (~30s). Agents should run this freely without optimization concerns.
+set -e
+cd "$(dirname "$0")/../.."
+
+echo "Stopping app..."
+npm stop 2>/dev/null || true
+
+echo "Building..."
+npm run build
+
+
+# Safety net: Claude Code / VS Code set this, which makes Electron act as plain Node.js
+unset ELECTRON_RUN_AS_NODE
+
+# Start with CDP enabled. On Linux, use xvfb for headless operation.
+# On macOS (and other platforms without xvfb), show the GUI window.
+if command -v xvfb-run >/dev/null 2>&1; then
+  echo "Starting with CDP enabled (headless via xvfb)..."
+  xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
+      env MAIN_ARGS="--remote-debugging-port=9223 --maximize" npm start &
+else
+  echo "Starting with CDP enabled (visible window — xvfb not available)..."
+  env MAIN_ARGS="--remote-debugging-port=9223 --maximize" npm start &
+fi
+APP_PID=$!
+
+# Kill the background process on failure/exit
+cleanup() {
+  if kill -0 "$APP_PID" 2>/dev/null; then
+    echo "Cleaning up background process $APP_PID..."
+    kill "$APP_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+# Wait for all ports (max 3 minutes)
+echo "Waiting for app to be ready..."
+for i in {1..36}; do
+  RENDERER=$(curl -s -m 2 http://localhost:1212 > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+  WS=$(curl -s -m 2 http://localhost:8876 > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+  CDP=$(curl -s -m 2 http://localhost:9223/json > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+  if [ "$RENDERER" = "UP" ] && [ "$WS" = "UP" ] && [ "$CDP" = "UP" ]; then
+    echo "✓ App ready (Renderer: $RENDERER, WebSocket: $WS, CDP: $CDP)"
+    # Disable the trap — app should keep running after successful startup
+    trap - EXIT
+    exit 0
+  fi
+  echo "  Waiting... (Renderer: $RENDERER, WebSocket: $WS, CDP: $CDP)"
+  sleep 5
+done
+echo "✗ Timeout waiting for app"
+exit 1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -63,10 +63,13 @@ jobs:
       - name: Run Chromatic
         uses: chromaui/action@v16
         with:
-          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN_10_POWER }}
           buildScriptName: storybook:build
+          # onlyStoryFiles and onlyChanged are mutually exclusive in Chromatic CLI v16.
+          # The story filter (from .chromatic-story-filter or the default) is what scopes
+          # the review to the relevant feature; onlyChanged was redundant and caused the
+          # CLI to reject the flags combination.
           onlyStoryFiles: ${{ steps.story_filter.outputs.glob }}
-          onlyChanged: true
           exitZeroOnChanges: true
         env:
           CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,74 @@
+name: Chromatic
+
+on:
+  pull_request:
+    types: [labeled, synchronize]
+    branches: [ai/main]
+
+jobs:
+  chromatic:
+    name: Publish to Chromatic
+    # Only run when the 'storybook-review' label is present
+    if: contains(github.event.pull_request.labels.*.name, 'storybook-review')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read package.json
+        id: package_json
+        uses: zoexx/github-action-json-file-properties@1.0.6
+        with:
+          file_path: 'package.json'
+
+      - name: Checkout scripture-editors
+        uses: actions/checkout@v4
+        with:
+          repository: eten-tech-foundation/scripture-editors
+          ref: platform-yalc
+          path: dev-packages/scripture-editors
+
+      - name: Install Volta and toolchain
+        uses: volta-cli/action@v4
+
+      - name: Install scripture-editors dependencies
+        env:
+          VOLTA_FEATURE_PNPM: '1'
+        run: |
+          cd dev-packages/scripture-editors
+          pnpm install
+
+      - name: Install Node.js and NPM
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ fromJson(steps.package_json.outputs.volta).node }}
+          cache: npm
+
+      - name: Install packages and build
+        run: |
+          npm ci
+          npm run build
+
+      - name: Read story filter
+        id: story_filter
+        run: |
+          if [ -f .chromatic-story-filter ]; then
+            echo "glob=$(cat .chromatic-story-filter)" >> "$GITHUB_OUTPUT"
+          else
+            echo "glob=extensions/src/**/*.stories.tsx" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Run Chromatic
+        uses: chromaui/action@v16
+        with:
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          buildScriptName: storybook:build
+          onlyStoryFiles: ${{ steps.story_filter.outputs.glob }}
+          onlyChanged: true
+          exitZeroOnChanges: true
+        env:
+          CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          CHROMATIC_SLUG: ${{ github.repository }}

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,16 @@ CLAUDE.md
 CLAUDE.md.backup
 
 .review
+
+# Secrets & credentials
+.env
+.env.*
+.env.local
+.env.*.local
+secrets/
+*.pem
+*.key
+*.pfx
+*.p12
+credentials.json
+service-account.json

--- a/.husky/lib/ai-hooks.sh
+++ b/.husky/lib/ai-hooks.sh
@@ -46,10 +46,78 @@ validate_branch_name() {
   fi
 }
 
+# Determine which npm workspaces need typechecking based on staged TS files.
+#
+# Rules (B1 hybrid — see .claude/rules/* or commit history for rationale):
+#   1. Staged files in lib/*, extensions/, extensions/src/* → include their workspace
+#   2. If ANY lib/* workspace is included → also include ALL extensions/* workspaces
+#      (extensions depend on lib, so lib changes can break extension consumers)
+#   3. Staged TS files outside any npm workspace (e.g., e2e-tests/, scripts/) are
+#      covered by `npm run typecheck:core`; they add no workspace to the list.
+#
+# Prints space-separated list of `--workspace=<path>` flags, or empty if nothing applies.
+compute_affected_workspaces() {
+  local files changed_workspaces lib_changed=0
+  files=$(get_staged_files | grep -E '\.(ts|tsx)$' || true)
+  if [ -z "$files" ]; then
+    return 0
+  fi
+
+  # Collect workspaces that contain staged TS files.
+  # NF guards ensure the path has at least one segment under the parent
+  # directory (e.g. lib/foo/bar.ts → "lib/foo", but lib/foo.ts at the
+  # top level — which isn't a valid workspace — falls through to the
+  # `extensions` fallback or is skipped).
+  changed_workspaces=$(
+    echo "$files" | awk -F/ '
+      /^lib\// && NF >= 3 { print "lib/" $2; next }
+      /^extensions\/src\// && NF >= 4 { print "extensions/src/" $3; next }
+      /^extensions\// && NF >= 2 { print "extensions"; next }
+    ' | sort -u
+  )
+
+  if echo "$changed_workspaces" | grep -q '^lib/'; then
+    lib_changed=1
+  fi
+
+  # If any lib/* workspace changed, expand to include all extensions/* workspaces
+  # (extensions consume lib via workspace symlinks — consumer types can break).
+  if [ "$lib_changed" = "1" ]; then
+    local all_extensions
+    all_extensions=$(ls -d extensions/src/*/ 2>/dev/null | sed 's|/$||')
+    changed_workspaces=$(printf '%s\n%s\n' "$changed_workspaces" "$all_extensions" | sort -u)
+  fi
+
+  # Emit as --workspace=<path> flags.
+  echo "$changed_workspaces" | while IFS= read -r ws; do
+    [ -n "$ws" ] && printf -- '--workspace=%s ' "$ws"
+  done
+}
+
 run_typecheck() {
   echo "Running TypeScript type checking..."
-  if ! npm run typecheck 2>&1; then
-    error_msg "AI-001" "TypeScript type checking failed" "Run 'npm run typecheck' to see errors"
+
+  # Always run root typecheck (covers src/main, src/renderer, src/extension-host,
+  # src/shared, and any non-workspace TS like e2e-tests/).
+  if ! npm run typecheck:core 2>&1; then
+    error_msg "AI-001" "TypeScript type checking failed (root)" "Run 'npm run typecheck:core' to see errors"
+    return $AI_EXIT_TYPECHECK
+  fi
+
+  # Scope workspace typecheck to workspaces affected by staged files (B1 hybrid).
+  local ws_flags
+  ws_flags=$(compute_affected_workspaces)
+
+  if [ -z "$ws_flags" ]; then
+    echo "No workspace TS files staged, skipping workspace typecheck"
+    echo "TypeScript type checking passed"
+    return 0
+  fi
+
+  echo "Typechecking affected workspaces: $ws_flags"
+  # shellcheck disable=SC2086  # Intentional word-splitting on ws_flags
+  if ! npm run typecheck $ws_flags --if-present 2>&1; then
+    error_msg "AI-001" "TypeScript type checking failed (workspace)" "Run 'npm run typecheck' to see errors"
     return $AI_EXIT_TYPECHECK
   fi
   echo "TypeScript type checking passed"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,6 +1,39 @@
 #!/usr/bin/env sh
 
 # ============================================
+# Secret scanning (ALL branches)
+# ============================================
+if ! command -v gitleaks >/dev/null 2>&1; then
+  echo ""
+  echo "=========================================="
+  echo "ERROR: gitleaks is not installed"
+  echo "=========================================="
+  echo "gitleaks is required to prevent committing secrets to this public repository."
+  echo ""
+  echo "Install it:"
+  echo "  macOS:   brew install gitleaks"
+  echo "  Windows: winget install Gitleaks.Gitleaks"
+  echo "  Linux:   https://github.com/gitleaks/gitleaks/releases"
+  echo ""
+  echo "Then retry your commit."
+  echo "=========================================="
+  exit 1
+fi
+
+echo "Scanning for secrets..."
+if ! gitleaks git --pre-commit --staged --no-banner; then
+  echo ""
+  echo "=========================================="
+  echo "SECRET DETECTED — commit blocked"
+  echo "=========================================="
+  echo "Remove the secret from your staged files before committing."
+  echo "See above for the file and line number."
+  echo "=========================================="
+  exit 1
+fi
+echo "No secrets found"
+
+# ============================================
 # Standard hooks (ALL branches)
 # ============================================
 echo "Format and stylelint fixes..."

--- a/README.md
+++ b/README.md
@@ -77,9 +77,21 @@ Set up pre-requisites, build, and run:
    # 8.0.412 (or similar 8.* version)
    ```
 
-3. Prerequisites for macOS or Linux (below).
+3. Install [`gitleaks`](https://github.com/gitleaks/gitleaks). The pre-commit hook runs `gitleaks` on staged files to block accidental secret commits — without it, every `git commit` fails.
 
-4. Clone, install, build, and run (below).
+   - **macOS**: `brew install gitleaks`
+   - **Windows**: `winget install Gitleaks.Gitleaks`
+   - **Linux**: download a prebuilt binary from the [releases page](https://github.com/gitleaks/gitleaks/releases) and place it on your `PATH` (e.g., `~/.local/bin/gitleaks`), or `sudo apt install gitleaks` on Ubuntu 24.04+.
+
+   To verify:
+
+   ```bash
+   gitleaks version
+   ```
+
+4. Prerequisites for macOS or Linux (below).
+
+5. Clone, install, build, and run (below).
 
 ### Linux Development Pre-requisites
 

--- a/c-sharp-tests/DummyScrText.cs
+++ b/c-sharp-tests/DummyScrText.cs
@@ -21,7 +21,10 @@ namespace TestParanextDataProvider
                 new ProjectName
                 {
                     ShortName = projectDetails.Name,
-                    ProjectPath = projectDetails.HomeDirectory
+                    ProjectPath = EnsureNonEmptyHomeDirectory(
+                        projectDetails.HomeDirectory,
+                        projectDetails.Metadata.Id
+                    ),
                 },
                 RegistrationInfo.DefaultUser
             )
@@ -30,7 +33,10 @@ namespace TestParanextDataProvider
             projectName = new ProjectName
             {
                 ShortName = projectDetails.Name + _id,
-                ProjectPath = projectDetails.HomeDirectory
+                ProjectPath = EnsureNonEmptyHomeDirectory(
+                    projectDetails.HomeDirectory,
+                    projectDetails.Metadata.Id
+                ),
             };
 
             Settings.Editable = true;
@@ -49,13 +55,46 @@ namespace TestParanextDataProvider
         }
 
         public DummyScrText()
-            : this(
-                new ProjectDetails(
-                    "Dummy",
-                    new ProjectMetadata(HexId.CreateNew().ToString(), []),
-                    ""
-                )
-            ) { }
+            : this(CreateUniqueDummyDetails()) { }
+
+        /// <summary>
+        /// Build <see cref="ProjectDetails"/> with a unique, non-empty
+        /// <see cref="ProjectDetails.HomeDirectory"/> per invocation.
+        /// </summary>
+        /// <remarks>
+        /// Using an empty <c>HomeDirectory</c> causes multiple instances to
+        /// share the same <c>ProjectPath</c> on the resulting <c>ScrText</c>.
+        /// When several such instances are added to the global
+        /// <c>ScrTextCollection</c> via <c>FakeAddProject</c>, internal
+        /// path-indexed lookups inside
+        /// <c>ScrTextCollection.RefreshScrTextsInternal</c> fail a
+        /// <c>SingleOrDefault</c> call with "Sequence contains more than one
+        /// matching element" the next time <c>ParatextData.Initialize</c> is
+        /// called — even after the tests that added them have completed and
+        /// called <c>ScrTextCollection.Remove</c>. A unique non-empty path
+        /// per instance sidesteps the collision entirely.
+        /// </remarks>
+        private static ProjectDetails CreateUniqueDummyDetails()
+        {
+            var id = HexId.CreateNew().ToString();
+            return new ProjectDetails("Dummy", new ProjectMetadata(id, []), "testDirectory_" + id);
+        }
+
+        /// <summary>
+        /// Returns <paramref name="homeDirectory"/> when non-empty; otherwise
+        /// returns a unique fake path derived from <paramref name="id"/>.
+        /// </summary>
+        /// <remarks>
+        /// Idempotent: for a given <paramref name="id"/>, multiple calls with
+        /// an empty <paramref name="homeDirectory"/> return the same
+        /// substituted path, so the constructor's two invocations (for the
+        /// <c>base(...)</c> call and the field assignment) stay consistent.
+        /// Protects all callers of the parameterized constructor — not just
+        /// the parameterless overload — from the collision described on
+        /// <see cref="CreateUniqueDummyDetails"/>.
+        /// </remarks>
+        private static string EnsureNonEmptyHomeDirectory(string homeDirectory, string id) =>
+            string.IsNullOrEmpty(homeDirectory) ? "testDirectory_" + id : homeDirectory;
 
         protected override void Load(bool ignoreLoadErrors = false)
         {
@@ -74,7 +113,7 @@ namespace TestParanextDataProvider
                 {
                     FullName = "Test ScrText",
                     MinParatextDataVersion = ParatextInfo.MinSupportedParatextDataVersion,
-                    Guid = _id
+                    Guid = _id,
                 };
 
             return settings;

--- a/c-sharp-tests/DummyScrTextTests.cs
+++ b/c-sharp-tests/DummyScrTextTests.cs
@@ -1,0 +1,123 @@
+using System.Diagnostics.CodeAnalysis;
+using Paranext.DataProvider.Projects;
+using Paratext.Data;
+using PtxUtils;
+
+namespace TestParanextDataProvider
+{
+    /// <summary>
+    /// Regression guard for the <see cref="DummyScrText"/> constructor's
+    /// empty-<c>HomeDirectory</c> handling. Pins the invariant that every
+    /// <see cref="DummyScrText"/> has a non-empty, unique <c>ProjectPath</c>
+    /// even when the test author passes (or the parameterless constructor
+    /// builds) a <see cref="ProjectDetails"/> with an empty
+    /// <c>HomeDirectory</c>.
+    /// </summary>
+    /// <remarks>
+    /// Motivation: multiple <see cref="DummyScrText"/> instances that share
+    /// an empty <c>ProjectPath</c> collide inside
+    /// <c>ScrTextCollection.RefreshScrTextsInternal</c>'s path-indexed
+    /// <c>SingleOrDefault</c> lookup. The collision surfaces as
+    /// "Sequence contains more than one matching element" thrown from an
+    /// unrelated test's <c>ParatextData.Initialize</c> call long after the
+    /// polluting test has finished. If a future change reintroduces empty
+    /// <c>ProjectPath</c> on <see cref="DummyScrText"/>, this test fails and
+    /// names the invariant explicitly rather than leaving future maintainers
+    /// to rediscover the symptom through a full-suite run.
+    /// </remarks>
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    internal class DummyScrTextTests
+    {
+        [Test]
+        public void ParameterlessConstructor_ProducesNonEmptyProjectPath()
+        {
+            using var scrText = new DummyScrText();
+
+            Assert.That(
+                scrText.Directory,
+                Is.Not.Null.And.Not.Empty,
+                "DummyScrText() must produce a non-empty ProjectPath to avoid "
+                    + "ScrTextCollection path-indexed lookup collisions"
+            );
+        }
+
+        [Test]
+        public void ParameterlessConstructor_TwoInstances_HaveDistinctProjectPaths()
+        {
+            using var a = new DummyScrText();
+            using var b = new DummyScrText();
+
+            Assert.That(
+                a.Directory,
+                Is.Not.EqualTo(b.Directory),
+                "Distinct DummyScrText instances must have distinct ProjectPaths"
+            );
+        }
+
+        [Test]
+        public void ParameterizedConstructor_EmptyHomeDirectory_IsSubstituted()
+        {
+            var details = new ProjectDetails(
+                "Dummy",
+                new ProjectMetadata(HexId.CreateNew().ToString(), []),
+                ""
+            );
+
+            using var scrText = new DummyScrText(details);
+
+            Assert.That(
+                scrText.Directory,
+                Is.Not.Null.And.Not.Empty,
+                "DummyScrText(details with empty HomeDirectory) must substitute a "
+                    + "non-empty ProjectPath so that instances do not collide "
+                    + "inside ScrTextCollection's path-indexed lookups"
+            );
+        }
+
+        [Test]
+        public void ParameterizedConstructor_EmptyHomeDirectory_TwoInstances_HaveDistinctProjectPaths()
+        {
+            var detailsA = new ProjectDetails(
+                "DummyA",
+                new ProjectMetadata(HexId.CreateNew().ToString(), []),
+                ""
+            );
+            var detailsB = new ProjectDetails(
+                "DummyB",
+                new ProjectMetadata(HexId.CreateNew().ToString(), []),
+                ""
+            );
+
+            using var a = new DummyScrText(detailsA);
+            using var b = new DummyScrText(detailsB);
+
+            Assert.That(
+                a.Directory,
+                Is.Not.EqualTo(b.Directory),
+                "Two DummyScrTexts built from details that both have empty "
+                    + "HomeDirectory must still end up with distinct ProjectPaths"
+            );
+        }
+
+        [Test]
+        public void ParameterizedConstructor_NonEmptyHomeDirectory_IsPreserved()
+        {
+            const string explicitPath = "some/real/project/path";
+            var details = new ProjectDetails(
+                "Dummy",
+                new ProjectMetadata(HexId.CreateNew().ToString(), []),
+                explicitPath
+            );
+
+            using var scrText = new DummyScrText(details);
+
+            Assert.That(
+                scrText.Directory,
+                Is.EqualTo(explicitPath),
+                "Substitution must only apply to empty HomeDirectory; a caller "
+                    + "that supplies an explicit path must see it preserved"
+            );
+        }
+    }
+}

--- a/c-sharp/JsonUtils/SerializationOptions.cs
+++ b/c-sharp/JsonUtils/SerializationOptions.cs
@@ -1,5 +1,6 @@
 using System.Text.Encodings.Web;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using System.Text.Unicode;
 using SIL.Extensions;
 using StreamJsonRpc;
@@ -30,6 +31,16 @@ internal static class SerializationOptions
         options.Converters.Add(new InventoryTextTypeConverter());
         options.Converters.Add(new RegistrationDataConverter());
         options.Converters.Add(new VerseRefConverter());
+        // Match the PropertyNamingPolicy: TypeScript string-union types on the wire (e.g.
+        // 'chapterVerse', 'copyDestination') correspond to C# enum values (ChapterVerse,
+        // CopyDestination). Without this converter, System.Text.Json only accepts integer
+        // enum values, which breaks any NetworkObject whose request record contains an enum
+        // field (e.g. ManageBooks CreateBooksRequest.CreationMethod, ProjectFilterInput.Purpose).
+        // Registered LAST so any future per-type enum JsonConverter<T> takes precedence —
+        // System.Text.Json resolves Converters in insertion order (first match wins on
+        // CanConvert), and JsonStringEnumConverter.CanConvert returns true for any enum.
+        // Confirmed at runtime via e2e-tests/tests/manage-books/manage-books-commands.spec.ts.
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
         return options;
     }
 

--- a/e2e-tests/fixtures/papi-live.fixture.ts
+++ b/e2e-tests/fixtures/papi-live.fixture.ts
@@ -96,6 +96,7 @@ export async function canConnectToPapi(
 async function connectWebSocket(): Promise<WebSocket> {
   for (let attempt = 1; attempt <= CONNECT_RETRIES; attempt++) {
     try {
+      // Sequential retries require awaiting each connection attempt before trying the next
       // eslint-disable-next-line no-await-in-loop -- intentional retry loop
       const ws = await new Promise<WebSocket>((resolve, reject) => {
         const socket = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}`);
@@ -115,7 +116,7 @@ async function connectWebSocket(): Promise<WebSocket> {
         });
       });
       return ws;
-    } catch (err) {
+    } catch {
       if (attempt === CONNECT_RETRIES) {
         throw new Error(
           `Failed to connect to PAPI WebSocket (ws://localhost:${WEBSOCKET_PORT}) after ${CONNECT_RETRIES} attempts. ` +
@@ -125,6 +126,7 @@ async function connectWebSocket(): Promise<WebSocket> {
       console.log(
         `PAPI WebSocket connection attempt ${attempt}/${CONNECT_RETRIES} failed, retrying in ${CONNECT_RETRY_DELAY_MS}ms...`,
       );
+      // Must wait between retries to give the server time to become available
       // eslint-disable-next-line no-await-in-loop -- intentional retry delay
       await new Promise<void>((resolve) => {
         setTimeout(resolve, CONNECT_RETRY_DELAY_MS);
@@ -185,9 +187,9 @@ export const test = base.extend<PapiLiveFixtures>({
       }
       const id = nextRequestId;
       nextRequestId += 1;
-      // createJSONRPCRequest expects JSONRPCParams (object | array); cast is safe because
-      // our callers always pass arrays (command args) or objects (rpc.discover params)
       const rpcParams: Record<string, unknown> | unknown[] | undefined =
+        // createJSONRPCRequest expects JSONRPCParams (object | array); cast is safe because
+        // our callers always pass arrays (command args) or objects (rpc.discover params)
         // eslint-disable-next-line no-type-assertion/no-type-assertion
         params as Record<string, unknown> | unknown[] | undefined;
       const request: JSONRPCRequest = createJSONRPCRequest(id, method, rpcParams);

--- a/e2e-tests/fixtures/papi-live.fixture.ts
+++ b/e2e-tests/fixtures/papi-live.fixture.ts
@@ -1,0 +1,232 @@
+/**
+ * === NEW IN PT10 === Reason: Standalone PAPI WebSocket fixture for command verification tests
+ * against an already-running Platform.Bible instance.
+ *
+ * Named "papi-live" to distinguish from the deprecated `papi.fixture.ts`:
+ *
+ * - `papi.fixture` launches its own Electron via app.fixture (port 8876 conflict with dev instance)
+ * - `papi-live.fixture` connects to an ALREADY-RUNNING instance (no app launch, no conflict)
+ *
+ * Use this fixture for:
+ *
+ * - Command verification tests (porting workflow runtime verification)
+ * - Any test that needs to call PAPI commands against the running dev instance
+ *
+ * Prerequisite: Platform.Bible running (WebSocket server on port 8876). Tests using this fixture
+ * should include a skip guard via {@link canConnectToPapi} so they gracefully skip in CI or when the
+ * app isn't running.
+ */
+import WebSocket from 'ws';
+import {
+  JSONRPCClient,
+  type JSONRPCRequest,
+  type JSONRPCResponse,
+  createJSONRPCRequest,
+} from 'json-rpc-2.0';
+import { test as base } from '@playwright/test';
+
+export { expect } from '@playwright/test';
+
+const WEBSOCKET_PORT = 8876;
+const CONNECT_TIMEOUT_MS = 2_000;
+const CONNECT_RETRIES = 3;
+const CONNECT_RETRY_DELAY_MS = 2_000;
+
+/** Client interface for PAPI command verification tests. */
+export interface PapiLiveClient {
+  /** Send a PAPI command and return the result. Throws on JSON-RPC errors. */
+  sendCommand<T>(commandName: string, ...args: unknown[]): Promise<T>;
+  /**
+   * Send a PAPI command and return the raw JSON-RPC response (including any error). Use this when
+   * you need to inspect error codes rather than just catching exceptions.
+   */
+  sendCommandRaw(commandName: string, ...args: unknown[]): Promise<JSONRPCResponse>;
+  /** Send a raw JSON-RPC request. Throws on JSON-RPC errors. */
+  request<T>(method: string, params?: unknown): Promise<T>;
+  /** Send a raw JSON-RPC request and return the full JSON-RPC response object. */
+  requestRaw(method: string, params?: unknown): Promise<JSONRPCResponse>;
+  /** Close the WebSocket connection. Called automatically during fixture teardown. */
+  close(): void;
+}
+
+/** All fixtures exposed by the papi-live fixture. */
+export interface PapiLiveFixtures {
+  papiLive: PapiLiveClient;
+}
+
+/**
+ * Check whether the PAPI WebSocket server is reachable. Use this in `test.beforeAll` to skip tests
+ * gracefully when the app isn't running:
+ *
+ * @example
+ *
+ * ```ts
+ * import { canConnectToPapi } from '../../fixtures/papi-live.fixture';
+ *
+ * test.beforeAll(async () => {
+ *   test.skip(!(await canConnectToPapi()), 'PAPI server not running');
+ * });
+ * ```
+ */
+export async function canConnectToPapi(
+  port: number = WEBSOCKET_PORT,
+  timeout: number = CONNECT_TIMEOUT_MS,
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    const ws = new WebSocket(`ws://localhost:${port}`);
+    const timer = setTimeout(() => {
+      ws.close();
+      resolve(false);
+    }, timeout);
+
+    ws.on('open', () => {
+      clearTimeout(timer);
+      ws.close();
+      resolve(true);
+    });
+    ws.on('error', () => {
+      clearTimeout(timer);
+      ws.close();
+      resolve(false);
+    });
+  });
+}
+
+/** Connect a WebSocket to the PAPI server with retry logic. Throws after all retries are exhausted. */
+async function connectWebSocket(): Promise<WebSocket> {
+  for (let attempt = 1; attempt <= CONNECT_RETRIES; attempt++) {
+    try {
+      // eslint-disable-next-line no-await-in-loop -- intentional retry loop
+      const ws = await new Promise<WebSocket>((resolve, reject) => {
+        const socket = new WebSocket(`ws://localhost:${WEBSOCKET_PORT}`);
+        const timer = setTimeout(() => {
+          socket.close();
+          reject(new Error('WebSocket connection timeout'));
+        }, CONNECT_TIMEOUT_MS);
+
+        socket.on('open', () => {
+          clearTimeout(timer);
+          resolve(socket);
+        });
+        socket.on('error', (err) => {
+          clearTimeout(timer);
+          socket.close();
+          reject(err);
+        });
+      });
+      return ws;
+    } catch (err) {
+      if (attempt === CONNECT_RETRIES) {
+        throw new Error(
+          `Failed to connect to PAPI WebSocket (ws://localhost:${WEBSOCKET_PORT}) after ${CONNECT_RETRIES} attempts. ` +
+            `Is Platform.Bible running? Start it with: ./refresh.sh`,
+        );
+      }
+      console.log(
+        `PAPI WebSocket connection attempt ${attempt}/${CONNECT_RETRIES} failed, retrying in ${CONNECT_RETRY_DELAY_MS}ms...`,
+      );
+      // eslint-disable-next-line no-await-in-loop -- intentional retry delay
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, CONNECT_RETRY_DELAY_MS);
+      });
+    }
+  }
+  // Unreachable, but TypeScript needs it
+  throw new Error('Unexpected: exhausted retries without throwing');
+}
+
+export const test = base.extend<PapiLiveFixtures>({
+  // Playwright fixtures require destructured parameter even when no dependencies are needed
+  // eslint-disable-next-line no-empty-pattern
+  papiLive: async ({}, use) => {
+    const ws = await connectWebSocket();
+    let nextRequestId = 1;
+
+    // Track connection state for clear error messages on mid-test disconnection
+    let connected = true;
+    ws.on('close', () => {
+      connected = false;
+    });
+    ws.on('error', (err) => {
+      console.error('PAPI WebSocket error:', err);
+      connected = false;
+    });
+
+    // Create JSON-RPC client with the WebSocket transport.
+    // Timeout is applied per-request via jsonRpcClient.timeout() rather than globally.
+    const jsonRpcClient = new JSONRPCClient((jsonRPCRequest) => {
+      if (!connected) {
+        return Promise.reject(
+          new Error(
+            'PAPI connection lost — the .NET data provider may have crashed. Check c-sharp logs.',
+          ),
+        );
+      }
+      ws.send(JSON.stringify(jsonRPCRequest));
+      return Promise.resolve();
+    });
+
+    // Route incoming messages to the JSON-RPC client
+    ws.on('message', (data) => {
+      try {
+        const response = JSON.parse(data.toString());
+        jsonRpcClient.receive(response);
+      } catch (err) {
+        console.error('Failed to parse PAPI response:', err);
+      }
+    });
+
+    /** Build a JSONRPCRequest and send it via requestAdvanced for raw response access. */
+    async function sendRaw(method: string, params?: unknown): Promise<JSONRPCResponse> {
+      if (!connected) {
+        throw new Error(
+          'PAPI connection lost — the .NET data provider may have crashed. Check c-sharp logs.',
+        );
+      }
+      const id = nextRequestId;
+      nextRequestId += 1;
+      // createJSONRPCRequest expects JSONRPCParams (object | array); cast is safe because
+      // our callers always pass arrays (command args) or objects (rpc.discover params)
+      const rpcParams: Record<string, unknown> | unknown[] | undefined =
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        params as Record<string, unknown> | unknown[] | undefined;
+      const request: JSONRPCRequest = createJSONRPCRequest(id, method, rpcParams);
+      return jsonRpcClient.requestAdvanced(request);
+    }
+
+    const papiLive: PapiLiveClient = {
+      async sendCommand<T>(commandName: string, ...args: unknown[]): Promise<T> {
+        // json-rpc-2.0 returns PromiseLike<unknown>; caller provides T
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        return jsonRpcClient.request(`command:${commandName}`, args) as Promise<T>;
+      },
+
+      async sendCommandRaw(commandName: string, ...args: unknown[]): Promise<JSONRPCResponse> {
+        return sendRaw(`command:${commandName}`, args);
+      },
+
+      async request<T>(method: string, params?: unknown): Promise<T> {
+        // json-rpc-2.0 returns PromiseLike<unknown>; caller provides T
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        return jsonRpcClient.request(method, params) as Promise<T>;
+      },
+
+      async requestRaw(method: string, params?: unknown): Promise<JSONRPCResponse> {
+        return sendRaw(method, params);
+      },
+
+      close() {
+        ws.close();
+      },
+    };
+
+    await use(papiLive);
+
+    // Fixture teardown: close the WebSocket cleanly
+    try {
+      ws.close();
+    } catch {
+      // Ignore close errors during cleanup — connection may already be gone
+    }
+  },
+});

--- a/lib/platform-bible-react/package.json
+++ b/lib/platform-bible-react/package.json
@@ -76,6 +76,7 @@
     "@lexical/react": "~0.43.0",
     "@lexical/rich-text": "~0.43.0",
     "@lexical/table": "~0.43.0",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.9",
     "@radix-ui/react-checkbox": "^1.3.1",
     "@radix-ui/react-context-menu": "^2.2.15",

--- a/lib/platform-bible-react/src/components/shadcn-ui/alert-dialog.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/alert-dialog.tsx
@@ -6,6 +6,7 @@ import { cn } from '@/utils/shadcn-ui.util';
 import { readDirection } from '@/utils/dir-helper.util';
 import { buttonVariants } from '@/components/shadcn-ui/button';
 
+// CUSTOM: JSDoc comments added to all exports for documentation (root JSDoc + @inheritdoc)
 /**
  * AlertDialog components display a modal dialog that interrupts the user with important content and
  * expects a response. These components are built and styled with Shadcn UI. See Shadcn UI
@@ -51,6 +52,7 @@ const AlertDialogContent = React.forwardRef<
       <AlertDialogPrimitive.Content
         ref={ref}
         className={cn(
+          // CUSTOM: Add `pr-twp` to scope tailwind preflight to portalled content
           // CUSTOM: Remove tw-z-50 and replace with shared Z_INDEX_MODAL constant (see style)
           'pr-twp tw-fixed tw-left-[50%] tw-top-[50%] tw-grid tw-w-full tw-max-w-lg tw-translate-x-[-50%] tw-translate-y-[-50%] tw-gap-4 tw-border tw-bg-background tw-p-6 tw-shadow-lg tw-duration-200 data-[state=open]:tw-animate-in data-[state=closed]:tw-animate-out data-[state=closed]:tw-fade-out-0 data-[state=open]:tw-fade-in-0 data-[state=closed]:tw-zoom-out-95 data-[state=open]:tw-zoom-in-95 data-[state=closed]:tw-slide-out-to-left-1/2 data-[state=closed]:tw-slide-out-to-top-[48%] data-[state=open]:tw-slide-in-from-left-1/2 data-[state=open]:tw-slide-in-from-top-[48%] sm:tw-rounded-lg',
           className,

--- a/lib/platform-bible-react/src/components/shadcn-ui/alert-dialog.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/alert-dialog.tsx
@@ -70,7 +70,8 @@ AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 function AlertDialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn('tw-flex tw-flex-col tw-space-y-2 tw-text-center sm:tw-text-left', className)}
+      // CUSTOM: Use logical `tw-text-start` (mirrors DialogHeader) so RTL respects dir=rtl
+      className={cn('tw-flex tw-flex-col tw-space-y-2 tw-text-center sm:tw-text-start', className)}
       {...props}
     />
   );

--- a/lib/platform-bible-react/src/components/shadcn-ui/alert-dialog.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/alert-dialog.tsx
@@ -1,0 +1,140 @@
+import React from 'react';
+import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
+
+import { cn } from '@/utils/shadcn-ui.util';
+import { buttonVariants } from '@/components/shadcn-ui/button';
+
+/**
+ * AlertDialog components display a modal dialog that interrupts the user with important content and
+ * expects a response. These components are built and styled with Shadcn UI. See Shadcn UI
+ * Documentation: https://ui.shadcn.com/docs/components/alert-dialog
+ */
+const AlertDialog = AlertDialogPrimitive.Root;
+
+/** @inheritdoc AlertDialog */
+const AlertDialogTrigger = AlertDialogPrimitive.Trigger;
+
+/** @inheritdoc AlertDialog */
+const AlertDialogPortal = AlertDialogPrimitive.Portal;
+
+/** @inheritdoc AlertDialog */
+const AlertDialogOverlay = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Overlay
+    className={cn(
+      'tw-fixed tw-inset-0 tw-z-50 tw-bg-black/80 data-[state=open]:tw-animate-in data-[state=closed]:tw-animate-out data-[state=closed]:tw-fade-out-0 data-[state=open]:tw-fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
+
+/** @inheritdoc AlertDialog */
+const AlertDialogContent = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPortal>
+    <AlertDialogOverlay />
+    <AlertDialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        'pr-twp tw-fixed tw-left-[50%] tw-top-[50%] tw-z-50 tw-grid tw-w-full tw-max-w-lg tw-translate-x-[-50%] tw-translate-y-[-50%] tw-gap-4 tw-border tw-bg-background tw-p-6 tw-shadow-lg tw-duration-200 data-[state=open]:tw-animate-in data-[state=closed]:tw-animate-out data-[state=closed]:tw-fade-out-0 data-[state=open]:tw-fade-in-0 data-[state=closed]:tw-zoom-out-95 data-[state=open]:tw-zoom-in-95 data-[state=closed]:tw-slide-out-to-left-1/2 data-[state=closed]:tw-slide-out-to-top-[48%] data-[state=open]:tw-slide-in-from-left-1/2 data-[state=open]:tw-slide-in-from-top-[48%] sm:tw-rounded-lg',
+        className,
+      )}
+      {...props}
+    />
+  </AlertDialogPortal>
+));
+AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
+
+/** @inheritdoc AlertDialog */
+function AlertDialogHeader({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('tw-flex tw-flex-col tw-space-y-2 tw-text-center sm:tw-text-left', className)}
+      {...props}
+    />
+  );
+}
+AlertDialogHeader.displayName = 'AlertDialogHeader';
+
+/** @inheritdoc AlertDialog */
+function AlertDialogFooter({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn(
+        'tw-flex tw-flex-col-reverse sm:tw-flex-row sm:tw-justify-end sm:tw-space-x-2',
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+AlertDialogFooter.displayName = 'AlertDialogFooter';
+
+/** @inheritdoc AlertDialog */
+const AlertDialogTitle = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Title
+    ref={ref}
+    className={cn('tw-text-lg tw-font-semibold', className)}
+    {...props}
+  />
+));
+AlertDialogTitle.displayName = AlertDialogPrimitive.Title.displayName;
+
+/** @inheritdoc AlertDialog */
+const AlertDialogDescription = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Description
+    ref={ref}
+    className={cn('tw-text-sm tw-text-muted-foreground', className)}
+    {...props}
+  />
+));
+AlertDialogDescription.displayName = AlertDialogPrimitive.Description.displayName;
+
+/** @inheritdoc AlertDialog */
+const AlertDialogAction = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Action>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Action>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Action ref={ref} className={cn(buttonVariants(), className)} {...props} />
+));
+AlertDialogAction.displayName = AlertDialogPrimitive.Action.displayName;
+
+/** @inheritdoc AlertDialog */
+const AlertDialogCancel = React.forwardRef<
+  React.ElementRef<typeof AlertDialogPrimitive.Cancel>,
+  React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Cancel>
+>(({ className, ...props }, ref) => (
+  <AlertDialogPrimitive.Cancel
+    ref={ref}
+    className={cn(buttonVariants({ variant: 'outline' }), 'tw-mt-2 sm:tw-mt-0', className)}
+    {...props}
+  />
+));
+AlertDialogCancel.displayName = AlertDialogPrimitive.Cancel.displayName;
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+};

--- a/lib/platform-bible-react/src/components/shadcn-ui/alert-dialog.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/alert-dialog.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import * as AlertDialogPrimitive from '@radix-ui/react-alert-dialog';
 
+import { Z_INDEX_MODAL, Z_INDEX_MODAL_BACKDROP } from '@/components/z-index';
 import { cn } from '@/utils/shadcn-ui.util';
+import { readDirection } from '@/utils/dir-helper.util';
 import { buttonVariants } from '@/components/shadcn-ui/button';
 
 /**
@@ -21,12 +23,15 @@ const AlertDialogPortal = AlertDialogPrimitive.Portal;
 const AlertDialogOverlay = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
+>(({ className, style, ...props }, ref) => (
   <AlertDialogPrimitive.Overlay
     className={cn(
-      'tw-fixed tw-inset-0 tw-z-50 tw-bg-black/80 data-[state=open]:tw-animate-in data-[state=closed]:tw-animate-out data-[state=closed]:tw-fade-out-0 data-[state=open]:tw-fade-in-0',
+      // CUSTOM: Remove tw-z-50 and replace with shared Z_INDEX_MODAL_BACKDROP constant (see style)
+      'tw-fixed tw-inset-0 tw-bg-black/80 data-[state=open]:tw-animate-in data-[state=closed]:tw-animate-out data-[state=closed]:tw-fade-out-0 data-[state=open]:tw-fade-in-0',
       className,
     )}
+    // CUSTOM: shared z-index scale so modals stack above rc-dock and overlay layers (replaces tw-z-50)
+    style={{ zIndex: Z_INDEX_MODAL_BACKDROP, ...style }}
     {...props}
     ref={ref}
   />
@@ -37,19 +42,28 @@ AlertDialogOverlay.displayName = AlertDialogPrimitive.Overlay.displayName;
 const AlertDialogContent = React.forwardRef<
   React.ElementRef<typeof AlertDialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof AlertDialogPrimitive.Content>
->(({ className, ...props }, ref) => (
-  <AlertDialogPortal>
-    <AlertDialogOverlay />
-    <AlertDialogPrimitive.Content
-      ref={ref}
-      className={cn(
-        'pr-twp tw-fixed tw-left-[50%] tw-top-[50%] tw-z-50 tw-grid tw-w-full tw-max-w-lg tw-translate-x-[-50%] tw-translate-y-[-50%] tw-gap-4 tw-border tw-bg-background tw-p-6 tw-shadow-lg tw-duration-200 data-[state=open]:tw-animate-in data-[state=closed]:tw-animate-out data-[state=closed]:tw-fade-out-0 data-[state=open]:tw-fade-in-0 data-[state=closed]:tw-zoom-out-95 data-[state=open]:tw-zoom-in-95 data-[state=closed]:tw-slide-out-to-left-1/2 data-[state=closed]:tw-slide-out-to-top-[48%] data-[state=open]:tw-slide-in-from-left-1/2 data-[state=open]:tw-slide-in-from-top-[48%] sm:tw-rounded-lg',
-        className,
-      )}
-      {...props}
-    />
-  </AlertDialogPortal>
-));
+>(({ className, style, ...props }, ref) => {
+  // CUSTOM: Read layout direction so the alert dialog respects the app's RTL setting
+  const dir = readDirection();
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        ref={ref}
+        className={cn(
+          // CUSTOM: Remove tw-z-50 and replace with shared Z_INDEX_MODAL constant (see style)
+          'pr-twp tw-fixed tw-left-[50%] tw-top-[50%] tw-grid tw-w-full tw-max-w-lg tw-translate-x-[-50%] tw-translate-y-[-50%] tw-gap-4 tw-border tw-bg-background tw-p-6 tw-shadow-lg tw-duration-200 data-[state=open]:tw-animate-in data-[state=closed]:tw-animate-out data-[state=closed]:tw-fade-out-0 data-[state=open]:tw-fade-in-0 data-[state=closed]:tw-zoom-out-95 data-[state=open]:tw-zoom-in-95 data-[state=closed]:tw-slide-out-to-left-1/2 data-[state=closed]:tw-slide-out-to-top-[48%] data-[state=open]:tw-slide-in-from-left-1/2 data-[state=open]:tw-slide-in-from-top-[48%] sm:tw-rounded-lg',
+          className,
+        )}
+        // CUSTOM: use shared Z_INDEX_MODAL constant
+        style={{ zIndex: Z_INDEX_MODAL, ...style }}
+        {...props}
+        // CUSTOM: pass dir for RTL support (mirrors DialogContent)
+        dir={dir}
+      />
+    </AlertDialogPortal>
+  );
+});
 AlertDialogContent.displayName = AlertDialogPrimitive.Content.displayName;
 
 /** @inheritdoc AlertDialog */

--- a/lib/platform-bible-react/src/index.ts
+++ b/lib/platform-bible-react/src/index.ts
@@ -178,6 +178,19 @@ export type { SpinnerProps } from './components/basics/spinner.component';
 export { default as TextField } from './components/basics/text-field.component';
 export type { TextFieldProps } from './components/basics/text-field.component';
 export { Alert, AlertTitle, AlertDescription } from './components/shadcn-ui/alert';
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+} from './components/shadcn-ui/alert-dialog';
 export { Avatar, AvatarFallback, AvatarImage } from './components/shadcn-ui/avatar';
 export { Badge, type BadgeProps, badgeVariants } from './components/shadcn-ui/badge';
 export { Button, type ButtonProps, buttonVariants } from './components/shadcn-ui/button';

--- a/lib/platform-bible-react/src/stories/shadcn-ui/alert-dialog.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/alert-dialog.stories.tsx
@@ -1,0 +1,157 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { useState } from 'react';
+import { Button } from '@/components/shadcn-ui/button';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/shadcn-ui/alert-dialog';
+import { ThemeProvider } from '@/storybook/theme-provider.component';
+
+const meta: Meta<typeof AlertDialog> = {
+  title: 'Shadcn/AlertDialog',
+  component: AlertDialog,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <ThemeProvider>
+        <Story />
+      </ThemeProvider>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AlertDialog>;
+
+export const Default: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="outline">Show Alert</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This action cannot be undone. This will permanently delete your account and remove your
+            data from our servers.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction>Continue</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A basic alert dialog asking the user to confirm an irreversible action. AlertDialog requires the user to choose Action or Cancel before it can be dismissed (no close button or click-outside-to-dismiss).',
+      },
+    },
+  },
+};
+
+export const Destructive: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button variant="destructive">Delete Project</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete project?</AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete the project and all of its files. This action cannot be
+            undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction className="tw-bg-destructive tw-text-destructive-foreground hover:tw-bg-destructive/90">
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'A destructive confirmation dialog whose Action button uses destructive styling.',
+      },
+    },
+  },
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [open, setOpen] = useState(false);
+
+    return (
+      <>
+        <Button onClick={() => setOpen(true)}>Open Controlled Alert</Button>
+        <AlertDialog open={open} onOpenChange={setOpen}>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Controlled Alert</AlertDialogTitle>
+              <AlertDialogDescription>
+                This alert dialog&apos;s open state is controlled by React state.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel onClick={() => setOpen(false)}>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={() => setOpen(false)}>Confirm</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'An alert dialog with controlled open state using React state.',
+      },
+    },
+  },
+};
+
+export const ActionOnly: Story = {
+  render: () => (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>
+        <Button>Show Notice</Button>
+      </AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Update available</AlertDialogTitle>
+          <AlertDialogDescription>
+            A new version is available. Please review the release notes before continuing.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogAction>OK</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'An informational alert with only an Action button — no Cancel — for acknowledgments where the user must read before continuing.',
+      },
+    },
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1252,6 +1252,7 @@
         "@lexical/react": "~0.43.0",
         "@lexical/rich-text": "~0.43.0",
         "@lexical/table": "~0.43.0",
+        "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.9",
         "@radix-ui/react-checkbox": "^1.3.1",
         "@radix-ui/react-context-menu": "^2.2.15",
@@ -6839,6 +6840,81 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-alert-dialog/-/react-alert-dialog-1.1.15.tgz",
+      "integrity": "sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dialog": "1.1.15",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/primitive": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+      "integrity": "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-alert-dialog/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-arrow": {
       "version": "1.1.6",


### PR DESCRIPTION
NOTE: 
We're not merging this component in until we're sure we actually need it. Some high level reasons to NOT use this:
- The devs have a very strong opinion that all dialogs should be shown through the dialog service if at all possible. There's a good chance current alert and/or confirm dialogs cover what we're looking for.
- The dialog service allows every dialog type to be shown either in modal or non-modal fashion. This component is modal-only, and so in some sense less flexible
- The dialog service was written to basically allow each dialog type to provide a react component to display internally as the content. If the existing dialogs don't render what we're looking for, it might be clearer/cleaner to create a dialog with the content we're looking for.
- ---------------------------------------------

## Summary

Adds the shadcn `AlertDialog` primitive (Radix-based modal confirm dialog with Action/Cancel) to the `platform-bible-react` UI library. Distinct from — and coexisting with — the renderer's existing `AlertDialog` dialog-service component (an OK-only dock-tab dialog shown via `papi.dialogs.showDialog`).

## Changes

- **`src/components/shadcn-ui/alert-dialog.tsx`** — installed via `npx shadcn add alert-dialog`, then aligned to project conventions:
  - Added `pr-twp` to `AlertDialogContent` for tailwind preflight scoping (matches `dialog.tsx` placement)
  - Fixed a stray `tw-` artifact in the overlay class string (shadcn CLI prefix bug)
  - Single quotes / function declarations for `Header`/`Footer` (matches `dialog.tsx`)
  - JSDoc style mirrored from `table.tsx` — root JSDoc with shadcn docs URL on `AlertDialog`, `/** @inheritdoc AlertDialog */` on every other export
- **`src/index.ts`** — re-exports all 11 AlertDialog parts.
- **`src/stories/shadcn-ui/alert-dialog.stories.tsx`** — Storybook stories: `Default`, `Destructive`, `Controlled`, `ActionOnly` (mirrors `dialog.stories.tsx`, uses `tags: ['autodocs']` and `ThemeProvider` decorator).
- **`package.json` / `package-lock.json`** — adds `@radix-ui/react-alert-dialog` dependency.

## Notable customizations not applied (flagged for reviewer)

- **Z-index swap**: `dialog.tsx` replaces the baseline `tw-z-50` with shared `Z_INDEX_MODAL` / `Z_INDEX_MODAL_BACKDROP` constants so modals stack above rc-dock. Not applied here — happy to add in a follow-up if desired.
- **RTL handling**: `dialog.tsx` uses `sm:tw-text-start` and reads `dir` for the close button. AlertDialog has no close button; left as `sm:tw-text-left` from baseline.

## Coexistence with renderer's `AlertDialog`

| | Renderer's `AlertDialog` | This (shadcn) `AlertDialog` |
|--|---|---|
| Layer | `src/renderer/components/dialogs/` (app code) | `lib/platform-bible-react/.../shadcn-ui/` (UI library primitive) |
| Triggered by | `papi.dialogs.showDialog(ALERT_DIALOG_TYPE, …)` | Imported and rendered anywhere in JSX |
| Renders as | docked tab via rc-dock | portalled modal overlay with backdrop + focus trap |
| API | `{ prompt, title, okLabel }` → returns `true` | composable parts (`Trigger`/`Content`/`Action`/`Cancel`/…) |

This PR does **not** refactor the renderer's component — they're different shapes for different needs.

## AI Involvement

**Level**: assisted

- Component file body was generated by `npx shadcn add alert-dialog`; AI applied the project's conventional customizations (`pr-twp`, lint-driven prettier/function-declaration style, JSDoc pattern from `table.tsx`).
- Storybook stories were AI-generated from the dialog.stories.tsx template.
- Index export was AI-added.
- All output reviewed and verified by author. Lint and typecheck both clean; pre-commit AI validations passed.

## Testing

- [x] `npx tsc --noEmit -p ./tsconfig.json` clean (in `lib/platform-bible-react`)
- [x] `npx eslint --cache` clean on changed files
- [x] Pre-commit AI validations (typecheck across affected workspaces, architecture boundaries) passed
- [ ] Manual Storybook verification of the new stories

## Risk Level

Low — additive UI library export, no consumers yet, no behavior change to existing components.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2232)
<!-- Reviewable:end -->

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/paranext/paranext-core/pull/2232" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

Closes paranext/ai-prompts#205
