### PR TITLE
fix(projects): avoid button-in-button nesting in ProjectList (PT-3924)

### DIFF
--- a/src/renderer/components/projects/project-list.component.test.tsx
+++ b/src/renderer/components/projects/project-list.component.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { ProjectList, fetchProjects } from './project-list.component';
+
+const PROJECTS = fetchProjects();
+
+// PT-3924 invariant: a row must never be a nested interactive control - no <button> may be a
+// descendant of another <button> (invalid DOM nesting). Asserted on every render path below.
+function findNestedButtons(container: HTMLElement) {
+  return Array.from(container.querySelectorAll('button')).filter((button) =>
+    button.querySelector('button'),
+  );
+}
+
+describe('ProjectList', () => {
+  describe('when isCheckable', () => {
+    function renderCheckable(selectedProjectIds: string[] = []) {
+      const handleSelectProject = vi.fn();
+      const { container } = render(
+        <ProjectList
+          projects={PROJECTS}
+          handleSelectProject={handleSelectProject}
+          selectedProjectIds={selectedProjectIds}
+          isMultiselect
+          isCheckable
+        />,
+      );
+      return { handleSelectProject, container };
+    }
+
+    // Regression for PT-3924: a Radix Checkbox renders as <button role="checkbox">, which was
+    // nested inside the row's shadcn <button>. <button> may not be a descendant of <button>
+    // (invalid DOM nesting -> React validateDOMNesting warning, broken click propagation, a11y).
+    it('does not nest a <button> inside another <button>', () => {
+      const { container } = renderCheckable(['project-1']);
+
+      expect(findNestedButtons(container)).toHaveLength(0);
+    });
+
+    it('still invokes handleSelectProject with the project id when a row is activated', () => {
+      const { handleSelectProject } = renderCheckable();
+
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Project 1' }));
+
+      expect(handleSelectProject).toHaveBeenCalledWith('project-1');
+    });
+
+    it('reflects the selected state accessibly via aria-checked on the row', () => {
+      renderCheckable(['project-1']);
+
+      expect(screen.getByRole('checkbox', { name: 'Project 1' })).toBeChecked();
+      expect(screen.getByRole('checkbox', { name: 'Project 2' })).not.toBeChecked();
+    });
+  });
+
+  it('renders each row as a plain button when not checkable, with no nested buttons', () => {
+    const handleSelectProject = vi.fn();
+    const { container } = render(
+      <ProjectList projects={PROJECTS} handleSelectProject={handleSelectProject} />,
+    );
+
+    expect(findNestedButtons(container)).toHaveLength(0);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Project 1' }));
+
+    expect(handleSelectProject).toHaveBeenCalledWith('project-1');
+  });
+});

--- a/src/renderer/components/projects/project-list.component.tsx
+++ b/src/renderer/components/projects/project-list.component.tsx
@@ -1,5 +1,6 @@
 import { ProjectMetadata } from '@shared/models/project-metadata.model';
-import { Button, Checkbox, Label } from 'platform-bible-react';
+import { Check } from 'lucide-react';
+import { Button, Label } from 'platform-bible-react';
 import { ProjectInterfaces } from 'papi-shared-types';
 import { PropsWithChildren, useCallback } from 'react';
 import './project-list.component.scss';
@@ -157,10 +158,30 @@ export function ProjectList({
   );
 
   const createListItemContents = (project: ProjectMetadataDisplay) => {
+    const selected = isSelected(project);
+    // When checkable, the row itself is the checkbox (role + aria-checked) so the selected state
+    // stays accessible. The visual indicator below is purely presentational (aria-hidden) - it must
+    // not be an interactive control, because a <button> (e.g. a Radix Checkbox) cannot be a
+    // descendant of this <button> (invalid DOM nesting). See PT-3924.
     return (
-      <Button variant="ghost" onClick={() => handleSelectProject(project.id)}>
+      <Button
+        variant="ghost"
+        onClick={() => handleSelectProject(project.id)}
+        role={isCheckable ? 'checkbox' : undefined}
+        aria-checked={isCheckable ? !!selected : undefined}
+      >
         {isCheckable && (
-          <Checkbox style={{ marginInlineEnd: '8px' }} checked={isSelected(project)} />
+          <span
+            aria-hidden
+            style={{ marginInlineEnd: '8px' }}
+            className={`pr-twp tw:flex tw:size-4 tw:shrink-0 tw:items-center tw:justify-center tw:rounded-[4px] tw:border ${
+              selected
+                ? 'tw:border-primary tw:bg-primary tw:text-primary-foreground'
+                : 'tw:border-input'
+            }`}
+          >
+            {selected && <Check className="tw:size-3.5" />}
+          </span>
         )}
         {children}
         <Label>{project.name}</Label>


### PR DESCRIPTION
## Summary

Fixes **[PT-3924](https://paratextstudio.atlassian.net/browse/PT-3924)** — invalid DOM nesting in `ProjectList`.

When `isCheckable`, each project row rendered a Radix `Checkbox` (which renders as `<button role="checkbox">`) **inside** the row's shadcn `Button` (`<button>`). A `<button>` cannot be a descendant of another `<button>`, so this produced:

- a React `validateDOMNesting` warning (`In HTML, <button> cannot be a descendant of <button>.`),
- potentially broken click propagation (the inner button can swallow the click), and
- an accessibility failure — screen readers cannot interpret nested interactive controls.

The inner checkbox was already display-only (no `onCheckedChange`); selection is driven entirely by the row's `onClick`.

## Fix

Minimal change in `src/renderer/components/projects/project-list.component.tsx`:

- Make the checkable row itself the checkbox: `role="checkbox"` + `aria-checked` on the row `Button`, so the selected state stays accessible (no a11y regression vs. the removed Radix Checkbox, which previously announced the checked state).
- Replace the nested interactive `Checkbox` with an `aria-hidden`, non-interactive `<span>` indicator that mirrors the Checkbox styling (no nested `<button>`).
- The non-checkable path (`select-project.dialog`) is unchanged.

## Reproduction evidence (regression test: RED → GREEN)

A regression test was written first and confirmed to **fail before** the fix and **pass after**.

**BEFORE (on the unfixed code):**

```
stderr | ProjectList > when isCheckable > does not nest a <button> inside another <button>
In HTML, <button> cannot be a descendant of <button>.
   × does not nest a <button> inside another <button>
   × still invokes handleSelectProject with the project id when a row is activated
       → Unable to find an accessible element with the role "checkbox" and name "Project 1"
   × reflects the selected state accessibly via aria-checked on the row
       → Unable to find an accessible element with the role "checkbox" and name "Project 1"
   ✓ renders each row as a plain button when not checkable
 Tests  3 failed | 1 passed (4)
```

**AFTER (with the fix):**

```
 ✓ src/renderer/components/projects/project-list.component.test.tsx (4 tests)
 Test Files  1 passed (1)
      Tests  4 passed (4)
```

The regression asserts the invariant on **both** render paths: no `<button>` is ever nested inside another `<button>`; the row still invokes `handleSelectProject`; and the selected state is conveyed via `aria-checked`.

`npm run typecheck` passes; `eslint` is clean on the changed files; the surrounding `projects` + `dialogs` renderer suites (28 tests) pass.

## Self-review summary

Reviewed across UX/accessibility, clarity, test quality, and scope:

- **A11y (UX review):** `role="checkbox"` + `aria-checked` on a native `<button>` is valid, well-supported ARIA, and is an improvement over the prior state (the old Radix checkbox was an *unnamed* nested control alongside the row button). `aria-hidden` on the visual indicator is correct — checked state lives on the row, so the glyph is pure decoration. No perf concern.
- **Scope:** Tightly scoped to the bug + its regression test. The `role`/`aria-checked` addition is justified (it prevents an a11y regression introduced by removing the Radix Checkbox), not scope creep. No opportunistic refactors.
- **Clarity:** The indicator duplicates a small subset of the shadcn Checkbox Tailwind classes; this is the necessary escape hatch (no standalone presentational check-indicator primitive exists in `platform-bible-react`, and a Radix Checkbox cannot legally nest here). Noted as a minor future-refactor opportunity, out of scope for this fix.
- **Tests:** Behavior-focused and falsifiable; the nested-`<button>` invariant is now guarded on every render path.

## Impact + confidence

- **Impact:** user-visible (broken click propagation on the checkbox area + screen-reader failure on the multi-select project dialog, reached via `platform.selectMultipleProjects`), plus a `validateDOMNesting` warning that surfaces in `test:e2e:isolated`. The issue's Definition of Done — "renders without any warnings or errors" — is met.
- **Confidence:** High. The defect was confirmed by an independent skeptic pass and a deterministic RED→GREEN regression test; the fix is minimal and the inner control was already display-only.

## Provenance

Found and fixed by the automated **quality-sweep** run (`qs-2026-06-25`), seeded from open Jira bugs.

---

🤖 AI-assisted — generated by the Platform.Bible quality-sweep (Claude). The human developer is the author and reviewer of record.


[PT-3924]: https://paratextstudio.atlassian.net/browse/PT-3924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2459)
<!-- Reviewable:end -->
