### PR TITLE
docs(stories): link shadcn component stories to shadcn/ui docs

### DIFF
--- a/lib/platform-bible-react/src/stories/advanced/multi-select-combo-box.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/multi-select-combo-box.stories.tsx
@@ -166,6 +166,14 @@ const meta: Meta<typeof MultiSelectComboBox> = {
     selected: { control: 'object' },
     onChange: { action: 'selection changed' },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A searchable dropdown that supports selecting multiple options simultaneously, extending the Combobox pattern with multi-select and "select all" functionality.\n\nShadcn docs: [Combobox](https://ui.shadcn.com/docs/components/combobox)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/basics/checklist.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/checklist.stories.tsx
@@ -21,6 +21,14 @@ const meta: Meta<typeof Checklist> = {
     listItems: { control: 'object' },
     selectedListItems: { control: 'object' },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A scrollable list of labeled checkboxes for toggling multiple items independently. This paranext component implements the Checkbox Group pattern from shadcn.\n\nShadcn docs: [Checkbox](https://ui.shadcn.com/docs/components/checkbox)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/basics/combo-box.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/combo-box.stories.tsx
@@ -65,6 +65,14 @@ const meta: Meta<typeof ComboBox<string>> = {
       </ThemeProvider>
     ),
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A searchable dropdown that combines a text input with a list of selectable options.\n\nShadcn docs: [Combobox](https://ui.shadcn.com/docs/components/combobox)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/basics/spinner.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/spinner.stories.tsx
@@ -17,6 +17,14 @@ const meta: Meta<typeof Spinner> = {
     size: { control: { type: 'number', min: 1, max: 100 } },
     className: { control: 'text' },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'An animated loading indicator that signals background activity.\n\nShadcn docs: [Spinner](https://ui.shadcn.com/docs/components/spinner)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/basics/tabs.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/tabs.stories.tsx
@@ -24,6 +24,14 @@ const meta: Meta<typeof Tabs> = {
     defaultValue: { control: 'text' },
     orientation: { control: 'select', options: ['horizontal', 'vertical'] },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A set of layered sections of content—known as tab panels—that are displayed one at a time. The `TabsList`/`TabsTrigger` acts as the segmented control (tab picker) and `TabsContent` renders the selected panel. This story also demonstrates `VerticalTabs`, a paranext variant with a side-by-side layout.\n\nShadcn docs: [Tabs](https://ui.shadcn.com/docs/components/tabs)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/basics/text-field.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/text-field.stories.tsx
@@ -10,11 +10,8 @@ const meta: Meta<typeof TextField> = {
   parameters: {
     docs: {
       description: {
-        component: `
-A text input field component with label, validation, and helper text support.
-
-Based on shadcn-ui Input component with additional features like error states and full-width support.
-        `,
+        component:
+          'A text input field with label, helper text, required, error, and full-width support. Wraps the shadcn Input component with additional field-level features.\n\nShadcn docs: [Input](https://ui.shadcn.com/docs/components/input)',
       },
     },
   },

--- a/lib/platform-bible-react/src/stories/shadcn-ui/alert.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/alert.stories.tsx
@@ -8,6 +8,14 @@ const meta: Meta<typeof Alert> = {
   title: 'Shadcn/Alert',
   component: Alert,
   tags: ['autodocs', 'test'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays a callout for user attention.\n\nShadcn docs: [Alert](https://ui.shadcn.com/docs/components/alert)',
+      },
+    },
+  },
   argTypes: {
     variant: {
       options: ['default', 'destructive'],

--- a/lib/platform-bible-react/src/stories/shadcn-ui/avatar.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/avatar.stories.tsx
@@ -6,6 +6,14 @@ const meta: Meta<typeof Avatar> = {
   title: 'Shadcn/Avatar',
   component: Avatar,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'An image element with a fallback for representing the user.\n\nShadcn docs: [Avatar](https://ui.shadcn.com/docs/components/avatar)',
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/shadcn-ui/badge.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/badge.stories.tsx
@@ -8,6 +8,14 @@ const meta: Meta<typeof Badge> = {
   title: 'Shadcn/Badge',
   component: Badge,
   tags: ['autodocs', 'test'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays a badge or a component that looks like a badge.\n\nShadcn docs: [Badge](https://ui.shadcn.com/docs/components/badge)',
+      },
+    },
+  },
   argTypes: {
     variant: {
       options: [

--- a/lib/platform-bible-react/src/stories/shadcn-ui/button.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/button.stories.tsx
@@ -7,6 +7,14 @@ const meta: Meta<typeof Button> = {
   title: 'Shadcn/Button',
   component: Button,
   tags: ['autodocs', 'test'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays a button or a component that looks like a button.\n\nShadcn docs: [Button](https://ui.shadcn.com/docs/components/button)',
+      },
+    },
+  },
   argTypes: {
     variant: {
       options: ['default', 'destructive', 'outline', 'secondary', 'ghost', 'link'],

--- a/lib/platform-bible-react/src/stories/shadcn-ui/card.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/card.stories.tsx
@@ -26,6 +26,14 @@ const meta: Meta<typeof Card> = {
   title: 'Shadcn/Card',
   component: Card,
   tags: ['autodocs', 'test'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays a card with header, content, and footer.\n\nShadcn docs: [Card](https://ui.shadcn.com/docs/components/card)',
+      },
+    },
+  },
   argTypes: {
     className: { control: 'text' },
   },

--- a/lib/platform-bible-react/src/stories/shadcn-ui/checkbox.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/checkbox.stories.tsx
@@ -9,6 +9,14 @@ const meta: Meta<typeof Checkbox> = {
   title: 'Shadcn/Checkbox',
   component: Checkbox,
   tags: ['autodocs', 'test'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A control that allows the user to toggle between checked and not checked.\n\nShadcn docs: [Checkbox](https://ui.shadcn.com/docs/components/checkbox)',
+      },
+    },
+  },
   argTypes: {
     checked: { control: 'boolean' },
     disabled: { control: 'boolean' },

--- a/lib/platform-bible-react/src/stories/shadcn-ui/context-menu.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/context-menu.stories.tsx
@@ -35,7 +35,7 @@ const meta: Meta<typeof ContextMenu> = {
     docs: {
       description: {
         component:
-          'Context Menu component displays a menu to the user — such as a set of actions or functions, triggered by right-clicking on an element.',
+          'Displays a menu to the user — such as a set of actions or functions — triggered by right-clicking on an element.\n\nShadcn docs: [Context Menu](https://ui.shadcn.com/docs/components/context-menu)',
       },
     },
   },

--- a/lib/platform-bible-react/src/stories/shadcn-ui/dialog.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/dialog.stories.tsx
@@ -18,6 +18,14 @@ const meta: Meta<typeof Dialog> = {
   title: 'Shadcn/Dialog',
   component: Dialog,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A window overlaid on either the primary window or another dialog window, rendering the content underneath inert.\n\nShadcn docs: [Dialog](https://ui.shadcn.com/docs/components/dialog)',
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/shadcn-ui/drawer.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/drawer.stories.tsx
@@ -18,6 +18,14 @@ const meta: Meta<typeof Drawer> = {
   title: 'Shadcn/Drawer',
   component: Drawer,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A drawer component for React that is built on top of Vaul.\n\nShadcn docs: [Drawer](https://ui.shadcn.com/docs/components/drawer)',
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/shadcn-ui/dropdown-menu.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/dropdown-menu.stories.tsx
@@ -22,6 +22,14 @@ const meta: Meta<typeof DropdownMenu> = {
   title: 'Shadcn/DropdownMenu',
   component: DropdownMenu,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays a menu to the user — such as a set of actions or functions — triggered by a button.\n\nShadcn docs: [Dropdown Menu](https://ui.shadcn.com/docs/components/dropdown-menu)',
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/shadcn-ui/input-group.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/input-group.stories.tsx
@@ -14,6 +14,14 @@ const meta: Meta<typeof InputGroup> = {
   title: 'Shadcn/InputGroup',
   component: InputGroup,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A composable input group that combines an input with inline or block addons such as icons, buttons, and labels.\n\nShadcn docs: [Input Group](https://ui.shadcn.com/docs/components/input-group)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/shadcn-ui/input.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/input.stories.tsx
@@ -7,6 +7,14 @@ const meta: Meta<typeof Input> = {
   title: 'Shadcn/Input',
   component: Input,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays a form input field or a component that looks like an input field.\n\nShadcn docs: [Input](https://ui.shadcn.com/docs/components/input)',
+      },
+    },
+  },
   argTypes: {
     placeholder: { control: 'text' },
     disabled: { control: 'boolean' },

--- a/lib/platform-bible-react/src/stories/shadcn-ui/kbd.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/kbd.stories.tsx
@@ -6,6 +6,14 @@ const meta: Meta<typeof Kbd> = {
   title: 'Shadcn/Kbd',
   component: Kbd,
   tags: ['autodocs', 'test'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays a keyboard key or shortcut.\n\nShadcn docs: [Kbd](https://ui.shadcn.com/docs/components/kbd)',
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/shadcn-ui/menubar.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/menubar.stories.tsx
@@ -21,6 +21,14 @@ const meta: Meta<typeof Menubar> = {
   title: 'Shadcn/Menubar',
   component: Menubar,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A visually persistent menu common in desktop applications that provides quick access to a consistent set of commands.\n\nShadcn docs: [Menubar](https://ui.shadcn.com/docs/components/menubar)',
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/shadcn-ui/progress.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/progress.stories.tsx
@@ -7,6 +7,14 @@ const meta: Meta<typeof Progress> = {
   title: 'Shadcn/Progress',
   component: Progress,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays an indicator showing the completion progress of a task, typically displayed as a progress bar.\n\nShadcn docs: [Progress](https://ui.shadcn.com/docs/components/progress)',
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/shadcn-ui/radio-group.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/radio-group.stories.tsx
@@ -9,6 +9,14 @@ const meta: Meta<typeof RadioGroup> = {
   title: 'Shadcn/RadioGroup',
   component: RadioGroup,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A set of checkable buttons—known as radio buttons—where no more than one of the buttons can be checked at a time.\n\nShadcn docs: [Radio Group](https://ui.shadcn.com/docs/components/radio-group)',
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/shadcn-ui/resizable.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/resizable.stories.tsx
@@ -9,6 +9,14 @@ import {
 const meta: Meta = {
   title: 'Shadcn/Resizable',
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Accessible resizable panel groups and layouts with keyboard support.\n\nShadcn docs: [Resizable](https://ui.shadcn.com/docs/components/resizable)',
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/shadcn-ui/select.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/select.stories.tsx
@@ -16,6 +16,14 @@ const meta: Meta<typeof Select> = {
   title: 'Shadcn/Select',
   component: Select,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Displays a list of options for the user to pick from—triggered by a button.\n\nShadcn docs: [Select](https://ui.shadcn.com/docs/components/select)',
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/shadcn-ui/sidebar.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/sidebar.stories.tsx
@@ -34,6 +34,14 @@ const meta: Meta<typeof Sidebar> = {
     variant: { control: 'select', options: ['sidebar', 'floating', 'inset'] },
     collapsible: { control: 'select', options: ['offcanvas', 'icon', 'none'] },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A composable, themeable, and accessible sidebar component.\n\nShadcn docs: [Sidebar](https://ui.shadcn.com/docs/components/sidebar)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/shadcn-ui/skeleton.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/skeleton.stories.tsx
@@ -16,6 +16,14 @@ const meta: Meta<typeof Skeleton> = {
   argTypes: {
     className: { control: 'text' },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Use to show a placeholder while content is loading.\n\nShadcn docs: [Skeleton](https://ui.shadcn.com/docs/components/skeleton)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/shadcn-ui/slider.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/slider.stories.tsx
@@ -22,6 +22,14 @@ const meta: Meta<typeof Slider> = {
     disabled: { control: 'boolean' },
     onValueChange: { action: 'value changed' },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'An input where the user selects a value from within a given range.\n\nShadcn docs: [Slider](https://ui.shadcn.com/docs/components/slider)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/shadcn-ui/sonner.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/sonner.stories.tsx
@@ -14,6 +14,14 @@ const meta: Meta<typeof Sonner> = {
       </ThemeProvider>
     ),
   ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'An opinionated toast component for React built on top of Sonner.\n\nShadcn docs: [Sonner](https://ui.shadcn.com/docs/components/sonner)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/shadcn-ui/switch.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/switch.stories.tsx
@@ -21,6 +21,14 @@ const meta: Meta<typeof Switch> = {
     disabled: { control: 'boolean' },
     onCheckedChange: { action: 'checked changed' },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A control that allows the user to toggle between two states.\n\nShadcn docs: [Switch](https://ui.shadcn.com/docs/components/switch)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/shadcn-ui/table.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/table.stories.tsx
@@ -25,6 +25,14 @@ const meta: Meta<typeof Table> = {
   argTypes: {
     stickyHeader: { control: 'boolean' },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A responsive table component.\n\nShadcn docs: [Table](https://ui.shadcn.com/docs/components/table)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/shadcn-ui/toggle-group.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/toggle-group.stories.tsx
@@ -23,6 +23,14 @@ const meta: Meta<typeof ToggleGroup> = {
     disabled: { control: 'boolean' },
     onValueChange: { action: 'value changed' },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A set of two-state buttons that can be toggled on or off.\n\nShadcn docs: [Toggle Group](https://ui.shadcn.com/docs/components/toggle-group)',
+      },
+    },
+  },
 };
 
 export default meta;

--- a/lib/platform-bible-react/src/stories/shadcn-ui/tooltip.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/tooltip.stories.tsx
@@ -17,6 +17,14 @@ const meta: Meta<typeof Tooltip> = {
     delayDuration: { control: 'number' },
     disableHoverableContent: { control: 'boolean' },
   },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A popup that displays information related to an element when the element receives keyboard focus or the mouse hovers over it.\n\nShadcn docs: [Tooltip](https://ui.shadcn.com/docs/components/tooltip)',
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>


### PR DESCRIPTION
## Summary

Adds component-level shadcn docs links to the Storybook autodocs page for every shadcn-derived component in `lib/platform-bible-react/src/stories/`.

- All 26 files in `stories/shadcn-ui/` (except the paranext-only `scope-selector`) now include `Shadcn docs: [Name](https://ui.shadcn.com/docs/components/{slug})` at the top of their autodocs page.
- Six paranext-named components that map onto shadcn patterns also got links with a sentence describing the relationship:
  - `basics/checklist` → Checkbox (Checkbox Group pattern)
  - `basics/spinner` → Spinner (direct)
  - `basics/tabs` → Tabs (notes `TabsList`/`TabsTrigger` vs `TabsContent` and the paranext `VerticalTabs` variant)
  - `basics/text-field` → Input (existing description already noted this; updated with the link)
  - `basics/combo-box` → Combobox (direct)
  - `advanced/multi-select-combo-box` → Combobox (multi-select extension)
- `basics/smart-label` was evaluated and **not** linked — it dynamically renders labels via callback factories and has no close shadcn counterpart; linking to Label or Field would mislead readers.

## Known gap: story-level subsection links

The original task asked for per-story subsection links (e.g. `button.stories.tsx`'s `VariantsDemo` linking to `#variants` on the shadcn page). The sandbox can't reach `ui.shadcn.com` (Cloudflare 403 via both WebFetch and `curl`) or the `shadcn-ui/ui` repo on GitHub (rate-limited / restricted MCP scope), so anchor IDs couldn't be verified and no subsection links were added — better than fabricating anchors. This is a follow-up task that needs an environment with shadcn.com access.

## Test plan

- [ ] Run Storybook for `platform-bible-react` and confirm the "Shadcn docs:" link appears at the top of each affected component's autodocs page.
- [ ] Click each link from the autodocs page and verify it lands on the correct shadcn docs page.
- [ ] Confirm the relationship-note descriptions on Checklist, Tabs, Combobox-family, and Text Field read correctly.
- [ ] Verify nothing renders for `Shadcn/ScopeSelector` (intentionally unchanged) or `Basics/SmartLabel` (intentionally unchanged).

https://claude.ai/code/session_01ABuqfyKY9NSZuNFBKUZuU4

---
_Generated by [Claude Code](https://claude.ai/code/session_01ABuqfyKY9NSZuNFBKUZuU4)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2303)
<!-- Reviewable:end -->
