### PR TITLE
ci: pin snapcraft to 8.x to fix Linux snap build (electron-builder 26 vs snapcraft 9)

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -77,7 +77,11 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y snapd
-          sudo snap install snapcraft --classic
+          # Pin snapcraft to the 8.x track. snapcraft 9 (now latest/stable) removed the
+          # deprecated `snap` command alias, which electron-builder 26.x still invokes,
+          # breaking the snap build. Remove this pin once we move to electron-builder >= 27
+          # (which calls `snapcraft pack`). See electron-builder issue #8880 / PR #9517.
+          sudo snap install snapcraft --classic --channel=8.x/stable
           sudo snap install lxd
           sudo snap refresh lxd
           sudo lxd init --auto

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,7 +96,11 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y snapd
-          sudo snap install snapcraft --classic
+          # Pin snapcraft to the 8.x track. snapcraft 9 (now latest/stable) removed the
+          # deprecated `snap` command alias, which electron-builder 26.x still invokes,
+          # breaking the snap build. Remove this pin once we move to electron-builder >= 27
+          # (which calls `snapcraft pack`). See electron-builder issue #8880 / PR #9517.
+          sudo snap install snapcraft --classic --channel=8.x/stable
           sudo snap install lxd
           sudo snap refresh lxd
           sudo lxd init --auto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,7 +92,11 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y snapd
-          sudo snap install snapcraft --classic
+          # Pin snapcraft to the 8.x track. snapcraft 9 (now latest/stable) removed the
+          # deprecated `snap` command alias, which electron-builder 26.x still invokes,
+          # breaking the snap build. Remove this pin once we move to electron-builder >= 27
+          # (which calls `snapcraft pack`). See electron-builder issue #8880 / PR #9517.
+          sudo snap install snapcraft --classic --channel=8.x/stable
           sudo snap install lxd
           sudo snap refresh lxd
           sudo lxd init --auto


### PR DESCRIPTION
## Problem

CI Linux snap builds (`check packaging` → `electron-builder build`) fail on the snap target:

```
The 'snap' command was renamed to 'pack'.
⨯ exit status 1  ERR_ELECTRON_BUILDER_CANNOT_EXECUTE
```

## Root cause

External toolchain breaking change — nothing in this repo changed:

1. Workflows install snapcraft with `sudo snap install snapcraft --classic` (no channel pin), so runners get `latest/stable`.
2. **snapcraft 9.0 recently became stable** and removed the `snap` → `pack` alias (a deprecation warning through v8; now a hard error).
3. `electron-builder` 26.x builds snaps via its bundled `app-builder`, which still invokes `snapcraft snap` → exits 1.

## Fix

Pin the CI snapcraft install to the `8.x` track in the **test**, **package**, and **publish** workflows. Minimal and easy to revert.

Temporary until we upgrade to electron-builder ≥ 27 (electron-builder [PR #9517](https://github.com/electron-userland/electron-builder/pull/9517) / [issue #8880](https://github.com/electron-userland/electron-builder/issues/8880)), which calls `snapcraft pack` and adds core24 support — currently alpha-only (`27.0.0-alpha.x`). At that point, drop the pin and revisit `snap.base: core22` in `electron-builder.json5`.

Cherry-picked from the equivalent fix targeting `main` (#2388), squashed into one commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2390)
<!-- Reviewable:end -->
