### PR TITLE
add theme switching to root  storybook

### DIFF
--- a/.storybook/manager.tsx
+++ b/.storybook/manager.tsx
@@ -1,0 +1,4 @@
+// Re-uses the Appearance + Theme toolbar tools registered for the platform-bible-react
+// Storybook. Importing the lib manager triggers its `addons.register(...)` side effect, so
+// the root Storybook gets the same toolbar controls without duplicating the implementation.
+import '../lib/platform-bible-react/.storybook/manager';

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -2,7 +2,10 @@ import type { Preview } from '@storybook/react-webpack5';
 import { fn } from 'storybook/test';
 import React, { useEffect } from 'react';
 import { DocsPageWithFilePath } from './blocks/DocsPageWithFilePath';
+import { withPlatformBibleThemes } from '../lib/platform-bible-react/.storybook/theme-decorator';
 import '../lib/platform-bible-react/src/index.css';
+// Provides the Shadcn Neutral palette referenced by the Theme toolbar (not shipped in index.css).
+import '../lib/platform-bible-react/.storybook/storybook-themes.css';
 
 const preview: Preview = {
   parameters: {
@@ -28,6 +31,10 @@ const preview: Preview = {
   },
 
   decorators: [
+    // Toolbar theme (Appearance + Theme family): applies theme classes on `document.documentElement`
+    // from `localStorage` + the manager channel. See `.storybook/manager.tsx` and the lib's
+    // theme-decorator for details.
+    withPlatformBibleThemes(),
     // Apply Platform.Bible Tailwind preflight wrapper to the iframe's body, and paint the body with
     // the app panel background (`bg-background`/`text-foreground`) so every story renders on the
     // same surface a web view occupies inside an app dock panel — not Storybook's default white.

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -11,6 +11,7 @@
     ".erb/mocks",
     ".erb/scripts",
     ".storybook/**/*.ts",
+    ".storybook/**/*.tsx",
     "src",
     "assets",
     "e2e-tests"


### PR DESCRIPTION
just like storybook in platform-bible-react already has it.

I've seen a little inconstancy with e.g. the verse numbers, but that just means the general theme switch is working and this can be looked at as a follow up (as it was not even possible to view dark mode in storybook earlier)

<img width="1972" height="1405" alt="grafik" src="https://github.com/user-attachments/assets/9ae3e9b9-6da5-47a2-8167-f52db2a5741b" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2424)
<!-- Reviewable:end -->
