### PR TITLE
fix(flaky): UI Interaction › should open the About dialog from the Help menu

### DIFF
--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -34,22 +34,46 @@ test.describe('UI Interaction', () => {
       BrowserWindow.getAllWindows()[0].maximize();
     });
 
-    // Force the interface language to English so menu-item text matchers
-    // (e.g. /Help/i) are deterministic regardless of the developer's saved
-    // platform.interfaceLanguage setting in dev-appdata.
-    // Fast-fail guard: on slow CI the settings data provider can register
-    // after this beforeAll starts; this throws a clear error if it never does.
-    await waitForPapiMethodRegistered(
-      SETTINGS_SET_METHOD,
-      undefined,
-      SETTINGS_REGISTRATION_TIMEOUT_MS,
-    );
-    await sendPapiRequestOnce(
-      SETTINGS_SET_METHOD,
-      ['platform.interfaceLanguage', ['en']],
-      undefined,
-      SLOW_CI_PAPI_TIMEOUT_MS,
-    );
+    // Force the interface language to English so menu-item text matchers (e.g. /Help/i) are
+    // deterministic. This override is a "belt and suspenders" guard — note it never *defaults*
+    // the language; defaulting happens earlier, at app startup, inside the settings service:
+    //   - Belt:       with no saved platform.interfaceLanguage, the settings service's get()
+    //                 returns the registered default ['en'] (settings.service-host.ts get() ->
+    //                 getDefaultValueForKey; default declared in core-settings-info.data.ts).
+    //                 CI runs on a fresh checkout with dev-appdata/ gitignored, so the app has
+    //                 ALREADY booted English before this beforeAll runs.
+    //   - Suspenders: this explicit set('en') additionally defends a developer running the suite
+    //                 locally with a non-English locale saved in dev-appdata.
+    // On CI only the belt applies, so the override is redundant here — which is what makes the
+    // catch below safe to swallow.
+    try {
+      await waitForPapiMethodRegistered(
+        SETTINGS_SET_METHOD,
+        undefined,
+        SETTINGS_REGISTRATION_TIMEOUT_MS,
+      );
+      await sendPapiRequestOnce(
+        SETTINGS_SET_METHOD,
+        ['platform.interfaceLanguage', ['en']],
+        undefined,
+        SLOW_CI_PAPI_TIMEOUT_MS,
+      );
+    } catch (e) {
+      // This catch does NOT set any language — the app already booted with the English default
+      // (the belt above), so we just proceed without the redundant override. Tolerate ONLY the
+      // two known-transient startup errors seen on slow / memory-pressured macOS runners: the PAPI
+      // socket cycling mid-request ("Web socket N has closed") and the settings provider being slow
+      // to register on a Playwright retry ("not listed in rpc.discover"). Re-throw anything else —
+      // an unexpected error means the settings provider is genuinely broken and the suite should
+      // fail loudly rather than pass silently.
+      const msg = e instanceof Error ? e.message : String(e);
+      if (!(msg.includes('Web socket') || msg.includes('not listed in rpc.discover'))) throw e;
+      console.warn(
+        '[smoke/beforeAll] Skipped the interface-language override after a transient startup' +
+          ` error; the app already booted with the default English locale, so menu matchers stay` +
+          ` valid. Error: ${msg}`,
+      );
+    }
   });
 
   test('should open the About dialog from the Help menu', async ({ mainPage }) => {


### PR DESCRIPTION
## Problem

The `UI Interaction` smoke suite shares a `beforeAll` that forces the interface language to English. On macOS CI it fails ~100% of the time, and because the failure is in `beforeAll` it takes down **all 5 tests** in the block. Two failure modes:

1. **Initial attempt** — `sendPapiRequestOnce` throws `PAPI error: "Web socket N has closed"`: the extension host cycles its internal connection during startup, after `waitForPapiMethodRegistered` already found the method.
2. **Playwright retries** — each retry relaunches Electron on an already memory-pressured runner, and `waitForPapiMethodRegistered` then times out (`not listed in rpc.discover within 120000ms`) before the test body runs.

#2357 already raised that registration timeout 60 s → 120 s and the test still fails at 120000 ms, so no timeout increase alone is sufficient.

## Fix

Make the language override **non-fatal**: wrap both calls in `try/catch`, tolerate only the two known-transient startup errors and re-throw anything else, so a genuinely broken settings provider still fails the suite. The guard is an allowlist:

```ts
const msg = e instanceof Error ? e.message : String(e);
// re-throw unless the message is one of the two known-transient errors
if (!(msg.includes('Web socket') || msg.includes('not listed in rpc.discover'))) throw e;
```

A `console.warn` records the tolerated error for CI triage.

## Why this is safe — the override is "belt and suspenders"

First, an important clarification: **nothing in this test defaults the language.** Defaulting happens earlier, at **app startup**, inside the settings service — when no `platform.interfaceLanguage` is saved, `get()` returns the registered default `['en']` (`settings.service-host.ts` `get()` → `getDefaultValueForKey`; default declared in `core-settings-info.data.ts`). The `beforeAll` override is only an *additional* attempt to set it; the `catch` sets nothing — it just proceeds with whatever the app already booted with.

That makes the override two independent safeguards for the same goal (deterministic English menus):

- **Belt** — CI runs on a fresh checkout with `dev-appdata/` gitignored (dev mode stores settings in `<repo>/dev-appdata`, not Electron's user-data dir — `getAppDir()` in `src/node/utils/util.ts`). So no saved locale exists and the app has **already** booted English before `beforeAll` runs.
- **Suspenders** — the explicit `set('en')` additionally defends a developer running the suite *locally* with a non-English locale saved in `dev-appdata`.

On CI only the belt applies, so the override is redundant there. If it fails with one of the two known-transient errors, the already-loaded English locale stands and the test's matchers (`/Help/i`, `/About Platform\.Bible/i`) work regardless — hence tolerating those two errors is safe. Any other error is re-thrown so a genuinely broken settings provider still fails the suite. This fixes the test itself; it complements the workflow-level non-blocking change in #2399.

## Evidence (macOS, last 7 days)

Same cross-platform split on every run — Linux + Windows pass, macOS fails on the same SHA:

| Run | SHA |
|-----|-----|
| [27217841212](https://github.com/paranext/paranext-core/actions/runs/27217841212) | `7238c67` |
| [27152836093](https://github.com/paranext/paranext-core/actions/runs/27152836093) | `204f8eb` |
| [26976756798](https://github.com/paranext/paranext-core/actions/runs/26976756798) | `6dd923f` |

## Notes

- Approach endorsed in review on #2394 (making the settings round-trip non-fatal beats extending timeouts, since the root cause is the extension host stalling under load). Supersedes earlier attempts #2368, #2372, #2394.
- Selected over the retry-loop alternative #2403 (closed): retrying only `sendPapiRequestOnce` leaves failure mode 2 unaddressed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HPpAsYGHeEqJWEwQZ2UhoX)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2382)
<!-- Reviewable:end -->
