### PR TITLE
chore(pbr): exclude design-principles.mdx from remark --output

### DIFF
--- a/lib/platform-bible-react/.remarkignore
+++ b/lib/platform-bible-react/.remarkignore
@@ -1,0 +1,3 @@
+# remark's MDX serializer reformats JSX inside attribute values (e.g. preview={...} props),
+# removing intentional indentation. Files listed here are excluded from remark --output.
+src/stories/guidelines/design-principles.mdx


### PR DESCRIPTION
## Problem

`remark . --ext .mdx --output` (run as part of `npm run format` via the `platform-bible-react` workspace's `format:mdx` script) reformats JSX inside attribute values — specifically the `preview={...}` props used extensively in `design-principles.mdx` — by stripping manual indentation. This produces bogus whitespace-only diffs that creep into unrelated PRs.

There is no in-file mechanism to suppress remark's reformatting of specific JSX sections. `*.mdx` is already in `.prettierignore` (Prettier is not the culprit).

Since the prose content is relatively simple (short paragraphs, one table, a few bullet lists), it is human-reviewed whenever it changes, and the vast majority of the file's content is inside JSX components, reformatting with remark doesn't add much value to anyway. So the practical risk of letting markdown drift is low for this particular file.

## Fix

Add `lib/platform-bible-react/.remarkignore` listing `design-principles.mdx`. This is remark-cli's standard ignore mechanism — remark-cli sets `ignoreName: '.remarkignore'` so `remark . --ext .mdx --output` will skip files listed there.

## Related

- The `/review-paratext` skill was also updated ([ai-prompts PR #282](https://github.com/paranext/ai-prompts/pull/282)) to scope its format step to only changed files rather than running `npm run format` globally.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2270)
<!-- Reviewable:end -->
