### PR TITLE
fix(manage-books): detect import book id by reconstructed Paratext filename

### DIFF
--- a/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.component.tsx
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.component.tsx
@@ -79,6 +79,7 @@ import {
   computeImportCompareState,
   deleteConfirmVariant,
   fmtTemplate,
+  resolveImportBookId,
   versificationFallbackName,
   versificationLabelKey,
 } from './manage-books-dialog.utils';
@@ -962,24 +963,11 @@ export function ManageBooksDialog({
     });
   }, [action, copySource, copySourceId, universe, current]);
 
-  // Book-id detection relies on the `\id` marker in the file content, not the
-  // filename. A filename like
-  // `38ZECCUNP89T.SFM` contains "ECC" before "ZEC", so the old filename-only
-  // substring scan misidentified the book. We now read the first `\id`
-  // marker and only fall back to a filename match when the content is missing
-  // or carries no usable id (story decorators / unreadable files).
+  // Book-id detection prefers the `\id` marker in the file content over the filename; see
+  // `resolveImportBookId` for the filename-fallback details (USX/XML imports have no `\id` marker).
   const detectBookId = useCallback(
-    (filename: string, content?: string): string | undefined => {
-      if (content) {
-        const idMatch = content.match(/^\s*\\id\s+([A-Za-z0-9]{2,4})/m);
-        if (idMatch) {
-          const candidate = idMatch[1].toUpperCase();
-          if (allBooks.includes(candidate)) return candidate;
-        }
-      }
-      const upper = filename.toUpperCase();
-      return allBooks.find((b) => upper.includes(b));
-    },
+    (filename: string, content?: string): string | undefined =>
+      resolveImportBookId(filename, content, allBooks),
     [allBooks],
   );
 

--- a/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.utils.test.ts
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.utils.test.ts
@@ -1,10 +1,36 @@
 import { describe, it, expect } from 'vitest';
+import { Canon } from '@sillsdev/scripture';
 import {
   computeCompareState,
   computeImportCompareState,
   deleteConfirmVariant,
   fmtTemplate,
+  resolveImportBookId,
 } from './manage-books-dialog.utils';
+
+/** Canonical book ids, built the same way the dialog builds its default `allBooks` list. */
+const ALL_BOOKS: string[] = (() => {
+  const ids: string[] = [];
+  for (let n = 1; n <= 102; n += 1) {
+    const id = Canon.bookNumberToId(n, '');
+    if (id) ids.push(id);
+  }
+  return ids;
+})();
+
+/**
+ * Paratext's book-number filename prefix, mirroring ParatextData
+ * `ProjectSettings.BookFileNameDigits` (01-09, 10-39, then a +1 gap for 40-99 so Matthew is `41`,
+ * and A0/B0/C0 letter codes for >=100). Used to build authentic import filenames for the sweep.
+ */
+const paratextBookFileDigits = (bookNum: number): string => {
+  if (bookNum < 10) return `0${bookNum}`;
+  if (bookNum < 40) return `${bookNum}`;
+  if (bookNum < 100) return `${bookNum + 1}`;
+  if (bookNum < 110) return `A${bookNum - 100}`;
+  if (bookNum < 120) return `B${bookNum - 110}`;
+  return `C${bookNum - 120}`;
+};
 
 describe('fmtTemplate', () => {
   it('substitutes positional placeholders in order', () => {
@@ -124,5 +150,81 @@ describe('deleteConfirmVariant', () => {
     // project was about to be deleted — the highest-impact case.
     expect(deleteConfirmVariant(true, true)).not.toBe('all');
     expect(deleteConfirmVariant(true, true)).toBe('allShared');
+  });
+});
+
+describe('resolveImportBookId', () => {
+  it('prefers the \\id marker in SFM content over the filename', () => {
+    // Even a misleading filename must yield the content's book id.
+    expect(resolveImportBookId('38ZECCUNP89T.SFM', '\\id ZEC\n\\c 1\n', ALL_BOOKS)).toBe('ZEC');
+    expect(resolveImportBookId('whatever.sfm', '  \\id MAT - World English\n', ALL_BOOKS)).toBe(
+      'MAT',
+    );
+  });
+
+  it('falls back to the filename when content carries no usable \\id marker', () => {
+    expect(resolveImportBookId('ZEC.SFM', undefined, ALL_BOOKS)).toBe('ZEC');
+    expect(resolveImportBookId('41MAT.usx', undefined, ALL_BOOKS)).toBe('MAT');
+  });
+
+  it('handles book ids that contain a leading digit (e.g. 1SA)', () => {
+    expect(resolveImportBookId('091SACUNP.SFM', undefined, ALL_BOOKS)).toBe('1SA');
+  });
+
+  it('returns undefined when nothing matches', () => {
+    expect(resolveImportBookId('123-456.txt', undefined, ALL_BOOKS)).toBeUndefined();
+  });
+
+  it('regression: picks the book id at the front of the name, not an earlier-canon substring', () => {
+    // `38ZECCUNP89T` (Zechariah) contains "ECC" (Ecclesiastes, an earlier book) inside "ZEC...".
+    // A canonical-order substring scan returned ECC and imported Zechariah into the wrong book.
+    // USX/XML imports always hit this path because their content has no \id marker.
+    expect(resolveImportBookId('38ZECCUNP89T.SFM', undefined, ALL_BOOKS)).toBe('ZEC');
+    expect(resolveImportBookId('38ZECCUNP89T.usx', undefined, ALL_BOOKS)).toBe('ZEC');
+  });
+
+  it('regression: a digit-leading id earlier in the name does not win over the real book', () => {
+    // Paratext prefixes NT files with bookNum+1, so Matthew is `41MAT`. A plain leftmost scan would
+    // pick `1MA` (1 Maccabees) at index 1 over `MAT` at index 2 — the real book must win.
+    expect(resolveImportBookId('41MAT.usx', undefined, ALL_BOOKS)).toBe('MAT');
+    expect(resolveImportBookId('52COL.usx', undefined, ALL_BOOKS)).toBe('COL');
+    expect(resolveImportBookId('84MAN.usx', undefined, ALL_BOOKS)).toBe('MAN');
+  });
+
+  it('regression: a digit-leading book whose letters + project initial form another book', () => {
+    // `471COLXX` is 1 Corinthians (prefix 47 + `1CO`) from a project named `LXX...`. The id's
+    // letters (`CO`) plus the project's first letter (`L`) spell `COL` (Colossians); reconstructing
+    // the expected `<prefix><id>` stem keeps it `1CO`, not `COL`.
+    expect(resolveImportBookId('471COLXX.usx', undefined, ALL_BOOKS)).toBe('1CO');
+    expect(resolveImportBookId('551TITEV.SFM', undefined, ALL_BOOKS)).toBe('1TI'); // not Titus
+    expect(resolveImportBookId('1COLXX.SFM', undefined, ALL_BOOKS)).toBe('1CO'); // MAT form
+  });
+
+  it('regression: a project short name containing a book code does not override the real book', () => {
+    // Paratext names files <bookNumber><bookId><projectShortName>; a project short name that
+    // happens to contain an earlier-canon code (e.g. "GEN") must not win over the leading id.
+    expect(resolveImportBookId('40MATGEN.SFM', undefined, ALL_BOOKS)).toBe('MAT');
+  });
+
+  it('resolves every book from its authentic Paratext filename (digits + id + project)', () => {
+    // Sweep all books through real Paratext filenames so a regression on any single book (e.g. the
+    // +1 NT gap, digit-leading ids, or A0/B0/C0 apocrypha prefixes) is caught. Build the
+    // (filename -> expected id) cases first so the assertions are not inside a conditional.
+    const cases: Array<{ filename: string; expected: string }> = [];
+    for (let n = 1; n <= 102; n += 1) {
+      const id = Canon.bookNumberToId(n, '');
+      if (id) {
+        const prefix = paratextBookFileDigits(n);
+        cases.push({ filename: `${prefix}${id}CUNP08.SFM`, expected: id });
+        cases.push({ filename: `${prefix}${id}.usx`, expected: id });
+        // FileNameForm === 'MAT' (bare id, no number prefix).
+        cases.push({ filename: `${id}CUNP08.SFM`, expected: id });
+      }
+    }
+    const resolved = cases.map((c) => ({
+      ...c,
+      actual: resolveImportBookId(c.filename, undefined, ALL_BOOKS),
+    }));
+    expect(resolved.filter((r) => r.actual !== r.expected)).toEqual([]);
   });
 });

--- a/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.utils.ts
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.utils.ts
@@ -4,7 +4,7 @@
  * can import without dragging in React or PAPI.
  */
 
-import { ScrVersType } from '@sillsdev/scripture';
+import { Canon, ScrVersType } from '@sillsdev/scripture';
 import type {
   ManageBooksComparisonState,
   ManageBooksDialogLocalizedStrings,
@@ -147,3 +147,82 @@ export const versificationFallbackName = (value: number | string): string => {
       return 'Unknown';
   }
 };
+
+/**
+ * Paratext's book-number filename prefix, mirroring ParatextData
+ * `ProjectSettings.BookFileNameDigits` (`bookNum` is the 1-based canonical number, GEN=1):
+ * `01`-`09`, `10`-`39`, then a `+1` gap for 40-99 (so Matthew=40 is `41`), and `A0`/`B0`/`C0`
+ * letter codes for 100+.
+ */
+function bookFileNamePrefix(bookNum: number): string {
+  if (bookNum < 10) return `0${bookNum}`;
+  if (bookNum < 40) return `${bookNum}`;
+  if (bookNum < 100) return `${bookNum + 1}`;
+  if (bookNum < 110) return `A${bookNum - 100}`;
+  if (bookNum < 120) return `B${bookNum - 110}`;
+  return `C${bookNum - 120}`;
+}
+
+/**
+ * Detect the book id for an import file from its `\id` marker (preferred) or its filename.
+ *
+ * The book id is taken from the first `\id` marker in the SFM `content` when present and valid.
+ * Otherwise it falls back to the filename, which covers USX/XML imports (whose content never
+ * carries a `\id` marker), story decorators, and files whose text could not be read.
+ *
+ * Paratext names book files `<bookNumberDigits><bookId><projectShortName>` — or, in the `MAT`
+ * filename form, just `<bookId><projectShortName>` (see ParatextData
+ * `ProjectSettings.GetFileNameBookPart`). The fallback reconstructs each book's expected stem and
+ * returns the one the filename actually starts with. This replaces the old canonical-order
+ * substring scan, which returned the first book id appearing _anywhere_ in the name and so
+ * mis-detected:
+ *
+ * - Ids that appear earlier as a substring — `38ZECCUNP89T` contains `ECC` (Ecclesiastes) inside
+ *   `ZEC...`, so Zechariah was read as Ecclesiastes; and
+ * - Project short names that contain a book code.
+ *
+ * Anchoring to the reconstructed `<prefix><id>` keeps digit-leading ids correct too: `471COLXX` (1
+ * Corinthians from a project named `LXX...`) resolves to `1CO`, not `COL`, and `41MAT` resolves to
+ * `MAT`, not `1MA`. A leftmost-occurrence scan remains only as a last resort for names that match
+ * neither expected form.
+ *
+ * @param filename Import file name (e.g. `38ZECCUNP89T.SFM`).
+ * @param content Optional file text; the `\id` marker is used when present and recognized.
+ * @param allBooks Recognized book ids to match against, in canonical order.
+ * @returns The detected book id, or `undefined` when nothing matches.
+ */
+export function resolveImportBookId(
+  filename: string,
+  content: string | undefined,
+  allBooks: readonly string[],
+): string | undefined {
+  if (content) {
+    const idMatch = content.match(/^\s*\\id\s+([A-Za-z0-9]{2,4})/m);
+    if (idMatch) {
+      const candidate = idMatch[1].toUpperCase();
+      if (allBooks.includes(candidate)) return candidate;
+    }
+  }
+  const upper = filename.toUpperCase();
+  // Standard form: the name starts with the book's number prefix followed by its id.
+  const standard = allBooks.find((book) => {
+    const bookNum = Canon.bookIdToNumber(book);
+    return bookNum > 0 && upper.startsWith(`${bookFileNamePrefix(bookNum)}${book}`);
+  });
+  if (standard) return standard;
+  // `MAT` filename form: the name starts with the bare id (no number prefix).
+  const bareId = allBooks.find((book) => upper.startsWith(book));
+  if (bareId) return bareId;
+  // Last resort for names that follow neither form: the book id that occurs earliest in the name
+  // (position-based, so an earlier-canon substring no longer wins over the real book).
+  let detected: string | undefined;
+  let detectedIndex = Number.POSITIVE_INFINITY;
+  allBooks.forEach((book) => {
+    const index = upper.indexOf(book);
+    if (index !== -1 && index < detectedIndex) {
+      detectedIndex = index;
+      detected = book;
+    }
+  });
+  return detected;
+}


### PR DESCRIPTION
## Summary

The Manage Books **import** grid detected each file's book id from its filename with
`allBooks.find((b) => upper.includes(b))` — the first book id, in **canonical order**, that appeared
*anywhere* as a substring of the name. For any import file without a usable `\id` marker this silently
imported the content into the **wrong book**:

- `38ZECCUNP89T.SFM` (Zechariah) contains `ECC` inside `ZEC...`, so it was read as **Ecclesiastes**.
- A project short name that contains a book code could also win over the real id.

This path is reached far more often than it looks: **USX/XML imports never carry a `\id` marker**, so
they *always* fall back to the filename, as do content-read failures and malformed SFM files.

A prior in-code comment claimed this was fixed, but only the SFM `\id`-content path was — the filename
fallback was unchanged.

## Fix

Extract the detection into a pure, unit-tested `resolveImportBookId(filename, content, allBooks)` util
and match the filename against each book's **reconstructed Paratext stem** — `BookFileNameDigits(num) + id`
(or the bare id for the `MAT` filename form) — instead of a canonical-order substring scan. The prefix
scheme mirrors ParatextData `ProjectSettings.BookFileNameDigits`. Reconstruction anchors to the id's real
position and is unambiguous, so it correctly handles:

- the NT `+1` number gap — `41MAT` → `MAT` (not `1MA`);
- digit-leading ids whose letters collide with another book — `471COLXX` (1 Corinthians from a project
  named `LXX...`) → `1CO` (not `COL`);
- apocrypha `A0`/`B0`/`C0` prefixes.

A leftmost-occurrence scan remains only as a last resort for names matching neither form (still strictly
better than the old canonical-order scan). The component now delegates to the util; the `\id`-content path
is unchanged.

## Reproduction evidence (regression test: RED → GREEN)

A regression test was added in `manage-books-dialog.utils.test.ts`, including a sweep over **all 102 books
× 3 filename forms** built from the authentic Paratext digit scheme.

**Before (original canonical-order logic):**
```
RED assertions on ORIGINAL logic: 8 / 308
  RED: 38ZECCUNP89T.SFM -> ECC (want ZEC)
  RED: 38ZECCUNP89T.usx -> ECC (want ZEC)
  RED: 52COL.usx        -> 2CO (want COL)
  ...
```

**After (this fix):**
```
 Test Files  1 passed (1)
      Tests  31 passed (31)
```

Full extension suite: **180 passed**. `tsc` typecheck: clean. ESLint + Prettier: clean.

## Self-review summary

Reviewed at max depth via adversarial subagents. Two real defects were caught **in review and fixed
before this PR**:

1. An intermediate "leftmost-position" approach regressed `41MAT.usx` → `1MA` (Paratext's NT `+1` gap).
2. A boundary-aware approach then regressed `471COLXX.usx` → `COL` (a digit-leading id's letters plus the
   project name's first letter spelling another book).

The final **reconstruction** approach was validated exhaustively (102 books × {standard SFM, USX, bare-id
`MAT` form} = 0 failures) plus 20 adversarial real-world filenames. Scope is minimal: one extracted util,
one delegating call site, and tests — no behavior change to the `\id`-content path.

## Impact & confidence

- **Impact:** user-visible **data-integrity** defect — importing a book's content into the wrong book,
  silently. Severity high; frequency bounded (requires a filename whose code collides under the old scan,
  but USX imports always take this path). Triage score among the run's survivors: highest severity.
- **Confidence:** high — root cause confirmed in code, reproduced with a failing test, fix proven against
  the full canon and adversarial inputs.

## Provenance

Found by the **AI quality-sweep** (run `qs-2026-06-20`), cold-scan of `extensions/src/platform-scripture`.
No Jira issue seeded this run (Jira MCP was unavailable).

🤖 This change was found, implemented, and reviewed with AI assistance (Claude Code).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2446)
<!-- Reviewable:end -->
