### PR TITLE
fix(notifications): update existing toast instead of duplicating on resend (PT-4002)

### DIFF
--- a/src/renderer/services/notification.service-host.test.ts
+++ b/src/renderer/services/notification.service-host.test.ts
@@ -99,4 +99,28 @@ describe('notification service host', () => {
       expect(mockToast.dismiss).not.toHaveBeenCalled();
     });
   });
+
+  describe('send with a reused notificationId', () => {
+    it('passes the existing toast id as the top-level id so Sonner updates instead of duplicating', async () => {
+      mockToastInfo.mockReturnValueOnce('toast-1');
+      const notification: PlatformNotification = {
+        message: 'Syncing...',
+        severity: 'info',
+        notificationId: 'sync-status',
+      };
+
+      // First send creates the toast and maps notificationId -> 'toast-1'.
+      await capturedService.send(notification);
+      // Re-sending with the same notificationId must UPDATE the existing toast, i.e. pass the
+      // existing toast id as the top-level `id` option (what Sonner uses to update vs create).
+      await capturedService.send(notification);
+
+      expect(mockToastInfo).toHaveBeenCalledTimes(2);
+      expect(mockToastInfo).toHaveBeenNthCalledWith(
+        2,
+        'Syncing...',
+        expect.objectContaining({ id: 'toast-1' }),
+      );
+    });
+  });
 });

--- a/src/renderer/services/notification.service-host.ts
+++ b/src/renderer/services/notification.service-host.ts
@@ -36,12 +36,15 @@ async function send(notification: PlatformNotification): Promise<string | number
   if (notification.duration !== undefined)
     duration = notification.duration <= 0 ? Infinity : notification.duration;
   const toastOptions = {
+    // When re-sending with the same notificationId, reuse the existing toast id so Sonner
+    // updates the existing toast instead of creating a duplicate. Sonner reads this from the
+    // top-level `id` (not from `action.id`, which it ignores).
+    id: toastId,
     action:
       clickCommandLabel && clickCommand
         ? {
             label: await localize(clickCommandLabel),
             onClick: () => commandService.sendCommand(clickCommand, effectiveNotificationId),
-            id: toastId,
           }
         : undefined,
     // Duration calc from https://paratextstudio.atlassian.net/browse/PT-2196?focusedCommentId=13075


### PR DESCRIPTION
## Summary

Fixes [PT-4002](https://paratextstudio.atlassian.net/browse/PT-4002): on startup, auto-sync displays two notifications and one lingers until dismissed.

`send()` in `notification.service-host.ts` looks up the existing toast id from `mapOfNotificationIdsToToastIds` when re-sending with the same `notificationId`, but passed it as `action.id` (a field Sonner ignores) instead of the top-level `id` that Sonner uses to update an existing toast. So every resend with the same `notificationId` created a brand-new toast, leaving the previous one on screen.

This moves `id: toastId` to the top level of the toast options (and drops the dead `action.id`). On the first send `toastId` is `undefined`, so Sonner generates a fresh id; on resend the existing id is reused, so Sonner updates the toast in place.

## Reproduction

Adds a regression test `notification.service-host.test.ts > send with a reused notificationId (PT-4002)`:

- Before: the 2nd `toast.info` call options are `{ action: undefined, duration: 10000 }` (no top-level `id`) - the test fails.
- After: the 2nd call options include `{ id: 'toast-1' }`, so Sonner updates the existing toast - the test passes. All 5 tests in the file pass.

## Notes

- Root cause confirmed against the Sonner 1.7.4 types: `Action` has no `id` field; `ExternalToast.id` (optional `string | number`) controls update-vs-create.
- Minimal change; no change to the click-action or duration logic.

---

AI-assisted - [session](https://claude.ai/code/session_01TJiEdG7rKJY7aBxEM6nsSc). Surfaced and prepared by an automated quality sweep (seeded from Jira bug reports), then reproduced, tested, and reviewed before this PR was opened.


[PT-4002]: https://paratextstudio.atlassian.net/browse/PT-4002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2435)
<!-- Reviewable:end -->
