### PR TITLE
searchbar: fix spacing and hover behavior of x button

### DIFF
--- a/lib/platform-bible-react/src/components/basics/search-bar.component.tsx
+++ b/lib/platform-bible-react/src/components/basics/search-bar.component.tsx
@@ -66,7 +66,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
         <Input
           ref={inputRef}
           className={cn(
-            'tw:w-full tw:overflow-hidden tw:text-ellipsis tw:ps-9 tw:@max-[7rem]/search:ps-3',
+            'tw:w-full tw:overflow-hidden tw:text-ellipsis tw:text-sm tw:ps-9 tw:@max-[7rem]/search:ps-3',
             {
               'tw:pe-8': value,
             },

--- a/lib/platform-bible-react/src/components/basics/search-bar.component.tsx
+++ b/lib/platform-bible-react/src/components/basics/search-bar.component.tsx
@@ -52,19 +52,25 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
     const dir: Direction = readDirection();
 
     return (
-      <div id={id} className={cn('tw:relative', { 'tw:w-full': isFullWidth }, className)}>
+      <div
+        id={id}
+        className={cn('tw:relative tw:@container/search', { 'tw:w-full': isFullWidth }, className)}
+      >
         <Search
           className={cn(
-            'tw:absolute tw:top-1/2 tw:h-4 tw:w-4 tw:-translate-y-1/2 tw:transform tw:opacity-50',
+            'tw:absolute tw:top-1/2 tw:h-4 tw:w-4 tw:-translate-y-1/2 tw:transform tw:opacity-50 tw:@max-[7rem]/search:hidden',
             { 'tw:right-3': dir === 'rtl' },
             { 'tw:left-3': dir === 'ltr' },
           )}
         />
         <Input
           ref={inputRef}
-          className={cn('tw:w-full tw:overflow-hidden tw:text-ellipsis tw:ps-9', {
-            'tw:pe-8': value,
-          })}
+          className={cn(
+            'tw:w-full tw:overflow-hidden tw:text-ellipsis tw:ps-9 tw:@max-[7rem]/search:ps-3',
+            {
+              'tw:pe-8': value,
+            },
+          )}
           placeholder={placeholder}
           value={value}
           onChange={(e) => onSearch(e.target.value)}

--- a/lib/platform-bible-react/src/components/basics/search-bar.component.tsx
+++ b/lib/platform-bible-react/src/components/basics/search-bar.component.tsx
@@ -62,7 +62,9 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
         />
         <Input
           ref={inputRef}
-          className="tw:w-full tw:text-ellipsis tw:pe-9 tw:ps-9"
+          className={cn('tw:w-full tw:overflow-hidden tw:text-ellipsis tw:ps-9', {
+            'tw:pe-8': value,
+          })}
           placeholder={placeholder}
           value={value}
           onChange={(e) => onSearch(e.target.value)}
@@ -73,7 +75,7 @@ export const SearchBar = forwardRef<HTMLInputElement, SearchBarProps>(
             variant="ghost"
             size="icon"
             className={cn(
-              'tw:absolute tw:top-1/2 tw:h-7 tw:-translate-y-1/2 tw:transform tw:hover:bg-transparent',
+              'tw:absolute tw:inset-y-0 tw:my-auto tw:h-7',
               { 'tw:left-0': dir === 'rtl' },
               { 'tw:right-0': dir === 'ltr' },
             )}


### PR DESCRIPTION
**before:**
<img width="609" height="74" alt="image" src="https://github.com/user-attachments/assets/079635d4-365b-474f-80c0-f775cd54c77d" />
(button hover)
<img width="608" height="74" alt="image" src="https://github.com/user-attachments/assets/c09ad2b6-8f17-42a1-94b3-14652b9d1bed" />

**after:**
<img width="622" height="122" alt="image" src="https://github.com/user-attachments/assets/be7d58ec-4ec0-4212-8f98-12a5f3e3c67f" />
(button hover)
<img width="624" height="86" alt="image" src="https://github.com/user-attachments/assets/a1272343-2467-463c-8838-d4bfd490d3c7" />
<img width="219" height="80" alt="image" src="https://github.com/user-attachments/assets/3d4ea12a-b0b7-4d45-9adf-a5bad8a9d936" />
<img width="212" height="75" alt="image" src="https://github.com/user-attachments/assets/9988d5fa-2667-4a66-a089-dc2b6c21072a" />



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2359)
<!-- Reviewable:end -->
