### PR TITLE
PT-3991: fixed model text saying no model text found

### DIFF
--- a/extensions/src/platform-scripture-editor/src/model-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/model-text-panel.web-view.tsx
@@ -82,14 +82,17 @@ globalThis.webViewComponent = function ModelTextPanel({
   const [resourcesPossiblyUndefined, isLoadingResources] = usePromise(
     useCallback(async () => {
       if (fetchResources) {
-        const cachedResources = await papi.commands.sendCommand(
-          'platformGetResources.getCachedResources',
-        );
+        // Sets the `fetchResources` flag to false which will trigger the promise again next render
+        // to fetch the resources
         setFetchResources(false);
-        return cachedResources;
+        return Promise.resolve(undefined);
       }
 
-      return Promise.resolve(undefined);
+      const cachedResources = await papi.commands.sendCommand(
+        'platformGetResources.getCachedResources',
+      );
+      setFetchResources(false);
+      return cachedResources;
     }, [fetchResources]),
     undefined,
   );
@@ -250,10 +253,13 @@ globalThis.webViewComponent = function ModelTextPanel({
   }
 
   // Zero state: no model text configured (or still loading)
-  if (!effectiveModelTexts || effectiveModelTexts.items.length === 0) {
+  if (isLoadingResources || !effectiveModelTexts || effectiveModelTexts.items.length === 0) {
     return (
       <div className="tw:flex tw:h-screen tw:flex-col tw:items-center tw:justify-center tw:gap-4 tw:p-8 tw:text-center">
-        {isEffectiveModelTextsLoading ? (
+        {/* Also shows spinner for if loading resources, except if there is no model text then */}
+        {/* it should directly show the button to pick a model text bellow */}
+        {isEffectiveModelTextsLoading ||
+        (isLoadingResources && effectiveModelText && effectiveModelTexts.items.length !== 0) ? (
           <Spinner />
         ) : (
           <>
@@ -287,7 +293,7 @@ globalThis.webViewComponent = function ModelTextPanel({
   }
 
   // Loading state: USJ not yet fetched (usjPossiblyError is undefined while the subscription is initializing)
-  if (isLoadingResources || !resourceProjectId || usjPossiblyError === undefined) {
+  if (!resourceProjectId || usjPossiblyError === undefined) {
     return (
       <div className="tw:flex tw:h-screen tw:items-center tw:justify-center tw:p-8 tw:text-center">
         <Spinner />

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -1,9 +1,8 @@
 import { Editorial, EditorOptions, EditorRef } from '@eten-tech-foundation/platform-editor';
 import { EMPTY_USJ } from '@eten-tech-foundation/scripture-utilities';
 import type { WebViewProps } from '@papi/core';
-import { logger } from '@papi/frontend';
+import papi, { logger } from '@papi/frontend';
 import {
-  useData,
   useDataProvider,
   useDialogCallback,
   useLocalizedStrings,
@@ -20,6 +19,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
   Spinner,
+  usePromise,
 } from 'platform-bible-react';
 import {
   DblResourceData,
@@ -29,7 +29,7 @@ import {
   ResourceType,
 } from 'platform-bible-utils';
 import { ChevronDown } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { DblResourceReference, EffectiveResourceReference } from 'platform-scripture';
 import { useEffectiveResourceReferenceList } from './use-effective-resource-reference-list.hook';
 import { isDblResourceReference, isProjectReference } from './resource-reference.utils';
@@ -166,14 +166,28 @@ globalThis.webViewComponent = function ResourceTextPanel({
     projectId,
   );
 
+  const [fetchResources, setFetchResources] = useState(true);
   const dblResourcesProvider = useDataProvider('platformGetResources.dblResourcesProvider');
-  const [resourcesPossiblyError] = useData(
-    'platformGetResources.dblResourcesProvider',
-  ).DblResources(undefined, []);
-  // Memoize to prevent a new [] reference on every render when resourcesPossiblyError is an error
+  const [resourcesPossiblyUndefined, isLoadingResources] = usePromise(
+    useCallback(async () => {
+      if (fetchResources) {
+        // Sets the `fetchResources` flag to false which will trigger the promise again next render
+        // to fetch the resources
+        setFetchResources(false);
+        return Promise.resolve(undefined);
+      }
+
+      const cachedResources = await papi.commands.sendCommand(
+        'platformGetResources.getCachedResources',
+      );
+      setFetchResources(false);
+      return cachedResources;
+    }, [fetchResources]),
+    undefined,
+  );
   const dblResources = useMemo(
-    () => (isPlatformError(resourcesPossiblyError) ? [] : resourcesPossiblyError),
-    [resourcesPossiblyError],
+    () => resourcesPossiblyUndefined ?? [],
+    [resourcesPossiblyUndefined],
   );
 
   // #endregion
@@ -365,7 +379,9 @@ globalThis.webViewComponent = function ResourceTextPanel({
     );
   }
 
-  if (!effectiveResources) {
+  // Also shows spinner for if loading resources, except if there is no resources then it should
+  // directly show the button to pick a resource bellow
+  if (!effectiveResources || (isLoadingResources && filteredResources.length !== 0)) {
     return (
       <div className="tw:flex tw:h-screen tw:items-center tw:justify-center tw:p-8 tw:text-center">
         <Spinner />


### PR DESCRIPTION
Fixed PT-3991 bug (breaking bug) and also implemented the `getCachedResources` command in the resource text

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2350)
<!-- Reviewable:end -->
