### PR TITLE
fix: retry src/renderer/services inits after failure

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -12058,7 +12058,7 @@ declare module 'renderer/services/theme.service-host' {
     ): Promise<DataProviderUpdateInstructions<ThemeDataTypes>>;
     dispose(): Promise<boolean>;
   }
-  export function initialize(): Promise<void>;
+  export const initialize: () => Promise<void>;
   /** This is an internal-only export for testing purposes and should not be used in development */
   export const testingThemeService: {
     implementThemeDataProviderEngine: (

--- a/src/renderer/services/dialog.service-host.ts
+++ b/src/renderer/services/dialog.service-host.ts
@@ -21,6 +21,7 @@ import { localizationService } from '@shared/services/localization.service';
 import { logger } from '@shared/services/logger.service';
 import * as networkService from '@shared/services/network.service';
 import { serializeRequestType } from '@shared/utils/util';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import {
   aggregateUnsubscriberAsyncs,
   isLocalizeKey,
@@ -49,16 +50,10 @@ type DialogRequest<DialogTabType extends DialogTabTypes> = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const dialogRequests = new Map<string, DialogRequest<any>>();
 
-let initializationPromise: Promise<void>;
 /** Sets up the dialog service. Runs only once */
-async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = (async () => {
-      await webViewService.initialize();
-    })();
-  }
-  return initializationPromise;
-}
+const initialize = createCachedInitializer(async () => {
+  await webViewService.initialize();
+});
 
 /**
  * Determine whether there is an unresolved dialog request for a specified dialog id

--- a/src/renderer/services/theme.service-host.test.ts
+++ b/src/renderer/services/theme.service-host.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { mockRegisterEngine } = vi.hoisted(() => ({
   mockRegisterEngine: vi.fn(),
@@ -12,10 +12,8 @@ vi.mock('@shared/services/logger.service', () => ({
   logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
-// subscribeAllThemes is invoked inside an async IIFE in the engine constructor. Calling handler
-// synchronously here resolves the engine's AsyncVariable immediately so that a later dispose()
-// call (in the catch block of initialize()) finds the variable already settled and skips
-// rejectWithReason — preventing unhandled promise rejections in tests.
+// Call handler synchronously so the engine's AsyncVariable settles before a later dispose() (in
+// initialize()'s catch) can call rejectWithReason, avoiding unhandled rejections in tests.
 vi.mock('@shared/services/theme-data.service', () => ({
   themeDataService: {
     subscribeAllThemes: vi

--- a/src/renderer/services/theme.service-host.test.ts
+++ b/src/renderer/services/theme.service-host.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockRegisterEngine } = vi.hoisted(() => ({
+  mockRegisterEngine: vi.fn(),
+}));
+
+vi.mock('@shared/services/data-provider.service', () => ({
+  dataProviderService: { registerEngine: mockRegisterEngine },
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+// subscribeAllThemes is invoked inside an async IIFE in the engine constructor. Calling handler
+// synchronously here resolves the engine's AsyncVariable immediately so that a later dispose()
+// call (in the catch block of initialize()) finds the variable already settled and skips
+// rejectWithReason — preventing unhandled promise rejections in tests.
+vi.mock('@shared/services/theme-data.service', () => ({
+  themeDataService: {
+    subscribeAllThemes: vi
+      .fn()
+      .mockImplementation(
+        (_selector: unknown, handler: (data: Record<string, unknown>) => void) => {
+          handler({});
+          return Promise.resolve(() => true);
+        },
+      ),
+  },
+}));
+
+/** Creates a minimal MediaQueryList stand-in with jest-spy addEventListener/removeEventListener */
+function makeFakeMediaQuery() {
+  return {
+    addEventListener: vi.fn(),
+    addListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+    matches: false,
+    media: '(prefers-color-scheme: dark)',
+    onchange: undefined,
+    removeEventListener: vi.fn(),
+    removeListener: vi.fn(),
+  };
+}
+
+describe('theme.service-host', () => {
+  beforeEach(() => {
+    // mockReset clears call history AND queued once-implementations on the shared mock
+    mockRegisterEngine.mockReset();
+    vi.resetModules();
+    // jsdom does not implement matchMedia; stub it before the module loads (module-level code
+    // calls getSystemDarkThemeMediaQuery().matches to seed the initial engine)
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: vi.fn().mockImplementation(() => makeFakeMediaQuery()),
+      writable: true,
+    });
+  });
+
+  it('getCurrentThemeSync returns a theme before initialize is called', async () => {
+    const { localThemeService } = await import('@renderer/services/theme.service-host');
+
+    const theme = localThemeService.getCurrentThemeSync();
+
+    expect(theme).toBeDefined();
+    expect(typeof theme).toBe('object');
+  });
+
+  describe('initialize', () => {
+    it('registers the engine exactly once on the first successful call', async () => {
+      mockRegisterEngine.mockResolvedValueOnce({ onDidDispose: vi.fn() });
+
+      const { initialize } = await import('@renderer/services/theme.service-host');
+      await initialize();
+
+      expect(mockRegisterEngine).toHaveBeenCalledOnce();
+    });
+
+    it('registers a different engine instance on each attempt (fresh-engine-per-attempt invariant)', async () => {
+      const registeredEngines: object[] = [];
+      mockRegisterEngine
+        .mockImplementationOnce(async (_name: unknown, engine: object) => {
+          registeredEngines.push(engine);
+          throw new Error('simulated first failure');
+        })
+        .mockImplementationOnce(async (_name: unknown, engine: object) => {
+          registeredEngines.push(engine);
+          return { onDidDispose: vi.fn() };
+        });
+
+      const { initialize } = await import('@renderer/services/theme.service-host');
+
+      await expect(initialize()).rejects.toThrow('simulated first failure');
+      await initialize();
+
+      expect(registeredEngines).toHaveLength(2);
+      expect(registeredEngines[0]).not.toBe(registeredEngines[1]);
+    });
+
+    it('disposes the engine when registerEngine fails', async () => {
+      let disposeSpy: ReturnType<typeof vi.spyOn> | undefined;
+      mockRegisterEngine.mockImplementationOnce(async (_name: unknown, engine: object) => {
+        // Spy on dispose while we have a reference to the engine; the catch block calls
+        // themeServiceEngine.dispose() (same object) after registerEngine rejects
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        disposeSpy = vi.spyOn(engine as { dispose(): Promise<boolean> }, 'dispose');
+        throw new Error('simulated failure');
+      });
+      mockRegisterEngine.mockResolvedValue({ onDidDispose: vi.fn() });
+
+      const { initialize } = await import('@renderer/services/theme.service-host');
+      await expect(initialize()).rejects.toThrow('simulated failure');
+
+      expect(disposeSpy).toBeDefined();
+      expect(disposeSpy).toHaveBeenCalledOnce();
+    });
+
+    it('removes the system-theme change listener when registerEngine fails', async () => {
+      // Use a single shared MediaQueryList so calls from both createThemeServiceEngine (module
+      // load) and listenToSystemThemeChanges (inside initialize) hit the same spy object
+      const fakeMediaQuery = makeFakeMediaQuery();
+      Object.defineProperty(window, 'matchMedia', {
+        configurable: true,
+        value: vi.fn().mockReturnValue(fakeMediaQuery),
+        writable: true,
+      });
+
+      mockRegisterEngine.mockRejectedValueOnce(new Error('fail'));
+      mockRegisterEngine.mockResolvedValue({ onDidDispose: vi.fn() });
+
+      const { initialize } = await import('@renderer/services/theme.service-host');
+      await expect(initialize()).rejects.toThrow('fail');
+
+      // listenToSystemThemeChanges adds a 'change' listener; the catch block's unsubscribe removes it
+      expect(fakeMediaQuery.addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+      expect(fakeMediaQuery.removeEventListener).toHaveBeenCalledWith(
+        'change',
+        expect.any(Function),
+      );
+    });
+  });
+});

--- a/src/renderer/services/theme.service-host.ts
+++ b/src/renderer/services/theme.service-host.ts
@@ -443,13 +443,16 @@ class ThemeDataProviderEngine
   }
 
   async dispose(): Promise<boolean> {
+    // Set before awaiting runAllUnsubscribers so a constructor theme subscription resolving
+    // mid-disposal unsubscribes itself instead of being added to the list that's about to clear.
+    this.#isDisposed = true;
+
     const success = await this.unsubscribeEventListeners.runAllUnsubscribers();
 
     if (!this.#allThemeFamiliesByIdAsyncVariable.hasSettled) {
       this.#allThemeFamiliesByIdAsyncVariable.rejectWithReason('Theme service host disposing');
     }
 
-    this.#isDisposed = true;
     return success;
   }
 
@@ -589,9 +592,9 @@ export const initialize = createCachedInitializer(async () => {
   const systemThemeChangesInfo = listenToSystemThemeChanges();
 
   // registerEngine mutates the engine it receives (not idempotent), so build a fresh instance per
-  // attempt and dispose the replaced one to avoid leaking timers/subscriptions. Build the
-  // replacement before disposing so getCurrentThemeSync never observes a mid-disposal engine; after
-  // a failed attempt it holds the disposed engine, which is safe since dispose() keeps currentTheme.
+  // attempt and dispose the replaced one to avoid leaking timers/subscriptions. Building the
+  // replacement before disposing keeps getCurrentThemeSync on a live engine; after a catch-block
+  // failure it reads the disposed engine, still safe since dispose() retains currentTheme.
   const previousEngine = themeServiceEngine;
   themeServiceEngine = createThemeServiceEngine();
   await previousEngine

--- a/src/renderer/services/theme.service-host.ts
+++ b/src/renderer/services/theme.service-host.ts
@@ -588,13 +588,11 @@ let dataProvider: IThemeService;
 export const initialize = createCachedInitializer(async () => {
   const systemThemeChangesInfo = listenToSystemThemeChanges();
 
-  // registerEngine mutates the engine it receives (layering over notifyUpdate, set, and dispose),
-  // which is not idempotent. Since createCachedInitializer retries after a failure, use a fresh
-  // instance each attempt so a retry after a post-mutation failure doesn't double-layer the engine.
-  // Dispose the instance being replaced — the eager module-scope one on the first attempt, or a
-  // failed prior attempt's — so its constructor's timer and theme subscriptions don't leak. Build
-  // the replacement first so themeServiceEngine never points at a disposed engine (getCurrentThemeSync
-  // reads it synchronously). dispose() is idempotent, so re-disposing a failed attempt is harmless.
+  // registerEngine mutates the engine it receives (not idempotent), so build a fresh instance on
+  // each attempt and dispose the replaced one to avoid leaking its timer and theme subscriptions.
+  // Build the replacement before disposing so getCurrentThemeSync never observes a mid-disposal
+  // engine. After a catch-block failure, themeServiceEngine holds the disposed attempt — safe
+  // because dispose() tears down subscriptions/timers but does not clear currentTheme.
   const previousEngine = themeServiceEngine;
   themeServiceEngine = createThemeServiceEngine();
   await previousEngine

--- a/src/renderer/services/theme.service-host.ts
+++ b/src/renderer/services/theme.service-host.ts
@@ -588,11 +588,10 @@ let dataProvider: IThemeService;
 export const initialize = createCachedInitializer(async () => {
   const systemThemeChangesInfo = listenToSystemThemeChanges();
 
-  // registerEngine mutates the engine it receives (not idempotent), so build a fresh instance on
-  // each attempt and dispose the replaced one to avoid leaking its timer and theme subscriptions.
-  // Build the replacement before disposing so getCurrentThemeSync never observes a mid-disposal
-  // engine. After a catch-block failure, themeServiceEngine holds the disposed attempt — safe
-  // because dispose() tears down subscriptions/timers but does not clear currentTheme.
+  // registerEngine mutates the engine it receives (not idempotent), so build a fresh instance per
+  // attempt and dispose the replaced one to avoid leaking timers/subscriptions. Build the
+  // replacement before disposing so getCurrentThemeSync never observes a mid-disposal engine; after
+  // a failed attempt it holds the disposed engine, which is safe since dispose() keeps currentTheme.
   const previousEngine = themeServiceEngine;
   themeServiceEngine = createThemeServiceEngine();
   await previousEngine

--- a/src/renderer/services/theme.service-host.ts
+++ b/src/renderer/services/theme.service-host.ts
@@ -34,6 +34,7 @@ import themesDataObject from '@shared/data/themes.data.json';
 import { DEFAULT_THEME_FAMILY, DEFAULT_THEME_TYPE } from '@shared/data/platform.data';
 import { themeDataService } from '@shared/services/theme-data.service';
 import { logger } from '@shared/services/logger.service';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 
 /** Raw un-expanded themes that are built into the software */
 // We know this is the right data type because we write this data
@@ -561,48 +562,66 @@ class ThemeDataProviderEngine
   }
 }
 
-const themeServiceEngine = new ThemeDataProviderEngine(
-  currentThemeFromLocalStorage,
-  saveCurrentThemeToLocalStorage,
-  shouldMatchSystemFromLocalStorage,
-  saveShouldMatchSystemToLocalStorage,
-  async (allThemesHandler) => {
-    return themeDataService.subscribeAllThemes(undefined, allThemesHandler);
-  },
-  getSystemDarkThemeMediaQuery().matches ? 'dark' : 'light',
-  onDidChangeSystemThemeEmitter.event,
-  userThemesFromLocalStorage,
-  saveUserThemesToLocalStorage,
-);
+/** Builds a fresh theme data provider engine seeded from the current local-storage values. */
+function createThemeServiceEngine(): ThemeDataProviderEngine {
+  return new ThemeDataProviderEngine(
+    currentThemeFromLocalStorage,
+    saveCurrentThemeToLocalStorage,
+    shouldMatchSystemFromLocalStorage,
+    saveShouldMatchSystemToLocalStorage,
+    async (allThemesHandler) => {
+      return themeDataService.subscribeAllThemes(undefined, allThemesHandler);
+    },
+    getSystemDarkThemeMediaQuery().matches ? 'dark' : 'light',
+    onDidChangeSystemThemeEmitter.event,
+    userThemesFromLocalStorage,
+    saveUserThemesToLocalStorage,
+  );
+}
 
-let initializationPromise: Promise<void>;
+// Constructed eagerly so getCurrentThemeSync works before (or without) initialization. Reassigned
+// to a fresh instance on each initialize attempt below.
+let themeServiceEngine = createThemeServiceEngine();
+
 /** Need to run initialize before using this */
 let dataProvider: IThemeService;
-export async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          const systemThemeChangesInfo = listenToSystemThemeChanges();
+export const initialize = createCachedInitializer(async () => {
+  const systemThemeChangesInfo = listenToSystemThemeChanges();
 
-          dataProvider = await dataProviderService.registerEngine(
-            themeServiceDataProviderName,
-            themeServiceEngine,
-          );
+  // registerEngine mutates the engine it receives (layering over notifyUpdate, set, and dispose),
+  // which is not idempotent. Since createCachedInitializer retries after a failure, use a fresh
+  // instance each attempt so a retry after a post-mutation failure doesn't double-layer the engine.
+  // Dispose the instance being replaced — the eager module-scope one on the first attempt, or a
+  // failed prior attempt's — so its constructor's timer and theme subscriptions don't leak. Build
+  // the replacement first so themeServiceEngine never points at a disposed engine (getCurrentThemeSync
+  // reads it synchronously). dispose() is idempotent, so re-disposing a failed attempt is harmless.
+  const previousEngine = themeServiceEngine;
+  themeServiceEngine = createThemeServiceEngine();
+  await previousEngine
+    .dispose()
+    .catch((e) => logger.warn(`Failed to dispose previous ThemeDataProviderEngine: ${e}`));
 
-          dataProvider.onDidDispose(() => {
-            systemThemeChangesInfo.unsubscribe();
-          });
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
+  try {
+    dataProvider = await dataProviderService.registerEngine(
+      themeServiceDataProviderName,
+      themeServiceEngine,
+    );
+  } catch (error) {
+    // Stop listening so a retried initialization doesn't add a duplicate listener, and dispose the
+    // engine so its constructor's timer and theme subscriptions don't leak on a retry
+    systemThemeChangesInfo.unsubscribe();
+    await themeServiceEngine
+      .dispose()
+      .catch((e) =>
+        logger.warn(`Failed to dispose ThemeDataProviderEngine after failed init: ${e}`),
+      );
+    throw error;
   }
-  return initializationPromise;
-}
+
+  dataProvider.onDidDispose(() => {
+    systemThemeChangesInfo.unsubscribe();
+  });
+});
 
 /** This is an internal-only export for testing purposes and should not be used in development */
 export const testingThemeService = {

--- a/src/renderer/services/theme.service-host.ts
+++ b/src/renderer/services/theme.service-host.ts
@@ -213,6 +213,10 @@ class ThemeDataProviderEngine
       'theme.service-host.allThemeFamiliesById',
       STARTUP_TIME_MS,
     );
+    // Real consumers await this via #getAllThemeFamiliesByIdResolved and get their own rejection;
+    // this no-op keeps a dispose-time (or timeout) rejection with no awaiter from surfacing as an
+    // unhandled rejection, which the renderer's global handler would log at error level.
+    this.#allThemeFamiliesByIdAsyncVariable.promise.catch(() => {});
 
     // Setup timeout to reset theme to default at end of startup if the current theme does not exist
     const resetThemeTimeout = setTimeout(async () => {

--- a/src/renderer/services/window.service-host.test.ts
+++ b/src/renderer/services/window.service-host.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, test, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 import {
   getLastFocusedTabId,
   getLastSelectedScriptureNavigableWebViewId,
@@ -25,6 +25,7 @@ const {
   getTabInfoByIdMock,
   getSavedWebViewDefinitionSyncMock,
   getAllOpenWebViewDefinitionsSyncMock,
+  registerEngineMock,
 } = vi.hoisted(() => {
   const callbacks: CloseWebViewCallback[] = [];
   const openCallbacks: WebViewLifecycleCallback[] = [];
@@ -47,6 +48,10 @@ const {
   const allOpenDefinitionsMock = vi.fn(
     (): { id: string; webViewType: string; projectId?: string }[] => [],
   );
+  // Default implementation returns the engine it is handed, mirroring the real
+  // `dataProviderService.registerEngine`. The initialize-retry tests reset and override this to
+  // simulate registration failures.
+  const registerMock = vi.fn(async (_name, engine) => engine);
   return {
     closeWebViewCallbacks: callbacks,
     openWebViewCallbacks: openCallbacks,
@@ -54,6 +59,7 @@ const {
     getTabInfoByIdMock: tabInfoMock,
     getSavedWebViewDefinitionSyncMock: definitionMock,
     getAllOpenWebViewDefinitionsSyncMock: allOpenDefinitionsMock,
+    registerEngineMock: registerMock,
   };
 });
 
@@ -81,7 +87,11 @@ vi.mock('@renderer/services/web-view.service-host', () => ({
 }));
 
 vi.mock('@shared/services/data-provider.service', () => ({
-  dataProviderService: { registerEngine: vi.fn(async (_name, engine) => engine) },
+  dataProviderService: { registerEngine: registerEngineMock },
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
 }));
 
 // The module-load `platform.interfaceMode` subscription drives Simple-mode nav-target pinning. This
@@ -438,5 +448,44 @@ describe('navigation target web view', () => {
     emitCloseWebView('editor-1');
 
     expect(getNavigationTargetWebView()).toBeUndefined();
+  });
+});
+
+describe('window.service-host initialize', () => {
+  beforeEach(() => {
+    registerEngineMock.mockReset();
+    vi.resetModules();
+  });
+
+  it('disposes the engine on registerEngine failure, removing window focus listeners', async () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    try {
+      registerEngineMock.mockRejectedValueOnce(new Error('simulated failure'));
+
+      const { initialize } = await import('@renderer/services/window.service-host');
+      await expect(initialize()).rejects.toThrow('simulated failure');
+
+      // The engine constructor adds focusin/focusout listeners; dispose() removes them
+      expect(addSpy).toHaveBeenCalledWith('focusin', expect.any(Function));
+      expect(addSpy).toHaveBeenCalledWith('focusout', expect.any(Function));
+      expect(removeSpy).toHaveBeenCalledWith('focusin', expect.any(Function));
+      expect(removeSpy).toHaveBeenCalledWith('focusout', expect.any(Function));
+    } finally {
+      addSpy.mockRestore();
+      removeSpy.mockRestore();
+    }
+  });
+
+  it('succeeds on retry after a failed attempt', async () => {
+    registerEngineMock.mockRejectedValueOnce(new Error('first failure')).mockResolvedValueOnce({});
+
+    const { initialize } = await import('@renderer/services/window.service-host');
+
+    await expect(initialize()).rejects.toThrow('first failure');
+    await initialize();
+
+    expect(registerEngineMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/renderer/services/window.service-host.test.ts
+++ b/src/renderer/services/window.service-host.test.ts
@@ -64,12 +64,18 @@ const {
 });
 
 vi.mock('@renderer/services/web-view.service-host', () => ({
+  getAllOpenWebViewDefinitionsSync: getAllOpenWebViewDefinitionsSyncMock,
+  // detectFocus() calls getDockLayout().getTabInfoByElement, so the dock layout stays stubbed for
+  // the engine constructor's initial focus detection (see enginesToDispose below). That detection
+  // can resolve after the test finishes, so this mock must not be cleared — a cleared getDockLayout
+  // would resolve to undefined and throw.
   getDockLayout: vi.fn(async () => ({
     focusTab: vi.fn(),
-    getTabInfoByElement: vi.fn(() => undefined),
+    getTabInfoByDirectionFromTab: vi.fn().mockReturnValue(undefined),
+    getTabInfoByElement: vi.fn().mockReturnValue(undefined),
     getTabInfoById: getTabInfoByIdMock,
-    getTabInfoByDirectionFromTab: vi.fn(() => undefined),
   })),
+  getSavedWebViewDefinitionSync: getSavedWebViewDefinitionSyncMock,
   onDidCloseWebView: (callback: CloseWebViewCallback) => {
     closeWebViewCallbacks.push(callback);
     return () => true;
@@ -82,8 +88,6 @@ vi.mock('@renderer/services/web-view.service-host', () => ({
     updateWebViewCallbacks.push(callback);
     return () => true;
   },
-  getSavedWebViewDefinitionSync: getSavedWebViewDefinitionSyncMock,
-  getAllOpenWebViewDefinitionsSync: getAllOpenWebViewDefinitionsSyncMock,
 }));
 
 vi.mock('@shared/services/data-provider.service', () => ({

--- a/src/renderer/services/window.service-host.ts
+++ b/src/renderer/services/window.service-host.ts
@@ -11,6 +11,8 @@ import {
   getWebViewIdFromFocusSubject,
 } from '@shared/services/window.service-model';
 import { dataProviderService } from '@shared/services/data-provider.service';
+import { logger } from '@shared/services/logger.service';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import { DataProviderEngine, IDataProviderEngine } from '@shared/models/data-provider-engine.model';
 import { DataProviderUpdateInstructions } from '@shared/models/data-provider.model';
 import {
@@ -508,28 +510,22 @@ async function detectFocus(): Promise<FocusSubject | FocusSubjectElement | undef
   return { focusType: 'element', element: activeElement };
 }
 
-let initializationPromise: Promise<void>;
 /** Need to run initialize before using this */
 let dataProvider: IWindowService;
-export async function initialize(): Promise<void> {
-  if (!initializationPromise) {
-    initializationPromise = new Promise<void>((resolve, reject) => {
-      const executor = async () => {
-        try {
-          dataProvider = await dataProviderService.registerEngine(
-            windowServiceProviderName,
-            new WindowDataProviderEngine(),
-          );
-          resolve();
-        } catch (error) {
-          reject(error);
-        }
-      };
-      executor();
-    });
+export const initialize = createCachedInitializer(async () => {
+  const engine = new WindowDataProviderEngine();
+  try {
+    dataProvider = await dataProviderService.registerEngine(windowServiceProviderName, engine);
+  } catch (error) {
+    // Dispose so the engine's window focus listeners don't leak if initialization is retried
+    await engine
+      .dispose()
+      .catch((e) =>
+        logger.warn(`Failed to dispose WindowDataProviderEngine after failed init: ${e}`),
+      );
+    throw error;
   }
-  return initializationPromise;
-}
+});
 
 /** This is an internal-only export for testing purposes and should not be used in development */
 export const testingWindowService = {

--- a/src/renderer/services/window.service-host.ts
+++ b/src/renderer/services/window.service-host.ts
@@ -11,8 +11,6 @@ import {
   getWebViewIdFromFocusSubject,
 } from '@shared/services/window.service-model';
 import { dataProviderService } from '@shared/services/data-provider.service';
-import { logger } from '@shared/services/logger.service';
-import { createCachedInitializer } from '@shared/utils/cached-initializer';
 import { DataProviderEngine, IDataProviderEngine } from '@shared/models/data-provider-engine.model';
 import { DataProviderUpdateInstructions } from '@shared/models/data-provider.model';
 import {
@@ -40,6 +38,7 @@ import { isDirectionFromTab } from '@shared/models/docking-framework.model';
 import { SCRIPTURE_EDITOR_WEBVIEW_TYPE, WebViewId } from '@shared/models/web-view.model';
 import { logger } from '@shared/services/logger.service';
 import { settingsService } from '@shared/services/settings.service';
+import { createCachedInitializer } from '@shared/utils/cached-initializer';
 
 const FOCUS_SUBJECT_OTHER: FocusSubjectOther = Object.freeze({
   focusType: 'other',


### PR DESCRIPTION
This is a follow-up to #2420, the `src/renderer/services/` slice of #2389.

If this slice is evaluated as worthwhile, this retry pattern can also be applied to `extensions/src/platform-scripture/` and `src/extension-host/services/` slices.

## Changes from `main`

- All three renderer service-host `initialize` functions converted from a hand-rolled `let initializationPromise` pattern to `createCachedInitializer`.
- Fixed a pre-existing disposal race in `ThemeDataProviderEngine`: `dispose()` now sets `#isDisposed` before awaiting `runAllUnsubscribers()`, so a constructor theme subscription that resolves mid-disposal unsubscribes itself instead of being added to the list that's about to be cleared (which would leak it). More exercisable now that the retry path disposes freshly constructed engines on failure.
- New tests:
  - `theme.service-host.test.ts` — end-to-end regression for init retry and re-registration
  - `window.service-host.test.ts` — init retry regression
  
## Scenario where this retry is useful

The renderer service-hosts (`dialog`, `theme`, `window`) all need to register with or wait on the extension host over the network connection before they're considered initialized. The most likely scenario:

The renderer bundle finishes executing and immediately tries to initialize its service-hosts, but the WebSocket connection to the extension host process isn't fully established yet. `dataProviderService.registerEngine` or `webViewService.initialize` fails because the network layer isn't ready. With the old code, that rejected promise is cached forever — the renderer services all appear permanently broken for the session. With the fix, the next caller (e.g. the first command that needs a dialog) triggers a fresh attempt that succeeds.

In practice this is more likely to surface in dev: slow first load with a large unminified bundle, or immediately after a hot reload where the renderer reinitializes faster than the extension host re-registers its network objects.

## Why extra cleanup logic is needed

Unlike `src/shared/services` (which are pure consumer/lookup initializers), the renderer service-hosts call `dataProviderService.registerEngine` — a mutation that is **not idempotent**. A retry after a partially-failed attempt must avoid leaking the old engine. Each changed service-host now:

1. Constructs a fresh engine at the start of each attempt.
2. Disposes the previous engine (or the current attempt's engine on failure) so its listeners/timers don't leak.
3. `dispose()` is idempotent, so re-disposing a failed attempt is harmless.

### `theme.service-host.ts`

The engine was previously constructed eagerly at module scope (required for `getCurrentThemeSync` to work before initialization). That is preserved — the module-scope instance is still constructed eagerly — but `initialize` now replaces it with a fresh instance on each attempt and disposes the one being replaced. The replacement is built *before* the old one is disposed so `getCurrentThemeSync` never observes a disposed engine.

### `dialog.service-host.ts`

It delegates entirely to `webViewService.initialize()` — no engine registration — so the conversion is a straightforward one-liner with no cleanup needed.

## Devin review

https://app.devin.ai/review/paranext/paranext-core/pull/2440

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2440)
<!-- Reviewable:end -->
