### PR TITLE
Add CONTEXT.md domain glossary for model text epic

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,7 +18,7 @@ Ghost content shows **structure only** — translated text is stripped; structur
 
 ## Committed Content
 
-Project data that a translator has explicitly entered. A chapter (or unit) moves from ghost to committed as the translator fills in content. Ghost content in chapters with no committed data can be freely swapped by switching the model text.
+Project data that a translator has explicitly entered. The **chapter** is the atomic unit of commitment: if any project data exists for a chapter in the PDP, the entire chapter is treated as committed and ghost content is suppressed for it. Ghost content only appears in chapters with no existing project data.
 
 ## Model Text Panel
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -47,7 +47,9 @@ A "Reset chapter" action with a confirmation warning is appropriate (the transla
 
 Future possibility (unrelated, not re-ghosting): a preview/conversion tool that dynamically maps an existing translated structure onto a different model text's structure. Not expected soon.
 
-**Note:** "Ghost" is an internal developer term and must not appear in any user-facing text, labels, or UI copy.
+## Template (user-facing term)
+
+The user-facing term for ghost content — the structural scaffolding shown in the translation editor for chapters with no committed content. Communicates "a pattern from the model text that you fill in and make your own." The word "Ghost" must never appear in user-facing text; "Template" is used instead in all UI copy, labels, and help text.
 
 When a chapter is adopted (committed), the ID of the current Structural Model Text is written to a new project setting — tentatively `platformScripture.chapterModelTexts` — as a map of chapter references to model text IDs. This stamp persists even if the global model text is later changed, and is the authoritative record of which model text a chapter's structure came from. It enables future features such as per-chapter re-structuring and provenance display.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -34,6 +34,8 @@ The point at which a chapter transitions from ghost to committed. Triggered by a
 
 This is the same mechanism as Gmail's "undo send": the default outcome is commitment; the user must act within the window to prevent it.
 
+**Navigation during grace period:** If the translator navigates away before the timer expires, the countdown continues in the background. The undo notice persists in a global notification area and remains actionable until the timer expires. The chapter is committed (PDP write occurs) when the timer runs out, regardless of where the translator is.
+
 ## Model Text Panel
 
 An existing separate, synchronized, read-only panel that displays the current chapter of the model text alongside the translation editor. Serves the **reading reference** role. Distinct from ghost content.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,10 @@ This is the same mechanism as Gmail's "undo send": the default outcome is commit
 
 **Multiple in-flight grace periods:** Multiple chapters can be in pending-adoption state simultaneously. Each has its own independent timer and undo notice. Typing in Genesis 2 before Genesis 1's timer expires does not affect Genesis 1's timer.
 
+## Chapter Model Text Stamp
+
+When a chapter is adopted (committed), the ID of the current Structural Model Text is written to a new project setting — tentatively `platformScripture.chapterModelTexts` — as a map of chapter references to model text IDs. This stamp persists even if the global model text is later changed, and is the authoritative record of which model text a chapter's structure came from. It enables future features such as per-chapter re-structuring and provenance display.
+
 ## Structural Model Text
 
 The model text resource used as the source of ghost content (paragraph structure, markers, versification). Today this is always `platformScripture.modelTexts items[0]` — the same resource shown in the Model Text Panel (reading reference role). The two roles may be separated in a future setting, so ghost content code must route through a named abstraction rather than hardcoding `items[0]` directly.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -18,9 +18,17 @@ Ghost content shows **structure only** — translated text is stripped; structur
 
 ## Committed Content
 
-Project data that a translator has explicitly entered. The **chapter** is the atomic unit of commitment: if any project data exists for a chapter in the PDP, the entire chapter is treated as committed and ghost content is suppressed for it. Ghost content only appears in chapters with no existing project data.
+Project data that a translator has entered that crosses the **meaningful content threshold** (see below). The **chapter** is the atomic unit of commitment.
 
-**Adoption:** When a translator first types into a ghost chapter, the ghost structure (paranodes, verse slot positions, heading slots) is promoted to become the initial real project data for that chapter. The translator then edits within that committed scaffold. Ghost content is never written to the PDP directly — adoption is the only path from ghost to committed.
+**Per-chapter model text:** Once a chapter is committed, the global model text active at that moment is stamped onto the chapter as its model text. That stamp is what the chapter's ghost structure came from, and it persists even if the global model text is later changed.
+
+**Before commitment:** A chapter with no meaningful content has no stamped model text. It displays ghost content derived from the current global model text. Changing the global model text immediately updates the ghost for all uncommitted chapters.
+
+**Adoption:** When a chapter crosses the meaningful content threshold, its ghost structure (paranodes, verse slot positions, heading slots) is promoted to real project data, the current global model text is stamped onto the chapter, and subsequent edits are made within that committed scaffold.
+
+## Meaningful Content Threshold
+
+The point at which a chapter transitions from ghost to committed. Not yet precisely defined — "first keystroke" was proposed but the intent is something higher: content that represents real translation work, not an accidental or trivial edit. Needs to be resolved.
 
 ## Model Text Panel
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -36,6 +36,8 @@ This is the same mechanism as Gmail's "undo send": the default outcome is commit
 
 **Navigation during grace period:** If the translator navigates away before the timer expires, the countdown continues in the background. The undo notice persists in a global notification area and remains actionable until the timer expires. The chapter is committed (PDP write occurs) when the timer runs out, regardless of where the translator is.
 
+**Multiple in-flight grace periods:** Multiple chapters can be in pending-adoption state simultaneously. Each has its own independent timer and undo notice. Typing in Genesis 2 before Genesis 1's timer expires does not affect Genesis 1's timer.
+
 ## Model Text Panel
 
 An existing separate, synchronized, read-only panel that displays the current chapter of the model text alongside the translation editor. Serves the **reading reference** role. Distinct from ghost content.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,6 +51,8 @@ Future possibility (unrelated, not re-ghosting): a preview/conversion tool that 
 
 The user-facing term for ghost content — the structural scaffolding shown in the translation editor for chapters with no committed content. Communicates "a pattern from the model text that you fill in and make your own." The word "Ghost" must never appear in user-facing text; "Template" is used instead in all UI copy, labels, and help text.
 
+## Chapter Model Text Stamp
+
 When a chapter is adopted (committed), the ID of the current Structural Model Text is written to a new project setting — tentatively `platformScripture.chapterModelTexts` — as a map of chapter references to model text IDs. This stamp persists even if the global model text is later changed, and is the authoritative record of which model text a chapter's structure came from. It enables future features such as per-chapter re-structuring and provenance display.
 
 ## Structural Model Text

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -28,7 +28,11 @@ Project data that a translator has entered that crosses the **meaningful content
 
 ## Meaningful Content Threshold
 
-The point at which a chapter transitions from ghost to committed. Not yet precisely defined — "first keystroke" was proposed but the intent is something higher: content that represents real translation work, not an accidental or trivial edit. Needs to be resolved.
+The point at which a chapter transitions from ghost to committed. Triggered by any non-whitespace text entry in a verse slot (Option A), but with a **grace period** before the PDP write actually occurs.
+
+**Grace period (Undo Adoption):** When a translator first enters text into a ghost chapter, a countdown timer begins (initially 60 seconds — a magic number subject to tuning). The content exists in the editor's local state but is NOT yet written to the PDP. A dismissible notice lets the translator undo — discarding the local edits and reverting the chapter to ghost. If the timer expires without an undo, adoption completes: the ghost structure plus the translator's edits are written to the PDP and the chapter is committed.
+
+This is the same mechanism as Gmail's "undo send": the default outcome is commitment; the user must act within the window to prevent it.
 
 ## Model Text Panel
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -51,6 +51,10 @@ Future possibility (unrelated, not re-ghosting): a preview/conversion tool that 
 
 The user-facing term for ghost content — the structural scaffolding shown in the translation editor for chapters with no committed content. Communicates "a pattern from the model text that you fill in and make your own." The word "Ghost" must never appear in user-facing text; "Template" is used instead in all UI copy, labels, and help text.
 
+## Pending Adoption Service
+
+An extension-level service (outside the React component tree) that manages in-flight grace periods. Holds a map of `{ chapterRef → pendingUsj, timerId, modelTextId }` for each chapter currently in the adoption countdown. Fires the PDP write when the timer expires; exposes an undo method that discards the pending content and reverts the chapter to ghost. The translation editor web view registers with and reads from this service on mount, enabling timers to survive chapter navigation.
+
 ## Chapter Model Text Stamp
 
 When a chapter is adopted (committed), the ID of the current Structural Model Text is written to a new project setting — tentatively `platformScripture.chapterModelTexts` — as a map of chapter references to model text IDs. This stamp persists even if the global model text is later changed, and is the authoritative record of which model text a chapter's structure came from. It enables future features such as per-chapter re-structuring and provenance display.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,6 +38,6 @@ This is the same mechanism as Gmail's "undo send": the default outcome is commit
 
 **Multiple in-flight grace periods:** Multiple chapters can be in pending-adoption state simultaneously. Each has its own independent timer and undo notice. Typing in Genesis 2 before Genesis 1's timer expires does not affect Genesis 1's timer.
 
-## Model Text Panel
+## Structural Model Text
 
-An existing separate, synchronized, read-only panel that displays the current chapter of the model text alongside the translation editor. Serves the **reading reference** role. Distinct from ghost content.
+The model text resource used as the source of ghost content (paragraph structure, markers, versification). Today this is always `platformScripture.modelTexts items[0]` — the same resource shown in the Model Text Panel (reading reference role). The two roles may be separated in a future setting, so ghost content code must route through a named abstraction rather than hardcoding `items[0]` directly.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -20,6 +20,8 @@ Ghost content shows **structure only** — translated text is stripped; structur
 
 Project data that a translator has explicitly entered. The **chapter** is the atomic unit of commitment: if any project data exists for a chapter in the PDP, the entire chapter is treated as committed and ghost content is suppressed for it. Ghost content only appears in chapters with no existing project data.
 
+**Adoption:** When a translator first types into a ghost chapter, the ghost structure (paranodes, verse slot positions, heading slots) is promoted to become the initial real project data for that chapter. The translator then edits within that committed scaffold. Ghost content is never written to the PDP directly — adoption is the only path from ghost to committed.
+
 ## Model Text Panel
 
 An existing separate, synchronized, read-only panel that displays the current chapter of the model text alongside the translation editor. Serves the **reading reference** role. Distinct from ghost content.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -5,6 +5,7 @@
 A scripture resource (e.g. a DBL translation) used as a reference for a translation project. Stored as a `ResourceReferenceList` under `platformScripture.modelTexts`.
 
 Has two distinct roles:
+
 - **Reading reference** — the text the team reads while translating (currently served by the Model Text Panel)
 - **Structural template** — the source of paragraph structure, headings, markers, and versification used to scaffold the translation editor
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -38,7 +38,15 @@ This is the same mechanism as Gmail's "undo send": the default outcome is commit
 
 **Multiple in-flight grace periods:** Multiple chapters can be in pending-adoption state simultaneously. Each has its own independent timer and undo notice. Typing in Genesis 2 before Genesis 1's timer expires does not affect Genesis 1's timer.
 
-## Chapter Model Text Stamp
+## Re-ghosting
+
+Returning a committed chapter to ghost state. Accomplished by deleting the chapter's content from the PDP — once the chapter is empty, ghost content automatically appears. There is no smart structure conversion; the translator starts fresh from the new model text's ghost.
+
+A "Reset chapter" action with a confirmation warning is appropriate (the translator is knowingly discarding existing work). Lower implementation priority — its existence is useful for developer understanding of the system, but it is not a near-term user-facing feature.
+
+Future possibility (unrelated, not re-ghosting): a preview/conversion tool that dynamically maps an existing translated structure onto a different model text's structure. Not expected soon.
+
+**Note:** "Ghost" is an internal developer term and must not appear in any user-facing text, labels, or UI copy.
 
 When a chapter is adopted (committed), the ID of the current Structural Model Text is written to a new project setting — tentatively `platformScripture.chapterModelTexts` — as a map of chapter references to model text IDs. This stamp persists even if the global model text is later changed, and is the authoritative record of which model text a chapter's structure came from. It enables future features such as per-chapter re-structuring and provenance display.
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -14,7 +14,7 @@ These roles may be served by the same resource or by different resources.
 
 Structural scaffolding from the model text rendered **inside the translation editor** as fill-in-the-blank placeholders. Ghost content is display-only: it is not project data and has not been committed. When a translator enters content into a ghost slot, that content becomes project data and the ghost is replaced.
 
-Ghost content shows **structure only** — the model text's content (translated text) is stripped; only the structural elements remain.
+Ghost content shows **structure only** — translated text is stripped; structural elements remain. At minimum, block-level elements (**paranodes**) are preserved; some inline elements (**charnodes**) may be preserved (TBD). Heading text is stripped (it must be translated), but the heading slot position is preserved. The exact structure definition is decided separately and does not affect the ghost content architecture.
 
 ## Committed Content
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,25 @@
+# Domain Glossary
+
+## Model Text
+
+A scripture resource (e.g. a DBL translation) used as a reference for a translation project. Stored as a `ResourceReferenceList` under `platformScripture.modelTexts`.
+
+Has two distinct roles:
+- **Reading reference** — the text the team reads while translating (currently served by the Model Text Panel)
+- **Structural template** — the source of paragraph structure, headings, markers, and versification used to scaffold the translation editor
+
+These roles may be served by the same resource or by different resources.
+
+## Ghost Content
+
+Structural scaffolding from the model text rendered **inside the translation editor** as fill-in-the-blank placeholders. Ghost content is display-only: it is not project data and has not been committed. When a translator enters content into a ghost slot, that content becomes project data and the ghost is replaced.
+
+Ghost content shows **structure only** — the model text's content (translated text) is stripped; only the structural elements remain.
+
+## Committed Content
+
+Project data that a translator has explicitly entered. A chapter (or unit) moves from ghost to committed as the translator fills in content. Ghost content in chapters with no committed data can be freely swapped by switching the model text.
+
+## Model Text Panel
+
+An existing separate, synchronized, read-only panel that displays the current chapter of the model text alongside the translation editor. Serves the **reading reference** role. Distinct from ghost content.


### PR DESCRIPTION
## Summary

- Adds `CONTEXT.md` at the repo root with an initial domain glossary capturing terminology being established during the model text architecture interview
- Defines: Model Text, Ghost Content, Committed Content, Model Text Panel

## Context

This glossary is being built incrementally during a design interview session to sharpen domain language before implementation decisions are made. It will continue to grow as terms are resolved.

https://claude.ai/code/session_01KGjTK6bt3hEX2z7zYtJunM

---
_Generated by [Claude Code](https://claude.ai/code/session_01KGjTK6bt3hEX2z7zYtJunM)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2337)
<!-- Reviewable:end -->
