### PR TITLE
Hide scroll group selector for 'simple'

### DIFF
--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -149,6 +149,9 @@ const DEFAULT_WEBVIEW_MENU = {
 
 const scrollGroupLocalizedStringKeys = getLocalizeKeysForScrollGroupIds(availableScrollGroupIds);
 
+// Matches the key used by PlatformBibleToolbar to persist its active scroll group
+const TOOLBAR_SCROLL_GROUP_ID_LOCAL_STORAGE_KEY = 'platform-bible-toolbar.scrollGroupId';
+
 /**
  * Extracts scripture text snippets from a selection range.
  *
@@ -344,6 +347,30 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
     if (isPlatformError(interfaceModePossiblyError)) return false;
     return interfaceModePossiblyError === 'power';
   }, [interfaceModePossiblyError]);
+
+  // setScrollGroupId changes reference on every scrRef update (it has scrRefLocal in its deps), so
+  // stabilize it via a ref to avoid the effect below calling updateWebViewDefinition on every verse
+  const setScrollGroupIdRef = useRef(setScrollGroupId);
+  setScrollGroupIdRef.current = setScrollGroupId;
+
+  // In simple mode the scroll group selector is hidden, so follow the toolbar's active scroll group
+  useEffect(() => {
+    if (isPowerMode) return undefined;
+
+    const syncToToolbar = () =>
+      setScrollGroupIdRef.current(
+        JSON.parse(localStorage.getItem(TOOLBAR_SCROLL_GROUP_ID_LOCAL_STORAGE_KEY) ?? '0'),
+      );
+
+    syncToToolbar();
+
+    const handleStorageChange = (event: StorageEvent) => {
+      if (event.key === TOOLBAR_SCROLL_GROUP_ID_LOCAL_STORAGE_KEY) syncToToolbar();
+    };
+
+    window.addEventListener('storage', handleStorageChange);
+    return () => window.removeEventListener('storage', handleStorageChange);
+  }, [isPowerMode]);
 
   const textDirectionEffective = useMemo(() => {
     // OHEBGRK is a special case where we want to show the OT in RTL but the NT in LTR

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -1645,6 +1645,15 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
     />
   ) : undefined;
 
+  const sgSelector = isPowerMode ? (
+    <ScrollGroupSelector
+      availableScrollGroupIds={availableScrollGroupIds}
+      scrollGroupId={scrollGroupId}
+      onChangeScrollGroupId={setScrollGroupId}
+      localizedStrings={scrollGroupLocalizedStrings}
+    />
+  ) : undefined;
+
   return (
     <div className="tw:flex tw:flex-col tw:h-screen">
       <TabToolbar
@@ -1697,14 +1706,7 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
             )}
           </>
         }
-        endAreaChildren={
-          <ScrollGroupSelector
-            availableScrollGroupIds={availableScrollGroupIds}
-            scrollGroupId={scrollGroupId}
-            onChangeScrollGroupId={setScrollGroupId}
-            localizedStrings={scrollGroupLocalizedStrings}
-          />
-        }
+        endAreaChildren={sgSelector}
       />
       {/* Mount the editor in a reverse portal so it doesn't unmount and lose its internal state */}
       <InPortal node={editorPortalNode}>{renderEditor()}</InPortal>


### PR DESCRIPTION
Part 2 of #2249, which has the following commit comment:
> Navigation is now exclusively through the main app toolbar. The editor already synced with the main toolbar via scroll group 0; this removes the redundant in-editor BookChapterControl and ScrollGroupSelector

Keeping this in draft because there is a bug in 'simple' mode without the controls:
- Platform Scripture Editor doesn't stay synced with the top-bar control if they are on different scroll groups. That was already an issue, but is made harder to diagnose if this pr removes the scroll group selector.

The second commit of this pr is one proposed solution: adding a listener to the local storage to see when the scroll group changes.

Another possible approach would be to refactor `useWebViewScrollGroupScrRef` to (e.g.) have two different versions of `scrRef` and `setScrRefWithScroll`, one that tracks with the global scroll group (for simple) and one that doesn't (for power).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2280)
<!-- Reviewable:end -->
