### PR TITLE
PT-4068/PT-4069: Add Comments tab to Column 3 in Simple mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,8 +64,6 @@ docs/superpowers/
 docs/adr/
 .superpowers/
 .review
-/.claude/*.lock
-/.claude/settings.local.json
 
 # cursor
 .cursor/

--- a/e2e-tests/CLAUDE.md
+++ b/e2e-tests/CLAUDE.md
@@ -1,0 +1,27 @@
+# E2E Test Instructions
+
+## Where to put new E2E tests
+
+| What you're testing | Where it goes | How to run |
+|---|---|---|
+| Core happy path (app launch, basic nav) | `tests/smoke/` | `npm run test:e2e:smoke` (also CI) |
+| Feature tests, state-mutating flows | `tests/isolated/` | `npm run test:e2e:isolated` |
+| Tests needing real Marble resources | `tests/enhanced-resources/` | `npm run test:e2e:enhanced-resources` |
+
+**Feature-specific isolated tests belong in `tests/isolated/`** — not in their own directory.
+The `isolated` project covers the whole `tests/isolated/` tree, so a new spec file there is
+immediately discoverable and runnable without any config changes.
+
+Only create a new top-level directory under `tests/` if the tests genuinely cannot share a
+project entry with `isolated/` (e.g., they need a completely different fixture or launch
+strategy). If you do, register a named project in `playwright.config.ts` and add a
+`test:e2e:<name>` npm script — see `enhanced-resources` as the template.
+
+## What NOT to do
+
+- Do not put feature tests in `smoke/` — smoke tests are for the core happy path and must stay
+  fast and CI-green.
+- Do not use `manage-books/` or `markers-checklist/` as models — those are legacy AI-porting
+  experiments not wired into any standard test run. See the README in each directory.
+- Do not create a new top-level directory just to give a feature its own folder; prefer adding
+  a well-named spec file to `isolated/` instead.

--- a/e2e-tests/fixtures/comment-test-helpers.ts
+++ b/e2e-tests/fixtures/comment-test-helpers.ts
@@ -220,7 +220,7 @@ export async function createCommentThreads(
  * 1. Waits for the dock layout's `loadLayout()` to complete (signalled by the first iframe — the Home
  *    webview — appearing). This prevents a race where `addWebViewToDock` runs before
  *    `loadLayout(testLayout)`, causing `loadLayout` to wipe the newly added editor tab.
- * 2. Calls `platformScriptureEditor.openResourceViewer` to open the scripture editor and get its
+ * 2. Calls `platformScriptureEditor.openScriptureEditor` to open the scripture editor and get its
  *    webViewId, then immediately calls `legacyCommentManager.openCommentList` with that webViewId.
  *    Both calls are retried together up to 5 times.
  *
@@ -237,7 +237,7 @@ export async function openCommentList(mainPage: Page, project: CommentTestProjec
   //
   //    Why: `registerDockLayout` (called from the PlatformDockLayout `useEffect`) calls
   //    `loadLayout()` asynchronously. `loadLayout` calls `getDockLayout()` (an already-resolved
-  //    promise), so its continuation is queued as a *microtask*. If `openResourceViewer` also
+  //    promise), so its continuation is queued as a *microtask*. If `openScriptureEditor` also
   //    resolves `getDockLayout()` around the same time — which happens when the PDP is cached and
   //    the extension-host round-trip is fast — `addWebViewToDock` can run *before* `loadLayout`'s
   //    `dockLayout.loadLayout(testLayout)` does. Then `loadLayout` wipes the newly added editor
@@ -249,7 +249,7 @@ export async function openCommentList(mainPage: Page, project: CommentTestProjec
 
   // 2. Pre-register both commands so individual PAPI calls don't time out while waiting.
   await waitForPapiMethodRegistered(
-    'command:platformScriptureEditor.openResourceViewer',
+    'command:platformScriptureEditor.openScriptureEditor',
     DEFAULT_WEBSOCKET_PORT,
     30_000,
   );
@@ -283,7 +283,7 @@ export async function openCommentList(mainPage: Page, project: CommentTestProjec
     // ── Phase A: open the editor and wait for its iframe ──────────────────────
 
     const editorId = await sendPapiRequestOnce<string | undefined>(
-      'command:platformScriptureEditor.openResourceViewer',
+      'command:platformScriptureEditor.openScriptureEditor',
       [project.projectId],
       DEFAULT_WEBSOCKET_PORT,
       60_000,
@@ -291,7 +291,7 @@ export async function openCommentList(mainPage: Page, project: CommentTestProjec
 
     if (!editorId) {
       console.warn(
-        `[openCommentList] Attempt ${attempt + 1}: openResourceViewer returned no webViewId`,
+        `[openCommentList] Attempt ${attempt + 1}: openScriptureEditor returned no webViewId`,
       );
       continue;
     }

--- a/e2e-tests/fixtures/comment.fixture.ts
+++ b/e2e-tests/fixtures/comment.fixture.ts
@@ -19,7 +19,12 @@ import {
   TestInfo,
   ConsoleMessage,
 } from '@playwright/test';
-import { launchElectronApp, ElectronAppContext, teardownElectronApp } from './helpers';
+import {
+  launchElectronApp,
+  ElectronAppContext,
+  teardownElectronApp,
+  preConfigureSettings,
+} from './helpers';
 
 export { expect } from '@playwright/test';
 
@@ -41,11 +46,21 @@ export const test = base.extend<CommentTestFixtures, CommentWorkerFixtures>({
     // Playwright worker-scoped fixtures use empty destructuring when they have no fixture dependencies
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
+      // Pre-configure English locale and simple mode in the settings file before launching so
+      // the app starts in the expected state. This avoids the mid-session locale-reload path
+      // (which sequentially reloads every open WebView and can take 5+ minutes).
+      const restoreSettings = preConfigureSettings({
+        'platform.interfaceLanguage': ['en'],
+        'platform.interfaceMode': 'simple',
+      });
       const ctx = await launchElectronApp({ envOverrides: { DEV_NOISY: 'false' } });
       await use(ctx);
 
       console.log('[teardown] Comment worker-scoped app teardown starting...');
       await teardownElectronApp(ctx);
+      // Restore the developer's settings file only after the app has fully closed so the app's
+      // own shutdown writes cannot clobber the restored contents.
+      restoreSettings();
       console.log('[teardown] Comment worker-scoped app teardown complete');
     },
     { scope: 'worker' },

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -482,16 +482,23 @@ export function addUsersToProject(projectDir: string, users: string[]): void {
 /**
  * Wait for the Platform.Bible UI to be fully ready beyond just React mounting. Waits for the
  * platform-dock layout to appear, then for the dialog service to finish registering menu commands
- * like `platform.about` (the dock can render before that async work completes).
+ * like `platform.about` (the dock can render before that async work completes), and finally for the
+ * full-screen initialization overlay to clear. The overlay lingers while async services (settings,
+ * theme) finish initializing — it must be gone before tests interact with the UI.
  */
-export async function waitForAppReady(page: Page, timeout = 60_000): Promise<void> {
+export async function waitForAppReady(page: Page, timeout = 90_000): Promise<void> {
   const start = Date.now();
   await page.waitForSelector('div[class*="dock-layout"]', {
     state: 'attached',
     timeout,
   });
-  const remaining = Math.max(0, timeout - (Date.now() - start));
-  await waitForPapiMethodRegistered(PLATFORM_ABOUT_COMMAND, DEFAULT_WEBSOCKET_PORT, remaining);
+  const remaining1 = Math.max(1000, timeout - (Date.now() - start));
+  await waitForPapiMethodRegistered(PLATFORM_ABOUT_COMMAND, DEFAULT_WEBSOCKET_PORT, remaining1);
+  const remaining2 = Math.max(1000, timeout - (Date.now() - start));
+  // The overlay (<div role="status" class="tw:fixed tw:inset-0 …">) intercepts pointer events
+  // while it is visible. Services like settings and theme finish async work after dock-layout
+  // mounts and platform.about registers, so the overlay can outlast both earlier signals.
+  await expect(page.locator('.pr-twp [role="status"]')).not.toBeVisible({ timeout: remaining2 });
 }
 
 /** Options accepted by {@link openFromEditorHamburger}. */

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -444,6 +444,49 @@ export async function waitForAtLeastOneProjectMetadata(
 }
 
 /**
+ * Path to the shared dev-appdata settings file. Platform.Bible reads this file at startup in
+ * development mode to restore user settings. Writing it before launching Electron is the correct
+ * way to pre-configure locale and interface mode for E2E tests — it avoids triggering the
+ * mid-session locale reload path, which sequentially reloads every open WebView.
+ */
+const DEV_APPDATA_SETTINGS_PATH = path.resolve(__dirname, '../../dev-appdata/data/settings.json');
+
+/**
+ * Merge the given key-value pairs into the dev-appdata settings file before launching the app.
+ * Preserves any existing settings (e.g. `platform.verseRef`) so the app session starts from the
+ * developer's saved state plus the overrides.
+ *
+ * Must be called BEFORE `launchElectronApp` so the app reads the correct values at startup.
+ *
+ * @returns A restore function that writes the settings file back to its exact pre-call contents (or
+ *   deletes it if it did not exist). Call it in worker teardown, AFTER the app has closed, so the
+ *   developer's saved settings are not permanently replaced by test values.
+ */
+export function preConfigureSettings(overrides: Record<string, unknown>): () => void {
+  const settingsDir = path.dirname(DEV_APPDATA_SETTINGS_PATH);
+  let originalContents: string | undefined;
+  let existing: Record<string, unknown> = {};
+  if (fs.existsSync(DEV_APPDATA_SETTINGS_PATH)) {
+    originalContents = fs.readFileSync(DEV_APPDATA_SETTINGS_PATH, 'utf-8');
+    try {
+      // JSON.parse returns `any`; asserting the known shape of the settings file
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      existing = JSON.parse(originalContents) as Record<string, unknown>;
+    } catch {
+      // Corrupt file — start fresh with only the overrides
+    }
+  }
+  fs.mkdirSync(settingsDir, { recursive: true });
+  fs.writeFileSync(DEV_APPDATA_SETTINGS_PATH, JSON.stringify({ ...existing, ...overrides }));
+
+  return () => {
+    if (originalContents !== undefined)
+      fs.writeFileSync(DEV_APPDATA_SETTINGS_PATH, originalContents);
+    else fs.rmSync(DEV_APPDATA_SETTINGS_PATH, { force: true });
+  };
+}
+
+/**
  * Adds the given usernames as team members of the specified Paratext project so they appear in the
  * "Assign to" dropdown.
  *
@@ -480,6 +523,16 @@ export function addUsersToProject(projectDir: string, users: string[]): void {
 }
 
 /**
+ * Wait for the full-screen workspace-updating overlay to be gone. The overlay (`<div role="status"
+ * class="tw:fixed tw:inset-0 …">`) intercepts pointer events while it is visible; it appears during
+ * app initialization and during dock rebuilds (e.g. project switches in simple mode). Clicks and
+ * iframe loads fail while it is up.
+ */
+export async function waitForOverlayGone(page: Page, timeout: number): Promise<void> {
+  await expect(page.locator('.pr-twp [role="status"]')).not.toBeVisible({ timeout });
+}
+
+/**
  * Wait for the Platform.Bible UI to be fully ready beyond just React mounting. Waits for the
  * platform-dock layout to appear, then for the dialog service to finish registering menu commands
  * like `platform.about` (the dock can render before that async work completes), and finally for the
@@ -495,10 +548,9 @@ export async function waitForAppReady(page: Page, timeout = 90_000): Promise<voi
   const remaining1 = Math.max(1000, timeout - (Date.now() - start));
   await waitForPapiMethodRegistered(PLATFORM_ABOUT_COMMAND, DEFAULT_WEBSOCKET_PORT, remaining1);
   const remaining2 = Math.max(1000, timeout - (Date.now() - start));
-  // The overlay (<div role="status" class="tw:fixed tw:inset-0 …">) intercepts pointer events
-  // while it is visible. Services like settings and theme finish async work after dock-layout
-  // mounts and platform.about registers, so the overlay can outlast both earlier signals.
-  await expect(page.locator('.pr-twp [role="status"]')).not.toBeVisible({ timeout: remaining2 });
+  // Services like settings and theme finish async work after dock-layout mounts and platform.about
+  // registers, so the overlay can outlast both earlier signals.
+  await waitForOverlayGone(page, remaining2);
 }
 
 /** Options accepted by {@link openFromEditorHamburger}. */

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -26,9 +26,17 @@ const config = defineConfig({
   globalSetup: './global-setup.ts',
   globalTeardown: './global-teardown.ts',
   outputDir: './test-results',
-  // Invariant: every directory under `tests/` (except `_example/`) MUST be reachable
-  // from at least one project entry below. If you add a new test directory, register it
-  // here AND wire it into either CI (`test:e2e:smoke`) or a local-only npm script.
+  // Convention: directories under `tests/` should generally be reachable from at least one project
+  // entry below. Most feature-specific e2e tests can be added under `isolated`. If you add a new
+  // test directory, register it here AND wire it into either CI (`test:e2e:smoke`) or a local-only
+  // npm script (`test:e2e:<name>`).
+  //
+  // See the README in each directory for more information about the nature of the tests.
+  //
+  // Exceptions:
+  // `_example/` — reference template for new tests, not a runnable test suite.
+  // Experimental tests that should not be wired into any standard test run. (e.g.,
+  // `manage-books/` and `markers-checklist/`)
   projects: [
     {
       name: 'smoke',

--- a/e2e-tests/tests/enhanced-resources/README.md
+++ b/e2e-tests/tests/enhanced-resources/README.md
@@ -1,0 +1,25 @@
+# enhanced-resources E2E Tests
+
+Local-only E2E tests that require real Marble resources (e.g., ESV16UK+) unavailable in CI.
+
+## What belongs here
+
+Tests that exercise features requiring licensed or large external resources that cannot be
+included in the repository or CI environment.
+
+## Prerequisites
+
+- A local Platform.Bible installation with the required Marble resources installed
+- The app running with CDP enabled: `./.erb/scripts/refresh.sh`
+
+## How to run
+
+```bash
+# Boot the app with CDP enabled (once)
+./.erb/scripts/refresh.sh
+
+# Run the tests
+npm run test:e2e:enhanced-resources
+```
+
+These tests are **not** wired into CI (`test:e2e:smoke`).

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -1,0 +1,24 @@
+# isolated E2E Tests
+
+Feature and state-mutating E2E tests that each run against their own Electron instance.
+
+## What belongs here
+
+- Feature-specific tests that can't share app state with other tests
+- Tests that mutate settings, projects, or layout state that would affect later tests if shared
+- Tests that need the app in a specific initial state (e.g., a particular interface mode)
+
+## How to run
+
+```bash
+# All isolated tests
+npm run test:e2e:isolated
+
+# A single file
+npx playwright test --config e2e-tests/playwright.config.ts --project=isolated e2e-tests/tests/isolated/<file>.spec.ts
+```
+
+## Subdirectories
+
+- `comment-assignment/` — tests for assigning comments to users
+- `overlay/` — tests for the project-switch transition overlay

--- a/e2e-tests/tests/isolated/comments-tab.spec.ts
+++ b/e2e-tests/tests/isolated/comments-tab.spec.ts
@@ -92,7 +92,7 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
     // Seed one comment thread in the test project
     await createCommentThreads(project, ['GEN 1:1'], ['Visible comment for PT-4068 test']);
 
-    // Open the project in the scripture editor (triggers openTextConnectionPanels in simple mode)
+    // Open the project in the scripture editor (triggers openOrUpdateRelatedPanels in simple mode)
     await waitForPapiMethodRegistered(
       'command:platformScriptureEditor.openResourceViewer',
       DEFAULT_WEBSOCKET_PORT,
@@ -181,7 +181,7 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
         SETTINGS_TIMEOUT_MS,
       );
 
-      // Open Project A — triggers openTextConnectionPanels(projectA.projectId)
+      // Open Project A — triggers openOrUpdateRelatedPanels(projectA.projectId)
       await sendPapiRequestOnce(
         'command:platformScriptureEditor.openResourceViewer',
         [projectA.projectId],
@@ -196,7 +196,7 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
         timeout: 20_000,
       });
 
-      // Switch to Project B — triggers openTextConnectionPanels(projectB.projectId)
+      // Switch to Project B — triggers openOrUpdateRelatedPanels(projectB.projectId)
       await sendPapiRequestOnce(
         'command:platformScriptureEditor.openResourceViewer',
         [projectB.projectId],

--- a/e2e-tests/tests/isolated/comments-tab.spec.ts
+++ b/e2e-tests/tests/isolated/comments-tab.spec.ts
@@ -3,38 +3,44 @@
  *
  * Tests verify:
  *
- * - The "Comments" tab is present in Column 3 in Simple mode (English)
+ * - The "Comments" tab is present in Column 3 in Simple mode
  * - Selecting the tab renders the comment-list panel
- * - When a project with comments is open, at least one comment is visible
- * - The Spanish tab label differs from English, is distinct from other Column 3 tabs, and uses
- *   sentence case
+ * - When a project with comments is open, at least one is visible in the Comments tab
  * - When the active project changes, the Comments tab updates
+ *
+ * ## Stable selectors
+ *
+ * Tab buttons use `data-web-view-id` (added to `PlatformTabTitle`) so tests find them by the fixed
+ * UUID from `simple-layout.data.ts`, not by localized text. This makes the tests locale-independent
+ * and immune to translation changes.
+ *
+ * The Comment List Panel's fixed UUID in the simple layout is COMMENT_LIST_PANEL_UUID below.
  *
  * ## Tab overflow
  *
- * At the default test window width (1280 px) the Column 3 tab titles ("Bible Texts",
- * "Commentaries", "Comments", etc.) might not all fit in the visible portion of the tab bar.
- * rc-tabs renders ALL tab nodes in the DOM at all times, but clips the ones that fall outside the
- * scrollable container. Although this might not be the case when tabs are represented by icons, the
- * "Comments" tab is typically clipped.
+ * At the default test window width (1280 px) the Column 3 tab titles may not all fit in the visible
+ * portion of the tab bar. (Once we replace named tabs with icon-identified tabs, this issue will
+ * not be relevant at most reasonable window widths.) Our tab component, rc-tabs, renders ALL tab
+ * nodes in the DOM at all times, but clips those that fall outside the scrollable container.
  *
- * Consequently:
- *
- * - `toBeAttached()` succeeds for the Comments tab even when it is clipped.
+ * - `toBeAttached()` / `data-web-view-id` queries succeed even for clipped tabs.
  * - `toBeVisible()` fails for a clipped tab (Playwright detects the overflow-hidden clip).
- * - `toBeVisible()` / direct `.click()` works for Commentaries because it is always in the visible
- *   area (it is the second tab).
  *
- * `clickCommentsTab` handles both cases: it clicks the tab directly if visible, or opens the
- * rc-tabs overflow dropdown (.dock-nav-more) and activates the tab from there — rc-tabs then
- * scrolls the now-active tab into the visible area as a side-effect.
+ * `clickCommentsTab` handles both cases: it clicks the tab title directly if visible, or opens the
+ * rc-tabs overflow dropdown (.dock-nav-more) and activates the tab from there.
  *
- * This workaround is temporary: once tab titles are replaced by icons the tabs will fit comfortably
- * at any reasonable window width.
+ * ## Locale / interface mode
+ *
+ * The comment fixture pre-configures `platform.interfaceLanguage: ['en']` and
+ * `platform.interfaceMode: 'simple'` in the settings file BEFORE launching Electron. The app
+ * therefore starts in the correct state without any mid-session locale reload (which would
+ * sequentially reload every open WebView).
  */
+import type { Page } from '@playwright/test';
 import { test, expect } from '../../fixtures/comment.fixture';
 import {
   waitForAppReady,
+  waitForOverlayGone,
   waitForPapiMethodRegistered,
   sendPapiRequestOnce,
 } from '../../fixtures/helpers';
@@ -45,103 +51,143 @@ import {
   createCommentThreads,
 } from '../../fixtures/comment-test-helpers';
 
-const SETTINGS_SET_METHOD = 'object:platform.settingsServiceDataProvider-data.set';
 const DEFAULT_WEBSOCKET_PORT = 8876;
 const SETTINGS_TIMEOUT_MS = 60_000;
-const PAPI_REQUEST_TIMEOUT_MS = 30_000;
 /**
- * `openResourceViewer` triggers `openOrUpdateRelatedPanels`, which sequentially awaits four PAPI
+ * `openScriptureEditor` triggers `openOrUpdateRelatedPanels`, which sequentially awaits four PAPI
  * commands. Each command opens a panel and can take several seconds; the combined response can
- * exceed the default 30 s PAPI request timeout. On a fresh Electron (warm startup, no cached
- * layout) the four panels can collectively take 2+ minutes. Use a generous timeout.
+ * exceed the default 30 s PAPI request timeout. Use a generous timeout.
  */
-const OPEN_RESOURCE_VIEWER_TIMEOUT_MS = 150_000;
+const OPEN_EDITOR_TIMEOUT_MS = 150_000;
 
 /**
- * Switch the app to English + Simple mode and wait for the dock to reload.
- *
- * Uses the Commentaries tab (expected to be one of the actually visible tabs) as the dock-reload
- * signal rather than the Comments tab, which may be clipped in the overflow area.
+ * Fixed UUID for the Comment List Panel tab in Column 3 of the simple layout. Source:
+ * src/renderer/components/docking/simple-layout.data.ts
  */
-async function switchToSimpleModeEnglish(mainPage: import('@playwright/test').Page): Promise<void> {
-  await waitForPapiMethodRegistered(
-    SETTINGS_SET_METHOD,
-    DEFAULT_WEBSOCKET_PORT,
-    SETTINGS_TIMEOUT_MS,
-  );
-  await sendPapiRequestOnce(
-    SETTINGS_SET_METHOD,
-    ['platform.interfaceLanguage', ['en']],
-    DEFAULT_WEBSOCKET_PORT,
-    PAPI_REQUEST_TIMEOUT_MS,
-  );
-  await sendPapiRequestOnce(
-    SETTINGS_SET_METHOD,
-    ['platform.interfaceMode', 'simple'],
-    DEFAULT_WEBSOCKET_PORT,
-    PAPI_REQUEST_TIMEOUT_MS,
-  );
-  // Commentaries is always one of the first two visible tabs — its appearance confirms the
-  // dock has reloaded with the simple layout. Use a generous timeout: the simple layout may
-  // not render until after the project-load overlay clears (up to ~90 s on a slow machine,
-  // after a language switch from Spanish → English, or when transitioning between locales in
-  // consecutive tests sharing the same Electron worker).
-  await expect(mainPage.locator('.dock-tab', { hasText: /^Commentaries$/ })).toBeVisible({
-    timeout: 120_000,
-  });
-  // Wait for any loading overlay to clear after the mode switch. waitForAppReady already cleared
-  // the initial app overlay; this catches any brief re-appearance during the layout transition.
-  await expect(mainPage.locator('.pr-twp [role="status"]')).not.toBeVisible({ timeout: 90_000 });
+const COMMENT_LIST_PANEL_UUID = 'c7e4a8b2-3d91-4f06-8e5a-1b2c9d0e7f83';
+
+/**
+ * Fixed UUID for the Column 2 scripture-editor slot in the simple layout. Source:
+ * src/renderer/components/docking/simple-layout.data.ts
+ *
+ * `openScriptureEditor` replaces this slot with the project editor. It must be present in the dock
+ * state before `openScriptureEditor` is called, otherwise the replace fails with "target tab not
+ * found". Waiting for its tab title to be attached confirms the dock has fully processed the simple
+ * layout — the slot is guaranteed to be in the dock state at that point.
+ */
+const SCRIPTURE_EDITOR_SLOT_UUID = '3cf575f0-2cc2-464b-8765-b588f216dfce';
+
+/**
+ * Wait for the simple layout to be ready with all Column 2 and Column 3 tabs present, and the
+ * workspace-updating overlay cleared.
+ *
+ * Waits for:
+ *
+ * 1. The Comment List Panel tab title (UUID-based) — confirms legacyCommentManager activated.
+ * 2. The scripture editor slot tab title — confirms the dock processed the Column 2 slot so that
+ *    `openScriptureEditor` can replace it without a "target tab not found" error.
+ * 3. The workspace-updating overlay to be gone — confirms no dock rebuild is in progress that would
+ *    block clicks or iframe loading.
+ */
+async function waitForSimpleLayout(mainPage: Page): Promise<void> {
+  await Promise.all([
+    expect(
+      mainPage.locator(`.platform-tab-title[data-web-view-id="${COMMENT_LIST_PANEL_UUID}"]`),
+    ).toBeAttached({ timeout: 120_000 }),
+    expect(
+      mainPage.locator(`.platform-tab-title[data-web-view-id="${SCRIPTURE_EDITOR_SLOT_UUID}"]`),
+    ).toBeAttached({ timeout: 120_000 }),
+  ]);
+  // Wait for any workspace-updating overlay to clear. It can appear (and reappear) during dock
+  // rebuilds triggered by extension activation.
+  await waitForOverlayGone(mainPage, 90_000);
 }
 
-/** Column 3 tab bar, identified by the always-visible Commentaries tab as an anchor. */
-function getCol3Bar(mainPage: import('@playwright/test').Page): import('@playwright/test').Locator {
-  return mainPage.locator('.dock-bar').filter({
-    has: mainPage.locator('.dock-tab', { hasText: /^Commentaries$/ }),
-  });
+/**
+ * Returns a FrameLocator for the comment-list-panel iframe.
+ *
+ * Uses the UUID-based `data-web-view-id` attribute on the iframe (set by `web-view.component.tsx`)
+ * rather than `iframe[title="Comments"]`, which depends on the localization service having
+ * initialized before the WebView's first `getWebView()` call. The UUID attribute is always present
+ * regardless of whether the title resolved.
+ */
+function commentsFrameLocator(mainPage: Page) {
+  return mainPage.frameLocator(`iframe[data-web-view-id="${COMMENT_LIST_PANEL_UUID}"]`);
+}
+
+/**
+ * Calls `openScriptureEditor` via PAPI to open the main (editable) project, retrying up to
+ * `maxRetries` times if the dock throws "Replacing tab failed". That error is a known transient
+ * race condition: `openOrUpdateRelatedPanels` can trigger a dock rebuild that briefly removes the
+ * editor slot from the layout, causing the subsequent replace to fail. A short delay and retry
+ * reliably succeeds once the dock settles.
+ */
+async function openScriptureEditor(
+  projectId: string,
+  port: number,
+  timeout: number,
+  maxRetries = 2,
+): Promise<void> {
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    if (attempt > 0)
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 2_000);
+      });
+    try {
+      await sendPapiRequestOnce(
+        'command:platformScriptureEditor.openScriptureEditor',
+        [projectId],
+        port,
+        timeout,
+      );
+      return;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (attempt >= maxRetries || !msg.includes('Replacing tab failed')) throw e;
+      // Otherwise fall through to the next loop iteration to retry after a short delay
+    }
+  }
 }
 
 /**
  * Click the Comments tab in Column 3.
  *
- * If the tab is scrolled outside the visible portion of the tab bar (clipped by the rc-tabs
+ * If the tab title is scrolled outside the visible portion of the tab bar (clipped by the rc-tabs
  * overflow container), hover the `.dock-nav-more` overflow button to open the dropdown, then click
- * the Comments option. rc-tabs scrolls the newly-active tab into the visible bar area as a
- * side-effect of activating it via the dropdown.
+ * the Comments option via its UUID attribute.
  */
-async function clickCommentsTab(
-  mainPage: import('@playwright/test').Page,
-  col3Bar: import('@playwright/test').Locator,
-): Promise<void> {
-  const tab = mainPage.locator('.dock-tab', { hasText: /^Comments$/ });
-  if (await tab.isVisible()) {
-    await tab.click();
+async function clickCommentsTab(mainPage: Page): Promise<void> {
+  const tabTitle = mainPage.locator(
+    `.platform-tab-title[data-web-view-id="${COMMENT_LIST_PANEL_UUID}"]`,
+  );
+  if (await tabTitle.isVisible()) {
+    await tabTitle.click();
     return;
   }
-  // Tab is clipped outside the visible scroll area — open the overflow dropdown and activate it.
-  await col3Bar.locator('.dock-nav-more').hover();
+  // Tab is outside the visible scroll area — open the overflow dropdown and activate it.
+  const dockBar = mainPage.locator('.dock-bar').filter({ has: tabTitle });
+  await dockBar.locator('.dock-nav-more').hover();
+  // rc-tabs re-renders PlatformTabTitle (including our data-web-view-id) in the overflow popup.
   await mainPage
-    .locator('[role="listbox"] [role="option"]', { hasText: /^Comments$/ })
+    .locator('[role="listbox"] [role="option"]')
+    .filter({ has: mainPage.locator(`[data-web-view-id="${COMMENT_LIST_PANEL_UUID}"]`) })
     .click({ timeout: 5_000 });
 }
 
 test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
-  // Test 5 (project changes) calls openResourceViewer twice with a 150 s budget each; on a
-  // fresh-Electron retry the combined time can exceed 5 minutes. Use 7 minutes to cover the
-  // worst case (two cold openResourceViewer calls + app startup + locale switch).
+  // First 3 tests: app startup (up to 180 s) + waitForSimpleLayout (up to 120 s) + test actions.
+  // "Project changes" test: two openScriptureEditor calls at 150 s each on top of startup.
+  // 7 minutes covers all cases.
   test.setTimeout(420_000);
   let project: CommentTestProject;
-  // projectA and projectB are used by the "project changes" test.  They are created here in
-  // beforeAll — before the Electron worker fixture starts — so that ScrTextCollection finds them
-  // when it initialises at app startup.  Creating them inside the test body (after startup) causes
-  // a race condition where GetProjectDataProviderID throws "Project not found" because
-  // ScrTextCollection hasn't scanned the new directories yet.
+  // projectA and projectB are used by the "project changes" test. Created here in beforeAll —
+  // before the Electron worker fixture starts — so that ScrTextCollection discovers them at
+  // startup. Creating them inside the test body (after startup) causes a race condition where
+  // GetProjectDataProviderID throws "Project not found".
   let projectA: CommentTestProject;
   let projectB: CommentTestProject;
 
   test.beforeAll(async () => {
-    // Create test projects before app starts (file system only, no WebSocket needed yet).
-    // All three must be created here so ScrTextCollection can discover them at startup.
     project = await createCommentTestProject([]);
     projectA = await createCommentTestProject([]);
     projectB = await createCommentTestProject([]);
@@ -155,21 +201,20 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
 
   test('Comments tab is visible in Column 3 in the English UI', async ({ mainPage }) => {
     await waitForAppReady(mainPage, 180_000);
-    await switchToSimpleModeEnglish(mainPage);
-
-    // The tab may be clipped in the rc-tabs overflow area at default window width, but it is
-    // always present in the DOM as part of the Column 3 layout (see file-level TSDoc).
-    await expect(mainPage.locator('.dock-tab', { hasText: /^Comments$/ })).toBeAttached();
+    await waitForSimpleLayout(mainPage);
+    // The UUID-based locator confirms the tab is in the DOM regardless of scroll position.
+    await expect(
+      mainPage.locator(`.platform-tab-title[data-web-view-id="${COMMENT_LIST_PANEL_UUID}"]`),
+    ).toBeAttached();
   });
 
   test('selecting the Comments tab displays the panel', async ({ mainPage }) => {
     await waitForAppReady(mainPage, 180_000);
-    await switchToSimpleModeEnglish(mainPage);
+    await waitForSimpleLayout(mainPage);
 
-    await clickCommentsTab(mainPage, getCol3Bar(mainPage));
+    await clickCommentsTab(mainPage);
 
-    // The Comments panel is an iframe; wait for its body to be attached
-    const commentsFrame = mainPage.frameLocator('iframe[title="Comments"]');
+    const commentsFrame = commentsFrameLocator(mainPage);
     await commentsFrame.locator('body').waitFor({ state: 'attached', timeout: 15_000 });
   });
 
@@ -177,138 +222,73 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
     mainPage,
   }) => {
     await waitForAppReady(mainPage, 180_000);
-    await switchToSimpleModeEnglish(mainPage);
+    await waitForSimpleLayout(mainPage);
 
-    // Seed one comment thread in the test project
     await createCommentThreads(project, ['GEN 1:1'], ['Visible comment for PT-4068 test']);
 
-    // Open the project in the scripture editor (triggers openOrUpdateRelatedPanels in simple mode)
+    // Point the panel at the test project. We call openCommentListPanel directly rather than
+    // going through openScriptureEditor/openOrUpdateRelatedPanels: the latter triggers three
+    // concurrent dock rebuilds (model text + two resource text panels) that call getWebView for
+    // the comment list panel while the sentinel is in flight, occasionally overwriting it with
+    // the previously-open developer project. Calling directly here is safe because
+    // waitForSimpleLayout already confirmed the dock is stable (overlay gone).
     await waitForPapiMethodRegistered(
-      'command:platformScriptureEditor.openResourceViewer',
+      'command:legacyCommentManager.openCommentListPanel',
       DEFAULT_WEBSOCKET_PORT,
       SETTINGS_TIMEOUT_MS,
     );
     await sendPapiRequestOnce(
-      'command:platformScriptureEditor.openResourceViewer',
+      'command:legacyCommentManager.openCommentListPanel',
       [project.projectId],
       DEFAULT_WEBSOCKET_PORT,
-      OPEN_RESOURCE_VIEWER_TIMEOUT_MS,
+      OPEN_EDITOR_TIMEOUT_MS,
     );
 
-    // Click the Comments tab
-    await clickCommentsTab(mainPage, getCol3Bar(mainPage));
+    await clickCommentsTab(mainPage);
 
-    // Verify at least the seeded comment content is visible
-    const commentsFrame = mainPage.frameLocator('iframe[title="Comments"]');
+    const commentsFrame = commentsFrameLocator(mainPage);
     await expect(commentsFrame.locator('body')).toContainText('Visible comment for PT-4068 test', {
-      timeout: 20_000,
+      timeout: 90_000,
     });
-  });
-
-  test('Spanish tab label differs from English, is distinct from other Column 3 tabs, and uses sentence case', async ({
-    mainPage,
-  }) => {
-    await waitForAppReady(mainPage, 180_000);
-    await switchToSimpleModeEnglish(mainPage);
-
-    // Switch to Spanish locale
-    await sendPapiRequestOnce(
-      SETTINGS_SET_METHOD,
-      ['platform.interfaceLanguage', ['es']],
-      DEFAULT_WEBSOCKET_PORT,
-      PAPI_REQUEST_TIMEOUT_MS,
-    );
-
-    // Wait directly for the Spanish Commentaries label to appear. This is more robust than waiting
-    // for the English label to disappear: on locale switch the dock may go through a full rebuild
-    // ("Updating project view" overlay) that can take 2+ minutes when multiple WebViews are open
-    // from prior tests sharing the same Electron worker (each WebView reload is sequential). A
-    // fresh-Electron retry is faster. Use a 3-minute timeout to cover both cases.
-    await expect(mainPage.locator('.dock-tab', { hasText: 'Comentarios bíblicos' })).toBeAttached({
-      timeout: 180_000,
-    });
-
-    // Locate Column 3's tab bar using the Spanish Commentaries label as a stable anchor. The tab
-    // is already attached (we just waited for it), so toBeVisible should pass quickly.
-    const col3TabBar = mainPage.locator('.dock-bar').filter({
-      has: mainPage.locator('.dock-tab', { hasText: 'Comentarios bíblicos' }),
-    });
-    await expect(col3TabBar).toBeVisible({ timeout: 15_000 });
-
-    // Column 3 should now have 3 tabs (Bible Texts, Commentaries, Comments — all in Spanish).
-    // All .dock-tab nodes are always in the DOM even if one or more is clipped by the overflow
-    // container, so toHaveCount and allTextContents work regardless of scroll position.
-    const col3Tabs = col3TabBar.locator('.dock-tab');
-    await expect(col3Tabs).toHaveCount(3, { timeout: 10_000 });
-    const tabTexts = await col3Tabs.allTextContents();
-    const [text0, text1, text2] = tabTexts.map((t) => t.trim());
-
-    // The 3rd tab (index 2) is our Comments tab in Spanish
-    const spanishLabel = text2;
-
-    // (a) Differs from the English label
-    expect(spanishLabel).not.toBe('Comments');
-
-    // (b) Distinct from all other Column 3 tab labels
-    expect(spanishLabel).not.toBe(text0);
-    expect(spanishLabel).not.toBe(text1);
-
-    // (c) Sentence case: first character uppercase, remaining characters lowercase
-    //     (Spanish sentence case: only the first word capitalised)
-    expect(spanishLabel.charAt(0)).toMatch(/[A-ZÁÉÍÓÚÜÑ]/);
-    expect(spanishLabel.slice(1)).toBe(spanishLabel.slice(1).toLowerCase());
   });
 
   test('Comments tab updates when the active project changes (PT-4069)', async ({ mainPage }) => {
+    // Two openScriptureEditor calls on top of normal startup. 10 minutes is comfortable.
+    test.setTimeout(600_000);
     await waitForAppReady(mainPage, 180_000);
-    await switchToSimpleModeEnglish(mainPage);
+    await waitForSimpleLayout(mainPage);
 
-    // Seed each project with a distinct comment thread (requires WebSocket — done inside test body)
     await createCommentThreads(projectA, ['GEN 1:1'], ['Project A unique comment text']);
     await createCommentThreads(projectB, ['GEN 1:1'], ['Project B unique comment text']);
 
     await waitForPapiMethodRegistered(
-      'command:platformScriptureEditor.openResourceViewer',
+      'command:platformScriptureEditor.openScriptureEditor',
       DEFAULT_WEBSOCKET_PORT,
       SETTINGS_TIMEOUT_MS,
     );
 
-    // Project A and B are opened via command rather than the active project dropdown in the title
-    // bar since newly created test projects won't be in the recent list, so there will be no easy
-    // and reliable UI path for project switching in this mode. The Home UI might also fail to
-    // display them without a force refresh, but in any case that will eventually not be available
-    // in Simple mode.
-    // Open Project A — triggers openOrUpdateRelatedPanels(projectA.projectId)
-    await sendPapiRequestOnce(
-      'command:platformScriptureEditor.openResourceViewer',
-      [projectA.projectId],
-      DEFAULT_WEBSOCKET_PORT,
-      OPEN_RESOURCE_VIEWER_TIMEOUT_MS,
-    );
+    // Open Project A and wait for the dock rebuilds triggered by openOrUpdateRelatedPanels to
+    // settle. The overlay intercepts pointer events while it is visible; clickCommentsTab fails
+    // if called while a rebuild is in progress.
+    await openScriptureEditor(projectA.projectId, DEFAULT_WEBSOCKET_PORT, OPEN_EDITOR_TIMEOUT_MS);
+    await waitForOverlayGone(mainPage, 90_000);
 
-    // Click the Comments tab and verify Project A's comment is visible
-    await clickCommentsTab(mainPage, getCol3Bar(mainPage));
-    // Wait for the Comments iframe to exist before accessing its frame — reloadWebView (called by
-    // openOrUpdateRelatedPanels) briefly removes and re-adds the iframe during content refresh.
-    await expect(mainPage.locator('iframe[title="Comments"]')).toBeAttached({ timeout: 30_000 });
-    const commentsFrame = mainPage.frameLocator('iframe[title="Comments"]');
+    await clickCommentsTab(mainPage);
+    await expect(
+      mainPage.locator(`iframe[data-web-view-id="${COMMENT_LIST_PANEL_UUID}"]`),
+    ).toBeAttached({ timeout: 30_000 });
+    const commentsFrame = commentsFrameLocator(mainPage);
     await expect(commentsFrame.locator('body')).toContainText('Project A unique comment text', {
-      timeout: 20_000,
+      timeout: 90_000,
     });
 
-    // Switch to Project B — triggers openOrUpdateRelatedPanels(projectB.projectId)
-    await sendPapiRequestOnce(
-      'command:platformScriptureEditor.openResourceViewer',
-      [projectB.projectId],
-      DEFAULT_WEBSOCKET_PORT,
-      OPEN_RESOURCE_VIEWER_TIMEOUT_MS,
-    );
+    // Switch to Project B and wait for dock rebuilds to settle before asserting.
+    await openScriptureEditor(projectB.projectId, DEFAULT_WEBSOCKET_PORT, OPEN_EDITOR_TIMEOUT_MS);
+    await waitForOverlayGone(mainPage, 90_000);
 
-    // Comments tab should now show Project B's comments
     await expect(commentsFrame.locator('body')).toContainText('Project B unique comment text', {
-      timeout: 20_000,
+      timeout: 90_000,
     });
-    // And no longer show Project A's
     await expect(commentsFrame.locator('body')).not.toContainText('Project A unique comment text');
   });
 });

--- a/e2e-tests/tests/isolated/comments-tab.spec.ts
+++ b/e2e-tests/tests/isolated/comments-tab.spec.ts
@@ -181,6 +181,11 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
         SETTINGS_TIMEOUT_MS,
       );
 
+      // Project A and B are opened via command rather than the active project dropdown in the title
+      // bar since newly created test projects won't be in the recent list, so there will be no easy
+      // and reliable UI path for project switching in this mode. The Home UI might also fail to
+      // display them without a force refresh, but in any case that will eventually not be available
+      // in Simple mode.
       // Open Project A — triggers openOrUpdateRelatedPanels(projectA.projectId)
       await sendPapiRequestOnce(
         'command:platformScriptureEditor.openResourceViewer',

--- a/e2e-tests/tests/isolated/comments-tab.spec.ts
+++ b/e2e-tests/tests/isolated/comments-tab.spec.ts
@@ -3,12 +3,34 @@
  *
  * Tests verify:
  *
- * - The "Comments" tab is visible in Column 3 in Simple mode (English)
+ * - The "Comments" tab is present in Column 3 in Simple mode (English)
  * - Selecting the tab renders the comment-list panel
  * - When a project with comments is open, at least one comment is visible
  * - The Spanish tab label differs from English, is distinct from other Column 3 tabs, and uses
  *   sentence case
  * - When the active project changes, the Comments tab updates
+ *
+ * ## Tab overflow
+ *
+ * At the default test window width (1280 px) the Column 3 tab titles ("Bible Texts",
+ * "Commentaries", "Comments", etc.) might not all fit in the visible portion of the tab bar.
+ * rc-tabs renders ALL tab nodes in the DOM at all times, but clips the ones that fall outside the
+ * scrollable container. Although this might not be the case when tabs are represented by icons, the
+ * "Comments" tab is typically clipped.
+ *
+ * Consequently:
+ *
+ * - `toBeAttached()` succeeds for the Comments tab even when it is clipped.
+ * - `toBeVisible()` fails for a clipped tab (Playwright detects the overflow-hidden clip).
+ * - `toBeVisible()` / direct `.click()` works for Commentaries because it is always in the visible
+ *   area (it is the second tab).
+ *
+ * `clickCommentsTab` handles both cases: it clicks the tab directly if visible, or opens the
+ * rc-tabs overflow dropdown (.dock-nav-more) and activates the tab from there — rc-tabs then
+ * scrolls the now-active tab into the visible area as a side-effect.
+ *
+ * This workaround is temporary: once tab titles are replaced by icons the tabs will fit comfortably
+ * at any reasonable window width.
  */
 import { test, expect } from '../../fixtures/comment.fixture';
 import {
@@ -27,8 +49,20 @@ const SETTINGS_SET_METHOD = 'object:platform.settingsServiceDataProvider-data.se
 const DEFAULT_WEBSOCKET_PORT = 8876;
 const SETTINGS_TIMEOUT_MS = 60_000;
 const PAPI_REQUEST_TIMEOUT_MS = 30_000;
+/**
+ * `openResourceViewer` triggers `openOrUpdateRelatedPanels`, which sequentially awaits four PAPI
+ * commands. Each command opens a panel and can take several seconds; the combined response can
+ * exceed the default 30 s PAPI request timeout. On a fresh Electron (warm startup, no cached
+ * layout) the four panels can collectively take 2+ minutes. Use a generous timeout.
+ */
+const OPEN_RESOURCE_VIEWER_TIMEOUT_MS = 150_000;
 
-/** Switch the app to English + Simple mode and wait for the Comments tab to appear. */
+/**
+ * Switch the app to English + Simple mode and wait for the dock to reload.
+ *
+ * Uses the Commentaries tab (expected to be one of the actually visible tabs) as the dock-reload
+ * signal rather than the Comments tab, which may be clipped in the overflow area.
+ */
 async function switchToSimpleModeEnglish(mainPage: import('@playwright/test').Page): Promise<void> {
   await waitForPapiMethodRegistered(
     SETTINGS_SET_METHOD,
@@ -47,36 +81,92 @@ async function switchToSimpleModeEnglish(mainPage: import('@playwright/test').Pa
     DEFAULT_WEBSOCKET_PORT,
     PAPI_REQUEST_TIMEOUT_MS,
   );
-  // Wait for the Comments tab to appear (confirms dock reloaded with simple layout)
-  await expect(mainPage.locator('.dock-tab', { hasText: /^Comments$/ })).toBeVisible({
-    timeout: 30_000,
+  // Commentaries is always one of the first two visible tabs — its appearance confirms the
+  // dock has reloaded with the simple layout. Use a generous timeout: the simple layout may
+  // not render until after the project-load overlay clears (up to ~90 s on a slow machine,
+  // after a language switch from Spanish → English, or when transitioning between locales in
+  // consecutive tests sharing the same Electron worker).
+  await expect(mainPage.locator('.dock-tab', { hasText: /^Commentaries$/ })).toBeVisible({
+    timeout: 120_000,
+  });
+  // Wait for any loading overlay to clear after the mode switch. waitForAppReady already cleared
+  // the initial app overlay; this catches any brief re-appearance during the layout transition.
+  await expect(mainPage.locator('.pr-twp [role="status"]')).not.toBeVisible({ timeout: 90_000 });
+}
+
+/** Column 3 tab bar, identified by the always-visible Commentaries tab as an anchor. */
+function getCol3Bar(mainPage: import('@playwright/test').Page): import('@playwright/test').Locator {
+  return mainPage.locator('.dock-bar').filter({
+    has: mainPage.locator('.dock-tab', { hasText: /^Commentaries$/ }),
   });
 }
 
+/**
+ * Click the Comments tab in Column 3.
+ *
+ * If the tab is scrolled outside the visible portion of the tab bar (clipped by the rc-tabs
+ * overflow container), hover the `.dock-nav-more` overflow button to open the dropdown, then click
+ * the Comments option. rc-tabs scrolls the newly-active tab into the visible bar area as a
+ * side-effect of activating it via the dropdown.
+ */
+async function clickCommentsTab(
+  mainPage: import('@playwright/test').Page,
+  col3Bar: import('@playwright/test').Locator,
+): Promise<void> {
+  const tab = mainPage.locator('.dock-tab', { hasText: /^Comments$/ });
+  if (await tab.isVisible()) {
+    await tab.click();
+    return;
+  }
+  // Tab is clipped outside the visible scroll area — open the overflow dropdown and activate it.
+  await col3Bar.locator('.dock-nav-more').hover();
+  await mainPage
+    .locator('[role="listbox"] [role="option"]', { hasText: /^Comments$/ })
+    .click({ timeout: 5_000 });
+}
+
 test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
+  // Test 5 (project changes) calls openResourceViewer twice with a 150 s budget each; on a
+  // fresh-Electron retry the combined time can exceed 5 minutes. Use 7 minutes to cover the
+  // worst case (two cold openResourceViewer calls + app startup + locale switch).
+  test.setTimeout(420_000);
   let project: CommentTestProject;
+  // projectA and projectB are used by the "project changes" test.  They are created here in
+  // beforeAll — before the Electron worker fixture starts — so that ScrTextCollection finds them
+  // when it initialises at app startup.  Creating them inside the test body (after startup) causes
+  // a race condition where GetProjectDataProviderID throws "Project not found" because
+  // ScrTextCollection hasn't scanned the new directories yet.
+  let projectA: CommentTestProject;
+  let projectB: CommentTestProject;
 
   test.beforeAll(async () => {
-    // Create test project before app starts (file system only, no WebSocket needed yet)
+    // Create test projects before app starts (file system only, no WebSocket needed yet).
+    // All three must be created here so ScrTextCollection can discover them at startup.
     project = await createCommentTestProject([]);
+    projectA = await createCommentTestProject([]);
+    projectB = await createCommentTestProject([]);
   });
 
   test.afterAll(() => {
     cleanupCommentTestProject(project);
+    cleanupCommentTestProject(projectA);
+    cleanupCommentTestProject(projectB);
   });
 
   test('Comments tab is visible in Column 3 in the English UI', async ({ mainPage }) => {
-    await waitForAppReady(mainPage);
+    await waitForAppReady(mainPage, 180_000);
     await switchToSimpleModeEnglish(mainPage);
 
-    await expect(mainPage.locator('.dock-tab', { hasText: /^Comments$/ })).toBeVisible();
+    // The tab may be clipped in the rc-tabs overflow area at default window width, but it is
+    // always present in the DOM as part of the Column 3 layout (see file-level TSDoc).
+    await expect(mainPage.locator('.dock-tab', { hasText: /^Comments$/ })).toBeAttached();
   });
 
   test('selecting the Comments tab displays the panel', async ({ mainPage }) => {
-    await waitForAppReady(mainPage);
+    await waitForAppReady(mainPage, 180_000);
     await switchToSimpleModeEnglish(mainPage);
 
-    await mainPage.locator('.dock-tab', { hasText: /^Comments$/ }).click();
+    await clickCommentsTab(mainPage, getCol3Bar(mainPage));
 
     // The Comments panel is an iframe; wait for its body to be attached
     const commentsFrame = mainPage.frameLocator('iframe[title="Comments"]');
@@ -86,7 +176,7 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
   test('when a project has comments, at least one is visible in the Comments tab', async ({
     mainPage,
   }) => {
-    await waitForAppReady(mainPage);
+    await waitForAppReady(mainPage, 180_000);
     await switchToSimpleModeEnglish(mainPage);
 
     // Seed one comment thread in the test project
@@ -102,11 +192,11 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
       'command:platformScriptureEditor.openResourceViewer',
       [project.projectId],
       DEFAULT_WEBSOCKET_PORT,
-      PAPI_REQUEST_TIMEOUT_MS,
+      OPEN_RESOURCE_VIEWER_TIMEOUT_MS,
     );
 
     // Click the Comments tab
-    await mainPage.locator('.dock-tab', { hasText: /^Comments$/ }).click();
+    await clickCommentsTab(mainPage, getCol3Bar(mainPage));
 
     // Verify at least the seeded comment content is visible
     const commentsFrame = mainPage.frameLocator('iframe[title="Comments"]');
@@ -118,7 +208,7 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
   test('Spanish tab label differs from English, is distinct from other Column 3 tabs, and uses sentence case', async ({
     mainPage,
   }) => {
-    await waitForAppReady(mainPage);
+    await waitForAppReady(mainPage, 180_000);
     await switchToSimpleModeEnglish(mainPage);
 
     // Switch to Spanish locale
@@ -129,19 +219,25 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
       PAPI_REQUEST_TIMEOUT_MS,
     );
 
-    // Wait for the English "Comments" tab to disappear (dock has re-rendered in Spanish)
-    await expect(mainPage.locator('.dock-tab', { hasText: /^Comments$/ })).not.toBeVisible({
-      timeout: 15_000,
+    // Wait directly for the Spanish Commentaries label to appear. This is more robust than waiting
+    // for the English label to disappear: on locale switch the dock may go through a full rebuild
+    // ("Updating project view" overlay) that can take 2+ minutes when multiple WebViews are open
+    // from prior tests sharing the same Electron worker (each WebView reload is sequential). A
+    // fresh-Electron retry is faster. Use a 3-minute timeout to cover both cases.
+    await expect(mainPage.locator('.dock-tab', { hasText: 'Comentarios bíblicos' })).toBeAttached({
+      timeout: 180_000,
     });
 
-    // Locate Column 3's tab bar using the known Spanish Commentaries label "Comentario bíblico"
-    // as a stable anchor. This avoids hardcoding our new label.
+    // Locate Column 3's tab bar using the Spanish Commentaries label as a stable anchor. The tab
+    // is already attached (we just waited for it), so toBeVisible should pass quickly.
     const col3TabBar = mainPage.locator('.dock-bar').filter({
-      has: mainPage.locator('.dock-tab', { hasText: 'Comentario bíblico' }),
+      has: mainPage.locator('.dock-tab', { hasText: 'Comentarios bíblicos' }),
     });
     await expect(col3TabBar).toBeVisible({ timeout: 15_000 });
 
-    // Column 3 should now have 3 tabs (Bible Texts, Commentaries, Comments — all in Spanish)
+    // Column 3 should now have 3 tabs (Bible Texts, Commentaries, Comments — all in Spanish).
+    // All .dock-tab nodes are always in the DOM even if one or more is clipped by the overflow
+    // container, so toHaveCount and allTextContents work regardless of scroll position.
     const col3Tabs = col3TabBar.locator('.dock-tab');
     await expect(col3Tabs).toHaveCount(3, { timeout: 10_000 });
     const tabTexts = await col3Tabs.allTextContents();
@@ -164,62 +260,55 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
   });
 
   test('Comments tab updates when the active project changes (PT-4069)', async ({ mainPage }) => {
-    await waitForAppReady(mainPage);
+    await waitForAppReady(mainPage, 180_000);
     await switchToSimpleModeEnglish(mainPage);
 
-    // Create two independent projects, each with a distinct comment
-    const projectA = await createCommentTestProject([]);
-    const projectB = await createCommentTestProject([]);
+    // Seed each project with a distinct comment thread (requires WebSocket — done inside test body)
+    await createCommentThreads(projectA, ['GEN 1:1'], ['Project A unique comment text']);
+    await createCommentThreads(projectB, ['GEN 1:1'], ['Project B unique comment text']);
 
-    try {
-      await createCommentThreads(projectA, ['GEN 1:1'], ['Project A unique comment text']);
-      await createCommentThreads(projectB, ['GEN 1:1'], ['Project B unique comment text']);
+    await waitForPapiMethodRegistered(
+      'command:platformScriptureEditor.openResourceViewer',
+      DEFAULT_WEBSOCKET_PORT,
+      SETTINGS_TIMEOUT_MS,
+    );
 
-      await waitForPapiMethodRegistered(
-        'command:platformScriptureEditor.openResourceViewer',
-        DEFAULT_WEBSOCKET_PORT,
-        SETTINGS_TIMEOUT_MS,
-      );
+    // Project A and B are opened via command rather than the active project dropdown in the title
+    // bar since newly created test projects won't be in the recent list, so there will be no easy
+    // and reliable UI path for project switching in this mode. The Home UI might also fail to
+    // display them without a force refresh, but in any case that will eventually not be available
+    // in Simple mode.
+    // Open Project A — triggers openOrUpdateRelatedPanels(projectA.projectId)
+    await sendPapiRequestOnce(
+      'command:platformScriptureEditor.openResourceViewer',
+      [projectA.projectId],
+      DEFAULT_WEBSOCKET_PORT,
+      OPEN_RESOURCE_VIEWER_TIMEOUT_MS,
+    );
 
-      // Project A and B are opened via command rather than the active project dropdown in the title
-      // bar since newly created test projects won't be in the recent list, so there will be no easy
-      // and reliable UI path for project switching in this mode. The Home UI might also fail to
-      // display them without a force refresh, but in any case that will eventually not be available
-      // in Simple mode.
-      // Open Project A — triggers openOrUpdateRelatedPanels(projectA.projectId)
-      await sendPapiRequestOnce(
-        'command:platformScriptureEditor.openResourceViewer',
-        [projectA.projectId],
-        DEFAULT_WEBSOCKET_PORT,
-        PAPI_REQUEST_TIMEOUT_MS,
-      );
+    // Click the Comments tab and verify Project A's comment is visible
+    await clickCommentsTab(mainPage, getCol3Bar(mainPage));
+    // Wait for the Comments iframe to exist before accessing its frame — reloadWebView (called by
+    // openOrUpdateRelatedPanels) briefly removes and re-adds the iframe during content refresh.
+    await expect(mainPage.locator('iframe[title="Comments"]')).toBeAttached({ timeout: 30_000 });
+    const commentsFrame = mainPage.frameLocator('iframe[title="Comments"]');
+    await expect(commentsFrame.locator('body')).toContainText('Project A unique comment text', {
+      timeout: 20_000,
+    });
 
-      // Click the Comments tab and verify Project A's comment is visible
-      await mainPage.locator('.dock-tab', { hasText: /^Comments$/ }).click();
-      const commentsFrame = mainPage.frameLocator('iframe[title="Comments"]');
-      await expect(commentsFrame.locator('body')).toContainText('Project A unique comment text', {
-        timeout: 20_000,
-      });
+    // Switch to Project B — triggers openOrUpdateRelatedPanels(projectB.projectId)
+    await sendPapiRequestOnce(
+      'command:platformScriptureEditor.openResourceViewer',
+      [projectB.projectId],
+      DEFAULT_WEBSOCKET_PORT,
+      OPEN_RESOURCE_VIEWER_TIMEOUT_MS,
+    );
 
-      // Switch to Project B — triggers openOrUpdateRelatedPanels(projectB.projectId)
-      await sendPapiRequestOnce(
-        'command:platformScriptureEditor.openResourceViewer',
-        [projectB.projectId],
-        DEFAULT_WEBSOCKET_PORT,
-        PAPI_REQUEST_TIMEOUT_MS,
-      );
-
-      // Comments tab should now show Project B's comments
-      await expect(commentsFrame.locator('body')).toContainText('Project B unique comment text', {
-        timeout: 20_000,
-      });
-      // And no longer show Project A's
-      await expect(commentsFrame.locator('body')).not.toContainText(
-        'Project A unique comment text',
-      );
-    } finally {
-      cleanupCommentTestProject(projectA);
-      cleanupCommentTestProject(projectB);
-    }
+    // Comments tab should now show Project B's comments
+    await expect(commentsFrame.locator('body')).toContainText('Project B unique comment text', {
+      timeout: 20_000,
+    });
+    // And no longer show Project A's
+    await expect(commentsFrame.locator('body')).not.toContainText('Project A unique comment text');
   });
 });

--- a/e2e-tests/tests/isolated/comments-tab.spec.ts
+++ b/e2e-tests/tests/isolated/comments-tab.spec.ts
@@ -155,18 +155,22 @@ async function openScriptureEditor(
  * If the tab title is scrolled outside the visible portion of the tab bar (clipped by the rc-tabs
  * overflow container), hover the `.dock-nav-more` overflow button to open the dropdown, then click
  * the Comments option via its UUID attribute.
+ *
+ * `actionTimeoutMs` bounds the click/hover actions — pass a short value when calling inside a retry
+ * loop so a blocked click (e.g. the workspace-updating overlay intercepting pointer events) fails
+ * fast and the loop can retry, instead of burning the default 30 s action timeout.
  */
-async function clickCommentsTab(mainPage: Page): Promise<void> {
+async function clickCommentsTab(mainPage: Page, actionTimeoutMs = 30_000): Promise<void> {
   const tabTitle = mainPage.locator(
     `.platform-tab-title[data-web-view-id="${COMMENT_LIST_PANEL_UUID}"]`,
   );
   if (await tabTitle.isVisible()) {
-    await tabTitle.click();
+    await tabTitle.click({ timeout: actionTimeoutMs });
     return;
   }
   // Tab is outside the visible scroll area — open the overflow dropdown and activate it.
   const dockBar = mainPage.locator('.dock-bar').filter({ has: tabTitle });
-  await dockBar.locator('.dock-nav-more').hover();
+  await dockBar.locator('.dock-nav-more').hover({ timeout: actionTimeoutMs });
   // rc-tabs re-renders PlatformTabTitle (including our data-web-view-id) in the overflow popup.
   await mainPage
     .locator('[role="listbox"] [role="option"]')
@@ -212,10 +216,26 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
     await waitForAppReady(mainPage, 180_000);
     await waitForSimpleLayout(mainPage);
 
-    await clickCommentsTab(mainPage);
-
+    // Assert on rendered panel UI, not just the iframe body: the body is "attached" as soon as
+    // the frame element exists, which would pass even for an empty or errored WebView. The panel
+    // renders skeleton placeholders while loading (this test opens no project, so it stays in the
+    // loading state) and the filter toolbar dropdowns once loaded — either proves the
+    // CommentListPanel component actually rendered.
+    //
+    // Click and assert inside ONE retry loop: a workspace rebuild ("Updating project view"
+    // overlay) can still fire after waitForSimpleLayout. It recreates the Column 3 tabs and resets
+    // the active tab, unmounting the comments iframe — so a single click-then-assert sequence
+    // flakes. Each attempt first waits out any in-progress rebuild (the overlay also intercepts
+    // pointer events, so clicking during one always fails), then clicks and asserts with short
+    // timeouts so the loop can retry promptly if another rebuild lands mid-attempt.
     const commentsFrame = commentsFrameLocator(mainPage);
-    await commentsFrame.locator('body').waitFor({ state: 'attached', timeout: 15_000 });
+    await expect(async () => {
+      await waitForOverlayGone(mainPage, 60_000);
+      await clickCommentsTab(mainPage, 5_000);
+      await expect(
+        commentsFrame.locator('[data-slot="skeleton"], [data-slot="select-trigger"]').first(),
+      ).toBeVisible({ timeout: 10_000 });
+    }).toPass({ timeout: 180_000 });
   });
 
   test('when a project has comments, at least one is visible in the Comments tab', async ({

--- a/e2e-tests/tests/manage-books/README.md
+++ b/e2e-tests/tests/manage-books/README.md
@@ -1,0 +1,6 @@
+# manage-books E2E Tests
+
+> **Note:** These tests are experimental and are **not wired into any standard test run**
+> (`test:e2e:smoke`, `test:e2e:all`, etc.). They are not registered as a project in
+> `playwright.config.ts` and will not run via `npm run test:e2e:all`. They were generated as part of
+> an AI-assisted porting workflow.

--- a/e2e-tests/tests/markers-checklist/README.md
+++ b/e2e-tests/tests/markers-checklist/README.md
@@ -1,0 +1,6 @@
+# markers-checklist E2E Tests
+
+> **Note:** These tests are experimental and are **not wired into any standard test run**
+> (`test:e2e:smoke`, `test:e2e:all`, etc.). They are not registered as a project in
+> `playwright.config.ts` and will not run via `npm run test:e2e:all`. They were generated as part of
+> an AI-assisted porting workflow.

--- a/e2e-tests/tests/simple-mode-comments/comments-tab.spec.ts
+++ b/e2e-tests/tests/simple-mode-comments/comments-tab.spec.ts
@@ -96,7 +96,7 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
     await waitForPapiMethodRegistered(
       'command:platformScriptureEditor.openResourceViewer',
       DEFAULT_WEBSOCKET_PORT,
-      PAPI_REQUEST_TIMEOUT_MS,
+      SETTINGS_TIMEOUT_MS,
     );
     await sendPapiRequestOnce(
       'command:platformScriptureEditor.openResourceViewer',
@@ -178,7 +178,7 @@ test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
       await waitForPapiMethodRegistered(
         'command:platformScriptureEditor.openResourceViewer',
         DEFAULT_WEBSOCKET_PORT,
-        PAPI_REQUEST_TIMEOUT_MS,
+        SETTINGS_TIMEOUT_MS,
       );
 
       // Open Project A — triggers openTextConnectionPanels(projectA.projectId)

--- a/e2e-tests/tests/simple-mode-comments/comments-tab.spec.ts
+++ b/e2e-tests/tests/simple-mode-comments/comments-tab.spec.ts
@@ -1,0 +1,220 @@
+/**
+ * E2E tests for PT-4068 / PT-4069: Comments tab in Column 3 of P10 Simple mode.
+ *
+ * Tests verify:
+ *
+ * - The "Comments" tab is visible in Column 3 in Simple mode (English)
+ * - Selecting the tab renders the comment-list panel
+ * - When a project with comments is open, at least one comment is visible
+ * - The Spanish tab label differs from English, is distinct from other Column 3 tabs, and uses
+ *   sentence case
+ * - When the active project changes, the Comments tab updates
+ */
+import { test, expect } from '../../fixtures/comment.fixture';
+import {
+  waitForAppReady,
+  waitForPapiMethodRegistered,
+  sendPapiRequestOnce,
+} from '../../fixtures/helpers';
+import {
+  type CommentTestProject,
+  createCommentTestProject,
+  cleanupCommentTestProject,
+  createCommentThreads,
+} from '../../fixtures/comment-test-helpers';
+
+const SETTINGS_SET_METHOD = 'object:platform.settingsServiceDataProvider-data.set';
+const DEFAULT_WEBSOCKET_PORT = 8876;
+const SETTINGS_TIMEOUT_MS = 60_000;
+const PAPI_REQUEST_TIMEOUT_MS = 30_000;
+
+/** Switch the app to English + Simple mode and wait for the Comments tab to appear. */
+async function switchToSimpleModeEnglish(mainPage: import('@playwright/test').Page): Promise<void> {
+  await waitForPapiMethodRegistered(
+    SETTINGS_SET_METHOD,
+    DEFAULT_WEBSOCKET_PORT,
+    SETTINGS_TIMEOUT_MS,
+  );
+  await sendPapiRequestOnce(
+    SETTINGS_SET_METHOD,
+    ['platform.interfaceLanguage', ['en']],
+    DEFAULT_WEBSOCKET_PORT,
+    PAPI_REQUEST_TIMEOUT_MS,
+  );
+  await sendPapiRequestOnce(
+    SETTINGS_SET_METHOD,
+    ['platform.interfaceMode', 'simple'],
+    DEFAULT_WEBSOCKET_PORT,
+    PAPI_REQUEST_TIMEOUT_MS,
+  );
+  // Wait for the Comments tab to appear (confirms dock reloaded with simple layout)
+  await expect(mainPage.locator('.dock-tab', { hasText: /^Comments$/ })).toBeVisible({
+    timeout: 30_000,
+  });
+}
+
+test.describe('Comments tab in P10 Simple mode (PT-4068 / PT-4069)', () => {
+  let project: CommentTestProject;
+
+  test.beforeAll(async () => {
+    // Create test project before app starts (file system only, no WebSocket needed yet)
+    project = await createCommentTestProject([]);
+  });
+
+  test.afterAll(() => {
+    cleanupCommentTestProject(project);
+  });
+
+  test('Comments tab is visible in Column 3 in the English UI', async ({ mainPage }) => {
+    await waitForAppReady(mainPage);
+    await switchToSimpleModeEnglish(mainPage);
+
+    await expect(mainPage.locator('.dock-tab', { hasText: /^Comments$/ })).toBeVisible();
+  });
+
+  test('selecting the Comments tab displays the panel', async ({ mainPage }) => {
+    await waitForAppReady(mainPage);
+    await switchToSimpleModeEnglish(mainPage);
+
+    await mainPage.locator('.dock-tab', { hasText: /^Comments$/ }).click();
+
+    // The Comments panel is an iframe; wait for its body to be attached
+    const commentsFrame = mainPage.frameLocator('iframe[title="Comments"]');
+    await commentsFrame.locator('body').waitFor({ state: 'attached', timeout: 15_000 });
+  });
+
+  test('when a project has comments, at least one is visible in the Comments tab', async ({
+    mainPage,
+  }) => {
+    await waitForAppReady(mainPage);
+    await switchToSimpleModeEnglish(mainPage);
+
+    // Seed one comment thread in the test project
+    await createCommentThreads(project, ['GEN 1:1'], ['Visible comment for PT-4068 test']);
+
+    // Open the project in the scripture editor (triggers openTextConnectionPanels in simple mode)
+    await waitForPapiMethodRegistered(
+      'command:platformScriptureEditor.openResourceViewer',
+      DEFAULT_WEBSOCKET_PORT,
+      PAPI_REQUEST_TIMEOUT_MS,
+    );
+    await sendPapiRequestOnce(
+      'command:platformScriptureEditor.openResourceViewer',
+      [project.projectId],
+      DEFAULT_WEBSOCKET_PORT,
+      PAPI_REQUEST_TIMEOUT_MS,
+    );
+
+    // Click the Comments tab
+    await mainPage.locator('.dock-tab', { hasText: /^Comments$/ }).click();
+
+    // Verify at least the seeded comment content is visible
+    const commentsFrame = mainPage.frameLocator('iframe[title="Comments"]');
+    await expect(commentsFrame.locator('body')).toContainText('Visible comment for PT-4068 test', {
+      timeout: 20_000,
+    });
+  });
+
+  test('Spanish tab label differs from English, is distinct from other Column 3 tabs, and uses sentence case', async ({
+    mainPage,
+  }) => {
+    await waitForAppReady(mainPage);
+    await switchToSimpleModeEnglish(mainPage);
+
+    // Switch to Spanish locale
+    await sendPapiRequestOnce(
+      SETTINGS_SET_METHOD,
+      ['platform.interfaceLanguage', ['es']],
+      DEFAULT_WEBSOCKET_PORT,
+      PAPI_REQUEST_TIMEOUT_MS,
+    );
+
+    // Wait for the English "Comments" tab to disappear (dock has re-rendered in Spanish)
+    await expect(mainPage.locator('.dock-tab', { hasText: /^Comments$/ })).not.toBeVisible({
+      timeout: 15_000,
+    });
+
+    // Locate Column 3's tab bar using the known Spanish Commentaries label "Comentario bíblico"
+    // as a stable anchor. This avoids hardcoding our new label.
+    const col3TabBar = mainPage.locator('.dock-bar').filter({
+      has: mainPage.locator('.dock-tab', { hasText: 'Comentario bíblico' }),
+    });
+    await expect(col3TabBar).toBeVisible({ timeout: 15_000 });
+
+    // Column 3 should now have 3 tabs (Bible Texts, Commentaries, Comments — all in Spanish)
+    const col3Tabs = col3TabBar.locator('.dock-tab');
+    await expect(col3Tabs).toHaveCount(3, { timeout: 10_000 });
+    const tabTexts = await col3Tabs.allTextContents();
+    const [text0, text1, text2] = tabTexts.map((t) => t.trim());
+
+    // The 3rd tab (index 2) is our Comments tab in Spanish
+    const spanishLabel = text2;
+
+    // (a) Differs from the English label
+    expect(spanishLabel).not.toBe('Comments');
+
+    // (b) Distinct from all other Column 3 tab labels
+    expect(spanishLabel).not.toBe(text0);
+    expect(spanishLabel).not.toBe(text1);
+
+    // (c) Sentence case: first character uppercase, remaining characters lowercase
+    //     (Spanish sentence case: only the first word capitalised)
+    expect(spanishLabel.charAt(0)).toMatch(/[A-ZÁÉÍÓÚÜÑ]/);
+    expect(spanishLabel.slice(1)).toBe(spanishLabel.slice(1).toLowerCase());
+  });
+
+  test('Comments tab updates when the active project changes (PT-4069)', async ({ mainPage }) => {
+    await waitForAppReady(mainPage);
+    await switchToSimpleModeEnglish(mainPage);
+
+    // Create two independent projects, each with a distinct comment
+    const projectA = await createCommentTestProject([]);
+    const projectB = await createCommentTestProject([]);
+
+    try {
+      await createCommentThreads(projectA, ['GEN 1:1'], ['Project A unique comment text']);
+      await createCommentThreads(projectB, ['GEN 1:1'], ['Project B unique comment text']);
+
+      await waitForPapiMethodRegistered(
+        'command:platformScriptureEditor.openResourceViewer',
+        DEFAULT_WEBSOCKET_PORT,
+        PAPI_REQUEST_TIMEOUT_MS,
+      );
+
+      // Open Project A — triggers openTextConnectionPanels(projectA.projectId)
+      await sendPapiRequestOnce(
+        'command:platformScriptureEditor.openResourceViewer',
+        [projectA.projectId],
+        DEFAULT_WEBSOCKET_PORT,
+        PAPI_REQUEST_TIMEOUT_MS,
+      );
+
+      // Click the Comments tab and verify Project A's comment is visible
+      await mainPage.locator('.dock-tab', { hasText: /^Comments$/ }).click();
+      const commentsFrame = mainPage.frameLocator('iframe[title="Comments"]');
+      await expect(commentsFrame.locator('body')).toContainText('Project A unique comment text', {
+        timeout: 20_000,
+      });
+
+      // Switch to Project B — triggers openTextConnectionPanels(projectB.projectId)
+      await sendPapiRequestOnce(
+        'command:platformScriptureEditor.openResourceViewer',
+        [projectB.projectId],
+        DEFAULT_WEBSOCKET_PORT,
+        PAPI_REQUEST_TIMEOUT_MS,
+      );
+
+      // Comments tab should now show Project B's comments
+      await expect(commentsFrame.locator('body')).toContainText('Project B unique comment text', {
+        timeout: 20_000,
+      });
+      // And no longer show Project A's
+      await expect(commentsFrame.locator('body')).not.toContainText(
+        'Project A unique comment text',
+      );
+    } finally {
+      cleanupCommentTestProject(projectA);
+      cleanupCommentTestProject(projectB);
+    }
+  });
+});

--- a/e2e-tests/tests/smoke/README.md
+++ b/e2e-tests/tests/smoke/README.md
@@ -1,0 +1,23 @@
+# smoke E2E Tests
+
+Fast, CI-wired E2E tests that share a single Electron instance per worker.
+
+## What belongs here
+
+- Core happy-path tests: app launches, basic navigation, fundamental platform behaviors
+- Tests that don't mutate persistent state (settings, projects, layout)
+- Tests fast enough to run on every PR in CI
+
+## What does NOT belong here
+
+Feature-specific or state-mutating tests belong in `isolated/` instead.
+
+## How to run
+
+```bash
+# All smoke tests (also runs in CI)
+npm run test:e2e:smoke
+
+# A single file
+npx playwright test --config e2e-tests/playwright.config.ts --project=smoke e2e-tests/tests/smoke/<file>.spec.ts
+```

--- a/extensions/src/legacy-comment-manager/contributions/localizedStrings.json
+++ b/extensions/src/legacy-comment-manager/contributions/localizedStrings.json
@@ -126,7 +126,7 @@
       "%conflict_note_summary_unresolved%": "Ediciones en conflicto. Elija qué cambio conservar.",
       "%no_comments%": "Todavía no hay comentarios",
       "%no_comments_match_filter%": "No hay comentarios que coincidan con sus parámetros de filtros.",
-      "%webView_legacyCommentManager_commentList_title%": "Comentarios",
+      "%webView_legacyCommentManager_commentList_title%": "Comentarios de proyecto",
       "%webView_legacyCommentManager_openComments%": "Abrir Comentarios"
     }
   }

--- a/extensions/src/legacy-comment-manager/contributions/localizedStrings.json
+++ b/extensions/src/legacy-comment-manager/contributions/localizedStrings.json
@@ -8,6 +8,9 @@
     },
     "%webView_legacyCommentManager_commentList_title%": {
       "fallbackKey": "%Paratext.ProjectComments.CommentListForm.CommentListForm_11CommentListForm_ShortTitle%"
+    },
+    "%webView_legacyCommentManager_commentListPanel_title%": {
+      "fallbackKey": "%Paratext.ProjectComments.CommentListForm.CommentListForm_11CommentListForm_ShortTitle%"
     }
   },
   "localizedStrings": {

--- a/extensions/src/legacy-comment-manager/contributions/localizedStrings.json
+++ b/extensions/src/legacy-comment-manager/contributions/localizedStrings.json
@@ -68,6 +68,7 @@
       "%no_comments%": "No comments yet",
       "%no_comments_match_filter%": "No comments match your filter settings.",
       "%webView_legacyCommentManager_commentList_title%": "Comments",
+      "%webView_legacyCommentManager_commentListPanel_title%": "Comments",
       "%webView_legacyCommentManager_openComments%": "Open Comments"
     },
     "es": {
@@ -126,7 +127,8 @@
       "%conflict_note_summary_unresolved%": "Ediciones en conflicto. Elija qué cambio conservar.",
       "%no_comments%": "Todavía no hay comentarios",
       "%no_comments_match_filter%": "No hay comentarios que coincidan con sus parámetros de filtros.",
-      "%webView_legacyCommentManager_commentList_title%": "Comentarios de proyecto",
+      "%webView_legacyCommentManager_commentList_title%": "Comentarios",
+      "%webView_legacyCommentManager_commentListPanel_title%": "Comentarios de proyecto",
       "%webView_legacyCommentManager_openComments%": "Abrir Comentarios"
     }
   }

--- a/extensions/src/legacy-comment-manager/src/comment-list-panel.utils.test.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-panel.utils.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCommentListPanelProjectId } from './comment-list-panel.utils';
+
+describe('resolveCommentListPanelProjectId', () => {
+  it('returns the pending sentinel when set, ignoring options and saved', () => {
+    expect(resolveCommentListPanelProjectId('pending-id', 'options-id', 'saved-id')).toBe(
+      'pending-id',
+    );
+  });
+
+  it('returns fromOptions when pending is undefined', () => {
+    expect(resolveCommentListPanelProjectId(undefined, 'options-id', 'saved-id')).toBe(
+      'options-id',
+    );
+  });
+
+  it('returns fromSaved when pending and fromOptions are both undefined', () => {
+    expect(resolveCommentListPanelProjectId(undefined, undefined, 'saved-id')).toBe('saved-id');
+  });
+
+  it('returns undefined when all three are undefined', () => {
+    expect(resolveCommentListPanelProjectId(undefined, undefined, undefined)).toBeUndefined();
+  });
+});

--- a/extensions/src/legacy-comment-manager/src/comment-list-panel.utils.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-panel.utils.ts
@@ -19,5 +19,5 @@ export function resolveCommentListPanelProjectId(
   fromOptions: string | undefined,
   fromSaved: string | undefined,
 ): string | undefined {
-  return pending !== undefined ? pending : (fromOptions ?? fromSaved);
+  return pending ?? fromOptions ?? fromSaved;
 }

--- a/extensions/src/legacy-comment-manager/src/comment-list-panel.utils.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-panel.utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Resolves the projectId to display in the Comment List Panel.
+ *
+ * Priority: pending sentinel (set by openCommentListPanel before reloadWebView) >
+ * openWebViewOptions
+ *
+ * > SavedWebView. The sentinel exists because reloadWebView has no way to forward extra data into
+ * > getWebView; the caller writes to the sentinel and getWebView reads and clears it.
+ *
+ * @param pending The module-level sentinel set by openCommentListPanel, or undefined if not set
+ * @param fromOptions The projectId from OpenWebViewOptions passed to getWebView
+ * @param fromSaved The projectId stored on the SavedWebViewDefinition
+ */
+export function resolveCommentListPanelProjectId(
+  pending: string | undefined,
+  fromOptions: string | undefined,
+  fromSaved: string | undefined,
+): string | undefined {
+  return pending !== undefined ? pending : (fromOptions ?? fromSaved);
+}

--- a/extensions/src/legacy-comment-manager/src/comment-list-panel.utils.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-panel.utils.ts
@@ -1,11 +1,14 @@
 /**
  * Resolves the projectId to display in the Comment List Panel.
  *
- * Priority: pending sentinel (set by openCommentListPanel before reloadWebView) >
- * openWebViewOptions
+ * Priority order (highest to lowest):
  *
- * > SavedWebView. The sentinel exists because reloadWebView has no way to forward extra data into
- * > getWebView; the caller writes to the sentinel and getWebView reads and clears it.
+ * 1. Pending sentinel (set by openCommentListPanel before reloadWebView)
+ * 2. OpenWebViewOptions
+ * 3. SavedWebView
+ *
+ * The sentinel exists because reloadWebView has no way to forward extra data into getWebView; the
+ * caller writes to the sentinel and getWebView reads and clears it.
  *
  * @param pending The module-level sentinel set by openCommentListPanel, or undefined if not set
  * @param fromOptions The projectId from OpenWebViewOptions passed to getWebView

--- a/extensions/src/legacy-comment-manager/src/localized-strings.test.ts
+++ b/extensions/src/legacy-comment-manager/src/localized-strings.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+const PANEL_TITLE_KEY = '%webView_legacyCommentManager_commentListPanel_title%';
+const COMMENTARIES_TAB_TITLE_KEY = '%webView_resourcePanel_commentaries_title%';
+
+type LocalizedStringsFile = {
+  localizedStrings: Record<string, Record<string, string>>;
+};
+
+function readLocalizedStrings(
+  relativePathFromThisDir: string,
+): LocalizedStringsFile['localizedStrings'] {
+  const stringsFilePath = path.resolve(__dirname, relativePathFromThisDir);
+  // JSON.parse returns `any`; asserting the known shape of localized strings contribution files
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  const stringsFile = JSON.parse(readFileSync(stringsFilePath, 'utf-8')) as LocalizedStringsFile;
+  return stringsFile.localizedStrings;
+}
+
+const localizedStrings = readLocalizedStrings('../contributions/localizedStrings.json');
+// The Commentaries tab title is contributed by the platform-scripture-editor extension
+const scriptureEditorLocalizedStrings = readLocalizedStrings(
+  '../../platform-scripture-editor/contributions/localizedStrings.json',
+);
+
+describe('legacyCommentManager comment list panel tab title', () => {
+  it('has an English label', () => {
+    expect(localizedStrings.en[PANEL_TITLE_KEY]).toBeTruthy();
+  });
+
+  it('has a Spanish label', () => {
+    expect(localizedStrings.es[PANEL_TITLE_KEY]).toBeTruthy();
+  });
+
+  it('Spanish label differs from English', () => {
+    expect(localizedStrings.es[PANEL_TITLE_KEY]).not.toBe(localizedStrings.en[PANEL_TITLE_KEY]);
+  });
+
+  // In the Spanish UI, we actually want to ensure that the “Commentaries” and “Comments” tabs are
+  // not easily confused. In practice, that probably means that they are significantly different
+  // (“Commentarios” is probably too similar to “Comentario bíblico”), but that is difficult to
+  // test for conclusively.
+  it('Spanish label differs from the Spanish Commentaries tab title', () => {
+    const commentariesTabTitle = scriptureEditorLocalizedStrings.es[COMMENTARIES_TAB_TITLE_KEY];
+    // If the Commentaries title key is renamed or removed, fail loudly rather than letting the
+    // comparison below pass vacuously against `undefined`
+    expect(commentariesTabTitle).toBeDefined();
+    expect(localizedStrings.es[PANEL_TITLE_KEY]).not.toBe(commentariesTabTitle);
+  });
+
+  it('Spanish label uses sentence case', () => {
+    const es = localizedStrings.es[PANEL_TITLE_KEY];
+    expect(es.charAt(0)).toMatch(/[A-ZÁÉÍÓÚÜÑ]/);
+    expect(es.slice(1)).toBe(es.slice(1).toLowerCase());
+  });
+});

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -160,7 +160,10 @@ const commentListPanelProvider: IWebViewProvider = {
     savedWebView: SavedWebViewDefinition,
     openWebViewOptions: CommentListPanelOptions,
   ): Promise<WebViewDefinition | undefined> {
-    if (savedWebView.webViewType !== COMMENT_LIST_PANEL_WEBVIEW_TYPE) return undefined;
+    if (savedWebView.webViewType !== COMMENT_LIST_PANEL_WEBVIEW_TYPE)
+      throw new Error(
+        `${COMMENT_LIST_PANEL_WEBVIEW_TYPE} provider received request to provide a ${savedWebView.webViewType} web view`,
+      );
 
     const projectId =
       currentCommentListPanelProjectId ?? openWebViewOptions.projectId ?? savedWebView.projectId;

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -197,8 +197,8 @@ const commentListPanelProvider: IWebViewProvider = {
  * @returns The webView ID of the panel, or `undefined` if opening failed
  */
 async function openCommentListPanel(projectId: string | undefined): Promise<string | undefined> {
-  // Use existingId: '?' to detect-and-reuse the fixed Column 3 tab without calling
-  // getAllOpenWebViewDefinitions (which is not reliably available from extension context).
+  // Use existingId: '?' to passively probe for the existing Column 3 tab (returns its id, or
+  // undefined if not found) without bringing it to front or creating one if absent.
   const existingId = await papi.webViews.openWebView(
     COMMENT_LIST_PANEL_WEBVIEW_TYPE,
     { type: 'tab' },

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -26,7 +26,7 @@ import { LEGACY_COMMENT_USJ_PROJECT_INTERFACES } from './project-data-provider/l
 import { resolveCommentListPanelProjectId } from './comment-list-panel.utils';
 
 const commentListWebViewType = 'legacyCommentManager.commentList';
-const COMMENT_LIST_PANEL_WEBVIEW_TYPE = 'legacyCommentManager.commentListPanel';
+const commentListPanelWebViewType = 'legacyCommentManager.commentListPanel';
 
 // #region Comment List WebView
 
@@ -153,7 +153,13 @@ interface CommentListPanelOptions extends OpenWebViewOptions {
   projectId?: string;
 }
 
-/** Pending projectId consumed by commentListPanelProvider.getWebView() after reloadWebView() */
+/**
+ * Pending projectId consumed by commentListPanelProvider.getWebView() after reloadWebView().
+ *
+ * Note: `undefined` doubles as the "no pending value" sentinel, so a pending `undefined` cannot
+ * clear an already-open panel's project — resolution falls back to the saved projectId. This is an
+ * accepted limitation; see {@link openCommentListPanel}.
+ */
 let currentCommentListPanelProjectId: string | undefined;
 
 const commentListPanelProvider: IWebViewProvider = {
@@ -161,9 +167,9 @@ const commentListPanelProvider: IWebViewProvider = {
     savedWebView: SavedWebViewDefinition,
     openWebViewOptions: CommentListPanelOptions,
   ): Promise<WebViewDefinition | undefined> {
-    if (savedWebView.webViewType !== COMMENT_LIST_PANEL_WEBVIEW_TYPE)
+    if (savedWebView.webViewType !== commentListPanelWebViewType)
       throw new Error(
-        `${COMMENT_LIST_PANEL_WEBVIEW_TYPE} provider received request to provide a ${savedWebView.webViewType} web view`,
+        `${commentListPanelWebViewType} provider received request to provide a ${savedWebView.webViewType} web view`,
       );
 
     const projectId = resolveCommentListPanelProjectId(
@@ -193,28 +199,32 @@ const commentListPanelProvider: IWebViewProvider = {
  *
  * This implements the `legacyCommentManager.openCommentListPanel` command.
  *
- * @param projectId The project whose comments to display, or `undefined` to show an empty panel
+ * @param projectId The project whose comments to display. If `undefined`, a newly created panel
+ *   opens empty, but an already-open panel keeps its current project (`undefined` is
+ *   indistinguishable from "no pending value" in the sentinel, so resolution falls back to the
+ *   saved projectId). This is an accepted limitation: in Simple mode there is no scenario where an
+ *   active project needs to be cleared after having been set.
  * @returns The webView ID of the panel, or `undefined` if opening failed
  */
 async function openCommentListPanel(projectId: string | undefined): Promise<string | undefined> {
   // Use existingId: '?' to passively probe for the existing Column 3 tab (returns its id, or
   // undefined if not found) without bringing it to front or creating one if absent.
   const existingId = await papi.webViews.openWebView(
-    COMMENT_LIST_PANEL_WEBVIEW_TYPE,
+    commentListPanelWebViewType,
     { type: 'tab' },
     { existingId: '?', createNewIfNotFound: false, bringToFront: false },
   );
 
   if (existingId) {
     currentCommentListPanelProjectId = projectId;
-    return papi.webViews.reloadWebView(COMMENT_LIST_PANEL_WEBVIEW_TYPE, existingId, {
+    return papi.webViews.reloadWebView(commentListPanelWebViewType, existingId, {
       bringToFront: false, // Don't steal focus from the scripture editor on project switch
     });
   }
 
   // Panel not yet open (shouldn't happen in Simple mode where it's always in the layout).
   const openOptions: CommentListPanelOptions = { projectId };
-  return papi.webViews.openWebView(COMMENT_LIST_PANEL_WEBVIEW_TYPE, { type: 'tab' }, openOptions);
+  return papi.webViews.openWebView(commentListPanelWebViewType, { type: 'tab' }, openOptions);
 }
 
 // #endregion Comment List Panel WebView
@@ -375,7 +385,7 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
   );
 
   const commentListPanelWebViewProviderPromise = papi.webViewProviders.registerWebViewProvider(
-    COMMENT_LIST_PANEL_WEBVIEW_TYPE,
+    commentListPanelWebViewType,
     commentListPanelProvider,
   );
 

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -23,6 +23,7 @@ import {
   LegacyCommentManagerUsjProjectDataProviderEngineFactory,
 } from './project-data-provider/legacy-comment-manager-usj-pdpef.model';
 import { LEGACY_COMMENT_USJ_PROJECT_INTERFACES } from './project-data-provider/legacy-comment-manager-usj-pdpe.model';
+import { resolveCommentListPanelProjectId } from './comment-list-panel.utils';
 
 const commentListWebViewType = 'legacyCommentManager.commentList';
 const COMMENT_LIST_PANEL_WEBVIEW_TYPE = 'legacyCommentManager.commentListPanel';
@@ -165,10 +166,11 @@ const commentListPanelProvider: IWebViewProvider = {
         `${COMMENT_LIST_PANEL_WEBVIEW_TYPE} provider received request to provide a ${savedWebView.webViewType} web view`,
       );
 
-    const projectId =
-      currentCommentListPanelProjectId !== undefined
-        ? currentCommentListPanelProjectId
-        : (openWebViewOptions.projectId ?? savedWebView.projectId);
+    const projectId = resolveCommentListPanelProjectId(
+      currentCommentListPanelProjectId,
+      openWebViewOptions.projectId,
+      savedWebView.projectId,
+    );
     currentCommentListPanelProjectId = undefined;
 
     const title = await papi.localization.getLocalizedString({
@@ -200,7 +202,7 @@ async function openCommentListPanel(projectId: string | undefined): Promise<stri
   const existingId = await papi.webViews.openWebView(
     COMMENT_LIST_PANEL_WEBVIEW_TYPE,
     { type: 'tab' },
-    { existingId: '?', createNewIfNotFound: false },
+    { existingId: '?', createNewIfNotFound: false, bringToFront: false },
   );
 
   if (existingId) {

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -55,7 +55,7 @@ class CommentListWebViewFactory extends WebViewFactory<typeof commentListWebView
   ): Promise<WebViewDefinition | undefined> {
     if (savedWebView.webViewType !== commentListWebViewType)
       throw new Error(
-        `${commentListWebViewType} provider received request to provide a ${savedWebView.webViewType} WebView`,
+        `${commentListWebViewType} provider received request to provide a ${savedWebView.webViewType} web view`,
       );
 
     const projectId = getWebViewOptions.projectId || savedWebView.projectId || undefined;
@@ -186,10 +186,10 @@ const commentListPanelProvider: IWebViewProvider = {
 };
 
 /**
- * Opens or updates the fixed Comment List Panel in Column 3 for the given project.
+ * Opens or updates the fixed Comment List Panel in Column 3 for the given project. If the panel is
+ * already open, reloads it in place without bringing it to the front.
  *
- * This implements the `legacyCommentManager.openCommentListPanel` command. Called by
- * `openTextConnectionPanels` whenever the active project changes in Simple mode.
+ * This implements the `legacyCommentManager.openCommentListPanel` command.
  *
  * @param projectId The project whose comments to display, or `undefined` to show an empty panel
  * @returns The webView ID of the panel, or `undefined` if opening failed

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -172,7 +172,7 @@ const commentListPanelProvider: IWebViewProvider = {
     currentCommentListPanelProjectId = undefined;
 
     const title = await papi.localization.getLocalizedString({
-      localizeKey: '%webView_legacyCommentManager_commentList_title%',
+      localizeKey: '%webView_legacyCommentManager_commentListPanel_title%',
     });
 
     return {

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -166,7 +166,9 @@ const commentListPanelProvider: IWebViewProvider = {
       );
 
     const projectId =
-      currentCommentListPanelProjectId ?? openWebViewOptions.projectId ?? savedWebView.projectId;
+      currentCommentListPanelProjectId !== undefined
+        ? currentCommentListPanelProjectId
+        : (openWebViewOptions.projectId ?? savedWebView.projectId);
     currentCommentListPanelProjectId = undefined;
 
     const title = await papi.localization.getLocalizedString({
@@ -201,7 +203,7 @@ async function openCommentListPanel(projectId: string | undefined): Promise<stri
   if (existingPanel) {
     currentCommentListPanelProjectId = projectId;
     return papi.webViews.reloadWebView(COMMENT_LIST_PANEL_WEBVIEW_TYPE, existingPanel.id, {
-      bringToFront: false,
+      bringToFront: false, // Don't steal focus from the scripture editor on project switch
     });
   }
 

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -25,6 +25,7 @@ import {
 import { LEGACY_COMMENT_USJ_PROJECT_INTERFACES } from './project-data-provider/legacy-comment-manager-usj-pdpe.model';
 
 const commentListWebViewType = 'legacyCommentManager.commentList';
+const COMMENT_LIST_PANEL_WEBVIEW_TYPE = 'legacyCommentManager.commentListPanel';
 
 // #region Comment List WebView
 
@@ -144,6 +145,68 @@ class CommentListWebViewFactory extends WebViewFactory<typeof commentListWebView
 const commentListWebViewProvider: IWebViewProvider = new CommentListWebViewFactory();
 
 // #endregion Comment List WebView
+
+// #region Comment List Panel WebView (Column 3 fixed tab)
+
+interface CommentListPanelOptions extends OpenWebViewOptions {
+  projectId?: string;
+}
+
+/** Pending projectId consumed by commentListPanelProvider.getWebView() after reloadWebView() */
+let currentCommentListPanelProjectId: string | undefined;
+
+const commentListPanelProvider: IWebViewProvider = {
+  async getWebView(
+    savedWebView: SavedWebViewDefinition,
+    openWebViewOptions: CommentListPanelOptions,
+  ): Promise<WebViewDefinition | undefined> {
+    if (savedWebView.webViewType !== COMMENT_LIST_PANEL_WEBVIEW_TYPE) return undefined;
+
+    const projectId =
+      currentCommentListPanelProjectId ?? openWebViewOptions.projectId ?? savedWebView.projectId;
+    currentCommentListPanelProjectId = undefined;
+
+    const title = await papi.localization.getLocalizedString({
+      localizeKey: '%webView_legacyCommentManager_commentList_title%',
+    });
+
+    return {
+      ...savedWebView,
+      title,
+      projectId,
+      content: commentListWebView,
+      styles: tailwindStyles,
+    };
+  },
+};
+
+/**
+ * Opens or updates the fixed Comment List Panel in Column 3 for the given project.
+ *
+ * This implements the `legacyCommentManager.openCommentListPanel` command. Called by
+ * `openTextConnectionPanels` whenever the active project changes in Simple mode.
+ *
+ * @param projectId The project whose comments to display, or `undefined` to show an empty panel
+ * @returns The webView ID of the panel, or `undefined` if opening failed
+ */
+async function openCommentListPanel(projectId: string | undefined): Promise<string | undefined> {
+  const allOpenDefs = await papi.webViews.getAllOpenWebViewDefinitions();
+  const existingPanel = allOpenDefs.find(
+    (def) => def.webViewType === COMMENT_LIST_PANEL_WEBVIEW_TYPE,
+  );
+
+  if (existingPanel) {
+    currentCommentListPanelProjectId = projectId;
+    return papi.webViews.reloadWebView(COMMENT_LIST_PANEL_WEBVIEW_TYPE, existingPanel.id, {
+      bringToFront: false,
+    });
+  }
+
+  const openOptions: CommentListPanelOptions = { projectId };
+  return papi.webViews.openWebView(COMMENT_LIST_PANEL_WEBVIEW_TYPE, { type: 'tab' }, openOptions);
+}
+
+// #endregion Comment List Panel WebView
 
 /**
  * Open or focus the Comment List WebView for the project ID associated with the specified WebView
@@ -300,6 +363,34 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     commentListWebViewProvider,
   );
 
+  const commentListPanelWebViewProviderPromise = papi.webViewProviders.registerWebViewProvider(
+    COMMENT_LIST_PANEL_WEBVIEW_TYPE,
+    commentListPanelProvider,
+  );
+
+  const openCommentListPanelPromise = papi.commands.registerCommand(
+    'legacyCommentManager.openCommentListPanel',
+    openCommentListPanel,
+    {
+      method: {
+        summary: 'Open or update the fixed Comment List panel in Column 3',
+        params: [
+          {
+            name: 'projectId',
+            required: false,
+            summary: 'The project whose comments to display',
+            schema: { type: 'string' },
+          },
+        ],
+        result: {
+          name: 'return value',
+          summary: 'The webView ID of the panel',
+          schema: { type: 'string' },
+        },
+      },
+    },
+  );
+
   // Subscribe to web view updates to clean up tracking when comment list is closed
   const webViewUpdateUnsub = papi.webViews.onDidCloseWebView((event) => {
     // Check if this was one of our tracked comment lists
@@ -393,7 +484,9 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
 
   context.registrations.add(
     await commentListWebViewProviderPromise,
+    await commentListPanelWebViewProviderPromise,
     await openCommentListPromise,
+    await openCommentListPanelPromise,
     await commentsUsjPdpefPromise,
     webViewUpdateUnsub,
   );

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -195,18 +195,22 @@ const commentListPanelProvider: IWebViewProvider = {
  * @returns The webView ID of the panel, or `undefined` if opening failed
  */
 async function openCommentListPanel(projectId: string | undefined): Promise<string | undefined> {
-  const allOpenDefs = await papi.webViews.getAllOpenWebViewDefinitions();
-  const existingPanel = allOpenDefs.find(
-    (def) => def.webViewType === COMMENT_LIST_PANEL_WEBVIEW_TYPE,
+  // Use existingId: '?' to detect-and-reuse the fixed Column 3 tab without calling
+  // getAllOpenWebViewDefinitions (which is not reliably available from extension context).
+  const existingId = await papi.webViews.openWebView(
+    COMMENT_LIST_PANEL_WEBVIEW_TYPE,
+    { type: 'tab' },
+    { existingId: '?', createNewIfNotFound: false },
   );
 
-  if (existingPanel) {
+  if (existingId) {
     currentCommentListPanelProjectId = projectId;
-    return papi.webViews.reloadWebView(COMMENT_LIST_PANEL_WEBVIEW_TYPE, existingPanel.id, {
+    return papi.webViews.reloadWebView(COMMENT_LIST_PANEL_WEBVIEW_TYPE, existingId, {
       bringToFront: false, // Don't steal focus from the scripture editor on project switch
     });
   }
 
+  // Panel not yet open (shouldn't happen in Simple mode where it's always in the layout).
   const openOptions: CommentListPanelOptions = { projectId };
   return papi.webViews.openWebView(COMMENT_LIST_PANEL_WEBVIEW_TYPE, { type: 'tab' }, openOptions);
 }

--- a/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
+++ b/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
@@ -579,6 +579,18 @@ declare module 'papi-shared-types' {
       webViewId?: string | undefined,
       options?: OpenCommentListWebViewOptions,
     ) => Promise<string | undefined>;
+
+    /**
+     * Opens or updates the fixed Comment List panel in Column 3 for the given project.
+     *
+     * Called by `openTextConnectionPanels` whenever the active project changes in Simple mode.
+     *
+     * @param projectId The project whose comments to display
+     * @returns The webView ID of the panel
+     */
+    'legacyCommentManager.openCommentListPanel': (
+      projectId?: string | undefined,
+    ) => Promise<string | undefined>;
   }
 
   export interface WebViewControllers {

--- a/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
+++ b/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
@@ -585,7 +585,7 @@ declare module 'papi-shared-types' {
      * is already open, reloads it in place without bringing it to the front.
      *
      * @param projectId The project whose comments to display
-     * @returns The webView ID of the panel
+     * @returns The webView ID of the panel, or `undefined` if opening failed
      */
     'legacyCommentManager.openCommentListPanel': (
       projectId?: string | undefined,

--- a/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
+++ b/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
@@ -581,9 +581,8 @@ declare module 'papi-shared-types' {
     ) => Promise<string | undefined>;
 
     /**
-     * Opens or updates the fixed Comment List panel in Column 3 for the given project.
-     *
-     * Called by `openTextConnectionPanels` whenever the active project changes in Simple mode.
+     * Opens or updates the fixed Comment List panel in Column 3 for the given project. If the panel
+     * is already open, reloads it in place without bringing it to the front.
      *
      * @param projectId The project whose comments to display
      * @returns The webView ID of the panel

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -36,6 +36,7 @@ import {
   convertScriptureRangeToEditorRange,
   formatEditorTitle,
   openCommentListAndSelectThread,
+  type OpenEditorDispatch,
   openOrUpdateRelatedPanels,
   resolveOpenEditorDispatch,
   SCRIPTURE_EDITOR_WEBVIEW_TYPE,
@@ -323,11 +324,39 @@ async function open(
     if (interfaceMode === 'simple' && projectForWebView.projectId)
       await openOrUpdateRelatedPanels(papi, projectForWebView.projectId);
 
+    // Re-check the replace-tab target after openOrUpdateRelatedPanels: concurrent panel
+    // operations can remove the target tab between when the dispatch was resolved (above) and
+    // when openWebView runs. If the target is gone, re-resolve with fresh dock state so we
+    // don't throw "Replacing tab failed".
+    let finalDispatch: OpenEditorDispatch = dispatch;
+    if (dispatch.kind === 'replace-tab') {
+      const freshDefs = await papi.webViews.getAllOpenWebViewDefinitions();
+      if (!freshDefs.some((def) => def.id === dispatch.targetTabId)) {
+        const freshEditors = freshDefs
+          .filter((def) => def.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE)
+          .map((def) => ({
+            id: def.id,
+            projectId: def.projectId,
+            // WebView state isn't statically typed, but `getWebViewDefinition` always stores
+            // `isReadOnly` as boolean here. Treat any other value as `false` for safety.
+            // eslint-disable-next-line no-type-assertion/no-type-assertion
+            isReadOnly: !!(def.state?.isReadOnly as boolean | undefined),
+          }));
+        finalDispatch = resolveOpenEditorDispatch(
+          freshEditors,
+          projectForWebView.projectId,
+          requestedIsReadOnly,
+          interfaceMode,
+          existingTabIdToReplace,
+        );
+      }
+    }
+
     const openedWebViewId = await papi.webViews
       .openWebView(
         SCRIPTURE_EDITOR_WEBVIEW_TYPE,
-        dispatch.kind === 'replace-tab'
-          ? { type: 'replace-tab', targetTabId: dispatch.targetTabId }
+        finalDispatch.kind === 'replace-tab'
+          ? { type: 'replace-tab', targetTabId: finalDispatch.targetTabId }
           : undefined,
         openWebViewOptions,
       )

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -249,13 +249,13 @@ async function open(
     // (one editor slot, no duplicate-(project, readonly) tabs) and the empty-editor probe; see
     // resolveOpenEditorDispatch JSDoc for the priority order.
     // getAllOpenWebViewDefinitions can time out under load; fall back to an empty list so that
-    // openResourceViewer still succeeds (opening a new editor tab) rather than throwing.
+    // open still succeeds (opening a new editor tab) rather than throwing.
     let allOpenDefs: SavedWebViewDefinition[] = [];
     try {
       allOpenDefs = await papi.webViews.getAllOpenWebViewDefinitions();
     } catch (e) {
       logger.warn(
-        `openResourceViewer: getAllOpenWebViewDefinitions timed out or failed (${getErrorMessage(e)}); opening as new tab`,
+        `open: getAllOpenWebViewDefinitions timed out or failed (${getErrorMessage(e)}); opening as new tab`,
       );
     }
     const allScriptureEditors = toScriptureEditorInfos(allOpenDefs);
@@ -352,7 +352,7 @@ async function open(
         }
       } catch (e) {
         logger.warn(
-          `openResourceViewer: re-check getAllOpenWebViewDefinitions timed out or failed (${getErrorMessage(e)}); using original dispatch`,
+          `open: re-check getAllOpenWebViewDefinitions timed out or failed (${getErrorMessage(e)}); using original dispatch`,
         );
       }
     }

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -43,6 +43,7 @@ import {
   selectProjectIdsForOpenMode,
   startDefaultProjectPicker,
   syncOnProjectSwitch,
+  toScriptureEditorInfos,
 } from './platform-scripture-editor.utils';
 import { MarkersViewNotifier } from './markers-view-notifier.model';
 
@@ -247,17 +248,17 @@ async function open(
     // Decide where to route this open. The dispatch helper centralizes the simple-mode invariants
     // (one editor slot, no duplicate-(project, readonly) tabs) and the empty-editor probe; see
     // resolveOpenEditorDispatch JSDoc for the priority order.
-    const allOpenDefs = await papi.webViews.getAllOpenWebViewDefinitions();
-    const allScriptureEditors = allOpenDefs
-      .filter((def) => def.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE)
-      .map((def) => ({
-        id: def.id,
-        projectId: def.projectId,
-        // WebView state isn't statically typed, but `getWebViewDefinition` always stores
-        // `isReadOnly` as boolean here. Treat any other value as `false` for safety.
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        isReadOnly: !!(def.state?.isReadOnly as boolean | undefined),
-      }));
+    // getAllOpenWebViewDefinitions can time out under load; fall back to an empty list so that
+    // openResourceViewer still succeeds (opening a new editor tab) rather than throwing.
+    let allOpenDefs: SavedWebViewDefinition[] = [];
+    try {
+      allOpenDefs = await papi.webViews.getAllOpenWebViewDefinitions();
+    } catch (e) {
+      logger.warn(
+        `openResourceViewer: getAllOpenWebViewDefinitions timed out or failed (${getErrorMessage(e)}); opening as new tab`,
+      );
+    }
+    const allScriptureEditors = toScriptureEditorInfos(allOpenDefs);
     const interfaceMode = await papi.settings.get('platform.interfaceMode');
     const requestedIsReadOnly = !projectForWebView.isEditable;
 
@@ -320,34 +321,38 @@ async function open(
       options,
     };
 
-    // If in simple interface mode, open/update the model text, bible text, and commentary text panels
-    if (interfaceMode === 'simple' && projectForWebView.projectId)
+    // If in simple interface mode and opening an editable project, open/update the related panels
+    // (model text, bible texts, commentaries, comments). Gated on isEditable: the related panels
+    // follow the active translation project, so opening a read-only published resource in the
+    // editor column must not switch them over to the resource.
+    if (interfaceMode === 'simple' && projectForWebView.projectId && projectForWebView.isEditable)
       await openOrUpdateRelatedPanels(papi, projectForWebView.projectId);
 
     // Re-check the replace-tab target after openOrUpdateRelatedPanels: concurrent panel
     // operations can remove the target tab between when the dispatch was resolved (above) and
     // when openWebView runs. If the target is gone, re-resolve with fresh dock state so we
     // don't throw "Replacing tab failed".
+    // Only applies in simple mode: openOrUpdateRelatedPanels (the source of the race) only runs
+    // there, and in power mode re-resolving would return the same caller-supplied
+    // existingTabIdToReplace anyway, so the re-check couldn't help.
+    // getAllOpenWebViewDefinitions can time out under load; if that happens keep the original
+    // dispatch — the target tab may still be present and openWebView will proceed normally.
     let finalDispatch: OpenEditorDispatch = dispatch;
-    if (dispatch.kind === 'replace-tab') {
-      const freshDefs = await papi.webViews.getAllOpenWebViewDefinitions();
-      if (!freshDefs.some((def) => def.id === dispatch.targetTabId)) {
-        const freshEditors = freshDefs
-          .filter((def) => def.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE)
-          .map((def) => ({
-            id: def.id,
-            projectId: def.projectId,
-            // WebView state isn't statically typed, but `getWebViewDefinition` always stores
-            // `isReadOnly` as boolean here. Treat any other value as `false` for safety.
-            // eslint-disable-next-line no-type-assertion/no-type-assertion
-            isReadOnly: !!(def.state?.isReadOnly as boolean | undefined),
-          }));
-        finalDispatch = resolveOpenEditorDispatch(
-          freshEditors,
-          projectForWebView.projectId,
-          requestedIsReadOnly,
-          interfaceMode,
-          existingTabIdToReplace,
+    if (interfaceMode === 'simple' && dispatch.kind === 'replace-tab') {
+      try {
+        const freshDefs = await papi.webViews.getAllOpenWebViewDefinitions();
+        if (!freshDefs.some((def) => def.id === dispatch.targetTabId)) {
+          finalDispatch = resolveOpenEditorDispatch(
+            toScriptureEditorInfos(freshDefs),
+            projectForWebView.projectId,
+            requestedIsReadOnly,
+            interfaceMode,
+            existingTabIdToReplace,
+          );
+        }
+      } catch (e) {
+        logger.warn(
+          `openResourceViewer: re-check getAllOpenWebViewDefinitions timed out or failed (${getErrorMessage(e)}); using original dispatch`,
         );
       }
     }

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -36,7 +36,7 @@ import {
   convertScriptureRangeToEditorRange,
   formatEditorTitle,
   openCommentListAndSelectThread,
-  openTextConnectionPanels,
+  openOrUpdateRelatedPanels,
   resolveOpenEditorDispatch,
   SCRIPTURE_EDITOR_WEBVIEW_TYPE,
   selectProjectIdsForOpenMode,
@@ -321,7 +321,7 @@ async function open(
 
     // If in simple interface mode, open/update the model text, bible text, and commentary text panels
     if (interfaceMode === 'simple' && projectForWebView.projectId)
-      await openTextConnectionPanels(papi, projectForWebView.projectId);
+      await openOrUpdateRelatedPanels(papi, projectForWebView.projectId);
 
     const openedWebViewId = await papi.webViews
       .openWebView(
@@ -440,7 +440,7 @@ class ScriptureEditorWebViewFactory extends WebViewFactory<typeof SCRIPTURE_EDIT
   ): Promise<WebViewDefinition | undefined> {
     if (savedWebView.webViewType !== SCRIPTURE_EDITOR_WEBVIEW_TYPE)
       throw new Error(
-        `${SCRIPTURE_EDITOR_WEBVIEW_TYPE} provider received request to provide a ${savedWebView.webViewType} WebView`,
+        `${SCRIPTURE_EDITOR_WEBVIEW_TYPE} provider received request to provide a ${savedWebView.webViewType} web view`,
       );
 
     // We know that the projectId (if present in the state) will be a string.

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest';
 import { ScriptureRange } from 'platform-scripture-editor';
 import type PapiBackend from '@papi/backend';
 import { UsjTextContentLocation } from 'platform-bible-utils';
+import type { SavedWebViewDefinition } from '@papi/core';
 import { MutableRefObject } from 'react';
 import { EditorRef } from '@eten-tech-foundation/platform-editor';
 import {
@@ -15,6 +16,7 @@ import {
   SCRIPTURE_EDITOR_WEBVIEW_TYPE,
   selectProjectIdsForOpenMode,
   startDefaultProjectPicker,
+  toScriptureEditorInfos,
 } from './platform-scripture-editor.utils';
 
 /** Build a mock editor ref exposing spies for the methods the generators call. */
@@ -2016,6 +2018,61 @@ describe('resolveOpenEditorDispatch', () => {
 });
 
 // #endregion resolveOpenEditorDispatch
+
+// #region toScriptureEditorInfos
+
+describe('toScriptureEditorInfos', () => {
+  it('filters out web views that are not Scripture Editors', () => {
+    const defs: SavedWebViewDefinition[] = [
+      { id: 'editor-1', webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: 'PROJ_A' },
+      { id: 'model-text', webViewType: 'platformScriptureEditor.modelText', projectId: 'PROJ_A' },
+      { id: 'comments', webViewType: 'legacyCommentManager.commentListPanel' },
+    ];
+    expect(toScriptureEditorInfos(defs)).toEqual([
+      { id: 'editor-1', projectId: 'PROJ_A', isReadOnly: false },
+    ]);
+  });
+
+  it('maps id and projectId through, including an undefined projectId (empty editor slot)', () => {
+    const defs: SavedWebViewDefinition[] = [
+      { id: 'editor-empty', webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE },
+    ];
+    expect(toScriptureEditorInfos(defs)).toEqual([
+      { id: 'editor-empty', projectId: undefined, isReadOnly: false },
+    ]);
+  });
+
+  it('reads isReadOnly from state, defaulting to false when state or the flag is missing', () => {
+    const defs: SavedWebViewDefinition[] = [
+      {
+        id: 'viewer',
+        webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE,
+        projectId: 'PROJ_A',
+        state: { isReadOnly: true },
+      },
+      {
+        id: 'editor',
+        webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE,
+        projectId: 'PROJ_B',
+        state: { isReadOnly: false },
+      },
+      { id: 'no-state', webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: 'PROJ_C' },
+      { id: 'no-flag', webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: 'PROJ_D', state: {} },
+    ];
+    expect(toScriptureEditorInfos(defs).map((e) => e.isReadOnly)).toEqual([
+      true,
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(toScriptureEditorInfos([])).toEqual([]);
+  });
+});
+
+// #endregion toScriptureEditorInfos
 
 // #region selectProjectIdsForOpenMode
 

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -949,7 +949,7 @@ export async function syncOnProjectSwitch(
  * @param papi The instance of papi to send the commands
  * @param projectId The id of the project to open the text connections for
  */
-export async function openTextConnectionPanels(
+export async function openOrUpdateRelatedPanels(
   papi: typeof PapiBackend,
   projectId: string,
 ): Promise<void> {

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -1,6 +1,6 @@
 /* Small utility helpers for the platform-scripture-editor extension. */
 
-import { LocalizationSelectors } from '@papi/core';
+import { LocalizationSelectors, SavedWebViewDefinition } from '@papi/core';
 import type PapiBackend from '@papi/backend';
 import type PapiFrontend from '@papi/frontend';
 import {
@@ -438,6 +438,32 @@ export type OpenEditorDispatch =
   | { kind: 'focus-existing'; existingId: string }
   | { kind: 'replace-tab'; targetTabId: string }
   | { kind: 'open-new' };
+
+/** Scripture Editor tab info consumed by {@link resolveOpenEditorDispatch}. */
+export type ScriptureEditorInfo = { id: string; projectId?: string; isReadOnly: boolean };
+
+/**
+ * Convert open web view definitions to the Scripture Editor info shape consumed by
+ * {@link resolveOpenEditorDispatch}: filters to Scripture Editor web views and extracts `id`,
+ * `projectId`, and `isReadOnly` from each definition.
+ *
+ * Pure function — does not touch PAPI. The caller is responsible for fetching the definitions
+ * (`papi.webViews.getAllOpenWebViewDefinitions`).
+ */
+export function toScriptureEditorInfos(
+  allOpenDefs: readonly SavedWebViewDefinition[],
+): ScriptureEditorInfo[] {
+  return allOpenDefs
+    .filter((def) => def.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE)
+    .map((def) => ({
+      id: def.id,
+      projectId: def.projectId,
+      // WebView state isn't statically typed, but `getWebViewDefinition` always stores
+      // `isReadOnly` as boolean here. Treat any other value as `false` for safety.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      isReadOnly: !!(def.state?.isReadOnly as boolean | undefined),
+    }));
+}
 
 /**
  * Decide where to route a Scripture Editor open request based on what's currently in the dock and

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -976,6 +976,11 @@ export async function openTextConnectionPanels(
   } catch (e) {
     papi.logger.warn(`Error opening scripture resource text panel: ${getErrorMessage(e)}`);
   }
+  try {
+    await papi.commands.sendCommand('legacyCommentManager.openCommentListPanel', projectId);
+  } catch (e) {
+    papi.logger.warn(`Error opening comment list panel: ${getErrorMessage(e)}`);
+  }
 }
 
 // #endregion Text Connection Panels

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -944,7 +944,8 @@ export async function syncOnProjectSwitch(
 // #region Text Connection Panels
 
 /**
- * Opens or updates the model text, commentary, and scripture resource panels for a project.
+ * Opens or updates the model text and the various views to be displayed in tabs in "column 3" (
+ * reference texts, commentaries, comments, etc.) for a project.
  *
  * @param papi The instance of papi to send the commands
  * @param projectId The id of the project to open the text connections for

--- a/src/renderer/components/docking/platform-dock-tab.component.tsx
+++ b/src/renderer/components/docking/platform-dock-tab.component.tsx
@@ -1,5 +1,4 @@
-import { TabInfo } from '@shared/models/docking-framework.model';
-import { TAB_TYPE_WEBVIEW } from '@renderer/components/web-view.component';
+import { TabInfo, TAB_TYPE_WEBVIEW } from '@shared/models/docking-framework.model';
 
 import { TAB_GROUP } from './platform-dock-layout-positioning.util';
 import { PlatformPanel } from './platform-panel.component';

--- a/src/renderer/components/docking/platform-dock-tab.component.tsx
+++ b/src/renderer/components/docking/platform-dock-tab.component.tsx
@@ -1,4 +1,5 @@
 import { TabInfo } from '@shared/models/docking-framework.model';
+import { TAB_TYPE_WEBVIEW } from '@renderer/components/web-view.component';
 
 import { TAB_GROUP } from './platform-dock-layout-positioning.util';
 import { PlatformPanel } from './platform-panel.component';
@@ -28,6 +29,8 @@ export function createRCDockTabFromTabInfo(tabInfo: TabInfo, shouldFlash = false
         tooltip={tabInfo.tabTooltip}
         flashTriggerTime={flashTriggerTime}
         id={tabInfo.id}
+        // For WebView tabs, the tab id IS the web view id
+        webViewId={tabInfo.tabType === TAB_TYPE_WEBVIEW ? tabInfo.id : undefined}
       />
     ),
     content: <PlatformPanel id={tabInfo.id}>{tabInfo.content}</PlatformPanel>,

--- a/src/renderer/components/docking/platform-tab-title.component.tsx
+++ b/src/renderer/components/docking/platform-tab-title.component.tsx
@@ -34,6 +34,12 @@ type PlatformTabTitleProps = {
   flashTriggerTime?: number;
   /** ID of the tab */
   id: string;
+  /**
+   * ID of the WebView this tab hosts, if it is a WebView tab (equals the tab ID); `undefined` for
+   * non-WebView tabs. Emitted as a `data-web-view-id` attribute to give tests a stable,
+   * locale-independent selector.
+   */
+  webViewId?: string;
 };
 
 // CSS classes for highlighting the active tab header and content
@@ -76,6 +82,7 @@ const handleFloatTab = async (tabId: string) => {
  * @param flashTriggerTime Trigger to make the tab flash. Each time this value changes to a truthy
  *   value, it will trigger a new flash animation.
  * @param id ID of the tab
+ * @param webViewId ID of the WebView this tab hosts, if it is a WebView tab; `undefined` otherwise
  */
 export function PlatformTabTitle({
   iconUrl,
@@ -83,6 +90,7 @@ export function PlatformTabTitle({
   tooltip,
   flashTriggerTime,
   id,
+  webViewId,
 }: PlatformTabTitleProps) {
   const lastFlashTriggerTimeRef = useRef<number | undefined>(undefined);
 
@@ -291,7 +299,12 @@ export function PlatformTabTitle({
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <div ref={containerRef} className="platform-tab-title" aria-label={tabLabel}>
+              <div
+                ref={containerRef}
+                className="platform-tab-title"
+                aria-label={tabLabel}
+                data-web-view-id={webViewId}
+              >
                 <span>{icon}</span>
                 <span>{title}</span>
               </div>

--- a/src/renderer/components/docking/simple-layout.data.test.ts
+++ b/src/renderer/components/docking/simple-layout.data.test.ts
@@ -38,11 +38,11 @@ describe('simple-layout.data', () => {
       });
     });
 
-    it('column 3 has exactly 2 tabs', () => {
+    it('column 3 has exactly 3 tabs', () => {
       // Narrowing column to BoxData and its first child to PanelData to access tabs.
       // eslint-disable-next-line no-type-assertion/no-type-assertion
       const col3Panel = (columns[2] as BoxData).children[0] as PanelData;
-      expect(col3Panel.tabs).toHaveLength(2);
+      expect(col3Panel.tabs).toHaveLength(3);
     });
 
     it('all tab ids are unique across the layout', () => {
@@ -56,7 +56,7 @@ describe('simple-layout.data', () => {
       expect(new Set(allIds).size).toBe(allIds.length);
     });
 
-    it('contains the four expected webViewType strings', () => {
+    it('contains the five expected webViewType strings', () => {
       const allWebViewTypes: string[] = [];
       columns.forEach((col) => {
         // Narrowing column to BoxData and its first child to PanelData to iterate tabs.
@@ -73,6 +73,7 @@ describe('simple-layout.data', () => {
       expect(allWebViewTypes).toContain('platformScriptureEditor.react');
       expect(allWebViewTypes).toContain('platformScriptureEditor.bibleTexts');
       expect(allWebViewTypes).toContain('platformScriptureEditor.commentaries');
+      expect(allWebViewTypes).toContain('legacyCommentManager.commentListPanel');
     });
   });
 });

--- a/src/renderer/components/docking/simple-layout.data.ts
+++ b/src/renderer/components/docking/simple-layout.data.ts
@@ -77,6 +77,16 @@ export const simpleLayout: LayoutBase = {
                   state: {},
                 },
               },
+              {
+                id: 'c7e4a8b2-3d91-4f06-8e5a-1b2c9d0e7f83',
+                tabType: TAB_TYPE_WEBVIEW,
+                data: {
+                  webViewType: 'legacyCommentManager.commentListPanel',
+                  id: 'c7e4a8b2-3d91-4f06-8e5a-1b2c9d0e7f83',
+                  contentType: 'react',
+                  state: {},
+                },
+              },
             ] as SavedTabInfo[],
           },
         ],


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-4068-add-comments-tab-to-column-3

**Base**: origin/main

**Date**: 2026-07-08

**Review model**: Claude Fable 5

**Files changed**: 24 (23 at review start; `.gitignore` reverted to base and 2 renderer/test files touched by review fixes)

## Overview

This review pass covers the latest commits and staged changes since the last review pass on the PT-4068 PR (Comments tab in Column 3 of Simple mode). The changes are mostly (a) improved/added comments and documentation, and (b) reliability work for the new E2E tests: pre-configuring locale/interface-mode before app launch, UUID-based locale-independent selectors (`data-web-view-id`), retry/re-check logic for the "Replacing tab failed" dock race, overlay-clear waits, and E2E test-organization docs.

During the interview, a pre-existing behavior gap was found and fixed: `openOrUpdateRelatedPanels` (formerly `openTextConnectionPanels`) ran for **any** project opened in simple mode, including read-only published resources — which would have re-pointed the model text, Bible texts, Commentaries, and (new in this PR) Comments panels at the resource. The call is now gated on the project being editable, and the E2E tests were aligned to call `openScriptureEditor` (semantically correct for the editable fixture projects) instead of `openResourceViewer`.

## API Changes

- `extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts` (`papi-shared-types` / `CommandHandlers`): Added `'legacyCommentManager.openCommentListPanel': (projectId?: string | undefined) => Promise<string | undefined>` — new command, additive only.
- `lib/platform-bible-react/`: no changes.
- `lib/platform-bible-utils/`: no changes.
- `lib/papi-dts/papi.d.ts` (`@papi/` modules): no changes.
- Note: `openTextConnectionPanels` was renamed to `openOrUpdateRelatedPanels` in `extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts`. This is an extension-internal module, not a public API surface; zero references to the old name remain.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **Non-falsifiable test in `localized-strings.test.ts`**: the "Spanish label differs from the Spanish Commentaries tab title" test read `%webView_resourcePanel_commentaries_title%` from legacy-comment-manager's strings file, but the key lives in platform-scripture-editor's file, so the comparison was always against `undefined` and could never fail. _(fixed during review: test now loads platform-scripture-editor's `localizedStrings.json` via a shared `readLocalizedStrings` helper and asserts the Commentaries key `toBeDefined()` so a future rename fails loudly)_
- [x] **Lint error (CI-failing) in `localized-strings.test.ts`**: `eslint-disable` without required justification comment + prettier warnings. _(fixed during review: justification added as part of the test rewrite; file lints clean)_
- [x] **Lint error (CI-failing) in `e2e-tests/fixtures/helpers.ts`**: `eslint-disable no-type-assertion` in `preConfigureSettings` without justification + prettier warning. _(fixed during review: justification comment added; prettier applied)_
- [x] **Lint error (CI-failing) in `comments-tab.spec.ts`**: `continue` in the retry loop flagged by `no-continue`. _(fixed during review: condition inverted to throw in the non-retry case and fall through otherwise; behavior unchanged)_
- [x] **Prettier violation in `platform-tab-title.component.tsx`**: `data-web-view-id` pushed the `<div>` past print width. _(fixed during review: prettier applied — one attribute per line)_
- [x] **JSDoc contradicted behavior of `openCommentListPanel`**: claimed `projectId: undefined` shows an empty panel, but an already-open panel keeps its current project because `undefined` doubles as the sentinel's "no pending value". This is the same issue Devin review flagged; the team decision (recorded on the PR) was to accept it as a known limitation since clearing an active project is never needed in Simple mode. _(fixed during review: JSDoc and sentinel comment now document the actual behavior and the accepted limitation)_
- [x] **Replace-tab re-check was ineffective in power mode** (`platform-scripture-editor/src/main.ts`): re-resolving with the caller-supplied `existingTabIdToReplace` returns the same gone tab id in power mode, so `openWebView` would still throw. _(fixed during review: re-check gated to `interfaceMode === 'simple'` — the race source, `openOrUpdateRelatedPanels`, only runs there; also avoids an extra `getAllOpenWebViewDefinitions` round trip in power mode)_
- [x] **Related panels updated for read-only resource opens in simple mode** (found during interview; pre-existing gap made user-visible by the new Comments panel): opening a published resource (e.g. from Get Resources) re-pointed all four related panels — including Comments — at the resource project. _(fixed during review: `openOrUpdateRelatedPanels` call gated on `projectForWebView.isEditable`; E2E tests aligned to call `openScriptureEditor` instead of `openResourceViewer` — see Interview Notes)_
- [ ] ~~**Mismatched meanings across locales for `%webView_legacyCommentManager_commentListPanel_title%`** (en "Comments" vs es "Comentarios de proyecto")~~ _(deliberate: in the Spanish Simple UI the Comments and Commentaries ("Comentarios bíblicos") tabs sit side-by-side and must be clearly distinct — both cannot say "Comentarios"; in English the comments/commentaries distinction is judged self-explanatory. Final wording awaits UX research covering both upgrading P9 users and new P10 users. The floating comment list (power) and the fixed tab (simple) will soon never be visible simultaneously, so the same-locale duplicate-title concern does not apply.)_
- [x] **No `fallbackKey` for the new title key**: users in languages other than en/es would see English "Comments" on the Column 3 panel even though the equivalent tab title is localized via Paratext fallback. _(fixed during review: same `fallbackKey` as `%webView_legacyCommentManager_commentList_title%` added. Author notes it is possible-but-unlikely this yields the same word for both tabs in some language — which underscores the need to eventually ensure good P10 localization.)_

### Minor — Consider

- [ ] ~~**`focus-existing` re-resolve edge case** (`platform-scripture-editor/src/main.ts`): if the simple-mode re-resolve returns `focus-existing` (an editor for the same `(projectId, isReadOnly)` appeared concurrently — plausibly via the default project picker reacting to web-view-open events during dock rebuilds), the final `openWebView` treats it like open-new and creates a duplicate editor~~ _(deferred: the re-resolve block is new in this PR, but before it the same race simply threw "Replacing tab failed" — the rare-race outcome changed from a hard error to a possible duplicate tab. Author judged the realistic trigger window not winnable in practice and not this PR's concern. The future fix would mirror the existing focus-existing early return:)_

  ```ts
  // Mirror the focus-existing early return above: an editor for this (projectId, isReadOnly)
  // appeared during openOrUpdateRelatedPanels — bring it to the front instead of duplicating it.
  // emitDidFinish still runs so the workspace-updating overlay is not left stuck.
  if (finalDispatch.kind === 'focus-existing') {
    return papi.webViews
      .openWebView(SCRIPTURE_EDITOR_WEBVIEW_TYPE, undefined, {
        existingId: finalDispatch.existingId,
        createNewIfNotFound: false,
        bringToFront: true,
      })
      .finally(emitDidFinish);
  }
  ```

- [x] **`data-web-view-id` emitted on non-WebView tabs** (`platform-tab-title.component.tsx`): the attribute used the dock tab id for every tab, misleading for non-WebView tabs. _(fixed during review: new optional `webViewId` prop; `platform-dock-tab.component.tsx` passes it only when `tabInfo.tabType === TAB_TYPE_WEBVIEW`, so the attribute is omitted elsewhere. E2E selectors unaffected — their targets are WebView tabs.)_
- [x] **`preConfigureSettings` permanently switched the developer's dev profile** to English/simple mode while its JSDoc claimed state preservation. _(fixed during review: it now snapshots the original file contents and returns a restore function; `comment.fixture.ts` calls it in worker teardown after the app closes. If the file did not exist, restore deletes it.)_
- [x] **Duplicated defs→editors mapping in `platform-scripture-editor/src/main.ts`** (same comment + `eslint-disable` twice) and the new resilience logic was not unit-testable. _(fixed during review: extracted `toScriptureEditorInfos` (+ `ScriptureEditorInfo` type) into `platform-scripture-editor.utils.ts`; both call sites use it; 4 new unit tests cover filtering, mapping, `isReadOnly` defaulting, and empty input — 89/89 tests in the file pass)_
- [x] **Ternary in `comment-list-panel.utils.ts`** equivalent to a `??` chain. _(fixed during review: `pending ?? fromOptions ?? fromSaved`; the 4 priority unit tests still pass)_
- [x] **Naming inconsistency `COMMENT_LIST_PANEL_WEBVIEW_TYPE`** vs the file's existing camelCase `commentListWebViewType`. _(fixed during review: renamed to `commentListPanelWebViewType`; neither the local Code-Style-Guide nor the paranext wiki style guide prescribes constant casing, so the file's pre-existing convention wins)_
- [ ] ~~**Panel provider is an object literal with a module-level mutable sentinel** while its in-file sibling uses the class-based `WebViewFactory` pattern ("state tracking needed → use class")~~ _(dismissed: the provider deliberately mirrors its functional siblings — `modelTextPanelWebViewProvider` and the resource text panel providers in platform-scripture-editor use exactly this object-literal + reload-sentinel shape. Flagged for review: which pattern should the reload-sentinel panels converge on?)_
- [x] **Overlay-gone wait duplicated 4×** across `helpers.ts` and `comments-tab.spec.ts`. _(fixed during review: extracted `waitForOverlayGone(page, timeout)` into `helpers.ts`; the `.pr-twp [role="status"]` selector now has one home)_
- [x] **Inline `import('@playwright/test').Page` repeated 3×** in the spec. _(fixed during review: single top-level `import type { Page }`)_
- [ ] ~~**Sentence-case test asserts on translation content** (`localized-strings.test.ts`): would fail on a legitimate future translation containing a proper noun/acronym~~ _(dismissed as-is; flagged for review: the suite's main purpose is ensuring uniqueness vs. the Commentaries tab, so this particular test is probably not really necessary — tweak or scrap it if a legitimate proper-noun localization ever arrives)_
- [x] **`.gitignore` scope creep**: `/.claude/*.lock` and `/.claude/settings.local.json` were unrelated to PT-4068. _(fixed during review: removed from this branch — `.gitignore` now matches the merge base. Plan: include them in a separate housekeeping branch/PR together with the stashed `stop-processes.mjs` change, stash commit `f5e77a08`. Until then `.claude/scheduled_tasks.lock` shows as untracked locally and must not be committed.)_
- [ ] ~~**`waitForAppReady` default timeout raised 60s→90s + new overlay wait** — silently extends worst-case runtime for all E2E suites using it~~ _(dismissed: leave as is; will be re-evaluated in a subsequent pass — see the timeout/reliability follow-on task in Interview Notes)_
- [ ] ~~**"WebView" → "web view" in error messages** diverges from the design-guide terminology page~~ _(dismissed: deliberate — matches the prevailing "web view" wording used in the dozens of similar provider-mismatch messages across the codebase; changing all the others to "WebView" was judged not worth it)_

### Template Propagation

#### Shared Regions Modified

None. (No changed file contains a `#region shared with` marker.)

#### Extension Config Changes

- [n/a] `extensions/src/legacy-comment-manager/contributions/localizedStrings.json` — extension-specific content, no propagation needed
- [n/a] extension source under `legacy-comment-manager/` and `platform-scripture-editor/` — no propagation needed
- [n/a] `e2e-tests/playwright.config.ts`, `.gitignore` — repo-root files, not extension template files

## Positive Observations

- The only public API change is purely additive; the `.d.ts` declaration, command registration metadata, and handler signature are all consistent, and both new registrations are added to `context.registrations` for cleanup.
- `resolveCommentListPanelProjectId` extracted as a pure, well-documented utility with unit tests covering all four priority combinations; the `existingId: '?'` / `createNewIfNotFound: false` / `bringToFront: false` probe matches the documented `OpenWebViewOptions` contract exactly.
- `openCommentListPanel` passes `bringToFront: false` on project-switch reloads so focus is not stolen from the Scripture editor; the panel reuses the existing comment list webview content and theming, keeping the Column 3 panel and standalone Comments tab consistent.
- The new panel title is properly localized (correct alphabetical insertion, en+es, resolved via `papi.localization.getLocalizedString`) — no hardcoded UI strings anywhere in the new code.
- E2E selectors use the stable `data-web-view-id` attribute instead of localized tab text — locale-independent, with the rc-tabs overflow-clipping behavior thoughtfully handled and documented.
- The `getAllOpenWebViewDefinitions` timeout fallbacks degrade gracefully with clear warnings rather than throwing, and each fallback's reasoning is documented inline.
- `openOrUpdateRelatedPanels` wraps the comments-panel command in try/catch matching the sibling panels, so a comments-panel failure cannot break editor opening.
- `simple-layout.data.test.ts` was updated in lockstep with the layout change, keeping the layout invariants enforced.
- The new E2E test-organization docs (`e2e-tests/CLAUDE.md`, per-directory READMEs, `playwright.config.ts` comment) codify conventions clearly, including warning away from the legacy directories.

## Interview Notes

- **Stated purpose**: review the latest commits and staged changes since the last review pass — mostly improved/added comments plus changes to make the new E2E tests pass reliably.
- **Localization strategy (title key)**: the author explained the en/es asymmetry is deliberate (see the dismissed Important finding). Final wording awaits UX research; the shared `fallbackKey` was accepted knowing the small cross-language collision risk.
- **Sentinel limitation**: the author connected the JSDoc finding to the earlier Devin-review discussion and the recorded decision to accept the limitation rather than add a `hasPending` flag; the fix was documentation, not behavior.
- **`openOrUpdateRelatedPanels` gating**: the author's instinct that only the editable path should trigger related panels was verified as correct against the code; the gap pre-existed the branch (as `openTextConnectionPanels`) but became user-visible with the Comments panel. Fixed with a one-line editability gate.
- **Author uncertainty (resolved during interview)**: the author was "not very sure" whether the `openResourceViewer` retry logic in the E2E spec was still needed, and suspected the comment tests shouldn't call `openResourceViewer` directly. Analysis confirmed: the retry remains justified as defense-in-depth (the app-side re-check's timeout fallback can still throw), the PT-4069 test must go through the editor-open command (not `openCommentListPanel`) because the integration under test is "active project change → Comments tab follows", and the tests were switched to the semantically correct `openScriptureEditor`.
- **Not verified in this session**: the E2E suite was NOT re-run after the in-review changes (unit tests, lint, typecheck, and formatting were). A full E2E re-run is recommended before merge.
- **Follow-on task (author)**: when re-running the E2E tests, evaluate whether the reliability improvements allow shorter timeouts (including the `waitForAppReady` 90s default) or measurably better reliability.
- **Separate PR plan**: the `.claude` `.gitignore` entries removed from this branch should ship in a housekeeping branch/PR together with the stashed `stop-processes.mjs` change (stash commit `f5e77a08`).

## In-Review Quality Check

- `npm run typecheck` — passed (only the known pre-existing, unrelated `PARAGRAPH_STRUCTURE_VIEW_MODE` error in `platform-scripture-editor.web-view.tsx` from `@eten-tech-foundation/platform-editor`).
- `npm run lint` — passed, 0 errors (5 pre-existing `no-console` warnings in files untouched by this review).
- Prettier over all 24 changed files — clean, no fixes needed.
- `npm test` — all review-related workspaces pass, including the new `localized-strings.test.ts`, `comment-list-panel.utils.test.ts` (4 tests), and `platform-scripture-editor.utils.test.ts` (89 tests incl. 4 new `toScriptureEditorInfos` tests). The only failure was environmental: `lib/platform-bible-react` (untouched) could not launch its vitest browser mode because the local Playwright chromium-headless-shell binary was missing; it was installed machine-level for future runs.
- No code fixes were required by the quality checks.

## Suggested Review Focus

Prioritized areas for the author-reviewer meeting:

- [ ] **Editability gate on `openOrUpdateRelatedPanels`** (`platform-scripture-editor/src/main.ts` `open()`): simple-mode opens of read-only published resources no longer update the related panels. This is a behavior change slightly beyond the PR's comments scope (it also affects model text / Bible texts / Commentaries panels) — confirm it matches the intended simple-mode UX for opening resources.
- [ ] **E2E re-run before merge**, then the follow-on evaluation of whether timeouts can be shortened given the reliability fixes.
- [ ] **Provider pattern for reload-sentinel panels**: object literal + module-level sentinel (current, matching platform-scripture-editor's panels) vs class-based `WebViewFactory` per the extension-patterns guidance — pick a direction for future panels.
- [ ] **Sentence-case localization test**: probably unnecessary given the suite's uniqueness purpose — keep, tweak, or scrap.
- [ ] **`focus-existing` re-resolve edge case**: deferred with a ready-to-apply snippet (above) — decide whether to ticket it.
- [ ] **Comments/Commentaries tab wording** (en "Comments" / es "Comentarios de proyecto"): pending UX research; the shared fallbackKey may yield identical words in some locales.
<!-- review-paratext:summary:end -->

---

## Summary

- Adds a \"Comments\" tab as a fixed third tab in Column 3 of Platform.Bible Simple mode (PT-4068)
- Wires the tab to automatically reload when the active project changes in Column 2 (PT-4069)
- Registers `legacyCommentManager.commentListPanel` WebView provider and `legacyCommentManager.openCommentListPanel` PAPI command in `legacy-comment-manager`
- Calls `openCommentListPanel` from `openOrUpdateRelatedPanels` (renamed from `openTextConnectionPanels`) in `platform-scripture-editor`
- Dedicated localization key `%webView_legacyCommentManager_commentListPanel_title%` (en: \"Comments\", es: \"Comentarios de proyecto\") so the panel tab and floating list can diverge independently
- E2E tests in `tests/isolated/` for tab visibility, panel rendering, comments content, Spanish label, and project-tracking (PT-4069)

## Changes made during review (both sessions)

- `bringToFront: false` added to the `existingId: '?'` probe call in `openCommentListPanel` — the omission caused the Comments panel to briefly steal focus on every project switch
- Extracted `resolveCommentListPanelProjectId` into `comment-list-panel.utils.ts` with 4 unit tests covering the sentinel priority chain
- Dedicated localization key (instead of changing the existing floating-list key)
- `openTextConnectionPanels` renamed to `openOrUpdateRelatedPanels`
- JSDoc updated to describe behavior rather than callers
- Error message casing normalized (`"WebView"` → `"web view"`)
- E2E spec moved to `tests/isolated/`; READMEs added to all standard E2E directories; `e2e-tests/CLAUDE.md` added documenting test placement conventions

## Known limitations / reviewer notes

- **Sentinel ambiguity**: `currentCommentListPanelProjectId` uses `undefined` as both sentinel and valid value; `openCommentListPanel(undefined)` when a panel is open would silently keep the old project. Accepted: this path is never taken in current UX (Simple mode doesn't allow clearing a project). Mirrors the same pattern as `currentModelTextProjectId` in `platform-scripture-editor`.
- **PT-4088**: The colon+project-name append in the floating comment list title is a known localization concern, deferred to a follow-up.
- **Floating list in Simple mode**: Two tabs titled \"Comments\" could appear if both the panel and a floating list are open. Accepted: the floating list will eventually be made inaccessible in Simple mode (future work).

## Test plan

- [x] Unit tests: `comment-list-panel.utils.test.ts` (4 tests, all pass)
- [x] Unit test: `simple-layout.data.test.ts` updated (tab count 2→3)
- [x] lint / format / typecheck: clean (pre-existing unrelated typecheck failure in `platform-scripture-editor.web-view.tsx`)
- [x] E2E (local): 2/5 tests pass when app boots cleanly; 3/5 fail due to pre-existing first-Electron environment issue on the review machine (same failure seen in `comment-assignment` isolated tests — not introduced by this PR)

AI-assisted — [session 1](https://claude.ai/code/28cdd4e1-f95f-409e-9721-f18c433482a3), [session 2](https://claude.ai/code/28cdd4e1-f95f-409e-9721-f18c433242a3), [session 3](https://claude.ai/code/a92ed8bf-d14e-48fa-af5a-0a7175c8f40d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2500)
<!-- Reviewable:end -->

