### PR TITLE
fix(flaky): increase timeouts for two flaky e2e smoke tests

### DIFF
--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -129,8 +129,7 @@ test.describe('UI Interaction', () => {
 
     // Wait for theme data provider to update the stylesheet.
     // Allow 10 s: on slow CI (Windows/Linux) the data provider can take
-    // longer than 5 s to propagate the change. This test failed all retries
-    // on two main-branch SHAs (cdb61fe6, 80130761) with a 5 s limit.
+    // longer than 5 s to propagate the change.
     await expect(async () => {
       const newThemeId = await getThemeId();
       expect(newThemeId).not.toBe(initialThemeId);
@@ -141,6 +140,7 @@ test.describe('UI Interaction', () => {
     const restoreButton = mainPage.getByTestId(`user-profile-appearance-${restoreTarget}`);
     await expect(restoreButton).toBeVisible({ timeout: 10_000 });
     await restoreButton.click();
+    // Same 10 s allowance as the flip wait above — identical propagation risk.
     await expect(async () => {
       const restoredThemeId = await getThemeId();
       expect(restoredThemeId).toBe(initialThemeId);

--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -83,7 +83,10 @@ test.describe('UI Interaction', () => {
 
     // The about dialog opens as a floating dock tab (same as Help menu path).
     const aboutTab = mainPage.locator('.dock-tab', { hasText: /About/i });
-    await expect(aboutTab).toBeVisible({ timeout: 10_000 });
+    // Allow 20 s: on slow CI the dock panel can take longer than 10 s to render
+    // after the PAPI command fires. Playwright itself flagged this as "1 flaky"
+    // in two separate main-branch runs (SHA 80130761, 4b2894ec).
+    await expect(aboutTab).toBeVisible({ timeout: 20_000 });
 
     // Close the About tab via dispatchEvent (see comment in first test).
     const closeButton = aboutTab.locator('.dock-tab-close-btn');
@@ -124,11 +127,14 @@ test.describe('UI Interaction', () => {
     await expect(flipButton).toBeVisible({ timeout: 10_000 });
     await flipButton.click();
 
-    // Wait for theme data provider to update the stylesheet
+    // Wait for theme data provider to update the stylesheet.
+    // Allow 15 s: on slow CI (Windows/Linux) the data provider can take
+    // longer than 5 s to propagate the change. This test failed all retries
+    // on two main-branch SHAs (cdb61fe6, 80130761) with a 5 s limit.
     await expect(async () => {
       const newThemeId = await getThemeId();
       expect(newThemeId).not.toBe(initialThemeId);
-    }).toPass({ timeout: 5_000 });
+    }).toPass({ timeout: 15_000 });
 
     // The popover stays open after an appearance click (the handler doesn't close it), so we
     // can click the restore target without re-opening the popover.
@@ -138,7 +144,7 @@ test.describe('UI Interaction', () => {
     await expect(async () => {
       const restoredThemeId = await getThemeId();
       expect(restoredThemeId).toBe(initialThemeId);
-    }).toPass({ timeout: 5_000 });
+    }).toPass({ timeout: 15_000 });
   });
 
   test('should have a functional toolbar with book/chapter control', async ({ mainPage }) => {

--- a/e2e-tests/tests/smoke/ui-interaction.spec.ts
+++ b/e2e-tests/tests/smoke/ui-interaction.spec.ts
@@ -83,10 +83,10 @@ test.describe('UI Interaction', () => {
 
     // The about dialog opens as a floating dock tab (same as Help menu path).
     const aboutTab = mainPage.locator('.dock-tab', { hasText: /About/i });
-    // Allow 20 s: on slow CI the dock panel can take longer than 10 s to render
+    // Allow 15 s: on slow CI the dock panel can take longer than 10 s to render
     // after the PAPI command fires. Playwright itself flagged this as "1 flaky"
     // in two separate main-branch runs (SHA 80130761, 4b2894ec).
-    await expect(aboutTab).toBeVisible({ timeout: 20_000 });
+    await expect(aboutTab).toBeVisible({ timeout: 15_000 });
 
     // Close the About tab via dispatchEvent (see comment in first test).
     const closeButton = aboutTab.locator('.dock-tab-close-btn');
@@ -128,13 +128,13 @@ test.describe('UI Interaction', () => {
     await flipButton.click();
 
     // Wait for theme data provider to update the stylesheet.
-    // Allow 15 s: on slow CI (Windows/Linux) the data provider can take
+    // Allow 10 s: on slow CI (Windows/Linux) the data provider can take
     // longer than 5 s to propagate the change. This test failed all retries
     // on two main-branch SHAs (cdb61fe6, 80130761) with a 5 s limit.
     await expect(async () => {
       const newThemeId = await getThemeId();
       expect(newThemeId).not.toBe(initialThemeId);
-    }).toPass({ timeout: 15_000 });
+    }).toPass({ timeout: 10_000 });
 
     // The popover stays open after an appearance click (the handler doesn't close it), so we
     // can click the restore target without re-opening the popover.
@@ -144,7 +144,7 @@ test.describe('UI Interaction', () => {
     await expect(async () => {
       const restoredThemeId = await getThemeId();
       expect(restoredThemeId).toBe(initialThemeId);
-    }).toPass({ timeout: 15_000 });
+    }).toPass({ timeout: 10_000 });
   });
 
   test('should have a functional toolbar with book/chapter control', async ({ mainPage }) => {

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -136,23 +136,31 @@ describe('useProjectPickerData', () => {
     expect(result.current.currentProject).toBeUndefined();
   });
 
-  it('returns currentProject from the first open Scripture Editor web view', async () => {
-    const { webViews, papiFrontendProjectDataProviderService } = await importMocks();
-    vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
-      { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-abc' },
-    ] as never);
-    vi.mocked(papiFrontendProjectDataProviderService.get).mockResolvedValue({
-      getSetting: vi.fn(async () => 'Genesis Project'),
-    } as never);
+  // Timeout raised to 15 s: asyncUtilTimeout is already 5 s (see beforeAll), and
+  // importMocks() + renderHook setup can consume non-trivial wall-clock time on a
+  // starved Windows CI runner, causing the default 5 s Vitest test timeout to
+  // expire before waitFor resolves (observed in run 27636725842 on 2026-06-16).
+  it(
+    'returns currentProject from the first open Scripture Editor web view',
+    async () => {
+      const { webViews, papiFrontendProjectDataProviderService } = await importMocks();
+      vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
+        { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-abc' },
+      ] as never);
+      vi.mocked(papiFrontendProjectDataProviderService.get).mockResolvedValue({
+        getSetting: vi.fn(async () => 'Genesis Project'),
+      } as never);
 
-    const { result } = renderHook(() => useProjectPickerData());
+      const { result } = renderHook(() => useProjectPickerData());
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.currentProject?.fullName).toBe('Genesis Project');
-    });
-    expect(result.current.currentProject?.id).toBe('proj-abc');
-  });
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+        expect(result.current.currentProject?.fullName).toBe('Genesis Project');
+      });
+      expect(result.current.currentProject?.id).toBe('proj-abc');
+    },
+    15_000,
+  );
 
   it('returns allProjects from projectLookupService', async () => {
     const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -136,10 +136,6 @@ describe('useProjectPickerData', () => {
     expect(result.current.currentProject).toBeUndefined();
   });
 
-  // Timeout raised to 15 s: asyncUtilTimeout is already 5 s (see beforeAll), and
-  // importMocks() + renderHook setup can consume non-trivial wall-clock time on a
-  // starved Windows CI runner, causing the default 5 s Vitest test timeout to
-  // expire before waitFor resolves (observed in run 27636725842 on 2026-06-16).
   it('returns currentProject from the first open Scripture Editor web view', async () => {
     const { webViews, papiFrontendProjectDataProviderService } = await importMocks();
     vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
@@ -156,7 +152,7 @@ describe('useProjectPickerData', () => {
       expect(result.current.currentProject?.fullName).toBe('Genesis Project');
     });
     expect(result.current.currentProject?.id).toBe('proj-abc');
-  }, 15_000);
+  });
 
   it('returns allProjects from projectLookupService', async () => {
     const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -143,7 +143,8 @@ describe('useProjectPickerData', () => {
   it(
     'returns currentProject from the first open Scripture Editor web view',
     async () => {
-      const { webViews, papiFrontendProjectDataProviderService } = await importMocks();
+      const { webViews, papiFrontendProjectDataProviderService } =
+        await importMocks();
       vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
         { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-abc' },
       ] as never);

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -140,28 +140,23 @@ describe('useProjectPickerData', () => {
   // importMocks() + renderHook setup can consume non-trivial wall-clock time on a
   // starved Windows CI runner, causing the default 5 s Vitest test timeout to
   // expire before waitFor resolves (observed in run 27636725842 on 2026-06-16).
-  it(
-    'returns currentProject from the first open Scripture Editor web view',
-    async () => {
-      const { webViews, papiFrontendProjectDataProviderService } =
-        await importMocks();
-      vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
-        { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-abc' },
-      ] as never);
-      vi.mocked(papiFrontendProjectDataProviderService.get).mockResolvedValue({
-        getSetting: vi.fn(async () => 'Genesis Project'),
-      } as never);
+  it('returns currentProject from the first open Scripture Editor web view', async () => {
+    const { webViews, papiFrontendProjectDataProviderService } = await importMocks();
+    vi.mocked(webViews.getAllOpenWebViewDefinitions).mockResolvedValue([
+      { id: 'wv-1', webViewType: EDITOR_WEB_VIEW_TYPE, projectId: 'proj-abc' },
+    ] as never);
+    vi.mocked(papiFrontendProjectDataProviderService.get).mockResolvedValue({
+      getSetting: vi.fn(async () => 'Genesis Project'),
+    } as never);
 
-      const { result } = renderHook(() => useProjectPickerData());
+    const { result } = renderHook(() => useProjectPickerData());
 
-      await waitFor(() => {
-        expect(result.current.isLoading).toBe(false);
-        expect(result.current.currentProject?.fullName).toBe('Genesis Project');
-      });
-      expect(result.current.currentProject?.id).toBe('proj-abc');
-    },
-    15_000,
-  );
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+      expect(result.current.currentProject?.fullName).toBe('Genesis Project');
+    });
+    expect(result.current.currentProject?.id).toBe('proj-abc');
+  }, 15_000);
 
   it('returns allProjects from projectLookupService', async () => {
     const { projectLookupService, papiFrontendProjectDataProviderService } = await importMocks();


### PR DESCRIPTION
## Problem

A week-long CI scan surfaced tests that pass and fail intermittently. None has a logic bug — each is a correct test whose time budget is occasionally exhausted on a slow / starved CI runner. Raising the budgets fixes the flake without affecting the happy path: Playwright and Vitest both resolve as soon as the condition is met, so a larger timeout can only help a slow run, never slow a fast one.

| Test | File | Symptom | Fix |
|------|------|---------|-----|
| `should toggle theme via user profile popover` | `e2e-tests/tests/smoke/ui-interaction.spec.ts` | `toPass` 5 s exhausted before the theme data provider propagates the change — failed all 3 retries on 2 main SHAs (`4b2894ec` Windows, `80130761` Linux) | `toPass` 5 s → **10 s** (flip + restore) |
| `should open the About dialog via PAPI command` | `e2e-tests/tests/smoke/ui-interaction.spec.ts` | dock panel sometimes renders >10 s after the PAPI command fires — Playwright flagged "1 flaky" on 2 main runs | `toBeVisible` 10 s → **15 s** |
| ~`returns currentProject from the first open Scripture Editor web view`~ | ~`src/renderer/hooks/use-project-picker-data.hook.test.ts`~ | ~Vitest `Test timed out in 5000ms` on Windows; `asyncUtilTimeout` is already 5 s, so `importMocks()` + `renderHook` setup overhead eats the whole budget before `waitFor` resolves~ | ~per-test Vitest timeout 5 s → **15 s**~ |

Changes are additive-only — no logic changes.

> ~The per-test Vitest timeout uses a plain number as the 3rd arg to `it()`; this project's typings reject `{ timeout: number }` (TS2345).~

## Predicted impact — failures this would have prevented

Estimated against the flaky-tracker's documented scans (Jun 11 → 16). Each run below was confirmed to have **failed on the stated platform/SHA**; the per-test attribution comes from the scans recorded when the logs were fresh (the per-test log lines have since aged out of retention). Because these three tests are independent and the `beforeAll` passes on Linux/Windows, each is an isolated failure — no cascade.

| Test | Build-breaking failures avoided | Runs | Confidence |
|------|--------------------------------|------|-----------|
| `returns currentProject…` (unit) | **2** | [27636725842](https://github.com/paranext/paranext-core/actions/runs/27636725842) (`cdb61fe6`), [27359084151](https://github.com/paranext/paranext-core/actions/runs/27359084151) (`96861c65`) | High — 5 s → 10 s is 2× headroom for setup starvation |
| `should toggle theme…` (E2E) | **2** | [27636124266](https://github.com/paranext/paranext-core/actions/runs/27636124266) (`80130761`), [27418667383](https://github.com/paranext/paranext-core/actions/runs/27418667383) (`4b2894ec`) | Medium — it failed all 3 retries at 5 s, so 10 s being enough is an assumption |
| ~`should open the About dialog via PAPI command` (E2E)~ | ~0 (non-fatal)~ | ~`80130761`, `4b2894ec`~ | ~Flagged "1 flaky" but passed on retry; 20 s just removes the flaky noise~ |

**Bottom line:** ~**4 red builds** (4 test failures across 4 separate CI runs) would most likely have been turned green, plus~ **2 non-fatal flaky retries** of the About-via-PAPI test eliminated.

**Boundary:** this PR does **not** cover the macOS `beforeAll` "Web socket closed" / registration-timeout failures (see #2382) or any non-timeout cause — those builds would still have gone red. A larger timeout only helps when the operation finishes within the new window.

---
_Generated by [Claude Code](https://claude.ai/code/session_0186SxGQVtPuG3s2f3cBXxzp)_

Devin review: https://app.devin.ai/review/paranext/paranext-core/pull/2442

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2442)
<!-- Reviewable:end -->

