### PR TITLE
feat: add SessionStart hook for remote web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR}"
+
+npm install --ignore-scripts

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -60,7 +60,10 @@ e2e-tests/test-results/
 e2e-tests/.dev-server.pid
 
 # claude
-.claude
+.claude/todos/
+.claude/projects/
+.claude/statsig/
+.claude/cache/
 .claude.backup/
 .context
 c-sharp/CLAUDE.md


### PR DESCRIPTION
## Summary

- Adds `.claude/hooks/session-start.sh` that runs `npm install --ignore-scripts` when a Claude Code web session starts, ensuring ESLint and Vitest are available without needing `dotnet`
- Adds `.claude/settings.json` registering the hook as a `SessionStart` event handler
- Updates `.gitignore` to track `.claude/hooks/` and `.claude/settings.json` while still ignoring local-only Claude data directories (todos, projects, statsig, cache)

## Test plan

- [ ] Merge to main
- [ ] Start a new Claude Code web session on this repo
- [ ] Verify `node_modules` are populated at session start
- [ ] Verify `npx eslint --ext .ts src/main/main.ts` runs without error
- [ ] Verify `npx vitest run src/extension-host/services/settings.service-host.test.ts` passes

https://claude.ai/code/session_01XVKTeFYsF4ihywM46miAb1

---
_Generated by [Claude Code](https://claude.ai/code/session_01XVKTeFYsF4ihywM46miAb1)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2335)
<!-- Reviewable:end -->
