### PR TITLE
fix(platform-scripture): add missing structureProtected label

### DIFF
--- a/extensions/src/platform-scripture/contributions/localizedStrings.json
+++ b/extensions/src/platform-scripture/contributions/localizedStrings.json
@@ -619,6 +619,7 @@
       "%project_settings_platformScripture_referencedProjectsAndResources_label%": "Proyectos y recursos referenciados",
       "%project_settings_platformScripture_repeatableWords_description%": "Lista de palabras que se permiten repetir en este proyecto",
       "%project_settings_platformScripture_repeatableWords_label%": "Palabras Repetibles",
+      "%project_settings_platformScripture_structureProtected_label%": "Estructura protegida",
       "%project_settings_platformScripture_validCharacters_description%": "Lista de caracteres aceptados en este proyecto",
       "%project_settings_platformScripture_validCharacters_label%": "Caracteres válidos",
       "%project_settings_platformScripture_validMarkers_description%": "Lista de marcadores permitidos en este proyecto",

--- a/extensions/src/platform-scripture/contributions/localizedStrings.json
+++ b/extensions/src/platform-scripture/contributions/localizedStrings.json
@@ -358,6 +358,7 @@
       "%project_settings_platformScripture_referencedProjectsAndResources_label%": "Referenced Projects and Resources",
       "%project_settings_platformScripture_repeatableWords_description%": "List of words that are allowed to be repeated in this project.",
       "%project_settings_platformScripture_repeatableWords_label%": "Repeatable Words",
+      "%project_settings_platformScripture_structureProtected_label%": "Structure Protected",
       "%project_settings_platformScripture_validCharacters_description%": "List of characters that are accepted in this project.",
       "%project_settings_platformScripture_validCharacters_label%": "Valid Characters",
       "%project_settings_platformScripture_validMarkers_description%": "List of markers that are accepted in this project.",

--- a/extensions/src/platform-scripture/contributions/projectSettings.json
+++ b/extensions/src/platform-scripture/contributions/projectSettings.json
@@ -107,6 +107,7 @@
         "includeProjectInterfaces": ["Paratext", "Scripture"]
       },
       "platformScripture.structureProtected": {
+        "label": "%project_settings_platformScripture_structureProtected_label%",
         "isHidden": true,
         "default": false,
         "includeProjectInterfaces": ["Paratext", "Scripture"]


### PR DESCRIPTION
## Summary

In `projectSettings.json`, `platformScripture.structureProtected` was missing the required `label` property, causing a schema validation error:

```
[warn]  [exth] Could not add project settings contribution for platformScripture: Error: Invalid platformScripture project settings document: data must be object, data/0/properties/platformScripture.structureProtected must have required property 'label', data/0/properties/platformScripture.structureProtected must match a schema in anyOf, data must match a schema in anyOf
```

- Added the `label` key (with a localized string reference) to `platformScripture.structureProtected` in `projectSettings.json`
- Added English and Spanish translations for the new key to `localizedStrings.json`

## Test plan

- [ ] Start Platform.Bible and confirm the `Error: Invalid platformScripture project settings document` warning no longer appears in the extension host log

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2448)
<!-- Reviewable:end -->
