### PR TITLE
fix(platform-bible-react): stop raw i18n keys leaking in Storybook

### DIFF
--- a/lib/platform-bible-react/src/stories/advanced/inventory.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/inventory.stories.tsx
@@ -28,6 +28,9 @@ const localizedStrings = {
   '%webView_inventory_scope_currentBook%': 'Current book',
   '%webView_inventory_scope_chapter%': 'Current chapter',
   '%webView_inventory_scope_verse%': 'Current verse',
+  // Shown by the results table when a filter matches nothing. Missing here previously, so the raw
+  // key `%webView_inventory_no_results%` leaked into the UI once a filter emptied the list.
+  '%webView_inventory_no_results%': 'No results.',
 };
 
 const sampleInventoryItems: InventorySummaryItem[] = [

--- a/lib/platform-bible-react/src/stories/advanced/inventory.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/inventory.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import {
   Inventory,
+  InventoryLocalizedStrings,
   InventorySummaryItem,
 } from '@/components/advanced/inventory/inventory.component';
 import {
@@ -16,7 +17,9 @@ import { Scope } from '@/components/utils/scripture.util';
 import { escapeStringRegexp } from 'platform-bible-utils';
 import { useState } from 'react';
 
-const localizedStrings = {
+// Typed `Required<InventoryLocalizedStrings>` so the compiler flags a dropped key: Inventory
+// resolves `strings[key] ?? key`, so a missing key would render the raw `%…%` token in the UI.
+const localizedStrings: Required<InventoryLocalizedStrings> = {
   '%webView_inventory_all%': 'All items',
   '%webView_inventory_approved%': 'Approved items',
   '%webView_inventory_unapproved%': 'Unapproved items',

--- a/lib/platform-bible-react/src/stories/advanced/scope-selector.stories.tsx
+++ b/lib/platform-bible-react/src/stories/advanced/scope-selector.stories.tsx
@@ -2,7 +2,10 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState } from 'react';
 import { SerializedVerseRef } from '@sillsdev/scripture';
 import { defaultScrRef } from 'platform-bible-utils';
-import { ScopeSelector } from '@/components/advanced/scope-selector/scope-selector.component';
+import {
+  ScopeSelector,
+  ScopeSelectorLocalizedStrings,
+} from '@/components/advanced/scope-selector/scope-selector.component';
 import { ScopeWithRange } from '@/components/utils/scripture.util';
 
 // Mock book information - represents which books are available (all books available in this case)
@@ -20,6 +23,47 @@ const mockLocalizedBookNames = new Map([
   ['JHN', { localizedId: 'Jhn', localizedName: 'John' }],
   ['ROM', { localizedId: 'Rom', localizedName: 'Romans' }],
 ]);
+
+// A complete set of localized strings covering every key the ScopeSelector — and the SelectBooks
+// picker it embeds — can render. Typed as `Required<ScopeSelectorLocalizedStrings>` so the compiler
+// flags any key that goes missing: a partial object leaks raw keys (e.g.
+// `%webView_scope_selector_range%`) into the UI as soon as the matching control is shown (switching
+// scope, opening the range/books dialog, etc.). Shared across every story so all of them stay fully
+// localized regardless of which scope or dialog the viewer interacts with.
+const sampleLocalizedStrings: Required<ScopeSelectorLocalizedStrings> = {
+  '%webView_scope_selector_selected_text%': 'Selected text',
+  '%webView_scope_selector_verse%': 'Verse',
+  '%webView_scope_selector_chapter%': 'Chapter',
+  '%webView_scope_selector_book%': 'Book',
+  '%webView_scope_selector_current_verse%': 'Current verse',
+  '%webView_scope_selector_current_chapter%': 'Current chapter',
+  '%webView_scope_selector_current_book%': 'Current book',
+  '%webView_scope_selector_choose_books%': 'Choose specific books',
+  '%webView_scope_selector_scope%': 'Scope',
+  '%webView_scope_selector_select_books%': 'Select books',
+  '%webView_scope_selector_range%': 'Range',
+  '%webView_scope_selector_select_range%': 'Select a range',
+  '%webView_scope_selector_range_start%': 'From',
+  '%webView_scope_selector_range_end%': 'To',
+  '%webView_scope_selector_ok%': 'OK',
+  '%webView_scope_selector_cancel%': 'Cancel',
+  '%webView_scope_selector_navigate%': 'Change current reference',
+  '%webView_book_selector_books_selected%': 'books selected',
+  '%webView_book_selector_select_books%': 'Select books',
+  '%webView_book_selector_search_books%': 'Search books',
+  '%webView_book_selector_select_all%': 'Select all',
+  '%webView_book_selector_clear_all%': 'Clear all',
+  '%webView_book_selector_no_book_found%': 'No book found',
+  '%webView_book_selector_more%': 'more',
+  '%scripture_section_ot_long%': 'Old Testament',
+  '%scripture_section_ot_short%': 'OT',
+  '%scripture_section_nt_long%': 'New Testament',
+  '%scripture_section_nt_short%': 'NT',
+  '%scripture_section_dc_long%': 'Deuterocanonical',
+  '%scripture_section_dc_short%': 'DC',
+  '%scripture_section_extra_long%': 'Extra material',
+  '%scripture_section_extra_short%': 'Extra',
+};
 
 const meta: Meta<typeof ScopeSelector> = {
   title: 'Advanced/Scope Selector',
@@ -63,18 +107,7 @@ export const BookScope: Story = {
           console.log('Selected books:', bookIds);
           setSelectedBookIds(bookIds);
         }}
-        localizedStrings={{
-          '%webView_scope_selector_book%': 'Book',
-          '%webView_scope_selector_current_book%': 'Current book',
-          '%webView_scope_selector_chapter%': 'Chapter',
-          '%webView_scope_selector_current_chapter%': 'Current chapter',
-          '%webView_scope_selector_verse%': 'Verse',
-          '%webView_scope_selector_current_verse%': 'Current verse',
-          '%webView_scope_selector_scope%': 'Scope',
-          '%webView_scope_selector_choose_books%': 'Choose specific books',
-          '%webView_book_selector_books_selected%': 'books selected',
-          '%webView_book_selector_select_books%': 'Select books',
-        }}
+        localizedStrings={sampleLocalizedStrings}
         localizedBookNames={mockLocalizedBookNames}
       />
     );
@@ -106,16 +139,7 @@ export const ChapterScope: Story = {
           console.log('Selected books:', bookIds);
           setSelectedBookIds(bookIds);
         }}
-        localizedStrings={{
-          '%webView_scope_selector_book%': 'Book',
-          '%webView_scope_selector_current_book%': 'Current book',
-          '%webView_scope_selector_chapter%': 'Chapter',
-          '%webView_scope_selector_current_chapter%': 'Current chapter',
-          '%webView_scope_selector_verse%': 'Verse',
-          '%webView_scope_selector_current_verse%': 'Current verse',
-          '%webView_scope_selector_scope%': 'Scope',
-          '%webView_scope_selector_choose_books%': 'Choose specific books',
-        }}
+        localizedStrings={sampleLocalizedStrings}
         localizedBookNames={mockLocalizedBookNames}
       />
     );
@@ -147,16 +171,7 @@ export const VerseScope: Story = {
           console.log('Selected books:', bookIds);
           setSelectedBookIds(bookIds);
         }}
-        localizedStrings={{
-          '%webView_scope_selector_book%': 'Book',
-          '%webView_scope_selector_current_book%': 'Current book',
-          '%webView_scope_selector_chapter%': 'Chapter',
-          '%webView_scope_selector_current_chapter%': 'Current chapter',
-          '%webView_scope_selector_verse%': 'Verse',
-          '%webView_scope_selector_current_verse%': 'Current verse',
-          '%webView_scope_selector_scope%': 'Scope',
-          '%webView_scope_selector_choose_books%': 'Choose specific books',
-        }}
+        localizedStrings={sampleLocalizedStrings}
         localizedBookNames={mockLocalizedBookNames}
       />
     );
@@ -168,31 +183,6 @@ export const VerseScope: Story = {
       },
     },
   },
-};
-
-const rangeLocalizedStrings = {
-  '%webView_scope_selector_book%': 'Book',
-  '%webView_scope_selector_current_book%': 'Current book',
-  '%webView_scope_selector_chapter%': 'Chapter',
-  '%webView_scope_selector_current_chapter%': 'Current chapter',
-  '%webView_scope_selector_verse%': 'Verse',
-  '%webView_scope_selector_current_verse%': 'Current verse',
-  '%webView_scope_selector_selected_text%': 'Selected text',
-  '%webView_scope_selector_scope%': 'Scope',
-  '%webView_scope_selector_choose_books%': 'Choose specific books',
-  '%webView_scope_selector_range%': 'Range',
-  '%webView_scope_selector_select_range%': 'Select a range',
-  '%webView_scope_selector_range_start%': 'From',
-  '%webView_scope_selector_range_end%': 'To',
-  '%webView_scope_selector_ok%': 'OK',
-  '%webView_scope_selector_navigate%': 'Change current reference',
-  '%webView_book_selector_books_selected%': 'books selected',
-  '%webView_book_selector_select_books%': 'Select books',
-  '%webView_book_selector_search_books%': 'Search books',
-  '%webView_book_selector_select_all%': 'Select all',
-  '%webView_book_selector_clear_all%': 'Clear all',
-  '%webView_book_selector_no_book_found%': 'No book found',
-  '%webView_book_selector_more%': 'more',
 };
 
 // A small sample verse-count table so the range BCV pickers can show a verse grid.
@@ -225,7 +215,7 @@ export const DropdownVariant: Story = {
         selectedBookIds={selectedBookIds}
         onScopeChange={(newScope: ScopeWithRange) => setScope(newScope)}
         onSelectedBookIdsChange={(bookIds: string[]) => setSelectedBookIds(bookIds)}
-        localizedStrings={rangeLocalizedStrings}
+        localizedStrings={sampleLocalizedStrings}
         localizedBookNames={mockLocalizedBookNames}
         currentScrRef={currentScrRef}
         onCurrentScrRefChange={setCurrentScrRef}
@@ -261,7 +251,7 @@ export const RangeScope: Story = {
         selectedBookIds={selectedBookIds}
         onScopeChange={(newScope: ScopeWithRange) => setScope(newScope)}
         onSelectedBookIdsChange={(bookIds: string[]) => setSelectedBookIds(bookIds)}
-        localizedStrings={rangeLocalizedStrings}
+        localizedStrings={sampleLocalizedStrings}
         localizedBookNames={mockLocalizedBookNames}
         rangeStart={rangeStart}
         rangeEnd={rangeEnd}
@@ -301,7 +291,7 @@ export const DropdownVariantWithRange: Story = {
         selectedBookIds={selectedBookIds}
         onScopeChange={(newScope: ScopeWithRange) => setScope(newScope)}
         onSelectedBookIdsChange={(bookIds: string[]) => setSelectedBookIds(bookIds)}
-        localizedStrings={rangeLocalizedStrings}
+        localizedStrings={sampleLocalizedStrings}
         localizedBookNames={mockLocalizedBookNames}
         currentScrRef={currentScrRef}
         onCurrentScrRefChange={setCurrentScrRef}
@@ -340,21 +330,7 @@ export const SelectedBooksScope: Story = {
           console.log('Selected books:', bookIds);
           setSelectedBookIds(bookIds);
         }}
-        localizedStrings={{
-          '%webView_scope_selector_book%': 'Book',
-          '%webView_scope_selector_current_book%': 'Current book',
-          '%webView_scope_selector_chapter%': 'Chapter',
-          '%webView_scope_selector_current_chapter%': 'Current chapter',
-          '%webView_scope_selector_verse%': 'Verse',
-          '%webView_scope_selector_current_verse%': 'Current verse',
-          '%webView_scope_selector_scope%': 'Scope',
-          '%webView_scope_selector_choose_books%': 'Choose specific books',
-          '%webView_book_selector_books_selected%': 'books selected',
-          '%webView_book_selector_select_books%': 'Select books',
-          '%webView_book_selector_search_books%': 'Search books',
-          '%webView_book_selector_select_all%': 'Select all',
-          '%webView_book_selector_clear_all%': 'Clear all',
-        }}
+        localizedStrings={sampleLocalizedStrings}
         localizedBookNames={mockLocalizedBookNames}
       />
     );
@@ -490,19 +466,7 @@ export const WithLocalizedSpanishBookNames: Story = {
           console.log('Selected books:', bookIds);
           setSelectedBookIds(bookIds);
         }}
-        localizedStrings={{
-          '%webView_scope_selector_book%': 'Book',
-          '%webView_scope_selector_current_book%': 'Current book',
-          '%webView_scope_selector_chapter%': 'Chapter',
-          '%webView_scope_selector_current_chapter%': 'Current chapter',
-          '%webView_scope_selector_scope%': 'Scope',
-          '%webView_scope_selector_choose_books%': 'Choose specific books',
-          '%webView_book_selector_books_selected%': 'books selected',
-          '%webView_book_selector_select_books%': 'Select books',
-          '%webView_book_selector_search_books%': 'Search books',
-          '%webView_book_selector_select_all%': 'Select all',
-          '%webView_book_selector_clear_all%': 'Clear all',
-        }}
+        localizedStrings={sampleLocalizedStrings}
         localizedBookNames={spanishBookNames}
       />
     );
@@ -551,19 +515,7 @@ export const WithLocalizedGermanBookNames: Story = {
           console.log('Selected books:', bookIds);
           setSelectedBookIds(bookIds);
         }}
-        localizedStrings={{
-          '%webView_scope_selector_book%': 'Book',
-          '%webView_scope_selector_current_book%': 'Current book',
-          '%webView_scope_selector_chapter%': 'Chapter',
-          '%webView_scope_selector_current_chapter%': 'Current chapter',
-          '%webView_scope_selector_scope%': 'Scope',
-          '%webView_scope_selector_choose_books%': 'Choose specific books',
-          '%webView_book_selector_books_selected%': 'books selected',
-          '%webView_book_selector_select_books%': 'Select books',
-          '%webView_book_selector_search_books%': 'Search books',
-          '%webView_book_selector_select_all%': 'Select all',
-          '%webView_book_selector_clear_all%': 'Clear all',
-        }}
+        localizedStrings={sampleLocalizedStrings}
         localizedBookNames={germanBookNames}
       />
     );


### PR DESCRIPTION
## Summary

Several **ScopeSelector** Storybook stories rendered raw localization keys instead of translated text — e.g. `%webView_scope_selector_range%`, `%webView_scope_selector_range_start%` — as soon as you switched scope or opened a picker.

Root cause: `ScopeSelector` resolves each label with `localizedStrings[key] ?? key`, so a **missing** key falls back to the *raw key*. In the radio variant with no `availableScopes`, every scope option renders (including `selectedText` and `range`), and selecting `range` renders the `range_start` / `range_end` labels. Most stories passed **partial** `localizedStrings` objects, so those keys leaked on interaction. Even the shared `rangeLocalizedStrings` object was missing `select_books`, `cancel`, and all 8 `%scripture_section_*%` keys.

## Before / After

Chapter Scope story with the **Range** option selected — the exact case from the report:

![Before/after: raw keys vs. localized labels](https://raw.githubusercontent.com/paranext/media/main/paranext-core/pr-2501/range-before-after.png)

The scope radio list (no interaction):

![Before/after: scope options](https://raw.githubusercontent.com/paranext/media/main/paranext-core/pr-2501/default-before-after.png)

> Images are hosted in the private [`paranext/media`](https://github.com/paranext/media/tree/main/paranext-core/pr-2501) repo per the dev-lead policy (agents never commit binaries to `paranext-core`). Because that repo is private, GitHub may not render them inline here — click through to the [range](https://github.com/paranext/media/blob/main/paranext-core/pr-2501/range-before-after.png) or [radio-list](https://github.com/paranext/media/blob/main/paranext-core/pr-2501/default-before-after.png) blobs, or drag the files directly into this description for guaranteed inline rendering.

## Changes

- **`scope-selector.stories.tsx`** — Replace all six partial per-story `localizedStrings` objects (and the incomplete `rangeLocalizedStrings`) with a single shared `sampleLocalizedStrings` covering all 32 keys the component and its embedded `SelectBooks` can render. Typed **`Required<ScopeSelectorLocalizedStrings>`** so the compiler fails if any key is ever dropped again. (net −48 lines)
- **`inventory.stories.tsx`** — Add the missing `%webView_inventory_no_results%` key (`Inventory` uses the same raw-key fallback; the key leaked once a filter emptied the list), and type the story object `Required<InventoryLocalizedStrings>` so it has the same compiler guard.

## Scope of the fix vs. the wider pattern

This PR fixes the **two components with observed accidental leaks in normal-usage stories**: `ScopeSelector` and `Inventory`.

The raw-key fallback (`strings[key] ?? key`) is **not** unique to these two — a deterministic grep finds **8** components sharing the identical helper: `scope-selector`, `inventory` (fixed here), plus `error-dump`, `undo-redo-buttons`, `cancel-accept-buttons`, `book-selector`, `ui-language-selector`, `resource-picker-dialog`. The other six aren't fixed here because they currently pass complete strings, or only leak in stories that *intentionally* demonstrate the fallback (e.g. `MissingLocalizedStrings`). Converting all of them to English-default fallback at the source is tracked in **PT-4103**.

Components like `BookChapterControl`, `CommentList`, and `CommentEditor` already fall back to English defaults (`?? 'Select Chapter'`), not the raw key, so they never leak.

## Follow-ups

- **#2502** — adds `.claude/rules/code-quality/localized-string-fallbacks.md` (the `?? 'English'` contract + `Required<…>` story fixtures) and corrects a `react-patterns.md` claim that overstated CI lint enforcement.
- **PT-4103** — convert the remaining 6 raw-key-fallback components to English defaults, and correct the Localization-Guide precedent list.

## Testing

- [x] `npm run typecheck` (platform-bible-react) — passes; the `Required<>` annotations statically verify both story objects are complete.
- [x] `npm run lint:scripts` (platform-bible-react) — passes.
- [x] Verified before/after in Storybook (Chapter Scope → Range) — raw keys gone; see **Before / After** above.

## Risk Level

Low — Storybook stories only; no component/runtime behavior changed.

## AI Involvement

AI-assisted (Claude Code). AI mapped the component's key resolution, made the story edits, ran a cross-component audit, and ran an adversarial review that caught the audit-narrative overstatement and the missing Inventory compiler guard (both corrected here). All findings were verified against the source before commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2501)
<!-- Reviewable:end -->





Resume this session: `claude --resume 63aed4b7-897a-4465-80ad-b0aa34d4a0c2` (run from the `fix-localisation-in-storybook-scope-selector` worktree).
