### PR TITLE
PT-2602: Main toolbar scroll group follows the active tab

### DIFF
--- a/docs/superpowers/plans/2026-07-01-pt-2602-toolbar-follows-active-tab.md
+++ b/docs/superpowers/plans/2026-07-01-pt-2602-toolbar-follows-active-tab.md
@@ -1,0 +1,650 @@
+# PT-2602 - Main toolbar follows the active tab's scroll group - Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the Platform.Bible main toolbar's scroll group and BCV follow the active (focused) scripture tab, showing the identical reference the tab shows.
+
+**Architecture:** A new toolbar-internal hook (`useActiveTabScrollGroup`) reads the window-service `Focus` data provider and the focused WebView's saved definition to expose the active scripture tab's `{ scrollGroupId, projectId }`. `PlatformBibleToolbar` consumes it: a follow-effect adopts the active tab's numbered scroll group, and the `projectId` fed to the (already versification-aware) `useScrollGroupScrRef` is the active tab's project when attached, or the driven group's own source project otherwise.
+
+**Tech Stack:** React + TypeScript (renderer), Vitest + @testing-library/react, PAPI hooks (`useData`, `useScrollGroupScrRef`), window/web-view services.
+
+## Global Constraints
+
+- **Base branch:** `pt-4036-versification-aware-sync` (PR #2478). This plan assumes #2478's `useScrollGroupScrRef(scrollGroupScrRef, setScrollGroupScrRef, projectId?)` signature and `getScrRefSourceProjectIdSync` helper exist.
+- **No new services/providers/top-level structures.** Reuse `windowService`, `web-view.service-host` (`getSavedWebViewDefinitionSync`, `onDidUpdateWebView`), and the scroll-group host. The only new file is one toolbar-internal hook.
+- **Hook is app-internal:** co-located with the toolbar, imported directly, **not** exported through any shared/public barrel (notably not `papi-hooks/index.ts`).
+- **TDD required** (this is behavior/logic). RED → GREEN → REFACTOR; every test must be able to fail.
+- **Scripture refs** use `SerializedVerseRef` (already the type on `scrollGroupScrRef`); we never introduce a display-string-only ref.
+- **Repo must stay lint/typecheck/test clean.** Run the repo-wide checks in Task 3 before the final report (per project lint-sweep rules).
+- **projectId rule (the crux):** while the toolbar's group equals the active tab's group ("attached"), pass the active tab's `projectId`; otherwise pass `getScrRefSourceProjectIdSync(toolbarGroup)`. Switching the toolbar group performs no writes; only a navigation writes, and in override mode it preserves the group's source ("move the verse, nothing else").
+- **Keep-last fallback:** when the active tab has no numbered scroll group (non-scripture WebView, or an independent "no scroll group" ref), do not change the toolbar's group.
+
+## File Structure
+
+- **Create:** `src/renderer/components/use-active-tab-scroll-group.hook.ts` - the toolbar-internal follow-source hook. One responsibility: expose the last active scripture tab's `{ webViewId, scrollGroupId, projectId }`.
+- **Create:** `src/renderer/components/use-active-tab-scroll-group.hook.test.ts` - hook behavior tests.
+- **Modify:** `src/renderer/components/platform-bible-toolbar.tsx` - consume the hook (follow-effect + `effectiveProjectId`), replacing the current `currentProject?.id` argument at line 100.
+- **Modify:** `src/renderer/components/platform-bible-toolbar.test.tsx` - mock the new hook + add follow/projectId/keep-last tests.
+
+Reference key facts (verified in the base branch):
+
+- Toolbar today (lines 78-101): `scrollGroupIdInternal` from `localStorage` key `platform-bible-toolbar.scrollGroupId` (default `0`); `updateScrollGroupIdInternal` writes state + localStorage and throws on non-number; `useScrollGroupScrRef(scrollGroupIdInternal, updateScrollGroupIdInternal, currentProject?.id)`.
+- `useData(windowService.dataProviderName).Focus(undefined, undefined)` returns `[FocusSubject | undefined | PlatformError, setter]` (pattern from `platform-tab-title.component.tsx:123-125`).
+- `FocusSubject` = `{ focusType:'webView'; id }` | `{ focusType:'tab'; tabType; id }` | `{ focusType:'other' }` (`window.service-model.ts:22-49`); for a WebView tab, `id` is the WebView id.
+- `getSavedWebViewDefinitionSync(webViewId): SavedWebViewDefinition | undefined` (`web-view.service-host.ts:1115`); `SavedWebViewDefinition` carries required `id` + optional `projectId`, `scrollGroupScrRef`.
+- `onDidUpdateWebView` is `PlatformEvent<UpdateWebViewEvent>`; `UpdateWebViewEvent = { webView: SavedWebViewDefinition }` (`web-view.service-model.ts:254`); exported from `@renderer/services/web-view.service-host`.
+- `getScrRefSourceProjectIdSync(scrollGroupId): string | undefined` (`scroll-group.service-host.ts:136`).
+
+**Single-file test command (from the worktree root):**
+`npx vitest run <relative-test-path>`
+
+---
+
+### Task 1: `useActiveTabScrollGroup` hook
+
+**Files:**
+
+- Create: `src/renderer/components/use-active-tab-scroll-group.hook.ts`
+- Test: `src/renderer/components/use-active-tab-scroll-group.hook.test.ts`
+
+**Interfaces:**
+
+- Consumes: `useData` (`@renderer/hooks/papi-hooks`); `getSavedWebViewDefinitionSync`, `onDidUpdateWebView` (`@renderer/services/web-view.service-host`); `windowService` (`@shared/services/window.service`); `useEvent` (`platform-bible-react`); `isPlatformError`, `getErrorMessage`, `ScrollGroupId` (`platform-bible-utils`); `logger` (`@shared/services/logger.service`); `UpdateWebViewEvent` (`@shared/services/web-view.service-model`).
+- Produces (for Task 2):
+
+  ```ts
+  export type ActiveTabScrollGroup = {
+    webViewId?: string;
+    scrollGroupId?: ScrollGroupId;
+    projectId?: string;
+  };
+  export function useActiveTabScrollGroup(): ActiveTabScrollGroup;
+  ```
+
+- [ ] **Step 1: Write the failing test file (focus derivation + definition read)**
+
+Create `src/renderer/components/use-active-tab-scroll-group.hook.test.ts`:
+
+```ts
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Controllable focus subject the mocked useData(...).Focus() returns.
+let currentFocus: unknown;
+// Captures the onDidUpdateWebView handler the hook registers via useEvent.
+let lastWebViewUpdateHandler: ((event: unknown) => void) | undefined;
+
+const getSavedWebViewDefinitionSync = vi.fn();
+
+vi.mock('@renderer/hooks/papi-hooks', () => ({
+  useData: () => ({ Focus: () => [currentFocus, vi.fn()] }),
+}));
+
+vi.mock('@renderer/services/web-view.service-host', () => ({
+  getSavedWebViewDefinitionSync: (...args: unknown[]) => getSavedWebViewDefinitionSync(...args),
+  onDidUpdateWebView: vi.fn(),
+}));
+
+vi.mock('@shared/services/window.service', () => ({
+  windowService: { dataProviderName: 'platform.windowServiceDataProvider' },
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('platform-bible-react', () => ({
+  useEvent: (_event: unknown, handler: (event: unknown) => void) => {
+    lastWebViewUpdateHandler = handler;
+  },
+}));
+
+async function importHook() {
+  return (await import('./use-active-tab-scroll-group.hook')).useActiveTabScrollGroup;
+}
+
+describe('useActiveTabScrollGroup', () => {
+  beforeEach(() => {
+    currentFocus = undefined;
+    lastWebViewUpdateHandler = undefined;
+    getSavedWebViewDefinitionSync.mockReset();
+  });
+
+  it('returns the group and project of the focused webView', async () => {
+    currentFocus = { focusType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      scrollGroupScrRef: 2,
+      projectId: 'projA',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result } = renderHook(() => useActiveTabScrollGroup());
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ webViewId: 'wv1', scrollGroupId: 2, projectId: 'projA' }),
+    );
+  });
+
+  it('treats a focused webView-type tab the same as the webView iframe', async () => {
+    currentFocus = { focusType: 'tab', tabType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      scrollGroupScrRef: 3,
+      projectId: 'projA',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result } = renderHook(() => useActiveTabScrollGroup());
+
+    await waitFor(() => expect(result.current.scrollGroupId).toBe(3));
+  });
+
+  it('reports no scrollGroupId when the active tab is on an independent ref', async () => {
+    currentFocus = { focusType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      scrollGroupScrRef: { book: 'GEN', chapterNum: 1, verseNum: 1 },
+      projectId: 'projA',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result } = renderHook(() => useActiveTabScrollGroup());
+
+    await waitFor(() => expect(result.current.webViewId).toBe('wv1'));
+    expect(result.current.scrollGroupId).toBeUndefined();
+    expect(result.current.projectId).toBe('projA');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `npx vitest run src/renderer/components/use-active-tab-scroll-group.hook.test.ts`
+Expected: FAIL - cannot resolve `./use-active-tab-scroll-group.hook` (module does not exist yet).
+
+- [ ] **Step 3: Write the hook implementation**
+
+Create `src/renderer/components/use-active-tab-scroll-group.hook.ts`:
+
+```ts
+import { useData } from '@renderer/hooks/papi-hooks';
+import {
+  getSavedWebViewDefinitionSync,
+  onDidUpdateWebView,
+} from '@renderer/services/web-view.service-host';
+import { logger } from '@shared/services/logger.service';
+import { UpdateWebViewEvent } from '@shared/services/web-view.service-model';
+import { windowService } from '@shared/services/window.service';
+import { useEvent } from 'platform-bible-react';
+import { getErrorMessage, isPlatformError, ScrollGroupId } from 'platform-bible-utils';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+/** Describes the active scripture tab the main toolbar should follow. */
+export type ActiveTabScrollGroup = {
+  /** Identity of the last active scripture tab. Undefined until one is focused. */
+  webViewId?: string;
+  /** The tab's scroll group - defined only when it is synced to a numbered group. */
+  scrollGroupId?: ScrollGroupId;
+  /** The tab's project id (from its WebViewDefinition). */
+  projectId?: string;
+};
+
+/**
+ * Reads a WebView's saved definition, tolerating the brief early-mount window before the dock
+ * layout is registered (`getSavedWebViewDefinitionSync` throws then).
+ */
+function readDefinitionSafely(webViewId: string | undefined) {
+  if (!webViewId) return undefined;
+  try {
+    return getSavedWebViewDefinitionSync(webViewId);
+  } catch (e) {
+    logger.warn(
+      `useActiveTabScrollGroup: could not read WebView definition ${webViewId}: ${getErrorMessage(e)}`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * The active scripture tab the main toolbar should follow: the most recently focused WebView tab.
+ * Transient `'other'` focus (e.g. clicking the toolbar's own controls) and non-WebView tabs are
+ * ignored so the last scripture tab is retained.
+ */
+export function useActiveTabScrollGroup(): ActiveTabScrollGroup {
+  const [focusPossiblyError] = useData(windowService.dataProviderName).Focus(undefined, undefined);
+
+  // The webview id currently focused, or undefined for 'other'/non-webview focus.
+  const focusedWebViewId = useMemo(() => {
+    if (!focusPossiblyError || isPlatformError(focusPossiblyError)) return undefined;
+    if (focusPossiblyError.focusType === 'webView') return focusPossiblyError.id;
+    if (focusPossiblyError.focusType === 'tab' && focusPossiblyError.tabType === 'webView')
+      return focusPossiblyError.id;
+    return undefined;
+  }, [focusPossiblyError]);
+
+  // Track the LAST focused webview; ignore transient 'other'/non-webview focus (keep last).
+  const [trackedWebViewId, setTrackedWebViewId] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    if (focusedWebViewId !== undefined) setTrackedWebViewId(focusedWebViewId);
+  }, [focusedWebViewId]);
+
+  // The tracked tab's saved definition (scrollGroupScrRef + projectId).
+  const [definition, setDefinition] = useState(() => readDefinitionSafely(trackedWebViewId));
+  useEffect(() => {
+    setDefinition(readDefinitionSafely(trackedWebViewId));
+  }, [trackedWebViewId]);
+
+  // Ref so the (deps-stable) update handler always sees the current tracked id.
+  const trackedWebViewIdRef = useRef(trackedWebViewId);
+  trackedWebViewIdRef.current = trackedWebViewId;
+
+  useEvent(
+    onDidUpdateWebView,
+    useCallback((event: UpdateWebViewEvent) => {
+      if (event.webView.id === trackedWebViewIdRef.current)
+        setDefinition(readDefinitionSafely(trackedWebViewIdRef.current));
+    }, []),
+  );
+
+  return useMemo(() => {
+    const scrollGroupScrRef = definition?.scrollGroupScrRef;
+    return {
+      webViewId: trackedWebViewId,
+      scrollGroupId: typeof scrollGroupScrRef === 'number' ? scrollGroupScrRef : undefined,
+      projectId: definition?.projectId,
+    };
+  }, [trackedWebViewId, definition]);
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `npx vitest run src/renderer/components/use-active-tab-scroll-group.hook.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Add the "keep last" + reactivity + throw-safety tests**
+
+Append these tests inside the `describe` block in `use-active-tab-scroll-group.hook.test.ts`:
+
+```ts
+it('keeps the last active tab when focus moves to "other"', async () => {
+  currentFocus = { focusType: 'webView', id: 'wv1' };
+  getSavedWebViewDefinitionSync.mockReturnValue({
+    id: 'wv1',
+    webViewType: 'scriptureEditor',
+    scrollGroupScrRef: 2,
+    projectId: 'projA',
+  });
+  const useActiveTabScrollGroup = await importHook();
+
+  const { result, rerender } = renderHook(() => useActiveTabScrollGroup());
+  await waitFor(() => expect(result.current.scrollGroupId).toBe(2));
+
+  // Focus leaves all tabs (e.g. user clicked the toolbar) -> keep last.
+  currentFocus = { focusType: 'other' };
+  rerender();
+
+  expect(result.current).toEqual({ webViewId: 'wv1', scrollGroupId: 2, projectId: 'projA' });
+});
+
+it('ignores focus on a non-webview tab (keeps last)', async () => {
+  currentFocus = { focusType: 'webView', id: 'wv1' };
+  getSavedWebViewDefinitionSync.mockReturnValue({
+    id: 'wv1',
+    webViewType: 'scriptureEditor',
+    scrollGroupScrRef: 2,
+    projectId: 'projA',
+  });
+  const useActiveTabScrollGroup = await importHook();
+
+  const { result, rerender } = renderHook(() => useActiveTabScrollGroup());
+  await waitFor(() => expect(result.current.webViewId).toBe('wv1'));
+
+  currentFocus = { focusType: 'tab', tabType: 'someOtherType', id: 'other-tab' };
+  rerender();
+
+  expect(result.current.webViewId).toBe('wv1');
+});
+
+it('refreshes when the tracked webview definition updates', async () => {
+  currentFocus = { focusType: 'webView', id: 'wv1' };
+  getSavedWebViewDefinitionSync.mockReturnValue({
+    id: 'wv1',
+    webViewType: 'scriptureEditor',
+    scrollGroupScrRef: 2,
+    projectId: 'projA',
+  });
+  const useActiveTabScrollGroup = await importHook();
+
+  const { result } = renderHook(() => useActiveTabScrollGroup());
+  await waitFor(() => expect(result.current.scrollGroupId).toBe(2));
+
+  // The tracked tab is moved to group 4; the update event fires.
+  getSavedWebViewDefinitionSync.mockReturnValue({
+    id: 'wv1',
+    webViewType: 'scriptureEditor',
+    scrollGroupScrRef: 4,
+    projectId: 'projA',
+  });
+  act(() => lastWebViewUpdateHandler?.({ webView: { id: 'wv1', webViewType: 'scriptureEditor' } }));
+
+  await waitFor(() => expect(result.current.scrollGroupId).toBe(4));
+});
+
+it('ignores update events for other webviews', async () => {
+  currentFocus = { focusType: 'webView', id: 'wv1' };
+  getSavedWebViewDefinitionSync.mockReturnValue({
+    id: 'wv1',
+    webViewType: 'scriptureEditor',
+    scrollGroupScrRef: 2,
+    projectId: 'projA',
+  });
+  const useActiveTabScrollGroup = await importHook();
+
+  const { result } = renderHook(() => useActiveTabScrollGroup());
+  await waitFor(() => expect(result.current.scrollGroupId).toBe(2));
+
+  getSavedWebViewDefinitionSync.mockClear();
+  act(() =>
+    lastWebViewUpdateHandler?.({ webView: { id: 'other', webViewType: 'scriptureEditor' } }),
+  );
+
+  // A different webview's update must not trigger a re-read of the tracked tab.
+  expect(getSavedWebViewDefinitionSync).not.toHaveBeenCalled();
+  expect(result.current.scrollGroupId).toBe(2);
+});
+
+it('does not throw when the definition read throws (dock layout not registered yet)', async () => {
+  currentFocus = { focusType: 'webView', id: 'wv1' };
+  getSavedWebViewDefinitionSync.mockImplementation(() => {
+    throw new Error('papi dock layout has not been registered');
+  });
+  const useActiveTabScrollGroup = await importHook();
+
+  const { result } = renderHook(() => useActiveTabScrollGroup());
+
+  // webViewId still tracked; group/project simply unresolved.
+  await waitFor(() => expect(result.current.webViewId).toBe('wv1'));
+  expect(result.current.scrollGroupId).toBeUndefined();
+});
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+Run: `npx vitest run src/renderer/components/use-active-tab-scroll-group.hook.test.ts`
+Expected: PASS (8 tests). If the reactivity test flakes on effect timing, the `waitFor` wrappers already handle it - do not add fixed delays.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/components/use-active-tab-scroll-group.hook.ts src/renderer/components/use-active-tab-scroll-group.hook.test.ts
+git commit -m "feat(PT-2602): add useActiveTabScrollGroup follow-source hook
+
+Toolbar-internal hook exposing the last active scripture tab's scroll
+group + project from window focus and the WebView definition, ignoring
+transient 'other'/non-webview focus.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire the toolbar to follow the active tab
+
+**Files:**
+
+- Modify: `src/renderer/components/platform-bible-toolbar.tsx` (lines ~13-14 imports, ~97-101 hook call; add follow-effect + `effectiveProjectId`)
+- Test: `src/renderer/components/platform-bible-toolbar.test.tsx`
+
+**Interfaces:**
+
+- Consumes: `useActiveTabScrollGroup(): ActiveTabScrollGroup` (Task 1); `getScrRefSourceProjectIdSync(scrollGroupId): string | undefined` (`@renderer/services/scroll-group.service-host`).
+- Produces: no new exports (behavior change only).
+
+- [ ] **Step 1: Write the failing toolbar tests**
+
+In `src/renderer/components/platform-bible-toolbar.test.tsx`:
+
+(a) Add a mock for the new hook near the other `vi.mock` calls:
+
+```ts
+vi.mock('./use-active-tab-scroll-group.hook', () => ({
+  useActiveTabScrollGroup: vi.fn(() => ({
+    webViewId: undefined,
+    scrollGroupId: undefined,
+    projectId: undefined,
+  })),
+}));
+```
+
+(b) Extend the existing `@renderer/services/scroll-group.service-host` mock (currently only `availableScrollGroupIds`) to add the source-project getter:
+
+```ts
+vi.mock('@renderer/services/scroll-group.service-host', () => ({
+  availableScrollGroupIds: [1, 2, 3, 4, 5],
+  getScrRefSourceProjectIdSync: vi.fn(() => 'group-source-proj'),
+}));
+```
+
+(c) Add imports at the top of the test file:
+
+```ts
+import { useScrollGroupScrRef } from '@renderer/hooks/papi-hooks';
+import { useActiveTabScrollGroup } from './use-active-tab-scroll-group.hook';
+```
+
+(d) Append this describe block at the end of the file:
+
+```ts
+describe('PlatformBibleToolbar — follows the active tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockSendCommand(true);
+    vi.mocked(useScrollGroupScrRef).mockReturnValue([
+      { book: 1, chapter: 1, verse: 1 },
+      vi.fn(),
+      0,
+      vi.fn(),
+    ]);
+  });
+
+  it("adopts the active tab's numbered scroll group and passes its project", async () => {
+    vi.mocked(useActiveTabScrollGroup).mockReturnValue({
+      webViewId: 'wv1',
+      scrollGroupId: 2,
+      projectId: 'active-proj',
+    });
+
+    render(<PlatformBibleToolbar />);
+
+    // Follow-effect adopts group 2; attached (2===2) so the active tab's project is passed.
+    await waitFor(() =>
+      expect(vi.mocked(useScrollGroupScrRef)).toHaveBeenLastCalledWith(
+        2,
+        expect.any(Function),
+        'active-proj',
+      ),
+    );
+  });
+
+  it('keeps the last group and uses the group source project when the active tab has no numbered group', async () => {
+    vi.mocked(useActiveTabScrollGroup).mockReturnValue({
+      webViewId: 'settings',
+      scrollGroupId: undefined,
+      projectId: 'irrelevant',
+    });
+
+    render(<PlatformBibleToolbar />);
+
+    // Group stays at the persisted default (0); not attached, so the group's own source is used.
+    await waitFor(() =>
+      expect(vi.mocked(useScrollGroupScrRef)).toHaveBeenLastCalledWith(
+        0,
+        expect.any(Function),
+        'group-source-proj',
+      ),
+    );
+  });
+});
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `npx vitest run src/renderer/components/platform-bible-toolbar.test.tsx`
+Expected: FAIL - the toolbar still calls `useScrollGroupScrRef(0, fn, currentProject?.id)` (=`'proj-1'`), never adopts group 2, and doesn't import the new hook.
+
+- [ ] **Step 3: Modify the toolbar - imports**
+
+In `src/renderer/components/platform-bible-toolbar.tsx`, change the scroll-group-host import (currently line 14) to add the getter, and add the new hook import:
+
+```ts
+import {
+  availableScrollGroupIds,
+  getScrRefSourceProjectIdSync,
+} from '@renderer/services/scroll-group.service-host';
+```
+
+Add near the other local component imports (e.g. after the `useProjectPickerData` import):
+
+```ts
+import { useActiveTabScrollGroup } from './use-active-tab-scroll-group.hook';
+```
+
+- [ ] **Step 4: Modify the toolbar - follow-effect + effectiveProjectId**
+
+Replace the current hook call (lines ~94-101):
+
+```ts
+const { currentProject, recentProjects, allProjects, currentProjectError } = useProjectPickerData();
+
+const [scrRef, setScrRef, scrollGroupId, setScrollGroupId] = useScrollGroupScrRef(
+  scrollGroupIdInternal,
+  updateScrollGroupIdInternal,
+  currentProject?.id,
+);
+```
+
+with:
+
+```ts
+const { recentProjects, allProjects, currentProjectError } = useProjectPickerData();
+
+const activeTab = useActiveTabScrollGroup();
+
+// Follow the active scripture tab: when it is synced to a numbered group, adopt that group.
+// Keyed on the active tab's identity so switching to a different tab re-attaches even to the same
+// group number; a manual top-bar override therefore holds until the active tab changes.
+useEffect(() => {
+  if (activeTab.scrollGroupId !== undefined) updateScrollGroupIdInternal(activeTab.scrollGroupId);
+}, [activeTab.webViewId, activeTab.scrollGroupId, updateScrollGroupIdInternal]);
+
+// Versification frame for the toolbar BCV. Attached (mirroring the active tab): use the tab's
+// project so the toolbar shows the identical ref. Otherwise (manual override / no numbered-group
+// tab active): use the driven group's own source project, so display shows the group's raw ref and
+// a navigation preserves that source ("move the verse, nothing else").
+const attached = scrollGroupIdInternal === activeTab.scrollGroupId;
+const effectiveProjectId = attached
+  ? activeTab.projectId
+  : getScrRefSourceProjectIdSync(scrollGroupIdInternal);
+
+const [scrRef, setScrRef, scrollGroupId, setScrollGroupId] = useScrollGroupScrRef(
+  scrollGroupIdInternal,
+  updateScrollGroupIdInternal,
+  effectiveProjectId,
+);
+```
+
+Note: `currentProject` was only used for the removed `projectId` argument here; the project **picker** UI still uses `recentProjects`/`allProjects`. If TypeScript flags `currentProject` as now-unused elsewhere, confirm and remove only that destructured field. (`useEffect` is already imported at line 49.)
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `npx vitest run src/renderer/components/platform-bible-toolbar.test.tsx`
+Expected: PASS - including the two new tests and the pre-existing suites (Sync button, scroll-group visibility, project picker visibility).
+
+- [ ] **Step 6: Typecheck the touched files**
+
+Run: `npm run typecheck:core`
+Expected: PASS with no errors. Fix any `currentProject`-unused or type errors inline.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/renderer/components/platform-bible-toolbar.tsx src/renderer/components/platform-bible-toolbar.test.tsx
+git commit -m "feat(PT-2602): main toolbar follows the active tab's scroll group
+
+The toolbar adopts the active scripture tab's numbered scroll group and
+renders its BCV in the active tab's versification (via the #2478
+projectId), keeping the last group when the active tab has none.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Whole-branch verification
+
+**Files:** none (verification only; commit only if the formatter changes files).
+
+- [ ] **Step 1: Typecheck the whole repo**
+
+Run: `npm run typecheck`
+Expected: PASS, 0 errors.
+
+- [ ] **Step 2: Lint the whole repo**
+
+Run: `npm run lint`
+Expected: 0 errors. Fix any inline (do not blanket-disable rules - see eslint-disable-discipline). Re-run until clean.
+
+- [ ] **Step 3: Run the full test suite**
+
+Run: `npm test`
+Expected: all suites pass, 0 failed. (If the pre-existing, known-flaky `use-project-picker-data.hook.test.ts` flakes, re-run that file; it is unrelated to this change.)
+
+- [ ] **Step 4: Format**
+
+Run: `npm run format`
+Expected: no changes, or only formatting of the files this branch touched.
+
+- [ ] **Step 5: Commit any formatting changes (only if `git status` is non-empty)**
+
+```bash
+git add -A
+git commit -m "style(PT-2602): formatting after toolbar follow-active-tab change
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+- [ ] **Step 6: Manual / visual verification (record the result)**
+
+With two projects of different versifications open in one scroll group (reuse #2478's setup), in **power mode**:
+
+1. Focus the tab on group A -> the top toolbar shows group A and the same reference that tab shows (verify at a divergence point, e.g. a Psalm heading).
+2. Focus a tab on group C -> the toolbar switches to group C and that tab's reference.
+3. Change the top-bar scroll-group selector to a different group -> the active tab is **not** re-grouped; focus a different scripture tab -> the toolbar re-attaches.
+4. Focus a non-scripture WebView -> the toolbar keeps the last group.
+
+Note: automated coverage stops at the hook + toolbar seams (mocked PAPI); this manual pass is what confirms the end-to-end versification display. Record pass/fail in the PR description.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+- Read direction (follow active tab's group) -> Task 2 Step 4 follow-effect; Task 2 test (a).
+- Versification (active tab's project) -> Task 2 `effectiveProjectId` attached branch; Task 2 test (a) asserts `'active-proj'`.
+- Override / no-active-group projectId (group source) -> Task 2 `effectiveProjectId` else branch; Task 2 test (b).
+- Keep-last -> Task 1 focus tracking + `scrollGroupId: undefined` for independent/no-group tabs; Task 2 test (b) group stays 0.
+- Focus -> 'other' handling -> Task 1 "keep last" test; toolbar re-attach keyed on `webViewId`.
+- Reactivity to the active tab's own group change -> Task 1 `onDidUpdateWebView` test.
+- Non-destructive top selector / "move the verse, nothing else" -> no write-back from the toolbar (Task 2 change adds none); override branch preserves source via `getScrRefSourceProjectIdSync`. (Full override-navigate behavior is exercised by #2478's own `useScrollGroupScrRef` tests plus the Task 3 manual pass.)
+- Simple vs power mode -> unchanged gating; read-direction applies in both (follow-effect is mode-agnostic); selector still power-only.
+
+**Placeholder scan:** none - every code/test step contains full content and exact commands.
+
+**Type consistency:** `ActiveTabScrollGroup` / `useActiveTabScrollGroup` names match between Task 1 (produced) and Task 2 (consumed); `getScrRefSourceProjectIdSync`, `useScrollGroupScrRef`, `effectiveProjectId` used consistently; the hook's `{ webViewId, scrollGroupId, projectId }` shape matches the toolbar's usage.

--- a/docs/superpowers/specs/2026-07-01-pt-2602-toolbar-follows-active-tab-scroll-group-design.md
+++ b/docs/superpowers/specs/2026-07-01-pt-2602-toolbar-follows-active-tab-scroll-group-design.md
@@ -1,0 +1,172 @@
+# PT-2602 - Main toolbar scroll group follows the active tab
+
+- **Ticket:** [PT-2602](https://paratextstudio.atlassian.net/browse/PT-2602) - "Scroll Group - PB not changing the main toolbar scroll group based on the 'Active Tab'/cursor placement"
+- **Depends on (done):** [PT-1517](https://paratextstudio.atlassian.net/browse/PT-1517) "Determine active tab" (shipped - the window focus service)
+- **Builds on (open PR):** [#2478 / `pt-4036-versification-aware-sync`](https://github.com/paranext/paranext-core/pull/2478) - versification-aware scroll-group sync
+- **Base branch:** `pt-4036-versification-aware-sync` (not `main`)
+- **Date:** 2026-07-01
+
+## 1. Problem
+
+The main application toolbar (`src/renderer/components/platform-bible-toolbar.tsx`) owns a Book/Chapter/Verse (BCV) control and, in power mode, a scroll-group selector. Its scroll group is a standalone value persisted in `localStorage` under `platform-bible-toolbar.scrollGroupId` (default `0`), fed into `useScrollGroupScrRef`. It has **no awareness of which tab is focused**.
+
+So if a user focuses a tab synced to scroll group C, the main toolbar keeps showing whatever group it was last set to (e.g. A). PT9 does not behave this way - its top toolbar reflects the active window's scroll group and reference. This ticket closes that gap.
+
+## 2. Goal / Definition of Done
+
+1. The main toolbar's scroll group follows the scroll group of the **active (focused) scripture tab**.
+2. The main toolbar's BCV shows the **same reference the active tab shows** - i.e. the active tab's scroll-group reference converted into the active tab's project versification (leveraging #2478), so at cross-versification divergence points the two agree.
+3. Switching the active tab, or changing the active tab's own scroll group, updates the toolbar accordingly.
+4. The behavior degrades safely for tabs that are not scripture views synced to a numbered scroll group.
+
+## 3. Background - the three subsystems this stitches together
+
+### 3a. Scroll groups
+
+- A scroll group is a `ScrollGroupId` (number). The **scroll-group service host** (`src/renderer/services/scroll-group.service-host.ts`) owns the actual `SerializedVerseRef` per group and (post-#2478) the group's `sourceProjectId`.
+- Each WebView stores its association on its definition: `WebViewDefinition.scrollGroupScrRef` (`src/shared/models/web-view.model.ts:124`) - a **number** (synced to that group) or a `SerializedVerseRef` object (independent / "no scroll group").
+- `WebViewDefinition.projectId` (`web-view.model.ts:119`) carries the tab's project (both fields are updatable and persisted; readable via `getSavedWebViewDefinition(webViewId)`).
+- Hook `useScrollGroupScrRef(scrollGroupScrRef, setScrollGroupScrRef, projectId?)` returns `[scrRef, setScrRef, scrollGroupId, setScrollGroupId]`.
+
+### 3b. Active-tab / focus (PT-1517, shipped)
+
+- The **window service** (`src/renderer/services/window.service-host.ts`, model `src/shared/services/window.service-model.ts`) tracks focus via DOM `focusin`/`focusout` and exposes `papi.window.subscribeFocus(undefined, cb, options)` / `getFocus()`.
+- `FocusSubject` is `{ focusType: 'webView', id }` | `{ focusType: 'tab', tabType, id }` | `{ focusType: 'other' }`. For a WebView tab, the tab `id` equals the WebView id.
+- **Caveat that shapes this design:** focus collapses to `'other'` whenever it leaves all tabs - including when the user clicks the toolbar's own controls (the documented PT-1517 "known issue"). `getFocus()` does not remember the last active tab.
+
+### 3c. Versification-aware sync (#2478, the base branch)
+
+- The scroll group records the `sourceProjectId` its stored ref is expressed in; `ScrollGroupUpdateInfo` and `onDidUpdateScrRef` carry it.
+- `useScrollGroupScrRef`'s third arg `projectId` converts the group's ref into that project's versification **for display**, and `setScrRef` stamps that project as the source. Conversion is display-only, stale-guarded, and pass-through-safe.
+- Helpers available in the renderer: `getScrRefSourceProjectIdSync(scrollGroupId)` and `getScrRefForProject(...)`.
+
+## 4. Design decisions (settled with the reporter)
+
+| Decision                                                                                              | Resolution                                                                                                                                             | Rationale                                                                                                                                                                                                                   |
+| ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Base branch**                                                                                       | `pt-4036-versification-aware-sync` (#2478)                                                                                                             | It already reworks the exact hook + toolbar; basing here avoids conflicts and delivers the versification half of the DoD                                                                                                    |
+| **Read direction**                                                                                    | Toolbar attaches to the active scripture tab's scroll group on active-tab change (and when that tab's own group changes)                               | The core of the ticket                                                                                                                                                                                                      |
+| **Versification**                                                                                     | While attached, the toolbar passes the **active tab's `projectId`** to `useScrollGroupScrRef`, so its BCV shows the identical ref the tab shows        | Satisfies DoD #2 for free via #2478                                                                                                                                                                                         |
+| **Top-bar selector (power mode)**                                                                     | **Non-destructive.** Changing it re-points the toolbar to the chosen group; it does **not** re-group any editor. The standalone toolbar group is kept  | PT10 already has a per-tab selector that mutates a tab's group; making the top selector a second mutator (PT9's model) would be redundant. Giving it a distinct "drive/attach" role is clearer. See §7 for the PT9 analysis |
+| **Manual override persistence**                                                                       | A manual top-bar selection holds until the active tab changes to a **different** scripture tab, then the toolbar re-attaches                           | "Your override holds until you move on"                                                                                                                                                                                     |
+| **No numbered-group active tab** (non-scripture webview, or a scripture tab set to "no scroll group") | **Keep the last group**; the standalone group persists                                                                                                 | Avoids the toolbar going blank/undefined                                                                                                                                                                                    |
+| **Focus -> `'other'`**                                                                                | Track the _last active scripture tab_; ignore transient `'other'` focus (the toolbar's own controls)                                                   | Works around the PT-1517 caveat                                                                                                                                                                                             |
+| **Override-navigate**                                                                                 | Navigating a group from the toolbar while overridden **moves that group's verse but preserves its `sourceProjectId`** ("move the verse, nothing else") | Upholds the reporter's principle that a top-bar change affects only the verse                                                                                                                                               |
+
+## 5. Behavior specification
+
+### 5.1 What the toolbar follows
+
+The toolbar follows the **last active scripture tab** = the most recently focused WebView tab whose `scrollGroupScrRef` is a **number** (a numbered scroll group). Focus subjects that are `'other'`, non-WebView tabs, non-scripture WebViews, or WebViews on an independent ("no scroll group") ref do **not** change the followed group - the toolbar keeps its last group.
+
+### 5.2 The `projectId` the toolbar passes to `useScrollGroupScrRef`
+
+This single value drives both the displayed-ref conversion and the navigation stamp. Let `toolbarGroup` be the toolbar's current group and `activeGroup`/`activeProjectId` describe the followed tab.
+
+- **Attached** (`toolbarGroup === activeGroup`, the normal state): pass **`activeProjectId`**.
+  - Display: the group's ref is converted into the active tab's versification -> identical to what the tab shows (**DoD #2**).
+  - Navigate: `setScrRef` stamps `activeProjectId` as source - exactly as if the user navigated inside the tab.
+- **Override / no active group** (`toolbarGroup !== activeGroup`, incl. no scripture tab active): pass **`getScrRefSourceProjectIdSync(toolbarGroup)`** (the group's own established owner).
+  - Display: consumer equals source -> no conversion -> the group's raw stored ref is shown.
+  - Navigate: `setScrRef` re-stamps the same source -> the group's versification owner is unchanged ("move the verse, nothing else").
+
+Conceptually: _the toolbar always speaks the versification of whatever it currently reflects_ - the active tab (attached) or the driven group's established owner (override). The act of **switching** the toolbar's group performs no writes at all; only a **navigation** writes.
+
+### 5.3 Read direction (attach) details
+
+- On active-tab change to a scripture tab with numbered group `g`, set `toolbarGroup := g` (re-attaches). If `g` equals the current toolbar group, the group is unchanged but the passed `projectId` still updates to the new tab's project (display re-converts).
+- While a tab stays active, changes to _its own_ `scrollGroupScrRef` (e.g. the user changes the tab's per-tab selector) propagate: the toolbar re-reads and follows.
+- Re-attachment is keyed on the **active tab's identity**, so moving focus to a different scripture tab re-attaches even if both share a group number. A manual override therefore holds while the same tab stays active (a top-bar interaction only makes focus `'other'`, which is ignored) and is released when a different scripture tab becomes active.
+
+### 5.4 Interface-mode differences
+
+- **Power mode:** per-tab BCV + scroll-group selector exist on each tab _and_ on the toolbar (both gated on `isPowerMode`). This is the only mode where the override path (§5.2) is reachable.
+- **Simple mode:** no scroll-group selector anywhere; the toolbar BCV is "the single navigation point" (see `web-view.component.tsx:517-521`). Only the read direction applies - the toolbar BCV reflects and navigates the active tab's group. There is no override.
+
+### 5.5 Worked scenarios
+
+Setup: power mode; editor **W** = WEB project (English versification) in group **A**; editor **G** = an Original-versification project in group **B**.
+
+1. **Follow + versification (DoD).** Focus W. Toolbar attaches to A and passes W's project; if A's verse was last set from an Original editor at `PSA 51:3` (Original), the toolbar shows `PSA 51:1` (WEB) - the same ref W shows.
+2. **Navigate from the toolbar while attached.** Focused in W, type `PSA 51:1`. Group A's ref is set stamped WEB - identical to typing it in W; an Original follower of A lands on `51:3`.
+3. **Override display.** Still focused in W, pick group **B** from the toolbar selector. Toolbar shows B's raw ref in B's own versification; W is untouched and still in A.
+4. **Override navigate.** Driving B, type `PSA 51:1`. B's verse moves; B's `sourceProjectId` is preserved; B's followers convert as before.
+5. **Release override.** Focus editor **G**. Toolbar re-attaches to G's group (B) and passes G's project.
+6. **Non-scripture tab.** Focus a settings WebView (no group). Toolbar keeps the last group and ref.
+
+## 6. Architecture / implementation sketch
+
+No new services, providers, or top-level structures. The change reuses `windowService` (focus), `webViewService` (`getSavedWebViewDefinition`, `onDidUpdateWebView`), and the #2478 scroll-group hook/host. The only new artifact is one renderer hook, plus edits to the existing toolbar.
+
+### 6.1 New hook: `useActiveTabScrollGroup` (toolbar-internal)
+
+A renderer hook, but deliberately **toolbar-owned, not a public reuse surface**. The top toolbar is its only consumer today, and none is planned - so this extraction is **not** justified by reuse. It is justified by (a) keeping `PlatformBibleToolbar` (~335 lines, already busy) lean, and (b) making the ~30-50 lines of subscription/tracking logic **unit-testable in isolation** (feed it focus + WebView definitions, assert the returned tuple), which the testing strategy relies on. It reads renderer-local focus + WebView-definition state, so it lives in the renderer per the shared-patterns "host where the data lives" rule.
+
+- **Placement:** co-located with the toolbar (a sibling file), imported directly by `platform-bible-toolbar.tsx`. **Not** exported through any shared/public hook barrel (notably not `papi-hooks/index.ts`), so it stays app-internal. If a second consumer ever appears, promoting it to a shared hook is a trivial follow-up - build that only when it's real.
+
+Returns a description of the **current follow target**:
+
+```ts
+{
+  webViewId?: string;            // identity of the last active scripture tab (for re-attach keying)
+  scrollGroupId?: ScrollGroupId; // defined only when that tab is synced to a numbered group
+  projectId?: string;            // that tab's WebViewDefinition.projectId
+}
+```
+
+Internals:
+
+1. Consume the existing window-service `Focus` data provider reactively via `useData('platform.windowServiceDataProvider').Focus(...)` (preferred over hand-rolling `subscribeFocus`, which duplicates the subscribe/unsubscribe the `useData` hook already manages). Derive the active WebView id from `focusType: 'webView'`, or `focusType: 'tab'` with `tabType === 'webView'`; ignore `'other'` and non-WebView tabs (keep last).
+2. Read that WebView's definition via `getSavedWebViewDefinition(webViewId)` -> `scrollGroupScrRef`, `projectId`.
+3. Subscribe to `papi.webViews.onDidUpdateWebView` and refresh when the tracked WebView's definition changes (its group or project).
+4. Expose `scrollGroupId` only when `scrollGroupScrRef` is a number; otherwise leave it `undefined` (so the toolbar keeps its last group).
+
+### 6.2 Toolbar changes: `platform-bible-toolbar.tsx`
+
+- Consume `const active = useActiveTabScrollGroup();`.
+- **Follow effect:** when `active.scrollGroupId` is a defined number, key an effect on `active.webViewId` (identity) and call `updateScrollGroupIdInternal(active.scrollGroupId)`.
+- **`projectId` selection** (feeds the existing `useScrollGroupScrRef` third arg, replacing today's `currentProject`):
+  `const attached = scrollGroupIdInternal === active.scrollGroupId;`
+  `const effectiveProjectId = attached ? active.projectId : getScrRefSourceProjectIdSync(scrollGroupIdInternal);`
+- The selector's `onChangeScrollGroupId` (`setScrollGroupId` -> `updateScrollGroupIdInternal`) is unchanged - it writes only the toolbar's own group, which naturally becomes an override until the next active-tab change.
+- No write-back to any WebView definition from the toolbar (guarantees "move the verse, nothing else" and avoids feedback loops).
+
+### 6.3 Files expected to change
+
+- **New:** a toolbar-internal hook file co-located with the toolbar (e.g. `src/renderer/components/use-active-tab-scroll-group.hook.ts`) + its test. **No** shared/public barrel export (see §6.1).
+- **Edit:** `src/renderer/components/platform-bible-toolbar.tsx` (consume hook, follow effect, `effectiveProjectId`).
+- Possibly a tiny helper/getter if reading `getScrRefSourceProjectIdSync` from the toolbar warrants a cleaner surface (decide during planning; may be unnecessary).
+
+## 7. Why Option B (non-destructive top selector), verified against PT9
+
+PT9 source (`ParatextBase/ParatextWindows/WindowManagerHelper.cs`) shows its **single** top-toolbar scroll-group split button both reflects the active window's group (`:150`) and, on click, mutates it (`:406-414` -> `ActiveWindow.ScrollingGroup = group`). PT9 has no per-window group _selector_ (only display-only badges, hidden when all windows share a group - `ScrollGroupBadgeHelper.cs:54-67`).
+
+PT10 differs: each tab **already** has its own scroll-group selector (`web-view.component.tsx:533-542`, power mode) that mutates that tab's group - i.e. PT10 already provides PT9's "change this editor's group" affordance, on the tab. Reproducing it on the top bar (Option A) would make the top selector a redundant second mutator. Option B gives the two selectors complementary roles: **per-tab selector = change this editor's group; top selector = choose which group the top bar drives**, auto-attaching to the active tab. The PT9-A capability is not lost - it lives on the per-tab selector.
+
+## 8. Edge cases & known limitations
+
+- **Active tab on an independent ("no scroll group") ref.** The toolbar cannot represent "no group" (its group is always a number), so it keeps the last group and does **not** mirror the independent tab's ref. Accepted limitation; out of scope to relax the toolbar's number-only model.
+- **Override-navigate downgrades correctness only if misused.** Preserving `sourceProjectId` keeps followers correct; there is no correctness regression versus today.
+- **Startup / no scripture tab yet.** The toolbar shows its persisted `localStorage` group (today's behavior) until a scripture tab is focused.
+- **Debounce.** Focus detection is debounced (~250 ms) upstream; the toolbar update inherits that latency, which is acceptable.
+- **Popup focus.** Because we ignore `'other'` and key re-attachment on tab identity, opening the toolbar's own dropdown does not disturb the followed tab.
+
+## 9. Testing strategy
+
+Behavior-focused (Vitest; testing-trophy - favor the hook + integration seams over DOM snapshots):
+
+- **`useActiveTabScrollGroup` unit/hook tests:** focus a WebView -> returns its group + project; `'other'` and non-scripture/non-WebView focus -> keeps last; `onDidUpdateWebView` on the tracked tab -> refreshes group/project; independent-ref tab -> `scrollGroupId` undefined.
+- **Toolbar integration tests (mock the hook + scroll-group host):** active-tab change updates the toolbar group; attached state passes the active tab's `projectId`; override passes the group's `sourceProjectId` and holds until active-tab change; no write-back to WebView definitions occurs on selector change.
+- **Manual / visual verification:** two projects with different versifications in one group - confirm the toolbar BCV matches the active tab's displayed ref across a divergence point (e.g. Psalm heading). (Reuses #2478's verification setup.)
+
+## 10. Out of scope
+
+- Relaxing the toolbar to represent "no scroll group" / independent refs.
+- Any change to the per-tab selector semantics.
+- New E2E automation (manual verification for the versification display this pass; automate later if desired).
+- Reconciling PT-4036/PT-4037 ticket text (tracked on #2478).
+
+## 11. Risks
+
+- **Dependency on an open PR.** This branches from `pt-4036-versification-aware-sync`. If #2478 changes in review, rebase this branch; if #2478 is reworked substantially, the `projectId` plumbing here may need matching updates. Low risk - #2478 is marked mergeable/low-risk and the surface we depend on (`useScrollGroupScrRef(..., projectId)`, `getScrRefSourceProjectIdSync`) is small and stable.
+- **Behavior change to the top-bar selector** (now non-destructive) - intentional and documented here; no data migration needed (the `localStorage` group key is retained).

--- a/src/renderer/components/platform-bible-toolbar.test.tsx
+++ b/src/renderer/components/platform-bible-toolbar.test.tsx
@@ -2,10 +2,11 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import React from 'react';
-import { useSetting } from '@renderer/hooks/papi-hooks';
+import { useSetting, useScrollGroupScrRef } from '@renderer/hooks/papi-hooks';
 import { sendCommand } from '@shared/services/command.service';
 import { getNetworkEvent } from '@shared/services/network.service';
 import { PlatformBibleToolbar } from './platform-bible-toolbar';
+import { useActiveTabScrollGroup } from './use-active-tab-scroll-group.hook';
 
 // Mock asset
 vi.mock('@assets/icon.png', () => ({ default: 'icon.png' }));
@@ -70,6 +71,15 @@ vi.mock('@renderer/services/theme.service-host', () => ({
 
 vi.mock('@renderer/services/scroll-group.service-host', () => ({
   availableScrollGroupIds: [1, 2, 3, 4, 5],
+  getScrRefSourceProjectIdSync: vi.fn(() => 'group-source-proj'),
+}));
+
+vi.mock('./use-active-tab-scroll-group.hook', () => ({
+  useActiveTabScrollGroup: vi.fn(() => ({
+    webViewId: undefined,
+    scrollGroupId: undefined,
+    projectId: undefined,
+  })),
 }));
 
 vi.mock('@shared/data/platform-bible-menu.commands', () => ({
@@ -451,5 +461,79 @@ describe('PlatformBibleToolbar — project picker Select visibility by interface
     await waitFor(() => {
       expect(screen.queryByTestId('project-picker-select')).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('PlatformBibleToolbar — follows the active tab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    mockSendCommand(true);
+    vi.mocked(useScrollGroupScrRef).mockReturnValue([
+      { book: 'GEN', chapterNum: 1, verseNum: 1 },
+      vi.fn(),
+      0,
+      vi.fn(),
+    ]);
+  });
+
+  it("adopts the active tab's numbered scroll group and passes its project", async () => {
+    vi.mocked(useActiveTabScrollGroup).mockReturnValue({
+      webViewId: 'wv1',
+      scrollGroupId: 2,
+      projectId: 'active-proj',
+    });
+
+    render(<PlatformBibleToolbar />);
+
+    // Follow-effect adopts group 2; attached (2===2) so the active tab's project is passed.
+    await waitFor(() =>
+      expect(vi.mocked(useScrollGroupScrRef)).toHaveBeenLastCalledWith(
+        2,
+        expect.any(Function),
+        'active-proj',
+      ),
+    );
+  });
+
+  it("attaches to the active tab's default group 0 and passes its project", async () => {
+    // A freshly-opened scripture reader/resource sits on the default group 0; useActiveTabScrollGroup
+    // reports scrollGroupId 0 (not undefined) for it. The toolbar must treat 0 as attached and pass
+    // the tab's project so a toolbar navigation stamps that project as the source and followers
+    // convert versification. Regression guard for PT-2602 (toolbar ignored the active tab's project).
+    vi.mocked(useActiveTabScrollGroup).mockReturnValue({
+      webViewId: 'wv1',
+      scrollGroupId: 0,
+      projectId: 'active-proj',
+    });
+
+    render(<PlatformBibleToolbar />);
+
+    await waitFor(() =>
+      expect(vi.mocked(useScrollGroupScrRef)).toHaveBeenLastCalledWith(
+        0,
+        expect.any(Function),
+        'active-proj',
+      ),
+    );
+  });
+
+  it('keeps the last group and uses the group source project when the active tab has no numbered group', async () => {
+    vi.mocked(useActiveTabScrollGroup).mockReturnValue({
+      webViewId: 'settings',
+      scrollGroupId: undefined,
+      projectId: 'irrelevant',
+    });
+
+    render(<PlatformBibleToolbar />);
+
+    // Group stays at the persisted default (0); not attached, so the group's own source is used.
+    await waitFor(() =>
+      expect(vi.mocked(useScrollGroupScrRef)).toHaveBeenLastCalledWith(
+        0,
+        expect.any(Function),
+        'group-source-proj',
+      ),
+    );
   });
 });

--- a/src/renderer/components/platform-bible-toolbar.tsx
+++ b/src/renderer/components/platform-bible-toolbar.tsx
@@ -11,7 +11,10 @@ import { useIsPowerMode } from '@renderer/hooks/use-is-power-mode.hook';
 import { useProjectPickerData } from '@renderer/hooks/use-project-picker-data.hook';
 import { PROJECT_PICKER_DIALOG_TYPE } from '@renderer/components/dialogs/dialog-definition.model';
 import { app, dataProviders } from '@renderer/services/papi-frontend.service';
-import { availableScrollGroupIds } from '@renderer/services/scroll-group.service-host';
+import {
+  availableScrollGroupIds,
+  getScrRefSourceProjectIdSync,
+} from '@renderer/services/scroll-group.service-host';
 import { handleMenuCommand } from '@shared/data/platform-bible-menu.commands';
 import { sendCommand } from '@shared/services/command.service';
 import { getNetworkEvent } from '@shared/services/network.service';
@@ -47,6 +50,7 @@ import {
   ScrollGroupId,
 } from 'platform-bible-utils';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useActiveTabScrollGroup } from './use-active-tab-scroll-group.hook';
 
 const TOOLTIP_DELAY = 300;
 
@@ -94,10 +98,28 @@ export function PlatformBibleToolbar() {
   const { currentProject, recentProjects, allProjects, currentProjectError } =
     useProjectPickerData();
 
+  const activeTab = useActiveTabScrollGroup();
+
+  // Follow the active scripture tab: when it is synced to a numbered group, adopt that group.
+  // Keyed on the active tab's identity so switching to a different tab re-attaches even to the same
+  // group number; a manual top-bar override therefore holds until the active tab changes.
+  useEffect(() => {
+    if (activeTab.scrollGroupId !== undefined) updateScrollGroupIdInternal(activeTab.scrollGroupId);
+  }, [activeTab.webViewId, activeTab.scrollGroupId, updateScrollGroupIdInternal]);
+
+  // Versification frame for the toolbar BCV. Attached (mirroring the active tab): use the tab's
+  // project so the toolbar shows the identical ref. Otherwise (manual override / no numbered-group
+  // tab active): use the driven group's own source project, so display shows the group's raw ref and
+  // a navigation preserves that source ("move the verse, nothing else").
+  const attached = scrollGroupIdInternal === activeTab.scrollGroupId;
+  const effectiveProjectId = attached
+    ? activeTab.projectId
+    : getScrRefSourceProjectIdSync(scrollGroupIdInternal);
+
   const [scrRef, setScrRef, scrollGroupId, setScrollGroupId] = useScrollGroupScrRef(
     scrollGroupIdInternal,
     updateScrollGroupIdInternal,
-    currentProject?.id,
+    effectiveProjectId,
   );
 
   const isPowerMode = useIsPowerMode();

--- a/src/renderer/components/use-active-tab-scroll-group.hook.test.ts
+++ b/src/renderer/components/use-active-tab-scroll-group.hook.test.ts
@@ -1,0 +1,269 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Controllable focus subject the mocked useData(...).Focus() returns.
+let currentFocus: unknown;
+// Captures the onDidUpdateWebView handler the hook registers via useEvent.
+let lastWebViewUpdateHandler: ((event: unknown) => void) | undefined;
+
+const getSavedWebViewDefinitionSync = vi.fn();
+
+vi.mock('@renderer/hooks/papi-hooks', () => ({
+  useData: () => ({ Focus: () => [currentFocus, vi.fn()] }),
+}));
+
+vi.mock('@renderer/services/web-view.service-host', () => ({
+  getSavedWebViewDefinitionSync: (...args: unknown[]) => getSavedWebViewDefinitionSync(...args),
+  onDidUpdateWebView: vi.fn(),
+}));
+
+vi.mock('@shared/services/window.service', () => ({
+  windowService: { dataProviderName: 'platform.windowServiceDataProvider' },
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { warn: vi.fn(), error: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('platform-bible-react', () => ({
+  useEvent: (_event: unknown, handler: (event: unknown) => void) => {
+    lastWebViewUpdateHandler = handler;
+  },
+}));
+
+async function importHook() {
+  return (await import('./use-active-tab-scroll-group.hook')).useActiveTabScrollGroup;
+}
+
+describe('useActiveTabScrollGroup', () => {
+  beforeEach(() => {
+    currentFocus = undefined;
+    lastWebViewUpdateHandler = undefined;
+    getSavedWebViewDefinitionSync.mockReset();
+  });
+
+  it('returns the group and project of the focused webView', async () => {
+    currentFocus = { focusType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      scrollGroupScrRef: 2,
+      projectId: 'projA',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result } = renderHook(() => useActiveTabScrollGroup());
+
+    await waitFor(() =>
+      expect(result.current).toEqual({ webViewId: 'wv1', scrollGroupId: 2, projectId: 'projA' }),
+    );
+  });
+
+  it('treats a focused webView-type tab the same as the webView iframe', async () => {
+    currentFocus = { focusType: 'tab', tabType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      scrollGroupScrRef: 3,
+      projectId: 'projA',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result } = renderHook(() => useActiveTabScrollGroup());
+
+    await waitFor(() => expect(result.current.scrollGroupId).toBe(3));
+  });
+
+  it('reports no scrollGroupId when the active tab is on an independent ref', async () => {
+    currentFocus = { focusType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      scrollGroupScrRef: { book: 'GEN', chapterNum: 1, verseNum: 1 },
+      projectId: 'projA',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result } = renderHook(() => useActiveTabScrollGroup());
+
+    await waitFor(() => expect(result.current.webViewId).toBe('wv1'));
+    expect(result.current.scrollGroupId).toBeUndefined();
+    expect(result.current.projectId).toBe('projA');
+  });
+
+  it('treats a project tab with no scrollGroupScrRef as the default group 0', async () => {
+    currentFocus = { focusType: 'webView', id: 'wv1' };
+    // A freshly-opened scripture reader/editor persists no scrollGroupScrRef until the user changes
+    // its group, but is effectively on the default scroll group 0 (matching the use-open-project-tabs
+    // convention and useScrollGroupScrRef's own `?? 0` default). The toolbar must see it as group 0
+    // so it recognizes the tab as attached and adopts its project for versification framing.
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      projectId: 'projA',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result } = renderHook(() => useActiveTabScrollGroup());
+
+    await waitFor(() => expect(result.current.webViewId).toBe('wv1'));
+    expect(result.current.scrollGroupId).toBe(0);
+    expect(result.current.projectId).toBe('projA');
+  });
+
+  it('leaves a non-project tab with no scrollGroupScrRef unattached (keeps last)', async () => {
+    currentFocus = { focusType: 'webView', id: 'settings' };
+    // A non-scripture webview (settings/home) has no projectId and no scroll group; it must NOT be
+    // treated as group 0, so the toolbar keeps its last group instead of attaching to a projectless
+    // tab (which would stamp an undefined source and break follower conversion).
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'settings',
+      webViewType: 'platformSettings',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result } = renderHook(() => useActiveTabScrollGroup());
+
+    await waitFor(() => expect(result.current.webViewId).toBe('settings'));
+    expect(result.current.scrollGroupId).toBeUndefined();
+    expect(result.current.projectId).toBeUndefined();
+  });
+
+  it('keeps the last active tab when focus moves to "other"', async () => {
+    currentFocus = { focusType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      scrollGroupScrRef: 2,
+      projectId: 'projA',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result, rerender } = renderHook(() => useActiveTabScrollGroup());
+    await waitFor(() => expect(result.current.scrollGroupId).toBe(2));
+
+    // Focus leaves all tabs (e.g. user clicked the toolbar) -> keep last.
+    currentFocus = { focusType: 'other' };
+    rerender();
+
+    expect(result.current).toEqual({ webViewId: 'wv1', scrollGroupId: 2, projectId: 'projA' });
+  });
+
+  it('ignores focus on a non-webview tab (keeps last)', async () => {
+    currentFocus = { focusType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      scrollGroupScrRef: 2,
+      projectId: 'projA',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result, rerender } = renderHook(() => useActiveTabScrollGroup());
+    await waitFor(() => expect(result.current.webViewId).toBe('wv1'));
+
+    currentFocus = { focusType: 'tab', tabType: 'someOtherType', id: 'other-tab' };
+    rerender();
+
+    expect(result.current.webViewId).toBe('wv1');
+  });
+
+  it('refreshes when the tracked webview definition updates', async () => {
+    currentFocus = { focusType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      scrollGroupScrRef: 2,
+      projectId: 'projA',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result } = renderHook(() => useActiveTabScrollGroup());
+    await waitFor(() => expect(result.current.scrollGroupId).toBe(2));
+
+    // The tracked tab is moved to group 4; the update event fires.
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      scrollGroupScrRef: 4,
+      projectId: 'projA',
+    });
+    act(() =>
+      lastWebViewUpdateHandler?.({ webView: { id: 'wv1', webViewType: 'scriptureEditor' } }),
+    );
+
+    await waitFor(() => expect(result.current.scrollGroupId).toBe(4));
+  });
+
+  it('ignores update events for other webviews', async () => {
+    currentFocus = { focusType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockReturnValue({
+      id: 'wv1',
+      webViewType: 'scriptureEditor',
+      scrollGroupScrRef: 2,
+      projectId: 'projA',
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result } = renderHook(() => useActiveTabScrollGroup());
+    await waitFor(() => expect(result.current.scrollGroupId).toBe(2));
+
+    getSavedWebViewDefinitionSync.mockClear();
+    act(() =>
+      lastWebViewUpdateHandler?.({ webView: { id: 'other', webViewType: 'scriptureEditor' } }),
+    );
+
+    // A different webview's update must not trigger a re-read of the tracked tab.
+    expect(getSavedWebViewDefinitionSync).not.toHaveBeenCalled();
+    expect(result.current.scrollGroupId).toBe(2);
+  });
+
+  it('does not throw when the definition read throws (dock layout not registered yet)', async () => {
+    currentFocus = { focusType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockImplementation(() => {
+      throw new Error('papi dock layout has not been registered');
+    });
+    const useActiveTabScrollGroup = await importHook();
+
+    const { result } = renderHook(() => useActiveTabScrollGroup());
+
+    // webViewId still tracked; group/project simply unresolved.
+    await waitFor(() => expect(result.current.webViewId).toBe('wv1'));
+    expect(result.current.scrollGroupId).toBeUndefined();
+  });
+
+  it('never pairs a new webViewId with the previous tab definition on a direct switch', async () => {
+    currentFocus = { focusType: 'webView', id: 'wv1' };
+    getSavedWebViewDefinitionSync.mockImplementation((id: string) =>
+      id === 'wv2'
+        ? { id: 'wv2', webViewType: 'scriptureEditor', scrollGroupScrRef: 3, projectId: 'projB' }
+        : { id: 'wv1', webViewType: 'scriptureEditor', scrollGroupScrRef: 1, projectId: 'projA' },
+    );
+    const useActiveTabScrollGroup = await importHook();
+
+    const observed: Array<{ webViewId?: string; scrollGroupId?: number; projectId?: string }> = [];
+    const { rerender } = renderHook(() => {
+      const value = useActiveTabScrollGroup();
+      observed.push(value);
+      return value;
+    });
+    await waitFor(() =>
+      expect(observed.at(-1)).toEqual({ webViewId: 'wv1', scrollGroupId: 1, projectId: 'projA' }),
+    );
+
+    currentFocus = { focusType: 'webView', id: 'wv2' };
+    rerender();
+    await waitFor(() =>
+      expect(observed.at(-1)).toEqual({ webViewId: 'wv2', scrollGroupId: 3, projectId: 'projB' }),
+    );
+
+    // The definition is derived synchronously from trackedWebViewId, so no render ever pairs the new
+    // tab's id with the previous tab's group/project.
+    expect(observed).not.toContainEqual(
+      expect.objectContaining({ webViewId: 'wv2', projectId: 'projA' }),
+    );
+    expect(observed).not.toContainEqual(
+      expect.objectContaining({ webViewId: 'wv2', scrollGroupId: 1 }),
+    );
+  });
+});

--- a/src/renderer/components/use-active-tab-scroll-group.hook.ts
+++ b/src/renderer/components/use-active-tab-scroll-group.hook.ts
@@ -1,0 +1,115 @@
+import { useData } from '@renderer/hooks/papi-hooks';
+import {
+  getSavedWebViewDefinitionSync,
+  onDidUpdateWebView,
+} from '@renderer/services/web-view.service-host';
+import { logger } from '@shared/services/logger.service';
+import { UpdateWebViewEvent } from '@shared/services/web-view.service-model';
+import { windowService } from '@shared/services/window.service';
+import { useEvent } from 'platform-bible-react';
+import { getErrorMessage, isPlatformError, ScrollGroupId } from 'platform-bible-utils';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+/** Describes the active scripture tab the main toolbar should follow. */
+export type ActiveTabScrollGroup = {
+  /** Identity of the last active scripture tab. Undefined until one is focused. */
+  webViewId?: string;
+  /**
+   * The tab's scroll group. A project-bound tab that has not persisted an explicit group is
+   * reported as the default group `0` (see the mapping in {@link useActiveTabScrollGroup}).
+   * `undefined` when the tab is genuinely off any numbered group (detached/independent ref) or is
+   * not a project tab.
+   */
+  scrollGroupId?: ScrollGroupId;
+  /** The tab's project id (from its WebViewDefinition). */
+  projectId?: string;
+};
+
+/**
+ * Reads a WebView's saved definition, tolerating the brief early-mount window before the dock
+ * layout is registered (`getSavedWebViewDefinitionSync` throws then).
+ */
+function readDefinitionSafely(webViewId: string | undefined) {
+  if (!webViewId) return undefined;
+  try {
+    return getSavedWebViewDefinitionSync(webViewId);
+  } catch (e) {
+    logger.warn(
+      `useActiveTabScrollGroup: could not read WebView definition ${webViewId}: ${getErrorMessage(e)}`,
+    );
+    return undefined;
+  }
+}
+
+/**
+ * The active scripture tab the main toolbar should follow: the most recently focused WebView tab.
+ * Transient `'other'` focus (e.g. clicking the toolbar's own controls) and non-WebView tabs are
+ * ignored so the last scripture tab is retained.
+ */
+export function useActiveTabScrollGroup(): ActiveTabScrollGroup {
+  const [focusPossiblyError] = useData(windowService.dataProviderName).Focus(undefined, undefined);
+
+  // The webview id currently focused, or undefined for 'other'/non-webview focus.
+  const focusedWebViewId = useMemo(() => {
+    if (!focusPossiblyError || isPlatformError(focusPossiblyError)) return undefined;
+    if (focusPossiblyError.focusType === 'webView') return focusPossiblyError.id;
+    if (focusPossiblyError.focusType === 'tab' && focusPossiblyError.tabType === 'webView')
+      return focusPossiblyError.id;
+    return undefined;
+  }, [focusPossiblyError]);
+
+  // Track the LAST focused webview; ignore transient 'other'/non-webview focus (keep last).
+  const [trackedWebViewId, setTrackedWebViewId] = useState<string | undefined>(undefined);
+  useEffect(() => {
+    if (focusedWebViewId !== undefined) setTrackedWebViewId(focusedWebViewId);
+  }, [focusedWebViewId]);
+
+  // Bumped by an onDidUpdateWebView event for the tracked tab to force a definition re-read.
+  const [definitionRefresh, setDefinitionRefresh] = useState(0);
+
+  // Ref so the (deps-stable) update handler always sees the current tracked id.
+  const trackedWebViewIdRef = useRef(trackedWebViewId);
+  trackedWebViewIdRef.current = trackedWebViewId;
+
+  useEvent(
+    onDidUpdateWebView,
+    useCallback((event: UpdateWebViewEvent) => {
+      if (event.webView.id === trackedWebViewIdRef.current) setDefinitionRefresh((n) => n + 1);
+    }, []),
+  );
+
+  // The tracked tab's saved definition (scrollGroupScrRef + projectId). Derived synchronously from
+  // trackedWebViewId so the returned webViewId and its definition always update in the same render
+  // (no transient stale pairing); definitionRefresh re-reads it after an external update event.
+  const definition = useMemo(() => {
+    // Referenced so this memo re-runs whenever an onDidUpdateWebView event bumps it
+    // eslint-disable-next-line no-unused-expressions
+    definitionRefresh;
+    return readDefinitionSafely(trackedWebViewId);
+  }, [trackedWebViewId, definitionRefresh]);
+
+  return useMemo(() => {
+    const scrollGroupScrRef = definition?.scrollGroupScrRef;
+    const projectId = definition?.projectId;
+    let scrollGroupId: ScrollGroupId | undefined;
+    if (typeof scrollGroupScrRef === 'number') {
+      scrollGroupId = scrollGroupScrRef;
+    } else if (scrollGroupScrRef === undefined && projectId !== undefined) {
+      // A project-bound scripture tab persists no `scrollGroupScrRef` until the user changes its
+      // group, yet is effectively on the default scroll group 0 — the same convention
+      // `useScrollGroupScrRef`'s `?? 0` default and `use-open-project-tabs` apply. Reporting 0 (rather
+      // than undefined) lets the toolbar recognize the tab as attached and adopt its project for
+      // versification framing, instead of falling back to the group's stored source and stamping an
+      // undefined frame that leaves followers unconverted. Gate on `projectId`: a non-scripture tab
+      // (settings/home, no projectId) or a missing definition must stay unattached so the toolbar
+      // keeps its last group. An object (`SerializedVerseRef`) means genuinely detached — also left
+      // undefined (keep last).
+      scrollGroupId = 0;
+    }
+    return {
+      webViewId: trackedWebViewId,
+      scrollGroupId,
+      projectId,
+    };
+  }, [trackedWebViewId, definition]);
+}

--- a/src/renderer/services/scroll-group.service-host.test.ts
+++ b/src/renderer/services/scroll-group.service-host.test.ts
@@ -19,9 +19,22 @@ vi.mock('@shared/services/network.service', () => ({
 vi.mock('@shared/services/network-object.service', () => ({
   networkObjectService: { set: vi.fn() },
 }));
-const settingsSet = vi.fn();
+const { settingsSet, verseRefSubscriberRef } = vi.hoisted(() => {
+  // Captures the callback the host registers for the `platform.verseRef` setting so tests can drive
+  // its echoes directly.
+  const capturedVerseRefSubscriber: { current: ((value: unknown) => void) | undefined } = {
+    current: undefined,
+  };
+  return { settingsSet: vi.fn(), verseRefSubscriberRef: capturedVerseRefSubscriber };
+});
 vi.mock('@shared/services/settings.service', () => ({
-  settingsService: { set: (...args: unknown[]) => settingsSet(...args), subscribe: vi.fn() },
+  settingsService: {
+    set: (...args: unknown[]) => settingsSet(...args),
+    subscribe: vi.fn(async (key: string, callback: (value: unknown) => void) => {
+      if (key === 'platform.verseRef') verseRefSubscriberRef.current = callback;
+      return () => {};
+    }),
+  },
 }));
 vi.mock('@shared/services/logger.service', () => ({ logger: { warn: vi.fn(), error: vi.fn() } }));
 
@@ -52,6 +65,7 @@ describe('scroll-group.service-host source project tracking', () => {
       delete projectVersifications[key];
     });
     Object.keys(emitters).forEach((key) => delete emitters[key]);
+    verseRefSubscriberRef.current = undefined;
     pdpGet.mockReset();
     pdpGet.mockImplementation(async (_projectInterface: string, projectId: string) => ({
       subscribeSetting: (_key: string, callback: (value: unknown) => void) => {
@@ -339,5 +353,46 @@ describe('scroll-group.service-host source project tracking', () => {
     callbacks.sourceProj('a-different-versification'); // genuine mid-session change
     expect(emit).toHaveBeenCalledTimes(1);
     expect(emit).toHaveBeenCalledWith({ projectId: 'sourceProj' });
+  });
+
+  it('ignores its own platform.verseRef mirror echoes so a stale echo cannot clear a known source', async () => {
+    const host = await import('@renderer/services/scroll-group.service-host');
+    await host.startScrollGroupService();
+    const verseRefEcho = verseRefSubscriberRef.current;
+    expect(verseRefEcho).toBeDefined();
+    if (!verseRefEcho) throw new Error('verseRef subscriber was not captured');
+
+    // A group-0 navigation stamps a source and mirrors the ref out to platform.verseRef.
+    host.setScrRefSync(0, { book: 'PSA', chapterNum: 40, verseNum: 5 }, 'projSource');
+    // A second group-0 write (e.g. the editor settling on the chapter after a scroll) moves the ref
+    // and re-mirrors it. Both writes carry a known source.
+    host.setScrRefSync(0, { book: 'PSA', chapterNum: 40, verseNum: 0 }, 'projSource');
+    expect(host.getScrRefSourceProjectIdSync(0)).toBe('projSource');
+
+    // The setting echoes arrive out of order. Previously the STALE echo (40:5) — no longer matching
+    // the stored 40:0 — was treated as an external, frame-unknown change and CLEARED the source,
+    // leaving followers unable to convert (both panels show the raw ref). Both echoes are ours and
+    // must be ignored.
+    verseRefEcho({ book: 'PSA', chapterNum: 40, verseNum: 5 });
+    verseRefEcho({ book: 'PSA', chapterNum: 40, verseNum: 0 });
+
+    expect(host.getScrRefSourceProjectIdSync(0)).toBe('projSource'); // source preserved
+    expect(host.getScrRefSync(0)).toEqual({ book: 'PSA', chapterNum: 40, verseNum: 0 });
+  });
+
+  it('still applies a genuine external platform.verseRef change it never mirrored', async () => {
+    const host = await import('@renderer/services/scroll-group.service-host');
+    await host.startScrollGroupService();
+    const verseRefEcho = verseRefSubscriberRef.current;
+    if (!verseRefEcho) throw new Error('verseRef subscriber was not captured');
+
+    host.setScrRefSync(0, { book: 'PSA', chapterNum: 40, verseNum: 5 }, 'projSource');
+
+    // An external writer sets a reference this host never mirrored: it must still take effect, and
+    // (frame unknown) clear the source so followers do not mis-frame it — the documented behavior.
+    verseRefEcho({ book: 'GEN', chapterNum: 1, verseNum: 1 });
+
+    expect(host.getScrRefSync(0)).toEqual({ book: 'GEN', chapterNum: 1, verseNum: 1 });
+    expect(host.getScrRefSourceProjectIdSync(0)).toBeUndefined();
   });
 });

--- a/src/renderer/services/scroll-group.service-host.ts
+++ b/src/renderer/services/scroll-group.service-host.ts
@@ -117,6 +117,31 @@ const scrRefSourceProjectIdsSerialized = localStorage.getItem(
 const scrRefSourceProjectIds: { [scrollGroupId: ScrollGroupId]: string | undefined } =
   scrRefSourceProjectIdsSerialized ? (deserialize(scrRefSourceProjectIdsSerialized) ?? {}) : {};
 
+/**
+ * Verse-number keys of `platform.verseRef` values THIS host mirrored out (see the mirror in
+ * {@link setScrRefSync}), so the setting subscription in {@link startScrollGroupService} can
+ * recognize its own echoes and skip them. Reprocessing a self-mirrored value — which the
+ * subscription does with an undefined, frame-unknown source — can CLEAR a known versification
+ * source; and when several group-0 writes happen in quick succession (e.g. a toolbar navigation
+ * immediately followed by an editor settling on the chapter), a stale echo arrives after the stored
+ * ref has already moved on, so the no-op guard in `setScrRefSync` no longer catches it. Bounded:
+ * only very recent writes can still be echoing, so old keys are pruned.
+ */
+const recentlyMirroredVerseRefKeys = new Set<string>();
+const RECENTLY_MIRRORED_VERSE_REF_MAX = 20;
+/** Frame-blind key (book/chapter/verse only) for {@link recentlyMirroredVerseRefKeys}. */
+function verseRefKey(scrRef: SerializedVerseRef): string {
+  return `${scrRef.book}|${scrRef.chapterNum}|${scrRef.verseNum}`;
+}
+function rememberMirroredVerseRef(scrRef: SerializedVerseRef): void {
+  recentlyMirroredVerseRefKeys.add(verseRefKey(scrRef));
+  // Bound memory: drop the oldest (Set preserves insertion order) once over the cap.
+  if (recentlyMirroredVerseRefKeys.size > RECENTLY_MIRRORED_VERSE_REF_MAX) {
+    const oldestKey = recentlyMirroredVerseRefKeys.values().next().value;
+    if (oldestKey !== undefined) recentlyMirroredVerseRefKeys.delete(oldestKey);
+  }
+}
+
 // The scrRefs object might contain old values that are of older types that are no longer supported.
 // We need to check if this is the case, and convert them to `SerializedVerseRef`.
 Object.entries(scrRefs).forEach(([key, value]) => {
@@ -533,7 +558,11 @@ export function setScrRefSync(
   // event above so followers re-convert, but must NOT rewrite the setting: platform.verseRef tracks
   // the verse, not the frame, and settingsService.set fans out to every settings subscriber — an
   // identical-value write would be a needless app-wide notification.
-  if (shouldSetVerseRefSetting && scrollGroupIdDefaulted === 0 && !scrRefUnchanged)
+  if (shouldSetVerseRefSetting && scrollGroupIdDefaulted === 0 && !scrRefUnchanged) {
+    // Record what we're about to mirror so the setting subscription can skip the echo this write
+    // triggers (see recentlyMirroredVerseRefKeys). Done synchronously — before the async set below —
+    // so the key is already present when the echo fires.
+    rememberMirroredVerseRef(scrRefClone);
     (async () => {
       try {
         settingsService.set('platform.verseRef', scrRefClone);
@@ -543,6 +572,7 @@ export function setScrRefSync(
         );
       }
     })();
+  }
 
   return true;
 }
@@ -573,6 +603,15 @@ export async function startScrollGroupService(): Promise<void> {
       );
       return;
     }
+    // Skip our own mirror echoes. setScrRefSync mirrors every group-0 verse change out to this
+    // setting, so most notifications here are values this host just wrote. Reprocessing one (with an
+    // undefined source, below) can CLEAR a known versification source — and when several group-0
+    // writes race (e.g. a toolbar navigation immediately followed by an editor settling on the
+    // chapter), a stale echo arrives after the stored ref has moved on, so setScrRefSync's no-op
+    // guard no longer catches it and it wrongly clears the frame, leaving followers unable to convert
+    // (both panels then show the same raw ref). Recognize the echo by the key recorded when mirroring
+    // and consume it; genuine external writers (values this host never mirrored) still flow through.
+    if (recentlyMirroredVerseRefKeys.delete(verseRefKey(newScrRef))) return;
     // Pass `undefined` for the source: the setting carries no source-project frame, so a restored /
     // external platform.verseRef value has an unknown versification and must NOT be assumed to be in
     // the previous source project's frame. When the numbers match the stored ref this is a harmless


### PR DESCRIPTION
## Summary

The main application toolbar's scroll group and Book/Chapter/Verse (BCV) control now follow the active (focused) scripture tab. Focus a tab synced to scroll group C and the toolbar switches to group C and shows that tab's reference — matching PT9's behavior. Previously the toolbar's scroll group was a standalone `localStorage` value with no awareness of the active tab.

Jira: [PT-2602](https://paratextstudio.atlassian.net/browse/PT-2602)

## Stacked on #2478 (please review that first)

This is **based on `pt-4036-versification-aware-sync` (#2478)**, not `main`, because it depends on that PR's versification-aware `useScrollGroupScrRef`. This PR therefore targets `pt-4036-versification-aware-sync` as its base so its diff shows only the PT-2602 changes. **Once #2478 merges, this branch will be rebased onto `main` and retargeted.**

The toolbar passes the **active tab's `projectId`** to #2478's versification-aware hook, so the toolbar BCV shows the identical reference the active tab shows, even across versification divergence points (Psalm headings, 3 John, etc.).

## Changes

- **New toolbar-internal hook** `src/renderer/components/use-active-tab-scroll-group.hook.ts` — reads window focus (the `platform.windowServiceDataProvider` `Focus` type) and the focused WebView's saved definition to expose the last active scripture tab's `{ webViewId, scrollGroupId, projectId }`, ignoring transient `'other'`/non-webview focus (keep-last). Not exported through any shared barrel.
- **Toolbar wiring** `src/renderer/components/platform-bible-toolbar.tsx` — a follow-effect (keyed on the active tab's identity) adopts the active tab's numbered scroll group; a small `effectiveProjectId` derivation (attached → the active tab's project; otherwise the driven group's own source project) replaces the `currentProject?.id` argument #2478 introduced.
- Design spec + implementation plan under `docs/superpowers/`.

## Key design decisions (full rationale + PT9 source analysis in the spec)

- **Non-destructive top selector (intentional divergence from PT9):** changing the top-bar scroll-group selector re-points what the toolbar drives; it does **not** re-group the active editor. PT10 already has a per-tab selector for that, so making the top one a second mutator would be redundant. The toolbar performs **no write-back** to any WebView definition.
- **Keep-last:** when the active tab has no numbered scroll group (non-scripture WebView, or an independent "no scroll group" ref), the toolbar keeps its last group.
- **Override "move the verse, nothing else":** navigating a group from the toolbar while overridden preserves that group's versification source.

## AI Involvement

AI-assisted. The human developer (Matt Lyons) directed and reviewed every design decision. Workflow: collaborative brainstorming (including verifying the actual PT9 behavior against the Paratext 9 source), a written design spec, an implementation plan, then subagent-driven TDD implementation with an independent code review after each task and a whole-branch review before opening this PR. All code was human-reviewed. (Session link to be added.)

## Testing

- [x] Unit tests pass — 25 tests (9 hook + 16 toolbar), including a falsifiable regression test guarding the synchronous definition derivation (no stale `webViewId`/group pairing on a tab switch).
- [x] `npm run typecheck` / `npm run lint` clean for the changed files.
- [ ] **Manual/visual verification — not yet run** (why this is a draft): confirm in power mode that the toolbar BCV matches the active tab's displayed ref across a versification divergence point with two different-versification projects in one scroll group; plus a simple-mode display sanity check.

## Risk Level

**Low** — additive, renderer-only, display-follow behavior; no new services or cross-process contracts; backward compatible (the `platform-bible-toolbar.scrollGroupId` `localStorage` key is retained); no write-back to WebView definitions.

[PT-2602]: https://paratextstudio.atlassian.net/browse/PT-2602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2489)
<!-- Reviewable:end -->
