### PR TITLE
Clean up developer-facing log noise

### DIFF
--- a/c-sharp-tests/JsonUtils/CommentThreadSelectorConverterTests.cs
+++ b/c-sharp-tests/JsonUtils/CommentThreadSelectorConverterTests.cs
@@ -154,11 +154,12 @@ internal class CommentThreadSelectorConverterTests
         Assert.That(selector, Is.Not.Null);
         Assert.That(selector!.ScriptureRanges, Is.Not.Null);
         Assert.That(selector.ScriptureRanges!, Has.Count.EqualTo(1));
-        Assert.That(selector.ScriptureRanges[0].Start.BookNum, Is.EqualTo(1));
-        Assert.That(selector.ScriptureRanges[0].Start.ChapterNum, Is.EqualTo(1));
-        Assert.That(selector.ScriptureRanges[0].Start.VerseNum, Is.EqualTo(1));
-        Assert.That(selector.ScriptureRanges[0].End.VerseNum, Is.EqualTo(31));
-        Assert.That(selector.ScriptureRanges[0].Granularity, Is.EqualTo("verse"));
+        var range = selector.ScriptureRanges![0];
+        Assert.That(range.Start.BookNum, Is.EqualTo(1));
+        Assert.That(range.Start.ChapterNum, Is.EqualTo(1));
+        Assert.That(range.Start.VerseNum, Is.EqualTo(1));
+        Assert.That(range.End.VerseNum, Is.EqualTo(31));
+        Assert.That(range.Granularity, Is.EqualTo("verse"));
     }
 
     [Test]

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -68,7 +68,6 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         _commentManager = CommentManager.Get(
             LocalParatextProjects.GetParatextProject(projectDetails.Metadata.Id)
         );
-        RegisterSettingsValidators();
     }
 
     #endregion
@@ -1012,10 +1011,10 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
 
     public static string VisibilitySettingName => Setting.Visibility.ToString();
 
-    private void RegisterSettingsValidators()
+    internal static void RegisterSettingsValidators(PapiClient papiClient)
     {
         ProjectSettingsService.RegisterValidator(
-            PapiClient,
+            papiClient,
             VisibilitySettingName,
             VisibilityValidator
         );

--- a/c-sharp/Projects/ParatextProjectDataProviderFactory.cs
+++ b/c-sharp/Projects/ParatextProjectDataProviderFactory.cs
@@ -24,6 +24,9 @@ internal class ParatextProjectDataProviderFactory : ProjectDataProviderFactory
     protected override Task StartFactoryAsync()
     {
         _paratextProjects.Initialize();
+        // Settings validators are global (not per-project), so register them exactly once here
+        // rather than in each ParatextProjectDataProvider instance
+        ParatextProjectDataProvider.RegisterSettingsValidators(PapiClient);
         return Task.CompletedTask;
     }
 

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -5,6 +5,10 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// <summary>
 /// Commands on the papi that handle Send/Receive-related operations
 /// </summary>
+// pdpFactory and appInfo are unread in this open-source implementation, but the closed-source
+// Paratext 10 Studio overlay patch binds them into properties, so the constructor signature must
+// keep them. Suppress the unread-parameter warning rather than removing the parameters.
+#pragma warning disable CS9113
 internal class ParatextProjectSendReceiveService(
     PapiClient papiClient,
     ParatextProjectDataProviderFactory pdpFactory,

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -14,6 +14,7 @@ internal class ParatextProjectSendReceiveService(
     ParatextProjectDataProviderFactory pdpFactory,
     AppInfo appInfo
 )
+#pragma warning restore CS9113
 {
     #region Public properties and methods
 

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -78,7 +78,7 @@ import {
   ScriptureEditorViewType,
   ScriptureRangeUsjVerseRefChapterLocation,
 } from 'platform-scripture-editor';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { PropsWithChildren, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createHtmlPortalNode, InPortal, OutPortal } from 'react-reverse-portal';
 import { ChevronDown } from 'lucide-react';
 import { useAnnotationStyleSheet } from './annotations/use-annotation-stylesheet.hook';
@@ -100,6 +100,16 @@ import {
   openCommentListAndSelectThreadSafe,
   SCRIPTURE_EDITOR_WEBVIEW_TYPE,
 } from './platform-scripture-editor.utils';
+
+/**
+ * Pass-through wrapper for the editor inside {@link InPortal}. `react-reverse-portal`'s `InPortal`
+ * clones its child with the props passed to `OutPortal` (always at least `node: undefined`), and
+ * cloning a `Fragment` with any prop other than `key`/`children` makes React log an error. This
+ * wrapper absorbs those props so `renderEditor` can keep returning a Fragment.
+ */
+function PortalContents({ children }: PropsWithChildren) {
+  return children;
+}
 
 /**
  * Time in ms to delay taking action to wait for the editor to load. Hope to be obsoleted by a way
@@ -1721,7 +1731,9 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
         endAreaChildren={scrollGroupSelector}
       />
       {/* Mount the editor in a reverse portal so it doesn't unmount and lose its internal state */}
-      <InPortal node={editorPortalNode}>{renderEditor()}</InPortal>
+      <InPortal node={editorPortalNode}>
+        <PortalContents>{renderEditor()}</PortalContents>
+      </InPortal>
       <div
         ref={editorContainerRef}
         className="tw:h-auto tw:flex-1 tw:min-h-0 tw:overflow-auto"

--- a/extensions/webpack/webpack.config.base.ts
+++ b/extensions/webpack/webpack.config.base.ts
@@ -142,7 +142,19 @@ const configBase: webpack.Configuration = {
           // Processes style transformations in PostCSS - after scss so PostCSS runs on just css
           'postcss-loader',
           // Compiles Sass to CSS
-          'sass-loader',
+          {
+            loader: 'sass-loader',
+            options: {
+              sassOptions: {
+                // The tailwind prebuild loader below inlines machine-generated Tailwind CSS into
+                // each style file before sass compiles it. Tailwind's typography plugin emits
+                // custom-property declarations after nested rules, which trips sass's mixed-decls
+                // deprecation warning. We cannot restructure generated CSS, so silence just this
+                // deprecation. https://sass-lang.com/d/mixed-decls
+                silenceDeprecations: ['mixed-decls'],
+              },
+            },
+          },
           // Redirect tailwind.css imports to the pre-built version (only works in CSS, not in code)
           // by recursively inlining local @use/@import and replacing tailwind.css with prebuilt
           // tailwind styles. This runs BEFORE sass-loader (loaders execute bottom-to-top)

--- a/src/extension-host/extension-host.ts
+++ b/src/extension-host/extension-host.ts
@@ -51,18 +51,29 @@ process.on('exit', () => {
   logger.info('Finished killing child processes created by extensions');
 });
 
+/**
+ * Determines if an error is a broken pipe error e.g. the stdout pipe from extension host to main
+ * broke. Checks the `code` property because Node formats the message as `'write EPIPE'` (syscall
+ * first), with a message check as a fallback.
+ */
+function isEpipeError(error: unknown): boolean {
+  if (typeof error === 'object' && error && 'code' in error && error.code === 'EPIPE') return true;
+  return getErrorMessage(error).includes('EPIPE');
+}
+
 // Add unhandled exception and rejection handlers
 process.on('uncaughtException', (error) => {
-  const errorMessage = getErrorMessage(error);
+  // If the pipe from extension host to main breaks, stop logging to console because writing to the
+  // broken pipe throws EPIPE again, producing an infinite uncaughtException loop
+  if (isEpipeError(error)) logger.transports.console.level = false;
 
-  // If the pipe from extension host to main breaks, stop logging to console because it will infinitely
-  // produce errors in a loop
-  if (errorMessage.startsWith('EPIPE')) logger.transports.console.level = false;
-
-  logger.error(`Unhandled exception in extension host: ${errorMessage}`);
+  logger.error(`Unhandled exception in extension host: ${getErrorMessage(error)}`);
 });
 
 process.on('unhandledRejection', (reason) => {
+  // Same EPIPE feedback loop protection as uncaughtException above
+  if (isEpipeError(reason)) logger.transports.console.level = false;
+
   logger.error(`Unhandled promise rejection in extension host, reason: ${getErrorMessage(reason)}`);
 });
 

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -260,15 +260,17 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
   }
 
   private onClientConnect(webSocket: WebSocket): void {
+    const socketId = this.nextSocketId;
     const rpcServer = new RpcServer(
-      this.nextSocketId,
+      socketId,
       webSocket,
       this.propagateEvent,
       this.rpcMethodDetailsByMethodName,
     );
     rpcServer.connect();
     this.rpcServerBySocket.set(webSocket, rpcServer);
-    logger.warn(`Websocket client connected: ${webSocket.url}`);
+    // Note: `webSocket.url` is always undefined for server-side sockets, so log the socket id
+    logger.info(`Websocket client ${socketId} connected`);
     webSocket.addEventListener('close', this.onClientDisconnect);
   }
 
@@ -278,7 +280,7 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
     const webSocket = ev.target as WebSocket;
     webSocket.removeEventListener('close', this.onClientDisconnect);
     if (!this.rpcServerBySocket.delete(webSocket)) {
-      logger.warn(`Close called on socket for '${webSocket.url}' but no handler found`);
+      logger.warn('Close called on a websocket, but no rpc server handler was found for it');
     }
   }
 }

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -1,4 +1,4 @@
-import { renderHook, waitFor, act } from '@testing-library/react';
+import { renderHook, waitFor, act, configure, getConfig } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { EVENT_NAME_ON_DID_UPDATE_WEB_VIEW } from '@shared/services/web-view.service-model';
@@ -83,6 +83,22 @@ async function importMocks() {
 // vitest mocks use as-never to coerce partial objects to the full inferred return type
 /* eslint-disable no-type-assertion/no-type-assertion */
 describe('useProjectPickerData', () => {
+  // The hook ORs four async loading flags (three usePromise calls + one useData). They resolve in
+  // ~60ms locally, but waitFor's deadline is wall-clock: on a starved CI runner the event loop can
+  // be blocked past RTL's 1000ms default before the (already-scheduled) resolutions run, producing
+  // spurious "isLoading still true" timeouts. There is no re-render loop (each callback runs exactly
+  // once), so a longer deadline only tolerates scheduler starvation - waitFor still returns the
+  // instant the condition is met, so the happy path is not slowed. Restored in afterAll so the
+  // raised timeout does not leak to other test files sharing the worker.
+  let originalAsyncUtilTimeout: number;
+  beforeAll(() => {
+    originalAsyncUtilTimeout = getConfig().asyncUtilTimeout;
+    configure({ asyncUtilTimeout: 5000 });
+  });
+  afterAll(() => {
+    configure({ asyncUtilTimeout: originalAsyncUtilTimeout });
+  });
+
   beforeEach(async () => {
     // resetAllMocks clears both call history and any mockReturnValue/mockImplementation overrides
     // set by individual tests. clearAllMocks only clears call history, so without reset, a test


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: fix/log-noise-cleanup-matt-06-11-2026

**Base**: origin/main

**Date**: 2026-06-11

**Review model**: Claude Opus 4.8

**Files changed**: 8

## Overview

This branch cleans up developer-facing log noise across the C# data provider, the
Electron extension-host and main processes, and the scripture-editor webview. The
purpose was given briefly as "Cleanup log noise," and in practice the work is a mix
of literal log-text/level adjustments and small behavioral fixes that each eliminate
a source of spurious error/warning output:

- **EPIPE handling** (`src/extension-host/extension-host.ts`): extracts an `isEpipeError`
  helper that checks the structured `error.code === 'EPIPE'` first (the old
  `errorMessage.startsWith('EPIPE')` never matched, because Node formats the message
  as `'write EPIPE'` syscall-first), and applies the console-disable feedback-loop
  protection to `unhandledRejection` as well as `uncaughtException`.
- **Settings validator registration** (`ParatextProjectDataProvider.cs` +
  `ParatextProjectDataProviderFactory.cs`): moves global validator registration from
  the per-provider constructor to `StartFactoryAsync` (once), eliminating duplicate
  re-registration warnings on every project open.
- **WebSocket connect logging** (`rpc-websocket-listener.ts`): logs by `socketId`
  instead of the always-`undefined` `webSocket.url`, and downgrades the routine connect
  from `warn` to `info`.
- **React Fragment portal fix** (`platform-scripture-editor.web-view.tsx`): adds a
  `PortalContents` pass-through wrapper to absorb `react-reverse-portal` props and stop
  React from logging an invalid-prop error.
- **Warning suppressions** with justification comments: CS9113 (unread constructor
  params bound by the closed-source PT10 Studio overlay), CS8602, and the sass
  `mixed-decls` deprecation from generated Tailwind CSS.

Reviewers should expect the diff to include these behavioral fixes, not just log-string
edits — they are all noise-reduction-adjacent.

## API Changes

None. No public API surfaces changed. The diff touches only internal C# backend
(`RegisterSettingsValidators` changed from `private` instance to `internal static`;
`ParatextProjectSendReceiveService` constructor signature unchanged, only a pragma
added), internal TypeScript (extension-host handlers, main-process RPC listener), a
non-exported webview wrapper component, build config, and a C# test file. No changes
to `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `@papi/` modules, or
extension `types/*.d.ts`.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [ ] ~~Scope vs. stated purpose: several changes are behavioral (EPIPE refactor, validator-registration move, React Fragment portal fix) rather than pure log-text edits.~~ _(Author: the purpose was given as a deliberately brief PR summary; the behavioral, noise-reduction-adjacent diffs are called out in the PR Overview above so reviewers expect them.)_
- [x] **`ParatextProjectSendReceiveService.cs:11` — `#pragma warning disable CS9113` had no matching `restore`, leaking the suppression to end-of-file.** _(fixed during review: added `#pragma warning restore CS9113` immediately after the primary constructor's closing paren, scoping the suppression to just the constructor parameters. Verified via clean C# rebuild — 0 warnings, 0 errors, CS9113 still suppressed within scope.)_
- [ ] ~~`isEpipeError` is pure and unit-testable, but `extension-host.ts` has no test harness.~~ _(Author acknowledged; no test required — the helper is a small defensive guard in an untested entry-point module with no established test pattern.)_

[Author response: The scope and testability findings were acknowledged as intentional/non-issues. The CS9113 scoping finding was fixed during the interview.]

### Template Propagation

#### Shared Regions Modified

- [ ] `extensions/webpack/webpack.config.base.ts:145-157` — region shared with `paranext-extension-template` (`#region shared with https://github.com/paranext/paranext-extension-template/blob/main/webpack/webpack.config.base.ts`). The `sass-loader` `silenceDeprecations: ['mixed-decls']` addition should be propagated to `paranext-extension-template`. **Tracked as a follow-up item** (see Suggested Review Focus).

#### Extension Config Changes

- [n/a] `extensions/webpack/webpack.config.base.ts` — covered by the shared-region marker above. The marker names `paranext-extension-template` as the authoritative propagation target, overriding the generic `extensions/` → `paranext-multi-extension-template` heuristic.

## Positive Observations

- The `isEpipeError` change is a genuine correctness fix, not just cleanup: the old
  `errorMessage.startsWith('EPIPE')` guard never matched (Node formats EPIPE as
  `'write EPIPE'`, syscall-first), so the console-disable protection never fired. The
  new `error.code === 'EPIPE'` check with a message fallback correctly catches it, and
  the JSDoc documents the rationale.
- Extending the EPIPE feedback-loop protection to `unhandledRejection` (previously only
  on `uncaughtException`) is a sound consistency fix.
- Moving validator registration to `StartFactoryAsync` (once) is the correct fix for the
  repeated-registration noise; `internal static` refactor is clean and well-commented.
- Every suppression (CS9113, CS8602, sass `mixed-decls`) carries a clear comment
  explaining what is suppressed and why, consistent with the "fix code, don't
  thoughtlessly suppress" discipline. The sass change is narrowly scoped to a single
  deprecation with a link to the upstream doc.
- `rpc-websocket-listener.ts` documents *why* `webSocket.url` logging was useless
  (always `undefined` server-side), replaces it with a stable `socketId`, and downgrades
  the routine connect from `warn` to `info` — exactly the targeted noise reduction the
  branch describes.
- `PortalContents` is a transparent pass-through wrapper with excellent JSDoc; valid in
  React 19 and introduces no visual/interactive change while resolving the console error.
- `CommentThreadSelectorConverterTests.cs` hoists `selector.ScriptureRanges![0]` into a
  `range` local, removing five repeated index/null-forgiving expressions — a clean DRY
  improvement.

## Interview Notes

- **Stated purpose**: "Cleanup log noise" — given deliberately briefly. The author
  confirmed the behavioral diffs are intentional and asked that they be called out in the
  PR description (done in the Overview).
- **CS9113 scoping**: the author requested the fix during the interview; applied and
  verified.
- **isEpipeError testability**: acknowledged as a non-issue given the untested
  entry-point context.
- **Template propagation**: the author confirmed the sass `mixed-decls` change to the
  shared webpack region should be tracked as a follow-up propagation item rather than
  handled in this branch.
- No unresolved items. The author demonstrated clear understanding of the changes; no
  areas were deferred to AI.

## In-Review Quality Check

One in-review change was made (C#-only: the CS9113 pragma scoping fix). Verification was
run with the checks that actually exercise a C# change:

- **csharpier format**: passed — the changed file was already correctly formatted; no
  reformat needed.
- **C# build (clean rebuild of `ParanextDataProvider.csproj`)**: passed — 0 warnings,
  0 errors. CS9113 confirmed suppressed within the restored scope, with no leak to code
  after the constructor and no other warning introduced.

The TypeScript test suite was not run, as it does not exercise a C# pragma edit. No
unfixable failures.

## Suggested Review Focus

Prioritized areas for the author-reviewer meeting:

- [ ] **Follow-up — template propagation**: propagate the `sass-loader`
  `silenceDeprecations: ['mixed-decls']` change in `extensions/webpack/webpack.config.base.ts`
  to `paranext-extension-template` (the file's shared-region marker names it as the
  authoritative target). Confirm whether this should be a separate PR against the template repo.
- [ ] **Behavioral scope confirmation**: the branch includes small behavioral fixes
  (EPIPE refactor, validator-registration move, React Fragment portal wrapper) beyond
  literal log-text edits. Confirm these are in-scope for this cleanup PR vs. splitting out.
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2387)
<!-- Reviewable:end -->
