### PR TITLE
ci: pin snapcraft to 8.x to fix Linux snap build (electron-builder 26 vs snapcraft 9)

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -77,7 +77,11 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y snapd
-          sudo snap install snapcraft --classic
+          # Pin snapcraft to the 8.x track. snapcraft 9 (now latest/stable) removed the
+          # deprecated `snap` command alias, which electron-builder 26.x still invokes,
+          # breaking the snap build. Remove this pin once we move to electron-builder >= 27
+          # (which calls `snapcraft pack`). See electron-builder issue #8880 / PR #9517.
+          sudo snap install snapcraft --classic --channel=8.x/stable
           sudo snap install lxd
           sudo snap refresh lxd
           sudo lxd init --auto

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,7 +96,11 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y snapd
-          sudo snap install snapcraft --classic
+          # Pin snapcraft to the 8.x track. snapcraft 9 (now latest/stable) removed the
+          # deprecated `snap` command alias, which electron-builder 26.x still invokes,
+          # breaking the snap build. Remove this pin once we move to electron-builder >= 27
+          # (which calls `snapcraft pack`). See electron-builder issue #8880 / PR #9517.
+          sudo snap install snapcraft --classic --channel=8.x/stable
           sudo snap install lxd
           sudo snap refresh lxd
           sudo lxd init --auto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,11 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y snapd
-          sudo snap install snapcraft --classic
+          # Pin snapcraft to the 8.x track. snapcraft 9 (now latest/stable) removed the
+          # deprecated `snap` command alias, which electron-builder 26.x still invokes,
+          # breaking the snap build. Remove this pin once we move to electron-builder >= 27
+          # (which calls `snapcraft pack`). See electron-builder issue #8880 / PR #9517.
+          sudo snap install snapcraft --classic --channel=8.x/stable
           sudo snap install lxd
           sudo snap refresh lxd
           sudo lxd init --auto


### PR DESCRIPTION
## Problem

CI builds are failing on Ubuntu in the `check packaging` step (`npm run package` → `electron-builder build`) when building the Linux `snap` target:

```
• building target=snap ...
The 'snap' command was renamed to 'pack'.
Recommended resolution: Use 'pack' instead.
⨯ exit status 1
⨯ app-builder process failed ERR_ELECTRON_BUILDER_CANNOT_EXECUTE
```

Example failure: https://github.com/paranext/paranext-core/actions/runs/27363927138/job/80879859338

## Root cause

Nothing in this repo changed — it's an external toolchain breaking change:

1. Our workflows install snapcraft with `sudo snap install snapcraft --classic` (no channel pin), so runners get whatever is `latest/stable`.
2. **snapcraft 9.0 recently became the stable release.** snapcraft renamed `snap` → `pack` in v7, kept `snap` as a deprecation-warning alias through v8, and **v9 removed the alias entirely** — it is now a hard error.
3. `electron-builder` 26.x (we're on `^26.0.16`) builds snaps via its bundled `app-builder`, which still invokes `snapcraft snap`. Under snapcraft 9 that exits 1.

## Fix

Pin the CI snapcraft install to the `8.x` track in both the **Test** and **Package** workflows. Minimal, well-understood, and easy to revert.

The real upstream fix — electron-builder [PR #9517](https://github.com/electron-userland/electron-builder/pull/9517) (tracked by [issue #8880](https://github.com/electron-userland/electron-builder/issues/8880)), which switches to `snapcraft pack` and adds core24 support — was merged 2026-05-27 as a **major version bump** but is currently **alpha-only** (`27.0.0-alpha.x`); stable `latest` is `26.15.x`. Once electron-builder ≥ 27 ships stable, we should upgrade and drop this pin (and revisit `snap.base: core22` vs core24 in `electron-builder.json5`).

## Testing

Verified the change is limited to the two workflow `snap install` lines. CI on this PR exercises the pinned snapcraft path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2388)
<!-- Reviewable:end -->
