### PR TITLE
small user profile style fixes

### DIFF
--- a/src/renderer/components/user-profile-popover/user-profile-popover.component.tsx
+++ b/src/renderer/components/user-profile-popover/user-profile-popover.component.tsx
@@ -7,6 +7,7 @@ import {
   PopoverHeader,
   PopoverTitle,
   PopoverTrigger,
+  Separator,
   Skeleton,
   ToggleGroup,
   ToggleGroupItem,
@@ -251,7 +252,7 @@ export function UserProfilePopover() {
         </Tooltip>
       </TooltipProvider>
       <PopoverContent align="end" className={cn('tw:w-80 tw:gap-1.5')}>
-        <PopoverHeader className="tw:gap-0 tw:border-b tw:px-2 tw:pb-1.5">
+        <PopoverHeader className="tw:gap-0 tw:px-2">
           {isRegistrationLoading ? (
             <>
               <Skeleton data-testid="user-profile-name-skeleton" className="tw:h-4 tw:w-32" />
@@ -279,12 +280,13 @@ export function UserProfilePopover() {
             </>
           )}
         </PopoverHeader>
+        <Separator />
         <ToggleGroup
           type="single"
           value={safeInterfaceMode}
           onValueChange={handleInterfaceModeChange}
           spacing={2}
-          className="tw:w-full tw:items-stretch tw:px-2"
+          className="tw:mb-0.5 tw:w-full tw:items-stretch tw:px-2"
         >
           <ToggleGroupItem
             value="simple"
@@ -331,7 +333,8 @@ export function UserProfilePopover() {
             </span>
           </ToggleGroupItem>
         </ToggleGroup>
-        <div className="tw:flex tw:flex-col tw:gap-0 tw:border-t tw:pt-1">
+        <Separator />
+        <div className="tw:flex tw:flex-col tw:gap-0">
           <Button
             variant="ghost"
             size="sm"
@@ -363,7 +366,6 @@ export function UserProfilePopover() {
             value={primaryLanguage}
             onValueChange={handleLanguageChange}
             size="sm"
-            spacing={2}
             className="tw:min-w-0 tw:flex-1 tw:flex-wrap tw:justify-end"
           >
             {sortedLanguageEntries.map(([tag, info]) => (
@@ -389,7 +391,6 @@ export function UserProfilePopover() {
             value={appearanceValue}
             onValueChange={handleAppearanceChange}
             size="sm"
-            spacing={2}
           >
             <ToggleGroupItem
               value="light"


### PR DESCRIPTION
- use separator instead of border
- use toggle group instead of indivudual buttons

before:
<img width="330" height="320" alt="image" src="https://github.com/user-attachments/assets/99b160d3-c1af-4c4e-8d1e-50a9e6aacc7c" />

after:
<img width="416" height="397" alt="image" src="https://github.com/user-attachments/assets/fd419b7c-0561-4a73-aa7d-d22d6f888dbb" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2398)
<!-- Reviewable:end -->
