### PR TITLE
workflow: e2e cdp.fixture enforces 1920x1080 viewport + screenshot dimensions

### DIFF
--- a/e2e-tests/fixtures/cdp.fixture.ts
+++ b/e2e-tests/fixtures/cdp.fixture.ts
@@ -24,11 +24,20 @@
  *
  * - The fixture explicitly excludes `devtools://` URLs when finding the renderer page (so connecting
  *   to a DevTools page is impossible).
- * - The fixture calls `setViewportSize({ width: 1920, height: 1080 })` after connecting so
- *   screenshots capture the Full HD layout regardless of the underlying Electron window size.
- * - Tests can call `assertFullHdScreenshot(path)` after a `screenshot()` to guarantee evidence
- *   dimensions are at least 1920x1080. Smaller PNGs FAIL the test, no matter how nice the partial
- *   UI looks.
+ * - The fixture calls `setViewportSize({ width: 1920, height: 1080 })` after connecting AND verifies
+ *   the actual rendered viewport via `page.evaluate(() => ({ width: window.innerWidth, height:
+ *   window.innerHeight }))`. The `evaluate()` reading runs IN the renderer and reflects the real
+ *   constrained-by-OS-window viewport, unlike `page.viewportSize()` which only echoes Playwright's
+ *   cached requested-value.
+ * - The fixture wraps `page.screenshot` to auto-validate PNG dimensions against the Full HD minimum
+ *   the moment the file lands on disk. Tests do NOT need to call `assertFullHdScreenshot` manually
+ *   — it runs automatically for every `screenshot({ path })` whose path is OUTSIDE Playwright's
+ *   `test-results/` output directory (failure-capture screenshots that Playwright takes via
+ *   `screenshot: 'only-on-failure'` are intentionally exempted so the dimension assertion never
+ *   masks the real failure cause).
+ * - The exported `assertFullHdScreenshot(path)` helper remains available for ad-hoc validation of
+ *   PNGs written outside the fixture (e.g. from the visual-verification skill or from CI artifact
+ *   checks). Inside the fixture's `screenshot()` calls, it is already automatic.
  *
  * Prerequisite: Platform.Bible running with --remote-debugging-port=9223
  */
@@ -83,8 +92,19 @@ function readPngDimensions(filePath: string): { width: number; height: number } 
  * the assertion regardless of UI content — this defends against reviews-by-vibes when
  * DevTools-shrunk or default-window-sized screenshots slip into the evidence directory.
  *
- * @example Await mainPage.screenshot({ path: 'proofs/foo.png' });
- * assertFullHdScreenshot('proofs/foo.png');
+ * Inside the fixture, the wrapped `page.screenshot()` calls this automatically for every
+ * evidence-path screenshot. Use this helper directly only for PNGs written **outside** the fixture
+ * (e.g. from the `visual-verification` skill, post-test CI artifact validators, or other tooling
+ * that produces PNGs without going through `mainPage.screenshot()`).
+ *
+ * @example
+ *
+ * ```ts
+ * import { assertFullHdScreenshot } from './fixtures/cdp.fixture';
+ *
+ * // Validating a PNG produced outside the cdp.fixture page.screenshot() wrapper:
+ * assertFullHdScreenshot('/path/to/external-tool-output.png');
+ * ```
  */
 export function assertFullHdScreenshot(filePath: string): void {
   const { width, height } = readPngDimensions(filePath);
@@ -101,6 +121,21 @@ export function assertFullHdScreenshot(filePath: string): void {
       `Likely cause: the renderer window is smaller than 1920x1080 OR DevTools is docked. ` +
       `Resize the Electron window OR close DevTools and re-run. Tiny screenshots always FAIL.`,
   ).toBeGreaterThanOrEqual(MIN_SCREENSHOT_HEIGHT);
+}
+
+/**
+ * Decide whether a screenshot path should be dimension-validated. Returns `false` when the path is
+ * inside Playwright's test-output directory (`test-results/`, `playwright-report/`) — those are
+ * diagnostic captures from the test runner (e.g. `screenshot: 'only-on-failure'`) which we do NOT
+ * want to fail on a dimension mismatch (that would mask the real failure cause). Every other path —
+ * relative or absolute, in `proofs/`, `/tmp/`, or anywhere else a caller chose — IS validated.
+ */
+function shouldValidateScreenshotPath(path: string): boolean {
+  // Normalise separators so the same check works on Windows + POSIX.
+  const normalised = path.replace(/\\/g, '/');
+  if (normalised.includes('/test-results/')) return false;
+  if (normalised.includes('/playwright-report/')) return false;
+  return true;
 }
 
 export interface CdpFixtures {
@@ -163,17 +198,19 @@ export const test = base.extend<CdpFixtures>({
     // docblock for the full failure-mode discussion.
     await page.setViewportSize({ width: MIN_SCREENSHOT_WIDTH, height: MIN_SCREENSHOT_HEIGHT });
 
-    // Sanity check: confirm the viewport actually applied. setViewportSize on a CDP-connected page
-    // can silently fail under certain configurations; better to throw here than to silently accept
-    // tiny screenshots downstream.
-    const actualSize = page.viewportSize();
-    if (
-      !actualSize ||
-      actualSize.width < MIN_SCREENSHOT_WIDTH ||
-      actualSize.height < MIN_SCREENSHOT_HEIGHT
-    ) {
+    // Sanity check: confirm the viewport ACTUALLY applied at the renderer level — not just at
+    // Playwright's bookkeeping. `page.viewportSize()` returns the cached requested-value (it just
+    // echoes back what we asked for), so it cannot detect the case where the OS window is smaller
+    // than the requested viewport (CDP can't grow a viewport past the OS window size). The only
+    // reliable signal is reading `window.innerWidth` / `window.innerHeight` IN the renderer via
+    // `page.evaluate()` — those properties reflect the actual rendered viewport.
+    const actualSize = await page.evaluate(() => ({
+      width: window.innerWidth,
+      height: window.innerHeight,
+    }));
+    if (actualSize.width < MIN_SCREENSHOT_WIDTH || actualSize.height < MIN_SCREENSHOT_HEIGHT) {
       throw new Error(
-        `cdp.fixture: viewport enforcement failed — page reports ${actualSize?.width}x${actualSize?.height}, ` +
+        `cdp.fixture: viewport enforcement failed — renderer reports ${actualSize.width}x${actualSize.height}, ` +
           `expected at least ${MIN_SCREENSHOT_WIDTH}x${MIN_SCREENSHOT_HEIGHT}. Likely cause: the ` +
           `Electron window itself is smaller than the requested viewport (CDP cannot grow a viewport ` +
           `past the OS window size). Resize the Electron window before running tests, or restart the ` +
@@ -187,8 +224,19 @@ export const test = base.extend<CdpFixtures>({
     // with a precise dimension report. This enforces "small screenshots are failures, no matter
     // how nice the UI looks" without requiring per-test assertion calls.
     //
-    // Only screenshots written to a `path` are validated (returned-buffer screenshots have no file
-    // to dimension-check; those are typically used for inline diff snapshots, not evidence).
+    // Two important exemptions:
+    //
+    //   (1) Screenshots without a `path` (returned-buffer screenshots — typically used for inline
+    //       diff snapshots, not evidence) are not file-system-validated.
+    //   (2) Playwright's `screenshot: 'only-on-failure'` test-runner feature uses the public
+    //       `page.screenshot()` API, which our wrapper would otherwise intercept. Failure-capture
+    //       screenshots are diagnostic, not evidence — and if a test failure happens BEFORE the
+    //       fixture's viewport-set completes, the failure-capture would be small and our assertion
+    //       would mask the real failure cause. We therefore skip the dimension assertion when the
+    //       path falls inside Playwright's `test-results/` output directory (the configured
+    //       outputDir in `playwright-cdp.config.ts`). Evidence screenshots all live in `proofs/`
+    //       OR another caller-chosen path, so this exemption only catches Playwright's internal
+    //       failure captures.
     //
     // Implementation note: Playwright's `Page.screenshot` overloads (with-options vs no-args, with
     // and without `path`) make a fully-typed wrapper noisy. We reuse Playwright's exported
@@ -199,7 +247,11 @@ export const test = base.extend<CdpFixtures>({
       options?: PageScreenshotOptions,
     ): Promise<Buffer> {
       const result = await originalScreenshot(options);
-      if (options && typeof options.path === 'string') {
+      if (
+        options &&
+        typeof options.path === 'string' &&
+        shouldValidateScreenshotPath(options.path)
+      ) {
         assertFullHdScreenshot(options.path);
       }
       return result;

--- a/e2e-tests/fixtures/cdp.fixture.ts
+++ b/e2e-tests/fixtures/cdp.fixture.ts
@@ -8,13 +8,100 @@
  * - Tests run against the same app instance used during development
  * - No teardown/shutdown of the app on completion
  *
+ * ## Viewport / Screenshot Dimension Enforcement
+ *
+ * Reviewer experience requires screenshots taken at a consistent, large viewport (1920x1080) so the
+ * full UI layout is captured. Two failure modes have been observed in the past and are now actively
+ * defended against:
+ *
+ * 1. **Small renderer window** — Electron defaults to a 1024x728 window which yields a ~675x728 usable
+ *    viewport; screenshots at that size hide most of the UI and produce reviews-by-vibes.
+ * 2. **DevTools panel open** — when DevTools is docked-bottom or docked-right, the renderer area
+ *    shrinks to the remaining sliver (~300x768 typical), producing useless screenshots that pass
+ *    `toBeVisible` checks but are visually unreviewable.
+ *
+ * Mitigations applied here:
+ *
+ * - The fixture explicitly excludes `devtools://` URLs when finding the renderer page (so connecting
+ *   to a DevTools page is impossible).
+ * - The fixture calls `setViewportSize({ width: 1920, height: 1080 })` after connecting so
+ *   screenshots capture the Full HD layout regardless of the underlying Electron window size.
+ * - Tests can call `assertFullHdScreenshot(path)` after a `screenshot()` to guarantee evidence
+ *   dimensions are at least 1920x1080. Smaller PNGs FAIL the test, no matter how nice the partial
+ *   UI looks.
+ *
  * Prerequisite: Platform.Bible running with --remote-debugging-port=9223
  */
-import { test as base, chromium, Page } from '@playwright/test';
+import {
+  test as base,
+  chromium,
+  expect as baseExpect,
+  Page,
+  PageScreenshotOptions,
+} from '@playwright/test';
+import * as fs from 'fs';
 
 export { expect } from '@playwright/test';
 
 const CDP_URL = process.env.CDP_URL || 'http://localhost:9223';
+
+/**
+ * Minimum acceptable screenshot dimensions for UI evidence captures. Aligns with `pw-server.mjs`
+ * viewport defaults (1920x1080 — Full HD).
+ *
+ * Override per-suite via PW_VIEWPORT_WIDTH / PW_VIEWPORT_HEIGHT environment variables (same names
+ * the visual-verification skill uses).
+ */
+export const MIN_SCREENSHOT_WIDTH = parseInt(process.env.PW_VIEWPORT_WIDTH || '', 10) || 1920;
+export const MIN_SCREENSHOT_HEIGHT = parseInt(process.env.PW_VIEWPORT_HEIGHT || '', 10) || 1080;
+
+/**
+ * Read PNG header bytes and return `{ width, height }`. PNG header layout:
+ *
+ * - Bytes 0-7: PNG signature (`89 50 4E 47 0D 0A 1A 0A`)
+ * - Bytes 8-11: IHDR chunk length (always 13)
+ * - Bytes 12-15: chunk type "IHDR"
+ * - Bytes 16-19: width (BE uint32)
+ * - Bytes 20-23: height (BE uint32)
+ *
+ * No third-party image library required.
+ */
+function readPngDimensions(filePath: string): { width: number; height: number } {
+  const buffer = fs.readFileSync(filePath);
+  if (buffer.length < 24) throw new Error(`File too small to be a PNG: ${filePath}`);
+  const sig = buffer.slice(0, 8);
+  const expectedSig = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+  if (!sig.equals(expectedSig)) throw new Error(`Not a PNG file: ${filePath}`);
+  return {
+    width: buffer.readUInt32BE(16),
+    height: buffer.readUInt32BE(20),
+  };
+}
+
+/**
+ * Assert that a screenshot file on disk is at least Full HD (1920x1080). Smaller dimensions FAIL
+ * the assertion regardless of UI content — this defends against reviews-by-vibes when
+ * DevTools-shrunk or default-window-sized screenshots slip into the evidence directory.
+ *
+ * @example Await mainPage.screenshot({ path: 'proofs/foo.png' });
+ * assertFullHdScreenshot('proofs/foo.png');
+ */
+export function assertFullHdScreenshot(filePath: string): void {
+  const { width, height } = readPngDimensions(filePath);
+  baseExpect(
+    width,
+    `Screenshot ${filePath} width ${width}px is below the ${MIN_SCREENSHOT_WIDTH}px minimum. ` +
+      `Likely cause: the renderer window is smaller than 1920x1080 OR DevTools is docked, ` +
+      `cropping the renderer area. Resize the Electron window OR close DevTools and re-run. ` +
+      `Tiny screenshots always FAIL — no matter how nice the partial UI looks.`,
+  ).toBeGreaterThanOrEqual(MIN_SCREENSHOT_WIDTH);
+  baseExpect(
+    height,
+    `Screenshot ${filePath} height ${height}px is below the ${MIN_SCREENSHOT_HEIGHT}px minimum. ` +
+      `Likely cause: the renderer window is smaller than 1920x1080 OR DevTools is docked. ` +
+      `Resize the Electron window OR close DevTools and re-run. Tiny screenshots always FAIL.`,
+  ).toBeGreaterThanOrEqual(MIN_SCREENSHOT_HEIGHT);
+}
 
 export interface CdpFixtures {
   mainPage: Page;
@@ -42,22 +129,81 @@ export const test = base.extend<CdpFixtures>({
     }
     if (!browser) throw new Error('Failed to connect to CDP after 3 attempts');
 
-    // Find the renderer page (not devtools) — same logic as pw-server.mjs
+    // Find the renderer page (not devtools) — same logic as pw-server.mjs.
+    // Filter out `devtools://` AND prefer `localhost:1212` (renderer dev server) over generic
+    // `localhost` matches so we never end up on a non-renderer localhost page.
     const allPages = browser.contexts().flatMap((ctx) => ctx.pages());
     let page: Page | undefined = allPages.find((p) => {
       const url = p.url();
-      return (
-        (url.includes('localhost') || url.includes('index.html') || url.startsWith('file://')) &&
-        !url.includes('devtools://')
-      );
+      return url.includes('localhost:1212') && !url.includes('devtools://');
     });
 
-    // Fallback: pick the first non-devtools page
+    // Secondary preference: any localhost / index.html / file:// renderer
+    if (!page) {
+      page = allPages.find((p) => {
+        const url = p.url();
+        return (
+          (url.includes('localhost') || url.includes('index.html') || url.startsWith('file://')) &&
+          !url.includes('devtools://')
+        );
+      });
+    }
+
+    // Final fallback: any non-devtools page
     if (!page) {
       page = allPages.find((p) => !p.url().includes('devtools://'));
     }
 
     if (!page) throw new Error('No renderer page found via CDP');
+
+    // ENFORCE Full HD viewport (1920x1080) so screenshots capture the full UI layout regardless of
+    // the underlying Electron window size or whether DevTools is docked. Without this, screenshots
+    // taken at the default 1024x728 window — or worse, the ~300x768 sliver left when DevTools is
+    // docked-right — slip into the evidence directory and produce reviews-by-vibes. See module
+    // docblock for the full failure-mode discussion.
+    await page.setViewportSize({ width: MIN_SCREENSHOT_WIDTH, height: MIN_SCREENSHOT_HEIGHT });
+
+    // Sanity check: confirm the viewport actually applied. setViewportSize on a CDP-connected page
+    // can silently fail under certain configurations; better to throw here than to silently accept
+    // tiny screenshots downstream.
+    const actualSize = page.viewportSize();
+    if (
+      !actualSize ||
+      actualSize.width < MIN_SCREENSHOT_WIDTH ||
+      actualSize.height < MIN_SCREENSHOT_HEIGHT
+    ) {
+      throw new Error(
+        `cdp.fixture: viewport enforcement failed — page reports ${actualSize?.width}x${actualSize?.height}, ` +
+          `expected at least ${MIN_SCREENSHOT_WIDTH}x${MIN_SCREENSHOT_HEIGHT}. Likely cause: the ` +
+          `Electron window itself is smaller than the requested viewport (CDP cannot grow a viewport ` +
+          `past the OS window size). Resize the Electron window before running tests, or restart the ` +
+          `app via ./.erb/scripts/refresh.sh which sizes the window to 1920x1080.`,
+      );
+    }
+
+    // AUTO-VALIDATE screenshot dimensions. Wrap `page.screenshot` so every screenshot taken via
+    // the fixture is validated against the Full HD minimum the moment the file lands on disk.
+    // Tests can no longer accidentally produce tiny screenshots — they FAIL fast at the call site
+    // with a precise dimension report. This enforces "small screenshots are failures, no matter
+    // how nice the UI looks" without requiring per-test assertion calls.
+    //
+    // Only screenshots written to a `path` are validated (returned-buffer screenshots have no file
+    // to dimension-check; those are typically used for inline diff snapshots, not evidence).
+    //
+    // Implementation note: Playwright's `Page.screenshot` overloads (with-options vs no-args, with
+    // and without `path`) make a fully-typed wrapper noisy. We reuse Playwright's exported
+    // `PageScreenshotOptions` type so the wrapper retains the public signature with no `any`
+    // casts.
+    const originalScreenshot = page.screenshot.bind(page);
+    page.screenshot = async function patchedScreenshot(
+      options?: PageScreenshotOptions,
+    ): Promise<Buffer> {
+      const result = await originalScreenshot(options);
+      if (options && typeof options.path === 'string') {
+        assertFullHdScreenshot(options.path);
+      }
+      return result;
+    };
 
     await use(page);
     // When connected via connectOverCDP (vs launching), browser.close() only

--- a/e2e-tests/playwright-cdp.config.ts
+++ b/e2e-tests/playwright-cdp.config.ts
@@ -22,10 +22,14 @@ const config = defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
-    // Default viewport for screenshots — matches the visual-verification skill's pw-server.mjs and
-    // is enforced by cdp.fixture.ts. Anything smaller produces reviews-by-vibes (a tiny screenshot
-    // can pass `toBeVisible` checks but hides most of the UI). See cdp.fixture.ts module docblock.
-    viewport: { width: 1920, height: 1080 },
+    // NOTE: a `viewport: { width: 1920, height: 1080 }` setting was previously here. Playwright's
+    // `use.viewport` is applied to pages CREATED by the test framework inside a browser context.
+    // For pages obtained via `connectOverCDP` (already-running Electron renderer), the config
+    // viewport is NOT retroactively applied — Playwright never gets to call `setViewportSize`
+    // during page creation because the page already exists. Viewport enforcement therefore happens
+    // exclusively in `cdp.fixture.ts` via an explicit `setViewportSize` + an `evaluate()`
+    // verification that reads the renderer's actual `window.innerWidth` / `innerHeight`. See
+    // `cdp.fixture.ts` module docblock for the full enforcement chain.
   },
   outputDir: './test-results',
   // NO globalSetup/globalTeardown — app is already running

--- a/e2e-tests/playwright-cdp.config.ts
+++ b/e2e-tests/playwright-cdp.config.ts
@@ -7,7 +7,7 @@ import { defineConfig } from '@playwright/test';
  * Prerequisites: Platform.Bible running with --remote-debugging-port=9223 Use: npx playwright test
  * --config=e2e-tests/playwright-cdp.config.ts
  */
-export default defineConfig({
+const config = defineConfig({
   testDir: './tests',
   // Smoke tests use app.fixture/papi.fixture (launch their own Electron instance).
   // CDP tests connect to an already-running app. They cannot mix.
@@ -22,7 +22,13 @@ export default defineConfig({
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
+    // Default viewport for screenshots — matches the visual-verification skill's pw-server.mjs and
+    // is enforced by cdp.fixture.ts. Anything smaller produces reviews-by-vibes (a tiny screenshot
+    // can pass `toBeVisible` checks but hides most of the UI). See cdp.fixture.ts module docblock.
+    viewport: { width: 1920, height: 1080 },
   },
   outputDir: './test-results',
   // NO globalSetup/globalTeardown — app is already running
 });
+
+export default config;


### PR DESCRIPTION
## Summary

Three layers of defense against tiny screenshots in CDP-mode E2E tests:

1. **Strict renderer page selection** — `cdp.fixture.ts` now prefers `localhost:1212` (the renderer dev-server origin) when finding the page, with a documented `devtools://` exclusion. Prevents Playwright from accidentally connecting to the DevTools panel when it's open.

2. **Viewport enforcement** — `cdp.fixture.ts` calls `setViewportSize(1920×1080)` after connecting and sanity-checks that the viewport actually applied (CDP can silently fail on smaller OS windows). Throws with a precise diagnostic message if the Electron window is smaller than Full HD.

3. **Auto-validation of screenshot dimensions** — `page.screenshot` is wrapped to read the resulting PNG header bytes and assert `width ≥ 1920 ∧ height ≥ 1080` whenever a `path` is given. Tests that produce smaller screenshots **FAIL fast** at the call site with a clear error explaining the likely cause (small window or DevTools docked). PNG dimensions are read directly from the header — no third-party image library needed.

The exported `assertFullHdScreenshot(path)` helper is also available for ad-hoc validation outside the fixture (e.g. visual-verification skill captures, CI artifact checks).

## Why

Prior runs produced screenshots at the default Electron 1024×728 window — or worse, the ~300×768 sliver left when DevTools was docked-right. Those screenshots passed `toBeVisible` checks but were visually unreviewable. Reviews-by-vibes followed.

User direction: small screenshots are failures, no matter how nice the partial UI looks.

## Verified

- ✅ TypeScript: \`npx tsc --noEmit -p e2e-tests/tsconfig.json\` exit 0
- ✅ ESLint: \`npx eslint --config .eslintrc.ai.js e2e-tests/fixtures/cdp.fixture.ts e2e-tests/playwright-cdp.config.ts\` exit 0
- ✅ Direct test of \`assertFullHdScreenshot\` on a 640×480 PNG: throws as expected
- ✅ WP-001 functional suite (manage-books): 25/30 passing on fresh fixture, no regressions from the changes (5 \`test.fixme()\` are pre-existing FN-010 / EXT-103 deferrals, not new failures)

## Related

Cherry-picked from feature branch \`ai/feature/manage-books-rolf-03-11-2026\` commit \`e118c90a11\`. Encountered while finishing manage-books Phase 3 UI — the screenshots produced during that run were 469×728 and the user (Rolf) flagged the issue.

## Test plan

- [ ] Run any CDP-mode E2E suite and confirm screenshots are 1920×1080
- [ ] Manually shrink the Electron window before running tests and confirm the fixture throws the documented "viewport enforcement failed" error
- [ ] Manually fake a small screenshot (\`fs.writeFileSync\`) and call \`assertFullHdScreenshot\` to confirm it fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2240)
<!-- Reviewable:end -->
