### PR TITLE
fix(flaky): should open the About dialog from the Help menu

### DIFF
--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -333,12 +333,16 @@ export async function sendPapiRequestOnce<T>(
 /**
  * Poll `rpc.discover` until `methodName` appears in `result.methods` or `timeoutMs` elapses. Uses
  * the same registration map as the live PAPI server (renderer-registered commands included).
+ *
+ * `port` is optional so callers can skip it and supply only `timeoutMs`:
+ * `waitForPapiMethodRegistered(method, undefined, 120_000)`.
  */
 export async function waitForPapiMethodRegistered(
   methodName: string,
-  port: number = DEFAULT_WEBSOCKET_PORT,
+  port?: number,
   timeoutMs = 60_000,
 ): Promise<void> {
+  const resolvedPort = port ?? DEFAULT_WEBSOCKET_PORT;
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     const remaining = timeoutMs - (Date.now() - start);
@@ -346,7 +350,7 @@ export async function waitForPapiMethodRegistered(
       const result = await sendPapiRequestOnce<RpcDiscoverResult>(
         GET_METHODS,
         [],
-        port,
+        resolvedPort,
         Math.min(10_000, Math.max(1000, remaining)),
       );
       if (result.methods?.some((m) => m.name === methodName)) return;

--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -16,6 +16,9 @@ test.describe('UI Interaction', () => {
   // which blocks until `extensionService.initialize()` finishes in the extension
   // host. On slow CI that can exceed the default 10s PAPI request timeout.
   const SLOW_CI_PAPI_TIMEOUT_MS = 30_000;
+  // macOS ARM CI runners initialize the extension host more slowly than Linux/Windows;
+  // 60 s is not enough to wait for the settings data provider to register.
+  const PAPI_REGISTRATION_TIMEOUT_MS = 120_000;
 
   test.beforeAll(async ({ electronApp }) => {
     // Maximize the window once so everything is visible and clickable for all tests
@@ -28,9 +31,10 @@ test.describe('UI Interaction', () => {
     // Force the interface language to English so menu-item text matchers
     // (e.g. /Help/i) are deterministic regardless of the developer's saved
     // platform.interfaceLanguage setting in dev-appdata.
-    // Fast-fail guard: on slow CI the settings data provider can register
-    // after this beforeAll starts; this throws a clear error if it never does.
-    await waitForPapiMethodRegistered(SETTINGS_SET_METHOD);
+    // Fast-fail guard: on slow CI (especially macOS ARM) the settings data provider can
+    // register after this beforeAll starts. Pass undefined for the port so the default
+    // is used, and a longer timeout to avoid spurious failures on slow runners.
+    await waitForPapiMethodRegistered(SETTINGS_SET_METHOD, undefined, PAPI_REGISTRATION_TIMEOUT_MS);
     await sendPapiRequestOnce(
       SETTINGS_SET_METHOD,
       ['platform.interfaceLanguage', ['en']],


### PR DESCRIPTION
## Root-cause analysis

`e2e-tests/tests/smoke/ui-interaction.spec.ts` — test **"UI Interaction › should open the About dialog from the Help menu"** — failed on every macOS ARM CI run while passing on Windows on the **same commit**.

| SHA | macOS result | Windows result |
|---|---|---|
| `1a59544b` (2026-06-04) | ❌ FAILED (job 79611875936) | ✅ PASSED (job 79611875947) |
| `20892870` (2026-06-04) | ❌ FAILED (job 79617376789) | — (cancelled) |

**Failure message (all three attempts per run):**
```
Error: PAPI method "object:platform.settingsServiceDataProvider-data.set"
       not listed in rpc.discover within 60000ms
  at waitForPapiMethodRegistered (e2e-tests/fixtures/helpers.ts:362)
```

**Why:** `beforeAll` calls `waitForPapiMethodRegistered(SETTINGS_SET_METHOD)` which polls `rpc.discover` for up to 60 s (the default). The settings-set handler internally awaits `waitForResyncContributions()` which blocks until `extensionService.initialize()` finishes in the extension host. On macOS ARM GitHub-hosted runners this takes **> 60 s**, while Linux/Windows runners finish well within the limit.

## Fix

Two small changes:

1. **`e2e-tests/fixtures/helpers.ts`** — make `port` optional (`port?: number`) in `waitForPapiMethodRegistered`. All existing callers are unaffected (explicit numbers still work; omitting the argument still uses the default port).

2. **`e2e-tests/tests/smoke/ui-interaction.spec.ts`** — add `PAPI_REGISTRATION_TIMEOUT_MS = 120_000` and pass it to `waitForPapiMethodRegistered` in `beforeAll`, giving macOS runners twice the budget without changing behaviour for Linux/Windows.

## Test plan

- [x] TypeScript compiles cleanly with the new optional-port signature (`tsc --noEmit`)
- [x] All existing callers in `comment-test-helpers.ts`, `dialog-rendering.spec.ts`, and `helpers.ts` remain valid (explicit port numbers still type-check; omitted port still resolves to default)
- [ ] Next macOS CI run on `main` should pass the `E2E tests (Windows/macOS)` step (previously failing at ~60 s, now has 120 s budget)

## Flaky CI runs re-queued

The two stalled main-branch runs have been re-triggered:
- Run [26978609495](https://github.com/paranext/paranext-core/actions/runs/26978609495) (SHA `1a59544b`)
- Run [26980242477](https://github.com/paranext/paranext-core/actions/runs/26980242477) (SHA `20892870`)

https://claude.ai/code/session_01XFMSba7aPxNuErfAwvW5m2

---
_Generated by [Claude Code](https://claude.ai/code/session_01XFMSba7aPxNuErfAwvW5m2)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2368)
<!-- Reviewable:end -->
