### PR TITLE
fix(platform-scripture): Select-All excludes not-in-reference books

### DIFF
--- a/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.component.tsx
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.component.tsx
@@ -77,8 +77,10 @@ import {
 import {
   computeCompareState,
   computeImportCompareState,
+  computeSelectableVisibleBooks,
   deleteConfirmVariant,
   fmtTemplate,
+  isBookNotInCreateReference,
   versificationFallbackName,
   versificationLabelKey,
 } from './manage-books-dialog.utils';
@@ -1152,11 +1154,30 @@ export function ManageBooksDialog({
       return next;
     });
 
-  const selectableVisibleBooks = useMemo<string[]>(() => {
-    if (action === 'view') return [];
-    if (action === 'import') return visibleBooks.filter((b) => !!importFiles[b]);
-    return visibleBooks;
-  }, [action, visibleBooks, importFiles]);
+  // "Selectable" excludes books the grid disables (Create > Based on template books not present in
+  // the reference project). Deriving Select-All / counts from this set keeps Select-All from
+  // selecting non-creatable books — the bug where it inflated the count and tripped the
+  // missing-model preflight. Shares `isBookNotInCreateReference` with `gridItems` so the grid's
+  // disabled pills and the selection logic can never disagree.
+  const selectableVisibleBooks = useMemo<string[]>(
+    () =>
+      computeSelectableVisibleBooks({
+        action,
+        visibleBooks,
+        hasImportFile: (b) => !!importFiles[b],
+        createMethod,
+        hasReferenceProject: !!createReferenceProject,
+        referencePresentBooks: createReferenceBookState?.present,
+      }),
+    [
+      action,
+      visibleBooks,
+      importFiles,
+      createMethod,
+      createReferenceProject,
+      createReferenceBookState,
+    ],
+  );
   const visibleSelectedCount = selectableVisibleBooks.filter((b) => selected.has(b)).length;
 
   const headerSelectState: boolean | 'indeterminate' = (() => {
@@ -1701,11 +1722,15 @@ export function ManageBooksDialog({
       let disabled: boolean | undefined;
       let disabledReason: string | undefined;
       if (
-        action === 'create' &&
-        createMethod === 'fromTemplate' &&
-        createReferenceBookState &&
+        // `createReferenceProject &&` is kept so TS narrows it for `.shortName` below; the
+        // not-in-reference determination itself lives in the shared predicate.
         createReferenceProject &&
-        !createReferenceBookState.present.has(book)
+        isBookNotInCreateReference(book, {
+          action,
+          createMethod,
+          hasReferenceProject: true,
+          referencePresentBooks: createReferenceBookState?.present,
+        })
       ) {
         disabled = true;
         disabledReason = fmtTemplate(

--- a/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.utils.test.ts
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.utils.test.ts
@@ -2,8 +2,10 @@ import { describe, it, expect } from 'vitest';
 import {
   computeCompareState,
   computeImportCompareState,
+  computeSelectableVisibleBooks,
   deleteConfirmVariant,
   fmtTemplate,
+  isBookNotInCreateReference,
 } from './manage-books-dialog.utils';
 
 describe('fmtTemplate', () => {
@@ -124,5 +126,177 @@ describe('deleteConfirmVariant', () => {
     // project was about to be deleted — the highest-impact case.
     expect(deleteConfirmVariant(true, true)).not.toBe('all');
     expect(deleteConfirmVariant(true, true)).toBe('allShared');
+  });
+});
+
+describe('isBookNotInCreateReference', () => {
+  const reference = new Set(['GEN', 'EXO']);
+
+  it('is true for a Create-from-template book absent from the reference project', () => {
+    expect(
+      isBookNotInCreateReference('LEV', {
+        action: 'create',
+        createMethod: 'fromTemplate',
+        hasReferenceProject: true,
+        referencePresentBooks: reference,
+      }),
+    ).toBe(true);
+  });
+
+  it('is false for a Create-from-template book present in the reference project', () => {
+    expect(
+      isBookNotInCreateReference('GEN', {
+        action: 'create',
+        createMethod: 'fromTemplate',
+        hasReferenceProject: true,
+        referencePresentBooks: reference,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false for create methods other than fromTemplate', () => {
+    expect(
+      isBookNotInCreateReference('LEV', {
+        action: 'create',
+        createMethod: 'empty',
+        hasReferenceProject: true,
+        referencePresentBooks: reference,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false for actions other than create', () => {
+    expect(
+      isBookNotInCreateReference('LEV', {
+        action: 'delete',
+        createMethod: 'fromTemplate',
+        hasReferenceProject: true,
+        referencePresentBooks: reference,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false while no reference project is selected', () => {
+    expect(
+      isBookNotInCreateReference('LEV', {
+        action: 'create',
+        createMethod: 'fromTemplate',
+        hasReferenceProject: false,
+        referencePresentBooks: undefined,
+      }),
+    ).toBe(false);
+  });
+
+  it('is false while the reference book set is still loading (undefined)', () => {
+    // Nothing is disabled until we actually know the reference's book set.
+    expect(
+      isBookNotInCreateReference('LEV', {
+        action: 'create',
+        createMethod: 'fromTemplate',
+        hasReferenceProject: true,
+        referencePresentBooks: undefined,
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('computeSelectableVisibleBooks', () => {
+  const neverImport = () => false;
+
+  it('selects nothing in view mode', () => {
+    expect(
+      computeSelectableVisibleBooks({
+        action: 'view',
+        visibleBooks: ['GEN', 'EXO'],
+        hasImportFile: neverImport,
+        createMethod: 'empty',
+        hasReferenceProject: false,
+        referencePresentBooks: undefined,
+      }),
+    ).toEqual([]);
+  });
+
+  it('limits import mode to books that have an attached file', () => {
+    expect(
+      computeSelectableVisibleBooks({
+        action: 'import',
+        visibleBooks: ['GEN', 'EXO', 'LEV'],
+        hasImportFile: (b) => b === 'EXO',
+        createMethod: 'empty',
+        hasReferenceProject: false,
+        referencePresentBooks: undefined,
+      }),
+    ).toEqual(['EXO']);
+  });
+
+  it('returns all visible books for delete (no reference filtering)', () => {
+    expect(
+      computeSelectableVisibleBooks({
+        action: 'delete',
+        visibleBooks: ['GEN', 'EXO', 'LEV'],
+        hasImportFile: neverImport,
+        createMethod: 'empty',
+        hasReferenceProject: false,
+        referencePresentBooks: undefined,
+      }),
+    ).toEqual(['GEN', 'EXO', 'LEV']);
+  });
+
+  it('regression: Create-from-template excludes books not in the reference project (so Select-All cannot select disabled books)', () => {
+    // Before the fix, this helper included not-in-reference books in the selectable set — the set
+    // Select-All and the selection count derive from — so Select-All could select books the grid
+    // disables. (The end-to-end count/missing-model-preflight symptoms are wired in the component;
+    // this unit only proves the selectable set excludes them.)
+    expect(
+      computeSelectableVisibleBooks({
+        action: 'create',
+        visibleBooks: ['GEN', 'EXO', 'LEV', 'NUM'],
+        hasImportFile: neverImport,
+        createMethod: 'fromTemplate',
+        hasReferenceProject: true,
+        referencePresentBooks: new Set(['GEN', 'EXO']),
+      }),
+    ).toEqual(['GEN', 'EXO']);
+  });
+
+  it('Create-from-template returns all visible books while the reference set is still loading', () => {
+    expect(
+      computeSelectableVisibleBooks({
+        action: 'create',
+        visibleBooks: ['GEN', 'EXO', 'LEV'],
+        hasImportFile: neverImport,
+        createMethod: 'fromTemplate',
+        hasReferenceProject: true,
+        referencePresentBooks: undefined,
+      }),
+    ).toEqual(['GEN', 'EXO', 'LEV']);
+  });
+
+  it('Create returns all visible books when no reference project is selected (reference filter inert)', () => {
+    expect(
+      computeSelectableVisibleBooks({
+        action: 'create',
+        visibleBooks: ['GEN', 'EXO', 'LEV'],
+        hasImportFile: neverImport,
+        createMethod: 'fromTemplate',
+        hasReferenceProject: false,
+        referencePresentBooks: new Set(['GEN']),
+      }),
+    ).toEqual(['GEN', 'EXO', 'LEV']);
+  });
+
+  it('import filtering ignores the reference set (create-only filter is inert during import)', () => {
+    // The not-in-reference filter must never narrow a non-create action, even if a reference set
+    // happens to be populated — import is gated only by attached files.
+    expect(
+      computeSelectableVisibleBooks({
+        action: 'import',
+        visibleBooks: ['GEN', 'EXO', 'LEV'],
+        hasImportFile: (b) => b === 'GEN' || b === 'LEV',
+        createMethod: 'fromTemplate',
+        hasReferenceProject: true,
+        referencePresentBooks: new Set(['GEN']),
+      }),
+    ).toEqual(['GEN', 'LEV']);
   });
 });

--- a/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.utils.ts
+++ b/extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.utils.ts
@@ -6,7 +6,9 @@
 
 import { ScrVersType } from '@sillsdev/scripture';
 import type {
+  ManageBooksAction,
   ManageBooksComparisonState,
+  ManageBooksCreateMethod,
   ManageBooksDialogLocalizedStrings,
 } from './manage-books-dialog.types';
 
@@ -146,4 +148,90 @@ export const versificationFallbackName = (value: number | string): string => {
     default:
       return 'Unknown';
   }
+};
+
+/**
+ * Whether a visible book is _not creatable_ from the current Create-from-template reference
+ * project, and so must be treated as non-selectable. In Create > Based on template a book that is
+ * not present in the reference project has no template content to base a new book on; the grid
+ * disables its pill (see `gridItems` in the component) and the selection logic must exclude it
+ * too.
+ *
+ * This is the single source of truth for that determination, shared by the grid (pill disabling)
+ * and `computeSelectableVisibleBooks` (Select-All / counts). Keeping both on one predicate is what
+ * prevents the two notions of "selectable" from drifting — the drift that let Select-All re-add
+ * not-in-reference books, inflating the selection count and tripping the missing-model preflight.
+ *
+ * Returns `false` for any action/method other than Create-from-template, or while no reference
+ * project / book set is available yet (nothing is disabled until we know the reference's book
+ * set).
+ *
+ * @param book 3-letter USFM book id to test.
+ * @param params.action Current dialog action.
+ * @param params.createMethod Current create method.
+ * @param params.hasReferenceProject Whether a reference project is currently selected.
+ * @param params.referencePresentBooks The reference project's present-book set, once loaded
+ *   (`undefined` while it is still loading).
+ * @returns `true` when the book is not in the reference project and so is not selectable.
+ */
+export const isBookNotInCreateReference = (
+  book: string,
+  params: {
+    action: ManageBooksAction;
+    createMethod: ManageBooksCreateMethod;
+    hasReferenceProject: boolean;
+    referencePresentBooks: ReadonlySet<string> | undefined;
+  },
+): boolean =>
+  params.action === 'create' &&
+  params.createMethod === 'fromTemplate' &&
+  params.hasReferenceProject &&
+  params.referencePresentBooks !== undefined &&
+  !params.referencePresentBooks.has(book);
+
+/**
+ * Compute the genuinely _selectable_ visible books for the dialog's current action — the set that
+ * Select-All, the header tri-state checkbox, the selection count, and the "{n} of {m} selected"
+ * announcement all derive from.
+ *
+ * "Selectable" excludes books the grid renders as disabled: in Create > Based on template, books
+ * not present in the reference project (`isBookNotInCreateReference`). Excluding them here is what
+ * keeps Select-All from selecting non-creatable books — the bug where Select-All inflated the count
+ * and tripped the missing-model preflight with books that the orchestrator would only filter out at
+ * submit time anyway.
+ *
+ * Mirrors the dialog's per-action rules: `view` selects nothing; `import` is limited to books with
+ * an attached file; every other action starts from all visible books — then the not-in-reference
+ * books are removed.
+ *
+ * @param params.action Current dialog action.
+ * @param params.visibleBooks Books currently visible (already text/status filtered).
+ * @param params.hasImportFile Predicate: does this book have an attached import file? Only
+ *   consulted for the `import` action (kept as a callback so this helper stays free of the
+ *   importFiles shape).
+ * @param params.createMethod Current create method.
+ * @param params.hasReferenceProject Whether a reference project is currently selected.
+ * @param params.referencePresentBooks The reference project's present-book set, once loaded.
+ * @returns The visible books the user can actually select, in `visibleBooks` order.
+ */
+export const computeSelectableVisibleBooks = (params: {
+  action: ManageBooksAction;
+  visibleBooks: readonly string[];
+  hasImportFile: (book: string) => boolean;
+  createMethod: ManageBooksCreateMethod;
+  hasReferenceProject: boolean;
+  referencePresentBooks: ReadonlySet<string> | undefined;
+}): string[] => {
+  const { action, visibleBooks, hasImportFile } = params;
+  if (action === 'view') return [];
+  const base = action === 'import' ? visibleBooks.filter((b) => hasImportFile(b)) : visibleBooks;
+  return base.filter(
+    (b) =>
+      !isBookNotInCreateReference(b, {
+        action,
+        createMethod: params.createMethod,
+        hasReferenceProject: params.hasReferenceProject,
+        referencePresentBooks: params.referencePresentBooks,
+      }),
+  );
 };


### PR DESCRIPTION
## Summary

Manage Books → Create → Based on template: **"Select all" was selecting books that are not present in the reference project** — the books the grid renders as disabled. This inflated the selection count and tripped the missing-model preflight prompt for books the orchestrator would only filter out at submit time anyway.

The set that Select-All, the header tri-state checkbox, the selection count, and the "{n} of {m} selected" announcement all derive from (`selectableVisibleBooks`) now excludes not-in-reference books. It shares a single predicate (`isBookNotInCreateReference`) with the grid's pill-disabling logic so the grid's "disabled" and the selection logic's "selectable" can no longer drift — the drift that caused this bug.

## Root cause

`selectableVisibleBooks` included disabled (not-in-reference) books, and `toggleAllVisible` (Select-All) added all of them. The grid disabled those pills and an existing prune effect removed them on reference change, but Select-All re-added them. `extensions/src/platform-scripture/src/manage-books-dialog/manage-books-dialog.component.tsx`.

## Fix

- Extracted two pure helpers into `manage-books-dialog.utils.ts` (matching the existing `deleteConfirmVariant` / `computeCompareState` pure-helper pattern):
  - `isBookNotInCreateReference(book, …)` — single source of truth for "not creatable from the reference project".
  - `computeSelectableVisibleBooks(…)` — the genuinely-selectable set, excluding not-in-reference books.
- Rewired `selectableVisibleBooks` and the grid's `disabled` condition to both use the shared predicate. The grid change is behavior-preserving (verified equivalent below).

Minimal diff: 3 files, changes confined to one dialog. No opportunistic refactors.

## Reproduction & regression evidence (RED → GREEN)

Backend/logic defect — reproduced with a failing unit test, then fixed.

**Before (RED):**

```
× computeSelectableVisibleBooks > regression: Create-from-template excludes books not in the reference project (so Select-All cannot select disabled books)
  → expected [ 'GEN', 'EXO', 'LEV', 'NUM' ] to deeply equal [ 'GEN', 'EXO' ]
 Test Files  1 failed (1)
      Tests  1 failed | 32 passed (33)
```

**After (GREEN):**

```
✓ computeSelectableVisibleBooks > regression: Create-from-template excludes books not in the reference project (so Select-All cannot select disabled books)
 Test Files  1 passed (1)
      Tests  35 passed (35)
```

An independent reviewer ran the Revert Test: removing the fix's `.filter(…)` fails **exactly** the regression test and nothing else.

## Self-review

Three adversarial reviews (architecture/correctness, scope/clarity, tests):

- **Correctness:** the grid's `disabled` condition is provably equivalent to the original (verified by truth table including undefined reference state and empty present-set); no `selectableVisibleBooks` consumer regresses; the header tri-state now correctly reaches "all selected"; complements (does not conflict with) the existing prune effect; no null/undefined hazards.
- **Scope/clarity:** tight scope, no dead code, helper extraction justified and pattern-conforming.
- **Tests:** regression test meaningful, falsifiable (Revert Test confirmed), behavior-focused; added 2 extra coverage cases per review feedback.

A pre-existing, out-of-scope finding (the per-group `toggleAllInGroup` header does not filter disabled books — cosmetic, and after this fix it no longer affects the count or preflight) was recorded for follow-up rather than expanded into this PR.

## Impact & confidence

- **User-visible:** yes. **Severity:** medium (spurious preflight prompt + wrong selection count in Create-from-template). **Frequency:** occasional (Create-from-template when the reference project lacks some destination books). **Confidence:** ~0.95.

## Provenance

Found by the automated **quality-sweep** run `qs-2026-06-26` (cold-scan fallback; the Jira seed was unavailable this run, so the run degraded to backlog + cold scan). Scan dedup key: `scan:platform-scripture:selectall-selects-disabled-books`.

AI-assisted — generated by Claude Opus 4.8 via the quality-sweep harness.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2463)
<!-- Reviewable:end -->
