### PR TITLE
Link Basics stories to corresponding shadcn/ui docs pages

### DIFF
--- a/lib/platform-bible-react/src/stories/basics/cancel-accept-buttons.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/cancel-accept-buttons.stories.tsx
@@ -12,7 +12,8 @@ const meta: Meta<typeof CancelAcceptButtons> = {
   parameters: {
     docs: {
       description: {
-        component: `
+        component: `Composed from shadcn/ui primitives: [Button](https://ui.shadcn.com/docs/components/button) (incl. Button Group) and [Tooltip](https://ui.shadcn.com/docs/components/tooltip).
+
 Cancel and Accept buttons with tooltips for use in editor toolbars.
 
 - Pass \`canAccept\` to control the disabled state of each button.

--- a/lib/platform-bible-react/src/stories/basics/checklist.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/checklist.stories.tsx
@@ -9,6 +9,13 @@ const meta: Meta<typeof Checklist> = {
   title: 'Basics/Checklist',
   component: Checklist,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: `Built on shadcn/ui's [Checkbox](https://ui.shadcn.com/docs/components/checkbox) primitive.`,
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/basics/combo-box.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/combo-box.stories.tsx
@@ -40,6 +40,13 @@ const meta: Meta<typeof ComboBox<string>> = {
   title: 'Basics/ComboBox',
   component: ComboBox<string>,
   tags: ['autodocs', 'test'],
+  parameters: {
+    docs: {
+      description: {
+        component: `Built on shadcn/ui's [Combobox](https://ui.shadcn.com/docs/components/combobox) primitive.`,
+      },
+    },
+  },
   argTypes: {
     options: { control: 'object' },
     textPlaceholder: { control: 'text' },

--- a/lib/platform-bible-react/src/stories/basics/search-bar.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/search-bar.stories.tsx
@@ -30,6 +30,13 @@ const meta: Meta<typeof SearchBar> = {
   title: 'Basics/SearchBar',
   component: SearchBar,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: `Wraps shadcn/ui's [Input](https://ui.shadcn.com/docs/components/input) with a clear [Button](https://ui.shadcn.com/docs/components/button).`,
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/basics/smart-label.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/smart-label.stories.tsx
@@ -11,7 +11,8 @@ const meta: Meta<typeof SmartLabel> = {
   parameters: {
     docs: {
       description: {
-        component: `
+        component: `Built on shadcn/ui's [Label](https://ui.shadcn.com/docs/components/label) primitive.
+
 A flexible label component that can create labels with plain text, transformed text, or complex React elements.
 
 This component provides three ways to render labels:

--- a/lib/platform-bible-react/src/stories/basics/tabs.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/tabs.stories.tsx
@@ -13,6 +13,13 @@ const meta: Meta<typeof Tabs> = {
   title: 'Basics/Tabs',
   component: Tabs,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component: `Built on shadcn/ui's [Tabs](https://ui.shadcn.com/docs/components/tabs) primitive.`,
+      },
+    },
+  },
   decorators: [
     (Story) => (
       <ThemeProvider>

--- a/lib/platform-bible-react/src/stories/basics/text-field.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/text-field.stories.tsx
@@ -10,7 +10,8 @@ const meta: Meta<typeof TextField> = {
   parameters: {
     docs: {
       description: {
-        component: `
+        component: `Built on shadcn/ui's [Input](https://ui.shadcn.com/docs/components/input) primitive, with an optional [Label](https://ui.shadcn.com/docs/components/label).
+
 A text input field component with label, validation, and helper text support.
 
 Based on shadcn-ui Input component with additional features like error states and full-width support.

--- a/lib/platform-bible-react/src/stories/basics/undo-redo-buttons.stories.tsx
+++ b/lib/platform-bible-react/src/stories/basics/undo-redo-buttons.stories.tsx
@@ -12,7 +12,8 @@ const meta: Meta<typeof UndoRedoButtons> = {
   parameters: {
     docs: {
       description: {
-        component: `
+        component: `Composed from shadcn/ui primitives: [Button](https://ui.shadcn.com/docs/components/button) (incl. Button Group), [Tooltip](https://ui.shadcn.com/docs/components/tooltip), and [Kbd](https://ui.shadcn.com/docs/components/radix/kbd).
+
 Undo and (optionally) Redo buttons with tooltips for use in editor toolbars.
 
 - Omit \`onRedoClick\` to render only the Undo button.


### PR DESCRIPTION
## Summary

Adds links from "Basics" component Storybook docs to the corresponding shadcn/ui documentation pages so consumers can jump from a paranext component to the primitive it's built on.

Each link is added to the meta object's `parameters.docs.description.component`, rendering at the top of the Docs tab in Storybook. The phrasing is tiered to reflect how directly the component maps to a shadcn primitive.

### Tier 1 — Clear primary wraps (prominent line)
| Story | Linked to |
|---|---|
| `checklist.stories.tsx` | [Checkbox](https://ui.shadcn.com/docs/components/checkbox) |
| `combo-box.stories.tsx` | [Combobox](https://ui.shadcn.com/docs/components/combobox) |
| `smart-label.stories.tsx` | [Label](https://ui.shadcn.com/docs/components/label) |
| `tabs.stories.tsx` | [Tabs](https://ui.shadcn.com/docs/components/tabs) |
| `text-field.stories.tsx` | [Input](https://ui.shadcn.com/docs/components/input) + [Label](https://ui.shadcn.com/docs/components/label) |

### Tier 2 — Composed/partial (subtle, explanatory)
| Story | Linked to |
|---|---|
| `cancel-accept-buttons.stories.tsx` | [Button](https://ui.shadcn.com/docs/components/button) (incl. Button Group), [Tooltip](https://ui.shadcn.com/docs/components/tooltip) |
| `undo-redo-buttons.stories.tsx` | [Button](https://ui.shadcn.com/docs/components/button) (incl. Button Group), [Tooltip](https://ui.shadcn.com/docs/components/tooltip), [Kbd](https://ui.shadcn.com/docs/components/radix/kbd) |
| `search-bar.stories.tsx` | [Input](https://ui.shadcn.com/docs/components/input), [Button](https://ui.shadcn.com/docs/components/button) |

### Skipped (no shadcn equivalent)
- `error-dump.stories.tsx` — custom utility component
- `spinner.stories.tsx` — lucide-react wrapper, not a shadcn primitive
- `results-card.stories.tsx` — domain-specific card pattern; doesn't wrap shadcn's Card

URLs follow the conventions already used in each component's JSDoc (notably: `button-group.tsx` already documents itself under the Button page, and `kbd.tsx` already documents itself under `/radix/kbd`).

### Notes on subsections
The original request also asked about linking individual story variants to docs subsections. Live shadcn docs return 403 to automated fetches and the shadcn CLI requires registry auth in this environment, so subsection anchor IDs could not be reliably verified. Subsection links were intentionally omitted to avoid shipping broken anchors at the top of every Docs page. The page-level link covers the same examples (e.g. the "Vertical" variant of Tabs is documented on the main Tabs page).

## Test plan

- [ ] Run Storybook (`npm run storybook` in `lib/platform-bible-react`) and open each modified story under **Basics/**.
- [ ] Confirm the docs link appears at the top of the **Docs** tab and is clickable.
- [ ] Spot-check that pre-existing per-story descriptions still render below the new link.
- [ ] Verify the linked shadcn pages are reachable (in particular `button-group` is documented under Button per the repo convention, and `kbd` lives at `/radix/kbd`).

https://claude.ai/code/session_019YX1nFDNxQdSWoUg8QaPoJ

---
_Generated by [Claude Code](https://claude.ai/code/session_019YX1nFDNxQdSWoUg8QaPoJ)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2312)
<!-- Reviewable:end -->
