### PR TITLE
docs: link storybook interactivity guidelines from design principles

### DIFF
--- a/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/design-principles.mdx
@@ -232,3 +232,11 @@ All interactive UI must be keyboard navigable. Focus should be indicated by a fo
 Be aware that the focus ring sometimes goes on a **container** rather than the interactive element itself. For example, when a text input field contains buttons, the focus ring wraps the entire container — not each individual button.
 
 See also: [Responsiveness](./responsiveness.mdx) for minimum width requirements and container query guidance.
+
+---
+
+## Storybook stories
+
+Storybook stories for PAPI-coupled components (bundled-extension web views and similar) must behave like the running app — filters actually filter, search re-highlights, scope changes change the results, state transitions run, and writes reflect in the UI. A story that only renders a fixed snapshot and ignores its own controls is a bug.
+
+For the full conventions — the three-file split (`.component.tsx` / `.web-view.tsx` / `.stories.tsx`), where UI logic must live vs. what the story may mock, callback conventions, and the pre-commit verification gate — see [Storybook story guidelines](../../../../../.storybook/storybook-interactivity.md).


### PR DESCRIPTION
## Summary

- Adds a **Storybook stories** section to `lib/platform-bible-react/src/stories/guidelines/design-principles.mdx` that links to `.storybook/storybook-interactivity.md`.
- `/review-paratext`'s `ux` focus reads every file under `lib/platform-bible-react/src/stories/guidelines/`, so surfacing the link here brings the story-interactivity rules into scope for ongoing PR review.
- The new section also tells UI developers (Saroj-focused folks reading the Definition of Done) where the deeper story-authoring conventions live.

## Test plan

- [ ] Confirm the relative link `../../../../../.storybook/storybook-interactivity.md` resolves from `design-principles.mdx` (verified locally with `ls`).
- [ ] Open the rendered "Design Principles" page in Storybook and verify the new section and link appear at the bottom.
- [ ] On a future PR that touches a `*.stories.tsx`, confirm `/review-paratext` picks up the linked file's guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2378)
<!-- Reviewable:end -->
