### PR TITLE
PT-4010: Register platformScripture.structureProtected project setting

### DIFF
--- a/c-sharp/Services/ProjectSettingsNames.cs
+++ b/c-sharp/Services/ProjectSettingsNames.cs
@@ -105,8 +105,16 @@ public sealed class ProjectSettingsNames
         "platformScripture.referencedProjectsAndResources";
     public const string PT_REFERENCED_PROJECTS_AND_RESOURCES = "ReferencedProjectsAndResources";
 
-    public const string PB_STRUCTURE_PROTECTION = "platformScripture.structureProtection";
-    public const string PT_STRUCTURE_PROTECTION = "PlatformBibleStructureProtection";
+    /// <summary>
+    /// Whether the paragraph/verse structure of this project is protected from changes. A project
+    /// Admin may define a structure for the translated Scripture text or adopt the structure of a
+    /// model text to provide consistency and ensure the acceptability of the published text. When
+    /// true, other team members cannot change the structure of the translated text. The Admin can
+    /// set this to false to temporarily allow structural changes. Stored in Paratext's Settings.xml
+    /// as "StructureProtected".
+    /// </summary>
+    public const string PB_STRUCTURE_PROTECTED = "platformScripture.structureProtected";
+    public const string PT_STRUCTURE_PROTECTED = "StructureProtected";
 
     /// <summary>
     /// Paratext setting names that are either T or F and need to be converted to booleans
@@ -118,7 +126,7 @@ public sealed class ProjectSettingsNames
         "AllowReadAccess",
         "AllowSharingWithSLDR",
         "AllowInvisibleChars",
-        "PlatformBibleStructureProtection",
+        "StructureProtected",
     ];
 
     // Make sure this dictionary gets updated whenever new settings are added
@@ -144,7 +152,7 @@ public sealed class ProjectSettingsNames
             { PB_ALLOW_INVISIBLE_CHARACTERS, PT_ALLOW_INVISIBLE_CHARACTERS },
             { PB_MODEL_TEXTS, PT_MODEL_TEXTS },
             { PB_REFERENCED_PROJECTS_AND_RESOURCES, PT_REFERENCED_PROJECTS_AND_RESOURCES },
-            { PB_STRUCTURE_PROTECTION, PT_STRUCTURE_PROTECTION },
+            { PB_STRUCTURE_PROTECTED, PT_STRUCTURE_PROTECTED },
         };
 
     private static readonly Dictionary<string, string> s_paratextToPlatformBibleSettingsNames =

--- a/c-sharp/Services/ProjectSettingsNames.cs
+++ b/c-sharp/Services/ProjectSettingsNames.cs
@@ -105,6 +105,9 @@ public sealed class ProjectSettingsNames
         "platformScripture.referencedProjectsAndResources";
     public const string PT_REFERENCED_PROJECTS_AND_RESOURCES = "ReferencedProjectsAndResources";
 
+    public const string PB_STRUCTURE_PROTECTION = "platformScripture.structureProtection";
+    public const string PT_STRUCTURE_PROTECTION = "PlatformBibleStructureProtection";
+
     /// <summary>
     /// Paratext setting names that are either T or F and need to be converted to booleans
     /// </summary>
@@ -115,6 +118,7 @@ public sealed class ProjectSettingsNames
         "AllowReadAccess",
         "AllowSharingWithSLDR",
         "AllowInvisibleChars",
+        "PlatformBibleStructureProtection",
     ];
 
     // Make sure this dictionary gets updated whenever new settings are added
@@ -128,6 +132,7 @@ public sealed class ProjectSettingsNames
             { PB_NAME, PT_NAME },
             { PB_VERSIFICATION, PT_VERSIFICATION },
             { PB_IS_EDITABLE, PT_IS_EDITABLE },
+            { PB_STRUCTURE_PROTECTION, PT_STRUCTURE_PROTECTION },
             { PB_TEXT_DIRECTION, PT_TEXT_DIRECTION },
             { PB_VALID_CHARACTERS, PT_VALID_CHARACTERS },
             { PB_INVALID_CHARACTERS, PT_INVALID_CHARACTERS },

--- a/c-sharp/Services/ProjectSettingsNames.cs
+++ b/c-sharp/Services/ProjectSettingsNames.cs
@@ -132,7 +132,6 @@ public sealed class ProjectSettingsNames
             { PB_NAME, PT_NAME },
             { PB_VERSIFICATION, PT_VERSIFICATION },
             { PB_IS_EDITABLE, PT_IS_EDITABLE },
-            { PB_STRUCTURE_PROTECTION, PT_STRUCTURE_PROTECTION },
             { PB_TEXT_DIRECTION, PT_TEXT_DIRECTION },
             { PB_VALID_CHARACTERS, PT_VALID_CHARACTERS },
             { PB_INVALID_CHARACTERS, PT_INVALID_CHARACTERS },
@@ -145,6 +144,7 @@ public sealed class ProjectSettingsNames
             { PB_ALLOW_INVISIBLE_CHARACTERS, PT_ALLOW_INVISIBLE_CHARACTERS },
             { PB_MODEL_TEXTS, PT_MODEL_TEXTS },
             { PB_REFERENCED_PROJECTS_AND_RESOURCES, PT_REFERENCED_PROJECTS_AND_RESOURCES },
+            { PB_STRUCTURE_PROTECTION, PT_STRUCTURE_PROTECTION },
         };
 
     private static readonly Dictionary<string, string> s_paratextToPlatformBibleSettingsNames =

--- a/extensions/src/platform-scripture/contributions/localizedStrings.json
+++ b/extensions/src/platform-scripture/contributions/localizedStrings.json
@@ -358,8 +358,6 @@
       "%project_settings_platformScripture_referencedProjectsAndResources_label%": "Referenced Projects and Resources",
       "%project_settings_platformScripture_repeatableWords_description%": "List of words that are allowed to be repeated in this project.",
       "%project_settings_platformScripture_repeatableWords_label%": "Repeatable Words",
-      "%project_settings_platformScripture_structureProtection_description%": "Whether the paragraph structure of this project is protected from changes",
-      "%project_settings_platformScripture_structureProtection_label%": "Structure Protection",
       "%project_settings_platformScripture_validCharacters_description%": "List of characters that are accepted in this project.",
       "%project_settings_platformScripture_validCharacters_label%": "Valid Characters",
       "%project_settings_platformScripture_validMarkers_description%": "List of markers that are accepted in this project.",

--- a/extensions/src/platform-scripture/contributions/localizedStrings.json
+++ b/extensions/src/platform-scripture/contributions/localizedStrings.json
@@ -358,6 +358,8 @@
       "%project_settings_platformScripture_referencedProjectsAndResources_label%": "Referenced Projects and Resources",
       "%project_settings_platformScripture_repeatableWords_description%": "List of words that are allowed to be repeated in this project.",
       "%project_settings_platformScripture_repeatableWords_label%": "Repeatable Words",
+      "%project_settings_platformScripture_structureProtection_description%": "Whether the paragraph structure of this project is protected from changes",
+      "%project_settings_platformScripture_structureProtection_label%": "Structure Protection",
       "%project_settings_platformScripture_validCharacters_description%": "List of characters that are accepted in this project.",
       "%project_settings_platformScripture_validCharacters_label%": "Valid Characters",
       "%project_settings_platformScripture_validMarkers_description%": "List of markers that are accepted in this project.",

--- a/extensions/src/platform-scripture/contributions/projectSettings.json
+++ b/extensions/src/platform-scripture/contributions/projectSettings.json
@@ -105,6 +105,12 @@
         "default": { "dataVersion": "1.0.0", "items": [] },
         "isHidden": true,
         "includeProjectInterfaces": ["Paratext", "Scripture"]
+      },
+      "platformScripture.structureProtection": {
+        "label": "%project_settings_platformScripture_structureProtection_label%",
+        "description": "%project_settings_platformScripture_structureProtection_description%",
+        "default": false,
+        "includeProjectInterfaces": ["Paratext", "Scripture"]
       }
     }
   }

--- a/extensions/src/platform-scripture/contributions/projectSettings.json
+++ b/extensions/src/platform-scripture/contributions/projectSettings.json
@@ -109,6 +109,7 @@
       "platformScripture.structureProtection": {
         "label": "%project_settings_platformScripture_structureProtection_label%",
         "description": "%project_settings_platformScripture_structureProtection_description%",
+        "isHidden": true,
         "default": false,
         "includeProjectInterfaces": ["Paratext", "Scripture"]
       }

--- a/extensions/src/platform-scripture/contributions/projectSettings.json
+++ b/extensions/src/platform-scripture/contributions/projectSettings.json
@@ -106,9 +106,7 @@
         "isHidden": true,
         "includeProjectInterfaces": ["Paratext", "Scripture"]
       },
-      "platformScripture.structureProtection": {
-        "label": "%project_settings_platformScripture_structureProtection_label%",
-        "description": "%project_settings_platformScripture_structureProtection_description%",
+      "platformScripture.structureProtected": {
         "isHidden": true,
         "default": false,
         "includeProjectInterfaces": ["Paratext", "Scripture"]

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -65,6 +65,7 @@ const versificationValidator: ProjectSettingValidator<'platformScripture.versifi
   return valueAsNumber >= 0 && valueAsNumber <= 6 && Number.isInteger(valueAsNumber);
 };
 
+// C# converts Paratext's "T"/"F" to boolean before it reaches this validator
 const structureProtectionValidator: ProjectSettingValidator<
   'platformScripture.structureProtection'
 > = async (newValue: unknown) => typeof newValue === 'boolean';

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -66,8 +66,8 @@ const versificationValidator: ProjectSettingValidator<'platformScripture.versifi
 };
 
 // C# converts Paratext's "T"/"F" to boolean before it reaches this validator
-const structureProtectionValidator: ProjectSettingValidator<
-  'platformScripture.structureProtection'
+const structureProtectedValidator: ProjectSettingValidator<
+  'platformScripture.structureProtected'
 > = async (newValue: unknown) => typeof newValue === 'boolean';
 
 // A character can be any string value
@@ -383,9 +383,9 @@ export async function activate(context: ExecutionActivationContext) {
     'platformScripture.versification',
     versificationValidator,
   );
-  const structureProtectionPromise = papi.projectSettings.registerValidator(
-    'platformScripture.structureProtection',
-    structureProtectionValidator,
+  const structureProtectedPromise = papi.projectSettings.registerValidator(
+    'platformScripture.structureProtected',
+    structureProtectedValidator,
   );
   const validCharactersPromise = papi.projectSettings.registerValidator(
     'platformScripture.validCharacters',
@@ -703,7 +703,7 @@ export async function activate(context: ExecutionActivationContext) {
     await scriptureFinderPdpefPromise,
     await booksPresentPromise,
     await versificationPromise,
-    await structureProtectionPromise,
+    await structureProtectedPromise,
     await validCharactersPromise,
     await invalidCharactersPromise,
     await openCharactersInventoryPromise,

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -65,6 +65,10 @@ const versificationValidator: ProjectSettingValidator<'platformScripture.versifi
   return valueAsNumber >= 0 && valueAsNumber <= 6 && Number.isInteger(valueAsNumber);
 };
 
+const structureProtectionValidator: ProjectSettingValidator<
+  'platformScripture.structureProtection'
+> = async (newValue: unknown) => typeof newValue === 'boolean';
+
 // A character can be any string value
 const charactersValidator: ProjectSettingValidator<
   'platformScripture.validCharacters' | 'platformScripture.invalidCharacters'
@@ -377,6 +381,10 @@ export async function activate(context: ExecutionActivationContext) {
   const versificationPromise = papi.projectSettings.registerValidator(
     'platformScripture.versification',
     versificationValidator,
+  );
+  const structureProtectionPromise = papi.projectSettings.registerValidator(
+    'platformScripture.structureProtection',
+    structureProtectionValidator,
   );
   const validCharactersPromise = papi.projectSettings.registerValidator(
     'platformScripture.validCharacters',
@@ -694,6 +702,7 @@ export async function activate(context: ExecutionActivationContext) {
     await scriptureFinderPdpefPromise,
     await booksPresentPromise,
     await versificationPromise,
+    await structureProtectionPromise,
     await validCharactersPromise,
     await invalidCharactersPromise,
     await openCharactersInventoryPromise,

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2380,6 +2380,9 @@ declare module 'papi-shared-types' {
      * tilde character, not a whitespace substitute.
      */
     'platformScripture.allowInvisibleCharacters': boolean;
+
+    /** Whether the paragraph structure of this project is protected from changes */
+    'platformScripture.structureProtection': boolean;
   }
 
   export interface NetworkEvents {

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2381,8 +2381,18 @@ declare module 'papi-shared-types' {
      */
     'platformScripture.allowInvisibleCharacters': boolean;
 
-    /** Whether the paragraph structure of this project is protected from changes */
-    'platformScripture.structureProtection': boolean;
+    /**
+     * Whether the paragraph/verse structure of this project is protected from changes.
+     *
+     * A project Admin may define a structure for the translated scripture text or adopt the
+     * structure of a model text to provide consistency and ensure the acceptability of the
+     * published text. When `true`, team members other than the Admin cannot intentionally or
+     * unintentionally change that structure. The Admin can set this to `false` to temporarily allow
+     * structural changes when needed.
+     *
+     * Corresponds to the `StructureProtected` field in Paratext's `Settings.xml`.
+     */
+    'platformScripture.structureProtected': boolean;
   }
 
   export interface NetworkEvents {


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-4010-structure-protection

**Base**: origin/main

**Date**: 2026-06-17

**Review model**: Claude Sonnet 4.6

**Files changed**: 5

## Overview

These changes register `platformScripture.structureProtected` as a hidden boolean project setting (default `false`) that syncs to Paratext's `Settings.xml` as `StructureProtected` via Send/Receive. The feature implements a PRD requirement: a project Admin needs to be able to protect the paragraph/verse structure of the translated scripture text so that other team members cannot accidentally or intentionally change it. The Admin can also temporarily unprotect it when intentional structural changes are needed.

The implementation follows the same full wiring pattern as the closely analogous `platformScripture.allowInvisibleCharacters` setting: C# constants, boolean T/F-to-boolean conversion registration, bidirectional name mapping for Send/Receive, TypeScript type declaration, `projectSettings.json` contribution, and a registered PAPI validator. The setting is marked `isHidden: true` throughout, so no UI label or description is exposed. During the review, the PAPI key was renamed from `structureProtection` to `structureProtected` and the Paratext setting name from `PlatformBibleStructureProtection` to `StructureProtected` to better match the adjectival naming style of existing Paratext settings.

## API Changes

- `extensions/src/platform-scripture/src/types/platform-scripture.d.ts` (`papi-shared-types` augmentation): Added `'platformScripture.structureProtected': boolean` to `ProjectSettingTypes`

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] `extensions/src/platform-scripture/contributions/localizedStrings.json` — The new `structureProtected` label and description strings existed only in the English (`en`) locale section, with no Spanish translations. Other comparable hidden settings have Spanish translations, and the gap could be forgotten when the setting is un-hidden. _(fixed during review: author decided to remove all UI localization strings entirely since the setting is fully hidden; `label` and `description` fields were also removed from `projectSettings.json` to avoid dangling `%…%` references)_

### Minor — Consider

- [ ] `c-sharp/Services/ProjectSettingsNames.cs` — The Paratext-side setting name `StructureProtected` was not discussed with the PT9/Paratext team. Author notes it is hard to imagine this setting meaning anything outside the Platform.Bible/PT10 environment, but a more generic name may still be preferable. **Alternatives for reviewer consideration**: `StructureLocked`, `ProtectStructure`, `LockStructure`, `PreventStructuralChanges`. The rename away from `PlatformBibleStructureProtection` was made during review because existing Paratext settings tend to use verb-first or adjectival names.

- [x] `extensions/src/platform-scripture/src/types/platform-scripture.d.ts` — The JSDoc for `'platformScripture.structureProtected'` was a single brief line with no explanation of the Admin's role, the model-text use case, or the true/false semantics. _(fixed during review: expanded to explain Admin role, model-text use case, true/false behavior, and corresponding `Settings.xml` field name, drawing on PRD wording)_

- [x] `c-sharp/Services/ProjectSettingsNames.cs` — The `PB_STRUCTURE_PROTECTED` / `PT_STRUCTURE_PROTECTED` constant pair lacked an XML `<summary>` doc comment, while several neighboring pairs have one. _(fixed during review: added XML doc comment with PRD-derived semantics)_

- [x] `extensions/src/platform-scripture/contributions/localizedStrings.json` — The description string was missing a trailing period, inconsistent with all other description strings in the file. _(fixed during review: moot — the string was removed entirely)_

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- The implementation follows the full wiring pattern correctly and completely across all five layers (C# constants, boolean conversion set, bidirectional name mapping, TypeScript type, `projectSettings.json`, validator) — nothing is missing.
- The analogous `allowInvisibleCharacters` setting serves as an ideal side-by-side comparison, making correctness easy to verify.
- The validator comment ("C# converts Paratext's 'T'/'F' to boolean before it reaches this validator") correctly documents an important cross-process contract that would otherwise be non-obvious to TypeScript readers.
- `isHidden: true` is consistent with `allowInvisibleCharacters` and appropriate for a setting not yet exposed in any UI.
- The `awaitPromise` placement in `context.registrations.add` is correct alongside the other setting validator promises.

## Interview Notes

**Stated purpose**: Register the structure-protection project setting from the PRD. A project Admin may define a paragraph/verse structure for the translated scripture text (or adopt it from a model text) to ensure consistency and acceptability of the published text. Other team members may change that structure unintentionally. The setting lets the Admin protect it, with the ability to temporarily unprotect it for intentional structural changes.

**Localization strings removed**: Author decided the setting does not need to appear in any settings UI at this stage. All UI strings were removed, and `label`/`description` were stripped from the `projectSettings.json` entry to avoid unresolved `%…%` references.

**PT setting name renamed**: `PlatformBibleStructureProtection` → `StructureProtected`. Author flagged that the original name was unusual and had not been discussed with the PT9 team. Agreed a more generic adjectival name is better. Reviewer should confirm the final name.

**PAPI key renamed**: `platformScripture.structureProtection` → `platformScripture.structureProtected` for consistency with the adjectival rename.

**C# constant renamed**: `PB_STRUCTURE_PROTECTION`/`PT_STRUCTURE_PROTECTION` → `PB_STRUCTURE_PROTECTED`/`PT_STRUCTURE_PROTECTED` for symmetry.

## In-Review Quality Check

Changes were made during the review across all five files. All checks passed.

- **TypeCheck**: One pre-existing error in `platform-scripture-editor` (`PARAGRAPH_STRUCTURE_VIEW_MODE` not exported) — confirmed pre-existing, unrelated to this branch.
- **Lint**: PASSED after one auto-fix — expanded JSDoc in `platform-scripture.d.ts` needed word-wrap reformatting. Staged automatically.
- **Format**: PASSED — no net changes to any in-review files.
- **Tests**: PASSED for all tests relevant to the in-review changes. 45 pre-existing parallel-environment failures confirmed unrelated to this branch.

## Suggested Review Focus

- [ ] **Paratext setting name `StructureProtected`** — was not discussed with the PT9/Paratext team. Is this the right name? Alternatives: `StructureLocked`, `ProtectStructure`, `LockStructure`, `PreventStructuralChanges`. The choice determines what key is written to `Settings.xml` and must align with whatever PT9 uses or will use.
- [ ] **No `label`/`description` in `projectSettings.json`** — confirm it is acceptable for a hidden setting to omit these fields entirely; check that schema validation and any settings infrastructure that iterates registered settings handles the absence gracefully.
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2430)
<!-- Reviewable:end -->
