### PR TITLE
Fix: smoke E2E `beforeAll` PAPI timeout

### DIFF
--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -1,9 +1,18 @@
 // SMOKE TEST ONLY — uses papi.fixture for CI smoke testing.
 // Per-feature E2E tests MUST use cdp.fixture instead. See e2e-tests/tests/_example/.
 import { test, expect } from '../../fixtures/papi.fixture';
-import { sendPapiRequestOnce, waitForAppReady } from '../../fixtures/helpers';
+import {
+  sendPapiRequestOnce,
+  waitForAppReady,
+  waitForPapiMethodRegistered,
+} from '../../fixtures/helpers';
 
 test.describe('UI Interaction', () => {
+  // The settings service is exposed as a data-provider network object — data providers
+  // append a `-data` suffix to the provider name, so the JSON-RPC method is
+  // `object:<providerName>-data.set`.
+  const SETTINGS_SET_METHOD = 'object:platform.settingsServiceDataProvider-data.set';
+
   test.beforeAll(async ({ electronApp }) => {
     // Maximize the window once so everything is visible and clickable for all tests
     // Wait for the first window to exist before maximizing
@@ -14,14 +23,12 @@ test.describe('UI Interaction', () => {
 
     // Force the interface language to English so menu-item text matchers
     // (e.g. /Help/i) are deterministic regardless of the developer's saved
-    // platform.interfaceLanguage setting in dev-appdata. The settings service
-    // is exposed as a data-provider network object — data providers append a
-    // `-data` suffix to the provider name, so the JSON-RPC method is
-    // `object:<providerName>-data.set`.
-    await sendPapiRequestOnce('object:platform.settingsServiceDataProvider-data.set', [
-      'platform.interfaceLanguage',
-      ['en'],
-    ]);
+    // platform.interfaceLanguage setting in dev-appdata. Wait for the method
+    // to register on the PAPI network first — on slow CI the settings data
+    // provider can register after this beforeAll starts, and the 10s
+    // single-shot timeout in sendPapiRequestOnce isn't enough to absorb that.
+    await waitForPapiMethodRegistered(SETTINGS_SET_METHOD);
+    await sendPapiRequestOnce(SETTINGS_SET_METHOD, ['platform.interfaceLanguage', ['en']]);
   });
 
   test('should open the About dialog from the Help menu', async ({ mainPage }) => {


### PR DESCRIPTION
## What changed

**File:** `e2e-tests/tests/smoke/ui-interaction.spec.ts` (one file, 16 insertions / 9 deletions)

- Extended the existing import from `../../fixtures/helpers` to also pull in
  `waitForPapiMethodRegistered`.
- Lifted the settings-set method name into a describe-scoped `const`
  (`SETTINGS_SET_METHOD = 'object:platform.settingsServiceDataProvider-data.set'`)
  so the wait and the send refer to the same string.
- Inside `test.beforeAll`, added `await waitForPapiMethodRegistered(SETTINGS_SET_METHOD)`
  immediately before the existing `await sendPapiRequestOnce(SETTINGS_SET_METHOD, …)` call.

## Why it was needed

The smoke suite intermittently aborted on CI before any test ran, with:

> Error: PAPI request "object:platform.settingsServiceDataProvider-data.set"
> timed out after 10000ms

The `beforeAll` forces the interface language to English so menu-item text
matchers (`/Help/i`, `/About Platform\.Bible/i`) are deterministic. It did so
by calling `sendPapiRequestOnce` — a single-shot JSON-RPC call with a 10-second
timeout — immediately after the Electron window appeared.

On slow CI runs, the settings data provider hadn't yet finished registering
with the PAPI network when that call fired. The WebSocket got no response,
the 10-second timeout tripped, and Playwright's three retries all hit the
same wall. The whole suite aborted.

## Why this fix

The rest of the E2E suite already established the pattern: any time you
intend to call `sendPapiRequestOnce` directly, first poll `rpc.discover` via
`waitForPapiMethodRegistered` to confirm the method is registered. That
pattern appears in `fixtures/comment-test-helpers.ts`, in `dialog-rendering.spec.ts`,
and inside `waitForAppReady` itself. The `ui-interaction.spec.ts` `beforeAll`
was the only direct caller that skipped it.

`waitForPapiMethodRegistered` polls every 250 ms with a 60-second timeout and
returns as soon as the method appears — so once the provider registers, the
subsequent `sendPapiRequestOnce` returns near-instantly. No new abstractions,
no fixture changes, no new tests; the existing smoke suite is the regression
test.

## Verification

- TypeScript typecheck: clean on the changed file (a single pre-existing
  `'hello-world'` types error remains in the project, unrelated to this
  change).
- ESLint: clean on the changed file.
- `npm run test:e2e:smoke`: all 13 smoke tests pass locally in ~33 s,
  including all five `UI Interaction` tests that exercise the modified
  `beforeAll`.

Local verification can only confirm "the change didn't break what was
passing locally." The CI-specific timing failure can't be reproduced
deterministically without simulating a slow PAPI startup, so confirmation
of the fix arrives on the next CI run that previously would have flaked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2336)
<!-- Reviewable:end -->
