### PR TITLE
fix(platform-bible-react): sync comment thread read state with backend (PT-3852)

### DIFF
--- a/lib/platform-bible-react/src/components/advanced/comment-list/comment-thread.component.test.tsx
+++ b/lib/platform-bible-react/src/components/advanced/comment-list/comment-thread.component.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { LegacyComment, LegacyCommentThread } from 'platform-bible-utils';
@@ -228,5 +228,74 @@ describe('CommentThread assignee state machine', () => {
       expect(screen.getByText('Assigning to: Alice')).toBeInTheDocument();
     });
     expect(screen.queryByText('Assigning to: Charlie')).not.toBeInTheDocument();
+  });
+});
+
+describe('CommentThread read-state sync (PT-3852)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The thread seeds its read state from the `isRead` prop once on mount; the parent reuses a
+  // stable key per thread, so a later backend read update arrives as a prop change rather than a
+  // remount. Without syncing the prop, those updates never reach the UI.
+  it('reflects a backend read update delivered as a prop change after mount', () => {
+    const { rerender } = render(
+      <CommentThread {...defaultProps} isSelected={false} isRead={false} />,
+    );
+
+    // Unread: the toggle offers "Mark as read"
+    expect(screen.getByRole('button', { name: 'Mark as read' })).toBeInTheDocument();
+
+    rerender(<CommentThread {...defaultProps} isSelected={false} isRead />);
+
+    // The backend now reports the thread as read, so the toggle must offer "Mark as unread"
+    expect(screen.getByRole('button', { name: 'Mark as unread' })).toBeInTheDocument();
+  });
+
+  // PT-3852: after a user manually marks a thread unread, adding a reply re-marks the thread read
+  // on the backend (verified persisted). That read state must reach the view; previously the manual
+  // unread plus the missing prop sync kept the thread visually unread until an app restart.
+  it('shows read again when a manual unread is followed by a backend re-mark-read', () => {
+    const handleReadStatusChange = vi.fn();
+    const { rerender } = render(
+      <CommentThread
+        {...defaultProps}
+        isSelected={false}
+        isRead
+        handleReadStatusChange={handleReadStatusChange}
+      />,
+    );
+
+    // Starts read
+    expect(screen.getByRole('button', { name: 'Mark as unread' })).toBeInTheDocument();
+
+    // User manually marks it unread (this persists isRead=false to the backend)
+    fireEvent.click(screen.getByRole('button', { name: 'Mark as unread' }));
+    expect(handleReadStatusChange).toHaveBeenLastCalledWith('thread-1', false);
+    expect(screen.getByRole('button', { name: 'Mark as read' })).toBeInTheDocument();
+
+    // The persisted unread round-trips back as a prop update; the manual unread must be preserved
+    rerender(
+      <CommentThread
+        {...defaultProps}
+        isSelected={false}
+        isRead={false}
+        handleReadStatusChange={handleReadStatusChange}
+      />,
+    );
+    expect(screen.getByRole('button', { name: 'Mark as read' })).toBeInTheDocument();
+
+    // A reply re-marks the thread read on the backend, arriving as an isRead prop change
+    rerender(
+      <CommentThread
+        {...defaultProps}
+        isSelected={false}
+        isRead
+        handleReadStatusChange={handleReadStatusChange}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Mark as unread' })).toBeInTheDocument();
   });
 });

--- a/lib/platform-bible-react/src/components/advanced/comment-list/comment-thread.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/comment-list/comment-thread.component.tsx
@@ -261,6 +261,17 @@ export function CommentThread({
     handleReadStatusChange?.(threadId, newIsRead);
   }, [isRead, handleReadStatusChange, threadId]);
 
+  // Keep the local read state in sync with the backend's read state. The thread seeds `isRead`
+  // from the prop once on mount, and the parent reuses a stable key per thread, so a later backend
+  // update (e.g. adding a reply re-marks the thread read, PT-3852) arrives as a prop change rather
+  // than a remount and would otherwise never reach the UI. An incoming read also clears a prior
+  // manual unread so the thread doesn't stay visually unread after the backend marks it read; a
+  // manual unread persists to the backend as `isRead=false`, so it is preserved here.
+  useEffect(() => {
+    setIsRead(isReadProp);
+    if (isReadProp) setManuallyUnread(false);
+  }, [isReadProp]);
+
   useEffect(() => {
     setShowAllReplies(false);
   }, [isSelected]);


### PR DESCRIPTION
## Summary

Fixes [PT-3852](https://paratextstudio.atlassian.net/browse/PT-3852) — *Adding a reply to a comment thread that was manually marked as unread does not make it read again.*

`CommentThread` seeded its local `isRead` state from the `isRead` prop **once on mount** (`useState(isReadProp)`) and never synced later prop changes. Because `CommentList` renders each thread with a stable `key={thread.id}` and passes `isRead={thread.isRead}`, a backend read-state update arrives as a **prop change, not a remount** — so the component dropped it. After a user manually marked a thread unread, adding a reply re-marks the thread read on the backend (the read state persists via `pdp.setIsCommentThreadRead` and round-trips through `useProjectData().CommentThreads`), but the view stayed visually unread until the app was restarted. This matches the reporter's diagnosis that the *persisted* state was correct while the *view* was not updating.

## Fix

Add an effect to `comment-thread.component.tsx` that syncs local read state to the prop:

```tsx
useEffect(() => {
  setIsRead(isReadProp);
  if (isReadProp) setManuallyUnread(false);
}, [isReadProp]);
```

An incoming **read** is authoritative and clears a prior manual unread so the thread reflects the backend. An incoming **unread** leaves `manuallyUnread` untouched, so a user's manual unread (persisted as `isRead=false`) is preserved across the round-trip. The effect does not call `handleReadStatusChange`, so there is no echo-write back to the backend, and the auto-read timer defers (its `!isRead` guard) rather than racing.

Minimal diff — 1 component file + its test. No refactor, no behavior change beyond the sync.

## Evidence (before → after)

Regression tests added to `comment-thread.component.test.tsx`. Verified falsifiable: with the sync effect removed both fail (RED); with it, both pass (GREEN). The 6 pre-existing tests are unaffected.

**Before (RED — effect removed):**
```
× CommentThread read-state sync (PT-3852) > reflects a backend read update delivered as a prop change after mount
× CommentThread read-state sync (PT-3852) > shows read again when a manual unread is followed by a backend re-mark-read
 Tests  2 failed | 6 passed (8)
```

**After (GREEN — with fix):**
```
✓ CommentThread read-state sync (PT-3852) > reflects a backend read update delivered as a prop change after mount
✓ CommentThread read-state sync (PT-3852) > shows read again when a manual unread is followed by a backend re-mark-read
 Tests  8 passed (8)
```

Full `lib/platform-bible-react` suite: **803 passed (100 files)**. `npm run typecheck` and package ESLint clean.

## Self-review summary

Reviewed via two independent reviewers (clarity/correctness and tests). Findings: **approve as-is**, no blocker/major/minor issues.
- Manual-unread is correctly preserved through the persist round-trip; the asymmetric `if (isReadProp)` clear is the right design.
- No mount flash, no infinite loop, no echo-write, no fight with the auto-read timer.
- `react-hooks/exhaustive-deps` on `[isReadProp]` is correct.
- Tests assert observable behavior (the read toggle's accessible name), are deterministic without fake timers (`isSelected={false}` so the auto-read timer never arms), and the intermediate `isRead={false}` rerender meaningfully guards that manual-unread survives the round-trip.

## Impact & confidence

- **Impact:** user-visible correctness bug in comment read/unread state (severity moderate, low-medium frequency — requires manual-unread then a reply). Stale read state can mislead reviewers about which threads they've addressed.
- **Confidence:** high. Root cause and the full data round-trip were traced through `CommentList`, the `legacy-comment-manager` consumer (`handleReadStatusChange` → `setIsCommentThreadRead`), and the C# `AddCommentToThread` mark-read path. The fix is deterministically reproduced by the regression tests.

## Notes

- A related ticket, PT-3855 (*old read comments toggle to unread when a new comment is created*), touches the same surface but appears to be a backend read-state recompute in the opposite direction; it is **not** addressed here and remains open.

---

🔍 Found by the automated quality-sweep run (qs-2026-06-28); selected from the backlog.

AI-assisted — generated by the daily quality-sweep (Claude Code).


[PT-3852]: https://paratextstudio.atlassian.net/browse/PT-3852?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2470)
<!-- Reviewable:end -->
