### PR TITLE
Add typescript-language-server devDependency for Claude Code LSP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,6 +159,7 @@
         "tw-animate-css": "^1.0.0",
         "typedoc": "^0.28.3",
         "typescript": "^5.8.3",
+        "typescript-language-server": "^5.3.0",
         "url-loader": "^4.1.1",
         "vite": "^6.4.2",
         "vite-tsconfig-paths": "^5.1.4",
@@ -30459,6 +30460,19 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-language-server": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/typescript-language-server/-/typescript-language-server-5.3.0.tgz",
+      "integrity": "sha512-5puofxZHgFdAYtfNpmwCAvgtaYgg8wrUnH30m7Ze3QuguId5RNRadKASpOpyDxTyUdAF51FjhTdjntLw/EuWcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "typescript-language-server": "lib/cli.mjs"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/uc.micro": {

--- a/package.json
+++ b/package.json
@@ -269,6 +269,7 @@
     "tw-animate-css": "^1.0.0",
     "typedoc": "^0.28.3",
     "typescript": "^5.8.3",
+    "typescript-language-server": "^5.3.0",
     "url-loader": "^4.1.1",
     "vite": "^6.4.2",
     "vite-tsconfig-paths": "^5.1.4",


### PR DESCRIPTION
Adds `typescript-language-server` (`^5.3.0`) as a root devDependency.

## Why

The `ai-prompts` `general` Claude Code profile ships a committed `typescript-lsp-volta` plugin (paranext/ai-prompts#328) that launches a TypeScript language server via `node` against the **repo-local** `typescript-language-server`, giving Claude Code cross-platform code intelligence (go-to-definition, find-references, post-edit diagnostics) that works under Volta on Windows where the official plugin fails (`ENOENT`). This dependency is what makes the server resolvable in every dev's checkout via a normal `npm install` — no global install.

## Scope / impact

- `package.json` + `package-lock.json` only.
- devDependency, so **no runtime/app/bundle impact**; it's used solely by the local Claude Code tooling.

## Verification

After `npm install`, `node -e "require.resolve('typescript-language-server')"` resolves from the repo root, and the ai-prompts plugin's shell-free launch was verified end-to-end on Windows + Volta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2431)
<!-- Reviewable:end -->
