### PR TITLE
Add handling for extensions with boolean project settings

### DIFF
--- a/c-sharp-tests/Projects/ParatextProjectDataProviderBooleanSettingTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderBooleanSettingTests.cs
@@ -5,15 +5,9 @@ using Paranext.DataProvider.Projects;
 namespace TestParanextDataProvider.Projects;
 
 /// <summary>
-/// Integration tests for the GetProjectSetting / SetProjectSetting logic that handles extension
-/// project settings registered with a boolean default.
-///
-/// The write path stores a <c>bool</c> as the string <c>"T"</c> / <c>"F"</c>. The read path looks
-/// up the registered default via <c>ProjectSettingsService.GetDefault</c>; when that default is a
-/// JSON boolean, a stored <c>"T"/"F"</c> token is converted back to a real <c>bool</c>. A stored
-/// value that is not one of those tokens is returned as the raw string on purpose (a setting with a
-/// boolean default may legitimately hold a non-boolean value — a union/mixed type), and a setting
-/// with no registered default falls back to returning the raw string.
+/// Tests for GetProjectSetting / SetProjectSetting handling of extension settings registered with a
+/// boolean default: the write path stores a bool as "T"/"F", and the read path converts a stored
+/// "T"/"F" token back to a bool.
 /// </summary>
 [ExcludeFromCodeCoverage]
 [TestFixture]
@@ -21,9 +15,7 @@ internal class ParatextProjectDataProviderBooleanSettingTests : PapiTestBase
 {
     private const string PdpName = "booleanSettingTestProject";
 
-    // An extension setting name that is NOT a known Paratext setting, so it is treated as an
-    // extension setting (its Paratext name equals the Platform.Bible name and it is not in the
-    // known-boolean list).
+    // An extension setting name that is NOT a known Paratext setting.
     private const string BoolSettingName = "myExtension.someBooleanSetting";
 
     private DummyScrText _scrText = null!;
@@ -35,8 +27,7 @@ internal class ParatextProjectDataProviderBooleanSettingTests : PapiTestBase
     {
         await base.TestSetupAsync();
 
-        // Register a stub for ProjectSettingsService.isValid that always approves changes.
-        // SetProjectSetting calls this before writing any value.
+        // SetProjectSetting calls isValid before writing; approve everything.
         await Client.RegisterRequestHandlerAsync(
             "object:ProjectSettingsService.isValid",
             new Func<string, object?, object?, object?, bool>(
@@ -67,28 +58,44 @@ internal class ParatextProjectDataProviderBooleanSettingTests : PapiTestBase
     // Helpers
     // ------------------------------------------------------------------
 
-    /// <summary>
-    /// Registers a stub for ProjectSettingsService.getDefault that returns the given boolean as a
-    /// JSON boolean default (mirroring how an extension registers a boolean-typed default).
-    /// </summary>
-    private void RegisterBooleanDefault(string settingName, bool defaultValue)
-    {
-        Client.RegisterRequestHandlerAsync(
+    /// <summary>Stubs getDefault to return the given bool as a JSON boolean default.</summary>
+    private async Task RegisterBooleanDefault(string settingName, bool defaultValue) =>
+        await Client.RegisterRequestHandlerAsync(
             "object:ProjectSettingsService.getDefault",
             new Func<string, object?>(key =>
                 key == settingName ? JsonSerializer.SerializeToElement(defaultValue) : null
             ),
             null
         );
-    }
+
+    /// <summary>Writes a raw string straight into the project so GetProjectSetting reads it back.</summary>
+    private void SetRawSetting(string settingName, string rawValue) =>
+        _scrText.Settings.ParametersDictionary[settingName] = rawValue;
 
     /// <summary>
-    /// Directly writes a raw string value into the project's ParametersDictionary so that
-    /// GetProjectSetting reads whatever we put there, without going through SetProjectSetting.
+    /// Sets <paramref name="setValue"/>, then asserts it stored as <paramref name="expectedStored"/>
+    /// and reads back as the bool <paramref name="expectedRead"/>.
     /// </summary>
-    private void SetRawSetting(string settingName, string rawValue)
+    private async Task AssertSetRoundTrips(
+        object setValue,
+        bool defaultValue,
+        string expectedStored,
+        bool expectedRead
+    )
     {
-        _scrText.Settings.ParametersDictionary[settingName] = rawValue;
+        await RegisterBooleanDefault(BoolSettingName, defaultValue);
+
+        bool setResult = _provider.SetProjectSetting(BoolSettingName, setValue);
+        string stored = _scrText.Settings.ParametersDictionary[BoolSettingName];
+        object? readBack = _provider.GetProjectSetting(BoolSettingName);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(setResult, Is.True);
+            Assert.That(stored, Is.EqualTo(expectedStored));
+            Assert.That(readBack, Is.TypeOf<bool>());
+            Assert.That(readBack, Is.EqualTo(expectedRead));
+        });
     }
 
     // ------------------------------------------------------------------
@@ -96,64 +103,48 @@ internal class ParatextProjectDataProviderBooleanSettingTests : PapiTestBase
     // ------------------------------------------------------------------
 
     [Test]
-    public void SetThenGetProjectSetting_True_StoresTAndReturnsBoolTrue()
-    {
-        RegisterBooleanDefault(BoolSettingName, false);
-
-        bool result = _provider.SetProjectSetting(BoolSettingName, true);
-        Assert.That(result, Is.True);
-
-        // The value is stored as the string "T".
-        Assert.That(_scrText.Settings.ParametersDictionary[BoolSettingName], Is.EqualTo("T"));
-
-        // Reading it back yields a real boolean true.
-        object? readBack = _provider.GetProjectSetting(BoolSettingName);
-        Assert.That(readBack, Is.TypeOf<bool>());
-        Assert.That(readBack, Is.True);
-    }
+    public Task SetThenGet_NativeBoolTrue() => AssertSetRoundTrips(true, false, "T", true);
 
     [Test]
-    public void SetThenGetProjectSetting_False_StoresFAndReturnsBoolFalse()
-    {
-        RegisterBooleanDefault(BoolSettingName, true);
+    public Task SetThenGet_NativeBoolFalse() => AssertSetRoundTrips(false, true, "F", false);
 
-        bool result = _provider.SetProjectSetting(BoolSettingName, false);
-        Assert.That(result, Is.True);
-
-        // The value is stored as the string "F".
-        Assert.That(_scrText.Settings.ParametersDictionary[BoolSettingName], Is.EqualTo("F"));
-
-        // Reading it back yields a real boolean false.
-        object? readBack = _provider.GetProjectSetting(BoolSettingName);
-        Assert.That(readBack, Is.TypeOf<bool>());
-        Assert.That(readBack, Is.False);
-    }
+    // PAPI deserializes wire values as JsonElement, so these mirror the production path.
+    [Test]
+    public Task SetThenGet_JsonElementTrue() =>
+        AssertSetRoundTrips(JsonSerializer.SerializeToElement(true), false, "T", true);
 
     [Test]
-    public void GetProjectSetting_BooleanDefaultButNonBooleanStoredValue_ReturnsRawString()
+    public Task SetThenGet_JsonElementFalse() =>
+        AssertSetRoundTrips(JsonSerializer.SerializeToElement(false), true, "F", false);
+
+    // A boolean-default setting may legitimately hold a non-boolean value (union type).
+    [Test]
+    public async Task GetProjectSetting_BooleanDefaultButNonBooleanStoredValue_ReturnsRawString()
     {
-        // The setting has a registered boolean default, but the stored value is not a T/F token.
-        // This pins the intentional union-type permissiveness: the raw string is returned, not an
-        // exception.
-        RegisterBooleanDefault(BoolSettingName, false);
+        await RegisterBooleanDefault(BoolSettingName, false);
         SetRawSetting(BoolSettingName, "hello");
 
         object? result = _provider.GetProjectSetting(BoolSettingName);
 
-        Assert.That(result, Is.TypeOf<string>());
-        Assert.That(result, Is.EqualTo("hello"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.TypeOf<string>());
+            Assert.That(result, Is.EqualTo("hello"));
+        });
     }
 
+    // With no registered default, GetDefault throws and the raw string is returned.
     [Test]
     public void GetProjectSetting_NoRegisteredDefault_ReturnsStoredValueAsString()
     {
-        // No getDefault handler is registered, so ProjectSettingsService.GetDefault throws and the
-        // legacy behavior of returning the raw stored string is preserved.
         SetRawSetting(BoolSettingName, "T");
 
         object? result = _provider.GetProjectSetting(BoolSettingName);
 
-        Assert.That(result, Is.TypeOf<string>());
-        Assert.That(result, Is.EqualTo("T"));
+        Assert.Multiple(() =>
+        {
+            Assert.That(result, Is.TypeOf<string>());
+            Assert.That(result, Is.EqualTo("T"));
+        });
     }
 }

--- a/c-sharp-tests/Projects/ParatextProjectDataProviderBooleanSettingTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderBooleanSettingTests.cs
@@ -1,0 +1,159 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Paranext.DataProvider.Projects;
+
+namespace TestParanextDataProvider.Projects;
+
+/// <summary>
+/// Integration tests for the GetProjectSetting / SetProjectSetting logic that handles extension
+/// project settings registered with a boolean default.
+///
+/// The write path stores a <c>bool</c> as the string <c>"T"</c> / <c>"F"</c>. The read path looks
+/// up the registered default via <c>ProjectSettingsService.GetDefault</c>; when that default is a
+/// JSON boolean, a stored <c>"T"/"F"</c> token is converted back to a real <c>bool</c>. A stored
+/// value that is not one of those tokens is returned as the raw string on purpose (a setting with a
+/// boolean default may legitimately hold a non-boolean value — a union/mixed type), and a setting
+/// with no registered default falls back to returning the raw string.
+/// </summary>
+[ExcludeFromCodeCoverage]
+[TestFixture]
+internal class ParatextProjectDataProviderBooleanSettingTests : PapiTestBase
+{
+    private const string PdpName = "booleanSettingTestProject";
+
+    // An extension setting name that is NOT a known Paratext setting, so it is treated as an
+    // extension setting (its Paratext name equals the Platform.Bible name and it is not in the
+    // known-boolean list).
+    private const string BoolSettingName = "myExtension.someBooleanSetting";
+
+    private DummyScrText _scrText = null!;
+    private ProjectDetails _projectDetails = null!;
+    private DummyParatextProjectDataProvider _provider = null!;
+
+    [SetUp]
+    public override async Task TestSetupAsync()
+    {
+        await base.TestSetupAsync();
+
+        // Register a stub for ProjectSettingsService.isValid that always approves changes.
+        // SetProjectSetting calls this before writing any value.
+        await Client.RegisterRequestHandlerAsync(
+            "object:ProjectSettingsService.isValid",
+            new Func<string, object?, object?, object?, bool>(
+                (key, newValue, currentValue, allChanges) => true
+            ),
+            null
+        );
+
+        _scrText = CreateDummyProject();
+        _projectDetails = CreateProjectDetails(_scrText);
+        ParatextProjects.FakeAddProject(_projectDetails, _scrText);
+
+        _provider = new DummyParatextProjectDataProvider(
+            PdpName,
+            Client,
+            _projectDetails,
+            ParatextProjects
+        );
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        _scrText?.Dispose();
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Registers a stub for ProjectSettingsService.getDefault that returns the given boolean as a
+    /// JSON boolean default (mirroring how an extension registers a boolean-typed default).
+    /// </summary>
+    private void RegisterBooleanDefault(string settingName, bool defaultValue)
+    {
+        Client.RegisterRequestHandlerAsync(
+            "object:ProjectSettingsService.getDefault",
+            new Func<string, object?>(key =>
+                key == settingName ? JsonSerializer.SerializeToElement(defaultValue) : null
+            ),
+            null
+        );
+    }
+
+    /// <summary>
+    /// Directly writes a raw string value into the project's ParametersDictionary so that
+    /// GetProjectSetting reads whatever we put there, without going through SetProjectSetting.
+    /// </summary>
+    private void SetRawSetting(string settingName, string rawValue)
+    {
+        _scrText.Settings.ParametersDictionary[settingName] = rawValue;
+    }
+
+    // ------------------------------------------------------------------
+    // Tests
+    // ------------------------------------------------------------------
+
+    [Test]
+    public void SetThenGetProjectSetting_True_StoresTAndReturnsBoolTrue()
+    {
+        RegisterBooleanDefault(BoolSettingName, false);
+
+        bool result = _provider.SetProjectSetting(BoolSettingName, true);
+        Assert.That(result, Is.True);
+
+        // The value is stored as the string "T".
+        Assert.That(_scrText.Settings.ParametersDictionary[BoolSettingName], Is.EqualTo("T"));
+
+        // Reading it back yields a real boolean true.
+        object? readBack = _provider.GetProjectSetting(BoolSettingName);
+        Assert.That(readBack, Is.TypeOf<bool>());
+        Assert.That(readBack, Is.True);
+    }
+
+    [Test]
+    public void SetThenGetProjectSetting_False_StoresFAndReturnsBoolFalse()
+    {
+        RegisterBooleanDefault(BoolSettingName, true);
+
+        bool result = _provider.SetProjectSetting(BoolSettingName, false);
+        Assert.That(result, Is.True);
+
+        // The value is stored as the string "F".
+        Assert.That(_scrText.Settings.ParametersDictionary[BoolSettingName], Is.EqualTo("F"));
+
+        // Reading it back yields a real boolean false.
+        object? readBack = _provider.GetProjectSetting(BoolSettingName);
+        Assert.That(readBack, Is.TypeOf<bool>());
+        Assert.That(readBack, Is.False);
+    }
+
+    [Test]
+    public void GetProjectSetting_BooleanDefaultButNonBooleanStoredValue_ReturnsRawString()
+    {
+        // The setting has a registered boolean default, but the stored value is not a T/F token.
+        // This pins the intentional union-type permissiveness: the raw string is returned, not an
+        // exception.
+        RegisterBooleanDefault(BoolSettingName, false);
+        SetRawSetting(BoolSettingName, "hello");
+
+        object? result = _provider.GetProjectSetting(BoolSettingName);
+
+        Assert.That(result, Is.TypeOf<string>());
+        Assert.That(result, Is.EqualTo("hello"));
+    }
+
+    [Test]
+    public void GetProjectSetting_NoRegisteredDefault_ReturnsStoredValueAsString()
+    {
+        // No getDefault handler is registered, so ProjectSettingsService.GetDefault throws and the
+        // legacy behavior of returning the raw stored string is preserved.
+        SetRawSetting(BoolSettingName, "T");
+
+        object? result = _provider.GetProjectSetting(BoolSettingName);
+
+        Assert.That(result, Is.TypeOf<string>());
+        Assert.That(result, Is.EqualTo("T"));
+    }
+}

--- a/c-sharp-tests/Projects/ParatextProjectDataProviderBooleanSettingTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderBooleanSettingTests.cs
@@ -54,10 +54,6 @@ internal class ParatextProjectDataProviderBooleanSettingTests : PapiTestBase
         _scrText?.Dispose();
     }
 
-    // ------------------------------------------------------------------
-    // Helpers
-    // ------------------------------------------------------------------
-
     /// <summary>Stubs getDefault to return the given bool as a JSON boolean default.</summary>
     private async Task RegisterBooleanDefault(string settingName, bool defaultValue) =>
         await Client.RegisterRequestHandlerAsync(
@@ -85,22 +81,16 @@ internal class ParatextProjectDataProviderBooleanSettingTests : PapiTestBase
     {
         await RegisterBooleanDefault(BoolSettingName, defaultValue);
 
-        bool setResult = _provider.SetProjectSetting(BoolSettingName, setValue);
-        string stored = _scrText.Settings.ParametersDictionary[BoolSettingName];
+        Assert.That(_provider.SetProjectSetting(BoolSettingName, setValue), Is.True);
+        Assert.That(
+            _scrText.Settings.ParametersDictionary[BoolSettingName],
+            Is.EqualTo(expectedStored)
+        );
+
         object? readBack = _provider.GetProjectSetting(BoolSettingName);
-
-        Assert.Multiple(() =>
-        {
-            Assert.That(setResult, Is.True);
-            Assert.That(stored, Is.EqualTo(expectedStored));
-            Assert.That(readBack, Is.TypeOf<bool>());
-            Assert.That(readBack, Is.EqualTo(expectedRead));
-        });
+        Assert.That(readBack, Is.TypeOf<bool>());
+        Assert.That(readBack, Is.EqualTo(expectedRead));
     }
-
-    // ------------------------------------------------------------------
-    // Tests
-    // ------------------------------------------------------------------
 
     [Test]
     public Task SetThenGet_NativeBoolTrue() => AssertSetRoundTrips(true, false, "T", true);
@@ -126,11 +116,8 @@ internal class ParatextProjectDataProviderBooleanSettingTests : PapiTestBase
 
         object? result = _provider.GetProjectSetting(BoolSettingName);
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(result, Is.TypeOf<string>());
-            Assert.That(result, Is.EqualTo("hello"));
-        });
+        Assert.That(result, Is.TypeOf<string>());
+        Assert.That(result, Is.EqualTo("hello"));
     }
 
     // With no registered default, GetDefault throws and the raw string is returned.
@@ -141,10 +128,7 @@ internal class ParatextProjectDataProviderBooleanSettingTests : PapiTestBase
 
         object? result = _provider.GetProjectSetting(BoolSettingName);
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(result, Is.TypeOf<string>());
-            Assert.That(result, Is.EqualTo("T"));
-        });
+        Assert.That(result, Is.TypeOf<string>());
+        Assert.That(result, Is.EqualTo("T"));
     }
 }

--- a/c-sharp-tests/Projects/ParatextProjectDataProviderBooleanSettingTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderBooleanSettingTests.cs
@@ -1,13 +1,15 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Paranext.DataProvider.Projects;
+using Paranext.DataProvider.Services;
 
 namespace TestParanextDataProvider.Projects;
 
 /// <summary>
 /// Tests for GetProjectSetting / SetProjectSetting handling of extension settings registered with a
 /// boolean default: the write path stores a bool as "T"/"F", and the read path converts a stored
-/// "T"/"F" token back to a bool.
+/// Paratext boolean token back to a bool. Settings that map to a Paratext setting name keep their
+/// raw value, and a value that is not a boolean token passes through as a string.
 /// </summary>
 [ExcludeFromCodeCoverage]
 [TestFixture]
@@ -93,19 +95,109 @@ internal class ParatextProjectDataProviderBooleanSettingTests : PapiTestBase
     }
 
     [Test]
-    public Task SetThenGet_NativeBoolTrue() => AssertSetRoundTrips(true, false, "T", true);
+    public Task SetThenGet_NativeBoolTrue_StoresTAndReadsBackAsBool() =>
+        AssertSetRoundTrips(
+            setValue: true,
+            defaultValue: false,
+            expectedStored: "T",
+            expectedRead: true
+        );
 
     [Test]
-    public Task SetThenGet_NativeBoolFalse() => AssertSetRoundTrips(false, true, "F", false);
+    public Task SetThenGet_NativeBoolFalse_StoresFAndReadsBackAsBool() =>
+        AssertSetRoundTrips(
+            setValue: false,
+            defaultValue: true,
+            expectedStored: "F",
+            expectedRead: false
+        );
 
     // PAPI deserializes wire values as JsonElement, so these mirror the production path.
     [Test]
-    public Task SetThenGet_JsonElementTrue() =>
-        AssertSetRoundTrips(JsonSerializer.SerializeToElement(true), false, "T", true);
+    public Task SetThenGet_JsonElementTrue_StoresTAndReadsBackAsBool() =>
+        AssertSetRoundTrips(
+            setValue: JsonSerializer.SerializeToElement(true),
+            defaultValue: false,
+            expectedStored: "T",
+            expectedRead: true
+        );
 
     [Test]
-    public Task SetThenGet_JsonElementFalse() =>
-        AssertSetRoundTrips(JsonSerializer.SerializeToElement(false), true, "F", false);
+    public Task SetThenGet_JsonElementFalse_StoresFAndReadsBackAsBool() =>
+        AssertSetRoundTrips(
+            setValue: JsonSerializer.SerializeToElement(false),
+            defaultValue: true,
+            expectedStored: "F",
+            expectedRead: false
+        );
+
+    // Settings.xml written by other tools can hold the long and lowercase forms, which
+    // SetProjectSetting never produces, so drive these through the raw stored value.
+    [TestCase("T", true)]
+    [TestCase("TRUE", true)]
+    [TestCase("true", true)]
+    [TestCase("F", false)]
+    [TestCase("FALSE", false)]
+    [TestCase("f", false)]
+    public async Task GetProjectSetting_BooleanTokenVariant_ReturnsBool(
+        string storedValue,
+        bool expected
+    )
+    {
+        // Register the opposite default so a pass can't come from the default value.
+        await RegisterBooleanDefault(BoolSettingName, !expected);
+        SetRawSetting(BoolSettingName, storedValue);
+
+        object? result = _provider.GetProjectSetting(BoolSettingName);
+
+        Assert.That(result, Is.TypeOf<bool>());
+        Assert.That(result, Is.EqualTo(expected));
+    }
+
+    // Only settings with no Paratext mapping use the compact T/F encoding, so a mapped setting
+    // keeps its raw value even when it looks like a boolean token.
+    [Test]
+    public async Task GetProjectSetting_MappedSettingStoringBooleanToken_ReturnsRawString()
+    {
+        await RegisterBooleanDefault(ProjectSettingsNames.PB_VALID_CHARACTERS, true);
+        SetRawSetting(ProjectSettingsNames.PT_VALID_CHARACTERS, "T");
+
+        object? result = _provider.GetProjectSetting(ProjectSettingsNames.PB_VALID_CHARACTERS);
+
+        Assert.That(result, Is.TypeOf<string>());
+        Assert.That(result, Is.EqualTo("T"));
+    }
+
+    // The write path only encodes actual booleans; anything else is stored as-is.
+    [Test]
+    public async Task SetProjectSetting_NonBooleanJsonElement_StoresVerbatim()
+    {
+        await RegisterBooleanDefault(BoolSettingName, false);
+
+        Assert.That(
+            _provider.SetProjectSetting(
+                BoolSettingName,
+                JsonSerializer.SerializeToElement("hello")
+            ),
+            Is.True
+        );
+        Assert.That(_scrText.Settings.ParametersDictionary[BoolSettingName], Is.EqualTo("hello"));
+    }
+
+    // ResetProjectSetting feeds GetDefault's JsonElement straight back into SetProjectSetting.
+    [Test]
+    public async Task ResetThenGet_BooleanDefault_ReturnsBool()
+    {
+        await RegisterBooleanDefault(BoolSettingName, true);
+        SetRawSetting(BoolSettingName, "F");
+
+        Assert.That(_provider.ResetProjectSetting(BoolSettingName), Is.True);
+        Assert.That(_scrText.Settings.ParametersDictionary[BoolSettingName], Is.EqualTo("T"));
+
+        object? readBack = _provider.GetProjectSetting(BoolSettingName);
+        Assert.That(readBack, Is.TypeOf<bool>());
+        Assert.That(readBack, Is.True);
+    }
 
     // A boolean-default setting may legitimately hold a non-boolean value (union type).
     [Test]

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using System.Text;
+using System.Text.Json;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.XPath;
@@ -1328,6 +1329,32 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                     ),
                 };
             }
+
+            // Check if extension setting is a non-string type
+            bool? defaultBool = null;
+            try
+            {
+                if (ProjectSettingsService.GetDefault(PapiClient, settingName) is JsonElement elem)
+                    defaultBool = elem.Deserialize<bool?>();
+            }
+            catch
+            {
+                // No registered default; keep original string behavior
+            }
+
+            // Boolean setting found, so convert from string
+            if (defaultBool != null)
+            {
+                return settingValue.ToUpperInvariant() switch
+                {
+                    "F" => false,
+                    "FALSE" => false,
+                    "T" => true,
+                    "TRUE" => true,
+                    _ => defaultBool,
+                };
+            }
+
             return settingValue;
         }
 
@@ -1474,6 +1501,8 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                                 ),
                             };
                         }
+                        else if (value is bool boolValue)
+                            value = boolValue ? "T" : "F";
                         scrText.Settings.SetSetting(paratextSettingName, value!.ToString());
                         // We are notifying when we release our lock, so don't automatically
                         // notify in `Save`

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1330,7 +1330,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                 };
             }
 
-            // Check if extension setting is a non-string type
+            // Check if extension setting is a supported non-string type
             bool? defaultBool = null;
             try
             {
@@ -1351,7 +1351,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                     "FALSE" => false,
                     "T" => true,
                     "TRUE" => true,
-                    _ => defaultBool,
+                    _ => settingValue,
                 };
             }
 

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1330,10 +1330,9 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                 };
             }
 
-            // If this extension setting has a registered boolean default, treat it as a boolean.
-            // GetDefault throws if no default is registered for this setting (and is
-            // indistinguishable from a transient PAPI failure here); in either case fall back to
-            // the legacy string behavior below.
+            // Convert to bool if this extension setting has a registered boolean default. GetDefault
+            // throws when there is no default (indistinguishable from a PAPI failure), so any error
+            // falls back to the raw string.
             bool? defaultBool = null;
             try
             {
@@ -1345,10 +1344,9 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             }
             catch
             {
-                // No registered default (or PAPI unavailable); keep original string behavior
+                // No registered default (or PAPI error); keep the raw string
             }
 
-            // Boolean setting found, so convert from string
             if (defaultBool != null)
             {
                 return settingValue.ToUpperInvariant() switch
@@ -1357,8 +1355,8 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                     "FALSE" => false,
                     "T" => true,
                     "TRUE" => true,
-                    // A setting with a boolean default may legitimately hold a non-boolean value
-                    // (a union/mixed type), so pass the raw string through rather than throwing.
+                    // A boolean-default setting may hold a non-boolean value (union type), so pass
+                    // the raw string through rather than throwing.
                     _ => settingValue,
                 };
             }
@@ -1511,6 +1509,12 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                         }
                         else if (value is bool boolValue)
                             value = boolValue ? "T" : "F";
+                        // PAPI wire values arrive as JsonElement (value is object?), not native bool.
+                        else if (
+                            value is JsonElement je
+                            && je.ValueKind is JsonValueKind.True or JsonValueKind.False
+                        )
+                            value = je.GetBoolean() ? "T" : "F";
                         scrText.Settings.SetSetting(paratextSettingName, value!.ToString());
                         // We are notifying when we release our lock, so don't automatically
                         // notify in `Save`

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1330,16 +1330,22 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                 };
             }
 
-            // Check if extension setting is a supported non-string type
+            // If this extension setting has a registered boolean default, treat it as a boolean.
+            // GetDefault throws if no default is registered for this setting (and is
+            // indistinguishable from a transient PAPI failure here); in either case fall back to
+            // the legacy string behavior below.
             bool? defaultBool = null;
             try
             {
-                if (ProjectSettingsService.GetDefault(PapiClient, settingName) is JsonElement elem)
-                    defaultBool = elem.Deserialize<bool?>();
+                if (
+                    ProjectSettingsService.GetDefault(PapiClient, settingName) is JsonElement elem
+                    && elem.ValueKind is JsonValueKind.True or JsonValueKind.False
+                )
+                    defaultBool = elem.GetBoolean();
             }
             catch
             {
-                // No registered default; keep original string behavior
+                // No registered default (or PAPI unavailable); keep original string behavior
             }
 
             // Boolean setting found, so convert from string
@@ -1351,6 +1357,8 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                     "FALSE" => false,
                     "T" => true,
                     "TRUE" => true,
+                    // A setting with a boolean default may legitimately hold a non-boolean value
+                    // (a union/mixed type), so pass the raw string through rather than throwing.
                     _ => settingValue,
                 };
             }

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1647,6 +1647,14 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         }
     }
 
+    /// <summary>
+    /// Gets a project setting value. Settings contributed by extensions store booleans in
+    /// Paratext's compact "T"/"F" form; a stored value that is not one of Paratext's boolean tokens
+    /// is returned as a raw string rather than throwing, so a setting whose type is a union of
+    /// boolean and something else keeps working.
+    /// </summary>
+    /// <param name="settingName">Setting name in Platform.Bible terminology</param>
+    /// <returns>The setting value, or its registered default if the project has no value</returns>
     public object? GetProjectSetting(string settingName)
     {
         var paratextSettingName =
@@ -1778,35 +1786,29 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                 return boolValue;
             }
 
-            // Convert to bool if this extension setting has a registered boolean default. GetDefault
-            // throws when there is no default (indistinguishable from a PAPI failure), so any error
-            // falls back to the raw string.
-            bool? defaultBool = null;
-            try
+            // Only extension settings use the compact T/F encoding, and only a value already in
+            // that form can convert. Both checks are local, so make them before paying for a
+            // GetDefault round trip. Extension settings have no Paratext mapping, so the names match.
+            if (
+                paratextSettingName == settingName
+                && ProjectSettingsNames.TryParseParatextBoolean(settingValue, out bool storedBool)
+            )
             {
-                if (
-                    ProjectSettingsService.GetDefault(PapiClient, settingName) is JsonElement elem
-                    && elem.ValueKind is JsonValueKind.True or JsonValueKind.False
-                )
-                    defaultBool = elem.GetBoolean();
-            }
-            catch
-            {
-                // No registered default (or PAPI error); keep the raw string
-            }
-
-            if (defaultBool != null)
-            {
-                return settingValue.ToUpperInvariant() switch
+                // Convert only when the setting is registered with a boolean default. GetDefault
+                // throws when there is no default, so any error falls back to the raw string.
+                try
                 {
-                    "F" => false,
-                    "FALSE" => false,
-                    "T" => true,
-                    "TRUE" => true,
-                    // A boolean-default setting may hold a non-boolean value (union type), so pass
-                    // the raw string through rather than throwing.
-                    _ => settingValue,
-                };
+                    if (
+                        ProjectSettingsService.GetDefault(PapiClient, settingName)
+                            is JsonElement elem
+                        && elem.ValueKind is JsonValueKind.True or JsonValueKind.False
+                    )
+                        return storedBool;
+                }
+                catch
+                {
+                    // No registered default (or PAPI error); keep the raw string
+                }
             }
 
             return settingValue;
@@ -1990,14 +1992,14 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                             // Normalize to the canonical single-letter form Paratext stores
                             value = boolValue ? "T" : "F";
                         }
-                        else if (value is bool boolValue)
-                            value = boolValue ? "T" : "F";
-                        // PAPI wire values arrive as JsonElement (value is object?), not native bool.
+                        // Only extension settings use the compact T/F encoding; mapped Paratext
+                        // settings are handled above. Extension settings have no Paratext mapping,
+                        // so the names match.
                         else if (
-                            value is JsonElement je
-                            && je.ValueKind is JsonValueKind.True or JsonValueKind.False
+                            paratextSettingName == settingName
+                            && TryGetBoolean(value, out bool extensionBool)
                         )
-                            value = je.GetBoolean() ? "T" : "F";
+                            value = extensionBool ? "T" : "F";
                         scrText.Settings.SetSetting(paratextSettingName, value!.ToString());
                         // We are notifying when we release our lock, so don't automatically
                         // notify in `Save`
@@ -2158,19 +2160,40 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         return bool.TryParse(content.Value, out bool result) ? result : null;
     }
 
+    /// <summary>
+    /// Gets a boolean from a value that may be a native bool or a <see cref="JsonElement"/>. Values
+    /// crossing the JSON-RPC boundary arrive as JsonElement, not a native bool, so accept both
+    /// (matches the bool-handling pattern in Checks/InventoryOption.SerializeValue). Try-shaped so
+    /// each caller applies its own policy for a non-boolean value.
+    /// </summary>
+    /// <param name="value">Value to interpret as a boolean</param>
+    /// <param name="result">The boolean; false when <paramref name="value"/> was not one</param>
+    /// <returns>True if <paramref name="value"/> was a native bool or a boolean JsonElement</returns>
+    private static bool TryGetBoolean(object? value, out bool result)
+    {
+        switch (value)
+        {
+            case bool boolValue:
+                result = boolValue;
+                return true;
+            case JsonElement { ValueKind: JsonValueKind.True }:
+                result = true;
+                return true;
+            case JsonElement { ValueKind: JsonValueKind.False }:
+                result = false;
+                return true;
+            default:
+                result = false;
+                return false;
+        }
+    }
+
     public bool SetUserStructureProtected(object? value)
     {
-        // Values crossing the JSON-RPC boundary arrive as JsonElement, not a native bool, so accept
-        // both (matches the bool-handling pattern in Checks/InventoryOption.SerializeValue).
-        bool boolValue = value switch
-        {
-            bool b => b,
-            JsonElement { ValueKind: JsonValueKind.True } => true,
-            JsonElement { ValueKind: JsonValueKind.False } => false,
-            _ => throw new InvalidDataException(
+        if (!TryGetBoolean(value, out bool boolValue))
+            throw new InvalidDataException(
                 $"Expected boolean for UserStructureProtected, got: {value}"
-            ),
-        };
+            );
         var itemsElement = new XElement("Items", boolValue.ToString().ToLowerInvariant());
         // Version stored for consistency with other settings; ignored on read
         GetUserProjectSettings().SetSetting("StructureProtected", "1.0.0", itemsElement);

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1777,6 +1777,32 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                     );
                 return boolValue;
             }
+
+            // Check if extension setting is a non-string type
+            bool? defaultBool = null;
+            try
+            {
+                if (ProjectSettingsService.GetDefault(PapiClient, settingName) is JsonElement elem)
+                    defaultBool = elem.Deserialize<bool?>();
+            }
+            catch
+            {
+                // No registered default; keep original string behavior
+            }
+
+            // Boolean setting found, so convert from string
+            if (defaultBool != null)
+            {
+                return settingValue.ToUpperInvariant() switch
+                {
+                    "F" => false,
+                    "FALSE" => false,
+                    "T" => true,
+                    "TRUE" => true,
+                    _ => defaultBool,
+                };
+            }
+
             return settingValue;
         }
 
@@ -1958,6 +1984,8 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                             // Normalize to the canonical single-letter form Paratext stores
                             value = boolValue ? "T" : "F";
                         }
+                        else if (value is bool boolValue)
+                            value = boolValue ? "T" : "F";
                         scrText.Settings.SetSetting(paratextSettingName, value!.ToString());
                         // We are notifying when we release our lock, so don't automatically
                         // notify in `Save`

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1778,10 +1778,9 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                 return boolValue;
             }
 
-            // If this extension setting has a registered boolean default, treat it as a boolean.
-            // GetDefault throws if no default is registered for this setting (and is
-            // indistinguishable from a transient PAPI failure here); in either case fall back to
-            // the legacy string behavior below.
+            // Convert to bool if this extension setting has a registered boolean default. GetDefault
+            // throws when there is no default (indistinguishable from a PAPI failure), so any error
+            // falls back to the raw string.
             bool? defaultBool = null;
             try
             {
@@ -1793,10 +1792,9 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             }
             catch
             {
-                // No registered default (or PAPI unavailable); keep original string behavior
+                // No registered default (or PAPI error); keep the raw string
             }
 
-            // Boolean setting found, so convert from string
             if (defaultBool != null)
             {
                 return settingValue.ToUpperInvariant() switch
@@ -1805,8 +1803,8 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                     "FALSE" => false,
                     "T" => true,
                     "TRUE" => true,
-                    // A setting with a boolean default may legitimately hold a non-boolean value
-                    // (a union/mixed type), so pass the raw string through rather than throwing.
+                    // A boolean-default setting may hold a non-boolean value (union type), so pass
+                    // the raw string through rather than throwing.
                     _ => settingValue,
                 };
             }
@@ -1994,6 +1992,12 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                         }
                         else if (value is bool boolValue)
                             value = boolValue ? "T" : "F";
+                        // PAPI wire values arrive as JsonElement (value is object?), not native bool.
+                        else if (
+                            value is JsonElement je
+                            && je.ValueKind is JsonValueKind.True or JsonValueKind.False
+                        )
+                            value = je.GetBoolean() ? "T" : "F";
                         scrText.Settings.SetSetting(paratextSettingName, value!.ToString());
                         // We are notifying when we release our lock, so don't automatically
                         // notify in `Save`

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1778,16 +1778,22 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                 return boolValue;
             }
 
-            // Check if extension setting is a supported non-string type
+            // If this extension setting has a registered boolean default, treat it as a boolean.
+            // GetDefault throws if no default is registered for this setting (and is
+            // indistinguishable from a transient PAPI failure here); in either case fall back to
+            // the legacy string behavior below.
             bool? defaultBool = null;
             try
             {
-                if (ProjectSettingsService.GetDefault(PapiClient, settingName) is JsonElement elem)
-                    defaultBool = elem.Deserialize<bool?>();
+                if (
+                    ProjectSettingsService.GetDefault(PapiClient, settingName) is JsonElement elem
+                    && elem.ValueKind is JsonValueKind.True or JsonValueKind.False
+                )
+                    defaultBool = elem.GetBoolean();
             }
             catch
             {
-                // No registered default; keep original string behavior
+                // No registered default (or PAPI unavailable); keep original string behavior
             }
 
             // Boolean setting found, so convert from string
@@ -1799,6 +1805,8 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                     "FALSE" => false,
                     "T" => true,
                     "TRUE" => true,
+                    // A setting with a boolean default may legitimately hold a non-boolean value
+                    // (a union/mixed type), so pass the raw string through rather than throwing.
                     _ => settingValue,
                 };
             }

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1778,7 +1778,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                 return boolValue;
             }
 
-            // Check if extension setting is a non-string type
+            // Check if extension setting is a supported non-string type
             bool? defaultBool = null;
             try
             {
@@ -1799,7 +1799,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                     "FALSE" => false,
                     "T" => true,
                     "TRUE" => true,
-                    _ => defaultBool,
+                    _ => settingValue,
                 };
             }
 


### PR DESCRIPTION
## The problem

A boolean project setting contributed by an extension doesn't come back as a boolean. For a setting that isn't a known Paratext boolean, `SetProjectSetting` falls through to `SetSetting(paratextSettingName, value!.ToString())`; the value arrives over the wire as a `JsonElement`, and `JsonElement.ToString()` returns `bool.FalseString` for `ValueKind.False`, so setting `false` stores `"False"`. Reading it back returns the string `"False"` — truthy in JS, so `false` reads as enabled.

Paratext stores its own booleans as the compact `"T"`/`"F"`, which is what the write path below normalizes to. Existing projects therefore contain `"True"`/`"False"`, which is why the read path also accepts the long forms.

## What this does

Extension-registered **boolean** project settings now round-trip as real booleans instead of strings in `ParatextProjectDataProvider`:

- **Write** (`SetProjectSetting`): boolean values are stored in Paratext's compact `"T"`/`"F"` format. Values arriving over the PAPI wire are deserialized as `JsonElement` (the parameter type is `object?`), not a native `bool`, so both a native `bool` and a boolean `JsonElement` are converted.
- **Read** (`GetProjectSetting`): for settings that aren't known Paratext booleans, the setting's registered default is looked up via `ProjectSettingsService.GetDefault`. If that default is a JSON boolean, the stored `"T"`/`"F"`/`"TRUE"`/`"FALSE"` string (case-insensitive) is converted back to a real `bool`.

Edge cases are handled deliberately:

- A setting whose registered default is a boolean but whose stored value is **not** one of the boolean tokens (a union/mixed type) passes the raw string through unchanged rather than throwing.
- If no default is registered (or the default lookup fails), the legacy behavior of returning the raw string is preserved.

The boolean-default check gates on `JsonElement.ValueKind` so a non-boolean default does not depend on exception handling for control flow.

---

This is a possible fix, though I'm sure other approaches would work. Anybody on the PT team is welcome to suggest changes and/or take over the work themselves.

Before:
<img width="682" height="257" alt="Screenshot 2026-05-01 134253" src="https://github.com/user-attachments/assets/fe28c3b3-c8ad-40da-8dc2-70681c85cbad" />

After:
<img width="665" height="257" alt="Screenshot 2026-05-01 134056" src="https://github.com/user-attachments/assets/af37a40b-853c-4e48-829c-0efb57ec1782" />

Devin review: https://app.devin.ai/review/paranext/paranext-core/pull/2238

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2238)
<!-- Reviewable:end -->

