### PR TITLE
docs: clarify where agents should place rules and guidance

### DIFF
--- a/.claude/rules/where-to-add-guidance.md
+++ b/.claude/rules/where-to-add-guidance.md
@@ -1,21 +1,20 @@
+---
+paths:
+  - .claude/rules/**
+  - .context/standards/**
+  - lib/platform-bible-react/src/stories/guidelines/**
+  - CLAUDE.md
+  - docs/adr/**
+---
+
 # Where to Add Rules and Guidance
 
-When adding new rules, guidelines, or decisions to the codebase, place them in the correct location based on ownership and scope.
-
-## Quick Reference
-
-| Location | Owner | Who reviews changes |
+| Location | Ownership | Review required |
 |---|---|---|
 | `.claude/rules/ux/` | UX team | UX team internally |
 | `lib/platform-bible-react/src/stories/guidelines/` | UX team | UX team internally |
-| `.claude/rules/` (other subdirectories) | Dev team | Dev team |
-| `.context/standards/` | Dev team | Requires broader dev review |
-| `CLAUDE.md` | Dev team | Requires broader dev review |
+| `.claude/rules/` (other) | Dev team | Dev team |
+| `.context/standards/` | Any team | Broader dev review |
+| `CLAUDE.md` | Dev team | Broader dev review |
 
-## Rules
-
-1. **UX-owned areas**: `.claude/rules/ux/` and `lib/platform-bible-react/src/stories/guidelines/` are where the UX team has autonomy to document conventions, vocabulary, and decisions. Changes there do not require cross-team review. Note: these guidelines _are_ picked up by LLMs doing work across the whole codebase, not just UX work.
-
-2. **Common areas** (`.context/standards/`, `CLAUDE.md`): These apply to the whole team. Changes require broader dev team review — do not add to these unilaterally on behalf of one group.
-
-3. **When in doubt**: Prefer a UX-owned location and note that broader adoption can be discussed separately. Do not promote a decision to a common area without consensus.
+Prefer `.claude/rules/` for focused, path-scoped guidance; use `.context/standards/` for universal policies that apply everywhere. When in doubt, use a narrower scope — broader adoption can always be promoted later with team consensus.

--- a/.claude/rules/where-to-add-guidance.md
+++ b/.claude/rules/where-to-add-guidance.md
@@ -4,6 +4,9 @@ paths:
   - .context/standards/**
   - lib/platform-bible-react/src/stories/guidelines/**
   - CLAUDE.md
+  # docs/adr/** is intentional: catches agents that try to create ADR files here and
+  # redirects them to the correct location via the table below. No ADRs live here yet.
+  - docs/adr/**
 ---
 
 # Where to Add Rules and Guidance

--- a/.claude/rules/where-to-add-guidance.md
+++ b/.claude/rules/where-to-add-guidance.md
@@ -4,7 +4,6 @@ paths:
   - .context/standards/**
   - lib/platform-bible-react/src/stories/guidelines/**
   - CLAUDE.md
-  - docs/adr/**
 ---
 
 # Where to Add Rules and Guidance

--- a/.claude/rules/where-to-add-guidance.md
+++ b/.claude/rules/where-to-add-guidance.md
@@ -1,0 +1,21 @@
+# Where to Add Rules and Guidance
+
+When adding new rules, guidelines, or decisions to the codebase, place them in the correct location based on ownership and scope.
+
+## Quick Reference
+
+| Location | Owner | Who reviews changes |
+|---|---|---|
+| `.claude/rules/ux/` | UX team | UX team internally |
+| `lib/platform-bible-react/src/stories/guidelines/` | UX team | UX team internally |
+| `.claude/rules/` (other subdirectories) | Dev team | Dev team |
+| `.context/standards/` | Dev team | Requires broader dev review |
+| `CLAUDE.md` | Dev team | Requires broader dev review |
+
+## Rules
+
+1. **UX-owned areas**: `.claude/rules/ux/` and `lib/platform-bible-react/src/stories/guidelines/` are where the UX team has autonomy to document conventions, vocabulary, and decisions. Changes there do not require cross-team review. Note: these guidelines _are_ picked up by LLMs doing work across the whole codebase, not just UX work.
+
+2. **Common areas** (`.context/standards/`, `CLAUDE.md`): These apply to the whole team. Changes require broader dev team review — do not add to these unilaterally on behalf of one group.
+
+3. **When in doubt**: Prefer a UX-owned location and note that broader adoption can be discussed separately. Do not promote a decision to a common area without consensus.

--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,7 @@ e2e-tests/.dev-server.pid
 
 
 docs/superpowers/
+docs/adr/
 .superpowers/
 .review
 


### PR DESCRIPTION
## Summary

Adds `.claude/rules/where-to-add-guidance.md` — a single small file that tells future agents (and people) where to put new rules and guidelines based on ownership:

- `.claude/rules/ux/` and `lib/platform-bible-react/src/stories/guidelines/` → UX team owns, no cross-team review needed
- `.context/standards/`, `CLAUDE.md` → common area, requires broader dev review

This captures the decision from the UX/dev-lead conversation so agents don't silently put UX-specific guidance into shared areas (or vice versa).

AI-assisted — [session](https://claude.ai/code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CMVEY3F7fFUGJAhMQ1oTNx)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2498)
<!-- Reviewable:end -->
