### PR TITLE
fix(scripture-editor): hide insert menus for read-only editor (PT-3880)

### DIFF
--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -1,13 +1,15 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ScriptureRange } from 'platform-scripture-editor';
 import type PapiBackend from '@papi/backend';
-import { UsjTextContentLocation } from 'platform-bible-utils';
+import { Localized, MultiColumnMenu, UsjTextContentLocation } from 'platform-bible-utils';
 import { MutableRefObject } from 'react';
 import { EditorRef } from '@eten-tech-foundation/platform-editor';
 import {
   convertScriptureRangeToEditorRange,
-  generateParagraphMenuListItems,
+  EDITOR_INSERT_AT_SELECTION_COMMANDS,
+  filterTopMenuForReadOnly,
   generateInlineMarkerMenuListItems,
+  generateParagraphMenuListItems,
   openDefaultActiveProjectIfApplicable,
   resolveOpenEditorDispatch,
   syncOnProjectSwitch,
@@ -2442,3 +2444,165 @@ describe('generateInlineMarkerMenuListItems', () => {
     expect(generateInlineMarkerMenuListItems(ref, noop, {}, false, vi.fn())).toEqual([]);
   });
 });
+
+// #region filterTopMenuForReadOnly
+
+/**
+ * A localized top menu that mirrors the real Scripture editor menu structure: an "Insert" column
+ * whose only group holds the three insert-at-selection items, plus an unrelated "Edit" column.
+ */
+function makeSampleTopMenu(): Localized<MultiColumnMenu> {
+  return {
+    columns: {
+      'platformScriptureEditor.edit': { label: 'Edit', order: 2, isExtensible: true },
+      'platformScriptureEditor.insert': { label: 'Insert', order: 5 },
+    },
+    groups: {
+      'platformScriptureEditor.find': { column: 'platformScriptureEditor.edit', order: 1 },
+      'platformScriptureEditor.insertTextualNotes': {
+        column: 'platformScriptureEditor.insert',
+        order: 1,
+      },
+    },
+    items: [
+      {
+        label: 'Find',
+        group: 'platformScriptureEditor.find',
+        order: 1,
+        command: 'platformScripture.openFind',
+        localizeNotes: '',
+      },
+      {
+        label: 'Insert footnote',
+        group: 'platformScriptureEditor.insertTextualNotes',
+        order: 1,
+        command: 'platformScriptureEditor.insertFootnoteAtSelection',
+        localizeNotes: '',
+      },
+      {
+        label: 'Insert cross-reference',
+        group: 'platformScriptureEditor.insertTextualNotes',
+        order: 2,
+        command: 'platformScriptureEditor.insertCrossReferenceAtSelection',
+        localizeNotes: '',
+      },
+      {
+        label: 'Insert comment',
+        group: 'platformScriptureEditor.insertTextualNotes',
+        order: 3,
+        command: 'platformScriptureEditor.insertCommentAtSelection',
+        localizeNotes: '',
+      },
+    ],
+  };
+}
+
+describe('filterTopMenuForReadOnly', () => {
+  it('removes the insert-at-selection items when read-only so resources are not editable via menus', () => {
+    const result = filterTopMenuForReadOnly(makeSampleTopMenu(), true);
+
+    const commands = result?.items.flatMap((item) => ('command' in item ? [item.command] : []));
+    EDITOR_INSERT_AT_SELECTION_COMMANDS.forEach((command) => {
+      expect(commands).not.toContain(command);
+    });
+    // The unrelated item is left intact.
+    expect(commands).toContain('platformScripture.openFind');
+  });
+
+  it('prunes the menu group and column left empty by the removal when read-only', () => {
+    const result = filterTopMenuForReadOnly(makeSampleTopMenu(), true);
+
+    expect(result?.groups).not.toHaveProperty('platformScriptureEditor.insertTextualNotes');
+    expect(result?.columns).not.toHaveProperty('platformScriptureEditor.insert');
+    // The unrelated group and column remain (with their fields intact) so the rest of the menu is
+    // unaffected.
+    expect(result?.groups).toHaveProperty('platformScriptureEditor.find');
+    expect(result?.columns['platformScriptureEditor.edit']).toEqual(
+      makeSampleTopMenu().columns['platformScriptureEditor.edit'],
+    );
+  });
+
+  it('keeps a column that still has a non-empty group after the removal', () => {
+    // Give the "Insert" column a second, non-insert group. Removing the insert items empties only
+    // the insertTextualNotes group, so the column and its surviving group must remain.
+    const menu = makeSampleTopMenu();
+    menu.groups['platformScriptureEditor.insertOther'] = {
+      column: 'platformScriptureEditor.insert',
+      order: 2,
+    };
+    menu.items.push({
+      label: 'Insert something else',
+      group: 'platformScriptureEditor.insertOther',
+      order: 1,
+      command: 'platformScriptureEditor.insertSomethingElse',
+      localizeNotes: '',
+    });
+
+    const result = filterTopMenuForReadOnly(menu, true);
+
+    expect(result?.columns).toHaveProperty('platformScriptureEditor.insert');
+    expect(result?.groups).toHaveProperty('platformScriptureEditor.insertOther');
+    expect(result?.groups).not.toHaveProperty('platformScriptureEditor.insertTextualNotes');
+    const commands = result?.items.flatMap((item) => ('command' in item ? [item.command] : []));
+    expect(commands).toContain('platformScriptureEditor.insertSomethingElse');
+    expect(commands).not.toContain('platformScriptureEditor.insertFootnoteAtSelection');
+  });
+
+  it('never removes a submenu item that has an id instead of a command', () => {
+    const menu = makeSampleTopMenu();
+    menu.items.push({
+      label: 'A submenu',
+      group: 'platformScriptureEditor.find',
+      order: 2,
+      id: 'platformScriptureEditor.someSubmenu',
+      localizeNotes: '',
+    });
+
+    const ids = (candidate: Localized<MultiColumnMenu> | undefined) =>
+      candidate?.items.flatMap((item) => ('id' in item ? [item.id] : []));
+
+    // Survives whether or not insert items are removed.
+    expect(ids(filterTopMenuForReadOnly(menu, true))).toContain(
+      'platformScriptureEditor.someSubmenu',
+    );
+    expect(ids(filterTopMenuForReadOnly(menu, false))).toContain(
+      'platformScriptureEditor.someSubmenu',
+    );
+  });
+
+  it('returns the menu unchanged when the editor is editable', () => {
+    const menu = makeSampleTopMenu();
+
+    const result = filterTopMenuForReadOnly(menu, false);
+
+    expect(result).toBe(menu);
+  });
+
+  it('returns undefined when there is no menu', () => {
+    expect(filterTopMenuForReadOnly(undefined, true)).toBeUndefined();
+  });
+
+  it('returns the menu unchanged when read-only but there are no insert items to remove', () => {
+    const menu: Localized<MultiColumnMenu> = {
+      columns: { 'platformScriptureEditor.edit': { label: 'Edit', order: 2 } },
+      groups: {
+        'platformScriptureEditor.find': { column: 'platformScriptureEditor.edit', order: 1 },
+      },
+      items: [
+        {
+          label: 'Find',
+          group: 'platformScriptureEditor.find',
+          order: 1,
+          command: 'platformScripture.openFind',
+          localizeNotes: '',
+        },
+      ],
+    };
+
+    const result = filterTopMenuForReadOnly(menu, true);
+
+    expect(result).toBe(menu);
+  });
+});
+
+// #endregion filterTopMenuForReadOnly

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -11,7 +11,9 @@ import {
   isLocalizeKey,
   isPlatformError,
   LanguageStrings,
+  Localized,
   LocalizeKey,
+  MultiColumnMenu,
   serialize,
   Unsubscriber,
   USFM_MARKERS_MAP_PARATEXT_3_0,
@@ -28,6 +30,68 @@ import { MarkerMenuItem } from 'platform-bible-react';
 
 // Note: src/main/shutdown-tasks.ts has a copy of this value — keep them in sync.
 export const SCRIPTURE_EDITOR_WEBVIEW_TYPE = 'platformScriptureEditor.react';
+
+/**
+ * PAPI commands that insert editable content (footnote, cross-reference, comment) into the
+ * Scripture editor at the current selection. These actions are meaningless when the editor is not
+ * editable (e.g. when viewing a resource, or in a non-editable markers view), so the menu items
+ * that run them are hidden in that case. See PT-3880.
+ */
+export const EDITOR_INSERT_AT_SELECTION_COMMANDS: readonly string[] = [
+  'platformScriptureEditor.insertFootnoteAtSelection',
+  'platformScriptureEditor.insertCrossReferenceAtSelection',
+  'platformScriptureEditor.insertCommentAtSelection',
+];
+
+/**
+ * Returns the Scripture editor's top menu adjusted for the editor's editability. When the editor is
+ * not editable (e.g. a resource, or a non-editable markers view), the insert-footnote/
+ * cross-reference/comment items are removed so non-editable content cannot be edited via the menus,
+ * and any menu group or column left empty by that removal is pruned so no empty menu remains. When
+ * the editor is editable, the menu is returned unchanged. See PT-3880.
+ *
+ * @param topMenu The localized top menu to adjust, or `undefined`.
+ * @param isReadOnly Whether the editor is (effectively) read-only/non-editable.
+ * @returns The adjusted menu, or `undefined` if `topMenu` was `undefined`.
+ */
+export function filterTopMenuForReadOnly(
+  topMenu: Localized<MultiColumnMenu> | undefined,
+  isReadOnly: boolean,
+): Localized<MultiColumnMenu> | undefined {
+  if (!topMenu || !isReadOnly) return topMenu;
+
+  const insertCommands = new Set<string>(EDITOR_INSERT_AT_SELECTION_COMMANDS);
+  const items = topMenu.items.filter(
+    (item) => !('command' in item) || !insertCommands.has(item.command),
+  );
+  // Nothing was removed; return the menu unchanged.
+  if (items.length === topMenu.items.length) return topMenu;
+
+  // Prune any group the removal left without items, tracking the columns those groups belonged to.
+  // `Reflect.deleteProperty` is used (rather than `delete groups[key]`) because the menu's group and
+  // column collections use template-literal index signatures that a plain `string` key cannot index.
+  const survivingGroupKeys = new Set(items.map((item) => item.group));
+  const emptiedColumnKeys = new Set<string>();
+  const groups = { ...topMenu.groups };
+  Object.entries(topMenu.groups).forEach(([groupKey, group]) => {
+    if (survivingGroupKeys.has(groupKey)) return;
+    if ('column' in group && group.column) emptiedColumnKeys.add(group.column);
+    Reflect.deleteProperty(groups, groupKey);
+  });
+
+  // Prune any column that the group removal left without any groups, so no empty column remains.
+  const survivingColumnKeys = new Set(
+    Object.values(groups)
+      .map((group) => ('column' in group ? group.column : undefined))
+      .filter((columnKey): columnKey is string => columnKey !== undefined),
+  );
+  const columns = { ...topMenu.columns };
+  emptiedColumnKeys.forEach((columnKey) => {
+    if (!survivingColumnKeys.has(columnKey)) Reflect.deleteProperty(columns, columnKey);
+  });
+
+  return { ...topMenu, columns, groups, items };
+}
 
 /**
  * Check deep equality of two values such that two equal objects or arrays created in two different

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -106,6 +106,7 @@ import {
   availableScrollGroupIds,
   blockMarkerToBlockNames,
   deepEqualAcrossIframes,
+  filterTopMenuForReadOnly,
   formatEditorTitle,
   generateInlineMarkerMenuListItems,
   generateParagraphMenuListItems,
@@ -1649,6 +1650,14 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
     return webViewMenuPossiblyError;
   }, [webViewMenuPossiblyError]);
 
+  // When the editor is not editable (a resource, or a non-editable markers view), hide the
+  // insert-footnote/cross-reference/comment menu items so non-editable content cannot be edited via
+  // the menus (PT-3880).
+  const effectiveTopMenu = useMemo(
+    () => filterTopMenuForReadOnly(webViewMenu.topMenu, isReadOnlyEffective),
+    [webViewMenu, isReadOnlyEffective],
+  );
+
   const [booksPresentPossiblyError] = useProjectSetting(
     projectId,
     'platformScripture.booksPresent',
@@ -1771,7 +1780,7 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
       <TabToolbar
         onSelectProjectMenuItem={menuCommandHandler}
         onSelectViewInfoMenuItem={menuCommandHandler}
-        projectMenuData={webViewMenu.topMenu}
+        projectMenuData={effectiveTopMenu}
         className="scripture-editor-tab-nav tw:block tw:z-10"
         startAreaChildren={
           <>


### PR DESCRIPTION
## Summary

Fixes **[PT-3880](https://paratextstudio.atlassian.net/browse/PT-3880)** — "Resources should not be editable using the menus to insert FT/Comments."

The Scripture editor and the read-only resource viewer are the **same** web view (`platformScriptureEditor.react`) opened in read-only mode (`main.ts` uses `isReadOnly ? 'resourceViewer' : 'scriptureEditor'`). Its top menu — loaded for that one web view type — contributes **Insert footnote / Insert cross-reference / Insert comment** items. They were shown even when the editor is read-only (i.e. when viewing a resource), so resources could be edited via the menus.

### Fix

A small pure helper `filterTopMenuForReadOnly(topMenu, isReadOnly)` in `platform-scripture-editor.utils.ts`:

- When the editor is read-only, removes the three insert-at-selection command items from the localized `MultiColumnMenu`.
- Prunes any menu **group** left without items and any **column** left without groups, so no empty "Insert" menu button remains (`PlatformMenubar` renders one button per column unconditionally).
- Returns the menu unchanged when the editor is editable, or when there is nothing to remove.

The web view applies it (memoized) gated on `isReadOnlyEffective` — the same signal that already drives the editor's own `isReadonly` prop and the hiding of the Undo/Redo buttons — so the insert menus are hidden whenever the editor cannot be edited (resources, and non-editable markers view), and remain available for editable projects (including editable markers view via the `dev-editableMarkersView` flag).

### Scope

Minimal and targeted at the reported surface (the menus). The insert commands have no keyboard bindings and the editor is independently read-only for resources, so hiding the menu items is the complete user-facing fix.

## Reproduction evidence (before → after)

This is a TS-logic defect; reproduced with a RED regression test, then made GREEN by the fix.

**BEFORE (filtering reverted to identity — demonstrates the bug):**

```
 × filterTopMenuForReadOnly > removes the insert-at-selection items when read-only so resources are not editable via menus
   → expected [ 'platformScripture.openFind', …(3) ] to not include 'platformScriptureEditor.insertFootnoteAtSelection'
 × filterTopMenuForReadOnly > prunes the menu group and column left empty by the removal when read-only
   → expected { …(2) } to not have property "platformScriptureEditor.insertTextualNotes"

 Tests  2 failed | 3 passed (5)
```

**AFTER (fix applied):**

```
 ✓ filterTopMenuForReadOnly (5 tests)
 Test Files  1 passed (1)
      Tests  90 passed (90)   // full platform-scripture-editor.utils.test.ts
```

Full extension suite: **187 passed (8 files)**. `npm run typecheck` and workspace ESLint are clean.

## Self-review

- No scope creep: a single pure helper + 3-line wiring in the web view + tests.
- Minimal diff; no opportunistic refactors.
- Regression test is present and meaningful (fails before the fix, passes after; asserts behavior — items removed, emptied group/column pruned, other columns/groups/items preserved, identity when editable / when nothing to remove).

## Impact & confidence

User-visible correctness bug (resources exposed editing actions they should not). Severity moderate, in-scope and localized. Confidence high — root cause and fix fully contained in paranext-core with deterministic test coverage.

---

_Found by the automated quality-sweep run (qs-2026-06-30)._

AI-assisted — generated by an automated Claude Code quality-sweep session.


[PT-3880]: https://paratextstudio.atlassian.net/browse/PT-3880?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2479)
<!-- Reviewable:end -->
