### PR TITLE
Change macos-latest to macos-15 to fix CI errors

### DIFF
--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -36,7 +36,7 @@ jobs:
         uses: paranext/setup-macports@v0.2.0
 
       - name: Update MacPorts ports tree
-        if: ${{ matrix.os == 'macos-15' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         # Not using `-v` for verbose because it is very slow and does not add much value
         run: |
           sudo port sync

--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -3,7 +3,7 @@ name: Package
 # Make sure these match with the matrix.os values below
 env:
   OS_WINDOWS: windows-latest
-  OS_MACOS: macos-latest
+  OS_MACOS: macos-15
   # The Ubuntu version must align with the "core" version in electron-builder.json5
   OS_LINUX: ubuntu-22.04
 
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         # Make sure these match with the env values above
-        os: [windows-latest, macos-latest, ubuntu-22.04]
+        os: [windows-latest, macos-15, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:
@@ -36,7 +36,7 @@ jobs:
         uses: paranext/setup-macports@v0.2.0
 
       - name: Update MacPorts ports tree
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-15' }}
         # Not using `-v` for verbose because it is very slow and does not add much value
         run: |
           sudo port sync

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,7 +4,7 @@ run-name: Publish release v${{ github.event.inputs.version }} on ${{ github.head
 # Make sure these match with the matrix.os values below
 env:
   OS_WINDOWS: windows-latest
-  OS_MACOS: macos-latest
+  OS_MACOS: macos-15
   # The Ubuntu version must align with the "core" version in electron-builder.json5
   OS_LINUX: ubuntu-22.04
 
@@ -43,7 +43,7 @@ jobs:
     strategy:
       matrix:
         # Make sure these match with the env values above
-        os: [windows-latest, macos-latest, ubuntu-22.04]
+        os: [windows-latest, macos-15, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ name: Test
 # Make sure these match with the matrix.os values below
 env:
   OS_WINDOWS: windows-latest
-  OS_MACOS: macos-latest
+  OS_MACOS: macos-15
   # The Ubuntu version must align with the "core" version in electron-builder.json5
   OS_LINUX: ubuntu-22.04
 
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
         # Make sure these match with the env values above
-        os: [windows-latest, macos-latest, ubuntu-22.04]
+        os: [windows-latest, macos-15, ubuntu-22.04]
         dotnet_version: [8.0.x]
 
     steps:
@@ -39,7 +39,7 @@ jobs:
         uses: paranext/setup-macports@v0.2.0
 
       - name: Update MacPorts ports tree
-        if: ${{ matrix.os == 'macos-latest' }}
+        if: ${{ matrix.os == 'macos-15' }}
         # Not using `-v` for verbose because it is very slow and does not add much value
         run: |
           sudo port sync

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         uses: paranext/setup-macports@v0.2.0
 
       - name: Update MacPorts ports tree
-        if: ${{ matrix.os == 'macos-15' }}
+        if: ${{ matrix.os == env.OS_MACOS }}
         # Not using `-v` for verbose because it is very slow and does not add much value
         run: |
           sudo port sync


### PR DESCRIPTION
Pin macOS CI runner to macos-15

GitHub is migrating what macos-latest resolves to (now macOS 26), and the newer macOS 26 toolchain breaks the paranext/setup-macports@v0.2.0 action (it fails with curl: option : blank argument). This pins the macOS runner to macos-15 — the image macos-latest resolved to before the migration — across all three workflows (test.yml, package-main.yml, publish.yml), restoring green CI.

Each workflow updates the OS_MACOS env var, the matrix.os array, and the if: matrix.os == ... guards together, keeping them in sync.

This is a temporary workaround until setup-macports supports macOS 26, at which point we can revert to macos-latest.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2466)
<!-- Reviewable:end -->
