### PR TITLE
Fix flaky useProjectPickerData hook test via deterministic settling

### DIFF
--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -1,8 +1,8 @@
-import { renderHook, waitFor, act, configure, getConfig } from '@testing-library/react';
+import { renderHook, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { EVENT_NAME_ON_DID_UPDATE_WEB_VIEW } from '@shared/services/web-view.service-model';
-import { useProjectPickerData } from './use-project-picker-data.hook';
+import { useProjectPickerData, type ProjectPickerData } from './use-project-picker-data.hook';
 
 // --- Mocks ---
 
@@ -56,10 +56,13 @@ vi.mock('@shared/services/project-data-provider.service', () => ({
 
 const EDITOR_WEB_VIEW_TYPE = 'platformScriptureEditor.react';
 
-// Stable reference across renders so rawRecentIds keeps the same array identity, preventing
+// Stable references across renders so rawRecentIds keeps the same array identity, preventing
 // useMemo from recomputing safeRecentIds every render which would recreate the useCallback
-// and trigger an infinite reload loop in usePromise.
+// and trigger an infinite reload loop in usePromise. This mirrors production, where useData
+// returns referentially-stable React state; a fresh array literal per render does not.
 const DEFAULT_RECENT_IDS: string[] = [];
+const RECENT_IDS_R1_R2: string[] = ['proj-r1', 'proj-r2'];
+const RECENT_IDS_R1: string[] = ['proj-r1'];
 
 async function importMocks() {
   const { getNetworkEvent } = await import('@shared/services/network.service');
@@ -78,26 +81,33 @@ async function importMocks() {
   };
 }
 
+/**
+ * Deterministically settle the hook's mocked async work. usePromise resolves purely through
+ * microtasks (no timers, polling, or retries), so draining the microtask queue inside act() drives
+ * the hook to completion regardless of CPU speed. This replaces RTL's waitFor, whose wall-clock
+ * deadline flaked on CPU-starved CI runners even though the underlying resolution order is fully
+ * deterministic. The iteration cap is a safety net against a genuine hang, not a tuned timeout - if
+ * it is ever hit, the follow-up assertions fail loudly rather than the whole test timing out.
+ */
+async function settle(result: { current: ProjectPickerData }) {
+  for (let i = 0; i < 20 && result.current.isLoading; i += 1) {
+    // Each turn must run sequentially so React commits the resulting state before the next check
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => {
+      await Promise.resolve();
+    });
+  }
+}
+
 // --- Tests ---
 
 // vitest mocks use as-never to coerce partial objects to the full inferred return type
 /* eslint-disable no-type-assertion/no-type-assertion */
 describe('useProjectPickerData', () => {
-  // The hook ORs four async loading flags (three usePromise calls + one useData). They resolve in
-  // ~60ms locally, but waitFor's deadline is wall-clock: on a starved CI runner the event loop can
-  // be blocked past RTL's 1000ms default before the (already-scheduled) resolutions run, producing
-  // spurious "isLoading still true" timeouts. There is no re-render loop (each callback runs exactly
-  // once), so a longer deadline only tolerates scheduler starvation - waitFor still returns the
-  // instant the condition is met, so the happy path is not slowed. Restored in afterAll so the
-  // raised timeout does not leak to other test files sharing the worker.
-  let originalAsyncUtilTimeout: number;
-  beforeAll(() => {
-    originalAsyncUtilTimeout = getConfig().asyncUtilTimeout;
-    configure({ asyncUtilTimeout: 5000 });
-  });
-  afterAll(() => {
-    configure({ asyncUtilTimeout: originalAsyncUtilTimeout });
-  });
+  // The hook ORs four async loading flags (three usePromise calls + one useData) that settle purely
+  // through microtasks - no timers, polling, or retries. Tests therefore drive it to completion with
+  // settle() (a deterministic microtask drain) rather than waitFor, whose wall-clock deadline flaked
+  // on CPU-starved CI runners even though the resolution order is fully deterministic.
 
   beforeEach(async () => {
     // resetAllMocks clears both call history and any mockReturnValue/mockImplementation overrides
@@ -132,7 +142,8 @@ describe('useProjectPickerData', () => {
   it('returns undefined currentProject when no Scripture Editor web view is open', async () => {
     const { result } = renderHook(() => useProjectPickerData());
 
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await settle(result);
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.currentProject).toBeUndefined();
   });
 
@@ -147,10 +158,9 @@ describe('useProjectPickerData', () => {
 
     const { result } = renderHook(() => useProjectPickerData());
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.currentProject?.fullName).toBe('Genesis Project');
-    });
+    await settle(result);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.currentProject?.fullName).toBe('Genesis Project');
     expect(result.current.currentProject?.id).toBe('proj-abc');
   });
 
@@ -175,7 +185,8 @@ describe('useProjectPickerData', () => {
 
     const { result } = renderHook(() => useProjectPickerData());
 
-    await waitFor(() => expect(result.current.allProjects.length).toBe(2));
+    await settle(result);
+    expect(result.current.allProjects).toHaveLength(2);
     expect(result.current.allProjects[0]).toMatchObject({
       id: 'p1',
       fullName: 'Full p1',
@@ -193,7 +204,7 @@ describe('useProjectPickerData', () => {
   it('recentProjects reflects recent project IDs from data provider', async () => {
     const { papiFrontendProjectDataProviderService, useData } = await importMocks();
     vi.mocked(useData).mockImplementation(() => ({
-      RecentProjects: vi.fn().mockReturnValue([['proj-r1', 'proj-r2'], vi.fn(), false]),
+      RecentProjects: vi.fn().mockReturnValue([RECENT_IDS_R1_R2, vi.fn(), false]),
     }));
     vi.mocked(papiFrontendProjectDataProviderService.get).mockImplementation(
       async (_iface: string, projectId: string) =>
@@ -210,10 +221,9 @@ describe('useProjectPickerData', () => {
 
     const { result } = renderHook(() => useProjectPickerData());
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.recentProjects).toHaveLength(2);
-    });
+    await settle(result);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.recentProjects).toHaveLength(2);
     expect(result.current.recentProjects[0]).toMatchObject({
       id: 'proj-r1',
       fullName: 'Full proj-r1',
@@ -247,10 +257,9 @@ describe('useProjectPickerData', () => {
 
     const { result } = renderHook(() => useProjectPickerData());
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.allProjects).toHaveLength(1);
-    });
+    await settle(result);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.allProjects).toHaveLength(1);
     expect(result.current.allProjects[0].id).toBe('editable');
   });
 
@@ -258,7 +267,7 @@ describe('useProjectPickerData', () => {
     const { projectLookupService, papiFrontendProjectDataProviderService, useData } =
       await importMocks();
     vi.mocked(useData).mockImplementation(() => ({
-      RecentProjects: vi.fn().mockReturnValue([['proj-r1'], vi.fn(), false]),
+      RecentProjects: vi.fn().mockReturnValue([RECENT_IDS_R1, vi.fn(), false]),
     }));
     vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([
       { id: 'proj-r1', projectInterfaces: [], pdpFactoryInfo: {} },
@@ -279,10 +288,9 @@ describe('useProjectPickerData', () => {
 
     const { result } = renderHook(() => useProjectPickerData());
 
-    await waitFor(() => {
-      expect(result.current.isLoading).toBe(false);
-      expect(result.current.allProjects).toHaveLength(1);
-    });
+    await settle(result);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.allProjects).toHaveLength(1);
     expect(result.current.allProjects[0].id).toBe('proj-other');
     expect(result.current.recentProjects[0].id).toBe('proj-r1');
   });
@@ -309,13 +317,15 @@ describe('useProjectPickerData', () => {
     } as never);
 
     const { result } = renderHook(() => useProjectPickerData());
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await settle(result);
+    expect(result.current.isLoading).toBe(false);
     expect(result.current.currentProject).toBeUndefined();
 
     expect(capturedCallback).toBeDefined();
     act(() => capturedCallback!());
 
-    await waitFor(() => expect(result.current.currentProject?.fullName).toBe('Updated Project'));
+    await settle(result);
+    expect(result.current.currentProject?.fullName).toBe('Updated Project');
   });
 });
 /* eslint-enable no-type-assertion/no-type-assertion */


### PR DESCRIPTION
## Summary

The `useProjectPickerData` hook test flaked in CI on `windows-latest` with `Error: Test timed out in 5000ms` (e.g. run 28526163625, on the post-merge CI for the unrelated context-menu PR #2471). This makes the suite deterministic so the flake becomes structurally impossible rather than merely rarer.

## Root cause

- The suite waited on RTL's `waitFor`, whose deadline is **wall-clock**. On a CPU-starved runner the vitest worker loses that race.
- The prior mitigation raised `configure({ asyncUtilTimeout: 5000 })`, but vitest's per-test `testTimeout` defaults to **5000ms** and is not overridden, so it bounds the whole test and fired first. The raised `waitFor` budget was capped by an equal `testTimeout` and gave essentially zero extra tolerance. (Diagnostic tell: the CI stack pointed at the `it(...)` line, i.e. vitest's `testTimeout`, not `waitFor`'s line.)

## Why a deterministic fix is possible here (not a band-aid)

`usePromise` resolves purely through **microtasks** - no `setTimeout`, polling, or retry/backoff - and every dependency in the test is mocked to resolve immediately. So the hook's settling order is deterministic regardless of CPU speed; only `waitFor`'s wall-clock deadline was non-deterministic. This is categorically different from the Playwright Win/macOS tests that were disabled: those are real-browser E2E whose slowness is intrinsic. This is a fully-mocked unit test that settles in ~36ms.

## Changes

- Replaced every `waitFor` with `settle()` - a bounded microtask drain inside `act()` - and removed the `asyncUtilTimeout`/`beforeAll`/`afterAll` scaffolding.
- Stabilized the `useData` mock in two tests that returned a **fresh recent-ids array per render**. That unstable identity drove the hook's `useMemo([rawRecentIds])` into a genuine re-render loop (previously masked because `waitFor` sampled a transient settled frame; under a deterministic drain it hangs `act()`). Hoisting the arrays to stable module-level consts mirrors production, where `useData` returns referentially-stable React state.

## Testing

- [x] `use-project-picker-data.hook.test.ts` - 7/7 pass in ~36ms, stable across repeated runs
- [x] `npm run typecheck` clean
- [x] ESLint clean on the changed file

## AI Involvement

AI-assisted. Claude diagnosed the CI failure, identified that the earlier `asyncUtilTimeout` mitigation was capped by vitest's `testTimeout`, verified the microtask-drain approach experimentally before applying it, implemented the conversion, and surfaced the latent re-render-loop the unstable mocks were hiding. All changes were reviewed by the author, and the deterministic behavior was confirmed by repeated local runs, typecheck, and lint.

## Follow-up (out of scope)

The hook has a latent robustness gap: if `rawRecentIds` ever changes identity across renders it re-render-loops. Production `useData` is referentially stable so it doesn't bite today, but hardening `useProjectPickerData` to memoize on recent-ids *content* rather than array identity would remove the sharp edge. Tracking separately.

## Risk Level

Low - test-only change; no product code touched.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2485)
<!-- Reviewable:end -->
