### PR TITLE
refactor(c-sharp): unify scripture-range types on a canonical ScriptureRange

### DIFF
--- a/c-sharp-tests/Checklists/ChecklistContentItemPolymorphismTests.cs
+++ b/c-sharp-tests/Checklists/ChecklistContentItemPolymorphismTests.cs
@@ -2,6 +2,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using Paranext.DataProvider.Checklists;
 using Paranext.DataProvider.JsonUtils;
+using Paranext.DataProvider.Scripture;
 using SIL.Scripture;
 
 namespace TestParanextDataProvider.Checklists;

--- a/c-sharp-tests/Checklists/ChecklistDataModelTests.cs
+++ b/c-sharp-tests/Checklists/ChecklistDataModelTests.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using Paranext.DataProvider.Checklists;
 using Paranext.DataProvider.Checklists.Markers;
 using Paranext.DataProvider.JsonUtils;
+using Paranext.DataProvider.Scripture;
 using SIL.Scripture;
 
 namespace TestParanextDataProvider.Checklists;

--- a/c-sharp-tests/Checklists/ChecklistRowBuilderTests.cs
+++ b/c-sharp-tests/Checklists/ChecklistRowBuilderTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Paranext.DataProvider.Checklists;
+using Paranext.DataProvider.Scripture;
 using SIL.Scripture;
 
 namespace TestParanextDataProvider.Checklists;

--- a/c-sharp-tests/Checklists/ChecklistServiceBuildChecklistDataTests.cs
+++ b/c-sharp-tests/Checklists/ChecklistServiceBuildChecklistDataTests.cs
@@ -8,7 +8,7 @@ using Paranext.DataProvider.Checklists.Markers;
 using Paranext.DataProvider.Projects;
 using Paratext.Data;
 using SIL.Scripture;
-using ScriptureRange = Paranext.DataProvider.Checklists.ScriptureRange;
+using ScriptureRange = Paranext.DataProvider.Scripture.ScriptureRange;
 
 namespace TestParanextDataProvider.Checklists;
 

--- a/c-sharp-tests/Checklists/ChecklistServiceEditLinkGatingTests.cs
+++ b/c-sharp-tests/Checklists/ChecklistServiceEditLinkGatingTests.cs
@@ -8,7 +8,7 @@ using Paranext.DataProvider.Checklists.Markers;
 using Paranext.DataProvider.Projects;
 using Paratext.Data;
 using SIL.Scripture;
-using ScriptureRange = Paranext.DataProvider.Checklists.ScriptureRange;
+using ScriptureRange = Paranext.DataProvider.Scripture.ScriptureRange;
 
 namespace TestParanextDataProvider.Checklists;
 

--- a/c-sharp-tests/Checklists/Markers/MarkersDataSourceTests.cs
+++ b/c-sharp-tests/Checklists/Markers/MarkersDataSourceTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Paranext.DataProvider.Checklists;
 using Paranext.DataProvider.Checklists.Markers;
+using Paranext.DataProvider.Scripture;
 using Paratext.Data;
 using SIL.Scripture;
 

--- a/c-sharp-tests/Checks/InputRangeTests.cs
+++ b/c-sharp-tests/Checks/InputRangeTests.cs
@@ -1,4 +1,6 @@
+using System.Text.Json;
 using Paranext.DataProvider.Checks;
+using Paranext.DataProvider.JsonUtils;
 using SIL.Scripture;
 
 namespace TestParanextDataProvider.Checks;
@@ -68,5 +70,35 @@ public class InputRangeTests
         }
 
         Assert.That(exceptionMessage, Does.Contain(expectedPartialMessage));
+    }
+
+    [Test]
+    public void JsonRoundTrip_PreservesFlatWireShapeAndValueEquality()
+    {
+        var options = SerializationOptions.CreateSerializationOptions();
+        var original = new InputRange("pid1", new VerseRef("GEN 1:1"), new VerseRef("GEN 5:10"));
+
+        string json = JsonSerializer.Serialize(original, options);
+        var roundTripped = JsonSerializer.Deserialize<InputRange>(json, options);
+
+        // CheckInputRange is the flat `ScriptureRange & { projectId }` wire shape — start, end,
+        // and projectId all sit at the top level of one JSON object.
+        Assert.That(json, Does.Contain("\"projectId\""));
+        Assert.That(json, Does.Contain("\"start\""));
+        Assert.That(json, Does.Contain("\"end\""));
+        Assert.That(roundTripped, Is.EqualTo(original));
+    }
+
+    [Test]
+    public void JsonRoundTrip_SingleVerseRangeHasNullEnd()
+    {
+        var options = SerializationOptions.CreateSerializationOptions();
+        var original = new InputRange("pid1", new VerseRef("GEN 1:1"), null);
+
+        string json = JsonSerializer.Serialize(original, options);
+        var roundTripped = JsonSerializer.Deserialize<InputRange>(json, options);
+
+        Assert.That(roundTripped, Is.EqualTo(original));
+        Assert.That(roundTripped!.End, Is.Null);
     }
 }

--- a/c-sharp-tests/JsonUtils/CommentThreadSelectorConverterTests.cs
+++ b/c-sharp-tests/JsonUtils/CommentThreadSelectorConverterTests.cs
@@ -157,7 +157,7 @@ internal class CommentThreadSelectorConverterTests
         Assert.That(selector.ScriptureRanges[0].Start.BookNum, Is.EqualTo(1));
         Assert.That(selector.ScriptureRanges[0].Start.ChapterNum, Is.EqualTo(1));
         Assert.That(selector.ScriptureRanges[0].Start.VerseNum, Is.EqualTo(1));
-        Assert.That(selector.ScriptureRanges[0].End.VerseNum, Is.EqualTo(31));
+        Assert.That(selector.ScriptureRanges[0].End!.Value.VerseNum, Is.EqualTo(31));
         Assert.That(selector.ScriptureRanges[0].Granularity, Is.EqualTo("verse"));
     }
 

--- a/c-sharp-tests/Projects/ParatextProjectDataProviderCommentTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderCommentTests.cs
@@ -454,22 +454,21 @@ namespace TestParanextDataProvider.Projects
             {
                 ScriptureRanges =
                 [
-                    new()
-                    {
-                        Start = new VerseRef
+                    new CommentScriptureRange(
+                        new VerseRef
                         {
                             BookNum = 1,
                             ChapterNum = 1,
                             VerseNum = 1,
                         },
-                        End = new VerseRef
+                        new VerseRef
                         {
                             BookNum = 1,
                             ChapterNum = 1,
                             VerseNum = 1,
                         },
-                        Granularity = "verse",
-                    },
+                        "verse"
+                    ),
                 ],
             };
 
@@ -659,22 +658,21 @@ namespace TestParanextDataProvider.Projects
                 IsRead = true,
                 ScriptureRanges =
                 [
-                    new()
-                    {
-                        Start = new VerseRef
+                    new CommentScriptureRange(
+                        new VerseRef
                         {
                             BookNum = 1,
                             ChapterNum = 1,
                             VerseNum = 1,
                         },
-                        End = new VerseRef
+                        new VerseRef
                         {
                             BookNum = 1,
                             ChapterNum = 1,
                             VerseNum = 1,
                         },
-                        Granularity = "verse",
-                    },
+                        "verse"
+                    ),
                 ],
             };
 

--- a/c-sharp/Checklists/ChecklistRequest.cs
+++ b/c-sharp/Checklists/ChecklistRequest.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using Paranext.DataProvider.Checklists.Markers;
+using Paranext.DataProvider.Scripture;
 
 namespace Paranext.DataProvider.Checklists;
 

--- a/c-sharp/Checklists/ChecklistResult.cs
+++ b/c-sharp/Checklists/ChecklistResult.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
+using Paranext.DataProvider.Scripture;
 
 namespace Paranext.DataProvider.Checklists;
 

--- a/c-sharp/Checklists/ChecklistRowBuilder.cs
+++ b/c-sharp/Checklists/ChecklistRowBuilder.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Paranext.DataProvider.Scripture;
 using SIL.Scripture;
 
 namespace Paranext.DataProvider.Checklists;

--- a/c-sharp/Checklists/ChecklistService.cs
+++ b/c-sharp/Checklists/ChecklistService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading;
 using Paranext.DataProvider.Checklists.Markers;
 using Paranext.DataProvider.Projects;
+using Paranext.DataProvider.Scripture;
 using Paratext.Data;
 using PtxUtils;
 using SIL.Scripture;

--- a/c-sharp/Checklists/LinkItem.cs
+++ b/c-sharp/Checklists/LinkItem.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Paranext.DataProvider.Scripture;
 
 namespace Paranext.DataProvider.Checklists;
 

--- a/c-sharp/Checks/InputRange.cs
+++ b/c-sharp/Checks/InputRange.cs
@@ -1,13 +1,20 @@
+using System;
+using System.Text.Json.Serialization;
+using Paranext.DataProvider.Scripture;
 using SIL.Scripture;
 
 namespace Paranext.DataProvider.Checks;
 
 /// <summary>
-/// Represents a range of text within a project that checks can target. This class must
-/// serialize/deserialize to the CheckInputRange type defined in TypeScript.
+/// Represents a range of text within a project that checks can target. This record must
+/// serialize/deserialize to the CheckInputRange type defined in TypeScript — the canonical
+/// <see cref="ScriptureRange"/> (<see cref="ScriptureRange.Start"/> / <see cref="ScriptureRange.End"/>)
+/// plus a <see cref="ProjectId"/>, serialized flat. <see cref="InputRange"/> derives from
+/// <see cref="ScriptureRange"/>, so the inherited <c>Start</c>/<c>End</c> serialize alongside
+/// <c>ProjectId</c> on a single JSON object.
 /// <br />
-/// An <see cref="InputRange"/> represents a selection of scripture text. If <see cref="End"/> is
-/// null, then only the verse indicated by <see cref="Start"/> is included.
+/// An <see cref="InputRange"/> represents a selection of scripture text. If <see cref="ScriptureRange.End"/>
+/// is null, then only the verse indicated by <see cref="ScriptureRange.Start"/> is included.
 /// <br />
 /// Special values for verse and chapter numbers:
 /// - Verse 0: Includes all parts of the chapter, including content before the first verse.
@@ -18,42 +25,42 @@ namespace Paranext.DataProvider.Checks;
 ///   desired and the exact number of chapters is unknown.
 /// <br />
 /// Note that Paratext checks cannot be run on less than an entire book because of the definition of
-/// <see cref="ScriptureCheckBase.Run"/>. The <see cref="InputRange"/> class allows defining a
+/// <see cref="ScriptureCheckBase.Run"/>. The <see cref="InputRange"/> record allows defining a
 /// range that is more granular than an entire book because that is how Platform.Bible's interfaces
 /// work, and we need to serialize and deserialize these structures when communicating with the
 /// platform. Whenever a Paratext check is given a range, though, it can only target entire books.
 /// <br />
 /// See the TypeScript check data types for more details.
 /// </summary>
-internal sealed class InputRange
+internal sealed record InputRange : ScriptureRange
 {
-    private string _projectId;
-    private VerseRef _start;
-    private VerseRef? _end;
-
     // Maximum verse/chapter number that can be represented in BBBCCCVVV format
     public const int MAX_CHAPTER_OR_VERSE_NUM = 999;
 
+    public string ProjectId { get; }
+
+    [JsonConstructor]
     public InputRange(string projectId, VerseRef start, VerseRef? end)
+        : base(Clamp(start), ClampNullable(end))
     {
         ArgumentException.ThrowIfNullOrEmpty(projectId);
-
-        // Clamp verse and chapter numbers to MAX values
-        if (start.VerseNum > MAX_CHAPTER_OR_VERSE_NUM)
-            start.VerseNum = MAX_CHAPTER_OR_VERSE_NUM;
-        if (start.ChapterNum > MAX_CHAPTER_OR_VERSE_NUM)
-            start.ChapterNum = MAX_CHAPTER_OR_VERSE_NUM;
-        if (end.HasValue && end.Value.VerseNum > MAX_CHAPTER_OR_VERSE_NUM)
-            end = new VerseRef(end.Value) { VerseNum = MAX_CHAPTER_OR_VERSE_NUM };
-        if (end.HasValue && end.Value.ChapterNum > MAX_CHAPTER_OR_VERSE_NUM)
-            end = new VerseRef(end.Value) { ChapterNum = MAX_CHAPTER_OR_VERSE_NUM };
-
-        VerifyRange(start, end);
-
-        _projectId = projectId;
-        _start = start;
-        _end = end;
+        VerifyRange(Start, End);
+        ProjectId = projectId;
     }
+
+    // Clamp verse and chapter numbers to MAX_CHAPTER_OR_VERSE_NUM. VerseRef is a struct, so the
+    // parameter is a by-value copy — mutating and returning it does not affect the caller.
+    private static VerseRef Clamp(VerseRef verseRef)
+    {
+        if (verseRef.VerseNum > MAX_CHAPTER_OR_VERSE_NUM)
+            verseRef.VerseNum = MAX_CHAPTER_OR_VERSE_NUM;
+        if (verseRef.ChapterNum > MAX_CHAPTER_OR_VERSE_NUM)
+            verseRef.ChapterNum = MAX_CHAPTER_OR_VERSE_NUM;
+        return verseRef;
+    }
+
+    private static VerseRef? ClampNullable(VerseRef? verseRef) =>
+        verseRef.HasValue ? Clamp(verseRef.Value) : null;
 
     private static void VerifyRange(VerseRef start, VerseRef? end)
     {
@@ -71,34 +78,6 @@ internal sealed class InputRange
 
         if (end.HasValue && (start > end.Value))
             throw new ArgumentException("end must come after start");
-    }
-
-    public string ProjectId
-    {
-        get { return _projectId; }
-        set
-        {
-            ArgumentException.ThrowIfNullOrEmpty(value, "ProjectId");
-            _projectId = value;
-        }
-    }
-    public VerseRef Start
-    {
-        get { return _start; }
-        set
-        {
-            VerifyRange(value, _end);
-            _start = value;
-        }
-    }
-    public VerseRef? End
-    {
-        get { return _end; }
-        set
-        {
-            VerifyRange(_start, value);
-            _end = value;
-        }
     }
 
     /// <summary>
@@ -131,19 +110,5 @@ internal sealed class InputRange
         if (bookNum == End.Value.BookNum && chapterNum > End.Value.ChapterNum)
             return false;
         return true;
-    }
-
-    public override bool Equals(object? obj)
-    {
-        if (obj is not InputRange other)
-            return false;
-        return _projectId == other._projectId
-            && _start.Equals(other._start)
-            && Nullable.Equals(_end, other._end);
-    }
-
-    public override int GetHashCode()
-    {
-        return HashCode.Combine(_projectId, _start, _end);
     }
 }

--- a/c-sharp/JsonUtils/CommentThreadSelectorConverter.cs
+++ b/c-sharp/JsonUtils/CommentThreadSelectorConverter.cs
@@ -134,12 +134,12 @@ public class CommentThreadSelectorConverter : JsonConverter<CommentThreadSelecto
         return dateFilter;
     }
 
-    private static List<ScriptureRange> ReadScriptureRanges(
+    private static List<CommentScriptureRange> ReadScriptureRanges(
         JsonElement element,
         JsonSerializerOptions options
     )
     {
-        var ranges = new List<ScriptureRange>();
+        var ranges = new List<CommentScriptureRange>();
 
         foreach (JsonElement rangeEl in element.EnumerateArray())
         {
@@ -155,14 +155,7 @@ public class CommentThreadSelectorConverter : JsonConverter<CommentThreadSelecto
                 ? granEl.GetString()
                 : null;
 
-            ranges.Add(
-                new ScriptureRange
-                {
-                    Start = start,
-                    End = end,
-                    Granularity = granularity,
-                }
-            );
+            ranges.Add(new CommentScriptureRange(start, end, granularity));
         }
 
         return ranges;

--- a/c-sharp/Projects/CommentScriptureRange.cs
+++ b/c-sharp/Projects/CommentScriptureRange.cs
@@ -1,0 +1,14 @@
+using Paranext.DataProvider.Scripture;
+using SIL.Scripture;
+
+namespace Paranext.DataProvider.Projects;
+
+/// <summary>
+/// A scripture range used by <see cref="CommentThreadSelector"/> to filter note threads — the
+/// canonical <see cref="ScriptureRange"/> plus an optional <see cref="Granularity"/>
+/// (<c>"verse"</c> — the default — <c>"chapter"</c>, or <c>"book"</c>) consumed by note-thread
+/// matching. Constructed by <c>CommentThreadSelectorConverter</c>. <c>End</c> is nullable
+/// (inherited from the canonical range); the converter always supplies it.
+/// </summary>
+public sealed record CommentScriptureRange(VerseRef Start, VerseRef? End, string? Granularity)
+    : ScriptureRange(Start, End);

--- a/c-sharp/Projects/CommentThreadSelector.cs
+++ b/c-sharp/Projects/CommentThreadSelector.cs
@@ -1,30 +1,7 @@
 using Paratext.Data.ProjectComments;
 using PtxUtils;
-using SIL.Scripture;
 
 namespace Paranext.DataProvider.Projects;
-
-/// <summary>
-/// Specifies which category of note threads to include in results.
-/// </summary>
-public enum NoteCategory
-{
-    /// <summary>
-    /// Regular user-created notes. Excludes Biblical Term notes and spelling notes, which are
-    /// managed by dedicated tools.
-    /// </summary>
-    General,
-
-    /// <summary>
-    /// Biblical Term notes only (threads tagged with <see cref="CommentTag.biblicalTermTagId"/>).
-    /// </summary>
-    BtNotes,
-
-    /// <summary>
-    /// Spelling suggestion notes only (threads tagged with <see cref="CommentTag.spellingTagId"/>).
-    /// </summary>
-    SpellingNotes,
-}
 
 public class CommentThreadSelector
 {
@@ -44,7 +21,7 @@ public class CommentThreadSelector
     public DateFilter? DateFilter { get; set; }
     public string? Author { get; set; }
     public string? AssignedTo { get; set; }
-    public List<ScriptureRange>? ScriptureRanges { get; set; }
+    public List<CommentScriptureRange>? ScriptureRanges { get; set; }
 
     public bool? IsRead { get; set; }
 
@@ -63,20 +40,4 @@ public class CommentThreadSelector
     /// comments are deleted are dropped. Defaults to true.
     /// </summary>
     public bool DeduplicateThreads { get; set; } = true;
-}
-
-public class DateFilter
-{
-    public string? Exact { get; set; }
-    public string? Before { get; set; }
-    public string? After { get; set; }
-    public string? Start { get; set; }
-    public string? End { get; set; }
-}
-
-public class ScriptureRange
-{
-    public required VerseRef Start { get; set; }
-    public required VerseRef End { get; set; }
-    public string? Granularity { get; set; }
 }

--- a/c-sharp/Projects/DateFilter.cs
+++ b/c-sharp/Projects/DateFilter.cs
@@ -1,0 +1,14 @@
+namespace Paranext.DataProvider.Projects;
+
+/// <summary>
+/// Date-based filter for comment-thread selection. Each field is an optional ISO-8601 date string;
+/// unset fields impose no constraint.
+/// </summary>
+public class DateFilter
+{
+    public string? Exact { get; set; }
+    public string? Before { get; set; }
+    public string? After { get; set; }
+    public string? Start { get; set; }
+    public string? End { get; set; }
+}

--- a/c-sharp/Projects/NoteCategory.cs
+++ b/c-sharp/Projects/NoteCategory.cs
@@ -1,0 +1,25 @@
+using Paratext.Data.ProjectComments;
+
+namespace Paranext.DataProvider.Projects;
+
+/// <summary>
+/// Specifies which category of note threads to include in results.
+/// </summary>
+public enum NoteCategory
+{
+    /// <summary>
+    /// Regular user-created notes. Excludes Biblical Term notes and spelling notes, which are
+    /// managed by dedicated tools.
+    /// </summary>
+    General,
+
+    /// <summary>
+    /// Biblical Term notes only (threads tagged with <see cref="CommentTag.biblicalTermTagId"/>).
+    /// </summary>
+    BtNotes,
+
+    /// <summary>
+    /// Spelling suggestion notes only (threads tagged with <see cref="CommentTag.spellingTagId"/>).
+    /// </summary>
+    SpellingNotes,
+}

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -964,7 +964,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
 
     private IEnumerable<CommentThread> FilterByScriptureRanges(
         IEnumerable<CommentThread> threads,
-        List<ScriptureRange> scriptureRanges
+        List<CommentScriptureRange> scriptureRanges
     )
     {
         var scrText = LocalParatextProjects.GetParatextProject(ProjectDetails.Metadata.Id);
@@ -976,29 +976,32 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         });
     }
 
-    private static bool MatchesScriptureRange(VerseRef verseRef, ScriptureRange range)
+    private static bool MatchesScriptureRange(VerseRef verseRef, CommentScriptureRange range)
     {
         // Match based on granularity
         string granularity = range.Granularity ?? "verse";
+
+        // End is optional on the canonical ScriptureRange; a null End is a single-verse range,
+        // so the start verse doubles as the end. (The converter always supplies a non-null End.)
+        VerseRef end = range.End ?? range.Start;
 
         switch (granularity.ToLowerInvariant())
         {
             case "book":
                 // Match if the comment is in any book within the range
-                return verseRef.BookNum >= range.Start.BookNum
-                    && verseRef.BookNum <= range.End.BookNum;
+                return verseRef.BookNum >= range.Start.BookNum && verseRef.BookNum <= end.BookNum;
 
             case "chapter":
                 // Match if the comment is in the same book and within the chapter range
                 if (verseRef.BookNum != range.Start.BookNum)
                     return false;
                 return verseRef.ChapterNum >= range.Start.ChapterNum
-                    && verseRef.ChapterNum <= range.End.ChapterNum;
+                    && verseRef.ChapterNum <= end.ChapterNum;
 
             case "verse":
             default:
                 // Match if the comment's verse is within the range
-                return verseRef.CompareTo(range.Start) >= 0 && verseRef.CompareTo(range.End) <= 0;
+                return verseRef.CompareTo(range.Start) >= 0 && verseRef.CompareTo(end) <= 0;
         }
     }
 

--- a/c-sharp/Scripture/ScriptureRange.cs
+++ b/c-sharp/Scripture/ScriptureRange.cs
@@ -2,35 +2,32 @@ using System.Linq;
 using System.Text.Json.Serialization;
 using SIL.Scripture;
 
-namespace Paranext.DataProvider.Checklists;
+namespace Paranext.DataProvider.Scripture;
 
 // === NEW IN PT10 ===
-// Reason: PT9's `VerseRangeChooserForm` holds start/end VerseRefs in form state; the PT10
-// PAPI payload needs a serializable record. Originally colocated in `ChecklistRequest.cs`
-// (its sole consumer was `ChecklistRequest.VerseRange`, so the PNX004 one-type-per-file
-// exclusive-use exception applied). Promoted to its own file when the checklist *result*
-// records were retyped from bespoke reference strings to this canonical type — it is now a
-// shared Checklists-module type (`ChecklistCell.Reference`, `ChecklistRow.FirstRef`,
-// `LinkItem.Reference`, and `ChecklistRequest.VerseRange`), so plain one-type-per-file
-// (PNX004) applies and the exclusive-use exception no longer does.
-// Maps to: data-contracts.md §2.1 (VerseRange field) + §§3.2/3.3/3.5 (result references)
+// The canonical paranext-core scripture *range* type — a start verse plus an optional end
+// verse. `VerseRef` (SIL.Scripture) remains the canonical single *reference*; this record is
+// the canonical two-point range. It mirrors the TypeScript `ScriptureRange`
+// (`extensions/src/platform-scripture/src/types/platform-scripture.d.ts` —
+// `{ start: SerializedVerseRef; end?: SerializedVerseRef }`).
+//
+// Originally introduced for the markers checklist and promoted to this shared namespace so
+// the whole C# data provider shares one range type instead of three divergent ones
+// (Checklists, Checks `InputRange`, Comments). `Checks.InputRange` and
+// `Projects.CommentScriptureRange` derive from this record.
+// See working-docs/csharp-scripture-range-canonicalization-design.md.
 //
 // EXPLANATION:
 // `VerseRef` serializes to the canonical scripture-reference wire shape via the repo-wide
-// `VerseRefConverter` (registered in `JsonUtils/SerializationOptions.cs`). A `ScriptureRange`
-// is the single canonical structured scripture reference used throughout the Checklists
-// module — there is no bespoke per-feature reference string. The two static factories funnel
-// every producer (the cell builder in `ChecklistService` and the row builder in
-// `ChecklistRowBuilder`) through one conversion from `SIL.Scripture.VerseRef`.
+// `VerseRefConverter` (registered in `JsonUtils/SerializationOptions.cs`). The two static
+// factories are the one canonical conversion from a (possibly-bridged)
+// `SIL.Scripture.VerseRef` — used by the Checklists cell/row builders. Producers that
+// already hold explicit start/end points construct the record directly.
 /// <summary>
 /// A scripture verse range: a start verse plus an optional end verse. Bridge-capable —
-/// <c>{Start}</c> alone is a single verse; <c>{Start, End}</c> is a verse bridge. Used both
-/// as <see cref="ChecklistRequest.VerseRange"/> (the requested range) and as the structured
-/// reference on checklist result records (<see cref="ChecklistCell.Reference"/>,
-/// <see cref="ChecklistRow.FirstRef"/>, <see cref="LinkItem.Reference"/>). Serializes via the
-/// repo-wide <c>VerseRefConverter</c>. Not to be confused with the unrelated mutable
-/// <c>ScriptureRange</c> class in <c>c-sharp/Projects/CommentThreadSelector.cs</c> (different
-/// semantics — mutable, required <c>End</c>, carries a <c>Granularity</c> field).
+/// <c>{Start}</c> alone is a single verse; <c>{Start, End}</c> is a verse bridge or a
+/// multi-verse range. The canonical paranext-core scripture-range type; serializes via the
+/// repo-wide <c>VerseRefConverter</c>.
 /// </summary>
 [method: JsonConstructor]
 public record ScriptureRange(VerseRef Start, VerseRef? End)


### PR DESCRIPTION
## Summary

Unifies the C# data provider's **three divergent scripture-range types** onto one canonical type. Before this PR the backend had:

| Type | Where | Problem |
|---|---|---|
| `ScriptureRange` (record) | `Checklists/` | fine — the cleanest of the three |
| `InputRange` (class) | `Checks/` | really "a `ScriptureRange` + `ProjectId`" |
| `ScriptureRange` (class) | `Projects/CommentThreadSelector.cs` | **duplicate type name**, different shape |

The TypeScript side already has one canonical `ScriptureRange`; the C# side never factored one out. This change does.

## What changed

- **Canonical type** — `ScriptureRange` (record: `VerseRef Start` + optional `End`, with the `FromVerseRef` / `FromBounds` factories) moved to `c-sharp/Scripture/`, namespace `Paranext.DataProvider.Scripture`. Checklists references repointed (mechanical `using` change).
- **`Checks/InputRange`** — converted from a mutable class to an immutable `sealed record InputRange : ScriptureRange`. An audit confirmed no consumer mutates it, so the validating setters and hand-written `Equals`/`GetHashCode` drop out; clamping moves to static helpers in the base-constructor arguments. Added JSON round-trip tests pinning the flat `CheckInputRange` wire shape (the design note assumed such a test existed — it did not).
- **Comments** — the `Projects.ScriptureRange` class is renamed to `CommentScriptureRange`, now a `sealed record : ScriptureRange` carrying `Granularity`. `End` widens required → nullable (inherited); `MatchesScriptureRange` treats a null `End` as a single-verse range. The duplicate `ScriptureRange` type name is gone.
- **PNX004 cleanup** — `CommentThreadSelector.cs` held 4 top-level types; staging it tripped the one-type-per-file analyzer, so it is split into `CommentThreadSelector.cs`, `NoteCategory.cs`, `DateFilter.cs`, and `CommentScriptureRange.cs`.

## Behavior

Behavior-preserving — **wire shapes are unchanged**. `InputRange` still serializes flat (`{ start, end?, projectId }`); the Comments range still serializes `{ start, end, granularity }` via `CommentThreadSelectorConverter`; the Checklists `ScriptureRange` is byte-identical (only its namespace moved).

## Verification

- `dotnet build` (solution) — clean
- `dotnet test` — **804 passed**, 0 failed, 6 skipped (includes golden masters + 2 new `InputRange` round-trip tests)
- `npm run build` — clean

A full E2E pass (Checks / Comments / Checklists) is recommended before merge, consistent with #2309's own recommendation.

## Stacking

This PR is **stacked on #2309** — Step 1 deletes `Checklists/ScriptureRange.cs`, which only exists on that branch. Its base is the #2309 branch and will auto-retarget to `ai/main` when #2309 merges. Review #2309 first.

## Related

- paranext-core #2309 — the markers scripture-ref retype that surfaced this
- Design note: ai-prompts PR https://github.com/paranext/ai-prompts/pull/304 (`working-docs/csharp-scripture-range-canonicalization-design.md`)

## AI transparency

Implemented with Claude Code, following the committed design note. Audits (consumer mutation, `End`-nullability reliance, the custom converter) drove the derived-record vs. class decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2313)
<!-- Reviewable:end -->
