### PR TITLE
Add test & typecheck to platform-enhanced-resources

### DIFF
--- a/extensions/package.json
+++ b/extensions/package.json
@@ -27,6 +27,7 @@
     "lint-fix:scripts": "prettier --write \"**/*.{ts,tsx,js,jsx,cjs}\" && npm run lint:scripts -- --fix",
     "lint-fix:styles": "npm run lint:styles -- --fix",
     "lint:staged": "lint-staged -q",
+    "test": "vitest",
     "postinstall": "tsx ./lib/add-remotes.ts",
     "create-extension": "tsx ./lib/create-extension.ts",
     "update-from-templates": "tsx ./lib/update-from-templates.ts",

--- a/extensions/package.json
+++ b/extensions/package.json
@@ -27,7 +27,6 @@
     "lint-fix:scripts": "prettier --write \"**/*.{ts,tsx,js,jsx,cjs}\" && npm run lint:scripts -- --fix",
     "lint-fix:styles": "npm run lint:styles -- --fix",
     "lint:staged": "lint-staged -q",
-    "test": "vitest",
     "postinstall": "tsx ./lib/add-remotes.ts",
     "create-extension": "tsx ./lib/create-extension.ts",
     "update-from-templates": "tsx ./lib/update-from-templates.ts",

--- a/extensions/src/platform-enhanced-resources/package.json
+++ b/extensions/src/platform-enhanced-resources/package.json
@@ -26,7 +26,9 @@
     "lint:styles": "stylelint **/*.{css,scss} --allow-empty-input",
     "lint-fix": "npm run lint-fix:scripts && npm run lint:styles -- --fix",
     "lint-fix:scripts": "npm run format && npm run lint:scripts",
-    "bump-versions": "ts-node ./lib/bump-versions.ts"
+    "bump-versions": "ts-node ./lib/bump-versions.ts",
+    "test": "vitest",
+    "typecheck": "tsc -p ./tsconfig.json"
   },
   "browserslist": [],
   "peerDependencies": {


### PR DESCRIPTION
Go to a successful test run on `main`, expand
- "type checking" (e.g., https://github.com/paranext/paranext-core/actions/runs/27767097355/job/82156688190#step:15:1) or
- "npm unit tests" (e.g., https://github.com/paranext/paranext-core/actions/runs/27767097355/job/82156688190#step:21:1),

and search the logs for `platform-enhanced-resources` ... no hits.

On this pr, you now see both:
- "type checking": https://github.com/paranext/paranext-core/actions/runs/27772201446/job/82174882850?pr=2433#step:15:66
- "npm unit tests": https://github.com/paranext/paranext-core/actions/runs/27772201446/job/82174882850?pr=2433#step:21:8261

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2433)
<!-- Reviewable:end -->

Devin review: https://app.devin.ai/review/paranext/paranext-core/pull/2433