### PR TITLE
Sync stitching

### DIFF
--- a/c-sharp-tests/DummyLocalParatextProjects.cs
+++ b/c-sharp-tests/DummyLocalParatextProjects.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Paranext.DataProvider;
 using Paranext.DataProvider.Projects;
 using Paratext.Data;
 
@@ -7,6 +8,9 @@ namespace TestParanextDataProvider
     [ExcludeFromCodeCoverage]
     internal class DummyLocalParatextProjects : LocalParatextProjects
     {
+        public DummyLocalParatextProjects()
+            : base(new AppInfo("platform-bible", "0.0.0", "platform-bible")) { }
+
         public void FakeAddProject(ProjectDetails details, ScrText? scrText = null)
         {
             scrText ??= new DummyScrText(details);

--- a/c-sharp-tests/DummyLocalParatextProjects.cs
+++ b/c-sharp-tests/DummyLocalParatextProjects.cs
@@ -9,7 +9,7 @@ namespace TestParanextDataProvider
     internal class DummyLocalParatextProjects : LocalParatextProjects
     {
         public DummyLocalParatextProjects()
-            : base(new AppInfo("platform-bible", "0.0.0", "platform-bible")) { }
+            : base(new AppInfo("test-app", "0.0.0", "test-app")) { }
 
         public void FakeAddProject(ProjectDetails details, ScrText? scrText = null)
         {

--- a/c-sharp-tests/Projects/TestLocalParatextProjectsInTempDir.cs
+++ b/c-sharp-tests/Projects/TestLocalParatextProjectsInTempDir.cs
@@ -1,3 +1,4 @@
+using Paranext.DataProvider;
 using Paranext.DataProvider.Projects;
 using Paratext.Data;
 using SIL.TestUtilities;
@@ -10,6 +11,7 @@ namespace TestParanextDataProvider.Projects
         private TemporaryFolder _folder;
 
         public TestLocalParatextProjectsInTempDir()
+            : base(new AppInfo("platform-bible", "0.0.0", "platform-bible"))
         {
             _folder = new TemporaryFolder(TestContext.CurrentContext.Test.ID);
         }

--- a/c-sharp-tests/Projects/TestLocalParatextProjectsInTempDir.cs
+++ b/c-sharp-tests/Projects/TestLocalParatextProjectsInTempDir.cs
@@ -11,7 +11,7 @@ namespace TestParanextDataProvider.Projects
         private TemporaryFolder _folder;
 
         public TestLocalParatextProjectsInTempDir()
-            : base(new AppInfo("platform-bible", "0.0.0", "platform-bible"))
+            : base(new AppInfo("test-app", "0.0.0", "test-app"))
         {
             _folder = new TemporaryFolder(TestContext.CurrentContext.Test.ID);
         }

--- a/c-sharp/Program.cs
+++ b/c-sharp/Program.cs
@@ -58,7 +58,7 @@ public static class Program
             );
             ParatextInfo.ParatextVersion = appVersion;
 
-            var paratextProjects = new LocalParatextProjects();
+            var paratextProjects = new LocalParatextProjects(appInfo);
 
             // Adapted from Paratext's `Program.StaticInitialization`
             ParatextDataSettings.Initialize(new PersistedParatextDataSettings(papi));

--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -55,10 +55,7 @@ internal class LocalParatextProjects
             "Paratext 9 Projects"
         );
 
-        Paratext9ProjectsFolder = Path.Join(
-            Path.GetPathRoot(Environment.CurrentDirectory),
-            "My Paratext 9 Projects"
-        );
+        Paratext9ProjectsFolder = ComputeParatext9ProjectsFolder();
     }
 
     #endregion
@@ -123,6 +120,9 @@ internal class LocalParatextProjects
     {
         return [.. s_paratextProjectInterfaces];
     }
+
+    public static string ComputeParatext9ProjectsFolder() =>
+        Path.Join(Path.GetPathRoot(Environment.CurrentDirectory), "My Paratext 9 Projects");
 
     #endregion
 

--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -46,11 +46,11 @@ internal class LocalParatextProjects
         ProjectInterfaces.MARKER_NAMES,
     ];
 
-    public LocalParatextProjects()
+    public LocalParatextProjects(AppInfo appInfo)
     {
         ProjectRootFolder = Path.Join(
             Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".platform.bible",
+            $".{appInfo.Name}",
             "projects",
             "Paratext 9 Projects"
         );

--- a/extensions/src/platform-get-resources/src/home.web-view.tsx
+++ b/extensions/src/platform-get-resources/src/home.web-view.tsx
@@ -101,6 +101,14 @@ globalThis.webViewComponent = function HomeWebView() {
 
   const [isSendReceiveInProgress, setIsSendReceiveInProgress] = useState<boolean>(false);
   const [activeSendReceiveProjects, setActiveSendReceiveProjects] = useState<string[]>([]);
+  const [syncRefreshKey, setSyncRefreshKey] = useState<number>(0);
+
+  useEvent(
+    papi.network.getNetworkEvent('paratextBibleSendReceive.onSyncStateChanged'),
+    useCallback(({ isSyncing }: { isSyncing: boolean }) => {
+      if (!isSyncing) setSyncRefreshKey((k) => k + 1);
+    }, []),
+  );
 
   const sendReceiveProject = async (projectId: string) => {
     if (!isSendReceiveAvailable) return;
@@ -189,7 +197,12 @@ globalThis.webViewComponent = function HomeWebView() {
       // Mark this promise as old and not to be used
       promiseIsCurrent = false;
     };
-  }, [isSendReceiveAvailable, isSendReceiveInProgress, sharedProjectErrorNotificationId]);
+  }, [
+    isSendReceiveAvailable,
+    isSendReceiveInProgress,
+    sharedProjectErrorNotificationId,
+    syncRefreshKey,
+  ]);
 
   const [localProjectsInfo, setLocalProjectsInfo] = useState<LocalProjectInfo[]>([]);
   const [isLoadingLocalProjects, setIsLoadingLocalProjects] = useState<boolean>(true);
@@ -245,7 +258,7 @@ globalThis.webViewComponent = function HomeWebView() {
       // Mark this promise as old and not to be used
       promiseIsCurrent = false;
     };
-  }, [isSendReceiveInProgress, excludePdpFactoryIds, resourcesList]);
+  }, [isSendReceiveInProgress, excludePdpFactoryIds, resourcesList, syncRefreshKey]);
 
   const [interfaceLanguages] = useSetting('platform.interfaceLanguage', defaultInterfaceLanguages);
 

--- a/extensions/src/platform-get-resources/src/home.web-view.tsx
+++ b/extensions/src/platform-get-resources/src/home.web-view.tsx
@@ -101,12 +101,12 @@ globalThis.webViewComponent = function HomeWebView() {
 
   const [isSendReceiveInProgress, setIsSendReceiveInProgress] = useState<boolean>(false);
   const [activeSendReceiveProjects, setActiveSendReceiveProjects] = useState<string[]>([]);
-  const [syncRefreshKey, setSyncRefreshKey] = useState<number>(0);
+  const [syncsCompletedCount, setSyncsCompletedCount] = useState<number>(0);
 
   useEvent(
     papi.network.getNetworkEvent('paratextBibleSendReceive.onSyncStateChanged'),
     useCallback(({ isSyncing }: { isSyncing: boolean }) => {
-      if (!isSyncing) setSyncRefreshKey((k) => k + 1);
+      if (!isSyncing) setSyncsCompletedCount((k) => k + 1);
     }, []),
   );
 
@@ -201,7 +201,7 @@ globalThis.webViewComponent = function HomeWebView() {
     isSendReceiveAvailable,
     isSendReceiveInProgress,
     sharedProjectErrorNotificationId,
-    syncRefreshKey,
+    syncsCompletedCount, // triggers a re-fetch each time a sync completes
   ]);
 
   const [localProjectsInfo, setLocalProjectsInfo] = useState<LocalProjectInfo[]>([]);
@@ -258,7 +258,12 @@ globalThis.webViewComponent = function HomeWebView() {
       // Mark this promise as old and not to be used
       promiseIsCurrent = false;
     };
-  }, [isSendReceiveInProgress, excludePdpFactoryIds, resourcesList, syncRefreshKey]);
+  }, [
+    isSendReceiveInProgress,
+    excludePdpFactoryIds,
+    resourcesList,
+    syncsCompletedCount, // triggers a re-fetch each time a sync completes
+  ]);
 
   const [interfaceLanguages] = useSetting('platform.interfaceLanguage', defaultInterfaceLanguages);
 

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4771,7 +4771,7 @@ declare module 'shared/models/project-lookup.service-model' {
   /**
    * Transform a network object id for a pdp factory into its well-known pdp factory id
    *
-   * @param pdpFactoryNetworkObjectName Id for then network object for this pdp factory
+   * @param pdpFactoryNetworkObjectName Id for the network object for this pdp factory
    * @returns Id extensions use to identify this pdp factory
    */
   export function getPDPFactoryIdFromNetworkObjectName(pdpFactoryNetworkObjectName: string): string;
@@ -4868,7 +4868,13 @@ declare module 'shared/models/project-lookup.service-model' {
       projectsMetadata: ProjectMetadata[],
       options: ProjectMetadataFilterOptions,
     ): ProjectMetadata[];
-    /** Combines two project metadata filters, removing duplicate items */
+    /**
+     * Combines two project metadata filters, removing duplicate items
+     *
+     * Note: uses additive (OR) semantics for include lists — if one filter specifies an include list
+     * and the other does not, the merged filter keeps the include list (not "include all"). If you
+     * need "include all" to win, ensure both sides are undefined.
+     */
     mergeMetadataFilters(
       metadataFilter1: ProjectMetadataFilterOptions | undefined,
       metadataFilter2: ProjectMetadataFilterOptions | undefined,

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4880,11 +4880,8 @@ declare module 'shared/models/project-lookup.service-model' {
       metadataFilter2: ProjectMetadataFilterOptions | undefined,
     ): ProjectMetadataFilterOptions;
     /**
-     * Get the PDP Factory info whose `projectInterface`s are most minimally matching to the provided
-     * `projectInterface`
-     *
-     * Hopefully this will allow us to get the PDP that most closely matches the `projectInterface`s
-     * to avoid unnecessary redirects through layered PDPs
+     * Get the best (most specific) PDP Factory match for the provided `projectInterface` to avoid
+     * unnecessary PDP layering
      *
      * @param projectMetadata Metadata for project for which to get minimally matching PDPF
      * @param projectInterface Which `projectInterface` to minimally match for
@@ -4944,11 +4941,8 @@ declare module 'shared/models/project-lookup.service-model' {
     excludeProjectInterfaces: (RegExp | RegExp[])[],
   ): boolean;
   /**
-   * Compare function (for array sorting and such) that compares two PDPF Metadata infos by most
-   * minimal match to the `projectInterface` in question.
-   *
-   * Hopefully this will allow us to get the PDP that most closely matches the `projectInterface`s to
-   * avoid unnecessary redirects through layered PDPs
+   * Compare function (for array sorting and such) that compares two PDPF Metadata infos by best (most
+   * specific) match to the `projectInterface` in question to avoid unnecessary PDP layering
    *
    * @param pdpFMetadataInfoA First ProjectDataProviderFactoryMetadataInfo to compare
    * @param pdpFMetadataInfoB Second ProjectDataProviderFactoryMetadataInfo to compare

--- a/src/shared/models/project-lookup.service-model.ts
+++ b/src/shared/models/project-lookup.service-model.ts
@@ -49,7 +49,7 @@ export function getPDPFactoryNetworkObjectNameFromId(pdpFactoryId: string) {
 /**
  * Transform a network object id for a pdp factory into its well-known pdp factory id
  *
- * @param pdpFactoryNetworkObjectName Id for then network object for this pdp factory
+ * @param pdpFactoryNetworkObjectName Id for the network object for this pdp factory
  * @returns Id extensions use to identify this pdp factory
  */
 export function getPDPFactoryIdFromNetworkObjectName(pdpFactoryNetworkObjectName: string) {
@@ -156,7 +156,13 @@ export type ProjectLookupServiceType = {
     projectsMetadata: ProjectMetadata[],
     options: ProjectMetadataFilterOptions,
   ): ProjectMetadata[];
-  /** Combines two project metadata filters, removing duplicate items */
+  /**
+   * Combines two project metadata filters, removing duplicate items
+   *
+   * Note: uses additive (OR) semantics for include lists — if one filter specifies an include list
+   * and the other does not, the merged filter keeps the include list (not "include all"). If you
+   * need "include all" to win, ensure both sides are undefined.
+   */
   mergeMetadataFilters(
     metadataFilter1: ProjectMetadataFilterOptions | undefined,
     metadataFilter2: ProjectMetadataFilterOptions | undefined,
@@ -209,7 +215,9 @@ export const projectLookupServiceBase: ProjectLookupServiceType = {
           timeoutInMS,
         );
       } catch (e) {
-        throw new Error(`getMetadataForProject wait for PDPF ${pdpFactoryId} threw! ${e}`);
+        throw new Error(
+          `getMetadataForProject wait for PDPF ${pdpFactoryId} threw! ${getErrorMessage(e)}`,
+        );
       }
     } else if (projectInterface) {
       try {
@@ -232,7 +240,7 @@ export const projectLookupServiceBase: ProjectLookupServiceType = {
           timeoutInMS,
         );
       } catch (e) {
-        throw new Error(`getMetadataForProject wait for any PDPF threw! ${e}`);
+        throw new Error(`getMetadataForProject wait for any PDPF threw! ${getErrorMessage(e)}`);
       }
     }
 
@@ -240,9 +248,6 @@ export const projectLookupServiceBase: ProjectLookupServiceType = {
       transformGetMetadataForProjectParametersToFilter(projectId, projectInterface, pdpFactoryId),
     );
 
-    // Get the most minimal match to the projectInterface in question. Hopefully this will give us the
-    // PDP that most closely matches the projectInterfaces to avoid unnecessary redirects through
-    // layered PDPs
     if (metadata && metadata.length > 0) return metadata[0];
     throw new Error(
       `No project found with ID ${projectId}${projectInterface ? ` and project interface ${projectInterface}` : ''}${pdpFactoryId ? ` from ${pdpFactoryId}` : ''}`,
@@ -253,8 +258,6 @@ export const projectLookupServiceBase: ProjectLookupServiceType = {
     projectsMetadata: ProjectMetadata[],
     options: ProjectMetadataFilterOptions,
   ): ProjectMetadata[] {
-    if (!options) return [...projectsMetadata];
-
     if (
       !options.excludeProjectIds &&
       !options.includeProjectIds &&
@@ -753,9 +756,8 @@ function compareProjectDataProviderFactoryMetadataInfoMinimalMatch(
   const lengthA = pdpFMetadataInfoA.projectInterfaces.length;
   const lengthB = pdpFMetadataInfoB.projectInterfaces.length;
 
-  // If one only has the original interface or is smaller than the other, it should be first
-  if (lengthA === 1 || lengthA < lengthB) return -1;
-  if (lengthB === 1 || lengthB < lengthA) return 1;
+  if (lengthA < lengthB) return -1;
+  if (lengthB < lengthA) return 1;
   // Otherwise they are pretty much the same as far as we can tell
   return 0;
 }

--- a/src/shared/models/project-lookup.service-model.ts
+++ b/src/shared/models/project-lookup.service-model.ts
@@ -168,11 +168,8 @@ export type ProjectLookupServiceType = {
     metadataFilter2: ProjectMetadataFilterOptions | undefined,
   ): ProjectMetadataFilterOptions;
   /**
-   * Get the PDP Factory info whose `projectInterface`s are most minimally matching to the provided
-   * `projectInterface`
-   *
-   * Hopefully this will allow us to get the PDP that most closely matches the `projectInterface`s
-   * to avoid unnecessary redirects through layered PDPs
+   * Get the best (most specific) PDP Factory match for the provided `projectInterface` to avoid
+   * unnecessary PDP layering
    *
    * @param projectMetadata Metadata for project for which to get minimally matching PDPF
    * @param projectInterface Which `projectInterface` to minimally match for
@@ -729,11 +726,8 @@ function arePdpFactoryIdsIncluded(
 }
 
 /**
- * Compare function (for array sorting and such) that compares two PDPF Metadata infos by most
- * minimal match to the `projectInterface` in question.
- *
- * Hopefully this will allow us to get the PDP that most closely matches the `projectInterface`s to
- * avoid unnecessary redirects through layered PDPs
+ * Compare function (for array sorting and such) that compares two PDPF Metadata infos by best (most
+ * specific) match to the `projectInterface` in question to avoid unnecessary PDP layering
  *
  * @param pdpFMetadataInfoA First ProjectDataProviderFactoryMetadataInfo to compare
  * @param pdpFMetadataInfoB Second ProjectDataProviderFactoryMetadataInfo to compare


### PR DESCRIPTION
A lot of the sync changes happened across repos. Here are some fixes needed when those changes were able to be combined.

# PR Summary: sync-stitching

## Fix `LocalParatextProjects` constructor using hardcoded app folder name

**Files changed:** `c-sharp/Projects/LocalParatextProjects.cs`, `c-sharp/Program.cs`, `c-sharp-tests/DummyLocalParatextProjects.cs`, `c-sharp-tests/Projects/TestLocalParatextProjectsInTempDir.cs`

The `LocalParatextProjects` constructor had `.platform.bible` hardcoded as the user-profile subfolder name, so `ProjectRootFolder` resolved to a path like `C:\Users\<user>\.platform.bible\projects\Paratext 9 Projects` regardless of which product was actually running. This broke `SendReceiveMementoUtils.InitializeMementoTipIdsFromLocalRepo`, which constructs repo paths from `ProjectRootFolder`, causing connected projects to fail to sync.

The fix adds an `AppInfo` parameter to the constructor and uses `$".{appInfo.Name}"` so the folder name matches the running product (e.g. `.paratext-10-studio`). `AppInfo` was already available at the call site in `Program.cs` (retrieved on line 54), so only a one-line change was needed there. Two test helper subclasses (`DummyLocalParatextProjects` and `TestLocalParatextProjectsInTempDir`) were also updated to forward a fixture `AppInfo` to the base constructor.

## Refresh Home view after a sync completes

**File changed:** `extensions/src/platform-get-resources/src/home.web-view.tsx`

After a Send/Receive sync finished, the Home web view was not refreshing, so users would see stale project information until they manually reloaded. The fix subscribes to the `paratextBibleSendReceive.onSyncStateChanged` network event and increments a `syncRefreshKey` counter whenever `isSyncing` transitions to `false`. That counter is added to the dependency arrays of the two `useEffect` hooks that load shared-project and local-project data, causing them to re-run and repopulate the UI as soon as a sync completes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2244)
<!-- Reviewable:end -->
