### PR TITLE
PT-3982: Add recently-opened-projects service

### DIFF
--- a/extensions/__test-mocks__/@papi/backend.ts
+++ b/extensions/__test-mocks__/@papi/backend.ts
@@ -1,3 +1,10 @@
+// This file legitimately exports two mock classes (`ProjectDataProviderEngine` and
+// `DataProviderEngine`) — they mirror the two real exports from `@papi/backend` that extension
+// service code extends. Splitting them across two files would duplicate the file-level Vitest
+// import and the @papi/backend module alias, and any consumer of one mock implicitly needs the
+// other. Disable the rule for this mock-only file.
+/* eslint-disable max-classes-per-file */
+
 import { vi } from 'vitest';
 
 /**
@@ -16,6 +23,10 @@ export const logger = {
 };
 
 export class ProjectDataProviderEngine {
+  notifyUpdate = vi.fn();
+}
+
+export class DataProviderEngine {
   notifyUpdate = vi.fn();
 }
 

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -411,6 +411,8 @@ interface PickerMocks {
   mockGetSetting: ReturnType<typeof vi.fn>;
   mockGetAllOpenWebViewDefinitions: ReturnType<typeof vi.fn>;
   mockSendCommand: ReturnType<typeof vi.fn>;
+  mockDataProvidersGet: ReturnType<typeof vi.fn>;
+  mockRecordProjectOpened: ReturnType<typeof vi.fn>;
   mockWarn: ReturnType<typeof vi.fn>;
   mockInfo: ReturnType<typeof vi.fn>;
   mockDebug: ReturnType<typeof vi.fn>;
@@ -479,6 +481,14 @@ function createPickerMocks(): PickerMocks {
     };
   });
 
+  const mockRecordProjectOpened = vi.fn().mockResolvedValue(undefined);
+  const mockDataProvidersGet = vi.fn().mockImplementation(async (name: string) => {
+    if (name === 'platformScripture.recentlyOpenedProjects') {
+      return { recordProjectOpened: mockRecordProjectOpened };
+    }
+    return undefined;
+  });
+
   // Mocking just the parts of PAPI the picker and its driver touch at runtime.
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   const papi = {
@@ -490,6 +500,7 @@ function createPickerMocks(): PickerMocks {
     },
     commands: { sendCommand: mockSendCommand },
     network: { getNetworkEvent: mockGetNetworkEvent },
+    dataProviders: { get: mockDataProvidersGet },
     logger: { warn: mockWarn, info: mockInfo, debug: mockDebug },
   } as unknown as typeof PapiBackend;
 
@@ -498,6 +509,8 @@ function createPickerMocks(): PickerMocks {
     mockGetSetting,
     mockGetAllOpenWebViewDefinitions,
     mockSendCommand,
+    mockDataProvidersGet,
+    mockRecordProjectOpened,
     mockWarn,
     mockInfo,
     mockDebug,
@@ -854,6 +867,162 @@ describe('openDefaultActiveProjectIfApplicable', () => {
 
     expect(outcome).toBe('failed');
     expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('records the opened project as recently-opened on the filled path', async () => {
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      mockRecordProjectOpened,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'paratextBibleSendReceive.getSharedProjects') {
+        return {
+          proj1: {
+            id: 'proj1',
+            name: 'P1',
+            fullName: 'Project 1',
+            language: 'en',
+            editedStatus: 'edited',
+            lastSendReceiveDate: '2025-06-01T00:00:00Z',
+          },
+        };
+      }
+      if (commandName === 'platformScriptureEditor.openScriptureEditor') {
+        return 'opened-webview-id';
+      }
+      return undefined;
+    });
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('filled');
+    expect(mockRecordProjectOpened).toHaveBeenCalledWith('proj1');
+    expect(mockRecordProjectOpened).toHaveBeenCalledTimes(1);
+  });
+
+  it('still reports filled even if recordProjectOpened throws', async () => {
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      mockRecordProjectOpened,
+      mockWarn,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'paratextBibleSendReceive.getSharedProjects') {
+        return {
+          proj1: {
+            id: 'proj1',
+            name: 'P1',
+            fullName: 'Project 1',
+            language: 'en',
+            editedStatus: 'edited',
+            lastSendReceiveDate: '2025-06-01T00:00:00Z',
+          },
+        };
+      }
+      if (commandName === 'platformScriptureEditor.openScriptureEditor') {
+        return 'opened-webview-id';
+      }
+      return undefined;
+    });
+    mockRecordProjectOpened.mockRejectedValueOnce(new Error('storage write blew up'));
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('filled');
+    expect(mockWarn).toHaveBeenCalled();
+  });
+
+  it('does not record when openScriptureEditor fails', async () => {
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      mockRecordProjectOpened,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'paratextBibleSendReceive.getSharedProjects') {
+        return {
+          proj1: {
+            id: 'proj1',
+            name: 'P1',
+            fullName: 'Project 1',
+            language: 'en',
+            editedStatus: 'edited',
+            lastSendReceiveDate: '2025-06-01T00:00:00Z',
+          },
+        };
+      }
+      if (commandName === 'platformScriptureEditor.openScriptureEditor') {
+        throw new Error('open failed');
+      }
+      return undefined;
+    });
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('failed');
+    expect(mockRecordProjectOpened).not.toHaveBeenCalled();
+  });
+
+  it('still reports filled when dataProviders.get returns undefined', async () => {
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      mockDataProvidersGet,
+      mockRecordProjectOpened,
+      mockWarn,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'paratextBibleSendReceive.getSharedProjects') {
+        return {
+          proj1: {
+            id: 'proj1',
+            name: 'P1',
+            fullName: 'Project 1',
+            language: 'en',
+            editedStatus: 'edited',
+            lastSendReceiveDate: '2025-06-01T00:00:00Z',
+          },
+        };
+      }
+      if (commandName === 'platformScriptureEditor.openScriptureEditor') {
+        return 'opened-webview-id';
+      }
+      return undefined;
+    });
+    // Override the default mock so dataProviders.get returns undefined for the recents service.
+    mockDataProvidersGet.mockResolvedValue(undefined);
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('filled');
+    expect(mockRecordProjectOpened).not.toHaveBeenCalled();
+    expect(mockWarn).not.toHaveBeenCalled();
   });
 });
 

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -598,8 +598,8 @@ export async function openDefaultActiveProjectIfApplicable(
     hasFailed = true;
   }
 
-  // Best-effort: record the project in the recent projects list so the toolbar picker (PT-3983) can surface
-  // it. Failure here must NOT change the outcome — opening succeeded.
+  // Best-effort: record the project in the recent projects list so the future Recent projects picker
+  // can surface it. Failure here must NOT change the outcome — opening succeeded.
   if (openedScriptureEditor) {
     try {
       const recentlyOpenedProjects = await papi.dataProviders.get(

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -586,14 +586,31 @@ export async function openDefaultActiveProjectIfApplicable(
 
   const top = candidates[0];
   let hasFailed = false;
+  let openedScriptureEditor = false;
   papi.logger.info(`Default active project picker: opening project=${top.id}`);
   try {
     await papi.commands.sendCommand('platformScriptureEditor.openScriptureEditor', top.id);
+    openedScriptureEditor = true;
   } catch (e) {
     papi.logger.warn(
       `Default active project picker: openScriptureEditor for ${top.id} failed: ${getErrorMessage(e)}`,
     );
     hasFailed = true;
+  }
+
+  // Best-effort: record the project in the recent projects list so the toolbar picker (PT-3983) can surface
+  // it. Failure here must NOT change the outcome — opening succeeded.
+  if (openedScriptureEditor) {
+    try {
+      const recentlyOpenedProjects = await papi.dataProviders.get(
+        'platformScripture.recentlyOpenedProjects',
+      );
+      await recentlyOpenedProjects?.recordProjectOpened(top.id);
+    } catch (e) {
+      papi.logger.warn(
+        `Default active project picker: failed to record recently-opened project ${top.id}: ${getErrorMessage(e)}`,
+      );
+    }
   }
 
   // Tries to open the model text

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -461,7 +461,7 @@ export async function activate(context: ExecutionActivationContext) {
   await checkHostingService.initialize();
   await checkAggregatorService.initialize();
 
-  const readRecentlyOpenedProjectsRaw = async (): Promise<string> => {
+  async function readRawRecentlyOpenedProjects(): Promise<string> {
     try {
       return await papi.storage.readUserData(
         context.executionToken,
@@ -471,12 +471,17 @@ export async function activate(context: ExecutionActivationContext) {
       // No data yet — treat as empty list.
       return '[]';
     }
-  };
-  const writeRecentlyOpenedProjectsRaw = (data: string): Promise<void> =>
-    papi.storage.writeUserData(context.executionToken, RECENTLY_OPENED_PROJECTS_STORAGE_KEY, data);
+  }
+  function writeRawRecentlyOpenedProjects(data: string): Promise<void> {
+    return papi.storage.writeUserData(
+      context.executionToken,
+      RECENTLY_OPENED_PROJECTS_STORAGE_KEY,
+      data,
+    );
+  }
   await recentlyOpenedProjectsService.initialize(
-    readRecentlyOpenedProjectsRaw,
-    writeRecentlyOpenedProjectsRaw,
+    readRawRecentlyOpenedProjects,
+    writeRawRecentlyOpenedProjects,
   );
 
   context.registrations.add(

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -12,10 +12,6 @@ import {
   notifyCheckResultsInvalidated,
 } from './checks/check-aggregator.service';
 import { checkHostingService } from './checks/extension-host-check-runner.service';
-import {
-  recentlyOpenedProjectsService,
-  RECENTLY_OPENED_PROJECTS_STORAGE_KEY,
-} from './recently-opened-projects.service';
 import { InventoryWebViewOptions, InventoryWebViewProvider } from './inventory.web-view-provider';
 import { SCRIPTURE_EXTENDER_PROJECT_INTERFACES } from './project-data-provider/platform-scripture-extender-pdpe.model';
 import {
@@ -27,6 +23,10 @@ import {
   ScriptureFinderProjectDataProviderEngineFactory,
 } from './project-data-provider/platform-scripture-finder.pdpef.model';
 import { SCRIPTURE_FINDER_PROJECT_INTERFACES } from './project-data-provider/platform-scripture-finder-pdpe.model';
+import {
+  recentlyOpenedProjectsService,
+  RECENTLY_OPENED_PROJECTS_STORAGE_KEY,
+} from './recently-opened-projects.service';
 import { resourceReferenceListValidator } from './resource-reference-list.utils';
 
 const characterInventoryWebViewType = 'platformScripture.characterInventory';

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -12,6 +12,10 @@ import {
   notifyCheckResultsInvalidated,
 } from './checks/check-aggregator.service';
 import { checkHostingService } from './checks/extension-host-check-runner.service';
+import {
+  recentlyOpenedProjectsService,
+  RECENTLY_OPENED_PROJECTS_STORAGE_KEY,
+} from './recently-opened-projects.service';
 import { InventoryWebViewOptions, InventoryWebViewProvider } from './inventory.web-view-provider';
 import { SCRIPTURE_EXTENDER_PROJECT_INTERFACES } from './project-data-provider/platform-scripture-extender-pdpe.model';
 import {
@@ -457,6 +461,24 @@ export async function activate(context: ExecutionActivationContext) {
   await checkHostingService.initialize();
   await checkAggregatorService.initialize();
 
+  const readRecentlyOpenedProjectsRaw = async (): Promise<string> => {
+    try {
+      return await papi.storage.readUserData(
+        context.executionToken,
+        RECENTLY_OPENED_PROJECTS_STORAGE_KEY,
+      );
+    } catch {
+      // No data yet — treat as empty list.
+      return '[]';
+    }
+  };
+  const writeRecentlyOpenedProjectsRaw = (data: string): Promise<void> =>
+    papi.storage.writeUserData(context.executionToken, RECENTLY_OPENED_PROJECTS_STORAGE_KEY, data);
+  await recentlyOpenedProjectsService.initialize(
+    readRecentlyOpenedProjectsRaw,
+    writeRecentlyOpenedProjectsRaw,
+  );
+
   context.registrations.add(
     await scriptureExtenderPdpefPromise,
     await scriptureFinderPdpefPromise,
@@ -487,6 +509,7 @@ export async function activate(context: ExecutionActivationContext) {
     await invalidateResultsPromise,
     checkHostingService.dispose,
     checkAggregatorService.dispose,
+    recentlyOpenedProjectsService.dispose,
   );
 
   logger.debug('platformScripture is finished activating!');

--- a/extensions/src/platform-scripture/src/recently-opened-projects.service.test.ts
+++ b/extensions/src/platform-scripture/src/recently-opened-projects.service.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  MAX_RECENT_PROJECTS,
+  RecentlyOpenedProjectsDataProviderEngine,
+} from './recently-opened-projects.service';
+
+type Fakes = {
+  readRaw: ReturnType<typeof vi.fn<() => Promise<string>>>;
+  writeRaw: ReturnType<typeof vi.fn<(data: string) => Promise<void>>>;
+};
+
+function createFakes(initial: string = '[]'): Fakes {
+  let stored = initial;
+  const readRaw = vi.fn<() => Promise<string>>().mockImplementation(async () => stored);
+  const writeRaw = vi.fn<(data: string) => Promise<void>>().mockImplementation(async (data) => {
+    stored = data;
+  });
+  return { readRaw, writeRaw };
+}
+
+describe('RecentlyOpenedProjectsDataProviderEngine', () => {
+  it('returns [] when storage is empty / missing', async () => {
+    const { readRaw, writeRaw } = createFakes('[]');
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    const result = await engine.getRecentProjects();
+
+    expect(result).toEqual([]);
+    expect(writeRaw).not.toHaveBeenCalled();
+  });
+
+  it('returns the persisted list when storage holds a valid array', async () => {
+    const { readRaw, writeRaw } = createFakes(JSON.stringify(['A', 'B', 'C']));
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    const result = await engine.getRecentProjects();
+
+    expect(result).toEqual(['A', 'B', 'C']);
+    expect(writeRaw).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when storage contains invalid JSON', async () => {
+    const { readRaw, writeRaw } = createFakes('not-json{{');
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    const result = await engine.getRecentProjects();
+
+    expect(result).toEqual([]);
+    expect(writeRaw).not.toHaveBeenCalled();
+  });
+
+  it('returns [] when storage contains a non-array value', async () => {
+    const { readRaw, writeRaw } = createFakes(JSON.stringify({ not: 'an array' }));
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    expect(await engine.getRecentProjects()).toEqual([]);
+    expect(writeRaw).not.toHaveBeenCalled();
+  });
+
+  it('strips non-string and empty-string entries on read', async () => {
+    // Deliberate null in the fixture to verify the filter discards non-string entries.
+    // eslint-disable-next-line no-null/no-null
+    const { readRaw, writeRaw } = createFakes(JSON.stringify(['A', 42, '', 'B', null]));
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    expect(await engine.getRecentProjects()).toEqual(['A', 'B']);
+    expect(writeRaw).not.toHaveBeenCalled();
+  });
+
+  it('caps the returned list at MAX_RECENT_PROJECTS even when storage holds more', async () => {
+    const stored = ['A', 'B', 'C', 'D', 'E', 'F', 'G'];
+    const { readRaw, writeRaw } = createFakes(JSON.stringify(stored));
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    const result = await engine.getRecentProjects();
+
+    expect(result).toEqual(stored.slice(0, MAX_RECENT_PROJECTS));
+    expect(result).toHaveLength(MAX_RECENT_PROJECTS);
+    expect(writeRaw).not.toHaveBeenCalled();
+  });
+
+  it('caches after first read — only one readRaw call across many getRecentProjects', async () => {
+    const { readRaw, writeRaw } = createFakes(JSON.stringify(['A']));
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    await engine.getRecentProjects();
+    await engine.getRecentProjects();
+    await engine.getRecentProjects();
+
+    expect(readRaw).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats readRaw rejection as empty list and caches the empty state', async () => {
+    const readRaw = vi.fn<() => Promise<string>>().mockRejectedValueOnce(new Error('disk gone'));
+    const writeRaw = vi.fn<(data: string) => Promise<void>>();
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    expect(await engine.getRecentProjects()).toEqual([]);
+    // Second call must not re-attempt the read — the empty state should be cached.
+    expect(await engine.getRecentProjects()).toEqual([]);
+    expect(readRaw).toHaveBeenCalledTimes(1);
+    expect(writeRaw).not.toHaveBeenCalled();
+  });
+
+  it('recordProjectOpened on an empty list yields [projectId] and persists it', async () => {
+    const { readRaw, writeRaw } = createFakes('[]');
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    await engine.recordProjectOpened('A');
+
+    expect(await engine.getRecentProjects()).toEqual(['A']);
+    expect(writeRaw).toHaveBeenCalledTimes(1);
+    expect(writeRaw).toHaveBeenCalledWith(JSON.stringify(['A']));
+  });
+
+  it('recordProjectOpened with a new ID pushes it to the front of the existing list', async () => {
+    const { readRaw, writeRaw } = createFakes(JSON.stringify(['A']));
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    await engine.recordProjectOpened('B');
+
+    expect(await engine.getRecentProjects()).toEqual(['B', 'A']);
+    expect(writeRaw).toHaveBeenCalledTimes(1);
+    expect(writeRaw).toHaveBeenCalledWith(JSON.stringify(['B', 'A']));
+  });
+
+  it('notifies subscribers when the list changes', async () => {
+    const { readRaw, writeRaw } = createFakes('[]');
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+    const notifySpy = vi.spyOn(engine, 'notifyUpdate');
+
+    await engine.recordProjectOpened('A');
+
+    expect(notifySpy).toHaveBeenCalledWith('RecentProjects');
+    expect(notifySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves an existing ID to the front without changing the list length', async () => {
+    const { readRaw, writeRaw } = createFakes(JSON.stringify(['B', 'A']));
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    await engine.recordProjectOpened('A');
+
+    expect(await engine.getRecentProjects()).toEqual(['A', 'B']);
+    expect(writeRaw).toHaveBeenCalledTimes(1);
+    expect(writeRaw).toHaveBeenCalledWith(JSON.stringify(['A', 'B']));
+  });
+
+  it('caps the list at MAX_RECENT_PROJECTS, dropping the oldest entries', async () => {
+    const { readRaw, writeRaw } = createFakes('[]');
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    await engine.recordProjectOpened('A');
+    await engine.recordProjectOpened('B');
+    await engine.recordProjectOpened('C');
+    await engine.recordProjectOpened('D');
+    await engine.recordProjectOpened('E');
+    await engine.recordProjectOpened('F');
+
+    const result = await engine.getRecentProjects();
+    expect(result).toEqual(['F', 'E', 'D', 'C', 'B']);
+    expect(result).toHaveLength(MAX_RECENT_PROJECTS);
+  });
+
+  it('re-recording the already-most-recent ID is a no-op (no write, no notify)', async () => {
+    const { readRaw, writeRaw } = createFakes(JSON.stringify(['A', 'B']));
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+    // Prime the cache so the first call doesn't write either.
+    await engine.getRecentProjects();
+    const notifySpy = vi.spyOn(engine, 'notifyUpdate');
+
+    await engine.recordProjectOpened('A');
+
+    expect(await engine.getRecentProjects()).toEqual(['A', 'B']);
+    expect(writeRaw).not.toHaveBeenCalled();
+    expect(notifySpy).not.toHaveBeenCalled();
+  });
+
+  it.each(['', '   ', '\t', '\n'])(
+    'silently rejects empty / whitespace projectId (%j) — no write, no notify',
+    async (projectId) => {
+      const { readRaw, writeRaw } = createFakes('[]');
+      const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+      const notifySpy = vi.spyOn(engine, 'notifyUpdate');
+
+      await engine.recordProjectOpened(projectId);
+
+      expect(await engine.getRecentProjects()).toEqual([]);
+      expect(writeRaw).not.toHaveBeenCalled();
+      expect(notifySpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it('setRecentProjects throws — external set is unsupported', async () => {
+    const { readRaw, writeRaw } = createFakes('[]');
+    const engine = new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw);
+
+    expect(() => engine.setRecentProjects()).toThrow(/not supported/i);
+  });
+});

--- a/extensions/src/platform-scripture/src/recently-opened-projects.service.ts
+++ b/extensions/src/platform-scripture/src/recently-opened-projects.service.ts
@@ -74,7 +74,7 @@ export class RecentlyOpenedProjectsDataProviderEngine
   }
 
   async recordProjectOpened(projectId: string): Promise<void> {
-    if (!projectId || !projectId.trim()) return;
+    if (!projectId?.trim()) return;
     const current = await this.loadCache();
     const next = [projectId, ...current.filter((id) => id !== projectId)].slice(
       0,
@@ -110,14 +110,12 @@ async function initialize(
   readRaw: () => Promise<string>,
   writeRaw: (data: string) => Promise<void>,
 ): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = (async () => {
-      dataProvider = await papi.dataProviders.registerEngine(
-        RECENTLY_OPENED_PROJECTS_DATA_PROVIDER_NAME,
-        new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw),
-      );
-    })();
-  }
+  initializationPromise ??= (async () => {
+    dataProvider = await papi.dataProviders.registerEngine(
+      RECENTLY_OPENED_PROJECTS_DATA_PROVIDER_NAME,
+      new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw),
+    );
+  })();
   return initializationPromise;
 }
 
@@ -142,5 +140,3 @@ export const recentlyOpenedProjectsService = {
   dispose,
   serviceObject,
 };
-
-export default recentlyOpenedProjectsService;

--- a/extensions/src/platform-scripture/src/recently-opened-projects.service.ts
+++ b/extensions/src/platform-scripture/src/recently-opened-projects.service.ts
@@ -1,6 +1,10 @@
 import papi, { DataProviderEngine, logger } from '@papi/backend';
-import type { IDisposableDataProvider } from '@papi/core';
-import { createSyncProxyForAsyncObject, getErrorMessage } from 'platform-bible-utils';
+import type {
+  DataProviderUpdateInstructions,
+  IDataProviderEngine,
+  IDisposableDataProvider,
+} from '@papi/core';
+import { createSyncProxyForAsyncObject, deepEqual, getErrorMessage } from 'platform-bible-utils';
 import type {
   IRecentlyOpenedProjectsService,
   RecentlyOpenedProjectsDataTypes,
@@ -13,8 +17,7 @@ export const RECENTLY_OPENED_PROJECTS_STORAGE_KEY = 'recentlyOpenedProjects';
 export const MAX_RECENT_PROJECTS = 5;
 
 /** Name used to register and look up this data provider on the PAPI. */
-export const RECENTLY_OPENED_PROJECTS_DATA_PROVIDER_NAME =
-  'platformScripture.recentlyOpenedProjects';
+const RECENTLY_OPENED_PROJECTS_DATA_PROVIDER_NAME = 'platformScripture.recentlyOpenedProjects';
 
 /**
  * Parse a raw JSON string from user storage into a validated list of project IDs. Returns `[]` on
@@ -36,14 +39,6 @@ function parseAndValidate(raw: string): string[] {
   return filtered.slice(0, MAX_RECENT_PROJECTS);
 }
 
-function arraysShallowEqual(a: readonly string[], b: readonly string[]): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i += 1) {
-    if (a[i] !== b[i]) return false;
-  }
-  return true;
-}
-
 /**
  * Engine for the recently-opened-projects data provider.
  *
@@ -51,7 +46,10 @@ function arraysShallowEqual(a: readonly string[], b: readonly string[]): boolean
  * without standing up papi.storage. Production wiring in main.ts supplies callbacks backed by
  * `papi.storage.readUserData` / `writeUserData` scoped to the extension's execution token.
  */
-export class RecentlyOpenedProjectsDataProviderEngine extends DataProviderEngine<RecentlyOpenedProjectsDataTypes> {
+export class RecentlyOpenedProjectsDataProviderEngine
+  extends DataProviderEngine<RecentlyOpenedProjectsDataTypes>
+  implements IDataProviderEngine<RecentlyOpenedProjectsDataTypes>
+{
   private cache: string[] | undefined;
 
   constructor(
@@ -62,14 +60,16 @@ export class RecentlyOpenedProjectsDataProviderEngine extends DataProviderEngine
   }
 
   async getRecentProjects(): Promise<string[]> {
-    return this.loadCache();
+    // Return a copy so callers cannot mutate the engine's internal cache by reference.
+    return [...(await this.loadCache())];
   }
 
-  // Set is not supported externally; recordProjectOpened is the only mutation path. The data type
-  // declares the set value as `never`, so TypeScript prevents external callers; this throw is the
-  // runtime safety net for callers that bypass types.
+  // setRecentProjects is not supported externally; recordProjectOpened is the only mutation path.
+  // The data type declares the set value as `never`, so TypeScript prevents external callers;
+  // this throw is the runtime safety net for callers that bypass types. It cannot be static
+  // because it implements the IDataProviderEngine<RecentlyOpenedProjectsDataTypes> interface.
   // eslint-disable-next-line @typescript-eslint/class-methods-use-this
-  setRecentProjects(): never {
+  setRecentProjects(): Promise<DataProviderUpdateInstructions<RecentlyOpenedProjectsDataTypes>> {
     throw new Error('setRecentProjects is not supported; use recordProjectOpened instead');
   }
 
@@ -80,7 +80,7 @@ export class RecentlyOpenedProjectsDataProviderEngine extends DataProviderEngine
       0,
       MAX_RECENT_PROJECTS,
     );
-    if (arraysShallowEqual(next, current)) return;
+    if (deepEqual(next, current)) return;
     await this.writeRaw(JSON.stringify(next));
     this.cache = next;
     this.notifyUpdate('RecentProjects');
@@ -133,7 +133,7 @@ const serviceObject = createSyncProxyForAsyncObject<IRecentlyOpenedProjectsServi
 }, serviceObjectToProxy);
 
 async function dispose(): Promise<boolean> {
-  return dataProvider ? dataProvider.dispose() : true;
+  return dataProvider.dispose();
 }
 
 /** Service for tracking which projects the user has opened as a main project in Simple mode. */

--- a/extensions/src/platform-scripture/src/recently-opened-projects.service.ts
+++ b/extensions/src/platform-scripture/src/recently-opened-projects.service.ts
@@ -1,0 +1,146 @@
+import papi, { DataProviderEngine, logger } from '@papi/backend';
+import type { IDisposableDataProvider } from '@papi/core';
+import { createSyncProxyForAsyncObject, getErrorMessage } from 'platform-bible-utils';
+import type {
+  IRecentlyOpenedProjectsService,
+  RecentlyOpenedProjectsDataTypes,
+} from 'platform-scripture';
+
+/** Storage key under the platform-scripture extension's user data. */
+export const RECENTLY_OPENED_PROJECTS_STORAGE_KEY = 'recentlyOpenedProjects';
+
+/** Maximum number of project IDs kept in the recent projects list. */
+export const MAX_RECENT_PROJECTS = 5;
+
+/** Name used to register and look up this data provider on the PAPI. */
+export const RECENTLY_OPENED_PROJECTS_DATA_PROVIDER_NAME =
+  'platformScripture.recentlyOpenedProjects';
+
+/**
+ * Parse a raw JSON string from user storage into a validated list of project IDs. Returns `[]` on
+ * any deviation from the expected shape: invalid JSON, non-array root, non-string elements, empty
+ * strings. Caps the result at {@link MAX_RECENT_PROJECTS}.
+ */
+function parseAndValidate(raw: string): string[] {
+  if (!raw) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+  const filtered = parsed.filter(
+    (item): item is string => typeof item === 'string' && item.length > 0,
+  );
+  return filtered.slice(0, MAX_RECENT_PROJECTS);
+}
+
+function arraysShallowEqual(a: readonly string[], b: readonly string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Engine for the recently-opened-projects data provider.
+ *
+ * Storage I/O is delegated to constructor-injected callbacks so tests can use in-memory fakes
+ * without standing up papi.storage. Production wiring in main.ts supplies callbacks backed by
+ * `papi.storage.readUserData` / `writeUserData` scoped to the extension's execution token.
+ */
+export class RecentlyOpenedProjectsDataProviderEngine extends DataProviderEngine<RecentlyOpenedProjectsDataTypes> {
+  private cache: string[] | undefined;
+
+  constructor(
+    private readonly readRaw: () => Promise<string>,
+    private readonly writeRaw: (data: string) => Promise<void>,
+  ) {
+    super();
+  }
+
+  async getRecentProjects(): Promise<string[]> {
+    return this.loadCache();
+  }
+
+  // Set is not supported externally; recordProjectOpened is the only mutation path. The data type
+  // declares the set value as `never`, so TypeScript prevents external callers; this throw is the
+  // runtime safety net for callers that bypass types.
+  // eslint-disable-next-line @typescript-eslint/class-methods-use-this
+  setRecentProjects(): never {
+    throw new Error('setRecentProjects is not supported; use recordProjectOpened instead');
+  }
+
+  async recordProjectOpened(projectId: string): Promise<void> {
+    if (!projectId || !projectId.trim()) return;
+    const current = await this.loadCache();
+    const next = [projectId, ...current.filter((id) => id !== projectId)].slice(
+      0,
+      MAX_RECENT_PROJECTS,
+    );
+    if (arraysShallowEqual(next, current)) return;
+    await this.writeRaw(JSON.stringify(next));
+    this.cache = next;
+    this.notifyUpdate('RecentProjects');
+  }
+
+  private async loadCache(): Promise<string[]> {
+    if (this.cache) return this.cache;
+    let raw: string;
+    try {
+      raw = await this.readRaw();
+    } catch (e) {
+      logger.warn(
+        `Recently opened projects: read from storage failed (${getErrorMessage(e)}); treating as empty`,
+      );
+      this.cache = [];
+      return this.cache;
+    }
+    this.cache = parseAndValidate(raw);
+    return this.cache;
+  }
+}
+
+let initializationPromise: Promise<void> | undefined;
+let dataProvider: IDisposableDataProvider<IRecentlyOpenedProjectsService>;
+
+async function initialize(
+  readRaw: () => Promise<string>,
+  writeRaw: (data: string) => Promise<void>,
+): Promise<void> {
+  if (!initializationPromise) {
+    initializationPromise = (async () => {
+      dataProvider = await papi.dataProviders.registerEngine(
+        RECENTLY_OPENED_PROJECTS_DATA_PROVIDER_NAME,
+        new RecentlyOpenedProjectsDataProviderEngine(readRaw, writeRaw),
+      );
+    })();
+  }
+  return initializationPromise;
+}
+
+const serviceObjectToProxy = Object.freeze({});
+
+const serviceObject = createSyncProxyForAsyncObject<IRecentlyOpenedProjectsService>(async () => {
+  // The service-object proxy is created at module-load time, but initialize() requires the
+  // execution-token-bound storage callbacks supplied by activate(). Callers that touch this proxy
+  // must therefore wait until initialize() has been awaited in activate(). The proxy itself simply
+  // re-fetches the registered data provider; it is not the place to construct one.
+  if (!dataProvider) throw new Error('Recently opened projects service is not initialized');
+  return dataProvider;
+}, serviceObjectToProxy);
+
+async function dispose(): Promise<boolean> {
+  return dataProvider ? dataProvider.dispose() : true;
+}
+
+/** Service for tracking which projects the user has opened as a main project in Simple mode. */
+export const recentlyOpenedProjectsService = {
+  initialize,
+  dispose,
+  serviceObject,
+};
+
+export default recentlyOpenedProjectsService;

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -1772,6 +1772,45 @@ declare module 'platform-scripture' {
   };
 
   // #endregion Resource Reference Types
+
+  // #region Recently Opened Projects Types
+
+  /** Data types for the recently-opened-projects data provider. */
+  export type RecentlyOpenedProjectsDataTypes = {
+    /**
+     * Ordered list of project IDs that the user has opened as their main/active project in the
+     * Simple interface, most-recent first. Capped at 5 entries.
+     *
+     * `get` takes no selector and returns `string[]`. `set` is not supported — use
+     * {@link IRecentlyOpenedProjectsService.recordProjectOpened} instead.
+     */
+    RecentProjects: DataProviderDataType<undefined, string[], never>;
+  };
+
+  /**
+   * Service that maintains an ordered list of the projects the user has most recently opened as
+   * their main/active project in the Simple interface. Use the
+   * "platformScripture.recentlyOpenedProjects" data provider name to access it.
+   *
+   * History is stored locally for the OS user only; it is not synced via the Paratext Registry.
+   *
+   * Opens of a project as a resource or model text MUST NOT be recorded — only main-project opens.
+   */
+  export type IRecentlyOpenedProjectsService = IDataProvider<RecentlyOpenedProjectsDataTypes> & {
+    /**
+     * Records that the given project was opened as the active/main project in the Simple interface.
+     * The project ID is moved (or pushed) to the front of the recents list, the list is capped at 5
+     * entries, persisted to user storage, and subscribers are notified.
+     *
+     * Re-recording the project that is already at the front of the list is a no-op (no write, no
+     * notification). Empty or whitespace-only `projectId` values are rejected silently.
+     *
+     * @param projectId The ID of the project that was just opened as a main project.
+     */
+    recordProjectOpened: (projectId: string) => Promise<void>;
+  };
+
+  // #endregion Recently Opened Projects Types
 }
 
 declare module 'papi-shared-types' {
@@ -1799,6 +1838,7 @@ declare module 'papi-shared-types' {
     CheckCreatorFunction,
     CheckResultsInvalidated,
     ResourceReferenceList,
+    IRecentlyOpenedProjectsService,
   } from 'platform-scripture';
 
   export interface ProjectDataProviderInterfaces {
@@ -1829,6 +1869,11 @@ declare module 'papi-shared-types' {
     'platformScripture.extensionHostCheckRunner': ICheckRunner;
     /** Data provider for managing inventories and their options */
     'platformScripture.inventoryDataProvider': IInventoryDataProvider;
+    /**
+     * Service that maintains the list of projects most recently opened as a main project in the
+     * Simple interface. See {@link IRecentlyOpenedProjectsService}.
+     */
+    'platformScripture.recentlyOpenedProjects': IRecentlyOpenedProjectsService;
   }
 
   export interface CommandHandlers {

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -1779,7 +1779,7 @@ declare module 'platform-scripture' {
   export type RecentlyOpenedProjectsDataTypes = {
     /**
      * Ordered list of project IDs that the user has opened as their main/active project in the
-     * Simple interface, most-recent first. Capped at 5 entries.
+     * Simple interface, most-recent first. Capped at a small number of entries (currently 5).
      *
      * `get` takes no selector and returns `string[]`. `set` is not supported — use
      * {@link IRecentlyOpenedProjectsService.recordProjectOpened} instead.
@@ -1799,8 +1799,9 @@ declare module 'platform-scripture' {
   export type IRecentlyOpenedProjectsService = IDataProvider<RecentlyOpenedProjectsDataTypes> & {
     /**
      * Records that the given project was opened as the active/main project in the Simple interface.
-     * The project ID is moved (or pushed) to the front of the recents list, the list is capped at 5
-     * entries, persisted to user storage, and subscribers are notified.
+     * The project ID is moved (or pushed) to the front of the recents list, the list is capped at a
+     * small number of entries (currently 5), persisted to user storage, and subscribers are
+     * notified.
      *
      * Re-recording the project that is already at the front of the list is a no-op (no write, no
      * notification). Empty or whitespace-only `projectId` values are rejected silently.

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -1794,7 +1794,8 @@ declare module 'platform-scripture' {
    *
    * History is stored locally for the OS user only; it is not synced via the Paratext Registry.
    *
-   * Opens of a project as a resource or model text MUST NOT be recorded — only main-project opens.
+   * Only record opens of a project as the main project; do not record opens as a resource or model
+   * text.
    */
   export type IRecentlyOpenedProjectsService = IDataProvider<RecentlyOpenedProjectsDataTypes> & {
     /**


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: `pt-3982-recent-project-service`

**Base**: `origin/main`

**Date**: 2026-05-20

**Review model**: Claude Opus 4.7

**Files changed**: 7

## Overview

Adds a new `recentlyOpenedProjectsService` in the `platform-scripture` extension that tracks the last 5 projects a user has opened as a main/active project in the Simple interface. The service is exposed as a PAPI data provider under the name `platformScripture.recentlyOpenedProjects` with a single data type (`RecentProjects`, read-only externally) and one mutation method (`recordProjectOpened`). History is persisted to local user storage (no registry sync). The `platform-scripture-editor` extension's `openDefaultActiveProjectIfApplicable` flow now calls `recordProjectOpened` on a best-effort basis after a successful main-project open — failure to record never changes the outer outcome.

This is a backend-only change. There is no UI consumer yet; the next ticket (PT-3983) will introduce the picker that reads this service.

## API Changes

- `extensions/src/platform-scripture/src/types/platform-scripture.d.ts` (public extension type declarations): Added new exports — `RecentlyOpenedProjectsDataTypes` and `IRecentlyOpenedProjectsService`.
- `extensions/src/platform-scripture/src/types/platform-scripture.d.ts` — `papi-shared-types` augmentation: Added new entry `'platformScripture.recentlyOpenedProjects': IRecentlyOpenedProjectsService` to the `DataProviders` interface.
- No changes to `lib/platform-bible-react/`, `lib/platform-bible-utils/`, or `papi.d.ts`. No exports removed or modified — purely additive.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **Class declaration omitted `implements IDataProviderEngine<...>` and `setRecentProjects(): never` diverged from the peer pattern** _(fixed during review: added `implements IDataProviderEngine<RecentlyOpenedProjectsDataTypes>` clause and changed `setRecentProjects()` to return `Promise<DataProviderUpdateInstructions<RecentlyOpenedProjectsDataTypes>>` matching peers like `lexical-reference.service.ts`. The method still throws synchronously, so the existing runtime-safety test continues to pass.)_
- [x] **Data-provider name string `'platformScripture.recentlyOpenedProjects'` was both exported as a constant and hardcoded at the call site** _(fixed during review: un-exported `RECENTLY_OPENED_PROJECTS_DATA_PROVIDER_NAME` to match the `checkAggregatorServiceProviderName` peer pattern. Constant is now used only inside the service file; the call site uses the literal as the rest of the file does.)_
- [x] **`getRecentProjects()` returned the cached array by reference, allowing in-process callers to silently mutate the engine's cache** _(fixed during review: returns `[...await this.loadCache()]` — a fresh copy on every call.)_

Author response: All three Important findings were fixed in-review.

### Minor — Consider

- [x] **JSDoc on `RecentProjects` hardcoded "Capped at 5 entries"** — drift risk if `MAX_RECENT_PROJECTS` ever changes _(fixed during review: softened to "Capped at a small number of entries (currently 5)" in both the data-type doc and the `recordProjectOpened` doc.)_
- [ ] ~~`RecentProjects` declares get as `string[]` rather than `readonly string[]`~~ _(Author asked whether any peer data type uses `readonly` arrays — none do. All peer `DataProviderDataType` arrays in the codebase are mutable. Dismissed to match codebase convention; the new copy-return in `getRecentProjects()` already prevents cache corruption.)_
- [ ] ~~`recordProjectOpened` is the only mutation method (no clear / remove)~~ _(Author chose to defer to PT-3983 — adding methods later is non-breaking, and questions about callers (UI button vs. project-deletion hook) are properly the UI ticket's concern. Flagged in the PT-3983 handoff notes below.)_
- [x] **Import placement in `main.ts:15-18`** _(fixed during review: moved the `recently-opened-projects.service` import to its alphabetical position between `project-data-provider/...` and `resource-reference-list.utils`.)_
- [x] **Local `arraysShallowEqual` helper duplicated existing `deepEqual` from `platform-bible-utils`** _(fixed during review: removed the local helper and replaced the call with `deepEqual` from `platform-bible-utils`. For two `string[]` arrays the semantics are identical.)_
- [x] **`dispose()` guarded `dataProvider` against undefined, but the branch is unreachable because `main.ts` awaits `initialize` before registering the disposer** _(fixed during review: simplified to `return dataProvider.dispose()` to match the `check-aggregator.service.ts:424` peer pattern.)_
- [x] **Comment in `platform-scripture-editor.utils.ts:601` referenced PT-3983 and exceeded the ~100-char wrap** _(fixed during review: dropped the ticket number, rewrote as "the future Recent projects picker", and reflowed.)_
- [ ] ~~`papi.logger.warn` for record-failure could be `info`/`debug` like the nearby `getSharedProjects` log~~ _(Dismissed — the two situations differ. `getSharedProjects` is `debug` because the S/R extension is optional and absent in the steady state on vanilla Platform.Bible; a failure of `recordProjectOpened` is genuinely unexpected because the recents service is registered by the same extension, so `warn` is appropriate to surface real load-order or registration issues.)_
- [ ] **`extensions/__test-mocks__/@papi/backend.ts` — added `DataProviderEngine` mock at the `extensions/` root** _(see Template Propagation section below — flagged as a follow-up to keep `paranext-multi-extension-template` in sync.)_

Author response: 6 minor findings were fixed in-review. 3 were dismissed with reasoning (no readonly arrays in peer data types; clear/remove deferred to PT-3983; warn log level is intentional).

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

- [ ] `extensions/__test-mocks__/@papi/backend.ts` — added a `DataProviderEngine` mock export so the new `RecentlyOpenedProjectsDataProviderEngine` unit tests can run against a `notifyUpdate` stub. This file sits at the `extensions/` root (extension-root infrastructure, not extension-specific), and its sibling `ProjectDataProviderEngine` mock almost certainly originated from a template. Propagate this addition to `paranext-multi-extension-template` (and check `paranext-extension-template`) so future template merges do not drift or revert it. Per `.context/standards/Git-Guide.md`, template-propagation merges must NOT be squash-merged — use a normal merge commit.

## Positive Observations

- Public API additions are purely additive — new types plus a new entry in the `DataProviders` augmentation. No exports were removed or modified, so the change is fully backward-compatible. All types referenced in the new public exports (`IDataProvider`, `DataProviderDataType`) are already exported from `@papi/core`; no new transitive exports are needed.
- JSDoc on the public types explicitly states the contract (the 5-cap, no-op-on-rewrite semantics, whitespace rejection, local-only storage, main-project opens only) — exactly the contract documentation the next UI consumer (PT-3983) will need.
- The `set` channel is explicitly disabled (`never`) at the type level and at runtime — a clean way to expose a one-way mutation API without leaving a footgun open.
- Constructor injection of storage callbacks is a clean testability pattern — the service tests do not need to stand up `papi.storage` and faithfully exercise the engine logic.
- Comprehensive unit test coverage: 19 tests on the service (parse/validate edge cases — invalid JSON, non-array root, non-string elements, empty strings; MAX cap; caching; read-failure handling; no-op-when-most-recent; whitespace rejection via `it.each`; explicit unsupported-set throw), plus 4 new tests on the caller (happy path, record-throws, opening-failed-do-not-record, dataProviders.get-returns-undefined) — exactly the four meaningful branches the new wiring introduced.
- The "best-effort" semantics around recording in `openDefaultActiveProjectIfApplicable` (don't fail the outer outcome if record fails) is well-reasoned and well-commented.
- The `setRecentProjects` runtime safety net is paired with a clear `eslint-disable` comment explaining why the method can't be `static`, matching the established codebase idiom.
- The mock-file `eslint-disable` for `max-classes-per-file` is well-justified and clearly explained in a leading comment.

## Interview Notes

The author was responsive throughout and demonstrated clear understanding of the service and its design. Key context for the reviewer:

- **Patterns over preferences**: For every Important finding and most Minor findings, the author explicitly asked to match the surrounding peer pattern rather than diverge — confirming that the divergences flagged were unintentional and should be reconciled. This is the right instinct.
- **Trade-off accepted on `readonly` data type**: Author dismissed switching to `readonly string[]` after confirming no peer data type uses readonly arrays. The decision relies on `getRecentProjects()` now returning a copy, which the author also approved adding.
- **Deferred work to PT-3983**: Author chose not to pre-emptively add `clearRecentProjects()` / `removeProject()` methods. Reasonable — the API surface is easier to extend than to retract, and questions about callers are the UI ticket's concern.
- **Log-level pushback was substantive**: Author dismissed downgrading the record-failure log from `warn` after confirming the situations differ (recents service is co-located in the same extension, unlike the optional S/R extension). Good call.

No areas where the author deferred to AI or expressed uncertainty about their own changes.

## In-Review Quality Check

- **`npm run typecheck`**: pre-existing errors only (missing extension `.d.ts` artifacts for `hello-world`, `platform-home`, `resource-viewer`). Verified by `git stash` against the base commit — these errors exist before any in-review changes. CI's build step generates these files; locally a full `npm run build` would resolve.
- **`npm run lint`**: one prettier warning on the in-review JSDoc edit in `types/platform-scripture.d.ts`. Auto-fixed by `npm run format`. Two pre-existing `no-console` warnings in `use-effective-resource-reference-list.ts` (not touched by this branch).
- **`npm run format`**: applied minor whitespace tweaks to the 4 modified extension files. Re-running lint after format reports 0 errors.
- **Targeted unit tests**: `recently-opened-projects.service.test.ts` (19/19) and `platform-scripture-editor.utils.test.ts` (54/54) all pass.

No unfixable failures introduced by the in-review changes.

## Suggested Review Focus

Prioritized areas for the author-reviewer meeting:

- [x] **Confirm the data-provider proxy forwards `recordProjectOpened`**: The new service exposes `recordProjectOpened` as a custom engine method on top of the standard data-provider get/set surface. Existing peers (e.g., `IInventoryDataProvider.buildInventorySummary`) follow the same shape, but a quick hand-test (call `recordProjectOpened` through `papi.dataProviders.get(...)` rather than via `serviceObject`) before PT-3983 begins would be worthwhile.
- [ ] **Template-propagation follow-up**: Decide who will propagate the `DataProviderEngine` mock addition to `paranext-multi-extension-template` (and verify `paranext-extension-template`). Remember to use a normal merge commit, not squash.
- [x] **PT-3983 handoff** (the author asked this be highlighted) — items the next UI consumer should know:
  - Access the service by name: `await papi.dataProviders.get('platformScripture.recentlyOpenedProjects')`. The type augmentation provides full typing for that key.
  - `recordProjectOpened` is already wired into `openDefaultActiveProjectIfApplicable`, so the recents list will populate on Simple-mode default opens. The next UI task is the *read* side, plus likely a manual call site for non-default main-project opens.
  - **No `clearRecentProjects()` or `removeProject(projectId)` exists yet** — if the UI offers a "clear recents" affordance or auto-removal when a project is deleted from disk, the service will need to grow these methods. Each is ~5 lines of engine code plus tests; the design question is who calls them.
  - The cap is `MAX_RECENT_PROJECTS = 5`, currently a private constant in the service file (not part of the public type declaration). If the UI needs to know the cap (e.g., to label "5 most recent…"), promote it to the type declaration or expose via provider metadata.
  - The data type is `RecentProjects` (singular noun + plural collection), accessed via `useDataProvider(...).RecentProjects` patterns or via the `getRecentProjects()` method on the engine.
  - Only **main-project opens in the Simple interface** should be recorded — opens as resource or model text MUST NOT call `recordProjectOpened`. This invariant is in the JSDoc but is the caller's responsibility to honor.
  - History is local-only (not synced to the Paratext Registry) — switching computers will not carry it over.
<!-- review-paratext:summary:end -->

---

Add a `platformScripture.recentlyOpenedProjects` data provider that maintains an ordered list of the last 5 projects opened as the main project in 10Simple. The list is persisted to local user storage via papi.storage, and exposes a `recordProjectOpened(projectId)` mutator plus subscription semantics for future consumers (PT-3983).

Wire it into `openDefaultActiveProjectIfApplicable` so the existing zero-state opener populates the list on day one. The wiring is best-effort and never affects the picker outcome on failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2311)
<!-- Reviewable:end -->

