### PR TITLE
Add Claude Code attribution config and session-start hook

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -7,7 +7,7 @@ The human developer working in this session is the author of all commits and pul
 - Attribute commits and PRs to the human developer, not to yourself.
 - Use `git config user.name` and `git config user.email` to identify the author. If both are unset or look like placeholders (e.g. `noreply@`), ask the developer their name before making any commit.
 - Always append a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer to commits where Claude generated or substantially rewrote code.
-- PR bodies may include an "AI-assisted" label or a session link, but the PR *author* field must name the human.
+- PR bodies may include an "AI-assisted" label or a session link, but the PR _author_ field must name the human.
 
 ## Why this file exists
 

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,20 @@
+# AI Attribution
+
+The human developer working in this session is the author of all commits and pull requests. Claude is a tool, not an author.
+
+## Rules for Claude
+
+- Attribute commits and PRs to the human developer, not to yourself.
+- Use `git config user.name` and `git config user.email` to identify the author. If both are unset or look like placeholders (e.g. `noreply@`), ask the developer their name before making any commit.
+- Always append a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer to commits where Claude generated or substantially rewrote code.
+- PR bodies may include an "AI-assisted" label or a session link, but the PR *author* field must name the human.
+
+## Why this file exists
+
+Claude Code on the web runs in ephemeral containers — a fresh git clone starts every session, so personal `~/.claude/CLAUDE.md` files do not persist automatically. Without an explicit instruction file, Claude has no context about who the human author is and may default to attributing work to itself.
+
+This project-level file ensures the attribution rule applies to everyone on the team, regardless of whether they have set up personal Claude Code configuration.
+
+## For developers
+
+If you work in Claude Code on the web and want your full name (rather than your email) to appear in session-generated content, add a personal `~/.claude/CLAUDE.md` to your home directory. The `SessionStart` hook in this repo writes a baseline version automatically using your authenticated email; you can overwrite it with richer content by creating the file before the hook runs.

--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+# Only relevant in remote (cloud) containers. Local devs' ~/.claude/CLAUDE.md
+# persists naturally across sessions and should not be overwritten.
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+# Don't overwrite a personal ~/.claude/CLAUDE.md a developer already has.
+if [ -f "$HOME/.claude/CLAUDE.md" ]; then
+  exit 0
+fi
+
+# CLAUDE_CODE_USER_EMAIL is injected by the Claude Code on the web platform and
+# identifies the authenticated session owner. It is more reliable than
+# `git config user.name/email`, which may be unset or set to a bot identity
+# in a fresh container.
+AUTHOR="${CLAUDE_CODE_USER_EMAIL:-the human developer}"
+
+mkdir -p "$HOME/.claude"
+cat > "$HOME/.claude/CLAUDE.md" << EOF
+# Session Attribution
+Commits and PRs in this session are authored by ${AUTHOR}, not Claude.
+Claude may be credited as a generator (e.g., Co-Authored-By: Claude <noreply@anthropic.com>
+trailer, "AI-assisted" tag, or a session link in the PR body), but the commit author,
+PR author, and any prose about who did the work should attribute ${AUTHOR}.
+EOF

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -59,12 +59,18 @@ e2e-tests/playwright-report/
 e2e-tests/test-results/
 e2e-tests/.dev-server.pid
 
-# claude
-.claude
+# claude - personal/generated files are ignored; shared config is tracked in .claude/
+.claude/*
+!.claude/CLAUDE.md
+!.claude/settings.json
+!.claude/hooks/
+.claude/hooks/*
+!.claude/hooks/session-start.sh
 .claude.backup/
 .context
 c-sharp/CLAUDE.md
 CLAUDE.md
+!.claude/CLAUDE.md
 CLAUDE.md.backup
 
 docs/superpowers/


### PR DESCRIPTION
## The problem: ephemeral containers and vanishing personal config

Claude Code on the web runs every session in a fresh cloud container that starts from a clean `git clone`. There is no persistent home directory — anything a developer put in `~/.claude/CLAUDE.md` (their personal attribution instructions, preferences, etc.) simply does not exist when the new container starts.

Without that file, Claude has no context about who the human author is. It may default to attributing commits and pull requests to itself rather than to the developer who actually did the work.

### What I'm doing as a workaround

I added a personal `~/.claude/CLAUDE.md` in my own environment with attribution instructions. I also added a `SessionStart` hook (this PR) that re-creates it automatically on each remote container session using `CLAUDE_CODE_USER_EMAIL` — an environment variable the Claude Code on the web platform injects reliably for the authenticated user. That means even in a brand-new container I get the right attribution without doing anything manually.

### Why teammates might not do this — and why it matters

Not every developer on the team will set up a personal hook or know about the container-lifecycle issue. If they start a Claude Code web session and ask Claude to make commits or open PRs without any attribution config in place, Claude may credit itself as the author. That's wrong, and it's invisible — the developer might not notice until they look at commit history.

## What this PR adds

### `.claude/CLAUDE.md` — team-wide attribution rules
A project-level instruction file that tells Claude:
- The human developer running the session is the author of all commits and PRs
- Use `git config user.name/email` to identify them; ask if it looks like a bot placeholder
- Always append a `Co-Authored-By: Claude <noreply@anthropic.com>` trailer to AI-assisted commits
- Explains the ephemeral-container issue so the rule applies even without a personal config

### `.claude/hooks/session-start.sh` — baseline personal config for every session
On each remote container session:
1. Does nothing if the developer already has a `~/.claude/CLAUDE.md` (their personal config wins)
2. Otherwise writes a minimal `~/.claude/CLAUDE.md` using `CLAUDE_CODE_USER_EMAIL` so Claude knows who is running the session

This gives every team member correct attribution out of the box, without requiring them to set up anything personal.

### `.gitignore` update
The repo previously had a blanket `.claude` ignore, which excluded all Claude Code configuration. This PR replaces it with specific patterns:
- `!.claude/CLAUDE.md` — tracked (shared team instructions)
- `!.claude/settings.json` — tracked (hook registration)
- `!.claude/hooks/session-start.sh` — tracked (the hook itself)
- Everything else inside `.claude/` remains ignored (personal cache, local overrides, etc.)

## Trade-offs and limitations

- **Hook email vs. full name**: The hook writes the user's email (e.g. `alex_mercado@sil.org`) not their display name, because display names aren't reliably available in a fresh container. Developers who want their full name in session-generated content can create `~/.claude/CLAUDE.md` before or alongside the hook — see the note in `.claude/CLAUDE.md`.
- **Local developers**: The hook exits early if `CLAUDE_CODE_REMOTE` is not set, so it has no effect on developers running Claude Code locally. Their own `~/.claude/CLAUDE.md` persists normally.
- **Opt-out**: A developer who wants different behavior just needs to create `~/.claude/CLAUDE.md` before starting a session; the hook's "if not exists" guard means it will never overwrite their file.

---

AI-assisted | https://claude.ai/code/session_01Twqv39bx2Cc6AiSTsqymQ3

---
_Generated by [Claude Code](https://claude.ai/code/session_01Twqv39bx2Cc6AiSTsqymQ3)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2402)
<!-- Reviewable:end -->
