### PR TITLE
PT-3986: Sync incoming and outgoing projects on simple-mode switch

### DIFF
--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -241,11 +241,13 @@ async function open(
     );
 
     if (interfaceMode === 'simple' && dispatch.kind === 'replace-tab') {
-      const outgoingProjectId = allScriptureEditors.find(
-        (e) => e.id === dispatch.targetTabId,
-      )?.projectId;
+      const outgoing = allScriptureEditors.find((e) => e.id === dispatch.targetTabId);
+      // Skip outgoing S/R for read-only viewers — no local changes are possible.
+      // ENHANCE: also skip if the outgoing editor had no user edits during the session (would
+      // require tracking a dirty flag in the editor controller, which doesn't exist yet).
+      const outgoingProjectId = outgoing?.isReadOnly ? undefined : outgoing?.projectId;
       // Fire-and-forget: new editor is already open. Sync incoming first, then outgoing.
-      syncOnProjectSwitch(papi, projectForWebView.projectId, outgoingProjectId);
+      void syncOnProjectSwitch(papi, projectForWebView.projectId, outgoingProjectId);
     }
 
     return openedWebViewId;

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -34,6 +34,7 @@ import {
   resolveOpenEditorDispatch,
   SCRIPTURE_EDITOR_WEBVIEW_TYPE,
   startDefaultProjectPicker,
+  syncOnProjectSwitch,
 } from './platform-scripture-editor.utils';
 import { MarkersViewNotifier } from './markers-view-notifier.model';
 
@@ -139,36 +140,6 @@ async function insertCommentAtSelection(webViewId: string | undefined): Promise<
   await webViewController.insertCommentAtSelection();
 }
 
-/**
- * Fire-and-forget helper that syncs the incoming project first, then the outgoing one. Each sync is
- * independently error-isolated so a failure in one doesn't block the other. Only called in simple
- * mode after a replace-tab project switch.
- */
-async function syncOnProjectSwitch(
-  incomingProjectId: string,
-  outgoingProjectId: string | undefined,
-): Promise<void> {
-  try {
-    await papi.commands.sendCommand('paratextBibleSendReceive.syncProjects', [incomingProjectId]);
-  } catch (e) {
-    logger.warn(
-      `Project-switch sync: incoming sync for ${incomingProjectId} failed: ${getErrorMessage(e)}`,
-    );
-  }
-
-  if (outgoingProjectId) {
-    try {
-      await papi.commands.sendCommand('paratextBibleSendReceive.sendReceiveProjects', [
-        outgoingProjectId,
-      ]);
-    } catch (e) {
-      logger.warn(
-        `Project-switch sync: outgoing sync for ${outgoingProjectId} failed: ${getErrorMessage(e)}`,
-      );
-    }
-  }
-}
-
 /** Function to prompt for a project or use the one passed in and open it in the editor */
 async function open(
   isReadOnly: boolean,
@@ -261,11 +232,6 @@ async function open(
       isReadOnly: !projectForWebView.isEditable,
       options,
     };
-    const outgoingProjectId =
-      dispatch.kind === 'replace-tab'
-        ? allScriptureEditors.find((e) => e.id === dispatch.targetTabId)?.projectId
-        : undefined;
-
     const openedWebViewId = await papi.webViews.openWebView(
       SCRIPTURE_EDITOR_WEBVIEW_TYPE,
       dispatch.kind === 'replace-tab'
@@ -275,8 +241,11 @@ async function open(
     );
 
     if (interfaceMode === 'simple' && dispatch.kind === 'replace-tab') {
+      const outgoingProjectId = allScriptureEditors.find(
+        (e) => e.id === dispatch.targetTabId,
+      )?.projectId;
       // Fire-and-forget: new editor is already open. Sync incoming first, then outgoing.
-      syncOnProjectSwitch(projectForWebView.projectId, outgoingProjectId);
+      syncOnProjectSwitch(papi, projectForWebView.projectId, outgoingProjectId);
     }
 
     return openedWebViewId;

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -139,6 +139,36 @@ async function insertCommentAtSelection(webViewId: string | undefined): Promise<
   await webViewController.insertCommentAtSelection();
 }
 
+/**
+ * Fire-and-forget helper that syncs the incoming project first, then the outgoing one. Each sync is
+ * independently error-isolated so a failure in one doesn't block the other. Only called in simple
+ * mode after a replace-tab project switch.
+ */
+async function syncOnProjectSwitch(
+  incomingProjectId: string,
+  outgoingProjectId: string | undefined,
+): Promise<void> {
+  try {
+    await papi.commands.sendCommand('paratextBibleSendReceive.syncProjects', [incomingProjectId]);
+  } catch (e) {
+    logger.warn(
+      `Project-switch sync: incoming sync for ${incomingProjectId} failed: ${getErrorMessage(e)}`,
+    );
+  }
+
+  if (outgoingProjectId) {
+    try {
+      await papi.commands.sendCommand('paratextBibleSendReceive.sendReceiveProjects', [
+        outgoingProjectId,
+      ]);
+    } catch (e) {
+      logger.warn(
+        `Project-switch sync: outgoing sync for ${outgoingProjectId} failed: ${getErrorMessage(e)}`,
+      );
+    }
+  }
+}
+
 /** Function to prompt for a project or use the one passed in and open it in the editor */
 async function open(
   isReadOnly: boolean,
@@ -231,13 +261,25 @@ async function open(
       isReadOnly: !projectForWebView.isEditable,
       options,
     };
-    return papi.webViews.openWebView(
+    const outgoingProjectId =
+      dispatch.kind === 'replace-tab'
+        ? allScriptureEditors.find((e) => e.id === dispatch.targetTabId)?.projectId
+        : undefined;
+
+    const openedWebViewId = await papi.webViews.openWebView(
       SCRIPTURE_EDITOR_WEBVIEW_TYPE,
       dispatch.kind === 'replace-tab'
         ? { type: 'replace-tab', targetTabId: dispatch.targetTabId }
         : undefined,
       openWebViewOptions,
     );
+
+    if (interfaceMode === 'simple' && dispatch.kind === 'replace-tab') {
+      // Fire-and-forget: new editor is already open. Sync incoming first, then outgoing.
+      syncOnProjectSwitch(projectForWebView.projectId, outgoingProjectId);
+    }
+
+    return openedWebViewId;
   }
   return undefined;
 }

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -227,6 +227,16 @@ async function open(
       });
     }
 
+    if (interfaceMode === 'simple' && dispatch.kind === 'replace-tab') {
+      const outgoing = allScriptureEditors.find((e) => e.id === dispatch.targetTabId);
+      // Skip outgoing S/R for read-only viewers — no local changes are possible.
+      // ENHANCE: also skip if the outgoing editor had no user edits during the session (would
+      // require tracking a dirty flag in the editor controller, which doesn't exist yet).
+      const outgoingProjectId = outgoing?.isReadOnly ? undefined : outgoing?.projectId;
+      // Fire-and-forget: runs concurrently with `openWebView`.
+      syncOnProjectSwitch(papi, projectForWebView.projectId, outgoingProjectId);
+    }
+
     const openWebViewOptions: PlatformScriptureEditorOptions = {
       projectId: projectForWebView.projectId,
       isReadOnly: !projectForWebView.isEditable,
@@ -239,16 +249,6 @@ async function open(
         : undefined,
       openWebViewOptions,
     );
-
-    if (interfaceMode === 'simple' && dispatch.kind === 'replace-tab') {
-      const outgoing = allScriptureEditors.find((e) => e.id === dispatch.targetTabId);
-      // Skip outgoing S/R for read-only viewers — no local changes are possible.
-      // ENHANCE: also skip if the outgoing editor had no user edits during the session (would
-      // require tracking a dirty flag in the editor controller, which doesn't exist yet).
-      const outgoingProjectId = outgoing?.isReadOnly ? undefined : outgoing?.projectId;
-      // Fire-and-forget: new editor is already open. Sync incoming first, then outgoing.
-      void syncOnProjectSwitch(papi, projectForWebView.projectId, outgoingProjectId);
-    }
 
     return openedWebViewId;
   }

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -139,7 +139,7 @@ async function insertCommentAtSelection(webViewId: string | undefined): Promise<
   await webViewController.insertCommentAtSelection();
 }
 
-/** Function to prompt for a project and open it in the editor */
+/** Function to prompt for a project or use the one passed in and open it in the editor */
 async function open(
   isReadOnly: boolean,
   projectId?: string,

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -9,6 +9,7 @@ import {
   type OpenEditorDispatch,
   SCRIPTURE_EDITOR_WEBVIEW_TYPE,
   startDefaultProjectPicker,
+  syncOnProjectSwitch,
 } from './platform-scripture-editor.utils';
 
 // Sample USJ chapter data for Genesis chapter 1 with multiple verses
@@ -1350,3 +1351,85 @@ describe('startDefaultProjectPicker', () => {
 });
 
 // #endregion startDefaultProjectPicker
+
+// #region syncOnProjectSwitch
+
+function createSyncMockPapi() {
+  const mockSendCommand = vi.fn().mockResolvedValue(undefined);
+  const mockWarn = vi.fn();
+  // Constructing a minimal mock for PapiBackend to test syncOnProjectSwitch in isolation
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  const papi = {
+    commands: { sendCommand: mockSendCommand },
+    logger: { warn: mockWarn },
+  } as unknown as typeof PapiBackend;
+  return { papi, mockSendCommand, mockWarn };
+}
+
+describe('syncOnProjectSwitch', () => {
+  it('calls syncProjects with the incoming project ID', async () => {
+    const { papi, mockSendCommand } = createSyncMockPapi();
+
+    await syncOnProjectSwitch(papi, 'incoming-id', undefined);
+
+    expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.syncProjects', [
+      'incoming-id',
+    ]);
+  });
+
+  it('calls sendReceiveProjects with the outgoing project ID after syncProjects', async () => {
+    const { papi, mockSendCommand } = createSyncMockPapi();
+    const callOrder: string[] = [];
+    mockSendCommand.mockImplementation(async (command: string) => {
+      callOrder.push(command);
+    });
+
+    await syncOnProjectSwitch(papi, 'incoming-id', 'outgoing-id');
+
+    expect(callOrder).toEqual([
+      'paratextBibleSendReceive.syncProjects',
+      'paratextBibleSendReceive.sendReceiveProjects',
+    ]);
+    expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.sendReceiveProjects', [
+      'outgoing-id',
+    ]);
+  });
+
+  it('skips sendReceiveProjects when outgoingProjectId is undefined', async () => {
+    const { papi, mockSendCommand } = createSyncMockPapi();
+
+    await syncOnProjectSwitch(papi, 'incoming-id', undefined);
+
+    expect(mockSendCommand).toHaveBeenCalledTimes(1);
+    expect(mockSendCommand).not.toHaveBeenCalledWith(
+      'paratextBibleSendReceive.sendReceiveProjects',
+      expect.anything(),
+    );
+  });
+
+  it('still calls sendReceiveProjects when syncProjects throws', async () => {
+    const { papi, mockSendCommand, mockWarn } = createSyncMockPapi();
+    mockSendCommand.mockImplementation(async (command: string) => {
+      if (command === 'paratextBibleSendReceive.syncProjects') throw new Error('sync failed');
+    });
+
+    await syncOnProjectSwitch(papi, 'incoming-id', 'outgoing-id');
+
+    expect(mockWarn).toHaveBeenCalled();
+    expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.sendReceiveProjects', [
+      'outgoing-id',
+    ]);
+  });
+
+  it('warns and resolves when sendReceiveProjects throws', async () => {
+    const { papi, mockSendCommand, mockWarn } = createSyncMockPapi();
+    mockSendCommand.mockImplementation(async (command: string) => {
+      if (command === 'paratextBibleSendReceive.sendReceiveProjects') throw new Error('s/r failed');
+    });
+
+    await expect(syncOnProjectSwitch(papi, 'incoming-id', 'outgoing-id')).resolves.toBeUndefined();
+    expect(mockWarn).toHaveBeenCalled();
+  });
+});
+
+// #endregion syncOnProjectSwitch

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -738,3 +738,38 @@ export function startDefaultProjectPicker(papi: typeof PapiBackend): Unsubscribe
 }
 
 // #endregion Default Active Project Picker
+
+// #region Project-Switch Sync
+
+/**
+ * Fire-and-forget helper that syncs the incoming project first, then the outgoing one. Each sync is
+ * independently error-isolated so a failure in one doesn't block the other. Only called in simple
+ * mode after a replace-tab project switch.
+ */
+export async function syncOnProjectSwitch(
+  papi: typeof PapiBackend,
+  incomingProjectId: string,
+  outgoingProjectId: string | undefined,
+): Promise<void> {
+  try {
+    await papi.commands.sendCommand('paratextBibleSendReceive.syncProjects', [incomingProjectId]);
+  } catch (e) {
+    papi.logger.warn(
+      `Project-switch sync: incoming sync for ${incomingProjectId} failed: ${getErrorMessage(e)}`,
+    );
+  }
+
+  if (outgoingProjectId) {
+    try {
+      await papi.commands.sendCommand('paratextBibleSendReceive.sendReceiveProjects', [
+        outgoingProjectId,
+      ]);
+    } catch (e) {
+      papi.logger.warn(
+        `Project-switch sync: outgoing sync for ${outgoingProjectId} failed: ${getErrorMessage(e)}`,
+      );
+    }
+  }
+}
+
+// #endregion Project-Switch Sync

--- a/extensions/src/platform-scripture-editor/src/types/paratext-bible-send-receive.d.ts
+++ b/extensions/src/platform-scripture-editor/src/types/paratext-bible-send-receive.d.ts
@@ -252,8 +252,9 @@ declare module 'papi-shared-types' {
      * sends/receives connected translation projects or DBL-updates connected resources as needed.
      * Unknown project IDs are skipped. Deduplication is handled internally.
      *
-     * @param projectIds Ids of the projects to sync. If omitted, all shared projects already
-     *   present locally are synced.
+     * @param projectIds IDs of the projects to sync. If omitted, all shared projects already
+     *   present locally are synced. If provided, only projects already present locally are synced;
+     *   new projects (not yet received) and unknown IDs are skipped.
      * @throws `PlatformUnimplementedException` if not running in an application that implements
      *   this command (e.g., Paratext 10 Studio)
      */

--- a/extensions/src/platform-scripture-editor/src/types/paratext-bible-send-receive.d.ts
+++ b/extensions/src/platform-scripture-editor/src/types/paratext-bible-send-receive.d.ts
@@ -260,14 +260,6 @@ declare module 'papi-shared-types' {
      */
     'paratextBibleSendReceive.syncProjects': (projectIds?: string[]) => Promise<void>;
     /**
-     * Cancels an in-progress sync operation if one is running. The process will finish dealing with
-     * the current project/resource and then abort. It will not undo what has been done.
-     *
-     * @throws `PlatformUnimplementedException` if not running in an application that implements
-     *   this command (e.g., Paratext 10 Studio)
-     */
-    'paratextBibleSendReceive.cancelSync': () => Promise<void>;
-    /**
      * Accepts a project id, and returns a RevisionInfo[] of all revisions for the given project.
      *
      * @param projectId Id of project to retrieve revisions from

--- a/extensions/src/platform-scripture-editor/src/types/paratext-bible-send-receive.d.ts
+++ b/extensions/src/platform-scripture-editor/src/types/paratext-bible-send-receive.d.ts
@@ -247,6 +247,26 @@ declare module 'papi-shared-types' {
       webViewId: string,
     ) => Promise<ResultsData>;
     /**
+     * Syncs projects: sends/receives each project, then reads each project's connected resources
+     * and projects (one level deep — connections of connections are not included) and
+     * sends/receives connected translation projects or DBL-updates connected resources as needed.
+     * Unknown project IDs are skipped. Deduplication is handled internally.
+     *
+     * @param projectIds Ids of the projects to sync. If omitted, all shared projects already
+     *   present locally are synced.
+     * @throws `PlatformUnimplementedException` if not running in an application that implements
+     *   this command (e.g., Paratext 10 Studio)
+     */
+    'paratextBibleSendReceive.syncProjects': (projectIds?: string[]) => Promise<void>;
+    /**
+     * Cancels an in-progress sync operation if one is running. The process will finish dealing with
+     * the current project/resource and then abort. It will not undo what has been done.
+     *
+     * @throws `PlatformUnimplementedException` if not running in an application that implements
+     *   this command (e.g., Paratext 10 Studio)
+     */
+    'paratextBibleSendReceive.cancelSync': () => Promise<void>;
+    /**
      * Accepts a project id, and returns a RevisionInfo[] of all revisions for the given project.
      *
      * @param projectId Id of project to retrieve revisions from


### PR DESCRIPTION
﻿<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-3986-sync-closed-project

**Base**: origin/main

**Date**: 2026-05-22

**Review model**: Claude Sonnet 4.6

**Files changed**: 2 (original); 4 after in-review fixes

## Overview

This branch adds a fire-and-forget post-switch sync to the Scripture Editor's `open()` function. When a user switches projects in simple mode (which resolves as a `replace-tab` dispatch), the new `syncOnProjectSwitch` helper fires: it first calls `paratextBibleSendReceive.syncProjects` on the incoming project (full sync including connected resources), then calls `paratextBibleSendReceive.sendReceiveProjects` on the outgoing project (lighter S/R, skipped entirely for read-only editors). Both calls are independently error-isolated and the overall call is not awaited, so the UI remains responsive. The `syncProjects` type declaration was added to the scripture editor's local copy of `paratext-bible-send-receive.d.ts`.

During the review, `syncOnProjectSwitch` was moved from a private function in `main.ts` to an exported function in `platform-scripture-editor.utils.ts` (following the established utils pattern of receiving `papi` as a parameter), and five unit tests were added.

## API Changes

Changes are confined to the `platform-scripture-editor` extension. No changes to `papi.d.ts`, `lib/platform-bible-react/`, or `lib/platform-bible-utils/`.

- `extensions/src/platform-scripture-editor/src/types/paratext-bible-send-receive.d.ts`: Added `'paratextBibleSendReceive.syncProjects'` command handler declaration (additive; follows the established pattern of each extension copying only the type declarations it needs)
- `extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts`: New exported `syncOnProjectSwitch(papi, incomingProjectId, outgoingProjectId)` function
- `extensions/src/platform-scripture-editor/src/main.ts`: `open()` calls `syncOnProjectSwitch` fire-and-forget in simple mode on `replace-tab` dispatch; outgoing S/R skipped for read-only editors

## Findings

### Critical — ” Must address before merge

None.

### Important — ” Should address before merge

- [x] **Fire-and-forget call missing `void` prefix** _(fixed during review: changed to `void syncOnProjectSwitch(...)` to make the intentional discard explicit and satisfy the `promise/no-floating-promises` lint rule)_
- [x] **`@param` description for `syncProjects` truncated vs `platform-get-resources` version** _(fixed during review: updated to include "If provided, only projects already present locally are synced; new projects (not yet received) and unknown IDs are skipped")_
- [x] **`cancelSync` declared but never called from TypeScript â€” no cancellation on re-switch** _(Cancel button is invoked from C# by the Sonner toast; TypeScript never calls it. Confirmed that `cancelSync` is registered as a C# command handler in `ParatextProjectSendReceiveService.cs`. Declaration removed from the TypeScript `.d.ts` file post-review.)_
- [x] **No tests for `syncOnProjectSwitch`** _(fixed during review: moved function to `platform-scripture-editor.utils.ts` as an exported function (papi as first param, matching the existing utils pattern), and added 5 unit tests covering: correct project IDs, call ordering (incoming before outgoing), outgoing skipped when undefined, incoming failure does not block outgoing, outgoing failure resolves cleanly)_

Author response: All four findings discussed. The `void` prefix and `@param` fixes were straightforward. The `cancelSync` finding was dismissed â€” the Cancel button is wired up in the C# Sonner notification layer. The tests finding led to a refactor that improves the design (exported, testable function).

### Minor — ” Consider

- [x] **`outgoingProjectId` computed unconditionally regardless of `interfaceMode`** _(fixed during review: scoped the lookup inside the `if (interfaceMode === 'simple' && dispatch.kind === 'replace-tab')` guard so it only runs when needed)_
- [ ] ~~**SHA comment header in `paratext-bible-send-receive.d.ts` is a stale snapshot reference**~~ _(author: acceptable as a historical note; follows the same pattern as the `platform-get-resources` copy of the same file)_
- [x] **`cancelSync` declared but unused from TypeScript** _(post-review: declaration removed â€” confirmed the command is registered and invoked entirely within C#)_

Author response: Fix #1 accepted. Finding #2 dismissed with explanation. Finding #3 fixed post-review after human reviewer confirmed the same concern.

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- Error isolation in `syncOnProjectSwitch` is clean: each sync leg has its own independent `try/catch`, so a failure on the incoming project does not prevent the outgoing sync from running.
- Both new command declarations include thorough JSDoc with `@throws PlatformUnimplementedException` annotation.
- The guard `interfaceMode === 'simple' && dispatch.kind === 'replace-tab'` precisely limits the sync to the intended scenario (not for new-tab opens or focus-existing navigations).
- `outgoingProjectId` lookup reads dock state before `openWebView` is called, correctly avoiding any race where the tab list might have changed.
- No user-visible strings were added without localization treatment; log output goes through `logger.warn` only.
- No new React components, no Storybook gap, no build config changes.

## Interview Notes

**Purpose**: After a project switch in simple mode, automatically sync the incoming project first (via `syncProjects` â€” full sync including connected resources), then the outgoing project (via `sendReceiveProjects` â€” lighter S/R), fire-and-forget so the UI stays responsive. The C# `SyncProjects` implementation handles the Sonner notification.

**Key decisions**:

- **`syncProjects` for incoming, `sendReceiveProjects` for outgoing**: The full connected-resources sweep is needed for the incoming project. For the outgoing project, `sendReceiveProjects` is correct â€” **PO (Ian) confirmed**: "I don't see any value in checking for resource updates on close. S/R of the project is only necessary if the user has changes to push." The outgoing S/R is further skipped entirely when the outgoing editor was read-only, since no local changes are possible in that case. An `ENHANCE` comment notes the potential future optimization of also skipping when the editor had no user edits during the session (would require a dirty-flag mechanism not currently available in the editor controller).

- **Duplicate type declaration is intentional**: `syncProjects` is also declared in `platform-get-resources.d.ts`, but the pattern in this codebase is for each extension to copy only the type declarations it needs â€” no cross-extension imports. The duplication is by design.

- **`cancelSync` not declared in TypeScript**: The Cancel button for an in-progress sync lives in the C# Sonner toast notification; `cancelSync` is registered as a C# command handler in `ParatextProjectSendReceiveService.cs` and never called from TypeScript. The declaration was removed post-review.

**Design explanation**: The author understood the design clearly â€” `open()` already has the dock state and dispatch kind in scope, making it the natural place to fire the post-switch sync.

## In-Review Quality Check

Four changes were made during the interview; one post-review follow-up was added after PO confirmation:

1. Added `void` prefix to the fire-and-forget `syncOnProjectSwitch` call
2. Updated `@param` description for `syncProjects` to match the fuller wording in `platform-get-resources.d.ts`
3. Moved `syncOnProjectSwitch` from a private function in `main.ts` to an exported function in `platform-scripture-editor.utils.ts`; added 5 unit tests
4. Scoped `outgoingProjectId` lookup inside the `interfaceMode === 'simple'` guard
5. _(post-review)_ Skip outgoing S/R when the outgoing editor is read-only; added `ENHANCE` comment about dirty-flag optimization
6. _(post-review)_ Removed `cancelSync` TypeScript declaration â€” confirmed it is registered and invoked entirely in C#

Quality checks:
- **typecheck**: All errors are pre-existing (`@eten-tech-foundation/*` packages not installed for local compilation). Zero new errors in the changed files.
- **lint**: One auto-fix applied (trailing newline in test file). Pre-existing `import/no-unresolved` in `utils.ts` remains â€” confirmed pre-existing.
- **format**: All files correctly formatted after lint auto-fix.
- **tests**: Skipped —” pre-existing broken module resolution for `@eten-tech-foundation/scripture-utilities` prevents the extension test suite from running regardless of these changes.

## Suggested Review Focus

- [x] **`sendReceiveProjects` vs `syncProjects` for the outgoing project**: Resolved â€” PO confirmed `sendReceiveProjects` is correct. Outgoing S/R is additionally skipped for read-only editors. An `ENHANCE` comment notes the potential future optimization of tracking editor dirty state.
- [ ] **Overlapping syncs on rapid project switches**: The fire-and-forget pattern means a second switch while a sync is in flight launches a new sync without cancelling the first. Confirm the C# layer handles concurrent sync requests gracefully.
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src= height= align= alt=/>](https://reviewable.io/reviews/paranext/paranext-core/2330)
<!-- Reviewable:end -->