### PR TITLE
fix: fixed no get resources bug and removed redundant code

### DIFF
--- a/extensions/src/platform-get-resources/src/get-resources.web-view.tsx
+++ b/extensions/src/platform-get-resources/src/get-resources.web-view.tsx
@@ -205,6 +205,8 @@ globalThis.webViewComponent = function GetResourcesDialog({ useWebViewState }: W
   const [resources, isLoadingResources] = usePromise(
     useCallback(async () => {
       if (fetchResources) {
+        // Sets the `fetchResources` flag to false which will trigger the promise again next render
+        // to fetch the resources
         setFetchResources(false);
         return papi.commands.sendCommand('platformGetResources.getCachedResources');
       }

--- a/extensions/src/platform-scripture-editor/src/model-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/model-text-panel.web-view.tsx
@@ -88,11 +88,7 @@ globalThis.webViewComponent = function ModelTextPanel({
         return Promise.resolve(undefined);
       }
 
-      const cachedResources = await papi.commands.sendCommand(
-        'platformGetResources.getCachedResources',
-      );
-      setFetchResources(false);
-      return cachedResources;
+      return papi.commands.sendCommand('platformGetResources.getCachedResources');
     }, [fetchResources]),
     undefined,
   );

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -177,11 +177,7 @@ globalThis.webViewComponent = function ResourceTextPanel({
         return Promise.resolve(undefined);
       }
 
-      const cachedResources = await papi.commands.sendCommand(
-        'platformGetResources.getCachedResources',
-      );
-      setFetchResources(false);
-      return cachedResources;
+      return papi.commands.sendCommand('platformGetResources.getCachedResources');
     }, [fetchResources]),
     undefined,
   );


### PR DESCRIPTION
Implements a similar fix as the PR I pushed yesterday to account for the actual behavior of the `usePromise` hook to make it so that the fetched promise value doesn't get overriden.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2351)
<!-- Reviewable:end -->
