### PR TITLE
workflow(chromatic): post verified Storybook URLs to the PR as a sticky comment

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -11,6 +11,10 @@ jobs:
     # Only run when the 'storybook-review' label is present
     if: contains(github.event.pull_request.labels.*.name, 'storybook-review')
     runs-on: ubuntu-latest
+    # Needs write access to post the chromatic-urls sticky comment back onto the PR.
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -67,6 +71,7 @@ jobs:
           echo "glob=$glob" >> "$GITHUB_OUTPUT"
 
       - name: Run Chromatic
+        id: chromatic
         uses: chromaui/action@v16
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN_10_POWER }}
@@ -81,3 +86,43 @@ jobs:
           CHROMATIC_BRANCH: ${{ github.event.pull_request.head.ref || github.ref_name }}
           CHROMATIC_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           CHROMATIC_SLUG: ${{ github.repository }}
+
+      # Post the AUTHORITATIVE Chromatic URLs back onto the PR as a sticky comment so humans (and
+      # the porting pr-updater agent) get a link that actually resolves. We do NOT reconstruct the
+      # URL from the branch name: Chromatic slugifies + truncates the branch to 37 chars
+      # (https://www.chromatic.com/docs/permalinks/), so long AI branch names produce ambiguous or
+      # non-resolving permalinks. chromaui/action exposes verified outputs — storybookUrl (the
+      # per-branch/PR preview) and buildUrl — which we surface verbatim.
+      - name: Post Chromatic URLs to PR
+        if: ${{ github.event_name == 'pull_request' && steps.chromatic.outputs.storybookUrl }}
+        uses: actions/github-script@v7
+        # Pass the action outputs through env (NOT inline ${{ }} in the script body) so nothing is
+        # string-interpolated into the JS — the safe pattern for github-script. These are
+        # chromaui/action outputs (Chromatic-generated URLs), but env + process.env keeps it
+        # injection-proof regardless.
+        env:
+          STORYBOOK_URL: ${{ steps.chromatic.outputs.storybookUrl }}
+          BUILD_URL: ${{ steps.chromatic.outputs.buildUrl }}
+        with:
+          script: |
+            const storybookUrl = process.env.STORYBOOK_URL;
+            const buildUrl = process.env.BUILD_URL;
+            const marker = '<!-- chromatic-urls -->';
+            const body = [
+              marker,
+              '## 🎨 Chromatic — Storybook Visual Review',
+              '',
+              `Storybook: ${storybookUrl}`,
+              `Build: ${buildUrl}`,
+              '',
+              '_Posted automatically by the Chromatic workflow on each publish (latest build wins)._',
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number });
+            const existing = comments.find((c) => c.body && c.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }


### PR DESCRIPTION
## Summary

Surface the **verified** Chromatic Storybook/build URLs on the PR so reviewers (and the porting `pr-updater` agent) get a link that actually resolves.

### Problem
The Chromatic workflow published to chromatic.com but never wrote the URL anywhere on the PR — reviewers had to dig into the "Publish to Chromatic" check → Details. The porting `pr-updater` *reconstructed* the link from the branch name, which is unreliable: per [Chromatic's permalink docs](https://www.chromatic.com/docs/permalinks/) the branch slug is truncated to 37 chars, so long AI branch names yield ambiguous / non-resolving hostnames (a 70-char branch → 96-char host, over the 63-char DNS label limit → NXDOMAIN).

### Fix
After the `Run Chromatic` step, capture `chromaui/action`'s authoritative outputs (`storybookUrl`, `buildUrl`) and post/update a sticky `<!-- chromatic-urls -->` comment on the PR via `actions/github-script`.

- Adds `pull-requests: write` permission (scoped to this job) + an `id` on the Chromatic step.
- URLs passed via `env:` + `process.env` in the script (injection-safe — no inline `${{ }}` interpolation in the script body).
- Idempotent: updates the existing sticky comment on re-publish (latest build wins).

### Companion PR (ai-prompts #318)
The porting `pr-updater` agent + `phase-3-implementation-ui-design` command are updated in ai-prompts #318 to (a) run the PR update *before* the P3D.3 human gate and (b) read `storybookUrl` from this `<!-- chromatic-urls -->` comment instead of string-deriving it. The comment is the contract between the two PRs.

### Testing
- YAML validated; github-script body verified to contain no inline `${{ }}` interpolation.
- Will exercise live on the next `storybook-review`-labelled Chromatic run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2345)
<!-- Reviewable:end -->
