### PR TITLE
Conditional autosync on startup

### DIFF
--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -91,9 +91,20 @@ internal class ParatextProjectSendReceiveService(
     /// </param>
     protected void SyncProjects(String[]? projectIds)
     {
+#if DEBUG
+        // Dev-only placeholder: paranext-core has no S/R impl. PT10 patches the whole method.
+        NotificationService.Send(
+            papiClient,
+            new("Syncing projects… (dev placeholder)", NotificationSeverity.Info)
+            {
+                Duration = 3000,
+            }
+        );
+#else
         throw new PlatformUnimplementedException(
             $"Command '{nameof(SyncProjects)}' is not implemented in Platform.Bible. Must be running Paratext 10 Studio to use this command."
         );
+#endif
     }
 
     /// <summary>

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -229,10 +229,15 @@ async function main() {
 
   // Fire-and-forget startup tasks (e.g. simple-mode initial S/R). Must not block window creation.
   // The S/R command is registered by the .NET data provider, which may not yet be reachable;
-  // performStartupTasks uses retrying request semantics and swallows failures.
-  performStartupTasks().catch((e) =>
-    logger.error(`performStartupTasks threw unexpectedly: ${getErrorMessage(e)}`),
-  );
+  // performStartupTasks uses retrying sendCommand semantics and swallows failures internally.
+  // Wrapped in an async IIFE per code-style preference for try/catch over `.catch()` chains.
+  (async () => {
+    try {
+      await performStartupTasks();
+    } catch (e) {
+      logger.warn(`performStartupTasks threw unexpectedly: ${getErrorMessage(e)}`);
+    }
+  })();
 
   // Keep a global reference of the window object. If you don't, the window will
   // be closed automatically when the JavaScript object is garbage collected.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -29,6 +29,7 @@ import { extensionHostService } from '@main/services/extension-host.service';
 import { startNetworkObjectStatusService } from '@main/services/network-object-status.service-host';
 import { startProjectLookupService } from '@main/services/project-lookup.service-host';
 import { performShutdownTasks } from '@main/shutdown-tasks';
+import { performStartupTasks } from '@main/startup-tasks';
 import { HANDLE_URI_REQUEST_TYPE } from '@node/services/extension.service-model';
 import {
   CommandLineArgs,
@@ -225,6 +226,13 @@ async function main() {
 
   // TODO (maybe): Wait for signal from the extension host process that it is ready (except 'getWebView')
   // We could then wait for the renderer to be ready and signal the extension host
+
+  // Fire-and-forget startup tasks (e.g. simple-mode initial S/R). Must not block window creation.
+  // The S/R command is registered by the .NET data provider, which may not yet be reachable;
+  // performStartupTasks uses retrying request semantics and swallows failures.
+  performStartupTasks().catch((e) =>
+    logger.error(`performStartupTasks threw unexpectedly: ${getErrorMessage(e)}`),
+  );
 
   // Keep a global reference of the window object. If you don't, the window will
   // be closed automatically when the JavaScript object is garbage collected.

--- a/src/main/startup-tasks.test.ts
+++ b/src/main/startup-tasks.test.ts
@@ -1,0 +1,58 @@
+import { vi } from 'vitest';
+import { settingsService } from '@shared/services/settings.service';
+import * as networkService from '@shared/services/network.service';
+import { performStartupTasks } from './startup-tasks';
+
+vi.mock('@shared/services/settings.service', () => ({
+  settingsService: { get: vi.fn() },
+}));
+
+vi.mock('@shared/services/network.service', () => ({
+  request: vi.fn(),
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const mockSettingsGet = vi.mocked(settingsService.get);
+const mockRequest = vi.mocked(networkService.request);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequest.mockResolvedValue(undefined);
+});
+
+describe('performStartupTasks', () => {
+  it('returns without firing sync when interface mode is power', async () => {
+    mockSettingsGet.mockResolvedValue('power');
+    await performStartupTasks();
+    expect(mockRequest).not.toHaveBeenCalled();
+  });
+
+  it('fires syncProjects with no project IDs when interface mode is simple', async () => {
+    mockSettingsGet.mockResolvedValue('simple');
+    await performStartupTasks();
+    expect(mockRequest).toHaveBeenCalledWith(expect.stringContaining('syncProjects'), undefined);
+  });
+
+  it('fires syncProjects (simple-mode fallback) when settings service throws', async () => {
+    mockSettingsGet.mockRejectedValue(new Error('settings unavailable'));
+    await performStartupTasks();
+    expect(mockRequest).toHaveBeenCalledWith(expect.stringContaining('syncProjects'), undefined);
+  });
+
+  it('swallows sync failures without throwing', async () => {
+    mockSettingsGet.mockResolvedValue('simple');
+    mockRequest.mockRejectedValue(new Error('sync command not registered'));
+    await expect(performStartupTasks()).resolves.toBeUndefined();
+  });
+
+  it('swallows unexpected errors and does not throw', async () => {
+    mockSettingsGet.mockResolvedValue('simple');
+    mockRequest.mockImplementation(() => {
+      throw new Error('unexpected non-async throw');
+    });
+    await expect(performStartupTasks()).resolves.toBeUndefined();
+  });
+});

--- a/src/main/startup-tasks.test.ts
+++ b/src/main/startup-tasks.test.ts
@@ -12,7 +12,7 @@ vi.mock('@shared/services/network.service', () => ({
 }));
 
 vi.mock('@shared/services/logger.service', () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
 const mockSettingsGet = vi.mocked(settingsService.get);

--- a/src/main/startup-tasks.test.ts
+++ b/src/main/startup-tasks.test.ts
@@ -1,14 +1,14 @@
 import { vi } from 'vitest';
 import { settingsService } from '@shared/services/settings.service';
-import * as networkService from '@shared/services/network.service';
+import * as commandService from '@shared/services/command.service';
 import { performStartupTasks } from './startup-tasks';
 
 vi.mock('@shared/services/settings.service', () => ({
   settingsService: { get: vi.fn() },
 }));
 
-vi.mock('@shared/services/network.service', () => ({
-  request: vi.fn(),
+vi.mock('@shared/services/command.service', () => ({
+  sendCommand: vi.fn(),
 }));
 
 vi.mock('@shared/services/logger.service', () => ({
@@ -16,41 +16,47 @@ vi.mock('@shared/services/logger.service', () => ({
 }));
 
 const mockSettingsGet = vi.mocked(settingsService.get);
-const mockRequest = vi.mocked(networkService.request);
+const mockSendCommand = vi.mocked(commandService.sendCommand);
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockRequest.mockResolvedValue(undefined);
+  mockSendCommand.mockResolvedValue(undefined);
 });
 
 describe('performStartupTasks', () => {
   it('returns without firing sync when interface mode is power', async () => {
     mockSettingsGet.mockResolvedValue('power');
     await performStartupTasks();
-    expect(mockRequest).not.toHaveBeenCalled();
+    expect(mockSendCommand).not.toHaveBeenCalled();
   });
 
   it('fires syncProjects with no project IDs when interface mode is simple', async () => {
     mockSettingsGet.mockResolvedValue('simple');
     await performStartupTasks();
-    expect(mockRequest).toHaveBeenCalledWith(expect.stringContaining('syncProjects'), undefined);
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      'paratextBibleSendReceive.syncProjects',
+      undefined,
+    );
   });
 
   it('fires syncProjects (simple-mode fallback) when settings service throws', async () => {
     mockSettingsGet.mockRejectedValue(new Error('settings unavailable'));
     await performStartupTasks();
-    expect(mockRequest).toHaveBeenCalledWith(expect.stringContaining('syncProjects'), undefined);
+    expect(mockSendCommand).toHaveBeenCalledWith(
+      'paratextBibleSendReceive.syncProjects',
+      undefined,
+    );
   });
 
   it('swallows sync failures without throwing', async () => {
     mockSettingsGet.mockResolvedValue('simple');
-    mockRequest.mockRejectedValue(new Error('sync command not registered'));
+    mockSendCommand.mockRejectedValue(new Error('sync command not registered'));
     await expect(performStartupTasks()).resolves.toBeUndefined();
   });
 
   it('swallows unexpected errors and does not throw', async () => {
     mockSettingsGet.mockResolvedValue('simple');
-    mockRequest.mockImplementation(() => {
+    mockSendCommand.mockImplementation(() => {
       throw new Error('unexpected non-async throw');
     });
     await expect(performStartupTasks()).resolves.toBeUndefined();

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -25,6 +25,8 @@ export async function performStartupTasks(): Promise<void> {
 }
 
 async function performStartupTasksInternal(): Promise<void> {
+  logger.info('performStartupTasks invoked');
+
   // Power mode: no automatic sync on startup.
   // If the setting can't be read, default to simple mode to avoid skipping sync.
   let interfaceMode: string | undefined;
@@ -33,6 +35,7 @@ async function performStartupTasksInternal(): Promise<void> {
   } catch {
     /* settings service unavailable — treat as simple mode */
   }
+  logger.info(`performStartupTasks: interfaceMode=${interfaceMode}`);
   if (interfaceMode !== undefined && interfaceMode !== 'simple') return;
 
   // Simple mode: sync all locally-known shared projects (no project IDs = "sync all" per the

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -1,8 +1,7 @@
-import { CATEGORY_COMMAND } from '@shared/data/rpc.model';
+import * as commandService from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
-import * as networkService from '@shared/services/network.service';
 import { settingsService } from '@shared/services/settings.service';
-import { serializeRequestType } from '@shared/utils/util';
+import { getErrorMessage } from 'platform-bible-utils';
 
 /**
  * Runs initialization tasks (currently: triggering an initial project sync) shortly after the app
@@ -20,7 +19,7 @@ export async function performStartupTasks(): Promise<void> {
   try {
     await performStartupTasksInternal();
   } catch (e) {
-    logger.error('Unexpected error during startup tasks:', e);
+    logger.warn(`Unexpected error during startup tasks: ${getErrorMessage(e)}`);
   }
 }
 
@@ -32,25 +31,26 @@ async function performStartupTasksInternal(): Promise<void> {
   let interfaceMode: string | undefined;
   try {
     interfaceMode = await settingsService.get('platform.interfaceMode');
-  } catch {
-    /* settings service unavailable — treat as simple mode */
+  } catch (e) {
+    logger.warn(
+      `Could not read platform.interfaceMode; defaulting to simple-mode behavior: ${getErrorMessage(e)}`,
+    );
   }
   logger.debug(`performStartupTasks: interfaceMode=${interfaceMode}`);
   if (interfaceMode !== undefined && interfaceMode !== 'simple') return;
 
   // Simple mode: sync all locally-known shared projects (no project IDs = "sync all" per the
-  // C# `String[]? projectIds` contract). Uses `request` (with retry on missing handler), not
-  // `requestNoRetry`, because the C# S/R command registers asynchronously during startup; this
-  // call may race ahead of it. `undefined` as the single arg serializes as `null` in the
-  // JSON-RPC params array — matching the "sync all" sentinel on the C# side.
+  // C# `String[]? projectIds` contract). The C# S/R command registers asynchronously during
+  // startup; `sendCommand` will wait (with retry on missing handler) until it's available or
+  // times out. `undefined` as the single arg serializes as `null` in the JSON-RPC params array
+  // — matching the "sync all" sentinel on the C# side.
   logger.debug('Startup sync starting');
   try {
-    await networkService.request(
-      serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.syncProjects'),
-      undefined,
-    );
+    await commandService.sendCommand('paratextBibleSendReceive.syncProjects', undefined);
     logger.debug('Startup sync complete');
-  } catch {
-    /* command absent (Platform.Bible) / extension not yet activated / sync failed — no-op */
+  } catch (e) {
+    logger.warn(
+      `Startup sync failed or skipped (command absent / extension not yet activated): ${getErrorMessage(e)}`,
+    );
   }
 }

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -25,7 +25,7 @@ export async function performStartupTasks(): Promise<void> {
 }
 
 async function performStartupTasksInternal(): Promise<void> {
-  logger.info('performStartupTasks invoked');
+  logger.debug('performStartupTasks invoked');
 
   // Power mode: no automatic sync on startup.
   // If the setting can't be read, default to simple mode to avoid skipping sync.
@@ -35,7 +35,7 @@ async function performStartupTasksInternal(): Promise<void> {
   } catch {
     /* settings service unavailable — treat as simple mode */
   }
-  logger.info(`performStartupTasks: interfaceMode=${interfaceMode}`);
+  logger.debug(`performStartupTasks: interfaceMode=${interfaceMode}`);
   if (interfaceMode !== undefined && interfaceMode !== 'simple') return;
 
   // Simple mode: sync all locally-known shared projects (no project IDs = "sync all" per the
@@ -43,13 +43,13 @@ async function performStartupTasksInternal(): Promise<void> {
   // `requestNoRetry`, because the C# S/R command registers asynchronously during startup; this
   // call may race ahead of it. `undefined` as the single arg serializes as `null` in the
   // JSON-RPC params array — matching the "sync all" sentinel on the C# side.
-  logger.info('Startup sync starting');
+  logger.debug('Startup sync starting');
   try {
     await networkService.request(
       serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.syncProjects'),
       undefined,
     );
-    logger.info('Startup sync complete');
+    logger.debug('Startup sync complete');
   } catch {
     /* command absent (Platform.Bible) / extension not yet activated / sync failed — no-op */
   }

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -1,0 +1,53 @@
+import { CATEGORY_COMMAND } from '@shared/data/rpc.model';
+import { logger } from '@shared/services/logger.service';
+import * as networkService from '@shared/services/network.service';
+import { settingsService } from '@shared/services/settings.service';
+import { serializeRequestType } from '@shared/utils/util';
+
+/**
+ * Runs initialization tasks (currently: triggering an initial project sync) shortly after the app
+ * finishes starting up.
+ *
+ * In Simple mode: requests a sync of all locally-known shared projects so the user sees the latest
+ * content as soon as they open the app. All errors are swallowed — the S/R extension may not be
+ * installed (e.g. Platform.Bible), the command may not yet be registered, or the sync may fail.
+ * Startup must never be blocked or visibly affected by this.
+ *
+ * In Power mode (or any non-Simple mode): returns immediately with no automatic sync. Power-mode
+ * users manage Send/Receive manually. Mirrors the mode gating in {@link performShutdownTasks}.
+ */
+export async function performStartupTasks(): Promise<void> {
+  try {
+    await performStartupTasksInternal();
+  } catch (e) {
+    logger.error('Unexpected error during startup tasks:', e);
+  }
+}
+
+async function performStartupTasksInternal(): Promise<void> {
+  // Power mode: no automatic sync on startup.
+  // If the setting can't be read, default to simple mode to avoid skipping sync.
+  let interfaceMode: string | undefined;
+  try {
+    interfaceMode = await settingsService.get('platform.interfaceMode');
+  } catch {
+    /* settings service unavailable — treat as simple mode */
+  }
+  if (interfaceMode !== undefined && interfaceMode !== 'simple') return;
+
+  // Simple mode: sync all locally-known shared projects (no project IDs = "sync all" per the
+  // C# `String[]? projectIds` contract). Uses `request` (with retry on missing handler), not
+  // `requestNoRetry`, because the C# S/R command registers asynchronously during startup; this
+  // call may race ahead of it. `undefined` as the single arg serializes as `null` in the
+  // JSON-RPC params array — matching the "sync all" sentinel on the C# side.
+  logger.info('Startup sync starting');
+  try {
+    await networkService.request(
+      serializeRequestType(CATEGORY_COMMAND, 'paratextBibleSendReceive.syncProjects'),
+      undefined,
+    );
+    logger.info('Startup sync complete');
+  } catch {
+    /* command absent (Platform.Bible) / extension not yet activated / sync failed — no-op */
+  }
+}


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: on-startup-autosync-only-in-simple

**Base**: origin/main

**Date**: 2026-06-18

**Review model**: Claude Opus 4.7

**Files changed**: 4

## Overview

Moves the startup auto-sync trigger from the closed-source PT10 patch into open-source paranext-core, gated on `platform.interfaceMode === 'simple'` so it never runs in Power mode. The C# `SyncProjects` stub also gains a `#if DEBUG`-only placeholder notification so developers running `npm start` against open-source paranext-core can see that the autosync trigger fires, even though no real Send/Receive implementation exists outside PT10.

Architecturally this makes the main-process lifecycle symmetric: shutdown-tasks (in paranext-core) and startup-tasks (now also in paranext-core) read the same `platform.interfaceMode` setting, follow the same error-swallowing pattern, and share testing conventions. As a side effect this also fixes a latent Power-mode bug where startup autosync could fire concurrently with shutdown (shutdown returns early in Power mode without calling `cancelSync`).

## API Changes

None. No changes to public API surfaces (`lib/platform-bible-react/`, `lib/platform-bible-utils/`, `@papi/` modules in `papi.d.ts`, or extensions' type declaration files in `extensions/src/*/src/types/*.d.ts`).

The branch touches only:

- `src/main/startup-tasks.ts` (new internal main-process module)
- `src/main/startup-tasks.test.ts` (new test file)
- `src/main/main.ts` (wires up the new internal call)
- `c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs` (internal C# behavior change inside an existing method, gated by `#if DEBUG`)

`performStartupTasks` is exported only for internal consumption by `main.ts` (and its test). It is not re-exported through any `@papi/` module or other extension-facing surface.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [ ] ~~`c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs:91-110`: DEBUG/Release behavioral asymmetry — in DEBUG `SyncProjects` succeeds with a notification side effect; in Release it still throws `PlatformUnimplementedException`. Any caller that today distinguishes "S/R unavailable" via the throw will see the success path in DEBUG only.~~ _(Author confirmed the asymmetry is intentional — that's the whole point of the dev placeholder. Callers in paranext-core (only `performStartupTasks` and the project-switch sync in `platform-scripture-editor.utils.ts`) already swallow either outcome silently, so no observable behavior diverges. PT10's patch replaces the whole method, so the asymmetry is invisible in production builds.)_

### Minor — Consider

- [ ] ~~`src/main/startup-tasks.ts:44`: Inverted mode-check `if (interfaceMode !== undefined && interfaceMode !== 'simple') return;` is hard to parse — could be `if (interfaceMode === 'power') return;`.~~ _(Keep for symmetry with `shutdown-tasks.ts:44`, which uses the identical form. Tightening to `=== 'power'` would also change behavior for any future non-simple/non-power mode values.)_
- [ ] ~~`src/main/startup-tasks.ts:48-51`: Hardcoded command string `'paratextBibleSendReceive.syncProjects'` will silently no-op if the S/R extension renames it.~~ _(Same pattern in `shutdown-tasks.ts` which hardcodes `'paratextBibleSendReceive.cancelSync'` and `'paratextBibleSendReceive.sendReceiveProjects'`. Keep for symmetry.)_
- [ ] ~~`src/main/startup-tasks.ts`: Outer `performStartupTasks` try/catch may be dead defensive code since the internal function already wraps both fallible calls and never re-throws.~~ _(Keep for symmetry with `performShutdownTasks`.)_
- [ ] ~~`src/main/startup-tasks.ts:38`: `interfaceMode` typed as `string | undefined` — could use `SettingTypes['platform.interfaceMode']` (`'simple' | 'power'`).~~ _(Keep for symmetry with `shutdown-tasks.ts`, which uses the same loose typing. Tightening here without also tightening shutdown would create inconsistency.)_
- [x] **Five `logger.info` calls is noisy for a fire-and-forget startup task** — `performStartupTasks invoked`, `interfaceMode=...`, `Startup sync starting`, `Startup sync complete`, plus the outer error path. Shutdown-tasks has just 2 info logs. _(Fixed during review: all 4 info calls converted to `logger.debug` so they're quiet by default and only visible when the log level is set to debug. The `logger.error` for the outer unexpected-throw path is unchanged. Test mock updated to include `debug` method.)_
- [ ] ~~`c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs:98`: Hardcoded English string `"Syncing projects… (dev placeholder)"` is not localized.~~ _(Acceptable — gated behind `#if DEBUG`, never reaches release builds. Marked as a "don't forget" if this ever gets promoted to a real implementation, but no action needed now.)_

### Template Propagation

#### Shared Regions Modified

None. No `#region shared with` markers exist in any of the changed files.

#### Extension Config Changes

None. No files under `extensions/` were modified.

## Positive Observations

- Public API surfaces are untouched — this is purely an internal addition with no breaking-change risk for extension authors.
- `performStartupTasks` mirrors `performShutdownTasks` end-to-end (mode gating, try/catch shape, comment phrasing, error-swallow pattern) — strong consistency makes the symmetric pair easy to reason about.
- Strong test coverage on the new module: power-mode skip, simple-mode fire, settings-throw fallback, sync-failure swallow, and unexpected-throw swallow are all covered.
- Fire-and-forget invocation in `main.ts:230-235` correctly attaches a `.catch` so an unexpected throw cannot become an unhandled rejection.
- JSDoc on `performStartupTasks` clearly explains the contract (mode gating, error-swallowing rationale, why startup must not block) and cross-links to `performShutdownTasks`.
- The comment at `startup-tasks.ts:41-45` explaining why `request` (with retry) is used over `requestNoRetry`, and why `undefined` serializes to `null` for the "sync all" sentinel, is exactly the right level of context for a future maintainer.
- The C# DEBUG/Release split is wrapped tightly around just the placeholder, leaving the Release behavior (throw `PlatformUnimplementedException`) unchanged. The inline comment `paranext-core has no S/R impl. PT10 patches the whole method` makes the intent obvious.
- Latent shutdown-time bug fixed as a side-effect: previously in Power mode the C# autosync would fire on startup and `performShutdownTasks` would return early without calling `cancelSync`, leaving a sync running concurrently with shutdown. After this change autosync never starts in Power mode, so the race disappears.

## Interview Notes

- **Author's stated purpose**: Move startup-autosync from PT10 patch into paranext-core, gated on `interfaceMode === 'simple'`. Power mode no longer auto-syncs on startup. C# stub shows a `#if DEBUG` placeholder notification in local dev. Symmetric with `shutdown-tasks.ts`.
- **Key decisions explained**:
  - Doing the mode gating entirely in TS (paranext-core) instead of the original C#-side approach makes the policy visible in open source and removes it from PT10's closed-source patch.
  - Used `networkService.request` (with retry) instead of `requestNoRetry` because the C# `syncProjects` command may not yet be registered when `performStartupTasks` fires; retry gives the .NET process time to come up.
  - Picked `#if DEBUG` (rather than an env var or runtime check) for the C# placeholder because `dotnet watch` defaults to Debug and `npm run build:data-release` does Release, so the placeholder is automatically dev-only with no configuration needed.
  - Six minor findings reviewed; five dismissed for explicit symmetry with `shutdown-tasks.ts` (same loose typing, same hardcoded command strings, same defensive outer try/catch, same inverted mode check). One was fixed in-review (logger.info → logger.debug).
- **No unresolved items** — author had clear reasoning for every design choice.

## In-Review Quality Check

- **Lint** (`npx eslint src/main/startup-tasks.ts src/main/startup-tasks.test.ts`): 0 errors, 0 warnings.
- **Type check** (`npx tsc --noEmit -p tsconfig.json`): exit 0.
- **Tests** (`npx vitest run src/main/startup-tasks.test.ts src/main/shutdown-tasks.test.ts`): initial run failed 2/5 startup tests because the test's logger mock didn't include a `debug` method after the `logger.info` → `logger.debug` change. Mock updated to include `debug: vi.fn()`. Re-run: 12/12 passed (5 startup + 7 shutdown).

## Suggested Review Focus

Prioritized areas for the author-reviewer meeting:

- [ ] Confirm the cross-repo coordination plan: the paranext-core PR adds the trigger; a paired PR in `paratext-10-studio` removes the C# autosync block from the PT10 patch so the trigger isn't double-fired in PT10 builds. Both must land together or PT10 will have redundant sync on startup.
- [ ] Sanity-check the placement of `performStartupTasks()` in `main.ts:233` — fires after `extensionHostService.start()` resolves but before window creation. Question worth asking: is there ever a case where the .NET data provider's `syncProjects` command takes long enough to register that our `networkService.request` timeout fires? If so, the silent catch loses the sync; we may want to add a debug log to make the timeout visible.
- [ ] Symmetry with shutdown-tasks is leaned on as a design rationale for five separate dismissed findings. If a reviewer disagrees with any of those choices in shutdown-tasks, that disagreement should propagate to both files together.
<!-- review-paratext:summary:end -->

---

- Implement like shutdown and do not autosync in Power
- In addition: make Sonner appear in local dev mode for easier debugging & expectations (only appears in Simple, as per condition above)

This goes along with a patch PR for Paratext 10 Studio, see https://github.com/paranext/paratext-10-studio/pull/145

<img width="1307" height="927" alt="image" src="https://github.com/user-attachments/assets/0657ac22-9340-4891-9a8e-52130da71f3b" />


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2434)
<!-- Reviewable:end -->

