### PR TITLE
Fix tw className

### DIFF
--- a/extensions/src/platform-lexical-tools/src/components/dictionary/dictionary-entry-display.component.tsx
+++ b/extensions/src/platform-lexical-tools/src/components/dictionary/dictionary-entry-display.component.tsx
@@ -174,7 +174,7 @@ export function DictionaryEntryDisplay({
             {dictionaryEntry.strongsCodes.map((strongsCode) => (
               <li
                 key={strongsCode}
-                className="tw:ml-auto tw:rounded tw:bg-accent tw:px-2 tw:py-0.5 tw:text-sm tw:accent-foreground"
+                className="tw:ml-auto tw:rounded tw:bg-accent tw:px-2 tw:py-0.5 tw:text-sm tw:text-accent-foreground"
               >
                 {strongsCode}
               </li>

--- a/extensions/src/platform-lexical-tools/src/components/dictionary/domains-display.component.tsx
+++ b/extensions/src/platform-lexical-tools/src/components/dictionary/domains-display.component.tsx
@@ -36,7 +36,7 @@ export function DomainsDisplay({ domains, domainText }: DomainsDisplayProps) {
         <TooltipProvider key={domain.code}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="tw:rounded tw:bg-accent tw:px-2 tw:py-0.5 tw:text-xs tw:accent-foreground tw:flex tw:items-center tw:gap-1">
+              <span className="tw:rounded tw:bg-accent tw:px-2 tw:py-0.5 tw:text-xs tw:text-accent-foreground tw:flex tw:items-center tw:gap-1">
                 {getDomainIcon(domain.taxonomy)}
                 <span>{domain.code}</span>
                 <span>{domain.label ?? ''}</span>


### PR DESCRIPTION
`accent-foreground` isn't valid without some sort of prefix, so I updated `tw:accent-foreground` to `tw:text-accent-foreground` (recommended by both Claude and [Devin](https://app.devin.ai/review/paranext/paranext-core/pull/2362)). TBH, I cannot see a visual difference.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2362)
<!-- Reviewable:end -->
