### PR TITLE
fix(scripture-editor): respect dark mode in model/resource panel empty states

### DIFF
--- a/extensions/src/platform-scripture-editor/src/model-text-panel.web-view.scss
+++ b/extensions/src/platform-scripture-editor/src/model-text-panel.web-view.scss
@@ -1,6 +1,7 @@
 @use './usj-nodes';
 @use './editor';
 @use './editor-overrides';
+@use './tailwind';
 
 body {
   margin: 0;

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.scss
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.scss
@@ -1,6 +1,7 @@
 @use './usj-nodes';
 @use './editor';
 @use './editor-overrides';
+@use './tailwind';
 
 body {
   margin: 0;


### PR DESCRIPTION
## Summary

The Model text panel and the Bible texts / Commentaries panels show empty-state prompts ("No model text selected. Pick one to display a reference translation alongside your project." / "No Bible texts selected. Pick one to display a reference translation alongside your project.") that did **not** respect the active dark theme.

**Why fix?** Fixes empty states of scripture text view / text collections (current PRD).

Before:
<img width="1920" height="1080" alt="pr2467-before-fullwindow" src="https://github.com/user-attachments/assets/1590f68c-8769-4c70-8ef6-74c1094af59b" />
After:
<img width="1920" height="1080" alt="pr2467-after-fullwindow" src="https://github.com/user-attachments/assets/91fa8c04-bd2b-4827-918c-48a2d9061b8e" />



## Root cause

The two panel webview stylesheets omitted the tailwind import that the main editor stylesheet has:

- `platform-scripture-editor.web-view.scss` → `@use './tailwind';` ✅
- `model-text-panel.web-view.scss` → missing ❌
- `resource-text-panel.web-view.scss` (shared by Bible texts + Commentaries) → missing ❌

`tailwind.css` is what defines the theme CSS variables (`--background`, `--foreground`, the `.dark { … }` block) and the base rule:

```css
@layer base {
  body { @apply tw:bg-background tw:text-foreground; }
}
```

Each webview iframe gets the active theme class (e.g. `dark`) added to its `<body>` by the webview host, but without the tailwind import these panels never defined the matching CSS variables or the `body` background/text colors. So the empty-state text rendered with default colors instead of theme-aware ones — failing to respect dark mode.

## Fix

Add `@use './tailwind';` to both panel stylesheets so they match the main editor and pick up the theme-aware `body` styling (and the `tw:` utilities). This covers the Model text, Bible texts, and Commentaries empty states.

## Testing

- Verified all three webview SCSS files in the extension now include `@use './tailwind';`.
- The change is a one-line addition identical to the proven import already used by `platform-scripture-editor.web-view.scss` in the same directory.

AI-assisted — [session](https://claude.ai/code/session_01GyVicRy5VvNPxgyryovrgV)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyVicRy5VvNPxgyryovrgV)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2467)
<!-- Reviewable:end -->
