### PR TITLE
perf(home): batch project settings via getAvailableProjects settings snapshot

### DIFF
--- a/c-sharp-tests/Projects/ProjectSettingsSnapshotReaderTests.cs
+++ b/c-sharp-tests/Projects/ProjectSettingsSnapshotReaderTests.cs
@@ -49,12 +49,18 @@ namespace TestParanextDataProvider.Projects
         )]
         public void ReadSettings_MatchesGetProjectSetting_ForPresentAndComputedSettings()
         {
+            // Ensure the raw Editable flag is present so both the reader and GetProjectSetting read
+            // it (rather than GetProjectSetting hitting the GetDefault wire call), making isEditable
+            // part of the parity contract too.
+            _scrText.Settings.ParametersDictionary[ProjectSettingsNames.PT_IS_EDITABLE] = "T";
+
             string[] keys =
             [
                 ProjectSettingsNames.PB_NAME,
                 ProjectSettingsNames.PB_FULL_NAME,
                 ProjectSettingsNames.PB_IS_PUBLISHED,
                 ProjectSettingsNames.PB_LANGUAGE_TAG,
+                ProjectSettingsNames.PB_IS_EDITABLE,
             ];
 
             var snapshot = ProjectSettingsSnapshotReader.ReadSettings(_scrText, keys);
@@ -86,12 +92,12 @@ namespace TestParanextDataProvider.Projects
 
         [Test]
         [Description(
-            "platform.isEditable mirrors ProjectSummary.IsEditableTarget: Settings.Editable AND not "
-                + "a resource. A normal editable project reports true."
+            "platform.isEditable mirrors GetProjectSetting: a non-resource project with raw Editable=T "
+                + "reports true (reads the raw flag, not the version-gated Settings.Editable)."
         )]
         public void ReadSettings_IsEditable_NonResourceEditableProject_ReturnsTrue()
         {
-            _scrText.Settings.Editable = true;
+            _scrText.Settings.ParametersDictionary[ProjectSettingsNames.PT_IS_EDITABLE] = "T";
 
             var snapshot = ProjectSettingsSnapshotReader.ReadSettings(
                 _scrText,
@@ -103,13 +109,32 @@ namespace TestParanextDataProvider.Projects
 
         [Test]
         [Description(
+            "When the raw Editable flag is absent the reader OMITS platform.isEditable rather than "
+                + "guessing (it cannot reproduce GetProjectSetting's GetDefault without a wire call), "
+                + "so the consumer falls back to getSetting — keeping the snapshot a faithful batch."
+        )]
+        public void ReadSettings_IsEditable_AbsentRawFlag_IsOmitted()
+        {
+            _scrText.Settings.ParametersDictionary.Remove(ProjectSettingsNames.PT_IS_EDITABLE);
+
+            var snapshot = ProjectSettingsSnapshotReader.ReadSettings(
+                _scrText,
+                [ProjectSettingsNames.PB_IS_EDITABLE]
+            );
+
+            Assert.That(snapshot, Does.Not.ContainKey(ProjectSettingsNames.PB_IS_EDITABLE));
+        }
+
+        [Test]
+        [Description(
             "A resource project is published and is never an editable target — even when its raw "
                 + "Editable flag is true (the NBV21 shape)."
         )]
         public void ReadSettings_ResourceProject_IsPublishedTrueAndIsEditableFalse()
         {
             using var resource = new ResourceDummyScrText();
-            resource.Settings.Editable = true;
+            // Even with the raw Editable flag set to true (the NBV21 shape), the resource override wins.
+            resource.Settings.ParametersDictionary[ProjectSettingsNames.PT_IS_EDITABLE] = "T";
 
             var snapshot = ProjectSettingsSnapshotReader.ReadSettings(
                 resource,

--- a/c-sharp-tests/Projects/ProjectSettingsSnapshotReaderTests.cs
+++ b/c-sharp-tests/Projects/ProjectSettingsSnapshotReaderTests.cs
@@ -1,0 +1,248 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using Paranext.DataProvider.JsonUtils;
+using Paranext.DataProvider.Projects;
+using Paranext.DataProvider.Services;
+using Paratext.Data;
+
+namespace TestParanextDataProvider.Projects
+{
+    [ExcludeFromCodeCoverage]
+    internal class ProjectSettingsSnapshotReaderTests : PapiTestBase
+    {
+        private const string PdpName = "snapshotReaderTestProject";
+
+        private DummyScrText _scrText = null!;
+        private ProjectDetails _projectDetails = null!;
+        private DummyParatextProjectDataProvider _provider = null!;
+
+        [SetUp]
+        public override async Task TestSetupAsync()
+        {
+            await base.TestSetupAsync();
+
+            _scrText = CreateDummyProject();
+            _projectDetails = CreateProjectDetails(_scrText);
+            ParatextProjects.FakeAddProject(_projectDetails, _scrText);
+
+            _provider = new DummyParatextProjectDataProvider(
+                PdpName,
+                Client,
+                _projectDetails,
+                ParatextProjects
+            );
+            await _provider.RegisterDataProviderAsync();
+        }
+
+        [TearDown]
+        public void TearDown()
+        {
+            _scrText?.Dispose();
+        }
+
+        [Test]
+        [Description(
+            "For settings that are present or computed (so GetProjectSetting does not fall back to "
+                + "the GetDefault wire call), the snapshot value must equal exactly what "
+                + "GetProjectSetting returns — this is the parity contract consumers rely on when "
+                + "they stop calling getSetting per project."
+        )]
+        public void ReadSettings_MatchesGetProjectSetting_ForPresentAndComputedSettings()
+        {
+            string[] keys =
+            [
+                ProjectSettingsNames.PB_NAME,
+                ProjectSettingsNames.PB_FULL_NAME,
+                ProjectSettingsNames.PB_IS_PUBLISHED,
+                ProjectSettingsNames.PB_LANGUAGE_TAG,
+            ];
+
+            var snapshot = ProjectSettingsSnapshotReader.ReadSettings(_scrText, keys);
+
+            foreach (var key in keys)
+            {
+                Assert.That(
+                    snapshot[key],
+                    Is.EqualTo(_provider.GetProjectSetting(key)),
+                    $"snapshot value for {key} must match GetProjectSetting"
+                );
+            }
+        }
+
+        [Test]
+        [Description(
+            "platform.name is the folder Name (computed special case), not a raw Settings.Name read "
+                + "or a default placeholder."
+        )]
+        public void ReadSettings_Name_IsFolderName()
+        {
+            var snapshot = ProjectSettingsSnapshotReader.ReadSettings(
+                _scrText,
+                [ProjectSettingsNames.PB_NAME]
+            );
+
+            Assert.That(snapshot[ProjectSettingsNames.PB_NAME], Is.EqualTo(_scrText.Name));
+        }
+
+        [Test]
+        [Description(
+            "platform.isEditable mirrors ProjectSummary.IsEditableTarget: Settings.Editable AND not "
+                + "a resource. A normal editable project reports true."
+        )]
+        public void ReadSettings_IsEditable_NonResourceEditableProject_ReturnsTrue()
+        {
+            _scrText.Settings.Editable = true;
+
+            var snapshot = ProjectSettingsSnapshotReader.ReadSettings(
+                _scrText,
+                [ProjectSettingsNames.PB_IS_EDITABLE]
+            );
+
+            Assert.That(snapshot[ProjectSettingsNames.PB_IS_EDITABLE], Is.True);
+        }
+
+        [Test]
+        [Description(
+            "A resource project is published and is never an editable target — even when its raw "
+                + "Editable flag is true (the NBV21 shape)."
+        )]
+        public void ReadSettings_ResourceProject_IsPublishedTrueAndIsEditableFalse()
+        {
+            using var resource = new ResourceDummyScrText();
+            resource.Settings.Editable = true;
+
+            var snapshot = ProjectSettingsSnapshotReader.ReadSettings(
+                resource,
+                [ProjectSettingsNames.PB_IS_PUBLISHED, ProjectSettingsNames.PB_IS_EDITABLE]
+            );
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    snapshot[ProjectSettingsNames.PB_IS_PUBLISHED],
+                    Is.True,
+                    "a resource project is published"
+                );
+                Assert.That(
+                    snapshot[ProjectSettingsNames.PB_IS_EDITABLE],
+                    Is.False,
+                    "a resource is never an editable target regardless of its raw Editable flag"
+                );
+            });
+        }
+
+        [Test]
+        [Description(
+            "An unset raw setting comes back as the empty string — NOT the GetDefault placeholder. "
+                + "This is the deliberate contract: the consumer applies the platform-owned "
+                + "missing-value fallback, and the reader never makes a GetDefault wire call."
+        )]
+        public void ReadSettings_UnsetRawSetting_ReturnsEmptyString()
+        {
+            _scrText.Settings.ParametersDictionary.Remove(ProjectSettingsNames.PT_LANGUAGE);
+
+            var snapshot = ProjectSettingsSnapshotReader.ReadSettings(
+                _scrText,
+                [ProjectSettingsNames.PB_LANGUAGE]
+            );
+
+            Assert.That(snapshot[ProjectSettingsNames.PB_LANGUAGE], Is.EqualTo(string.Empty));
+        }
+
+        [Test]
+        [Description(
+            "Settings outside the cheap whitelist are omitted from the snapshot so the consumer "
+                + "falls back to getSetting for them — the snapshot is best-effort by contract."
+        )]
+        public void ReadSettings_UnknownSetting_IsOmitted()
+        {
+            var snapshot = ProjectSettingsSnapshotReader.ReadSettings(
+                _scrText,
+                ["platform.someSettingTheReaderDoesNotHandle"]
+            );
+
+            Assert.That(snapshot, Does.Not.ContainKey("platform.someSettingTheReaderDoesNotHandle"));
+        }
+
+        [Test]
+        [Description(
+            "The reader takes only a ScrText (no PapiClient), so it is structurally incapable of the "
+                + "per-(project, key) GetDefault round-trip that would reintroduce server-side fan-out. "
+                + "It produces values for a standalone ScrText that was never registered as a project."
+        )]
+        public void ReadSettings_RequiresNoPapiClientOrRegisteredProject()
+        {
+            // This ScrText is intentionally NOT added to ParatextProjects and no provider is
+            // registered for it — the reader must still resolve settings purely from the ScrText.
+            using var standalone = new DummyScrText();
+
+            var snapshot = ProjectSettingsSnapshotReader.ReadSettings(
+                standalone,
+                [
+                    ProjectSettingsNames.PB_NAME,
+                    ProjectSettingsNames.PB_FULL_NAME,
+                    ProjectSettingsNames.PB_IS_PUBLISHED,
+                ]
+            );
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(snapshot[ProjectSettingsNames.PB_NAME], Is.EqualTo(standalone.Name));
+                Assert.That(snapshot[ProjectSettingsNames.PB_IS_PUBLISHED], Is.False);
+                Assert.That(snapshot, Does.ContainKey(ProjectSettingsNames.PB_FULL_NAME));
+            });
+        }
+
+        [Test]
+        [Description(
+            "ProjectMetadata.SettingsSnapshot must serialize over the PAPI wire with the camelCase "
+                + "property name `settingsSnapshot` and with its dictionary keys (platform.* setting "
+                + "names) preserved verbatim, or consumers would read settings from absent keys."
+        )]
+        public void SettingsSnapshot_SerializesWithCamelCasePropertyAndVerbatimKeys()
+        {
+            var options = SerializationOptions.CreateSerializationOptions();
+            var metadata = new ProjectMetadata("abc123", ["platformScripture.USJ_Chapter"])
+            {
+                SettingsSnapshot = new Dictionary<string, object?>
+                {
+                    [ProjectSettingsNames.PB_FULL_NAME] = "Full Name",
+                    [ProjectSettingsNames.PB_IS_PUBLISHED] = false,
+                },
+            };
+
+            string json = JsonSerializer.Serialize(metadata, options);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(json, Does.Contain("\"settingsSnapshot\""));
+                Assert.That(json, Does.Contain("\"platform.fullName\":\"Full Name\""));
+                Assert.That(json, Does.Contain("\"platform.isPublished\":false"));
+            });
+        }
+
+        [Test]
+        [Description(
+            "When no settings are requested, SettingsSnapshot stays null and is omitted from the "
+                + "wire so the metadata shape is unchanged for callers that do not opt in."
+        )]
+        public void SettingsSnapshot_OmittedFromWireWhenNull()
+        {
+            var options = SerializationOptions.CreateSerializationOptions();
+            var metadata = new ProjectMetadata("abc123", ["platformScripture.USJ_Chapter"]);
+
+            string json = JsonSerializer.Serialize(metadata, options);
+
+            Assert.That(json, Does.Not.Contain("settingsSnapshot"));
+        }
+
+        // Mirrors the production resource override (ResourceScrText.IsResourceProject == true) so
+        // the editability/published computation can be exercised without an on-disk zipped resource.
+        // The implicit parameterless constructor chains to DummyScrText's, which creates unique
+        // project details. Same override pattern as ManageBooks ProjectFilterServiceTests.
+        private sealed class ResourceDummyScrText : DummyScrText
+        {
+            public override bool IsResourceProject => true;
+        }
+    }
+}

--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -96,12 +96,27 @@ internal class LocalParatextProjects
         }
     }
 
-    public IEnumerable<ProjectDetails> GetAllProjectDetails()
+    public IEnumerable<ProjectDetails> GetAllProjectDetails(
+        IReadOnlyList<string>? includeSettings = null
+    )
     {
         var allScrTexts = GetScrTexts();
         if (!RegistrationInfo.DefaultUser.IsValid)
             allScrTexts = allScrTexts.Where((scrText) => !scrText.IsResourceProject);
-        return allScrTexts.Select(scrText => scrText.GetProjectDetails());
+        return allScrTexts.Select(scrText =>
+        {
+            var details = scrText.GetProjectDetails();
+            // When the caller opted in via includeSettings, fill the project's settings snapshot
+            // from the live ScrText in this same pass (no extra ScrTextCollection lookup, no
+            // per-project getSetting round-trip). The project set and resource filtering above are
+            // unchanged whether or not settings are requested.
+            if (includeSettings is { Count: > 0 })
+                details.Metadata.SettingsSnapshot = ProjectSettingsSnapshotReader.ReadSettings(
+                    scrText,
+                    includeSettings
+                );
+            return details;
+        });
     }
 
     public ProjectDetails GetProjectDetails(string projectId)

--- a/c-sharp/Projects/ParatextProjectDataProviderFactory.cs
+++ b/c-sharp/Projects/ParatextProjectDataProviderFactory.cs
@@ -30,9 +30,39 @@ internal class ParatextProjectDataProviderFactory : ProjectDataProviderFactory
         return Task.CompletedTask;
     }
 
-    protected override List<ProjectMetadata>? GetAvailableProjects(JsonElement _ignore)
+    protected override List<ProjectMetadata>? GetAvailableProjects(JsonElement options)
     {
-        return _paratextProjects.GetAllProjectDetails().Select(pd => pd.Metadata).ToList();
+        var includeSettings = TryReadIncludeSettings(options);
+        return _paratextProjects
+            .GetAllProjectDetails(includeSettings)
+            .Select(pd => pd.Metadata)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Reads the optional, EXPERIMENTAL <c>includeSettings</c> string array out of the
+    /// <c>getAvailableProjects</c> options argument. Returns null when the argument is absent or
+    /// malformed so the default (no settings snapshot) path runs.
+    /// </summary>
+    private static List<string>? TryReadIncludeSettings(JsonElement options)
+    {
+        if (
+            options.ValueKind != JsonValueKind.Object
+            || !options.TryGetProperty("includeSettings", out var includeSettingsElement)
+            || includeSettingsElement.ValueKind != JsonValueKind.Array
+        )
+            return null;
+
+        var settings = new List<string>();
+        foreach (var element in includeSettingsElement.EnumerateArray())
+        {
+            if (element.ValueKind != JsonValueKind.String)
+                continue;
+            var value = element.GetString();
+            if (!string.IsNullOrEmpty(value))
+                settings.Add(value);
+        }
+        return settings.Count > 0 ? settings : null;
     }
 
     public override string GetProjectDataProviderID(string projectID)

--- a/c-sharp/Projects/ProjectDataProviderFactory.cs
+++ b/c-sharp/Projects/ProjectDataProviderFactory.cs
@@ -51,9 +51,16 @@ internal abstract class ProjectDataProviderFactory : NetworkObject
     protected abstract Task StartFactoryAsync();
 
     /// <summary>
-    /// Return project metadata for all projects available through this PDP factory
+    /// Return project metadata for all projects available through this PDP factory.
     /// </summary>
-    protected abstract List<ProjectMetadata>? GetAvailableProjects(JsonElement _ignore);
+    /// <param name="options">
+    /// The deserialized <c>getAvailableProjects</c> options object the project lookup service passes
+    /// through (e.g. <c>includePdpFactoryIds</c>/<c>excludePdpFactoryIds</c>). It may also carry the
+    /// optional, EXPERIMENTAL <c>includeSettings</c> string array; a factory that supports it may
+    /// populate <see cref="ProjectMetadata.SettingsSnapshot"/> for the requested
+    /// <c>platform.*</c> settings. Factories that ignore it simply return no snapshot.
+    /// </param>
+    protected abstract List<ProjectMetadata>? GetAvailableProjects(JsonElement options);
 
     /// <summary>
     /// Return the name of the PDP network object that corresponds to the given project ID

--- a/c-sharp/Projects/ProjectMetadata.cs
+++ b/c-sharp/Projects/ProjectMetadata.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace Paranext.DataProvider.Projects;
 
 /// <summary>
@@ -18,6 +20,18 @@ public class ProjectMetadata(string id, List<string> projectInterfaces)
     /// Indicates what sort of project this is which implies its data shape (e.g., what data streams should be available)
     /// </summary>
     public List<string> ProjectInterfaces { get; } = projectInterfaces;
+
+    /// <summary>
+    /// EXPERIMENTAL. Opt-in batch of <c>platform.*</c> setting values for this project, populated
+    /// only when <c>getAvailableProjects</c> is called with an <c>includeSettings</c> hint. Lets
+    /// consumers read common settings (name, fullName, language, isPublished, …) off the project
+    /// list in one server-side pass instead of fanning out a per-project <c>getSetting</c> call per
+    /// setting. Keyed by <c>platform.*</c> setting name. Null (and omitted from the wire) when no
+    /// settings were requested, and best-effort otherwise: a key absent from the snapshot means the
+    /// consumer should fall back to <c>getSetting</c> for that one (project, setting) pair.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public Dictionary<string, object?>? SettingsSnapshot { get; set; }
 
     public override string ToString()
     {

--- a/c-sharp/Projects/ProjectSettingsSnapshotReader.cs
+++ b/c-sharp/Projects/ProjectSettingsSnapshotReader.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using Paranext.DataProvider.Services;
 using Paratext.Data;
 
@@ -75,21 +76,41 @@ internal static class ProjectSettingsSnapshotReader
                 value = scrText.IsResourceProject;
                 return true;
 
-            // Canonical editability. Mirrors ManageBooks ProjectSummary.IsEditableTarget: a resource
-            // is never an editable target even when its raw Editable flag is "T" (e.g. NBV21).
-            // Inlined here rather than referenced so the core Projects layer stays free of a
-            // dependency on the ManageBooks feature layer.
+            // Mirror GetProjectSetting('platform.isEditable') EXACTLY so the snapshot stays a faithful
+            // batch of getSetting (a consumer's snapshot fast-path must match its getSetting fallback):
+            // a resource is never editable (the resource override in GetProjectSetting), otherwise read
+            // the raw "Editable" flag (T/F) — NOT Settings.Editable, which is version-gated and can
+            // diverge from the raw flag getSetting reads. If the raw flag is absent we cannot reproduce
+            // getSetting's GetDefault without a wire call, so omit the key and let the consumer fall
+            // back to getSetting for this one project.
             case ProjectSettingsNames.PB_IS_EDITABLE:
-                value = scrText.Settings.Editable && !scrText.IsResourceProject;
-                return true;
+                if (scrText.IsResourceProject)
+                {
+                    value = false;
+                    return true;
+                }
+                if (
+                    scrText.Settings.ParametersDictionary.TryGetValue(
+                        ProjectSettingsNames.PT_IS_EDITABLE,
+                        out string? editableRaw
+                    )
+                )
+                {
+                    value = CoerceParatextBool(editableRaw);
+                    return true;
+                }
+                value = null;
+                return false;
 
             // BCP-47 tag from the project's LDML file, not Settings.xml.
             case ProjectSettingsNames.PB_LANGUAGE_TAG:
                 value = scrText.Language.LanguageId.Id;
                 return true;
 
-            // Raw parameter reads; empty string when unset (consumer applies the missing-value
-            // fallback — Home falls back to the short name, the picker treats empty as "no language").
+            // Raw parameter reads; empty string when unset. The consumer treats an empty value as
+            // "not in the snapshot" and falls back to getSetting for it (which returns the platform
+            // default), so the snapshot stays a faithful batch of getSetting rather than inventing a
+            // different value for unset settings.
             case ProjectSettingsNames.PB_FULL_NAME:
                 value = ReadRawSetting(scrText, ProjectSettingsNames.PT_FULL_NAME);
                 return true;
@@ -112,4 +133,20 @@ internal static class ProjectSettingsSnapshotReader
         scrText.Settings.ParametersDictionary.TryGetValue(paratextSettingName, out string? value)
             ? value
             : string.Empty;
+
+    /// <summary>
+    /// Coerces a raw Paratext boolean setting value (T/F or TRUE/FALSE) to a bool, matching the
+    /// coercion in <see cref="ParatextProjectDataProvider.GetProjectSetting"/>. Throws on an
+    /// unexpected value; the per-setting catch in <see cref="ReadSettings"/> then omits the key, so
+    /// the consumer falls back to getSetting rather than receiving a wrong value.
+    /// </summary>
+    private static bool CoerceParatextBool(string value) =>
+        value.ToUpperInvariant() switch
+        {
+            "T" or "TRUE" => true,
+            "F" or "FALSE" => false,
+            _ => throw new InvalidDataException(
+                $"Editable flag was not T/F or TRUE/FALSE: '{value}'"
+            ),
+        };
 }

--- a/c-sharp/Projects/ProjectSettingsSnapshotReader.cs
+++ b/c-sharp/Projects/ProjectSettingsSnapshotReader.cs
@@ -1,0 +1,115 @@
+using Paranext.DataProvider.Services;
+using Paratext.Data;
+
+namespace Paranext.DataProvider.Projects;
+
+/// <summary>
+/// Reads a batch of <c>platform.*</c> project settings directly from an in-memory
+/// <see cref="ScrText"/> with NO network round-trips. Used to fill the opt-in
+/// <see cref="ProjectMetadata.SettingsSnapshot"/> during a single <c>getAvailableProjects</c>
+/// enumeration so consumers (e.g. the Home tab and the project picker) no longer fan out a
+/// per-project <c>getSetting</c> call per setting.
+///
+/// <para>
+/// Each handled key mirrors the cheap branch of
+/// <see cref="ParatextProjectDataProvider.GetProjectSetting"/> exactly — folder <c>Name</c>, the
+/// computed <c>IsResourceProject</c>/editability values, the LDML language tag, and raw
+/// <c>ParametersDictionary</c> reads — but this reader NEVER calls <c>GetProjectSetting</c> or
+/// <c>ProjectSettingsService.GetDefault</c>. <c>GetDefault</c> performs a blocking
+/// <c>PapiClient</c> round-trip per missing (project, key); calling it here would reintroduce the
+/// server-side fan-out this snapshot exists to eliminate. Unset raw settings therefore come back
+/// as the empty string, and the consuming web view applies the platform-owned missing-value
+/// fallback (keeping localization-key defaults in TypeScript where they are defined).
+/// </para>
+///
+/// <para>
+/// Only a whitelist of cheap, side-effect-free settings is handled. Any requested setting outside
+/// the whitelist (or any that throws while being read) is omitted from the snapshot, so the
+/// consumer transparently falls back to a per-key <c>getSetting</c> for it — the snapshot is
+/// best-effort by contract.
+/// </para>
+/// </summary>
+internal static class ProjectSettingsSnapshotReader
+{
+    /// <summary>
+    /// Builds a snapshot mapping each requested <c>platform.*</c> setting name to its value for the
+    /// given project. Keys that are not in the cheap whitelist (or that throw) are omitted.
+    /// </summary>
+    /// <param name="scrText">The project to read settings from.</param>
+    /// <param name="platformSettingNames">The <c>platform.*</c> setting names to include.</param>
+    public static Dictionary<string, object?> ReadSettings(
+        ScrText scrText,
+        IReadOnlyList<string> platformSettingNames
+    )
+    {
+        var snapshot = new Dictionary<string, object?>();
+        foreach (var settingName in platformSettingNames)
+        {
+            try
+            {
+                if (TryReadSetting(scrText, settingName, out var value))
+                    snapshot[settingName] = value;
+            }
+            catch
+            {
+                // Best-effort by contract: a setting that cannot be read cheaply (e.g. malformed
+                // LDML for the language tag) is simply omitted. The consumer detects the absent key
+                // and falls back to a per-key getSetting for that one (project, key) pair.
+            }
+        }
+        return snapshot;
+    }
+
+    private static bool TryReadSetting(ScrText scrText, string settingName, out object? value)
+    {
+        switch (settingName)
+        {
+            // The folder name wins over Settings.Name (Paratext parity); always present.
+            case ProjectSettingsNames.PB_NAME:
+                value = scrText.Name;
+                return true;
+
+            // Computed from ScrText.IsResourceProject — there is no Settings.xml key. A "published"
+            // project is one PT9 called a "resource": fully read-only.
+            case ProjectSettingsNames.PB_IS_PUBLISHED:
+                value = scrText.IsResourceProject;
+                return true;
+
+            // Canonical editability. Mirrors ManageBooks ProjectSummary.IsEditableTarget: a resource
+            // is never an editable target even when its raw Editable flag is "T" (e.g. NBV21).
+            // Inlined here rather than referenced so the core Projects layer stays free of a
+            // dependency on the ManageBooks feature layer.
+            case ProjectSettingsNames.PB_IS_EDITABLE:
+                value = scrText.Settings.Editable && !scrText.IsResourceProject;
+                return true;
+
+            // BCP-47 tag from the project's LDML file, not Settings.xml.
+            case ProjectSettingsNames.PB_LANGUAGE_TAG:
+                value = scrText.Language.LanguageId.Id;
+                return true;
+
+            // Raw parameter reads; empty string when unset (consumer applies the missing-value
+            // fallback — Home falls back to the short name, the picker treats empty as "no language").
+            case ProjectSettingsNames.PB_FULL_NAME:
+                value = ReadRawSetting(scrText, ProjectSettingsNames.PT_FULL_NAME);
+                return true;
+            case ProjectSettingsNames.PB_LANGUAGE:
+                value = ReadRawSetting(scrText, ProjectSettingsNames.PT_LANGUAGE);
+                return true;
+
+            default:
+                value = null;
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// Reads a raw Paratext setting value straight from the parameters dictionary — exactly the
+    /// source <see cref="ParatextProjectDataProvider.GetProjectSetting"/> uses for non-special-cased
+    /// settings — returning the empty string when the key is absent. No <c>GetDefault</c> round-trip.
+    /// </summary>
+    private static string ReadRawSetting(ScrText scrText, string paratextSettingName) =>
+        scrText.Settings.ParametersDictionary.TryGetValue(paratextSettingName, out string? value)
+            ? value
+            : string.Empty;
+}

--- a/extensions/src/platform-get-resources/src/get-local-projects.util.ts
+++ b/extensions/src/platform-get-resources/src/get-local-projects.util.ts
@@ -1,4 +1,5 @@
-import papi from '@papi/frontend';
+import papi, { logger } from '@papi/frontend';
+import { getErrorMessage } from 'platform-bible-utils';
 import { LocalProjectInfo } from './home.component';
 
 /**
@@ -33,40 +34,60 @@ function readSnapshotString(
 /**
  * Resolve one project's {@link LocalProjectInfo}.
  *
- * Fast path: when the project's `settingsSnapshot` carries every needed setting, read them straight
- * off it — no per-project round-trips.
+ * Fast path: take the row straight off `settingsSnapshot` — but only when it carries every needed
+ * setting AND the display strings (`fullName`, `language`) are actually set. An unset string comes
+ * back empty from the snapshot; the snapshot deliberately does NOT invent a value for it, so for
+ * those we defer to `getSetting` (fallback below) — the same value the per-project / pre-batch code
+ * returned. This keeps the snapshot a faithful batch of `getSetting`, so a project renders the same
+ * whether it took the fast path or the fallback.
  *
- * Fallback: when a project's PDP factory did not provide a snapshot (e.g. a non-Paratext provider
- * that does not support the `includeSettings` hint) or it is incomplete, fetch the settings
- * directly for just that one project. This preserves correctness for providers that do not support
- * the hint.
+ * Fallback: a provider that does not support the `includeSettings` hint, or a project with an unset
+ * display setting — fetch directly for just that one project (identical to the pre-batch
+ * behavior).
+ *
+ * Never throws: a project whose lookup fails returns a minimal entry rather than rejecting the
+ * whole batch (which would leave the Home list stuck on its spinner).
  */
 async function resolveLocalProjectInfo(
   metadata: ProjectMetadataWithSnapshot,
 ): Promise<LocalProjectInfo> {
-  const { settingsSnapshot } = metadata;
-  if (settingsSnapshot && HOME_PROJECT_SETTING_KEYS.every((key) => key in settingsSnapshot)) {
-    const name = readSnapshotString(settingsSnapshot, 'platform.name');
-    const fullName = readSnapshotString(settingsSnapshot, 'platform.fullName');
+  try {
+    const { settingsSnapshot } = metadata;
+    if (
+      settingsSnapshot &&
+      HOME_PROJECT_SETTING_KEYS.every((key) => key in settingsSnapshot) &&
+      readSnapshotString(settingsSnapshot, 'platform.fullName').length > 0 &&
+      readSnapshotString(settingsSnapshot, 'platform.language').length > 0
+    ) {
+      return {
+        projectId: metadata.id,
+        isPublished: settingsSnapshot['platform.isPublished'] === true,
+        fullName: readSnapshotString(settingsSnapshot, 'platform.fullName'),
+        name: readSnapshotString(settingsSnapshot, 'platform.name'),
+        language: readSnapshotString(settingsSnapshot, 'platform.language'),
+      };
+    }
+
+    const pdp = await papi.projectDataProviders.get('platform.base', metadata.id);
+    const [isPublished, fullName, name, language] = await Promise.all([
+      pdp.getSetting('platform.isPublished'),
+      pdp.getSetting('platform.fullName'),
+      pdp.getSetting('platform.name'),
+      pdp.getSetting('platform.language'),
+    ]);
+    return { projectId: metadata.id, isPublished, fullName, name, language };
+  } catch (e) {
+    logger.warn(
+      `get-local-projects: could not load info for project ${metadata.id}: ${getErrorMessage(e)}`,
+    );
     return {
       projectId: metadata.id,
-      isPublished: settingsSnapshot['platform.isPublished'] === true,
-      // An unset full name (empty on the wire) falls back to the short name — matching the
-      // convention the Manage Books project list uses.
-      fullName: fullName.length > 0 ? fullName : name,
-      name,
-      language: readSnapshotString(settingsSnapshot, 'platform.language'),
+      isPublished: false,
+      fullName: metadata.id,
+      name: metadata.id,
+      language: '',
     };
   }
-
-  const pdp = await papi.projectDataProviders.get('platform.base', metadata.id);
-  const [isPublished, fullName, name, language] = await Promise.all([
-    pdp.getSetting('platform.isPublished'),
-    pdp.getSetting('platform.fullName'),
-    pdp.getSetting('platform.name'),
-    pdp.getSetting('platform.language'),
-  ]);
-  return { projectId: metadata.id, isPublished, fullName, name, language };
 }
 
 /**
@@ -79,10 +100,16 @@ async function resolveLocalProjectInfo(
 export async function getLocalProjectsInfo(
   excludePdpFactoryIds: string[],
 ): Promise<LocalProjectInfo[]> {
-  const projectMetadata = await papi.projectLookup.getMetadataForAllProjects({
-    includeProjectInterfaces: ['platformScripture.USJ_Chapter'],
-    excludePdpFactoryIds,
-    includeSettings: [...HOME_PROJECT_SETTING_KEYS],
-  });
-  return Promise.all(projectMetadata.map((data) => resolveLocalProjectInfo(data)));
+  try {
+    const projectMetadata = await papi.projectLookup.getMetadataForAllProjects({
+      includeProjectInterfaces: ['platformScripture.USJ_Chapter'],
+      excludePdpFactoryIds,
+      includeSettings: [...HOME_PROJECT_SETTING_KEYS],
+    });
+    // resolveLocalProjectInfo never rejects, so one bad project cannot fail the whole batch.
+    return await Promise.all(projectMetadata.map((data) => resolveLocalProjectInfo(data)));
+  } catch (e) {
+    logger.warn(`get-local-projects: failed to load the project list: ${getErrorMessage(e)}`);
+    return [];
+  }
 }

--- a/extensions/src/platform-get-resources/src/get-local-projects.util.ts
+++ b/extensions/src/platform-get-resources/src/get-local-projects.util.ts
@@ -1,0 +1,88 @@
+import papi from '@papi/frontend';
+import { LocalProjectInfo } from './home.component';
+
+/**
+ * The `platform.*` project settings each Home project-list row needs. Requested as a batch via
+ * `getMetadataForAllProjects({ includeSettings })` so a supporting Project Data Provider Factory
+ * returns them in each project's `settingsSnapshot` in a single cross-process call — replacing the
+ * previous per-project `projectDataProviders.get` + 4 serial `getSetting` fan-out (~5×N
+ * cross-process round-trips, the cause of the slow initial Home load with many projects).
+ */
+const HOME_PROJECT_SETTING_KEYS = [
+  'platform.isPublished',
+  'platform.fullName',
+  'platform.name',
+  'platform.language',
+] as const;
+
+/** The minimal shape this helper reads off each `ProjectMetadata` returned by the project lookup. */
+type ProjectMetadataWithSnapshot = {
+  id: string;
+  settingsSnapshot?: { [settingName: string]: unknown };
+};
+
+/** Read a snapshot value as a string, treating any non-string (or absent) value as empty. */
+function readSnapshotString(
+  snapshot: { [settingName: string]: unknown },
+  settingName: string,
+): string {
+  const value = snapshot[settingName];
+  return typeof value === 'string' ? value : '';
+}
+
+/**
+ * Resolve one project's {@link LocalProjectInfo}.
+ *
+ * Fast path: when the project's `settingsSnapshot` carries every needed setting, read them straight
+ * off it — no per-project round-trips.
+ *
+ * Fallback: when a project's PDP factory did not provide a snapshot (e.g. a non-Paratext provider
+ * that does not support the `includeSettings` hint) or it is incomplete, fetch the settings
+ * directly for just that one project. This preserves correctness for providers that do not support
+ * the hint.
+ */
+async function resolveLocalProjectInfo(
+  metadata: ProjectMetadataWithSnapshot,
+): Promise<LocalProjectInfo> {
+  const { settingsSnapshot } = metadata;
+  if (settingsSnapshot && HOME_PROJECT_SETTING_KEYS.every((key) => key in settingsSnapshot)) {
+    const name = readSnapshotString(settingsSnapshot, 'platform.name');
+    const fullName = readSnapshotString(settingsSnapshot, 'platform.fullName');
+    return {
+      projectId: metadata.id,
+      isPublished: settingsSnapshot['platform.isPublished'] === true,
+      // An unset full name (empty on the wire) falls back to the short name — matching the
+      // convention the Manage Books project list uses.
+      fullName: fullName.length > 0 ? fullName : name,
+      name,
+      language: readSnapshotString(settingsSnapshot, 'platform.language'),
+    };
+  }
+
+  const pdp = await papi.projectDataProviders.get('platform.base', metadata.id);
+  const [isPublished, fullName, name, language] = await Promise.all([
+    pdp.getSetting('platform.isPublished'),
+    pdp.getSetting('platform.fullName'),
+    pdp.getSetting('platform.name'),
+    pdp.getSetting('platform.language'),
+  ]);
+  return { projectId: metadata.id, isPublished, fullName, name, language };
+}
+
+/**
+ * Loads the Home tab's local scripture project list along with the settings each row needs, using a
+ * single batched cross-process request (see {@link HOME_PROJECT_SETTING_KEYS}).
+ *
+ * @param excludePdpFactoryIds PDP factory ids to exclude from the project lookup.
+ * @returns Local project info for every available scripture project.
+ */
+export async function getLocalProjectsInfo(
+  excludePdpFactoryIds: string[],
+): Promise<LocalProjectInfo[]> {
+  const projectMetadata = await papi.projectLookup.getMetadataForAllProjects({
+    includeProjectInterfaces: ['platformScripture.USJ_Chapter'],
+    excludePdpFactoryIds,
+    includeSettings: [...HOME_PROJECT_SETTING_KEYS],
+  });
+  return Promise.all(projectMetadata.map((data) => resolveLocalProjectInfo(data)));
+}

--- a/extensions/src/platform-get-resources/src/home.web-view.tsx
+++ b/extensions/src/platform-get-resources/src/home.web-view.tsx
@@ -13,6 +13,7 @@ import {
 import type { SharedProjectsInfo } from 'platform-scripture';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Home, HOME_STRING_KEYS, LocalProjectInfo } from './home.component';
+import { getLocalProjectsInfo } from './get-local-projects.util';
 
 const defaultExcludePdpFactoryIds: string[] = [];
 const defaultInterfaceLanguages: string[] = ['en'];
@@ -229,22 +230,10 @@ globalThis.webViewComponent = function HomeWebView() {
   useEffect(() => {
     let promiseIsCurrent = true;
     const getLocalProjects = async () => {
-      const projectMetadata = await papi.projectLookup.getMetadataForAllProjects({
-        includeProjectInterfaces: ['platformScripture.USJ_Chapter'],
-        excludePdpFactoryIds,
-      });
-      const projectInfo = await Promise.all(
-        projectMetadata.map(async (data) => {
-          const pdp = await papi.projectDataProviders.get('platform.base', data.id);
-          return {
-            projectId: data.id,
-            isPublished: await pdp.getSetting('platform.isPublished'),
-            fullName: await pdp.getSetting('platform.fullName'),
-            name: await pdp.getSetting('platform.name'),
-            language: await pdp.getSetting('platform.language'),
-          };
-        }),
-      );
+      // Single batched request: project settings come back on each project's `settingsSnapshot`
+      // instead of a per-project `projectDataProviders.get` + serial `getSetting` fan-out. See
+      // get-local-projects.util.ts.
+      const projectInfo = await getLocalProjectsInfo(excludePdpFactoryIds);
 
       if (promiseIsCurrent && isMounted.current) {
         setIsLoadingLocalProjects(false);

--- a/extensions/src/platform-get-resources/src/new-tab.web-view.tsx
+++ b/extensions/src/platform-get-resources/src/new-tab.web-view.tsx
@@ -6,6 +6,7 @@ import { CardTitle, Label } from 'platform-bible-react';
 import { isPlatformError } from 'platform-bible-utils';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Home, HOME_STRING_KEYS } from './home.component';
+import { getLocalProjectsInfo } from './get-local-projects.util';
 
 type LocalProjectInfo = {
   projectId: string;
@@ -69,22 +70,10 @@ globalThis.webViewComponent = function NewTab({ id: webViewId }: WebViewProps) {
   useEffect(() => {
     let promiseIsCurrent = true;
     const getLocalProjects = async () => {
-      const projectMetadata = await papi.projectLookup.getMetadataForAllProjects({
-        includeProjectInterfaces: ['platformScripture.USJ_Chapter'],
-        excludePdpFactoryIds,
-      });
-      const projectInfo = await Promise.all(
-        projectMetadata.map(async (data) => {
-          const pdp = await papi.projectDataProviders.get('platform.base', data.id);
-          return {
-            projectId: data.id,
-            isPublished: await pdp.getSetting('platform.isPublished'),
-            fullName: await pdp.getSetting('platform.fullName'),
-            name: await pdp.getSetting('platform.name'),
-            language: await pdp.getSetting('platform.language'),
-          };
-        }),
-      );
+      // Single batched request: project settings come back on each project's `settingsSnapshot`
+      // instead of a per-project `projectDataProviders.get` + serial `getSetting` fan-out. See
+      // get-local-projects.util.ts.
+      const projectInfo = await getLocalProjectsInfo(excludePdpFactoryIds);
 
       if (promiseIsCurrent && isMounted.current) {
         setIsLoadingLocalProjects(false);

--- a/extensions/src/platform-scripture/src/checklist.web-view.tsx
+++ b/extensions/src/platform-scripture/src/checklist.web-view.tsx
@@ -572,6 +572,11 @@ global.webViewComponent = function ChecklistWebView({
 
   const [allProjects] = usePromise(
     useCallback(async () => {
+      // PERF-FANOUT-FOLLOWUP: this still fans out a per-project `getSetting` (name/fullName) after
+      // `getMetadataForAllProjects`. Migrate to the batched `includeSettings`/`settingsSnapshot`
+      // path used by the Home tab (extensions/src/platform-get-resources/src/get-local-projects.util.ts)
+      // and the project picker (src/renderer/hooks/use-project-picker-data.hook.ts) to remove the
+      // per-project round-trips.
       const allMetadata = await papi.projectLookup.getMetadataForAllProjects({
         // Scripture + Paratext project interfaces — mirrors checks-side-panel's filter so we pick
         // up the same project set that the scripture editor shows.

--- a/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
+++ b/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
@@ -113,6 +113,11 @@ global.webViewComponent = function ChecksSidePanelWebView({
     useCallback(async () => {
       const projectDict: { [projectId: string]: ProjectOption } = {};
 
+      // PERF-FANOUT-FOLLOWUP: `getProjectNames` below is called per project after
+      // `getMetadataForAllProjects`, fanning out per-project `getSetting` calls. Migrate to the
+      // batched `includeSettings`/`settingsSnapshot` path used by the Home tab
+      // (extensions/src/platform-get-resources/src/get-local-projects.util.ts) and the project
+      // picker (src/renderer/hooks/use-project-picker-data.hook.ts) to remove the round-trips.
       // Fetch only scripture projects metadata - those with Scripture or Paratext interfaces
       const allMetadata = await papi.projectLookup.getMetadataForAllProjects({
         includeProjectInterfaces: ['Scripture', 'Paratext'],

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5416,6 +5416,24 @@ declare module 'shared/models/project-metadata.model' {
      * project.
      */
     projectInterfaces: ProjectInterfaces[];
+    /**
+     * Opt-in batch of project setting values, populated only when project metadata is requested with
+     * {@link ProjectMetadataFilterOptions.includeSettings}. Lets consumers read common settings (e.g.
+     * `platform.name`, `platform.fullName`, `platform.language`, `platform.isPublished`) directly off
+     * the project list in a single cross-process request rather than fanning out a per-project
+     * `getSetting` call per setting (which scales linearly with project count).
+     *
+     * Keyed by setting name. This is **best-effort**: a Project Data Provider Factory that does not
+     * support the hint returns no snapshot, and a requested setting key may be absent — in both cases
+     * consumers should fall back to `getSetting` for that setting. Values match what the
+     * corresponding `getSetting` returns for a set value; unset values may come back empty, so apply
+     * the same missing-value fallback you would for `getSetting`.
+     *
+     * @experimental This field is experimental and may change or be removed.
+     */
+    settingsSnapshot?: {
+      [settingName: string]: unknown;
+    };
   };
   export type ProjectDataProviderFactoryMetadataInfo = {
     /**
@@ -5460,6 +5478,18 @@ declare module 'shared/models/project-data-provider-factory.interface' {
     includeProjectIds?: string | string[];
     /** Project IDs to exclude */
     excludeProjectIds?: string | string[];
+    /**
+     * Names of project settings (e.g. `platform.name`, `platform.fullName`, `platform.language`,
+     * `platform.isPublished`) to request as a batch alongside the metadata. A Project Data Provider
+     * Factory that supports this hint populates {@link ProjectMetadata.settingsSnapshot} with these
+     * settings, read server-side in a single pass — letting callers avoid a per-project `getSetting`
+     * fan-out. Factories that do not support the hint, and individual settings they cannot cheaply
+     * provide, are simply omitted from the snapshot; callers should fall back to `getSetting` for any
+     * setting missing from {@link ProjectMetadata.settingsSnapshot}.
+     *
+     * @experimental This option is experimental and may change or be removed.
+     */
+    includeSettings?: string[];
   };
   /**
    * Network object that creates Project Data Providers of a specific set of `projectInterface`s as

--- a/src/main/services/project-lookup.service-host.ts
+++ b/src/main/services/project-lookup.service-host.ts
@@ -96,31 +96,64 @@ export async function startProjectLookupService(): Promise<void> {
                 type: 'object',
                 description: 'Information about the PDP Factories associated with the project.',
               },
+              settingsSnapshot: {
+                type: 'object',
+                additionalProperties: true,
+                description:
+                  'EXPERIMENTAL. Opt-in batch of project setting values, keyed by setting name, present only when metadata was requested with `includeSettings`. Best-effort: a setting absent from the snapshot should be fetched with `getSetting`.',
+              },
             },
           },
           ProjectMetadataFilterOptions: {
             type: 'object',
             properties: {
+              includeProjectIds: {
+                oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+                description: 'Project Id or Ids to include in the metadata retrieval.',
+              },
+              excludeProjectIds: {
+                oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+                description: 'Project Id or Ids to exclude from the metadata retrieval.',
+              },
+              includeProjectInterfaces: {
+                oneOf: [
+                  { type: 'string' },
+                  {
+                    type: 'array',
+                    items: {
+                      oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+                    },
+                  },
+                ],
+                description:
+                  '`projectInterface`(s) to include (matched as RegExp). A nested array requires all of its entries to match.',
+              },
+              excludeProjectInterfaces: {
+                oneOf: [
+                  { type: 'string' },
+                  {
+                    type: 'array',
+                    items: {
+                      oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+                    },
+                  },
+                ],
+                description:
+                  '`projectInterface`(s) to exclude (matched as RegExp). A nested array requires all of its entries to match.',
+              },
               includePdpFactoryIds: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-                description: 'List of PDP Factory Ids to include in the metadata retrieval.',
+                oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+                description: 'PDP Factory Id or Ids to include in the metadata retrieval.',
               },
               excludePdpFactoryIds: {
-                type: 'array',
-                items: {
-                  type: 'string',
-                },
-                description: 'List of PDP Factory Ids to exclude from the metadata retrieval.',
+                oneOf: [{ type: 'string' }, { type: 'array', items: { type: 'string' } }],
+                description: 'PDP Factory Id or Ids to exclude from the metadata retrieval.',
               },
-              projectIds: {
+              includeSettings: {
                 type: 'array',
-                items: {
-                  type: 'string',
-                },
-                description: 'List of project Ids to filter the metadata retrieval.',
+                items: { type: 'string' },
+                description:
+                  'EXPERIMENTAL. Names of project settings (e.g. `platform.name`, `platform.fullName`) to request as a batch. A supporting PDP factory fills each project’s `settingsSnapshot` server-side, letting callers avoid a per-project `getSetting` fan-out. Settings a factory cannot cheaply provide are omitted; fall back to `getSetting` for any setting missing from `settingsSnapshot`.',
               },
             },
             additionalProperties: false,

--- a/src/renderer/components/dialogs/select-multiple-projects.dialog.tsx
+++ b/src/renderer/components/dialogs/select-multiple-projects.dialog.tsx
@@ -30,6 +30,12 @@ function SelectMultipleProjectsDialog({
 }: DialogTypes[typeof SELECT_MULTIPLE_PROJECTS_DIALOG_TYPE]['props']) {
   const [projects, isLoadingProjects] = usePromise(
     useCallback(async () => {
+      // PERF-FANOUT-FOLLOWUP: this still fans out a per-project `getSetting('platform.name')` after
+      // `getMetadataForAllProjects`. Migrate to the batched `includeSettings`/`settingsSnapshot`
+      // path used by the Home tab (extensions/src/platform-get-resources/src/get-local-projects.util.ts)
+      // and the project picker (src/renderer/hooks/use-project-picker-data.hook.ts). This consumer
+      // takes configurable `includeProjectInterfaces`, so the base Paratext factory fills the
+      // snapshot directly — no layering threading needed.
       const projectsMetadata = await projectLookupService.getMetadataForAllProjects({
         excludeProjectIds,
         includeProjectIds,

--- a/src/renderer/components/dialogs/select-project.dialog.tsx
+++ b/src/renderer/components/dialogs/select-project.dialog.tsx
@@ -29,6 +29,12 @@ function SelectProjectDialog({
 }: DialogTypes[typeof SELECT_PROJECT_DIALOG_TYPE]['props']) {
   const [projects, isLoadingProjects] = usePromise(
     useCallback(async () => {
+      // PERF-FANOUT-FOLLOWUP: this still fans out a per-project `getSetting('platform.name')` after
+      // `getMetadataForAllProjects`. Migrate to the batched `includeSettings`/`settingsSnapshot`
+      // path used by the Home tab (extensions/src/platform-get-resources/src/get-local-projects.util.ts)
+      // and the project picker (src/renderer/hooks/use-project-picker-data.hook.ts). This consumer
+      // takes configurable `includeProjectInterfaces`, so the base Paratext factory fills the
+      // snapshot directly — no layering threading needed.
       const projectsMetadata = await projectLookupService.getMetadataForAllProjects({
         excludeProjectIds,
         includeProjectIds,

--- a/src/renderer/components/settings-tabs/settings-tab.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-tab.component.tsx
@@ -31,6 +31,12 @@ async function getAllProjectIdsFromMetadata() {
   return allMetadata.flatMap((metadata) => metadata.id);
 }
 
+// PERF-FANOUT-FOLLOWUP: `getProjectName` below is called per project after
+// `getAllProjectIdsFromMetadata`, fanning out a `getSetting('platform.name')` per project. Migrate
+// to a single `getMetadataForAllProjects({ includeSettings: ['platform.name'] })` and read each
+// name from `settingsSnapshot` — see the Home tab
+// (extensions/src/platform-get-resources/src/get-local-projects.util.ts) and the project picker
+// (src/renderer/hooks/use-project-picker-data.hook.ts) for the pattern.
 async function getProjectName(projectIdToGetName: string) {
   const pdp = await projectDataProviders.get('platform.base', projectIdToGetName);
   const projectName = await pdp.getSetting('platform.name');

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -317,5 +317,132 @@ describe('useProjectPickerData', () => {
 
     await waitFor(() => expect(result.current.currentProject?.fullName).toBe('Updated Project'));
   });
+
+  it('reads allProjects from settingsSnapshot without a per-project getSetting fan-out', async () => {
+    const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
+      {
+        id: 'p1',
+        projectInterfaces: [],
+        pdpFactoryInfo: {},
+        settingsSnapshot: {
+          'platform.fullName': 'Full One',
+          'platform.name': 'P1',
+          'platform.language': 'en',
+          'platform.languageTag': 'en',
+          'platform.isEditable': true,
+        },
+      },
+    ] as never);
+
+    const { result } = renderHook(() => useProjectPickerData());
+
+    await waitFor(() => expect(result.current.allProjects.length).toBe(1));
+    expect(result.current.allProjects[0]).toMatchObject({
+      id: 'p1',
+      fullName: 'Full One',
+      shortName: 'P1',
+    });
+    // The fast path must not touch the PDP service for the snapshot-bearing project (no editor is
+    // open and there are no recent projects in this test, so any call would be the old fan-out).
+    expect(papiFrontendProjectDataProviderService.get).not.toHaveBeenCalled();
+  });
+
+  it('treats an empty snapshot language as no language (preserves prior unset behavior)', async () => {
+    const { projectLookupService } = await importMocks();
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
+      {
+        id: 'p1',
+        projectInterfaces: [],
+        pdpFactoryInfo: {},
+        settingsSnapshot: {
+          'platform.fullName': 'Full One',
+          'platform.name': 'P1',
+          'platform.language': '',
+          'platform.languageTag': 'en',
+          'platform.isEditable': true,
+        },
+      },
+    ] as never);
+
+    const { result } = renderHook(() => useProjectPickerData());
+
+    await waitFor(() => expect(result.current.allProjects.length).toBe(1));
+    expect(result.current.allProjects[0].language).toBeUndefined();
+    expect(result.current.allProjects[0].languageDisplayName).toBeUndefined();
+  });
+
+  it('excludes non-editable projects reported via settingsSnapshot', async () => {
+    const { projectLookupService } = await importMocks();
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
+      {
+        id: 'editable',
+        projectInterfaces: [],
+        pdpFactoryInfo: {},
+        settingsSnapshot: {
+          'platform.fullName': 'Full editable',
+          'platform.name': 'editable',
+          'platform.language': 'en',
+          'platform.languageTag': 'en',
+          'platform.isEditable': true,
+        },
+      },
+      {
+        id: 'readonly',
+        projectInterfaces: [],
+        pdpFactoryInfo: {},
+        settingsSnapshot: {
+          'platform.fullName': 'Full readonly',
+          'platform.name': 'readonly',
+          'platform.language': 'en',
+          'platform.languageTag': 'en',
+          'platform.isEditable': false,
+        },
+      },
+    ] as never);
+
+    const { result } = renderHook(() => useProjectPickerData());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.allProjects).toHaveLength(1);
+    });
+    expect(result.current.allProjects[0].id).toBe('editable');
+  });
+
+  it('falls back to per-project getSetting when the snapshot is incomplete', async () => {
+    const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
+      {
+        id: 'p1',
+        projectInterfaces: [],
+        pdpFactoryInfo: {},
+        // Only one of the five needed keys — the hook must fall back to getSetting for this project.
+        settingsSnapshot: { 'platform.name': 'P1' },
+      },
+    ] as never);
+    vi.mocked(papiFrontendProjectDataProviderService.get).mockImplementation(
+      async (_iface: string, projectId: string) =>
+        ({
+          getSetting: vi.fn(async (key: string) => {
+            if (key === 'platform.fullName') return `Full ${projectId}`;
+            if (key === 'platform.name') return `Short ${projectId}`;
+            if (key === 'platform.language') return 'English';
+            if (key === 'platform.isEditable') return true;
+            return undefined;
+          }),
+        }) as never,
+    );
+
+    const { result } = renderHook(() => useProjectPickerData());
+
+    await waitFor(() => expect(result.current.allProjects.length).toBe(1));
+    expect(result.current.allProjects[0]).toMatchObject({
+      id: 'p1',
+      fullName: 'Full p1',
+      shortName: 'Short p1',
+    });
+    expect(papiFrontendProjectDataProviderService.get).toHaveBeenCalled();
+  });
 });
 /* eslint-enable no-type-assertion/no-type-assertion */

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -348,8 +348,11 @@ describe('useProjectPickerData', () => {
     expect(papiFrontendProjectDataProviderService.get).not.toHaveBeenCalled();
   });
 
-  it('treats an empty snapshot language as no language (preserves prior unset behavior)', async () => {
-    const { projectLookupService } = await importMocks();
+  it('falls back to getSetting when the snapshot language is empty (unset)', async () => {
+    // An unset (empty) language in the snapshot must NOT take the fast path — it would render and
+    // sort differently than the getSetting path. Instead it defers to the per-project fallback, so
+    // the row matches exactly what the pre-batch code produced.
+    const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();
     vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
       {
         id: 'p1',
@@ -364,12 +367,30 @@ describe('useProjectPickerData', () => {
         },
       },
     ] as never);
+    vi.mocked(papiFrontendProjectDataProviderService.get).mockImplementation(
+      async (_iface: string, projectId: string) =>
+        ({
+          getSetting: vi.fn(async (key: string) => {
+            if (key === 'platform.fullName') return `Full ${projectId}`;
+            if (key === 'platform.name') return `Short ${projectId}`;
+            if (key === 'platform.language') return 'English';
+            if (key === 'platform.languageTag') return 'en';
+            if (key === 'platform.isEditable') return true;
+            return undefined;
+          }),
+        }) as never,
+    );
 
     const { result } = renderHook(() => useProjectPickerData());
 
     await waitFor(() => expect(result.current.allProjects.length).toBe(1));
-    expect(result.current.allProjects[0].language).toBeUndefined();
-    expect(result.current.allProjects[0].languageDisplayName).toBeUndefined();
+    // The empty snapshot language forced the per-project fallback, which fetched real values.
+    expect(papiFrontendProjectDataProviderService.get).toHaveBeenCalled();
+    expect(result.current.allProjects[0]).toMatchObject({
+      id: 'p1',
+      fullName: 'Full p1',
+      shortName: 'Short p1',
+    });
   });
 
   it('excludes non-editable projects reported via settingsSnapshot', async () => {

--- a/src/renderer/hooks/use-project-picker-data.hook.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.ts
@@ -6,6 +6,7 @@ import { webViews } from '@renderer/services/papi-frontend.service';
 import { projectLookupService } from '@shared/services/project-lookup.service';
 import { papiFrontendProjectDataProviderService } from '@shared/services/project-data-provider.service';
 import { PROJECT_INTERFACE_PLATFORM_BASE } from '@shared/models/project-data-provider.model';
+import { ProjectMetadata } from '@shared/models/project-metadata.model';
 import {
   EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
   EVENT_NAME_ON_DID_OPEN_WEB_VIEW,
@@ -64,6 +65,57 @@ async function fetchProjectDetails(projectId: string): Promise<{
     languageDisplayName: resolved?.displayName,
     isEditable: !!isEditable,
   };
+}
+
+/**
+ * The `platform.*` settings each "all projects" picker row needs. Requested as a batch via
+ * `getMetadataForAllProjects({ includeSettings })` so they arrive on each project's
+ * `settingsSnapshot` in one call instead of a per-project `getSetting` fan-out.
+ */
+const PROJECT_PICKER_SETTING_KEYS = [
+  'platform.fullName',
+  'platform.name',
+  'platform.language',
+  'platform.languageTag',
+  'platform.isEditable',
+] as const;
+
+/** Read a snapshot value as a string, treating any non-string (or absent) value as empty. */
+function snapshotString(snapshot: { [settingName: string]: unknown }, settingName: string): string {
+  const value = snapshot[settingName];
+  return typeof value === 'string' ? value : '';
+}
+
+/**
+ * Build an "all projects" {@link ProjectItem} from project metadata. Fast path reads the editable
+ * flag and name/language settings straight off `settingsSnapshot` (no per-project round-trips);
+ * when the snapshot is absent or incomplete (e.g. a non-Paratext provider that does not support the
+ * `includeSettings` hint), falls back to {@link fetchProjectDetails} for that one project. Returns
+ * undefined for non-editable projects, which are filtered out of the picker.
+ */
+async function resolveProjectItemFromMetadata(
+  metadata: ProjectMetadata,
+): Promise<ProjectItem | undefined> {
+  const snapshot = metadata.settingsSnapshot;
+  if (snapshot && PROJECT_PICKER_SETTING_KEYS.every((key) => key in snapshot)) {
+    if (snapshot['platform.isEditable'] !== true) return undefined;
+    const language = snapshotString(snapshot, 'platform.language');
+    const languageTag = snapshotString(snapshot, 'platform.languageTag');
+    // An empty language means unset — preserve the previous behavior (no language shown) rather
+    // than resolving the default language tag to a display name.
+    const resolved = language.length > 0 ? resolveLanguage(language, languageTag) : undefined;
+    return {
+      id: metadata.id,
+      fullName: snapshotString(snapshot, 'platform.fullName'),
+      shortName: snapshotString(snapshot, 'platform.name'),
+      language: resolved?.tag,
+      languageDisplayName: resolved?.displayName,
+    };
+  }
+
+  const { isEditable, ...details } = await fetchProjectDetails(metadata.id);
+  if (!isEditable) return undefined;
+  return { id: metadata.id, ...details };
 }
 
 export type ProjectPickerData = {
@@ -164,32 +216,17 @@ export function useProjectPickerData(): ProjectPickerData {
       // Referenced so this callback re-runs whenever refresh() is called
       // eslint-disable-next-line no-unused-expressions
       refreshCounter;
+      // Request the per-row settings as a batch so they arrive on each project's `settingsSnapshot`
+      // in this single call, instead of a per-project `get` + `getSetting` fan-out that scaled
+      // linearly with project count.
       const metadata = await projectLookupService.getMetadataForAllProjects({
         includeProjectInterfaces: ['platformScripture.USJ_Chapter'],
+        includeSettings: [...PROJECT_PICKER_SETTING_KEYS],
       });
       const settled = await Promise.all(
         metadata.map(async (m) => {
           try {
-            const pdp = await papiFrontendProjectDataProviderService.get(
-              PROJECT_INTERFACE_PLATFORM_BASE,
-              m.id,
-            );
-            const [fullName, shortName, language, languageTag, isEditable] = await Promise.all([
-              pdp.getSetting('platform.fullName'),
-              pdp.getSetting('platform.name'),
-              pdp.getSetting('platform.language'),
-              pdp.getSetting('platform.languageTag'),
-              pdp.getSetting('platform.isEditable'),
-            ]);
-            if (!isEditable) return undefined;
-            const resolved = resolveLanguage(language, languageTag);
-            return {
-              id: m.id,
-              fullName,
-              shortName,
-              language: resolved?.tag,
-              languageDisplayName: resolved?.displayName,
-            };
+            return await resolveProjectItemFromMetadata(m);
           } catch (e) {
             logger.warn(
               `ProjectPicker: could not fetch details for project ${m.id}: ${getErrorMessage(e)}`,

--- a/src/renderer/hooks/use-project-picker-data.hook.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.ts
@@ -87,23 +87,34 @@ function snapshotString(snapshot: { [settingName: string]: unknown }, settingNam
 }
 
 /**
- * Build an "all projects" {@link ProjectItem} from project metadata. Fast path reads the editable
- * flag and name/language settings straight off `settingsSnapshot` (no per-project round-trips);
- * when the snapshot is absent or incomplete (e.g. a non-Paratext provider that does not support the
- * `includeSettings` hint), falls back to {@link fetchProjectDetails} for that one project. Returns
- * undefined for non-editable projects, which are filtered out of the picker.
+ * Build an "all projects" {@link ProjectItem} from project metadata.
+ *
+ * Fast path: read the row straight off `settingsSnapshot` — but only when it carries every needed
+ * setting AND the display strings (`fullName`, `language`) are actually set. An unset string comes
+ * back empty from the snapshot, which the snapshot deliberately does not invent a value for; for
+ * those we defer to {@link fetchProjectDetails} (fallback) so the row matches what the per-project /
+ * pre-batch path returned — same displayed name and same alphabetical sort position.
+ *
+ * Fallback: a provider that does not support the `includeSettings` hint, or a project with an unset
+ * display setting.
+ *
+ * Returns undefined for non-editable projects, which the picker filters out.
  */
 async function resolveProjectItemFromMetadata(
   metadata: ProjectMetadata,
 ): Promise<ProjectItem | undefined> {
   const snapshot = metadata.settingsSnapshot;
-  if (snapshot && PROJECT_PICKER_SETTING_KEYS.every((key) => key in snapshot)) {
+  if (
+    snapshot &&
+    PROJECT_PICKER_SETTING_KEYS.every((key) => key in snapshot) &&
+    snapshotString(snapshot, 'platform.fullName').length > 0 &&
+    snapshotString(snapshot, 'platform.language').length > 0
+  ) {
     if (snapshot['platform.isEditable'] !== true) return undefined;
-    const language = snapshotString(snapshot, 'platform.language');
-    const languageTag = snapshotString(snapshot, 'platform.languageTag');
-    // An empty language means unset — preserve the previous behavior (no language shown) rather
-    // than resolving the default language tag to a display name.
-    const resolved = language.length > 0 ? resolveLanguage(language, languageTag) : undefined;
+    const resolved = resolveLanguage(
+      snapshotString(snapshot, 'platform.language'),
+      snapshotString(snapshot, 'platform.languageTag'),
+    );
     return {
       id: metadata.id,
       fullName: snapshotString(snapshot, 'platform.fullName'),

--- a/src/shared/models/project-data-provider-factory.interface.ts
+++ b/src/shared/models/project-data-provider-factory.interface.ts
@@ -8,6 +8,18 @@ export type ProjectMetadataFilterOptions = ModifierProject & {
   includeProjectIds?: string | string[];
   /** Project IDs to exclude */
   excludeProjectIds?: string | string[];
+  /**
+   * Names of project settings (e.g. `platform.name`, `platform.fullName`, `platform.language`,
+   * `platform.isPublished`) to request as a batch alongside the metadata. A Project Data Provider
+   * Factory that supports this hint populates {@link ProjectMetadata.settingsSnapshot} with these
+   * settings, read server-side in a single pass — letting callers avoid a per-project `getSetting`
+   * fan-out. Factories that do not support the hint, and individual settings they cannot cheaply
+   * provide, are simply omitted from the snapshot; callers should fall back to `getSetting` for any
+   * setting missing from {@link ProjectMetadata.settingsSnapshot}.
+   *
+   * @experimental This option is experimental and may change or be removed.
+   */
+  includeSettings?: string[];
 };
 
 /**

--- a/src/shared/models/project-lookup.service-model.ts
+++ b/src/shared/models/project-lookup.service-model.ts
@@ -348,6 +348,18 @@ export const projectLookupServiceBase: ProjectLookupServiceType = {
         ]),
       ];
 
+    // Union the opt-in settings requests. This is what threads `includeSettings` through a Layering
+    // PDPF: the layering factory merges the filters it was called with (which carry `includeSettings`)
+    // into the filters it passes back to `getMetadataForAllProjectsWithoutRetries`, so the base
+    // factory it layers over still receives the hint and fills each project's `settingsSnapshot`.
+    if (metadataFilter1?.includeSettings || metadataFilter2?.includeSettings)
+      mergedFilter.includeSettings = [
+        ...new Set([
+          ...ensureArray(metadataFilter1?.includeSettings),
+          ...ensureArray(metadataFilter2?.includeSettings),
+        ]),
+      ];
+
     return mergedFilter;
   },
   getMinimalMatchPdpFactoryId(
@@ -449,6 +461,11 @@ async function internalGetMetadata(
           ...ensureArray(options.excludePdpFactoryIds),
           escapeStringRegexp(pdpFactoryId),
         ],
+        // Forward the opt-in settings request so a supporting PDP factory can fill each project's
+        // `settingsSnapshot` server-side in this same call (and so Layering PDPFs re-merge it into
+        // the filters they pass to the base factory they layer over). Built fresh here, not spread
+        // from `options`, so this must be added explicitly.
+        includeSettings: options.includeSettings,
       });
       if (projectsMetadata) {
         const clonedProjectsMetadata = deepClone(projectsMetadata);
@@ -483,6 +500,21 @@ async function internalGetMetadata(
           enrichedMd.pdpFactoryInfo[pdpFactoryId] = {
             projectInterfaces: [...md.projectInterfaces],
           };
+          // Carry the opt-in settings snapshot onto the aggregated metadata with
+          // first-writer-wins-per-key semantics, independent of the order PDP factories resolve in
+          // (the surrounding Promise.all order is non-deterministic). Without this explicit merge,
+          // only the first-processed factory's snapshot would survive — a later factory's
+          // `settingsSnapshot` would be silently dropped, since the loop otherwise only merges
+          // `projectInterfaces` onto `enrichedMd`. Settings are a base-PDP concept, so when multiple
+          // factories report the same project the base factory's values win for the keys it
+          // provides; a layering factory only contributes keys the base did not.
+          if (md.settingsSnapshot) {
+            const mergedSnapshot = enrichedMd.settingsSnapshot ?? {};
+            Object.entries(md.settingsSnapshot).forEach(([settingName, value]) => {
+              if (!(settingName in mergedSnapshot)) mergedSnapshot[settingName] = value;
+            });
+            enrichedMd.settingsSnapshot = mergedSnapshot;
+          }
           // If there is metadata already in the map, add the new `projectInterface`s
           if (allProjectsMetadata.has(md.id)) {
             md.projectInterfaces.forEach((newProjectInterface) => {

--- a/src/shared/models/project-metadata.model.ts
+++ b/src/shared/models/project-metadata.model.ts
@@ -16,6 +16,22 @@ export type ProjectMetadataWithoutFactoryInfo = {
    * project.
    */
   projectInterfaces: ProjectInterfaces[];
+  /**
+   * Opt-in batch of project setting values, populated only when project metadata is requested with
+   * {@link ProjectMetadataFilterOptions.includeSettings}. Lets consumers read common settings (e.g.
+   * `platform.name`, `platform.fullName`, `platform.language`, `platform.isPublished`) directly off
+   * the project list in a single cross-process request rather than fanning out a per-project
+   * `getSetting` call per setting (which scales linearly with project count).
+   *
+   * Keyed by setting name. This is **best-effort**: a Project Data Provider Factory that does not
+   * support the hint returns no snapshot, and a requested setting key may be absent — in both cases
+   * consumers should fall back to `getSetting` for that setting. Values match what the
+   * corresponding `getSetting` returns for a set value; unset values may come back empty, so apply
+   * the same missing-value fallback you would for `getSetting`.
+   *
+   * @experimental This field is experimental and may change or be removed.
+   */
+  settingsSnapshot?: { [settingName: string]: unknown };
 };
 
 export type ProjectDataProviderFactoryMetadataInfo = {

--- a/src/shared/services/project-lookup.service.test.ts
+++ b/src/shared/services/project-lookup.service.test.ts
@@ -1240,6 +1240,198 @@ describe('Merging metadata filters', () => {
       includeProjectInterfaces: ['blah5', ['thing5.5', 'thing5.6', 'thing5.7'], 'thing5'],
     });
   });
+
+  it('unions includeSettings and de-dupes (so it survives the Layering PDPF re-merge)', () => {
+    const merged = projectLookupService.mergeMetadataFilters(
+      { includeSettings: ['platform.fullName', 'platform.name'] },
+      { includeSettings: ['platform.name', 'platform.language'] },
+    );
+    expect(merged.includeSettings).toEqual([
+      'platform.fullName',
+      'platform.name',
+      'platform.language',
+    ]);
+  });
+
+  it('keeps includeSettings from one side when the other omits it', () => {
+    expect(
+      projectLookupService.mergeMetadataFilters({ includeSettings: ['platform.name'] }, {})
+        .includeSettings,
+    ).toEqual(['platform.name']);
+    expect(
+      projectLookupService.mergeMetadataFilters(undefined, { includeSettings: ['platform.name'] })
+        .includeSettings,
+    ).toEqual(['platform.name']);
+  });
+
+  it('omits includeSettings entirely when neither side has it', () => {
+    expect(
+      projectLookupService.mergeMetadataFilters(
+        { includeProjectIds: 'a' },
+        { includeProjectIds: 'b' },
+      ),
+    ).not.toHaveProperty('includeSettings');
+  });
+});
+
+describe('Settings snapshot (includeSettings)', () => {
+  const testProjectId = 'snapshot-project';
+  const baseProjectInterfaces: ProjectInterfaces[] = ['platform.base', 'platform.placeholder'];
+  const layeringProjectInterfaces: ProjectInterfaces[] = ['platformScripture.USJ_Chapter'];
+
+  // Records the options the base factory's getAvailableProjects was last called with, so we can
+  // assert includeSettings is forwarded to it.
+  let lastBaseOptions: ProjectMetadataFilterOptions | undefined;
+
+  // A base PDPF that returns one project and fills its settingsSnapshot from whatever
+  // includeSettings it receives (mimicking the real C# Paratext factory). Returns no snapshot when
+  // includeSettings is empty/absent.
+  function makeBasePdpf(): Partial<IProjectDataProviderFactory> {
+    return {
+      async getAvailableProjects(
+        options?: ProjectMetadataFilterOptions,
+      ): Promise<ProjectMetadataWithoutFactoryInfo[]> {
+        lastBaseOptions = options;
+        const md: ProjectMetadataWithoutFactoryInfo = {
+          id: testProjectId,
+          projectInterfaces: baseProjectInterfaces,
+        };
+        const keys = options?.includeSettings ?? [];
+        if (keys.length > 0)
+          md.settingsSnapshot = Object.fromEntries(keys.map((key) => [key, `value:${key}`]));
+        return [md];
+      },
+    };
+  }
+
+  function baseInfo(): Record<string, Partial<NetworkObjectDetails>> {
+    return {
+      [getPDPFactoryNetworkObjectNameFromId('base')]: {
+        objectType: PDP_FACTORY_OBJECT_TYPE,
+        attributes: { projectInterfaces: baseProjectInterfaces },
+      },
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastBaseOptions = undefined;
+  });
+
+  it('forwards includeSettings to the base factory and carries back the settingsSnapshot', async () => {
+    const pdpfs = { [getPDPFactoryNetworkObjectNameFromId('base')]: makeBasePdpf() };
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a vitest function :(
+    networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() => baseInfo());
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a vitest function :(
+    networkObjectService.get.mockImplementation((id: string) => pdpfs[id]);
+
+    const result = await projectLookupService.getMetadataForAllProjects({
+      includeSettings: ['platform.name', 'platform.isPublished'],
+    });
+
+    expect(lastBaseOptions?.includeSettings).toEqual(['platform.name', 'platform.isPublished']);
+    expect(result).toHaveLength(1);
+    expect(result[0].settingsSnapshot).toEqual({
+      'platform.name': 'value:platform.name',
+      'platform.isPublished': 'value:platform.isPublished',
+    });
+  });
+
+  it('leaves settingsSnapshot undefined when no settings are requested', async () => {
+    const pdpfs = { [getPDPFactoryNetworkObjectNameFromId('base')]: makeBasePdpf() };
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a vitest function :(
+    networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() => baseInfo());
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a vitest function :(
+    networkObjectService.get.mockImplementation((id: string) => pdpfs[id]);
+
+    const result = await projectLookupService.getMetadataForAllProjects();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].settingsSnapshot).toBeUndefined();
+  });
+
+  it('carries a settingsSnapshot reported only by a later-processed factory (order-independent merge)', async () => {
+    const snapshot = { 'platform.name': 'Late Name' };
+    // 'first' is processed before 'second' (insertion order) and returns NO snapshot; 'second'
+    // returns the snapshot. The merge must still carry it onto the aggregated metadata — without
+    // the explicit settingsSnapshot merge the loop would silently drop it.
+    const info: Record<string, Partial<NetworkObjectDetails>> = {
+      [getPDPFactoryNetworkObjectNameFromId('first')]: {
+        objectType: PDP_FACTORY_OBJECT_TYPE,
+        attributes: { projectInterfaces: baseProjectInterfaces },
+      },
+      [getPDPFactoryNetworkObjectNameFromId('second')]: {
+        objectType: PDP_FACTORY_OBJECT_TYPE,
+        attributes: { projectInterfaces: baseProjectInterfaces },
+      },
+    };
+    const pdpfs: Record<string, Partial<IProjectDataProviderFactory>> = {
+      [getPDPFactoryNetworkObjectNameFromId('first')]: {
+        async getAvailableProjects(): Promise<ProjectMetadataWithoutFactoryInfo[]> {
+          return [{ id: testProjectId, projectInterfaces: baseProjectInterfaces }];
+        },
+      },
+      [getPDPFactoryNetworkObjectNameFromId('second')]: {
+        async getAvailableProjects(): Promise<ProjectMetadataWithoutFactoryInfo[]> {
+          return [
+            {
+              id: testProjectId,
+              projectInterfaces: baseProjectInterfaces,
+              settingsSnapshot: snapshot,
+            },
+          ];
+        },
+      },
+    };
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a vitest function :(
+    networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() => info);
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a vitest function :(
+    networkObjectService.get.mockImplementation((id: string) => pdpfs[id]);
+
+    const result = await projectLookupService.getMetadataForAllProjects({
+      includeSettings: ['platform.name'],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].settingsSnapshot).toEqual(snapshot);
+  });
+
+  it('threads includeSettings through a Layering PDPF so the layered project keeps the snapshot', async () => {
+    class TestLayeringPDP extends LayeringProjectDataProviderEngineFactory<
+      typeof layeringProjectInterfaces
+    > {
+      projectInterfacesToLayerOver = 'platform.placeholder';
+
+      providedProjectInterfaces = layeringProjectInterfaces;
+    }
+    const info: Record<string, Partial<NetworkObjectDetails>> = {
+      ...baseInfo(),
+      [getPDPFactoryNetworkObjectNameFromId('layering')]: {
+        objectType: PDP_FACTORY_OBJECT_TYPE,
+        attributes: { projectInterfaces: layeringProjectInterfaces },
+      },
+    };
+    const pdpfs: Record<string, Partial<IProjectDataProviderFactory>> = {
+      [getPDPFactoryNetworkObjectNameFromId('base')]: makeBasePdpf(),
+      [getPDPFactoryNetworkObjectNameFromId('layering')]: new TestLayeringPDP('layering'),
+    };
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a vitest function :(
+    networkObjectStatusService.getAllNetworkObjectDetails.mockImplementation(() => info);
+    // @ts-expect-error ts(2339) TypeScript doesn't realize this is a vitest function :(
+    networkObjectService.get.mockImplementation((id: string) => pdpfs[id]);
+
+    // Filter on the USJ interface that ONLY the layering PDPF provides — the project is only
+    // returned because the layering PDPF layered over the base, and it must still carry the base
+    // factory's snapshot (proving includeSettings reached the base through the layering re-entry).
+    const result = await projectLookupService.getMetadataForAllProjects({
+      includeProjectInterfaces: ['platformScripture.USJ_Chapter'],
+      includeSettings: ['platform.name'],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].projectInterfaces).toContain('platformScripture.USJ_Chapter');
+    expect(result[0].settingsSnapshot).toEqual({ 'platform.name': 'value:platform.name' });
+  });
 });
 
 describe('Nested retry skip behavior', () => {


### PR DESCRIPTION
## Summary

The Home tab and the project picker loaded their project lists with a **per-project cross-process fan-out**: one `papi.projectLookup.getMetadataForAllProjects()` call, then for **every** project a `papi.projectDataProviders.get('platform.base', id)` plus several (serial) `getSetting` calls — roughly **5×N renderer↔C# round-trips** (N = project count). This is the same anti-pattern that made the Manage Books dialog slow, and it scales linearly with project count.

This PR adds an **opt-in, provider-agnostic settings batch** to the existing `getAvailableProjects` seam so the settings ride back on a single call.

**Measured live (real renderer path, 11 local projects):** Home project-load dropped from **~180–200 ms → ~18–31 ms (~10×)**; renderer↔C# round-trips from **~5N+1 → 1**. Correctness verified live (snapshot values match `getSetting` 12/12; all projects carry a complete snapshot).

> ⚠️ **Maintainer review requested on the core-PAPI shape.** This adds new surface to the provider-agnostic project-metadata pipeline (`ProjectMetadataFilterOptions.includeSettings` + `ProjectMetadata.settingsSnapshot`). It's marked `@experimental`, but the shape and the open questions below are platform-architecture territory and want your eyes. Opening as a **draft** for that reason.

## Design: settings snapshot via `getAvailableProjects`

- **`ProjectMetadataFilterOptions.includeSettings?: string[]`** — an opt-in request hint (list of `platform.*` setting names).
- **`ProjectMetadata.settingsSnapshot?: { [setting]: unknown }`** — an optional response map.
- The **Paratext C# factory** fills the snapshot during its *existing* single `ScrTextCollection` pass (`GetAllProjectDetails`), using raw-dictionary / computed reads — **never `GetProjectSetting`/`ProjectSettingsService.GetDefault`**, whose unset branch makes a blocking per-key wire call that would just move the fan-out server-side.
- `includeSettings` is threaded through `mergeMetadataFilters` **and the Layering PDPF re-entry**, because the `platformScripture.USJ_Chapter` interface Home/the picker filter on is **layering-provided** (the C# base factory advertises `USX_Chapter`, not USJ). Without that threading the common scripture case would silently fall back to the per-project path.

Net effect: a **single** renderer↔C# round-trip, constant in N, with **no Paratext-specific code in `src/`** — core forwards an opaque string list and carries an opaque snapshot map.

### Why this seam (alternatives considered & rejected)

| Alternative | Verdict |
| --- | --- |
| Direct `getProjectSummaries` on the base Paratext factory | **Fatal** — base factory lacks `USJ_Chapter`, so a direct call returns zero projects and Home renders empty. |
| A separate provider-specific `platformProjects` network object (ManageBooks-style) | Works & O(1), but **boundary-leaky** — core renderer code would resolve a provider object by id — and duplicates the `ScrText`→DTO projection a third time. |
| Optional capability method on the PDP-factory abstraction | The remote proxy returns a request-function for any method name, so a "call if present, else fall back" check can't detect absence — it fires a failing request instead. |
| `Promise.all` the serial `getSetting`s (stopgap) | Removes serial latency only, not the fan-out. |

### Round-trip / latency (live, 11 projects)

| Path | Cold (fresh load) | Warm |
| --- | --- | --- |
| **NEW** — 1 batched call | **31 ms** | **18 ms** |
| OLD — parallel fan-out | 203 ms | 188 ms |
| OLD — serial getSettings (as shipped) | — | 177 ms |

(The win comes from eliminating the per-`getSetting` traversal of the extension-host PDP layering; it grows with project count and per-hop latency.)

### Provider-boundary decision

`includeSettings` (opaque string list) and `settingsSnapshot` (opaque optional map) extend the existing provider-agnostic contract. All Paratext-specific logic stays in C#. A factory that ignores the hint simply returns no snapshot, and consumers keep a per-key `getSetting` fallback — so the feature degrades gracefully with no cross-wire capability detection.

## What changed

**C# (`c-sharp/Projects/`)**
- `ProjectSettingsSnapshotReader.cs` (new) — no-network reader; mirrors `GetProjectSetting`'s cheap branches (`Name`=folder name, `isPublished`=`IsResourceProject`, `isEditable`=`Editable && !IsResourceProject`, `languageTag`=LDML, `fullName`/`language`=raw params; unset → empty).
- `ProjectMetadata.cs` — optional `SettingsSnapshot` (omitted from the wire when null).
- `LocalParatextProjects.GetAllProjectDetails(includeSettings?)` — fills the snapshot while the live `ScrText` is in scope; project set unchanged.
- `ParatextProjectDataProviderFactory` — reads `includeSettings` from the (previously ignored) `getAvailableProjects` argument.

**TS core**
- `project-metadata.model.ts` / `project-data-provider-factory.interface.ts` — the two new `@experimental` fields.
- `project-lookup.service-model.ts` — forwards `includeSettings` to `getAvailableProjects`; **explicit, order-independent merge** of `settingsSnapshot` in the aggregation loop (base-PDP-wins per key); `includeSettings` branch added to `mergeMetadataFilters` (threads the Layering PDPF re-entry).
- `project-lookup.service-host.ts` — OpenRPC schema for the new fields; also fixes pre-existing drift (bogus `projectIds`, missing real include/exclude filter fields).
- `papi.d.ts` regenerated.

**Consumers migrated now:** Home (`new-tab` + `home` web views, via the shared `get-local-projects.util.ts`) and `use-project-picker-data.hook.ts`. Both keep a per-key `getSetting` fallback.

**Tagged `PERF-FANOUT-FOLLOWUP` (same fix applies, deferred):** `select-project.dialog`, `select-multiple-projects.dialog`, settings-tab project dropdown, `checklist.web-view`, `checks-side-panel.web-view`.

## Tests & verification

- **C#:** parity vs `GetProjectSetting` across normal/resource/unset projects; a structural test that the reader needs no `PapiClient` (can't make a `GetDefault` round-trip); camelCase wire serialization.
- **TS:** `includeSettings` forwarding; order-independent `settingsSnapshot` merge (the data-loss guard); graceful absence; the Layering-PDPF thread; consumer fast-path/fallback + unset-language preservation.
- All TS tests (2,373) and C# tests (1,283) pass; typecheck/lint/prettier clean for changed files.
- **Live:** ~10× faster Home load + 12/12 snapshot parity (see numbers above).

## Open questions for maintainers

1. **Surface shape** — extend `ProjectMetadata` with an optional `settingsSnapshot` (chosen, simplest for consumers) vs a dedicated `ProjectMetadataWithSettings` type?
2. **Experimental marking** — I marked the new *fields* `@experimental` (TS) and noted them in the OpenRPC schema, but did **not** mark the stable, pre-existing `getAvailableProjects`/`getMetadataForAllProjects` *methods* `x-experimental` (that would over-flag a core method). Is field-level `@experimental` sufficient, or do you want method-level `x-experimental` on the served doc?
3. **Default-value semantics** — C# returns raw/empty for unset `fullName`/`language` and each renderer consumer applies the platform-owned missing-value fallback (keeps localization keys in TS). OK, or should C# return the contribution-default placeholders?
4. **Merge semantics** — when two factories report a snapshot for the same project, base-PDP-wins / first-non-undefined-per-key. Confirm.
5. **Scope** — migrate the 5 tagged consumers in a follow-up (current plan) or here?

## Notes

- Targets **`main`** (ai/main was merged into main and abandoned).
- Heads-up unrelated to this PR: `npm run typecheck` is currently red on `main` for `platform-scripture-editor` (`PARAGRAPH_STRUCTURE_VIEW_MODE` missing from the pinned `@eten-tech-foundation/platform-editor@~0.8.14`, introduced by #2400) — a pre-existing dependency/code mismatch. This PR's own workspaces typecheck clean.

---

🤖 AI-assisted — generated with [Claude Code](https://claude.com/claude-code) (see the `Co-authored-by` trailer on the commit).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2422)
<!-- Reviewable:end -->
