### PR TITLE
Add per-OS keyboard shortcut conventions guideline

### DIFF
--- a/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
@@ -203,7 +203,7 @@ Render keyboard shortcut hints using the HTML `<kbd>` element, not plain text in
   </ExampleBlock>
 
   <ExampleBlock
-    variant="dont"
+    variant="avoid"
     preview={<span>Undo <kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
 Cmd+Z
 </kbd></span>}

--- a/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
@@ -201,6 +201,16 @@ Render keyboard shortcut hints using the HTML `<kbd>` element, not plain text in
   <ExampleBlock variant="avoid" preview={<span>Undo (⌘Z)</span>} code="Undo (⌘Z)">
     Parentheses blend into prose and don't signal "keyboard shortcut" to the reader.
   </ExampleBlock>
+
+  <ExampleBlock
+    variant="dont"
+    preview={<span>Undo <kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
+Cmd+Z
+</kbd></span>}
+    code="Undo <kbd>Cmd+Z</kbd>  // on macOS"
+  >
+    Each OS has its own convention for writing shortcuts. On macOS, modifier keys are symbols with no separator (<code>⌘Z</code>), not spelled-out words joined with <code>+</code>. See <a href="./keyboard-shortcuts.mdx">Keyboard shortcuts</a> for the full per-OS reference.
+  </ExampleBlock>
 </ExampleBlockGroup>
 
 Caveat: The shared `Kbd` component doesn't exist yet and won't until after we upgrade shadcn/ui, so style `<kbd>` inline:
@@ -210,6 +220,8 @@ Caveat: The shared `Kbd` component doesn't exist yet and won't until after we up
   ⌘Z
 </kbd>
 ```
+
+For which symbol or word to use per key on each OS — Command, Option, Control, Shift, Tab, Caps Lock, Space, Return, Delete, Escape, and more — see [Keyboard shortcuts](./keyboard-shortcuts.mdx).
 
 ---
 

--- a/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
@@ -8,8 +8,8 @@ When displaying a keyboard shortcut in the UI, write it the way the user's opera
 
 The two conventions to know:
 
-- **macOS** uses **symbols** for modifier and special keys, written together with no separator (e.g. `⇧⌘Z`). Modifier order is Control, Option, Shift, Command.
-- **Windows and Linux** use **words** joined with `+` (e.g. `Ctrl+Shift+Z`). Modifier order is Ctrl, Alt, Shift.
+- **macOS** uses **symbols** for modifier and special keys, written together with no separator (e.g. `⇧⌘Z`). Modifier order is Control, Option, Shift, Command ([Apple HIG](https://developer.apple.com/design/human-interface-guidelines/keyboards)).
+- **Windows and Linux** use **words** joined with `+` (e.g. `Ctrl+Shift+Z`). Modifier order is Ctrl, Shift, Alt ([Windows](<https://learn.microsoft.com/en-us/previous-versions/windows/desktop/bb246452(v=vs.85)>) / [GNOME HIG](https://developer.gnome.org/hig/guidelines/keyboard.html)).
 
 For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, parentheses vs. no parentheses), see [Design Principles → Keyboard shortcuts in tooltips](./design-principles.mdx).
 
@@ -38,7 +38,7 @@ For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, par
 ## Combining keys
 
 - **macOS:** concatenate the symbols with no separator and no spaces. Order: Control, Option, Shift, Command, then the key. Example: `⌃⌥⇧⌘T`.
-- **Windows / Linux:** join with `+` and no spaces. Order: Ctrl, Alt, Shift, then the key. Example: `Ctrl+Shift+T`.
+- **Windows / Linux:** join with `+` and no spaces. Order: Ctrl, Shift, Alt, then the key. Example: `Ctrl+Shift+T`.
 
 ## Detecting the platform
 

--- a/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
@@ -6,10 +6,11 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 When displaying a keyboard shortcut in the UI, write it the way the user's operating system writes it. Each OS has its own established convention for naming and combining modifier and special keys, and users recognize their own platform's convention at a glance. Mixing conventions — or inventing a new one — makes shortcuts harder to scan and signals that the app isn't paying attention.
 
-The two conventions to know:
+The conventions to know:
 
 - **macOS** uses **symbols** for modifier and special keys, written together with no separator (e.g. `⇧⌘Z`). Modifier order is Control, Option, Shift, Command ([Apple HIG](https://developer.apple.com/design/human-interface-guidelines/keyboards)).
-- **Windows and Linux** use **words** joined with `+` (e.g. `Ctrl+Shift+Z`). Modifier order is Ctrl, Shift, Alt ([Windows](<https://learn.microsoft.com/en-us/previous-versions/windows/desktop/bb246452(v=vs.85)>) / [GNOME HIG](https://developer.gnome.org/hig/guidelines/keyboard.html)).
+- **Windows** uses **words** joined with `+` (e.g. `Ctrl+Shift+Z`). Modifier order is Ctrl, Shift, Alt ([Microsoft](https://support.microsoft.com/en-us/windows/keyboard-shortcuts-in-windows-dcc61a57-8ff0-cffe-9796-cb9706c75eec)).
+- **Linux** uses **words** joined with `+`. Modifier order varies by desktop environment; on GNOME and Ubuntu, the typical order is Ctrl, Alt, Shift ([Ubuntu](https://help.ubuntu.com/stable/ubuntu-help/shell-keyboard-shortcuts.html.en) / [GNOME HIG](https://developer.gnome.org/hig/guidelines/keyboard.html)).
 
 For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, parentheses vs. no parentheses), see [Design Principles → Keyboard shortcuts in tooltips](./design-principles.mdx).
 
@@ -38,7 +39,8 @@ For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, par
 ## Combining keys
 
 - **macOS:** concatenate the symbols with no separator and no spaces. Order: Control, Option, Shift, Command, then the key. Example: `⌃⌥⇧⌘T`.
-- **Windows / Linux:** join with `+` and no spaces. Order: Ctrl, Shift, Alt, then the key. Example: `Ctrl+Shift+T`.
+- **Windows:** join with `+` and no spaces. Order: Ctrl, Shift, Alt, then the key. Example: `Ctrl+Shift+T`.
+- **Linux:** join with `+` and no spaces. Order varies; GNOME typically uses Ctrl, Alt, Shift, then the key. Example: `Ctrl+Alt+Shift+R`.
 
 ## Detecting the platform
 

--- a/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
@@ -1,0 +1,55 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Guidelines/Keyboard shortcuts" />
+
+# Keyboard shortcuts
+
+When displaying a keyboard shortcut in the UI, write it the way the user's operating system writes it. Each OS has its own established convention for naming and combining modifier and special keys, and users recognize their own platform's convention at a glance. Mixing conventions — or inventing a new one — makes shortcuts harder to scan and signals that the app isn't paying attention.
+
+The two conventions to know:
+
+- **macOS** uses **symbols** for modifier and special keys, written together with no separator (e.g. `⇧⌘Z`). Modifier order is Control, Option, Shift, Command.
+- **Windows and Linux** use **words** joined with `+` (e.g. `Ctrl+Shift+Z`). Modifier order is Ctrl, Alt, Shift.
+
+For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, parentheses vs. no parentheses), see [Design Principles → Keyboard shortcuts in tooltips](./design-principles.mdx).
+
+---
+
+## Preferred representations by OS
+
+| Key             | macOS              | Windows           | Linux             |
+| --------------- | ------------------ | ----------------- | ----------------- |
+| Command         | `⌘`                | — (no equivalent) | — (no equivalent) |
+| Windows / Super | — (no equivalent)  | `Win` or `⊞`      | `Super`           |
+| Option / Alt    | `⌥`                | `Alt`             | `Alt`             |
+| Control         | `⌃`                | `Ctrl`            | `Ctrl`            |
+| Shift           | `⇧`                | `Shift`           | `Shift`           |
+| Caps Lock       | `⇪`                | `Caps Lock`       | `Caps Lock`       |
+| Tab             | `⇥`                | `Tab`             | `Tab`             |
+| Return / Enter  | `⏎` (or `Return`)  | `Enter`           | `Enter`           |
+| Backspace       | `⌫` (or `Delete`)  | `Backspace`       | `Backspace`       |
+| Forward Delete  | `⌦`                | `Delete`          | `Delete`          |
+| Escape          | `⎋` (or `Esc`)     | `Esc`             | `Esc`             |
+| Space           | `Space` (or `␣`)   | `Space`           | `Space`           |
+| Arrow keys      | `↑` `↓` `←` `→`    | `↑` `↓` `←` `→`   | `↑` `↓` `←` `→`   |
+| Page Up / Down  | `⇞` / `⇟`          | `Page Up` / `Page Down` | `Page Up` / `Page Down` |
+| Home / End      | `↖` / `↘`          | `Home` / `End`    | `Home` / `End`    |
+
+## Combining keys
+
+- **macOS:** concatenate the symbols with no separator and no spaces. Order: Control, Option, Shift, Command, then the key. Example: `⌃⌥⇧⌘T`.
+- **Windows / Linux:** join with `+` and no spaces. Order: Ctrl, Alt, Shift, then the key. Example: `Ctrl+Shift+T`.
+
+## Detecting the platform
+
+For shortcuts rendered at runtime, branch on the user's OS rather than hardcoding one convention:
+
+```tsx
+import { Kbd } from 'platform-bible-react';
+
+<Kbd>{isMac ? '⌘Z' : 'Ctrl+Z'}</Kbd>
+```
+
+## Why this matters
+
+Writing `Cmd+Z` on macOS, or `⌘Z` on Windows, looks wrong to users who know their platform — and it looks doubly wrong to users who use both. Following each OS's own convention is a small detail that makes the app feel native everywhere it runs.


### PR DESCRIPTION
## Summary

- Add a new **Keyboard shortcuts** guidelines doc (`keyboard-shortcuts.mdx`) with a per-OS reference table covering Command, Option/Alt, Control, Shift, Caps Lock, Tab, Return, Backspace/Delete, Escape, Space, arrows, Page Up/Down, and Home/End — plus modifier-combining order and a runtime platform-branching snippet.
- Add a second anti-pattern to the keyboard-shortcuts section in Design Principles: writing macOS shortcuts with spelled-out modifier words (e.g. `Cmd+Z`) instead of the platform symbols (`⌘Z`). Each OS has its own convention; the app should match it.
- Cross-link the two docs: Design Principles points to Keyboard shortcuts for the full reference, and Keyboard shortcuts points back to Design Principles for `<kbd>` / `Kbd` rendering guidance.

## Test plan

- [ ] Open Storybook and verify the new **Guidelines → Keyboard shortcuts** page renders, the per-OS table is readable, and the link back to Design Principles works
- [ ] On the **Design Principles** page, verify the keyboard-shortcuts section now shows two "don't" anti-patterns (`Undo (⌘Z)` and `Undo Cmd+Z`) and the link to the new doc works

https://claude.ai/code/session_01KFNTR5Q9QLw6n7CkwBNxMj

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFNTR5Q9QLw6n7CkwBNxMj)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2326)
<!-- Reviewable:end -->
