### PR TITLE
ci: make Windows/macOS E2E smoke tests non-blocking

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -169,9 +169,22 @@ jobs:
         if: ${{ matrix.os == env.OS_LINUX }}
         run: xvfb-run --auto-servernum npm run test:e2e:smoke
 
+      # Non-blocking on Windows AND macOS: the smoke suite is chronically flaky on the
+      # smaller macOS runners (extension host fails to start under load; see #2336,
+      # #2338, #2357 for failed timeout-based fixes), and Windows has occasional E2E
+      # flakes of its own (e.g. the theme-toggle failure on 2026-06-12). Linux remains
+      # blocking; it passed every run in the prior 30 days. Failures still upload
+      # Playwright artifacts below and surface as a warning annotation.
+      # Remove continue-on-error once the macOS startup failure is resolved.
       - name: E2E tests (Windows/macOS)
+        id: e2e-win-mac
         if: ${{ matrix.os != env.OS_LINUX }}
+        continue-on-error: true
         run: npm run test:e2e:smoke
+
+      - name: Warn on non-blocking E2E failure (Windows/macOS)
+        if: ${{ steps.e2e-win-mac.outcome == 'failure' }}
+        run: echo "::warning title=E2E smoke tests failed (non-blocking)::E2E smoke tests failed on ${{ matrix.os }} but did not fail the build. See the playwright-results-${{ matrix.os }} artifact."
 
       - name: Upload Playwright test results
         if: ${{ !cancelled() }}


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: ai/workflow/e2e-nonblocking-win-mac-matt-06-12-2026

**Base**: origin/main

**Date**: 2026-06-12

**Review model**: Claude Fable 5

**Files changed**: 1

## Overview

Makes the "E2E tests (Windows/macOS)" step in `.github/workflows/test.yml` non-blocking (`continue-on-error: true`) while keeping the Linux E2E step fully blocking, so chronic E2E smoke flakiness stops turning `main` red while the root cause is investigated. A follow-up step emits a `::warning` annotation in the run summary whenever the non-blocking step fails, and the existing Playwright artifact upload (`if: !cancelled()`) continues to capture traces/videos/screenshots for investigation.

The change is backed by a 30-day CI census (May 13 - June 12, 59 runs on `main`): the E2E smoke suite caused 13 of 16 red runs - 12 on macOS (11 from a single root cause: the extension host's websocket closes during dev-mode startup on the small 3-core/7GB macOS runners, after which the settings data provider never registers) and 1 on Windows (theme-toggle test). Three prior timeout-raising fixes (#2336, #2338, #2357; 60s → 90s → 120s) did not resolve the macOS failure. The Linux E2E step passed in every run over the same window.

## API Changes

None. The only changed file is `.github/workflows/test.yml`. No files in `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `papi.d.ts`, or extension type declarations were touched.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **`continue-on-error: true` applies to the combined Windows/macOS step, but the justification comment was macOS-specific** - a genuine Windows E2E regression would surface only as a warning annotation on a green build, without the comment documenting why Windows is included. _(fixed during review: comment updated to explicitly document the Windows rationale - Windows has occasional E2E flakes of its own, e.g. the theme-toggle failure on 2026-06-12 - and to note Linux passed every run in the prior 30 days; amended into the single commit)_

Author response: Including Windows was a deliberate, data-informed decision made before this review - the author has seen failures on both Windows and macOS and chose to unblock both rather than chase a moving target. The author requested the comment update to document this and asked for it to be amended into the existing commit rather than added as a new one.

### Minor — Consider

- [ ] ~~Passive failure visibility: the warning annotation only appears inside the workflow run's summary - nothing proactively notifies anyone when the non-blocking Windows/macOS smoke tests fail on a `main` push, so the temporary measure could quietly become permanent. Possible follow-ups: a scheduled job scanning recent runs for the warning, or periodic manual review.~~ _(author: fine as-is - manual inspection on demand is sufficient; the in-code removal reminder also mitigates this)_

Author response: Author dismissed the only minor finding - on-demand manual inspection is the intended workflow.

### Template Propagation

#### Shared Regions Modified

None. The changed file contains no `#region shared with` markers.

#### Extension Config Changes

None. `.github/workflows/test.yml` is outside `extensions/` and is specific to paranext-core; no propagation to template repos needed.

## Positive Observations

- Correct GitHub Actions semantics throughout, verified by multiple analyzers: the warning step checks `steps.e2e-win-mac.outcome` (the pre-`continue-on-error` result) rather than `conclusion` (which would always be `success`); on Linux the step is skipped (`outcome == 'skipped'`), so the warning correctly never fires there; and because `continue-on-error` keeps the job successful, the implicit `success()` in the warning step's `if` does not suppress the annotation.
- The artifact name referenced in the warning message (`playwright-results-${{ matrix.os }}`) exactly matches the upload step's artifact name, and that step's `if: ${{ !cancelled() }}` guarantees artifacts still upload after a non-blocking failure.
- High-quality justification comment: cites three real prior fix attempts (#2336, #2338, #2357 - all verified in git history), states an explicit removal condition, and follows the same in-file convention as the existing snapcraft-pin workaround comment.
- Minimal possible gate adjustment: Linux E2E remains fully blocking and all other quality gates (typecheck, lint, unit tests, packaging) are untouched. No silent skipping - failures still appear as a red step in the job log plus an explicit warning annotation.

## Interview Notes

- **Stated purpose**: Make Windows/macOS E2E smoke tests non-blocking in CI (continue-on-error with a warning annotation) while keeping Linux blocking, so chronic macOS extension-host startup flakiness stops turning `main` red while it is investigated.
- **Platform-scoping decision**: The author deliberately included Windows in the non-blocking step (not just macOS). Rationale: the author has observed failures on both platforms; the 30-day census shows 1 Windows E2E failure (theme-toggle, possibly a real product bug in the week-old user-profile popover rather than flakiness) alongside the 12 macOS failures; and the author explicitly wants to avoid "chasing a moving target." Linux, with zero E2E failures in 30 days, remains the blocking gate.
- **Deliberately deferred work**: The author chose NOT to include the candidate fix for the macOS root cause (replacing the `beforeAll` PAPI settings round-trip in `ui-interaction.spec.ts` with seeding `settings.json` into the isolated user-data dir) in this PR. This PR is intentionally scoped to the CI gate change only.
- The author demonstrated full understanding of the change and the underlying failure analysis (the author directed the investigation that produced it). No unresolved items.
- An untracked file at the repo root (`0001-feat-dynamic-menu-items-driven-by-context-keys-when-.patch`, the author's unrelated June 11 format-patch export) was deliberately excluded from this branch and from all review commits.

## In-Review Quality Check

- The only in-review change was to a YAML comment in `.github/workflows/test.yml`, amended into the existing commit per the author's request.
- YAML re-validated clean after the amend.
- The TypeScript/C# quality suite (`typecheck`, `lint`, `format`, `npm test`) is not applicable to a workflow-comment-only change; the repo's pre-commit hooks (secret scan, lint-staged, architecture boundary checks) ran on the amend and passed.

## Suggested Review Focus

Prioritized areas for the author-reviewer meeting:

- [ ] Is the team comfortable losing the blocking E2E gate on Windows (not just macOS)? The data shows only 1 Windows E2E failure in 30 days, and that one may be a real product bug (theme-toggle via user profile popover, 3/3 attempts failed on fresh app instances - artifacts on run 27418667383).
- [ ] Follow-up plan for the macOS root cause so `continue-on-error` actually gets removed: the highest-leverage next steps identified are (a) closing the CI observability gap (extension-host stdout/stderr and `main.log` are currently lost - pipe Electron child output into test output and copy logs into `test-results/` on failure) and (b) eliminating the fragile `beforeAll` PAPI settings round-trip by seeding `settings.json` directly.
- [ ] Whether on-demand manual inspection of warning annotations is sufficient long-term visibility for non-blocking failures (author's current position: yes).
<!-- review-paratext:summary:end -->

---

## Summary

The E2E smoke suite caused 13 of 16 red runs on `main` over the last 30 days (May 13 - June 12, 59 runs): 12 on macOS and 1 on Windows. The **Linux E2E step passed in every run** over the same window.

11 of the 12 macOS failures are a single root cause: the `beforeAll` hook in `ui-interaction.spec.ts` waits for the settings data provider to register, and on the smaller macOS runners (3 cores / 7GB) the extension host's websocket connection closes during dev-mode startup (`PAPI error: "Web socket N has closed"`), after which the provider never registers. Three timeout-based fixes (#2336, #2338, #2357, raising the wait 60s → 90s → 120s) did not resolve it - the failure is a process dying under load, not slowness.

This PR keeps Linux E2E blocking and makes the Windows/macOS E2E step non-blocking (`continue-on-error: true`) so `main` stays green while we investigate the macOS extension-host startup failure with real evidence instead of timeout guesses.

## Changes

- Add `continue-on-error: true` to the "E2E tests (Windows/macOS)" step (Linux step untouched and still blocking)
- Add a follow-up step that emits a `::warning` annotation in the run summary when the non-blocking step fails, so failures stay visible
- Playwright artifact upload already runs on failure (`if: !cancelled()`), so traces/videos/screenshots keep flowing for investigation

## Removal condition

Remove `continue-on-error` once the macOS extension-host startup failure is resolved (tracked in the workflow comment).

## AI Involvement

**Level**: generated

- Failure analysis (30-day CI run census, log classification across all 16 failed runs) and the workflow change were AI-generated with human direction and review.

## Testing

- [x] YAML validated
- [x] No code changes - workflow only; Linux blocking behavior unchanged

## Risk Level

Low - worst case, a real Windows/macOS-only regression surfaces as a warning annotation instead of a red check until `continue-on-error` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2399)
<!-- Reviewable:end -->

