### PR TITLE
E2E smoke `beforeAll` PAPI timeout fix (round 2)

### DIFF
--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -1,9 +1,18 @@
 // SMOKE TEST ONLY — uses papi.fixture for CI smoke testing.
 // Per-feature E2E tests MUST use cdp.fixture instead. See e2e-tests/tests/_example/.
 import { test, expect } from '../../fixtures/papi.fixture';
-import { sendPapiRequestOnce, waitForAppReady } from '../../fixtures/helpers';
+import {
+  sendPapiRequestOnce,
+  waitForAppReady,
+  waitForPapiMethodRegistered,
+} from '../../fixtures/helpers';
 
 test.describe('UI Interaction', () => {
+  // The settings service is exposed as a data-provider network object — data providers
+  // append a `-data` suffix to the provider name, so the JSON-RPC method is
+  // `object:<providerName>-data.set`.
+  const SETTINGS_SET_METHOD = 'object:platform.settingsServiceDataProvider-data.set';
+
   test.beforeAll(async ({ electronApp }) => {
     // Maximize the window once so everything is visible and clickable for all tests
     // Wait for the first window to exist before maximizing
@@ -14,14 +23,12 @@ test.describe('UI Interaction', () => {
 
     // Force the interface language to English so menu-item text matchers
     // (e.g. /Help/i) are deterministic regardless of the developer's saved
-    // platform.interfaceLanguage setting in dev-appdata. The settings service
-    // is exposed as a data-provider network object — data providers append a
-    // `-data` suffix to the provider name, so the JSON-RPC method is
-    // `object:<providerName>-data.set`.
-    await sendPapiRequestOnce('object:platform.settingsServiceDataProvider-data.set', [
-      'platform.interfaceLanguage',
-      ['en'],
-    ]);
+    // platform.interfaceLanguage setting in dev-appdata. Wait for the method
+    // to register on the PAPI network first — on slow CI the settings data
+    // provider can register after this beforeAll starts, and the 10s
+    // single-shot timeout in sendPapiRequestOnce isn't enough to absorb that.
+    await waitForPapiMethodRegistered(SETTINGS_SET_METHOD);
+    await sendPapiRequestOnce(SETTINGS_SET_METHOD, ['platform.interfaceLanguage', ['en']]);
   });
 
   test('should open the About dialog from the Help menu', async ({ mainPage }) => {

--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -12,6 +12,10 @@ test.describe('UI Interaction', () => {
   // append a `-data` suffix to the provider name, so the JSON-RPC method is
   // `object:<providerName>-data.set`.
   const SETTINGS_SET_METHOD = 'object:platform.settingsServiceDataProvider-data.set';
+  // The settings `set` handler internally awaits `waitForResyncContributions()`,
+  // which blocks until `extensionService.initialize()` finishes in the extension
+  // host. On slow CI that can exceed the default 10s PAPI request timeout.
+  const SLOW_CI_PAPI_TIMEOUT_MS = 90_000;
 
   test.beforeAll(async ({ electronApp }) => {
     // Maximize the window once so everything is visible and clickable for all tests
@@ -27,16 +31,11 @@ test.describe('UI Interaction', () => {
     // Fast-fail guard: on slow CI the settings data provider can register
     // after this beforeAll starts; this throws a clear error if it never does.
     await waitForPapiMethodRegistered(SETTINGS_SET_METHOD);
-    // The `set` handler internally awaits `waitForResyncContributions()`
-    // (via `get` → `getDefaultValueForKey`) — that doesn't resolve until the
-    // extension host finishes extensionService.initialize(). On slow CI that
-    // wait can exceed the default 10s sendPapiRequestOnce timeout, so give
-    // this call enough headroom to absorb it.
     await sendPapiRequestOnce(
       SETTINGS_SET_METHOD,
       ['platform.interfaceLanguage', ['en']],
       undefined,
-      90_000,
+      SLOW_CI_PAPI_TIMEOUT_MS,
     );
   });
 

--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -23,12 +23,21 @@ test.describe('UI Interaction', () => {
 
     // Force the interface language to English so menu-item text matchers
     // (e.g. /Help/i) are deterministic regardless of the developer's saved
-    // platform.interfaceLanguage setting in dev-appdata. Wait for the method
-    // to register on the PAPI network first — on slow CI the settings data
-    // provider can register after this beforeAll starts, and the 10s
-    // single-shot timeout in sendPapiRequestOnce isn't enough to absorb that.
+    // platform.interfaceLanguage setting in dev-appdata.
+    // Fast-fail guard: on slow CI the settings data provider can register
+    // after this beforeAll starts; this throws a clear error if it never does.
     await waitForPapiMethodRegistered(SETTINGS_SET_METHOD);
-    await sendPapiRequestOnce(SETTINGS_SET_METHOD, ['platform.interfaceLanguage', ['en']]);
+    // The `set` handler internally awaits `waitForResyncContributions()`
+    // (via `get` → `getDefaultValueForKey`) — that doesn't resolve until the
+    // extension host finishes extensionService.initialize(). On slow CI that
+    // wait can exceed the default 10s sendPapiRequestOnce timeout, so give
+    // this call enough headroom to absorb it.
+    await sendPapiRequestOnce(
+      SETTINGS_SET_METHOD,
+      ['platform.interfaceLanguage', ['en']],
+      undefined,
+      90_000,
+    );
   });
 
   test('should open the About dialog from the Help menu', async ({ mainPage }) => {

--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -15,7 +15,7 @@ test.describe('UI Interaction', () => {
   // The settings `set` handler internally awaits `waitForResyncContributions()`,
   // which blocks until `extensionService.initialize()` finishes in the extension
   // host. On slow CI that can exceed the default 10s PAPI request timeout.
-  const SLOW_CI_PAPI_TIMEOUT_MS = 90_000;
+  const SLOW_CI_PAPI_TIMEOUT_MS = 30_000;
 
   test.beforeAll(async ({ electronApp }) => {
     // Maximize the window once so everything is visible and clickable for all tests


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: `fix-test-timeout`

**Base**: `origin/main`

**Date**: 2026-05-27

**Review model**: Claude Opus 4.7

**Files changed**: 1

## Overview

This branch fixes a recurring flake in the `UI Interaction` smoke suite's
`beforeAll`: the `sendPapiRequestOnce` call that sets `platform.interfaceLanguage`
was hitting the helper's default 10s timeout on slow CI. The new behavior passes
an explicit 90s `perRequestTimeoutMs` so the call can absorb the time the
settings `set` handler spends waiting on `waitForResyncContributions()` (which
blocks until `extensionService.initialize()` finishes in the extension host).

The change is one file, three lines of behavioral diff. The `waitForPapiMethodRegistered`
fast-fail guard from PR #2336 is retained but its comment is rewritten to
accurately describe its role; the inline rationale block above the call was
folded into a named constant (`SLOW_CI_PAPI_TIMEOUT_MS`) during this review.

## API Changes

None. The only changed file is `e2e-tests/tests/smoke/ui-interaction.spec.ts`,
which is an internal end-to-end test file and not part of any public API surface
(`lib/platform-bible-react/`, `lib/platform-bible-utils/`, `@papi/` modules in
`papi.d.ts`, or extension `.d.ts` declarations).

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [x] **Magic number `90_000` inlined at the call site** _(fixed during review: extracted to `const SLOW_CI_PAPI_TIMEOUT_MS = 90_000;` at the top of the describe block; moved the resync rationale into the constant's declaration comment and removed the now-redundant inline comment block above the call)_
- [ ] ~~**`undefined` for `port` is inconsistent with other `sendPapiRequestOnce` call sites**~~ _(dismissed: the analyzer cited `comment-test-helpers.ts:174,190,279,319` as evidence of a convention, but those sites pass a local `resolvedPort` variable, not `DEFAULT_WEBSOCKET_PORT`. They pass a port because they have one in scope from their fixture context, not as a style rule. `DEFAULT_WEBSOCKET_PORT` is also not exported from `helpers.ts` — it's a file-private const. In the smoke `beforeAll` there's no port in scope; `undefined` correctly opts into the default without forcing a new export.)_
- [ ] ~~**Comment doesn't justify why 90s specifically**~~ _(dismissed: the constant name plus its 3-line declaration comment already cover what blocks. The specific magnitude rationale (under the 120s Playwright per-test ceiling; well above worst-observed extension-host init time on macOS CI) lives in the local design doc and adding it inline would be noise without changing tunability.)_

### Template Propagation

#### Shared Regions Modified

None. The changed file contains no `#region shared with` markers.

#### Extension Config Changes

None. The only changed file is `e2e-tests/tests/smoke/ui-interaction.spec.ts`,
which is outside `extensions/` and is not an extension config file.

## Positive Observations

- The change is appropriately minimal and surgical — a single call-site argument
  added, no signature or export changes, no new code paths.
- Rationale for the long timeout is captured in code (now via the named constant)
  rather than relying on git history.
- The `waitForPapiMethodRegistered(SETTINGS_SET_METHOD)` fast-fail guard from
  PR #2336 is preserved with a comment that accurately labels its purpose now
  that the real hang is known to be inside the handler — useful diagnostic
  signal preserved without conflating it with the timeout fix.
- The numeric separator (`90_000`) matches the local style of other timeouts
  in this file (`10_000`, `5_000`).
- Comments call out the upstream race in clear, mechanical terms (the
  `set` → `get` → `getDefaultValueForKey` → `waitForResyncContributions()`
  chain) so a future maintainer knows what to actually fix on the source side.

## Interview Notes

The author already had a clear mental model of why PR #2336 didn't work and
why this round addresses the actual root cause. The summary doc on the branch
(`docs/summary.md`, kept local per the author's preference) walks through:

- Why "method registered" ≠ "handler can respond" — PR #2336 synchronized on
  the wrong signal
- The empirical tell from CI run `26522625632`: the previous smoke test passed
  via `waitForAppReady`, so renderer-side readiness was confirmed, but the
  next `beforeAll` still timed out
- Why 90s specifically: under the 120s Playwright per-test ceiling, with
  headroom for `firstWindow` / `maximize` / `waitForPapiMethodRegistered`

During the interview the author chose to extract the inlined `90_000` into a
named constant (Finding 1), dismissed the `port` consistency suggestion after
the analyzer's factual basis (`DEFAULT_WEBSOCKET_PORT` being exported, and
peer call sites using it) was disproven, and declined to expand the comment
with magnitude rationale since the source-side fix in
`settings.service-host.ts` is the durable resolution path.

No unresolved areas — the author can explain every part of the change without
deferral.

## In-Review Quality Check

- `npm run typecheck` — passed cleanly across all 21 workspaces.
- `npm run lint` — passed (the only warnings are pre-existing `no-console`
  hits in `extensions/src/platform-scripture/src/use-effective-resource-reference-list.ts`,
  unrelated to this branch's diff).
- Prettier on changed file — already formatted, no diff produced.
- `npm test` — skipped: the only changed file is an e2e test (not part of the
  vitest suite). The smoke suite was confirmed to type-check cleanly via the
  typecheck step.

No fixes were required.

## Suggested Review Focus

- [ ] **Is 90s the right ceiling?** It sits well under the 120s Playwright
      per-test timeout and covers worst-observed extension-host init on
      macOS CI, but the reviewer may want to discuss whether they'd prefer
      a smaller value (e.g. 60s) with a faster fail signal on regression.
- [ ] **The source-side race in `settings.service-host.ts`.** The data
      provider registers before `extensionService.initialize()` completes
      but its `get` path awaits `waitForResyncContributions()`. Two source
      fixes are documented in the local spec. This PR intentionally defers
      that work — confirm with the reviewer that the deferral is the right
      call vs. fixing the root cause now.
- [ ] **Whether to promote `SLOW_CI_PAPI_TIMEOUT_MS` to a shared helper.**
      Currently scoped to this describe block. If other smoke suites' settings
      writes are likely to hit the same wait, it could move to
      `e2e-tests/fixtures/helpers.ts` — but only one call site needs it today.

<!-- review-paratext:summary:end -->

---

## What we changed

A single edit in [e2e-tests/tests/smoke/ui-interaction.spec.ts](../e2e-tests/tests/smoke/ui-interaction.spec.ts):

- Passed an explicit `90_000` ms `perRequestTimeoutMs` to the `sendPapiRequestOnce` call that sets `platform.interfaceLanguage` in the `UI Interaction` smoke suite's `beforeAll`.
- Rewrote the inline comments to describe the actual mechanism: the `set` handler internally awaits `waitForResyncContributions()` (via `get` → `getDefaultValueForKey`), which doesn't resolve until `extensionService.initialize()` finishes in the extension host. On slow CI that wait legitimately exceeds the default 10 s `sendPapiRequestOnce` timeout.
- Kept the `waitForPapiMethodRegistered(SETTINGS_SET_METHOD)` call from PR #2336 as a fast-fail guard (clear error if the provider never registers), and split its rationale into its own short comment.

No source-side changes; no fixture or helper API changes; no new imports.

## Why the previous fix (PR #2336) didn't work

PR #2336 polled `rpc.discover` until the settings `set` method appeared, on the theory that the provider hadn't registered yet. But the provider HAD registered — the hang was inside the `set` handler itself, waiting on extension-host extension loading. Synchronizing on "method registered" tells you nothing about whether the handler can respond.

The empirical tell from the post-merge CI failure (run `26522625632`): the previous smoke test (`platform-basics` #8) used `waitForAppReady` and passed, which means the renderer's `command:platform.about` was already registered. The next `beforeAll` started and still timed out. Renderer-side readiness ≠ extension-host `resyncContributions` resolved.

## Why 90 s

- Per-test Playwright timeout is 120 s ([e2e-tests/playwright.config.ts](../e2e-tests/playwright.config.ts)).
- 90 s leaves headroom for the surrounding `firstWindow`/`maximize`/`waitForPapiMethodRegistered` work.
- Worst-observed extension-host load window on macOS CI is well under that.

## Verification performed

- `npm run typecheck` — clean across all 21 workspaces; no errors on the changed file.
- `npx eslint e2e-tests/tests/smoke/ui-interaction.spec.ts` — zero errors, zero warnings.
- `npm run test:e2e:smoke` — all 13 smoke tests pass locally (total runtime: 36.1 s). The target test `UI Interaction › should open the About dialog from the Help menu` passed on the first attempt without retries in 12.8 s, well under the new 90 s timeout.
- CI confirmation will only come from the next run that would previously have flaked.

## Follow-up (deferred, source-side)

The underlying race is in [src/extension-host/services/settings.service-host.ts](../src/extension-host/services/settings.service-host.ts) — the data provider registers before `extensionService.initialize()` completes, but its `get` path awaits `waitForResyncContributions()`. Two clean source-side fixes are documented in the spec; either would let us drop the bumped timeout. Out of scope for this change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2338)
<!-- Reviewable:end -->

