### PR TITLE
fix(platform-scripture): show "No markers found." for empty checklist

### DIFF
--- a/extensions/src/platform-scripture/src/components/checklist.component.test.tsx
+++ b/extensions/src/platform-scripture/src/components/checklist.component.test.tsx
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { ChecklistTool } from './checklist.component';
+import type { ChecklistData, ChecklistLocalizedStrings } from './checklist.types';
+
+// jsdom does not implement ResizeObserver; DataTable (rendered by ChecklistTool) queries it. A
+// no-op stub keeps the render path from throwing.
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    const stubResizeObserver = vi.fn(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+    }));
+    // The DOM lib types ResizeObserver as a constructor with browser-only fields; a vi.fn factory
+    // satisfies the runtime contract but not the structural typing, so cast through `unknown`.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    globalThis.ResizeObserver = stubResizeObserver as unknown as typeof ResizeObserver;
+  }
+});
+
+const NO_RESULTS_TEXT = 'No markers found.';
+const IDENTICAL_MARKERS_TEXT = 'Comparative texts have identical markers.';
+
+const localizedStrings: ChecklistLocalizedStrings = {
+  '%markersChecklist_noResults%': NO_RESULTS_TEXT,
+  '%markersChecklist_emptyResult_identicalMarkers%': IDENTICAL_MARKERS_TEXT,
+};
+
+/** Empty-result data with NO backend-supplied empty-result message. */
+const emptyDataNoBackendMessage: ChecklistData = {
+  rows: [],
+  columnHeaders: ['ENGA', 'ENGB'],
+  columnProjectIds: ['projectA', 'projectB'],
+  excludedCount: 0,
+  emptyResultMessage: undefined,
+};
+
+describe('ChecklistTool empty-result message', () => {
+  it('shows the generic "No markers found." message when the backend supplies no empty-result message', () => {
+    render(
+      <ChecklistTool
+        isLoading={false}
+        hideMatches={false}
+        showVerseText={false}
+        localizedStringsWithLoadingState={[localizedStrings, false]}
+        data={emptyDataNoBackendMessage}
+      />,
+    );
+
+    // Regression for the bug: with no backend message the component must NOT claim the markers are
+    // identical (a false positive) — it should fall back to the neutral generic no-results string.
+    expect(screen.getByText(NO_RESULTS_TEXT)).toBeInTheDocument();
+    expect(screen.queryByText(IDENTICAL_MARKERS_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('shows "No markers found." for the "noResults" variant (backend ships an empty message)', () => {
+    // The common real empty state: a filtered check that yields no rows. The C# backend emits the
+    // "noResults" variant with message: "" (string.Empty) by design, leaving the wording to the UI.
+    // An empty string must fall back to the generic string, not render a blank panel.
+    render(
+      <ChecklistTool
+        isLoading={false}
+        hideMatches={false}
+        showVerseText={false}
+        localizedStringsWithLoadingState={[localizedStrings, false]}
+        data={{
+          ...emptyDataNoBackendMessage,
+          emptyResultMessage: { variant: 'noResults', message: '', searchedMarkers: ['p'] },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(NO_RESULTS_TEXT)).toBeInTheDocument();
+    expect(screen.queryByText(IDENTICAL_MARKERS_TEXT)).not.toBeInTheDocument();
+  });
+
+  it('prefers a non-empty backend-supplied empty-result message over the generic fallback', () => {
+    render(
+      <ChecklistTool
+        isLoading={false}
+        hideMatches={false}
+        showVerseText={false}
+        localizedStringsWithLoadingState={[localizedStrings, false]}
+        data={{
+          ...emptyDataNoBackendMessage,
+          emptyResultMessage: { variant: 'identical', message: IDENTICAL_MARKERS_TEXT },
+        }}
+      />,
+    );
+
+    expect(screen.getByText(IDENTICAL_MARKERS_TEXT)).toBeInTheDocument();
+    expect(screen.queryByText(NO_RESULTS_TEXT)).not.toBeInTheDocument();
+  });
+});

--- a/extensions/src/platform-scripture/src/components/checklist.component.tsx
+++ b/extensions/src/platform-scripture/src/components/checklist.component.tsx
@@ -684,12 +684,16 @@ export function ChecklistTool({
     return undefined;
   };
 
-  // Backend-supplied empty-result message is preferred over the generic no-results string — e.g.
-  // gm-002 emits "Comparative texts have identical markers." (BHV-600).
+  // A non-empty backend-supplied empty-result message is preferred over the generic no-results
+  // string — the "identical" variant ships a resolved message (gm-002's "Comparative texts have
+  // identical markers.", BHV-600). The "noResults" variant intentionally ships an EMPTY message
+  // (the backend leaves the wording to the UI), and the field is also absent on the defensive
+  // undefined-data path. In both of those cases fall back to the neutral generic "No markers
+  // found." — not the identical-markers string (which would falsely claim a match that was never
+  // computed) and not a blank panel. `||` (not `??`) so an empty backend message also falls back.
+  const backendEmptyResultMessage = data?.emptyResultMessage?.message;
   const noResultsMessage =
-    data?.emptyResultMessage?.message ??
-    getLocalizedString('%markersChecklist_emptyResult_identicalMarkers%') ??
-    getLocalizedString('%markersChecklist_noResults%');
+    backendEmptyResultMessage || getLocalizedString('%markersChecklist_noResults%');
 
   return (
     <div


### PR DESCRIPTION
## Summary

The Markers Checklist empty-state message was derived from a `??` chain whose generic **"No markers found."** fallback was unreachable, so the wrong message (or a blank panel) showed when a checklist had no rows.

```ts
// before
data?.emptyResultMessage?.message
  ?? getLocalizedString('%markersChecklist_emptyResult_identicalMarkers%')  // wrong default
  ?? getLocalizedString('%markersChecklist_noResults%');                    // DEAD: ?? never falls through
```

`getLocalizedString` returns `strings[key] ?? key` and never yields nullish, so the chain always stopped at the **identical-markers** string. Two user-visible faults:

1. **Defensive/undefined path** — when `emptyResultMessage` was absent, the empty checklist falsely showed *"Comparative texts have identical markers."* — asserting a match that was never computed.
2. **The common `noResults` path** — the C# backend ships the `noResults` variant (a filtered check that yields no rows) with `Message: string.Empty` **by design** (`MarkersDataSource.PostProcessRows`, `ChecklistNetworkObject.ResolveLocalizeKeys` leaves `""` unresolved), leaving the wording to the UI. `'' ?? key` does **not** coalesce empty strings, so that path rendered a **blank** empty state.

## Fix

```ts
// after
const backendEmptyResultMessage = data?.emptyResultMessage?.message;
const noResultsMessage =
  backendEmptyResultMessage || getLocalizedString('%markersChecklist_noResults%');
```

`||` (not `??`) so an **absent OR empty** backend message both fall back to the neutral generic *"No markers found."*, while a non-empty backend message (the resolved `identical` variant) is still preferred. One-line logic change; no backend/contract changes.

## Evidence (backend/logic defect — failing→passing test)

New render-test `checklist.component.test.tsx` (3 cases: undefined message, empty `noResults` message, non-empty message).

**BEFORE (RED)** against the original code:
- *"shows generic No markers found when backend supplies no message"* → rendered "Comparative texts have identical markers." → **FAIL**
- *"shows No markers found for the noResults variant (empty message)"* → rendered blank → **FAIL**

**AFTER (GREEN)**
```
Test Files  1 passed (1)
     Tests  3 passed (3)
Full platform-scripture suite: 8 files, 174 passed. typecheck + workspace lint clean.
```

**Revert test:** swapping `||` back to `??` re-fails the empty-`noResults` test (blank panel); the undefined-message test fails against the original three-operand code. Both regression tests are falsifiable against the relevant prior states.

## Self-review summary

An adversarial review of the first cut (`??`) caught that it only fixed the rare defensive path and left the **common** `noResults` path blank (backend ships `message: ""`); this was corrected to `||` and a dedicated regression test was added. Diff is minimal (one logic line + a focused test). Out of scope and intentionally not changed: the now-frontend-unreferenced `%markersChecklist_emptyResult_identicalMarkers%` key remains in `CHECKLIST_STRING_KEYS` (still load-bearing on the C# side and in stories) — a harmless future cleanup.

## Impact + confidence

- **Impact:** user-visible. Severity 2 (misleading/blank empty state — a false "identical markers" claim or a blank panel), frequency 2 (every empty checklist, and the filtered-no-results case is a common state). Score 4.
- **Confidence:** 0.9 — dead-code path proven, C# contract verified, deterministic RED→GREEN with a revert test.

## Provenance

Found by the automated quality-sweep run (`qs-2026-06-27`); scan-source finding (no Jira issue). Not seeded from a Jira ticket.

AI-assisted — generated by the quality-sweep (Claude Opus 4.8).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2468)
<!-- Reviewable:end -->
