### PR TITLE
Fix false-negative not.toHaveBeenCalledWith assertions on optional args

### DIFF
--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -665,6 +665,10 @@ describe('openDefaultActiveProjectIfApplicable', () => {
       'platformScriptureEditor.openScriptureEditor',
       expect.anything(),
     );
+    expect(mockSendCommand).not.toHaveBeenCalledWith(
+      'platformScriptureEditor.openScriptureEditor',
+      undefined,
+    );
     // Expected steady state on Platform.Bible — logged at debug, not warn.
     expect(mockDebug).toHaveBeenCalled();
     expect(mockWarn).not.toHaveBeenCalled();
@@ -2306,6 +2310,10 @@ describe('syncOnProjectSwitch', () => {
     expect(mockSendCommand).not.toHaveBeenCalledWith(
       'paratextBibleSendReceive.sendReceiveProjects',
       expect.anything(),
+    );
+    expect(mockSendCommand).not.toHaveBeenCalledWith(
+      'paratextBibleSendReceive.sendReceiveProjects',
+      undefined,
     );
   });
 

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -661,13 +661,8 @@ describe('openDefaultActiveProjectIfApplicable', () => {
 
     expect(outcome).toBe('no-send-receive');
     expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.getSharedProjects');
-    expect(mockSendCommand).not.toHaveBeenCalledWith(
+    expect(mockSendCommand.mock.calls.map(([cmd]) => cmd)).not.toContain(
       'platformScriptureEditor.openScriptureEditor',
-      expect.anything(),
-    );
-    expect(mockSendCommand).not.toHaveBeenCalledWith(
-      'platformScriptureEditor.openScriptureEditor',
-      undefined,
     );
     // Expected steady state on Platform.Bible — logged at debug, not warn.
     expect(mockDebug).toHaveBeenCalled();
@@ -2307,13 +2302,8 @@ describe('syncOnProjectSwitch', () => {
 
     await syncOnProjectSwitch(papi, 'proj-incoming', undefined);
 
-    expect(mockSendCommand).not.toHaveBeenCalledWith(
+    expect(mockSendCommand.mock.calls.map(([cmd]) => cmd)).not.toContain(
       'paratextBibleSendReceive.sendReceiveProjects',
-      expect.anything(),
-    );
-    expect(mockSendCommand).not.toHaveBeenCalledWith(
-      'paratextBibleSendReceive.sendReceiveProjects',
-      undefined,
     );
   });
 

--- a/src/main/shutdown-tasks.test.ts
+++ b/src/main/shutdown-tasks.test.ts
@@ -52,6 +52,10 @@ describe('performShutdownTasks', () => {
       expect.stringContaining('sendReceiveProjects'),
       expect.anything(),
     );
+    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
+      expect.stringContaining('sendReceiveProjects'),
+      undefined,
+    );
   });
 
   it('skips S/R when the only open Scripture Editor is read-only', async () => {
@@ -69,6 +73,10 @@ describe('performShutdownTasks', () => {
     expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
       expect.stringContaining('sendReceiveProjects'),
       expect.anything(),
+    );
+    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
+      expect.stringContaining('sendReceiveProjects'),
+      undefined,
     );
   });
 
@@ -97,6 +105,10 @@ describe('performShutdownTasks', () => {
     expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
       expect.stringContaining('sendReceiveProjects'),
       expect.anything(),
+    );
+    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
+      expect.stringContaining('sendReceiveProjects'),
+      undefined,
     );
   });
 

--- a/src/main/shutdown-tasks.test.ts
+++ b/src/main/shutdown-tasks.test.ts
@@ -48,13 +48,8 @@ describe('performShutdownTasks', () => {
     mockNetworkObjectGet.mockResolvedValue(makeWebViewService([]));
     await performShutdownTasks();
     expect(mockRequestNoRetry).toHaveBeenCalledWith(expect.stringContaining('cancelSync'));
-    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
+    expect(mockRequestNoRetry.mock.calls.map(([cmd]) => cmd)).not.toContainEqual(
       expect.stringContaining('sendReceiveProjects'),
-      expect.anything(),
-    );
-    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
-      expect.stringContaining('sendReceiveProjects'),
-      undefined,
     );
   });
 
@@ -70,13 +65,8 @@ describe('performShutdownTasks', () => {
       ]),
     );
     await performShutdownTasks();
-    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
+    expect(mockRequestNoRetry.mock.calls.map(([cmd]) => cmd)).not.toContainEqual(
       expect.stringContaining('sendReceiveProjects'),
-      expect.anything(),
-    );
-    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
-      expect.stringContaining('sendReceiveProjects'),
-      undefined,
     );
   });
 
@@ -102,13 +92,8 @@ describe('performShutdownTasks', () => {
     mockSettingsGet.mockResolvedValue('simple');
     mockNetworkObjectGet.mockRejectedValue(new Error('service unavailable'));
     await performShutdownTasks();
-    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
+    expect(mockRequestNoRetry.mock.calls.map(([cmd]) => cmd)).not.toContainEqual(
       expect.stringContaining('sendReceiveProjects'),
-      expect.anything(),
-    );
-    expect(mockRequestNoRetry).not.toHaveBeenCalledWith(
-      expect.stringContaining('sendReceiveProjects'),
-      undefined,
     );
   });
 


### PR DESCRIPTION
## Problem

`expect.anything()` does not match `undefined`, so `not.toHaveBeenCalledWith(cmd, expect.anything())` passes even when the command is called with `undefined` as the second argument — a false negative. This affected assertions on commands whose second parameter is optional (`sendReceiveProjects projectIds?: string[]`, `openScriptureEditor projectId?: string`).

## Changes

Replaced each affected assertion with `mock.calls.map(([cmd]) => cmd) / not.toContainEqual(...)`, which checks that no call had the target command as its first argument regardless of what other arguments were passed.

**Files changed:**
- `src/main/shutdown-tasks.test.ts` — 3 assertions on `sendReceiveProjects`
- `extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts` — 1 assertion on `openScriptureEditor`, 1 on `sendReceiveProjects`

## Devin review

https://app.devin.ai/review/paranext/paranext-core/pull/2455

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2455)
<!-- Reviewable:end -->
