### PR TITLE
Add .agents/ and skills-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ docs/superpowers/
 
 # cursor
 .cursor/
+
+# agent skills (managed in paranext/ai-prompts, symlinked locally)
+.agents/
+skills-lock.json


### PR DESCRIPTION
## Summary

- Adds `.agents/` and `skills-lock.json` to `.gitignore`
- These are agent skill files managed in `paranext/ai-prompts` and symlinked locally into this repo; they should not be committed here

## Test plan

- [ ] Confirm `.agents/` and `skills-lock.json` no longer appear as untracked files after installing skills locally

https://claude.ai/code/session_01BFGvtGDChpMx8GXMZMKzuS

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFGvtGDChpMx8GXMZMKzuS)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2363)
<!-- Reviewable:end -->
