### PR TITLE
fix(flaky): should open the About dialog from the Help menu

### DIFF
--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -2,7 +2,6 @@
 // Per-feature E2E tests MUST use cdp.fixture instead. See e2e-tests/tests/_example/.
 import { test, expect } from '../../fixtures/papi.fixture';
 import {
-  PROCESS_READY_TIMEOUT,
   sendPapiRequestOnce,
   waitForAppReady,
   waitForPapiMethodRegistered,

--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -17,16 +17,15 @@ test.describe('UI Interaction', () => {
   // which blocks until `extensionService.initialize()` finishes in the extension
   // host. On slow CI that can exceed the default 10s PAPI request timeout.
   const SLOW_CI_PAPI_TIMEOUT_MS = 30_000;
-  // On slow macOS CI runners the settings data provider can take longer than the
-  // default 60 s to appear in rpc.discover. Use PROCESS_READY_TIMEOUT (120 s) as
-  // the upper bound; the beforeAll timeout is extended below to fit both this wait
-  // and the subsequent sendPapiRequestOnce call.
-  const SETTINGS_REGISTRATION_TIMEOUT_MS = PROCESS_READY_TIMEOUT;
+  // On slow macOS ARM64 CI runners the settings data provider can take longer than
+  // 120 s to appear in rpc.discover (120 s proved insufficient despite the fix in
+  // #2357). Use 180 s here so the beforeAll timeout has enough headroom.
+  const SETTINGS_REGISTRATION_TIMEOUT_MS = 180_000;
 
   test.beforeAll(async ({ electronApp }) => {
-    // Extend the beforeAll timeout to fit SETTINGS_REGISTRATION_TIMEOUT_MS (120 s)
+    // Extend the beforeAll timeout to fit SETTINGS_REGISTRATION_TIMEOUT_MS (180 s)
     // + SLOW_CI_PAPI_TIMEOUT_MS (30 s) + slack (30 s) on the slowest CI runners.
-    test.setTimeout(180_000);
+    test.setTimeout(240_000);
     // Maximize the window once so everything is visible and clickable for all tests
     // Wait for the first window to exist before maximizing
     await electronApp.firstWindow({ timeout: 10_000 });

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -131,10 +131,15 @@ describe('useProjectPickerData', () => {
 
     const { result } = renderHook(() => useProjectPickerData());
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.currentProject?.fullName).toBe('Genesis Project');
-    });
+    await waitFor(
+      () => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.currentProject?.fullName).toBe('Genesis Project');
+      },
+      // Default 1000 ms is too tight for the three concurrent usePromise chains to
+      // settle on slow Windows CI runners; 3000 ms gives comfortable headroom.
+      { timeout: 3000 },
+    );
     expect(result.current.currentProject?.id).toBe('proj-abc');
   });
 


### PR DESCRIPTION
## Summary

Fixes two intermittent CI failures identified across the last 7 days on `main`.

### Flaky test #1 — E2E macOS (flake rate ~60 % on macOS, ~30 % overall)

**Test:** `UI Interaction › should open the About dialog from the Help menu`  
**File:** `e2e-tests/tests/smoke/ui-interaction.spec.ts`  
**Platform:** macOS ARM64 CI only  

**Root cause:** `waitForPapiMethodRegistered` polls `rpc.discover` waiting for `object:platform.settingsServiceDataProvider-data.set` to appear. On slow macOS ARM64 CI runners, the settings service data provider (which must wait for `extensionService.initialize()` to complete) can take longer than 120 s. PR #2357 already raised this from 60 s → 120 s, but 120 s still proved insufficient on Jun 9 (SHA `7238c67`).

**Fix:** Raise the local `SETTINGS_REGISTRATION_TIMEOUT_MS` to 180 s and the `beforeAll` budget to 240 s (180 + 30 PAPI timeout + 30 slack).

**Evidence:** 3 failures on SHAs `178a920910` (Jun 5, run attempt 3), `204f8eb20d` (Jun 8), `7238c6719e` (Jun 9); passed on `51e695cff2` (Jun 7) and `598d31eb4a` (Jun 11). Consistent error: `PAPI method "object:platform.settingsServiceDataProvider-data.set" not listed in rpc.discover within 60000ms/120000ms`.

### Flaky test #2 — Unit Windows (flake rate ~28 % on Windows)

**Test:** `useProjectPickerData › returns currentProject from the first open Scripture Editor web view`  
**File:** `src/renderer/hooks/use-project-picker-data.hook.test.ts`  
**Platform:** Windows CI only  

**Root cause:** The `waitFor` default timeout of 1000 ms is too tight for `useProjectPickerData`'s three concurrent `usePromise` chains (`currentProject`, `recentProjects`, `allProjects`) to all settle on slow Windows CI runners. Both Jun 11 failures show `isLoading` still `true` when the timeout fires. The same test passes on macOS and Linux in the same commit.

**Fix:** Add `{ timeout: 3000 }` to the specific `waitFor` that checks `isLoading` and `currentProject.fullName`. This gives 3× more time for the async chains to complete on slow runners without changing test semantics.

**Evidence:** 2 failures on SHAs `96861c6589` and `598d31eb4a` (both Jun 11); passed on all prior Windows runs in the 7-day window. Error: `AssertionError: expected true to be false` at `use-project-picker-data.hook.test.ts:135`.

## Test plan

- [ ] Confirm macOS E2E "should open the About dialog from the Help menu" passes across multiple CI runs (no 120 s timeout exceeded)
- [ ] Confirm Windows unit test "returns currentProject from the first open Scripture Editor web view" passes consistently
- [ ] Verify no regressions in other E2E smoke tests or unit tests

https://claude.ai/code/session_01AYigTNppj8tTfrh19khVQ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01AYigTNppj8tTfrh19khVQ4)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2394)
<!-- Reviewable:end -->
