### PR TITLE
Remove redundant Spanish overrides for product name localization keys

### DIFF
--- a/assets/localization/es.json
+++ b/assets/localization/es.json
@@ -405,8 +405,6 @@
   "%overlay_commandPalette_searchPlaceholder%": "Buscar...",
   "%overlay_commandPalette_noResults%": "No se encontraron resultados",
   "%overlay_workspaceUpdating%": "Actualizando la vista del proyecto",
-  "%product_name%": "Platform.Bible",
-  "%product_shortName%": "Platform",
   "%project_full_name_missing%": "*Falta el Nombre*",
   "%project_language_missing%": "*Falta el Idioma*",
   "%project_name_missing%": "_SinNombre_",


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: remove-es-product-name-overrides

**Base**: origin/main

**Date**: 2026-06-01

**Review model**: Claude Sonnet 4.6

**Files changed**: 1

## Overview

This change removes two Spanish localization overrides — `%product_name%` (`"Platform.Bible"`) and `%product_shortName%` (`"Platform"`) — from `assets/localization/es.json`. Because these values were identical to the English fallbacks defined in `en.json`, they had no effect on the rendered UI: the localization system would have produced the same output with or without them.

The removal reduces unnecessary maintenance burden and, importantly, simplifies the process of patching the file for whitelabel products. Whitelabel builds typically need to override these product name keys; having redundant identical overrides in `es.json` required extra patching effort to keep things consistent. With the overrides removed, a whitelabel patch to `en.json` is sufficient, and `es.json` inherits it automatically through the fallback chain.

## API Changes

None. The only changed file is `assets/localization/es.json`, which is not part of any public API surface (`lib/platform-bible-react/`, `lib/platform-bible-utils/`, `papi.d.ts`, or extension type declarations).

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

None.

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- The removed overrides were byte-for-byte identical to their English counterparts, so no translation meaning was lost and runtime behavior is unchanged.
- The canonical definitions remain in `en.json`; all usages in `src/` and `extensions/` continue to resolve correctly through the English fallback.
- Alphabetical ordering of the remaining keys in `es.json` is preserved after the removal (`%overlay_workspaceUpdating%` is directly followed by `%project_full_name_missing%`, which is correct).
- Other locale files (`fr.json`, `km.json`, `zh-hans.json`, `zh-hant.json`) did not have these redundant overrides to begin with, so the Spanish file is now consistent with the rest of the locale set.
- The change is minimal and precisely scoped — exactly two lines removed, no unrelated edits.

## Interview Notes

Author's stated purpose: the Spanish overrides for `%product_name%` and `%product_shortName%` were identical to the English values, making them redundant. In addition to being unnecessary noise, they created extra work when patching `es.json` for whitelabel products. Removing them means whitelabel builds only need to patch the product name in `en.json`, and `es.json` inherits the customized value through the normal fallback chain without any additional effort.

No unresolved items. The rationale is clear and the implementation is correct.

## Suggested Review Focus

- [ ] **Confirm the whitelabel patching workflow assumption**: verify that the whitelabel build process patches `en.json` (not `es.json` directly) for product name overrides, so the fallback-chain approach works as intended after this change.
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2348)
<!-- Reviewable:end -->
