### PR TITLE
Move/rename `canUserWriteProjectSettings` to `ITextConnectionSettingsProjectDataProvider` (was: `IBaseProjectDataProvider`)

### DIFF
--- a/c-sharp-tests/Projects/ParatextProjectDataProviderTextConnectionSettingsTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderTextConnectionSettingsTests.cs
@@ -1,0 +1,71 @@
+using System.Diagnostics.CodeAnalysis;
+using Paranext.DataProvider.Projects;
+using Paratext.Data;
+
+namespace TestParanextDataProvider.Projects
+{
+    [ExcludeFromCodeCoverage]
+    internal class ParatextProjectDataProviderTextConnectionSettingsTests : PapiTestBase
+    {
+        private const string PdpName = "textConnectionSettingsTestProject";
+
+        private ScrText _scrText = null!;
+        private ProjectDetails _projectDetails = null!;
+        private DummyParatextProjectDataProvider _provider = null!;
+
+        [SetUp]
+        public override async Task TestSetupAsync()
+        {
+            await base.TestSetupAsync();
+
+            _scrText = CreateDummyProject();
+            _projectDetails = CreateProjectDetails(_scrText);
+            ParatextProjects.FakeAddProject(_projectDetails, _scrText);
+
+            _provider = new DummyParatextProjectDataProvider(
+                PdpName,
+                Client,
+                _projectDetails,
+                ParatextProjects
+            );
+            await _provider.RegisterDataProviderAsync();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _scrText?.Dispose();
+        }
+
+        [Test]
+        public void CanUserWriteProjectTextConnectionSettings_ProjectRemovedFromCollection_ReturnsFalse()
+        {
+            // Arrange - simulate a project being deleted while the provider is still alive
+            ScrTextCollection.Remove(_scrText, false);
+
+            // Act
+            bool canWrite = _provider.CanUserWriteProjectTextConnectionSettings();
+
+            // Assert
+            Assert.That(
+                canWrite,
+                Is.False,
+                "Should return false when the project has been removed from the collection"
+            );
+        }
+
+        [Test]
+        public void CanUserWriteProjectTextConnectionSettings_NormalProject_ReturnsTrue()
+        {
+            // Act
+            bool canWrite = _provider.CanUserWriteProjectTextConnectionSettings();
+
+            // Assert
+            Assert.That(
+                canWrite,
+                Is.True,
+                "Default user should have write permission on text connection project settings in a normal project"
+            );
+        }
+    }
+}

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -123,7 +123,9 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         retVal.Add(
             ("resetUserReferencedProjectsAndResources", ResetUserReferencedProjectsAndResources)
         );
-        retVal.Add(("canUserWriteProjectSettings", CanUserWriteProjectSettings));
+        retVal.Add(
+            ("canUserWriteProjectTextConnectionSettings", CanUserWriteProjectTextConnectionSettings)
+        );
 
         retVal.Add(("getMarkerNames", GetMarkerNames));
 
@@ -1334,10 +1336,23 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     }
 
     /// <summary>
-    /// Determines if the current user can write to the project settings.
+    /// Determines if the current user can write the project settings for "text connections"
+    /// (model text and referenced resources).
     /// </summary>
-    /// <returns>True if the user can write the project settings, false otherwise</returns>
-    public bool CanUserWriteProjectSettings()
+    /// <returns>True if the user can write these settings, false otherwise</returns>
+    /// <remarks>At this time, the only check for this is whether the user is an administrator on
+    /// the project.
+    public bool CanUserWriteProjectTextConnectionSettings() => IsUserProjectAdministrator();
+
+    /// <summary>
+    /// Determines if the current user id a project administrator
+    /// </summary>
+    /// <returns>
+    /// True if the user has an Administrator role on this project, false otherwise
+    /// </returns>
+    /// <remarks>All project-level settings *should* only be able to be set by administrators, but
+    /// this is not currently enforced for most settings.
+    private bool IsUserProjectAdministrator()
     {
         try
         {

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -773,7 +773,7 @@ declare module 'platform-scripture' {
   };
 
   /** Provides user-specific text connection settings (model texts and referenced projects/resources) */
-  export type IUserTextConnectionSettingsProjectDataProvider =
+  export type ITextConnectionSettingsProjectDataProvider =
     IProjectDataProvider<UserTextConnectionSettingsProjectInterfaceDataTypes> & {
       /** Gets the list of model texts for this project */
       getUserModelTexts(): Promise<ResourceReferenceList>;
@@ -829,8 +829,8 @@ declare module 'platform-scripture' {
         ) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
-      /** Determines whether the current user can write to project settings. */
-      canUserWriteProjectSettings(): Promise<boolean>;
+      /** Determines whether the current user can write to text connection project settings. */
+      canUserWriteProjectTextConnectionSettings(): Promise<boolean>;
     };
 
   // #endregion User Text Connection Settings Types
@@ -1791,7 +1791,7 @@ declare module 'papi-shared-types' {
     IMarkerNamesProjectDataProvider,
     IFindInScriptureProjectDataProvider,
     IReplaceWithUsfmProjectDataProvider,
-    IUserTextConnectionSettingsProjectDataProvider,
+    ITextConnectionSettingsProjectDataProvider,
     ICheckAggregatorService,
     ICheckRunner,
     IInventoryDataProvider,
@@ -1815,7 +1815,7 @@ declare module 'papi-shared-types' {
     'platformScripture.MarkerNames': IMarkerNamesProjectDataProvider;
     'platformScripture.findInScripture': IFindInScriptureProjectDataProvider;
     'platformScripture.replaceWithUsfm': IReplaceWithUsfmProjectDataProvider;
-    'platformScripture.userTextConnectionSettings': IUserTextConnectionSettingsProjectDataProvider;
+    'platformScripture.userTextConnectionSettings': ITextConnectionSettingsProjectDataProvider;
   }
 
   export interface DataProviders {

--- a/extensions/src/platform-scripture/src/use-effective-resource-reference-list.test.ts
+++ b/extensions/src/platform-scripture/src/use-effective-resource-reference-list.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook } from '@testing-library/react';
 import type {
   ResourceReferenceList,
-  IUserTextConnectionSettingsProjectDataProvider,
+  ITextConnectionSettingsProjectDataProvider,
 } from 'platform-scripture';
 import { useProjectSetting, useProjectDataProvider } from '@papi/frontend/react';
 import { useEffectiveResourceReferenceList } from './use-effective-resource-reference-list';
@@ -30,7 +30,7 @@ const emptyList = (dataVersion = '1.0.0'): ResourceReferenceList => ({
 function makeMockPdp(
   returnValue: ResourceReferenceList | undefined,
   subscribeMethod: 'subscribeUserModelTexts' | 'subscribeUserReferencedProjectsAndResources',
-): IUserTextConnectionSettingsProjectDataProvider {
+): ITextConnectionSettingsProjectDataProvider {
   const mockSubscribe = vi.fn(
     async (_selector: undefined, callback: (val: ResourceReferenceList | undefined) => void) => {
       if (returnValue !== undefined) {
@@ -44,7 +44,7 @@ function makeMockPdp(
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   return {
     [subscribeMethod]: mockSubscribe,
-  } as unknown as IUserTextConnectionSettingsProjectDataProvider;
+  } as unknown as ITextConnectionSettingsProjectDataProvider;
 }
 
 describe('useEffectiveResourceReferenceList', () => {
@@ -294,7 +294,7 @@ describe('useEffectiveResourceReferenceList', () => {
     );
 
     // Should fall back to project-level list, not return undefined
-    expect(result.current).toBeDefined();
+    expect(result.current[0]).toBeDefined();
     expect(result.current[0]?.items).toHaveLength(1);
     expect(result.current[0]?.items[0]).toMatchObject({ name: 'ESV', source: 'admin' });
   });


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: move-canwriteprojectsettings-to-base-pdp

**Base**: origin/main

**Date**: 2026-05-19

**Review model**: Claude Sonnet 4.6

**Files changed**: 7

## Overview

`canUserWriteProjectSettings` was placed on `IUserTextConnectionSettingsProjectDataProvider` in PR #2289 (merged the day before this branch), but that location is architecturally wrong: write-permission checking is a concern of the base settings API, not of the user text connection settings sub-interface. This branch moves the method to `WithProjectDataProviderEngineSettingMethods`, which is the mixin that already carries `getSetting`, `setSetting`, and `resetSetting` — making `canUserWriteProjectSettings` available on `IBaseProjectDataProvider` and therefore on every PDP, not just those typed as `IUserTextConnectionSettingsProjectDataProvider`.

On the TypeScript side, `BaseProjectDataProviderEngine` gains a default implementation that returns `Promise.resolve(true)`, so extensions using the recommended inheritance pattern need zero code changes. On the C# side, the virtual method and its function registration are promoted from `ParatextProjectDataProvider` to the base `ProjectDataProvider` class, and `ParatextProjectDataProvider` now properly declares `override`. Two NUnit tests cover the normal case and the race-condition case (project removed from collection while the PDP is still alive).

## API Changes

- **Removed**: `canUserWriteProjectSettings(): Promise<boolean>` from `IUserTextConnectionSettingsProjectDataProvider` in `extensions/src/platform-scripture/src/types/platform-scripture.d.ts`
- **Added**: `canUserWriteProjectSettings: () => Promise<boolean>` to `WithProjectDataProviderEngineSettingMethods` in `papi-shared-types` (propagated to `papi.d.ts`), making it part of `IBaseProjectDataProvider<TProjectDataTypes>` and `IBaseProjectDataProviderEngine<SupportedProjectInterfaces>`
- **Added**: Default implementation `canUserWriteProjectSettings(): Promise<boolean>` to `BaseProjectDataProviderEngine` abstract class, returning `true`

## Findings

### Critical — Must address before merge

- [ ] ~~**Breaking change for `IUserTextConnectionSettingsProjectDataProvider` callers** — removing `canUserWriteProjectSettings()` from that interface breaks any code typed to it that calls this method.~~ _(Method was added the day before in #2289 with no release; no known callers use it through `IUserTextConnectionSettingsProjectDataProvider` specifically — not within this repo or any external consumers.)_
- [ ] ~~**Potentially breaking for direct implementers of `IBaseProjectDataProviderEngine`** — adding `canUserWriteProjectSettings` to `WithProjectDataProviderEngineSettingMethods` means any extension that implements the interface directly (without extending `BaseProjectDataProviderEngine`) must now also implement this method.~~ _(No known direct implementers exist; all internal engines extend `BaseProjectDataProviderEngine`. The existing JSDoc already recommends extending the class rather than implementing the interface directly.)_

Author dismissed both: method is brand-new (no release), no known external consumers, and the recommended extension pattern is unaffected.

### Important — Should address before merge

- [ ] ~~**No TypeScript unit test for `BaseProjectDataProviderEngine.canUserWriteProjectSettings()`** — the default implementation is untested at the TypeScript layer.~~ _(Dismissed: body is `return Promise.resolve(true)` — trivially correct. No tests exist for other similar defaults in `BaseProjectDataProviderEngine`, and the C# parallel is covered by two NUnit tests.)_

### Minor — Consider

- [x] **JSDoc for `canUserWriteProjectSettings` lacked implementation guidance** _(fixed during review: added "Note for implementing" paragraph explaining that the default returns `true` and that non-trivial implementations should consider the user's role, project nature, and settings type)_
- [x] **XML doc comment in `ProjectDataProvider.cs` used single-line format** _(fixed during review: converted to multi-line `/// <summary>` / `/// text` / `/// </summary>` style consistent with surrounding code)_
- [ ] ~~**Interface shape distinction** — `WithProjectDataProviderEngineSettingMethods` defines `canUserWriteProjectSettings` as a property type (`() => Promise<boolean>`) while `BaseProjectDataProviderEngine` declares it as a method.~~ _(Dismissed: standard TypeScript — both forms satisfy a function-type interface property. Consistent with how `getSetting`/`setSetting`/`resetSetting` are handled throughout this area.)_

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

- [n/a] `extensions/src/platform-scripture/src/types/platform-scripture.d.ts` — extension-specific type declaration; no propagation needed.

## Positive Observations

- The migration cleanly moves `canUserWriteProjectSettings` from an extension-specific sub-interface to the platform base, placing it alongside `getSetting`/`setSetting`/`resetSetting` where it conceptually belongs.
- `BaseProjectDataProviderEngine` provides a sensible default (`Promise.resolve(true)`), so extensions using the recommended pattern require zero code changes.
- The C# refactoring is well-structured: `ProjectDataProvider` (base class) now owns both the virtual method and its function registration; `ParatextProjectDataProvider` uses `override` and no longer registers it redundantly.
- Two NUnit tests cover both the expected-true path and the race-condition edge case (project removed from the collection while the PDP is still alive).
- The ESLint suppression is accompanied by a clear comment explaining exactly why the instance method cannot be static.
- `papi.d.ts` was regenerated rather than hand-edited — confirmed by consistent, clean output matching the source changes.
- No UI, Storybook, or localization concerns.

## Interview Notes

**Stated purpose**: Move `canUserWriteProjectSettings` from `IUserTextConnectionSettingsProjectDataProvider` to `IBaseProjectDataProvider` (via `WithProjectDataProviderEngineSettingMethods`), scoped alongside `setSetting` — because write-permission checking is a base settings concern, not a user-text-connection-settings concern.

**Critical findings dismissed**: Both breaking-change findings were dismissed with confidence. The method was added the day before with no public release, and no callers (internal or external) are known to reference it through `IUserTextConnectionSettingsProjectDataProvider` specifically. The author understood the change clearly and explained the reasoning without prompting.

**Important finding dismissed**: The missing TypeScript test for the default was dismissed as consistent with how other trivial defaults are treated in this codebase. The C# layer is covered.

**Minor findings**: Two fixed in-review (JSDoc note, C# doc comment format). One dismissed (TypeScript interface-vs-method shape distinction is standard and consistent).

**Author understanding**: Clear throughout. The author understood and articulated the architectural rationale, the virtual dispatch behavior in C#, the TypeScript interface compliance, and the race condition motivating the "project removed" test case.

## In-Review Quality Check

In-review changes were limited to documentation only (expanded JSDoc in `papi-shared-types.ts` + `papi.d.ts`, multi-line XML doc format in `ProjectDataProvider.cs`). Full typecheck/lint/test runs were skipped due to process hangs encountered during the session. These changes carry no logical risk and are safe to verify with a normal CI run.

## Suggested Review Focus

- [ ] **API placement decision**: Confirm that `WithProjectDataProviderEngineSettingMethods` is the right home (alongside `setSetting`/`getSetting`/`resetSetting`) and that the removal from `IUserTextConnectionSettingsProjectDataProvider` is intentional and complete.
- [ ] **C# virtual dispatch**: Verify that registering the delegate in `ProjectDataProvider.GetFunctions()` correctly routes to `ParatextProjectDataProvider.CanUserWriteProjectSettings()` at runtime via virtual dispatch — the author understands this but a reviewer may want to confirm it explicitly.
- [ ] **Race condition test**: Review `CanUserWriteProjectSettings_ProjectRemovedFromCollection_ReturnsFalse` — the test uses `ScrTextCollection.Remove(_scrText, false)` mid-test to simulate a deleted project. Confirm this accurately reflects the real deletion path and that the `try/catch` in `ParatextProjectDataProvider` handles it correctly.

<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2298)
<!-- Reviewable:end -->
