### PR TITLE
fix(utils): round formatTimeSpan seconds to nearest instead of flooring

### DIFF
--- a/lib/platform-bible-utils/src/date-time-format-util.test.ts
+++ b/lib/platform-bible-utils/src/date-time-format-util.test.ts
@@ -1,0 +1,49 @@
+import { formatTimeSpan } from './date-time-format-util';
+
+const MS_PER_SECOND = 1000;
+const MS_PER_MINUTE = 60 * MS_PER_SECOND;
+const MS_PER_DAY = 24 * 60 * MS_PER_MINUTE;
+
+/** Fixed reference "now" so the tests never depend on the real clock. */
+const to = new Date('2024-08-03T08:00:00.000Z');
+const rtf = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+describe('formatTimeSpan', () => {
+  it('reports a sub-second-past span as "now", not "1 second ago"', () => {
+    // Any past event less than a full second ago should round to 0 seconds ("now"),
+    // matching the behavior for a sub-second future event.
+    const since = new Date(to.getTime() - 1); // 1 ms ago
+    expect(formatTimeSpan(rtf, since, to)).toBe(rtf.format(0, 'second'));
+  });
+
+  it('rounds elapsed seconds to nearest rather than always rounding away from zero', () => {
+    // 1.4 s ago should round to 1 second ago, not 2.
+    const since = new Date(to.getTime() - 1400);
+    expect(formatTimeSpan(rtf, since, to)).toBe(rtf.format(-1, 'second'));
+  });
+
+  it('formats a whole-second past span correctly', () => {
+    const since = new Date(to.getTime() - 3 * MS_PER_SECOND);
+    expect(formatTimeSpan(rtf, since, to)).toBe(rtf.format(-3, 'second'));
+  });
+
+  it('formats a minutes-ago span correctly', () => {
+    const since = new Date(to.getTime() - 5 * MS_PER_MINUTE);
+    expect(formatTimeSpan(rtf, since, to)).toBe(rtf.format(-5, 'minute'));
+  });
+
+  it('formats an hours-ago span correctly', () => {
+    const since = new Date(to.getTime() - 3 * 60 * MS_PER_MINUTE);
+    expect(formatTimeSpan(rtf, since, to)).toBe(rtf.format(-3, 'hour'));
+  });
+
+  it('formats a multi-day-ago span correctly', () => {
+    const since = new Date(to.getTime() - 2 * MS_PER_DAY);
+    expect(formatTimeSpan(rtf, since, to)).toBe(rtf.format(-2, 'day'));
+  });
+
+  it('formats a sub-second future span as "now"', () => {
+    const since = new Date(to.getTime() + 1);
+    expect(formatTimeSpan(rtf, since, to)).toBe(rtf.format(0, 'second'));
+  });
+});

--- a/lib/platform-bible-utils/src/date-time-format-util.ts
+++ b/lib/platform-bible-utils/src/date-time-format-util.ts
@@ -23,7 +23,10 @@ export function formatTimeSpan(
   since: Date,
   to = new Date(),
 ) {
-  const spanSeconds = Math.floor((since.getTime() - to.getTime()) / MILLISECONDS_PER_SECOND);
+  // Round to the nearest second (consistent with the day/hour/minute buckets below). Using
+  // Math.floor here rounded negative spans away from zero, so a sub-second-past timestamp reported
+  // "1 second ago" instead of "now" and elapsed seconds were over-reported by up to one second.
+  const spanSeconds = Math.round((since.getTime() - to.getTime()) / MILLISECONDS_PER_SECOND);
 
   const totalDays = Math.round(spanSeconds / SECONDS_PER_DAY);
   if (Math.abs(totalDays) >= 1) return relativeTimeFormatter.format(totalDays, 'day');


### PR DESCRIPTION
## Summary

`formatTimeSpan` computed `spanSeconds` with `Math.floor`, which rounds a **negative** span away from zero. Since the primary usage passes a **past** `since` against `to = now`, the raw difference is negative, so:

- a sub-second-past timestamp produced `spanSeconds = -1` → **"1 second ago"** instead of **"now"**, and
- elapsed seconds were over-reported by up to one second (e.g. 1.4 s ago rendered as "2 seconds ago").

The day/hour/minute buckets already use `Math.round`; the seconds computation was the lone `Math.floor`. Fix: use `Math.round`, making the seconds bucket consistent and symmetric.

Real call site: `extensions/src/platform-get-resources/src/home.component.tsx:558` renders a project's last send/receive time, so a just-synced project showed "1 second ago" instead of "now".

## Before / after (regression test)

New `date-time-format-util.test.ts` (the function had no test file). Deterministic — passes an explicit `to`, and compares against the formatter's own output so it is locale-robust.

**Before the fix (RED):**
```
FAIL  formatTimeSpan > reports a sub-second-past span as "now", not "1 second ago"
  expected '1 second ago' to be 'now'
FAIL  formatTimeSpan > rounds elapsed seconds to nearest rather than always rounding away from zero
  expected '2 seconds ago' to be '1 second ago'
Tests  2 failed | 5 passed (7)
```

**After the fix (GREEN):**
```
✓ src/date-time-format-util.test.ts (7 tests)
Test Files  1 passed (1)
      Tests  7 passed (7)
```

Full `platform-bible-utils` suite: **371 passed** (25 files). Package lint + typecheck clean.

## Self-review

- Minimal diff: one operator change (`Math.floor` → `Math.round`) plus an explanatory comment and a new test file. No unrelated changes.
- No caller depends on the old truncation for logic — the only consumer displays the string.
- `Math.round` is the correct, consistent choice (matches the existing day/hour/minute buckets) and is strictly more accurate; verified across boundary inputs (sub-second, half-second, whole-second, minute/hour/day).

## Impact + confidence

- **Impact:** user-visible but low-severity (relative-time label off by up to one second / "1 second ago" instead of "now" on the Home screen just after a send/receive). userVisible=1, severity 1, frequency 2.
- **Confidence:** high (0.9) — verified by reading the source, an independent boundary trace, and a fails-before/passes-after regression test.

## Provenance

Found by the automated daily quality-sweep (cold-scan fallback over `lib/platform-bible-utils`) after the Jira bug pool yielded no minimally-fixable defect this run.

---
AI-assisted — this fix was found and implemented by an automated quality-sweep agent (Claude).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2483)
<!-- Reviewable:end -->
