### PR TITLE
fix(platform-bible-react): restore listbox type-ahead when the container is focused

### DIFF
--- a/lib/platform-bible-react/src/hooks/listbox-keyboard-navigation.hook.test.tsx
+++ b/lib/platform-bible-react/src/hooks/listbox-keyboard-navigation.hook.test.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { useListbox, type ListboxOption } from './listbox-keyboard-navigation.hook';
+
+/**
+ * Minimal harness that wires `useListbox` to a listbox container exactly like real consumers (e.g.
+ * `SourceLanguageIndexedList`): a `<ul role="listbox" tabIndex={0}>` whose options carry
+ * `tabIndex={-1}`. The container receives DOM focus in the ARIA activedescendant pattern, so it is
+ * the keyboard event target on initial focus and after a detail panel closes.
+ */
+function ListboxHarness({ onCharacterPress }: { onCharacterPress?: (char: string) => void }) {
+  const options: ListboxOption[] = [{ id: 'apple' }, { id: 'banana' }];
+  const { listboxRef, handleKeyDown } = useListbox({ options, onCharacterPress });
+  return (
+    <ul
+      role="listbox"
+      tabIndex={0}
+      // useListbox returns a generic HTMLElement ref; consumers cast it the same way.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      ref={listboxRef as React.RefObject<HTMLUListElement>}
+      onKeyDown={handleKeyDown}
+      data-testid="listbox"
+    >
+      {options.map((option) => (
+        <li key={option.id} id={option.id} role="option" aria-selected={false} tabIndex={-1}>
+          {option.id}
+          {/* A real interactive control nested inside an option (used by the guard test). */}
+          {/* tabIndex={-1} ensures the guard test exercises the interactive-tag detection
+              path specifically, not an incidental tabindex classification. */}
+          <input
+            data-testid={`input-${option.id}`}
+            aria-label={`edit ${option.id}`}
+            tabIndex={-1}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+describe('useListbox type-ahead', () => {
+  it('invokes onCharacterPress when a printable key is pressed while the listbox container is focused', () => {
+    const onCharacterPress = vi.fn();
+    render(<ListboxHarness onCharacterPress={onCharacterPress} />);
+
+    const listbox = screen.getByTestId('listbox');
+    // The container itself is the event target before any arrow navigation (initial focus).
+    fireEvent.keyDown(listbox, { key: 'b' });
+
+    expect(onCharacterPress).toHaveBeenCalledTimes(1);
+    expect(onCharacterPress).toHaveBeenCalledWith('b');
+  });
+
+  it('does NOT invoke onCharacterPress when typing inside a genuine interactive control in an option', () => {
+    const onCharacterPress = vi.fn();
+    render(<ListboxHarness onCharacterPress={onCharacterPress} />);
+
+    const input = screen.getByTestId('input-apple');
+    fireEvent.keyDown(input, { key: 'b' });
+
+    expect(onCharacterPress).not.toHaveBeenCalled();
+  });
+});

--- a/lib/platform-bible-react/src/hooks/listbox-keyboard-navigation.hook.ts
+++ b/lib/platform-bible-react/src/hooks/listbox-keyboard-navigation.hook.ts
@@ -86,6 +86,11 @@ export const useListbox = ({
   // Detect if the key event originated from an interactive element inside the currently selected option
   const isInteractiveElement = (element: HTMLElement | undefined) => {
     if (!element) return false;
+    // The listbox container itself is the element whose keydown we handle; it carries tabIndex={0}
+    // only for the ARIA activedescendant focus pattern and is never a control the user types into.
+    // Treating it as interactive would suppress type-ahead (onCharacterPress) whenever DOM focus is
+    // on the container (e.g. on initial focus or after a detail panel closes).
+    if (element === listboxRef.current) return false;
     const tag = element.tagName.toLowerCase();
     if (element.isContentEditable) return true;
     if (INTERACTIVE_ELEMENT_TAG_SELECTORS.includes(tag)) return true;


### PR DESCRIPTION
## Summary

`isInteractiveElement` in `useListbox` (the shared listbox keyboard-navigation hook) wrongly classified the **listbox container itself** as an interactive control. The container is rendered as `<ul role="listbox" tabIndex={0}>`; the `tabIndex={0}` exists only for the ARIA activedescendant focus pattern. Because `isInteractiveElement` returned `true` for any element with a `tabindex` other than `-1`, whenever DOM focus rested on the container the keydown target was the container and the type-ahead handler (`onCharacterPress`) was suppressed - so pressing a printable letter to jump to a matching item did nothing.

Focus rests on the container in exactly the moments a user starts type-ahead:
- on initial focus of the list, and
- after a detail panel closes (the consumer calls `listboxRef.current?.focus()` to restore navigation).

After arrow-navigating, focus moves to an `<li tabIndex={-1}>` option, so type-ahead "recovered" - which is why the bug looks intermittent.

**Fix:** exclude the container (`element === listboxRef.current`) at the top of `isInteractiveElement`. The container is the element whose keydown we are handling and is never a control the user types into. One logic line; behavior for options and genuine controls (inputs, buttons, contenteditable) is unchanged.

## Affected user-facing surface

`onCharacterPress` (type-ahead) is wired by `SourceLanguageIndexedList`, used by the **lexical-tools dictionary** and the **enhanced-resources** dictionary/encyclopedia/media tabs. Keyboard/screen-reader users who type a letter to jump to a word saw nothing happen on first focus.

## Reproduction evidence (regression test: RED -> GREEN)

New test `lib/platform-bible-react/src/hooks/listbox-keyboard-navigation.hook.test.tsx`.

**Before the fix** (revert test - fix line removed):
```
× useListbox type-ahead > invokes onCharacterPress when a printable key is pressed while the listbox container is focused
  → expected "spy" to be called 1 times, but got 0 times
✓ useListbox type-ahead > does NOT invoke onCharacterPress when typing inside a genuine interactive control in an option
Tests  1 failed | 1 passed (2)
```

**After the fix:**
```
✓ src/hooks/listbox-keyboard-navigation.hook.test.tsx (2 tests)
Tests  2 passed (2)
```

Full package unit suite stays green: **17 files, 218 tests passed**. `tsc` typecheck and ESLint both clean.

## Self-review summary

Reviewed at max scrutiny (independent reviewer pass):
- **Correctness:** The other call site of `isInteractiveElement` (`isInteractiveInsideSelected`) is gated by `selectedElement.contains(target) && target !== selectedElement`, so its target can never be the container - no behavior change there.
- **Minimal diff / no scope creep:** 1 logic line + comment in the hook; a focused test file. A separate latent defect on the adjacent line (`tabIndex !== undefined` should be `!== null`; harmless because no consumer relies on it) was deliberately left untouched - the container case is handled independently, before that line runs. Recorded in the quality-sweep backlog rather than folded in here.
- **Test quality:** Revert-tested (fails without the fix); asserts on the `onCharacterPress` callback (behavior, not internals); the guard test pins the interactive-tag detection path via an explicit `tabIndex={-1}`.

## Impact + confidence rationale

- **Impact:** user-visible (severity 2 x frequency 2 = score 4). Type-ahead is dead at the most natural moment to use it (initial focus), with a workaround (arrow once, then type) that users would not discover.
- **Confidence:** ~0.78 it is a real user-impacting bug. The code mechanism is certain (`getAttribute('tabindex')` returns the string `"0"` for the container, which is not `-1`); the discount reflects that impact is limited to the container-focused state.

## Provenance

Found by the AI quality-sweep run **qs-2026-06-22** (cold-scan seed: `lib/platform-bible-react`). The Jira seed was unavailable this run (Atlassian MCP permission was not granted), so this was scan-sourced; no linked Jira issue.

---

This pull request was created with the assistance of AI (Claude Opus 4.8). A human should review before merge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2449)
<!-- Reviewable:end -->
