### PR TITLE
feat(progress): forward ProgressCapture value via optional onValue callback

### DIFF
--- a/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
+++ b/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
@@ -95,6 +95,35 @@ namespace TestParanextDataProvider.ParatextUtils
         }
 
         [Test]
+        public void SetProgressValue_ForwardsValueToOnValueCallback()
+        {
+            var values = new List<double>();
+            using (ProgressCapture.StartCapture(_ => { }, v => values.Add(v)))
+            {
+                // Drive SetProgressValue via a determinate task session (StartTask maps
+                // Value → SetProgressValue as a 0..1 fraction; Value=42 on a 0..100 task → 0.42).
+                using var session = Progress.Mgr.StartTask(0, 100, "");
+                session.Value = 42;
+            }
+            Assert.That(values, Does.Contain(0.42));
+        }
+
+        [Test]
+        public void SetProgressValue_SwallowsCallbackException()
+        {
+            using var scope = ProgressCapture.StartCapture(
+                _ => { },
+                _ => throw new InvalidOperationException("value callback boom")
+            );
+
+            Assert.DoesNotThrow(() =>
+            {
+                using var session = Progress.Mgr.StartTask(0, 100, "");
+                session.Value = 42;
+            });
+        }
+
+        [Test]
         public void Cancel_FromAnotherThread_SetsFlagOnCapturedInstanceNotTheCaller()
         {
             // The whole point of ProgressScope holding a direct Progress reference (instead of

--- a/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
+++ b/c-sharp-tests/ParatextUtils/ProgressCaptureTests.cs
@@ -109,6 +109,28 @@ namespace TestParanextDataProvider.ParatextUtils
         }
 
         [Test]
+        public void SetProgressValue_DropsIndefiniteSentinelValue()
+        {
+            // ParatextData runs Send/Receive phases as indefinite tasks: StartIndefiniteTask →
+            // Begin(-1, -1) → SetProgressValue(AbsVal == -1). onValue's contract is a non-negative
+            // fraction, so the indefinite sentinel must be dropped, not forwarded as a negative
+            // "progress" (which a consumer would render as e.g. a -100% bar). Without the guard the
+            // values below would be [-1, -1]; with it the callback is never invoked.
+            var values = new List<double>();
+            using (ProgressCapture.StartCapture(_ => { }, values.Add))
+            {
+                using var session = Progress.Mgr.StartIndefiniteTask();
+                session.Incr(); // refresh — drives another SetProgressValue(-1)
+            }
+
+            Assert.That(
+                values,
+                Has.None.LessThan(0),
+                "indefinite -1 sentinel must not reach onValue"
+            );
+        }
+
+        [Test]
         public void SetProgressValue_SwallowsCallbackException()
         {
             using var scope = ProgressCapture.StartCapture(

--- a/c-sharp/ParatextUtils/ProgressCapture.cs
+++ b/c-sharp/ParatextUtils/ProgressCapture.cs
@@ -8,8 +8,10 @@ namespace Paranext.DataProvider.ParatextUtils;
 /// ParatextData's thread-static <see cref="Progress.Mgr"/>. Mirrors
 /// <c>AlertCapture</c>: a caller opens a scope around long-running
 /// ParatextData work, receives live status text through the
-/// <c>onText</c> callback, and can cancel the in-flight operation by
-/// calling <see cref="ProgressScope.Cancel"/> (safe from another thread).
+/// <c>onText</c> callback and an optional 0.0–1.0 progress fraction
+/// through the <c>onValue</c> callback, and can cancel the in-flight
+/// operation by calling <see cref="ProgressScope.Cancel"/> (safe from
+/// another thread).
 ///
 /// <para>ParatextData's <c>InternetSharedRepositorySource.RetryIndefinitely</c>,
 /// <c>Hg</c>, and <c>ExeRunner</c> consult <see cref="Progress.Cancelled"/>
@@ -28,8 +30,13 @@ namespace Paranext.DataProvider.ParatextUtils;
 public sealed class ProgressCapture : ProgressDisplay
 {
     private readonly Action<string>? _onText;
+    private readonly Action<double>? _onValue;
 
-    private ProgressCapture(Action<string>? onText) => _onText = onText;
+    private ProgressCapture(Action<string>? onText, Action<double>? onValue)
+    {
+        _onText = onText;
+        _onValue = onValue;
+    }
 
     /// <summary>
     /// Installs a new <see cref="ProgressCapture"/> as the display on the
@@ -51,9 +58,17 @@ public sealed class ProgressCapture : ProgressDisplay
     /// read <c>AllowAbort</c>. Exceptions it throws are caught and ignored so they cannot unwind
     /// ParatextData's retry loop.
     /// </param>
-    public static ProgressScope StartCapture(Action<string>? onText = null)
+    /// <param name="onValue">
+    /// Optional. Invoked with the 0.0–1.0 progress fraction reported by ParatextData. Subject to
+    /// the same threading and exception-isolation constraints as <paramref name="onText"/>: called
+    /// synchronously inside ParatextData's progress path; exceptions are caught and ignored.
+    /// </param>
+    public static ProgressScope StartCapture(
+        Action<string>? onText = null,
+        Action<double>? onValue = null
+    )
     {
-        var display = new ProgressCapture(onText);
+        var display = new ProgressCapture(onText, onValue);
         Progress progress = Progress.Mgr;
         progress.Reset(); // clear stale cancelled/display left on a pooled thread
         progress.SetDisplay(display);
@@ -84,7 +99,16 @@ public sealed class ProgressCapture : ProgressDisplay
 
     void ProgressDisplay.SetProgressValue(double val)
     {
-        // Indefinite Send/Receive has no determinate progress value; ignore.
+        try
+        {
+            _onValue?.Invoke(val);
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(
+                $"ProgressCapture onValue callback threw (ignored): {AlertCapture.RedactPathsForLog(e.ToString())}"
+            );
+        }
     }
 
     /// <summary>

--- a/c-sharp/ParatextUtils/ProgressCapture.cs
+++ b/c-sharp/ParatextUtils/ProgressCapture.cs
@@ -59,9 +59,12 @@ public sealed class ProgressCapture : ProgressDisplay
     /// ParatextData's retry loop.
     /// </param>
     /// <param name="onValue">
-    /// Optional. Invoked with the 0.0–1.0 progress fraction reported by ParatextData. Subject to
-    /// the same threading and exception-isolation constraints as <paramref name="onText"/>: called
-    /// synchronously inside ParatextData's progress path; exceptions are caught and ignored.
+    /// Optional. Invoked with the progress fraction (normally 0.0–1.0) reported by ParatextData for
+    /// determinate tasks. Indefinite tasks report no fraction — ParatextData signals this as a
+    /// negative sentinel (-1) — and those updates are dropped rather than forwarded, so the callback
+    /// is never invoked with a negative value. Subject to the same threading and exception-isolation
+    /// constraints as <paramref name="onText"/>: called synchronously inside ParatextData's progress
+    /// path; exceptions are caught and ignored.
     /// </param>
     public static ProgressScope StartCapture(
         Action<string>? onText = null,
@@ -78,8 +81,15 @@ public sealed class ProgressCapture : ProgressDisplay
     void ProgressDisplay.SetProgressText(string text) =>
         SafeInvokeCallback("onText", _onText, text);
 
-    void ProgressDisplay.SetProgressValue(double val) =>
-        SafeInvokeCallback("onValue", _onValue, val);
+    void ProgressDisplay.SetProgressValue(double val)
+    {
+        // ParatextData reports -1 for indefinite tasks (StartIndefiniteTask → Begin(-1, -1) →
+        // AbsVal == -1): there is no determinate fraction, so drop the sentinel rather than
+        // forward a negative "progress" that a consumer would render as e.g. a -100% bar.
+        // onValue's contract is a non-negative fraction.
+        if (val >= 0)
+            SafeInvokeCallback("onValue", _onValue, val);
+    }
 
     // Both progress callbacks run synchronously inside ParatextData's progress path (e.g.
     // RetryIndefinitely's catch block, while Progress's lock is held). A callback that throws

--- a/c-sharp/ParatextUtils/ProgressCapture.cs
+++ b/c-sharp/ParatextUtils/ProgressCapture.cs
@@ -75,38 +75,30 @@ public sealed class ProgressCapture : ProgressDisplay
         return new ProgressScope(progress);
     }
 
-    void ProgressDisplay.SetProgressText(string text)
-    {
-        // The caller-supplied callback runs synchronously inside ParatextData's status-update
-        // path (e.g. RetryIndefinitely's catch block, while holding Progress's lock). A callback
-        // that throws would unwind ParatextData's retry loop and turn an otherwise-recoverable
-        // reconnect into a hard failure, so isolate it: a dropped status update is harmless;
-        // tearing down the in-flight operation is not.
-        try
-        {
-            _onText?.Invoke(text);
-        }
-        catch (Exception e)
-        {
-            // Redact filesystem-path-shaped substrings before logging, mirroring AlertCapture's
-            // console fallback (Theme 4): a callback wrapping IO can surface raw paths in the
-            // exception text, and server logs may be aggregated / shipped off-host.
-            Console.WriteLine(
-                $"ProgressCapture onText callback threw (ignored): {AlertCapture.RedactPathsForLog(e.ToString())}"
-            );
-        }
-    }
+    void ProgressDisplay.SetProgressText(string text) =>
+        SafeInvokeCallback("onText", _onText, text);
 
-    void ProgressDisplay.SetProgressValue(double val)
+    void ProgressDisplay.SetProgressValue(double val) =>
+        SafeInvokeCallback("onValue", _onValue, val);
+
+    // Both progress callbacks run synchronously inside ParatextData's progress path (e.g.
+    // RetryIndefinitely's catch block, while Progress's lock is held). A callback that throws
+    // would unwind ParatextData's retry loop and turn an otherwise-recoverable reconnect into a
+    // hard failure, so isolate it: a dropped progress update is harmless; tearing down the
+    // in-flight operation is not. Redact filesystem-path-shaped substrings before logging,
+    // mirroring AlertCapture's console fallback (Theme 4): a callback wrapping IO can surface raw
+    // paths in the exception text, and server logs may be aggregated / shipped off-host. Generic
+    // (rather than an Action closure) so the hot status-update path stays allocation-free.
+    private static void SafeInvokeCallback<T>(string callbackName, Action<T>? callback, T arg)
     {
         try
         {
-            _onValue?.Invoke(val);
+            callback?.Invoke(arg);
         }
         catch (Exception e)
         {
             Console.WriteLine(
-                $"ProgressCapture onValue callback threw (ignored): {AlertCapture.RedactPathsForLog(e.ToString())}"
+                $"ProgressCapture {callbackName} callback threw (ignored): {AlertCapture.RedactPathsForLog(e.ToString())}"
             );
         }
     }


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: send-receive-progress

**Base**: origin/main

**Date**: 2026-06-28

**Review model**: Claude Opus 4.8

**Files changed**: 2

## Overview

This branch is the paranext-core slice of a larger, cross-repo effort to visualize Send/Receive
progress. It converts `ProgressCapture.SetProgressValue` from a no-op into a forwarder: a new
optional `onValue` callback receives the 0.0–1.0 progress fraction that ParatextData reports,
mirroring the existing `onText` text-status callback. The callback is exception-isolated (a throwing
callback can't unwind ParatextData's retry loop) and path-redacted on the log fallback, exactly like
its `onText` sibling. Two tests cover the new behavior (value forwarding through the real
`Progress.Mgr` task path, and exception swallowing).

The actual wiring (installing this capture on the live Send/Receive path) and the UI that renders the
value are **not** in this diff — by design, they land in parallel PRs in
`paratext-bible-internal-extension` and `paratext-10-studio`. This is an additive, backward-compatible
building-block change.

## API Changes

None on a tracked TS / `@papi/` public-API surface. For completeness, the C# backend change is:
`Paranext.DataProvider.ParatextUtils.ProgressCapture.StartCapture(...)` gained an optional trailing
parameter `Action<double>? onValue = null`, and the previously no-op
`ProgressDisplay.SetProgressValue(double)` now forwards the value to that callback. Backward-compatible
— the `null` default preserves the prior "ignore the value" behavior, and existing `onText`-only call
shapes are unaffected.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [ ] ~~Scope vs. stated purpose: this diff adds only the paranext-core backend plumbing (`onValue` forwarding). Verified by grep that nothing outside the tests calls `ProgressCapture.StartCapture`, so within this repo nothing installs the capture on the S/R path or renders the value — no progress is visualized by this diff alone.~~ _(Intentional. Send/Receive is distributed across paranext-core, paratext-bible-internal-extension, and paratext-10-studio; this branch is the paranext-core part only. The wiring and UI land in parallel PRs in the other two repos.)_

[Author response: Confirmed this is an intentional, incremental, cross-repo split — the paranext-core part is deliberately minor. Consistent with the merge-base commit `2bc74eace5` that introduced `ProgressCapture`, which also had no callers yet.]

### Minor — Consider

- [x] **DRY: `SetProgressText` and the new `SetProgressValue` shared a near-identical try/catch exception-isolation block (invoke callback, swallow + `Console.WriteLine` with `RedactPathsForLog`).** _(fixed during review: extracted a generic `SafeInvokeCallback<T>(string callbackName, Action<T>? callback, T arg)` helper; both methods are now one-line expression bodies delegating to it. Made generic rather than an `Action` closure so the hot status-update path — which runs while `Progress`'s lock is held — stays allocation-free. Net −8 lines.)_
- [x] **Missing inline rationale comment on the new `SetProgressValue` try/catch (its `onText` sibling had a detailed one).** _(fixed during review: the rationale comment is now consolidated onto the shared `SafeInvokeCallback` helper, covering both callbacks in one place.)_
- [ ] ~~Exact float-equality assertion `Assert.That(values, Does.Contain(0.42))` in `SetProgressValue_ForwardsValueToOnValueCallback`; a tolerance-based check (`Is.EqualTo(0.42).Within(1e-9)`) would be more robust. (Flagged by both the api and style passes.)~~ _(Author dismissed: this is a progress-bar fraction, not a numeric model; `42.0/100.0` is bit-identical to the literal `0.42` today, and the brittleness is purely hypothetical — it would only bite if ParatextData computed the fraction by a different route. Not worth a tolerance assertion here. Reviewer agreed.)_

[Author response: Asked for #1 (DRY) and it was implemented. Said #2 was no longer needed given #1. Judged #3 immaterial for a progress bar; left as-is.]

### Template Propagation

#### Shared Regions Modified

None. (Neither changed file contains `#region shared with` markers — verified via grep.)

#### Extension Config Changes

None. (Both changed files are under `c-sharp/` and `c-sharp-tests/`, not `extensions/`.)

## Positive Observations

- The `onValue` path faithfully mirrors the established `onText` / `AlertCapture` pattern: explicit-interface implementation, exception isolation to protect ParatextData's retry loop, and `AlertCapture.RedactPathsForLog(...)` on the console fallback (single source of truth for path redaction, matching the documented Theme-4 rationale).
- The new optional parameter is correctly placed last with a `= null` default, keeping the change additive and backward-compatible.
- XML/TSDoc was updated thoroughly — the class summary, the new `<param name="onValue">`, and the threading/exception-isolation constraints are all documented to the rigor of the surrounding code.
- Strong test coverage: both new branches of `SetProgressValue` are exercised (forwarding and exception-swallowing), driven through the real `Progress.Mgr.StartTask(...)` API rather than mocking the explicit-interface method, and following the fixture's `Method_Scenario` naming convention.
- The in-review DRY refactor preserved the allocation-light property of the hot path by using a generic helper instead of per-call closures.

## Interview Notes

- **Stated purpose**: Visualize progress information when running Send/Receive.
- **Scope is intentional and cross-repo**: The author clearly explained that Send/Receive is distributed over paranext-core, `paratext-bible-internal-extension`, and `paratext-10-studio`. This branch is the (minor) paranext-core part only; the caller wiring and the UI that consumes `onValue` are landing in parallel PRs in the other two repos. No misunderstanding — the author understands exactly what this diff does and does not do.
- **Decisions**: Author requested the DRY extraction (#1), agreed the duplicate-comment nit (#2) was subsumed by it, and made a deliberate, well-reasoned call to leave the exact-float assertion (#3) as-is.
- **No unresolved items.** No areas were deferred to AI or left unexplained.

## In-Review Quality Check

One change was made during the review (the DRY refactor on `ProgressCapture.cs`). Because the change is C#-only, the C# toolchain was run rather than the TS checks:

- **csharpier**: no reformatting needed — the staged refactor was already correctly formatted.
- **Build**: succeeded; the generic `SafeInvokeCallback<T>` helper and the two expression-bodied delegating methods compile cleanly.
- **Tests** (`dotnet test c-sharp-tests/`): **Passed 1296, Failed 0, Skipped 6** (the 6 skips are pre-existing platform/fixture gates, unrelated to this change). The full `ProgressCapture` suite passes 7/7, including the two new value-callback tests.
- No unfixable failures.

## Suggested Review Focus

- [ ] Confirm the cross-repo plan: link the parallel PRs in `paratext-bible-internal-extension` and `paratext-10-studio` so the reviewer can verify the wiring (`StartCapture(..., onValue)`) and the progress-bar UI exist and are consistent with this `onValue` contract.
- [ ] Sanity-check the value contract: ParatextData reports the progress value as a 0.0–1.0 fraction (per the doc and the `42/100 → 0.42` test). Confirm the consumer in the UI repo treats it as a fraction, not a percent.
- [ ] (Optional) The in-review DRY refactor changed shared callback-invocation code used by both `onText` and `onValue` — a quick look that the consolidated `SafeInvokeCallback<T>` reads cleanly.
<!-- review-paratext:summary:end -->

---

## Summary

Follow-up to #2457. `ProgressCapture` already bridges ParatextData's `Progress.Mgr` status **text** to a caller via `onText`; this adds the **determinate progress value** so callers (e.g. a Send/Receive UI) can render a real progress bar, not just status text.

- Adds an optional `Action<double>? onValue` parameter to `StartCapture` (defaults to `null`, so all existing callers are source-compatible and unchanged).
- Replaces the previously no-op `ProgressDisplay.SetProgressValue` with a `try/catch` invocation of `_onValue`, mirroring the exact threading and exception-isolation pattern already used for `SetProgressText` (called synchronously on ParatextData's progress path; exceptions are caught, redacted, and logged so they can't unwind ParatextData's retry loop).

## Tests

Two new tests in `ProgressCaptureTests.cs`:
- `SetProgressValue_ForwardsValueToOnValueCallback` — drives a determinate `Progress.Mgr` task and asserts the 0.0–1.0 fraction reaches `onValue`.
- `SetProgressValue_SwallowsCallbackException` — asserts a throwing `onValue` callback does not propagate.

`dotnet build ParanextDataProvider.csproj` — 0 errors / 0 warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dtp12SAT5gyU4PnS2ftPUw

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2469)
<!-- Reviewable:end -->
