### PR TITLE
Patch renderer: mitigate Usersnap init failure

### DIFF
--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -85,16 +85,23 @@ async function runPromisesAndThrowIfRejected(...promises: Promise<unknown>[]) {
 (async () => {
   try {
     // The network service has to start first, and it uses the shared store after initialization
+    logger.debug('renderer startup: initializing network service');
     await networkService.initialize();
+    logger.debug('renderer startup: network service initialized');
     await initializeSharedStoreService(networkService);
+    logger.debug('renderer startup: shared store service initialized');
 
     // This needs to run before web views start running and after the network service is running
     blockWebSocketsToPapiNetwork();
+    logger.debug('renderer startup: WebSockets to PAPI network blocked');
 
     // This needs to run before the web view service host starts running and blocks us from creating
     // an iframe for the Usersnap feedback forms
+    logger.debug('renderer startup: initializing Usersnap API');
     await initializeUsersnapApi();
+    logger.debug('renderer startup: Usersnap API initialized');
 
+    logger.debug('renderer startup: starting core services');
     await runPromisesAndThrowIfRejected(
       webViewProviderService.initialize(),
       startWebViewService(),
@@ -105,6 +112,7 @@ async function runPromisesAndThrowIfRejected(...promises: Promise<unknown>[]) {
       initializeThemeService(),
       initializeWindowService(),
     );
+    logger.debug('renderer startup: all core services started');
 
     // Subscribe to updates to the current theme
     await localThemeService.subscribeCurrentTheme(undefined, (newTheme) => {

--- a/src/renderer/index.tsx
+++ b/src/renderer/index.tsx
@@ -85,23 +85,16 @@ async function runPromisesAndThrowIfRejected(...promises: Promise<unknown>[]) {
 (async () => {
   try {
     // The network service has to start first, and it uses the shared store after initialization
-    logger.debug('renderer startup: initializing network service');
     await networkService.initialize();
-    logger.debug('renderer startup: network service initialized');
     await initializeSharedStoreService(networkService);
-    logger.debug('renderer startup: shared store service initialized');
 
     // This needs to run before web views start running and after the network service is running
     blockWebSocketsToPapiNetwork();
-    logger.debug('renderer startup: WebSockets to PAPI network blocked');
 
     // This needs to run before the web view service host starts running and blocks us from creating
     // an iframe for the Usersnap feedback forms
-    logger.debug('renderer startup: initializing Usersnap API');
     await initializeUsersnapApi();
-    logger.debug('renderer startup: Usersnap API initialized');
 
-    logger.debug('renderer startup: starting core services');
     await runPromisesAndThrowIfRejected(
       webViewProviderService.initialize(),
       startWebViewService(),
@@ -112,7 +105,6 @@ async function runPromisesAndThrowIfRejected(...promises: Promise<unknown>[]) {
       initializeThemeService(),
       initializeWindowService(),
     );
-    logger.debug('renderer startup: all core services started');
 
     // Subscribe to updates to the current theme
     await localThemeService.subscribeCurrentTheme(undefined, (newTheme) => {

--- a/src/renderer/services/usersnap.service.test.ts
+++ b/src/renderer/services/usersnap.service.test.ts
@@ -104,16 +104,14 @@ describe('initializeUsersnapApi loadSpace timeout/race logic', () => {
     await vi.waitFor(() => expect(spaceApi.destroy).toHaveBeenCalledTimes(1));
   });
 
-  it('rejects before the timeout: no init, no destroy', async () => {
+  it('rejects before the timeout: initialization resolves without throwing', async () => {
     const { initializeUsersnapApi } = await importService();
-    const spaceApi = createMockSpaceApi();
 
     const initPromise = initializeUsersnapApi();
 
     loadSpaceDeferred.reject(new Error('network down'));
-    await initPromise;
 
-    expect(spaceApi.init).not.toHaveBeenCalled();
-    expect(spaceApi.destroy).not.toHaveBeenCalled();
+    // The rejection flows into the outer catch, so startup settles gracefully rather than throwing.
+    await expect(initPromise).resolves.toBeUndefined();
   });
 });

--- a/src/renderer/services/usersnap.service.test.ts
+++ b/src/renderer/services/usersnap.service.test.ts
@@ -61,7 +61,7 @@ function resetLoadSpaceDeferred(): void {
   });
 }
 
-describe('initializeUsersnapApi loadSpace timeout/race logic', () => {
+describe('initializeUsersnapApi load/init timeout/race logic', () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
@@ -85,19 +85,18 @@ describe('initializeUsersnapApi loadSpace timeout/race logic', () => {
     expect(spaceApi.destroy).not.toHaveBeenCalled();
   });
 
-  it('resolves after the timeout: init not called, late space destroyed', async () => {
-    const { initializeUsersnapApi, LOAD_SPACE_TIMEOUT_MS } = await importService();
+  it('resolves after the timeout: startup unblocked, late space destroyed', async () => {
+    const { initializeUsersnapApi, USERSNAP_INIT_TIMEOUT_MS } = await importService();
     const spaceApi = createMockSpaceApi();
 
     const initPromise = initializeUsersnapApi();
 
-    // Fire the timeout first; this rejects loadVar.promise so init is never reached.
-    await vi.advanceTimersByTimeAsync(LOAD_SPACE_TIMEOUT_MS);
-    await initPromise;
+    // Fire the timeout first; this rejects initVar.promise so startup settles via the outer catch
+    // rather than waiting on the load.
+    await vi.advanceTimersByTimeAsync(USERSNAP_INIT_TIMEOUT_MS);
+    await expect(initPromise).resolves.toBeUndefined();
 
-    expect(spaceApi.init).not.toHaveBeenCalled();
-
-    // loadSpace resolves late: the orphan is destroyed in the fire-and-forget IIFE, so wait for
+    // load + init completes late: the orphan is destroyed in the fire-and-forget IIFE, so wait for
     // that side effect. `vi.waitFor` polls on a timer, hence real timers.
     loadSpaceDeferred.resolve(spaceApi);
     vi.useRealTimers();
@@ -113,5 +112,52 @@ describe('initializeUsersnapApi loadSpace timeout/race logic', () => {
 
     // The rejection flows into the outer catch, so startup settles gracefully rather than throwing.
     await expect(initPromise).resolves.toBeUndefined();
+  });
+
+  it('rejects after the timeout: late rejection is swallowed, startup still resolves', async () => {
+    const { initializeUsersnapApi, USERSNAP_INIT_TIMEOUT_MS } = await importService();
+    const { logger } = await import('@shared/services/logger.service');
+
+    const initPromise = initializeUsersnapApi();
+
+    // Timeout fires first, so startup has already settled via the outer catch.
+    await vi.advanceTimersByTimeAsync(USERSNAP_INIT_TIMEOUT_MS);
+    await expect(initPromise).resolves.toBeUndefined();
+
+    // loadSpace rejects late: the IIFE catch logs it at debug rather than letting it surface as an
+    // unhandled rejection that could crash startup.
+    loadSpaceDeferred.reject(new Error('network down'));
+    vi.useRealTimers();
+    await vi.waitFor(() =>
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Usersnap load/init failed (or cleanup failed) after timeout:',
+        expect.any(Error),
+      ),
+    );
+  });
+
+  it('destroy rejecting after the timeout is swallowed, startup still resolves', async () => {
+    const { initializeUsersnapApi, USERSNAP_INIT_TIMEOUT_MS } = await importService();
+    const { logger } = await import('@shared/services/logger.service');
+    const spaceApi = createMockSpaceApi();
+    // Cleanup of the late orphan itself fails.
+    spaceApi.destroy = vi.fn().mockRejectedValue(new Error('destroy failed'));
+
+    const initPromise = initializeUsersnapApi();
+
+    await vi.advanceTimersByTimeAsync(USERSNAP_INIT_TIMEOUT_MS);
+    await expect(initPromise).resolves.toBeUndefined();
+
+    // load + init completes late; destroying the orphan throws, but the same IIFE catch keeps it
+    // from becoming an unhandled rejection.
+    loadSpaceDeferred.resolve(spaceApi);
+    vi.useRealTimers();
+    await vi.waitFor(() =>
+      expect(logger.debug).toHaveBeenCalledWith(
+        'Usersnap load/init failed (or cleanup failed) after timeout:',
+        expect.any(Error),
+      ),
+    );
+    expect(spaceApi.destroy).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/renderer/services/usersnap.service.test.ts
+++ b/src/renderer/services/usersnap.service.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * A deferred promise whose resolution/rejection is controlled externally, so each test can decide
+ * exactly when `loadSpace` settles relative to the AsyncVariable timeout.
+ */
+type Deferred = {
+  promise: Promise<unknown>;
+  resolve: (value: unknown) => void;
+  reject: (reason?: unknown) => void;
+};
+
+// `loadSpace` mock; reassigned per test to a fresh deferred.
+let loadSpaceDeferred: Deferred;
+const mockLoadSpace = vi.fn(() => loadSpaceDeferred.promise);
+
+vi.mock('@shared/services/app.service', () => ({
+  appService: { getAppInfo: vi.fn().mockResolvedValue({ name: 'test' }) },
+}));
+
+vi.mock('@shared/services/command.service', () => ({
+  sendCommand: vi.fn(),
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+vi.mock('@shared/services/notification.service', () => ({
+  notificationService: { send: vi.fn() },
+}));
+
+vi.mock('@usersnap/browser', () => ({
+  loadSpace: () => mockLoadSpace(),
+}));
+
+/** Builds a mock SpaceApi with spy-able methods. */
+function createMockSpaceApi() {
+  return {
+    destroy: vi.fn().mockResolvedValue(undefined),
+    hide: vi.fn(),
+    init: vi.fn().mockResolvedValue(undefined),
+    logEvent: vi.fn(),
+    on: vi.fn(),
+    show: vi.fn(),
+  };
+}
+
+async function importService() {
+  vi.resetModules();
+  return import('@renderer/services/usersnap.service');
+}
+
+function resetLoadSpaceDeferred(): void {
+  // Starts empty; the Promise executor below fills in resolve/reject synchronously.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  loadSpaceDeferred = {} as Deferred;
+  loadSpaceDeferred.promise = new Promise<unknown>((resolve, reject) => {
+    loadSpaceDeferred.resolve = resolve;
+    loadSpaceDeferred.reject = reject;
+  });
+}
+
+describe('initializeUsersnapApi loadSpace timeout/race logic', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    resetLoadSpaceDeferred();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('resolves before the timeout: api.init called, no destroy', async () => {
+    const { initializeUsersnapApi } = await importService();
+    const spaceApi = createMockSpaceApi();
+
+    const initPromise = initializeUsersnapApi();
+
+    loadSpaceDeferred.resolve(spaceApi);
+    await initPromise;
+
+    expect(spaceApi.init).toHaveBeenCalledTimes(1);
+    expect(spaceApi.destroy).not.toHaveBeenCalled();
+  });
+
+  it('resolves after the timeout: init not called, late space destroyed', async () => {
+    const { initializeUsersnapApi, LOAD_SPACE_TIMEOUT_MS } = await importService();
+    const spaceApi = createMockSpaceApi();
+
+    const initPromise = initializeUsersnapApi();
+
+    // Fire the timeout first; this rejects loadVar.promise so init is never reached.
+    await vi.advanceTimersByTimeAsync(LOAD_SPACE_TIMEOUT_MS);
+    await initPromise;
+
+    expect(spaceApi.init).not.toHaveBeenCalled();
+
+    // loadSpace resolves late: the orphan is destroyed in the fire-and-forget IIFE, so wait for
+    // that side effect. `vi.waitFor` polls on a timer, hence real timers.
+    loadSpaceDeferred.resolve(spaceApi);
+    vi.useRealTimers();
+    await vi.waitFor(() => expect(spaceApi.destroy).toHaveBeenCalledTimes(1));
+  });
+
+  it('rejects before the timeout: no init, no destroy', async () => {
+    const { initializeUsersnapApi } = await importService();
+    const spaceApi = createMockSpaceApi();
+
+    const initPromise = initializeUsersnapApi();
+
+    loadSpaceDeferred.reject(new Error('network down'));
+    await initPromise;
+
+    expect(spaceApi.init).not.toHaveBeenCalled();
+    expect(spaceApi.destroy).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/services/usersnap.service.ts
+++ b/src/renderer/services/usersnap.service.ts
@@ -18,7 +18,7 @@ export const USERSNAP_PROJECT_SUBMIT_IDEA_API_KEY: string = 'bd3bc542-1f0c-40e4-
 export const USERSNAP_SPACE_API_KEY: string = '1cf2709b-3ff0-4cff-8952-a2d2bca7590d';
 
 /** Milliseconds to wait for `loadSpace` to resolve before giving up. */
-const LOAD_SPACE_TIMEOUT_MS = 5 * 1000;
+export const LOAD_SPACE_TIMEOUT_MS = 5 * 1000;
 
 /** Global UserSnap API instance service */
 
@@ -171,6 +171,7 @@ export async function initializeUsersnapApi() {
     const startTime = performance.now();
     // Set a timeout, since `loadSpace` reaches an external server that can hang indefinitely.
     const loadVar = new AsyncVariable<SpaceApi>('usersnapLoadSpace', LOAD_SPACE_TIMEOUT_MS);
+    // Fire-and-forget: startup awaits `loadVar.promise`, so the timeout can win even if this hangs.
     (async () => {
       try {
         const spaceApi = await loadSpace(USERSNAP_SPACE_API_KEY);
@@ -179,7 +180,7 @@ export async function initializeUsersnapApi() {
         else loadVar.resolveToValue(spaceApi);
       } catch (error) {
         if (loadVar.hasSettled)
-          logger.debug('Usersnap loadSpace settled or failed cleanup after timeout:', error);
+          logger.debug('Usersnap loadSpace rejected (or cleanup failed) after timeout:', error);
         else loadVar.rejectWithReason(getErrorMessage(error));
       }
     })();

--- a/src/renderer/services/usersnap.service.ts
+++ b/src/renderer/services/usersnap.service.ts
@@ -154,6 +154,38 @@ function stopUsersnapObserver(): void {
   }
 }
 
+/**
+ * Loads a Usersnap space, rejecting if it takes longer than `timeoutMs`. Usersnap reaches an
+ * external server, which can hang indefinitely in offline or firewalled environments; the timeout
+ * keeps a hung load from blocking any renderer startup await that depends on it.
+ *
+ * Since a promise can't be cancelled, a `loadSpace` that resolves after the timeout has its space
+ * destroyed so the loaded SDK isn't left orphaned.
+ *
+ * @param apiKey Usersnap Space API key to load.
+ * @param timeoutMs Milliseconds to wait for `loadSpace` before rejecting.
+ * @returns The loaded `SpaceApi`.
+ * @throws If `loadSpace` rejects, or if it doesn't resolve within `timeoutMs`.
+ */
+function loadSpaceWithTimeout(apiKey: string, timeoutMs: number): Promise<SpaceApi> {
+  const loadPromise = loadSpace(apiKey);
+  return new Promise<SpaceApi>((resolve, reject) => {
+    const timeoutId = setTimeout(() => {
+      loadPromise.then((late) => late.destroy()).catch(() => {});
+      reject(new Error(`Usersnap loadSpace timed out after ${timeoutMs} ms`));
+    }, timeoutMs);
+    loadPromise
+      .then((result) => {
+        clearTimeout(timeoutId);
+        return resolve(result);
+      })
+      .catch((error: unknown) => {
+        clearTimeout(timeoutId);
+        reject(error);
+      });
+  });
+}
+
 /** Initializes the global UserSnap API instance */
 export async function initializeUsersnapApi() {
   try {
@@ -165,21 +197,7 @@ export async function initializeUsersnapApi() {
     };
 
     const startTime = performance.now();
-    const api = await new Promise<Awaited<ReturnType<typeof loadSpace>>>((resolve, reject) => {
-      const id = setTimeout(
-        () => reject(new Error('Usersnap loadSpace timed out after 5 s')),
-        5000,
-      );
-      loadSpace(USERSNAP_SPACE_API_KEY)
-        .then((result) => {
-          clearTimeout(id);
-          return resolve(result);
-        })
-        .catch((error: unknown) => {
-          clearTimeout(id);
-          reject(error);
-        });
-    });
+    const api = await loadSpaceWithTimeout(USERSNAP_SPACE_API_KEY, 5000);
     await api.init(defaultInitParams);
     const endTime = performance.now();
     logger.info(`UserSnap initialized successfully in ${endTime - startTime}ms`);

--- a/src/renderer/services/usersnap.service.ts
+++ b/src/renderer/services/usersnap.service.ts
@@ -240,12 +240,7 @@ export async function initializeUsersnapApi() {
 
     initializeUsersnapDomObserver();
   } catch (error) {
-    logger.error('Failed to initialize UserSnap API:', error);
-    logger.warn(
-      'UserSnap functionality will be unavailable. This may be due to network connectivity issues, invalid API keys, or blocked external requests.',
-    );
-
-    // Set globalUsersnapApi to undefined to indicate initialization failed
+    logger.warn('Failed to initialize UserSnap API; feedback forms will be unavailable:', error);
     globalUsersnapApi = undefined;
   }
 }

--- a/src/renderer/services/usersnap.service.ts
+++ b/src/renderer/services/usersnap.service.ts
@@ -17,6 +17,9 @@ export const USERSNAP_PROJECT_REPORT_ISSUE_API_KEY: string = '68df6b26-c519-4829
 export const USERSNAP_PROJECT_SUBMIT_IDEA_API_KEY: string = 'bd3bc542-1f0c-40e4-85f7-315f5138ea88';
 export const USERSNAP_SPACE_API_KEY: string = '1cf2709b-3ff0-4cff-8952-a2d2bca7590d';
 
+/** Milliseconds to wait for `loadSpace` to resolve before giving up. */
+const LOAD_SPACE_TIMEOUT_MS = 5 * 1000;
+
 /** Global UserSnap API instance service */
 
 let globalUsersnapApi: SpaceApi | undefined;
@@ -166,19 +169,20 @@ export async function initializeUsersnapApi() {
     };
 
     const startTime = performance.now();
-    // `loadSpace` reaches an external server that can hang indefinitely in offline or firewalled
-    // environments; bound it so a hung load can't block renderer startup.
-    const loadVar = new AsyncVariable<SpaceApi>('usersnapLoadSpace', 5000);
-    loadSpace(USERSNAP_SPACE_API_KEY)
-      .then((space) => {
-        // Since a pending promise can't be cancelled, a space that loads after the timeout fires is
-        // destroyed so the loaded SDK isn't left orphaned.
-        if (loadVar.hasSettled) return space.destroy();
-        return loadVar.resolveToValue(space);
-      })
-      .catch((error: unknown) => {
-        if (!loadVar.hasSettled) loadVar.rejectWithReason(getErrorMessage(error));
-      });
+    // Set a timeout, since `loadSpace` reaches an external server that can hang indefinitely.
+    const loadVar = new AsyncVariable<SpaceApi>('usersnapLoadSpace', LOAD_SPACE_TIMEOUT_MS);
+    (async () => {
+      try {
+        const spaceApi = await loadSpace(USERSNAP_SPACE_API_KEY);
+        // If a space loads after the timeout fires, destroy it to avoid an orphaned instance.
+        if (loadVar.hasSettled) await spaceApi.destroy();
+        else loadVar.resolveToValue(spaceApi);
+      } catch (error) {
+        if (loadVar.hasSettled)
+          logger.debug('Usersnap loadSpace settled or failed cleanup after timeout:', error);
+        else loadVar.rejectWithReason(getErrorMessage(error));
+      }
+    })();
     const api = await loadVar.promise;
     await api.init(defaultInitParams);
     const endTime = performance.now();

--- a/src/renderer/services/usersnap.service.ts
+++ b/src/renderer/services/usersnap.service.ts
@@ -165,7 +165,21 @@ export async function initializeUsersnapApi() {
     };
 
     const startTime = performance.now();
-    const api = await loadSpace(USERSNAP_SPACE_API_KEY);
+    const api = await new Promise<Awaited<ReturnType<typeof loadSpace>>>((resolve, reject) => {
+      const id = setTimeout(
+        () => reject(new Error('Usersnap loadSpace timed out after 5 s')),
+        5000,
+      );
+      loadSpace(USERSNAP_SPACE_API_KEY)
+        .then((result) => {
+          clearTimeout(id);
+          return resolve(result);
+        })
+        .catch((error: unknown) => {
+          clearTimeout(id);
+          reject(error);
+        });
+    });
     await api.init(defaultInitParams);
     const endTime = performance.now();
     logger.info(`UserSnap initialized successfully in ${endTime - startTime}ms`);

--- a/src/renderer/services/usersnap.service.ts
+++ b/src/renderer/services/usersnap.service.ts
@@ -3,6 +3,7 @@ import { sendCommand } from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
 import { notificationService } from '@shared/services/notification.service';
 import { loadSpace, type InitOptions, type SpaceApi } from '@usersnap/browser';
+import { AsyncVariable, getErrorMessage } from 'platform-bible-utils';
 
 /**
  * These API keys are unique IDs that can be used to interact with our feedback forms on Usersnap. A
@@ -154,38 +155,6 @@ function stopUsersnapObserver(): void {
   }
 }
 
-/**
- * Loads a Usersnap space, rejecting if it takes longer than `timeoutMs`. Usersnap reaches an
- * external server, which can hang indefinitely in offline or firewalled environments; the timeout
- * keeps a hung load from blocking any renderer startup await that depends on it.
- *
- * Since a promise can't be cancelled, a `loadSpace` that resolves after the timeout has its space
- * destroyed so the loaded SDK isn't left orphaned.
- *
- * @param apiKey Usersnap Space API key to load.
- * @param timeoutMs Milliseconds to wait for `loadSpace` before rejecting.
- * @returns The loaded `SpaceApi`.
- * @throws If `loadSpace` rejects, or if it doesn't resolve within `timeoutMs`.
- */
-function loadSpaceWithTimeout(apiKey: string, timeoutMs: number): Promise<SpaceApi> {
-  const loadPromise = loadSpace(apiKey);
-  return new Promise<SpaceApi>((resolve, reject) => {
-    const timeoutId = setTimeout(() => {
-      loadPromise.then((late) => late.destroy()).catch(() => {});
-      reject(new Error(`Usersnap loadSpace timed out after ${timeoutMs} ms`));
-    }, timeoutMs);
-    loadPromise
-      .then((result) => {
-        clearTimeout(timeoutId);
-        return resolve(result);
-      })
-      .catch((error: unknown) => {
-        clearTimeout(timeoutId);
-        reject(error);
-      });
-  });
-}
-
 /** Initializes the global UserSnap API instance */
 export async function initializeUsersnapApi() {
   try {
@@ -197,7 +166,20 @@ export async function initializeUsersnapApi() {
     };
 
     const startTime = performance.now();
-    const api = await loadSpaceWithTimeout(USERSNAP_SPACE_API_KEY, 5000);
+    // `loadSpace` reaches an external server that can hang indefinitely in offline or firewalled
+    // environments; bound it so a hung load can't block renderer startup.
+    const loadVar = new AsyncVariable<SpaceApi>('usersnapLoadSpace', 5000);
+    loadSpace(USERSNAP_SPACE_API_KEY)
+      .then((space) => {
+        // Since a pending promise can't be cancelled, a space that loads after the timeout fires is
+        // destroyed so the loaded SDK isn't left orphaned.
+        if (loadVar.hasSettled) return space.destroy();
+        return loadVar.resolveToValue(space);
+      })
+      .catch((error: unknown) => {
+        if (!loadVar.hasSettled) loadVar.rejectWithReason(getErrorMessage(error));
+      });
+    const api = await loadVar.promise;
     await api.init(defaultInitParams);
     const endTime = performance.now();
     logger.info(`UserSnap initialized successfully in ${endTime - startTime}ms`);

--- a/src/renderer/services/usersnap.service.ts
+++ b/src/renderer/services/usersnap.service.ts
@@ -17,8 +17,12 @@ export const USERSNAP_PROJECT_REPORT_ISSUE_API_KEY: string = '68df6b26-c519-4829
 export const USERSNAP_PROJECT_SUBMIT_IDEA_API_KEY: string = 'bd3bc542-1f0c-40e4-85f7-315f5138ea88';
 export const USERSNAP_SPACE_API_KEY: string = '1cf2709b-3ff0-4cff-8952-a2d2bca7590d';
 
-/** Milliseconds to wait for `loadSpace` to resolve before giving up. */
-export const LOAD_SPACE_TIMEOUT_MS = 5 * 1000;
+/**
+ * Milliseconds to wait for Usersnap's `loadSpace` + `init` to finish before giving up.
+ *
+ * Exported so the test can advance fake timers by exactly this amount.
+ */
+export const USERSNAP_INIT_TIMEOUT_MS = 5 * 1000;
 
 /** Global UserSnap API instance service */
 
@@ -169,23 +173,28 @@ export async function initializeUsersnapApi() {
     };
 
     const startTime = performance.now();
-    // Set a timeout, since `loadSpace` reaches an external server that can hang indefinitely.
-    const loadVar = new AsyncVariable<SpaceApi>('usersnapLoadSpace', LOAD_SPACE_TIMEOUT_MS);
-    // Fire-and-forget: startup awaits `loadVar.promise`, so the timeout can win even if this hangs.
+    // Bound the whole load + init: both reach an external server that can hang indefinitely, and
+    // both run on the awaited renderer startup path.
+    const initVar = new AsyncVariable<SpaceApi>('usersnapInit', USERSNAP_INIT_TIMEOUT_MS);
+    // Fire-and-forget: startup awaits `initVar.promise`, so the timeout can win even if this hangs.
     (async () => {
       try {
         const spaceApi = await loadSpace(USERSNAP_SPACE_API_KEY);
-        // If a space loads after the timeout fires, destroy it to avoid an orphaned instance.
-        if (loadVar.hasSettled) await spaceApi.destroy();
-        else loadVar.resolveToValue(spaceApi);
+        await spaceApi.init(defaultInitParams);
+        // If load + init finish after the timeout fired, destroy the space to avoid an orphan.
+        if (initVar.hasTimedOut) await spaceApi.destroy();
+        else initVar.resolveToValue(spaceApi);
       } catch (error) {
-        if (loadVar.hasSettled)
-          logger.debug('Usersnap loadSpace rejected (or cleanup failed) after timeout:', error);
-        else loadVar.rejectWithReason(getErrorMessage(error));
+        if (initVar.hasTimedOut)
+          logger.debug('Usersnap load/init failed (or cleanup failed) after timeout:', error);
+        else {
+          // `rejectWithReason` only takes a string, so log the real error here to keep its stack.
+          logger.warn('Usersnap load/init failed:', error);
+          initVar.rejectWithReason(getErrorMessage(error));
+        }
       }
     })();
-    const api = await loadVar.promise;
-    await api.init(defaultInitParams);
+    const api = await initVar.promise;
     const endTime = performance.now();
     logger.info(`UserSnap initialized successfully in ${endTime - startTime}ms`);
 
@@ -252,9 +261,7 @@ export async function initializeUsersnapApi() {
 
 export async function openUsersnapForm(apiKey: string) {
   if (!globalUsersnapApi) {
-    logger.warn(
-      'Cannot open Usersnap form: UserSnap API is not initialized. This may be due to network connectivity issues or blocked external requests.',
-    );
+    logger.warn('Cannot open Usersnap form: UserSnap API is not initialized.');
     await notificationService.send({
       message: '%mainMenu_feedback_unavailable%',
       severity: 'warning',


### PR DESCRIPTION
## Summary

Hardens renderer startup against a non-critical Usersnap initialization failure. Usersnap is an optional feedback widget loaded from an external service; in offline or firewalled environments its load can hang or fail, and that shouldn't surface as an error or stall startup.

Changes in `src/renderer/services/usersnap.service.ts` (+ a new test file):

- **Bound `loadSpace` + `init` with a 5 s timeout.** Both are awaited on the startup path and both talk to Usersnap infrastructure, so a hang in either (blocked egress, dead connection) would otherwise stall the renderer. Load and init now run inside an `AsyncVariable` (the project's promise-with-timeout utility) that rejects after 5 s, letting the existing `catch` handle the failure. Since a promise can't be cancelled, a load/init that finishes *after* the timeout has its space destroyed so the SDK isn't left orphaned.
- **Downgrade the failure log from `error` to `warn`.** Usersnap being unavailable is expected and recoverable, not an app error, so logging it at `error` just adds noise. `globalUsersnapApi` is still cleared to `undefined` as before.
- **Tests.** Added `usersnap.service.test.ts` covering the timeout/race branches against the real `AsyncVariable` with fake timers: resolve before timeout, resolve after timeout → orphan destroyed, reject before timeout, reject after timeout → late failure swallowed, and destroy-failure after timeout → swallowed.

## Behavior

Startup no longer risks hanging on Usersnap, and a blocked load logs a single warning instead of an error. No functional change — feedback forms degrade gracefully as they did before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Devin review: https://app.devin.ai/review/paranext/paranext-core/pull/2460

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2460)
<!-- Reviewable:end -->
