### PR TITLE
PT-3971: Fix CancelSync to accept optional notification ID

### DIFF
--- a/c-sharp-tests/Services/NotificationServiceTests.cs
+++ b/c-sharp-tests/Services/NotificationServiceTests.cs
@@ -97,6 +97,16 @@ public class NotificationServiceTests
     }
 
     [Test]
+    public void NotificationIdConverter_DeserializesNullToken_WhenTargetIsNullable()
+    {
+        // System.Text.Json intercepts `null` before invoking the converter for nullable structs,
+        // so NotificationIdConverter.Read (which would throw on Null tokens) is never called.
+        // This is the same path StreamJsonRpc takes when cancelSync is called with no argument.
+        NotificationId? result = JsonSerializer.Deserialize<NotificationId?>("null");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
     public void NotificationIdConverter_FromJsonElement_StringElement()
     {
         var element = JsonDocument.Parse(@"""hello""").RootElement;

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -1,3 +1,5 @@
+using Paranext.DataProvider.Services;
+
 namespace Paranext.DataProvider.Projects.SendReceive;
 
 /// <summary>
@@ -95,7 +97,12 @@ internal class ParatextProjectSendReceiveService(
     /// done.
     /// Exception is thrown if this function is not implemented in the current application.
     /// </summary>
-    protected void CancelSync()
+    /// <param name="notificationId">
+    /// ID of the notification that triggered this cancel, if any. Implementations may use this to
+    /// validate that the cancel is for the expected sync operation. <see langword="null"/> when
+    /// not called from a notification (e.g., on app shutdown).
+    /// </param>
+    protected void CancelSync(NotificationId? notificationId)
     {
         throw new PlatformUnimplementedException(
             $"Command '{nameof(CancelSync)}' is not implemented in Platform.Bible. Must be running Paratext 10 Studio to use this command."

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -102,7 +102,7 @@ internal class ParatextProjectSendReceiveService(
     /// validate that the cancel is for the expected sync operation. <see langword="null"/> when
     /// not called from a notification (e.g., on app shutdown).
     /// </param>
-    protected void CancelSync(NotificationId? notificationId)
+    protected void CancelSync(NotificationId? notificationId = null)
     {
         throw new PlatformUnimplementedException(
             $"Command '{nameof(CancelSync)}' is not implemented in Platform.Bible. Must be running Paratext 10 Studio to use this command."

--- a/extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts
+++ b/extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts
@@ -124,10 +124,13 @@ declare module 'papi-shared-types' {
      * Cancels an in-progress sync operation if one is running. The process will finish dealing with
      * the current project/resource and then it will abort. It will not undo what has been done.
      *
+     * @param notificationId ID of the notification that triggered this cancel, if any.
+     *   Implementations may use this to validate that the cancel is for the expected sync
+     *   operation.
      * @throws `PlatformUnimplementedException` if not running in an application that implements
      *   this command (e.g., Paratext 10 Studio)
      */
-    'paratextBibleSendReceive.cancelSync': () => Promise<void>;
+    'paratextBibleSendReceive.cancelSync': (notificationId?: string | number) => Promise<void>;
   }
 
   export interface SettingTypes {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -553,7 +553,6 @@ async function main() {
       try {
         await networkService.requestNoRetry(
           serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.cancelSync'),
-          undefined, // not triggered from a notification
         );
       } catch {
         /* no sync in progress, or extension unavailable */

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -553,6 +553,7 @@ async function main() {
       try {
         await networkService.requestNoRetry(
           serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.cancelSync'),
+          undefined, // not triggered from a notification
         );
       } catch {
         /* no sync in progress, or extension unavailable */


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-3971-fix-cancelsync-to-accept-notification-id

**Base**: origin/main

**Date**: 2026-06-01

**Review model**: Claude Sonnet 4.6

**Files changed**: 2 (+ 1 test file added during review)

## Overview

These changes fix a JSON-RPC error that occurred when the TypeScript `cancelSync` call included a notification ID in the request. The C# `CancelSync` stub method previously had no parameters, causing StreamJsonRpc to fail when it received a request carrying a notification ID argument. The fix adds an optional `NotificationId? notificationId = null` parameter to `CancelSync` in `ParatextProjectSendReceiveService` (with an explicit `= null` default so StreamJsonRpc treats it as optional), and updates the TypeScript declaration for `paratextBibleSendReceive.cancelSync` to accept an optional `notificationId?: string | number`. The `main.ts` call site is unchanged — it passes no argument, which now correctly resolves to `null` via the C# default.

**This is the paranext-core side of the fix only.** There is a corresponding PT10-specific fix required in the `paratext-10-studio` repo, which will be a separate PR. The prompt for that work is attached to Jira issue PT-3971.

## API Changes

- `extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts`: Modified `'paratextBibleSendReceive.cancelSync'` — added optional parameter `notificationId?: string | number` (previously `() => Promise<void>`, now `(notificationId?: string | number) => Promise<void>`)

No changes to `lib/platform-bible-react/`, `lib/platform-bible-utils/`, or `lib/papi-dts/papi.d.ts`.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [x] **`NotificationIdConverter.Read` throws on `Null` tokens, but `CancelSync` takes `NotificationId?` — confirm null is safe** _(fixed during review: (1) added `NotificationIdConverter_DeserializesNullToken_WhenTargetIsNullable` test confirming System.Text.Json intercepts `null` before invoking the converter for nullable value types; (2) added `= null` default to the C# parameter so StreamJsonRpc treats it as explicitly optional; (3) reverted the `main.ts` call site to pass no argument — the C# default now handles that case cleanly.)_

Author response: Author had not confirmed this path was safe. During review it was established that `requestNoRetry` uses rest parameters, so passing no argument sends an empty params array while passing `undefined` sends `[null]`. Since StreamJsonRpc requires explicit provision of all non-defaulted parameters, the original PR's approach of passing `undefined` from `main.ts` was functionally necessary — but the cleaner fix is to give the C# parameter a `= null` default, making it truly optional from StreamJsonRpc's perspective and allowing `main.ts` to remain parameterless.

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None. `extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts` is extension-specific — no propagation needed.

## Positive Observations

- The TypeScript signature change (`() => Promise<void>` → `(notificationId?: string | number) => Promise<void>`) is non-breaking: the parameter is optional and all existing callers that pass no argument continue to work unchanged.
- The `NotificationId` struct's custom JSON converter correctly represents StreamJsonRpc's dual-mode serialization: `string | number` in TypeScript mirrors `string` vs `long` in C#, which is important because JavaScript `Map.get()` is type-sensitive (`42 !== "42"`).
- The `using Paranext.DataProvider.Services;` import was correctly added — the original file had no `using` directives.
- JSDoc on the new parameter is clear and consistent between the TypeScript declaration and the C# XML doc comment.
- The changeset is surgical: exactly two files changed from origin/main, both tightly related to the stated purpose.

## Interview Notes

- **Stated purpose**: Fix the JSON-RPC error caused by `cancelSync`'s C# implementation not expecting a notification ID in the request payload.
- **Companion PR**: There is a PT10-specific side to this fix that will be a separate PR in the `paratext-10-studio` repo. Jira PT-3971 has an attached file containing the prompt to apply the corresponding patch there. This paranext-core PR alone is not sufficient to fully resolve the issue end-to-end.
- **Null safety and `= null` default**: The original PR passed `undefined` explicitly from `main.ts` to satisfy a one-parameter C# method. During review it was established that the cleaner approach is `= null` on the C# parameter — this makes the parameter truly optional from StreamJsonRpc's perspective and allows `main.ts` to remain parameterless. Both approaches are functionally equivalent at runtime; the `= null` form is more self-documenting and places the optionality contract where it belongs (the C# API surface).
- No other tradeoffs or uncertainties were raised.

## In-Review Quality Check

Three changes were made during the review interview:

1. Added `NotificationIdConverter_DeserializesNullToken_WhenTargetIsNullable` test to `c-sharp-tests/Services/NotificationServiceTests.cs` — verified with `dotnet test --filter` (1 test, Passed).
2. Added `= null` default to `CancelSync(NotificationId? notificationId = null)` in `ParatextProjectSendReceiveService.cs`.
3. Reverted the `main.ts` call site to pass no argument (the `undefined` added in the original commit is removed).

No TypeScript files were added or modified (the `main.ts` revert is a net-zero change), so `typecheck`, `lint`, and `format` are not applicable to these in-review changes.

## Suggested Review Focus

- [ ] **Companion PR in `paratext-10-studio`**: Confirm the PT10-specific side of the fix (referenced in Jira PT-3971) is planned and will be submitted — this paranext-core PR alone is not sufficient to fully resolve the issue end-to-end.
- [ ] **`CancelSync` is still a stub** (`throw PlatformUnimplementedException`): The parameter is accepted but the implementation is deferred. Confirm the reviewer is aware this is intentional for now.
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2346)
<!-- Reviewable:end -->
