### PR TITLE
docs(rules): guardrail against raw-key i18n leaks (follow-up to #2501)

### DIFF
--- a/.claude/rules/architecture/react-patterns.md
+++ b/.claude/rules/architecture/react-patterns.md
@@ -78,22 +78,22 @@ When you modify any vendored shadcn component (under `lib/platform-bible-react/s
 
 **Verification**: before committing changes to any `shadcn-ui/` file, diff against the prior commit on the base branch and confirm every changed line is covered by a `CUSTOM` marker. Reviewers will grep for `CUSTOM` to find all customizations.
 
-## What's Enforced by Linting (Don't Duplicate)
+## Linting: What CI Enforces vs. What It Doesn't
 
-- Tailwind `tw:` prefix on utility classes → enforced by the project's Tailwind/ESLint config
+**Enforced by CI (`npm run lint`, via `.eslintrc.js`) — don't duplicate:**
 
-The following `paranext/*` rules exist but are **not** part of the default `npm run lint` that CI
-runs (which uses `.eslintrc.js` and enables only `paranext/require-disable-comment`). They live in
-`.eslintrc.ai.js`, reachable only via `npm run lint:ai-strict`, and are turned **off** for
-`*.stories.tsx` / test files. They also target hardcoded JSX literals, not missing localize keys.
-Treat them as advisory, not a CI safety net — do not assume they will catch anything:
+- Tailwind `tw:` prefix on utility classes
 
-- Localized strings → `paranext/no-hardcoded-jsx-strings` (ai-strict only; off in stories/tests)
-- ARIA localization → `paranext/require-localized-aria` (ai-strict only; off in stories/tests)
-- Theme colors → `paranext/no-hardcoded-tailwind-colors` (ai-strict only)
+**NOT enforced by CI — advisory only.** These `paranext/*` rules live in `.eslintrc.ai.js`
+(`npm run lint:ai-strict`, which CI does not run), have varying severity (several are only `warn`),
+and are turned **off** for `*.stories.tsx` / test files. They also target hardcoded JSX literals,
+not missing localize keys — so none of them catch a raw-key leak:
 
-Because none of these run in CI, localized-string mistakes are **not** caught automatically. For the
-raw-key-leak class specifically, see
-[localized-string-fallbacks.md](../code-quality/localized-string-fallbacks.md).
+- `paranext/no-hardcoded-jsx-strings` — hardcoded strings in JSX
+- `paranext/require-localized-aria` — hardcoded ARIA labels
+- `paranext/no-hardcoded-tailwind-colors` — hardcoded theme colors
+
+Don't assume localized-string or ARIA mistakes are caught automatically. For the raw-key-leak class,
+see [localized-string-fallbacks.md](../code-quality/localized-string-fallbacks.md).
 
 See [Component-Selection-Quick-Reference.md](../../../.context/standards/Component-Selection-Quick-Reference.md).

--- a/.claude/rules/architecture/react-patterns.md
+++ b/.claude/rules/architecture/react-patterns.md
@@ -78,22 +78,21 @@ When you modify any vendored shadcn component (under `lib/platform-bible-react/s
 
 **Verification**: before committing changes to any `shadcn-ui/` file, diff against the prior commit on the base branch and confirm every changed line is covered by a `CUSTOM` marker. Reviewers will grep for `CUSTOM` to find all customizations.
 
-## Linting: What CI Enforces vs. What It Doesn't
+## Linting: What Tooling Catches (and What It Doesn't)
 
-**Enforced by CI (`npm run lint`, via `.eslintrc.js`) — don't duplicate:**
+Don't assume these concerns are caught automatically in CI — most are not:
 
-- Tailwind `tw:` prefix on utility classes
+- **Tailwind `tw:` prefix** — required by the Tailwind v4 config (`prefix(tw)` in
+  `lib/platform-bible-react/src/index.css`, and `twMerge` in `utils/shadcn-ui/utils.ts`), **not** by
+  a lint rule. A missing prefix silently produces no styling — no build or lint error flags it.
+- **Localized strings** (`paranext/no-hardcoded-jsx-strings`), **ARIA localization**
+  (`paranext/require-localized-aria`), **theme colors** (`paranext/no-hardcoded-tailwind-colors`) —
+  all live in `.eslintrc.ai.js` (`npm run lint:ai-strict`), which **CI does not run**. The
+  localization/ARIA rules are additionally **off** for `*.stories.tsx` / test files, and target
+  hardcoded JSX literals, not missing localize keys.
 
-**NOT enforced by CI — advisory only.** These `paranext/*` rules live in `.eslintrc.ai.js`
-(`npm run lint:ai-strict`, which CI does not run), have varying severity (several are only `warn`),
-and are turned **off** for `*.stories.tsx` / test files. They also target hardcoded JSX literals,
-not missing localize keys — so none of them catch a raw-key leak:
-
-- `paranext/no-hardcoded-jsx-strings` — hardcoded strings in JSX
-- `paranext/require-localized-aria` — hardcoded ARIA labels
-- `paranext/no-hardcoded-tailwind-colors` — hardcoded theme colors
-
-Don't assume localized-string or ARIA mistakes are caught automatically. For the raw-key-leak class,
-see [localized-string-fallbacks.md](../code-quality/localized-string-fallbacks.md).
+CI's `npm run lint` uses `.eslintrc.js`, which enables only `paranext/require-disable-comment` among
+the `paranext/*` rules — so none of the above catch a raw-key leak. For that class, see
+[localized-string-fallbacks.md](../code-quality/localized-string-fallbacks.md).
 
 See [Component-Selection-Quick-Reference.md](../../../.context/standards/Component-Selection-Quick-Reference.md).

--- a/.claude/rules/architecture/react-patterns.md
+++ b/.claude/rules/architecture/react-patterns.md
@@ -81,8 +81,19 @@ When you modify any vendored shadcn component (under `lib/platform-bible-react/s
 ## What's Enforced by Linting (Don't Duplicate)
 
 - Tailwind `tw:` prefix on utility classes → enforced by the project's Tailwind/ESLint config
-- Localized strings → ESLint: no-hardcoded-jsx-strings
-- ARIA localization → ESLint: require-localized-aria
-- Theme colors → ESLint: no-hardcoded-tailwind-colors
+
+The following `paranext/*` rules exist but are **not** part of the default `npm run lint` that CI
+runs (which uses `.eslintrc.js` and enables only `paranext/require-disable-comment`). They live in
+`.eslintrc.ai.js`, reachable only via `npm run lint:ai-strict`, and are turned **off** for
+`*.stories.tsx` / test files. They also target hardcoded JSX literals, not missing localize keys.
+Treat them as advisory, not a CI safety net — do not assume they will catch anything:
+
+- Localized strings → `paranext/no-hardcoded-jsx-strings` (ai-strict only; off in stories/tests)
+- ARIA localization → `paranext/require-localized-aria` (ai-strict only; off in stories/tests)
+- Theme colors → `paranext/no-hardcoded-tailwind-colors` (ai-strict only)
+
+Because none of these run in CI, localized-string mistakes are **not** caught automatically. For the
+raw-key-leak class specifically, see
+[localized-string-fallbacks.md](../code-quality/localized-string-fallbacks.md).
 
 See [Component-Selection-Quick-Reference.md](../../../.context/standards/Component-Selection-Quick-Reference.md).

--- a/.claude/rules/code-quality/localized-string-fallbacks.md
+++ b/.claude/rules/code-quality/localized-string-fallbacks.md
@@ -2,12 +2,10 @@
 
 Components in `lib/platform-bible-react/` are process-agnostic: they never call
 `useLocalizedStrings`/PAPI. The consumer resolves strings and passes them in as an optional,
-`Partial`-typed `localizedStrings` prop. That means **any key can be absent at runtime** — a story,
-a test, or a real extension may pass a subset — so how a component resolves a missing key matters.
+`Partial`-typed `localizedStrings` prop — so **any key can be absent at runtime** (a story, a test,
+or a real extension may pass a subset). How a component resolves a missing key matters.
 
 ### Fall back to English, never to the raw key
-
-When reading a localized string, fall back to a built-in **English default**, not to the key:
 
 ```tsx
 // ✅ Missing key degrades to readable English
@@ -17,23 +15,20 @@ const rangeText = localizedStrings?.['%webView_scope_selector_range%'] ?? 'Range
 const rangeText = localizedStrings[key] ?? key;
 ```
 
-A `strings[key] ?? key` resolver renders `%webView_scope_selector_range%` verbatim on screen the
-moment a caller omits that key. The English fallback is the contract documented in
-`.context/standards/Localization-Guide.md` §"Localizing Shared Library Components", and is what
-`BookChapterControl`, `CommentList`, and `CommentEditor` already do (e.g.
-`book-chapter-control.component.tsx`: `?? 'Select Chapter'`).
+`strings[key] ?? key` renders `%webView_scope_selector_range%` verbatim on screen the moment a caller
+omits that key. Fall back to a built-in English default instead — the contract documented in
+`.context/standards/Localization-Guide.md` §"Localizing Shared Library Components", and what
+`BookChapterControl` (`?? 'Select Chapter'`) and `CommentEditor` (`?? 'Unassigned'`) already do.
 
-**When adding or reviewing a library component:** if you see the shared helper
-`const localizeString = (strings, key) => strings[key] ?? key;`, treat it as a bug — replace each
-read with a per-key `?? 'English default'`. This protects real extension consumers, not just
-stories.
+When reviewing: a local `localizeString` helper of the shape `(strings, key) => strings[key] ?? key`
+(copy-pasted across several components, not shared) is a bug — replace each read with a per-key
+`?? 'English default'`.
 
 ### Type story fixtures as `Required<…>`
 
-The `…LocalizedStrings` type is `Partial` by design, so a story passing a subset is type-valid and
-TypeScript stays silent when a key is dropped. For stories of these components, type the fixture as
-`Required<XxxLocalizedStrings>` and share one object across all stories in the file, so the compiler
-fails when a key goes missing:
+The `…LocalizedStrings` type is `Partial` by design, so a story passing a subset is type-valid and a
+dropped key is silent. Type the fixture `Required<XxxLocalizedStrings>` and share one object across
+the file's stories, so a missing key fails to compile:
 
 ```tsx
 const sampleLocalizedStrings: Required<ScopeSelectorLocalizedStrings> = {
@@ -42,13 +37,6 @@ const sampleLocalizedStrings: Required<ScopeSelectorLocalizedStrings> = {
 };
 ```
 
-This is belt-and-suspenders on top of the English fallback: the fallback protects runtime consumers;
-`Required<…>` keeps the story fixtures honest and self-documenting.
-
-### Don't rely on lint to catch this
-
-The ESLint rules that sound relevant (`paranext/no-hardcoded-jsx-strings`,
-`paranext/require-localized-aria`) run **only** under `npm run lint:ai-strict` (`.eslintrc.ai.js`),
-not the CI `npm run lint`, and are disabled for `*.stories.tsx` / test files. They also target
-hardcoded JSX literals, not missing keys. Nothing in CI flags a raw-key leak — the fallback contract
-and `Required<…>` fixtures above are the actual guardrails.
+No CI lint rule catches a raw-key leak (see
+[react-patterns.md § Linting](../architecture/react-patterns.md)) — the English fallback and
+`Required<…>` fixtures are the actual guardrails.

--- a/.claude/rules/code-quality/localized-string-fallbacks.md
+++ b/.claude/rules/code-quality/localized-string-fallbacks.md
@@ -1,0 +1,54 @@
+## Localized-String Fallbacks in Library Components
+
+Components in `lib/platform-bible-react/` are process-agnostic: they never call
+`useLocalizedStrings`/PAPI. The consumer resolves strings and passes them in as an optional,
+`Partial`-typed `localizedStrings` prop. That means **any key can be absent at runtime** — a story,
+a test, or a real extension may pass a subset — so how a component resolves a missing key matters.
+
+### Fall back to English, never to the raw key
+
+When reading a localized string, fall back to a built-in **English default**, not to the key:
+
+```tsx
+// ✅ Missing key degrades to readable English
+const rangeText = localizedStrings?.['%webView_scope_selector_range%'] ?? 'Range';
+
+// ❌ Missing key leaks the raw token into the UI as literal text
+const rangeText = localizedStrings[key] ?? key;
+```
+
+A `strings[key] ?? key` resolver renders `%webView_scope_selector_range%` verbatim on screen the
+moment a caller omits that key. The English fallback is the contract documented in
+`.context/standards/Localization-Guide.md` §"Localizing Shared Library Components", and is what
+`BookChapterControl`, `CommentList`, and `CommentEditor` already do (e.g.
+`book-chapter-control.component.tsx`: `?? 'Select Chapter'`).
+
+**When adding or reviewing a library component:** if you see the shared helper
+`const localizeString = (strings, key) => strings[key] ?? key;`, treat it as a bug — replace each
+read with a per-key `?? 'English default'`. This protects real extension consumers, not just
+stories.
+
+### Type story fixtures as `Required<…>`
+
+The `…LocalizedStrings` type is `Partial` by design, so a story passing a subset is type-valid and
+TypeScript stays silent when a key is dropped. For stories of these components, type the fixture as
+`Required<XxxLocalizedStrings>` and share one object across all stories in the file, so the compiler
+fails when a key goes missing:
+
+```tsx
+const sampleLocalizedStrings: Required<ScopeSelectorLocalizedStrings> = {
+  '%webView_scope_selector_range%': 'Range',
+  // ...every key, or it won't compile
+};
+```
+
+This is belt-and-suspenders on top of the English fallback: the fallback protects runtime consumers;
+`Required<…>` keeps the story fixtures honest and self-documenting.
+
+### Don't rely on lint to catch this
+
+The ESLint rules that sound relevant (`paranext/no-hardcoded-jsx-strings`,
+`paranext/require-localized-aria`) run **only** under `npm run lint:ai-strict` (`.eslintrc.ai.js`),
+not the CI `npm run lint`, and are disabled for `*.stories.tsx` / test files. They also target
+hardcoded JSX literals, not missing keys. Nothing in CI flags a raw-key leak — the fallback contract
+and `Required<…>` fixtures above are the actual guardrails.

--- a/.context/standards/Localization-Guide.md
+++ b/.context/standards/Localization-Guide.md
@@ -177,7 +177,7 @@ The consuming extension resolves the keys with `useLocalizedStrings(STRING_KEYS)
 
 **Avoid:**
 - Calling `useLocalizedStrings` (or any `@papi/*` hook) inside a `lib/platform-bible-react/` component — it couples the process-agnostic library to PAPI.
-- Hardcoded English text in JSX. This is enforced by the ESLint rule **`paranext/no-hardcoded-jsx-strings`** (in `lib/eslint-plugin-paranext/`).
+- Hardcoded English text in JSX. The ESLint rule **`paranext/no-hardcoded-jsx-strings`** (in `lib/eslint-plugin-paranext/`) flags this, but only under `npm run lint:ai-strict` — it is **not** part of CI's `npm run lint`, so don't rely on it to catch hardcoded strings.
 - Ad-hoc `localizedStrings: Record<string, string>` props with no typed `STRING_KEYS` tuple — callers lose the typed key list and the partial-map guarantee.
 
 **Why:** the `STRING_KEYS` tuple gives consumers a typed, single-source key list for the `useLocalizedStrings` lookup; the `Partial<Record>` type lets stories pass a subset and trust the fallback; the English-fallback read keeps the component usable in isolation. Established precedent: `BookChapterControl`, `BookSelector`, `MarkerMenu`, `Inventory`, `ScopeSelector`, `CommentEditor`, `CommentList`, `FootnoteEditor`, `UndoRedoButtons`, `ErrorPopover`, `ErrorDump`. See `lib/platform-bible-react/src/components/advanced/book-chapter-control/book-chapter-control.types.ts` for the `STRING_KEYS` + `…LocalizedStrings` pair and `book-chapter-control.component.tsx` for the `?? 'English'` fallback reads.

--- a/.context/standards/Localization-Guide.md
+++ b/.context/standards/Localization-Guide.md
@@ -184,6 +184,12 @@ The consuming extension resolves the keys with `useLocalizedStrings(STRING_KEYS)
 
 > Note: a few components also accept a separate data map prop such as `localizedBookNames?: Map<…>` for localized book names — that is a distinct, data-shaped prop, not the string-key mechanism described here.
 
+> ⚠️ Several components in the precedent list above currently resolve with `strings[key] ?? key`
+> (raw-key fallback) rather than the `?? 'English'` fallback described here — a known deviation
+> tracked for cleanup. A raw-key fallback renders the localize key verbatim on screen when a key is
+> absent. New or edited library components MUST use the English fallback. See the agent rule
+> [`.claude/rules/code-quality/localized-string-fallbacks.md`](../../.claude/rules/code-quality/localized-string-fallbacks.md).
+
 ---
 
 ## Conventions


### PR DESCRIPTION
## Why

#2501 fixed a case where raw localization keys (e.g. `%webView_scope_selector_range%`) leaked into the UI: several `lib/platform-bible-react/` components resolve `localizedStrings[key] ?? key`, so a missing key falls back to the *raw key*. That class of bug will keep recurring unless the guardrail is written down somewhere agents and contributors actually read.

**This PR is my stab at that guardrail — a starting point, not a finished spec. I'd like a dev to take it from here** and shape it into whatever the team actually wants to enforce.

## What's here (a first cut)

- **New agent rule** `.claude/rules/code-quality/localized-string-fallbacks.md`: resolve a missing string to an English default (`?? 'Range'`), never `?? key`; and type story fixtures `Required<XxxLocalizedStrings>` so a dropped key fails to compile.
- **Corrected** `.claude/rules/architecture/react-patterns.md` — it listed the localization/ARIA `paranext/*` rules under "What's Enforced by Linting," but CI's `npm run lint` doesn't run them (they live in `.eslintrc.ai.js` / `lint:ai-strict` and are off for stories). Restructured as CI-enforced vs. advisory-only.
- **Fixed** the same overstatement in `.context/standards/Localization-Guide.md`.

Docs/rules only — no code paths change.

## Open questions for whoever picks this up

- **Right home / right mechanism?** Is a `.claude/rules` agent-rule the right vehicle, or should this be a real lint rule (e.g. `paranext/no-raw-key-fallback` flagging `strings[key] ?? key`)? Honest caveat: the `paranext/*` plugin rules aren't wired into CI lint today, so a new rule buys nothing until `.eslintrc.js` adopts the plugin's recommended config — a bigger, separate decision I didn't want to make unilaterally.
- **How far to push the `Required<>` story-fixture convention** — just these components, or library-wide?
- The **actual source fix** (converting the 6 remaining raw-key components to English fallbacks, and correcting the Localization-Guide precedent list) is tracked in **PT-4103** — this PR is only the guardrail/guidance, not the fix.

- **Governance / review path:** `.context/standards/Localization-Guide.md` is a broader-review file per `.claude/rules/where-to-add-guidance.md` — standards changes need broader dev sign-off, not just a quick rubber-stamp. Route that file's change to the right reviewer.
- **Pairs with PT-4103:** the guide's "established precedent" list still names raw-key components as English-fallback exemplars; the ⚠️ note this PR adds is a band-aid until **PT-4103** converts those components and corrects the list. Treat #2502 (the rule) and PT-4103 (the conformance) as a pair.

## Verification

Docs only. The ESLint-enforcement claims were checked against `.eslintrc.js`, `.eslintrc.ai.js`, `package.json`, `.github/workflows/test.yml`, and `lib/eslint-plugin-paranext/`.

## AI Involvement

AI-assisted (Claude Code): ran the retro that surfaced the guidance gap, drafted the rule, verified the config claims, and ran an adversarial review that tightened the wording. Reviewed before commit — but this is explicitly a draft for a human to own and finish.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2502)
<!-- Reviewable:end -->




Resume this session: `claude --resume 63aed4b7-897a-4465-80ad-b0aa34d4a0c2` (run from the `fix-localisation-in-storybook-scope-selector` worktree).
