### PR TITLE
fix(extension-marketplace): keep MoreInfo dividers centered under Tailwind v4

### DIFF
--- a/lib/platform-bible-react/src/components/advanced/extension-marketplace/more-info.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/extension-marketplace/more-info.component.tsx
@@ -58,27 +58,31 @@ export function MoreInfo({
     window.scrollTo(0, document.body.scrollHeight);
   };
 
+  // Tailwind v4's `divide-x` adds the divider border to the inline-end of each non-last child (v3
+  // added it to the inline-start of each non-first child). Use symmetric horizontal padding
+  // (`tw:px-4`) on the children instead of a parent `tw:gap-4` + per-child `tw:ps-4` so dividers
+  // stay centered between columns rather than hugging the end of each column's content.
   return (
     <div
       id={id}
-      className="pr-twp tw:flex tw:items-center tw:justify-center tw:gap-4 tw:divide-x tw:border-b tw:border-t tw:py-2 tw:text-center"
+      className="pr-twp tw:flex tw:items-center tw:justify-center tw:divide-x tw:border-b tw:border-t tw:py-2 tw:text-center"
     >
       {category && (
-        <div className="tw:flex tw:flex-col tw:items-center tw:gap-1">
+        <div className="tw:flex tw:flex-col tw:items-center tw:gap-1 tw:px-4">
           <div className="tw:flex">
             <span className="tw:text-xs tw:font-semibold tw:text-foreground">{category}</span>
           </div>
           <span className="tw:text-xs tw:text-foreground">CATEGORY</span>
         </div>
       )}
-      <div className="tw:flex tw:flex-col tw:items-center tw:gap-1 tw:ps-4">
+      <div className="tw:flex tw:flex-col tw:items-center tw:gap-1 tw:px-4">
         <div className="tw:flex tw:gap-1">
           <User className="tw:h-4 tw:w-4" />
           <span className="tw:text-xs tw:font-semibold tw:text-foreground">{numberFormatted}</span>
         </div>
         <span className="tw:text-xs tw:text-foreground">USERS</span>
       </div>
-      <div className="tw:flex tw:flex-col tw:items-center tw:gap-1 tw:ps-4">
+      <div className="tw:flex tw:flex-col tw:items-center tw:gap-1 tw:px-4">
         <div className="tw:flex tw:gap-2">
           {languages.slice(0, 3).map((locale) => (
             <span key={locale} className="tw:text-xs tw:font-semibold tw:text-foreground">
@@ -97,7 +101,7 @@ export function MoreInfo({
         )}
       </div>
       {(moreInfoUrl || supportUrl) && (
-        <div className="tw:flex tw:flex-col tw:gap-1 tw:ps-4">
+        <div className="tw:flex tw:flex-col tw:gap-1 tw:px-4">
           {moreInfoUrl && (
             <div className="tw:flex tw:gap-1">
               <Button


### PR DESCRIPTION
Fix Extension Marketplace More Info component after Tailwind 4 upgrade.

Before:

<img width="431" height="97" alt="image" src="https://github.com/user-attachments/assets/d0020bbc-740c-4910-856b-2967e43971e3" />

After:

<img width="445" height="96" alt="image" src="https://github.com/user-attachments/assets/dacdfd13-3eef-46fc-a374-3705bb7bb47d" />




## Problem

In the extension-marketplace details drawer, the `MoreInfo` row (category / users / languages / links) renders its vertical dividers hugging the **right edge** of each column's content instead of sitting centered between columns.

## Root cause

Tailwind v4 changed the `divide-x` selector:

```css
/* v3 */ .divide-x > :not([hidden]) ~ :not([hidden]) { border-left-width }      /* inline-start of each non-first child */
/* v4 */ .divide-x > :not(:last-child)               { border-inline-end-width } /* inline-end of each non-last child */
```

`MoreInfo` pairs `divide-x` with a parent `gap-4` and per-child `ps-4` (inline-start padding). Under v3 the border landed on the start of each child, centered in the `gap`/`ps` trough. Under v4 the border moved to the **inline-end** of each child while the padding stayed on the inline-start, so all the spacing now lands on one side and the divider hugs the end of each column's content.

The Tailwind v4 upgrade guide explicitly calls this out: the `divide-*` selector change "might observe changes" for "projects using these utilities with custom margins/padding on children."

## Fix

Drop the parent `gap-4` and give each child symmetric horizontal padding (`px-4`) so each divider has equal space on both sides and stays centered between columns. No visual change in spacing magnitude — only the divider position is corrected. Added a comment documenting the v4 nuance.

## Notes

- Found while updating the internal extensions for the React 19 / Tailwind 4 / shadcn upgrade.
- `Footer` in the same drawer was also reviewed; its only issue was extension-side data (an empty version string), which is fixed in the extension repo, not here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2426)
<!-- Reviewable:end -->
