### PR TITLE
Add tooltip UX guidelines to Storybook

### DIFF
--- a/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
@@ -1,7 +1,5 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { Button } from '@/components/shadcn-ui/button';
-import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from '@/components/shadcn-ui/tooltip';
-import { Save } from 'lucide-react';
 import { ExampleBlock, ExampleBlockGroup } from '@/storybook/example-block.component';
 
 <Meta title="Guidelines/Design Principles" />
@@ -107,121 +105,12 @@ Every icon-only button must have an `aria-label`. Screen readers cannot infer me
 
 ## Tooltips
 
-Tooltips are required for every icon button and any control without a visible label — including toolbar items. At the same time, tooltips are supplementary. If the tooltip would only repeat the visible label, omit it.
+Tooltips are required for every icon button and any control without a visible label — including
+toolbar items. Tooltips are supplementary: if the tooltip would only repeat the visible label,
+omit it. Keep tooltip text short enough to scan at a glance.
 
-<ExampleBlockGroup>
-  <ExampleBlock
-    variant="avoid"
-    previewClassName="tw:pb-8"
-    preview={
-<Button variant="outline" size="icon" aria-label="Save" >
-<Save />
-</Button>
-}
-  >
-    This icon button lacks a tooltip, so users can't learn what it means.
-  </ExampleBlock>
-
-  <ExampleBlock
-    title="Avoid redundant tooltips"
-    variant="avoid"
-    previewClassName="tw:pb-8"
-    preview={
-<TooltipProvider>
-<Tooltip open>
-<TooltipTrigger asChild>
-<Button>Save</Button>
-</TooltipTrigger>
-<TooltipContent side="bottom">Save</TooltipContent>
-</Tooltip>
-</TooltipProvider>
-}
-  >
-    The tooltip only repeats the visible label — omit it.
-  </ExampleBlock>
-</ExampleBlockGroup>
-
-Keep tooltip text short enough to scan at a glance. A tooltip is a hint, not an explanation.
-
-<ExampleBlockGroup>
-  <ExampleBlock
-    variant="avoid"
-    previewClassName="tw:pb-16"
-    preview={
-<TooltipProvider>
-<Tooltip open>
-<TooltipTrigger asChild>
-<Button variant="outline" size="icon" aria-label="Save">
-<Save />
-</Button>
-</TooltipTrigger>
-<TooltipContent side="bottom" className="tw:max-w-[200px]">Click this button to apply your changes and save the current document</TooltipContent>
-</Tooltip>
-</TooltipProvider>
-}
-  >
-    Too long to scan — a tooltip is a hint, not a sentence.
-  </ExampleBlock>
-
-  <ExampleBlock
-    variant="prefer"
-    previewClassName="tw:pb-16"
-    preview={
-<TooltipProvider>
-<Tooltip open>
-<TooltipTrigger asChild>
-<Button variant="outline" size="icon" aria-label="Save">
-<Save />
-</Button>
-</TooltipTrigger>
-<TooltipContent side="bottom">Save changes</TooltipContent>
-</Tooltip>
-</TooltipProvider>
-}
-  >
-    The tooltip adds meaning an icon alone cannot convey, and it's short enough to read at a glance.
-  </ExampleBlock>
-</ExampleBlockGroup>
-
-### Keyboard shortcuts in tooltips
-
-Render keyboard shortcut hints using the HTML `<kbd>` element, not plain text in parentheses. The `<kbd>` styling provides sufficient visual distinction on its own — no parentheses needed.
-
-<ExampleBlockGroup>
-  <ExampleBlock
-    variant="prefer"
-    preview={<span>Undo <kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
-⌘Z
-</kbd></span>}
-    code="Undo <kbd>⌘</kbd><kbd>Z</kbd>"
-  >
-    The <code>kbd</code> element provides visual distinction without extra punctuation.
-  </ExampleBlock>
-
-  <ExampleBlock variant="avoid" preview={<span>Undo (⌘Z)</span>} code="Undo (⌘Z)">
-    Parentheses blend into prose and don't signal "keyboard shortcut" to the reader.
-  </ExampleBlock>
-
-  <ExampleBlock
-    variant="avoid"
-    preview={<span>Undo <kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
-Cmd+Z
-</kbd></span>}
-    code="Undo <kbd>Cmd+Z</kbd>  // on macOS"
-  >
-    Each OS has its own convention for writing shortcuts. On macOS, modifier keys are symbols with no separator (<code>⌘Z</code>), not spelled-out words joined with <code>+</code>. See <a href="./keyboard-shortcuts.mdx">Keyboard shortcuts</a> for the full per-OS reference.
-  </ExampleBlock>
-</ExampleBlockGroup>
-
-Caveat: The shared `Kbd` component doesn't exist yet and won't until after we upgrade shadcn/ui, so style `<kbd>` inline:
-
-```tsx
-<kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
-  ⌘Z
-</kbd>
-```
-
-For which symbol or word to use per key on each OS — Command, Option, Control, Shift, Tab, Caps Lock, Space, Return, Delete, Escape, and more — see [Keyboard shortcuts](./keyboard-shortcuts.mdx).
+For full tooltip guidance — when to use a tooltip vs. a popover, keyboard-shortcut formatting,
+and patterns under consideration — see [Tooltips](./tooltips.mdx).
 
 ---
 

--- a/lib/platform-bible-react/src/stories/guidelines/tooltips.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/tooltips.mdx
@@ -1,0 +1,30 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="Guidelines/Tooltips" />
+
+# Tooltips
+
+## When to use a tooltip
+
+Use a `Tooltip` when the extra information is purely supplemental — the UI is fully usable without it,
+it is triggered only by hover or keyboard focus, and it contains no interactive elements.
+Keep tooltip text brief: a single sentence or short phrase is the target.
+
+## When to use a popover instead
+
+If the content requires keyboard focus, multiple controls, links, form fields, or any meaningful interaction,
+use a `Popover`. The tooltip role is not in the tab order and cannot contain interactive elements.
+
+A concrete example: an info icon next to "API key" could show a tooltip saying
+"Used to authenticate requests." But if the panel also includes a _Copy key_ button,
+that interaction belongs in a click-triggered popover, not a tooltip.
+
+## Exceptions — supplemental links and navigation
+
+Tooltips may contain a single text link **only when** both of the following are true:
+
+1. The link points to an article or entity that provides more context than fits in the tooltip.
+2. There is already another way for the user to reach that destination — the tooltip link is a shortcut, not the only path.
+
+The same rule applies to navigation to a specific entity described in the tooltip.
+If either condition is not met, move the link into a popover or surface it elsewhere in the UI.

--- a/lib/platform-bible-react/src/stories/guidelines/tooltips.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/tooltips.mdx
@@ -4,27 +4,30 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Tooltips
 
+See [Design Principles → Tooltips](./design-principles.mdx) for the baseline rules: tooltips are
+required on every icon button and unlabelled control, they are supplementary, and text must be short
+enough to scan at a glance.
+
+This page covers the **tooltip vs. popover decision**.
+
 ## When to use a tooltip
 
-Use a `Tooltip` when the extra information is purely supplemental — the UI is fully usable without it,
-it is triggered only by hover or keyboard focus, and it contains no interactive elements.
-Keep tooltip text brief: a single sentence or short phrase is the target.
+Use a `Tooltip` when the extra information is purely supplemental — the UI is fully usable without
+it, it is triggered only by hover or keyboard focus, and it contains no interactive elements.
 
 ## When to use a popover instead
 
-If the content requires keyboard focus, multiple controls, links, form fields, or any meaningful interaction,
-use a `Popover`. The tooltip role is not in the tab order and cannot contain interactive elements.
+Use a `Popover` when any of the following apply:
+
+- The content requires keyboard focus, multiple controls, links, form fields, or any meaningful interaction.
+- The content must stay open while the user acts on it.
+- The content includes a link or navigation to another destination.
+
+The tooltip role is not in the tab order and cannot contain interactive elements. Our `Tooltip`
+component is Radix-based — it carries `role="tooltip"` and dismisses on pointer-leave and blur,
+so a link inside it cannot be reached by keyboard and is nearly unreachable by mouse before the
+tooltip closes. If you need tooltip-like behaviour that includes a link or action, use a `Popover`.
 
 A concrete example: an info icon next to "API key" could show a tooltip saying
 "Used to authenticate requests." But if the panel also includes a _Copy key_ button,
 that interaction belongs in a click-triggered popover, not a tooltip.
-
-## Exceptions — supplemental links and navigation
-
-Tooltips may contain a single text link **only when** both of the following are true:
-
-1. The link points to an article or entity that provides more context than fits in the tooltip.
-2. There is already another way for the user to reach that destination — the tooltip link is a shortcut, not the only path.
-
-The same rule applies to navigation to a specific entity described in the tooltip.
-If either condition is not met, move the link into a popover or surface it elsewhere in the UI.

--- a/lib/platform-bible-react/src/stories/guidelines/tooltips.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/tooltips.mdx
@@ -1,12 +1,17 @@
 import { Meta } from '@storybook/addon-docs/blocks';
 import { Button } from '@/components/shadcn-ui/button';
 import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from '@/components/shadcn-ui/tooltip';
-import { Save } from 'lucide-react';
+import { Kbd, KbdGroup } from '@/components/shadcn-ui/kbd';
+import { Info, Save } from 'lucide-react';
 import { ExampleBlock, ExampleBlockGroup } from '@/storybook/example-block.component';
 
 <Meta title="Guidelines/Tooltips" />
 
 # Tooltips
+
+Tooltips are required for every icon button and any control without a visible label — including
+toolbar items. Tooltips are supplementary: if the tooltip would only repeat the visible label,
+omit it. Keep tooltip text short enough to scan at a glance.
 
 ## Required contexts
 
@@ -93,42 +98,93 @@ Tooltip text must be short enough to scan at a glance. A tooltip is a hint, not 
 
 ## Keyboard shortcuts in tooltips
 
-Render keyboard shortcut hints using the HTML `<kbd>` element, not plain text in parentheses. The
-`<kbd>` styling provides sufficient visual distinction on its own — no parentheses needed.
+Render keyboard shortcut hints using the `Kbd` component, not plain text in parentheses. The
+`Kbd` styling provides sufficient visual distinction on its own — no parentheses needed.
 
 <ExampleBlockGroup>
-  <ExampleBlock
-    variant="prefer"
-    preview={<span>Undo <kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
-⌘Z
-</kbd></span>}
-    code="Undo <kbd>⌘</kbd><kbd>Z</kbd>"
-  >
-    The <code>kbd</code> element provides visual distinction without extra punctuation.
-  </ExampleBlock>
-
   <ExampleBlock variant="avoid" preview={<span>Undo (⌘Z)</span>} code="Undo (⌘Z)">
     Parentheses blend into prose and don't signal "keyboard shortcut" to the reader.
   </ExampleBlock>
+
+  <ExampleBlock
+    variant="prefer"
+    preview={<span>Undo <KbdGroup><Kbd>⌘</Kbd><Kbd>Z</Kbd></KbdGroup></span>}
+    code="Undo <KbdGroup><Kbd>⌘</Kbd><Kbd>Z</Kbd></KbdGroup>"
+  >
+    The <code>Kbd</code> component provides visual distinction without extra punctuation.
+  </ExampleBlock>
 </ExampleBlockGroup>
-
-Caveat: The shared `Kbd` component doesn't exist yet and won't until after we upgrade shadcn/ui,
-so style `<kbd>` inline:
-
-```tsx
-<kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
-  ⌘Z
-</kbd>
-```
 
 For which symbol or word to use per key on each OS, see [Keyboard shortcuts](./keyboard-shortcuts.mdx).
 
 ---
 
-## When to use a tooltip vs. a popover
+## When to use a tooltip
 
 Use a `Tooltip` when the extra information is purely supplemental — the UI is fully usable without
 it, it is triggered only by hover or keyboard focus, and it contains no interactive elements.
+
+### Tooltip-like overlays with redundant links
+
+<ExampleBlockGroup>
+  <ExampleBlock
+    variant="neutral"
+    title="Currently valid"
+    previewClassName="tw:pb-12"
+    preview={
+<TooltipProvider>
+<Tooltip open>
+<TooltipTrigger asChild>
+<Button variant="ghost" size="icon" aria-label="API key info">
+<Info />
+</Button>
+</TooltipTrigger>
+<TooltipContent side="bottom">Used to authenticate requests.</TooltipContent>
+</Tooltip>
+</TooltipProvider>
+}
+  >
+    A tooltip with supplemental text only — no link needed.
+  </ExampleBlock>
+
+  <ExampleBlock
+    variant="under-consideration"
+    previewClassName="tw:pb-12"
+    preview={
+<div className="tw:relative tw:inline-flex tw:items-center tw:justify-center">
+<Button variant="ghost" size="icon" aria-label="API key info">
+<Info />
+</Button>
+<div className="tw:absolute tw:top-full tw:left-1/2 tw:-translate-x-1/2 tw:mt-2 tw:rounded-md tw:border tw:border-border tw:bg-popover tw:px-3 tw:py-1.5 tw:text-xs tw:text-popover-foreground tw:shadow-md tw:whitespace-nowrap">
+Used to authenticate requests.{' '}<a href="#" className="tw:text-primary tw:underline">Learn more →</a>
+</div>
+</div>
+}
+  >
+    A hover-triggered overlay that looks and feels like a tooltip but can contain a
+    single supplemental navigation link.
+  </ExampleBlock>
+</ExampleBlockGroup>
+
+**This pattern is not yet adopted.** It must not be implemented without explicit UX sign-off.
+Patterns like this need agreement across the team and a formal addition to the style guide;
+ad-hoc implementations by individual contributors are not acceptable.
+
+**If adopted, the requirements would be:**
+
+- Must use a component with an appropriate ARIA role that supports interactive content (e.g. a
+  hover-card or popover-style overlay) — **not** the `Tooltip` component, which carries
+  `role="tooltip"` and cannot safely contain links.
+- The link must be **redundant**: the same destination must already be reachable by another path
+  in the UI. The overlay link is a shortcut, never the only route. This also makes the
+  keyboard-accessibility concern acceptable — users who cannot reach the hover-triggered link can
+  always navigate to the destination the regular way.
+- A single link only. Multiple links or other interactive controls push the pattern into standard
+  Popover territory.
+
+---
+
+## When to use a popover instead
 
 Use a `Popover` when any of the following apply:
 
@@ -143,28 +199,3 @@ tooltip closes.
 A concrete example: an info icon next to "API key" could show a tooltip saying
 "Used to authenticate requests." But if the panel also includes a _Copy key_ button,
 that interaction belongs in a click-triggered popover, not a tooltip.
-
----
-
-## Under consideration — hover-triggered overlays with supplemental links
-
-<ExampleBlock variant="under-consideration">
-  **Pattern:** A hover-triggered overlay that looks and feels like a tooltip but can contain a
-  single supplemental navigation link.
-
-  **This pattern is not yet adopted.** It must not be implemented without explicit UX sign-off.
-  Patterns like this need agreement across the team and a formal addition to the style guide;
-  ad-hoc implementations by individual contributors are not acceptable.
-
-  **If adopted, the requirements would be:**
-
-  - Must use a component with an appropriate ARIA role that supports interactive content (e.g. a
-    hover-card or popover-style overlay) — **not** the `Tooltip` component, which carries
-    `role="tooltip"` and cannot safely contain links.
-  - The link must be **redundant**: the same destination must already be reachable by another path
-    in the UI. The overlay link is a shortcut, never the only route. This also makes the
-    keyboard-accessibility concern acceptable — users who cannot reach the hover-triggered link can
-    always navigate to the destination the regular way.
-  - A single link only. Multiple links or other interactive controls push the pattern into standard
-    Popover territory.
-</ExampleBlock>

--- a/lib/platform-bible-react/src/stories/guidelines/tooltips.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/tooltips.mdx
@@ -1,33 +1,170 @@
 import { Meta } from '@storybook/addon-docs/blocks';
+import { Button } from '@/components/shadcn-ui/button';
+import { Tooltip, TooltipProvider, TooltipTrigger, TooltipContent } from '@/components/shadcn-ui/tooltip';
+import { Save } from 'lucide-react';
+import { ExampleBlock, ExampleBlockGroup } from '@/storybook/example-block.component';
 
 <Meta title="Guidelines/Tooltips" />
 
 # Tooltips
 
-See [Design Principles → Tooltips](./design-principles.mdx) for the baseline rules: tooltips are
-required on every icon button and unlabelled control, they are supplementary, and text must be short
-enough to scan at a glance.
+## Required contexts
 
-This page covers the **tooltip vs. popover decision**.
+Tooltips are required for every icon button and any control without a visible label — including
+toolbar items.
 
-## When to use a tooltip
+<ExampleBlockGroup>
+  <ExampleBlock
+    variant="avoid"
+    previewClassName="tw:pb-8"
+    preview={
+<TooltipProvider>
+<Button variant="outline" size="icon" aria-label="Save">
+<Save />
+</Button>
+</TooltipProvider>
+}
+  >
+    This icon button lacks a tooltip, so users can't learn what it means.
+  </ExampleBlock>
+
+  <ExampleBlock
+    title="Avoid redundant tooltips"
+    variant="avoid"
+    previewClassName="tw:pb-8"
+    preview={
+<TooltipProvider>
+<Tooltip open>
+<TooltipTrigger asChild>
+<Button>Save</Button>
+</TooltipTrigger>
+<TooltipContent side="bottom">Save</TooltipContent>
+</Tooltip>
+</TooltipProvider>
+}
+  >
+    The tooltip only repeats the visible label — omit it.
+  </ExampleBlock>
+</ExampleBlockGroup>
+
+## Keep text short
+
+Tooltip text must be short enough to scan at a glance. A tooltip is a hint, not an explanation.
+
+<ExampleBlockGroup>
+  <ExampleBlock
+    variant="avoid"
+    previewClassName="tw:pb-16"
+    preview={
+<TooltipProvider>
+<Tooltip open>
+<TooltipTrigger asChild>
+<Button variant="outline" size="icon" aria-label="Save">
+<Save />
+</Button>
+</TooltipTrigger>
+<TooltipContent side="bottom" className="tw:max-w-[200px]">Click this button to apply your changes and save the current document</TooltipContent>
+</Tooltip>
+</TooltipProvider>
+}
+  >
+    Too long to scan — a tooltip is a hint, not a sentence.
+  </ExampleBlock>
+
+  <ExampleBlock
+    variant="prefer"
+    previewClassName="tw:pb-16"
+    preview={
+<TooltipProvider>
+<Tooltip open>
+<TooltipTrigger asChild>
+<Button variant="outline" size="icon" aria-label="Save">
+<Save />
+</Button>
+</TooltipTrigger>
+<TooltipContent side="bottom">Save changes</TooltipContent>
+</Tooltip>
+</TooltipProvider>
+}
+  >
+    The tooltip adds meaning an icon alone cannot convey, and it's short enough to read at a glance.
+  </ExampleBlock>
+</ExampleBlockGroup>
+
+## Keyboard shortcuts in tooltips
+
+Render keyboard shortcut hints using the HTML `<kbd>` element, not plain text in parentheses. The
+`<kbd>` styling provides sufficient visual distinction on its own — no parentheses needed.
+
+<ExampleBlockGroup>
+  <ExampleBlock
+    variant="prefer"
+    preview={<span>Undo <kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
+⌘Z
+</kbd></span>}
+    code="Undo <kbd>⌘</kbd><kbd>Z</kbd>"
+  >
+    The <code>kbd</code> element provides visual distinction without extra punctuation.
+  </ExampleBlock>
+
+  <ExampleBlock variant="avoid" preview={<span>Undo (⌘Z)</span>} code="Undo (⌘Z)">
+    Parentheses blend into prose and don't signal "keyboard shortcut" to the reader.
+  </ExampleBlock>
+</ExampleBlockGroup>
+
+Caveat: The shared `Kbd` component doesn't exist yet and won't until after we upgrade shadcn/ui,
+so style `<kbd>` inline:
+
+```tsx
+<kbd className="tw:rounded tw:border tw:border-border tw:bg-muted tw:px-1 tw:py-0.5 tw:text-xs tw:font-mono">
+  ⌘Z
+</kbd>
+```
+
+For which symbol or word to use per key on each OS, see [Keyboard shortcuts](./keyboard-shortcuts.mdx).
+
+---
+
+## When to use a tooltip vs. a popover
 
 Use a `Tooltip` when the extra information is purely supplemental — the UI is fully usable without
 it, it is triggered only by hover or keyboard focus, and it contains no interactive elements.
-
-## When to use a popover instead
 
 Use a `Popover` when any of the following apply:
 
 - The content requires keyboard focus, multiple controls, links, form fields, or any meaningful interaction.
 - The content must stay open while the user acts on it.
-- The content includes a link or navigation to another destination.
 
 The tooltip role is not in the tab order and cannot contain interactive elements. Our `Tooltip`
-component is Radix-based — it carries `role="tooltip"` and dismisses on pointer-leave and blur,
-so a link inside it cannot be reached by keyboard and is nearly unreachable by mouse before the
-tooltip closes. If you need tooltip-like behaviour that includes a link or action, use a `Popover`.
+component is Radix-based — it carries `role="tooltip"` and dismisses on pointer-leave and blur.
+A link inside it cannot be reached by keyboard and is nearly unreachable by mouse before the
+tooltip closes.
 
 A concrete example: an info icon next to "API key" could show a tooltip saying
 "Used to authenticate requests." But if the panel also includes a _Copy key_ button,
 that interaction belongs in a click-triggered popover, not a tooltip.
+
+---
+
+## Under consideration — hover-triggered overlays with supplemental links
+
+<ExampleBlock variant="under-consideration">
+  **Pattern:** A hover-triggered overlay that looks and feels like a tooltip but can contain a
+  single supplemental navigation link.
+
+  **This pattern is not yet adopted.** It must not be implemented without explicit UX sign-off.
+  Patterns like this need agreement across the team and a formal addition to the style guide;
+  ad-hoc implementations by individual contributors are not acceptable.
+
+  **If adopted, the requirements would be:**
+
+  - Must use a component with an appropriate ARIA role that supports interactive content (e.g. a
+    hover-card or popover-style overlay) — **not** the `Tooltip` component, which carries
+    `role="tooltip"` and cannot safely contain links.
+  - The link must be **redundant**: the same destination must already be reachable by another path
+    in the UI. The overlay link is a shortcut, never the only route. This also makes the
+    keyboard-accessibility concern acceptable — users who cannot reach the hover-triggered link can
+    always navigate to the destination the regular way.
+  - A single link only. Multiple links or other interactive controls push the pattern into standard
+    Popover territory.
+</ExampleBlock>

--- a/lib/platform-bible-react/src/storybook/example-block.component.tsx
+++ b/lib/platform-bible-react/src/storybook/example-block.component.tsx
@@ -63,8 +63,7 @@ const variantConfig = {
  * - `variant="prefer"` — teal, thumbs-up, "Prefer"
  * - `variant="avoid"` — rose, thumbs-down, "Avoid"
  * - `variant="neutral"` (default) — sky, info icon, "Example"
- * - `variant="under-consideration"` — amber, lightbulb, "Under Consideration" — for patterns that
- *   are not yet adopted and need UX sign-off before any implementation
+ * - `variant="under-consideration"` — amber, lightbulb; patterns needing UX sign-off
  *
  * Pass a live component to `preview` to render it in a framed stage. Pass source code to `code` —
  * single-line displays inline, multiline collapses and expands on click. The preview and code share

--- a/lib/platform-bible-react/src/storybook/example-block.component.tsx
+++ b/lib/platform-bible-react/src/storybook/example-block.component.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import { ThumbsUp, ThumbsDown, Info, ChevronDown } from 'lucide-react';
+import { ThumbsUp, ThumbsDown, Info, ChevronDown, Lightbulb } from 'lucide-react';
 import { cn } from '@/utils/shadcn-ui/utils';
 
-type Variant = 'prefer' | 'avoid' | 'neutral';
+type Variant = 'prefer' | 'avoid' | 'neutral' | 'under-consideration';
 
 type ExampleBlockProps = {
   variant?: Variant;
@@ -47,6 +47,14 @@ const variantConfig = {
     textClass: 'tw:text-sky-600 tw:dark:text-sky-400',
     iconBgClass: 'tw:bg-sky-500/15',
   },
+  'under-consideration': {
+    Icon: Lightbulb,
+    label: 'Under Consideration',
+    accentClass: 'tw:bg-amber-500',
+    bgClass: 'tw:bg-amber-500/5',
+    textClass: 'tw:text-amber-600 tw:dark:text-amber-400',
+    iconBgClass: 'tw:bg-amber-500/15',
+  },
 };
 
 /**
@@ -55,6 +63,8 @@ const variantConfig = {
  * - `variant="prefer"` — teal, thumbs-up, "Prefer"
  * - `variant="avoid"` — rose, thumbs-down, "Avoid"
  * - `variant="neutral"` (default) — sky, info icon, "Example"
+ * - `variant="under-consideration"` — amber, lightbulb, "Under Consideration" — for patterns that
+ *   are not yet adopted and need UX sign-off before any implementation
  *
  * Pass a live component to `preview` to render it in a framed stage. Pass source code to `code` —
  * single-line displays inline, multiline collapses and expands on click. The preview and code share


### PR DESCRIPTION
## Summary

Adds `lib/platform-bible-react/src/stories/guidelines/tooltips.mdx` — a new Guidelines page in Storybook covering:

- **When to use a tooltip** — supplemental, hover/focus-only, no interactive elements, keep text brief
- **When to use a Popover instead** — keyboard focus needed, multiple controls, links, form fields, or meaningful interaction; includes a concrete API-key example
- **Exceptions — supplemental links and navigation** — a single text link is allowed only when it points to more context than fits in the tooltip *and* there is already another path to that destination

## Test plan

- [x] `tooltips.mdx` added under `Guidelines/Tooltips` in Storybook
- [x] Open Storybook → Guidelines → Tooltips and verify the page renders correctly
- [x] Review "when to use" and "exceptions" sections for accuracy

🤖 Generated with [Claude Code](https://claude.ai/code/session_01NLJBqNxNKbiB12kX33b6ar)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2360)
<!-- Reviewable:end -->
