### PR TITLE
PT-3992 Reopen previous project

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -79,6 +79,7 @@
     "plusplus",
     "proxied",
     "pubnumber",
+    "recents",
     "reinitializing",
     "reserialized",
     "saroj",

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -509,7 +509,10 @@ function createPickerMocks(): PickerMocks {
   const mockRecordProjectOpened = vi.fn().mockResolvedValue(undefined);
   const mockDataProvidersGet = vi.fn().mockImplementation(async (name: string) => {
     if (name === 'platformScripture.recentlyOpenedProjects') {
-      return { get: mockRecentProjectsGet, recordProjectOpened: mockRecordProjectOpened };
+      return {
+        getRecentProjects: mockRecentProjectsGet,
+        recordProjectOpened: mockRecordProjectOpened,
+      };
     }
     return undefined;
   });

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -1792,6 +1792,31 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.getSharedProjects');
   });
 
+  it('falls through to S/R when getRecentProjects throws after service is obtained', async () => {
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      mockRecentProjectsGet,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    mockRecentProjectsGet.mockRejectedValueOnce(new Error('Storage read failed'));
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'paratextBibleSendReceive.getSharedProjects')
+        throw new Error('S/R not registered');
+      throw new Error(`Unexpected command in test: ${commandName}`);
+    });
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('no-send-receive');
+    expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.getSharedProjects');
+  });
+
   it("returns 'filled' even when recordProjectOpened throws in the recents path", async () => {
     const {
       papi,

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -1666,6 +1666,155 @@ describe('openDefaultActiveProjectIfApplicable', () => {
   });
 
   // #endregion Error and edge cases
+
+  // #region Recents-first behavior (Tasks 2-4)
+
+  it("returns 'filled' from recents and does not call S/R when a recent project opens", async () => {
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      mockRecordProjectOpened,
+      setRecentProjects,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    setRecentProjects(['proj-recent']);
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'platformScriptureEditor.openScriptureEditor') return undefined;
+      throw new Error(`Unexpected command in test: ${commandName}`);
+    });
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('filled');
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      'platformScriptureEditor.openScriptureEditor',
+      'proj-recent',
+    );
+    expect(mockSendCommand).not.toHaveBeenCalledWith('paratextBibleSendReceive.getSharedProjects');
+    expect(mockRecordProjectOpened).toHaveBeenCalledWith('proj-recent');
+  });
+
+  it('tries each recent project in order and opens the first one that succeeds', async () => {
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      mockRecordProjectOpened,
+      setRecentProjects,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    setRecentProjects(['proj-gone', 'proj-alive']);
+    mockSendCommand.mockImplementation(async (commandName: string, projectId?: string) => {
+      if (commandName === 'platformScriptureEditor.openScriptureEditor') {
+        if (projectId === 'proj-gone') throw new Error('Project not found');
+        return undefined;
+      }
+      throw new Error(`Unexpected command in test: ${commandName}`);
+    });
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('filled');
+    expect(mockSendCommand).toHaveBeenCalledTimes(2);
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      'platformScriptureEditor.openScriptureEditor',
+      'proj-gone',
+    );
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      'platformScriptureEditor.openScriptureEditor',
+      'proj-alive',
+    );
+    expect(mockRecordProjectOpened).toHaveBeenCalledWith('proj-alive');
+    expect(mockSendCommand).not.toHaveBeenCalledWith('paratextBibleSendReceive.getSharedProjects');
+  });
+
+  it('falls through to S/R when all recent projects fail to open', async () => {
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      setRecentProjects,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    setRecentProjects(['proj-gone']);
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'platformScriptureEditor.openScriptureEditor')
+        throw new Error('Project not found');
+      if (commandName === 'paratextBibleSendReceive.getSharedProjects')
+        throw new Error('S/R not registered');
+      throw new Error(`Unexpected command in test: ${commandName}`);
+    });
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('no-send-receive');
+    expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.getSharedProjects');
+  });
+
+  it('falls through to S/R when recentlyOpenedProjects service is unavailable', async () => {
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      mockDataProvidersGet,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    mockDataProvidersGet.mockResolvedValue(undefined);
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'paratextBibleSendReceive.getSharedProjects')
+        throw new Error('S/R not registered');
+      throw new Error(`Unexpected command in test: ${commandName}`);
+    });
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('no-send-receive');
+    expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.getSharedProjects');
+  });
+
+  it("returns 'filled' even when recordProjectOpened throws in the recents path", async () => {
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      mockRecordProjectOpened,
+      setRecentProjects,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    setRecentProjects(['proj-recent']);
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'platformScriptureEditor.openScriptureEditor') return undefined;
+      throw new Error(`Unexpected command in test: ${commandName}`);
+    });
+    mockRecordProjectOpened.mockRejectedValue(new Error('Storage write failed'));
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('filled');
+  });
+
+  // #endregion Recents-first behavior (Tasks 2-4)
 });
 
 // #endregion openDefaultActiveProjectIfApplicable

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -419,11 +419,14 @@ interface PickerMocks {
   mockProjectDataProvidersGet: ReturnType<typeof vi.fn>;
   mockDataProvidersGet: ReturnType<typeof vi.fn>;
   mockRecordProjectOpened: ReturnType<typeof vi.fn>;
+  mockRecentProjectsGet: ReturnType<typeof vi.fn>;
   /**
    * Sets the `canUserEditScripture` mock return value for a specific project id. Values default to
    * `true` for any project id not configured. Call before triggering the picker.
    */
   setCanUserEditScripture: (projectId: string, canEdit: boolean) => void;
+  /** Sets the list of recently opened project IDs. */
+  setRecentProjects: (ids: string[]) => void;
   /** Synthesize a `webViews.onDidOpenWebView` event from within a test. */
   fireWebViewOpen: () => void;
   /**
@@ -501,10 +504,12 @@ function createPickerMocks(): PickerMocks {
     canUserEditScripture: async () => canUserEditScriptureByProjectId.get(projectId) ?? true,
   }));
 
+  const mockRecentProjects: string[] = [];
+  const mockRecentProjectsGet = vi.fn().mockImplementation(async () => [...mockRecentProjects]);
   const mockRecordProjectOpened = vi.fn().mockResolvedValue(undefined);
   const mockDataProvidersGet = vi.fn().mockImplementation(async (name: string) => {
     if (name === 'platformScripture.recentlyOpenedProjects') {
-      return { recordProjectOpened: mockRecordProjectOpened };
+      return { get: mockRecentProjectsGet, recordProjectOpened: mockRecordProjectOpened };
     }
     return undefined;
   });
@@ -536,7 +541,12 @@ function createPickerMocks(): PickerMocks {
     mockProjectDataProvidersGet,
     mockDataProvidersGet,
     mockRecordProjectOpened,
+    mockRecentProjectsGet,
     setCanUserEditScripture,
+    setRecentProjects: (ids: string[]) => {
+      mockRecentProjects.length = 0;
+      mockRecentProjects.push(...ids);
+    },
     fireWebViewOpen: () => {
       if (!webViewOpenListener) throw new Error('fireWebViewOpen: no listener captured');
       webViewOpenListener({});

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -555,6 +555,49 @@ export type DefaultProjectPickerOutcome =
   | 'filled';
 
 /**
+ * Try to open the most-recently-used project from the `platformScripture.recentlyOpenedProjects`
+ * data provider. Returns `'filled'` if a recent project was successfully opened, or `undefined` if
+ * the service is unavailable, the recents list is empty, or every recent project fails to open (in
+ * which case the caller should fall through to the S/R-based picker).
+ */
+async function tryOpenFromRecentlyOpened(
+  papi: typeof PapiBackend,
+): Promise<DefaultProjectPickerOutcome | undefined> {
+  let recentProjects: string[];
+  let recordOpened: (projectId: string) => Promise<void>;
+  try {
+    const service = await papi.dataProviders.get('platformScripture.recentlyOpenedProjects');
+    if (!service) return undefined;
+    recentProjects = (await service.get('RecentProjects', undefined)) ?? [];
+    recordOpened = (projectId: string) => service.recordProjectOpened(projectId);
+  } catch (e) {
+    papi.logger.debug(
+      `Default active project picker: recentlyOpenedProjects unavailable; skipping recents (${getErrorMessage(e)})`,
+    );
+    return undefined;
+  }
+  for (const projectId of recentProjects) {
+    try {
+      await papi.commands.sendCommand('platformScriptureEditor.openScriptureEditor', projectId);
+      papi.logger.info(`Default active project picker: opened recently-used project=${projectId}`);
+      try {
+        await recordOpened(projectId);
+      } catch (e) {
+        papi.logger.warn(
+          `Default active project picker: failed to record recently-opened project ${projectId}: ${getErrorMessage(e)}`,
+        );
+      }
+      return 'filled';
+    } catch (e) {
+      papi.logger.debug(
+        `Default active project picker: recent project ${projectId} failed to open, trying next (${getErrorMessage(e)})`,
+      );
+    }
+  }
+  return undefined;
+}
+
+/**
  * Attempt to fill the empty Scripture Editor in the simple layout with the most-recently-active
  * shared project. Candidates come from `paratextBibleSendReceive.getSharedProjects` (internet S/R
  * excludes Observer-only projects upstream; local-repository S/R does not). The picker partitions
@@ -586,6 +629,11 @@ export async function openDefaultActiveProjectIfApplicable(
     (def) => def.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE && !def.projectId,
   );
   if (!emptyEditor) return 'no-empty';
+
+  // Before consulting S/R, try the recently-opened-projects list. If a recent project opens
+  // successfully, return immediately without touching the S/R service at all.
+  const recentsOutcome = await tryOpenFromRecentlyOpened(papi);
+  if (recentsOutcome !== undefined) return recentsOutcome;
 
   // Try `paratextBibleSendReceive.getSharedProjects` directly. If S/R hasn't activated yet (cold
   // start, picker fires inside `platformScriptureEditor.activate()` before `paratextBibleSendReceive`

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -560,46 +560,43 @@ export type DefaultProjectPickerOutcome =
 async function tryOpenFromRecentlyOpened(
   papi: typeof PapiBackend,
 ): Promise<DefaultProjectPickerOutcome | undefined> {
-  let recentProjects: string[];
-  let recordOpened: (projectId: string) => Promise<void>;
   try {
     const service = await papi.dataProviders.get('platformScripture.recentlyOpenedProjects');
     if (!service) return undefined;
     // Data-provider getter requires an explicit selector argument, even though the value is ignored.
-    recentProjects = (await service.getRecentProjects(undefined)) ?? [];
-    recordOpened = (projectId: string) => service.recordProjectOpened(projectId);
+    const recentProjects = (await service.getRecentProjects(undefined)) ?? [];
+    return recentProjects.reduce(
+      async (prev: Promise<DefaultProjectPickerOutcome | undefined>, projectId: string) => {
+        const earlier = await prev;
+        if (earlier !== undefined) return earlier;
+        try {
+          await papi.commands.sendCommand('platformScriptureEditor.openScriptureEditor', projectId);
+          papi.logger.info(
+            `Default active project picker: opened recently-used project=${projectId}`,
+          );
+          try {
+            await service.recordProjectOpened(projectId);
+          } catch (e) {
+            papi.logger.warn(
+              `Default active project picker: failed to record recently-opened project ${projectId}: ${getErrorMessage(e)}`,
+            );
+          }
+          return 'filled' as const;
+        } catch (e) {
+          papi.logger.debug(
+            `Default active project picker: recent project ${projectId} failed to open, trying next (${getErrorMessage(e)})`,
+          );
+          return undefined;
+        }
+      },
+      Promise.resolve<DefaultProjectPickerOutcome | undefined>(undefined),
+    );
   } catch (e) {
     papi.logger.debug(
       `Default active project picker: recentlyOpenedProjects unavailable; skipping recents (${getErrorMessage(e)})`,
     );
     return undefined;
   }
-  return recentProjects.reduce(
-    async (prev: Promise<DefaultProjectPickerOutcome | undefined>, projectId: string) => {
-      const earlier = await prev;
-      if (earlier !== undefined) return earlier;
-      try {
-        await papi.commands.sendCommand('platformScriptureEditor.openScriptureEditor', projectId);
-        papi.logger.info(
-          `Default active project picker: opened recently-used project=${projectId}`,
-        );
-        try {
-          await recordOpened(projectId);
-        } catch (e) {
-          papi.logger.warn(
-            `Default active project picker: failed to record recently-opened project ${projectId}: ${getErrorMessage(e)}`,
-          );
-        }
-        return 'filled' as const;
-      } catch (e) {
-        papi.logger.debug(
-          `Default active project picker: recent project ${projectId} failed to open, trying next (${getErrorMessage(e)})`,
-        );
-        return undefined;
-      }
-    },
-    Promise.resolve<DefaultProjectPickerOutcome | undefined>(undefined),
-  );
 }
 
 /**

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -565,7 +565,7 @@ async function tryOpenFromRecentlyOpened(
   try {
     const service = await papi.dataProviders.get('platformScripture.recentlyOpenedProjects');
     if (!service) return undefined;
-    recentProjects = (await service.get('RecentProjects', undefined)) ?? [];
+    recentProjects = (await service.getRecentProjects(undefined)) ?? [];
     recordOpened = (projectId: string) => service.recordProjectOpened(projectId);
   } catch (e) {
     papi.logger.debug(

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -565,6 +565,11 @@ async function tryOpenFromRecentlyOpened(
     if (!service) return undefined;
     // Data-provider getter requires an explicit selector argument, even though the value is ignored.
     const recentProjects = (await service.getRecentProjects(undefined)) ?? [];
+    // Try each recent project in order until one opens successfully — in almost all cases the first
+    // entry opens and the loop exits immediately. `reduce` with a Promise accumulator is used instead
+    // of `for...of + await` to satisfy the no-await-in-loop ESLint rule; each callback awaits the
+    // previous result before deciding whether to attempt the next project, so entries are tried
+    // sequentially (not in parallel) and the chain short-circuits as soon as one succeeds.
     return recentProjects.reduce(
       async (prev: Promise<DefaultProjectPickerOutcome | undefined>, projectId: string) => {
         const earlier = await prev;

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -573,25 +573,32 @@ async function tryOpenFromRecentlyOpened(
     );
     return undefined;
   }
-  for (const projectId of recentProjects) {
-    try {
-      await papi.commands.sendCommand('platformScriptureEditor.openScriptureEditor', projectId);
-      papi.logger.info(`Default active project picker: opened recently-used project=${projectId}`);
+  return recentProjects.reduce(
+    async (prev: Promise<DefaultProjectPickerOutcome | undefined>, projectId: string) => {
+      const earlier = await prev;
+      if (earlier !== undefined) return earlier;
       try {
-        await recordOpened(projectId);
-      } catch (e) {
-        papi.logger.warn(
-          `Default active project picker: failed to record recently-opened project ${projectId}: ${getErrorMessage(e)}`,
+        await papi.commands.sendCommand('platformScriptureEditor.openScriptureEditor', projectId);
+        papi.logger.info(
+          `Default active project picker: opened recently-used project=${projectId}`,
         );
+        try {
+          await recordOpened(projectId);
+        } catch (e) {
+          papi.logger.warn(
+            `Default active project picker: failed to record recently-opened project ${projectId}: ${getErrorMessage(e)}`,
+          );
+        }
+        return 'filled' as const;
+      } catch (e) {
+        papi.logger.debug(
+          `Default active project picker: recent project ${projectId} failed to open, trying next (${getErrorMessage(e)})`,
+        );
+        return undefined;
       }
-      return 'filled';
-    } catch (e) {
-      papi.logger.debug(
-        `Default active project picker: recent project ${projectId} failed to open, trying next (${getErrorMessage(e)})`,
-      );
-    }
-  }
-  return undefined;
+    },
+    Promise.resolve<DefaultProjectPickerOutcome | undefined>(undefined),
+  );
 }
 
 /**

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -533,12 +533,9 @@ export function selectProjectIdsForOpenMode(
  * - `'wrong-mode'` — `platform.interfaceMode` is not `'simple'`; the picker does nothing until it is.
  * - `'no-empty'` — no empty Scripture Editor (no `projectId`) is currently open. The driver may retry
  *   when a new web view opens.
- * - `'no-send-receive'` — `paratextBibleSendReceive.getSharedProjects` was unavailable (command not
- *   registered yet, or the extension is absent). Expected steady state on Platform.Bible; expected
- *   transiently on paratext-10-studio during the window between platform-scripture-editor's
- *   activation and paratextBibleSendReceive's activation. The driver retries on subsequent
- *   web-view-open and sync-completion events. Logged at debug, not warn — silent on
- *   Platform.Bible.
+ * - `'no-send-receive'` — `recentlyOpenedProjects` was empty or all entries failed to open, and S/R
+ *   is unavailable or hasn't activated yet. Expected on Platform.Bible on first launch (no recents
+ *   yet, no S/R). Logged at debug.
  * - `'failed'` — the open command rejected; logged at warn. The driver may retry on the next trigger.
  * - `'no-candidate'` — S/R was reachable, but no shared project passed the activity / `editedStatus`
  *   filter. Projects with `editedStatus` of `'new'` (not yet downloaded locally) or
@@ -599,11 +596,12 @@ async function tryOpenFromRecentlyOpened(
 
 /**
  * Attempt to fill the empty Scripture Editor in the simple layout with the most-recently-active
- * shared project. Candidates come from `paratextBibleSendReceive.getSharedProjects` (internet S/R
- * excludes Observer-only projects upstream; local-repository S/R does not). The picker partitions
- * remaining candidates by `canUserEditScripture` and prefers editable projects, falling back to the
- * most-recently-S/R'd Observer-only project so an Observer-only user is not stranded with an empty
- * editor (Observer projects are otherwise reachable via the project switcher).
+ * project. Candidates come first from `recentlyOpenedProjects` (tried in order, most-recent first);
+ * `paratextBibleSendReceive.getSharedProjects` is the fallback when recents is empty or all entries
+ * fail to open. The picker partitions remaining candidates by `canUserEditScripture` and prefers
+ * editable projects, falling back to the most-recently-S/R'd Observer-only project so an
+ * Observer-only user is not stranded with an empty editor (Observer projects are otherwise
+ * reachable via the project switcher).
  *
  * Idempotent: each invocation re-reads the dock and the shared-projects list. The driver in
  * {@link startDefaultProjectPicker} is responsible for re-invoking on events that change those

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -572,8 +572,8 @@ async function tryOpenFromRecentlyOpened(
     // sequentially (not in parallel) and the chain short-circuits as soon as one succeeds.
     return recentProjects.reduce(
       async (prev: Promise<DefaultProjectPickerOutcome | undefined>, projectId: string) => {
-        const earlier = await prev;
-        if (earlier !== undefined) return earlier;
+        const outcome = await prev;
+        if (outcome !== undefined) return outcome;
         try {
           await papi.commands.sendCommand('platformScriptureEditor.openScriptureEditor', projectId);
           papi.logger.info(

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -565,6 +565,7 @@ async function tryOpenFromRecentlyOpened(
   try {
     const service = await papi.dataProviders.get('platformScripture.recentlyOpenedProjects');
     if (!service) return undefined;
+    // Data-provider getter requires an explicit selector argument, even though the value is ignored.
     recentProjects = (await service.getRecentProjects(undefined)) ?? [];
     recordOpened = (projectId: string) => service.recordProjectOpened(projectId);
   } catch (e) {

--- a/extensions/src/platform-scripture/src/recently-opened-projects.service.ts
+++ b/extensions/src/platform-scripture/src/recently-opened-projects.service.ts
@@ -59,6 +59,9 @@ export class RecentlyOpenedProjectsDataProviderEngine
     super();
   }
 
+  // REVIEW: Does the get/set data-provider pattern make sense here? The setter always
+  // throws and the getter's selector is structurally required but always ignored — no foreseeable
+  // future use. Consider whether a plain PAPI command or a custom interface would be cleaner.
   async getRecentProjects(): Promise<string[]> {
     // Return a copy so callers cannot mutate the engine's internal cache by reference.
     return [...(await this.loadCache())];


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-3992-reopen-previous-project

**Base**: origin/main

**Date**: 2026-06-15

**Review model**: Claude Sonnet 4.6

**Files changed**: 2 (3 after in-review fixes)

## Overview

These changes implement the PT-3992 requirement: on every startup in simple mode, Platform.Bible now opens the most recently used project before falling back to the Send/Receive–based picker. A new private helper `tryOpenFromRecentlyOpened` consults the `platformScripture.recentlyOpenedProjects` data provider, iterates recents in order (most-recent first), and attempts to open each one. The first successful open returns `'filled'`; if the service is unavailable, the list is empty, or every entry fails to open, the function returns `undefined` and the existing S/R path runs unchanged. All existing behavior for users without S/R, without recents, or on non-simple layouts is preserved.

The change is well-contained: two files on the feature branch (utils + tests), with two small in-review additions to an adjacent service file and the test suite.

## API Changes

None. The only changed files are an internal extension utility (`platform-scripture-editor.utils.ts`) and its test file. No public API surfaces — `lib/platform-bible-react`, `lib/platform-bible-utils`, `papi.d.ts`, or extension type declarations — were touched.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [ ] ~~`platform-scripture-editor.utils.ts:795–799`: The `startDefaultProjectPicker` driver logs any outcome other than `'filled'` as `"unexpected outcome received"`. Now that `'no-send-receive'`, `'no-candidate'`, etc. are all expected non-error outcomes, this message may be misleading.~~ _(Once a user has successfully opened a project, that same project will almost always be available again on the next startup. In the rare case it isn't, the remaining logic is identical to before, so these outcomes won't become significantly more common.)_

- [x] `platform-scripture-editor.utils.ts:568`: `service.getRecentProjects(undefined)` — the explicit `undefined` argument reads as surprising since the engine ignores the selector entirely. _(fixed during review: added a one-line comment explaining that the data-provider getter structurally requires an explicit selector argument even though its value is always ignored. A `// REVIEW:` comment was also added in `recently-opened-projects.service.ts` at the engine's `getRecentProjects` method to flag the broader design question — see Suggested Review Focus. @tjcouch-sil to weigh in.)_

- [x] `platform-scripture-editor.utils.test.ts`: The catch path where `getRecentProjects()` itself throws (after the service is successfully obtained from `dataProviders.get`) had no test. _(fixed during review: added "falls through to S/R when getRecentProjects throws after service is obtained" using `mockRecentProjectsGet.mockRejectedValueOnce`. All 85 tests pass.)_

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- `tryOpenFromRecentlyOpened` is correctly private (not exported), keeping extension internals encapsulated.
- The `reduce`-based sequential async iteration correctly avoids the `no-restricted-syntax`/`no-await-in-loop` ESLint violations that a `for...of`/`await` pattern would trigger, while preserving short-circuit semantics — first successful open stops iteration immediately.
- Error isolation is consistent: `recordProjectOpened` failures are demoted to warnings and do not affect the `'filled'` outcome, matching the same best-effort pattern used in the existing S/R path.
- The observable semantics of `'no-send-receive'` are unchanged for callers of `openDefaultActiveProjectIfApplicable`; only the JSDoc description was updated to reflect the expanded context in which it now arises.
- Test coverage for the new recents-first path is thorough: five tests cover the happy path, sequential retry with one failure, all-recents-fail fallthrough, service-unavailable fallthrough, and `recordProjectOpened`-throws resilience.
- `setRecentProjects` mock helper mutates the backing array in-place, consistent with how all other mock state is managed in `createPickerMocks`.
- No user-visible strings were introduced — all new string literals are developer-facing logger messages, so there are no localization gaps.

## Interview Notes

**Purpose**: On every startup in simple mode, open the most recently opened project that is still available — regardless of whether S/R is installed, reachable, or has any qualifying candidates.

**Minor 1 (log message) dismissed**: Once a user has successfully opened any project, that same project will almost always still be available on next startup. In the rare case it isn't, the remaining logic (fall through to S/R) is identical to before, so the non-`'filled'` outcomes won't become significantly more common. Finding dismissed.

**Minor 2 (design question flagged for review)**: Author wanted a brief inline comment explaining the explicit `undefined` argument, and wants @tjcouch-sil to weigh in on the broader design question in code review rather than in a TODO comment. A `// REVIEW:` comment was added in `recently-opened-projects.service.ts` and @tjcouch-sil is called out in Suggested Review Focus below.

**Minor 3 (test gap)**: Author confirmed the missing test should be added. Test was written and passes.

## In-Review Quality Check

Three files staged; no TypeScript, lint, or format issues introduced. Tests run in the extensions workspace: 85 passed (up from 84 — the new test is included and green).

## Suggested Review Focus

- [ ] **`// REVIEW:` in `recently-opened-projects.service.ts:62`** — @tjcouch-sil: Does the get/set data-provider pattern make sense for `recentlyOpenedProjects`? The setter always throws and the getter's selector is structurally required but always ignored, with no foreseeable future use. Would a plain PAPI command or a custom interface be cleaner?
- [ ] **`tryOpenFromRecentlyOpened` fallthrough chain** — Confirm the three fallthrough cases (service unavailable, `getRecentProjects` throws, all entries fail to open) each produce the expected downstream behavior and that the S/R path is invoked exactly once per fallthrough with no risk of double-open.
<!-- review-paratext:summary:end -->

---



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2401)
<!-- Reviewable:end -->
