### PR TITLE
Avoid full dock reload on the first BCV navigation

### DIFF
--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -820,6 +820,13 @@ export function registerDockLayout(dockLayout: PapiDockLayout): Unsubscriber {
             );
             return;
           }
+          // All settings share one data provider data type, so the settings service notifies every
+          // settings subscriber on any setting write (e.g. `platform.verseRef` syncing on the first
+          // BCV navigation), not just when `platform.interfaceMode` changes. Only reload when the
+          // mode actually changed; otherwise an unrelated first settings write needlessly reloads
+          // the entire dock layout. `currentInterfaceMode` was seeded by the `loadLayout()` call in
+          // `registerDockLayout`, so it reflects the real mode by the time this fires.
+          if (newMode === currentInterfaceMode) return;
           // Update the cache synchronously with the notification so any `saveLayout` racing the
           // switch reads the new mode immediately (before `loadLayout`'s own read resolves).
           currentInterfaceMode = newMode;


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: fix/dock-reload-on-first-bcv-navigation

**Base**: origin/main

**Date**: 2026-06-16

**Review model**: Claude Opus 4.8

**Files changed**: 1

## Overview

This change fixes a spurious full dock-layout reload that occurred on the first
Book/Chapter/Verse (BCV) navigation of a session. The dock layout subscribes to
`platform.interfaceMode` so it can swap the simple/power layout live when the user
switches modes. However, all settings share one data-provider data type, so the
settings service notifies *every* settings subscriber on *any* setting write — and
the scroll group writes `platform.verseRef` on each BCV change. Because the
subscription uses `retrieveDataImmediately: false`, the first such notification ran
the reload callback and re-mounted every WebView even though the interface mode had
not changed.

The fix adds a single early-return guard (`if (newMode === currentInterfaceMode) return;`)
inside the subscription callback so the dock only reloads when the mode actually
changed. `currentInterfaceMode` is seeded by the startup `loadLayout()` call in
`registerDockLayout`, so it holds the real mode by the time the spurious notification
arrives. The change is one line of logic plus an explanatory comment, with no public
API surface, UI, or string changes.

## API Changes

None. The only changed file is `src/renderer/services/web-view.service-host.ts`, an
internal renderer service. No modifications to `lib/platform-bible-react/`,
`lib/platform-bible-utils/`, `papi.d.ts`, or any `extensions/src/*/src/types/*.d.ts`.
The exported signature of `registerDockLayout` is unchanged — the guard is an internal
early return inside the `platform.interfaceMode` subscription callback.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [ ] ~~`web-view.service-host.ts:823-829` — theoretical seeding race: a real interface-mode write landing in the narrow window between `loadLayout()` reading the mode (line 737) and the async `subscribe()` resolving could in principle compare against a stale-but-equal seed.~~ _(Author acknowledged this is not a real bug. The mode is user-driven via `UserProfilePopover` and only changes long after startup; and even if `currentInterfaceMode` were still `undefined`, the guard would not early-return (`'simple'|'power' !== undefined`), so the worst case is an unnecessary reload — never a missed one. Safe fallback direction; no change requested.)_

[Author response: Author acknowledged the seeding-race note is not a real bug and requested no change. A style-pass finding flagging an em dash in the new comment was dropped as a false positive — verified there is no em dash in lines 823-829.]

### Template Propagation

#### Shared Regions Modified

None. (No `#region shared with` markers in the file; the changed region is not inside a shared region.)

#### Extension Config Changes

None. (The only changed file is core renderer code, not under `extensions/`.)

## Positive Observations

- The fix is minimal and surgical — a single early-return guard reusing the existing
  `currentInterfaceMode` module-level cache rather than introducing a new "last mode"
  tracking variable. Minimal surface area, consistent with the existing caching
  strategy.
- The guard is correctly placed: after the `isPlatformError` check (so error
  notifications still short-circuit first) and before the cache write / `loadLayout`
  (so the cache is only updated on a genuine mode change).
- The accompanying comment thoroughly documents the non-obvious root cause (all
  settings sharing one data-provider data type → every subscriber notified on any
  write) and why the guard is safe (seed ordering via `loadLayout()`). This is exactly
  the kind of "why" comment that prevents a future maintainer from removing the guard
  as apparently redundant. Verified accurate against lines 737-740 and 799/812.
- The implementation accomplishes the stated purpose precisely: it suppresses the
  spurious reload on the first `platform.verseRef`/BCV write while still reloading on
  genuine mode changes.
- No stubs, TODOs, or dead code added; the guard is reachable and the existing
  race-handling comment below it remains accurate.

## Interview Notes

- **Stated purpose**: Avoid a spurious full dock reload (re-mounting every WebView) on
  the first BCV navigation of a session, caused by the `platform.interfaceMode`
  subscription firing on any settings write because all settings share one data-provider
  data type. Guard so the dock only reloads when the interface mode actually changed.
- The author acknowledged the single minor (theoretical seeding-race) finding as a
  non-issue and requested no change, correctly noting it is the safe fallback direction.
- The author was offered context that this fix patches the symptom at the dock-layout
  consumer while the underlying behavior — the settings service notifying every
  subscriber on any write — still affects other `platform.*` subscribers. The author
  had nothing further to add.
- No areas of uncertainty or deferral to AI were expressed. The change is small and the
  author's stated reasoning matches the verified code behavior.

## Suggested Review Focus

- [ ] **Altitude / scope (optional discussion):** This guard fixes the dock-layout
  consumer specifically. The root behavior — the settings service notifying *every*
  settings subscriber on *any* write because all settings share one data-provider data
  type — still affects other `platform.*` subscribers (e.g. the `platform.requestTimeout`
  subscriber in `settings.service.ts`). Worth a brief discussion on whether a deeper fix
  in the settings service (notify only subscribers whose key actually changed) is planned
  or explicitly out of scope here.
- [ ] **Seeding-order assumption:** Confirm comfort with the guard's reliance on the
  un-awaited startup `loadLayout()` having seeded `currentInterfaceMode` before the first
  genuine mode-change notification. (Analysis concluded the fallback is safe — an unseeded
  cache causes an unnecessary reload, never a missed one.)
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2421)
<!-- Reviewable:end -->
