### PR TITLE
Experimental API flag for PAPI surfaces (TSDoc + OpenRPC)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -209,6 +209,7 @@ module.exports = {
       },
       rules: {
         // Rules from jest/recommended not included in vitest/legacy-recommended
+        'vitest/expect-expect': ['error', { assertFunctionNames: ['expect', 'expectTypeOf'] }],
         'vitest/no-alias-methods': 'error',
         'vitest/no-conditional-expect': 'error',
         'vitest/no-disabled-tests': 'warn',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -208,8 +208,10 @@ module.exports = {
         'vitest/env': true,
       },
       rules: {
-        // Rules from jest/recommended not included in vitest/legacy-recommended
+        // `vitest/expect-expect` is already enabled by legacy-recommended; this only customizes
+        // `assertFunctionNames` so `expectTypeOf()` counts as an assertion.
         'vitest/expect-expect': ['error', { assertFunctionNames: ['expect', 'expectTypeOf'] }],
+        // Rules from jest/recommended not included in vitest/legacy-recommended
         'vitest/no-alias-methods': 'error',
         'vitest/no-conditional-expect': 'error',
         'vitest/no-disabled-tests': 'warn',

--- a/docs/superpowers/plans/2026-06-08-experimental-api-flag.md
+++ b/docs/superpowers/plans/2026-06-08-experimental-api-flag.md
@@ -1,0 +1,1680 @@
+# Experimental API Flag Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Introduce a uniform `experimental` marker across PAPI surfaces (TypeScript types + live OpenRPC document), and as a side-benefit add central registration for network events with shared/exclusive semantics.
+
+**Architecture:** Additive, non-breaking. The TSDoc `@experimental` tag flows through `papi.d.ts` via existing JSDOC SOURCE/DESTINATION machinery. The wire-level `x-experimental` field rides as a vendor extension on OpenRPC `Method`/`Notification`/`NetworkObjectDocumentation` types. Events become first-class in OpenRPC through a new `createNetworkEventEmitterAsync` that centrally registers with `RpcWebsocketListener`; the deprecated sync `createNetworkEventEmitter` continues working unchanged.
+
+**Tech Stack:** TypeScript, Electron, WebSocket JSON-RPC, Vitest, TypeDoc 0.28.3.
+
+**Spec:** [`../specs/2026-06-08-experimental-api-flag-design.md`](../specs/2026-06-08-experimental-api-flag-design.md)
+**Companion wiki page (must be kept in sync):** [`../specs/2026-06-08-experimental-apis-wiki-page.md`](../specs/2026-06-08-experimental-apis-wiki-page.md)
+
+---
+
+## File Structure
+
+### Created files
+
+- `src/shared/services/__tests__/network.service.shared-events.test.ts` — new Vitest file for the `SHARED_EVENT_NAMES` ↔ `SharedNetworkEventTypes` sync assertion and central-registration behavior tests.
+- `src/shared/models/__tests__/openrpc.model.test.ts` — type-shape tests (if not already covered) for the new `Notification` shape and `x-experimental` field.
+
+### Modified files (by phase)
+
+**Phase 1 — Foundational types**
+
+- `src/shared/models/openrpc.model.ts` — Method+x-experimental, new Notification type, NetworkObjectDocumentation top-level x-experimental, root `methods` accepts `Method | Notification`.
+- `src/declarations/papi-shared-types.ts` — closed `SharedNetworkEventTypes` alias + augmentable `NetworkEventTypes` interface that extends it.
+- `lib/platform-bible-utils/src/extension-contributions/menus.model.ts` — `isExperimental?: boolean` on `OrderedExtensibleContainer`, `ColumnsWithHeaders`, `WebViewMenu`, plus JSON Schema entries.
+
+**Phase 2 — Foundational runtime**
+
+- `src/shared/services/network.service.ts` — `SHARED_EVENT_NAMES` constant, `createNetworkEventEmitterAsync`, `@deprecated` on sync `createNetworkEventEmitter`, `getNetworkEvent` typed + deprecated overloads, `PapiNetworkService` interface additions.
+- `src/shared/models/rpc.interface.ts` — `registerEvent` method (parallel to `registerMethod`).
+- `src/main/services/rpc-server.ts` — `registerRemoteEvent` (parallel to `registerRemoteMethod`), `rpcEventDetailsByEventName` reference.
+- `src/main/services/rpc-websocket-listener.ts` — `rpcEventDetailsByEventName: Map<>` field, REGISTER_EVENT special-method dispatch, `generateOpenRpcSchema()` emits notifications.
+- `src/shared/data/rpc.model.ts` (or wherever `REGISTER_METHOD` is defined as a constant) — add `REGISTER_EVENT` constant.
+
+**Phase 3 — Registration surfaces**
+
+- `src/shared/services/network-object.service.ts` — fanout `documentation['x-experimental']` onto every method's docs inside `set`.
+- `src/shared/services/data-provider.service.ts` — new `NetworkObjectDocumentation` parameter on `registerEngine` and `registerEngineByType`; thread to `networkObjectService.set`.
+- `src/shared/services/web-view-provider.service.ts` — new `attributes` parameter then new `NetworkObjectDocumentation` parameter on `registerWebViewProvider`.
+- `src/shared/services/project-data-provider.service.ts` — new `attributes` + `documentation` params on `registerProjectDataProviderEngineFactory`; consume `{ projectDataProviderEngine, attributes?, documentation? }` from the factory.
+- `src/shared/models/project-data-provider-engine-factory.model.ts` — augment factory return type union.
+
+**Phase 4 — Event migration (25 sites)**
+
+- `src/shared/services/network-object.service.ts:124-144` — 2 emitters
+- `src/shared/services/shared-store.service.ts:84` — 1 emitter
+- `src/shared/services/data-provider.service.ts:817` — 1 emitter (type-assertion pattern)
+- `src/extension-host/services/extension.service.ts` — 2 emitters
+- `src/renderer/services/scroll-group.service-host.ts` — 1 emitter
+- `src/renderer/services/web-view.service-host.ts:96,101,120,128` — 4 emitters (init refactor)
+- `extensions/src/platform-scripture/src/checks/check-aggregator.service.ts:410` — 1 emitter (init refactor)
+- `extensions/src/hello-rock3/src/main.ts:462` — 1 emitter
+- `extensions/src/platform-scripture-editor/src/main.ts:286,290,1234` — 3 emitters
+- 4 test files: `src/shared/services/shared-store.service.test.ts`, `src/renderer/app.component.test.tsx`, `src/renderer/hooks/use-project-picker-data.hook.test.ts`
+
+**Phase 5 — Docs**
+
+- TSDoc additions on `Method`, `Notification`, `NetworkObjectDocumentation`, `SingleMethodDocumentation`, `SingleNotificationDocumentation` in `openrpc.model.ts`.
+- TSDoc additions on `OrderedExtensibleContainer`, `ColumnsWithHeaders`, `WebViewMenu` in `menus.model.ts`.
+- `.context/standards/Extension-Development-Guide.md` (or `Paranext-Core-Patterns.md` — pick whichever has more API-author guidance today).
+- Wiki page at `docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md` updated as each implementation task lands.
+
+---
+
+## Conventions for this plan
+
+- **TDD:** Tests come first wherever the behavior is testable. For pure type-only changes, use a small "compile-time" assertion test that asserts the shape.
+- **Commits:** Commit at the end of every task. Commit messages start with `feat(experimental):`, `refactor(experimental):`, or `docs(experimental):` and are short and specific.
+- **Test command:** `npm test -- <path> --run` (Vitest, single-run). Use `--watch` only for local iteration.
+- **Type-check command:** `npm run typecheck`
+- **Lint command:** `npm run lint` (do not auto-fix; review output)
+- **No `unknown as` chains** unless explicitly noted. The data-provider migration is the only sanctioned double-assertion site.
+- **Wiki page maintenance:** Each task that changes a behavior the wiki page documents updates the wiki page in the same commit.
+
+---
+
+## Phase 1 — Foundational types
+
+### Task 1: Extend `openrpc.model.ts` with `Notification` and `x-experimental`
+
+**Files:**
+
+- Modify: `src/shared/models/openrpc.model.ts`
+- Create: `src/shared/models/__tests__/openrpc.model.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/shared/models/__tests__/openrpc.model.test.ts`:
+
+```typescript
+import { describe, it, expectTypeOf } from 'vitest';
+import type {
+  Method,
+  Notification,
+  NetworkObjectDocumentation,
+  OpenRpc,
+  SingleNotificationDocumentation,
+} from '@shared/models/openrpc.model';
+
+describe('openrpc.model — experimental marker types', () => {
+  it('Method accepts an optional x-experimental boolean', () => {
+    const m: Method = {
+      name: 'x',
+      params: [],
+      result: { name: 'r', schema: {} },
+      'x-experimental': true,
+    };
+    expectTypeOf(m['x-experimental']).toEqualTypeOf<boolean | undefined>();
+  });
+
+  it('Notification has no result field', () => {
+    const n: Notification = {
+      name: 'x',
+      params: [],
+      'x-experimental': true,
+    };
+    // @ts-expect-error — Notification cannot have a result
+    const bad: Notification = { name: 'x', params: [], result: { name: 'r', schema: {} } };
+    void bad;
+    expectTypeOf(n.name).toEqualTypeOf<string>();
+  });
+
+  it('NetworkObjectDocumentation accepts x-experimental at top level and methods are Method[] only', () => {
+    const d: NetworkObjectDocumentation = { 'x-experimental': true, methods: [] };
+    expectTypeOf(d['x-experimental']).toEqualTypeOf<boolean | undefined>();
+  });
+
+  it('OpenRpc.methods accepts both Method and Notification', () => {
+    const doc: OpenRpc = {
+      openrpc: '1.2.6',
+      info: { title: 't', version: 'v' },
+      methods: [
+        { name: 'a', params: [], result: { name: 'r', schema: {} } },
+        { name: 'b', params: [] }, // notification
+      ],
+    };
+    expectTypeOf(doc.methods).toEqualTypeOf<(Method | Notification)[]>();
+  });
+
+  it('SingleNotificationDocumentation has notification omitting name and result', () => {
+    const d: SingleNotificationDocumentation = {
+      notification: { params: [], 'x-experimental': true },
+    };
+    expectTypeOf(d.notification).toEqualTypeOf<Omit<Omit<Method, 'result'>, 'name'>>();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — expect type-shape failures**
+
+Run: `npm test -- src/shared/models/__tests__/openrpc.model.test.ts --run`
+Expected: FAIL — `Notification`, `SingleNotificationDocumentation`, `'x-experimental'` not exported.
+
+- [ ] **Step 3: Implement the type changes in `openrpc.model.ts`**
+
+In `src/shared/models/openrpc.model.ts`, modify the `Method` type to add `'x-experimental'?: boolean;` after `result`. Add new types directly after the existing `MethodDocumentationWithoutName`:
+
+```typescript
+export type Method = {
+  /** The canonical name for the method. The name MUST be unique within the methods array. */
+  name: string;
+  params: (ContentDescriptor | Reference)[];
+  result: ContentDescriptor | Reference;
+  /**
+   * Set to `true` to mark this method as experimental — its shape may change without notice.
+   * Informational only; does not affect runtime behavior. See the experimental APIs wiki page.
+   */
+  'x-experimental'?: boolean;
+  /** A short summary of what the method does. */
+  summary?: string;
+  /** ... existing fields unchanged ... */
+  description?: string;
+  deprecated?: boolean;
+  servers?: Server[];
+  tags?: (Tag | Reference)[];
+  paramStructure?: 'by-name' | 'by-position' | 'either';
+  errors?: (Error | Reference)[];
+  links?: (Link | Reference)[];
+  examples?: (ExamplePairingObject | Reference)[];
+  externalDocs?: ExternalDocumentation;
+};
+
+/**
+ * An OpenRPC notification — same shape as a Method, but without `result`. Used for events / one-way
+ * messages from server to client. Per the OpenRPC convention (no `result` ⇒ notification), these
+ * are serialized into the same root `methods` array as Methods on the wire.
+ */
+export type Notification = Omit<Method, 'result'>;
+
+/** Documentation about a single notification */
+export type SingleNotificationDocumentation = {
+  notification: Omit<Notification, 'name'>;
+  components?: Components;
+};
+```
+
+Then update `NetworkObjectDocumentation` to add the top-level `'x-experimental'` field:
+
+```typescript
+export type NetworkObjectDocumentation = {
+  summary?: string;
+  description?: string;
+  methods?: Method[];
+  components?: Components;
+  /**
+   * Set to `true` to mark every method registered for this network object as experimental. The
+   * marker is fanned out onto each method's `'x-experimental'` field inside
+   * `networkObjectService.set`.
+   */
+  'x-experimental'?: boolean;
+};
+```
+
+And update `OpenRpc` to accept `Method | Notification` at the root:
+
+```typescript
+export type OpenRpc = {
+  openrpc: string;
+  info: Info;
+  servers?: Server[];
+  methods: (Method | Notification)[];
+  components?: Components;
+  externalDocs?: ExternalDocumentation;
+};
+```
+
+- [ ] **Step 4: Run the test — expect pass**
+
+Run: `npm test -- src/shared/models/__tests__/openrpc.model.test.ts --run`
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck — verify no downstream breakage**
+
+Run: `npm run typecheck`
+Expected: PASS. If a downstream file passed a `Method[]` where `(Method | Notification)[]` is now expected, fix the producer's typing (e.g., explicit `Method[]` cast on `NetworkObjectDocumentation.methods` consumers).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/models/openrpc.model.ts src/shared/models/__tests__/openrpc.model.test.ts
+git commit -m "feat(experimental): add Notification type and x-experimental field to openrpc.model"
+```
+
+---
+
+### Task 2: Add `SharedNetworkEventTypes` and `NetworkEventTypes` to `papi-shared-types.ts`
+
+**Files:**
+
+- Modify: `src/declarations/papi-shared-types.ts`
+
+The platform-shared event payload types referenced (`NetworkObjectDetails`, `StoreChangeEvent`) already exist in the codebase. Grep for them to confirm import paths:
+
+- `NetworkObjectDetails` — in `src/shared/models/network-object-info.model.ts` (or similar; confirm)
+- `StoreChangeEvent` — in `src/shared/services/shared-store.service.ts`
+
+- [ ] **Step 1: Add the type declarations**
+
+Insert near the other module-augmentation interfaces (e.g., after `CommandHandlers`):
+
+````typescript
+declare module 'papi-shared-types' {
+  /**
+   * Network events emitted from multiple processes (each process emits its own local event under
+   * the same name). Declared by the platform; not extensible by extensions.
+   *
+   * The names listed here are the source of truth for which event names use shared semantics at the
+   * central registry. An event name in this type allows registration from multiple processes (each
+   * process registers once, all emitters are valid sources). Any other event name uses exclusive
+   * semantics (one registrant ever).
+   *
+   * Subscribers do not need to know which events are shared — `getNetworkEvent` handles both kinds
+   * identically.
+   */
+  export type SharedNetworkEventTypes = {
+    'network-object.onDidCreateNetworkObject': NetworkObjectDetails;
+    'network-object.onDidDisposeNetworkObject': string;
+    'shared-store.onDidChange': StoreChangeEvent;
+  };
+
+  /**
+   * All known network events. Extensions augment this to declare their own events. Inherits the
+   * platform's shared events automatically.
+   *
+   * To declare a new event for use with `createNetworkEventEmitterAsync`:
+   *
+   * ```ts
+   * declare module 'papi-shared-types' {
+   *   export interface NetworkEventTypes {
+   *     'myExt.somethingHappened': { foo: string };
+   *   }
+   * }
+   * ```
+   *
+   * Mark a single event as experimental by adding `/** @experimental *\/` directly above its entry.
+   */
+  export interface NetworkEventTypes extends SharedNetworkEventTypes {}
+}
+````
+
+If `NetworkObjectDetails` or `StoreChangeEvent` aren't imported in this file, add the imports near the top.
+
+- [ ] **Step 2: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS. Confirm the new types are exported and resolvable.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/declarations/papi-shared-types.ts
+git commit -m "feat(experimental): add NetworkEventTypes and SharedNetworkEventTypes registries"
+```
+
+---
+
+### Task 3: Add `isExperimental` to menus model + JSON Schema
+
+**Files:**
+
+- Modify: `lib/platform-bible-utils/src/extension-contributions/menus.model.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to (or create) `lib/platform-bible-utils/src/extension-contributions/__tests__/menus.model.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+import {
+  menuDocumentSchema,
+  type ColumnsWithHeaders,
+  type WebViewMenu,
+  type OrderedExtensibleContainer,
+} from '../menus.model';
+
+describe('menus.model — isExperimental field', () => {
+  it('OrderedExtensibleContainer permits isExperimental', () => {
+    const c: OrderedExtensibleContainer = { order: 1, isExtensible: true, isExperimental: true };
+    expect(c.isExperimental).toBe(true);
+  });
+
+  it('ColumnsWithHeaders permits isExperimental at the columns-collection level', () => {
+    const c: ColumnsWithHeaders = { isExtensible: true, isExperimental: true };
+    expect(c.isExperimental).toBe(true);
+  });
+
+  it('WebViewMenu permits isExperimental', () => {
+    const m: WebViewMenu = {
+      includeDefaults: undefined,
+      topMenu: undefined,
+      contextMenu: undefined,
+      isExperimental: true,
+    };
+    expect(m.isExperimental).toBe(true);
+  });
+
+  it('JSON schema accepts isExperimental on column entries', () => {
+    const ajv = new Ajv({ allErrors: true });
+    const validate = ajv.compile(menuDocumentSchema);
+    const doc = {
+      mainMenu: {
+        columns: { 'a.b': { label: '%x%', order: 1, isExtensible: true, isExperimental: true } },
+        groups: {},
+        items: [],
+      },
+      defaultWebViewTopMenu: { columns: {}, groups: {}, items: [] },
+      defaultWebViewContextMenu: { groups: {}, items: [] },
+      webViewMenus: {},
+    };
+    expect(validate(doc)).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test — expect failure**
+
+Run: `npm test -- lib/platform-bible-utils/src/extension-contributions/__tests__/menus.model.test.ts --run`
+Expected: FAIL — `isExperimental` not on the types or in the schema.
+
+- [ ] **Step 3: Update the types**
+
+In `lib/platform-bible-utils/src/extension-contributions/menus.model.ts`, modify `OrderedExtensibleContainer`, add `isExperimental` to `ColumnsWithHeaders`, and add `isExperimental` to `WebViewMenu`:
+
+```typescript
+export type OrderedExtensibleContainer = OrderedItem & {
+  /** Determines whether other items can be added to this after it has been defined */
+  isExtensible?: boolean;
+  /**
+   * Set to `true` to mark this extension point as experimental. Extensions reading menu data should
+   * check this before contributing to the point. Informational only.
+   */
+  isExperimental?: boolean;
+};
+
+export type ColumnsWithHeaders = {
+  [property: ReferencedItem]: MenuColumnWithHeader;
+  /** Defines whether columns can be added to this multi-column menu */
+  isExtensible?: boolean;
+  /**
+   * Set to `true` to mark the entire columns-collection as an experimental extension point.
+   * Informational only.
+   */
+  isExperimental?: boolean;
+};
+
+export type WebViewMenu = {
+  /** Indicates whether the platform default menus should be included for this webview */
+  includeDefaults: boolean | undefined;
+  topMenu: MultiColumnMenu | undefined;
+  contextMenu: SingleColumnMenu | undefined;
+  /** Set to `true` to mark this entire WebView menu shape as experimental. Informational only. */
+  isExperimental?: boolean;
+};
+```
+
+- [ ] **Step 4: Update the JSON schema**
+
+Edit the `menuDocumentSchema` `$defs` section. Inside `columnsWithHeaders.patternProperties.<column>.properties`, add `isExperimental` next to `isExtensible`:
+
+```javascript
+isExperimental: {
+  description: 'Marks this extension point as experimental. Informational only.',
+  type: 'boolean',
+},
+```
+
+And add the same property at the `columnsWithHeaders.properties` level (the columns-collection level), in `menuGroups.patternProperties.<group>.oneOf[*].properties` (both alternatives), and in `menusForOneWebView.properties` (for `WebViewMenu`'s schema).
+
+- [ ] **Step 5: Run the test — expect pass**
+
+Run: `npm test -- lib/platform-bible-utils/src/extension-contributions/__tests__/menus.model.test.ts --run`
+Expected: PASS.
+
+- [ ] **Step 6: Update the wiki page**
+
+The wiki page already includes the menus example with `isExperimental` — no change needed for this task. Verify by skimming `docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md` § Menu extensibility.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add lib/platform-bible-utils/src/extension-contributions/menus.model.ts lib/platform-bible-utils/src/extension-contributions/__tests__/menus.model.test.ts
+git commit -m "feat(experimental): add isExperimental to menus model + JSON schema"
+```
+
+---
+
+## Phase 2 — Foundational runtime
+
+### Task 4: Add `SHARED_EVENT_NAMES` constant and sync-check test
+
+**Files:**
+
+- Modify: `src/shared/services/network.service.ts`
+- Create: `src/shared/services/__tests__/network.service.shared-events.test.ts`
+
+- [ ] **Step 1: Write the sync-check failing test**
+
+Create the file:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { SHARED_EVENT_NAMES } from '@shared/services/network.service';
+import type { SharedNetworkEventTypes } from 'papi-shared-types';
+
+describe('SHARED_EVENT_NAMES stays in sync with SharedNetworkEventTypes', () => {
+  it('contains every key of SharedNetworkEventTypes', () => {
+    type RequiredKeys = keyof SharedNetworkEventTypes;
+    const required: RequiredKeys[] = [
+      'network-object.onDidCreateNetworkObject',
+      'network-object.onDidDisposeNetworkObject',
+      'shared-store.onDidChange',
+    ];
+    for (const name of required) expect(SHARED_EVENT_NAMES.has(name)).toBe(true);
+  });
+
+  it('contains no names absent from SharedNetworkEventTypes', () => {
+    type AllowedKeys = keyof SharedNetworkEventTypes;
+    for (const name of SHARED_EVENT_NAMES) {
+      // The cast verifies the runtime constant only contains keys SharedNetworkEventTypes declares.
+      // If a new entry is added to SHARED_EVENT_NAMES without adding it to SharedNetworkEventTypes,
+      // this assignment is a type error and the test fails to compile.
+      const typed: AllowedKeys = name;
+      expect(typeof typed).toBe('string');
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+Run: `npm test -- src/shared/services/__tests__/network.service.shared-events.test.ts --run`
+Expected: FAIL — `SHARED_EVENT_NAMES` not exported.
+
+- [ ] **Step 3: Add the constant**
+
+Near the top of `src/shared/services/network.service.ts` (after imports, before the existing emitter logic):
+
+```typescript
+import type { SharedNetworkEventTypes } from 'papi-shared-types';
+
+/**
+ * Source of truth for which event names use shared semantics at the central registry. Must stay in
+ * sync with the `SharedNetworkEventTypes` type alias in `papi-shared-types.ts` — the test
+ * `network.service.shared-events.test.ts` enforces the invariant.
+ *
+ * Add entries here when adding a new shared event to `SharedNetworkEventTypes`.
+ */
+export const SHARED_EVENT_NAMES = new Set<keyof SharedNetworkEventTypes>([
+  'network-object.onDidCreateNetworkObject',
+  'network-object.onDidDisposeNetworkObject',
+  'shared-store.onDidChange',
+]);
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run: `npm test -- src/shared/services/__tests__/network.service.shared-events.test.ts --run`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/services/network.service.ts src/shared/services/__tests__/network.service.shared-events.test.ts
+git commit -m "feat(experimental): add SHARED_EVENT_NAMES constant mirroring SharedNetworkEventTypes"
+```
+
+---
+
+### Task 5: Add `REGISTER_EVENT` plumbing (constant + RPC interface + rpc-server + listener)
+
+**Files:**
+
+- Modify: `src/shared/data/rpc.model.ts` (or wherever `REGISTER_METHOD` is defined — confirm with grep)
+- Modify: `src/shared/models/rpc.interface.ts`
+- Modify: `src/main/services/rpc-server.ts`
+- Modify: `src/main/services/rpc-websocket-listener.ts`
+
+- [ ] **Step 1: Locate `REGISTER_METHOD` to mirror its plumbing**
+
+Run: `grep -rn "REGISTER_METHOD" src/`
+Expected output: shows the constant definition (likely in `src/shared/data/rpc.model.ts` or `src/main/services/rpc-server.ts`) plus its uses in the listener and the server. Mirror every appearance with a `REGISTER_EVENT` analog.
+
+- [ ] **Step 2: Add `REGISTER_EVENT` constant alongside `REGISTER_METHOD`**
+
+```typescript
+export const REGISTER_EVENT = 'register-event';
+```
+
+- [ ] **Step 3: Add `registerEvent` to the RPC interface**
+
+In `src/shared/models/rpc.interface.ts`, after the existing `registerMethod` declaration:
+
+```typescript
+/**
+ * Register a centrally-tracked network event with the main process. Determines shared vs
+ * exclusive semantics by looking up the event name in `SHARED_EVENT_NAMES`.
+ *
+ * Returns `true` if the registration was accepted, `false` otherwise. Used by
+ * `createNetworkEventEmitterAsync`; not for direct caller use.
+ */
+registerEvent(
+  eventName: string,
+  documentation?: SingleNotificationDocumentation,
+): Promise<boolean>;
+```
+
+Add an import for `SingleNotificationDocumentation` from `@shared/models/openrpc.model`.
+
+- [ ] **Step 4: Implement `registerRemoteEvent` on `RpcServer`**
+
+In `src/main/services/rpc-server.ts`, after `registerRemoteMethod`:
+
+```typescript
+registerRemoteEvent(
+  eventName: string,
+  documentation?: SingleNotificationDocumentation,
+): boolean {
+  return this.rpcEventDetailsByEventName.tryRegister(this, eventName, documentation);
+}
+
+unregisterRemoteEvent(eventName: string): boolean {
+  return this.rpcEventDetailsByEventName.tryUnregister(this, eventName);
+}
+```
+
+The `rpcEventDetailsByEventName` field is added in the next step (it's typed as a small helper class to hide the shared/exclusive lookup behind a method).
+
+- [ ] **Step 5: Add `RpcEventRegistry` helper and field on `RpcWebsocketListener`**
+
+In `src/main/services/rpc-websocket-listener.ts`, near the existing `rpcMethodDetailsByMethodName`:
+
+```typescript
+import { SHARED_EVENT_NAMES } from '@shared/services/network.service';
+import type { SingleNotificationDocumentation } from '@shared/models/openrpc.model';
+
+interface EventRegistrant {
+  handler: RpcServer | RpcWebsocketListener;
+  documentation?: SingleNotificationDocumentation;
+}
+
+class RpcEventRegistry {
+  private byName = new Map<string, EventRegistrant[]>();
+
+  tryRegister(
+    handler: RpcServer | RpcWebsocketListener,
+    eventName: string,
+    documentation?: SingleNotificationDocumentation,
+  ): boolean {
+    const isShared = SHARED_EVENT_NAMES.has(eventName as keyof SharedNetworkEventTypes);
+    const existing = this.byName.get(eventName);
+
+    if (!existing) {
+      this.byName.set(eventName, [{ handler, documentation }]);
+      return true;
+    }
+
+    if (isShared) {
+      // Reject only if THIS handler already registered (same-process duplicate).
+      if (existing.some((r) => r.handler === handler)) return false;
+      existing.push({ handler, documentation });
+      return true;
+    }
+
+    // Exclusive: any subsequent registration is rejected.
+    return false;
+  }
+
+  tryUnregister(handler: RpcServer | RpcWebsocketListener, eventName: string): boolean {
+    const existing = this.byName.get(eventName);
+    if (!existing) return false;
+    const index = existing.findIndex((r) => r.handler === handler);
+    if (index < 0) return false;
+    existing.splice(index, 1);
+    if (existing.length === 0) this.byName.delete(eventName);
+    return true;
+  }
+
+  entries(): IterableIterator<[string, EventRegistrant[]]> {
+    return this.byName.entries();
+  }
+}
+```
+
+Add `private rpcEventDetailsByEventName = new RpcEventRegistry();` as a field on `RpcWebsocketListener`. Also pass a reference to each `RpcServer` so its `registerRemoteEvent` can call into it (mirror how `rpcMethodDetailsByMethodName` is shared today).
+
+- [ ] **Step 6: Wire `REGISTER_EVENT` into the listener's special-method dispatch**
+
+In the same file, find where `REGISTER_METHOD` is matched and dispatched (parallel of `registerRemoteMethod` call). Add a sibling case:
+
+```typescript
+case REGISTER_EVENT:
+  return this.rpcEventDetailsByEventName.tryRegister(this, params[0] as string, params[1]);
+```
+
+Add an analogous case for `UNREGISTER_EVENT` if `UNREGISTER_METHOD` exists.
+
+- [ ] **Step 7: Run typecheck**
+
+Run: `npm run typecheck`
+Expected: PASS.
+
+- [ ] **Step 8: Write a behavior test**
+
+Append to `src/shared/services/__tests__/network.service.shared-events.test.ts`:
+
+```typescript
+import { RpcWebsocketListener } from '@main/services/rpc-websocket-listener'; // use the actual class path
+
+describe('central event registry — shared vs exclusive policy', () => {
+  // These are unit tests against the registry's tryRegister method. Use a minimal fake handler.
+  const fakeA = {} as never;
+  const fakeB = {} as never;
+
+  it('exclusive: first registrant wins; subsequent registrations from any handler rejected', () => {
+    const listener = new RpcWebsocketListener(/* construct as in other tests */);
+    const reg = (listener as any).rpcEventDetailsByEventName;
+    expect(reg.tryRegister(fakeA, 'myExt.exclusive')).toBe(true);
+    expect(reg.tryRegister(fakeA, 'myExt.exclusive')).toBe(false); // same handler
+    expect(reg.tryRegister(fakeB, 'myExt.exclusive')).toBe(false); // different handler
+  });
+
+  it('shared: multiple handlers may register; same handler twice rejected', () => {
+    const listener = new RpcWebsocketListener(/* */);
+    const reg = (listener as any).rpcEventDetailsByEventName;
+    expect(reg.tryRegister(fakeA, 'network-object.onDidCreateNetworkObject')).toBe(true);
+    expect(reg.tryRegister(fakeB, 'network-object.onDidCreateNetworkObject')).toBe(true);
+    expect(reg.tryRegister(fakeA, 'network-object.onDidCreateNetworkObject')).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 9: Run test — expect pass**
+
+Run: `npm test -- src/shared/services/__tests__/network.service.shared-events.test.ts --run`
+Expected: PASS.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/shared/data/rpc.model.ts src/shared/models/rpc.interface.ts src/main/services/rpc-server.ts src/main/services/rpc-websocket-listener.ts src/shared/services/__tests__/network.service.shared-events.test.ts
+git commit -m "feat(experimental): add REGISTER_EVENT RPC plumbing with shared/exclusive policy"
+```
+
+---
+
+### Task 6: Implement `createNetworkEventEmitterAsync`; deprecate sync
+
+**Files:**
+
+- Modify: `src/shared/services/network.service.ts`
+
+- [ ] **Step 1: Write the behavior test**
+
+Append to `src/shared/services/__tests__/network.service.shared-events.test.ts`:
+
+```typescript
+import { createNetworkEventEmitterAsync, getNetworkEvent } from '@shared/services/network.service';
+
+describe('createNetworkEventEmitterAsync', () => {
+  it('resolves to a functional emitter for a declared event name', async () => {
+    // Assumes test setup provides a working network service.
+    const emitter = await createNetworkEventEmitterAsync('myExt.testEvent' as never);
+    let received: unknown;
+    getNetworkEvent('myExt.testEvent' as never)((event) => {
+      received = event;
+    });
+    emitter.emit({ value: 42 } as never);
+    await new Promise((r) => setTimeout(r, 10));
+    expect((received as { value: number }).value).toBe(42);
+  });
+
+  it('rejects a second registration of the same exclusive event name within one process', async () => {
+    await createNetworkEventEmitterAsync('myExt.unique' as never);
+    await expect(createNetworkEventEmitterAsync('myExt.unique' as never)).rejects.toThrow();
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure (function not exported)**
+
+- [ ] **Step 3: Implement the function**
+
+In `src/shared/services/network.service.ts`, after the existing `createNetworkEventEmitter`:
+
+```typescript
+import type { NetworkEventTypes } from 'papi-shared-types';
+import type { SingleNotificationDocumentation } from '@shared/models/openrpc.model';
+import { REGISTER_EVENT } from '@shared/data/rpc.model';
+
+/**
+ * Create a network event emitter that participates in central registration. The returned emitter
+ * appears in the OpenRPC document if `documentation` is provided.
+ *
+ * If the event name is in `SharedNetworkEventTypes`, the central registry uses shared semantics:
+ * multiple processes may register the same name (each process registers once); all corresponding
+ * emitters are valid sources.
+ *
+ * Otherwise the registry uses exclusive semantics: only one process may register a given name;
+ * subsequent registrations from any process are rejected.
+ *
+ * Intra-process duplicate registration is always rejected regardless of the event's domain.
+ *
+ * @param eventType A key of `NetworkEventTypes` (which inherits `SharedNetworkEventTypes`).
+ * @param documentation Optional notification documentation. Carries `'x-experimental': true` to
+ *   mark the event as experimental.
+ */
+export const createNetworkEventEmitterAsync = async <EventType extends keyof NetworkEventTypes>(
+  eventType: EventType,
+  documentation?: SingleNotificationDocumentation,
+): Promise<PlatformEventEmitter<NetworkEventTypes[EventType]>> => {
+  await initialize();
+  if (!jsonRpc) throw new Error('RPC handler not set');
+  const accepted = await jsonRpc.registerEvent(eventType, documentation);
+  if (!accepted) {
+    throw new Error(
+      `Event "${eventType}" was rejected by the central registry (likely already registered from another process).`,
+    );
+  }
+  return createNetworkEventEmitterInternal<NetworkEventTypes[EventType]>(
+    eventType,
+    true,
+  ) as PlatformEventEmitter<NetworkEventTypes[EventType]>;
+};
+```
+
+- [ ] **Step 4: Add `@deprecated` to the sync variant**
+
+Update the JSDoc on `createNetworkEventEmitter` in the same file:
+
+```typescript
+/**
+ * Creates an event emitter that works properly over the network.
+ *
+ * @deprecated 8 June 2026. Use `createNetworkEventEmitterAsync`. Events created via the sync API
+ *   are not centrally registered and do not appear in the OpenRPC document. The async version
+ *   properly restricts event registration to prevent multiple sources from emitting the same
+ *   network event (unless the event is declared in `SharedNetworkEventTypes`, in which case it
+ *   accepts multiple registrants by design).
+ * @param eventType Unique network event type for coordinating between connections
+ * @returns Event emitter whose event works between connections
+ */
+export const createNetworkEventEmitter = <T>(eventType: string): PlatformEventEmitter<T> =>
+  createNetworkEventEmitterInternal(eventType, true);
+```
+
+- [ ] **Step 5: Surface `createNetworkEventEmitterAsync` on `PapiNetworkService`**
+
+In the same file, extend the `PapiNetworkService` interface and the exported instance:
+
+```typescript
+export interface PapiNetworkService {
+  /** @deprecated 8 June 2026. Use createNetworkEventEmitterAsync. */
+  createNetworkEventEmitter: typeof createNetworkEventEmitter;
+  createNetworkEventEmitterAsync: typeof createNetworkEventEmitterAsync;
+  getNetworkEvent: typeof getNetworkEvent;
+}
+
+export const papiNetworkService: PapiNetworkService = {
+  createNetworkEventEmitter,
+  createNetworkEventEmitterAsync,
+  getNetworkEvent,
+};
+```
+
+- [ ] **Step 6: Run tests — expect pass**
+
+Run: `npm test -- src/shared/services/__tests__/network.service.shared-events.test.ts --run`
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/shared/services/network.service.ts src/shared/services/__tests__/network.service.shared-events.test.ts
+git commit -m "feat(experimental): add createNetworkEventEmitterAsync; deprecate sync variant"
+```
+
+---
+
+### Task 7: Add `getNetworkEvent` typed overload + deprecate explicit-`<T>` form
+
+**Files:**
+
+- Modify: `src/shared/services/network.service.ts`
+
+- [ ] **Step 1: Write the test**
+
+Append to `src/shared/services/__tests__/network.service.shared-events.test.ts`:
+
+```typescript
+import { getNetworkEvent as gne } from '@shared/services/network.service';
+
+describe('getNetworkEvent overloads', () => {
+  it('typed call infers payload from NetworkEventTypes', () => {
+    // Compile-time test — if this compiles, the typed overload exists.
+    const ev = gne('network-object.onDidCreateNetworkObject');
+    // ev is PlatformEvent<NetworkObjectDetails>
+    void ev;
+  });
+
+  it('explicit <T> call still resolves (deprecated overload)', () => {
+    const ev = gne<{ foo: string }>('arbitraryName');
+    void ev;
+  });
+});
+```
+
+- [ ] **Step 2: Replace the single `getNetworkEvent` definition with two overloads**
+
+Update `src/shared/services/network.service.ts`:
+
+```typescript
+/**
+ * Subscribe to a typed network event. Declare the event in `NetworkEventTypes` (or rely on
+ * `SharedNetworkEventTypes` inheritance for platform events) and the payload type is inferred.
+ */
+export function getNetworkEvent<EventType extends keyof NetworkEventTypes>(
+  eventType: EventType,
+): PlatformEvent<NetworkEventTypes[EventType]>;
+/**
+ * @deprecated 8 June 2026. Use the typed signature: declare the event in `NetworkEventTypes` and
+ *   call `getNetworkEvent('your.event.name')` without an explicit type parameter. If your event
+ *   name is dynamic (e.g., per-instance data-provider events), this signature continues to work
+ *   functionally; suppress the deprecation warning at the call site with a brief comment.
+ */
+export function getNetworkEvent<T>(eventType: string): PlatformEvent<T>;
+export function getNetworkEvent(eventType: string): PlatformEvent<unknown> {
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  return createNetworkEventEmitterInternal(eventType, false).event as PlatformEvent<unknown>;
+}
+```
+
+- [ ] **Step 3: Run tests + typecheck — expect pass**
+
+Run: `npm test -- src/shared/services/__tests__/network.service.shared-events.test.ts --run && npm run typecheck`
+Expected: PASS. The typecheck may report deprecation warnings on existing call sites that use explicit `<T>` — leave those for the migration phase.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shared/services/network.service.ts src/shared/services/__tests__/network.service.shared-events.test.ts
+git commit -m "feat(experimental): add typed getNetworkEvent overload; deprecate explicit-T form"
+```
+
+---
+
+### Task 8: Emit notifications in `generateOpenRpcSchema()`
+
+**Files:**
+
+- Modify: `src/main/services/rpc-websocket-listener.ts`
+
+- [ ] **Step 1: Locate `generateOpenRpcSchema()`**
+
+Around `src/main/services/rpc-websocket-listener.ts:157-244`. It iterates `rpcMethodDetailsByMethodName` and emits method entries.
+
+- [ ] **Step 2: Extend iteration to include events**
+
+After the existing methods loop, add:
+
+```typescript
+for (const [eventName, registrants] of this.rpcEventDetailsByEventName.entries()) {
+  // First registration's documentation wins (matches the conflict policy).
+  const docs = registrants.find((r) => r.documentation)?.documentation;
+  if (!docs) continue; // events with no documentation are not surfaced in OpenRPC
+
+  const notificationEntry: Notification = {
+    name: eventName,
+    ...docs.notification,
+  };
+  result.methods.push(notificationEntry);
+  // Merge any components the notification's docs declare
+  if (docs.components) mergeComponents(result.components ?? {}, docs.components);
+}
+```
+
+(Use the file's existing `mergeComponents` helper or pattern. Confirm name by reading the file.)
+
+- [ ] **Step 3: Write a snapshot test**
+
+In `src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts` (create if missing), add a test that:
+
+1. Constructs a `RpcWebsocketListener` instance with a mock setup.
+2. Registers a method (with `'x-experimental': true`).
+3. Registers an event (with `'x-experimental': true`).
+4. Calls `generateOpenRpcSchema()`.
+5. Asserts the output's `methods[]` contains both, with the notification entry lacking `result` and both carrying the `x-experimental` flag.
+
+- [ ] **Step 4: Run test — expect pass**
+
+Run: `npm test -- src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts --run`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/services/rpc-websocket-listener.ts src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
+git commit -m "feat(experimental): include notifications in generated OpenRPC schema"
+```
+
+---
+
+## Phase 3 — Registration surfaces
+
+### Task 9: Fanout `documentation['x-experimental']` inside `networkObjectService.set`
+
+**Files:**
+
+- Modify: `src/shared/services/network-object.service.ts`
+
+- [ ] **Step 1: Write the test**
+
+In `src/shared/services/__tests__/network-object.service.test.ts` (create if missing):
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { networkObjectService } from '@shared/services/network-object.service';
+
+describe('networkObjectService.set — x-experimental fanout', () => {
+  it('marks every registered method experimental when documentation has top-level x-experimental: true', async () => {
+    const impl = { method1: async () => 'a', method2: async () => 'b' };
+    // Use test helpers / mocks for the network layer.
+    const result = await networkObjectService.set('test-obj', impl, 'object', undefined, {
+      'x-experimental': true,
+    });
+    // Assert the registered method docs include 'x-experimental': true.
+    // (Test inspects internal state — pull from rpcMethodDetailsByMethodName or similar.)
+    expect(/* docs for object.test-obj.method1 */).toMatchObject({ 'x-experimental': true });
+    expect(/* docs for object.test-obj.method2 */).toMatchObject({ 'x-experimental': true });
+    await result.dispose();
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+- [ ] **Step 3: Implement the fanout**
+
+In `src/shared/services/network-object.service.ts:424-486` (the `set` function and its internal `registerRequestHandler` calls): when `objectDocumentation['x-experimental']` is `true`, ensure each call to `networkService.registerRequestHandler(...)` includes a `methodDocs.method['x-experimental']: true` field — synthesizing minimal docs (`{ method: { 'x-experimental': true, params: [], result: { name: 'r', schema: {} } } }`) if the caller didn't supply per-method docs.
+
+```typescript
+const objectIsExperimental = objectDocumentation['x-experimental'] === true;
+
+for (const [functionName, handler] of /* iterate object.functions */) {
+  const methodName = serializeRequestType(id, functionName);
+  const perMethodDocs = objectDocumentation.methods?.find((m) => m.name === functionName);
+  const methodDocs: SingleMethodDocumentation | undefined =
+    perMethodDocs
+      ? {
+          method: { ...perMethodDocs, 'x-experimental': perMethodDocs['x-experimental'] ?? objectIsExperimental },
+          components: objectDocumentation.components,
+        }
+      : objectIsExperimental
+        ? { method: { 'x-experimental': true, params: [], result: { name: 'return', schema: {} } } }
+        : undefined;
+  await networkService.registerRequestHandler(methodName, handler, methodDocs);
+}
+```
+
+(Adjust to match the actual structure of the existing loop.)
+
+- [ ] **Step 4: Run test — expect pass**
+
+- [ ] **Step 5: Update the wiki page**
+
+The wiki page already shows the fanout example. Verify wording still matches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/shared/services/network-object.service.ts src/shared/services/__tests__/network-object.service.test.ts
+git commit -m "feat(experimental): fanout x-experimental from network object onto its method docs"
+```
+
+---
+
+### Task 10: Add `documentation` parameter to `dataProviderService.registerEngine` + `registerEngineByType`
+
+**Files:**
+
+- Modify: `src/shared/services/data-provider.service.ts`
+
+- [ ] **Step 1: Write the test**
+
+In `src/shared/services/__tests__/data-provider.service.test.ts` (extend if exists), assert that registering with `{ 'x-experimental': true }` propagates through to `networkObjectService.set`.
+
+- [ ] **Step 2: Run test — expect failure**
+
+- [ ] **Step 3: Add the parameter**
+
+Locate `registerEngine` and `registerEngineByType` exports. Add a trailing parameter:
+
+```typescript
+export const registerEngine = async <DataProviderName extends DataProviderNames>(
+  providerName: DataProviderName,
+  engine: IDataProviderEngine<DataProviderTypes[DataProviderName]>,
+  // ... existing parameters ...
+  attributes?: DataProviderAttributes,
+  documentation?: NetworkObjectDocumentation,
+): Promise<DisposableDataProvider<DataProviderTypes[DataProviderName]>> => {
+  // ... existing logic ...
+  return networkObjectService.set(
+    serializeRequestType(CATEGORY_DATA_PROVIDER, providerName),
+    dataProvider,
+    'data-provider',
+    attributes,
+    documentation,
+  );
+};
+```
+
+Mirror for `registerEngineByType`.
+
+- [ ] **Step 4: Run tests + typecheck — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/services/data-provider.service.ts src/shared/services/__tests__/data-provider.service.test.ts
+git commit -m "feat(experimental): add NetworkObjectDocumentation parameter to data provider registration"
+```
+
+---
+
+### Task 11: Add `attributes` then `documentation` to `webViewProviderService.registerWebViewProvider`
+
+**Files:**
+
+- Modify: `src/shared/services/web-view-provider.service.ts`
+
+- [ ] **Step 1: Write the test**
+
+In `src/shared/services/__tests__/web-view-provider.service.test.ts`, register a provider with `{ 'x-experimental': true }` and assert the underlying network object set received the documentation.
+
+- [ ] **Step 2: Implement the parameter additions**
+
+Locate `registerWebViewProvider` (around line 138 by earlier exploration). Today it does not pass `objectAttributes` or `objectDocumentation` to `networkObjectService.set`. Update:
+
+```typescript
+const registerWebViewProvider = async (
+  webViewType: WebViewType,
+  webViewProvider: IWebViewProvider | IWebViewProviderWithSubscribe,
+  attributes?: { [property: string]: unknown },
+  documentation?: NetworkObjectDocumentation,
+): Promise<DisposableWebViewProvider> => {
+  // ... existing logic ...
+  return networkObjectService.set(
+    getWebViewProviderObjectId(webViewType),
+    webViewProvider,
+    'web-view-provider',
+    attributes,
+    documentation,
+  );
+};
+```
+
+- [ ] **Step 3: Update the `PapiWebViewProviderService` deprecated `register` alias to forward**
+
+Confirm the deprecated `register` alias signature on line 296-298 in the same file still passes through. Since it uses `Parameters<typeof registerWebViewProvider>`, it inherits the new parameters automatically.
+
+- [ ] **Step 4: Run tests + typecheck — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/shared/services/web-view-provider.service.ts src/shared/services/__tests__/web-view-provider.service.test.ts
+git commit -m "feat(experimental): add attributes and documentation params to WebView provider registration"
+```
+
+---
+
+### Task 12: Augment `registerProjectDataProviderEngineFactory` (attributes, documentation, factory return)
+
+**Files:**
+
+- Modify: `src/shared/services/project-data-provider.service.ts`
+- Modify: `src/shared/models/project-data-provider-engine-factory.model.ts`
+
+- [ ] **Step 1: Augment the factory return type**
+
+In `project-data-provider-engine-factory.model.ts`:
+
+```typescript
+import type { NetworkObjectDocumentation } from '@shared/models/openrpc.model';
+
+export interface IProjectDataProviderEngineFactory<PI extends ProjectInterfaces> {
+  createProjectDataProviderEngine(projectId: string): Promise<
+    | IProjectDataProviderEngine<PI>
+    | {
+        /**
+         * Discriminating property name chosen specifically so it cannot collide with a property an
+         * engine itself exposes — the platform's narrowing check on this return value is
+         * unambiguous.
+         */
+        projectDataProviderEngine: IProjectDataProviderEngine<PI>;
+        /** Per-PDP attributes. The platform overwrites `projectId` regardless of what you supply. */
+        attributes?: { [property: string]: unknown };
+        /** Per-PDP documentation. Carries `'x-experimental': true` to mark the PDP experimental. */
+        documentation?: NetworkObjectDocumentation;
+      }
+  >;
+}
+```
+
+- [ ] **Step 2: Write the test**
+
+In `src/shared/services/__tests__/project-data-provider.service.test.ts`, register a factory whose `createProjectDataProviderEngine` returns the new envelope; assert the per-PDP `documentation` and `attributes` reach the underlying `networkObjectService.set`.
+
+- [ ] **Step 3: Update `registerProjectDataProviderEngineFactory`**
+
+Add `attributes` and `documentation` parameters, spread `attributes` then overlay `projectInterfaces`:
+
+```typescript
+export const registerProjectDataProviderEngineFactory = async <PI extends ProjectInterfaces>(
+  projectInterfaces: PI[],
+  factory: IProjectDataProviderEngineFactory<PI>,
+  attributes?: { [property: string]: unknown },
+  documentation?: NetworkObjectDocumentation,
+): Promise<UnsubscriberAsync> => {
+  // ... existing logic ...
+  const effectiveAttributes = { ...attributes, projectInterfaces };
+  // Pass attributes + documentation through to the underlying network object registration.
+  // For each PDP instance created by factory.createProjectDataProviderEngine, check whether the
+  // return value matches the envelope shape (has `projectDataProviderEngine`) and merge.
+};
+```
+
+The narrowing check at the call site:
+
+```typescript
+const factoryReturn = await factory.createProjectDataProviderEngine(projectId);
+const isEnvelope =
+  typeof factoryReturn === 'object' &&
+  factoryReturn !== null &&
+  'projectDataProviderEngine' in factoryReturn;
+const engine = isEnvelope ? factoryReturn.projectDataProviderEngine : factoryReturn;
+const perPdpAttributes = isEnvelope ? factoryReturn.attributes : undefined;
+const perPdpDocs = isEnvelope ? factoryReturn.documentation : undefined;
+
+const mergedAttributes = { ...attributes, ...perPdpAttributes, projectId };
+const mergedDocs = perPdpDocs ?? documentation;
+```
+
+Locate the actual PDP registration site within `project-data-provider.service.ts` and apply this pattern.
+
+- [ ] **Step 4: TSDoc the overwrite behavior**
+
+Add explicit TSDoc on `registerProjectDataProviderEngineFactory` warning that `projectInterfaces` (at the registration level) and `projectId` (at the per-PDP level) are overwritten if supplied through `attributes`.
+
+- [ ] **Step 5: Update the wiki page**
+
+Verify the wiki page's "Project data providers" section shows the new shape with `projectDataProviderEngine` discriminator. (It already does — verify wording.)
+
+- [ ] **Step 6: Run tests + typecheck — expect pass**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/shared/services/project-data-provider.service.ts src/shared/models/project-data-provider-engine-factory.model.ts src/shared/services/__tests__/project-data-provider.service.test.ts
+git commit -m "feat(experimental): add attributes, documentation, and factory return augmentation to PDP registration"
+```
+
+---
+
+## Phase 4 — Event migration (25 sites)
+
+### Task 13: Migrate the 3 shared platform events (network-object lifecycle + shared-store change)
+
+**Files:**
+
+- Modify: `src/shared/services/network-object.service.ts:124-127, 142-144`
+- Modify: `src/shared/services/shared-store.service.ts:84`
+
+The event names are already in `SharedNetworkEventTypes` (Phase 1 Task 2). Migration replaces sync calls with async calls.
+
+- [ ] **Step 1: Convert `onDidCreateNetworkObjectEmitter` and `onDidDisposeNetworkObjectEmitter`**
+
+In `src/shared/services/network-object.service.ts`, the two module-level `const` emitters need to move into the existing `initialize` function (or equivalent) so they can `await`. Replace:
+
+```typescript
+const onDidCreateNetworkObjectEmitter =
+  networkService.createNetworkEventEmitter<NetworkObjectDetails>(
+    serializeRequestType(CATEGORY_NETWORK_OBJECT, 'onDidCreateNetworkObject'),
+  );
+```
+
+with:
+
+```typescript
+let onDidCreateNetworkObjectEmitter: PlatformEventEmitter<NetworkObjectDetails> | undefined;
+// inside initialize():
+onDidCreateNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
+  'network-object.onDidCreateNetworkObject',
+);
+```
+
+Update `export const onDidCreateNetworkObject = onDidCreateNetworkObjectEmitter.event;` to an accessor:
+
+```typescript
+export const onDidCreateNetworkObject = (callback: PlatformEventHandler<NetworkObjectDetails>) => {
+  if (!onDidCreateNetworkObjectEmitter) throw new Error('network-object.service not initialized');
+  return onDidCreateNetworkObjectEmitter.event(callback);
+};
+```
+
+Repeat for `onDidDisposeNetworkObjectEmitter` / `onDidDisposeNetworkObject`.
+
+- [ ] **Step 2: Convert `storeChangeEmitter`**
+
+In `src/shared/services/shared-store.service.ts:84`:
+
+```typescript
+storeChangeEmitter = await networkService.createNetworkEventEmitterAsync(
+  'shared-store.onDidChange',
+);
+```
+
+(The variable `storeChangeEmitter` is already declared `let` and assigned inside an init function.)
+
+- [ ] **Step 3: Run all relevant tests**
+
+Run: `npm test -- src/shared/services/__tests__/network-object.service.test.ts src/shared/services/shared-store.service.test.ts --run`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/shared/services/network-object.service.ts src/shared/services/shared-store.service.ts
+git commit -m "refactor(experimental): migrate shared platform events to createNetworkEventEmitterAsync"
+```
+
+---
+
+### Task 14: Migrate easy single-process platform events
+
+**Files:**
+
+- Modify: `src/extension-host/services/extension.service.ts` (2 emitters)
+- Modify: `src/renderer/services/scroll-group.service-host.ts` (1 emitter)
+
+For each emitter, declare the event name in `NetworkEventTypes` (in `papi-shared-types.ts`) with its payload type, then replace the sync call with async + `await`.
+
+- [ ] **Step 1: Declare event types**
+
+In `src/declarations/papi-shared-types.ts`, augment `NetworkEventTypes`:
+
+```typescript
+declare module 'papi-shared-types' {
+  export interface NetworkEventTypes {
+    'platform.onDidReloadExtensions': boolean;
+    // ... other extension-service event ...
+    'scroll-group.onDidUpdateScrRef': ScrollGroupUpdateInfo;
+  }
+}
+```
+
+(Confirm the second extension-service event name by reading the file.)
+
+- [ ] **Step 2: Migrate `extension.service.ts:1566`**
+
+```typescript
+reloadFinishedEventEmitter = await createNetworkEventEmitterAsync('platform.onDidReloadExtensions');
+```
+
+(Replace `createNetworkEventEmitter` import with `createNetworkEventEmitterAsync` import.)
+
+- [ ] **Step 3: Migrate the second `extension.service.ts` emitter**
+
+(Confirm location, name; same pattern.)
+
+- [ ] **Step 4: Migrate `scroll-group.service-host.ts:59`**
+
+The emitter is module-level; refactor into the service's init function with a `let` binding and an accessor that throws if invoked before initialization (same pattern as Task 13 Step 1).
+
+- [ ] **Step 5: Run tests + typecheck — expect pass**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/extension-host/services/extension.service.ts src/renderer/services/scroll-group.service-host.ts src/declarations/papi-shared-types.ts
+git commit -m "refactor(experimental): migrate single-process platform events to createNetworkEventEmitterAsync"
+```
+
+---
+
+### Task 15: Migrate WebView lifecycle emitters (4 emitters, init refactor)
+
+**Files:**
+
+- Modify: `src/renderer/services/web-view.service-host.ts:96,101,120,128`
+
+- [ ] **Step 1: Declare event types**
+
+In `src/declarations/papi-shared-types.ts`:
+
+```typescript
+export interface NetworkEventTypes {
+  // ... existing ...
+  'web-view.onDidAddWebView': OpenWebViewEvent;
+  'web-view.onDidOpenWebView': OpenWebViewEvent;
+  'web-view.onDidUpdateWebView': UpdateWebViewEvent;
+  'web-view.onDidCloseWebView': CloseWebViewEvent;
+}
+```
+
+Confirm exact wire names by reading `EVENT_NAME_ON_DID_*_WEB_VIEW` constants — they may differ slightly.
+
+- [ ] **Step 2: Move emitters into the service's init function**
+
+The four module-level `const` emitters at lines 96, 101, 120, 128 become `let` bindings declared at module scope, assigned inside the existing `initialize` function. Each call site that today references `onDidAddWebViewEmitter`, `onDidOpenWebViewEmitter`, `onDidUpdateWebViewEmitter`, `onDidCloseWebViewEmitter` is wrapped in accessors that throw if the service isn't initialized:
+
+```typescript
+let onDidAddWebViewEmitter: PlatformEventEmitter<OpenWebViewEvent> | undefined;
+
+async function initialize() {
+  // ... existing init ...
+  onDidAddWebViewEmitter = await createNetworkEventEmitterAsync('web-view.onDidAddWebView');
+  // ... three more ...
+}
+
+function getOnDidAddWebViewEmitter() {
+  if (!onDidAddWebViewEmitter) throw new Error('web-view.service-host not initialized');
+  return onDidAddWebViewEmitter;
+}
+```
+
+Update any direct uses of the emitters to go through the getters.
+
+- [ ] **Step 3: Run tests — expect pass**
+
+Run: `npm test -- src/renderer/services --run`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/renderer/services/web-view.service-host.ts src/declarations/papi-shared-types.ts
+git commit -m "refactor(experimental): migrate WebView lifecycle emitters with lazy-init pattern"
+```
+
+---
+
+### Task 16: Migrate `check-aggregator.service.ts` emitter (init refactor)
+
+**Files:**
+
+- Modify: `extensions/src/platform-scripture/src/checks/check-aggregator.service.ts:410`
+
+- [ ] **Step 1: Declare the event type in the extension's `.d.ts`**
+
+In `extensions/src/platform-scripture/src/types/platform-scripture.d.ts` (or similar):
+
+```typescript
+declare module 'papi-shared-types' {
+  export interface NetworkEventTypes {
+    'platform-scripture.checkResultsInvalidated': CheckResultsInvalidated;
+  }
+}
+```
+
+(Confirm the `CHECK_RESULTS_INVALIDATED_EVENT` constant's value.)
+
+- [ ] **Step 2: Refactor the module-level emitter**
+
+Move into an `initialize` function with a `let` binding + accessor pattern (same as Task 15 Step 2).
+
+- [ ] **Step 3: Run tests, typecheck**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add extensions/src/platform-scripture
+git commit -m "refactor(experimental): migrate check-aggregator emitter to async"
+```
+
+---
+
+### Task 17: Migrate data-provider per-instance emitter (type-assertion pattern)
+
+**Files:**
+
+- Modify: `src/shared/services/data-provider.service.ts:817`
+
+- [ ] **Step 1: Replace the sync call with the documented type-assertion pattern**
+
+```typescript
+const dynamicName = serializeRequestType(dataProviderObjectId, ON_DID_UPDATE);
+// Per-instance data provider events have dynamic names that can't be declared in
+// NetworkEventTypes. Cast the name to satisfy the constraint; the payload type is
+// recovered from the surrounding function's generic context.
+// eslint-disable-next-line no-type-assertion/no-type-assertion
+const onDidUpdateEmitter = (await networkService.createNetworkEventEmitterAsync(
+  dynamicName as keyof NetworkEventTypes,
+)) as unknown as PlatformEventEmitter<
+  DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>
+>;
+```
+
+- [ ] **Step 2: Run tests + typecheck**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/services/data-provider.service.ts
+git commit -m "refactor(experimental): migrate data-provider per-instance emitter with type assertion"
+```
+
+---
+
+### Task 18: Migrate extension main.ts emitters (3 extensions)
+
+**Files:**
+
+- Modify: `extensions/src/hello-rock3/src/main.ts:462`
+- Modify: `extensions/src/platform-scripture-editor/src/main.ts:286,290,1234`
+
+For each: declare the event in the extension's `.d.ts` augmentation, then `await createNetworkEventEmitterAsync(...)` in the existing async `activate`/lifecycle function.
+
+- [ ] **Step 1: Declare event types in each extension's `.d.ts`**
+
+For hello-rock3:
+
+```typescript
+declare module 'papi-shared-types' {
+  export interface NetworkEventTypes {
+    'hello-rock3.onHelloRock3': HelloRock3Event;
+  }
+}
+```
+
+For platform-scripture-editor:
+
+```typescript
+declare module 'papi-shared-types' {
+  export interface NetworkEventTypes {
+    'platform-scripture-editor.projectSwitchWillStart': Record<string, never>;
+    'platform-scripture-editor.projectSwitchDidFinish': Record<string, never>;
+    'platform-scripture-editor.editorSelectionChanged': SelectionChangeEvent;
+  }
+}
+```
+
+(Confirm exact wire names from the constants `PROJECT_SWITCH_WILL_START_EVENT` etc.)
+
+- [ ] **Step 2: Replace the four sync calls with async + await**
+
+- [ ] **Step 3: Run extension tests + typecheck**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add extensions/src/hello-rock3 extensions/src/platform-scripture-editor
+git commit -m "refactor(experimental): migrate extension emitters to createNetworkEventEmitterAsync"
+```
+
+---
+
+### Task 19: Migrate test files (4 test files)
+
+**Files:**
+
+- Modify: `src/shared/services/shared-store.service.test.ts`
+- Modify: `src/renderer/app.component.test.tsx`
+- Modify: `src/renderer/hooks/use-project-picker-data.hook.test.ts`
+
+(One of the 4 listed earlier — `shared-store.service.test.ts` — has 3 occurrences. Migrate each.)
+
+- [ ] **Step 1: For each test file, replace `createNetworkEventEmitter` with `createNetworkEventEmitterAsync` and `await` in the surrounding async setup**
+
+If the event name is well-known (in `NetworkEventTypes`/`SharedNetworkEventTypes`), pass it directly. If it's a test-controlled name, declare it in `NetworkEventTypes` (in a test-scoped augmentation if possible, or in the global declaration file with a `// test only` comment).
+
+- [ ] **Step 2: Run all 4 test files — expect pass**
+
+```bash
+npm test -- src/shared/services/shared-store.service.test.ts src/renderer/app.component.test.tsx src/renderer/hooks/use-project-picker-data.hook.test.ts --run
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/services/shared-store.service.test.ts src/renderer/app.component.test.tsx src/renderer/hooks/use-project-picker-data.hook.test.ts
+git commit -m "refactor(experimental): migrate test fixtures to createNetworkEventEmitterAsync"
+```
+
+---
+
+## Phase 5 — Docs
+
+### Task 20: Add TSDoc to documentation types explaining where to set `'x-experimental': true`
+
+**Files:**
+
+- Modify: `src/shared/models/openrpc.model.ts`
+
+- [ ] **Step 1: Add or extend TSDoc on each relevant type**
+
+For each of `Method`, `Notification`, `SingleMethodDocumentation`, `SingleNotificationDocumentation`, `NetworkObjectDocumentation`: ensure the TSDoc explicitly says where to set `'x-experimental': true` to mark the documented entity experimental. (Some were added in Task 1; this task ensures completeness and consistency.)
+
+Sample additions:
+
+```typescript
+/**
+ * Documentation about a single method.
+ *
+ * To mark the method experimental, set `method['x-experimental']: true`. This becomes visible in
+ * the generated OpenRPC document under `methods[].'x-experimental'`.
+ */
+export type SingleMethodDocumentation = {
+  /* ... */
+};
+
+/**
+ * Documentation about a single notification (event).
+ *
+ * To mark the notification experimental, set `notification['x-experimental']: true`. This becomes
+ * visible in the generated OpenRPC document under the notification's entry in `methods[]`.
+ */
+export type SingleNotificationDocumentation = {
+  /* ... */
+};
+
+/**
+ * Documentation about all methods on a network object.
+ *
+ * Set top-level `'x-experimental': true` to mark every method of the object as experimental.
+ * Alternatively, set it per-method via `methods[].'x-experimental'`. The platform fans out the
+ * top-level marker onto each method when the object is registered.
+ */
+export type NetworkObjectDocumentation = {
+  /* ... */
+};
+```
+
+- [ ] **Step 2: Run typecheck (verifies docs propagate through JSDOC SOURCE/DESTINATION)**
+
+Run: `npm run typecheck && cd lib/papi-dts && npm run build` to regenerate `papi.d.ts` and confirm the docs appear in the generated file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/shared/models/openrpc.model.ts lib/papi-dts/papi.d.ts
+git commit -m "docs(experimental): add TSDoc on doc types explaining where to set x-experimental"
+```
+
+---
+
+### Task 21: Update `.context/standards/` with experimental authoring conventions
+
+**Files:**
+
+- Modify: `.context/standards/Extension-Development-Guide.md` (or `Paranext-Core-Patterns.md` — pick the file with more API-authoring guidance; check both)
+
+- [ ] **Step 1: Determine the appropriate target file**
+
+Read both standards files briefly. Pick the one that already covers PAPI authoring conventions. If neither does, prefer `Extension-Development-Guide.md`.
+
+- [ ] **Step 2: Add an "Experimental APIs" section**
+
+The section should cover:
+
+- What `@experimental` means and that it's informational only.
+- Where to put it: TSDoc tag on type declarations, `'x-experimental': true` in registration documentation.
+- A surface-by-surface quick reference (lift from the wiki page; do NOT duplicate the wiki — link to it).
+- Decision guidance: mark as experimental whenever the API is not a confident, solid, general-purpose contract.
+- Note on `createNetworkEventEmitter` deprecation in favor of `…Async`.
+
+Cross-link to the wiki page at `docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md` for full authoring details.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .context/standards/<file>.md
+git commit -m "docs(experimental): add Experimental APIs section to standards"
+```
+
+---
+
+### Task 22: Final wiki page sync + complete the rollout
+
+**Files:**
+
+- Modify: `docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md`
+
+- [ ] **Step 1: Diff the wiki page against the implemented behavior**
+
+Read the wiki page top to bottom. For each code snippet, verify it matches the as-implemented signatures (parameter order, factory return shape, etc.). Fix any drift.
+
+- [ ] **Step 2: Run the full test suite as a final gate**
+
+Run: `npm test -- --run && npm run typecheck && npm run lint`
+Expected: PASS across the board.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md
+git commit -m "docs(experimental): final wiki page sync after implementation"
+```
+
+---
+
+## Self-review checklist
+
+After completing all tasks, run:
+
+- [ ] `npm test -- --run` — all tests pass
+- [ ] `npm run typecheck` — no type errors
+- [ ] `npm run lint` — no lint errors introduced (existing warnings OK)
+- [ ] `npm run build` — full build succeeds; `papi.d.ts` regenerates cleanly
+- [ ] `git log --oneline tjc/experimental-api-flag ^main` — review the commit series for clarity and atomicity
+- [ ] Open `lib/papi-dts/papi.d.ts` and search for `x-experimental` and `@experimental` — confirm the markers appear in the generated public types
+- [ ] Manually inspect the wiki page for any remaining drift vs implementation
+
+Then either:
+
+- Open a PR with the design and wiki page as part of the change set; or
+- Cherry-pick the implementation commits onto a fresh branch off `main` and open PR from there.

--- a/docs/superpowers/specs/2026-06-08-experimental-api-flag-design.md
+++ b/docs/superpowers/specs/2026-06-08-experimental-api-flag-design.md
@@ -1,0 +1,589 @@
+# Experimental API Flag — Design
+
+**Status:** Draft for review
+**Date:** 2026-06-08
+**Owner:** tjcouch-sil
+**Related:** wiki page at `2026-06-08-experimental-apis-wiki-page.md` (companion to this spec)
+
+## Summary
+
+Introduce a uniform `experimental` marker for PAPI APIs that surfaces on both the TypeScript types (via the `@experimental` TSDoc modifier tag) and the live OpenRPC document over the WebSocket (via an `x-experimental: true` field). The marker applies to every PAPI surface — commands, network objects, data providers, project data providers, WebView providers, network events, types referenced by methods, and extensible menu features.
+
+The marker is **informational only**. It changes no runtime behavior. It exists so consumers — extension developers, IDE tooling, and the future API documentation site — can identify APIs whose shape is not yet stable.
+
+## Goals
+
+- One marker convention covering every PAPI surface.
+- Both authoring locations work: a TSDoc tag on the type/member, and a registration-time field for the wire representation.
+- Both layers participate: the marker appears in `papi.d.ts` (for IDE consumers) and in the generated OpenRPC document (for runtime introspection tooling).
+- Non-breaking — additive across the codebase. Existing code continues to work unchanged.
+- Establish a side benefit: central registration for network events with a duplicate-registration warning across processes.
+
+## Non-goals
+
+- No runtime gate, opt-in, or manifest acknowledgement. Experimental APIs work identically to stable ones at runtime.
+- No date or message in the OpenRPC encoding — boolean only. Prose belongs in the regular `description` field of the doc objects.
+- No automatic extraction from TSDoc tags to OpenRPC. Developers fill in both intentionally; the locations are documented in the wiki page.
+- No JSON Schema lift of shared types into OpenRPC `components.schemas`. Per-provider granularity is achieved by the provider-level mark.
+- No `tsdoc.json`. TypeDoc 0.28.3 recognizes `@experimental` as a built-in modifier tag and cascades it to members by default. Held in reserve for the future if TSDoc-strict linting is adopted.
+- No backfill of currently-experimental APIs as part of this design. That follows in a separate cleanup PR.
+
+## Authoring model
+
+The marker can be applied two complementary ways. Both are encouraged together:
+
+- **TSDoc `@experimental` modifier tag** on the type, interface, member, or augmentation entry. Surfaces in IDE tooltips and TypeDoc-generated HTML. Cascades to child members.
+- **Registration-time documentation** carrying `'x-experimental': true`. Surfaces in the live OpenRPC document.
+
+### Commands
+
+```typescript
+declare module 'papi-shared-types' {
+  export interface CommandHandlers {
+    /** @experimental */
+    'myExt.expCmd': (arg: string) => Promise<void>;
+  }
+}
+
+await papi.commands.registerCommand('myExt.expCmd', handler, {
+  method: {
+    'x-experimental': true,
+    summary: 'Does the experimental thing',
+    params: [{ name: 'arg', schema: { type: 'string' } }],
+    result: { name: 'returns', schema: { type: 'null' } },
+  },
+});
+```
+
+### Network objects
+
+```typescript
+await papi.networkObjects.set(
+  'myObj',
+  impl,
+  'object',
+  undefined,
+  { 'x-experimental': true }, // 5th param: NetworkObjectDocumentation
+);
+```
+
+### Data providers
+
+```typescript
+await papi.dataProviders.registerEngine(
+  'myDP',
+  engine,
+  dataTypes,
+  attributes,
+  { 'x-experimental': true }, // new NetworkObjectDocumentation parameter
+);
+```
+
+### Project data providers
+
+```typescript
+declare module 'papi-shared-types' {
+  export interface ProjectDataProviderInterfaces {
+    /** @experimental */
+    'myExt.expInterface': IProjectDataProvider<MyDataTypes>;
+  }
+}
+
+await papi.projectDataProviders.registerProjectDataProviderEngineFactory(
+  ['myExt.expInterface'],
+  {
+    async createProjectDataProviderEngine(projectId) {
+      // Option A — return engine only
+      return new MyEngine(projectId);
+
+      // Option B — return engine plus per-PDP-instance attributes + docs
+      return {
+        projectDataProviderEngine: new MyEngine(projectId),
+        attributes: {
+          /* per-PDP attributes; projectId and projectInterfaces overwritten */
+        },
+        documentation: { 'x-experimental': true },
+      };
+    },
+  },
+  /* attributes */ {
+    /* registration-level attributes; projectInterfaces overwritten */
+  },
+  /* documentation */ { 'x-experimental': true },
+);
+```
+
+### WebView providers
+
+```typescript
+await papi.webViewProviders.registerWebViewProvider(
+  'myView',
+  provider,
+  /* attributes */ undefined,
+  /* documentation */ { 'x-experimental': true },
+);
+```
+
+### Network events
+
+```typescript
+declare module 'papi-shared-types' {
+  export interface NetworkEventTypes {
+    /** @experimental */
+    'myExt.somethingHappened': { foo: string };
+  }
+}
+
+const emitter = await papi.network.createNetworkEventEmitterAsync('myExt.somethingHappened', {
+  notification: {
+    'x-experimental': true,
+    summary: 'Fires when something experimental happens',
+    params: [
+      {
+        name: 'event',
+        schema: {
+          /* json schema for { foo: string } */
+        },
+      },
+    ],
+  },
+});
+// emitter is PapiEventEmitter<{ foo: string }> — inferred from the event name
+```
+
+A small set of platform infrastructure events (e.g., `network-object.onDidCreateNetworkObject`) are intentionally emitted from multiple processes. They live in a closed `SharedNetworkEventTypes` type that `NetworkEventTypes` inherits from. Extensions don't author shared events — but they can subscribe to them like any other event. See the "Event registration plumbing" section for how this is enforced at the central registry.
+
+### Menus
+
+```jsonc
+{
+  "columns": {
+    "myExt.myColumn": {
+      "label": "%myColumn.label%",
+      "order": 1,
+      "isExtensible": true,
+      "isExperimental": true,
+    },
+  },
+}
+```
+
+## Encoding
+
+| Surface                         | Field name         | Type      | Notes                                                                                               |
+| ------------------------------- | ------------------ | --------- | --------------------------------------------------------------------------------------------------- |
+| TSDoc tag                       | `@experimental`    | modifier  | Built-in TypeDoc tag; cascades by default in 0.28.3+                                                |
+| TypeScript registration options | `isExperimental`   | `boolean` | Used on the menus model (parallels existing `isExtensible`)                                         |
+| OpenRPC wire                    | `'x-experimental'` | `boolean` | Vendor extension on `Method`, `Notification`, `NetworkObjectDocumentation`, and JSON Schema objects |
+
+`@experimental` is the TSDoc convention (no `@isExperimental` form). `'x-experimental'` follows OpenRPC's existing field-naming style (matches `deprecated`/`summary`/etc., which also are not `is`-prefixed). `isExperimental` is used on our internal types where the code style guide applies.
+
+## `openrpc.model.ts` changes
+
+Two distinct types so each registration site can constrain what it accepts:
+
+```typescript
+export type Method = {
+  name: string;
+  params: (ContentDescriptor | Reference)[];
+  result: ContentDescriptor | Reference;
+  'x-experimental'?: boolean;
+  // ... existing fields unchanged
+};
+
+export type Notification = Omit<Method, 'result'>;
+
+export type SingleNotificationDocumentation = {
+  notification: Omit<Notification, 'name'>;
+  components?: Components;
+};
+
+export type NetworkObjectDocumentation = {
+  summary?: string;
+  description?: string;
+  methods?: Method[]; // Method only — object methods always have a return value
+  components?: Components;
+  'x-experimental'?: boolean; // object-wide; fans out to every method registered for this object
+};
+
+export type OpenRpc = {
+  openrpc: string;
+  info: Info;
+  servers?: Server[];
+  methods: (Method | Notification)[]; // both at root — spec convention is no-result == notification
+  components?: Components;
+  externalDocs?: ExternalDocumentation;
+};
+```
+
+Spec compliance: the root `methods` array holds both, distinguishable by the absence of `result` on notifications. This matches the current OpenRPC convention (issue #230 lineage). The local `Notification` type gives us tighter compile-time guarantees at every site where notifications are not allowed (e.g., `NetworkObjectDocumentation.methods`).
+
+## Event registration plumbing
+
+Today's events have no central registry. Each process holds a local `eventEmittersByEventType` Map and emission propagates via JSON-RPC notifications across processes. Adding events to the OpenRPC document requires central registration.
+
+### Type registry shape
+
+A single augmentable interface for events, with a closed type alias declaring the platform's shared events. The shared alias is the source of truth at both the type level and the runtime registry.
+
+````typescript
+declare module 'papi-shared-types' {
+  /**
+   * Network events emitted from multiple processes (each process emits its own local event under
+   * the same name). Declared by the platform; not extensible by extensions.
+   *
+   * The names listed here are the source of truth for which event names use shared semantics at the
+   * central registry. An event name in this type allows registration from multiple processes (each
+   * process registers once, all emitters are valid sources). Any other event name uses exclusive
+   * semantics (one registrant ever).
+   *
+   * Subscribers do not need to know which events are shared — `getNetworkEvent` handles both kinds
+   * identically.
+   */
+  export type SharedNetworkEventTypes = {
+    'network-object.onDidCreateNetworkObject': NetworkObjectDetails;
+    'network-object.onDidDisposeNetworkObject': string;
+    'shared-store.onDidChange': StoreChangeEvent;
+  };
+
+  /**
+   * All known network events. Extensions augment this to declare their own events. Inherits the
+   * platform's shared events automatically.
+   *
+   * To declare a new event for use with `createNetworkEventEmitterAsync`:
+   *
+   * ```ts
+   * declare module 'papi-shared-types' {
+   *   export interface NetworkEventTypes {
+   *     'myExt.somethingHappened': { foo: string };
+   *   }
+   * }
+   * ```
+   */
+  export interface NetworkEventTypes extends SharedNetworkEventTypes {}
+}
+````
+
+The runtime mirror is a constant in `network.service.ts`:
+
+```typescript
+const SHARED_EVENT_NAMES = new Set<keyof SharedNetworkEventTypes>([
+  'network-object.onDidCreateNetworkObject',
+  'network-object.onDidDisposeNetworkObject',
+  'shared-store.onDidChange',
+]);
+```
+
+The constant and the type alias must stay in sync; a build-time assertion (or a unit test) verifies that every key in `SharedNetworkEventTypes` appears in `SHARED_EVENT_NAMES`.
+
+### New emitter creator — single function
+
+One function. Whether the runtime treats a registration as shared or exclusive is determined by the name's presence in `SHARED_EVENT_NAMES`, not by which function the caller invokes.
+
+```typescript
+/**
+ * Create a network event emitter that participates in central registration. The returned emitter
+ * appears in the OpenRPC document if `documentation` is provided.
+ *
+ * If the event name is in `SharedNetworkEventTypes`, the central registry uses **shared** semantics:
+ * multiple processes may register the same name (each process registers once); all corresponding
+ * emitters are valid sources.
+ *
+ * Otherwise the central registry uses **exclusive** semantics: only one process may register a given
+ * name; subsequent registrations from any process are rejected.
+ *
+ * Intra-process duplicate registration is always rejected regardless of the event's domain.
+ *
+ * @param eventType  Must be a key of `NetworkEventTypes` (which inherits `SharedNetworkEventTypes`).
+ * @param documentation  Optional notification documentation. Carries `'x-experimental': true` to
+ *                       mark the event as experimental.
+ */
+createNetworkEventEmitterAsync<EventType extends keyof NetworkEventTypes>(
+  eventType: EventType,
+  documentation?: SingleNotificationDocumentation,
+): Promise<PapiEventEmitter<NetworkEventTypes[EventType]>>;
+```
+
+### Subscriber — typed overload + deprecated fallback
+
+```typescript
+/**
+ * Subscribe to a typed network event. Declare the event in `NetworkEventTypes` (or rely on
+ * `SharedNetworkEventTypes` inheritance for platform events) and the payload type is inferred.
+ */
+function getNetworkEvent<EventType extends keyof NetworkEventTypes>(
+  eventType: EventType,
+): PlatformEvent<NetworkEventTypes[EventType]>;
+
+/**
+ * @deprecated 8 June 2026. Use the typed signature: declare the event in `NetworkEventTypes` and
+ *   call `getNetworkEvent('your.event.name')` without an explicit type parameter. If your event
+ *   name is dynamic (e.g., per-instance data-provider events), this signature continues to work
+ *   functionally; suppress the deprecation warning at the call site.
+ */
+function getNetworkEvent<T>(eventType: string): PlatformEvent<T>;
+```
+
+Per-overload `@deprecated` is honored by TypeScript-language-server clients (VSCode and equivalents), so existing call sites that pass an explicit `<T>` show the strikethrough; migrated call sites that omit `<T>` resolve to the non-deprecated overload.
+
+### Deprecation of the sync emitter
+
+The sync `createNetworkEventEmitter` signature is **unchanged** — preserving full backward compatibility. Only the deprecation tag is added.
+
+```typescript
+/**
+ * @deprecated 8 June 2026. Use createNetworkEventEmitterAsync. Events created via the sync API
+ *   are not centrally registered and do not appear in the OpenRPC document. The async version
+ *   properly restricts event registration to prevent multiple sources from emitting the same
+ *   network event (unless the event is declared in `SharedNetworkEventTypes`, in which case it
+ *   accepts multiple registrants by design).
+ */
+createNetworkEventEmitter<T>(eventType: string): PapiEventEmitter<T>;
+```
+
+### Wire-level plumbing
+
+1. Add a new `REGISTER_EVENT` RPC method on the main process, modeled directly on `REGISTER_METHOD` at `src/main/services/rpc-server.ts:141-145`. The payload carries the event name and optional `SingleNotificationDocumentation`. No domain discriminator is sent over the wire — the registry decides shared vs exclusive by looking up the name in `SHARED_EVENT_NAMES`.
+2. Add `rpcEventDetailsByEventName: Map<string, { registrants: { processId: string; documentation?: SingleNotificationDocumentation }[] }>` to `RpcWebsocketListener`, parallel to the existing `rpcMethodDetailsByMethodName` at `src/main/services/rpc-websocket-listener.ts:47`.
+3. `createNetworkEventEmitterAsync` invokes `REGISTER_EVENT` and awaits the response before resolving the returned emitter.
+4. `generateOpenRpcSchema()` iterates the event registry and includes each event once as a `Notification` entry in the root `methods` array. Whether the event is shared or exclusive is not exposed in OpenRPC output — both kinds appear as notifications, indistinguishable on the wire.
+
+### Conflict policy
+
+The central registry decides behavior per registration by checking the event name against `SHARED_EVENT_NAMES`:
+
+**Name in `SHARED_EVENT_NAMES` (shared).** Multiple processes may register; each process may register only once. The first registration's documentation is used for OpenRPC output; subsequent documentation is ignored with a debug-level log noting that the documentation was already established.
+
+**Name not in `SHARED_EVENT_NAMES` (exclusive).** First registrant wins. Any subsequent registration from any process is rejected with an error that names the existing registrant's process ID.
+
+**Intra-process duplicate (either kind).** Always rejected — preserves today's hard error at `src/shared/services/network.service.ts:328-329`.
+
+The sync `createNetworkEventEmitter` (deprecated) bypasses all of the above — it doesn't participate in central registration at all. That preserves today's behavior.
+
+### Sync emitter behavior is unchanged
+
+The deprecated sync `createNetworkEventEmitter` continues to function exactly as today — no central registration, not visible in OpenRPC. This is the back-compat guarantee. Migration is opt-in.
+
+## Event migration
+
+`createNetworkEventEmitter` has 36 occurrences in the codebase. 11 of those are foundational — the API implementation in `src/shared/services/network.service.ts` (7), the emitter model in `src/shared/models/papi-network-event-emitter.model.ts` (1), and generated `lib/papi-dts/papi.d.ts` references (3) — and are touched as part of the foundational work below, not the migration.
+
+The remaining 25 are user-level call sites that all migrate to the same `createNetworkEventEmitterAsync` function. Whether an event is treated as shared or exclusive is determined at the central registry by name lookup against `SHARED_EVENT_NAMES`, not by which function is called — so the migration code path is identical regardless. The categorization below only determines **where each event name's type is declared**: in `SharedNetworkEventTypes` (closed alias in core, for the 3 platform-shared events) or in `NetworkEventTypes` (the augmentable interface, for everything else).
+
+### Events whose names go in `SharedNetworkEventTypes` (3 sites)
+
+These live in `src/shared/services/*` and are emitted by every process that hosts the service. Their names are added to the closed `SharedNetworkEventTypes` type alias in core declarations and to the `SHARED_EVENT_NAMES` runtime constant:
+
+- `src/shared/services/network-object.service.ts:124-127` — `onDidCreateNetworkObjectEmitter`. Every process emits when it creates a local network object.
+- `src/shared/services/network-object.service.ts:142-144` — `onDidDisposeNetworkObjectEmitter`. Every process emits when it disposes a local network object (comment at lines 139-141 explicitly notes the multi-process intent).
+- `src/shared/services/shared-store.service.ts:84` — `storeChangeEmitter`. Every process emits when its local store changes.
+
+### Events whose names go in `NetworkEventTypes` (22 sites)
+
+Single-process emitters. Names are added to the augmentable `NetworkEventTypes` interface (in core declarations for platform events; in extension `.d.ts` files for extension events). One site (the data-provider per-instance emitter) has a dynamic name and uses the type-assertion pattern shown below. Categorized by migration ease:
+
+**Easy** — already in an async initialization context, straightforward `await` swap:
+
+- All 4 test files: `src/shared/services/shared-store.service.test.ts`, `src/renderer/app.component.test.tsx`, `src/renderer/hooks/use-project-picker-data.hook.test.ts`
+- `extensions/src/hello-rock3/src/main.ts:462`
+- `extensions/src/platform-scripture-editor/src/main.ts:286,290,1234`
+- `src/extension-host/services/extension.service.ts` (2 occurrences)
+- `src/renderer/services/scroll-group.service-host.ts` (1 emitter + 1 import line)
+
+**Dynamic-name (type-assertion pattern)** — one site has a name that can't be a literal in the registry:
+
+- `src/shared/services/data-provider.service.ts:817` — the name is `serializeRequestType(dataProviderObjectId, ON_DID_UPDATE)`, computed per data-provider instance. The payload type is statically known from the surrounding function's generics. Migration uses a double assertion (name into `keyof NetworkEventTypes` to satisfy the constraint, then result into the known emitter type) with a comment explaining why the literal-name path isn't available:
+
+  ```ts
+  const dynamicName = serializeRequestType(dataProviderObjectId, ON_DID_UPDATE);
+  const onDidUpdateEmitter = (await networkService.createNetworkEventEmitterAsync(
+    // Per-instance data provider events have dynamic names that can't be declared in
+    // NetworkEventTypes. Cast the name to satisfy the constraint; the payload type is
+    // recovered from the surrounding function's generic context.
+    dynamicName as keyof NetworkEventTypes,
+  )) as unknown as PapiEventEmitter<
+    DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>
+  >;
+  ```
+
+  Runtime behavior is identical to the typed path; the cast is purely to thread the static-name constraint at the API boundary.
+
+**Trickier** — module-level `const` emitters that need lazy-init refactoring:
+
+- `src/renderer/services/web-view.service-host.ts:96,101,120,128` — four lifecycle emitters at module top level. Move into the existing service-host initialization function, store in `let` bindings, expose via accessor functions that throw with a descriptive error if invoked before initialization.
+- `extensions/src/platform-scripture/src/checks/check-aggregator.service.ts:410` — same pattern.
+
+### Foundational work (this design)
+
+The core implementation — included in this design, not deferred:
+
+- `src/shared/services/network.service.ts` — add `createNetworkEventEmitterAsync` alongside the deprecated sync variant; extend `createNetworkEventEmitterInternal` to optionally perform central registration; update the `PapiNetworkService` interface.
+- `src/main/services/rpc-websocket-listener.ts` — add `rpcEventDetailsByEventName` and emit notifications during schema generation.
+- `src/main/services/rpc-server.ts` — implement `REGISTER_EVENT` handler.
+
+Bootstrap-order note: the `REGISTER_EVENT` RPC method itself must be registered before any emitter creation calls it. Main process registers its own handler at startup, same way it does for `REGISTER_METHOD`. Same-process emitter creation on main does not need to await network availability — it registers directly into the central map.
+
+### Dynamic event-name escape hatch
+
+Some core code (data-provider change events, etc.) creates emitters with names not declared in `NetworkEventTypes`. The async signature requires `keyof NetworkEventTypes`, so these sites use `as keyof NetworkEventTypes` to type-assert. Document the reason inline with a brief comment.
+
+## Registration surfaces — fanout
+
+A single registration-time mark on a network-object-backed surface fans out `'x-experimental': true` onto every method's `methodDocs` that the object exposes. The fanout happens at the one site where method registration is centralized — inside `networkObjectService.set` and its callers.
+
+| Registration                                                         | Where the mark goes                                                                |
+| -------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `commandService.registerCommand`                                     | Existing 3rd parameter `commandDocs.method['x-experimental']`                      |
+| `networkObjectService.set`                                           | Existing 5th parameter `objectDocumentation['x-experimental']`                     |
+| `dataProviderService.registerEngine` / `registerEngineByType`        | New `NetworkObjectDocumentation` parameter                                         |
+| `webViewProviderService.registerWebViewProvider`                     | New `attributes?` parameter followed by new `NetworkObjectDocumentation` parameter |
+| `papi.projectDataProviders.registerProjectDataProviderEngineFactory` | New parameters; see PDP section below                                              |
+| `createNetworkEventEmitterAsync`                                     | Documentation parameter `notification['x-experimental']`                           |
+
+### PDP registration changes
+
+`registerProjectDataProviderEngineFactory` needs to match the network-object-backed registration pattern used elsewhere:
+
+```typescript
+registerProjectDataProviderEngineFactory(
+  projectInterfaces: ProjectInterfaces[],
+  factory: IProjectDataProviderEngineFactory,
+  attributes?: ProjectDataProviderFactoryAttributes,
+  documentation?: NetworkObjectDocumentation,
+): Promise<UnsubscriberAsync>;
+```
+
+The platform spreads `attributes` and then overlays the canonical `projectInterfaces` on top. Setting `projectInterfaces` inside `attributes` has no effect — the platform-computed value wins. Document this in TSDoc.
+
+The factory's `createProjectDataProviderEngine` return type is augmented:
+
+```typescript
+interface IProjectDataProviderEngineFactory<PI extends ProjectInterfaces> {
+  createProjectDataProviderEngine(projectId: string): Promise<
+    | IProjectDataProviderEngine<PI>
+    | {
+        projectDataProviderEngine: IProjectDataProviderEngine<PI>;
+        /** Per-PDP attributes. `projectId` will be overwritten by the platform. */
+        attributes?: ProjectDataProviderAttributes;
+        /** Per-PDP documentation. */
+        documentation?: NetworkObjectDocumentation;
+      }
+  >;
+}
+```
+
+Existing factories that return just the engine continue to work. New factories that need per-PDP customization return the object form. The platform handles both via a narrow union check at the call site that invokes the factory — the discriminating property `projectDataProviderEngine` is named specifically so it cannot accidentally collide with a property an engine itself might expose, eliminating any risk of misreading an engine as an envelope.
+
+## Menus
+
+Add `isExperimental?: boolean` to the menus model at `lib/platform-bible-utils/src/extension-contributions/menus.model.ts`:
+
+- `OrderedExtensibleContainer` (cascades into `MenuGroupDetailsInColumn`, `MenuGroupDetailsInSubMenu`, `MenuColumnWithHeader`)
+- `ColumnsWithHeaders` (sibling to existing `isExtensible`)
+- `WebViewMenu` (sibling to `includeDefaults`, `topMenu`, `contextMenu`)
+
+Add matching `isExperimental: { type: 'boolean' }` entries to the JSON Schema at the bottom of the same file alongside each existing `isExtensible` schema entry.
+
+No runtime plumbing. The field is data on the contribution; extensions reading menu data check it before extending an experimental anchor point.
+
+## TSDoc on the documentation types
+
+Each of the following types receives a TSDoc block explaining where to put `'x-experimental': true` to mark the documented entity experimental:
+
+- `Method` — "Set `'x-experimental': true` to mark this method as experimental."
+- `Notification` — same, for notifications.
+- `NetworkObjectDocumentation` — "Set top-level `'x-experimental': true` to mark every method on this object experimental, or set it per-method via `methods[].'x-experimental'`."
+- `SingleMethodDocumentation`, `SingleNotificationDocumentation` — references the inner type.
+- Menus model: `OrderedExtensibleContainer`, `ColumnsWithHeaders`, `WebViewMenu` — "Set `isExperimental: true` to mark this extension point as experimental."
+
+These TSDocs are part of the implementation, not separate docs files.
+
+## Testing
+
+### Unit tests
+
+`generateOpenRpcSchema()` snapshot tests:
+
+- Method registered with `commandDocs.method['x-experimental']: true` appears with `x-experimental: true` in the OpenRPC output.
+- Network object registered with `objectDocumentation['x-experimental']: true` fans out to all its methods.
+- Notification registered via `createNetworkEventEmitterAsync` with `notification['x-experimental']: true` appears in `methods[]` with no `result` and with `x-experimental: true`.
+- Components schema with `x-experimental: true` round-trips through generation.
+
+`network.service.ts` tests:
+
+- `createNetworkEventEmitterAsync` resolves to a functional emitter for any name in `NetworkEventTypes`; central registry is populated.
+- For a name in `SHARED_EVENT_NAMES`: same-name re-registration from a different process succeeds; the new registrant is appended to `registrants[]`; subsequent documentation is ignored.
+- For a name not in `SHARED_EVENT_NAMES`: same-name re-registration (from any process) rejects with an error naming the existing registrant's process ID.
+- Intra-process duplicate (either kind) rejects with the existing error.
+- Build-time/test-time assertion: every key in `SharedNetworkEventTypes` appears in `SHARED_EVENT_NAMES` and vice versa — the two sources must stay in sync.
+- Events created via the deprecated sync API do **not** appear in OpenRPC output and do **not** populate the central registry.
+
+`getNetworkEvent` overload tests:
+
+- New call without `<T>` for a name in `NetworkEventTypes` resolves to the typed overload and the returned payload type is correctly inferred.
+- New call without `<T>` for a name in `SharedNetworkEventTypes` (inherited) likewise infers correctly.
+- Existing call with explicit `<T>` (e.g., `getNetworkEvent<MyType>('foo')`) continues to compile and returns `PlatformEvent<MyType>`; resolves to the deprecated overload.
+- IDE strikethrough on the deprecated overload verified (manual / snapshot).
+
+Menu tests:
+
+- Existing menu-document validation accepts `isExperimental` on `OrderedExtensibleContainer`, `ColumnsWithHeaders`, and `WebViewMenu`.
+- Menu data merge preserves `isExperimental` through `menuDocumentCombiner`.
+
+### Integration
+
+- Generate OpenRPC for a running platform with at least one experimental command, one experimental network object, and one experimental event registered. Verify the generated document at the `GET_METHODS` endpoint contains all three markers.
+
+## Documentation
+
+### In-source TSDoc
+
+See the "TSDoc on the documentation types" section above.
+
+### Context standards
+
+Update `.context/standards/Extension-Development-Guide.md` (or `Paranext-Core-Patterns.md` — placement chosen during implementation) with:
+
+- Authoring conventions covering every surface from this design.
+- The `createNetworkEventEmitter` → `…Async` deprecation note.
+- Cross-reference to the wiki page.
+
+### Wiki page
+
+A separate output of this brainstorming session: `2026-06-08-experimental-apis-wiki-page.md`. Intended for the Paranext wiki, covering what experimental means, when to apply it, how to apply it on each surface, and what it means for consumers.
+
+**The wiki page must be kept in sync with the implementation as the work proceeds.** Every implementation PR that changes any of the API surfaces touched by this design — registration signatures, factory return shapes, type-registry names, event creator APIs, encoding fields — updates `2026-06-08-experimental-apis-wiki-page.md` in the same commit. The wiki page is treated as part of the implementation artifact, not as a one-time output of brainstorming. When the implementation is complete, the file's contents are copied to the public Paranext wiki page.
+
+## Rollout
+
+All changes are additive and non-breaking.
+
+In one PR / change set:
+
+1. `openrpc.model.ts` type changes (`Method`, `Notification`, `NetworkObjectDocumentation`, root `OpenRpc.methods`).
+2. `papi-shared-types.ts` additions: `SharedNetworkEventTypes` (closed type alias with platform shared events) and `NetworkEventTypes` (augmentable interface extending `SharedNetworkEventTypes`); TSDoc on each explaining authoring and the `@experimental` convention.
+3. `SHARED_EVENT_NAMES` constant in `network.service.ts` mirroring `SharedNetworkEventTypes`; build-time / test-time assertion that the two stay in sync.
+4. `createNetworkEventEmitterAsync` implementation + `createNetworkEventEmitter` deprecation tag (signature unchanged).
+5. `getNetworkEvent` typed overload + deprecated explicit-`<T>` overload (signature behavior unchanged for existing callers).
+6. `REGISTER_EVENT` RPC method + `rpcEventDetailsByEventName` in `RpcWebsocketListener` (storing registrants list; shared-vs-exclusive decided by name lookup on each registration).
+7. `generateOpenRpcSchema()` extended to include notifications.
+8. Registration site updates: commands (existing docs param), `networkObjectService.set` (existing 5th param), `dataProviderService.registerEngine` / `registerEngineByType` (new docs param after existing attributes), `webViewProviderService.registerWebViewProvider` (new `attributes` param, then new docs param), PDP factory (new attributes + docs params; return shape augmented with `projectDataProviderEngine` discriminator).
+9. Menus model `isExperimental` additions on `OrderedExtensibleContainer`, `ColumnsWithHeaders`, `WebViewMenu`, plus matching JSON Schema entries.
+10. 25-site migration of `createNetworkEventEmitter` to `createNetworkEventEmitterAsync` (single function; 3 of the names go into `SharedNetworkEventTypes`, the rest into `NetworkEventTypes`).
+11. TSDoc on documentation types pointing out where to set `'x-experimental': true`.
+12. Context standards update.
+13. Wiki page kept in sync with each implementation PR; final contents published to the Paranext wiki at the end.
+
+Follow-up (separate PR): backfill `@experimental` and `x-experimental` on currently-experimental APIs in the codebase (e.g., `platform.interfaceMode` setting at `src/declarations/papi-shared-types.ts:190`).
+
+## Open questions
+
+None at this point. All design decisions resolved during brainstorming.
+
+## References
+
+- TypeDoc 0.28.3 — `package.json:270`. `@experimental` is built-in; `cascadedModifierTags` default includes it.
+- OpenRPC 1.2.6 spec — locked at this version by `src/shared/models/openrpc.model.ts:14-16` due to playground tool support.
+- OpenRPC notifications convention — open-rpc/spec issue #230 (method without `result` represents a notification/event).
+- Existing `@deprecated` usage as a reference for tag style (e.g., `src/declarations/papi-shared-types.ts:94`).
+- Existing ad-hoc experimental warning at `src/declarations/papi-shared-types.ts:190` (the marker this design replaces).

--- a/docs/superpowers/specs/2026-06-08-experimental-api-flag-design.md
+++ b/docs/superpowers/specs/2026-06-08-experimental-api-flag-design.md
@@ -128,7 +128,7 @@ await papi.webViewProviders.registerWebViewProvider(
 
 ```typescript
 declare module 'papi-shared-types' {
-  export interface NetworkEventTypes {
+  export interface NetworkEvents {
     /** @experimental */
     'myExt.somethingHappened': { foo: string };
   }
@@ -151,7 +151,7 @@ const emitter = await papi.network.createNetworkEventEmitterAsync('myExt.somethi
 // emitter is PapiEventEmitter<{ foo: string }> — inferred from the event name
 ```
 
-A small set of platform infrastructure events (e.g., `network-object.onDidCreateNetworkObject`) are intentionally emitted from multiple processes. They live in a closed `SharedNetworkEventTypes` type that `NetworkEventTypes` inherits from. Extensions don't author shared events — but they can subscribe to them like any other event. See the "Event registration plumbing" section for how this is enforced at the central registry.
+A small set of platform infrastructure events (e.g., `network-object.onDidCreateNetworkObject`) are intentionally emitted from multiple processes. They live in a closed `MultiSourceNetworkEvents` type that `NetworkEvents` inherits from. Extensions don't author multi-source events — but they can subscribe to them like any other event. See the "Event registration plumbing" section for how this is enforced at the central registry.
 
 ### Menus
 
@@ -224,7 +224,7 @@ Today's events have no central registry. Each process holds a local `eventEmitte
 
 ### Type registry shape
 
-A single augmentable interface for events, with a closed type alias declaring the platform's shared events. The shared alias is the source of truth at both the type level and the runtime registry.
+A single augmentable interface for events, with a closed type alias declaring the platform's multi-source events. The multi-source alias is the source of truth at both the type level and the runtime registry.
 
 ````typescript
 declare module 'papi-shared-types' {
@@ -232,93 +232,97 @@ declare module 'papi-shared-types' {
    * Network events emitted from multiple processes (each process emits its own local event under
    * the same name). Declared by the platform; not extensible by extensions.
    *
-   * The names listed here are the source of truth for which event names use shared semantics at the
-   * central registry. An event name in this type allows registration from multiple processes (each
-   * process registers once, all emitters are valid sources). Any other event name uses exclusive
-   * semantics (one registrant ever).
+   * The names listed here are the source of truth for which event names use multi-source semantics
+   * at the central registry. An event name in this type allows registration from multiple processes
+   * (each process registers once, all emitters are valid sources). Any other event name uses
+   * single-source semantics (one registrant ever).
    *
-   * Subscribers do not need to know which events are shared — `getNetworkEvent` handles both kinds
-   * identically.
+   * Subscribers do not need to know which events are multi-source — `getNetworkEvent` handles both
+   * kinds identically.
    */
-  export type SharedNetworkEventTypes = {
+  export type MultiSourceNetworkEvents = {
     'network-object.onDidCreateNetworkObject': NetworkObjectDetails;
     'network-object.onDidDisposeNetworkObject': string;
     'shared-store.onDidChange': StoreChangeEvent;
   };
 
   /**
-   * All known network events. Extensions augment this to declare their own events. Inherits the
-   * platform's shared events automatically.
+   * Mapping of network event names to their payload types. Extensions augment this to declare their
+   * own events. Inherits the platform's multi-source events automatically.
    *
    * To declare a new event for use with `createNetworkEventEmitterAsync`:
    *
    * ```ts
    * declare module 'papi-shared-types' {
-   *   export interface NetworkEventTypes {
+   *   export interface NetworkEvents {
    *     'myExt.somethingHappened': { foo: string };
    *   }
    * }
    * ```
    */
-  export interface NetworkEventTypes extends SharedNetworkEventTypes {}
+  export interface NetworkEvents extends MultiSourceNetworkEvents {}
+
+  /** Union of all known network event names (keys of {@link NetworkEvents}). */
+  export type NetworkEventTypes = keyof NetworkEvents;
 }
 ````
 
 The runtime mirror is a constant in `network.service.ts`:
 
 ```typescript
-const SHARED_EVENT_NAMES = new Set<keyof SharedNetworkEventTypes>([
+const MULTI_SOURCE_EVENT_NAMES = new Set<keyof MultiSourceNetworkEvents>([
   'network-object.onDidCreateNetworkObject',
   'network-object.onDidDisposeNetworkObject',
   'shared-store.onDidChange',
 ]);
 ```
 
-The constant and the type alias must stay in sync; a build-time assertion (or a unit test) verifies that every key in `SharedNetworkEventTypes` appears in `SHARED_EVENT_NAMES`.
+The constant and the type alias must stay in sync; a build-time assertion (or a unit test) verifies that every key in `MultiSourceNetworkEvents` appears in `MULTI_SOURCE_EVENT_NAMES`.
 
 ### New emitter creator — single function
 
-One function. Whether the runtime treats a registration as shared or exclusive is determined by the name's presence in `SHARED_EVENT_NAMES`, not by which function the caller invokes.
+One function. Whether the runtime treats a registration as multi-source or single-source is determined by the name's presence in `MULTI_SOURCE_EVENT_NAMES`, not by which function the caller invokes.
 
 ```typescript
 /**
  * Create a network event emitter that participates in central registration. The returned emitter
  * appears in the OpenRPC document if `documentation` is provided.
  *
- * If the event name is in `SharedNetworkEventTypes`, the central registry uses **shared** semantics:
- * multiple processes may register the same name (each process registers once); all corresponding
- * emitters are valid sources.
+ * If the event name is in `MultiSourceNetworkEvents`, the central registry uses **multi-source**
+ * semantics: multiple processes may register the same name (each process registers once); all
+ * corresponding emitters are valid sources.
  *
- * Otherwise the central registry uses **exclusive** semantics: only one process may register a given
- * name; subsequent registrations from any process are rejected.
+ * Otherwise the central registry uses **single-source** semantics: only one process may register a
+ * given name; subsequent registrations from any process are rejected.
  *
  * Intra-process duplicate registration is always rejected regardless of the event's domain.
  *
- * @param eventType  Must be a key of `NetworkEventTypes` (which inherits `SharedNetworkEventTypes`).
+ * @param eventType  Must be a key of `NetworkEvents` (which inherits `MultiSourceNetworkEvents`).
+ *                   Equivalently, must satisfy the `NetworkEventTypes` string-union alias.
  * @param documentation  Optional notification documentation. Carries `'x-experimental': true` to
  *                       mark the event as experimental.
  */
-createNetworkEventEmitterAsync<EventType extends keyof NetworkEventTypes>(
+createNetworkEventEmitterAsync<EventType extends NetworkEventTypes>(
   eventType: EventType,
   documentation?: SingleNotificationDocumentation,
-): Promise<PapiEventEmitter<NetworkEventTypes[EventType]>>;
+): Promise<PapiEventEmitter<NetworkEvents[EventType]>>;
 ```
 
 ### Subscriber — typed overload + deprecated fallback
 
 ```typescript
 /**
- * Subscribe to a typed network event. Declare the event in `NetworkEventTypes` (or rely on
- * `SharedNetworkEventTypes` inheritance for platform events) and the payload type is inferred.
+ * Subscribe to a typed network event. Declare the event in `NetworkEvents` (or rely on
+ * `MultiSourceNetworkEvents` inheritance for platform events) and the payload type is inferred.
  */
-function getNetworkEvent<EventType extends keyof NetworkEventTypes>(
+function getNetworkEvent<EventType extends NetworkEventTypes>(
   eventType: EventType,
-): PlatformEvent<NetworkEventTypes[EventType]>;
+): PlatformEvent<NetworkEvents[EventType]>;
 
 /**
- * @deprecated 8 June 2026. Use the typed signature: declare the event in `NetworkEventTypes` and
- *   call `getNetworkEvent('your.event.name')` without an explicit type parameter. If your event
- *   name is dynamic (e.g., per-instance data-provider events), this signature continues to work
+ * @deprecated 8 June 2026. Use the typed signature: declare the event in `NetworkEvents` and call
+ *   `getNetworkEvent('your.event.name')` without an explicit type parameter. If your event name is
+ *   dynamic (e.g., per-instance data-provider events), this signature continues to work
  *   functionally; suppress the deprecation warning at the call site.
  */
 function getNetworkEvent<T>(eventType: string): PlatformEvent<T>;
@@ -335,7 +339,7 @@ The sync `createNetworkEventEmitter` signature is **unchanged** — preserving f
  * @deprecated 8 June 2026. Use createNetworkEventEmitterAsync. Events created via the sync API
  *   are not centrally registered and do not appear in the OpenRPC document. The async version
  *   properly restricts event registration to prevent multiple sources from emitting the same
- *   network event (unless the event is declared in `SharedNetworkEventTypes`, in which case it
+ *   network event (unless the event is declared in `MultiSourceNetworkEvents`, in which case it
  *   accepts multiple registrants by design).
  */
 createNetworkEventEmitter<T>(eventType: string): PapiEventEmitter<T>;
@@ -343,18 +347,18 @@ createNetworkEventEmitter<T>(eventType: string): PapiEventEmitter<T>;
 
 ### Wire-level plumbing
 
-1. Add a new `REGISTER_EVENT` RPC method on the main process, modeled directly on `REGISTER_METHOD` at `src/main/services/rpc-server.ts:141-145`. The payload carries the event name and optional `SingleNotificationDocumentation`. No domain discriminator is sent over the wire — the registry decides shared vs exclusive by looking up the name in `SHARED_EVENT_NAMES`.
+1. Add a new `REGISTER_EVENT` RPC method on the main process, modeled directly on `REGISTER_METHOD` at `src/main/services/rpc-server.ts:141-145`. The payload carries the event name and optional `SingleNotificationDocumentation`. No domain discriminator is sent over the wire — the registry decides multi-source vs single-source by looking up the name in `MULTI_SOURCE_EVENT_NAMES`.
 2. Add `rpcEventDetailsByEventName: Map<string, { registrants: { processId: string; documentation?: SingleNotificationDocumentation }[] }>` to `RpcWebsocketListener`, parallel to the existing `rpcMethodDetailsByMethodName` at `src/main/services/rpc-websocket-listener.ts:47`.
 3. `createNetworkEventEmitterAsync` invokes `REGISTER_EVENT` and awaits the response before resolving the returned emitter.
-4. `generateOpenRpcSchema()` iterates the event registry and includes each event once as a `Notification` entry in the root `methods` array. Whether the event is shared or exclusive is not exposed in OpenRPC output — both kinds appear as notifications, indistinguishable on the wire.
+4. `generateOpenRpcSchema()` iterates the event registry and includes each event once as a `Notification` entry in the root `methods` array. Whether the event is multi-source or single-source is not exposed in OpenRPC output — both kinds appear as notifications, indistinguishable on the wire.
 
 ### Conflict policy
 
-The central registry decides behavior per registration by checking the event name against `SHARED_EVENT_NAMES`:
+The central registry decides behavior per registration by checking the event name against `MULTI_SOURCE_EVENT_NAMES`:
 
-**Name in `SHARED_EVENT_NAMES` (shared).** Multiple processes may register; each process may register only once. The first registration's documentation is used for OpenRPC output; subsequent documentation is ignored with a debug-level log noting that the documentation was already established.
+**Name in `MULTI_SOURCE_EVENT_NAMES` (multi-source).** Multiple processes may register; each process may register only once. The first registration's documentation is used for OpenRPC output; subsequent documentation is ignored with a debug-level log noting that the documentation was already established.
 
-**Name not in `SHARED_EVENT_NAMES` (exclusive).** First registrant wins. Any subsequent registration from any process is rejected with an error that names the existing registrant's process ID.
+**Name not in `MULTI_SOURCE_EVENT_NAMES` (single-source).** First registrant wins. Any subsequent registration from any process is rejected with an error that names the existing registrant's process ID.
 
 **Intra-process duplicate (either kind).** Always rejected — preserves today's hard error at `src/shared/services/network.service.ts:328-329`.
 
@@ -368,19 +372,19 @@ The deprecated sync `createNetworkEventEmitter` continues to function exactly as
 
 `createNetworkEventEmitter` has 36 occurrences in the codebase. 11 of those are foundational — the API implementation in `src/shared/services/network.service.ts` (7), the emitter model in `src/shared/models/papi-network-event-emitter.model.ts` (1), and generated `lib/papi-dts/papi.d.ts` references (3) — and are touched as part of the foundational work below, not the migration.
 
-The remaining 25 are user-level call sites that all migrate to the same `createNetworkEventEmitterAsync` function. Whether an event is treated as shared or exclusive is determined at the central registry by name lookup against `SHARED_EVENT_NAMES`, not by which function is called — so the migration code path is identical regardless. The categorization below only determines **where each event name's type is declared**: in `SharedNetworkEventTypes` (closed alias in core, for the 3 platform-shared events) or in `NetworkEventTypes` (the augmentable interface, for everything else).
+The remaining 25 are user-level call sites that all migrate to the same `createNetworkEventEmitterAsync` function. Whether an event is treated as multi-source or single-source is determined at the central registry by name lookup against `MULTI_SOURCE_EVENT_NAMES`, not by which function is called — so the migration code path is identical regardless. The categorization below only determines **where each event name's type is declared**: in `MultiSourceNetworkEvents` (closed alias in core, for the 3 platform multi-source events) or in `NetworkEvents` (the augmentable interface, for everything else).
 
-### Events whose names go in `SharedNetworkEventTypes` (3 sites)
+### Events whose names go in `MultiSourceNetworkEvents` (3 sites)
 
-These live in `src/shared/services/*` and are emitted by every process that hosts the service. Their names are added to the closed `SharedNetworkEventTypes` type alias in core declarations and to the `SHARED_EVENT_NAMES` runtime constant:
+These live in `src/shared/services/*` and are emitted by every process that hosts the service. Their names are added to the closed `MultiSourceNetworkEvents` type alias in core declarations and to the `MULTI_SOURCE_EVENT_NAMES` runtime constant:
 
 - `src/shared/services/network-object.service.ts:124-127` — `onDidCreateNetworkObjectEmitter`. Every process emits when it creates a local network object.
 - `src/shared/services/network-object.service.ts:142-144` — `onDidDisposeNetworkObjectEmitter`. Every process emits when it disposes a local network object (comment at lines 139-141 explicitly notes the multi-process intent).
 - `src/shared/services/shared-store.service.ts:84` — `storeChangeEmitter`. Every process emits when its local store changes.
 
-### Events whose names go in `NetworkEventTypes` (22 sites)
+### Events whose names go in `NetworkEvents` (22 sites)
 
-Single-process emitters. Names are added to the augmentable `NetworkEventTypes` interface (in core declarations for platform events; in extension `.d.ts` files for extension events). One site (the data-provider per-instance emitter) has a dynamic name and uses the type-assertion pattern shown below. Categorized by migration ease:
+Single-source emitters. Names are added to the augmentable `NetworkEvents` interface (in core declarations for platform events; in extension `.d.ts` files for extension events). One site (the data-provider per-instance emitter) has a dynamic name and uses the type-assertion pattern shown below. Categorized by migration ease:
 
 **Easy** — already in an async initialization context, straightforward `await` swap:
 
@@ -392,15 +396,15 @@ Single-process emitters. Names are added to the augmentable `NetworkEventTypes` 
 
 **Dynamic-name (type-assertion pattern)** — one site has a name that can't be a literal in the registry:
 
-- `src/shared/services/data-provider.service.ts:817` — the name is `serializeRequestType(dataProviderObjectId, ON_DID_UPDATE)`, computed per data-provider instance. The payload type is statically known from the surrounding function's generics. Migration uses a double assertion (name into `keyof NetworkEventTypes` to satisfy the constraint, then result into the known emitter type) with a comment explaining why the literal-name path isn't available:
+- `src/shared/services/data-provider.service.ts:817` — the name is `serializeRequestType(dataProviderObjectId, ON_DID_UPDATE)`, computed per data-provider instance. The payload type is statically known from the surrounding function's generics. Migration uses a double assertion (name into `NetworkEventTypes` to satisfy the constraint, then result into the known emitter type) with a comment explaining why the literal-name path isn't available:
 
   ```ts
   const dynamicName = serializeRequestType(dataProviderObjectId, ON_DID_UPDATE);
   const onDidUpdateEmitter = (await networkService.createNetworkEventEmitterAsync(
     // Per-instance data provider events have dynamic names that can't be declared in
-    // NetworkEventTypes. Cast the name to satisfy the constraint; the payload type is
-    // recovered from the surrounding function's generic context.
-    dynamicName as keyof NetworkEventTypes,
+    // NetworkEvents. Cast the name to satisfy the NetworkEventTypes constraint; the payload
+    // type is recovered from the surrounding function's generic context.
+    dynamicName as NetworkEventTypes,
   )) as unknown as PapiEventEmitter<
     DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>
   >;
@@ -425,7 +429,7 @@ Bootstrap-order note: the `REGISTER_EVENT` RPC method itself must be registered 
 
 ### Dynamic event-name escape hatch
 
-Some core code (data-provider change events, etc.) creates emitters with names not declared in `NetworkEventTypes`. The async signature requires `keyof NetworkEventTypes`, so these sites use `as keyof NetworkEventTypes` to type-assert. Document the reason inline with a brief comment.
+Some core code (data-provider change events, etc.) creates emitters with names not declared in `NetworkEvents`. The async signature requires `NetworkEventTypes` (the string-union alias), so these sites use `as NetworkEventTypes` to type-assert. Document the reason inline with a brief comment.
 
 ## Registration surfaces — fanout
 
@@ -511,17 +515,17 @@ These TSDocs are part of the implementation, not separate docs files.
 
 `network.service.ts` tests:
 
-- `createNetworkEventEmitterAsync` resolves to a functional emitter for any name in `NetworkEventTypes`; central registry is populated.
-- For a name in `SHARED_EVENT_NAMES`: same-name re-registration from a different process succeeds; the new registrant is appended to `registrants[]`; subsequent documentation is ignored.
-- For a name not in `SHARED_EVENT_NAMES`: same-name re-registration (from any process) rejects with an error naming the existing registrant's process ID.
+- `createNetworkEventEmitterAsync` resolves to a functional emitter for any name in `NetworkEvents`; central registry is populated.
+- For a name in `MULTI_SOURCE_EVENT_NAMES`: same-name re-registration from a different process succeeds; the new registrant is appended to `registrants[]`; subsequent documentation is ignored.
+- For a name not in `MULTI_SOURCE_EVENT_NAMES`: same-name re-registration (from any process) rejects with an error naming the existing registrant's process ID.
 - Intra-process duplicate (either kind) rejects with the existing error.
-- Build-time/test-time assertion: every key in `SharedNetworkEventTypes` appears in `SHARED_EVENT_NAMES` and vice versa — the two sources must stay in sync.
+- Build-time/test-time assertion: every key in `MultiSourceNetworkEvents` appears in `MULTI_SOURCE_EVENT_NAMES` and vice versa — the two sources must stay in sync.
 - Events created via the deprecated sync API do **not** appear in OpenRPC output and do **not** populate the central registry.
 
 `getNetworkEvent` overload tests:
 
-- New call without `<T>` for a name in `NetworkEventTypes` resolves to the typed overload and the returned payload type is correctly inferred.
-- New call without `<T>` for a name in `SharedNetworkEventTypes` (inherited) likewise infers correctly.
+- New call without `<T>` for a name in `NetworkEvents` resolves to the typed overload and the returned payload type is correctly inferred.
+- New call without `<T>` for a name in `MultiSourceNetworkEvents` (inherited) likewise infers correctly.
 - Existing call with explicit `<T>` (e.g., `getNetworkEvent<MyType>('foo')`) continues to compile and returns `PlatformEvent<MyType>`; resolves to the deprecated overload.
 - IDE strikethrough on the deprecated overload verified (manual / snapshot).
 
@@ -561,15 +565,15 @@ All changes are additive and non-breaking.
 In one PR / change set:
 
 1. `openrpc.model.ts` type changes (`Method`, `Notification`, `NetworkObjectDocumentation`, root `OpenRpc.methods`).
-2. `papi-shared-types.ts` additions: `SharedNetworkEventTypes` (closed type alias with platform shared events) and `NetworkEventTypes` (augmentable interface extending `SharedNetworkEventTypes`); TSDoc on each explaining authoring and the `@experimental` convention.
-3. `SHARED_EVENT_NAMES` constant in `network.service.ts` mirroring `SharedNetworkEventTypes`; build-time / test-time assertion that the two stay in sync.
+2. `papi-shared-types.ts` additions: `MultiSourceNetworkEvents` (closed type alias with platform multi-source events), `NetworkEvents` (augmentable interface extending `MultiSourceNetworkEvents`), and `NetworkEventTypes` (= `keyof NetworkEvents`); TSDoc on each explaining authoring and the `@experimental` convention.
+3. `MULTI_SOURCE_EVENT_NAMES` constant in `network.service.ts` mirroring `MultiSourceNetworkEvents`; build-time / test-time assertion that the two stay in sync.
 4. `createNetworkEventEmitterAsync` implementation + `createNetworkEventEmitter` deprecation tag (signature unchanged).
 5. `getNetworkEvent` typed overload + deprecated explicit-`<T>` overload (signature behavior unchanged for existing callers).
 6. `REGISTER_EVENT` RPC method + `rpcEventDetailsByEventName` in `RpcWebsocketListener` (storing registrants list; shared-vs-exclusive decided by name lookup on each registration).
 7. `generateOpenRpcSchema()` extended to include notifications.
 8. Registration site updates: commands (existing docs param), `networkObjectService.set` (existing 5th param), `dataProviderService.registerEngine` / `registerEngineByType` (new docs param after existing attributes), `webViewProviderService.registerWebViewProvider` (new `attributes` param, then new docs param), PDP factory (new attributes + docs params; return shape augmented with `projectDataProviderEngine` discriminator).
 9. Menus model `isExperimental` additions on `OrderedExtensibleContainer`, `ColumnsWithHeaders`, `WebViewMenu`, plus matching JSON Schema entries.
-10. 25-site migration of `createNetworkEventEmitter` to `createNetworkEventEmitterAsync` (single function; 3 of the names go into `SharedNetworkEventTypes`, the rest into `NetworkEventTypes`).
+10. 25-site migration of `createNetworkEventEmitter` to `createNetworkEventEmitterAsync` (single function; 3 of the names go into `MultiSourceNetworkEvents`, the rest into `NetworkEvents`).
 11. TSDoc on documentation types pointing out where to set `'x-experimental': true`.
 12. Context standards update.
 13. Wiki page kept in sync with each implementation PR; final contents published to the Paranext wiki at the end.

--- a/docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md
+++ b/docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md
@@ -1,0 +1,238 @@
+# Experimental APIs in Platform.Bible
+
+This page explains what "experimental" means for a Platform.Bible API, how to recognize one, and how to mark one when you're authoring an API yourself.
+
+> **Note for maintainers:** this page is kept in sync with the implementation. Every PR that changes any of the API surfaces below updates this page in the same commit. When the work is complete, the contents here will be the canonical wiki content.
+
+## What does experimental mean
+
+An API marked **experimental** is one whose shape is not yet considered stable enough to depend on. It may change or be removed in any future release without following semantic versioning. The marker is informational only: experimental APIs behave identically to stable ones at runtime — nothing is gated, no consent is required.
+
+Mark an API experimental whenever it is not a confident, solid, general-purpose contract. Specifically:
+
+- APIs designed for one particular UI or use case rather than a broad audience.
+- APIs whose shape is likely to change as you learn how they're used.
+- APIs added to unblock a feature without long-term-suitability review.
+- APIs not yet covered by tests in a meaningful way.
+
+When the API has stabilized and earned confidence, remove the experimental marker. Promote out of experimental deliberately, not by accident.
+
+## Recognizing experimental APIs
+
+Two ways:
+
+**In your editor.** Hover over an API in TypeScript and look for the `@experimental` tag in the docstring. Members of an interface marked `@experimental` inherit the marker — every method on an experimental type is itself experimental in the generated documentation.
+
+**At runtime.** Inspect the live OpenRPC document (call the `rpc.discover` JSON-RPC method against the platform's WebSocket on port 8876). Experimental methods, notifications, and network objects carry `"x-experimental": true`.
+
+## Marking an API experimental — by surface
+
+For each surface there are two complementary places to apply the marker: the TypeScript types (so IDE consumers see it) and the registration call's documentation (so the OpenRPC document reflects it). Apply both whenever you can.
+
+### Commands
+
+```typescript
+declare module 'papi-shared-types' {
+  export interface CommandHandlers {
+    /** @experimental */
+    'myExt.expCmd': (arg: string) => Promise<void>;
+  }
+}
+
+await papi.commands.registerCommand('myExt.expCmd', handler, {
+  method: {
+    'x-experimental': true,
+    summary: 'Does the experimental thing',
+    params: [{ name: 'arg', schema: { type: 'string' } }],
+    result: { name: 'returns', schema: { type: 'null' } },
+  },
+});
+```
+
+### Network objects
+
+`networkObjectService.set` already accepts a `NetworkObjectDocumentation` parameter. Setting `'x-experimental': true` at the top level fans out to every method exposed by the object — no need to mark each method individually.
+
+```typescript
+await papi.networkObjects.set('myObj', impl, 'object', /* attributes */ undefined, {
+  'x-experimental': true,
+});
+```
+
+To mark only a specific method on the object, set it on that method's entry in `documentation.methods[]` instead of at the top level.
+
+### Data providers
+
+Data providers are network objects underneath, so the same fanout applies. The documentation parameter is new — pass it as `NetworkObjectDocumentation`:
+
+```typescript
+await papi.dataProviders.registerEngine('myDP', engine, dataTypes, attributes, {
+  'x-experimental': true,
+});
+```
+
+### WebView providers
+
+```typescript
+await papi.webViewProviders.registerWebViewProvider(
+  'myView',
+  provider,
+  /* attributes */ undefined,
+  /* documentation */ { 'x-experimental': true },
+);
+```
+
+Marking a WebView provider experimental implies the provider's WebView state shape and `getWebView` options shape are also experimental. There's no per-property granularity for state/options at this level — graduate the whole provider out of experimental when ready.
+
+### Project data providers
+
+PDPs need marking in two places: the `projectInterfaces` declaration (TypeScript) and the registration call (wire).
+
+```typescript
+declare module 'papi-shared-types' {
+  export interface ProjectDataProviderInterfaces {
+    /** @experimental */
+    'myExt.expInterface': IProjectDataProvider<MyDataTypes>;
+  }
+}
+
+await papi.projectDataProviders.registerProjectDataProviderEngineFactory(
+  ['myExt.expInterface'],
+  factory,
+  /* attributes */ {},
+  /* documentation */ { 'x-experimental': true },
+);
+```
+
+`registerProjectDataProviderEngineFactory` lets you specify both registration-level attributes and per-PDP-instance attributes (the latter via the return value of `createProjectDataProviderEngine`). The platform overlays canonical `projectInterfaces` and `projectId` over whatever you supply — those fields cannot be overridden through attributes.
+
+For per-PDP-instance customization, the factory's `createProjectDataProviderEngine` method can return `{ projectDataProviderEngine, attributes?, documentation? }` instead of just the engine. The unusual property name (`projectDataProviderEngine` rather than `engine`) is deliberate — it cannot accidentally collide with a property an engine itself exposes, so the platform's narrowing check on the return value is unambiguous.
+
+### Network events
+
+Declare your event in the `NetworkEventTypes` interface and create the emitter — the payload type is inferred from the registry, and the platform handles registration uniformly.
+
+```typescript
+declare module 'papi-shared-types' {
+  export interface NetworkEventTypes {
+    /** @experimental */
+    'myExt.somethingHappened': { foo: string };
+  }
+}
+
+const emitter = await papi.network.createNetworkEventEmitterAsync('myExt.somethingHappened', {
+  notification: {
+    'x-experimental': true,
+    summary: 'Fires when something experimental happens',
+    params: [
+      { name: 'event', schema: { type: 'object', properties: { foo: { type: 'string' } } } },
+    ],
+  },
+});
+// emitter is PapiEventEmitter<{ foo: string }> — the payload type is inferred
+```
+
+If any other process tries to register the same event name, the platform rejects the second registration. Each event has exactly one source.
+
+Subscribing is symmetric — pass the same name, no explicit type parameter needed:
+
+```typescript
+papi.network.getNetworkEvent('myExt.somethingHappened')((event) => {
+  // event is { foo: string } — inferred from the registry
+});
+```
+
+#### Subscribing to platform events
+
+A small set of platform infrastructure events (network-object lifecycle, shared-store changes) are emitted from every process that hosts the corresponding service. These are declared in `SharedNetworkEventTypes`, which `NetworkEventTypes` inherits from, so they show up in IntelliSense alongside extension-declared events. As a subscriber, you don't need to know which events are shared — `getNetworkEvent` handles both the same way.
+
+The platform owns this list; extensions don't author shared events. If you ever find yourself wanting a single name emitted from multiple processes (rare), you can either:
+
+1. Pick the more natural pattern: each process emits its own distinctly-named event (`myExt.fromMain.thing`, `myExt.fromExtHost.thing`) and subscribers listen to whichever they care about.
+2. Open a platform issue describing the use case — the shared-event surface is intentionally small.
+
+#### Deprecated sync API
+
+The synchronous `createNetworkEventEmitter` is deprecated as of 8 June 2026. It continues to function but does not participate in central event registration, so events created via the sync API:
+
+- Are invisible in the OpenRPC document.
+- Cannot be marked as experimental on the wire.
+- Don't enforce the "single registrant per event name" guarantee.
+
+Migrate new code to `createNetworkEventEmitterAsync`.
+
+The legacy `getNetworkEvent<T>(name)` overload that takes an explicit type parameter is also deprecated — IntelliSense will show strikethrough on calls that resolve to it. Migrate by declaring your event in `NetworkEventTypes` and dropping the explicit `<T>`:
+
+```typescript
+// Before (deprecated)
+const ev = papi.network.getNetworkEvent<MyType>('myExt.somethingHappened');
+
+// After
+declare module 'papi-shared-types' {
+  export interface NetworkEventTypes {
+    'myExt.somethingHappened': MyType;
+  }
+}
+const ev = papi.network.getNetworkEvent('myExt.somethingHappened');
+```
+
+If your event name is dynamic (e.g., per-instance data-provider events that include an object id), the deprecated explicit-`<T>` overload remains functional — suppress the warning at the call site with a brief comment explaining why a static declaration isn't possible.
+
+### Menu extensibility
+
+Mark an extension point (a column, group, or whole WebView menu) experimental so other extensions know not to depend on its shape:
+
+```jsonc
+{
+  "columns": {
+    "myExt.myColumn": {
+      "label": "%myColumn.label%",
+      "order": 1,
+      "isExtensible": true,
+      "isExperimental": true,
+    },
+  },
+}
+```
+
+Available on `OrderedExtensibleContainer` (columns, groups), `ColumnsWithHeaders`, and `WebViewMenu`. Extensions reading menu data should check `isExperimental` before contributing to it.
+
+## Encoding reference
+
+Three field-name conventions show up across the surfaces — each follows the surrounding code style:
+
+| Where you see it                         | Field                    |
+| ---------------------------------------- | ------------------------ |
+| TSDoc tag in `.ts` source                | `@experimental`          |
+| OpenRPC document (over the wire)         | `"x-experimental": true` |
+| Menus model JSON                         | `"isExperimental": true` |
+| Internal TypeScript registration options | `isExperimental: true`   |
+
+You write all of them; nothing is auto-extracted. The TSDoc tag is for IDE/documentation consumers. The OpenRPC field is for runtime tooling that reads the live document. The menus field is data on a menu contribution that other extensions can read.
+
+## What experimental does NOT do
+
+- It does **not** prevent extensions from calling the API.
+- It does **not** require any opt-in or manifest acknowledgement.
+- It does **not** emit runtime warnings when called.
+- It does **not** affect the generated `papi.d.ts` types beyond rendering the tag in TypeDoc HTML.
+
+The marker is purely informational — its purpose is to set expectations, not to enforce them.
+
+## When to graduate an API out of experimental
+
+Once the API has:
+
+- Settled on a stable shape that hasn't needed change in some time.
+- Meaningful test coverage exercising its real use.
+- Demonstrated suitability for a broader audience than the original use case.
+
+Remove the `@experimental` TSDoc tag from the type declaration. Remove the `'x-experimental'` field from the registration documentation. Note the promotion in the changelog or release notes so consumers see the API has stabilized.
+
+## See also
+
+- [`@deprecated` convention][deprecated] — sibling marker for APIs being phased out.
+- [`createNetworkEventEmitterAsync` migration guide][migration] — for moving existing event emitters to the new async API.
+
+[deprecated]: # 'Existing pattern: /** @deprecated 3 December 2024. Renamed to X. */ — date plus reason.'
+[migration]: # 'Replace createNetworkEventEmitter with await createNetworkEventEmitterAsync. Module-level constants become let bindings inside an initialize function with accessor functions that throw if not yet initialized.'

--- a/docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md
+++ b/docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md
@@ -97,6 +97,7 @@ declare module 'papi-shared-types' {
 }
 
 await papi.projectDataProviders.registerProjectDataProviderEngineFactory(
+  'myExt.expFactory',
   ['myExt.expInterface'],
   factory,
   /* attributes */ {},

--- a/docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md
+++ b/docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md
@@ -111,11 +111,11 @@ For per-PDP-instance customization, the factory's `createProjectDataProviderEngi
 
 ### Network events
 
-Declare your event in the `NetworkEventTypes` interface and create the emitter — the payload type is inferred from the registry, and the platform handles registration uniformly.
+Declare your event in the `NetworkEvents` interface and create the emitter — the payload type is inferred from the registry, and the platform handles registration uniformly.
 
 ```typescript
 declare module 'papi-shared-types' {
-  export interface NetworkEventTypes {
+  export interface NetworkEvents {
     /** @experimental */
     'myExt.somethingHappened': { foo: string };
   }
@@ -145,9 +145,9 @@ papi.network.getNetworkEvent('myExt.somethingHappened')((event) => {
 
 #### Subscribing to platform events
 
-A small set of platform infrastructure events (network-object lifecycle, shared-store changes) are emitted from every process that hosts the corresponding service. These are declared in `SharedNetworkEventTypes`, which `NetworkEventTypes` inherits from, so they show up in IntelliSense alongside extension-declared events. As a subscriber, you don't need to know which events are shared — `getNetworkEvent` handles both the same way.
+A small set of platform infrastructure events (network-object lifecycle, shared-store changes) are emitted from every process that hosts the corresponding service. These are declared in `MultiSourceNetworkEvents`, which `NetworkEvents` inherits from, so they show up in IntelliSense alongside extension-declared events. As a subscriber, you don't need to know which events are multi-source — `getNetworkEvent` handles both the same way.
 
-The platform owns this list; extensions don't author shared events. If you ever find yourself wanting a single name emitted from multiple processes (rare), you can either:
+The platform owns this list; extensions don't author multi-source events. If you ever find yourself wanting a single name emitted from multiple processes (rare), you can either:
 
 1. Pick the more natural pattern: each process emits its own distinctly-named event (`myExt.fromMain.thing`, `myExt.fromExtHost.thing`) and subscribers listen to whichever they care about.
 2. Open a platform issue describing the use case — the shared-event surface is intentionally small.
@@ -162,7 +162,7 @@ The synchronous `createNetworkEventEmitter` is deprecated as of 8 June 2026. It 
 
 Migrate new code to `createNetworkEventEmitterAsync`.
 
-The legacy `getNetworkEvent<T>(name)` overload that takes an explicit type parameter is also deprecated — IntelliSense will show strikethrough on calls that resolve to it. Migrate by declaring your event in `NetworkEventTypes` and dropping the explicit `<T>`:
+The legacy `getNetworkEvent<T>(name)` overload that takes an explicit type parameter is also deprecated — IntelliSense will show strikethrough on calls that resolve to it. Migrate by declaring your event in `NetworkEvents` and dropping the explicit `<T>`:
 
 ```typescript
 // Before (deprecated)
@@ -170,7 +170,7 @@ const ev = papi.network.getNetworkEvent<MyType>('myExt.somethingHappened');
 
 // After
 declare module 'papi-shared-types' {
-  export interface NetworkEventTypes {
+  export interface NetworkEvents {
     'myExt.somethingHappened': MyType;
   }
 }

--- a/docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md
+++ b/docs/superpowers/specs/2026-06-08-experimental-apis-wiki-page.md
@@ -21,7 +21,7 @@ When the API has stabilized and earned confidence, remove the experimental marke
 
 Two ways:
 
-**In your editor.** Hover over an API in TypeScript and look for the `@experimental` tag in the docstring. Members of an interface marked `@experimental` inherit the marker — every method on an experimental type is itself experimental in the generated documentation.
+**In your editor.** Hover over an API in TypeScript and look for the `@experimental` tag in the docstring. Members of an interface marked `@experimental` inherit the marker — every method on an experimental type is itself experimental in the generated documentation. (TypeDoc 0.28.3+ treats `@experimental` as a built-in modifier tag and cascades it to members automatically — no configuration needed.)
 
 **At runtime.** Inspect the live OpenRPC document (call the `rpc.discover` JSON-RPC method against the platform's WebSocket on port 8876). Experimental methods, notifications, and network objects carry `"x-experimental": true`.
 
@@ -130,7 +130,7 @@ const emitter = await papi.network.createNetworkEventEmitterAsync('myExt.somethi
     ],
   },
 });
-// emitter is PapiEventEmitter<{ foo: string }> — the payload type is inferred
+// emitter is PlatformEventEmitter<{ foo: string }> — the payload type is inferred
 ```
 
 If any other process tries to register the same event name, the platform rejects the second registration. Each event has exactly one source.

--- a/extensions/src/hello-rock3/src/main.ts
+++ b/extensions/src/hello-rock3/src/main.ts
@@ -239,8 +239,8 @@ const helloRock3ProjectViewerProvider: IWebViewProviderWithType = {
 /** Number of times the `helloRock3` function has been called */
 let helloRock3Count = 0;
 /** Emitter to inform subscribers when `helloRock3` is called */
-let onHelloRock3Emitter: PlatformEventEmitter<HelloRock3Event>;
-const onHelloRock3EventType = 'helloRock3.onHelloRock3';
+let onHelloRock3Emitter: PlatformEventEmitter<HelloRock3Event> | undefined;
+const onHelloRock3EventType = 'helloRock3.onHelloRock3' as const;
 
 /**
  * Simple function to return `Hello Third Rock!`. Registered as a command handler.
@@ -250,7 +250,9 @@ const onHelloRock3EventType = 'helloRock3.onHelloRock3';
  */
 function helloRock3() {
   helloRock3Count += 1;
-  onHelloRock3Emitter?.emit({ times: helloRock3Count });
+  if (!onHelloRock3Emitter)
+    throw new Error('hello-rock3 not initialized — call activate() before emitting onHelloRock3');
+  onHelloRock3Emitter.emit({ times: helloRock3Count });
   return 'Hello Third Rock!';
 }
 
@@ -458,9 +460,7 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     reactWebView2Provider,
   );
 
-  onHelloRock3Emitter = await papi.network.createNetworkEventEmitterAsync(
-    onHelloRock3EventType as 'helloRock3.onHelloRock3',
-  );
+  onHelloRock3Emitter = await papi.network.createNetworkEventEmitterAsync(onHelloRock3EventType);
 
   const helloRock3Promise = papi.commands.registerCommand('helloRock3.helloRock3', helloRock3);
 

--- a/extensions/src/hello-rock3/src/main.ts
+++ b/extensions/src/hello-rock3/src/main.ts
@@ -7,7 +7,7 @@ import type {
   WebViewDefinition,
 } from '@papi/core';
 import type { HelloRock3Event, HelloRock3ProjectWebViewController } from 'hello-rock3';
-import { getErrorMessage, isPlatformError, PlatformEventEmitter } from 'platform-bible-utils';
+import { getErrorMessage, isPlatformError } from 'platform-bible-utils';
 import { checkDetails, createHelloCheck } from './checks';
 import { HelloRock3ProjectDataProviderEngineFactory } from './models/hello-rock3-project-data-provider-engine-factory.model';
 import { HELLO_ROCK3_PROJECT_INTERFACES } from './models/hello-rock3-project-data-provider-engine.model';
@@ -238,8 +238,13 @@ const helloRock3ProjectViewerProvider: IWebViewProviderWithType = {
 
 /** Number of times the `helloRock3` function has been called */
 let helloRock3Count = 0;
-/** Emitter to inform subscribers when `helloRock3` is called */
-let onHelloRock3Emitter: PlatformEventEmitter<HelloRock3Event> | undefined;
+/**
+ * Buffered emitter to inform subscribers when `helloRock3` is called. Buffered so a call that
+ * happens before the emitter finishes registering is queued and flushed, not thrown away.
+ */
+let onHelloRock3Emitter:
+  | { emit: (event: HelloRock3Event) => void; dispose: () => void }
+  | undefined;
 const onHelloRock3EventType = 'helloRock3.onHelloRock3' as const;
 
 /**
@@ -250,9 +255,9 @@ const onHelloRock3EventType = 'helloRock3.onHelloRock3' as const;
  */
 function helloRock3() {
   helloRock3Count += 1;
-  if (!onHelloRock3Emitter)
-    throw new Error('hello-rock3 not initialized — call activate() before emitting onHelloRock3');
-  onHelloRock3Emitter.emit({ times: helloRock3Count });
+  // Buffered emit — if this runs before the emitter has registered, the event is queued and flushed
+  // once registration completes (rather than throwing).
+  onHelloRock3Emitter?.emit({ times: helloRock3Count });
   return 'Hello Third Rock!';
 }
 
@@ -460,7 +465,9 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     reactWebView2Provider,
   );
 
-  onHelloRock3Emitter = await papi.network.createNetworkEventEmitterAsync(onHelloRock3EventType, {
+  // Created synchronously (buffered) so a `helloRock3` call can't outrun registration. Buffered
+  // emits are flushed once registration completes.
+  onHelloRock3Emitter = papi.network.createBufferedNetworkEventEmitter(onHelloRock3EventType, {
     notification: {
       summary: 'Emitted each time the helloRock3.helloRock3 command is called.',
       params: [
@@ -512,7 +519,12 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     await htmlWebViewProviderPromise,
     await reactWebViewProviderPromise,
     await reactWebView2ProviderPromise,
-    onHelloRock3Emitter,
+    {
+      dispose: async () => {
+        onHelloRock3Emitter?.dispose();
+        return true;
+      },
+    },
     await helloRock3Promise,
     await showContextMenuAlertPromise,
     await helloExceptionPromise,

--- a/extensions/src/hello-rock3/src/main.ts
+++ b/extensions/src/hello-rock3/src/main.ts
@@ -460,7 +460,19 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     reactWebView2Provider,
   );
 
-  onHelloRock3Emitter = await papi.network.createNetworkEventEmitterAsync(onHelloRock3EventType);
+  onHelloRock3Emitter = await papi.network.createNetworkEventEmitterAsync(onHelloRock3EventType, {
+    notification: {
+      summary: 'Emitted each time the helloRock3.helloRock3 command is called.',
+      params: [
+        {
+          name: 'event',
+          required: true,
+          summary: 'The hello-rock3 event payload.',
+          schema: { type: 'object' },
+        },
+      ],
+    },
+  });
 
   const helloRock3Promise = papi.commands.registerCommand('helloRock3.helloRock3', helloRock3);
 

--- a/extensions/src/hello-rock3/src/main.ts
+++ b/extensions/src/hello-rock3/src/main.ts
@@ -458,8 +458,9 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     reactWebView2Provider,
   );
 
-  onHelloRock3Emitter =
-    papi.network.createNetworkEventEmitter<HelloRock3Event>(onHelloRock3EventType);
+  onHelloRock3Emitter = await papi.network.createNetworkEventEmitterAsync(
+    onHelloRock3EventType as 'helloRock3.onHelloRock3',
+  );
 
   const helloRock3Promise = papi.commands.registerCommand('helloRock3.helloRock3', helloRock3);
 

--- a/extensions/src/hello-rock3/src/types/hello-rock3.d.ts
+++ b/extensions/src/hello-rock3/src/types/hello-rock3.d.ts
@@ -204,7 +204,7 @@ declare module 'papi-shared-types' {
     HelloRock3Event,
   } from 'hello-rock3';
 
-  export interface NetworkEventTypes {
+  export interface NetworkEvents {
     /** Emitted each time the `helloRock3.helloRock3` command is called */
     'helloRock3.onHelloRock3': HelloRock3Event;
   }

--- a/extensions/src/hello-rock3/src/types/hello-rock3.d.ts
+++ b/extensions/src/hello-rock3/src/types/hello-rock3.d.ts
@@ -33,7 +33,7 @@ declare module 'hello-rock3' {
     IBaseProjectDataProvider<HelloRock3ProjectDataTypes> & HelloRock3ProjectDataProviderMethods;
 
   /** Event containing information about `helloRock3` */
-  type HelloRock3Event = {
+  export type HelloRock3Event = {
     /**
      * How many times the `helloRock3` function has been run (called by `helloRock3.helloRock3`
      * command)
@@ -201,7 +201,13 @@ declare module 'papi-shared-types' {
     IHelloRock3ProjectDataProvider,
     HelloRock3ProjectWebViewController,
     HTMLColorNames,
+    HelloRock3Event,
   } from 'hello-rock3';
+
+  export interface NetworkEventTypes {
+    /** Emitted each time the `helloRock3.helloRock3` command is called */
+    'helloRock3.onHelloRock3': HelloRock3Event;
+  }
 
   export interface CommandHandlers {
     /**

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -1237,6 +1237,19 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
   // Create the selection changed event emitter
   selectionChangedEventEmitter = await papi.network.createNetworkEventEmitterAsync(
     EDITOR_SELECTION_CHANGED_EVENT,
+    {
+      notification: {
+        summary: 'Emitted when the selection in a Scripture editor changes.',
+        params: [
+          {
+            name: 'selectionChange',
+            required: true,
+            summary: 'The new editor selection.',
+            schema: { type: 'object' },
+          },
+        ],
+      },
+    },
   );
 
   // Default active project picker for simple layout. Subscribes to web-view-open and

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -16,7 +16,6 @@ import {
 } from 'platform-bible-utils';
 import {
   EditorDecorations,
-  SelectionChangeEvent,
   EditorWebViewMessage,
   OpenEditorOptions,
   PlatformScriptureEditorWebViewController,
@@ -57,8 +56,28 @@ const COMMENTARIES_PANEL_WEBVIEW_TYPE = 'platformScriptureEditor.commentaries';
  */
 const EDITOR_SELECTION_CHANGED_EVENT = 'platformScriptureEditor.onDidSelectionChange' as const;
 
-/** Event emitter for selection change events. Created in activate() */
-let selectionChangedEventEmitter: PlatformEventEmitter<SelectionChangeEvent> | undefined;
+/**
+ * Buffered emitter for editor selection changes. Created at module load so a restored editor that
+ * pushes its first selection on mount — before `activate()` finishes registering the emitter — is
+ * not lost: the latest selection per web view is buffered and flushed once registration completes.
+ */
+const selectionChangedEventEmitter = papi.network.createBufferedNetworkEventEmitter(
+  EDITOR_SELECTION_CHANGED_EVENT,
+  {
+    notification: {
+      summary: 'Emitted when the selection in a Scripture editor changes.',
+      params: [
+        {
+          name: 'selectionChange',
+          required: true,
+          summary: 'The new editor selection.',
+          schema: { type: 'object' },
+        },
+      ],
+    },
+  },
+  { bufferStrategy: { latestByKey: (event) => event.webViewId } },
+);
 
 // Selection is stored per-WebViewController instance in createWebViewController.
 
@@ -811,10 +830,8 @@ class ScriptureEditorWebViewFactory extends WebViewFactory<typeof SCRIPTURE_EDIT
         if (firstSelectionAsync && !firstSelectionAsync.hasSettled) {
           firstSelectionAsync.resolveToValue(selection);
         }
-        if (!selectionChangedEventEmitter)
-          throw new Error(
-            'platform-scripture-editor not initialized — call activate() before emitting selectionChanged',
-          );
+        // Buffered emit — if a restored editor pushes a selection before the emitter has registered,
+        // the latest selection per web view is buffered and flushed rather than thrown away.
         selectionChangedEventEmitter.emit({ webViewId, selection });
       },
       async dispose() {
@@ -1234,23 +1251,7 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     },
   );
 
-  // Create the selection changed event emitter
-  selectionChangedEventEmitter = await papi.network.createNetworkEventEmitterAsync(
-    EDITOR_SELECTION_CHANGED_EVENT,
-    {
-      notification: {
-        summary: 'Emitted when the selection in a Scripture editor changes.',
-        params: [
-          {
-            name: 'selectionChange',
-            required: true,
-            summary: 'The new editor selection.',
-            schema: { type: 'object' },
-          },
-        ],
-      },
-    },
-  );
+  // The selection-changed emitter is created at module load (buffered); nothing to set up here.
 
   // Default active project picker for simple layout. Subscribes to web-view-open and
   // sync-completion events and attempts to fill the empty Scripture Editor with the
@@ -1278,7 +1279,12 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     await bibleTextsPanelWebViewProviderPromise,
     await commentariesPanelWebViewProviderPromise,
     await openResourceTextPromise,
-    selectionChangedEventEmitter,
+    {
+      dispose: async () => {
+        selectionChangedEventEmitter.dispose();
+        return true;
+      },
+    },
     {
       dispose: async () => {
         projectSwitchWillStartEmitter?.dispose();

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -55,7 +55,7 @@ const COMMENTARIES_PANEL_WEBVIEW_TYPE = 'platformScriptureEditor.commentaries';
  * Network event name for editor selection change events. Use
  * `papi.network.getNetworkEvent('platformScriptureEditor.onDidSelectionChange')` to subscribe.
  */
-const EDITOR_SELECTION_CHANGED_EVENT = 'platformScriptureEditor.onDidSelectionChange';
+const EDITOR_SELECTION_CHANGED_EVENT = 'platformScriptureEditor.onDidSelectionChange' as const;
 
 /** Event emitter for selection change events. Created in activate() */
 let selectionChangedEventEmitter: PlatformEventEmitter<SelectionChangeEvent> | undefined;
@@ -811,7 +811,11 @@ class ScriptureEditorWebViewFactory extends WebViewFactory<typeof SCRIPTURE_EDIT
         if (firstSelectionAsync && !firstSelectionAsync.hasSettled) {
           firstSelectionAsync.resolveToValue(selection);
         }
-        selectionChangedEventEmitter?.emit({ webViewId, selection });
+        if (!selectionChangedEventEmitter)
+          throw new Error(
+            'platform-scripture-editor not initialized — call activate() before emitting selectionChanged',
+          );
+        selectionChangedEventEmitter.emit({ webViewId, selection });
       },
       async dispose() {
         currentSelection = undefined;
@@ -1232,7 +1236,7 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
 
   // Create the selection changed event emitter
   selectionChangedEventEmitter = await papi.network.createNetworkEventEmitterAsync(
-    EDITOR_SELECTION_CHANGED_EVENT as 'platformScriptureEditor.onDidSelectionChange',
+    EDITOR_SELECTION_CHANGED_EVENT,
   );
 
   // Default active project picker for simple layout. Subscribes to web-view-open and

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -1231,8 +1231,8 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
   );
 
   // Create the selection changed event emitter
-  selectionChangedEventEmitter = papi.network.createNetworkEventEmitter<SelectionChangeEvent>(
-    EDITOR_SELECTION_CHANGED_EVENT,
+  selectionChangedEventEmitter = await papi.network.createNetworkEventEmitterAsync(
+    EDITOR_SELECTION_CHANGED_EVENT as 'platformScriptureEditor.onDidSelectionChange',
   );
 
   // Default active project picker for simple layout. Subscribes to web-view-open and

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -57,27 +57,36 @@ const COMMENTARIES_PANEL_WEBVIEW_TYPE = 'platformScriptureEditor.commentaries';
 const EDITOR_SELECTION_CHANGED_EVENT = 'platformScriptureEditor.onDidSelectionChange' as const;
 
 /**
- * Buffered emitter for editor selection changes. Created at module load so a restored editor that
- * pushes its first selection on mount — before `activate()` finishes registering the emitter — is
- * not lost: the latest selection per web view is buffered and flushed once registration completes.
+ * Creates the buffered emitter for editor selection changes. Buffered so a restored editor that
+ * pushes its first selection on mount — before the emitter finishes registering — is not lost: the
+ * latest selection per web view is buffered and flushed once registration completes.
  */
-const selectionChangedEventEmitter = papi.network.createBufferedNetworkEventEmitter(
-  EDITOR_SELECTION_CHANGED_EVENT,
-  {
-    notification: {
-      summary: 'Emitted when the selection in a Scripture editor changes.',
-      params: [
-        {
-          name: 'selectionChange',
-          required: true,
-          summary: 'The new editor selection.',
-          schema: { type: 'object' },
-        },
-      ],
+function createSelectionChangedEventEmitter() {
+  return papi.network.createBufferedNetworkEventEmitter(
+    EDITOR_SELECTION_CHANGED_EVENT,
+    {
+      notification: {
+        summary: 'Emitted when the selection in a Scripture editor changes.',
+        params: [
+          {
+            name: 'selectionChange',
+            required: true,
+            summary: 'The new editor selection.',
+            schema: { type: 'object' },
+          },
+        ],
+      },
     },
-  },
-  { bufferStrategy: { latestByKey: (event) => event.webViewId } },
-);
+    { bufferStrategy: { latestByKey: (event) => event.webViewId } },
+  );
+}
+
+/**
+ * Buffered emitter for editor selection changes. Created in `activate` (not at module load) so it
+ * is re-created on re-activation after a `deactivate` disposed it. Stays `undefined` until
+ * `activate` runs; emit sites guard with `?.`.
+ */
+let selectionChangedEventEmitter: ReturnType<typeof createSelectionChangedEventEmitter> | undefined;
 
 // Selection is stored per-WebViewController instance in createWebViewController.
 
@@ -831,8 +840,9 @@ class ScriptureEditorWebViewFactory extends WebViewFactory<typeof SCRIPTURE_EDIT
           firstSelectionAsync.resolveToValue(selection);
         }
         // Buffered emit — if a restored editor pushes a selection before the emitter has registered,
-        // the latest selection per web view is buffered and flushed rather than thrown away.
-        selectionChangedEventEmitter.emit({ webViewId, selection });
+        // the latest selection per web view is buffered and flushed rather than thrown away. Guarded
+        // with `?.` since the emitter only exists between activate and deactivate.
+        selectionChangedEventEmitter?.emit({ webViewId, selection });
       },
       async dispose() {
         currentSelection = undefined;
@@ -965,6 +975,10 @@ async function openResourceText(
 
 export async function activate(context: ExecutionActivationContext): Promise<void> {
   logger.debug('Scripture editor is activating!');
+
+  // Create the buffered selection-changed emitter early so a restored editor's first selection
+  // (pushed before registration completes) is buffered rather than lost. Recreated each activation.
+  selectionChangedEventEmitter = createSelectionChangedEventEmitter();
 
   const openPlatformScriptureEditorPromise = papi.commands.registerCommand(
     'platformScriptureEditor.openScriptureEditor',
@@ -1251,8 +1265,6 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     },
   );
 
-  // The selection-changed emitter is created at module load (buffered); nothing to set up here.
-
   // Default active project picker for simple layout. Subscribes to web-view-open and
   // sync-completion events and attempts to fill the empty Scripture Editor with the
   // most-recently-active editable project. Re-runs on each subscribed event; concurrent
@@ -1281,7 +1293,8 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     await openResourceTextPromise,
     {
       dispose: async () => {
-        selectionChangedEventEmitter.dispose();
+        selectionChangedEventEmitter?.dispose();
+        selectionChangedEventEmitter = undefined;
         return true;
       },
     },

--- a/extensions/src/platform-scripture-editor/src/types/platform-scripture-editor.d.ts
+++ b/extensions/src/platform-scripture-editor/src/types/platform-scripture-editor.d.ts
@@ -679,7 +679,7 @@ declare module 'papi-shared-types' {
   // @ts-ignore: TS2307 - Cannot find module '@papi/core' or its corresponding type declarations
   import type { NotificationClickCommandHandler } from '@papi/core';
 
-  export interface NetworkEventTypes {
+  export interface NetworkEvents {
     /**
      * Emitted when the selection in a Scripture editor changes. Subscribe using
      * `papi.network.getNetworkEvent('platformScriptureEditor.onDidSelectionChange')`.

--- a/extensions/src/platform-scripture-editor/src/types/platform-scripture-editor.d.ts
+++ b/extensions/src/platform-scripture-editor/src/types/platform-scripture-editor.d.ts
@@ -673,10 +673,19 @@ declare module 'papi-shared-types' {
     AnnotationStyleDataProvider,
     OpenEditorOptions,
     PlatformScriptureEditorWebViewController,
+    SelectionChangeEvent,
   } from 'platform-scripture-editor';
   import type { ResourceType } from 'platform-bible-utils';
   // @ts-ignore: TS2307 - Cannot find module '@papi/core' or its corresponding type declarations
   import type { NotificationClickCommandHandler } from '@papi/core';
+
+  export interface NetworkEventTypes {
+    /**
+     * Emitted when the selection in a Scripture editor changes. Subscribe using
+     * `papi.network.getNetworkEvent('platformScriptureEditor.onDidSelectionChange')`.
+     */
+    'platformScriptureEditor.onDidSelectionChange': SelectionChangeEvent;
+  }
 
   export interface CommandHandlers {
     /**

--- a/extensions/src/platform-scripture/src/checklist.web-view.tsx
+++ b/extensions/src/platform-scripture/src/checklist.web-view.tsx
@@ -517,10 +517,7 @@ global.webViewComponent = function ChecklistWebView({
   const handleOpenSettingsEvent = useCallback(() => {
     setIsSettingsOpen(true);
   }, []);
-  useEvent(
-    network.getNetworkEvent<undefined>(CHECKLIST_OPEN_SETTINGS_EVENT),
-    handleOpenSettingsEvent,
-  );
+  useEvent(network.getNetworkEvent(CHECKLIST_OPEN_SETTINGS_EVENT), handleOpenSettingsEvent);
 
   // ─── Project-menu item selection handler ──────────────────────────────────
   //

--- a/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
+++ b/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
@@ -398,6 +398,20 @@ async function initialize(): Promise<void> {
           );
           resultsInvalidatedEventEmitter = await papi.network.createNetworkEventEmitterAsync(
             CHECK_RESULTS_INVALIDATED_EVENT,
+            {
+              notification: {
+                summary:
+                  'Emitted when check results are invalidated and subscribers should refresh their data.',
+                params: [
+                  {
+                    name: 'details',
+                    required: true,
+                    summary: 'Details describing which check results were invalidated.',
+                    schema: { type: 'object' },
+                  },
+                ],
+              },
+            },
           );
           resolve();
         } catch (error) {

--- a/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
+++ b/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
@@ -397,7 +397,7 @@ async function initialize(): Promise<void> {
             new CheckAggregatorDataProviderEngine(),
           );
           resultsInvalidatedEventEmitter = await papi.network.createNetworkEventEmitterAsync(
-            CHECK_RESULTS_INVALIDATED_EVENT as 'checkResultsInvalidated',
+            CHECK_RESULTS_INVALIDATED_EVENT,
           );
           resolve();
         } catch (error) {
@@ -412,7 +412,11 @@ async function initialize(): Promise<void> {
 
 /** Notify all listeners that check results have been invalidated and should be refreshed */
 export function notifyCheckResultsInvalidated(e: CheckResultsInvalidated): void {
-  if (resultsInvalidatedEventEmitter) resultsInvalidatedEventEmitter.emit(e);
+  if (!resultsInvalidatedEventEmitter)
+    throw new Error(
+      'check-aggregator.service not initialized — call initialize() before emitting checkResultsInvalidated',
+    );
+  resultsInvalidatedEventEmitter.emit(e);
 }
 
 const checkAggregatorServiceObjectToProxy = Object.freeze({});

--- a/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
+++ b/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
@@ -1,7 +1,7 @@
 import papi, { DataProviderEngine, logger } from '@papi/backend';
 import { DataProviderUpdateInstructions, IDisposableDataProvider } from '@papi/core';
 import { SerializedVerseRef } from '@sillsdev/scripture';
-import { createSyncProxyForAsyncObject, newGuid, PlatformEventEmitter } from 'platform-bible-utils';
+import { createSyncProxyForAsyncObject, newGuid } from 'platform-bible-utils';
 import {
   CheckJobRunner,
   CheckJobScope,
@@ -386,7 +386,28 @@ const checkAggregatorServiceProviderName = 'platformScripture.checkAggregator';
 
 let initializationPromise: Promise<void> | undefined;
 let dataProvider: IDisposableDataProvider<ICheckAggregatorService>;
-let resultsInvalidatedEventEmitter: PlatformEventEmitter<CheckResultsInvalidated> | undefined;
+/**
+ * Buffered emitter for check-results-invalidated events. Created at module load so a
+ * `platformScripture.invalidateCheckResults` command invocation (C# fires this) that arrives before
+ * `initialize()` finishes registering the emitter is queued and flushed, rather than thrown away.
+ */
+const resultsInvalidatedEventEmitter = papi.network.createBufferedNetworkEventEmitter(
+  CHECK_RESULTS_INVALIDATED_EVENT,
+  {
+    notification: {
+      summary:
+        'Emitted when check results are invalidated and subscribers should refresh their data.',
+      params: [
+        {
+          name: 'details',
+          required: true,
+          summary: 'Details describing which check results were invalidated.',
+          schema: { type: 'object' },
+        },
+      ],
+    },
+  },
+);
 async function initialize(): Promise<void> {
   if (!initializationPromise) {
     initializationPromise = new Promise<void>((resolve, reject) => {
@@ -395,23 +416,6 @@ async function initialize(): Promise<void> {
           dataProvider = await papi.dataProviders.registerEngine(
             checkAggregatorServiceProviderName,
             new CheckAggregatorDataProviderEngine(),
-          );
-          resultsInvalidatedEventEmitter = await papi.network.createNetworkEventEmitterAsync(
-            CHECK_RESULTS_INVALIDATED_EVENT,
-            {
-              notification: {
-                summary:
-                  'Emitted when check results are invalidated and subscribers should refresh their data.',
-                params: [
-                  {
-                    name: 'details',
-                    required: true,
-                    summary: 'Details describing which check results were invalidated.',
-                    schema: { type: 'object' },
-                  },
-                ],
-              },
-            },
           );
           resolve();
         } catch (error) {
@@ -426,10 +430,8 @@ async function initialize(): Promise<void> {
 
 /** Notify all listeners that check results have been invalidated and should be refreshed */
 export function notifyCheckResultsInvalidated(e: CheckResultsInvalidated): void {
-  if (!resultsInvalidatedEventEmitter)
-    throw new Error(
-      'check-aggregator.service not initialized — call initialize() before emitting checkResultsInvalidated',
-    );
+  // Buffered emit — usable immediately. If the C#-invoked `invalidateCheckResults` command fires
+  // before registration completes, the event is queued and flushed rather than thrown away.
   resultsInvalidatedEventEmitter.emit(e);
 }
 
@@ -441,10 +443,8 @@ const serviceObject = createSyncProxyForAsyncObject<ICheckAggregatorService>(asy
 }, checkAggregatorServiceObjectToProxy);
 
 async function dispose(): Promise<boolean> {
-  const disposalResults: boolean[] = await Promise.all([
-    dataProvider.dispose(),
-    ...(resultsInvalidatedEventEmitter ? [resultsInvalidatedEventEmitter.dispose()] : []),
-  ]);
+  resultsInvalidatedEventEmitter.dispose();
+  const disposalResults: boolean[] = await Promise.all([dataProvider.dispose()]);
   return disposalResults.every((result) => result);
 }
 

--- a/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
+++ b/extensions/src/platform-scripture/src/checks/check-aggregator.service.ts
@@ -1,7 +1,7 @@
 import papi, { DataProviderEngine, logger } from '@papi/backend';
 import { DataProviderUpdateInstructions, IDisposableDataProvider } from '@papi/core';
 import { SerializedVerseRef } from '@sillsdev/scripture';
-import { createSyncProxyForAsyncObject, newGuid } from 'platform-bible-utils';
+import { createSyncProxyForAsyncObject, newGuid, PlatformEventEmitter } from 'platform-bible-utils';
 import {
   CheckJobRunner,
   CheckJobScope,
@@ -386,6 +386,7 @@ const checkAggregatorServiceProviderName = 'platformScripture.checkAggregator';
 
 let initializationPromise: Promise<void> | undefined;
 let dataProvider: IDisposableDataProvider<ICheckAggregatorService>;
+let resultsInvalidatedEventEmitter: PlatformEventEmitter<CheckResultsInvalidated> | undefined;
 async function initialize(): Promise<void> {
   if (!initializationPromise) {
     initializationPromise = new Promise<void>((resolve, reject) => {
@@ -394,6 +395,9 @@ async function initialize(): Promise<void> {
           dataProvider = await papi.dataProviders.registerEngine(
             checkAggregatorServiceProviderName,
             new CheckAggregatorDataProviderEngine(),
+          );
+          resultsInvalidatedEventEmitter = await papi.network.createNetworkEventEmitterAsync(
+            CHECK_RESULTS_INVALIDATED_EVENT as 'checkResultsInvalidated',
           );
           resolve();
         } catch (error) {
@@ -406,12 +410,9 @@ async function initialize(): Promise<void> {
   return initializationPromise;
 }
 
-const resultsInvalidatedEventEmitter =
-  papi.network.createNetworkEventEmitter<CheckResultsInvalidated>(CHECK_RESULTS_INVALIDATED_EVENT);
-
 /** Notify all listeners that check results have been invalidated and should be refreshed */
 export function notifyCheckResultsInvalidated(e: CheckResultsInvalidated): void {
-  resultsInvalidatedEventEmitter.emit(e);
+  if (resultsInvalidatedEventEmitter) resultsInvalidatedEventEmitter.emit(e);
 }
 
 const checkAggregatorServiceObjectToProxy = Object.freeze({});
@@ -424,7 +425,7 @@ const serviceObject = createSyncProxyForAsyncObject<ICheckAggregatorService>(asy
 async function dispose(): Promise<boolean> {
   const disposalResults: boolean[] = await Promise.all([
     dataProvider.dispose(),
-    resultsInvalidatedEventEmitter.dispose(),
+    ...(resultsInvalidatedEventEmitter ? [resultsInvalidatedEventEmitter.dispose()] : []),
   ]);
   return disposalResults.every((result) => result);
 }

--- a/extensions/src/platform-scripture/src/checks/check.model.ts
+++ b/extensions/src/platform-scripture/src/checks/check.model.ts
@@ -2,7 +2,7 @@
 export const CHECK_RUNNER_NETWORK_OBJECT_TYPE = 'checkRunner';
 
 /** Name of event emitted when check results have been invalidated */
-export const CHECK_RESULTS_INVALIDATED_EVENT = 'checkResultsInvalidated';
+export const CHECK_RESULTS_INVALIDATED_EVENT = 'checkResultsInvalidated' as const;
 
 // This should match the stop default timeout in CheckRunner.cs
 /** Default timeout in milliseconds to wait for a check job to stop gracefully */

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -1,5 +1,6 @@
 import papi, { logger } from '@papi/backend';
 import { ExecutionActivationContext, ProjectSettingValidator } from '@papi/core';
+import { PlatformEventEmitter } from 'platform-bible-utils';
 import { CheckResultsInvalidated } from 'platform-scripture';
 import {
   ChecksSidePanelWebViewOptions,
@@ -197,9 +198,7 @@ async function openMarkersChecklist(webViewId: string | undefined): Promise<stri
  * still succeed (no-op) if the emitter hasn't been initialized yet (e.g. in tests that stub out
  * activation).
  */
-let openSettingsEventEmitter:
-  | ReturnType<typeof papi.network.createNetworkEventEmitter<undefined>>
-  | undefined;
+let openSettingsEventEmitter: PlatformEventEmitter<undefined> | undefined;
 
 async function openMarkersChecklistSettings(): Promise<void> {
   if (!openSettingsEventEmitter) {
@@ -324,8 +323,14 @@ export async function activate(context: ExecutionActivationContext) {
   // command handler is exposed. The web-view subscribes to this event (via `useEvent`) and flips
   // its local `isSettingsOpen` state when it fires. The emitter is disposed through
   // `context.registrations` below so re-activation gets a fresh channel.
-  openSettingsEventEmitter = papi.network.createNetworkEventEmitter<undefined>(
+  openSettingsEventEmitter = await papi.network.createNetworkEventEmitterAsync(
     CHECKLIST_OPEN_SETTINGS_EVENT,
+    {
+      notification: {
+        summary: 'Asks any mounted Markers Checklist web view to open its Marker Settings dialog.',
+        params: [],
+      },
+    },
   );
 
   const scriptureExtenderPdpefPromise =

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2305,7 +2305,7 @@ declare module 'papi-shared-types' {
     'platformScripture.allowInvisibleCharacters': boolean;
   }
 
-  export interface NetworkEventTypes {
+  export interface NetworkEvents {
     /** Emitted when check results are invalidated and subscribers should refresh their data. */
     checkResultsInvalidated: CheckResultsInvalidated;
   }

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2308,5 +2308,10 @@ declare module 'papi-shared-types' {
   export interface NetworkEvents {
     /** Emitted when check results are invalidated and subscribers should refresh their data. */
     checkResultsInvalidated: CheckResultsInvalidated;
+    /**
+     * Emitted by the tab menu when the user opens the markers-checklist settings. The web view
+     * subscribes to flip its internal settings panel open.
+     */
+    'platformScripture.openMarkersChecklistSettings': undefined;
   }
 }

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2304,4 +2304,8 @@ declare module 'papi-shared-types' {
      */
     'platformScripture.allowInvisibleCharacters': boolean;
   }
+
+  export interface NetworkEventTypes {
+    checkResultsInvalidated: CheckResultsInvalidated;
+  }
 }

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2306,6 +2306,7 @@ declare module 'papi-shared-types' {
   }
 
   export interface NetworkEventTypes {
+    /** Emitted when check results are invalidated and subscribers should refresh their data. */
     checkResultsInvalidated: CheckResultsInvalidated;
   }
 }

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -980,6 +980,17 @@ declare module 'shared/data/rpc.model' {
    */
   export const UNREGISTER_METHOD = 'network:unregisterMethod';
   /**
+   * Register a network event emitter with the main process so that the event is tracked centrally.
+   * Shared vs. exclusive semantics are determined by looking up the event name in
+   * `SHARED_EVENT_NAMES`.
+   */
+  export const REGISTER_EVENT = 'network:registerEvent';
+  /**
+   * Unregister a network event emitter from the main process so that the event is no longer tracked
+   * centrally.
+   */
+  export const UNREGISTER_EVENT = 'network:unregisterEvent';
+  /**
    * Get all methods that are currently registered on the network. Required to be 'rpc.discover' by
    * the OpenRPC specification.
    */
@@ -988,6 +999,17 @@ declare module 'shared/data/rpc.model' {
   export const CATEGORY_COMMAND = 'command';
 }
 declare module 'shared/services/shared-store.service' {
+  type LamportClock = {
+    counter: number;
+    processId: string;
+  };
+  type StoreEntry = {
+    value?: unknown;
+    clock: LamportClock;
+  };
+  export type StoreChangeEvent = StoreEntry & {
+    key: string;
+  };
   type NetworkService = typeof import('shared/services/network.service');
   /**
    * Initialize the shared store service, setting up request handlers and event listeners. This
@@ -1127,7 +1149,7 @@ declare module 'shared/models/openrpc.model' {
     openrpc: string;
     info: Info;
     servers?: Server[];
-    methods: Method[];
+    methods: (Method | OpenRpcNotification)[];
     components?: Components;
     externalDocs?: ExternalDocumentation;
   };
@@ -1213,6 +1235,11 @@ declare module 'shared/models/openrpc.model' {
     name: string;
     params: (ContentDescriptor | Reference)[];
     result: ContentDescriptor | Reference;
+    /**
+     * Set to `true` to mark this method as experimental — its shape may change without notice.
+     * Informational only; does not affect runtime behavior. See the experimental APIs wiki page.
+     */
+    'x-experimental'?: boolean;
     /** A short summary of what the method does. */
     summary?: string;
     /**
@@ -1259,12 +1286,29 @@ declare module 'shared/models/openrpc.model' {
     method: MethodDocumentationWithoutName;
     components?: Components;
   };
+  /**
+   * An OpenRPC notification — same shape as a {@link Method}, but without `result`. Used for events /
+   * one-way messages from server to client. Per the OpenRPC convention (no `result` ⇒ notification),
+   * these are serialized into the same root `methods` array as Methods on the wire.
+   */
+  export type OpenRpcNotification = Omit<Method, 'result'>;
+  /** Documentation about a single notification */
+  export type SingleNotificationDocumentation = {
+    notification: Omit<OpenRpcNotification, 'name'>;
+    components?: Components;
+  };
   /** Documentation about all methods on a network object */
   export type NetworkObjectDocumentation = {
     summary?: string;
     description?: string;
     methods?: Method[];
     components?: Components;
+    /**
+     * Set to `true` to mark every method registered for this network object as experimental. The
+     * marker is fanned out onto each method's `'x-experimental'` field inside
+     * `networkObjectService.set`.
+     */
+    'x-experimental'?: boolean;
   };
   /** Create an object of type {@link OpenRpc} to hold documentation for PAPI websocket methods */
   export function createEmptyOpenRpc(papiVersion: string): OpenRpc;
@@ -1281,7 +1325,10 @@ declare module 'shared/models/rpc.interface' {
     InternalRequestHandler,
     RequestParams,
   } from 'shared/data/rpc.model';
-  import { SingleMethodDocumentation } from 'shared/models/openrpc.model';
+  import {
+    SingleMethodDocumentation,
+    SingleNotificationDocumentation,
+  } from 'shared/models/openrpc.model';
   import { SerializedRequestType } from 'shared/utils/util';
   import { JSONRPCResponse } from 'json-rpc-2.0';
   /**
@@ -1359,11 +1406,41 @@ declare module 'shared/models/rpc.interface' {
     ) => Promise<boolean>;
     /** Unregister a method so it is no longer available to RPC requests */
     unregisterMethod: (methodName: string) => Promise<boolean>;
+    /**
+     * Register a centrally-tracked network event with the main process. Shared vs exclusive semantics
+     * is determined by looking up the event name in `SHARED_EVENT_NAMES`.
+     *
+     * Returns `true` if the registration was accepted, `false` otherwise. Used by
+     * `createNetworkEventEmitterAsync`; not for direct caller use.
+     */
+    registerEvent: (
+      eventName: string,
+      documentation?: SingleNotificationDocumentation,
+    ) => Promise<boolean>;
+    /** Unregister a network event emitter so it is no longer tracked centrally */
+    unregisterEvent: (eventName: string) => Promise<boolean>;
   }
   export type RegisteredRpcMethodDetails = {
     handler: IRpcHandler;
     methodDocs?: SingleMethodDocumentation;
   };
+  /**
+   * Minimal interface for event registries so that {@link RpcServer} can participate in event
+   * registration without importing from `rpc-websocket-listener.ts` (which would create a circular
+   * dependency).
+   *
+   * @internal
+   */
+  export interface IRpcEventRegistry {
+    tryRegister(
+      handler: unknown,
+      eventName: string,
+      documentation?: SingleNotificationDocumentation,
+    ): boolean;
+    tryUnregister(handler: unknown, eventName: string): boolean;
+    /** Remove all event registrations for the given handler (e.g. when a websocket closes) */
+    unregisterAll(handler: unknown): void;
+  }
 }
 declare module 'client/services/web-socket.interface' {
   /**
@@ -1443,7 +1520,10 @@ declare module 'client/services/rpc-client' {
     RequestParams,
   } from 'shared/data/rpc.model';
   import { SerializedRequestType } from 'shared/utils/util';
-  import { SingleMethodDocumentation } from 'shared/models/openrpc.model';
+  import {
+    SingleMethodDocumentation,
+    SingleNotificationDocumentation,
+  } from 'shared/models/openrpc.model';
   /**
    * Manages the JSON-RPC protocol on the client end of a websocket that connects to main
    *
@@ -1477,6 +1557,11 @@ declare module 'client/services/rpc-client' {
       methodDocs?: SingleMethodDocumentation,
     ): Promise<boolean>;
     unregisterMethod(methodName: string): Promise<boolean>;
+    registerEvent(
+      eventName: string,
+      documentation?: SingleNotificationDocumentation,
+    ): Promise<boolean>;
+    unregisterEvent(eventName: string): Promise<boolean>;
     private createNextRequestId;
     private addEventListenersToWebSocket;
     private removeEventListenersFromWebSocket;
@@ -1488,10 +1573,17 @@ declare module 'client/services/rpc-client' {
 }
 declare module 'main/services/rpc-server' {
   import { JSONRPCResponse } from 'json-rpc-2.0';
-  import { IRpcHandler, RegisteredRpcMethodDetails } from 'shared/models/rpc.interface';
+  import {
+    IRpcEventRegistry,
+    IRpcHandler,
+    RegisteredRpcMethodDetails,
+  } from 'shared/models/rpc.interface';
   import { ConnectionStatus, RequestParams } from 'shared/data/rpc.model';
   import { SerializedRequestType } from 'shared/utils/util';
-  import { SingleMethodDocumentation } from 'shared/models/openrpc.model';
+  import {
+    SingleMethodDocumentation,
+    SingleNotificationDocumentation,
+  } from 'shared/models/openrpc.model';
   type PropagateEventMethod = <T>(source: RpcServer, eventType: string, event: T) => void;
   /**
    * Manages the JSON-RPC protocol on the server end of a websocket owned by main. This class is not
@@ -1511,6 +1603,7 @@ declare module 'main/services/rpc-server' {
     /** Refers to any process that connected to main over the websocket */
     private readonly jsonRpcClient;
     private readonly rpcMethodDetailsByMethodName;
+    private readonly rpcEventDetailsByEventName;
     /** Called by an RpcServer when all other RpcServers should emit an event over the network */
     private readonly propagateEventMethod;
     constructor(
@@ -1518,6 +1611,7 @@ declare module 'main/services/rpc-server' {
       webSocket: WebSocket,
       propagateEventMethod: PropagateEventMethod,
       rpcMethodDetailsByMethodName: Map<string, RegisteredRpcMethodDetails>,
+      rpcEventDetailsByEventName: IRpcEventRegistry,
     );
     connect(): Promise<boolean>;
     disconnect(): Promise<void>;
@@ -1529,6 +1623,11 @@ declare module 'main/services/rpc-server' {
     emitEventOnNetwork<T>(eventType: string, event: T): void;
     registerRemoteMethod(methodName: string, methodDocs?: SingleMethodDocumentation): boolean;
     unregisterRemoteMethod(methodName: string): boolean;
+    registerRemoteEvent(
+      eventName: string,
+      documentation?: SingleNotificationDocumentation,
+    ): boolean;
+    unregisterRemoteEvent(eventName: string): boolean;
     private createNextRequestId;
     private addMethodToRpcServer;
     private handleError;
@@ -1549,9 +1648,40 @@ declare module 'main/services/rpc-websocket-listener' {
     RequestParams,
   } from 'shared/data/rpc.model';
   import { IRpcMethodRegistrar } from 'shared/models/rpc.interface';
+  import { SingleNotificationDocumentation } from 'shared/models/openrpc.model';
   import { JSONRPCResponse } from 'json-rpc-2.0';
   import { SerializedRequestType } from 'shared/utils/util';
   import { OpenRpc, SingleMethodDocumentation } from 'shared/models/openrpc.model';
+  interface EventRegistrant {
+    handler: unknown;
+    documentation?: SingleNotificationDocumentation;
+  }
+  /**
+   * Tracks registered network event emitters, enforcing shared vs. exclusive ownership policy.
+   *
+   * @internal Exported for unit-testing only; not part of the public API.
+   */
+  export class RpcEventRegistry {
+    private byName;
+    /**
+     * Try to register an event. Returns `true` if accepted, `false` if rejected.
+     *
+     * - Name in `SHARED_EVENT_NAMES` (shared): multiple handlers may register; same handler twice
+     *   rejected.
+     * - Name not in `SHARED_EVENT_NAMES` (exclusive): first registrant wins; any subsequent
+     *   registration from any handler is rejected.
+     */
+    tryRegister(
+      handler: unknown,
+      eventName: string,
+      documentation?: SingleNotificationDocumentation,
+    ): boolean;
+    /** Remove a registrant. Returns `true` if the handler had registered this event. */
+    tryUnregister(handler: unknown, eventName: string): boolean;
+    /** Remove all event registrations for the given handler (e.g. when a websocket closes) */
+    unregisterAll(handler: unknown): void;
+    entries(): IterableIterator<[string, EventRegistrant[]]>;
+  }
   /**
    * Owns the WebSocketServer that listens for clients to connect to the web socket. When a client
    * connects, an RpcServer is created in this same process to service that connection.
@@ -1572,6 +1702,7 @@ declare module 'main/services/rpc-websocket-listener' {
     private readonly rpcServerBySocket;
     private readonly rpcMethodDetailsByMethodName;
     private readonly localMethodsByMethodName;
+    private readonly rpcEventDetailsByEventName;
     constructor();
     get nextSocketId(): string;
     connect(localEventHandler: EventHandler): Promise<boolean>;
@@ -1587,6 +1718,11 @@ declare module 'main/services/rpc-websocket-listener' {
       methodDocs?: SingleMethodDocumentation,
     ): Promise<boolean>;
     unregisterMethod(methodName: string): Promise<boolean>;
+    registerEvent(
+      eventName: string,
+      documentation?: SingleNotificationDocumentation,
+    ): Promise<boolean>;
+    unregisterEvent(eventName: string): Promise<boolean>;
     generateOpenRpcSchema(): OpenRpc;
     emitEventOnNetwork<T>(eventType: string, event: T): void;
     private propagateEvent;
@@ -1619,8 +1755,20 @@ declare module 'shared/services/network.service' {
   import { InternalRequestHandler } from 'shared/data/rpc.model';
   import { PlatformEvent, PlatformEventEmitter, UnsubscriberAsync } from 'platform-bible-utils';
   import { SerializedRequestType } from 'shared/utils/util';
-  import { SingleMethodDocumentation } from 'shared/models/openrpc.model';
+  import {
+    SingleMethodDocumentation,
+    SingleNotificationDocumentation,
+  } from 'shared/models/openrpc.model';
   import { NetworkMethodHandlerOptions } from 'shared/models/network.model';
+  import type { NetworkEventTypes, SharedNetworkEventTypes } from 'papi-shared-types';
+  /**
+   * Source of truth for which event names use shared semantics at the central registry. Must stay in
+   * sync with the `SharedNetworkEventTypes` type alias in `papi-shared-types.ts` — the test
+   * `network.service.shared-events.test.ts` enforces the invariant.
+   *
+   * Add entries here when adding a new shared event to `SharedNetworkEventTypes`.
+   */
+  export const SHARED_EVENT_NAMES: Set<keyof SharedNetworkEventTypes>;
   export function initialize(): Promise<void>;
   /** Closes the network services gracefully */
   export const shutdown: () => Promise<void>;
@@ -1678,25 +1826,66 @@ declare module 'shared/services/network.service' {
     requestType: SerializedRequestType,
   ) => (...args: TParam) => Promise<TReturn>;
   /**
-   * Creates an event emitter that works properly over the network. Other connections receive this
-   * event when it is emitted.
+   * Creates an event emitter that works properly over the network.
    *
-   * WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
-   * emitters.
+   * @deprecated 8 June 2026. Use `createNetworkEventEmitterAsync`. Events created via the sync API
+   *   are not centrally registered and do not appear in the OpenRPC document. The async version
+   *   properly restricts event registration to prevent multiple sources from emitting the same
+   *   network event (unless the event is declared in `SharedNetworkEventTypes`, in which case it
+   *   accepts multiple registrants by design).
    *
+   *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
+   *   emitters.
    * @param eventType Unique network event type for coordinating between connections
    * @returns Event emitter whose event works between connections
    */
   export const createNetworkEventEmitter: <T>(eventType: string) => PlatformEventEmitter<T>;
   /**
-   * Gets the network event with the specified type. Creates the emitter if it does not exist
+   * Create a network event emitter that participates in central registration. The returned emitter
+   * appears in the OpenRPC document if `documentation` is provided.
+   *
+   * If the event name is in `SharedNetworkEventTypes`, the central registry uses shared semantics:
+   * multiple processes may register the same name (each process registers once); all corresponding
+   * emitters are valid sources.
+   *
+   * Otherwise the registry uses exclusive semantics: only one process may register a given name;
+   * subsequent registrations from any process are rejected.
+   *
+   * Intra-process duplicate registration is always rejected regardless of the event's domain.
+   *
+   * @param eventType A key of `NetworkEventTypes` (which inherits `SharedNetworkEventTypes`).
+   * @param documentation Optional notification documentation. Carries `'x-experimental': true` to
+   *   mark the event as experimental.
+   */
+  export const createNetworkEventEmitterAsync: <EventType extends keyof NetworkEventTypes>(
+    eventType: EventType,
+    documentation?: SingleNotificationDocumentation,
+  ) => Promise<PlatformEventEmitter<NetworkEventTypes[EventType]>>;
+  /**
+   * Subscribe to a typed network event. Declare the event in `NetworkEventTypes` (or rely on
+   * `SharedNetworkEventTypes` inheritance for platform events) and the payload type is inferred.
    *
    * @param eventType Unique network event type for coordinating between connections
    * @returns Event for the event type that runs the callback provided when the event is emitted
    */
-  export const getNetworkEvent: <T>(eventType: string) => PlatformEvent<T>;
+  export function getNetworkEvent<EventType extends keyof NetworkEventTypes>(
+    eventType: EventType,
+  ): PlatformEvent<NetworkEventTypes[EventType]>;
+  /**
+   * Subscribe to a network event with an explicit payload type.
+   *
+   * @deprecated 8 June 2026. Use the typed signature: declare the event in `NetworkEventTypes` and
+   *   call `getNetworkEvent('your.event.name')` without an explicit type parameter. If your event
+   *   name is dynamic (e.g., per-instance data-provider events), this signature continues to work
+   *   functionally; suppress the deprecation warning at the call site with a brief comment.
+   * @param eventType Unique network event type for coordinating between connections
+   * @returns Event for the event type that runs the callback provided when the event is emitted
+   */
+  export function getNetworkEvent<T>(eventType: string): PlatformEvent<T>;
   export interface PapiNetworkService {
+    /** @deprecated 8 June 2026. Use createNetworkEventEmitterAsync. */
     createNetworkEventEmitter: typeof createNetworkEventEmitter;
+    createNetworkEventEmitterAsync: typeof createNetworkEventEmitterAsync;
     getNetworkEvent: typeof getNetworkEvent;
   }
   /**
@@ -2576,128 +2765,6 @@ declare module 'shared/models/extract-data-provider-data-types.model' {
             : never;
   export default ExtractDataProviderDataTypes;
 }
-declare module 'shared/models/web-view-provider.model' {
-  import {
-    WebViewDefinition,
-    SavedWebViewDefinition,
-    OpenWebViewOptions,
-  } from 'shared/models/web-view.model';
-  import {
-    DisposableNetworkObject,
-    NetworkObject,
-    NetworkableObject,
-  } from 'shared/models/network-object.model';
-  /**
-   * An object associated with a specific `webViewType` that provides a {@link WebViewDefinition} when
-   * the PAPI wants to open a web view with that `webViewType`. An extension registers a web view
-   * provider with `papi.webViewProviders.register`.
-   *
-   * Web View Providers provide the contents of all web views in Platform.Bible.
-   *
-   * If you want to provide {@link WebViewControllers} to facilitate interaction between your web views
-   * and extensions, you can extend the abstract class {@link WebViewFactory} to make the process
-   * easier. Alternatively, if you want to manage web view controllers manually, you can register them
-   * in {@link IWebViewProvider.getWebView}.
-   */
-  export interface IWebViewProvider extends NetworkableObject {
-    /**
-     * Receives a {@link SavedWebViewDefinition} and fills it out into a full {@link WebViewDefinition},
-     * providing the contents of the web view and other properties that are important for displaying
-     * the web view.
-     *
-     * The PAPI calls this method as part of opening a new web view or (re)loading an existing web
-     * view. If you want to create {@link WebViewControllers} for the web views the PAPI creates from
-     * this method, you should register it using `papi.webViewProviders.registerWebViewController`
-     * before returning from this method (resolving the returned promise). The {@link WebViewFactory}
-     * abstract class handles this for you, so please consider extending it.
-     *
-     * @param savedWebViewDefinition The saved web view information from which to build a complete web
-     *   view definition. Filled out with all {@link SavedWebViewDefinition} properties of the existing
-     *   web view if an existing webview is being called for (matched by ID). Just provides the
-     *   minimal properties required on {@link SavedWebViewDefinition} if this is a new request or if
-     *   the web view with the existing ID was not found.
-     * @param openWebViewOptions Various options that affect what calling `papi.webViews.openWebView`
-     *   should do. When options are passed to `papi.webViews.openWebView`, some defaults are set up
-     *   on the options, then those options are passed directly through to this method. That way, if
-     *   you want to adjust what this method does based on the contents of the options passed to
-     *   `papi.WebViews.openWebView`, you can. You can even read other properties on these options if
-     *   someone passes options with other properties to `papi.webViews.openWebView`.
-     * @param webViewNonce Nonce used to perform privileged interactions with the web view created
-     *   from this method's returned {@link WebViewDefinition} such as
-     *   `papi.webViewProviders.postMessageToWebView`. The web view service generates this nonce and
-     *   sends it _only here_ to this web view provider that creates the web view with this id. It is
-     *   generally recommended that this web view provider not share this nonce with anyone else but
-     *   only use it within itself and in the web view controller created for this web view if
-     *   applicable (See `papi.webViewProviders.registerWebViewController`).
-     * @returns Full {@link WebViewDefinition} including the content and other important display
-     *   properties based on the {@link SavedWebViewDefinition} provided
-     */
-    getWebView(
-      savedWebViewDefinition: SavedWebViewDefinition,
-      openWebViewOptions: OpenWebViewOptions,
-      webViewNonce: string,
-    ): Promise<WebViewDefinition | undefined>;
-  }
-  /**
-   * A web view provider that has been registered with the PAPI.
-   *
-   * This is what the papi gives on `webViewProviderService.get` (not exposed on the PAPI). Basically
-   * a layer over NetworkObject
-   *
-   * This type is internal to core and is not used by extensions
-   */
-  export interface IRegisteredWebViewProvider extends NetworkObject<IWebViewProvider> {}
-  /**
-   * A web view provider that has been registered with the PAPI and returned to the extension that
-   * registered it. It is able to be disposed with `dispose`.
-   *
-   * The PAPI returns this type from `papi.webViewProviders.register`.
-   */
-  export interface IDisposableWebViewProvider extends DisposableNetworkObject<IWebViewProvider> {}
-}
-declare module 'shared/models/network-object-status.service-model' {
-  import { NetworkObjectDetails } from 'shared/models/network-object.model';
-  export interface NetworkObjectStatusRemoteServiceType {
-    /**
-     * Get details about all available network objects
-     *
-     * @returns Object whose keys are the names of the network objects and whose values are the
-     *   {@link NetworkObjectDetails} for each network object
-     */
-    getAllNetworkObjectDetails: () => Promise<Record<string, NetworkObjectDetails>>;
-  }
-  /**
-   *
-   * Provides functions related to the set of available network objects
-   */
-  export interface NetworkObjectStatusServiceType extends NetworkObjectStatusRemoteServiceType {
-    /**
-     * Get a promise that resolves when a network object is registered or rejects if a timeout is hit
-     *
-     * @param objectDetailsToMatch Subset of object details on the network object to wait for.
-     *   Compared to object details using {@link isSubset}
-     * @param timeoutInMS Max duration to wait for the network object. If not provided, it will wait
-     *   indefinitely
-     * @returns Promise that either resolves to the {@link NetworkObjectDetails} for a network object
-     *   once the network object is registered, or rejects if a timeout is provided and the timeout is
-     *   reached before the network object is registered
-     */
-    waitForNetworkObject: (
-      objectDetailsToMatch: Partial<NetworkObjectDetails>,
-      timeoutInMS?: number,
-    ) => Promise<NetworkObjectDetails>;
-  }
-  export const networkObjectStatusServiceNetworkObjectName = 'NetworkObjectStatusService';
-}
-declare module 'shared/services/network-object-status.service' {
-  import { NetworkObjectStatusServiceType } from 'shared/models/network-object-status.service-model';
-  /**
-   *
-   * Provides functions related to the set of available network objects
-   */
-  export const networkObjectStatusService: NetworkObjectStatusServiceType;
-  export default networkObjectStatusService;
-}
 declare module 'shared/models/docking-framework.model' {
   import { MutableRefObject, ReactNode } from 'react';
   import { WebViewDefinition, WebViewDefinitionUpdateInfo } from 'shared/models/web-view.model';
@@ -3144,6 +3211,49 @@ declare module 'shared/models/docking-framework.model' {
     simpleLayout: LayoutInfo;
   };
 }
+declare module 'shared/models/network-object-status.service-model' {
+  import { NetworkObjectDetails } from 'shared/models/network-object.model';
+  export interface NetworkObjectStatusRemoteServiceType {
+    /**
+     * Get details about all available network objects
+     *
+     * @returns Object whose keys are the names of the network objects and whose values are the
+     *   {@link NetworkObjectDetails} for each network object
+     */
+    getAllNetworkObjectDetails: () => Promise<Record<string, NetworkObjectDetails>>;
+  }
+  /**
+   *
+   * Provides functions related to the set of available network objects
+   */
+  export interface NetworkObjectStatusServiceType extends NetworkObjectStatusRemoteServiceType {
+    /**
+     * Get a promise that resolves when a network object is registered or rejects if a timeout is hit
+     *
+     * @param objectDetailsToMatch Subset of object details on the network object to wait for.
+     *   Compared to object details using {@link isSubset}
+     * @param timeoutInMS Max duration to wait for the network object. If not provided, it will wait
+     *   indefinitely
+     * @returns Promise that either resolves to the {@link NetworkObjectDetails} for a network object
+     *   once the network object is registered, or rejects if a timeout is provided and the timeout is
+     *   reached before the network object is registered
+     */
+    waitForNetworkObject: (
+      objectDetailsToMatch: Partial<NetworkObjectDetails>,
+      timeoutInMS?: number,
+    ) => Promise<NetworkObjectDetails>;
+  }
+  export const networkObjectStatusServiceNetworkObjectName = 'NetworkObjectStatusService';
+}
+declare module 'shared/services/network-object-status.service' {
+  import { NetworkObjectStatusServiceType } from 'shared/models/network-object-status.service-model';
+  /**
+   *
+   * Provides functions related to the set of available network objects
+   */
+  export const networkObjectStatusService: NetworkObjectStatusServiceType;
+  export default networkObjectStatusService;
+}
 declare module 'shared/services/web-view.service-model' {
   import {
     GetWebViewOptions,
@@ -3323,6 +3433,85 @@ declare module 'shared/services/web-view.service-model' {
   };
   export const NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE = 'WebViewService';
 }
+declare module 'shared/models/web-view-provider.model' {
+  import {
+    WebViewDefinition,
+    SavedWebViewDefinition,
+    OpenWebViewOptions,
+  } from 'shared/models/web-view.model';
+  import {
+    DisposableNetworkObject,
+    NetworkObject,
+    NetworkableObject,
+  } from 'shared/models/network-object.model';
+  /**
+   * An object associated with a specific `webViewType` that provides a {@link WebViewDefinition} when
+   * the PAPI wants to open a web view with that `webViewType`. An extension registers a web view
+   * provider with `papi.webViewProviders.register`.
+   *
+   * Web View Providers provide the contents of all web views in Platform.Bible.
+   *
+   * If you want to provide {@link WebViewControllers} to facilitate interaction between your web views
+   * and extensions, you can extend the abstract class {@link WebViewFactory} to make the process
+   * easier. Alternatively, if you want to manage web view controllers manually, you can register them
+   * in {@link IWebViewProvider.getWebView}.
+   */
+  export interface IWebViewProvider extends NetworkableObject {
+    /**
+     * Receives a {@link SavedWebViewDefinition} and fills it out into a full {@link WebViewDefinition},
+     * providing the contents of the web view and other properties that are important for displaying
+     * the web view.
+     *
+     * The PAPI calls this method as part of opening a new web view or (re)loading an existing web
+     * view. If you want to create {@link WebViewControllers} for the web views the PAPI creates from
+     * this method, you should register it using `papi.webViewProviders.registerWebViewController`
+     * before returning from this method (resolving the returned promise). The {@link WebViewFactory}
+     * abstract class handles this for you, so please consider extending it.
+     *
+     * @param savedWebViewDefinition The saved web view information from which to build a complete web
+     *   view definition. Filled out with all {@link SavedWebViewDefinition} properties of the existing
+     *   web view if an existing webview is being called for (matched by ID). Just provides the
+     *   minimal properties required on {@link SavedWebViewDefinition} if this is a new request or if
+     *   the web view with the existing ID was not found.
+     * @param openWebViewOptions Various options that affect what calling `papi.webViews.openWebView`
+     *   should do. When options are passed to `papi.webViews.openWebView`, some defaults are set up
+     *   on the options, then those options are passed directly through to this method. That way, if
+     *   you want to adjust what this method does based on the contents of the options passed to
+     *   `papi.WebViews.openWebView`, you can. You can even read other properties on these options if
+     *   someone passes options with other properties to `papi.webViews.openWebView`.
+     * @param webViewNonce Nonce used to perform privileged interactions with the web view created
+     *   from this method's returned {@link WebViewDefinition} such as
+     *   `papi.webViewProviders.postMessageToWebView`. The web view service generates this nonce and
+     *   sends it _only here_ to this web view provider that creates the web view with this id. It is
+     *   generally recommended that this web view provider not share this nonce with anyone else but
+     *   only use it within itself and in the web view controller created for this web view if
+     *   applicable (See `papi.webViewProviders.registerWebViewController`).
+     * @returns Full {@link WebViewDefinition} including the content and other important display
+     *   properties based on the {@link SavedWebViewDefinition} provided
+     */
+    getWebView(
+      savedWebViewDefinition: SavedWebViewDefinition,
+      openWebViewOptions: OpenWebViewOptions,
+      webViewNonce: string,
+    ): Promise<WebViewDefinition | undefined>;
+  }
+  /**
+   * A web view provider that has been registered with the PAPI.
+   *
+   * This is what the papi gives on `webViewProviderService.get` (not exposed on the PAPI). Basically
+   * a layer over NetworkObject
+   *
+   * This type is internal to core and is not used by extensions
+   */
+  export interface IRegisteredWebViewProvider extends NetworkObject<IWebViewProvider> {}
+  /**
+   * A web view provider that has been registered with the PAPI and returned to the extension that
+   * registered it. It is able to be disposed with `dispose`.
+   *
+   * The PAPI returns this type from `papi.webViewProviders.register`.
+   */
+  export interface IDisposableWebViewProvider extends DisposableNetworkObject<IWebViewProvider> {}
+}
 declare module 'shared/services/web-view.service' {
   import { WebViewServiceType } from 'shared/services/web-view.service-model';
   export const webViewService: WebViewServiceType;
@@ -3338,6 +3527,7 @@ declare module 'shared/services/web-view-provider.service' {
     IWebViewProvider,
     IRegisteredWebViewProvider,
   } from 'shared/models/web-view-provider.model';
+  import type { NetworkObjectDocumentation } from 'shared/models/openrpc.model';
   import { WebViewControllers, WebViewControllerTypes } from 'papi-shared-types';
   import { DisposableNetworkObject } from 'shared/models/network-object.model';
   import { WebViewId } from 'shared/models/web-view.model';
@@ -3351,11 +3541,17 @@ declare module 'shared/services/web-view-provider.service' {
    *   of it.
    *
    *   WARNING: setting a webView provider mutates the provided object.
+   * @param attributes Optional additional attributes to attach to the network object
+   * @param documentation Optional OpenRPC-style documentation for the network object
    * @returns `webViewProvider` modified to be a network object and able to be disposed with `dispose`
    */
   function registerWebViewProvider(
     webViewType: string,
     webViewProvider: IWebViewProvider,
+    attributes?: {
+      [property: string]: unknown;
+    },
+    documentation?: NetworkObjectDocumentation,
   ): Promise<IDisposableWebViewProvider>;
   /**
    * Get a web view provider that has previously been set up
@@ -3580,7 +3776,14 @@ declare module 'papi-shared-types' {
     IDisposableDataProvider,
   } from 'shared/models/data-provider.interface';
   import type { ExtractDataProviderDataTypes } from 'shared/models/extract-data-provider-data-types.model';
-  import type { NetworkableObject } from 'shared/models/network-object.model';
+  import type { NetworkableObject, NetworkObjectDetails } from 'shared/models/network-object.model';
+  import type { StoreChangeEvent } from 'shared/services/shared-store.service';
+  import type { ScrollGroupUpdateInfo } from 'shared/services/scroll-group.service-model';
+  import type {
+    CloseWebViewEvent,
+    OpenWebViewEvent,
+    UpdateWebViewEvent,
+  } from 'shared/services/web-view.service-model';
   import { WebViewId } from 'shared/models/web-view.model';
   import { SerializedVerseRef } from '@sillsdev/scripture';
   /**
@@ -4283,6 +4486,57 @@ declare module 'papi-shared-types' {
    * @example 'platform.placeholderWebView'
    */
   type WebViewControllerTypes = keyof WebViewControllers;
+  /**
+   * Network events emitted from multiple processes (each process emits its own local event under
+   * the same name). Declared by the platform; not extensible by extensions.
+   *
+   * The names listed here are the source of truth for which event names use shared semantics at the
+   * central registry. An event name in this type allows registration from multiple processes (each
+   * process registers once, all emitters are valid sources). Any other event name uses exclusive
+   * semantics (one registrant ever).
+   *
+   * Subscribers do not need to know which events are shared — `getNetworkEvent` handles both kinds
+   * identically.
+   */
+  type SharedNetworkEventTypes = {
+    'network-object.onDidCreateNetworkObject': NetworkObjectDetails;
+    'network-object.onDidDisposeNetworkObject': string;
+    'shared-store.onDidChange': StoreChangeEvent;
+  };
+  /**
+   * All known network events. Extensions augment this to declare their own events. Inherits the
+   * platform's shared events automatically.
+   *
+   * To declare a new event for use with `createNetworkEventEmitterAsync`:
+   *
+   * ```ts
+   * declare module 'papi-shared-types' {
+   *   export interface NetworkEventTypes {
+   *     'myExt.somethingHappened': { foo: string };
+   *   }
+   * }
+   * ```
+   *
+   * Mark a single event as experimental by adding `\/** @experimental *\/` directly above its
+   * entry.
+   */
+  interface NetworkEventTypes extends SharedNetworkEventTypes {
+    /** Emitted when extensions finish reloading. `true` if reload succeeded, `false` if it failed. */
+    'platform.onDidReloadExtensions': boolean;
+    /** Emitted when the Scripture reference for a scroll group changes. */
+    'scrollGroup:onDidUpdateScrRef': ScrollGroupUpdateInfo;
+    /**
+     * @deprecated 13 November 2024. Use {@link NetworkEventTypes.'webView:onDidOpenWebView'}
+     *   instead.
+     */
+    'webView:onDidAddWebView': OpenWebViewEvent;
+    /** Emitted when a WebView is created. */
+    'webView:onDidOpenWebView': OpenWebViewEvent;
+    /** Emitted when a WebView is updated. */
+    'webView:onDidUpdateWebView': UpdateWebViewEvent;
+    /** Emitted when a WebView is closed. */
+    'webView:onDidCloseWebView': CloseWebViewEvent;
+  }
 }
 declare module 'shared/services/command.service' {
   import { UnsubscriberAsync } from 'platform-bible-utils';
@@ -4443,6 +4697,7 @@ declare module 'shared/services/data-provider.service' {
     DisposableDataProviders,
   } from 'papi-shared-types';
   import { IDataProvider, IDisposableDataProvider } from 'shared/models/data-provider.interface';
+  import type { NetworkObjectDocumentation } from 'shared/models/openrpc.model';
   /**
    *
    * Indicate if we are aware of an existing data provider with the given name. If a data provider
@@ -4643,6 +4898,9 @@ declare module 'shared/services/data-provider.service' {
    *   providers), a unique type name should be used to distinguish from generic data providers.
    * @param dataProviderAttributes Optional object that will be sent in a network event to provide
    *   additional metadata about the data provider represented by this engine.
+   * @param documentation Optional OpenRPC-style documentation for the data provider network object.
+   *   When `documentation['x-experimental']` is `true`, the provider's methods will be automatically
+   *   tagged as experimental in the OpenRPC document.
    *
    *   WARNING: registering a dataProviderEngine mutates the provided object. Its `notifyUpdate` and
    *   `set` methods are layered over to facilitate data provider subscriptions.
@@ -4658,6 +4916,7 @@ declare module 'shared/services/data-provider.service' {
           [property: string]: unknown;
         }
       | undefined,
+    documentation?: NetworkObjectDocumentation,
   ): Promise<DisposableDataProviders[DataProviderName]>;
   /**
    * Creates a data provider to be shared on the network layering over the provided data provider
@@ -4676,6 +4935,9 @@ declare module 'shared/services/data-provider.service' {
    *   providers), a unique type name should be used to distinguish from generic data providers.
    * @param dataProviderAttributes Optional object that will be sent in a network event to provide
    *   additional metadata about the data provider represented by this engine.
+   * @param documentation Optional OpenRPC-style documentation for the data provider network object.
+   *   When `documentation['x-experimental']` is `true`, the provider's methods will be automatically
+   *   tagged as experimental in the OpenRPC document.
    *
    *   WARNING: registering a dataProviderEngine mutates the provided object. Its `notifyUpdate` and
    *   `set` methods are layered over to facilitate data provider subscriptions.
@@ -4691,6 +4953,7 @@ declare module 'shared/services/data-provider.service' {
           [property: string]: unknown;
         }
       | undefined,
+    documentation?: NetworkObjectDocumentation,
   ): Promise<IDisposableDataProvider<IDataProvider<TDataTypes>>>;
   /**
    *
@@ -4738,6 +5001,9 @@ declare module 'shared/services/data-provider.service' {
      *   providers), a unique type name should be used to distinguish from generic data providers.
      * @param dataProviderAttributes Optional object that will be sent in a network event to provide
      *   additional metadata about the data provider represented by this engine.
+     * @param documentation Optional OpenRPC-style documentation for the data provider network object.
+     *   When `documentation['x-experimental']` is `true`, the provider's methods will be automatically
+     *   tagged as experimental in the OpenRPC document.
      *
      *   WARNING: registering a dataProviderEngine mutates the provided object. Its `notifyUpdate` and
      *   `set` methods are layered over to facilitate data provider subscriptions.
@@ -5120,6 +5386,7 @@ declare module 'shared/models/project-data-provider-engine-factory.model' {
   import { IProjectDataProviderEngine } from 'shared/models/project-data-provider-engine.model';
   import { ProjectMetadataFilterOptions } from 'shared/models/project-data-provider-factory.interface';
   import { ProjectMetadataWithoutFactoryInfo } from 'shared/models/project-metadata.model';
+  import type { NetworkObjectDocumentation } from 'shared/models/openrpc.model';
   import { ProjectInterfaces } from 'papi-shared-types';
   /**
    * A factory object registered with the papi that creates a Project Data Provider Engine for each
@@ -5182,16 +5449,31 @@ declare module 'shared/models/project-data-provider-engine-factory.model' {
     ): Promise<ProjectMetadataWithoutFactoryInfo[]>;
     /**
      * Create a {@link IProjectDataProviderEngine} for the project requested so the papi can create an
-     * {@link IProjectDataProvider} for the project. This project will have the same
-     * `projectInterface`s as this Project Data Provider Engine Factory
+     * {@link IProjectDataProvider} for the project.
+     *
+     * The return value may be either the engine directly, or an envelope object with the engine plus
+     * optional per-PDP-instance attributes and documentation. The unusual property name
+     * `projectDataProviderEngine` (rather than `engine`) is deliberate — it cannot collide with a
+     * property the engine itself might expose, so the platform's narrowing check on the return shape
+     * is unambiguous.
+     *
+     * The platform overwrites `projectId` in any supplied per-PDP attributes — that field is always
+     * the platform-canonical value.
      *
      * @param projectId Id of the project for which to create a {@link IProjectDataProviderEngine}
-     * @returns A promise that resolves to a {@link IProjectDataProviderEngine} for the project passed
-     *   in
+     * @returns Either the engine, or an envelope `{ projectDataProviderEngine, attributes?,
+     *   documentation? }`
      */
-    createProjectDataProviderEngine(
-      projectId: string,
-    ): Promise<IProjectDataProviderEngine<SupportedProjectInterfaces>>;
+    createProjectDataProviderEngine(projectId: string): Promise<
+      | IProjectDataProviderEngine<SupportedProjectInterfaces>
+      | {
+          projectDataProviderEngine: IProjectDataProviderEngine<SupportedProjectInterfaces>;
+          attributes?: {
+            [property: string]: unknown;
+          };
+          documentation?: NetworkObjectDocumentation;
+        }
+    >;
   }
   /**
    *
@@ -5450,15 +5732,18 @@ declare module 'shared/services/project-data-provider.service' {
   import { ProjectInterfaces, ProjectDataProviderInterfaces } from 'papi-shared-types';
   import { Dispose } from 'platform-bible-utils';
   import { IProjectDataProviderEngineFactory } from 'shared/models/project-data-provider-engine-factory.model';
+  import type { NetworkObjectDocumentation } from 'shared/models/openrpc.model';
   /**
    * Add a new Project Data Provider Factory to PAPI that uses the given engine.
    *
-   * @param pdpFactoryId Unique id for this PDP factory
+   * @param pdpFactoryId Unique id for this PDP factory.
    * @param projectInterfaces The standardized sets of methods (`projectInterface`s) supported by the
-   *   Project Data Provider Engines produced by this factory. Indicates what sort of project data
-   *   should be available on the PDPEs created by this factory.
-   * @param pdpEngineFactory Used in a ProjectDataProviderFactory to create ProjectDataProviders
-   * @returns Promise that resolves to a disposable object when the registration operation completes
+   *   Project Data Provider Engines produced by this factory.
+   * @param pdpEngineFactory Used in a ProjectDataProviderFactory to create ProjectDataProviders.
+   * @param attributes Optional registration-level attributes. The platform overwrites the
+   *   `projectInterfaces` field — that field is always the platform-canonical value.
+   * @param documentation Optional `NetworkObjectDocumentation` for the factory itself.
+   * @returns Promise that resolves to a disposable object when the registration operation completes.
    */
   export function registerProjectDataProviderEngineFactory<
     SupportedProjectInterfaces extends ProjectInterfaces[],
@@ -5466,6 +5751,10 @@ declare module 'shared/services/project-data-provider.service' {
     pdpFactoryId: string,
     projectInterfaces: SupportedProjectInterfaces,
     pdpEngineFactory: IProjectDataProviderEngineFactory<SupportedProjectInterfaces>,
+    attributes?: {
+      [property: string]: unknown;
+    },
+    documentation?: NetworkObjectDocumentation,
   ): Promise<Dispose>;
   /**
    * Get a Project Data Provider for the given project ID.
@@ -7426,7 +7715,7 @@ declare module 'shared/services/settings.service' {
 declare module 'renderer/services/scroll-group.service-host' {
   import { ScrollGroupUpdateInfo } from 'shared/services/scroll-group.service-model';
   import { SerializedVerseRef } from '@sillsdev/scripture';
-  import { ScrollGroupId } from 'platform-bible-utils';
+  import { type PlatformEvent, ScrollGroupId } from 'platform-bible-utils';
   /**
    * All Scroll Group IDs that are intended to be shown in scroll group selectors. This is a
    * placeholder and will be refactored significantly in
@@ -7434,7 +7723,7 @@ declare module 'renderer/services/scroll-group.service-host' {
    */
   export const availableScrollGroupIds: (number | undefined)[];
   /** Event that emits with information about a changed Scripture Reference for a scroll group */
-  export const onDidUpdateScrRef: import('platform-bible-utils').PlatformEvent<ScrollGroupUpdateInfo>;
+  export const onDidUpdateScrRef: PlatformEvent<ScrollGroupUpdateInfo>;
   /** See {@link IScrollGroupRemoteService.getScrRef} */
   export function getScrRefSync(scrollGroupId?: ScrollGroupId): SerializedVerseRef;
   /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1282,8 +1282,10 @@ declare module 'shared/models/openrpc.model' {
   };
   export type MethodDocumentationWithoutName = Omit<Method, 'name'>;
   /**
-   * Documentation about a single method. Set `method['x-experimental']: true` to mark this method as
-   * experimental. Informational only; appears in the generated OpenRPC document.
+   * Documentation about a single {@link Method}. Informational only; appears in the generated
+   * OpenRPC document.
+   *
+   * Set `method['x-experimental']: true` to mark this method as experimental.
    */
   export type SingleMethodDocumentation = {
     method: MethodDocumentationWithoutName;
@@ -1299,22 +1301,27 @@ declare module 'shared/models/openrpc.model' {
    */
   export type OpenRpcNotification = Omit<Method, 'result'>;
   /**
-   * Documentation about a single notification. Set `notification['x-experimental']: true` to mark
-   * this notification as experimental. Informational only; appears in the generated OpenRPC document.
+   * Documentation about a single {@link OpenRpcNotification}. Informational only; appears in the
+   * generated OpenRPC document.
+   *
+   * Set `notification['x-experimental']: true` to mark this notification as experimental.
    */
   export type SingleNotificationDocumentation = {
     notification: Omit<OpenRpcNotification, 'name'>;
     components?: Components;
   };
-  /** Documentation about all methods on a network object */
+  /**
+   * Documentation about all methods on a network object. Pass to `networkObjectService.set`,
+   * `dataProviderService.registerEngine`, or `webViewProviderService.registerWebViewProvider`.
+   */
   export type NetworkObjectDocumentation = {
     summary?: string;
     description?: string;
     methods?: Method[];
     components?: Components;
     /**
-     * Set to `true` to mark every method registered for this network object as experimental. The
-     * marker is fanned out onto each method's `'x-experimental'` field inside
+     * Set to `true` to mark every {@link Method} registered for this network object as experimental.
+     * The marker is fanned out onto each method's `'x-experimental'` field inside
      * `networkObjectService.set`.
      */
     'x-experimental'?: boolean;
@@ -1417,7 +1424,8 @@ declare module 'shared/models/rpc.interface' {
     unregisterMethod: (methodName: string) => Promise<boolean>;
     /**
      * Register a centrally-tracked network event with the main process. Shared vs exclusive semantics
-     * is determined by looking up the event name in `SHARED_EVENT_NAMES`.
+     * is determined by looking up the event name in `SHARED_EVENT_NAMES`. See
+     * {@link SharedNetworkEventTypes} for shared vs exclusive semantics.
      *
      * Returns `true` if the registration was accepted, `false` otherwise. Used by
      * `createNetworkEventEmitterAsync`; not for direct caller use.
@@ -1840,7 +1848,7 @@ declare module 'shared/services/network.service' {
    * @deprecated 8 June 2026. Use `createNetworkEventEmitterAsync`. Events created via the sync API
    *   are not centrally registered and do not appear in the OpenRPC document. The async version
    *   properly restricts event registration to prevent multiple sources from emitting the same
-   *   network event (unless the event is declared in `SharedNetworkEventTypes`, in which case it
+   *   network event (unless the event is declared in {@link SharedNetworkEventTypes}, in which case it
    *   accepts multiple registrants by design).
    *
    *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
@@ -1853,28 +1861,31 @@ declare module 'shared/services/network.service' {
    * Create a network event emitter that participates in central registration. The returned emitter
    * appears in the OpenRPC document if `documentation` is provided.
    *
-   * If the event name is in `SharedNetworkEventTypes`, the central registry uses shared semantics:
-   * multiple processes may register the same name (each process registers once); all corresponding
-   * emitters are valid sources.
+   * If the event name is in {@link SharedNetworkEventTypes}, the central registry uses shared
+   * semantics: multiple processes may register the same name (each process registers once); all
+   * corresponding emitters are valid sources.
    *
    * Otherwise the registry uses exclusive semantics: only one process may register a given name;
    * subsequent registrations from any process are rejected.
    *
    * Intra-process duplicate registration is always rejected regardless of the event's domain.
    *
-   * @param eventType A key of `NetworkEventTypes` (which inherits `SharedNetworkEventTypes`).
-   * @param documentation Optional notification documentation. Carries `'x-experimental': true` to
-   *   mark the event as experimental.
+   * See {@link SharedNetworkEventTypes} for shared vs exclusive semantics.
+   *
+   * @param eventType The name of the event to register. Must be a key of {@link NetworkEventTypes}.
+   * @param documentation Optional notification documentation. Carries
+   *   `notification['x-experimental']: true` to mark the event as experimental.
    */
   export const createNetworkEventEmitterAsync: <EventType extends keyof NetworkEventTypes>(
     eventType: EventType,
     documentation?: SingleNotificationDocumentation,
   ) => Promise<PlatformEventEmitter<NetworkEventTypes[EventType]>>;
   /**
-   * Subscribe to a typed network event. Declare the event in `NetworkEventTypes` (or rely on
-   * `SharedNetworkEventTypes` inheritance for platform events) and the payload type is inferred.
+   * Subscribe to a typed network event. The payload type is inferred from the event's declaration in
+   * {@link NetworkEventTypes}.
    *
-   * @param eventType Unique network event type for coordinating between connections
+   * @param eventType The name of the event to subscribe to. Must be a key of
+   *   {@link NetworkEventTypes}.
    * @returns Event for the event type that runs the callback provided when the event is emitted
    */
   export function getNetworkEvent<EventType extends keyof NetworkEventTypes>(
@@ -1883,16 +1894,13 @@ declare module 'shared/services/network.service' {
   /**
    * Subscribe to a network event with an explicit payload type.
    *
-   * @deprecated 8 June 2026. Use the typed signature: declare the event in `NetworkEventTypes` and
-   *   call `getNetworkEvent('your.event.name')` without an explicit type parameter. If your event
-   *   name is dynamic (e.g., per-instance data-provider events), this signature continues to work
-   *   functionally; suppress the deprecation warning at the call site with a brief comment.
+   * @deprecated 8 June 2026. Use the typed signature: declare the event in {@link NetworkEventTypes}
+   *   and call `getNetworkEvent('your.event.name')` without an explicit type parameter.
    * @param eventType Unique network event type for coordinating between connections
    * @returns Event for the event type that runs the callback provided when the event is emitted
    */
   export function getNetworkEvent<T>(eventType: string): PlatformEvent<T>;
   export interface PapiNetworkService {
-    /** @deprecated 8 June 2026. Use createNetworkEventEmitterAsync. */
     createNetworkEventEmitter: typeof createNetworkEventEmitter;
     createNetworkEventEmitterAsync: typeof createNetworkEventEmitterAsync;
     getNetworkEvent: typeof getNetworkEvent;
@@ -1966,6 +1974,11 @@ declare module 'shared/services/network-object.service' {
    *   object did not already define a `dispose` function, one will be added.
    *
    *   WARNING: setting a network object mutates the provided object.
+   * @param objectType String identifier for the network object type (e.g. `'object'`, `'dataProvider'`)
+   * @param objectAttributes Optional key-value metadata attached to the network object registration.
+   * @param objectDocumentation Optional {@link NetworkObjectDocumentation} for this network object.
+   *   Set `objectDocumentation['x-experimental']: true` to mark all methods on this network object
+   *   as experimental.
    * @returns `objectToShare` modified to be a network object
    */
   const set: <T extends NetworkableObject>(
@@ -3551,7 +3564,9 @@ declare module 'shared/services/web-view-provider.service' {
    *
    *   WARNING: setting a webView provider mutates the provided object.
    * @param attributes Optional additional attributes to attach to the network object
-   * @param documentation Optional OpenRPC-style documentation for the network object
+   * @param documentation Optional {@link NetworkObjectDocumentation} for this web view provider. Set
+   *   `documentation['x-experimental']: true` to mark all methods on this web view provider as
+   *   experimental.
    * @returns `webViewProvider` modified to be a network object and able to be disposed with `dispose`
    */
   function registerWebViewProvider(
@@ -4506,15 +4521,20 @@ declare module 'papi-shared-types' {
    *
    * Subscribers do not need to know which events are shared — `getNetworkEvent` handles both kinds
    * identically.
+   *
+   * See {@link NetworkEventTypes} for the full registry of known event names.
    */
   type SharedNetworkEventTypes = {
-    'network-object.onDidCreateNetworkObject': NetworkObjectDetails;
-    'network-object.onDidDisposeNetworkObject': string;
-    'shared-store.onDidChange': StoreChangeEvent;
+    /** Emitted when a network object is created in any process. Payload includes the new object's details. */
+    'object:onDidCreateNetworkObject': NetworkObjectDetails;
+    /** Emitted when a network object is disposed in any process. Payload is the disposed object's ID. */
+    'object:onDidDisposeNetworkObject': string;
+    /** Emitted when a value in the shared store changes. Payload includes the key and new value with Lamport timestamp. */
+    'shared-store:change': StoreChangeEvent;
   };
   /**
    * All known network events. Extensions augment this to declare their own events. Inherits the
-   * platform's shared events automatically.
+   * platform's shared events from {@link SharedNetworkEventTypes} automatically.
    *
    * To declare a new event for use with `createNetworkEventEmitterAsync`:
    *
@@ -5457,21 +5477,18 @@ declare module 'shared/models/project-data-provider-engine-factory.model' {
       layeringFilters?: ProjectMetadataFilterOptions,
     ): Promise<ProjectMetadataWithoutFactoryInfo[]>;
     /**
-     * Create a {@link IProjectDataProviderEngine} for the project requested so the papi can create an
-     * {@link IProjectDataProvider} for the project.
+     * Create an {@link IProjectDataProviderEngine} for the project requested so the papi can create
+     * an {@link IProjectDataProvider} for the project.
      *
-     * The return value may be either the engine directly, or an envelope object with the engine plus
-     * optional per-PDP-instance attributes and documentation. The unusual property name
-     * `projectDataProviderEngine` (rather than `engine`) is deliberate — it cannot collide with a
-     * property the engine itself might expose, so the platform's narrowing check on the return shape
-     * is unambiguous.
+     * The return value may be either the engine directly, or an envelope containing the engine and
+     * PDP network metadata (per-PDP attributes and documentation).
      *
-     * The platform overwrites `projectId` in any supplied per-PDP attributes — that field is always
-     * the platform-canonical value.
+     * The platform overwrites `projectId` and `projectInterfaces` in any supplied per-PDP attributes
+     * — those fields are always the platform-canonical values.
      *
-     * @param projectId Id of the project for which to create a {@link IProjectDataProviderEngine}
-     * @returns Either the engine, or an envelope `{ projectDataProviderEngine, attributes?,
-     *   documentation? }`
+     * @param projectId Id of the project for which to create an {@link IProjectDataProviderEngine}
+     * @returns Either the {@link IProjectDataProviderEngine} directly, or an envelope
+     *   `{ projectDataProviderEngine, attributes?, documentation? }`
      */
     createProjectDataProviderEngine(projectId: string): Promise<
       | IProjectDataProviderEngine<SupportedProjectInterfaces>
@@ -5747,11 +5764,13 @@ declare module 'shared/services/project-data-provider.service' {
    *
    * @param pdpFactoryId Unique id for this PDP factory.
    * @param projectInterfaces The standardized sets of methods (`projectInterface`s) supported by the
-   *   Project Data Provider Engines produced by this factory.
+   *   Project Data Provider Engines produced by this factory. Indicates what sort of project data
+   *   should be available on the PDPEs created by this factory.
    * @param pdpEngineFactory Used in a ProjectDataProviderFactory to create ProjectDataProviders.
    * @param attributes Optional registration-level attributes. The platform overwrites the
    *   `projectInterfaces` field — that field is always the platform-canonical value.
-   * @param documentation Optional `NetworkObjectDocumentation` for the factory itself.
+   * @param documentation Optional {@link NetworkObjectDocumentation} for the factory itself. Set
+   *   `documentation['x-experimental']: true` to mark all methods on this factory as experimental.
    * @returns Promise that resolves to a disposable object when the registration operation completes.
    */
   export function registerProjectDataProviderEngineFactory<

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1003,17 +1003,17 @@ declare module 'shared/models/openrpc.model' {
   /**
    * Describes APIs available to call using JSON-RPC 2.0
    *
-   * See https://github.com/open-rpc/meta-schema/releases - Release 1.14.2 aligns with OpenRPC 1.2.6.
-   * https://github.com/open-rpc/meta-schema/releases/download/1.14.2/open-rpc-meta-schema.json
+   * See https://github.com/open-rpc/meta-schema/releases - Release 1.14.3 aligns with OpenRPC 1.3.0.
+   * https://github.com/open-rpc/meta-schema/releases/download/1.14.3/open-rpc-meta-schema.json
    *
    * We declare OpenRPC `1.3.0` because notifications (a method with no `result`) were introduced in
    * 1.3.0 — `result` was required in 1.2.6, so a document with notifications is invalid under the
    * 1.2.6 meta-schema. The OpenRPC playground (https://playground.open-rpc.org/) is still capped at
    * 1.2.6 (https://github.com/open-rpc/playground/issues/606), but it renders a 1.3.0 document fine
-   * in practice; it just lists notifications under the same "Methods" heading, which we mitigate by
-   * prefixing notification summaries with {@link NOTIFICATION_OPENRPC_PREFIX}.
+   * in practice; it lists notifications under the same "Methods" heading (without a results field),
+   * which we mitigate by prefixing notification summaries with {@link NOTIFICATION_OPENRPC_PREFIX}.
    *
-   * Note that the types from https://www.npmjs.com/package/@open-rpc/meta-schema/v/1.14.2 are not
+   * Note that the types from https://www.npmjs.com/package/@open-rpc/meta-schema/v/1.14.3 are not
    * very good. For example, all the properties of `Components` are of type `any` instead of the
    * specific types they should be, and they redefine types for JSON Schema. So we're using our own
    * types here instead.
@@ -1172,10 +1172,6 @@ declare module 'shared/models/openrpc.model' {
    *
    * Set `'x-experimental': true` on the notification object to mark it as experimental. Informational
    * only; appears in the generated OpenRPC document.
-   *
-   * Named `OpenRpcNotification` (rather than `Notification`) to avoid shadowing the DOM global
-   * `Notification` type — a file that forgot to import this would otherwise silently typecheck
-   * against the wrong type.
    */
   export type OpenRpcNotification = Omit<Method, 'result'>;
   /**
@@ -5745,10 +5741,10 @@ declare module 'shared/models/project-data-provider-engine-factory.model' {
   }
   /**
    * Type guard: whether a `createProjectDataProviderEngine` return value is a
-   * {@link ProjectDataProviderEngineEnvelope} rather than a raw engine. Guards against
-   * `typeof null === 'object'` and against a raw engine that merely exposes a
-   * `projectDataProviderEngine` property of a non-object type. Written as a user-defined type guard so
-   * the value check doesn't defeat the narrowing at call sites.
+   * {@link ProjectDataProviderEngineEnvelope} rather than a raw engine. Guards against `typeof null
+   * === 'object'` and against a raw engine that merely exposes a `projectDataProviderEngine` property
+   * of a non-object type. Written as a user-defined type guard so the value check doesn't defeat the
+   * narrowing at call sites.
    */
   export function isProjectDataProviderEngineEnvelope<
     SupportedProjectInterfaces extends ProjectInterfaces[],

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1209,6 +1209,15 @@ declare module 'shared/models/openrpc.model' {
    * document (mirroring how undocumented methods are surfaced via {@link getEmptyMethodDocs}).
    */
   export function getEmptyNotificationDocs(): Omit<MethodDocumentationWithoutName, 'result'>;
+  /** Prefix prepended to the `summary` and `description` of experimental methods and notifications. */
+  export const EXPERIMENTAL_OPENRPC_PREFIX = 'EXPERIMENTAL: ';
+  /**
+   * Returns a shallow copy of an OpenRPC {@link Method} or {@link Notification} with
+   * {@link EXPERIMENTAL_OPENRPC_PREFIX} prepended to its `summary` and `description` when the entry is
+   * marked `'x-experimental'`. Returns the entry unchanged when it is not experimental. Call this on a
+   * freshly-built entry so the prefix is applied at most once.
+   */
+  export function withExperimentalPrefix<T extends Method | Notification>(entry: T): T;
 }
 declare module 'shared/services/shared-store.service' {
   /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -981,8 +981,8 @@ declare module 'shared/data/rpc.model' {
   export const UNREGISTER_METHOD = 'network:unregisterMethod';
   /**
    * Register a network event emitter with the main process so that the event is tracked centrally.
-   * Shared vs. exclusive semantics are determined by looking up the event name in
-   * `SHARED_EVENT_NAMES`.
+   * Multi-source vs. single-source semantics are determined by looking up the event name in
+   * `MULTI_SOURCE_EVENT_NAMES`.
    */
   export const REGISTER_EVENT = 'network:registerEvent';
   /**
@@ -1149,7 +1149,7 @@ declare module 'shared/models/openrpc.model' {
     openrpc: string;
     info: Info;
     servers?: Server[];
-    methods: (Method | OpenRpcNotification)[];
+    methods: (Method | Notification)[];
     components?: Components;
     externalDocs?: ExternalDocumentation;
   };
@@ -1282,8 +1282,8 @@ declare module 'shared/models/openrpc.model' {
   };
   export type MethodDocumentationWithoutName = Omit<Method, 'name'>;
   /**
-   * Documentation about a single {@link Method}. Informational only; appears in the generated
-   * OpenRPC document.
+   * Documentation about a single {@link Method}. Informational only; appears in the generated OpenRPC
+   * document.
    *
    * Set `method['x-experimental']: true` to mark this method as experimental.
    */
@@ -1299,15 +1299,15 @@ declare module 'shared/models/openrpc.model' {
    * Set `'x-experimental': true` on the notification object to mark it as experimental. Informational
    * only; appears in the generated OpenRPC document.
    */
-  export type OpenRpcNotification = Omit<Method, 'result'>;
+  export type Notification = Omit<Method, 'result'>;
   /**
-   * Documentation about a single {@link OpenRpcNotification}. Informational only; appears in the
-   * generated OpenRPC document.
+   * Documentation about a single {@link Notification}. Informational only; appears in the generated
+   * OpenRPC document.
    *
    * Set `notification['x-experimental']: true` to mark this notification as experimental.
    */
   export type SingleNotificationDocumentation = {
-    notification: Omit<OpenRpcNotification, 'name'>;
+    notification: Omit<Notification, 'name'>;
     components?: Components;
   };
   /**
@@ -1423,9 +1423,9 @@ declare module 'shared/models/rpc.interface' {
     /** Unregister a method so it is no longer available to RPC requests */
     unregisterMethod: (methodName: string) => Promise<boolean>;
     /**
-     * Register a centrally-tracked network event with the main process. Shared vs exclusive semantics
-     * is determined by looking up the event name in `SHARED_EVENT_NAMES`. See
-     * {@link SharedNetworkEventTypes} for shared vs exclusive semantics.
+     * Register a centrally-tracked network event with the main process. Multi-source vs single-source
+     * semantics is determined by looking up the event name in `MULTI_SOURCE_EVENT_NAMES`. See
+     * {@link MultiSourceNetworkEvents} for multi-source vs single-source semantics.
      *
      * Returns `true` if the registration was accepted, `false` otherwise. Used by
      * `createNetworkEventEmitterAsync`; not for direct caller use.
@@ -1683,10 +1683,10 @@ declare module 'main/services/rpc-websocket-listener' {
     /**
      * Try to register an event. Returns `true` if accepted, `false` if rejected.
      *
-     * - Name in `SHARED_EVENT_NAMES` (shared): multiple handlers may register; same handler twice
-     *   rejected.
-     * - Name not in `SHARED_EVENT_NAMES` (exclusive): first registrant wins; any subsequent
-     *   registration from any handler is rejected.
+     * - Name in `MULTI_SOURCE_EVENT_NAMES` (multi-source): multiple handlers may register; same
+     *   handler twice rejected.
+     * - Name not in `MULTI_SOURCE_EVENT_NAMES` (single-source): first registrant wins; any
+     *   subsequent registration from any handler is rejected.
      */
     tryRegister(
       handler: unknown,
@@ -1777,15 +1777,19 @@ declare module 'shared/services/network.service' {
     SingleNotificationDocumentation,
   } from 'shared/models/openrpc.model';
   import { NetworkMethodHandlerOptions } from 'shared/models/network.model';
-  import type { NetworkEventTypes, SharedNetworkEventTypes } from 'papi-shared-types';
+  import type {
+    MultiSourceNetworkEvents,
+    NetworkEvents,
+    NetworkEventTypes,
+  } from 'papi-shared-types';
   /**
-   * Source of truth for which event names use shared semantics at the central registry. Must stay in
-   * sync with the `SharedNetworkEventTypes` type alias in `papi-shared-types.ts` — the test
+   * Source of truth for which event names use multi-source semantics at the central registry. Must
+   * stay in sync with the `MultiSourceNetworkEvents` type alias in `papi-shared-types.ts` — the test
    * `network.service.shared-events.test.ts` enforces the invariant.
    *
-   * Add entries here when adding a new shared event to `SharedNetworkEventTypes`.
+   * Add entries here when adding a new multi-source event to `MultiSourceNetworkEvents`.
    */
-  export const SHARED_EVENT_NAMES: Set<keyof SharedNetworkEventTypes>;
+  export const MULTI_SOURCE_EVENT_NAMES: Set<keyof MultiSourceNetworkEvents>;
   export function initialize(): Promise<void>;
   /** Closes the network services gracefully */
   export const shutdown: () => Promise<void>;
@@ -1848,11 +1852,11 @@ declare module 'shared/services/network.service' {
    * @deprecated 8 June 2026. Use `createNetworkEventEmitterAsync`. Events created via the sync API
    *   are not centrally registered and do not appear in the OpenRPC document. The async version
    *   properly restricts event registration to prevent multiple sources from emitting the same
-   *   network event (unless the event is declared in {@link SharedNetworkEventTypes}, in which case it
-   *   accepts multiple registrants by design).
+   *   network event (unless the event is declared in {@link MultiSourceNetworkEvents}, in which case
+   *   it accepts multiple registrants by design).
    *
-   *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
-   *   emitters.
+   *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked
+   *   event emitters.
    * @param eventType Unique network event type for coordinating between connections
    * @returns Event emitter whose event works between connections
    */
@@ -1861,41 +1865,40 @@ declare module 'shared/services/network.service' {
    * Create a network event emitter that participates in central registration. The returned emitter
    * appears in the OpenRPC document if `documentation` is provided.
    *
-   * If the event name is in {@link SharedNetworkEventTypes}, the central registry uses shared
+   * If the event name is in {@link MultiSourceNetworkEvents}, the central registry uses multi-source
    * semantics: multiple processes may register the same name (each process registers once); all
    * corresponding emitters are valid sources.
    *
-   * Otherwise the registry uses exclusive semantics: only one process may register a given name;
+   * Otherwise the registry uses single-source semantics: only one process may register a given name;
    * subsequent registrations from any process are rejected.
    *
    * Intra-process duplicate registration is always rejected regardless of the event's domain.
    *
-   * See {@link SharedNetworkEventTypes} for shared vs exclusive semantics.
+   * See {@link MultiSourceNetworkEvents} for multi-source vs single-source semantics.
    *
-   * @param eventType The name of the event to register. Must be a key of {@link NetworkEventTypes}.
+   * @param eventType The name of the event to register. Must be a key of {@link NetworkEvents}.
    * @param documentation Optional notification documentation. Carries
    *   `notification['x-experimental']: true` to mark the event as experimental.
    */
-  export const createNetworkEventEmitterAsync: <EventType extends keyof NetworkEventTypes>(
+  export const createNetworkEventEmitterAsync: <EventType extends NetworkEventTypes>(
     eventType: EventType,
     documentation?: SingleNotificationDocumentation,
-  ) => Promise<PlatformEventEmitter<NetworkEventTypes[EventType]>>;
+  ) => Promise<PlatformEventEmitter<NetworkEvents[EventType]>>;
   /**
    * Subscribe to a typed network event. The payload type is inferred from the event's declaration in
-   * {@link NetworkEventTypes}.
+   * {@link NetworkEvents}.
    *
-   * @param eventType The name of the event to subscribe to. Must be a key of
-   *   {@link NetworkEventTypes}.
+   * @param eventType The name of the event to subscribe to. Must be a key of {@link NetworkEvents}.
    * @returns Event for the event type that runs the callback provided when the event is emitted
    */
-  export function getNetworkEvent<EventType extends keyof NetworkEventTypes>(
+  export function getNetworkEvent<EventType extends NetworkEventTypes>(
     eventType: EventType,
-  ): PlatformEvent<NetworkEventTypes[EventType]>;
+  ): PlatformEvent<NetworkEvents[EventType]>;
   /**
    * Subscribe to a network event with an explicit payload type.
    *
-   * @deprecated 8 June 2026. Use the typed signature: declare the event in {@link NetworkEventTypes}
-   *   and call `getNetworkEvent('your.event.name')` without an explicit type parameter.
+   * @deprecated 8 June 2026. Use the typed signature: declare the event in {@link NetworkEvents} and
+   *   call `getNetworkEvent('your.event.name')` without an explicit type parameter.
    * @param eventType Unique network event type for coordinating between connections
    * @returns Event for the event type that runs the callback provided when the event is emitted
    */
@@ -1974,11 +1977,12 @@ declare module 'shared/services/network-object.service' {
    *   object did not already define a `dispose` function, one will be added.
    *
    *   WARNING: setting a network object mutates the provided object.
-   * @param objectType String identifier for the network object type (e.g. `'object'`, `'dataProvider'`)
+   * @param objectType String identifier for the network object type (e.g. `'object'`,
+   *   `'dataProvider'`)
    * @param objectAttributes Optional key-value metadata attached to the network object registration.
    * @param objectDocumentation Optional {@link NetworkObjectDocumentation} for this network object.
-   *   Set `objectDocumentation['x-experimental']: true` to mark all methods on this network object
-   *   as experimental.
+   *   Set `objectDocumentation['x-experimental']: true` to mark all methods on this network object as
+   *   experimental.
    * @returns `objectToShare` modified to be a network object
    */
   const set: <T extends NetworkableObject>(
@@ -4514,33 +4518,43 @@ declare module 'papi-shared-types' {
    * Network events emitted from multiple processes (each process emits its own local event under
    * the same name). Declared by the platform; not extensible by extensions.
    *
-   * The names listed here are the source of truth for which event names use shared semantics at the
-   * central registry. An event name in this type allows registration from multiple processes (each
-   * process registers once, all emitters are valid sources). Any other event name uses exclusive
-   * semantics (one registrant ever).
+   * The names listed here are the source of truth for which event names use multi-source semantics
+   * at the central registry. An event name in this type allows registration from multiple processes
+   * (each process registers once, all emitters are valid sources). Any other event name uses
+   * single-source semantics (one registrant ever).
    *
-   * Subscribers do not need to know which events are shared — `getNetworkEvent` handles both kinds
-   * identically.
+   * Subscribers do not need to know which events are multi-source — `getNetworkEvent` handles both
+   * kinds identically.
    *
-   * See {@link NetworkEventTypes} for the full registry of known event names.
+   * See {@link NetworkEvents} for the full registry of known event names.
    */
-  type SharedNetworkEventTypes = {
-    /** Emitted when a network object is created in any process. Payload includes the new object's details. */
+  type MultiSourceNetworkEvents = {
+    /**
+     * Emitted when a network object is created in any process. Payload includes the new object's
+     * details.
+     */
     'object:onDidCreateNetworkObject': NetworkObjectDetails;
-    /** Emitted when a network object is disposed in any process. Payload is the disposed object's ID. */
+    /**
+     * Emitted when a network object is disposed in any process. Payload is the disposed object's
+     * ID.
+     */
     'object:onDidDisposeNetworkObject': string;
-    /** Emitted when a value in the shared store changes. Payload includes the key and new value with Lamport timestamp. */
+    /**
+     * Emitted when a value in the shared store changes. Payload includes the key and new value with
+     * Lamport timestamp.
+     */
     'shared-store:change': StoreChangeEvent;
   };
   /**
-   * All known network events. Extensions augment this to declare their own events. Inherits the
-   * platform's shared events from {@link SharedNetworkEventTypes} automatically.
+   * Mapping of network event names to their payload types. Extensions augment this to declare their
+   * own events. Inherits the platform's multi-source events from {@link MultiSourceNetworkEvents}
+   * automatically.
    *
    * To declare a new event for use with `createNetworkEventEmitterAsync`:
    *
    * ```ts
    * declare module 'papi-shared-types' {
-   *   export interface NetworkEventTypes {
+   *   export interface NetworkEvents {
    *     'myExt.somethingHappened': { foo: string };
    *   }
    * }
@@ -4549,14 +4563,13 @@ declare module 'papi-shared-types' {
    * Mark a single event as experimental by adding `\/** @experimental *\/` directly above its
    * entry.
    */
-  interface NetworkEventTypes extends SharedNetworkEventTypes {
+  interface NetworkEvents extends MultiSourceNetworkEvents {
     /** Emitted when extensions finish reloading. `true` if reload succeeded, `false` if it failed. */
     'platform.onDidReloadExtensions': boolean;
     /** Emitted when the Scripture reference for a scroll group changes. */
     'scrollGroup:onDidUpdateScrRef': ScrollGroupUpdateInfo;
     /**
-     * @deprecated 13 November 2024. Use {@link NetworkEventTypes.'webView:onDidOpenWebView'}
-     *   instead.
+     * @deprecated 13 November 2024. Use {@link NetworkEvents.'webView:onDidOpenWebView'} instead.
      */
     'webView:onDidAddWebView': OpenWebViewEvent;
     /** Emitted when a WebView is created. */
@@ -4566,6 +4579,8 @@ declare module 'papi-shared-types' {
     /** Emitted when a WebView is closed. */
     'webView:onDidCloseWebView': CloseWebViewEvent;
   }
+  /** Union of all known network event names (keys of {@link NetworkEvents}). */
+  type NetworkEventTypes = keyof NetworkEvents;
 }
 declare module 'shared/services/command.service' {
   import { UnsubscriberAsync } from 'platform-bible-utils';
@@ -5477,8 +5492,8 @@ declare module 'shared/models/project-data-provider-engine-factory.model' {
       layeringFilters?: ProjectMetadataFilterOptions,
     ): Promise<ProjectMetadataWithoutFactoryInfo[]>;
     /**
-     * Create an {@link IProjectDataProviderEngine} for the project requested so the papi can create
-     * an {@link IProjectDataProvider} for the project.
+     * Create an {@link IProjectDataProviderEngine} for the project requested so the papi can create an
+     * {@link IProjectDataProvider} for the project.
      *
      * The return value may be either the engine directly, or an envelope containing the engine and
      * PDP network metadata (per-PDP attributes and documentation).
@@ -5487,8 +5502,8 @@ declare module 'shared/models/project-data-provider-engine-factory.model' {
      * — those fields are always the platform-canonical values.
      *
      * @param projectId Id of the project for which to create an {@link IProjectDataProviderEngine}
-     * @returns Either the {@link IProjectDataProviderEngine} directly, or an envelope
-     *   `{ projectDataProviderEngine, attributes?, documentation? }`
+     * @returns Either the {@link IProjectDataProviderEngine} directly, or an envelope `{
+     *   projectDataProviderEngine, attributes?, documentation? }`
      */
     createProjectDataProviderEngine(projectId: string): Promise<
       | IProjectDataProviderEngine<SupportedProjectInterfaces>

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -998,6 +998,218 @@ declare module 'shared/data/rpc.model' {
   /** Prefix on requests that indicates that the request is a command */
   export const CATEGORY_COMMAND = 'command';
 }
+declare module 'shared/models/openrpc.model' {
+  import type { JSONSchema7 } from 'json-schema';
+  /**
+   * Describes APIs available to call using JSON-RPC 2.0
+   *
+   * See https://github.com/open-rpc/meta-schema/releases - Release 1.14.2 aligns with OpenRPC 1.2.6.
+   * https://github.com/open-rpc/meta-schema/releases/download/1.14.2/open-rpc-meta-schema.json
+   *
+   * We don't want to go past 1.2.6 because https://playground.open-rpc.org/ doesn't support anything
+   * past 1.2.6 for now. See https://github.com/open-rpc/playground/issues/606.
+   *
+   * Note that the types from https://www.npmjs.com/package/@open-rpc/meta-schema/v/1.14.2 are not
+   * very good. For example, all the properties of `Components` are of type `any` instead of the
+   * specific types they should be, and they redefine types for JSON Schema. So we're using our own
+   * types here instead.
+   */
+  export type OpenRpc = {
+    openrpc: string;
+    info: Info;
+    servers?: Server[];
+    methods: (Method | Notification)[];
+    components?: Components;
+    externalDocs?: ExternalDocumentation;
+  };
+  export type Components = {
+    schemas?: {
+      [key: string]: Schema;
+    };
+    contentDescriptors?: {
+      [key: string]: ContentDescriptor;
+    };
+    examples?: {
+      [key: string]: Example;
+    };
+    links?: {
+      [key: string]: Link;
+    };
+    errors?: {
+      [key: string]: Error;
+    };
+    tags?: {
+      [key: string]: Tag;
+    };
+  };
+  export type ComponentsReference = `#/components/${string}`;
+  export type Contact = {
+    name?: string;
+    email?: string;
+    url?: string;
+  };
+  export type ContentDescriptor = {
+    name: string;
+    schema: Schema;
+    required?: boolean;
+    summary?: string;
+    description?: string;
+    deprecated?: boolean;
+  };
+  export type Error = {
+    code: number;
+    message: string;
+    data?: any;
+  };
+  export type Example = {
+    name: string;
+    value: any;
+    summary?: string;
+    description?: string;
+  };
+  export type ExamplePairingObject = {
+    name: string;
+    params: (Example | Reference)[];
+    result: Example | Reference;
+    description?: string;
+  };
+  export type ExternalDocumentation = {
+    url: string;
+    description?: string;
+  };
+  export type Info = {
+    title: string;
+    version: string;
+    description?: string;
+    termsOfService?: string;
+    contact?: Contact;
+    license?: License;
+  };
+  export type License = {
+    name: string;
+    url?: string;
+  };
+  export type Link = {
+    name?: string;
+    summary?: string;
+    description?: string;
+    method?: string;
+    params?: {
+      [key: string]: any;
+    };
+    server?: Server;
+  };
+  export type Method = {
+    /** The canonical name for the method. The name MUST be unique within the methods array. */
+    name: string;
+    params: (ContentDescriptor | Reference)[];
+    result: ContentDescriptor | Reference;
+    /**
+     * Set to `true` to mark this method as experimental — its shape may change without notice.
+     * Informational only; does not affect runtime behavior. See the
+     * {@link https://github.com/paranext/paranext-extension-template/wiki/Experimental-APIs | experimental APIs wiki page}.
+     */
+    'x-experimental'?: boolean;
+    /** A short summary of what the method does. */
+    summary?: string;
+    /**
+     * A verbose explanation of the method behavior. GitHub Flavored Markdown syntax MAY be used for
+     * rich text representation.
+     */
+    description?: string;
+    deprecated?: boolean;
+    servers?: Server[];
+    tags?: (Tag | Reference)[];
+    /** Format the server expects the params. Defaults to 'either'. */
+    paramStructure?: 'by-name' | 'by-position' | 'either';
+    errors?: (Error | Reference)[];
+    links?: (Link | Reference)[];
+    examples?: (ExamplePairingObject | Reference)[];
+    externalDocs?: ExternalDocumentation;
+  };
+  export type Reference = {
+    $ref: ComponentsReference;
+  };
+  export type Server = {
+    url: string;
+    name?: string;
+    description?: string;
+    summary?: string;
+    variables?: {
+      [key: string]: ServerVariable;
+    };
+  };
+  export type ServerVariable = {
+    default: string;
+    description?: string;
+    enum?: string[];
+  };
+  export type Schema = JSONSchema7;
+  export type Tag = {
+    name: string;
+    description?: string;
+    externalDocs?: ExternalDocumentation;
+  };
+  export type MethodDocumentationWithoutName = Omit<Method, 'name'>;
+  /**
+   * Documentation about a single {@link Method}.
+   *
+   * Set `method['x-experimental']: true` to mark this method as experimental. Informational only;
+   * appears in the generated OpenRPC document.
+   */
+  export type SingleMethodDocumentation = {
+    method: MethodDocumentationWithoutName;
+    components?: Components;
+  };
+  /**
+   * An OpenRPC notification — same shape as a {@link Method}, but without `result`. Used for events /
+   * one-way messages from server to client. Per the OpenRPC convention (no `result` ⇒ notification),
+   * these are serialized into the same root `methods` array as Methods on the wire.
+   *
+   * Set `'x-experimental': true` on the notification object to mark it as experimental. Informational
+   * only; appears in the generated OpenRPC document.
+   */
+  export type Notification = Omit<Method, 'result'>;
+  /**
+   * Documentation about a single {@link Notification}.
+   *
+   * Set `notification['x-experimental']: true` to mark this notification as experimental.
+   * Informational only; appears in the generated OpenRPC document.
+   */
+  export type SingleNotificationDocumentation = {
+    notification: Omit<Notification, 'name'>;
+    components?: Components;
+  };
+  /**
+   * Documentation about a network object — what it is, and OpenRPC documentation for each of its
+   * methods.
+   */
+  export type NetworkObjectDocumentation = {
+    summary?: string;
+    description?: string;
+    methods?: Method[];
+    components?: Components;
+    /**
+     * Set to `true` to mark every {@link Method} registered for this network object as experimental.
+     * The marker is fanned out onto each method's `'x-experimental'` field inside
+     * `networkObjectService.set`.
+     */
+    'x-experimental'?: boolean;
+  };
+  /** Create an object of type {@link OpenRpc} to hold documentation for PAPI websocket methods */
+  export function createEmptyOpenRpc(papiVersion: string): OpenRpc;
+  /**
+   * Get an empty {@link OpenRpc} method document object. Useful for populating documentation for
+   * methods that didn't have their own documentation provided.
+   */
+  export function getEmptyMethodDocs(): MethodDocumentationWithoutName;
+  /**
+   * Get an empty {@link Notification} documentation object. Useful for surfacing events that didn't
+   * have their own documentation provided so that every registered event still appears in the OpenRPC
+   * document (mirroring how undocumented methods are surfaced via {@link getEmptyMethodDocs}).
+   */
+  export function getEmptyNotificationDocs(): Omit<MethodDocumentationWithoutName, 'result'>;
+}
 declare module 'shared/services/shared-store.service' {
   /**
    * Internal request type used by the shared store service to fetch the initial store contents during
@@ -1160,211 +1372,6 @@ declare module 'shared/models/papi-network-event-emitter.model' {
     dispose: () => Promise<boolean>;
   }
   export default PapiNetworkEventEmitter;
-}
-declare module 'shared/models/openrpc.model' {
-  import type { JSONSchema7 } from 'json-schema';
-  /**
-   * Describes APIs available to call using JSON-RPC 2.0
-   *
-   * See https://github.com/open-rpc/meta-schema/releases - Release 1.14.2 aligns with OpenRPC 1.2.6.
-   * https://github.com/open-rpc/meta-schema/releases/download/1.14.2/open-rpc-meta-schema.json
-   *
-   * We don't want to go past 1.2.6 because https://playground.open-rpc.org/ doesn't support anything
-   * past 1.2.6 for now. See https://github.com/open-rpc/playground/issues/606.
-   *
-   * Note that the types from https://www.npmjs.com/package/@open-rpc/meta-schema/v/1.14.2 are not
-   * very good. For example, all the properties of `Components` are of type `any` instead of the
-   * specific types they should be, and they redefine types for JSON Schema. So we're using our own
-   * types here instead.
-   */
-  export type OpenRpc = {
-    openrpc: string;
-    info: Info;
-    servers?: Server[];
-    methods: (Method | Notification)[];
-    components?: Components;
-    externalDocs?: ExternalDocumentation;
-  };
-  export type Components = {
-    schemas?: {
-      [key: string]: Schema;
-    };
-    contentDescriptors?: {
-      [key: string]: ContentDescriptor;
-    };
-    examples?: {
-      [key: string]: Example;
-    };
-    links?: {
-      [key: string]: Link;
-    };
-    errors?: {
-      [key: string]: Error;
-    };
-    tags?: {
-      [key: string]: Tag;
-    };
-  };
-  export type ComponentsReference = `#/components/${string}`;
-  export type Contact = {
-    name?: string;
-    email?: string;
-    url?: string;
-  };
-  export type ContentDescriptor = {
-    name: string;
-    schema: Schema;
-    required?: boolean;
-    summary?: string;
-    description?: string;
-    deprecated?: boolean;
-  };
-  export type Error = {
-    code: number;
-    message: string;
-    data?: any;
-  };
-  export type Example = {
-    name: string;
-    value: any;
-    summary?: string;
-    description?: string;
-  };
-  export type ExamplePairingObject = {
-    name: string;
-    params: (Example | Reference)[];
-    result: Example | Reference;
-    description?: string;
-  };
-  export type ExternalDocumentation = {
-    url: string;
-    description?: string;
-  };
-  export type Info = {
-    title: string;
-    version: string;
-    description?: string;
-    termsOfService?: string;
-    contact?: Contact;
-    license?: License;
-  };
-  export type License = {
-    name: string;
-    url?: string;
-  };
-  export type Link = {
-    name?: string;
-    summary?: string;
-    description?: string;
-    method?: string;
-    params?: {
-      [key: string]: any;
-    };
-    server?: Server;
-  };
-  export type Method = {
-    /** The canonical name for the method. The name MUST be unique within the methods array. */
-    name: string;
-    params: (ContentDescriptor | Reference)[];
-    result: ContentDescriptor | Reference;
-    /**
-     * Set to `true` to mark this method as experimental — its shape may change without notice.
-     * Informational only; does not affect runtime behavior. See the experimental APIs wiki page.
-     */
-    'x-experimental'?: boolean;
-    /** A short summary of what the method does. */
-    summary?: string;
-    /**
-     * A verbose explanation of the method behavior. GitHub Flavored Markdown syntax MAY be used for
-     * rich text representation.
-     */
-    description?: string;
-    deprecated?: boolean;
-    servers?: Server[];
-    tags?: (Tag | Reference)[];
-    /** Format the server expects the params. Defaults to 'either'. */
-    paramStructure?: 'by-name' | 'by-position' | 'either';
-    errors?: (Error | Reference)[];
-    links?: (Link | Reference)[];
-    examples?: (ExamplePairingObject | Reference)[];
-    externalDocs?: ExternalDocumentation;
-  };
-  export type Reference = {
-    $ref: ComponentsReference;
-  };
-  export type Server = {
-    url: string;
-    name?: string;
-    description?: string;
-    summary?: string;
-    variables?: {
-      [key: string]: ServerVariable;
-    };
-  };
-  export type ServerVariable = {
-    default: string;
-    description?: string;
-    enum?: string[];
-  };
-  export type Schema = JSONSchema7;
-  export type Tag = {
-    name: string;
-    description?: string;
-    externalDocs?: ExternalDocumentation;
-  };
-  export type MethodDocumentationWithoutName = Omit<Method, 'name'>;
-  /**
-   * Documentation about a single {@link Method}.
-   *
-   * Set `method['x-experimental']: true` to mark this method as experimental. Informational only;
-   * appears in the generated OpenRPC document.
-   */
-  export type SingleMethodDocumentation = {
-    method: MethodDocumentationWithoutName;
-    components?: Components;
-  };
-  /**
-   * An OpenRPC notification — same shape as a {@link Method}, but without `result`. Used for events /
-   * one-way messages from server to client. Per the OpenRPC convention (no `result` ⇒ notification),
-   * these are serialized into the same root `methods` array as Methods on the wire.
-   *
-   * Set `'x-experimental': true` on the notification object to mark it as experimental. Informational
-   * only; appears in the generated OpenRPC document.
-   */
-  export type Notification = Omit<Method, 'result'>;
-  /**
-   * Documentation about a single {@link Notification}.
-   *
-   * Set `notification['x-experimental']: true` to mark this notification as experimental.
-   * Informational only; appears in the generated OpenRPC document.
-   */
-  export type SingleNotificationDocumentation = {
-    notification: Omit<Notification, 'name'>;
-    components?: Components;
-  };
-  /**
-   * Documentation about a network object — what it is, and OpenRPC documentation for each of its
-   * methods.
-   */
-  export type NetworkObjectDocumentation = {
-    summary?: string;
-    description?: string;
-    methods?: Method[];
-    components?: Components;
-    /**
-     * Set to `true` to mark every {@link Method} registered for this network object as experimental.
-     * The marker is fanned out onto each method's `'x-experimental'` field inside
-     * `networkObjectService.set`.
-     */
-    'x-experimental'?: boolean;
-  };
-  /** Create an object of type {@link OpenRpc} to hold documentation for PAPI websocket methods */
-  export function createEmptyOpenRpc(papiVersion: string): OpenRpc;
-  /**
-   * Get an empty {@link OpenRpc} method document object. Useful for populating documentation for
-   * methods that didn't have their own documentation provided.
-   */
-  export function getEmptyMethodDocs(): MethodDocumentationWithoutName;
 }
 declare module 'shared/models/rpc.interface' {
   import {
@@ -1903,8 +1910,9 @@ declare module 'shared/services/network.service' {
    */
   export const createNetworkEventEmitter: <T>(eventType: string) => PlatformEventEmitter<T>;
   /**
-   * Create a network event emitter that participates in central registration. The returned emitter
-   * appears in the OpenRPC document if `documentation` is provided.
+   * Create a network event emitter that participates in central registration. Every centrally
+   * registered event appears in the OpenRPC document; providing `documentation` fills in its summary,
+   * params, and `x-experimental` flag, otherwise it is surfaced with placeholder docs.
    *
    * If the event name is in {@link MultiSourceNetworkEvents}, the central registry uses multi-source
    * semantics: multiple processes may register the same name (each process registers once); all
@@ -3608,7 +3616,8 @@ declare module 'shared/services/web-view-provider.service' {
    *   of it.
    *
    *   WARNING: setting a webView provider mutates the provided object.
-   * @param attributes Optional additional attributes to attach to the network object
+   * @param attributes Optional additional attributes to attach to the network object. The platform
+   *   overwrites the `webViewType` field — that field is always the platform-canonical value.
    * @param documentation Optional {@link NetworkObjectDocumentation} for this web view provider. Set
    *   `documentation['x-experimental']: true` to mark all methods on this web view provider as
    *   experimental.
@@ -9484,6 +9493,7 @@ declare module '@papi/core' {
     MethodDocumentationWithoutName,
     NetworkObjectDocumentation,
     SingleMethodDocumentation,
+    SingleNotificationDocumentation,
   } from 'shared/models/openrpc.model';
   export type {
     ExtensionDataScope,
@@ -9514,6 +9524,11 @@ declare module '@papi/core' {
     IDisposableWebViewProvider,
     IWebViewProvider,
   } from 'shared/models/web-view-provider.model';
+  export type {
+    CloseWebViewEvent,
+    OpenWebViewEvent,
+    UpdateWebViewEvent,
+  } from 'shared/services/web-view.service-model';
   export type { AppInfo } from 'shared/services/app.service-model';
   export type {
     NamedSqlParameters,
@@ -9529,8 +9544,12 @@ declare module '@papi/core' {
     SimultaneousProjectSettingsChanges,
     ProjectSettingValidator,
   } from 'shared/services/project-settings.service-model';
-  export type { ScrollGroupScrRef } from 'shared/services/scroll-group.service-model';
+  export type {
+    ScrollGroupScrRef,
+    ScrollGroupUpdateInfo,
+  } from 'shared/services/scroll-group.service-model';
   export type { SettingValidator } from 'shared/services/settings.service-model';
+  export type { StoreChangeEvent } from 'shared/services/shared-store.service';
   export type {
     FocusSubject,
     SetFocusSubject,

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1210,12 +1210,14 @@ declare module 'shared/models/openrpc.model' {
    */
   export function getEmptyNotificationDocs(): Omit<MethodDocumentationWithoutName, 'result'>;
   /** Prefix prepended to the `summary` and `description` of experimental methods and notifications. */
-  export const EXPERIMENTAL_OPENRPC_PREFIX = 'EXPERIMENTAL: ';
+  export const EXPERIMENTAL_OPENRPC_PREFIX = '[EXPERIMENTAL] ';
   /**
    * Returns a shallow copy of an OpenRPC {@link Method} or {@link Notification} with
    * {@link EXPERIMENTAL_OPENRPC_PREFIX} prepended to its `summary` and `description` when the entry is
-   * marked `'x-experimental'`. Returns the entry unchanged when it is not experimental. Call this on a
-   * freshly-built entry so the prefix is applied at most once.
+   * marked `'x-experimental'`. Both fields are always set on an experimental entry — even a missing
+   * or empty summary/description becomes the bare prefix so the marker is never lost. Idempotent: an
+   * entry already starting with the prefix is left unchanged. Returns the entry untouched when it is
+   * not experimental.
    */
   export function withExperimentalPrefix<T extends Method | Notification>(entry: T): T;
 }

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -66,7 +66,7 @@ declare module 'shared/services/scroll-group.service-model' {
   import { PlatformEvent, ScrollGroupId } from 'platform-bible-utils';
   export const NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE = 'ScrollGroupService';
   /** Name to use when creating a network event that is fired when webViews are updated */
-  export const EVENT_NAME_ON_DID_UPDATE_SCR_REF: `${string}:${string}`;
+  export const EVENT_NAME_ON_DID_UPDATE_SCR_REF: 'scrollGroup:onDidUpdateScrRef';
   /**
    * Combination of a {@link ScrollGroupId} and a SerializedVerseRef. If this value is a number, that
    * means this should be synced with the scroll group sharing that number. If this value is an
@@ -1282,10 +1282,10 @@ declare module 'shared/models/openrpc.model' {
   };
   export type MethodDocumentationWithoutName = Omit<Method, 'name'>;
   /**
-   * Documentation about a single {@link Method}. Informational only; appears in the generated OpenRPC
-   * document.
+   * Documentation about a single {@link Method}.
    *
-   * Set `method['x-experimental']: true` to mark this method as experimental.
+   * Set `method['x-experimental']: true` to mark this method as experimental. Informational only;
+   * appears in the generated OpenRPC document.
    */
   export type SingleMethodDocumentation = {
     method: MethodDocumentationWithoutName;
@@ -1301,18 +1301,18 @@ declare module 'shared/models/openrpc.model' {
    */
   export type Notification = Omit<Method, 'result'>;
   /**
-   * Documentation about a single {@link Notification}. Informational only; appears in the generated
-   * OpenRPC document.
+   * Documentation about a single {@link Notification}.
    *
    * Set `notification['x-experimental']: true` to mark this notification as experimental.
+   * Informational only; appears in the generated OpenRPC document.
    */
   export type SingleNotificationDocumentation = {
     notification: Omit<Notification, 'name'>;
     components?: Components;
   };
   /**
-   * Documentation about all methods on a network object. Pass to `networkObjectService.set`,
-   * `dataProviderService.registerEngine`, or `webViewProviderService.registerWebViewProvider`.
+   * Documentation about a network object — what it is, and OpenRPC documentation for each of its
+   * methods.
    */
   export type NetworkObjectDocumentation = {
     summary?: string;
@@ -3437,22 +3437,22 @@ declare module 'shared/services/web-view.service-model' {
     webViewId: WebViewId,
   ): Promise<NetworkObject<WebViewControllers[WebViewType]> | undefined>;
   /** @deprecated 13 November 2024. Renamed to {@link EVENT_NAME_ON_DID_OPEN_WEB_VIEW} */
-  export const EVENT_NAME_ON_DID_ADD_WEB_VIEW: `${string}:${string}`;
+  export const EVENT_NAME_ON_DID_ADD_WEB_VIEW: 'webView:onDidAddWebView';
   /** Name to use when creating a network event that is fired when webViews are created */
-  export const EVENT_NAME_ON_DID_OPEN_WEB_VIEW: `${string}:${string}`;
+  export const EVENT_NAME_ON_DID_OPEN_WEB_VIEW: 'webView:onDidOpenWebView';
   /** Event emitted when webViews are created */
   export type OpenWebViewEvent = {
     webView: SavedWebViewDefinition;
     layout: Layout;
   };
   /** Name to use when creating a network event that is fired when webViews are updated */
-  export const EVENT_NAME_ON_DID_UPDATE_WEB_VIEW: `${string}:${string}`;
+  export const EVENT_NAME_ON_DID_UPDATE_WEB_VIEW: 'webView:onDidUpdateWebView';
   /** Event emitted when webViews are updated */
   export type UpdateWebViewEvent = {
     webView: SavedWebViewDefinition;
   };
   /** Name to use when creating a network event that is fired when webViews are closed */
-  export const EVENT_NAME_ON_DID_CLOSE_WEB_VIEW: `${string}:${string}`;
+  export const EVENT_NAME_ON_DID_CLOSE_WEB_VIEW: 'webView:onDidCloseWebView';
   /** Event emitted when webViews are closed */
   export type CloseWebViewEvent = {
     webView: SavedWebViewDefinition;
@@ -5500,8 +5500,8 @@ declare module 'shared/models/project-data-provider-engine-factory.model' {
      * — those fields are always the platform-canonical values.
      *
      * @param projectId Id of the project for which to create an {@link IProjectDataProviderEngine}
-     * @returns Either the {@link IProjectDataProviderEngine} directly, or an envelope `{
-     *   projectDataProviderEngine, attributes?, documentation? }`
+     * @returns Either the {@link IProjectDataProviderEngine} or an envelope containing the engine and
+     *   per-PDP network object metadata (attributes and documentation).
      */
     createProjectDataProviderEngine(projectId: string): Promise<
       | IProjectDataProviderEngine<SupportedProjectInterfaces>
@@ -7756,7 +7756,7 @@ declare module 'shared/services/settings.service' {
 declare module 'renderer/services/scroll-group.service-host' {
   import { ScrollGroupUpdateInfo } from 'shared/services/scroll-group.service-model';
   import { SerializedVerseRef } from '@sillsdev/scripture';
-  import { ScrollGroupId } from 'platform-bible-utils';
+  import { type PlatformEvent, ScrollGroupId } from 'platform-bible-utils';
   /**
    * All Scroll Group IDs that are intended to be shown in scroll group selectors. This is a
    * placeholder and will be refactored significantly in
@@ -7764,7 +7764,7 @@ declare module 'renderer/services/scroll-group.service-host' {
    */
   export const availableScrollGroupIds: (number | undefined)[];
   /** Event that emits with information about a changed Scripture Reference for a scroll group */
-  export const onDidUpdateScrRef: import('platform-bible-utils').PlatformEvent<ScrollGroupUpdateInfo>;
+  export const onDidUpdateScrRef: PlatformEvent<ScrollGroupUpdateInfo>;
   /** See {@link IScrollGroupRemoteService.getScrRef} */
   export function getScrRefSync(scrollGroupId?: ScrollGroupId): SerializedVerseRef;
   /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1842,6 +1842,8 @@ declare module 'main/services/rpc-event-registry' {
       handler: unknown,
       eventName: string,
     ): 'ok' | 'unregistered' | 'foreign-single-source';
+    /** Whether any handler has centrally registered this event name. */
+    has(eventName: string): boolean;
     /** Remove a registrant. Returns `true` if the handler had registered this event. */
     tryUnregister(handler: unknown, eventName: string): boolean;
     /** Remove all event registrations for the given handler (e.g. when a websocket closes) */
@@ -2044,9 +2046,12 @@ declare module 'shared/services/network.service' {
    *   are not centrally registered and do not appear in the OpenRPC document. The async version
    *   restricts central _registration_ of an event name to a single source (unless the event is
    *   declared in {@link MultiSourceNetworkEvents}, in which case it accepts multiple registrants by
-   *   design). Note this restricts registration only — emission itself is not gated by the registry;
-   *   the central registry instead warns when an event is announced unregistered or from a process
-   *   that did not register it.
+   *   design). Note this restricts central _registration_, not emission: the registry does not block
+   *   emits today, but it warns when an event is announced without a matching registration or from a
+   *   process that did not register it. That tolerance is transitional — announcing an unregistered
+   *   or cross-process single-source event is deprecated and is expected to become an error (with the
+   *   registry gating emission) in a future release, so treat the warning as something to fix, not as
+   *   the permanent behavior.
    *
    *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
    *   emitters.
@@ -9769,7 +9774,10 @@ declare module '@papi/core' {
     MandatoryProjectDataTypes,
   } from 'shared/models/project-data-provider.model';
   export type { IProjectDataProviderEngine } from 'shared/models/project-data-provider-engine.model';
-  export type { IProjectDataProviderEngineFactory } from 'shared/models/project-data-provider-engine-factory.model';
+  export type {
+    IProjectDataProviderEngineFactory,
+    ProjectDataProviderEngineEnvelope,
+  } from 'shared/models/project-data-provider-engine-factory.model';
   export type {
     IProjectDataProviderFactory,
     ProjectMetadataFilterOptions,

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1683,10 +1683,10 @@ declare module 'main/services/rpc-websocket-listener' {
     /**
      * Try to register an event. Returns `true` if accepted, `false` if rejected.
      *
-     * - Name in `MULTI_SOURCE_EVENT_NAMES` (multi-source): multiple handlers may register; same
-     *   handler twice rejected.
-     * - Name not in `MULTI_SOURCE_EVENT_NAMES` (single-source): first registrant wins; any
-     *   subsequent registration from any handler is rejected.
+     * - Name in `MULTI_SOURCE_EVENT_NAMES` (multi-source): multiple handlers may register; same handler
+     *   twice rejected.
+     * - Name not in `MULTI_SOURCE_EVENT_NAMES` (single-source): first registrant wins; any subsequent
+     *   registration from any handler is rejected.
      */
     tryRegister(
       handler: unknown,
@@ -1855,8 +1855,8 @@ declare module 'shared/services/network.service' {
    *   network event (unless the event is declared in {@link MultiSourceNetworkEvents}, in which case
    *   it accepts multiple registrants by design).
    *
-   *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked
-   *   event emitters.
+   *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
+   *   emitters.
    * @param eventType Unique network event type for coordinating between connections
    * @returns Event emitter whose event works between connections
    */
@@ -4568,9 +4568,7 @@ declare module 'papi-shared-types' {
     'platform.onDidReloadExtensions': boolean;
     /** Emitted when the Scripture reference for a scroll group changes. */
     'scrollGroup:onDidUpdateScrRef': ScrollGroupUpdateInfo;
-    /**
-     * @deprecated 13 November 2024. Use {@link NetworkEvents.'webView:onDidOpenWebView'} instead.
-     */
+    /** @deprecated 13 November 2024. Use {@link NetworkEvents.'webView:onDidOpenWebView'} instead. */
     'webView:onDidAddWebView': OpenWebViewEvent;
     /** Emitted when a WebView is created. */
     'webView:onDidOpenWebView': OpenWebViewEvent;

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1222,13 +1222,6 @@ declare module 'shared/models/openrpc.model' {
   export function withExperimentalPrefix<T extends Method | Notification>(entry: T): T;
 }
 declare module 'shared/services/shared-store.service' {
-  /**
-   * Internal request type used by the shared store service to fetch the initial store contents during
-   * its own initialization. Exported so the network service's `doRequest` gate can identify this
-   * request and skip awaiting shared-store initialization on it (otherwise we'd deadlock: init awaits
-   * this request, the request awaits init).
-   */
-  export const STORE_GET_REQUEST = 'shared-store:get';
   type LamportClock = {
     counter: number;
     processId: string;
@@ -1236,6 +1229,7 @@ declare module 'shared/services/shared-store.service' {
   type StoreEntry = {
     value?: unknown;
     clock: LamportClock;
+    deleted?: boolean;
   };
   export type StoreChangeEvent = StoreEntry & {
     key: string;
@@ -1254,16 +1248,13 @@ declare module 'shared/services/shared-store.service' {
    *
    * - If {@link initialize} has already been called, returns the existing in-flight promise (no timeout
    *   — we wait as long as init takes).
-   * - If {@link initialize} has not been called yet, waits up to `startTimeoutMs` for it to start then
-   *   returns the resulting promise.
+   * - Otherwise waits for {@link initialize} to be called, then returns the resulting promise.
    *
-   * Throws if {@link initialize} never starts within `startTimeoutMs`. Callers that can tolerate the
-   * absence of a ready shared store should catch and fall back.
-   *
-   * @param startTimeoutMs Time to wait for initialize() to be called before throwing. Default 1000ms
-   *   — generous enough to cover normal bootstrap, short enough to avoid hanging requests when
-   *   initialize is never called.
-   * @throws If initialize() does not start within `startTimeoutMs`.
+   * @param startTimeoutMs Time to wait for initialize() to be called before throwing. A non-positive
+   *   value (the default, `0`) waits indefinitely. A positive value throws if initialize() is not
+   *   called within that many milliseconds. Callers that can tolerate the absence of a ready shared
+   *   store should pass a positive timeout and catch/fall back.
+   * @throws If `startTimeoutMs` is positive and initialize() is not called within that window.
    */
   export function waitForInitialization(startTimeoutMs?: number): Promise<void>;
   /**
@@ -1272,16 +1263,27 @@ declare module 'shared/services/shared-store.service' {
    */
   export function resetForTesting(): void;
   /**
-   * Get a value from the shared store with proper typing
+   * Get a value from the shared store with proper typing.
+   *
+   * This runs synchronously and does not wait for initialization: it may return `undefined` if the
+   * shared store service has not yet been populated (e.g. during the bootstrap window, before initial
+   * sync completes). Use {@link getAsync} if you need to wait for a populated value. Note that even
+   * after the store is populated, the returned value may not reflect the most up-to-date value, since
+   * changes from other processes arrive asynchronously.
    *
    * @param key The key of the value to retrieve
-   * @returns A cloned copy of the value associated with the key, or undefined if not found
+   * @returns A cloned copy of the value associated with the key, or `undefined` if not found, not yet
+   *   populated, or the value could not be cloned
    */
   function get<K extends SharedStoreKeys>(key: K): SharedStoreValues[K] | undefined;
   /**
    * Set a value in the shared store and notify other processes. Note that if a value with the given
    * key already exists, it can only be set again by the process that created it. This is to prevent
    * race conditions between processes setting values that don't incorporate each others' updates.
+   *
+   * This runs synchronously and throws if the shared store service has not started initializing (it
+   * must be able to broadcast the change). Use {@link setAsync} if you need to wait for initialization
+   * before setting.
    *
    * @param key The key to set
    * @param value The value to set. Note that the stored value is a cloned copy of the provided value,
@@ -1292,18 +1294,74 @@ declare module 'shared/services/shared-store.service' {
   /**
    * Remove a value from the shared store and notify other processes of the change.
    *
-   * Note that removing a key sets its value to undefined in the store. The key-value pair isn't
-   * actually deleted. This is done to avoid race conditions if a value for this key is set again
-   * quickly.
+   * After removal the key is treated as absent — reads return no value (a removed key is distinct
+   * from a key whose value is `undefined`). The entry and its Lamport clock are retained internally
+   * for conflict resolution (so the removal can win against concurrent sets and the key can be re-set
+   * quickly), but they are not exposed as a value.
+   *
+   * This runs synchronously and throws if the shared store service has not started initializing. Use
+   * {@link removeAsync} if you need to wait for initialization before removing.
    *
    * @param key The key to remove
    */
   function remove<K extends SharedStoreKeys>(key: K): void;
   /**
-   * Returns `true` once {@link initialize} has fully completed. Use this to gate optional reads of the
-   * shared store from code that may run during the bootstrap window — e.g., network-request timeout
-   * lookups that have a sensible default. Required reads of the shared store should `await
-   * initialize` instead so the value is guaranteed accurate per the Lamport-clock contract.
+   * Get a value from the shared store, waiting for the shared store service to be initialized first.
+   *
+   * Unlike {@link get}, this waits (via {@link waitForInitialization}) until the shared store service
+   * is initialized, then reads synchronously. A key with a live value returns that value — which may
+   * legitimately be `undefined`. A key that is absent or has been removed has no value: with no
+   * `defaultValue` argument this throws; with a `defaultValue` (which may itself be `undefined`) it
+   * returns that default.
+   *
+   * If the shared store service is already initialized, the awaited promise is already settled, so
+   * execution continues here on the next microtask without yielding to timers or other queued
+   * macrotasks — effectively synchronous from the caller's perspective. Note the returned value may
+   * not reflect the most up-to-date value, since changes from other processes arrive asynchronously.
+   *
+   * @param key The key of the value to retrieve
+   * @param defaultValue Returned when the key has no value. Omit to throw instead.
+   * @returns A cloned copy of the stored value, or `defaultValue` if the key has no value
+   * @throws If the key has no value and no `defaultValue` was provided
+   */
+  function getAsync<K extends SharedStoreKeys>(key: K): Promise<SharedStoreValues[K]>;
+  function getAsync<K extends SharedStoreKeys>(
+    key: K,
+    defaultValue: SharedStoreValues[K],
+  ): Promise<SharedStoreValues[K]>;
+  /**
+   * Set a value in the shared store, waiting for the shared store service to be initialized first.
+   *
+   * Unlike {@link set}, this waits (via {@link waitForInitialization}) until the shared store service
+   * has been initialized, then performs the set synchronously. See {@link set} for the per-key
+   * ownership and cloning semantics.
+   *
+   * If the shared store service is already initialized, the awaited promise is already settled, so
+   * execution continues here on the next microtask without yielding to timers or other queued
+   * macrotasks — effectively synchronous from the caller's perspective.
+   *
+   * @param key The key to set
+   * @param value The value to set
+   */
+  function setAsync<K extends SharedStoreKeys>(key: K, value?: SharedStoreValues[K]): Promise<void>;
+  /**
+   * Remove a value from the shared store, waiting for the shared store service to be initialized
+   * first.
+   *
+   * Unlike {@link remove}, this waits (via {@link waitForInitialization}) until the shared store
+   * service has been initialized, then performs the removal synchronously.
+   *
+   * If the shared store service is already initialized, the awaited promise is already settled, so
+   * execution continues here on the next microtask without yielding to timers or other queued
+   * macrotasks — effectively synchronous from the caller's perspective.
+   *
+   * @param key The key to remove
+   */
+  function removeAsync<K extends SharedStoreKeys>(key: K): Promise<void>;
+  /**
+   * Returns `true` once {@link initialize} has fully completed (process ID assigned, emitter ready,
+   * and — outside the main process — initial store data synced). Used to distinguish "value genuinely
+   * absent" from "shared store not initialized yet" for optional reads that have a sensible default.
    */
   function isInitialized(): boolean;
   /**
@@ -1338,6 +1396,9 @@ declare module 'shared/services/shared-store.service' {
     get: typeof get;
     set: typeof set;
     remove: typeof remove;
+    getAsync: typeof getAsync;
+    setAsync: typeof setAsync;
+    removeAsync: typeof removeAsync;
     isInitialized: typeof isInitialized;
   };
 }
@@ -1708,15 +1769,16 @@ declare module 'main/services/rpc-server' {
   export default RpcServer;
 }
 declare module 'shared/data/network-event-names' {
-  import type { MultiSourceNetworkEvents } from 'papi-shared-types';
   /**
    * Source of truth for which event names use multi-source semantics at the central registry. Must
-   * stay in sync with the `MultiSourceNetworkEvents` type alias in `papi-shared-types.ts` — the test
-   * `network.service.shared-events.test.ts` enforces the invariant.
+   * stay in sync with `MultiSourceNetworkEvents` (the public events) plus the platform-internal
+   * multi-source events — the test `network.service.shared-events.test.ts` checks the contents.
    *
-   * Add entries here when adding a new multi-source event to `MultiSourceNetworkEvents`.
+   * Add entries to {@link PUBLIC_MULTI_SOURCE_EVENT_NAMES} when adding a new public multi-source event
+   * to `MultiSourceNetworkEvents`, or to {@link INTERNAL_MULTI_SOURCE_EVENT_NAMES} for a new internal
+   * one.
    */
-  export const MULTI_SOURCE_EVENT_NAMES: Set<keyof MultiSourceNetworkEvents>;
+  export const MULTI_SOURCE_EVENT_NAMES: ReadonlySet<string>;
 }
 declare module 'main/services/rpc-event-registry' {
   import { SingleNotificationDocumentation } from 'shared/models/openrpc.model';
@@ -1744,6 +1806,22 @@ declare module 'main/services/rpc-event-registry' {
       eventName: string,
       documentation?: SingleNotificationDocumentation,
     ): boolean;
+    /**
+     * Classify an attempt to announce (emit) an event on the network against the registry. Used to
+     * warn about misuse without blocking the announcement.
+     *
+     * - `'ok'` — the announcement is valid: the event is multi-source (any process may announce it,
+     *   whether or not it registered), or it is single-source and announced by its registrant.
+     * - `'unregistered'` — the event is single-source and no process has registered this name
+     *   centrally. Emitting a single-source event that was never registered is deprecated (it does
+     *   not appear in the OpenRPC document).
+     * - `'foreign-single-source'` — the event is single-source but is being announced by a handler that
+     *   did not register it; only the registering process should emit a single-source event.
+     */
+    checkAnnouncement(
+      handler: unknown,
+      eventName: string,
+    ): 'ok' | 'unregistered' | 'foreign-single-source';
     /** Remove a registrant. Returns `true` if the handler had registered this event. */
     tryUnregister(handler: unknown, eventName: string): boolean;
     /** Remove all event registrations for the given handler (e.g. when a websocket closes) */
@@ -1790,6 +1868,17 @@ declare module 'main/services/rpc-websocket-listener' {
     private readonly rpcMethodDetailsByMethodName;
     private readonly localMethodsByMethodName;
     private readonly rpcEventDetailsByEventName;
+    /**
+     * Event names we've already warned about being announced while unregistered. Deduped so a
+     * high-frequency unregistered event does not flood the log — the deprecation notice only needs to
+     * be surfaced once per event name.
+     */
+    private readonly warnedUnregisteredAnnouncements;
+    /**
+     * Event names we've already warned about being announced from a process that did not register the
+     * single-source event. Deduped for the same reason as {@link warnedUnregisteredAnnouncements}.
+     */
+    private readonly warnedForeignAnnouncements;
     constructor();
     get nextSocketId(): string;
     connect(localEventHandler: EventHandler): Promise<boolean>;
@@ -1813,6 +1902,23 @@ declare module 'main/services/rpc-websocket-listener' {
     generateOpenRpcSchema(): OpenRpc;
     emitEventOnNetwork<T>(eventType: string, event: T): void;
     private propagateEvent;
+    /**
+     * Warn (once per event name) when an event is announced (emitted) on the network that the central
+     * registry would flag as misuse:
+     *
+     * - The event is single-source and was never registered centrally — emitting an unregistered event
+     *   is deprecated and the ability to do so will be removed in a future release.
+     * - The event is single-source but is being announced from a process that did not register it,
+     *   which is also deprecated.
+     *
+     * Announcements are never blocked; this only surfaces a warning to help authors migrate to
+     * `createNetworkEventEmitterAsync` or `createCoreMultiSourceEventEmitter` for core code.
+     *
+     * @param handler The handler announcing the event (an {@link RpcServer} for a client, or `this`
+     *   for main's own emissions).
+     * @param eventType The event name being announced.
+     */
+    private warnIfInvalidEventAnnouncement;
     private onClientConnect;
     private onClientDisconnect;
   }
@@ -1841,14 +1947,20 @@ declare module 'shared/services/network.service' {
    */
   import { InternalRequestHandler } from 'shared/data/rpc.model';
   import { PlatformEvent, PlatformEventEmitter, UnsubscriberAsync } from 'platform-bible-utils';
+  import { StoreChangeEvent } from 'shared/services/shared-store.service';
   import { SerializedRequestType } from 'shared/utils/util';
   import {
     SingleMethodDocumentation,
     SingleNotificationDocumentation,
   } from 'shared/models/openrpc.model';
   import { NetworkMethodHandlerOptions } from 'shared/models/network.model';
-  import type { NetworkEvents, NetworkEventTypes } from 'papi-shared-types';
-  export { MULTI_SOURCE_EVENT_NAMES } from 'shared/data/network-event-names';
+  import type {
+    MultiSourceNetworkEvents,
+    NetworkEvents,
+    NetworkEventTypes,
+  } from 'papi-shared-types';
+  import { MULTI_SOURCE_EVENT_NAMES } from 'shared/data/network-event-names';
+  export { MULTI_SOURCE_EVENT_NAMES };
   export function initialize(): Promise<void>;
   /** Closes the network services gracefully */
   export const shutdown: () => Promise<void>;
@@ -1944,6 +2056,51 @@ declare module 'shared/services/network.service' {
     eventType: EventType,
     documentation?: SingleNotificationDocumentation,
   ) => Promise<PlatformEventEmitter<NetworkEvents[EventType]>>;
+  /**
+   * Core-internal map of multi-source network events. Extends the public
+   * {@link MultiSourceNetworkEvents} with platform-internal multi-source events that are intentionally
+   * NOT advertised on the PAPI — the shared store change event, for example, because the shared store
+   * service is not part of the public API. Used to type {@link createCoreMultiSourceEventEmitter}.
+   */
+  export type InternalMultiSourceNetworkEvents = MultiSourceNetworkEvents & {
+    'shared-store:change': StoreChangeEvent;
+  };
+  /**
+   * Synchronously create a network event emitter for one of the pre-approved multi-source events —
+   * those listed in {@link MULTI_SOURCE_EVENT_NAMES}. Throws synchronously if `eventType` is not such
+   * an event.
+   *
+   * This is core-internal (not exposed on `papiNetworkService`, hence the `Core` in the name):
+   * multi-source events are platform events, not for extensions to create.
+   *
+   * Unlike {@link createNetworkEventEmitterAsync}, the emitter is returned immediately so callers can
+   * use it without awaiting. Central registration with the RPC handler is performed in the
+   * background; the returned `registeredEmitterPromise` resolves to the same emitter once
+   * registration completes. If registration fails, the promise logs a warning and rejects with the
+   * underlying error.
+   *
+   * Multi-source emitters are NOT unregistered on dispose (multiple emitters for the same name can
+   * coexist); the central registry cleans them up when the process disconnects. See
+   * {@link disposeNetworkEventEmitter}.
+   *
+   * @param eventType The name of the multi-source event to create. Must be a key of
+   *   {@link InternalMultiSourceNetworkEvents}.
+   * @param documentation Optional notification documentation. Carries
+   *   `notification['x-experimental']: true` to mark the event as experimental.
+   * @returns An object with the synchronously-created `emitter` and a `registeredEmitterPromise` that
+   *   resolves to that same emitter when central registration completes.
+   */
+  export const createCoreMultiSourceEventEmitter: <
+    EventType extends keyof InternalMultiSourceNetworkEvents,
+  >(
+    eventType: EventType,
+    documentation?: SingleNotificationDocumentation,
+  ) => {
+    emitter: PlatformEventEmitter<InternalMultiSourceNetworkEvents[EventType]>;
+    registeredEmitterPromise: Promise<
+      PlatformEventEmitter<InternalMultiSourceNetworkEvents[EventType]>
+    >;
+  };
   /**
    * Subscribe to a typed network event. The payload type is inferred from the event's declaration in
    * {@link NetworkEvents}.
@@ -3866,7 +4023,6 @@ declare module 'papi-shared-types' {
   } from 'shared/models/data-provider.interface';
   import type { ExtractDataProviderDataTypes } from 'shared/models/extract-data-provider-data-types.model';
   import type { NetworkableObject, NetworkObjectDetails } from 'shared/models/network-object.model';
-  import type { StoreChangeEvent } from 'shared/services/shared-store.service';
   import type { ScrollGroupUpdateInfo } from 'shared/services/scroll-group.service-model';
   import type {
     CloseWebViewEvent,
@@ -4600,11 +4756,6 @@ declare module 'papi-shared-types' {
      * ID.
      */
     'object:onDidDisposeNetworkObject': string;
-    /**
-     * Emitted when a value in the shared store changes. Payload includes the key and new value with
-     * Lamport timestamp.
-     */
-    'shared-store:change': StoreChangeEvent;
   };
   /**
    * Mapping of network event names to their payload types. Extensions augment this to declare their
@@ -9560,7 +9711,6 @@ declare module '@papi/core' {
     ScrollGroupUpdateInfo,
   } from 'shared/services/scroll-group.service-model';
   export type { SettingValidator } from 'shared/services/settings.service-model';
-  export type { StoreChangeEvent } from 'shared/services/shared-store.service';
   export type {
     FocusSubject,
     SetFocusSubject,

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -2083,6 +2083,64 @@ declare module 'shared/services/network.service' {
     documentation?: SingleNotificationDocumentation,
   ) => Promise<PlatformEventEmitter<NetworkEvents[EventType]>>;
   /**
+   * How to buffer emits made before a buffered network event finishes registering.
+   *
+   * - `'queue'` — keep every buffered event and flush them in emit order.
+   * - `{ latestByKey }` — keep only the most recent buffered event per key, flushed in first-seen key
+   *   order. Use for "only the latest matters" events (e.g. a scroll reference per scroll group, or a
+   *   web view update per web view id).
+   */
+  export type NetworkEventBufferStrategy<T> =
+    | 'queue'
+    | {
+        latestByKey: (event: T) => string;
+      };
+  /**
+   * Buffers network events emitted before their emitter is ready, per a
+   * {@link NetworkEventBufferStrategy}. Exported only for unit testing.
+   *
+   * @internal
+   */
+  export class NetworkEventBuffer<T> {
+    private readonly strategy;
+    private readonly queued;
+    private readonly latest;
+    constructor(strategy: NetworkEventBufferStrategy<T>);
+    add(event: T): void;
+    /** Returns the buffered events in flush order and empties the buffer. */
+    drain(): T[];
+    clear(): void;
+  }
+  /**
+   * Synchronously create a buffered emitter for a single-source network event. Use this for events
+   * that may be emitted before the network emitter finishes registering — e.g. from a UI handler or a
+   * command that can fire during extension activation, where the eager
+   * {@link createNetworkEventEmitterAsync} would leave a module-level emitter `undefined`.
+   *
+   * The returned `emit` is usable immediately. Emits made before central registration completes are
+   * buffered per `options.bufferStrategy` and flushed once registration succeeds; after that `emit`
+   * passes straight through. If registration fails, buffered events are dropped (with a warning) and
+   * `registeredEmitter` rejects so the caller can respond.
+   *
+   * @param eventType A key of {@link NetworkEvents}.
+   * @param documentation Optional notification documentation. Carries
+   *   `notification['x-experimental']: true` to mark the event as experimental.
+   * @param options.bufferStrategy How to buffer pre-registration emits. Defaults to `'queue'`.
+   * @returns `emit` (usable immediately), `registeredEmitter` (resolves to the underlying emitter, or
+   *   rejects if registration failed), and `dispose`.
+   */
+  export const createBufferedNetworkEventEmitter: <EventType extends NetworkEventTypes>(
+    eventType: EventType,
+    documentation?: SingleNotificationDocumentation,
+    options?: {
+      bufferStrategy?: NetworkEventBufferStrategy<NetworkEvents[EventType]>;
+    },
+  ) => {
+    emit: (event: NetworkEvents[EventType]) => void;
+    registeredEmitter: Promise<PlatformEventEmitter<NetworkEvents[EventType]>>;
+    dispose: () => void;
+  };
+  /**
    * Core-internal map of multi-source network events. Extends the public
    * {@link MultiSourceNetworkEvents} with platform-internal multi-source events that are intentionally
    * NOT advertised on the PAPI — the shared store change event, for example, because the shared store
@@ -2149,6 +2207,7 @@ declare module 'shared/services/network.service' {
   export interface PapiNetworkService {
     createNetworkEventEmitter: typeof createNetworkEventEmitter;
     createNetworkEventEmitterAsync: typeof createNetworkEventEmitterAsync;
+    createBufferedNetworkEventEmitter: typeof createBufferedNetworkEventEmitter;
     getNetworkEvent: typeof getNetworkEvent;
   }
   /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -999,6 +999,13 @@ declare module 'shared/data/rpc.model' {
   export const CATEGORY_COMMAND = 'command';
 }
 declare module 'shared/services/shared-store.service' {
+  /**
+   * Internal request type used by the shared store service to fetch the initial store contents during
+   * its own initialization. Exported so the network service's `doRequest` gate can identify this
+   * request and skip awaiting shared-store initialization on it (otherwise we'd deadlock: init awaits
+   * this request, the request awaits init).
+   */
+  export const STORE_GET_REQUEST = 'shared-store:get';
   type LamportClock = {
     counter: number;
     processId: string;
@@ -1012,13 +1019,30 @@ declare module 'shared/services/shared-store.service' {
   };
   type NetworkService = typeof import('shared/services/network.service');
   /**
-   * Initialize the shared store service, setting up request handlers and event listeners. This
-   * function should be called by each of our JS processes early during start up.
+   * Initialize the shared store service, setting up request handlers and event listeners. Idempotent:
+   * subsequent calls return the same promise as the first call.
    *
-   * @param networkService The network service to use for communication between processes
+   * @param networkService The network service module.
    * @returns A promise that resolves when the service is initialized
    */
   export function initialize(networkService: NetworkService): Promise<void>;
+  /**
+   * Wait for the shared store service to be ready.
+   *
+   * - If {@link initialize} has already been called, returns the existing in-flight promise (no timeout
+   *   — we wait as long as init takes).
+   * - If {@link initialize} has not been called yet, waits up to `startTimeoutMs` for it to start then
+   *   returns the resulting promise.
+   *
+   * Throws if {@link initialize} never starts within `startTimeoutMs`. Callers that can tolerate the
+   * absence of a ready shared store should catch and fall back.
+   *
+   * @param startTimeoutMs Time to wait for initialize() to be called before throwing. Default 1000ms
+   *   — generous enough to cover normal bootstrap, short enough to avoid hanging requests when
+   *   initialize is never called.
+   * @throws If initialize() does not start within `startTimeoutMs`.
+   */
+  export function waitForInitialization(startTimeoutMs?: number): Promise<void>;
   /**
    * Reset the shared store service state for testing. This function is only exported for testing
    * purposes and should not be used in production code.
@@ -1053,6 +1077,13 @@ declare module 'shared/services/shared-store.service' {
    */
   function remove<K extends SharedStoreKeys>(key: K): void;
   /**
+   * Returns `true` once {@link initialize} has fully completed. Use this to gate optional reads of the
+   * shared store from code that may run during the bootstrap window — e.g., network-request timeout
+   * lookups that have a sensible default. Required reads of the shared store should `await
+   * initialize` instead so the value is guaranteed accurate per the Lamport-clock contract.
+   */
+  function isInitialized(): boolean;
+  /**
    * Keys for timeout lengths for network requests. Keys are dynamically constructed by adding this
    * prefix to the `requestType`.
    */
@@ -1084,6 +1115,7 @@ declare module 'shared/services/shared-store.service' {
     get: typeof get;
     set: typeof set;
     remove: typeof remove;
+    isInitialized: typeof isInitialized;
   };
 }
 declare module 'shared/models/papi-network-event-emitter.model' {
@@ -1657,18 +1689,19 @@ declare module 'main/services/rpc-server' {
   }
   export default RpcServer;
 }
-declare module 'main/services/rpc-websocket-listener' {
-  import {
-    ConnectionStatus,
-    EventHandler,
-    InternalRequestHandler,
-    RequestParams,
-  } from 'shared/data/rpc.model';
-  import { IRpcMethodRegistrar } from 'shared/models/rpc.interface';
+declare module 'shared/data/network-event-names' {
+  import type { MultiSourceNetworkEvents } from 'papi-shared-types';
+  /**
+   * Source of truth for which event names use multi-source semantics at the central registry. Must
+   * stay in sync with the `MultiSourceNetworkEvents` type alias in `papi-shared-types.ts` — the test
+   * `network.service.shared-events.test.ts` enforces the invariant.
+   *
+   * Add entries here when adding a new multi-source event to `MultiSourceNetworkEvents`.
+   */
+  export const MULTI_SOURCE_EVENT_NAMES: Set<keyof MultiSourceNetworkEvents>;
+}
+declare module 'main/services/rpc-event-registry' {
   import { SingleNotificationDocumentation } from 'shared/models/openrpc.model';
-  import { JSONRPCResponse } from 'json-rpc-2.0';
-  import { SerializedRequestType } from 'shared/utils/util';
-  import { OpenRpc, SingleMethodDocumentation } from 'shared/models/openrpc.model';
   interface EventRegistrant {
     handler: unknown;
     documentation?: SingleNotificationDocumentation;
@@ -1699,6 +1732,25 @@ declare module 'main/services/rpc-websocket-listener' {
     unregisterAll(handler: unknown): void;
     entries(): IterableIterator<[string, EventRegistrant[]]>;
   }
+  export default RpcEventRegistry;
+}
+declare module 'main/services/rpc-websocket-listener' {
+  import {
+    ConnectionStatus,
+    EventHandler,
+    InternalRequestHandler,
+    RequestParams,
+  } from 'shared/data/rpc.model';
+  import { IRpcMethodRegistrar } from 'shared/models/rpc.interface';
+  import {
+    OpenRpc,
+    SingleMethodDocumentation,
+    SingleNotificationDocumentation,
+  } from 'shared/models/openrpc.model';
+  import { JSONRPCResponse } from 'json-rpc-2.0';
+  import { SerializedRequestType } from 'shared/utils/util';
+  import { RpcEventRegistry } from 'main/services/rpc-event-registry';
+  export { RpcEventRegistry };
   /**
    * Owns the WebSocketServer that listens for clients to connect to the web socket. When a client
    * connects, an RpcServer is created in this same process to service that connection.
@@ -1777,19 +1829,8 @@ declare module 'shared/services/network.service' {
     SingleNotificationDocumentation,
   } from 'shared/models/openrpc.model';
   import { NetworkMethodHandlerOptions } from 'shared/models/network.model';
-  import type {
-    MultiSourceNetworkEvents,
-    NetworkEvents,
-    NetworkEventTypes,
-  } from 'papi-shared-types';
-  /**
-   * Source of truth for which event names use multi-source semantics at the central registry. Must
-   * stay in sync with the `MultiSourceNetworkEvents` type alias in `papi-shared-types.ts` — the test
-   * `network.service.shared-events.test.ts` enforces the invariant.
-   *
-   * Add entries here when adding a new multi-source event to `MultiSourceNetworkEvents`.
-   */
-  export const MULTI_SOURCE_EVENT_NAMES: Set<keyof MultiSourceNetworkEvents>;
+  import type { NetworkEvents, NetworkEventTypes } from 'papi-shared-types';
+  export { MULTI_SOURCE_EVENT_NAMES } from 'shared/data/network-event-names';
   export function initialize(): Promise<void>;
   /** Closes the network services gracefully */
   export const shutdown: () => Promise<void>;
@@ -4958,7 +4999,7 @@ declare module 'shared/services/data-provider.service' {
           [property: string]: unknown;
         }
       | undefined,
-    documentation?: NetworkObjectDocumentation,
+    documentation?: NetworkObjectDocumentation | undefined,
   ): Promise<DisposableDataProviders[DataProviderName]>;
   /**
    * Creates a data provider to be shared on the network layering over the provided data provider
@@ -4995,7 +5036,7 @@ declare module 'shared/services/data-provider.service' {
           [property: string]: unknown;
         }
       | undefined,
-    documentation?: NetworkObjectDocumentation,
+    documentation?: NetworkObjectDocumentation | undefined,
   ): Promise<IDisposableDataProvider<IDataProvider<TDataTypes>>>;
   /**
    *

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5728,6 +5728,36 @@ declare module 'shared/models/project-data-provider-engine-factory.model' {
   import type { NetworkObjectDocumentation } from 'shared/models/openrpc.model';
   import { ProjectInterfaces } from 'papi-shared-types';
   /**
+   * Envelope that {@link IProjectDataProviderEngineFactory.createProjectDataProviderEngine} may return
+   * instead of the engine directly, carrying per-PDP network object metadata alongside the engine.
+   *
+   * WARNING: `projectDataProviderEngine` is a reserved discriminating property — do not expose a
+   * property by that name on a raw engine, or the platform will treat the engine as an envelope.
+   */
+  export interface ProjectDataProviderEngineEnvelope<
+    SupportedProjectInterfaces extends ProjectInterfaces[],
+  > {
+    projectDataProviderEngine: IProjectDataProviderEngine<SupportedProjectInterfaces>;
+    attributes?: {
+      [property: string]: unknown;
+    };
+    documentation?: NetworkObjectDocumentation;
+  }
+  /**
+   * Type guard: whether a `createProjectDataProviderEngine` return value is a
+   * {@link ProjectDataProviderEngineEnvelope} rather than a raw engine. Guards against
+   * `typeof null === 'object'` and against a raw engine that merely exposes a
+   * `projectDataProviderEngine` property of a non-object type. Written as a user-defined type guard so
+   * the value check doesn't defeat the narrowing at call sites.
+   */
+  export function isProjectDataProviderEngineEnvelope<
+    SupportedProjectInterfaces extends ProjectInterfaces[],
+  >(
+    value:
+      | IProjectDataProviderEngine<SupportedProjectInterfaces>
+      | ProjectDataProviderEngineEnvelope<SupportedProjectInterfaces>,
+  ): value is ProjectDataProviderEngineEnvelope<SupportedProjectInterfaces>;
+  /**
    * A factory object registered with the papi that creates a Project Data Provider Engine for each
    * project with the factory's specified `projectInterface`s when the papi requests. Used by the papi
    * to create {@link IProjectDataProviderEngine}s for a specific project and `projectInterface` when
@@ -5800,15 +5830,11 @@ declare module 'shared/models/project-data-provider-engine-factory.model' {
      * @returns Either the {@link IProjectDataProviderEngine} or an envelope containing the engine and
      *   per-PDP network object metadata (attributes and documentation).
      */
-    createProjectDataProviderEngine(projectId: string): Promise<
+    createProjectDataProviderEngine(
+      projectId: string,
+    ): Promise<
       | IProjectDataProviderEngine<SupportedProjectInterfaces>
-      | {
-          projectDataProviderEngine: IProjectDataProviderEngine<SupportedProjectInterfaces>;
-          attributes?: {
-            [property: string]: unknown;
-          };
-          documentation?: NetworkObjectDocumentation;
-        }
+      | ProjectDataProviderEngineEnvelope<SupportedProjectInterfaces>
     >;
   }
   /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -7756,7 +7756,7 @@ declare module 'shared/services/settings.service' {
 declare module 'renderer/services/scroll-group.service-host' {
   import { ScrollGroupUpdateInfo } from 'shared/services/scroll-group.service-model';
   import { SerializedVerseRef } from '@sillsdev/scripture';
-  import { type PlatformEvent, ScrollGroupId } from 'platform-bible-utils';
+  import { ScrollGroupId } from 'platform-bible-utils';
   /**
    * All Scroll Group IDs that are intended to be shown in scroll group selectors. This is a
    * placeholder and will be refactored significantly in
@@ -7764,7 +7764,7 @@ declare module 'renderer/services/scroll-group.service-host' {
    */
   export const availableScrollGroupIds: (number | undefined)[];
   /** Event that emits with information about a changed Scripture Reference for a scroll group */
-  export const onDidUpdateScrRef: PlatformEvent<ScrollGroupUpdateInfo>;
+  export const onDidUpdateScrRef: import('platform-bible-utils').PlatformEvent<ScrollGroupUpdateInfo>;
   /** See {@link IScrollGroupRemoteService.getScrRef} */
   export function getScrRefSync(scrollGroupId?: ScrollGroupId): SerializedVerseRef;
   /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1281,7 +1281,10 @@ declare module 'shared/models/openrpc.model' {
     externalDocs?: ExternalDocumentation;
   };
   export type MethodDocumentationWithoutName = Omit<Method, 'name'>;
-  /** Documentation about a single method */
+  /**
+   * Documentation about a single method. Set `method['x-experimental']: true` to mark this method as
+   * experimental. Informational only; appears in the generated OpenRPC document.
+   */
   export type SingleMethodDocumentation = {
     method: MethodDocumentationWithoutName;
     components?: Components;
@@ -1290,9 +1293,15 @@ declare module 'shared/models/openrpc.model' {
    * An OpenRPC notification — same shape as a {@link Method}, but without `result`. Used for events /
    * one-way messages from server to client. Per the OpenRPC convention (no `result` ⇒ notification),
    * these are serialized into the same root `methods` array as Methods on the wire.
+   *
+   * Set `'x-experimental': true` on the notification object to mark it as experimental. Informational
+   * only; appears in the generated OpenRPC document.
    */
   export type OpenRpcNotification = Omit<Method, 'result'>;
-  /** Documentation about a single notification */
+  /**
+   * Documentation about a single notification. Set `notification['x-experimental']: true` to mark
+   * this notification as experimental. Informational only; appears in the generated OpenRPC document.
+   */
   export type SingleNotificationDocumentation = {
     notification: Omit<OpenRpcNotification, 'name'>;
     components?: Components;

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -1006,8 +1006,12 @@ declare module 'shared/models/openrpc.model' {
    * See https://github.com/open-rpc/meta-schema/releases - Release 1.14.2 aligns with OpenRPC 1.2.6.
    * https://github.com/open-rpc/meta-schema/releases/download/1.14.2/open-rpc-meta-schema.json
    *
-   * We don't want to go past 1.2.6 because https://playground.open-rpc.org/ doesn't support anything
-   * past 1.2.6 for now. See https://github.com/open-rpc/playground/issues/606.
+   * We declare OpenRPC `1.3.0` because notifications (a method with no `result`) were introduced in
+   * 1.3.0 — `result` was required in 1.2.6, so a document with notifications is invalid under the
+   * 1.2.6 meta-schema. The OpenRPC playground (https://playground.open-rpc.org/) is still capped at
+   * 1.2.6 (https://github.com/open-rpc/playground/issues/606), but it renders a 1.3.0 document fine
+   * in practice; it just lists notifications under the same "Methods" heading, which we mitigate by
+   * prefixing notification summaries with {@link NOTIFICATION_OPENRPC_PREFIX}.
    *
    * Note that the types from https://www.npmjs.com/package/@open-rpc/meta-schema/v/1.14.2 are not
    * very good. For example, all the properties of `Components` are of type `any` instead of the
@@ -1018,7 +1022,7 @@ declare module 'shared/models/openrpc.model' {
     openrpc: string;
     info: Info;
     servers?: Server[];
-    methods: (Method | Notification)[];
+    methods: (Method | OpenRpcNotification)[];
     components?: Components;
     externalDocs?: ExternalDocumentation;
   };
@@ -1168,16 +1172,20 @@ declare module 'shared/models/openrpc.model' {
    *
    * Set `'x-experimental': true` on the notification object to mark it as experimental. Informational
    * only; appears in the generated OpenRPC document.
+   *
+   * Named `OpenRpcNotification` (rather than `Notification`) to avoid shadowing the DOM global
+   * `Notification` type — a file that forgot to import this would otherwise silently typecheck
+   * against the wrong type.
    */
-  export type Notification = Omit<Method, 'result'>;
+  export type OpenRpcNotification = Omit<Method, 'result'>;
   /**
-   * Documentation about a single {@link Notification}.
+   * Documentation about a single {@link OpenRpcNotification}.
    *
    * Set `notification['x-experimental']: true` to mark this notification as experimental.
    * Informational only; appears in the generated OpenRPC document.
    */
   export type SingleNotificationDocumentation = {
-    notification: Omit<Notification, 'name'>;
+    notification: Omit<OpenRpcNotification, 'name'>;
     components?: Components;
   };
   /**
@@ -1204,22 +1212,38 @@ declare module 'shared/models/openrpc.model' {
    */
   export function getEmptyMethodDocs(): MethodDocumentationWithoutName;
   /**
-   * Get an empty {@link Notification} documentation object. Useful for surfacing events that didn't
-   * have their own documentation provided so that every registered event still appears in the OpenRPC
-   * document (mirroring how undocumented methods are surfaced via {@link getEmptyMethodDocs}).
+   * Get an empty {@link OpenRpcNotification} documentation object. Useful for surfacing events that
+   * didn't have their own documentation provided so that every registered event still appears in the
+   * OpenRPC document (mirroring how undocumented methods are surfaced via
+   * {@link getEmptyMethodDocs}).
    */
   export function getEmptyNotificationDocs(): Omit<MethodDocumentationWithoutName, 'result'>;
   /** Prefix prepended to the `summary` and `description` of experimental methods and notifications. */
   export const EXPERIMENTAL_OPENRPC_PREFIX = '[EXPERIMENTAL] ';
   /**
-   * Returns a shallow copy of an OpenRPC {@link Method} or {@link Notification} with
+   * Returns a shallow copy of an OpenRPC {@link Method} or {@link OpenRpcNotification} with
    * {@link EXPERIMENTAL_OPENRPC_PREFIX} prepended to its `summary` and `description` when the entry is
    * marked `'x-experimental'`. Both fields are always set on an experimental entry — even a missing
    * or empty summary/description becomes the bare prefix so the marker is never lost. Idempotent: an
    * entry already starting with the prefix is left unchanged. Returns the entry untouched when it is
    * not experimental.
    */
-  export function withExperimentalPrefix<T extends Method | Notification>(entry: T): T;
+  export function withExperimentalPrefix<T extends Method | OpenRpcNotification>(entry: T): T;
+  /**
+   * Prefix prepended to a notification's `summary`. OpenRPC carries notifications in the same root
+   * `methods` array as methods, so tooling that lists both together (e.g. the OpenRPC playground)
+   * shows them under one "Methods" heading. This prefix makes notifications distinguishable at a
+   * glance, the same way {@link EXPERIMENTAL_OPENRPC_PREFIX} marks experimental entries.
+   */
+  export const NOTIFICATION_OPENRPC_PREFIX = '(Notification) ';
+  /**
+   * Returns a shallow copy of an OpenRPC {@link OpenRpcNotification} with
+   * {@link NOTIFICATION_OPENRPC_PREFIX} prepended to its `summary` so it is distinguishable from
+   * methods in tooling that lists both together. Applied to every notification (unlike the
+   * experimental prefix). Idempotent: an entry whose summary already starts with the prefix is left
+   * unchanged.
+   */
+  export function withNotificationPrefix(entry: OpenRpcNotification): OpenRpcNotification;
 }
 declare module 'shared/services/shared-store.service' {
   type LamportClock = {
@@ -2022,9 +2046,11 @@ declare module 'shared/services/network.service' {
    *
    * @deprecated 8 June 2026. Use `createNetworkEventEmitterAsync`. Events created via the sync API
    *   are not centrally registered and do not appear in the OpenRPC document. The async version
-   *   properly restricts event registration to prevent multiple sources from emitting the same
-   *   network event (unless the event is declared in {@link MultiSourceNetworkEvents}, in which case
-   *   it accepts multiple registrants by design).
+   *   restricts central _registration_ of an event name to a single source (unless the event is
+   *   declared in {@link MultiSourceNetworkEvents}, in which case it accepts multiple registrants by
+   *   design). Note this restricts registration only — emission itself is not gated by the registry;
+   *   the central registry instead warns when an event is announced unregistered or from a process
+   *   that did not register it.
    *
    *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
    *   emitters.
@@ -4772,15 +4798,15 @@ declare module 'papi-shared-types' {
    * }
    * ```
    *
-   * Mark a single event as experimental by adding `\/** @experimental *\/` directly above its
-   * entry.
+   * Mark a single event as experimental by adding an `@experimental` JSDoc tag in a doc comment
+   * directly above its entry.
    */
   interface NetworkEvents extends MultiSourceNetworkEvents {
     /** Emitted when extensions finish reloading. `true` if reload succeeded, `false` if it failed. */
     'platform.onDidReloadExtensions': boolean;
     /** Emitted when the Scripture reference for a scroll group changes. */
     'scrollGroup:onDidUpdateScrRef': ScrollGroupUpdateInfo;
-    /** @deprecated 13 November 2024. Use {@link NetworkEvents.'webView:onDidOpenWebView'} instead. */
+    /** @deprecated 13 November 2024. Use the `webView:onDidOpenWebView` event instead. */
     'webView:onDidAddWebView': OpenWebViewEvent;
     /** Emitted when a WebView is created. */
     'webView:onDidOpenWebView': OpenWebViewEvent;

--- a/lib/platform-bible-utils/src/extension-contributions/__tests__/menus.model.test.ts
+++ b/lib/platform-bible-utils/src/extension-contributions/__tests__/menus.model.test.ts
@@ -28,19 +28,57 @@ describe('menus.model — isExperimental field', () => {
     expect(m.isExperimental).toBe(true);
   });
 
+  // Builds a minimal valid menu document, optionally overriding the `mainMenu`.
+  const makeDoc = (mainMenu: object) => ({
+    mainMenu,
+    defaultWebViewTopMenu: { columns: {}, groups: {}, items: [] },
+    defaultWebViewContextMenu: { groups: {}, items: [] },
+    webViewMenus: {},
+  });
+
+  const compileValidator = () => new Ajv2019({ allErrors: true }).compile(menuDocumentSchema);
+
   it('JSON schema accepts isExperimental on column entries', () => {
-    const ajv = new Ajv2019({ allErrors: true });
-    const validate = ajv.compile(menuDocumentSchema);
+    const validate = compileValidator();
+    const doc = makeDoc({
+      columns: { 'a.b': { label: '%x%', order: 1, isExtensible: true, isExperimental: true } },
+      groups: {},
+      items: [],
+    });
+    expect(validate(doc)).toBe(true);
+  });
+
+  it('JSON schema accepts isExperimental at the columns-collection level', () => {
+    const validate = compileValidator();
+    const doc = makeDoc({ columns: { isExperimental: true }, groups: {}, items: [] });
+    expect(validate(doc)).toBe(true);
+  });
+
+  it('JSON schema rejects a non-boolean isExperimental', () => {
+    const validate = compileValidator();
+    const doc = makeDoc({
+      columns: { 'a.b': { label: '%x%', order: 1, isExperimental: 'true' } },
+      groups: {},
+      items: [],
+    });
+    expect(validate(doc)).toBe(false);
+  });
+
+  it('JSON schema rejects a typo at the columns-collection level (additionalProperties: false)', () => {
+    const validate = compileValidator();
+    // `isExperimentl` is neither a column key (no dot) nor a known property.
+    const doc = makeDoc({ columns: { isExperimentl: true }, groups: {}, items: [] });
+    expect(validate(doc)).toBe(false);
+  });
+
+  it('JSON schema rejects a typo on a webViewMenus entry (additionalProperties: false)', () => {
+    const validate = compileValidator();
     const doc = {
-      mainMenu: {
-        columns: { 'a.b': { label: '%x%', order: 1, isExtensible: true, isExperimental: true } },
-        groups: {},
-        items: [],
-      },
+      mainMenu: { columns: {}, groups: {}, items: [] },
       defaultWebViewTopMenu: { columns: {}, groups: {}, items: [] },
       defaultWebViewContextMenu: { groups: {}, items: [] },
-      webViewMenus: {},
+      webViewMenus: { 'a.b': { isExperimentl: true } },
     };
-    expect(validate(doc)).toBe(true);
+    expect(validate(doc)).toBe(false);
   });
 });

--- a/lib/platform-bible-utils/src/extension-contributions/__tests__/menus.model.test.ts
+++ b/lib/platform-bible-utils/src/extension-contributions/__tests__/menus.model.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import Ajv2019 from 'ajv/dist/2019';
+import {
+  menuDocumentSchema,
+  type ColumnsWithHeaders,
+  type WebViewMenu,
+  type OrderedExtensibleContainer,
+} from '../menus.model';
+
+describe('menus.model — isExperimental field', () => {
+  it('OrderedExtensibleContainer permits isExperimental', () => {
+    const c: OrderedExtensibleContainer = { order: 1, isExtensible: true, isExperimental: true };
+    expect(c.isExperimental).toBe(true);
+  });
+
+  it('ColumnsWithHeaders permits isExperimental at the columns-collection level', () => {
+    const c: ColumnsWithHeaders = { isExtensible: true, isExperimental: true };
+    expect(c.isExperimental).toBe(true);
+  });
+
+  it('WebViewMenu permits isExperimental', () => {
+    const m: WebViewMenu = {
+      includeDefaults: undefined,
+      topMenu: undefined,
+      contextMenu: undefined,
+      isExperimental: true,
+    };
+    expect(m.isExperimental).toBe(true);
+  });
+
+  it('JSON schema accepts isExperimental on column entries', () => {
+    const ajv = new Ajv2019({ allErrors: true });
+    const validate = ajv.compile(menuDocumentSchema);
+    const doc = {
+      mainMenu: {
+        columns: { 'a.b': { label: '%x%', order: 1, isExtensible: true, isExperimental: true } },
+        groups: {},
+        items: [],
+      },
+      defaultWebViewTopMenu: { columns: {}, groups: {}, items: [] },
+      defaultWebViewContextMenu: { groups: {}, items: [] },
+      webViewMenus: {},
+    };
+    expect(validate(doc)).toBe(true);
+  });
+});

--- a/lib/platform-bible-utils/src/extension-contributions/menus.model.ts
+++ b/lib/platform-bible-utils/src/extension-contributions/menus.model.ts
@@ -19,6 +19,11 @@ export type OrderedItem = {
 export type OrderedExtensibleContainer = OrderedItem & {
   /** Determines whether other items can be added to this after it has been defined */
   isExtensible?: boolean;
+  /**
+   * Set to `true` to mark this extension point as experimental. Extensions reading menu data should
+   * check this before contributing to the point. Informational only.
+   */
+  isExperimental?: boolean;
 };
 
 /** Group of menu items that belongs in a column */
@@ -98,6 +103,11 @@ export type ColumnsWithHeaders = {
   [property: ReferencedItem]: MenuColumnWithHeader;
   /** Defines whether columns can be added to this multi-column menu */
   isExtensible?: boolean;
+  /**
+   * Set to `true` to mark the entire columns-collection as an experimental extension point.
+   * Informational only.
+   */
+  isExperimental?: boolean;
 };
 
 /** Menu that contains a column without a header */
@@ -126,6 +136,10 @@ export type WebViewMenu = {
   topMenu: MultiColumnMenu | undefined;
   /** Menu that opens when you right click on the main body/area of a tab */
   contextMenu: SingleColumnMenu | undefined;
+  /**
+   * Set to `true` to mark this entire WebView menu shape as experimental. Informational only.
+   */
+  isExperimental?: boolean;
 };
 
 /** Menus for all web views */
@@ -226,6 +240,10 @@ export const menuDocumentSchema = {
                 'Defines whether contributions are allowed to add menu groups to this column',
               type: 'boolean',
             },
+            isExperimental: {
+              description: 'Marks this extension point as experimental. Informational only.',
+              type: 'boolean',
+            },
           },
           required: ['label', 'order'],
           additionalProperties: false,
@@ -235,6 +253,11 @@ export const menuDocumentSchema = {
         isExtensible: {
           description:
             'Defines whether contributions are allowed to add columns to this multi-column menu',
+          type: 'boolean',
+        },
+        isExperimental: {
+          description:
+            'Marks the entire columns-collection as an experimental extension point. Informational only.',
           type: 'boolean',
         },
       },
@@ -265,6 +288,10 @@ export const menuDocumentSchema = {
                     'Defines whether contributions are allowed to add menu items to this menu group',
                   type: 'boolean',
                 },
+                isExperimental: {
+                  description: 'Marks this extension point as experimental. Informational only.',
+                  type: 'boolean',
+                },
               },
               required: ['order'],
               additionalProperties: false,
@@ -283,6 +310,10 @@ export const menuDocumentSchema = {
                 isExtensible: {
                   description:
                     'Defines whether contributions are allowed to add menu items to this menu group',
+                  type: 'boolean',
+                },
+                isExperimental: {
+                  description: 'Marks this extension point as experimental. Informational only.',
                   type: 'boolean',
                 },
               },
@@ -417,6 +448,10 @@ export const menuDocumentSchema = {
         contextMenu: {
           description: 'Menu that opens when you right click on the main body/area of a tab',
           $ref: '#/$defs/singleColumnMenu',
+        },
+        isExperimental: {
+          description: 'Marks this WebView menu as experimental. Informational only.',
+          type: 'boolean',
         },
       },
       additionalProperties: false,

--- a/lib/platform-bible-utils/src/extension-contributions/menus.model.ts
+++ b/lib/platform-bible-utils/src/extension-contributions/menus.model.ts
@@ -266,6 +266,9 @@ export const menuDocumentSchema = {
           type: 'boolean',
         },
       },
+      // Reject unknown keys at the collection level (e.g. a typo'd `isExperimentl`). Column entries
+      // are still allowed via `patternProperties` above.
+      additionalProperties: false,
     },
     menuGroups: {
       description:

--- a/lib/platform-bible-utils/src/extension-contributions/menus.model.ts
+++ b/lib/platform-bible-utils/src/extension-contributions/menus.model.ts
@@ -20,8 +20,9 @@ export type OrderedExtensibleContainer = OrderedItem & {
   /** Determines whether other items can be added to this after it has been defined */
   isExtensible?: boolean;
   /**
-   * Set to `true` to mark this extension point as experimental. Extensions reading menu data should
-   * check this before contributing to the point. Informational only.
+   * Set to `true` to mark this extension point as experimental. Experimental menu content may
+   * change or be removed without notice. Extensions reading this should treat the marker as
+   * informational.
    */
   isExperimental?: boolean;
 };
@@ -104,8 +105,9 @@ export type ColumnsWithHeaders = {
   /** Defines whether columns can be added to this multi-column menu */
   isExtensible?: boolean;
   /**
-   * Set to `true` to mark the entire columns-collection as an experimental extension point.
-   * Informational only.
+   * Set to `true` to mark this columns collection as experimental. Experimental menu content may
+   * change or be removed without notice. Extensions reading this should treat the marker as
+   * informational.
    */
   isExperimental?: boolean;
 };
@@ -137,7 +139,8 @@ export type WebViewMenu = {
   /** Menu that opens when you right click on the main body/area of a tab */
   contextMenu: SingleColumnMenu | undefined;
   /**
-   * Set to `true` to mark this entire WebView menu shape as experimental. Informational only.
+   * Set to `true` to mark this WebView menu as experimental. Experimental menu content may change
+   * or be removed without notice. Extensions reading this should treat the marker as informational.
    */
   isExperimental?: boolean;
 };

--- a/lib/platform-bible-utils/src/extension-contributions/menus.model.ts
+++ b/lib/platform-bible-utils/src/extension-contributions/menus.model.ts
@@ -244,7 +244,8 @@ export const menuDocumentSchema = {
               type: 'boolean',
             },
             isExperimental: {
-              description: 'Marks this extension point as experimental. Informational only.',
+              description:
+                'Set to `true` to mark this extension point as experimental. Experimental menu content may change or be removed without notice.',
               type: 'boolean',
             },
           },
@@ -260,7 +261,7 @@ export const menuDocumentSchema = {
         },
         isExperimental: {
           description:
-            'Marks the entire columns-collection as an experimental extension point. Informational only.',
+            'Set to `true` to mark this columns collection as experimental. Experimental menu content may change or be removed without notice.',
           type: 'boolean',
         },
       },
@@ -292,7 +293,8 @@ export const menuDocumentSchema = {
                   type: 'boolean',
                 },
                 isExperimental: {
-                  description: 'Marks this extension point as experimental. Informational only.',
+                  description:
+                    'Set to `true` to mark this extension point as experimental. Experimental menu content may change or be removed without notice.',
                   type: 'boolean',
                 },
               },
@@ -316,7 +318,8 @@ export const menuDocumentSchema = {
                   type: 'boolean',
                 },
                 isExperimental: {
-                  description: 'Marks this extension point as experimental. Informational only.',
+                  description:
+                    'Set to `true` to mark this extension point as experimental. Experimental menu content may change or be removed without notice.',
                   type: 'boolean',
                 },
               },
@@ -453,7 +456,8 @@ export const menuDocumentSchema = {
           $ref: '#/$defs/singleColumnMenu',
         },
         isExperimental: {
-          description: 'Marks this WebView menu as experimental. Informational only.',
+          description:
+            'Set to `true` to mark this WebView menu as experimental. Experimental menu content may change or be removed without notice.',
           type: 'boolean',
         },
       },

--- a/lib/platform-bible-utils/src/extension-contributions/menus.model.ts
+++ b/lib/platform-bible-utils/src/extension-contributions/menus.model.ts
@@ -140,7 +140,8 @@ export type WebViewMenu = {
   contextMenu: SingleColumnMenu | undefined;
   /**
    * Set to `true` to mark this WebView menu as experimental. Experimental menu content may change
-   * or be removed without notice. Extensions reading this should treat the marker as informational.
+   * or be removed without notice. Extensions reading this should treat the marker as
+   * informational.
    */
   isExperimental?: boolean;
 };

--- a/src/client/services/rpc-client.ts
+++ b/src/client/services/rpc-client.ts
@@ -16,16 +16,21 @@ import {
   deserializeMessage,
   EventHandler,
   InternalRequestHandler,
+  REGISTER_EVENT,
   REGISTER_METHOD,
   RequestParams,
   sendPayloadToWebSocket,
+  UNREGISTER_EVENT,
   UNREGISTER_METHOD,
   WEBSOCKET_PORT,
 } from '@shared/data/rpc.model';
 import { createWebSocket } from '@client/services/web-socket.factory';
 import { AsyncVariable, getErrorMessage, Mutex, MutexMap } from 'platform-bible-utils';
 import { bindClassMethods, SerializedRequestType } from '@shared/utils/util';
-import { SingleMethodDocumentation } from '@shared/models/openrpc.model';
+import {
+  SingleMethodDocumentation,
+  SingleNotificationDocumentation,
+} from '@shared/models/openrpc.model';
 
 /**
  * Manages the JSON-RPC protocol on the client end of a websocket that connects to main
@@ -177,6 +182,25 @@ export class RpcClient implements IRpcMethodRegistrar {
       if (!this.jsonRpcServer.hasMethod(methodName)) return false;
       const successful = await this.jsonRpcClient.request(UNREGISTER_METHOD, [methodName]);
       if (successful) this.jsonRpcServer.removeMethod(methodName);
+      return successful;
+    });
+  }
+
+  async registerEvent(
+    eventName: string,
+    documentation?: SingleNotificationDocumentation,
+  ): Promise<boolean> {
+    const mutex = this.registrationMutexMap.get(eventName);
+    return mutex.runExclusive(async () => {
+      const success = await this.jsonRpcClient.request(REGISTER_EVENT, [eventName, documentation]);
+      return success;
+    });
+  }
+
+  async unregisterEvent(eventName: string): Promise<boolean> {
+    const mutex = this.registrationMutexMap.get(eventName);
+    return mutex.runExclusive(async () => {
+      const successful = await this.jsonRpcClient.request(UNREGISTER_EVENT, [eventName]);
       return successful;
     });
   }

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -22,6 +22,7 @@ declare module 'papi-shared-types' {
     NetworkObjectDetails,
   } from '@shared/models/network-object.model';
   import type { StoreChangeEvent } from '@shared/services/shared-store.service';
+  import type { ScrollGroupUpdateInfo } from '@shared/services/scroll-group.service-model';
   // Used in JSDocs
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   import type { WebViewFactory } from '@shared/models/web-view-factory.model';
@@ -805,7 +806,12 @@ declare module 'papi-shared-types' {
    * Mark a single event as experimental by adding `\/** @experimental *\/` directly above its
    * entry.
    */
-  export interface NetworkEventTypes extends SharedNetworkEventTypes {}
+  export interface NetworkEventTypes extends SharedNetworkEventTypes {
+    /** Emitted when extensions finish reloading. `true` if reload succeeded, `false` if it failed. */
+    'platform.onDidReloadExtensions': boolean;
+    /** Emitted when the Scripture reference for a scroll group changes. */
+    'scrollGroup:onDidUpdateScrRef': ScrollGroupUpdateInfo;
+  }
 
   // #endregion
 }

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -787,16 +787,30 @@ declare module 'papi-shared-types' {
    *
    * Subscribers do not need to know which events are shared — `getNetworkEvent` handles both kinds
    * identically.
+   *
+   * See {@link NetworkEventTypes} for the full registry of known event names.
    */
   export type SharedNetworkEventTypes = {
+    /**
+     * Emitted when a network object is created in any process. Payload includes the new object's
+     * details.
+     */
     'object:onDidCreateNetworkObject': NetworkObjectDetails;
+    /**
+     * Emitted when a network object is disposed in any process. Payload is the disposed object's
+     * ID.
+     */
     'object:onDidDisposeNetworkObject': string;
+    /**
+     * Emitted when a value in the shared store changes. Payload includes the key and new value with
+     * Lamport timestamp.
+     */
     'shared-store:change': StoreChangeEvent;
   };
 
   /**
    * All known network events. Extensions augment this to declare their own events. Inherits the
-   * platform's shared events automatically.
+   * platform's shared events from {@link SharedNetworkEventTypes} automatically.
    *
    * To declare a new event for use with `createNetworkEventEmitterAsync`:
    *

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -17,7 +17,11 @@ declare module 'papi-shared-types' {
     IDisposableDataProvider,
   } from '@shared/models/data-provider.interface';
   import type { ExtractDataProviderDataTypes } from '@shared/models/extract-data-provider-data-types.model';
-  import type { NetworkableObject } from '@shared/models/network-object.model';
+  import type {
+    NetworkableObject,
+    NetworkObjectDetails,
+  } from '@shared/models/network-object.model';
+  import type { StoreChangeEvent } from '@shared/services/shared-store.service';
   // Used in JSDocs
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   import type { WebViewFactory } from '@shared/models/web-view-factory.model';
@@ -761,6 +765,47 @@ declare module 'papi-shared-types' {
    * @example 'platform.placeholderWebView'
    */
   export type WebViewControllerTypes = keyof WebViewControllers;
+
+  // #endregion
+
+  // #region Network Events
+
+  /**
+   * Network events emitted from multiple processes (each process emits its own local event under
+   * the same name). Declared by the platform; not extensible by extensions.
+   *
+   * The names listed here are the source of truth for which event names use shared semantics at the
+   * central registry. An event name in this type allows registration from multiple processes (each
+   * process registers once, all emitters are valid sources). Any other event name uses exclusive
+   * semantics (one registrant ever).
+   *
+   * Subscribers do not need to know which events are shared — `getNetworkEvent` handles both kinds
+   * identically.
+   */
+  export type SharedNetworkEventTypes = {
+    'network-object.onDidCreateNetworkObject': NetworkObjectDetails;
+    'network-object.onDidDisposeNetworkObject': string;
+    'shared-store.onDidChange': StoreChangeEvent;
+  };
+
+  /**
+   * All known network events. Extensions augment this to declare their own events. Inherits the
+   * platform's shared events automatically.
+   *
+   * To declare a new event for use with `createNetworkEventEmitterAsync`:
+   *
+   * ```ts
+   * declare module 'papi-shared-types' {
+   *   export interface NetworkEventTypes {
+   *     'myExt.somethingHappened': { foo: string };
+   *   }
+   * }
+   * ```
+   *
+   * Mark a single event as experimental by adding `\/** @experimental *\/` directly above its
+   * entry.
+   */
+  export interface NetworkEventTypes extends SharedNetworkEventTypes {}
 
   // #endregion
 }

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -780,17 +780,17 @@ declare module 'papi-shared-types' {
    * Network events emitted from multiple processes (each process emits its own local event under
    * the same name). Declared by the platform; not extensible by extensions.
    *
-   * The names listed here are the source of truth for which event names use shared semantics at the
-   * central registry. An event name in this type allows registration from multiple processes (each
-   * process registers once, all emitters are valid sources). Any other event name uses exclusive
-   * semantics (one registrant ever).
+   * The names listed here are the source of truth for which event names use multi-source semantics
+   * at the central registry. An event name in this type allows registration from multiple processes
+   * (each process registers once, all emitters are valid sources). Any other event name uses
+   * single-source semantics (one registrant ever).
    *
-   * Subscribers do not need to know which events are shared — `getNetworkEvent` handles both kinds
-   * identically.
+   * Subscribers do not need to know which events are multi-source — `getNetworkEvent` handles both
+   * kinds identically.
    *
-   * See {@link NetworkEventTypes} for the full registry of known event names.
+   * See {@link NetworkEvents} for the full registry of known event names.
    */
-  export type SharedNetworkEventTypes = {
+  export type MultiSourceNetworkEvents = {
     /**
      * Emitted when a network object is created in any process. Payload includes the new object's
      * details.
@@ -809,14 +809,15 @@ declare module 'papi-shared-types' {
   };
 
   /**
-   * All known network events. Extensions augment this to declare their own events. Inherits the
-   * platform's shared events from {@link SharedNetworkEventTypes} automatically.
+   * Mapping of network event names to their payload types. Extensions augment this to declare their
+   * own events. Inherits the platform's multi-source events from {@link MultiSourceNetworkEvents}
+   * automatically.
    *
    * To declare a new event for use with `createNetworkEventEmitterAsync`:
    *
    * ```ts
    * declare module 'papi-shared-types' {
-   *   export interface NetworkEventTypes {
+   *   export interface NetworkEvents {
    *     'myExt.somethingHappened': { foo: string };
    *   }
    * }
@@ -825,15 +826,12 @@ declare module 'papi-shared-types' {
    * Mark a single event as experimental by adding `\/** @experimental *\/` directly above its
    * entry.
    */
-  export interface NetworkEventTypes extends SharedNetworkEventTypes {
+  export interface NetworkEvents extends MultiSourceNetworkEvents {
     /** Emitted when extensions finish reloading. `true` if reload succeeded, `false` if it failed. */
     'platform.onDidReloadExtensions': boolean;
     /** Emitted when the Scripture reference for a scroll group changes. */
     'scrollGroup:onDidUpdateScrRef': ScrollGroupUpdateInfo;
-    /**
-     * @deprecated 13 November 2024. Use {@link NetworkEventTypes.'webView:onDidOpenWebView'}
-     *   instead.
-     */
+    /** @deprecated 13 November 2024. Use {@link NetworkEvents.'webView:onDidOpenWebView'} instead. */
     'webView:onDidAddWebView': OpenWebViewEvent;
     /** Emitted when a WebView is created. */
     'webView:onDidOpenWebView': OpenWebViewEvent;
@@ -842,6 +840,9 @@ declare module 'papi-shared-types' {
     /** Emitted when a WebView is closed. */
     'webView:onDidCloseWebView': CloseWebViewEvent;
   }
+
+  /** Union of all known network event names (keys of {@link NetworkEvents}). */
+  export type NetworkEventTypes = keyof NetworkEvents;
 
   // #endregion
 }

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -789,9 +789,9 @@ declare module 'papi-shared-types' {
    * identically.
    */
   export type SharedNetworkEventTypes = {
-    'network-object.onDidCreateNetworkObject': NetworkObjectDetails;
-    'network-object.onDidDisposeNetworkObject': string;
-    'shared-store.onDidChange': StoreChangeEvent;
+    'object:onDidCreateNetworkObject': NetworkObjectDetails;
+    'object:onDidDisposeNetworkObject': string;
+    'shared-store:change': StoreChangeEvent;
   };
 
   /**

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -23,6 +23,11 @@ declare module 'papi-shared-types' {
   } from '@shared/models/network-object.model';
   import type { StoreChangeEvent } from '@shared/services/shared-store.service';
   import type { ScrollGroupUpdateInfo } from '@shared/services/scroll-group.service-model';
+  import type {
+    CloseWebViewEvent,
+    OpenWebViewEvent,
+    UpdateWebViewEvent,
+  } from '@shared/services/web-view.service-model';
   // Used in JSDocs
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   import type { WebViewFactory } from '@shared/models/web-view-factory.model';
@@ -811,6 +816,17 @@ declare module 'papi-shared-types' {
     'platform.onDidReloadExtensions': boolean;
     /** Emitted when the Scripture reference for a scroll group changes. */
     'scrollGroup:onDidUpdateScrRef': ScrollGroupUpdateInfo;
+    /**
+     * @deprecated 13 November 2024. Use {@link NetworkEventTypes.'webView:onDidOpenWebView'}
+     *   instead.
+     */
+    'webView:onDidAddWebView': OpenWebViewEvent;
+    /** Emitted when a WebView is created. */
+    'webView:onDidOpenWebView': OpenWebViewEvent;
+    /** Emitted when a WebView is updated. */
+    'webView:onDidUpdateWebView': UpdateWebViewEvent;
+    /** Emitted when a WebView is closed. */
+    'webView:onDidCloseWebView': CloseWebViewEvent;
   }
 
   // #endregion

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -817,15 +817,15 @@ declare module 'papi-shared-types' {
    * }
    * ```
    *
-   * Mark a single event as experimental by adding `\/** @experimental *\/` directly above its
-   * entry.
+   * Mark a single event as experimental by adding an `@experimental` JSDoc tag in a doc comment
+   * directly above its entry.
    */
   export interface NetworkEvents extends MultiSourceNetworkEvents {
     /** Emitted when extensions finish reloading. `true` if reload succeeded, `false` if it failed. */
     'platform.onDidReloadExtensions': boolean;
     /** Emitted when the Scripture reference for a scroll group changes. */
     'scrollGroup:onDidUpdateScrRef': ScrollGroupUpdateInfo;
-    /** @deprecated 13 November 2024. Use {@link NetworkEvents.'webView:onDidOpenWebView'} instead. */
+    /** @deprecated 13 November 2024. Use the `webView:onDidOpenWebView` event instead. */
     'webView:onDidAddWebView': OpenWebViewEvent;
     /** Emitted when a WebView is created. */
     'webView:onDidOpenWebView': OpenWebViewEvent;

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -21,7 +21,6 @@ declare module 'papi-shared-types' {
     NetworkableObject,
     NetworkObjectDetails,
   } from '@shared/models/network-object.model';
-  import type { StoreChangeEvent } from '@shared/services/shared-store.service';
   import type { ScrollGroupUpdateInfo } from '@shared/services/scroll-group.service-model';
   import type {
     CloseWebViewEvent,
@@ -801,11 +800,6 @@ declare module 'papi-shared-types' {
      * ID.
      */
     'object:onDidDisposeNetworkObject': string;
-    /**
-     * Emitted when a value in the shared store changes. Payload includes the key and new value with
-     * Lamport timestamp.
-     */
-    'shared-store:change': StoreChangeEvent;
   };
 
   /**

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -68,7 +68,7 @@ import {
   UriHandler,
 } from '@shared/models/handle-uri-privilege.model';
 import {
-  createNetworkEventEmitter,
+  createNetworkEventEmitterAsync,
   registerRequestHandler,
 } from '@shared/services/network.service';
 import { HANDLE_URI_REQUEST_TYPE } from '@node/services/extension.service-model';
@@ -1563,7 +1563,7 @@ export const initialize = () => {
 
     appUriScheme = (await appService.getAppInfo()).uriScheme;
 
-    reloadFinishedEventEmitter = createNetworkEventEmitter<boolean>(
+    reloadFinishedEventEmitter = await createNetworkEventEmitterAsync(
       'platform.onDidReloadExtensions',
     );
 

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -1565,6 +1565,19 @@ export const initialize = () => {
 
     reloadFinishedEventEmitter = await createNetworkEventEmitterAsync(
       'platform.onDidReloadExtensions',
+      {
+        notification: {
+          summary: 'Emitted when extensions finish reloading.',
+          params: [
+            {
+              name: 'success',
+              required: true,
+              summary: 'True if the reload succeeded, false if it failed.',
+              schema: { type: 'boolean' },
+            },
+          ],
+        },
+      },
     );
 
     await registerRequestHandler(HANDLE_URI_REQUEST_TYPE, handleExtensionUri);

--- a/src/main/services/__tests__/rpc-event-registry.test.ts
+++ b/src/main/services/__tests__/rpc-event-registry.test.ts
@@ -25,9 +25,9 @@ describe('RpcEventRegistry — shared vs exclusive policy', () => {
   });
 
   it('shared: multiple handlers may register; same handler twice rejected', () => {
-    expect(reg.tryRegister(fakeA, 'network-object.onDidCreateNetworkObject')).toBe(true);
-    expect(reg.tryRegister(fakeB, 'network-object.onDidCreateNetworkObject')).toBe(true);
-    expect(reg.tryRegister(fakeA, 'network-object.onDidCreateNetworkObject')).toBe(false);
+    expect(reg.tryRegister(fakeA, 'object:onDidCreateNetworkObject')).toBe(true);
+    expect(reg.tryRegister(fakeB, 'object:onDidCreateNetworkObject')).toBe(true);
+    expect(reg.tryRegister(fakeA, 'object:onDidCreateNetworkObject')).toBe(false);
   });
 
   it('tryUnregister removes a handler and returns true', () => {

--- a/src/main/services/__tests__/rpc-event-registry.test.ts
+++ b/src/main/services/__tests__/rpc-event-registry.test.ts
@@ -38,6 +38,15 @@ describe('RpcEventRegistry — multi-source vs single-source policy', () => {
   it('tryUnregister returns false for a never-registered handler', () => {
     expect(reg.tryUnregister(fakeA, 'myExt.exclusive')).toBe(false);
   });
+
+  it('has() reports whether any handler has registered a name', () => {
+    expect(reg.has('myExt.exclusive')).toBe(false);
+    reg.tryRegister(fakeA, 'myExt.exclusive');
+    expect(reg.has('myExt.exclusive')).toBe(true);
+    // Still registered while any registrant remains; false once the last one unregisters.
+    reg.tryUnregister(fakeA, 'myExt.exclusive');
+    expect(reg.has('myExt.exclusive')).toBe(false);
+  });
 });
 
 describe('RpcEventRegistry — checkAnnouncement', () => {

--- a/src/main/services/__tests__/rpc-event-registry.test.ts
+++ b/src/main/services/__tests__/rpc-event-registry.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RpcEventRegistry } from '@main/services/rpc-websocket-listener';
 
 // Mock heavy dependencies so this test can run outside the Electron main process
 vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
@@ -6,8 +7,6 @@ vi.mock('ws', () => ({ WebSocketServer: vi.fn() }));
 vi.mock('@shared/services/logger.service', () => ({
   logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
 }));
-
-import { RpcEventRegistry } from '@main/services/rpc-websocket-listener';
 
 describe('RpcEventRegistry — multi-source vs single-source policy', () => {
   const fakeA = { id: 'A' };

--- a/src/main/services/__tests__/rpc-event-registry.test.ts
+++ b/src/main/services/__tests__/rpc-event-registry.test.ts
@@ -9,7 +9,7 @@ vi.mock('@shared/services/logger.service', () => ({
 
 import { RpcEventRegistry } from '@main/services/rpc-websocket-listener';
 
-describe('RpcEventRegistry — shared vs exclusive policy', () => {
+describe('RpcEventRegistry — multi-source vs single-source policy', () => {
   const fakeA = { id: 'A' };
   const fakeB = { id: 'B' };
 
@@ -18,13 +18,13 @@ describe('RpcEventRegistry — shared vs exclusive policy', () => {
     reg = new RpcEventRegistry();
   });
 
-  it('exclusive: first registrant wins; subsequent registrations from any handler rejected', () => {
+  it('single-source: first registrant wins; subsequent registrations from any handler rejected', () => {
     expect(reg.tryRegister(fakeA, 'myExt.exclusive')).toBe(true);
     expect(reg.tryRegister(fakeA, 'myExt.exclusive')).toBe(false);
     expect(reg.tryRegister(fakeB, 'myExt.exclusive')).toBe(false);
   });
 
-  it('shared: multiple handlers may register; same handler twice rejected', () => {
+  it('multi-source: multiple handlers may register; same handler twice rejected', () => {
     expect(reg.tryRegister(fakeA, 'object:onDidCreateNetworkObject')).toBe(true);
     expect(reg.tryRegister(fakeB, 'object:onDidCreateNetworkObject')).toBe(true);
     expect(reg.tryRegister(fakeA, 'object:onDidCreateNetworkObject')).toBe(false);

--- a/src/main/services/__tests__/rpc-event-registry.test.ts
+++ b/src/main/services/__tests__/rpc-event-registry.test.ts
@@ -39,3 +39,44 @@ describe('RpcEventRegistry — multi-source vs single-source policy', () => {
     expect(reg.tryUnregister(fakeA, 'myExt.exclusive')).toBe(false);
   });
 });
+
+describe('RpcEventRegistry — checkAnnouncement', () => {
+  const fakeA = { id: 'A' };
+  const fakeB = { id: 'B' };
+
+  let reg: RpcEventRegistry;
+  beforeEach(() => {
+    reg = new RpcEventRegistry();
+  });
+
+  it("returns 'unregistered' when no one has registered a single-source event", () => {
+    expect(reg.checkAnnouncement(fakeA, 'myExt.neverRegistered')).toBe('unregistered');
+  });
+
+  it("returns 'ok' for an unregistered multi-source event (any process may emit it)", () => {
+    expect(reg.checkAnnouncement(fakeA, 'object:onDidCreateNetworkObject')).toBe('ok');
+  });
+
+  it("returns 'ok' when a single-source event is announced by its registrant", () => {
+    reg.tryRegister(fakeA, 'myExt.exclusive');
+    expect(reg.checkAnnouncement(fakeA, 'myExt.exclusive')).toBe('ok');
+  });
+
+  it("returns 'foreign-single-source' when a single-source event is announced by a non-registrant", () => {
+    reg.tryRegister(fakeA, 'myExt.exclusive');
+    expect(reg.checkAnnouncement(fakeB, 'myExt.exclusive')).toBe('foreign-single-source');
+  });
+
+  it("returns 'ok' for a multi-source event regardless of which registrant announces it", () => {
+    reg.tryRegister(fakeA, 'object:onDidCreateNetworkObject');
+    reg.tryRegister(fakeB, 'object:onDidCreateNetworkObject');
+    expect(reg.checkAnnouncement(fakeA, 'object:onDidCreateNetworkObject')).toBe('ok');
+    expect(reg.checkAnnouncement(fakeB, 'object:onDidCreateNetworkObject')).toBe('ok');
+  });
+
+  it("returns 'ok' for a multi-source event announced by a process that never registered it", () => {
+    reg.tryRegister(fakeA, 'object:onDidCreateNetworkObject');
+    // Multi-source semantics allow multiple sources; a non-registrant announcement is not flagged.
+    expect(reg.checkAnnouncement(fakeB, 'object:onDidCreateNetworkObject')).toBe('ok');
+  });
+});

--- a/src/main/services/__tests__/rpc-event-registry.test.ts
+++ b/src/main/services/__tests__/rpc-event-registry.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock heavy dependencies so this test can run outside the Electron main process
+vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
+vi.mock('ws', () => ({ WebSocketServer: vi.fn() }));
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+import { RpcEventRegistry } from '@main/services/rpc-websocket-listener';
+
+describe('RpcEventRegistry — shared vs exclusive policy', () => {
+  const fakeA = { id: 'A' };
+  const fakeB = { id: 'B' };
+
+  let reg: RpcEventRegistry;
+  beforeEach(() => {
+    reg = new RpcEventRegistry();
+  });
+
+  it('exclusive: first registrant wins; subsequent registrations from any handler rejected', () => {
+    expect(reg.tryRegister(fakeA, 'myExt.exclusive')).toBe(true);
+    expect(reg.tryRegister(fakeA, 'myExt.exclusive')).toBe(false);
+    expect(reg.tryRegister(fakeB, 'myExt.exclusive')).toBe(false);
+  });
+
+  it('shared: multiple handlers may register; same handler twice rejected', () => {
+    expect(reg.tryRegister(fakeA, 'network-object.onDidCreateNetworkObject')).toBe(true);
+    expect(reg.tryRegister(fakeB, 'network-object.onDidCreateNetworkObject')).toBe(true);
+    expect(reg.tryRegister(fakeA, 'network-object.onDidCreateNetworkObject')).toBe(false);
+  });
+
+  it('tryUnregister removes a handler and returns true', () => {
+    reg.tryRegister(fakeA, 'myExt.exclusive');
+    expect(reg.tryUnregister(fakeA, 'myExt.exclusive')).toBe(true);
+    expect(reg.tryUnregister(fakeA, 'myExt.exclusive')).toBe(false); // already gone
+  });
+
+  it('tryUnregister returns false for a never-registered handler', () => {
+    expect(reg.tryUnregister(fakeA, 'myExt.exclusive')).toBe(false);
+  });
+});

--- a/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
@@ -57,7 +57,7 @@ describe('generateOpenRpcSchema() includes notifications from the event registry
     expect(foundDocs).toBeUndefined();
   });
 
-  it('first registration documentation wins for shared events', () => {
+  it('first registration documentation wins for multi-source events', () => {
     const firstDocs = {
       notification: { params: [], summary: 'First handler summary' },
     };

--- a/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RpcEventRegistry } from '@main/services/rpc-websocket-listener';
 
 // Mock heavy dependencies so this test can run outside the Electron main process
 vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
@@ -6,8 +7,6 @@ vi.mock('ws', () => ({ WebSocketServer: vi.fn() }));
 vi.mock('@shared/services/logger.service', () => ({
   logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
 }));
-
-import { RpcEventRegistry } from '@main/services/rpc-websocket-listener';
 
 describe('generateOpenRpcSchema() includes notifications from the event registry', () => {
   // We test via RpcEventRegistry directly because constructing a full RpcWebSocketListener
@@ -41,6 +40,9 @@ describe('generateOpenRpcSchema() includes notifications from the event registry
     expect(foundDocs?.notification['x-experimental']).toBe(true);
 
     // Verify the notification entry shape (no result field):
+    // The non-null assertion is needed here: we have already asserted foundDocs is defined above,
+    // but TypeScript's narrowing doesn't carry across the expression boundary.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     const notificationEntry = { name: eventName, ...foundDocs!.notification };
     expect('result' in notificationEntry).toBe(false);
     expect(notificationEntry.name).toBe('myExt.onDidSomething');
@@ -53,7 +55,7 @@ describe('generateOpenRpcSchema() includes notifications from the event registry
     expect(entries).toHaveLength(1);
     const [, registrants] = entries[0];
     const foundDocs = registrants.find((r) => r.documentation)?.documentation;
-    // The production loop does `if (!docs) continue;` — confirm docs is undefined here
+    // The production loop does `if (!docs) return;` — confirm docs is undefined here
     expect(foundDocs).toBeUndefined();
   });
 

--- a/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mock heavy dependencies so this test can run outside the Electron main process
+vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
+vi.mock('ws', () => ({ WebSocketServer: vi.fn() }));
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+import { RpcEventRegistry } from '@main/services/rpc-websocket-listener';
+
+describe('generateOpenRpcSchema() includes notifications from the event registry', () => {
+  // We test via RpcEventRegistry directly because constructing a full RpcWebSocketListener
+  // requires mocking Electron IPC, WebSocketServer, network service startup, and more.
+  // The registry itself is the unit under test here; the integration with generateOpenRpcSchema
+  // is verified by checking that the entries() API returns the correct shape.
+
+  let reg: RpcEventRegistry;
+
+  beforeEach(() => {
+    reg = new RpcEventRegistry();
+  });
+
+  it('entries() returns registered events with documentation, enabling notification emission', () => {
+    const docs = {
+      notification: {
+        params: [],
+        summary: 'Fired when something happens',
+        'x-experimental': true as const,
+      },
+    };
+    reg.tryRegister({}, 'myExt.onDidSomething', docs);
+
+    const entries = [...reg.entries()];
+    expect(entries).toHaveLength(1);
+    const [eventName, registrants] = entries[0];
+    expect(eventName).toBe('myExt.onDidSomething');
+    const foundDocs = registrants.find((r) => r.documentation)?.documentation;
+    expect(foundDocs).toBeDefined();
+    expect(foundDocs?.notification.summary).toBe('Fired when something happens');
+    expect(foundDocs?.notification['x-experimental']).toBe(true);
+
+    // Verify the notification entry shape (no result field):
+    const notificationEntry = { name: eventName, ...foundDocs!.notification };
+    expect('result' in notificationEntry).toBe(false);
+    expect(notificationEntry.name).toBe('myExt.onDidSomething');
+  });
+
+  it('events without documentation are not surfaced (entries with no docs are skipped)', () => {
+    reg.tryRegister({}, 'myExt.undocumented'); // no docs
+
+    const entries = [...reg.entries()];
+    expect(entries).toHaveLength(1);
+    const [, registrants] = entries[0];
+    const foundDocs = registrants.find((r) => r.documentation)?.documentation;
+    // The production loop does `if (!docs) continue;` — confirm docs is undefined here
+    expect(foundDocs).toBeUndefined();
+  });
+
+  it('first registration documentation wins for shared events', () => {
+    const firstDocs = {
+      notification: { params: [], summary: 'First handler summary' },
+    };
+    const secondDocs = {
+      notification: { params: [], summary: 'Second handler summary' },
+    };
+    const sharedName = 'network-object.onDidCreateNetworkObject';
+    reg.tryRegister({ id: 'A' }, sharedName, firstDocs);
+    reg.tryRegister({ id: 'B' }, sharedName, secondDocs);
+
+    const entries = [...reg.entries()];
+    expect(entries).toHaveLength(1);
+    const [, registrants] = entries[0];
+    // Both registrants are present; find() returns the first with documentation
+    const foundDocs = registrants.find((r) => r.documentation)?.documentation;
+    expect(foundDocs?.notification.summary).toBe('First handler summary');
+  });
+});

--- a/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { RpcEventRegistry } from '@main/services/rpc-websocket-listener';
+import { RpcEventRegistry, RpcWebSocketListener } from '@main/services/rpc-websocket-listener';
 
 // Mock heavy dependencies so this test can run outside the Electron main process
 vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
@@ -48,17 +48,6 @@ describe('generateOpenRpcSchema() includes notifications from the event registry
     expect(notificationEntry.name).toBe('myExt.onDidSomething');
   });
 
-  it('events without documentation are not surfaced (entries with no docs are skipped)', () => {
-    reg.tryRegister({}, 'myExt.undocumented'); // no docs
-
-    const entries = [...reg.entries()];
-    expect(entries).toHaveLength(1);
-    const [, registrants] = entries[0];
-    const foundDocs = registrants.find((r) => r.documentation)?.documentation;
-    // The production loop does `if (!docs) return;` — confirm docs is undefined here
-    expect(foundDocs).toBeUndefined();
-  });
-
   it('first registration documentation wins for multi-source events', () => {
     const firstDocs = {
       notification: { params: [], summary: 'First handler summary' },
@@ -76,5 +65,41 @@ describe('generateOpenRpcSchema() includes notifications from the event registry
     // Both registrants are present; find() returns the first with documentation
     const foundDocs = registrants.find((r) => r.documentation)?.documentation;
     expect(foundDocs?.notification.summary).toBe('First handler summary');
+  });
+});
+
+describe('generateOpenRpcSchema() surfaces every registered event', () => {
+  let listener: RpcWebSocketListener;
+
+  beforeEach(() => {
+    // The constructor only binds methods (no Electron/WebSocket startup), so a bare instance is
+    // enough to register events and generate the schema directly.
+    listener = new RpcWebSocketListener();
+  });
+
+  it('includes a documented event with its provided documentation', async () => {
+    await listener.registerEvent('myExt.onDidSomething', {
+      notification: { params: [], summary: 'Fired when something happens' },
+    });
+
+    const schema = listener.generateOpenRpcSchema();
+    const entry = schema.methods.find((m) => m.name === 'myExt.onDidSomething');
+    expect(entry).toBeDefined();
+    expect(entry?.summary).toBe('Fired when something happens');
+    // Notifications carry no `result` field.
+    expect(entry && 'result' in entry).toBe(false);
+  });
+
+  it('includes an undocumented event with placeholder documentation (not skipped)', async () => {
+    await listener.registerEvent('myExt.undocumented'); // no docs
+
+    const schema = listener.generateOpenRpcSchema();
+    const entry = schema.methods.find((m) => m.name === 'myExt.undocumented');
+    // Previously undocumented events were dropped from the document; now they are surfaced with a
+    // placeholder so the OpenRPC document lists every registered event.
+    expect(entry).toBeDefined();
+    expect(entry?.description).toBe('Notification: No documentation provided');
+    expect(entry?.params).toEqual([]);
+    expect(entry && 'result' in entry).toBe(false);
   });
 });

--- a/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RpcEventRegistry, RpcWebSocketListener } from '@main/services/rpc-websocket-listener';
 import { EXPERIMENTAL_OPENRPC_PREFIX } from '@shared/models/openrpc.model';
+import { logger } from '@shared/services/logger.service';
 
 // Mock heavy dependencies so this test can run outside the Electron main process
 vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
@@ -113,5 +114,46 @@ describe('generateOpenRpcSchema() surfaces every registered event', () => {
     const entry = schema.methods.find((m) => m.name === 'myExt.expEvent');
     expect(entry?.summary).toBe(`${EXPERIMENTAL_OPENRPC_PREFIX}Fires experimentally`);
     expect(entry?.['x-experimental']).toBe(true);
+  });
+});
+
+describe('emitEventOnNetwork warns about invalid event announcements', () => {
+  let listener: RpcWebSocketListener;
+
+  beforeEach(() => {
+    vi.mocked(logger.warn).mockClear();
+    // The constructor only binds methods (no Electron/WebSocket startup). There are no connected
+    // sockets, so emitEventOnNetwork only runs the announcement validation and the (empty) fan-out.
+    listener = new RpcWebSocketListener();
+  });
+
+  it('warns that announcing an unregistered single-source event is deprecated', () => {
+    listener.emitEventOnNetwork('myExt.unregistered', { foo: 1 });
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(logger.warn).mock.calls[0][0]).toMatch(
+      /not registered with the central registry.*deprecated as of 12 June 2026/s,
+    );
+  });
+
+  it('warns only once per unregistered event name (deduped)', () => {
+    listener.emitEventOnNetwork('myExt.unregistered', { foo: 1 });
+    listener.emitEventOnNetwork('myExt.unregistered', { foo: 2 });
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not warn when an unregistered multi-source event is announced', () => {
+    // Multi-source events may be emitted by any process whether or not they registered.
+    listener.emitEventOnNetwork('object:onDidCreateNetworkObject', { foo: 1 });
+    expect(logger.warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when main announces an event it registered itself', async () => {
+    // Registering through the listener ties the event to the listener (`this`), which is the same
+    // handler emitEventOnNetwork announces under — so the announcement is valid.
+    await listener.registerEvent('myExt.mainOwned', {
+      notification: { params: [], summary: 'Owned by main' },
+    });
+    listener.emitEventOnNetwork('myExt.mainOwned', { foo: 1 });
+    expect(logger.warn).not.toHaveBeenCalled();
   });
 });

--- a/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
@@ -124,6 +124,66 @@ describe('generateOpenRpcSchema() surfaces every registered event', () => {
   });
 });
 
+describe('method/notification name collisions are rejected (names must be unique across both)', () => {
+  let listener: RpcWebSocketListener;
+
+  beforeEach(() => {
+    vi.mocked(logger.warn).mockClear();
+    listener = new RpcWebSocketListener();
+  });
+
+  it('rejects registering an event whose name is already a method, and warns', async () => {
+    const registeredMethod = await listener.registerMethod('myExt.sharedName', vi.fn(), {
+      method: { params: [], result: { name: 'r', schema: {} }, summary: 'A method' },
+    });
+    expect(registeredMethod).toBe(true);
+
+    const registeredEvent = await listener.registerEvent('myExt.sharedName', {
+      notification: { params: [], summary: 'An event' },
+    });
+    expect(registeredEvent).toBe(false);
+    expect(vi.mocked(logger.warn).mock.calls[0][0]).toMatch(
+      /Cannot register network event "myExt\.sharedName".*method with this name is already registered/s,
+    );
+
+    // The document carries exactly one entry for the name (the method), so it stays valid.
+    const schema = listener.generateOpenRpcSchema();
+    expect(schema.methods.filter((m) => m.name === 'myExt.sharedName')).toHaveLength(1);
+  });
+
+  it('rejects registering a method whose name is already an event, and warns', async () => {
+    const registeredEvent = await listener.registerEvent('myExt.sharedName', {
+      notification: { params: [], summary: 'An event' },
+    });
+    expect(registeredEvent).toBe(true);
+
+    const registeredMethod = await listener.registerMethod('myExt.sharedName', vi.fn(), {
+      method: { params: [], result: { name: 'r', schema: {} }, summary: 'A method' },
+    });
+    expect(registeredMethod).toBe(false);
+    expect(vi.mocked(logger.warn).mock.calls[0][0]).toMatch(
+      /Cannot register method "myExt\.sharedName".*notification\) with this name is already registered/s,
+    );
+
+    const schema = listener.generateOpenRpcSchema();
+    expect(schema.methods.filter((m) => m.name === 'myExt.sharedName')).toHaveLength(1);
+  });
+
+  it('allows a method and an event with distinct names (both surface in the document)', async () => {
+    await listener.registerMethod('myExt.doThing', vi.fn(), {
+      method: { params: [], result: { name: 'r', schema: {} }, summary: 'A method' },
+    });
+    await listener.registerEvent('myExt.onDidThing', {
+      notification: { params: [], summary: 'An event' },
+    });
+
+    const schema = listener.generateOpenRpcSchema();
+    expect(schema.methods.find((m) => m.name === 'myExt.doThing')).toBeDefined();
+    expect(schema.methods.find((m) => m.name === 'myExt.onDidThing')).toBeDefined();
+    expect(vi.mocked(logger.warn)).not.toHaveBeenCalled();
+  });
+});
+
 describe('emitEventOnNetwork warns about invalid event announcements', () => {
   let listener: RpcWebSocketListener;
 

--- a/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RpcEventRegistry, RpcWebSocketListener } from '@main/services/rpc-websocket-listener';
-import { EXPERIMENTAL_OPENRPC_PREFIX } from '@shared/models/openrpc.model';
+import {
+  EXPERIMENTAL_OPENRPC_PREFIX,
+  NOTIFICATION_OPENRPC_PREFIX,
+} from '@shared/models/openrpc.model';
 import { logger } from '@shared/services/logger.service';
 
 // Mock heavy dependencies so this test can run outside the Electron main process
@@ -87,7 +90,9 @@ describe('generateOpenRpcSchema() surfaces every registered event', () => {
     const schema = listener.generateOpenRpcSchema();
     const entry = schema.methods.find((m) => m.name === 'myExt.onDidSomething');
     expect(entry).toBeDefined();
-    expect(entry?.summary).toBe('Fired when something happens');
+    // Notification summaries get the `(Notification) ` prefix so they're distinguishable from
+    // methods in tooling that lists both together.
+    expect(entry?.summary).toBe(`${NOTIFICATION_OPENRPC_PREFIX}Fired when something happens`);
     // Notifications carry no `result` field.
     expect(entry && 'result' in entry).toBe(false);
   });
@@ -105,14 +110,16 @@ describe('generateOpenRpcSchema() surfaces every registered event', () => {
     expect(entry && 'result' in entry).toBe(false);
   });
 
-  it('prepends EXPERIMENTAL: to the summary of an experimental event', async () => {
+  it('prepends (Notification) and [EXPERIMENTAL] to the summary of an experimental event', async () => {
     await listener.registerEvent('myExt.expEvent', {
       notification: { params: [], summary: 'Fires experimentally', 'x-experimental': true },
     });
 
     const schema = listener.generateOpenRpcSchema();
     const entry = schema.methods.find((m) => m.name === 'myExt.expEvent');
-    expect(entry?.summary).toBe(`${EXPERIMENTAL_OPENRPC_PREFIX}Fires experimentally`);
+    expect(entry?.summary).toBe(
+      `${NOTIFICATION_OPENRPC_PREFIX}${EXPERIMENTAL_OPENRPC_PREFIX}Fires experimentally`,
+    );
     expect(entry?.['x-experimental']).toBe(true);
   });
 });

--- a/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.openrpc.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RpcEventRegistry, RpcWebSocketListener } from '@main/services/rpc-websocket-listener';
+import { EXPERIMENTAL_OPENRPC_PREFIX } from '@shared/models/openrpc.model';
 
 // Mock heavy dependencies so this test can run outside the Electron main process
 vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
@@ -101,5 +102,16 @@ describe('generateOpenRpcSchema() surfaces every registered event', () => {
     expect(entry?.description).toBe('Notification: No documentation provided');
     expect(entry?.params).toEqual([]);
     expect(entry && 'result' in entry).toBe(false);
+  });
+
+  it('prepends EXPERIMENTAL: to the summary of an experimental event', async () => {
+    await listener.registerEvent('myExt.expEvent', {
+      notification: { params: [], summary: 'Fires experimentally', 'x-experimental': true },
+    });
+
+    const schema = listener.generateOpenRpcSchema();
+    const entry = schema.methods.find((m) => m.name === 'myExt.expEvent');
+    expect(entry?.summary).toBe(`${EXPERIMENTAL_OPENRPC_PREFIX}Fires experimentally`);
+    expect(entry?.['x-experimental']).toBe(true);
   });
 });

--- a/src/main/services/network-object-status.service-host.ts
+++ b/src/main/services/network-object-status.service-host.ts
@@ -16,17 +16,6 @@ import {
 // that avoids race conditions with the events that fire around the same time.
 const networkObjectIDsToDetails = new Map<string, NetworkObjectDetails>();
 
-onDidCreateNetworkObject((networkObjectDetails) => {
-  if (networkObjectIDsToDetails.has(networkObjectDetails.id))
-    logger.warn(`Re-saving network object details for ${networkObjectDetails.id}`);
-  networkObjectIDsToDetails.set(networkObjectDetails.id, networkObjectDetails);
-});
-
-onDidDisposeNetworkObject((networkObjectId) => {
-  if (!networkObjectIDsToDetails.delete(networkObjectId))
-    logger.warn(`Notification of disposed object ${networkObjectId} that was previously unknown`);
-});
-
 // Making this async to align with the service model even though it could really be synchronous
 async function getAllNetworkObjectDetails(): Promise<Record<string, NetworkObjectDetails>> {
   const allNetworkObjectDetails: Record<string, NetworkObjectDetails> = {};
@@ -40,8 +29,29 @@ const networkObjectStatusService: NetworkObjectStatusRemoteServiceType = {
   getAllNetworkObjectDetails,
 };
 
+/**
+ * Initialize the network object status service by setting up subscriptions to network object
+ * lifecycle events. Must be called after `networkObjectService.initialize()` (which initializes the
+ * event emitters), and before any network objects are registered.
+ */
+async function initialize(): Promise<void> {
+  await networkObjectService.initialize();
+
+  onDidCreateNetworkObject((networkObjectDetails) => {
+    if (networkObjectIDsToDetails.has(networkObjectDetails.id))
+      logger.warn(`Re-saving network object details for ${networkObjectDetails.id}`);
+    networkObjectIDsToDetails.set(networkObjectDetails.id, networkObjectDetails);
+  });
+
+  onDidDisposeNetworkObject((networkObjectId) => {
+    if (!networkObjectIDsToDetails.delete(networkObjectId))
+      logger.warn(`Notification of disposed object ${networkObjectId} that was previously unknown`);
+  });
+}
+
 /** Register the network object that backs the network object status service */
 export async function startNetworkObjectStatusService(): Promise<void> {
+  await initialize();
   await networkObjectService.set<NetworkObjectStatusRemoteServiceType>(
     networkObjectStatusServiceNetworkObjectName,
     networkObjectStatusService,

--- a/src/main/services/network-object-status.service-host.ts
+++ b/src/main/services/network-object-status.service-host.ts
@@ -16,6 +16,17 @@ import {
 // that avoids race conditions with the events that fire around the same time.
 const networkObjectIDsToDetails = new Map<string, NetworkObjectDetails>();
 
+onDidCreateNetworkObject((networkObjectDetails) => {
+  if (networkObjectIDsToDetails.has(networkObjectDetails.id))
+    logger.warn(`Re-saving network object details for ${networkObjectDetails.id}`);
+  networkObjectIDsToDetails.set(networkObjectDetails.id, networkObjectDetails);
+});
+
+onDidDisposeNetworkObject((networkObjectId) => {
+  if (!networkObjectIDsToDetails.delete(networkObjectId))
+    logger.warn(`Notification of disposed object ${networkObjectId} that was previously unknown`);
+});
+
 // Making this async to align with the service model even though it could really be synchronous
 async function getAllNetworkObjectDetails(): Promise<Record<string, NetworkObjectDetails>> {
   const allNetworkObjectDetails: Record<string, NetworkObjectDetails> = {};
@@ -29,29 +40,8 @@ const networkObjectStatusService: NetworkObjectStatusRemoteServiceType = {
   getAllNetworkObjectDetails,
 };
 
-/**
- * Initialize the network object status service by setting up subscriptions to network object
- * lifecycle events. Must be called after `networkObjectService.initialize()` (which initializes the
- * event emitters), and before any network objects are registered.
- */
-async function initialize(): Promise<void> {
-  await networkObjectService.initialize();
-
-  onDidCreateNetworkObject((networkObjectDetails) => {
-    if (networkObjectIDsToDetails.has(networkObjectDetails.id))
-      logger.warn(`Re-saving network object details for ${networkObjectDetails.id}`);
-    networkObjectIDsToDetails.set(networkObjectDetails.id, networkObjectDetails);
-  });
-
-  onDidDisposeNetworkObject((networkObjectId) => {
-    if (!networkObjectIDsToDetails.delete(networkObjectId))
-      logger.warn(`Notification of disposed object ${networkObjectId} that was previously unknown`);
-  });
-}
-
 /** Register the network object that backs the network object status service */
 export async function startNetworkObjectStatusService(): Promise<void> {
-  await initialize();
   await networkObjectService.set<NetworkObjectStatusRemoteServiceType>(
     networkObjectStatusServiceNetworkObjectName,
     networkObjectStatusService,

--- a/src/main/services/rpc-event-registry.ts
+++ b/src/main/services/rpc-event-registry.ts
@@ -68,6 +68,12 @@ export class RpcEventRegistry {
     return existing.some((r) => r.handler === handler) ? 'ok' : 'foreign-single-source';
   }
 
+  /** Whether any handler has centrally registered this event name. */
+  has(eventName: string): boolean {
+    const existing = this.byName.get(eventName);
+    return existing !== undefined && existing.length > 0;
+  }
+
   /** Remove a registrant. Returns `true` if the handler had registered this event. */
   tryUnregister(handler: unknown, eventName: string): boolean {
     const existing = this.byName.get(eventName);

--- a/src/main/services/rpc-event-registry.ts
+++ b/src/main/services/rpc-event-registry.ts
@@ -1,0 +1,76 @@
+import { SingleNotificationDocumentation } from '@shared/models/openrpc.model';
+import { MULTI_SOURCE_EVENT_NAMES } from '@shared/data/network-event-names';
+import type { MultiSourceNetworkEvents } from 'papi-shared-types';
+
+interface EventRegistrant {
+  handler: unknown;
+  documentation?: SingleNotificationDocumentation;
+}
+
+/**
+ * Tracks registered network event emitters, enforcing shared vs. exclusive ownership policy.
+ *
+ * @internal Exported for unit-testing only; not part of the public API.
+ */
+export class RpcEventRegistry {
+  private byName = new Map<string, EventRegistrant[]>();
+
+  /**
+   * Try to register an event. Returns `true` if accepted, `false` if rejected.
+   *
+   * - Name in `MULTI_SOURCE_EVENT_NAMES` (multi-source): multiple handlers may register; same handler
+   *   twice rejected.
+   * - Name not in `MULTI_SOURCE_EVENT_NAMES` (single-source): first registrant wins; any subsequent
+   *   registration from any handler is rejected.
+   */
+  tryRegister(
+    handler: unknown,
+    eventName: string,
+    documentation?: SingleNotificationDocumentation,
+  ): boolean {
+    // Cast is needed: MULTI_SOURCE_EVENT_NAMES is typed as Set<keyof MultiSourceNetworkEvents> but
+    // we receive an arbitrary string from the caller — the cast lets Set.has() accept it.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    const isMultiSource = MULTI_SOURCE_EVENT_NAMES.has(eventName as keyof MultiSourceNetworkEvents);
+    const existing = this.byName.get(eventName);
+
+    if (!existing) {
+      this.byName.set(eventName, [{ handler, documentation }]);
+      return true;
+    }
+
+    if (isMultiSource) {
+      if (existing.some((r) => r.handler === handler)) return false;
+      existing.push({ handler, documentation });
+      return true;
+    }
+
+    return false;
+  }
+
+  /** Remove a registrant. Returns `true` if the handler had registered this event. */
+  tryUnregister(handler: unknown, eventName: string): boolean {
+    const existing = this.byName.get(eventName);
+    if (!existing) return false;
+    const index = existing.findIndex((r) => r.handler === handler);
+    if (index < 0) return false;
+    existing.splice(index, 1);
+    if (existing.length === 0) this.byName.delete(eventName);
+    return true;
+  }
+
+  /** Remove all event registrations for the given handler (e.g. when a websocket closes) */
+  unregisterAll(handler: unknown): void {
+    this.byName.forEach((registrants, eventName) => {
+      const filtered = registrants.filter((r) => r.handler !== handler);
+      if (filtered.length === 0) this.byName.delete(eventName);
+      else this.byName.set(eventName, filtered);
+    });
+  }
+
+  entries(): IterableIterator<[string, EventRegistrant[]]> {
+    return this.byName.entries();
+  }
+}
+
+export default RpcEventRegistry;

--- a/src/main/services/rpc-event-registry.ts
+++ b/src/main/services/rpc-event-registry.ts
@@ -1,6 +1,5 @@
 import { SingleNotificationDocumentation } from '@shared/models/openrpc.model';
 import { MULTI_SOURCE_EVENT_NAMES } from '@shared/data/network-event-names';
-import type { MultiSourceNetworkEvents } from 'papi-shared-types';
 
 interface EventRegistrant {
   handler: unknown;
@@ -28,10 +27,7 @@ export class RpcEventRegistry {
     eventName: string,
     documentation?: SingleNotificationDocumentation,
   ): boolean {
-    // Cast is needed: MULTI_SOURCE_EVENT_NAMES is typed as Set<keyof MultiSourceNetworkEvents> but
-    // we receive an arbitrary string from the caller — the cast lets Set.has() accept it.
-    // eslint-disable-next-line no-type-assertion/no-type-assertion
-    const isMultiSource = MULTI_SOURCE_EVENT_NAMES.has(eventName as keyof MultiSourceNetworkEvents);
+    const isMultiSource = MULTI_SOURCE_EVENT_NAMES.has(eventName);
     const existing = this.byName.get(eventName);
 
     if (!existing) {
@@ -46,6 +42,30 @@ export class RpcEventRegistry {
     }
 
     return false;
+  }
+
+  /**
+   * Classify an attempt to announce (emit) an event on the network against the registry. Used to
+   * warn about misuse without blocking the announcement.
+   *
+   * - `'ok'` — the announcement is valid: the event is multi-source (any process may announce it,
+   *   whether or not it registered), or it is single-source and announced by its registrant.
+   * - `'unregistered'` — the event is single-source and no process has registered this name
+   *   centrally. Emitting a single-source event that was never registered is deprecated (it does
+   *   not appear in the OpenRPC document).
+   * - `'foreign-single-source'` — the event is single-source but is being announced by a handler that
+   *   did not register it; only the registering process should emit a single-source event.
+   */
+  checkAnnouncement(
+    handler: unknown,
+    eventName: string,
+  ): 'ok' | 'unregistered' | 'foreign-single-source' {
+    // Multi-source events may be announced by any process regardless of registration, so they are
+    // always fine to emit.
+    if (MULTI_SOURCE_EVENT_NAMES.has(eventName)) return 'ok';
+    const existing = this.byName.get(eventName);
+    if (!existing || existing.length === 0) return 'unregistered';
+    return existing.some((r) => r.handler === handler) ? 'ok' : 'foreign-single-source';
   }
 
   /** Remove a registrant. Returns `true` if the handler had registered this event. */

--- a/src/main/services/rpc-server.ts
+++ b/src/main/services/rpc-server.ts
@@ -10,7 +10,11 @@ import {
   JSONRPCServer,
 } from 'json-rpc-2.0';
 import { logger } from '@shared/services/logger.service';
-import { IRpcHandler, RegisteredRpcMethodDetails } from '@shared/models/rpc.interface';
+import {
+  IRpcEventRegistry,
+  IRpcHandler,
+  RegisteredRpcMethodDetails,
+} from '@shared/models/rpc.interface';
 import {
   ConnectionStatus,
   createErrorResponse,
@@ -18,14 +22,19 @@ import {
   createSuccessResponse,
   deserializeMessage,
   InternalRequestHandler,
+  REGISTER_EVENT,
   REGISTER_METHOD,
   RequestParams,
   requestWithRetry,
   sendPayloadToWebSocket,
+  UNREGISTER_EVENT,
   UNREGISTER_METHOD,
 } from '@shared/data/rpc.model';
 import { bindClassMethods, SerializedRequestType } from '@shared/utils/util';
-import { SingleMethodDocumentation } from '@shared/models/openrpc.model';
+import {
+  SingleMethodDocumentation,
+  SingleNotificationDocumentation,
+} from '@shared/models/openrpc.model';
 import { getErrorMessage } from 'platform-bible-utils';
 
 type PropagateEventMethod = <T>(source: RpcServer, eventType: string, event: T) => void;
@@ -48,6 +57,7 @@ export class RpcServer implements IRpcHandler {
   /** Refers to any process that connected to main over the websocket */
   private readonly jsonRpcClient: JSONRPCClient;
   private readonly rpcMethodDetailsByMethodName: Map<string, RegisteredRpcMethodDetails>;
+  private readonly rpcEventDetailsByEventName: IRpcEventRegistry;
   /** Called by an RpcServer when all other RpcServers should emit an event over the network */
   private readonly propagateEventMethod: PropagateEventMethod;
 
@@ -56,6 +66,7 @@ export class RpcServer implements IRpcHandler {
     webSocket: WebSocket,
     propagateEventMethod: PropagateEventMethod,
     rpcMethodDetailsByMethodName: Map<string, RegisteredRpcMethodDetails>,
+    rpcEventDetailsByEventName: IRpcEventRegistry,
   ) {
     bindClassMethods.call(this);
     this.name = name;
@@ -77,9 +88,12 @@ export class RpcServer implements IRpcHandler {
       this.createNextRequestId,
     );
     this.rpcMethodDetailsByMethodName = rpcMethodDetailsByMethodName;
+    this.rpcEventDetailsByEventName = rpcEventDetailsByEventName;
 
     this.addMethodToRpcServer(REGISTER_METHOD, this.registerRemoteMethod);
     this.addMethodToRpcServer(UNREGISTER_METHOD, this.unregisterRemoteMethod);
+    this.addMethodToRpcServer(REGISTER_EVENT, this.registerRemoteEvent);
+    this.addMethodToRpcServer(UNREGISTER_EVENT, this.unregisterRemoteEvent);
   }
 
   async connect(): Promise<boolean> {
@@ -161,6 +175,14 @@ export class RpcServer implements IRpcHandler {
     return handlersMatch;
   }
 
+  registerRemoteEvent(eventName: string, documentation?: SingleNotificationDocumentation): boolean {
+    return this.rpcEventDetailsByEventName.tryRegister(this, eventName, documentation);
+  }
+
+  unregisterRemoteEvent(eventName: string): boolean {
+    return this.rpcEventDetailsByEventName.tryUnregister(this, eventName);
+  }
+
   private createNextRequestId(): number {
     const retVal = this.requestId;
     this.requestId += 1;
@@ -207,6 +229,7 @@ export class RpcServer implements IRpcHandler {
       logger.debug(`Method '${methodName}' removed since websocket ${this.name} closed`);
       this.rpcMethodDetailsByMethodName.delete(methodName);
     });
+    this.rpcEventDetailsByEventName.unregisterAll(this);
   }
 
   private onWebSocketError(ev: Event): void {

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -330,6 +330,10 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
       // arrives as untyped JSON over the websocket, so without this a client could list its event
       // under a different name.
       notificationEntry.name = eventName;
+      // A notification is identified by having no `result`; strip any `result` smuggled in over the
+      // websocket so an event can't masquerade as a method.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      delete (notificationEntry as { result?: unknown }).result;
       // Mark it as a notification — OpenRPC lists notifications alongside methods, so the
       // `(Notification) ` summary prefix distinguishes them. Then prepend the experimental prefix
       // ([EXPERIMENTAL] ) to the summary/description when the event is experimental.

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -23,6 +23,7 @@ import {
   OpenRpc,
   SingleMethodDocumentation,
   SingleNotificationDocumentation,
+  withExperimentalPrefix,
 } from '@shared/models/openrpc.model';
 import { getErrorMessage, Mutex } from 'platform-bible-utils';
 import { WebSocketServer } from 'ws';
@@ -264,7 +265,8 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
         const newDocs = { name: methodName, ...details.methodDocs.method };
         // Overwrite the name with `methodName` in case `details.methodDocs.method` included a name
         newDocs.name = methodName;
-        openRpcSchema.methods.push(newDocs);
+        // Prepend "EXPERIMENTAL: " to the summary/description when the method is experimental.
+        openRpcSchema.methods.push(withExperimentalPrefix(newDocs));
         if (details.methodDocs.components) {
           openRpcSchema.components = {
             schemas: {
@@ -310,7 +312,8 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
       const notificationEntry: Notification = docs
         ? { name: eventName, ...docs.notification }
         : { name: eventName, ...getEmptyNotificationDocs() };
-      openRpcSchema.methods.push(notificationEntry);
+      // Prepend "EXPERIMENTAL: " to the summary/description when the event is experimental.
+      openRpcSchema.methods.push(withExperimentalPrefix(notificationEntry));
 
       if (docs?.components) {
         openRpcSchema.components = {

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -18,6 +18,7 @@ import { IRpcMethodRegistrar, RegisteredRpcMethodDetails } from '@shared/models/
 import {
   createEmptyOpenRpc,
   getEmptyMethodDocs,
+  getEmptyNotificationDocs,
   Notification,
   OpenRpc,
   SingleMethodDocumentation,
@@ -303,16 +304,15 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
     Array.from(this.rpcEventDetailsByEventName.entries()).forEach(([eventName, registrants]) => {
       // First registration's documentation wins (matches the conflict policy).
       const docs = registrants.find((r) => r.documentation)?.documentation;
-      // Events with no documentation are not surfaced in OpenRPC
-      if (!docs) return;
-
-      const notificationEntry: Notification = {
-        name: eventName,
-        ...docs.notification,
-      };
+      // Surface every registered event, mirroring how undocumented methods are surfaced above:
+      // events without their own documentation get a placeholder entry so the OpenRPC document
+      // lists all events, not just documented ones.
+      const notificationEntry: Notification = docs
+        ? { name: eventName, ...docs.notification }
+        : { name: eventName, ...getEmptyNotificationDocs() };
       openRpcSchema.methods.push(notificationEntry);
 
-      if (docs.components) {
+      if (docs?.components) {
         openRpcSchema.components = {
           schemas: {
             ...docs.components.schemas,

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -57,6 +57,17 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
   private readonly rpcMethodDetailsByMethodName = new Map<string, RegisteredRpcMethodDetails>();
   private readonly localMethodsByMethodName = new Map<string, InternalRequestHandler>();
   private readonly rpcEventDetailsByEventName = new RpcEventRegistry();
+  /**
+   * Event names we've already warned about being announced while unregistered. Deduped so a
+   * high-frequency unregistered event does not flood the log — the deprecation notice only needs to
+   * be surfaced once per event name.
+   */
+  private readonly warnedUnregisteredAnnouncements = new Set<string>();
+  /**
+   * Event names we've already warned about being announced from a process that did not register the
+   * single-source event. Deduped for the same reason as {@link warnedUnregisteredAnnouncements}.
+   */
+  private readonly warnedForeignAnnouncements = new Set<string>();
 
   constructor() {
     bindClassMethods.call(this);
@@ -350,6 +361,8 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
   }
 
   emitEventOnNetwork<T>(eventType: string, event: T): void {
+    // Main is announcing one of its own events; `this` is the handler the event was registered under.
+    this.warnIfInvalidEventAnnouncement(this, eventType);
     // Wrap each subscriber's emit in try/catch so one broken socket cannot abort the
     // broadcast to the remaining (healthy) subscribers. See D-010: `write EPIPE`
     // unhandled exception during multi-webview scroll-group fan-out.
@@ -368,6 +381,8 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
   private propagateEvent<T>(source: RpcServer, eventType: string, event: T): void {
     if (!this.localEventHandler) throw new Error(`localEventHandler not set`);
     if (!Array.isArray(event) || event.length !== 1) throw new Error(`event not wrapped in array`);
+    // A client (`source`) is announcing this event; validate the announcement against the registry.
+    this.warnIfInvalidEventAnnouncement(source, eventType);
     this.localEventHandler(eventType, event[0]);
     this.rpcServerBySocket.forEach((rpcServer) => {
       if (rpcServer === source) return;
@@ -380,6 +395,43 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
         );
       }
     });
+  }
+
+  /**
+   * Warn (once per event name) when an event is announced (emitted) on the network that the central
+   * registry would flag as misuse:
+   *
+   * - The event is single-source and was never registered centrally — emitting an unregistered event
+   *   is deprecated and the ability to do so will be removed in a future release.
+   * - The event is single-source but is being announced from a process that did not register it,
+   *   which is also deprecated.
+   *
+   * Announcements are never blocked; this only surfaces a warning to help authors migrate to
+   * `createNetworkEventEmitterAsync` or `createCoreMultiSourceEventEmitter` for core code.
+   *
+   * @param handler The handler announcing the event (an {@link RpcServer} for a client, or `this`
+   *   for main's own emissions).
+   * @param eventType The event name being announced.
+   */
+  private warnIfInvalidEventAnnouncement(handler: unknown, eventType: string): void {
+    const status = this.rpcEventDetailsByEventName.checkAnnouncement(handler, eventType);
+    if (status === 'ok') return;
+
+    if (status === 'unregistered') {
+      if (this.warnedUnregisteredAnnouncements.has(eventType)) return;
+      this.warnedUnregisteredAnnouncements.add(eventType);
+      logger.warn(
+        `Network event '${eventType}' was announced but is not registered with the central registry. Announcing unregistered network events is deprecated as of 12 June 2026 and will be removed in a future release; create the emitter with createNetworkEventEmitterAsync.`,
+      );
+      return;
+    }
+
+    // status === 'foreign-single-source'
+    if (this.warnedForeignAnnouncements.has(eventType)) return;
+    this.warnedForeignAnnouncements.add(eventType);
+    logger.warn(
+      `Single-source network event '${eventType}' was announced from a process that did not register it. Announcing a single-source event from a different process is deprecated as of 12 June 2026; only the process that registered the event should announce it.`,
+    );
   }
 
   private onClientConnect(webSocket: WebSocket): void {

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -15,90 +15,24 @@ import {
   WEBSOCKET_PORT,
 } from '@shared/data/rpc.model';
 import { IRpcMethodRegistrar, RegisteredRpcMethodDetails } from '@shared/models/rpc.interface';
-import { SingleNotificationDocumentation } from '@shared/models/openrpc.model';
-import { MULTI_SOURCE_EVENT_NAMES } from '@shared/services/network.service';
-import type { MultiSourceNetworkEvents } from 'papi-shared-types';
-import { getErrorMessage, Mutex } from 'platform-bible-utils';
-import { WebSocketServer } from 'ws';
-import { logger } from '@shared/services/logger.service';
-import { JSONRPCErrorCode, JSONRPCResponse } from 'json-rpc-2.0';
-import { bindClassMethods, SerializedRequestType } from '@shared/utils/util';
 import {
   createEmptyOpenRpc,
   getEmptyMethodDocs,
   Notification,
   OpenRpc,
   SingleMethodDocumentation,
+  SingleNotificationDocumentation,
 } from '@shared/models/openrpc.model';
+import { getErrorMessage, Mutex } from 'platform-bible-utils';
+import { WebSocketServer } from 'ws';
+import { logger } from '@shared/services/logger.service';
+import { JSONRPCErrorCode, JSONRPCResponse } from 'json-rpc-2.0';
+import { bindClassMethods, SerializedRequestType } from '@shared/utils/util';
 import { RpcServer } from './rpc-server';
+// RpcEventRegistry was extracted to its own file to satisfy max-classes-per-file
+import { RpcEventRegistry } from './rpc-event-registry';
 
-interface EventRegistrant {
-  handler: unknown;
-  documentation?: SingleNotificationDocumentation;
-}
-
-/**
- * Tracks registered network event emitters, enforcing shared vs. exclusive ownership policy.
- *
- * @internal Exported for unit-testing only; not part of the public API.
- */
-export class RpcEventRegistry {
-  private byName = new Map<string, EventRegistrant[]>();
-
-  /**
-   * Try to register an event. Returns `true` if accepted, `false` if rejected.
-   *
-   * - Name in `MULTI_SOURCE_EVENT_NAMES` (multi-source): multiple handlers may register; same handler
-   *   twice rejected.
-   * - Name not in `MULTI_SOURCE_EVENT_NAMES` (single-source): first registrant wins; any subsequent
-   *   registration from any handler is rejected.
-   */
-  tryRegister(
-    handler: unknown,
-    eventName: string,
-    documentation?: SingleNotificationDocumentation,
-  ): boolean {
-    const isMultiSource = MULTI_SOURCE_EVENT_NAMES.has(eventName as keyof MultiSourceNetworkEvents);
-    const existing = this.byName.get(eventName);
-
-    if (!existing) {
-      this.byName.set(eventName, [{ handler, documentation }]);
-      return true;
-    }
-
-    if (isMultiSource) {
-      if (existing.some((r) => r.handler === handler)) return false;
-      existing.push({ handler, documentation });
-      return true;
-    }
-
-    return false;
-  }
-
-  /** Remove a registrant. Returns `true` if the handler had registered this event. */
-  tryUnregister(handler: unknown, eventName: string): boolean {
-    const existing = this.byName.get(eventName);
-    if (!existing) return false;
-    const index = existing.findIndex((r) => r.handler === handler);
-    if (index < 0) return false;
-    existing.splice(index, 1);
-    if (existing.length === 0) this.byName.delete(eventName);
-    return true;
-  }
-
-  /** Remove all event registrations for the given handler (e.g. when a websocket closes) */
-  unregisterAll(handler: unknown): void {
-    this.byName.forEach((registrants, eventName) => {
-      const filtered = registrants.filter((r) => r.handler !== handler);
-      if (filtered.length === 0) this.byName.delete(eventName);
-      else this.byName.set(eventName, filtered);
-    });
-  }
-
-  entries(): IterableIterator<[string, EventRegistrant[]]> {
-    return this.byName.entries();
-  }
-}
+export { RpcEventRegistry };
 
 /**
  * Owns the WebSocketServer that listens for clients to connect to the web socket. When a client
@@ -365,10 +299,12 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
         });
       }
     });
-    for (const [eventName, registrants] of this.rpcEventDetailsByEventName.entries()) {
+    // Convert the entries iterator to an array so we can use .forEach() (avoids for-of + continue)
+    Array.from(this.rpcEventDetailsByEventName.entries()).forEach(([eventName, registrants]) => {
       // First registration's documentation wins (matches the conflict policy).
       const docs = registrants.find((r) => r.documentation)?.documentation;
-      if (!docs) continue; // events with no documentation are not surfaced in OpenRPC
+      // Events with no documentation are not surfaced in OpenRPC
+      if (!docs) return;
 
       const notificationEntry: Notification = {
         name: eventName,
@@ -404,7 +340,7 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
           },
         };
       }
-    }
+    });
     openRpcSchema.methods.sort((a, b) => a.name.localeCompare(b.name));
     return openRpcSchema;
   }

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -16,8 +16,8 @@ import {
 } from '@shared/data/rpc.model';
 import { IRpcMethodRegistrar, RegisteredRpcMethodDetails } from '@shared/models/rpc.interface';
 import { SingleNotificationDocumentation } from '@shared/models/openrpc.model';
-import { SHARED_EVENT_NAMES } from '@shared/services/network.service';
-import type { SharedNetworkEventTypes } from 'papi-shared-types';
+import { MULTI_SOURCE_EVENT_NAMES } from '@shared/services/network.service';
+import type { MultiSourceNetworkEvents } from 'papi-shared-types';
 import { getErrorMessage, Mutex } from 'platform-bible-utils';
 import { WebSocketServer } from 'ws';
 import { logger } from '@shared/services/logger.service';
@@ -26,8 +26,8 @@ import { bindClassMethods, SerializedRequestType } from '@shared/utils/util';
 import {
   createEmptyOpenRpc,
   getEmptyMethodDocs,
+  Notification,
   OpenRpc,
-  OpenRpcNotification,
   SingleMethodDocumentation,
 } from '@shared/models/openrpc.model';
 import { RpcServer } from './rpc-server';
@@ -48,9 +48,9 @@ export class RpcEventRegistry {
   /**
    * Try to register an event. Returns `true` if accepted, `false` if rejected.
    *
-   * - Name in `SHARED_EVENT_NAMES` (shared): multiple handlers may register; same handler twice
-   *   rejected.
-   * - Name not in `SHARED_EVENT_NAMES` (exclusive): first registrant wins; any subsequent
+   * - Name in `MULTI_SOURCE_EVENT_NAMES` (multi-source): multiple handlers may register; same handler
+   *   twice rejected.
+   * - Name not in `MULTI_SOURCE_EVENT_NAMES` (single-source): first registrant wins; any subsequent
    *   registration from any handler is rejected.
    */
   tryRegister(
@@ -58,7 +58,7 @@ export class RpcEventRegistry {
     eventName: string,
     documentation?: SingleNotificationDocumentation,
   ): boolean {
-    const isShared = SHARED_EVENT_NAMES.has(eventName as keyof SharedNetworkEventTypes);
+    const isMultiSource = MULTI_SOURCE_EVENT_NAMES.has(eventName as keyof MultiSourceNetworkEvents);
     const existing = this.byName.get(eventName);
 
     if (!existing) {
@@ -66,7 +66,7 @@ export class RpcEventRegistry {
       return true;
     }
 
-    if (isShared) {
+    if (isMultiSource) {
       if (existing.some((r) => r.handler === handler)) return false;
       existing.push({ handler, documentation });
       return true;
@@ -370,7 +370,7 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
       const docs = registrants.find((r) => r.documentation)?.documentation;
       if (!docs) continue; // events with no documentation are not surfaced in OpenRPC
 
-      const notificationEntry: OpenRpcNotification = {
+      const notificationEntry: Notification = {
         name: eventName,
         ...docs.notification,
       };

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -6,13 +6,18 @@ import {
   EventHandler,
   GET_METHODS,
   InternalRequestHandler,
+  REGISTER_EVENT,
   REGISTER_METHOD,
   RequestParams,
   requestWithRetry,
+  UNREGISTER_EVENT,
   UNREGISTER_METHOD,
   WEBSOCKET_PORT,
 } from '@shared/data/rpc.model';
 import { IRpcMethodRegistrar, RegisteredRpcMethodDetails } from '@shared/models/rpc.interface';
+import { SingleNotificationDocumentation } from '@shared/models/openrpc.model';
+import { SHARED_EVENT_NAMES } from '@shared/services/network.service';
+import type { SharedNetworkEventTypes } from 'papi-shared-types';
 import { getErrorMessage, Mutex } from 'platform-bible-utils';
 import { WebSocketServer } from 'ws';
 import { logger } from '@shared/services/logger.service';
@@ -25,6 +30,74 @@ import {
   SingleMethodDocumentation,
 } from '@shared/models/openrpc.model';
 import { RpcServer } from './rpc-server';
+
+interface EventRegistrant {
+  handler: unknown;
+  documentation?: SingleNotificationDocumentation;
+}
+
+/**
+ * Tracks registered network event emitters, enforcing shared vs. exclusive ownership policy.
+ *
+ * @internal Exported for unit-testing only; not part of the public API.
+ */
+export class RpcEventRegistry {
+  private byName = new Map<string, EventRegistrant[]>();
+
+  /**
+   * Try to register an event. Returns `true` if accepted, `false` if rejected.
+   *
+   * - Name in `SHARED_EVENT_NAMES` (shared): multiple handlers may register; same handler twice
+   *   rejected.
+   * - Name not in `SHARED_EVENT_NAMES` (exclusive): first registrant wins; any subsequent
+   *   registration from any handler is rejected.
+   */
+  tryRegister(
+    handler: unknown,
+    eventName: string,
+    documentation?: SingleNotificationDocumentation,
+  ): boolean {
+    const isShared = SHARED_EVENT_NAMES.has(eventName as keyof SharedNetworkEventTypes);
+    const existing = this.byName.get(eventName);
+
+    if (!existing) {
+      this.byName.set(eventName, [{ handler, documentation }]);
+      return true;
+    }
+
+    if (isShared) {
+      if (existing.some((r) => r.handler === handler)) return false;
+      existing.push({ handler, documentation });
+      return true;
+    }
+
+    return false;
+  }
+
+  /** Remove a registrant. Returns `true` if the handler had registered this event. */
+  tryUnregister(handler: unknown, eventName: string): boolean {
+    const existing = this.byName.get(eventName);
+    if (!existing) return false;
+    const index = existing.findIndex((r) => r.handler === handler);
+    if (index < 0) return false;
+    existing.splice(index, 1);
+    if (existing.length === 0) this.byName.delete(eventName);
+    return true;
+  }
+
+  /** Remove all event registrations for the given handler (e.g. when a websocket closes) */
+  unregisterAll(handler: unknown): void {
+    this.byName.forEach((registrants, eventName) => {
+      const filtered = registrants.filter((r) => r.handler !== handler);
+      if (filtered.length === 0) this.byName.delete(eventName);
+      else this.byName.set(eventName, filtered);
+    });
+  }
+
+  entries(): IterableIterator<[string, EventRegistrant[]]> {
+    return this.byName.entries();
+  }
+}
 
 /**
  * Owns the WebSocketServer that listens for clients to connect to the web socket. When a client
@@ -46,6 +119,7 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
   private readonly rpcServerBySocket = new Map<WebSocket, RpcServer>();
   private readonly rpcMethodDetailsByMethodName = new Map<string, RegisteredRpcMethodDetails>();
   private readonly localMethodsByMethodName = new Map<string, InternalRequestHandler>();
+  private readonly rpcEventDetailsByEventName = new RpcEventRegistry();
 
   constructor() {
     bindClassMethods.call(this);
@@ -154,6 +228,17 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
     return true;
   }
 
+  async registerEvent(
+    eventName: string,
+    documentation?: SingleNotificationDocumentation,
+  ): Promise<boolean> {
+    return this.rpcEventDetailsByEventName.tryRegister(this, eventName, documentation);
+  }
+
+  async unregisterEvent(eventName: string): Promise<boolean> {
+    return this.rpcEventDetailsByEventName.tryUnregister(this, eventName);
+  }
+
   generateOpenRpcSchema(): OpenRpc {
     const openRpcSchema = createEmptyOpenRpc(app.getVersion());
     openRpcSchema.methods = [
@@ -194,6 +279,46 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
         result: {
           name: 'return value',
           summary: 'Whether the method was successfully unregistered',
+          schema: { type: 'boolean' },
+        },
+      },
+      {
+        name: REGISTER_EVENT,
+        summary: 'Register a network event emitter with the main process',
+        params: [
+          {
+            name: 'eventName',
+            required: true,
+            summary: 'Name of the event to register',
+            schema: { type: 'string' },
+          },
+          {
+            name: 'documentation',
+            required: false,
+            summary: 'Documentation for the event in OpenRPC notification format',
+            schema: { type: 'object' },
+          },
+        ],
+        result: {
+          name: 'return value',
+          summary: 'Whether the event was successfully registered',
+          schema: { type: 'boolean' },
+        },
+      },
+      {
+        name: UNREGISTER_EVENT,
+        summary: 'Unregister a network event emitter from the main process',
+        params: [
+          {
+            name: 'eventName',
+            required: true,
+            summary: 'Name of the event to unregister',
+            schema: { type: 'string' },
+          },
+        ],
+        result: {
+          name: 'return value',
+          summary: 'Whether the event was successfully unregistered',
           schema: { type: 'boolean' },
         },
       },
@@ -282,6 +407,7 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
       webSocket,
       this.propagateEvent,
       this.rpcMethodDetailsByMethodName,
+      this.rpcEventDetailsByEventName,
     );
     rpcServer.connect();
     this.rpcServerBySocket.set(webSocket, rpcServer);

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -164,6 +164,17 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
     )
       return false;
 
+    // A method and a network event (notification) must not share a name: both surface in the OpenRPC
+    // document's `methods` array, where names must be unique. By convention events are `on*`-prefixed
+    // and methods are not, so this realistically never collides — reject loudly if it somehow does
+    // rather than emit a malformed document.
+    if (this.rpcEventDetailsByEventName.has(methodName)) {
+      logger.warn(
+        `Cannot register method "${methodName}": a network event (notification) with this name is already registered. Method and notification names must be unique across both.`,
+      );
+      return false;
+    }
+
     this.rpcMethodDetailsByMethodName.set(methodName, { handler: this, methodDocs });
     this.localMethodsByMethodName.set(methodName, method);
     return true;
@@ -181,6 +192,17 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
     eventName: string,
     documentation?: SingleNotificationDocumentation,
   ): Promise<boolean> {
+    // Mirror of registerMethod's cross-kind guard: a network event must not share a name with a
+    // method, since both land in the OpenRPC `methods` array where names must be unique.
+    if (
+      this.rpcMethodDetailsByMethodName.has(eventName) ||
+      this.localMethodsByMethodName.has(eventName)
+    ) {
+      logger.warn(
+        `Cannot register network event "${eventName}": a method with this name is already registered. Method and notification names must be unique across both.`,
+      );
+      return false;
+    }
     return this.rpcEventDetailsByEventName.tryRegister(this, eventName, documentation);
   }
 

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -19,11 +19,12 @@ import {
   createEmptyOpenRpc,
   getEmptyMethodDocs,
   getEmptyNotificationDocs,
-  Notification,
+  OpenRpcNotification,
   OpenRpc,
   SingleMethodDocumentation,
   SingleNotificationDocumentation,
   withExperimentalPrefix,
+  withNotificationPrefix,
 } from '@shared/models/openrpc.model';
 import { getErrorMessage, Mutex } from 'platform-bible-utils';
 import { WebSocketServer } from 'ws';
@@ -322,16 +323,17 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
       // Surface every registered event, mirroring how undocumented methods are surfaced above:
       // events without their own documentation get a placeholder entry so the OpenRPC document
       // lists all events, not just documented ones.
-      const notificationEntry: Notification = docs
+      const notificationEntry: OpenRpcNotification = docs
         ? { name: eventName, ...docs.notification }
         : { name: eventName, ...getEmptyNotificationDocs() };
       // Overwrite the name after the spread (mirrors the method path above). `docs.notification`
       // arrives as untyped JSON over the websocket, so without this a client could list its event
       // under a different name.
       notificationEntry.name = eventName;
-      // Prepend the experimental prefix ([EXPERIMENTAL] ) to the summary/description when the event
-      // is experimental.
-      openRpcSchema.methods.push(withExperimentalPrefix(notificationEntry));
+      // Mark it as a notification — OpenRPC lists notifications alongside methods, so the
+      // `(Notification) ` summary prefix distinguishes them. Then prepend the experimental prefix
+      // ([EXPERIMENTAL] ) to the summary/description when the event is experimental.
+      openRpcSchema.methods.push(withNotificationPrefix(withExperimentalPrefix(notificationEntry)));
 
       if (docs?.components) {
         openRpcSchema.components = {

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -276,7 +276,8 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
         const newDocs = { name: methodName, ...details.methodDocs.method };
         // Overwrite the name with `methodName` in case `details.methodDocs.method` included a name
         newDocs.name = methodName;
-        // Prepend "EXPERIMENTAL: " to the summary/description when the method is experimental.
+        // Prepend the experimental prefix ([EXPERIMENTAL] ) to the summary/description when the
+        // method is experimental.
         openRpcSchema.methods.push(withExperimentalPrefix(newDocs));
         if (details.methodDocs.components) {
           openRpcSchema.components = {
@@ -324,7 +325,12 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
       const notificationEntry: Notification = docs
         ? { name: eventName, ...docs.notification }
         : { name: eventName, ...getEmptyNotificationDocs() };
-      // Prepend "EXPERIMENTAL: " to the summary/description when the event is experimental.
+      // Overwrite the name after the spread (mirrors the method path above). `docs.notification`
+      // arrives as untyped JSON over the websocket, so without this a client could list its event
+      // under a different name.
+      notificationEntry.name = eventName;
+      // Prepend the experimental prefix ([EXPERIMENTAL] ) to the summary/description when the event
+      // is experimental.
       openRpcSchema.methods.push(withExperimentalPrefix(notificationEntry));
 
       if (docs?.components) {

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -296,10 +296,11 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
           };
         }
       } else {
-        openRpcSchema.methods.push({
-          name: methodName,
-          ...getEmptyMethodDocs(),
-        });
+        // Wrap the placeholder too (a no-op unless experimental) so methods and events handle the
+        // experimental prefix consistently regardless of whether docs were provided.
+        openRpcSchema.methods.push(
+          withExperimentalPrefix({ name: methodName, ...getEmptyMethodDocs() }),
+        );
       }
     });
     // Convert the entries iterator to an array so we can use .forEach() (avoids for-of + continue)

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -27,6 +27,7 @@ import {
   createEmptyOpenRpc,
   getEmptyMethodDocs,
   OpenRpc,
+  OpenRpcNotification,
   SingleMethodDocumentation,
 } from '@shared/models/openrpc.model';
 import { RpcServer } from './rpc-server';
@@ -364,6 +365,46 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
         });
       }
     });
+    for (const [eventName, registrants] of this.rpcEventDetailsByEventName.entries()) {
+      // First registration's documentation wins (matches the conflict policy).
+      const docs = registrants.find((r) => r.documentation)?.documentation;
+      if (!docs) continue; // events with no documentation are not surfaced in OpenRPC
+
+      const notificationEntry: OpenRpcNotification = {
+        name: eventName,
+        ...docs.notification,
+      };
+      openRpcSchema.methods.push(notificationEntry);
+
+      if (docs.components) {
+        openRpcSchema.components = {
+          schemas: {
+            ...docs.components.schemas,
+            ...openRpcSchema.components?.schemas,
+          },
+          contentDescriptors: {
+            ...docs.components.contentDescriptors,
+            ...openRpcSchema.components?.contentDescriptors,
+          },
+          examples: {
+            ...docs.components.examples,
+            ...openRpcSchema.components?.examples,
+          },
+          links: {
+            ...docs.components.links,
+            ...openRpcSchema.components?.links,
+          },
+          errors: {
+            ...docs.components.errors,
+            ...openRpcSchema.components?.errors,
+          },
+          tags: {
+            ...docs.components.tags,
+            ...openRpcSchema.components?.tags,
+          },
+        };
+      }
+    }
     openRpcSchema.methods.sort((a, b) => a.name.localeCompare(b.name));
     return openRpcSchema;
   }

--- a/src/renderer/app.component.test.tsx
+++ b/src/renderer/app.component.test.tsx
@@ -26,8 +26,14 @@ vi.mock('@shared/services/network.service', async (importOriginal) => {
     createNetworkEventEmitter: () => {
       return new PlatformEventEmitter();
     },
+    createNetworkEventEmitterAsync: async () => {
+      return new PlatformEventEmitter();
+    },
     papiNetworkService: {
       createNetworkEventEmitter: () => {
+        return new PlatformEventEmitter();
+      },
+      createNetworkEventEmitterAsync: async () => {
         return new PlatformEventEmitter();
       },
       onDidClientConnect: new PlatformEventEmitter().event,

--- a/src/renderer/services/scroll-group.service-host.ts
+++ b/src/renderer/services/scroll-group.service-host.ts
@@ -145,7 +145,22 @@ const scrollGroupService: IScrollGroupRemoteService = {
 
 /** Register the network object that backs the scroll group service */
 export async function startScrollGroupService(): Promise<void> {
-  onDidUpdateScrRefEmitter = await createNetworkEventEmitterAsync(EVENT_NAME_ON_DID_UPDATE_SCR_REF);
+  onDidUpdateScrRefEmitter = await createNetworkEventEmitterAsync(
+    EVENT_NAME_ON_DID_UPDATE_SCR_REF,
+    {
+      notification: {
+        summary: 'Emitted when the Scripture reference for a scroll group changes.',
+        params: [
+          {
+            name: 'update',
+            required: true,
+            summary: 'The scroll group and its new Scripture reference.',
+            schema: { type: 'object' },
+          },
+        ],
+      },
+    },
+  );
 
   await networkObjectService.set(NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE, scrollGroupService);
 

--- a/src/renderer/services/scroll-group.service-host.ts
+++ b/src/renderer/services/scroll-group.service-host.ts
@@ -61,6 +61,16 @@ function saveScrRefs() {
 let onDidUpdateScrRefEmitter: PlatformEventEmitter<ScrollGroupUpdateInfo> | undefined;
 
 /**
+ * Subscribers that called `onDidUpdateScrRef` before the emitter was created. They get bound to the
+ * real emitter inside `startScrollGroupService` and removed from this list.
+ */
+const pendingOnDidUpdateScrRefSubscribers: {
+  callback: (event: ScrollGroupUpdateInfo) => void;
+  realUnsub?: () => boolean;
+  disposed: boolean;
+}[] = [];
+
+/**
  * All Scroll Group IDs that are intended to be shown in scroll group selectors. This is a
  * placeholder and will be refactored significantly in
  * https://github.com/paranext/paranext-core/issues/788
@@ -69,11 +79,20 @@ export const availableScrollGroupIds = [undefined, ...Array(5).keys()];
 
 /** Event that emits with information about a changed Scripture Reference for a scroll group */
 export const onDidUpdateScrRef: PlatformEvent<ScrollGroupUpdateInfo> = (callback) => {
-  if (!onDidUpdateScrRefEmitter)
-    throw new Error(
-      'scroll-group.service-host not initialized — call startScrollGroupService() before subscribing to onDidUpdateScrRef',
-    );
-  return onDidUpdateScrRefEmitter.event(callback);
+  if (onDidUpdateScrRefEmitter) return onDidUpdateScrRefEmitter.event(callback);
+
+  const entry: (typeof pendingOnDidUpdateScrRefSubscribers)[number] = {
+    callback,
+    disposed: false,
+  };
+  pendingOnDidUpdateScrRefSubscribers.push(entry);
+  return () => {
+    entry.disposed = true;
+    if (entry.realUnsub) return entry.realUnsub();
+    const i = pendingOnDidUpdateScrRefSubscribers.indexOf(entry);
+    if (i >= 0) pendingOnDidUpdateScrRefSubscribers.splice(i, 1);
+    return true;
+  };
 };
 
 /** See {@link IScrollGroupRemoteService.getScrRef} */
@@ -154,6 +173,14 @@ export async function startScrollGroupService(): Promise<void> {
   onDidUpdateScrRefEmitter = await createNetworkEventEmitterAsync(
     EVENT_NAME_ON_DID_UPDATE_SCR_REF as 'scrollGroup:onDidUpdateScrRef',
   );
+
+  // Drain any subscribers that registered before the emitter existed.
+  while (pendingOnDidUpdateScrRefSubscribers.length > 0) {
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    const entry = pendingOnDidUpdateScrRefSubscribers.shift()!;
+    if (entry.disposed) continue;
+    entry.realUnsub = onDidUpdateScrRefEmitter.event(entry.callback);
+  }
 
   await networkObjectService.set(NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE, scrollGroupService);
 

--- a/src/renderer/services/scroll-group.service-host.ts
+++ b/src/renderer/services/scroll-group.service-host.ts
@@ -1,6 +1,6 @@
 import { logger } from '@shared/services/logger.service';
 import { networkObjectService } from '@shared/services/network-object.service';
-import { createNetworkEventEmitterAsync } from '@shared/services/network.service';
+import { createNetworkEventEmitterAsync, getNetworkEvent } from '@shared/services/network.service';
 import {
   EVENT_NAME_ON_DID_UPDATE_SCR_REF,
   IScrollGroupRemoteService,
@@ -14,7 +14,6 @@ import {
   deepClone,
   deserialize,
   isPlatformError,
-  type PlatformEvent,
   type PlatformEventEmitter,
   ScrollGroupId,
   serialize,
@@ -61,16 +60,6 @@ function saveScrRefs() {
 let onDidUpdateScrRefEmitter: PlatformEventEmitter<ScrollGroupUpdateInfo> | undefined;
 
 /**
- * Subscribers that called `onDidUpdateScrRef` before the emitter was created. They get bound to the
- * real emitter inside `startScrollGroupService` and removed from this list.
- */
-const pendingOnDidUpdateScrRefSubscribers: {
-  callback: (event: ScrollGroupUpdateInfo) => void;
-  realUnsub?: () => boolean;
-  disposed: boolean;
-}[] = [];
-
-/**
  * All Scroll Group IDs that are intended to be shown in scroll group selectors. This is a
  * placeholder and will be refactored significantly in
  * https://github.com/paranext/paranext-core/issues/788
@@ -78,22 +67,11 @@ const pendingOnDidUpdateScrRefSubscribers: {
 export const availableScrollGroupIds = [undefined, ...Array(5).keys()];
 
 /** Event that emits with information about a changed Scripture Reference for a scroll group */
-export const onDidUpdateScrRef: PlatformEvent<ScrollGroupUpdateInfo> = (callback) => {
-  if (onDidUpdateScrRefEmitter) return onDidUpdateScrRefEmitter.event(callback);
-
-  const entry: (typeof pendingOnDidUpdateScrRefSubscribers)[number] = {
-    callback,
-    disposed: false,
-  };
-  pendingOnDidUpdateScrRefSubscribers.push(entry);
-  return () => {
-    entry.disposed = true;
-    if (entry.realUnsub) return entry.realUnsub();
-    const i = pendingOnDidUpdateScrRefSubscribers.indexOf(entry);
-    if (i >= 0) pendingOnDidUpdateScrRefSubscribers.splice(i, 1);
-    return true;
-  };
-};
+export const onDidUpdateScrRef = getNetworkEvent(
+  // serializeRequestType returns SerializedRequestType, not a literal — cast to match the registry key
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  EVENT_NAME_ON_DID_UPDATE_SCR_REF as 'scrollGroup:onDidUpdateScrRef',
+);
 
 /** See {@link IScrollGroupRemoteService.getScrRef} */
 export function getScrRefSync(scrollGroupId: ScrollGroupId = 0): SerializedVerseRef {
@@ -173,14 +151,6 @@ export async function startScrollGroupService(): Promise<void> {
   onDidUpdateScrRefEmitter = await createNetworkEventEmitterAsync(
     EVENT_NAME_ON_DID_UPDATE_SCR_REF as 'scrollGroup:onDidUpdateScrRef',
   );
-
-  // Drain any subscribers that registered before the emitter existed.
-  while (pendingOnDidUpdateScrRefSubscribers.length > 0) {
-    // eslint-disable-next-line no-type-assertion/no-type-assertion
-    const entry = pendingOnDidUpdateScrRefSubscribers.shift()!;
-    if (entry.disposed) continue;
-    entry.realUnsub = onDidUpdateScrRefEmitter.event(entry.callback);
-  }
 
   await networkObjectService.set(NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE, scrollGroupService);
 

--- a/src/renderer/services/scroll-group.service-host.ts
+++ b/src/renderer/services/scroll-group.service-host.ts
@@ -169,8 +169,6 @@ const scrollGroupService: IScrollGroupRemoteService = {
 
 /** Register the network object that backs the scroll group service */
 export async function startScrollGroupService(): Promise<void> {
-  // The `onDidUpdateScrRef` emitter is created at module load (buffered), so there's nothing to set
-  // up for it here.
   await networkObjectService.set(NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE, scrollGroupService);
 
   // Keep scroll group 0 in sync with the verse ref setting for backwards compatibility

--- a/src/renderer/services/scroll-group.service-host.ts
+++ b/src/renderer/services/scroll-group.service-host.ts
@@ -14,6 +14,7 @@ import {
   deepClone,
   deserialize,
   isPlatformError,
+  type PlatformEvent,
   type PlatformEventEmitter,
   ScrollGroupId,
   serialize,
@@ -67,10 +68,8 @@ let onDidUpdateScrRefEmitter: PlatformEventEmitter<ScrollGroupUpdateInfo> | unde
 export const availableScrollGroupIds = [undefined, ...Array(5).keys()];
 
 /** Event that emits with information about a changed Scripture Reference for a scroll group */
-export const onDidUpdateScrRef = getNetworkEvent(
-  // serializeRequestType returns SerializedRequestType, not a literal — cast to match the registry key
-  // eslint-disable-next-line no-type-assertion/no-type-assertion
-  EVENT_NAME_ON_DID_UPDATE_SCR_REF as 'scrollGroup:onDidUpdateScrRef',
+export const onDidUpdateScrRef: PlatformEvent<ScrollGroupUpdateInfo> = getNetworkEvent(
+  EVENT_NAME_ON_DID_UPDATE_SCR_REF,
 );
 
 /** See {@link IScrollGroupRemoteService.getScrRef} */
@@ -146,11 +145,7 @@ const scrollGroupService: IScrollGroupRemoteService = {
 
 /** Register the network object that backs the scroll group service */
 export async function startScrollGroupService(): Promise<void> {
-  // serializeRequestType returns SerializedRequestType, not a string literal — cast needed
-  // eslint-disable-next-line no-type-assertion/no-type-assertion
-  onDidUpdateScrRefEmitter = await createNetworkEventEmitterAsync(
-    EVENT_NAME_ON_DID_UPDATE_SCR_REF as 'scrollGroup:onDidUpdateScrRef',
-  );
+  onDidUpdateScrRefEmitter = await createNetworkEventEmitterAsync(EVENT_NAME_ON_DID_UPDATE_SCR_REF);
 
   await networkObjectService.set(NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE, scrollGroupService);
 

--- a/src/renderer/services/scroll-group.service-host.ts
+++ b/src/renderer/services/scroll-group.service-host.ts
@@ -1,6 +1,6 @@
 import { logger } from '@shared/services/logger.service';
 import { networkObjectService } from '@shared/services/network-object.service';
-import { createNetworkEventEmitter } from '@shared/services/network.service';
+import { createNetworkEventEmitterAsync } from '@shared/services/network.service';
 import {
   EVENT_NAME_ON_DID_UPDATE_SCR_REF,
   IScrollGroupRemoteService,
@@ -14,6 +14,8 @@ import {
   deepClone,
   deserialize,
   isPlatformError,
+  type PlatformEvent,
+  type PlatformEventEmitter,
   ScrollGroupId,
   serialize,
 } from 'platform-bible-utils';
@@ -56,9 +58,7 @@ function saveScrRefs() {
 }
 
 /** Emitter for changing Scripture reference on a scroll group */
-const onDidUpdateScrRefEmitter = createNetworkEventEmitter<ScrollGroupUpdateInfo>(
-  EVENT_NAME_ON_DID_UPDATE_SCR_REF,
-);
+let onDidUpdateScrRefEmitter: PlatformEventEmitter<ScrollGroupUpdateInfo> | undefined;
 
 /**
  * All Scroll Group IDs that are intended to be shown in scroll group selectors. This is a
@@ -68,7 +68,13 @@ const onDidUpdateScrRefEmitter = createNetworkEventEmitter<ScrollGroupUpdateInfo
 export const availableScrollGroupIds = [undefined, ...Array(5).keys()];
 
 /** Event that emits with information about a changed Scripture Reference for a scroll group */
-export const onDidUpdateScrRef = onDidUpdateScrRefEmitter.event;
+export const onDidUpdateScrRef: PlatformEvent<ScrollGroupUpdateInfo> = (callback) => {
+  if (!onDidUpdateScrRefEmitter)
+    throw new Error(
+      'scroll-group.service-host not initialized — call startScrollGroupService() before subscribing to onDidUpdateScrRef',
+    );
+  return onDidUpdateScrRefEmitter.event(callback);
+};
 
 /** See {@link IScrollGroupRemoteService.getScrRef} */
 export function getScrRefSync(scrollGroupId: ScrollGroupId = 0): SerializedVerseRef {
@@ -109,7 +115,7 @@ export function setScrRefSync(
   // Update the scr ref and send out an event
   scrRefs[scrollGroupIdDefaulted] = scrRefClone;
   saveScrRefs();
-  onDidUpdateScrRefEmitter.emit({ scrollGroupId: scrollGroupIdDefaulted, scrRef: scrRefClone });
+  onDidUpdateScrRefEmitter?.emit({ scrollGroupId: scrollGroupIdDefaulted, scrRef: scrRefClone });
 
   if (shouldSetVerseRefSetting && scrollGroupIdDefaulted === 0)
     (async () => {
@@ -139,6 +145,11 @@ const scrollGroupService: IScrollGroupRemoteService = {
 
 /** Register the network object that backs the scroll group service */
 export async function startScrollGroupService(): Promise<void> {
+  onDidUpdateScrRefEmitter = await createNetworkEventEmitterAsync(
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    EVENT_NAME_ON_DID_UPDATE_SCR_REF as 'scrollGroup:onDidUpdateScrRef',
+  );
+
   await networkObjectService.set(NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE, scrollGroupService);
 
   // Keep scroll group 0 in sync with the verse ref setting for backwards compatibility

--- a/src/renderer/services/scroll-group.service-host.ts
+++ b/src/renderer/services/scroll-group.service-host.ts
@@ -115,7 +115,11 @@ export function setScrRefSync(
   // Update the scr ref and send out an event
   scrRefs[scrollGroupIdDefaulted] = scrRefClone;
   saveScrRefs();
-  onDidUpdateScrRefEmitter?.emit({ scrollGroupId: scrollGroupIdDefaulted, scrRef: scrRefClone });
+  if (!onDidUpdateScrRefEmitter)
+    throw new Error(
+      'scroll-group.service-host not initialized — call startScrollGroupService() before emitting onDidUpdateScrRef',
+    );
+  onDidUpdateScrRefEmitter.emit({ scrollGroupId: scrollGroupIdDefaulted, scrRef: scrRefClone });
 
   if (shouldSetVerseRefSetting && scrollGroupIdDefaulted === 0)
     (async () => {
@@ -145,8 +149,9 @@ const scrollGroupService: IScrollGroupRemoteService = {
 
 /** Register the network object that backs the scroll group service */
 export async function startScrollGroupService(): Promise<void> {
+  // serializeRequestType returns SerializedRequestType, not a string literal — cast needed
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
   onDidUpdateScrRefEmitter = await createNetworkEventEmitterAsync(
-    // eslint-disable-next-line no-type-assertion/no-type-assertion
     EVENT_NAME_ON_DID_UPDATE_SCR_REF as 'scrollGroup:onDidUpdateScrRef',
   );
 

--- a/src/renderer/services/scroll-group.service-host.ts
+++ b/src/renderer/services/scroll-group.service-host.ts
@@ -1,6 +1,9 @@
 import { logger } from '@shared/services/logger.service';
 import { networkObjectService } from '@shared/services/network-object.service';
-import { createNetworkEventEmitterAsync, getNetworkEvent } from '@shared/services/network.service';
+import {
+  createBufferedNetworkEventEmitter,
+  getNetworkEvent,
+} from '@shared/services/network.service';
 import {
   EVENT_NAME_ON_DID_UPDATE_SCR_REF,
   IScrollGroupRemoteService,
@@ -15,10 +18,34 @@ import {
   deserialize,
   isPlatformError,
   type PlatformEvent,
-  type PlatformEventEmitter,
   ScrollGroupId,
   serialize,
 } from 'platform-bible-utils';
+
+/**
+ * Buffered emitter for changing the Scripture reference on a scroll group. Buffered (and created at
+ * module load, before the scrRefs migration below which can call `setScrRefSync`) so a verse-ref
+ * change from a UI handler that fires before central registration completes is kept — the latest
+ * per scroll group — and flushed once registration finishes, rather than throwing after the local
+ * state was already mutated and persisted.
+ */
+const onDidUpdateScrRefBufferedEmitter = createBufferedNetworkEventEmitter(
+  EVENT_NAME_ON_DID_UPDATE_SCR_REF,
+  {
+    notification: {
+      summary: 'Emitted when the Scripture reference for a scroll group changes.',
+      params: [
+        {
+          name: 'update',
+          required: true,
+          summary: 'The scroll group and its new Scripture reference.',
+          schema: { type: 'object' },
+        },
+      ],
+    },
+  },
+  { bufferStrategy: { latestByKey: (update) => String(update.scrollGroupId) } },
+);
 
 const DEFAULT_SCR_REF: SerializedVerseRef = Object.freeze({
   book: 'GEN',
@@ -56,9 +83,6 @@ Object.entries(scrRefs).forEach(([key, value]) => {
 function saveScrRefs() {
   localStorage.setItem(SCR_REFS_STORAGE_KEY, serialize(scrRefs));
 }
-
-/** Emitter for changing Scripture reference on a scroll group */
-let onDidUpdateScrRefEmitter: PlatformEventEmitter<ScrollGroupUpdateInfo> | undefined;
 
 /**
  * All Scroll Group IDs that are intended to be shown in scroll group selectors. This is a
@@ -108,14 +132,14 @@ export function setScrRefSync(
   if (compareScrRefs(scrRefs[scrollGroupIdDefaulted] ?? DEFAULT_SCR_REF, scrRefClone) === 0)
     return false;
 
-  // Update the scr ref and send out an event
+  // Update the scr ref and send out an event. The buffered emitter is usable immediately; if it
+  // hasn't finished registering yet, the latest update per scroll group is buffered and flushed.
   scrRefs[scrollGroupIdDefaulted] = scrRefClone;
   saveScrRefs();
-  if (!onDidUpdateScrRefEmitter)
-    throw new Error(
-      'scroll-group.service-host not initialized — call startScrollGroupService() before emitting onDidUpdateScrRef',
-    );
-  onDidUpdateScrRefEmitter.emit({ scrollGroupId: scrollGroupIdDefaulted, scrRef: scrRefClone });
+  onDidUpdateScrRefBufferedEmitter.emit({
+    scrollGroupId: scrollGroupIdDefaulted,
+    scrRef: scrRefClone,
+  });
 
   if (shouldSetVerseRefSetting && scrollGroupIdDefaulted === 0)
     (async () => {
@@ -145,23 +169,8 @@ const scrollGroupService: IScrollGroupRemoteService = {
 
 /** Register the network object that backs the scroll group service */
 export async function startScrollGroupService(): Promise<void> {
-  onDidUpdateScrRefEmitter = await createNetworkEventEmitterAsync(
-    EVENT_NAME_ON_DID_UPDATE_SCR_REF,
-    {
-      notification: {
-        summary: 'Emitted when the Scripture reference for a scroll group changes.',
-        params: [
-          {
-            name: 'update',
-            required: true,
-            summary: 'The scroll group and its new Scripture reference.',
-            schema: { type: 'object' },
-          },
-        ],
-      },
-    },
-  );
-
+  // The `onDidUpdateScrRef` emitter is created at module load (buffered), so there's nothing to set
+  // up for it here.
   await networkObjectService.set(NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE, scrollGroupService);
 
   // Keep scroll group 0 in sync with the verse ref setting for backwards compatibility

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -1952,7 +1952,7 @@ export const initialize = () => {
     // Create network event emitters
     // These EVENT_NAME_* constants are produced by `serializeRequestType`, which returns
     // `SerializedRequestType` (a branded string), not the literal string type. The casts tell
-    // TypeScript which entry in `NetworkEventTypes` each constant corresponds to.
+    // TypeScript which entry in `NetworkEvents` each constant corresponds to.
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     onDidAddWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_ADD_WEB_VIEW as 'webView:onDidAddWebView',

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -43,7 +43,7 @@ import {
 import { registerCommand } from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
 import { networkObjectService } from '@shared/services/network-object.service';
-import { createNetworkEventEmitter } from '@shared/services/network.service';
+import { createNetworkEventEmitterAsync } from '@shared/services/network.service';
 import { settingsService } from '@shared/services/settings.service';
 import { webViewProviderService } from '@shared/services/web-view-provider.service';
 import {
@@ -71,6 +71,8 @@ import {
   isSerializable,
   isString,
   newGuid,
+  type PlatformEvent,
+  type PlatformEventEmitter,
   serialize,
   split,
   startsWith,
@@ -95,14 +97,16 @@ import {
  * @deprecated 13 November 2024. Changed to {@link onDidOpenWebViewEmitter}. This remains for now to
  *   support anyone listening to this event over websocket
  */
-const onDidAddWebViewEmitter = createNetworkEventEmitter<OpenWebViewEvent>(
-  EVENT_NAME_ON_DID_ADD_WEB_VIEW,
-);
+let onDidAddWebViewEmitter: PlatformEventEmitter<OpenWebViewEvent> | undefined;
 
 /** Emitter for when a webview is created */
-const onDidOpenWebViewEmitter = createNetworkEventEmitter<OpenWebViewEvent>(
-  EVENT_NAME_ON_DID_OPEN_WEB_VIEW,
-);
+let onDidOpenWebViewEmitter: PlatformEventEmitter<OpenWebViewEvent> | undefined;
+
+/** Emitter for when a webview is updated */
+let onDidUpdateWebViewEmitter: PlatformEventEmitter<UpdateWebViewEvent> | undefined;
+
+/** Emitter for when a webview is removed */
+let onDidCloseWebViewEmitter: PlatformEventEmitter<CloseWebViewEvent> | undefined;
 
 /**
  * Emits an event for when a web view is created
@@ -111,28 +115,36 @@ const onDidOpenWebViewEmitter = createNetworkEventEmitter<OpenWebViewEvent>(
  * {@link onDidAddWebViewEmitter}, but this will likely be removed at some point
  */
 function emitOnDidOpenWebView(event: OpenWebViewEvent) {
-  onDidAddWebViewEmitter.emit(event);
-  onDidOpenWebViewEmitter.emit(event);
+  if (onDidAddWebViewEmitter) onDidAddWebViewEmitter.emit(event);
+  if (onDidOpenWebViewEmitter) onDidOpenWebViewEmitter.emit(event);
 }
 
 /** Event that emits with webView info when a webView is created */
-export const onDidOpenWebView = onDidOpenWebViewEmitter.event;
-
-/** Emitter for when a webview is updated */
-const onDidUpdateWebViewEmitter = createNetworkEventEmitter<UpdateWebViewEvent>(
-  EVENT_NAME_ON_DID_UPDATE_WEB_VIEW,
-);
+export const onDidOpenWebView: PlatformEvent<OpenWebViewEvent> = (callback) => {
+  if (!onDidOpenWebViewEmitter)
+    throw new Error(
+      'web-view.service-host not initialized — call initialize() before subscribing to onDidOpenWebView',
+    );
+  return onDidOpenWebViewEmitter.event(callback);
+};
 
 /** Event that emits with webView info when a webView is updated */
-export const onDidUpdateWebView = onDidUpdateWebViewEmitter.event;
-
-/** Emitter for when a webview is removed */
-const onDidCloseWebViewEmitter = createNetworkEventEmitter<CloseWebViewEvent>(
-  EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
-);
+export const onDidUpdateWebView: PlatformEvent<UpdateWebViewEvent> = (callback) => {
+  if (!onDidUpdateWebViewEmitter)
+    throw new Error(
+      'web-view.service-host not initialized — call initialize() before subscribing to onDidUpdateWebView',
+    );
+  return onDidUpdateWebViewEmitter.event(callback);
+};
 
 /** Event that emits with webView info when a webView is removed */
-export const onDidCloseWebView = onDidCloseWebViewEmitter.event;
+export const onDidCloseWebView: PlatformEvent<CloseWebViewEvent> = (callback) => {
+  if (!onDidCloseWebViewEmitter)
+    throw new Error(
+      'web-view.service-host not initialized — call initialize() before subscribing to onDidCloseWebView',
+    );
+  return onDidCloseWebViewEmitter.event(callback);
+};
 
 /**
  * Alias for `window.open` because `window.open` is deleted to prevent web views from accessing it.
@@ -640,7 +652,7 @@ function setDockLayout(dockLayout: PapiDockLayout | undefined): void {
 // TODO: We could short-circuit saveLayout when no meaningful change happened. - IJH 2023-05-1
 const onLayoutChange: OnLayoutChange = async (newLayout, _currentTabId, changeInfo) => {
   if (changeInfo?.didCloseWebView && changeInfo.webViewDefinition)
-    onDidCloseWebViewEmitter.emit({
+    onDidCloseWebViewEmitter?.emit({
       webView: convertWebViewDefinitionToSaved(changeInfo.webViewDefinition),
     });
 
@@ -945,7 +957,7 @@ export function updateWebViewDefinitionSync(
       }
 
       // Emit the update event
-      onDidUpdateWebViewEmitter.emit({
+      onDidUpdateWebViewEmitter?.emit({
         webView,
       });
     }
@@ -1697,7 +1709,7 @@ async function openOrReloadWebView(
       layout: finalLayout,
     });
   else
-    onDidUpdateWebViewEmitter.emit({
+    onDidUpdateWebViewEmitter?.emit({
       webView: convertWebViewDefinitionToSaved(finalWebView),
     });
 
@@ -1921,6 +1933,24 @@ export const initialize = () => {
     };
 
     // #endregion
+
+    // Create network event emitters
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    onDidAddWebViewEmitter = await createNetworkEventEmitterAsync(
+      EVENT_NAME_ON_DID_ADD_WEB_VIEW as 'webView:onDidAddWebView',
+    );
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    onDidOpenWebViewEmitter = await createNetworkEventEmitterAsync(
+      EVENT_NAME_ON_DID_OPEN_WEB_VIEW as 'webView:onDidOpenWebView',
+    );
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    onDidUpdateWebViewEmitter = await createNetworkEventEmitterAsync(
+      EVENT_NAME_ON_DID_UPDATE_WEB_VIEW as 'webView:onDidUpdateWebView',
+    );
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    onDidCloseWebViewEmitter = await createNetworkEventEmitterAsync(
+      EVENT_NAME_ON_DID_CLOSE_WEB_VIEW as 'webView:onDidCloseWebView',
+    );
 
     isInitialized = true;
 

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -109,6 +109,36 @@ let onDidUpdateWebViewEmitter: PlatformEventEmitter<UpdateWebViewEvent> | undefi
 let onDidCloseWebViewEmitter: PlatformEventEmitter<CloseWebViewEvent> | undefined;
 
 /**
+ * Subscribers that called `onDidOpenWebView` before the emitter was created. They get bound to the
+ * real emitter inside `initialize` and removed from this list.
+ */
+const pendingOnDidOpenWebViewSubscribers: {
+  callback: (event: OpenWebViewEvent) => void;
+  realUnsub?: Unsubscriber;
+  disposed: boolean;
+}[] = [];
+
+/**
+ * Subscribers that called `onDidUpdateWebView` before the emitter was created. They get bound to
+ * the real emitter inside `initialize` and removed from this list.
+ */
+const pendingOnDidUpdateWebViewSubscribers: {
+  callback: (event: UpdateWebViewEvent) => void;
+  realUnsub?: Unsubscriber;
+  disposed: boolean;
+}[] = [];
+
+/**
+ * Subscribers that called `onDidCloseWebView` before the emitter was created. They get bound to the
+ * real emitter inside `initialize` and removed from this list.
+ */
+const pendingOnDidCloseWebViewSubscribers: {
+  callback: (event: CloseWebViewEvent) => void;
+  realUnsub?: Unsubscriber;
+  disposed: boolean;
+}[] = [];
+
+/**
  * Emits an event for when a web view is created
  *
  * Actually emits two updates to support backwards compatibility with deprecated
@@ -129,29 +159,56 @@ function emitOnDidOpenWebView(event: OpenWebViewEvent) {
 
 /** Event that emits with webView info when a webView is created */
 export const onDidOpenWebView: PlatformEvent<OpenWebViewEvent> = (callback) => {
-  if (!onDidOpenWebViewEmitter)
-    throw new Error(
-      'web-view.service-host not initialized — call initialize() before subscribing to onDidOpenWebView',
-    );
-  return onDidOpenWebViewEmitter.event(callback);
+  if (onDidOpenWebViewEmitter) return onDidOpenWebViewEmitter.event(callback);
+
+  const entry: (typeof pendingOnDidOpenWebViewSubscribers)[number] = {
+    callback,
+    disposed: false,
+  };
+  pendingOnDidOpenWebViewSubscribers.push(entry);
+  return () => {
+    entry.disposed = true;
+    if (entry.realUnsub) return entry.realUnsub();
+    const i = pendingOnDidOpenWebViewSubscribers.indexOf(entry);
+    if (i >= 0) pendingOnDidOpenWebViewSubscribers.splice(i, 1);
+    return true;
+  };
 };
 
 /** Event that emits with webView info when a webView is updated */
 export const onDidUpdateWebView: PlatformEvent<UpdateWebViewEvent> = (callback) => {
-  if (!onDidUpdateWebViewEmitter)
-    throw new Error(
-      'web-view.service-host not initialized — call initialize() before subscribing to onDidUpdateWebView',
-    );
-  return onDidUpdateWebViewEmitter.event(callback);
+  if (onDidUpdateWebViewEmitter) return onDidUpdateWebViewEmitter.event(callback);
+
+  const entry: (typeof pendingOnDidUpdateWebViewSubscribers)[number] = {
+    callback,
+    disposed: false,
+  };
+  pendingOnDidUpdateWebViewSubscribers.push(entry);
+  return () => {
+    entry.disposed = true;
+    if (entry.realUnsub) return entry.realUnsub();
+    const i = pendingOnDidUpdateWebViewSubscribers.indexOf(entry);
+    if (i >= 0) pendingOnDidUpdateWebViewSubscribers.splice(i, 1);
+    return true;
+  };
 };
 
 /** Event that emits with webView info when a webView is removed */
 export const onDidCloseWebView: PlatformEvent<CloseWebViewEvent> = (callback) => {
-  if (!onDidCloseWebViewEmitter)
-    throw new Error(
-      'web-view.service-host not initialized — call initialize() before subscribing to onDidCloseWebView',
-    );
-  return onDidCloseWebViewEmitter.event(callback);
+  if (onDidCloseWebViewEmitter) return onDidCloseWebViewEmitter.event(callback);
+
+  const entry: (typeof pendingOnDidCloseWebViewSubscribers)[number] = {
+    callback,
+    disposed: false,
+  };
+  pendingOnDidCloseWebViewSubscribers.push(entry);
+  return () => {
+    entry.disposed = true;
+    if (entry.realUnsub) return entry.realUnsub();
+    const i = pendingOnDidCloseWebViewSubscribers.indexOf(entry);
+    if (i >= 0) pendingOnDidCloseWebViewSubscribers.splice(i, 1);
+    return true;
+  };
 };
 
 /**
@@ -1961,16 +2018,42 @@ export const initialize = () => {
     onDidOpenWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_OPEN_WEB_VIEW as 'webView:onDidOpenWebView',
     );
+
+    // Drain any subscribers that registered before the emitter existed.
+    while (pendingOnDidOpenWebViewSubscribers.length > 0) {
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      const entry = pendingOnDidOpenWebViewSubscribers.shift()!;
+      if (entry.disposed) continue;
+      entry.realUnsub = onDidOpenWebViewEmitter.event(entry.callback);
+    }
+
     // serializeRequestType returns SerializedRequestType, not a string literal — cast needed
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     onDidUpdateWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_UPDATE_WEB_VIEW as 'webView:onDidUpdateWebView',
     );
+
+    // Drain any subscribers that registered before the emitter existed.
+    while (pendingOnDidUpdateWebViewSubscribers.length > 0) {
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      const entry = pendingOnDidUpdateWebViewSubscribers.shift()!;
+      if (entry.disposed) continue;
+      entry.realUnsub = onDidUpdateWebViewEmitter.event(entry.callback);
+    }
+
     // serializeRequestType returns SerializedRequestType, not a string literal — cast needed
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     onDidCloseWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_CLOSE_WEB_VIEW as 'webView:onDidCloseWebView',
     );
+
+    // Drain any subscribers that registered before the emitter existed.
+    while (pendingOnDidCloseWebViewSubscribers.length > 0) {
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      const entry = pendingOnDidCloseWebViewSubscribers.shift()!;
+      if (entry.disposed) continue;
+      entry.realUnsub = onDidCloseWebViewEmitter.event(entry.callback);
+    }
 
     onDidCloseWebView(({ webView: { id, webViewType } }) => {
       if (!deleteWebViewNonce(id))

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -115,8 +115,16 @@ let onDidCloseWebViewEmitter: PlatformEventEmitter<CloseWebViewEvent> | undefine
  * {@link onDidAddWebViewEmitter}, but this will likely be removed at some point
  */
 function emitOnDidOpenWebView(event: OpenWebViewEvent) {
-  if (onDidAddWebViewEmitter) onDidAddWebViewEmitter.emit(event);
-  if (onDidOpenWebViewEmitter) onDidOpenWebViewEmitter.emit(event);
+  if (!onDidAddWebViewEmitter)
+    throw new Error(
+      'web-view.service-host not initialized — call initialize() before emitting onDidAddWebView',
+    );
+  if (!onDidOpenWebViewEmitter)
+    throw new Error(
+      'web-view.service-host not initialized — call initialize() before emitting onDidOpenWebView',
+    );
+  onDidAddWebViewEmitter.emit(event);
+  onDidOpenWebViewEmitter.emit(event);
 }
 
 /** Event that emits with webView info when a webView is created */
@@ -651,10 +659,15 @@ function setDockLayout(dockLayout: PapiDockLayout | undefined): void {
  */
 // TODO: We could short-circuit saveLayout when no meaningful change happened. - IJH 2023-05-1
 const onLayoutChange: OnLayoutChange = async (newLayout, _currentTabId, changeInfo) => {
-  if (changeInfo?.didCloseWebView && changeInfo.webViewDefinition)
-    onDidCloseWebViewEmitter?.emit({
+  if (changeInfo?.didCloseWebView && changeInfo.webViewDefinition) {
+    if (!onDidCloseWebViewEmitter)
+      throw new Error(
+        'web-view.service-host not initialized — call initialize() before emitting onDidCloseWebView',
+      );
+    onDidCloseWebViewEmitter.emit({
       webView: convertWebViewDefinitionToSaved(changeInfo.webViewDefinition),
     });
+  }
 
   return saveLayout(newLayout);
 };
@@ -957,7 +970,11 @@ export function updateWebViewDefinitionSync(
       }
 
       // Emit the update event
-      onDidUpdateWebViewEmitter?.emit({
+      if (!onDidUpdateWebViewEmitter)
+        throw new Error(
+          'web-view.service-host not initialized — call initialize() before emitting onDidUpdateWebView',
+        );
+      onDidUpdateWebViewEmitter.emit({
         webView,
       });
     }
@@ -1701,10 +1718,15 @@ async function openOrReloadWebView(
       webView: convertWebViewDefinitionToSaved(finalWebView),
       layout: finalLayout,
     });
-  else
-    onDidUpdateWebViewEmitter?.emit({
+  else {
+    if (!onDidUpdateWebViewEmitter)
+      throw new Error(
+        'web-view.service-host not initialized — call initialize() before emitting onDidUpdateWebView',
+      );
+    onDidUpdateWebViewEmitter.emit({
       webView: convertWebViewDefinitionToSaved(finalWebView),
     });
+  }
 
   return webView.id;
 }
@@ -1928,6 +1950,9 @@ export const initialize = () => {
     // #endregion
 
     // Create network event emitters
+    // These EVENT_NAME_* constants are produced by `serializeRequestType`, which returns
+    // `SerializedRequestType` (a branded string), not the literal string type. The casts tell
+    // TypeScript which entry in `NetworkEventTypes` each constant corresponds to.
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     onDidAddWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_ADD_WEB_VIEW as 'webView:onDidAddWebView',
@@ -1936,10 +1961,12 @@ export const initialize = () => {
     onDidOpenWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_OPEN_WEB_VIEW as 'webView:onDidOpenWebView',
     );
+    // serializeRequestType returns SerializedRequestType, not a string literal — cast needed
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     onDidUpdateWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_UPDATE_WEB_VIEW as 'webView:onDidUpdateWebView',
     );
+    // serializeRequestType returns SerializedRequestType, not a string literal — cast needed
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     onDidCloseWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_CLOSE_WEB_VIEW as 'webView:onDidCloseWebView',

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -127,22 +127,13 @@ function emitOnDidOpenWebView(event: OpenWebViewEvent) {
 }
 
 /** Event that emits with webView info when a webView is created */
-export const onDidOpenWebView = getNetworkEvent(
-  // eslint-disable-next-line no-type-assertion/no-type-assertion
-  EVENT_NAME_ON_DID_OPEN_WEB_VIEW as 'webView:onDidOpenWebView',
-);
+export const onDidOpenWebView = getNetworkEvent(EVENT_NAME_ON_DID_OPEN_WEB_VIEW);
 
 /** Event that emits with webView info when a webView is updated */
-export const onDidUpdateWebView = getNetworkEvent(
-  // eslint-disable-next-line no-type-assertion/no-type-assertion
-  EVENT_NAME_ON_DID_UPDATE_WEB_VIEW as 'webView:onDidUpdateWebView',
-);
+export const onDidUpdateWebView = getNetworkEvent(EVENT_NAME_ON_DID_UPDATE_WEB_VIEW);
 
 /** Event that emits with webView info when a webView is removed */
-export const onDidCloseWebView = getNetworkEvent(
-  // eslint-disable-next-line no-type-assertion/no-type-assertion
-  EVENT_NAME_ON_DID_CLOSE_WEB_VIEW as 'webView:onDidCloseWebView',
-);
+export const onDidCloseWebView = getNetworkEvent(EVENT_NAME_ON_DID_CLOSE_WEB_VIEW);
 
 /**
  * Alias for `window.open` because `window.open` is deleted to prevent web views from accessing it.
@@ -1940,28 +1931,13 @@ export const initialize = () => {
     // #endregion
 
     // Create network event emitters
-    // These EVENT_NAME_* constants are produced by `serializeRequestType`, which returns
-    // `SerializedRequestType` (a branded string), not the literal string type. The casts tell
-    // TypeScript which entry in `NetworkEvents` each constant corresponds to.
-    // eslint-disable-next-line no-type-assertion/no-type-assertion
-    onDidAddWebViewEmitter = await createNetworkEventEmitterAsync(
-      EVENT_NAME_ON_DID_ADD_WEB_VIEW as 'webView:onDidAddWebView',
-    );
-    // eslint-disable-next-line no-type-assertion/no-type-assertion
-    onDidOpenWebViewEmitter = await createNetworkEventEmitterAsync(
-      EVENT_NAME_ON_DID_OPEN_WEB_VIEW as 'webView:onDidOpenWebView',
-    );
-
-    // serializeRequestType returns SerializedRequestType, not a string literal — cast needed
-    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    onDidAddWebViewEmitter = await createNetworkEventEmitterAsync(EVENT_NAME_ON_DID_ADD_WEB_VIEW);
+    onDidOpenWebViewEmitter = await createNetworkEventEmitterAsync(EVENT_NAME_ON_DID_OPEN_WEB_VIEW);
     onDidUpdateWebViewEmitter = await createNetworkEventEmitterAsync(
-      EVENT_NAME_ON_DID_UPDATE_WEB_VIEW as 'webView:onDidUpdateWebView',
+      EVENT_NAME_ON_DID_UPDATE_WEB_VIEW,
     );
-
-    // serializeRequestType returns SerializedRequestType, not a string literal — cast needed
-    // eslint-disable-next-line no-type-assertion/no-type-assertion
     onDidCloseWebViewEmitter = await createNetworkEventEmitterAsync(
-      EVENT_NAME_ON_DID_CLOSE_WEB_VIEW as 'webView:onDidCloseWebView',
+      EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
     );
 
     onDidCloseWebView(({ webView: { id, webViewType } }) => {

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -1931,13 +1931,67 @@ export const initialize = () => {
     // #endregion
 
     // Create network event emitters
-    onDidAddWebViewEmitter = await createNetworkEventEmitterAsync(EVENT_NAME_ON_DID_ADD_WEB_VIEW);
-    onDidOpenWebViewEmitter = await createNetworkEventEmitterAsync(EVENT_NAME_ON_DID_OPEN_WEB_VIEW);
+    onDidAddWebViewEmitter = await createNetworkEventEmitterAsync(EVENT_NAME_ON_DID_ADD_WEB_VIEW, {
+      notification: {
+        summary: 'Emitted when a WebView is created.',
+        deprecated: true,
+        params: [
+          {
+            name: 'webView',
+            required: true,
+            summary: 'The created WebView.',
+            schema: { type: 'object' },
+          },
+        ],
+      },
+    });
+    onDidOpenWebViewEmitter = await createNetworkEventEmitterAsync(
+      EVENT_NAME_ON_DID_OPEN_WEB_VIEW,
+      {
+        notification: {
+          summary: 'Emitted when a WebView is created.',
+          params: [
+            {
+              name: 'webView',
+              required: true,
+              summary: 'The created WebView.',
+              schema: { type: 'object' },
+            },
+          ],
+        },
+      },
+    );
     onDidUpdateWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_UPDATE_WEB_VIEW,
+      {
+        notification: {
+          summary: 'Emitted when a WebView is updated.',
+          params: [
+            {
+              name: 'webView',
+              required: true,
+              summary: 'The updated WebView.',
+              schema: { type: 'object' },
+            },
+          ],
+        },
+      },
     );
     onDidCloseWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
+      {
+        notification: {
+          summary: 'Emitted when a WebView is closed.',
+          params: [
+            {
+              name: 'webView',
+              required: true,
+              summary: 'The closed WebView.',
+              schema: { type: 'object' },
+            },
+          ],
+        },
+      },
     );
 
     onDidCloseWebView(({ webView: { id, webViewType } }) => {

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -43,11 +43,13 @@ import {
 import { registerCommand } from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
 import { networkObjectService } from '@shared/services/network-object.service';
-import { createNetworkEventEmitterAsync, getNetworkEvent } from '@shared/services/network.service';
+import {
+  createBufferedNetworkEventEmitter,
+  getNetworkEvent,
+} from '@shared/services/network.service';
 import { settingsService } from '@shared/services/settings.service';
 import { webViewProviderService } from '@shared/services/web-view-provider.service';
 import {
-  CloseWebViewEvent,
   EVENT_NAME_ON_DID_ADD_WEB_VIEW,
   EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
   EVENT_NAME_ON_DID_OPEN_WEB_VIEW,
@@ -55,7 +57,6 @@ import {
   getWebViewController,
   NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
   OpenWebViewEvent,
-  UpdateWebViewEvent,
   WebViewServiceType,
 } from '@shared/services/web-view.service-model';
 import { newNonce } from '@shared/utils/util';
@@ -71,7 +72,6 @@ import {
   isSerializable,
   isString,
   newGuid,
-  type PlatformEventEmitter,
   serialize,
   split,
   startsWith,
@@ -92,38 +92,97 @@ import {
   transformLegacyColorVars,
 } from './web-views/web-view-legacy-color-vars.util';
 
+// These web view lifecycle emitters are created at module load as buffered emitters so they're
+// usable immediately. Sync paths like `onLayoutChange` and `updateWebViewDefinitionSync` can run
+// before the websocket finishes connecting; buffered emits are queued and flushed once each event
+// registers (and the four register concurrently in the background rather than sequentially).
+
 /**
- * @deprecated 13 November 2024. Changed to {@link onDidOpenWebViewEmitter}. This remains for now to
- *   support anyone listening to this event over websocket
+ * @deprecated 13 November 2024. Changed to {@link onDidOpenWebViewBufferedEmitter}. This remains for
+ *   now to support anyone listening to this event over websocket
  */
-let onDidAddWebViewEmitter: PlatformEventEmitter<OpenWebViewEvent> | undefined;
+const onDidAddWebViewBufferedEmitter = createBufferedNetworkEventEmitter(
+  EVENT_NAME_ON_DID_ADD_WEB_VIEW,
+  {
+    notification: {
+      summary: 'Emitted when a WebView is created.',
+      deprecated: true,
+      params: [
+        {
+          name: 'webView',
+          required: true,
+          summary: 'The created WebView.',
+          schema: { type: 'object' },
+        },
+      ],
+    },
+  },
+);
 
-/** Emitter for when a webview is created */
-let onDidOpenWebViewEmitter: PlatformEventEmitter<OpenWebViewEvent> | undefined;
+/** Buffered emitter for when a webview is created */
+const onDidOpenWebViewBufferedEmitter = createBufferedNetworkEventEmitter(
+  EVENT_NAME_ON_DID_OPEN_WEB_VIEW,
+  {
+    notification: {
+      summary: 'Emitted when a WebView is created.',
+      params: [
+        {
+          name: 'webView',
+          required: true,
+          summary: 'The created WebView.',
+          schema: { type: 'object' },
+        },
+      ],
+    },
+  },
+);
 
-/** Emitter for when a webview is updated */
-let onDidUpdateWebViewEmitter: PlatformEventEmitter<UpdateWebViewEvent> | undefined;
+/** Buffered emitter for when a webview is updated. Only the latest update per webview matters. */
+const onDidUpdateWebViewBufferedEmitter = createBufferedNetworkEventEmitter(
+  EVENT_NAME_ON_DID_UPDATE_WEB_VIEW,
+  {
+    notification: {
+      summary: 'Emitted when a WebView is updated.',
+      params: [
+        {
+          name: 'webView',
+          required: true,
+          summary: 'The updated WebView.',
+          schema: { type: 'object' },
+        },
+      ],
+    },
+  },
+  { bufferStrategy: { latestByKey: (event) => event.webView.id } },
+);
 
-/** Emitter for when a webview is removed */
-let onDidCloseWebViewEmitter: PlatformEventEmitter<CloseWebViewEvent> | undefined;
+/** Buffered emitter for when a webview is removed */
+const onDidCloseWebViewBufferedEmitter = createBufferedNetworkEventEmitter(
+  EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
+  {
+    notification: {
+      summary: 'Emitted when a WebView is closed.',
+      params: [
+        {
+          name: 'webView',
+          required: true,
+          summary: 'The closed WebView.',
+          schema: { type: 'object' },
+        },
+      ],
+    },
+  },
+);
 
 /**
  * Emits an event for when a web view is created
  *
  * Actually emits two updates to support backwards compatibility with deprecated
- * {@link onDidAddWebViewEmitter}, but this will likely be removed at some point
+ * {@link onDidAddWebViewBufferedEmitter}, but this will likely be removed at some point
  */
 function emitOnDidOpenWebView(event: OpenWebViewEvent) {
-  if (!onDidAddWebViewEmitter)
-    throw new Error(
-      'web-view.service-host not initialized — call initialize() before emitting onDidAddWebView',
-    );
-  if (!onDidOpenWebViewEmitter)
-    throw new Error(
-      'web-view.service-host not initialized — call initialize() before emitting onDidOpenWebView',
-    );
-  onDidAddWebViewEmitter.emit(event);
-  onDidOpenWebViewEmitter.emit(event);
+  onDidAddWebViewBufferedEmitter.emit(event);
+  onDidOpenWebViewBufferedEmitter.emit(event);
 }
 
 /** Event that emits with webView info when a webView is created */
@@ -641,11 +700,8 @@ function setDockLayout(dockLayout: PapiDockLayout | undefined): void {
 // TODO: We could short-circuit saveLayout when no meaningful change happened. - IJH 2023-05-1
 const onLayoutChange: OnLayoutChange = async (newLayout, _currentTabId, changeInfo) => {
   if (changeInfo?.didCloseWebView && changeInfo.webViewDefinition) {
-    if (!onDidCloseWebViewEmitter)
-      throw new Error(
-        'web-view.service-host not initialized — call initialize() before emitting onDidCloseWebView',
-      );
-    onDidCloseWebViewEmitter.emit({
+    // Buffered emit — usable even if a restored tab is closed before the websocket connects.
+    onDidCloseWebViewBufferedEmitter.emit({
       webView: convertWebViewDefinitionToSaved(changeInfo.webViewDefinition),
     });
   }
@@ -950,12 +1006,8 @@ export function updateWebViewDefinitionSync(
         else deleteFullWebViewStateById(webViewId);
       }
 
-      // Emit the update event
-      if (!onDidUpdateWebViewEmitter)
-        throw new Error(
-          'web-view.service-host not initialized — call initialize() before emitting onDidUpdateWebView',
-        );
-      onDidUpdateWebViewEmitter.emit({
+      // Emit the update event (buffered — usable before the websocket connects).
+      onDidUpdateWebViewBufferedEmitter.emit({
         webView,
       });
     }
@@ -1700,11 +1752,7 @@ async function openOrReloadWebView(
       layout: finalLayout,
     });
   else {
-    if (!onDidUpdateWebViewEmitter)
-      throw new Error(
-        'web-view.service-host not initialized — call initialize() before emitting onDidUpdateWebView',
-      );
-    onDidUpdateWebViewEmitter.emit({
+    onDidUpdateWebViewBufferedEmitter.emit({
       webView: convertWebViewDefinitionToSaved(finalWebView),
     });
   }
@@ -1930,70 +1978,7 @@ export const initialize = () => {
 
     // #endregion
 
-    // Create network event emitters
-    onDidAddWebViewEmitter = await createNetworkEventEmitterAsync(EVENT_NAME_ON_DID_ADD_WEB_VIEW, {
-      notification: {
-        summary: 'Emitted when a WebView is created.',
-        deprecated: true,
-        params: [
-          {
-            name: 'webView',
-            required: true,
-            summary: 'The created WebView.',
-            schema: { type: 'object' },
-          },
-        ],
-      },
-    });
-    onDidOpenWebViewEmitter = await createNetworkEventEmitterAsync(
-      EVENT_NAME_ON_DID_OPEN_WEB_VIEW,
-      {
-        notification: {
-          summary: 'Emitted when a WebView is created.',
-          params: [
-            {
-              name: 'webView',
-              required: true,
-              summary: 'The created WebView.',
-              schema: { type: 'object' },
-            },
-          ],
-        },
-      },
-    );
-    onDidUpdateWebViewEmitter = await createNetworkEventEmitterAsync(
-      EVENT_NAME_ON_DID_UPDATE_WEB_VIEW,
-      {
-        notification: {
-          summary: 'Emitted when a WebView is updated.',
-          params: [
-            {
-              name: 'webView',
-              required: true,
-              summary: 'The updated WebView.',
-              schema: { type: 'object' },
-            },
-          ],
-        },
-      },
-    );
-    onDidCloseWebViewEmitter = await createNetworkEventEmitterAsync(
-      EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
-      {
-        notification: {
-          summary: 'Emitted when a WebView is closed.',
-          params: [
-            {
-              name: 'webView',
-              required: true,
-              summary: 'The closed WebView.',
-              schema: { type: 'object' },
-            },
-          ],
-        },
-      },
-    );
-
+    // The web view lifecycle emitters are created at module load (buffered); nothing to set up here.
     onDidCloseWebView(({ webView: { id, webViewType } }) => {
       if (!deleteWebViewNonce(id))
         logger.warn(

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -1978,7 +1978,6 @@ export const initialize = () => {
 
     // #endregion
 
-    // The web view lifecycle emitters are created at module load (buffered); nothing to set up here.
     onDidCloseWebView(({ webView: { id, webViewType } }) => {
       if (!deleteWebViewNonce(id))
         logger.warn(

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -43,7 +43,7 @@ import {
 import { registerCommand } from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
 import { networkObjectService } from '@shared/services/network-object.service';
-import { createNetworkEventEmitterAsync } from '@shared/services/network.service';
+import { createNetworkEventEmitterAsync, getNetworkEvent } from '@shared/services/network.service';
 import { settingsService } from '@shared/services/settings.service';
 import { webViewProviderService } from '@shared/services/web-view-provider.service';
 import {
@@ -71,7 +71,6 @@ import {
   isSerializable,
   isString,
   newGuid,
-  type PlatformEvent,
   type PlatformEventEmitter,
   serialize,
   split,
@@ -109,36 +108,6 @@ let onDidUpdateWebViewEmitter: PlatformEventEmitter<UpdateWebViewEvent> | undefi
 let onDidCloseWebViewEmitter: PlatformEventEmitter<CloseWebViewEvent> | undefined;
 
 /**
- * Subscribers that called `onDidOpenWebView` before the emitter was created. They get bound to the
- * real emitter inside `initialize` and removed from this list.
- */
-const pendingOnDidOpenWebViewSubscribers: {
-  callback: (event: OpenWebViewEvent) => void;
-  realUnsub?: Unsubscriber;
-  disposed: boolean;
-}[] = [];
-
-/**
- * Subscribers that called `onDidUpdateWebView` before the emitter was created. They get bound to
- * the real emitter inside `initialize` and removed from this list.
- */
-const pendingOnDidUpdateWebViewSubscribers: {
-  callback: (event: UpdateWebViewEvent) => void;
-  realUnsub?: Unsubscriber;
-  disposed: boolean;
-}[] = [];
-
-/**
- * Subscribers that called `onDidCloseWebView` before the emitter was created. They get bound to the
- * real emitter inside `initialize` and removed from this list.
- */
-const pendingOnDidCloseWebViewSubscribers: {
-  callback: (event: CloseWebViewEvent) => void;
-  realUnsub?: Unsubscriber;
-  disposed: boolean;
-}[] = [];
-
-/**
  * Emits an event for when a web view is created
  *
  * Actually emits two updates to support backwards compatibility with deprecated
@@ -158,58 +127,22 @@ function emitOnDidOpenWebView(event: OpenWebViewEvent) {
 }
 
 /** Event that emits with webView info when a webView is created */
-export const onDidOpenWebView: PlatformEvent<OpenWebViewEvent> = (callback) => {
-  if (onDidOpenWebViewEmitter) return onDidOpenWebViewEmitter.event(callback);
-
-  const entry: (typeof pendingOnDidOpenWebViewSubscribers)[number] = {
-    callback,
-    disposed: false,
-  };
-  pendingOnDidOpenWebViewSubscribers.push(entry);
-  return () => {
-    entry.disposed = true;
-    if (entry.realUnsub) return entry.realUnsub();
-    const i = pendingOnDidOpenWebViewSubscribers.indexOf(entry);
-    if (i >= 0) pendingOnDidOpenWebViewSubscribers.splice(i, 1);
-    return true;
-  };
-};
+export const onDidOpenWebView = getNetworkEvent(
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  EVENT_NAME_ON_DID_OPEN_WEB_VIEW as 'webView:onDidOpenWebView',
+);
 
 /** Event that emits with webView info when a webView is updated */
-export const onDidUpdateWebView: PlatformEvent<UpdateWebViewEvent> = (callback) => {
-  if (onDidUpdateWebViewEmitter) return onDidUpdateWebViewEmitter.event(callback);
-
-  const entry: (typeof pendingOnDidUpdateWebViewSubscribers)[number] = {
-    callback,
-    disposed: false,
-  };
-  pendingOnDidUpdateWebViewSubscribers.push(entry);
-  return () => {
-    entry.disposed = true;
-    if (entry.realUnsub) return entry.realUnsub();
-    const i = pendingOnDidUpdateWebViewSubscribers.indexOf(entry);
-    if (i >= 0) pendingOnDidUpdateWebViewSubscribers.splice(i, 1);
-    return true;
-  };
-};
+export const onDidUpdateWebView = getNetworkEvent(
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  EVENT_NAME_ON_DID_UPDATE_WEB_VIEW as 'webView:onDidUpdateWebView',
+);
 
 /** Event that emits with webView info when a webView is removed */
-export const onDidCloseWebView: PlatformEvent<CloseWebViewEvent> = (callback) => {
-  if (onDidCloseWebViewEmitter) return onDidCloseWebViewEmitter.event(callback);
-
-  const entry: (typeof pendingOnDidCloseWebViewSubscribers)[number] = {
-    callback,
-    disposed: false,
-  };
-  pendingOnDidCloseWebViewSubscribers.push(entry);
-  return () => {
-    entry.disposed = true;
-    if (entry.realUnsub) return entry.realUnsub();
-    const i = pendingOnDidCloseWebViewSubscribers.indexOf(entry);
-    if (i >= 0) pendingOnDidCloseWebViewSubscribers.splice(i, 1);
-    return true;
-  };
-};
+export const onDidCloseWebView = getNetworkEvent(
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  EVENT_NAME_ON_DID_CLOSE_WEB_VIEW as 'webView:onDidCloseWebView',
+);
 
 /**
  * Alias for `window.open` because `window.open` is deleted to prevent web views from accessing it.
@@ -2019,41 +1952,17 @@ export const initialize = () => {
       EVENT_NAME_ON_DID_OPEN_WEB_VIEW as 'webView:onDidOpenWebView',
     );
 
-    // Drain any subscribers that registered before the emitter existed.
-    while (pendingOnDidOpenWebViewSubscribers.length > 0) {
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      const entry = pendingOnDidOpenWebViewSubscribers.shift()!;
-      if (entry.disposed) continue;
-      entry.realUnsub = onDidOpenWebViewEmitter.event(entry.callback);
-    }
-
     // serializeRequestType returns SerializedRequestType, not a string literal — cast needed
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     onDidUpdateWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_UPDATE_WEB_VIEW as 'webView:onDidUpdateWebView',
     );
 
-    // Drain any subscribers that registered before the emitter existed.
-    while (pendingOnDidUpdateWebViewSubscribers.length > 0) {
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      const entry = pendingOnDidUpdateWebViewSubscribers.shift()!;
-      if (entry.disposed) continue;
-      entry.realUnsub = onDidUpdateWebViewEmitter.event(entry.callback);
-    }
-
     // serializeRequestType returns SerializedRequestType, not a string literal — cast needed
     // eslint-disable-next-line no-type-assertion/no-type-assertion
     onDidCloseWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_CLOSE_WEB_VIEW as 'webView:onDidCloseWebView',
     );
-
-    // Drain any subscribers that registered before the emitter existed.
-    while (pendingOnDidCloseWebViewSubscribers.length > 0) {
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      const entry = pendingOnDidCloseWebViewSubscribers.shift()!;
-      if (entry.disposed) continue;
-      entry.realUnsub = onDidCloseWebViewEmitter.event(entry.callback);
-    }
 
     onDidCloseWebView(({ webView: { id, webViewType } }) => {
       if (!deleteWebViewNonce(id))

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -1242,13 +1242,6 @@ function deleteWebViewNonce(id: WebViewId) {
   return webViewNoncesById.delete(id);
 }
 
-onDidCloseWebView(({ webView: { id, webViewType } }) => {
-  if (!deleteWebViewNonce(id))
-    logger.warn(
-      `Tried to delete webViewNonce for web view with id ${id} (type ${webViewType}), but a nonce was not found. May not be an issue, but worth investigating`,
-    );
-});
-
 // #endregion webViewNonce
 
 // #region Set up global variables to use in `openWebView`'s `imports` below
@@ -1951,6 +1944,13 @@ export const initialize = () => {
     onDidCloseWebViewEmitter = await createNetworkEventEmitterAsync(
       EVENT_NAME_ON_DID_CLOSE_WEB_VIEW as 'webView:onDidCloseWebView',
     );
+
+    onDidCloseWebView(({ webView: { id, webViewType } }) => {
+      if (!deleteWebViewNonce(id))
+        logger.warn(
+          `Tried to delete webViewNonce for web view with id ${id} (type ${webViewType}), but a nonce was not found. May not be an issue, but worth investigating`,
+        );
+    });
 
     isInitialized = true;
 

--- a/src/shared/data/network-event-names.ts
+++ b/src/shared/data/network-event-names.ts
@@ -1,0 +1,14 @@
+import type { MultiSourceNetworkEvents } from 'papi-shared-types';
+
+/**
+ * Source of truth for which event names use multi-source semantics at the central registry. Must
+ * stay in sync with the `MultiSourceNetworkEvents` type alias in `papi-shared-types.ts` — the test
+ * `network.service.shared-events.test.ts` enforces the invariant.
+ *
+ * Add entries here when adding a new multi-source event to `MultiSourceNetworkEvents`.
+ */
+export const MULTI_SOURCE_EVENT_NAMES = new Set<keyof MultiSourceNetworkEvents>([
+  'object:onDidCreateNetworkObject',
+  'object:onDidDisposeNetworkObject',
+  'shared-store:change',
+]);

--- a/src/shared/data/network-event-names.ts
+++ b/src/shared/data/network-event-names.ts
@@ -1,14 +1,34 @@
 import type { MultiSourceNetworkEvents } from 'papi-shared-types';
 
 /**
- * Source of truth for which event names use multi-source semantics at the central registry. Must
- * stay in sync with the `MultiSourceNetworkEvents` type alias in `papi-shared-types.ts` — the test
- * `network.service.shared-events.test.ts` enforces the invariant.
- *
- * Add entries here when adding a new multi-source event to `MultiSourceNetworkEvents`.
+ * Public multi-source event names. `satisfies` checks each entry is a real key of
+ * `MultiSourceNetworkEvents` (so the runtime list stays in sync with the public type) without
+ * widening the value's type.
  */
-export const MULTI_SOURCE_EVENT_NAMES = new Set<keyof MultiSourceNetworkEvents>([
+const PUBLIC_MULTI_SOURCE_EVENT_NAMES = [
   'object:onDidCreateNetworkObject',
   'object:onDidDisposeNetworkObject',
-  'shared-store:change',
+] satisfies (keyof MultiSourceNetworkEvents)[];
+
+/**
+ * Multi-source event names the platform uses internally and intentionally does NOT advertise in the
+ * public `MultiSourceNetworkEvents`/`NetworkEvents` types (e.g. the shared store service is not
+ * part of the public API). They are still tracked as multi-source at the central registry and
+ * surfaced in the OpenRPC document, but kept as plain strings here so they never appear in the
+ * public types.
+ */
+const INTERNAL_MULTI_SOURCE_EVENT_NAMES = ['shared-store:change'];
+
+/**
+ * Source of truth for which event names use multi-source semantics at the central registry. Must
+ * stay in sync with `MultiSourceNetworkEvents` (the public events) plus the platform-internal
+ * multi-source events — the test `network.service.shared-events.test.ts` checks the contents.
+ *
+ * Add entries to {@link PUBLIC_MULTI_SOURCE_EVENT_NAMES} when adding a new public multi-source event
+ * to `MultiSourceNetworkEvents`, or to {@link INTERNAL_MULTI_SOURCE_EVENT_NAMES} for a new internal
+ * one.
+ */
+export const MULTI_SOURCE_EVENT_NAMES: ReadonlySet<string> = new Set<string>([
+  ...PUBLIC_MULTI_SOURCE_EVENT_NAMES,
+  ...INTERNAL_MULTI_SOURCE_EVENT_NAMES,
 ]);

--- a/src/shared/data/rpc.model.ts
+++ b/src/shared/data/rpc.model.ts
@@ -236,6 +236,19 @@ export const REGISTER_METHOD = 'network:registerMethod';
 export const UNREGISTER_METHOD = 'network:unregisterMethod';
 
 /**
+ * Register a network event emitter with the main process so that the event is tracked centrally.
+ * Shared vs. exclusive semantics are determined by looking up the event name in
+ * `SHARED_EVENT_NAMES`.
+ */
+export const REGISTER_EVENT = 'network:registerEvent';
+
+/**
+ * Unregister a network event emitter from the main process so that the event is no longer tracked
+ * centrally.
+ */
+export const UNREGISTER_EVENT = 'network:unregisterEvent';
+
+/**
  * Get all methods that are currently registered on the network. Required to be 'rpc.discover' by
  * the OpenRPC specification.
  */

--- a/src/shared/data/rpc.model.ts
+++ b/src/shared/data/rpc.model.ts
@@ -237,8 +237,8 @@ export const UNREGISTER_METHOD = 'network:unregisterMethod';
 
 /**
  * Register a network event emitter with the main process so that the event is tracked centrally.
- * Shared vs. exclusive semantics are determined by looking up the event name in
- * `SHARED_EVENT_NAMES`.
+ * Multi-source vs. single-source semantics are determined by looking up the event name in
+ * `MULTI_SOURCE_EVENT_NAMES`.
  */
 export const REGISTER_EVENT = 'network:registerEvent';
 

--- a/src/shared/models/__tests__/openrpc.model.test.ts
+++ b/src/shared/models/__tests__/openrpc.model.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expectTypeOf } from 'vitest';
 import type {
   Method,
-  Notification,
+  OpenRpcNotification,
   NetworkObjectDocumentation,
   OpenRpc,
   SingleNotificationDocumentation,
@@ -18,14 +18,14 @@ describe('openrpc.model — experimental marker types', () => {
     expectTypeOf(m['x-experimental']).toEqualTypeOf<boolean | undefined>();
   });
 
-  it('Notification has no result field', () => {
-    const n: Notification = {
+  it('OpenRpcNotification has no result field', () => {
+    const n: OpenRpcNotification = {
       name: 'x',
       params: [],
       'x-experimental': true,
     };
-    // @ts-expect-error — Notification cannot have a result
-    const bad: Notification = { name: 'x', params: [], result: { name: 'r', schema: {} } };
+    // @ts-expect-error — OpenRpcNotification cannot have a result
+    const bad: OpenRpcNotification = { name: 'x', params: [], result: { name: 'r', schema: {} } };
     void bad;
     expectTypeOf(n.name).toEqualTypeOf<string>();
   });
@@ -35,7 +35,7 @@ describe('openrpc.model — experimental marker types', () => {
     expectTypeOf(d['x-experimental']).toEqualTypeOf<boolean | undefined>();
   });
 
-  it('OpenRpc.methods accepts both Method and Notification', () => {
+  it('OpenRpc.methods accepts both Method and OpenRpcNotification', () => {
     const doc: OpenRpc = {
       openrpc: '1.2.6',
       info: { title: 't', version: 'v' },
@@ -44,13 +44,22 @@ describe('openrpc.model — experimental marker types', () => {
         { name: 'b', params: [] }, // notification
       ],
     };
-    expectTypeOf(doc.methods).toEqualTypeOf<(Method | Notification)[]>();
+    expectTypeOf(doc.methods).toEqualTypeOf<(Method | OpenRpcNotification)[]>();
   });
 
   it('SingleNotificationDocumentation has notification omitting name and result', () => {
     const d: SingleNotificationDocumentation = {
       notification: { params: [], 'x-experimental': true },
     };
-    expectTypeOf(d.notification).toEqualTypeOf<Omit<Omit<Method, 'result'>, 'name'>>();
+    expectTypeOf(d.notification).toEqualTypeOf<Omit<OpenRpcNotification, 'name'>>();
+  });
+
+  it('NetworkObjectDocumentation.methods rejects notifications', () => {
+    const notification: OpenRpcNotification = { name: 'evt', params: [] };
+    const bad: NetworkObjectDocumentation = {
+      // @ts-expect-error — NetworkObjectDocumentation.methods only accepts Method[], not OpenRpcNotification[]
+      methods: [notification],
+    };
+    void bad;
   });
 });

--- a/src/shared/models/__tests__/openrpc.model.test.ts
+++ b/src/shared/models/__tests__/openrpc.model.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expectTypeOf } from 'vitest';
+import type {
+  Method,
+  Notification,
+  NetworkObjectDocumentation,
+  OpenRpc,
+  SingleNotificationDocumentation,
+} from '@shared/models/openrpc.model';
+
+describe('openrpc.model — experimental marker types', () => {
+  it('Method accepts an optional x-experimental boolean', () => {
+    const m: Method = {
+      name: 'x',
+      params: [],
+      result: { name: 'r', schema: {} },
+      'x-experimental': true,
+    };
+    expectTypeOf(m['x-experimental']).toEqualTypeOf<boolean | undefined>();
+  });
+
+  it('Notification has no result field', () => {
+    const n: Notification = {
+      name: 'x',
+      params: [],
+      'x-experimental': true,
+    };
+    // @ts-expect-error — Notification cannot have a result
+    const bad: Notification = { name: 'x', params: [], result: { name: 'r', schema: {} } };
+    void bad;
+    expectTypeOf(n.name).toEqualTypeOf<string>();
+  });
+
+  it('NetworkObjectDocumentation accepts x-experimental at top level and methods are Method[] only', () => {
+    const d: NetworkObjectDocumentation = { 'x-experimental': true, methods: [] };
+    expectTypeOf(d['x-experimental']).toEqualTypeOf<boolean | undefined>();
+  });
+
+  it('OpenRpc.methods accepts both Method and Notification', () => {
+    const doc: OpenRpc = {
+      openrpc: '1.2.6',
+      info: { title: 't', version: 'v' },
+      methods: [
+        { name: 'a', params: [], result: { name: 'r', schema: {} } },
+        { name: 'b', params: [] }, // notification
+      ],
+    };
+    expectTypeOf(doc.methods).toEqualTypeOf<(Method | Notification)[]>();
+  });
+
+  it('SingleNotificationDocumentation has notification omitting name and result', () => {
+    const d: SingleNotificationDocumentation = {
+      notification: { params: [], 'x-experimental': true },
+    };
+    expectTypeOf(d.notification).toEqualTypeOf<Omit<Omit<Method, 'result'>, 'name'>>();
+  });
+});

--- a/src/shared/models/__tests__/openrpc.model.test.ts
+++ b/src/shared/models/__tests__/openrpc.model.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, expectTypeOf } from 'vitest';
+import { getEmptyNotificationDocs } from '@shared/models/openrpc.model';
 import type {
   Method,
   Notification,
@@ -61,5 +62,19 @@ describe('openrpc.model — experimental marker types', () => {
       methods: [notification],
     };
     expect(bad).toBeDefined();
+  });
+
+  it('getEmptyNotificationDocs returns frozen placeholder docs with no result', () => {
+    const docs = getEmptyNotificationDocs();
+    expect(docs).toEqual({
+      summary: '',
+      description: 'Notification: No documentation provided',
+      params: [],
+    });
+    expect('result' in docs).toBe(false);
+    // Building a Notification from the placeholder yields a valid notification entry.
+    const entry: Notification = { name: 'myExt.undocumented', ...docs };
+    expect(entry.name).toBe('myExt.undocumented');
+    expect(Object.isFrozen(docs)).toBe(true);
   });
 });

--- a/src/shared/models/__tests__/openrpc.model.test.ts
+++ b/src/shared/models/__tests__/openrpc.model.test.ts
@@ -2,11 +2,13 @@ import { describe, it, expect, expectTypeOf } from 'vitest';
 import {
   EXPERIMENTAL_OPENRPC_PREFIX,
   getEmptyNotificationDocs,
+  NOTIFICATION_OPENRPC_PREFIX,
   withExperimentalPrefix,
+  withNotificationPrefix,
 } from '@shared/models/openrpc.model';
 import type {
   Method,
-  Notification,
+  OpenRpcNotification,
   NetworkObjectDocumentation,
   OpenRpc,
   SingleNotificationDocumentation,
@@ -24,13 +26,13 @@ describe('openrpc.model — experimental marker types', () => {
   });
 
   it('Notification has no result field', () => {
-    const n: Notification = {
+    const n: OpenRpcNotification = {
       name: 'x',
       params: [],
       'x-experimental': true,
     };
     // @ts-expect-error — Notification cannot have a result
-    const bad: Notification = { name: 'x', params: [], result: { name: 'r', schema: {} } };
+    const bad: OpenRpcNotification = { name: 'x', params: [], result: { name: 'r', schema: {} } };
     expect(bad).toBeDefined();
     expectTypeOf(n.name).toEqualTypeOf<string>();
   });
@@ -49,18 +51,18 @@ describe('openrpc.model — experimental marker types', () => {
         { name: 'b', params: [] }, // notification
       ],
     };
-    expectTypeOf(doc.methods).toEqualTypeOf<(Method | Notification)[]>();
+    expectTypeOf(doc.methods).toEqualTypeOf<(Method | OpenRpcNotification)[]>();
   });
 
   it('SingleNotificationDocumentation has notification omitting name and result', () => {
     const d: SingleNotificationDocumentation = {
       notification: { params: [], 'x-experimental': true },
     };
-    expectTypeOf(d.notification).toEqualTypeOf<Omit<Notification, 'name'>>();
+    expectTypeOf(d.notification).toEqualTypeOf<Omit<OpenRpcNotification, 'name'>>();
   });
 
   it('NetworkObjectDocumentation.methods rejects notifications', () => {
-    const notification: Notification = { name: 'evt', params: [] };
+    const notification: OpenRpcNotification = { name: 'evt', params: [] };
     const bad: NetworkObjectDocumentation = {
       // @ts-expect-error — NetworkObjectDocumentation.methods only accepts Method[], not Notification[]
       methods: [notification],
@@ -77,7 +79,7 @@ describe('openrpc.model — experimental marker types', () => {
     });
     expect('result' in docs).toBe(false);
     // Building a Notification from the placeholder yields a valid notification entry.
-    const entry: Notification = { name: 'myExt.undocumented', ...docs };
+    const entry: OpenRpcNotification = { name: 'myExt.undocumented', ...docs };
     expect(entry.name).toBe('myExt.undocumented');
     expect(Object.isFrozen(docs)).toBe(true);
   });
@@ -111,7 +113,7 @@ describe('openrpc.model — experimental marker types', () => {
   });
 
   it('withExperimentalPrefix fills missing summary/description with the bare prefix', () => {
-    const notification: Notification = { name: 'evt', params: [], 'x-experimental': true };
+    const notification: OpenRpcNotification = { name: 'evt', params: [], 'x-experimental': true };
     const prefixed = withExperimentalPrefix(notification);
     // Even with no text, an experimental entry is marked so the flag is never lost.
     expect(prefixed.summary).toBe(EXPERIMENTAL_OPENRPC_PREFIX);
@@ -119,7 +121,7 @@ describe('openrpc.model — experimental marker types', () => {
   });
 
   it('withExperimentalPrefix does not double-prefix an already-prefixed entry', () => {
-    const notification: Notification = {
+    const notification: OpenRpcNotification = {
       name: 'evt',
       params: [],
       'x-experimental': true,
@@ -127,5 +129,33 @@ describe('openrpc.model — experimental marker types', () => {
     };
     const prefixed = withExperimentalPrefix(notification);
     expect(prefixed.summary).toBe(`${EXPERIMENTAL_OPENRPC_PREFIX}Already marked`);
+  });
+
+  it('withNotificationPrefix prepends (Notification) to a notification summary', () => {
+    const notification: OpenRpcNotification = { name: 'evt', params: [], summary: 'Fires' };
+    const prefixed = withNotificationPrefix(notification);
+    expect(prefixed.summary).toBe(`${NOTIFICATION_OPENRPC_PREFIX}Fires`);
+    // Original is not mutated.
+    expect(notification.summary).toBe('Fires');
+  });
+
+  it('withNotificationPrefix marks a notification even with no summary, and is idempotent', () => {
+    const notification: OpenRpcNotification = { name: 'evt', params: [] };
+    const once = withNotificationPrefix(notification);
+    expect(once.summary).toBe(NOTIFICATION_OPENRPC_PREFIX);
+    expect(withNotificationPrefix(once).summary).toBe(NOTIFICATION_OPENRPC_PREFIX);
+  });
+
+  it('notification + experimental prefixes compose as "(Notification) [EXPERIMENTAL] ..."', () => {
+    const notification: OpenRpcNotification = {
+      name: 'evt',
+      params: [],
+      'x-experimental': true,
+      summary: 'Fires',
+    };
+    const prefixed = withNotificationPrefix(withExperimentalPrefix(notification));
+    expect(prefixed.summary).toBe(
+      `${NOTIFICATION_OPENRPC_PREFIX}${EXPERIMENTAL_OPENRPC_PREFIX}Fires`,
+    );
   });
 });

--- a/src/shared/models/__tests__/openrpc.model.test.ts
+++ b/src/shared/models/__tests__/openrpc.model.test.ts
@@ -110,10 +110,22 @@ describe('openrpc.model — experimental marker types', () => {
     expect(result).toBe(stable);
   });
 
-  it('withExperimentalPrefix leaves missing summary/description untouched', () => {
+  it('withExperimentalPrefix fills missing summary/description with the bare prefix', () => {
     const notification: Notification = { name: 'evt', params: [], 'x-experimental': true };
     const prefixed = withExperimentalPrefix(notification);
-    expect(prefixed.summary).toBeUndefined();
-    expect(prefixed.description).toBeUndefined();
+    // Even with no text, an experimental entry is marked so the flag is never lost.
+    expect(prefixed.summary).toBe(EXPERIMENTAL_OPENRPC_PREFIX);
+    expect(prefixed.description).toBe(EXPERIMENTAL_OPENRPC_PREFIX);
+  });
+
+  it('withExperimentalPrefix does not double-prefix an already-prefixed entry', () => {
+    const notification: Notification = {
+      name: 'evt',
+      params: [],
+      'x-experimental': true,
+      summary: `${EXPERIMENTAL_OPENRPC_PREFIX}Already marked`,
+    };
+    const prefixed = withExperimentalPrefix(notification);
+    expect(prefixed.summary).toBe(`${EXPERIMENTAL_OPENRPC_PREFIX}Already marked`);
   });
 });

--- a/src/shared/models/__tests__/openrpc.model.test.ts
+++ b/src/shared/models/__tests__/openrpc.model.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, expectTypeOf } from 'vitest';
-import { getEmptyNotificationDocs } from '@shared/models/openrpc.model';
+import {
+  EXPERIMENTAL_OPENRPC_PREFIX,
+  getEmptyNotificationDocs,
+  withExperimentalPrefix,
+} from '@shared/models/openrpc.model';
 import type {
   Method,
   Notification,
@@ -76,5 +80,40 @@ describe('openrpc.model — experimental marker types', () => {
     const entry: Notification = { name: 'myExt.undocumented', ...docs };
     expect(entry.name).toBe('myExt.undocumented');
     expect(Object.isFrozen(docs)).toBe(true);
+  });
+
+  it('withExperimentalPrefix prepends EXPERIMENTAL: to experimental entries only', () => {
+    const experimental: Method = {
+      name: 'x',
+      params: [],
+      result: { name: 'r', schema: {} },
+      'x-experimental': true,
+      summary: 'Does the thing',
+      description: 'Long description',
+    };
+    const prefixed = withExperimentalPrefix(experimental);
+    expect(prefixed.summary).toBe(`${EXPERIMENTAL_OPENRPC_PREFIX}Does the thing`);
+    expect(prefixed.description).toBe(`${EXPERIMENTAL_OPENRPC_PREFIX}Long description`);
+    // Original is not mutated.
+    expect(experimental.summary).toBe('Does the thing');
+  });
+
+  it('withExperimentalPrefix is a no-op for non-experimental entries', () => {
+    const stable: Method = {
+      name: 'x',
+      params: [],
+      result: { name: 'r', schema: {} },
+      summary: 'Does the thing',
+    };
+    const result = withExperimentalPrefix(stable);
+    expect(result.summary).toBe('Does the thing');
+    expect(result).toBe(stable);
+  });
+
+  it('withExperimentalPrefix leaves missing summary/description untouched', () => {
+    const notification: Notification = { name: 'evt', params: [], 'x-experimental': true };
+    const prefixed = withExperimentalPrefix(notification);
+    expect(prefixed.summary).toBeUndefined();
+    expect(prefixed.description).toBeUndefined();
   });
 });

--- a/src/shared/models/__tests__/openrpc.model.test.ts
+++ b/src/shared/models/__tests__/openrpc.model.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expectTypeOf } from 'vitest';
 import type {
   Method,
-  OpenRpcNotification,
+  Notification,
   NetworkObjectDocumentation,
   OpenRpc,
   SingleNotificationDocumentation,
@@ -18,14 +18,14 @@ describe('openrpc.model — experimental marker types', () => {
     expectTypeOf(m['x-experimental']).toEqualTypeOf<boolean | undefined>();
   });
 
-  it('OpenRpcNotification has no result field', () => {
-    const n: OpenRpcNotification = {
+  it('Notification has no result field', () => {
+    const n: Notification = {
       name: 'x',
       params: [],
       'x-experimental': true,
     };
-    // @ts-expect-error — OpenRpcNotification cannot have a result
-    const bad: OpenRpcNotification = { name: 'x', params: [], result: { name: 'r', schema: {} } };
+    // @ts-expect-error — Notification cannot have a result
+    const bad: Notification = { name: 'x', params: [], result: { name: 'r', schema: {} } };
     void bad;
     expectTypeOf(n.name).toEqualTypeOf<string>();
   });
@@ -35,7 +35,7 @@ describe('openrpc.model — experimental marker types', () => {
     expectTypeOf(d['x-experimental']).toEqualTypeOf<boolean | undefined>();
   });
 
-  it('OpenRpc.methods accepts both Method and OpenRpcNotification', () => {
+  it('OpenRpc.methods accepts both Method and Notification', () => {
     const doc: OpenRpc = {
       openrpc: '1.2.6',
       info: { title: 't', version: 'v' },
@@ -44,20 +44,20 @@ describe('openrpc.model — experimental marker types', () => {
         { name: 'b', params: [] }, // notification
       ],
     };
-    expectTypeOf(doc.methods).toEqualTypeOf<(Method | OpenRpcNotification)[]>();
+    expectTypeOf(doc.methods).toEqualTypeOf<(Method | Notification)[]>();
   });
 
   it('SingleNotificationDocumentation has notification omitting name and result', () => {
     const d: SingleNotificationDocumentation = {
       notification: { params: [], 'x-experimental': true },
     };
-    expectTypeOf(d.notification).toEqualTypeOf<Omit<OpenRpcNotification, 'name'>>();
+    expectTypeOf(d.notification).toEqualTypeOf<Omit<Notification, 'name'>>();
   });
 
   it('NetworkObjectDocumentation.methods rejects notifications', () => {
-    const notification: OpenRpcNotification = { name: 'evt', params: [] };
+    const notification: Notification = { name: 'evt', params: [] };
     const bad: NetworkObjectDocumentation = {
-      // @ts-expect-error — NetworkObjectDocumentation.methods only accepts Method[], not OpenRpcNotification[]
+      // @ts-expect-error — NetworkObjectDocumentation.methods only accepts Method[], not Notification[]
       methods: [notification],
     };
     void bad;

--- a/src/shared/models/__tests__/openrpc.model.test.ts
+++ b/src/shared/models/__tests__/openrpc.model.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expectTypeOf } from 'vitest';
+import { describe, it, expect, expectTypeOf } from 'vitest';
 import type {
   Method,
   Notification,
@@ -26,7 +26,7 @@ describe('openrpc.model — experimental marker types', () => {
     };
     // @ts-expect-error — Notification cannot have a result
     const bad: Notification = { name: 'x', params: [], result: { name: 'r', schema: {} } };
-    void bad;
+    expect(bad).toBeDefined();
     expectTypeOf(n.name).toEqualTypeOf<string>();
   });
 
@@ -60,6 +60,6 @@ describe('openrpc.model — experimental marker types', () => {
       // @ts-expect-error — NetworkObjectDocumentation.methods only accepts Method[], not Notification[]
       methods: [notification],
     };
-    void bad;
+    expect(bad).toBeDefined();
   });
 });

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -110,7 +110,8 @@ export type Method = {
   result: ContentDescriptor | Reference;
   /**
    * Set to `true` to mark this method as experimental — its shape may change without notice.
-   * Informational only; does not affect runtime behavior. See the experimental APIs wiki page.
+   * Informational only; does not affect runtime behavior. See the
+   * {@link https://github.com/paranext/paranext-extension-template/wiki/Experimental-APIs | experimental APIs wiki page}.
    */
   'x-experimental'?: boolean;
   /** A short summary of what the method does. */
@@ -249,7 +250,7 @@ export function createEmptyOpenRpc(papiVersion: string): OpenRpc {
 
 const emptyDocs: MethodDocumentationWithoutName = {
   summary: '',
-  description: 'No documentation provided',
+  description: 'Method: No documentation provided',
   params: [],
   result: {
     name: 'return value',
@@ -268,4 +269,23 @@ Object.freeze(emptyDocs.result.schema);
  */
 export function getEmptyMethodDocs(): MethodDocumentationWithoutName {
   return emptyDocs;
+}
+
+// A notification is a {@link Method} without a `result`, so its placeholder docs are the empty
+// method docs minus `result`.
+const emptyNotificationDocs: Omit<MethodDocumentationWithoutName, 'result'> = {
+  summary: '',
+  description: 'Notification: No documentation provided',
+  params: [],
+};
+Object.freeze(emptyNotificationDocs);
+Object.freeze(emptyNotificationDocs.params);
+
+/**
+ * Get an empty {@link Notification} documentation object. Useful for surfacing events that didn't
+ * have their own documentation provided so that every registered event still appears in the OpenRPC
+ * document (mirroring how undocumented methods are surfaced via {@link getEmptyMethodDocs}).
+ */
+export function getEmptyNotificationDocs(): Omit<MethodDocumentationWithoutName, 'result'> {
+  return emptyNotificationDocs;
 }

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -162,10 +162,10 @@ export type Tag = {
 export type MethodDocumentationWithoutName = Omit<Method, 'name'>;
 
 /**
- * Documentation about a single {@link Method}. Informational only; appears in the generated OpenRPC
- * document.
+ * Documentation about a single {@link Method}.
  *
- * Set `method['x-experimental']: true` to mark this method as experimental.
+ * Set `method['x-experimental']: true` to mark this method as experimental. Informational only;
+ * appears in the generated OpenRPC document.
  */
 export type SingleMethodDocumentation = {
   method: MethodDocumentationWithoutName;
@@ -183,10 +183,10 @@ export type SingleMethodDocumentation = {
 export type Notification = Omit<Method, 'result'>;
 
 /**
- * Documentation about a single {@link Notification}. Informational only; appears in the generated
- * OpenRPC document.
+ * Documentation about a single {@link Notification}.
  *
  * Set `notification['x-experimental']: true` to mark this notification as experimental.
+ * Informational only; appears in the generated OpenRPC document.
  */
 export type SingleNotificationDocumentation = {
   notification: Omit<Notification, 'name'>;
@@ -194,8 +194,8 @@ export type SingleNotificationDocumentation = {
 };
 
 /**
- * Documentation about all methods on a network object. Pass to `networkObjectService.set`,
- * `dataProviderService.registerEngine`, or `webViewProviderService.registerWebViewProvider`.
+ * Documentation about a network object — what it is, and OpenRPC documentation for each of its
+ * methods.
  */
 export type NetworkObjectDocumentation = {
   summary?: string;

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -162,8 +162,10 @@ export type Tag = {
 export type MethodDocumentationWithoutName = Omit<Method, 'name'>;
 
 /**
- * Documentation about a single method. Set `method['x-experimental']: true` to mark this method as
- * experimental. Informational only; appears in the generated OpenRPC document.
+ * Documentation about a single {@link Method}. Informational only; appears in the generated OpenRPC
+ * document.
+ *
+ * Set `method['x-experimental']: true` to mark this method as experimental.
  */
 export type SingleMethodDocumentation = {
   method: MethodDocumentationWithoutName;
@@ -181,24 +183,28 @@ export type SingleMethodDocumentation = {
 export type OpenRpcNotification = Omit<Method, 'result'>;
 
 /**
- * Documentation about a single notification. Set `notification['x-experimental']: true` to mark
- * this notification as experimental. Informational only; appears in the generated OpenRPC
- * document.
+ * Documentation about a single {@link OpenRpcNotification}. Informational only; appears in the
+ * generated OpenRPC document.
+ *
+ * Set `notification['x-experimental']: true` to mark this notification as experimental.
  */
 export type SingleNotificationDocumentation = {
   notification: Omit<OpenRpcNotification, 'name'>;
   components?: Components;
 };
 
-/** Documentation about all methods on a network object */
+/**
+ * Documentation about all methods on a network object. Pass to `networkObjectService.set`,
+ * `dataProviderService.registerEngine`, or `webViewProviderService.registerWebViewProvider`.
+ */
 export type NetworkObjectDocumentation = {
   summary?: string;
   description?: string;
   methods?: Method[];
   components?: Components;
   /**
-   * Set to `true` to mark every method registered for this network object as experimental. The
-   * marker is fanned out onto each method's `'x-experimental'` field inside
+   * Set to `true` to mark every {@link Method} registered for this network object as experimental.
+   * The marker is fanned out onto each method's `'x-experimental'` field inside
    * `networkObjectService.set`.
    */
   'x-experimental'?: boolean;

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -24,7 +24,7 @@ export type OpenRpc = {
   openrpc: string;
   info: Info;
   servers?: Server[];
-  methods: (Method | Notification)[];
+  methods: (Method | OpenRpcNotification)[];
   components?: Components;
   externalDocs?: ExternalDocumentation;
 };
@@ -172,11 +172,11 @@ export type SingleMethodDocumentation = {
  * one-way messages from server to client. Per the OpenRPC convention (no `result` ⇒ notification),
  * these are serialized into the same root `methods` array as Methods on the wire.
  */
-export type Notification = Omit<Method, 'result'>;
+export type OpenRpcNotification = Omit<Method, 'result'>;
 
 /** Documentation about a single notification */
 export type SingleNotificationDocumentation = {
-  notification: Omit<Notification, 'name'>;
+  notification: Omit<OpenRpcNotification, 'name'>;
   components?: Components;
 };
 

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -12,8 +12,12 @@ import type { JSONSchema7 } from 'json-schema';
  * See https://github.com/open-rpc/meta-schema/releases - Release 1.14.2 aligns with OpenRPC 1.2.6.
  * https://github.com/open-rpc/meta-schema/releases/download/1.14.2/open-rpc-meta-schema.json
  *
- * We don't want to go past 1.2.6 because https://playground.open-rpc.org/ doesn't support anything
- * past 1.2.6 for now. See https://github.com/open-rpc/playground/issues/606.
+ * We declare OpenRPC `1.3.0` because notifications (a method with no `result`) were introduced in
+ * 1.3.0 — `result` was required in 1.2.6, so a document with notifications is invalid under the
+ * 1.2.6 meta-schema. The OpenRPC playground (https://playground.open-rpc.org/) is still capped at
+ * 1.2.6 (https://github.com/open-rpc/playground/issues/606), but it renders a 1.3.0 document fine
+ * in practice; it just lists notifications under the same "Methods" heading, which we mitigate by
+ * prefixing notification summaries with {@link NOTIFICATION_OPENRPC_PREFIX}.
  *
  * Note that the types from https://www.npmjs.com/package/@open-rpc/meta-schema/v/1.14.2 are not
  * very good. For example, all the properties of `Components` are of type `any` instead of the
@@ -24,7 +28,7 @@ export type OpenRpc = {
   openrpc: string;
   info: Info;
   servers?: Server[];
-  methods: (Method | Notification)[];
+  methods: (Method | OpenRpcNotification)[];
   components?: Components;
   externalDocs?: ExternalDocumentation;
 };
@@ -180,17 +184,21 @@ export type SingleMethodDocumentation = {
  *
  * Set `'x-experimental': true` on the notification object to mark it as experimental. Informational
  * only; appears in the generated OpenRPC document.
+ *
+ * Named `OpenRpcNotification` (rather than `Notification`) to avoid shadowing the DOM global
+ * `Notification` type — a file that forgot to import this would otherwise silently typecheck
+ * against the wrong type.
  */
-export type Notification = Omit<Method, 'result'>;
+export type OpenRpcNotification = Omit<Method, 'result'>;
 
 /**
- * Documentation about a single {@link Notification}.
+ * Documentation about a single {@link OpenRpcNotification}.
  *
  * Set `notification['x-experimental']: true` to mark this notification as experimental.
  * Informational only; appears in the generated OpenRPC document.
  */
 export type SingleNotificationDocumentation = {
-  notification: Omit<Notification, 'name'>;
+  notification: Omit<OpenRpcNotification, 'name'>;
   components?: Components;
 };
 
@@ -214,7 +222,7 @@ export type NetworkObjectDocumentation = {
 /** Create an object of type {@link OpenRpc} to hold documentation for PAPI websocket methods */
 export function createEmptyOpenRpc(papiVersion: string): OpenRpc {
   return {
-    openrpc: '1.2.6',
+    openrpc: '1.3.0',
     info: {
       version: papiVersion,
       title: 'Live PAPI documentation',
@@ -282,9 +290,10 @@ Object.freeze(emptyNotificationDocs);
 Object.freeze(emptyNotificationDocs.params);
 
 /**
- * Get an empty {@link Notification} documentation object. Useful for surfacing events that didn't
- * have their own documentation provided so that every registered event still appears in the OpenRPC
- * document (mirroring how undocumented methods are surfaced via {@link getEmptyMethodDocs}).
+ * Get an empty {@link OpenRpcNotification} documentation object. Useful for surfacing events that
+ * didn't have their own documentation provided so that every registered event still appears in the
+ * OpenRPC document (mirroring how undocumented methods are surfaced via
+ * {@link getEmptyMethodDocs}).
  */
 export function getEmptyNotificationDocs(): Omit<MethodDocumentationWithoutName, 'result'> {
   return emptyNotificationDocs;
@@ -304,17 +313,37 @@ function prependExperimental(text: string | undefined): string {
 }
 
 /**
- * Returns a shallow copy of an OpenRPC {@link Method} or {@link Notification} with
+ * Returns a shallow copy of an OpenRPC {@link Method} or {@link OpenRpcNotification} with
  * {@link EXPERIMENTAL_OPENRPC_PREFIX} prepended to its `summary` and `description` when the entry is
  * marked `'x-experimental'`. Both fields are always set on an experimental entry — even a missing
  * or empty summary/description becomes the bare prefix so the marker is never lost. Idempotent: an
  * entry already starting with the prefix is left unchanged. Returns the entry untouched when it is
  * not experimental.
  */
-export function withExperimentalPrefix<T extends Method | Notification>(entry: T): T {
+export function withExperimentalPrefix<T extends Method | OpenRpcNotification>(entry: T): T {
   if (!entry['x-experimental']) return entry;
   const prefixed = { ...entry };
   prefixed.summary = prependExperimental(prefixed.summary);
   prefixed.description = prependExperimental(prefixed.description);
   return prefixed;
+}
+
+/**
+ * Prefix prepended to a notification's `summary`. OpenRPC carries notifications in the same root
+ * `methods` array as methods, so tooling that lists both together (e.g. the OpenRPC playground)
+ * shows them under one "Methods" heading. This prefix makes notifications distinguishable at a
+ * glance, the same way {@link EXPERIMENTAL_OPENRPC_PREFIX} marks experimental entries.
+ */
+export const NOTIFICATION_OPENRPC_PREFIX = '(Notification) ';
+
+/**
+ * Returns a shallow copy of an OpenRPC {@link OpenRpcNotification} with
+ * {@link NOTIFICATION_OPENRPC_PREFIX} prepended to its `summary` so it is distinguishable from
+ * methods in tooling that lists both together. Applied to every notification (unlike the
+ * experimental prefix). Idempotent: an entry whose summary already starts with the prefix is left
+ * unchanged.
+ */
+export function withNotificationPrefix(entry: OpenRpcNotification): OpenRpcNotification {
+  if (entry.summary?.startsWith(NOTIFICATION_OPENRPC_PREFIX)) return entry;
+  return { ...entry, summary: `${NOTIFICATION_OPENRPC_PREFIX}${entry.summary ?? ''}` };
 }

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -161,7 +161,10 @@ export type Tag = {
 
 export type MethodDocumentationWithoutName = Omit<Method, 'name'>;
 
-/** Documentation about a single method */
+/**
+ * Documentation about a single method. Set `method['x-experimental']: true` to mark this method as
+ * experimental. Informational only; appears in the generated OpenRPC document.
+ */
 export type SingleMethodDocumentation = {
   method: MethodDocumentationWithoutName;
   components?: Components;
@@ -171,10 +174,17 @@ export type SingleMethodDocumentation = {
  * An OpenRPC notification — same shape as a {@link Method}, but without `result`. Used for events /
  * one-way messages from server to client. Per the OpenRPC convention (no `result` ⇒ notification),
  * these are serialized into the same root `methods` array as Methods on the wire.
+ *
+ * Set `'x-experimental': true` on the notification object to mark it as experimental. Informational
+ * only; appears in the generated OpenRPC document.
  */
 export type OpenRpcNotification = Omit<Method, 'result'>;
 
-/** Documentation about a single notification */
+/**
+ * Documentation about a single notification. Set `notification['x-experimental']: true` to mark
+ * this notification as experimental. Informational only; appears in the generated OpenRPC
+ * document.
+ */
 export type SingleNotificationDocumentation = {
   notification: Omit<OpenRpcNotification, 'name'>;
   components?: Components;

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -9,17 +9,17 @@ import type { JSONSchema7 } from 'json-schema';
 /**
  * Describes APIs available to call using JSON-RPC 2.0
  *
- * See https://github.com/open-rpc/meta-schema/releases - Release 1.14.2 aligns with OpenRPC 1.2.6.
- * https://github.com/open-rpc/meta-schema/releases/download/1.14.2/open-rpc-meta-schema.json
+ * See https://github.com/open-rpc/meta-schema/releases - Release 1.14.3 aligns with OpenRPC 1.3.0.
+ * https://github.com/open-rpc/meta-schema/releases/download/1.14.3/open-rpc-meta-schema.json
  *
  * We declare OpenRPC `1.3.0` because notifications (a method with no `result`) were introduced in
  * 1.3.0 — `result` was required in 1.2.6, so a document with notifications is invalid under the
  * 1.2.6 meta-schema. The OpenRPC playground (https://playground.open-rpc.org/) is still capped at
  * 1.2.6 (https://github.com/open-rpc/playground/issues/606), but it renders a 1.3.0 document fine
- * in practice; it just lists notifications under the same "Methods" heading, which we mitigate by
- * prefixing notification summaries with {@link NOTIFICATION_OPENRPC_PREFIX}.
+ * in practice; it lists notifications under the same "Methods" heading (without a results field),
+ * which we mitigate by prefixing notification summaries with {@link NOTIFICATION_OPENRPC_PREFIX}.
  *
- * Note that the types from https://www.npmjs.com/package/@open-rpc/meta-schema/v/1.14.2 are not
+ * Note that the types from https://www.npmjs.com/package/@open-rpc/meta-schema/v/1.14.3 are not
  * very good. For example, all the properties of `Components` are of type `any` instead of the
  * specific types they should be, and they redefine types for JSON Schema. So we're using our own
  * types here instead.
@@ -184,10 +184,6 @@ export type SingleMethodDocumentation = {
  *
  * Set `'x-experimental': true` on the notification object to mark it as experimental. Informational
  * only; appears in the generated OpenRPC document.
- *
- * Named `OpenRpcNotification` (rather than `Notification`) to avoid shadowing the DOM global
- * `Notification` type — a file that forgot to import this would otherwise silently typecheck
- * against the wrong type.
  */
 export type OpenRpcNotification = Omit<Method, 'result'>;
 

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -24,7 +24,7 @@ export type OpenRpc = {
   openrpc: string;
   info: Info;
   servers?: Server[];
-  methods: Method[];
+  methods: (Method | Notification)[];
   components?: Components;
   externalDocs?: ExternalDocumentation;
 };
@@ -108,6 +108,11 @@ export type Method = {
   name: string;
   params: (ContentDescriptor | Reference)[];
   result: ContentDescriptor | Reference;
+  /**
+   * Set to `true` to mark this method as experimental — its shape may change without notice.
+   * Informational only; does not affect runtime behavior. See the experimental APIs wiki page.
+   */
+  'x-experimental'?: boolean;
   /** A short summary of what the method does. */
   summary?: string;
   /**
@@ -162,12 +167,31 @@ export type SingleMethodDocumentation = {
   components?: Components;
 };
 
+/**
+ * An OpenRPC notification — same shape as a {@link Method}, but without `result`. Used for events /
+ * one-way messages from server to client. Per the OpenRPC convention (no `result` ⇒ notification),
+ * these are serialized into the same root `methods` array as Methods on the wire.
+ */
+export type Notification = Omit<Method, 'result'>;
+
+/** Documentation about a single notification */
+export type SingleNotificationDocumentation = {
+  notification: Omit<Notification, 'name'>;
+  components?: Components;
+};
+
 /** Documentation about all methods on a network object */
 export type NetworkObjectDocumentation = {
   summary?: string;
   description?: string;
   methods?: Method[];
   components?: Components;
+  /**
+   * Set to `true` to mark every method registered for this network object as experimental. The
+   * marker is fanned out onto each method's `'x-experimental'` field inside
+   * `networkObjectService.set`.
+   */
+  'x-experimental'?: boolean;
 };
 
 /** Create an object of type {@link OpenRpc} to hold documentation for PAPI websocket methods */

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -291,20 +291,30 @@ export function getEmptyNotificationDocs(): Omit<MethodDocumentationWithoutName,
 }
 
 /** Prefix prepended to the `summary` and `description` of experimental methods and notifications. */
-export const EXPERIMENTAL_OPENRPC_PREFIX = 'EXPERIMENTAL: ';
+export const EXPERIMENTAL_OPENRPC_PREFIX = '[EXPERIMENTAL] ';
+
+/**
+ * Prepends {@link EXPERIMENTAL_OPENRPC_PREFIX} to a summary/description string. Leaves the string
+ * unchanged when it already starts with the prefix (idempotent). A falsy string still receives the
+ * prefix, so an experimental entry is always visibly marked even when it had no text.
+ */
+function prependExperimental(text: string | undefined): string {
+  if (text?.startsWith(EXPERIMENTAL_OPENRPC_PREFIX)) return text;
+  return `${EXPERIMENTAL_OPENRPC_PREFIX}${text ?? ''}`;
+}
 
 /**
  * Returns a shallow copy of an OpenRPC {@link Method} or {@link Notification} with
  * {@link EXPERIMENTAL_OPENRPC_PREFIX} prepended to its `summary` and `description` when the entry is
- * marked `'x-experimental'`. Returns the entry unchanged when it is not experimental. Call this on
- * a freshly-built entry so the prefix is applied at most once.
+ * marked `'x-experimental'`. Both fields are always set on an experimental entry — even a missing
+ * or empty summary/description becomes the bare prefix so the marker is never lost. Idempotent: an
+ * entry already starting with the prefix is left unchanged. Returns the entry untouched when it is
+ * not experimental.
  */
 export function withExperimentalPrefix<T extends Method | Notification>(entry: T): T {
   if (!entry['x-experimental']) return entry;
   const prefixed = { ...entry };
-  if (prefixed.summary !== undefined)
-    prefixed.summary = `${EXPERIMENTAL_OPENRPC_PREFIX}${prefixed.summary}`;
-  if (prefixed.description !== undefined)
-    prefixed.description = `${EXPERIMENTAL_OPENRPC_PREFIX}${prefixed.description}`;
+  prefixed.summary = prependExperimental(prefixed.summary);
+  prefixed.description = prependExperimental(prefixed.description);
   return prefixed;
 }

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -289,3 +289,22 @@ Object.freeze(emptyNotificationDocs.params);
 export function getEmptyNotificationDocs(): Omit<MethodDocumentationWithoutName, 'result'> {
   return emptyNotificationDocs;
 }
+
+/** Prefix prepended to the `summary` and `description` of experimental methods and notifications. */
+export const EXPERIMENTAL_OPENRPC_PREFIX = 'EXPERIMENTAL: ';
+
+/**
+ * Returns a shallow copy of an OpenRPC {@link Method} or {@link Notification} with
+ * {@link EXPERIMENTAL_OPENRPC_PREFIX} prepended to its `summary` and `description` when the entry is
+ * marked `'x-experimental'`. Returns the entry unchanged when it is not experimental. Call this on
+ * a freshly-built entry so the prefix is applied at most once.
+ */
+export function withExperimentalPrefix<T extends Method | Notification>(entry: T): T {
+  if (!entry['x-experimental']) return entry;
+  const prefixed = { ...entry };
+  if (prefixed.summary !== undefined)
+    prefixed.summary = `${EXPERIMENTAL_OPENRPC_PREFIX}${prefixed.summary}`;
+  if (prefixed.description !== undefined)
+    prefixed.description = `${EXPERIMENTAL_OPENRPC_PREFIX}${prefixed.description}`;
+  return prefixed;
+}

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -24,7 +24,7 @@ export type OpenRpc = {
   openrpc: string;
   info: Info;
   servers?: Server[];
-  methods: (Method | OpenRpcNotification)[];
+  methods: (Method | Notification)[];
   components?: Components;
   externalDocs?: ExternalDocumentation;
 };
@@ -180,16 +180,16 @@ export type SingleMethodDocumentation = {
  * Set `'x-experimental': true` on the notification object to mark it as experimental. Informational
  * only; appears in the generated OpenRPC document.
  */
-export type OpenRpcNotification = Omit<Method, 'result'>;
+export type Notification = Omit<Method, 'result'>;
 
 /**
- * Documentation about a single {@link OpenRpcNotification}. Informational only; appears in the
- * generated OpenRPC document.
+ * Documentation about a single {@link Notification}. Informational only; appears in the generated
+ * OpenRPC document.
  *
  * Set `notification['x-experimental']: true` to mark this notification as experimental.
  */
 export type SingleNotificationDocumentation = {
-  notification: Omit<OpenRpcNotification, 'name'>;
+  notification: Omit<Notification, 'name'>;
   components?: Components;
 };
 

--- a/src/shared/models/project-data-provider-engine-factory.model.ts
+++ b/src/shared/models/project-data-provider-engine-factory.model.ts
@@ -42,21 +42,18 @@ export interface IProjectDataProviderEngineFactory<
     layeringFilters?: ProjectMetadataFilterOptions,
   ): Promise<ProjectMetadataWithoutFactoryInfo[]>;
   /**
-   * Create a {@link IProjectDataProviderEngine} for the project requested so the papi can create an
+   * Create an {@link IProjectDataProviderEngine} for the project requested so the papi can create an
    * {@link IProjectDataProvider} for the project.
    *
-   * The return value may be either the engine directly, or an envelope object with the engine plus
-   * optional per-PDP-instance attributes and documentation. The unusual property name
-   * `projectDataProviderEngine` (rather than `engine`) is deliberate — it cannot collide with a
-   * property the engine itself might expose, so the platform's narrowing check on the return shape
-   * is unambiguous.
+   * The return value may be either the engine directly, or an envelope containing the engine and
+   * PDP network metadata (per-PDP attributes and documentation).
    *
-   * The platform overwrites `projectId` in any supplied per-PDP attributes — that field is always
-   * the platform-canonical value.
+   * The platform overwrites `projectId` and `projectInterfaces` in any supplied per-PDP attributes
+   * — those fields are always the platform-canonical values.
    *
-   * @param projectId Id of the project for which to create a {@link IProjectDataProviderEngine}
-   * @returns Either the engine, or an envelope `{ projectDataProviderEngine, attributes?,
-   *   documentation? }`
+   * @param projectId Id of the project for which to create an {@link IProjectDataProviderEngine}
+   * @returns Either the {@link IProjectDataProviderEngine} directly, or an envelope `{
+   *   projectDataProviderEngine, attributes?, documentation? }`
    */
   createProjectDataProviderEngine(projectId: string): Promise<
     | IProjectDataProviderEngine<SupportedProjectInterfaces>

--- a/src/shared/models/project-data-provider-engine-factory.model.ts
+++ b/src/shared/models/project-data-provider-engine-factory.model.ts
@@ -1,6 +1,7 @@
 import { IProjectDataProviderEngine } from '@shared/models/project-data-provider-engine.model';
 import { ProjectMetadataFilterOptions } from '@shared/models/project-data-provider-factory.interface';
 import { ProjectMetadataWithoutFactoryInfo } from '@shared/models/project-metadata.model';
+import type { NetworkObjectDocumentation } from '@shared/models/openrpc.model';
 import { projectLookupService } from '@shared/services/project-lookup.service';
 import { ProjectInterfaces } from 'papi-shared-types';
 import { escapeStringRegexp, getErrorMessage } from 'platform-bible-utils';
@@ -42,16 +43,29 @@ export interface IProjectDataProviderEngineFactory<
   ): Promise<ProjectMetadataWithoutFactoryInfo[]>;
   /**
    * Create a {@link IProjectDataProviderEngine} for the project requested so the papi can create an
-   * {@link IProjectDataProvider} for the project. This project will have the same
-   * `projectInterface`s as this Project Data Provider Engine Factory
+   * {@link IProjectDataProvider} for the project.
+   *
+   * The return value may be either the engine directly, or an envelope object with the engine plus
+   * optional per-PDP-instance attributes and documentation. The unusual property name
+   * `projectDataProviderEngine` (rather than `engine`) is deliberate — it cannot collide with a
+   * property the engine itself might expose, so the platform's narrowing check on the return shape
+   * is unambiguous.
+   *
+   * The platform overwrites `projectId` in any supplied per-PDP attributes — that field is always
+   * the platform-canonical value.
    *
    * @param projectId Id of the project for which to create a {@link IProjectDataProviderEngine}
-   * @returns A promise that resolves to a {@link IProjectDataProviderEngine} for the project passed
-   *   in
+   * @returns Either the engine, or an envelope `{ projectDataProviderEngine, attributes?,
+   *   documentation? }`
    */
-  createProjectDataProviderEngine(
-    projectId: string,
-  ): Promise<IProjectDataProviderEngine<SupportedProjectInterfaces>>;
+  createProjectDataProviderEngine(projectId: string): Promise<
+    | IProjectDataProviderEngine<SupportedProjectInterfaces>
+    | {
+        projectDataProviderEngine: IProjectDataProviderEngine<SupportedProjectInterfaces>;
+        attributes?: { [property: string]: unknown };
+        documentation?: NetworkObjectDocumentation;
+      }
+  >;
 }
 
 /**

--- a/src/shared/models/project-data-provider-engine-factory.model.ts
+++ b/src/shared/models/project-data-provider-engine-factory.model.ts
@@ -52,8 +52,8 @@ export interface IProjectDataProviderEngineFactory<
    * — those fields are always the platform-canonical values.
    *
    * @param projectId Id of the project for which to create an {@link IProjectDataProviderEngine}
-   * @returns Either the {@link IProjectDataProviderEngine} directly, or an envelope `{
-   *   projectDataProviderEngine, attributes?, documentation? }`
+   * @returns Either the {@link IProjectDataProviderEngine} or an envelope containing the engine and
+   *   per-PDP network object metadata (attributes and documentation).
    */
   createProjectDataProviderEngine(projectId: string): Promise<
     | IProjectDataProviderEngine<SupportedProjectInterfaces>

--- a/src/shared/models/project-data-provider-engine-factory.model.ts
+++ b/src/shared/models/project-data-provider-engine-factory.model.ts
@@ -7,6 +7,43 @@ import { ProjectInterfaces } from 'papi-shared-types';
 import { escapeStringRegexp, getErrorMessage } from 'platform-bible-utils';
 
 /**
+ * Envelope that {@link IProjectDataProviderEngineFactory.createProjectDataProviderEngine} may return
+ * instead of the engine directly, carrying per-PDP network object metadata alongside the engine.
+ *
+ * WARNING: `projectDataProviderEngine` is a reserved discriminating property — do not expose a
+ * property by that name on a raw engine, or the platform will treat the engine as an envelope.
+ */
+export interface ProjectDataProviderEngineEnvelope<
+  SupportedProjectInterfaces extends ProjectInterfaces[],
+> {
+  projectDataProviderEngine: IProjectDataProviderEngine<SupportedProjectInterfaces>;
+  attributes?: { [property: string]: unknown };
+  documentation?: NetworkObjectDocumentation;
+}
+
+/**
+ * Type guard: whether a `createProjectDataProviderEngine` return value is a
+ * {@link ProjectDataProviderEngineEnvelope} rather than a raw engine. Guards against `typeof null
+ * === 'object'` and against a raw engine that merely exposes a `projectDataProviderEngine` property
+ * of a non-object type. Written as a user-defined type guard so the value check doesn't defeat the
+ * narrowing at call sites.
+ */
+export function isProjectDataProviderEngineEnvelope<
+  SupportedProjectInterfaces extends ProjectInterfaces[],
+>(
+  value:
+    | IProjectDataProviderEngine<SupportedProjectInterfaces>
+    | ProjectDataProviderEngineEnvelope<SupportedProjectInterfaces>,
+): value is ProjectDataProviderEngineEnvelope<SupportedProjectInterfaces> {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'projectDataProviderEngine' in value &&
+    typeof value.projectDataProviderEngine === 'object'
+  );
+}
+
+/**
  * A factory object registered with the papi that creates a Project Data Provider Engine for each
  * project with the factory's specified `projectInterface`s when the papi requests. Used by the papi
  * to create {@link IProjectDataProviderEngine}s for a specific project and `projectInterface` when
@@ -55,13 +92,11 @@ export interface IProjectDataProviderEngineFactory<
    * @returns Either the {@link IProjectDataProviderEngine} or an envelope containing the engine and
    *   per-PDP network object metadata (attributes and documentation).
    */
-  createProjectDataProviderEngine(projectId: string): Promise<
+  createProjectDataProviderEngine(
+    projectId: string,
+  ): Promise<
     | IProjectDataProviderEngine<SupportedProjectInterfaces>
-    | {
-        projectDataProviderEngine: IProjectDataProviderEngine<SupportedProjectInterfaces>;
-        attributes?: { [property: string]: unknown };
-        documentation?: NetworkObjectDocumentation;
-      }
+    | ProjectDataProviderEngineEnvelope<SupportedProjectInterfaces>
   >;
 }
 

--- a/src/shared/models/rpc.interface.ts
+++ b/src/shared/models/rpc.interface.ts
@@ -4,7 +4,10 @@ import {
   InternalRequestHandler,
   RequestParams,
 } from '@shared/data/rpc.model';
-import { SingleMethodDocumentation } from '@shared/models/openrpc.model';
+import {
+  SingleMethodDocumentation,
+  SingleNotificationDocumentation,
+} from '@shared/models/openrpc.model';
 import { SerializedRequestType } from '@shared/utils/util';
 import { JSONRPCResponse } from 'json-rpc-2.0';
 
@@ -84,9 +87,40 @@ export interface IRpcMethodRegistrar extends IRpcHandler {
   ) => Promise<boolean>;
   /** Unregister a method so it is no longer available to RPC requests */
   unregisterMethod: (methodName: string) => Promise<boolean>;
+  /**
+   * Register a centrally-tracked network event with the main process. Shared vs exclusive semantics
+   * is determined by looking up the event name in `SHARED_EVENT_NAMES`.
+   *
+   * Returns `true` if the registration was accepted, `false` otherwise. Used by
+   * `createNetworkEventEmitterAsync`; not for direct caller use.
+   */
+  registerEvent: (
+    eventName: string,
+    documentation?: SingleNotificationDocumentation,
+  ) => Promise<boolean>;
+  /** Unregister a network event emitter so it is no longer tracked centrally */
+  unregisterEvent: (eventName: string) => Promise<boolean>;
 }
 
 export type RegisteredRpcMethodDetails = {
   handler: IRpcHandler;
   methodDocs?: SingleMethodDocumentation;
 };
+
+/**
+ * Minimal interface for event registries so that {@link RpcServer} can participate in event
+ * registration without importing from `rpc-websocket-listener.ts` (which would create a circular
+ * dependency).
+ *
+ * @internal
+ */
+export interface IRpcEventRegistry {
+  tryRegister(
+    handler: unknown,
+    eventName: string,
+    documentation?: SingleNotificationDocumentation,
+  ): boolean;
+  tryUnregister(handler: unknown, eventName: string): boolean;
+  /** Remove all event registrations for the given handler (e.g. when a websocket closes) */
+  unregisterAll(handler: unknown): void;
+}

--- a/src/shared/models/rpc.interface.ts
+++ b/src/shared/models/rpc.interface.ts
@@ -88,9 +88,9 @@ export interface IRpcMethodRegistrar extends IRpcHandler {
   /** Unregister a method so it is no longer available to RPC requests */
   unregisterMethod: (methodName: string) => Promise<boolean>;
   /**
-   * Register a centrally-tracked network event with the main process. Shared vs exclusive semantics
-   * is determined by looking up the event name in `SHARED_EVENT_NAMES`. See
-   * {@link SharedNetworkEventTypes} for shared vs exclusive semantics.
+   * Register a centrally-tracked network event with the main process. Multi-source vs single-source
+   * semantics is determined by looking up the event name in `MULTI_SOURCE_EVENT_NAMES`. See
+   * {@link MultiSourceNetworkEvents} for multi-source vs single-source semantics.
    *
    * Returns `true` if the registration was accepted, `false` otherwise. Used by
    * `createNetworkEventEmitterAsync`; not for direct caller use.

--- a/src/shared/models/rpc.interface.ts
+++ b/src/shared/models/rpc.interface.ts
@@ -89,7 +89,8 @@ export interface IRpcMethodRegistrar extends IRpcHandler {
   unregisterMethod: (methodName: string) => Promise<boolean>;
   /**
    * Register a centrally-tracked network event with the main process. Shared vs exclusive semantics
-   * is determined by looking up the event name in `SHARED_EVENT_NAMES`.
+   * is determined by looking up the event name in `SHARED_EVENT_NAMES`. See
+   * {@link SharedNetworkEventTypes} for shared vs exclusive semantics.
    *
    * Returns `true` if the registration was accepted, `false` otherwise. Used by
    * `createNetworkEventEmitterAsync`; not for direct caller use.

--- a/src/shared/services/__tests__/data-provider.service.test.ts
+++ b/src/shared/services/__tests__/data-provider.service.test.ts
@@ -1,0 +1,41 @@
+import { describe, it } from 'vitest';
+import type { NetworkObjectDocumentation } from '@shared/models/openrpc.model';
+import { dataProviderService } from '@shared/services/data-provider.service';
+import type { registerEngineByType } from '@shared/services/data-provider.service';
+
+/**
+ * Tests for dataProviderService.registerEngine and registerEngineByType —
+ * NetworkObjectDocumentation parameter.
+ *
+ * Integration-style tests that call the actual functions are skipped here because the test
+ * environment doesn't bootstrap the full RPC/WebSocket layer required by networkObjectService.set.
+ * The new parameter is verified at the type level below.
+ */
+
+// ---------------------------------------------------------------------------
+// Compile-time / type-level tests
+// ---------------------------------------------------------------------------
+
+describe('dataProviderService.registerEngine — documentation parameter', () => {
+  it('accepts NetworkObjectDocumentation as a trailing parameter (compile-time)', () => {
+    // Compile-time only: confirm the function signature includes the new parameter.
+    type Sig = Parameters<typeof dataProviderService.registerEngine>;
+    // The 5th parameter (index 4) should be NetworkObjectDocumentation | undefined.
+    type DocParam = Sig[4];
+    // This assignment would fail to compile if DocParam is not assignable from
+    // NetworkObjectDocumentation | undefined.
+    const _check: DocParam = undefined satisfies NetworkObjectDocumentation | undefined;
+    void _check;
+  });
+});
+
+describe('registerEngineByType — documentation parameter', () => {
+  it('accepts NetworkObjectDocumentation as a trailing parameter (compile-time)', () => {
+    // Compile-time only: confirm the function signature includes the new parameter.
+    type Sig = Parameters<typeof registerEngineByType>;
+    // The 5th parameter (index 4) should be NetworkObjectDocumentation | undefined.
+    type DocParam = Sig[4];
+    const _check: DocParam = undefined satisfies NetworkObjectDocumentation | undefined;
+    void _check;
+  });
+});

--- a/src/shared/services/__tests__/data-provider.service.test.ts
+++ b/src/shared/services/__tests__/data-provider.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import type { NetworkObjectDocumentation } from '@shared/models/openrpc.model';
 import { dataProviderService } from '@shared/services/data-provider.service';
 import type { registerEngineByType } from '@shared/services/data-provider.service';
@@ -24,8 +24,8 @@ describe('dataProviderService.registerEngine — documentation parameter', () =>
     type DocParam = Sig[4];
     // This assignment would fail to compile if DocParam is not assignable from
     // NetworkObjectDocumentation | undefined.
-    const _check: DocParam = undefined satisfies NetworkObjectDocumentation | undefined;
-    void _check;
+    const docParamCheck: DocParam = undefined satisfies NetworkObjectDocumentation | undefined;
+    expect(docParamCheck).toBeUndefined();
   });
 });
 
@@ -35,7 +35,7 @@ describe('registerEngineByType — documentation parameter', () => {
     type Sig = Parameters<typeof registerEngineByType>;
     // The 5th parameter (index 4) should be NetworkObjectDocumentation | undefined.
     type DocParam = Sig[4];
-    const _check: DocParam = undefined satisfies NetworkObjectDocumentation | undefined;
-    void _check;
+    const docParamCheck: DocParam = undefined satisfies NetworkObjectDocumentation | undefined;
+    expect(docParamCheck).toBeUndefined();
   });
 });

--- a/src/shared/services/__tests__/data-provider.service.test.ts
+++ b/src/shared/services/__tests__/data-provider.service.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, expectTypeOf, vi, beforeEach } from 'vitest';
 import type { NetworkObjectDocumentation } from '@shared/models/openrpc.model';
+import * as networkService from '@shared/services/network.service';
+import { networkObjectService } from '@shared/services/network-object.service';
 import { dataProviderService } from '@shared/services/data-provider.service';
 import type { registerEngineByType } from '@shared/services/data-provider.service';
 
@@ -7,35 +9,102 @@ import type { registerEngineByType } from '@shared/services/data-provider.servic
  * Tests for dataProviderService.registerEngine and registerEngineByType —
  * NetworkObjectDocumentation parameter.
  *
- * Integration-style tests that call the actual functions are skipped here because the test
- * environment doesn't bootstrap the full RPC/WebSocket layer required by networkObjectService.set.
- * The new parameter is verified at the type level below.
+ * The type-level tests confirm the new `documentation` parameter exists on the public signatures.
+ * The runtime test confirms `registerEngine` actually forwards that documentation through to
+ * `networkObjectService.set`, where the OpenRPC fanout happens.
  */
 
+// Mock the boundaries registerEngine touches so it can run without the RPC/WebSocket layer.
+vi.mock('@shared/services/network.service', () => ({
+  initialize: vi.fn(() => Promise.resolve()),
+  createNetworkEventEmitterAsync: vi.fn(),
+}));
+
+vi.mock('@shared/services/network-object.service', () => ({
+  networkObjectService: {
+    hasKnown: vi.fn(() => false),
+    set: vi.fn(),
+    get: vi.fn(),
+  },
+  overrideDispose: vi.fn(),
+}));
+
+vi.mock('@shared/services/notification.service', () => ({ notificationService: {} }));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
 // ---------------------------------------------------------------------------
-// Compile-time / type-level tests
+// Type-level tests
 // ---------------------------------------------------------------------------
 
 describe('dataProviderService.registerEngine — documentation parameter', () => {
   it('accepts NetworkObjectDocumentation as a trailing parameter (compile-time)', () => {
-    // Compile-time only: confirm the function signature includes the new parameter.
     type Sig = Parameters<typeof dataProviderService.registerEngine>;
-    // The 5th parameter (index 4) should be NetworkObjectDocumentation | undefined.
-    type DocParam = Sig[4];
-    // This assignment would fail to compile if DocParam is not assignable from
-    // NetworkObjectDocumentation | undefined.
-    const docParamCheck: DocParam = undefined satisfies NetworkObjectDocumentation | undefined;
-    expect(docParamCheck).toBeUndefined();
+    // The 5th parameter (index 4) is the optional documentation parameter.
+    expectTypeOf<Sig[4]>().toEqualTypeOf<NetworkObjectDocumentation | undefined>();
   });
 });
 
 describe('registerEngineByType — documentation parameter', () => {
   it('accepts NetworkObjectDocumentation as a trailing parameter (compile-time)', () => {
-    // Compile-time only: confirm the function signature includes the new parameter.
     type Sig = Parameters<typeof registerEngineByType>;
-    // The 5th parameter (index 4) should be NetworkObjectDocumentation | undefined.
-    type DocParam = Sig[4];
-    const docParamCheck: DocParam = undefined satisfies NetworkObjectDocumentation | undefined;
-    expect(docParamCheck).toBeUndefined();
+    expectTypeOf<Sig[4]>().toEqualTypeOf<NetworkObjectDocumentation | undefined>();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime test: documentation is forwarded to networkObjectService.set
+// ---------------------------------------------------------------------------
+
+describe('dataProviderService.registerEngine — documentation forwarding', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // A networked update emitter with the surface buildDataProvider/registerEngine use.
+    const mockEmitter = { emit: vi.fn(), event: vi.fn(() => () => {}), dispose: vi.fn() };
+    vi.mocked(networkService.createNetworkEventEmitterAsync).mockResolvedValue(
+      // Needed for testing — the real return carries the full emitter surface.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      mockEmitter as unknown as Awaited<
+        ReturnType<typeof networkService.createNetworkEventEmitterAsync>
+      >,
+    );
+
+    // set() returns the disposable network object; get() must return a truthy proxy so the
+    // registration's AsyncVariable resolves.
+    const disposable = { dispose: vi.fn(async () => true) };
+    // The mocks stand in for the full disposable/proxy types; cast the minimal test doubles.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    vi.mocked(networkObjectService.set).mockResolvedValue(disposable as never);
+    // The mocks stand in for the full disposable/proxy types; cast the minimal test doubles.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    vi.mocked(networkObjectService.get).mockResolvedValue({ getData: vi.fn() } as never);
+  });
+
+  it('forwards the documentation argument through to networkObjectService.set', async () => {
+    // Minimal engine with matching get/set functions so buildDataProvider validates.
+    const engine = {
+      getData: async () => 1,
+      setData: async () => true,
+    };
+    const documentation: NetworkObjectDocumentation = { 'x-experimental': true };
+
+    await dataProviderService.registerEngine(
+      // The name/engine are generic in this test context; cast to satisfy the typed signature.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      'test.documentationForwarding' as never,
+      // The name/engine are generic in this test context; cast to satisfy the typed signature.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      engine as never,
+      'dataProvider',
+      undefined,
+      documentation,
+    );
+
+    // networkObjectService.set is called as (id, object, type, attributes, documentation).
+    expect(networkObjectService.set).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(networkObjectService.set).mock.calls[0][4]).toBe(documentation);
   });
 });

--- a/src/shared/services/__tests__/network-object.service.test.ts
+++ b/src/shared/services/__tests__/network-object.service.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Tests for networkObjectService.set — x-experimental fanout behavior.
+ *
+ * Integration-style tests that call networkObjectService.set are skipped here because the test
+ * environment doesn't bootstrap the full RPC/WebSocket layer required by networkObjectService.set.
+ * The fanout logic is a simple conditional spread that is verified by the type-check and the
+ * unit-level test below.
+ */
+
+// ---------------------------------------------------------------------------
+// Pure-logic unit test: fanout merge function
+// ---------------------------------------------------------------------------
+
+/**
+ * Mirror the fanout merge logic from networkObjectService.set so we can test it independently
+ * without needing the full service infrastructure.
+ */
+function applyExperimentalFanout(
+  objectIsExperimental: boolean,
+  baseMethodDocs: { 'x-experimental'?: boolean; [key: string]: unknown },
+): { 'x-experimental'?: boolean; [key: string]: unknown } {
+  return objectIsExperimental && baseMethodDocs['x-experimental'] === undefined
+    ? { ...baseMethodDocs, 'x-experimental': true as const }
+    : baseMethodDocs;
+}
+
+describe('networkObjectService.set — x-experimental fanout', () => {
+  it.skip('marks every registered method experimental when top-level x-experimental is true (integration)', async () => {
+    // Skipped: networkObjectService.set requires the RPC/WebSocket layer
+    // (networkService.registerRequestHandler) which is not initialized in this test
+    // environment. The fanout logic is covered by the unit tests below.
+  });
+
+  describe('applyExperimentalFanout (unit-level mirror of the fanout logic)', () => {
+    it('propagates x-experimental:true when object is experimental and method has no override', () => {
+      const result = applyExperimentalFanout(true, { summary: 'foo' });
+      expect(result['x-experimental']).toBe(true);
+    });
+
+    it('respects per-method x-experimental:false over the object-level true', () => {
+      const base = { summary: 'foo', 'x-experimental': false as const };
+      const result = applyExperimentalFanout(true, base);
+      expect(result['x-experimental']).toBe(false);
+    });
+
+    it('respects per-method x-experimental:true when object is not experimental', () => {
+      const base = { summary: 'foo', 'x-experimental': true as const };
+      const result = applyExperimentalFanout(false, base);
+      expect(result['x-experimental']).toBe(true);
+    });
+
+    it('leaves method docs unchanged when object is not experimental', () => {
+      const base = { summary: 'foo' };
+      const result = applyExperimentalFanout(false, base);
+      expect(result).toBe(base); // same reference — no spread
+      expect(result['x-experimental']).toBeUndefined();
+    });
+
+    it('leaves method docs unchanged when object is experimental but method explicitly sets x-experimental:true', () => {
+      const base = { summary: 'foo', 'x-experimental': true as const };
+      const result = applyExperimentalFanout(true, base);
+      // Method already had the flag; still the same reference (no-op spread)
+      expect(result).toBe(base);
+    });
+
+    it('does not mutate the original baseMethodDocs when spreading', () => {
+      const base = { summary: 'foo' };
+      const result = applyExperimentalFanout(true, base);
+      expect(result).not.toBe(base);
+      expect((base as { 'x-experimental'?: boolean })['x-experimental']).toBeUndefined();
+    });
+  });
+});

--- a/src/shared/services/__tests__/network-object.service.test.ts
+++ b/src/shared/services/__tests__/network-object.service.test.ts
@@ -19,8 +19,8 @@ import { describe, it, expect } from 'vitest';
  */
 function applyExperimentalFanout(
   objectIsExperimental: boolean,
-  baseMethodDocs: { 'x-experimental'?: boolean; [key: string]: unknown },
-): { 'x-experimental'?: boolean; [key: string]: unknown } {
+  baseMethodDocs: { [key: string]: unknown; 'x-experimental'?: boolean },
+): { [key: string]: unknown; 'x-experimental'?: boolean } {
   return objectIsExperimental && baseMethodDocs['x-experimental'] === undefined
     ? { ...baseMethodDocs, 'x-experimental': true as const }
     : baseMethodDocs;
@@ -69,6 +69,9 @@ describe('networkObjectService.set — x-experimental fanout', () => {
       const base = { summary: 'foo' };
       const result = applyExperimentalFanout(true, base);
       expect(result).not.toBe(base);
+      // Cast is needed: `base` is typed as `{ summary: string }` but we need to access the
+      // index signature to verify the property was not mutated.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       expect((base as { 'x-experimental'?: boolean })['x-experimental']).toBeUndefined();
     });
   });

--- a/src/shared/services/__tests__/network-object.service.test.ts
+++ b/src/shared/services/__tests__/network-object.service.test.ts
@@ -1,78 +1,152 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as networkService from '@shared/services/network.service';
+import { logger } from '@shared/services/logger.service';
+import { networkObjectService } from '@shared/services/network-object.service';
+import type { Method } from '@shared/models/openrpc.model';
 
 /**
  * Tests for networkObjectService.set — x-experimental fanout behavior.
  *
- * Integration-style tests that call networkObjectService.set are skipped here because the test
- * environment doesn't bootstrap the full RPC/WebSocket layer required by networkObjectService.set.
- * The fanout logic is a simple conditional spread that is verified by the type-check and the
- * unit-level test below.
+ * These exercise the real `networkObjectService.set` code path by mocking the network service so we
+ * can capture exactly what method documentation `set` registers for the existence method and for
+ * each exposed function. This verifies the actual fanout logic in the service rather than a copy of
+ * it.
  */
 
-// ---------------------------------------------------------------------------
-// Pure-logic unit test: fanout merge function
-// ---------------------------------------------------------------------------
+// Mock the network service so set() can run without the RPC/WebSocket layer. vitest hoists these
+// vi.mock calls above the imports above, so the mocks are in place before the service is imported.
+vi.mock('@shared/services/network.service', () => ({
+  initialize: vi.fn(() => Promise.resolve()),
+  createCoreMultiSourceEventEmitter: vi.fn(),
+  registerRequestHandler: vi.fn(),
+  request: vi.fn(),
+  // Evaluated at module load by the service for onDidCreateNetworkObject; return a no-op subscriber.
+  getNetworkEvent: vi.fn(() => () => () => {}),
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** Method documentation as captured from a registerRequestHandler call. */
+type RegisteredMethodDocs = { method?: { [key: string]: unknown; 'x-experimental'?: boolean } };
+/** Captures the documentation passed to registerRequestHandler, keyed by request type. */
+type RegisteredDocs = Map<string, RegisteredMethodDocs>;
+
+/** Build a minimal valid method doc (params/result are required on the Method type). */
+function methodDoc(name: string, extra?: Partial<Method>): Method {
+  return {
+    name,
+    params: [],
+    result: { name: 'return value', summary: 'result', schema: {} },
+    ...extra,
+  };
+}
 
 /**
- * Mirror the fanout merge logic from networkObjectService.set so we can test it independently
- * without needing the full service infrastructure.
+ * Wire up the network service mocks and return a map that records the docs registered for each
+ * request type as set() runs.
  */
-function applyExperimentalFanout(
-  objectIsExperimental: boolean,
-  baseMethodDocs: { [key: string]: unknown; 'x-experimental'?: boolean },
-): { [key: string]: unknown; 'x-experimental'?: boolean } {
-  return objectIsExperimental && baseMethodDocs['x-experimental'] === undefined
-    ? { ...baseMethodDocs, 'x-experimental': true as const }
-    : baseMethodDocs;
+function setupNetworkServiceMocks(): RegisteredDocs {
+  const registeredDocs: RegisteredDocs = new Map();
+
+  const mockEmitter = {
+    emit: vi.fn(),
+    event: vi.fn(() => () => {}),
+    dispose: vi.fn(),
+  };
+  vi.mocked(networkService.createCoreMultiSourceEventEmitter).mockReturnValue(
+    // Needed for testing — the real return type carries the full emitter surface.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    {
+      emitter: mockEmitter,
+      registeredEmitterPromise: Promise.resolve(mockEmitter),
+    } as unknown as ReturnType<typeof networkService.createCoreMultiSourceEventEmitter>,
+  );
+
+  vi.mocked(networkService.registerRequestHandler).mockImplementation(
+    // Capture the docs for this request type, then resolve to a no-op unsubscriber.
+    (requestType, _handler, requestDocs) => {
+      // requestDocs is SingleMethodDocumentation; narrow to the shape we assert on.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      registeredDocs.set(requestType, requestDocs as RegisteredMethodDocs);
+      return Promise.resolve(async () => true);
+    },
+  );
+
+  return registeredDocs;
 }
 
 describe('networkObjectService.set — x-experimental fanout', () => {
-  it.skip('marks every registered method experimental when top-level x-experimental is true (integration)', async () => {
-    // Skipped: networkObjectService.set requires the RPC/WebSocket layer
-    // (networkService.registerRequestHandler) which is not initialized in this test
-    // environment. The fanout logic is covered by the unit tests below.
+  beforeEach(() => {
+    vi.resetAllMocks();
   });
 
-  describe('applyExperimentalFanout (unit-level mirror of the fanout logic)', () => {
-    it('propagates x-experimental:true when object is experimental and method has no override', () => {
-      const result = applyExperimentalFanout(true, { summary: 'foo' });
-      expect(result['x-experimental']).toBe(true);
+  it('marks the existence method and every method experimental when the object is experimental', async () => {
+    const registeredDocs = setupNetworkServiceMocks();
+
+    const objectToShare = {
+      doThing: async () => 1,
+      doOther: async () => 2,
+    };
+
+    await networkObjectService.set('exp-obj', objectToShare, 'object', undefined, {
+      'x-experimental': true,
+      summary: 'An experimental object',
+      methods: [methodDoc('doOther', { summary: 'Does other' })],
     });
 
-    it('respects per-method x-experimental:false over the object-level true', () => {
-      const base = { summary: 'foo', 'x-experimental': false as const };
-      const result = applyExperimentalFanout(true, base);
-      expect(result['x-experimental']).toBe(false);
+    // The existence method (object:{id}) carries the object-level experimental marker.
+    expect(registeredDocs.get('object:exp-obj')?.method?.['x-experimental']).toBe(true);
+    // A method with documentation but no explicit override inherits the object-level flag.
+    expect(registeredDocs.get('object:exp-obj.doOther')?.method?.['x-experimental']).toBe(true);
+    // A method with no documentation at all also gets the flag fanned out onto its placeholder docs.
+    expect(registeredDocs.get('object:exp-obj.doThing')?.method?.['x-experimental']).toBe(true);
+  });
+
+  it('lets a per-method x-experimental:false override the object-level true', async () => {
+    const registeredDocs = setupNetworkServiceMocks();
+
+    const objectToShare = {
+      doThing: async () => 1,
+      doOther: async () => 2,
+    };
+
+    await networkObjectService.set('mixed-obj', objectToShare, 'object', undefined, {
+      'x-experimental': true,
+      methods: [methodDoc('doThing', { summary: 'Stable', 'x-experimental': false })],
     });
 
-    it('respects per-method x-experimental:true when object is not experimental', () => {
-      const base = { summary: 'foo', 'x-experimental': true as const };
-      const result = applyExperimentalFanout(false, base);
-      expect(result['x-experimental']).toBe(true);
+    // Explicit false wins over the object-level true.
+    expect(registeredDocs.get('object:mixed-obj.doThing')?.method?.['x-experimental']).toBe(false);
+    // The unflagged method still inherits the object-level true.
+    expect(registeredDocs.get('object:mixed-obj.doOther')?.method?.['x-experimental']).toBe(true);
+  });
+
+  it('leaves methods unflagged when the object is not experimental', async () => {
+    const registeredDocs = setupNetworkServiceMocks();
+
+    const objectToShare = { doThing: async () => 1 };
+
+    await networkObjectService.set('plain-obj', objectToShare, 'object', undefined, {
+      methods: [methodDoc('doThing', { summary: 'Does thing' })],
     });
 
-    it('leaves method docs unchanged when object is not experimental', () => {
-      const base = { summary: 'foo' };
-      const result = applyExperimentalFanout(false, base);
-      expect(result).toBe(base); // same reference — no spread
-      expect(result['x-experimental']).toBeUndefined();
+    expect(registeredDocs.get('object:plain-obj')?.method?.['x-experimental']).toBeUndefined();
+    expect(
+      registeredDocs.get('object:plain-obj.doThing')?.method?.['x-experimental'],
+    ).toBeUndefined();
+  });
+
+  it('warns when documentation references a method that matches no exposed function', async () => {
+    setupNetworkServiceMocks();
+
+    const objectToShare = { doThing: async () => 1 };
+
+    await networkObjectService.set('typo-obj', objectToShare, 'object', undefined, {
+      methods: [methodDoc('doThingg', { summary: 'Typo' })],
     });
 
-    it('leaves method docs unchanged when object is experimental but method explicitly sets x-experimental:true', () => {
-      const base = { summary: 'foo', 'x-experimental': true as const };
-      const result = applyExperimentalFanout(true, base);
-      // Method already had the flag; still the same reference (no-op spread)
-      expect(result).toBe(base);
-    });
-
-    it('does not mutate the original baseMethodDocs when spreading', () => {
-      const base = { summary: 'foo' };
-      const result = applyExperimentalFanout(true, base);
-      expect(result).not.toBe(base);
-      // Cast is needed: `base` is typed as `{ summary: string }` but we need to access the
-      // index signature to verify the property was not mutated.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      expect((base as { 'x-experimental'?: boolean })['x-experimental']).toBeUndefined();
-    });
+    expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(expect.stringContaining('doThingg'));
   });
 });

--- a/src/shared/services/__tests__/network.service.shared-events.test.ts
+++ b/src/shared/services/__tests__/network.service.shared-events.test.ts
@@ -1,32 +1,61 @@
 import { describe, it, expect } from 'vitest';
 import {
   MULTI_SOURCE_EVENT_NAMES,
+  createCoreMultiSourceEventEmitter,
   createNetworkEventEmitterAsync,
   getNetworkEvent,
 } from '@shared/services/network.service';
 import type { MultiSourceNetworkEvents } from 'papi-shared-types';
 import type { PlatformEvent } from 'platform-bible-utils';
 
-describe('MULTI_SOURCE_EVENT_NAMES stays in sync with MultiSourceNetworkEvents', () => {
-  it('contains every key of MultiSourceNetworkEvents', () => {
-    type RequiredKeys = keyof MultiSourceNetworkEvents;
-    const required: RequiredKeys[] = [
+describe('MULTI_SOURCE_EVENT_NAMES stays in sync with the multi-source event names', () => {
+  it('contains every public MultiSourceNetworkEvents key', () => {
+    const publicKeys: (keyof MultiSourceNetworkEvents)[] = [
+      'object:onDidCreateNetworkObject',
+      'object:onDidDisposeNetworkObject',
+    ];
+    publicKeys.forEach((name) => expect(MULTI_SOURCE_EVENT_NAMES.has(name)).toBe(true));
+  });
+
+  it('contains the platform-internal multi-source events not declared in the public types', () => {
+    expect(MULTI_SOURCE_EVENT_NAMES.has('shared-store:change')).toBe(true);
+  });
+
+  it('contains only known multi-source names', () => {
+    // The compile-time invariant (set members must be a MultiSourceNetworkEventName) is enforced
+    // where MULTI_SOURCE_EVENT_NAMES is declared; here we just guard against accidental additions.
+    const known = [
       'object:onDidCreateNetworkObject',
       'object:onDidDisposeNetworkObject',
       'shared-store:change',
     ];
-    required.forEach((name) => expect(MULTI_SOURCE_EVENT_NAMES.has(name)).toBe(true));
+    Array.from(MULTI_SOURCE_EVENT_NAMES).forEach((name) => expect(known).toContain(name));
+  });
+});
+
+describe('createCoreMultiSourceEventEmitter (synchronous)', () => {
+  it('throws synchronously for an event name that is not a pre-approved multi-source event', () => {
+    expect(() =>
+      // 'as never' bypasses the keyof MultiSourceNetworkEvents constraint to exercise the runtime
+      // guard that protects untyped/cast callers.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      createCoreMultiSourceEventEmitter('myExt.notApproved' as never),
+    ).toThrow(/not a pre-approved multi-source event/);
   });
 
-  it('contains no names absent from MultiSourceNetworkEvents', () => {
-    type AllowedKeys = keyof MultiSourceNetworkEvents;
-    Array.from(MULTI_SOURCE_EVENT_NAMES).forEach((name) => {
-      // The cast verifies the runtime constant only contains keys MultiSourceNetworkEvents declares.
-      // If a new entry is added to MULTI_SOURCE_EVENT_NAMES without adding it to
-      // MultiSourceNetworkEvents, this assignment is a type error and the test fails to compile.
-      const typed: AllowedKeys = name;
-      expect(typeof typed).toBe('string');
-    });
+  it('synchronously returns an emitter and a registeredEmitterPromise for a pre-approved event', () => {
+    const result = createCoreMultiSourceEventEmitter('object:onDidCreateNetworkObject');
+    try {
+      expect(typeof result.emitter.emit).toBe('function');
+      expect(typeof result.emitter.event).toBe('function');
+      expect(result.registeredEmitterPromise).toBeInstanceOf(Promise);
+    } finally {
+      // The background registration touches the (unavailable) network in unit mode; swallow its
+      // result so it can't surface as an unhandled rejection, and dispose the emitter so its
+      // module-level record doesn't leak into other tests.
+      result.registeredEmitterPromise.catch(() => {});
+      result.emitter.dispose();
+    }
   });
 });
 

--- a/src/shared/services/__tests__/network.service.shared-events.test.ts
+++ b/src/shared/services/__tests__/network.service.shared-events.test.ts
@@ -10,9 +10,9 @@ describe('SHARED_EVENT_NAMES stays in sync with SharedNetworkEventTypes', () => 
   it('contains every key of SharedNetworkEventTypes', () => {
     type RequiredKeys = keyof SharedNetworkEventTypes;
     const required: RequiredKeys[] = [
-      'network-object.onDidCreateNetworkObject',
-      'network-object.onDidDisposeNetworkObject',
-      'shared-store.onDidChange',
+      'object:onDidCreateNetworkObject',
+      'object:onDidDisposeNetworkObject',
+      'shared-store:change',
     ];
     for (const name of required) expect(SHARED_EVENT_NAMES.has(name)).toBe(true);
   });
@@ -86,7 +86,7 @@ import type { PlatformEvent } from 'platform-bible-utils';
 describe('getNetworkEvent overloads', () => {
   it('typed call infers payload from NetworkEventTypes', () => {
     // Compile-time test — if this compiles, the typed overload exists.
-    const ev = gne('network-object.onDidCreateNetworkObject');
+    const ev = gne('object:onDidCreateNetworkObject');
     // ev should be PlatformEvent<NetworkObjectDetails> — verify by satisfying the structural type.
     const checked: PlatformEvent<unknown> = ev;
     void checked;

--- a/src/shared/services/__tests__/network.service.shared-events.test.ts
+++ b/src/shared/services/__tests__/network.service.shared-events.test.ts
@@ -3,7 +3,6 @@ import {
   MULTI_SOURCE_EVENT_NAMES,
   NetworkEventBuffer,
   createCoreMultiSourceEventEmitter,
-  createNetworkEventEmitterAsync,
   getNetworkEvent,
 } from '@shared/services/network.service';
 import type { MultiSourceNetworkEvents } from 'papi-shared-types';
@@ -43,12 +42,17 @@ describe('NetworkEventBuffer', () => {
 });
 
 describe('MULTI_SOURCE_EVENT_NAMES stays in sync with the multi-source event names', () => {
-  it('contains every public MultiSourceNetworkEvents key', () => {
-    const publicKeys: (keyof MultiSourceNetworkEvents)[] = [
-      'object:onDidCreateNetworkObject',
-      'object:onDidDisposeNetworkObject',
-    ];
-    publicKeys.forEach((name) => expect(MULTI_SOURCE_EVENT_NAMES.has(name)).toBe(true));
+  it('contains every public MultiSourceNetworkEvents key (exhaustive)', () => {
+    // `Record<keyof MultiSourceNetworkEvents, true>` forces every public key to be listed here —
+    // adding a key to MultiSourceNetworkEvents without also adding it to the runtime set becomes a
+    // compile error (the exact invariant this test exists to enforce).
+    const publicKeys: Record<keyof MultiSourceNetworkEvents, true> = {
+      'object:onDidCreateNetworkObject': true,
+      'object:onDidDisposeNetworkObject': true,
+    };
+    Object.keys(publicKeys).forEach((name) =>
+      expect(MULTI_SOURCE_EVENT_NAMES.has(name)).toBe(true),
+    );
   });
 
   it('contains the platform-internal multi-source events not declared in the public types', () => {
@@ -89,70 +93,6 @@ describe('createCoreMultiSourceEventEmitter (synchronous)', () => {
       // module-level record doesn't leak into other tests.
       result.registeredEmitterPromise.catch(() => {});
       result.emitter.dispose();
-    }
-  });
-});
-
-// These integration tests require a running RPC/WebSocket server that the unit test environment
-// does not provide. They are kept here for documentation and for future integration test suites;
-// skip them in unit test mode to avoid connection timeouts.
-describe.skip('createNetworkEventEmitterAsync', () => {
-  // The async emitter creator requires network initialization, which involves the WebSocket and RPC
-  // setup. If the test environment doesn't bootstrap those, these tests may need mocks. For now,
-  // write the tests as integration tests that may be skipped via `describe.skip` if the
-  // initialization can't be satisfied in unit test mode. Detect this by trying to await it; if it
-  // rejects with a clear "RPC handler not set" or similar error, skip rather than fail.
-
-  it('resolves to a functional emitter for a declared event name', async () => {
-    try {
-      // The 'as never' cast bypasses the NetworkEventTypes constraint at the call site for a name
-      // that won't have been declared in this test's compilation unit. The runtime accepts any
-      // string; the typed constraint is enforced at production call sites by NetworkEventTypes.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      const emitter = await createNetworkEventEmitterAsync('myExt.testEvent' as never);
-      let received: unknown;
-      // 'as never' bypasses the NetworkEventTypes constraint — same reason as above.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      getNetworkEvent('myExt.testEvent' as never)((event) => {
-        received = event;
-      });
-      // 'as never' bypasses the typed payload constraint for an ad-hoc test event.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      emitter.emit({ value: 42 } as never);
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 10);
-      });
-      // Cast is needed: `received` is typed as `unknown`; narrowing to the expected shape.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      expect((received as { value: number }).value).toBe(42);
-    } catch (err) {
-      if (
-        err instanceof Error &&
-        /not initialized|RPC handler|not connected|send payload|connect/i.test(err.message)
-      ) {
-        // Test environment doesn't bootstrap RPC — skip this integration check.
-        return;
-      }
-      throw err;
-    }
-  });
-
-  it('rejects a second registration of the same single-source event name within one process', async () => {
-    try {
-      // 'as never' bypasses the NetworkEventTypes constraint for a test-only event name.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      await createNetworkEventEmitterAsync('myExt.unique' as never);
-      // 'as never' bypasses the NetworkEventTypes constraint for a test-only event name.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      await expect(createNetworkEventEmitterAsync('myExt.unique' as never)).rejects.toThrow();
-    } catch (err) {
-      if (
-        err instanceof Error &&
-        /not initialized|RPC handler|not connected|send payload|connect/i.test(err.message)
-      ) {
-        return;
-      }
-      throw err;
     }
   });
 });

--- a/src/shared/services/__tests__/network.service.shared-events.test.ts
+++ b/src/shared/services/__tests__/network.service.shared-events.test.ts
@@ -1,12 +1,46 @@
 import { describe, it, expect } from 'vitest';
 import {
   MULTI_SOURCE_EVENT_NAMES,
+  NetworkEventBuffer,
   createCoreMultiSourceEventEmitter,
   createNetworkEventEmitterAsync,
   getNetworkEvent,
 } from '@shared/services/network.service';
 import type { MultiSourceNetworkEvents } from 'papi-shared-types';
 import type { PlatformEvent } from 'platform-bible-utils';
+
+describe('NetworkEventBuffer', () => {
+  it("'queue' keeps every event and flushes them in emit order", () => {
+    const buffer = new NetworkEventBuffer<number>('queue');
+    buffer.add(1);
+    buffer.add(2);
+    buffer.add(2);
+    expect(buffer.drain()).toEqual([1, 2, 2]);
+    // Draining empties the buffer.
+    expect(buffer.drain()).toEqual([]);
+  });
+
+  it("'latestByKey' keeps only the latest event per key, in first-seen key order", () => {
+    const buffer = new NetworkEventBuffer<{ id: string; n: number }>({
+      latestByKey: (e) => e.id,
+    });
+    buffer.add({ id: 'a', n: 1 });
+    buffer.add({ id: 'b', n: 1 });
+    buffer.add({ id: 'a', n: 2 }); // updates 'a', keeps its first-seen position
+    expect(buffer.drain()).toEqual([
+      { id: 'a', n: 2 },
+      { id: 'b', n: 1 },
+    ]);
+    expect(buffer.drain()).toEqual([]);
+  });
+
+  it('clear() empties the buffer', () => {
+    const buffer = new NetworkEventBuffer<number>('queue');
+    buffer.add(1);
+    buffer.clear();
+    expect(buffer.drain()).toEqual([]);
+  });
+});
 
 describe('MULTI_SOURCE_EVENT_NAMES stays in sync with the multi-source event names', () => {
   it('contains every public MultiSourceNetworkEvents key', () => {

--- a/src/shared/services/__tests__/network.service.shared-events.test.ts
+++ b/src/shared/services/__tests__/network.service.shared-events.test.ts
@@ -79,3 +79,22 @@ describe.skip('createNetworkEventEmitterAsync', () => {
     }
   });
 });
+
+import { getNetworkEvent as gne } from '@shared/services/network.service';
+import type { PlatformEvent } from 'platform-bible-utils';
+
+describe('getNetworkEvent overloads', () => {
+  it('typed call infers payload from NetworkEventTypes', () => {
+    // Compile-time test — if this compiles, the typed overload exists.
+    const ev = gne('network-object.onDidCreateNetworkObject');
+    // ev should be PlatformEvent<NetworkObjectDetails> — verify by satisfying the structural type.
+    const checked: PlatformEvent<unknown> = ev;
+    void checked;
+  });
+
+  it('explicit <T> call still resolves (deprecated overload)', () => {
+    const ev = gne<{ foo: string }>('arbitraryName');
+    const checked: PlatformEvent<{ foo: string }> = ev;
+    void checked;
+  });
+});

--- a/src/shared/services/__tests__/network.service.shared-events.test.ts
+++ b/src/shared/services/__tests__/network.service.shared-events.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { SHARED_EVENT_NAMES } from '@shared/services/network.service';
+import type { SharedNetworkEventTypes } from 'papi-shared-types';
+
+describe('SHARED_EVENT_NAMES stays in sync with SharedNetworkEventTypes', () => {
+  it('contains every key of SharedNetworkEventTypes', () => {
+    type RequiredKeys = keyof SharedNetworkEventTypes;
+    const required: RequiredKeys[] = [
+      'network-object.onDidCreateNetworkObject',
+      'network-object.onDidDisposeNetworkObject',
+      'shared-store.onDidChange',
+    ];
+    for (const name of required) expect(SHARED_EVENT_NAMES.has(name)).toBe(true);
+  });
+
+  it('contains no names absent from SharedNetworkEventTypes', () => {
+    type AllowedKeys = keyof SharedNetworkEventTypes;
+    for (const name of SHARED_EVENT_NAMES) {
+      // The cast verifies the runtime constant only contains keys SharedNetworkEventTypes declares.
+      // If a new entry is added to SHARED_EVENT_NAMES without adding it to SharedNetworkEventTypes,
+      // this assignment is a type error and the test fails to compile.
+      const typed: AllowedKeys = name;
+      expect(typeof typed).toBe('string');
+    }
+  });
+});

--- a/src/shared/services/__tests__/network.service.shared-events.test.ts
+++ b/src/shared/services/__tests__/network.service.shared-events.test.ts
@@ -5,6 +5,7 @@ import {
   getNetworkEvent,
 } from '@shared/services/network.service';
 import type { MultiSourceNetworkEvents } from 'papi-shared-types';
+import type { PlatformEvent } from 'platform-bible-utils';
 
 describe('MULTI_SOURCE_EVENT_NAMES stays in sync with MultiSourceNetworkEvents', () => {
   it('contains every key of MultiSourceNetworkEvents', () => {
@@ -14,18 +15,18 @@ describe('MULTI_SOURCE_EVENT_NAMES stays in sync with MultiSourceNetworkEvents',
       'object:onDidDisposeNetworkObject',
       'shared-store:change',
     ];
-    for (const name of required) expect(MULTI_SOURCE_EVENT_NAMES.has(name)).toBe(true);
+    required.forEach((name) => expect(MULTI_SOURCE_EVENT_NAMES.has(name)).toBe(true));
   });
 
   it('contains no names absent from MultiSourceNetworkEvents', () => {
     type AllowedKeys = keyof MultiSourceNetworkEvents;
-    for (const name of MULTI_SOURCE_EVENT_NAMES) {
+    Array.from(MULTI_SOURCE_EVENT_NAMES).forEach((name) => {
       // The cast verifies the runtime constant only contains keys MultiSourceNetworkEvents declares.
       // If a new entry is added to MULTI_SOURCE_EVENT_NAMES without adding it to
       // MultiSourceNetworkEvents, this assignment is a type error and the test fails to compile.
       const typed: AllowedKeys = name;
       expect(typeof typed).toBe('string');
-    }
+    });
   });
 });
 
@@ -44,13 +45,22 @@ describe.skip('createNetworkEventEmitterAsync', () => {
       // The 'as never' cast bypasses the NetworkEventTypes constraint at the call site for a name
       // that won't have been declared in this test's compilation unit. The runtime accepts any
       // string; the typed constraint is enforced at production call sites by NetworkEventTypes.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       const emitter = await createNetworkEventEmitterAsync('myExt.testEvent' as never);
       let received: unknown;
+      // 'as never' bypasses the NetworkEventTypes constraint — same reason as above.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       getNetworkEvent('myExt.testEvent' as never)((event) => {
         received = event;
       });
+      // 'as never' bypasses the typed payload constraint for an ad-hoc test event.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       emitter.emit({ value: 42 } as never);
-      await new Promise((r) => setTimeout(r, 10));
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 10);
+      });
+      // Cast is needed: `received` is typed as `unknown`; narrowing to the expected shape.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       expect((received as { value: number }).value).toBe(42);
     } catch (err) {
       if (
@@ -66,7 +76,11 @@ describe.skip('createNetworkEventEmitterAsync', () => {
 
   it('rejects a second registration of the same single-source event name within one process', async () => {
     try {
+      // 'as never' bypasses the NetworkEventTypes constraint for a test-only event name.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       await createNetworkEventEmitterAsync('myExt.unique' as never);
+      // 'as never' bypasses the NetworkEventTypes constraint for a test-only event name.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
       await expect(createNetworkEventEmitterAsync('myExt.unique' as never)).rejects.toThrow();
     } catch (err) {
       if (
@@ -80,21 +94,18 @@ describe.skip('createNetworkEventEmitterAsync', () => {
   });
 });
 
-import { getNetworkEvent as gne } from '@shared/services/network.service';
-import type { PlatformEvent } from 'platform-bible-utils';
-
 describe('getNetworkEvent overloads', () => {
   it('typed call infers payload from NetworkEvents', () => {
     // Compile-time test — if this compiles, the typed overload exists.
-    const ev = gne('object:onDidCreateNetworkObject');
+    const ev = getNetworkEvent('object:onDidCreateNetworkObject');
     // ev should be PlatformEvent<NetworkObjectDetails> — verify by satisfying the structural type.
     const checked: PlatformEvent<unknown> = ev;
-    void checked;
+    expect(checked).toBeDefined();
   });
 
   it('explicit <T> call still resolves (deprecated overload)', () => {
-    const ev = gne<{ foo: string }>('arbitraryName');
+    const ev = getNetworkEvent<{ foo: string }>('arbitraryName');
     const checked: PlatformEvent<{ foo: string }> = ev;
-    void checked;
+    expect(checked).toBeDefined();
   });
 });

--- a/src/shared/services/__tests__/network.service.shared-events.test.ts
+++ b/src/shared/services/__tests__/network.service.shared-events.test.ts
@@ -1,28 +1,28 @@
 import { describe, it, expect } from 'vitest';
 import {
-  SHARED_EVENT_NAMES,
+  MULTI_SOURCE_EVENT_NAMES,
   createNetworkEventEmitterAsync,
   getNetworkEvent,
 } from '@shared/services/network.service';
-import type { SharedNetworkEventTypes } from 'papi-shared-types';
+import type { MultiSourceNetworkEvents } from 'papi-shared-types';
 
-describe('SHARED_EVENT_NAMES stays in sync with SharedNetworkEventTypes', () => {
-  it('contains every key of SharedNetworkEventTypes', () => {
-    type RequiredKeys = keyof SharedNetworkEventTypes;
+describe('MULTI_SOURCE_EVENT_NAMES stays in sync with MultiSourceNetworkEvents', () => {
+  it('contains every key of MultiSourceNetworkEvents', () => {
+    type RequiredKeys = keyof MultiSourceNetworkEvents;
     const required: RequiredKeys[] = [
       'object:onDidCreateNetworkObject',
       'object:onDidDisposeNetworkObject',
       'shared-store:change',
     ];
-    for (const name of required) expect(SHARED_EVENT_NAMES.has(name)).toBe(true);
+    for (const name of required) expect(MULTI_SOURCE_EVENT_NAMES.has(name)).toBe(true);
   });
 
-  it('contains no names absent from SharedNetworkEventTypes', () => {
-    type AllowedKeys = keyof SharedNetworkEventTypes;
-    for (const name of SHARED_EVENT_NAMES) {
-      // The cast verifies the runtime constant only contains keys SharedNetworkEventTypes declares.
-      // If a new entry is added to SHARED_EVENT_NAMES without adding it to SharedNetworkEventTypes,
-      // this assignment is a type error and the test fails to compile.
+  it('contains no names absent from MultiSourceNetworkEvents', () => {
+    type AllowedKeys = keyof MultiSourceNetworkEvents;
+    for (const name of MULTI_SOURCE_EVENT_NAMES) {
+      // The cast verifies the runtime constant only contains keys MultiSourceNetworkEvents declares.
+      // If a new entry is added to MULTI_SOURCE_EVENT_NAMES without adding it to
+      // MultiSourceNetworkEvents, this assignment is a type error and the test fails to compile.
       const typed: AllowedKeys = name;
       expect(typeof typed).toBe('string');
     }
@@ -41,9 +41,9 @@ describe.skip('createNetworkEventEmitterAsync', () => {
 
   it('resolves to a functional emitter for a declared event name', async () => {
     try {
-      // The 'as never' cast bypasses the keyof NetworkEventTypes constraint at the call site for
-      // a name that won't have been declared in this test's compilation unit. The runtime accepts
-      // any string; the typed constraint is enforced at production call sites by NetworkEventTypes.
+      // The 'as never' cast bypasses the NetworkEventTypes constraint at the call site for a name
+      // that won't have been declared in this test's compilation unit. The runtime accepts any
+      // string; the typed constraint is enforced at production call sites by NetworkEventTypes.
       const emitter = await createNetworkEventEmitterAsync('myExt.testEvent' as never);
       let received: unknown;
       getNetworkEvent('myExt.testEvent' as never)((event) => {
@@ -64,7 +64,7 @@ describe.skip('createNetworkEventEmitterAsync', () => {
     }
   });
 
-  it('rejects a second registration of the same exclusive event name within one process', async () => {
+  it('rejects a second registration of the same single-source event name within one process', async () => {
     try {
       await createNetworkEventEmitterAsync('myExt.unique' as never);
       await expect(createNetworkEventEmitterAsync('myExt.unique' as never)).rejects.toThrow();
@@ -84,7 +84,7 @@ import { getNetworkEvent as gne } from '@shared/services/network.service';
 import type { PlatformEvent } from 'platform-bible-utils';
 
 describe('getNetworkEvent overloads', () => {
-  it('typed call infers payload from NetworkEventTypes', () => {
+  it('typed call infers payload from NetworkEvents', () => {
     // Compile-time test — if this compiles, the typed overload exists.
     const ev = gne('object:onDidCreateNetworkObject');
     // ev should be PlatformEvent<NetworkObjectDetails> — verify by satisfying the structural type.

--- a/src/shared/services/__tests__/network.service.shared-events.test.ts
+++ b/src/shared/services/__tests__/network.service.shared-events.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { SHARED_EVENT_NAMES } from '@shared/services/network.service';
+import {
+  SHARED_EVENT_NAMES,
+  createNetworkEventEmitterAsync,
+  getNetworkEvent,
+} from '@shared/services/network.service';
 import type { SharedNetworkEventTypes } from 'papi-shared-types';
 
 describe('SHARED_EVENT_NAMES stays in sync with SharedNetworkEventTypes', () => {
@@ -21,6 +25,57 @@ describe('SHARED_EVENT_NAMES stays in sync with SharedNetworkEventTypes', () => 
       // this assignment is a type error and the test fails to compile.
       const typed: AllowedKeys = name;
       expect(typeof typed).toBe('string');
+    }
+  });
+});
+
+// These integration tests require a running RPC/WebSocket server that the unit test environment
+// does not provide. They are kept here for documentation and for future integration test suites;
+// skip them in unit test mode to avoid connection timeouts.
+describe.skip('createNetworkEventEmitterAsync', () => {
+  // The async emitter creator requires network initialization, which involves the WebSocket and RPC
+  // setup. If the test environment doesn't bootstrap those, these tests may need mocks. For now,
+  // write the tests as integration tests that may be skipped via `describe.skip` if the
+  // initialization can't be satisfied in unit test mode. Detect this by trying to await it; if it
+  // rejects with a clear "RPC handler not set" or similar error, skip rather than fail.
+
+  it('resolves to a functional emitter for a declared event name', async () => {
+    try {
+      // The 'as never' cast bypasses the keyof NetworkEventTypes constraint at the call site for
+      // a name that won't have been declared in this test's compilation unit. The runtime accepts
+      // any string; the typed constraint is enforced at production call sites by NetworkEventTypes.
+      const emitter = await createNetworkEventEmitterAsync('myExt.testEvent' as never);
+      let received: unknown;
+      getNetworkEvent('myExt.testEvent' as never)((event) => {
+        received = event;
+      });
+      emitter.emit({ value: 42 } as never);
+      await new Promise((r) => setTimeout(r, 10));
+      expect((received as { value: number }).value).toBe(42);
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        /not initialized|RPC handler|not connected|send payload|connect/i.test(err.message)
+      ) {
+        // Test environment doesn't bootstrap RPC — skip this integration check.
+        return;
+      }
+      throw err;
+    }
+  });
+
+  it('rejects a second registration of the same exclusive event name within one process', async () => {
+    try {
+      await createNetworkEventEmitterAsync('myExt.unique' as never);
+      await expect(createNetworkEventEmitterAsync('myExt.unique' as never)).rejects.toThrow();
+    } catch (err) {
+      if (
+        err instanceof Error &&
+        /not initialized|RPC handler|not connected|send payload|connect/i.test(err.message)
+      ) {
+        return;
+      }
+      throw err;
     }
   });
 });

--- a/src/shared/services/__tests__/project-data-provider.service.test.ts
+++ b/src/shared/services/__tests__/project-data-provider.service.test.ts
@@ -1,18 +1,52 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, expectTypeOf, vi, beforeEach } from 'vitest';
 import { registerProjectDataProviderEngineFactory } from '@shared/services/project-data-provider.service';
-import type { IProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model';
+import { networkObjectService } from '@shared/services/network-object.service';
+import { registerEngineByType } from '@shared/services/data-provider.service';
+import type {
+  IProjectDataProviderEngineFactory,
+  ProjectDataProviderEngineEnvelope,
+} from '@shared/models/project-data-provider-engine-factory.model';
+import type { NetworkObjectDocumentation } from '@shared/models/openrpc.model';
+
+// Mock the boundaries the PDP service registers through so we can inspect the attributes it merges.
+vi.mock('@shared/services/network-object.service', () => ({
+  networkObjectService: { set: vi.fn(), hasKnown: vi.fn(() => false) },
+}));
+
+vi.mock('@shared/services/data-provider.service', () => ({
+  registerEngineByType: vi.fn(),
+  getByType: vi.fn(),
+}));
+
+vi.mock('@shared/services/project-lookup.service', () => ({
+  projectLookupService: {},
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/** Minimal `platform.base` engine — has the keys the base-projectInterface check looks for. */
+function makeBaseEngine() {
+  return {
+    getExtensionData: vi.fn(),
+    setExtensionData: vi.fn(),
+    getSetting: vi.fn(),
+    setSetting: vi.fn(),
+    resetSetting: vi.fn(),
+  };
+}
 
 describe('registerProjectDataProviderEngineFactory — attributes + documentation parameters', () => {
-  it('accepts attributes and documentation as optional trailing parameters (compile-time)', () => {
-    // Compile-time only: verify the function signature.
+  it('exposes attributes and documentation as optional trailing parameters (compile-time)', () => {
     type Sig = Parameters<typeof registerProjectDataProviderEngineFactory>;
-    // Should have 5 parameters: id, projectInterfaces, factory, attributes?, documentation?
-    const sigCheck: Sig | undefined = undefined;
-    expect(sigCheck).toBeUndefined();
+    // id, projectInterfaces, factory, attributes?, documentation?
+    expectTypeOf<Sig['length']>().toEqualTypeOf<3 | 4 | 5>();
+    expectTypeOf<Sig[3]>().toEqualTypeOf<{ [property: string]: unknown } | undefined>();
+    expectTypeOf<Sig[4]>().toEqualTypeOf<NetworkObjectDocumentation | undefined>();
   });
 
-  it('factory can return either engine or envelope (compile-time)', () => {
-    // Verifies the return shape augmentation compiles.
+  it('factory can return either a raw engine or an envelope (compile-time)', () => {
     const factoryEngine: IProjectDataProviderEngineFactory<['platform.base']> = {
       getAvailableProjects: async () => [],
       // The cast is needed to satisfy the generic engine type in a test context without a real engine
@@ -31,5 +65,84 @@ describe('registerProjectDataProviderEngineFactory — attributes + documentatio
     };
     expect(factoryEngine).toBeDefined();
     expect(factoryEnvelope).toBeDefined();
+  });
+});
+
+describe('registerProjectDataProviderEngineFactory — platform-canonical attributes win (anti-spoofing)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // The mocks return minimal disposables standing in for the full network object / data provider.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    vi.mocked(networkObjectService.set).mockResolvedValue({ dispose: vi.fn() } as never);
+    // The mocks return minimal disposables standing in for the full network object / data provider.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    vi.mocked(registerEngineByType).mockResolvedValue({
+      dispose: vi.fn(async () => true),
+    } as never);
+  });
+
+  it('overwrites caller-supplied projectInterfaces with the canonical value at the factory level', async () => {
+    const engineFactory: IProjectDataProviderEngineFactory<['platform.base']> = {
+      getAvailableProjects: async () => [],
+      // The test engine isn't a full typed engine; cast to satisfy the generic engine return type.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      createProjectDataProviderEngine: async () => makeBaseEngine() as never,
+    };
+    const documentation: NetworkObjectDocumentation = { 'x-experimental': true };
+
+    await registerProjectDataProviderEngineFactory(
+      'pdpf-id',
+      ['platform.base'],
+      engineFactory,
+      // A malicious/incorrect caller tries to spoof projectInterfaces and slip in extra attributes.
+      { projectInterfaces: ['spoofed.interface'], custom: 'keep' },
+      documentation,
+    );
+
+    expect(networkObjectService.set).toHaveBeenCalledTimes(1);
+    const setCall = vi.mocked(networkObjectService.set).mock.calls[0];
+    const mergedAttributes = setCall[3];
+    // The platform-canonical projectInterfaces wins; the caller's spoofed value is discarded.
+    expect(mergedAttributes).toEqual({ projectInterfaces: ['platform.base'], custom: 'keep' });
+    // Documentation is forwarded untouched as the 5th argument.
+    expect(setCall[4]).toBe(documentation);
+  });
+
+  it('overwrites caller-supplied projectId and projectInterfaces with canonical values per PDP', async () => {
+    const baseEngine = makeBaseEngine();
+    const envelope: ProjectDataProviderEngineEnvelope<['platform.base']> = {
+      // The test engine isn't a full typed engine; cast to satisfy the generic engine type.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      projectDataProviderEngine: baseEngine as never,
+      // The per-PDP attributes try to spoof both projectId and projectInterfaces.
+      attributes: {
+        projectId: 'spoofed-id',
+        projectInterfaces: ['spoofed.interface'],
+        custom: 'keep',
+      },
+    };
+    const engineFactory: IProjectDataProviderEngineFactory<['platform.base']> = {
+      getAvailableProjects: async () => [],
+      createProjectDataProviderEngine: async () => envelope,
+    };
+
+    await registerProjectDataProviderEngineFactory('pdpf-id', ['platform.base'], engineFactory);
+
+    // Capture the internal factory the service registered, then drive a PDP creation through it.
+    // set() types its object argument as a generic NetworkableObject, so cast to reach the method.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    const factory = vi.mocked(networkObjectService.set).mock.calls[0][1] as unknown as {
+      getProjectDataProviderId(projectId: string): Promise<string>;
+    };
+    await factory.getProjectDataProviderId('real-project-id');
+
+    expect(registerEngineByType).toHaveBeenCalledTimes(1);
+    const mergedAttributes = vi.mocked(registerEngineByType).mock.calls[0][3];
+    // Canonical projectId (the real argument) and projectInterfaces win; custom attribute survives.
+    expect(mergedAttributes).toEqual({
+      projectId: 'real-project-id',
+      projectInterfaces: ['platform.base'],
+      custom: 'keep',
+    });
   });
 });

--- a/src/shared/services/__tests__/project-data-provider.service.test.ts
+++ b/src/shared/services/__tests__/project-data-provider.service.test.ts
@@ -1,0 +1,32 @@
+import { describe, it } from 'vitest';
+import { registerProjectDataProviderEngineFactory } from '@shared/services/project-data-provider.service';
+import type { IProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model';
+
+describe('registerProjectDataProviderEngineFactory — attributes + documentation parameters', () => {
+  it('accepts attributes and documentation as optional trailing parameters (compile-time)', () => {
+    // Compile-time only: verify the function signature.
+    type Sig = Parameters<typeof registerProjectDataProviderEngineFactory>;
+    // Should have 5 parameters: id, projectInterfaces, factory, attributes?, documentation?
+    void (null as unknown as Sig);
+  });
+
+  it('factory can return either engine or envelope (compile-time)', () => {
+    // Verifies the return shape augmentation compiles.
+    const factoryEngine: IProjectDataProviderEngineFactory<['platform.base']> = {
+      getAvailableProjects: async () => [],
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      createProjectDataProviderEngine: async () => ({}) as any, // raw engine
+    };
+    const factoryEnvelope: IProjectDataProviderEngineFactory<['platform.base']> = {
+      getAvailableProjects: async () => [],
+      createProjectDataProviderEngine: async () => ({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        projectDataProviderEngine: {} as any,
+        attributes: { extra: 1 },
+        documentation: { 'x-experimental': true },
+      }),
+    };
+    void factoryEngine;
+    void factoryEnvelope;
+  });
+});

--- a/src/shared/services/__tests__/project-data-provider.service.test.ts
+++ b/src/shared/services/__tests__/project-data-provider.service.test.ts
@@ -1,4 +1,4 @@
-import { describe, it } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { registerProjectDataProviderEngineFactory } from '@shared/services/project-data-provider.service';
 import type { IProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model';
 
@@ -7,26 +7,29 @@ describe('registerProjectDataProviderEngineFactory — attributes + documentatio
     // Compile-time only: verify the function signature.
     type Sig = Parameters<typeof registerProjectDataProviderEngineFactory>;
     // Should have 5 parameters: id, projectInterfaces, factory, attributes?, documentation?
-    void (null as unknown as Sig);
+    const sigCheck: Sig | undefined = undefined;
+    expect(sigCheck).toBeUndefined();
   });
 
   it('factory can return either engine or envelope (compile-time)', () => {
     // Verifies the return shape augmentation compiles.
     const factoryEngine: IProjectDataProviderEngineFactory<['platform.base']> = {
       getAvailableProjects: async () => [],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      createProjectDataProviderEngine: async () => ({}) as any, // raw engine
+      // The cast is needed to satisfy the generic engine type in a test context without a real engine
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      createProjectDataProviderEngine: async () => ({}) as never, // raw engine
     };
     const factoryEnvelope: IProjectDataProviderEngineFactory<['platform.base']> = {
       getAvailableProjects: async () => [],
       createProjectDataProviderEngine: async () => ({
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        projectDataProviderEngine: {} as any,
+        // The cast is needed to satisfy the generic engine type in a test context without a real engine
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        projectDataProviderEngine: {} as never,
         attributes: { extra: 1 },
         documentation: { 'x-experimental': true },
       }),
     };
-    void factoryEngine;
-    void factoryEnvelope;
+    expect(factoryEngine).toBeDefined();
+    expect(factoryEnvelope).toBeDefined();
   });
 });

--- a/src/shared/services/data-provider.service.ts
+++ b/src/shared/services/data-provider.service.ts
@@ -822,11 +822,11 @@ async function registerEngine<DataProviderName extends DataProviderNames>(
   // Create a networked update event
   const dynamicEventName = serializeRequestType(dataProviderObjectId, ON_DID_UPDATE);
   // Per-instance data provider events have dynamic names that can't be declared in
-  // NetworkEventTypes. Cast the name to satisfy the constraint; the payload type is recovered
+  // NetworkEvents. Cast the name to satisfy the constraint; the payload type is recovered
   // from the surrounding function's generic context.
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   const onDidUpdateEmitter = (await networkService.createNetworkEventEmitterAsync(
-    dynamicEventName as keyof NetworkEventTypes,
+    dynamicEventName as NetworkEventTypes,
   )) as unknown as PlatformEventEmitter<
     DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>
   >;

--- a/src/shared/services/data-provider.service.ts
+++ b/src/shared/services/data-provider.service.ts
@@ -796,11 +796,10 @@ function buildDataProvider<DataProviderName extends DataProviderNames>(
 async function registerEngine<DataProviderName extends DataProviderNames>(
   providerName: DataProviderName,
   dataProviderEngine: IDataProviderEngine<DataProviderTypes[DataProviderName]>,
-  dataProviderType?: string,
-  dataProviderAttributes?: { [property: string]: unknown },
-  documentation?: NetworkObjectDocumentation,
+  dataProviderType: string = 'dataProvider',
+  dataProviderAttributes: { [property: string]: unknown } | undefined = undefined,
+  documentation: NetworkObjectDocumentation | undefined = undefined,
 ): Promise<DisposableDataProviders[DataProviderName]> {
-  const resolvedDataProviderType = dataProviderType ?? 'dataProvider';
   await initialize();
 
   if (hasKnown(providerName))
@@ -848,7 +847,7 @@ async function registerEngine<DataProviderName extends DataProviderNames>(
   const disposableDataProvider = (await networkObjectService.set(
     dataProviderObjectId,
     dataProviderInternal,
-    resolvedDataProviderType,
+    dataProviderType,
     dataProviderAttributes,
     documentation,
   )) as unknown as DisposableDataProviders[DataProviderName];
@@ -899,9 +898,9 @@ async function registerEngine<DataProviderName extends DataProviderNames>(
 export async function registerEngineByType<TDataTypes extends DataProviderDataTypes>(
   providerName: string,
   dataProviderEngine: IDataProviderEngine<TDataTypes>,
-  dataProviderType?: string,
-  dataProviderAttributes?: { [property: string]: unknown },
-  documentation?: NetworkObjectDocumentation,
+  dataProviderType: string = 'dataProvider',
+  dataProviderAttributes: { [property: string]: unknown } | undefined = undefined,
+  documentation: NetworkObjectDocumentation | undefined = undefined,
 ): Promise<IDisposableDataProvider<IDataProvider<TDataTypes>>> {
   // All the types on this function and `registerEngine` are just TypeScript helpers. They do not
   // serve us well in this particular case, so we're ignoring the types and using our own since we

--- a/src/shared/services/data-provider.service.ts
+++ b/src/shared/services/data-provider.service.ts
@@ -44,6 +44,7 @@ import {
 import { IDataProvider, IDisposableDataProvider } from '@shared/models/data-provider.interface';
 import { notificationService } from '@shared/services/notification.service';
 import { PlatformNotification } from '@shared/models/notification.service-model';
+import type { NetworkObjectDocumentation } from '@shared/models/openrpc.model';
 
 /** Suffix on network objects that indicates that the network object is a data provider */
 const DATA_PROVIDER_LABEL = 'data';
@@ -782,6 +783,9 @@ function buildDataProvider<DataProviderName extends DataProviderNames>(
  *   providers), a unique type name should be used to distinguish from generic data providers.
  * @param dataProviderAttributes Optional object that will be sent in a network event to provide
  *   additional metadata about the data provider represented by this engine.
+ * @param documentation Optional OpenRPC-style documentation for the data provider network object.
+ *   When `documentation['x-experimental']` is `true`, the provider's methods will be automatically
+ *   tagged as experimental in the OpenRPC document.
  *
  *   WARNING: registering a dataProviderEngine mutates the provided object. Its `notifyUpdate` and
  *   `set` methods are layered over to facilitate data provider subscriptions.
@@ -793,6 +797,7 @@ async function registerEngine<DataProviderName extends DataProviderNames>(
   dataProviderEngine: IDataProviderEngine<DataProviderTypes[DataProviderName]>,
   dataProviderType: string = 'dataProvider',
   dataProviderAttributes: { [property: string]: unknown } | undefined = undefined,
+  documentation?: NetworkObjectDocumentation,
 ): Promise<DisposableDataProviders[DataProviderName]> {
   await initialize();
 
@@ -835,6 +840,7 @@ async function registerEngine<DataProviderName extends DataProviderNames>(
     dataProviderInternal,
     dataProviderType,
     dataProviderAttributes,
+    documentation,
   )) as unknown as DisposableDataProviders[DataProviderName];
 
   // Get the local network object proxy for the data provider so the provider can't be disposed
@@ -869,6 +875,9 @@ async function registerEngine<DataProviderName extends DataProviderNames>(
  *   providers), a unique type name should be used to distinguish from generic data providers.
  * @param dataProviderAttributes Optional object that will be sent in a network event to provide
  *   additional metadata about the data provider represented by this engine.
+ * @param documentation Optional OpenRPC-style documentation for the data provider network object.
+ *   When `documentation['x-experimental']` is `true`, the provider's methods will be automatically
+ *   tagged as experimental in the OpenRPC document.
  *
  *   WARNING: registering a dataProviderEngine mutates the provided object. Its `notifyUpdate` and
  *   `set` methods are layered over to facilitate data provider subscriptions.
@@ -882,6 +891,7 @@ export async function registerEngineByType<TDataTypes extends DataProviderDataTy
   dataProviderEngine: IDataProviderEngine<TDataTypes>,
   dataProviderType: string = 'dataProvider',
   dataProviderAttributes: { [property: string]: unknown } | undefined = undefined,
+  documentation?: NetworkObjectDocumentation,
 ): Promise<IDisposableDataProvider<IDataProvider<TDataTypes>>> {
   // All the types on this function and `registerEngine` are just TypeScript helpers. They do not
   // serve us well in this particular case, so we're ignoring the types and using our own since we
@@ -892,6 +902,7 @@ export async function registerEngineByType<TDataTypes extends DataProviderDataTy
     dataProviderEngine as any,
     dataProviderType,
     dataProviderAttributes,
+    documentation,
   );
   /* eslint-enable no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any */
 }

--- a/src/shared/services/data-provider.service.ts
+++ b/src/shared/services/data-provider.service.ts
@@ -932,10 +932,18 @@ function createLocalDataProviderToProxy<DataProviderName extends DataProviderNam
   dataProviderObjectId: DataProviderName,
   dataProviderPromise: Promise<DataProviders[DataProviderName]>,
 ): Partial<DataProviderInternal<DataProviderTypes[DataProviderName]>> {
-  // Create a networked update event
-  const onDidUpdate = networkService.getNetworkEvent<boolean>(
-    serializeRequestType(dataProviderObjectId, ON_DID_UPDATE),
-  );
+  // Create a networked update event. Per-instance data provider events have dynamic names that
+  // can't be declared in NetworkEvents, so we use the documented escape hatch: cast the name to
+  // satisfy the typed overload's constraint, then assert the result type.
+  const dynamicEventName = serializeRequestType(dataProviderObjectId, ON_DID_UPDATE);
+  // Two unavoidable type assertions for the dynamic-name escape hatch — see comment above.
+  /* eslint-disable no-type-assertion/no-type-assertion */
+  const onDidUpdate = networkService.getNetworkEvent(
+    dynamicEventName as NetworkEventTypes,
+  ) as unknown as PlatformEvent<
+    DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>
+  >;
+  /* eslint-enable no-type-assertion/no-type-assertion */
 
   return createDataProviderProxy(undefined, dataProviderPromise, onDidUpdate);
 }

--- a/src/shared/services/data-provider.service.ts
+++ b/src/shared/services/data-provider.service.ts
@@ -796,10 +796,11 @@ function buildDataProvider<DataProviderName extends DataProviderNames>(
 async function registerEngine<DataProviderName extends DataProviderNames>(
   providerName: DataProviderName,
   dataProviderEngine: IDataProviderEngine<DataProviderTypes[DataProviderName]>,
-  dataProviderType: string = 'dataProvider',
-  dataProviderAttributes: { [property: string]: unknown } | undefined = undefined,
+  dataProviderType?: string,
+  dataProviderAttributes?: { [property: string]: unknown },
   documentation?: NetworkObjectDocumentation,
 ): Promise<DisposableDataProviders[DataProviderName]> {
+  const resolvedDataProviderType = dataProviderType ?? 'dataProvider';
   await initialize();
 
   if (hasKnown(providerName))
@@ -824,12 +825,13 @@ async function registerEngine<DataProviderName extends DataProviderNames>(
   // Per-instance data provider events have dynamic names that can't be declared in
   // NetworkEvents. Cast the name to satisfy the constraint; the payload type is recovered
   // from the surrounding function's generic context.
-  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  /* eslint-disable no-type-assertion/no-type-assertion */
   const onDidUpdateEmitter = (await networkService.createNetworkEventEmitterAsync(
     dynamicEventName as NetworkEventTypes,
   )) as unknown as PlatformEventEmitter<
     DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>
   >;
+  /* eslint-enable no-type-assertion/no-type-assertion */
 
   // Build the data provider
   const dataProviderInternal = buildDataProvider(
@@ -846,7 +848,7 @@ async function registerEngine<DataProviderName extends DataProviderNames>(
   const disposableDataProvider = (await networkObjectService.set(
     dataProviderObjectId,
     dataProviderInternal,
-    dataProviderType,
+    resolvedDataProviderType,
     dataProviderAttributes,
     documentation,
   )) as unknown as DisposableDataProviders[DataProviderName];
@@ -897,8 +899,8 @@ async function registerEngine<DataProviderName extends DataProviderNames>(
 export async function registerEngineByType<TDataTypes extends DataProviderDataTypes>(
   providerName: string,
   dataProviderEngine: IDataProviderEngine<TDataTypes>,
-  dataProviderType: string = 'dataProvider',
-  dataProviderAttributes: { [property: string]: unknown } | undefined = undefined,
+  dataProviderType?: string,
+  dataProviderAttributes?: { [property: string]: unknown },
   documentation?: NetworkObjectDocumentation,
 ): Promise<IDisposableDataProvider<IDataProvider<TDataTypes>>> {
   // All the types on this function and `registerEngine` are just TypeScript helpers. They do not

--- a/src/shared/services/data-provider.service.ts
+++ b/src/shared/services/data-provider.service.ts
@@ -827,6 +827,22 @@ async function registerEngine<DataProviderName extends DataProviderNames>(
   /* eslint-disable no-type-assertion/no-type-assertion */
   const onDidUpdateEmitter = (await networkService.createNetworkEventEmitterAsync(
     dynamicEventName as NetworkEventTypes,
+    {
+      notification: {
+        // Mark the update event experimental in lockstep with the provider's methods, so an
+        // experimental provider's `<id>:onDidUpdate` isn't surfaced as non-experimental.
+        'x-experimental': documentation?.['x-experimental'],
+        summary: 'Emitted when the data served by this data provider changes.',
+        params: [
+          {
+            name: 'updateInstructions',
+            required: true,
+            summary: 'Which data types changed (or all/none).',
+            schema: {},
+          },
+        ],
+      },
+    },
   )) as unknown as PlatformEventEmitter<
     DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>
   >;

--- a/src/shared/services/data-provider.service.ts
+++ b/src/shared/services/data-provider.service.ts
@@ -40,6 +40,7 @@ import {
   DataProviderTypes,
   DataProviders,
   DisposableDataProviders,
+  NetworkEventTypes,
 } from 'papi-shared-types';
 import { IDataProvider, IDisposableDataProvider } from '@shared/models/data-provider.interface';
 import { notificationService } from '@shared/services/notification.service';
@@ -819,9 +820,16 @@ async function registerEngine<DataProviderName extends DataProviderNames>(
   );
 
   // Create a networked update event
-  const onDidUpdateEmitter = networkService.createNetworkEventEmitter<
+  const dynamicEventName = serializeRequestType(dataProviderObjectId, ON_DID_UPDATE);
+  // Per-instance data provider events have dynamic names that can't be declared in
+  // NetworkEventTypes. Cast the name to satisfy the constraint; the payload type is recovered
+  // from the surrounding function's generic context.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  const onDidUpdateEmitter = (await networkService.createNetworkEventEmitterAsync(
+    dynamicEventName as keyof NetworkEventTypes,
+  )) as unknown as PlatformEventEmitter<
     DataProviderUpdateInstructions<DataProviderTypes[DataProviderName]>
-  >(serializeRequestType(dataProviderObjectId, ON_DID_UPDATE));
+  >;
 
   // Build the data provider
   const dataProviderInternal = buildDataProvider(

--- a/src/shared/services/network-object.service.ts
+++ b/src/shared/services/network-object.service.ts
@@ -45,10 +45,11 @@ const initialize = (): Promise<void> => {
     // TODO: Might be best to make a singleton or something
     await networkService.initialize();
 
-    // `initialize` is only called after module evaluation is complete, so all module-level
+    // These are pre-approved multi-source events, so create them synchronously and register them
+    // centrally in the background (we don't await registration — it isn't needed for the emitter to
+    // work). `initialize` is only called after module evaluation is complete, so all module-level
     // variables below are already defined by the time this async body runs.
-    // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    onDidCreateNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
+    const createEmitter = networkService.createCoreMultiSourceEventEmitter(
       'object:onDidCreateNetworkObject',
       {
         notification: {
@@ -64,10 +65,12 @@ const initialize = (): Promise<void> => {
         },
       },
     );
-
-    // `initialize` runs after module evaluation; the emitter variable is defined later in the module.
+    // The emitter variable is declared later in the module; safe at runtime since initialize runs
+    // after module evaluation.
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    onDidDisposeNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
+    onDidCreateNetworkObjectEmitter = createEmitter.emitter;
+
+    const disposeEmitter = networkService.createCoreMultiSourceEventEmitter(
       'object:onDidDisposeNetworkObject',
       {
         notification: {
@@ -83,6 +86,20 @@ const initialize = (): Promise<void> => {
         },
       },
     );
+    // `initialize` runs after module evaluation; the emitter variable is defined later in the module.
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    onDidDisposeNetworkObjectEmitter = disposeEmitter.emitter;
+
+    // Central registration runs in the background — it isn't needed for the emitters to work and we
+    // don't block startup on it. Consume the results (failures are already logged inside the network
+    // service) so a rejected registration can't surface as an unhandled rejection. allSettled never
+    // rejects, so nothing escapes this IIFE.
+    (async () => {
+      await Promise.allSettled([
+        createEmitter.registeredEmitterPromise,
+        disposeEmitter.registeredEmitterPromise,
+      ]);
+    })();
 
     // Subscribe to the dispose event to clean up local and remote network object registrations
     // eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/src/shared/services/network-object.service.ts
+++ b/src/shared/services/network-object.service.ts
@@ -8,7 +8,6 @@ import {
   PlatformEventEmitter,
   aggregateUnsubscriberAsyncs,
   serialize,
-  Unsubscriber,
   UnsubscriberAsync,
   getAllObjectFunctionNames,
   isString,
@@ -50,25 +49,9 @@ const initialize = (): Promise<void> => {
       'object:onDidCreateNetworkObject',
     );
 
-    // Drain any subscribers that registered before the emitter existed.
-    while (pendingOnDidCreateNetworkObjectSubscribers.length > 0) {
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      const entry = pendingOnDidCreateNetworkObjectSubscribers.shift()!;
-      if (entry.disposed) continue;
-      entry.realUnsub = onDidCreateNetworkObjectEmitter.event(entry.callback);
-    }
-
     onDidDisposeNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
       'object:onDidDisposeNetworkObject',
     );
-
-    // Drain any subscribers that registered before the emitter existed.
-    while (pendingOnDidDisposeNetworkObjectSubscribers.length > 0) {
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      const entry = pendingOnDidDisposeNetworkObjectSubscribers.shift()!;
-      if (entry.disposed) continue;
-      entry.realUnsub = onDidDisposeNetworkObjectEmitter.event(entry.callback);
-    }
 
     // Subscribe to the dispose event to clean up local and remote network object registrations
     onDidDisposeNetworkObject((id: string) => {
@@ -168,35 +151,12 @@ const hasKnown = (id: string): boolean => networkObjectRegistrations.has(id);
 let onDidCreateNetworkObjectEmitter: PlatformEventEmitter<NetworkObjectDetails> | undefined;
 
 /**
- * Subscribers that called `onDidCreateNetworkObject` before the emitter was created. They get bound
- * to the real emitter inside `initialize` and removed from this list.
- */
-const pendingOnDidCreateNetworkObjectSubscribers: {
-  callback: (event: NetworkObjectDetails) => void;
-  realUnsub?: Unsubscriber;
-  disposed: boolean;
-}[] = [];
-
-/**
  * Event that fires when a new object has been created on the network (locally or remotely). The
  * event contains information about the new network object.
  */
-export const onDidCreateNetworkObject: PlatformEvent<NetworkObjectDetails> = (callback) => {
-  if (onDidCreateNetworkObjectEmitter) return onDidCreateNetworkObjectEmitter.event(callback);
-
-  const entry: (typeof pendingOnDidCreateNetworkObjectSubscribers)[number] = {
-    callback,
-    disposed: false,
-  };
-  pendingOnDidCreateNetworkObjectSubscribers.push(entry);
-  return () => {
-    entry.disposed = true;
-    if (entry.realUnsub) return entry.realUnsub();
-    const i = pendingOnDidCreateNetworkObjectSubscribers.indexOf(entry);
-    if (i >= 0) pendingOnDidCreateNetworkObjectSubscribers.splice(i, 1);
-    return true;
-  };
-};
+export const onDidCreateNetworkObject = networkService.getNetworkEvent(
+  'object:onDidCreateNetworkObject',
+);
 
 /**
  * Emitter for when a network object is disposed. Provides the ID so that the local emitter specific
@@ -207,33 +167,10 @@ export const onDidCreateNetworkObject: PlatformEvent<NetworkObjectDetails> = (ca
  */
 let onDidDisposeNetworkObjectEmitter: PlatformEventEmitter<string> | undefined;
 
-/**
- * Subscribers that called `onDidDisposeNetworkObject` before the emitter was created. They get
- * bound to the real emitter inside `initialize` and removed from this list.
- */
-const pendingOnDidDisposeNetworkObjectSubscribers: {
-  callback: (event: string) => void;
-  realUnsub?: Unsubscriber;
-  disposed: boolean;
-}[] = [];
-
 /** Event that fires with a network object ID when that object is disposed locally or remotely */
-export const onDidDisposeNetworkObject: PlatformEvent<string> = (callback) => {
-  if (onDidDisposeNetworkObjectEmitter) return onDidDisposeNetworkObjectEmitter.event(callback);
-
-  const entry: (typeof pendingOnDidDisposeNetworkObjectSubscribers)[number] = {
-    callback,
-    disposed: false,
-  };
-  pendingOnDidDisposeNetworkObjectSubscribers.push(entry);
-  return () => {
-    entry.disposed = true;
-    if (entry.realUnsub) return entry.realUnsub();
-    const i = pendingOnDidDisposeNetworkObjectSubscribers.indexOf(entry);
-    if (i >= 0) pendingOnDidDisposeNetworkObjectSubscribers.splice(i, 1);
-    return true;
-  };
-};
+export const onDidDisposeNetworkObject = networkService.getNetworkEvent(
+  'object:onDidDisposeNetworkObject',
+);
 
 // #endregion
 

--- a/src/shared/services/network-object.service.ts
+++ b/src/shared/services/network-object.service.ts
@@ -8,6 +8,7 @@ import {
   PlatformEventEmitter,
   aggregateUnsubscriberAsyncs,
   serialize,
+  Unsubscriber,
   UnsubscriberAsync,
   getAllObjectFunctionNames,
   isString,
@@ -49,9 +50,25 @@ const initialize = (): Promise<void> => {
       'object:onDidCreateNetworkObject',
     );
 
+    // Drain any subscribers that registered before the emitter existed.
+    while (pendingOnDidCreateNetworkObjectSubscribers.length > 0) {
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      const entry = pendingOnDidCreateNetworkObjectSubscribers.shift()!;
+      if (entry.disposed) continue;
+      entry.realUnsub = onDidCreateNetworkObjectEmitter.event(entry.callback);
+    }
+
     onDidDisposeNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
       'object:onDidDisposeNetworkObject',
     );
+
+    // Drain any subscribers that registered before the emitter existed.
+    while (pendingOnDidDisposeNetworkObjectSubscribers.length > 0) {
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      const entry = pendingOnDidDisposeNetworkObjectSubscribers.shift()!;
+      if (entry.disposed) continue;
+      entry.realUnsub = onDidDisposeNetworkObjectEmitter.event(entry.callback);
+    }
 
     // Subscribe to the dispose event to clean up local and remote network object registrations
     onDidDisposeNetworkObject((id: string) => {
@@ -151,15 +168,34 @@ const hasKnown = (id: string): boolean => networkObjectRegistrations.has(id);
 let onDidCreateNetworkObjectEmitter: PlatformEventEmitter<NetworkObjectDetails> | undefined;
 
 /**
+ * Subscribers that called `onDidCreateNetworkObject` before the emitter was created. They get bound
+ * to the real emitter inside `initialize` and removed from this list.
+ */
+const pendingOnDidCreateNetworkObjectSubscribers: {
+  callback: (event: NetworkObjectDetails) => void;
+  realUnsub?: Unsubscriber;
+  disposed: boolean;
+}[] = [];
+
+/**
  * Event that fires when a new object has been created on the network (locally or remotely). The
  * event contains information about the new network object.
  */
 export const onDidCreateNetworkObject: PlatformEvent<NetworkObjectDetails> = (callback) => {
-  if (!onDidCreateNetworkObjectEmitter)
-    throw new Error(
-      'network-object.service not initialized — call initialize() before subscribing to onDidCreateNetworkObject',
-    );
-  return onDidCreateNetworkObjectEmitter.event(callback);
+  if (onDidCreateNetworkObjectEmitter) return onDidCreateNetworkObjectEmitter.event(callback);
+
+  const entry: (typeof pendingOnDidCreateNetworkObjectSubscribers)[number] = {
+    callback,
+    disposed: false,
+  };
+  pendingOnDidCreateNetworkObjectSubscribers.push(entry);
+  return () => {
+    entry.disposed = true;
+    if (entry.realUnsub) return entry.realUnsub();
+    const i = pendingOnDidCreateNetworkObjectSubscribers.indexOf(entry);
+    if (i >= 0) pendingOnDidCreateNetworkObjectSubscribers.splice(i, 1);
+    return true;
+  };
 };
 
 /**
@@ -171,13 +207,32 @@ export const onDidCreateNetworkObject: PlatformEvent<NetworkObjectDetails> = (ca
  */
 let onDidDisposeNetworkObjectEmitter: PlatformEventEmitter<string> | undefined;
 
+/**
+ * Subscribers that called `onDidDisposeNetworkObject` before the emitter was created. They get
+ * bound to the real emitter inside `initialize` and removed from this list.
+ */
+const pendingOnDidDisposeNetworkObjectSubscribers: {
+  callback: (event: string) => void;
+  realUnsub?: Unsubscriber;
+  disposed: boolean;
+}[] = [];
+
 /** Event that fires with a network object ID when that object is disposed locally or remotely */
 export const onDidDisposeNetworkObject: PlatformEvent<string> = (callback) => {
-  if (!onDidDisposeNetworkObjectEmitter)
-    throw new Error(
-      'network-object.service not initialized — call initialize() before subscribing to onDidDisposeNetworkObject',
-    );
-  return onDidDisposeNetworkObjectEmitter.event(callback);
+  if (onDidDisposeNetworkObjectEmitter) return onDidDisposeNetworkObjectEmitter.event(callback);
+
+  const entry: (typeof pendingOnDidDisposeNetworkObjectSubscribers)[number] = {
+    callback,
+    disposed: false,
+  };
+  pendingOnDidDisposeNetworkObjectSubscribers.push(entry);
+  return () => {
+    entry.disposed = true;
+    if (entry.realUnsub) return entry.realUnsub();
+    const i = pendingOnDidDisposeNetworkObjectSubscribers.indexOf(entry);
+    if (i >= 0) pendingOnDidDisposeNetworkObjectSubscribers.splice(i, 1);
+    return true;
+  };
 };
 
 // #endregion

--- a/src/shared/services/network-object.service.ts
+++ b/src/shared/services/network-object.service.ts
@@ -433,6 +433,12 @@ const get = async <T extends object>(
  *   object did not already define a `dispose` function, one will be added.
  *
  *   WARNING: setting a network object mutates the provided object.
+ * @param objectType String identifier for the network object type (e.g. `'object'`,
+ *   `'dataProvider'`)
+ * @param objectAttributes Optional key-value metadata attached to the network object registration.
+ * @param objectDocumentation Optional {@link NetworkObjectDocumentation} for this network object.
+ *   Set `objectDocumentation['x-experimental']: true` to mark all methods on this network object as
+ *   experimental.
  * @returns `objectToShare` modified to be a network object
  */
 
@@ -553,7 +559,11 @@ const set = async <T extends NetworkableObject>(
 
       // Send an event notifying everyone that this network object is no longer available
       // The event listener removes the network object from the registration map
-      if (onDidDisposeNetworkObjectEmitter) onDidDisposeNetworkObjectEmitter.emit(id);
+      if (!onDidDisposeNetworkObjectEmitter)
+        throw new Error(
+          'network-object.service not initialized — call initialize() before emitting onDidDisposeNetworkObject',
+        );
+      onDidDisposeNetworkObjectEmitter.emit(id);
       return true;
     });
 
@@ -569,7 +579,11 @@ const set = async <T extends NetworkableObject>(
 
     // Notify that the network object was successfully registered
     logger.debug(`Network object registered: ${serialize(netObjDetails)}`);
-    if (onDidCreateNetworkObjectEmitter) onDidCreateNetworkObjectEmitter.emit(netObjDetails);
+    if (!onDidCreateNetworkObjectEmitter)
+      throw new Error(
+        'network-object.service not initialized — call initialize() before emitting onDidCreateNetworkObject',
+      );
+    onDidCreateNetworkObjectEmitter.emit(netObjDetails);
 
     // Override objectToShare's type's force-undefined onDidDispose to DisposableNetworkObject's
     // onDidDispose type because it had an onDidDispose added in overrideOnDidDispose.

--- a/src/shared/services/network-object.service.ts
+++ b/src/shared/services/network-object.service.ts
@@ -508,6 +508,10 @@ const set = async <T extends NetworkableObject>(
         () => Promise.resolve(true),
         {
           method: {
+            // The existence method (`object:{id}`) carries the object's own summary, so it must also
+            // carry the object-level experimental marker — otherwise it would render unmarked while
+            // every `object:{id}.method` is `[EXPERIMENTAL]`.
+            'x-experimental': objectDocumentation['x-experimental'],
             summary: objectDocumentation.summary ?? '',
             description: objectDocumentation.description ?? '',
             params: [],
@@ -556,6 +560,16 @@ const set = async <T extends NetworkableObject>(
         { method: methodDocs },
       );
       unsubPromises.push(unsub);
+    });
+
+    // Warn about documentation entries for methods that don't match any exposed function name
+    // (typos, or names filtered out such as on*/dispose) — those entries are otherwise silently
+    // discarded and the method falls back to placeholder docs.
+    objectDocumentation.methods?.forEach((method) => {
+      if (!netObjDetails.functionNames.includes(method.name))
+        logger.warn(
+          `Network object "${id}" documentation includes method "${method.name}" that matches no exposed function name; the entry is ignored.`,
+        );
     });
 
     // Await all of the registrations finishing, successful or not

--- a/src/shared/services/network-object.service.ts
+++ b/src/shared/services/network-object.service.ts
@@ -470,11 +470,19 @@ const set = async <T extends NetworkableObject>(
       objectAttributes,
     );
 
+    const objectIsExperimental = objectDocumentation['x-experimental'] === true;
+
     netObjDetails.functionNames.forEach((functionName) => {
       const requestType = getNetworkObjectRequestType(id, functionName);
-      const methodDocs =
+      const baseMethodDocs =
         objectDocumentation.methods?.find((method) => method.name === functionName) ??
         getEmptyMethodDocs();
+      // Fan out the object-level experimental marker onto each method's docs. A per-method explicit
+      // 'x-experimental' wins; absent that, the object-level value propagates.
+      const methodDocs =
+        objectIsExperimental && baseMethodDocs['x-experimental'] === undefined
+          ? { ...baseMethodDocs, 'x-experimental': true as const }
+          : baseMethodDocs;
       const unsub = networkService.registerRequestHandler(
         requestType,
         // Assert as any to allow indexing on the function name

--- a/src/shared/services/network-object.service.ts
+++ b/src/shared/services/network-object.service.ts
@@ -46,11 +46,11 @@ const initialize = (): Promise<void> => {
     await networkService.initialize();
 
     onDidCreateNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
-      'network-object.onDidCreateNetworkObject',
+      'object:onDidCreateNetworkObject',
     );
 
     onDidDisposeNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
-      'network-object.onDidDisposeNetworkObject',
+      'object:onDidDisposeNetworkObject',
     );
 
     // Subscribe to the dispose event to clean up local and remote network object registrations

--- a/src/shared/services/network-object.service.ts
+++ b/src/shared/services/network-object.service.ts
@@ -50,12 +50,38 @@ const initialize = (): Promise<void> => {
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     onDidCreateNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
       'object:onDidCreateNetworkObject',
+      {
+        notification: {
+          summary: 'Emitted when a network object is created in any process.',
+          params: [
+            {
+              name: 'networkObjectDetails',
+              required: true,
+              summary: "The new network object's details.",
+              schema: { type: 'object' },
+            },
+          ],
+        },
+      },
     );
 
     // `initialize` runs after module evaluation; the emitter variable is defined later in the module.
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
     onDidDisposeNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
       'object:onDidDisposeNetworkObject',
+      {
+        notification: {
+          summary: 'Emitted when a network object is disposed in any process.',
+          params: [
+            {
+              name: 'id',
+              required: true,
+              summary: "The disposed network object's ID.",
+              schema: { type: 'string' },
+            },
+          ],
+        },
+      },
     );
 
     // Subscribe to the dispose event to clean up local and remote network object registrations

--- a/src/shared/services/network-object.service.ts
+++ b/src/shared/services/network-object.service.ts
@@ -45,6 +45,33 @@ const initialize = (): Promise<void> => {
     // TODO: Might be best to make a singleton or something
     await networkService.initialize();
 
+    onDidCreateNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
+      'network-object.onDidCreateNetworkObject',
+    );
+
+    onDidDisposeNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
+      'network-object.onDidDisposeNetworkObject',
+    );
+
+    // Subscribe to the dispose event to clean up local and remote network object registrations
+    onDidDisposeNetworkObject((id: string) => {
+      const networkObjectRegistration = networkObjectRegistrations.get(id);
+
+      if (networkObjectRegistration) {
+        // Alert users of this specific network object that it was disposed
+        networkObjectRegistration.onDidDisposeEmitter.emit();
+
+        // Dispose of the network object registration itself
+        networkObjectRegistration.onDidDisposeEmitter.dispose();
+
+        // Dispose of the proxy
+        networkObjectRegistration.revokeProxy();
+
+        // Dispose of the network object registration
+        networkObjectRegistrations.delete(id);
+      }
+    });
+
     isInitialized = true;
   })();
 
@@ -119,51 +146,39 @@ const hasKnown = (id: string): boolean => networkObjectRegistrations.has(id);
 
 /**
  * Emitter for when a network object is created. Includes the list of functions exposed by the
- * network object.
+ * network object. Initialized inside `initialize()`.
  */
-const onDidCreateNetworkObjectEmitter =
-  networkService.createNetworkEventEmitter<NetworkObjectDetails>(
-    serializeRequestType(CATEGORY_NETWORK_OBJECT, 'onDidCreateNetworkObject'),
-  );
+let onDidCreateNetworkObjectEmitter: PlatformEventEmitter<NetworkObjectDetails> | undefined;
 
 /**
  * Event that fires when a new object has been created on the network (locally or remotely). The
  * event contains information about the new network object.
  */
-export const onDidCreateNetworkObject = onDidCreateNetworkObjectEmitter.event;
+export const onDidCreateNetworkObject: PlatformEvent<NetworkObjectDetails> = (callback) => {
+  if (!onDidCreateNetworkObjectEmitter)
+    throw new Error(
+      'network-object.service not initialized — call initialize() before subscribing to onDidCreateNetworkObject',
+    );
+  return onDidCreateNetworkObjectEmitter.event(callback);
+};
 
 /**
  * Emitter for when a network object is disposed. Provides the ID so that the local emitter specific
  * to that object can be run.
  *
  * Only run on local network object registration! Processes should only dispose their own network
- * objects
+ * objects. Initialized inside `initialize()`.
  */
-const onDidDisposeNetworkObjectEmitter = networkService.createNetworkEventEmitter<string>(
-  serializeRequestType(CATEGORY_NETWORK_OBJECT, 'onDidDisposeNetworkObject'),
-);
+let onDidDisposeNetworkObjectEmitter: PlatformEventEmitter<string> | undefined;
 
 /** Event that fires with a network object ID when that object is disposed locally or remotely */
-export const onDidDisposeNetworkObject = onDidDisposeNetworkObjectEmitter.event;
-
-/** Runs to dispose of local and remote network objects when we receive events telling us to do so */
-onDidDisposeNetworkObject((id: string) => {
-  const networkObjectRegistration = networkObjectRegistrations.get(id);
-
-  if (networkObjectRegistration) {
-    // Alert users of this specific network object that it was disposed
-    networkObjectRegistration.onDidDisposeEmitter.emit();
-
-    // Dispose of the network object registration itself
-    networkObjectRegistration.onDidDisposeEmitter.dispose();
-
-    // Dispose of the proxy
-    networkObjectRegistration.revokeProxy();
-
-    // Dispose of the network object registration
-    networkObjectRegistrations.delete(id);
-  }
-});
+export const onDidDisposeNetworkObject: PlatformEvent<string> = (callback) => {
+  if (!onDidDisposeNetworkObjectEmitter)
+    throw new Error(
+      'network-object.service not initialized — call initialize() before subscribing to onDidDisposeNetworkObject',
+    );
+  return onDidDisposeNetworkObjectEmitter.event(callback);
+};
 
 // #endregion
 
@@ -538,7 +553,7 @@ const set = async <T extends NetworkableObject>(
 
       // Send an event notifying everyone that this network object is no longer available
       // The event listener removes the network object from the registration map
-      onDidDisposeNetworkObjectEmitter.emit(id);
+      if (onDidDisposeNetworkObjectEmitter) onDidDisposeNetworkObjectEmitter.emit(id);
       return true;
     });
 
@@ -554,7 +569,7 @@ const set = async <T extends NetworkableObject>(
 
     // Notify that the network object was successfully registered
     logger.debug(`Network object registered: ${serialize(netObjDetails)}`);
-    onDidCreateNetworkObjectEmitter.emit(netObjDetails);
+    if (onDidCreateNetworkObjectEmitter) onDidCreateNetworkObjectEmitter.emit(netObjDetails);
 
     // Override objectToShare's type's force-undefined onDidDispose to DisposableNetworkObject's
     // onDidDispose type because it had an onDidDispose added in overrideOnDidDispose.

--- a/src/shared/services/network-object.service.ts
+++ b/src/shared/services/network-object.service.ts
@@ -45,16 +45,24 @@ const initialize = (): Promise<void> => {
     // TODO: Might be best to make a singleton or something
     await networkService.initialize();
 
+    // `initialize` is only called after module evaluation is complete, so all module-level
+    // variables below are already defined by the time this async body runs.
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     onDidCreateNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
       'object:onDidCreateNetworkObject',
     );
 
+    // `initialize` runs after module evaluation; the emitter variable is defined later in the module.
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     onDidDisposeNetworkObjectEmitter = await networkService.createNetworkEventEmitterAsync(
       'object:onDidDisposeNetworkObject',
     );
 
     // Subscribe to the dispose event to clean up local and remote network object registrations
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
     onDidDisposeNetworkObject((id: string) => {
+      // networkObjectRegistrations is defined later in the module; safe at runtime since initialize runs after module eval.
+      // eslint-disable-next-line @typescript-eslint/no-use-before-define
       const networkObjectRegistration = networkObjectRegistrations.get(id);
 
       if (networkObjectRegistration) {
@@ -68,6 +76,7 @@ const initialize = (): Promise<void> => {
         networkObjectRegistration.revokeProxy();
 
         // Dispose of the network object registration
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
         networkObjectRegistrations.delete(id);
       }
     });

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -28,8 +28,7 @@ import {
 import {
   RequestTimeoutSharedStoreKey,
   sharedStoreService,
-  STORE_GET_REQUEST,
-  waitForInitialization as waitForSharedStoreInitialization,
+  StoreChangeEvent,
 } from '@shared/services/shared-store.service';
 import { deserializeRequestType, SerializedRequestType } from '@shared/utils/util';
 import { PapiNetworkEventEmitter } from '@shared/models/papi-network-event-emitter.model';
@@ -42,9 +41,10 @@ import {
 } from '@shared/models/openrpc.model';
 import { JSONRPCResponse } from 'json-rpc-2.0';
 import { NetworkMethodHandlerOptions } from '@shared/models/network.model';
-import type { NetworkEvents, NetworkEventTypes } from 'papi-shared-types';
+import type { MultiSourceNetworkEvents, NetworkEvents, NetworkEventTypes } from 'papi-shared-types';
+import { MULTI_SOURCE_EVENT_NAMES } from '@shared/data/network-event-names';
 
-export { MULTI_SOURCE_EVENT_NAMES } from '@shared/data/network-event-names';
+export { MULTI_SOURCE_EVENT_NAMES };
 
 // #region Local event handling
 
@@ -58,7 +58,16 @@ export { MULTI_SOURCE_EVENT_NAMES } from '@shared/data/network-event-names';
 // TODO: sync these between processes
 const eventEmittersByEventType = new Map<
   string,
-  { emitter: PapiNetworkEventEmitter<unknown>; isRegistered: boolean }
+  {
+    emitter: PapiNetworkEventEmitter<unknown>;
+    isRegistered: boolean;
+    /**
+     * Whether this emitter's event was registered centrally with the RPC handler (via
+     * `jsonRpc.registerEvent`). When `true`, disposing the emitter also unregisters the event from
+     * the central registry.
+     */
+    isCentrallyRegistered: boolean;
+  }
 >();
 
 /**
@@ -101,13 +110,15 @@ export const shutdown = async () => {
     if (!jsonRpc) return;
 
     await jsonRpc.disconnect();
+    // Tear down the handler reference before disposing emitters so their disposers skip the
+    // now-pointless per-event unregister call — the whole connection is already going away.
+    jsonRpc = undefined;
     await Promise.all(
       [...eventEmittersByEventType.values()].map(async (emitter) => {
         await emitter.emitter.dispose();
       }),
     );
     eventEmittersByEventType.clear();
-    jsonRpc = undefined;
   });
 };
 
@@ -137,21 +148,15 @@ function sharedStoreKeyForRequestType(
 }
 
 function getTimeoutMsForRequestType(requestType: SerializedRequestType): number {
-  // Custom timeouts live in the shared store. Reading shared store before it has finished
-  // initializing would throw (and would break its Lamport-clock sync guarantee anyway). The
-  // bootstrap window can include network requests fired by React components mounted before
-  // initializeSharedStoreService() resolves, so during that window fall back to the default
-  // timeout — a small bootstrapping problem that can be improved later.
-  if (!sharedStoreService.isInitialized()) {
-    // Suppress the warning for shared-store's own internal bootstrap request — it's expected to
-    // run before initialization completes (it's part of the initialization).
-    if (requestType !== STORE_GET_REQUEST)
-      logger.warn(
-        `Shared store not initialized; using default request timeout of ${requestTimeoutMs}ms for request type ${requestType}`,
-      );
-    return requestTimeoutMs;
-  }
+  // Custom timeouts live in the shared store. The sync `get` returns undefined both when no custom
+  // timeout has been set (normal) and when the shared store has not finished initializing. Only the
+  // latter is noteworthy, so log a debug note when we read undefined before the shared store is
+  // initialized; otherwise undefined just means "no custom timeout" and we use the default silently.
   const sharedVal = sharedStoreService.get(sharedStoreKeyForRequestType(requestType));
+  if (sharedVal === undefined && !sharedStoreService.isInitialized())
+    logger.debug(
+      `Custom timeout for request type ${requestType} requested before the shared store finished initializing; using default ${requestTimeoutMs}ms`,
+    );
   return typeof sharedVal === 'number' && sharedVal >= 0 ? sharedVal : requestTimeoutMs;
 }
 
@@ -204,21 +209,6 @@ async function doRequest<TParam extends Array<unknown>, TReturn>(
 ): Promise<TReturn> {
   validateRequestTypeFormatting(requestType);
   await initialize();
-  // Ensure the shared store service is ready before this request so any custom timeout for the
-  // request type is honored. Skip the gate for shared-store's own internal requests fired during
-  // its initialization — they cannot wait for the service that fires them, or we'd deadlock.
-  // waitForSharedStoreInitialization throws if shared-store init does not start within its
-  // timeout; we catch and continue with the default timeout in that case so a missing/late
-  // shared-store init does not block all network traffic.
-  if (requestType !== STORE_GET_REQUEST) {
-    try {
-      await waitForSharedStoreInitialization();
-    } catch (e) {
-      logger.warn(
-        `Proceeding with default timeout for ${requestType} — shared store not ready: ${getErrorMessage(e)}`,
-      );
-    }
-  }
   if (!jsonRpc) throw new Error('RPC handler not set');
   const responseAsyncVariable = new AsyncVariable<JSONRPCResponse | PlatformError>(
     `response to ${requestType}`,
@@ -364,6 +354,45 @@ const emitEventOnNetwork = async <T>(eventType: string, event: T) => {
   jsonRpc.emitEventOnNetwork(eventType, event);
 };
 
+/**
+ * Cleans up the record for an event emitter when it is disposed. If the emitter had been centrally
+ * registered with the RPC handler, also unregister the (single-source) event from the central
+ * registry so it stops appearing in the OpenRPC document and frees the name for re-registration.
+ *
+ * Multi-source events are intentionally NOT unregistered here: multiple emitters for the same name
+ * can exist (even within one process), so unregistering one could disrupt the others. They are
+ * cleaned up centrally when the process disconnects (the RPC server unregisters all of a
+ * connection's events on close), the same way registered methods are.
+ *
+ * `dispose` on {@link PapiNetworkEventEmitter} is synchronous, but `unregisterEvent` is async, so we
+ * cannot await it here. We fire it from an IIFE and log a warning if it rejects.
+ */
+const disposeNetworkEventEmitter = (eventType: string) => {
+  const emitterRecord = eventEmittersByEventType.get(eventType);
+  eventEmittersByEventType.delete(eventType);
+  if (!emitterRecord?.isCentrallyRegistered || !jsonRpc) return;
+  if (MULTI_SOURCE_EVENT_NAMES.has(eventType)) return;
+  const rpc = jsonRpc;
+  (async () => {
+    try {
+      await rpc.unregisterEvent(eventType);
+    } catch (e) {
+      logger.warn(
+        `Failed to unregister event "${eventType}" from the central registry: ${getErrorMessage(e)}`,
+      );
+    }
+  })();
+};
+
+/**
+ * Marks an event emitter's record as centrally registered so that disposing it also unregisters the
+ * event from the central registry. See {@link disposeNetworkEventEmitter}.
+ */
+const markEmitterCentrallyRegistered = (eventType: string) => {
+  const emitterRecord = eventEmittersByEventType.get(eventType);
+  if (emitterRecord) emitterRecord.isCentrallyRegistered = true;
+};
+
 const createNetworkEventEmitterInternal = <T>(
   eventType: string,
   registerEmitter: boolean,
@@ -375,9 +404,10 @@ const createNetworkEventEmitterInternal = <T>(
       // eslint-disable-next-line no-type-assertion/no-type-assertion
       emitter: new PapiNetworkEventEmitter<T>(
         (event) => emitEventOnNetwork(eventType, event),
-        () => eventEmittersByEventType.delete(eventType),
+        () => disposeNetworkEventEmitter(eventType),
       ) as PapiNetworkEventEmitter<unknown>,
       isRegistered: false,
+      isCentrallyRegistered: false,
     };
     eventEmittersByEventType.set(eventType, emitterRecord);
   }
@@ -443,7 +473,93 @@ export const createNetworkEventEmitterAsync = async <EventType extends NetworkEv
       `Event "${eventType}" was rejected by the central registry (likely already registered from another process).`,
     );
   }
-  return createNetworkEventEmitterInternal<NetworkEvents[EventType]>(eventType, true);
+  const emitter = createNetworkEventEmitterInternal<NetworkEvents[EventType]>(eventType, true);
+  // Tie the central registration to this emitter so disposing it also unregisters the event.
+  markEmitterCentrallyRegistered(eventType);
+  return emitter;
+};
+
+/**
+ * Core-internal map of multi-source network events. Extends the public
+ * {@link MultiSourceNetworkEvents} with platform-internal multi-source events that are intentionally
+ * NOT advertised on the PAPI — the shared store change event, for example, because the shared store
+ * service is not part of the public API. Used to type {@link createCoreMultiSourceEventEmitter}.
+ */
+export type InternalMultiSourceNetworkEvents = MultiSourceNetworkEvents & {
+  'shared-store:change': StoreChangeEvent;
+};
+
+/**
+ * Synchronously create a network event emitter for one of the pre-approved multi-source events —
+ * those listed in {@link MULTI_SOURCE_EVENT_NAMES}. Throws synchronously if `eventType` is not such
+ * an event.
+ *
+ * This is core-internal (not exposed on `papiNetworkService`, hence the `Core` in the name):
+ * multi-source events are platform events, not for extensions to create.
+ *
+ * Unlike {@link createNetworkEventEmitterAsync}, the emitter is returned immediately so callers can
+ * use it without awaiting. Central registration with the RPC handler is performed in the
+ * background; the returned `registeredEmitterPromise` resolves to the same emitter once
+ * registration completes. If registration fails, the promise logs a warning and rejects with the
+ * underlying error.
+ *
+ * Multi-source emitters are NOT unregistered on dispose (multiple emitters for the same name can
+ * coexist); the central registry cleans them up when the process disconnects. See
+ * {@link disposeNetworkEventEmitter}.
+ *
+ * @param eventType The name of the multi-source event to create. Must be a key of
+ *   {@link InternalMultiSourceNetworkEvents}.
+ * @param documentation Optional notification documentation. Carries
+ *   `notification['x-experimental']: true` to mark the event as experimental.
+ * @returns An object with the synchronously-created `emitter` and a `registeredEmitterPromise` that
+ *   resolves to that same emitter when central registration completes.
+ */
+export const createCoreMultiSourceEventEmitter = <
+  EventType extends keyof InternalMultiSourceNetworkEvents,
+>(
+  eventType: EventType,
+  documentation?: SingleNotificationDocumentation,
+): {
+  emitter: PlatformEventEmitter<InternalMultiSourceNetworkEvents[EventType]>;
+  registeredEmitterPromise: Promise<
+    PlatformEventEmitter<InternalMultiSourceNetworkEvents[EventType]>
+  >;
+} => {
+  if (!MULTI_SOURCE_EVENT_NAMES.has(eventType))
+    throw new Error(
+      `Event "${eventType}" is not a pre-approved multi-source event. Use createNetworkEventEmitterAsync for single-source events.`,
+    );
+
+  // Create the emitter synchronously so the caller can use it right away.
+  const emitter = createNetworkEventEmitterInternal<InternalMultiSourceNetworkEvents[EventType]>(
+    eventType,
+    true,
+  );
+
+  // Register the event centrally in the background. The returned promise resolves to the same
+  // emitter so callers can await registration completion when they need it.
+  const registeredEmitterPromise = (async () => {
+    try {
+      await initialize();
+      if (!jsonRpc) throw new Error('RPC handler not set');
+      const accepted = await jsonRpc.registerEvent(eventType, documentation);
+      if (!accepted)
+        throw new Error(
+          `Event "${eventType}" was rejected by the central registry (likely already registered from this process).`,
+        );
+      // Record that this emitter's event is registered centrally. Disposing it will NOT unregister
+      // (disposeNetworkEventEmitter skips multi-source names); the flag just reflects reality.
+      markEmitterCentrallyRegistered(eventType);
+      return emitter;
+    } catch (e) {
+      logger.warn(
+        `Failed to register multi-source event "${eventType}" with the central registry: ${getErrorMessage(e)}`,
+      );
+      throw e;
+    }
+  })();
+
+  return { emitter, registeredEmitterPromise };
 };
 
 /**

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -428,16 +428,30 @@ export const createNetworkEventEmitterAsync = async <EventType extends keyof Net
 };
 
 /**
- * Gets the network event with the specified type. Creates the emitter if it does not exist
+ * Subscribe to a typed network event. Declare the event in `NetworkEventTypes` (or rely on
+ * `SharedNetworkEventTypes` inheritance for platform events) and the payload type is inferred.
  *
  * @param eventType Unique network event type for coordinating between connections
  * @returns Event for the event type that runs the callback provided when the event is emitted
  */
-export const getNetworkEvent = <T>(eventType: string): PlatformEvent<T> => {
-  // Return event with the generic type.
+export function getNetworkEvent<EventType extends keyof NetworkEventTypes>(
+  eventType: EventType,
+): PlatformEvent<NetworkEventTypes[EventType]>;
+/**
+ * Subscribe to a network event with an explicit payload type.
+ *
+ * @deprecated 8 June 2026. Use the typed signature: declare the event in `NetworkEventTypes` and
+ *   call `getNetworkEvent('your.event.name')` without an explicit type parameter. If your event
+ *   name is dynamic (e.g., per-instance data-provider events), this signature continues to work
+ *   functionally; suppress the deprecation warning at the call site with a brief comment.
+ * @param eventType Unique network event type for coordinating between connections
+ * @returns Event for the event type that runs the callback provided when the event is emitted
+ */
+export function getNetworkEvent<T>(eventType: string): PlatformEvent<T>;
+export function getNetworkEvent(eventType: string): PlatformEvent<unknown> {
   // eslint-disable-next-line no-type-assertion/no-type-assertion
-  return createNetworkEventEmitterInternal(eventType, false).event as PlatformEvent<T>;
-};
+  return createNetworkEventEmitterInternal(eventType, false).event as PlatformEvent<unknown>;
+}
 
 // #endregion
 

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -50,9 +50,9 @@ import type { NetworkEventTypes, SharedNetworkEventTypes } from 'papi-shared-typ
  * Add entries here when adding a new shared event to `SharedNetworkEventTypes`.
  */
 export const SHARED_EVENT_NAMES = new Set<keyof SharedNetworkEventTypes>([
-  'network-object.onDidCreateNetworkObject',
-  'network-object.onDidDisposeNetworkObject',
-  'shared-store.onDidChange',
+  'object:onDidCreateNetworkObject',
+  'object:onDidDisposeNetworkObject',
+  'shared-store:change',
 ]);
 
 // #region Local event handling

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -25,9 +25,15 @@ import {
   stringLength,
   UnsubscriberAsync,
 } from 'platform-bible-utils';
+// Shared-store imports network.service dynamically inside its own initialize() to break what would
+// otherwise be a static cycle. The runtime cycle is safe because the dynamic import resolves after
+// both modules have loaded their declarations.
+// eslint-disable-next-line import/no-cycle
 import {
+  initialize as initializeSharedStoreService,
   RequestTimeoutSharedStoreKey,
   sharedStoreService,
+  STORE_GET_REQUEST,
 } from '@shared/services/shared-store.service';
 import { deserializeRequestType, SerializedRequestType } from '@shared/utils/util';
 import { PapiNetworkEventEmitter } from '@shared/models/papi-network-event-emitter.model';
@@ -139,8 +145,13 @@ function getTimeoutMsForRequestType(requestType: SerializedRequestType): number 
   // initializing would throw (and would break its Lamport-clock sync guarantee anyway). The
   // bootstrap window can include network requests fired by React components mounted before
   // initializeSharedStoreService() resolves, so during that window fall back to the default
-  // timeout — a custom override is an optimization, not a correctness requirement here.
-  if (!sharedStoreService.isInitialized()) return requestTimeoutMs;
+  // timeout — a small bootstrapping problem that can be improved later..
+  if (!sharedStoreService.isInitialized()) {
+    logger.warn(
+      `Shared store not initialized; using default request timeout of ${requestTimeoutMs}ms for request type ${requestType}`,
+    );
+    return requestTimeoutMs;
+  }
   const sharedVal = sharedStoreService.get(sharedStoreKeyForRequestType(requestType));
   return typeof sharedVal === 'number' && sharedVal >= 0 ? sharedVal : requestTimeoutMs;
 }
@@ -194,6 +205,11 @@ async function doRequest<TParam extends Array<unknown>, TReturn>(
 ): Promise<TReturn> {
   validateRequestTypeFormatting(requestType);
   await initialize();
+  // Ensure the shared store service is initialized before this request so any custom timeout for
+  // the request type is honored. Skip the gate for shared-store's own internal requests fired
+  // during its initialization — they cannot wait for the service that fires them, or we'd
+  // deadlock. The initialize call is idempotent and safe to invoke from anywhere.
+  if (requestType !== STORE_GET_REQUEST) await initializeSharedStoreService();
   if (!jsonRpc) throw new Error('RPC handler not set');
   const responseAsyncVariable = new AsyncVariable<JSONRPCResponse | PlatformError>(
     `response to ${requestType}`,

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -163,24 +163,10 @@ function getTimeoutMsForRequestType(requestType: SerializedRequestType): number 
 function setTimeoutMsForRequestType(requestType: SerializedRequestType, timeoutMs: number) {
   if (timeoutMs < 0)
     throw new Error(`Invalid request timeout ${timeoutMs}: must be a non-negative number`);
-  // The sync `set` throws if the shared store has not initialized. This runs from
-  // registerRequestHandler *after* the method has already been registered with the RPC handler, so a
-  // throw here would leak that registration. Custom timeouts are non-critical (the default applies
-  // when one is absent), so when the store isn't ready yet we debug-log and skip rather than throw.
-  if (!sharedStoreService.isInitialized()) {
-    logger.debug(
-      `Custom timeout for request type ${requestType} set before the shared store finished initializing; using default ${requestTimeoutMs}ms instead`,
-    );
-    return;
-  }
   sharedStoreService.set(sharedStoreKeyForRequestType(requestType), timeoutMs);
 }
 
 function removeTimeoutMsForRequestType(requestType: SerializedRequestType) {
-  // Mirror setTimeoutMsForRequestType: skip (rather than throw) if the shared store isn't ready, so
-  // the unsubscriber returned by registerRequestHandler can't throw mid-teardown. If the store never
-  // initialized then no custom timeout was ever stored, so there is nothing to remove.
-  if (!sharedStoreService.isInitialized()) return;
   sharedStoreService.remove(sharedStoreKeyForRequestType(requestType));
 }
 
@@ -445,9 +431,12 @@ const createNetworkEventEmitterInternal = <T>(
  *   are not centrally registered and do not appear in the OpenRPC document. The async version
  *   restricts central _registration_ of an event name to a single source (unless the event is
  *   declared in {@link MultiSourceNetworkEvents}, in which case it accepts multiple registrants by
- *   design). Note this restricts registration only — emission itself is not gated by the registry;
- *   the central registry instead warns when an event is announced unregistered or from a process
- *   that did not register it.
+ *   design). Note this restricts central _registration_, not emission: the registry does not block
+ *   emits today, but it warns when an event is announced without a matching registration or from a
+ *   process that did not register it. That tolerance is transitional — announcing an unregistered
+ *   or cross-process single-source event is deprecated and is expected to become an error (with the
+ *   registry gating emission) in a future release, so treat the warning as something to fix, not as
+ *   the permanent behavior.
  *
  *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
  *   emitters.

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -29,7 +29,7 @@ import {
   RequestTimeoutSharedStoreKey,
   sharedStoreService,
   STORE_GET_REQUEST,
-  whenInitialized as whenSharedStoreInitialized,
+  waitForInitialization as waitForSharedStoreInitialization,
 } from '@shared/services/shared-store.service';
 import { deserializeRequestType, SerializedRequestType } from '@shared/utils/util';
 import { PapiNetworkEventEmitter } from '@shared/models/papi-network-event-emitter.model';
@@ -204,10 +204,18 @@ async function doRequest<TParam extends Array<unknown>, TReturn>(
   // Ensure the shared store service is ready before this request so any custom timeout for the
   // request type is honored. Skip the gate for shared-store's own internal requests fired during
   // its initialization — they cannot wait for the service that fires them, or we'd deadlock.
-  // whenInitialized resolves immediately if shared-store init has already started; if not, it
-  // waits up to a short timeout, then falls through to the default-timeout fallback in
-  // getTimeoutMsForRequestType.
-  if (requestType !== STORE_GET_REQUEST) await whenSharedStoreInitialized();
+  // waitForSharedStoreInitialization throws if shared-store init does not start within its
+  // timeout; we catch and continue with the default timeout in that case so a missing/late
+  // shared-store init does not block all network traffic.
+  if (requestType !== STORE_GET_REQUEST) {
+    try {
+      await waitForSharedStoreInitialization();
+    } catch (e) {
+      logger.warn(
+        `Proceeding with default timeout for ${requestType} — shared store not ready: ${getErrorMessage(e)}`,
+      );
+    }
+  }
   if (!jsonRpc) throw new Error('RPC handler not set');
   const responseAsyncVariable = new AsyncVariable<JSONRPCResponse | PlatformError>(
     `response to ${requestType}`,

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -412,8 +412,9 @@ export const createNetworkEventEmitter = <T>(eventType: string): PlatformEventEm
   createNetworkEventEmitterInternal(eventType, true);
 
 /**
- * Create a network event emitter that participates in central registration. The returned emitter
- * appears in the OpenRPC document if `documentation` is provided.
+ * Create a network event emitter that participates in central registration. Every centrally
+ * registered event appears in the OpenRPC document; providing `documentation` fills in its summary,
+ * params, and `x-experimental` flag, otherwise it is surfaced with placeholder docs.
  *
  * If the event name is in {@link MultiSourceNetworkEvents}, the central registry uses multi-source
  * semantics: multiple processes may register the same name (each process registers once); all

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -135,6 +135,12 @@ function sharedStoreKeyForRequestType(
 }
 
 function getTimeoutMsForRequestType(requestType: SerializedRequestType): number {
+  // Custom timeouts live in the shared store. Reading shared store before it has finished
+  // initializing would throw (and would break its Lamport-clock sync guarantee anyway). The
+  // bootstrap window can include network requests fired by React components mounted before
+  // initializeSharedStoreService() resolves, so during that window fall back to the default
+  // timeout — a custom override is an optimization, not a correctness requirement here.
+  if (!sharedStoreService.isInitialized()) return requestTimeoutMs;
   const sharedVal = sharedStoreService.get(sharedStoreKeyForRequestType(requestType));
   return typeof sharedVal === 'number' && sharedVal >= 0 ? sharedVal : requestTimeoutMs;
 }

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -37,6 +37,20 @@ import { logger } from '@shared/services/logger.service';
 import { SingleMethodDocumentation } from '@shared/models/openrpc.model';
 import { JSONRPCResponse } from 'json-rpc-2.0';
 import { NetworkMethodHandlerOptions } from '@shared/models/network.model';
+import type { SharedNetworkEventTypes } from 'papi-shared-types';
+
+/**
+ * Source of truth for which event names use shared semantics at the central registry. Must stay in
+ * sync with the `SharedNetworkEventTypes` type alias in `papi-shared-types.ts` — the test
+ * `network.service.shared-events.test.ts` enforces the invariant.
+ *
+ * Add entries here when adding a new shared event to `SharedNetworkEventTypes`.
+ */
+export const SHARED_EVENT_NAMES = new Set<keyof SharedNetworkEventTypes>([
+  'network-object.onDidCreateNetworkObject',
+  'network-object.onDidDisposeNetworkObject',
+  'shared-store.onDidChange',
+]);
 
 // #region Local event handling
 

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -141,11 +141,14 @@ function getTimeoutMsForRequestType(requestType: SerializedRequestType): number 
   // initializing would throw (and would break its Lamport-clock sync guarantee anyway). The
   // bootstrap window can include network requests fired by React components mounted before
   // initializeSharedStoreService() resolves, so during that window fall back to the default
-  // timeout — a small bootstrapping problem that can be improved later..
+  // timeout — a small bootstrapping problem that can be improved later.
   if (!sharedStoreService.isInitialized()) {
-    logger.warn(
-      `Shared store not initialized; using default request timeout of ${requestTimeoutMs}ms for request type ${requestType}`,
-    );
+    // Suppress the warning for shared-store's own internal bootstrap request — it's expected to
+    // run before initialization completes (it's part of the initialization).
+    if (requestType !== STORE_GET_REQUEST)
+      logger.warn(
+        `Shared store not initialized; using default request timeout of ${requestTimeoutMs}ms for request type ${requestType}`,
+      );
     return requestTimeoutMs;
   }
   const sharedVal = sharedStoreService.get(sharedStoreKeyForRequestType(requestType));

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -380,7 +380,7 @@ const createNetworkEventEmitterInternal = <T>(
  * @deprecated 8 June 2026. Use `createNetworkEventEmitterAsync`. Events created via the sync API
  *   are not centrally registered and do not appear in the OpenRPC document. The async version
  *   properly restricts event registration to prevent multiple sources from emitting the same
- *   network event (unless the event is declared in `SharedNetworkEventTypes`, in which case it
+ *   network event (unless the event is declared in {@link SharedNetworkEventTypes}, in which case it
  *   accepts multiple registrants by design).
  *
  *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
@@ -395,18 +395,20 @@ export const createNetworkEventEmitter = <T>(eventType: string): PlatformEventEm
  * Create a network event emitter that participates in central registration. The returned emitter
  * appears in the OpenRPC document if `documentation` is provided.
  *
- * If the event name is in `SharedNetworkEventTypes`, the central registry uses shared semantics:
- * multiple processes may register the same name (each process registers once); all corresponding
- * emitters are valid sources.
+ * If the event name is in {@link SharedNetworkEventTypes}, the central registry uses shared
+ * semantics: multiple processes may register the same name (each process registers once); all
+ * corresponding emitters are valid sources.
  *
  * Otherwise the registry uses exclusive semantics: only one process may register a given name;
  * subsequent registrations from any process are rejected.
  *
  * Intra-process duplicate registration is always rejected regardless of the event's domain.
  *
- * @param eventType A key of `NetworkEventTypes` (which inherits `SharedNetworkEventTypes`).
- * @param documentation Optional notification documentation. Carries `'x-experimental': true` to
- *   mark the event as experimental.
+ * See {@link SharedNetworkEventTypes} for shared vs exclusive semantics.
+ *
+ * @param eventType The name of the event to register. Must be a key of {@link NetworkEventTypes}.
+ * @param documentation Optional notification documentation. Carries
+ *   `notification['x-experimental']: true` to mark the event as experimental.
  */
 export const createNetworkEventEmitterAsync = async <EventType extends keyof NetworkEventTypes>(
   eventType: EventType,
@@ -428,10 +430,11 @@ export const createNetworkEventEmitterAsync = async <EventType extends keyof Net
 };
 
 /**
- * Subscribe to a typed network event. Declare the event in `NetworkEventTypes` (or rely on
- * `SharedNetworkEventTypes` inheritance for platform events) and the payload type is inferred.
+ * Subscribe to a typed network event. The payload type is inferred from the event's declaration in
+ * {@link NetworkEventTypes}.
  *
- * @param eventType Unique network event type for coordinating between connections
+ * @param eventType The name of the event to subscribe to. Must be a key of
+ *   {@link NetworkEventTypes}.
  * @returns Event for the event type that runs the callback provided when the event is emitted
  */
 export function getNetworkEvent<EventType extends keyof NetworkEventTypes>(
@@ -440,10 +443,8 @@ export function getNetworkEvent<EventType extends keyof NetworkEventTypes>(
 /**
  * Subscribe to a network event with an explicit payload type.
  *
- * @deprecated 8 June 2026. Use the typed signature: declare the event in `NetworkEventTypes` and
- *   call `getNetworkEvent('your.event.name')` without an explicit type parameter. If your event
- *   name is dynamic (e.g., per-instance data-provider events), this signature continues to work
- *   functionally; suppress the deprecation warning at the call site with a brief comment.
+ * @deprecated 8 June 2026. Use the typed signature: declare the event in {@link NetworkEventTypes}
+ *   and call `getNetworkEvent('your.event.name')` without an explicit type parameter.
  * @param eventType Unique network event type for coordinating between connections
  * @returns Event for the event type that runs the callback provided when the event is emitted
  */
@@ -457,7 +458,6 @@ export function getNetworkEvent(eventType: string): PlatformEvent<unknown> {
 
 // Declare an interface for the object we're exporting so that JSDoc comments propagate
 export interface PapiNetworkService {
-  /** @deprecated 8 June 2026. Use createNetworkEventEmitterAsync. */
   createNetworkEventEmitter: typeof createNetworkEventEmitter;
   createNetworkEventEmitterAsync: typeof createNetworkEventEmitterAsync;
   getNetworkEvent: typeof getNetworkEvent;

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -40,16 +40,16 @@ import {
 } from '@shared/models/openrpc.model';
 import { JSONRPCResponse } from 'json-rpc-2.0';
 import { NetworkMethodHandlerOptions } from '@shared/models/network.model';
-import type { NetworkEventTypes, SharedNetworkEventTypes } from 'papi-shared-types';
+import type { MultiSourceNetworkEvents, NetworkEvents, NetworkEventTypes } from 'papi-shared-types';
 
 /**
- * Source of truth for which event names use shared semantics at the central registry. Must stay in
- * sync with the `SharedNetworkEventTypes` type alias in `papi-shared-types.ts` — the test
+ * Source of truth for which event names use multi-source semantics at the central registry. Must
+ * stay in sync with the `MultiSourceNetworkEvents` type alias in `papi-shared-types.ts` — the test
  * `network.service.shared-events.test.ts` enforces the invariant.
  *
- * Add entries here when adding a new shared event to `SharedNetworkEventTypes`.
+ * Add entries here when adding a new multi-source event to `MultiSourceNetworkEvents`.
  */
-export const SHARED_EVENT_NAMES = new Set<keyof SharedNetworkEventTypes>([
+export const MULTI_SOURCE_EVENT_NAMES = new Set<keyof MultiSourceNetworkEvents>([
   'object:onDidCreateNetworkObject',
   'object:onDidDisposeNetworkObject',
   'shared-store:change',
@@ -380,8 +380,8 @@ const createNetworkEventEmitterInternal = <T>(
  * @deprecated 8 June 2026. Use `createNetworkEventEmitterAsync`. Events created via the sync API
  *   are not centrally registered and do not appear in the OpenRPC document. The async version
  *   properly restricts event registration to prevent multiple sources from emitting the same
- *   network event (unless the event is declared in {@link SharedNetworkEventTypes}, in which case it
- *   accepts multiple registrants by design).
+ *   network event (unless the event is declared in {@link MultiSourceNetworkEvents}, in which case
+ *   it accepts multiple registrants by design).
  *
  *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
  *   emitters.
@@ -395,25 +395,25 @@ export const createNetworkEventEmitter = <T>(eventType: string): PlatformEventEm
  * Create a network event emitter that participates in central registration. The returned emitter
  * appears in the OpenRPC document if `documentation` is provided.
  *
- * If the event name is in {@link SharedNetworkEventTypes}, the central registry uses shared
+ * If the event name is in {@link MultiSourceNetworkEvents}, the central registry uses multi-source
  * semantics: multiple processes may register the same name (each process registers once); all
  * corresponding emitters are valid sources.
  *
- * Otherwise the registry uses exclusive semantics: only one process may register a given name;
+ * Otherwise the registry uses single-source semantics: only one process may register a given name;
  * subsequent registrations from any process are rejected.
  *
  * Intra-process duplicate registration is always rejected regardless of the event's domain.
  *
- * See {@link SharedNetworkEventTypes} for shared vs exclusive semantics.
+ * See {@link MultiSourceNetworkEvents} for multi-source vs single-source semantics.
  *
- * @param eventType The name of the event to register. Must be a key of {@link NetworkEventTypes}.
+ * @param eventType The name of the event to register. Must be a key of {@link NetworkEvents}.
  * @param documentation Optional notification documentation. Carries
  *   `notification['x-experimental']: true` to mark the event as experimental.
  */
-export const createNetworkEventEmitterAsync = async <EventType extends keyof NetworkEventTypes>(
+export const createNetworkEventEmitterAsync = async <EventType extends NetworkEventTypes>(
   eventType: EventType,
   documentation?: SingleNotificationDocumentation,
-): Promise<PlatformEventEmitter<NetworkEventTypes[EventType]>> => {
+): Promise<PlatformEventEmitter<NetworkEvents[EventType]>> => {
   await initialize();
   if (!jsonRpc) throw new Error('RPC handler not set');
   const accepted = await jsonRpc.registerEvent(eventType, documentation);
@@ -423,28 +423,27 @@ export const createNetworkEventEmitterAsync = async <EventType extends keyof Net
     );
   }
   // eslint-disable-next-line no-type-assertion/no-type-assertion
-  return createNetworkEventEmitterInternal<NetworkEventTypes[EventType]>(
+  return createNetworkEventEmitterInternal<NetworkEvents[EventType]>(
     eventType,
     true,
-  ) as PlatformEventEmitter<NetworkEventTypes[EventType]>;
+  ) as PlatformEventEmitter<NetworkEvents[EventType]>;
 };
 
 /**
  * Subscribe to a typed network event. The payload type is inferred from the event's declaration in
- * {@link NetworkEventTypes}.
+ * {@link NetworkEvents}.
  *
- * @param eventType The name of the event to subscribe to. Must be a key of
- *   {@link NetworkEventTypes}.
+ * @param eventType The name of the event to subscribe to. Must be a key of {@link NetworkEvents}.
  * @returns Event for the event type that runs the callback provided when the event is emitted
  */
-export function getNetworkEvent<EventType extends keyof NetworkEventTypes>(
+export function getNetworkEvent<EventType extends NetworkEventTypes>(
   eventType: EventType,
-): PlatformEvent<NetworkEventTypes[EventType]>;
+): PlatformEvent<NetworkEvents[EventType]>;
 /**
  * Subscribe to a network event with an explicit payload type.
  *
- * @deprecated 8 June 2026. Use the typed signature: declare the event in {@link NetworkEventTypes}
- *   and call `getNetworkEvent('your.event.name')` without an explicit type parameter.
+ * @deprecated 8 June 2026. Use the typed signature: declare the event in {@link NetworkEvents} and
+ *   call `getNetworkEvent('your.event.name')` without an explicit type parameter.
  * @param eventType Unique network event type for coordinating between connections
  * @returns Event for the event type that runs the callback provided when the event is emitted
  */

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -482,6 +482,140 @@ export const createNetworkEventEmitterAsync = async <EventType extends NetworkEv
 };
 
 /**
+ * How to buffer emits made before a buffered network event finishes registering.
+ *
+ * - `'queue'` — keep every buffered event and flush them in emit order.
+ * - `{ latestByKey }` — keep only the most recent buffered event per key, flushed in first-seen key
+ *   order. Use for "only the latest matters" events (e.g. a scroll reference per scroll group, or a
+ *   web view update per web view id).
+ */
+export type NetworkEventBufferStrategy<T> = 'queue' | { latestByKey: (event: T) => string };
+
+/**
+ * Buffers network events emitted before their emitter is ready, per a
+ * {@link NetworkEventBufferStrategy}. Exported only for unit testing.
+ *
+ * @internal
+ */
+export class NetworkEventBuffer<T> {
+  private readonly queued: T[] = [];
+
+  private readonly latest = new Map<string, T>();
+
+  constructor(private readonly strategy: NetworkEventBufferStrategy<T>) {}
+
+  add(event: T): void {
+    if (this.strategy === 'queue') {
+      this.queued.push(event);
+      return;
+    }
+    // `Map.set` on an existing key updates the value but keeps the original insertion position, so
+    // the latest value per key flushes in first-seen key order.
+    this.latest.set(this.strategy.latestByKey(event), event);
+  }
+
+  /** Returns the buffered events in flush order and empties the buffer. */
+  drain(): T[] {
+    if (this.strategy === 'queue') return this.queued.splice(0);
+    const events = [...this.latest.values()];
+    this.latest.clear();
+    return events;
+  }
+
+  clear(): void {
+    this.queued.length = 0;
+    this.latest.clear();
+  }
+}
+
+/**
+ * Synchronously create a buffered emitter for a single-source network event. Use this for events
+ * that may be emitted before the network emitter finishes registering — e.g. from a UI handler or a
+ * command that can fire during extension activation, where the eager
+ * {@link createNetworkEventEmitterAsync} would leave a module-level emitter `undefined`.
+ *
+ * The returned `emit` is usable immediately. Emits made before central registration completes are
+ * buffered per `options.bufferStrategy` and flushed once registration succeeds; after that `emit`
+ * passes straight through. If registration fails, buffered events are dropped (with a warning) and
+ * `registeredEmitter` rejects so the caller can respond.
+ *
+ * @param eventType A key of {@link NetworkEvents}.
+ * @param documentation Optional notification documentation. Carries
+ *   `notification['x-experimental']: true` to mark the event as experimental.
+ * @param options.bufferStrategy How to buffer pre-registration emits. Defaults to `'queue'`.
+ * @returns `emit` (usable immediately), `registeredEmitter` (resolves to the underlying emitter, or
+ *   rejects if registration failed), and `dispose`.
+ */
+export const createBufferedNetworkEventEmitter = <EventType extends NetworkEventTypes>(
+  eventType: EventType,
+  documentation?: SingleNotificationDocumentation,
+  options?: { bufferStrategy?: NetworkEventBufferStrategy<NetworkEvents[EventType]> },
+): {
+  emit: (event: NetworkEvents[EventType]) => void;
+  registeredEmitter: Promise<PlatformEventEmitter<NetworkEvents[EventType]>>;
+  dispose: () => void;
+} => {
+  const buffer = new NetworkEventBuffer<NetworkEvents[EventType]>(
+    options?.bufferStrategy ?? 'queue',
+  );
+  let readyEmitter: PlatformEventEmitter<NetworkEvents[EventType]> | undefined;
+  let failed = false;
+  let disposed = false;
+
+  const registeredEmitter = (async () => {
+    let emitter: PlatformEventEmitter<NetworkEvents[EventType]>;
+    try {
+      emitter = await createNetworkEventEmitterAsync(eventType, documentation);
+    } catch (e) {
+      failed = true;
+      buffer.clear();
+      logger.warn(
+        `Buffered network event "${eventType}" failed to register; dropping buffered events: ${getErrorMessage(e)}`,
+      );
+      throw e;
+    }
+    if (disposed) {
+      // Disposed before registration finished — tear down the emitter we just created.
+      emitter.dispose();
+      return emitter;
+    }
+    readyEmitter = emitter;
+    buffer.drain().forEach((event) => emitter.emit(event));
+    return emitter;
+  })();
+  // Consume the rejection internally so a caller that ignores `registeredEmitter` doesn't surface an
+  // unhandled rejection (the failure is already logged above). Callers that want to respond can
+  // still await/catch `registeredEmitter` independently.
+  (async () => {
+    try {
+      await registeredEmitter;
+    } catch {
+      // Already handled above.
+    }
+  })();
+
+  const emit = (event: NetworkEvents[EventType]) => {
+    if (readyEmitter) {
+      readyEmitter.emit(event);
+      return;
+    }
+    if (failed) {
+      logger.warn(`Network event "${eventType}" emit dropped — its emitter failed to register`);
+      return;
+    }
+    buffer.add(event);
+  };
+
+  const dispose = () => {
+    disposed = true;
+    buffer.clear();
+    readyEmitter?.dispose();
+  };
+
+  return { emit, registeredEmitter, dispose };
+};
+
+/**
  * Core-internal map of multi-source network events. Extends the public
  * {@link MultiSourceNetworkEvents} with platform-internal multi-source events that are intentionally
  * NOT advertised on the PAPI — the shared store change event, for example, because the shared store
@@ -593,6 +727,7 @@ export function getNetworkEvent(eventType: string): PlatformEvent<unknown> {
 export interface PapiNetworkService {
   createNetworkEventEmitter: typeof createNetworkEventEmitter;
   createNetworkEventEmitterAsync: typeof createNetworkEventEmitterAsync;
+  createBufferedNetworkEventEmitter: typeof createBufferedNetworkEventEmitter;
   getNetworkEvent: typeof getNetworkEvent;
 }
 
@@ -604,5 +739,6 @@ export interface PapiNetworkService {
 export const papiNetworkService: PapiNetworkService = {
   createNetworkEventEmitter,
   createNetworkEventEmitterAsync,
+  createBufferedNetworkEventEmitter,
   getNetworkEvent,
 };

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -25,15 +25,11 @@ import {
   stringLength,
   UnsubscriberAsync,
 } from 'platform-bible-utils';
-// Shared-store imports network.service dynamically inside its own initialize() to break what would
-// otherwise be a static cycle. The runtime cycle is safe because the dynamic import resolves after
-// both modules have loaded their declarations.
-// eslint-disable-next-line import/no-cycle
 import {
-  initialize as initializeSharedStoreService,
   RequestTimeoutSharedStoreKey,
   sharedStoreService,
   STORE_GET_REQUEST,
+  whenInitialized as whenSharedStoreInitialized,
 } from '@shared/services/shared-store.service';
 import { deserializeRequestType, SerializedRequestType } from '@shared/utils/util';
 import { PapiNetworkEventEmitter } from '@shared/models/papi-network-event-emitter.model';
@@ -205,11 +201,13 @@ async function doRequest<TParam extends Array<unknown>, TReturn>(
 ): Promise<TReturn> {
   validateRequestTypeFormatting(requestType);
   await initialize();
-  // Ensure the shared store service is initialized before this request so any custom timeout for
-  // the request type is honored. Skip the gate for shared-store's own internal requests fired
-  // during its initialization — they cannot wait for the service that fires them, or we'd
-  // deadlock. The initialize call is idempotent and safe to invoke from anywhere.
-  if (requestType !== STORE_GET_REQUEST) await initializeSharedStoreService();
+  // Ensure the shared store service is ready before this request so any custom timeout for the
+  // request type is honored. Skip the gate for shared-store's own internal requests fired during
+  // its initialization — they cannot wait for the service that fires them, or we'd deadlock.
+  // whenInitialized resolves immediately if shared-store init has already started; if not, it
+  // waits up to a short timeout, then falls through to the default-timeout fallback in
+  // getTimeoutMsForRequestType.
+  if (requestType !== STORE_GET_REQUEST) await whenSharedStoreInitialized();
   if (!jsonRpc) throw new Error('RPC handler not set');
   const responseAsyncVariable = new AsyncVariable<JSONRPCResponse | PlatformError>(
     `response to ${requestType}`,

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -40,20 +40,9 @@ import {
 } from '@shared/models/openrpc.model';
 import { JSONRPCResponse } from 'json-rpc-2.0';
 import { NetworkMethodHandlerOptions } from '@shared/models/network.model';
-import type { MultiSourceNetworkEvents, NetworkEvents, NetworkEventTypes } from 'papi-shared-types';
+import type { NetworkEvents, NetworkEventTypes } from 'papi-shared-types';
 
-/**
- * Source of truth for which event names use multi-source semantics at the central registry. Must
- * stay in sync with the `MultiSourceNetworkEvents` type alias in `papi-shared-types.ts` — the test
- * `network.service.shared-events.test.ts` enforces the invariant.
- *
- * Add entries here when adding a new multi-source event to `MultiSourceNetworkEvents`.
- */
-export const MULTI_SOURCE_EVENT_NAMES = new Set<keyof MultiSourceNetworkEvents>([
-  'object:onDidCreateNetworkObject',
-  'object:onDidDisposeNetworkObject',
-  'shared-store:change',
-]);
+export { MULTI_SOURCE_EVENT_NAMES } from '@shared/data/network-event-names';
 
 // #region Local event handling
 
@@ -422,11 +411,7 @@ export const createNetworkEventEmitterAsync = async <EventType extends NetworkEv
       `Event "${eventType}" was rejected by the central registry (likely already registered from another process).`,
     );
   }
-  // eslint-disable-next-line no-type-assertion/no-type-assertion
-  return createNetworkEventEmitterInternal<NetworkEvents[EventType]>(
-    eventType,
-    true,
-  ) as PlatformEventEmitter<NetworkEvents[EventType]>;
+  return createNetworkEventEmitterInternal<NetworkEvents[EventType]>(eventType, true);
 };
 
 /**
@@ -449,8 +434,7 @@ export function getNetworkEvent<EventType extends NetworkEventTypes>(
  */
 export function getNetworkEvent<T>(eventType: string): PlatformEvent<T>;
 export function getNetworkEvent(eventType: string): PlatformEvent<unknown> {
-  // eslint-disable-next-line no-type-assertion/no-type-assertion
-  return createNetworkEventEmitterInternal(eventType, false).event as PlatformEvent<unknown>;
+  return createNetworkEventEmitterInternal(eventType, false).event;
 }
 
 // #endregion

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -34,10 +34,13 @@ import { PapiNetworkEventEmitter } from '@shared/models/papi-network-event-emitt
 import { IRpcMethodRegistrar } from '@shared/models/rpc.interface';
 import { createRpcHandler } from '@shared/services/rpc-handler.factory';
 import { logger } from '@shared/services/logger.service';
-import { SingleMethodDocumentation } from '@shared/models/openrpc.model';
+import {
+  SingleMethodDocumentation,
+  SingleNotificationDocumentation,
+} from '@shared/models/openrpc.model';
 import { JSONRPCResponse } from 'json-rpc-2.0';
 import { NetworkMethodHandlerOptions } from '@shared/models/network.model';
-import type { SharedNetworkEventTypes } from 'papi-shared-types';
+import type { NetworkEventTypes, SharedNetworkEventTypes } from 'papi-shared-types';
 
 /**
  * Source of truth for which event names use shared semantics at the central registry. Must stay in
@@ -372,17 +375,57 @@ const createNetworkEventEmitterInternal = <T>(
 };
 
 /**
- * Creates an event emitter that works properly over the network. Other connections receive this
- * event when it is emitted.
+ * Creates an event emitter that works properly over the network.
  *
- * WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
- * emitters.
+ * @deprecated 8 June 2026. Use `createNetworkEventEmitterAsync`. Events created via the sync API
+ *   are not centrally registered and do not appear in the OpenRPC document. The async version
+ *   properly restricts event registration to prevent multiple sources from emitting the same
+ *   network event (unless the event is declared in `SharedNetworkEventTypes`, in which case it
+ *   accepts multiple registrants by design).
  *
+ *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
+ *   emitters.
  * @param eventType Unique network event type for coordinating between connections
  * @returns Event emitter whose event works between connections
  */
 export const createNetworkEventEmitter = <T>(eventType: string): PlatformEventEmitter<T> =>
   createNetworkEventEmitterInternal(eventType, true);
+
+/**
+ * Create a network event emitter that participates in central registration. The returned emitter
+ * appears in the OpenRPC document if `documentation` is provided.
+ *
+ * If the event name is in `SharedNetworkEventTypes`, the central registry uses shared semantics:
+ * multiple processes may register the same name (each process registers once); all corresponding
+ * emitters are valid sources.
+ *
+ * Otherwise the registry uses exclusive semantics: only one process may register a given name;
+ * subsequent registrations from any process are rejected.
+ *
+ * Intra-process duplicate registration is always rejected regardless of the event's domain.
+ *
+ * @param eventType A key of `NetworkEventTypes` (which inherits `SharedNetworkEventTypes`).
+ * @param documentation Optional notification documentation. Carries `'x-experimental': true` to
+ *   mark the event as experimental.
+ */
+export const createNetworkEventEmitterAsync = async <EventType extends keyof NetworkEventTypes>(
+  eventType: EventType,
+  documentation?: SingleNotificationDocumentation,
+): Promise<PlatformEventEmitter<NetworkEventTypes[EventType]>> => {
+  await initialize();
+  if (!jsonRpc) throw new Error('RPC handler not set');
+  const accepted = await jsonRpc.registerEvent(eventType, documentation);
+  if (!accepted) {
+    throw new Error(
+      `Event "${eventType}" was rejected by the central registry (likely already registered from another process).`,
+    );
+  }
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  return createNetworkEventEmitterInternal<NetworkEventTypes[EventType]>(
+    eventType,
+    true,
+  ) as PlatformEventEmitter<NetworkEventTypes[EventType]>;
+};
 
 /**
  * Gets the network event with the specified type. Creates the emitter if it does not exist
@@ -400,7 +443,9 @@ export const getNetworkEvent = <T>(eventType: string): PlatformEvent<T> => {
 
 // Declare an interface for the object we're exporting so that JSDoc comments propagate
 export interface PapiNetworkService {
+  /** @deprecated 8 June 2026. Use createNetworkEventEmitterAsync. */
   createNetworkEventEmitter: typeof createNetworkEventEmitter;
+  createNetworkEventEmitterAsync: typeof createNetworkEventEmitterAsync;
   getNetworkEvent: typeof getNetworkEvent;
 }
 
@@ -411,5 +456,6 @@ export interface PapiNetworkService {
  */
 export const papiNetworkService: PapiNetworkService = {
   createNetworkEventEmitter,
+  createNetworkEventEmitterAsync,
   getNetworkEvent,
 };

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -462,11 +462,6 @@ export const createNetworkEventEmitter = <T>(eventType: string): PlatformEventEm
  *
  * See {@link MultiSourceNetworkEvents} for multi-source vs single-source semantics.
  *
- * An event name must also not collide with a registered method name: both appear in the OpenRPC
- * document's `methods` array, where names must be unique, so the registry rejects an event whose
- * name is already a method (and vice versa). By convention events are `on*`-prefixed and methods
- * are not, so this should not happen in practice.
- *
  * @param eventType The name of the event to register. Must be a key of {@link NetworkEvents}.
  * @param documentation Optional notification documentation. Carries
  *   `notification['x-experimental']: true` to mark the event as experimental.

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -429,9 +429,11 @@ const createNetworkEventEmitterInternal = <T>(
  *
  * @deprecated 8 June 2026. Use `createNetworkEventEmitterAsync`. Events created via the sync API
  *   are not centrally registered and do not appear in the OpenRPC document. The async version
- *   properly restricts event registration to prevent multiple sources from emitting the same
- *   network event (unless the event is declared in {@link MultiSourceNetworkEvents}, in which case
- *   it accepts multiple registrants by design).
+ *   restricts central _registration_ of an event name to a single source (unless the event is
+ *   declared in {@link MultiSourceNetworkEvents}, in which case it accepts multiple registrants by
+ *   design). Note this restricts registration only — emission itself is not gated by the registry;
+ *   the central registry instead warns when an event is announced unregistered or from a process
+ *   that did not register it.
  *
  *   WARNING: You can only create a network event emitter once per eventType to prevent hijacked event
  *   emitters.

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -462,6 +462,11 @@ export const createNetworkEventEmitter = <T>(eventType: string): PlatformEventEm
  *
  * See {@link MultiSourceNetworkEvents} for multi-source vs single-source semantics.
  *
+ * An event name must also not collide with a registered method name: both appear in the OpenRPC
+ * document's `methods` array, where names must be unique, so the registry rejects an event whose
+ * name is already a method (and vice versa). By convention events are `on*`-prefixed and methods
+ * are not, so this should not happen in practice.
+ *
  * @param eventType The name of the event to register. Must be a key of {@link NetworkEvents}.
  * @param documentation Optional notification documentation. Carries
  *   `notification['x-experimental']: true` to mark the event as experimental.

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -163,10 +163,24 @@ function getTimeoutMsForRequestType(requestType: SerializedRequestType): number 
 function setTimeoutMsForRequestType(requestType: SerializedRequestType, timeoutMs: number) {
   if (timeoutMs < 0)
     throw new Error(`Invalid request timeout ${timeoutMs}: must be a non-negative number`);
+  // The sync `set` throws if the shared store has not initialized. This runs from
+  // registerRequestHandler *after* the method has already been registered with the RPC handler, so a
+  // throw here would leak that registration. Custom timeouts are non-critical (the default applies
+  // when one is absent), so when the store isn't ready yet we debug-log and skip rather than throw.
+  if (!sharedStoreService.isInitialized()) {
+    logger.debug(
+      `Custom timeout for request type ${requestType} set before the shared store finished initializing; using default ${requestTimeoutMs}ms instead`,
+    );
+    return;
+  }
   sharedStoreService.set(sharedStoreKeyForRequestType(requestType), timeoutMs);
 }
 
 function removeTimeoutMsForRequestType(requestType: SerializedRequestType) {
+  // Mirror setTimeoutMsForRequestType: skip (rather than throw) if the shared store isn't ready, so
+  // the unsubscriber returned by registerRequestHandler can't throw mid-teardown. If the store never
+  // initialized then no custom timeout was ever stored, so there is nothing to remove.
+  if (!sharedStoreService.isInitialized()) return;
   sharedStoreService.remove(sharedStoreKeyForRequestType(requestType));
 }
 

--- a/src/shared/services/papi-core.service.ts
+++ b/src/shared/services/papi-core.service.ts
@@ -57,6 +57,7 @@ export type {
   MethodDocumentationWithoutName,
   NetworkObjectDocumentation,
   SingleMethodDocumentation,
+  SingleNotificationDocumentation,
 } from '@shared/models/openrpc.model';
 export type {
   ExtensionDataScope,
@@ -87,6 +88,11 @@ export type {
   IDisposableWebViewProvider,
   IWebViewProvider,
 } from '@shared/models/web-view-provider.model';
+export type {
+  CloseWebViewEvent,
+  OpenWebViewEvent,
+  UpdateWebViewEvent,
+} from '@shared/services/web-view.service-model';
 export type { AppInfo } from '@shared/services/app.service-model';
 export type {
   NamedSqlParameters,
@@ -102,8 +108,12 @@ export type {
   SimultaneousProjectSettingsChanges,
   ProjectSettingValidator,
 } from '@shared/services/project-settings.service-model';
-export type { ScrollGroupScrRef } from '@shared/services/scroll-group.service-model';
+export type {
+  ScrollGroupScrRef,
+  ScrollGroupUpdateInfo,
+} from '@shared/services/scroll-group.service-model';
 export type { SettingValidator } from '@shared/services/settings.service-model';
+export type { StoreChangeEvent } from '@shared/services/shared-store.service';
 export type {
   FocusSubject,
   SetFocusSubject,

--- a/src/shared/services/papi-core.service.ts
+++ b/src/shared/services/papi-core.service.ts
@@ -113,7 +113,6 @@ export type {
   ScrollGroupUpdateInfo,
 } from '@shared/services/scroll-group.service-model';
 export type { SettingValidator } from '@shared/services/settings.service-model';
-export type { StoreChangeEvent } from '@shared/services/shared-store.service';
 export type {
   FocusSubject,
   SetFocusSubject,

--- a/src/shared/services/papi-core.service.ts
+++ b/src/shared/services/papi-core.service.ts
@@ -64,7 +64,10 @@ export type {
   MandatoryProjectDataTypes,
 } from '@shared/models/project-data-provider.model';
 export type { IProjectDataProviderEngine } from '@shared/models/project-data-provider-engine.model';
-export type { IProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model.ts';
+export type {
+  IProjectDataProviderEngineFactory,
+  ProjectDataProviderEngineEnvelope,
+} from '@shared/models/project-data-provider-engine-factory.model.ts';
 export type {
   IProjectDataProviderFactory,
   ProjectMetadataFilterOptions,

--- a/src/shared/services/project-data-provider.service.ts
+++ b/src/shared/services/project-data-provider.service.ts
@@ -141,11 +141,13 @@ class ProjectDataProviderFactory<SupportedProjectInterfaces extends ProjectInter
  *
  * @param pdpFactoryId Unique id for this PDP factory.
  * @param projectInterfaces The standardized sets of methods (`projectInterface`s) supported by the
- *   Project Data Provider Engines produced by this factory.
+ *   Project Data Provider Engines produced by this factory. Indicates what sort of project data
+ *   should be available on the PDPEs created by this factory.
  * @param pdpEngineFactory Used in a ProjectDataProviderFactory to create ProjectDataProviders.
  * @param attributes Optional registration-level attributes. The platform overwrites the
  *   `projectInterfaces` field — that field is always the platform-canonical value.
- * @param documentation Optional `NetworkObjectDocumentation` for the factory itself.
+ * @param documentation Optional {@link NetworkObjectDocumentation} for the factory itself. Set
+ *   `documentation['x-experimental']: true` to mark all methods on this factory as experimental.
  * @returns Promise that resolves to a disposable object when the registration operation completes.
  */
 export async function registerProjectDataProviderEngineFactory<

--- a/src/shared/services/project-data-provider.service.ts
+++ b/src/shared/services/project-data-provider.service.ts
@@ -22,7 +22,10 @@ import { projectLookupService } from '@shared/services/project-lookup.service';
 import { ProjectMetadataWithoutFactoryInfo } from '@shared/models/project-metadata.model';
 import { PROJECT_INTERFACE_PLATFORM_BASE } from '@shared/models/project-data-provider.model';
 import { getPDPFactoryNetworkObjectNameFromId } from '@shared/models/project-lookup.service-model';
-import { IProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model';
+import {
+  IProjectDataProviderEngineFactory,
+  isProjectDataProviderEngineEnvelope,
+} from '@shared/models/project-data-provider-engine-factory.model';
 import type { NetworkObjectDocumentation } from '@shared/models/openrpc.model';
 
 /**
@@ -79,12 +82,7 @@ class ProjectDataProviderFactory<SupportedProjectInterfaces extends ProjectInter
       if (!pdpId) {
         const factoryReturn =
           await this.pdpEngineFactory.createProjectDataProviderEngine(projectId);
-        // `!!factoryReturn` guards against `typeof null === 'object'`, which would otherwise throw
-        // `Cannot use 'in' operator` for a factory that returns null.
-        const isEnvelope =
-          !!factoryReturn &&
-          typeof factoryReturn === 'object' &&
-          'projectDataProviderEngine' in factoryReturn;
+        const isEnvelope = isProjectDataProviderEngineEnvelope(factoryReturn);
         const projectDataProviderEngine = isEnvelope
           ? factoryReturn.projectDataProviderEngine
           : factoryReturn;

--- a/src/shared/services/project-data-provider.service.ts
+++ b/src/shared/services/project-data-provider.service.ts
@@ -23,6 +23,7 @@ import { ProjectMetadataWithoutFactoryInfo } from '@shared/models/project-metada
 import { PROJECT_INTERFACE_PLATFORM_BASE } from '@shared/models/project-data-provider.model';
 import { getPDPFactoryNetworkObjectNameFromId } from '@shared/models/project-lookup.service-model';
 import { IProjectDataProviderEngineFactory } from '@shared/models/project-data-provider-engine-factory.model';
+import type { NetworkObjectDocumentation } from '@shared/models/openrpc.model';
 
 /**
  * Class that creates Project Data Providers of a specific set of `projectInterface`s. Layers over
@@ -76,9 +77,23 @@ class ProjectDataProviderFactory<SupportedProjectInterfaces extends ProjectInter
     return lock.runExclusive(async () => {
       let pdpId = this.pdpIds.get(key);
       if (!pdpId) {
+        const factoryReturn =
+          await this.pdpEngineFactory.createProjectDataProviderEngine(projectId);
+        const isEnvelope =
+          typeof factoryReturn === 'object' &&
+          factoryReturn !== null &&
+          'projectDataProviderEngine' in factoryReturn;
+        const projectDataProviderEngine = isEnvelope
+          ? factoryReturn.projectDataProviderEngine
+          : factoryReturn;
+        const perPdpAttributes = isEnvelope ? factoryReturn.attributes : undefined;
+        const perPdpDocumentation = isEnvelope ? factoryReturn.documentation : undefined;
+
         pdpId = await this.#registerProjectDataProvider(
-          await this.pdpEngineFactory.createProjectDataProviderEngine(projectId),
+          projectDataProviderEngine,
           projectId,
+          perPdpAttributes,
+          perPdpDocumentation,
         );
         if (!pdpId) throw new Error(`Could not register project data provider for ${projectId}`);
         this.pdpIds.set(key, pdpId);
@@ -91,6 +106,8 @@ class ProjectDataProviderFactory<SupportedProjectInterfaces extends ProjectInter
   async #registerProjectDataProvider(
     projectDataProviderEngine: IProjectDataProviderEngine<SupportedProjectInterfaces>,
     projectId: string,
+    perPdpAttributes?: { [property: string]: unknown },
+    perPdpDocumentation?: NetworkObjectDocumentation,
   ): Promise<string> {
     // Check to make sure new Base PDPs fulfill the requirements of the `platform.base` `projectInterface`
     if (
@@ -105,12 +122,15 @@ class ProjectDataProviderFactory<SupportedProjectInterfaces extends ProjectInter
     // fulfills `platform.base`
 
     const pdpId: string = `${newNonce()}-pdp`;
-    const pdp = await registerEngineByType<
-      UnionToIntersection<ProjectInterfaceDataTypes[SupportedProjectInterfaces[number]]> & {}
-    >(pdpId, projectDataProviderEngine, 'pdp', {
+    // Per-PDP attributes spread first; platform-canonical fields (projectId, projectInterfaces) win.
+    const mergedAttributes = {
+      ...perPdpAttributes,
       projectId,
       projectInterfaces: this.projectInterfaces,
-    });
+    };
+    const pdp = await registerEngineByType<
+      UnionToIntersection<ProjectInterfaceDataTypes[SupportedProjectInterfaces[number]]> & {}
+    >(pdpId, projectDataProviderEngine, 'pdp', mergedAttributes, perPdpDocumentation);
     this.pdpCleanupList.add(pdp);
     return pdpId;
   }
@@ -119,12 +139,14 @@ class ProjectDataProviderFactory<SupportedProjectInterfaces extends ProjectInter
 /**
  * Add a new Project Data Provider Factory to PAPI that uses the given engine.
  *
- * @param pdpFactoryId Unique id for this PDP factory
+ * @param pdpFactoryId Unique id for this PDP factory.
  * @param projectInterfaces The standardized sets of methods (`projectInterface`s) supported by the
- *   Project Data Provider Engines produced by this factory. Indicates what sort of project data
- *   should be available on the PDPEs created by this factory.
- * @param pdpEngineFactory Used in a ProjectDataProviderFactory to create ProjectDataProviders
- * @returns Promise that resolves to a disposable object when the registration operation completes
+ *   Project Data Provider Engines produced by this factory.
+ * @param pdpEngineFactory Used in a ProjectDataProviderFactory to create ProjectDataProviders.
+ * @param attributes Optional registration-level attributes. The platform overwrites the
+ *   `projectInterfaces` field — that field is always the platform-canonical value.
+ * @param documentation Optional `NetworkObjectDocumentation` for the factory itself.
+ * @returns Promise that resolves to a disposable object when the registration operation completes.
  */
 export async function registerProjectDataProviderEngineFactory<
   SupportedProjectInterfaces extends ProjectInterfaces[],
@@ -132,14 +154,19 @@ export async function registerProjectDataProviderEngineFactory<
   pdpFactoryId: string,
   projectInterfaces: SupportedProjectInterfaces,
   pdpEngineFactory: IProjectDataProviderEngineFactory<SupportedProjectInterfaces>,
+  attributes?: { [property: string]: unknown },
+  documentation?: NetworkObjectDocumentation,
 ): Promise<Dispose> {
   const factoryNetworkObjectId = getPDPFactoryNetworkObjectNameFromId(pdpFactoryId);
   const factory = new ProjectDataProviderFactory(pdpFactoryId, projectInterfaces, pdpEngineFactory);
+  // Spread caller attributes first, then overlay canonical projectInterfaces (platform always wins).
+  const mergedAttributes = { ...attributes, projectInterfaces };
   return networkObjectService.set<ProjectDataProviderFactory<SupportedProjectInterfaces>>(
     factoryNetworkObjectId,
     factory,
     PDP_FACTORY_OBJECT_TYPE,
-    { projectInterfaces },
+    mergedAttributes,
+    documentation,
   );
 }
 

--- a/src/shared/services/project-data-provider.service.ts
+++ b/src/shared/services/project-data-provider.service.ts
@@ -80,9 +80,7 @@ class ProjectDataProviderFactory<SupportedProjectInterfaces extends ProjectInter
         const factoryReturn =
           await this.pdpEngineFactory.createProjectDataProviderEngine(projectId);
         const isEnvelope =
-          typeof factoryReturn === 'object' &&
-          factoryReturn !== null &&
-          'projectDataProviderEngine' in factoryReturn;
+          typeof factoryReturn === 'object' && 'projectDataProviderEngine' in factoryReturn;
         const projectDataProviderEngine = isEnvelope
           ? factoryReturn.projectDataProviderEngine
           : factoryReturn;

--- a/src/shared/services/project-data-provider.service.ts
+++ b/src/shared/services/project-data-provider.service.ts
@@ -79,8 +79,12 @@ class ProjectDataProviderFactory<SupportedProjectInterfaces extends ProjectInter
       if (!pdpId) {
         const factoryReturn =
           await this.pdpEngineFactory.createProjectDataProviderEngine(projectId);
+        // `!!factoryReturn` guards against `typeof null === 'object'`, which would otherwise throw
+        // `Cannot use 'in' operator` for a factory that returns null.
         const isEnvelope =
-          typeof factoryReturn === 'object' && 'projectDataProviderEngine' in factoryReturn;
+          !!factoryReturn &&
+          typeof factoryReturn === 'object' &&
+          'projectDataProviderEngine' in factoryReturn;
         const projectDataProviderEngine = isEnvelope
           ? factoryReturn.projectDataProviderEngine
           : factoryReturn;

--- a/src/shared/services/scroll-group.service-model.ts
+++ b/src/shared/services/scroll-group.service-model.ts
@@ -8,6 +8,9 @@ export const NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE = 'ScrollGroupService';
 const CATEGORY_SCROLL_GROUP = 'scrollGroup';
 
 /** Name to use when creating a network event that is fired when webViews are updated */
+// serializeRequestType returns SerializedRequestType (an opaque branded string), but we know the
+// actual value matches this NetworkEvents key. Cast to the literal so consumers can use this
+// constant directly without re-casting at every usage site.
 // eslint-disable-next-line no-type-assertion/no-type-assertion
 export const EVENT_NAME_ON_DID_UPDATE_SCR_REF = serializeRequestType(
   CATEGORY_SCROLL_GROUP,

--- a/src/shared/services/scroll-group.service-model.ts
+++ b/src/shared/services/scroll-group.service-model.ts
@@ -8,10 +8,11 @@ export const NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE = 'ScrollGroupService';
 const CATEGORY_SCROLL_GROUP = 'scrollGroup';
 
 /** Name to use when creating a network event that is fired when webViews are updated */
+// eslint-disable-next-line no-type-assertion/no-type-assertion
 export const EVENT_NAME_ON_DID_UPDATE_SCR_REF = serializeRequestType(
   CATEGORY_SCROLL_GROUP,
   'onDidUpdateScrRef',
-);
+) as 'scrollGroup:onDidUpdateScrRef';
 
 /**
  * Combination of a {@link ScrollGroupId} and a SerializedVerseRef. If this value is a number, that

--- a/src/shared/services/scroll-group.service.ts
+++ b/src/shared/services/scroll-group.service.ts
@@ -3,13 +3,12 @@ import {
   EVENT_NAME_ON_DID_UPDATE_SCR_REF,
   NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE,
   IScrollGroupService,
-  ScrollGroupUpdateInfo,
 } from '@shared/services/scroll-group.service-model';
 import { createSyncProxyForAsyncObject } from 'platform-bible-utils';
 import { networkObjectStatusService } from '@shared/services/network-object-status.service';
 import { networkObjectService } from '@shared/services/network-object.service';
 
-const onDidUpdateScrRef = getNetworkEvent<ScrollGroupUpdateInfo>(EVENT_NAME_ON_DID_UPDATE_SCR_REF);
+const onDidUpdateScrRef = getNetworkEvent(EVENT_NAME_ON_DID_UPDATE_SCR_REF);
 
 let networkObject: IScrollGroupService;
 let initializationPromise: Promise<void>;

--- a/src/shared/services/shared-store.service.test.ts
+++ b/src/shared/services/shared-store.service.test.ts
@@ -13,6 +13,7 @@ import {
 vi.mock('@shared/services/network.service', () => ({
   createNetworkEventEmitter: vi.fn(),
   createNetworkEventEmitterAsync: vi.fn(),
+  createCoreMultiSourceEventEmitter: vi.fn(),
   getNetworkEvent: vi.fn(),
   request: vi.fn(),
   registerRequestHandler: vi.fn(),
@@ -38,9 +39,6 @@ describe('sharedStoreService', () => {
     emitLocal: vi.fn(),
   };
 
-  // Mock network event handler function
-  const mockEventHandler = vi.fn();
-
   // Save original globalThis.processType
   const originalProcessType = globalThis.processType;
 
@@ -63,9 +61,18 @@ describe('sharedStoreService', () => {
         ReturnType<typeof networkService.createNetworkEventEmitterAsync>
       >,
     );
-
-    // Mock event handler subscription
-    vi.mocked(networkService.getNetworkEvent).mockReturnValue(mockEventHandler);
+    // Multi-source events (like 'shared-store:change') use the synchronous
+    // createCoreMultiSourceEventEmitter, which returns the emitter and a registration promise that
+    // resolves to that same emitter. The shared store subscribes to changes via the emitter's
+    // `event`, so no getNetworkEvent mock is needed.
+    vi.mocked(networkService.createCoreMultiSourceEventEmitter).mockReturnValue(
+      // Needed for testing
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      {
+        emitter: mockEmitter,
+        registeredEmitterPromise: Promise.resolve(mockEmitter),
+      } as unknown as ReturnType<typeof networkService.createCoreMultiSourceEventEmitter>,
+    );
 
     // Set process type to Main by default
     globalThis.processType = ProcessType.Main;
@@ -81,12 +88,12 @@ describe('sharedStoreService', () => {
   describe('initialize', () => {
     it('should initialize the service with a unique process ID', async () => {
       await initializeSharedStore(networkService);
-      expect(networkService.createNetworkEventEmitterAsync).toHaveBeenCalledWith(
+      expect(networkService.createCoreMultiSourceEventEmitter).toHaveBeenCalledWith(
         'shared-store:change',
         expect.objectContaining({ notification: expect.any(Object) }),
       );
-      expect(networkService.getNetworkEvent).toHaveBeenCalledWith('shared-store:change');
-      expect(mockEventHandler).toHaveBeenCalled();
+      // The store subscribes to remote changes via the emitter's `event`.
+      expect(mockEmitter.event).toHaveBeenCalled();
     });
 
     it('should register a request handler for store access in the Main process', async () => {
@@ -118,10 +125,10 @@ describe('sharedStoreService', () => {
       expect(second).toBe(first);
       await first;
       // After resolution, further calls still no-op (no second registration of handlers/emitters)
-      const createEmitterCallCount = vi.mocked(networkService.createNetworkEventEmitterAsync).mock
-        .calls.length;
+      const createEmitterCallCount = vi.mocked(networkService.createCoreMultiSourceEventEmitter)
+        .mock.calls.length;
       await initializeSharedStore(networkService);
-      expect(vi.mocked(networkService.createNetworkEventEmitterAsync).mock.calls.length).toBe(
+      expect(vi.mocked(networkService.createCoreMultiSourceEventEmitter).mock.calls.length).toBe(
         createEmitterCallCount,
       );
     });
@@ -184,7 +191,7 @@ describe('sharedStoreService', () => {
       const newValue = 6000;
 
       // Simulate receiving a remote change
-      const changeEventHandler = vi.mocked(mockEventHandler).mock.calls[0][0];
+      const changeEventHandler = vi.mocked(mockEmitter.event).mock.calls[0][0];
       changeEventHandler({
         key: testKey,
         value: testValue,
@@ -198,7 +205,7 @@ describe('sharedStoreService', () => {
       expect(sharedStoreService.get(testKey)).toBe(testValue);
     });
 
-    it('should remove a value by setting it to undefined', () => {
+    it('should remove a value, emitting a deleted change event', () => {
       const testValue = 5000;
       sharedStoreService.set(testKey, testValue);
 
@@ -210,6 +217,7 @@ describe('sharedStoreService', () => {
       expect(mockEmitter.emit).toHaveBeenCalledWith({
         key: testKey,
         value: undefined,
+        deleted: true,
         clock: expect.objectContaining({
           counter: expect.any(Number),
           processId: expect.any(String),
@@ -221,13 +229,89 @@ describe('sharedStoreService', () => {
       expect(valueAfterRemove).toBeUndefined();
     });
 
-    it('should throw if trying to use the service before initialization', async () => {
+    it('get returns undefined before initialization; set/remove throw', async () => {
       resetForTesting();
       const error = 'Shared store service is not initialized';
 
-      expect(() => sharedStoreService.get(testKey)).toThrow(error);
+      // get no longer throws before init — it returns undefined until the store is populated.
+      expect(sharedStoreService.get(testKey)).toBeUndefined();
+      // set/remove still require the service to be initialized so they can broadcast the change.
       expect(() => sharedStoreService.set(testKey, 5000)).toThrow(error);
       expect(() => sharedStoreService.remove(testKey)).toThrow(error);
+    });
+  });
+
+  describe('async get/set/remove operations', () => {
+    beforeEach(async () => {
+      await initializeSharedStore(networkService);
+    });
+
+    it('getAsync resolves to a stored value', async () => {
+      sharedStoreService.set(testKey, 5000);
+      await expect(sharedStoreService.getAsync(testKey)).resolves.toBe(5000);
+    });
+
+    it('getAsync throws when the key is absent and no default is provided', async () => {
+      await expect(sharedStoreService.getAsync(testKey)).rejects.toThrow(
+        /no default value was provided/,
+      );
+    });
+
+    it('getAsync returns the provided default when the key is absent', async () => {
+      await expect(sharedStoreService.getAsync(testKey, 1234)).resolves.toBe(1234);
+    });
+
+    it('getAsync returns an explicit undefined default when the key is absent', async () => {
+      await expect(sharedStoreService.getAsync(testKey, undefined)).resolves.toBeUndefined();
+    });
+
+    it('getAsync returns a present value that is explicitly undefined', async () => {
+      // `undefined` is a valid live value (distinct from removed); getAsync returns it without
+      // applying a default or throwing.
+      sharedStoreService.set(testKey, undefined);
+      await expect(sharedStoreService.getAsync(testKey)).resolves.toBeUndefined();
+    });
+
+    it('getAsync throws after a key is removed (removed means no value)', async () => {
+      sharedStoreService.set(testKey, 5000);
+      sharedStoreService.remove(testKey);
+      await expect(sharedStoreService.getAsync(testKey)).rejects.toThrow(
+        /no default value was provided/,
+      );
+    });
+
+    it('getAsync returns the default after a key is removed', async () => {
+      sharedStoreService.set(testKey, 5000);
+      sharedStoreService.remove(testKey);
+      await expect(sharedStoreService.getAsync(testKey, 99)).resolves.toBe(99);
+    });
+
+    it('getAsync rejects (rather than returning undefined) when the stored value cannot be cloned', async () => {
+      // Inject a value that cannot be serialized (a circular reference) via a simulated remote
+      // change. setFromRemote stores the raw entry without cloning, so the unserializable value
+      // reaches the store; cloning it on read then throws, which getAsync must surface rather than
+      // swallow as `undefined`.
+      const circular: { self?: unknown } = {};
+      circular.self = circular;
+      const changeEventHandler = vi.mocked(mockEmitter.event).mock.calls[0][0];
+      changeEventHandler({
+        key: testKey,
+        value: circular,
+        clock: { counter: 1, processId: 'other-process' },
+      });
+      await expect(sharedStoreService.getAsync(testKey)).rejects.toThrow();
+    });
+
+    it('setAsync waits for initialization, then sets and emits the change', async () => {
+      await sharedStoreService.setAsync(testKey, 5000);
+      expect(sharedStoreService.get(testKey)).toBe(5000);
+      expect(mockEmitter.emit).toHaveBeenCalled();
+    });
+
+    it('removeAsync waits for initialization, then removes the value', async () => {
+      sharedStoreService.set(testKey, 5000);
+      await sharedStoreService.removeAsync(testKey);
+      expect(sharedStoreService.get(testKey)).toBeUndefined();
     });
   });
 
@@ -243,7 +327,7 @@ describe('sharedStoreService', () => {
       sharedStoreService.set(testKey, initialValue);
 
       // Simulate receiving a remote change with higher counter
-      const changeEventHandler = vi.mocked(mockEventHandler).mock.calls[0][0];
+      const changeEventHandler = vi.mocked(mockEmitter.event).mock.calls[0][0];
       changeEventHandler({
         key: testKey,
         value: newValue,
@@ -267,7 +351,7 @@ describe('sharedStoreService', () => {
       sharedStoreService.set(testKey, initialValue + 1);
 
       // Simulate receiving a remote change with lower counter
-      const changeEventHandler = vi.mocked(mockEventHandler).mock.calls[0][0];
+      const changeEventHandler = vi.mocked(mockEmitter.event).mock.calls[0][0];
       changeEventHandler({
         key: testKey,
         value: newValue,
@@ -292,7 +376,7 @@ describe('sharedStoreService', () => {
       const currentCounter = vi.mocked(mockEmitter.emit).mock.calls[0][0].clock.counter;
 
       // Simulate receiving a remote change with same counter but alphabetically higher process ID
-      const changeEventHandler = vi.mocked(mockEventHandler).mock.calls[0][0];
+      const changeEventHandler = vi.mocked(mockEmitter.event).mock.calls[0][0];
       changeEventHandler({
         key: testKey,
         value: newValue,

--- a/src/shared/services/shared-store.service.test.ts
+++ b/src/shared/services/shared-store.service.test.ts
@@ -190,11 +190,14 @@ describe('sharedStoreService', () => {
       expect(valueAfterRemove).toBeUndefined();
     });
 
-    it('should throw if trying to use the service before initialization', async () => {
+    it('should return undefined on get and throw on set/remove if used before initialization', async () => {
       resetForTesting();
       const error = 'Shared store service is not initialized';
 
-      expect(() => sharedStoreService.get(testKey)).toThrow(error);
+      // get is forgiving during bootstrap — early callers (e.g., network-request timeout lookup)
+      // can run before the service finishes initializing without crashing
+      expect(sharedStoreService.get(testKey)).toBeUndefined();
+      // set and remove still throw because they mutate state
       expect(() => sharedStoreService.set(testKey, 5000)).toThrow(error);
       expect(() => sharedStoreService.remove(testKey)).toThrow(error);
     });

--- a/src/shared/services/shared-store.service.test.ts
+++ b/src/shared/services/shared-store.service.test.ts
@@ -11,6 +11,7 @@ import {
 // Mock dependencies
 vi.mock('@shared/services/network.service', () => ({
   createNetworkEventEmitter: vi.fn(),
+  createNetworkEventEmitterAsync: vi.fn(),
   getNetworkEvent: vi.fn(),
   request: vi.fn(),
   registerRequestHandler: vi.fn(),
@@ -54,6 +55,11 @@ describe('sharedStoreService', () => {
       // eslint-disable-next-line no-type-assertion/no-type-assertion
       mockEmitter as unknown as PlatformEventEmitter<unknown>,
     );
+    vi.mocked(networkService.createNetworkEventEmitterAsync).mockResolvedValue(
+      // Needed for testing
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      mockEmitter as unknown as PlatformEventEmitter<unknown>,
+    );
 
     // Mock event handler subscription
     vi.mocked(networkService.getNetworkEvent).mockReturnValue(mockEventHandler);
@@ -72,8 +78,10 @@ describe('sharedStoreService', () => {
   describe('initialize', () => {
     it('should initialize the service with a unique process ID', async () => {
       await initializeSharedStore(networkService);
-      expect(networkService.createNetworkEventEmitter).toHaveBeenCalledWith('shared-store:change');
-      expect(networkService.getNetworkEvent).toHaveBeenCalledWith('shared-store:change');
+      expect(networkService.createNetworkEventEmitterAsync).toHaveBeenCalledWith(
+        'shared-store.onDidChange',
+      );
+      expect(networkService.getNetworkEvent).toHaveBeenCalledWith('shared-store.onDidChange');
       expect(mockEventHandler).toHaveBeenCalled();
     });
 

--- a/src/shared/services/shared-store.service.test.ts
+++ b/src/shared/services/shared-store.service.test.ts
@@ -109,13 +109,18 @@ describe('sharedStoreService', () => {
 
     it('should fetch initial store data in non-Main processes', async () => {
       globalThis.processType = ProcessType.ExtensionHost;
+      // Entries must be full StoreEntry shapes (value + Lamport clock); otherwise setFromRemote
+      // throws on `entry.clock.counter` and the error is swallowed, so the fetched data would never
+      // actually land in the local store.
       const mockStoreData = {
-        'platform.customNetworkTimeouts': { 'test.request': 5000 },
+        [testKey]: { value: 5000, clock: { counter: 1, processId: 'remote-process' } },
       };
       vi.mocked(networkService.request).mockResolvedValue(mockStoreData);
 
       await initializeSharedStore(networkService);
       expect(networkService.request).toHaveBeenCalledWith('shared-store:get');
+      // The fetched entry actually populated the local store.
+      expect(sharedStoreService.get(testKey)).toBe(5000);
     });
 
     it('should be idempotent — subsequent initialize calls return the same promise', async () => {

--- a/src/shared/services/shared-store.service.test.ts
+++ b/src/shared/services/shared-store.service.test.ts
@@ -132,6 +132,24 @@ describe('sharedStoreService', () => {
         createEmitterCallCount,
       );
     });
+
+    it('clears the cached promise on failure so a later call can retry', async () => {
+      globalThis.processType = ProcessType.ExtensionHost;
+      // First initialize() fails while fetching the initial store snapshot.
+      vi.mocked(networkService.request).mockRejectedValueOnce(new Error('boom'));
+      // The non-Main initial fetch swallows request errors, so force a hard failure by making the
+      // emitter creation throw on the first attempt instead.
+      vi.mocked(networkService.createCoreMultiSourceEventEmitter).mockImplementationOnce(() => {
+        throw new Error('emitter boom');
+      });
+
+      await expect(initializeSharedStore(networkService)).rejects.toThrow('emitter boom');
+      expect(sharedStoreService.isInitialized()).toBe(false);
+
+      // A subsequent call must re-run initialization rather than return the rejected promise forever.
+      await expect(initializeSharedStore(networkService)).resolves.toBeUndefined();
+      expect(sharedStoreService.isInitialized()).toBe(true);
+    });
   });
 
   describe('waitForInitialization', () => {

--- a/src/shared/services/shared-store.service.test.ts
+++ b/src/shared/services/shared-store.service.test.ts
@@ -82,6 +82,7 @@ describe('sharedStoreService', () => {
       await initializeSharedStore(networkService);
       expect(networkService.createNetworkEventEmitterAsync).toHaveBeenCalledWith(
         'shared-store:change',
+        expect.objectContaining({ notification: expect.any(Object) }),
       );
       expect(networkService.getNetworkEvent).toHaveBeenCalledWith('shared-store:change');
       expect(mockEventHandler).toHaveBeenCalled();

--- a/src/shared/services/shared-store.service.test.ts
+++ b/src/shared/services/shared-store.service.test.ts
@@ -81,9 +81,9 @@ describe('sharedStoreService', () => {
     it('should initialize the service with a unique process ID', async () => {
       await initializeSharedStore(networkService);
       expect(networkService.createNetworkEventEmitterAsync).toHaveBeenCalledWith(
-        'shared-store.onDidChange',
+        'shared-store:change',
       );
-      expect(networkService.getNetworkEvent).toHaveBeenCalledWith('shared-store.onDidChange');
+      expect(networkService.getNetworkEvent).toHaveBeenCalledWith('shared-store:change');
       expect(mockEventHandler).toHaveBeenCalled();
     });
 

--- a/src/shared/services/shared-store.service.test.ts
+++ b/src/shared/services/shared-store.service.test.ts
@@ -58,7 +58,9 @@ describe('sharedStoreService', () => {
     vi.mocked(networkService.createNetworkEventEmitterAsync).mockResolvedValue(
       // Needed for testing
       // eslint-disable-next-line no-type-assertion/no-type-assertion
-      mockEmitter as unknown as PlatformEventEmitter<unknown>,
+      mockEmitter as unknown as Awaited<
+        ReturnType<typeof networkService.createNetworkEventEmitterAsync>
+      >,
     );
 
     // Mock event handler subscription

--- a/src/shared/services/shared-store.service.test.ts
+++ b/src/shared/services/shared-store.service.test.ts
@@ -190,14 +190,11 @@ describe('sharedStoreService', () => {
       expect(valueAfterRemove).toBeUndefined();
     });
 
-    it('should return undefined on get and throw on set/remove if used before initialization', async () => {
+    it('should throw if trying to use the service before initialization', async () => {
       resetForTesting();
       const error = 'Shared store service is not initialized';
 
-      // get is forgiving during bootstrap — early callers (e.g., network-request timeout lookup)
-      // can run before the service finishes initializing without crashing
-      expect(sharedStoreService.get(testKey)).toBeUndefined();
-      // set and remove still throw because they mutate state
+      expect(() => sharedStoreService.get(testKey)).toThrow(error);
       expect(() => sharedStoreService.set(testKey, 5000)).toThrow(error);
       expect(() => sharedStoreService.remove(testKey)).toThrow(error);
     });

--- a/src/shared/services/shared-store.service.test.ts
+++ b/src/shared/services/shared-store.service.test.ts
@@ -6,6 +6,7 @@ import {
   initialize as initializeSharedStore,
   resetForTesting,
   sharedStoreService,
+  waitForInitialization,
 } from './shared-store.service';
 
 // Mock dependencies
@@ -122,6 +123,27 @@ describe('sharedStoreService', () => {
       await initializeSharedStore(networkService);
       expect(vi.mocked(networkService.createNetworkEventEmitterAsync).mock.calls.length).toBe(
         createEmitterCallCount,
+      );
+    });
+  });
+
+  describe('waitForInitialization', () => {
+    it('resolves immediately when initialize() has already been called', async () => {
+      await initializeSharedStore(networkService);
+      await expect(waitForInitialization()).resolves.toBeUndefined();
+    });
+
+    it('resolves once initialize() starts within the timeout', async () => {
+      // Begin waiting before initialize() is called; the generous timeout has not elapsed.
+      const waiting = waitForInitialization(1000);
+      await initializeSharedStore(networkService);
+      await expect(waiting).resolves.toBeUndefined();
+    });
+
+    it('throws if initialize() does not start within the timeout', async () => {
+      // initialize() is never called, so the start-timeout should elapse and reject.
+      await expect(waitForInitialization(30)).rejects.toThrow(
+        /initialize\(\) was not called within 30ms/,
       );
     });
   });

--- a/src/shared/services/shared-store.service.test.ts
+++ b/src/shared/services/shared-store.service.test.ts
@@ -109,10 +109,18 @@ describe('sharedStoreService', () => {
       expect(networkService.request).toHaveBeenCalledWith('shared-store:get');
     });
 
-    it('should throw if initialized multiple times', async () => {
+    it('should be idempotent — subsequent initialize calls return the same promise', async () => {
+      const first = initializeSharedStore(networkService);
+      const second = initializeSharedStore(networkService);
+      // Both calls return the same in-flight promise
+      expect(second).toBe(first);
+      await first;
+      // After resolution, further calls still no-op (no second registration of handlers/emitters)
+      const createEmitterCallCount = vi.mocked(networkService.createNetworkEventEmitterAsync).mock
+        .calls.length;
       await initializeSharedStore(networkService);
-      await expect(initializeSharedStore(networkService)).rejects.toThrow(
-        'Shared store service is already initialized',
+      expect(vi.mocked(networkService.createNetworkEventEmitterAsync).mock.calls.length).toBe(
+        createEmitterCallCount,
       );
     });
   });

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -31,7 +31,7 @@ type StoreEntry = {
 };
 
 // Store change event emitted when a value is set or removed
-type StoreChangeEvent = StoreEntry & {
+export type StoreChangeEvent = StoreEntry & {
   key: string;
 };
 

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -10,7 +10,7 @@ import { ProcessType } from '@shared/global-this.model';
 
 const SHARED_STORE_PREFIX = 'shared-store';
 const STORE_GET_REQUEST = `${SHARED_STORE_PREFIX}:get`;
-const STORE_CHANGE_EVENT = `${SHARED_STORE_PREFIX}:change`;
+const STORE_CHANGE_EVENT = 'shared-store.onDidChange';
 
 // https://en.wikipedia.org/wiki/Lamport_timestamp
 let localCounter: number = 0;
@@ -81,7 +81,7 @@ export async function initialize(networkService: NetworkService): Promise<void> 
   logger.debug(`Initializing shared store service`);
 
   // Prepare to emit changes as they are made to the local store
-  storeChangeEmitter = networkService.createNetworkEventEmitter(STORE_CHANGE_EVENT);
+  storeChangeEmitter = await networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT);
 
   // Listen for changes from other processes to update the local store
   networkService.getNetworkEvent<StoreChangeEvent>(STORE_CHANGE_EVENT)((event) => {

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -25,6 +25,7 @@ const STORE_CHANGE_EVENT = `${SHARED_STORE_PREFIX}:change` as 'shared-store:chan
 /** OpenRPC notification documentation for the {@link STORE_CHANGE_EVENT} network event. */
 const STORE_CHANGE_EVENT_DOCS: SingleNotificationDocumentation = {
   notification: {
+    'x-experimental': true,
     summary: 'Emitted when a value in the shared store changes.',
     params: [
       {
@@ -171,6 +172,7 @@ export function initialize(networkService: NetworkService): Promise<void> {
         (key?: string) => (key === undefined ? { ...localStore } : localStore[key]?.value),
         {
           method: {
+            'x-experimental': true,
             summary: 'Get values from the shared store',
             params: [
               {

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -135,44 +135,51 @@ resetInitializationStartedSignal();
 export function initialize(networkService: NetworkService): Promise<void> {
   if (initializationPromise) return initializationPromise;
   initializationStartedResolve();
+
+  // Synchronous setup. `processId` and `storeChangeEmitter` MUST be assigned synchronously here —
+  // before this function yields — so that `set` and `remove` work synchronously as soon as
+  // initialize() has been called, without callers having to await initialization first. (The
+  // `shared-store:change` emitter is created synchronously via createCoreMultiSourceEventEmitter; its
+  // central registration runs in the background and isn't needed for the emitter to work.) Only the
+  // cross-process initial data sync below is asynchronous.
+  try {
+    // Generate a unique process ID for this process that still includes the process type
+    processId = `${globalThis.processType}-${Math.random().toString(36).substring(2, 10)}`;
+    logger.debug(`Initializing shared store service`);
+
+    const { emitter, registeredEmitterPromise } = networkService.createCoreMultiSourceEventEmitter(
+      STORE_CHANGE_EVENT,
+      STORE_CHANGE_EVENT_DOCS,
+    );
+    storeChangeEmitter = emitter;
+    // Consume the registration result in the background (failures are already logged inside the
+    // network service) so a rejection can't surface as an unhandled rejection.
+    (async () => {
+      try {
+        await registeredEmitterPromise;
+      } catch {
+        // Registration failure is already logged inside createCoreMultiSourceEventEmitter.
+      }
+    })();
+
+    // Listen for changes from other processes to update the local store.
+    storeChangeEmitter.event((event) => {
+      if (event.clock.processId !== processId) setFromRemote(event.key, event);
+    });
+  } catch (error) {
+    // Synchronous setup failed before initializationPromise was assigned. Reset the partial state and
+    // the started signal so a later initialize()/waitForInitialization() can retry from scratch.
+    // Surface the failure as a rejected promise rather than throwing synchronously, so initialize()
+    // always returns a promise. initializationPromise stays undefined, so the retry path is open.
+    storeChangeEmitter?.dispose();
+    storeChangeEmitter = undefined;
+    processId = '';
+    resetInitializationStartedSignal();
+    return Promise.reject(error instanceof Error ? error : new Error(getErrorMessage(error)));
+  }
+
   initializationPromise = (async () => {
     try {
-      // Defer the rest of init to a microtask so the synchronous part of initialize() (the
-      // `initializationPromise = ...` assignment below) completes first. Otherwise a synchronous
-      // throw in the body (e.g. from createCoreMultiSourceEventEmitter) would run the catch's
-      // `initializationPromise = undefined` reset *before* the outer assignment, which would then
-      // clobber it back to the rejected promise — permanently stuck. Yielding first guarantees the
-      // catch runs after the assignment, so a failed init can be retried.
-      await Promise.resolve();
-      // Generate a unique process ID for this process that still includes the process type
-      processId = `${globalThis.processType}-${Math.random().toString(36).substring(2, 10)}`;
-      logger.debug(`Initializing shared store service`);
-
-      // Create the multi-source emitter for `shared-store:change` synchronously and assign it
-      // immediately so the store can emit and subscribe right away. Central registration with the RPC
-      // handler runs in the background — we don't await it (it isn't needed for the emitter to work),
-      // keeping startup simple.
-      const { emitter, registeredEmitterPromise } =
-        networkService.createCoreMultiSourceEventEmitter(
-          STORE_CHANGE_EVENT,
-          STORE_CHANGE_EVENT_DOCS,
-        );
-      storeChangeEmitter = emitter;
-      // Consume the registration result in the background (failures are already logged inside the
-      // network service) so a rejection can't surface as an unhandled rejection.
-      (async () => {
-        try {
-          await registeredEmitterPromise;
-        } catch {
-          // Registration failure is already logged inside createCoreMultiSourceEventEmitter.
-        }
-      })();
-
-      // Listen for changes from other processes to update the local store.
-      storeChangeEmitter.event((event) => {
-        if (event.clock.processId !== processId) setFromRemote(event.key, event);
-      });
-
       if (globalThis.processType !== ProcessType.Main) {
         // Outside the main process, sync the local store to the main store's data initially.
         try {

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -4,6 +4,7 @@ import {
   getErrorMessage,
   PlatformEventEmitter,
   serialize,
+  wait,
 } from 'platform-bible-utils';
 import { logger } from '@shared/services/logger.service';
 import { ProcessType } from '@shared/global-this.model';
@@ -85,8 +86,8 @@ let initializationPromise: Promise<void> | undefined;
 
 /**
  * Resolved when {@link initialize} is first called (regardless of whether it has completed).
- * {@link whenInitialized} awaits this to know when to start waiting on the actual init promise.
- * Recreated by {@link resetForTesting} so each test starts with a fresh signal.
+ * {@link waitForInitialization} awaits this to know when to start waiting on the actual init
+ * promise. Recreated by {@link resetForTesting} so each test starts with a fresh signal.
  */
 let initializationStartedResolve: () => void;
 let initializationStartedPromise: Promise<void>;
@@ -112,27 +113,44 @@ export function initialize(networkService: NetworkService): Promise<void> {
     processId = `${globalThis.processType}-${Math.random().toString(36).substring(2, 10)}`;
     logger.debug(`Initializing shared store service`);
 
-    // Prepare to emit changes as they are made to the local store
-    storeChangeEmitter = await networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT);
-
-    // Listen for changes from other processes to update the local store
+    // Subscribe to remote changes immediately. getNetworkEvent is synchronous-effective — it
+    // attaches a handler to the local emitter for this name; no network round-trip — so we don't
+    // gate the parallel work below on it.
     networkService.getNetworkEvent(STORE_CHANGE_EVENT)((event) => {
       if (event.clock.processId !== processId) setFromRemote(event.key, event);
     });
 
-    // Outside of the main process, sync the local store to the main store's data initially
+    // The two network round-trips below (create emitter + fetch initial / register handler) are
+    // independent and can run in parallel. Each cuts the network-latency contribution of bootstrap
+    // roughly in half.
     if (globalThis.processType !== ProcessType.Main) {
-      try {
-        const initial: Record<string, StoreEntry> = await networkService.request(STORE_GET_REQUEST);
-        if (!initial) return;
-        Object.entries(initial).forEach(([key, entry]) => setFromRemote(key, entry));
-      } catch (error) {
-        logger.warn(`Error initializing local store: ${getErrorMessage(error)}`);
-      }
+      // Outside the main process: create the emitter AND fetch initial store data concurrently.
+      // Catch the entire initial-sync failure path (request error OR malformed entries) so it
+      // doesn't reject the Promise.all and lose the emitter — we want the emitter assigned even
+      // if the initial sync fails.
+      const [emitter] = await Promise.all([
+        networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT),
+        (async () => {
+          try {
+            const initial = await networkService.request<[], Record<string, StoreEntry>>(
+              STORE_GET_REQUEST,
+            );
+            if (!initial) return;
+            Object.entries(initial).forEach(([key, entry]) => setFromRemote(key, entry));
+          } catch (error) {
+            logger.warn(`Error initializing local store: ${getErrorMessage(error)}`);
+          }
+        })(),
+      ]);
+      storeChangeEmitter = emitter;
+      return;
     }
-    // Inside the main process, handle get requests to return data
-    else {
-      await networkService.registerRequestHandler(
+
+    // Inside the main process: create the emitter AND register the handler that serves the other
+    // processes' initial-fetch requests, concurrently.
+    const [emitter] = await Promise.all([
+      networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT),
+      networkService.registerRequestHandler(
         STORE_GET_REQUEST,
         (key?: string) => (key === undefined ? { ...localStore } : localStore[key]?.value),
         {
@@ -164,8 +182,9 @@ export function initialize(networkService: NetworkService): Promise<void> {
             },
           },
         },
-      );
-    }
+      ),
+    ]);
+    storeChangeEmitter = emitter;
   })();
   return initializationPromise;
 }
@@ -188,12 +207,8 @@ export function initialize(networkService: NetworkService): Promise<void> {
  */
 export async function waitForInitialization(startTimeoutMs: number = 1000): Promise<void> {
   if (initializationPromise) return initializationPromise;
-  const timeoutPromise = new Promise<'timeout'>((resolve) => {
-    setTimeout(() => resolve('timeout'), startTimeoutMs);
-  });
-  const startedPromise = initializationStartedPromise.then(() => 'started' as const);
-  const result = await Promise.race([startedPromise, timeoutPromise]);
-  if (result === 'timeout' || !initializationPromise)
+  await Promise.race([initializationStartedPromise, wait(startTimeoutMs)]);
+  if (!initializationPromise)
     throw new Error(
       `Shared store service initialize() was not called within ${startTimeoutMs}ms — caller cannot wait for readiness.`,
     );

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -136,86 +136,107 @@ export function initialize(networkService: NetworkService): Promise<void> {
   if (initializationPromise) return initializationPromise;
   initializationStartedResolve();
   initializationPromise = (async () => {
-    // Generate a unique process ID for this process that still includes the process type
-    processId = `${globalThis.processType}-${Math.random().toString(36).substring(2, 10)}`;
-    logger.debug(`Initializing shared store service`);
+    try {
+      // Defer the rest of init to a microtask so the synchronous part of initialize() (the
+      // `initializationPromise = ...` assignment below) completes first. Otherwise a synchronous
+      // throw in the body (e.g. from createCoreMultiSourceEventEmitter) would run the catch's
+      // `initializationPromise = undefined` reset *before* the outer assignment, which would then
+      // clobber it back to the rejected promise — permanently stuck. Yielding first guarantees the
+      // catch runs after the assignment, so a failed init can be retried.
+      await Promise.resolve();
+      // Generate a unique process ID for this process that still includes the process type
+      processId = `${globalThis.processType}-${Math.random().toString(36).substring(2, 10)}`;
+      logger.debug(`Initializing shared store service`);
 
-    // Create the multi-source emitter for `shared-store:change` synchronously and assign it
-    // immediately so the store can emit and subscribe right away. Central registration with the RPC
-    // handler runs in the background — we don't await it (it isn't needed for the emitter to work),
-    // keeping startup simple.
-    const { emitter, registeredEmitterPromise } = networkService.createCoreMultiSourceEventEmitter(
-      STORE_CHANGE_EVENT,
-      STORE_CHANGE_EVENT_DOCS,
-    );
-    storeChangeEmitter = emitter;
-    // Consume the registration result in the background (failures are already logged inside the
-    // network service) so a rejection can't surface as an unhandled rejection.
-    (async () => {
-      try {
-        await registeredEmitterPromise;
-      } catch {
-        // Registration failure is already logged inside createCoreMultiSourceEventEmitter.
-      }
-    })();
-
-    // Listen for changes from other processes to update the local store.
-    storeChangeEmitter.event((event) => {
-      if (event.clock.processId !== processId) setFromRemote(event.key, event);
-    });
-
-    if (globalThis.processType !== ProcessType.Main) {
-      // Outside the main process, sync the local store to the main store's data initially.
-      try {
-        const initial = await networkService.request<[], Record<string, StoreEntry>>(
-          STORE_GET_REQUEST,
+      // Create the multi-source emitter for `shared-store:change` synchronously and assign it
+      // immediately so the store can emit and subscribe right away. Central registration with the RPC
+      // handler runs in the background — we don't await it (it isn't needed for the emitter to work),
+      // keeping startup simple.
+      const { emitter, registeredEmitterPromise } =
+        networkService.createCoreMultiSourceEventEmitter(
+          STORE_CHANGE_EVENT,
+          STORE_CHANGE_EVENT_DOCS,
         );
-        if (initial) Object.entries(initial).forEach(([key, entry]) => setFromRemote(key, entry));
-      } catch (error) {
-        logger.warn(`Error initializing local store: ${getErrorMessage(error)}`);
-      }
-    } else {
-      // Inside the main process, register the handler that serves the other processes' initial-fetch
-      // requests.
-      await networkService.registerRequestHandler(
-        STORE_GET_REQUEST,
-        (key?: string) => (key === undefined ? { ...localStore } : localStore[key]?.value),
-        {
-          method: {
-            'x-experimental': true,
-            summary: 'Get values from the shared store',
-            params: [
-              {
-                name: 'key',
-                required: false,
+      storeChangeEmitter = emitter;
+      // Consume the registration result in the background (failures are already logged inside the
+      // network service) so a rejection can't surface as an unhandled rejection.
+      (async () => {
+        try {
+          await registeredEmitterPromise;
+        } catch {
+          // Registration failure is already logged inside createCoreMultiSourceEventEmitter.
+        }
+      })();
+
+      // Listen for changes from other processes to update the local store.
+      storeChangeEmitter.event((event) => {
+        if (event.clock.processId !== processId) setFromRemote(event.key, event);
+      });
+
+      if (globalThis.processType !== ProcessType.Main) {
+        // Outside the main process, sync the local store to the main store's data initially.
+        try {
+          const initial = await networkService.request<[], Record<string, StoreEntry>>(
+            STORE_GET_REQUEST,
+          );
+          if (initial) Object.entries(initial).forEach(([key, entry]) => setFromRemote(key, entry));
+        } catch (error) {
+          logger.warn(`Error initializing local store: ${getErrorMessage(error)}`);
+        }
+      } else {
+        // Inside the main process, register the handler that serves the other processes' initial-fetch
+        // requests.
+        await networkService.registerRequestHandler(
+          STORE_GET_REQUEST,
+          (key?: string) => (key === undefined ? { ...localStore } : localStore[key]?.value),
+          {
+            method: {
+              'x-experimental': true,
+              summary: 'Get values from the shared store',
+              params: [
+                {
+                  name: 'key',
+                  required: false,
+                  summary:
+                    'The key of the value to retrieve (leave undefined to get the entire store)',
+                  schema: { type: 'string' },
+                },
+              ],
+              result: {
+                name: 'return value',
                 summary:
-                  'The key of the value to retrieve (leave undefined to get the entire store)',
-                schema: { type: 'string' },
-              },
-            ],
-            result: {
-              name: 'return value',
-              summary:
-                'The value associated with the key, or the entire store if no key is provided',
-              schema: {
-                oneOf: [
-                  { type: 'string' },
-                  { type: 'number' },
-                  { type: 'boolean' },
-                  { type: 'object' },
-                  { type: 'array' },
-                  { type: 'null' },
-                ],
+                  'The value associated with the key, or the entire store if no key is provided',
+                schema: {
+                  oneOf: [
+                    { type: 'string' },
+                    { type: 'number' },
+                    { type: 'boolean' },
+                    { type: 'object' },
+                    { type: 'array' },
+                    { type: 'null' },
+                  ],
+                },
               },
             },
           },
-        },
-      );
-    }
+        );
+      }
 
-    // The store is now fully initialized (process ID assigned, emitter ready, and — outside main —
-    // initial data synced).
-    isFullyInitialized = true;
+      // The store is now fully initialized (process ID assigned, emitter ready, and — outside main —
+      // initial data synced).
+      isFullyInitialized = true;
+    } catch (error) {
+      // Initialization failed. Tear down any partial state and clear the cached promise so a later
+      // initialize()/waitForInitialization() can retry from scratch instead of being permanently
+      // stuck on this rejected promise.
+      storeChangeEmitter?.dispose();
+      storeChangeEmitter = undefined;
+      processId = '';
+      isFullyInitialized = false;
+      initializationPromise = undefined;
+      resetInitializationStartedSignal();
+      throw error;
+    }
   })();
   return initializationPromise;
 }

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -1,13 +1,14 @@
 import {
+  AsyncVariable,
   deepEqual,
   deserialize,
   getErrorMessage,
   PlatformEventEmitter,
   serialize,
-  wait,
 } from 'platform-bible-utils';
 import { logger } from '@shared/services/logger.service';
 import { ProcessType } from '@shared/global-this.model';
+import type { SingleNotificationDocumentation } from '@shared/models/openrpc.model';
 
 const SHARED_STORE_PREFIX = 'shared-store';
 /**
@@ -20,6 +21,21 @@ export const STORE_GET_REQUEST = `${SHARED_STORE_PREFIX}:get`;
 // The template literal widens to `string`; cast to the matching NetworkEvents key.
 // eslint-disable-next-line no-type-assertion/no-type-assertion
 const STORE_CHANGE_EVENT = `${SHARED_STORE_PREFIX}:change` as 'shared-store:change';
+
+/** OpenRPC notification documentation for the {@link STORE_CHANGE_EVENT} network event. */
+const STORE_CHANGE_EVENT_DOCS: SingleNotificationDocumentation = {
+  notification: {
+    summary: 'Emitted when a value in the shared store changes.',
+    params: [
+      {
+        name: 'change',
+        required: true,
+        summary: 'The changed key and new value with its Lamport timestamp.',
+        schema: { type: 'object' },
+      },
+    ],
+  },
+};
 
 // https://en.wikipedia.org/wiki/Lamport_timestamp
 let localCounter: number = 0;
@@ -129,7 +145,7 @@ export function initialize(networkService: NetworkService): Promise<void> {
       // doesn't reject the Promise.all and lose the emitter — we want the emitter assigned even
       // if the initial sync fails.
       const [emitter] = await Promise.all([
-        networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT),
+        networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT, STORE_CHANGE_EVENT_DOCS),
         (async () => {
           try {
             const initial = await networkService.request<[], Record<string, StoreEntry>>(
@@ -149,7 +165,7 @@ export function initialize(networkService: NetworkService): Promise<void> {
     // Inside the main process: create the emitter AND register the handler that serves the other
     // processes' initial-fetch requests, concurrently.
     const [emitter] = await Promise.all([
-      networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT),
+      networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT, STORE_CHANGE_EVENT_DOCS),
       networkService.registerRequestHandler(
         STORE_GET_REQUEST,
         (key?: string) => (key === undefined ? { ...localStore } : localStore[key]?.value),
@@ -207,7 +223,21 @@ export function initialize(networkService: NetworkService): Promise<void> {
  */
 export async function waitForInitialization(startTimeoutMs: number = 1000): Promise<void> {
   if (initializationPromise) return initializationPromise;
-  await Promise.race([initializationStartedPromise, wait(startTimeoutMs)]);
+  // Wait for initialize() to start, bounded by startTimeoutMs. Use AsyncVariable for the timeout
+  // (per the async-coordination decision registry entry) rather than a raw Promise.race. The
+  // variable is created per call so its timeout is measured from this call, matching the previous
+  // per-call semantics; the long-lived `initializationStartedPromise` signal resolves it when
+  // initialize() starts. The timeout rejection is swallowed because the `initializationPromise`
+  // check below is what distinguishes "started" from "timed out".
+  const startGate = new AsyncVariable<undefined>(
+    'shared store initialization start',
+    startTimeoutMs,
+  );
+  // `initializationStartedPromise` only ever resolves (never rejects), but the `.catch` is required
+  // by lint and harmless; we intentionally do not await this — it just bridges the signal into the
+  // gate.
+  initializationStartedPromise.then(() => startGate.resolveToValue(undefined)).catch(() => {});
+  await startGate.promise.catch(() => {});
   if (!initializationPromise)
     throw new Error(
       `Shared store service initialize() was not called within ${startTimeoutMs}ms — caller cannot wait for readiness.`,

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -10,7 +10,7 @@ import { ProcessType } from '@shared/global-this.model';
 
 const SHARED_STORE_PREFIX = 'shared-store';
 const STORE_GET_REQUEST = `${SHARED_STORE_PREFIX}:get`;
-const STORE_CHANGE_EVENT = 'shared-store.onDidChange';
+const STORE_CHANGE_EVENT = 'shared-store:change';
 
 // https://en.wikipedia.org/wiki/Lamport_timestamp
 let localCounter: number = 0;

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -12,15 +12,17 @@ import type { SingleNotificationDocumentation } from '@shared/models/openrpc.mod
 
 const SHARED_STORE_PREFIX = 'shared-store';
 /**
- * Internal request type used by the shared store service to fetch the initial store contents during
- * its own initialization. Exported so the network service's `doRequest` gate can identify this
- * request and skip awaiting shared-store initialization on it (otherwise we'd deadlock: init awaits
- * this request, the request awaits init).
+ * Internal request type used by the shared store service to fetch the initial store contents from
+ * the main process during its own initialization.
  */
-export const STORE_GET_REQUEST = `${SHARED_STORE_PREFIX}:get`;
-// The template literal widens to `string`; cast to the matching NetworkEvents key.
-// eslint-disable-next-line no-type-assertion/no-type-assertion
-const STORE_CHANGE_EVENT = `${SHARED_STORE_PREFIX}:change` as 'shared-store:change';
+const STORE_GET_REQUEST = `${SHARED_STORE_PREFIX}:get`;
+/**
+ * The `shared-store:change` event name. This is a multi-source network event the platform uses
+ * internally; it is intentionally NOT declared in the public `MultiSourceNetworkEvents`/
+ * `NetworkEvents` types (the shared store service is not part of the public API), but it is tracked
+ * as multi-source at runtime via `MULTI_SOURCE_EVENT_NAMES` and surfaced in the OpenRPC document.
+ */
+const STORE_CHANGE_EVENT = `${SHARED_STORE_PREFIX}:change` as const;
 
 /** OpenRPC notification documentation for the {@link STORE_CHANGE_EVENT} network event. */
 const STORE_CHANGE_EVENT_DOCS: SingleNotificationDocumentation = {
@@ -44,16 +46,24 @@ let localCounter: number = 0;
 // Unique process ID used for tie-breaking in Lamport clock comparisons
 let processId: string = '';
 
+// Whether initialize() has fully completed (process ID assigned, emitter ready, and — outside the
+// main process — initial store data synced). Used by isInitialized().
+let isFullyInitialized = false;
+
 // Lamport clock for ordering events across processes
 type LamportClock = {
   counter: number;
   processId: string;
 };
 
-// Store entry with Lamport clock for conflict resolution
+// Store entry with Lamport clock for conflict resolution.
 type StoreEntry = {
   value?: unknown;
   clock: LamportClock;
+  // True for a removed key. The entry (and its clock) is kept for conflict resolution, but the key
+  // is treated as absent: reads return no value. A removed key is distinct from a key whose value
+  // is `undefined`.
+  deleted?: boolean;
 };
 
 // Store change event emitted when a value is set or removed
@@ -130,44 +140,44 @@ export function initialize(networkService: NetworkService): Promise<void> {
     processId = `${globalThis.processType}-${Math.random().toString(36).substring(2, 10)}`;
     logger.debug(`Initializing shared store service`);
 
-    // Subscribe to remote changes immediately. getNetworkEvent is synchronous-effective — it
-    // attaches a handler to the local emitter for this name; no network round-trip — so we don't
-    // gate the parallel work below on it.
-    networkService.getNetworkEvent(STORE_CHANGE_EVENT)((event) => {
+    // Create the multi-source emitter for `shared-store:change` synchronously and assign it
+    // immediately so the store can emit and subscribe right away. Central registration with the RPC
+    // handler runs in the background — we don't await it (it isn't needed for the emitter to work),
+    // keeping startup simple.
+    const { emitter, registeredEmitterPromise } = networkService.createCoreMultiSourceEventEmitter(
+      STORE_CHANGE_EVENT,
+      STORE_CHANGE_EVENT_DOCS,
+    );
+    storeChangeEmitter = emitter;
+    // Consume the registration result in the background (failures are already logged inside the
+    // network service) so a rejection can't surface as an unhandled rejection.
+    (async () => {
+      try {
+        await registeredEmitterPromise;
+      } catch {
+        // Registration failure is already logged inside createCoreMultiSourceEventEmitter.
+      }
+    })();
+
+    // Listen for changes from other processes to update the local store.
+    storeChangeEmitter.event((event) => {
       if (event.clock.processId !== processId) setFromRemote(event.key, event);
     });
 
-    // The two network round-trips below (create emitter + fetch initial / register handler) are
-    // independent and can run in parallel. Each cuts the network-latency contribution of bootstrap
-    // roughly in half.
     if (globalThis.processType !== ProcessType.Main) {
-      // Outside the main process: create the emitter AND fetch initial store data concurrently.
-      // Catch the entire initial-sync failure path (request error OR malformed entries) so it
-      // doesn't reject the Promise.all and lose the emitter — we want the emitter assigned even
-      // if the initial sync fails.
-      const [emitter] = await Promise.all([
-        networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT, STORE_CHANGE_EVENT_DOCS),
-        (async () => {
-          try {
-            const initial = await networkService.request<[], Record<string, StoreEntry>>(
-              STORE_GET_REQUEST,
-            );
-            if (!initial) return;
-            Object.entries(initial).forEach(([key, entry]) => setFromRemote(key, entry));
-          } catch (error) {
-            logger.warn(`Error initializing local store: ${getErrorMessage(error)}`);
-          }
-        })(),
-      ]);
-      storeChangeEmitter = emitter;
-      return;
-    }
-
-    // Inside the main process: create the emitter AND register the handler that serves the other
-    // processes' initial-fetch requests, concurrently.
-    const [emitter] = await Promise.all([
-      networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT, STORE_CHANGE_EVENT_DOCS),
-      networkService.registerRequestHandler(
+      // Outside the main process, sync the local store to the main store's data initially.
+      try {
+        const initial = await networkService.request<[], Record<string, StoreEntry>>(
+          STORE_GET_REQUEST,
+        );
+        if (initial) Object.entries(initial).forEach(([key, entry]) => setFromRemote(key, entry));
+      } catch (error) {
+        logger.warn(`Error initializing local store: ${getErrorMessage(error)}`);
+      }
+    } else {
+      // Inside the main process, register the handler that serves the other processes' initial-fetch
+      // requests.
+      await networkService.registerRequestHandler(
         STORE_GET_REQUEST,
         (key?: string) => (key === undefined ? { ...localStore } : localStore[key]?.value),
         {
@@ -200,9 +210,12 @@ export function initialize(networkService: NetworkService): Promise<void> {
             },
           },
         },
-      ),
-    ]);
-    storeChangeEmitter = emitter;
+      );
+    }
+
+    // The store is now fully initialized (process ID assigned, emitter ready, and — outside main —
+    // initial data synced).
+    isFullyInitialized = true;
   })();
   return initializationPromise;
 }
@@ -212,38 +225,51 @@ export function initialize(networkService: NetworkService): Promise<void> {
  *
  * - If {@link initialize} has already been called, returns the existing in-flight promise (no timeout
  *   — we wait as long as init takes).
- * - If {@link initialize} has not been called yet, waits up to `startTimeoutMs` for it to start then
- *   returns the resulting promise.
+ * - Otherwise waits for {@link initialize} to be called, then returns the resulting promise.
  *
- * Throws if {@link initialize} never starts within `startTimeoutMs`. Callers that can tolerate the
- * absence of a ready shared store should catch and fall back.
- *
- * @param startTimeoutMs Time to wait for initialize() to be called before throwing. Default 1000ms
- *   — generous enough to cover normal bootstrap, short enough to avoid hanging requests when
- *   initialize is never called.
- * @throws If initialize() does not start within `startTimeoutMs`.
+ * @param startTimeoutMs Time to wait for initialize() to be called before throwing. A non-positive
+ *   value (the default, `0`) waits indefinitely. A positive value throws if initialize() is not
+ *   called within that many milliseconds. Callers that can tolerate the absence of a ready shared
+ *   store should pass a positive timeout and catch/fall back.
+ * @throws If `startTimeoutMs` is positive and initialize() is not called within that window.
  */
-export async function waitForInitialization(startTimeoutMs: number = 1000): Promise<void> {
+export async function waitForInitialization(startTimeoutMs: number = 0): Promise<void> {
   if (initializationPromise) return initializationPromise;
-  // Wait for initialize() to start, bounded by startTimeoutMs. Use AsyncVariable for the timeout
-  // (per the async-coordination decision registry entry) rather than a raw Promise.race. The
-  // variable is created per call so its timeout is measured from this call, matching the previous
-  // per-call semantics; the long-lived `initializationStartedPromise` signal resolves it when
-  // initialize() starts. The timeout rejection is swallowed because the `initializationPromise`
-  // check below is what distinguishes "started" from "timed out".
-  const startGate = new AsyncVariable<undefined>(
-    'shared store initialization start',
-    startTimeoutMs,
-  );
-  // `initializationStartedPromise` only ever resolves (never rejects), but the `.catch` is required
-  // by lint and harmless; we intentionally do not await this — it just bridges the signal into the
-  // gate.
-  initializationStartedPromise.then(() => startGate.resolveToValue(undefined)).catch(() => {});
-  await startGate.promise.catch(() => {});
-  if (!initializationPromise)
-    throw new Error(
-      `Shared store service initialize() was not called within ${startTimeoutMs}ms — caller cannot wait for readiness.`,
+
+  if (startTimeoutMs <= 0) {
+    // Wait indefinitely for initialize() to be called.
+    await initializationStartedPromise;
+  } else {
+    // Bounded wait. Use AsyncVariable for the timeout (per the async-coordination decision registry
+    // entry) rather than a raw Promise.race. Bridge the long-lived `initializationStartedPromise`
+    // signal into the gate from an IIFE; it only ever resolves, never rejects.
+    const startGate = new AsyncVariable<undefined>(
+      'shared store initialization start',
+      startTimeoutMs,
     );
+    (async () => {
+      try {
+        await initializationStartedPromise;
+        startGate.resolveToValue(undefined);
+      } catch {
+        // `initializationStartedPromise` never rejects; nothing to handle.
+      }
+    })();
+    try {
+      await startGate.promise;
+    } catch {
+      // The gate timed out waiting for initialize() to start.
+    }
+    if (!initializationPromise)
+      throw new Error(
+        `Shared store service initialize() was not called within ${startTimeoutMs}ms — caller cannot wait for readiness.`,
+      );
+  }
+
+  // `initializationPromise` is assigned synchronously immediately after the start signal resolves in
+  // initialize(), so it is defined here once we have observed the start signal.
+  if (!initializationPromise)
+    throw new Error('Shared store service initialize() did not start as expected');
   return initializationPromise;
 }
 
@@ -253,6 +279,7 @@ export async function waitForInitialization(startTimeoutMs: number = 1000): Prom
  */
 export function resetForTesting(): void {
   processId = '';
+  isFullyInitialized = false;
   localCounter = 0;
   Object.keys(localStore).forEach((key) => delete localStore[key]);
   storeChangeEmitter = undefined;
@@ -261,17 +288,32 @@ export function resetForTesting(): void {
 }
 
 /**
- * Get a value from the shared store with proper typing
+ * Returns a cloned copy of the value currently stored at the key. Throws if the value cannot be
+ * cloned (serialize/deserialize failure). Does not check presence — callers that care about
+ * presence should check {@link hasValue} first.
+ */
+function cloneStoredValue<K extends SharedStoreKeys>(key: K): SharedStoreValues[K] {
+  // Assert the specific type associated with this key
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  return deserialize(serialize(localStore[key]?.value)) as SharedStoreValues[K];
+}
+
+/**
+ * Get a value from the shared store with proper typing.
+ *
+ * This runs synchronously and does not wait for initialization: it may return `undefined` if the
+ * shared store service has not yet been populated (e.g. during the bootstrap window, before initial
+ * sync completes). Use {@link getAsync} if you need to wait for a populated value. Note that even
+ * after the store is populated, the returned value may not reflect the most up-to-date value, since
+ * changes from other processes arrive asynchronously.
  *
  * @param key The key of the value to retrieve
- * @returns A cloned copy of the value associated with the key, or undefined if not found
+ * @returns A cloned copy of the value associated with the key, or `undefined` if not found, not yet
+ *   populated, or the value could not be cloned
  */
 function get<K extends SharedStoreKeys>(key: K): SharedStoreValues[K] | undefined {
-  if (!processId || !storeChangeEmitter) throw new Error('Shared store service is not initialized');
   try {
-    // Assert the specific type associated with this key
-    // eslint-disable-next-line no-type-assertion/no-type-assertion
-    return deserialize(serialize(localStore[key]?.value)) as SharedStoreValues[K];
+    return cloneStoredValue(key);
   } catch (error) {
     logger.error(`Error getting value for key ${key} from shared store:`, getErrorMessage(error));
     return undefined;
@@ -282,6 +324,10 @@ function get<K extends SharedStoreKeys>(key: K): SharedStoreValues[K] | undefine
  * Set a value in the shared store and notify other processes. Note that if a value with the given
  * key already exists, it can only be set again by the process that created it. This is to prevent
  * race conditions between processes setting values that don't incorporate each others' updates.
+ *
+ * This runs synchronously and throws if the shared store service has not started initializing (it
+ * must be able to broadcast the change). Use {@link setAsync} if you need to wait for initialization
+ * before setting.
  *
  * @param key The key to set
  * @param value The value to set. Note that the stored value is a cloned copy of the provided value,
@@ -294,7 +340,9 @@ function set<K extends SharedStoreKeys>(key: K, value?: SharedStoreValues[K]): v
     const currentEntry = localStore[key];
     if (currentEntry && currentEntry.clock.processId !== processId)
       throw new Error('Cannot set value from a different process than the one that created it');
-    if (currentEntry && deepEqual(currentEntry.value, value)) return;
+    // Skip a redundant set only when there is already a live (non-removed) value equal to the new
+    // one. A removed key must be re-set even if its stored value also happens to equal `value`.
+    if (currentEntry && !currentEntry.deleted && deepEqual(currentEntry.value, value)) return;
     const clock = getNextClock();
     const clonedValue = deserialize(serialize(value));
     localStore[key] = {
@@ -318,28 +366,130 @@ function setFromRemote(key: string, entry: StoreEntry): void {
     localStore[key] = entry;
 }
 
+/** Whether there is a live (set, not removed) value at the key in the local store. */
+function hasValue(key: string): boolean {
+  const entry = localStore[key];
+  return entry !== undefined && !entry.deleted;
+}
+
 /**
  * Remove a value from the shared store and notify other processes of the change.
  *
- * Note that removing a key sets its value to undefined in the store. The key-value pair isn't
- * actually deleted. This is done to avoid race conditions if a value for this key is set again
- * quickly.
+ * After removal the key is treated as absent — reads return no value (a removed key is distinct
+ * from a key whose value is `undefined`). The entry and its Lamport clock are retained internally
+ * for conflict resolution (so the removal can win against concurrent sets and the key can be re-set
+ * quickly), but they are not exposed as a value.
+ *
+ * This runs synchronously and throws if the shared store service has not started initializing. Use
+ * {@link removeAsync} if you need to wait for initialization before removing.
  *
  * @param key The key to remove
  */
 function remove<K extends SharedStoreKeys>(key: K): void {
   if (!processId || !storeChangeEmitter) throw new Error('Shared store service is not initialized');
-  if (key in localStore) set(key, undefined);
+  try {
+    const currentEntry = localStore[key];
+    if (currentEntry && currentEntry.clock.processId !== processId)
+      throw new Error('Cannot remove value from a different process than the one that created it');
+    // Nothing to remove if the key is already absent or already removed.
+    if (!currentEntry || currentEntry.deleted) return;
+    const clock = getNextClock();
+    localStore[key] = { value: undefined, clock, deleted: true };
+    storeChangeEmitter.emit({ key, value: undefined, clock, deleted: true });
+  } catch (error) {
+    logger.error(`Error removing value for key ${key} from shared store:`, getErrorMessage(error));
+  }
 }
 
 /**
- * Returns `true` once {@link initialize} has fully completed. Use this to gate optional reads of the
- * shared store from code that may run during the bootstrap window — e.g., network-request timeout
- * lookups that have a sensible default. Required reads of the shared store should `await
- * initialize` instead so the value is guaranteed accurate per the Lamport-clock contract.
+ * Get a value from the shared store, waiting for the shared store service to be initialized first.
+ *
+ * Unlike {@link get}, this waits (via {@link waitForInitialization}) until the shared store service
+ * is initialized, then reads synchronously. A key with a live value returns that value — which may
+ * legitimately be `undefined`. A key that is absent or has been removed has no value: with no
+ * `defaultValue` argument this throws; with a `defaultValue` (which may itself be `undefined`) it
+ * returns that default.
+ *
+ * If the shared store service is already initialized, the awaited promise is already settled, so
+ * execution continues here on the next microtask without yielding to timers or other queued
+ * macrotasks — effectively synchronous from the caller's perspective. Note the returned value may
+ * not reflect the most up-to-date value, since changes from other processes arrive asynchronously.
+ *
+ * @param key The key of the value to retrieve
+ * @param defaultValue Returned when the key has no value. Omit to throw instead.
+ * @returns A cloned copy of the stored value, or `defaultValue` if the key has no value
+ * @throws If the key has no value and no `defaultValue` was provided
+ */
+function getAsync<K extends SharedStoreKeys>(key: K): Promise<SharedStoreValues[K]>;
+function getAsync<K extends SharedStoreKeys>(
+  key: K,
+  defaultValue: SharedStoreValues[K],
+): Promise<SharedStoreValues[K]>;
+async function getAsync<K extends SharedStoreKeys>(
+  key: K,
+  ...rest: [defaultValue?: SharedStoreValues[K]]
+): Promise<SharedStoreValues[K]> {
+  await waitForInitialization();
+  // Live value present — return a clone of it (which may legitimately be undefined). Use the
+  // throwing clone rather than `get`, so a serialize/deserialize failure rejects this promise
+  // instead of being silently swallowed as `undefined`.
+  if (hasValue(key)) return cloneStoredValue(key);
+  // No value at the key (absent or removed). `rest.length === 0` means no default was passed.
+  if (rest.length === 0)
+    throw new Error(`Shared store has no value for key "${key}" and no default value was provided`);
+  // rest[0] is typed `SharedStoreValues[K] | undefined` (optional tuple element); the public
+  // overloads guarantee a provided default is a valid SharedStoreValues[K].
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  return rest[0] as SharedStoreValues[K];
+}
+
+/**
+ * Set a value in the shared store, waiting for the shared store service to be initialized first.
+ *
+ * Unlike {@link set}, this waits (via {@link waitForInitialization}) until the shared store service
+ * has been initialized, then performs the set synchronously. See {@link set} for the per-key
+ * ownership and cloning semantics.
+ *
+ * If the shared store service is already initialized, the awaited promise is already settled, so
+ * execution continues here on the next microtask without yielding to timers or other queued
+ * macrotasks — effectively synchronous from the caller's perspective.
+ *
+ * @param key The key to set
+ * @param value The value to set
+ */
+async function setAsync<K extends SharedStoreKeys>(
+  key: K,
+  value?: SharedStoreValues[K],
+): Promise<void> {
+  await waitForInitialization();
+  set(key, value);
+}
+
+/**
+ * Remove a value from the shared store, waiting for the shared store service to be initialized
+ * first.
+ *
+ * Unlike {@link remove}, this waits (via {@link waitForInitialization}) until the shared store
+ * service has been initialized, then performs the removal synchronously.
+ *
+ * If the shared store service is already initialized, the awaited promise is already settled, so
+ * execution continues here on the next microtask without yielding to timers or other queued
+ * macrotasks — effectively synchronous from the caller's perspective.
+ *
+ * @param key The key to remove
+ */
+async function removeAsync<K extends SharedStoreKeys>(key: K): Promise<void> {
+  await waitForInitialization();
+  remove(key);
+}
+
+/**
+ * Returns `true` once {@link initialize} has fully completed (process ID assigned, emitter ready,
+ * and — outside the main process — initial store data synced). Used to distinguish "value genuinely
+ * absent" from "shared store not initialized yet" for optional reads that have a sensible default.
  */
 function isInitialized(): boolean {
-  return !!processId && !!storeChangeEmitter;
+  return isFullyInitialized;
 }
 
 /**
@@ -378,5 +528,8 @@ export const sharedStoreService = {
   get,
   set,
   remove,
+  getAsync,
+  setAsync,
+  removeAsync,
   isInitialized,
 };

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -9,7 +9,13 @@ import { logger } from '@shared/services/logger.service';
 import { ProcessType } from '@shared/global-this.model';
 
 const SHARED_STORE_PREFIX = 'shared-store';
-const STORE_GET_REQUEST = `${SHARED_STORE_PREFIX}:get`;
+/**
+ * Internal request type used by the shared store service to fetch the initial store contents during
+ * its own initialization. Exported so the network service's `doRequest` gate can identify this
+ * request and skip awaiting shared-store initialization on it (otherwise we'd deadlock: init awaits
+ * this request, the request awaits init).
+ */
+export const STORE_GET_REQUEST = `${SHARED_STORE_PREFIX}:get`;
 // The template literal widens to `string`; cast to the matching NetworkEvents key.
 // eslint-disable-next-line no-type-assertion/no-type-assertion
 const STORE_CHANGE_EVENT = `${SHARED_STORE_PREFIX}:change` as 'shared-store:change';
@@ -66,74 +72,95 @@ function compareClocks(x: LamportClock, y: LamportClock): number {
 // Create an event emitter to notify about store changes
 let storeChangeEmitter: PlatformEventEmitter<StoreChangeEvent> | undefined;
 
-// Cannot import the network service directly because it would create a circular dependency
+// Cannot import the network service directly at module scope because it would create a circular
+// dependency. The dynamic import inside `initialize` resolves at runtime after both modules have
+// loaded, which is safe.
 type NetworkService = typeof import('@shared/services/network.service');
 
 /**
- * Initialize the shared store service, setting up request handlers and event listeners. This
- * function should be called by each of our JS processes early during start up.
+ * In-flight initialization promise. Subsequent calls to {@link initialize} return this same promise
+ * so the function is idempotent.
+ */
+let initializationPromise: Promise<void> | undefined;
+
+/**
+ * Initialize the shared store service, setting up request handlers and event listeners. Idempotent:
+ * subsequent calls return the same promise as the first call. May be called from anywhere — the
+ * first caller from index.tsx may pass `networkService`; subsequent calls (e.g., from
+ * `network.service.doRequest` gating on shared-store readiness) need not.
  *
- * @param networkService The network service to use for communication between processes
+ * @param networkService Optional network service module. If omitted, it is loaded via dynamic
+ *   `import()` to break the static circular dependency.
  * @returns A promise that resolves when the service is initialized
  */
-export async function initialize(networkService: NetworkService): Promise<void> {
-  if (processId) throw new Error('Shared store service is already initialized');
-  // Generate a unique process ID for this process that still includes the process type
-  processId = `${globalThis.processType}-${Math.random().toString(36).substring(2, 10)}`;
-  logger.debug(`Initializing shared store service`);
+export function initialize(networkService?: NetworkService): Promise<void> {
+  if (initializationPromise) return initializationPromise;
+  initializationPromise = (async () => {
+    // Dynamic import breaks what would otherwise be a static circular dependency: network.service
+    // statically imports this module for the bootstrap gate in doRequest. The runtime cycle is
+    // safe because by the time this function runs, both modules have loaded their declarations.
+    // eslint-disable-next-line import/no-cycle
+    const ns: NetworkService = networkService ?? (await import('@shared/services/network.service'));
+    // Generate a unique process ID for this process that still includes the process type
+    processId = `${globalThis.processType}-${Math.random().toString(36).substring(2, 10)}`;
+    logger.debug(`Initializing shared store service`);
 
-  // Prepare to emit changes as they are made to the local store
-  storeChangeEmitter = await networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT);
+    // Prepare to emit changes as they are made to the local store
+    storeChangeEmitter = await ns.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT);
 
-  // Listen for changes from other processes to update the local store
-  networkService.getNetworkEvent<StoreChangeEvent>(STORE_CHANGE_EVENT)((event) => {
-    if (event.clock.processId !== processId) setFromRemote(event.key, event);
-  });
+    // Listen for changes from other processes to update the local store
+    ns.getNetworkEvent(STORE_CHANGE_EVENT)((event) => {
+      if (event.clock.processId !== processId) setFromRemote(event.key, event);
+    });
 
-  // Outside of the main process, sync the local store to the main store's data initially
-  if (globalThis.processType !== ProcessType.Main) {
-    try {
-      const initial: Record<string, StoreEntry> = await networkService.request(STORE_GET_REQUEST);
-      if (!initial) return;
-      Object.entries(initial).forEach(([key, entry]) => setFromRemote(key, entry));
-    } catch (error) {
-      logger.warn(`Error initializing local store: ${getErrorMessage(error)}`);
+    // Outside of the main process, sync the local store to the main store's data initially
+    if (globalThis.processType !== ProcessType.Main) {
+      try {
+        const initial: Record<string, StoreEntry> = await ns.request(STORE_GET_REQUEST);
+        if (!initial) return;
+        Object.entries(initial).forEach(([key, entry]) => setFromRemote(key, entry));
+      } catch (error) {
+        logger.warn(`Error initializing local store: ${getErrorMessage(error)}`);
+      }
     }
-  }
-  // Inside the main process, handle get requests to return data
-  else {
-    await networkService.registerRequestHandler(
-      STORE_GET_REQUEST,
-      (key?: string) => (key === undefined ? { ...localStore } : localStore[key]?.value),
-      {
-        method: {
-          summary: 'Get values from the shared store',
-          params: [
-            {
-              name: 'key',
-              required: false,
-              summary: 'The key of the value to retrieve (leave undefined to get the entire store)',
-              schema: { type: 'string' },
-            },
-          ],
-          result: {
-            name: 'return value',
-            summary: 'The value associated with the key, or the entire store if no key is provided',
-            schema: {
-              oneOf: [
-                { type: 'string' },
-                { type: 'number' },
-                { type: 'boolean' },
-                { type: 'object' },
-                { type: 'array' },
-                { type: 'null' },
-              ],
+    // Inside the main process, handle get requests to return data
+    else {
+      await ns.registerRequestHandler(
+        STORE_GET_REQUEST,
+        (key?: string) => (key === undefined ? { ...localStore } : localStore[key]?.value),
+        {
+          method: {
+            summary: 'Get values from the shared store',
+            params: [
+              {
+                name: 'key',
+                required: false,
+                summary:
+                  'The key of the value to retrieve (leave undefined to get the entire store)',
+                schema: { type: 'string' },
+              },
+            ],
+            result: {
+              name: 'return value',
+              summary:
+                'The value associated with the key, or the entire store if no key is provided',
+              schema: {
+                oneOf: [
+                  { type: 'string' },
+                  { type: 'number' },
+                  { type: 'boolean' },
+                  { type: 'object' },
+                  { type: 'array' },
+                  { type: 'null' },
+                ],
+              },
             },
           },
         },
-      },
-    );
-  }
+      );
+    }
+  })();
+  return initializationPromise;
 }
 
 /**
@@ -145,6 +172,7 @@ export function resetForTesting(): void {
   localCounter = 0;
   Object.keys(localStore).forEach((key) => delete localStore[key]);
   storeChangeEmitter = undefined;
+  initializationPromise = undefined;
 }
 
 /**

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -72,9 +72,9 @@ function compareClocks(x: LamportClock, y: LamportClock): number {
 // Create an event emitter to notify about store changes
 let storeChangeEmitter: PlatformEventEmitter<StoreChangeEvent> | undefined;
 
-// Cannot import the network service directly at module scope because it would create a circular
-// dependency. The dynamic import inside `initialize` resolves at runtime after both modules have
-// loaded, which is safe.
+// Type-only reference to the network service. Type-only imports are erased at compile time and do
+// not create a runtime cycle, so it's safe even though network.service statically imports from
+// this module.
 type NetworkService = typeof import('@shared/services/network.service');
 
 /**
@@ -84,39 +84,54 @@ type NetworkService = typeof import('@shared/services/network.service');
 let initializationPromise: Promise<void> | undefined;
 
 /**
+ * Resolved when {@link initialize} is first called (regardless of whether it has completed).
+ * {@link whenInitialized} awaits this to know when to start waiting on the actual init promise.
+ * Recreated by {@link resetForTesting} so each test starts with a fresh signal.
+ */
+let initializationStartedResolve: () => void;
+let initializationStartedPromise: Promise<void>;
+function resetInitializationStartedSignal(): void {
+  initializationStartedPromise = new Promise<void>((resolve) => {
+    initializationStartedResolve = resolve;
+  });
+}
+resetInitializationStartedSignal();
+
+/**
  * Initialize the shared store service, setting up request handlers and event listeners. Idempotent:
- * subsequent calls return the same promise as the first call. May be called from anywhere — the
- * first caller from index.tsx may pass `networkService`; subsequent calls (e.g., from
- * `network.service.doRequest` gating on shared-store readiness) need not.
+ * subsequent calls return the same promise as the first call, and the `networkService` argument is
+ * ignored on subsequent calls. The first caller (e.g., index.tsx during startup) MUST provide
+ * `networkService` — calling without one before any prior call throws, because shared-store cannot
+ * statically import the network service (it would create a circular dependency).
  *
- * @param networkService Optional network service module. If omitted, it is loaded via dynamic
- *   `import()` to break the static circular dependency.
+ * @param networkService The network service module. Required on the first call; ignored thereafter.
  * @returns A promise that resolves when the service is initialized
  */
-export function initialize(networkService?: NetworkService): Promise<void> {
+export function initialize(networkService: NetworkService): Promise<void> {
   if (initializationPromise) return initializationPromise;
+  if (!networkService)
+    throw new Error(
+      'Shared store service initialize() requires networkService on the first call. ' +
+        'Call this from the process bootstrap before any consumers (e.g., index.tsx).',
+    );
+  initializationStartedResolve();
   initializationPromise = (async () => {
-    // Dynamic import breaks what would otherwise be a static circular dependency: network.service
-    // statically imports this module for the bootstrap gate in doRequest. The runtime cycle is
-    // safe because by the time this function runs, both modules have loaded their declarations.
-    // eslint-disable-next-line import/no-cycle
-    const ns: NetworkService = networkService ?? (await import('@shared/services/network.service'));
     // Generate a unique process ID for this process that still includes the process type
     processId = `${globalThis.processType}-${Math.random().toString(36).substring(2, 10)}`;
     logger.debug(`Initializing shared store service`);
 
     // Prepare to emit changes as they are made to the local store
-    storeChangeEmitter = await ns.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT);
+    storeChangeEmitter = await networkService.createNetworkEventEmitterAsync(STORE_CHANGE_EVENT);
 
     // Listen for changes from other processes to update the local store
-    ns.getNetworkEvent(STORE_CHANGE_EVENT)((event) => {
+    networkService.getNetworkEvent(STORE_CHANGE_EVENT)((event) => {
       if (event.clock.processId !== processId) setFromRemote(event.key, event);
     });
 
     // Outside of the main process, sync the local store to the main store's data initially
     if (globalThis.processType !== ProcessType.Main) {
       try {
-        const initial: Record<string, StoreEntry> = await ns.request(STORE_GET_REQUEST);
+        const initial: Record<string, StoreEntry> = await networkService.request(STORE_GET_REQUEST);
         if (!initial) return;
         Object.entries(initial).forEach(([key, entry]) => setFromRemote(key, entry));
       } catch (error) {
@@ -125,7 +140,7 @@ export function initialize(networkService?: NetworkService): Promise<void> {
     }
     // Inside the main process, handle get requests to return data
     else {
-      await ns.registerRequestHandler(
+      await networkService.registerRequestHandler(
         STORE_GET_REQUEST,
         (key?: string) => (key === undefined ? { ...localStore } : localStore[key]?.value),
         {
@@ -164,6 +179,33 @@ export function initialize(networkService?: NetworkService): Promise<void> {
 }
 
 /**
+ * Wait for the shared store service to be ready.
+ *
+ * - If {@link initialize} has already been called, returns the existing in-flight promise (no timeout
+ *   — we wait as long as init takes).
+ * - If {@link initialize} has not been called yet, waits up to `startTimeoutMs` for it to start then
+ *   returns the resulting promise. If init never starts within that window, resolves anyway so the
+ *   caller can fall back to a default.
+ *
+ * Use this from code that benefits from but does not require accurate shared-store data — e.g.,
+ * `network.service.doRequest` gating its custom-timeout lookup. Code that requires accuracy should
+ * `await initialize(networkService)` instead, or fail loudly if shared store is not ready.
+ *
+ * @param startTimeoutMs Time to wait for initialize() to be called before giving up. Default 1000ms
+ *   — generous enough to cover normal bootstrap, short enough to avoid hanging requests when
+ *   initialize is never called.
+ */
+export async function whenInitialized(startTimeoutMs: number = 1000): Promise<void> {
+  if (initializationPromise) return initializationPromise;
+  const timeoutPromise = new Promise<'timeout'>((resolve) => {
+    setTimeout(() => resolve('timeout'), startTimeoutMs);
+  });
+  const startedPromise = initializationStartedPromise.then(() => 'started' as const);
+  const result = await Promise.race([startedPromise, timeoutPromise]);
+  if (result === 'started' && initializationPromise) return initializationPromise;
+}
+
+/**
  * Reset the shared store service state for testing. This function is only exported for testing
  * purposes and should not be used in production code.
  */
@@ -173,6 +215,7 @@ export function resetForTesting(): void {
   Object.keys(localStore).forEach((key) => delete localStore[key]);
   storeChangeEmitter = undefined;
   initializationPromise = undefined;
+  resetInitializationStartedSignal();
 }
 
 /**

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -148,13 +148,17 @@ export function resetForTesting(): void {
 }
 
 /**
- * Get a value from the shared store with proper typing
+ * Get a value from the shared store with proper typing.
+ *
+ * Returns `undefined` if the service has not yet completed initialization. This lets callers (e.g.,
+ * network-request timeout lookup) run during the bootstrap window without crashing.
  *
  * @param key The key of the value to retrieve
- * @returns A cloned copy of the value associated with the key, or undefined if not found
+ * @returns A cloned copy of the value associated with the key, or undefined if not found or if the
+ *   service is not yet initialized
  */
 function get<K extends SharedStoreKeys>(key: K): SharedStoreValues[K] | undefined {
-  if (!processId || !storeChangeEmitter) throw new Error('Shared store service is not initialized');
+  if (!processId || !storeChangeEmitter) return undefined;
   try {
     // Assert the specific type associated with this key
     // eslint-disable-next-line no-type-assertion/no-type-assertion

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -148,17 +148,13 @@ export function resetForTesting(): void {
 }
 
 /**
- * Get a value from the shared store with proper typing.
- *
- * Returns `undefined` if the service has not yet completed initialization. This lets callers (e.g.,
- * network-request timeout lookup) run during the bootstrap window without crashing.
+ * Get a value from the shared store with proper typing
  *
  * @param key The key of the value to retrieve
- * @returns A cloned copy of the value associated with the key, or undefined if not found or if the
- *   service is not yet initialized
+ * @returns A cloned copy of the value associated with the key, or undefined if not found
  */
 function get<K extends SharedStoreKeys>(key: K): SharedStoreValues[K] | undefined {
-  if (!processId || !storeChangeEmitter) return undefined;
+  if (!processId || !storeChangeEmitter) throw new Error('Shared store service is not initialized');
   try {
     // Assert the specific type associated with this key
     // eslint-disable-next-line no-type-assertion/no-type-assertion

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -10,7 +10,7 @@ import { ProcessType } from '@shared/global-this.model';
 
 const SHARED_STORE_PREFIX = 'shared-store';
 const STORE_GET_REQUEST = `${SHARED_STORE_PREFIX}:get`;
-// The template literal widens to `string`; cast to the matching NetworkEventTypes key.
+// The template literal widens to `string`; cast to the matching NetworkEvents key.
 // eslint-disable-next-line no-type-assertion/no-type-assertion
 const STORE_CHANGE_EVENT = `${SHARED_STORE_PREFIX}:change` as 'shared-store:change';
 

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -10,7 +10,9 @@ import { ProcessType } from '@shared/global-this.model';
 
 const SHARED_STORE_PREFIX = 'shared-store';
 const STORE_GET_REQUEST = `${SHARED_STORE_PREFIX}:get`;
-const STORE_CHANGE_EVENT = 'shared-store:change';
+// The template literal widens to `string`; cast to the matching NetworkEventTypes key.
+// eslint-disable-next-line no-type-assertion/no-type-assertion
+const STORE_CHANGE_EVENT = `${SHARED_STORE_PREFIX}:change` as 'shared-store:change';
 
 // https://en.wikipedia.org/wiki/Lamport_timestamp
 let localCounter: number = 0;

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -99,21 +99,13 @@ resetInitializationStartedSignal();
 
 /**
  * Initialize the shared store service, setting up request handlers and event listeners. Idempotent:
- * subsequent calls return the same promise as the first call, and the `networkService` argument is
- * ignored on subsequent calls. The first caller (e.g., index.tsx during startup) MUST provide
- * `networkService` — calling without one before any prior call throws, because shared-store cannot
- * statically import the network service (it would create a circular dependency).
+ * subsequent calls return the same promise as the first call.
  *
- * @param networkService The network service module. Required on the first call; ignored thereafter.
+ * @param networkService The network service module.
  * @returns A promise that resolves when the service is initialized
  */
 export function initialize(networkService: NetworkService): Promise<void> {
   if (initializationPromise) return initializationPromise;
-  if (!networkService)
-    throw new Error(
-      'Shared store service initialize() requires networkService on the first call. ' +
-        'Call this from the process bootstrap before any consumers (e.g., index.tsx).',
-    );
   initializationStartedResolve();
   initializationPromise = (async () => {
     // Generate a unique process ID for this process that still includes the process type
@@ -184,25 +176,28 @@ export function initialize(networkService: NetworkService): Promise<void> {
  * - If {@link initialize} has already been called, returns the existing in-flight promise (no timeout
  *   — we wait as long as init takes).
  * - If {@link initialize} has not been called yet, waits up to `startTimeoutMs` for it to start then
- *   returns the resulting promise. If init never starts within that window, resolves anyway so the
- *   caller can fall back to a default.
+ *   returns the resulting promise.
  *
- * Use this from code that benefits from but does not require accurate shared-store data — e.g.,
- * `network.service.doRequest` gating its custom-timeout lookup. Code that requires accuracy should
- * `await initialize(networkService)` instead, or fail loudly if shared store is not ready.
+ * Throws if {@link initialize} never starts within `startTimeoutMs`. Callers that can tolerate the
+ * absence of a ready shared store should catch and fall back.
  *
- * @param startTimeoutMs Time to wait for initialize() to be called before giving up. Default 1000ms
+ * @param startTimeoutMs Time to wait for initialize() to be called before throwing. Default 1000ms
  *   — generous enough to cover normal bootstrap, short enough to avoid hanging requests when
  *   initialize is never called.
+ * @throws If initialize() does not start within `startTimeoutMs`.
  */
-export async function whenInitialized(startTimeoutMs: number = 1000): Promise<void> {
+export async function waitForInitialization(startTimeoutMs: number = 1000): Promise<void> {
   if (initializationPromise) return initializationPromise;
   const timeoutPromise = new Promise<'timeout'>((resolve) => {
     setTimeout(() => resolve('timeout'), startTimeoutMs);
   });
   const startedPromise = initializationStartedPromise.then(() => 'started' as const);
   const result = await Promise.race([startedPromise, timeoutPromise]);
-  if (result === 'started' && initializationPromise) return initializationPromise;
+  if (result === 'timeout' || !initializationPromise)
+    throw new Error(
+      `Shared store service initialize() was not called within ${startTimeoutMs}ms — caller cannot wait for readiness.`,
+    );
+  return initializationPromise;
 }
 
 /**

--- a/src/shared/services/shared-store.service.ts
+++ b/src/shared/services/shared-store.service.ts
@@ -220,6 +220,16 @@ function remove<K extends SharedStoreKeys>(key: K): void {
 }
 
 /**
+ * Returns `true` once {@link initialize} has fully completed. Use this to gate optional reads of the
+ * shared store from code that may run during the bootstrap window — e.g., network-request timeout
+ * lookups that have a sensible default. Required reads of the shared store should `await
+ * initialize` instead so the value is guaranteed accurate per the Lamport-clock contract.
+ */
+function isInitialized(): boolean {
+  return !!processId && !!storeChangeEmitter;
+}
+
+/**
  * Keys for timeout lengths for network requests. Keys are dynamically constructed by adding this
  * prefix to the `requestType`.
  */
@@ -255,4 +265,5 @@ export const sharedStoreService = {
   get,
   set,
   remove,
+  isInitialized,
 };

--- a/src/shared/services/web-view-provider.service.ts
+++ b/src/shared/services/web-view-provider.service.ts
@@ -99,7 +99,8 @@ function hasKnownWebViewProvider(webViewType: string): boolean {
  *   of it.
  *
  *   WARNING: setting a webView provider mutates the provided object.
- * @param attributes Optional additional attributes to attach to the network object
+ * @param attributes Optional additional attributes to attach to the network object. The platform
+ *   overwrites the `webViewType` field — that field is always the platform-canonical value.
  * @param documentation Optional {@link NetworkObjectDocumentation} for this web view provider. Set
  *   `documentation['x-experimental']: true` to mark all methods on this web view provider as
  *   experimental.
@@ -146,7 +147,8 @@ async function registerWebViewProvider(
     webViewProviderObjectId,
     webViewProvider,
     WEB_VIEW_PROVIDER_OBJECT_TYPE,
-    { webViewType, ...attributes },
+    // Spread caller attributes first, then overlay canonical webViewType (platform always wins).
+    { ...attributes, webViewType },
     documentation,
   );
 

--- a/src/shared/services/web-view-provider.service.ts
+++ b/src/shared/services/web-view-provider.service.ts
@@ -100,7 +100,9 @@ function hasKnownWebViewProvider(webViewType: string): boolean {
  *
  *   WARNING: setting a webView provider mutates the provided object.
  * @param attributes Optional additional attributes to attach to the network object
- * @param documentation Optional OpenRPC-style documentation for the network object
+ * @param documentation Optional {@link NetworkObjectDocumentation} for this web view provider. Set
+ *   `documentation['x-experimental']: true` to mark all methods on this web view provider as
+ *   experimental.
  * @returns `webViewProvider` modified to be a network object and able to be disposed with `dispose`
  */
 async function registerWebViewProvider(

--- a/src/shared/services/web-view-provider.service.ts
+++ b/src/shared/services/web-view-provider.service.ts
@@ -8,6 +8,7 @@ import {
   IWebViewProvider,
   IRegisteredWebViewProvider,
 } from '@shared/models/web-view-provider.model';
+import type { NetworkObjectDocumentation } from '@shared/models/openrpc.model';
 import { networkObjectService, overrideDispose } from '@shared/services/network-object.service';
 import * as networkService from '@shared/services/network.service';
 import { logger } from '@shared/services/logger.service';
@@ -98,11 +99,15 @@ function hasKnownWebViewProvider(webViewType: string): boolean {
  *   of it.
  *
  *   WARNING: setting a webView provider mutates the provided object.
+ * @param attributes Optional additional attributes to attach to the network object
+ * @param documentation Optional OpenRPC-style documentation for the network object
  * @returns `webViewProvider` modified to be a network object and able to be disposed with `dispose`
  */
 async function registerWebViewProvider(
   webViewType: string,
   webViewProvider: IWebViewProvider,
+  attributes?: { [property: string]: unknown },
+  documentation?: NetworkObjectDocumentation,
 ): Promise<IDisposableWebViewProvider> {
   await initialize();
 
@@ -139,7 +144,8 @@ async function registerWebViewProvider(
     webViewProviderObjectId,
     webViewProvider,
     WEB_VIEW_PROVIDER_OBJECT_TYPE,
-    { webViewType },
+    { webViewType, ...attributes },
+    documentation,
   );
 
   return disposableWebViewProvider;

--- a/src/shared/services/web-view.service-model.ts
+++ b/src/shared/services/web-view.service-model.ts
@@ -215,6 +215,9 @@ export async function getWebViewController<WebViewType extends WebViewController
 }
 
 /** @deprecated 13 November 2024. Renamed to {@link EVENT_NAME_ON_DID_OPEN_WEB_VIEW} */
+// serializeRequestType returns SerializedRequestType (an opaque branded string), but we know the
+// actual value matches this NetworkEvents key. Cast to the literal so consumers can use this
+// constant directly without re-casting at every usage site.
 // eslint-disable-next-line no-type-assertion/no-type-assertion
 export const EVENT_NAME_ON_DID_ADD_WEB_VIEW = serializeRequestType(
   CATEGORY_WEB_VIEW,
@@ -222,6 +225,9 @@ export const EVENT_NAME_ON_DID_ADD_WEB_VIEW = serializeRequestType(
 ) as 'webView:onDidAddWebView';
 
 /** Name to use when creating a network event that is fired when webViews are created */
+// serializeRequestType returns SerializedRequestType (an opaque branded string), but we know the
+// actual value matches this NetworkEvents key. Cast to the literal so consumers can use this
+// constant directly without re-casting at every usage site.
 // eslint-disable-next-line no-type-assertion/no-type-assertion
 export const EVENT_NAME_ON_DID_OPEN_WEB_VIEW = serializeRequestType(
   CATEGORY_WEB_VIEW,
@@ -235,6 +241,9 @@ export type OpenWebViewEvent = {
 };
 
 /** Name to use when creating a network event that is fired when webViews are updated */
+// serializeRequestType returns SerializedRequestType (an opaque branded string), but we know the
+// actual value matches this NetworkEvents key. Cast to the literal so consumers can use this
+// constant directly without re-casting at every usage site.
 // eslint-disable-next-line no-type-assertion/no-type-assertion
 export const EVENT_NAME_ON_DID_UPDATE_WEB_VIEW = serializeRequestType(
   CATEGORY_WEB_VIEW,
@@ -247,6 +256,9 @@ export type UpdateWebViewEvent = {
 };
 
 /** Name to use when creating a network event that is fired when webViews are closed */
+// serializeRequestType returns SerializedRequestType (an opaque branded string), but we know the
+// actual value matches this NetworkEvents key. Cast to the literal so consumers can use this
+// constant directly without re-casting at every usage site.
 // eslint-disable-next-line no-type-assertion/no-type-assertion
 export const EVENT_NAME_ON_DID_CLOSE_WEB_VIEW = serializeRequestType(
   CATEGORY_WEB_VIEW,

--- a/src/shared/services/web-view.service-model.ts
+++ b/src/shared/services/web-view.service-model.ts
@@ -215,16 +215,18 @@ export async function getWebViewController<WebViewType extends WebViewController
 }
 
 /** @deprecated 13 November 2024. Renamed to {@link EVENT_NAME_ON_DID_OPEN_WEB_VIEW} */
+// eslint-disable-next-line no-type-assertion/no-type-assertion
 export const EVENT_NAME_ON_DID_ADD_WEB_VIEW = serializeRequestType(
   CATEGORY_WEB_VIEW,
   'onDidAddWebView',
-);
+) as 'webView:onDidAddWebView';
 
 /** Name to use when creating a network event that is fired when webViews are created */
+// eslint-disable-next-line no-type-assertion/no-type-assertion
 export const EVENT_NAME_ON_DID_OPEN_WEB_VIEW = serializeRequestType(
   CATEGORY_WEB_VIEW,
   'onDidOpenWebView',
-);
+) as 'webView:onDidOpenWebView';
 
 /** Event emitted when webViews are created */
 export type OpenWebViewEvent = {
@@ -233,10 +235,11 @@ export type OpenWebViewEvent = {
 };
 
 /** Name to use when creating a network event that is fired when webViews are updated */
+// eslint-disable-next-line no-type-assertion/no-type-assertion
 export const EVENT_NAME_ON_DID_UPDATE_WEB_VIEW = serializeRequestType(
   CATEGORY_WEB_VIEW,
   'onDidUpdateWebView',
-);
+) as 'webView:onDidUpdateWebView';
 
 /** Event emitted when webViews are updated */
 export type UpdateWebViewEvent = {
@@ -244,10 +247,11 @@ export type UpdateWebViewEvent = {
 };
 
 /** Name to use when creating a network event that is fired when webViews are closed */
+// eslint-disable-next-line no-type-assertion/no-type-assertion
 export const EVENT_NAME_ON_DID_CLOSE_WEB_VIEW = serializeRequestType(
   CATEGORY_WEB_VIEW,
   'onDidCloseWebView',
-);
+) as 'webView:onDidCloseWebView';
 
 /** Event emitted when webViews are closed */
 export type CloseWebViewEvent = {

--- a/src/shared/services/web-view.service.ts
+++ b/src/shared/services/web-view.service.ts
@@ -1,30 +1,21 @@
-import { PlatformEvent, createSyncProxyForAsyncObject } from 'platform-bible-utils';
+import { createSyncProxyForAsyncObject } from 'platform-bible-utils';
 import { getNetworkEvent } from '@shared/services/network.service';
 import {
-  OpenWebViewEvent,
   EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
   EVENT_NAME_ON_DID_OPEN_WEB_VIEW,
   EVENT_NAME_ON_DID_UPDATE_WEB_VIEW,
   NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
-  CloseWebViewEvent,
-  UpdateWebViewEvent,
   WebViewServiceType,
   getWebViewController,
 } from '@shared/services/web-view.service-model';
 import { networkObjectService } from '@shared/services/network-object.service';
 import { networkObjectStatusService } from './network-object-status.service';
 
-const onDidOpenWebView: PlatformEvent<OpenWebViewEvent> = getNetworkEvent<OpenWebViewEvent>(
-  EVENT_NAME_ON_DID_OPEN_WEB_VIEW,
-);
+const onDidOpenWebView = getNetworkEvent(EVENT_NAME_ON_DID_OPEN_WEB_VIEW);
 
-const onDidUpdateWebView: PlatformEvent<UpdateWebViewEvent> = getNetworkEvent<UpdateWebViewEvent>(
-  EVENT_NAME_ON_DID_UPDATE_WEB_VIEW,
-);
+const onDidUpdateWebView = getNetworkEvent(EVENT_NAME_ON_DID_UPDATE_WEB_VIEW);
 
-const onDidCloseWebView: PlatformEvent<CloseWebViewEvent> = getNetworkEvent<CloseWebViewEvent>(
-  EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
-);
+const onDidCloseWebView = getNetworkEvent(EVENT_NAME_ON_DID_CLOSE_WEB_VIEW);
 
 let networkObject: WebViewServiceType;
 let initializationPromise: Promise<void>;


### PR DESCRIPTION
## 📖 Companion Wiki Page

A user-facing **Experimental APIs** wiki page was created for this feature on branch **`docs/experimental-apis-page`** in the [`paranext-extension-template.wiki`](https://github.com/paranext/paranext-extension-template/wiki) repo. That branch has two commits:

1. **Add `Experimental-APIs.md`** (+ a sidebar link under *Platform.Bible APIs*) — the canonical user-facing reference for the experimental marker.
2. **Update `PAPI.md`** — replaces the old `createNetworkEventEmitter` / `getNetworkEvent<T>` instructions with the new `createNetworkEventEmitterAsync` + inferred-`getNetworkEvent` (central-registration) model, and links to the new page.

> ⚠️ GitHub wikis only render their **default (`master`) branch**, so `docs/experimental-apis-page` must be merged into `master` to go live. The `openrpc.model.ts` `x-experimental` TSDoc links to this page's eventual URL: `https://github.com/paranext/paranext-extension-template/wiki/Experimental-APIs`.

<details>
<summary><b>📄 New wiki page — <code>Experimental-APIs.md</code> (click to expand)</b></summary>

# Experimental APIs in Platform.Bible

This page explains what "experimental" means for a Platform.Bible API, how to recognize one, and how to mark one when you're authoring an API yourself.

## What does experimental mean

An API marked **experimental** is one whose shape is not yet considered stable enough to depend on. It may change or be removed in any future release without following semantic versioning. The marker is informational only: experimental APIs behave identically to stable ones at runtime — nothing is gated, no consent is required.

Mark an API experimental whenever it is not a confident, solid, general-purpose contract. Specifically:

- APIs designed for one particular UI or use case rather than a broad audience.
- APIs whose shape is likely to change as you learn how they're used.
- APIs added to unblock a feature without long-term-suitability review.
- APIs not yet covered by tests in a meaningful way.

When the API has stabilized and earned confidence, remove the experimental marker. Promote out of experimental deliberately, not by accident.

## Recognizing experimental APIs

Two ways:

**In your editor.** Hover over an API in TypeScript and look for the `@experimental` tag in the docstring. Members of an interface marked `@experimental` inherit the marker — every method on an experimental type is itself experimental in the generated documentation. (TypeDoc 0.28.3+ treats `@experimental` as a built-in modifier tag and cascades it to members automatically — no configuration needed.)

**At runtime.** Inspect the live OpenRPC document (call the `rpc.discover` JSON-RPC method against the platform's WebSocket on port 8876). Experimental methods, notifications, and network objects carry `"x-experimental": true`.

## Marking an API experimental — by surface

For each surface there are two complementary places to apply the marker: the TypeScript types (so IDE consumers see it) and the registration call's documentation (so the OpenRPC document reflects it). Apply both whenever you can.

### Commands

```typescript
declare module 'papi-shared-types' {
  export interface CommandHandlers {
    /** @experimental */
    'myExt.expCmd': (arg: string) => Promise<void>;
  }
}

await papi.commands.registerCommand('myExt.expCmd', handler, {
  method: {
    'x-experimental': true,
    summary: 'Does the experimental thing',
    params: [{ name: 'arg', schema: { type: 'string' } }],
    result: { name: 'returns', schema: { type: 'null' } },
  },
});
```

### Network objects

`networkObjectService.set` already accepts a `NetworkObjectDocumentation` parameter. Setting `'x-experimental': true` at the top level fans out to every method exposed by the object — no need to mark each method individually.

```typescript
await papi.networkObjects.set('myObj', impl, 'object', /* attributes */ undefined, {
  'x-experimental': true,
});
```

To mark only a specific method on the object, set it on that method's entry in `documentation.methods[]` instead of at the top level.

### Data providers

Data providers are network objects underneath, so the same fanout applies. The documentation parameter is new — pass it as `NetworkObjectDocumentation`:

```typescript
await papi.dataProviders.registerEngine('myDP', engine, dataTypes, attributes, {
  'x-experimental': true,
});
```

### WebView providers

```typescript
await papi.webViewProviders.registerWebViewProvider(
  'myView',
  provider,
  /* attributes */ undefined,
  /* documentation */ { 'x-experimental': true },
);
```

Marking a WebView provider experimental implies the provider's WebView state shape and `getWebView` options shape are also experimental. There's no per-property granularity for state/options at this level — graduate the whole provider out of experimental when ready.

### Project data providers

PDPs need marking in two places: the `projectInterfaces` declaration (TypeScript) and the registration call (wire).

```typescript
declare module 'papi-shared-types' {
  export interface ProjectDataProviderInterfaces {
    /** @experimental */
    'myExt.expInterface': IProjectDataProvider<MyDataTypes>;
  }
}

await papi.projectDataProviders.registerProjectDataProviderEngineFactory(
  'myExt.expFactory',
  ['myExt.expInterface'],
  factory,
  /* attributes */ {},
  /* documentation */ { 'x-experimental': true },
);
```

`registerProjectDataProviderEngineFactory` lets you specify both registration-level attributes and per-PDP-instance attributes (the latter via the return value of `createProjectDataProviderEngine`). The platform overlays canonical `projectInterfaces` and `projectId` over whatever you supply — those fields cannot be overridden through attributes.

For per-PDP-instance customization, the factory's `createProjectDataProviderEngine` method can return `{ projectDataProviderEngine, attributes?, documentation? }` instead of just the engine. The unusual property name (`projectDataProviderEngine` rather than `engine`) is deliberate — it cannot accidentally collide with a property an engine itself exposes, so the platform's narrowing check on the return value is unambiguous.

### Network events

Declare your event in the `NetworkEvents` interface and create the emitter — the payload type is inferred from the registry, and the platform handles registration uniformly.

```typescript
declare module 'papi-shared-types' {
  export interface NetworkEvents {
    /** @experimental */
    'myExt.somethingHappened': { foo: string };
  }
}

const emitter = await papi.network.createNetworkEventEmitterAsync('myExt.somethingHappened', {
  notification: {
    'x-experimental': true,
    summary: 'Fires when something experimental happens',
    params: [
      { name: 'event', schema: { type: 'object', properties: { foo: { type: 'string' } } } },
    ],
  },
});
// emitter is PlatformEventEmitter<{ foo: string }> — the payload type is inferred
```

If any other process tries to register the same event name, the platform rejects the second registration. Each event has exactly one source.

Subscribing is symmetric — pass the same name, no explicit type parameter needed:

```typescript
papi.network.getNetworkEvent('myExt.somethingHappened')((event) => {
  // event is { foo: string } — inferred from the registry
});
```

#### Subscribing to platform events

A small set of platform infrastructure events (network-object lifecycle, shared-store changes) are emitted from every process that hosts the corresponding service. These are declared in `MultiSourceNetworkEvents`, which `NetworkEvents` inherits from, so they show up in IntelliSense alongside extension-declared events. As a subscriber, you don't need to know which events are multi-source — `getNetworkEvent` handles both the same way.

The platform owns this list; extensions don't author multi-source events. If you ever find yourself wanting a single name emitted from multiple processes (rare), you can either:

1. Pick the more natural pattern: each process emits its own distinctly-named event (`myExt.fromMain.thing`, `myExt.fromExtHost.thing`) and subscribers listen to whichever they care about.
2. Open a platform issue describing the use case — the shared-event surface is intentionally small.

#### Deprecated sync API

The synchronous `createNetworkEventEmitter` is deprecated as of 8 June 2026. It continues to function but does not participate in central event registration, so events created via the sync API:

- Are invisible in the OpenRPC document.
- Cannot be marked as experimental on the wire.
- Don't enforce the "single registrant per event name" guarantee.

Migrate new code to `createNetworkEventEmitterAsync`.

The legacy `getNetworkEvent<T>(name)` overload that takes an explicit type parameter is also deprecated — IntelliSense will show strikethrough on calls that resolve to it. Migrate by declaring your event in `NetworkEvents` and dropping the explicit `<T>`:

```typescript
// Before (deprecated)
const ev = papi.network.getNetworkEvent<MyType>('myExt.somethingHappened');

// After
declare module 'papi-shared-types' {
  export interface NetworkEvents {
    'myExt.somethingHappened': MyType;
  }
}
const ev = papi.network.getNetworkEvent('myExt.somethingHappened');
```

If your event name is dynamic (e.g., per-instance data-provider events that include an object id), the deprecated explicit-`<T>` overload remains functional — suppress the warning at the call site with a brief comment explaining why a static declaration isn't possible.

### Menu extensibility

Mark an extension point (a column, group, or whole WebView menu) experimental so other extensions know not to depend on its shape:

```jsonc
{
  "columns": {
    "myExt.myColumn": {
      "label": "%myColumn.label%",
      "order": 1,
      "isExtensible": true,
      "isExperimental": true,
    },
  },
}
```

Available on `OrderedExtensibleContainer` (columns, groups), `ColumnsWithHeaders`, and `WebViewMenu`. Extensions reading menu data should check `isExperimental` before contributing to it.

## Encoding reference

Three field-name conventions show up across the surfaces — each follows the surrounding code style:

| Where you see it                         | Field                    |
| ---------------------------------------- | ------------------------ |
| TSDoc tag in `.ts` source                | `@experimental`          |
| OpenRPC document (over the wire)         | `"x-experimental": true` |
| Menus model JSON                         | `"isExperimental": true` |
| Internal TypeScript registration options | `isExperimental: true`   |

You write all of them; nothing is auto-extracted. The TSDoc tag is for IDE/documentation consumers. The OpenRPC field is for runtime tooling that reads the live document. The menus field is data on a menu contribution that other extensions can read.

## What experimental does NOT do

- It does **not** prevent extensions from calling the API.
- It does **not** require any opt-in or manifest acknowledgement.
- It does **not** emit runtime warnings when called.
- It does **not** affect the generated `papi.d.ts` types beyond rendering the tag in TypeDoc HTML.

The marker is purely informational — its purpose is to set expectations, not to enforce them.

## When to graduate an API out of experimental

Once the API has:

- Settled on a stable shape that hasn't needed change in some time.
- Meaningful test coverage exercising its real use.
- Demonstrated suitability for a broader audience than the original use case.

Remove the `@experimental` TSDoc tag from the type declaration. Remove the `'x-experimental'` field from the registration documentation. Note the promotion in the changelog or release notes so consumers see the API has stabilized.

## See also

- **`@deprecated` convention** — the sibling marker for APIs being phased out. Format: `/** @deprecated 3 December 2024. Renamed to X. */` — a date plus the reason.
- **Migrating event emitters to the async API** — replace `createNetworkEventEmitter` with `await createNetworkEventEmitterAsync`. Module-level emitter constants become `let` bindings assigned inside an `initialize` function, with accessor logic that handles the not-yet-initialized case. See [PAPI](PAPI) for the network event APIs.

</details>

---

## Summary

Introduces a uniform `experimental` marker for PAPI APIs that surfaces on both the TypeScript types (`@experimental` TSDoc modifier tag) and the live OpenRPC document over the WebSocket (`x-experimental: true` vendor extension field). Applies to every PAPI surface: commands, network objects, data providers, project data providers, WebView providers, network events, and extensible menu features.

As a side benefit, network events become first-class in the OpenRPC document via a new `createNetworkEventEmitterAsync` with central registration. The sync `createNetworkEventEmitter` is deprecated but unchanged.

The marker is informational only — no runtime gate, no manifest opt-in. The wiki page in this PR is the canonical user-facing reference (will be published once this lands); the design spec and plan are kept for reviewers and will be deleted in a follow-up.

## Changes

**Foundational types**
- `OpenRpcNotification` type + `x-experimental` field on `Method`, `NetworkObjectDocumentation`; `OpenRpc.methods` widened to `(Method | OpenRpcNotification)[]`
- `SharedNetworkEventTypes` (closed alias) + augmentable `NetworkEventTypes` interface (extends shared)
- `isExperimental?: boolean` on menus model (`OrderedExtensibleContainer`, `ColumnsWithHeaders`, `WebViewMenu`) + matching JSON schema entries

**Foundational runtime**
- `SHARED_EVENT_NAMES` constant with sync-check test
- `REGISTER_EVENT` RPC plumbing — `RpcEventRegistry` class, listener field, server methods, client request
- `createNetworkEventEmitterAsync` (new) + `@deprecated` tag on sync `createNetworkEventEmitter`
- `getNetworkEvent` typed overload + deprecated explicit-`<T>` fallback
- Notifications surfaced in `generateOpenRpcSchema()`

**Registration surfaces**
- `x-experimental` fanout from object-level docs onto every method in `networkObjectService.set`
- New `documentation` parameter on `dataProviderService.registerEngine`/`registerEngineByType`
- New `attributes` + `documentation` parameters on `webViewProviderService.registerWebViewProvider`
- PDP factory: registration-level `attributes`/`documentation`; augmented `createProjectDataProviderEngine` return shape with `projectDataProviderEngine` discriminator for per-PDP customization

**Event migration (25 sites)**
- 3 platform-shared events (network-object lifecycle, shared-store change) declared in `SharedNetworkEventTypes`
- 22 exclusive events declared in `NetworkEventTypes` (core platform + 2 extensions: hello-rock3, platform-scripture-editor)
- Module-level emitters refactored to lazy-init pattern with throw-if-not-initialized accessors (web-view.service-host, scroll-group, check-aggregator)
- Data-provider per-instance emitter uses double-assertion escape hatch for its dynamic name

## AI Involvement

**Level**: generated

This work was driven end-to-end by an AI agent in auto mode:
- Brainstorming and design (multi-round Q&A producing `docs/superpowers/specs/2026-06-08-experimental-api-flag-design.md` and the companion wiki page)
- Implementation plan (`docs/superpowers/plans/2026-06-08-experimental-api-flag.md`) covering 22 tasks
- Implementation via subagent dispatches per task, with the controller doing context curation, review, and integration

Human author iterated extensively on the design via course corrections during brainstorming (sharded/exclusive event split, type registry shape, factory return discriminator name, wire-name regression catch). Implementation was reviewed during execution; the design spec and plan capture the final agreed shape.

## Testing

- [x] Unit tests pass (typecheck clean; targeted Vitest runs across affected modules pass)
- [x] No new lint errors introduced
- [x] `papi.d.ts` regenerated cleanly with `x-experimental` and `@experimental` propagated
- [ ] Manual smoke test of an experimental API end-to-end (e.g., register an experimental command, verify it appears in OpenRPC) — recommended before merge

## Risk Level

**Medium** — Changes are additive and non-breaking by design (existing sync APIs preserved with deprecation tags; new parameters are optional). The work does touch foundational network/RPC plumbing and migrates 25 emitter call sites, so the surface area is broad.

Specific risks worth reviewing:

- **Wire-name conventions for shared events.** During migration an implementer attempted to canonicalize wire names (e.g., `'object:onDidCreateNetworkObject'` → `'network-object.onDidCreateNetworkObject'`). This was caught and reverted to preserve the original wire protocol. Worth double-checking the three shared event wire names are unchanged.
- **WebView lifecycle lazy-init.** The 4 module-level emitters in `web-view.service-host.ts` were converted to lazy-init `let` bindings. Accessors throw if invoked before `initialize()`. A regression where a module-level subscription called the accessor too early was caught and fixed (subscription moved into `initialize`).
- **PDP factory return shape change.** New union return for `createProjectDataProviderEngine`. Existing factories that return the engine directly continue to compile and work; the envelope form is opt-in.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2380)
<!-- Reviewable:end -->


---

<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: tjc/experimental-api-flag

**Base**: origin/ai/main

**Date**: 2026-06-11

**Review model**: Claude Opus 4.8

**Files changed**: 49

## Overview

This branch adds a way to flag APIs as **experimental** across both the TypeScript PAPI (`@experimental` TSDoc) and the OpenRPC PAPI (`'x-experimental': true` on the wire), spanning all seven PAPI surfaces (commands, network objects, data providers, project data providers, WebView providers, network events, and menu extension points). To make network events flaggable, events were reworked to be **centrally registered** with the main process via a new `RpcEventRegistry` and the new async `createNetworkEventEmitterAsync` API — central registration both surfaces events in the live OpenRPC document (so non-TypeScript clients can see experimental flags) and enforces event exclusivity (the registering process owns the event name, preventing impersonation). The sync `createNetworkEventEmitter` and the explicit-`<T>` `getNetworkEvent` overload are deprecated (non-breaking). The branch also partially reworks the shared store service so reads can wait for initialization (`waitForInitialization`), with the author noting more shared-store work remains for a future PR.

During review, several gaps were fixed in-place (see Findings), an API-surface asymmetry was corrected (undocumented events are now surfaced in OpenRPC like undocumented methods), all centrally-registered events were given OpenRPC documentation transcribed from their TSDocs, and the companion wiki documentation was created/updated.

## API Changes

- **`@papi/core`** (`papi-core.service.ts`): added re-exports `SingleNotificationDocumentation`, `StoreChangeEvent`, `ScrollGroupUpdateInfo`, `OpenWebViewEvent`, `UpdateWebViewEvent`, `CloseWebViewEvent` (the last six added during review for parity so developers can name network-event payload/doc types).
- **`papi.network`** (`PapiNetworkService`, via `@papi/backend` and `@papi/frontend`): added `createNetworkEventEmitterAsync(eventType, documentation?)`; added a typed `getNetworkEvent<EventType extends NetworkEventTypes>(eventType)` overload; the original `createNetworkEventEmitter` and untyped `getNetworkEvent<T>(eventType: string)` are retained as `@deprecated`.
- **`papi-shared-types`** (public augmentable surface): added `NetworkEvents`, `MultiSourceNetworkEvents`, `NetworkEventTypes`. Platform events (`webView:onDid*`, `scrollGroup:onDidUpdateScrRef`, `platform.onDidReloadExtensions`, `object:onDid*`, `shared-store:change`) are declared here.
- **`shared/models/openrpc.model`** (partly re-exported via `@papi/core`): added `Notification`, `SingleNotificationDocumentation`, `NetworkObjectDocumentation['x-experimental']`, `Method['x-experimental']`; `OpenRpc.methods` widened from `Method[]` to `(Method | Notification)[]`; added `getEmptyNotificationDocs()` (review). Placeholder descriptions are now prefixed `Method:` / `Notification:` (review).
- **Registration signatures** (`@papi/backend`): added optional `attributes?` and/or `documentation?: NetworkObjectDocumentation` trailing params to `registerEngine`/`registerEngineByType`, `registerWebViewProvider`, and `registerProjectDataProviderEngineFactory`; `IProjectDataProviderEngineFactory.createProjectDataProviderEngine` return type widened to allow an envelope `{ projectDataProviderEngine, attributes?, documentation? }`. All additive/optional.
- **`lib/platform-bible-utils`** (`menus.model.ts`): added optional `isExperimental?: boolean` to `OrderedExtensibleContainer`, `ColumnsWithHeaders`, `WebViewMenu` (+ JSON schema). Additive.
- **Behavior change (review):** `generateOpenRpcSchema` now surfaces **every** registered event (undocumented ones get a placeholder), matching how methods are handled. Previously undocumented events were omitted.
- **Behavior change (review):** in the generated OpenRPC document, experimental methods and notifications now get `[EXPERIMENTAL] ` prepended to their `summary` and `description` (via the new `withExperimentalPrefix` helper in `openrpc.model.ts`), so the marker is visible to humans reading the document, not just tooling reading the `x-experimental` field. A missing/empty summary or description on an experimental entry still receives the bare prefix so the flag is never lost.
- **Review:** the shared store's `shared-store:get` request and `shared-store:change` event are now marked `'x-experimental': true`, flagging that internal surface as unstable.
- Extension `.d.ts` augmentations added for `helloRock3.onHelloRock3`, `platformScriptureEditor.onDidSelectionChange`, `platformScripture` check/checklist events.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **`SingleNotificationDocumentation` was not re-exported from any `@papi/` module**, so extension developers could not type the `documentation` arg of `createNetworkEventEmitterAsync` — the core purpose of the feature. _(fixed during review: added to the `@papi/core` re-export block in `papi-core.service.ts`; regenerated `papi.d.ts`.)_
- [x] **`waitForInitialization` used `await Promise.race([…, wait(startTimeoutMs)])` for its timeout**, which the decision registry (`patterns.asyncCoordination`) lists under `notAllowed`, prescribing `AsyncVariable` instead. _(fixed during review: converted to a per-call `AsyncVariable` whose built-in timeout is measured from the call, preserving the original per-call semantics; the one-shot "started" signal is kept as it is a signal, not a timeout. All shared-store tests pass.)_
- [x] **`web-view-provider.service.ts` attribute merge `{ webViewType, ...attributes }` let a caller override the canonical `webViewType`**, opposite to the deliberate "platform wins" ordering in `project-data-provider.service.ts`. _(fixed during review: flipped to `{ ...attributes, webViewType }` with an inline comment and a `@param attributes` JSDoc note mirroring the PDP service.)_

[Author response: All three were oversights, not intentional. Author directed each fix — knew the PDP "platform wins" pattern and asked the web-view doc to match it; confirmed the `AsyncVariable` conversion should preserve behavior.]

### Minor — Consider

- [x] **Platform event payload types not re-exported from `@papi/core`** (`StoreChangeEvent`, `ScrollGroupUpdateInfo`, `OpenWebViewEvent`/`UpdateWebViewEvent`/`CloseWebViewEvent`). _(fixed during review: added to `@papi/core`; regenerated `papi.d.ts`.)_
- [x] **`extensions/src/platform-scripture/src/main.ts` still created `openSettingsEventEmitter` with the deprecated sync API** for a newly-declared `NetworkEvents` key. _(fixed during review: migrated to `createNetworkEventEmitterAsync`, matching the `check-aggregator` migration.)_
- [ ] ~~**DRY: the `if (!emitter) throw …; emitter.emit(…)` guard is duplicated ~10×**; could become an `assertEmitter` helper.~~ _(Author declined: call sites are not uniform — some throw, some warn-and-return, some emit inline — so a single helper would only cover a subset; not worth a new shared/exported surface, and explicitly no addition to `platform-bible-utils`.)_
- [ ] ~~**`data-provider.service.ts` dynamic per-instance event name needs a double assertion.**~~ _(Informational; suppressions carry justifying comments. No action — the dynamic name legitimately cannot live in the static `NetworkEvents` registry.)_
- [ ] ~~**`.eslintrc.js` added `vitest/expect-expect` with `assertFunctionNames: ['expect', 'expectTypeOf']`.**~~ _(Informational; teaches the rule that `expectTypeOf` is a valid assertion so type-only tests aren't flagged as empty. Does not weaken the gate.)_

[Author response: Author had #1 and #2 fixed, declined #3 after weighing it, and accepted #4/#5 as no-action FYIs once the `.eslintrc` rule was explained.]

### Template Propagation

#### Shared Regions Modified

None. The only changed file containing `#region shared with` markers is `.eslintrc.js`, and its modified line (the `vitest` override) does not overlap any shared region.

#### Extension Config Changes

None. The changed extension files are source/type files, not config/build files.

## Positive Observations

- The deprecation strategy is non-breaking and well executed: both the sync `createNetworkEventEmitter` and the untyped `getNetworkEvent<T>` are retained with clear `@deprecated` dates and migration guidance.
- The circular-dependency risk between `RpcServer` and `RpcWebSocketListener` is cleanly avoided via the minimal `IRpcEventRegistry` interface and dependency injection; `RpcEventRegistry` was extracted to its own file with an explanatory comment for `max-classes-per-file`.
- `MULTI_SOURCE_EVENT_NAMES` has a single source of truth (`network-event-names.ts`) with its sync invariant against `MultiSourceNetworkEvents` enforced by a dedicated test (`network.service.shared-events.test.ts`).
- New non-trivial logic ships with focused tests (registry policy, openrpc experimental flagging, shared-events invariant, idempotent shared-store init, menus `isExperimental`).
- Type assertions throughout carry justification comments per the project's suppression-discipline rule.
- `papi.d.ts` was regenerated rather than hand-edited.

## Interview Notes

**Stated purpose:** Flag TypeScript and OpenRPC PAPI surfaces as experimental; rework events to be centrally registered to enable that; partially rework the shared store so some reads wait for initialization (with more shared-store work deferred to a follow-up).

**Design understanding (Step 3.3):** The author clearly explained _why_ central registration was required — it puts events in the OpenRPC document so non-TypeScript clients can see `x-experimental` flags — and identified event exclusivity (single registering source per name, preventing impersonation) as a deliberate secondary benefit. This matches the exclusive/shared policy covered by `rpc-event-registry.test.ts`. No gaps or AI-deferral observed; the author drove each fix decision with correct reasoning.

**Discussion items that became work:**

1. **Undocumented events not surfaced in OpenRPC.** The author noticed `generateOpenRpcSchema` skipped undocumented events (`if (!docs) return;`) while undocumented _methods_ are surfaced with a placeholder, and asked whether this was specified. It was **not** — no design-spec or TSDoc rationale; the plan only restated the behavior as a code comment. Author chose option (a): **surface all events**. Implemented with a `getEmptyNotificationDocs()` placeholder, a real integration test against `generateOpenRpcSchema` (instantiates `RpcWebSocketListener`, asserts both a documented and an undocumented event appear), and a `getEmptyNotificationDocs` unit test. Placeholder descriptions were then differentiated as `Method:` / `Notification:` per author request.

2. **Fill in event docs from TSDocs.** All 12 centrally-registered emitters across 9 files now pass `documentation` with summaries transcribed from each event's TSDoc and a payload param (`onDidAddWebView` marked `deprecated: true`; void payloads use `params: []`). The dynamic data-provider event was intentionally left undocumented.

3. **Wiki work.** Verified the in-repo wiki source doc against the implementation and found one inaccuracy (`PapiEventEmitter` → `PlatformEventEmitter`, fixed in both the source doc and the wiki). Cross-checked `Paranext-Core-Patterns.md` (v1.4.1) — already in sync; added only the missing TypeDoc-0.28.3 detail to the wiki. Created `Experimental-APIs.md` + sidebar entry in `paranext-extension-template.wiki`, and updated that wiki's `PAPI.md` to replace the old `createNetworkEventEmitter`/`getNetworkEvent<T>` instructions with the async/central-registration model. Committed on wiki branch `docs/experimental-apis-page` (two commits). `openrpc.model.ts` now links to the wiki page via a real `{@link …}` URL.

**Author-flagged context for the reviewer:**

- The shared-store rework is intentionally partial; more work is planned for a follow-up PR.

## In-Review Quality Check

Changes were made during the interview, so the full quality suite was run afterward:

- **`npm run typecheck`** — passed clean.
- **`npm run lint`** — passed after one hand-fix: the `AsyncVariable` conversion's `void initializationStartedPromise.then(…)` tripped `no-void`; rewritten as `.then(() => startGate.resolveToValue(undefined)).catch(() => {})` (the source promise never rejects; the no-op catch satisfies `promise/catch-or-return`).
- **`npm run format`** — passed clean.
- **`npm test`** — full TypeScript suite passing (root + all extensions). No pre-existing or unrelated failures encountered.

A second round of changes (mark shared store experimental, `EXPERIMENTAL:` OpenRPC prefix, `waitForInitialization` tests) was likewise verified: `build:types`, `typecheck`, `lint`, and `format` all clean, and the **full** test suite passes (all workspaces, exit 0).

## Suggested Review Focus

Prioritized areas for the author–reviewer meeting:

- [x] **Public-surface decision for `shared-store:change` / `StoreChangeEvent`.** This event is declared in the public `MultiSourceNetworkEvents` registry and its payload type is re-exported from `@papi/core`, yet `shared-store.service.ts` documents itself as "not part of the public API." _(Addressed during review: the shared store's `shared-store:change` event **and** its `shared-store:get` request are now marked `'x-experimental': true`, signaling the surface is intentionally unstable and may change/be removed. Whether extensions should subscribe at all remains a judgment call, but consumers are now warned.)_
- [x] **`waitForInitialization` direct test.** _(Added during review: three tests in `shared-store.service.test.ts` cover the already-initialized fast path, the resolves-once-initialize-starts path, and the timeout-throw path.)_
- [ ] **Remaining shared-store rework** the author deferred to a follow-up PR. Concretely: this PR added `waitForInitialization` and wired it into `network.service`'s request path so a request's _custom_ timeout (read from the shared store) waits for the store to be ready before falling back. But other shared-store reads still degrade gracefully rather than waiting — e.g. `getTimeoutMsForRequestType` returns the **default** timeout during the bootstrap window when `sharedStoreService.isInitialized()` is false (a React component mounted before init can fire requests then). The follow-up should make more of these reads reliably await initialization (so they get the accurate, Lamport-clock-correct value) instead of silently using defaults, and tighten the start-timeout fallback semantics. Confirm scope/expectations with the author.
- [ ] **OpenRPC "surface all events" decision** — confirm the team is happy that every centrally-registered event now appears in the live OpenRPC document (with a placeholder when undocumented), matching method behavior.
- [ ] **Wiki branch is not yet live.** `docs/experimental-apis-page` in `paranext-extension-template.wiki` is pushed but not merged; GitHub wikis render only the default branch, so it must be merged to `master` to appear (and for the `openrpc.model.ts` `{@link}` to resolve). Separately, `PAPI.md` had other event/WebView sections beyond the events block that may warrant a later sweep.
<!-- review-paratext:summary:end -->


