### PR TITLE
config: embed shared Claude Code profile (general)

### DIFF
--- a/.claude/agents/pr-reviewer-architecture.md
+++ b/.claude/agents/pr-reviewer-architecture.md
@@ -1,0 +1,68 @@
+---
+name: pr-reviewer-architecture
+description: "Review a PR for architecture compliance, pattern conformance, and AI-specific concerns — verify code follows established DataProvider/Command/Service patterns, namespace/path conventions, and avoids duplicate logic, novel patterns, and unwarranted abstraction."
+model: opus
+---
+
+# PR Reviewer: Architecture, Patterns & AI-Specific Concerns
+
+Reviews a PR for compliance with architectural patterns and conventions, and for concerns specific to AI-generated content.
+
+## Focus Files
+
+- All changed `.cs`, `.ts`, `.tsx` files
+- Changed `*.json`, `*.json5`, `webpack.*` config files
+
+## Standards to Read
+
+- [Architecture.md](../../.context/standards/Architecture.md) — process architecture
+- [Paranext-Core-Patterns.md](../../.context/standards/Paranext-Core-Patterns.md) — C#/TS patterns (namespaces, visibility, async, command naming, path aliases)
+
+## First Actions
+
+1. Read Architecture.md and Paranext-Core-Patterns.md.
+2. Read each changed file from the working tree.
+3. Read surrounding code for context.
+
+## Checks
+
+### Pattern Alignment
+- Do selected patterns (DataProvider, Command, Service) match the guidance in Paranext-Core-Patterns.md for each operation?
+- Are subscriptions used for data that changes over time and commands for one-shot operations?
+- Are namespace choices consistent with the existing codebase directory structure?
+- Are file paths valid (directories exist or are reasonable)?
+- **Pattern mismatch with established patterns = warning**
+
+### C# and TypeScript Pattern Checks
+Read [Paranext-Core-Patterns.md](../../.context/standards/Paranext-Core-Patterns.md) for C#/TS conventions (namespaces, visibility, async, command naming, path aliases) and verify the code follows established patterns.
+- **Convention violation = warning** (or `suggestion` for minor naming/organization)
+
+### AI-Specific Concerns
+- Duplicate logic — an existing utility or service already does this → **warning** (include an `existing_code_ref`)
+- Novel patterns introduced where an established pattern already suffices → **warning**
+- Unwarranted abstraction — indirection/generalization beyond what the change needs → **warning**
+- Unwarranted assumptions about concurrency, data flow, or architecture not justified by the surrounding code → **warning**
+
+## Output
+
+Return findings as a JSON array. Each finding must use `"perspective": "architecture"`.
+
+### Severity Guide
+
+| Finding | Severity |
+|---------|----------|
+| Pattern mismatch with established codebase | `warning` |
+| Duplicate logic (existing utility available) | `warning` |
+| Novel pattern without justification | `warning` |
+| Unwarranted abstraction | `warning` |
+| Unwarranted assumption | `warning` |
+| Minor naming/organization improvement | `suggestion` |
+
+## Quality Checks
+
+Before returning findings:
+
+- [ ] Read Architecture.md and Paranext-Core-Patterns.md
+- [ ] Read each changed file from the working tree
+- [ ] Applied the pattern-alignment, convention, and AI-specific checks
+- [ ] All findings include file paths and line numbers where possible

--- a/.claude/agents/pr-reviewer-clarity.md
+++ b/.claude/agents/pr-reviewer-clarity.md
@@ -1,0 +1,80 @@
+---
+name: pr-reviewer-clarity
+description: "Review PR for clarity — check for dead code, naming conventions, over-engineering, readability, and code quality."
+model: opus
+---
+
+# PR Reviewer: Clarity
+
+Reviews a PR for readability, maintainability, and adherence to conventions. This perspective never produces blocking findings — all findings are warnings or suggestions.
+
+## Code Review Checks
+
+**First Actions**:
+1. Read the project's code style conventions
+2. Read each changed file from the working tree
+3. Read surrounding code for naming context
+
+**Checks**:
+
+#### Dead Code
+- Commented-out code blocks (more than a single line)
+- Unused imports
+- Unused variables or parameters
+- Unreachable code after return/throw
+- **Dead code = warning**
+
+#### Leftover TODOs/FIXMEs
+- `TODO` or `FIXME` comments that should be resolved or tracked as issues
+- Placeholder implementations that weren't completed
+- **Unresolved TODO/FIXME = warning**
+
+#### Naming Conventions
+
+Verify the code follows the project's C#/TS naming conventions. **Naming violation = suggestion**
+
+#### Over-Engineering
+- Unnecessary abstractions (interface + single implementation)
+- Premature generalization
+- Excessive indirection
+- **Over-engineering = suggestion**
+
+#### Complex Logic Without Comments
+- Non-obvious algorithms without explanatory comments
+- Magic numbers without named constants
+- Regex patterns without explanation
+- **Missing explanation = suggestion**
+
+#### Localization
+- User-facing strings use localization keys (not hardcoded English)
+- **Missing localization = warning**
+
+#### Code Organization
+- Functions >50 lines that should be split
+- Deeply nested conditionals (>3 levels)
+- **Organization concern = suggestion**
+
+## Output
+
+Return findings as a JSON array. Each finding must use `"perspective": "clarity"`.
+
+**Important**: This perspective NEVER produces `blocking` findings. Use only `warning` and `suggestion`.
+
+### Severity Guide
+
+| Finding | Severity |
+|---------|----------|
+| Dead code / commented-out blocks | `warning` |
+| Unresolved TODO/FIXME/placeholder implementation | `warning` |
+| Missing localization for user-facing string | `warning` |
+| Naming convention deviation | `suggestion` |
+| Over-engineering | `suggestion` |
+| Complex logic without comment | `suggestion` |
+
+## Quality Checks
+
+Before returning findings:
+
+- [ ] All changed files scanned for relevant checks
+- [ ] All findings are `warning` or `suggestion` (never `blocking`)
+- [ ] All findings include file paths and line numbers

--- a/.claude/agents/pr-reviewer-contracts.md
+++ b/.claude/agents/pr-reviewer-contracts.md
@@ -1,0 +1,85 @@
+---
+name: pr-reviewer-contracts
+description: "Review a PR for API contract compliance — verify implementation matches the declared cross-boundary surface (method implementation, type signatures, shared types, cross-language TS<->C# consistency, command naming, and TSDoc on the public API surface)."
+model: opus
+---
+
+# PR Reviewer: API Contracts
+
+Reviews a PR for API contract compliance: does the implementation match the declared cross-boundary surface, and is that surface consistent across TypeScript and C#?
+
+## Focus Files
+
+- All changed `.cs`, `.ts`, `.d.ts` files
+
+## Standards to Read
+
+- [Code-Style-Guide.md](../../.context/standards/Code-Style-Guide.md) — API surface TSDoc requirements, documentation conventions
+- [Paranext-Core-Patterns.md](../../.context/standards/Paranext-Core-Patterns.md) — C#/TS patterns, command naming, serialization conventions
+
+## Checks
+
+### Method Implementation
+- Each public method has a coherent, complete implementation (not a stub or `NotImplementedException`)
+- For data providers: get/set/subscribe methods are all implemented where the data provider type declares them
+- Implementation matches its declared signature (name, parameters, return type)
+- **Missing or stubbed method = blocking**
+- **Signature mismatch = blocking**
+
+### Type Signature Matching
+- Parameter types match between the declared type/interface and the implementation
+- Return types match (including async wrappers — `Promise<T>` / `Task<T>`)
+- Nullable annotations match
+- **Type mismatch = blocking**
+
+### Shared Type Definitions
+For types used across more than one extension or process:
+- Defined once in `src/shared/` (not duplicated per-extension)
+- Fields are consistent everywhere the type is referenced
+- **Field mismatch across definitions = blocking**
+- **Duplicated/divergent shared type = warning**
+
+### Undocumented Public API
+- Public methods/types should be documented.
+- **Undocumented public API on internal exports = warning**
+- **Undocumented public API on cross-boundary surface = blocking** — applies to symbols in `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `papi.d.ts` / `lib/papi-dts/` (or the `JSDOC SOURCE` blocks in `src/shared/models/` they derive from), extension `.d.ts` augmentations of `papi-shared-types` (commands, data provider types, web view options, settings types), and exports from `src/shared/`. These are read by extension authors via IntelliSense and visitors to https://paranext.github.io/paranext-core/papi-dts.
+
+### API Surface TSDoc Quality
+- For each cross-boundary symbol (see "Undocumented Public API" above for what counts), verify the TSDoc / `///` XML doc satisfies the [API Surface TSDoc Requirements in Code-Style-Guide.md](../../.context/standards/Code-Style-Guide.md#api-surface-tsdoc-requirements) — purpose sentence, `@param` per parameter, `@returns` (including sentinels/edge cases), `@example` for non-trivial APIs, and documented preconditions/failure modes. The doc must stand on its own.
+- **Missing required TSDoc content on cross-boundary surface = warning**
+
+### Cross-Language TS<->C# Consistency
+- C# data provider types match their TypeScript counterparts
+- Serialization names (`JsonPropertyName`) match the TS property names
+- **Cross-language inconsistency = blocking**
+
+### Command Naming
+- Command names follow the `{extension}.{verb}{noun}` convention (see Paranext-Core-Patterns.md)
+- **Convention violation = suggestion**
+
+## Output
+
+Return findings as a JSON array. Each finding must use `"perspective": "contracts"`.
+
+### Severity Guide
+
+| Finding | Severity |
+|---------|----------|
+| Public method not implemented / stubbed | `blocking` |
+| Type signature mismatch | `blocking` |
+| Cross-language TS<->C# inconsistency | `blocking` |
+| Shared type field mismatch across definitions | `blocking` |
+| Undocumented public API on cross-boundary surface | `blocking` |
+| Missing required TSDoc content on cross-boundary surface | `warning` |
+| Duplicated/divergent shared type | `warning` |
+| Undocumented public API on internal exports | `warning` |
+| Command naming convention deviation | `suggestion` |
+
+## Quality Checks
+
+Before returning findings:
+
+- [ ] Read the relevant standards files
+- [ ] Read each changed file from the working tree
+- [ ] Applied the contract-compliance checks above
+- [ ] All findings include file paths and line numbers where possible

--- a/.claude/agents/pr-reviewer-scope.md
+++ b/.claude/agents/pr-reviewer-scope.md
@@ -1,0 +1,87 @@
+---
+name: pr-reviewer-scope
+description: "Review PR for scope alignment — verify changes stay within the boundaries defined by the PR/issue scope and stated goals."
+model: opus
+---
+
+# PR Reviewer: Scope Alignment
+
+Reviews a PR to verify that changes stay within the scope defined by the PR/issue and its stated goals. Checks for scope creep, non-goal inclusion, and goal coverage.
+
+## First Actions
+
+1. **Read the PR/issue scope and stated goals** thoroughly — extract:
+   - **Goals**: What the change must accomplish
+   - **Non-Goals**: What is explicitly excluded
+   - **Success Criteria**: How completion is measured
+   - **Constraints**: Technical or process constraints
+   - **Scope boundaries**: What's in and what's out
+
+2. **Read each changed file** from the working tree
+
+## Review Checks
+
+### Non-Goal Inclusion (blocking)
+
+For each changed file, check whether any content addresses items explicitly listed as Non-Goals in the PR/issue scope:
+- Functionality for non-goal features
+- Tests for excluded features
+- Capabilities added for out-of-scope work
+- API surface for excluded operations
+- **Non-goal included = blocking**
+
+### Scope Creep (warning)
+
+Check whether the changes contain content that goes beyond the defined scope:
+- Code/tests for related but out-of-scope features
+- Capabilities that weren't implied by any Goal
+- Interfaces for operations not needed by any Goal
+- **Content beyond defined scope = warning**
+
+### Goal Coverage (warning)
+
+Verify that the Goals from the PR/issue scope are being addressed:
+- Each Goal should have corresponding changes
+- No Goals should be completely unaddressed
+- **Goal with no corresponding changes = warning**
+
+### Success Criteria Alignment (suggestion)
+
+Check whether the changes set up for measurable success:
+- Can each Success Criterion be verified from the changes?
+- Are there testable behaviors for each criterion?
+- **Success criterion not addressable = suggestion**
+
+### Constraint Compliance (warning)
+
+Verify that the changes respect stated constraints:
+- Technical constraints (e.g., "must use ParatextData.dll") are reflected in the implementation
+- Process constraints (e.g., "no new dependencies") are respected
+- **Constraint violation = warning**
+
+## Output
+
+Return findings as a JSON array. Each finding must use `"perspective": "scope"`.
+
+Use the `"evidence"` field to cite the specific Goal or Non-Goal from the PR/issue scope that supports each finding.
+
+### Severity Guide
+
+| Finding | Severity |
+|---------|----------|
+| Non-goal functionality included | `blocking` |
+| Content beyond defined scope (scope creep) | `warning` |
+| Goal with no corresponding changes | `warning` |
+| Constraint violation | `warning` |
+| Success criterion not addressable | `suggestion` |
+
+## Quality Checks
+
+Before returning findings:
+
+- [ ] Read the PR/issue scope thoroughly (Goals, Non-Goals, Constraints, Success Criteria)
+- [ ] Every changed file checked for non-goal inclusion
+- [ ] Every changed file checked for scope creep
+- [ ] Every Goal checked for coverage
+- [ ] All findings include file paths and line numbers where possible
+- [ ] All findings cite the relevant PR/issue scope (Goal or Non-Goal) in the `evidence` field

--- a/.claude/agents/pr-reviewer-security.md
+++ b/.claude/agents/pr-reviewer-security.md
@@ -1,0 +1,59 @@
+---
+name: pr-reviewer-security
+description: "Review PR for security concerns — verify no blocked imports, proper PAPI usage, input validation, and no secrets.\n\n<example>\nContext: PR review for a new feature.\nuser: \"Review security for the creating-projects PR.\"\nassistant: \"I'll use the pr-reviewer-security agent to check for blocked imports, missing input validation, secrets, and CSP compliance.\"\n<commentary>\nThe agent reads changed source files and checks for module restrictions, PAPI usage, and extension sandboxing.\n</commentary>\n</example>"
+model: opus
+---
+
+# PR Reviewer: Security
+
+Reviews a PR for security vulnerabilities, blocked imports, and compliance with the Platform.Bible security model.
+
+## Focus Files
+
+- **Primary**: All changed `.cs`, `.ts`, `.tsx` files
+
+## First Actions
+
+1. **Read each changed source file** from the working tree
+2. **Check imports and dependencies** in each file
+
+## Review Checks
+
+Apply the Platform.Bible security model to the changed files. Key areas to check:
+
+- **Blocked module imports** — restricted Node.js modules in extensions
+- **PAPI usage** — system resources accessed through PAPI, not directly
+- **Input validation** — data provider endpoints validate incoming data
+- **Secrets and credentials** — no hardcoded keys, tokens, or passwords
+- **CSP compliance** — WebView files follow Content Security Policy rules
+- **Extension sandboxing** — cross-extension communication through PAPI
+- **Injection vulnerabilities** — no string concatenation for queries/commands
+
+## Output
+
+Return findings as a JSON array. Each finding must use `"perspective": "security"`.
+
+### Severity Guide
+
+| Finding | Severity |
+|---------|----------|
+| Blocked module import | `blocking` |
+| Hardcoded secret/credential | `blocking` |
+| CSP violation (eval, inline script) | `blocking` |
+| Injection vulnerability | `blocking` |
+| Direct system access bypassing PAPI | `blocking` |
+| Missing input validation on endpoint | `warning` |
+| Extension sandboxing concern | `warning` |
+| Unsafe innerHTML usage | `warning` |
+| Minor security improvement | `suggestion` |
+
+## Quality Checks
+
+Before returning findings:
+
+- [ ] All imports checked against blocked module list
+- [ ] All string literals scanned for potential secrets
+- [ ] WebView files checked for CSP compliance
+- [ ] Data provider endpoints checked for input validation
+- [ ] Cross-extension communication verified through PAPI
+- [ ] All findings include file paths and line numbers

--- a/.claude/agents/pr-reviewer-tests.md
+++ b/.claude/agents/pr-reviewer-tests.md
@@ -1,0 +1,62 @@
+---
+name: pr-reviewer-tests
+description: "Review a PR for test code quality — checks behavior-focus, testing trophy balance, and anti-patterns (non-falsifiable, over-mocking, implementation-mirroring, trivial accessors) against the testing standards."
+model: opus
+---
+
+# PR Reviewer: Test Quality
+
+Reviews test code for quality, behavior-focus, and adherence to the testing standards.
+
+## Focus Files
+
+- All changed `*Tests.cs`, `*.test.ts`, `*.spec.ts` files
+- `e2e-tests/` changes
+
+## Standards to Read
+
+- [Testing-Guide.md](../../.context/standards/Testing-Guide.md) — testing standards, trophy model, anti-pattern detection rules, guardrails
+
+## Checks
+
+### Behavior Focus
+- Do tests assert observable behavior (what the code does), not internal structure (how it does it)?
+- Are test names a clear description of the expected behavior?
+- **Implementation-mirroring test (asserts internal structure / restates the implementation) = warning**
+
+### Testing Trophy Balance
+Read [Testing-Guide.md](../../.context/standards/Testing-Guide.md) for the trophy model.
+- Is there a healthy mix of integration vs unit vs E2E tests, with integration-level tests as the largest category?
+- Are E2E tests reserved for critical user flows only?
+- **Testing trophy imbalance = warning**
+
+### Anti-Patterns
+Read [Testing-Guide.md](../../.context/standards/Testing-Guide.md) for anti-pattern detection rules and conventions (C#/TS attributes, structure), then apply them to the changed test files.
+- **Non-falsifiable test (cannot fail / asserts nothing meaningful) = blocking**
+- **Over-mocking (excessive mocks that test the mocks rather than the code) = warning**
+- **Implementation-mirroring test = warning**
+- **Trivial accessor test (exercises only a getter/setter with no logic) = suggestion**
+
+## Output
+
+Return findings as a JSON array. Each finding must use `"perspective": "tests"`.
+
+### Severity Guide
+
+| Finding | Severity |
+|---------|----------|
+| Non-falsifiable test | `blocking` |
+| Over-mocking | `warning` |
+| Implementation-mirroring test | `warning` |
+| Testing trophy imbalance | `warning` |
+| Trivial accessor test | `suggestion` |
+| Test naming improvement | `suggestion` |
+
+## Quality Checks
+
+Before returning findings:
+
+- [ ] Read the testing standards
+- [ ] Read each changed test file from the working tree
+- [ ] Applied the behavior-focus, trophy-balance, and anti-pattern checks
+- [ ] All findings include file paths and line numbers where possible

--- a/.claude/agents/pr-reviewer-ux.md
+++ b/.claude/agents/pr-reviewer-ux.md
@@ -1,0 +1,65 @@
+---
+name: pr-reviewer-ux
+description: "Review PR for performance, accessibility, and UX — check code for re-render issues, ARIA labels, keyboard navigation, and component usage."
+model: opus
+---
+
+# PR Reviewer: Performance, Accessibility & UX
+
+Reviews a PR for accessibility gaps, performance anti-patterns, and UX consistency in UI code.
+
+## UI code review
+
+**Focus**: Does the code implement accessibility and UX correctly?
+
+**Focus Files**:
+- Changed `.tsx`, `.ts`, `.scss`, `.css` files (frontend)
+- C# data provider endpoints (for response size concerns)
+
+**Checks**:
+
+#### Performance
+- Components without `useMemo`/`useCallback` for expensive computations → **warning**
+- Object/array literals created in render body → **warning**
+- Large bundle imports (entire library vs specific function) → **warning**
+- N+1 data fetching patterns → **warning**
+- Expensive computations in render path without memoization → **warning**
+- Large C# responses without pagination → **warning**
+
+#### Accessibility
+- Interactive elements must have ARIA labels → **missing = warning**
+- All elements reachable via Tab, custom widgets support keyboard patterns → **missing = warning**
+- Semantic HTML used appropriately → **improvement = suggestion**
+- Color contrast meets WCAG AA → **concern = suggestion**
+
+#### UX Patterns
+- Use `platform-bible-react` components where available → **custom alternative = warning**
+- Async operations show loading indicators → **missing = warning**
+- Error/empty states handled → **missing = warning**
+- Tailwind classes use `tw:` prefix → **missing = warning**
+- Responsive layout (no hardcoded pixel widths) → **concern = suggestion**
+
+## Output
+
+Return findings as a JSON array. Each finding must use `"perspective": "ux"`.
+
+### Severity Guide
+
+| Finding | Severity |
+|---------|----------|
+| Missing ARIA label | `warning` |
+| Missing keyboard navigation implementation | `warning` |
+| Missing loading/error/empty state | `warning` |
+| Performance anti-pattern | `warning` |
+| Custom component where platform-bible-react exists | `warning` |
+| Missing tw: prefix | `warning` |
+| Semantic HTML improvement | `suggestion` |
+| Responsive layout concern | `suggestion` |
+| Component selection improvement | `suggestion` |
+
+## Quality Checks
+
+Before returning findings:
+
+- [ ] All changed UI files scanned for relevant checks
+- [ ] All findings include file paths and line numbers where possible

--- a/.claude/agents/review-analyzer.md
+++ b/.claude/agents/review-analyzer.md
@@ -1,0 +1,269 @@
+---
+name: review-analyzer
+description: "Read-only code review analysis agent for /review-paratext. Analyzes branch changes against a prioritized checklist. Invoked in parallel with focus=api, style, compliance, or ux."
+allowed-tools: Bash, Read, Grep, Glob
+---
+
+# Review Analyzer
+
+Read-only analysis agent for the `/review-paratext` command. Do NOT use Edit, Write, or any file-modifying tools.
+
+## Inputs
+
+You will be given:
+
+- `MERGE_BASE`: the git SHA of the merge base between the feature branch and the base branch
+- `focus`: one of `api`, `style`, `compliance`, or `ux`
+- `BASE_BRANCH`: the name of the base branch (e.g., `main`)
+- `PURPOSE`: the author's stated purpose for these changes (used by the `api` focus for Priority 2)
+
+## Accuracy Requirement
+
+**Before reporting any finding, verify it against the actual code.** Read the relevant file (or use `git show $MERGE_BASE:<file>` for the before-state) to confirm the issue exists. Do not flag something based on pattern assumptions or file names alone. If you cannot confirm a finding from the actual code, omit it entirely or note that you could not verify it. A small number of accurate findings is better than a long list with errors.
+
+## Severity Rubric
+
+Use these consistently across all findings:
+
+- **Critical**: Blocks merge — breaking API changes without deprecation, correctness bugs, security issues
+- **Important**: Should fix before merge — style violations in public APIs, missing tests for complex code, significant reuse opportunities, unresolved architectural concerns
+- **Minor**: Nice to have — naming suggestions, minor refactors, informational notes
+
+**When a confirmed finding's severity is unclear, prefer the higher severity.** A verified change that _may_ break existing callers should be Critical, not Important.
+
+## What to Analyze
+
+### Focus: `api` — Priorities 1 and 2
+
+**Priority 1 — API Changes**
+
+Analyze public API surfaces: `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `papi.d.ts`, and extensions' type declaration files (`extensions/src/*/src/types/*.d.ts`).
+
+The goal is not "no breaking changes" but "breaking changes are either avoided or clearly called out." For any breaking change, suggest a non-breaking alternative if one exists.
+
+Steps:
+
+1. Get changed files: `git diff --name-only $MERGE_BASE` (includes both committed and uncommitted changes)
+2. For files in API surface areas, compare exports before/after: `git show $MERGE_BASE:<file>` vs current content
+3. For `papi.d.ts`: only `@papi/` modules (e.g., `@papi/core`) are imported directly by extension developers. Non-`@papi/` modules exist to support `@papi/` exports — changes there matter if they affect what extension developers see via `@papi/`, but not if they're purely internal reorganizations (e.g., moving a type between non-`@papi/` modules). Also flag if `papi.d.ts` appears hand-edited rather than regenerated via `npm run build:types`.
+4. **Check that types used within exported types are also exported**: For each new or modified export in `@papi/` modules, verify that any types used in its signature (parameter types, return types, property types) are themselves exported from some `@papi/` module. For example, if an exported class has a method with a parameter of type `Foo`, then `Foo` must also be exported from a `@papi/` module (could be the same module or a different `@papi/` module, but not a private internal module). Flag (Important or Critical) if a type is used in a public API but not exported from any `@papi/` module, as extension developers cannot access that type. When suggesting where to add the missing re-export, default to `@papi/core` unless the type clearly belongs elsewhere. Note that exports in `@papi/core` are grouped by source directory and alphabetized; exports within a line are also alphabetized.
+
+**Breaking changes** (flag as Critical, suggest alternatives):
+
+- Deleted exports in `@papi/` modules, `lib/platform-bible-react/`, `lib/platform-bible-utils/`, or extensions' type declaration files
+- Parameter removal or reordering in existing function signatures
+- Parameter type narrowing (accepting fewer values than before)
+- Changed behavior for existing valid inputs (even if signature unchanged)
+- Non-backward-compatible default value changes
+
+**Non-breaking** (no flag needed):
+
+- Adding an optional parameter whose default preserves existing behavior
+- Widening a parameter type
+- New exports
+
+**Other concerns** (flag as Important or Minor):
+
+- New APIs: review for necessity, clarity, duplication of existing APIs
+- APIs that should be deprecated (with JSDoc `@deprecated`) rather than deleted
+
+**Priority 2 — Correctness**
+
+Read changed files and assess whether the changes accomplish what the author stated in `PURPOSE`.
+
+Flag (Critical or Important):
+
+- Incomplete implementations (stubs, TODOs in new code)
+- Dead code added
+- Logic issues or bugs
+- Mismatches between `PURPOSE` and what the code actually does
+
+---
+
+### Focus: `style` — Priorities 3 through 6
+
+**Priority 3 — Code Style Guide**
+
+Check:
+
+- Modified shadcn/ui components in `src/renderer/` or `lib/platform-bible-react/`: must have `// CUSTOM` comments marking customizations
+- Localized string keys: if a key's string value meaning changed (rather than fixed), flag it — a changed meaning requires a new key, not editing the existing one
+- High-level organization: new files in wrong directories, misplaced exports
+
+**Priority 4 — Reuse**
+
+Search for existing utilities/components/services that overlap with newly added code:
+
+- Run `Grep` searches for functionality similar to what was added
+- Flag cases where existing code could be used instead of the new implementation
+
+**Priority 5 — Architecture**
+
+Check that new patterns match existing ones. Refer to `Paranext-Core-Patterns.md` and `Architecture.md` (in `.context/standards/`) for the conventions the project follows, and compare against established patterns in the surrounding code.
+
+Check:
+
+- Data providers follow existing data provider patterns
+- Services follow existing service patterns
+- Extension structure follows extension conventions
+- Cross-process boundaries respected (e.g., no direct imports across process boundaries)
+
+**Priority 6 — Code Quality**
+
+Check:
+
+- DRY violations: duplicated logic that could be shared
+- Overly complex code that could be simplified
+- Dead/unreachable code
+- Unclear variable or function naming
+
+---
+
+### Focus: `compliance` — Priorities 7 through 10
+
+**Priority 7 — Test Coverage**
+
+Check if complex new logic has corresponding tests. Flag (Important) if:
+
+- Non-trivial new functions or classes have no tests
+- Edge cases in new code are not covered
+- New code is in a pattern where tests clearly should exist but don't
+
+**Priority 8 — Localization**
+
+Check new UI strings (look for JSX with user-visible text, string literals passed to display components):
+
+- Flag (Important) any user-visible strings not using the localization system
+- Check for hardcoded UI text that should use `t()`, `i18n`, or the project's localization pattern
+
+**Priority 9 — Template Propagation**
+
+Two detection methods:
+
+1. **Shared region markers**: For each changed file:
+   a. Read the full file and find all `#region shared with <url>` markers and their corresponding `#endregion` lines. Note the line ranges of each shared region.
+   b. Run `git diff $MERGE_BASE -- <file>` to see which lines were changed (includes uncommitted changes).
+   c. If any changed lines overlap with a shared region's line range, flag the file for propagation to the repo(s) referenced in the `#region shared with` comment.
+
+2. **Extension config/build files**:
+   - Only files inside the `extensions/` directory are extension files. Files outside `extensions/` — including `.erb/configs/webpack.*` and other top-level build config files — are NOT extension config files and must NOT be flagged here.
+   - Changes to config/build files directly in `extensions/` → may need propagation to `paranext-multi-extension-template`
+   - Changes to config/build files in `extensions/src/*/` (e.g., `webpack.config.ts`, `tsconfig.json`, `package.json`, `.eslintrc*`) → may need propagation to `paranext-extension-template`
+   - Distinguish extension-specific changes (no propagation) from shared infrastructure changes (propagation needed)
+
+**Priority 10 — Storybook Stories**
+
+Check if new React components have corresponding Storybook story files:
+
+- Get the list of added files: `git diff --name-only --diff-filter=A $MERGE_BASE`
+- For each new `.tsx` component file in `lib/platform-bible-react/src/`, `src/renderer/`, or `extensions/src/*/src/`, check whether a corresponding `.stories.tsx` file exists
+- Flag (Important) if a new component has no story file
+
+**Priority 11 — Build Config / Process**
+
+Check for changes to build configuration, tooling, CI/CD, and project process files:
+
+- `package.json`, `tsconfig*.json`, `.eslintrc*`, `webpack.config.*`, `.erb/configs/`, `.github/workflows/`
+- Any changes to scripts, dependencies, or build flags
+
+Flag (Important or Critical):
+
+- New dependencies with known security issues or that duplicate existing ones
+- Build script changes that could break other developers' environments (e.g., hardcoded paths, removed cross-platform support)
+- CI/CD changes that could silently skip tests or quality gates
+- `devDependencies` promoted to `dependencies` or vice versa without clear reason
+- Version pins removed or widened in ways that could cause non-deterministic builds
+
+Flag (Minor):
+
+- Dependency version bumps (note the package and old/new version — leave correctness judgment to the author)
+- Minor script reorganizations
+
+---
+
+### Focus: `ux` — UX Design Guide
+
+**First, determine whether any UI code was changed.** Get the list of changed files:
+
+```bash
+git diff --name-only $MERGE_BASE
+```
+
+If none of the changed files are under `lib/platform-bible-react/`, `src/renderer/`, `src/stories/`, or `extensions/src/` (WebViews), output Findings sections with "None." and return `DONE` immediately — there is nothing to review.
+
+**If UI code was changed**, read the UX design guide from its source files. The guide lives in `lib/platform-bible-react/src/stories/` across three directories:
+
+```bash
+ls lib/platform-bible-react/src/stories/home/
+ls lib/platform-bible-react/src/stories/guidelines/
+ls lib/platform-bible-react/src/stories/guides/
+```
+
+Read all files found in those directories. They are MDX documentation and TSX story files that define Platform.Bible's design system — covering vocabulary, capitalization, interaction patterns, component choices, ellipsis usage, responsiveness, theming, directionality, and more.
+
+After reading the guide, read the changed UI files and check them against what you learned. Use your own judgment about which guidelines apply to the specific changes — not every guideline is relevant to every change. Prioritize clear, verifiable violations over speculative ones.
+
+Apply the same severity rubric as the other focus areas:
+
+- **Important**: Clear violation of a written guideline that affects user-facing consistency or usability
+- **Minor**: Deviation from preferred vocabulary or a minor inconsistency unlikely to affect users
+
+---
+
+## Output Format
+
+**For `api` focus only**: Begin your response with an `## API Changes Summary` section **before** the Findings section. This section is factual only — list what actually changed in public API surfaces (exports added, modified, or removed in `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `@papi/` modules in `papi.d.ts`, and extensions' type declaration files in `extensions/src/*/src/types/*.d.ts`). Write "None" if no public API surfaces changed. Do not include judgments about whether changes are problematic here — those go in Findings.
+
+```
+## API Changes Summary
+
+[Factual list of additions, modifications, and removals in public API surfaces.
+One bullet per change. E.g.:
+- `lib/platform-bible-utils`: Added `fooBar()` export
+- `lib/platform-bible-utils`: Removed `oldHelper()` export
+- `@papi/core`: Modified `useSetting()` — added optional `defaultValue` parameter]
+```
+
+Return your findings in this exact markdown format:
+
+```
+## Findings
+
+### Critical (must address)
+
+- [ ] `path/to/file.ts`: [specific finding with explanation and suggested fix if applicable]
+
+### Important (should address)
+
+- [ ] `path/to/file.ts`: [specific finding with explanation]
+
+### Minor (consider)
+
+- [ ] `path/to/file.ts`: [specific finding]
+
+### Positive Observations
+
+- [things done well — good patterns, clean code, good tests, etc.]
+
+### Template Propagation
+
+#### Shared Regions Modified
+
+- [ ] `path/to/file.ts:42-87` — region shared with `https://github.com/paranext/paranext-multi-extension-template`
+
+#### Extension Config Changes
+
+- [ ] `extensions/webpack.config.ts` — propagate to `paranext-multi-extension-template`
+- [n/a] `extensions/src/hello-world/src/types.ts` — extension-specific, no propagation needed
+```
+
+If a section has no entries, write "None." instead of leaving it empty.
+
+## Status reporting
+
+End your response with one of:
+
+- **DONE** — analysis complete, findings returned in the format above
+- **DONE_WITH_CONCERNS** — findings returned, but you have a caveat about the analysis itself (e.g., a git command failed for some files, or the diff was too large to analyze fully)
+- **NEEDS_CONTEXT** — missing required input (`MERGE_BASE`, `focus`, or `BASE_BRANCH` not provided)
+- **BLOCKED** — git commands failed and findings cannot be produced (describe the error)

--- a/.claude/agents/shadcn-customization-tracker.md
+++ b/.claude/agents/shadcn-customization-tracker.md
@@ -1,0 +1,168 @@
+---
+name: shadcn-customization-tracker
+description: "Analyzes a batch of shadcn component files in lib/platform-bible-react/src/components/shadcn-ui/ and reports all customizations made relative to the original boilerplate. Returns one structured markdown report block per file for aggregation by the shadcn-customizations command. Input: a list of file paths relative to the paranext-core repo root."
+allowed-tools: Bash, Read, Grep
+---
+
+# Shadcn Customization Tracker
+
+You analyze a batch of shadcn component files and produce a structured markdown report of all customizations made to each one relative to the original boilerplate.
+
+**Before doing anything else**, read [shadcn/ui Guidelines](../../.context/standards/Code-Style-Guide.md#shadcnui-guidelines). It is the authoritative source for all conventions you will apply: boilerplate baseline, `// CUSTOM:` annotations, and the standard customizations. If anything in these instructions conflicts with that section, trust the section.
+
+## Input
+
+You will be given a list of file paths relative to the paranext-core repo root, one per line, e.g.:
+
+```
+lib/platform-bible-react/src/components/shadcn-ui/button.tsx
+lib/platform-bible-react/src/components/shadcn-ui/card.tsx
+lib/platform-bible-react/src/components/shadcn-ui/checkbox.tsx
+```
+
+The repo root can be resolved via `git rev-parse --show-toplevel` from anywhere inside the repo.
+
+**Run the full algorithm below for each file in the list, in order.** Output one `## filename.tsx` report block per file. Concatenate all blocks in the order the files were given.
+
+## Algorithm
+
+Run Steps 1–4 for each file, then output its Step 5 report block before moving on to the next file.
+
+### Step 1 — Read the current file
+
+Read the full file. As you read:
+
+- Collect every `// CUSTOM:` comment and the code it annotates (the line(s) immediately after)
+- Collect any other comments that clearly indicate customization intent (e.g. "CUSTOM JSDoc comments added", "Changed from X to Y", "Added for accessibility")
+- List every exported symbol (functions, interfaces, constants, types) for the TSDocs check, and for each:
+  - **Presence**: Does it have a TSDoc comment (`/** ... */`)?
+  - **Library links**: Does the TSDoc contain a URL linking to the upstream library docs? Required links depend on what the file imports:
+    - shadcn/ui boilerplate → link to the shadcn/ui component page (e.g., `https://ui.shadcn.com/docs/components/...`)
+    - `@radix-ui/*` imports → link to Radix UI docs (e.g., `https://www.radix-ui.com/...`)
+    - `vaul` → link to Vaul docs; other notable upstream libraries → link to their docs
+  - **`@inheritdoc` handling**: If a TSDoc consists of `@inheritdoc <Symbol>` (or `{@inheritdoc}`), locate that symbol's TSDoc (same file or imported) and check it for library links — if the linked TSDoc has the required links, count this export as passing both checks.
+- Identify all DOM-rendered components (see criteria below)
+
+**Identifying DOM-rendered components:** A component is DOM-rendered if it produces actual DOM output and could be used standalone. Criteria:
+
+- Prop types include an HTML element type directly: `HTMLDivElement`, `HTMLButtonElement`, `HTMLInputElement`, `HTMLSpanElement`, etc.
+- Prop types use `React.ComponentPropsWithoutRef<typeof SomePrimitive>`, `React.ComponentProps<...>`, or `React.HTMLAttributes<...>` — these wrap an underlying DOM element via a Radix primitive
+- Component is declared with `React.forwardRef<HTMLSomeElement, Props>(...)`
+- When uncertain: look at what the component renders — if it renders an HTML tag or a Radix primitive (`PopoverPrimitive.Content`, `DialogPrimitive.Content`, etc.), it is DOM-rendered
+
+**Not DOM-rendered:** compound root components that coordinate state without a DOM representation (e.g. `Popover`, `Dialog`, `DropdownMenu` roots); cva variant factories like `buttonVariants` (these are functions, not components).
+
+**For each exported symbol**, determine:
+1. Is it DOM-rendered? → check for `pr-twp` in its rendered output (either directly in its JSX or via a variant factory it applies as className). Record `ComponentName → pr-twp ✅` or `ComponentName → pr-twp ❌`.
+2. Is it not DOM-rendered? → record `ExportName — not DOM-rendered (reason)`.
+3. Include ALL exported symbols (components, interfaces, variant factories, types) in the DOM-rendered components list so the reader has a complete picture. Interfaces/types that are not components can be noted as `TypeName — type/interface, not a component`.
+
+### Step 2 — Get boilerplate diff
+
+Run exactly:
+
+```bash
+REPO_ROOT=$(git rev-parse --show-toplevel)
+FILE="<the file path you were given, relative to repo root>"
+FIRST_ADD=$(git -C "$REPO_ROOT" log --grep 'npx shadcn apply --preset' --follow --pretty=format:%h -1 -- "$FILE")
+if [ -z "$FIRST_ADD" ]; then
+  FIRST_ADD=$(git -C "$REPO_ROOT" log --diff-filter=A --follow --pretty=format:%h -1 -- "$FILE")
+fi
+echo "Boilerplate baseline commit: $FIRST_ADD"
+git -C "$REPO_ROOT" diff "${FIRST_ADD}..HEAD" -- "$FILE"
+```
+
+**Why `--grep 'npx shadcn apply --preset' --follow --pretty=format:%h -1`:** Finds only commits where the baseline was re-applied. `--follow` ensures we find the commit even if the file was renamed. `--pretty=format:%h` takes just the commit hash. `-1` takes the most recent matching commit — correct even if the baseline was applied multiple times, because the most recent matching commit is the last known boilerplate state.
+
+**Edge case — `$FIRST_ADD` is empty:** The file was introduced in a way git doesn't surface with `--diff-filter=A` (e.g., a squash-merge). Do NOT silently skip. In the Uncalled-out section, write:
+
+> ⚠️ Could not determine boilerplate baseline: no new baseline commit found via `git log --grep 'npx shadcn apply --preset' --follow`. Uncalled-out customizations from git history are unavailable for this file.
+
+**Edge case — diff is empty (but `$FIRST_ADD` exists):** The file was added in its already-customized form and hasn't changed since. In the Uncalled-out section, write:
+
+> File appears unchanged since its baseline commit (diff is empty). Either all customizations were already present at the time of the baseline commit, or no customizations have been made since.
+
+### Step 3 — Non-shadcn heuristic check
+
+Inspect the boilerplate state:
+
+```bash
+git -C "$REPO_ROOT" show "${FIRST_ADD}:${FILE}" | head -30
+```
+
+Check whether the boilerplate content includes recognizable shadcn patterns: imports from `@radix-ui`, use of `cva`, use of the `cn` utility. If none are present, inspect the commit message (`git -C "$REPO_ROOT" show --no-patch "$FIRST_ADD"`) and the file's overall structure before continuing.
+
+**Known limitation:** This heuristic only catches files that look nothing like shadcn. A custom component that uses the same conventions (radix, cva, cn) will pass the check even if it was never copied from the shadcn boilerplate. The check is a safety net, not a guarantee. If genuinely uncertain, skip with a note rather than produce a potentially misleading analysis.
+
+### Step 4 — Analyze uncalled-out changes
+
+Go through the diff line by line. For each changed section:
+
+1. Determine whether it is already documented by a `// CUSTOM:` comment or another custom-indicating comment in the current file
+2. If not documented: record it as an uncalled-out customization with:
+   - **Where**: which component, which element, prop, or class string
+   - **What**: what changed from the boilerplate to now
+   - **Why**: your best assessment of the purpose (note uncertainty if unsure)
+
+Be thorough. If in doubt about whether something should be listed, list it with a note that you weren't certain.
+
+### Step 5 — Output this file's report block
+
+After completing Steps 1–4 for the current file, output its report block before proceeding to the next file. Use `(none)` for empty sections, never leave them blank.
+
+```markdown
+## <filename.tsx>
+
+### Standard customizations
+
+- TSDocs present: [✅ all exports / ❌ missing on: ExportA, ExportB]
+- TSDocs library links: [✅ all have links / ❌ missing links on: ExportC, ExportD (via @inheritdoc: ✅ ExportE)]
+- DOM-rendered components:
+  - `ComponentName` → pr-twp ✅
+  - `OtherComponent` → pr-twp ❌
+  - `VariantFactory` — not DOM-rendered (cva variant factory, not a component)
+  - `RootComponent` — not DOM-rendered (compound root, coordinates state only)
+
+### Explicit `// CUSTOM:` customizations
+
+- **Where:** [exact location — component name, prop, class string, etc.]
+  **What:** [what was changed or added]
+  **Why:** [the explanation from the comment]
+
+### Other comment-indicated customizations
+
+- **Where:** [location]
+  **What:** [what was changed]
+  **Note:** [explanation from the comment]
+
+### Uncalled-out customizations (from git history)
+
+- **Where:** [location]
+  **What:** [what changed from boilerplate to current]
+  **Why:** [your assessment]
+  **Note:** [if uncertain, say so here]
+```
+
+**If you skip the file**, return:
+
+```markdown
+## <filename.tsx>
+
+⚠️ Skipped: [reason — e.g., "boilerplate state contains no shadcn patterns and commit message does not reference shadcn"]
+
+### Standard customizations
+
+⚠️ Skipped — see above
+
+### Explicit `// CUSTOM:` customizations
+
+⚠️ Skipped — see above
+
+### Other comment-indicated customizations
+
+⚠️ Skipped — see above
+
+### Uncalled-out customizations (from git history)
+
+⚠️ Skipped — see above
+```

--- a/.claude/commands/add-shadcn-component.md
+++ b/.claude/commands/add-shadcn-component.md
@@ -1,0 +1,235 @@
+# Add Shadcn Component
+
+This command adds a single new shadcn/ui component to `lib/platform-bible-react/src/components/shadcn-ui/` as a clean baseline, then adds the standard project customizations (`pr-twp` and TSDocs with library links) in a second commit. It follows the same two-stage commit pattern as `/upgrade-shadcn` so future upgrades can cleanly diff what shadcn generated vs. what we customized.
+
+**Component parameter**: This command accepts an optional component name argument (e.g. `/add-shadcn-component progress`). If no component is provided, see [Determining the Component Name](#determining-the-component-name) below.
+
+**Before doing anything else**, read [shadcn/ui Guidelines](../../.context/standards/Code-Style-Guide.md#shadcnui-guidelines). It is the authoritative source for all conventions used in this command: folder structure, boilerplate baseline, `// CUSTOM:` annotations, and the standard customizations. If anything in this command conflicts with that section, trust the section.
+
+## Determining the Component Name
+
+If a component argument was provided to this command, record it as `$COMPONENT` and skip to [Pre-flight Checks](#pre-flight-checks).
+
+If no component was provided, ask the user:
+
+> Which shadcn/ui component would you like to add? (e.g. `progress`, `slider`, `toast`)
+
+Record the response as `$COMPONENT`.
+
+## Pre-flight Checks
+
+Perform these checks in sequence. Do not proceed past a failed check.
+
+### Check 1 — No uncommitted working changes
+
+Run:
+
+```bash
+git status --porcelain
+```
+
+If any output appears, tell the user:
+
+> There are uncommitted working changes. Please commit or stash them before continuing, then let me know when the working tree is clean.
+
+Do not continue until `git status --porcelain` returns empty output.
+
+### Check 2 — Component not already present
+
+Run:
+
+```bash
+ls lib/platform-bible-react/src/components/shadcn-ui/
+```
+
+If `$COMPONENT.tsx` appears in the listing, tell the user:
+
+> `$COMPONENT.tsx` already exists in the shadcn-ui folder. This command is for adding new components. To re-document or fix customizations on an existing component, use `/shadcn-customizations` instead.
+
+Do not continue.
+
+### Create Branch
+
+After both checks pass, create a new branch:
+
+```bash
+FIRST_NAME=$(git config user.name | awk '{print tolower($1)}')
+TODAY=$(date +%m-%d-%Y)
+git checkout -b "ai/feature/add-shadcn-${COMPONENT}-${FIRST_NAME}-${TODAY}"
+```
+
+## Determine Preset
+
+Run the following to detect the most recently used preset:
+
+```bash
+cd lib/platform-bible-react && npm run get-latest-preset
+```
+
+Record the output as `$PRESET`. This value is embedded in the baseline commit message so future shadcn tooling — including `get-latest-preset` itself, which greps git history for `npx shadcn apply --preset` — can locate this component's baseline even though `npx shadcn apply` is not literally run.
+
+## Step 0 — Verify Standard Customizations Are In Sync
+
+After reading the [shadcn/ui Guidelines](../../.context/standards/Code-Style-Guide.md#shadcnui-guidelines), compare the standard customizations listed there against the standard customizations this command tracks — named in this Step 0 and in Step 2 below (currently: "TSDocs on all exports?" and "pr-twp on DOM-rendered components?").
+
+If the style guide lists standard customizations that are not represented here, or vice versa, **stop immediately** and tell the user:
+
+> The standard customizations in [shadcn/ui Guidelines](.context/standards/Code-Style-Guide.md#shadcnui-guidelines) no longer match what this command tracks. Please update this command, all other shadcn commands, and the `shadcn-customization-tracker` agent to reflect the current standard customizations before running.
+>
+> Suggested prompt to fix this:
+>
+> ```
+> The shadcn/ui Guidelines section of .context/standards/Code-Style-Guide.md defines these standard customizations: [fill in from what you read in the style guide]. The shadcn commands and `shadcn-customization-tracker` agent are out of date — they still track: [fill in from what you read in the commands]. Read the commands and agent to determine what parts need to be updated, and update them to match the style guide.
+> ```
+
+## Step 1 — Add the Component
+
+Run the following from `lib/platform-bible-react/` to add the component and capture output in one step:
+
+```bash
+cd lib/platform-bible-react
+npm run add-shadcn-component -- $COMPONENT $PRESET 2>&1 | tee ../../shadcn-add-output.txt
+```
+
+```powershell
+# Windows (PowerShell):
+cd lib\platform-bible-react
+npm run add-shadcn-component -- $COMPONENT $PRESET 2>&1 | Tee-Object ..\..\shadcn-add-output.txt
+```
+
+This script internally adds the new component, applies the standard project file transforms, runs formatting and lint-fix, and commits to establish a new baseline. The full output is always saved to `shadcn-add-output.txt` in the repository root, whether the script succeeds or fails — tell the user it is available there for reference.
+
+**If the script succeeds and commits on its own**, verify that the commit message contains `npx shadcn apply --preset $PRESET`. If it does, this is **commit 1 of 2** — the fresh shadcn component with no customizations applied. Do not squash or amend it. Proceed to Step 2.
+
+**If the script fails:**
+
+> **Do NOT re-run `add-shadcn-component`** — the output captured above gives you all the information you need.
+
+1. Stage changes in `lib/platform-bible-react` exactly as they came from the script (do not modify anything yet):
+
+   ```bash
+   git add lib/platform-bible-react/
+   git add package-lock.json
+   ```
+
+2. **Dispatch a subagent** to fix any simple, obvious problems flagged by the script output. Give it this prompt:
+
+   > You are fixing format and lint errors that occurred after running `add-shadcn-component` for shadcn/ui in `lib/platform-bible-react`. The script output is saved at `shadcn-add-output.txt` in the repository root — read that file to understand exactly what problems were flagged.
+   >
+   > Attempt to fix **simple, obvious problems** — for example, straightforward type errors, missing imports, or lint issues with clear fixes that the script identified. Do **not** run `npm run typecheck` or `npm run build`; those will be handled later after customizations are added. Stick to what the `add-shadcn-component` output flagged.
+   >
+   > For each problem, prefer small, targeted fixes: changing `null` to `undefined`, small type reworks, scoped type assertions with an explanation comment, or minor accessibility improvements. Add a `// CUSTOM: <explanation>` comment immediately before each change you make, explaining what you changed and why.
+   >
+   > **Do NOT add ESLint rule overrides or disable comments to `.eslintrc.cjs` or any other config file.** If a small code-level fix is not possible, leave the problem unfixed and record it.
+   >
+   > When done:
+   > 1. If you fixed **all** problems, re-run the format/lint commands that `add-shadcn-component` specified to verify everything passes (typically `npm run format` and/or `npm run lint-fix` from `lib/platform-bible-react`). Include the output of those commands in your report.
+   > 2. Return a complete report that includes:
+   >    - Every problem you fixed: a description of the problem and exactly how you fixed it (file path, what changed)
+   >    - Every problem you left unfixed: a description with concrete suggestions for how to address it
+   >    - The exact format/lint commands that the `add-shadcn-component` output instructed should be run to verify everything passes
+   >    - If you ran those commands: whether they passed or failed, and the output if they failed
+
+   Wait for the subagent to complete.
+
+3. **STOP — always wait for user review before proceeding**, even if the subagent fixed every problem and all commands passed. Show the user the subagent's complete report and say:
+
+   > The subagent made changes after `add-shadcn-component` failed. Please review the changes above and let me know:
+   >
+   > - If you approve the changes and are ready for me to continue, or
+   > - If you want to fix anything yourself, ask me to fix something differently, or suggest an alternative approach.
+   >
+   > The full script output is also available at `shadcn-add-output.txt` in the repository root for your reference.
+
+   **Do not proceed until the user explicitly confirms they approve the changes.**
+
+4. If you or the user made any further changes after the subagent, re-run the format/lint commands that the `add-shadcn-component` output specified to verify everything still passes:
+
+   ```bash
+   cd lib/platform-bible-react
+   # run whichever commands the script output specified (typically npm run format and/or npm run lint-fix)
+   ```
+
+   If any command fails, stop and report the errors to the user before proceeding. If no further changes were made and the subagent already verified those commands passed, skip this step.
+
+5. Once all commands pass, stage changes and commit using the message the `add-shadcn-component` output provided:
+
+   ```bash
+   git add lib/platform-bible-react/
+   git add package-lock.json
+   git commit --no-verify -m "<message from add-shadcn-component output>"
+   ```
+
+   **Before committing**, verify the commit message contains `npx shadcn apply --preset $PRESET`. If the script did not supply a commit message, use: `chore: add shadcn component $COMPONENT (npx shadcn apply --preset $PRESET) as a new baseline`.
+
+This is **commit 1 of 2**: the raw shadcn component with no project customizations. Do not squash or amend it — it is the reference point for all future customization diffs, mirroring the role of `/upgrade-shadcn`'s commit 1.
+
+## Step 2 — Add Standard Customizations
+
+Read `lib/platform-bible-react/src/components/shadcn-ui/$COMPONENT.tsx`.
+
+Apply the following standard customizations. Each change must be annotated with a `// CUSTOM:` comment placed **immediately before** the changed code, explaining what was changed, what it does, and why — see [shadcn/ui Guidelines](../../.context/standards/Code-Style-Guide.md#shadcnui-guidelines) for the full `// CUSTOM:` convention.
+
+**Standard customizations to apply:**
+
+1. **`pr-twp` on DOM-rendered components** — Add `pr-twp` at the **front** of the base Tailwind class string on every DOM-rendered component (components whose props use `HTMLElement`-flavored types, `React.ComponentPropsWithoutRef<...>`, `React.HTMLAttributes<...>`, or `React.forwardRef<HTMLSomeElement, ...>`). Does NOT apply to compound state-coordinating roots (e.g. `Dialog`, `Popover` roots) or cva variant factories.
+
+2. **TSDocs with library links on all exports** — Add a `/** ... */` TSDoc comment on every exported symbol (components, interfaces, types, constants). Each TSDoc must include hyperlinks to the upstream library docs for that component (the shadcn/ui component page, the Radix UI primitive page, the Vaul page for drawer components, etc.). A TSDoc that uses `@inheritdoc <Symbol>` pointing to a symbol whose TSDoc already has the required links also passes.
+
+   To get the canonical shadcn/ui docs URL for the component, run:
+
+   ```bash
+   npx shadcn docs $COMPONENT --json
+   ```
+
+   Use the `docs` URL from the output as the shadcn/ui link. For Radix UI links, search [radix-ui.com/primitives](https://www.radix-ui.com/primitives/docs/overview/introduction) manually.
+
+## Step 3 — Code Quality
+
+Run these commands in sequence from `lib/platform-bible-react/`. Resolve any issues in the component file before moving to the next command:
+
+1. ```bash
+   cd lib/platform-bible-react && npm run typecheck
+   ```
+
+   Fix any TypeScript errors in `src/components/shadcn-ui/$COMPONENT.tsx` before proceeding.
+
+2. ```bash
+   cd lib/platform-bible-react && npm run lint-fix
+   ```
+
+   Auto-fix lint issues. If non-auto-fixable errors remain, fix them manually in the component file. Do **not** add ESLint rule overrides or disable comments to `lib/platform-bible-react/.eslintrc.cjs` or any other config file — fix the code instead.
+
+3. ```bash
+   cd lib/platform-bible-react && npm run format
+   ```
+
+   Auto-format. No manual action needed unless it exits non-zero.
+
+4. ```bash
+   cd lib/platform-bible-react && npm run build
+   ```
+
+   The build must pass before committing. If the build fails, fix the issues in the component file before continuing.
+
+If any issue cannot be resolved with a small, targeted fix (e.g. a type error requires understanding design intent or the build failure has an unclear root cause), **stop and discuss with the user** before proceeding. Do not commit until all four commands pass cleanly.
+
+## Step 4 — Commit the Customizations
+
+```bash
+git add lib/platform-bible-react/
+git commit -m "chore: apply standard customizations to new shadcn component $COMPONENT"
+```
+
+This is **commit 2 of 2**. Do not squash — the two-commit history allows future shadcn upgrades to cleanly diff what shadcn generated vs what we customized, the same way the three-commit history works for `/upgrade-shadcn`.
+
+## Step 5 — Create PR
+
+Use the `pr-creator` skill to create the PR targeting **`main`**.
+
+The PR description must include:
+
+- A summary of the two-commit structure: commit 1 is the raw shadcn baseline (with standard file transforms but no project customizations), commit 2 is the standard project customizations (`pr-twp` and TSDocs).
+- A prominent warning:
+
+> ⚠️ **This PR MUST NOT be squash-merged.** Use a normal merge. The two-commit history is essential for future shadcn upgrades: commit 1 shows exactly what shadcn generated (baseline with no customizations), commit 2 shows the project customizations. Squashing destroys this history.

--- a/.claude/commands/review-paratext.md
+++ b/.claude/commands/review-paratext.md
@@ -1,0 +1,648 @@
+---
+description: Optionally pass the branch purpose as an argument. AI-assisted code review with author interview. e.g. /review-paratext Fix the app freeze when opening the editor
+---
+
+# Review Paratext
+
+AI-assisted code review with author interview. Run this before posting a PR. Optionally pass the branch purpose as an argument, e.g. `/review-paratext Fix the app freeze when opening the editor`.
+
+## Overview
+
+This command:
+
+1. Analyzes all changes on your branch since it diverged from the base branch
+2. Runs four parallel analysis passes (API/correctness, style/patterns, coverage/compliance, UX design guide)
+3. Interviews you about the changes to verify understanding and surface issues
+4. Writes `.review/summary.md` with findings and interview notes
+5. Optionally creates or updates a PR with the summary as the description
+
+---
+
+## Initial Setup
+
+### Step 0 — Determine the Claude model and session URL
+
+Determine which Claude model is currently running this command and set a `MODEL_NAME` variable to be used in all commit messages. The variable should be in the format "Claude Sonnet 4.6" or "Claude Haiku 4.5", etc.
+
+**Approach**:
+- Check if there is an environment variable (e.g., `CLAUDE_MODEL`) set by Claude Code
+- If available, parse it to extract the friendly name and store it as `MODEL_NAME`
+- If not available, use introspection or context to determine the model name
+- If still unable to determine, ask the author: "What Claude model are you using for this review?" and use their response
+
+Store the result as `MODEL_NAME` for use in all subsequent commit messages.
+
+Also determine the current Claude Code **session URL** (e.g. `https://claude.ai/code/session_<id>`) and store it as `SESSION_URL`. Look for it in the session/transcript context or an environment variable; if it cannot be determined, ask the author to paste their session URL, or fall back to the literal `<session URL>` for them to fill in. `SESSION_URL` is used for the `Session-URL:` commit trailer and the PR-body AI-assisted line, per the project's authorship convention (see CLAUDE.md).
+
+### Step 0.5 — Introduce the review process
+
+Output the following to the author before doing anything else:
+
+> **Here's what this review will do:**
+>
+> 1. **Setup** — Check your branch and ask a couple of quick questions
+> 2. **Analysis** — Run four parallel analysis passes (API/correctness, style/patterns, coverage/compliance, UX design guide) — this happens automatically
+> 3. **Interview** — Walk through the findings with you
+> 4. **Output** — Write `.review/summary.md` and optionally create or update a PR
+>
+> **During the interview, you can:**
+> - Explain your changes — your explanations go into the summary for your reviewer
+> - Tell me a finding is not an issue — it will be marked as dismissed with your explanation
+> - Ask me to fix something — I will implement it and stage it, then keep going
+> - Say you don't know or aren't sure about something — that gets recorded so your reviewer can help you learn about it in the meeting
+>
+> **What I will do** based on what you say:
+> - Record your explanations and context in the summary
+> - Make code changes you request
+> - After the interview, if any fixes were made, run quality checks (`typecheck`, `lint`, `format`, `test`) and fix any issues introduced
+>
+> **At the end**, I will write `.review/summary.md` then offer to commit changes and check for an existing PR and update it, or create a new one.
+>
+> Let's get started.
+
+---
+
+## Phase 1: Setup
+
+### Step 1.1 — Validate branch
+
+```bash
+BRANCH=$(git branch --show-current)
+echo "Current branch: $BRANCH"
+```
+
+If `$BRANCH` is `main`, stop and tell the author:
+
+> "You must run this command from a feature branch, not from `$BRANCH`."
+
+### Step 1.2 — Check for uncommitted changes
+
+```bash
+git status --porcelain
+```
+
+If there are uncommitted changes, inform the author:
+
+> "You have uncommitted changes. During the review, I will stage any fixes I make. All uncommitted changes — yours and mine — will be committed together in a single commit at the end.
+>
+> **If you have changes you want to keep as a separate commit from any review fixes**, commit them now before continuing.
+>
+> Would you like to commit all your current working changes now with a commit message you provide — or say 'continue' to fold them into the final review commit?"
+
+- If the author provides a commit message: run `git add -A` and commit with their message (append `Co-Authored-By: $MODEL_NAME <noreply@anthropic.com>` and `Session-URL: $SESSION_URL` to the commit body). Then continue.
+- If the author says to continue: proceed with the working changes included in the review.
+
+### Step 1.3 — Auto-detect base branch and compute diff range
+
+Run this entire block as a **single bash command** so that `BASE_BRANCH` flows directly into the diff range computation without any risk of the variable being lost between calls:
+
+```bash
+git fetch origin --quiet 2>/dev/null || true
+
+MAIN_MERGE_BASE=$(git merge-base origin/main HEAD 2>/dev/null || echo "")
+
+if [ -z "$MAIN_MERGE_BASE" ]; then
+  echo "BASE_BRANCH=UNKNOWN"
+  echo "ERROR: Could not detect base branch — will ask author"
+else
+  BASE_BRANCH="origin/main"
+fi
+
+echo "BASE_BRANCH=$BASE_BRANCH"
+
+if [ "$BASE_BRANCH" != "UNKNOWN" ]; then
+  MERGE_BASE=$(git merge-base "$BASE_BRANCH" HEAD)
+  HEAD_SHA=$(git rev-parse HEAD)
+  FILE_COUNT=$(git diff --name-only "$MERGE_BASE" | wc -l | tr -d ' ')
+  INITIAL_COMMIT_COUNT=$(git log "$MERGE_BASE..$HEAD_SHA" --oneline | wc -l | tr -d ' ')
+  echo "MERGE_BASE=$MERGE_BASE"
+  echo "HEAD_SHA=$HEAD_SHA"
+  echo "FILE_COUNT=$FILE_COUNT"
+  echo "INITIAL_COMMIT_COUNT=$INITIAL_COMMIT_COUNT"
+  echo "Changed files (including uncommitted):"
+  git diff --name-only "$MERGE_BASE"
+fi
+```
+
+**If BASE_BRANCH is UNKNOWN**: ask the author: "Could not auto-detect your base branch. Which branch should I diff against?" Accept their input, then re-run the diff range portion of the script above using that value.
+
+Store `BASE_BRANCH`, `MERGE_BASE`, `HEAD_SHA`, `FILE_COUNT`, and `INITIAL_COMMIT_COUNT` from the script output for use in all later steps.
+
+Report to the author: "Analyzing $FILE_COUNT files changed since branching from `$BASE_BRANCH`."
+
+### Step 1.5 — Check .gitignore
+
+```bash
+grep -qE "^\.review(/?)$" .gitignore 2>/dev/null && echo "present" || echo "missing"
+```
+
+If `.review` is not in `.gitignore` (output is "missing"), ask and **wait for the author's response before continuing**:
+
+> "As part of this review, I will write a review summary to `.review/summary.md`. The `.review/` folder is not in `.gitignore`, so it may show up as untracked in git status. Would you like me to add it to `.gitignore` now?"
+
+If yes:
+
+```bash
+echo ".review" >> .gitignore
+git add .gitignore
+git commit -m "$(cat <<'EOF'
+chore: add .review to .gitignore
+
+Co-Authored-By: $MODEL_NAME <noreply@anthropic.com>
+Session-URL: $SESSION_URL
+EOF
+)"
+```
+
+**Complete this step fully before proceeding to Step 1.6. Do not combine this question with the purpose statement question.**
+
+### Step 1.6 — Retrieve purpose statement
+
+Check if the user provided text after `/review-paratext` (i.e., a purpose argument).
+
+- **If a purpose argument was provided**: use it directly as `PURPOSE`.
+- **If no argument was provided**: ask the author:
+  > "What is the overall purpose of these changes? Please describe it in your own words.
+  >
+  > (Tip: you can skip this question next time by passing the purpose as an argument — e.g. `/review-paratext Fix the app freeze when opening the editor`)"
+
+  Wait for their response. Do not proceed until the author provides one.
+
+Store as `PURPOSE`.
+
+---
+
+## Phase 2: Parallel Analysis
+
+Dispatch four instances of the `review-analyzer` agent in parallel using the Agent tool. All four must be dispatched in a single response (four Agent tool calls in the same message). Pass `MERGE_BASE`, `BASE_BRANCH`, and the `focus` value for each:
+
+| Instance | focus        | Covers                                                                                                             |
+| -------- | ------------ | ------------------------------------------------------------------------------------------------------------------ |
+| Agent 1  | `api`        | Priority 1 (API changes), Priority 2 (Correctness)                                                                |
+| Agent 2  | `style`      | Priority 3 (Code style), Priority 4 (Reuse), Priority 5 (Architecture), Priority 6 (Code quality)                 |
+| Agent 3  | `compliance` | Priority 7 (Test coverage), Priority 8 (Localization), Priority 9 (Template propagation), Priority 10 (Storybook Stories), Priority 11 (Build config/process) |
+| Agent 4  | `ux`         | UX Design Guide — reads guide files from Storybook source; skips automatically if no UI code was changed           |
+
+When dispatching each agent, use `subagent_type: "review-analyzer"` in the Agent tool call to target the specialized analysis agent (not a generic agent).
+
+Prompt for each agent instance (substitute `$FOCUS`, the actual values, and `$PURPOSE`):
+
+> Analyze the branch changes with focus=`$FOCUS`.
+>
+> MERGE_BASE: `$MERGE_BASE`
+> BASE_BRANCH: `$BASE_BRANCH`
+> PURPOSE: `$PURPOSE`
+> focus: `$FOCUS`
+>
+> Follow the instructions in your agent definition exactly. Return findings in the specified output format.
+
+### Merging Results
+
+After all four agents return:
+
+1. Combine all findings into a single unified list
+2. Order by priority (Critical first, then Important, then Minor)
+3. Deduplicate: if two agents flagged the same file for the same concern type (e.g., both flag a missing `// CUSTOM` comment on the same component), keep the higher-severity version with the more detailed description. Do NOT deduplicate findings about the same file that are for different concerns — those are distinct issues and must both be kept.
+4. Collect the Template Propagation sections from the compliance agent's output separately (as `TEMPLATE_PROPAGATION`). Collect Positive Observations from all four agents and union them (removing near-duplicates) into `POSITIVE_OBSERVATIONS`. Extract the `## API Changes Summary` section from the `api` agent's output as `API_CHANGES_SUMMARY` — this is the factual list of public API changes that goes directly into the summary. Store these alongside `MERGED_FINDINGS` for use in Phase 4.
+
+**Partial failure**: If one agent fails to return, note which focus area failed in the summary output and proceed with the other agents' results.
+
+**Agent status handling**: Each `review-analyzer` agent ends its response with a status token. Handle as follows:
+- `DONE` — proceed normally with the findings
+- `DONE_WITH_CONCERNS` — include the agent's caveat in the summary (e.g., note that some files couldn't be analyzed due to size)
+- `BLOCKED` — treat the same as partial failure: note which focus area was blocked, proceed with the other three agents' results
+- `NEEDS_CONTEXT` — this indicates a bug in the dispatch (missing MERGE_BASE, HEAD, focus, or BASE_BRANCH); stop and report the error to the author
+
+Internally store the merged findings as `MERGED_FINDINGS` for use in the interview.
+
+---
+
+## Phase 3: Adaptive Interview
+
+Conduct a conversation with the author to verify understanding and surface context for the summary.
+
+**Interview budget**: Aim for 5-15 questions total. If the author cannot explain a Critical finding after 2 follow-up attempts, record it as "unresolved" in Interview Notes rather than continuing to drill.
+
+**In-review changes**: During the interview, the author may instruct you to make changes to resolve findings. **If the author asks you to make a change, you MUST implement it.** If the change is ambiguous enough that you cannot safely implement it without more information, ask one clarifying question. Otherwise implement immediately — do not defer it, and do not suggest the author do it themselves. Implement the change, stage it with `git add` (do not commit yet), and continue the interview. All in-review changes are committed together in Step 5.1.
+
+- For **small, focused changes** (editing a few lines, renaming a variable, adding a comment): implement it directly, stage it with `git add`, and continue the interview.
+- For **large or context-heavy changes** (many files affected, or likely to require running checking tools like `npm run typecheck`): spin up a general-purpose subagent to implement the change and report back. Pass the subagent the relevant file paths, the finding description, and the desired change. Instruct the subagent to stage (git add) but not commit the changes. Wait for the subagent to complete before continuing the interview.
+
+In both cases, record the change in `INTERVIEW_CHANGES` (a list of `{ finding, description_of_change }`). Do **not** remove the finding from `MERGED_FINDINGS` — it will appear as checked off in the final summary with a note about what was changed. Then continue the interview.
+
+**Empty findings case**: If `MERGED_FINDINGS` has zero Critical and zero Important findings, skip Step 3.2 and Step 3.3. In Step 3.4, go directly to presenting Minor findings (if any) as a list, leading with: "The analysis found no critical or important issues — nice work."
+
+### Step 3.1 — Opening summary
+
+Present a concise summary of the analysis results:
+
+> "Here's what I found:
+>
+> - **$FILE_COUNT files changed** since branching from `$BASE_BRANCH`
+> - **Critical findings**: N
+> - **Important findings**: N
+> - **Minor findings**: N
+> - **Areas affected**: [list top areas, e.g., lib/platform-bible-utils, extensions]
+>
+> Let's talk through the changes."
+
+### Step 3.2 — Critical and Important findings
+
+**Present one finding at a time.** Ask about one Critical or Important finding, wait for the author's response, then move to the next. Do not batch unrelated findings together.
+
+**Exception**: If two or more adjacent findings are closely related (e.g., two issues in the same file, or two findings that stem from the same root cause), you may present them together in a single message. If you do, end the message with: "I'm asking about N findings at once — please respond to each."
+
+For each Critical finding, then each Important finding:
+
+- Ask the author about it directly and specifically
+- Example: "I noticed you removed the `getFoo()` export from `platform-bible-utils`. Was this intentional? Consumers may depend on it — is there an alternative?"
+- If the author has a good explanation, note it and move on
+- If the response is vague or reveals misunderstanding, ask one follow-up
+- If still unresolved after the follow-up, record as "unresolved" in the notes
+
+### Step 3.3 — Design understanding
+
+**IMPORTANT**: Step 3.3 must never be combined with the last Step 3.2 question in the same message. After receiving the author's response to the final Critical/Important finding, send a fresh message to begin Step 3.3.
+
+Assess the author's demonstrated understanding from their responses in Step 3.2.
+
+**If the changes are large (>10 files changed) or involve non-obvious design decisions**, or **if any responses in Step 3.2 were vague or revealed gaps in understanding**, ask the author to explain the most complex or non-obvious part in their own words:
+
+> "Can you walk me through the most complex or non-obvious part of these changes? I want to make sure I understand the reasoning."
+
+**Wait for the author's response before continuing to Step 3.4.**
+
+Record their explanation.
+
+**Lack of understanding signals — watch for these in the author's response:**
+
+- "The AI did it / Claude handled that" or similar deferrals to an AI tool
+- "I'm not sure" / "I don't know" / "I'm not entirely certain how it works"
+- Vague answers that don't actually explain the reasoning or mechanism
+- Inability to describe what a specific changed section does
+
+**If the author defers to an AI or expresses genuine uncertainty about their own changes**, record this explicitly as a lack of understanding — do NOT interpret it as satisfaction or acceptance. Note the specific areas they could not explain.
+
+**If the changes are small and the author demonstrated clear understanding**: skip this question entirely and proceed directly to Step 3.4.
+
+### Step 3.4 — Minor findings
+
+Always print all minor findings as a list first, then follow the flow below based on the count.
+
+If there were no Critical or Important findings, lead with: "The analysis found no critical or important issues — nice work."
+
+**If there are more than 3 minor findings**: After printing the list, go through them one at a time. For each finding, ask the author about it, wait for their response, then move to the next. Do not batch them. Example:
+
+> "Here are the minor findings:
+>
+> [full list]
+>
+> Let's go through them one at a time. First: [finding 1 — specific question]"
+
+**If there are 3 or fewer minor findings**: After printing the list, ask the author:
+
+> "Here are the minor findings:
+>
+> [full list]
+>
+> You can respond to all of them now if you'd like, or tell me to go through them one at a time."
+
+Wait for the author's response. If they say to go one at a time, do so. If they respond to all at once, record each response.
+
+Record the author's responses as `MINOR_FINDINGS_RESPONSE` (e.g., "Author said none need discussion" or "Author requested fix for finding X").
+
+**Complete this step and receive the author's response(s) before proceeding to Step 3.5.**
+
+### Step 3.5 — Wrap-up
+
+Ask (as a separate question, after receiving the response to Step 3.4):
+
+> "Is there anything else you want to flag or discuss before I write up the summary? Any tradeoffs you made, things you're uncertain about, or context a reviewer should know?"
+
+Record the author's response.
+
+### Step 3.6 — Collect interview notes
+
+Synthesize from the conversation:
+
+- The author's stated purpose
+- Key decisions the author made and their reasoning
+- Any explanations provided for flagged items
+- Any unresolved items (Critical/Important findings the author could not explain)
+- The author's design explanation from Step 3.3 (if that question was asked), including any uncertainties they expressed
+- **Areas the author did not understand or deferred to AI**: if the author said something like "the AI handled it", "I'm not sure how this works", or could not explain a section, list those areas explicitly as "Author does not understand: [area]". Do NOT reframe this as satisfaction or acceptance.
+- Any additional context the author volunteered
+
+Store as `INTERVIEW_NOTES` for the output phase.
+
+---
+
+## Phase 4: Output
+
+### Step 4.1 — Quality check after in-review changes
+
+**Always run this step.** Do not skip it.
+
+**Sub-step A — Detect whether in-review changes were made:**
+
+```bash
+CURRENT_COMMIT_COUNT=$(git log $MERGE_BASE..HEAD --oneline | wc -l | tr -d ' ')
+HAS_UNCOMMITTED=$(git status --porcelain | wc -l | tr -d ' ')
+echo "Commits at start: $INITIAL_COMMIT_COUNT"
+echo "Commits now: $CURRENT_COMMIT_COUNT"
+echo "Uncommitted changes: $HAS_UNCOMMITTED"
+```
+
+- If `CURRENT_COMMIT_COUNT > INITIAL_COMMIT_COUNT` OR `HAS_UNCOMMITTED > 0` → in-review changes exist; continue to Sub-step B.
+- If both are false → no in-review changes were made; set `QUALITY_CHECK_RESULTS` to empty and skip to Step 4.2.
+
+**Sub-step B — Run quality checks in a subagent:**
+
+Dispatch a general-purpose subagent to run quality checks and fix any issues introduced by the in-review changes. **Instruct the subagent to run all commands synchronously (not as background tasks)** so their output is captured cleanly:
+
+> Run the following quality checks in this order. Fix any failures that are clearly caused by the in-review changes. Stage all fixes with `git add -A` — do NOT commit; all changes will be committed together in a later step. Report which checks passed, which required auto-fixes, and any unfixable failures.
+>
+> 0. **Library rebuilds (if applicable)** — check whether any in-review changes touched files under `lib/platform-bible-react/` or `lib/platform-bible-utils/`. If so, rebuild those libraries first before running the checks below:
+>    - If `lib/platform-bible-react/` has changes: run `npm run build:platform-bible-react`
+>    - If `lib/platform-bible-utils/` has changes: run `npm run build:platform-bible-utils`
+>
+> 1. `npm run typecheck`
+> 2. `npm run lint` (run `npm run lint-fix` to auto-fix if it fails)
+> 3. Format only the files changed in this review — do NOT run `npm run format` as it processes the entire workspace and reformats unrelated files (e.g. MDX documentation via `remark`). Instead run:
+>    ```bash
+>    git diff --name-only $MERGE_BASE | xargs npx prettier --write --ignore-unknown --ignore-path .prettierignorerun 2>/dev/null; echo "format done"
+>    ```
+> 4. `npm test` (run the full test suite; fix only test failures clearly related to the changes made during review)
+>
+> For each command: if it fails, try to fix the root cause in the code, then re-run. If you cannot determine whether a failure is related to the in-review changes, report it but do not fix it. Run all commands synchronously — not as background tasks.
+
+After the subagent completes, ensure any remaining changes are staged:
+
+```bash
+git add -A
+```
+
+Store the subagent's results as `QUALITY_CHECK_RESULTS` (a summary of which checks passed, which needed fixes, and any unfixable failures) for inclusion in the summary. Display `QUALITY_CHECK_RESULTS` now, **before proceeding to Step 4.2**, so the quality output appears above the review summary message.
+
+If there are unfixable failures, notify the author before proceeding:
+
+> "I ran quality checks after the in-review changes and found [X] issue(s) I could not automatically fix: [list]. You may want to address these before posting the PR."
+
+### Step 4.2 — Write .review/summary.md
+
+Always write a completely fresh `.review/summary.md` — never read and merge with any existing file. Use the Write tool to create or overwrite `.review/summary.md` with this structure, filling in all values from the analysis and interview. Use `MERGED_FINDINGS` for the Findings sections, `TEMPLATE_PROPAGATION` for the Template Propagation section, `POSITIVE_OBSERVATIONS` for the Positive Observations section, `INTERVIEW_NOTES` for the Interview Notes section, and `QUALITY_CHECK_RESULTS` for the In-Review Quality Check section (omit that section if Step 4.1 was skipped):
+
+```markdown
+# Code Review Summary
+
+**Branch**: <BRANCH>
+
+**Base**: <BASE_BRANCH>
+
+**Date**: <today's date>
+
+**Review model**: $MODEL_NAME
+
+**Files changed**: <FILE_COUNT — the exact count from Step 1.3>
+
+## Overview
+
+[1-2 paragraph summary of what the changes do, combining the author's stated purpose
+with the analysis findings. Written in plain prose for a reviewer to read quickly.]
+
+## API Changes
+
+[Use the API_CHANGES_SUMMARY extracted from the `api` analysis agent's output.
+This is a factual list of what changed in public API surfaces — do not paraphrase
+or editorialize. Write "None" if no public API surfaces changed.]
+
+## Findings
+
+Finding states — follow this exactly:
+- `- [ ] **Description**` — **Open**: unchecked, not struck through. Needs author attention.
+- `- [ ] ~~Description~~  _(author's explanation)_` — **Dismissed**: unchecked + struck through. Author explained without a code change. The explanation goes *outside* the strikethrough.
+- `- [x] **Description** _(fixed during review: what changed)_` — **Fixed**: checked, NOT struck through. Addressed with a code change.
+
+**IMPORTANT**: Dismissed items use `[ ]` (unchecked) WITH strikethrough. Fixed items use `[x]` (checked) WITHOUT strikethrough. Never check the box on a dismissed item. Never strike through a fixed item.
+
+Include **ALL** findings in each section — open, dismissed, and fixed.
+
+### Critical — Must address before merge
+
+- [ ] [open finding]
+- [ ] ~~[dismissed finding]~~ _(author's explanation)_
+- [x] [fixed finding] _(fixed during review: [description of change made])_
+
+[Author response: e.g., "Author defended X as intentional because Y. Finding Z was fixed in-review."]
+
+### Important — Should address before merge
+
+- [ ] [open finding]
+- [ ] ~~[dismissed finding]~~ _(author's explanation)_
+- [x] [fixed finding] _(fixed during review: [description of change made])_
+
+[Author response: e.g., "Author acknowledged Y and fixed it during the interview."]
+
+### Minor — Consider
+
+- [ ] [open finding]
+- [ ] ~~[dismissed finding]~~ _(author's explanation)_
+- [x] [fixed finding] _(fixed during review: [description of change made])_
+
+[Author response: e.g., "Author said none of the remaining minor issues need discussion." or "Author addressed X; the rest are acknowledged."]
+
+### Template Propagation
+
+#### Shared Regions Modified
+
+- [ ] `file:lines` — region shared with `repo`
+
+#### Extension Config Changes
+
+- [ ] `file` — propagate to `repo`
+- [n/a] `file` — extension-specific, no propagation needed
+
+## Positive Observations
+
+- [things done well — good patterns, clean code, good tests, etc.]
+
+## Interview Notes
+
+[Key points from the author interview: stated purpose, explanations for
+flagged items, decisions and reasoning. If Step 3.3 was asked, summarize the author's design explanation with enough
+detail that a reviewer can tell what the author was uncertain about and raise
+it in the meeting. Unresolved items (author could not explain
+after follow-ups) are explicitly called out here.
+
+**If the author expressed uncertainty or deferred to AI for any part of the changes**, list those areas explicitly:
+- "Author does not understand: [area] — deferred to AI / said 'I'm not sure how this works'"
+
+Do NOT soften this as "author is satisfied with the approach" or similar. Lack of understanding must be called out directly so the reviewer knows to cover it in the meeting.]
+
+## In-Review Quality Check
+
+[Only present if changes were made during the interview. Summary of quality
+check results: which checks passed cleanly, which required auto-fixes (with
+a brief description of what was fixed), and any unfixable failures the author
+should address. Omit this section entirely if no changes were made during the
+interview.]
+
+## Suggested Review Focus
+
+Prioritized areas for the author-reviewer meeting:
+
+- [ ] [area or concern — e.g., "API change to `foo()` in platform-bible-utils: is the behavior change intentional?"]
+- [ ] [area or concern]
+
+[Include any points where the author expressed uncertainty in Step 3.3, with enough context for the reviewer to discuss them specifically. If the author could not explain certain changes (deferred to AI or said they were unsure), list those areas here as explicit agenda items — e.g., "Author does not understand the X implementation — walk through it in the review meeting."]
+```
+
+If a findings section is empty, write "None." instead of leaving it blank.
+
+### Step 4.3 — Offer PR creation
+
+Display:
+
+> "Review summary written to `.review/summary.md`.
+>
+> Please review `.review/summary.md`, make changes to your branch where appropriate, and run `/review-paratext` again until you are ready to post the PR.
+>
+> If you do not want to make any changes and are ready for review, would you like me to commit (if there are uncommitted changes), push, and post the PR? I will check if one already exists for this branch and update it, or create a new one if not — using this summary as the description."
+
+If the author confirms, proceed to Phase 5. Otherwise, display:
+
+> **Next steps:**
+>
+> 1. Review the summary and fix any issues you agree with
+> 2. If you fixed things, run `/review-paratext` again
+> 3. When satisfied, run `/review-paratext` again and choose to create the PR at that point — or if you prefer to post manually, wrap the summary in `<!-- review-paratext:summary:start -->` / `<!-- review-paratext:summary:end -->` markers so future runs can update it automatically
+> 4. Address Devin AI feedback on the PR
+> 5. Schedule a review meeting with your reviewer — use the "Suggested Review Focus" section as the agenda
+
+---
+
+## Phase 5: PR Creation / Update
+
+This phase runs only if the author confirmed they are ready to create or update a PR.
+
+### Step 5.1 — Commit any working changes and push
+
+**First, commit any uncommitted changes** (fixes made during the interview, quality check fixes, and any pre-existing working changes):
+
+```bash
+git status --porcelain
+```
+
+If there are uncommitted changes, generate a descriptive commit message based on `INTERVIEW_CHANGES`. The message should summarize what was actually fixed during the review — not a generic placeholder. Examples:
+
+- Single fix: `"fix: use ellipsis character instead of three dots in menu labels"`
+- Multiple fixes: `"fix: address review findings\n\n- Replace three-dot ellipses with proper … character\n- Add missing null check in FooComponent\n- Correct sentence case on dialog headings"`
+- If the only changes are from the quality check auto-formatter: `"chore: apply auto-formatting"`
+
+Then commit:
+
+```bash
+git add -A
+git commit -m "$(cat <<'EOF'
+<generated descriptive message>
+
+Co-Authored-By: $MODEL_NAME <noreply@anthropic.com>
+Session-URL: $SESSION_URL
+EOF
+)"
+```
+
+**Then push if there are commits that haven't been pushed yet:**
+
+```bash
+UNPUSHED=$(git log @{u}..HEAD --oneline 2>/dev/null | wc -l || echo "0")
+if [ "$UNPUSHED" -gt "0" ]; then
+  git push
+fi
+```
+
+If the branch has no upstream yet (the push fails with no upstream), push with `-u`:
+
+```bash
+git push -u origin "$(git branch --show-current)"
+```
+
+### Step 5.2 — Detect existing PR
+
+```bash
+PR_INFO=$(gh pr list --head "$(git branch --show-current)" --json number,url --jq '.[0]' 2>/dev/null)
+PR_NUMBER=$(echo "$PR_INFO" | jq -r '.number // empty')
+PR_URL=$(echo "$PR_INFO" | jq -r '.url // empty')
+```
+
+- If `PR_NUMBER` is empty → no PR exists, go to "Create new PR"
+- If `PR_NUMBER` is set → PR exists, go to "Update existing PR"
+
+### Step 5.3a — Create new PR
+
+1. Generate PR title:
+   - Extract JIRA prefix from branch name: `pt-1234-anything` → `PT-1234:`
+   - If no JIRA prefix found, use no prefix
+   - Derive a sentence-case title from the main focus of the changes as understood from the analysis and interview — not just the branch slug
+   - Example: branch `pt-1234-improve-my-feature`, main change is a performance fix → `PT-1234: Improve performance of foo rendering`
+
+2. Build PR body by reading `.review/summary.md`, wrapping with markers, and appending the AI-assisted attribution line:
+
+```
+<!-- review-paratext:summary:start -->
+[full contents of .review/summary.md]
+<!-- review-paratext:summary:end -->
+
+AI-assisted — [session]($SESSION_URL)
+```
+
+3. Create PR using a temporary file to avoid shell escaping issues:
+
+```bash
+BASE_REF=${BASE_BRANCH#origin/}
+echo "$WRAPPED_SUMMARY" > /tmp/pr-body.md
+gh pr create \
+  --title "<generated title>" \
+  --body-file /tmp/pr-body.md \
+  --base "$BASE_REF"
+rm /tmp/pr-body.md
+```
+
+4. Capture and print the PR URL.
+
+### Step 5.3b — Update existing PR
+
+1. Fetch current body:
+
+```bash
+CURRENT_BODY=$(gh pr view "$PR_NUMBER" --json body --jq '.body')
+```
+
+2. Build new wrapped summary (same as creation — read `.review/summary.md` and wrap with markers).
+
+3. Replace or inject:
+   - **If markers present** in `CURRENT_BODY`: replace everything from `<!-- review-paratext:summary:start -->` through `<!-- review-paratext:summary:end -->` (inclusive) with the new wrapped summary
+   - **If markers not present**: prepend the wrapped summary to `CURRENT_BODY`, separated by a horizontal rule with blank lines before and after it (`\n\n---\n\n`)
+
+4. Update PR using a temporary file to avoid shell escaping issues:
+
+```bash
+echo "$NEW_BODY" > /tmp/pr-body.md
+gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.md
+rm /tmp/pr-body.md
+```
+
+5. Print the PR URL.
+
+### Step 5.4 — Next steps
+
+Display:
+
+> PR [created/updated]: <PR_URL>
+>
+> **Next steps:**
+>
+> 1. Review the summary and fix any issues you agree with
+> 2. If you fixed things, run `/review-paratext` again
+> 3. Address Devin AI feedback on the PR
+> 4. Schedule a review meeting with your reviewer — use the "Suggested Review Focus" section as the agenda

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,354 @@
+# Review PR
+
+Review the PR: **$ARGUMENTS**
+
+## Overview
+
+This command performs a multi-perspective AI review of a GitHub PR. It runs a fixed default panel of reviewer agents **in parallel**, fanned out over the PR's changed files. Findings are consolidated and posted as line-level review comments to the PR.
+
+## Argument Parsing
+
+Parse `$ARGUMENTS` to extract:
+
+```
+[PR-number] [--reviewers <list>] [--repo <owner/name>] [--dev] [--dry-run]
+```
+
+- **PR number**: Optional (numeric token). If omitted, detect from the current branch (see Step 1).
+- **`--reviewers`**: Optional. Comma-separated explicit reviewer list (e.g. `--reviewers security,tests,architecture`). Overrides the default panel and auto-narrowing. Valid values: `security`, `scope`, `ux`, `contracts`, `tests`, `architecture`, `clarity`.
+- **`--repo`**: Optional. Target `owner/name`. If omitted, use the repo of the current working directory (`gh repo view --json nameWithOwner -q .nameWithOwner`).
+- **`--dev`**: Skip user confirmation prompts.
+- **`--dry-run`**: Write a local report but do NOT post comments to GitHub.
+
+Set `REPO` to the resolved `owner/name`.
+
+## Step 1: Find PR Number
+
+If a PR number was not provided in arguments, detect it from the current branch:
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+gh pr list --head "$BRANCH" --json number,url --jq '.[0]' --repo "$REPO"
+```
+
+If still not found, ask the user (skip in `--dev` mode — error instead):
+
+```
+What is the PR number to review?
+```
+
+If no PR exists, error: "No PR found. Create a PR first, then re-run this command."
+
+## Step 2: Fetch Changed Files
+
+```bash
+# Changed file list with metadata
+gh api repos/{REPO}/pulls/{PR}/files --paginate \
+  --jq '.[] | {filename, status, additions, deletions}'
+```
+
+If no changed files, post "No changes to review" comment and exit.
+
+### Categorize Files by Language
+
+Sort changed files by language so the panel can be auto-narrowed and so each agent reads only its relevant subset:
+
+| Category | Variable | Patterns |
+|----------|----------|----------|
+| C# source | `CS_FILES` | `**/*.cs` (exclude `*Tests*`) |
+| C# tests | `CS_TEST_FILES` | `**/*Tests*/**/*.cs`, `**/*.Tests.cs` |
+| TS/React source | `TS_FILES` | `**/*.ts`, `**/*.tsx` (exclude `*.test.ts`, `*.spec.ts`) |
+| TS tests | `TS_TEST_FILES` | `**/*.test.ts`, `**/*.test.tsx`, `**/*.spec.ts` |
+| Styles | `STYLE_FILES` | `**/*.scss`, `**/*.css` |
+| Config | `CONFIG_FILES` | `*.json`, `*.json5`, `webpack.*` |
+| Docs | `DOC_FILES` | `**/*.md` |
+
+Store the categorized lists as JSON for passing to agents. Set `CHANGED_FILES` to the full changed-file list.
+
+## Step 3: Check for Previous AI Review
+
+```bash
+gh api repos/{REPO}/pulls/{PR}/reviews --jq '[.[] | select(.body | contains("[Claude AI Review]"))] | length'
+```
+
+If a previous AI review exists:
+- In `--dev` mode: log warning, continue
+- Otherwise: warn the user and ask for confirmation to post another review
+
+## Step 4: Select the Reviewer Panel
+
+The panel references the general `pr-reviewer-*` agents in `.claude/agents/`. Available reviewers:
+
+| Reviewer | Agent | Focus |
+|----------|-------|-------|
+| security | `pr-reviewer-security` | Blocked imports, input validation, secrets, PAPI usage |
+| scope | `pr-reviewer-scope` | Changes stay within the PR's stated purpose; no scope creep |
+| ux | `pr-reviewer-ux` | Performance, accessibility, re-renders, ARIA, keyboard nav, component usage |
+| contracts | `pr-reviewer-contracts` | API contract correctness, type/signature alignment |
+| tests | `pr-reviewer-tests` | Test quality, behavior-focus, testing-trophy balance, anti-patterns |
+| architecture | `pr-reviewer-architecture` | Pattern conformance, codebase conventions, structural soundness |
+| clarity | `pr-reviewer-clarity` | Dead code, naming, over-engineering, readability |
+
+### Default panel
+
+If `--reviewers` was NOT provided, start from the **fixed default panel**:
+
+```
+security, scope, ux, contracts, tests, architecture, clarity
+```
+
+Then **auto-narrow by changed-file language**:
+
+- If there are **no C# files** (`CS_FILES` and `CS_TEST_FILES` both empty) → drop `contracts` and `architecture`.
+- If there are **no TS/React files** (`TS_FILES`, `TS_TEST_FILES`, `STYLE_FILES` all empty) → drop `ux`.
+
+This keeps the panel relevant: C# changes pull in `contracts` and `architecture`; TS/React changes pull in `ux`. `security`, `scope`, `tests`, and `clarity` always run, so the panel is never empty — a docs-only PR still runs those four.
+
+### Explicit override
+
+If `--reviewers` WAS provided, use exactly that list (validate each name against the table above; error on unknown names). Skip auto-narrowing — an explicit list is taken as-is.
+
+Set `PANEL` to the resolved reviewer list. Log: "Reviewer panel: {PANEL} (default + auto-narrow | explicit override)."
+
+## Step 5: Spawn Reviewer Agents — IN PARALLEL
+
+**CRITICAL**: Launch ALL selected agents in a **single message with multiple Agent tool calls**. This runs them concurrently. Fan out over the changed files — each agent reads only the file categories relevant to its perspective.
+
+### Context Block
+
+Each agent receives the same context block as its prompt:
+
+```
+PR: #{PR}
+Repository: {REPO}
+Changed files (JSON): {CHANGED_FILES, with per-language categorization}
+
+Instructions:
+- ONLY review the files listed in "Changed files" above
+- Review changed files from the working tree (read the actual files, not just the diff)
+- Review the code IN CONTEXT — check cross-references, call sites, and consistency with the surrounding codebase
+- Return findings as a JSON array using the Finding Schema below
+- IMPORTANT: For every finding, you MUST provide a "line" number pointing to the most relevant line in the file where the reviewer's attention should be drawn. Read the file to find the right line. Findings without "line" will not be posted as inline comments on the PR — they will only appear in the summary, which reviewers are less likely to see.
+
+Finding Schema:
+Each finding must be a JSON object with these fields:
+- "perspective": "{agent's perspective}" (required)
+- "severity": "blocking" | "warning" | "suggestion" (required)
+- "needs_decision": true | false (REQUIRED) — `true` when a reviewer must approve / reject / pick an option / make a judgment call; `false` when the finding is purely informational (e.g., a confirmation summary that work was applied, a recap of changes made in a prior round). Informational findings (`needs_decision: false`) are NOT posted as inline comments — they appear in the PR body summary only. Reviewer-blocking decisions MUST set this to `true`.
+- "file": "path/to/file" (required)
+- "line": 42 (strongly recommended — line number for inline comment. Omit ONLY if the finding is truly file-level with no specific line)
+- "line_content": "exact text at that line" (required when "line" is present — the literal file content at the reported line, used to validate placement)
+- "end_line": 45 (optional — end line for multi-line comment)
+- "language": "csharp" | "typescript" | "markdown" | "json" | "other" (required)
+- "message": "Human-readable description" (required)
+- "question": "Decision-formulating question for the reviewer" (REQUIRED when `needs_decision: true`) — the explicit question/decision request the reviewer needs to answer. Should be short (1-2 sentences). Used as the LEADING content of the inline review comment.
+- "context": "Supporting detail" (optional) — additional context, rationale, citations, or alternatives to inform the decision. Used as the supporting (collapsed) content of the inline review comment when `needs_decision: true`.
+- "evidence": "Reference to a standard or convention supporting this" (optional)
+- "existing_code_ref": "c-sharp/SomeOther/Utility.cs:88 — existing utility that should be reused" (optional)
+
+**Deciding `needs_decision`**: if you can imagine the reviewer reading the finding and saying "OK, noted" without changing anything, the finding is informational — set `needs_decision: false`. If the reviewer must ALMOST ALWAYS take an action (approve / reject / pick A or B / fix something) before merge, set `needs_decision: true`. When in doubt, prefer `needs_decision: false` and surface in the PR body summary — that wastes less reviewer attention than spurious inline comments. Reviewer pushback observed in practice ("Don't post inline comments like this if it's just info") confirms over-eager `needs_decision: true` is the worse error mode.
+
+Return ONLY the JSON array. No markdown wrapping, no explanation outside the array.
+```
+
+## Step 6: Consolidate Findings
+
+After ALL agents return:
+
+1. **Parse** JSON findings from each agent's response. If an agent returned malformed JSON, log a warning and skip that agent's findings.
+
+2. **Deduplicate**: If two findings reference the same file+line (within 3 lines), merge their messages and keep both perspective tags:
+   ```
+   **[Security]** **[Architecture]** Combined message here
+   ```
+
+3. **Sort** by severity: blocking first, then warning, then suggestion.
+
+4. **Build summary table**:
+
+   ```markdown
+   ## 🤖 [Claude AI Review] — PR #{PR}
+
+   | Perspective  | Blocking | Warning | Suggestion |
+   |--------------|----------|---------|------------|
+   | Security     | 0        | 2       | 1          |
+   | Architecture | 0        | 1       | 0          |
+   | ...          | ...      | ...     | ...        |
+   | **Total**    | **0**    | **3**   | **1**      |
+   ```
+
+## Step 6.5: Validate Line Numbers
+
+For each finding that has a `line` field, validate that the comment will be placed on the correct line:
+
+1. **If `line_content` is present**:
+   - Read the actual file at the reported `line` number
+   - If the file content at that line contains the `line_content` string → keep `line` as-is
+   - If no match → search lines within ±10 of the reported `line` for a line containing `line_content`
+   - If found nearby → correct `line` to the matching line number. Log: "Corrected {file}:{reported_line} → {actual_line} (content match found {N} lines away)"
+   - If not found within ±10 → remove the `line` and `end_line` fields from the finding (it becomes a non-inline comment included in the summary body). Log: "Dropped inline placement for {file}:{reported_line} — line_content not found nearby"
+
+2. **If `line_content` is absent** (backward compatibility):
+   - Keep the finding as-is (no validation possible)
+   - Log: "Finding for {file}:{line} has no line_content — skipping validation"
+
+3. **Also validate that `line` exists in the PR diff**:
+   - Using the changed files metadata from Step 2, verify the file is in the PR
+   - For modified files, verify the line falls within a diff hunk (not in an unchanged region)
+   - If the line is outside the diff → remove `line` and `end_line` (becomes non-inline). Log: "Line {line} in {file} is outside the PR diff — moved to summary"
+
+After validation, log a summary: "Line validation: {N} kept, {M} corrected, {K} moved to summary"
+
+## Step 6.6: Apply Decision-Needed Gating
+
+For each finding with `needs_decision: false`, drop the `line` and `end_line` fields so the finding falls into the summary path (the existing "no `line` → summary" logic in Step 7 handles it). Informational findings — confirmations, recaps, "noted" items — must not appear as inline comments because they create reviewer fatigue without requesting an action.
+
+Findings with `needs_decision: true` keep their `line`/`end_line` and are posted inline using the decision-leads template defined in Step 7.
+
+If a finding is missing `needs_decision` (older agent output), default to `false` — the safer behavior is to NOT post inline.
+
+Log a summary: "Decision-needed gating: {kept_inline} kept inline, {moved_to_summary} moved to summary (needs_decision: false)"
+
+## Step 7: Post to GitHub
+
+**Skip this step entirely if `--dry-run` is set.** Log: "Dry run — skipping GitHub post. See local report at {path}."
+
+Determine review event:
+- If any **blocking** findings → `REQUEST_CHANGES`
+- Otherwise → `COMMENT` (never `APPROVE` — human approval is always required)
+
+Format each **inline** finding (those still carrying a `line` after Steps 6.5 and 6.6 — i.e. `needs_decision: true`) using the **decision-leads template**:
+```
+🤖 **Claude AI** · **[{Perspective}]** · Decision needed ({severity})
+
+{question}
+
+<details><summary>Context</summary>
+
+{message}
+
+{context if present}
+
+{evidence if present}
+{existing_code_ref if present}
+
+</details>
+```
+
+The template puts the actionable `question` first so the reviewer sees the call-to-action at a glance, and collapses the descriptive `message`, supporting `context`, and any references behind a `<details>` block.
+
+For findings posted in the **summary body** (those without `line` — including findings dropped by Step 6.5 line validation and findings dropped by Step 6.6 needs_decision gating), use the original informational format:
+```
+🤖 **Claude AI** · **[{Perspective}]** ({severity})
+
+{message}
+
+{context if present}
+
+{evidence if present}
+{existing_code_ref if present}
+```
+
+Post using the GitHub Reviews API. Build a single JSON payload containing `body`, `event`, and `comments` keys, then pass it via `--input`:
+
+```bash
+# Build the review payload as a single JSON object
+jq -n --arg body "$SUMMARY" --arg event "$EVENT" --slurpfile comments comments.json \
+  '{body: $body, event: $event, comments: $comments[0]}' > review-payload.json
+
+gh api repos/{REPO}/pulls/{PR}/reviews \
+  --method POST \
+  --input review-payload.json
+```
+
+Where `comments.json` contains the inline comments array (one entry per inline finding):
+```json
+[{
+  "path": "path/to/file",
+  "line": 42,
+  "body": "🤖 **Claude AI** · **[Security]** · Decision needed (warning)\n\nShould this user input be validated before it reaches the data provider?\n\n<details><summary>Context</summary>\n\nThe value flows straight into the query without bounds checking — ...\n\n</details>"
+}]
+```
+
+Findings without a `line` number (after Steps 6.5 and 6.6) are appended to the summary body using the informational format above instead of as inline comments.
+
+If the API call fails, log the error and inform the user. The local report is still available.
+
+## Step 8: Write Local Report
+
+**Always written**, even in `--dry-run` mode.
+
+Write the report to `pr-review-{PR}.md` in the current working directory:
+
+```markdown
+# PR Review Report: PR #{PR}
+
+**Repository**: {REPO}
+**Date**: {date}
+**Posted by**: Claude AI (via `/review-pr`)
+**Mode**: {normal | dry-run}
+**Event**: {REQUEST_CHANGES | COMMENT}
+**Reviewers**: {PANEL}
+
+## Summary
+
+{summary table from Step 6}
+
+## All Findings
+
+### Blocking
+
+{for each blocking finding:}
+#### [{Perspective}] {file}:{line}
+**Severity**: blocking
+**Language**: {language}
+**Message**: {message}
+**Evidence**: {evidence}
+**Cross-ref**: {existing_code_ref}
+
+---
+
+### Warnings
+
+{same format}
+
+### Suggestions
+
+{same format}
+
+## Line Validation
+
+{summary from Step 6.5: N kept, M corrected, K moved to summary}
+
+{if any corrections:}
+| File | Reported | Corrected | Offset |
+|------|----------|-----------|--------|
+| {file} | {reported_line} | {actual_line} | {±N} |
+```
+
+## Step 9: Final Output
+
+Report to user:
+
+```
+PR Review complete for PR #{PR}.
+
+- {N} blocking, {N} warnings, {N} suggestions across {agent count} perspectives ({PANEL})
+- {Posted to GitHub as REQUEST_CHANGES/COMMENT | Dry run — not posted}
+- Local report: pr-review-{PR}.md
+
+Next steps:
+1. Human devs review the PR (AI comments are inline)
+2. Run `/triage-feedback {PR}` to consolidate reviewer feedback
+```
+
+## Edge Cases
+
+- **No PR found**: Error with instructions to create PR first
+- **Previous AI review exists**: Warn user, ask confirmation (skip in `--dev` mode)
+- **Very large PR (100+ files)**: Each agent reads only its relevant file subset; log a warning
+- **Empty diff**: Post "No changes to review" comment and exit
+- **Docs-only PR**: Auto-narrowing drops `contracts`, `architecture`, and `ux`; `security`, `scope`, `tests`, and `clarity` always remain
+- **`--dry-run`**: Full analysis runs, local report written, nothing posted to GitHub
+- **Agent returns malformed JSON**: Log warning, skip that agent's findings, note in summary
+- **Unknown `--reviewers` name**: Error listing the valid reviewer names

--- a/.claude/commands/shadcn-customizations.md
+++ b/.claude/commands/shadcn-customizations.md
@@ -1,0 +1,144 @@
+# Shadcn Customizations
+
+Analyze all shadcn component files in `lib/platform-bible-react/src/components/shadcn-ui/` and write a `CUSTOMIZATIONS.md` documenting every customization made relative to the original boilerplate.
+
+**Before doing anything else**, read [shadcn/ui Guidelines](../../.context/standards/Code-Style-Guide.md#shadcnui-guidelines). It is the authoritative source for all conventions used in this command: folder structure, boilerplate baseline, `// CUSTOM:` annotations, and the standard customizations. If anything in this command conflicts with that section, trust the section.
+
+## Steps
+
+### Step 0 — Verify standard customizations are in sync
+
+After reading the [shadcn/ui Guidelines](../../.context/standards/Code-Style-Guide.md#shadcnui-guidelines), compare the standard customizations listed there against the standard customizations this command tracks — which are the table columns in the `## Standard Customizations` section of `CUSTOMIZATIONS.md` (currently: "TSDocs on all exports?" and "pr-twp on DOM-rendered components?").
+
+If the style guide lists standard customizations that are not represented as table columns in this command, or vice versa, **stop immediately** and tell the user:
+
+> The standard customizations in [shadcn/ui Guidelines](.context/standards/Code-Style-Guide.md#shadcnui-guidelines) no longer match what this command tracks. Please update this command (table columns and assembly instructions), all other shadcn commands, and the `shadcn-customization-tracker` agent to reflect the current standard customizations before running.
+>
+> Suggested prompt to fix this:
+>
+> ```
+> The shadcn/ui Guidelines section of .context/standards/Code-Style-Guide.md defines these standard customizations: [fill in from what you read in the style guide]. The shadcn commands and `shadcn-customization-tracker` agent are out of date — they still track: [fill in from what you read in the commands]. Read the commands and agent to determine what parts need to be updated, and update them to match the style guide.
+> ```
+
+### Step 1 — List files
+
+```bash
+ls "$(git rev-parse --show-toplevel)/lib/platform-bible-react/src/components/shadcn-ui/"
+```
+
+Collect all filenames excluding `CUSTOMIZATIONS.md`. These are the files to analyze.
+
+### Step 2 — Dispatch agents in parallel
+
+Divide the file list into **5 roughly equal groups** by splitting the sorted list into consecutive chunks (e.g. files 1–7, 8–13, 14–19, 20–25, 26–31). Dispatch **5 `shadcn-customization-tracker` agents** in a **single message** so they run in parallel. Pass each agent its chunk as a plain list of repo-relative paths, e.g.:
+
+```
+Analyze these files:
+lib/platform-bible-react/src/components/shadcn-ui/alert.tsx
+lib/platform-bible-react/src/components/shadcn-ui/avatar.tsx
+lib/platform-bible-react/src/components/shadcn-ui/badge.tsx
+...
+```
+
+Do not use worktree isolation — agents are read-only. Each agent returns one `## filename.tsx` report block per file. Collect all blocks from all 5 agents.
+
+### Step 3 — Assemble CUSTOMIZATIONS.md
+
+Once all agents return their reports, write `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md` (overwrite if it already exists).
+
+**Document structure:**
+
+#### Disclaimer and h1 heading (exact text)
+
+```
+> This file is AI-generated at specific times for use with updating shadcn components and may not reflect current code. It is retained for ease of reference only. To regenerate, run `/shadcn-customizations` in Claude Code.
+
+# Shadcn UI Component Customizations
+
+This document captures all customizations made to shadcn/ui components relative to their original boilerplate, to aid future shadcn version upgrades. For each component, it records: whether TSDocs are present on all exports, whether DOM-rendered components have the `pr-twp` Tailwind scope class applied, and the specific code changes made (explicit annotations, other comment-indicated changes, and uncalled-out changes detected via git history).
+```
+
+#### `## Standard Customizations`
+
+Emit this exact text before the table:
+
+```
+The table below summarizes the two standard customizations that every shadcn component should have:
+
+- **TSDocs on all exports?** — Whether every exported symbol (components, interfaces, types, constants) has a TSDoc comment (`/** ... */`) that includes links to the upstream libraries it uses (e.g. the shadcn/ui component page, the Radix UI primitive page, the Vaul page for drawer components). ✅ means all exports have TSDocs with appropriate library links; ❌ lists exports that are missing TSDocs or missing library links. A TSDoc that uses `@inheritdoc` pointing to a symbol whose TSDoc has the required links also passes.
+- **pr-twp on DOM-rendered components?** — Whether each component that renders actual DOM output has `pr-twp` in its base Tailwind class string. `pr-twp` is a scope marker required for Platform.Bible's Tailwind CSS isolation (see `tailwind.config.ts`). ✅ means the class is present; ❌ means it is missing. Only components that produce DOM output are listed — compound root components (e.g. `Dialog`, `Popover`) that coordinate state without rendering DOM nodes are excluded, as are cva variant factories.
+```
+
+Build a single table from the `### Standard customizations` section of every agent report. Sort rows alphabetically by component filename.
+
+| Component | TSDocs on all exports? | pr-twp on DOM-rendered components? |
+| --------- | ---------------------- | ---------------------------------- |
+
+- **TSDocs column:** ✅ only if all exports have TSDocs AND all TSDocs have library links. Otherwise: `❌ missing TSDocs: ExportA` and/or `❌ missing links: ExportB`. These can both appear in the same cell separated by ` / `.
+- **pr-twp on DOM-rendered components? column:** list each DOM-rendered component with its `pr-twp` status (✅ or ❌). Components the agent identified as not DOM-rendered should NOT appear in this column. For skipped files: `⚠️ skipped — see note below`
+
+#### `## Per-Component Customizations`
+
+Emit this exact text before the per-component entries:
+
+```
+Each section below details the non-standard customizations for one component. There are three subsections:
+
+- **Explicit `// CUSTOM:` customizations** — changes that are already annotated in the source with a `// CUSTOM:` comment.
+- **Other comment-indicated customizations** — changes documented by other comments that indicate intent (e.g. "Changed from X to Y", "Added for accessibility").
+- **Uncalled-out customizations (from git history)** — changes detected by diffing the current file against its first-add commit, which were not already documented by a comment.
+```
+
+For each component (alphabetical order), emit a `### filename.tsx` section containing the agent's three non-standard sections, re-leveled from `###` to `####`:
+
+```markdown
+### filename.tsx
+
+#### Explicit `// CUSTOM:` customizations
+
+[content from agent]
+
+#### Other comment-indicated customizations
+
+[content from agent]
+
+#### Uncalled-out customizations (from git history)
+
+[content from agent]
+```
+
+If all three sections are `(none)`, replace with a single line:
+
+> No non-standard customizations.
+
+For skipped files, emit:
+
+```markdown
+### filename.tsx
+
+⚠️ Skipped: [reason from agent report]
+```
+
+### Step 4 — Offer to apply fixes
+
+After writing `CUSTOMIZATIONS.md`, ask the user:
+
+> `CUSTOMIZATIONS.md` is written. Would you like me to apply fixes to the component source files? This will:
+>
+> 1. **Document uncalled-out customizations** — add `// CUSTOM:` comments in the source for every customization reported under "Other comment-indicated" and "Uncalled-out customizations (from git history)" that does not already have a `// CUSTOM:` annotation.
+> 2. **Apply missing standard customizations** — for every component with ❌ in the Standard Customizations table, add the missing TSDocs (with library links) and/or add `pr-twp` to the base class string, each annotated with a `// CUSTOM:` comment.
+>
+> Changes will be applied by 5 parallel subagents, each handling a batch of component files. Proceed?
+
+If the user says yes, collect all component files that have any work to do, divide them into **5 roughly equal groups**, and dispatch **5 editing agents** in a **single message** so they work in parallel. Pass each agent its group of files along with the full tracker report for each file in that group, so it knows exactly what to add.
+
+Once all agents complete, commit the changes:
+
+```bash
+git add lib/platform-bible-react/src/components/shadcn-ui/
+git commit -m "chore: apply shadcn standard customizations and annotate uncalled-out changes"
+```
+
+Then tell the user:
+
+> Changes committed. Note: `CUSTOMIZATIONS.md` now reflects the state **before** these fixes were applied. If you plan to upgrade shadcn with `/upgrade-shadcn`, re-run `/shadcn-customizations` first to regenerate it against the updated source files.

--- a/.claude/commands/triage-feedback.md
+++ b/.claude/commands/triage-feedback.md
@@ -1,0 +1,397 @@
+# Triage PR Feedback
+
+Triage PR feedback: **$ARGUMENTS**
+
+## Overview
+
+This command triages PR review feedback into a structured, actionable **triage brief**. It fetches the inline review comments, conversation-level comments, and review-thread metadata for a single PR, filters out already-resolved threads, inspects the code each remaining comment actually refers to, groups the comments into themes confirmed with the user, and writes a brief that a follow-up revision pass can consume.
+
+## Argument Parsing
+
+Parse `$ARGUMENTS` to extract:
+
+```
+[PR-number] [--repo <owner/name>]
+```
+
+- **PR number**: Optional (numeric token). If omitted, resolve from the current branch (see Step 1).
+- **`--repo`**: Optional. Target `owner/name`. If omitted, use the repo of the current working directory (`gh repo view --json nameWithOwner -q .nameWithOwner`).
+
+Set `REPO` to the resolved `owner/name`.
+
+## Step 1: Resolve the PR
+
+If a PR number was provided in arguments, use it directly. Otherwise resolve it from the current branch:
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+gh pr list --head "$BRANCH" --state all --json number,url --jq '.[0]' --repo "$REPO"
+```
+
+If still not found, ask the user:
+
+```
+What is the PR number to triage?
+```
+
+Set `PR` to the resolved number. If no PR exists, error: "No PR found. Provide a PR number or push a branch with an open PR."
+
+## Step 2: Fetch PR Comments
+
+Fetch inline review comments, conversation-level comments, and review-thread metadata. **Save the raw JSON to disk** as the source of truth. Work in a scratch directory, e.g. `WORK=$(mktemp -d)`.
+
+```bash
+# Inline review comments (have path + line)
+gh api repos/{REPO}/pulls/{PR}/comments --paginate \
+  > "$WORK/raw-comments.json"
+
+# Conversation-level comments and reviews
+gh pr view {PR} --json comments,reviews --repo {REPO} \
+  > "$WORK/raw-conversations.json"
+
+# Review-thread metadata (GraphQL — paginated; --slurp combines pages)
+OWNER="${REPO%/*}"; NAME="${REPO#*/}"
+gh api graphql --paginate --slurp -f query='
+query($owner: String!, $name: String!, $pr: Int!, $endCursor: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $pr) {
+      reviewThreads(first: 100, after: $endCursor) {
+        nodes { id isResolved isOutdated comments(first: 50) { nodes { databaseId } } }
+        pageInfo { hasNextPage endCursor }
+      }
+    }
+  }
+}' -f owner="$OWNER" -f name="$NAME" -F pr={PR} \
+  > "$WORK/raw-threads.json"
+```
+
+The saved JSON files are the **source of truth** for all subsequent steps. All processing (categorization, walkthrough, brief writing, resolution) must read from these files. If context limits force you to process comments in batches, always re-read from the JSON files — never rely on in-memory summaries of earlier batches.
+
+For each comment, capture: `id`, `path` (if inline), `line` (if inline), `body`, `user.login`, `created_at`.
+
+For each thread, capture: `id` (GraphQL node ID, used by `resolveReviewThread`), `isResolved`, and the list of `databaseId`s of comments inside it.
+
+**Filter resolved threads out of the working set.** Comments in threads where `isResolved: true` are already handled — skip them in all subsequent steps. Only unresolved threads carry open feedback.
+
+### Anti-Truncation Rules (CRITICAL)
+
+| Anti-Pattern | Why It Fails | Do Instead |
+|--------------|-------------|------------|
+| Truncating body text (e.g., `body[:200]`, `body.slice(0, N)`) | Reviewer detail is lost; the downstream revision works with incomplete input | Always use the complete `body` field from the JSON file |
+| Summarizing comment bodies during fetch or storage | Summaries lose specific technical details (method signatures, parameters, edge cases) | Store and display verbatim text |
+| Using `--jq` to extract only selected fields during fetch | May silently drop fields needed later | Save full API response first, then filter in subsequent steps |
+| Processing from memory after reading a large batch | Context pressure causes silent dropping of long comments | Re-read from the JSON file when processing each comment |
+
+## Step 3: Inspect Referenced Code and Artifacts (CRITICAL)
+
+Action items grounded only in comment text are speculation, not triage. Before grouping comments into themes, inspect the actual code or files each remaining comment refers to. The walkthrough (Step 5) is the user's review checkpoint — proposing meaningless or fabricated action items wastes it.
+
+**Rule**: For every comment in the working set, read the cited code BEFORE drafting an action item for it. This applies to vague AND well-articulated comments — vague comments need archaeology to mean anything; well-articulated comments still need scope validation.
+
+### What to inspect
+
+| Comment context | What to read |
+|----------------|--------------|
+| Inline review comment with `path` + `line` | Current file at that path, with ±20 lines of context around `line`. Note `commit_id` from the JSON — if the file has materially changed since, flag it (the comment may be stale). |
+| Comment body mentions a file path | The referenced file (or the relevant section) |
+| Comment body mentions a symbol (class/function/method/component name) | Grep to locate it, then read the definition and key call sites |
+| Conversation-level comment that references code/files | Same rules apply by topic or symbol |
+| Conversation-level comment with no code reference (process question, acknowledgement, etc.) | No inspection needed — record `Inspected: n/a` |
+
+Batch Read calls in parallel where comments are independent — a single tool turn with multiple Read invocations keeps the triage loop fast. Never skip reads to save time.
+
+### Findings to capture per comment
+
+For each comment, record (working memory or scratch notes — Step 6's brief will consolidate):
+
+- **Cited location(s)**: file:line or symbol
+- **What's actually there**: 1–3 sentences describing the current state factually — no hedges, no "likely". You read the file; state what it contains.
+- **Comment-vs-reality check**:
+  - Vague comments ("Why is this here?", "This doesn't work", "Is this wired up?") → identify what "this" is, in concrete terms
+  - Explicit comments (with method signatures, parameter lists, line refs) → verify the cited details match the current state, and confirm scope
+  - Claim-style comments ("X is missing", "Y is wrong", "Z should be removed") → confirm the claim is true on the current branch
+- **Already-resolved flag**: If a later commit on the branch addressed the concern, mark it — likely no-action
+
+### When inspection contradicts the comment
+
+Do NOT silently fabricate a fix that aligns with the comment text when the code shows the premise is wrong or stale. Surface the contradiction during the walkthrough (Step 5) so the user decides. Possible outcomes:
+
+- Already fixed → no-action
+- Real issue is different from what the comment suggests → reclassify with the grounded action
+- Comment is based on a stale view of the code → flag for the user; consider asking the reviewer for clarification before applying any fix
+
+### Anti-speculation rules
+
+| Anti-pattern | Why it fails | Do instead |
+|-------------|--------------|------------|
+| Drafting action items with hedge words ("likely test code", "probably a typo", "may be debug scaffolding", "appears to be unused") | Hedges signal the file wasn't read. Specific descriptions only come from inspection. | Read the file. State concretely what's there. |
+| Skipping inspection because the comment "looks clear" | Even explicit comments can cite wrong lines, miss scope, or refer to since-changed code | Inspect anyway — it validates scope and grounds the description |
+| Reading only the cited line without surrounding context | Loses meaning of "this", "here", "the function above", or scope of a block | Read with ±20 lines of context (or wider if the cited construct spans more) |
+| Reading only one location for multi-reference comments | A comment may cite line N but actually mean function F or class C that spans more | Follow every reference in the body — file paths and symbols |
+| Treating "Delete this" as self-executing | An imperative comment is still speculation if you don't know what "this" is — you might propose deleting the wrong thing, or something already gone | Read what "this" actually is before recommending deletion |
+
+## Step 4: Propose Initial Grouping
+
+**Pre-condition**: Step 3 has produced inspection findings for every comment in the working set. Grouping in this step MUST be grounded in those findings — not in the comment text alone. If you find yourself drafting an action item without a concrete inspection result behind it, stop and inspect first (or surface the gap during the walkthrough rather than fabricating).
+
+Using the comment bodies AND the Step 3 findings, group the comments into **themes** and identify which comments need **no action**.
+
+### Long Comment Analysis (CRITICAL)
+
+Reviewer comments often start with a confirmation ("This is correct", "I agree", "Yes") but then provide corrections, additions, or important technical detail in subsequent paragraphs. **You MUST analyze the entire comment body, not just the opening sentence.**
+
+For every comment, follow this procedure:
+
+1. **Read the complete body** from the raw JSON file — not a truncated or summarized version
+2. **Break multi-paragraph comments into sections** and treat each independently:
+   - Opening confirmation → may be no-action
+   - "I would add..." / "Also..." / "More specifically..." → an addition to make
+   - "Actually..." / "Instead..." / "The correct..." → a correction to make
+   - Technical details (method signatures, parameters, edge cases) → an action item
+3. **If ANY section contains actionable content**, the comment is NOT no-action — make it part of a theme
+
+**Examples of misclassification to avoid:**
+
+| Comment starts with | But also contains | Actionable? |
+|--------------------|--------------------|-------------|
+| "I agree with the summary" | "I would add that this class also stores X, Y, Z..." | Yes — add X, Y, Z |
+| "This is correct" | "but the method signature is actually `Foo(a, b, c)` not `Foo(a)`" | Yes — fix the signature |
+| "Yes, the way you summarized X is correct" | "I will add that for Hebrew codes the final 'H' is ignored" | Yes — add the edge case |
+| "The trigger is correct" | "there is also a default option which is to open a Text Window" | Yes — add the default option |
+
+### No-Action Self-Check
+
+After proposing all themes and no-action comments, perform a self-check before presenting to the user:
+
+1. **Re-read every proposed no-action comment's full body** from the raw JSON file
+2. For each, verify: "Does this comment contain ONLY acknowledgment/confirmation, with NO additional technical detail, corrections, or suggestions?"
+3. **If the full body is longer than 200 characters**, scrutinize it more carefully — long "acknowledgment" comments almost always contain actionable content
+4. Reclassify any that fail the check
+
+### Theme Grouping
+
+Cluster related comments into **themes** by shared topic:
+- All comments mentioning the same subsystem, file, or concept → one theme
+- All comments about a single isolated item → individual theme
+- "No action" comments → grouped separately (not a theme)
+
+Each theme gets a proposed:
+- **Name** (short descriptive label)
+- **Affected files** (which file(s) the action items touch)
+- **Action Items** — a numbered list where each item has:
+  - A **target** (which file, and where in it)
+  - A **detailed description** that preserves the reviewer's specific technical details (method names, parameter lists, exact values, tiered suggestions, code snippets). Must include enough context for a follow-up revision pass to execute without re-reading the original comment.
+
+## Step 5: Collaborative Walkthrough (CRITICAL)
+
+**This is a human-in-the-loop step.** Walk through each proposed theme with the user, one at a time, because autonomous grouping can misinterpret reviewer intent.
+
+For each theme, present using `AskUserQuestion` or direct output.
+
+**Display the COMPLETE comment body for every comment in the theme.** Never truncate, summarize, or excerpt. If a comment is long (500+ characters), that makes it MORE important to show in full — long comments contain the most actionable detail. Read the body from the raw JSON file, not from memory.
+
+```markdown
+## Theme {N}: {Proposed Name}
+
+### Original feedback (verbatim — complete text)
+> @{reviewer} on {file}:{line}:
+> "{full comment body — every word, no truncation}"
+>
+> @{reviewer} on {file}:{line}:
+> "{full comment body — every word, no truncation}"
+
+### Inspection findings (from Step 3)
+- `{file}:{line}` — {concrete factual description of what's there now}
+- `{symbol}` — {description}
+- {comment-vs-reality note, e.g. "Comment claim verified" / "Cited line has since changed; current contents: ..." / "Concern already addressed in commit {sha}"}
+- (or "n/a — conversation-level, no code reference" when applicable)
+
+### My interpretation
+- **Affected files**: {files}
+- **Action Items**:
+  1. ({target}): {detailed description preserving reviewer's technical specifics, grounded in the findings above}
+  2. ({target}): {detailed description preserving reviewer's technical specifics, grounded in the findings above}
+
+### Questions
+- Are these action items correct?
+- {any specific questions about scope or intent}
+- {if findings contradict the comment: explicitly raise the contradiction here and ask how to proceed}
+```
+
+The user can:
+- **Confirm**: "Yes, that's right"
+- **Adjust scope**: "Also include the helper in foo.ts in this theme"
+- **Split/merge themes**: "These two should be separate themes" or "Combine with Theme 3"
+- **Add context**: "The reviewer told me in Slack that this also applies to X"
+
+Record the user's response for each theme (confirmation, corrections, additions).
+
+### No-Action Comments
+
+After all themes, present the "no action" comments. **Display the full comment body for each** — never truncate. The user needs to see the complete text to verify nothing actionable was missed.
+
+```markdown
+## Comments Requiring No Action ({N} comments)
+
+These comments were categorized as informational/resolved:
+- @{reviewer} on {file}:{line}: "{full comment body}" — {reason for no action}
+
+Any of these actually need action? (yes: specify / no)
+```
+
+### Final Summary
+
+After walking through all themes, present the complete summary:
+
+```markdown
+## Triage Summary
+
+**PR**: #{PR} ({REPO})
+**Themes**: {count}
+
+| # | Theme | Action Items | Affected Files |
+|---|-------|-------------|----------------|
+| 1 | {name} | {count} items | {files} |
+| 2 | {name} | {count} items | {files} |
+| ... |
+
+**No action**: {count} comments
+
+Confirm this triage? (yes / modify theme {N})
+```
+
+Wait for user confirmation before proceeding to Step 6.
+
+## Step 6: Write Triage Brief
+
+Write the triage brief to a file in the current working directory, e.g. `triage-brief-{PR}.md`.
+
+Use this format:
+
+```markdown
+# Triage Brief: PR #{PR}
+
+## Metadata
+- Repository: {REPO}
+- PR: #{PR}
+- Triage date: {date}
+- Themes: {count}
+- Triage mode: collaborative (user confirmed each theme)
+
+## Raw Feedback Source
+
+Raw comment data is stored in the JSON files saved during Step 2:
+
+- Inline: `raw-comments.json`
+- Conversation: `raw-conversations.json`
+- Threads: `raw-threads.json`
+
+These JSON files are the **authoritative source** for comment bodies. A follow-up revision pass should read from them when it needs the full reviewer text. Do NOT duplicate full comment bodies in this brief except where the format calls for verbatim quotes — reference the JSON files instead.
+
+### Comment Index
+
+For each comment, record a brief index entry (NOT the full body):
+
+### Comment 1
+- **Author**: @{reviewer}
+- **File**: {path}:{line} (or "conversation-level" if not inline)
+- **Date**: {date}
+- **GitHub ID**: {comment_id}
+- **Thread ID**: {graphql_thread_id} (from the threads file; omit for conversation-level comments)
+- **Summary**: {1-sentence summary of what the comment says — for index purposes only}
+- **Inspected** (from Step 3):
+  - `{file}:{line}` — {concrete factual description of what's there now}
+  - `{symbol}` — {description}
+  - {comment-vs-reality note, if applicable}
+  - (or "n/a — conversation-level, no code reference" when no inspection was warranted)
+
+### Comment 2
+...
+
+## Confirmed Themes
+
+### Theme 1: {Name}
+- **Confirmed by**: user on {date}
+- **PR Comments**: #{id1}, #{id2}
+- **Thread IDs**: {graphql_thread_id1}, {graphql_thread_id2} (for inline review comments — used when resolving threads after the fix is posted)
+- **Original quotes** (COMPLETE verbatim text — read from raw JSON file, never truncated):
+  > "{full comment body — every word}" — @{reviewer}
+  > "{full comment body — every word}" — @{reviewer}
+- **Inspection Findings** (from Step 3; per-comment findings consolidated for the theme):
+  - `{file}:{line}` — {concrete factual description of what's there now}
+  - `{symbol}` — {description}
+  - {comment-vs-reality note, if applicable}
+- **Affected files**: {file paths, with lines where relevant}
+- **Action Items**:
+  1. ({target}): {detailed description grounded in the Inspection Findings above and preserving reviewer's technical specifics — method names, parameter lists, exact values, tiered suggestions. Must be detailed enough for a follow-up revision pass to execute without re-reading the original comment.}
+  2. ({target}): {detailed description}
+- **User Notes**: "{any corrections or additions from the user}" (or "None")
+
+### Theme 2: {Name}
+...
+
+## No-Action Comments
+- Comment #{id} (thread `{graphql_thread_id}`): @{reviewer} — "{full comment body}" — Reason: {why no action}
+
+> **Thread ID format**: Inline review comments → record `(thread \`{graphql_thread_id}\`)`. Conversation-level comments have no review thread → record `(conversation-level)` instead. Step 6.5 only resolves entries with a real thread ID.
+```
+
+## Step 6.5: Resolve No-Action Threads
+
+After the brief is written, close out the **no-action items** by posting a reply and resolving the thread. This removes genuinely-done items from the unresolved pile so future triage runs have less noise.
+
+**Scope rule**: Resolve ONLY no-action items here. Themed / actionable items remain unresolved until the fix is committed and the reviewer's thread is replied to as part of that revision.
+
+**Golden rule**: Never resolve a thread without first posting a visible reply. The reply is the audit trail; resolution is the state.
+
+For each no-action comment in the brief:
+
+1. **Post a reply** explaining why no action is being taken. For inline review comments, reply on the comment's thread:
+   ```bash
+   REPLY_BODY="No action needed — {reason}."
+   gh api repos/{REPO}/pulls/{PR}/comments/{comment-id}/replies \
+     -f body="$REPLY_BODY"
+   ```
+   For conversation-level comments, post a conversation reply instead:
+   ```bash
+   gh pr comment {PR} --repo {REPO} --body "$REPLY_BODY"
+   ```
+2. **Resolve the thread** — only for inline comments (entries that recorded a real `{graphql_thread_id}`). Skip this for entries marked `(conversation-level)`; conversation-level comments have no review thread to resolve:
+   ```bash
+   gh api graphql -f query='
+   mutation($threadId: ID!) {
+     resolveReviewThread(input: { threadId: $threadId }) {
+       thread { id isResolved }
+     }
+   }' -F threadId="{graphql_thread_id}"
+   ```
+3. **On failure** (rate limit, permissions, deleted thread): log a warning with the comment ID and error, and continue — do not block brief delivery.
+
+Report a summary to the user:
+
+```
+Resolved {M} of {N} no-action threads on PR #{PR}.
+Failures: {list of thread-id + error} (if any)
+```
+
+## Step 7: Notify User
+
+After writing the triage brief:
+
+```markdown
+Triage brief written to: `triage-brief-{PR}.md`
+
+**{count} themes** categorized across {count} PR comments.
+**{M}** no-action threads resolved on PR #{PR}.
+
+Each theme lists grounded action items ready to apply. The raw comment JSON
+(`raw-comments.json`, `raw-conversations.json`, `raw-threads.json`) remains the
+authoritative source for full reviewer text.
+```
+
+## Error Handling
+
+- **No PR found**: Ask the user for a PR number or URL.
+- **No comments on the PR**: Inform the user — nothing to triage. Ask if they want to provide feedback manually.
+- **All comments are no-action**: Write a minimal triage brief with no themes; inform the user no revisions are needed.
+- **All comments already resolved**: Inform the user and stop — every thread is resolved, so there is no open feedback to triage.

--- a/.claude/commands/upgrade-shadcn.md
+++ b/.claude/commands/upgrade-shadcn.md
@@ -1,0 +1,354 @@
+# Upgrade Shadcn
+
+This command upgrades all shadcn/ui components in `lib/platform-bible-react/src/components/shadcn-ui/` to the latest version defined by a shadcn preset, while preserving all project-specific customizations. It will: archive the existing components, apply a shadcn preset to establish a clean new baseline, propagate relevant changes to extension files, re-apply every customization from `CUSTOMIZATIONS.md` via parallel subagents, and create a PR.
+
+**Preset parameter**: This command accepts an optional preset argument (e.g. `/upgrade-shadcn <preset-url-or-name>`). If no preset is provided, see [Determining the Preset](#determining-the-preset) below.
+
+**Before doing anything else**, read [shadcn/ui Guidelines](../../.context/standards/Code-Style-Guide.md#shadcnui-guidelines). It is the authoritative source for all conventions used in this command: folder structure, boilerplate baseline, `// CUSTOM:` annotations, and the standard customizations. If anything in this command conflicts with that section, trust the section.
+
+## Determining the Preset
+
+If a preset argument was provided to this command, record it as `$PRESET` and skip to [Pre-flight Checks](#pre-flight-checks).
+
+If no preset was provided:
+
+1. Run the following to detect the most recently used preset:
+
+```bash
+cd lib/platform-bible-react && npm run get-latest-preset
+```
+
+2. Note the preset URL/name from the output and ask the user:
+
+> The last-used preset is: `<detected-preset>`
+>
+> Would you like to:
+> - **Reuse** this preset (just type "reuse" or press enter)
+> - **Provide a different preset** (paste or type the new preset URL/name)
+
+Record whichever preset the user confirms as `$PRESET`.
+
+## Pre-flight Checks
+
+Perform these checks in sequence. Do not proceed past a failed check.
+
+### Check 1 — CUSTOMIZATIONS.md exists and is current
+
+`CUSTOMIZATIONS.md` is the source of truth for every project-specific customization that must be re-applied after the upstream shadcn baseline is replaced. This file is **not** kept in the repo between upgrades — it is regenerated on demand. If it does not exist, you must regenerate it before continuing.
+
+1. **Verify the file exists**: check whether `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md` is present.
+
+   If it does **not** exist, instruct the user:
+
+   > `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md` does not exist. This file is required to drive the upgrade and must be regenerated from the current shadcn-ui components before continuing.
+   >
+   > Please run `/shadcn-customizations` to generate it, then run `/shadcn-customizations` again after applying any fixes to confirm everything is documented. Let me know when it is in place and current.
+
+   Do not continue until the file exists.
+
+2. **Verify it is current**: ask the user:
+
+   > Is `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md` up to date? (i.e., have you already run `/shadcn-customizations`, applied fixes, and run it again to confirm everything is documented?)
+
+   If the user says **no**: tell them they must run `/shadcn-customizations` first and confirm all customizations are documented before continuing. Do not continue until they confirm it is current.
+
+### Check 2 — `shadcn-ui-old/` does not exist
+
+Check whether `lib/platform-bible-react/src/components/shadcn-ui-old/` exists. If it does, instruct the user:
+
+> A `shadcn-ui-old/` folder already exists. Please review and delete or move it, then let me know when it's gone.
+>
+> - Linux / macOS / WSL2: `rm -rf lib/platform-bible-react/src/components/shadcn-ui-old`
+> - Windows (PowerShell): `Remove-Item -Recurse -Force lib\platform-bible-react\src\components\shadcn-ui-old`
+
+Do not continue until the user confirms it is gone and you have verified the folder is absent.
+
+### Create Branch
+
+After both checks pass, create a new branch:
+
+```bash
+FIRST_NAME=$(git config user.name | awk '{print tolower($1)}')
+TODAY=$(date +%m-%d-%Y)
+git checkout -b "ai/feature/upgrade-shadcn-${FIRST_NAME}-${TODAY}"
+```
+
+## Step 0 — Verify Standard Customizations Are In Sync
+
+After reading the [shadcn/ui Guidelines](../../.context/standards/Code-Style-Guide.md#shadcnui-guidelines), compare the standard customizations listed there against the standard customizations this command tracks — named in Step 0 and the Step 5 subagent instructions (currently: "TSDocs on all exports?" and "pr-twp on DOM-rendered components?").
+
+If the style guide lists standard customizations that are not represented as table columns, or vice versa, **stop immediately** and tell the user:
+
+> The standard customizations in [shadcn/ui Guidelines](.context/standards/Code-Style-Guide.md#shadcnui-guidelines) no longer match what this command tracks. Please update this command (the standard customizations named in Step 0 and the Step 5 subagent instructions), all other shadcn commands, and the `shadcn-customization-tracker` agent to reflect the current standard customizations before running.
+>
+> Suggested prompt to fix this:
+>
+> ```
+> The shadcn/ui Guidelines section of .context/standards/Code-Style-Guide.md defines these standard customizations: [fill in from what you read in the style guide]. The shadcn commands and `shadcn-customization-tracker` agent are out of date — they still track: [fill in from what you read in the commands]. Read the commands and agent to determine what parts need to be updated, and update them to match the style guide.
+> ```
+
+## Step 1 — Copy Files to `shadcn-ui-old/`
+
+Run the appropriate platform command. No subagent is needed — the operation produces no file-content output.
+
+```bash
+# Linux / macOS / WSL2:
+mkdir -p lib/platform-bible-react/src/components/shadcn-ui-old
+cp lib/platform-bible-react/src/components/shadcn-ui/*.tsx lib/platform-bible-react/src/components/shadcn-ui-old/
+
+# Windows (PowerShell):
+New-Item -ItemType Directory -Force lib\platform-bible-react\src\components\shadcn-ui-old
+Copy-Item lib\platform-bible-react\src\components\shadcn-ui\*.tsx lib\platform-bible-react\src\components\shadcn-ui-old\
+```
+
+`shadcn-ui-old/` is gitignored, so the copied files will not appear in git. The originals remain in place. The folder is left after this command completes so the customization subagents can refer back to it in Step 5.
+
+## Step 2 — Apply Preset
+
+Run the following from `lib/platform-bible-react/` to apply the preset and capture output in one step:
+
+```bash
+cd lib/platform-bible-react
+npm run apply-shadcn-preset-destructive -- $PRESET 2>&1 | tee ../../shadcn-apply-output.txt
+```
+
+This script internally applies the new preset to all shadcn components, adds any missing ones from the updated preset, runs formatting, and commits to establish a new baseline. The full output is always saved to `shadcn-apply-output.txt` in the repository root, whether the script succeeds or fails — tell the user it is available there for reference.
+
+**If the script succeeds and commits on its own**, verify that the commit message contains `npx shadcn apply --preset $PRESET`. If it does, this is **commit 1 of 3** — the fresh shadcn baseline with no customizations applied. Do not squash or amend it. Proceed to Step 3.
+
+**If the script fails:**
+
+> **Do NOT re-run `apply-shadcn-preset-destructive`** — the output captured above gives you all the information you need.
+
+1. Stage changes in `lib/platform-bible-react` exactly as they came from the script (do not modify anything yet):
+
+   ```bash
+   git add lib/platform-bible-react/
+   git add package-lock.json
+   ```
+
+2. **Dispatch a subagent** to fix any simple, obvious problems flagged by the script output. Give it this prompt:
+
+   > You are fixing format and lint errors that occurred after running `apply-shadcn-preset-destructive` for shadcn/ui in `lib/platform-bible-react`. The script output is saved at `shadcn-apply-output.txt` in the repository root — read that file to understand exactly what problems were flagged.
+   >
+   > Attempt to fix **simple, obvious problems** — for example, straightforward type errors, missing imports, or lint issues with clear fixes that the script identified. Do **not** run `npm run typecheck` or `npm run build`; those will be handled later after customizations are re-applied. Stick to what the `apply-shadcn-preset-destructive` output flagged.
+   >
+   > For each problem, prefer small, targeted fixes: changing `null` to `undefined`, small type reworks, scoped type assertions with an explanation comment, or minor accessibility improvements. Add a `// CUSTOM: <explanation>` comment immediately before each change you make, explaining what you changed and why.
+   >
+   > **Do NOT add ESLint rule overrides or disable comments to `.eslintrc.cjs` or any other config file.** If a small code-level fix is not possible, leave the problem unfixed and record it.
+   >
+   > When done:
+   > 1. If you fixed **all** problems, re-run the format/lint commands that `apply-shadcn-preset-destructive` specified to verify everything passes (typically `npm run format` and/or `npm run lint-fix` from `lib/platform-bible-react`). Include the output of those commands in your report.
+   > 2. Return a complete report that includes:
+   >    - Every problem you fixed: a description of the problem and exactly how you fixed it (file path, what changed)
+   >    - Every problem you left unfixed: a description with concrete suggestions for how to address it
+   >    - The exact format/lint commands that the `apply-shadcn-preset-destructive` output instructed should be run to verify everything passes
+   >    - If you ran those commands: whether they passed or failed, and the output if they failed
+
+   Wait for the subagent to complete.
+
+3. **STOP — always wait for user review before proceeding**, even if the subagent fixed every problem and all commands passed. Show the user the subagent's complete report and say:
+
+   > The subagent made changes after `apply-shadcn-preset-destructive` failed. Please review the changes above and let me know:
+   > - If you approve the changes and are ready for me to continue, or
+   > - If you want to fix anything yourself, ask me to fix something differently, or suggest an alternative approach.
+   >
+   > The full script output is also available at `shadcn-apply-output.txt` in the repository root for your reference.
+
+   **Do not proceed until the user explicitly confirms they approve the changes.**
+
+4. If the user or you made any further changes after the subagent, re-run the format/lint commands that the `apply-shadcn-preset-destructive` output specified to verify everything still passes:
+
+   ```bash
+   cd lib/platform-bible-react
+   # run whichever commands the script output specified (typically npm run format and/or npm run lint-fix)
+   ```
+
+   If any command fails, stop and report the errors to the user before proceeding. If no further changes were made and the subagent already verified those commands passed, skip this step.
+
+5. Once all commands pass, stage changes and commit using the message the `apply-shadcn-preset-destructive` output provided:
+
+   ```bash
+   git add lib/platform-bible-react/
+   git add package-lock.json
+   git commit --no-verify -m "<message from apply-shadcn-preset-destructive output>"
+   ```
+
+   **Before committing**, verify the commit message contains `npx shadcn apply --preset $PRESET`. If the script did not supply a commit message, use: `chore: apply shadcn preset (npx shadcn apply --preset $PRESET) to re-add shadcn components from latest version as a new baseline`.
+
+This is **commit 1 of 3**: the fresh shadcn baseline with no customizations applied. Do not squash or amend it — it is the reference point for all future customization diffs.
+
+## Step 3 — Propagate Changes to Extensions
+
+After the baseline commit, **dispatch a general-purpose subagent** to propagate relevant changes from `lib/platform-bible-react` to all extension files. Give it this prompt:
+
+> You are propagating changes from a shadcn/ui upgrade in `lib/platform-bible-react` to all extensions in the `extensions/` directory.
+>
+> **3a — Propagate CSS changes**
+>
+> Find all extension `tailwind.css` files:
+> ```bash
+> find extensions -name "tailwind.css"
+> ```
+> Read the diff of `lib/platform-bible-react/src/index.css` from the most recent git commit to understand exactly what changed:
+> ```bash
+> git diff HEAD~1 HEAD -- lib/platform-bible-react/src/index.css
+> ```
+> Apply those same changes to each found `tailwind.css` file.
+>
+> **3b — Propagate package.json changes**
+>
+> Read the diff of `lib/platform-bible-react/package.json` from the most recent commit:
+> ```bash
+> git diff HEAD~1 HEAD -- lib/platform-bible-react/package.json
+> ```
+>
+> Apply two types of changes to package.json files:
+>
+> 1. **Updated packages**: For any package already present in an extension's `package.json` whose version changed in `lib/platform-bible-react/package.json`, update the extension's version to match.
+> 2. **New packages**: For any new package added to `lib/platform-bible-react/package.json` by this commit, add it as **`devDependencies`** (not `dependencies`) to every qualifying extension's `package.json`. Extensions are bundled differently from `platform-bible-react` — almost no packages should be in `dependencies`.
+>
+> Which files to update:
+> - Individual extension `package.json` files (in the same directory as each `tailwind.css` found in step 3a) — add all new/updated packages here
+> - The root `extensions/package.json` (if it exists) — add all new/updated packages **except** packages that are used only via CSS `@import` or font `url()` references (i.e., purely CSS-referenced font or asset packages that are not imported anywhere in JS/TS). Those CSS-only packages belong in the individual extensions that reference them, not in the shared root.
+>
+> When done, return a summary of every file you changed and what you changed in each one (package name, old version → new version, or "added as devDependency").
+
+Wait for the subagent to complete. Then commit its changes:
+
+```bash
+git add extensions/
+git add package-lock.json
+git commit -m "chore: propagate shadcn preset CSS and package changes to extensions"
+```
+
+This is **commit 2 of 3**.
+
+## Step 4 — List Component Files
+
+```bash
+ls lib/platform-bible-react/src/components/shadcn-ui/
+```
+
+Collect all `.tsx` filenames (exclude `CUSTOMIZATIONS.md`). Note which filenames are **new** — i.e., present here but absent from `shadcn-ui-old/` — because these were added by the new preset and will have no entry in `CUSTOMIZATIONS.md`.
+
+Record the **filenames** (e.g. `button.tsx`) — used for subagents in Step 5.
+
+## Step 5 — Re-apply Customizations
+
+Divide the component list from Step 4 into **5 roughly equal consecutive chunks** by splitting the sorted list (e.g. files 1–7, 8–13, 14–19, 20–25, 26–32 for 32 components). Dispatch **5 general-purpose subagents in a single message** so they run in parallel. Do not use worktree isolation — each subagent works on a non-overlapping set of files.
+
+Copy the block below verbatim into each subagent's prompt, substituting the assigned filenames:
+
+---
+
+**Instructions for each subagent:**
+
+You are re-applying project customizations to a set of freshly updated shadcn/ui component files. For each component file assigned to you:
+
+1. **Check whether this component has an entry in CUSTOMIZATIONS.md** — read `lib/platform-bible-react/src/components/shadcn-ui/CUSTOMIZATIONS.md`. If the component has **no entry**, it is a new component added by the updated preset. Skip steps 2–5 and apply only the standard customizations listed in step 6. If the component **has an entry**, continue with all steps.
+
+2. **Read the CUSTOMIZATIONS.md entry** for this component. Identify every customization listed under "Explicit `// CUSTOM:` customizations", "Other comment-indicated customizations", and "Uncalled-out customizations (from git history)".
+
+3. **Read the old file** from `lib/platform-bible-react/src/components/shadcn-ui-old/<filename>` to understand how the customization was previously implemented.
+
+4. **Read the new file** from `lib/platform-bible-react/src/components/shadcn-ui/<filename>` to understand the current structure from the latest shadcn version.
+
+5. **Re-apply every customization by hand.** Do NOT copy code from the old file literally — the new file may have a different structure. Instead, understand the *intent* of each customization (what it does and why) from CUSTOMIZATIONS.md and the old file, then implement that intent in the new file's context.
+
+6. **Add a `// CUSTOM:` comment** immediately before every changed line or block. The comment must state what was changed, what it does, and why. Example:
+   ```
+   // CUSTOM: Added pr-twp to apply Platform.Bible's Tailwind CSS scope isolation
+   ```
+
+7. **Standard customizations** that must be present on every applicable component (from the shadcn/ui Guidelines):
+   - `pr-twp` at the **front** of the base Tailwind class string on every DOM-rendered component (components with HTMLElement props, `React.ComponentPropsWithoutRef`, or `React.forwardRef`). Does NOT apply to state-coordinating roots (Dialog, Popover) or cva factories.
+   - TSDoc (`/** ... */`) on every exported symbol, with hyperlinks to the upstream library docs (shadcn/ui page, Radix UI primitive page, etc.).
+
+If a customization in CUSTOMIZATIONS.md no longer makes sense (e.g. the new version already implements the same behavior), skip it — do NOT leave a comment in the file. Instead, include it in your report using this exact format at the end of your response:
+
+```
+## Skipped Customizations
+
+### <filename.tsx>
+- **Customization:** <brief description of the customization from CUSTOMIZATIONS.md>
+  **Reason skipped:** <why it no longer applies>
+
+### <filename.tsx>
+- **Customization:** <brief description>
+  **Reason skipped:** <why>
+```
+
+If you skipped no customizations, omit the section entirely.
+
+---
+End of subagent instructions.
+
+After all 5 subagents complete:
+
+1. **Collect skipped customizations** from each subagent's report. If any subagents reported skipped customizations, compile them all into `lib/platform-bible-react/src/components/shadcn-ui/SKIPPED-CUSTOMIZATIONS.md`:
+
+   ```markdown
+   # Skipped Customizations
+
+   These customizations from `CUSTOMIZATIONS.md` were not re-applied during the shadcn upgrade because they no longer made sense in the new version. Review and delete this file once you have decided whether any of these need to be addressed differently.
+
+   ### <filename.tsx>
+   - **Customization:** <description>
+     **Reason skipped:** <reason>
+   ```
+
+   If no subagents reported any skipped customizations, do not create this file.
+
+2. **Stage all changes** in the shadcn-ui folder (component files + SKIPPED-CUSTOMIZATIONS.md if created):
+
+```bash
+git add lib/platform-bible-react/src/components/shadcn-ui/
+```
+
+3. **If any skipped customizations were found**, stop and tell the user:
+
+   > Some customizations were skipped during the upgrade and recorded in `lib/platform-bible-react/src/components/shadcn-ui/SKIPPED-CUSTOMIZATIONS.md`. Please review that file and let me know:
+   > - If any skipped customizations need to be reconsidered (describe what you'd like to do and I'll handle it), or
+   > - If everything looks fine and you're ready for me to continue.
+
+   Do not proceed until the user confirms they are ready. If no skipped customizations were found, proceed directly.
+
+4. **Dispatch a subagent** to verify and fix code quality. Give it this prompt:
+
+   > You are verifying and fixing code quality for freshly customized shadcn/ui components in `lib/platform-bible-react`. Run the following commands in sequence, resolving any issues that arise before moving on to the next:
+   >
+   > 1. `cd lib/platform-bible-react && npm run typecheck` — fix any TypeScript errors in `src/components/shadcn-ui/` before proceeding
+   > 2. `cd lib/platform-bible-react && npm run lint-fix` — auto-fix lint issues; if any non-auto-fixable errors remain, fix them manually in the component files
+   > 3. `cd lib/platform-bible-react && npm run format` — auto-format; no manual action needed unless it exits non-zero
+   > 4. `cd lib/platform-bible-react && npm run build` — the build must pass before you finish
+   >
+   > For each issue you encounter, try your best to resolve it by editing files in `lib/platform-bible-react/src/components/shadcn-ui/`. Prefer small, targeted fixes: changing `null` to `undefined`, small type reworks, scoped type assertions with an explanation comment, or minor accessibility improvements. Re-run the relevant command after each fix to confirm it passes before moving to the next step.
+   >
+   > **Do NOT add ESLint rule overrides or disable comments to `lib/platform-bible-react/.eslintrc.cjs` or any other config file.** If small code-level fixes cannot resolve a lint issue, record the problem as unresolved and move on — do not reach for config overrides. The orchestrator will discuss with the user whether an override is appropriate.
+   >
+   > When you cannot resolve an issue (e.g. a type error requires understanding design intent, or a build failure has an unclear root cause), record the problem — including the exact error output and what you tried — and **continue attempting to fix all remaining issues** before returning. Do not stop at the first failure; exhaust all issues first, then return a summary listing every unresolved problem.
+   >
+   > When all four commands pass, return a brief success summary. If any issues remain unresolved, return a detailed description of each one — exact error output, what you tried, and why you could not fix it.
+
+   Wait for the subagent to complete. If it reports unresolved problems, **stop and discuss with the user** before proceeding. Do not commit until all four commands pass cleanly.
+
+5. **Commit all changes** (component files, SKIPPED-CUSTOMIZATIONS.md if created, and build artifacts from `npm run build`):
+
+```bash
+git add lib/platform-bible-react/
+git commit -m "chore: re-apply project customizations to upgraded shadcn components"
+```
+
+This is **commit 3 of 3**. Using `git add lib/platform-bible-react/` (not just the shadcn-ui subfolder) ensures the rebuilt dist output and any other generated files are included in the same commit rather than as a separate one.
+
+## Step 6 — Create PR
+
+Use the `pr-creator` skill to create the PR targeting **`main`**.
+
+The PR description must include:
+
+- A summary of the three-commit structure: what each commit represents (shadcn preset baseline → extension propagation → re-applied customizations)
+- A prominent warning:
+
+> ⚠️ **This PR MUST NOT be squash-merged.** Use a normal merge. The three-commit history is essential for future shadcn upgrades: commit 1 shows exactly what the new shadcn preset changed (baseline with no customizations), commit 2 propagates CSS and package changes to extensions, and commit 3 shows the re-applied customizations. Squashing destroys this history.

--- a/.claude/rules/architecture/csharp-patterns.md
+++ b/.claude/rules/architecture/csharp-patterns.md
@@ -1,0 +1,57 @@
+---
+paths:
+  - "c-sharp/**/*.cs"
+---
+
+# C# Architecture Decisions
+
+Design decisions for the C# data-provider backend (not enforceable by linting). See [Paranext-Core-Patterns.md](../../../.context/standards/Paranext-Core-Patterns.md) for the full patterns and code examples.
+
+## Data Provider Contract: `get`/`set`/`subscribe` Are Magic Prefixes
+
+`get`, `set`, and `subscribe` are **reserved** for methods that are part of a data provider's contract — the prefix opts the method into the TS data-provider service:
+
+- `Get*` / `Set*` are implemented in **C#**; `subscribe*` is **auto-generated** TS-side from the events `Set*` emits (declare it in the `.d.ts`, never write a body).
+- Every `Set*` MUST call `SendDataUpdateEvent(...)` for each affected data type — that is how subscribers get notified.
+- Each data type needs its own paired `Get*` / `Set*` / `subscribe*`; they cannot be shared across methods.
+- A provider helper that is **not** part of the contract MUST NOT start with `get`/`set`/`subscribe` — use another verb (`lookup*`, `compute*`, `list*`).
+
+## Visibility
+
+| Component | Visibility | Why |
+| --- | --- | --- |
+| Static services | `internal static class` | Used only within the C# backend |
+| DataProviders / Workers | `internal sealed class` | Single implementation, not inherited |
+| Exceptions | `public class` | May cross process boundaries (serialized) |
+| Result / Options records | `public record` | Returned/passed via PAPI |
+
+## Returns & Errors
+
+- **Return records, not tuples**, from `DataProvider`/`NetworkObject` methods — tuples serialize as `{}` over JSON-RPC and silently lose data (this is what PNX007 catches).
+- Throw **custom exception types** with structured properties for domain errors that cross process boundaries (e.g. `MissingBookException`); keep shared ones at the `c-sharp/` root.
+
+### Cross-process parameter alignment
+
+When a PAPI command spans the TS↔C# boundary, StreamJsonRpc matches the handler by method name **and argument count** (`AddLocalRpcMethod` in `PapiClient.cs`). An **arity** mismatch between the TS call site and the C# handler lambda therefore fails **silently** with JSON-RPC `-32602` (Invalid params) — a distinct failure from the tuple/serialization-shape issue PNX007 catches. When adding or editing such a command:
+
+- **TS optional params change the actual arg count.** A `b?: T` parameter is only sent when the call site passes it, so an arity that looks correct against the type declaration can still be wrong. Check every call site, not just the signature.
+- **Object-param vs positional must match exactly.** `sendCommand` spreads positional args (`networkService.request(..., ...args)` in `command.service.ts`): `sendCommand("cmd", obj)` maps to a C# handler taking one `(RequestType request)`, whereas `sendCommand("cmd", a, b)` maps to `(Type1 a, Type2 b)` — never a single object's separate properties as positional args.
+
+See [Paranext-Core-Patterns.md](../../../.context/standards/Paranext-Core-Patterns.md).
+
+## Concurrency
+
+- Assume registered PAPI methods are called **concurrently**. If a method isn't thread-safe, `lock` it.
+- `ConcurrentDictionary` for simple key/value access; `Interlocked` for atomic counters/flags.
+- If updating shared state takes **more than one operation**, you MUST `lock` for atomicity — a concurrent collection alone is not enough.
+- Bridge sync↔async with `ThreadingUtils.RunTask(...)`, not `.Result` / `.Wait()`.
+
+## What's Enforced by Linting (Don't Duplicate)
+
+Roslyn analyzers in `c-sharp/Paranext.Analyzers` (`DiagnosticIds.cs`) — don't re-document these:
+
+- **PNX001** — ban `System.Diagnostics.Trace` (use `Console.WriteLine`)
+- **PNX004** — one type per file
+- **PNX005** — namespace must match directory
+- **PNX007** — no tuple returns from `DataProvider`/`NetworkObject` (use records)
+- **PNX008** — ban the `dynamic` keyword

--- a/.claude/rules/architecture/discover-before-implementing.md
+++ b/.claude/rules/architecture/discover-before-implementing.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - "c-sharp/**"
+  - "extensions/src/**"
+  - "src/**"
+---
+
+# Discover Before Implementing
+
+Before writing new code, find where the behavior already lives. The codebase aggregates related classes into per-feature directories ([Paranext-Core-Patterns.md#directory-structure](../../../.context/standards/Paranext-Core-Patterns.md#directory-structure)) — new work usually belongs inside one of those, not beside it.
+
+## Search Recipe
+
+Run all four; a name-based grep alone misses code that does the same thing under a different name.
+
+1. **`ls` the feature folders** to learn the existing taxonomy — `c-sharp/` (e.g. `Projects/`, `Services/`, `Checks/`, `Scripture/`, `Users/`) and `extensions/src/` (one folder per extension). Name your work against this taxonomy, not against a folder you invent.
+2. **Concept grep** on what the feature *does* — the verbs and data nouns (`grep -ri "inventory\|checklist\|versification"`), not just a guessed class name. A subscriber may call it something you wouldn't.
+3. **File-name search** — `find . -iname "*resource*"` / `*check*` — folders and files are named after the capability.
+4. **Read the 2–3 likeliest candidates IN FULL.** Open the files, don't skim grep snippets — the integration point (an existing service to register against, a base class, a paired `Get*`/`Set*`) is usually off-screen from the matched line.
+
+## New-Top-Level-Structure Justification Gate
+
+Prefer extending an existing folder/service over standing up a parallel one. Before introducing any new top-level directory, service, or data provider, write down — in the PR or design doc — both of:
+
+- **Why no existing folder fits.** Name the candidates the recipe surfaced and state what each cannot absorb.
+- **What you will call, not duplicate.** The existing service/base class/utility the new code reuses.
+
+If neither can be stated, the new structure is premature — extend instead.

--- a/.claude/rules/architecture/extension-patterns.md
+++ b/.claude/rules/architecture/extension-patterns.md
@@ -1,0 +1,50 @@
+---
+paths:
+  - "extensions/src/**"
+---
+
+# Extension Development Decisions
+
+Design decisions when building extensions (not enforceable by linting).
+
+## Type Declaration Pattern (Two-Module)
+
+Every extension needs `src/types/{extension-name}.d.ts`:
+
+```typescript
+// 1. Local module types
+declare module 'extension-name' {
+  export type MyDataTypes = {
+    /* ... */
+  };
+}
+
+// 2. PAPI augmentations (exposes to other extensions)
+declare module 'papi-shared-types' {
+  export interface CommandHandlers {
+    'extensionName.commandName': (param: Type) => Promise<Result>;
+  }
+}
+```
+
+## WebView Provider Choice
+
+| Use Class (`WebViewFactory`) | Use Object Literal    |
+| ---------------------------- | --------------------- |
+| State tracking needed        | Simple stateless views |
+| Complex initialization       | Minimal setup         |
+| Multiple view types          | Single view type      |
+
+## Service Lifecycle
+
+- Create service → Register with PAPI → Add to `context.registrations`
+- If service has cleanup: `context.registrations.add({ dispose: () => service.cleanup() })`
+- Track multiple unsubscribers if needed
+
+## What's Enforced by Linting (Don't Duplicate)
+
+- Registration cleanup → ESLint: registration-cleanup
+- Method metadata → ESLint: registration-structure
+- File naming → ESLint: webview-file-naming, service-file-naming
+
+See [Extension-Development-Guide.md](../../../.context/standards/Extension-Development-Guide.md) for details.

--- a/.claude/rules/architecture/react-patterns.md
+++ b/.claude/rules/architecture/react-patterns.md
@@ -1,0 +1,88 @@
+---
+paths:
+  - "lib/platform-bible-react/**"
+  - "**/*.web-view.tsx"
+---
+
+# React Component Decisions
+
+Design decisions for React components (not enforceable by linting).
+
+## Colocation Principle
+
+Create folder when component has 2+ of: test, story, types, utils
+
+```
+component-name/
+├── component-name.component.tsx
+├── component-name.stories.tsx
+├── component-name.test.tsx
+├── component-name.types.ts    # If props > 20 lines
+└── component-name.utils.ts    # If has helpers
+```
+
+## Component Style Decisions
+
+Terse decisions (choice → what to avoid → one-line why). Add only the net-new; don't restate what's already covered above.
+
+### Component authoring
+
+- **Functional components with hooks.**
+  - Avoid: class components; HOCs for state management.
+  - Why: modern React, simpler testing, cleaner code.
+
+### Web view self-close (stopgap)
+
+- **A web view closes itself with a DOM walk** (PAPI has no self-close method yet): from `window.top.document`, find the iframe whose `contentWindow === window`, walk up to the enclosing `.dock-panel`, then click `.dock-tab-active .dock-tab-close-btn`.
+  - Avoid: re-deriving this each time; relying on it long-term once a PAPI self-close ships.
+  - Why: documented stopgap until `papi.webViews.closeSelf()` exists on `@papi/frontend`. Web views are same-origin iframes, so `top.document` walking works; it is fragile against rc-dock DOM changes, so it is recorded here so agents don't re-invent it.
+
+### Single-instance web views
+
+- **Detect-and-reuse with the two-call pattern**: `papi.webViews.openWebView(type, layout, { ...options, existingId: '?', createNewIfNotFound: false })` → if the returned id is truthy, `papi.webViews.reloadWebView(type, id, options)` and return that id; otherwise call `openWebView` again without `existingId`.
+  - Avoid: opening a second instance when only one of a web-view-type should be open at a time.
+  - Why: `existingId: '?'` is PAPI's documented detect-and-reuse mechanism; `reloadWebView` hands fresh options to the existing instance. See `openManageBooks` / `openFind` in `extensions/src/platform-scripture/src/main.ts`.
+
+## Storybook Conventions
+
+- **Hierarchy**: `'Basics/'`, `'Advanced/'`, `'Shadcn/'` based on complexity
+- **Tags**: `['autodocs', 'test']` - enables docs + a11y checks
+- **Sample data**: Extract to `.data.ts` if reused across stories
+
+## Handler Naming Convention
+
+| Prefix     | When to Use                                             |
+| ---------- | ------------------------------------------------------- |
+| `on*`      | Simple callbacks passed as props: `onSave`, `onChange`  |
+| `handle*`  | Internal/story handlers: `handleUpdateComment`          |
+| `can*`     | Permission checks: `canUserAssignThread`                |
+
+## Accessibility Checklist
+
+- Interactive elements need `aria-label` or visible text
+- Keyboard navigation for custom controls (arrow keys, escape)
+- Focus management with `aria-activedescendant` for listboxes
+
+## shadcn Customization Markers
+
+When you modify any vendored shadcn component (under `lib/platform-bible-react/src/components/shadcn-ui/` or any other `shadcn-ui/` subdir), every changed/added line MUST carry a `CUSTOM` marker so the diff against upstream is greppable.
+
+**Patterns** (mirror the existing files for consistency):
+
+- Multi-line regions → `/* #region CUSTOM <description> */ ... /* #endregion CUSTOM */`
+- Inline single-line changes → `// CUSTOM: <description>` or `// CUSTOM <short description>` at end of line
+- New top-level exports / functions / variables → `// CUSTOM: <description>` immediately above the declaration
+- JSX additions → `{/* CUSTOM <description> */}`
+
+**Examples**: `alert.tsx`, `dialog.tsx`, `dropdown-menu.tsx`, `menubar.tsx`.
+
+**Verification**: before committing changes to any `shadcn-ui/` file, diff against the prior commit on the base branch and confirm every changed line is covered by a `CUSTOM` marker. Reviewers will grep for `CUSTOM` to find all customizations.
+
+## What's Enforced by Linting (Don't Duplicate)
+
+- Tailwind `tw:` prefix on utility classes → enforced by the project's Tailwind/ESLint config
+- Localized strings → ESLint: no-hardcoded-jsx-strings
+- ARIA localization → ESLint: require-localized-aria
+- Theme colors → ESLint: no-hardcoded-tailwind-colors
+
+See [Component-Selection-Quick-Reference.md](../../../.context/standards/Component-Selection-Quick-Reference.md).

--- a/.claude/rules/architecture/shared-patterns.md
+++ b/.claude/rules/architecture/shared-patterns.md
@@ -1,0 +1,68 @@
+---
+paths:
+  - "src/shared/**"
+  - "src/node/**"
+---
+
+# Cross-Process Code Decisions
+
+Rules for code shared across processes (main, renderer, extension-host).
+
+## Process Boundary Rules
+
+| Can Cross Boundary    | Cannot Cross Boundary |
+| --------------------- | --------------------- |
+| Plain objects         | Functions             |
+| Primitive types       | Class instances       |
+| Serializable data     | Closures              |
+| JSON-compatible types | DOM references        |
+
+## Serialization Safety
+
+- All cross-process data must be JSON-serializable
+- Use `structuredClone()` for deep copies
+- Never pass callbacks over process boundaries
+
+## src/shared/ vs src/node/
+
+| Location       | Purpose                                            |
+| -------------- | -------------------------------------------------- |
+| `src/shared/`  | Code for ALL processes (including renderer)        |
+| `src/node/`    | Code for Node.js processes only (main, extension-host) |
+
+## Network Service Patterns
+
+- Services in `src/shared/services/` define interfaces
+- Implementation lives in process-specific code
+- Use request/response patterns over IPC/WebSocket
+
+## DataProvider Engine Hosting
+
+Host a DataProvider engine in the process where its **dominant data source** lives, so subscribers don't fan out cross-process. The renderer hosts focus/window state, browser-only APIs (`localStorage`), `WebViewDefinition` reads, and theme/system-preference observers — engines reading those belong in the renderer (`src/renderer/services/*.service-host.ts`). The extension host hosts engines whose data is genuinely extension-host-local (extension lifecycle, cross-extension coordination).
+
+- **Choice:** put the engine in the process that owns its primary data source. e.g. `theme.service-host.ts` (reads OS color-scheme preference + `localStorage`) and `window.service-host.ts` (emits `Focus` / `AppFocus` from renderer-local events) both live in the renderer.
+- **Avoid:** hosting an engine in the extension host when ALL its data sources are renderer-local — every event would then JSON-RPC across the boundary for each subscriber.
+- **Rationale:** the decision is per-engine; a cross-process subscription chain is fine as the exception, not the rule for every event.
+
+## Service-Internal Key-Value State
+
+For service-internal key-value state that must survive restart, is scoped to a single renderer, and must NOT be mutable by callers, use renderer `window.localStorage` under a namespaced key (`<feature>.<store-name>`).
+
+- **Choice:** namespaced renderer `localStorage`; mutate only through the service's own internal methods (no public setter). Synchronous API, so no write-queue; on corrupted JSON, fall back to fresh state rather than throw.
+- **Avoid:**
+  - `papi.settings.get/set` for internal-only state — `papi.settings.set` is a PUBLIC PAPI surface (`ISettingsService.set`), so any extension could mutate it.
+  - Custom IndexedDB / SQLite for small key-value state — `localStorage` is synchronous, small, and sufficient.
+- **Rationale:** `papi.settings` is for state that genuinely IS user-configurable across processes / via settings UI; this pattern is specifically for state only the service should write.
+
+## Scripture-Reference Contracts
+
+Any cross-process contract carrying a scripture reference (book + chapter + verse + versification) — PAPI event payload, web-view state, or cross-process message — uses `SerializedVerseRef` from `@sillsdev/scripture`, including the matching C# DTO shape.
+
+- **Choice:** `SerializedVerseRef` everywhere; a display string (e.g. `"GEN 1:1"`) MAY accompany the structured form but never replaces it. This is the canonical shape already used across `platform-bible-utils` (`scripture-util.ts`, `scripture.model.ts`) and `platform-bible-react` (book-chapter-control, scope-selector).
+- **Avoid:**
+  - Generic `VerseRef` placeholder types in data contracts.
+  - Display-string-only fields like `{ ref: string }` when the consumer needs to route to an editor / verse picker.
+  - Per-feature parallel types (`ScriptureReferenceDto`, ad-hoc `{ book, chapter, verse }` interfaces).
+- **Rationale:** one canonical shape keeps producers and consumers aligned across PAPI boundaries without ad-hoc string-parsing.
+
+See [Architecture.md](../../../.context/standards/Architecture.md) for process architecture.

--- a/.claude/rules/code-quality/eslint-disable-discipline.md
+++ b/.claude/rules/code-quality/eslint-disable-discipline.md
@@ -1,0 +1,15 @@
+## Fix Code, Don't Suppress Warnings
+
+When you encounter any code quality error — ESLint, TypeScript, Prettier, Stylelint, or other tooling — pause and reconsider before suppressing it:
+
+1. **Understand the error** — read the message and understand what the tool is protecting against.
+2. **Try to fix the code** — can you restructure, retype, or refactor so the tool is satisfied naturally? This is usually the better path.
+3. **Suppress only as a last resort** — if the fix would be significantly worse (more complex, less readable, or fighting the type system), then suppressing is fine. Write a clear comment explaining why the alternatives don't work well here.
+
+This applies to all suppression mechanisms: `eslint-disable`, `@ts-expect-error`, `// prettier-ignore`, `/* stylelint-disable */`, type assertions (`as Type`), etc.
+
+When suppressing TypeScript errors, always use `@ts-expect-error` instead of `@ts-ignore` — it will flag when the suppression is no longer needed. Include the error code so the suppression is precise, e.g. `// @ts-expect-error ts(2345) - explanation here`.
+
+When ESLint's `paranext/require-disable-comment` rule asks you for a justification, use that as a prompt to reconsider whether there's a better fix before writing the comment.
+
+The goal is not zero suppressions — it's zero *thoughtless* suppressions.

--- a/.claude/rules/code-quality/lint-sweep-verification.md
+++ b/.claude/rules/code-quality/lint-sweep-verification.md
@@ -1,0 +1,23 @@
+## Lint-Sweep Verification
+
+When you make a "lint-fix sweep" commit (one whose stated purpose is to clear lint errors across multiple files), the commit MUST include a final repo-wide verification step, not just per-file `eslint --fix` runs.
+
+### Why
+
+`eslint --fix` only fixes **auto-fixable** rules. Many rules — including high-frequency ones like `react/destructuring-assignment` (most cases), `no-type-assertion/no-type-assertion`, `no-nested-ternary`, `promise/always-return`, and several `paranext/*` plugin rules — are **not auto-fixable**. A per-file sweep that only runs `--fix` will leave those errors in place, but produce a green-looking diff that suggests the sweep "fixed lint". CI then catches the residual errors at merge time, often after several commits have piled on top.
+
+### The rule
+
+Per-file `eslint --fix` is fine as a starting point — but before committing, run a repo-wide lint check as the final verification step:
+
+1. Run `npm run lint` from the repo root (this is the same command CI runs).
+2. Confirm zero remaining errors. Fix any unfixable ones inline as part of the sweep — don't punt them to a follow-up commit, since the whole point of the sweep is to leave the repo green.
+3. Only then commit, with a message that asserts the verification (e.g. `style: lint-fix sweep across X — full repo lint clean`).
+
+### Easy verification command
+
+```bash
+npm run lint   # repo-root, runs across all workspaces; non-zero exit on any error
+```
+
+Run it once before committing the sweep.

--- a/.claude/rules/code-quality/no-secrets.md
+++ b/.claude/rules/code-quality/no-secrets.md
@@ -1,0 +1,12 @@
+## Never Commit Secrets
+
+This is an open-source repository. Never introduce secrets into the codebase:
+
+- **No hardcoded credentials**: API keys, tokens, passwords, connection strings, private keys
+- **No secret files**: `.env`, `.env.*`, `*.pem`, `*.key`, `*.pfx`, `*.p12`, `credentials.json`, `service-account.json`
+- **No secrets in commit messages or PR descriptions**
+- **No base64-encoded or obfuscated secrets** — encoding is not encryption
+
+If a feature needs a secret at runtime, use environment variables or Platform.Bible's settings system. Never provide a default value that is an actual secret.
+
+If you suspect you've staged a file containing secrets, unstage it before committing.

--- a/.claude/rules/code-quality/shadcn-discipline.md
+++ b/.claude/rules/code-quality/shadcn-discipline.md
@@ -1,0 +1,23 @@
+## shadcn/ui Edit Discipline
+
+Every change to any file in `lib/platform-bible-react/src/components/shadcn-ui/`
+**must** be annotated with a `// CUSTOM:` comment placed immediately before the
+changed code. The comment must explain:
+
+- **What** was changed (be specific — name the class, prop, or element)
+- **What** the change does
+- **Why** it was made
+
+Example:
+
+```tsx
+// CUSTOM: Updated shadow color from hsl(var(--sidebar-border)) to var(--sidebar-border)
+// to use the updated CSS variable format that includes the color space in the variable value
+outline:
+  'tw:bg-background tw:shadow-[0_0_0_1px_var(--sidebar-border)] ...',
+```
+
+This applies to **every** edit — including small find-and-replace changes that feel
+mechanical. There are no exceptions.
+
+See the full convention: `.context/standards/Code-Style-Guide.md#shadcnui-guidelines`

--- a/.claude/rules/grep-safety-net.md
+++ b/.claude/rules/grep-safety-net.md
@@ -1,0 +1,11 @@
+## Grep Safety-Net for Large-List Selection
+
+When you pick a subset from a LARGE list by judgment — file names, symbols, test names, log lines, all usages of a symbol, all importers of a module — bracket the semantic scan with a DETERMINISTIC `grep` for the obvious keywords over the same corpus.
+
+A cheap deterministic grep catches the obvious item that an attention failure would otherwise drop when the match is buried in noise. Reading-by-eye degrades as the list grows; `grep` does not.
+
+The rule:
+
+1. **Scan by judgment**, then **grep the same corpus** for the keywords any correct answer must contain.
+2. **Every grep hit is a mandatory candidate** — it MUST appear in your result, or you must state why it is a false positive.
+3. **Tag each result by source** (`keyword-grep` vs `judgment`) so the deterministic hits stay distinguishable from the ones you reasoned in.

--- a/.claude/rules/testing/tdd-discipline.md
+++ b/.claude/rules/testing/tdd-discipline.md
@@ -1,0 +1,44 @@
+---
+paths:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "c-sharp-tests/**/*.cs"
+---
+
+# TDD Discipline Rules
+
+These are PROCESS rules that linting cannot enforce.
+
+## When TDD is Required
+
+TDD is required for logic/behavior changes; pure-UI work may use a component-first approach.
+
+## RED-GREEN-REFACTOR Cycle
+
+1. **RED**: Write ONE failing test first
+2. **GREEN**: Write MINIMUM code to pass
+3. **REFACTOR**: Clean up while tests stay green
+
+## The Revert Test
+
+Every test must be capable of failing. Verify by:
+
+1. Comment out the implementation
+2. Run the test - it MUST fail
+3. If it passes without implementation, rewrite it
+
+## Test Quality (Not Enforceable by Lint)
+
+- Test behavior (WHAT), not implementation (HOW)
+- Favor integration tests over excessive unit tests (Testing Trophy)
+- Mock only at external boundaries, not internal collaborators
+
+### Integration Test Definition
+
+**Integration test**: Verifies cross-capability call chains where the output of one capability feeds into another. These tests exercise the wiring between components without mocking internal collaborators. Only external boundaries (file system, network, PAPI) should be mocked.
+
+## What's Enforced by Linting (Don't Duplicate)
+
+- File naming, structure → ESLint/Roslyn
+
+See [Testing-Guide.md](../../../.context/standards/Testing-Guide.md) for detailed patterns.

--- a/.claude/scripts/preflight-check.sh
+++ b/.claude/scripts/preflight-check.sh
@@ -1,0 +1,104 @@
+#!/bin/bash
+# Platform.Bible Environment Pre-Flight Check
+#
+# Use this script to verify the development environment is ready for
+# AI agents that need visual verification or PAPI access.
+#
+# Usage:
+#   .claude/scripts/preflight-check.sh
+#
+# Exit codes:
+#   0 - All checks passed
+#   1 - One or more checks failed
+
+set -e
+
+echo "=== Platform.Bible Pre-Flight Check ==="
+echo ""
+
+ERRORS=0
+WARNINGS=0
+
+# Colors for output (if terminal supports it)
+if [ -t 1 ]; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  NC='\033[0m' # No Color
+else
+  RED=''
+  GREEN=''
+  YELLOW=''
+  NC=''
+fi
+
+# Check 1: Renderer (Webpack Dev Server) on port 1212
+echo -n "Checking localhost:1212 (Renderer)... "
+if curl -s -m 2 http://localhost:1212 > /dev/null 2>&1; then
+  echo -e "${GREEN}OK${NC}"
+else
+  echo -e "${RED}FAIL${NC}"
+  ERRORS=$((ERRORS+1))
+fi
+
+# Check 2: WebSocket Server (PAPI) on port 8876
+echo -n "Checking localhost:8876 (WebSocket)... "
+if curl -s -m 2 http://localhost:8876 > /dev/null 2>&1; then
+  echo -e "${GREEN}OK${NC}"
+else
+  echo -e "${RED}FAIL${NC}"
+  ERRORS=$((ERRORS+1))
+fi
+
+# Check 3: Electron process
+echo -n "Checking Electron process... "
+if pgrep -f "electron.*paranext" > /dev/null 2>&1; then
+  echo -e "${GREEN}RUNNING${NC}"
+else
+  echo -e "${YELLOW}NOT FOUND${NC}"
+  WARNINGS=$((WARNINGS+1))
+fi
+
+# Check 4: websocat for PAPI client
+echo -n "Checking websocat... "
+if which websocat > /dev/null 2>&1; then
+  echo -e "${GREEN}OK${NC} ($(which websocat))"
+else
+  echo -e "${YELLOW}NOT INSTALLED${NC} (papi-client skill limited)"
+  WARNINGS=$((WARNINGS+1))
+fi
+
+# Check 5: .NET Data Provider process (optional)
+echo -n "Checking .NET Data Provider... "
+if pgrep -f "ParanextDataProvider" > /dev/null 2>&1; then
+  echo -e "${GREEN}RUNNING${NC}"
+else
+  echo -e "${YELLOW}NOT FOUND${NC} (may be bundled with main app)"
+fi
+
+echo ""
+echo "=== Summary ==="
+
+if [ $ERRORS -eq 0 ]; then
+  echo -e "${GREEN}All critical checks PASSED${NC}"
+  if [ $WARNINGS -gt 0 ]; then
+    echo -e "${YELLOW}$WARNINGS warning(s)${NC}"
+  fi
+  echo ""
+  echo "Environment is ready for:"
+  echo "  - visual-verification skill"
+  echo "  - papi-client skill (API queries)"
+  echo "  - Visual evidence capture"
+  exit 0
+else
+  echo -e "${RED}$ERRORS check(s) FAILED${NC}"
+  echo ""
+  echo "To fix, start Platform.Bible:"
+  echo ""
+  echo "    ./.erb/scripts/refresh.sh"
+  echo ""
+  echo "Wait for the script to complete (shows 'Platform.Bible is ready')."
+  echo ""
+  echo "Then re-run this check."
+  exit 1
+fi

--- a/.claude/scripts/statusline.sh
+++ b/.claude/scripts/statusline.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# Cross-platform status line. Uses Node (universally available; required by
+# the project via Volta) for JSON parsing instead of jq, which is not
+# reliably installed on Windows. Bash is still the executor — Git Bash on
+# Windows handles that too.
+input=$(cat)
+
+# Parse JSON via Node, emitting one field per line so spaces inside values
+# (e.g. model display names like "Opus 4.7 (1M context)") survive.
+node_output=$(node -e '
+let buf = "";
+process.stdin.on("data", c => (buf += c));
+process.stdin.on("end", () => {
+  let j; try { j = JSON.parse(buf); } catch { j = {}; }
+  const model = j?.model?.display_name ?? "unknown";
+  const pct = Math.round(j?.context_window?.used_percentage ?? 0);
+  const total = j?.context_window?.context_window_size ?? 200000;
+  const used = Math.floor(total * pct / 100);
+  const cwd = j?.cwd ?? "~";
+  console.log(model);
+  console.log(pct);
+  console.log(total);
+  console.log(used);
+  console.log(cwd);
+});
+' <<< "$input")
+
+{
+  IFS= read -r MODEL
+  IFS= read -r PCT
+  IFS= read -r TOTAL
+  IFS= read -r USED
+  IFS= read -r CWD
+} <<< "$node_output"
+
+# Default values for robustness when node output is empty (node absent)
+PCT=${PCT:-0}
+TOTAL=${TOTAL:-200000}
+USED=${USED:-0}
+
+DIR=$(basename "$CWD")
+
+BRANCH=$(git -C "$CWD" rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [ -n "$BRANCH" ]; then
+  GIT=" | $BRANCH"
+else
+  GIT=""
+fi
+
+# Format token counts with k suffix
+fmt_tokens() {
+  local n=$1
+  n=${n:-0}
+  if [ "$n" -ge 1000 ]; then
+    echo "$((n / 1000))k"
+  else
+    echo "$n"
+  fi
+}
+
+printf "%s | %s%% ctx | %s/%s tokens | %s%s" "$MODEL" "$PCT" "$(fmt_tokens "$USED")" "$(fmt_tokens "$TOTAL")" "$DIR" "$GIT"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+
+  "statusLine": {
+    "type": "command",
+    "command": ".claude/scripts/statusline.sh",
+    "padding": 2
+  },
+
+  "permissions": {
+    "allow": [
+      "Bash",
+      "Read",
+      "Write",
+      "Edit",
+      "Glob",
+      "Grep",
+      "WebFetch",
+      "WebSearch",
+      "NotebookEdit",
+      "Skill(test-runner)",
+      "Skill(app-runner)",
+      "mcp__ide__*"
+    ],
+    "deny": [
+      "Bash(rm -rf /)",
+      "Bash(rm -rf /*)",
+      "Bash(mkfs:*)",
+      "Bash(chmod -R 777 /)",
+      "Bash(git push origin main)",
+      "Bash(git push origin main:*)",
+      "Bash(git push origin master)",
+      "Bash(git push origin master:*)",
+      "Bash(git checkout main && git push)",
+      "Bash(git push --force:*)",
+      "Bash(git push -f:*)",
+      "Bash(git commit --no-verify:*)",
+      "Bash(git commit -n:*)",
+      "Bash(HUSKY=0:*)",
+      "Edit(.claude/settings.json)",
+      "Write(.claude/settings.json)",
+      "Edit(.claude/settings.local.json)",
+      "Write(.claude/settings.local.json)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./secrets/**)",
+      "Read(~/.ssh/**)",
+      "Read(~/.aws/**)",
+      "Read(~/.netrc)",
+      "Read(~/.config/gh/**)",
+      "Read(~/.gnupg/**)",
+      "Read(**/dist/**)",
+      "Read(**/*.min.js)",
+      "Read(**/*.min.css)",
+      "Read(**/*.map)",
+      "Glob(**/dist/**)",
+      "Grep(**/dist/**)"
+    ],
+    "ask": [
+      "Bash(rm -rf:*)",
+      "Bash(rm -r:*)",
+      "Bash(git reset --hard:*)",
+      "Bash(git clean -f:*)",
+      "Bash(chmod -R:*)",
+      "Bash(chown -R:*)",
+      "Bash(sudo:*)",
+      "Bash(eval:*)",
+      "Bash(npm publish:*)",
+      "Bash(git push --force-with-lease:*)"
+    ]
+  },
+
+  "respectGitignore": true
+}

--- a/.claude/skills/app-runner/SKILL.md
+++ b/.claude/skills/app-runner/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: app-runner
+description: "[paranext-core ONLY] Manage Platform.Bible application lifecycle - start, stop, restart, and recover. Use when the app needs to be running for testing, debugging, or visual verification."
+allowed-tools: Bash, Read
+---
+
+# App Runner Skill
+
+Manage Platform.Bible application lifecycle.
+
+## Primary Command: `./.erb/scripts/refresh.sh`
+
+For all start/restart operations, use the refresh script from the paranext-core root:
+
+```bash
+./.erb/scripts/refresh.sh
+```
+
+This script:
+- Stops any running instance
+- Rebuilds the project
+- Starts with CDP enabled on port 9223 (headless via `xvfb-run` on Linux; visible window on macOS)
+- Waits for all three ports (1212, 8876, 9223) to be ready
+- Takes ~30-120 seconds depending on what needs rebuilding
+
+**Use `./.erb/scripts/refresh.sh` for**: Starting app, restarting after code changes, recovering from crashes, preparing for visual verification.
+
+### When to refresh
+
+Run `./.erb/scripts/refresh.sh` at the **start of any UI work**, and again **immediately** when the app stops responding — don't keep retrying `curl`. Treat these as signals to refresh rather than retry:
+
+- CDP on port 9223 is dead (`http://localhost:9223/json` not answering)
+- PAPI WebSocket on port 8876 times out
+- Screenshots come back blank
+
+A clean rebuild-and-restart resolves these far more reliably than polling a stuck instance.
+
+## Stop Application
+
+```bash
+npm stop
+```
+
+## Responsibility Matrix
+
+| Task | Action |
+|------|--------|
+| Start app | `./.erb/scripts/refresh.sh` |
+| Restart app | `./.erb/scripts/refresh.sh` |
+| Stop app | `npm stop` |
+| Visual verification | `./.erb/scripts/refresh.sh` if not running, then verify |
+| PAPI queries | `./.erb/scripts/refresh.sh` if not running, then query |
+| Log inspection | Read log files directly (no app needed) |
+| Running tests | `npm test` / `dotnet test` |
+
+## Quick Status Check
+
+Always check whether the app is already running before any action:
+
+```bash
+RENDERER=$(curl -s -m 2 http://localhost:1212 > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+WEBSOCKET=$(curl -s -m 2 http://localhost:8876 > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+CDP=$(curl -s -m 2 http://localhost:9223/json > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+
+echo "Renderer (1212): $RENDERER"
+echo "WebSocket (8876): $WEBSOCKET"
+echo "CDP Debug (9223): $CDP"
+```
+
+### Interpreting Status
+
+| Renderer | WebSocket | CDP | State | Action |
+|----------|-----------|-----|-------|--------|
+| DOWN | DOWN | DOWN | Not running | Run `./.erb/scripts/refresh.sh` |
+| UP | DOWN | DOWN | Starting | Wait 10-30s, or run `./.erb/scripts/refresh.sh` |
+| UP | UP | DOWN | No CDP | Run `./.erb/scripts/refresh.sh` to enable CDP |
+| UP | UP | UP | **Ready** | All operations available |
+
+## Auto-Start Pattern
+
+If detection shows the app is not ready, start it. The guard below only refreshes
+when WebSocket or CDP is actually down, so it is safe to run before any operation
+that needs the app — it is a no-op when the app is already up:
+
+```bash
+WEBSOCKET=$(curl -s -m 2 http://localhost:8876 > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+CDP=$(curl -s -m 2 http://localhost:9223/json > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+
+if [ "$WEBSOCKET" = "DOWN" ] || [ "$CDP" = "DOWN" ]; then
+  echo "App not ready. Starting..."
+  ./.erb/scripts/refresh.sh
+fi
+```
+
+## PAPI Recovery
+
+When PAPI commands fail, restart and retry (up to 3 attempts):
+
+```bash
+MAX_RETRIES=3
+RETRY_COUNT=0
+
+while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
+  # Try PAPI command
+  RESULT=$( (echo '{"jsonrpc":"2.0","id":1,"method":"rpc.discover","params":[]}'; sleep 3) | websocat ws://localhost:8876 2>&1 )
+
+  if echo "$RESULT" | grep -q '"result"'; then
+    echo "PAPI command succeeded"
+    break
+  fi
+
+  RETRY_COUNT=$((RETRY_COUNT + 1))
+  echo "PAPI failed (attempt $RETRY_COUNT/$MAX_RETRIES). Restarting..."
+  ./.erb/scripts/refresh.sh
+done
+
+if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
+  echo "ERROR: PAPI unresponsive after $MAX_RETRIES restart attempts"
+fi
+```
+
+## Ports Reference
+
+| Port | Service | Required For |
+|------|---------|--------------|
+| 1212 | Webpack Dev Server | Hot-reload, development builds |
+| 8876 | WebSocket (PAPI) | papi-client skill, API queries |
+| 9223 | Chrome DevTools Protocol (CDP) | visual-verification skill, screenshots |
+| 5858 | Node.js Inspector | Debugging main process |
+
+## Individual Processes (Debugging Only)
+
+For specific debugging scenarios only:
+
+| Process | Command | Port | Use Case |
+|---------|---------|------|----------|
+| Full app | `./.erb/scripts/refresh.sh` | 1212, 8876, 9223 | Normal development, visual verification |
+| Renderer only | `npm run start:renderer` | 1212 | Fast UI iteration (no PAPI) |
+| Main only | `npm run start:main` | - | Main process debugging |
+| Data provider | `npm run start:data` | - | C# backend debugging |
+
+## Troubleshooting
+
+### Port Already in Use
+
+```bash
+lsof -i :1212
+lsof -i :8876
+lsof -ti:1212 | xargs kill -9
+```
+
+### Zombie Processes
+
+```bash
+pkill -f electron; pkill -f webpack
+./.erb/scripts/refresh.sh
+```
+
+### App Started But Not Responding
+
+1. Check logs with the `log-inspector` skill
+2. Run `./.erb/scripts/refresh.sh` to restart cleanly
+
+## See Also
+
+- [reference.md](reference.md) - Detailed process architecture
+- [app-state-detection.md](app-state-detection.md) - Shared detection patterns
+- [log-inspector skill](../log-inspector/SKILL.md) - Debug app issues via logs
+- [visual-verification skill](../visual-verification/SKILL.md) - Visual verification
+- [papi-client skill](../papi-client/SKILL.md) - API queries

--- a/.claude/skills/app-runner/app-state-detection.md
+++ b/.claude/skills/app-runner/app-state-detection.md
@@ -1,0 +1,145 @@
+# Platform.Bible App State Detection
+
+Shared reference for detecting Platform.Bible application state across all skills.
+
+## Quick One-Liner Check
+
+```bash
+# Comprehensive status check
+echo "Renderer: $(curl -s -m 2 http://localhost:1212 > /dev/null && echo UP || echo DOWN), WebSocket: $(curl -s -m 2 http://localhost:8876 > /dev/null && echo UP || echo DOWN), Electron: $(pgrep -f 'electron.*paranext' > /dev/null && echo RUNNING || echo STOPPED)"
+```
+
+## Port Reference
+
+| Port | Service | Purpose | Check Command |
+|------|---------|---------|---------------|
+| 1212 | Webpack Dev Server | React renderer, hot reload | `curl -s http://localhost:1212` |
+| 8876 | WebSocket Server | PAPI (JSON-RPC) | `curl -s http://localhost:8876` |
+| 5858 | Node.js Inspector | Main process debugging | - |
+| 9223 | Chrome DevTools | Renderer debugging (VS Code) | - |
+
+## State Matrix
+
+| Renderer (1212) | WebSocket (8876) | Electron Process | State | Description |
+|-----------------|------------------|------------------|-------|-------------|
+| DOWN | DOWN | STOPPED | **not_running** | App not started |
+| UP | DOWN | STOPPED | **webpack_only** | User ran `npm run start:renderer` only |
+| UP | DOWN | RUNNING | **starting** | App initializing (wait 10-30s) |
+| UP | UP | RUNNING | **full_app** | Fully operational |
+| DOWN | UP | RUNNING | **rare** | Renderer crashed |
+
+## Skill Compatibility by State
+
+| Skill | not_running | webpack_only | starting | full_app |
+|-------|-------------|--------------|----------|----------|
+| **app-runner** | Can guide user | Can detect | Wait | Can stop |
+| **papi-client** | BLOCKED | BLOCKED | Wait | WORKS |
+| **log-inspector** | Historical only | Historical | Both | Both |
+| **visual-verification** | BLOCKED | Limited | Wait | WORKS* |
+
+*visual-verification requires visible window AND Chrome MCP enabled (`claude --chrome`)
+
+## Detection Script
+
+```bash
+#!/bin/bash
+# Full status detection
+
+RENDERER=$(curl -s -m 2 http://localhost:1212 > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+WEBSOCKET=$(curl -s -m 2 http://localhost:8876 > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+ELECTRON=$(pgrep -f "electron.*paranext" > /dev/null 2>&1 && echo "RUNNING" || echo "STOPPED")
+DOTNET=$(pgrep -f "ParanextDataProvider" > /dev/null 2>&1 && echo "RUNNING" || echo "STOPPED")
+
+echo "=== Platform.Bible Status ==="
+echo "Renderer (1212):    $RENDERER"
+echo "WebSocket (8876):   $WEBSOCKET"
+echo "Electron process:   $ELECTRON"
+echo ".NET Data Provider: $DOTNET"
+
+# Determine overall state
+if [ "$RENDERER" = "UP" ] && [ "$WEBSOCKET" = "UP" ]; then
+  echo ""
+  echo "State: FULL_APP - Ready for all operations"
+elif [ "$RENDERER" = "UP" ] && [ "$ELECTRON" = "RUNNING" ]; then
+  echo ""
+  echo "State: STARTING - Wait for WebSocket server"
+elif [ "$RENDERER" = "UP" ]; then
+  echo ""
+  echo "State: WEBPACK_ONLY - Run './.erb/scripts/refresh.sh' for full app"
+else
+  echo ""
+  echo "State: NOT_RUNNING - User must start app"
+fi
+```
+
+## Claude Background Process Limitation
+
+When Claude Code runs `./.erb/scripts/refresh.sh` in a background process:
+- Webpack dev server starts (port 1212 works)
+- Electron main process may start
+- **GUI window may NOT be visible** to the user
+
+This happens because background processes lack access to the display environment.
+
+### Implications
+
+| Scenario | What Works | What Doesn't |
+|----------|------------|--------------|
+| Claude starts app | WebSocket API (PAPI) | Visual verification (no visible window) |
+| User starts app | Everything | N/A |
+
+### Recommended Approach
+
+1. **Always check** if app is already running before any action
+2. **For visual verification**: Ask user to start app manually
+3. **For PAPI-only work**: Can attempt background start, but user won't see window
+4. **Document** when visual verification is skipped due to this limitation
+
+## Standard User Prompt
+
+When the app needs to be running and isn't:
+
+```
+================================================================================
+ACTION REQUIRED: Start Platform.Bible
+================================================================================
+
+Please run this command in your terminal:
+
+    npm start
+
+Wait for:
+1. The Platform.Bible window to appear (30-60 seconds)
+2. Terminal shows "Compiled successfully"
+
+Let me know when it's ready.
+================================================================================
+```
+
+## Wait-for-Ready Pattern
+
+When user has started the app and you need to wait:
+
+```bash
+# Wait up to 2 minutes
+for i in {1..24}; do
+  R=$(curl -s -m 2 http://localhost:1212 > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+  W=$(curl -s -m 2 http://localhost:8876 > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+
+  if [ "$R" = "UP" ] && [ "$W" = "UP" ]; then
+    echo "Platform.Bible is ready!"
+    break
+  fi
+
+  echo "Waiting... Renderer: $R, WebSocket: $W ($i/24)"
+  sleep 5
+done
+```
+
+## See Also
+
+- [SKILL.md](SKILL.md) - Main app-runner skill documentation
+- [reference.md](reference.md) - Process architecture details
+- [../visual-verification/SKILL.md](../visual-verification/SKILL.md) - Visual verification skill
+- [../papi-client/SKILL.md](../papi-client/SKILL.md) - WebSocket API skill
+- [../../scripts/preflight-check.sh](../../scripts/preflight-check.sh) - Pre-flight check script

--- a/.claude/skills/app-runner/reference.md
+++ b/.claude/skills/app-runner/reference.md
@@ -1,0 +1,145 @@
+# App Runner Reference
+
+## Platform.Bible Process Architecture
+
+Platform.Bible runs as a multi-process Electron application:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Main Process (Electron)               │
+│  • Window management & app lifecycle                     │
+│  • Spawns and manages child processes                    │
+│  • Port 5858 for Node.js debugging                       │
+└────────────────┬────────────────────────────────────────┘
+                 │ JSON-RPC over WebSocket (port 8876)
+    ┌────────────┼────────────┬───────────────────┐
+    │            │            │                   │
+┌───▼────────┐ ┌─▼──────────┐ ┌▼────────────────┐
+│ Renderer   │ │ Extension  │ │ .NET Data       │
+│ (React UI) │ │ Host       │ │ Provider        │
+│            │ │            │ │                 │
+│ localhost  │ │ • Loads    │ │ • Project data  │
+│ :1212      │ │   extensions│ │ • Paratext     │
+│            │ │ • PAPI     │ │   integration   │
+└────────────┘ └────────────┘ └─────────────────┘
+```
+
+## npm Scripts Deep Dive
+
+### `npm start`
+
+The main development command. Orchestrates multiple processes:
+
+1. **Webpack Dev Server** starts on port 1212
+2. **Preload script** builds and watches
+3. **Extensions** build and watch
+4. **Main process** builds, watches, and launches Electron via `electronmon`
+
+**Configuration**: `.erb/configs/webpack.config.renderer.dev.ts`
+
+### `npm run start:renderer`
+
+Starts only the webpack dev server for the renderer. Useful when:
+- You're only changing React/TypeScript UI code
+- You want faster startup
+- You don't need the Electron shell (testing in browser)
+
+**Note**: Some features require the full app (PAPI access, native dialogs, etc.)
+
+### `npm run start:main`
+
+Starts the main Electron process with webpack watch. Use when:
+- Debugging main process code
+- Testing IPC communication
+- Working on window management
+
+### `npm run start:data`
+
+Starts the .NET data provider with `dotnet watch`. Use when:
+- Working on C# backend code
+- Testing ParatextData integration
+- Debugging data provider issues
+
+**Tip**: Run in a separate terminal since it has its own output stream.
+
+## Ports Used
+
+| Port | Process | Purpose |
+|------|---------|---------|
+| 1212 | Webpack Dev Server | React app hot reload |
+| 8876 | Main Process | JSON-RPC WebSocket server |
+| 5858 | Main Process | Node.js inspector (debugging) |
+| 9223 | Renderer | Chrome DevTools Protocol |
+
+## Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `PORT` | 1212 | Webpack dev server port |
+| `MAIN_ARGS` | - | Extra args for Electron main |
+| `IN_VSCODE` | - | Set when debugging from VS Code |
+| `DEV_NOISY` | false | Enable verbose dev logging |
+| `DEBUG_PROD` | false | Debug packaged builds |
+
+## Debugging with VS Code
+
+The `.vscode/launch.json` provides debug configurations:
+
+1. **Debug Platform** - Compound config for full debugging
+2. **Debug Platform Backend** - Main + extension host
+3. **Attach to Renderer** - Chrome DevTools for renderer
+4. **Debug .NET Core** - C# data provider
+
+To debug:
+1. Open VS Code
+2. Select "Debug Platform" from Run and Debug
+3. Press F5
+
+## Process Lifecycle
+
+### Startup Sequence
+
+1. npm start triggers webpack dev server
+2. Webpack spawns preload, extensions, and main builders
+3. electronmon waits for webpack completion
+4. Electron launches with hot reload support
+5. Main process starts WebSocket server on 8876
+6. Renderer loads from localhost:1212
+7. Extension host initializes
+8. .NET data provider connects (if running)
+
+### Shutdown Sequence
+
+1. Close Electron window
+2. Main process sends shutdown signals
+3. Child processes receive SIGTERM
+4. WebSocket connections close
+5. Webpack dev server stops
+
+## Common Issues
+
+### "EADDRINUSE" Error
+
+Port 1212 is already in use:
+
+```bash
+# Find the process
+lsof -i :1212
+
+# Kill it
+kill -9 $(lsof -ti:1212)
+```
+
+### Electron Won't Start
+
+1. Check for running instances
+2. Verify webpack built successfully
+3. Check main process logs
+4. Try rebuilding: `./.erb/scripts/refresh.sh`
+
+### Hot Reload Not Working
+
+1. Check webpack dev server is running
+2. Verify file is in watched path
+3. Check for TypeScript errors
+4. Restart webpack: run `./.erb/scripts/refresh.sh`

--- a/.claude/skills/extension-creator/SKILL.md
+++ b/.claude/skills/extension-creator/SKILL.md
@@ -1,0 +1,307 @@
+---
+name: extension-creator
+description: "[paranext-core ONLY] Create new extensions using the proper template workflow. Ensures git subtree tracking is set up correctly so extensions can receive future template updates. Use whenever a new extension is needed for feature implementation."
+allowed-tools: Bash, Read
+---
+
+# Extension Creator Skill
+
+Create new extensions in paranext-core/extensions following the proper template workflow.
+
+## CRITICAL: Why This Skill Exists
+
+Extensions MUST be created using the template workflow to:
+1. Set up **git subtree tracking** for future template updates
+2. Ensure proper **merge/squash commits** that Git uses for diffs
+3. Enable automatic updates when `paranext-extension-template` improves
+
+**DO NOT manually create extension folders.** This breaks template tracking.
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Create extension | `npm run create-extension -- <extension-name>` |
+| Update from templates | `npm run update-from-templates` |
+| Check remotes | `git remote -v \| grep template` |
+
+## Prerequisites
+
+Before creating an extension:
+
+```bash
+# Verify you're in the extensions directory
+cd /path/to/paranext-core/extensions
+
+# Check for uncommitted changes (MUST be clean)
+git status
+# If dirty, commit or stash changes first
+
+# Verify template remotes exist
+git remote -v | grep -E "(paranext-multi-extension-template|paranext-extension-template)"
+# If missing, run: npm install (adds remotes automatically)
+```
+
+## Creating a New Extension
+
+### Step 1: Ensure Clean Working Directory
+
+```bash
+cd /path/to/paranext-core/extensions
+git status
+# Must show "nothing to commit, working tree clean"
+```
+
+### Step 2: Run the Create Script
+
+```bash
+# Use kebab-case for extension names
+npm run create-extension -- <extension-name>
+
+# Examples:
+npm run create-extension -- project-notes
+npm run create-extension -- checking-tool
+npm run create-extension -- parallel-passages
+```
+
+### Step 3: Apply Required Post-Creation Fixes (CRITICAL)
+
+The template creates placeholder content that **MUST** be customized before the extension will typecheck correctly. Apply ALL fixes below:
+
+#### 3a. Verify tsconfig.json typeRoots
+
+The template's path-fixing regex should set `typeRoots` to use `../../../` relative paths (monorepo-relative). **Verify they are correct:**
+
+```jsonc
+// extensions/src/<ext>/tsconfig.json - typeRoots MUST look like this:
+"typeRoots": [
+  "../../../node_modules/@types",
+  "../../../lib",
+  "../../../extensions/src",
+  "../../../src/@types",
+  "src/types"
+]
+```
+
+If any paths start with `../paranext-core/` or `../../`, they are WRONG. Fix them to `../../../` (three levels up from `extensions/src/<ext>/`).
+
+**Reference**: `extensions/src/platform-scripture/tsconfig.json` is the canonical pattern.
+
+#### 3b. Add `typecheck` Script to package.json
+
+The template may not include a `typecheck` script. Without it, `npm run typecheck` at the repo root **silently skips** the extension.
+
+```bash
+# Check if script exists
+grep '"typecheck"' extensions/src/<ext>/package.json || echo "MISSING - must add"
+```
+
+If missing, add to `scripts` section:
+
+```json
+"typecheck": "tsc -p ./tsconfig.json"
+```
+
+#### 3c. Declare Commands in papi-shared-types
+
+Any PAPI commands the extension registers MUST be declared in the extension's `.d.ts` file:
+
+```typescript
+// src/types/<ext>.d.ts
+declare module 'papi-shared-types' {
+  export interface CommandHandlers {
+    '<extCamelCase>.<commandName>': (args...) => Promise<ReturnType>;
+  }
+}
+```
+
+Without this declaration, TypeScript will reject `papi.commands.registerCommand('<extCamelCase>.<commandName>', ...)`.
+
+#### 3d. Use `global.webViewComponent` (NOT `globalThis`)
+
+The template may use `globalThis.webViewComponent`. In strict TypeScript mode, this causes:
+
+```
+Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature
+```
+
+**Fix**: Use `global.webViewComponent` instead:
+
+```typescript
+// WRONG - TypeScript strict mode error
+globalThis.webViewComponent = function MyWebView({ ... }: WebViewProps) { ... };
+
+// CORRECT - works with strict mode
+global.webViewComponent = function MyWebView({ ... }: WebViewProps) { ... };
+```
+
+**Reference**: `extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx` uses `global.webViewComponent`.
+
+#### 3e. Type Custom WebView Options Correctly
+
+When opening web views with custom options, create a typed interface and pass a typed variable (NOT an inline object literal):
+
+```typescript
+// In web-view-provider.ts
+import { OpenWebViewOptions } from '@papi/core';
+
+export interface MyWebViewOptions extends OpenWebViewOptions {
+  mode?: string;
+  projectId?: string;
+}
+
+// In main.ts - CORRECT: typed variable
+const options: MyWebViewOptions = { mode: 'create' };
+return papi.webViews.openWebView(webViewType, layoutOptions, options);
+
+// WRONG: inline object literal triggers excess property check
+return papi.webViews.openWebView(webViewType, layoutOptions, { mode: 'create' });
+```
+
+#### 3f. Verify TypeScript Compiles (MANDATORY)
+
+After ALL customizations, run typecheck to catch errors early:
+
+```bash
+npx tsc --noEmit --project extensions/src/<ext>/tsconfig.json
+```
+
+`npm run build` uses transpile-only mode (webpack) and **will NOT catch type errors**. Always run the explicit typecheck.
+
+### Step 4: Customize Extension Content
+
+After the required fixes, customize these files in `src/<extension-name>/`:
+
+| File | Customization |
+|------|---------------|
+| `package.json` | Update description, ownership, replace `paranextExtensionTemplate` placeholders with <extension-name> |
+| `manifest.json` | Set display name, permissions, web view types, replace `paranextExtensionTemplate` placeholders with <extension-name> |
+| `src/main.ts` | Implement extension entry point |
+| `src/types/<ext>.d.ts` | Define extension's PAPI types + CommandHandlers, replace `paranextExtensionTemplate` placeholders with <extension-name> |
+| `assets/displayData.json` | Replace `paranextExtensionTemplate` placeholders with <extension-name> |
+| `contributions/localizedStrings.json` | Add localized strings (English + Spanish) |
+
+### Step 5: Commit the New Extension
+
+The `create-extension` script creates merge commits automatically. Commit any additional customizations:
+
+```bash
+git add .
+git commit -m "Add <extension-name> extension
+
+Initial setup from paranext-extension-template"
+```
+
+## Extension Naming Conventions
+
+| Context | Case | Example |
+|---------|------|---------|
+| Folder name | kebab-case | `project-notes` |
+| npm package | kebab-case | `project-notes` |
+| PAPI commands | lowerCamelCase | `projectNotes.getData` |
+| TypeScript types | PascalCase | `ProjectNotesDataProvider` |
+| .d.ts module | kebab-case | `project-notes.d.ts` |
+
+## Updating Extensions from Template
+
+When `paranext-extension-template` receives updates:
+
+```bash
+cd /path/to/paranext-core/extensions
+npm run update-from-templates
+```
+
+If merge conflicts occur:
+1. Resolve conflicts
+2. Complete the commit
+3. Run the script again
+
+## What the Script Does
+
+The `npm run create-extension` script:
+
+1. Fetches latest `paranext-extension-template main`
+2. Creates folder via `git subtree add --prefix extensions/src/<name>`
+3. Uses `--squash` to create proper merge commit
+4. Runs regex replacements to fix relative paths
+5. Sets up tracking for future template merges
+
+## DO NOT Do This
+
+❌ **Manual folder creation** - loses template tracking:
+```bash
+# WRONG - don't do this!
+mkdir -p extensions/src/my-extension
+cp -r some-template/* extensions/src/my-extension/
+```
+
+❌ **Direct git subtree** without path fixes:
+```bash
+# INCOMPLETE - missing path corrections
+git subtree add --prefix extensions/src/my-ext paranext-extension-template main --squash
+```
+
+## NEVER Rename Extensions
+
+⛔ **Extensions cannot be renamed after creation.**
+
+Renaming an extension folder will break:
+- Git subtree tracking (template updates fail)
+- Extension loading (Platform.Bible expects original name)
+- User settings and data tied to extension ID
+- Other extensions that depend on it
+
+**Choose the extension name carefully when creating it.** The name is permanent.
+
+If you absolutely must change an extension's identity:
+1. Create a NEW extension with the desired name
+2. Migrate code and data manually
+3. Deprecate the old extension (do not delete immediately)
+4. Coordinate migration with users/dependent extensions
+
+## Verifying Template Tracking
+
+Check that template remotes are configured:
+
+```bash
+git remote -v | grep -E "paranext.*template"
+```
+
+Expected output:
+```
+paranext-extension-template    https://github.com/paranext/paranext-extension-template (fetch)
+paranext-extension-template    https://github.com/paranext/paranext-extension-template (push)
+paranext-multi-extension-template    https://github.com/paranext/paranext-multi-extension-template (fetch)
+paranext-multi-extension-template    https://github.com/paranext/paranext-multi-extension-template (push)
+```
+
+## Troubleshooting
+
+### "Template remote not found"
+
+```bash
+npm install  # Adds remotes automatically
+# Or manually:
+git remote add paranext-extension-template https://github.com/paranext/paranext-extension-template
+```
+
+### "Working tree not clean"
+
+```bash
+git stash  # Save changes temporarily
+npm run create-extension -- <name>
+git stash pop  # Restore changes
+```
+
+### "Subtree merge conflict"
+
+Resolve conflicts manually, then:
+```bash
+git add .
+git commit  # Complete the merge
+```
+
+## See Also
+
+- [extensions/README.md](../../../extensions/README.md) - Full extension development guide
+- [Extension Anatomy wiki](https://github.com/paranext/paranext-extension-template/wiki/Extension-Anatomy) - File structure details

--- a/.claude/skills/log-inspector/SKILL.md
+++ b/.claude/skills/log-inspector/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: log-inspector
+description: "[paranext-core ONLY] Read and analyze Platform.Bible application logs including Electron (main, renderer, extension-host) and C# data provider logs. Use when debugging test failures, runtime errors, or unexpected behavior. Works whether app is running or stopped. NOT for use in PT9/legacy Paratext codebases."
+allowed-tools: Bash, Read, Grep
+---
+
+# Log Inspector Skill
+
+Read and analyze Platform.Bible application logs for debugging and troubleshooting.
+
+## App Status Awareness
+
+**This skill works in BOTH states - app running or stopped.**
+
+| App State | Log Analysis Mode | Use Case |
+|-----------|-------------------|----------|
+| **Running** | Live monitoring (`tail -f`) | Debug issues as they happen |
+| **Stopped** | Historical analysis (`grep`, `cat`) | Investigate past crashes/errors |
+
+**Note**: You do NOT need to ask the user to start the app for log inspection. Log files persist between sessions.
+
+### When to Check App Status
+
+If you need to debug a *live* issue (reproduce and watch):
+
+```bash
+# Optional: Check if app is currently running
+RUNNING=$(pgrep -f "electron.*paranext" > /dev/null && echo "yes" || echo "no")
+echo "App currently running: $RUNNING"
+```
+
+If live debugging is needed and app is not running, you may ask the user to start it. But for historical log analysis, this is not necessary.
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Recent errors | `grep -i "error\|exception" "$LOG_PATH" \| tail -20` |
+| Watch live | `tail -f "$LOG_PATH"` |
+| Filter by process | `grep "\[main\]" "$LOG_PATH"` |
+| Last 50 lines | `tail -50 "$LOG_PATH"` |
+
+## Log Locations
+
+### Electron Logs (main, renderer, extension-host)
+
+```bash
+# macOS (development - uses "Electron" as app name)
+LOG_PATH=~/Library/Logs/Electron/main.log
+# macOS (packaged/production app)
+# LOG_PATH=~/Library/Logs/platform-bible/main.log
+
+# Windows (PowerShell, development)
+$LOG_PATH="$env:APPDATA\Electron\logs\main.log"
+# Windows (packaged/production app)
+# $LOG_PATH="$env:APPDATA\platform-bible\logs\main.log"
+
+# Linux (development)
+LOG_PATH=~/.config/Electron/logs/main.log
+# Linux (packaged/production app)
+# LOG_PATH=~/.config/platform-bible/logs/main.log
+```
+
+**Note**: During development on **all** platforms, `electron-log` uses the default Electron app name `Electron` for the log directory. In packaged releases, logs use the packaged app name `platform-bible` (from `release/app/package.json` `name`). The logic is `setAppName(globalThis.isPackaged ? APP_NAME : 'Electron')` in `src/shared/services/logger.service.ts`.
+
+### C# Data Provider Logs
+
+The .NET data provider has **no separate file-log directory**. It writes to its own
+stdout/stderr (via `Console.WriteLine`), and the Electron main process captures that output
+and forwards it into the unified `electron-log` `main.log` file tagged `[.net]` (see
+`dotnet.stdout.on('data', ...)` in `src/main/services/dotnet-data-provider.service.ts`).
+
+```bash
+# Find the C# (.net) provider lines in the unified main.log (dev path shown)
+grep "\.net" ~/.config/Electron/logs/main.log   # adjust path per platform
+```
+
+## Viewing Logs
+
+### Recent Errors
+
+Find the most recent errors across all processes:
+
+```bash
+# macOS example (development)
+grep -iE "error|exception|fail" ~/Library/Logs/Electron/main.log | tail -30
+```
+
+### Watch Live Logs
+
+Monitor logs in real-time while testing:
+
+```bash
+# macOS (development)
+tail -f ~/Library/Logs/Electron/main.log
+
+# With highlighting (if `ccze` installed)
+tail -f ~/Library/Logs/Electron/main.log | ccze -A
+```
+
+### Filter by Process Type
+
+Platform.Bible logs include process tags:
+
+| Tag | Process |
+|-----|---------|
+| `[main]` | Main Electron process |
+| `[rend]` | Renderer process |
+| `[exth]` | Extension host |
+| `[unkn]` | Unknown/other |
+
+```bash
+# Only main process logs
+grep "\[main\]" ~/Library/Logs/Electron/main.log
+
+# Only renderer logs
+grep "\[rend\]" ~/Library/Logs/Electron/main.log
+
+# Only extension host
+grep "\[exth\]" ~/Library/Logs/Electron/main.log
+```
+
+### Filter by Log Level
+
+Log levels: `error`, `warn`, `info`, `verbose`, `debug`
+
+```bash
+# Only errors and warnings
+grep -E "\[(error|warn)\]" ~/Library/Logs/Electron/main.log
+
+# Debug messages (verbose)
+grep "\[debug\]" ~/Library/Logs/Electron/main.log
+```
+
+### Search for Specific Patterns
+
+```bash
+# Find stack traces
+grep -A 10 "Error:" ~/Library/Logs/Electron/main.log
+
+# Find specific function/class
+grep "DataProvider" ~/Library/Logs/Electron/main.log
+
+# Find by timestamp (logs format: [YYYY-MM-DD HH:MM:SS.mmm])
+grep "2025-12-31 14:" ~/Library/Logs/Electron/main.log
+```
+
+## Log Format
+
+Platform.Bible uses `electron-log` with this format:
+
+```
+[YYYY-MM-DD HH:MM:SS.mmm] [level] [process] message [at function file.ts:line:col]
+```
+
+Example:
+```
+[2025-12-31 14:30:15.123] [error] [main] Failed to connect [at connect network.ts:45:8]
+```
+
+## Log Rotation
+
+- **Max file size**: 3 MB before archiving
+- **Archive count**: 5 total log files (the current `main.log` plus up to 4 archived)
+- **Archive naming**: `main.old-1.log`, `main.old-2.log`, ... `main.old-4.log` (the archiver inserts `.old-{n}` BEFORE the extension; template `{name}.old-{n}{ext}` in `src/node/utils/log-archiver.util.ts`)
+
+To view older logs:
+```bash
+# List all log files (development)
+ls -la ~/Library/Logs/Electron/
+
+# View previous log
+cat ~/Library/Logs/Electron/main.old-1.log
+```
+
+## Debugging Workflows
+
+### Test Failure Investigation
+
+1. **Clear logs** (optional):
+   ```bash
+   echo "" > ~/Library/Logs/Electron/main.log
+   ```
+
+2. **Run the failing test**
+
+3. **Check for errors**:
+   ```bash
+   grep -iE "error|exception" ~/Library/Logs/Electron/main.log
+   ```
+
+4. **Look for stack traces**:
+   ```bash
+   grep -A 20 "Error:" ~/Library/Logs/Electron/main.log
+   ```
+
+### Runtime Issue Investigation
+
+1. **Start watching logs**:
+   ```bash
+   tail -f ~/Library/Logs/Electron/main.log
+   ```
+
+2. **Reproduce the issue in the app**
+
+3. **Look for errors in the output**
+
+4. **Search for specific component**:
+   ```bash
+   grep "ComponentName" ~/Library/Logs/Electron/main.log
+   ```
+
+### C# Data Provider Issues
+
+When debugging .NET backend:
+
+1. **Run data provider in foreground**:
+   ```bash
+   npm run start:data
+   # Watch console output for errors
+   ```
+
+2. **Check for .NET exceptions**:
+   ```bash
+   # In the console output, look for:
+   # - System.Exception
+   # - Unhandled exception
+   # - Stack trace lines starting with "at"
+   ```
+
+## Command-Line Log Level Override
+
+When starting the app, override log verbosity:
+
+```bash
+# More verbose
+npm start -- --logLevel=debug
+
+# Less verbose (production-like)
+npm start -- --logLevel=warn
+```
+
+## See Also
+
+- [log-locations.md](log-locations.md) - Platform-specific paths
+- [reference.md](reference.md) - Log format details
+- [app-runner skill](../app-runner/SKILL.md) - Start/stop the app

--- a/.claude/skills/log-inspector/log-locations.md
+++ b/.claude/skills/log-inspector/log-locations.md
@@ -1,0 +1,210 @@
+# Log Locations by Platform
+
+## Electron Logs (Platform.Bible)
+
+### macOS
+
+**Development** (when running `npm start`):
+
+```bash
+# Main log file (development uses "Electron" as app name)
+~/Library/Logs/Electron/main.log
+
+# Archived logs
+~/Library/Logs/Electron/main.old-1.log
+~/Library/Logs/Electron/main.old-2.log
+
+# Full path expansion
+/Users/$USER/Library/Logs/Electron/
+```
+
+**Production** (packaged app):
+
+```bash
+# Main log file
+~/Library/Logs/platform-bible/main.log
+
+# Archived logs
+~/Library/Logs/platform-bible/main.old-1.log
+~/Library/Logs/platform-bible/main.old-2.log
+
+# Full path expansion
+/Users/$USER/Library/Logs/platform-bible/
+```
+
+**Note**: During development, `electron-log` uses the default Electron app name (`Electron`). In packaged releases, logs use the packaged app name (`platform-bible`, from `release/app/package.json` `name`). See `setAppName(globalThis.isPackaged ? APP_NAME : 'Electron')` in `src/shared/services/logger.service.ts`.
+
+### Windows
+
+**Development** (when running `npm start`):
+
+```powershell
+# Main log file (development uses "Electron" as app name)
+%APPDATA%\Electron\logs\main.log
+
+# Full path (typical)
+C:\Users\<username>\AppData\Roaming\Electron\logs\main.log
+
+# PowerShell variable
+$env:APPDATA + "\Electron\logs\main.log"
+```
+
+**Production** (packaged app):
+
+```powershell
+# Main log file
+%APPDATA%\platform-bible\logs\main.log
+
+# Full path (typical)
+C:\Users\<username>\AppData\Roaming\platform-bible\logs\main.log
+
+# PowerShell variable
+$env:APPDATA + "\platform-bible\logs\main.log"
+```
+
+### Linux
+
+**Development** (when running `npm start`):
+
+```bash
+# Main log file (development uses "Electron" as app name)
+~/.config/Electron/logs/main.log
+
+# Full path expansion
+/home/$USER/.config/Electron/logs/main.log
+
+# XDG compliant location
+$XDG_CONFIG_HOME/Electron/logs/main.log
+```
+
+**Production** (packaged app):
+
+```bash
+# Main log file
+~/.config/platform-bible/logs/main.log
+
+# Full path expansion
+/home/$USER/.config/platform-bible/logs/main.log
+
+# XDG compliant location
+$XDG_CONFIG_HOME/platform-bible/logs/main.log
+```
+
+## C# Data Provider Logs
+
+The .NET data provider has **no separate file-log directory**. It writes to its own
+stdout/stderr (via `Console.WriteLine`), and the Electron main process captures that
+output and forwards it into the unified `electron-log` `main.log` file tagged `[.net]`
+(see `dotnet.stdout.on('data', ...)` in `src/main/services/dotnet-data-provider.service.ts`).
+
+### Development Mode
+
+When running via `npm run start:data` standalone, logs go to stdout/stderr (console).
+When the app launches it, those same logs appear in the unified `main.log` (look for `[.net]`).
+
+### Finding C# logs in the unified file
+
+```bash
+# Filter the C# (.net) provider lines out of the unified main.log
+grep "\.net" ~/.config/Electron/logs/main.log   # Linux (dev); adjust path per platform
+```
+
+## Crash Reports
+
+### macOS
+
+```bash
+# Apple Crash Reports (packaged app)
+~/Library/Logs/DiagnosticReports/platform-bible*
+
+# Electron crash dumps (packaged app; dev uses "Electron")
+~/Library/Application Support/platform-bible/Crashpad/
+```
+
+### Windows
+
+```powershell
+# Windows Error Reporting
+%LOCALAPPDATA%\CrashDumps\
+
+# Electron crash dumps (packaged app; dev uses "Electron")
+%APPDATA%\platform-bible\Crashpad\
+```
+
+### Linux
+
+```bash
+# Core dumps (if enabled)
+/var/crash/
+
+# Electron crash dumps (packaged app; dev uses "Electron")
+~/.config/platform-bible/Crashpad/
+```
+
+## Quick Access Commands
+
+### macOS
+
+```bash
+# Open log file in default editor (development)
+open ~/Library/Logs/Electron/main.log
+
+# Open log directory in Finder (development)
+open ~/Library/Logs/Electron/
+
+# Tail logs (development)
+tail -f ~/Library/Logs/Electron/main.log
+```
+
+### Windows (PowerShell)
+
+```powershell
+# Open log file (development; use platform-bible for packaged app)
+notepad "$env:APPDATA\Electron\logs\main.log"
+
+# Open log directory
+explorer "$env:APPDATA\Electron\logs"
+
+# Tail logs (PowerShell 7+)
+Get-Content "$env:APPDATA\Electron\logs\main.log" -Wait
+```
+
+### Linux
+
+```bash
+# Open with default editor (development; use platform-bible for packaged app)
+xdg-open ~/.config/Electron/logs/main.log
+
+# Open directory in file manager
+xdg-open ~/.config/Electron/logs/
+
+# Tail logs
+tail -f ~/.config/Electron/logs/main.log
+```
+
+## Environment Variable Helpers
+
+Add to your shell profile for quick access:
+
+### Bash/Zsh (macOS/Linux)
+
+```bash
+# Add to ~/.bashrc or ~/.zshrc
+export PBIBLE_LOGS=~/Library/Logs/Electron/main.log  # macOS (development)
+# export PBIBLE_LOGS=~/Library/Logs/platform-bible/main.log  # macOS (production)
+# export PBIBLE_LOGS=~/.config/Electron/logs/main.log  # Linux (development)
+# export PBIBLE_LOGS=~/.config/platform-bible/logs/main.log  # Linux (production)
+
+alias pblogs="tail -f $PBIBLE_LOGS"
+alias pberrors="grep -i error $PBIBLE_LOGS | tail -20"
+```
+
+### PowerShell (Windows)
+
+```powershell
+# Add to $PROFILE (development; use platform-bible for packaged app)
+$env:PBIBLE_LOGS = "$env:APPDATA\Electron\logs\main.log"
+
+function pblogs { Get-Content $env:PBIBLE_LOGS -Wait }
+function pberrors { Select-String -Path $env:PBIBLE_LOGS -Pattern "error" | Select-Object -Last 20 }
+```

--- a/.claude/skills/log-inspector/reference.md
+++ b/.claude/skills/log-inspector/reference.md
@@ -1,0 +1,212 @@
+# Log Inspector Reference
+
+## Logging Architecture
+
+Platform.Bible uses `electron-log` for unified cross-process logging.
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `src/shared/services/logger.service.ts` | Logger configuration |
+| `src/shared/utils/logger.utils.ts` | Format and parsing utilities |
+| `src/node/utils/log-archiver.util.ts` | Log rotation logic |
+
+### Log Flow
+
+```
+┌──────────────┐    ┌──────────────┐    ┌──────────────┐
+│   Renderer   │    │  Ext Host    │    │    Main      │
+│   Process    │    │   Process    │    │   Process    │
+└──────┬───────┘    └──────┬───────┘    └──────┬───────┘
+       │                   │                   │
+       │   IPC transport   │                   │
+       └──────────────────►│◄──────────────────┘
+                           │
+                    ┌──────▼───────┐
+                    │  Log File    │
+                    │  (main.log)  │
+                    └──────────────┘
+```
+
+All processes send logs to the main process, which writes to disk.
+
+## Log Format Specification
+
+### Standard Format
+
+```
+[{date}] [{level}] [{process}] {message} [at {function} {file}:{line}:{col}]
+```
+
+### Components
+
+| Component | Example | Description |
+|-----------|---------|-------------|
+| `{date}` | `2025-12-31 14:30:15.123` | ISO timestamp with milliseconds |
+| `{level}` | `info`, `warn`, `error` | Log severity |
+| `{process}` | `main`, `rend`, `exth` | Source process abbreviation |
+| `{message}` | Any text | Log message content |
+| `{function}` | `handleClick` | Function name (when available) |
+| `{file}` | `button.ts` | Source file name |
+| `{line}:{col}` | `42:8` | Line and column number |
+
+### Process Abbreviations
+
+| Abbreviation | Full Name | Description |
+|--------------|-----------|-------------|
+| `main` | Main | Electron main process |
+| `rend` | Renderer | Browser window (React UI) |
+| `exth` | Extension Host | Extension runtime |
+| `unkn` | Unknown | Unidentified source |
+
+### Log Levels
+
+In order of severity (most to least):
+
+| Level | When Used | Color (Console) |
+|-------|-----------|-----------------|
+| `error` | Exceptions, failures | Red |
+| `warn` | Potential issues | Yellow |
+| `info` | General information | Default |
+| `verbose` | Detailed info | Dim |
+| `debug` | Development details | Gray |
+| `silly` | Extremely verbose | Gray |
+
+## Log Archiving
+
+### Configuration
+
+From `src/node/utils/log-archiver.util.ts`:
+
+- **Max file size**: 3 MB (3 * 1024 * 1024 bytes)
+- **Max archive count**: 5 total files (`NUM_LOG_FILES = 5`) — the current `main.log` plus up to 4 archived
+- **Archive naming**: `{name}.old-{n}{ext}` where n = 1-4 — the `.old-{n}` is inserted BEFORE the extension, so the real files are `main.old-1.log` ... `main.old-4.log`
+
+### Rotation Logic
+
+When `main.log` exceeds 3 MB:
+
+1. `main.old-4.log` is deleted (if exists)
+2. `main.old-3.log` → `main.old-4.log`
+3. `main.old-2.log` → `main.old-3.log`
+4. `main.old-1.log` → `main.old-2.log`
+5. `main.log` → `main.old-1.log`
+6. New empty `main.log` created
+
+## Log Parsing
+
+### Extract Timestamp
+
+```bash
+# Parse the date portion
+grep -oE "^\[[0-9]{4}-[0-9]{2}-[0-9]{2} [0-9]{2}:[0-9]{2}:[0-9]{2}\.[0-9]{3}\]" main.log
+```
+
+### Extract Errors with Context
+
+```bash
+# Get 5 lines before and 10 lines after each error
+grep -B5 -A10 "\[error\]" main.log
+```
+
+### Count by Level
+
+```bash
+# Count occurrences of each log level
+grep -oE "\[(error|warn|info|debug)\]" main.log | sort | uniq -c
+```
+
+### Timeline Analysis
+
+```bash
+# Errors in the last hour (approximate)
+grep "$(date +%Y-%m-%d' '%H:)" main.log | grep "\[error\]"
+```
+
+## C# Data Provider Logging
+
+The .NET data provider uses a separate logging mechanism.
+
+### Console Output
+
+When running `npm run start:data`, logs appear in stdout/stderr:
+
+```
+info: Microsoft.Hosting.Lifetime[14]
+      Now listening on: http://localhost:...
+info: ParanextDataProvider[0]
+      Connected to WebSocket server
+```
+
+### Log Levels (C#)
+
+```
+Trace → Debug → Information → Warning → Error → Critical
+```
+
+### Common .NET Log Patterns
+
+```bash
+# Filter .NET exceptions from console
+npm run start:data 2>&1 | grep -E "(Exception|Error|at .*\()"
+```
+
+## Useful Grep Patterns
+
+### Find Unhandled Exceptions
+
+```bash
+grep -E "(UnhandledException|unhandledRejection|uncaughtException)" main.log
+```
+
+### Find Network Errors
+
+```bash
+grep -iE "(network|connection|socket|timeout|ECONNREFUSED)" main.log
+```
+
+### Find Extension Issues
+
+```bash
+grep "\[exth\]" main.log | grep -iE "(error|fail|exception)"
+```
+
+### Find Slow Operations
+
+```bash
+# Look for timing logs
+grep -E "[0-9]+ms" main.log | grep -E "[0-9]{4,}ms"  # Operations over 1 second
+```
+
+## Integration with Other Tools
+
+### VS Code Debug Console
+
+When debugging via VS Code, logs also appear in the Debug Console.
+
+### Chrome DevTools
+
+Renderer logs can be viewed in Chrome DevTools console:
+- Press F12 in the app window
+- Or use `claude --chrome` and read console via MCP
+
+### JSON-RPC Message Logging
+
+To enable message logging in `src/main/services/rpc-server.ts`, uncomment the commented
+`this.ws.send` override block near the top of the `RpcServer` constructor (roughly lines
+66-72, between the `/*` and `*/`):
+
+```typescript
+// Uncomment the following to log every message sent
+/*
+const originalSend = this.ws.send;
+this.ws.send = (data) => {
+  logger.warn(`Sending message on ${this.name}: ${data}`);
+  originalSend.call(this.ws, data);
+};
+*/
+```
+
+There is also a commented "log every message received" line in
+`onMessageReceivedByWebSocket` you can uncomment for inbound messages.

--- a/.claude/skills/papi-client/SKILL.md
+++ b/.claude/skills/papi-client/SKILL.md
@@ -1,0 +1,379 @@
+---
+name: papi-client
+description: "[paranext-core ONLY] Send JSON-RPC requests to the Platform.Bible WebSocket API (PAPI). Use for service discovery, executing commands, querying project data, and debugging. Requires app to be running (GUI visibility not required). NOT for use in PT9/legacy Paratext codebases."
+allowed-tools: Bash, Read
+---
+
+# PAPI Client Skill
+
+Send JSON-RPC requests to the Platform.Bible WebSocket API for debugging, testing, and automation.
+
+## Prerequisites
+
+### 1. websocat Required
+
+This skill requires `websocat` for WebSocket communication:
+
+```bash
+# Check if available
+which websocat || echo "websocat not found - please install"
+
+# macOS
+brew install websocat
+
+# Linux (via cargo)
+cargo install websocat
+```
+
+If `websocat` is not available, ask the user to install it before proceeding.
+
+### 2. Platform.Bible Must Be Running
+
+**REQUIRED**: The WebSocket server runs on port 8876 as part of Platform.Bible.
+
+The user must start Platform.Bible in their terminal. Claude CANNOT reliably start GUI applications.
+
+## Connection Check (Do This First!)
+
+**Before ANY PAPI requests, verify the WebSocket server is available:**
+
+```bash
+# Quick check
+if curl -s -m 2 http://localhost:8876 > /dev/null 2>&1; then
+  echo "PAPI WebSocket server is available"
+else
+  echo "PAPI WebSocket server is NOT available"
+fi
+```
+
+### If WebSocket Server is NOT Available
+
+**Provide this message to the user:**
+
+```
+================================================================================
+PAPI CLIENT REQUIRES PLATFORM.BIBLE
+
+The WebSocket server at localhost:8876 is not responding.
+Please start Platform.Bible in your terminal:
+
+    ./.erb/scripts/refresh.sh
+
+Wait for the script to complete (shows "Platform.Bible is ready").
+
+Let me know when it's ready, and I'll retry the PAPI command.
+================================================================================
+```
+
+**WAIT for user confirmation, then verify:**
+
+```bash
+# Verify after user says ready
+curl -s -m 2 http://localhost:8876 > /dev/null && echo "Verified: PAPI available" || echo "Still not responding"
+```
+
+## Headless Operation Note
+
+PAPI client can work even if the GUI window is not visible, as long as the WebSocket server is running on port 8876. However, the app must still be started.
+
+## Connection Timing (IMPORTANT)
+
+The PAPI WebSocket server requires the connection to stay open while processing requests. Simple piping (`echo | websocat`) closes the connection too quickly, resulting in empty responses.
+
+**Pattern for reliable requests:**
+
+```bash
+# WRONG - connection closes before response arrives
+echo '{"jsonrpc":"2.0","id":1,"method":"...","params":[]}' | websocat ws://localhost:8876
+
+# CORRECT - sleep keeps connection open for response
+(echo '{"jsonrpc":"2.0","id":1,"method":"...","params":[]}'; sleep 1) | websocat ws://localhost:8876
+```
+
+**Sleep duration guidelines:**
+- Simple commands: `sleep 1`
+- Data queries: `sleep 2`
+- Large responses (rpc.discover): `sleep 3` + save to file
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Check if app running | `curl -s http://localhost:8876 > /dev/null && echo "Running" \|\| echo "Stopped"` |
+| Get OS platform | `(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.getOSPlatform","params":[]}'; sleep 1) \| websocat ws://localhost:8876` |
+| Get all projects | `(echo '{"jsonrpc":"2.0","id":1,"method":"object:ProjectLookupService.getMetadataForAllProjects","params":[{}]}'; sleep 2) \| websocat ws://localhost:8876` |
+| **Discover all methods** | See "Working with Large Responses" section below |
+
+## Working with Large Responses
+
+The `rpc.discover` response is ~80KB+ (OpenRPC schema with 300+ methods). It requires special handling:
+
+1. **Save to a file** (too large for inline processing)
+2. **Use grep or Python for parsing** (the schema contains embedded newlines that can break `jq`)
+
+### Save and Query Schema
+
+```bash
+# Step 1: Save the full schema to a temporary file
+(echo '{"jsonrpc":"2.0","id":1,"method":"rpc.discover","params":[]}'; sleep 3) \
+  | websocat ws://localhost:8876 > /tmp/papi-schema.json
+
+# Step 2: Extract method names using grep (most reliable)
+grep -o '"name":"[^"]*"' /tmp/papi-schema.json | sed 's/"name":"//g' | sed 's/"//g' | grep '^command:' | head -20
+grep -o '"name":"[^"]*"' /tmp/papi-schema.json | sed 's/"name":"//g' | sed 's/"//g' | grep '^object:' | head -20
+
+# Count methods by type
+echo "Commands: $(grep -o '"name":"command:[^"]*"' /tmp/papi-schema.json | wc -l)"
+echo "Objects: $(grep -o '"name":"object:[^"]*"' /tmp/papi-schema.json | wc -l)"
+```
+
+### Parse with Python (for detailed queries)
+
+If you need to parse the full schema structure, use Python (handles embedded newlines):
+
+```bash
+python3 << 'PYEOF'
+import json, re
+with open('/tmp/papi-schema.json', 'r') as f:
+    content = f.read().strip()
+# Fix embedded newlines in JSON strings
+fixed = re.sub(r'"[^"\\]*(?:\\.[^"\\]*)*"',
+               lambda m: m.group(0).replace('\n', '\\n'), content, flags=re.DOTALL)
+data = json.loads(fixed)
+# List command methods
+for m in data['result']['methods']:
+    if m['name'].startswith('command:'):
+        print(m['name'])
+PYEOF
+```
+
+**Tip**: For common operations, call methods directly rather than parsing the full schema. See "Platform Commands" section below.
+
+## Method Discovery (OpenRPC)
+
+**IMPORTANT**: PAPI methods are dynamic - they change as extensions load/unload. The `rpc.discover` method returns an OpenRPC 1.2.6 schema.
+
+### Open Interactive API Docs
+
+The easiest way to explore methods is via the OpenRPC playground:
+
+```bash
+# Opens OpenRPC playground in your browser
+(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.openDeveloperDocumentationUrl","params":[]}'; sleep 1) | websocat ws://localhost:8876
+```
+
+### Method Categories
+
+Methods follow the `category:directive` naming pattern:
+
+| Category | Prefix | Example |
+|----------|--------|---------|
+| Command | `command:` | `command:platform.quit` |
+| Network Object | `object:` | `object:ProjectLookupService.getMetadataForAllProjects` |
+| Dialog | `dialog:` | `dialog:showDialog` |
+| WebView | `webView:` | `webView:getWebView` |
+
+See [reference.md](reference.md) for full protocol documentation.
+
+## Checking Connection
+
+Always verify the app is running before sending requests:
+
+```bash
+# Quick check - WebSocket server available
+curl -s http://localhost:8876 > /dev/null && echo "App running" || echo "Start app first with: ./.erb/scripts/refresh.sh"
+
+# Check if port is in use
+lsof -i :8876
+```
+
+
+## Platform Commands
+
+### Safe (Read-Only)
+
+```bash
+# Get OS platform ("win32", "darwin", "linux")
+(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.getOSPlatform","params":[]}'; sleep 1) | websocat ws://localhost:8876
+
+# Get current log file content
+(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.getLogFileContent","params":[]}'; sleep 2) | websocat ws://localhost:8876
+
+# Check if in full screen mode
+(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.isFullScreen","params":[]}'; sleep 1) | websocat ws://localhost:8876
+```
+
+### UI Modification
+
+```bash
+# Increase zoom by 10%
+(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.zoomIn","params":[]}'; sleep 1) | websocat ws://localhost:8876
+
+# Decrease zoom by 10%
+(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.zoomOut","params":[]}'; sleep 1) | websocat ws://localhost:8876
+```
+
+### Destructive Commands
+
+**Use with caution - these affect the running application:**
+
+```bash
+# Restart extension host (extensions will reload)
+(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.restartExtensionHost","params":[]}'; sleep 1) | websocat ws://localhost:8876
+
+# Restart the entire application
+(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.restart","params":[]}'; sleep 1) | websocat ws://localhost:8876
+
+# Close the application
+(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.quit","params":[]}'; sleep 1) | websocat ws://localhost:8876
+```
+
+## Network Object Queries
+
+Query data from registered network objects:
+
+```bash
+# Get metadata for all projects
+(echo '{"jsonrpc":"2.0","id":1,"method":"object:ProjectLookupService.getMetadataForAllProjects","params":[{}]}'; sleep 2) | websocat ws://localhost:8876
+
+# Pretty print project list
+(echo '{"jsonrpc":"2.0","id":1,"method":"object:ProjectLookupService.getMetadataForAllProjects","params":[{}]}'; sleep 2) | websocat ws://localhost:8876 | jq '.result'
+
+# Get metadata for a specific project (replace <projectId>)
+(echo '{"jsonrpc":"2.0","id":1,"method":"object:ProjectLookupService.getMetadataForProject","params":["<projectId>"]}'; sleep 2) | websocat ws://localhost:8876
+```
+
+## Response Handling
+
+### Success Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": <data>
+}
+```
+
+Extract the result with `jq`:
+```bash
+(echo '...'; sleep 1) | websocat ws://localhost:8876 | jq '.result'
+```
+
+### Error Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "error": {
+    "code": -32601,
+    "message": "Method not found"
+  }
+}
+```
+
+Check for errors:
+```bash
+(echo '...'; sleep 1) | websocat ws://localhost:8876 | jq 'if .error then "Error: " + .error.message else .result end'
+```
+
+## Common Workflows
+
+### Debug Project Discovery
+
+```bash
+# 1. Verify app is running
+curl -s http://localhost:8876 > /dev/null && echo "App running" || exit 1
+
+# 2. Check how many methods are registered (save schema to file first)
+(echo '{"jsonrpc":"2.0","id":1,"method":"rpc.discover","params":[]}'; sleep 3) | websocat ws://localhost:8876 > /tmp/papi-schema.json
+echo "Commands: $(grep -o '"name":"command:[^"]*"' /tmp/papi-schema.json | wc -l)"
+echo "Objects: $(grep -o '"name":"object:[^"]*"' /tmp/papi-schema.json | wc -l)"
+
+# 3. List all projects
+(echo '{"jsonrpc":"2.0","id":1,"method":"object:ProjectLookupService.getMetadataForAllProjects","params":[{}]}'; sleep 2) | websocat ws://localhost:8876 | jq '.result'
+```
+
+### Check Application State
+
+```bash
+# Get platform info
+(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.getOSPlatform","params":[]}'; sleep 1) | websocat ws://localhost:8876
+
+# Get recent logs
+(echo '{"jsonrpc":"2.0","id":1,"method":"command:platform.getLogFileContent","params":[]}'; sleep 2) | websocat ws://localhost:8876 | jq -r '.result' | tail -50
+```
+
+## Troubleshooting
+
+### Empty Response / No Output
+
+The WebSocket connection closes before receiving the response. **Use the sleep pattern:**
+
+```bash
+# WRONG - closes too quickly
+echo '{"jsonrpc":"2.0",...}' | websocat ws://localhost:8876
+
+# CORRECT - sleep keeps connection open
+(echo '{"jsonrpc":"2.0",...}'; sleep 1) | websocat ws://localhost:8876
+```
+
+### Response Truncated / jq Parse Error
+
+For large responses (like `rpc.discover`), the output may be cut off or contain embedded newlines that break `jq`. **Save to file and use grep:**
+
+```bash
+# Save to file
+(echo '{"jsonrpc":"2.0","id":1,"method":"rpc.discover","params":[]}'; sleep 3) \
+  | websocat ws://localhost:8876 > /tmp/response.json
+
+# Use grep to extract method names (more reliable than jq for this schema)
+grep -o '"name":"[^"]*"' /tmp/response.json | sed 's/"name":"//g' | sed 's/"//g'
+```
+
+See "Working with Large Responses" section for full parsing with Python.
+
+### Connection Refused
+
+```bash
+# Check if app is running
+ps aux | grep -E "(electron|ParanextDataProvider)" | grep -v grep
+
+# Check if port 8876 is in use
+lsof -i :8876
+```
+
+**If not running, ask the user to start the app:**
+
+```
+Platform.Bible is not running. Please start it in your terminal:
+    ./.erb/scripts/refresh.sh
+Let me know when it's ready.
+```
+
+### Method Not Found (-32601)
+
+1. Save the schema: `(echo '{"jsonrpc":"2.0","id":1,"method":"rpc.discover","params":[]}'; sleep 3) | websocat ws://localhost:8876 > /tmp/schema.json`
+2. Search for the method: `grep -o '"name":"[^"]*"' /tmp/schema.json | grep "yourmethod"`
+3. Check method name format: `category:directive`
+4. Commands need `command:` prefix, network objects need `object:` prefix
+
+### websocat Not Found
+
+Install websocat:
+```bash
+# macOS
+brew install websocat
+
+# Linux (requires Rust/cargo)
+cargo install websocat
+
+# Or download binary from: https://github.com/vi/websocat/releases
+```
+
+## See Also
+
+- [reference.md](reference.md) - Protocol details and method catalog
+- [app-runner skill](../app-runner/SKILL.md) - Start/stop the application
+- [log-inspector skill](../log-inspector/SKILL.md) - Analyze application logs

--- a/.claude/skills/papi-client/reference.md
+++ b/.claude/skills/papi-client/reference.md
@@ -1,0 +1,329 @@
+# PAPI Client Reference
+
+## Protocol Overview
+
+Platform.Bible uses JSON-RPC 2.0 over WebSocket for inter-process communication between the Main process, Renderer, Extension Host, and .NET Data Provider.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Main Process (Electron)               │
+│  • WebSocket server on port 8876                         │
+│  • Routes messages between processes                     │
+└────────────────┬────────────────────────────────────────┘
+                 │ JSON-RPC over WebSocket (port 8876)
+    ┌────────────┼────────────┬───────────────────┐
+    │            │            │                   │
+┌───▼────────┐ ┌─▼──────────┐ ┌▼────────────────┐
+│ Renderer   │ │ Extension  │ │ .NET Data       │
+│ (React UI) │ │ Host       │ │ Provider        │
+└────────────┘ └────────────┘ └─────────────────┘
+```
+
+### Connection Details
+
+| Property | Value |
+|----------|-------|
+| Protocol | WebSocket |
+| Host | localhost |
+| Port | 8876 |
+| URL | `ws://localhost:8876` |
+| Authentication | None (localhost trust model) |
+
+## Message Formats
+
+### Request Message
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <number | string>,
+  "method": "<category>:<directive>",
+  "params": [...]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `jsonrpc` | string | Always `"2.0"` |
+| `id` | number/string | Unique request identifier |
+| `method` | string | Method name in `category:directive` format |
+| `params` | array | Method parameters (always an array) |
+
+### Success Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <matching request id>,
+  "result": <any>
+}
+```
+
+### Error Response
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": <matching request id>,
+  "error": {
+    "code": <number>,
+    "message": "<string>",
+    "data": <optional any>
+  }
+}
+```
+
+### Notification (Event)
+
+Notifications are one-way messages without an `id` field:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "<eventType>",
+  "params": [<eventData>]
+}
+```
+
+## Method Categories
+
+Methods follow the `category:directive` naming pattern:
+
+| Category | Prefix | Purpose | Example |
+|----------|--------|---------|---------|
+| Command | `command:` | Execute platform/extension commands | `command:platform.quit` |
+| Network Object | `object:` | Call methods on registered objects | `object:ProjectLookupService.getMetadataForAllProjects` |
+| Dialog | `dialog:` | Show dialogs | `dialog:showDialog` |
+| WebView | `webView:` | Manage web views | `webView:getWebView` |
+| Extension Service | `extensionService:` | Extension services | Extension-specific |
+| Extension Asset | `extensionAsset:` | Get extension assets | `extensionAsset:getExtensionAsset` |
+| Scroll Group | `scrollGroup:` | Scroll synchronization | Scroll coordination |
+
+### Special Methods
+
+These methods don't follow the `category:directive` pattern:
+
+| Method | Purpose |
+|--------|---------|
+| `rpc.discover` | Get OpenRPC schema with all registered methods |
+| `network:registerMethod` | Register a new method handler |
+| `network:unregisterMethod` | Unregister a method handler |
+
+## Platform Commands Reference
+
+### Safe (Read-Only)
+
+| Method | Description | Returns |
+|--------|-------------|---------|
+| `command:platform.getOSPlatform` | Get operating system | `"win32"`, `"darwin"`, or `"linux"` |
+| `command:platform.getLogFileContent` | Get current log content | string |
+| `command:platform.isFullScreen` | Check full screen mode | boolean |
+
+### UI Modification
+
+| Method | Description |
+|--------|-------------|
+| `command:platform.zoomIn` | Increase zoom by 10% |
+| `command:platform.zoomOut` | Decrease zoom by 10% |
+
+### Destructive
+
+| Method | Description | Warning |
+|--------|-------------|---------|
+| `command:platform.quit` | Close the application | Terminates all processes |
+| `command:platform.restart` | Restart the application | All state is lost |
+| `command:platform.restartExtensionHost` | Restart extension host | Extensions reload |
+
+### Utility
+
+| Method | Description |
+|--------|-------------|
+| `command:platform.openDeveloperDocumentationUrl` | Open OpenRPC docs in browser |
+| `command:platform.openWindow` | Open URL in default browser |
+
+## Network Object Services
+
+### ProjectLookupService
+
+| Method | Parameters | Description |
+|--------|------------|-------------|
+| `getMetadataForAllProjects` | `[{}]` | Get all project metadata |
+| `getMetadataForProject` | `["<projectId>"]` | Get specific project metadata |
+| `areProjectIdsEqual` | `["<id1>", "<id2>"]` | Compare project IDs |
+| `filterProjectsMetadata` | `[<options>]` | Filter projects by criteria |
+
+## Error Codes
+
+Standard JSON-RPC 2.0 error codes:
+
+| Code | Name | Description |
+|------|------|-------------|
+| -32700 | ParseError | Invalid JSON received |
+| -32600 | InvalidRequest | Missing required fields |
+| -32601 | MethodNotFound | Method not registered |
+| -32602 | InvalidParams | Wrong parameter types/count |
+| -32603 | InternalError | Server-side exception |
+
+### Retry Behavior
+
+When receiving `MethodNotFound` (-32601), the platform automatically retries up to 10 times with 1-second delays. This handles race conditions during startup when methods are still being registered.
+
+## Service Discovery (OpenRPC)
+
+The `rpc.discover` method returns an OpenRPC 1.2.6 schema:
+
+```json
+{
+  "openrpc": "1.2.6",
+  "info": {
+    "title": "Live PAPI documentation",
+    "version": "<app version>",
+    "description": "..."
+  },
+  "servers": [...],
+  "methods": [
+    {
+      "name": "methodName",
+      "summary": "...",
+      "params": [...],
+      "result": {...}
+    }
+  ],
+  "components": {...}
+}
+```
+
+### Extracting Method Information
+
+```bash
+# Get method count
+... | jq '.result.methods | length'
+
+# List all method names
+... | jq -r '.result.methods[].name'
+
+# Filter by category
+... | jq -r '.result.methods[].name | select(startswith("command:"))'
+
+# Get method details
+... | jq '.result.methods[] | select(.name == "command:platform.quit")'
+```
+
+## Security Model
+
+### Localhost Trust
+
+- WebSocket server only accepts connections from localhost
+- No authentication tokens required for process-to-process communication
+- Assumes all local connections are trusted (controlled by Electron)
+
+### Extension Isolation
+
+- Extensions use execution tokens for isolated storage
+- Tokens are SHA256 hashed with type, name, and nonce
+- Not relevant for external clients connecting via WebSocket
+
+### Method Ownership
+
+- Only the connection that registered a method can unregister it
+- Methods are automatically cleaned up when connections close
+- Prevents hijacking of method handlers
+
+## Serialization Notes
+
+- Uses custom serialization from `platform-bible-utils`
+- `null` values from network are converted to `undefined` internally
+- Exception: `null` in `result` field is preserved per JSON-RPC spec
+- Arrays and objects should be JSON-formatted
+
+## Timeout Configuration
+
+- Default request timeout: 30 seconds
+- Configurable per request type via settings
+- Maximum retry attempts: 10 with 1-second intervals
+
+## Source Files
+
+Key implementation files in the codebase:
+
+| File | Purpose |
+|------|---------|
+| `src/shared/data/rpc.model.ts` | Constants, message creation, serialization |
+| `src/main/main.ts` | Platform command registrations |
+| `src/main/services/rpc-websocket-listener.ts` | WebSocket server, OpenRPC schema |
+| `src/client/services/rpc-client.ts` | Client implementation |
+| `src/shared/models/openrpc.model.ts` | OpenRPC schema types |
+
+## Common Patterns
+
+This section documents multi-step PAPI patterns that are non-obvious but commonly needed.
+
+### Get Project Name (Two-Step Lookup)
+
+Project names are stored in project settings, not in the project metadata. Getting a human-readable name requires:
+
+1. Get the Project Data Provider (PDP) ID from the project ID
+2. Query the `platform.name` setting from that PDP
+
+```bash
+# Step 1: Get PDP ID for a project
+PROJECT_ID="32664DC3288A28DF2E2BB75DED887FC8F17A15FB"
+PDP_ID=$((echo "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"object:platform.Paratext-pdpf.getProjectDataProviderId\",\"params\":[\"$PROJECT_ID\"]}"; sleep 2) | websocat ws://localhost:8876 | jq -r '.result')
+
+# Step 2: Query project name setting
+(echo "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"object:${PDP_ID}.getSetting\",\"params\":[\"platform.name\"]}"; sleep 2) | websocat ws://localhost:8876
+# Returns: {"jsonrpc":"2.0","id":1,"result":"WEB"}
+```
+
+### List All Projects with Names
+
+Combine project discovery with name resolution:
+
+```bash
+# Get all project IDs, then resolve names
+for PROJECT_ID in $((echo '{"jsonrpc":"2.0","id":1,"method":"object:ProjectLookupService.getMetadataForAllProjects","params":[{}]}'; sleep 2) | websocat ws://localhost:8876 | jq -r '.result[].id'); do
+  # Skip lexical resources (SDBG, SDBH) - they don't have Paratext PDPs
+  if [[ "$PROJECT_ID" == "SDBG" || "$PROJECT_ID" == "SDBH" ]]; then
+    echo "$PROJECT_ID (Lexical Resource)"
+    continue
+  fi
+  PDP_ID=$((echo "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"object:platform.Paratext-pdpf.getProjectDataProviderId\",\"params\":[\"$PROJECT_ID\"]}"; sleep 2) | websocat ws://localhost:8876 | jq -r '.result')
+  NAME=$((echo "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"object:${PDP_ID}.getSetting\",\"params\":[\"platform.name\"]}"; sleep 2) | websocat ws://localhost:8876 | jq -r '.result')
+  echo "$NAME ($PROJECT_ID)"
+done
+```
+
+### Common Project Settings
+
+Use `object:{pdpId}.getSetting` with these keys for Paratext projects:
+
+| Setting Key | Description | Example Value |
+|-------------|-------------|---------------|
+| `platform.name` | Human-readable project name | `"WEB"` |
+| `platformScripture.booksPresent` | Which books exist in the project | `"GEN,EXO,..."` |
+| `platformScripture.versification` | Versification scheme | `"English"` |
+
+## Agent Convention: Adding New Patterns
+
+Agents using this skill may discover new useful patterns during their work. When this happens, consider adding them to this section.
+
+### When to Document a Pattern
+
+**DO document if:**
+- It requires multiple PAPI calls to achieve a common goal
+- The method parameters are non-obvious (like `[{}]` for empty options)
+- It solves a task that agents will commonly need
+- The discovery process took trial and error
+
+**DON'T document if:**
+- It's a one-off edge case unlikely to be reused
+- The method is obvious from its name and takes standard parameters
+- It's already covered by existing documentation
+
+### How to Add a Pattern
+
+1. Add a new subsection under "Common Patterns"
+2. Include a brief description of what it achieves
+3. Provide a working bash example with comments
+4. Note any prerequisites (e.g., "requires Paratext project, not lexical resources")
+5. Use the sleep pattern for reliable responses

--- a/.claude/skills/pr-creator/SKILL.md
+++ b/.claude/skills/pr-creator/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: pr-creator
+description: "[paranext-core ONLY] Create PRs with AI transparency, code steward integration, and team workflow compliance. Handles branch naming, template change detection, and Reviewable integration. NOT for use in PT9/legacy Paratext codebases."
+allowed-tools: Bash, Read, Grep
+---
+
+# PR Creator Skill
+
+Create pull requests for Platform.Bible following team standards.
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| Check branch | `git rev-parse --abbrev-ref HEAD` |
+| Extract JIRA ID | `git rev-parse --abbrev-ref HEAD \| grep -oE '^[a-z]+-[0-9]+' \| tr 'a-z' 'A-Z'` |
+| Check for template changes | `git log main..HEAD --oneline \| grep -i template` |
+| Push branch | `git push -u origin $(git rev-parse --abbrev-ref HEAD)` |
+| Create PR | `gh pr create --title "..." --body "..."` |
+| View PR | `gh pr view --web` |
+
+## Pre-Flight Checks
+
+Before creating a PR, verify:
+
+```bash
+# 1. Not on main branch
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" = "main" ]; then
+  echo "ERROR: Cannot create PR from main branch"
+  exit 1
+fi
+
+# 2. Branch follows naming convention (lowercase, JIRA prefix)
+if ! echo "$BRANCH" | grep -qE '^[a-z]+-[0-9]+-'; then
+  echo "WARNING: Branch name should follow pattern: pt-1234-description"
+fi
+
+# 3. Branch is pushed
+git push -u origin "$BRANCH" 2>/dev/null || true
+
+# 4. Tests pass (optional but recommended)
+npm test
+dotnet test c-sharp-tests/
+```
+
+## Automated Analysis
+
+### Extract JIRA ID
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+JIRA_ID=$(echo "$BRANCH" | grep -oE '^[a-z]+-[0-9]+' | tr 'a-z' 'A-Z')
+
+if [ -n "$JIRA_ID" ]; then
+  echo "JIRA: $JIRA_ID"
+  echo "Link: https://paratext.atlassian.net/browse/$JIRA_ID"
+else
+  echo "No JIRA ID found in branch name"
+fi
+```
+
+### Detect Template Changes
+
+Template updates must NOT be squash-merged. Check before creating PR:
+
+```bash
+# Check git log for template merges
+if git log main..HEAD --oneline | grep -qiE 'template|allow-unrelated-histories'; then
+  echo "WARNING: Template changes detected!"
+  echo "Use 'Create a merge commit' - NOT 'Squash and merge'"
+fi
+
+# Check for template-related files
+if git diff main...HEAD --name-only | grep -qiE 'template'; then
+  echo "WARNING: Template files changed!"
+fi
+```
+
+### Identify Code Stewards
+
+```bash
+# Get changed files and match against CODEOWNERS
+CHANGED=$(git diff main...HEAD --name-only)
+
+echo "Changed files:"
+echo "$CHANGED"
+
+echo ""
+echo "Check .github/CODEOWNERS for required reviewers"
+```
+
+Key code steward areas:
+- `lib/platform-bible-react/*` - @jolierabideau @rolfheij-sil @tjcouch-sil @lyonsil @irahopkinson
+- `lib/platform-bible-utils/*` - @rolfheij-sil @tjcouch-sil @lyonsil @jolierabideau @irahopkinson
+- Most other paths - @tjcouch-sil @lyonsil @irahopkinson
+
+## PR Templates
+
+### Minimal Template (Simple Changes)
+
+```bash
+gh pr create \
+  --title "PT-1234: Brief description" \
+  --body "$(cat <<'EOF'
+## Summary
+
+[Brief description of what this PR does]
+
+## Changes
+
+- [Change 1]
+- [Change 2]
+
+## Testing
+
+- [ ] Tests pass
+- [ ] Manual verification done
+EOF
+)"
+```
+
+### Full Template (AI-Generated or Complex Changes)
+
+```bash
+gh pr create \
+  --title "PT-1234: Brief description" \
+  --body "$(cat <<'EOF'
+## Summary
+
+[Description of what this PR does and why]
+
+## Changes
+
+- [Change 1]
+- [Change 2]
+
+## AI Involvement
+
+[Disclose AI assistance per the repository's authorship-attribution rule
+(see "Git & PR Conventions" in the project CLAUDE.md). Briefly describe what
+AI contributed and how it was reviewed.]
+
+## Testing
+
+- [ ] Tests pass
+- [ ] Manual verification done
+
+## Risk Level
+
+[Low|Medium|High] - [Brief justification]
+EOF
+)"
+```
+
+### Template Update PR (Auto-Add Warning)
+
+When template changes are detected, include this warning banner at the top:
+
+```bash
+gh pr create \
+  --title "PT-1234: Update from template" \
+  --body "$(cat <<'EOF'
+> **Warning**
+> **TEMPLATE UPDATE - DO NOT SQUASH MERGE**
+>
+> This PR contains template changes. Use "Create a merge commit" instead of "Squash and merge" to preserve git history.
+
+## Summary
+
+Merge latest changes from paranext-extension-template.
+
+## Changes
+
+- [Template updates]
+
+## Testing
+
+- [ ] Build succeeds
+- [ ] Existing functionality unaffected
+EOF
+)"
+```
+
+## AI Transparency
+
+When AI was involved in creating code, disclose it according to the
+repository's authorship-attribution rule (see the "Git & PR Conventions"
+section of the project `CLAUDE.md`). That rule is the source of truth for
+how AI assistance is credited in commits and PR descriptions — follow its
+format rather than inventing one here. The human developer remains the
+author; AI is attributed as a generator/assistant, not an author.
+
+If the repository's rule does not specify a format for a given situation,
+add a brief, honest note in the PR body describing what AI contributed
+(for example, which files or portions were AI-generated and how they were
+reviewed). The "Full Template" above leaves room for such a note.
+
+## Merge Strategy
+
+### Default: Squash and Merge
+
+Use "Squash and merge" in GitHub UI for most PRs.
+
+### Exception: Template Updates
+
+**NEVER squash-merge template updates!**
+
+If your PR includes:
+- Creating new extensions
+- Merging from paranext-extension-template
+- Merging from paranext-multi-extension-template
+
+You MUST use "Create a merge commit" to preserve git history. Squash-merging will cause future template updates to fail.
+
+## Post-Creation Steps
+
+After creating the PR:
+
+1. **Post in Discord `#reviews` channel**
+   ```
+   [New PR] PT-1234: Brief description
+   https://github.com/paranext/paranext-core/pull/XXX
+   ```
+
+2. **Monitor Reviewable**
+   - Badge auto-added to PR
+   - Use Reviewable (not GitHub) for detailed reviews
+
+3. **Watch for reactions**
+   - `:code_review:` = partial review in progress
+   - `:white_check_mark:` = complete review done
+
+4. **After approval**
+   - Merge using "Squash and merge" (or merge commit for templates)
+   - Delete branch if prompted
+
+## Troubleshooting
+
+### "Branch name doesn't match convention"
+
+```bash
+# Rename branch
+git branch -m old-name pt-1234-new-name
+git push origin :old-name
+git push -u origin pt-1234-new-name
+```
+
+### "gh: command not found"
+
+```bash
+# Install GitHub CLI (macOS)
+brew install gh
+gh auth login
+```
+
+### "Cannot create PR - not pushed"
+
+```bash
+git push -u origin $(git rev-parse --abbrev-ref HEAD)
+```
+
+### "Need to update PR after creation"
+
+```bash
+# Update title or body
+gh pr edit --title "New title"
+gh pr edit --body "New body"
+
+# Add more commits
+git add .
+git commit -m "Address review feedback"
+git push
+```
+
+## See Also
+
+- [Git-Guide.md](../../../.context/standards/Git-Guide.md) - Branch naming, merge practices
+- [Code-Review-Guide.md](../../../.context/standards/Code-Review-Guide.md) - Review workflow
+- [test-runner skill](../test-runner/SKILL.md) - Run tests before PR

--- a/.claude/skills/test-runner/SKILL.md
+++ b/.claude/skills/test-runner/SKILL.md
@@ -1,0 +1,376 @@
+---
+name: test-runner
+description: "[paranext-core ONLY] Run TypeScript and C# tests with structured output, filtering, and coverage. Use when running unit tests, integration tests, or checking test coverage for Platform.Bible."
+allowed-tools: Bash, Read
+---
+
+# Test Runner Skill
+
+Run and analyze tests for Platform.Bible (paranext-core) with structured output.
+
+## Quick Reference
+
+| Action | Command |
+|--------|---------|
+| All TypeScript tests | `npm test` |
+| All C# tests | `dotnet test c-sharp-tests/` |
+| Specific TS test | `npm test -- path/to/test.ts` |
+| C# by category | `dotnet test --filter "Category=Contract"` |
+| Watch mode | `npm test -- --watch` |
+| E2E (CDP, running app) | `npx playwright test --config=e2e-tests/playwright-cdp.config.ts` |
+| E2E (standalone) | `npx playwright test --config=e2e-tests/playwright.config.ts --project=development` |
+
+## TypeScript Tests (Vitest)
+
+### Run All Tests
+
+```bash
+npm test
+```
+
+### Run Specific Test File
+
+```bash
+npm test -- path/to/test.test.ts
+```
+
+### Run Tests Matching Pattern
+
+```bash
+# By file name pattern
+npm test -- --testNamePattern="ComponentName"
+
+# By file path pattern
+npm test -- src/renderer/components/
+```
+
+### Watch Mode
+
+Automatically re-run tests on file changes:
+
+```bash
+npm test -- --watch
+```
+
+### With Coverage
+
+```bash
+npm test -- --coverage
+```
+
+### Verbose Output
+
+```bash
+npm test -- --reporter=verbose
+```
+
+## C# Tests (NUnit)
+
+### Run All Tests
+
+```bash
+dotnet test c-sharp-tests/
+```
+
+### Filter by Category
+
+See `categories.md` for the full set. The most common are:
+
+| Category | Purpose |
+|----------|---------|
+| `Contract` | API/behavior contract tests (most of the suite) |
+| `Integration` | Integration tests |
+| `Acceptance` | Feature-level acceptance tests |
+| `GoldenMaster` | Golden-master comparison tests |
+
+```bash
+# Run only contract tests
+dotnet test --filter "Category=Contract"
+
+# Run multiple categories
+dotnet test --filter "Category=Contract|Category=Integration"
+```
+
+### Filter by Test Name
+
+```bash
+# By test method name
+dotnet test --filter "FullyQualifiedName~CreateProject"
+
+# By class name
+dotnet test --filter "ClassName~ProjectDataProviderTests"
+```
+
+### Verbose Output
+
+```bash
+dotnet test --logger:"console;verbosity=detailed"
+```
+
+### With Coverage
+
+```bash
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+## Playwright E2E Tests
+
+### Two Execution Modes
+
+| Mode | Config | When to Use |
+|------|--------|-------------|
+| **CDP (connect to running app)** | `e2e-tests/playwright-cdp.config.ts` | During development, app already running |
+| **Standalone (launches own Electron)** | `e2e-tests/playwright.config.ts` | CI, standalone testing |
+
+### CDP Mode (Recommended during development)
+
+```bash
+# Run all E2E tests against running app
+npx playwright test --config=e2e-tests/playwright-cdp.config.ts
+
+# Run specific test file
+npx playwright test e2e-tests/tests/{feature}/{feature}.spec.ts --config=e2e-tests/playwright-cdp.config.ts
+```
+
+Prerequisite: App running with `--remote-debugging-port=9223` (the `app-runner` skill enables this).
+
+### Standalone Mode (CI)
+
+```bash
+npm stop  # Port 8876 must be free
+npx playwright test --config=e2e-tests/playwright.config.ts --project=development
+```
+
+### Debug Failing E2E Tests
+
+```bash
+# View HTML report
+npx playwright show-report e2e-tests/playwright-report
+
+# Check failure artifacts
+ls e2e-tests/test-results/
+```
+
+## Debugging Failed Tests
+
+### Get More Context
+
+```bash
+# TypeScript - show full diff
+npm test -- --reporter=verbose
+
+# C# - detailed output
+dotnet test --logger:"console;verbosity=detailed" -v n
+```
+
+### Run Single Failing Test
+
+```bash
+# TypeScript
+npm test -- --testNamePattern="exact test name"
+
+# C#
+dotnet test --filter "FullyQualifiedName=Namespace.Class.MethodName"
+```
+
+## TDD Workflow
+
+### RED Phase (Test Writer)
+
+1. Write failing tests:
+   ```bash
+   # Verify tests fail (expected)
+   npm test -- path/to/new.test.ts
+   # Should see failures
+   ```
+
+### GREEN Phase (Implementer)
+
+1. Implement minimum code
+2. Run tests:
+   ```bash
+   npm test -- path/to/new.test.ts
+   # Should pass
+   ```
+
+### REFACTOR Phase
+
+1. Make small change
+2. Verify tests still pass:
+   ```bash
+   npm test
+   dotnet test c-sharp-tests/
+   ```
+3. Repeat
+
+## Mutation Testing
+
+Mutation testing verifies test quality by introducing small changes (mutations) to code and checking if tests catch them.
+
+### Prerequisites
+
+Mutation testing requires Stryker to be installed:
+
+```bash
+# TypeScript - check if configured
+ls stryker.config.json
+
+# C# - check if tool installed
+dotnet tool list | grep stryker
+```
+
+### Running Mutation Tests
+
+**TypeScript (Stryker-JS):**
+
+```bash
+# Run for entire project
+npx stryker run
+
+# Run for specific feature
+npx stryker run --mutate "src/**/{feature}*.ts"
+```
+
+**C# (Stryker.NET):**
+
+The C# tests are a single project: `c-sharp-tests/c-sharp-tests.csproj` (there is no
+per-feature `.csproj`).
+
+```bash
+# Run from the c-sharp-tests directory (it has one test project)
+cd c-sharp-tests && dotnet stryker
+
+# Run with HTML report
+cd c-sharp-tests && dotnet stryker --reporters "['html', 'progress']"
+```
+
+### Interpreting Mutation Results
+
+| Status | Meaning | Action |
+|--------|---------|--------|
+| **Killed** | Test caught the mutation | Good - test is effective |
+| **Survived** | Mutation wasn't detected | Weak test - add better assertion |
+| **No Coverage** | Code not exercised by tests | Add test coverage |
+| **Timeout** | Infinite loop suspected | Investigate the mutation |
+| **Runtime Error** | Mutation caused crash | Usually okay, mutation is lethal |
+
+### Mutation Score
+
+```
+Mutation Score = (Killed + Timeout) / Total Mutants × 100
+
+Target: >= 70% for critical logic
+```
+
+### Common Surviving Mutants
+
+| Mutation Type | Example | How to Kill |
+|---------------|---------|-------------|
+| Boundary | `<` → `<=` | Test boundary values |
+| Arithmetic | `+` → `-` | Assert on calculation results |
+| Boolean | `true` → `false` | Assert on conditionals |
+| Return value | `return x` → `return null` | Assert return values aren't null |
+
+## Continuous Testing (Background Monitoring)
+
+For TDD workflows, run tests continuously in the background.
+
+### Watch Mode
+
+**TypeScript:**
+```bash
+# Watch all tests
+npm test -- --watch
+
+# Watch specific directory
+npm test -- --watch extensions/src/{feature}/
+```
+
+**C# (dotnet watch):**
+```bash
+# Watch tests for changes
+dotnet watch test --project c-sharp-tests/
+
+# Watch specific test filter
+dotnet watch test --project c-sharp-tests/ -- --filter "{Feature}"
+```
+
+### Monitoring Tips
+
+1. **Keep watch running in separate terminal** during implementation
+2. **Check output after each edit** - don't wait to batch up changes
+3. **If test fails unexpectedly** - stop, investigate, fix before continuing
+
+## Coverage Thresholds
+
+For features with backend logic, verify coverage meets thresholds.
+
+### TypeScript Coverage
+
+```bash
+npm test -- --coverage
+```
+
+Check output for:
+- Line coverage: >= 90%
+- Branch coverage: >= 80%
+
+### C# Coverage
+
+```bash
+dotnet test --collect:"XPlat Code Coverage"
+```
+
+### Coverage Report Locations
+
+| Platform | Report Location |
+|----------|-----------------|
+| TypeScript | `coverage/` directory (HTML) |
+| C# | `coverage.*` files written under `c-sharp-tests/` |
+
+## Pre-Commit Validation
+
+```bash
+npm run typecheck && npm run lint && npm test && dotnet test c-sharp-tests/
+```
+
+## Test File Locations
+
+### TypeScript Tests
+
+```
+paranext-core/
+├── src/
+│   ├── main/__tests__/           # Main process tests
+│   ├── renderer/__tests__/       # Renderer tests
+│   ├── shared/__tests__/         # Shared code tests
+│   └── extension-host/__tests__/ # Extension host tests
+├── extensions/
+│   └── src/{ext}/
+│       └── __tests__/            # Extension tests
+└── lib/
+    └── {package}/
+        └── __tests__/            # Library tests
+```
+
+### C# Tests
+
+Feature tests live in feature-named subdirectories (no `Tests` suffix on the dir
+name). Shared helpers and test doubles live at the `c-sharp-tests/` root — there is
+no `TestHelpers/` directory.
+
+```
+paranext-core/
+└── c-sharp-tests/
+    ├── PapiTestBase.cs      # shared abstract test base (at root)
+    ├── FixtureSetup.cs      # shared fixture setup (at root)
+    ├── Dummy*.cs            # test doubles, e.g. DummyScrText.cs (at root)
+    ├── Checks/
+    ├── Projects/
+    ├── Services/
+    ├── ParatextUtils/
+    ├── JsonUtils/
+    ├── NetworkObjects/
+    ├── ManageBooks/
+    └── Checklists/
+```

--- a/.claude/skills/test-runner/categories.md
+++ b/.claude/skills/test-runner/categories.md
@@ -1,0 +1,158 @@
+# Test Categories Reference
+
+## C# Test Categories
+
+The C# tests in `c-sharp-tests/` annotate tests with `[Category("...")]`. Use these
+categories with `dotnet test --filter "Category=..."`.
+
+These are the categories that actually exist in the codebase (grep
+`\[Category("...")\]` in `c-sharp-tests/` to confirm). The most heavily used by far is
+`Contract`.
+
+| Category | Purpose |
+|----------|---------|
+| `Contract` | API/behavior contract verification — the bulk of the suite |
+| `Acceptance` | End-to-end acceptance of a feature's behavior |
+| `GoldenMaster` | Golden-master comparisons against recorded expected output |
+| `Integration` | Tests exercising multiple components together |
+| `Critical` | Critical-path tests that must not regress |
+| `Invariant` | Properties/invariants that must always hold |
+| `Regression` | Tests pinned to specific past bugs |
+| `EdgeCase` | Boundary and edge-case behavior |
+| `Infrastructure` | Test/infrastructure plumbing |
+| `ErrorPath` | Error-handling and failure paths |
+| `DiskVerification` | Verifies on-disk results (e.g. files written) |
+
+There is no `Unit`, `Fast`, `Slow`, `VeryLong`, `PAPI`, `Network`, `Scripture`,
+`Project`, or `Extension` category — do not filter on those.
+
+## Category Usage Examples
+
+### Single Category
+
+```bash
+# Run only contract tests
+dotnet test --filter "Category=Contract"
+
+# Run only golden-master tests
+dotnet test --filter "Category=GoldenMaster"
+```
+
+### Multiple Categories (OR)
+
+```bash
+# Run contract OR integration tests
+dotnet test --filter "Category=Contract|Category=Integration"
+```
+
+### Multiple Categories (AND)
+
+```bash
+# Run tests that are both Acceptance AND Critical
+dotnet test --filter "Category=Acceptance&Category=Critical"
+```
+
+### Exclude Category
+
+```bash
+# Run all except golden-master tests
+dotnet test --filter "Category!=GoldenMaster"
+
+# Run all except integration tests
+dotnet test --filter "Category!=Integration"
+```
+
+### Combine with Name Filter
+
+```bash
+# Contract tests for the Projects feature
+dotnet test --filter "Category=Contract&FullyQualifiedName~Project"
+```
+
+## TypeScript Test Organization
+
+TypeScript tests use describe blocks for organization:
+
+```typescript
+describe('FeatureName', () => {
+  describe('Unit', () => {
+    it('tests isolated behavior', () => {});
+  });
+
+  describe('Integration', () => {
+    it('tests component interaction', () => {});
+  });
+
+  describe('Snapshot', () => {
+    it('matches visual snapshot', () => {});
+  });
+});
+```
+
+### Filtering TypeScript Tests
+
+```bash
+# By describe block name
+npm test -- --testNamePattern="Unit"
+
+# By test name
+npm test -- --testNamePattern="tests isolated behavior"
+
+# By file pattern
+npm test -- src/**/*.unit.test.ts
+```
+
+## TDD Phase Categories
+
+### RED Phase (Test Writer)
+
+Write tests with the categories that match what they verify. For most new behavior,
+that is `Contract`:
+
+```csharp
+[Test]
+[Category("Contract")]
+public void Method_Condition_ExpectedBehavior() { }
+```
+
+### GREEN Phase (Implementer)
+
+Run in this order:
+
+```bash
+# 1. Contract tests (the bulk of the suite — verify API/behavior compliance)
+dotnet test --filter "Category=Contract"
+
+# 2. Integration tests (component interactions)
+dotnet test --filter "Category=Integration"
+
+# 3. Acceptance tests (feature-level behavior)
+dotnet test --filter "Category=Acceptance"
+
+# 4. All tests
+dotnet test c-sharp-tests/c-sharp-tests.csproj
+```
+
+### REFACTOR Phase
+
+Run all tests frequently:
+
+```bash
+# Quick check during refactor
+dotnet test --filter "Category=Contract|Category=Integration"
+
+# Full validation before commit
+dotnet test c-sharp-tests/c-sharp-tests.csproj
+```
+
+## CI Pipeline Order
+
+CI does not filter by category. The `Test` workflow
+(`.github/workflows/test.yml`) runs the entire C# suite in a single step:
+
+```bash
+dotnet test c-sharp-tests/c-sharp-tests.csproj
+```
+
+There is no per-category ordering in CI — every category runs together as one
+`dotnet test` invocation.

--- a/.claude/skills/test-runner/reference.md
+++ b/.claude/skills/test-runner/reference.md
@@ -1,0 +1,299 @@
+# Test Runner Reference
+
+This is a quick reference for common test patterns. For comprehensive testing standards, see [Testing-Guide.md](../../../.context/standards/Testing-Guide.md).
+
+## Testing Stack
+
+### TypeScript
+
+| Tool | Purpose |
+|------|---------|
+| Vitest | Test runner |
+| React Testing Library | Component testing |
+| jsdom | DOM environment |
+| @testing-library/user-event | User interaction simulation |
+
+### C#
+
+The C# test project (`c-sharp-tests/c-sharp-tests.csproj`) uses NUnit only. There is
+no xUnit, Moq, FluentAssertions, or FsCheck. Test doubles are the project's own
+`Dummy*` classes; assertions use NUnit's `Assert.That(...)`.
+
+| Tool | Purpose |
+|------|---------|
+| NUnit 4.0.1 | Test framework (`Assert.That`, `[Test]`, `[TestFixture]`, `[Category]`) |
+| NUnit3TestAdapter | Test runner integration for `dotnet test` |
+| NUnit.Analyzers | NUnit-specific Roslyn analyzers |
+| Microsoft.NET.Test.Sdk | Test host |
+| SIL.TestUtilities | SIL test helpers |
+| coverlet.collector | Code coverage |
+| ParatextData | Production dependency under test |
+
+## Test File Locations
+
+### TypeScript Tests
+
+```
+paranext-core/
+├── src/
+│   ├── main/__tests__/           # Main process tests
+│   ├── renderer/__tests__/       # Renderer tests
+│   ├── shared/__tests__/         # Shared code tests
+│   └── extension-host/__tests__/ # Extension host tests
+├── extensions/
+│   └── src/{ext}/
+│       └── __tests__/            # Extension tests
+│       └── tests/                # Alternative location
+└── lib/
+    └── {package}/
+        └── __tests__/            # Library tests
+```
+
+### C# Tests
+
+Feature tests live in feature-named subdirectories (no `Tests` suffix on the dir
+name; the suffix is on the test file/class names). Shared helpers and test doubles
+live at the `c-sharp-tests/` root — there is no `TestHelpers/` directory.
+
+```
+paranext-core/
+└── c-sharp-tests/
+    ├── PapiTestBase.cs            # shared abstract test base (at root)
+    ├── FixtureSetup.cs           # shared fixture setup (at root)
+    ├── DummyScrText.cs           # test doubles (Dummy*.cs, at root)
+    ├── DummyPapiClient.cs
+    ├── Checks/                   # feature-named dirs, e.g.
+    │   └── {Feature}Tests.cs
+    ├── Projects/
+    ├── Services/
+    ├── ParatextUtils/
+    ├── JsonUtils/
+    ├── NetworkObjects/
+    ├── ManageBooks/
+    └── Checklists/
+```
+
+## Test Patterns
+
+### Unit Test Pattern
+
+```typescript
+// TypeScript
+describe('ComponentName', () => {
+  it('does something specific', () => {
+    // Arrange
+    const props = { value: 'test' };
+
+    // Act
+    render(<Component {...props} />);
+
+    // Assert
+    expect(screen.getByText('test')).toBeInTheDocument();
+  });
+});
+```
+
+```csharp
+// C#
+[TestFixture]
+public class FeatureTests
+{
+    [Test]
+    [Category("Unit")]
+    public void Method_Condition_ExpectedResult()
+    {
+        // Arrange
+        var sut = new Feature();
+
+        // Act
+        var result = sut.Method();
+
+        // Assert
+        Assert.That(result, Is.EqualTo(expected));
+    }
+}
+```
+
+### Invariant / Round-Trip Test Pattern
+
+The C# suite has no property-based framework (no FsCheck). Invariants and round-trip
+properties are expressed as ordinary NUnit tests, often over `[TestCase]` data and
+tagged `[Category("Invariant")]`:
+
+```csharp
+[TestFixture]
+public class FeatureInvariantTests
+{
+    [TestCase("")]
+    [TestCase("plain text")]
+    [TestCase("text with \"quotes\" and \\backslashes\\")]
+    [Category("Invariant")]
+    public void RoundTrip_PreservesData(string input)
+    {
+        var encoded = Encode(input);
+        var decoded = Decode(encoded);
+
+        Assert.That(decoded, Is.EqualTo(input));
+    }
+}
+```
+
+### Snapshot Test Pattern
+
+```typescript
+describe('Component Snapshots', () => {
+  it('matches snapshot', () => {
+    const { container } = render(<Component />);
+    expect(container).toMatchSnapshot();
+  });
+});
+```
+
+## Test Configuration
+
+### Vitest Config
+
+Located in `vitest.config.ts` or `vite.config.ts`:
+
+```typescript
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'html'],
+    },
+  },
+});
+```
+
+### NUnit Config
+
+Test settings in `.runsettings` or project file:
+
+```xml
+<PropertyGroup>
+  <IsTestProject>true</IsTestProject>
+  <GenerateProgramFile>false</GenerateProgramFile>
+</PropertyGroup>
+```
+
+## Mocking Patterns
+
+### TypeScript (Vitest)
+
+```typescript
+// Mock a module
+vi.mock('@shared/services/logger.service', () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock PAPI
+vi.mock('papi-shared-types', () => ({
+  papi: {
+    commands: {
+      sendCommand: vi.fn(),
+    },
+  },
+}));
+```
+
+### C# (Dummy test doubles)
+
+The C# tests do not use Moq. Instead they use hand-written `Dummy*` test doubles that
+live at the `c-sharp-tests/` root (e.g. `DummyScrText`, `DummyPapiClient`,
+`DummyLocalParatextProjects`, `DummyParatextProjectDataProvider`). Tests derived from
+`PapiTestBase` get `Client` (a `DummyPapiClient`) and `ParatextProjects` (a
+`DummyLocalParatextProjects`) for free.
+
+```csharp
+// A dummy project (created via the PapiTestBase helper)
+DummyScrText scrText = CreateDummyProject();
+
+// Register it so the rest of the system can find it
+ProjectDetails details = CreateProjectDetails(scrText);
+ParatextProjects.FakeAddProject(details, scrText);
+```
+
+## Test Base Classes
+
+### C# Test Base
+
+Most C# tests derive from `PapiTestBase` (`c-sharp-tests/PapiTestBase.cs`, namespace
+`TestParanextDataProvider`). It is an `internal abstract` `[TestFixture]` that wires up
+encoding, sets up/tears down a `DummyPapiClient` (`Client`) and
+`DummyLocalParatextProjects` (`ParatextProjects`), and exposes `protected static`
+helpers for building and verifying test data.
+
+```csharp
+namespace TestParanextDataProvider
+{
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    internal abstract class PapiTestBase
+    {
+        protected DummyPapiClient Client { get; }
+        protected DummyLocalParatextProjects ParatextProjects { get; }
+
+        // Helper methods to create test data
+        protected static DummyScrText CreateDummyProject();
+        protected static ProjectDetails CreateProjectDetails(ScrText scrText);
+
+        // Helper methods to verify data
+        protected static void VerifyUsfmSame(string usfm1, string usfm2, ScrText scrText, int bookNum);
+        protected static void VerifyUsxSame(string usx1, string usx2);
+    }
+}
+```
+
+Example derived fixture:
+
+```csharp
+[TestFixture]
+[Category("Contract")]
+internal class FeatureTests : PapiTestBase
+{
+    [Test]
+    public void Method_Condition_ExpectedResult()
+    {
+        DummyScrText scrText = CreateDummyProject();
+        // ... exercise behavior, then verify ...
+        Assert.That(result, Is.EqualTo(expected));
+    }
+}
+```
+
+## Common Test Commands
+
+### Full Test Suite
+
+```bash
+# TypeScript
+npm test
+
+# C#
+dotnet test c-sharp-tests/
+
+# Both
+npm test && dotnet test c-sharp-tests/
+```
+
+### Pre-Commit Validation
+
+```bash
+# Run before committing
+npm run typecheck && npm run lint && npm test && dotnet test c-sharp-tests/
+```
+
+### CI-Style Run
+
+```bash
+# Simulate CI environment
+CI=true npm test -- --coverage
+dotnet test c-sharp-tests/ --configuration Release
+```

--- a/.claude/skills/visual-verification/SKILL.md
+++ b/.claude/skills/visual-verification/SKILL.md
@@ -1,0 +1,650 @@
+---
+name: visual-verification
+description: "[paranext-core ONLY] Visual verification and UI interaction for Platform.Bible using Playwright over CDP. Use to take screenshots, click buttons, fill inputs, inspect DOM, navigate menus, and verify UI. Requires app started with remote debugging enabled. NOT for use in PT9/legacy Paratext codebases."
+---
+
+# Visual Verification Skill
+
+Visual verification and **full UI interaction** for Platform.Bible using Playwright connected via CDP (Chrome DevTools Protocol) to the Electron renderer.
+
+## Architecture Overview
+
+This skill provides two levels of access:
+
+1. **Playwright Interaction Server (`pw-server.mjs`)** — Full UI interaction: click, fill, type, press, scroll, screenshot, eval, frame switching. Connects via CDP port 9223 using Playwright's `connectOverCDP`. **Preferred for all interaction.**
+2. **PAPI WebSocket (port 8876)** — Send commands via `papi-client` skill. **For triggering app-level actions (open dialogs, settings, etc.).**
+
+## Prerequisites
+
+### Remote Debugging Enabled
+
+**REQUIRED**: Platform.Bible must be started with remote debugging enabled:
+
+```bash
+./.erb/scripts/refresh.sh
+```
+
+This script stops, builds, and starts Platform.Bible with CDP enabled on port 9223.
+
+## Pre-Flight Check (MANDATORY)
+
+**Before ANY visual verification work, run this check:**
+
+```bash
+# Check if Platform.Bible is running with debugging enabled
+RENDERER=$(curl -s -m 2 http://localhost:1212 > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+CDP=$(curl -s -m 2 http://localhost:9223/json > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+WEBSOCKET=$(curl -s -m 2 http://localhost:8876 > /dev/null 2>&1 && echo "UP" || echo "DOWN")
+
+echo "Renderer (1212): $RENDERER"
+echo "CDP Debug (9223): $CDP"
+echo "WebSocket (8876): $WEBSOCKET"
+
+if [ "$RENDERER" = "UP" ] && [ "$CDP" = "UP" ] && [ "$WEBSOCKET" = "UP" ]; then
+  echo "Platform.Bible is running with debugging - ready for visual verification"
+elif [ "$RENDERER" = "UP" ] && [ "$CDP" = "DOWN" ]; then
+  echo "Platform.Bible is running but debugging NOT enabled"
+  echo "Restart with: ./.erb/scripts/refresh.sh"
+else
+  echo "Platform.Bible is NOT running - cannot proceed"
+fi
+```
+
+### If App is NOT Running or CDP is DOWN
+
+**Use the `app-runner` skill to start the app autonomously.** Claude has full authority over app lifecycle — no user intervention is required.
+
+```bash
+# Use app-runner skill to start Platform.Bible with CDP enabled
+# The app-runner skill automatically passes MAIN_ARGS="--remote-debugging-port=9223"
+# and waits for all three ports (1212, 8876, 9223) to be ready
+```
+
+After `app-runner` completes, verify CDP is available:
+
+```bash
+# Verify app is ready with debugging
+if curl -s -m 2 http://localhost:9223/json > /dev/null 2>&1; then
+  echo "Verified: Platform.Bible is ready for visual verification"
+else
+  echo "FATAL: CDP still unavailable after app-runner. BLOCKED."
+  echo "This is a stop condition — cannot proceed without CDP."
+fi
+```
+
+**If CDP is still unavailable after `app-runner`**: This is a **BLOCKING** condition. Do NOT skip visual verification. Set status to BLOCKED and escalate.
+
+## Quick Reference
+
+| Action | Method |
+|--------|--------|
+| **Click a button** | `pw-interact.sh '{"cmd":"click","role":"button","name":"Save"}'` |
+| **Fill an input** | `pw-interact.sh '{"cmd":"fill","selector":"input","text":"Genesis"}'` |
+| **Take screenshot** | `pw-interact.sh '{"cmd":"screenshot","output":"/tmp/ss.png"}'` |
+| **Check visibility** | `pw-interact.sh '{"cmd":"visible","role":"dialog"}'` |
+| **Quick verify** | `quick-verify.sh "[selector]" <output-dir> [filename]` |
+| Execute JavaScript | `pw-interact.sh '{"cmd":"eval","code":"document.title"}'` |
+| Send PAPI command | Use `papi-client` skill |
+| Read app logs | Use `log-inspector` skill |
+
+All scripts are in `.claude/skills/visual-verification/scripts/`.
+
+## UI Interaction via Playwright (`pw-server.mjs`)
+
+The Playwright interaction server connects to the running app via CDP and provides full UI interaction — clicking, typing, scrolling, waiting for elements, and screenshotting.
+
+### Single Command
+
+```bash
+# Single command (connects, runs, disconnects)
+.claude/skills/visual-verification/scripts/pw-interact.sh '{"cmd":"click","role":"menuitem","name":"Help"}'
+```
+
+### Multi-Command Sequence (Recommended)
+
+For sequences of actions, pipe multiple commands to `pw-server.mjs`. This uses a **single connection** and is much faster.
+
+```bash
+echo '{"cmd":"click","role":"menuitem","name":"Help"}
+{"cmd":"wait-ms","ms":500}
+{"cmd":"click","role":"menuitem","name":"About Platform.Bible"}
+{"cmd":"wait","selector":".dock-tab","hasText":"About","timeout":10000}
+{"cmd":"screenshot","output":"/tmp/about-dialog.png"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+```
+
+Each command produces one JSON line on stdout. Stderr has server log messages.
+
+### Command Reference
+
+#### Navigation and Clicks
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `click` | Click by role/selector/text | `{"cmd":"click","role":"button","name":"Save"}` |
+| `dblclick` | Double-click | `{"cmd":"dblclick","selector":".item"}` |
+| `hover` | Hover over element | `{"cmd":"hover","role":"menuitem","name":"File"}` |
+
+#### Text Input
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `fill` | Set input value (clears first) | `{"cmd":"fill","selector":"input","text":"Gen"}` |
+| `type` | Type char-by-char (triggers events) | `{"cmd":"type","selector":"input","text":"Gen","delay":50}` |
+| `press` | Press keyboard key | `{"cmd":"press","key":"Enter"}` |
+
+#### Waiting
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `wait` | Wait for element state | `{"cmd":"wait","role":"dialog","timeout":10000}` |
+| `wait-ms` | Wait fixed time | `{"cmd":"wait-ms","ms":1000}` |
+
+#### Reading State
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `text` | Get element textContent | `{"cmd":"text","selector":".title"}` |
+| `inner-text` | Get element innerText | `{"cmd":"inner-text","selector":".content"}` |
+| `value` | Get input value | `{"cmd":"value","selector":"input"}` |
+| `visible` | Check if visible | `{"cmd":"visible","role":"button","name":"Save"}` |
+| `count` | Count matching elements | `{"cmd":"count","selector":".dock-tab"}` |
+| `attribute` | Get attribute value | `{"cmd":"attribute","selector":"#theme-styles","attr":"data-theme-id"}` |
+| `locators` | List matching elements (debug) | `{"cmd":"locators","role":"button","limit":10}` |
+
+#### Screenshots, Eval, and Accessibility
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `screenshot` | Capture screenshot | `{"cmd":"screenshot","output":"/tmp/ss.png"}` |
+| `eval` | Execute JS in renderer | `{"cmd":"eval","code":"document.title"}` |
+| `snapshot` | AX tree with interactive element refs | `{"cmd":"snapshot"}` |
+| `annotated-screenshot` | Screenshot with numbered badges | `{"cmd":"annotated-screenshot","output":"/tmp/ann.png"}` |
+| `click-ref` | Click element by ref from last snapshot | `{"cmd":"click-ref","ref":"@ref3"}` |
+
+#### Scrolling
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `scroll` | Scroll element | `{"cmd":"scroll","selector":".content","down":500}` |
+
+#### Frame Switching
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `frame` | Switch to iframe | `{"cmd":"frame","selector":"iframe","url":"extension"}` |
+| `frame-by-title` | Switch to iframe by title | `{"cmd":"frame-by-title","title":"Home"}` |
+| `frame-reset` | Return to main page | `{"cmd":"frame-reset"}` |
+| `frames` | List all frames (with titles) | `{"cmd":"frames"}` |
+
+#### Accessibility Snapshot & Annotated Screenshots
+
+These commands let agents discover and target UI elements without knowing selectors in advance.
+
+**`snapshot`** — Returns the accessibility tree filtered to interactive elements, each assigned an ephemeral `@refN` label.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `roles` | all interactive | Array of ARIA roles to include (e.g. `["button","textbox"]`) |
+| `limit` | 100 | Max elements to return |
+
+```bash
+echo '{"cmd":"snapshot"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+# → {"cmd":"snapshot","count":12,"elements":[{"ref":"@ref1","role":"button","name":"Save",...},...]
+```
+
+**`annotated-screenshot`** — Takes a screenshot with red numbered badges and outlines on interactive elements, plus a JSON mapping.
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `output` | `/tmp/pw-annotated.png` | Screenshot path |
+| `roles` | all interactive | Array of ARIA roles to include |
+| `limit` | 50 | Max elements to annotate |
+
+```bash
+echo '{"cmd":"annotated-screenshot","output":"/tmp/annotated.png"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+# → {"cmd":"annotated-screenshot","path":"/tmp/annotated.png","count":12,"annotations":[...]}
+```
+
+**`click-ref`** — Click an element by its `@refN` from the last `snapshot` or `annotated-screenshot`.
+
+```bash
+echo '{"cmd":"snapshot"}
+{"cmd":"click-ref","ref":"@ref3"}
+{"cmd":"screenshot","output":"/tmp/after-click.png"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+```
+
+**Typical workflow** — Discover elements, view annotated screenshot, then click:
+
+```bash
+echo '{"cmd":"annotated-screenshot","output":"/tmp/annotated.png"}
+{"cmd":"click-ref","ref":"@ref1"}
+{"cmd":"wait-ms","ms":500}
+{"cmd":"screenshot","output":"/tmp/after-click.png"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+```
+
+**Notes:**
+- Refs are ephemeral — they reset on each `snapshot` or `annotated-screenshot` call
+- Works in sub-frames: badge positions account for iframe offset
+- CDP session is created per-command (not long-lived) to avoid stale sessions
+- Hidden or zero-size elements are automatically skipped
+
+#### Other
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `select` | Select dropdown option | `{"cmd":"select","selector":"select","option":"English"}` |
+| `check` | Check checkbox | `{"cmd":"check","selector":"input[type=checkbox]"}` |
+| `uncheck` | Uncheck checkbox | `{"cmd":"uncheck","selector":"input[type=checkbox]"}` |
+| `status` | Server connection info | `{"cmd":"status"}` |
+| `quit` | Disconnect and exit | `{"cmd":"quit"}` |
+
+### Common Command and Parameter Pitfalls
+
+A few parameter names have intuitive-but-wrong alternatives:
+
+| Command | Param to use | Common wrong guess |
+|---------|--------------|--------------------|
+| `screenshot` | `output` | ~~`path`~~ |
+| `eval` | `code` | ~~`expression`~~ |
+
+**Don't confuse `wait` with `wait-ms`** — these are two different commands, not a parameter variant:
+
+- `wait` waits for an **element state** (takes a locator + optional `timeout`, `hasText`, etc.). Use it to block until an element appears, becomes visible, etc.
+- `wait-ms` is a **fixed-duration sleep** (takes `ms`). Use it as a deliberate pause.
+
+Writing `{"cmd":"wait","ms":500}` does not produce a 500 ms delay — the `ms` field is ignored and the command will fail or hang waiting for a locator that wasn't supplied.
+
+If a command silently no-ops or rejects with a generic error, double-check the command and parameter spelling against the tables above.
+
+### Locator Resolution
+
+Commands accept these locator parameters (in priority order):
+
+1. **`selector`** — CSS selector: `{"selector": ".dock-tab"}`. Can combine with `hasText` for filtering.
+2. **`role`** + optional **`name`** — ARIA role locator: `{"role": "button", "name": "Save"}`. Names are case-insensitive regex.
+3. **`text`** — Text content locator: `{"text": "About"}`. Case-insensitive regex.
+
+### Common Interaction Patterns
+
+```bash
+# Open Help → About dialog
+echo '{"cmd":"click","role":"menuitem","name":"Help"}
+{"cmd":"wait-ms","ms":300}
+{"cmd":"click","role":"menuitem","name":"About Platform.Bible"}
+{"cmd":"wait","selector":".dock-tab","hasText":"About"}
+{"cmd":"screenshot","output":"/tmp/about.png"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+
+# Search for a book in the book/chapter selector
+echo '{"cmd":"click","selector":"[aria-label=book-chapter-trigger]"}
+{"cmd":"wait-ms","ms":300}
+{"cmd":"fill","selector":"[data-radix-popper-content-wrapper] input","text":"Genesis"}
+{"cmd":"wait-ms","ms":500}
+{"cmd":"screenshot","output":"/tmp/book-search.png"}
+{"cmd":"press","key":"Escape"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+
+# Close the active tab (return to Home)
+echo '{"cmd":"click","selector":".dock-tab.dock-tab-active .dock-tab-close-btn"}
+{"cmd":"wait-ms","ms":500}
+{"cmd":"screenshot","output":"/tmp/after-close.png"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+
+# Check theme and toggle it
+echo '{"cmd":"attribute","selector":"#theme-styles","attr":"data-theme-id"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+```
+
+### Working with WebView Iframes
+
+All Platform.Bible web views render inside `about:srcdoc` iframes with unique `title` attributes (e.g., "Home", "wgPIDGIN (Editable)", "RH2 (Editable)", "Checks"). Since they all share the same URL (`about:srcdoc`), URL-based frame matching does not work.
+
+**Use `frame-by-title` to enter specific web view frames:**
+
+```bash
+echo '{"cmd":"frame-by-title","title":"Home"}
+{"cmd":"visible","selector":".title-bar"}
+{"cmd":"screenshot","output":"/tmp/home-webview.png"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+```
+
+**Important notes:**
+- `pw-interact.sh` creates a fresh connection per call, so **frame context is lost between calls**. Use `pw-server.mjs` pipelines for multi-step iframe interaction.
+- The first line of `pw-server.mjs` output is always `{"cmd":"connected",...}` — responses to your commands start at line 2.
+- Use `{"cmd":"frames"}` to discover available frames and their titles.
+
+#### Disambiguation
+
+- **Multiple matching elements**: Use `nth=N` (zero-indexed) in selector or `:has-text('text')` filter
+- **Multiple iframes**: Use `frame-by-title` (not `frame` with URL, since all webviews are `about:srcdoc`)
+
+#### Platform.Bible UI Layout
+
+Understanding which elements live in the **main frame** vs inside **webview iframes** is critical — selectors targeting the wrong frame will never match.
+
+**Main frame** (no frame switching needed):
+- **Tabs**: `.dock-tab:has-text("Home")`, `.dock-tab:has-text("Checks")`. New web-view tabs always appear here regardless of which iframe triggered them.
+- **BookChapter triggers**: `button[aria-label="book-chapter-trigger"]` — one on the main toolbar plus one per open webview. Use `>> nth=0` for toolbar, `>> nth=1` for the second editor's, etc.
+- **Dock-tab project menus**: `button[aria-label="Project"]` — small (~2 items: "Open Project Settings", "Settings"), one per open webview's tab. **NOT the editor's full hamburger** — see "Scripture Editor Hamburger Menu" below for that.
+- **Top-level menu bar**: Platform, Help menu items
+- **BookChapter popover**: `[data-radix-popper-content-wrapper]` (search input and results)
+- **Tab close buttons**: `.dock-tab-close-btn` div inside each `.dock-tab`. Close active tab: `.dock-tab.dock-tab-active .dock-tab-close-btn`. Close all non-Home tabs: `.dock-tab` filtered by `hasNotText: 'Home'`, then `.dock-tab-close-btn` inside.
+
+**Inside webview iframes** (must `frame-by-title` first):
+- **Editor content**: contenteditable div, verse markers (`span.verse[data-number="5"]`)
+- **Home project list**: target rows with `tr:has-text("ProjectName") button:has-text("Open")` — must `frame-by-title` `"Home"` first.
+- **Scripture editor hamburger menu**: `button[aria-label="Project"]` — the full editor hamburger (~15+ items: tools, navigation). See "Scripture Editor Hamburger Menu" below.
+- **Checks panel controls**: check type dropdown, results list
+- **Extension-specific UI elements**
+
+#### Scripture Editor Hamburger Menu
+
+PT10 tools that need a project context (markers-checklist, markers-inventory, checks-side-panel, etc.) are exposed from the **scripture editor's own hamburger menu**, not from the main app menu. The main app menu only carries project-agnostic items like "Open...", "Settings", "Exit".
+
+**Why**: when a command is fired from a web-view's topMenu, the platform passes the web-view's `webViewId` to the command handler, which reads the active `projectId` from the web-view definition. Main-menu commands get no web-view context.
+
+**Two distinct buttons named "Project"** — they look identical via the CDP accessibility tree:
+
+| Where it lives | What it opens | Use it for |
+|---|---|---|
+| Main frame (per dock-tab) | Small ~2-item dock-tab menu ("Open Project Settings", "Settings") | NOT for tool launching |
+| Inside the editor's iframe | Full topMenu hamburger (~15+ items: tools, navigation, etc.) | Tool launching, project actions |
+
+Always enter the editor's iframe first when you want the full hamburger.
+
+**Iframe titles**: a project opened in Edit mode has iframe title `"{PROJECT_NAME} (Editable)"`; Read-only is `"{PROJECT_NAME} (Read-only)"`. Use a broad `title*="${projectName}" i` plus `title*="Editable" i` (or relax to just the project name if you don't care which mode).
+
+**Menu items render inside the iframe.** Radix's `DropdownMenu` portals to `document.body`, which inside an iframe context means *the iframe's own body* — not the main page. So selectors after the click must also target the iframe.
+
+**Navigation pattern** (open project from Home → click hamburger → click menu item):
+
+```bash
+# Assumes the project is already open as a tab. If not, open it from Home first
+# (frame-by-title "Home" → click "Open" on the project row).
+echo '{"cmd":"frame-by-title","title":"wgPIDGIN (Editable)"}
+{"cmd":"click","selector":"button[aria-label=\"Project\"]"}
+{"cmd":"wait-ms","ms":300}
+{"cmd":"click","role":"menuitem","name":"Markers Checklist"}
+{"cmd":"frame-reset"}
+{"cmd":"wait","selector":".dock-tab","hasText":"Markers Checklist","timeout":10000}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+```
+
+**Debugging**: list the buttons or menu items inside the editor frame:
+
+```bash
+# Buttons inside the editor iframe
+echo '{"cmd":"frame-by-title","title":"wgPIDGIN (Editable)"}
+{"cmd":"eval","code":"Array.from(document.querySelectorAll(\"button\")).map(b => b.getAttribute(\"aria-label\") || b.textContent?.trim()?.slice(0,30))"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+
+# Menu items after opening the hamburger
+echo '{"cmd":"frame-by-title","title":"wgPIDGIN (Editable)"}
+{"cmd":"click","selector":"button[aria-label=\"Project\"]"}
+{"cmd":"wait-ms","ms":500}
+{"cmd":"eval","code":"Array.from(document.querySelectorAll(\"[role=menuitem]\")).map(e => e.textContent?.trim())"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+```
+
+**Note**: the newly opened tool's dock-tab is at the **main-page level** (not in any iframe). After clicking the menu item, `frame-reset` and target `.dock-tab` from the main page.
+
+#### Contenteditable Editors
+
+`fill` and `type` commands do NOT work on contenteditable editors (they are not `<input>` elements). Use this approach instead:
+
+1. Switch to the editor iframe with `frame-by-title`
+2. Click a verse marker (`span.verse[data-number="N"]`) to focus nearby
+3. Use `eval` with the Selection API to place the cursor precisely:
+   ```json
+   {"cmd":"eval","code":"const v = document.querySelector('span.verse[data-number=\"5\"]'); const t = v.nextSibling; const r = document.createRange(); r.setStart(t, 1); r.collapse(true); const s = window.getSelection(); s.removeAllRanges(); s.addRange(r);"}
+   ```
+4. Use individual `press` commands for each character:
+   ```json
+   {"cmd":"press","key":"H"}
+   {"cmd":"press","key":"e"}
+   {"cmd":"press","key":"l"}
+   {"cmd":"press","key":"l"}
+   {"cmd":"press","key":"o"}
+   ```
+
+#### WebView Interaction Example
+
+```bash
+# Navigate BookChapter to Genesis 3, then screenshot
+echo '{"cmd":"click","selector":"button[aria-label=\"book-chapter-trigger\"]"}
+{"cmd":"wait-ms","ms":300}
+{"cmd":"fill","selector":"[data-radix-popper-content-wrapper] input","text":"Genesis"}
+{"cmd":"wait-ms","ms":500}
+{"cmd":"click","selector":"[data-radix-popper-content-wrapper] >> text=/^3$/"}
+{"cmd":"wait-ms","ms":500}
+{"cmd":"screenshot","output":"/tmp/genesis-3.png"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+```
+
+**Note**: BookChapter triggers and the popover are in the **main frame** — do NOT switch into a webview iframe first.
+
+## Quick Verify Command
+
+Run all visual verification checks in one command:
+
+```bash
+# Default filename (verify-YYYYMMDD-HHMMSS.png):
+.claude/skills/visual-verification/scripts/quick-verify.sh '[data-testid="my-component"]' \
+  /tmp/component-evidence/
+
+# Custom filename:
+.claude/skills/visual-verification/scripts/quick-verify.sh '[data-testid="my-component"]' \
+  /tmp/component-evidence/ \
+  render-verification.png
+```
+
+**IMPORTANT**: The output directory argument is required. Optional third argument specifies the screenshot filename (defaults to `verify-YYYYMMDD-HHMMSS.png`).
+
+### Output
+
+- CDP status check
+- DOM element existence
+- Console error check
+- Screenshot capture
+
+### Exit Codes
+
+- `0` = PASS (all checks passed)
+- `1` = FAIL (one or more checks failed)
+
+## Workflow: Visual Verification
+
+### 1. Pre-Flight Check (FIRST!)
+
+**Always check before starting:**
+
+```bash
+curl -s -m 2 http://localhost:9223/json > /dev/null && echo "Ready" || echo "Not running with debugging - use app-runner skill"
+```
+
+If not running with debugging, use the `app-runner` skill to start the app.
+
+### 2. Interact with UI
+
+Use `pw-server.mjs` to interact with the app directly — click buttons, navigate menus, fill forms:
+
+```bash
+# Open a dialog via menu click
+echo '{"cmd":"click","role":"menuitem","name":"Help"}
+{"cmd":"click","role":"menuitem","name":"About Platform.Bible"}
+{"cmd":"wait","selector":".dock-tab","hasText":"About"}
+{"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+
+# Or trigger via PAPI (using papi-client skill) for commands with no UI element
+```
+
+### 3. Take Screenshot
+
+```bash
+# Via interaction server (can combine with other commands in a pipeline)
+.claude/skills/visual-verification/scripts/pw-interact.sh '{"cmd":"screenshot","output":"/tmp/screenshot.png"}'
+```
+
+### 4. Review the Screenshot
+
+Visual review checklist:
+
+- [ ] Layout renders as expected
+- [ ] Colors and styling correct
+- [ ] Text content correct
+- [ ] Icons and images present
+- [ ] Spacing and alignment correct
+
+## DOM Inspection
+
+### Query Elements via Playwright
+
+Use `pw-interact.sh` (or `pw-server.mjs` pipelines) to query DOM elements:
+
+```bash
+# Check if element exists
+pw-interact.sh '{"cmd":"visible","selector":"[data-testid=\"save-button\"]"}'
+
+# Get element text
+pw-interact.sh '{"cmd":"text","selector":".title"}'
+
+# Get element count
+pw-interact.sh '{"cmd":"count","selector":".list-item"}'
+
+# Check element via JavaScript eval
+pw-interact.sh '{"cmd":"eval","code":"getComputedStyle(document.querySelector(\".modal\")).display"}'
+```
+
+All commands above use the short form via `pw-interact.sh`. For the full path:
+`.claude/skills/visual-verification/scripts/pw-interact.sh`
+
+### Common Selectors
+
+Platform.Bible uses consistent patterns:
+
+```css
+/* Test IDs */
+[data-testid="component-name"]
+
+/* Component classes */
+.papi-button
+.papi-input
+.papi-select
+
+/* Layout sections */
+#main-content
+#sidebar
+#toolbar
+```
+
+## Console Log Inspection
+
+For console logs and errors, use the `log-inspector` skill which reads from the app's log files.
+
+## Verifying a UI Component
+
+A typical verification flow for a UI component:
+
+1. **Pre-flight check**: Verify app is running with debugging (see above)
+   - If not running: Use `app-runner` skill (Claude has full authority)
+
+2. **Interact with UI and verify state** using `pw-server.mjs`:
+   ```bash
+   echo '{"cmd":"screenshot","output":"/tmp/initial-state.png"}
+   {"cmd":"click","role":"button","name":"Open Project"}
+   {"cmd":"wait","role":"dialog","timeout":10000}
+   {"cmd":"screenshot","output":"/tmp/dialog-open.png"}
+   {"cmd":"fill","selector":"input","text":"Test Project"}
+   {"cmd":"screenshot","output":"/tmp/form-filled.png"}
+   {"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+   ```
+
+3. **Milestone screenshots**:
+   - Initial render
+   - Loading state
+   - Populated state
+   - After interactions (clicks, form fills)
+   - Error state (if applicable)
+
+4. **Check logs for errors** (using log-inspector skill)
+
+5. **Review the screenshots** against expected appearance and behavior
+
+## If CDP Is Not Available
+
+If CDP is not available:
+
+1. **Use `app-runner` skill** to start Platform.Bible with CDP enabled (Claude has full authority)
+2. **If `app-runner` fails after several attempts**: Set status to **BLOCKED** and escalate
+3. A UI component that hasn't been verified rendering is not complete
+
+### Reporting language
+
+State exactly what you did and observed — "opened the dialog, typed `p`, confirmed the inline error renders and OK disables" — not a bare "Verified". Never present a passing typecheck/lint/build as visual verification of a runtime-behavior change; those check that code compiles, not that it behaves. If a reviewer asks "did you actually verify anything you built?", treat it as a signal the prior claim was insufficient: tighten it and re-verify.
+
+## Troubleshooting
+
+### CDP Not Available
+
+Error: "Cannot connect to CDP on port 9223"
+
+Solution: Restart Platform.Bible with remote debugging:
+```bash
+./.erb/scripts/refresh.sh
+```
+
+### No Platform.Bible Renderer Found
+
+Error: "No Platform.Bible renderer found. Is the app running?"
+
+1. **List all CDP debug targets** (diagnostic):
+   ```bash
+   curl -s http://localhost:9223/json | jq .
+   ```
+
+2. **If no targets, app not running**:
+   ```bash
+   ps aux | grep -E "(electron|webpack)" | grep -v grep
+   ```
+
+3. **If processes exist but CDP fails**, app may still be starting. Wait for "Compiled successfully".
+
+### Screenshot Fails or Shows Blank Screen
+
+**First action: Restart the app.** Blank screenshots almost always mean the app needs a full rebuild:
+
+```bash
+./.erb/scripts/refresh.sh
+```
+
+After restart:
+1. Re-open the web view via PAPI command
+2. Wait 2 seconds for UI to render
+3. Re-capture the screenshot
+
+If still blank after restart:
+1. Check that the renderer target is available:
+   ```bash
+   .claude/skills/visual-verification/scripts/pw-interact.sh '{"cmd":"status"}'
+   ```
+2. Use `log-inspector` skill to check for extension loading errors
+3. Verify the web view provider is registered correctly in manifest.json
+
+## Benefits of CDP Approach
+
+- **Screenshots show actual app state** (not a separate browser instance)
+- **No service registration conflicts** (WebViewService, DialogService work correctly)
+- **PAPI commands affect the visible UI** (commands via papi-client reflect in screenshots)
+- **Simpler architecture** (no Chrome browser needed, no `claude --chrome` flag required)
+- **Works with existing skills** (papi-client for commands, log-inspector for logs)
+
+## See Also
+
+- [papi-client skill](../papi-client/SKILL.md) - Send PAPI commands
+- [app-runner skill](../app-runner/SKILL.md) - Check app status and guide user
+- [log-inspector skill](../log-inspector/SKILL.md) - Debug issues via logs

--- a/.claude/skills/visual-verification/scripts/pw-interact.sh
+++ b/.claude/skills/visual-verification/scripts/pw-interact.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Playwright Interaction Helper — single-shot wrapper around pw-server.mjs
+#
+# Sends one command and returns one JSON response line.
+# For multi-command sequences, pipe directly to pw-server.mjs instead.
+#
+# Usage:
+#   pw-interact.sh '{"cmd":"screenshot","output":"/tmp/ss.png"}'
+#   pw-interact.sh '{"cmd":"click","role":"menuitem","name":"Help"}'
+#   pw-interact.sh '{"cmd":"fill","selector":"input","text":"Genesis"}'
+#   pw-interact.sh '{"cmd":"visible","role":"button","name":"Save"}'
+#
+# For multi-command sequences (faster — single connection):
+#   echo '{"cmd":"click","role":"menuitem","name":"Help"}
+#   {"cmd":"screenshot","output":"/tmp/after-click.png"}
+#   {"cmd":"quit"}' | node .claude/skills/visual-verification/scripts/pw-server.mjs 2>/dev/null
+#
+# Exit codes:
+#   0 = success (response on stdout as JSON)
+#   1 = error (error JSON on stdout)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PW_SERVER="$SCRIPT_DIR/pw-server.mjs"
+
+case "${1:-}" in
+  ""|--help|-h)
+    echo "Usage: pw-interact.sh '<json-command>'"
+    echo ""
+    echo "Examples:"
+    echo "  pw-interact.sh '{\"cmd\":\"screenshot\",\"output\":\"/tmp/ss.png\"}'"
+    echo "  pw-interact.sh '{\"cmd\":\"click\",\"role\":\"button\",\"name\":\"Save\"}'"
+    echo "  pw-interact.sh '{\"cmd\":\"eval\",\"code\":\"document.title\"}'"
+    exit 0
+    ;;
+esac
+
+COMMAND="$1"
+
+# Validate JSON
+if ! echo "$COMMAND" | python3 -c "import sys,json; json.load(sys.stdin)" 2>/dev/null; then
+  echo '{"error":"Invalid JSON command"}'
+  exit 1
+fi
+
+# Check CDP
+if ! curl -s -m 2 http://localhost:9223/json > /dev/null 2>&1; then
+  echo '{"error":"CDP not available on port 9223. Start app with: MAIN_ARGS=\"--remote-debugging-port=9223\" npm start"}'
+  exit 1
+fi
+
+# Single-shot: connect, run command, quit
+# Output: line 1 = connected, line 2 = command result, line 3 = quit ack
+RESPONSE=$(printf '%s\n{"cmd":"quit"}\n' "$COMMAND" | node "$PW_SERVER" 2>/dev/null)
+
+# Normally line 1 is the connected banner and line 2 is the command result.
+# But on a startup failure (e.g. CDP reachable but no renderer page), the
+# server emits a SINGLE error line as line 1 and exits — leaving line 2 empty.
+LINE1=$(echo "$RESPONSE" | sed -n '1p')
+LINE2=$(echo "$RESPONSE" | sed -n '2p')
+
+# If there is no result line, or line 1 carries an "error" field (no banner
+# was printed), surface the error from line 1 and fail.
+if [ -z "$LINE2" ] || echo "$LINE1" | grep -q '"error"'; then
+  echo "$LINE1"
+  exit 1
+fi
+
+# Return just the command result (line 2)
+echo "$LINE2"

--- a/.claude/skills/visual-verification/scripts/pw-server.mjs
+++ b/.claude/skills/visual-verification/scripts/pw-server.mjs
@@ -1,0 +1,830 @@
+#!/usr/bin/env node
+/**
+ * Playwright Interaction Server
+ *
+ * A persistent server that connects to Platform.Bible via CDP and accepts
+ * line-delimited JSON commands on stdin. Provides full UI interaction
+ * capabilities: click, fill, press, screenshot, wait, eval, scroll, frame.
+ *
+ * Usage:
+ *   node .claude/skills/visual-verification/scripts/pw-server.mjs
+ *
+ * Prerequisites:
+ *   Platform.Bible running with --remote-debugging-port=9223
+ *
+ * Protocol:
+ *   Send one JSON command per line on stdin.
+ *   Receive one JSON response per line on stdout.
+ *   Errors are also JSON responses with "error" field.
+ *
+ * Commands:
+ *   {"cmd":"screenshot","output":"/tmp/ss.png"}
+ *   {"cmd":"click","role":"button","name":"Save"}
+ *   {"cmd":"click","selector":".my-class"}
+ *   {"cmd":"click","text":"Save Changes"}
+ *   {"cmd":"fill","selector":"input","text":"Genesis"}
+ *   {"cmd":"fill","role":"textbox","name":"Search","text":"Genesis"}
+ *   {"cmd":"press","key":"Enter"}
+ *   {"cmd":"press","key":"Escape"}
+ *   {"cmd":"wait","role":"dialog","timeout":10000}
+ *   {"cmd":"wait","selector":".dock-tab","hasText":"About","timeout":10000}
+ *   {"cmd":"text","selector":".title"}
+ *   {"cmd":"text","role":"heading"}
+ *   {"cmd":"visible","role":"button","name":"Save"}
+ *   {"cmd":"visible","selector":".modal"}
+ *   {"cmd":"eval","code":"document.title"}
+ *   {"cmd":"scroll","selector":".content","down":500}
+ *   {"cmd":"scroll","selector":".content","up":300}
+ *   {"cmd":"frame","selector":"iframe[data-web-view-id]"}
+ *   {"cmd":"frame-by-title","title":"Home"}
+ *   {"cmd":"frame-reset"}
+ *   {"cmd":"locators","role":"button"}
+ *   {"cmd":"locators","selector":".dock-tab"}
+ *   {"cmd":"snapshot"}
+ *   {"cmd":"snapshot","roles":["button","textbox"]}
+ *   {"cmd":"annotated-screenshot","output":"/tmp/annotated.png"}
+ *   {"cmd":"annotated-screenshot","output":"/tmp/annotated.png","limit":30}
+ *   {"cmd":"click-ref","ref":"@ref3"}
+ *   {"cmd":"viewport","width":1920,"height":1080}
+ *   {"cmd":"status"}
+ *   {"cmd":"quit"}
+ */
+
+import { createRequire } from 'module';
+import fs from 'fs';
+import path from 'path';
+import readline from 'readline';
+
+// Resolve playwright from paranext-core's node_modules. This script lives in
+// ai-prompts (symlinked into paranext-core), so ESM resolution won't find
+// playwright. We use createRequire anchored at paranext-core's package.json.
+function findParanextRoot() {
+  const candidates = [
+    // When invoked as: node paranext-core/.claude/skills/.../pw-server.mjs
+    process.argv[1] ? path.resolve(path.dirname(process.argv[1]), '../../../..') : null,
+    process.env.PARANEXT_ROOT,
+    process.cwd(),
+  ].filter(Boolean);
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(candidate, 'node_modules', 'playwright'))) {
+      return candidate;
+    }
+  }
+  throw new Error(
+    'Cannot find paranext-core root with playwright installed. ' +
+    'Run from the paranext-core directory or set PARANEXT_ROOT env var.'
+  );
+}
+
+const paranextRoot = findParanextRoot();
+const require = createRequire(path.join(paranextRoot, 'package.json'));
+const { chromium } = require('playwright');
+
+const CDP_URL = process.env.CDP_URL || 'http://localhost:9223';
+
+/** JSON response helper */
+function respond(obj) {
+  console.log(JSON.stringify(obj));
+}
+
+/** Error response helper */
+function respondError(cmd, message) {
+  respond({ cmd, error: message });
+}
+
+/** Build a locator from command parameters */
+function buildLocator(page, params) {
+  const { role, name, selector, text, hasText } = params;
+
+  if (selector) {
+    const loc = page.locator(selector);
+    // Pass the raw string: Playwright matches hasText as a case-insensitive
+    // substring by default. Wrapping in new RegExp() would treat regex
+    // metacharacters in the param (e.g. "(", "[", "+") as syntax, which both
+    // breaks literal matches like "Save (Ctrl+S)" / "[Beta]" and is unsafe.
+    if (hasText) return loc.filter({ hasText });
+    return loc;
+  }
+
+  if (role) {
+    const opts = {};
+    // Raw string: getByRole matches name as a case-insensitive substring by
+    // default. See the hasText comment above re: regex metacharacters.
+    if (name) opts.name = name;
+    return page.getByRole(role, opts);
+  }
+
+  if (text) {
+    // Raw string: getByText matches as a case-insensitive substring by default.
+    return page.getByText(text);
+  }
+
+  return null;
+}
+
+/** Default set of ARIA roles considered "interactive" for snapshot/annotated-screenshot */
+const DEFAULT_INTERACTIVE_ROLES = new Set([
+  'button', 'link', 'textbox', 'checkbox', 'radio',
+  'combobox', 'listbox', 'menuitem', 'menuitemcheckbox',
+  'menuitemradio', 'option', 'searchbox', 'slider',
+  'spinbutton', 'switch', 'tab', 'treeitem',
+]);
+
+/** Filter AX tree nodes to only interactive ones with a backing DOM node */
+function filterInteractiveNodes(nodes, roles) {
+  const allowedRoles = roles ? new Set(roles) : DEFAULT_INTERACTIVE_ROLES;
+  return nodes.filter((node) => {
+    if (node.ignored) return false;
+    const role = node.role?.value;
+    return role && allowedRoles.has(role) && node.backendDOMNodeId;
+  });
+}
+
+/** Extract useful properties from an AX tree node */
+function extractNodeProps(node) {
+  const props = {};
+  if (node.properties) {
+    for (const prop of node.properties) {
+      if (['focused', 'disabled', 'checked', 'expanded', 'pressed', 'selected'].includes(prop.name))
+        props[prop.name] = prop.value?.value;
+    }
+  }
+  if (node.value?.value !== undefined) props.value = String(node.value.value);
+  return props;
+}
+
+async function main() {
+  // Connect to CDP
+  process.stderr.write(`[pw-server] Connecting to ${CDP_URL}...\n`);
+  let browser;
+  try {
+    browser = await chromium.connectOverCDP(CDP_URL, { timeout: 10_000 });
+  } catch (err) {
+    respondError('connect', `Failed to connect to CDP at ${CDP_URL}: ${err.message}`);
+    process.exit(1);
+  }
+
+  // Find the renderer page
+  let page;
+  for (const ctx of browser.contexts()) {
+    for (const p of ctx.pages()) {
+      const url = p.url();
+      if (url.includes('localhost') || url.includes('index.html') || url.startsWith('file://')) {
+        // Skip devtools
+        if (!url.includes('devtools://')) {
+          page = p;
+          break;
+        }
+      }
+    }
+    if (page) break;
+  }
+
+  if (!page) {
+    // Fallback to first non-devtools page
+    for (const ctx of browser.contexts()) {
+      for (const p of ctx.pages()) {
+        if (!p.url().includes('devtools://')) {
+          page = p;
+          break;
+        }
+      }
+      if (page) break;
+    }
+  }
+
+  if (!page) {
+    respondError('connect', 'No renderer page found');
+    process.exit(1);
+  }
+
+  // Set a consistent viewport size for screenshots.
+  // Electron defaults to 1024x728 window, yielding ~675x728 usable viewport.
+  // Force 1920x1080 (Full HD) so screenshots capture the full UI layout.
+  const viewportWidth = parseInt(process.env.PW_VIEWPORT_WIDTH, 10) || 1920;
+  const viewportHeight = parseInt(process.env.PW_VIEWPORT_HEIGHT, 10) || 1080;
+  await page.setViewportSize({ width: viewportWidth, height: viewportHeight });
+
+  // Track current frame context (for frame switching)
+  let currentFrame = page;
+
+  // Ephemeral ref map for snapshot/annotated-screenshot → click-ref
+  // Maps "@refN" → { backendDOMNodeId, frameId }
+  let lastSnapshotRefMap = {};
+
+  process.stderr.write(`[pw-server] Connected. Page: ${page.url()} (viewport: ${viewportWidth}x${viewportHeight})\n`);
+  respond({ cmd: 'connected', url: page.url(), viewport: { width: viewportWidth, height: viewportHeight } });
+
+  // Read commands from stdin
+  const rl = readline.createInterface({ input: process.stdin });
+
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let params;
+    try {
+      params = JSON.parse(trimmed);
+    } catch {
+      respondError('parse', `Invalid JSON: ${trimmed}`);
+      continue;
+    }
+
+    const { cmd } = params;
+    const timeout = params.timeout || 10_000;
+
+    try {
+      switch (cmd) {
+        case 'screenshot': {
+          const output = params.output || '/tmp/pw-screenshot.png';
+          const dir = output.substring(0, output.lastIndexOf('/'));
+          if (dir) fs.mkdirSync(dir, { recursive: true });
+          await page.screenshot({ path: output, fullPage: params.fullPage !== false });
+          respond({ cmd: 'screenshot', path: output });
+          break;
+        }
+
+        case 'click': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          await locator.click({ timeout });
+          respond({ cmd: 'click', clicked: true });
+          break;
+        }
+
+        case 'dblclick': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          await locator.dblclick({ timeout });
+          respond({ cmd: 'dblclick', clicked: true });
+          break;
+        }
+
+        case 'fill': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          await locator.fill(params.text || '', { timeout });
+          respond({ cmd: 'fill', filled: true });
+          break;
+        }
+
+        case 'type': {
+          // Type character-by-character (useful when fill() doesn't trigger events)
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          await locator.pressSequentially(params.text || '', {
+            delay: params.delay ?? 50,
+            timeout,
+          });
+          respond({ cmd: 'type', typed: true });
+          break;
+        }
+
+        case 'press': {
+          if (params.selector || params.role) {
+            const locator = buildLocator(currentFrame, params);
+            if (locator) {
+              await locator.press(params.key, { timeout });
+            }
+          } else {
+            await page.keyboard.press(params.key);
+          }
+          respond({ cmd: 'press', key: params.key });
+          break;
+        }
+
+        case 'wait': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          const state = params.state || 'visible';
+          await locator.waitFor({ state, timeout });
+          respond({ cmd: 'wait', found: true, state });
+          break;
+        }
+
+        case 'wait-ms': {
+          const ms = params.ms || 1000;
+          await page.waitForTimeout(ms);
+          respond({ cmd: 'wait-ms', ms });
+          break;
+        }
+
+        case 'text': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          const textContent = await locator.first().textContent({ timeout });
+          respond({ cmd: 'text', value: textContent });
+          break;
+        }
+
+        case 'inner-text': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          const innerText = await locator.first().innerText({ timeout });
+          respond({ cmd: 'inner-text', value: innerText });
+          break;
+        }
+
+        case 'value': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          const val = await locator.first().inputValue({ timeout });
+          respond({ cmd: 'value', value: val });
+          break;
+        }
+
+        case 'visible': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          const isVisible = await locator.first().isVisible();
+          respond({ cmd: 'visible', visible: isVisible });
+          break;
+        }
+
+        case 'count': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          const count = await locator.count();
+          respond({ cmd: 'count', count });
+          break;
+        }
+
+        case 'eval': {
+          const result = await currentFrame.evaluate(params.code);
+          respond({ cmd: 'eval', value: result });
+          break;
+        }
+
+        case 'scroll': {
+          const locator = buildLocator(currentFrame, params);
+          if (locator) {
+            if (params.down) {
+              await locator.evaluate((el, px) => el.scrollBy(0, px), params.down);
+            } else if (params.up) {
+              await locator.evaluate((el, px) => el.scrollBy(0, -px), params.up);
+            } else if (params.left) {
+              await locator.evaluate((el, px) => el.scrollBy(-px, 0), params.left);
+            } else if (params.right) {
+              await locator.evaluate((el, px) => el.scrollBy(px, 0), params.right);
+            }
+          } else {
+            // Scroll the page
+            const delta = params.down || -(params.up || 0);
+            await page.mouse.wheel(0, delta);
+          }
+          respond({ cmd: 'scroll', scrolled: true });
+          break;
+        }
+
+        case 'frame': {
+          const frames = page.frames();
+          let found = false;
+          for (const f of frames) {
+            if (f.url() !== page.url() && f.url() !== 'about:blank') {
+              // Try to match by selector or URL
+              if (params.url && f.url().includes(params.url)) {
+                currentFrame = f;
+                found = true;
+                break;
+              }
+            }
+          }
+
+          if (!found && params.selector) {
+            // Match the selector to a real frame element, then resolve its src
+            // to a live frame. A selector that matches NO frame must be an
+            // error — do NOT silently fall through to an arbitrary frame, since
+            // that would report SUCCESS for the wrong frame.
+            const selectorLocator = page.locator(params.selector);
+            const selectorMatches = await selectorLocator.count();
+            if (selectorMatches === 0) {
+              respondError(cmd, `Selector "${params.selector}" matched no frame element.`);
+              break;
+            }
+            const frameSrc = await selectorLocator.first().getAttribute('src', { timeout });
+            if (frameSrc) {
+              // Only match by src if it's non-null/non-empty (srcdoc iframes have no src)
+              for (const f of frames) {
+                if (f.url().includes(frameSrc)) {
+                  currentFrame = f;
+                  found = true;
+                  break;
+                }
+              }
+            } else if (params.index != null) {
+              // src is null (srcdoc iframe) AND the caller explicitly asked for
+              // an index — honor that intentional index-based selection.
+              const idx = params.index;
+              const nonMainFrames = frames.filter((f) => f !== page.mainFrame());
+              if (idx <= nonMainFrames.length) {
+                currentFrame = nonMainFrames[idx - 1];
+                found = true;
+              }
+            }
+          } else if (!found && params.index != null) {
+            // No selector, but an explicit index — intentional index-based selection.
+            const idx = params.index;
+            const nonMainFrames = frames.filter((f) => f !== page.mainFrame());
+            if (idx <= nonMainFrames.length) {
+              currentFrame = nonMainFrames[idx - 1];
+              found = true;
+            }
+          }
+
+          if (found) {
+            respond({ cmd: 'frame', url: currentFrame.url() });
+          } else {
+            respondError(cmd, `Frame not found. Available: ${frames.map((f) => f.url()).join(', ')}`);
+          }
+          break;
+        }
+
+        case 'frame-reset': {
+          currentFrame = page;
+          respond({ cmd: 'frame-reset', url: page.url() });
+          break;
+        }
+
+        case 'frame-by-title': {
+          const frames = page.frames();
+          let found = false;
+          for (const f of frames) {
+            if (f !== page.mainFrame()) {
+              try {
+                const el = await f.frameElement();
+                const title = await el.getAttribute('title');
+                if (title && title.includes(params.title)) {
+                  currentFrame = f;
+                  found = true;
+                  break;
+                }
+              } catch {
+                /* skip frames without elements */
+              }
+            }
+          }
+          if (found) {
+            respond({ cmd: 'frame-by-title', title: params.title, url: currentFrame.url() });
+          } else {
+            respondError(cmd, `Frame with title "${params.title}" not found`);
+          }
+          break;
+        }
+
+        case 'frames': {
+          const frames = page.frames();
+          const frameInfo = [];
+          for (const f of frames) {
+            const info = { url: f.url(), name: f.name() };
+            try {
+              const el = await f.frameElement();
+              if (el) info.title = await el.getAttribute('title');
+            } catch {
+              /* main frame has no frameElement */
+            }
+            frameInfo.push(info);
+          }
+          respond({ cmd: 'frames', frames: frameInfo });
+          break;
+        }
+
+        case 'locators': {
+          // List matching elements for debugging
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          const count = await locator.count();
+          const items = [];
+          for (let i = 0; i < Math.min(count, params.limit ?? 20); i++) {
+            const el = locator.nth(i);
+            const tag = await el.evaluate((e) => e.tagName.toLowerCase());
+            const text = await el.evaluate((e) => e.textContent?.trim().slice(0, 100));
+            const attrs = await el.evaluate((e) => {
+              const a = {};
+              for (const attr of ['id', 'class', 'role', 'aria-label', 'data-testid', 'name']) {
+                const v = e.getAttribute(attr);
+                if (v) a[attr] = v;
+              }
+              return a;
+            });
+            items.push({ index: i, tag, text, ...attrs });
+          }
+          respond({ cmd: 'locators', count, items });
+          break;
+        }
+
+        case 'hover': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          await locator.hover({ timeout });
+          respond({ cmd: 'hover', hovered: true });
+          break;
+        }
+
+        case 'select': {
+          // Select option in a <select> element
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          await locator.selectOption(params.option || params.value, { timeout });
+          respond({ cmd: 'select', selected: true });
+          break;
+        }
+
+        case 'check': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          await locator.check({ timeout });
+          respond({ cmd: 'check', checked: true });
+          break;
+        }
+
+        case 'uncheck': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          await locator.uncheck({ timeout });
+          respond({ cmd: 'uncheck', unchecked: true });
+          break;
+        }
+
+        case 'attribute': {
+          const locator = buildLocator(currentFrame, params);
+          if (!locator) {
+            respondError(cmd, 'Must provide role, selector, or text');
+            break;
+          }
+          const attrVal = await locator.first().getAttribute(params.attr, { timeout });
+          respond({ cmd: 'attribute', attr: params.attr, value: attrVal });
+          break;
+        }
+
+        case 'snapshot': {
+          // Accessibility tree snapshot with interactive element refs
+          const cdp = await page.context().newCDPSession(page);
+          try {
+            const { nodes } = await cdp.send('Accessibility.getFullAXTree');
+            const interactive = filterInteractiveNodes(nodes, params.roles);
+            const limit = params.limit ?? 100;
+            const elements = [];
+            const refMap = {};
+            let refIndex = 1;
+
+            for (const node of interactive) {
+              if (refIndex > limit) break;
+              const ref = `@ref${refIndex}`;
+              const role = node.role?.value;
+              const name = node.name?.value || '';
+              const nodeProps = extractNodeProps(node);
+              elements.push({ ref, role, name, ...nodeProps });
+              refMap[ref] = { backendDOMNodeId: node.backendDOMNodeId };
+              refIndex++;
+            }
+
+            lastSnapshotRefMap = refMap;
+            respond({ cmd: 'snapshot', count: elements.length, elements });
+          } finally {
+            await cdp.detach();
+          }
+          break;
+        }
+
+        case 'annotated-screenshot': {
+          // Screenshot with numbered badges on interactive elements
+          const output = params.output || '/tmp/pw-annotated.png';
+          const dir = output.substring(0, output.lastIndexOf('/'));
+          if (dir) fs.mkdirSync(dir, { recursive: true });
+
+          const cdp = await page.context().newCDPSession(page);
+          try {
+            const { nodes } = await cdp.send('Accessibility.getFullAXTree');
+            const interactive = filterInteractiveNodes(nodes, params.roles);
+            const limit = params.limit ?? 50;
+            const annotations = [];
+            const refMap = {};
+            let refIndex = 1;
+
+            // Get iframe offset if we're in a sub-frame
+            let frameOffsetX = 0;
+            let frameOffsetY = 0;
+            if (currentFrame !== page) {
+              try {
+                const frameEl = await currentFrame.frameElement();
+                if (frameEl) {
+                  const box = await frameEl.boundingBox();
+                  if (box) {
+                    frameOffsetX = box.x;
+                    frameOffsetY = box.y;
+                  }
+                }
+              } catch { /* ignore — main frame has no frameElement */ }
+            }
+
+            // Resolve bounding boxes for each interactive element
+            for (const node of interactive) {
+              if (refIndex > limit) break;
+              try {
+                const { model } = await cdp.send('DOM.getBoxModel', {
+                  backendNodeId: node.backendDOMNodeId,
+                });
+                // content quad: [x1,y1, x2,y2, x3,y3, x4,y4]
+                const quad = model.content;
+                const x = Math.min(quad[0], quad[2], quad[4], quad[6]);
+                const y = Math.min(quad[1], quad[3], quad[5], quad[7]);
+                const maxX = Math.max(quad[0], quad[2], quad[4], quad[6]);
+                const maxY = Math.max(quad[1], quad[3], quad[5], quad[7]);
+                const width = maxX - x;
+                const height = maxY - y;
+
+                // Skip zero-size or very tiny elements
+                if (width < 2 || height < 2) continue;
+
+                const absX = x + frameOffsetX;
+                const absY = y + frameOffsetY;
+
+                const ref = `@ref${refIndex}`;
+                const role = node.role?.value;
+                const name = node.name?.value || '';
+                annotations.push({
+                  ref, label: refIndex, role, name,
+                  x: Math.round(absX), y: Math.round(absY),
+                  width: Math.round(width), height: Math.round(height),
+                });
+                refMap[ref] = { backendDOMNodeId: node.backendDOMNodeId };
+                refIndex++;
+              } catch {
+                // Element hidden or detached — skip
+              }
+            }
+
+            // Inject overlay into main frame
+            const overlayId = '__pw_annotation_overlay__';
+            const overlayHtml = annotations.map((a) => {
+              const badgeSize = 20;
+              return `<div style="position:fixed;left:${a.x}px;top:${a.y}px;width:${a.width}px;height:${a.height}px;border:2px solid red;pointer-events:none;z-index:2147483646;box-sizing:border-box;"></div>` +
+                `<div style="position:fixed;left:${a.x - badgeSize / 2}px;top:${a.y - badgeSize / 2}px;width:${badgeSize}px;height:${badgeSize}px;background:red;color:white;border-radius:50%;font-size:11px;font-weight:bold;display:flex;align-items:center;justify-content:center;pointer-events:none;z-index:2147483647;font-family:Arial,sans-serif;">${a.label}</div>`;
+            }).join('');
+
+            await page.evaluate(({ id, html }) => {
+              const existing = document.getElementById(id);
+              if (existing) existing.remove();
+              const container = document.createElement('div');
+              container.id = id;
+              container.innerHTML = html;
+              document.body.appendChild(container);
+            }, { id: overlayId, html: overlayHtml });
+
+            try {
+              // Brief pause to let overlay render
+              await page.waitForTimeout(100);
+              await page.screenshot({ path: output, fullPage: false });
+            } finally {
+              // Always remove overlay
+              await page.evaluate((id) => {
+                const el = document.getElementById(id);
+                if (el) el.remove();
+              }, overlayId);
+            }
+
+            lastSnapshotRefMap = refMap;
+            respond({ cmd: 'annotated-screenshot', path: output, count: annotations.length, annotations });
+          } finally {
+            await cdp.detach();
+          }
+          break;
+        }
+
+        case 'click-ref': {
+          // Click element by ref from last snapshot
+          const ref = params.ref;
+          if (!ref || !lastSnapshotRefMap[ref]) {
+            respondError(cmd, `Unknown ref "${ref}". Run snapshot or annotated-screenshot first.`);
+            break;
+          }
+
+          const { backendDOMNodeId } = lastSnapshotRefMap[ref];
+          const cdp = await page.context().newCDPSession(page);
+          try {
+            const { model } = await cdp.send('DOM.getBoxModel', {
+              backendNodeId: backendDOMNodeId,
+            });
+            const quad = model.content;
+            const x = Math.min(quad[0], quad[2], quad[4], quad[6]);
+            const y = Math.min(quad[1], quad[3], quad[5], quad[7]);
+            const maxX = Math.max(quad[0], quad[2], quad[4], quad[6]);
+            const maxY = Math.max(quad[1], quad[3], quad[5], quad[7]);
+
+            // Add iframe offset if in sub-frame
+            let offsetX = 0;
+            let offsetY = 0;
+            if (currentFrame !== page) {
+              try {
+                const frameEl = await currentFrame.frameElement();
+                if (frameEl) {
+                  const box = await frameEl.boundingBox();
+                  if (box) {
+                    offsetX = box.x;
+                    offsetY = box.y;
+                  }
+                }
+              } catch { /* ignore */ }
+            }
+
+            const cx = Math.round((x + maxX) / 2 + offsetX);
+            const cy = Math.round((y + maxY) / 2 + offsetY);
+            await page.mouse.click(cx, cy);
+            respond({ cmd: 'click-ref', ref, clicked: true, x: cx, y: cy });
+          } finally {
+            await cdp.detach();
+          }
+          break;
+        }
+
+        case 'viewport': {
+          const w = params.width || 1920;
+          const h = params.height || 1080;
+          await page.setViewportSize({ width: w, height: h });
+          respond({ cmd: 'viewport', width: w, height: h });
+          break;
+        }
+
+        case 'status': {
+          const vp = page.viewportSize();
+          respond({
+            cmd: 'status',
+            connected: true,
+            pageUrl: page.url(),
+            currentFrameUrl: currentFrame === page ? page.url() : currentFrame.url(),
+            inFrame: currentFrame !== page,
+            viewport: vp,
+          });
+          break;
+        }
+
+        case 'quit': {
+          respond({ cmd: 'quit', disconnecting: true });
+          try { browser.close(); } catch { /* already disconnected */ }
+          process.exit(0);
+          break;
+        }
+
+        default:
+          respondError(cmd, `Unknown command: ${cmd}`);
+      }
+    } catch (err) {
+      respondError(cmd, err.message);
+    }
+  }
+
+  // stdin closed
+  process.stderr.write('[pw-server] stdin closed, disconnecting...\n');
+  try { browser.close(); } catch { /* already disconnected */ }
+}
+
+main().catch((err) => {
+  respondError('fatal', err.message);
+  process.exit(1);
+});

--- a/.claude/skills/visual-verification/scripts/pw-server.mjs
+++ b/.claude/skills/visual-verification/scripts/pw-server.mjs
@@ -55,9 +55,10 @@ import fs from 'fs';
 import path from 'path';
 import readline from 'readline';
 
-// Resolve playwright from paranext-core's node_modules. This script lives in
-// ai-prompts (symlinked into paranext-core), so ESM resolution won't find
-// playwright. We use createRequire anchored at paranext-core's package.json.
+// Resolve playwright from the repo root's node_modules. This script lives deep
+// under .claude/skills/visual-verification/scripts/, so we anchor createRequire
+// at the repo root's package.json (located by findParanextRoot) to resolve
+// playwright reliably regardless of how the script is invoked.
 function findParanextRoot() {
   const candidates = [
     // When invoked as: node paranext-core/.claude/skills/.../pw-server.mjs

--- a/.claude/skills/visual-verification/scripts/quick-verify.sh
+++ b/.claude/skills/visual-verification/scripts/quick-verify.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+# Quick visual verification for a component
+# Usage: quick-verify.sh <selector> <output-dir> [filename]
+#
+# Arguments:
+#   selector   - CSS selector for the component (e.g., '[data-testid="my-component"]')
+#   output-dir - Directory for screenshot output (REQUIRED)
+#   filename   - Screenshot filename (optional, defaults to verify-YYYYMMDD-HHMMSS.png)
+#                Pass a custom output filename here, e.g. render-verification.png
+
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: quick-verify.sh <selector> <output-dir> [filename]"
+  echo ""
+  echo "Arguments:"
+  echo "  selector   - CSS selector (e.g., '[data-testid=\"component\"]')"
+  echo "  output-dir - Evidence directory (REQUIRED)"
+  echo "  filename   - Screenshot filename (optional)"
+  echo ""
+  echo "Examples:"
+  echo "  # Default filename (verify-YYYYMMDD-HHMMSS.png):"
+  echo "  quick-verify.sh '[data-testid=\"my-component\"]' ./evidence/"
+  echo ""
+  echo "  # Custom output filename:"
+  echo "  quick-verify.sh '[data-testid=\"my-component\"]' ./evidence/ render-verification.png"
+  exit 1
+fi
+
+SELECTOR="$1"
+OUTPUT_DIR="$2"
+FILENAME="${3:-verify-$(date +%Y%m%d-%H%M%S).png}"
+SCRIPT_DIR="$(dirname "$0")"
+
+# Ensure output directory exists
+mkdir -p "$OUTPUT_DIR"
+
+echo "=== Visual Verification: $SELECTOR ==="
+echo ""
+
+# 1. Check CDP
+echo "1. CDP Status:"
+if curl -s -m 2 http://localhost:9223/json > /dev/null 2>&1; then
+  echo "   ✓ CDP available on port 9223"
+  CDP_OK=true
+else
+  echo "   ✗ CDP not available - run ./.erb/scripts/refresh.sh"
+  CDP_OK=false
+fi
+echo ""
+
+if [ "$CDP_OK" = false ]; then
+  echo "RESULT: FAIL (CDP not available)"
+  exit 1
+fi
+
+# 2. Check component exists in DOM + capture screenshot via pw-server.mjs
+echo "2. DOM Check + Screenshot:"
+SCREENSHOT="$OUTPUT_DIR/$FILENAME"
+# Build command JSON via node (not jq) for cross-platform parity with the rest of
+# the project — jq is not reliably installed on Windows, but node is a hard
+# dependency here (pw-server.mjs). Pass values via argv so they are JSON-escaped
+# safely (no shell injection into the JSON).
+CMD1=$(node -e 'process.stdout.write(JSON.stringify({cmd:"visible",selector:process.argv[1]}))' "$SELECTOR")
+CMD2=$(node -e 'process.stdout.write(JSON.stringify({cmd:"screenshot",output:process.argv[1]}))' "$SCREENSHOT")
+PW_RESPONSE=$(printf '%s\n%s\n{"cmd":"quit"}\n' "$CMD1" "$CMD2" \
+  | node "$SCRIPT_DIR/pw-server.mjs")
+
+# Parse responses (line 1 = connected, line 2 = visible result, line 3 = screenshot result)
+VISIBLE_LINE=$(echo "$PW_RESPONSE" | sed -n '2p')
+SCREENSHOT_LINE=$(echo "$PW_RESPONSE" | sed -n '3p')
+
+# Check DOM visibility (parse with node, not python3, for cross-platform parity)
+if node -e 'process.exit(JSON.parse(process.argv[1] || "{}").visible ? 0 : 1)' "$VISIBLE_LINE"; then
+  echo "   ✓ Component found: $SELECTOR"
+  DOM_OK=true
+else
+  echo "   ✗ Component NOT found: $SELECTOR"
+  DOM_OK=false
+fi
+
+# Check screenshot capture (parse with node, not python3, for cross-platform parity)
+if node -e 'process.exit(JSON.parse(process.argv[1] || "{}").path ? 0 : 1)' "$SCREENSHOT_LINE"; then
+  echo "   ✓ Screenshot saved: $SCREENSHOT"
+  SCREENSHOT_OK=true
+else
+  echo "   ✗ Failed to capture screenshot"
+  SCREENSHOT_OK=false
+fi
+echo ""
+
+# 3. Check console errors
+# The renderer never writes its own log file. electron-log routes renderer console
+# output into the single main log via spyRendererConsole (logger.service.ts), where
+# renderer-originated lines carry a [rend] tag and error-level lines carry [error].
+# Dev runs use the "Electron" app name; packaged runs use "platform-bible"
+# (release/app/package.json name) — check both.
+echo "3. Console Errors:"
+MAIN_LOG=~/.config/Electron/logs/main.log
+[ -f "$MAIN_LOG" ] || MAIN_LOG=~/.config/platform-bible/logs/main.log
+if [ ! -f "$MAIN_LOG" ]; then
+  # No log file means we cannot determine console health — report a distinct
+  # "unknown" state rather than falsely claiming the log is clean.
+  echo "   ? Main log not found (checked ~/.config/Electron and ~/.config/platform-bible) - console state unknown"
+  CONSOLE_OK=unknown
+else
+  ERRORS=$(grep -F "[error]" "$MAIN_LOG" | tail -5)
+  if [ -z "$ERRORS" ]; then
+    echo "   ✓ No errors in main log ($MAIN_LOG)"
+    CONSOLE_OK=true
+  else
+    echo "   ⚠ Found errors (renderer lines tagged [rend]):"
+    echo "$ERRORS" | sed 's/^/   /'
+    CONSOLE_OK=false
+  fi
+fi
+echo ""
+
+# Summary
+echo "=== Summary ==="
+echo "CDP:        $([ "$CDP_OK" = true ] && echo "✓ PASS" || echo "✗ FAIL")"
+echo "DOM:        $([ "$DOM_OK" = true ] && echo "✓ PASS" || echo "✗ FAIL")"
+case "$CONSOLE_OK" in
+  true)    CONSOLE_SUMMARY="✓ PASS" ;;
+  unknown) CONSOLE_SUMMARY="? UNKNOWN (log not found)" ;;
+  *)       CONSOLE_SUMMARY="⚠ WARN" ;;
+esac
+echo "Console:    $CONSOLE_SUMMARY"
+echo "Screenshot: $([ "$SCREENSHOT_OK" = true ] && echo "✓ PASS" || echo "✗ FAIL")"
+echo ""
+
+if [ "$CDP_OK" = true ] && [ "$DOM_OK" = true ] && [ "$SCREENSHOT_OK" = true ]; then
+  echo "RESULT: PASS"
+  exit 0
+else
+  echo "RESULT: FAIL"
+  exit 1
+fi

--- a/.context/standards/Architecture.md
+++ b/.context/standards/Architecture.md
@@ -1,0 +1,354 @@
+---
+title: Platform.Bible Architecture
+description: Multi-process architecture, data providers, network objects, WebViews, and security boundaries.
+version: 1.0.0
+status: active
+created: 2026-03-04
+last_updated: 2026-03-04
+---
+
+# Platform.Bible Architecture
+
+This document provides detailed architectural information for Platform.Bible (paranext-core).
+
+---
+
+## 1. Process Communication
+
+### Overview
+
+Platform.Bible uses **JSON-RPC 2.0 over WebSocket** for inter-process communication. All processes connect to the Main process which acts as the message broker.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Main Process (Electron)               │
+│  • WebSocket server on port 8876                         │
+│  • Routes messages between processes                     │
+└────────────────┬────────────────────────────────────────┘
+                 │ JSON-RPC over WebSocket (port 8876)
+    ┌────────────┼────────────┬───────────────────┐
+    │            │            │                   │
+┌───▼────────┐ ┌─▼──────────┐ ┌▼────────────────┐
+│ Renderer   │ │ Extension  │ │ .NET Data       │
+│ (React UI) │ │ Host       │ │ Provider        │
+└────────────┘ └────────────┘ └─────────────────┘
+```
+
+### Communication Patterns
+
+| Pattern | Use Case | Example |
+|---------|----------|---------|
+| Request/Response | Single operation with result | `papi.commands.sendCommand()` |
+| Events | Broadcast notifications | Data provider updates |
+| Subscriptions | Continuous data streaming | `useData()` hook subscriptions |
+
+### Key Files
+
+- `src/shared/services/network.service.ts` - Core network communication
+- `src/main/services/rpc-server.ts` - WebSocket server
+- `src/main/services/rpc-websocket-listener.ts` - Connection handling
+
+---
+
+## 2. Service Layer Patterns
+
+### Service Host vs Service
+
+Platform.Bible uses a **host/proxy pattern** for cross-process services:
+
+- **Service Host** (`*-host.ts`): Runs on one process, contains actual implementation
+- **Service** (`*.service.ts`): Proxy that forwards calls to the host
+
+```
+Extension Host Process              Main Process
+┌─────────────────────┐            ┌─────────────────────┐
+│ settings.service-   │  JSON-RPC  │ settings.service.ts │
+│ host.ts             │ ◄────────► │ (proxy)             │
+│ (implementation)    │            │                     │
+└─────────────────────┘            └─────────────────────┘
+```
+
+### Main Process Services (`src/main/services/`)
+
+| Service | Purpose |
+|---------|---------|
+| `extension-host.service.ts` | Spawns and manages Extension Host process |
+| `dotnet-data-provider.service.ts` | Spawns and manages .NET process |
+| `app.service-host.ts` | App metadata and lifecycle |
+| `data-protection.service-host.ts` | Encryption/decryption |
+| `rpc-server.ts` | WebSocket JSON-RPC server |
+
+### Shared Services (`src/shared/services/`)
+
+| Service | Purpose |
+|---------|---------|
+| `network.service.ts` | JSON-RPC communication layer |
+| `network-object.service.ts` | Cross-process object exposure |
+| `command.service.ts` | Command registration and dispatch |
+| `data-provider.service.ts` | Data provider registration |
+| `settings.service.ts` | Persistent configuration |
+| `localization.service.ts` | i18n support |
+
+### Extension Host Services (`src/extension-host/services/`)
+
+| Service | Purpose |
+|---------|---------|
+| `extension.service.ts` | Extension loading and lifecycle |
+| `papi-backend.service.ts` | PAPI backend implementation |
+| `settings.service-host.ts` | Settings storage implementation |
+| `menu-data.service-host.ts` | Menu contribution management |
+| `theme-data.service-host.ts` | Theme management |
+
+---
+
+## 3. Data Provider Pattern
+
+Data providers are the primary abstraction for exposing data across processes with subscription-based updates.
+
+### Lifecycle
+
+1. **Registration**: Extension registers a data provider engine
+2. **Exposure**: Engine is wrapped and exposed as a network object
+3. **Subscription**: Consumers subscribe to data types
+4. **Updates**: Changes trigger `onDidUpdate` events to subscribers
+
+### Structure
+
+```typescript
+// Data Provider Engine (implementation)
+class MyDataProviderEngine implements IDataProviderEngine<MyDataTypes> {
+  async getBook(selector: string): Promise<BookData> { /* ... */ }
+  async setBook(selector: string, data: BookData): Promise<DataProviderUpdateInstructions<MyDataTypes>> { /* ... */ }
+}
+
+// Registration
+const myDataProvider = await papi.dataProviders.registerEngine(
+  'myExtension.myDataProvider',
+  myDataProviderEngine
+);
+```
+
+### Subscription Pattern
+
+```typescript
+// In a React component
+const [data, setData, isLoading] = useData('myExtension.myDataProvider').Book('GEN');
+
+// Manual subscription
+const unsubscribe = await papi.dataProviders.get('myExtension.myDataProvider')
+  .subscribeBook('GEN', (bookData) => { /* handle update */ });
+```
+
+### Key Files
+
+- `src/shared/services/data-provider.service.ts` - Registration and routing
+- `src/shared/models/data-provider.model.ts` - Type definitions
+- `src/shared/models/data-provider-engine.model.ts` - Engine interface
+
+---
+
+## 4. Network Objects
+
+Network objects allow any object to be exposed across process boundaries via JSON-RPC.
+
+### How It Works
+
+1. **Set**: Object is registered with a unique ID
+2. **Proxy**: Remote processes get a proxy that forwards method calls
+3. **Serialization**: Arguments and return values are JSON-serialized
+
+```typescript
+// Expose an object
+const disposable = await networkObjectService.set('myObject', {
+  async doSomething(arg: string): Promise<string> {
+    return `Processed: ${arg}`;
+  }
+});
+
+// Get from another process
+const myObject = await networkObjectService.get<MyObjectType>('myObject');
+const result = await myObject.doSomething('test'); // JSON-RPC call
+```
+
+### Limitations
+
+- **No `instanceof`**: Objects are proxies, not real instances
+- **Serializable only**: Arguments/returns must be JSON-serializable
+- **No class instances**: Don't pass class instances over the network
+- **Async only**: All method calls become async
+
+### Key Files
+
+- `src/shared/services/network-object.service.ts` - Registration and proxy creation
+- `src/shared/models/network-object.model.ts` - Type definitions
+
+---
+
+## 5. Extension/WebView Isolation
+
+### Extension Execution
+
+Extensions run in the Extension Host process, isolated from the main Electron process:
+
+```
+Extension Host Process
+┌─────────────────────────────────────────────────────┐
+│  Extension A     Extension B     Extension C        │
+│  ┌───────────┐   ┌───────────┐   ┌───────────┐     │
+│  │ main.ts   │   │ main.ts   │   │ main.ts   │     │
+│  │           │   │           │   │           │     │
+│  │ Has `papi`│   │ Has `papi`│   │ Has `papi`│     │
+│  └───────────┘   └───────────┘   └───────────┘     │
+└─────────────────────────────────────────────────────┘
+```
+
+### WebView Isolation
+
+WebViews run in isolated renderer contexts within iframes:
+
+```
+Renderer Process
+┌─────────────────────────────────────────────────────┐
+│  Platform Shell (React)                             │
+│  ┌───────────────────────────────────────────────┐  │
+│  │ Docking Framework                             │  │
+│  │  ┌──────────┐  ┌──────────┐  ┌──────────┐    │  │
+│  │  │ WebView  │  │ WebView  │  │ WebView  │    │  │
+│  │  │ (iframe) │  │ (iframe) │  │ (iframe) │    │  │
+│  │  │          │  │          │  │          │    │  │
+│  │  │ Has papi │  │ Has papi │  │ Has papi │    │  │
+│  │  └──────────┘  └──────────┘  └──────────┘    │  │
+│  └───────────────────────────────────────────────┘  │
+└─────────────────────────────────────────────────────┘
+```
+
+### Why `instanceof` Doesn't Work
+
+Objects crossing process boundaries are serialized and deserialized:
+
+```typescript
+// In Extension Host
+class MyClass { value = 42; }
+const obj = new MyClass();
+await networkObjectService.set('myObj', obj);
+
+// In Renderer - THIS FAILS
+const proxy = await networkObjectService.get('myObj');
+proxy instanceof MyClass; // false! It's a proxy, not the original
+```
+
+### PAPI as the Bridge
+
+Extensions and WebViews interact with the platform through the PAPI (Platform API):
+
+```typescript
+// Extension main.ts
+export async function activate(context: ExecutionActivationContext) {
+  const { papi } = context;
+
+  // Register commands
+  papi.commands.registerCommand('myExt.doThing', handler);
+
+  // Register data providers
+  papi.dataProviders.registerEngine('myExt.data', engine);
+
+  // Register web views
+  papi.webViewProviders.register('myExt.view', webViewProvider);
+}
+```
+
+---
+
+## 6. Process Boundaries
+
+### Import Restrictions
+
+Webpack enforces strict boundaries between processes:
+
+| Process | Can Import | Cannot Import |
+|---------|------------|---------------|
+| Main | `@main/*`, `@shared/*`, `@node/*` | `@renderer/*`, `@extension-host/*` |
+| Renderer | `@renderer/*`, `@shared/*` | `@main/*`, `@extension-host/*`, `@node/*` |
+| Extension Host | `@extension-host/*`, `@shared/*`, `@node/*` | `@main/*`, `@renderer/*` |
+
+### Shared Code Rules
+
+Code in `src/shared/` must:
+- Be process-agnostic (no Node.js or browser-specific APIs)
+- Not import from process-specific directories
+- Use platform abstractions for environment differences
+
+### Path Aliases
+
+Defined in `tsconfig.json`:
+
+```json
+{
+  "paths": {
+    "@main/*": ["src/main/*"],
+    "@renderer/*": ["src/renderer/*"],
+    "@extension-host/*": ["src/extension-host/*"],
+    "@shared/*": ["src/shared/*"],
+    "@node/*": ["src/node/*"]
+  }
+}
+```
+
+### Violation Detection
+
+Webpack will fail the build if:
+- Renderer imports from `@main/*` or `@extension-host/*`
+- Main imports from `@renderer/*`
+- Any process imports from another process's directory
+
+---
+
+## 7. Security Model
+
+Platform.Bible implements a Content Security Policy (CSP) framework to protect against malicious code execution.
+
+### Security Goals
+
+1. **Extension-Defined Code Protection**: Extension code runs in the same origin but is restricted by CSP and iframe sandbox
+2. **Third-Party Code Isolation**: Non-extension code runs in a different origin with limited communication channels
+3. **Balanced Security**: Reasonable defaults with granular configuration for advanced needs
+
+### Extension Module Restrictions
+
+Extensions run in a partially sandboxed environment with restricted module imports:
+
+| Allowed | Blocked | Alternative |
+|---------|---------|-------------|
+| `@papi/core`, `@papi/backend`, `@papi/frontend` | `fs` | `papi.storage` |
+| `@sillsdev/scripture` | `http`, `https` | `fetch` |
+| `platform-bible-utils`, `platform-bible-react` | `child_process` | `elevatedPrivileges.createProcess` |
+| `react`, `react-dom` | `util` | N/A |
+| `crypto` (backend only) | | |
+
+For complete security documentation, see [Security-Guide.md](Security-Guide.md).
+
+---
+
+## 8. Key Patterns Summary
+
+| Pattern | Description | Used For |
+|---------|-------------|----------|
+| Service Host/Proxy | Implementation in one process, proxy in others | Settings, menu data, themes |
+| Data Provider | Subscription-based data access | Project data, resources |
+| Network Object | Cross-process object exposure | Commands, services |
+| Event Emitter | Pub/sub pattern for notifications | Data updates, lifecycle events |
+| Factory | Create instances on demand | Project data provider factory |
+
+---
+
+## Related Documentation
+
+- [Security-Guide.md](Security-Guide.md) - Full security policies and module restrictions
+- [Extension-Development-Guide.md](Extension-Development-Guide.md) - Extension development patterns
+- [Paranext-Core-Patterns.md](Paranext-Core-Patterns.md) - Implementation patterns
+
+## Version Log
+
+| Version | Date       | Change          |
+| ------- | ---------- | --------------- |
+| 1.0.0   | 2026-03-04 | Initial version |

--- a/.context/standards/Code-Review-Guide.md
+++ b/.context/standards/Code-Review-Guide.md
@@ -1,0 +1,92 @@
+---
+title: Code Review Guide
+description: Code review process, Reviewable workflow, code stewards, and PR approval best practices.
+version: 1.1.0
+status: active
+created: 2026-03-04
+last_updated: 2026-06-15
+---
+
+# Code Review Guide
+
+This document outlines the code review process and best practices for Platform.Bible development.
+
+---
+
+## Review Tools
+
+The team recommends using **Reviewable** rather than GitHub's native review tools when available. Reviewable enforces completion requirements: all conversations must be resolved and every changed file must be reviewed before merging is allowed.
+
+For detailed guidelines, see the [Code Review Guide wiki](https://github.com/paranext/paranext/wiki/Code-Review-Guide).
+
+---
+
+## Reviewer Responsibilities
+
+### Comment Resolution
+
+- Reviewers manage their own comment resolutions
+- Comments default to **Blocking** status unless changed
+- Set status to **Discussing** for optional/non-blocking items (allows authors to self-resolve)
+- For non-blocking discussions, prefer Discord communication to avoid delaying merges
+
+### Code Steward Requirements
+
+Code stewards (code owners) must approve changes to their designated sections:
+- At least one code steward for each affected section must approve
+- PRs spanning multiple sections may require multiple reviewers
+- Not every steward needs to review every file, but all files must be reviewed before approval
+
+For current code steward assignments, see the [Code Stewards wiki](https://github.com/paranext/paranext/wiki/Code-Stewards).
+
+### Review Workflow
+
+1. Author submits PR and posts in `#reviews` Discord channel
+2. GitHub automatically notifies relevant code stewards
+3. Stewards react with appropriate emoji:
+   - `:code_review:` for partial reviews
+   - `:white_check_mark:` for complete reviews
+4. Process completes when all sections receive required approval
+
+---
+
+## Author Responsibilities
+
+- Merge pull requests after approval or enable auto-merge through GitHub
+- For large PRs or those expecting multiple reviewers, skip auto-merge
+- Signal completion of feedback with "Done" or explanatory comments
+- Address tangentially related suggestions via new issues rather than the current PR
+
+### Deep-linking to a file's diff
+
+To point a reviewer straight at one file's diff, use GitHub's per-file anchor on the PR's `/files` tab: it is `diff-{sha256(repo-relative-path)}`. So the link is `https://github.com/{owner}/{repo}/pull/{N}/files#diff-{hash}`, and you can append `#L42-L58` for a line range. Compute the hash portably (when `shasum`/`awk` are sandbox-blocked) with: `python3 -c "import hashlib,sys; print(hashlib.sha256(sys.argv[1].encode()).hexdigest())" "path/to/file"`.
+
+---
+
+## Auto-Merge Guidelines
+
+Use **Squash and merge** for most PRs through the GitHub UI.
+
+**Exception:** Never squash template updates or new extensions—use normal merge to preserve git history. See [Git-Guide.md](Git-Guide.md) for details.
+
+---
+
+## Community Support
+
+Request code reviews in the `#reviews` channel on the [Platform.Bible Discord server](https://discord.com/invite/platformbible).
+
+---
+
+## Related Documentation
+
+- [Code Style Guide](Code-Style-Guide.md)
+- [Git Guide](Git-Guide.md)
+- [Code Review Guide wiki](https://github.com/paranext/paranext/wiki/Code-Review-Guide)
+- [Code Stewards wiki](https://github.com/paranext/paranext/wiki/Code-Stewards)
+
+## Version Log
+
+| Version | Date       | Change                                                              |
+| ------- | ---------- | ------------------------------------------------------------------- |
+| 1.0.0   | 2026-03-04 | Initial version                                                     |
+| 1.1.0   | 2026-06-15 | De-ported the AI-Assisted-Review (porting) section for the general profile |

--- a/.context/standards/Code-Style-Guide.md
+++ b/.context/standards/Code-Style-Guide.md
@@ -1,0 +1,496 @@
+---
+title: Code Style Guide
+description: TypeScript/C# conventions, design principles, localization, component patterns, and shadcn/ui usage.
+---
+
+# Code Style Guide
+
+## Software Design and Review Principles
+
+High-level guidelines that should shape both writing and reviewing code. The top-level bullets are essential; the sub-bullets are important clarifications and examples.
+
+- **Minimize breaking changes**
+  - Avoid changes to things other developers depend on that would cause their code to stop working as expected:
+    - Package APIs (props on components in `platform-bible-react`)
+    - Extension APIs (`contributions`, functions on the PAPI)
+    - Localized strings
+    - Template features (e.g. importing WebView code with `?inline`)
+  - Non-breaking additions are usually acceptable, but consider whether the change is necessary at all.
+  - Deprecate rather than remove when possible.
+  - Sometimes a break is necessary. When it is, announce it in the [#platform-changes Discord channel](https://discord.com/channels/1064938364597436416/1136038164818034849).
+- **Consider high-level organization**
+  - Colocate related code/files when reasonable. (Exception: code running in different processes.)
+  - For `platform-bible-react`, colocate component, story, and test files together:
+    - `Button.tsx`, `Button.stories.tsx`, `Button.test.tsx`.
+  - Keep files relatively small and self-contained. Use regions to divide larger files.
+  - Don't include tidying or unrelated refactors in a feature PR. Open a separate PR.
+  - Don't duplicate code when reasonably straightforward to share.
+- **Follow existing patterns and code**
+  - Respect separation of execution environments (processes, extension/renderer). Don't pass functions or class instances over the PAPI. Don't use `instanceof` on values that may have crossed execution environments — see [MDN's note](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/instanceof#instanceof_and_multiple_realms).
+  - Prefer string unions over multiple interdependent booleans. Instead of `didError`, `isRunning`, `didComplete`, use a finite state union. This reduces contradictory states and increases flexibility.
+- **Prioritize sustainability**
+  - As the code owner, you're responsible for maintaining what you approve in your area.
+  - If you aren't comfortable with the change, don't approve it.
+  - If the impact isn't obvious from the diff, check out the branch locally and run the code.
+- **Ask for help when unsure**
+  - Necessary divergence from existing patterns, breaking changes, or foundational changes with wide-spread impact all warrant a second opinion.
+
+---
+
+## TypeScript-specific Guidelines
+
+- **Filenames and paths are _kebab-case_** to avoid case-sensitivity issues across operating systems. Use the pattern `<feature>.<type>.{ts,tsx,html,scss}`, e.g. `network-object.service.ts`. Common types: `.component.tsx`, `.hook.ts`, `.context.tsx`, `.service.ts`, `.model.ts`, `.interface.ts`, `.test.tsx`, `.e2e-test.ts`. Use `.interface.ts` for class interfaces (prefix the interface name with capital `I`) and `.model.ts` for data-shape interfaces/types.
+- **Prefer truthy/falsy checks** over `variable === undefined` — unless you specifically need `variable === undefined || variable === null` (e.g., when `0` or `""` is a valid value).
+- **Explain rule exceptions**: If you disable a lint rule for a line or file, write a comment above the disable explaining why. This saves future readers from wondering whether the rule could be re-enabled.
+- **Type declarations for reused objects**: If an object shape is used in multiple places, define a `type` for it and annotate usages — e.g. `const connectionInfo: ConnectionInfo = {...}`. This way, adding required fields surfaces errors at every usage.
+- **Types vs interfaces**: Either is acceptable. Interfaces are open (extensible after declaration) and have better error messages; types are closed and can express primitives, unions, and tuples. Use whichever fits the situation. See [this comparison](https://stackoverflow.com/questions/37233735/interfaces-vs-types-in-typescript/52682220#52682220).
+- **Clear variable names**:
+  - Functions use verbs: `getClientId`, `checkStatus`.
+  - Booleans use status words: `didFinish`, `isInitialized`, `hasPolicy`. `success` is acceptable.
+  - Avoid abbreviations that aren't widely accepted.
+  - Capitalize acronyms per [.NET capitalization conventions](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions): two-letter together (`IOStream`), longer as words (`HttpRequest`).
+- **Use comments to explain why**, not what. Don't narrate obvious code; do explain non-obvious intent or purpose.
+- **Prefer `undefined` over `null`**: [JavaScript's two concepts of nothing](https://medium.com/@hbarcelos/why-i-banned-null-from-my-js-code-and-why-you-should-too-13df90323cfa) cause confusion. Use `undefined` throughout the codebase. Confine `null` to the boundary with external APIs that require or return it.
+- **Use empty arrays over `undefined`** when an absent collection is meaningful — empty arrays are always safe to iterate.
+- **Prefer path aliases for imports**: `import ... from '<alias>/...'` over long relative paths. Webpack is configured to understand the aliases.
+- **`async/await` by default**: Use `Promise.then()` only when there's a concrete reason, and comment the reason.
+- **`throw new Error()`**, not `throw Error()`.
+- **Bundled deps belong in `devDependencies`**: Webpack bundles non-`external` imports into the final output, so those packages are `devDependencies`. See [this discussion](https://reviewable.io/reviews/paranext/paranext-core/380#-NcPBady7ifJq0YLZtwN).
+- **Prefer TSDoc over JSDoc** in TypeScript. TSDoc does not duplicate types in the comment — TypeScript already has them.
+
+---
+
+## Sanctioned TypeScript Libraries
+
+For these concerns, use the platform-provided primitive — don't reach for the popular external library. Each entry lists what to use, what to avoid, and why.
+
+- **State management** — Use `PlatformEventEmitter` plus local state objects.
+  - **Avoid:** RxJS, Redux, MobX, Zustand, signals.
+  - Lightweight and event-driven; integrates with the PAPI network model rather than introducing a parallel store.
+- **Event emitting** — Use `PlatformEventEmitter` from `platform-bible-utils`.
+  - **Avoid:** Node.js `EventEmitter`, `mitt`, `eventemitter3`.
+  - The platform implementation adds lazy init, dispose support, and subscription tracking.
+- **Async coordination** — Use `Mutex` (exclusive execution) and `AsyncVariable` (promise-based sync with a built-in timeout) from `platform-bible-utils`.
+  - **Avoid:** raw `Promise.race` for timeouts, hand-rolled lock implementations.
+  - `Mutex.runExclusive` serializes access; `AsyncVariable` resolves/rejects with timeout handling so callers don't re-implement either.
+- **Serialization of wire data** — Use `serialize()`/`deserialize()` from `platform-bible-utils` for any cross-process/network payload.
+  - **Avoid:** direct `JSON.parse`/`JSON.stringify` on wire data.
+  - These handle the `null`↔`undefined` conversion across the boundary (`undefined` → `null` on the way out, `null` → `undefined` on the way back); raw `JSON` does not, so the codebase's `undefined`-everywhere convention silently breaks.
+- **Logging** — Use `electron-log` via `logger.service.ts` (`src/shared/services/logger.service.ts`).
+  - **Avoid:** `winston`, `pino`, `bunyan`, and `console.log` in production code.
+  - Process-aware with combined file + console output, integrated with Electron. (`no-console` is enforced as an ESLint warning.)
+- **Cross-boundary errors** — Use `PlatformError` (via `newPlatformError` from `platform-bible-utils`) for errors that cross a process/network boundary.
+  - **Avoid:** plain `Error` objects across boundaries.
+  - `PlatformError` is a serializable plain object that survives iframe/JSON-RPC serialization, carries a version field, and copies the source `stack` so the trace is preserved; a raw `Error` loses its prototype and stack across the boundary.
+
+For UI styling, the sanctioned framework (TailwindCSS with the `tw:` prefix) is covered under [Theming](#theming). One addition:
+
+- **CSS / styling** — **Avoid:** CSS-in-JS (`styled-components`, `emotion`), inline styles, and CSS modules. Use the `tw:`-prefixed Tailwind utilities described in [Theming](#theming) for consistent theming and performance.
+
+---
+
+## TypeScript Module Declaration Order
+
+When creating a module, put local (non-exported) members at the top and exported members afterward, unless functionality ordering makes more sense. Put types, interfaces, and fields before functions and classes.
+
+General layout:
+
+1. Types/interfaces/fields
+2. Functions
+3. Classes
+
+Occasionally [execution order](https://typescript-eslint.io/rules/no-use-before-define/) forces exported members to come first — that's acceptable.
+
+---
+
+## Class Declaration Order
+
+1. Interface properties
+2. Public properties
+3. Private properties
+4. Interface methods
+5. Public methods
+6. Private methods
+
+Small accessors or closely-related code may deviate for readability.
+
+---
+
+## package.json Dependency Guidelines
+
+`dependencies`, `devDependencies`, and `peerDependencies` are often confused. These guidelines matter most for packages others consume (e.g., `platform-bible-react`); they matter less for application projects like `paranext-core` itself.
+
+- **`dependencies`**: packages directly imported in executable code (except `peerDependencies`) that you do NOT bundle into your distributable. Consumers of your package can independently update these to non-breaking versions.
+- **`devDependencies`**: packages used only at dev time (linting, bundling, testing), OR packages whose code you bundle into your distributable. Bundled-in `devDependencies` are frozen into your package and can't be updated by consumers.
+- **`peerDependencies`**: packages the _user_ of your package must also install (e.g., a React component library requires `react` as a peer). Whether or not you also import these directly, users need to bring their own compatible version.
+
+---
+
+## Documentation Comments
+
+### TypeScript (TSDoc)
+
+- Use TSDoc (`/** ... */`) for all public TypeScript APIs.
+- Don't include types in the comment — TypeScript already has them.
+- Follow existing patterns in `papi.d.ts` for type declarations.
+- Use `@param`, `@returns`, `@example` where appropriate.
+- For symbols at the **API surface** (definition below), follow the [API Surface TSDoc Requirements](#api-surface-tsdoc-requirements) — TSDoc must stand on its own as documentation.
+- Reference the **JSDOC SOURCE/DESTINATION** pattern (documented in [`paranext-core`'s top-level `README.md`](https://github.com/paranext/paranext-core/blob/main/README.md)) when the same TSDoc needs to appear on more than one export — e.g. a service definition and its `papi.d.ts` re-export. It is _not_ the only way TSDoc reaches `papi.d.ts`; normal TSDoc on any exported symbol is already copied through by the type generator. Use SOURCE/DESTINATION only to _share_ one comment across multiple exports.
+
+#### API Surface TSDoc Requirements
+
+Code at the public **API surface** is read by extension authors using IntelliSense in their editors and visitors to the published TypeDoc site (https://paranext.github.io/paranext-core/papi-dts). **TSDoc on these symbols must stand on its own as documentation. Assume readers cannot look up anything outside the comment itself.**
+
+**What counts as API surface (cross-boundary):**
+
+- `lib/platform-bible-react/` — every exported component, hook, type, and prop interface
+- `lib/platform-bible-utils/` — every exported function, type, and class
+- `papi.d.ts` and `lib/papi-dts/` — auto-generated from `src/`; the type generator copies TSDoc through from each exported symbol's source file (typically `src/shared/services/`, `src/shared/models/`, etc.). Edit the source TSDoc, not the generated `.d.ts`. The `JSDOC SOURCE` / `JSDOC DESTINATION` pattern (see the TypeScript bullet under [Documentation Comments](#documentation-comments)) is reserved for when one comment must appear on multiple exports
+- Extension `.d.ts` files declaring `papi-shared-types` augmentations — `CommandHandlers`, `DataProviders`, `SettingTypes`, web view options interfaces, anything other extensions can import or invoke
+- Public types in `src/shared/` consumed across processes
+
+**What does NOT count as API surface:** extension-internal helpers, `*.web-view.tsx` and `*.web-view-provider.ts` files, and component-internal exports used only within the same feature. Rich standalone TSDoc is encouraged but not required.
+
+**Required content for API-surface TSDoc:**
+
+1. **Purpose sentence** — what the symbol is and when to use it
+2. **`@param` for each parameter** — describe the _meaning_; TypeScript already carries the type
+3. **`@returns`** — what the caller receives, including units, sentinels, and edge cases (e.g. empty array for "none found", `undefined` when the input is out of range)
+4. **`@example`** — for non-trivial functions, hooks, or components
+5. **Preconditions / failure modes** — when the call throws, returns `undefined`, or behaves differently from the naive expectation
+6. **`@deprecated <date> — <replacement>`** when superseding an older API; retain the old export marked deprecated rather than deleting it
+
+### C# (XML Documentation)
+
+- Use XML documentation comments (`/// <summary>`) for public APIs.
+- Follow [Microsoft XML documentation guidelines](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/xmldoc/).
+- Include `<param>`, `<returns>`, `<exception>`, and `<example>` where helpful.
+- The API-surface TSDoc guidance above applies equivalently to public C# APIs visible across processes (e.g. data provider methods exposed via JSON-RPC) — the `///` XML doc must stand on its own.
+
+---
+
+## C#-specific Guidelines
+
+Unless stated otherwise, follow:
+
+- [Microsoft C# Coding Conventions](https://learn.microsoft.com/en-us/dotnet/csharp/fundamentals/coding-style/coding-conventions)
+- [Microsoft .NET Design Guidelines](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/)
+- [Unit testing best practices](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices)
+
+---
+
+## Code Patterns We Use
+
+- **Early Return (Guard Clauses)** — see [this explanation](https://gomakethings.com/the-early-return-pattern-in-javascript/#what-is-the-early-return-pattern). Always add a blank line after an early return to visually separate it.
+- **[Get/Set/Reset for Value Stores](https://github.com/paranext/paranext/wiki/Get,-Set,-Reset-Pattern-for-Value-Stores)**.
+
+---
+
+## Editor Guidelines
+
+- The team primarily uses [VS Code](https://code.visualstudio.com/). Other editors work, but VS Code has the most integration support.
+- Prefer `npm` scripts over editor-specific build configuration. That way a script works in or out of VS Code.
+- To add a word to the [CSpell](https://cspell.org/) dictionary, use VS Code's Quick Fix → `Add: "<word>" to config: paranext-core/cspell.json`. This keeps the entries alphabetized.
+
+---
+
+## Localized Strings Guidelines
+
+- **Reuse vs new key**: Decide whether to reuse an existing localized string key or create a new one.
+  1. If the existing key is deprecated, use its replacement (if any) and re-evaluate.
+  2. If the texts are not exactly the same, make separate keys.
+  3. If the two uses might diverge in another language, make separate keys.
+  4. If the two uses serve the same purpose _and_ mean the same thing, reuse.
+- **Name keys by purpose, not by English text**: The key `%platformScriptureEditor_dialog_openResourceViewer_prompt%` tells a reader what the string is for. Embedding the English text into the key obscures that.
+- **Alphabetize** localized string key files.
+- **Don't change or remove localized string keys** — existing uses across other repositories may break. Instead, create a new key. If all known uses of an old key are migrated, mark the old key [deprecated](https://github.com/paranext/paranext-core/blob/197c0893752324fbb587c50e2f98699969cf39cc/assets/localization/metadata.json#L13).
+- **Don't change a string's meaning.** You can fix grammar or punctuation. If the meaning changes, create a new key.
+- **Concatenate with format strings**, not string concatenation, unless you're joining with a newline. This lets translators rearrange the pieces for their language.
+- **Be careful with counts and ordinals** — plural forms and ordinals localize very differently across languages. Prefer phrasings like "Puppies: 1" over "1 puppy".
+- **Use "..." on menu items that open a dialog**. E.g., "Send/Receive projects..." opens a dialog; "Send/Receive this project" primarily acts, even if it also shows a dialog.
+- **Never compare variables against hardcoded English strings**:
+
+  ```typescript
+  // ❌ Comparing against hardcoded English
+  if (status === "Loading...") { ... }
+  if (tabName === "General") { ... }
+  if (errorMessage.includes("not found")) { ... }
+
+  // ✅ Use constants or enums
+  if (status === LoadingStatus.Loading) { ... }
+  if (tabId === TabId.General) { ... }
+  if (errorCode === ErrorCode.NotFound) { ... }
+
+  // ✅ Or compare by localization key
+  if (statusKey === '%status_loading%') { ... }
+  ```
+
+  This applies to conditional logic, array filtering/finding, and string includes/matching.
+
+---
+
+## Component Usage and Creation
+
+Platform.Bible prioritizes intentional component selection based on **YAGNI** ("You aren't gonna need it"). Prefer a small set of consistently-deployed components over a proliferation of one-offs.
+
+### Selection Framework
+
+Before creating a new component:
+
+1. Can an existing `platform-bible-react` component meet the requirement? Use it.
+2. Should an existing component be enhanced to cover the new case?
+3. Can you build on `platform-bible-react`, Shadcn, or Radix? Prefer these over external libraries.
+4. Only then, consider an external library — and only if it meets quality and licensing standards.
+
+### Theming
+
+- Use **TailwindCSS** with the `tw:` prefix (configured via `@import 'tailwindcss/...' ... prefix(tw)` in `src/index.css`).
+- Use semantic color variables (e.g., `tw:bg-card`) instead of hardcoded colors.
+- Add `pr-twp` at the top level of components to apply scoped Tailwind Preflight.
+
+### RTL/LTR Support
+
+Components must support both text directions:
+
+- Use logical properties (`start`/`end`) instead of directional properties (`left`/`right`).
+- E.g., `margin-inline-start` instead of `margin-left`.
+
+### Preview App
+
+```bash
+cd lib/platform-bible-react
+npm start
+```
+
+For complete guidelines, see the [Component usage and creation wiki](https://github.com/paranext/paranext/wiki/Component-usage-and-creation).
+
+### Rebuild `platform-bible-react` After Editing Its Sources
+
+Extensions (and the renderer) import `platform-bible-react` as a package — type resolution goes through the **committed build artifact** `lib/platform-bible-react/dist/index.d.ts`, not the library's source. If you add a prop, export, or change a type under `lib/platform-bible-react/src/`, extension typechecks will still see the **old** types until you rebuild:
+
+```bash
+cd lib/platform-bible-react
+npm run build:basic   # tsc → vite build → dts-bundle-generator
+```
+
+`build:basic` is the fast path (the full `npm run build` also runs lint-fix and typedoc). Re-run it whenever the library's public surface changes.
+
+Symptoms when you forget:
+- Extension `npm run typecheck` reports a prop or export as missing that you just added.
+- `npm run build` (transpile-only webpack) may succeed misleadingly — the library's changes compile fine, but consumers fail type-checking against the stale `.d.ts`.
+
+The rebuilt `dist/` changes are normally part of the same PR that changes the library source.
+
+---
+
+## shadcn/ui Guidelines
+
+### Folder
+
+All shadcn/ui components live in `lib/platform-bible-react/src/components/shadcn-ui/`. Each file is a single shadcn component (e.g. `button.tsx`, `dialog.tsx`) copied directly from the [shadcn/ui](https://ui.shadcn.com) boilerplate and then customized in place. The folder also contains `CUSTOMIZATIONS.md`, an AI-generated snapshot of all customizations made relative to the boilerplate.
+
+### Boilerplate baseline
+
+When a shadcn component is first added to the repo, it should be committed as-is from the shadcn boilerplate in a standalone commit — no customizations yet. This "add" commit becomes the boilerplate baseline. All subsequent commits on that file are customizations. This convention lets tooling (and AI agents) diff the current file against the baseline commit to discover every customization ever made, including ones that were never annotated with a comment.
+
+### `// CUSTOM:` annotation convention
+
+Every customization to a shadcn component **must** be annotated with a `// CUSTOM:` comment placed immediately before the changed code. The comment must explain:
+
+- **What** was changed (be specific — name the class, prop, or element)
+- **What** the change does
+- **Why** it was made
+
+Example:
+
+```tsx
+// CUSTOM: Changed tw:p-1 to tw:p-2 to add additional padding according to UX specifications
+```
+
+The `// CUSTOM:` prefix makes customizations machine-readable and easy to audit when upgrading shadcn to a new version.
+
+### Standard customizations
+
+Every shadcn component in this folder must have two standard customizations applied (for ease of tracking, they should have `// CUSTOM:` comments even though they are standard):
+
+#### 1. `pr-twp` on DOM-rendered components
+
+Add `pr-twp` at the **front** of the base Tailwind class string for every component that renders actual DOM output. This applies the [scoped Tailwind Preflight](https://www.npmjs.com/package/tailwindcss-scoped-preflight) correctly wherever the component is used.
+
+- **Applies to**: components whose props include `HTMLDivElement`, `HTMLButtonElement`, etc., use `React.ComponentPropsWithoutRef<...>` or `React.HTMLAttributes<...>`, or are declared with `React.forwardRef<HTMLSomeElement, ...>`.
+- **Does not apply to**: compound root components that coordinate state without rendering DOM (e.g. `Dialog`, `Popover` roots), or cva variant factories (these are functions, not components).
+
+#### 2. TSDocs with library links on all exports
+
+Every exported symbol (components, interfaces, types, constants) must have a TSDoc comment (`/** ... */`) that includes a hyperlink to the upstream library page for that component. Required links depend on what the file imports:
+
+- shadcn/ui boilerplate → link to the [shadcn/ui component page](https://ui.shadcn.com/docs/components/)
+- `@radix-ui/*` imports → link to the [Radix UI primitive page](https://www.radix-ui.com/primitives/docs/overview/introduction)
+- `vaul` → link to [Vaul docs](https://vaul.emilkowal.ski/)
+- Other notable upstream libraries → link to their docs
+
+To get the canonical shadcn/ui docs and examples link for a component, run:
+
+```bash
+npx shadcn docs <component> --json
+```
+
+Example output for `button`:
+
+```json
+{
+  "results": [
+    {
+      "component": "button",
+      "links": {
+        "docs": "https://ui.shadcn.com/docs/components/radix/button",
+        "examples": "https://raw.githubusercontent.com/shadcn-ui/ui/refs/heads/main/apps/v4/registry/bases/radix/examples/button-example.tsx"
+      }
+    }
+  ]
+}
+```
+
+Use the `docs` URL as the shadcn/ui link in the TSDoc. For Radix UI links, you still need to search [radix-ui.com/primitives](https://www.radix-ui.com/primitives/docs/overview/introduction) manually.
+
+A TSDoc that uses `@inheritdoc <Symbol>` pointing to a symbol whose TSDoc already has the required links counts as passing.
+
+### Consult UX for visual changes
+
+UX has a defined understanding of what shadcn components look like. When changing how a component looks (colors, spacing, layout, variants), discuss with UX before committing. Standard customizations (`pr-twp`, TSDocs) do not require UX review.
+
+---
+
+## Storybook MDX Guidelines
+
+`.mdx` files used by Storybook are excluded from Prettier (MDX v3 is not supported). No formatter runs on them — indentation is purely manual. Follow these conventions to stay consistent and avoid merge conflicts.
+
+### JSX inside prop expressions
+
+**Inline form** — use when the JSX is a single element that fits on one line:
+
+```mdx
+preview={<Button>Save</Button>}
+```
+
+**Block form** — use for multi-element or multi-line JSX. The root element starts at **2 spaces from the left margin** (the project's standard tab width), each nested level adds 2 more spaces, and the closing `}` returns to column 0:
+
+```mdx
+preview={
+  <TooltipProvider>
+    <Tooltip open>
+      <TooltipTrigger asChild>
+        <Button>Save</Button>
+      </TooltipTrigger>
+      <TooltipContent side="bottom">Save</TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+}
+```
+
+Do **not** write JSX flush-left inside a block form, and do **not** align it to the surrounding prop's indentation depth — neither style survives the next person who edits the file and neither reflects the project convention.
+
+> **Note for LLMs and editors:** Prettier does not run on `.mdx` files in this repo. When you edit an `.mdx` file, preserve the indentation style above exactly. Do not reformat JSX blocks to flush-left, do not align them to the enclosing prop's column, and do not add or remove blank lines between sibling JSX elements inside a prop expression.
+
+---
+
+## Shared Utilities and Common Code
+
+**Parsing methods and scripture-related utilities are common code** and should NOT be added directly in new extension or data provider code. These include:
+
+- Scripture reference parsing (book/chapter/verse extraction)
+- Localized book name lookups
+- Arrays or constants of all Bible books
+- USJ/USFM manipulation
+- Any scripture-specific string parsing
+
+### Decision Framework
+
+Before creating utility functions:
+
+1. **Check `platform-bible-utils` first**:
+   - `lib/platform-bible-utils/src/scripture/` — scripture utilities
+   - `lib/platform-bible-utils/src/string-util.ts` — string manipulation
+   - `lib/platform-bible-utils/src/index.ts` — all public exports
+2. If it exists, use it — import from `platform-bible-utils`.
+3. If it doesn't exist, create it in the appropriate shared location (see Placement below).
+
+### Utility Placement
+
+```
+Is this logic specific to ONE feature's unique domain model?
+├─ YES → Feature directory (rare — justify it)
+└─ NO → Shared location:
+
+    C# Utilities:
+    ├─ Project operations     → c-sharp/Projects/
+    ├─ Scripture/verse logic  → c-sharp/Scripture/ (or ParatextUtils/)
+    ├─ Settings/configuration → c-sharp/Services/
+    ├─ JSON/serialization     → c-sharp/JsonUtils/
+    ├─ Checks/validation      → c-sharp/Checks/
+    └─ General helpers        → c-sharp/ (root or new domain folder)
+
+    TypeScript Utilities:
+    ├─ Scripture functions    → lib/platform-bible-utils/src/scripture/
+    ├─ String/data utilities  → lib/platform-bible-utils/src/
+    ├─ React hooks            → lib/platform-bible-react/src/hooks/
+    ├─ PAPI hooks             → src/renderer/hooks/papi-hooks/
+    └─ Shared extension code  → extensions/src/common/
+```
+
+### Adding to `platform-bible-utils` (ask first)
+
+Adding public API to `platform-bible-utils` is a load-bearing decision. Before creating new files there:
+
+1. **Pause and ask for user confirmation.**
+2. **List what already exists** in the relevant area.
+3. **Explain the proposed addition** and where it would fit.
+4. **Wait for approval** before creating new files or functions.
+
+After adding code to `platform-bible-utils`:
+
+1. Update `lib/platform-bible-utils/src/index.ts` with the new public exports.
+2. Build:
+   ```bash
+   cd lib/platform-bible-utils
+   npm run build
+   ```
+3. Verify new exports are accessible from the package.
+
+### Unit Tests for Utilities
+
+Always add unit tests with example-based cases for any parsing method or utility:
+
+- Co-locate: `{utility-name}.test.ts` next to `{utility-name}.ts`.
+- Document expected behavior with example inputs and outputs.
+- Cover edge cases (empty strings, invalid input, boundary conditions).
+- Follow patterns from existing tests like `scripture-util.test.ts`.
+
+### Regular Expressions
+
+Every regex in the codebase should have:
+
+1. **Example-based unit tests** — at least 5 cases covering valid matches and invalid non-matches.
+2. **A comment explaining what it matches and why.** Magic regexes without explanation are very hard to maintain.
+
+Example:
+
+```typescript
+describe('projectNamePattern', () => {
+  it.each(['ABC', 'Test123', 'My_Project'])('accepts: %s', (name) => {
+    expect(projectNamePattern.test(name)).toBe(true);
+  });
+  it.each(['', '123', 'a b c', 'CON'])('rejects: %s', (name) => {
+    expect(projectNamePattern.test(name)).toBe(false);
+  });
+});
+```
+
+---
+
+## Related Documentation
+
+- [Git-Guide.md](Git-Guide.md) — branch and merge practices
+- [Testing-Guide.md](Testing-Guide.md) — testing infrastructure
+- [Security-Guide.md](Security-Guide.md) — CSP and sandboxing
+- [Component usage and creation wiki](https://github.com/paranext/paranext/wiki/Component-usage-and-creation)

--- a/.context/standards/Component-Builder-Patterns.md
+++ b/.context/standards/Component-Builder-Patterns.md
@@ -1,0 +1,631 @@
+---
+title: Component Builder Patterns Reference
+description: Reference patterns and examples for building React UI components — file naming, structure, shadcn/ui conventions.
+version: 1.4.1
+status: active
+created: 2026-03-04
+last_updated: 2026-05-11
+toc: true
+---
+
+# Component Builder Patterns Reference
+
+This is a reference document containing patterns and examples for building Platform.Bible UI components.
+
+<!-- TOC:BEGIN -->
+<!-- | Line | Section | -->
+<!-- | --- | --- | -->
+<!-- | 36 | File Naming Conventions | -->
+<!-- | 52 | TypeScript & Build Configuration | -->
+<!-- | 88 | Web View Provider Patterns | -->
+<!-- | 180 | PAPI Integration Patterns | -->
+<!-- | 246 | Styling Patterns | -->
+<!-- | 287 | Localization Patterns | -->
+<!-- | 413 | EXPLANATION Comments for Complex Logic | -->
+<!-- | 483 | Common Component Patterns | -->
+<!-- | 511 | Debounce Usage Guidelines | -->
+<!-- | 542 | Controlled Radix Popover with Custom Outside-Pointer Handler | -->
+<!-- | 587 | Disabled Button with Tooltip Pattern | -->
+<!-- | 609 | Test File Patterns | -->
+<!-- | 654 | Reference Extensions | -->
+<!-- | 667 | Design Reference Resources | -->
+<!-- | 674 | Visual Review | -->
+<!-- | 678 | Version Log | -->
+<!-- TOC:END -->
+
+## File Naming Conventions
+
+Use kebab-case for all file names with the appropriate suffix:
+
+| Type      | Pattern                               | Example                        |
+| --------- | ------------------------------------- | ------------------------------ |
+| Web View  | `{feature-name}.web-view.tsx`         | `find.web-view.tsx`            |
+| Provider  | `{feature-name}.web-view-provider.ts` | `find.web-view-provider.ts`    |
+| Component | `{component-name}.component.tsx`      | `search-result.component.tsx`  |
+| Hook      | `use-{hook-name}.hook.ts`             | `use-project-settings.hook.ts` |
+| Types     | `{extension-name}.d.ts`               | `platform-scripture.d.ts`      |
+| Styles    | `{feature-name}.web-view.scss`        | `find.web-view.scss`           |
+| Tests     | `{feature-name}.test.tsx`             | `find.test.tsx`                |
+
+---
+
+## TypeScript & Build Configuration
+
+### Extension `tsconfig.json`
+
+Reference: `extensions/src/platform-scripture/tsconfig.json`. Each extension's `tsconfig.json` `typeRoots` must use **`../../../`** relative paths (the extension is three directories deep under `paranext-core/extensions/src/{ext}/`). Including:
+
+- `../../../node_modules/@types` — default type declarations
+- `../../../lib` — `papi-dts` type declarations (for `papi.d.ts`)
+- `../../../extensions/src` — sibling extensions' type declarations
+- `src/types` — this extension's own `.d.ts`
+
+Do **not** use `../paranext-core/...` — that's a path from outside the repo and will silently miss type roots.
+
+### Required `typecheck` script
+
+Each extension's `package.json` MUST declare:
+
+```json
+"scripts": {
+  "typecheck": "tsc -p ./tsconfig.json"
+}
+```
+
+Without it, the repo-wide `npm run typecheck` silently skips that extension. When building UI components, run `npx tsc --noEmit -p extensions/src/{ext}/tsconfig.json` per extension after creating or modifying files.
+
+### `npm run build` does NOT typecheck
+
+Webpack is configured to skip type checking for speed:
+
+- **Renderer / main**: `ts-loader` with `transpileOnly: true` (`.erb/configs/webpack.config.base.ts`)
+- **Extensions**: `swc-loader` (no type checking at all — `extensions/webpack/webpack.config.base.ts`)
+
+A successful `npm run build` therefore guarantees nothing about type safety. Always run per-extension `tsc --noEmit` (or repo-wide `npm run typecheck`) before declaring work done. CI runs typecheck separately, so untyped code that "builds locally" will block the PR.
+
+---
+
+## Web View Provider Patterns
+
+Every extension web view requires two files:
+
+### Web View Component (`{feature}.web-view.tsx`)
+
+```typescript
+import { WebViewProps } from '@papi/core';
+import { Button, Card, cn } from 'platform-bible-react';
+import './feature-name.web-view.scss'; // Optional SCSS
+
+// IMPORTANT: Use `global.webViewComponent` (NOT `globalThis.webViewComponent`)
+// `globalThis` causes TypeScript strict mode errors
+global.webViewComponent = function FeatureWebView({
+  projectId,
+  useWebViewState,
+  useWebViewScrollGroupScrRef,
+}: WebViewProps) {
+  // Component implementation using platform-bible-react components
+  return (
+    <div className={cn('tw:flex tw:flex-col tw:gap-2')}>
+      {/* Your UI here */}
+    </div>
+  );
+};
+```
+
+### Web View Provider (`{feature}.web-view-provider.ts`)
+
+```typescript
+import { IWebViewProvider, WebViewDefinition } from '@papi/core';
+import featureWebView from './feature-name.web-view.tsx?inline';
+import tailwindStyles from './tailwind.css?inline';
+
+export class FeatureWebViewProvider implements IWebViewProvider {
+  async getWebView(
+    savedWebView: WebViewDefinition,
+    options: FeatureWebViewOptions,
+  ): Promise<WebViewDefinition> {
+    return {
+      ...savedWebView,
+      title: 'Feature Title',
+      content: featureWebView,
+      styles: tailwindStyles,
+      projectId: options.projectId,
+    };
+  }
+}
+```
+
+**Note:** Use `?inline` imports for content and styles in providers.
+
+### Custom Web View Options
+
+When a web view accepts custom options (project IDs, mode flags, etc.), declare a typed interface that **extends `OpenWebViewOptions`** — do not pass an inline object literal.
+
+```typescript
+import type { OpenWebViewOptions } from '@papi/core';
+
+export interface FeatureWebViewOptions extends OpenWebViewOptions {
+  projectId?: string;
+  mode?: 'edit' | 'review';
+}
+
+// At the call site, pass a typed variable — not an inline literal:
+const options: FeatureWebViewOptions = { projectId, mode: 'edit' };
+await papi.webViews.openWebView(FEATURE_WEB_VIEW_TYPE, undefined, options);
+```
+
+Reference implementations: `extensions/src/platform-scripture/src/find.web-view-provider.ts`, `extensions/src/platform-scripture/src/checks-side-panel.web-view-provider.ts`, `extensions/src/platform-scripture-editor/src/main.ts`.
+
+---
+
+## PAPI Integration Patterns
+
+### Standard imports for extension web views
+
+```typescript
+import {
+  Button,
+  Card,
+  CardContent,
+  Badge,
+  cn,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from 'platform-bible-react';
+import { SomeIcon } from 'lucide-react';
+```
+
+### Component Usage Guidelines
+
+**Always import from `platform-bible-react`:**
+
+- Generic UI: Button, Card, Dialog, Input, Checkbox, Label, Badge, Alert, Tooltip, Popover, etc.
+- Complex components: DataTable, Inventory, CommentList, Editor, ScriptureResultsViewer, etc.
+- Utilities: `cn()` for class composition
+- Hooks: `useEvent`, `usePromise`, `useEventAsync`
+- Icons: Import from `lucide-react`
+
+**Create locally only when:**
+
+- Building domain-specific compositions that combine multiple library components
+- Adding custom logic specific to the extension's domain
+- Example: `CheckCard` that combines Badge + Tooltip + ResultsCard with check-specific logic
+
+### `ComboBox` Option Shape
+
+`ComboBox` does **not** take `{ label, value }[]` — that's the most common wrong guess. The accepted option type is:
+
+```typescript
+type ComboBoxOption = string | number | ComboBoxLabelOption;
+type ComboBoxLabelOption = { label: string; secondaryLabel?: string };
+// Note: NO `value` field. The option's identity IS its label/string/number.
+```
+
+So pass either an array of plain strings/numbers, or an array of `{ label, secondaryLabel? }` objects. If you need a separate machine value, look up the selected option by label in your local data.
+
+```typescript
+// String options — simplest case
+<ComboBox options={['Genesis', 'Exodus', 'Leviticus']} value={book} onChange={setBook} />
+
+// Label objects — when you want a secondary line of text under each option
+<ComboBox
+  options={[
+    { label: 'Genesis', secondaryLabel: 'GEN' },
+    { label: 'Exodus', secondaryLabel: 'EXO' },
+  ]}
+  value={selected}
+  onChange={setSelected}
+/>
+```
+
+Source: `lib/platform-bible-react/src/components/basics/combo-box.component.tsx`.
+
+---
+
+## Styling Patterns
+
+### Primary Approach: Tailwind CSS with `tw:` prefix
+
+```typescript
+// Tailwind with tw: prefix (primary approach)
+<div className="tw:flex tw:flex-col tw:gap-4 tw:p-4">
+
+// Conditional classes with cn()
+import { cn } from 'platform-bible-react';
+<div className={cn('tw:flex tw:gap-2', { 'tw:hidden': !visible })}>
+
+// Using platform-bible-react components
+import { Button, Card, CardContent, Input, Label } from 'platform-bible-react';
+<Card>
+  <CardContent>
+    <Label htmlFor="name">Name</Label>
+    <Input id="name" />
+    <Button variant="default">Submit</Button>
+  </CardContent>
+</Card>
+```
+
+### Styling Rules (Enforced by ESLint)
+
+These patterns are enforced by linting rules:
+
+| Prohibited | Allowed | Rule |
+|------------|---------|------|
+| Hardcoded colors (`tw:bg-black`, `tw:text-white`, `#fff`) | Theme tokens (`tw:bg-background`, `tw:text-foreground`) | `paranext/no-hardcoded-tailwind-colors` |
+| Shadow classes (`tw:shadow*`) | (Disallowed in AI-authored extension/web-view code via the AI-strict lint config; the platform-bible-react shadcn-ui components themselves do use shadows like `tw:shadow-md`) | `paranext/no-tailwind-shadows` |
+
+**Theme tokens to use**:
+- Backgrounds: `tw:bg-background`, `tw:bg-muted`, `tw:bg-primary`, `tw:bg-secondary`
+- Text: `tw:text-foreground`, `tw:text-muted-foreground`, `tw:text-destructive`
+- Borders: `tw:border-border`, `tw:border-input`, `tw:border-primary`
+
+See [Code-Style-Guide.md](Code-Style-Guide.md#theming) for details.
+
+---
+
+## Localization Patterns
+
+**Reference implementation**: `extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx`
+
+### Define Localized String Keys
+
+```typescript
+// {feature}.utils.ts
+import { LocalizeKey } from 'platform-bible-utils';
+
+export const LOCALIZED_STRINGS: LocalizeKey[] = [
+  '%webView_{feature}_title%',
+  '%webView_{feature}_submitButton%',
+  '%webView_{feature}_cancelButton%',
+  '%webView_{feature}_loadingMessage%',
+  // Add ALL user-facing strings
+];
+```
+
+### Use the useLocalizedStrings Hook
+
+```typescript
+import { useLocalizedStrings } from '@papi/frontend/react';
+import { useMemo } from 'react';
+import { LOCALIZED_STRINGS } from './{feature}.utils';
+
+global.webViewComponent = function FeatureWebView({ ... }: WebViewProps) {
+  const [localizedStrings] = useLocalizedStrings(useMemo(() => LOCALIZED_STRINGS, []));
+
+  return (
+    <div>
+      <h1>{localizedStrings['%webView_{feature}_title%']}</h1>
+      <Button>{localizedStrings['%webView_{feature}_submitButton%']}</Button>
+    </div>
+  );
+};
+```
+
+**Return type gotcha**: `useLocalizedStrings` returns `[localizedStrings: LocalizationData, isLoading: boolean]`. `LocalizationData` aliases `LanguageStrings`, whose keys are `LocalizeKey` (i.e. `` `%${string}%` ``) — **not** plain `Record<string, string>`. Index lookups must use the `%key%` form (`localizedStrings['%webView_foo_title%']`); typing the variable as `Record<string, string>` will compile via `any` but breaks IDE completion and type-checks. Source: `src/renderer/hooks/papi-hooks/use-localized-strings-hook.ts` and `lib/platform-bible-utils/src/extension-contributions/localized-strings.model.ts`.
+
+### Add Translations to localizedStrings.json
+
+```json
+{
+  "localizedStrings": {
+    "en": {
+      "%webView_{feature}_title%": "Feature Title",
+      "%webView_{feature}_submitButton%": "Submit",
+      "%webView_{feature}_cancelButton%": "Cancel"
+    },
+    "es": {
+      "%webView_{feature}_title%": "Titulo de la funcion",
+      "%webView_{feature}_submitButton%": "Enviar",
+      "%webView_{feature}_cancelButton%": "Cancelar"
+    }
+  }
+}
+```
+
+### Conventions
+
+- Key format: `%webView_{feature}_{elementDescription}%`
+- Use ellipsis (`...`) for items that open dialogs: "New Project..."
+- Always provide BOTH English (`en`) AND Spanish (`es`) translations
+
+### Dynamic Values with formatReplacementString
+
+```typescript
+import { formatReplacementString } from 'platform-bible-utils';
+
+const message = formatReplacementString(
+  localizedStrings['%webView_{feature}_resultsCount%'], // "{count} results found"
+  { count: results.length }
+);
+```
+
+### Localized Accessibility Attributes
+
+All accessibility attributes with user-facing text MUST be localized:
+
+```typescript
+// BAD - hardcoded English in accessibility
+<Input aria-label="Search projects" />
+<Button aria-label="Close dialog" />
+
+// GOOD - localized accessibility
+<Input aria-label={localizedStrings['%search_ariaLabel%']} />
+<Button aria-label={localizedStrings['%dialog_close_ariaLabel%']} />
+```
+
+**Enforced by ESLint**: `paranext/require-localized-aria`
+
+### Reuse Existing Strings
+
+Before creating new keys, scan the extension's `localizedStrings.json` for existing strings:
+
+```bash
+grep -i "cancel\|ok\|save\|close\|submit\|error\|loading" \
+  extensions/src/{ext}/contributions/localizedStrings.json
+```
+
+Common reusable keys: `%general_cancel%`, `%general_ok%`, `%general_save%`, `%general_close%`, `%general_loading%`
+
+### Existing Strings Are Immutable
+
+**NEVER modify existing key/value pairs.** If a string needs replacement:
+
+1. Create a NEW key with the desired value
+2. Add a fallback mapping in the `metadata` section:
+
+```json
+{
+  "metadata": {
+    "%oldKey_toReplace%": {
+      "fallbackKey": "%newKey_withCorrectValue%"
+    }
+  },
+  "localizedStrings": {
+    "en": { "%newKey_withCorrectValue%": "Correct text" },
+    "es": { "%newKey_withCorrectValue%": "Texto correcto" }
+  }
+}
+```
+
+---
+
+## EXPLANATION Comments for Complex Logic
+
+For functions that are >30 lines or contain regexes, place an `EXPLANATION:` block as `//` line comments **alongside the implementation** — inside the function body for normal functions, or directly above a class-level constant (e.g. a regex pattern field) when the constant *is* the algorithm — never inside TSDoc. Consumers reading the API surface don't need internals; future maintainers reading the implementation do.
+
+```typescript
+/**
+ * Sorts projects for display in the dropdown. Returns a new array; input
+ * is not mutated.
+ */
+export function sortProjects(projects: ProjectInfo[]): ProjectInfo[] {
+    // EXPLANATION:
+    // This sorting algorithm orders projects in the dropdown:
+    // 1. Active projects first, sorted alphabetically
+    // 2. Archived projects second, sorted by last modified date
+    // 3. Resources last, sorted by type then name
+
+    // Implementation
+}
+```
+
+---
+
+## Common Component Patterns
+
+### Grid/Table Components (Checklists, Parallel Passages)
+
+- Use virtualization for lists > 100 items
+- Implement row selection with visual feedback
+- Handle column sorting and filtering
+- Support full keyboard navigation (arrow keys, Enter, Escape)
+- Manage focus correctly when rows are added/removed
+
+### Form Components (Project Settings)
+
+- Use controlled inputs exclusively
+- Implement validation with clear error messages
+- Display error states adjacent to invalid fields
+- Handle submit/cancel with loading states
+- Track dirty state to warn on unsaved changes
+
+Any state that flips a loading/spinner flag true (`setIsLoading(true)`) must clear it to false on **every** exit path — success, early return, and the catch/error path — or the component hangs in a spinner forever; the codebase idiom is a `try`/`finally` that calls `setIsLoading(false)` in the `finally` block, guarded by a mounted-ref check so it doesn't set state on an unmounted component (see `use-inventory.ts`, `registration-form.component.tsx`).
+
+### Dialog Components (Conflict Resolution)
+
+- Manage modal overlay with proper z-index
+- Implement focus trapping within dialog
+- Handle Escape key to close
+- Disable action buttons during processing
+- Return focus to trigger element on close
+
+---
+
+## Debounce Usage Guidelines
+
+**When to use debounce:**
+- Search-as-you-type that triggers API calls
+- Autocomplete suggestions
+- Input that updates expensive derived calculations
+- Typing in a shared/synchronized view
+
+**When NOT to use debounce:**
+- Input in a modal dialog (user will click OK/Submit anyway)
+- Immediate local state updates
+- Toggle switches and checkboxes
+- Selections from dropdowns
+
+**Typical debounce values:**
+- Search/autocomplete: 300-500ms
+- Validation: 200-300ms
+
+```typescript
+// Use debounce for search in a main view
+const debouncedSearch = useDebouncedCallback(
+  (query: string) => papi.commands.sendCommand('search', query),
+  300
+);
+
+// DON'T debounce in a dialog - user will click Submit
+const handleNameChange = (name: string) => setProjectName(name);
+```
+
+---
+
+## Wire UI to Real PAPI — No Stubbing
+
+A web view's data providers and submit handlers must call the real `papi.commands.sendCommand` (or `papi.dataProviders` / `usePromise` over real commands) backed by actual backend services. Do **not** ship a component wired to mocked/stubbed PAPI, and do **not** substitute hardcoded arrays, static objects, or `// TODO` placeholders for data that is supposed to come from PAPI — that produces a UI that demos green but is dead in the running app.
+
+If the backend functionality a handler needs is genuinely out of scope, leave the call site wired and mark it clearly as DEFERRED (with the missing command named) rather than faking the data — so the gap is visible instead of hidden behind a plausible-looking stub.
+
+---
+
+## Controlled Radix Popover with Custom Outside-Pointer Handler
+
+### When this pattern applies
+
+Most `<Popover>` / `<DropdownMenu>` consumers can rely on Radix's defaults: the trigger toggles, outside clicks dismiss, no custom handlers needed. You only end up writing a custom `onPointerDownOutside` handler when you also need a "user clicked the trigger to close while we're already open" interlock — a flag the trigger's `onClick` reads to call `event.preventDefault()`, suppressing Radix's `onOpenToggle` and preventing it from re-opening the popover that was just closed by the outside-pointer path.
+
+That interlock pattern is how you avoid the "controlled state lags React render → click re-toggles → popover flickers back open" race in a fully-controlled `<Popover open={…} onOpenChange={…}>`.
+
+### The bug to avoid
+
+If you write that handler but **don't guard it with your controlled-open state**, it fires during the fade-out animation cleanup window after the popover has already closed:
+
+- Radix keeps `PopoverContent` mounted during the close animation (so `tw:data-[state=closed]:fade-out-0` can play).
+- During that cleanup window, `onPointerDownOutside`, `onInteractOutside`, and `onFocusOutside` are all still attached.
+- If the user clicks the trigger to **re-open** before the fade-out finishes, your handler still sees a pointerdown on the trigger, treats it as "user wants to close again", sets the interlock flag — and the legitimate reopen click is dropped by `preventDefault()` in the trigger's `onClick`.
+
+### Correct pattern
+
+Guard the handler with the controlled-open state your component owns. The same fix applies to `onInteractOutside` and `onFocusOutside` if you've attached custom handlers to them too.
+
+```tsx
+// `open` is your controlled state, `triggerRef` points at your trigger element,
+// `triggerJustClosedRef` is the interlock flag your trigger's onClick reads.
+<PopoverContent
+  // ...
+  onPointerDownOutside={(event) => {
+    if (
+      open &&  // ← only act while logically open; skip the fade-out window
+      triggerRef.current &&
+      event.target instanceof Node &&
+      triggerRef.current.contains(event.target)
+    ) {
+      triggerJustClosedRef.current = true;
+      setOpen(false);
+    }
+  }}
+>
+```
+
+### Reference incident
+
+Fixed in `lib/platform-bible-react/src/components/advanced/book-chapter-control/book-chapter-control.component.tsx` (markers-checklist branch). The four story interaction tests `Smart Parsing Demo`, `Book Search And Navigation`, `Single Chapter Book Demo`, and `Comprehensive Interaction Test` were all red and went green with the one-condition guard. Investigation writeup: paranext/ai-prompts#210; fix landed via paranext/paranext-core#2219.
+
+---
+
+## Disabled Button with Tooltip Pattern
+
+**CRITICAL:** Wrap disabled buttons in `<span>` - disabled elements don't fire mouse events.
+
+```typescript
+import { Button, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'platform-bible-react';
+
+// Wrap disabled button in span so tooltip works
+<TooltipProvider>
+  <Tooltip>
+    <TooltipTrigger asChild>
+      <span>
+        <Button disabled>Choose...</Button>
+      </span>
+    </TooltipTrigger>
+    <TooltipContent>This feature is not yet available</TooltipContent>
+  </Tooltip>
+</TooltipProvider>
+```
+
+---
+
+## Test File Patterns
+
+### Interaction Tests
+
+```typescript
+// {feature-name}.test.tsx - co-located with component
+import { render, fireEvent } from '@testing-library/react';
+
+describe('FeatureName interactions', () => {
+  it('handles row selection', () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(<FeatureName onSelect={onSelect} />);
+    fireEvent.click(getByRole('row'));
+    expect(onSelect).toHaveBeenCalled();
+  });
+});
+```
+
+### Snapshot Tests (optional)
+
+```typescript
+// {feature-name}.test.tsx - same file as interaction tests
+describe('FeatureName snapshots', () => {
+  it('renders default state', () => {
+    const { container } = render(<FeatureName {...defaultProps} />);
+    expect(container).toMatchSnapshot();
+  });
+  // Add snapshots for loading, error, empty, and populated states
+});
+```
+
+### Accessibility Tests
+
+```typescript
+import { axe } from 'jest-axe';
+
+it('has no accessibility violations', async () => {
+  const { container } = render(<FeatureName />);
+  const results = await axe(container);
+  expect(results).toHaveNoViolations();
+});
+```
+
+---
+
+## Reference Extensions
+
+Find similar React components in the codebase for patterns to follow:
+
+| Extension | Pattern | Location |
+|-----------|---------|----------|
+| checks-side-panel | Filter + results list | `extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx` |
+| find | Search + results | `extensions/src/platform-scripture/src/find.web-view.tsx` |
+| inventory | Data grid | `extensions/src/platform-scripture/src/inventory.web-view.tsx` |
+| project-settings | Settings/form | `extensions/src/platform-scripture/src/project-settings.web-view.tsx` |
+
+---
+
+## Design Reference Resources
+
+- `lib/platform-bible-react/src/stories/guidelines/` - Component choices, responsiveness, interactions
+- `Component-Selection-Quick-Reference.md` - Component decision tree, patterns, and detailed use cases
+- `extensions/src/platform-scripture/` - Reference implementation patterns
+- Run Storybook (`npm run storybook`) for live component examples
+
+## Visual Review
+
+After completing UI work on a feature PR, apply the `storybook-review` GitHub label to the paranext-core PR to trigger Chromatic snapshots for UX review. This is the recommended way to get UX sign-off on component visual fidelity before merge. See [Chromatic Visual Review](Testing-Guide.md#chromatic-visual-review) for details on how the workflow operates and cost considerations.
+
+## Version Log
+
+| Version | Date       | Change          |
+| ------- | ---------- | --------------- |
+| 1.0.0   | 2026-03-04 | Initial version |
+| 1.1.0   | 2026-04-01 | Add Visual Review subsection for Chromatic/storybook-review label |
+| 1.1.1   | 2026-04-22 | Refresh TOC line numbers (drift fix) |
+| 1.2.0   | 2026-04-30 | Add "Controlled Radix Popover with Custom Outside-Pointer Handler" section — guard custom outside-pointer handlers with the controlled-open state to avoid firing during the fade-out animation window. Covers `onPointerDownOutside`, `onInteractOutside`, and `onFocusOutside`. (markers-checklist BookChapterControl fix; writeup paranext/ai-prompts#210, fix paranext/paranext-core#2219.) |
+| 1.3.0   | 2026-05-01 | Add TypeScript & Build Configuration section (typeRoots, typecheck script, build-doesn't-typecheck). Add Custom Web View Options pattern (extend `OpenWebViewOptions`). Add `ComboBox` option shape callout (NOT `{label,value}[]`). Add return-type gotcha to useLocalizedStrings (`LocalizationData`/`LanguageStrings`, `LocalizeKey` indices). |
+| 1.4.0   | 2026-05-11 | Move `EXPLANATION:` blocks into the function body rather than TSDoc. |
+| 1.4.1   | 2026-05-11 | Code-review fix: align `EXPLANATION:` placement wording with the Code-Style-Guide v1.2.1 relaxation — also accommodate class-level constants (e.g. regex pattern fields) when the constant *is* the algorithm. |

--- a/.context/standards/Component-Selection-Quick-Reference.md
+++ b/.context/standards/Component-Selection-Quick-Reference.md
@@ -1,0 +1,394 @@
+---
+title: Component Selection Quick Reference
+description: Quick-reference guide for choosing the right platform-bible-react component for extension UI.
+version: 1.2.0
+status: active
+created: 2026-03-04
+last_updated: 2026-06-17
+---
+
+# Component Selection Quick Reference
+
+> **Source**: [UX Component Choices Google Doc](https://docs.google.com/document/d/1gKmb2PnCWtRAbVN8ERskRRy-IoTRTsEpC4-kpgEvzxY/)
+>
+> This guide helps you select appropriate components from `platform-bible-react` when building extension UI.
+
+## Common Patterns
+
+| Need | Component(s) | Reference Extension |
+|------|-------------|---------------------|
+| Search + Results | SearchBar, ScriptureResultsViewer | `find.web-view.tsx` |
+| Filter + List | ComboBox, DataTable/ResultsCard | `checks-side-panel.web-view.tsx` |
+| **Pick a project** | **ProjectSelector** (NOT ComboBox/Select) | `manage-books-sidebar.component.tsx`, `checklist.web-view.tsx` |
+| Data Grid | DataTable, Inventory | `inventory.web-view.tsx` |
+| Settings Form | Input, Select, Checkbox, Card | `project-settings.web-view.tsx` |
+| Scripture Selection | BookChapterControl, ScopeSelector | (multiple extensions) |
+| Comments/Notes | CommentList, CommentThread | `comment-manager.web-view.tsx` |
+| Progress/Loading | Progress, Spinner, Skeleton | (common pattern) |
+| Modal alert/confirm | `papi.dialogs.showDialog('platform.alert', …)` | `hello-rock3` |
+| Dialogs/Modals | Dialog, Drawer, Popover | (common pattern) |
+
+## Component Decision Tree
+
+### Data Display
+- Need sortable columns? → **DataTable**
+- Scripture results? → **ScriptureResultsViewer**
+- Comments/notes? → **CommentList**
+- Inventory items? → **Inventory**
+- Simple key-value? → **Card** + **SettingsList**
+- Hierarchical data? → **Tree** (not yet existing)
+- Otherwise → **Table** or custom Card layout
+
+### Display Text
+- Plain label? → **Label**
+- Markdown content? → **MarkdownRenderer**
+- Smart formatting? → **SmartLabel**
+
+### User Input
+- Single line text? → **Input**
+- Multi-line text? → **Textarea**
+- Scripture reference? → **BookChapterControl**
+- Scope selection? → **ScopeSelector**
+- **Pick a Paratext project (any mode)? → ProjectSelector** (never Select/ComboBox — see Project Picking below)
+- Single select (few options)? → **RadioGroup**
+- Single select (many options)? → **Select** or **ComboBox**
+- Multi-select? → **MultiSelectComboBox** or **Checklist**
+- Toggle? → **Switch** or **Checkbox**
+- Numeric value? → **Slider** or **Select**
+
+### Menus
+- Main application menu? → **Menubar**
+- Project/hamburger menu? → **DropdownMenu**
+- Right-click menu? → **ContextMenu**
+- Hover/in-context menu? → **DropdownMenu** or **ContextMenu**
+- Quick actions row? → **Icon Bar** / **Action Bar** (not yet existing)
+
+### Overlays
+- Blocking action? → **Dialog**
+- Blocking alert / confirm (acknowledge or yes-no)? → **`papi.dialogs.showDialog('platform.alert', …)`** (NOT a new Radix AlertDialog — see Alerts & Confirmations below)
+- Side panel? → **Drawer**
+- Tooltip info? → **Tooltip**
+- Dropdown menu? → **DropdownMenu** or **ContextMenu**
+- Autocomplete? → **Popover** with **CommandList**
+
+### Navigation
+- Tab content? → **Tabs**
+- Vertical menu? → **Sidebar** with **TabsVertical**
+- Toolbar actions? → **Toolbar** or **TabToolbar**
+- Switching between views (e.g., list/grid)? → **ButtonGroup**
+- Breadcrumb trail? → **Breadcrumb**
+
+### Toggles
+- Single toggle button? → **Toggle**
+- Group of toggle options? → **ToggleGroup**
+
+### Buttons
+- Primary action? → **Button** (default variant)
+- Dangerous action? → **Button** (destructive variant)
+- Secondary action? → **Button** (outline or secondary variant)
+- Other actions (not primary workflow)? → **Button** (ghost variant)
+- Link-style? → **Button** (link variant)
+- Icon only? → **Button** with `size="icon"`
+
+### Feedback
+- Inline message? → **Alert**
+- Toast notification? → **Sonner** (for critical updates or feedback)
+- Loading? → **Spinner** or **Skeleton** (prefer Skeletons)
+- Progress? → **Progress**
+- Status indicator? → **Badge**
+
+**Badge variants**: `default`, `secondary`, `muted`, `destructive`, `outline`, blue indicator, muted indicator, ghost
+- Status in checks side panel → Badge with appropriate variant
+- Tags in get resources → Badge
+
+## List and Table Styling
+
+Consistent selection and hover styles for all lists and tables:
+
+```typescript
+// Hover state
+<div className="tw:bg-muted">
+
+// Selected state
+<div className="tw:bg-muted/50">
+```
+
+Apply the [listbox keyboard navigation pattern](https://www.w3.org/WAI/ARIA/apg/patterns/listbox/) for accessibility.
+See: `platform-bible-react/src/hooks/listbox-keyboard-navigation.hook.ts`
+
+Lists may be styled as:
+- Single column table
+- List of Card-like items (see **ResultsCard**)
+
+List entries and table rows may use context menus and Ellipsis button for more options.
+
+## Icons
+
+### Standard Icons
+- Import from `lucide-react` for standard icons (inlines SVG into DOM)
+- Themeable via `currentColor`
+
+### Semantic Icons (planned)
+- Will be served from `platformIcons` extension
+- URL format: `papi-extension://platformIcons/assets/{icon}.svg`
+- Provides consistent, meaningful icons across Platform.Bible
+
+### Custom Icons
+- Bundle custom icons in your extension's `assets/` folder
+- Reference via `papi-extension://{extensionName}/assets/{icon}.svg`
+
+### Icons in Menus
+- Data-driven menus require URLs (cannot pass React components)
+- Download the icon, check it into the extension repo, and pass the URL to menu config
+- Example: `"iconPathAfter": "papi-extension://platformScripture/assets/icons/external-link.svg"`
+
+### Themeability Note
+- URLs in `<img>` tags don't respect `currentColor`
+- Platform.Bible uses `-webkit-mask-image` workaround for themeable URL-based icons
+- The icon component handles this automatically
+
+## Toolbar Components
+
+Common toolbar controls:
+- Scripture reference input? → **BookChapterControl** (BCV)
+- Scope selection? → **ScopeSelector** (dropdown or radio variants)
+- Book or chapter selection? → **BookSelector** / **ChapterSelector**
+- Navigation history? → Forward/Back buttons
+- Edit history? → Undo/Redo buttons
+- Synchronized scrolling? → **ScrollGroup**
+- **View options for a tab (especially boolean toggles)?** → single **"View" toggle button** on the **TabToolbar** with a dropdown menu containing all view options. Do NOT place each boolean toggle as its own toolbar button. Examples of view options that belong here: `showVerseText`, `hideMatches`, list-vs-grid density toggles, or other per-view preferences that don't change the data being viewed.
+
+## Project Picking
+
+**Decision: use `<ProjectSelector>` (from `platform-bible-react`) for ALL project-picking UI** — single-select, multi-select, and scroll-group modes. It ships shortName + fullName + scroll-group chips, keyboard search, "group by open tabs", "show selected only", per-row tooltips, a trigger tooltip, and per-row `isDisabled`/`disabledReason` out of the box.
+
+Avoid:
+- shadcn **ComboBox** for project lists
+- shadcn **Select** for project lists
+- ad-hoc **Popover + cmdk** wrappers for project lists
+- borrowing only the `ProjectSelectorProject` type while rendering a *different* picker
+
+*Why*: one canonical picker keeps every project-picking surface feature-complete (open-tabs grouping, multi-select chips, language hints) and lets cross-cutting fixes land once instead of per-feature; ComboBox/Select pickers consistently lose those features.
+
+Reference: `manage-books-sidebar.component.tsx` (`mode='project'`), `manage-books-dialog.component.tsx` Copy "From" / Create "Based on" (`mode='project'`), `checklist.web-view.tsx` primary picker (`mode='project'`) and comparative-texts multi-select (`mode='project-multi'`).
+
+### Read-only (non-editable) projects in a picker
+
+**Decision: surface `ProjectSummary.IsEditable` (the `platform.isEditable` wire field) all the way up to the picker**, then either:
+- **(a)** disable downstream mutating actions when the active target's `isEditable === false` — preferred when the picked project is the whole tab's target (e.g. the Manage Books sidebar disables Create/Copy/Import/Delete sections); or
+- **(b)** pass `isDisabled: !isEditable` + `disabledReason: '<localized read-only message>'` per row into `ProjectSelector` — preferred when a read-only project shouldn't be pickable at all (e.g. a "Copy into" picker).
+
+Avoid:
+- dropping the `IsEditable` field at the TS adapter boundary (silently lets the user start a mutation the backend rejects mid-flight)
+- inferring read-only from project name/type heuristics instead of consuming `IsEditable`
+
+*Why*: surface the read-only state in the picker **before** the user commits, rather than failing late with a generic "Cannot copy" toast.
+
+## Alerts & Confirmations
+
+**Decision: reuse the registered `'platform.alert'` dialog** via `papi.dialogs.showDialog('platform.alert', { title, prompt, … })` for blocking modal alerts and confirmations. The renderer already ships this dialog with `dialogRole: 'alertdialog'` and `aria-describedby`/`aria-labelledby` wired in, so focus-trap, Escape, and accessibility are handled uniformly.
+
+Avoid:
+- adding `@radix-ui/react-alert-dialog` to `platform-bible-react` (the renderer dialog system already covers this)
+- importing a Radix/shadcn `AlertDialog` directly into a webview/extension
+- nesting a Radix `AlertDialog` inside an existing webview `Dialog` as a workaround
+
+**Exception**: inline, in-webview **field-validation** messages stay inline (`tw:text-destructive` adjacent to the field, with a disabled OK button) — do NOT open a separate top-level alert just to report a validation error.
+
+*Why*: one registered dialog definition gives every alert/confirm the same accessibility and focus behavior without a new dependency.
+
+Reference: `hello-rock3/src/main.ts` — `papi.dialogs.showDialog('platform.alert', { title, prompt, isModal: true })`.
+
+## Key Guidelines
+
+1. **Always use platform-bible-react** components when available
+2. **Design narrow-first** (300px minimum width) - see `guidelines/responsiveness.mdx`
+3. **Use `tw:` prefix** for all Tailwind classes
+4. **Wrap in `pr-twp`** class for style scoping
+5. **Use `cn()`** from platform-bible-react for conditional classes
+6. **Import icons from `lucide-react`**
+
+## Styling Conventions
+
+```typescript
+// Standard imports for extension web views
+import {
+  Button,
+  Card,
+  CardContent,
+  Badge,
+  cn,
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from 'platform-bible-react';
+import { SomeIcon } from 'lucide-react';
+
+// Tailwind with tw: prefix
+<div className="tw:flex tw:flex-col tw:gap-4 tw:p-4">
+
+// Conditional classes with cn()
+<div className={cn('tw:flex tw:gap-2', { 'tw:hidden': !visible })}>
+
+// Style scoping at component root
+<div className="pr-twp">
+  {/* All content here gets Platform.Bible styling */}
+</div>
+```
+
+## Storybook Resources
+
+Run `npm run storybook` and see:
+- **Guidelines/Component Choices** - When to use which component
+- **Guidelines/Responsiveness** - Narrow-first design requirements
+- **Guidelines/Application Interactions** - Standard interaction patterns
+- **Guidelines/Vocabulary** - UI terminology standards
+
+## Design Resources
+
+- **Component Enhancements Backlog**: [PT-2218](https://paratextstudio.atlassian.net/browse/PT-2218)
+
+## Reference Extensions
+
+These extensions demonstrate good patterns:
+
+| Extension | Pattern | Location |
+|-----------|---------|----------|
+| platform-scripture | Search, filter, results | `extensions/src/platform-scripture/src/` |
+| platform-lexical-tools | Dictionary, data display | `extensions/src/platform-lexical-tools/src/` |
+| platform-get-resources | List, sorting, filtering | `extensions/src/platform-get-resources/src/` |
+
+## Form Validation
+
+**Note:** Form components (shadcn/ui form primitives) are NOT yet in platform-bible-react. For complex forms with validation:
+
+1. **Simple validation**: Use controlled inputs with local state validation
+2. **Complex forms**: Consider using React Hook Form directly:
+   ```typescript
+   import { useForm } from 'react-hook-form';
+   import { Input, Label } from 'platform-bible-react';
+
+   // Manual integration until Form components are added
+   const { register, handleSubmit, formState: { errors } } = useForm();
+   ```
+
+3. **Error display**: Show errors adjacent to fields with `tw:text-destructive`
+
+**Future**: When Form components are added to platform-bible-react, prefer those.
+
+## Prohibited Styling Patterns
+
+NEVER use these patterns:
+- `tw:bg-black/50` or any non-theme colors → Use `tw:bg-muted` or theme variants
+- `tw:shadow*` classes → Disallowed in AI-authored extension/web-view code via the AI-strict lint config (`paranext/no-tailwind-shadows`). Note: the platform-bible-react shadcn-ui components themselves do use shadows like `tw:shadow-md`, so this scopes the code you write, not the library.
+- Hardcoded colors (`#fff`, `rgb()`, `hsl()`, etc.) → Use theme tokens only
+- `tw:border-black` or non-theme border colors → Use `tw:border-border` or `tw:border-input`
+
+ALWAYS use theme colors:
+- **Backgrounds**: `tw:bg-background`, `tw:bg-muted`, `tw:bg-primary`, `tw:bg-secondary`
+- **Text**: `tw:text-foreground`, `tw:text-muted-foreground`, `tw:text-primary`, `tw:text-destructive`
+- **Borders**: `tw:border-border`, `tw:border-input`, `tw:border-primary`
+
+## Empty State Handling
+
+For form fields:
+- **Required fields**: Show asterisk (*) or "(required)" in the label
+- **Optional fields**: No indicator needed (optional is the default assumption)
+- **Empty state**: Use placeholder text explaining expected input format
+- **Invalid state**: Show validation message adjacent to the field using `tw:text-destructive`
+
+Example:
+```typescript
+<div className="tw:flex tw:flex-col tw:gap-1">
+  <Label htmlFor="project-name">{localizedStrings['%field_projectName_label%']} *</Label>
+  <Input id="project-name" placeholder={localizedStrings['%field_projectName_placeholder%']} />
+  {errors.projectName && (
+    <Label className="tw:text-sm tw:text-destructive">{errors.projectName.message}</Label>
+  )}
+</div>
+```
+
+## Placeholder Text Standards
+
+### When to Use Placeholders
+
+**Use placeholders for:**
+- Text inputs that need format hints
+- Search fields
+- Inputs where example values clarify expected format
+
+**Do NOT use placeholders for:**
+- Required field indicators (use asterisk in label instead)
+- Default values (set actual default)
+- Instructions that don't fit in the input (use helper text below)
+
+### Placeholder Content Guidelines
+
+| Type | Pattern | Example |
+|------|---------|---------|
+| Search fields | "Search {items}..." | "Search projects..." |
+| Name inputs | "Enter {thing} name" | "Enter project name" |
+| Format hints | Show format | "YYYY-MM-DD" |
+| Selection prompts | "Select {item}..." | "Select language..." |
+
+**Keep placeholders:**
+- Short (under 30 characters)
+- Action-oriented (verbs: Enter, Search, Select)
+- Helpful (format hints when non-obvious)
+
+### Placeholder Localization (MANDATORY)
+
+All placeholder text MUST be localized:
+
+```typescript
+// Key pattern
+'%{component}_{field}_placeholder%'
+
+// Example
+<Input
+  placeholder={localizedStrings['%projectName_input_placeholder%']}
+/>
+```
+
+```json
+{
+  "localizedStrings": {
+    "en": {
+      "%projectName_input_placeholder%": "Enter project name"
+    },
+    "es": {
+      "%projectName_input_placeholder%": "Ingrese el nombre del proyecto"
+    }
+  }
+}
+```
+
+### Placeholders vs Labels
+
+| Use Case | Use Label | Use Placeholder |
+|----------|-----------|-----------------|
+| Field identification | ✅ Always | ❌ Never alone |
+| Format example | ❌ | ✅ In addition to label |
+| Required indicator | ✅ (asterisk) | ❌ |
+| Helper instructions | ✅ (as helper text) | ❌ |
+
+**Note**: Placeholders disappear when typing. Critical information belongs in labels or helper text.
+
+## Creating Custom Components
+
+Only create extension-local components when:
+- Building domain-specific compositions that combine multiple library components
+- Adding custom logic specific to the extension's domain
+
+Example: A `CheckCard` that combines Badge + Tooltip + ResultsCard with check-specific logic.
+
+**Do NOT** create custom versions of components that already exist in `platform-bible-react`.
+
+## Version Log
+
+| Version | Date       | Change          |
+| ------- | ---------- | --------------- |
+| 1.0.0   | 2026-03-04 | Initial version |
+| 1.1.0   | 2026-04-23 | Added "View" toggle button pattern for the TabToolbar: view options (especially boolean toggles like `showVerseText`, `hideMatches`) belong under a single "View" dropdown button, not as individual toolbar buttons. Driven by Sebastian's markers-checklist review feedback. |
+| 1.2.0   | 2026-06-17 | Added Project Picking section: use `ProjectSelector` for ALL project-picking UI (not ComboBox/Select), plus the read-only (`IsEditable`) handling. Added Alerts & Confirmations section: reuse the registered `platform.alert` dialog for blocking alerts/confirms (no new Radix AlertDialog; inline field validation stays inline). Routed the Common Patterns table and User Input/Overlays decision trees accordingly. |

--- a/.context/standards/Entry-Point-Guide.md
+++ b/.context/standards/Entry-Point-Guide.md
@@ -1,0 +1,330 @@
+---
+title: Entry Point Registration Guide
+description: How to register menu entry points (menu items, commands, keyboard shortcuts) for Platform.Bible extensions.
+version: 1.0.0
+status: active
+created: 2026-03-04
+last_updated: 2026-03-04
+---
+
+# Entry Point Registration Guide
+
+This guide documents how to register menu entry points for Platform.Bible extensions. Entry points are how users access features from the UI (menus, toolbar buttons, etc.).
+
+## When to Use This Guide
+
+Use this guide when:
+- Adding menu items to access web views or dialogs
+- Registering commands that open features
+- Wiring up keyboard shortcuts
+- Understanding the menu contribution system
+
+---
+
+## Overview
+
+Entry point registration involves four files:
+1. **menus.json** - Menu structure and item definitions
+2. **main.ts** - Command handler registration
+3. **types/{ext}.d.ts** - TypeScript command type declarations
+4. **localizedStrings.json** - Localized labels for menu items
+
+---
+
+## Step 1: Identify Entry Points
+
+Gather the menu items and commands the feature needs. For each entry point, note the menu path it should appear under, the command it invokes, and the label users will see.
+
+---
+
+## Step 2: Determine Menu Groups
+
+Find the appropriate menu group by examining existing contributions:
+
+```bash
+# Check existing menu structure in the extension
+cat extensions/src/{ext}/contributions/menus.json
+
+# Check core menu groups (if needed)
+grep -r "mainMenu" extensions/src/*/contributions/menus.json
+```
+
+### Common Menu Groups
+
+| Group | Use Case |
+|-------|----------|
+| `platform.projectProjects` | Project creation, restore, management |
+| `platform.help` | Help and documentation |
+| `{ext}.tools` | Extension-specific tools |
+
+### Creating New Groups
+
+For new groups, define them in `menus.json`:
+
+```json
+{
+  "mainMenu": {
+    "groups": {
+      "{ext}.{newGroup}": {
+        "column": "platform.project",
+        "order": 10
+      }
+    }
+  }
+}
+```
+
+---
+
+## Step 3: Update Menu Contributions
+
+For each entry point, add to `extensions/src/{ext}/contributions/menus.json`:
+
+### Menu Item Structure
+
+```json
+{
+  "mainMenu": {
+    "columns": {},
+    "groups": {},
+    "items": [
+      {
+        "label": "%mainMenu_{feature}_{action}%",
+        "localizeNotes": "Application main menu > {Column} > {Item}",
+        "command": "{ext}.{commandName}",
+        "group": "{groupName}",
+        "order": {number}
+      }
+    ]
+  }
+}
+```
+
+**Notes:**
+- Use `localizeNotes` to document the menu path for translators
+- Order numbers determine sort order within the group
+- Commands must match exactly what's registered in main.ts
+
+---
+
+## Step 4: Register Command Handlers
+
+In `extensions/src/{ext}/src/main.ts`:
+
+### Step A: Import WebView Types
+
+Import options types from web view providers:
+
+```typescript
+import {
+  ProjectPropertiesWebViewOptions,
+  ProjectPropertiesWebViewProvider,
+  PROJECT_PROPERTIES_WEB_VIEW_TYPE,
+} from './project-properties.web-view-provider';
+```
+
+### Step B: Create Handler Function
+
+Create a handler function with properly typed options:
+
+```typescript
+async function openNewProject(): Promise<string | undefined> {
+  const options: ProjectPropertiesWebViewOptions = { mode: 'create' };
+  return papi.webViews.openWebView(
+    PROJECT_PROPERTIES_WEB_VIEW_TYPE,
+    { type: 'float', floatSize: { width: 700, height: 800 } },
+    options,
+  );
+}
+```
+
+### Step C: Register the Command
+
+Register the command in the `activate()` function:
+
+```typescript
+const openNewProjectPromise = papi.commands.registerCommand(
+  '{ext}.openNewProject',
+  openNewProject,
+  {
+    method: {
+      summary: 'Open the New Project dialog to create a new scripture project',
+      params: [],
+      result: {
+        name: 'return value',
+        summary: 'The ID of the opened web view',
+        schema: { type: 'string' },
+      },
+    },
+  },
+);
+```
+
+### Step D: Add to Registrations
+
+**Critical for proper lifecycle/cleanup:**
+
+```typescript
+context.registrations.add(
+  // ... existing registrations ...
+  await openNewProjectPromise,
+);
+```
+
+---
+
+## Step 5: Add Command Type Declarations
+
+In `extensions/src/{ext}/src/types/{ext}.d.ts`, add command signatures to the `CommandHandlers` interface:
+
+```typescript
+export interface CommandHandlers {
+  // ... existing commands ...
+
+  /** Open the New Project dialog to create a new scripture project */
+  '{ext}.openNewProject': () => Promise<string | undefined>;
+
+  /** Open the Restore Project dialog to restore from backup */
+  '{ext}.openRestoreProject': () => Promise<string | undefined>;
+
+  /** Open the Interlinear Setup dialog (requires project context) */
+  '{ext}.openInterlinearSetup': (
+    projectId?: string | undefined,
+  ) => Promise<string | undefined>;
+}
+```
+
+**This is required for TypeScript type checking to pass.** Without these declarations, you'll get errors like:
+```
+error TS2345: Argument of type '"platformScripture.openNewProject"' is not assignable to parameter of type 'keyof CommandHandlers'.
+```
+
+---
+
+## Step 6: Add Localized Strings
+
+In `extensions/src/{ext}/contributions/localizedStrings.json`, add labels for **all supported languages**:
+
+```json
+{
+  "localizedStrings": {
+    "en": {
+      "%mainMenu_newProject%": "New Project...",
+      "%mainMenu_restoreProject%": "Restore Project...",
+      "%mainMenu_interlinearSetup%": "Interlinear Setup..."
+    },
+    "es": {
+      "%mainMenu_newProject%": "Nuevo proyecto...",
+      "%mainMenu_restoreProject%": "Restaurar proyecto...",
+      "%mainMenu_interlinearSetup%": "Configurar interlineal..."
+    }
+  }
+}
+```
+
+### Conventions
+
+- Use ellipsis (`...`) for menu items that open dialogs
+- Match the string key pattern: `%mainMenu_{feature}_{action}%`
+- Provide translations for both `en` and `es` sections
+
+---
+
+## WebView Layout Options Reference
+
+When opening dialogs via commands, specify appropriate layout:
+
+| Type | Use Case | Example Options |
+|------|----------|-----------------|
+| `float` | Modal dialogs, property sheets | `{ type: 'float', floatSize: { width: 700, height: 800 } }` |
+| `panel` | Side panels, tool windows | `{ type: 'panel', direction: 'right', targetTabId: id }` |
+| `tab` | Main content area | `{ type: 'tab' }` |
+
+### Recommended Sizes
+
+| Dialog Type | Dimensions |
+|-------------|------------|
+| Small dialogs | `{ width: 500, height: 400 }` |
+| Medium dialogs | `{ width: 700, height: 600 }` |
+| Large dialogs (property sheets) | `{ width: 700, height: 800 }` |
+| Wide dialogs (grids/tables) | `{ width: 900, height: 700 }` |
+
+---
+
+## Entry Point Checklist
+
+Complete this checklist for each entry point:
+
+| Menu Path | Command | Label Key | menus.json | main.ts | types.d.ts | localized | Status |
+|-----------|---------|-----------|------------|---------|------------|-----------|--------|
+| Platform > New Project | {ext}.openNewProject | %mainMenu_newProject% | | | | | |
+| Platform > Restore Project | {ext}.openRestoreProject | %mainMenu_restoreProject% | | | | | |
+
+---
+
+## Build Verification
+
+Run build checks to verify the implementation:
+
+```bash
+# Run lint
+npm run lint
+
+# Run typecheck (critical - catches missing type declarations)
+npm run typecheck
+
+# Run build
+npm run build
+
+# Run tests
+npm test
+```
+
+**Note:** When running `npm run typecheck`, you may encounter pre-existing issues in files you didn't modify. Check if errors are in files you changed vs. elsewhere. Pre-existing issues may need `@ts-expect-error` comments or separate fixes. Don't let unrelated issues block entry point implementation.
+
+---
+
+## Commit Entry Points
+
+```bash
+git add extensions/src/{ext}/contributions/menus.json
+git add extensions/src/{ext}/contributions/localizedStrings.json
+git add extensions/src/{ext}/src/main.ts
+git add extensions/src/{ext}/src/types/{ext}.d.ts
+git commit -m "{feature}: Register menu entry points
+
+- Added {count} menu items to menus.json
+- Registered {count} commands in main.ts
+- Added command type declarations
+- Added localized strings (en, es)"
+```
+
+---
+
+## Troubleshooting
+
+### TypeScript Errors
+
+If you get `TS2345` errors about commands not being assignable:
+1. Check `types/{ext}.d.ts` has the command declaration
+2. Ensure the command name matches exactly in all locations
+3. Run `npm run typecheck` to verify
+
+### Menu Item Not Appearing
+
+1. Verify `menus.json` is valid JSON
+2. Check the `group` name matches a defined group
+3. Verify the command name matches exactly in `main.ts`
+4. Check console for registration errors
+
+### Command Not Working
+
+1. Check command handler is exported correctly
+2. Verify `context.registrations.add()` includes the command
+3. Check console for errors during `activate()`
+
+## Version Log
+
+| Version | Date       | Change          |
+| ------- | ---------- | --------------- |
+| 1.0.0   | 2026-03-04 | Initial version |

--- a/.context/standards/Extension-Development-Guide.md
+++ b/.context/standards/Extension-Development-Guide.md
@@ -1,0 +1,342 @@
+---
+title: Extension Development Guide
+description: Extension anatomy, lifecycle, PAPI usage, WebViews, and contribution points for Platform.Bible.
+version: 1.0.0
+status: active
+created: 2026-03-04
+last_updated: 2026-03-04
+---
+
+# Extension Development Guide
+
+This document provides a concise overview of extension development for Platform.Bible. For comprehensive details, refer to the linked wiki pages.
+
+---
+
+## Extension Anatomy
+
+Extensions follow a standardized directory structure:
+
+```
+extension-name/
+├── assets/              # Static files (icons, JSON marketplace data)
+├── contributions/       # Configuration files (menus, settings, localized strings)
+├── src/
+│   ├── main.ts          # Backend entry point (must be named main.ts)
+│   ├── types/
+│   │   └── extension-name.d.ts  # Type declarations
+│   └── web-views/        # (or flat in src/ — both layouts are used)
+│       ├── *.web-view.tsx   # React WebView components
+│       └── *.web-view.scss  # WebView styles
+├── manifest.json        # Extension metadata and entry points
+├── package.json         # NPM package configuration
+└── webpack/             # Build configuration
+```
+
+For complete details, see [Extension Anatomy wiki](https://github.com/paranext/paranext-extension-template/wiki/Extension-Anatomy).
+
+### Presentational Components vs. WebView Entry Points
+
+Keep pure presentational React in `src/components/*.component.tsx`, separate from the
+`*.web-view.tsx` files that serve as WebView entry points.
+
+- **Decision:** Reusable presentational components (those with dedicated Storybook
+  stories, free of WebView provider plumbing) live in `src/components/` as
+  `*.component.tsx`. The matching `*.web-view.tsx` entry point imports the component and
+  supplies the PAPI/data wiring.
+- **Avoid:** putting `*.web-view.tsx` (a WebView entry point) under `src/components/`.
+- **Rationale:** `*.component.tsx` is a different concern from `*.web-view.tsx` — pure
+  presentation versus the WebView entry point — so the two are kept in separate
+  locations. `paratext-registration`, `platform-lexical-tools`, and `platform-scripture`
+  follow this layout (e.g. `platform-scripture/src/checklist.web-view.tsx` imports
+  `ChecklistTool` from `./components/checklist.component`).
+
+---
+
+## Backend Entry Point (main.ts)
+
+The extension backend must export two functions:
+
+```typescript
+export async function activate(context: ExecutionActivationContext): Promise<void> {
+  // Register commands, data providers, web views, etc.
+  context.registrations.add(
+    await commandPromise,
+    await webViewProviderPromise,
+    // ... all other registrations
+  );
+}
+
+export async function deactivate(): Promise<boolean> {
+  // Cleanup when extension unloads
+  return true;
+}
+```
+
+Extensions cannot use static imports—code must be bundled with webpack.
+
+---
+
+## PAPI (Platform API)
+
+The Platform API enables extensions to interact with Platform.Bible:
+
+### Core Services
+
+| Service | Purpose |
+|---------|---------|
+| `papi.commands` | Register and send commands |
+| `papi.dataProviders` | Register and access data providers |
+| `papi.webViewProviders` | Register WebView providers |
+| `papi.storage` | Extension-specific data storage |
+| `papi.settings` | Access application settings |
+| `papi.dialogs` | Show user dialogs |
+
+### React Hooks (Frontend)
+
+| Hook | Purpose |
+|------|---------|
+| `useData` | Subscribe to data provider data |
+| `useDataProvider` | Access a data provider |
+| `useProjectData` | Subscribe to project-specific data |
+| `useSetting` | Access application settings |
+| `useProjectSetting` | Access project-specific settings |
+
+For complete PAPI documentation, see [PAPI wiki](https://github.com/paranext/paranext-extension-template/wiki/PAPI).
+
+---
+
+## Data Providers
+
+Data providers mediate communication between frontend and backend:
+
+```typescript
+class MyDataProviderEngine implements IDataProviderEngine<MyDataTypes> {
+  async getDataType(selector: string): Promise<Data> { /* ... */ }
+  async setDataType(selector: string, data: Data): Promise<DataProviderUpdateInstructions> { /* ... */ }
+}
+
+// Registration
+const provider = await papi.dataProviders.registerEngine(
+  'extensionName.dataProviderName',
+  new MyDataProviderEngine()
+);
+context.registrations.add(provider);
+```
+
+---
+
+## WebViews
+
+WebViews are React components rendered in sandboxed iframes:
+
+```typescript
+// my-component.web-view.tsx
+import { useData } from '@papi/frontend/react';
+
+globalThis.webViewComponent = function MyWebView() {
+  const [data] = useData('extensionName.dataProvider').DataType('selector');
+  return <div>{data}</div>;
+};
+```
+
+### Sandbox Constraints
+
+WebViews run in sandboxed iframes with restricted permissions:
+
+#### No `<form>` Elements
+
+The sandbox does not have `allow-forms` permission. Form submissions are blocked even with `e.preventDefault()`.
+
+**Pattern:** Use `<div>` with handlers instead:
+
+```tsx
+// ❌ BAD - causes sandbox error
+<form onSubmit={handleSubmit}>
+  <Button type="submit">OK</Button>
+</form>
+
+// ✅ GOOD - works in sandbox
+<div onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}>
+  <Button type="button" onClick={handleSubmit}>OK</Button>
+</div>
+```
+
+#### Select Component Constraints
+
+The Select component's value prop cannot be an empty string:
+
+```tsx
+// ❌ BAD - crashes with "value prop cannot be empty string"
+<SelectItem value="">(None)</SelectItem>
+
+// ✅ GOOD - use sentinel value
+<SelectItem value="__none__">(None)</SelectItem>
+// Handle in onChange: value === '__none__' ? undefined : value
+```
+
+#### React Key Anti-Patterns
+
+Never use editable content in list item keys:
+
+```tsx
+// ❌ BAD - key changes when name changes, causing focus loss
+{items.map(item => <Input key={item.name} value={item.name} />)}
+
+// ✅ GOOD - stable key
+{items.map(item => <Input key={item.id} value={item.name} />)}
+```
+
+### Styling Requirements
+
+- Use **TailwindCSS** (Tailwind v4) with the `tw:` prefix for theming
+- Use semantic color variables (e.g., `tw:bg-card`) instead of hardcoded colors
+- Support RTL/LTR layouts using logical properties (`start`/`end` instead of `left`/`right`)
+
+---
+
+## Contributions
+
+Extensions contribute to Platform.Bible through JSON configuration files in `contributions/`:
+
+### Settings (`settings.json`)
+
+`settings.json` is an **array of setting groups**. Each group has a `label` and a
+`properties` object keyed by `<extension>.<settingId>`:
+
+```json
+[
+  {
+    "label": "%settings_group_label%",
+    "properties": {
+      "extensionName.settingName": {
+        "label": "%setting_label%",
+        "default": "defaultValue"
+      }
+    }
+  }
+]
+```
+
+### Menus (`menus.json`)
+
+The main menu is defined under a `"mainMenu"` object with `columns`, `groups`, and
+an `items` **array**. Each item references a `group` and a `command` (there is no
+`"mainMenu.file"` key):
+
+```json
+{
+  "mainMenu": {
+    "columns": {},
+    "groups": {},
+    "items": [
+      {
+        "label": "%item_label%",
+        "localizeNotes": "Application main menu > Column > Item",
+        "group": "groupName",
+        "order": 1,
+        "command": "extensionName.commandName"
+      }
+    ]
+  }
+}
+```
+
+### Localized Strings (`localizedStrings.json`)
+
+The language map is nested under a `"localizedStrings"` key, alongside a sibling
+`"metadata"` object (use `{}` when there is no metadata):
+
+```json
+{
+  "metadata": {},
+  "localizedStrings": {
+    "en": {
+      "%setting_label%": "My Setting",
+      "%item_label%": "My Menu Item"
+    }
+  }
+}
+```
+
+For complete contribution examples, see [Extension Development How-To Guide wiki](https://github.com/paranext/paranext-extension-template/wiki/Extension-Development-'How-To'-Guide).
+
+---
+
+## Type Declarations
+
+Declare shared types in `src/types/extension-name.d.ts`:
+
+```typescript
+declare module 'extension-name' {
+  import type { DataProviderDataType, IDataProvider } from '@papi/core';
+
+  export type MyDataTypes = {
+    DataTypeName: DataProviderDataType<Selector, ReturnType, SetType>;
+  };
+
+  export type IMyProvider = IDataProvider<MyDataTypes>;
+}
+
+declare module 'papi-shared-types' {
+  export interface CommandHandlers {
+    'extensionName.commandName': (param: Type) => Promise<Result>;
+  }
+
+  export interface DataProviders {
+    'extensionName.dataName': IMyProvider;
+  }
+}
+```
+
+---
+
+## Running Extensions
+
+Load extensions via command-line arguments:
+
+```bash
+# Load specific extension
+platform-bible --extensions /path/to/extension
+
+# Load from extension directory
+platform-bible --extensionDirs /path/to/extensions/folder
+```
+
+---
+
+## Merging Template Updates
+
+Keep your extension synchronized with template improvements:
+
+```bash
+# One-time: Add template as remote
+git remote add template https://github.com/paranext/paranext-extension-template.git
+
+# Fetch and merge updates
+git fetch template
+git checkout main
+git merge template/main --allow-unrelated-histories
+```
+
+**Important:** Never squash template merges—use normal merge to preserve git history.
+
+For details, see [Merging Template Changes wiki](https://github.com/paranext/paranext-extension-template/wiki/Merging-Template-Changes-into-Your-Extension).
+
+---
+
+## Related Documentation
+
+- [Extension Anatomy wiki](https://github.com/paranext/paranext-extension-template/wiki/Extension-Anatomy)
+- [PAPI wiki](https://github.com/paranext/paranext-extension-template/wiki/PAPI)
+- [Extension Development How-To Guide wiki](https://github.com/paranext/paranext-extension-template/wiki/Extension-Development-'How-To'-Guide)
+- [System Architecture wiki](https://github.com/paranext/paranext-extension-template/wiki/System-Architecture)
+- [Security-Guide.md](Security-Guide.md) - Module restrictions and sandboxing
+- [Code-Style-Guide.md](Code-Style-Guide.md) - Coding conventions
+- [Paranext-Core-Patterns.md](Paranext-Core-Patterns.md) - Implementation patterns
+
+## Version Log
+
+| Version | Date       | Change          |
+| ------- | ---------- | --------------- |
+| 1.0.0   | 2026-03-04 | Initial version |

--- a/.context/standards/Git-Guide.md
+++ b/.context/standards/Git-Guide.md
@@ -1,0 +1,79 @@
+---
+title: Git and GitHub Guidelines
+description: Branch structure, branch naming, merge practices, and template updates.
+---
+
+# Git and GitHub Guidelines
+
+Our [release proposal](https://docs.google.com/document/d/1YDNTLUweF3USLUtxaoozMNMFBgzEzha91otWp4VlUuw/edit?tab=t.0#heading=h.udy5i8roaoxw) describes our branches and practices for interacting with the code base. This file is a condensed summary.
+
+---
+
+## Branch Structure
+
+- **`main`**: contains the latest code. Regular development PRs target this branch. Feature branches are usually created from `main`.
+- **`release-prep`**: code for the next release. Only branch admins merge here, and typically only via rebase/cherry-pick from `main`. Normal development does not target this branch.
+  - At some point soon, `main` is rebased into `release-prep`; after that, changes are only cherry-picked from `main` as appropriate until the beta release.
+- **hotfix branches (e.g. `hotfix-1.23.4`)**: created by branch admins from a release tag or from `main`. PRs targeting hotfix branches contain the specific fixes for a release. Changes can be made on the hotfix branch first and cherry-picked to `main`, or vice versa.
+
+**Branch Admins**: See the [Code Stewards wiki](https://github.com/paranext/paranext/wiki/Code-Stewards). To become a branch admin, ask the current branch admins.
+
+---
+
+## Branch Naming
+
+- **Start with the JIRA task ID** when applicable: `pt-1234-my-feature`.
+- **Use all lower-case.**
+
+---
+
+## Merge Practices
+
+### Squash and Merge (Default)
+
+Always use "Squash and merge" when merging a PR in GitHub or setting auto-merge.
+
+![Screenshot of a GitHub PR showing how to set to Squash and merge](https://github.com/user-attachments/assets/70f2ca49-4062-4468-8958-0939c67be9ba)
+
+### Template Updates Exception
+
+**Never squash and merge changes that create new extensions or pull updates from templates.** Template merges create git history that must be preserved for future template updates to work. Use a normal merge (merge commit) for these.
+
+If you accidentally squash-merge a template update:
+
+1. Tell an administrator immediately.
+2. The administrator will need to reset `main` to before your merge and restart the PR.
+3. Not fixing it causes future template updates to reset the extension to the template state.
+
+**Note:** Reviewable's UI does different kinds of merges in different situations. Always use the GitHub UI to perform the actual merge.
+
+---
+
+## Merging Template Changes into an Extension
+
+Keep extensions synchronized with template improvements.
+
+```bash
+# One-time setup: add the template as a remote
+git remote add template https://github.com/paranext/paranext-extension-template.git
+
+# Fetch and merge
+git fetch template
+git checkout main
+git merge template/main --allow-unrelated-histories
+```
+
+**Important:**
+
+- The merge commits created when updating from the template are part of the tracking history. Don't edit them out.
+- Removing these merge commits causes duplicate conflicts in future template updates.
+- After merging, resolve any conflicts and run `npm i` to update dependencies.
+
+For full details, see the [Merging Template Changes wiki](https://github.com/paranext/paranext-extension-template/wiki/Merging-Template-Changes-into-Your-Extension).
+
+---
+
+## Related Documentation
+
+- [Code Stewards wiki](https://github.com/paranext/paranext/wiki/Code-Stewards) — code ownership assignments
+- [Code Review Guide wiki](https://github.com/paranext/paranext/wiki/Code-Review-Guide) — PR review process

--- a/.context/standards/Localization-Guide.md
+++ b/.context/standards/Localization-Guide.md
@@ -1,0 +1,467 @@
+---
+title: Localization Guide
+description: Mandatory localization patterns for all user-facing text in paranext-core — UI web views (TS) and C# backend services.
+version: 1.4.0
+status: active
+created: 2026-03-04
+last_updated: 2026-06-17
+toc: true
+---
+
+# Localization Guide
+
+This guide documents localization patterns for paranext-core. All user-facing text MUST be localized — this applies to both UI web views (TypeScript/React) and C# backend services whose output reaches the user.
+
+<!-- TOC:BEGIN -->
+<!-- Anchor links are used instead of line numbers so this index cannot drift as the file changes. -->
+<!-- | Section | -->
+<!-- | --- | -->
+<!-- | [When to Use This Guide](#when-to-use-this-guide) | -->
+<!-- | [Core Principle](#core-principle) | -->
+<!-- | [Architecture: One Store, Two APIs](#architecture-one-store-two-apis) | -->
+<!-- | [Fallback Chain (How Missing Translations Are Handled)](#fallback-chain-how-missing-translations-are-handled) | -->
+<!-- | [Localization Pattern](#localization-pattern) | -->
+<!-- | [Localizing Shared Library Components (lib/platform-bible-react/)](#localizing-shared-library-components-libplatform-bible-react) | -->
+<!-- | [Conventions](#conventions) | -->
+<!-- | [Text Direction (RTL/LTR)](#text-direction-rtlltr) | -->
+<!-- | [Reusing Existing Strings (IMPORTANT)](#reusing-existing-strings-important) | -->
+<!-- | [Existing Strings Are Immutable (CRITICAL)](#existing-strings-are-immutable-critical) | -->
+<!-- | [Dynamic Values with formatReplacementString](#dynamic-values-with-formatreplacementstring) | -->
+<!-- | [Localization Checklist](#localization-checklist) | -->
+<!-- | [Blocking Issues](#blocking-issues) | -->
+<!-- | [C# Backend Localization](#c-backend-localization) | -->
+<!-- | [Version Log](#version-log) | -->
+<!-- TOC:END -->
+
+## When to Use This Guide
+
+Use this guide when:
+- Building new web view components with user-facing text
+- Writing C# backend services that return messages/errors to the wire
+- Adding labels, buttons, error messages, or any visible text to UI
+- Debugging localization issues in existing components
+- Understanding the `useLocalizedStrings` hook pattern (TS) or `LocalizationService.GetLocalizedString` (C#)
+
+## Core Principle
+
+**Never hardcode English text in code that faces users.** All user-visible strings — whether they originate in TypeScript UI components or in C# backend services — must go through the localization system.
+
+## Architecture: One Store, Two APIs
+
+Localization data lives in **one shared store**, and TypeScript and C# each have an API that reads from it:
+
+| Layer | Where strings live | How to read |
+|-------|-------------------|-------------|
+| Platform root (built-in UI, system messages) | `assets/localization/{lang}.json` — one flat file per language | TS: `useLocalizedStrings` hook; C#: `LocalizationService.GetLocalizedString(papiClient, key, default)` |
+| Extension (extension-namespaced UI + backend features) | `extensions/src/{ext}/contributions/localizedStrings.json` — single file with `localizedStrings.{lang}.{key}` sections | Same APIs as above |
+
+The extension-host merges all contribution files into a unified store. Both TS and C# APIs resolve the same keys against that store. There is **no separate C# translation database**; C# calls into the platform's localization service over PAPI.
+
+### Where does my string belong?
+
+- **Platform root** (`assets/localization/`) — strings that are part of the built-in paranext-core shell (top-level menus, system dialogs, common confirmations)
+- **Extension namespace** (`extensions/src/{ext}/contributions/localizedStrings.json`) — strings belonging to an extension or to a service whose PAPI name sits under the extension namespace. Example: `platformScripture.checklistService` lives in the `platform-scripture` extension, so its strings belong in `extensions/src/platform-scripture/contributions/localizedStrings.json` — even if the C# implementation is in the main `c-sharp/` data provider.
+
+> **Rule of thumb**: if the PAPI service name has a namespace prefix (e.g. `platformScripture.*`, `checkHost.*`), the strings belong in that extension's `localizedStrings.json`.
+
+## Fallback Chain (How Missing Translations Are Handled)
+
+Resolution order for any localize key lookup (see `src/extension-host/services/localization.service-host.ts:297-331`):
+
+1. **User's preferred languages** — from the `platform.interfaceLanguage` setting (ordered array)
+2. **English** — `BACKUP_LANGUAGE = 'en'` is hardcoded and always appended to the fallback list
+3. **`fallbackKey` metadata** — if a key declares `fallbackKey` in the `metadata` section (e.g. `%inventoryName_Character%` → `%CheckType_3%`), that sibling key is tried across all languages
+4. **Bare key** — if everything fails, the localize key (`%foo%`) itself is returned as a debug safety net
+
+**Practical implication**: if you add an English entry for a key, users in languages without that key automatically fall back to English. You do **not** need custom fallback logic in the consumer.
+
+---
+
+## Localization Pattern
+
+### 1. Create a LOCALIZED_STRINGS Array
+
+In a utils file or at the top of the web view file:
+
+```typescript
+// {feature}.utils.ts or at top of web view file
+import { LocalizeKey } from 'platform-bible-utils';
+
+export const LOCALIZED_STRINGS: LocalizeKey[] = [
+  '%webView_{feature}_title%',
+  '%webView_{feature}_submitButton%',
+  '%webView_{feature}_cancelButton%',
+  '%webView_{feature}_errorMessage%',
+  // Add all user-facing strings
+];
+```
+
+### 2. Use the useLocalizedStrings Hook
+
+In the web view component:
+
+```typescript
+import { useLocalizedStrings } from '@papi/frontend/react';
+import { useMemo } from 'react';
+import { LOCALIZED_STRINGS } from './{feature}.utils';
+
+globalThis.webViewComponent = function FeatureWebView({ ... }: WebViewProps) {
+  const [localizedStrings] = useLocalizedStrings(useMemo(() => LOCALIZED_STRINGS, []));
+
+  return (
+    <div>
+      <h1>{localizedStrings['%webView_{feature}_title%']}</h1>
+      <Button>{localizedStrings['%webView_{feature}_submitButton%']}</Button>
+    </div>
+  );
+};
+```
+
+### 3. Add Translations to localizedStrings.json
+
+In `contributions/localizedStrings.json`:
+
+```json
+{
+  "localizedStrings": {
+    "en": {
+      "%webView_{feature}_title%": "Feature Title",
+      "%webView_{feature}_submitButton%": "Submit",
+      "%webView_{feature}_cancelButton%": "Cancel",
+      "%webView_{feature}_errorMessage%": "An error occurred"
+    },
+    "es": {
+      "%webView_{feature}_title%": "Título de la función",
+      "%webView_{feature}_submitButton%": "Enviar",
+      "%webView_{feature}_cancelButton%": "Cancelar",
+      "%webView_{feature}_errorMessage%": "Ocurrió un error"
+    }
+  }
+}
+```
+
+---
+
+## Localizing Shared Library Components (`lib/platform-bible-react/`)
+
+The pattern above assumes a web view that can call `useLocalizedStrings` (a PAPI/`@papi/frontend` hook). **Components that live in `lib/platform-bible-react/` cannot do this.** That library is process-agnostic and must stay free of any PAPI dependency, so a library component must NOT resolve its own strings — the consuming extension resolves them and passes them in.
+
+The established contract for a localizable library component is three parts:
+
+1. **A frozen `STRING_KEYS` tuple** of the localize keys the component needs, exported so consumers have a typed handle to feed into `useLocalizedStrings`:
+
+   ```typescript
+   export const BOOK_CHAPTER_CONTROL_STRING_KEYS = Object.freeze([
+     '%webView_bookChapterControl_selectChapter%',
+     '%webView_bookChapterControl_selectVerse%',
+     // ...
+   ] as const);
+   ```
+
+2. **A `Partial<Record<…>>`-shaped type** derived from that tuple, so stories/tests can pass a partial map and rely on the fallback:
+
+   ```typescript
+   export type BookChapterControlLocalizedStrings = {
+     [key in (typeof BOOK_CHAPTER_CONTROL_STRING_KEYS)[number]]?: string;
+   };
+   ```
+
+3. **An optional `localizedStrings?` prop** typed as that mapped type (or the shared `LanguageStrings` type from `platform-bible-utils`). Inside the component, every read goes through an English-fallback lookup so the component still renders readable text when a key is absent:
+
+   ```tsx
+   const selectChapter =
+     localizedStrings?.['%webView_bookChapterControl_selectChapter%'] ?? 'Select Chapter';
+   ```
+
+The consuming extension resolves the keys with `useLocalizedStrings(STRING_KEYS)` and passes the result down as the `localizedStrings` prop — the library never imports PAPI.
+
+**Avoid:**
+- Calling `useLocalizedStrings` (or any `@papi/*` hook) inside a `lib/platform-bible-react/` component — it couples the process-agnostic library to PAPI.
+- Hardcoded English text in JSX. This is enforced by the ESLint rule **`paranext/no-hardcoded-jsx-strings`** (in `lib/eslint-plugin-paranext/`).
+- Ad-hoc `localizedStrings: Record<string, string>` props with no typed `STRING_KEYS` tuple — callers lose the typed key list and the partial-map guarantee.
+
+**Why:** the `STRING_KEYS` tuple gives consumers a typed, single-source key list for the `useLocalizedStrings` lookup; the `Partial<Record>` type lets stories pass a subset and trust the fallback; the English-fallback read keeps the component usable in isolation. Established precedent: `BookChapterControl`, `BookSelector`, `MarkerMenu`, `Inventory`, `ScopeSelector`, `CommentEditor`, `CommentList`, `FootnoteEditor`, `UndoRedoButtons`, `ErrorPopover`, `ErrorDump`. See `lib/platform-bible-react/src/components/advanced/book-chapter-control/book-chapter-control.types.ts` for the `STRING_KEYS` + `…LocalizedStrings` pair and `book-chapter-control.component.tsx` for the `?? 'English'` fallback reads.
+
+> Note: a few components also accept a separate data map prop such as `localizedBookNames?: Map<…>` for localized book names — that is a distinct, data-shaped prop, not the string-key mechanism described here.
+
+---
+
+## Conventions
+
+### Key Format
+
+Use the pattern: `%webView_{feature}_{elementDescription}%`
+
+Examples:
+- `%webView_projectProperties_title%`
+- `%webView_projectProperties_saveButton%`
+- `%webView_projectProperties_cancelButton%`
+
+#### One key-prefix convention per feature namespace
+
+**Within a single feature namespace in `localizedStrings.json`, all new keys MUST share one prefix convention.** Prefer **camelCase feature-prefix with `_` subsegment separators** (e.g. `%webView_bookSelector_more%`, `%markerMenu_searchPlaceholder%`) — this matches the dominant in-repo style. Lowercase `snake_case` throughout is acceptable *only* if the namespace has no pre-existing keys.
+
+- **Avoid:** mixing camelCase and snake_case variants of the same prefix inside one namespace (e.g. `markersChecklist_*` alongside `markers_checklist_*`).
+
+Consistency is scoped *per feature namespace*, not globally: existing files mix legacy PascalCase enum keys (e.g. `CheckType_3`) with modern camelCase prefix keys, and reconciling those globally would churn established translations. Just don't introduce a second style for the same prefix.
+
+### Ellipsis Usage
+
+Add `...` to labels that open dialogs:
+- "New Project..." (opens a dialog)
+- "Save" (immediate action, no ellipsis)
+
+### Language Requirements
+
+**Always provide both `en` AND `es` translations.** Both are required for the build to pass.
+
+---
+
+## Text Direction (RTL/LTR)
+
+**Per-content text direction MUST come from the `platform.textDirection` project setting.** Read it via:
+
+```typescript
+const [textDirection] = useProjectSetting(
+  projectId,
+  'platform.textDirection',
+  'ltr', // default
+);
+```
+
+The setting type is `'ltr' | 'rtl' | '' | undefined` (declared in `src/declarations/papi-shared-types.ts`). The platform derives it from the project's language definition by default; admins can override per project.
+
+### Do NOT hardcode language-code direction checks
+
+```tsx
+// ❌ WRONG — misses most RTL languages, ignores admin overrides
+<div dir={language === 'he' || language === 'ar' ? 'rtl' : undefined}>
+
+// ✅ RIGHT — sourced from the project setting
+<div dir={textDirection}>
+```
+
+Hardcoded language-code equality checks (`x === 'he'`, `x === 'ar'`, etc.) miss many RTL languages (Persian, Urdu, Pashto, Yiddish, Sindhi, Kurdish Sorani, Dhivehi, …) and ignore admin overrides. The project setting is the single source of truth.
+
+### Multi-project UIs
+
+When a UI shows content from multiple projects (e.g., parallel-passages, comparative-text columns in markers-checklist), resolve `platform.textDirection` per-project and apply the resolved direction at the column level. Cells inherit their column's direction.
+
+### Reference implementation
+
+`extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx` — uses `useProjectSetting(projectId, 'platform.textDirection', defaultTextDirection)` with a module-level `const defaultTextDirection = 'ltr'`. The same file shows the project-specific `OHEBGRK` exception pattern (in the `textDirectionEffective` memo) for projects that need conditional direction (OT=RTL, NT=LTR). Search for the `defaultTextDirection` constant and the `OHEBGRK` branch rather than relying on line numbers.
+
+### Global UI direction is separate
+
+`readDirection()` from `lib/platform-bible-react/src/utils/dir-helper.util.ts` reads the user's **global UI direction** preference from `localStorage`. That is the user's UI preference (controlling layout direction of toolbars, sidebars, dropdowns), not content direction. Do not use it for per-content / per-cell direction.
+
+---
+
+## Reusing Existing Strings (IMPORTANT)
+
+**Before creating new keys**, scan the extension's `localizedStrings.json` for existing strings you can reuse:
+
+```bash
+# Search for common strings in the extension's localization file
+grep -i "cancel\|ok\|save\|close\|submit\|error\|loading" \
+  extensions/src/{ext}/contributions/localizedStrings.json
+```
+
+Common reusable keys (check if they exist first):
+- `%general_cancel%` - "Cancel"
+- `%general_ok%` - "OK"
+- `%general_save%` - "Save"
+- `%general_close%` - "Close"
+- `%general_loading%` - "Loading..."
+- `%general_error%` - "Error"
+
+**Do NOT create duplicate keys** for generic strings that already exist.
+
+---
+
+## Existing Strings Are Immutable (CRITICAL)
+
+**NEVER modify existing key/value pairs in `localizedStrings.json`.** Changing existing strings breaks translations and downstream consumers.
+
+### If a String Needs Replacement
+
+If a string needs to be replaced with a different value:
+
+1. **Create a NEW key** with the desired value
+2. **Add a fallback mapping** in the `metadata` section to redirect the old key:
+
+```json
+{
+  "metadata": {
+    "%oldKey_thatNeedsReplacement%": {
+      "fallbackKey": "%newKey_withCorrectValue%"
+    }
+  },
+  "localizedStrings": {
+    "en": {
+      "%newKey_withCorrectValue%": "The new correct text"
+    },
+    "es": {
+      "%newKey_withCorrectValue%": "El nuevo texto correcto"
+    }
+  }
+}
+```
+
+**What this achieves:**
+- Old code using `%oldKey_thatNeedsReplacement%` continues to work (falls back to new key)
+- New code uses the new key directly
+- No breaking changes to existing translations
+
+---
+
+## Dynamic Values with formatReplacementString
+
+For strings with dynamic values (counts, names, etc.):
+
+```typescript
+import { formatReplacementString } from 'platform-bible-utils';
+
+const message = formatReplacementString(
+  localizedStrings['%webView_{feature}_resultsCount%'], // "Found {count} results"
+  { count: results.length }
+);
+```
+
+In `localizedStrings.json`:
+```json
+{
+  "en": {
+    "%webView_{feature}_resultsCount%": "Found {count} results"
+  },
+  "es": {
+    "%webView_{feature}_resultsCount%": "Se encontraron {count} resultados"
+  }
+}
+```
+
+---
+
+## Localization Checklist
+
+Before completing any UI work:
+
+- [ ] Scanned existing `localizedStrings.json` for reusable keys (Cancel, OK, Save, etc.)
+- [ ] Reused existing keys where applicable (no duplicates created)
+- [ ] All visible text uses `localizedStrings[key]`
+- [ ] `LOCALIZED_STRINGS` array includes all keys
+- [ ] English translations added to `localizedStrings.json`
+- [ ] Spanish translations added to `localizedStrings.json`
+- [ ] No hardcoded English strings in JSX
+- [ ] Dynamic values use `formatReplacementString`
+- [ ] NO existing key/value pairs were modified (used `metadata.fallbackKey` if replacement needed)
+
+---
+
+## Blocking Issues
+
+The following are **blocking issues** that must be resolved before the work can be marked complete:
+
+1. **Hardcoded English text** - Any user-visible text not going through localization
+2. **Missing translations** - Keys exist in `en` but not `es` (or vice versa)
+3. **Modified existing strings** - Changing values of existing keys (use `metadata.fallbackKey` instead)
+4. **Duplicate keys** - Creating new keys for strings that already exist
+
+---
+
+## C# Backend Localization
+
+Backend services (C# code in `c-sharp/`) that return user-facing strings across the PAPI wire **must** participate in localization. Two approaches, depending on where the string originates:
+
+### Approach 1: Resolve at the wire boundary (PREFERRED)
+
+Stateless services return **localize keys** (`%key%`); the wrapping `NetworkObject` / `DataProvider` resolves them via `LocalizationService.GetLocalizedString(...)` before serializing the wire response. This keeps pure-function services free of `PapiClient` coupling.
+
+```csharp
+// Pure static service — returns the KEY
+public static class MarkersDataSource
+{
+    public const string InvalidMarkerPairErrorKey = "%markersChecklist_errorInvalidMarkerPair%";
+
+    public static MarkerSettingsValidationResult ValidateMarkerSettings(string input)
+    {
+        // ... parsing ...
+        if (failed)
+            return new MarkerSettingsValidationResult(false, null, InvalidMarkerPairErrorKey);
+        return new MarkerSettingsValidationResult(true, parsed, null);
+    }
+}
+
+// NetworkObject wrapper — resolves the key before sending over the wire
+public class ChecklistNetworkObject(PapiClient papi, LocalParatextProjects projects)
+    : NetworkObject(papi, "platformScripture.checklistService")
+{
+    private MarkerSettingsValidationResult ValidateMarkerSettings(string input)
+    {
+        var result = MarkersDataSource.ValidateMarkerSettings(input);
+        if (result.ErrorMessageKey == null) return result;
+        var localized = LocalizationService.GetLocalizedString(
+            PapiClient,
+            result.ErrorMessageKey,
+            "Equivalent markers need to be entered in the form: p/q" // English fallback
+        );
+        return result with { ErrorMessage = localized, ErrorMessageKey = null };
+    }
+}
+```
+
+### Approach 2: Resolve inline (when `PapiClient` is in hand)
+
+If the code is already inside a `DataProvider`/`NetworkObject` method, call `LocalizationService.GetLocalizedString(PapiClient, key, defaultValue)` directly.
+
+### Suggested helper: `IsLocalizeKey` idempotence guard
+
+When the wire layer resolves localize keys inside a record field (rather than a dedicated `xxxKey`/`xxxMessage` field pair), add a lightweight check to avoid double-resolving an already-resolved value. This matters if a record could be passed through the resolver twice (test round-trips, future pipeline changes, re-entry after caching, etc.):
+
+```csharp
+/// <summary>
+/// Lightweight test for "looks like a localize key" — wrapped in %
+/// sentinels per paranext-core convention. Idempotence guard: ensures
+/// calling the resolver twice on the same record does not second-time
+/// through LocalizationService.GetLocalizedString on an already-resolved
+/// English value.
+/// </summary>
+private static bool IsLocalizeKey(string? s) =>
+    s != null && s.Length >= 2 && s[0] == '%' && s[^1] == '%';
+```
+
+Then gate resolution on the check:
+
+```csharp
+if (!IsLocalizeKey(result.Message)) return result;
+var resolved = LocalizationService.GetLocalizedString(PapiClient, result.Message, fallback);
+return result with { Message = resolved };
+```
+
+Alternative design: use a dedicated `xxxKey` field (e.g. `ErrorMessageKey`) alongside `xxxMessage`, and clear the key when resolving. That is stricter but requires contract changes. The `IsLocalizeKey` sentinel approach preserves the existing contract and costs two characters of runtime check.
+
+### What NOT to do
+
+- ❌ **Do not return byte-exact English literals** from C# to the wire — they bypass localization
+- ❌ **Do not thread `PapiClient` into stateless static services** just to localize — use Approach 1
+- ❌ **Do not call `LocalizationService.GetLocalizedString` from a static service without `PapiClient`** — static services don't have one
+
+### C# Localization Checklist
+
+- [ ] Every user-facing string returned from C# to the wire uses a localize key, not an English literal
+- [ ] The extension's `localizedStrings.json` contains the key in `en` (always) and any other supported languages
+- [ ] Resolution happens at the `NetworkObject` / `DataProvider` layer, not in static services
+- [ ] English fallback is provided as the `defaultValue` argument to `GetLocalizedString` so the service still returns something readable if localization lookup fails
+
+---
+
+## Version Log
+
+| Version | Date       | Change          |
+| ------- | ---------- | --------------- |
+| 1.4.0   | 2026-06-17 | Added "Localizing Shared Library Components (`lib/platform-bible-react/`)" section: process-agnostic library components must not call `useLocalizedStrings`/PAPI; they expose a frozen `STRING_KEYS` tuple + a `Partial<Record<…>>` type + an optional `localizedStrings?` prop with English-fallback reads, and the consumer resolves and passes strings down. Named the hardcoded-string enforcer as the real ESLint rule `paranext/no-hardcoded-jsx-strings`. Added a "one key-prefix convention per feature namespace" subsection under Conventions › Key Format (prefer camelCase feature-prefix with `_` subsegments; don't mix camelCase and snake_case variants of the same prefix). Grounded against `book-chapter-control`, `book-selector`, and `marker-menu`. |
+| 1.3.0   | 2026-04-29 | Added "Text Direction (RTL/LTR)" section codifying per-content direction via `useProjectSetting('platform.textDirection', defaultTextDirection)`. Forbids hardcoded language-code equality checks (`x === 'he' \|\| x === 'ar'`). References `platform-scripture-editor.web-view.tsx` (the `defaultTextDirection` constant and the `OHEBGRK` branch) as the canonical pattern. Clarifies separation between global UI direction (`readDirection()`) and per-content direction. Sourced from markers-checklist PR feedback (RTL-hardcoding comment). |
+| 1.2.0   | 2026-04-21 | Added `toc: true` + machine-readable TOC block now that the guide has grown past the stub-patterns.md threshold. No content changes. |
+| 1.1.1   | 2026-04-20 | Patch from markers-checklist post-implementation review. Clarified that extensions adding language sections do NOT register the language with the UI picker — picker reads `assets/localization/*.json` filenames, so a language is only end-user-reachable when a corresponding root file exists. Clarified that `assets/localization/metadata.json` is key-level metadata, not a language manifest. |
+| 1.1.0   | 2026-04-20 | Added C# Backend Localization section. Clarified single-store/two-APIs architecture, fallback chain, and where to put strings based on PAPI namespace. Scope widened beyond UI web views. |
+| 1.0.0   | 2026-03-04 | Initial version |

--- a/.context/standards/Paranext-Core-Patterns.md
+++ b/.context/standards/Paranext-Core-Patterns.md
@@ -1,0 +1,1171 @@
+---
+title: paranext-core Implementation Patterns
+description: Established C#/TypeScript patterns, naming conventions, file organization, and test infrastructure.
+---
+
+# paranext-core Implementation Patterns
+
+This document describes the established patterns in the paranext-core codebase — the conventions a new contributor should follow when adding C# services, data providers, TypeScript commands, or extensions.
+
+## C# Patterns
+
+### Namespaces
+
+- **Root namespace:** `Paranext.DataProvider`
+- **By directory:** `Paranext.DataProvider.{Directory}`
+
+The namespace of classes in each file should always match the directory where the file resides.
+
+### Directory Structure
+
+```
+c-sharp/
+├── Projects/              # Project data providers and factories
+├── Services/              # Static service classes
+├── Checks/                # Inventory and check management
+├── JsonUtils/             # JSON serialization utilities
+├── NetworkObjects/        # DataProvider/NetworkObject base classes
+├── ParatextUtils/         # Paratext integration utilities
+├── Users/                 # User management
+├── Program.cs             # Entry point
+└── PapiClient.cs          # Core PAPI communication client
+```
+
+The goal is to aggregate related classes into the same directory, providing a logical taxonomy of capabilities.
+
+### Library Choices
+
+Terse decisions for the C# backend. Each lists the chosen approach, what to avoid, and why.
+
+- **JSON serialization:** System.Text.Json.
+  - Avoid: Newtonsoft (Json.NET).
+  - Why: modern, built-in, faster. STJ is the established convention (54 files use it; a single legacy Newtonsoft usage survives in `EnhancedResources/PartOfSpeechTranslator.cs`).
+- **Dependency injection:** manual constructor wiring.
+  - Avoid: any DI container (Microsoft.Extensions.DependencyInjection, Autofac, etc.).
+  - Why: explicit, simpler to debug; the object graph is small and assembled in `Program.cs`.
+- **Custom exceptions:** structured exception classes with typed properties (e.g. `MissingBookException` carries `BookNum` / `ProjectId`; `PermissionsException` carries `ProjectId` / `SafetyCheckMessage`), declared `public` so they serialize across the process boundary.
+  - Avoid: bare `Exception` with only a message string when the caller needs structured metadata.
+  - Why: the structured properties survive serialization and let callers handle errors by data rather than by parsing the message. (See **Exception Handling** below for the full pattern. Note: to attach a machine-readable *code* across the PAPI wire, do not throw a custom type — use `PlatformErrorCodes.WithCode`; see **PlatformError Codes**.)
+- **Custom JSON converters:** a custom `JsonConverter<T>` registered in `SerializationOptions.CreateSerializationOptions()` (`c-sharp/JsonUtils/`).
+  - When: you don't own the type (e.g. `SIL.Scripture.VerseRef`), or the wire shape diverges from the C# shape (e.g. `VerseRefConverter` accepts both `book` and `bookNum` input forms).
+  - Avoid: hand-rolled per-call-site parsing, or registering the converter ad hoc instead of centrally in `CreateSerializationOptions()`.
+  - Why: centralized registration and consistent camelCase conversion; the converter is the escape hatch when attributes can't express the mapping. (See **JSON Serialization Converters** below.)
+- **Polymorphic serialization:** `[JsonPolymorphic(TypeDiscriminatorPropertyName = "type")]` + `[JsonDerivedType(typeof(Subtype), "discriminator")]` on the abstract base record.
+  - When: you define the discriminated-union hierarchy in this repository AND it has a simple tagged-union wire shape (one discriminator property naming the subtype).
+  - Avoid: attribute-based polymorphism for types you don't own or that need multiple input shapes / wire transformations beyond a single discriminator — fall back to a custom `JsonConverter<T>` there.
+  - Why: declarative, co-located with the type hierarchy, zero runtime registration, compile-time-validated subtype list. Example: `c-sharp/Checklists/ChecklistContentItem.cs` (the `TextItem` / `VerseItem` / `EditLinkItem` / `LinkItem` / `ErrorItem` / `MessageItem` union).
+- **D-Bus client (Linux-only IPC):** `Tmds.DBus.Protocol`.
+  - When: low-level Linux D-Bus IPC (e.g. IBus input-method-framework integration).
+  - Avoid: `Tmds.DBus` (the legacy higher-level package — in maintenance mode), and `dbus-sharp` (unmaintained).
+  - Why: the actively maintained low-level library (.NET 8/9 + AOT-compatible) where new D-Bus features land. (No D-Bus code is present in `main` today; this records the decision for when such IPC is added.)
+
+### Logic Placement
+
+Put business logic that needs direct `ParatextData` access in the C# process (`c-sharp/`).
+
+- Avoid: implementing such logic in TypeScript — the renderer/extension-host processes cannot reach `ParatextData.dll`, so anything depending on it must live in C#.
+- Why: C# has direct `ParatextData.dll` access and is the same language the logic was originally written in, keeping the port faithful. Expose the result to TS over PAPI (NetworkObject / DataProvider) rather than reimplementing the logic across the wire.
+
+### Service Patterns
+
+#### Outgoing Calls (C# → PAPI Network)
+
+##### 1. Static Service Wrappers
+
+Use for making one-time PAPI calls from C# to services hosted elsewhere on the network.
+
+**Location:** `c-sharp/Services/`
+
+**Pattern:**
+```csharp
+public static class MyService
+{
+    public static T MethodName(PapiClient client, params...)
+    {
+        return ThreadingUtils.GetTaskResult(
+            client.SendRequestAsync<T>(requestType, [params]),
+            $"MyService.MethodName",
+            ThreadingUtils.DefaultTimeout
+        );
+    }
+
+    public static void DoSomething(params...)
+    {
+        if (!ThreadingUtils.RunTask(
+            DoSomethingAsync([params]),
+            $"MyService.DoSomething",
+            ThreadingUtils.DefaultTimeout))
+        {
+            throw new Exception("DoSomething failed to complete in a timely fashion");
+        }
+    }
+}
+```
+
+Note: Services use synchronous wrappers via `ThreadingUtils.GetTaskResult()` to bridge async PAPI calls.
+
+**Examples:**
+- `AppService.GetAppInfo(client)` - Retrieves app metadata
+- `SettingsService.GetSetting<T>(client, key)` - Gets settings
+- `SettingsService.SetSetting(client, key, value)` - Sets settings
+
+**When to use:**
+- C# code needs to call a service hosted elsewhere on the PAPI network
+- Examples: getting settings, app info, localized strings
+
+#### Incoming Calls (PAPI Network → C#)
+
+##### 2. Individual Commands
+
+**Location:** `c-sharp/{Directory Containing Related Functionality}/`
+
+**Pattern:**
+```csharp
+public class MyService
+{
+    public void DoSomething(params...)
+    {
+        ...
+    }
+
+    public void DoSomethingElse(params...)
+    {
+        ...
+    }
+
+    public async Task InitializeAsync(PapiClient client)
+    {
+        await client.RegisterRequestHandlerAsync(
+            "command:{extensionName}.doSomething",
+            DoSomething);
+
+        await client.RegisterRequestHandlerAsync(
+            "command:{extensionName}.doSomethingElse",
+            DoSomethingElse);
+    }
+}
+```
+
+Note: `InitializeAsync()` must be called in `Program.cs` to make commands available to PAPI clients.
+
+**Examples:**
+- `ProjectSettingService.RegisterValidator(client, key, callback)` - Registers callback on PAPI network for project setting
+
+**When to use:**
+- Loose, unrelated handlers that don't belong to a named service (no cohesive service identity)
+- Ad-hoc utilities or cross-cutting helpers registered once in `Program.cs`
+
+**When not to use:**
+- Handlers belong to a cohesive named service — use NetworkObject, regardless of method count
+- Data needs subscription semantics — use DataProvider
+
+##### 3. DataProvider Classes (Stateful, Subscribable Data)
+
+Use for data that needs to be subscribed to or updated over time.
+
+**Location:** `c-sharp/{Directory Containing Related Functionality}/`
+
+**Inheritance:**
+```
+NetworkObject (base)
+  └── DataProvider (abstract)
+        ├── ProjectDataProvider (abstract)
+        │   └── ParatextProjectDataProvider
+        ├── InventoryDataProvider
+        └── TimeDataProvider (sample code, not used in production)
+```
+
+**Key methods:**
+- `RegisterDataProviderAsync()` - Registers on PAPI network
+- `GetFunctions()` - Returns callable functions as `List<(string functionName, Delegate function)>`
+- `SendDataUpdateEvent()` - Notifies network of data changes
+- `StartDataProviderAsync()` - Starts the provider after registration
+
+**When to use:**
+- Stateful data whose consumers need to observe changes over time (the `get` / `set` / `subscribe` triplet over named data types)
+- Project-specific data providers
+
+**When not to use:**
+- Pure stateless query/command services with no subscription semantics — use NetworkObject. DataProvider machinery (`DataProviderUpdateInstructions`, `SendDataUpdateEvent`, selector-parameter convention, `IDataProvider<TDataTypes>`) is unnecessary overhead when there is no subscribable data.
+
+Note: `RegisterDataProviderAsync()` must be called in `Program.cs` to be available to PAPI clients.
+
+##### 4. NetworkObject Classes (Cohesive Named Service, Non-Subscribable)
+
+Use to expose a stateless query/command service as a named, typed network object consumed via `papi.networkObjects.get<IService>(name)`. Any method count — the criterion is semantics, not size.
+
+**Location:** `c-sharp/{Directory Containing Related Functionality}/`
+
+**Inheritance:**
+```
+NetworkObject (base)
+  └── SomeNetworkObject (example name, not real network object)
+```
+
+**Key methods:**
+- `RegisterNetworkObjectAsync()` - Registers on PAPI network
+- `GetFunctions()` - Returns callable functions as `List<(string functionName, Delegate function)>`
+
+**When to use:**
+- Stateless query/command functions grouped as a named service with a cohesive identity (e.g. `platformScripture.checklistService`)
+- No subscription semantics (no `get`/`set`/`subscribe` over named data types)
+- Any method count — even a 3-method service belongs here if it represents a named service
+
+**When not to use:**
+- Stateful subscribable data — use DataProvider
+- Ad-hoc handlers with no service identity — use individual commands
+
+Note: `RegisterNetworkObjectAsync()` must be called in `Program.cs` to be available to PAPI clients. See the **When to use** / **When not to use** notes on each pattern above for choosing between DataProvider, NetworkObject, and individual commands.
+
+#### Adding a Method to an Existing Project Data Provider
+
+When you want to expose new data from an existing `ProjectDataProvider` (e.g. `ParatextProjectDataProvider`) — not create a new provider — the plumbing spans both C# and TypeScript. Follow all 6 steps; skipping any one of them silently breaks the method.
+
+**Illustrative example.** The snippets below use a hypothetical `BookSummary` data type (per-book summary text) so the recipe is unambiguous. The names are invented; the structure is what every contract method must follow.
+
+> **Naming rule (read first).** `get`, `set`, and `subscribe` are **magic prefixes** for the TS data provider service. Use them only for methods that are part of the data provider's interface/contract. The contract is split across the two languages:
+>
+> - `Get*` and `Set*` are implemented in **C#**. `Set*` must call `SendDataUpdateEvent` for each affected data type whenever the data changes — that is how subscribers get notified.
+> - `subscribe*` exists only on the **TS** side and is **auto-generated** by the TS data provider service from the events emitted by `Set*`. You declare `subscribe*` in the `.d.ts` so TS callers can reference it; you do not write a body for it in either C# or TS.
+> - Each data type needs its own paired `Set*` (C#) and `subscribe*` (TS `.d.ts`) to go with its `Get*`. They cannot be shared across multiple `Get*` methods.
+>
+> If you only need a helper method on the provider that is **not** part of the contract, the method MUST NOT start with `get`/`set`/`subscribe` — those prefixes opt the method into the contract. Use any other appropriate verb (e.g. `lookup*`, `compute*`, `list*`). The recipe below assumes you are adding a contract method.
+
+1. **C# methods.** Add `public` `Get*` and `Set*` methods on the provider class (e.g. `ParatextProjectDataProvider.cs`). Keep each focused — one method per conceptual operation. The `Get*` reads from the underlying source; the `Set*` writes and then calls `SendDataUpdateEvent` for the affected data type so subscribers get notified:
+   ```csharp
+   public string? GetBookSummary(int bookNum)
+   {
+       var scrText = LocalParatextProjects.GetParatextProject(ProjectDetails.Metadata.Id);
+       // ... read the per-book summary from your storage of choice ...
+       return summary;
+   }
+
+   public bool SetBookSummary(int bookNum, string summary)
+   {
+       var scrText = LocalParatextProjects.GetParatextProject(ProjectDetails.Metadata.Id);
+       // ... write the new value to your storage of choice ...
+       SendDataUpdateEvent(ProjectDataType.BOOK_SUMMARY, "book summary data update event");
+       return true;
+   }
+   ```
+   You will also need to add a matching `BOOK_SUMMARY` constant to `ProjectDataType.cs` (e.g. `public const string BOOK_SUMMARY = "BookSummary";`) — that is the string `SendDataUpdateEvent` carries to the TS side.
+2. **C# registration.** Register both methods in the provider's `GetFunctions()` override (string name → delegate). The string is what TS consumers call:
+   ```csharp
+   retVal.Add(("getBookSummary", GetBookSummary));
+   retVal.Add(("setBookSummary", SetBookSummary));
+   ```
+3. **C# interface constant.** Add the `projectInterface` name to `c-sharp/Projects/ProjectInterfaces.cs`:
+   ```csharp
+   public const string BOOK_SUMMARY = "platformScripture.BookSummary";
+   ```
+4. **C# project advertisement.** Add the constant to the provider's supported interfaces list (e.g. `s_paratextProjectInterfaces` in `LocalParatextProjects.cs`) so projects advertise it via `getMetadataForAllProjects`:
+   ```csharp
+   ProjectInterfaces.BOOK_SUMMARY,
+   ```
+5. **TypeScript types.** In the extension's `types/*.d.ts` (e.g. `platform-scripture.d.ts`), declare both the data-types record and the interface. The data-types record's **keys** (`BookSummary` here) determine the names of the `get*` / `set*` / `subscribe*` methods, and its three type parameters — `<TSelector, TGetData, TSetData>` — fix the argument and return types of all three methods (see `src/shared/models/data-provider.model.ts` for the canonical `DataProviderGetter` / `DataProviderSetter` / `DataProviderSubscriber` JSDoc):
+
+   ```ts
+   /** Provides per-book summary text */
+   export type BookSummaryProjectInterfaceDataTypes = {
+     /** Per-book summary text */
+     BookSummary: DataProviderDataType<number, string | undefined, string>;
+   };
+
+   /** Provides per-book summary text editable by the user */
+   export type IBookSummaryProjectDataProvider =
+     IProjectDataProvider<BookSummaryProjectInterfaceDataTypes> & {
+       getBookSummary(bookNum: number): Promise<string | undefined>;
+       setBookSummary(
+         bookNum: number,
+         summary: string,
+       ): Promise<DataProviderUpdateInstructions<BookSummaryProjectInterfaceDataTypes>>;
+       subscribeBookSummary(
+         bookNum: number,
+         callback: (summary: string | undefined | PlatformError) => void,
+         options?: DataProviderSubscriberOptions,
+       ): Promise<UnsubscriberAsync>;
+     };
+   ```
+
+   Each `get*` on the interface needs its own paired `set*` and `subscribe*` declaration — you cannot share them across multiple gets, even when the data is effectively read-only. The `subscribe*` declaration is **declaration-only**: the TS data provider service auto-generates the body from the events your C# `Set*` emits. Don't write an implementation in either C# or TS.
+6. **TypeScript registration.** Import the interface into the `papi-shared-types` block (same file) and add the entry to `ProjectDataProviderInterfaces`:
+   ```ts
+   import type {
+     // ...
+     IBookSummaryProjectDataProvider,
+   } from 'platform-scripture';
+
+   export interface ProjectDataProviderInterfaces {
+     // ...
+     'platformScripture.BookSummary': IBookSummaryProjectDataProvider;
+   }
+   ```
+   The string key here MUST match the value of the C# constant from step 3 byte-for-byte.
+
+**Consuming from a web view:**
+```tsx
+const pdp = useProjectDataProvider('platformScripture.BookSummary', projectId);
+const summary = await pdp?.getBookSummary(bookNum);
+```
+
+**Verification:**
+- Call over PAPI directly: `object:{pdpName}.{methodName}` via `papi-client` skill — confirms C# registration and delegate wiring.
+- Check project advertisement: `getMetadataForAllProjects` should list the new interface name on each qualifying project.
+- Extension typecheck (`npx tsc -p extensions/src/{ext}/tsconfig.json`) must pass — catches TS interface/registration mismatches.
+
+**Common mistakes:**
+- Forgetting step 4: method works over PAPI, but `useProjectDataProvider(...)` returns `undefined` because the project doesn't advertise support for the new interface name.
+- Step 2 name mismatch: C# registers `"getBookSummary"` but TS declares `getBookSummaries` (or any other variant) — method appears missing at runtime with a confusing error.
+- Step 3 ↔ step 6 mismatch: the C# constant value (e.g. `"platformScripture.BookSummary"`) and the TS `ProjectDataProviderInterfaces` key must be byte-identical.
+- Omitting `set*` / `subscribe*` on the TS interface: type check fails because `IProjectDataProvider<T>` requires them even for effectively read-only data.
+- **Sharing one `set*`/`subscribe*` across multiple `get*` methods.** Each `get*` needs its own paired `set*` and `subscribe*` — the data provider service does not allow shared partners.
+- **Implementing `subscribe*` body in C# or TS.** `subscribe*` is auto-generated by the TS data provider service from the events emitted by `Set*`. You only declare it in the TS `.d.ts`; never write a body for it in either language.
+- **Forgetting to call `SendDataUpdateEvent` from a C# `Set*`.** The write succeeds but no `subscribe*` callback ever fires, because the TS data provider service never sees the change.
+- **Using `get`/`set`/`subscribe` as a prefix for a non-contract helper method.** Those prefixes opt the method into the data provider contract; for extra (non-contract) methods, use any other appropriate verb (e.g. `lookup*`, `compute*`, `list*`).
+
+### Test Infrastructure
+
+- **Framework:** NUnit 4.0.1
+- **Test SDK:** Microsoft.NET.Test.Sdk v17.9.0
+- **Location:** `c-sharp-tests/{FeatureArea}/`
+
+**Base Classes:**
+- `PapiTestBase` - For tests needing PAPI client simulation
+  - Provides `CreateDummyProject()`, `CreateProjectDetails()`
+  - Provides `VerifyUsfmSame()`, `VerifyUsxSame()` for text comparison
+
+**Mock/Dummy Objects:**
+- `DummyScrText` - In-memory Paratext ScrText (complete file manager with in-memory storage)
+- `DummyPapiClient` - Simulates PAPI client, tracks sent events
+- `DummyLocalParatextProjects` - Allows fake project addition
+- `DummyParatextProjectDataProvider` - In-memory file storage
+
+**Fixture Setup Pattern:**
+```csharp
+[SetUpFixture]
+public class FixtureSetup
+{
+    [OneTimeSetUp]
+    public void RunBeforeAnyTests() => ParatextGlobals.Initialize(testFolder);
+
+    [OneTimeTearDown]
+    public void RunAfterAnyTests() => Directory.Delete(testFolder, true);
+}
+```
+
+**Test Parameterization:**
+```csharp
+[TestCase(1, 1, 0, @"\id GEN \ip intro \c 1 ")]
+[TestCase(1, 2, 1, @"\v 1 verse one ")]
+public void TestMethod(int bookNum, int chapterNum, int verseNum, string expected)
+{
+    // Test implementation
+}
+```
+
+---
+
+## Advanced C# Patterns
+
+These patterns cover cross-cutting concerns that implementers need to understand when building features in the C# backend.
+
+### Exception Handling
+
+Custom exception types with structured data for domain-specific errors.
+
+**Pattern:**
+```csharp
+// Custom exception with structured properties
+public class MissingBookException(int bookNum, string projectId)
+    : Exception($"Book number {bookNum} not found in project {projectId}.")
+{
+    public int BookNum { get; } = bookNum;
+    public string ProjectId { get; } = projectId;
+}
+```
+
+**When to create custom exceptions:**
+- Domain-specific errors that need structured metadata
+- Errors that cross process boundaries (will be serialized)
+- Errors that callers need to handle differently
+
+**Existing exceptions:**
+- `MissingBookException` - Book not found in project
+- `PermissionsException` - User lacks required permissions
+
+**Location:** `c-sharp/` (root level for shared exceptions)
+
+### PlatformError Codes (across the PAPI wire)
+
+When a C# exception crosses the PAPI wire boundary and the TS caller needs a machine-readable error code (`PERMISSION_DENIED`, `NOT_FOUND`, `UNAVAILABLE`, `INVALID_ARGUMENT`, `FAILED_PRECONDITION`, …), throw an exception built by `PlatformErrorCodes.WithCode(code, message)`.
+
+`WithCode` returns an `InvalidOperationException` and sets `ex.Data["platformErrorCode"] = code`. The exception *type* is informational only — the wire protocol keys solely off `Exception.Data`. On the TS side, `src/shared/services/network.service.ts` extracts `response.error.data?.data?.platformErrorCode` and forwards it to `newPlatformError(message, code)`, so the same string round-trips through JSON-RPC without re-encoding.
+
+The 16-value code set in `c-sharp/PlatformErrorCodes.cs` (`ABORTED`, `ALREADY_EXISTS`, `CANCELLED`, `DATA_LOSS`, `DEADLINE_EXCEEDED`, `FAILED_PRECONDITION`, `INTERNAL`, `INVALID_ARGUMENT`, `NOT_FOUND`, `OUT_OF_RANGE`, `PERMISSION_DENIED`, `RESOURCE_EXHAUSTED`, `UNAUTHENTICATED`, `UNAVAILABLE`, `UNIMPLEMENTED`, `UNKNOWN`) mirrors the TS `PlatformErrorCode` union in `lib/platform-bible-utils/src/platform-error.ts`. (`PlatformErrorCodes` also exposes `Throw(code, message)` — marked `[DoesNotReturn]` — and `TryGetCode(ex, out code)` for the catch side.)
+
+**Pattern:**
+```csharp
+throw PlatformErrorCodes.WithCode(
+    PlatformErrorCodes.PermissionDenied,
+    "You must be an administrator on this shared project.");
+```
+
+**Avoid:**
+- Throwing a *custom exception type* across the PAPI wire to signal a code — richer types do not survive the JSON-RPC serializer any better and complicate catch blocks. Use `WithCode` on the standard exception instead.
+- String-matching on `ex.Message` in TS — read the `platformErrorCode` property off the caught `PlatformError` instead.
+
+**Location:** `c-sharp/PlatformErrorCodes.cs`
+
+### Logging
+
+Uses Console for output to be logged. Do **NOT** use System.Diagnostics.Trace.
+
+**Pattern:**
+```csharp
+Console.WriteLine($"Processing feature: {featureName}");
+```
+
+**Anti-Pattern:**
+```csharp
+System.Diagnostics.Trace.WriteLine($"Processing feature: {featureName}");
+```
+
+### JSON Serialization Converters
+
+Custom converters for types that don't serialize naturally.
+
+**Pattern:**
+```csharp
+public class MyTypeConverter : JsonConverter<MyType>
+{
+    public override MyType? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        // Parse JSON and return object
+    }
+
+    public override void Write(Utf8JsonWriter writer, MyType value, JsonSerializerOptions options)
+    {
+        // Write object as JSON
+    }
+}
+```
+
+**Registering converters:**
+```csharp
+// In SerializationOptions.cs
+public static JsonSerializerOptions CreateSerializationOptions()
+{
+    var options = new JsonSerializerOptions
+    {
+        Encoder = JavaScriptEncoder.Create(UnicodeRanges.All),
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false,
+    };
+    options.Converters.Add(new MyTypeConverter());
+    return options;
+}
+```
+
+**Existing converters:**
+- `VerseRefConverter` - Paratext verse references
+- `CommentConverter` - Project comments
+- `InventoryOptionValueConverter` - Inventory option values
+- `InternetSettingsMementoConverter` - Internet settings
+
+**Location:** `c-sharp/JsonUtils/`
+
+### Multi-threaded/Concurrent Code
+
+#### Bridging sync/async code
+
+Use ThreadingUtils to bridge between sync/async code
+
+```csharp
+// Synchronous wrapper for async call
+protected void DoSomething(T parameter1, string description = "function call description")
+{
+    ThreadingUtils.RunTask(DoSomethingAsync(parameter1), description, ThreadingUtils.DefaultTimeout);
+}
+```
+
+**Location:** `c-sharp/ThreadingUtils.cs`
+
+#### Handling incoming PAPI calls
+
+Assume registered methods will be called concurrently. If some methods are not thread safe, lock all registered methods for the network object or data provider to achieve thread safety.
+
+```csharp
+internal sealed class MyDataProvider : NetworkObjects.DataProvider
+{
+    private readonly Dictionary<string, MyData> _dataByKey = new();
+    private readonly object _lock = new();
+
+    protected override List<(string functionName, Delegate function)> GetFunctions()
+    {
+        return [("getSomething", GetSomething), ("setSomething", SetSomething)];
+    }
+
+    protected MyData GetSomething(string scope)
+    {
+        if (string.IsNullOrEmpty(scope)) return null;
+        lock (_lock)
+        {
+            return _dataByKey[scope];
+        }
+    }
+
+    protected bool SetSomething(string scope, MyData data)
+    {
+        if (string.IsNullOrEmpty(scope)) return false;
+        lock (_lock)
+        {
+            _dataByKey[scope] = data;
+        }
+        SendDataUpdateEvent("MyDataType", "MyDataProvider updated Something");
+        return true;
+    }
+}
+```
+
+#### Concurrent collections
+
+Use to achieve thread safety without locking for simple key-value access
+
+```csharp
+private readonly ConcurrentDictionary<string, Worker> _workersByJobId = new();
+
+// Thread-safe add
+_workersByJobId.TryAdd(jobId, worker);
+
+// Thread-safe get or add
+var worker = _workersByJobId.GetOrAdd(jobId, _ => new Worker());
+
+// Thread-safe remove
+_workersByJobId.TryRemove(jobId, out _);
+```
+
+#### Interlocked
+
+Use to achieve thread safety without locking for atomic counter/flag operations
+
+```csharp
+Interlocked.Add(ref _totalCount, itemList.Count);
+```
+
+#### Double-checked locking for cached-instance factories
+
+For a factory that lazily creates and caches one instance per key, use the `ConcurrentDictionary` check → `lock` → re-check → create sequence. The lock-free first check handles the common (already-cached) path without contention; the re-check inside the lock prevents two callers from both creating the instance.
+
+```csharp
+if (_pdpMap.TryGetValue(projectID, out var existingPdp))
+    return existingPdp;
+
+lock (_creationLock)
+{
+    // Re-check: another caller may have created it while we waited for the lock.
+    if (_pdpMap.TryGetValue(projectID, out var existingPdpInLock))
+        return existingPdpInLock;
+
+    // ... create, add to _pdpMap, and return ...
+}
+```
+
+**When:** factory patterns with cached instances. Verified in `c-sharp/Projects/ParatextProjectDataProviderFactory.cs`.
+
+**Why:** minimizes lock contention for entries that already exist while keeping creation single-flighted.
+
+#### Atomicity
+
+If concurrent calls require more than a single operation to update shared state, then you **must** lock to achieve atomicity.
+
+```csharp
+private readonly ConcurrentDictionary<string, string> _dictionary1 = new();
+private readonly ConcurrentDictionary<string, string> _dictionary2 = new();
+private readonly object _lock = new();
+
+// ❌ Incorrect - multiple operations required to access shared state without locking
+public void NotThreadSafe(string key1, string key2, string value)
+{
+    _dictionary1.TryAdd(key1, value);
+    _dictionary2.TryAdd(key2, value);
+}
+
+// ✅ Correct - Locking when multiple operations required to access shared state
+public void ThreadSafe(string key1, string key2, string value)
+{
+    lock (_lock)
+    {
+        _dictionary1.TryAdd(key1, value);
+        _dictionary2.TryAdd(key2, value);
+    }
+}
+
+// ✅ Correct - No locking required because atomic operation used to access shared state
+public void ThreadSafe(string key1, string value)
+{
+    _dictionary1.TryAdd(key1, value);
+}
+```
+
+### PAPI Event/Request Registration
+
+Low-level patterns for registering handlers on the PAPI network.
+
+**Registering request handlers:**
+```csharp
+await PapiClient.RegisterRequestHandlerAsync(
+    $"object:{networkObjectName}.{functionName}",
+    functionDelegate,
+    optionalTimeout
+);
+```
+
+**Registering event handlers:**
+```csharp
+papiClient.RegisterEventHandler(
+    "platform.settingsServiceUpdate",
+    (JsonElement eventParams) =>
+    {
+        // Handle the event
+    }
+);
+```
+
+**Sending events:**
+```csharp
+await PapiClient.SendEventAsync(
+    "platform.dataProviderUpdate",
+    new { dataScope = scopeValue }
+);
+```
+
+**Location:** `c-sharp/PapiClient.cs`
+
+### Settings and Configuration Access
+
+**Services:**
+- `SettingsService` - Platform settings
+- `SharedStoreService` / `SharedStore` - Cross-process shared data
+- `ProjectSettingsService` - Project settings validation
+- `LocalizationService` - Localized strings
+
+**Location:** `c-sharp/Services/`
+
+#### Platform Settings (via PAPI)
+
+```csharp
+// Get setting (synchronous wrapper)
+public static T? GetSetting<T>(PapiClient papiClient, string key)
+{
+    return ThreadingUtils.GetTaskResult(
+        papiClient.SendRequestAsync<T?>("platform.settingsServiceGet", [key]),
+        $"SettingsService.GetSetting for {key}",
+        ThreadingUtils.DefaultTimeout
+    );
+}
+
+// Set setting
+public static void SetSetting(PapiClient papiClient, string key, object value)
+{
+    ThreadingUtils.GetTaskResult(
+        papiClient.SendRequestAsync<bool>("platform.settingsServiceSet", [key, value]),
+        $"SettingsService.SetSetting for {key}",
+        ThreadingUtils.DefaultTimeout
+    );
+}
+```
+
+**Location:** `c-sharp/Services/SettingsService.cs`
+
+#### Cross-Process Shared Data (Distributed Store with Lamport Clock)
+
+For settings that must reside in multiple processes for performance reasons (only one writer allowed)
+
+```csharp
+// Initialize shared store
+await SharedStoreService.InitializeAsync(papiClient);
+papiClient.SetSharedStore(SharedStoreService.GetSharedStore());
+
+// Access shared values
+var store = SharedStoreService.GetSharedStore();
+var value = store.Get<T>(key);
+store.Set(key, newValue);
+```
+
+**Location:** `c-sharp/Services/SharedStore.cs`
+
+#### Validating Project Settings
+
+```csharp
+public static bool IsValid(
+    PapiClient papiClient,
+    object? newValue,
+    object? currentValue,
+    string key,
+    object? allChanges)
+{
+    // Validate project-specific setting change
+}
+```
+
+**Location:** `c-sharp/Services/ProjectSettingsService.cs`
+
+#### Loading Localized Strings
+
+```csharp
+DoSomething(
+    arg1,
+    LocalizationService.GetLocalizedString(
+        PapiClient,
+        "%localization_key_for_error_message%",
+        $"Default value for error message"
+    )
+);
+```
+
+**Location:** `c-sharp/Services/LocalizationService.cs`
+
+### NetworkTimeout Attribute
+
+Attribute-based timeout configuration for network methods. If the method does not return within the timeout, a JSON-RPC error will be returned over JSON-RPC.
+
+**Pattern:**
+```csharp
+[NetworkTimeout(15000)]  // 15 second timeout
+public object? GetData(string selector)
+{
+    // Implementation
+}
+```
+
+**Location:** `c-sharp/NetworkTimeoutAttribute.cs`
+
+### Identifiers (API Design)
+
+Represent entity IDs as `string` (GUID form) on both the C# and TS sides of any PAPI contract.
+
+- Avoid: `int` IDs, or custom/strongly-typed ID wrapper types, in wire contracts.
+- Why: a plain string GUID round-trips through JSON-RPC unchanged and stays consistent across the C#/TS boundary and across systems. Example: `c-sharp/Projects/ScrTextExtensions.cs` surfaces a project's `scrText.Guid.ToString()` as its identifier.
+
+### Visibility and Access Modifiers
+
+Standard visibility patterns for different component types.
+
+| Component Type | Visibility | Reason |
+|----------------|------------|--------|
+| Static services | `internal static class` | Only used within C# backend |
+| DataProviders | `internal sealed class` | Single implementation, not inherited |
+| Workers | `internal sealed class` | Implementation detail |
+| Exceptions | `public class` | May cross process boundaries |
+| Result records | `public record` | Returned via PAPI |
+| Options records | `public record` | Passed via PAPI |
+
+**Pattern:**
+```csharp
+// Internal service - not exposed outside C# process
+internal static class FeatureService { }
+
+// Internal sealed DataProvider
+internal sealed class FeatureDataProvider : DataProvider { }
+
+// Public exception for serialization
+public class FeatureException : Exception { }
+
+// Public records for PAPI communication
+public record FeatureResult { }
+public record FeatureOptions { }
+```
+
+### File Organization Patterns
+
+**Principle**: One file per type. Do not combine multiple types into a single file except for one case: a record type is used by another record type exclusively. Then the exclusive record types should be in the same file with the shared record type.
+
+```csharp
+// ✅ Correct - One class in a file
+internal sealed class FeatureService
+{
+}
+```
+
+```csharp
+// ✅ Correct - Exclusively used records share file with primary record
+public record FeatureRecord
+{
+    public string Data { get; set; }
+    public FeatureRecordAttribute Attribute { get; set; }
+}
+
+public record FeatureRecordAttribute
+{
+}
+```
+
+```csharp
+// ❌ Incorrect - two or more shared types in a file
+public enum Enum1
+{
+}
+
+public enum Enum2
+{
+}
+
+public enum Enum3
+{
+}
+```
+
+**File-scoped namespaces**: Always use `namespace X;` (no braces), not `namespace X { }`
+
+```csharp
+// ✅ Correct - file-scoped namespace
+namespace Paranext.DataProvider.Feature;
+
+public record MyRecord { }
+
+// ❌ Incorrect - block-style namespace
+namespace Paranext.DataProvider.Feature
+{
+    public record MyRecord { }
+}
+```
+
+### Initialization Order
+
+Critical initialization sequence in Program.cs.
+
+**Pattern:**
+```csharp
+// 1. Initialize infrastructure first
+await SharedStoreService.InitializeAsync(papi);
+papi.SetSharedStore(SharedStoreService.GetSharedStore());
+SettingsService.Initialize(papi);
+
+// 2. Create providers and factories
+var factory = new ParatextProjectDataProviderFactory(papi);
+var inventoryProvider = new InventoryDataProvider(papi);
+var checkRunner = new CheckRunner(papi);
+
+// 3. Register in parallel where possible
+await Task.WhenAll(
+    factory.InitializeAsync(),
+    inventoryProvider.RegisterDataProviderAsync(),
+    checkRunner.RegisterDataProviderAsync()
+);
+
+// 4. Start providers after registration
+await Task.WhenAll(
+    factory.StartAsync(),
+    inventoryProvider.StartDataProviderAsync()
+);
+```
+
+**Key ordering rules:**
+1. SharedStore must initialize before PapiClient uses it
+2. Settings service must initialize before providers that need settings
+3. Registration before StartDataProviderAsync
+4. Use `Task.WhenAll` for independent parallel operations
+
+**Location:** `c-sharp/Program.cs`
+
+---
+
+## TypeScript Patterns
+
+### Command Naming
+
+- **Pattern:** `'{extensionName}.{commandName}'`
+- **Convention:** Lowercase extension name, camelCase command name
+
+**Examples:**
+- `'platformScripture.openCharactersInventory'`
+- `'platformScripture.openFind'`
+- `'helloRock3.helloRock3'`
+- `'helloSomeone.helloSomeone'`
+
+### Command Registration
+
+```typescript
+const commandPromise = papi.commands.registerCommand(
+  'extensionName.commandName',
+  asyncFunctionHandler,
+  {
+    method: {
+      summary: 'Command description',
+      params: [
+        {
+          name: 'paramName',
+          required: false,
+          summary: 'Parameter description',
+          schema: { type: 'string' },
+        },
+      ],
+      result: {
+        name: 'return value',
+        summary: 'Return value description',
+        schema: { type: 'string' },
+      },
+    },
+  },
+);
+
+context.registrations.add(await commandPromise);
+```
+
+### Type Declarations
+
+**Location:** `extensions/src/{extension}/src/types/{extension}.d.ts`
+
+**Pattern:**
+```typescript
+declare module '{extension-name}' {
+  // Import shared types
+  import type { DataProviderDataType, IDataProvider } from '@papi/core';
+
+  // Define data types
+  export type MyDataTypes = {
+    DataTypeName: DataProviderDataType<Selector, ReturnType, SetType>;
+  };
+
+  // Define provider interface
+  export type IMyProvider = IDataProvider<MyDataTypes> & {
+    methodName(param: Type): Promise<Result>;
+  };
+}
+
+declare module 'papi-shared-types' {
+  // Extend global interfaces
+  export interface CommandHandlers {
+    'extensionName.commandName': (param: Type) => Promise<Result>;
+  }
+
+  export interface DataProviders {
+    'extensionName.dataName': IMyProvider;
+  }
+
+  export interface SettingTypes {
+    'extensionName.settingName': SettingType;
+  }
+}
+```
+
+### Extension Structure
+
+```
+extensions/src/{extension}/
+├── src/
+│   ├── main.ts                    # Entry point with activate/deactivate
+│   ├── types/
+│   │   └── {extension}.d.ts       # Type declarations
+│   ├── web-views/                # (or flat in src/ — both layouts are used)
+│   │   ├── *.web-view.tsx         # React web view components
+│   │   └── *.web-view.scss        # Web view styles
+│   ├── models/
+│   │   └── *-provider-engine.model.ts  # Data provider implementations
+│   └── services/
+│       └── *.service.ts           # Business logic services
+├── contributions/                  # JSON contribution files
+├── assets/                        # Icons and static assets
+├── manifest.json                  # Extension metadata
+└── package.json                   # npm package metadata
+```
+
+### Extension Activate Function
+
+```typescript
+export async function activate(context: ExecutionActivationContext): Promise<void> {
+  // Register commands, validators, web views, data providers, etc.
+
+  // All registrations must be added to context.registrations:
+  context.registrations.add(
+    await commandPromise,
+    await webViewProviderPromise,
+    // ... all other registrations
+  );
+}
+
+// Optional - only implement if cleanup is needed
+export async function deactivate(): Promise<boolean> {
+  return true;
+}
+```
+
+### DataProviderDataType Format
+
+```typescript
+DataProviderDataType<Selector, ReturnType, SetType>
+```
+
+- **Selector:** Type of the get/subscribe selector (use `undefined` if no selector)
+- **ReturnType:** What `get` returns (can include `undefined` for missing data)
+- **SetType:** What `set` accepts (`never` if read-only)
+
+**Examples:**
+```typescript
+// Read-write with number selector
+RandomNumber: DataProviderDataType<number, number, number>;
+
+// Read-only with no selector
+Names: DataProviderDataType<undefined, string[], never>;
+
+// Scripture data
+BookUSFM: DataProviderDataType<SerializedVerseRef, string | undefined, string>;
+```
+
+---
+
+## Experimental APIs
+
+The `@experimental` marker applies to any PAPI surface — whether built into the platform or contributed by an extension. Mark an API experimental when it is not a confident, solid, general-purpose contract. Common cases:
+
+- APIs designed for one particular UI or use case rather than a broad audience.
+- APIs whose shape is likely to change as you learn how they're used.
+- APIs added to unblock a feature without long-term-suitability review.
+- APIs not yet covered by tests in a meaningful way.
+
+Two complementary places apply the marker. Use both when you can.
+
+### TSDoc (for IDE/type consumers)
+
+Add `/** @experimental */` to the type or member.
+
+**Cascade caveat — tag every member in extension `.d.ts` files.** TypeDoc (0.28.3+) treats `@experimental` as a built-in modifier tag and cascades it from an interface to its members — but **only in TypeDoc-generated output** (the `papi.d.ts` API site and the `platform-bible-react` / `platform-bible-utils` doc builds). It does **not** cascade in normal TypeScript or editor IntelliSense: a consumer hovering a method of an `@experimental` interface sees nothing on the method itself. Extension `.d.ts` files (e.g. `platform-scripture.d.ts`) and web-view-local interfaces are **not** run through TypeDoc — they ship as-is and are read by other extensions via IntelliSense. So in those files, tagging the interface alone is not enough: **put `@experimental` on each method (and other member) individually**, not just on the container type. (In `papi.d.ts` / `platform-bible-react` / `platform-bible-utils`, the container-level tag is sufficient because TypeDoc cascades it.)
+
+### Wire (for runtime/OpenRPC consumers)
+
+Pass `'x-experimental': true` in the registration's documentation object. The marker becomes visible in the live OpenRPC document at the WebSocket `rpc.discover` endpoint.
+
+### Quick reference per surface
+
+| Surface | TSDoc location | Wire field path |
+|---|---|---|
+| Commands | `CommandHandlers` entry in `papi-shared-types` augmentation | `commandDocs.method['x-experimental']: true` |
+| Network objects | (TSDoc on the interface registered) | `networkObjectService.set(..., { 'x-experimental': true })` (5th param) |
+| Data providers | (TSDoc on the data type interface) | `dataProviderService.registerEngine(..., { 'x-experimental': true })` (5th param) |
+| WebView providers | (TSDoc on the provider type) | `webViewProviderService.registerWebViewProvider(..., undefined, { 'x-experimental': true })` |
+| Project data providers | `ProjectDataProviderInterfaces` entry; factory return envelope | `registerProjectDataProviderEngineFactory(..., undefined, { 'x-experimental': true })` |
+| Network events | `NetworkEvents` entry in `papi-shared-types` augmentation | `createNetworkEventEmitterAsync(name, { notification: { 'x-experimental': true } })` |
+| Menus (extension points) | (none — JSON contribution) | `"isExperimental": true` next to `"isExtensible": true` |
+
+The wire-field column above shows the **TypeScript** registration functions. Network
+objects, data providers, and project data providers registered from the **.NET data
+provider** do not use those functions — they register over the wire from C# and use the
+C# path below instead.
+
+### C# (backend-registered surfaces)
+
+C#-registered network objects / data providers / PDPs carry the marker **only on the
+wire** (there is no C# TSDoc layer — mark the TS-facing interface, if any, with
+`@experimental` separately). The `network:registerMethod` wire call already accepts an
+optional documentation argument — the C# counterpart of the TS
+`SingleMethodDocumentation` — which the main process emits into the OpenRPC document.
+
+**Build docs with the `ExperimentalMethodDocumentation` factory** (`c-sharp/NetworkObjects/Documentation/`; every doc it builds carries `x-experimental: true`). Complex record params/results use the `"object"` type rather than a fully-expanded schema:
+
+```csharp
+using static Paranext.DataProvider.NetworkObjects.Documentation.ExperimentalMethodDocumentation;
+
+Create(
+    "Summary of the method.",
+    [Param("input", "The input.", "object")],
+    ResultOf("object", "The result"));
+```
+
+Pass a `NetworkObjectDocumentation` to `RegisterNetworkObjectAsync`. It mirrors the
+TypeScript `NetworkObjectDocumentation`: an object-level `Experimental` flag that
+**cascades** to the `object:{name}` existence method AND every function, plus optional
+per-method `Methods` for richer docs.
+
+**Object-wide** (the whole network object is experimental) — set `Experimental = true`.
+It marks the existence method and every function automatically (functions without their
+own `Methods` entry get a bare marker). Add `Methods` for richer per-function docs:
+
+```csharp
+await RegisterNetworkObjectAsync(
+    NetworkObjectName,
+    functions,
+    createdDetails,
+    new NetworkObjectDocumentation
+    {
+        Experimental = true,                       // cascades to object:{name} + every function
+        Methods = BuildExperimentalDocumentation(), // optional richer per-method docs
+    });
+```
+
+`{ Experimental = true }` alone (no `Methods`) is enough to mark the whole object.
+
+**Per-method** (only some methods experimental — e.g. one projectInterface on a PDP that
+also exposes stable ones like USFM/USJ) — leave `Experimental` unset and list only the
+experimental functions in `Methods`. The existence method and unlisted functions stay
+unmarked. For a data provider, override `DataProvider.GetNetworkObjectDocumentation()`:
+
+```csharp
+protected override NetworkObjectDocumentation GetNetworkObjectDocumentation() =>
+    new()
+    {
+        // Experimental left unset → object + stable interfaces stay unmarked
+        Methods = new Dictionary<string, OpenRpcSingleMethodDocumentation>
+        {
+            ["getFinalVerseNumber"] = Create("…", [Param("bookNum", "…", "number")], ResultOf("number", "…")),
+            // … only the experimental functions
+        },
+    };
+```
+
+`PapiClient.RegisterRequestHandlerAsync` also takes an optional `documentation:` argument
+for marking a single standalone method. Reference implementations:
+`EnhancedResourceFactory`, `ChecklistNetworkObject`, `ManageBooksService` (object-wide),
+and `ParatextProjectDataProvider` (per-method versification). Verify the result against the
+live OpenRPC document via the `rpc.discover` WebSocket method — C# changes require a data
+provider restart (no hot-reload).
+
+### What experimental does NOT do
+
+The `@experimental` marker is **informational only** — experimental APIs behave identically to stable ones at runtime. There is no opt-in mechanism, no runtime gate, and no change to how calling code works. The marker exists so consumers can tell which APIs are safe to depend on long-term.
+
+### Graduating out of experimental
+
+Once an API has a settled shape, meaningful test coverage, and has been validated against real use cases, remove the `@experimental` TSDoc tag and the `'x-experimental': true` field from its registration. No other changes are required.
+
+### Deprecation note for events
+
+`papi.network.createNetworkEventEmitter` (sync) is deprecated as of 8 June 2026. Use `createNetworkEventEmitterAsync` for new code. Events created via the sync API are not centrally registered and do not appear in the OpenRPC document.
+
+The legacy `getNetworkEvent<T>(name)` overload that takes an explicit type parameter is also deprecated. Declare the event in `NetworkEvents` and call `getNetworkEvent('event.name')` without `<T>` to get inference.
+
+---
+
+## Naming Conventions Summary
+
+| Category | Pattern | Example |
+|----------|---------|---------|
+| C# Namespace | `Paranext.DataProvider.{Area}` | `Paranext.DataProvider.Projects` |
+| C# Service | `{Name}Service` | `AppService`, `SettingsService` |
+| C# DataProvider | `{Name}DataProvider` | `ParatextProjectDataProvider` |
+| TS Command | `'{extensionName}.{commandName}'` | `'platformScripture.openFind'` |
+| TS Setting | `'{extensionName}.{settingName}'` | `'helloRock3.personName'` |
+| TS DataProvider | `'{extensionName}.{dataName}'` | `'helloSomeone.people'` |
+| TS WebView | `'{extensionName}.{viewName}'` | `'helloRock3.projectWebView'` |
+| Test File | `{Feature}Tests.cs` | `ProjectServiceTests.cs` |
+
+---
+
+## Key Files Reference
+
+### C# Entry Points
+- `c-sharp/Program.cs` - Application entry point
+- `c-sharp/PapiClient.cs` - Core PAPI communication
+
+### Base Classes
+- `c-sharp/NetworkObjects/DataProvider.cs` - Abstract data provider base
+- `c-sharp/NetworkObjects/NetworkObject.cs` - Abstract network object base
+- `c-sharp/Projects/ProjectDataProvider.cs` - Abstract project data provider
+
+### Test Base
+- `c-sharp-tests/PapiTestBase.cs` - Base class for integration tests
+- `c-sharp-tests/DummyScrText.cs` - In-memory ScrText mock
+- `c-sharp-tests/FixtureSetup.cs` - Global test fixture
+
+### TypeScript Core
+- `src/declarations/papi-shared-types.ts` - Global type extensions
+- `extensions/src/platform-scripture/src/main.ts` - Example extension

--- a/.context/standards/Security-Guide.md
+++ b/.context/standards/Security-Guide.md
@@ -1,0 +1,126 @@
+---
+title: Security Guide
+description: CSP design, module import restrictions, extension sandboxing, and security best practices for Platform.Bible.
+---
+
+# Security Guide
+
+This document covers security policies and restrictions for Platform.Bible development, with a focus on the extension sandbox.
+
+For secret-handling rules (no hardcoded credentials, no `.env` files, etc.), see the "Never Commit Secrets" section in root `CLAUDE.md`.
+
+---
+
+## Content Security Policy (CSP)
+
+Platform.Bible implements a CSP framework with three objectives:
+
+### 1. Extension-Defined Code Protection
+
+Code defined by the extension is allowed to run in the same origin as the parent, but must be restricted by CSP and iframe sandbox. This prevents:
+
+- Unauthorized code execution
+- XSS attacks
+- Extension code accessing the parent platform UI context
+
+### 2. Third-Party Code Isolation
+
+Code not specifically defined by the extension is only allowed to run in a different origin from the parent. Extensions communicate with third-party code through:
+
+- Message passing
+- WebAssembly function sharing
+
+This prevents granting excessive permissions or executing arbitrary downloaded code in the parent origin.
+
+### 3. Balanced Security with Developer Empowerment
+
+The framework provides reasonable defaults that empower extension developers without significantly compromising security, while also offering granular configuration for advanced functionality.
+
+For the full CSP design visualization, see the [CSP Design wiki](https://github.com/paranext/paranext/wiki/Content-Security-Policy-Design).
+
+---
+
+## Module Import Restrictions
+
+Platform.Bible runs extension code in a partially sandboxed environment. Only specific modules are available to extensions.
+
+### Security Approval Criteria
+
+Modules must not enable:
+
+- Access to arbitrary files on the file system
+- Execution of code outside the extension host sandbox
+- Execution of unintended arbitrary code
+- Access to data from the application or other extensions
+- Internet access when the application does not allow it
+
+### Allowed Modules
+
+#### Universal (all extension code)
+
+| Module                | Purpose                         |
+| --------------------- | ------------------------------- |
+| `@papi/core`          | Core PAPI types and utilities   |
+| `@sillsdev/scripture` | Scripture reference handling    |
+| `platform-bible-utils`| Shared utility functions        |
+
+#### Backend (extension entry file)
+
+| Module          | Purpose                |
+| --------------- | ---------------------- |
+| `@papi/backend` | Backend PAPI services  |
+| `crypto`        | Cryptographic operations |
+
+#### Frontend (WebView files)
+
+| Module                 | Purpose                 |
+| ---------------------- | ----------------------- |
+| `react`                | React library           |
+| `react/jsx-runtime`    | JSX transformation      |
+| `react-dom`            | React DOM rendering     |
+| `react-dom/client`     | React 18 client APIs    |
+| `@papi/frontend`       | Frontend PAPI services  |
+| `@papi/frontend/react` | React hooks for PAPI    |
+| `platform-bible-react` | UI component library    |
+
+### Blocked Modules and Alternatives
+
+| Blocked           | Use Instead                         | Reason                             |
+| ----------------- | ----------------------------------- | ---------------------------------- |
+| `fs`              | `papi.storage`                      | File system access control         |
+| `http`, `https`   | `fetch`                             | Network access control             |
+| `child_process`   | `elevatedPrivileges.createProcess`  | Process spawning control           |
+| `util`            | (no direct replacement)             | `getCallSites` / `inspect` concerns |
+
+Extensions may bundle additional packages into their own code, provided they meet the security requirements above.
+
+For the complete and up-to-date list, see the [Module Import Restrictions wiki](https://github.com/paranext/paranext/wiki/Module-import-restrictions).
+
+---
+
+## Extension Sandboxing
+
+Extensions run in isolated contexts:
+
+1. **Extension Host Process** — backend extension code runs in a separate Node.js process.
+2. **WebView Isolation** — frontend code runs in sandboxed iframes with restricted capabilities.
+3. **PAPI as Bridge** — all cross-process communication goes through the Platform API.
+
+---
+
+## Security Best Practices
+
+When developing extensions:
+
+- Use PAPI services instead of direct system access.
+- Validate all input data, especially from external sources.
+- Avoid storing sensitive data in plain text.
+- Use the provided storage APIs for persistence.
+- Follow the principle of least privilege.
+
+---
+
+## Related Documentation
+
+- [Content Security Policy Design wiki](https://github.com/paranext/paranext/wiki/Content-Security-Policy-Design)
+- [Module Import Restrictions wiki](https://github.com/paranext/paranext/wiki/Module-import-restrictions)

--- a/.context/standards/Testing-Guide.md
+++ b/.context/standards/Testing-Guide.md
@@ -1,0 +1,1372 @@
+---
+title: Testing Guide
+description: Vitest, NUnit, TDD, testing trophy model, AI agent test quality guardrails, mocking, and CI.
+---
+
+# Testing Guide for paranext-core
+
+An overview of the testing infrastructure in paranext-core and guidelines for writing tests that catch real defects.
+
+---
+
+## Overview
+
+paranext-core uses a **layered testing approach** rather than comprehensive end-to-end testing:
+
+| Layer                 | Framework                | Location            | Purpose                      |
+| --------------------- | ------------------------ | ------------------- | ---------------------------- |
+| TypeScript Unit Tests | Vitest                   | `src/**/*.test.ts`  | Services, utilities, hooks   |
+| React Component Tests | Vitest + Testing Library | `lib/**/*.test.tsx` | UI components                |
+| C# Unit Tests         | NUnit                    | `c-sharp-tests/`    | Data providers, services     |
+| Component Stories     | Storybook + Playwright   | `**/*.stories.tsx`  | Visual testing, interactions |
+
+---
+
+## TDD Discipline
+
+Test-Driven Development is the recommended default for non-trivial backend logic. It's not mandatory everywhere, but when you write tests first, you end up with better-specified code, tests that can actually fail, and fewer regressions.
+
+### The RED-GREEN-REFACTOR Cycle
+
+| Phase        | Action                          |
+| ------------ | ------------------------------- |
+| **RED**      | Write ONE failing test          |
+| **GREEN**    | Write MINIMUM code to pass      |
+| **REFACTOR** | Clean up while tests stay green |
+
+### Verifying Tests Can Fail
+
+Every test must be capable of failing when the implementation breaks. How you verify depends on context:
+
+| Context                         | Verification Method                                                |
+| ------------------------------- | ------------------------------------------------------------------ |
+| TDD (test-first)                | The RED phase proves it — test fails before implementation exists. |
+| Adding tests to existing code   | Revert Test required (see below).                                  |
+| Bug fix                         | Revert Test required — prove the test catches the bug.             |
+
+#### The Revert Test (for non-TDD contexts)
+
+```bash
+# 1. Comment out or revert the implementation
+git stash  # or comment out the code
+
+# 2. Run the test — it MUST fail
+npm test -- path/to/test.ts  # or: dotnet test --filter "TestName"
+
+# 3. Verify it failed for the RIGHT reason (assertion, not compilation error)
+
+# 4. Restore implementation
+git stash pop
+
+# 5. Run test again — it MUST pass
+```
+
+**If a test passes without the implementation, it proves nothing and must be rewritten.**
+
+### Continuous Testing Frequency
+
+| Trigger               | Scope                   | Time Budget |
+| --------------------- | ----------------------- | ----------- |
+| After every file save | Current test            | < 5s        |
+| Every 3–5 edits       | Feature tests           | < 30s       |
+| Before any commit     | Full suite              | < 5 min     |
+| Before push           | Full + lint + typecheck | < 10 min    |
+
+### Outside-In TDD (Double Loop)
+
+For non-trivial features, [Outside-In TDD](https://outsidein.dev/concepts/outside-in-tdd/) constrains the implementation by starting from the behavior the feature must deliver:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  OUTER LOOP (Acceptance Test)                               │
+│                                                             │
+│  Write the acceptance test FIRST                           │
+│  This test defines WHAT the feature must do                │
+│  It constrains the implementation scope                     │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │  INNER LOOP (Unit Tests)                             │   │
+│  │                                                      │   │
+│  │  Write unit tests that drive HOW to implement        │   │
+│  │  These guide the internal structure                  │   │
+│  └─────────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Key Principle**: The **outer acceptance test** is the done signal. When it passes, the feature is complete. The outer test source is your acceptance/E2E test for the feature.
+
+#### Acceptance Test Characteristics
+
+An acceptance test should:
+
+1. Call the **public API** of the feature.
+2. Verify the **complete outcome**, not an intermediate step.
+3. Be marked so it can be selected and run as a group (e.g. `[Test]` + `[Category("Acceptance")]` in NUnit).
+4. Include **side-effect verification** for methods with effects (create, update, delete).
+
+```csharp
+[Test]
+[Category("Acceptance")]
+[Description("Acceptance test: create project with valid settings succeeds and persists")]
+public async Task CreateProject_WithValidSettings_AcceptanceTest()
+{
+    // This test passes when the feature is COMPLETE.
+    // It calls the public API and verifies the expected outcome.
+}
+```
+
+#### Side-Effect Verification
+
+For methods with side effects, verify the **observable effect** — not just the return value:
+
+| Method Type | Verification                                                       |
+| ----------- | ------------------------------------------------------------------ |
+| Create      | Verify created item is findable via `ScrTextCollection` or on disk |
+| Update      | Verify changed property is reflected when re-queried               |
+| Delete      | Verify item is no longer findable                                  |
+
+**Anti-stub guidance**: A stub that returns `{ Success = true, Guid = NewGuid() }` passes return-value-only tests. Always include at least one test that verifies persistence.
+
+#### TDD Variant Selection (Outside-In vs Classic)
+
+| TDD Variant              | When to Use                                                       |
+| ------------------------ | ---------------------------------------------------------------- |
+| **Outside-In** (default) | Clear contracts, well-understood behavior, ParatextData-heavy features |
+| **Classic**              | Exploratory implementation, complex algorithms, interface emerges from extraction |
+
+---
+
+## Test Strategy: The Testing Trophy
+
+We adopt the **Testing Trophy** model rather than the traditional Test Pyramid.
+
+### Why Not the Pyramid?
+
+The Test Pyramid (many unit tests, fewer integration, few E2E) tends to produce:
+
+- Unit tests that assert implementation details
+- Tests that break on every refactor (opposite of fearless refactoring)
+- Over-mocking that hides real integration issues, giving false confidence
+
+This is especially problematic when AI is generating tests, because AI readily produces tests that mirror implementation.
+
+### The Testing Trophy Model
+
+```
+        ▲ E2E (few, high-value critical journeys)
+       ╱ ╲
+      ╱   ╲
+     ╱     ╲ Integration tests (MOST VALUABLE)
+    ╱       ╲ Test at service boundaries
+   ╱─────────╲
+  ╱           ╲ Unit tests (complex algorithms, pure functions only)
+ ╱─────────────╲
+╱               ╲ Static analysis (TypeScript, linting)
+```
+
+| Test Type       | When to Use                        | Coverage Focus               |
+| --------------- | ---------------------------------- | ---------------------------- |
+| **Integration** | Service boundaries, API contracts  | Behavior, not implementation |
+| **Unit**        | Complex algorithms, pure functions | Edge cases, calculations     |
+| **E2E**         | Critical user journeys             | Smoke tests only             |
+
+### Key Principle: Test Behavior, Not Implementation
+
+> "If a refactor breaks the test but not the behavior, the test is wrong."
+
+**Good test:** Calls public API, verifies output matches the expected value.
+**Bad test:** Verifies an internal method was called with specific arguments.
+
+### Prefer Real Dependencies
+
+| Approach           | Use When                                                      |
+| ------------------ | ------------------------------------------------------------ |
+| Real ParatextData  | Always for features with ParatextData logic — it's the oracle |
+| In-memory database | Integration tests needing data persistence                   |
+| Real services      | Whenever feasible and fast enough                            |
+| Mocks              | Only for external APIs, network, slow dependencies           |
+
+Real dependencies enable **fearless refactoring** — change internals without updating tests.
+
+---
+
+## AI Agent Test Quality Guardrails
+
+Apply these when AI agents (or humans moving fast) generate tests. They target the most common anti-patterns.
+
+### What NOT to Test
+
+| Category                | Examples                                  | Why Prohibited                 |
+| ----------------------- | ----------------------------------------- | ------------------------------ |
+| Trivial accessors       | Getter/setter, `getName()` returns name   | Zero defect-detection value    |
+| Implementation details  | Internal variables, private method calls  | Couples test to implementation |
+| Framework behavior      | `Array.push()` adds items                 | Testing someone else's code    |
+| Constructor assignments | `new User(name).name === name`            | Tautological                   |
+
+### Prohibited Test Patterns
+
+#### 1. Implementation-Mirroring Tests
+
+```typescript
+// BAD: expected value computed the same way as the implementation
+test('calculateTotal sums items', () => {
+  const items = [{ price: 10 }, { price: 20 }];
+  const expected = items.reduce((sum, i) => sum + i.price, 0); // this IS the implementation
+  expect(calculateTotal(items)).toBe(expected);
+});
+
+// GOOD: expected value is a literal
+test('calculateTotal returns sum of item prices', () => {
+  expect(calculateTotal([{ price: 10 }, { price: 20 }, { price: 5 }])).toBe(35);
+});
+```
+
+#### 2. Over-Mocking
+
+If you need more than 3 mocks for a test, reconsider:
+
+- Is the unit too large? Split it.
+- Is this actually an integration test? Use real dependencies.
+- Are mocks hiding real issues?
+
+#### 3. Non-Deterministic Tests
+
+| Source        | Required Mitigation                      |
+| ------------- | ---------------------------------------- |
+| System time   | Use `vi.useFakeTimers()` or inject clock |
+| Random values | Seed RNG or mock `Math.random()`         |
+| Network calls | Mock all HTTP/WebSocket calls            |
+| GUIDs         | Inject a generator or use fixed values   |
+
+### Mocking Decision Matrix
+
+| Dependency       | Unit Tests    | Integration Tests |
+| ---------------- | ------------- | ----------------- |
+| ParatextData.dll | **Keep real** | **Keep real**     |
+| Network services | Mock          | Mock or real      |
+| File system      | Mock          | Temp files        |
+| External APIs    | Mock          | Mock              |
+| System time      | Mock          | Mock              |
+
+**ParatextData Exception:** For features with ParatextData logic, NEVER mock ParatextData — it is the shared oracle that defines correct behavior. Run tests against the real `ScrTextCollection`.
+
+### Test Quality Checklist
+
+Before accepting AI-generated tests, verify:
+
+- [ ] **Falsifiable** — Test fails when the implementation is broken (Revert Test).
+- [ ] **Independent** — Passes/fails independently of other tests.
+- [ ] **Behavior-focused** — Tests WHAT, not HOW.
+- [ ] **Meaningful assertions** — Checks business value, not artifacts.
+- [ ] **Deterministic** — Same result on every run.
+
+### Stop and Ask Triggers
+
+AI agents should pause and ask when:
+
+1. Specification is ambiguous or contradictory.
+2. Domain-specific rules are involved (Bible versification, USFM semantics, Paratext conventions).
+3. Architecture decisions are needed (creating new utilities, modifying test infrastructure).
+4. Multiple interpretations of an edge case exist.
+
+---
+
+## General Style Guidelines
+
+### Making Tests Readable
+
+- Make it obvious what the SUT (Software Under Test) is.
+  - For simple tests, separate the Arrange / Act / Assert sections with blank lines.
+  - Alternatively, comment `// SUT` above the line where the SUT is invoked.
+
+### Best Practices
+
+- Follow [Unit testing best practices](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices). Though written for C#, the principles apply to any language.
+
+### Naming
+
+- **C#**: Use the [naming conventions](https://learn.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices#naming-your-tests) from the link above.
+- **TypeScript**: Use Vitest `test` blocks for simple tests and `describe`/`it` for structured groups. See [describe vs it vs test](https://webtips.dev/webtips/jest/describe-vs-test-vs-it).
+
+### When to Add Tests
+
+Add tests when they speed up development or make a critical part of the code more robust. You do not need 100% coverage — you need tests that would actually catch regressions.
+
+---
+
+## TypeScript/JavaScript Testing
+
+### Framework: Vitest (v3.2.4)
+
+Vitest is a Jest-compatible test runner optimized for Vite projects.
+
+### Configuration Files
+
+| File                                        | Purpose                  |
+| ------------------------------------------- | ------------------------ |
+| `vitest.config.ts`                          | Root configuration       |
+| `lib/platform-bible-react/vitest.config.ts` | Component library config |
+
+**Root Configuration:**
+
+```typescript
+// vitest.config.ts
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig(async () => {
+  const tsconfigPaths = (await import('vite-tsconfig-paths')).default;
+  return {
+    plugins: [tsconfigPaths()],
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
+    },
+  };
+});
+```
+
+### Key Dependencies
+
+```json
+{
+  "vitest": "^3.2.4",
+  "@testing-library/react": "^16.2.0",
+  "@testing-library/jest-dom": "^6.6.3",
+  "@testing-library/dom": "^10.4.0",
+  "jsdom": "^26.0.0"
+}
+```
+
+### Test File Locations
+
+```
+src/
+├── shared/
+│   ├── utils/papi-util.test.ts
+│   └── services/shared-store.service.test.ts
+├── node/
+│   └── services/*.test.ts
+├── extension-host/
+│   └── services/extension-storage.service.test.ts
+└── renderer/
+    └── components/*.test.tsx
+
+lib/
+├── platform-bible-utils/
+│   └── src/*.test.ts
+└── platform-bible-react/
+    └── src/components/**/*.test.ts
+
+extensions/
+└── src/platform-scripture/
+    └── src/*.test.ts
+```
+
+### Running TypeScript Tests
+
+```bash
+# Run all tests (non-watch mode)
+npm test
+
+# Run core tests in watch mode
+npm run test:core
+
+# Run tests for a specific workspace
+npm run test --workspace=lib/platform-bible-react
+
+# Run tests with coverage
+npm run test:core -- --coverage
+```
+
+---
+
+## C# Testing
+
+### Framework: NUnit 4.0.1
+
+### Project Configuration
+
+**File:** `c-sharp-tests/c-sharp-tests.csproj`
+
+```xml
+<ItemGroup>
+  <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+  <PackageReference Include="NUnit" Version="4.0.1" />
+  <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  <PackageReference Include="coverlet.collector" Version="6.0.0" />
+  <PackageReference Include="ParatextData" Version="9.5.0.18" />
+</ItemGroup>
+```
+
+### Test Directory Structure
+
+```
+c-sharp-tests/
+├── Checks/
+│   ├── CheckRunResultTests.cs
+│   ├── CheckRunnerCheckDetailsTests.cs
+│   ├── InputRangeTests.cs
+│   ├── InputRangesFilterTests.cs
+│   └── UsfmLocationTests.cs
+├── JsonUtils/
+│   ├── CommentConverterTests.cs
+│   └── InventoryOptionValueConverterTests.cs
+├── Projects/
+│   ├── FixtureSetup.cs              # Assembly-level setup
+│   ├── LocalParatextProjectsTests.cs
+│   ├── ParatextDataProviderTests.cs
+│   ├── ParatextDataProviderCommentTests.cs
+│   └── ParatextProjectDataProviderFactoryTests.cs
+├── Services/
+│   └── SettingsServiceTests.cs
+├── NetworkObjects/
+│   └── DummySettingsService.cs
+├── PapiTestBase.cs                  # Base class for tests
+├── DummyPapiClient.cs               # Mock PAPI client
+├── DummyParatextProjectDataProvider.cs
+├── DummyScrText.cs
+└── DummyLocalParatextProjects.cs
+```
+
+### Running C# Tests
+
+```bash
+# Run all C# tests
+dotnet test c-sharp-tests/c-sharp-tests.csproj
+
+# Verbose output
+dotnet test c-sharp-tests/c-sharp-tests.csproj --verbosity=detailed
+
+# Specific test class
+dotnet test c-sharp-tests/c-sharp-tests.csproj --filter "FullyQualifiedName~ParatextDataProviderTests"
+
+# With coverage
+dotnet test c-sharp-tests/c-sharp-tests.csproj --collect:"XPlat Code Coverage"
+```
+
+### Base Test Class
+
+`c-sharp-tests/PapiTestBase.cs` provides a shared base class for data-provider tests. It creates a `DummyPapiClient` and `DummyLocalParatextProjects`, and its `TestTearDown` cleans up `ScrTextCollection` with full index removal — see [ScrTextCollection Index Accumulation](#scrtextcollection-index-accumulation) below for why that matters.
+
+```csharp
+[TestFixture]
+[ExcludeFromCodeCoverage]
+internal abstract class PapiTestBase
+{
+    private DummyPapiClient? _client;
+    private DummyLocalParatextProjects? _projects;
+
+    [SetUp]
+    public virtual Task TestSetupAsync()
+    {
+        _projects = new DummyLocalParatextProjects();
+        _client = new DummyPapiClient();
+        return Task.CompletedTask;
+    }
+
+    [TearDown]
+    public virtual void TestTearDown()
+    {
+        // Clean up ScrTextCollection — pass `true` to trigger full index cleanup.
+        // Using `false` leaves stale entries in the internal project index, which
+        // causes "Sequence contains more than one matching element" errors when
+        // tests create many DummyScrText instances with unique HexIds.
+        List<ScrText> projects = ScrTextCollection
+            .ScrTexts(IncludeProjects.Everything)
+            .ToList();
+        foreach (ScrText project in projects)
+            ScrTextCollection.Remove(project, true);
+
+        _client?.Dispose();
+    }
+
+    protected DummyPapiClient Client => _client!;
+    protected DummyLocalParatextProjects ParatextProjects => _projects!;
+
+    // Helper methods for test data creation
+    protected static JsonNode CreateVerseRefNode(int bookNum, int chapterNum, int verseNum);
+    protected static JsonElement CreateRequestMessage(string function, params object[] parameters);
+    protected static void VerifyUsfmSame(string usfm1, string usfm2, ScrText scrText, int bookNum);
+}
+```
+
+### Assembly-Level Setup
+
+**File:** `c-sharp-tests/Projects/FixtureSetup.cs`
+
+```csharp
+[SetUpFixture]
+[ExcludeFromCodeCoverage]
+public class FixtureSetup
+{
+    private static readonly string s_testFolder = Path.Combine(
+        Path.GetTempPath(),
+        "Platform.Bible.Tests"
+    );
+
+    public static string TestFolderPath => s_testFolder;
+
+    [OneTimeSetUp]
+    public void RunBeforeAnyTests()
+    {
+        if (!Directory.Exists(s_testFolder))
+            Directory.CreateDirectory(s_testFolder);
+        ParatextGlobals.Initialize(s_testFolder);
+    }
+
+    [OneTimeTearDown]
+    public void RunAfterAnyTests()
+    {
+        if (Directory.Exists(s_testFolder))
+            Directory.Delete(s_testFolder, true);
+    }
+}
+```
+
+### Test Doubles
+
+paranext-core uses hand-crafted test doubles rather than mocking frameworks like Moq:
+
+| Test Double                        | Purpose                             |
+| ---------------------------------- | ----------------------------------- |
+| `DummyPapiClient`                  | Simulates JSON-RPC WebSocket client |
+| `DummyParatextProjectDataProvider` | In-memory project data              |
+| `DummyScrText`                     | Mock scripture text                 |
+| `DummySettingsService`             | Mock settings service               |
+| `DummyLocalParatextProjects`       | Mock project collection             |
+
+See `c-sharp-tests/DummyPapiClient.cs` and peers for examples.
+
+---
+
+## Component Testing with Storybook
+
+### Location
+
+`lib/platform-bible-react/.storybook/`
+
+### Capabilities
+
+- **70+ component stories** with visual documentation.
+- **Interactive play functions** for automated interaction testing.
+- **Accessibility testing** via axe-playwright.
+- **Vitest browser integration** with Playwright.
+
+### Story with Play Function Example
+
+```typescript
+// book-chapter-control.stories.tsx
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+export const Default: Story = {
+  args: {
+    scrRef: { book: 'GEN', chapterNum: 1, verseNum: 1 },
+    handleSubmit: fn(),
+  },
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button'));
+    await expect(canvas.getByRole('dialog')).toBeInTheDocument();
+
+    await userEvent.click(canvas.getByText('Exodus'));
+    await expect(args.handleSubmit).toHaveBeenCalled();
+  },
+};
+```
+
+### Stateful Harnesses for Callback-Heavy Components
+
+When a component's primary surface is callbacks — mutations, pickers, dialogs — `args`-only mock controls cannot exercise its real behavior. A reviewer opening such a story should be able to click through the full happy path and observe real state transitions, not just see a static screenshot.
+
+For these components, write a `StatefulHarness` render component that owns in-memory state and wires every callback to a state-mutating handler. Give each scenario its own story that renders the harness:
+
+```typescript
+function StatefulHarness(props: Partial<ManageBooksDialogProps>) {
+  const [selectedBooks, setSelectedBooks] = useState<string[]>([]);
+  // ...holds the in-memory state the component would normally receive from PAPI
+  return (
+    <ManageBooksDialog
+      {...props}
+      selectedBooks={selectedBooks}
+      onSelectBooks={setSelectedBooks} // every callback mutates harness state
+    />
+  );
+}
+
+export const Default: Story = { render: () => <StatefulHarness /> };
+export const PreSelected: Story = {
+  render: () => <StatefulHarness selectedBooks={['GEN', 'EXO']} />,
+};
+```
+
+**Avoid:**
+
+- Inline mock controls in `args:` for callback-heavy components — reviewers cannot observe state transitions.
+- Render-only stories with no callback wiring — they give a misleading static screenshot of a component that never reacts.
+
+Rationale: in-memory state plus callback-to-state wiring lets the story demonstrate the component's actual behavior. See `extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.stories.tsx` (`StatefulHarness`) and `extensions/src/platform-scripture/src/greek-esther-template-picker.stories.tsx` (`StatefulPickerHarness`).
+
+### Avoid Animation-Sensitive Assertions in Story Interaction Tests
+
+Story interaction tests can fire their next assertion before a CSS animation has finished playing. When that happens, assertions that read the **visual end-state of an animation** (`opacity: 1`, `toBeVisible()`, etc.) intermittently fail — even though the component is logically open and ready for interaction. Prefer semantic attributes that flip synchronously with the state change instead.
+
+**Don't** assert on animation-driven properties:
+
+```typescript
+// Fragile — opacity is animated from 0 → 1 by tw:fade-in-0; the assertion can fire before
+// the animation is done and `getComputedStyle().opacity` reaches 1.
+const popoverContent = await screen.findByRole('dialog');
+await waitFor(() => expect(popoverContent).toHaveStyle('opacity: 1'));
+await expect(popoverContent).toBeVisible(); // also opacity-driven
+```
+
+**Do** assert on a semantic attribute that flips synchronously, or on the inner content the test actually needs:
+
+```typescript
+// Robust — Radix flips data-state synchronously when open changes
+const popoverContent = await screen.findByRole('dialog');
+await waitFor(() => expect(popoverContent).toHaveAttribute('data-state', 'open'));
+
+// Even better — wait for the inner content the test will use next
+await within(popoverContent).findByRole('combobox');
+```
+
+For non-Radix animated components, the same principle applies: assert on the **content the animation reveals** (`findByRole`, `findByText`) rather than on the animation's terminal style. Anywhere `tailwindcss-animate` utilities, Radix's `tw:data-[state=open]:animate-in`, or a custom CSS keyframe would otherwise gate visibility, switching to a content-presence assertion sidesteps the timing race.
+
+### Chromatic Visual Review
+
+The `storybook-review` GitHub label triggers a Chromatic CI workflow that publishes the Storybook build for visual regression review by UX.
+
+- Triggers on PRs where the `storybook-review` label is applied.
+- By default snapshots `extensions/src/**/*.stories.tsx`; `.chromatic-story-filter` can override.
+- Uses TurboSnap (`onlyChanged`) to minimize snapshot count on subsequent pushes.
+- **Cost awareness**: Chromatic charges per snapshot — only apply the label when visual review is genuinely needed.
+
+---
+
+## CI/CD Pipeline
+
+`.github/workflows/test.yml` runs both test suites on every PR:
+
+```yaml
+jobs:
+  test:
+    steps:
+      - name: dotnet unit tests
+        run: dotnet test c-sharp-tests/c-sharp-tests.csproj
+
+      - name: Install Playwright Browsers
+        run: npx playwright install --with-deps
+
+      - name: npm unit tests
+        run: npm test
+```
+
+---
+
+## Mocking Strategies
+
+### TypeScript (Vitest)
+
+| Method               | Use Case                  |
+| -------------------- | ------------------------- |
+| `vi.mock()`          | Module-level mocking      |
+| `vi.fn()`            | Individual function mocks |
+| `vi.mocked()`        | Type-safe mock access     |
+| `vi.spyOn()`         | Spy on existing methods   |
+| `vi.useFakeTimers()` | Control time in tests     |
+
+```typescript
+// Module mock
+vi.mock('@shared/services/network.service', () => ({
+  request: vi.fn(),
+}));
+
+// Function mock with implementation
+const mockFn = vi.fn().mockImplementation((x) => x * 2);
+
+// Spy on method
+vi.spyOn(console, 'log');
+
+// Fake timers
+vi.useFakeTimers();
+vi.advanceTimersByTime(1000);
+vi.useRealTimers();
+```
+
+### C#
+
+Use the hand-crafted test doubles listed under [C# Testing](#c-testing). Example `DummyPapiClient` implementation:
+
+```csharp
+internal class DummyPapiClient : PapiClient
+{
+    private readonly Queue<(string eventType, object? eventParameters)> _sentEvents = [];
+
+    public override Task<bool> ConnectAsync() => Task.FromResult(true);
+    public override Task DisconnectAsync() => Task.CompletedTask;
+
+    public override Task SendEventAsync(string eventType, object? eventParameters)
+    {
+        _sentEvents.Enqueue((eventType, eventParameters));
+        return Task.CompletedTask;
+    }
+
+    public int SentEventCount => _sentEvents.Count;
+    public (string eventType, object? eventParameters) NextSentEvent => _sentEvents.Dequeue();
+}
+```
+
+---
+
+## Test Patterns and Examples
+
+### TypeScript: Service Testing with Mocks
+
+```typescript
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import * as networkService from '@shared/services/network.service';
+
+vi.mock('@shared/services/network.service', () => ({
+  createNetworkEventEmitter: vi.fn(),
+  getNetworkEvent: vi.fn(),
+  request: vi.fn(),
+}));
+
+describe('sharedStoreService', () => {
+  const mockEmitter = { emit: vi.fn(), subscribe: vi.fn(), dispose: vi.fn() };
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    vi.mocked(networkService.createNetworkEventEmitter).mockReturnValue(mockEmitter);
+  });
+
+  it('should initialize with network event emitter', async () => {
+    await initializeSharedStore(networkService);
+    expect(networkService.createNetworkEventEmitter).toHaveBeenCalledWith('shared-store:change');
+  });
+});
+```
+
+### TypeScript: React Hook Testing
+
+```typescript
+import { renderHook, act } from '@testing-library/react';
+import { vi } from 'vitest';
+import { useQuickNavButtons } from './book-chapter-control.navigation';
+
+vi.mock('./book-chapter-control.utils', () => ({
+  fetchEndChapter: vi.fn(),
+}));
+
+describe('useQuickNavButtons', () => {
+  const mockHandleSubmit = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test('returns correct number of navigation buttons', () => {
+    const { result } = renderHook(() =>
+      useQuickNavButtons({ book: 'GEN', chapterNum: 1, verseNum: 1 }, availableBooks, 'ltr', mockHandleSubmit),
+    );
+    expect(result.current).toHaveLength(4);
+  });
+});
+```
+
+### C#: Parameterized Tests
+
+```csharp
+[TestCase(1, 1, 0, @"\id GEN \ip intro \c 1 ")]
+[TestCase(1, 2, 1, @"\v 1 verse one ")]
+[TestCase(1, 2, 6, @"\v 6 verse six ")]
+[TestCase(1, 2, 10, "")]  // Missing verse
+[TestCase(1, 6, 1, "")]   // Missing chapter
+public void GetVerseUsfm_ValidResults(int bookNum, int chapterNum, int verseNum, string expected)
+{
+    _scrText.PutText(1, 0, false, TestUsfmContent, null);
+    var provider = new DummyParatextProjectDataProvider("test", Client, CreateProjectDetails(_scrText), ParatextProjects);
+
+    var verseRef = new VerseRef(bookNum, chapterNum, verseNum);
+    var result = provider.GetVerseUsfm(verseRef);
+
+    VerifyUsfmSame(result, expected, _scrText, bookNum);
+}
+```
+
+---
+
+## Invariant Testing
+
+Invariant testing verifies that **business rules and properties always hold** for specific test inputs.
+
+### When to Use Invariant Tests
+
+| Scenario                | Example Invariant                     |
+| ----------------------- | ------------------------------------- |
+| Data transformations    | `Deserialize(Serialize(x)) == x`      |
+| Business rules          | "Project GUID is always unique"       |
+| Mathematical operations | "Result is always within valid range" |
+| Parsing/formatting      | "Round-trip preserves content"        |
+
+### C# Invariant Tests
+
+Use regular NUnit tests with the `[Category("Invariant")]` attribute.
+
+```csharp
+[TestFixture]
+public class VerseRefInvariantTests
+{
+    [Test]
+    [Category("Invariant")]
+    [TestCase(1, 1, 1)]
+    [TestCase(66, 150, 176)]
+    [TestCase(40, 28, 20)]  // Matthew 28:20
+    public void VerseRef_ComponentsAlwaysValid(int bookNum, int chapterNum, int verseNum)
+    {
+        var verseRef = new VerseRef(bookNum, chapterNum, verseNum);
+
+        Assert.That(verseRef.BookNum, Is.InRange(1, 66));
+        Assert.That(verseRef.ChapterNum, Is.GreaterThanOrEqualTo(0));
+        Assert.That(verseRef.VerseNum, Is.GreaterThanOrEqualTo(0));
+    }
+
+    [Test]
+    [Category("Invariant")]
+    [TestCase("Project1", "Project2")]
+    [TestCase("Test", "AnotherTest")]
+    [TestCase("A", "B")]
+    public void ProjectGuid_IsAlwaysUnique(string name1, string name2)
+    {
+        var project1 = CreateProject(name1);
+        var project2 = CreateProject(name2);
+
+        Assert.That(project1.Guid, Is.Not.EqualTo(Guid.Empty));
+        Assert.That(project2.Guid, Is.Not.EqualTo(Guid.Empty));
+        Assert.That(project1.Guid, Is.Not.EqualTo(project2.Guid));
+    }
+}
+```
+
+### TypeScript Invariant Tests
+
+```typescript
+describe('VerseRef Invariants', () => {
+  test.each([
+    [1, 1, 1],
+    [66, 150, 176],
+    [40, 28, 20],
+  ])('verse reference components are always valid (%i, %i, %i)', (book, chapter, verse) => {
+    const ref = createVerseRef(book, chapter, verse);
+    expect(ref.bookNum).toBeGreaterThanOrEqual(1);
+    expect(ref.bookNum).toBeLessThanOrEqual(66);
+    expect(ref.chapterNum).toBeGreaterThanOrEqual(0);
+    expect(ref.verseNum).toBeGreaterThanOrEqual(0);
+  });
+});
+```
+
+### Best Practices for Invariant Tests
+
+1. **Choose representative inputs** — include typical values, boundary values, and edge cases.
+2. **Test multiple scenarios** — use `[TestCase]` or `test.each` for multiple inputs.
+3. **Keep tests focused** — one invariant per test method.
+
+For more thorough invariant verification with random input generation, see [Property-Based Testing](#property-based-testing) below.
+
+---
+
+## Test Categorization
+
+Test categorization enables fast feedback during development by running subsets of tests based on speed requirements.
+
+### Categories
+
+| Category        | Time Budget | When to Run     | Scope               |
+| --------------- | ----------- | --------------- | ------------------- |
+| **Smoke**       | < 10s       | After each edit | Core functionality  |
+| **Critical**    | < 60s       | Every 3–5 edits | Feature tests       |
+| **Full**        | < 5 min     | Before commit   | Complete suite      |
+| **Integration** | No limit    | CI only         | Cross-process tests |
+
+### Tagging Tests
+
+**C# (NUnit):**
+
+```csharp
+[Test]
+[Category("Smoke")]
+public void BasicOperation_Works() { }
+
+[Test]
+[Category("Critical")]
+public void ImportantFeature_HandlesEdgeCase() { }
+```
+
+**TypeScript (Vitest):**
+
+```typescript
+describe.concurrent('Smoke tests', () => {
+  test('basic operation works', () => {});
+});
+
+// Or use file naming: feature.smoke.test.ts, feature.critical.test.ts
+```
+
+### Running by Category
+
+```bash
+# C# — run only smoke tests
+dotnet test --filter "Category=Smoke"
+
+# TypeScript — run a specific test name pattern
+npm test -- --testNamePattern="Smoke"
+```
+
+---
+
+## Property-Based Testing
+
+Property-based testing verifies that **invariants hold for all possible inputs**, not just the cases you imagined. Humans define the invariant; the tool generates the inputs.
+
+It complements [Invariant Testing](#invariant-testing): start with regular invariant tests using specific inputs, then promote high-value invariants to property tests when random input generation would catch more.
+
+### When to Use Property Tests
+
+| Scenario                | Example Property                      |
+| ----------------------- | ------------------------------------- |
+| Data transformations    | `Deserialize(Serialize(x)) == x`      |
+| Business rules          | "Project GUID is always unique"       |
+| Mathematical operations | "Result is always within valid range" |
+| Parsing/formatting      | "Round-trip preserves content"        |
+
+### C# (no property-based framework)
+
+The C# test suite does **not** include a property-based testing framework — `c-sharp-tests/c-sharp-tests.csproj` references NUnit (with `NUnit3TestAdapter` and `coverlet.collector`) but no FsCheck or equivalent. Verify invariants in C# with ordinary NUnit `[Test]`/`[TestCase]` methods, supplying representative and boundary inputs by hand, and tag them with `[Category("Invariant")]`:
+
+```csharp
+[TestFixture]
+public class VerseRefInvariantTests
+{
+    [TestCase(1, 1, 1)]
+    [TestCase(66, 150, 176)]
+    [TestCase(40, 28, 20)]
+    [Category("Invariant")]
+    public void VerseRef_ComponentsAlwaysValid(int book, int chapter, int verse)
+    {
+        var verseRef = new VerseRef(book, chapter, verse);
+
+        Assert.That(verseRef.BookNum, Is.InRange(1, 66));
+        Assert.That(verseRef.ChapterNum, Is.GreaterThanOrEqualTo(0));
+        Assert.That(verseRef.VerseNum, Is.GreaterThanOrEqualTo(0));
+    }
+}
+```
+
+For random input generation, use TypeScript with `fast-check` (below).
+
+### TypeScript with fast-check
+
+```typescript
+import fc from 'fast-check';
+
+describe('VerseRef Properties', () => {
+  test.prop([fc.nat({ max: 65 }), fc.nat({ max: 149 }), fc.nat({ max: 175 })])(
+    'verse reference components are always non-negative',
+    (book, chapter, verse) => {
+      const ref = createVerseRef(book + 1, chapter + 1, verse);
+      expect(ref.bookNum).toBeGreaterThanOrEqual(1);
+      expect(ref.chapterNum).toBeGreaterThanOrEqual(0);
+      expect(ref.verseNum).toBeGreaterThanOrEqual(0);
+    },
+  );
+});
+```
+
+### Iteration Requirements
+
+| Invariant Criticality      | Minimum Iterations |
+| -------------------------- | ------------------ |
+| Critical (data integrity)  | 1000               |
+| Important (business logic) | 500                |
+| Standard                   | 100                |
+
+---
+
+## Mutation Testing
+
+Mutation testing verifies **test quality** by checking whether tests detect small code changes (mutations). A high mutation score means the tests catch real defects rather than just exercising the code.
+
+### When to Use
+
+- **Critical business logic** — merge algorithms, conflict resolution, data persistence.
+- **Threshold:** ≥70% mutation score for critical paths.
+
+### Tools
+
+| Language   | Tool        | Config File                         |
+| ---------- | ----------- | ----------------------------------- |
+| TypeScript | Stryker     | `stryker.config.json`               |
+| C#         | Stryker.NET | `c-sharp-tests/stryker-config.json` |
+
+### Running Mutation Tests
+
+```bash
+# TypeScript mutation tests
+npm run test:mutation
+
+# C# mutation tests
+npm run test:mutation:csharp
+```
+
+### Score Thresholds
+
+| Threshold | Score | Meaning                  |
+| --------- | ----- | ------------------------ |
+| High      | 80%   | Excellent test quality   |
+| Low       | 70%   | Minimum acceptable       |
+| Break     | 0%    | Build failure threshold  |
+
+### Interpreting Results
+
+- **Survived mutants** — code changes not caught by tests (bad).
+- **Killed mutants** — code changes caught by tests (good).
+- **Timeout/Error** — mutant caused an infinite loop or crash.
+
+---
+
+## E2E Testing
+
+End-to-end testing verifies complete user workflows across all processes (Electron main, renderer, extension host, and .NET data provider).
+
+### Tools
+
+- **Playwright** — browser automation for Electron apps.
+
+### Intended Use
+
+- **Critical user journeys** — project creation, editing, synchronization.
+- **Cross-process integration** — verify all processes communicate correctly.
+- **Smoke tests** — quick verification that the app starts and basic features work.
+
+### UI-Only Interaction Rule
+
+E2E tests that verify user flows MUST interact through visible UI only:
+
+- Use `cdp.fixture` for all per-feature E2E tests (connects to the running app via CDP).
+- Click menu items, buttons, and fill forms through the UI.
+- NEVER use `papi.fixture` or `app.fixture` for per-feature tests.
+- NEVER send JSON-RPC commands to set up UI state.
+- NEVER import `sendPapiCommand` from helpers in per-feature tests.
+
+Note: `app.fixture` is retained for CI smoke tests only (launches standalone Electron).
+
+### Opening a Project and Its Tool Menus (PT10 Navigation Pattern)
+
+Tools that need a project context (Markers Checklist, Markers Inventory, Checks side panel, etc.) are **NOT** exposed via the main app menu — they live in the **scripture editor's hamburger menu**. The main app menu (`%product_shortName%` — labeled "Platform") only hosts project-agnostic items (Open…, Settings, Exit, Help).
+
+The reason: when a command fires from a web-view's topMenu, the platform passes that web-view's `webViewId` to the command handler. The handler reads the active `projectId` from the web-view definition. Main-menu commands receive no web-view context, so they cannot resolve a project.
+
+**Navigation pattern** (copy-paste for Playwright/CDP tests):
+
+```typescript
+import { expect } from '../../fixtures/cdp.fixture';
+import type { Page } from '@playwright/test';
+
+const PROJECT_NAME = 'wgPIDGIN'; // any existing project in the dev env
+
+// 1. Open a project from Home (if not already open)
+async function openProject(page: Page, projectName: string): Promise<void> {
+  const existing = page.locator('.dock-tab', { hasText: new RegExp(projectName, 'i') });
+  if ((await existing.count()) > 0) return;
+  const homeFrame = page.frameLocator('iframe[title="Home"]');
+  await homeFrame
+    .locator('tr', { hasText: new RegExp(projectName, 'i') })
+    .locator('button', { hasText: /Open/i })
+    .click();
+  await expect(page.locator('.dock-tab', { hasText: new RegExp(projectName, 'i') }))
+    .toBeVisible({ timeout: 15_000 });
+}
+
+// 2. Click a menu item in the scripture editor's hamburger menu
+async function clickEditorMenuItem(page: Page, projectName: string, itemLabel: RegExp): Promise<void> {
+  // Scripture editor's iframe title follows: "{PROJECT_NAME} (Editable)" or "{PROJECT_NAME} (Read-only)"
+  const editorFrame = page.frameLocator(
+    `iframe[title*="${projectName}" i][title*="Editable" i]`,
+  );
+  // Hamburger button in top-left of the editor, aria-label="Project" INSIDE the iframe.
+  // WARNING: an identically-named button (aria-label="Project") exists OUTSIDE the iframe —
+  // that one opens a small dock-tab project menu with only 2 items, NOT the full topMenu.
+  await editorFrame.locator("button[aria-label='Project']").first().click();
+  // Radix portals the menu into the iframe's own document.body, so use editorFrame for
+  // menuitem selectors, not the top-level page.
+  await editorFrame.getByRole('menuitem', { name: itemLabel }).first().click();
+}
+```
+
+**Gotchas**:
+
+1. **Two buttons named "Project"** — one inside the editor iframe (the hamburger, opens the full topMenu with ~15 items), one outside in the dock tab bar (a dock-tab project menu with only "Open Project Settings..." and "Settings..."). They are indistinguishable via the CDP accessibility tree alone — always pick the one via `editorFrame.locator(...)`, not `page.locator(...)`.
+2. **Menu items render inside the iframe**, not at the top-level page. Radix's `DropdownMenu` portals to `document.body`, which in an iframe context means the iframe's body. Use `editorFrame.getByRole('menuitem', ...)`, NOT `page.getByRole('menuitem', ...)`.
+3. **Newly opened tool tabs are at the main-page level.** Dock tabs are rendered in the outer dock layout, not in any iframe. After clicking a menuitem that opens a new web view, `expect(page.locator('.dock-tab'))` is correct; `editorFrame.locator('.dock-tab')` is not.
+4. **Resolve iframe titles pragmatically.** A project opened in Edit mode has iframe title `"{PROJECT_NAME} (Editable)"`; Read-only is `"{PROJECT_NAME} (Read-only)"`. Use a broad `title*="${projectName}" i` plus `title*="Editable" i` (or relax to just the project name if you don't care which mode).
+5. **`openProject` must come BEFORE the editor-menu click** in each `beforeEach`. Without a project open, there's no scripture editor, so no hamburger menu, so no menu items.
+6. **Pass a precise `itemLabel` regex** — the helper calls `.first()` after `getByRole('menuitem', { name: itemLabel })`, which silently masks Playwright's strict-mode multi-match error. A broad pattern like `/markers/i` would match both "Markers Checklist" and "Markers Inventory" and click whichever appears first in DOM order. Anchor the regex (`/^Markers Checklist$/i`) when the menu has similarly-named items.
+
+**Related code pointers**:
+
+- The scripture editor's menu JSON lives at `extensions/src/platform-scripture-editor/contributions/menus.json`. That extension OWNS the topMenu declarations. Other extensions (e.g., `platform-scripture`) add their tool entries by editing that file — NOT by contributing from their own `menus.json`. The inventory-group items (`openCharactersInventory`, `openMarkersInventory`, etc.) are declared there with commands from other extensions, confirming this cross-extension pattern.
+- Main-menu contribution restrictions: extensions can only add items to existing extensible groups (`platform.projectProjects`, `platform.projectResources`, `platform.helpRegistration`). Base columns (`platform.app`, `platform.help`) are NOT extensible by default, so new top-level groups cannot be added from extensions.
+- Menu schema (`lib/platform-bible-utils/src/extension-contributions/menus.model.ts`): column/group IDs must match `^[\w\-]+\.[\w\-]+$` (single period; no nested `ext.ns.name`). Column orders must not conflict with existing base menu entries (`defaultWebViewTopMenu.platform.app` has `order: 1`, so custom columns should use `order: 2+`).
+
+### Test Location
+
+Create E2E tests in: `e2e-tests/tests/{feature}/`
+
+```
+e2e-tests/
+├── fixtures/
+│   ├── cdp.fixture.ts           # Connects to running app via CDP (DEFAULT for features)
+│   ├── app.fixture.ts           # Launches fresh Electron (CI smoke tests only)
+│   ├── papi.fixture.ts          # @deprecated — CI smoke tests only
+│   ├── papi-live.fixture.ts     # Connects to already-running app's WebSocket (command-surface verification)
+│   └── helpers.ts               # waitForAppReady(), sendPapiCommand()
+├── playwright-cdp.config.ts     # Config for CDP mode (no setup/teardown)
+├── playwright.config.ts         # Config for standalone mode (with setup/teardown)
+└── tests/
+    └── {feature}/
+        └── {feature}.spec.ts
+```
+
+### Fixture Selection
+
+| Fixture       | Mode                               | When to Use                               | Provides                  |
+| ------------- | ---------------------------------- | ----------------------------------------- | ------------------------- |
+| `cdp.fixture`      | Connects to running app (CDP 9223)        | **Default for all per-feature E2E tests** | `mainPage`                |
+| `app.fixture`      | Launches fresh Electron                   | CI smoke tests, standalone testing        | `electronApp`, `mainPage` |
+| `papi.fixture`     | Extends app.fixture + WebSocket           | **Deprecated** — CI smoke tests only      | `papiClient` + app.fixture |
+| `papi-live.fixture`| Connects to already-running app (WS 8876) | Command-surface verification only (see below) | `papiLive`                |
+
+### Command-Surface Verification (papi-live.fixture)
+
+This is a **separate test category** from the per-feature UI flows above — it verifies that a feature's PAPI command surface is registered, routed, and reachable on the wire, not that a user can drive the feature through the UI. The [UI-Only Interaction Rule](#ui-only-interaction-rule) ("never send JSON-RPC commands") applies to user-flow tests; it does **not** apply here, where sending JSON-RPC is the whole point.
+
+`papi-live.fixture` connects to an already-running instance over the PAPI WebSocket (port 8876) and exposes a `papiLive` client with `request`/`requestRaw` (raw JSON-RPC methods, e.g. `object:*` NetworkObject calls) and `sendCommand`/`sendCommandRaw` (the `*Raw` variants return the full response so you can inspect the error code). Pattern:
+
+1. **Skip guard** — gate the suite in `test.beforeAll` on `canConnectToPapi()` so it skips cleanly when the app is down or in CI:
+
+   ```typescript
+   import { test, expect, canConnectToPapi } from '../../fixtures/papi-live.fixture';
+
+   test.beforeAll(async () => {
+     test.skip(!(await canConnectToPapi()), 'PAPI server not running on ws://localhost:8876');
+   });
+   ```
+
+2. **Discovery test** — call `rpc.discover` once and assert every documented method name is present (the NetworkObject root itself is also registered, so it makes a good sentinel):
+
+   ```typescript
+   const schema = await papiLive.request<{ methods: { name: string }[] }>('rpc.discover', []);
+   const methodNames = new Set(schema.methods.map((m) => m.name));
+   expect(methodNames).toContain('object:myFeature.someMethod');
+   ```
+
+3. **One test per method** — call each method with `requestRaw` (`object:*` NetworkObject methods) or `sendCommandRaw` (`command:*` methods) and inspect the error code instead of catching an exception.
+
+**Reachability heuristic.** You can verify the whole command surface without real preconditions (an open project, a real project id, etc.) by distinguishing *where* an error originates:
+
+- A JSON-RPC error code **inside** the reserved/protocol range (`-32700`, or `-32600`..`-32603`) means the handler was never reached — missing registration, wrong parameter shape, or a serialization crash. **FAIL.**
+- A business error **outside** that range (e.g. `-32000` NOT_FOUND from a deliberately bogus id) proves the command is registered, routed, and executed before failing on the business precondition. **PASS.**
+
+So each per-method test sends a well-formed payload with a bogus id and asserts only that the error code is *outside* the reserved/protocol range — no real project required. For the full code table, see [papi-client/reference.md](../../.claude/skills/papi-client/reference.md#error-codes).
+
+```typescript
+const RESERVED = new Set([-32700, -32600, -32601, -32602, -32603]);
+const res = await papiLive.requestRaw('object:myFeature.someMethod', ['__bogus_id__']);
+if (res.error) expect(RESERVED, res.error.message).not.toContain(res.error.code);
+```
+
+### E2E Test Templates
+
+**UI Interaction Tests (cdp.fixture — default for per-feature tests):**
+
+```typescript
+import { test, expect } from '../../fixtures/cdp.fixture';
+import { waitForAppReady } from '../../fixtures/helpers';
+
+test.describe('{Feature} E2E Tests', () => {
+  test('should {action} - happy path', async ({ mainPage }) => {
+    await waitForAppReady(mainPage);
+    // Navigate via visible UI — click menu, then click feature entry
+    const menuTrigger = mainPage.getByRole('menuitem', { name: /Menu Name/i });
+    await menuTrigger.click();
+    const featureItem = mainPage.getByRole('menuitem', { name: /Feature Name/i });
+    await featureItem.click();
+    // Verify
+    await expect(mainPage.locator('.dock-tab', { hasText: /Feature Name/i })).toBeVisible({ timeout: 15_000 });
+  });
+});
+```
+
+**Render Smoke Test (cdp.fixture):**
+
+```typescript
+import { test, expect } from '../../fixtures/cdp.fixture';
+import { waitForAppReady } from '../../fixtures/helpers';
+
+test.describe('{Feature} Render Smoke Tests', () => {
+  test('component renders without errors', async ({ mainPage }) => {
+    await waitForAppReady(mainPage);
+    const consoleErrors: string[] = [];
+    mainPage.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text());
+    });
+
+    const menuTrigger = mainPage.getByRole('menuitem', { name: /Menu Name/i });
+    await menuTrigger.click();
+    const featureItem = mainPage.getByRole('menuitem', { name: /Feature Name/i });
+    await featureItem.click();
+    await expect(mainPage.locator('.dock-tab', { hasText: /Feature Name/i })).toBeVisible({ timeout: 15_000 });
+
+    // Standard noise filter — keep in sync with e2e-tests/tests/_example/
+    const criticalErrors = consoleErrors.filter(
+      (e) =>
+        !e.includes('DevTools') &&
+        !e.includes('favicon') &&
+        !e.includes('source map') &&
+        !e.includes('net::ERR_'),
+    );
+    expect(criticalErrors).toHaveLength(0);
+  });
+});
+```
+
+### E2E Test Best Practices
+
+| DO                                            | DON'T                                          |
+| --------------------------------------------- | ---------------------------------------------- |
+| Click buttons, fill forms, navigate via UI    | Call PAPI commands directly to change state    |
+| Use Playwright locators for real DOM elements | Mock PAPI responses (that's for unit tests)    |
+| Verify user-visible state changes             | Skip UI interactions by manipulating state     |
+| Use `data-testid` for stable selectors        | Use brittle selectors (class names, tag names) |
+| Handle timing with explicit waits             | Use `sleep()` without assertions               |
+
+### Running E2E Tests
+
+**IMPORTANT**: Always use the `--config` flag when running Playwright from the repo root. Without `--config`, Playwright uses defaults — the `--project` flag won't work, no dev server is started, and bare `npx playwright test` (without a test path) will discover vitest `.test.ts` files and fail.
+
+```bash
+# CDP mode (default — app already running via ./.erb/scripts/refresh.sh)
+npx playwright test e2e-tests/tests/{feature}/ --config=e2e-tests/playwright-cdp.config.ts --reporter=list
+
+# CDP mode with HTML report
+npx playwright test e2e-tests/tests/{feature}/ --config=e2e-tests/playwright-cdp.config.ts --reporter=html
+npx playwright show-report e2e-tests/playwright-report
+
+# Standalone mode (CI — launches own Electron, port 8876 must be free)
+npx playwright test e2e-tests/tests/{feature}/ --config=e2e-tests/playwright.config.ts --project=development --reporter=list
+```
+
+### Failure Analysis
+
+| Failure Type          | Diagnosis                       | Fix                                |
+| --------------------- | ------------------------------- | ---------------------------------- |
+| Selector not found    | Check actual DOM structure      | Update selector, add `data-testid` |
+| Command not registered| Check `main.ts` registration    | Add command registration           |
+| Data shape mismatch   | Compare response to contracts   | Fix types                           |
+| Timeout               | Operation takes too long        | Increase timeout or add waits       |
+| Fixture issue         | Wrong fixture for test type     | Switch to correct fixture           |
+
+---
+
+## Known Platform Constraints
+
+These constraints affect test authoring and are easy to miss.
+
+### PAPI Async Timing
+
+PAPI command responses are asynchronous and may not be immediately reflected in the UI. When writing E2E tests that verify data changes:
+
+- Always use Playwright `expect(...).toBeVisible({ timeout: ... })` or `expect.poll()` rather than asserting immediately after an action.
+- The default 5s timeout is often insufficient for PAPI round-trips. Use 10–15s for data operations, 5s for UI-only interactions.
+- Command execution order is not guaranteed across processes. If Test A sends a command and Test B reads the result, add explicit waits.
+- Sequential E2E tests sharing state must use `test.describe.serial()` and include polling for the expected state.
+
+### CDP Connection Exhaustion
+
+When running multiple sequential Playwright tests against the same CDP endpoint:
+
+- Always call `browser.close()` in test teardown. The CDP fixture handles this, but custom fixtures must include it.
+- Without explicit close, each test leaks a browser connection, eventually exhausting the CDP endpoint's connection limit.
+- Symptom: first N tests pass, then tests fail with connection/timeout errors.
+
+### Persisted Dock Layout
+
+Platform.Bible persists the dock/tab layout across sessions. When running E2E tests:
+
+- Stale tabs from previous runs may be open when your test starts.
+- Always include `beforeEach` cleanup to close any pre-existing tabs for the feature.
+- Pattern: loop to close matching tabs before each test, with a brief wait for UI settle.
+
+### ScrTextCollection Index Accumulation
+
+When C# tests create many `DummyScrText` instances with unique HexIds:
+
+- Always use `ScrTextCollection.Remove(scrText, true)` in test teardown — the second parameter triggers full internal index cleanup.
+- With `false`, stale index entries accumulate. After ~50 tests, `ScrTextCollection.RefreshScrTextsInternal` throws `"Sequence contains more than one matching element"`.
+- Symptom: first N tests pass, then tests fail with LINQ duplicate-key errors.
+- `PapiTestBase` handles this correctly; any custom test fixtures must also use `true`.
+
+---
+
+## Quick Reference
+
+### Run All Tests
+
+```bash
+# TypeScript
+npm test
+
+# C#
+dotnet test c-sharp-tests/c-sharp-tests.csproj
+```
+
+### Run Specific Tests
+
+```bash
+# TypeScript — specific file
+npm run test:core -- src/shared/services/shared-store.service.test.ts
+
+# C# — specific class
+dotnet test c-sharp-tests/c-sharp-tests.csproj --filter "FullyQualifiedName~ParatextDataProviderTests"
+```
+
+### Watch Mode
+
+```bash
+# TypeScript
+npm run test:core
+
+# C#
+dotnet watch test --project c-sharp-tests/c-sharp-tests.csproj
+```
+
+### Coverage Reports
+
+```bash
+# TypeScript
+npm run test:core -- --coverage
+
+# C#
+dotnet test c-sharp-tests/c-sharp-tests.csproj --collect:"XPlat Code Coverage"
+```
+
+---
+
+## Related Documentation
+
+- [Code-Style-Guide.md](Code-Style-Guide.md) — coding conventions
+- [Git-Guide.md](Git-Guide.md) — branch and merge practices
+- [Security-Guide.md](Security-Guide.md) — CSP and extension sandboxing

--- a/.eslintignore
+++ b/.eslintignore
@@ -64,3 +64,8 @@ dev-packages/
 # Playwright test output
 e2e-tests/test-results
 e2e-tests/playwright-report
+
+# Embedded Claude Code profile (vendored from ai-prompts; exempt from repo format/lint)
+.claude
+.context
+CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -59,13 +59,6 @@ e2e-tests/playwright-report/
 e2e-tests/test-results/
 e2e-tests/.dev-server.pid
 
-# claude
-.claude
-.claude.backup/
-.context
-c-sharp/CLAUDE.md
-CLAUDE.md
-CLAUDE.md.backup
 
 docs/superpowers/
 .superpowers/

--- a/.prettierignore
+++ b/.prettierignore
@@ -73,3 +73,8 @@ e2e-tests/playwright-report
 
 # format only
 .prettierignorerun
+
+# Embedded Claude Code profile (vendored from ai-prompts; exempt from repo format/lint)
+.claude
+.context
+CLAUDE.md

--- a/.prettierignorerun
+++ b/.prettierignorerun
@@ -70,3 +70,8 @@ e2e-tests/playwright-report
 # (no sync with .eslintignore and .stylelintignore)
 ## MDXv2+ (used by Storybook)
 *.mdx
+
+# Embedded Claude Code profile (vendored from ai-prompts; exempt from repo format/lint)
+.claude
+.context
+CLAUDE.md

--- a/.stylelintignore
+++ b/.stylelintignore
@@ -65,3 +65,8 @@ dev-packages/
 e2e-tests/test-results
 e2e-tests/playwright-report
 
+
+# Embedded Claude Code profile (vendored from ai-prompts; exempt from repo format/lint)
+.claude
+.context
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,22 +6,6 @@ This file provides guidance to Claude Code when working with code in the paranex
 
 Platform.Bible is extensible Bible translation software built on Electron with a TypeScript/React frontend and .NET 8 backend data provider. The core platform provides a minimal framework with functionality delivered primarily through extensions, giving developers flexibility to create and share their desired Bible translation experience.
 
-## Symlinked Configuration (ai-prompts Repository)
-
-`CLAUDE.md`, `.claude/`, and `.context/` in this checkout are **symlinks** to the `ai-prompts` repository. The files you see here are not local to paranext-core — editing them edits the upstream source shared by every team member who installed this profile.
-
-| Symlink in paranext-core | Physical location                        |
-| ------------------------ | ---------------------------------------- |
-| `CLAUDE.md`              | `ai-prompts/general/claude-md/CLAUDE.md` |
-| `.claude/`               | `ai-prompts/general/.claude/`            |
-| `.context/`              | `ai-prompts/general/.context/`           |
-
-When asked to change project-level instructions, Claude skills, `.claude/settings.json`, or any standards doc:
-
-1. Edit the files under `ai-prompts/general/` — not copies inside paranext-core.
-2. Commit the changes in the `ai-prompts` repo, not in paranext-core. All three symlinks are gitignored in paranext-core; commits there would not reach teammates.
-3. If the ai-prompts repo is not in your workspace, ask the user for its path rather than guessing — `ls -la CLAUDE.md` shows the target.
-
 ## Reference Documentation
 
 Read these when you need depth on a topic. Keep them in mind when writing or reviewing code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,230 @@
+# Project Instructions
+
+This file provides guidance to Claude Code when working with code in the paranext-core repository.
+
+## Project Overview
+
+Platform.Bible is extensible Bible translation software built on Electron with a TypeScript/React frontend and .NET 8 backend data provider. The core platform provides a minimal framework with functionality delivered primarily through extensions, giving developers flexibility to create and share their desired Bible translation experience.
+
+## Symlinked Configuration (ai-prompts Repository)
+
+`CLAUDE.md`, `.claude/`, and `.context/` in this checkout are **symlinks** to the `ai-prompts` repository. The files you see here are not local to paranext-core — editing them edits the upstream source shared by every team member who installed this profile.
+
+| Symlink in paranext-core | Physical location                        |
+| ------------------------ | ---------------------------------------- |
+| `CLAUDE.md`              | `ai-prompts/general/claude-md/CLAUDE.md` |
+| `.claude/`               | `ai-prompts/general/.claude/`            |
+| `.context/`              | `ai-prompts/general/.context/`           |
+
+When asked to change project-level instructions, Claude skills, `.claude/settings.json`, or any standards doc:
+
+1. Edit the files under `ai-prompts/general/` — not copies inside paranext-core.
+2. Commit the changes in the `ai-prompts` repo, not in paranext-core. All three symlinks are gitignored in paranext-core; commits there would not reach teammates.
+3. If the ai-prompts repo is not in your workspace, ask the user for its path rather than guessing — `ls -la CLAUDE.md` shows the target.
+
+## Reference Documentation
+
+Read these when you need depth on a topic. Keep them in mind when writing or reviewing code.
+
+| Topic                   | File                                                                      | Key Content                                                  |
+| ----------------------- | ------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| Architecture            | [Architecture.md](.context/standards/Architecture.md)                     | Multi-process architecture, core services, IPC, key patterns |
+| Code Style              | [Code-Style-Guide.md](.context/standards/Code-Style-Guide.md)             | TypeScript/C# conventions, API-surface TSDoc, localization, components, shadcn/ui |
+| Implementation Patterns | [Paranext-Core-Patterns.md](.context/standards/Paranext-Core-Patterns.md) | C# service/DataProvider/NetworkObject patterns, PAPI event registration, concurrency, extension structure, command naming |
+| Testing                 | [Testing-Guide.md](.context/standards/Testing-Guide.md)                   | Vitest/NUnit, TDD (outside-in), testing trophy, mutation/coverage, E2E, mocking, CI, platform gotchas |
+| Extensions              | [Extension-Development-Guide.md](.context/standards/Extension-Development-Guide.md) | Extension anatomy, PAPI, data providers, WebViews, contributions, type declarations |
+| Entry Points            | [Entry-Point-Guide.md](.context/standards/Entry-Point-Guide.md)           | Menus, commands, command handlers, WebView layout options    |
+| UI Components           | [Component-Selection-Quick-Reference.md](.context/standards/Component-Selection-Quick-Reference.md) · [Component-Builder-Patterns.md](.context/standards/Component-Builder-Patterns.md) | platform-bible-react component selection, styling, forms; web-view/provider/PAPI/styling patterns |
+| Localization            | [Localization-Guide.md](.context/standards/Localization-Guide.md)         | i18n store/APIs, fallback chain, RTL, immutable strings, C# localization |
+| Git and GitHub          | [Git-Guide.md](.context/standards/Git-Guide.md)                           | Branch structure, squash-merge, template merges              |
+| Code Review             | [Code-Review-Guide.md](.context/standards/Code-Review-Guide.md)           | Reviewable, code-steward, review workflow, auto-merge        |
+| Security                | [Security-Guide.md](.context/standards/Security-Guide.md)                 | CSP, module import restrictions, extension sandboxing        |
+
+## Terminology
+
+- **Platform.Bible**: The open-source, extensible Bible translation platform (paranext-core repository)
+- **paranext-core**: The GitHub repository containing Platform.Bible source code
+- **PAPI**: The Platform API — the service layer connecting frontend, extensions, and backend
+- **Data Provider**: A backend service (typically C#/.NET) that provides data to the frontend via PAPI
+- **WebView**: An extension-provided React UI that runs in an iframe within the renderer process
+
+## Tech Stack
+
+| Layer              | Technology                            |
+| ------------------ | ------------------------------------- |
+| Desktop Framework  | Electron                              |
+| Frontend           | React, TypeScript, SCSS, Tailwind CSS |
+| Backend (Node)     | TypeScript, WebSocket (JSON-RPC 2.0)  |
+| Backend (Data)     | .NET 8 / C#                           |
+| Build System       | Webpack                               |
+| Testing            | Vitest, Storybook                     |
+| Package Management | npm workspaces (monorepo)             |
+
+## Architecture
+
+### Multi-Process Architecture
+
+The application runs as four separate processes that communicate via JSON-RPC over WebSocket:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                    Main Process (Electron)               │
+│  • Window management & app lifecycle                     │
+│  • Spawns and manages child processes                    │
+└────────────────┬────────────────────────────────────────┘
+                 │ JSON-RPC over WebSocket (port 8876)
+    ┌────────────┼────────────┬───────────────────┐
+    │            │            │                   │
+┌───▼────────┐ ┌─▼──────────┐ ┌▼────────────────┐
+│ Renderer   │ │ Extension  │ │ .NET Data       │
+│ (React UI) │ │ Host       │ │ Provider        │
+│            │ │            │ │                 │
+│ • Web UI   │ │ • Loads    │ │ • Project data  │
+│ • Dialogs  │ │  extensions│ │ • Paratext     │
+│ • WebViews │ │ • PAPI     │ │   integration   │
+└────────────┘ └────────────┘ └─────────────────┘
+```
+
+### Key Codebase Locations
+
+| Path                        | Purpose                                         |
+| --------------------------- | ----------------------------------------------- |
+| `src/main/`                 | Main process (app lifecycle, window management)  |
+| `src/renderer/`             | Renderer (React UI, PAPI hooks)                  |
+| `src/extension-host/`       | Extension host (runs extensions, PAPI backend)   |
+| `c-sharp/`                  | .NET data provider (Paratext data, Bible text)   |
+| `src/shared/`               | Code shared across all processes                 |
+| `src/node/`                 | Code shared between Node.js processes            |
+| `extensions/src/`           | Core extensions                                  |
+| `lib/papi-dts/papi.d.ts`    | **Auto-generated** PAPI type declarations — NEVER edit by hand; run `npm run build:types` to regenerate |
+| `lib/platform-bible-react/` | React components and hooks for extensions        |
+| `lib/platform-bible-utils/` | Utility functions and classes                    |
+| `.erb/configs/`             | Webpack configurations                           |
+| `e2e-tests/`                | End-to-end Playwright tests (CDP-based)          |
+
+### Path Aliases (`tsconfig.json`)
+
+`@main/*` → `src/main/`, `@node/*` → `src/node/`, `@extension-host/*` → `src/extension-host/`, `@renderer/*` → `src/renderer/`, `@shared/*` → `src/shared/`
+
+## Common Commands
+
+### Development
+
+```bash
+# Start development (headless with CDP enabled)
+./.erb/scripts/refresh.sh
+
+# Start development (visible window - for manual development)
+npm start
+
+# Build the entire project (TypeScript, extensions, .NET, types)
+npm run build
+```
+
+### Testing
+
+```bash
+# Run all TypeScript tests
+npm test
+
+# Run single TypeScript test with watch mode
+npm test -- path/to/test-file.test.ts --watch
+
+# Run C# unit tests
+cd c-sharp-tests
+dotnet test
+
+# Run C# tests with watch mode
+cd c-sharp-tests
+dotnet watch test
+```
+
+### Code Quality
+
+```bash
+# Format code (happens automatically on commit)
+npm run format
+
+# Lint TypeScript
+npm run lint
+
+# Fix linting issues automatically
+npm run lint-fix
+
+# Format C# code
+cd c-sharp
+dotnet tool restore
+dotnet csharpier .
+
+# Type checking
+npm run typecheck
+```
+
+## Development Workflow
+
+1. Changes to renderer or main TypeScript code hot-reload automatically
+2. Extension changes are watched and rebuilt automatically
+3. .NET changes require manual rebuild or running `npm run start:data` in a separate terminal
+4. Use VS Code "Debug Platform" compound configuration to debug both frontend and backend
+
+## Coding Discipline
+
+- Read existing code before suggesting modifications.
+- If multiple interpretations of a task exist, present them — do not pick silently.
+- Frame tasks as verifiable goals: "Fix the bug" → "Write a test that reproduces it, then make it pass."
+- When any code quality tool flags your code (ESLint, TypeScript, Prettier, Stylelint), fix the code first. Only suppress warnings if the fix would be significantly worse.
+- Don't add features, refactor code, or make "improvements" beyond what was asked.
+
+## Never Commit Secrets
+
+This is an open-source repository. Never introduce secrets into the codebase:
+
+- **No hardcoded credentials**: API keys, tokens, passwords, connection strings, private keys.
+- **No secret files**: `.env`, `.env.*`, `*.pem`, `*.key`, `*.pfx`, `*.p12`, `credentials.json`, `service-account.json`.
+- **No secrets in commit messages or PR descriptions.**
+- **No base64-encoded or obfuscated secrets** — encoding is not encryption.
+
+If a feature needs a secret at runtime, use environment variables or Platform.Bible's settings system. Never provide a default value that is an actual secret.
+
+Never skip pre-commit hooks (`--no-verify`, `-n`, `HUSKY=0`) — they run the secret-detection linters. If a hook fails, fix the underlying issue. If you suspect you've staged a file containing secrets, unstage it before committing.
+
+## Git & PR Conventions
+
+- **Authorship**: The human developer is the author. Attribute AI assistance as a generator, not an author:
+  ```
+  Co-authored-by: <AI Tool> <noreply@example.com>
+  Session-URL: <session URL>
+  ```
+  PR body: `AI-assisted — [session 1](<url>), [session 2](<url>)`
+- Use squash-merge for PRs.
+- Keep PR titles short (under 70 characters) with a descriptive body.
+- Run `npm run typecheck && npm run lint && npm test && dotnet test c-sharp-tests/` before committing.
+- When committing, include ALL related files (plans, docs, configs) — never exclude supporting files unless they are gitignored or you are explicitly told to.
+- When git reports warnings about untracked or uncommitted files, investigate what they are before dismissing them. Never claim a file is unrelated without reading it first.
+- After completing file changes, push all relevant branches before reporting completion.
+- For rebases with many conflicts, prefer incremental conflict resolution over a single direct rebase. If a direct rebase produces massive conflicts, pause and discuss strategy with the user before attempting fixes.
+
+## WebView Special Imports
+
+- `import file from './path?inline'` — Imports as string (transformed by Webpack)
+- `import file from './path?raw'` — Imports as raw string (no transformation)
+
+## Platform-Specific Notes
+
+**Linux**: May need `--no-sandbox` flag for Electron on Ubuntu 24.04 with AppArmor.
+
+**macOS**: Requires MacPorts with icu4c libraries. The .NET build automatically copies dylibs to output directory.
+
+**Windows**: Use WSL2 for cross-platform testing.
+
+## Version Management
+
+- Use Node.js version specified in `package.json` → `volta.node` (recommend using Volta)
+- Requires .NET 8 SDK
+
+## Links
+
+- [PAPI Documentation](https://paranext.github.io/paranext-core/papi-dts)
+- [React Components Docs](https://paranext.github.io/paranext-core/platform-bible-react)
+- [Utilities Docs](https://paranext.github.io/paranext-core/platform-bible-utils)
+- [Extension Template](https://github.com/paranext/paranext-extension-template/wiki)


### PR DESCRIPTION
## Summary

Embeds the shared **Claude Code "general" profile** directly into paranext-core. Until now, `CLAUDE.md`, `.claude/`, and `.context/` were **gitignored symlinks** into a separate `ai-prompts` checkout, so every contributor had to run a setup script to wire them up and CI never saw them. This makes the profile a normal, tracked part of the repo.

## What's included

- **`CLAUDE.md`** — project instructions for Claude Code in this repo.
- **`.claude/`** — commands, agents, rules, skills, scripts, and `settings.json`.
- **`.context/standards/`** — the shared standards docs (architecture, code style, testing, security, etc.).
- **`.gitignore`** — removed the `# claude` block (`.claude`, `.context`, `CLAUDE.md`, plus the stale `.claude.backup/`, `CLAUDE.md.backup`, `c-sharp/CLAUDE.md` entries) so the config is tracked.

## Source & scope

- Copied from `ai-prompts` `general/` at `ai/main` (`31e3bb27`) — the config consolidation that merged there.
- **Config only** — the profile's `README.md` and `setup.sh` / `setup.ps1` (symlink-install helpers) are intentionally excluded.
- The `/investigate-prd` capability (ai-prompts PR #329) is **not** included — it is still unmerged.

## For contributors

After this merges, remove any local `CLAUDE.md` / `.claude` / `.context` symlinks that point into `ai-prompts` — the real files now live here.

AI-assisted — [session](https://claude.ai/code/session_01BwsL6Lfb4j4nsWUeWkNAPA)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BwsL6Lfb4j4nsWUeWkNAPA

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2436)
<!-- Reviewable:end -->
