### PR TITLE
fix(scripture-editor): toggle back from markers view in simple interface mode

### DIFF
--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -4,6 +4,7 @@ import type PapiBackend from '@papi/backend';
 import { UsjTextContentLocation } from 'platform-bible-utils';
 import {
   convertScriptureRangeToEditorRange,
+  getNextScriptureViewType,
   openDefaultActiveProjectIfApplicable,
   resolveOpenEditorDispatch,
   syncOnProjectSwitch,
@@ -2340,3 +2341,20 @@ describe('syncOnProjectSwitch', () => {
 });
 
 // #endregion syncOnProjectSwitch
+
+// #region getNextScriptureViewType
+
+describe('getNextScriptureViewType', () => {
+  // Regression: in simple interface mode both the formatted and markers views resolve to
+  // markerMode 'hidden', so a markerMode-based toggle got stuck and could never return to the
+  // formatted (editable) view. The toggle must simply alternate based on the current view type.
+  it('switches from the markers view back to the formatted view', () => {
+    expect(getNextScriptureViewType('markers')).toBe('formatted');
+  });
+
+  it('switches from the formatted view to the markers view', () => {
+    expect(getNextScriptureViewType('formatted')).toBe('markers');
+  });
+});
+
+// #endregion getNextScriptureViewType

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -19,7 +19,7 @@ import {
   UsjReaderWriter,
 } from 'platform-bible-utils';
 import { SerializedVerseRef } from '@sillsdev/scripture';
-import { ScriptureRange } from 'platform-scripture-editor';
+import { ScriptureEditorViewType, ScriptureRange } from 'platform-scripture-editor';
 import type { SharedProjectsInfo } from 'platform-scripture';
 import { MutableRefObject } from 'react';
 import { EditorRef } from '@eten-tech-foundation/platform-editor';
@@ -27,6 +27,24 @@ import { MarkerMenuItem } from 'platform-bible-react';
 
 // Note: src/main/shutdown-tasks.ts has a copy of this value — keep them in sync.
 export const SCRIPTURE_EDITOR_WEBVIEW_TYPE = 'platformScriptureEditor.react';
+
+/**
+ * Determine which Scripture editor view to switch to when the user toggles the view (e.g. via the
+ * "Switch Scripture View" menu command).
+ *
+ * The toggle simply alternates between the two view types. It must not be derived from the resolved
+ * `markerMode`: in simple interface mode both the formatted and markers views resolve to
+ * `markerMode: 'hidden'`, so a markerMode-based toggle stayed stuck in the (read-only) markers view
+ * and could never return to the formatted view.
+ *
+ * @param currentViewType The view type the editor is currently showing
+ * @returns The view type to switch to
+ */
+export function getNextScriptureViewType(
+  currentViewType: ScriptureEditorViewType,
+): ScriptureEditorViewType {
+  return currentViewType === 'markers' ? 'formatted' : 'markers';
+}
 
 /**
  * Check deep equality of two values such that two equal objects or arrays created in two different

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -99,6 +99,7 @@ import {
   formatEditorTitle,
   generateInlineMarkerMenuListItems,
   generateParagraphMenuListItems,
+  getNextScriptureViewType,
   openCommentListAndSelectThreadSafe,
   SCRIPTURE_EDITOR_WEBVIEW_TYPE,
 } from './platform-scripture-editor.utils';
@@ -735,7 +736,7 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
           break;
         }
         case 'changeScriptureView': {
-          setViewType(viewOptions.markerMode === 'hidden' ? 'markers' : 'formatted');
+          setViewType(getNextScriptureViewType(viewType));
           break;
         }
         case 'toggleFootnotesPaneVisibility': {
@@ -978,7 +979,7 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
     setDecorations,
     setFootnotesPaneVisible,
     setViewType,
-    viewOptions.markerMode,
+    viewType,
     localizedStrings,
     projectId,
   ]);


### PR DESCRIPTION
## Summary

The **Switch Scripture View** menu command could not toggle back from the **Markers** view to the **Formatted** view when the editor is in the default **simple** interface mode. A user who switched to Markers got stuck in the read-only Markers view — and because `viewType` is persisted (`useWebViewState`), a reload did not recover it. Power mode was unaffected.

### Root cause

`platform-scripture-editor.web-view.tsx` decided the next view from the resolved `markerMode`:

```ts
setViewType(viewOptions.markerMode === 'hidden' ? 'markers' : 'formatted');
```

In simple mode, `getViewOptionsForType` resolves **both** the formatted and markers views to the `paragraph-structure` preset, whose `markerMode` is `'hidden'` (the markers branch only overrides `noteMode`). So once `viewType === 'markers'`, the rule computed `'hidden' === 'hidden'` → `'markers'` again. Power mode worked because its markers view resolves to `markerMode: 'visible'`.

Verified library values (`@eten-tech-foundation/platform-editor`): default `formatted` → `markerMode 'hidden'`; `paragraph-structure` → `markerMode 'hidden'`.

### Fix

Decide the next view by simply alternating the current `viewType` via a new pure, exported `getNextScriptureViewType()` helper — independent of `markerMode`. The message-listener effect now depends on `viewType` (the `useWebViewState` setter has no functional-updater form, so the handler reads `viewType` from the closure and must list it as a dependency). Power-mode behavior is unchanged.

## Before / after evidence (regression test)

**BEFORE** — a faithful copy of the original production rule, run against the real `@eten-tech-foundation/platform-editor` library (throwaway, not committed):

```
× simple mode: from markers it WRONGLY stays in markers (bug)
    AssertionError: expected 'markers' to be 'formatted'
✓ simple mode: from formatted it goes to markers (works)
✓ power mode:  from markers it correctly returns to formatted (works)
```

And the committed regression test, before the fix existed:

```
× getNextScriptureViewType > switches from the markers view back to the formatted view
    TypeError: (0 , getNextScriptureViewType) is not a function
× getNextScriptureViewType > switches from the formatted view to the markers view
    TypeError: (0 , getNextScriptureViewType) is not a function
```

**AFTER** — full extension test suite:

```
✓ src/paragraph-marker-tooltip/paragraph-marker-tooltip.utils.test.ts (10 tests)
✓ src/select-dbl-resource.test.ts (16 tests)
✓ src/use-editor-pdp-sync.hook.test.ts (3 tests)
✓ src/use-effective-resource-reference-list.hook.test.ts (14 tests)
✓ src/platform-scripture-editor.utils.test.ts (87 tests)
Test Files  5 passed (5)   Tests  130 passed (130)
```

Also clean: `eslint` on changed files (exit 0) and `tsc --noEmit -p tsconfig.json` (exit 0).

## Self-review summary

Reviewed at max effort (adversarial). Verdict: **APPROVE-WITH-NITS** — no blockers, no should-fix. Confirmed: correct in all four view×mode combinations; power-mode behavior preserved; stale-closure handled (`viewType` added to deps; the setter has no functional-updater overload); dependency array exhaustive and lint-clean; single decision site (no duplicate logic in `main.ts`); minimal diff (3 files, 40 insertions / 3 deletions). Lone nit: the regression test guards the trivial extracted helper rather than the call-site wiring — a proportionate trade-off given the fix size and the `ScriptureEditorViewType` union keeping the helper exhaustive.

## Impact & confidence

- **User-visible:** yes — reachable from the editor top menu in the default interface mode.
- **Severity:** moderate — the affected editor instance is stuck in a read-only view (persisted across reloads); the only workarounds are opening a new editor or switching to power mode.
- **Frequency:** common path — simple mode is the default; anyone who uses "Switch Scripture View" twice hits it.
- **Confidence:** ~0.9 — root cause traced, library values verified, independently re-verified by an adversarial skeptic across 7 axes, and guarded by a failing→passing regression test.

## Provenance

Found by the automated **quality-sweep** run `qs-2026-06-21` (cold-scan of `extensions/src/platform-scripture-editor`). No linked Jira issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2447)
<!-- Reviewable:end -->
