### PR TITLE
PT-3086: render non-functional commentary link markers as plain text

### DIFF
--- a/extensions/src/platform-scripture-editor/src/marker-styles/commentary-overrides.scss
+++ b/extensions/src/platform-scripture-editor/src/marker-styles/commentary-overrides.scss
@@ -1,0 +1,27 @@
+/* Hand-authored overrides for the commentary marker stylesheets — NOT generated.
+ *
+ * Stopgap (PT-3086): the editor does not yet wire up navigation for commentary
+ * link markers, so `\jmp` (glossary / internal section jumps) and `\xtSee` /
+ * `\xtSeeAlso` (cross-reference "See …" links) render as clickable-looking links
+ * that do nothing when clicked. Until real jump navigation lands, render them as
+ * plain prose so users are not misled into clicking dead links.
+ *
+ * This file is imported `?inline` and appended AFTER the generated commentary
+ * stylesheet in use-commentary-marker-styles.hook.ts. Equal specificity + later
+ * source order means these rules win the cascade, and keeping them here (rather
+ * than editing the generated `hbkeng/tnn/tnd.scss`) means they survive every
+ * regeneration of those files by the CSS→SCSS pipeline.
+ *
+ * Scope: matches the `.formatted-font .usfm_<marker>` selectors the generated
+ * sheets emit for these markers, so the link appearance (color, weight, style,
+ * underline) is neutralized to look like the surrounding body text.
+ */
+.formatted-font .usfm_jmp,
+.formatted-font .usfm_xtSee,
+.formatted-font .usfm_xtSeeAlso {
+  color: inherit;
+  font-style: normal;
+  font-weight: normal;
+  text-decoration: none;
+  cursor: default;
+}

--- a/extensions/src/platform-scripture-editor/src/use-commentary-marker-styles.hook.test.ts
+++ b/extensions/src/platform-scripture-editor/src/use-commentary-marker-styles.hook.test.ts
@@ -10,12 +10,19 @@ import { useCommentaryMarkerStyles } from './use-commentary-marker-styles.hook';
 vi.mock('./marker-styles/hbkeng.scss?inline', () => ({ default: 'HBKENG_CSS' }));
 vi.mock('./marker-styles/tnn.scss?inline', () => ({ default: 'TNN_CSS' }));
 vi.mock('./marker-styles/tnd.scss?inline', () => ({ default: 'TND_CSS' }));
+// Hand-authored override appended after the generated commentary stylesheet (disabled-link stopgap).
+vi.mock('./marker-styles/commentary-overrides.scss?inline', () => ({ default: 'OVERRIDES_CSS' }));
 
 vi.mock('platform-bible-react', () => ({
   useStylesheet: vi.fn(),
 }));
 
 const mockUseStylesheet = vi.mocked(useStylesheet);
+
+/** The single string argument most recently passed to `useStylesheet`. */
+function lastStylesheet(): string | undefined {
+  return mockUseStylesheet.mock.lastCall?.[0];
+}
 
 // DBL entry UIDs — must match the keys in use-commentary-marker-styles.hook.ts and the C#
 // `CommentariesWhiteList` in DblResourcesDataProvider.cs.
@@ -34,23 +41,40 @@ describe('useCommentaryMarkerStyles', () => {
     ['TND', `${TND_UID}_local-suffix`, 'TND_CSS'],
   ])(
     'applies %s styles when projectId is prefixed by its DBL UID',
-    (_label, projectId, expected) => {
+    (_label, projectId, expectedCss) => {
       renderHook(() => useCommentaryMarkerStyles(projectId));
-      expect(mockUseStylesheet).toHaveBeenLastCalledWith(expected);
+      expect(lastStylesheet()).toContain(expectedCss);
+    },
+  );
+
+  it.each([
+    ['HBKENG', `${HBKENG_UID}_local-suffix`],
+    ['TNN', `${TNN_UID}_local-suffix`],
+    ['TND', `${TND_UID}_local-suffix`],
+  ])(
+    'appends the disabled-link override after the %s stylesheet so it wins the cascade',
+    (label, projectId) => {
+      renderHook(() => useCommentaryMarkerStyles(projectId));
+      const sheet = lastStylesheet() ?? '';
+      const generatedCss = `${label}_CSS`;
+      expect(sheet).toContain('OVERRIDES_CSS');
+      // The override must come AFTER the generated CSS — equal specificity, later source order wins.
+      expect(sheet.indexOf('OVERRIDES_CSS')).toBeGreaterThan(sheet.indexOf(generatedCss));
     },
   );
 
   it('matches DBL UID case-insensitively', () => {
     renderHook(() => useCommentaryMarkerStyles(`${HBKENG_UID.toUpperCase()}_LOCAL-SUFFIX`));
-    expect(mockUseStylesheet).toHaveBeenLastCalledWith('HBKENG_CSS');
+    expect(lastStylesheet()).toContain('HBKENG_CSS');
   });
 
   it.each<[string, string | undefined]>([
     ['undefined', undefined],
     ['empty string', ''],
     ['unrelated project id', 'some-other-project-id-1234567890abcdef'],
-  ])('applies no stylesheet when projectId is %s', (_label, projectId) => {
+  ])('applies no stylesheet (and no override) when projectId is %s', (_label, projectId) => {
     renderHook(() => useCommentaryMarkerStyles(projectId));
+    // No commentary matched, so nothing is injected — not even the override.
     expect(mockUseStylesheet).toHaveBeenLastCalledWith(undefined);
   });
 
@@ -60,10 +84,10 @@ describe('useCommentaryMarkerStyles', () => {
       ({ projectId }: { projectId: string | undefined }) => useCommentaryMarkerStyles(projectId),
       { initialProps },
     );
-    expect(mockUseStylesheet).toHaveBeenLastCalledWith('HBKENG_CSS');
+    expect(lastStylesheet()).toContain('HBKENG_CSS');
 
     rerender({ projectId: `${TNN_UID}_b` });
-    expect(mockUseStylesheet).toHaveBeenLastCalledWith('TNN_CSS');
+    expect(lastStylesheet()).toContain('TNN_CSS');
 
     rerender({ projectId: 'unrelated-project-id' });
     expect(mockUseStylesheet).toHaveBeenLastCalledWith(undefined);

--- a/extensions/src/platform-scripture-editor/src/use-commentary-marker-styles.hook.ts
+++ b/extensions/src/platform-scripture-editor/src/use-commentary-marker-styles.hook.ts
@@ -2,6 +2,7 @@ import { useStylesheet } from 'platform-bible-react';
 import hbkengStyles from './marker-styles/hbkeng.scss?inline';
 import tnnStyles from './marker-styles/tnn.scss?inline';
 import tndStyles from './marker-styles/tnd.scss?inline';
+import commentaryOverrides from './marker-styles/commentary-overrides.scss?inline';
 
 // Keyed on DBL entry UID (lowercase). A locally-installed DBL resource's projectId is the
 // dblEntryUid plus a suffix, so we match by `startsWith`. The same UIDs back the C#
@@ -40,5 +41,8 @@ export function useCommentaryMarkerStyles(projectId: string | undefined): void {
   );
   const css = matchedUid ? COMMENTARY_STYLES_BY_DBL_ENTRY_UID[matchedUid] : undefined;
 
-  useStylesheet(css);
+  // Append hand-authored overrides AFTER the generated stylesheet so they win the cascade (equal
+  // specificity, later source order) and survive regeneration of the generated SCSS. Only injected
+  // when a commentary actually matched, so it never leaks into other projects/resources.
+  useStylesheet(css ? `${css}\n${commentaryOverrides}` : undefined);
 }


### PR DESCRIPTION
## Summary

Stopgap for the commentaries (HBKENG / TNN / TND): the editor does not yet wire up navigation for commentary **link markers**, so they render as clickable-looking links that do nothing when clicked — e.g. a `\jmp` glossary link (`See kingdom of heaven in the Glossary…`) or a cross-reference like `See 3.6` that should jump to §3.6 but doesn't.

Until real jump navigation lands (a larger follow-up), this neutralizes their link *appearance* so users aren't misled into clicking dead links. Pure styling — no behavior change.

## Changes

- **New** `extensions/src/platform-scripture-editor/src/marker-styles/commentary-overrides.scss` (hand-authored, **not** generated) — neutralizes the link look for `\jmp`, `\xtSee`, `\xtSeeAlso`:
  ```scss
  .formatted-font .usfm_jmp,
  .formatted-font .usfm_xtSee,
  .formatted-font .usfm_xtSeeAlso {
    color: inherit; font-style: normal; font-weight: normal;
    text-decoration: none; cursor: default;
  }
  ```
- **Edit** `use-commentary-marker-styles.hook.ts` — import the override `?inline` and append it **after** the matched commentary stylesheet in the single `useStylesheet(...)` call.
- **Tests** updated/added in `use-commentary-marker-styles.hook.test.ts`.

## Why this layer (not the generated SCSS)

The per-commentary `hbkeng/tnn/tnd.scss` are **generated** (carry a `do not edit by hand` header) and are overwritten every time the CSS→SCSS pipeline runs. Editing them would mean re-applying the change on every regeneration and maintaining it in parallel with the audit/regen PR (#2474).

Instead the override lives in a hand-maintained sheet appended **after** the generated CSS in the same injected `<style>` string. Equal specificity + later source order → the override wins the cascade, and it **survives regeneration**. It's only injected when a commentary `projectId` matches, so the project editor and other resources are unaffected (per-iframe scoping is preserved).

This also makes the change **independent of #2474** — it applies the same whether the commentary SCSS is the hand-rolled MVP version or the pipeline-regenerated version.

## Scope / what this is NOT

- Does **not** make the links work — `\jmp` / cross-reference navigation is a separate, larger follow-up (tracked separately under PT-3086).
- Touches only the three commentaries (HBKENG, TNN, TND); no global change to `\jmp` elsewhere.

## Testing

- [x] TDD: added failing tests (override appended after each commentary sheet; nothing injected when no commentary matches), watched them fail, then implemented to green. **11/11 pass.**
- [x] Prettier clean; type-aware ESLint clean on changed files.
- [ ] **Visual check (operator, PT9-style):** in HBKENG/TNN/TND, `\jmp` and `See …` cross-references now render as plain body text (no blue/underline/italic link styling); other markers unchanged; project editor + non-commentary resources unchanged.

## AI Involvement

AI-assisted. Claude wrote the tests, the override stylesheet, and the hook change (test-first), and ran lint/format/tests. The human developer identified the broken-link behavior, chose the disabled appearance and marker scope, and performs the visual verification. Human is the author.

## Risk Level

**Low** — additive CSS override scoped to three commentaries, injected only when one is displayed; covered by unit tests; trivially revertable when real navigation lands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2477)
<!-- Reviewable:end -->
