### PR TITLE
fix settings ui: conditionally disable isEditable and isPublished

### DIFF
--- a/assets/localization/en.json
+++ b/assets/localization/en.json
@@ -343,6 +343,8 @@
   "%selectMultipleProjects_title_selectProjects%": "Select Projects",
   "%selectProject_title%": "Select Project",
   "%settings_defaultMessage_loadingOneSetting%": "Loading setting",
+  "%settings_disabledReason_isEditableBecausePublished%": "This setting is locked because the project is published.",
+  "%settings_disabledReason_isPublished%": "This setting cannot be changed from the settings tab.",
   "%settings_defaultMessage_loadingSettings%": "Loading settings...",
   "%settings_defaultMessage_noSettingComponent%": "Setting cannot be displayed",
   "%settings_defaultMessage_noSettings%": "No settings",

--- a/assets/localization/es.json
+++ b/assets/localization/es.json
@@ -461,6 +461,8 @@
   "%selectMultipleProjects_title_selectProjects%": "Seleccionar Proyectos",
   "%selectProject_title%": "Seleccionar Proyecto",
   "%settings_defaultMessage_loadingOneSetting%": "Cargando configuración",
+  "%settings_disabledReason_isEditableBecausePublished%": "Esta configuración está bloqueada porque el proyecto está publicado.",
+  "%settings_disabledReason_isPublished%": "Esta configuración no se puede cambiar desde la pestaña de configuración.",
   "%settings_defaultMessage_loadingSettings%": "Cargando settings...",
   "%settings_defaultMessage_noSettingComponent%": "Configuración no disponible",
   "%settings_defaultMessage_noSettings%": "Ninguna configuración",

--- a/src/renderer/components/settings-tabs/settings-components/project-setting.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-setting.component.tsx
@@ -21,6 +21,17 @@ export function ProjectSetting({
     defaultSetting,
   );
 
+  // `platform.isPublished` is the source of truth for whether the project is locked. When it's
+  // true, `platform.isEditable` is forced off in the UI and both switches become read-only.
+  const [isPublished] = useProjectSetting(projectId, 'platform.isPublished', false);
+  const isPublishedValue = isPublished === true;
+
+  const isPublishedSetting = settingKey === 'platform.isPublished';
+  const isEditableLockedByPublished = settingKey === 'platform.isEditable' && isPublishedValue;
+
+  const disabled = isPublishedSetting || isEditableLockedByPublished;
+  const displaySetting = isEditableLockedByPublished ? false : setting;
+
   const validateProjectSetting = async (
     currentSettingKey: ProjectSettingNames,
     newValue: ProjectSettingValues,
@@ -32,13 +43,14 @@ export function ProjectSetting({
   return (
     <Setting
       settingKey={settingKey}
-      setting={setting}
+      setting={displaySetting}
       setSetting={setSetting}
       isLoading={isLoading}
       validateProjectSetting={validateProjectSetting}
       label={label}
       description={description}
       className={className}
+      disabled={disabled}
     />
   );
 }

--- a/src/renderer/components/settings-tabs/settings-components/project-setting.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-setting.component.tsx
@@ -1,7 +1,15 @@
+import { useLocalizedStrings } from '@renderer/hooks/papi-hooks';
 import { useProjectSetting } from '@renderer/hooks/papi-hooks/use-project-setting.hook';
 import { ProjectSettingNames, ProjectSettingTypes } from 'papi-shared-types';
 import { projectSettingsService } from '@shared/services/project-settings.service';
+import { LocalizeKey } from 'platform-bible-utils';
+import { useMemo } from 'react';
 import { ProjectSettingProps, ProjectSettingValues, Setting } from './setting.component';
+
+const DISABLED_REASON_KEYS: LocalizeKey[] = [
+  '%settings_disabledReason_isPublished%',
+  '%settings_disabledReason_isEditableBecausePublished%',
+];
 
 /**
  * Provides a project-specific setting component by using the `Setting` component with
@@ -32,6 +40,13 @@ export function ProjectSetting({
   const disabled = isPublishedSetting || isEditableLockedByPublished;
   const displaySetting = isEditableLockedByPublished ? false : setting;
 
+  const [localizedStrings] = useLocalizedStrings(useMemo(() => DISABLED_REASON_KEYS, []));
+  let disabledReason: string | undefined;
+  if (isEditableLockedByPublished)
+    disabledReason = localizedStrings['%settings_disabledReason_isEditableBecausePublished%'];
+  else if (isPublishedSetting)
+    disabledReason = localizedStrings['%settings_disabledReason_isPublished%'];
+
   const validateProjectSetting = async (
     currentSettingKey: ProjectSettingNames,
     newValue: ProjectSettingValues,
@@ -51,6 +66,7 @@ export function ProjectSetting({
       description={description}
       className={className}
       disabled={disabled}
+      disabledReason={disabledReason}
     />
   );
 }

--- a/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
@@ -44,6 +44,8 @@ type BaseSettingProps<TSettingKey, TSettingValue> = {
   defaultSetting: TSettingValue;
   /** Additional css classes to help with unique styling of the Settings component */
   className?: string;
+  /** If true, render the control as read-only and reject change events */
+  disabled?: boolean;
 };
 
 /**
@@ -137,6 +139,7 @@ export function Setting({
   label,
   className,
   description,
+  disabled,
 }: CombinedSettingProps) {
   const validateSetting = validateOtherSetting || validateProjectSetting;
 
@@ -186,6 +189,7 @@ export function Setting({
   const handleChangeSetting = async (
     event: ChangeEvent<HTMLInputElement> | string[] | boolean | 'indeterminate',
   ) => {
+    if (disabled) return;
     let newValue: unknown;
 
     if (typeof event === 'string')
@@ -240,11 +244,31 @@ export function Setting({
 
     if (typeof setting === 'string' || typeof setting === 'number')
       component = (
-        <Input key={settingKey} onChange={debouncedHandleChange} defaultValue={setting} />
+        <Input
+          key={settingKey}
+          disabled={disabled}
+          onChange={debouncedHandleChange}
+          defaultValue={setting}
+        />
       );
     else if (typeof setting === 'boolean')
-      component = (
-        <Switch key={settingKey} onCheckedChange={debouncedHandleChange} defaultChecked={setting} />
+      // When disabled, render the switch as controlled so an externally driven value change (e.g.
+      // `platform.isEditable` flipping to false because `platform.isPublished` became true) is
+      // reflected visually. When not disabled, keep the existing uncontrolled behavior so the
+      // optimistic toggle state survives the debounced write.
+      component = disabled ? (
+        <Switch
+          key={`${settingKey}-disabled`}
+          disabled
+          onCheckedChange={debouncedHandleChange}
+          checked={setting}
+        />
+      ) : (
+        <Switch
+          key={`${settingKey}-enabled`}
+          onCheckedChange={debouncedHandleChange}
+          defaultChecked={setting}
+        />
       );
     else if (typeof setting === 'object')
       if (Array.isArray(setting) && settingKey === 'platform.interfaceLanguage') {
@@ -294,6 +318,7 @@ export function Setting({
     errorMessage,
     languages,
     defaultLanguages,
+    disabled,
   ]);
 
   return (

--- a/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
@@ -22,6 +22,7 @@ import {
   TooltipTrigger,
   UiLanguageSelector,
 } from 'platform-bible-react';
+import { Info } from 'lucide-react';
 import {
   debounce,
   getErrorMessage,
@@ -46,6 +47,8 @@ type BaseSettingProps<TSettingKey, TSettingValue> = {
   className?: string;
   /** If true, render the control as read-only and reject change events */
   disabled?: boolean;
+  /** Localized tooltip shown over the control when `disabled` is true */
+  disabledReason?: string;
 };
 
 /**
@@ -140,6 +143,7 @@ export function Setting({
   className,
   description,
   disabled,
+  disabledReason,
 }: CombinedSettingProps) {
   const validateSetting = validateOtherSetting || validateProjectSetting;
 
@@ -293,9 +297,23 @@ export function Setting({
         );
       }
 
+    const wrappedComponent =
+      disabled && disabledReason ? (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="setting-control-tooltip-trigger">{component}</span>
+            </TooltipTrigger>
+            <TooltipContent align="start">{disabledReason}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      ) : (
+        component
+      );
+
     return (
       <div className="setting-container">
-        {component}
+        {wrappedComponent}
         {errorMessage && (
           <>
             <Label className="error-label">
@@ -319,6 +337,7 @@ export function Setting({
     languages,
     defaultLanguages,
     disabled,
+    disabledReason,
   ]);
 
   return (
@@ -329,16 +348,25 @@ export function Setting({
         </Label>
       ) : (
         <div className="setting-label-container">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Label htmlFor={settingKey} className="setting-label">
-                  {label}
-                </Label>
-              </TooltipTrigger>
-              {description && <TooltipContent>{description}</TooltipContent>}
-            </Tooltip>
-          </TooltipProvider>
+          <div className="setting-label-wrapper">
+            {description ? (
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Label htmlFor={settingKey} className="setting-label">
+                      <span>{label}</span>
+                      <Info className="setting-label-info-icon" aria-hidden="true" />
+                    </Label>
+                  </TooltipTrigger>
+                  <TooltipContent align="start">{description}</TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
+            ) : (
+              <Label htmlFor={settingKey} className="setting-label">
+                {label}
+              </Label>
+            )}
+          </div>
           {generateComponent()}
         </div>
       )}

--- a/src/renderer/components/settings-tabs/settings-components/settings.component.scss
+++ b/src/renderer/components/settings-tabs/settings-components/settings.component.scss
@@ -26,9 +26,30 @@
   align-items: center;
 }
 
-.setting-label {
+.setting-label-wrapper {
   padding-right: 1rem;
   width: 50%;
+}
+
+.setting-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  width: fit-content;
+  max-width: 100%;
+}
+
+.setting-label-info-icon {
+  width: 0.875rem;
+  height: 0.875rem;
+  color: var(--muted-foreground);
+  flex-shrink: 0;
+}
+
+.setting-control-tooltip-trigger {
+  display: inline-flex;
+  width: fit-content;
+  max-width: 100%;
 }
 
 .error-view-link {


### PR DESCRIPTION
This PR
1. disables `Is Published` and conditionally `Is Editable` in the ui and adds tooltips to them
<img width="790" height="187" alt="image" src="https://github.com/user-attachments/assets/74630dc5-029d-4236-890a-b21d49448505" />
<img width="416" height="553" alt="image" src="https://github.com/user-attachments/assets/1c1c9b1c-f004-4ce6-9254-36ba1691b108" />


2. Changes settings labels to
    - `start` aligned tooltip (instead of centered, unless the app has no more space to the right side - as seen above)
    - add an info icon if tooltip is present
    - tooltip to only appear on hovering the text or icon (not the blank space like before)
<img width="806" height="487" alt="Screenshot 2026-06-16 130543" src="https://github.com/user-attachments/assets/8ca2477f-77be-4a7b-867f-381f16bab90f" />
<img width="461" height="483" alt="image" src="https://github.com/user-attachments/assets/ec4150a6-8aa5-4b58-aa53-c9c32c15cac9" />


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2412)
<!-- Reviewable:end -->
