### PR TITLE
fix(flaky): useProjectPickerData returns currentProject test times out on Windows CI

### DIFF
--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -70,7 +70,9 @@ const DEFAULT_RECENT_IDS: string[] = [];
 async function importMocks() {
   const { getNetworkEvent } = await import('@shared/services/network.service');
   const { webViews } = await import('@renderer/services/papi-frontend.service');
-  const { projectLookupService } = await import('@shared/services/project-lookup.service');
+  const { projectLookupService } = await import(
+    '@shared/services/project-lookup.service'
+  );
   const { papiFrontendProjectDataProviderService } = await import(
     '@shared/services/project-data-provider.service'
   );
@@ -121,7 +123,9 @@ describe('useProjectPickerData', () => {
 
     vi.mocked(getNetworkEvent).mockImplementation(() => vi.fn(() => vi.fn()));
     vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([]);
-    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([]);
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue(
+      [],
+    );
     vi.mocked(papiFrontendProjectDataProviderService.get).mockResolvedValue({
       getSetting: vi.fn(async (key: string) => {
         if (key === 'platform.fullName') return 'Mock Full Name';
@@ -131,7 +135,9 @@ describe('useProjectPickerData', () => {
       }),
     } as never);
     vi.mocked(useData).mockImplementation(() => ({
-      RecentProjects: vi.fn().mockReturnValue([DEFAULT_RECENT_IDS, vi.fn(), false]),
+      RecentProjects: vi
+        .fn()
+        .mockReturnValue([DEFAULT_RECENT_IDS, vi.fn(), false]),
     }));
   });
 
@@ -146,7 +152,8 @@ describe('useProjectPickerData', () => {
   // testTimeout must exceed it to leave room for test setup on starved Windows CI runners;
   // without that margin the test can time out before waitFor even starts polling.
   it('returns currentProject from the first open Scripture Editor web view', async () => {
-    const { webViews, papiFrontendProjectDataProviderService } = await importMocks();
+    const { webViews, papiFrontendProjectDataProviderService } =
+      await importMocks();
     vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
       { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-abc' },
     ] as never);
@@ -164,11 +171,14 @@ describe('useProjectPickerData', () => {
   }, 15_000);
 
   it('returns allProjects from projectLookupService', async () => {
-    const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();
-    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
-      { id: 'p1', projectInterfaces: [], pdpFactoryInfo: {} },
-      { id: 'p2', projectInterfaces: [], pdpFactoryInfo: {} },
-    ] as never);
+    const { projectLookupService, papiFrontendProjectDataProviderService } =
+      await importMocks();
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue(
+      [
+        { id: 'p1', projectInterfaces: [], pdpFactoryInfo: {} },
+        { id: 'p2', projectInterfaces: [], pdpFactoryInfo: {} },
+      ] as never,
+    );
     vi.mocked(papiFrontendProjectDataProviderService.get).mockImplementation(
       async (_iface: string, projectId: string) =>
         ({
@@ -200,9 +210,12 @@ describe('useProjectPickerData', () => {
   });
 
   it('recentProjects reflects recent project IDs from data provider', async () => {
-    const { papiFrontendProjectDataProviderService, useData } = await importMocks();
+    const { papiFrontendProjectDataProviderService, useData } =
+      await importMocks();
     vi.mocked(useData).mockImplementation(() => ({
-      RecentProjects: vi.fn().mockReturnValue([['proj-r1', 'proj-r2'], vi.fn(), false]),
+      RecentProjects: vi
+        .fn()
+        .mockReturnValue([['proj-r1', 'proj-r2'], vi.fn(), false]),
     }));
     vi.mocked(papiFrontendProjectDataProviderService.get).mockImplementation(
       async (_iface: string, projectId: string) =>
@@ -236,11 +249,14 @@ describe('useProjectPickerData', () => {
   });
 
   it('excludes non-editable projects from allProjects', async () => {
-    const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();
-    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
-      { id: 'editable', projectInterfaces: [], pdpFactoryInfo: {} },
-      { id: 'readonly', projectInterfaces: [], pdpFactoryInfo: {} },
-    ] as never);
+    const { projectLookupService, papiFrontendProjectDataProviderService } =
+      await importMocks();
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue(
+      [
+        { id: 'editable', projectInterfaces: [], pdpFactoryInfo: {} },
+        { id: 'readonly', projectInterfaces: [], pdpFactoryInfo: {} },
+      ] as never,
+    );
     vi.mocked(papiFrontendProjectDataProviderService.get).mockImplementation(
       async (_iface: string, projectId: string) =>
         ({
@@ -264,15 +280,20 @@ describe('useProjectPickerData', () => {
   });
 
   it('excludes recent projects from allProjects', async () => {
-    const { projectLookupService, papiFrontendProjectDataProviderService, useData } =
-      await importMocks();
+    const {
+      projectLookupService,
+      papiFrontendProjectDataProviderService,
+      useData,
+    } = await importMocks();
     vi.mocked(useData).mockImplementation(() => ({
       RecentProjects: vi.fn().mockReturnValue([['proj-r1'], vi.fn(), false]),
     }));
-    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
-      { id: 'proj-r1', projectInterfaces: [], pdpFactoryInfo: {} },
-      { id: 'proj-other', projectInterfaces: [], pdpFactoryInfo: {} },
-    ] as never);
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue(
+      [
+        { id: 'proj-r1', projectInterfaces: [], pdpFactoryInfo: {} },
+        { id: 'proj-other', projectInterfaces: [], pdpFactoryInfo: {} },
+      ] as never,
+    );
     vi.mocked(papiFrontendProjectDataProviderService.get).mockImplementation(
       async (_iface: string, projectId: string) =>
         ({
@@ -297,13 +318,17 @@ describe('useProjectPickerData', () => {
   });
 
   it('refreshes currentProject when onDidUpdateWebView fires', async () => {
-    const { getNetworkEvent, webViews, papiFrontendProjectDataProviderService } =
-      await importMocks();
+    const {
+      getNetworkEvent,
+      webViews,
+      papiFrontendProjectDataProviderService,
+    } = await importMocks();
     let capturedCallback: (() => void) | undefined;
     vi.mocked(getNetworkEvent).mockImplementation(
       (eventName: string) =>
         vi.fn((cb: () => void) => {
-          if (eventName === EVENT_NAME_ON_DID_UPDATE_WEB_VIEW) capturedCallback = cb;
+          if (eventName === EVENT_NAME_ON_DID_UPDATE_WEB_VIEW)
+            capturedCallback = cb;
           return vi.fn();
         }) as never,
     );
@@ -311,7 +336,11 @@ describe('useProjectPickerData', () => {
     vi.mocked(webViews.getAllOpenWebViewDefinitions)
       .mockResolvedValueOnce([])
       .mockResolvedValue([
-        { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-xyz' },
+        {
+          id: 'wv-1',
+          webViewType: EDITOR_WEB_VIEW_TYPE,
+          projectId: 'proj-xyz',
+        },
       ] as never);
     vi.mocked(papiFrontendProjectDataProviderService.get).mockResolvedValue({
       getSetting: vi.fn(async () => 'Updated Project'),
@@ -324,7 +353,9 @@ describe('useProjectPickerData', () => {
     expect(capturedCallback).toBeDefined();
     act(() => capturedCallback!());
 
-    await waitFor(() => expect(result.current.currentProject?.fullName).toBe('Updated Project'));
+    await waitFor(() =>
+      expect(result.current.currentProject?.fullName).toBe('Updated Project'),
+    );
   });
 });
 /* eslint-enable no-type-assertion/no-type-assertion */

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -145,27 +145,23 @@ describe('useProjectPickerData', () => {
   // asyncUtilTimeout (set in beforeAll) governs RTL's waitFor deadline (5 s). The Vitest
   // testTimeout must exceed it to leave room for test setup on starved Windows CI runners;
   // without that margin the test can time out before waitFor even starts polling.
-  it(
-    'returns currentProject from the first open Scripture Editor web view',
-    async () => {
-      const { webViews, papiFrontendProjectDataProviderService } = await importMocks();
-      vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
-        { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-abc' },
-      ] as never);
-      vi.mocked(papiFrontendProjectDataProviderService.get).mockResolvedValue({
-        getSetting: vi.fn(async () => 'Genesis Project'),
-      } as never);
+  it('returns currentProject from the first open Scripture Editor web view', async () => {
+    const { webViews, papiFrontendProjectDataProviderService } = await importMocks();
+    vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
+      { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-abc' },
+    ] as never);
+    vi.mocked(papiFrontendProjectDataProviderService.get).mockResolvedValue({
+      getSetting: vi.fn(async () => 'Genesis Project'),
+    } as never);
 
-      const { result } = renderHook(() => useProjectPickerData());
+    const { result } = renderHook(() => useProjectPickerData());
 
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-        expect(result.current.currentProject?.fullName).toBe('Genesis Project');
-      });
-      expect(result.current.currentProject?.id).toBe('proj-abc');
-    },
-    15_000,
-  );
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.currentProject?.fullName).toBe('Genesis Project');
+    });
+    expect(result.current.currentProject?.id).toBe('proj-abc');
+  }, 15_000);
 
   it('returns allProjects from projectLookupService', async () => {
     const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -1,10 +1,4 @@
-import {
-  renderHook,
-  waitFor,
-  act,
-  configure,
-  getConfig,
-} from '@testing-library/react';
+import { renderHook, waitFor, act, configure, getConfig } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { EVENT_NAME_ON_DID_UPDATE_WEB_VIEW } from '@shared/services/web-view.service-model';
@@ -70,9 +64,7 @@ const DEFAULT_RECENT_IDS: string[] = [];
 async function importMocks() {
   const { getNetworkEvent } = await import('@shared/services/network.service');
   const { webViews } = await import('@renderer/services/papi-frontend.service');
-  const { projectLookupService } = await import(
-    '@shared/services/project-lookup.service'
-  );
+  const { projectLookupService } = await import('@shared/services/project-lookup.service');
   const { papiFrontendProjectDataProviderService } = await import(
     '@shared/services/project-data-provider.service'
   );
@@ -123,9 +115,7 @@ describe('useProjectPickerData', () => {
 
     vi.mocked(getNetworkEvent).mockImplementation(() => vi.fn(() => vi.fn()));
     vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([]);
-    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue(
-      [],
-    );
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([]);
     vi.mocked(papiFrontendProjectDataProviderService.get).mockResolvedValue({
       getSetting: vi.fn(async (key: string) => {
         if (key === 'platform.fullName') return 'Mock Full Name';
@@ -135,9 +125,7 @@ describe('useProjectPickerData', () => {
       }),
     } as never);
     vi.mocked(useData).mockImplementation(() => ({
-      RecentProjects: vi
-        .fn()
-        .mockReturnValue([DEFAULT_RECENT_IDS, vi.fn(), false]),
+      RecentProjects: vi.fn().mockReturnValue([DEFAULT_RECENT_IDS, vi.fn(), false]),
     }));
   });
 
@@ -152,8 +140,7 @@ describe('useProjectPickerData', () => {
   // testTimeout must exceed it to leave room for test setup on starved Windows CI runners;
   // without that margin the test can time out before waitFor even starts polling.
   it('returns currentProject from the first open Scripture Editor web view', async () => {
-    const { webViews, papiFrontendProjectDataProviderService } =
-      await importMocks();
+    const { webViews, papiFrontendProjectDataProviderService } = await importMocks();
     vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
       { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-abc' },
     ] as never);
@@ -171,14 +158,11 @@ describe('useProjectPickerData', () => {
   }, 15_000);
 
   it('returns allProjects from projectLookupService', async () => {
-    const { projectLookupService, papiFrontendProjectDataProviderService } =
-      await importMocks();
-    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue(
-      [
-        { id: 'p1', projectInterfaces: [], pdpFactoryInfo: {} },
-        { id: 'p2', projectInterfaces: [], pdpFactoryInfo: {} },
-      ] as never,
-    );
+    const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
+      { id: 'p1', projectInterfaces: [], pdpFactoryInfo: {} },
+      { id: 'p2', projectInterfaces: [], pdpFactoryInfo: {} },
+    ] as never);
     vi.mocked(papiFrontendProjectDataProviderService.get).mockImplementation(
       async (_iface: string, projectId: string) =>
         ({
@@ -210,12 +194,9 @@ describe('useProjectPickerData', () => {
   });
 
   it('recentProjects reflects recent project IDs from data provider', async () => {
-    const { papiFrontendProjectDataProviderService, useData } =
-      await importMocks();
+    const { papiFrontendProjectDataProviderService, useData } = await importMocks();
     vi.mocked(useData).mockImplementation(() => ({
-      RecentProjects: vi
-        .fn()
-        .mockReturnValue([['proj-r1', 'proj-r2'], vi.fn(), false]),
+      RecentProjects: vi.fn().mockReturnValue([['proj-r1', 'proj-r2'], vi.fn(), false]),
     }));
     vi.mocked(papiFrontendProjectDataProviderService.get).mockImplementation(
       async (_iface: string, projectId: string) =>
@@ -249,14 +230,11 @@ describe('useProjectPickerData', () => {
   });
 
   it('excludes non-editable projects from allProjects', async () => {
-    const { projectLookupService, papiFrontendProjectDataProviderService } =
-      await importMocks();
-    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue(
-      [
-        { id: 'editable', projectInterfaces: [], pdpFactoryInfo: {} },
-        { id: 'readonly', projectInterfaces: [], pdpFactoryInfo: {} },
-      ] as never,
-    );
+    const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
+      { id: 'editable', projectInterfaces: [], pdpFactoryInfo: {} },
+      { id: 'readonly', projectInterfaces: [], pdpFactoryInfo: {} },
+    ] as never);
     vi.mocked(papiFrontendProjectDataProviderService.get).mockImplementation(
       async (_iface: string, projectId: string) =>
         ({
@@ -280,20 +258,15 @@ describe('useProjectPickerData', () => {
   });
 
   it('excludes recent projects from allProjects', async () => {
-    const {
-      projectLookupService,
-      papiFrontendProjectDataProviderService,
-      useData,
-    } = await importMocks();
+    const { projectLookupService, papiFrontendProjectDataProviderService, useData } =
+      await importMocks();
     vi.mocked(useData).mockImplementation(() => ({
       RecentProjects: vi.fn().mockReturnValue([['proj-r1'], vi.fn(), false]),
     }));
-    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue(
-      [
-        { id: 'proj-r1', projectInterfaces: [], pdpFactoryInfo: {} },
-        { id: 'proj-other', projectInterfaces: [], pdpFactoryInfo: {} },
-      ] as never,
-    );
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
+      { id: 'proj-r1', projectInterfaces: [], pdpFactoryInfo: {} },
+      { id: 'proj-other', projectInterfaces: [], pdpFactoryInfo: {} },
+    ] as never);
     vi.mocked(papiFrontendProjectDataProviderService.get).mockImplementation(
       async (_iface: string, projectId: string) =>
         ({
@@ -318,17 +291,13 @@ describe('useProjectPickerData', () => {
   });
 
   it('refreshes currentProject when onDidUpdateWebView fires', async () => {
-    const {
-      getNetworkEvent,
-      webViews,
-      papiFrontendProjectDataProviderService,
-    } = await importMocks();
+    const { getNetworkEvent, webViews, papiFrontendProjectDataProviderService } =
+      await importMocks();
     let capturedCallback: (() => void) | undefined;
     vi.mocked(getNetworkEvent).mockImplementation(
       (eventName: string) =>
         vi.fn((cb: () => void) => {
-          if (eventName === EVENT_NAME_ON_DID_UPDATE_WEB_VIEW)
-            capturedCallback = cb;
+          if (eventName === EVENT_NAME_ON_DID_UPDATE_WEB_VIEW) capturedCallback = cb;
           return vi.fn();
         }) as never,
     );
@@ -353,9 +322,7 @@ describe('useProjectPickerData', () => {
     expect(capturedCallback).toBeDefined();
     act(() => capturedCallback!());
 
-    await waitFor(() =>
-      expect(result.current.currentProject?.fullName).toBe('Updated Project'),
-    );
+    await waitFor(() => expect(result.current.currentProject?.fullName).toBe('Updated Project'));
   });
 });
 /* eslint-enable no-type-assertion/no-type-assertion */

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -158,7 +158,7 @@ describe('useProjectPickerData', () => {
       });
       expect(result.current.currentProject?.id).toBe('proj-abc');
     },
-    { timeout: 15_000 },
+    15_000,
   );
 
   it('returns allProjects from projectLookupService', async () => {

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -136,23 +136,30 @@ describe('useProjectPickerData', () => {
     expect(result.current.currentProject).toBeUndefined();
   });
 
-  it('returns currentProject from the first open Scripture Editor web view', async () => {
-    const { webViews, papiFrontendProjectDataProviderService } = await importMocks();
-    vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
-      { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-abc' },
-    ] as never);
-    vi.mocked(papiFrontendProjectDataProviderService.get).mockResolvedValue({
-      getSetting: vi.fn(async () => 'Genesis Project'),
-    } as never);
+  // asyncUtilTimeout (set in beforeAll) governs RTL's waitFor deadline (5 s). The Vitest
+  // testTimeout must exceed it to leave room for test setup on starved Windows CI runners;
+  // without that margin the test can time out before waitFor even starts polling.
+  it(
+    'returns currentProject from the first open Scripture Editor web view',
+    async () => {
+      const { webViews, papiFrontendProjectDataProviderService } = await importMocks();
+      vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
+        { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-abc' },
+      ] as never);
+      vi.mocked(papiFrontendProjectDataProviderService.get).mockResolvedValue({
+        getSetting: vi.fn(async () => 'Genesis Project'),
+      } as never);
 
-    const { result } = renderHook(() => useProjectPickerData());
+      const { result } = renderHook(() => useProjectPickerData());
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.currentProject?.fullName).toBe('Genesis Project');
-    });
-    expect(result.current.currentProject?.id).toBe('proj-abc');
-  });
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.currentProject?.fullName).toBe('Genesis Project');
+      });
+      expect(result.current.currentProject?.id).toBe('proj-abc');
+    },
+    { timeout: 15_000 },
+  );
 
   it('returns allProjects from projectLookupService', async () => {
     const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -1,4 +1,10 @@
-import { renderHook, waitFor, act, configure, getConfig } from '@testing-library/react';
+import {
+  renderHook,
+  waitFor,
+  act,
+  configure,
+  getConfig,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { EVENT_NAME_ON_DID_UPDATE_WEB_VIEW } from '@shared/services/web-view.service-model';


### PR DESCRIPTION
## Root-cause analysis

The test `useProjectPickerData › returns currentProject from the first open Scripture Editor web view` (`src/renderer/hooks/use-project-picker-data.hook.test.ts:139`) has been timing out on `windows-latest` CI runners twice in the past week:

| Date | Run | SHA | Platform | Result |
|------|-----|-----|----------|--------|
| 2026-06-11 | [27359084151](https://github.com/paranext/paranext-core/actions/runs/27359084151) | `96861c65` | windows-latest | ❌ `Test timed out in 5000ms` |
| 2026-06-16 | [27636725842](https://github.com/paranext/paranext-core/actions/runs/27636725842) | `cdb61fe6` | windows-latest | ❌ `Test timed out in 5000ms` |

In **both** cases the exact same test passed on `ubuntu-22.04` in the same workflow run (same commit SHA, different platform job). This confirms the failure is not a code bug but a Windows runner-starvation flake.

**Why it happens:** The `beforeAll` already raises RTL's `asyncUtilTimeout` to 5 s (from the default 1 s) to handle slow CI runners. However, Vitest's `testTimeout` was still at the global default of 5 s — identical to `asyncUtilTimeout`. Any overhead spent in `importMocks()`, `renderHook()`, and JavaScript microtask scheduling before `waitFor` starts polling eats into that 5 s window, eventually pushing total wall-clock time past the Vitest deadline before `waitFor` can succeed.

The CI logs confirm the timing: `environment 56.21 s` (module setup) and `collect 52.62 s` for the full file, indicating significant Windows I/O overhead that starves the event loop during early test execution.

## Fix

Pass `15_000` (plain number) as the third argument to `it()` for this one test. This raises the Vitest hard deadline to 15 s while RTL's `asyncUtilTimeout` stays at 5 s, giving the test 10 s of headroom for runner setup without changing the semantic assertion window.

Note: this project's Vitest typings accept a plain `number` as the third argument, not an options object — `{ timeout: number }` causes a TS2345 compile error.

No other tests in the file are affected; the per-test option has no global side-effects.

## Flaky test summary (full week scan)

Scanned 23 `Test` workflow runs on `main` from 2026-06-10 → 2026-06-17 (503 total historical runs).

| # | Test | File | Flake rate | Wasted runs |
|---|------|------|-----------|-------------|
| 1 | `useProjectPickerData › returns currentProject from first open Scripture Editor web view` | `src/renderer/hooks/use-project-picker-data.hook.test.ts:139` | ~50 % on Windows | 2 complete CI failures |
| 2 | `UI Interaction › should toggle theme via user profile popover` | `e2e-tests/tests/smoke/ui-interaction.spec.ts:94` | ~13 % (all 3 Playwright retries fail each time) | 2 complete CI failures |
| 3 | `UI Interaction › should open the About dialog via PAPI command` | `e2e-tests/tests/smoke/ui-interaction.spec.ts:78` | ~13 % (Playwright marks "1 flaky" — always passes on first retry) | 0 complete failures |

The two E2E flakes are tracked but not fixed here; they require deeper investigation into the PAPI command timing and theme data provider async update latency in Electron CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hxwnBL6xqyU1wJ4Hwg7iZ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2423)
<!-- Reviewable:end -->
