### PR TITLE
PT-3898: Add conditional sync button to toolbar

### DIFF
--- a/assets/localization/en.json
+++ b/assets/localization/en.json
@@ -372,7 +372,7 @@
   "%theme_label_user_dark%": "User-Defined Dark",
   "%theme_label_user_light%": "User-Defined Light",
   "%toolbar_sync%": "Sync",
-  "%toolbar_sync_projects%": "Sync open projects and linked resources",
+  "%toolbar_sync_open_status%": "Open sync status",
   "%toolbar_sync_status_synced%": "Synced",
   "%toolbar_sync_status_syncing%": "Syncing",
   "%toolbar_theme_change_to_dark%": "Change to Dark theme",

--- a/assets/localization/en.json
+++ b/assets/localization/en.json
@@ -372,7 +372,7 @@
   "%theme_label_user_dark%": "User-Defined Dark",
   "%theme_label_user_light%": "User-Defined Light",
   "%toolbar_sync%": "Sync",
-  "%toolbar_sync_open_status%": "Open sync status",
+  "%toolbar_sync_open_status%": "Sync status",
   "%toolbar_sync_status_synced%": "Synced",
   "%toolbar_sync_status_syncing%": "Syncing",
   "%toolbar_theme_change_to_dark%": "Change to Dark theme",

--- a/assets/localization/en.json
+++ b/assets/localization/en.json
@@ -373,6 +373,8 @@
   "%theme_label_user_light%": "User-Defined Light",
   "%toolbar_sync%": "Sync",
   "%toolbar_sync_projects%": "Sync open projects and linked resources",
+  "%toolbar_sync_status_synced%": "Synced",
+  "%toolbar_sync_status_syncing%": "Syncing",
   "%toolbar_theme_change_to_dark%": "Change to Dark theme",
   "%toolbar_theme_change_to_light%": "Change to Light theme",
   "%toolbar_theme_loading_error%": "There was a problem loading the theme",

--- a/assets/localization/es.json
+++ b/assets/localization/es.json
@@ -492,7 +492,7 @@
   "%theme_label_user_dark%": "Oscuro definido por el usuario",
   "%theme_label_user_light%": "Claro definido por el usuario",
   "%toolbar_sync%": "Sincronizar",
-  "%toolbar_sync_projects%": "Sincroniza los proyectos abiertos y sus recursos vinculados",
+  "%toolbar_sync_open_status%": "Abrir el estado de sincronización",
   "%toolbar_sync_status_synced%": "Sincronizado",
   "%toolbar_sync_status_syncing%": "Sincronizando",
   "%toolbar_theme_change_to_dark%": "Cambiar al tema Oscuro",

--- a/assets/localization/es.json
+++ b/assets/localization/es.json
@@ -493,6 +493,8 @@
   "%theme_label_user_light%": "Claro definido por el usuario",
   "%toolbar_sync%": "Sincronizar",
   "%toolbar_sync_projects%": "Sincroniza los proyectos abiertos y sus recursos vinculados",
+  "%toolbar_sync_status_synced%": "Sincronizado",
+  "%toolbar_sync_status_syncing%": "Sincronizando",
   "%toolbar_theme_change_to_dark%": "Cambiar al tema Oscuro",
   "%toolbar_theme_change_to_light%": "Cambiar al tema Claro",
   "%toolbar_theme_loading_error%": "Hubo un problema al cargar el tema",

--- a/assets/localization/es.json
+++ b/assets/localization/es.json
@@ -492,7 +492,7 @@
   "%theme_label_user_dark%": "Oscuro definido por el usuario",
   "%theme_label_user_light%": "Claro definido por el usuario",
   "%toolbar_sync%": "Sincronizar",
-  "%toolbar_sync_open_status%": "Abrir el estado de sincronización",
+  "%toolbar_sync_open_status%": "Estado de sincronización",
   "%toolbar_sync_status_synced%": "Sincronizado",
   "%toolbar_sync_status_syncing%": "Sincronizando",
   "%toolbar_theme_change_to_dark%": "Cambiar al tema Oscuro",

--- a/extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts
+++ b/extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts
@@ -33,6 +33,7 @@ declare module 'platform-get-resources' {
 
 declare module 'papi-shared-types' {
   import type { IDblResourcesProvider } from 'platform-get-resources';
+  import type { ResultsData } from 'paratext-bible-send-receive';
 
   export interface DataProviders {
     'platformGetResources.dblResourcesProvider': IDblResourcesProvider;
@@ -98,7 +99,7 @@ declare module 'papi-shared-types' {
      * @throws `PlatformUnimplementedException` if not running in an application that implements
      *   this command (e.g., Paratext 10 Studio)
      */
-    'paratextBibleSendReceive.syncProjects': (projectIds?: string[]) => Promise<void>;
+    'paratextBibleSendReceive.syncProjects': (projectIds?: string[]) => Promise<ResultsData>;
 
     /**
      * Gets all open webview project IDs and calls `paratextBibleSendReceive.syncProjects` with

--- a/extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts
+++ b/extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts
@@ -33,7 +33,6 @@ declare module 'platform-get-resources' {
 
 declare module 'papi-shared-types' {
   import type { IDblResourcesProvider } from 'platform-get-resources';
-  import type { ResultsData } from 'paratext-bible-send-receive';
 
   export interface DataProviders {
     'platformGetResources.dblResourcesProvider': IDblResourcesProvider;
@@ -99,7 +98,7 @@ declare module 'papi-shared-types' {
      * @throws `PlatformUnimplementedException` if not running in an application that implements
      *   this command (e.g., Paratext 10 Studio)
      */
-    'paratextBibleSendReceive.syncProjects': (projectIds?: string[]) => Promise<ResultsData>;
+    'paratextBibleSendReceive.syncProjects': (projectIds?: string[]) => Promise<void>;
 
     /**
      * Gets all open webview project IDs and calls `paratextBibleSendReceive.syncProjects` with

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -3543,6 +3543,8 @@ declare module 'papi-shared-types' {
     'platform.closeOpenUsersnapForm': () => Promise<void>;
     'test.addMany': (...nums: number[]) => number;
     'test.throwErrorExtensionHost': (message: string) => void;
+    /** Opens the Sync Status floating window. Returns the web view id, or undefined on failure. */
+    'paratextBibleSendReceive.openSyncStatus': () => Promise<string | undefined>;
   }
   /**
    * Names for each command available on the papi.
@@ -3552,6 +3554,39 @@ declare module 'papi-shared-types' {
    * @example 'platform.quit';
    */
   type CommandNames = keyof CommandHandlers;
+  /**
+   * Event data types for each network event available on the papi. Each extension can extend this
+   * interface to add events it emits with `papi.network.createNetworkEventEmitter`.
+   *
+   * Note: Event names must consist of two strings separated by at least one period. We recommend
+   * one period and lower camel case in case we expand the api in the future to allow dot notation.
+   *
+   * An extension can extend this interface to add types for the network events it emits by adding
+   * the following to its `.d.ts` file:
+   *
+   * @example
+   *
+   * ```typescript
+   * declare module 'papi-shared-types' {
+   *   export interface NetworkEventHandlers {
+   *     'myExtension.onSomethingChanged': { someData: string };
+   *   }
+   * }
+   * ```
+   */
+  interface NetworkEventHandlers {
+    /** Fired by paratextBibleSendReceive whenever a sync starts or ends. */
+    'paratextBibleSendReceive.onSyncStateChanged': {
+      isSyncing: boolean;
+    };
+  }
+  /**
+   * Names for each network event available on the papi.
+   *
+   * Automatically includes all extensions' network events that are added to
+   * {@link NetworkEventHandlers}.
+   */
+  type NetworkEventNames = keyof NetworkEventHandlers;
   /**
    * Types corresponding to each user setting available in Platform.Bible. Keys are setting names,
    * and values are setting data types. Extensions can add more user setting types with

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -3543,8 +3543,6 @@ declare module 'papi-shared-types' {
     'platform.closeOpenUsersnapForm': () => Promise<void>;
     'test.addMany': (...nums: number[]) => number;
     'test.throwErrorExtensionHost': (message: string) => void;
-    /** Opens the Sync Status floating window. Returns the web view id, or undefined on failure. */
-    'paratextBibleSendReceive.openSyncStatus': () => Promise<string | undefined>;
   }
   /**
    * Names for each command available on the papi.
@@ -3574,12 +3572,7 @@ declare module 'papi-shared-types' {
    * }
    * ```
    */
-  interface NetworkEventHandlers {
-    /** Fired by paratextBibleSendReceive whenever a sync starts or ends. */
-    'paratextBibleSendReceive.onSyncStateChanged': {
-      isSyncing: boolean;
-    };
-  }
+  interface NetworkEventHandlers {}
   /**
    * Names for each network event available on the papi.
    *

--- a/lib/platform-bible-react/src/index.css
+++ b/lib/platform-bible-react/src/index.css
@@ -49,7 +49,7 @@
     --accent-foreground: 222.2 47.4% 11.2%; /* slate-900 */
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%; /* slate-50 */
-    --success: 142 70% 36%; /* green-600 ish — readable on light backgrounds */
+    --success: 142 70% 36%; /* green-600; lightness raised to 50% in dark theme for contrast */
     --border: 214.3 31.8% 91.4%; /* slate-200 */
     --input: 214.3 31.8% 91.4%; /* slate-200 */
     --ring: 222.2 84% 4.9%; /* slate-950 */
@@ -83,7 +83,7 @@
     --accent-foreground: 210 40% 98%; /* slate-50 */
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%; /* slate-50 */
-    --success: 142 70% 50%; /* brighter green for dark backgrounds */
+    --success: 142 70% 50%; /* green-600 with lightness raised from 36% for contrast on dark backgrounds */
     --border: 215.3 19.3% 34.5%; /* slate-600 */
     --input: 215.3 19.3% 34.5%; /* slate-600 */
     --ring: 212.7 26.8% 83.9%; /* slate-300 */

--- a/lib/platform-bible-react/src/index.css
+++ b/lib/platform-bible-react/src/index.css
@@ -49,6 +49,7 @@
     --accent-foreground: 222.2 47.4% 11.2%; /* slate-900 */
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 40% 98%; /* slate-50 */
+    --success: 142 70% 36%; /* green-600 ish — readable on light backgrounds */
     --border: 214.3 31.8% 91.4%; /* slate-200 */
     --input: 214.3 31.8% 91.4%; /* slate-200 */
     --ring: 222.2 84% 4.9%; /* slate-950 */
@@ -82,6 +83,7 @@
     --accent-foreground: 210 40% 98%; /* slate-50 */
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 210 40% 98%; /* slate-50 */
+    --success: 142 70% 50%; /* brighter green for dark backgrounds */
     --border: 215.3 19.3% 34.5%; /* slate-600 */
     --input: 215.3 19.3% 34.5%; /* slate-600 */
     --ring: 212.7 26.8% 83.9%; /* slate-300 */
@@ -116,6 +118,7 @@
     --accent-foreground: 0 0% 12.549%;
     --destructive: 10.1639 77.8723% 53.9216%;
     --destructive-foreground: 0 0% 100%;
+    --success: 142 70% 36%;
     --ring: 16.6667 21.9512% 32.1569%;
 
     /* WARN: in Shadcn files, `--sidebar-background` is `--sidebar`
@@ -150,6 +153,7 @@
     --accent-foreground: 0 0% 93.3333%;
     --destructive: 10.1639 77.8723% 53.9216%;
     --destructive-foreground: 0 0% 100%;
+    --success: 142 70% 50%;
     --ring: 29.5082 100% 88.0392%;
 
     --sidebar-background: 240 5.8824% 10%;

--- a/lib/platform-bible-react/tailwind.config.ts
+++ b/lib/platform-bible-react/tailwind.config.ts
@@ -49,6 +49,7 @@ const config: Config = {
           DEFAULT: 'hsl(var(--accent))',
           foreground: 'hsl(var(--accent-foreground))',
         },
+        success: 'hsl(var(--success))',
         popover: {
           DEFAULT: 'hsl(var(--popover))',
           foreground: 'hsl(var(--popover-foreground))',

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -112,11 +112,6 @@ declare module 'papi-shared-types' {
     // `extension-host.ts`
     'test.addMany': (...nums: number[]) => number;
     'test.throwErrorExtensionHost': (message: string) => void;
-
-    // These commands are provided by the paratextBibleSendReceive extension. They are declared here
-    // so core renderer code (e.g. toolbar) can call them with type safety.
-    /** Opens the Sync Status floating window. Returns the web view id, or undefined on failure. */
-    'paratextBibleSendReceive.openSyncStatus': () => Promise<string | undefined>;
   }
 
   /**
@@ -148,10 +143,7 @@ declare module 'papi-shared-types' {
    * }
    * ```
    */
-  export interface NetworkEventHandlers {
-    /** Fired by paratextBibleSendReceive whenever a sync starts or ends. */
-    'paratextBibleSendReceive.onSyncStateChanged': { isSyncing: boolean };
-  }
+  export interface NetworkEventHandlers {}
 
   /**
    * Names for each network event available on the papi.

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -112,6 +112,11 @@ declare module 'papi-shared-types' {
     // `extension-host.ts`
     'test.addMany': (...nums: number[]) => number;
     'test.throwErrorExtensionHost': (message: string) => void;
+
+    // These commands are provided by the paratextBibleSendReceive extension. They are declared here
+    // so core renderer code (e.g. toolbar) can call them with type safety.
+    /** Opens the Sync Status floating window. Returns the web view id, or undefined on failure. */
+    'paratextBibleSendReceive.openSyncStatus': () => Promise<string | undefined>;
   }
 
   /**
@@ -122,6 +127,39 @@ declare module 'papi-shared-types' {
    * @example 'platform.quit';
    */
   export type CommandNames = keyof CommandHandlers;
+
+  /**
+   * Event data types for each network event available on the papi. Each extension can extend this
+   * interface to add events it emits with `papi.network.createNetworkEventEmitter`.
+   *
+   * Note: Event names must consist of two strings separated by at least one period. We recommend
+   * one period and lower camel case in case we expand the api in the future to allow dot notation.
+   *
+   * An extension can extend this interface to add types for the network events it emits by adding
+   * the following to its `.d.ts` file:
+   *
+   * @example
+   *
+   * ```typescript
+   * declare module 'papi-shared-types' {
+   *   export interface NetworkEventHandlers {
+   *     'myExtension.onSomethingChanged': { someData: string };
+   *   }
+   * }
+   * ```
+   */
+  export interface NetworkEventHandlers {
+    /** Fired by paratextBibleSendReceive whenever a sync starts or ends. */
+    'paratextBibleSendReceive.onSyncStateChanged': { isSyncing: boolean };
+  }
+
+  /**
+   * Names for each network event available on the papi.
+   *
+   * Automatically includes all extensions' network events that are added to
+   * {@link NetworkEventHandlers}.
+   */
+  export type NetworkEventNames = keyof NetworkEventHandlers;
 
   // #endregion
 

--- a/src/renderer/components/platform-bible-toolbar.test.tsx
+++ b/src/renderer/components/platform-bible-toolbar.test.tsx
@@ -17,9 +17,9 @@ vi.mock('@renderer/hooks/papi-hooks', () => ({
   useLocalizedStrings: vi.fn(() => [
     {
       '%toolbar_sync%': 'Sync',
-      '%toolbar_sync_open_status%': 'Open sync status',
-      '%toolbar_sync_status_synced%': 'Synced',
-      '%toolbar_sync_status_syncing%': 'Syncing',
+      '%toolbar_sync_open_status%': 'Test Sync status',
+      '%toolbar_sync_status_synced%': 'Test Synced',
+      '%toolbar_sync_status_syncing%': 'Test Syncing',
       '%mainMenu_openHome%': 'Home',
       '%mainMenu_openParatextRegistration%': 'Registration',
       '%mainMenu_openInternetSettings%': 'Internet Settings',
@@ -254,7 +254,7 @@ describe('PlatformBibleToolbar — Sync button', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Syncing' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Test Syncing' })).toBeInTheDocument();
     });
   });
 
@@ -292,7 +292,7 @@ describe('PlatformBibleToolbar — Sync button', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Synced' })).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Test Synced' })).toBeInTheDocument();
     });
   });
 

--- a/src/renderer/components/platform-bible-toolbar.test.tsx
+++ b/src/renderer/components/platform-bible-toolbar.test.tsx
@@ -169,14 +169,14 @@ describe('PlatformBibleToolbar — Sync button', () => {
     });
   });
 
-  it('calls syncOpenProjects command when clicked', async () => {
+  it('calls openSyncStatus command when clicked', async () => {
     mockSendCommand(true);
     render(<PlatformBibleToolbar />);
     const btn = await screen.findByRole('button', { name: 'Sync' });
     fireEvent.click(btn);
     await waitFor(() => {
       expect(vi.mocked(sendCommand)).toHaveBeenLastCalledWith(
-        'paratextBibleSendReceive.syncOpenProjects',
+        'paratextBibleSendReceive.openSyncStatus',
       );
     });
   });
@@ -218,13 +218,13 @@ describe('PlatformBibleToolbar — Sync button', () => {
     });
   });
 
-  it('logs a warning when syncOpenProjects command fails', async () => {
+  it('logs a warning when openSyncStatus command fails', async () => {
     const { logger } = await import('@shared/services/logger.service');
     vi.mocked(sendCommand).mockImplementation(
       // sendCommand has a complex generic signature; cast is required for the mock implementation
       // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
       (async (commandName: string) => {
-        if (commandName === 'paratextBibleSendReceive.syncOpenProjects')
+        if (commandName === 'paratextBibleSendReceive.openSyncStatus')
           throw new Error('Sync failed');
         if (commandName === 'platformGetResources.isSendReceiveAvailable') return true;
         if (commandName === 'platform.getOSPlatform') return 'win32';
@@ -239,7 +239,7 @@ describe('PlatformBibleToolbar — Sync button', () => {
     fireEvent.click(btn);
     await waitFor(() => {
       expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
-        expect.stringContaining('Toolbar caught an error while trying to sync open projects:'),
+        expect.stringContaining('Toolbar caught an error while trying to open sync status:'),
       );
     });
   });

--- a/src/renderer/components/platform-bible-toolbar.test.tsx
+++ b/src/renderer/components/platform-bible-toolbar.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import React from 'react';
@@ -17,7 +17,9 @@ vi.mock('@renderer/hooks/papi-hooks', () => ({
   useLocalizedStrings: vi.fn(() => [
     {
       '%toolbar_sync%': 'Sync',
-      '%toolbar_sync_projects%': 'Sync open projects and linked resources',
+      '%toolbar_sync_open_status%': 'Open sync status',
+      '%toolbar_sync_status_synced%': 'Synced',
+      '%toolbar_sync_status_syncing%': 'Syncing',
       '%mainMenu_openHome%': 'Home',
       '%mainMenu_openParatextRegistration%': 'Registration',
       '%mainMenu_openInternetSettings%': 'Internet Settings',
@@ -215,6 +217,82 @@ describe('PlatformBibleToolbar — Sync button', () => {
           .mock.calls.filter(([cmd]) => cmd === 'platformGetResources.isSendReceiveAvailable')
           .length,
       ).toBeGreaterThan(callsBefore);
+    });
+  });
+
+  it('shows Syncing label when onSyncStateChanged fires with isSyncing: true', async () => {
+    let capturedSyncStateCallback: ((arg: { isSyncing: boolean }) => void) | undefined;
+    vi.mocked(getNetworkEvent).mockImplementation(
+      // getNetworkEvent has a complex generic signature; cast is required for the mock implementation
+      // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
+      ((eventName: string) => {
+        if (eventName === 'paratextBibleSendReceive.onSyncStateChanged')
+          return vi.fn((cb: (arg: { isSyncing: boolean }) => void) => {
+            capturedSyncStateCallback = cb;
+            return vi.fn();
+          });
+        return vi.fn(() => vi.fn());
+        // getNetworkEvent has a complex generic signature; cast is required for the mock implementation
+        // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
+      }) as any,
+    );
+
+    mockSendCommand(true);
+    render(<PlatformBibleToolbar />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Sync' })).toBeInTheDocument();
+    });
+
+    expect(capturedSyncStateCallback).toBeDefined();
+    if (!capturedSyncStateCallback)
+      throw new Error('capturedSyncStateCallback was not set by mock');
+
+    const syncStateCallback = capturedSyncStateCallback;
+    act(() => {
+      syncStateCallback({ isSyncing: true });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Syncing' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows Synced label when onSyncStateChanged fires with isSyncing: false', async () => {
+    let capturedSyncStateCallback: ((arg: { isSyncing: boolean }) => void) | undefined;
+    vi.mocked(getNetworkEvent).mockImplementation(
+      // getNetworkEvent has a complex generic signature; cast is required for the mock implementation
+      // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
+      ((eventName: string) => {
+        if (eventName === 'paratextBibleSendReceive.onSyncStateChanged')
+          return vi.fn((cb: (arg: { isSyncing: boolean }) => void) => {
+            capturedSyncStateCallback = cb;
+            return vi.fn();
+          });
+        return vi.fn(() => vi.fn());
+        // getNetworkEvent has a complex generic signature; cast is required for the mock implementation
+        // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
+      }) as any,
+    );
+
+    mockSendCommand(true);
+    render(<PlatformBibleToolbar />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Sync' })).toBeInTheDocument();
+    });
+
+    expect(capturedSyncStateCallback).toBeDefined();
+    if (!capturedSyncStateCallback)
+      throw new Error('capturedSyncStateCallback was not set by mock');
+
+    const syncStateCallback = capturedSyncStateCallback;
+    act(() => {
+      syncStateCallback({ isSyncing: false });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Synced' })).toBeInTheDocument();
     });
   });
 

--- a/src/renderer/components/platform-bible-toolbar.tsx
+++ b/src/renderer/components/platform-bible-toolbar.tsx
@@ -33,7 +33,6 @@ import {
   useEvent,
   usePromise,
 } from 'platform-bible-react';
-import type { NetworkEventHandlers } from 'papi-shared-types';
 import {
   getErrorMessage,
   getLocalizeKeysForScrollGroupIds,
@@ -166,10 +165,7 @@ export function PlatformBibleToolbar() {
   );
 
   const onSyncStateChanged = useMemo(
-    () =>
-      getNetworkEvent<NetworkEventHandlers['paratextBibleSendReceive.onSyncStateChanged']>(
-        'paratextBibleSendReceive.onSyncStateChanged',
-      ),
+    () => getNetworkEvent<{ isSyncing: boolean }>('paratextBibleSendReceive.onSyncStateChanged'),
     [],
   );
   useEvent(onSyncStateChanged, handleSyncStateChanged);
@@ -263,10 +259,13 @@ export function PlatformBibleToolbar() {
                     aria-hidden={isSendReceiveAvailable === undefined || undefined}
                     tabIndex={isSendReceiveAvailable === undefined ? -1 : undefined}
                     onClick={() => {
-                      sendCommand('paratextBibleSendReceive.openSyncStatus').catch((e: unknown) =>
-                        logger.warn(
-                          `Toolbar caught an error while trying to open sync status: ${getErrorMessage(e)}`,
-                        ),
+                      // This command comes from an extension and is not typed in CommandHandlers.
+                      // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
+                      (sendCommand as any)('paratextBibleSendReceive.openSyncStatus').catch(
+                        (e: unknown) =>
+                          logger.warn(
+                            `Toolbar caught an error while trying to open sync status: ${getErrorMessage(e)}`,
+                          ),
                       );
                     }}
                   >

--- a/src/renderer/components/platform-bible-toolbar.tsx
+++ b/src/renderer/components/platform-bible-toolbar.tsx
@@ -16,7 +16,7 @@ import { getNetworkEvent } from '@shared/services/network.service';
 import { logger } from '@shared/services/logger.service';
 import { ScrollGroupScrRef } from '@shared/services/scroll-group.service-model';
 import { themeServiceDataProviderName } from '@shared/services/theme.service-model';
-import { CircleUserRound, HomeIcon, Moon, Network, Sun } from 'lucide-react';
+import { CircleCheck, CircleUserRound, HomeIcon, Moon, Network, Sun } from 'lucide-react';
 import {
   Badge,
   BookChapterControl,
@@ -24,6 +24,7 @@ import {
   cn,
   getToolbarOSReservedSpaceClassName,
   ScrollGroupSelector,
+  Spinner,
   Toolbar,
   Tooltip,
   TooltipContent,
@@ -72,6 +73,8 @@ const LOCALIZED_STRING_KEYS: LocalizeKey[] = [
   '%toolbar_theme_loading_error%',
   '%toolbar_sync%',
   '%toolbar_sync_projects%',
+  '%toolbar_sync_status_synced%',
+  '%toolbar_sync_status_syncing%',
 ];
 
 export function PlatformBibleToolbar() {
@@ -153,6 +156,19 @@ export function PlatformBibleToolbar() {
   const [isSendReceiveAvailable, setIsSendReceiveAvailable] = useState<boolean | undefined>(
     undefined,
   );
+
+  const [syncState, setSyncState] = useState<'idle' | 'syncing' | 'synced'>('idle');
+
+  const handleSyncStateChanged = useCallback(
+    ({ isSyncing }: { isSyncing: boolean }) => setSyncState(isSyncing ? 'syncing' : 'synced'),
+    [],
+  );
+
+  const onSyncStateChanged = useMemo(
+    () => getNetworkEvent<{ isSyncing: boolean }>('paratextBibleSendReceive.onSyncStateChanged'),
+    [],
+  );
+  useEvent(onSyncStateChanged, handleSyncStateChanged);
 
   const checkIfSendReceiveAvailable = useCallback(async () => {
     try {
@@ -243,17 +259,24 @@ export function PlatformBibleToolbar() {
                     aria-hidden={isSendReceiveAvailable === undefined || undefined}
                     tabIndex={isSendReceiveAvailable === undefined ? -1 : undefined}
                     onClick={() => {
-                      // This command comes from an extension and is not typed in CommandHandlers.
-                      // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
-                      (sendCommand as any)('paratextBibleSendReceive.syncOpenProjects').catch(
-                        (e: unknown) =>
-                          logger.warn(
-                            `Toolbar caught an error while trying to sync open projects: ${getErrorMessage(e)}`,
-                          ),
+                      sendCommand('paratextBibleSendReceive.openSyncStatus').catch((e: unknown) =>
+                        logger.warn(
+                          `Toolbar caught an error while trying to open sync status: ${getErrorMessage(e)}`,
+                        ),
                       );
                     }}
                   >
-                    {localizedStrings['%toolbar_sync%']}
+                    {syncState === 'syncing' && <Spinner className="tw-h-4 tw-w-4" />}
+                    {syncState === 'synced' && (
+                      <CircleCheck className="tw-h-4 tw-w-4 tw-text-green-500" />
+                    )}
+                    {
+                      {
+                        idle: localizedStrings['%toolbar_sync%'],
+                        syncing: localizedStrings['%toolbar_sync_status_syncing%'],
+                        synced: localizedStrings['%toolbar_sync_status_synced%'],
+                      }[syncState]
+                    }
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>

--- a/src/renderer/components/platform-bible-toolbar.tsx
+++ b/src/renderer/components/platform-bible-toolbar.tsx
@@ -33,6 +33,7 @@ import {
   useEvent,
   usePromise,
 } from 'platform-bible-react';
+import type { NetworkEventHandlers } from 'papi-shared-types';
 import {
   getErrorMessage,
   getLocalizeKeysForScrollGroupIds,
@@ -72,7 +73,7 @@ const LOCALIZED_STRING_KEYS: LocalizeKey[] = [
   '%toolbar_theme_loading%',
   '%toolbar_theme_loading_error%',
   '%toolbar_sync%',
-  '%toolbar_sync_projects%',
+  '%toolbar_sync_open_status%',
   '%toolbar_sync_status_synced%',
   '%toolbar_sync_status_syncing%',
 ];
@@ -165,7 +166,10 @@ export function PlatformBibleToolbar() {
   );
 
   const onSyncStateChanged = useMemo(
-    () => getNetworkEvent<{ isSyncing: boolean }>('paratextBibleSendReceive.onSyncStateChanged'),
+    () =>
+      getNetworkEvent<NetworkEventHandlers['paratextBibleSendReceive.onSyncStateChanged']>(
+        'paratextBibleSendReceive.onSyncStateChanged',
+      ),
     [],
   );
   useEvent(onSyncStateChanged, handleSyncStateChanged);
@@ -268,7 +272,7 @@ export function PlatformBibleToolbar() {
                   >
                     {syncState === 'syncing' && <Spinner className="tw-h-4 tw-w-4" />}
                     {syncState === 'synced' && (
-                      <CircleCheck className="tw-h-4 tw-w-4 tw-text-green-500" />
+                      <CircleCheck className="tw-h-4 tw-w-4 tw-text-success" />
                     )}
                     {
                       {
@@ -280,7 +284,7 @@ export function PlatformBibleToolbar() {
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent>
-                  <p className="tw-font-light">{localizedStrings['%toolbar_sync_projects%']}</p>
+                  <p className="tw-font-light">{localizedStrings['%toolbar_sync_open_status%']}</p>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-3898-notify-sync-outcome

**Base**: origin/main

**Date**: 2026-05-04

**Review model**: Claude Sonnet 4.6

**Files changed**: 6

## Overview

This branch adds a provisional sync button to the Platform.Bible toolbar that is only visible when the `paratextBibleSendReceive` extension reports that send/receive is available. The button calls `openSyncStatus` to open a sync status panel (rather than triggering a sync directly), and reflects live sync progress via a three-state model: `idle` → `syncing` → `synced`, driven by a new `onSyncStateChanged` network event. To enable type-safe calls from core toolbar code, the extension's command and event are declared in core `papi-shared-types.ts` alongside a new `NetworkEventHandlers` extensibility interface (mirroring the existing `CommandHandlers` pattern).

Several issues were fixed during the review: missing tests for the `syncing`/`synced` states were added, the hardcoded `tw-text-green-500` color was replaced with a new semantic `--success` CSS variable, the tooltip text was updated to accurately describe the action ("Open sync status"), and the inline `{ isSyncing: boolean }` type annotation was replaced with a reference to `NetworkEventHandlers` to keep the single source of truth in `papi-shared-types`.

## API Changes

- `papi-shared-types` (`src/declarations/papi-shared-types.ts` and generated `lib/papi-dts/papi.d.ts`): Added `CommandHandlers` entry `'paratextBibleSendReceive.openSyncStatus': () => Promise<string | undefined>`
- `papi-shared-types`: Added new `NetworkEventHandlers` interface (extensible via module augmentation) with entry `'paratextBibleSendReceive.onSyncStateChanged': { isSyncing: boolean }`
- `papi-shared-types`: Added new `NetworkEventNames` type alias (`keyof NetworkEventHandlers`)

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] ~~`src/declarations/papi-shared-types.ts` — `NetworkEventHandlers` and `NetworkEventNames` are not wired into `getNetworkEvent` / `createNetworkEventEmitter` function signatures (those still accept plain `string`), so extension developers cannot benefit from the type-safe event registry yet.~~ _(intentional scope limit: connecting these to the function signatures is non-trivial and is planned as follow-up work)_

- [x] `src/declarations/papi-shared-types.ts:54,151` — `'paratextBibleSendReceive.openSyncStatus'` (command) and `'paratextBibleSendReceive.onSyncStateChanged'` (event) are declared in core `papi-shared-types.ts` rather than in the extension's own type declarations. The inline comment explains the rationale (type-safe calls from core toolbar code), but it means these entries appear as always-present in the API surface even when the extension is absent.

[Author response: Decision was made to enable global type safety. Author is open to moving these out of core if a better pattern is available — explicitly flagged for reviewer discussion.]

- [x] `src/renderer/components/platform-bible-toolbar.test.tsx` — No tests for the `syncing` or `synced` state transitions. _(fixed during review: added two tests — "shows Syncing label when onSyncStateChanged fires with isSyncing: true" and "shows Synced label when onSyncStateChanged fires with isSyncing: false"; also added missing `%toolbar_sync_status_synced%` and `%toolbar_sync_status_syncing%` localization keys to the mock)_

- [x] `src/renderer/components/platform-bible-toolbar.tsx:271` — `tw-text-green-500` hardcoded Tailwind palette color, not theme-aware. _(fixed during review: added `--success` CSS variable to all four theme variants in `lib/platform-bible-react/src/index.css`, added `success` color to `lib/platform-bible-react/tailwind.config.ts`, replaced `tw-text-green-500` with `tw-text-success`)_

- [x] `src/renderer/components/platform-bible-toolbar.tsx:283` — Tooltip used `%toolbar_sync_projects%` ("Sync open projects and linked resources"), which describes an immediate sync but the button now opens a status panel. _(fixed during review: renamed key to `%toolbar_sync_open_status%` = "Open sync status" / "Abrir el estado de sincronización" in both `en.json` and `es.json`; retired the old unused key)_

[Author response: Confirmed fix for findings 3–5. Finding 2 flagged for reviewer discussion.]

### Minor — Consider

- [x] ~~`src/declarations/papi-shared-types.ts:151` — `NetworkEventHandlers` entry for `paratextBibleSendReceive.onSyncStateChanged` lives in core rather than the extension's type file — same coupling concern as the Important finding above.~~ _(same rationale applies; already flagged above for reviewer)_

- [x] `src/renderer/components/platform-bible-toolbar.tsx:168` — Inline type `{ isSyncing: boolean }` on `getNetworkEvent<...>` duplicated the declaration in `NetworkEventHandlers`, creating a potential divergence risk. _(fixed during review: replaced with `NetworkEventHandlers['paratextBibleSendReceive.onSyncStateChanged']`)_

- [x] ~~`assets/localization/en.json` — "Syncing" and "Synced" button labels pair icon and text that convey the same meaning; icon-only at narrow widths might reduce visual noise.~~ _(intentional design choice — author confirmed pairing is deliberate)_

[Author response: Minor 2 fixed. Minor 3 is an intentional design decision.]

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- The PR removes a pre-existing `eslint-disable` / `as any` cast on `paratextBibleSendReceive.openSyncStatus` by properly typing the command in `CommandHandlers` — genuine improvement in type safety.
- `papi.d.ts` was regenerated via `npm run build:types` rather than hand-edited, consistent with existing conventions.
- `NetworkEventHandlers` / `NetworkEventNames` mirrors the existing `CommandHandlers` / `CommandNames` extensibility pattern, making it easy for extension authors to understand.
- The object-map pattern for label text from `syncState` (`{ idle: ..., syncing: ..., synced: ... }[syncState]`) is clean and scales well if additional states are needed.
- New `NetworkEventHandlers` interface is well-documented with a TSDoc comment and `@example` showing how extensions extend it.
- The inline comment explaining why `tw-invisible`, `aria-hidden`, and `tabIndex=-1` are all required is excellent — documents a subtle invariant that would otherwise be surprising to future readers.
- All user-visible strings are properly routed through `useLocalizedStrings`; both `en.json` and `es.json` were updated in the same PR.
- Existing tests were correctly updated to match the renamed command (`syncOpenProjects` → `openSyncStatus`).
- `ghost` variant and `size="sm"` are consistent with the toolbar's existing button style.
- Button label and feature name use "Sync" consistently with the product naming guide.

## Interview Notes

Author's stated purpose: add a provisional sync button to the toolbar that only appears when the `paratextBibleSendReceive` extension's send/receive feature is available.

**Finding 1 (NetworkEventHandlers not wired to getNetworkEvent):** Author confirmed this is intentional scope-limiting — wiring the type into the function signatures is non-trivial and is planned as a follow-up. Not a gap introduced by this PR.

**Finding 2 (extension types in core papi-shared-types):** Author acknowledged the coupling concern and stated the decision was made to enable global type safety for core toolbar code. Author is explicitly open to moving these out of core if a better pattern exists — this is the primary design question for the reviewer to weigh in on.

**Findings 3–5:** All fixed during the review at author's request.

**Minor 3 (icon + text redundancy in synced/syncing states):** Author confirmed this is an intentional design choice.

No areas of uncertainty were expressed. Author had clear explanations for all decisions.

## In-Review Quality Check

Changes were made during the interview (tests, CSS variable, tooltip key rename, type annotation fix). Quality checks run after all changes:

- **`npm run typecheck`**: Passed cleanly.
- **`npm run lint`**: Initially failed; auto-fixed by `lint-fix`. Issues fixed: Tailwind class order on `CircleCheck` (`tw-text-success` moved after size classes per linter rule), `eslint-disable-next-line` comments in new tests required explanatory comment on preceding line (`paranext/require-disable-comment`), non-null assertion `capturedSyncStateCallback!` inside `act()` closure replaced with a narrowed local `const` variable to satisfy `no-type-assertion/no-type-assertion`.
- **`npm run format`**: Passed with no changes needed.
- **Tests (toolbar)**: 8/8 passed.

## Suggested Review Focus

- [x] **Extension types in core `papi-shared-types.ts`** — `'paratextBibleSendReceive.openSyncStatus'` and `'paratextBibleSendReceive.onSyncStateChanged'` are declared in core shared types to enable type-safe toolbar code. Author is open to moving them if a better pattern exists. Is this the right long-term approach, or should a mechanism for "optional extension commands known to core" be established?
- [ ] **`NetworkEventHandlers` / `getNetworkEvent` type gap** — The new registry is not yet connected to the `getNetworkEvent` / `createNetworkEventEmitter` signatures. Author confirmed follow-up is planned. Agree this is the right scope boundary, or should it be closed in this PR?
- [ ] **`--success` CSS variable values** — Light themes use `142 70% 36%`, dark themes `142 70% 50%`. Do these feel right, or should a designer sign off on the green hue/lightness before this ships?

<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2242)
<!-- Reviewable:end -->
