### PR TITLE
PT-3989: S/R active project on shutdown in Simple mode; skip in Power mode

### DIFF
--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -25,6 +25,7 @@ import { MutableRefObject } from 'react';
 import { EditorRef } from '@eten-tech-foundation/platform-editor';
 import { MarkerMenuItem } from 'platform-bible-react';
 
+// Note: src/main/shutdown-tasks.ts has a copy of this value — keep them in sync.
 export const SCRIPTURE_EDITOR_WEBVIEW_TYPE = 'platformScriptureEditor.react';
 
 /**

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -27,6 +27,7 @@ import { extensionAssetProtocolService } from '@main/services/extension-asset-pr
 import { extensionHostService } from '@main/services/extension-host.service';
 import { startNetworkObjectStatusService } from '@main/services/network-object-status.service-host';
 import { startProjectLookupService } from '@main/services/project-lookup.service-host';
+import { performShutdownTasks } from '@main/shutdown-tasks';
 import { HANDLE_URI_REQUEST_TYPE } from '@node/services/extension.service-model';
 import {
   CommandLineArgs,
@@ -41,7 +42,7 @@ import {
   MAX_ZOOM_FACTOR,
   MIN_ZOOM_FACTOR,
 } from '@shared/data/platform.data';
-import { CATEGORY_COMMAND, GET_METHODS } from '@shared/data/rpc.model';
+import { GET_METHODS } from '@shared/data/rpc.model';
 import { PROJECT_INTERFACE_PLATFORM_BASE } from '@shared/models/project-data-provider.model';
 import * as commandService from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
@@ -50,16 +51,11 @@ import { networkObjectService } from '@shared/services/network-object.service';
 import * as networkService from '@shared/services/network.service';
 import { get } from '@shared/services/project-data-provider.service';
 import { settingsService } from '@shared/services/settings.service';
-import {
-  NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
-  WebViewServiceType,
-} from '@shared/services/web-view.service-model';
 import { initialize as initializeSharedStoreService } from '@shared/services/shared-store.service';
-import { serializeRequestType, SerializedRequestType } from '@shared/utils/util';
+import { SerializedRequestType } from '@shared/utils/util';
 import windowStateKeeper from 'electron-window-state';
 import { CommandNames } from 'papi-shared-types';
 import {
-  AsyncVariable,
   getErrorMessage,
   isPlatformError,
   serialize,
@@ -150,7 +146,6 @@ if (!isFirstInstance) {
 // #endregion
 
 const PROCESS_CLOSE_TIME_OUT_MS = 2000;
-const SHUTDOWN_SYNC_TIME_OUT_MS = 10 * 60 * 1000; // 10 minutes
 
 /** Height of the custom title bar buttons on Windows */
 const TITLE_BAR_BUTTON_HEIGHT = 47;
@@ -529,66 +524,6 @@ async function main() {
           logger.info(`Failed to build the macOS menubar ${error}`);
         }
       })();
-    }
-
-    // Runs cleanup tasks (e.g., syncing projects) when the user closes the main window.
-    async function performShutdownTasks(): Promise<void> {
-      // Power mode: close immediately — no automatic S/R on shutdown.
-      const interfaceMode = await settingsService.get('platform.interfaceMode');
-      if (interfaceMode !== 'simple') return;
-
-      // Simple mode: cancel any in-progress sync first (e.g. a first-sync on startup), then S/R
-      // the active project. All errors are swallowed — extension may not be installed or may fail.
-      // Shutdown must never be permanently blocked.
-      // ENHANCE: cancelSync only cancels a full syncProjects, not a sendReceiveProjects (PT-3989).
-      try {
-        await networkService.requestNoRetry(
-          serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.cancelSync'),
-        );
-      } catch {
-        /* no sync in progress, or extension unavailable */
-      }
-
-      // S/R only the currently open writable Scripture Editor's project.
-      // If only a read-only Resource Viewer is open (no local changes possible), skip S/R.
-      let projectId: string | undefined;
-      try {
-        const webViewService = await networkObjectService.get<WebViewServiceType>(
-          NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
-        );
-        const openDefs = await webViewService?.getAllOpenWebViewDefinitions();
-        const activeEditor = openDefs?.find(
-          (def) => def.webViewType === 'platformScriptureEditor.react' && !def.state?.isReadOnly,
-        );
-        projectId = activeEditor?.projectId;
-      } catch {
-        /* WebView service unavailable */
-      }
-
-      if (!projectId) return;
-
-      logger.info('Syncing project on shutdown...');
-
-      const syncProjectId = projectId;
-      const syncComplete = new AsyncVariable<void>('shutdown sync', SHUTDOWN_SYNC_TIME_OUT_MS);
-      (async () => {
-        try {
-          await networkService.requestNoRetry(
-            serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.sendReceiveProjects'),
-            [syncProjectId],
-          );
-          if (!syncComplete.hasTimedOut) syncComplete.resolveToValue(undefined);
-        } catch {
-          // sync failed — settle anyway
-          if (!syncComplete.hasTimedOut) syncComplete.resolveToValue(undefined);
-        }
-      })();
-      try {
-        await syncComplete.promise;
-        logger.info('Sync on shutdown complete');
-      } catch {
-        /* timed out */
-      }
     }
 
     // The reason this code is here and not in the `app.on('will-quit')` code is that the

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -50,6 +50,10 @@ import { networkObjectService } from '@shared/services/network-object.service';
 import * as networkService from '@shared/services/network.service';
 import { get } from '@shared/services/project-data-provider.service';
 import { settingsService } from '@shared/services/settings.service';
+import {
+  NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
+  WebViewServiceType,
+} from '@shared/services/web-view.service-model';
 import { initialize as initializeSharedStoreService } from '@shared/services/shared-store.service';
 import { serializeRequestType, SerializedRequestType } from '@shared/utils/util';
 import windowStateKeeper from 'electron-window-state';
@@ -527,6 +531,66 @@ async function main() {
       })();
     }
 
+    // Runs cleanup tasks (e.g., syncing projects) when the user closes the main window.
+    async function performShutdownTasks(): Promise<void> {
+      // Power mode: close immediately — no automatic S/R on shutdown.
+      const interfaceMode = await settingsService.get('platform.interfaceMode');
+      if (interfaceMode !== 'simple') return;
+
+      // Simple mode: cancel any in-progress sync first (e.g. a first-sync on startup), then S/R
+      // the active project. All errors are swallowed — extension may not be installed or may fail.
+      // Shutdown must never be permanently blocked.
+      // ENHANCE: cancelSync only cancels a full syncProjects, not a sendReceiveProjects (PT-3989).
+      try {
+        await networkService.requestNoRetry(
+          serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.cancelSync'),
+        );
+      } catch {
+        /* no sync in progress, or extension unavailable */
+      }
+
+      // S/R only the currently open writable Scripture Editor's project.
+      // If only a read-only Resource Viewer is open (no local changes possible), skip S/R.
+      let projectId: string | undefined;
+      try {
+        const webViewService = await networkObjectService.get<WebViewServiceType>(
+          NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
+        );
+        const openDefs = await webViewService?.getAllOpenWebViewDefinitions();
+        const activeEditor = openDefs?.find(
+          (def) => def.webViewType === 'platformScriptureEditor.react' && !def.state?.isReadOnly,
+        );
+        projectId = activeEditor?.projectId;
+      } catch {
+        /* WebView service unavailable */
+      }
+
+      if (!projectId) return;
+
+      logger.info('Syncing project on shutdown...');
+
+      const syncProjectId = projectId;
+      const syncComplete = new AsyncVariable<void>('shutdown sync', SHUTDOWN_SYNC_TIME_OUT_MS);
+      (async () => {
+        try {
+          await networkService.requestNoRetry(
+            serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.sendReceiveProjects'),
+            [syncProjectId],
+          );
+          if (!syncComplete.hasTimedOut) syncComplete.resolveToValue(undefined);
+        } catch {
+          // sync failed — settle anyway
+          if (!syncComplete.hasTimedOut) syncComplete.resolveToValue(undefined);
+        }
+      })();
+      try {
+        await syncComplete.promise;
+        logger.info('Sync on shutdown complete');
+      } catch {
+        /* timed out */
+      }
+    }
+
     // The reason this code is here and not in the `app.on('will-quit')` code is that the
     // `will-quit` event only gets triggered after all windows have been closed (including this
     // one). According to the documentation the event sequence goes
@@ -545,42 +609,13 @@ async function main() {
       event.preventDefault();
       isWindowClosing = true;
 
-      logger.info('Syncing projects on shutdown...');
-
-      // Cancel any in-progress sync, then run a fresh full sync before shutdown.
-      // All errors are swallowed — extension may not be installed, or sync may fail.
-      // Shutdown must never be permanently blocked.
       try {
-        await networkService.requestNoRetry(
-          serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.cancelSync'),
-        );
-      } catch {
-        /* no sync in progress, or extension unavailable */
+        await performShutdownTasks();
+      } finally {
+        // `event.preventDefault()` above suppresses Electron's default close; destroy() here
+        // triggers the 'closed' event and allows the app to quit.
+        mainWindow?.destroy();
       }
-
-      const syncComplete = new AsyncVariable<void>('shutdown sync', SHUTDOWN_SYNC_TIME_OUT_MS);
-      (async () => {
-        try {
-          await networkService.requestNoRetry(
-            serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.syncProjects'),
-            undefined, // `undefined` means sync all projects
-          );
-          if (!syncComplete.hasTimedOut) syncComplete.resolveToValue(undefined);
-        } catch {
-          // sync failed — settle anyway
-          if (!syncComplete.hasTimedOut) syncComplete.resolveToValue(undefined);
-        }
-      })();
-      try {
-        await syncComplete.promise;
-        logger.info('Sync on shutdown complete');
-      } catch {
-        /* timed out */
-      }
-
-      // Destroys the main window allowing the rest of the close sequence to continue. This is the
-      // equivalent of doing `mainWindow.close()` just without triggering the `close` event.
-      mainWindow?.destroy();
     });
 
     mainWindow.on('closed', async () => {

--- a/src/main/shutdown-tasks.test.ts
+++ b/src/main/shutdown-tasks.test.ts
@@ -99,4 +99,33 @@ describe('performShutdownTasks', () => {
       expect.anything(),
     );
   });
+
+  it('proceeds with S/R (simple-mode fallback) when settings service throws', async () => {
+    mockSettingsGet.mockRejectedValue(new Error('settings unavailable'));
+    mockNetworkObjectGet.mockResolvedValue(
+      makeWebViewService([
+        {
+          webViewType: 'platformScriptureEditor.react',
+          state: { isReadOnly: false },
+          projectId: 'fallback-project',
+        },
+      ]),
+    );
+    await performShutdownTasks();
+    expect(mockRequestNoRetry).toHaveBeenCalledWith(expect.stringContaining('cancelSync'));
+    expect(mockRequestNoRetry).toHaveBeenCalledWith(
+      expect.stringContaining('sendReceiveProjects'),
+      ['fallback-project'],
+    );
+  });
+
+  it('swallows unexpected errors and does not throw', async () => {
+    mockSettingsGet.mockResolvedValue('simple');
+    mockNetworkObjectGet.mockResolvedValue(makeWebViewService([]));
+    // Force an unexpected throw deep inside by making cancelSync throw a non-Error value
+    mockRequestNoRetry.mockImplementation(() => {
+      throw 'unexpected non-error throw';
+    });
+    await expect(performShutdownTasks()).resolves.toBeUndefined();
+  });
 });

--- a/src/main/shutdown-tasks.test.ts
+++ b/src/main/shutdown-tasks.test.ts
@@ -124,7 +124,7 @@ describe('performShutdownTasks', () => {
     mockNetworkObjectGet.mockResolvedValue(makeWebViewService([]));
     // Force an unexpected throw deep inside by making cancelSync throw a non-Error value
     mockRequestNoRetry.mockImplementation(() => {
-      throw 'unexpected non-error throw';
+      throw new Error('unexpected non-error throw');
     });
     await expect(performShutdownTasks()).resolves.toBeUndefined();
   });

--- a/src/main/shutdown-tasks.test.ts
+++ b/src/main/shutdown-tasks.test.ts
@@ -1,0 +1,103 @@
+import { vi } from 'vitest';
+
+vi.mock('@shared/services/settings.service', () => ({
+  settingsService: { get: vi.fn() },
+}));
+
+vi.mock('@shared/services/network.service', () => ({
+  requestNoRetry: vi.fn(),
+}));
+
+vi.mock('@shared/services/network-object.service', () => ({
+  networkObjectService: { get: vi.fn() },
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+import { settingsService } from '@shared/services/settings.service';
+import * as networkService from '@shared/services/network.service';
+import { networkObjectService } from '@shared/services/network-object.service';
+import { performShutdownTasks } from './shutdown-tasks';
+
+const mockSettingsGet = vi.mocked(settingsService.get);
+const mockRequestNoRetry = vi.mocked(networkService.requestNoRetry);
+const mockNetworkObjectGet = vi.mocked(networkObjectService.get);
+
+function makeWebViewService(defs: object[]) {
+  return {
+    getAllOpenWebViewDefinitions: vi.fn().mockResolvedValue(defs),
+    onDidDispose: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequestNoRetry.mockResolvedValue(undefined);
+});
+
+describe('performShutdownTasks', () => {
+  it('returns without any network calls when interface mode is not simple', async () => {
+    mockSettingsGet.mockResolvedValue('power');
+    await performShutdownTasks();
+    expect(mockRequestNoRetry).not.toHaveBeenCalled();
+  });
+
+  it('cancels sync but skips S/R when no Scripture Editor is open', async () => {
+    mockSettingsGet.mockResolvedValue('simple');
+    mockNetworkObjectGet.mockResolvedValue(makeWebViewService([]));
+    await performShutdownTasks();
+    expect(mockRequestNoRetry).toHaveBeenCalledWith(expect.stringContaining('cancelSync'));
+    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
+      expect.stringContaining('sendReceiveProjects'),
+      expect.anything(),
+    );
+  });
+
+  it('skips S/R when the only open Scripture Editor is read-only', async () => {
+    mockSettingsGet.mockResolvedValue('simple');
+    mockNetworkObjectGet.mockResolvedValue(
+      makeWebViewService([
+        {
+          webViewType: 'platformScriptureEditor.react',
+          state: { isReadOnly: true },
+          projectId: 'p1',
+        }, // matches SCRIPTURE_EDITOR_WEBVIEW_TYPE
+      ]),
+    );
+    await performShutdownTasks();
+    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
+      expect.stringContaining('sendReceiveProjects'),
+      expect.anything(),
+    );
+  });
+
+  it('calls sendReceiveProjects with the writable editor project id', async () => {
+    mockSettingsGet.mockResolvedValue('simple');
+    mockNetworkObjectGet.mockResolvedValue(
+      makeWebViewService([
+        {
+          webViewType: 'platformScriptureEditor.react',
+          state: { isReadOnly: false },
+          projectId: 'test-project',
+        },
+      ]),
+    );
+    await performShutdownTasks();
+    expect(mockRequestNoRetry).toHaveBeenCalledWith(
+      expect.stringContaining('sendReceiveProjects'),
+      ['test-project'],
+    );
+  });
+
+  it('skips S/R when the WebView service is unavailable', async () => {
+    mockSettingsGet.mockResolvedValue('simple');
+    mockNetworkObjectGet.mockRejectedValue(new Error('service unavailable'));
+    await performShutdownTasks();
+    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
+      expect.stringContaining('sendReceiveProjects'),
+      expect.anything(),
+    );
+  });
+});

--- a/src/main/shutdown-tasks.test.ts
+++ b/src/main/shutdown-tasks.test.ts
@@ -1,4 +1,8 @@
 import { vi } from 'vitest';
+import { settingsService } from '@shared/services/settings.service';
+import * as networkService from '@shared/services/network.service';
+import { networkObjectService } from '@shared/services/network-object.service';
+import { performShutdownTasks } from './shutdown-tasks';
 
 vi.mock('@shared/services/settings.service', () => ({
   settingsService: { get: vi.fn() },
@@ -15,11 +19,6 @@ vi.mock('@shared/services/network-object.service', () => ({
 vi.mock('@shared/services/logger.service', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
-
-import { settingsService } from '@shared/services/settings.service';
-import * as networkService from '@shared/services/network.service';
-import { networkObjectService } from '@shared/services/network-object.service';
-import { performShutdownTasks } from './shutdown-tasks';
 
 const mockSettingsGet = vi.mocked(settingsService.get);
 const mockRequestNoRetry = vi.mocked(networkService.requestNoRetry);

--- a/src/main/shutdown-tasks.ts
+++ b/src/main/shutdown-tasks.ts
@@ -25,9 +25,23 @@ const SCRIPTURE_EDITOR_WEBVIEW_TYPE = 'platformScriptureEditor.react';
  * In Power mode (or any non-Simple mode): returns immediately with no automatic S/R.
  */
 export async function performShutdownTasks(): Promise<void> {
+  try {
+    await performShutdownTasksInternal();
+  } catch (e) {
+    logger.error('Unexpected error during shutdown tasks:', e);
+  }
+}
+
+async function performShutdownTasksInternal(): Promise<void> {
   // Power mode: close immediately — no automatic S/R on shutdown.
-  const interfaceMode = await settingsService.get('platform.interfaceMode');
-  if (interfaceMode !== 'simple') return;
+  // If the setting can't be read, default to simple mode to avoid skipping S/R and risking data loss.
+  let interfaceMode: string | undefined;
+  try {
+    interfaceMode = await settingsService.get('platform.interfaceMode');
+  } catch {
+    /* settings service unavailable — treat as simple mode to avoid data loss */
+  }
+  if (interfaceMode !== undefined && interfaceMode !== 'simple') return;
 
   // Simple mode: cancel any in-progress sync first (e.g. a first-sync on startup), then S/R
   // the active project.

--- a/src/main/shutdown-tasks.ts
+++ b/src/main/shutdown-tasks.ts
@@ -1,0 +1,85 @@
+import { CATEGORY_COMMAND } from '@shared/data/rpc.model';
+import { logger } from '@shared/services/logger.service';
+import { networkObjectService } from '@shared/services/network-object.service';
+import * as networkService from '@shared/services/network.service';
+import { settingsService } from '@shared/services/settings.service';
+import {
+  NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
+  WebViewServiceType,
+} from '@shared/services/web-view.service-model';
+import { serializeRequestType } from '@shared/utils/util';
+import { AsyncVariable } from 'platform-bible-utils';
+
+const SHUTDOWN_SYNC_TIME_OUT_MS = 10 * 60 * 1000; // 10 minutes
+
+// Must match SCRIPTURE_EDITOR_WEBVIEW_TYPE in platform-scripture-editor.utils.ts.
+const SCRIPTURE_EDITOR_WEBVIEW_TYPE = 'platformScriptureEditor.react';
+
+/**
+ * Runs cleanup tasks (e.g., syncing projects) when the user closes the main window.
+ *
+ * In Simple mode: cancels any in-progress sync, then S/Rs the open writable Scripture Editor's
+ * project. All errors are swallowed — extension may not be installed, or may fail — shutdown must
+ * never be permanently blocked.
+ *
+ * In Power mode (or any non-Simple mode): returns immediately with no automatic S/R.
+ */
+export async function performShutdownTasks(): Promise<void> {
+  // Power mode: close immediately — no automatic S/R on shutdown.
+  const interfaceMode = await settingsService.get('platform.interfaceMode');
+  if (interfaceMode !== 'simple') return;
+
+  // Simple mode: cancel any in-progress sync first (e.g. a first-sync on startup), then S/R
+  // the active project.
+  try {
+    await networkService.requestNoRetry(
+      serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.cancelSync'),
+    );
+  } catch {
+    /* no sync in progress, or extension unavailable */
+  }
+
+  // S/R only the currently open writable Scripture Editor's project.
+  // If only a read-only Resource Viewer is open (no local changes possible), skip S/R.
+  let projectId: string | undefined;
+  try {
+    const webViewService = await networkObjectService.get<WebViewServiceType>(
+      NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
+    );
+    const openDefs = await webViewService?.getAllOpenWebViewDefinitions();
+    // Simple mode allows at most one writable Scripture Editor at a time, so find() is sufficient.
+    // Power mode can have multiple — revisit this if S/R on shutdown is ever extended to Power mode.
+    const activeEditor = openDefs?.find(
+      (def) => def.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE && !def.state?.isReadOnly,
+    );
+    projectId = activeEditor?.projectId;
+  } catch {
+    /* WebView service unavailable */
+  }
+
+  if (!projectId) return;
+
+  logger.info('Syncing project on shutdown...');
+
+  // Copy to a const so TypeScript knows the type is string inside the async IIFE below.
+  const syncProjectId = projectId;
+  const syncComplete = new AsyncVariable<void>('shutdown sync', SHUTDOWN_SYNC_TIME_OUT_MS);
+  (async () => {
+    try {
+      await networkService.requestNoRetry(
+        serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.sendReceiveProjects'),
+        [syncProjectId],
+      );
+      if (!syncComplete.hasTimedOut) syncComplete.resolveToValue(undefined);
+    } catch {
+      // sync failed — settle anyway
+      if (!syncComplete.hasTimedOut) syncComplete.resolveToValue(undefined);
+    }
+  })();
+  try {
+    await syncComplete.promise;
+    logger.info('Sync on shutdown complete');
+  } catch {
+    /* timed out */
+  }
+}


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-3989-change-sync-to-sr-on-shutdown

**Base**: origin/main

**Date**: 2026-05-28

**Review model**: Claude Sonnet 4.6

**Files changed**: 4 (1 original + 3 added/modified during review)

## Overview

This change implements S/R-on-shutdown for Simple mode. When the user closes the app in Simple mode, any in-progress sync is cancelled and then Send/Receive runs on the active writable Scripture Editor's project only (not a full sync of all projects). Power mode is unchanged — it closes immediately with no automatic S/R. A read-only Resource Viewer with no writable editor is also correctly skipped.

The close handler was refactored to use `try/finally` so `destroy()` is guaranteed to run exactly once regardless of whether shutdown tasks succeed or fail. During review, `performShutdownTasks()` was extracted from `main.ts` into a new `src/main/shutdown-tasks.ts` module to make it independently testable, and a 5-test suite was added.

## API Changes

None. All changes are in internal main-process code (`src/main/`) and one extension utility file. No public API surfaces (`lib/`, `papi.d.ts`, extension type declarations) were modified.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] `src/main/main.ts` (originally lines 535–592): `performShutdownTasks()` had non-trivial conditional logic (mode check, WebView service lookup, projectId guard, S/R call with async timeout/racing) with no unit tests. _(fixed during review: extracted to `src/main/shutdown-tasks.ts` with 5-test suite covering Power mode early return, no editor open, read-only editor, writable editor happy path, and WebView service unavailable)_

Author response: Author agreed the extraction was a substantial improvement worth including in this PR. All 5 tests pass.

### Minor — Consider

- [x] `src/main/shutdown-tasks.ts`: `'platformScriptureEditor.react'` was a bare string literal with no named constant. _(fixed during review: extracted to `SCRIPTURE_EDITOR_WEBVIEW_TYPE` local constant; keep-in-sync comments added in both `shutdown-tasks.ts` and `platform-scripture-editor.utils.ts`)_
- [x] `src/main/shutdown-tasks.ts`: `getAllOpenWebViewDefinitions()` returns views in dock-layout order, not focus order — harmless in Simple mode but non-obvious to a future reader. _(fixed during review: comment added explaining that Simple mode allows at most one writable Scripture Editor at a time, and flagging that Power mode would need a different approach)_
- [x] `src/main/shutdown-tasks.ts`: `const syncProjectId = projectId` copy had no explanation. _(fixed during the extraction refactor: comment added explaining the copy ensures TypeScript knows the type is `string` inside the async IIFE)_

Author response: All minor findings fixed. The keep-in-sync comment pattern for the webview type string matches normal project practice.

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- The `try/finally` refactor guarantees `destroy()` runs exactly once regardless of whether `performShutdownTasks()` throws, eliminating the prior risk of the window never closing if the sync failed.
- The `isWindowClosing` guard is correctly placed before the `try`, preventing double-close races during the async shutdown work.
- All error paths swallow exceptions with explanatory comments — shutdown is never permanently blocked.
- `state?.isReadOnly` check correctly matches the documented convention in `platform-scripture-editor.utils.ts`.
- `interfaceMode !== 'simple'` (rather than `=== 'power'`) future-proofs the guard: unknown or unset interface mode values also skip the automatic sync.
- Switching from `syncProjects` (full sync of all projects) to `sendReceiveProjects([projectId])` correctly scopes the operation — avoids touching unrelated projects on shutdown.
- Early return on `!projectId` avoids creating the `AsyncVariable` and logging when there is nothing to sync.
- Extracting `performShutdownTasks()` into its own module makes `main.ts`'s close handler significantly easier to read.

## Interview Notes

**Stated purpose**: In Simple mode, cancel any in-progress sync (e.g. a first-sync started on startup), then S/R only the currently open writable Scripture Editor's project. Power mode closes immediately with no automatic sync. This dovetails with a separate P10 work item where `cancelSync` will be extended to also cancel `sendReceiveProjects` (currently it only cancels `syncProjects`).

**On "data loss"**: The author clarified this is not data loss in the traditional sense — uncommitted local changes persist and would be picked up on the next S/R. The concern is missing an S/R opportunity at shutdown.

**On the `cancelSync` timeout**: `requestNoRetry` uses a 30-second default timeout (from `network.service.ts`), swallowed by the surrounding `catch`. It cannot block shutdown.

**On the Simple mode invariant**: Author confirmed that Simple mode's `resolveOpenEditorDispatch` enforces at most one writable Scripture Editor open at a time, making `find()` correct. A comment was added to alert future developers if this is ever extended to Power mode.

## In-Review Quality Check

Changes made during the review:

1. Extracted `performShutdownTasks()` from `src/main/main.ts` into new `src/main/shutdown-tasks.ts`, along with `SHUTDOWN_SYNC_TIME_OUT_MS` and all associated imports. Removed now-unused imports from `main.ts` (`CATEGORY_COMMAND`, `NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE`, `WebViewServiceType`, `serializeRequestType`, `AsyncVariable`).
2. Added `src/main/shutdown-tasks.test.ts` with 5 tests.
3. Extracted `'platformScriptureEditor.react'` to `SCRIPTURE_EDITOR_WEBVIEW_TYPE` constant with keep-in-sync comments in both files.
4. Added Simple-mode invariant comment to the `find()` call.
5. Added comment explaining the `syncProjectId` copy.

**TypeScript**: Clean — zero errors excluding a pre-existing `buildInfo.json` unresolved module error unrelated to these changes.

**Tests**: 5/5 passing in `src/main/shutdown-tasks.test.ts`.

## Suggested Review Focus

- [ ] **`shutdown-tasks.ts` extraction** — confirm the module split is clean and the import cleanup in `main.ts` is complete (no lingering unused imports, no missing ones).
- [ ] **Simple mode invariant** — confirm that the architecture guarantee (at most one writable Scripture Editor in Simple mode) is stable enough to rely on here without a defensive fallback.
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2343)
<!-- Reviewable:end -->
