### PR TITLE
fix: retry src/shared/services inits after timeout

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -3578,6 +3578,26 @@ declare module 'shared/models/network-object-status.service-model' {
   }
   export const networkObjectStatusServiceNetworkObjectName = 'NetworkObjectStatusService';
 }
+declare module 'shared/utils/cached-initializer' {
+  /**
+   * Creates a function that runs an asynchronous initializer at most once, caching the promise so
+   * concurrent and subsequent calls share the same initialization attempt. If the initializer fails,
+   * the cached promise is cleared so the next call starts a fresh attempt instead of failing forever
+   * with the same error. This is useful for initializing access to a resource that may not be
+   * available yet, like a network object owned by a process that is still starting up.
+   *
+   * Note that the call that started a failed attempt still rejects with the initializer's error; only
+   * later calls retry. The initializer must therefore be safe to run again after a failure, e.g. it
+   * should not leave partial registrations behind.
+   *
+   * @param initializer Asynchronous function that performs the initialization
+   * @returns Function that returns the cached initialization promise, starting a new initialization
+   *   attempt if there is no cached promise
+   */
+  export function createCachedInitializer<T = void>(
+    initializer: () => Promise<T>,
+  ): () => Promise<T>;
+}
 declare module 'shared/services/network-object-status.service' {
   import { NetworkObjectStatusServiceType } from 'shared/models/network-object-status.service-model';
   /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -3586,9 +3586,9 @@ declare module 'shared/utils/cached-initializer' {
    * with the same error. This is useful for initializing access to a resource that may not be
    * available yet, like a network object owned by a process that is still starting up.
    *
-   * Note that the call that started a failed attempt still rejects with the initializer's error; only
-   * later calls retry. The initializer must therefore be safe to run again after a failure, e.g. it
-   * should not leave partial registrations behind.
+   * Note that calls that awaited the failed attempt all reject with its error; only calls arriving
+   * after the rejection settles retry. The initializer must therefore be safe to run again after a
+   * failure, e.g. it should not leave partial registrations behind.
    *
    * @param initializer Asynchronous function that performs the initialization
    * @returns Function that returns the cached initialization promise, starting a new initialization

--- a/src/shared/services/app.service.ts
+++ b/src/shared/services/app.service.ts
@@ -1,30 +1,15 @@
 import { appServiceNetworkObjectName, IAppService } from '@shared/services/app.service-model';
 import { networkObjectService } from '@shared/services/network-object.service';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import { createSyncProxyForAsyncObject } from 'platform-bible-utils';
 
 let networkObject: IAppService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const localAppService = await networkObjectService.get<IAppService>(
-            appServiceNetworkObjectName,
-          );
-          if (!localAppService)
-            throw new Error(`${appServiceNetworkObjectName} is not available as a network object`);
-          networkObject = localAppService;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const localAppService = await networkObjectService.get<IAppService>(appServiceNetworkObjectName);
+  if (!localAppService)
+    throw new Error(`${appServiceNetworkObjectName} is not available as a network object`);
+  networkObject = localAppService;
+});
 
 /**
  * JSDOC SOURCE appService

--- a/src/shared/services/data-protection.service.ts
+++ b/src/shared/services/data-protection.service.ts
@@ -3,33 +3,20 @@ import {
   IDataProtectionService,
 } from '@shared/models/data-protection.service-model';
 import { networkObjectService } from '@shared/services/network-object.service';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import { createSyncProxyForAsyncObject } from 'platform-bible-utils';
 
 let networkObject: IDataProtectionService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const localDataProtectionService = await networkObjectService.get<IDataProtectionService>(
-            dataProtectionServiceNetworkObjectName,
-          );
-          if (!localDataProtectionService)
-            throw new Error(
-              `${dataProtectionServiceNetworkObjectName} is not available as a network object`,
-            );
-          networkObject = localDataProtectionService;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const localDataProtectionService = await networkObjectService.get<IDataProtectionService>(
+    dataProtectionServiceNetworkObjectName,
+  );
+  if (!localDataProtectionService)
+    throw new Error(
+      `${dataProtectionServiceNetworkObjectName} is not available as a network object`,
+    );
+  networkObject = localDataProtectionService;
+});
 
 /**
  * JSDOC SOURCE dataProtectionService

--- a/src/shared/services/database.service.ts
+++ b/src/shared/services/database.service.ts
@@ -5,32 +5,17 @@ import {
   databaseServiceObjectToProxy,
   databaseServiceNetworkObjectName,
 } from '@shared/services/database.service-model';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 
 let networkObject: IDatabaseService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const localDatabaseService = await networkObjectService.get<IDatabaseService>(
-            databaseServiceNetworkObjectName,
-          );
-          if (!localDatabaseService)
-            throw new Error(
-              `${databaseServiceNetworkObjectName} is not available as a network object`,
-            );
-          networkObject = localDatabaseService;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const localDatabaseService = await networkObjectService.get<IDatabaseService>(
+    databaseServiceNetworkObjectName,
+  );
+  if (!localDatabaseService)
+    throw new Error(`${databaseServiceNetworkObjectName} is not available as a network object`);
+  networkObject = localDatabaseService;
+});
 
 export const databaseService = createSyncProxyForAsyncObject<IDatabaseService>(async () => {
   await initialize();

--- a/src/shared/services/dialog.service.ts
+++ b/src/shared/services/dialog.service.ts
@@ -1,17 +1,12 @@
 import * as networkService from '@shared/services/network.service';
 import { CATEGORY_DIALOG, DialogService } from '@shared/services/dialog.service-model';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import { serializeRequestType } from '@shared/utils/util';
 import { DialogTabTypes, DialogTypes } from '@renderer/components/dialogs/dialog-definition.model';
 
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = (async () => {
-      await networkService.initialize();
-    })();
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  await networkService.initialize();
+});
 
 export const dialogService: DialogService = {
   showDialog: async <DialogTabType extends DialogTabTypes>(

--- a/src/shared/services/dialog.service.ts
+++ b/src/shared/services/dialog.service.ts
@@ -4,6 +4,9 @@ import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import { serializeRequestType } from '@shared/utils/util';
 import { DialogTabTypes, DialogTypes } from '@renderer/components/dialogs/dialog-definition.model';
 
+// networkService.initialize() is already idempotent and retry-safe on its own, so this wrapper adds
+// no retry behavior; it exists only to keep this service structurally uniform with the other shared
+// services that use createCachedInitializer.
 const initialize = createCachedInitializer(async () => {
   await networkService.initialize();
 });

--- a/src/shared/services/localization.service.ts
+++ b/src/shared/services/localization.service.ts
@@ -5,27 +5,14 @@ import {
   localizationServiceProviderName,
   localizationServiceObjectToProxy,
 } from '@shared/services/localization.service-model';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 
 let dataProvider: ILocalizationService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const provider = await dataProviderService.get(localizationServiceProviderName);
-          if (!provider) throw new Error('Localization service undefined');
-          dataProvider = provider;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const provider = await dataProviderService.get(localizationServiceProviderName);
+  if (!provider) throw new Error('Localization service undefined');
+  dataProvider = provider;
+});
 
 export const localizationService = createSyncProxyForAsyncObject<ILocalizationService>(
   async () => {

--- a/src/shared/services/menu-data.service.ts
+++ b/src/shared/services/menu-data.service.ts
@@ -1,4 +1,5 @@
 import { dataProviderService } from '@shared/services/data-provider.service';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import { createSyncProxyForAsyncObject } from 'platform-bible-utils';
 import {
   IMenuDataService,
@@ -7,25 +8,11 @@ import {
 } from '@shared/services/menu-data.service-model';
 
 let dataProvider: IMenuDataService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const provider = await dataProviderService.get(menuDataServiceProviderName);
-          if (!provider) throw new Error('Menu data service undefined');
-          dataProvider = provider;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const provider = await dataProviderService.get(menuDataServiceProviderName);
+  if (!provider) throw new Error('Menu data service undefined');
+  dataProvider = provider;
+});
 
 export const menuDataService = createSyncProxyForAsyncObject<IMenuDataService>(async () => {
   await initialize();

--- a/src/shared/services/network-object-status.service.test.ts
+++ b/src/shared/services/network-object-status.service.test.ts
@@ -1,12 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NetworkObjectDetails } from '@shared/models/network-object.model';
 
-// network-object-status.service caches its initialization via createCachedInitializer and holds the
-// resolved status network object at module scope, so each test re-imports a fresh copy via
-// vi.resetModules() (see loadService). The real AsyncVariable and isSubset (platform-bible-utils)
-// are exercised; only network-object.service is mocked so a test can drive both the snapshot
-// (getAllNetworkObjectDetails) and the onDidCreateNetworkObject event stream that
-// waitForNetworkObject races against.
+// Each test re-imports the service (vi.resetModules, see loadService) because it caches init and
+// holds the resolved network object at module scope. Only network-object.service is mocked, so a
+// test can drive the snapshot (getAllNetworkObjectDetails) and the onDidCreateNetworkObject event
+// stream, while the real AsyncVariable and isSubset run.
 
 const { mockGet, mockUnsub, event } = vi.hoisted(() => {
   // Holds the latest waitForNetworkObject subscriber so a test can emit "object created" events

--- a/src/shared/services/network-object-status.service.test.ts
+++ b/src/shared/services/network-object-status.service.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NetworkObjectDetails } from '@shared/models/network-object.model';
+
+// network-object-status.service caches its initialization via createCachedInitializer and holds the
+// resolved status network object at module scope, so each test re-imports a fresh copy via
+// vi.resetModules() (see loadService). The real AsyncVariable and isSubset (platform-bible-utils)
+// are exercised; only network-object.service is mocked so a test can drive both the snapshot
+// (getAllNetworkObjectDetails) and the onDidCreateNetworkObject event stream that
+// waitForNetworkObject races against.
+
+const { mockGet, mockUnsub, event } = vi.hoisted(() => {
+  // Holds the latest waitForNetworkObject subscriber so a test can emit "object created" events
+  const noopEmit: (details: NetworkObjectDetails) => void = () => {};
+  return {
+    event: { emit: noopEmit },
+    mockGet: vi.fn(),
+    mockUnsub: vi.fn(),
+  };
+});
+
+vi.mock('@shared/services/network-object.service', () => ({
+  __esModule: true,
+  networkObjectService: { get: mockGet },
+  onDidCreateNetworkObject: (callback: (details: NetworkObjectDetails) => void) => {
+    event.emit = callback;
+    return mockUnsub;
+  },
+}));
+
+/** Re-imports the service fresh (resetting its cached initialization) and returns it. */
+async function loadService() {
+  vi.resetModules();
+  const { networkObjectStatusService } = await import(
+    '@shared/services/network-object-status.service'
+  );
+  return networkObjectStatusService;
+}
+
+/** Builds minimal NetworkObjectDetails; only the fields isSubset matches on are needed. */
+function makeDetails(id: string, extra: Partial<NetworkObjectDetails> = {}): NetworkObjectDetails {
+  return { functionNames: [], id, objectType: 'object', ...extra };
+}
+
+/** Makes networkObjectService.get resolve to a status object returning the given snapshot. */
+function mockSnapshot(snapshot: Record<string, NetworkObjectDetails>) {
+  mockGet.mockResolvedValue({ getAllNetworkObjectDetails: vi.fn(async () => snapshot) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  event.emit = () => {};
+});
+
+describe('waitForNetworkObject', () => {
+  it('resolves from the snapshot when a matching object already exists', async () => {
+    const service = await loadService();
+    const details = makeDetails('ScrollGroupService');
+    mockSnapshot({ ScrollGroupService: details, Other: makeDetails('Other') });
+
+    await expect(service.waitForNetworkObject({ id: 'ScrollGroupService' })).resolves.toEqual(
+      details,
+    );
+  });
+
+  it('resolves from a creation event when the snapshot has no match', async () => {
+    const service = await loadService();
+    const created = makeDetails('WebViewService');
+    // The object's creation event fires while the (empty) snapshot is being fetched; the stream we
+    // subscribed to before fetching must still deliver it. Driving the emit from inside the fetch
+    // keeps the ordering deterministic without waiting on the event loop.
+    mockGet.mockResolvedValue({
+      getAllNetworkObjectDetails: vi.fn(async () => {
+        event.emit(created);
+        return {};
+      }),
+    });
+
+    await expect(service.waitForNetworkObject({ id: 'WebViewService' })).resolves.toEqual(created);
+    expect(mockUnsub).toHaveBeenCalled();
+  });
+
+  it('does not let the snapshot override an event that arrived first', async () => {
+    const service = await loadService();
+    const fromSnapshot = makeDetails('WebViewService', { functionNames: ['fromSnapshot'] });
+    mockSnapshot({ WebViewService: fromSnapshot });
+
+    const waiting = service.waitForNetworkObject({ id: 'WebViewService' });
+    // Emit synchronously, before the async snapshot fetch can resolve, so the event settles first
+    const fromEvent = makeDetails('WebViewService', { functionNames: ['fromEvent'] });
+    event.emit(fromEvent);
+
+    await expect(waiting).resolves.toBe(fromEvent);
+  });
+
+  it('times out and rejects when no matching object ever appears', async () => {
+    const service = await loadService();
+    mockSnapshot({ Other: makeDetails('Other') });
+
+    await expect(service.waitForNetworkObject({ id: 'Missing' }, 30)).rejects.toThrow(
+      /Timeout reached/,
+    );
+  });
+
+  it('ignores non-matching snapshot entries and non-matching events', async () => {
+    const service = await loadService();
+    mockSnapshot({ Other: makeDetails('Other') });
+
+    const waiting = service.waitForNetworkObject({ id: 'Wanted' }, 30);
+    event.emit(makeDetails('StillNotIt'));
+
+    await expect(waiting).rejects.toThrow(/Timeout reached/);
+  });
+
+  it('propagates a failure from getAllNetworkObjectDetails', async () => {
+    const service = await loadService();
+    mockGet.mockRejectedValue(new Error('network object service unavailable'));
+
+    // waitForNetworkObject rejects its internal AsyncVariable and then re-throws; that
+    // AsyncVariable's promise is never returned, so its rejection surfaces (a tick later) as an
+    // unhandled rejection. Capture it so it can't fail the run, and assert it carries the reason.
+    const floating: unknown[] = [];
+    const onUnhandled = (reason: unknown) => floating.push(reason);
+    process.on('unhandledRejection', onUnhandled);
+    try {
+      await expect(service.waitForNetworkObject({ id: 'Anything' })).rejects.toThrow(
+        'network object service unavailable',
+      );
+      await vi.waitFor(() => expect(floating).toHaveLength(1));
+      expect(floating[0]).toMatch(/network object service unavailable/);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+    }
+  });
+});

--- a/src/shared/services/network-object-status.service.test.ts
+++ b/src/shared/services/network-object-status.service.test.ts
@@ -113,20 +113,8 @@ describe('waitForNetworkObject', () => {
     const service = await loadService();
     mockGet.mockRejectedValue(new Error('network object service unavailable'));
 
-    // waitForNetworkObject rejects its internal AsyncVariable and then re-throws; that
-    // AsyncVariable's promise is never returned, so its rejection surfaces (a tick later) as an
-    // unhandled rejection. Capture it so it can't fail the run, and assert it carries the reason.
-    const floating: unknown[] = [];
-    const onUnhandled = (reason: unknown) => floating.push(reason);
-    process.on('unhandledRejection', onUnhandled);
-    try {
-      await expect(service.waitForNetworkObject({ id: 'Anything' })).rejects.toThrow(
-        'network object service unavailable',
-      );
-      await vi.waitFor(() => expect(floating).toHaveLength(1));
-      expect(floating[0]).toMatch(/network object service unavailable/);
-    } finally {
-      process.off('unhandledRejection', onUnhandled);
-    }
+    await expect(service.waitForNetworkObject({ id: 'Anything' })).rejects.toThrow(
+      'network object service unavailable',
+    );
   });
 });

--- a/src/shared/services/network-object-status.service.ts
+++ b/src/shared/services/network-object-status.service.ts
@@ -48,30 +48,26 @@ async function waitForNetworkObject(
     `wait-for-net-obj with details ${JSON.stringify(objectDetailsToMatch)}`,
     timeoutInMS ?? -1,
   );
-  try {
-    // Watch the stream of incoming network objects before getting a snapshot to avoid race conditions
-    const unsub = onDidCreateNetworkObject((networkObjectDetails) => {
-      if (!asyncVar.hasSettled && isSubset(networkObjectDetails, objectDetailsToMatch)) {
-        asyncVar.resolveToValue(networkObjectDetails, false);
-      }
-      if (asyncVar.hasSettled) {
-        unsub();
-      }
-    });
-    // Now check if the needed network object has already been created
-    const existingNetworkObjectDetails = await getAllNetworkObjectDetails();
-    if (!asyncVar.hasSettled) {
-      const match = Object.values(existingNetworkObjectDetails).find((networkObjectDetails) =>
-        isSubset(networkObjectDetails, objectDetailsToMatch),
-      );
-      if (match) {
-        asyncVar.resolveToValue(match, false);
-      }
+  // Watch the stream of incoming network objects before getting a snapshot to avoid race conditions
+  const unsub = onDidCreateNetworkObject((networkObjectDetails) => {
+    if (!asyncVar.hasSettled && isSubset(networkObjectDetails, objectDetailsToMatch)) {
+      asyncVar.resolveToValue(networkObjectDetails, false);
     }
-  } catch (e) {
-    const message = `waitForNetworkObject failed for details ${JSON.stringify(objectDetailsToMatch)}! ${e}`;
-    asyncVar.rejectWithReason(message, true);
-    throw e;
+    if (asyncVar.hasSettled) {
+      unsub();
+    }
+  });
+  // Now check if the needed network object has already been created. If this throws, the rejection
+  // propagates straight to the caller; we deliberately don't reject asyncVar.promise on that path
+  // since it is never returned, and rejecting it would strand an unhandled rejection.
+  const existingNetworkObjectDetails = await getAllNetworkObjectDetails();
+  if (!asyncVar.hasSettled) {
+    const match = Object.values(existingNetworkObjectDetails).find((networkObjectDetails) =>
+      isSubset(networkObjectDetails, objectDetailsToMatch),
+    );
+    if (match) {
+      asyncVar.resolveToValue(match, false);
+    }
   }
   return asyncVar.promise;
 }

--- a/src/shared/services/network-object-status.service.ts
+++ b/src/shared/services/network-object-status.service.ts
@@ -8,34 +8,21 @@ import {
   networkObjectService,
   onDidCreateNetworkObject,
 } from '@shared/services/network-object.service';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import { AsyncVariable, isSubset } from 'platform-bible-utils';
 
 let networkObject: NetworkObjectStatusRemoteServiceType;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const localNetworkObjectStatusService =
-            await networkObjectService.get<NetworkObjectStatusServiceType>(
-              networkObjectStatusServiceNetworkObjectName,
-            );
-          if (!localNetworkObjectStatusService)
-            throw new Error(
-              `${networkObjectStatusServiceNetworkObjectName} is not available as a network object`,
-            );
-          networkObject = localNetworkObjectStatusService;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const localNetworkObjectStatusService =
+    await networkObjectService.get<NetworkObjectStatusServiceType>(
+      networkObjectStatusServiceNetworkObjectName,
+    );
+  if (!localNetworkObjectStatusService)
+    throw new Error(
+      `${networkObjectStatusServiceNetworkObjectName} is not available as a network object`,
+    );
+  networkObject = localNetworkObjectStatusService;
+});
 
 // If we ever want to be more clever, we could just keep a local (to this process) cache of the
 // active network objects. If we do that, we'll have to deal with initial race conditions around

--- a/src/shared/services/notification.service.ts
+++ b/src/shared/services/notification.service.ts
@@ -3,33 +3,18 @@ import {
   type INotificationService,
 } from '@shared/models/notification.service-model';
 import { networkObjectService } from '@shared/services/network-object.service';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import { createSyncProxyForAsyncObject } from 'platform-bible-utils';
 
 let networkObject: INotificationService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const localNotificationService = await networkObjectService.get<INotificationService>(
-            NotificationServiceNetworkObjectName,
-          );
-          if (!localNotificationService)
-            throw new Error(
-              `${NotificationServiceNetworkObjectName} is not available as a network object`,
-            );
-          networkObject = localNotificationService;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const localNotificationService = await networkObjectService.get<INotificationService>(
+    NotificationServiceNetworkObjectName,
+  );
+  if (!localNotificationService)
+    throw new Error(`${NotificationServiceNetworkObjectName} is not available as a network object`);
+  networkObject = localNotificationService;
+});
 
 /**
  * JSDOC SOURCE notificationService

--- a/src/shared/services/project-settings.service.ts
+++ b/src/shared/services/project-settings.service.ts
@@ -10,6 +10,7 @@ import {
   ReferencedItem,
   transformAndEnsureRegExpRegExpArray,
 } from 'platform-bible-utils';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import { ProjectSettingsContributionInfo } from '@shared/utils/project-settings-document-combiner';
 import { ProjectDataProviderInterfaces } from 'papi-shared-types';
 import { areProjectInterfacesIncluded } from '@shared/models/project-lookup.service-model';
@@ -80,31 +81,16 @@ export function filterProjectSettingsContributionsByProjectInterfaces(
 }
 
 let networkObject: IProjectSettingsService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const localProjectSettingsService =
-            await networkObjectService.get<IProjectSettingsService>(
-              projectSettingsServiceNetworkObjectName,
-            );
-          if (!localProjectSettingsService)
-            throw new Error(
-              `${projectSettingsServiceNetworkObjectName} is not available as a network object`,
-            );
-          networkObject = localProjectSettingsService;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const localProjectSettingsService = await networkObjectService.get<IProjectSettingsService>(
+    projectSettingsServiceNetworkObjectName,
+  );
+  if (!localProjectSettingsService)
+    throw new Error(
+      `${projectSettingsServiceNetworkObjectName} is not available as a network object`,
+    );
+  networkObject = localProjectSettingsService;
+});
 
 export const projectSettingsService = createSyncProxyForAsyncObject<IProjectSettingsService>(
   async () => {

--- a/src/shared/services/scroll-group.service.ts
+++ b/src/shared/services/scroll-group.service.ts
@@ -4,6 +4,7 @@ import {
   NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE,
   IScrollGroupService,
 } from '@shared/services/scroll-group.service-model';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import { createSyncProxyForAsyncObject } from 'platform-bible-utils';
 import { networkObjectStatusService } from '@shared/services/network-object-status.service';
 import { networkObjectService } from '@shared/services/network-object.service';
@@ -11,36 +12,22 @@ import { networkObjectService } from '@shared/services/network-object.service';
 const onDidUpdateScrRef = getNetworkEvent(EVENT_NAME_ON_DID_UPDATE_SCR_REF);
 
 let networkObject: IScrollGroupService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          await networkObjectStatusService.waitForNetworkObject(
-            { id: NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE },
-            // Wait 30 seconds for the scroll group service to appear
-            30000,
-          );
+const initialize = createCachedInitializer(async () => {
+  await networkObjectStatusService.waitForNetworkObject(
+    { id: NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE },
+    // Wait 30 seconds for the scroll group service to appear
+    30000,
+  );
 
-          const localWebViewService = await networkObjectService.get<IScrollGroupService>(
-            NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE,
-          );
-          if (!localWebViewService)
-            throw new Error(
-              `${NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE} is not available as a network object`,
-            );
-          networkObject = localWebViewService;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+  const localWebViewService = await networkObjectService.get<IScrollGroupService>(
+    NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE,
+  );
+  if (!localWebViewService)
+    throw new Error(
+      `${NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE} is not available as a network object`,
+    );
+  networkObject = localWebViewService;
+});
 
 /**
  * JSDOC SOURCE scrollGroupService

--- a/src/shared/services/settings.service.ts
+++ b/src/shared/services/settings.service.ts
@@ -21,7 +21,8 @@ const initialize = createCachedInitializer(async () => {
   // Inject the network timeout into every JS process once the settings service is available.
   // We can't pull from within the network service as it would create a dependency loop.
   // Fire-and-forget: subscribing is a side effect, not part of providing the service, so a failure
-  // here is logged rather than failing (and retrying) the whole settings-service initialization.
+  // here is logged rather than rejecting the whole settings-service initialization (which
+  // createCachedInitializer would then retry).
   dataProvider
     .subscribe('platform.requestTimeout', (newTimeout: number | PlatformError) => {
       if (isPlatformError(newTimeout)) {

--- a/src/shared/services/settings.service.ts
+++ b/src/shared/services/settings.service.ts
@@ -11,48 +11,34 @@ import {
   settingsServiceDataProviderName,
   settingsServiceObjectToProxy,
 } from '@shared/services/settings.service-model';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 
 let dataProvider: ISettingsService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const provider = await dataProviderService.get(settingsServiceDataProviderName);
-          if (!provider) throw new Error('Settings service undefined');
-          dataProvider = provider;
-          // Inject the network timeout into every JS process once the settings service is available
-          // We can't pull from within the network service as it would create a dependency loop
-          dataProvider.subscribe(
-            'platform.requestTimeout',
-            (newTimeout: number | PlatformError) => {
-              if (isPlatformError(newTimeout)) {
-                logger.warn(
-                  `Settings service error while retrieving value for setting platform.requestTimeout: ${newTimeout}`,
-                );
-                return;
-              }
-              // The request timeout is in seconds. Keep it between 0 (disabled) and 1 day
-              if (typeof newTimeout !== 'number' || newTimeout < 0 || newTimeout > 60 * 60 * 24) {
-                logger.warn(
-                  `Attempt to set an invalid value for platform.requestTimeout: ${newTimeout}.`,
-                );
-                return;
-              }
-              networkService.setRequestTimeout(newTimeout);
-            },
-          );
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const provider = await dataProviderService.get(settingsServiceDataProviderName);
+  if (!provider) throw new Error('Settings service undefined');
+  dataProvider = provider;
+  // Inject the network timeout into every JS process once the settings service is available.
+  // We can't pull from within the network service as it would create a dependency loop.
+  // Fire-and-forget: subscribing is a side effect, not part of providing the service, so a failure
+  // here is logged rather than failing (and retrying) the whole settings-service initialization.
+  dataProvider
+    .subscribe('platform.requestTimeout', (newTimeout: number | PlatformError) => {
+      if (isPlatformError(newTimeout)) {
+        logger.warn(
+          `Settings service error while retrieving value for setting platform.requestTimeout: ${newTimeout}`,
+        );
+        return;
+      }
+      // The request timeout is in seconds. Keep it between 0 (disabled) and 1 day
+      if (typeof newTimeout !== 'number' || newTimeout < 0 || newTimeout > 60 * 60 * 24) {
+        logger.warn(`Attempt to set an invalid value for platform.requestTimeout: ${newTimeout}.`);
+        return;
+      }
+      networkService.setRequestTimeout(newTimeout);
+    })
+    .catch((error) => logger.warn(`Failed to subscribe to platform.requestTimeout: ${error}`));
+});
 
 export const settingsService = createSyncProxyForAsyncObject<ISettingsService>(async () => {
   await initialize();

--- a/src/shared/services/theme-data.service.ts
+++ b/src/shared/services/theme-data.service.ts
@@ -5,27 +5,14 @@ import {
   themeDataServiceObjectToProxy,
   themeDataServiceProviderName,
 } from '@shared/services/theme-data.service-model';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 
 let dataProvider: IThemeDataService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const provider = await dataProviderService.get(themeDataServiceProviderName);
-          if (!provider) throw new Error('Theme data service undefined');
-          dataProvider = provider;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const provider = await dataProviderService.get(themeDataServiceProviderName);
+  if (!provider) throw new Error('Theme data service undefined');
+  dataProvider = provider;
+});
 
 export const themeDataService = createSyncProxyForAsyncObject<IThemeDataService>(async () => {
   await initialize();

--- a/src/shared/services/theme.service.ts
+++ b/src/shared/services/theme.service.ts
@@ -5,27 +5,14 @@ import {
   themeServiceDataProviderName,
   themeServiceObjectToProxy,
 } from '@shared/services/theme.service-model';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 
 let dataProvider: IThemeService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const provider = await dataProviderService.get(themeServiceDataProviderName);
-          if (!provider) throw new Error('Theme service undefined');
-          dataProvider = provider;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const provider = await dataProviderService.get(themeServiceDataProviderName);
+  if (!provider) throw new Error('Theme service undefined');
+  dataProvider = provider;
+});
 
 export const themeService = createSyncProxyForAsyncObject<IThemeService>(async () => {
   await initialize();

--- a/src/shared/services/web-view.service.test.ts
+++ b/src/shared/services/web-view.service.test.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { NetworkObject, NetworkObjectDetails } from '@shared/models/network-object.model';
+import { NetworkObject } from '@shared/models/network-object.model';
 import { networkObjectService } from '@shared/services/network-object.service';
 import { networkObjectStatusService } from '@shared/services/network-object-status.service';
 import { WebViewServiceType } from '@shared/services/web-view.service-model';
@@ -32,18 +32,17 @@ describe('webViewService initialization', () => {
     await expect(webViewService.openWebView('test.webView')).rejects.toThrow('Timeout reached');
 
     // Simulate the renderer having registered WebViewService by now
-    // Cast partial mock network objects for conciseness
-    /* eslint-disable no-type-assertion/no-type-assertion */
     vi.mocked(networkObjectStatusService.waitForNetworkObject).mockResolvedValue({
       functionNames: ['openWebView'],
       id: 'WebViewService',
       objectType: 'object',
-    } as NetworkObjectDetails);
+    });
     const openWebView = vi.fn(async () => 'web-view-id');
+    // The get() mock only implements the openWebView method this test calls, not all of NetworkObject
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
     vi.mocked(networkObjectService.get).mockResolvedValue({
       openWebView,
     } as unknown as NetworkObject<WebViewServiceType>);
-    /* eslint-enable no-type-assertion/no-type-assertion */
 
     // Without retrying initialization, this would reject with the cached timeout error
     await expect(webViewService.openWebView('test.webView')).resolves.toBe('web-view-id');

--- a/src/shared/services/web-view.service.test.ts
+++ b/src/shared/services/web-view.service.test.ts
@@ -1,0 +1,52 @@
+import { vi } from 'vitest';
+import { NetworkObject, NetworkObjectDetails } from '@shared/models/network-object.model';
+import { networkObjectService } from '@shared/services/network-object.service';
+import { networkObjectStatusService } from '@shared/services/network-object-status.service';
+import { WebViewServiceType } from '@shared/services/web-view.service-model';
+import { webViewService } from './web-view.service';
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@shared/services/network-object.service', () => ({
+  networkObjectService: { get: vi.fn() },
+}));
+
+vi.mock('@shared/services/network-object-status.service', () => ({
+  networkObjectStatusService: { waitForNetworkObject: vi.fn() },
+}));
+
+vi.mock('@shared/services/network.service', () => ({
+  getNetworkEvent: vi.fn(() => vi.fn()),
+}));
+
+describe('webViewService initialization', () => {
+  it('retries initialization after waiting for the WebViewService network object fails', async () => {
+    // Simulate the renderer not registering WebViewService within the timeout (e.g. a slow
+    // renderer startup in development)
+    vi.mocked(networkObjectStatusService.waitForNetworkObject).mockRejectedValueOnce(
+      new Error('Timeout reached waiting for wait-for-net-obj to settle'),
+    );
+
+    await expect(webViewService.openWebView('test.webView')).rejects.toThrow('Timeout reached');
+
+    // Simulate the renderer having registered WebViewService by now
+    // Cast partial mock network objects for conciseness
+    /* eslint-disable no-type-assertion/no-type-assertion */
+    vi.mocked(networkObjectStatusService.waitForNetworkObject).mockResolvedValue({
+      functionNames: ['openWebView'],
+      id: 'WebViewService',
+      objectType: 'object',
+    } as NetworkObjectDetails);
+    const openWebView = vi.fn(async () => 'web-view-id');
+    vi.mocked(networkObjectService.get).mockResolvedValue({
+      openWebView,
+    } as unknown as NetworkObject<WebViewServiceType>);
+    /* eslint-enable no-type-assertion/no-type-assertion */
+
+    // Without retrying initialization, this would reject with the cached timeout error
+    await expect(webViewService.openWebView('test.webView')).resolves.toBe('web-view-id');
+    expect(openWebView).toHaveBeenCalledWith('test.webView');
+  });
+});

--- a/src/shared/services/web-view.service.ts
+++ b/src/shared/services/web-view.service.ts
@@ -9,7 +9,8 @@ import {
   getWebViewController,
 } from '@shared/services/web-view.service-model';
 import { networkObjectService } from '@shared/services/network-object.service';
-import { networkObjectStatusService } from './network-object-status.service';
+import { networkObjectStatusService } from '@shared/services/network-object-status.service';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 
 const onDidOpenWebView = getNetworkEvent(EVENT_NAME_ON_DID_OPEN_WEB_VIEW);
 
@@ -18,36 +19,20 @@ const onDidUpdateWebView = getNetworkEvent(EVENT_NAME_ON_DID_UPDATE_WEB_VIEW);
 const onDidCloseWebView = getNetworkEvent(EVENT_NAME_ON_DID_CLOSE_WEB_VIEW);
 
 let networkObject: WebViewServiceType;
-let initializationPromise: Promise<void> | undefined;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          await networkObjectStatusService.waitForNetworkObject(
-            { id: NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE },
-            // Wait 30 seconds for the web view service to appear
-            30000,
-          );
+const initialize = createCachedInitializer(async () => {
+  await networkObjectStatusService.waitForNetworkObject(
+    { id: NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE },
+    // Wait 30 seconds for the web view service to appear
+    30000,
+  );
 
-          const localWebViewService = await networkObjectService.get<WebViewServiceType>(
-            NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
-          );
-          if (!localWebViewService)
-            throw new Error(
-              `${NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE} is not available as a network object`,
-            );
-          networkObject = localWebViewService;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+  const localWebViewService = await networkObjectService.get<WebViewServiceType>(
+    NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE,
+  );
+  if (!localWebViewService)
+    throw new Error(`${NETWORK_OBJECT_NAME_WEB_VIEW_SERVICE} is not available as a network object`);
+  networkObject = localWebViewService;
+});
 
 export const webViewService = createSyncProxyForAsyncObject<WebViewServiceType>(
   async () => {

--- a/src/shared/services/window.service.ts
+++ b/src/shared/services/window.service.ts
@@ -5,27 +5,14 @@ import {
   windowServiceObjectToProxy,
   windowServiceProviderName,
 } from '@shared/services/window.service-model';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 
 let dataProvider: IWindowService;
-let initializationPromise: Promise<void>;
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const provider = await dataProviderService.get(windowServiceProviderName);
-          if (!provider) throw new Error('Window service undefined');
-          dataProvider = provider;
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  const provider = await dataProviderService.get(windowServiceProviderName);
+  if (!provider) throw new Error('Window service undefined');
+  dataProvider = provider;
+});
 
 export const windowService = createSyncProxyForAsyncObject<IWindowService>(async () => {
   await initialize();

--- a/src/shared/utils/cached-initializer.test.ts
+++ b/src/shared/utils/cached-initializer.test.ts
@@ -1,0 +1,62 @@
+import { vi } from 'vitest';
+import { createCachedInitializer } from './cached-initializer';
+
+describe('createCachedInitializer', () => {
+  it('should run the initializer only once across sequential calls', async () => {
+    const initializer = vi.fn(async () => 'initialized');
+    const initialize = createCachedInitializer(initializer);
+
+    await expect(initialize()).resolves.toBe('initialized');
+    await expect(initialize()).resolves.toBe('initialized');
+    expect(initializer).toHaveBeenCalledTimes(1);
+  });
+
+  it('should share one in-flight attempt across concurrent calls', async () => {
+    let resolveInitializer = () => {};
+    const initializer = vi.fn(
+      async () =>
+        new Promise<void>((resolve) => {
+          resolveInitializer = resolve;
+        }),
+    );
+    const initialize = createCachedInitializer(initializer);
+
+    const firstCall = initialize();
+    const secondCall = initialize();
+    resolveInitializer();
+    await Promise.all([firstCall, secondCall]);
+    expect(initializer).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reject the failing call with the initializer error and retry on the next call', async () => {
+    const initializer = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(new Error('transient failure'))
+      .mockResolvedValue('initialized');
+    const initialize = createCachedInitializer(initializer);
+
+    await expect(initialize()).rejects.toThrow('transient failure');
+    await expect(initialize()).resolves.toBe('initialized');
+    expect(initializer).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reject instead of throwing when the initializer throws synchronously', async () => {
+    const initialize = createCachedInitializer(() => {
+      throw new Error('synchronous failure');
+    });
+
+    await expect(initialize()).rejects.toThrow('synchronous failure');
+  });
+
+  it('should not retry after a successful initialization', async () => {
+    const initializer = vi
+      .fn<() => Promise<string>>()
+      .mockResolvedValueOnce('first')
+      .mockResolvedValue('second');
+    const initialize = createCachedInitializer(initializer);
+
+    await expect(initialize()).resolves.toBe('first');
+    await expect(initialize()).resolves.toBe('first');
+    expect(initializer).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/shared/utils/cached-initializer.ts
+++ b/src/shared/utils/cached-initializer.ts
@@ -1,0 +1,26 @@
+/**
+ * Creates a function that runs an asynchronous initializer at most once, caching the promise so
+ * concurrent and subsequent calls share the same initialization attempt. If the initializer fails,
+ * the cached promise is cleared so the next call starts a fresh attempt instead of failing forever
+ * with the same error. This is useful for initializing access to a resource that may not be
+ * available yet, like a network object owned by a process that is still starting up.
+ *
+ * Note that the call that started a failed attempt still rejects with the initializer's error; only
+ * later calls retry. The initializer must therefore be safe to run again after a failure, e.g. it
+ * should not leave partial registrations behind.
+ *
+ * @param initializer Asynchronous function that performs the initialization
+ * @returns Function that returns the cached initialization promise, starting a new initialization
+ *   attempt if there is no cached promise
+ */
+export function createCachedInitializer<T = void>(initializer: () => Promise<T>): () => Promise<T> {
+  let cachedPromise: Promise<T> | undefined;
+  return () => {
+    // Wrap in an async IIFE so an initializer that throws synchronously rejects instead of throwing
+    cachedPromise ??= (async () => initializer())().catch((error) => {
+      cachedPromise = undefined;
+      throw error;
+    });
+    return cachedPromise;
+  };
+}

--- a/src/shared/utils/cached-initializer.ts
+++ b/src/shared/utils/cached-initializer.ts
@@ -16,7 +16,8 @@
 export function createCachedInitializer<T = void>(initializer: () => Promise<T>): () => Promise<T> {
   let cachedPromise: Promise<T> | undefined;
   return () => {
-    // Wrap in an async IIFE so an initializer that throws synchronously rejects instead of throwing
+    // Wrap in an async IIFE so this always returns a promise: a synchronous throw from the
+    // initializer becomes a rejected promise instead of throwing at the call site.
     cachedPromise ??= (async () => initializer())().catch((error) => {
       cachedPromise = undefined;
       throw error;

--- a/src/shared/utils/cached-initializer.ts
+++ b/src/shared/utils/cached-initializer.ts
@@ -5,9 +5,9 @@
  * with the same error. This is useful for initializing access to a resource that may not be
  * available yet, like a network object owned by a process that is still starting up.
  *
- * Note that the call that started a failed attempt still rejects with the initializer's error; only
- * later calls retry. The initializer must therefore be safe to run again after a failure, e.g. it
- * should not leave partial registrations behind.
+ * Note that calls that awaited the failed attempt all reject with its error; only calls arriving
+ * after the rejection settles retry. The initializer must therefore be safe to run again after a
+ * failure, e.g. it should not leave partial registrations behind.
  *
  * @param initializer Asynchronous function that performs the initialization
  * @returns Function that returns the cached initialization promise, starting a new initialization


### PR DESCRIPTION
## Motivating issue

If the renderer did not register `WebViewService` or `ScrollGroupService` within the 30s wait (e.g. a slow renderer startup in development), the **rejected** initialization promise was cached forever. Every later `papi.webViews` call in the extension host then failed instantly with the stale error, and the app appeared permanently locked up.

The fix is to clear the cached promise on failure so the next call starts a fresh attempt.

## Scope (narrowed from #2389)

[#2389](https://github.com/paranext/paranext-core/pull/2389) abstracts the fix into a `createCachedInitializer` helper and applies it across **all 26** converted initializers repo-wide, including registration-side services that needed extra cleanup logic to be safe to re-run.

This PR is a deliberately smaller, lower-risk slice of the same work:

- **Only `src/shared/services`.** None of the extension/extension-host/renderer services or host services are touched, so none of the cleanup-on-failure / fresh-engine machinery is needed here.
- **Every changed initializer is idempotent by construction** (see below), so the conversions themselves add no cleanup code and change no behavior. The one behavioral change in this PR is a follow-up fix in `network-object-status.service.ts` surfaced in review (see below), separate from the initializer conversions.
- **Helper lives in `src/shared/utils/cached-initializer.ts`**, not in the published `platform-bible-utils` package — so there are no `dist/` or package-export changes.

## Changes from `main`

- New `src/shared/utils/cached-initializer.ts` (`createCachedInitializer`) + unit tests + autoadded to `papi.d.ts`.
- All `src/shared/services/*` initializers converted from a hand-rolled "cache the init promise" pattern to `createCachedInitializer`, which clears the cached promise on rejection so a later call retries.
- New tests:
  - `web-view.service.test.ts` (end-to-end regression for the lockup);
  - `network-object-status.service.test.ts` (the `waitForNetworkObject` logic upstream of every other init, including clean error propagation when the snapshot lookup fails).

### Additional fix in `network-object-status.service.ts`

Review surfaced a pre-existing bug in `network-object-status.service.ts` that a new test had initially codified: on the error path, `waitForNetworkObject` rejected its internal `AsyncVariable` and then re-threw, stranding a rejected promise that was never returned (an unhandled rejection). The `try/catch` is removed so a `getAllNetworkObjectDetails` failure propagates straight to the caller, and the test now asserts clean propagation instead of trapping the leak.

## Why the changed initializers are idempotent

Every converted `src/shared` initializer is a **consumer/lookup** or **delegation** initializer — none registers an engine, sets a network object, or subscribes a listener — so re-running after a failure is just a read and an idempotent reassignment, with nothing to leak or double-register:

- **Lookup-and-assign** — `app`, `data-protection`, `database`, `localization`, `menu-data`, `network-object-status`, `notification`, `project-settings`, `theme`, `theme-data`, `window`:
  - `await …get(<name>)`, throw if missing, assign to a module variable. `get` is a read; re-running and re-assigning the same reference changes nothing.
- **Wait-then-lookup** — `scroll-group`, `web-view`:
  - `await networkObjectStatusService.waitForNetworkObject(...)` then the same lookup-and-assign. `waitForNetworkObject` is a read/wait; no registration.
- **Delegation** — `dialog`:
  - `await networkService.initialize()`. It registers nothing itself and only awaits another already-cached initializer, so re-running is a no-op on success.

### A note on `settings.service.ts`

`settings.service` is the only changed initializer that does more than a pure lookup: after fetching the provider it subscribes to `platform.requestTimeout`. That subscription is already fire-and-forget on `main`: `dataProvider.subscribe(...)` isn't awaited and `resolve()` runs right after. Thus, it never affected init success — the only change here is a `.catch(...)` that logs its rejection instead of leaving it unhandled. So the initializer still rejects only on the lookup itself, exactly like the lookup-and-assign services, and is safe to re-run for the same reason.

## Devin review

https://app.devin.ai/review/paranext/paranext-core/pull/2420

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2420)
<!-- Reviewable:end -->

