### PR TITLE
fix(storybook): resolve platform-bible-react/internal subpath from source

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -131,7 +131,15 @@ const config: StorybookConfig = {
       webpackConfig.resolve.alias = {
         ...webpackConfig.resolve.alias,
         '@': join(__dirname, '../lib/platform-bible-react/src'),
-        'platform-bible-react': join(__dirname, '../lib/platform-bible-react/src/index.ts'),
+        // Resolve the package from source. Exact-match ($) keys are required: the bare
+        // `platform-bible-react` rule would otherwise intercept the `platform-bible-react/internal`
+        // secondary entry point and mangle it to `src/index.ts/internal`, bypassing the package's
+        // `exports` map. Each entry point is aliased to its own source file.
+        'platform-bible-react/internal$': join(
+          __dirname,
+          '../lib/platform-bible-react/src/internal.ts',
+        ),
+        'platform-bible-react$': join(__dirname, '../lib/platform-bible-react/src/index.ts'),
         // `@papi/*` are runtime externals injected by the extension host - there is no npm package
         // for webpack to resolve. Extension components/web-views that use PAPI at runtime get pulled
         // into Storybook via their stories, so alias these to inert stubs. Exact-match ($) keys keep


### PR DESCRIPTION
## Problem

The `publish-docs.yml` workflow failed on `main` ([run 27588892416](https://github.com/paranext/paranext-core/actions/runs/27588892416/job/81565233805)) with:

```
SB_BUILDER-WEBPACK5_0002 (WebpackInvocationError): Module not found:
Error: Can't resolve 'platform-bible-react/internal' in './extensions/src/platform-scripture/src/components'
```

## Root cause

Storybook aliases `platform-bible-react` to its **source** (`src/index.ts`) so stories render components directly from source. That alias key is a non-exact (prefix) match, so it also intercepted the `platform-bible-react/internal` secondary entry point introduced in #2406 ("move lib exports to internal"), rewriting the request to `src/index.ts/internal` — which doesn't exist — and, because the alias matched, preventing webpack from falling through to the package's `exports` map.

Every other build (the app, the extensions) resolves `./internal` from `node_modules` via the package's `exports` map (`./internal` → `dist/internal.js`), so only the source-aliased Storybook build broke. The bug was latent on `ai/main` because `publish-docs.yml` only runs on `main`.

## Fix

In `.storybook/main.ts`, add an exact-match alias for the `platform-bible-react/internal` subpath → `src/internal.ts`, and make the bare `platform-bible-react` alias exact (`$`) so it no longer captures the subpath. This mirrors the existing `@papi/*$` exact-match convention already documented in the same file.

```ts
'platform-bible-react/internal$': join(__dirname, '../lib/platform-bible-react/src/internal.ts'),
'platform-bible-react$': join(__dirname, '../lib/platform-bible-react/src/index.ts'),
```

## Verification

`npm run storybook:build -- --output-dir docs-for-pages/paranext-core-storybook` now completes successfully — manager + preview built, output written, **0 resolve errors** (previously failed at the preview build step).

---
AI-assisted (Claude Code).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2411)
<!-- Reviewable:end -->
