### PR TITLE
fix: render context menus above the dock (PT-3877)

### DIFF
--- a/lib/platform-bible-react/src/components/shadcn-ui/context-menu.test.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/context-menu.test.tsx
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeAll } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import {
+  ContextMenu,
+  ContextMenuContent,
+  ContextMenuItem,
+  ContextMenuSub,
+  ContextMenuSubContent,
+  ContextMenuSubTrigger,
+  ContextMenuTrigger,
+} from '@/components/shadcn-ui/context-menu';
+import { Z_INDEX_ABOVE_DOCK } from '@/components/z-index';
+
+// jsdom doesn't ship a ResizeObserver, which Radix's Popper-positioned ContextMenu content
+// instantiates on mount. A no-op stub is sufficient since the test inspects style, not layout.
+class NoopResizeObserver implements ResizeObserver {
+  // Keep an internal record of observed targets so the no-op methods touch `this` and don't
+  // trip @typescript-eslint/class-methods-use-this. No test inspects this state.
+  private readonly targets = new Set<Element>();
+
+  observe(target: Element) {
+    this.targets.add(target);
+  }
+
+  unobserve(target: Element) {
+    this.targets.delete(target);
+  }
+
+  disconnect() {
+    this.targets.clear();
+  }
+}
+
+beforeAll(() => {
+  if (typeof globalThis.ResizeObserver === 'undefined') {
+    globalThis.ResizeObserver = NoopResizeObserver;
+  }
+  if (typeof Element.prototype.hasPointerCapture !== 'function') {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (typeof Element.prototype.scrollIntoView !== 'function') {
+    Element.prototype.scrollIntoView = () => {};
+  }
+});
+
+describe('ContextMenuContent', () => {
+  // Regression test for PT-3877: the tab header context menu ("Open as floating tab") rendered
+  // behind floating tab groups because ContextMenuContent inherited Tailwind `tw:z-50`, while
+  // rc-dock floating panels render at z-index ~200. The content must declare a z-index above the
+  // dock (matching the existing Popover fix) so it is never occluded.
+  it('renders with a z-index above the dock so floating tab groups cannot occlude it', () => {
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger>Tab header</ContextMenuTrigger>
+        <ContextMenuContent>
+          <ContextMenuItem>Open as floating tab</ContextMenuItem>
+        </ContextMenuContent>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Tab header'));
+
+    const content = screen.getByRole('menu');
+    expect(Number(content.style.zIndex)).toBeGreaterThanOrEqual(Z_INDEX_ABOVE_DOCK);
+  });
+
+  // Submenus (e.g. the dictionary copy submenu in platform-enhanced-resources) must sit on the
+  // same above-dock layer as their parent, or they would be occluded by the dock / render behind
+  // the parent menu once the parent was raised.
+  it('renders submenu content with a z-index above the dock', () => {
+    render(
+      <ContextMenu>
+        <ContextMenuTrigger>Tab header</ContextMenuTrigger>
+        <ContextMenuContent>
+          {/* forceMount so the submenu content is in the DOM without relying on jsdom layout/hover */}
+          <ContextMenuSub>
+            <ContextMenuSubTrigger>Copy as</ContextMenuSubTrigger>
+            <ContextMenuSubContent forceMount>
+              <ContextMenuItem>Surface form</ContextMenuItem>
+            </ContextMenuSubContent>
+          </ContextMenuSub>
+        </ContextMenuContent>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Tab header'));
+
+    const subContent = screen
+      .getAllByRole('menu', { hidden: true })
+      .find((menu) => menu.dataset.slot === 'context-menu-sub-content');
+    expect(subContent).toBeDefined();
+    expect(Number(subContent?.style.zIndex)).toBeGreaterThanOrEqual(Z_INDEX_ABOVE_DOCK);
+  });
+});

--- a/lib/platform-bible-react/src/components/shadcn-ui/context-menu.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/context-menu.tsx
@@ -3,6 +3,8 @@ import { ContextMenu as ContextMenuPrimitive } from 'radix-ui';
 
 import { cn } from '@/utils/shadcn-ui/utils';
 import { IconChevronRight, IconCheck } from '@tabler/icons-react';
+// CUSTOM: Import shared z-index constant to ensure context menus stack above the dock
+import { Z_INDEX_ABOVE_DOCK } from '@/components/z-index';
 
 /**
  * Context Menu component displays a menu to the user — such as a set of actions or functions,
@@ -54,6 +56,8 @@ function ContextMenuRadioGroup({
 /** @inheritdoc ContextMenu */
 function ContextMenuContent({
   className,
+  // CUSTOM: Destructure style so we can merge the shared z-index constant into it
+  style,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.Content> & {
   side?: 'top' | 'right' | 'bottom' | 'left';
@@ -65,9 +69,13 @@ function ContextMenuContent({
         className={cn(
           // CUSTOM: Added pr-twp to apply Platform.Bible's Tailwind CSS scope isolation
           // CUSTOM: Fixed tw: prefix not being on some classes and removed erroneous empty tw: tokens
-          'pr-twp tw:z-50 tw:max-h-(--radix-context-menu-content-available-height) tw:min-w-36 tw:origin-(--radix-context-menu-content-transform-origin) tw:overflow-x-hidden tw:overflow-y-auto tw:rounded-lg tw:bg-popover tw:p-1 tw:text-popover-foreground tw:shadow-md tw:ring-1 tw:ring-foreground/10 tw:duration-100 tw:data-[side=bottom]:slide-in-from-top-2 tw:data-[side=left]:slide-in-from-right-2 tw:data-[side=right]:slide-in-from-left-2 tw:data-[side=top]:slide-in-from-bottom-2 tw:data-open:animate-in tw:data-open:fade-in-0 tw:data-open:zoom-in-95 tw:data-closed:animate-out tw:data-closed:fade-out-0 tw:data-closed:zoom-out-95 tw:animate-none! tw:bg-popover/70 tw:before:-z-1 tw:**:data-[slot$=-item]:focus:bg-foreground/10 tw:**:data-[slot$=-item]:data-highlighted:bg-foreground/10 tw:**:data-[slot$=-separator]:bg-foreground/5 tw:**:data-[slot$=-trigger]:focus:bg-foreground/10 tw:**:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! tw:**:data-[variant=destructive]:focus:bg-foreground/10! tw:**:data-[variant=destructive]:text-accent-foreground! tw:**:data-[variant=destructive]:**:text-accent-foreground! tw:relative tw:before:pointer-events-none tw:before:absolute tw:before:inset-0 tw:before:rounded-[inherit] tw:before:backdrop-blur-2xl tw:before:backdrop-saturate-150',
+          // CUSTOM: Removed tw:z-50 to use the shared z-index constant below (see style prop)
+          'pr-twp tw:max-h-(--radix-context-menu-content-available-height) tw:min-w-36 tw:origin-(--radix-context-menu-content-transform-origin) tw:overflow-x-hidden tw:overflow-y-auto tw:rounded-lg tw:bg-popover tw:p-1 tw:text-popover-foreground tw:shadow-md tw:ring-1 tw:ring-foreground/10 tw:duration-100 tw:data-[side=bottom]:slide-in-from-top-2 tw:data-[side=left]:slide-in-from-right-2 tw:data-[side=right]:slide-in-from-left-2 tw:data-[side=top]:slide-in-from-bottom-2 tw:data-open:animate-in tw:data-open:fade-in-0 tw:data-open:zoom-in-95 tw:data-closed:animate-out tw:data-closed:fade-out-0 tw:data-closed:zoom-out-95 tw:animate-none! tw:bg-popover/70 tw:before:-z-1 tw:**:data-[slot$=-item]:focus:bg-foreground/10 tw:**:data-[slot$=-item]:data-highlighted:bg-foreground/10 tw:**:data-[slot$=-separator]:bg-foreground/5 tw:**:data-[slot$=-trigger]:focus:bg-foreground/10 tw:**:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! tw:**:data-[variant=destructive]:focus:bg-foreground/10! tw:**:data-[variant=destructive]:text-accent-foreground! tw:**:data-[variant=destructive]:**:text-accent-foreground! tw:relative tw:before:pointer-events-none tw:before:absolute tw:before:inset-0 tw:before:rounded-[inherit] tw:before:backdrop-blur-2xl tw:before:backdrop-saturate-150',
           className,
         )}
+        // CUSTOM: z-index uses shared constant instead of default tw:z-50, ensuring context menus
+        // (e.g. the tab header menu) render above rc-dock floating tab groups (PT-3877)
+        style={{ zIndex: Z_INDEX_ABOVE_DOCK, ...style }}
         {...props}
       />
     </ContextMenuPrimitive.Portal>
@@ -128,6 +136,8 @@ function ContextMenuSubTrigger({
 /** @inheritdoc ContextMenu */
 function ContextMenuSubContent({
   className,
+  // CUSTOM: Destructure style so we can merge the shared z-index constant into it
+  style,
   ...props
 }: React.ComponentProps<typeof ContextMenuPrimitive.SubContent>) {
   return (
@@ -136,9 +146,14 @@ function ContextMenuSubContent({
       className={cn(
         // CUSTOM: Added pr-twp to apply Platform.Bible's Tailwind CSS scope isolation
         // CUSTOM: Fixed tw: prefix not being on some classes and removed erroneous empty tw: tokens
-        'pr-twp tw:z-50 tw:min-w-32 tw:origin-(--radix-context-menu-content-transform-origin) tw:overflow-hidden tw:rounded-lg tw:border tw:bg-popover tw:p-1 tw:text-popover-foreground tw:shadow-lg tw:duration-100 tw:data-[side=bottom]:slide-in-from-top-2 tw:data-[side=left]:slide-in-from-right-2 tw:data-[side=right]:slide-in-from-left-2 tw:data-[side=top]:slide-in-from-bottom-2 tw:data-open:animate-in tw:data-open:fade-in-0 tw:data-open:zoom-in-95 tw:data-closed:animate-out tw:data-closed:fade-out-0 tw:data-closed:zoom-out-95 tw:animate-none! tw:bg-popover/70 tw:before:-z-1 tw:**:data-[slot$=-item]:focus:bg-foreground/10 tw:**:data-[slot$=-item]:data-highlighted:bg-foreground/10 tw:**:data-[slot$=-separator]:bg-foreground/5 tw:**:data-[slot$=-trigger]:focus:bg-foreground/10 tw:**:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! tw:**:data-[variant=destructive]:focus:bg-foreground/10! tw:**:data-[variant=destructive]:text-accent-foreground! tw:**:data-[variant=destructive]:**:text-accent-foreground! tw:relative tw:before:pointer-events-none tw:before:absolute tw:before:inset-0 tw:before:rounded-[inherit] tw:before:backdrop-blur-2xl tw:before:backdrop-saturate-150',
+        // CUSTOM: Removed tw:z-50 to use the shared z-index constant below (see style prop), keeping
+        // submenus on the same above-dock layer as their parent ContextMenuContent (PT-3877)
+        'pr-twp tw:min-w-32 tw:origin-(--radix-context-menu-content-transform-origin) tw:overflow-hidden tw:rounded-lg tw:border tw:bg-popover tw:p-1 tw:text-popover-foreground tw:shadow-lg tw:duration-100 tw:data-[side=bottom]:slide-in-from-top-2 tw:data-[side=left]:slide-in-from-right-2 tw:data-[side=right]:slide-in-from-left-2 tw:data-[side=top]:slide-in-from-bottom-2 tw:data-open:animate-in tw:data-open:fade-in-0 tw:data-open:zoom-in-95 tw:data-closed:animate-out tw:data-closed:fade-out-0 tw:data-closed:zoom-out-95 tw:animate-none! tw:bg-popover/70 tw:before:-z-1 tw:**:data-[slot$=-item]:focus:bg-foreground/10 tw:**:data-[slot$=-item]:data-highlighted:bg-foreground/10 tw:**:data-[slot$=-separator]:bg-foreground/5 tw:**:data-[slot$=-trigger]:focus:bg-foreground/10 tw:**:data-[slot$=-trigger]:aria-expanded:bg-foreground/10! tw:**:data-[variant=destructive]:focus:bg-foreground/10! tw:**:data-[variant=destructive]:text-accent-foreground! tw:**:data-[variant=destructive]:**:text-accent-foreground! tw:relative tw:before:pointer-events-none tw:before:absolute tw:before:inset-0 tw:before:rounded-[inherit] tw:before:backdrop-blur-2xl tw:before:backdrop-saturate-150',
         className,
       )}
+      // CUSTOM: z-index uses shared constant instead of default tw:z-50 so submenus also render
+      // above rc-dock floating tab groups, matching their parent ContextMenuContent (PT-3877)
+      style={{ zIndex: Z_INDEX_ABOVE_DOCK, ...style }}
       {...props}
     />
   );


### PR DESCRIPTION
## Summary

The tab header context menu ("Open as floating tab") rendered **behind** floating tab groups. The shadcn `ContextMenuContent` / `ContextMenuSubContent` used Tailwind `tw:z-50`, while rc-dock floating panels render at z-index ~200, so the menu was occluded.

Fix: replace `tw:z-50` with the shared `Z_INDEX_ABOVE_DOCK` constant via an inline `style` (caller `style` merged last), mirroring the existing **Popover** fix (`popover.tsx`). `ContextMenuSubContent` is fixed alongside `ContextMenuContent` so app submenus (e.g. the `platform-enhanced-resources` dictionary "Copy as" submenus) stay on the same above-dock layer instead of inverting under their raised parent.

Linked issue: **PT-3877** — "Tab header context menu hidden behind floating panel" (https://paratextstudio.atlassian.net/browse/PT-3877)

## Root cause

- `lib/platform-bible-react/src/components/shadcn-ui/context-menu.tsx`: `ContextMenuContent` and `ContextMenuSubContent` carried `tw:z-50`.
- rc-dock floating tab groups render at z-index ~200 (see `z-index.ts`: "rc-dock floating tabs manage their own z-index up to ~200").
- 50 < 200 → the menu portal renders behind the floating panel. Non-floating panels are in normal flow, so `z-50` sufficed there (why the bug only shows on floating tab groups).

The hamburger `TabDropdownMenu` already applies `Z_INDEX_ABOVE_DOCK` per-instance, and `popover.tsx` already fixed the same class for popovers — this brings context menus in line.

## Before / after evidence (regression test)

A new regression test guards the fix — it fails before and passes after.

**Before (RED):**
```
× ContextMenuContent > renders with a z-index above the dock so floating tab groups cannot occlude it
  → expected 0 to be greater than or equal to 600
 Tests  1 failed (1)
```

**After (GREEN):**
```
✓ src/components/shadcn-ui/context-menu.test.tsx (2 tests)
 Tests  2 passed (2)
```

Full PBR unit suite: **218 passed** (no regressions). Package `typecheck` and `eslint` on the changed files are clean.

## Self-review summary

Ran scope / clarity / tests reviewers on the diff — **no blocking findings**:
- **Scope**: minimal and on-target; both Content + SubContent justified (submenus would otherwise invert/occlude under their raised parent); sibling primitives (`dropdown-menu.tsx`, `menubar.tsx`) correctly left untouched.
- **Clarity**: faithful mirror of the `popover.tsx` precedent; every changed line carries the required `// CUSTOM:` marker; no dead code.
- **Tests**: falsifiable (verified via revert test), behavior-focused (asserts the "above the dock" stacking contract, not a hardcoded value), no over-mocking (only jsdom env polyfills).

## Impact + confidence

- **Impact**: user-visible — a user with a floating tab group who right-clicks the tab header sees the context menu occluded by the panel; also pre-empts the same occlusion for dictionary context submenus. Severity moderate (action obscured; workaround = non-floating tab), frequency moderate (floating tab groups only).
- **Confidence**: high (~0.85). Deterministic CSS-stacking root cause confirmed in code; fix mirrors an established, already-shipped precedent (`popover.tsx`) using the same shared constant; low regression risk (600 sits above modal 500 / tooltip 550, matching popover).

## Provenance

Found and fixed by the automated **quality-sweep** run (`qs-2026-06-29`), seeded from open Jira bugs.

AI-assisted — generated by Claude Code (quality-sweep).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2471)
<!-- Reviewable:end -->
