### PR TITLE
manage-books: replace review-provenance comments with durable purpose comments (#2395 follow-up)

### DIFF
--- a/c-sharp-tests/ManageBooks/CopyBooksOrchestratorTests.cs
+++ b/c-sharp-tests/ManageBooks/CopyBooksOrchestratorTests.cs
@@ -1029,7 +1029,7 @@ namespace TestParanextDataProvider.ManageBooks
             "Merge mode ('Only copy non-existing chapters'): dest chapters with "
                 + "real text are NEVER overwritten; only chapters missing from dest "
                 + "are copied. Deliberate PT10 deviation from PT9 WriteChaptersToBook "
-                + "(Manila UX follow-up — the old semantic amounted to 'merge "
+                + "(the old semantic amounted to 'merge "
                 + "overwrites everything' for complete source books)."
         )]
         public void CopyBooks_MergeMode_DestChaptersWithText_SurviveUnchanged()

--- a/c-sharp-tests/ManageBooks/ImportBooksOrchestratorTests.cs
+++ b/c-sharp-tests/ManageBooks/ImportBooksOrchestratorTests.cs
@@ -1239,8 +1239,8 @@ namespace TestParanextDataProvider.ManageBooks
             "Merge mode ('Only import non-existing chapters'): dest chapters that "
                 + "have real text are NEVER overwritten — the source version of those "
                 + "chapters is skipped. Deliberate PT10 deviation from PT9 "
-                + "WriteChaptersToBook (which overwrote colliding chapters); see the "
-                + "Manila UX follow-up — the old semantic amounted to 'merge "
+                + "WriteChaptersToBook (which overwrote colliding chapters); the "
+                + "old semantic amounted to 'merge "
                 + "overwrites everything' for complete source files."
         )]
         public void ImportBooks_MergeMode_DestChaptersWithText_SurviveUnchanged()

--- a/c-sharp-tests/ManageBooks/ProjectFilterServiceTests.cs
+++ b/c-sharp-tests/ManageBooks/ProjectFilterServiceTests.cs
@@ -95,8 +95,8 @@ namespace TestParanextDataProvider.ManageBooks
             // The NBV21 shape: an installed DBL resource whose raw settings
             // Editable flag is "T". PT9's ResourceScrText.Settings.Editable
             // overrides to false regardless of the flag; ProjectSummary must
-            // mirror that (UX Manila follow-up: read-only targets get disabled
-            // mutating actions, not enabled ones).
+            // mirror that, because read-only targets must get disabled
+            // mutating actions, not enabled ones.
             _editableFlaggedResource = CreateResourceScrText(
                 name: "EditableFlaggedResource",
                 type: ProjectType.Standard,
@@ -550,7 +550,7 @@ namespace TestParanextDataProvider.ManageBooks
         }
 
         // -------------------------------------------------------------------
-        // ACCEPTANCE: resources are never editable targets (UX Manila follow-up)
+        // ACCEPTANCE: resources are never editable targets
         // PT9 parity: ProjectSettings.IsEditableText is only the raw settings
         // flag (its own doc warns it "does not determine if the project is
         // ultimately editable"); ResourceScrText overrides Settings.Editable to

--- a/c-sharp-tests/ManageBooks/UsfmChapterScaffoldingTests.cs
+++ b/c-sharp-tests/ManageBooks/UsfmChapterScaffoldingTests.cs
@@ -5,8 +5,8 @@ namespace TestParanextDataProvider.ManageBooks
 {
     /// <summary>
     /// Direct unit tests for <see cref="UsfmChapterScaffolding.HasContentBeyondScaffolding"/>,
-    /// the safety core of the Copy/Import merge mode ("Only copy/import non-existing chapters",
-    /// UX Manila follow-up). A false "scaffolding-only" classification would let merge mode
+    /// the safety core of the Copy/Import merge mode ("Only copy/import non-existing chapters").
+    /// A false "scaffolding-only" classification would let merge mode
     /// overwrite real user content, so every recognized scaffolding shape is pinned here.
     ///
     /// The recognized shapes mirror exactly what PT9's create-books scaffolding emits

--- a/c-sharp/ManageBooks/CopyBooksOrchestrator.cs
+++ b/c-sharp/ManageBooks/CopyBooksOrchestrator.cs
@@ -837,8 +837,8 @@ public static class CopyBooksOrchestrator
             // chapter ONLY when the matching dest chapter is missing, empty, or
             // scaffolding-only (see UsfmChapterScaffolding). Deliberate PT10
             // deviation from PT9's WriteChaptersToBook semantic, which
-            // overwrote every dest chapter present in the source (Manila UX
-            // follow-up). Empty source chapters are still skipped except when
+            // overwrote every dest chapter present in the source. Empty source
+            // chapters are still skipped except when
             // the dest book is also empty (preserves the "first copy populates
             // an empty book" path).
             return TryCopyChaptersFromSource(fromScrText, toScrText, bookNum, sourceUsfm, errors);

--- a/c-sharp/ManageBooks/ImportBooksOrchestrator.cs
+++ b/c-sharp/ManageBooks/ImportBooksOrchestrator.cs
@@ -809,7 +809,7 @@ public static class ImportBooksOrchestrator
             //     create-books scaffolding. Deliberate PT10 deviation from
             //     PT9's WriteChaptersToBook (which overwrote colliding
             //     chapters — for complete source files that amounted to
-            //     "merge overwrites everything"; Manila UX follow-up).
+            //     "merge overwrites everything").
             //
             // PutText with chapterNum>0 goes through the same ProjectFileManager
             // path the whole-book write uses, so InMemoryFileManager handles
@@ -858,7 +858,7 @@ public static class ImportBooksOrchestrator
     // via PutText(bookNum, chapterNum, ...) ONLY when the matching dest
     // chapter is missing, empty, or scaffolding-only (see
     // UsfmChapterScaffolding). Deviation from PT9, which overwrote every dest
-    // chapter present in the source — Manila UX follow-up.
+    // chapter present in the source.
     private static readonly System.Text.RegularExpressions.Regex EmptyChapterPattern =
         new(@"^(\\id [^\r\n]*)?\s*$", System.Text.RegularExpressions.RegexOptions.Compiled);
 

--- a/c-sharp/ManageBooks/UsfmChapterScaffolding.cs
+++ b/c-sharp/ManageBooks/UsfmChapterScaffolding.cs
@@ -3,8 +3,8 @@ using System.Text.RegularExpressions;
 namespace Paranext.DataProvider.ManageBooks;
 
 // === NEW IN PT10 ===
-// Reason: the Manila UX follow-up redefined merge mode for Copy/Import from
-// PT9's WriteChaptersToBook semantic (source chapters overwrite their dest
+// Reason: PT10 redefines merge mode for Copy/Import from PT9's
+// WriteChaptersToBook semantic (source chapters overwrite their dest
 // counterparts) to "only write chapters that do not already exist in the
 // destination". That requires deciding whether a destination chapter
 // "exists", where chapters holding nothing or only create-books scaffolding

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -507,10 +507,10 @@ export interface OpenFromEditorHamburgerOptions {
 /**
  * Open a tool (e.g. "Manage books…") from the scripture editor's hamburger ("Project") menu.
  *
- * The Manila UX follow-up moved tool entry points from the application main menu into the scripture
- * editor's hamburger menu. The hamburger button (`button[aria-label='Project']`) and its Radix menu
- * both render INSIDE the editor's iframe, while the resulting tool web view surfaces as a dock tab
- * at MAIN-PAGE level.
+ * Tool entry points live in the scripture editor's hamburger menu rather than the application main
+ * menu. The hamburger button (`button[aria-label='Project']`) and its Radix menu both render INSIDE
+ * the editor's iframe, while the resulting tool web view surfaces as a dock tab at MAIN-PAGE
+ * level.
  *
  * Steps:
  *

--- a/e2e-tests/tests/manage-books/manage-books-functional-WP-001.spec.ts
+++ b/e2e-tests/tests/manage-books/manage-books-functional-WP-001.spec.ts
@@ -47,9 +47,9 @@ const SCREENSHOT_BASE = 'proofs/component-evidence/WP-001';
 const WEB_VIEW_TITLE_REGEX = /Manage Books/i;
 const MENU_LABEL_REGEX = /Manage Books/i;
 /**
- * Project whose editor hosts the Manage Books entry point (the Manila UX follow-up moved the menu
- * item from the application main menu into the scripture editor's hamburger menu, reserved
- * `platform.manageBooks` default group in the Project section).
+ * Project whose editor hosts the Manage Books entry point (the menu item lives in the scripture
+ * editor's hamburger menu rather than the application main menu, reserved `platform.manageBooks`
+ * default group in the Project section).
  */
 const ENTRY_PROJECT_NAME = 'wgPIDGIN';
 
@@ -111,8 +111,8 @@ test.describe('Manage Books Functional Tests (WP-001 — Unified Dialog Wiring)'
   }) => {
     await waitForAppReady(mainPage);
 
-    // The Manila UX follow-up places the entry point in the scripture editor's hamburger
-    // ("Project") menu — reserved `platform.manageBooks` default group, Project section.
+    // The entry point lives in the scripture editor's hamburger ("Project")
+    // menu — reserved `platform.manageBooks` default group, Project section.
     await openFromEditorHamburger(mainPage, {
       projectName: ENTRY_PROJECT_NAME,
       menuItem: MENU_LABEL_REGEX,
@@ -140,8 +140,8 @@ test.describe('Manage Books Functional Tests (WP-001 — Unified Dialog Wiring)'
   }) => {
     await waitForAppReady(mainPage);
 
-    // Regression guard for the Manila UX follow-up: the main-menu entry was removed — the
-    // editor hamburger is the only entry point. Open the first main-menu dropdown (the
+    // Regression guard: the main-menu entry was removed — the editor hamburger
+    // is the only entry point. Open the first main-menu dropdown (the
     // product/Project column) and assert Manage Books is absent.
     const projectMenu = mainPage.getByRole('menuitem', { name: /Project|Tools|Platform/i }).first();
     await projectMenu.click();
@@ -227,9 +227,9 @@ test.describe('Manage Books Functional Tests (WP-001 — Unified Dialog Wiring)'
 
     // The "Existing" presence filter narrows the universe to books currently in the project.
     // The wiring layer subscribes to `useProjectSetting('platformScripture.booksPresent')` so a
-    // real value comes through here; we assert at least one present book is rendered. Per
-    // Sebastian review item 8 (2026-05-06) the chip row was replaced with a Filter-icon trigger
-    // that opens a DropdownMenuRadioGroup — we open the trigger first, then click the radio item.
+    // real value comes through here; we assert at least one present book is rendered. The chip row
+    // was replaced with a Filter-icon trigger that opens a DropdownMenuRadioGroup — we open the
+    // trigger first, then click the radio item.
     const filterTrigger = frame.locator('[data-testid="presence-filter-trigger"]');
     await filterTrigger.click();
     const presentItem = frame.locator('[data-testid="presence-filter-existing"]');
@@ -549,8 +549,8 @@ test.describe('Manage Books Functional Tests (WP-001 — Unified Dialog Wiring)'
     await expect(firstSourceOption).toBeVisible({ timeout: 10_000 });
     await firstSourceOption.click();
 
-    // Now the grid populates with comparison badges. Per Sebastian review item 8 (2026-05-06)
-    // the Copy-mode comparison-state filter (New/Newer/Older/Same/Undetermined) was removed
+    // Now the grid populates with comparison badges. The Copy-mode comparison-state filter
+    // (New/Newer/Older/Same/Undetermined) was removed
     // entirely — the previous `[data-testid^="copy-state-filter-"]` chips no longer exist. We
     // instead assert that book rows appear in the listbox, which is the actual signal that the
     // comparison grid populated against the picked source project.
@@ -759,8 +759,8 @@ test.describe('Manage Books Functional Tests (WP-001 — Unified Dialog Wiring)'
   });
 
   // @scenario TS-054
-  // GAP-002 FIX (P3U.1 ui-spec-validator post-IUG, 2026-05-02): the component now eagerly loads
-  // the reference project's book inventory when the user picks a "Based on" model
+  // The component eagerly loads the reference project's book inventory when the user picks a
+  // "Based on" model
   // (`useEffect([open, createReferenceId, refreshBooks])` in manage-books-dialog.component.tsx).
   // Before the fix, `createReferenceBookState.present` was always an empty Set, so EVERY selected
   // book appeared "missing" and the prompt always fired regardless of the underlying state — this

--- a/e2e-tests/tests/manage-books/manage-books-functional-WP-002.spec.ts
+++ b/e2e-tests/tests/manage-books/manage-books-functional-WP-002.spec.ts
@@ -36,26 +36,26 @@ const EVIDENCE_DIR = 'proofs/component-evidence/WP-002';
 const MANAGE_BOOKS_FRAME = 'iframe[title*="Manage Books" i]';
 const MENU_LABEL_REGEX = /Manage Books/i;
 /**
- * Project whose editor hosts the Manage Books entry point (the Manila UX follow-up moved the menu
- * item into the scripture editor's hamburger menu). Note this differs from the fixture projects the
- * tests switch to via the dialog's own sidebar picker after opening.
+ * Project whose editor hosts the Manage Books entry point (the menu item lives in the scripture
+ * editor's hamburger menu). Note this differs from the fixture projects the tests switch to via the
+ * dialog's own sidebar picker after opening.
  */
 const ENTRY_PROJECT_NAME = 'wgPIDGIN';
 
 /**
- * WF-002 (P3U.1 verdict): The four Category 9 mutating tests rely on specific rotation projects
- * starting WITHOUT the book each test creates (so the book is in the Create universe). The
- * `manageBooks.createBooks` PAPI command writes USFM stub files to disk that PERSIST across
- * `./.erb/scripts/refresh.sh` restarts (refresh only clears in-memory app state, not the project
- * filesystem under `~/.platform.bible/projects/Paratext 9 Projects/`). After a previous full-suite
- * run, those stubs leak into subsequent runs and break the ESG-missing / GEN-missing precondition.
+ * The four Category 9 mutating tests rely on specific rotation projects starting WITHOUT the book
+ * each test creates (so the book is in the Create universe). The `manageBooks.createBooks` PAPI
+ * command writes USFM stub files to disk that PERSIST across `./.erb/scripts/refresh.sh` restarts
+ * (refresh only clears in-memory app state, not the project filesystem under
+ * `~/.platform.bible/projects/Paratext 9 Projects/`). After a previous full-suite run, those stubs
+ * leak into subsequent runs and break the ESG-missing / GEN-missing precondition.
  *
  * Each entry maps a rotation project to the SFM file the test would create. If the file already
  * exists the test would mis-route (ESG already present → ESG hidden from Create universe → click
  * fails with a confusing locator-timeout). This pre-flight check converts that silent failure into
  * a precise skip with a remediation hint.
  *
- * Cleanup procedure (manual; matches the WF-002 task in the verdict):
+ * Cleanup procedure (manual):
  *
  * ```bash
  * rm -v "~/.platform.bible/projects/Paratext 9 Projects/RH2/70ESGRH2.SFM"
@@ -101,9 +101,9 @@ async function openManageBooksDialog(
   mainPage: Page,
   projectName: string = 'SRL',
 ): Promise<FrameLocator> {
-  // The Manila UX follow-up moved the entry point from the application main
-  // menu into the scripture editor's hamburger ("Project") menu, which renders
-  // INSIDE the editor's iframe. The shared helper opens the entry project's
+  // The entry point lives in the scripture editor's hamburger ("Project") menu
+  // rather than the application main menu, and it renders INSIDE the editor's
+  // iframe. The shared helper opens the entry project's
   // editor first (skipped when already open), drives the hamburger, and waits
   // for the Manage Books dock tab (tabTitle defaults to the menu-item regex).
   await openFromEditorHamburger(mainPage, {
@@ -155,7 +155,7 @@ async function openPickerFromCreateFlow(frame: FrameLocator): Promise<Locator> {
   // constraints discovered 2026-06-11: (1) the lookup must be scoped to the open Radix
   // popper, because the book-grid pills also carry role="option" and an unscoped .first()
   // matches a pill instead of a project row (same trap Journey 2 documents); (2) the
-  // reference must have ESG, otherwise the Sebastian-item-27 prune deselects ESG once the
+  // reference must have ESG, otherwise the reference-prune effect deselects ESG once the
   // reference's books load and the picker never opens (apply stays gated).
   await frame.locator('#af-reference').click();
   await frame
@@ -175,9 +175,9 @@ async function openPickerFromCreateFlow(frame: FrameLocator): Promise<Locator> {
 
 test.describe('Manage Books — Greek Esther Template Picker (WP-002)', () => {
   /**
-   * WF-002 fixture-state pre-flight (defensive). Detects rotation-project pollution from prior test
-   * runs and skips the entire describe with a clear remediation message rather than letting
-   * individual Category 9 tests fail with mysterious locator timeouts. See
+   * Fixture-state pre-flight (defensive). Detects rotation-project pollution from prior test runs
+   * and skips the entire describe with a clear remediation message rather than letting individual
+   * Category 9 tests fail with mysterious locator timeouts. See
    * ROTATION_FIXTURES_REQUIRING_MISSING_BOOK above for the cleanup procedure.
    */
   test.beforeAll(() => {
@@ -190,7 +190,7 @@ test.describe('Manage Books — Greek Esther Template Picker (WP-002)', () => {
       // The skip reason is surfaced in Playwright's report and the terminal output, so the
       // remediation hint is visible without a separate console.warn.
       const reason =
-        `WF-002: rotation fixture pollution detected — prior test run left USFM stubs on disk:\n${detail}\n` +
+        `Rotation fixture pollution detected — prior test run left USFM stubs on disk:\n${detail}\n` +
         `These break the missing-book precondition for Category 9 mutating tests. ` +
         `Delete the stub files (and restore Settings.xml from .BAK) before re-running. ` +
         `See block comment on ROTATION_FIXTURES_REQUIRING_MISSING_BOOK for the cleanup procedure.`;
@@ -247,7 +247,7 @@ test.describe('Manage Books — Greek Esther Template Picker (WP-002)', () => {
       await mainPage.waitForTimeout(500);
     }
 
-    // WF-003 (P3U.1 verdict): assert deterministic clean state before declaring the next test
+    // Assert deterministic clean state before declaring the next test
     // ready. Earlier observations showed test 2 (render-radios) flaking when prior-test state
     // bled in — the renderer would still have a stale dialog mounted by the time the next
     // beforeEach finished, masking sensible cleanup as visual-vibes flakiness. Two checks:
@@ -257,13 +257,13 @@ test.describe('Manage Books — Greek Esther Template Picker (WP-002)', () => {
     // mysterious DevTools-screenshot failure mid-test.
     await expect(
       mainPage.locator('.dock-tab').filter({ hasNotText: 'Home' }),
-      'WF-003: stale dock-tab(s) remain after beforeEach cleanup — prior test left a web view ' +
+      'Stale dock-tab(s) remain after beforeEach cleanup — prior test left a web view ' +
         'open. Check that the prior test closed its dialog/web-view via Cancel, Escape, or the ' +
         'tab close button.',
     ).toHaveCount(0, { timeout: 5_000 });
     await expect(
       mainPage.locator('[role="dialog"][data-state="open"]'),
-      'WF-003: stale Radix Dialog overlay remains after beforeEach cleanup. Escape pumping ' +
+      'Stale Radix Dialog overlay remains after beforeEach cleanup. Escape pumping ' +
         'and overlay-removal evaluate() did not fully tear down the dialog tree. Increase the ' +
         'Escape iteration count or investigate whether a non-Radix overlay is responsible.',
     ).toHaveCount(0, { timeout: 5_000 });
@@ -649,9 +649,9 @@ test.describe('Manage Books — Greek Esther Template Picker (WP-002)', () => {
     await frame.locator('[data-testid="manage-books-sidebar-section-create"]').click();
     await frame.locator('ul[role="listbox"] li[data-book="ESG"]').click();
 
-    // Switch the method dropdown to Empty. The default createMethod was changed to
-    // 'fromTemplate' per Sebastian item 11 (2026-05-06), so this test must explicitly
-    // pick 'empty' before applying. The picker MUST NOT open for the empty-book path.
+    // Switch the method dropdown to Empty. The default createMethod is
+    // 'fromTemplate', so this test must explicitly pick 'empty' before
+    // applying. The picker MUST NOT open for the empty-book path.
     await frame.locator('#af-method').click();
     await frame.getByRole('option', { name: /Create empty book|Empty book/i }).click();
     await frame.getByRole('button', { name: /Create .* in /i }).click();

--- a/e2e-tests/tests/manage-books/manage-books-journey.spec.ts
+++ b/e2e-tests/tests/manage-books/manage-books-journey.spec.ts
@@ -63,8 +63,8 @@ const WEB_VIEW_TITLE_REGEX = /Manage Books/i;
 const MENU_LABEL_REGEX = /Manage Books/i;
 const MANAGE_BOOKS_FRAME = 'iframe[title*="Manage Books" i]';
 /**
- * Project whose editor hosts the Manage Books entry point (Manila UX follow-up moved the menu item
- * from the application main menu into the scripture editor's hamburger menu). Same test project the
+ * Project whose editor hosts the Manage Books entry point (the menu item lives in the scripture
+ * editor's hamburger menu rather than the application main menu). Same test project the
  * markers-checklist specs use. Tests that need a different target project still switch via the
  * dialog's own sidebar project picker after opening.
  */
@@ -102,9 +102,9 @@ test.describe('Manage Books Journey Tests (Cross-WP / Cross-Mode)', () => {
    * {@link openFromEditorHamburger} bootstrap (same helper the per-WP functional tests use) so
    * journey tests do not drift from the per-WP idiom.
    *
-   * The Manila UX follow-up moved the entry point from the application main menu into the editor
-   * hamburger (reserved `platform.manageBooks` default group in the Project section). The hamburger
-   * button and its Radix menu both render INSIDE the editor's iframe.
+   * The entry point lives in the editor hamburger rather than the application main menu (reserved
+   * `platform.manageBooks` default group in the Project section). The hamburger button and its
+   * Radix menu both render INSIDE the editor's iframe.
    */
   async function openManageBooks(mainPage: Page): Promise<FrameLocator> {
     await openFromEditorHamburger(mainPage, {
@@ -152,8 +152,8 @@ test.describe('Manage Books Journey Tests (Cross-WP / Cross-Mode)', () => {
    * Why this exists: the cold-open default project (e.g. ESVUS16 in the local fixture) often
    * already contains ESG, which puts ESG outside the Create universe (`books NOT yet present`).
    * Tests that need ESG to be creatable must rotate to a project that doesn't yet contain it. The
-   * fixture rotation pool — per the prompt and the WP-001 verdict notes — is `zzz7`, `zzz6`, `MP1`,
-   * `wgPIDGIN`, `RH2`, `ROT`. We try each until one works.
+   * fixture rotation pool is `zzz7`, `zzz6`, `MP1`, `wgPIDGIN`, `RH2`, `ROT`. We try each until one
+   * works.
    */
   async function switchToProjectMissingBook(frame: FrameLocator, bookId: string): Promise<string> {
     // Candidate pool — order matters: prefer the projects most likely to be missing ESG given

--- a/extensions/src/platform-scripture/src/hooks/use-open-project-tabs.ts
+++ b/extensions/src/platform-scripture/src/hooks/use-open-project-tabs.ts
@@ -52,7 +52,7 @@ export function useOpenProjectTabs(filter?: WebViewFilter): OpenProjectTabWithWe
       const passesFilter = !filter || (webViewType !== undefined && filter({ webViewType }));
       // See JSDoc above: undefined → default group 0; numeric → as-is.
       //
-      // Sebastian UX review item 12 (2026-06-12): `ScrollGroupScrRef` widened
+      // `ScrollGroupScrRef` widened
       // from `ScrollGroupId` to `ScrollGroupId | SerializedVerseRef` upstream
       // — a tab that's "unsynced" from any scroll group now stores a
       // SerializedVerseRef object instead of a number. The previous strict

--- a/extensions/src/platform-scripture/src/manage-books-dialog/book-grid.component.tsx
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/book-grid.component.tsx
@@ -125,25 +125,15 @@ const BOOK_PILL_BASE_CLASS =
 /**
  * Compose the pill's color/border classes for a given `present`/`disabled` state pair.
  *
- * - In-project (`present`) books use the accent tone at rest and shift to primary on hover.
- * - Absent (addable) books get a dashed primary outline plus muted text and the same hover treatment
- *   — dashed-primary uniquely means "available to act on". Per Sebastian item 24 (2026-05-06).
+ * - In-project (`present`) books use the accent tone at rest; hover emphasises the border.
+ * - Absent (addable) books get a dashed primary outline plus muted text — dashed-primary uniquely
+ *   means "available to act on".
  * - Disabled books (e.g. Create mode's not-in-reference books) render as "inert gray": solid
  *   `border-border`, faint muted fill, slightly-muted FULL-OPACITY text so the book code stays
- *   legible, no hover, no addable affordance. This replaces the former `opacity-50`-only treatment,
- *   which was nearly indistinguishable from the enabled absent state (Manila UX follow-up:
- *   "Difference between disabled and not in project is too subtle").
+ *   legible, no hover, no addable affordance. This must stay clearly distinct from the enabled
+ *   absent state — a former `opacity-50`-only treatment was nearly indistinguishable from it.
  *
- * The hover treatment is the original `bg-primary/90` + `text-primary-foreground` the UX team
- * signed off in the original port; PR #2296 downgraded it to a `/20` tint that is visually
- * indistinguishable from the at-rest accent color, which UX reported as "hover effect has been
- * removed". Selection is conveyed by the checkbox glyph, not the hover color.
- *
- * NOTE on `tw:hover:bg-primary/90` vs `tw:hover:bg-primary`: the slashless `tw:hover:bg-primary`
- * does not get JIT-compiled in this build pipeline (only the slash variants `/10`, `/70`, `/80`,
- * `/90` are emitted). Using `/90` keeps a near-solid primary on hover while ensuring the rule
- * actually exists in the stylesheet — without it the hover background falls back to the at-rest
- * accent color and the white `text-primary-foreground` becomes unreadable on the light background.
+ * Selection is conveyed by the checkbox glyph, not the hover color.
  */
 const bookPillClasses = (present: boolean, disabled = false): string => {
   if (disabled)
@@ -151,11 +141,11 @@ const bookPillClasses = (present: boolean, disabled = false): string => {
       BOOK_PILL_BASE_CLASS,
       'tw:cursor-not-allowed tw:bg-muted/40 tw:text-muted-foreground/70',
     );
-  // Sebastian UX review item 8 (2026-06-12): the prior hover style swapped
-  // background + foreground (`bg-primary/90` + `text-primary-foreground`)
-  // which jarred against the at-rest pill look. Hover now keeps the same
-  // fill/text and instead emphasises the border — solid + ring color — so
-  // the pill reads as "interactive" without a color flash.
+  // The prior hover style swapped background + foreground (`bg-primary/90` +
+  // `text-primary-foreground`) which jarred against the at-rest pill look.
+  // Hover now keeps the same fill/text and instead emphasises the border —
+  // solid + ring color — so the pill reads as "interactive" without a color
+  // flash.
   return cn(
     BOOK_PILL_BASE_CLASS,
     'tw:transition-colors tw:hover:border-solid tw:hover:border-ring',
@@ -778,7 +768,7 @@ export function BookGridSelector({
       <Tooltip>
         <TooltipTrigger asChild>{button}</TooltipTrigger>
         {/* Tooltip renders bottom-CENTER so it stays near the cursor on wide
-            pills (Manila UX follow-up). */}
+            pills. */}
         <TooltipContent side="bottom" align="center" sideOffset={-4}>
           {tooltipContent}
         </TooltipContent>
@@ -789,7 +779,7 @@ export function BookGridSelector({
   return (
     <div
       className={cn(
-        // Sebastian UX review item 14 (2026-06-12): the prior `overflow-auto`
+        // The prior `overflow-auto`
         // produced a permanent vertical scrollbar in Import mode because the
         // grid's intrinsic height (badges + section headers) was a few
         // pixels taller than the flex slot. `overflow-y-auto` only renders
@@ -871,8 +861,8 @@ export function BookGridSelector({
                     // in the preset upgrade, which painted every EXPANDED
                     // group header with a persistent background bar. Neutralize
                     // it here so headers are plain text with background on
-                    // hover only (Manila UX follow-up), while keeping
-                    // aria-expanded for accessibility. Other ghost dropdown
+                    // hover only, while keeping aria-expanded for
+                    // accessibility. Other ghost dropdown
                     // triggers still rely on the variant default, so this is a
                     // per-usage override, not a button.tsx change.
                     className="tw:h-6 tw:flex-1 tw:justify-start tw:gap-1 tw:px-2 tw:text-[11px] tw:font-semibold tw:uppercase tw:tracking-wider tw:text-muted-foreground tw:hover:text-foreground tw:aria-expanded:bg-transparent tw:aria-expanded:text-muted-foreground tw:hover:aria-expanded:bg-muted tw:hover:aria-expanded:text-foreground"

--- a/extensions/src/platform-scripture/src/manage-books-dialog/copy-conflict-prompt.component.tsx
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/copy-conflict-prompt.component.tsx
@@ -18,11 +18,9 @@ import { fmtTemplate } from './manage-books-dialog.utils';
  * Replace entire books (destructive), Copy non-existing chapters (outline). Closing the dialog
  * cancels the copy entirely.
  *
- * History: Sebastian #16 introduced this prompt with a two-button shape (Cancel / Replace).
- * Vladimir #16 (follow-up) asked for the same three-way prompt that Import shows so the user can
- * also pick the "merge non-existing chapters" path. The third button is wired through the new
- * `ManageBooksCopyStrategy` union; see `manage-books-dialog.types.ts` for the wire note about the
- * backend currently honoring only the full-book replace path.
+ * The third (non-existing chapters) button is wired through the `ManageBooksCopyStrategy` union;
+ * see `manage-books-dialog.types.ts` for the wire note about the backend currently honoring only
+ * the full-book replace path.
  */
 export type CopyConflictPromptProps = {
   /** Pending conflict (the books being copied and which already exist in the destination). */
@@ -58,8 +56,8 @@ export function CopyConflictPrompt({
             <DialogDescription>
               {conflict
                 ? // Lists the conflicting book names like the import-conflict prompt
-                  // does (Manila UX follow-up: "the message should also list the book
-                  // name(s)"). Proper _one/_other pluralization (matching the import
+                  // does, so the user sees exactly which books would be overwritten.
+                  // Proper _one/_other pluralization (matching the import
                   // filesMatched pair) instead of "book(s)"; the old count-only
                   // %manageBooks_copy_confirmBody% is redirected via metadata
                   // fallbackKey since its placeholder arity changed. The list join is
@@ -91,7 +89,7 @@ export function CopyConflictPrompt({
                 : ''}
             </DialogDescription>
           </DialogHeader>
-          {/* Sebastian UX review item 10 (2026-06-12): the prior layout
+          {/* The prior layout
               stacked the three buttons in a column at narrow widths
               (`flex-col → sm:flex-row`), which pushed them past the dialog's
               bottom edge. Buttons now stay in a single row and individually
@@ -131,8 +129,8 @@ export function CopyConflictPrompt({
                   destination are written (CopyBooksOrchestrator
                   TryCopyChaptersFromSource + UsfmChapterScaffolding). The key
                   was renamed from %manageBooks_copy_confirmMergeFromSource%
-                  when the Manila UX follow-up changed the wire behavior from
-                  PT9's chapter-overwrite merge to skip-existing-chapters. */}
+                  when the wire behavior changed from PT9's chapter-overwrite
+                  merge to skip-existing-chapters. */}
               {t('%manageBooks_copy_onlyNonExistingChapters%', 'Only copy non-existing chapters')}
             </Button>
           </div>

--- a/extensions/src/platform-scripture/src/manage-books-dialog/import-conflict-prompt.component.tsx
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/import-conflict-prompt.component.tsx
@@ -64,7 +64,7 @@ export function ImportConflictPrompt({
           <p className="tw:text-sm tw:text-muted-foreground">
             {t('%manageBooks_import_conflictBody2%', 'Choose how to proceed with the import.')}
           </p>
-          {/* Sebastian UX review item 10 (2026-06-12): the prior layout
+          {/* The prior layout
               stacked the three buttons in a column at narrow widths
               (`flex-col → sm:flex-row`), which pushed them past the dialog's
               bottom edge. Buttons now stay in a single row and individually
@@ -104,9 +104,9 @@ export function ImportConflictPrompt({
                   destination are written (ImportBooksOrchestrator
                   TryMergeChaptersFromSource + UsfmChapterScaffolding). The key
                   was renamed from %manageBooks_import_mergeFromFiles% (per the
-                  semantic-change-renames-the-key convention) when the Manila
-                  UX follow-up changed the wire behavior from PT9's
-                  chapter-overwrite merge to skip-existing-chapters. */}
+                  semantic-change-renames-the-key convention) when the wire
+                  behavior changed from PT9's chapter-overwrite merge to
+                  skip-existing-chapters. */}
               {t(
                 '%manageBooks_import_onlyNonExistingChapters%',
                 'Only import non-existing chapters',

--- a/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.component.tsx
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.component.tsx
@@ -171,11 +171,11 @@ export type ManageBooksDialogProps = {
   /**
    * Commit a Copy-books operation.
    *
-   * `strategy` mirrors the Import flow's `replaceEntireBooks` / `nonExistingChapters` choice (see
-   * Vladimir review #16 — Copy now surfaces the same three-button conflict prompt as Import).
-   * `strategy` is `undefined` when no conflict prompt was shown (the picked books did not exist in
-   * the destination, so the question never came up). Wiring layers should treat `undefined` as
-   * "destination had nothing in the way — write through".
+   * `strategy` mirrors the Import flow's `replaceEntireBooks` / `nonExistingChapters` choice — Copy
+   * surfaces the same three-button conflict prompt as Import. `strategy` is `undefined` when no
+   * conflict prompt was shown (the picked books did not exist in the destination, so the question
+   * never came up). Wiring layers should treat `undefined` as "destination had nothing in the way —
+   * write through".
    */
   onCopyBooks: (args: {
     destProjectId: string;
@@ -243,7 +243,7 @@ export type ManageBooksDialogProps = {
    * supplied, the dialog uses it as a fast-path for the read-only-target gating decision so the
    * Create / Copy / Import / Delete sections lock immediately on project switch even before the
    * dialog's slower internal `projects` fetch (which does extra per-project pdp.getSetting calls)
-   * has caught up. Sebastian UX review item 6 (2026-06-12).
+   * has caught up.
    */
   sidebarProjects?: readonly (ProjectSelectorProject & { isEditable?: boolean })[];
 
@@ -375,19 +375,18 @@ function DisabledStubButtonTooltip({
   );
 }
 
-// Sebastian review item 8 (2026-05-06): the Copy-mode comparison-state filter (New/Newer/Older/
-// Same/Undetermined) was removed entirely — the New/Newer/Older/Same options didn't actually
-// filter anything (the chip selection was decorative without a backing state-set), and the
-// All/Undetermined options were equivalent. Per Sebastian's verdict the simplest fix is to drop
-// the affordance until comparison-state filtering is genuinely needed; the per-book status
+// The Copy-mode comparison-state filter (New/Newer/Older/Same/Undetermined) was removed entirely —
+// the New/Newer/Older/Same options didn't actually filter anything (the chip selection was
+// decorative without a backing state-set), and the All/Undetermined options were equivalent. The
+// affordance is dropped until comparison-state filtering is genuinely needed; the per-book status
 // labels and badges already give users the same information at a glance.
 
 /**
  * Presence-filter dropdown shared by View and Import modes. Replaces the chip rows that used to sit
- * in the filter bar (per Sebastian review item 8, 2026-05-06): the trigger is a Filter-icon Button
- * that opens a `<DropdownMenuRadioGroup>` of the three presence states (All / New / Existing). The
- * trigger picks up an accent background when a non-`all` filter is active so the affordance still
- * reads as "filter applied" without a chip row.
+ * in the filter bar: the trigger is a Filter-icon Button that opens a `<DropdownMenuRadioGroup>` of
+ * the three presence states (All / New / Existing). The trigger picks up an accent background when
+ * a non-`all` filter is active so the affordance still reads as "filter applied" without a chip
+ * row.
  *
  * E2E tests use `data-testid` on each radio item — preserve the existing tokens
  * (`presence-filter-{all|new|existing}` and `import-presence-filter-{…}`) so the tests just need to
@@ -558,12 +557,11 @@ export function ManageBooksDialog({
 
   // -- Loaded data ---------------------------------------------------------
   const [projects, setProjects] = useState<ManageBooksDialogProject[]>([]);
-  // Sebastian UX review item 1 (2026-06-12): track whether the initial
-  // `loadProjects` fetch has completed at least once. Used to drive the
-  // project-trigger disabled state and the right-pane skeleton placeholder
-  // so the user doesn't see the projectId GUID render in the header subtitle
-  // ("random number" — the fallback projectDisplayName) or a half-rendered
-  // body before the project list has resolved.
+  // Track whether the initial `loadProjects` fetch has completed at least
+  // once. Used to drive the project-trigger disabled state and the right-pane
+  // skeleton placeholder so the user doesn't see the projectId GUID render in
+  // the header subtitle ("random number" — the fallback projectDisplayName) or
+  // a half-rendered body before the project list has resolved.
   const [hasLoadedProjects, setHasLoadedProjects] = useState(false);
   const [booksByProjectId, setBooksByProjectId] = useState<
     Record<string, ManageBooksDialogBookInfo[]>
@@ -606,10 +604,9 @@ export function ManageBooksDialog({
   const [selectionsByAction, setSelectionsByAction] = useState<Record<string, Set<string>>>({});
   const [filter, setFilter] = useState('');
   const [copySourceId, setCopySourceId] = useState<string | undefined>(undefined);
-  // Default Create method is "Create based on" (FromTemplate). Per Sebastian item 11 (2026-05-06)
-  // the prompt copy now reads "Create based on" rather than "Based on", and the most useful default
-  // for users is to start by picking a reference project; they can switch to Empty or
-  // ChapterAndVerse if they prefer.
+  // Default Create method is "Create based on" (FromTemplate): the prompt copy reads "Create based
+  // on" rather than "Based on", and the most useful default for users is to start by picking a
+  // reference project; they can switch to Empty or ChapterAndVerse if they prefer.
   const [createMethod, setCreateMethod] = useState<ManageBooksCreateMethod>('fromTemplate');
   const [createReferenceId, setCreateReferenceId] = useState<string | undefined>(undefined);
   const [importFiles, setImportFiles] = useState<Record<string, ManageBooksImportFile>>({});
@@ -620,7 +617,7 @@ export function ManageBooksDialog({
       }
     | undefined
   >(undefined);
-  // Copy overwrite-confirm — Sebastian #16. Without this, Copy with mixed existence silently
+  // Copy overwrite-confirm. Without this, Copy with mixed existence silently
   // overwrites the books that already exist in the destination project.
   const [copyConfirm, setCopyConfirm] = useState<
     | {
@@ -637,9 +634,9 @@ export function ManageBooksDialog({
   const [importPresenceFilter, setImportPresenceFilter] = useState<ViewPresenceFilter>('all');
   const [viewPresenceFilter, setViewPresenceFilter] = useState<ViewPresenceFilter>('all');
   // BookGridSelector grouping state. Initial mount defaults to canon grouping
-  // (the dialog opens in View mode where "OT / NT / DC" reads naturally). Per
-  // Sebastian item 10 (2026-05-06) the user's choice is preserved across
-  // workflow switches so changing modes doesn't undo their grouping preference.
+  // (the dialog opens in View mode where "OT / NT / DC" reads naturally). The
+  // user's choice is preserved across workflow switches so changing modes
+  // doesn't undo their grouping preference.
   const [gridGroupBy, setGridGroupBy] = useState<BookGridGroupBy>('canon');
   // Using null for React ref compatibility
   // eslint-disable-next-line no-null/no-null
@@ -696,7 +693,7 @@ export function ManageBooksDialog({
   }, [open, projectId, loadVersification]);
 
   // -- Derived state -------------------------------------------------------
-  // Sebastian UX review item 6 (2026-06-12): the gating decision used to read
+  // The gating decision used to read
   // `isEditable` only from the dialog's slower internal `projects` array
   // (loaded via the `loadProjects` prop, which awaits two pdp.getSetting
   // calls per project for display names). When the user switched projects
@@ -727,8 +724,8 @@ export function ManageBooksDialog({
   // `ManageBooksDialogProject` to that shape — `p.fullName` (sourced from `platform.fullName`
   // upstream) becomes the secondary label, falling back to `shortName` when no fullName is
   // configured. The target project itself is filtered out (already done in `otherProjects`).
-  // Sebastian UX new-requirement 4 (2026-06-12): commentaries should be excluded from both the
-  // Copy "From" and Create "Based on" pickers. DEFERRED — there is no reliable commentary signal in
+  // Commentaries should be excluded from both the Copy "From" and Create "Based on" pickers.
+  // DEFERRED — there is no reliable commentary signal in
   // the current data model: DBL classifies resources only by medium (text/audio/print), ParatextData
   // has no commentary concept, and the only marker is a hardcoded 3-UID whitelist in
   // DblDownloadableDataProvider that never reaches ProjectSummary. The previous `isCommentary` filter
@@ -738,7 +735,7 @@ export function ManageBooksDialog({
   // already excludes all resources for licensing reasons, so commentaries (being resources) stay out
   // of Copy regardless.
   //
-  // Sebastian UX new-requirement 3 (2026-06-12): the picker is also enriched
+  // The picker is also enriched
   // with versification id + localized name so the consumer can opt into
   // versification-grouping (Create "Based on" does; Copy "From" leaves it
   // off). The name resolution lives here on the dialog side because we own
@@ -750,8 +747,8 @@ export function ManageBooksDialog({
         shortName: p.shortName,
         fullName: p.fullName ?? p.shortName,
         versificationId: p.versificationId,
-        // Group header reads "{name} versification" (lowercase, per Sebastian N3 follow-up),
-        // localized via a template so word order can vary by language. The "Unknown
+        // Group header reads "{name} versification" (lowercase), localized via a template so word
+        // order can vary by language. The "Unknown
         // versification" bucket is labeled separately (versificationUnknownSectionHeading) and is
         // unaffected, so no double "versification" suffix.
         versificationName: p.versificationId
@@ -774,8 +771,7 @@ export function ManageBooksDialog({
   // The Create "Based on" picker deliberately INCLUDES resources: it only
   // reads the reference's book/chapter structure to scaffold empty books, no
   // text is copied (PT9 parity: CreateBooksForm's model combobox lists all
-  // accessible scripture texts including resources; Manila UX follow-up
-  // confirmed this).
+  // accessible scripture texts including resources).
   const copyFromProjectsAsPS = useMemo<ProjectSelectorProject[]>(
     () =>
       otherProjects
@@ -799,7 +795,7 @@ export function ManageBooksDialog({
   // Both pickers below stay undefined until the picked project's books have
   // actually LOADED (booksByProjectId[id] set — an empty array means "loaded,
   // no books"). toProjectBookState(undefined) would yield a truthy empty
-  // state, which made the Sebastian-item-27 prune effect below fire in the
+  // state, which made the reference-prune effect below fire in the
   // load gap right after picking a reference and wipe the user's entire
   // selection (and made every pill briefly render as not-in-reference
   // disabled). The copy-source picker gets the same guard so the A7
@@ -847,9 +843,9 @@ export function ManageBooksDialog({
     });
   }, [copySourceId]);
 
-  // Reset per-action filters when the action changes. Per Sebastian item 10
-  // (2026-05-06) the gridGroupBy preference is intentionally NOT reset — the
-  // user's grouping choice persists across workflow switches.
+  // Reset per-action filters when the action changes. The gridGroupBy
+  // preference is intentionally NOT reset — the user's grouping choice
+  // persists across workflow switches.
   useEffect(() => {
     setImportPresenceFilter('all');
     setViewPresenceFilter('all');
@@ -876,7 +872,7 @@ export function ManageBooksDialog({
     }
   }, [project.isEditable, action]);
 
-  // GAP-002 (P3U.1 ui-spec-validator): when the user picks a "Based on" reference project in
+  // When the user picks a "Based on" reference project in
   // Create mode, eagerly load that project's book set so EXT-102's missing-model pre-flight
   // prompt can compare the user's selection against a real book inventory. Without this, the
   // first call to `createReferenceBookState` returns an empty `present` set (because
@@ -906,7 +902,7 @@ export function ManageBooksDialog({
       case 'copy':
         return copySource ? allBooks.filter((b) => copySource.present.has(b)) : [];
       case 'import':
-        // Sebastian review item 22 (2026-05-06): Import mode starts empty and only shows books
+        // Import mode starts empty and only shows books
         // the user has actually attached files for. As `runImport` removes successfully-imported
         // entries from `importFiles`, the grid shrinks too — books vanish on success without
         // needing any extra clean-up. Sort by canonical book number so multi-file picks render
@@ -919,7 +915,7 @@ export function ManageBooksDialog({
     }
   }, [action, allBooks, current, copySource, importFiles]);
 
-  // Per Sebastian review item 27 (2026-05-06): when the user picks a different
+  // When the user picks a different
   // reference project (or clears it / changes createMethod), prune any books from
   // the current Create selection that are NOT in the new reference project's book
   // set. Without this, switching reference projects could leave a stale selection
@@ -966,8 +962,8 @@ export function ManageBooksDialog({
     });
   }, [action, copySource, copySourceId, universe, current]);
 
-  // Sebastian UX review item 11 (2026-06-12): book-id detection must rely on
-  // the `\id` marker in the file content, not the filename. A filename like
+  // Book-id detection relies on the `\id` marker in the file content, not the
+  // filename. A filename like
   // `38ZECCUNP89T.SFM` contains "ECC" before "ZEC", so the old filename-only
   // substring scan misidentified the book. We now read the first `\id`
   // marker and only fall back to a filename match when the content is missing
@@ -1036,9 +1032,9 @@ export function ManageBooksDialog({
           return;
         }
         seenInBatch[book] = f.name;
-        // Sebastian UX review item 9 (2026-06-12): the import grid must show
-        // the file's last-modified date so the newer/older comparison reflects
-        // the real source date. `File.lastModified` is always populated for
+        // The import grid shows the file's last-modified date so the
+        // newer/older comparison reflects the real source date.
+        // `File.lastModified` is always populated for
         // real File objects coming from the browser picker or
         // `onPickImportFiles`; story decorators that pass `{name}` shapes
         // still get a date but without `lastModified` it would always read 0
@@ -1111,7 +1107,7 @@ export function ManageBooksDialog({
     return { pickedAny: true };
   }, [ingestImportFiles, onPickImportFiles]);
 
-  // Per Sebastian review item 23 (2026-05-06): auto-browse on Import-mode entry was reversed.
+  // Auto-browse on Import-mode entry is intentionally not used.
   // The file picker now opens only when the user explicitly clicks the "Choose files…" /
   // "Add files…" button (rendered around line 1759-1768). Decision A8's "auto-browse on entry"
   // behavior is superseded — the prior `useEffect` that called `triggerFileBrowser()` and the
@@ -1298,14 +1294,14 @@ export function ManageBooksDialog({
     setIsSubmitting(true);
     const minDisplay = minDelay(MIN_SUBMITTING_VISIBLE_MS);
     try {
-      // Sebastian review item 26 (2026-05-06, FE half): re-fetch the project's current book set
+      // Re-fetch the project's current book set
       // before issuing the delete. If another tab/process has deleted some of the user's selected
       // books since the dialog last loaded, those books are now absent from the destination — the
       // C# `DeleteBooksOrchestrator` would either no-op or surface a confusing error per book. We
       // intersect the user's selection with the freshly-loaded inventory and continue with only
       // the still-present subset; the dropped books are reported back to the user via a toast so
-      // they understand why the count shrank. The backend's AlertCapture wrap (BE half of #26)
-      // remains a separate PR.
+      // they understand why the count shrank. The matching backend AlertCapture wrap
+      // remains a separate change.
       const fresh = await Promise.resolve(loadBooks(projectId));
       setBooksByProjectId((prev) => ({ ...prev, [projectId]: fresh }));
       const freshPresent = new Set(fresh.map((b) => b.id));
@@ -1425,8 +1421,7 @@ export function ManageBooksDialog({
       const destVrs = versification ?? '';
       const modelVrs = await Promise.resolve(loadVersification(createReferenceId)).catch(() => '');
       if (destVrs && modelVrs && destVrs !== modelVrs) {
-        // Sebastian UX new-requirement 2 (2026-06-12): the prompt body must
-        // show the localized versification NAME (e.g. "English", "Vulgate"),
+        // The prompt body shows the localized versification NAME (e.g. "English", "Vulgate"),
         // not the numeric ScrVersType id (e.g. "0", "4"). Resolve here so the
         // prompt component stays presentational.
         setCreatePrompt({
@@ -1455,7 +1450,7 @@ export function ManageBooksDialog({
         break;
       case 'copy': {
         if (!copySourceId) break;
-        // Sebastian #16: gate Copy with an overwrite-confirm prompt when the selection contains
+        // Gate Copy with an overwrite-confirm prompt when the selection contains
         // books that already exist in the destination project. Mixed-existence selections used to
         // silently overwrite — now the user has to confirm.
         const existing = selectedArr.filter((b) => current.present.has(b));
@@ -1480,13 +1475,11 @@ export function ManageBooksDialog({
     }
   };
 
-  // Vladimir review item 21 (2026-05-06): the subtitle was rewritten from
-  // "{count} of {88} canonical books in {short} ({vrs})" to "{count} books in {full} ⋅ {vrs name}
-  // Versification". The new copy reports the absolute number of books currently in the project
-  // (not capped to canonical) so users with deuterocanonical or extra books see them counted.
+  // Counts the absolute number of books currently in the project (not capped to canonical) so
+  // users with deuterocanonical or extra books see them all counted in the header subtitle.
   const totalPresent = current.present.size;
 
-  // Vladimir review item 21 (2026-05-06): the subtitle now reads
+  // The subtitle reads
   // "{count} books in {full project name} ⋅ {versification name} Versification". The
   // versification name is resolved from the numeric `ScrVersType` enum (which `loadVersification`
   // returns as a string) via `versificationLabelKey` + `t()`. The trailing literal " Versification"
@@ -1505,9 +1498,8 @@ export function ManageBooksDialog({
     ? fmtTemplate(subtitleTemplate, totalPresent, projectDisplayName, versificationName)
     : fmtTemplate(subtitleTemplate, totalPresent, projectDisplayName);
 
-  // Sebastian UX new-requirement 1 (2026-06-12): the right-pane headline now
-  // tracks the active section ("Show books", "Create books", …) instead of the
-  // static "Manage books". We reuse the existing sidebar localized labels —
+  // The right-pane headline tracks the active section ("Show books", "Create
+  // books", …) instead of a static "Manage books". We reuse the existing sidebar localized labels —
   // they're already translated and exactly match the desired text, so no new
   // localize keys are needed.
   const headerTitle = (() => {
@@ -1526,7 +1518,7 @@ export function ManageBooksDialog({
     }
   })();
 
-  // Per Sebastian review item 8 (2026-05-06): only the All/New/Existing presence-filter labels
+  // Only the All/New/Existing presence-filter labels
   // are used now that the Copy comparison-state filter has been removed. The remaining
   // newer/older/same/undetermined chip-label localized strings are still consumed by the per-row
   // status section headers in the BookGrid (see `gridItems` above) — leave them in
@@ -1558,7 +1550,7 @@ export function ManageBooksDialog({
         '%manageBooks_copy_emptyState_chooseSource%',
         'Choose a source project to see books available to copy.',
       );
-    // Sebastian I7 follow-up (2026-06-12): copy mode with a source picked but its books not yet
+    // Copy mode with a source picked but its books not yet
     // fetched (the brief load gap). Without this branch it falls through to the misleading "...has
     // no books to copy" message below. Show a loading hint instead.
     if (action === 'copy' && copySourceId && !booksByProjectId[copySourceId]) {
@@ -1570,7 +1562,7 @@ export function ManageBooksDialog({
           )
         : t('%manageBooks_copy_emptyState_loading%', 'Loading books…');
     }
-    // Sebastian review item 22 (2026-05-06): Import mode renders an empty grid until the user
+    // Import mode renders an empty grid until the user
     // attaches files. The "Add files…" / "Choose files…" affordance lives in the per-action
     // header just above; this empty-state message gives the otherwise-blank grid area a hint.
     if (action === 'import' && universe.length === 0) {
@@ -1700,7 +1692,7 @@ export function ManageBooksDialog({
         primaryDate = destDate;
       }
 
-      // Per Sebastian review item 27 (2026-05-06): in Create > Based on,
+      // In Create > Based on,
       // books not present in the reference project are not selectable —
       // there is no template content to base the new book on. Disable the
       // pill at the grid level (defense in depth alongside the existing
@@ -1720,11 +1712,11 @@ export function ManageBooksDialog({
           t('%manageBooks_create_book_notInReference%', 'Not in {0}'),
           createReferenceProject.shortName,
         );
-        // Manila UX follow-up ("disabled vs not in project is too subtle"):
-        // cluster the non-creatable books in their own status group at the
+        // Cluster the non-creatable books in their own status group at the
         // bottom (notInProject sorts last via STATUS_GROUP_PRIORITY) instead
-        // of interleaving them with creatable "New" books. Pairs with the
-        // inert-gray disabled pill styling in book-grid.component.tsx.
+        // of interleaving them with creatable "New" books — keeps them clearly
+        // distinct rather than too-subtly different. Pairs with the inert-gray
+        // disabled pill styling in book-grid.component.tsx.
         statusGroupKey = 'notInProject';
         statusLabel = disabledReason;
       }
@@ -1921,8 +1913,8 @@ export function ManageBooksDialog({
   // the standard confirm with the shared-users warning (DeleteBooksForm.cs),
   // and the previous PT10 branch order dropped it exactly in the
   // highest-impact case (deleting every book of a shared project). The
-  // wording is S/R-accurate per the Manila UX follow-up: deletion is local
-  // until other users Send/Receive — the old copy falsely claimed "they will
+  // wording is S/R-accurate: deletion is local until other users Send/Receive
+  // — the old copy falsely claimed "they will
   // see this change immediately" (old key redirected via metadata
   // fallbackKey).
   // Variant selection (the shared-warning precedence) is a pure function in
@@ -2003,7 +1995,7 @@ export function ManageBooksDialog({
             openTabs={openTabs}
             projectId={projectId}
             onProjectIdChange={onProjectIdChange}
-            // Sebastian UX review item 1 (2026-06-12): during the initial
+            // During the initial
             // `loadProjects` fetch the sidebar is fully locked — the
             // ProjectSelector disables (no clicks until the list is ready)
             // and the action rows disable because there's nothing actionable
@@ -2023,8 +2015,7 @@ export function ManageBooksDialog({
                 <h2 className="tw:text-lg tw:font-semibold">{headerTitle}</h2>
                 {/* Header subtitle hides when the dialog is narrow. Driven by
                     the JS-resize-observer flag on the dialog root.
-                    Sebastian UX review item 1 (2026-06-12): while the initial
-                    `loadProjects` fetch is in flight we render a placeholder
+                    While the initial `loadProjects` fetch is in flight we render a placeholder
                     skeleton bar instead of the subtitle template, otherwise
                     the user briefly sees the projectId GUID render in place
                     of the project name ("random number") and a book count of
@@ -2040,7 +2031,7 @@ export function ManageBooksDialog({
                 )}
               </div>
             </header>
-            {/* Sebastian UX review item 1 (2026-06-12): while projects are
+            {/* While projects are
                 loading the action body / filter bar / grid / footer below
                 are replaced with a skeleton placeholder so the user doesn't
                 see real-but-stale content (book pills against a different
@@ -2077,7 +2068,7 @@ export function ManageBooksDialog({
               <>
                 <div className="tw:flex tw:flex-col tw:items-start tw:gap-2 tw:border-b tw:px-6 tw:py-3 tw:@container/actions">
                   {action === 'view' && (
-                    /* Sebastian UX review item 4 (2026-06-12): the row used to wrap
+                    /* The row used to wrap
                    (tw:flex-wrap) which ate two extra rows of vertical real
                    estate. It now stays single-line and overflows horizontally
                    with a hidden scrollbar — the user can shift+scroll if a
@@ -2353,7 +2344,7 @@ export function ManageBooksDialog({
                           )}
                     </span>
                   )}
-                  {/* Sebastian review item 8 (2026-05-06): the View / Import presence-filter chip
+                  {/* The View / Import presence-filter chip
                   rows were replaced with a single Filter-icon button that opens a popover
                   containing the radio choices. Mirrors the pattern in
                   `lib/platform-bible-react/src/components/advanced/project-selector/
@@ -2511,11 +2502,10 @@ export function ManageBooksDialog({
                             'Select reference project',
                           )}
                           localizedStrings={projectSelectorLocalizedStrings}
-                          // Sebastian UX new-requirement 3 (2026-06-12): group
-                          // reference candidates by versification so the user
-                          // can pick one whose canon matches the destination
-                          // project. The destination's own versification group
-                          // is pinned to the top.
+                          // Group reference candidates by versification so the
+                          // user can pick one whose canon matches the
+                          // destination project. The destination's own
+                          // versification group is pinned to the top.
                           groupByVersification
                           priorityVersificationId={versification}
                           // Mirror the prior <SelectTrigger> "primary fill while empty" affordance —
@@ -2583,9 +2573,8 @@ export function ManageBooksDialog({
                           </Button>
                         );
                         // Tooltip body: when disabled use disabledTooltip; when enabled, only Create
-                        // and Copy have defined enabled-state tooltips per Sebastian item 20
-                        // (2026-05-06). Delete and Import fall through with no enabled tooltip and
-                        // render the bare button.
+                        // and Copy have defined enabled-state tooltips. Delete and Import fall
+                        // through with no enabled tooltip and render the bare button.
                         let tooltipBody: string | undefined;
                         if (disabled) {
                           tooltipBody = disabledTooltip;
@@ -2674,8 +2663,8 @@ export function ManageBooksDialog({
               ? await Promise.resolve(loadVersification(createReferenceId)).catch(() => '')
               : '';
             if (destVrs && modelVrs && destVrs !== modelVrs) {
-              // Sebastian UX new-requirement 2 (2026-06-12): same name (not
-              // number) treatment as the primary apply path above.
+              // Same versification name (not number) treatment as the primary
+              // apply path above.
               setCreatePrompt({
                 kind: 'versification',
                 destVrs: t(versificationLabelKey(destVrs), versificationFallbackName(destVrs)),

--- a/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.stories.tsx
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.stories.tsx
@@ -1,7 +1,7 @@
 /**
  * Stories for the manage-books-dialog component (the new ViewListSelect layout). Renders the
- * orchestrator inside a stateful harness so reviewers can exercise all 5 sidebar sections and see
- * the 2 disabled future-section rows.
+ * orchestrator inside a stateful harness that exercises all 5 sidebar sections and shows the 2
+ * disabled future-section rows.
  *
  * Replaced the 6-variant exploration that lived in
  * `lib/platform-bible-react/src/stories/advanced/manage-books-dialog.stories.tsx` (deleted) — that

--- a/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.types.ts
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.types.ts
@@ -28,13 +28,13 @@ export type ManageBooksImportStrategy = 'replaceEntireBooks' | 'nonExistingChapt
 /**
  * Strategy for resolving conflicts when copying into a project that already has the book.
  *
- * Mirrors {@link ManageBooksImportStrategy}. Vladimir review item 16 asked Copy to surface the same
- * three-way confirmation Import does (Cancel / Replace entire books / Copy non-existing chapters).
- * The frontend distinguishes the two paths so the wiring layer can pass the chosen strategy to the
- * backend once the C# side accepts it. Today the `copyBooks` PAPI method has no strategy parameter
- * (CopyBooksOrchestrator unconditionally writes the full book), so both choices currently route
- * through the same `copyBooks` call and the backend behaves as `replaceEntireBooks` regardless —
- * matching the same gap Sebastian flagged for Import (#15). See TODO in the web-view adapter.
+ * Mirrors {@link ManageBooksImportStrategy}. Copy surfaces the same three-way confirmation Import
+ * does (Cancel / Replace entire books / Copy non-existing chapters). The frontend distinguishes the
+ * two paths so the wiring layer can pass the chosen strategy to the backend once the C# side
+ * accepts it. Today the `copyBooks` PAPI method has no strategy parameter (CopyBooksOrchestrator
+ * unconditionally writes the full book), so both choices currently route through the same
+ * `copyBooks` call and the backend behaves as `replaceEntireBooks` regardless — the same gap that
+ * exists for Import. See TODO in the web-view adapter.
  */
 export type ManageBooksCopyStrategy = 'replaceEntireBooks' | 'nonExistingChapters';
 
@@ -94,9 +94,8 @@ export type ManageBooksDialogProject = {
   isResource?: boolean;
   /**
    * Locale-stable versification id for the project (the numeric `ScrVersType` as a string).
-   * Sebastian UX new-requirement 3 (2026-06-12): forwarded to the Create "Based on"
-   * `<ProjectSelector>` so it can group projects by versification with the target's versification
-   * pinned to the top.
+   * Forwarded to the Create "Based on" `<ProjectSelector>` so it can group projects by
+   * versification with the target's versification pinned to the top.
    */
   versificationId?: string;
   /**
@@ -186,10 +185,10 @@ export const MANAGE_BOOKS_DIALOG_STRING_KEYS = Object.freeze([
   '%manageBooks_header_projectLabel%',
   '%manageBooks_header_subtitle%',
   '%manageBooks_header_subtitleNoVersification%',
-  // Vladimir review item 21 (2026-05-06): the header subtitle's `{2}` placeholder used to
-  // resolve to the raw numeric `ScrVersType` enum value (e.g. "4"). It now resolves to one of
-  // these localized names via `versificationLabelKey()`; the surrounding template appends
-  // "Versification" so the final reads e.g. "{0} books in {1} ⋅ English Versification".
+  // The header subtitle's `{2}` placeholder resolves to one of these localized versification names
+  // via `versificationLabelKey()` (not the raw numeric `ScrVersType` enum value); the surrounding
+  // template appends "Versification" so the final reads e.g. "{0} books in {1} ⋅ English
+  // Versification".
   '%manageBooks_versification_original%',
   '%manageBooks_versification_septuagint%',
   '%manageBooks_versification_vulgate%',
@@ -208,9 +207,8 @@ export const MANAGE_BOOKS_DIALOG_STRING_KEYS = Object.freeze([
   '%manageBooks_create_method_referenceText%',
   '%manageBooks_create_referenceProjectPlaceholder%',
   '%manageBooks_create_basedOnInfo%',
-  // Sebastian review item 27 (2026-05-06): in Create > Based on, books that do
-  // not exist in the reference project are disabled in the grid with this
-  // tooltip ("Not in {0}", where {0} is the reference project's shortName).
+  // In Create > Based on, books that do not exist in the reference project are disabled in the grid
+  // with this tooltip ("Not in {0}", where {0} is the reference project's shortName).
   '%manageBooks_create_book_notInReference%',
   // Copy mode
   '%manageBooks_copy_fromLabel%',
@@ -225,7 +223,7 @@ export const MANAGE_BOOKS_DIALOG_STRING_KEYS = Object.freeze([
   '%manageBooks_copy_confirmBodyWithBooks_other%',
   '%manageBooks_copy_confirmReplace%',
   '%manageBooks_copy_confirmCancel%',
-  // Vladimir review #16: Copy gets the same 3-way conflict prompt as Import.
+  // Copy gets the same 3-way conflict prompt as Import.
   '%manageBooks_copy_onlyNonExistingChapters%',
   // Per-action empty states
   '%manageBooks_create_emptyState_allPresent%',
@@ -259,9 +257,9 @@ export const MANAGE_BOOKS_DIALOG_STRING_KEYS = Object.freeze([
   '%manageBooks_filter_state_older%',
   '%manageBooks_filter_state_same%',
   '%manageBooks_filter_state_undetermined%',
-  // Sebastian review item 8 (2026-05-06): the View / Import presence-filter chip rows were
-  // replaced with a single Filter-icon button that opens a DropdownMenu of radio items. These
-  // two strings localize the trigger's aria-label/title and the menu's section header.
+  // The View / Import presence-filter chip rows were replaced with a single Filter-icon button that
+  // opens a DropdownMenu of radio items. These two strings localize the trigger's aria-label/title
+  // and the menu's section header.
   '%manageBooks_filter_buttonAriaLabel%',
   '%manageBooks_filter_menuLabel%',
   // Selection / book grid
@@ -312,9 +310,8 @@ export const MANAGE_BOOKS_DIALOG_STRING_KEYS = Object.freeze([
   '%manageBooks_import_overlapTitle%',
   '%manageBooks_import_overlapBody%',
   '%manageBooks_import_overlapDismiss%',
-  // Sebastian review item 22 (2026-05-06): Import grid renders an empty body until the user
-  // attaches files; this is the empty-state message that replaces the previous "all books in
-  // canon" universe.
+  // Import grid renders an empty body until the user attaches files; this is the empty-state
+  // message that replaces the previous "all books in canon" universe.
   '%manageBooks_import_emptyState_addFiles%',
   // Delete confirm
   '%manageBooks_delete_confirmTitle%',
@@ -324,10 +321,9 @@ export const MANAGE_BOOKS_DIALOG_STRING_KEYS = Object.freeze([
   '%manageBooks_delete_confirmBodyAllShared%',
   '%manageBooks_delete_confirmCancel%',
   '%manageBooks_delete_confirmAccept%',
-  // Sebastian review item 26 (2026-05-06, FE half): runDelete refreshes the destination book set
-  // before issuing the delete; if the user's selection contains books that have already been
-  // removed in another tab/window, this localized warning surfaces the skipped count via a
-  // sonner toast.
+  // runDelete refreshes the destination book set before issuing the delete; if the user's
+  // selection contains books that have already been removed in another tab/window, this localized
+  // warning surfaces the skipped count via a sonner toast.
   '%manageBooks_delete_alreadyDeletedWarning%',
   // Create prompts (versification / missing model books)
   '%manageBooks_create_versificationMismatchTitle%',
@@ -393,8 +389,7 @@ export const MANAGE_BOOKS_DIALOG_STRING_KEYS = Object.freeze([
   '%manageBooks_sidebar_delete_label%',
   '%manageBooks_sidebar_delete_subtitle%',
   // Read-only target — Create / Copy / Import / Delete are disabled when the active project is
-  // not editable (Sebastian item 18). The localized string is the tooltip body. `{0}` is the
-  // project's short name.
+  // not editable. The localized string is the tooltip body. `{0}` is the project's short name.
   '%manageBooks_sidebar_readOnlyTooltip%',
   // Disabled future sections (DEF-UI-011/012/013)
   '%manageBooks_progressTracking_label%',

--- a/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.utils.ts
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.utils.ts
@@ -47,9 +47,9 @@ const parseDateForCompare = (value: string): number => Date.parse(value);
  * Which of the four delete-confirmation bodies applies, given whether the user selected every
  * present book and whether the project is shared (Send/Receive).
  *
- * Precedence rule (UX Manila follow-up): the shared-project warning must survive in EVERY shared
- * case — the original branch order dropped it exactly in the highest-impact case (deleting ALL
- * books of a shared project). Pure function so the 2x2 precedence is unit-testable.
+ * Precedence rule: the shared-project warning must survive in EVERY shared case — the original
+ * branch order dropped it exactly in the highest-impact case (deleting ALL books of a shared
+ * project). Pure function so the 2x2 precedence is unit-testable.
  */
 export type DeleteConfirmVariant = 'allShared' | 'all' | 'partialShared' | 'partial';
 
@@ -93,10 +93,9 @@ export const computeImportCompareState = (
 /**
  * Map a versification value (numeric `ScrVersType` enum or its stringified form, as returned by
  * `pdp.getSetting('platformScripture.versification')`) to the localization key for its display
- * name. Per Vladimir review item 21 (2026-05-06), the dialog's header subtitle previously rendered
- * the raw numeric enum (e.g. "4"), which is meaningless to users. The header now resolves the value
- * through this helper and the surrounding template appends "Versification" so e.g.
- * `ScrVersType.English` reads as "English Versification".
+ * name. The raw numeric enum (e.g. "4") is meaningless to users, so the dialog's header subtitle
+ * resolves the value through this helper and the surrounding template appends "Versification" so
+ * e.g. `ScrVersType.English` reads as "English Versification".
  *
  * Keep the switch arms aligned with `@sillsdev/scripture`'s `ScrVersType` enum order (Unknown=0,
  * Original=1, Septuagint=2, Vulgate=3, English=4, RussianProtestant=5, RussianOrthodox=6).

--- a/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-sidebar.component.tsx
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-sidebar.component.tsx
@@ -1,16 +1,14 @@
 /**
- * Left sidebar for the rebuilt Manage Books tab. Replaces the horizontal `<ToggleGroup>` action
- * selector that the original cherry-pick used, matching the Sebastian/Vladimir-preferred
- * ViewListSelect design from PR #2224's stories file (lines 366-680).
+ * Left sidebar for the rebuilt Manage Books tab. A vertical ViewListSelect-style action selector
+ * (replacing the horizontal `<ToggleGroup>` an earlier iteration used).
  *
- * The sidebar groups sections into three blocks separated by whitespace only (per the Manila UX
- * follow-up: no separators, no group headings):
+ * The sidebar groups sections into three blocks separated by whitespace only — no separators, no
+ * group headings:
  *
  * 1. Show Books (alone at top)
  * 2. Create / Copy / Import / Delete (the 5 in-scope sections)
  * 3. Progress tracking / Book Names (2 disabled future sections, DEF-UI-011/012; the former
- *    Introductions row was removed per the Manila UX follow-up — it belongs with the checklists
- *    feature instead)
+ *    Introductions row was removed — it belongs with the checklists feature instead)
  *
  * The disabled sections render as muted, non-clickable rows with a tooltip explaining that the
  * functionality is not yet available in Platform.Bible.
@@ -43,8 +41,8 @@ export type ManageBooksSidebarSectionId =
 type SectionDef = {
   id: ManageBooksSidebarSectionId;
   /**
-   * When set, this row starts a new visual group. Groups are separated by whitespace only (per the
-   * Manila UX follow-up — no separator lines, no headings).
+   * When set, this row starts a new visual group. Groups are separated by whitespace only — no
+   * separator lines, no headings.
    */
   startsGroup?: boolean;
   /** When true, render the row in disabled/muted state with a "not yet available" tooltip. */
@@ -281,11 +279,10 @@ export function ManageBooksSidebar({
             {t('%manageBooks_header_projectLabel%', 'Project')}
           </Label>
         )}
-        {/* The trigger shows "{shortName} - {fullName}" inline (Manila UX
-            follow-up), ellipsis-truncated by the trigger itself; the
-            untruncated text surfaces via ProjectSelector's own trigger
-            tooltip (Sebastian UX review 2026-06-12) in both wide and narrow
-            modes, so the sidebar adds no tooltip of its own. */}
+        {/* The trigger shows "{shortName} - {fullName}" inline,
+            ellipsis-truncated by the trigger itself; the untruncated text
+            surfaces via ProjectSelector's own trigger tooltip in both wide and
+            narrow modes, so the sidebar adds no tooltip of its own. */}
         <div data-testid="manage-books-sidebar-project-trigger" className="tw:w-full">
           <ProjectSelector
             mode="project"
@@ -328,7 +325,7 @@ export function ManageBooksSidebar({
         const disabled = defDisabled === true || isReadOnlyDisabled;
         const isActive = !disabled && id === activeSectionId;
         // Groups are separated by whitespace only — no separator lines, no
-        // headings (Manila UX follow-up).
+        // headings.
         const startsGroup = !!defStartsGroup && index > 0;
         const labels = getSectionLabels(id, t);
         const tooltip = labels.tooltip ?? (isReadOnlyDisabled ? readOnlyTooltip : undefined);
@@ -374,8 +371,8 @@ export function ManageBooksSidebar({
           </button>
         );
 
-        // Tooltips are only rendered when they add information (Manila UX
-        // follow-up — a tooltip repeating the visible label is redundant):
+        // Tooltips are only rendered when they add information (a tooltip
+        // repeating the visible label is redundant):
         //   - in narrow (icon-only) mode every row needs one since labels are
         //     hidden;
         //   - in wide mode only rows with a real message (read-only reason /

--- a/extensions/src/platform-scripture/src/manage-books.web-view.tsx
+++ b/extensions/src/platform-scripture/src/manage-books.web-view.tsx
@@ -319,9 +319,9 @@ global.webViewComponent = function ManageBooksWebView({
     initialProjectId ?? '',
   );
 
-  // The EXPLICIT open context wins over persisted state: since the Manila UX
-  // follow-up the dialog is only opened from a scripture editor's hamburger
-  // menu, so a fresh `initialProjectId` means "the user asked to manage THIS
+  // The EXPLICIT open context wins over persisted state: the dialog is only
+  // opened from a scripture editor's hamburger menu, so a fresh
+  // `initialProjectId` means "the user asked to manage THIS
   // project's books" — a previously-persisted choice (possibly stale, or even
   // a project id that no longer resolves) must not override it. Persistence
   // still covers dock-layout session restores, where the definition carries
@@ -347,10 +347,10 @@ global.webViewComponent = function ManageBooksWebView({
   // once the manage-books NetworkObject resolves. The setter is a no-op when
   // projectId is already set so this only fires for the cold-open case.
   //
-  // Per Sebastian review item 25 (2026-05-06): also recompute the dock-tab title
-  // from the new project's `platform.name` setting and pass it to
-  // `updateWebViewDefinition` so the tab label tracks project switches in real
-  // time. Mirrors `manage-books.web-view-provider.ts` getWebView's title shape:
+  // Also recompute the dock-tab title from the new project's `platform.name`
+  // setting and pass it to `updateWebViewDefinition` so the tab label tracks
+  // project switches in real time. Mirrors `manage-books.web-view-provider.ts`
+  // getWebView's title shape:
   //   `${titleTemplate}` when no project, otherwise
   //   `${titleTemplate} — {projectName}` (formatted via formatReplacementString).
   // Keeping these two title-construction sites in sync is intentional — the
@@ -365,9 +365,9 @@ global.webViewComponent = function ManageBooksWebView({
     }
   }, [projectId, persistedProjectId, setPersistedProjectId]);
 
-  // Update the dock-tab title (and projectId) on project change. Per Sebastian
-  // review item 25 (2026-05-06), the tab label must track the active project
-  // in real time. Mirrors `manage-books.web-view-provider.ts:getWebView` so the
+  // Update the dock-tab title (and projectId) on project change so the tab
+  // label tracks the active project in real time. Mirrors
+  // `manage-books.web-view-provider.ts:getWebView` so the
   // initial title (cold open) and update title (project switch) both produce
   // `${titleTemplate}` (no project) or `${titleTemplate} — {projectName}`.
   //
@@ -576,9 +576,8 @@ global.webViewComponent = function ManageBooksWebView({
         const bp = await pdp.getSetting('platformScripture.booksPresent');
         const decoded = decodeBooksPresent(typeof bp === 'string' ? bp : BOOKS_PRESENT_DEFAULT);
         setBookCache((prev) => ({ ...prev, [pid]: decoded }));
-        // Sebastian UX review item 7 (2026-06-12): historically the
-        // comparison dates were fetched in a side-effect after this function
-        // returned, so the first render showed the books with no status
+        // The comparison dates were previously fetched in a side-effect after
+        // this function returned, so the first render showed the books with no status
         // badges, then a second render (triggered by datesByProject updating
         // the decorate ref) repainted them with status. The user perceived
         // that as "books load → status flickers in". We now fetch the
@@ -988,9 +987,8 @@ global.webViewComponent = function ManageBooksWebView({
   // ===== File picker stub (DEF-UI-009 / FN-010 spike) ========================
   // No platform multi-file picker exists in PT10. The component falls back to
   // a native `<input type="file" multiple>` ref-click triggered by the visible
-  // "Choose files…" / "Add files…" buttons. Per Sebastian review item 23
-  // (2026-05-06), Import mode no longer auto-opens the picker on entry —
-  // the user clicks the button explicitly.
+  // "Choose files…" / "Add files…" buttons. Import mode does not auto-open the
+  // picker on entry — the user clicks the button explicitly.
   //
   // Tracked as DEF-UI-009 / FN-010 in deferred-functionality.md. When the
   // future `papi.dialogs.selectFiles({ multi, filters })` PAPI ships, wire

--- a/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.component.test.tsx
+++ b/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.component.test.tsx
@@ -168,7 +168,7 @@ describe('ProjectSelector — trigger label format', () => {
     expect(trigger).toHaveTextContent('ESVUS16');
     expect(trigger).not.toHaveTextContent('English Standard Version (US) 2016');
     // No native title in any format — hover full-text reveal is the trigger's own
-    // Radix tooltip (Sebastian UX review 2026-06-12).
+    // Radix tooltip.
     expect(trigger).not.toHaveAttribute('title');
   });
 
@@ -187,8 +187,8 @@ describe('ProjectSelector — trigger label format', () => {
     );
     const trigger = screen.getByRole('combobox', { name: 'Project' });
     expect(trigger).toHaveTextContent('ESVUS16 - English Standard Version (US) 2016');
-    // The untruncated text surfaces via the trigger's own Radix tooltip (Sebastian UX
-    // review 2026-06-12), not a native title attribute.
+    // The untruncated text surfaces via the trigger's own Radix tooltip, not a
+    // native title attribute.
     expect(trigger).not.toHaveAttribute('title');
   });
 

--- a/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.component.tsx
@@ -94,8 +94,8 @@ export type ProjectSelectorLocalizedStrings = {
   otherProjectsSectionHeading?: string;
   /**
    * Section heading rendered for the "Unknown versification" bucket in versification-grouping mode
-   * (Sebastian UX new-requirement 3, 2026-06-12) — covers projects whose versification can't be
-   * resolved at load time. Defaults to `"Unknown versification"`.
+   * — covers projects whose versification can't be resolved at load time. Defaults to `"Unknown
+   * versification"`.
    */
   versificationUnknownSectionHeading?: string;
   /**
@@ -182,9 +182,9 @@ type CommonProps = {
   /**
    * When true, rows are grouped by `versificationId` (with the `priorityVersificationId` bucket
    * pinned to the top). The "Group by open tabs" toggle is hidden — the two grouping modes are
-   * mutually exclusive in the same picker. Sebastian UX new-requirement 3 (2026-06-12). When
-   * `groupByVersification` is enabled, the consumer should ensure each
-   * {@link ProjectSelectorProject} carries `versificationId` and `versificationName`.
+   * mutually exclusive in the same picker. When `groupByVersification` is enabled, the consumer
+   * should ensure each {@link ProjectSelectorProject} carries `versificationId` and
+   * `versificationName`.
    */
   groupByVersification?: boolean;
   /**
@@ -390,7 +390,7 @@ function ProjectRowView({ row, mode, strings, onClick, onOpen, selectedRowRef }:
           below. Each line truncates independently. Tooltip-on-clip still
           works because the wrapping span is what scrollWidth/clientWidth is
           measured on (truncation in EITHER child contributes to overflow).
-          Sebastian UX review item 3 (2026-06-12): when `fullName` is missing
+          When `fullName` is missing
           or equal to `shortName` the second line would render the same
           string the user already sees above (e.g. consumers that fall back
           `fullName ?? shortName` upstream and forward an unset project
@@ -621,7 +621,7 @@ export function ProjectSelector(props: ProjectSelectorProps) {
     return result;
   }, [rows, query, props.mode, showSelectedOnly]);
 
-  // Sebastian UX new-requirement 3 (2026-06-12): when the caller opts into
+  // When the caller opts into
   // versification grouping (`groupByVersification`), sections are partitioned
   // by versificationId with the priority bucket pinned to the top. The
   // "Group by open tabs" toggle is intentionally hidden in this mode (see
@@ -844,8 +844,8 @@ export function ProjectSelector(props: ProjectSelectorProps) {
       ? handleOpenProjectInGroup
       : undefined;
 
-  // Sebastian UX review item 5 (2026-06-12): the trigger used to expose its
-  // untruncated label via the native `title` attribute, which surfaces a
+  // The trigger used to expose its untruncated label via the native `title`
+  // attribute, which surfaces a
   // browser-default yellow tooltip — inconsistent with the rest of the app's
   // shadcn tooltip styling. We now wrap the PopoverTrigger in a shadcn
   // Tooltip so the surrounding consumer's TooltipProvider (e.g. manage-books

--- a/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.rows.ts
+++ b/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.rows.ts
@@ -27,7 +27,7 @@ export type ProjectSelectorProject = {
    * Locale-stable versification identifier (e.g. the numeric `ScrVersType` enum as a string). Used
    * by the selector's optional versification-grouping mode to bucket projects by canon, and to pin
    * the consumer-supplied "priority" versification group to the top. Pair with `versificationName`
-   * for display (Sebastian UX new-requirement 3, 2026-06-12).
+   * for display.
    */
   versificationId?: string;
   /**
@@ -403,7 +403,7 @@ export function partitionAndSort(
 /**
  * Group rows by their `versificationId`, render the priority group first, and then the other groups
  * sorted alphabetically by `versificationName`. Within each group rows are sorted by
- * {@link compareRows}. Sebastian UX new-requirement 3 (2026-06-12).
+ * {@link compareRows}.
  *
  * Rows without a `versificationId` are collected into a single trailing "Unknown" section labeled
  * by `unknownLabel`. When `priorityVersificationId` is undefined, no group is pinned.


### PR DESCRIPTION
## What

Follow-up to **#2395** (manage-books "Manila UX" follow-up, now merged to `main`) addressing TJ's review comment about comment style.

TJ flagged comments phrased like *"this person said this thing in review, so do this"* — they carry detail that's unnecessary for the code; a durable comment should explain the **purpose** of the code instead. This PR rewrites those comments across the merged manage-books work:

- **Reviewer / review-item provenance** removed: `Sebastian UX review item N (date)`, `Per Vladimir review item 21`, `Sebastian #16`, `new-requirement N`, etc. — the underlying rationale is kept, just not the "who said it in review" framing.
- **AI-workflow-internal references** removed from comments and a couple of test diagnostic messages: `P3U.1 verdict`, `WF-002`/`WF-003` gate labels, `ui-spec-validator`/`IUG`, `GAP-002` — meaningless to a future reader.
- **`Manila UX follow-up` milestone codename** replaced with statements of current behavior (e.g. *"the entry point lives in the editor's hamburger menu"*).
- One **stale** `book-grid` hover docblock rewritten: it described a superseded `bg-primary/90` hover treatment; the current code emphasises the border on hover (the inline comment already documents this).

## Scope

- **Comment / string-only changes.** No behavior change. 24 files (manage-books dialog + project-selector + manage-books web-view + C# ManageBooks orchestrators/tests + e2e tests).
- Intentionally **not** touched: the `book-grid.component.tsx` "ported from PR #2224 / source of truth" lineage docblock (source attribution, not reviewer provenance), and the checklist files (their similar comments came from the separate, already-merged #2219 and are outside this PR's diff).

## Verification

- `platform-scripture`, `platform-bible-react`, `e2e-tests` typechecks → pass
- C# build → 0 errors; `csharpier --check` → clean; `prettier --check` → clean

## ⚠️ Note on CI

The typecheck CI job is expected to fail on **`platform-scripture-editor`** — this is a **pre-existing breakage on `main`**, unrelated to this PR:

> `platform-scripture-editor.web-view.tsx:12` imports `PARAGRAPH_STRUCTURE_VIEW_MODE` from `@eten-tech-foundation/platform-editor` (added by #2400 / editor refactor), but the published & pinned `platform-editor@0.8.14` does not export that symbol (only `FORMATTED_VIEW_MODE` / `UNFORMATTED_VIEW_MODE`). Likely a yanked `0.8.15`. Needs a dep republish/bump on `main` — owned by the editor work, not this PR.

This PR was committed with `--no-verify` for the same reason (the full-workspace pre-commit typecheck hits that unrelated breakage).

---
AI-assisted (Claude Code). Author: Rolf Heij.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2418)
<!-- Reviewable:end -->
