### PR TITLE
Fix project loading timeout bug

### DIFF
--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -9,6 +9,7 @@ import {
   syncOnProjectSwitch,
   type OpenEditorDispatch,
   SCRIPTURE_EDITOR_WEBVIEW_TYPE,
+  WEBVIEW_SERVICE_NOT_READY_ERROR_SUBSTRING,
   selectProjectIdsForOpenMode,
   startDefaultProjectPicker,
 } from './platform-scripture-editor.utils';
@@ -620,7 +621,7 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     mockGetSetting.mockResolvedValue('simple');
     mockGetAllOpenWebViewDefinitions.mockRejectedValue(
       new Error(
-        'Timeout reached when waiting for wait-for-net-obj with details {"id":"WebViewService"} to settle',
+        `Timeout reached when waiting for ${WEBVIEW_SERVICE_NOT_READY_ERROR_SUBSTRING} with details {"id":"WebViewService"} to settle`,
       ),
     );
 
@@ -632,6 +633,16 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     // Cold-start timing is expected — logged at debug, not warn.
     expect(mockDebug).toHaveBeenCalled();
     expect(mockWarn).not.toHaveBeenCalled();
+  });
+
+  it('re-throws unexpected errors from getAllOpenWebViewDefinitions so the caller warn path still fires', async () => {
+    const { papi, mockGetSetting, mockGetAllOpenWebViewDefinitions } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockRejectedValue(new Error('Something entirely unexpected'));
+
+    await expect(openDefaultActiveProjectIfApplicable(papi)).rejects.toThrow(
+      'Something entirely unexpected',
+    );
   });
 
   it("returns 'no-send-receive' when getSharedProjects rejects (S/R not registered yet)", async () => {

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -608,6 +608,32 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     expect(mockSendCommand).not.toHaveBeenCalled();
   });
 
+  it("returns 'no-empty' and logs debug (not warn) when getAllOpenWebViewDefinitions throws a wait-for-net-obj timeout (cold-start WebViewService not ready)", async () => {
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      mockWarn,
+      mockDebug,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockRejectedValue(
+      new Error(
+        'Timeout reached when waiting for wait-for-net-obj with details {"id":"WebViewService"} to settle',
+      ),
+    );
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('no-empty');
+    expect(mockGetAllOpenWebViewDefinitions).toHaveBeenCalled();
+    expect(mockSendCommand).not.toHaveBeenCalled();
+    // Cold-start timing is expected — logged at debug, not warn.
+    expect(mockDebug).toHaveBeenCalled();
+    expect(mockWarn).not.toHaveBeenCalled();
+  });
+
   it("returns 'no-send-receive' when getSharedProjects rejects (S/R not registered yet)", async () => {
     const {
       papi,

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -581,9 +581,27 @@ export async function openDefaultActiveProjectIfApplicable(
   }
   if (interfaceMode !== 'simple') return 'wrong-mode';
 
-  const openWebViews = await papi.webViews.getAllOpenWebViewDefinitions();
+  // On cold start the renderer (and therefore WebViewService) may not be up yet when the
+  // initial picker run fires inside platformScriptureEditor.activate(). The call waits 30 s
+  // then throws with a "wait-for-net-obj" timeout. Treat that as 'no-empty' — onDidOpenWebView
+  // fires naturally once the renderer is ready, so no extra retry wiring is needed. Any other
+  // error is unexpected and re-thrown so the caller's warn path still fires.
+  let openWebViews: Awaited<ReturnType<typeof papi.webViews.getAllOpenWebViewDefinitions>>;
+  try {
+    openWebViews = await papi.webViews.getAllOpenWebViewDefinitions();
+  } catch (e) {
+    const msg = getErrorMessage(e);
+    if (msg.includes('wait-for-net-obj')) {
+      papi.logger.debug(
+        `Default active project picker: WebViewService not ready; returning 'no-empty'. Will retry on next web-view event (${msg})`,
+      );
+      return 'no-empty';
+    }
+    throw e;
+  }
   const emptyEditor = openWebViews.find(
-    (def) => def.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE && !def.projectId,
+    (def: { webViewType: string; projectId?: string }) =>
+      def.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE && !def.projectId,
   );
   if (!emptyEditor) return 'no-empty';
 

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -28,6 +28,11 @@ import { MarkerMenuItem } from 'platform-bible-react';
 // Note: src/main/shutdown-tasks.ts has a copy of this value — keep them in sync.
 export const SCRIPTURE_EDITOR_WEBVIEW_TYPE = 'platformScriptureEditor.react';
 
+// Substring present in the error thrown by the network-object layer when a service hasn't
+// registered yet (30-second cold-start timeout). Used to distinguish expected timing errors
+// from unexpected failures in getAllOpenWebViewDefinitions.
+export const WEBVIEW_SERVICE_NOT_READY_ERROR_SUBSTRING = 'wait-for-net-obj';
+
 /**
  * Check deep equality of two values such that two equal objects or arrays created in two different
  * iframes successfully test as equal
@@ -591,7 +596,7 @@ export async function openDefaultActiveProjectIfApplicable(
     openWebViews = await papi.webViews.getAllOpenWebViewDefinitions();
   } catch (e) {
     const msg = getErrorMessage(e);
-    if (msg.includes('wait-for-net-obj')) {
+    if (msg.includes(WEBVIEW_SERVICE_NOT_READY_ERROR_SUBSTRING)) {
       papi.logger.debug(
         `Default active project picker: WebViewService not ready; returning 'no-empty'. Will retry on next web-view event (${msg})`,
       );


### PR DESCRIPTION
I was running into a problem where I couldn't open a project. Home wouldn't load unless I closed all of the tabs and even then clicking the "open" button next to a project didn't work. The project picker also didn't work. 

It looked like there might be a race condition with when the renderer and WebViewService are up so add a try catch to catch if it hasn't loaded yet and retry later rather than just failing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2393)
<!-- Reviewable:end -->
