### PR TITLE
docs: add decipherable-initialisms convention and wire into review

### DIFF
--- a/.claude/agents/pr-reviewer-clarity.md
+++ b/.claude/agents/pr-reviewer-clarity.md
@@ -31,7 +31,9 @@ Reviews a PR for readability, maintainability, and adherence to conventions. Thi
 
 #### Naming Conventions
 
-Verify the code follows the project's C#/TS naming conventions. **Naming violation = suggestion**
+- Verify the code follows the project's C#/TS naming conventions.
+- Flag indecipherable [initialisms and abbreviations](../../.context/standards/Code-Style-Guide.md#initialisms-and-abbreviations) in identifiers, types, comments, localization string names, and microcopy.
+- **Naming violation = suggestion**
 
 #### Over-Engineering
 - Unnecessary abstractions (interface + single implementation)
@@ -68,6 +70,7 @@ Return findings as a JSON array. Each finding must use `"perspective": "clarity"
 | Unresolved TODO/FIXME/placeholder implementation | `warning` |
 | Missing localization for user-facing string | `warning` |
 | Naming convention deviation | `suggestion` |
+| Indecipherable initialism/abbreviation | `suggestion` |
 | Over-engineering | `suggestion` |
 | Complex logic without comment | `suggestion` |
 

--- a/.claude/agents/pr-reviewer-ux.md
+++ b/.claude/agents/pr-reviewer-ux.md
@@ -39,6 +39,9 @@ Reviews a PR for accessibility gaps, performance anti-patterns, and UX consisten
 - Tailwind classes use `tw:` prefix → **missing = warning**
 - Responsive layout (no hardcoded pixel widths) → **concern = suggestion**
 
+#### Microcopy
+- User-facing text (labels, button text, messages, tooltips) avoids indecipherable [initialisms and abbreviations](../../.context/standards/Code-Style-Guide.md#initialisms-and-abbreviations) → **concern = suggestion**
+
 ## Output
 
 Return findings as a JSON array. Each finding must use `"perspective": "ux"`.
@@ -56,6 +59,7 @@ Return findings as a JSON array. Each finding must use `"perspective": "ux"`.
 | Semantic HTML improvement | `suggestion` |
 | Responsive layout concern | `suggestion` |
 | Component selection improvement | `suggestion` |
+| Indecipherable initialism in microcopy | `suggestion` |
 
 ## Quality Checks
 

--- a/.claude/agents/review-analyzer.md
+++ b/.claude/agents/review-analyzer.md
@@ -116,6 +116,7 @@ Check:
 - Overly complex code that could be simplified
 - Dead/unreachable code
 - Unclear variable or function naming
+- Indecipherable [initialisms and abbreviations](../../.context/standards/Code-Style-Guide.md#initialisms-and-abbreviations) in identifiers, types, comments, or localization keys
 
 ---
 
@@ -202,6 +203,8 @@ ls lib/platform-bible-react/src/stories/guides/
 Read all files found in those directories. They are MDX documentation and TSX story files that define Platform.Bible's design system — covering vocabulary, capitalization, interaction patterns, component choices, ellipsis usage, responsiveness, theming, directionality, and more.
 
 After reading the guide, read the changed UI files and check them against what you learned. Use your own judgment about which guidelines apply to the specific changes — not every guideline is relevant to every change. Prioritize clear, verifiable violations over speculative ones.
+
+Flag indecipherable [initialisms and abbreviations](../../.context/standards/Code-Style-Guide.md#initialisms-and-abbreviations) in user-facing microcopy: labels, button text, messages, and tooltips.
 
 Apply the same severity rubric as the other focus areas:
 

--- a/.context/standards/Code-Style-Guide.md
+++ b/.context/standards/Code-Style-Guide.md
@@ -47,7 +47,7 @@ High-level guidelines that should shape both writing and reviewing code. The top
 - **Clear variable names**:
   - Functions use verbs: `getClientId`, `checkStatus`.
   - Booleans use status words: `didFinish`, `isInitialized`, `hasPolicy`. `success` is acceptable.
-  - Avoid abbreviations that aren't widely accepted.
+  - Avoid [initialisms and abbreviations](#initialisms-and-abbreviations) that aren't explicitly established or widely accepted.
   - Capitalize acronyms per [.NET capitalization conventions](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions): two-letter together (`IOStream`), longer as words (`HttpRequest`).
 - **Use comments to explain why**, not what. Don't narrate obvious code; do explain non-obvious intent or purpose.
 - **Prefer `undefined` over `null`**: [JavaScript's two concepts of nothing](https://medium.com/@hbarcelos/why-i-banned-null-from-my-js-code-and-why-you-should-too-13df90323cfa) cause confusion. Use `undefined` throughout the codebase. Confine `null` to the boundary with external APIs that require or return it.
@@ -179,6 +179,22 @@ Unless stated otherwise, follow:
 
 ---
 
+## Initialisms and abbreviations
+
+Prefer spelling terms out. Only use an abbreviation or initialism a reader can decipher, and — when in doubt — define it on first use: a glossary entry, a TSDoc / `///` comment, or the full phrase the first time it appears.
+
+This applies to **code** (identifiers, types, comments) and to **UI microcopy** (labels, button text, messages, tooltips). Reviewers check it.
+
+**An initialism is likely _indecipherable_ — and must not be introduced — if it meets these signals:**
+
+- **Not findable by search** — a web search for it returns nothing relevant.
+- **No reference recognition** — it has no entry in Wikipedia, in this repo's glossary, or in the docs for a tool or library we build on (e.g. [USFM](https://docs.usfm.bible/), React, .NET).
+- **Not guessable** — a reasonably educated person working in Bible translation or software development would be unlikely to guess what it stands for.
+
+Domain-standard or glossary-defined initialisms (e.g. `USFM`, `RTL`, `PAPI`) are fine to use as-is. If an initialism is project-coined and undefined, either spell it out or define it on first use.
+
+---
+
 ## Code Patterns We Use
 
 - **Early Return (Guard Clauses)** — see [this explanation](https://gomakethings.com/the-early-return-pattern-in-javascript/#what-is-the-early-return-pattern). Always add a blank line after an early return to visually separate it.
@@ -226,6 +242,8 @@ Unless stated otherwise, follow:
   ```
 
   This applies to conditional logic, array filtering/finding, and string includes/matching.
+
+- **Avoid indecipherable [initialisms and abbreviations](#initialisms-and-abbreviations) in localization keys and user-facing text**.
 
 ---
 

--- a/.context/standards/Code-Style-Guide.md
+++ b/.context/standards/Code-Style-Guide.md
@@ -181,7 +181,7 @@ Unless stated otherwise, follow:
 
 ## Initialisms and abbreviations
 
-Prefer spelling terms out. Only use an abbreviation or initialism a reader can decipher, and — when in doubt — define it on first use: a glossary entry, a TSDoc / `///` comment, or the full phrase the first time it appears.
+Prefer spelling terms out. Only use an abbreviation or initialism a reader can decipher, and — when in doubt — define it on first use: a glossary entry, a TSDoc / `///` comment, a hyperlink to an explainer, or the full phrase the first time it appears.
 
 This applies to **code** (identifiers, types, comments) and to **UI microcopy** (labels, button text, messages, tooltips). Reviewers check it.
 
@@ -191,7 +191,7 @@ This applies to **code** (identifiers, types, comments) and to **UI microcopy** 
 - **No reference recognition** — it has no entry in Wikipedia, in this repo's glossary, or in the docs for a tool or library we build on (e.g. [USFM](https://docs.usfm.bible/), React, .NET).
 - **Not guessable** — a reasonably educated person working in Bible translation or software development would be unlikely to guess what it stands for.
 
-Domain-standard or glossary-defined initialisms (e.g. `USFM`, `RTL`, `PAPI`) are fine to use as-is. If an initialism is project-coined and undefined, either spell it out or define it on first use.
+Domain-standard or glossary-defined initialisms (e.g. `USFM`, `RTL`, `PAPI`) are fine to use as-is. If an initialism is project-coined and undefined, either spell it out or define it on first use. Prefer `Spelled Out Initialism (SOI)` to `SOI (Spelled Out Initialism)`.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,7 @@ npm run typecheck
 - Frame tasks as verifiable goals: "Fix the bug" → "Write a test that reproduces it, then make it pass."
 - When any code quality tool flags your code (ESLint, TypeScript, Prettier, Stylelint), fix the code first. Only suppress warnings if the fix would be significantly worse.
 - Don't add features, refactor code, or make "improvements" beyond what was asked.
+- Avoid indecipherable [initialisms and abbreviations](.context/standards/Code-Style-Guide.md#initialisms-and-abbreviations).
 
 ## Never Commit Secrets
 


### PR DESCRIPTION
## What

Adds a project convention for avoiding **indecipherable** initialisms and abbreviations, and wires it into the code-review agents.

- **`.context/standards/Code-Style-Guide.md`** — new `## Initialisms and abbreviations` section (the single source of truth). Defines the signals that mark an initialism as indecipherable — not findable by search, no reference recognition (Wikipedia / repo glossary / a dependency's docs), not guessable by an educated Bible-translation-or-software reader — plus how to resolve it (spell out, or define on first use) and a carve-out for domain-standard initialisms.
- **`CLAUDE.md`** — a short, always-loaded pointer to that section.
- **Review agents** — thin pointers so the convention is checked at review:
  - `pr-reviewer-clarity` — code identifiers, types, comments, localization key names, microcopy
  - `pr-reviewer-ux` — user-facing microcopy
  - `review-analyzer` — `style` focus (code) and `ux` focus (microcopy)

## Why

Indecipherable initialisms slip into code, localization keys, and UI microcopy and are hard to decode later. This makes the standard explicit and gives reviewers a concrete, testable definition. The full definition lives in one place; everything else links to it (single source of truth / DRY).

## Notes

- Docs/config only — no code or runtime behavior changes.
- AI-assisted with Claude Code (Opus 4.8).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2456)
<!-- Reviewable:end -->
