### PR TITLE
Add per-OS keyboard shortcut conventions guideline

### DIFF
--- a/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
@@ -201,6 +201,16 @@ Render keyboard shortcut hints using the HTML `<kbd>` element, not plain text in
   <ExampleBlock variant="dont" preview={<span>Undo (⌘Z)</span>} code="Undo (⌘Z)">
     Parentheses blend into prose and don't signal "keyboard shortcut" to the reader.
   </ExampleBlock>
+
+  <ExampleBlock
+    variant="dont"
+    preview={<span>Undo <kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
+Cmd+Z
+</kbd></span>}
+    code="Undo <kbd>Cmd+Z</kbd>  // on macOS"
+  >
+    Each OS has its own convention for writing shortcuts. On macOS, modifier keys are symbols with no separator (<code>⌘Z</code>), not spelled-out words joined with <code>+</code>. See <a href="./keyboard-shortcuts.mdx">Keyboard shortcuts</a> for the full per-OS reference.
+  </ExampleBlock>
 </ExampleBlockGroup>
 
 Use the shared `Kbd` component from `platform-bible-react` instead of styling `<kbd>` inline:
@@ -210,6 +220,8 @@ import { Kbd } from 'platform-bible-react';
 
 <Kbd>⌘Z</Kbd>
 ```
+
+For which symbol or word to use per key on each OS — Command, Option, Control, Shift, Tab, Caps Lock, Space, Return, Delete, Escape, and more — see [Keyboard shortcuts](./keyboard-shortcuts.mdx).
 
 ---
 

--- a/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
@@ -86,11 +86,11 @@ Labels should communicate what will happen — even if the user skips the surrou
 | Preferred  | Discard | Comment |
 
 <ExampleBlockGroup>
-  <ExampleBlock variant="dont" preview={<div style={{display: 'flex', gap: '8px'}}><Button variant="secondary">Cancel</Button><Button>OK</Button></div>}>
+  <ExampleBlock variant="avoid" preview={<div style={{display: 'flex', gap: '8px'}}><Button variant="secondary">Cancel</Button><Button>OK</Button></div>}>
     Neither label explains what will happen — users dismiss without reading.
   </ExampleBlock>
 
-  <ExampleBlock variant="do" preview={<div style={{display: 'flex', gap: '8px'}}><Button variant="secondary">Discard</Button><Button>Comment</Button></div>}>
+  <ExampleBlock variant="prefer" preview={<div style={{display: 'flex', gap: '8px'}}><Button variant="secondary">Discard</Button><Button>Comment</Button></div>}>
     Both actions are self-evident — the choice is clear without reading surrounding text.
   </ExampleBlock>
 </ExampleBlockGroup>
@@ -111,7 +111,7 @@ Tooltips are required for every icon button and any control without a visible la
 
 <ExampleBlockGroup>
   <ExampleBlock
-    variant="dont"
+    variant="avoid"
     previewClassName="tw:pb-8"
     preview={
 <Button variant="outline" size="icon" aria-label="Save" >
@@ -124,7 +124,7 @@ Tooltips are required for every icon button and any control without a visible la
 
   <ExampleBlock
     title="Avoid redundant tooltips"
-    variant="dont"
+    variant="avoid"
     previewClassName="tw:pb-8"
     preview={
 <TooltipProvider>
@@ -145,7 +145,7 @@ Keep tooltip text short enough to scan at a glance. A tooltip is a hint, not an 
 
 <ExampleBlockGroup>
   <ExampleBlock
-    variant="dont"
+    variant="avoid"
     previewClassName="tw:pb-16"
     preview={
 <TooltipProvider>
@@ -164,7 +164,7 @@ Keep tooltip text short enough to scan at a glance. A tooltip is a hint, not an 
   </ExampleBlock>
 
   <ExampleBlock
-    variant="do"
+    variant="prefer"
     previewClassName="tw:pb-16"
     preview={
 <TooltipProvider>
@@ -189,7 +189,7 @@ Render keyboard shortcut hints using the HTML `<kbd>` element, not plain text in
 
 <ExampleBlockGroup>
   <ExampleBlock
-    variant="do"
+    variant="prefer"
     preview={<span>Undo <kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
 ⌘Z
 </kbd></span>}
@@ -198,12 +198,12 @@ Render keyboard shortcut hints using the HTML `<kbd>` element, not plain text in
     The <code>kbd</code> element provides visual distinction without extra punctuation.
   </ExampleBlock>
 
-  <ExampleBlock variant="dont" preview={<span>Undo (⌘Z)</span>} code="Undo (⌘Z)">
+  <ExampleBlock variant="avoid" preview={<span>Undo (⌘Z)</span>} code="Undo (⌘Z)">
     Parentheses blend into prose and don't signal "keyboard shortcut" to the reader.
   </ExampleBlock>
 
   <ExampleBlock
-    variant="dont"
+    variant="avoid"
     preview={<span>Undo <kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
 Cmd+Z
 </kbd></span>}

--- a/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
@@ -8,8 +8,8 @@ When displaying a keyboard shortcut in the UI, write it the way the user's opera
 
 The two conventions to know:
 
-- **macOS** uses **symbols** for modifier and special keys, written together with no separator (e.g. `⇧⌘Z`). Modifier order is Control, Option, Shift, Command.
-- **Windows and Linux** use **words** joined with `+` (e.g. `Ctrl+Shift+Z`). Modifier order is Ctrl, Alt, Shift.
+- **macOS** uses **symbols** for modifier and special keys, written together with no separator (e.g. `⇧⌘Z`). Modifier order is Control, Option, Shift, Command ([Apple HIG](https://developer.apple.com/design/human-interface-guidelines/keyboards)).
+- **Windows and Linux** use **words** joined with `+` (e.g. `Ctrl+Shift+Z`). Modifier order is Ctrl, Shift, Alt ([Windows](<https://learn.microsoft.com/en-us/previous-versions/windows/desktop/bb246452(v=vs.85)>) / [GNOME HIG](https://developer.gnome.org/hig/guidelines/keyboard.html)).
 
 For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, parentheses vs. no parentheses), see [Design Principles → Keyboard shortcuts in tooltips](./design-principles.mdx).
 
@@ -38,7 +38,7 @@ For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, par
 ## Combining keys
 
 - **macOS:** concatenate the symbols with no separator and no spaces. Order: Control, Option, Shift, Command, then the key. Example: `⌃⌥⇧⌘T`.
-- **Windows / Linux:** join with `+` and no spaces. Order: Ctrl, Alt, Shift, then the key. Example: `Ctrl+Shift+T`.
+- **Windows / Linux:** join with `+` and no spaces. Order: Ctrl, Shift, Alt, then the key. Example: `Ctrl+Shift+T`.
 
 ## Detecting the platform
 

--- a/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
@@ -6,10 +6,11 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 When displaying a keyboard shortcut in the UI, write it the way the user's operating system writes it. Each OS has its own established convention for naming and combining modifier and special keys, and users recognize their own platform's convention at a glance. Mixing conventions — or inventing a new one — makes shortcuts harder to scan and signals that the app isn't paying attention.
 
-The two conventions to know:
+The conventions to know:
 
 - **macOS** uses **symbols** for modifier and special keys, written together with no separator (e.g. `⇧⌘Z`). Modifier order is Control, Option, Shift, Command ([Apple HIG](https://developer.apple.com/design/human-interface-guidelines/keyboards)).
-- **Windows and Linux** use **words** joined with `+` (e.g. `Ctrl+Shift+Z`). Modifier order is Ctrl, Shift, Alt ([Windows](<https://learn.microsoft.com/en-us/previous-versions/windows/desktop/bb246452(v=vs.85)>) / [GNOME HIG](https://developer.gnome.org/hig/guidelines/keyboard.html)).
+- **Windows** uses **words** joined with `+` (e.g. `Ctrl+Shift+Z`). Modifier order is Ctrl, Shift, Alt ([Microsoft](https://support.microsoft.com/en-us/windows/keyboard-shortcuts-in-windows-dcc61a57-8ff0-cffe-9796-cb9706c75eec)).
+- **Linux** uses **words** joined with `+`. Modifier order varies by desktop environment; on GNOME and Ubuntu, the typical order is Ctrl, Alt, Shift ([Ubuntu](https://help.ubuntu.com/stable/ubuntu-help/shell-keyboard-shortcuts.html.en) / [GNOME HIG](https://developer.gnome.org/hig/guidelines/keyboard.html)).
 
 For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, parentheses vs. no parentheses), see [Design Principles → Keyboard shortcuts in tooltips](./design-principles.mdx).
 
@@ -38,7 +39,8 @@ For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, par
 ## Combining keys
 
 - **macOS:** concatenate the symbols with no separator and no spaces. Order: Control, Option, Shift, Command, then the key. Example: `⌃⌥⇧⌘T`.
-- **Windows / Linux:** join with `+` and no spaces. Order: Ctrl, Shift, Alt, then the key. Example: `Ctrl+Shift+T`.
+- **Windows:** join with `+` and no spaces. Order: Ctrl, Shift, Alt, then the key. Example: `Ctrl+Shift+T`.
+- **Linux:** join with `+` and no spaces. Order varies; GNOME typically uses Ctrl, Alt, Shift, then the key. Example: `Ctrl+Alt+Shift+R`.
 
 ## Detecting the platform
 

--- a/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
@@ -1,0 +1,55 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Guidelines/Keyboard shortcuts" />
+
+# Keyboard shortcuts
+
+When displaying a keyboard shortcut in the UI, write it the way the user's operating system writes it. Each OS has its own established convention for naming and combining modifier and special keys, and users recognize their own platform's convention at a glance. Mixing conventions — or inventing a new one — makes shortcuts harder to scan and signals that the app isn't paying attention.
+
+The two conventions to know:
+
+- **macOS** uses **symbols** for modifier and special keys, written together with no separator (e.g. `⇧⌘Z`). Modifier order is Control, Option, Shift, Command.
+- **Windows and Linux** use **words** joined with `+` (e.g. `Ctrl+Shift+Z`). Modifier order is Ctrl, Alt, Shift.
+
+For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, parentheses vs. no parentheses), see [Design Principles → Keyboard shortcuts in tooltips](./design-principles.mdx).
+
+---
+
+## Preferred representations by OS
+
+| Key             | macOS              | Windows           | Linux             |
+| --------------- | ------------------ | ----------------- | ----------------- |
+| Command         | `⌘`                | — (no equivalent) | — (no equivalent) |
+| Windows / Super | — (no equivalent)  | `Win` or `⊞`      | `Super`           |
+| Option / Alt    | `⌥`                | `Alt`             | `Alt`             |
+| Control         | `⌃`                | `Ctrl`            | `Ctrl`            |
+| Shift           | `⇧`                | `Shift`           | `Shift`           |
+| Caps Lock       | `⇪`                | `Caps Lock`       | `Caps Lock`       |
+| Tab             | `⇥`                | `Tab`             | `Tab`             |
+| Return / Enter  | `⏎` (or `Return`)  | `Enter`           | `Enter`           |
+| Backspace       | `⌫` (or `Delete`)  | `Backspace`       | `Backspace`       |
+| Forward Delete  | `⌦`                | `Delete`          | `Delete`          |
+| Escape          | `⎋` (or `Esc`)     | `Esc`             | `Esc`             |
+| Space           | `Space` (or `␣`)   | `Space`           | `Space`           |
+| Arrow keys      | `↑` `↓` `←` `→`    | `↑` `↓` `←` `→`   | `↑` `↓` `←` `→`   |
+| Page Up / Down  | `⇞` / `⇟`          | `Page Up` / `Page Down` | `Page Up` / `Page Down` |
+| Home / End      | `↖` / `↘`          | `Home` / `End`    | `Home` / `End`    |
+
+## Combining keys
+
+- **macOS:** concatenate the symbols with no separator and no spaces. Order: Control, Option, Shift, Command, then the key. Example: `⌃⌥⇧⌘T`.
+- **Windows / Linux:** join with `+` and no spaces. Order: Ctrl, Alt, Shift, then the key. Example: `Ctrl+Shift+T`.
+
+## Detecting the platform
+
+For shortcuts rendered at runtime, branch on the user's OS rather than hardcoding one convention:
+
+```tsx
+import { Kbd } from 'platform-bible-react';
+
+<Kbd>{isMac ? '⌘Z' : 'Ctrl+Z'}</Kbd>
+```
+
+## Why this matters
+
+Writing `Cmd+Z` on macOS, or `⌘Z` on Windows, looks wrong to users who know their platform — and it looks doubly wrong to users who use both. Following each OS's own convention is a small detail that makes the app feel native everywhere it runs.

--- a/lib/platform-bible-react/src/stories/home/intro.mdx
+++ b/lib/platform-bible-react/src/stories/home/intro.mdx
@@ -47,7 +47,7 @@ This guide would provide developers with step-by-step instructions on how to imp
 
 ### Writing Documentation Examples
 
-Use `ExampleBlock` and `ExampleBlockGroup` from `@/storybook/example-block.component` to annotate Do / Don't / Tip patterns in any MDX doc page.
+Use `ExampleBlock` and `ExampleBlockGroup` from `@/storybook/example-block.component` to annotate Prefer / Avoid / Example patterns in any MDX doc page.
 
 ```mdx
 import { ExampleBlock, ExampleBlockGroup } from '@/storybook/example-block.component';
@@ -56,9 +56,9 @@ import { ExampleBlock, ExampleBlockGroup } from '@/storybook/example-block.compo
 **Text-only example:**
 
 ```mdx
-<ExampleBlock variant="do">Use semantic HTML elements like `<button>` for interactive controls.</ExampleBlock>
+<ExampleBlock variant="prefer">Use semantic HTML elements like `<button>` for interactive controls.</ExampleBlock>
 
-<ExampleBlock variant="dont">Avoid `<div onClick>` for buttons — it lacks keyboard and accessibility support.</ExampleBlock>
+<ExampleBlock variant="avoid">Avoid `<div onClick>` for buttons — it lacks keyboard and accessibility support.</ExampleBlock>
 
 <ExampleBlock variant="neutral">Add `aria-label` when the visual context isn't available to screen readers.</ExampleBlock>
 ```
@@ -70,13 +70,13 @@ Pass a rendered component to the `preview` prop. It appears in a framed stage ab
 ```mdx
 <ExampleBlockGroup>
   <ExampleBlock
-    variant="do"
+    variant="prefer"
     preview={<Button variant="secondary">Discard</Button>}
   >
     Use a specific verb — the action is self-evident without reading surrounding text.
   </ExampleBlock>
   <ExampleBlock
-    variant="dont"
+    variant="avoid"
     preview={<Button variant="secondary">Cancel</Button>}
   >
     Avoid vague labels — users learn to dismiss without reading.
@@ -86,13 +86,13 @@ Pass a rendered component to the `preview` prop. It appears in a framed stage ab
 
 **Props:**
 
-| Prop               | Type                          | Default     | Description                                                                            |
-| ------------------ | ----------------------------- | ----------- | -------------------------------------------------------------------------------------- |
-| `variant`          | `'do' \| 'dont' \| 'neutral'` | `'neutral'` | Color and icon theme                                                                   |
-| `title`            | `string`                      | —           | Overrides the default label ("Best Practice" / "Anti-pattern" / "Tip")                 |
-| `preview`          | `ReactNode`                   | —           | Live component rendered in a framed stage                                              |
-| `previewClassName` | `string`                      | —           | Extra classes on the preview container (e.g. `tw:pb-24` for floating UI like tooltips) |
-| `children`         | `ReactNode`                   | required    | Description text below the preview                                                     |
+| Prop               | Type                               | Default     | Description                                                                            |
+| ------------------ | ---------------------------------- | ----------- | -------------------------------------------------------------------------------------- |
+| `variant`          | `'prefer' \| 'avoid' \| 'neutral'` | `'neutral'` | Color and icon theme                                                                   |
+| `title`            | `string`                           | —           | Overrides the default label ("Prefer" / "Avoid" / "Example")                           |
+| `preview`          | `ReactNode`                        | —           | Live component rendered in a framed stage                                              |
+| `previewClassName` | `string`                           | —           | Extra classes on the preview container (e.g. `tw:pb-24` for floating UI like tooltips) |
+| `children`         | `ReactNode`                        | required    | Description text below the preview                                                     |
 
 ### MDX, TypeScript, and CSF Examples
 

--- a/lib/platform-bible-react/src/storybook/example-block.component.tsx
+++ b/lib/platform-bible-react/src/storybook/example-block.component.tsx
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
-import { ThumbsUp, ThumbsDown, Lightbulb, ChevronDown } from 'lucide-react';
+import { ThumbsUp, ThumbsDown, Info, ChevronDown } from 'lucide-react';
 import { cn } from '@/utils/shadcn-ui/utils';
 
-type Variant = 'do' | 'dont' | 'neutral';
+type Variant = 'prefer' | 'avoid' | 'neutral';
 
 type ExampleBlockProps = {
   variant?: Variant;
-  /** Overrides the default label ("Best Practice" / "Anti-pattern" / "Tip") */
+  /** Overrides the default label ("Prefer" / "Avoid" / "Example") */
   title?: string;
   /** Body content of the block — typically a sentence or two explaining what the example illustrates */
   children?: React.ReactNode;
@@ -23,25 +23,25 @@ type ExampleBlockProps = {
 };
 
 const variantConfig = {
-  do: {
+  prefer: {
     Icon: ThumbsUp,
-    label: 'Best Practice',
+    label: 'Prefer',
     accentClass: 'tw:bg-teal-500',
     bgClass: 'tw:bg-teal-500/5',
     textClass: 'tw:text-teal-600 tw:dark:text-teal-400',
     iconBgClass: 'tw:bg-teal-500/15',
   },
-  dont: {
+  avoid: {
     Icon: ThumbsDown,
-    label: 'Anti-pattern',
+    label: 'Avoid',
     accentClass: 'tw:bg-rose-500',
     bgClass: 'tw:bg-rose-500/5',
     textClass: 'tw:text-rose-600 tw:dark:text-rose-400',
     iconBgClass: 'tw:bg-rose-500/15',
   },
   neutral: {
-    Icon: Lightbulb,
-    label: 'Tip',
+    Icon: Info,
+    label: 'Example',
     accentClass: 'tw:bg-sky-500',
     bgClass: 'tw:bg-sky-500/5',
     textClass: 'tw:text-sky-600 tw:dark:text-sky-400',
@@ -50,11 +50,11 @@ const variantConfig = {
 };
 
 /**
- * Color-coded documentation block for Do / Don't / Tip examples in Storybook.
+ * Color-coded documentation block for prefer / avoid / neutral examples in Storybook.
  *
- * - `variant="do"` — teal, thumbs-up, "Best Practice"
- * - `variant="dont"` — rose, thumbs-down, "Anti-pattern"
- * - `variant="neutral"` (default) — sky, lightbulb, "Tip"
+ * - `variant="prefer"` — teal, thumbs-up, "Prefer"
+ * - `variant="avoid"` — rose, thumbs-down, "Avoid"
+ * - `variant="neutral"` (default) — sky, info icon, "Example"
  *
  * Pass a live component to `preview` to render it in a framed stage. Pass source code to `code` —
  * single-line displays inline, multiline collapses and expands on click. The preview and code share
@@ -178,7 +178,7 @@ type ExampleBlockGroupProps = {
 
 /**
  * Lays out two `ExampleBlock`s side by side on medium+ screens, stacked on mobile. Typically used
- * to show a Do and Don't example together.
+ * to show a Prefer and Avoid example together.
  */
 export function ExampleBlockGroup({ children, className }: ExampleBlockGroupProps) {
   return (


### PR DESCRIPTION
## Summary

- Add a new **Keyboard shortcuts** guidelines doc (`keyboard-shortcuts.mdx`) with a per-OS reference table covering Command, Option/Alt, Control, Shift, Caps Lock, Tab, Return, Backspace/Delete, Escape, Space, arrows, Page Up/Down, and Home/End — plus modifier-combining order and a runtime platform-branching snippet.
- Add a second anti-pattern to the keyboard-shortcuts section in Design Principles: writing macOS shortcuts with spelled-out modifier words (e.g. `Cmd+Z`) instead of the platform symbols (`⌘Z`). Each OS has its own convention; the app should match it.
- Cross-link the two docs: Design Principles points to Keyboard shortcuts for the full reference, and Keyboard shortcuts points back to Design Principles for `<kbd>` / `Kbd` rendering guidance.
- Update `ExampleBlock` component and all MDX usages to use the renamed variants (`prefer`/`avoid` replacing `do`/`dont`), fixing the deprecation flagged in review.

## Test plan

- [ ] Open Storybook and verify the new **Guidelines → Keyboard shortcuts** page renders, the per-OS table is readable, and the link back to Design Principles works
- [ ] On the **Design Principles** page, verify the keyboard-shortcuts section now shows two "avoid" anti-patterns (`Undo (⌘Z)` and `Undo Cmd+Z`) and the link to the new doc works
- [ ] Verify `ExampleBlock` renders correctly with the new `prefer`/`avoid`/`neutral` variant values

https://claude.ai/code/session_01Nu7vXcc4QJyqi2yBhQLBR9

---
_Generated by [Claude Code](https://claude.ai/code/session_01Nu7vXcc4QJyqi2yBhQLBR9)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2341)
<!-- Reviewable:end -->
