### PR TITLE
fix(find): skip books not in project instead of erroring (PT-4089)

### DIFF
--- a/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-finder-pdpe.model.ts
+++ b/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-finder-pdpe.model.ts
@@ -50,6 +50,28 @@ function getBookAndChapterFromLocation(location: UsjChapterLocation | UsfmVerseL
   return { book: verseRef.book, chapterNum: verseRef.chapterNum };
 }
 
+/**
+ * Error name marking the "scripture absent from the project" condition thrown by
+ * {@link ScriptureFinderProjectDataProviderEngine} internals when the underlying USX PDP returns no
+ * data for a requested book/chapter. Find uses {@link isScriptureNotFoundError} to skip scopes that
+ * reference books not present in the project instead of aborting the entire find job. See PT-4089.
+ */
+const SCRIPTURE_NOT_FOUND_ERROR_NAME = 'ScriptureNotFoundError';
+
+/** Creates the sentinel error thrown when a requested book/chapter is not present in the project. */
+function createScriptureNotFoundError(bookId: string, chapter: number | undefined): Error {
+  const error = new Error(
+    `No scripture found for: ${JSON.stringify({ bookId, chapter: chapter ?? 'entire book' })}`,
+  );
+  error.name = SCRIPTURE_NOT_FOUND_ERROR_NAME;
+  return error;
+}
+
+/** Whether an unknown thrown value is the "scripture not present in the project" sentinel. */
+function isScriptureNotFoundError(error: unknown): boolean {
+  return error instanceof Error && error.name === SCRIPTURE_NOT_FOUND_ERROR_NAME;
+}
+
 // This interface doesn't provide any normal data types that PDPs use
 export const SCRIPTURE_FINDER_PROJECT_INTERFACES = [
   'platformScripture.findInScripture',
@@ -906,11 +928,27 @@ export class ScriptureFinderProjectDataProviderEngine
 
   /** Find results within a single scope. Stop requests will not stop a scope in progress. */
   async #findInScope(scope: FindScope, job: FindJob): Promise<FindResult[]> {
-    // Fetch the reader writer and character categorizer in parallel
-    const [usj, characterCategorizer] = await Promise.all([
-      this.#getOrCreateCachedReaderWriter(scope.bookId, scope.chapter),
-      this.#getOrCreateCachedCharacterCategorizer(),
-    ]);
+    // A scope that references a book/chapter not present in this project has no scripture to
+    // search, so skip it (yielding no results) rather than aborting the whole find job — e.g. when
+    // the Find web view retains a selected-books scope that includes a book from a previous project
+    // the current project does not contain (PT-4089). Only the reader-writer fetch can raise the
+    // "not present" sentinel, so it is the only call wrapped here; a genuine failure from the
+    // categorizer fetch below still propagates and errors the job.
+    let usj: UsjReaderWriter;
+    try {
+      usj = await this.#getOrCreateCachedReaderWriter(scope.bookId, scope.chapter);
+    } catch (err) {
+      if (isScriptureNotFoundError(err)) {
+        logger.info(
+          `Scripture Finder: skipping scope for book "${scope.bookId}"${
+            scope.chapter !== undefined ? ` chapter ${scope.chapter}` : ''
+          } — not present in the project`,
+        );
+        return [];
+      }
+      throw err;
+    }
+    const characterCategorizer = await this.#getOrCreateCachedCharacterCategorizer();
 
     const matches = usj.search(buildSearchRegex(job.options, characterCategorizer), {
       markerStylesToInclude: job.options.verseTextOnly ? USFM_VERSE_TEXT_MARKERS_SET : undefined,
@@ -1015,10 +1053,7 @@ export class ScriptureFinderProjectDataProviderEngine
         const usx = isChapterLevel
           ? await this.#pdps['platformScripture.USX_Chapter'].getChapterUSX(verseRef)
           : await this.#pdps['platformScripture.USX_Book'].getBookUSX(verseRef);
-        if (!usx)
-          throw new Error(
-            `No scripture found for: ${JSON.stringify({ bookId, chapter: chapter ?? 'entire book' })}`,
-          );
+        if (!usx) throw createScriptureNotFoundError(bookId, chapter);
 
         // If the cache was invalidated during the fetch, the data we just got may be stale.
         // The retried USX is known to be out-of-date when this happens on the final retry, but

--- a/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-finder-pdpe.test.ts
+++ b/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-finder-pdpe.test.ts
@@ -2207,6 +2207,46 @@ describe('ScriptureFinderProjectDataProviderEngine find job API', () => {
     expect(foundBooks.has('MAT')).toBe(true);
     expect(foundBooks.has('MRK')).toBe(true);
   });
+
+  it('should skip a scoped book that is not present in the project and still return results from present books (PT-4089)', async () => {
+    // Reproduces PT-4089: the Find web view can retain a selected-books scope that includes a book
+    // from a previous project which the current project does not contain. When a scoped book is not
+    // present, its book USX is undefined. The whole find job must NOT abort — absent books are
+    // skipped and present books still return results. (Both scopes below are book-level, so only
+    // getBookUSX is exercised.)
+    vi.mocked(mockPdps['platformScripture.USX_Book'].getBookUSX).mockImplementation(
+      (verseRef: { book: string }) =>
+        Promise.resolve(verseRef.book === 'MAT' ? TEST_BOOK_USX : undefined),
+    );
+
+    // GEN (absent) is listed FIRST so the pre-fix behavior aborts the job before MAT is ever searched.
+    const jobId = await engine.beginFindJob({
+      searchString: 'Jesus',
+      scope: [{ bookId: 'GEN' }, { bookId: 'MAT' }],
+      caseInsensitive: false,
+    });
+
+    const foundBooks = new Set<string>();
+    let report = await engine.retrieveFindJobUpdate(jobId, 1000);
+    (report.nextResults ?? []).forEach((r) => foundBooks.add(r.start.verseRef.book));
+    while (report.status === 'running') {
+      // Polling requires sequential awaits; parallelizing would race against job completion.
+      // eslint-disable-next-line no-await-in-loop
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 10);
+      });
+      // Sequential await required to get updated status after each polling delay.
+      // eslint-disable-next-line no-await-in-loop
+      report = await engine.retrieveFindJobUpdate(jobId, 1000);
+      (report.nextResults ?? []).forEach((r) => foundBooks.add(r.start.verseRef.book));
+    }
+
+    // Before the fix: the absent GEN scope throws "No scripture found", aborting the entire job
+    // (status 'errored', no MAT results). After the fix: GEN is skipped and MAT still returns hits.
+    expect(report.status).toBe('completed');
+    expect(foundBooks.has('MAT')).toBe(true);
+    expect(foundBooks.has('GEN')).toBe(false);
+  });
 });
 
 describe('ScriptureFinderProjectDataProviderEngine ignoreDiacritics', () => {


### PR DESCRIPTION
## Summary

Fixes **[PT-4089](https://paratextstudio.atlassian.net/browse/PT-4089)** — *"Find: Books not in a project throws error."*

The Find/Replace web view persists its selected-books scope in web-view state (`findSelectedBookIds`), and the same web view is reused across project switches (`openFind` → `reloadWebView`). `findScope` maps those selected book IDs to search scopes **without filtering to the current project's `booksPresent`**, so a book selected in one project survives into another that does not contain it.

On the backend, `#getOrCreateCachedReaderWriter` returns no USX for the absent book and threw a generic error; `#processFindJob` wraps **all** scopes in a single `try/catch`, so one absent book marked the **entire** find job `errored` — "Find does not work at all" (zero results when the absent book sorts first in the scope).

### The fix (minimal, backend)

- The "no scripture for this book/chapter" condition is now a **named sentinel error** (`createScriptureNotFoundError` / `isScriptureNotFoundError`).
- `#findInScope` catches **only** that sentinel and **skips** the absent scope (returns no results) instead of aborting the whole job. Present books still return results; a job whose scopes are all absent completes with zero results rather than erroring.
- Genuine failures (rejected USX fetches, categorizer errors) still propagate and error the job. The `replace` path is unaffected — it still rejects on a missing book.

Only the reader-writer fetch is wrapped (the sole source of the sentinel), so a categorizer failure can't be masked.

## Reproduction evidence (regression test)

New test: `should skip a scoped book that is not present in the project and still return results from present books (PT-4089)` — a find over `[absent GEN, present MAT]` (absent book first).

**Before (RED):**
```
FAIL  platform-scripture-finder-pdpe.test.ts > ... > should skip a scoped book that is not present ... (PT-4089)
AssertionError: expected 'errored' to be 'completed'
Expected: "completed"
Received: "errored"
```

**After (GREEN):**
```
✓ src/platform-scripture/src/project-data-provider/platform-scripture-finder-pdpe.test.ts (76 tests)
  Test Files  1 passed (1)
       Tests  76 passed (76)
```

Also verified: `npm`-workspace ESLint clean and no new TypeScript errors on the changed file.

## Self-review

- Adversarial skeptic verified the root cause against the code (scope never filtered to present books; whole-job `try/catch`; order-dependent zero results).
- Correctness review (SHIP-WITH-NITS): sentinel round-trips (thrown and caught in-process, not serialized); catch is narrow so genuine errors still propagate; replace path preserved; all-absent job completes with zero results; `percentComplete` still advances; the regression test is falsifiable (fails without the fix). Both actionable nits addressed (narrowed the `try` to eliminate a `Promise.all` race; removed a dead mock override).

## Impact + confidence

- **Impact 6** — user-visible (`severity 3`: Find completely broken), `frequency 2` (any project switch after a selected-books search; common for testers). `userVisible × severity × frequency = 6`.
- **Confidence 0.8** — root cause verified in code and by an independent skeptic; reproduced with a failing test that passes after the fix.

### Known follow-ups (out of scope here)

This PR fixes the crash/"Find doesn't work" defect. The remaining UX items from PT-4089 are a separate, frontend concern and are intentionally **not** addressed here:
- Stale book badges still render for out-of-project selections, and there is no per-book deselect for a book absent from the current project (only "Clear all"). A frontend fix should prune `selectedBookIds` to `booksPresent` once the setting loads (gated on the setting actually being loaded to avoid dropping all books mid-load).

---

Provenance: found and fixed by the automated **quality-sweep** run (`qs-2026-07-02`).

AI-assisted — this change was drafted with AI assistance and reviewed by the author.


[PT-4089]: https://paratextstudio.atlassian.net/browse/PT-4089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2496)
<!-- Reviewable:end -->
