### PR TITLE
Update some vestigial Paranext references to Platform.Bible

### DIFF
--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -74,13 +74,15 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
     appSupportDir = process.env.APPDATA || '';
   }
 
-  ['Electron', 'paratext-10-studio', 'platform-bible', 'Paranext'].forEach((dir) => {
-    const lockPath = path.join(appSupportDir, dir, 'SingletonLock');
-    if (fs.existsSync(lockPath)) {
-      console.log(`Removing stale singleton lock: ${lockPath}`);
-      fs.unlinkSync(lockPath);
-    }
-  });
+  ['Electron', 'paratext-10-studio', 'platform-bible', 'Paranext', 'Platform.Bible'].forEach(
+    (dir) => {
+      const lockPath = path.join(appSupportDir, dir, 'SingletonLock');
+      if (fs.existsSync(lockPath)) {
+        console.log(`Removing stale singleton lock: ${lockPath}`);
+        fs.unlinkSync(lockPath);
+      }
+    },
+  );
 
   // Ensure the dev main bundle exists
   const devMainPath = path.join(rootDir, '.erb/dll/main.bundle.dev.js');

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -299,7 +299,7 @@ npm run update-from-templates
 
 If you encounter errors from merge conflicts, please resolve the merge conflicts, finish the commit, and run the script above again.
 
-For more information, read [the instructions on the Platform.Bible Extension Template wiki](https://github.com/paranext/paranext-extension-template/wiki/Merging-Template-Changes-into-Your-Extension).
+For more information, read [the instructions on the Extension Template wiki](https://github.com/paranext/paranext-extension-template/wiki/Merging-Template-Changes-into-Your-Extension).
 
 **Note:** The merge/squash commits created when updating this repo and its extensions from the templates are important; Git uses them to compare the files for future updates. If you edit this repo's Git history, please preserve these commits (do not squash them, for example) to avoid duplicated merge conflicts in the future.
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -299,7 +299,7 @@ npm run update-from-templates
 
 If you encounter errors from merge conflicts, please resolve the merge conflicts, finish the commit, and run the script above again.
 
-For more information, read [the instructions on the Paranext Extension Template wiki](https://github.com/paranext/paranext-extension-template/wiki/Merging-Template-Changes-into-Your-Extension).
+For more information, read [the instructions on the Platform.Bible Extension Template wiki](https://github.com/paranext/paranext-extension-template/wiki/Merging-Template-Changes-into-Your-Extension).
 
 **Note:** The merge/squash commits created when updating this repo and its extensions from the templates are important; Git uses them to compare the files for future updates. If you edit this repo's Git history, please preserve these commits (do not squash them, for example) to avoid duplicated merge conflicts in the future.
 

--- a/extensions/src/c-sharp-provider-test/manifest.json
+++ b/extensions/src/c-sharp-provider-test/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "cSharpProviderTest",
   "version": "0.6.0-alpha.0",
-  "description": "C# Data Provider Test Types for Paranext - provided by C# data provider",
+  "description": "C# Data Provider Test Types for Platform.Bible - provided by C# data provider",
   "author": "Paranext",
   "license": "MIT",
   "main": "",

--- a/extensions/src/legacy-comment-manager/assets/descriptions/description-en.md
+++ b/extensions/src/legacy-comment-manager/assets/descriptions/description-en.md
@@ -1,3 +1,3 @@
-Legacy Comment Manager extension for Platform.Bible. Powered by webpack.
+Legacy Comment Manager extension for Platform.Bible.
 
-This Platform.Bible extension for managing comments is the legacy extension.
+Manage comments from Paratext 9 projects.

--- a/extensions/src/legacy-comment-manager/assets/descriptions/description-en.md
+++ b/extensions/src/legacy-comment-manager/assets/descriptions/description-en.md
@@ -1,3 +1,3 @@
-Extension template for Platform.Bible. Powered by webpack.
+Legacy Comment Manager extension for Platform.Bible. Powered by webpack.
 
-This is a webpack project template pre-configured to build a Platform.Bible extension. It contains the bare minimum of what an extension needs.
+This Platform.Bible extension for managing comments is the legacy extension.

--- a/extensions/src/legacy-comment-manager/assets/descriptions/description-en.md
+++ b/extensions/src/legacy-comment-manager/assets/descriptions/description-en.md
@@ -1,3 +1,3 @@
 Legacy Comment Manager extension for Platform.Bible.
 
-Manage comments from Paratext 9 projects.
+Enables creating and managing comment threads compatible with the comment system used in Paratext 9 projects.

--- a/extensions/src/legacy-comment-manager/assets/descriptions/description-es.md
+++ b/extensions/src/legacy-comment-manager/assets/descriptions/description-es.md
@@ -1,0 +1,3 @@
+Legacy Comment Manager para Platform.Bible
+
+Permite crear y administrar hilos de comentarios compatibles con el sistema de comentarios utilizado en proyectos de Paratext 9.

--- a/extensions/src/legacy-comment-manager/assets/displayData.json
+++ b/extensions/src/legacy-comment-manager/assets/displayData.json
@@ -5,7 +5,7 @@
   "localizedDisplayInfo": {
     "en": {
       "displayName": "Legacy Comment Manager",
-      "shortSummary": "The legacy Platform.Bible Comment Manager extension",
+      "shortSummary": "Manage comments from Paratext 9 projects",
       "description": "assets/descriptions/description-en.md"
     }
   }

--- a/extensions/src/legacy-comment-manager/assets/displayData.json
+++ b/extensions/src/legacy-comment-manager/assets/displayData.json
@@ -4,7 +4,7 @@
   "supportUrl": "",
   "localizedDisplayInfo": {
     "en": {
-      "displayName": "Paranext Extension Template",
+      "displayName": "Platform.Bible Extension Template",
       "shortSummary": "Base template for a Platform.Bible Extension",
       "description": "assets/descriptions/description-en.md"
     }

--- a/extensions/src/legacy-comment-manager/assets/displayData.json
+++ b/extensions/src/legacy-comment-manager/assets/displayData.json
@@ -5,8 +5,13 @@
   "localizedDisplayInfo": {
     "en": {
       "displayName": "Legacy Comment Manager",
-      "shortSummary": "Manage comments from Paratext 9 projects",
+      "shortSummary": "Manage comments for Paratext projects",
       "description": "assets/descriptions/description-en.md"
+    },
+    "es": {
+      "displayName": "Legacy Comment Manager",
+      "shortSummary": "Administrar comentarios de los proyectos",
+      "description": "assets/descriptions/description-es.md"
     }
   }
 }

--- a/extensions/src/legacy-comment-manager/assets/displayData.json
+++ b/extensions/src/legacy-comment-manager/assets/displayData.json
@@ -4,8 +4,8 @@
   "supportUrl": "",
   "localizedDisplayInfo": {
     "en": {
-      "displayName": "Platform.Bible Extension Template",
-      "shortSummary": "Base template for a Platform.Bible Extension",
+      "displayName": "Legacy Comment Manager",
+      "shortSummary": "The legacy Platform.Bible Comment Manager extension",
       "description": "assets/descriptions/description-en.md"
     }
   }

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -673,8 +673,8 @@ declare module 'shared/global-this.model' {
     /** How much logging should be recorded. Defaults to 'debug' if not packaged, 'info' if packaged */
     var logLevel: LogLevel;
     /**
-     * A function that each React WebView extension must provide for Paranext to display it. Only used
-     * in WebView iframes.
+     * A function that each React WebView extension must provide for Platform.Bible to display it.
+     * Only used in WebView iframes.
      */
     var webViewComponent: FunctionComponent<WebViewProps>;
     /** The id of the current web view. Only used in WebView iframes. */
@@ -791,7 +791,7 @@ declare module 'shared/global-this.model' {
     /** Indicates whether test code meant just for developers to see should be run */
     var isNoisyDevModeEnabled: boolean;
   }
-  /** Type of Paranext process */
+  /** Type of Platform.Bible process */
   export enum ProcessType {
     Main = 'main',
     Renderer = 'renderer',
@@ -2721,7 +2721,7 @@ declare module 'shared/models/docking-framework.model' {
     data?: unknown;
   };
   /**
-   * Information that Paranext uses to create a tab in the dock layout.
+   * Information that Platform.Bible uses to create a tab in the dock layout.
    *
    * - {@link TabLoader} loads {@link SavedTabInfo} into this
    * - {@link TabSaver} saves this into {@link SavedTabInfo}
@@ -2752,19 +2752,19 @@ declare module 'shared/models/docking-framework.model' {
     lastFocusedElement?: HTMLElement;
   };
   /**
-   * Function that takes a {@link SavedTabInfo} and creates a Paranext tab out of it. Each type of tab
-   * must provide a {@link TabLoader}.
+   * Function that takes a {@link SavedTabInfo} and creates a Platform.Bible tab out of it. Each type
+   * of tab must provide a {@link TabLoader}.
    *
    * For now all tab creators must do their own data type verification
    */
   export type TabLoader = (savedTabInfo: SavedTabInfo) => TabInfo;
   /**
-   * Function that takes a Paranext tab and creates a saved tab out of it. Each type of tab can
+   * Function that takes a Platform.Bible tab and creates a saved tab out of it. Each type of tab can
    * provide a {@link TabSaver}. If they do not provide one, the properties added by `TabInfo` are
    * stripped from TabInfo by `saveTabInfoBase` before saving (so it is just a {@link SavedTabInfo}).
    *
-   * @param tabInfo The Paranext tab to save
-   * @returns The saved tab info for Paranext to persist. If `undefined`, does not save the tab
+   * @param tabInfo The Platform.Bible tab to save
+   * @returns The saved tab info for Platform.Bible to persist. If `undefined`, does not save the tab
    */
   export type TabSaver = (tabInfo: TabInfo) => SavedTabInfo | undefined;
   /**
@@ -2881,7 +2881,7 @@ declare module 'shared/models/docking-framework.model' {
     /** The ID of the tab to replace */
     targetTabId: string;
   }
-  /** Information about how a Paranext tab fits into the dock layout */
+  /** Information about how a Platform.Bible tab fits into the dock layout */
   export type Layout = TabLayout | FloatLayout | PanelLayout | ReplaceTabLayout;
   /** Props that are passed to the web view tab component */
   export type WebViewTabProps = WebViewDefinition;

--- a/lib/platform-bible-utils/package.json
+++ b/lib/platform-bible-utils/package.json
@@ -2,7 +2,7 @@
   "name": "platform-bible-utils",
   "version": "0.0.1",
   "type": "module",
-  "description": "Utilities to use in Paranext.",
+  "description": "Utilities to use in Platform.Bible.",
   "license": "MIT",
   "homepage": "https://github.com/paranext/paranext-core/tree/main/lib/platform-bible-utils",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,4 @@
 {
-  "name": "platform-bible",
-  "productName": "Platform.Bible",
   "description": "Extensible Bible translation software",
   "keywords": [
     "electron",

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "platform-bible",
+  "productName": "Platform.Bible",
   "description": "Extensible Bible translation software",
   "keywords": [
     "electron",

--- a/src/renderer/app.component.test.tsx
+++ b/src/renderer/app.component.test.tsx
@@ -36,7 +36,7 @@ vi.mock('@shared/services/network.service', async (importOriginal) => {
 });
 vi.mock('@renderer/components/docking/platform-dock-layout.component', () => ({
   __esModule: true,
-  default: /** ParanextDockLayout Mock */ () => undefined,
+  default: /** PlatformDockLayout Mock */ () => undefined,
   PlatformDockLayout: /** PlatformDockLayout Named Export Mock */ () => <div />,
 }));
 vi.mock('@renderer/components/platform-bible-toolbar', () => ({

--- a/src/renderer/testing/test-buttons-panel.component.tsx
+++ b/src/renderer/testing/test-buttons-panel.component.tsx
@@ -248,14 +248,14 @@ export function TestButtonsPanel() {
           className="test-button"
           onClick={async () => {
             const start = performance.now();
-            const result = await runPromise(() => helloSomeone('Paranext user'));
+            const result = await runPromise(() => helloSomeone('Platform.Bible user'));
             logger.debug(
               `command:helloSomeone.helloSomeone ${result} took ${performance.now() - start} ms`,
             );
           }}
           onContextMenu={(e) => {
             e.preventDefault();
-            executeMany(() => helloSomeone('Paranext user'));
+            executeMany(() => helloSomeone('Platform.Bible user'));
           }}
         >
           Hello Someone (Extension)

--- a/src/shared/global-this.model.ts
+++ b/src/shared/global-this.model.ts
@@ -31,8 +31,8 @@ declare global {
   /** How much logging should be recorded. Defaults to 'debug' if not packaged, 'info' if packaged */
   var logLevel: LogLevel;
   /**
-   * A function that each React WebView extension must provide for Paranext to display it. Only used
-   * in WebView iframes.
+   * A function that each React WebView extension must provide for Platform.Bible to display it.
+   * Only used in WebView iframes.
    */
   var webViewComponent: FunctionComponent<WebViewProps>;
   /** The id of the current web view. Only used in WebView iframes. */
@@ -72,7 +72,7 @@ declare global {
 }
 /* eslint-enable */
 
-/** Type of Paranext process */
+/** Type of Platform.Bible process */
 export enum ProcessType {
   Main = 'main',
   Renderer = 'renderer',

--- a/src/shared/models/docking-framework.model.ts
+++ b/src/shared/models/docking-framework.model.ts
@@ -22,7 +22,7 @@ export type SavedTabInfo = {
 };
 
 /**
- * Information that Paranext uses to create a tab in the dock layout.
+ * Information that Platform.Bible uses to create a tab in the dock layout.
  *
  * - {@link TabLoader} loads {@link SavedTabInfo} into this
  * - {@link TabSaver} saves this into {@link SavedTabInfo}
@@ -54,20 +54,20 @@ export type TabInfo = SavedTabInfo & {
 };
 
 /**
- * Function that takes a {@link SavedTabInfo} and creates a Paranext tab out of it. Each type of tab
- * must provide a {@link TabLoader}.
+ * Function that takes a {@link SavedTabInfo} and creates a Platform.Bible tab out of it. Each type
+ * of tab must provide a {@link TabLoader}.
  *
  * For now all tab creators must do their own data type verification
  */
 export type TabLoader = (savedTabInfo: SavedTabInfo) => TabInfo;
 
 /**
- * Function that takes a Paranext tab and creates a saved tab out of it. Each type of tab can
+ * Function that takes a Platform.Bible tab and creates a saved tab out of it. Each type of tab can
  * provide a {@link TabSaver}. If they do not provide one, the properties added by `TabInfo` are
  * stripped from TabInfo by `saveTabInfoBase` before saving (so it is just a {@link SavedTabInfo}).
  *
- * @param tabInfo The Paranext tab to save
- * @returns The saved tab info for Paranext to persist. If `undefined`, does not save the tab
+ * @param tabInfo The Platform.Bible tab to save
+ * @returns The saved tab info for Platform.Bible to persist. If `undefined`, does not save the tab
  */
 export type TabSaver = (tabInfo: TabInfo) => SavedTabInfo | undefined;
 
@@ -177,7 +177,7 @@ interface ReplaceTabLayout {
   targetTabId: string;
 }
 
-/** Information about how a Paranext tab fits into the dock layout */
+/** Information about how a Platform.Bible tab fits into the dock layout */
 export type Layout = TabLayout | FloatLayout | PanelLayout | ReplaceTabLayout;
 
 /** Props that are passed to the web view tab component */


### PR DESCRIPTION
The purpose of this pr is ~to give the Electron app a name, so that (on Windows) the cache will be located in `AppData/Roaming/Platform.Bible/` (instead of `AppData/Roaming/Electron/`, alongside any other unnamed Electron apps).~

~To that end, only the changes in `e2e-tests/global-setup.ts` and `package.json` are material.~

~The rest are just~ cleaning up some residual occurrences of "Paranext".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2257)
<!-- Reviewable:end -->
