### PR TITLE
fix: align radio group with stock shadcn outline design

### DIFF
--- a/lib/platform-bible-react/src/components/shadcn-ui/radio-group.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/radio-group.tsx
@@ -46,8 +46,15 @@ function RadioGroupItem({
     <RadioGroupPrimitive.Item
       data-slot="radio-group-item"
       className={cn(
-        // CUSTOM: Added pr-twp to apply Platform.Bible's Tailwind CSS scope isolation
-        'pr-twp tw:group/radio-group-item tw:peer tw:relative tw:flex tw:aspect-square tw:size-4 tw:shrink-0 tw:rounded-full tw:border tw:border-input tw:outline-none tw:after:absolute tw:after:-inset-x-3 tw:after:-inset-y-2 tw:focus-visible:border-ring tw:focus-visible:ring-3 tw:focus-visible:ring-ring/50 tw:disabled:cursor-not-allowed tw:disabled:opacity-50 tw:aria-invalid:border-destructive tw:aria-invalid:ring-3 tw:aria-invalid:ring-destructive/20 tw:aria-invalid:aria-checked:border-primary tw:dark:bg-input/30 tw:dark:aria-invalid:border-destructive/50 tw:dark:aria-invalid:ring-destructive/40 tw:data-checked:border-primary tw:data-checked:bg-primary tw:data-checked:text-primary-foreground tw:dark:data-checked:bg-primary',
+        // CUSTOM: Added pr-twp to apply Platform.Bible's Tailwind CSS scope isolation.
+        // CUSTOM: Use the upstream shadcn "outline" radio design instead of the b6rt8cvlC preset's
+        // "filled" variant: added tw:text-primary (drives the indicator dot color), tw:shadow-xs and
+        // tw:transition-[color,box-shadow] (the subtle outer shadow ring shadcn renders), and removed
+        // tw:data-checked:bg-primary / tw:data-checked:text-primary-foreground / tw:dark:data-checked:bg-primary.
+        // The filled variant turned the whole circle dark, which made the inner dot read as dimmed and
+        // merged the gray focus ring into the dark fill so it was no longer visible. Keeping the circle
+        // unfilled lets the focus ring contrast against the light interior, matching ui.shadcn.com.
+        'pr-twp tw:group/radio-group-item tw:peer tw:relative tw:flex tw:aspect-square tw:size-4 tw:shrink-0 tw:rounded-full tw:border tw:border-input tw:text-primary tw:shadow-xs tw:transition-[color,box-shadow] tw:outline-none tw:after:absolute tw:after:-inset-x-3 tw:after:-inset-y-2 tw:focus-visible:border-ring tw:focus-visible:ring-3 tw:focus-visible:ring-ring/50 tw:disabled:cursor-not-allowed tw:disabled:opacity-50 tw:aria-invalid:border-destructive tw:aria-invalid:ring-3 tw:aria-invalid:ring-destructive/20 tw:aria-invalid:aria-checked:border-primary tw:dark:bg-input/30 tw:dark:aria-invalid:border-destructive/50 tw:dark:aria-invalid:ring-destructive/40 tw:data-checked:border-primary',
         className,
       )}
       {...props}
@@ -56,7 +63,9 @@ function RadioGroupItem({
         data-slot="radio-group-indicator"
         className="tw:flex tw:size-4 tw:items-center tw:justify-center"
       >
-        <span className="tw:absolute tw:top-1/2 tw:start-1/2 tw:size-2 tw:-translate-x-1/2 tw:rtl:translate-x-1/2 tw:-translate-y-1/2 tw:rounded-full tw:bg-primary-foreground" />
+        {/* CUSTOM: Dot uses tw:bg-primary (was tw:bg-primary-foreground) so the dark primary dot
+            shows on the unfilled light circle, matching the upstream shadcn outline radio. */}
+        <span className="tw:absolute tw:top-1/2 tw:start-1/2 tw:size-2 tw:-translate-x-1/2 tw:rtl:translate-x-1/2 tw:-translate-y-1/2 tw:rounded-full tw:bg-primary" />
       </RadioGroupPrimitive.Indicator>
     </RadioGroupPrimitive.Item>
   );


### PR DESCRIPTION
## Summary

The radio group had two visual issues when an item was selected and focused: the inner dot looked dimmed, and the outer focus ring was not visible around the circle. Both trace to a single root cause — the shadcn preset (`b6rt8cvlC`) styled the radio as a **filled** control instead of the upstream shadcn **outline** radio.

- The selected circle was filled dark (`data-checked:bg-primary`) with a light (`bg-primary-foreground`) dot, so the small light dot read as dimmed inside the dark fill + dark border.
- The focus ring (`ring-ring/50` = slate-950 @ 50%) abutted the dark fill and slate-950 border and merged into the dark mass, so it was no longer visible. On outline controls (input/select/button) the identical ring contrasts fine against the light interior.

This restores the upstream shadcn outline radio (shadcn deliberately uses *filled checkbox / outline radio*), so the focus ring contrasts against the light interior and the dot is crisp — matching ui.shadcn.com.

## Changes

- Removed `data-checked:bg-primary`, `data-checked:text-primary-foreground`, `dark:data-checked:bg-primary` (no more dark fill).
- Added `text-primary`, `shadow-xs`, `transition-[color,box-shadow]` (the subtle outer shadow ring shadcn renders).
- Indicator dot changed `bg-primary-foreground` → `bg-primary` (dark dot on light circle).
- Kept `data-checked:border-primary` and all existing PT10 customizations (`pr-twp`, RTL `dir`, `tw:` prefix); every changed line carries a `CUSTOM` marker.

## AI Involvement

**Level**: generated

Diagnosis and fix produced by Claude Code with human direction (user chose the "match shadcn.com (outline)" approach). Verified by live-rendering the Storybook story and inspecting computed styles: selected item has a transparent interior, a primary border, a primary 8px dot, and `shadow-xs` — matching ui.shadcn.com.

## Testing

- [x] Verified in Storybook across selected/unselected/focused states (live render + computed-style check)
- [x] ESLint clean on the changed file
- [x] Pre-push validations (typecheck, secret scan, architecture boundaries) passed

## Risk Level

Low — scoped to one shared shadcn component's styling; no logic or API changes. Intentionally diverges from the filled checkbox, matching shadcn's own filled-checkbox / outline-radio convention.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2325)
<!-- Reviewable:end -->
