### PR TITLE
fix(flaky): retry sendPapiRequestOnce on transient WebSocket close in UI Interaction beforeAll

### DIFF
--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -44,12 +44,27 @@ test.describe('UI Interaction', () => {
       undefined,
       SETTINGS_REGISTRATION_TIMEOUT_MS,
     );
-    await sendPapiRequestOnce(
-      SETTINGS_SET_METHOD,
-      ['platform.interfaceLanguage', ['en']],
-      undefined,
-      SLOW_CI_PAPI_TIMEOUT_MS,
-    );
+    // The PAPI server sometimes responds with "Web socket N has closed" when the
+    // extension host's internal connection is briefly reset during startup. This
+    // is transient: re-confirm the method is still registered and retry the call.
+    for (let attempt = 1; ; attempt++) {
+      try {
+        await sendPapiRequestOnce(
+          SETTINGS_SET_METHOD,
+          ['platform.interfaceLanguage', ['en']],
+          undefined,
+          SLOW_CI_PAPI_TIMEOUT_MS,
+        );
+        break;
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (attempt >= 3 || !msg.includes('Web socket')) throw err;
+        await new Promise<void>((resolve) => {
+          setTimeout(resolve, 2_000);
+        });
+        await waitForPapiMethodRegistered(SETTINGS_SET_METHOD, undefined, 30_000);
+      }
+    }
   });
 
   test('should open the About dialog from the Help menu', async ({ mainPage }) => {


### PR DESCRIPTION
## Root-cause analysis

The `UI Interaction` smoke tests share a `beforeAll` that forces the interface language to English by calling `sendPapiRequestOnce` against `object:platform.settingsServiceDataProvider-data.set`. On slow macOS CI runners this call fails with:

```
PAPI error: {"code":0,"message":"Web socket N has closed"}
```

**What happens:** `waitForPapiMethodRegistered` successfully finds the method in `rpc.discover`, but by the time `sendPapiRequestOnce` opens its own fresh WebSocket and delivers the JSON-RPC request, the extension host has cycled its internal connection. The PAPI server returns a JSON-RPC error response (not a low-level socket close) saying the internal channel is gone.

This causes the entire describe block to fail (5 tests, 0 ms run time — the failure is in `beforeAll`). It is flaky because the same SHA passes when the runner is faster or when the Electron app happens to have fully settled before the request lands.

**Evidence from CI this week:**
| Run | SHA | Attempt | macOS E2E |
|-----|-----|---------|-----------|
| [27374750596](https://github.com/paranext/paranext-core/actions/runs/27374750596) | `598d31eb` | 1 | ✅ passed |
| [27374750596](https://github.com/paranext/paranext-core/actions/runs/27374750596) | `598d31eb` | 2 | ❌ "Web socket 3 has closed" |
| [27395606605](https://github.com/paranext/paranext-core/actions/runs/27395606605) | `7346d8ba` | 1 | ❌ "Web socket 4 has closed" |

## Fix

Wrap `sendPapiRequestOnce` in a retry loop (up to 3 attempts) that:
1. Catches errors whose message includes `"Web socket"` (the PAPI server's transient close signal)
2. Waits 2 s for the extension host to settle
3. Re-confirms the method is still registered (30 s budget — short, since it was recently found)
4. Retries the call

Non-`"Web socket"` errors and the 3-attempt exhaustion case still propagate immediately, so the fast-fail behaviour for real failures is preserved.

## Flaky-test scan summary (2026-06-08 → 2026-06-15, 8 Test workflow runs on `main`)

| # | Test | File | Flake rate | Platform |
|---|------|------|-----------|----------|
| 1 | `UI Interaction › should open the About dialog from the Help menu` | `e2e-tests/tests/smoke/ui-interaction.spec.ts:55` | 2/3 macOS runs (67%) | macOS |
| 2 | `UI Interaction › should open the About dialog via PAPI command` | `e2e-tests/tests/smoke/ui-interaction.spec.ts:78` | 1 flaky (Playwright-reported) | Windows |
| 3 | `useProjectPickerData › returns currentProject from the first open Scripture Editor web view` | `src/renderer/hooks/use-project-picker-data.hook.test.ts:135` | **Already fixed** in `4b2894ec` ("test: fix flaky use-project-picker-data hook test") | Windows |

## Test plan
- [ ] CI passes on this PR (macOS E2E smoke job green)
- [ ] The `UI Interaction` describe block completes all 5 tests on macOS
- [ ] Fast-fail still works: non-WebSocket errors still surface immediately

https://claude.ai/code/session_01K4eY3VFbx3PC9298N79i7V

---
_Generated by [Claude Code](https://claude.ai/code/session_01K4eY3VFbx3PC9298N79i7V)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2403)
<!-- Reviewable:end -->
