### PR TITLE
workflow: Allow multi-line .chromatic-story-filter

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -54,11 +54,17 @@ jobs:
       - name: Read story filter
         id: story_filter
         run: |
+          # .chromatic-story-filter may contain one glob per line for
+          # readability; join lines with spaces so the value stays a valid
+          # single-line GITHUB_OUTPUT entry. Chromatic's --only-story-files
+          # is variadic and accepts whitespace-separated filespecs, so the
+          # joined string passes through chromaui/action correctly.
           if [ -f .chromatic-story-filter ]; then
-            echo "glob=$(cat .chromatic-story-filter)" >> "$GITHUB_OUTPUT"
+            glob=$(tr '\n' ' ' < .chromatic-story-filter | sed -e 's/  */ /g' -e 's/^ //' -e 's/ $//')
           else
-            echo "glob=extensions/src/**/*.stories.tsx" >> "$GITHUB_OUTPUT"
+            glob="extensions/src/**/*.stories.tsx"
           fi
+          echo "glob=$glob" >> "$GITHUB_OUTPUT"
 
       - name: Run Chromatic
         uses: chromaui/action@v16


### PR DESCRIPTION
## Summary

The Chromatic workflow read the per-feature filter file with:

```bash
echo "glob=$(cat .chromatic-story-filter)" >> "$GITHUB_OUTPUT"
```

`$GITHUB_OUTPUT` requires single-line `key=value` entries (multi-line values need heredoc-style delimiter syntax), so any filter file with more than one line failed with:

```
##[error]Unable to process file command 'output' successfully.
##[error]Invalid format '<second-line-of-filter>'
```

This recurred on PR #2220 (manage-books) after previously biting markers-checklist (PR #2219). The earlier workaround was to collapse the filter file to a single line per feature — fine when the feature's stories share a directory, but it forces unrelated globs onto one line for features whose stories live in two locations (e.g. manage-books has stories in both `lib/platform-bible-react/...` and `extensions/src/platform-scripture/...`).

## Fix

Join the filter file's lines with spaces before writing to `$GITHUB_OUTPUT`. The output value stays single-line, and Chromatic's `--only-story-files` is variadic (accepts whitespace-separated filespecs), so `chromaui/action` passes the joined string through correctly.

Filter files may now use one glob per line for readability without breaking CI.

## Test plan

- [ ] Verify on PR #2220 (manage-books) that the next Chromatic run reads its 2-line filter and proceeds past the "Read story filter" step
- [ ] Spot-check that the Chromatic build's "Snapshots" count covers stories from both glob lines (manage-books-dialog + greek-esther-template-picker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2237)
<!-- Reviewable:end -->
