### PR TITLE
feat: add ProgressCapture (Progress.Mgr bridge for Send/Receive resilience)

### DIFF
--- a/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
+++ b/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
@@ -1,0 +1,59 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using Paranext.DataProvider.ParatextUtils;
+using PtxUtils.Progress;
+
+namespace TestParanextDataProvider.ParatextUtils
+{
+    /// <summary>
+    /// Pure unit tests for <see cref="ProgressCapture"/>: status forwarding,
+    /// cross-thread-safe cancellation flag, and scope cleanup. No ScrText,
+    /// no PAPI, no network. Mirrors the AlertCaptureTests style.
+    /// </summary>
+    [TestFixture]
+    internal class ProgressCaptureTests
+    {
+        [TearDown]
+        public void Teardown() => Progress.Mgr.Reset();
+
+        [Test]
+        public void SetProgressText_ForwardsParatextDataStatusToCallback()
+        {
+            var captured = new List<string>();
+            using var scope = ProgressCapture.StartCapture(captured.Add);
+
+            // Simulate ParatextData reporting status through Progress.Mgr.
+            using (var session = Progress.Mgr.StartIndefiniteTask())
+                session.Text = "Connection to server lost. Retrying...";
+
+            Assert.That(captured, Does.Contain("Connection to server lost. Retrying..."));
+        }
+
+        [Test]
+        public void Cancel_SetsCancelledFlagOnActiveProgress()
+        {
+            using var scope = ProgressCapture.StartCapture();
+            Assert.That(scope.Cancelled, Is.False);
+
+            scope.Cancel();
+
+            Assert.That(scope.Cancelled, Is.True);
+            Assert.That(Progress.Mgr.Cancelled, Is.True);
+        }
+
+        [Test]
+        public void Dispose_ClearsCancelledAndStopsForwarding()
+        {
+            var captured = new List<string>();
+            var scope = ProgressCapture.StartCapture(captured.Add);
+            scope.Cancel();
+            scope.Dispose();
+
+            Assert.That(Progress.Mgr.Cancelled, Is.False, "Reset() should clear stale cancel state");
+
+            using (var session = Progress.Mgr.StartIndefiniteTask())
+                session.Text = "after dispose";
+            Assert.That(captured, Does.Not.Contain("after dispose"), "display detached on dispose");
+        }
+    }
+}

--- a/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
+++ b/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using NUnit.Framework;
 using Paranext.DataProvider.ParatextUtils;
@@ -27,6 +28,23 @@ namespace TestParanextDataProvider.ParatextUtils
                 session.Text = "Connection to server lost. Retrying...";
 
             Assert.That(captured, Does.Contain("Connection to server lost. Retrying..."));
+        }
+
+        [Test]
+        public void SetProgressText_SwallowsCallbackException()
+        {
+            // A callback that throws must NOT escape into ParatextData's status-update path
+            // (it runs synchronously inside the retry loop), or it would turn an otherwise
+            // recoverable reconnect into a hard Send/Receive failure.
+            using var scope = ProgressCapture.StartCapture(_ =>
+                throw new InvalidOperationException("callback boom")
+            );
+
+            Assert.DoesNotThrow(() =>
+            {
+                using var session = Progress.Mgr.StartIndefiniteTask();
+                session.Text = "trigger";
+            });
         }
 
         [Test]

--- a/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
+++ b/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Threading;
 using NUnit.Framework;
 using Paranext.DataProvider.ParatextUtils;
 using PtxUtils.Progress;
@@ -60,18 +61,82 @@ namespace TestParanextDataProvider.ParatextUtils
         }
 
         [Test]
-        public void Dispose_ClearsCancelledAndStopsForwarding()
+        public void Dispose_ClearsCancelledStopsForwardingAndEmitsNoSpuriousText()
         {
             var captured = new List<string>();
             var scope = ProgressCapture.StartCapture(captured.Add);
             scope.Cancel();
+
+            int countBeforeDispose = captured.Count;
             scope.Dispose();
 
             Assert.That(Progress.Mgr.Cancelled, Is.False, "Reset() should clear stale cancel state");
+            // Dispose detaches the display before Reset()'s `Text = ""`, so it must NOT forward a
+            // spurious empty status to the callback. A bare Does.Not.Contain("after dispose") would
+            // pass even if captured were [""], so assert the count is exactly unchanged.
+            Assert.That(
+                captured,
+                Has.Count.EqualTo(countBeforeDispose),
+                "Dispose must not forward any status (including an empty string) to the callback"
+            );
 
             using (var session = Progress.Mgr.StartIndefiniteTask())
                 session.Text = "after dispose";
-            Assert.That(captured, Does.Not.Contain("after dispose"), "display detached on dispose");
+            Assert.That(
+                captured,
+                Has.Count.EqualTo(countBeforeDispose),
+                "display detached on dispose — no forwarding after dispose"
+            );
+            Assert.That(captured, Does.Not.Contain("after dispose"));
+        }
+
+        [Test]
+        public void Cancel_FromAnotherThread_SetsFlagOnCapturedInstanceNotTheCaller()
+        {
+            // The whole point of ProgressScope holding a direct Progress reference (instead of
+            // re-reading the [ThreadStatic] Progress.Mgr) is that Cancel() works from a thread
+            // other than the one running the captured operation. Single-threaded tests can't
+            // exercise that — there scope._progress and Progress.Mgr are the same instance.
+            ProgressCapture.ProgressScope? scope = null;
+            Progress workerProgress = null!;
+            using var started = new ManualResetEventSlim();
+            using var release = new ManualResetEventSlim();
+
+            var worker = new Thread(() =>
+            {
+                workerProgress = Progress.Mgr; // this thread's own [ThreadStatic] instance
+                scope = ProgressCapture.StartCapture();
+                started.Set();
+                release.Wait(); // keep the captured instance alive until the assertions run
+            })
+            {
+                IsBackground = true,
+            };
+            worker.Start();
+            started.Wait();
+
+            Assert.That(
+                Progress.Mgr,
+                Is.Not.SameAs(workerProgress),
+                "precondition: caller and worker must have distinct thread-static Progress instances"
+            );
+
+            scope!.Cancel(); // called from the test thread, not the worker thread
+
+            Assert.That(
+                workerProgress.Cancelled,
+                Is.True,
+                "cross-thread Cancel must set the flag on the captured (worker) instance"
+            );
+            Assert.That(
+                Progress.Mgr.Cancelled,
+                Is.False,
+                "Cancel must not touch the cancelling thread's own Progress.Mgr"
+            );
+
+            release.Set();
+            worker.Join();
+            workerProgress.Reset();
         }
     }
 }

--- a/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
+++ b/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
@@ -70,7 +70,11 @@ namespace TestParanextDataProvider.ParatextUtils
             int countBeforeDispose = captured.Count;
             scope.Dispose();
 
-            Assert.That(Progress.Mgr.Cancelled, Is.False, "Reset() should clear stale cancel state");
+            Assert.That(
+                Progress.Mgr.Cancelled,
+                Is.False,
+                "Reset() should clear stale cancel state"
+            );
             // Dispose detaches the display before Reset()'s `Text = ""`, so it must NOT forward a
             // spurious empty status to the callback. A bare Does.Not.Contain("after dispose") would
             // pass even if captured were [""], so assert the count is exactly unchanged.

--- a/c-sharp/ParatextUtils/AlertCapture.cs
+++ b/c-sharp/ParatextUtils/AlertCapture.cs
@@ -129,7 +129,9 @@ public sealed class AlertCapture : Alert
             RegexOptions.Compiled
         );
 
-    private static string RedactPathsForLog(string? value) =>
+    // internal (not private) so ProgressCapture's console fallback can reuse this exact redactor
+    // rather than duplicating the regex (Theme 4 defense-in-depth, kept to one source of truth).
+    internal static string RedactPathsForLog(string? value) =>
         string.IsNullOrEmpty(value) ? string.Empty : s_pathPattern.Replace(value, "<path>");
 
     /// <summary>

--- a/c-sharp/ParatextUtils/ProgressCapture.cs
+++ b/c-sharp/ParatextUtils/ProgressCapture.cs
@@ -45,7 +45,22 @@ public sealed class ProgressCapture : ProgressDisplay
         return new ProgressScope(progress);
     }
 
-    void ProgressDisplay.SetProgressText(string text) => _onText?.Invoke(text);
+    void ProgressDisplay.SetProgressText(string text)
+    {
+        // The caller-supplied callback runs synchronously inside ParatextData's status-update
+        // path (e.g. RetryIndefinitely's catch block, while holding Progress's lock). A callback
+        // that throws would unwind ParatextData's retry loop and turn an otherwise-recoverable
+        // reconnect into a hard failure, so isolate it: a dropped status update is harmless;
+        // tearing down the in-flight operation is not.
+        try
+        {
+            _onText?.Invoke(text);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"ProgressCapture onText callback threw (ignored): {e}");
+        }
+    }
 
     void ProgressDisplay.SetProgressValue(double val)
     {

--- a/c-sharp/ParatextUtils/ProgressCapture.cs
+++ b/c-sharp/ParatextUtils/ProgressCapture.cs
@@ -123,7 +123,18 @@ public sealed class ProgressCapture : ProgressDisplay
             {
                 if (_disposed)
                     return;
-                _progress.Cancel();
+                try
+                {
+                    _progress.Cancel();
+                }
+                catch (PlatformNotSupportedException)
+                {
+                    // See the remarks above: on a definite sub-task that set AllowAbort = true,
+                    // Progress.Cancel() can reach Thread.Abort(), which throws
+                    // PlatformNotSupportedException on .NET 8. Cancellation here is cooperative
+                    // (it sets Progress.Cancelled, which the retry loops poll), so swallow the
+                    // abort failure rather than faulting the cross-thread caller.
+                }
             }
         }
 

--- a/c-sharp/ParatextUtils/ProgressCapture.cs
+++ b/c-sharp/ParatextUtils/ProgressCapture.cs
@@ -1,0 +1,89 @@
+using System;
+using PtxUtils.Progress;
+
+namespace Paranext.DataProvider.ParatextUtils;
+
+/// <summary>
+/// Generic <see cref="ProgressDisplay"/> + cancellation bridge over
+/// ParatextData's thread-static <see cref="Progress.Mgr"/>. Mirrors
+/// <c>AlertCapture</c>: a caller opens a scope around long-running
+/// ParatextData work, receives live status text through the
+/// <c>onText</c> callback, and can cancel the in-flight operation by
+/// calling <see cref="ProgressScope.Cancel"/> (safe from another thread).
+///
+/// <para>ParatextData's <c>InternetSharedRepositorySource.RetryIndefinitely</c>,
+/// <c>Hg</c>, and <c>ExeRunner</c> consult <see cref="Progress.Cancelled"/>
+/// to break out of their retry/wait loops and push status via
+/// <see cref="Progress.Text"/>. P10 otherwise leaves <see cref="Progress.Mgr"/>
+/// at its no-op default, so retries are uninterruptible and status is dropped.
+/// Installing this display for the duration of an S/R operation restores
+/// both.</para>
+///
+/// <para>Because <see cref="Progress.Mgr"/> is <c>[ThreadStatic]</c>, the
+/// ParatextData work must run on the same thread that called
+/// <see cref="StartCapture"/> for status/cancel to reach it (true for the
+/// synchronous Send/Receive path). If ever violated, the display simply does
+/// not attach and behavior degrades to today's (no crash).</para>
+/// </summary>
+public sealed class ProgressCapture : ProgressDisplay
+{
+    private readonly Action<string>? _onText;
+
+    private ProgressCapture(Action<string>? onText) => _onText = onText;
+
+    /// <summary>
+    /// Installs a new <see cref="ProgressCapture"/> as the display on the
+    /// CURRENT thread's <see cref="Progress.Mgr"/> instance and returns a
+    /// scope the caller holds (and may share with another thread to cancel).
+    /// </summary>
+    public static ProgressScope StartCapture(Action<string>? onText = null)
+    {
+        var display = new ProgressCapture(onText);
+        Progress progress = Progress.Mgr;
+        progress.Reset(); // clear stale cancelled/display left on a pooled thread
+        progress.SetDisplay(display);
+        return new ProgressScope(progress);
+    }
+
+    void ProgressDisplay.SetProgressText(string text) => _onText?.Invoke(text);
+
+    void ProgressDisplay.SetProgressValue(double val)
+    {
+        // Indefinite Send/Receive has no determinate progress value; ignore.
+    }
+
+    /// <summary>
+    /// Handle to an installed capture. Holds a direct reference to the
+    /// <see cref="Progress"/> instance it installed on, so
+    /// <see cref="Cancel"/> can be invoked from a different thread (it only
+    /// sets a cooperative flag).
+    /// </summary>
+    public sealed class ProgressScope : IDisposable
+    {
+        private readonly Progress _progress;
+        private bool _disposed;
+
+        internal ProgressScope(Progress progress) => _progress = progress;
+
+        /// <summary>
+        /// Requests cancellation of the in-flight operation by setting
+        /// <see cref="Progress.Cancelled"/> on the captured instance. The
+        /// ParatextData retry loop throws <c>ProgressCancelledException</c>
+        /// within ~2s. Safe from any thread; never aborts the thread because
+        /// <c>AllowAbort</c> stays false for indefinite tasks.
+        /// </summary>
+        public void Cancel() => _progress.Cancel();
+
+        /// <summary>True once cancellation has been requested.</summary>
+        public bool Cancelled => _progress.Cancelled;
+
+        /// <summary>Detaches the display and clears progress state.</summary>
+        public void Dispose()
+        {
+            if (_disposed)
+                return;
+            _disposed = true;
+            _progress.Reset(); // clears display + cancelled + contexts
+        }
+    }
+}

--- a/c-sharp/ParatextUtils/ProgressCapture.cs
+++ b/c-sharp/ParatextUtils/ProgressCapture.cs
@@ -35,7 +35,22 @@ public sealed class ProgressCapture : ProgressDisplay
     /// Installs a new <see cref="ProgressCapture"/> as the display on the
     /// CURRENT thread's <see cref="Progress.Mgr"/> instance and returns a
     /// scope the caller holds (and may share with another thread to cancel).
+    ///
+    /// <para>Assumes a single active capture per thread. Unlike <c>AlertCapture</c>
+    /// (which saves its parent scope and restores it on dispose), <see cref="Progress"/>
+    /// exposes no getter for the currently-installed display, so this cannot save/restore
+    /// a prior one — disposing detaches the display and resets the thread's progress state
+    /// rather than restoring a previous display. Safe for the synchronous Send/Receive path
+    /// (the only caller), which installs no other display.</para>
     /// </summary>
+    /// <param name="onText">
+    /// Invoked synchronously on ParatextData's status thread while <see cref="Progress"/>'s
+    /// internal lock is held. Keep it fast, non-blocking, and allocation-light (e.g. stash the
+    /// latest string or enqueue lock-free): a blocking callback bounds cancellation latency and
+    /// can stall a concurrent <see cref="ProgressScope.Cancel"/>, which must take the same lock to
+    /// read <c>AllowAbort</c>. Exceptions it throws are caught and ignored so they cannot unwind
+    /// ParatextData's retry loop.
+    /// </param>
     public static ProgressScope StartCapture(Action<string>? onText = null)
     {
         var display = new ProgressCapture(onText);
@@ -58,7 +73,12 @@ public sealed class ProgressCapture : ProgressDisplay
         }
         catch (Exception e)
         {
-            Console.WriteLine($"ProgressCapture onText callback threw (ignored): {e}");
+            // Redact filesystem-path-shaped substrings before logging, mirroring AlertCapture's
+            // console fallback (Theme 4): a callback wrapping IO can surface raw paths in the
+            // exception text, and server logs may be aggregated / shipped off-host.
+            Console.WriteLine(
+                $"ProgressCapture onText callback threw (ignored): {AlertCapture.RedactPathsForLog(e.ToString())}"
+            );
         }
     }
 
@@ -76,6 +96,11 @@ public sealed class ProgressCapture : ProgressDisplay
     public sealed class ProgressScope : IDisposable
     {
         private readonly Progress _progress;
+
+        // Serializes Cancel() against Dispose() and makes the _disposed write visible across
+        // threads: this scope is explicitly designed for Cancel() to be called from a thread
+        // other than the one that owns Dispose(), so the flag needs a barrier, not a bare bool.
+        private readonly object _gate = new();
         private bool _disposed;
 
         internal ProgressScope(Progress progress) => _progress = progress;
@@ -84,10 +109,23 @@ public sealed class ProgressCapture : ProgressDisplay
         /// Requests cancellation of the in-flight operation by setting
         /// <see cref="Progress.Cancelled"/> on the captured instance. The
         /// ParatextData retry loop throws <c>ProgressCancelledException</c>
-        /// within ~2s. Safe from any thread; never aborts the thread because
-        /// <c>AllowAbort</c> stays false for indefinite tasks.
+        /// within ~2s. Safe to call from any thread; a no-op once disposed.
+        ///
+        /// <para>Does not abort the thread on the indefinite-task Send/Receive path, where
+        /// <c>AllowAbort</c> stays false. That is a property of the path, not a guarantee
+        /// <see cref="Progress"/> provides: a definite sub-task that set <c>AllowAbort = true</c>
+        /// would make <see cref="Progress.Cancel"/> reach <c>Thread.Abort()</c>, which throws
+        /// <c>PlatformNotSupportedException</c> on .NET 8.</para>
         /// </summary>
-        public void Cancel() => _progress.Cancel();
+        public void Cancel()
+        {
+            lock (_gate)
+            {
+                if (_disposed)
+                    return;
+                _progress.Cancel();
+            }
+        }
 
         /// <summary>True once cancellation has been requested.</summary>
         public bool Cancelled => _progress.Cancelled;
@@ -95,10 +133,18 @@ public sealed class ProgressCapture : ProgressDisplay
         /// <summary>Detaches the display and clears progress state.</summary>
         public void Dispose()
         {
-            if (_disposed)
-                return;
-            _disposed = true;
-            _progress.Reset(); // clears display + cancelled + contexts
+            lock (_gate)
+            {
+                if (_disposed)
+                    return;
+                _disposed = true;
+                // Detach BEFORE Reset(): Reset() sets Text = "" (forwarding to the still-attached
+                // display) before it nulls the display, so a consumer rendering the latest status
+                // would otherwise receive one spurious _onText("") on every clean teardown.
+                // Detaching first suppresses that final empty update.
+                _progress.SetDisplay(null);
+                _progress.Reset(); // clears cancelled + contexts left on this (possibly pooled) thread
+            }
         }
     }
 }


### PR DESCRIPTION
Adds `ProgressCapture`, a public utility that bridges ParatextData's thread-static
`Progress.Mgr`. It captures progress text (e.g. the "Reconnecting…" status surfaced
during S/R retries) and carries cancellation into long-running ParatextData
operations. Mirrors the existing `AlertCapture` pattern.

This is scaffolding — inert on its own. Paratext 10 Studio's private layer builds the
Send/Receive resilience UX (status display + cancel) on top of this seam.

Scope: 2 new files, additive (ProgressCapture.cs +89, ProgressCaptureTests.cs +59),
no change to existing behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
https://claude.ai/code/session_016AiNLvsU99EmtEzq5EudmU

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2457)
<!-- Reviewable:end -->
