### PR TITLE
demo: multiline text-outline / highlight Storybook sketches (PT-4008)

### DIFF
--- a/lib/platform-bible-react/src/stories/experimental/text-outlines.mdx
+++ b/lib/platform-bible-react/src/stories/experimental/text-outlines.mdx
@@ -1,0 +1,135 @@
+import { Meta, Canvas } from '@storybook/addon-docs/blocks';
+import * as TextOutlines from './text-outlines.stories';
+
+<Meta of={TextOutlines} />
+
+# Text Outlines (Multiline) — experimental sketches
+
+> **Status: experimental / demo-only.** These are not components, not part of the design system,
+> and not wired to design tokens. They are two self-contained sketches exploring how to draw a
+> non-rectangular outline or highlight that **hugs the ragged-right shape of a multiline text
+> block** — the "staircase" shape a text selection makes across lines. Copy ideas out of them;
+> don't import them.
+
+## The problem
+
+A normal border or background draws a rectangle around the text's bounding box. We wanted the
+opposite: an outline that follows each line's actual right edge, so the last (short) line doesn't
+get a big empty rectangle of highlight to its right. Two approaches below get there in very
+different ways.
+
+Both demos are **editable** — click into the text in the canvas and type to watch the outline
+re-fit. Sliders adjust padding and (depending on technique) border width or corner radius.
+
+---
+
+## Technique 1 — CSS `clip-path` pseudo-element
+
+<Canvas of={TextOutlines.Technique1ClipPath} />
+
+A wrapper element gets two stacked pseudo-elements behind the text: `::before` painted in the
+border colour and `::after` painted as the fill. JavaScript measures each line and writes a ragged
+staircase `polygon()` into each `clip-path`. The fill is clipped to a **slightly smaller (inset)**
+polygon than the border layer, so the exposed rim of the layer below reads as a true outline that
+hugs every line.
+
+The key trick is the outline. You can't just add a CSS `border`: `clip-path` clips the border away
+along with everything else. Instead, the same staircase is computed twice — once at `pad` (border
+layer) and once at `pad - borderWidth` (fill layer) — and the difference between them is the
+visible rim.
+
+```tsx
+// Two staircases from the same line rects, the inner one inset by the border width.
+const outer = staircasePoints(el, pad); // border layer  -> ::before
+const inner = staircasePoints(el, pad - borderWidth); // fill layer -> ::after
+```
+
+```css
+.wrap {
+  position: relative;
+  display: inline-block;
+  padding: 8px 14px;
+}
+.wrap::before,
+.wrap::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+}
+.wrap::before {
+  background: #ff5d8f;
+} /* outer = border colour */
+.wrap::after {
+  background: linear-gradient(120deg, #ffe08a, #ffb86c);
+} /* fill, inset */
+/* clip-path: polygon(...) for ::before and ::after written from JS measurements */
+```
+
+Set border width to `0` and it collapses to a plain highlight fill.
+
+---
+
+## Technique 4 — `Range.getClientRects()` → SVG path
+
+<Canvas of={TextOutlines.Technique4SvgPath} />
+
+JavaScript builds a `Range` over the text and reads **one rectangle per visual line** via
+`getClientRects()`. Those rectangles are stitched into a single connected SVG `<path>` that traces
+a ragged staircase around the whole block — like a selection marquee. Because the outline is a real
+stroked vector, it can be filled, dashed, animated, or exported.
+
+```tsx
+function staircasePoints(el, pad) {
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  const rows = mergeRectsPerLine(range.getClientRects());
+  const pts = [];
+  for (const r of rows) {
+    // down the right edge
+    pts.push([r.right + pad, r.top - pad]);
+    pts.push([r.right + pad, r.bottom + pad]);
+  }
+  for (let i = rows.length - 1; i >= 0; i--) {
+    // up the left edge
+    pts.push([rows[i].left - pad, rows[i].bottom + pad]);
+    pts.push([rows[i].left - pad, rows[i].top - pad]);
+  }
+  return pts;
+}
+path.setAttribute('d', roundedPath(staircasePoints(text, 6), 8));
+```
+
+The SVG sits in an absolutely-positioned overlay (`inset: 0`, `pointer-events: none`) over the text,
+with no `viewBox`, so 1 user unit = 1 CSS px and the path's element-local coordinates line up with
+the text.
+
+---
+
+## Which one?
+
+| | Technique 1 — `clip-path` | Technique 4 — SVG path |
+| --- | --- | --- |
+| Outline is a… | filled rim between two clipped layers | real stroked vector |
+| Rounded corners | no (polygon only) | yes (quadratic corners) |
+| Dashed / animated stroke | no | yes |
+| DOM cost | 2 pseudo-elements, no extra nodes | 1 SVG + 1 path overlay |
+| Both need JS to measure lines | yes | yes |
+
+Use **Technique 1** when you want a solid marker-style highlight with a coloured rim and don't need
+rounded corners or stroke effects. Use **Technique 4** when you want an actual outline you can
+stroke, round, dash, or animate.
+
+## Caveats (why these stay experimental)
+
+- **Both require JS measurement.** The outline is recomputed from `getClientRects()` on edit,
+  resize, and after web fonts load (a font swap re-wraps lines). There is no pure-CSS version that
+  follows ragged text on the right edge.
+- **Not RTL-aware** and not tested against bidi text, vertical writing modes, or `text-align: justify`.
+- **No theming.** Colours are hard-coded so the sketches read the same regardless of the selected
+  Storybook theme; a real component would pull from tokens.
+- **Accessibility:** the editable surfaces are a demo affordance only (a11y checks are turned off
+  for these stories). A shipped version would not make the text contentEditable.
+
+If we decide to productionize one of these, it should be rebuilt as a proper component with tokens,
+RTL handling, and tests — at which point it leaves this Experimental section.

--- a/lib/platform-bible-react/src/stories/experimental/text-outlines.mdx
+++ b/lib/platform-bible-react/src/stories/experimental/text-outlines.mdx
@@ -7,31 +7,45 @@ import * as TextOutlines from './text-outlines.stories';
 
 > **Status: experimental / demo-only.** These are not components, not part of the design system,
 > and not wired to design tokens. They are two self-contained sketches exploring how to draw a
-> non-rectangular outline or highlight that **hugs the ragged-right shape of a multiline text
-> block** — the "staircase" shape a text selection makes across lines. Copy ideas out of them;
-> don't import them.
+> non-rectangular outline or highlight that **wraps a multiline block of text** — the shape a text
+> selection makes across wrapped lines. Copy ideas out of them; don't import them.
 
 ## The problem
 
-A normal border or background draws a rectangle around the text's bounding box. We wanted the
-opposite: an outline that follows each line's actual right edge, so the last (short) line doesn't
-get a big empty rectangle of highlight to its right. Two approaches below get there in very
-different ways.
+A normal CSS border or background paints a rectangle around the text's _bounding box_ (the single
+box that encloses every line). When the last line is short, that leaves a big empty band of
+highlight to the right of it. Hugging _every_ line's exact right edge removes the empty band, but it
+also carves a notch into the outline wherever a **middle** line happens to wrap a little short —
+which reads as noisy. (An edge that steps in and out line by line is described here as **ragged**.)
 
-Both demos are **editable** — click into the text in the canvas and type to watch the outline
-re-fit. Sliders adjust padding and (depending on technique) border width or corner radius.
+The target shape is the one a **text selection** makes: the first and last lines stay tight to where
+the text really starts and ends, while the **middle lines fill the full block width**. Because the
+right edge steps in and out from line to line, the outline's silhouette looks like a **staircase**.
+Each demo has a **Block-width middle lines** toggle so you can compare the two shapes: off is the
+fully ragged per-line edge; on is the selection-style shape with full-width middles. The two
+approaches below reach the same shape in very different ways.
+
+Both demos are **editable** (they use `contentEditable`) — click into the text in the canvas and
+type to watch the outline re-fit. Each demo has two toggles and two sliders:
+
+- **Block-width middle lines** switches between ragged per-line edges (off) and the selection-style
+  shape with full-width middle lines (on).
+- **Right-to-left** flips the writing direction; the geometry is direction-agnostic because it reads
+  visual rectangles, so the outline works the same either way.
+- The sliders adjust padding and — depending on the approach — border width or corner radius.
 
 ---
 
-## Technique 1 — CSS `clip-path` pseudo-element
+## Clip-path outline — stacked CSS pseudo-elements
 
-<Canvas of={TextOutlines.Technique1ClipPath} />
+<Canvas of={TextOutlines.ClipPathOutline} />
 
-A wrapper element gets two stacked pseudo-elements behind the text: `::before` painted in the
-border colour and `::after` painted as the fill. JavaScript measures each line and writes a ragged
-staircase `polygon()` into each `clip-path`. The fill is clipped to a **slightly smaller (inset)**
-polygon than the border layer, so the exposed rim of the layer below reads as a true outline that
-hugs every line.
+A wrapper element gets two stacked **pseudo-elements** behind the text (a pseudo-element is a
+generated `::before`/`::after` box CSS paints behind the real element): `::before` painted in the
+border colour and `::after` painted as the fill. `clip-path` cuts each of those boxes down to an
+arbitrary polygon. JavaScript measures each line and writes a ragged staircase `polygon()` into each
+`clip-path`. The fill is clipped to a **slightly smaller (inset)** polygon than the border layer, so
+the exposed rim of the layer below reads as a true outline that follows every line.
 
 The key trick is the outline. You can't just add a CSS `border`: `clip-path` clips the border away
 along with everything else. Instead, the same staircase is computed twice — once at `pad` (border
@@ -70,14 +84,15 @@ Set border width to `0` and it collapses to a plain highlight fill.
 
 ---
 
-## Technique 4 — `Range.getClientRects()` → SVG path
+## SVG path outline — measured rectangles stitched into one path
 
-<Canvas of={TextOutlines.Technique4SvgPath} />
+<Canvas of={TextOutlines.SvgPathOutline} />
 
-JavaScript builds a `Range` over the text and reads **one rectangle per visual line** via
-`getClientRects()`. Those rectangles are stitched into a single connected SVG `<path>` that traces
-a ragged staircase around the whole block — like a selection marquee. Because the outline is a real
-stroked vector, it can be filled, dashed, animated, or exported.
+JavaScript builds a `Range` (a DOM object spanning a run of text) over the text and calls its
+`getClientRects()` method, which returns the on-screen rectangle of each wrapped line. Those
+rectangles are stitched into a single connected SVG `<path>` that traces a staircase around the
+whole block — like a selection marquee. Because the outline is a real stroked vector, it can be
+filled, dashed, animated, or exported.
 
 ```tsx
 function staircasePoints(el, pad) {
@@ -104,32 +119,39 @@ The SVG sits in an absolutely-positioned overlay (`inset: 0`, `pointer-events: n
 with no `viewBox`, so 1 user unit = 1 CSS px and the path's element-local coordinates line up with
 the text.
 
+The actual helper takes a `blockMiddles` flag (shown above as the loops over `r.right` / `r.left`):
+when set, every row except the first and last uses the block's max-right / min-left instead of its
+own edge, producing the selection-style shape rather than a fully ragged staircase.
+
 ---
 
 ## Which one?
 
-| | Technique 1 — `clip-path` | Technique 4 — SVG path |
-| --- | --- | --- |
-| Outline is a… | filled rim between two clipped layers | real stroked vector |
-| Rounded corners | no (polygon only) | yes (quadratic corners) |
-| Dashed / animated stroke | no | yes |
-| DOM cost | 2 pseudo-elements, no extra nodes | 1 SVG + 1 path overlay |
-| Both need JS to measure lines | yes | yes |
+|                                | Clip-path outline                     | SVG path outline                 |
+| ------------------------------ | ------------------------------------- | -------------------------------- |
+| Outline is a…                  | filled rim between two clipped layers | real stroked vector              |
+| Rounded corners                | no (polygon only)                     | yes (quadratic corners)          |
+| Dashed / animated stroke       | no                                    | yes                              |
+| DOM cost                       | 2 pseudo-elements, no extra nodes     | 1 SVG + 1 path overlay           |
+| Both need JS to measure lines  | yes                                   | yes                              |
 
-Use **Technique 1** when you want a solid marker-style highlight with a coloured rim and don't need
-rounded corners or stroke effects. Use **Technique 4** when you want an actual outline you can
-stroke, round, dash, or animate.
+Use the **clip-path outline** when you want a solid marker-style highlight with a coloured rim and
+don't need rounded corners or stroke effects. Use the **SVG path outline** when you want an actual
+outline you can stroke, round, dash, or animate.
 
 ## Caveats (why these stay experimental)
 
 - **Both require JS measurement.** The outline is recomputed from `getClientRects()` on edit,
   resize, and after web fonts load (a font swap re-wraps lines). There is no pure-CSS version that
-  follows ragged text on the right edge.
-- **Not RTL-aware** and not tested against bidi text, vertical writing modes, or `text-align: justify`.
+  follows the line-by-line shape of wrapped text.
+- **Right-to-left is handled.** Both demos have a **Right-to-left** toggle, and the geometry is
+  direction-agnostic — it reads visual rectangles and treats the left and right edges
+  symmetrically. Mixed-direction (bidi) text, vertical writing modes, and `text-align: justify` are
+  still untested.
 - **No theming.** Colours are hard-coded so the sketches read the same regardless of the selected
   Storybook theme; a real component would pull from tokens.
 - **Accessibility:** the editable surfaces are a demo affordance only (a11y checks are turned off
-  for these stories). A shipped version would not make the text contentEditable.
+  for these stories). A shipped version would not make the text `contentEditable`.
 
-If we decide to productionize one of these, it should be rebuilt as a proper component with tokens,
-RTL handling, and tests — at which point it leaves this Experimental section.
+Productionizing either of these means rebuilding it as a proper component with design tokens and
+tests — at which point it leaves this Experimental section.

--- a/lib/platform-bible-react/src/stories/experimental/text-outlines.stories.tsx
+++ b/lib/platform-bible-react/src/stories/experimental/text-outlines.stories.tsx
@@ -1,12 +1,18 @@
 /**
  * EXPERIMENTAL / DEMO-ONLY - not a design-system component.
  *
- * Two techniques for drawing a non-rectangular outline/highlight that hugs the ragged-right shape
- * of a multiline text block (the "staircase"/Z shape a text selection makes across lines):
+ * Two approaches for drawing a non-rectangular outline/highlight that wraps a multiline block of
+ * text. The target shape is the one a text selection makes across wrapped lines: tight to where the
+ * text starts and ends on the first and last lines, but filling the full block width on the lines
+ * in between. Because the right edge steps in and out from line to line, the silhouette looks like
+ * a staircase.
  *
- * - Technique 1: a CSS clip-path pseudo-element pair (border layer + inset fill layer).
- * - Technique 4: measuring per-line rects with Range.getClientRects() and stitching them into a
- *   single connected SVG path.
+ * - ClipPathOutline: a pair of stacked CSS clip-path pseudo-elements (a border-coloured layer and a
+ *   slightly inset fill layer; the exposed rim reads as the outline). A pseudo-element is a
+ *   generated `::before`/`::after` box that CSS paints behind the real element. `clip-path` cuts a
+ *   box down to an arbitrary polygon.
+ * - SvgPathOutline: measures each line's rectangle with `Range.getClientRects()` and stitches the
+ *   rectangles into a single connected SVG path that can be stroked, rounded, dashed, or animated.
  *
  * Everything here is self-contained (local helpers + inline styles). It intentionally avoids
  * shadcn/ui, design tokens, and shared components so it can be copied out as a sketch without
@@ -58,24 +64,38 @@ function lineRows(el: HTMLElement): Row[] {
 }
 
 /**
- * Build an ordered list of points (element-local px) tracing a ragged staircase around the text:
- * down the right edge, then back up the left edge. `pad` insets/expands the outline uniformly.
+ * Build an ordered list of points (element-local px) tracing an outline around the text: down the
+ * right edge, then back up the left edge. `pad` insets/expands the outline uniformly.
+ *
+ * When `blockMiddles` is true, every line _except the first and last_ is stretched to the block's
+ * full extent (its max right / min left) instead of its own ragged edge. That yields the shape a
+ * text selection makes: the first and last lines stay tight to where the text actually starts and
+ * ends, while the middle lines fill the block width. When false, every line follows its own edge (a
+ * fully ragged staircase). Only the trailing edge visibly changes, since every line already shares
+ * the same leading edge (the right edge in left-to-right text, the left edge in right-to-left).
  */
-function staircasePoints(el: HTMLElement, pad: number): Point[] {
+function staircasePoints(el: HTMLElement, pad: number, blockMiddles = false): Point[] {
   const rows = lineRows(el);
   if (rows.length === 0) return [];
   const base = el.getBoundingClientRect();
   const ox = base.left;
   const oy = base.top;
+  const maxRight = Math.max(...rows.map((r) => r.right));
+  const minLeft = Math.min(...rows.map((r) => r.left));
+  const last = rows.length - 1;
+  // First and last lines keep their own ragged edge; middle lines snap to the block extent.
+  const isEnd = (i: number) => i === 0 || i === last;
+  const rightX = (i: number) => (blockMiddles && !isEnd(i) ? maxRight : rows[i].right) - ox + pad;
+  const leftX = (i: number) => (blockMiddles && !isEnd(i) ? minLeft : rows[i].left) - ox - pad;
   const pts: Point[] = [];
-  rows.forEach((r) => {
-    pts.push([r.right - ox + pad, r.top - oy - pad]);
-    pts.push([r.right - ox + pad, r.bottom - oy + pad]);
+  rows.forEach((r, i) => {
+    pts.push([rightX(i), r.top - oy - pad]);
+    pts.push([rightX(i), r.bottom - oy + pad]);
   });
-  for (let i = rows.length - 1; i >= 0; i -= 1) {
+  for (let i = last; i >= 0; i -= 1) {
     const r = rows[i];
-    pts.push([r.left - ox - pad, r.bottom - oy + pad]);
-    pts.push([r.left - ox - pad, r.top - oy - pad]);
+    pts.push([leftX(i), r.bottom - oy + pad]);
+    pts.push([leftX(i), r.top - oy - pad]);
   }
   return pts;
 }
@@ -181,6 +201,23 @@ function Slider({ label, value, min, max, onChange }: SliderProps) {
   );
 }
 
+interface ToggleProps {
+  label: string;
+  checked: boolean;
+  onChange: Dispatch<SetStateAction<boolean>>;
+}
+
+function Toggle({ label, checked, onChange }: ToggleProps) {
+  return (
+    <label
+      style={{ display: 'inline-flex', gap: 6, alignItems: 'center', fontSize: 13, opacity: 0.8 }}
+    >
+      <input type="checkbox" checked={checked} onChange={(e) => onChange(e.target.checked)} />
+      {label}
+    </label>
+  );
+}
+
 const controlsRow: CSSProperties = {
   display: 'flex',
   gap: 18,
@@ -199,7 +236,7 @@ const demoStage: CSSProperties = {
 };
 
 // ---------------------------------------------------------------------------
-// Technique 1 - clip-path pseudo-element (border layer + inset fill layer)
+// Clip-path outline: pseudo-element pair (border layer + inset fill layer)
 // ---------------------------------------------------------------------------
 
 function ClipPathDemo() {
@@ -208,6 +245,8 @@ function ClipPathDemo() {
   const ref = useRef<HTMLDivElement>(null);
   const [pad, setPad] = useState(6);
   const [border, setBorder] = useState(3);
+  const [blockMiddles, setBlockMiddles] = useState(true);
+  const [rtl, setRtl] = useState(false);
   const [outer, setOuter] = useState('');
   const [inner, setInner] = useState('');
 
@@ -217,9 +256,12 @@ function ClipPathDemo() {
   const recompute = useCallback(() => {
     const el = ref.current;
     if (!el) return;
-    setOuter(toPolygon(staircasePoints(el, pad)));
-    setInner(toPolygon(staircasePoints(el, pad - border)));
-  }, [pad, border]);
+    // Measure in the chosen writing direction. The geometry reads visual rects, so it is
+    // direction-agnostic; flipping `dir` re-wraps the lines without resizing the box.
+    el.dir = rtl ? 'rtl' : 'ltr';
+    setOuter(toPolygon(staircasePoints(el, pad, blockMiddles)));
+    setInner(toPolygon(staircasePoints(el, pad - border, blockMiddles)));
+  }, [pad, border, blockMiddles, rtl]);
 
   useReflow(ref, recompute);
 
@@ -229,8 +271,9 @@ function ClipPathDemo() {
     <div>
       <style>{`
         .${cls} {
-          position: relative; display: inline-block; max-width: 26ch;
-          padding: 8px 14px; font-size: 1.5rem; font-weight: 600; line-height: 1.55;
+          position: relative; display: inline-block; max-inline-size: 26ch;
+          padding-block: 8px; padding-inline: 14px;
+          font-size: 1.5rem; font-weight: 600; line-height: 1.55;
           color: #1a1230; z-index: 0;
         }
         .${cls}::before, .${cls}::after {
@@ -255,19 +298,27 @@ function ClipPathDemo() {
           tabIndex={0}
           onInput={recompute}
         >
-          Outlines that wrap around ragged multiline text the way a marker would.
+          This editable demo draws a highlighter-style outline around a whole block of wrapped text.
+          The middle lines stay flush to the block width while the short last line tucks in. Type
+          here to watch the outline re-fit as the text re-wraps across several lines.
         </div>
       </div>
       <div style={controlsRow}>
         <Slider label="Padding" value={pad} min={0} max={16} onChange={setPad} />
         <Slider label="Border" value={border} min={0} max={10} onChange={setBorder} />
+        <Toggle
+          label="Block-width middle lines"
+          checked={blockMiddles}
+          onChange={setBlockMiddles}
+        />
+        <Toggle label="Right-to-left" checked={rtl} onChange={setRtl} />
       </div>
     </div>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Technique 4 - getClientRects() -> SVG staircase path
+// SVG path outline: getClientRects() -> single connected SVG staircase path
 // ---------------------------------------------------------------------------
 
 function SvgStaircaseDemo() {
@@ -276,13 +327,18 @@ function SvgStaircaseDemo() {
   const ref = useRef<HTMLDivElement>(null);
   const [pad, setPad] = useState(6);
   const [corner, setCorner] = useState(8);
+  const [blockMiddles, setBlockMiddles] = useState(true);
+  const [rtl, setRtl] = useState(false);
   const [d, setD] = useState('');
 
   const recompute = useCallback(() => {
     const el = ref.current;
     if (!el) return;
-    setD(roundedPath(staircasePoints(el, pad), corner));
-  }, [pad, corner]);
+    // Measure in the chosen writing direction. The geometry reads visual rects, so it is
+    // direction-agnostic; flipping `dir` re-wraps the lines without resizing the box.
+    el.dir = rtl ? 'rtl' : 'ltr';
+    setD(roundedPath(staircasePoints(el, pad, blockMiddles), corner));
+  }, [pad, corner, blockMiddles, rtl]);
 
   useReflow(ref, recompute);
 
@@ -326,18 +382,27 @@ function SvgStaircaseDemo() {
               fontSize: '1.5rem',
               fontWeight: 600,
               lineHeight: 1.85,
-              maxWidth: '26ch',
-              padding: '8px 12px',
+              maxInlineSize: '26ch',
+              paddingBlock: '8px',
+              paddingInline: '12px',
               color: 'inherit',
             }}
           >
-            A single connected outline traces the whole ragged block of multiline text.
+            This editable demo traces one connected outline around a whole block of wrapped text,
+            filling the middle lines to full width while the first and last lines hug the text. Type
+            here to watch the path re-fit as the text re-wraps across several lines.
           </div>
         </div>
       </div>
       <div style={controlsRow}>
         <Slider label="Padding" value={pad} min={0} max={16} onChange={setPad} />
         <Slider label="Corner" value={corner} min={0} max={20} onChange={setCorner} />
+        <Toggle
+          label="Block-width middle lines"
+          checked={blockMiddles}
+          onChange={setBlockMiddles}
+        />
+        <Toggle label="Right-to-left" checked={rtl} onChange={setRtl} />
       </div>
     </div>
   );
@@ -361,12 +426,12 @@ export default meta;
 
 type Story = StoryObj;
 
-export const Technique1ClipPath: Story = {
-  name: 'Technique 1 - clip-path outline',
+export const ClipPathOutline: Story = {
+  name: 'Clip-path outline',
   render: () => <ClipPathDemo />,
 };
 
-export const Technique4SvgPath: Story = {
-  name: 'Technique 4 - SVG staircase path',
+export const SvgPathOutline: Story = {
+  name: 'SVG staircase path',
   render: () => <SvgStaircaseDemo />,
 };

--- a/lib/platform-bible-react/src/stories/experimental/text-outlines.stories.tsx
+++ b/lib/platform-bible-react/src/stories/experimental/text-outlines.stories.tsx
@@ -1,0 +1,372 @@
+/**
+ * EXPERIMENTAL / DEMO-ONLY - not a design-system component.
+ *
+ * Two techniques for drawing a non-rectangular outline/highlight that hugs the ragged-right shape
+ * of a multiline text block (the "staircase"/Z shape a text selection makes across lines):
+ *
+ * - Technique 1: a CSS clip-path pseudo-element pair (border layer + inset fill layer).
+ * - Technique 4: measuring per-line rects with Range.getClientRects() and stitching them into a
+ *   single connected SVG path.
+ *
+ * Everything here is self-contained (local helpers + inline styles). It intentionally avoids
+ * shadcn/ui, design tokens, and shared components so it can be copied out as a sketch without
+ * implying it is supported UI.
+ */
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction,
+} from 'react';
+
+// ---------------------------------------------------------------------------
+// Shared geometry helpers
+// ---------------------------------------------------------------------------
+
+type Point = [number, number];
+interface Row {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+/** Collapse a Range's client rects into one row per visual line. */
+function lineRows(el: HTMLElement): Row[] {
+  const range = document.createRange();
+  range.selectNodeContents(el);
+  const rects = Array.from(range.getClientRects()).filter((r) => r.width > 0 && r.height > 1);
+  const rows: Row[] = [];
+  rects.forEach((r) => {
+    const row = rows.find((x) => Math.abs(x.top - r.top) < 4 && Math.abs(x.bottom - r.bottom) < 6);
+    if (row) {
+      row.left = Math.min(row.left, r.left);
+      row.right = Math.max(row.right, r.right);
+    } else {
+      rows.push({ top: r.top, bottom: r.bottom, left: r.left, right: r.right });
+    }
+  });
+  rows.sort((a, b) => a.top - b.top);
+  return rows;
+}
+
+/**
+ * Build an ordered list of points (element-local px) tracing a ragged staircase around the text:
+ * down the right edge, then back up the left edge. `pad` insets/expands the outline uniformly.
+ */
+function staircasePoints(el: HTMLElement, pad: number): Point[] {
+  const rows = lineRows(el);
+  if (rows.length === 0) return [];
+  const base = el.getBoundingClientRect();
+  const ox = base.left;
+  const oy = base.top;
+  const pts: Point[] = [];
+  rows.forEach((r) => {
+    pts.push([r.right - ox + pad, r.top - oy - pad]);
+    pts.push([r.right - ox + pad, r.bottom - oy + pad]);
+  });
+  for (let i = rows.length - 1; i >= 0; i -= 1) {
+    const r = rows[i];
+    pts.push([r.left - ox - pad, r.bottom - oy + pad]);
+    pts.push([r.left - ox - pad, r.top - oy - pad]);
+  }
+  return pts;
+}
+
+/** Format points as a CSS polygon() value (px units). */
+function toPolygon(pts: Point[]): string {
+  return pts.map(([x, y]) => `${x.toFixed(1)}px ${y.toFixed(1)}px`).join(', ');
+}
+
+function distance(a: Point, b: Point): number {
+  return Math.hypot(a[0] - b[0], a[1] - b[1]);
+}
+
+function unit(from: Point, to: Point): Point {
+  const dx = to[0] - from[0];
+  const dy = to[1] - from[1];
+  const len = Math.hypot(dx, dy) || 1;
+  return [dx / len, dy / len];
+}
+
+/** Build an SVG path through points with optional rounded corners of radius `r`. */
+function roundedPath(pts: Point[], r: number): string {
+  const n = pts.length;
+  if (n < 3) return '';
+  if (r <= 0) {
+    return `M${pts.map(([x, y]) => `${x.toFixed(1)},${y.toFixed(1)}`).join(' L')} Z`;
+  }
+  let d = '';
+  for (let i = 0; i < n; i += 1) {
+    const prev = pts[(i - 1 + n) % n];
+    const cur = pts[i];
+    const next = pts[(i + 1) % n];
+    const v1 = unit(cur, prev);
+    const v2 = unit(cur, next);
+    const d1 = Math.min(r, distance(cur, prev) / 2);
+    const d2 = Math.min(r, distance(cur, next) / 2);
+    const p1: Point = [cur[0] + v1[0] * d1, cur[1] + v1[1] * d1];
+    const p2: Point = [cur[0] + v2[0] * d2, cur[1] + v2[1] * d2];
+    d +=
+      i === 0
+        ? `M${p1[0].toFixed(1)},${p1[1].toFixed(1)}`
+        : `L${p1[0].toFixed(1)},${p1[1].toFixed(1)}`;
+    d += ` Q${cur[0].toFixed(1)},${cur[1].toFixed(1)} ${p2[0].toFixed(1)},${p2[1].toFixed(1)}`;
+  }
+  return `${d} Z`;
+}
+
+/**
+ * Run `recompute` on mount, on element/window resize, and after web fonts finish loading (a font
+ * swap re-wraps lines, which moves the outline). Wires and tears down its own listeners.
+ */
+function useReflow(target: RefObject<HTMLElement | null>, recompute: () => void): void {
+  useLayoutEffect(() => {
+    recompute();
+  }, [recompute]);
+
+  useEffect(() => {
+    const el = target.current;
+    const onChange = () => recompute();
+    window.addEventListener('resize', onChange);
+    let observer: ResizeObserver | undefined;
+    if (el) {
+      observer = new ResizeObserver(onChange);
+      observer.observe(el);
+    }
+    const { fonts } = document;
+    fonts?.addEventListener('loadingdone', onChange);
+    return () => {
+      window.removeEventListener('resize', onChange);
+      observer?.disconnect();
+      fonts?.removeEventListener('loadingdone', onChange);
+    };
+  }, [target, recompute]);
+}
+
+// ---------------------------------------------------------------------------
+// Small shared UI bits (plain HTML - no design-system dependency)
+// ---------------------------------------------------------------------------
+
+interface SliderProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  onChange: Dispatch<SetStateAction<number>>;
+}
+
+function Slider({ label, value, min, max, onChange }: SliderProps) {
+  return (
+    <label
+      style={{ display: 'inline-flex', gap: 6, alignItems: 'center', fontSize: 13, opacity: 0.8 }}
+    >
+      {label}
+      <input
+        type="range"
+        min={min}
+        max={max}
+        value={value}
+        onChange={(e) => onChange(Number(e.target.value))}
+      />
+      <span style={{ fontVariantNumeric: 'tabular-nums', minWidth: 22 }}>{value}</span>
+    </label>
+  );
+}
+
+const controlsRow: CSSProperties = {
+  display: 'flex',
+  gap: 18,
+  flexWrap: 'wrap',
+  alignItems: 'center',
+  marginTop: 16,
+};
+
+const demoStage: CSSProperties = {
+  display: 'flex',
+  padding: '26px 22px',
+  borderRadius: 10,
+  background: 'rgba(127,127,127,0.08)',
+  minHeight: 120,
+  alignItems: 'center',
+};
+
+// ---------------------------------------------------------------------------
+// Technique 1 - clip-path pseudo-element (border layer + inset fill layer)
+// ---------------------------------------------------------------------------
+
+function ClipPathDemo() {
+  // useRef's initial DOM value must be null until the element mounts.
+  // eslint-disable-next-line no-null/no-null
+  const ref = useRef<HTMLDivElement>(null);
+  const [pad, setPad] = useState(6);
+  const [border, setBorder] = useState(3);
+  const [outer, setOuter] = useState('');
+  const [inner, setInner] = useState('');
+
+  const rawId = useId();
+  const cls = `cpo-${rawId.replace(/[^a-zA-Z0-9]/g, '')}`;
+
+  const recompute = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    setOuter(toPolygon(staircasePoints(el, pad)));
+    setInner(toPolygon(staircasePoints(el, pad - border)));
+  }, [pad, border]);
+
+  useReflow(ref, recompute);
+
+  const fallback = '0 0, 100% 0, 100% 100%, 0 100%';
+
+  return (
+    <div>
+      <style>{`
+        .${cls} {
+          position: relative; display: inline-block; max-width: 26ch;
+          padding: 8px 14px; font-size: 1.5rem; font-weight: 600; line-height: 1.55;
+          color: #1a1230; z-index: 0;
+        }
+        .${cls}::before, .${cls}::after {
+          content: ""; position: absolute; inset: 0; z-index: -1; transition: clip-path .1s ease;
+        }
+        .${cls}::before { background: #ff5d8f; clip-path: polygon(${outer || fallback}); }
+        .${cls}::after  {
+          background: linear-gradient(120deg, #ffe08a, #ffb86c);
+          clip-path: polygon(${inner || fallback});
+        }
+      `}</style>
+      <div style={demoStage}>
+        <div
+          ref={ref}
+          className={cls}
+          contentEditable
+          suppressContentEditableWarning
+          spellCheck={false}
+          role="textbox"
+          aria-multiline="true"
+          aria-label="Editable demo text"
+          tabIndex={0}
+          onInput={recompute}
+        >
+          Outlines that wrap around ragged multiline text the way a marker would.
+        </div>
+      </div>
+      <div style={controlsRow}>
+        <Slider label="Padding" value={pad} min={0} max={16} onChange={setPad} />
+        <Slider label="Border" value={border} min={0} max={10} onChange={setBorder} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Technique 4 - getClientRects() -> SVG staircase path
+// ---------------------------------------------------------------------------
+
+function SvgStaircaseDemo() {
+  // useRef's initial DOM value must be null until the element mounts.
+  // eslint-disable-next-line no-null/no-null
+  const ref = useRef<HTMLDivElement>(null);
+  const [pad, setPad] = useState(6);
+  const [corner, setCorner] = useState(8);
+  const [d, setD] = useState('');
+
+  const recompute = useCallback(() => {
+    const el = ref.current;
+    if (!el) return;
+    setD(roundedPath(staircasePoints(el, pad), corner));
+  }, [pad, corner]);
+
+  useReflow(ref, recompute);
+
+  return (
+    <div>
+      <div style={demoStage}>
+        <div style={{ position: 'relative', display: 'inline-block' }}>
+          <svg
+            aria-hidden
+            style={{
+              position: 'absolute',
+              inset: 0,
+              width: '100%',
+              height: '100%',
+              pointerEvents: 'none',
+              overflow: 'visible',
+              zIndex: 0,
+            }}
+          >
+            <path
+              d={d}
+              fill="rgba(110,168,254,0.12)"
+              stroke="#6ea8fe"
+              strokeWidth={2}
+              strokeLinejoin="round"
+            />
+          </svg>
+          <div
+            ref={ref}
+            contentEditable
+            suppressContentEditableWarning
+            spellCheck={false}
+            role="textbox"
+            aria-multiline="true"
+            aria-label="Editable demo text"
+            tabIndex={0}
+            onInput={recompute}
+            style={{
+              position: 'relative',
+              zIndex: 1,
+              fontSize: '1.5rem',
+              fontWeight: 600,
+              lineHeight: 1.85,
+              maxWidth: '26ch',
+              padding: '8px 12px',
+              color: 'inherit',
+            }}
+          >
+            A single connected outline traces the whole ragged block of multiline text.
+          </div>
+        </div>
+      </div>
+      <div style={controlsRow}>
+        <Slider label="Padding" value={pad} min={0} max={16} onChange={setPad} />
+        <Slider label="Corner" value={corner} min={0} max={20} onChange={setCorner} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Storybook meta + stories
+// ---------------------------------------------------------------------------
+
+const meta: Meta = {
+  title: 'Experimental/Text Outlines',
+  // Custom MDX docs page (text-outlines.mdx) is the primary doc; opt out of autodocs.
+  tags: ['!autodocs'],
+  parameters: {
+    layout: 'padded',
+    // contentEditable demo surfaces trip a11y name/role checks; this is a sketch, not shipped UI.
+    a11y: { test: 'off' },
+  },
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Technique1ClipPath: Story = {
+  name: 'Technique 1 - clip-path outline',
+  render: () => <ClipPathDemo />,
+};
+
+export const Technique4SvgPath: Story = {
+  name: 'Technique 4 - SVG staircase path',
+  render: () => <SvgStaircaseDemo />,
+};


### PR DESCRIPTION
Experimental, **demo-only** Storybook sketches exploring how to draw an outline/highlight that wraps a multiline block of text in the shape a text selection makes — tight to the text on the first and last lines, but filling the full block width on the lines in between (no empty band after a short last line, no ragged notches in the middle).

@katherinejensen00 — sharing this to help with [PT-4008](https://paratextstudio.atlassian.net/browse/PT-4008). There are two self-contained approaches here; take a look and let's talk about whether either fits what we need.

### What's in it

Two approaches, both under **Experimental → Text Outlines** in Storybook:

- **Clip-path outline** — two stacked CSS `clip-path` pseudo-elements (a border-coloured layer and a slightly-inset fill layer; the exposed rim reads as the outline).
- **SVG path outline** — each line's rectangle is measured with `Range.getClientRects()` and the rects are stitched into a single connected, stroked SVG `<path>` (can be rounded, dashed, animated).

Both demos are editable (type into them) and have controls:

- **Block-width middle lines** — on = selection-style shape (full-width middles); off = every line hugs its own ragged edge.
- **Right-to-left** — the geometry reads visual rectangles and treats both edges symmetrically, so it works in either direction.
- Sliders for padding and (per approach) border width or corner radius.

### Screenshots

<table>
  <tr>
    <td align="center" width="50%"><strong>Clip-path outline — block-width middles</strong></td>
    <td align="center" width="50%"><strong>Clip-path outline — fully ragged (toggle off)</strong></td>
  </tr>
  <tr>
    <td><img src="https://raw.githubusercontent.com/paranext/paranext-core/d4ec27eae905d040522e53e879f54d52679fef75/text-outline-techniques/clip-path-block-middles.png" alt="Clip-path outline with block-width middle lines: middles flush, short last line tucked in"></td>
    <td><img src="https://raw.githubusercontent.com/paranext/paranext-core/d4ec27eae905d040522e53e879f54d52679fef75/text-outline-techniques/clip-path-ragged.png" alt="Clip-path outline with the toggle off: every line hugs its own ragged right edge"></td>
  </tr>
  <tr>
    <td align="center"><strong>SVG path outline — block-width middles</strong></td>
    <td align="center"><strong>SVG path outline — right-to-left</strong></td>
  </tr>
  <tr>
    <td><img src="https://raw.githubusercontent.com/paranext/paranext-core/d4ec27eae905d040522e53e879f54d52679fef75/text-outline-techniques/svg-path-block-middles.png" alt="SVG path outline with block-width middle lines and rounded corners"></td>
    <td><img src="https://raw.githubusercontent.com/paranext/paranext-core/d4ec27eae905d040522e53e879f54d52679fef75/text-outline-techniques/svg-path-rtl.png" alt="SVG path outline rendered right-to-left: the text right-aligns and the tuck mirrors to the left"></td>
  </tr>
</table>

The first two are the same demo with the **Block-width middle lines** toggle on vs off — note how the middle lines snap flush to the block on the left, and the ragged notches on the right. The last shot flips the SVG demo to **right-to-left**: the geometry is unchanged (it reads visual rectangles), so the tuck simply mirrors to the other side.

### How to view

```bash
npm run storybook:platform-bible-react
```

Then open **Experimental → Text Outlines** at http://localhost:6007.

### Status / caveats

- **Demo-only, not for merge as-is**: not a component, not wired to design tokens, colours are hard-coded, and the `contentEditable` surfaces are a demo affordance (a11y checks are off for these stories).
- Requires JS line measurement; the outline is recomputed on edit, resize, and after web fonts load.
- RTL is handled; bidi/mixed-direction text, vertical writing modes, and `text-align: justify` are untested.
- Productionizing either would mean rebuilding it as a proper component with design tokens and tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PT-4008]: https://paratextstudio.atlassian.net/browse/PT-4008?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2419)
<!-- Reviewable:end -->


