### PR TITLE
fix: patch watchboy to survive transient EPERM/EBUSY on Windows

### DIFF
--- a/patches/watchboy+0.4.3.patch
+++ b/patches/watchboy+0.4.3.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/watchboy/index.js b/node_modules/watchboy/index.js
+index c741263..88e031e 100644
+--- a/node_modules/watchboy/index.js
++++ b/node_modules/watchboy/index.js
+@@ -22,7 +22,7 @@ const stat = async (file) => {
+   try {
+     return await pStat(file);
+   } catch (e) {
+-    if (e.code === 'ENOENT') {
++    if (e.code === 'ENOENT' || e.code === 'EPERM' || e.code === 'EBUSY') {
+       return null;
+     }
+ 


### PR DESCRIPTION
On Windows, git writes lock files (e.g. AUTO_MERGE.lock) to .git/ using exclusive file handles. watchboy's recursive fs.watch fires on these creates, then immediately calls stat() — which hits EPERM or EBUSY if the lock file is still exclusively held. The stat helper only swallowed ENOENT; anything else became an unhandled rejection that crashed the electronmon monitor process.

Patch treats EPERM and EBUSY the same as ENOENT: return null, which watchboy already interprets as "path gone, skip it." For a genuinely watched path that transiently EPERMs, the recursive root watcher will re-deliver an event once the lock is released, so nothing is silently dropped.

Filed upstream: catdad/watchboy#28

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2385)
<!-- Reviewable:end -->
