### PR TITLE
PT-4109: Isolate each app's PAPI network via dynamic WebSocket port fallback

### DIFF
--- a/.context/standards/Architecture.md
+++ b/.context/standards/Architecture.md
@@ -22,10 +22,10 @@ Platform.Bible uses **JSON-RPC 2.0 over WebSocket** for inter-process communicat
 ```
 ┌─────────────────────────────────────────────────────────┐
 │                    Main Process (Electron)               │
-│  • WebSocket server on port 8876                         │
+│  • WebSocket server (default port 8876)                  │
 │  • Routes messages between processes                     │
 └────────────────┬────────────────────────────────────────┘
-                 │ JSON-RPC over WebSocket (port 8876)
+                 │ JSON-RPC over WebSocket (default port 8876)
     ┌────────────┼────────────┬───────────────────┐
     │            │            │                   │
 ┌───▼────────┐ ┌─▼──────────┐ ┌▼────────────────┐
@@ -33,6 +33,15 @@ Platform.Bible uses **JSON-RPC 2.0 over WebSocket** for inter-process communicat
 │ (React UI) │ │ Host       │ │ Provider        │
 └────────────┘ └────────────┘ └─────────────────┘
 ```
+
+Each app instance runs its own isolated PAPI network. Main prefers port 8876 (overridable with the
+`--webSocketPort` command-line argument or `PAPI_WEBSOCKET_PORT` environment variable) and falls
+back to an automatically assigned free port when it is in use — e.g. when another paranext-based
+app is running. Main advertises the actual port to the processes it spawns (renderer query
+parameter, extension host `--webSocketPort` argument, .NET `PAPI_WEBSOCKET_PORT` environment
+variable), so clients never attach to another app's network. In code, always resolve the port with
+`getWebSocketPort()` / `getWebSocketUrl()` from `src/shared/data/rpc.model.ts` instead of the
+`WEBSOCKET_PORT` constant.
 
 ### Communication Patterns
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ The application runs as four separate processes that communicate via JSON-RPC ov
 │  • Window management & app lifecycle                     │
 │  • Spawns and manages child processes                    │
 └────────────────┬────────────────────────────────────────┘
-                 │ JSON-RPC over WebSocket (port 8876)
+                 │ JSON-RPC over WebSocket (default port 8876; falls back to a free port when taken)
     ┌────────────┼────────────┬───────────────────┐
     │            │            │                   │
 ┌───▼────────┐ ┌─▼──────────┐ ┌▼────────────────┐

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,7 @@ npm run typecheck
 1. Changes to renderer or main TypeScript code hot-reload automatically
 2. Extension changes are watched and rebuilt automatically
 3. .NET changes require manual rebuild or running `npm run start:data` in a separate terminal
+   - A manually started data provider connects to the default port 8876. If your app instance fell back to another port (logged as `PAPI WebSocket server is listening on port N`), set `PAPI_WEBSOCKET_PORT=N` when running `npm run start:data` or it will attach to whichever app owns 8876
 4. Use VS Code "Debug Platform" compound configuration to debug both frontend and backend
 
 ## Coding Discipline

--- a/c-sharp-tests/PapiClientConnectionUriTests.cs
+++ b/c-sharp-tests/PapiClientConnectionUriTests.cs
@@ -1,0 +1,63 @@
+using Paranext.DataProvider;
+
+namespace TestParanextDataProvider;
+
+/// <summary>
+/// Tests that PapiClient connects to the port main advertises via the PAPI_WEBSOCKET_PORT
+/// environment variable so each paranext-based app talks to its own PAPI network (PT-4109)
+/// </summary>
+[TestFixture]
+// These tests mutate a process-wide environment variable, so they must not run in parallel with
+// each other or with other tests that might read it
+[NonParallelizable]
+public class PapiClientConnectionUriTests
+{
+    private string? _originalPortValue;
+
+    [SetUp]
+    public void Setup()
+    {
+        _originalPortValue = Environment.GetEnvironmentVariable(PapiClient.WEBSOCKET_PORT_ENV_VAR);
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable(PapiClient.WEBSOCKET_PORT_ENV_VAR, _originalPortValue);
+    }
+
+    [Test]
+    public void GetConnectionUri_NoEnvironmentVariable_UsesDefaultPort()
+    {
+        Environment.SetEnvironmentVariable(PapiClient.WEBSOCKET_PORT_ENV_VAR, null);
+
+        Uri uri = PapiClient.GetConnectionUri();
+
+        Assert.That(uri.Port, Is.EqualTo(PapiClient.DEFAULT_WEBSOCKET_PORT));
+    }
+
+    [Test]
+    public void GetConnectionUri_ValidPortAdvertised_UsesAdvertisedPort()
+    {
+        Environment.SetEnvironmentVariable(PapiClient.WEBSOCKET_PORT_ENV_VAR, "9123");
+
+        Uri uri = PapiClient.GetConnectionUri();
+
+        Assert.That(uri.Port, Is.EqualTo(9123));
+        Assert.That(uri.Host, Is.EqualTo("localhost"));
+        Assert.That(uri.Scheme, Is.EqualTo("ws"));
+    }
+
+    [TestCase("not-a-port")]
+    [TestCase("0")]
+    [TestCase("-1")]
+    [TestCase("70000")]
+    public void GetConnectionUri_InvalidPortAdvertised_UsesDefaultPort(string invalidPort)
+    {
+        Environment.SetEnvironmentVariable(PapiClient.WEBSOCKET_PORT_ENV_VAR, invalidPort);
+
+        Uri uri = PapiClient.GetConnectionUri();
+
+        Assert.That(uri.Port, Is.EqualTo(PapiClient.DEFAULT_WEBSOCKET_PORT));
+    }
+}

--- a/c-sharp/PapiClient.cs
+++ b/c-sharp/PapiClient.cs
@@ -14,7 +14,20 @@ internal class PapiClient : IDisposable
 {
     #region Delegates/Constants/Member variables
 
-    private static readonly Uri s_connectionUri = new("ws://localhost:8876");
+    /// <summary>
+    /// Default port for the PAPI WebSocket server. Must match WEBSOCKET_PORT in
+    /// src/shared/data/rpc.model.ts
+    /// </summary>
+    internal const int DEFAULT_WEBSOCKET_PORT = 8876;
+
+    /// <summary>
+    /// Environment variable main uses to advertise the port its PAPI WebSocket server is actually
+    /// listening on, which may differ from the default port when the default was in use by another
+    /// app (e.g. another paranext-based app running its own PAPI network)
+    /// </summary>
+    internal const string WEBSOCKET_PORT_ENV_VAR = "PAPI_WEBSOCKET_PORT";
+
+    private static readonly Uri s_connectionUri = GetConnectionUri();
 
     private readonly ClientWebSocket _webSocket = new();
     private readonly JsonRpc _jsonRpc;
@@ -26,6 +39,28 @@ internal class PapiClient : IDisposable
     private ISharedStore? _sharedStore = null;
 
     private bool _isDisposed = false;
+
+    /// <summary>
+    /// Determine the URI of this app's PAPI WebSocket server from the port advertised in
+    /// <see cref="WEBSOCKET_PORT_ENV_VAR"/>, falling back to <see cref="DEFAULT_WEBSOCKET_PORT"/>
+    /// when the variable is absent or invalid
+    /// </summary>
+    internal static Uri GetConnectionUri()
+    {
+        string? portValue = Environment.GetEnvironmentVariable(WEBSOCKET_PORT_ENV_VAR);
+        if (string.IsNullOrEmpty(portValue))
+            return new Uri($"ws://localhost:{DEFAULT_WEBSOCKET_PORT}");
+
+        if (!ushort.TryParse(portValue, out ushort port) || port == 0)
+        {
+            Console.WriteLine(
+                $"Ignoring invalid {WEBSOCKET_PORT_ENV_VAR} value \"{portValue}\". Using default port {DEFAULT_WEBSOCKET_PORT}"
+            );
+            return new Uri($"ws://localhost:{DEFAULT_WEBSOCKET_PORT}");
+        }
+
+        return new Uri($"ws://localhost:{port}");
+    }
 
     #endregion
 

--- a/c-sharp/PapiClient.cs
+++ b/c-sharp/PapiClient.cs
@@ -15,8 +15,8 @@ internal class PapiClient : IDisposable
     #region Delegates/Constants/Member variables
 
     /// <summary>
-    /// Default port for the PAPI WebSocket server. Must match WEBSOCKET_PORT in
-    /// src/shared/data/rpc.model.ts
+    /// Default port for the PAPI WebSocket server. Must match the value of the default port
+    /// constant WEBSOCKET_PORT in src/shared/data/rpc.model.ts
     /// </summary>
     internal const int DEFAULT_WEBSOCKET_PORT = 8876;
 
@@ -144,9 +144,9 @@ internal class PapiClient : IDisposable
     {
         ObjectDisposedException.ThrowIf(_isDisposed, this);
 
-        Console.WriteLine("PapiClient connecting");
+        Console.WriteLine($"PapiClient connecting to {s_connectionUri}");
         await _webSocket.ConnectAsync(s_connectionUri, _cancellationToken);
-        Console.WriteLine("PapiClient connected successfully");
+        Console.WriteLine($"PapiClient connected successfully to {s_connectionUri}");
 
         _jsonRpc.Disconnected += (object? _, JsonRpcDisconnectedEventArgs args) =>
         {

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -895,6 +895,15 @@ declare module 'shared/data/rpc.model' {
   /** Get the URL of this app's PAPI WebSocket server. See {@link getWebSocketPort} */
   export function getWebSocketUrl(): string;
   /**
+   * Determine whether a WebSocket URL might connect to a PAPI network so such connections can be
+   * blocked. Checks against this app's own PAPI port ({@link getWebSocketPort}) and also the default
+   * PAPI port ({@link WEBSOCKET_PORT}): when this app is running on a fallback port, a raw web socket
+   * to the default port could reach another paranext-based app's PAPI network.
+   *
+   * We are just filtering by port number on purpose to allow other connections to localhost.
+   */
+  export function isPotentialConnectionToPapiNetwork(url: string | URL): boolean;
+  /**
    * Whether an RPC object is setting up or has finished setting up its connection and is ready to
    * communicate on the network
    */
@@ -1776,10 +1785,10 @@ declare module 'node/utils/command-line.util' {
    *   1920x1080). Overrides the saved window state dimensions.
    * - Maximize - Command-line switch that specifies that the renderer should be maximized on launch.
    *   Only on main process
-   * - WebSocketPort - Command-line argument that specifies which port to use for the PAPI WebSocket.
-   *   On main, this is the preferred port for the WebSocket server (falls back to a free port if it
-   *   is in use). On the extension host, main passes this to advertise the port the server is
-   *   actually listening on
+   * - WebSocketPort - Command-line argument that specifies which port to use for the PAPI WebSocket. On
+   *   main, this is the preferred port for the WebSocket server (falls back to a free port if it is
+   *   in use). On the extension host, main passes this to advertise the port the server is actually
+   *   listening on
    */
   export enum CommandLineArgs {
     Extensions = 'extensions',
@@ -1852,6 +1861,43 @@ declare module 'node/utils/command-line.util' {
    */
   export function getCommandLineSwitch(argName: CommandLineArgs): boolean;
 }
+declare module 'shared/data/platform.data' {
+  /**
+   * Namespace to use for features like commands, settings, etc. on the PAPI that are provided by
+   * Platform.Bible core
+   */
+  export const PLATFORM_NAMESPACE = 'platform';
+  /** Query parameter passed to the renderer. Determines which log level to use */
+  export const LOG_LEVEL_QUERY_PARAMETER = 'logLevel';
+  /** Query parameter passed to the renderer. Determines if it should enable noisy dev mode */
+  export const DEV_MODE_QUERY_PARAMETER = 'noisyDevMode';
+  /**
+   * Query parameter passed to the renderer. Advertises the port this app's PAPI WebSocket server is
+   * listening on
+   */
+  export const WEBSOCKET_PORT_QUERY_PARAMETER = 'webSocketPort';
+  /**
+   * Parse a string that should contain a WebSocket port number
+   *
+   * Note: this lives here rather than in `rpc.model.ts` because it is used in each process's
+   * `global-this.model.ts`, which must not (transitively) import `logger.service` — the logger reads
+   * `globalThis` variables at module initialization, before `global-this.model.ts` sets them.
+   *
+   * @param portString String to parse, e.g. from a command-line argument, environment variable, or
+   *   query parameter
+   * @returns The port number, or `undefined` if the string is missing or is not a valid port number
+   *   (an integer from 1 to 65535)
+   */
+  export function parseWebSocketPort(portString: string | undefined): number | undefined;
+  /** ID of the default theme family for use in the application */
+  export const DEFAULT_THEME_FAMILY = '';
+  /** Type of the default theme for use in the application */
+  export const DEFAULT_THEME_TYPE = 'light';
+  /** Constants related to zoom factor of entire application */
+  export const DEFAULT_ZOOM_FACTOR = 1;
+  export const MIN_ZOOM_FACTOR = 0.5;
+  export const MAX_ZOOM_FACTOR = 3;
+}
 declare module 'main/services/web-socket-server.factory' {
   import { WebSocketServer } from 'ws';
   /**
@@ -1859,15 +1905,17 @@ declare module 'main/services/web-socket-server.factory' {
    * The {@link CommandLineArgs.WebSocketPort} command-line argument takes precedence over this.
    */
   export const WEBSOCKET_PORT_ENV_VAR = 'PAPI_WEBSOCKET_PORT';
-  interface PapiWebSocketServerInfo {
+  /** The WebSocketServer hosting this app's PAPI network and where it can be reached */
+  export interface PapiWebSocketServerInfo {
+    /** The listening WebSocket server */
     webSocketServer: WebSocketServer;
     /** Port the WebSocket server is actually listening on */
     port: number;
   }
   /**
-   * Determine which port this app should try first for its PAPI WebSocket server: the
-   * `--webSocketPort` command-line argument, then the {@link WEBSOCKET_PORT_ENV_VAR} environment
-   * variable, then {@link WEBSOCKET_PORT}
+   * Determine which port this app should try first for its PAPI WebSocket server: the first valid
+   * port among the `--webSocketPort` command-line argument, then the {@link WEBSOCKET_PORT_ENV_VAR}
+   * environment variable, then {@link WEBSOCKET_PORT}
    */
   export function getPreferredWebSocketPort(): number;
   /**
@@ -7892,30 +7940,6 @@ declare module 'renderer/hooks/papi-hooks/use-data.hook' {
    */
   export const useData: UseDataHook;
   export default useData;
-}
-declare module 'shared/data/platform.data' {
-  /**
-   * Namespace to use for features like commands, settings, etc. on the PAPI that are provided by
-   * Platform.Bible core
-   */
-  export const PLATFORM_NAMESPACE = 'platform';
-  /** Query parameter passed to the renderer. Determines which log level to use */
-  export const LOG_LEVEL_QUERY_PARAMETER = 'logLevel';
-  /** Query parameter passed to the renderer. Determines if it should enable noisy dev mode */
-  export const DEV_MODE_QUERY_PARAMETER = 'noisyDevMode';
-  /**
-   * Query parameter passed to the renderer. Advertises the port this app's PAPI WebSocket server is
-   * listening on
-   */
-  export const WEBSOCKET_PORT_QUERY_PARAMETER = 'webSocketPort';
-  /** ID of the default theme family for use in the application */
-  export const DEFAULT_THEME_FAMILY = '';
-  /** Type of the default theme for use in the application */
-  export const DEFAULT_THEME_TYPE = 'light';
-  /** Constants related to zoom factor of entire application */
-  export const DEFAULT_ZOOM_FACTOR = 1;
-  export const MIN_ZOOM_FACTOR = 0.5;
-  export const MAX_ZOOM_FACTOR = 3;
 }
 declare module 'shared/log-error.model' {
   /** Error that force logs the error message before throwing. Useful for debugging in some situations. */

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -790,6 +790,17 @@ declare module 'shared/global-this.model' {
     var updateWebViewDefinition: UpdateWebViewDefinition;
     /** Indicates whether test code meant just for developers to see should be run */
     var isNoisyDevModeEnabled: boolean;
+    /**
+     * Port this app's PAPI WebSocket server is listening on. Each app instance runs its own isolated
+     * PAPI network, and the port may differ from the default when the default port is already in use
+     * (e.g. another paranext-based app is running). `undefined` means the port is not (yet) known,
+     * and consumers should fall back to the default port.
+     *
+     * - Main: set when the WebSocket server starts listening
+     * - Renderer: set from the query parameter provided by main
+     * - Extension host: set from the command-line argument provided by main
+     */
+    var webSocketPort: number | undefined;
   }
   /** Type of Platform.Bible process */
   export enum ProcessType {
@@ -865,8 +876,24 @@ declare module 'shared/data/rpc.model' {
     JSONRPCResponse,
     JSONRPCSuccessResponse,
   } from 'json-rpc-2.0';
-  /** Port to use for the WebSocket */
+  /**
+   * Default port to use for the WebSocket. The port actually used may differ - see
+   * {@link getWebSocketPort}
+   */
   export const WEBSOCKET_PORT = 8876;
+  /**
+   * Get the port this app's PAPI WebSocket network is using.
+   *
+   * Each app instance runs its own isolated PAPI network. The main process starts the WebSocket
+   * server on {@link WEBSOCKET_PORT} (or the port specified by the `--webSocketPort` command-line
+   * argument or `PAPI_WEBSOCKET_PORT` environment variable) and falls back to an automatically
+   * assigned free port when that port is already in use, e.g. when another paranext-based app is
+   * running. Main advertises the port it is actually listening on to the processes it spawns, and
+   * each process records it in `globalThis.webSocketPort`.
+   */
+  export function getWebSocketPort(): number;
+  /** Get the URL of this app's PAPI WebSocket server. See {@link getWebSocketPort} */
+  export function getWebSocketUrl(): string;
   /**
    * Whether an RPC object is setting up or has finished setting up its connection and is ready to
    * communicate on the network
@@ -1718,6 +1745,142 @@ declare module 'client/services/rpc-client' {
     private onMessageReceivedByWebSocket;
   }
   export default RpcClient;
+}
+declare module 'node/utils/command-line.util' {
+  /** All command line arguments mapped from argument type to array of aliases for the argument */
+  type CommandLineArgumentAliases = {
+    [argument in CommandLineArgs]: string[];
+  };
+  /**
+   * Command-line arguments
+   *
+   * - Extensions - Command-line argument that specifies extra individual extension folders
+   *
+   *   - Note: when running in Snap on Linux, if an unzipped extension folder is provided this way, that
+   *       extension will not be able to launch separate processes.
+   * - ExtensionsDir - Command-line argument that specifies extra extension directories in which to
+   *   check all contained folders for extensions
+   *
+   *   - Note: when running in Snap on Linux, if unzipped extension folders are provided this way, those
+   *       extensions will not be able to launch separate processes.
+   * - LogLevel - Command-line argument that specifies log level to use Options: 'error' | 'warn' |
+   *   'info' | 'verbose' | 'debug'
+   * - ResourcesPath - Command-line argument that specifies the path to the resources folder
+   * - Packaged - Command-line switch that specifies if the application is packaged. Only on
+   *   extension-host
+   * - Portable - Command-line switch that specifies if the application is a windows portable app. Only
+   *   on extension-host
+   * - DidRestart - Command-line switch that specifies that the extension host was restarted and should
+   *   act accordingly, e.g. it should announce that the extensions reloaded. Only on extension-host
+   * - WindowSize - Command-line argument that specifies the initial window size as WIDTHxHEIGHT (e.g.
+   *   1920x1080). Overrides the saved window state dimensions.
+   * - Maximize - Command-line switch that specifies that the renderer should be maximized on launch.
+   *   Only on main process
+   * - WebSocketPort - Command-line argument that specifies which port to use for the PAPI WebSocket.
+   *   On main, this is the preferred port for the WebSocket server (falls back to a free port if it
+   *   is in use). On the extension host, main passes this to advertise the port the server is
+   *   actually listening on
+   */
+  export enum CommandLineArgs {
+    Extensions = 'extensions',
+    ExtensionsDir = 'extensions_dir',
+    LogLevel = 'log_level',
+    ResourcesPath = 'resources_path',
+    Packaged = 'packaged',
+    Portable = 'portable',
+    DidRestart = 'didRestart',
+    WindowSize = 'window_size',
+    Maximize = 'maximize',
+    WebSocketPort = 'web_socket_port',
+  }
+  /**
+   * Aliases for each command line argument mapped from argument type to an array of aliases for that
+   * argument type
+   */
+  export const commandLineArgumentsAliases: CommandLineArgumentAliases;
+  /** Get the index of the next command-line argument after the startIndex */
+  export function findNextCommandLineArgumentIndex(currentArgIndex: number): number;
+  /**
+   * Get a command-line argument's group of arguments. If no arguments are in its group, return
+   * nothing
+   *
+   * @param argName Name(s) of the command-line argument to search for
+   * @param shouldIncludeArgName Whether to include `argName` at the start of the returned array
+   * @returns Array of strings of the command-line args in this command-line argument group
+   *
+   *   Ex: '--things ben chuck jerry'
+   *
+   *   - `getCommandLineArgumentsGroup('--things')` returns `['ben', 'chuck', 'jerry']`
+   *   - `getCommandLineArgumentsGroup('--things', true)` returns `['--things', 'ben', 'chuck', 'jerry']`
+   *
+   *   Ex: '--things --stuff ben chuck jerry'
+   *
+   *   - `getCommandLineArgumentsGroup('--things')` returns `[]`
+   *   - `getCommandLineArgumentsGroup('--things', true)` returns `['--things']`
+   *
+   *   Ex: '--stuff ben chuck jerry'
+   *
+   *   - `getCommandLineArgumentsGroup('--things')` returns `[]`
+   *   - `getCommandLineArgumentsGroup('--things', true)` returns `[]`
+   */
+  export function getCommandLineArgumentsGroup(
+    argName: CommandLineArgs,
+    shouldIncludeArgName?: boolean,
+  ): string[];
+  /**
+   * Get a command-line argument's argument. If the argument is not present, return `undefined`
+   *
+   * @param argName Name and aliases of the command-line argument to search for
+   * @returns String of the command-line arg provided
+   *
+   *   Ex: '--thing ben'
+   *
+   *   - `getCommandLineArgument('--thing')` returns `'ben'`
+   */
+  export function getCommandLineArgument(argName: CommandLineArgs): string | undefined;
+  /**
+   * Determine whether a command-line argument name is present
+   *
+   * (a switch is a command-line argument without a value - just a boolean)
+   *
+   * @param argName Name of the switch to look for
+   * @returns True if present, false otherwise
+   *
+   *   Ex: '--thing --stuff bologna'
+   *
+   *   - `getCommandLineSwitch('--thing')` returns `true`
+   */
+  export function getCommandLineSwitch(argName: CommandLineArgs): boolean;
+}
+declare module 'main/services/web-socket-server.factory' {
+  import { WebSocketServer } from 'ws';
+  /**
+   * Environment variable that specifies which port to prefer for this app's PAPI WebSocket server.
+   * The {@link CommandLineArgs.WebSocketPort} command-line argument takes precedence over this.
+   */
+  export const WEBSOCKET_PORT_ENV_VAR = 'PAPI_WEBSOCKET_PORT';
+  interface PapiWebSocketServerInfo {
+    webSocketServer: WebSocketServer;
+    /** Port the WebSocket server is actually listening on */
+    port: number;
+  }
+  /**
+   * Determine which port this app should try first for its PAPI WebSocket server: the
+   * `--webSocketPort` command-line argument, then the {@link WEBSOCKET_PORT_ENV_VAR} environment
+   * variable, then {@link WEBSOCKET_PORT}
+   */
+  export function getPreferredWebSocketPort(): number;
+  /**
+   * Create the WebSocketServer that hosts this app's PAPI network, listening on `preferredPort` if it
+   * is available or an automatically assigned free port otherwise
+   *
+   * @param preferredPort Port to try first. Defaults to {@link getPreferredWebSocketPort}
+   * @returns The listening server and the port it is actually listening on
+   * @throws If a server could not be started even on an automatically assigned port
+   */
+  export function createPapiWebSocketServer(
+    preferredPort?: number,
+  ): Promise<PapiWebSocketServerInfo>;
 }
 declare module 'main/services/rpc-server' {
   import { JSONRPCResponse } from 'json-rpc-2.0';
@@ -7740,6 +7903,11 @@ declare module 'shared/data/platform.data' {
   export const LOG_LEVEL_QUERY_PARAMETER = 'logLevel';
   /** Query parameter passed to the renderer. Determines if it should enable noisy dev mode */
   export const DEV_MODE_QUERY_PARAMETER = 'noisyDevMode';
+  /**
+   * Query parameter passed to the renderer. Advertises the port this app's PAPI WebSocket server is
+   * listening on
+   */
+  export const WEBSOCKET_PORT_QUERY_PARAMETER = 'webSocketPort';
   /** ID of the default theme family for use in the application */
   export const DEFAULT_THEME_FAMILY = '';
   /** Type of the default theme for use in the application */

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "platform-bible",
+  "displayName": "Platform.Bible",
   "version": "0.6.0-alpha.0",
   "marketingVersion": "",
   "marketingVersionMoniker": "",

--- a/src/client/services/rpc-client.ts
+++ b/src/client/services/rpc-client.ts
@@ -15,6 +15,7 @@ import {
   createRequest,
   deserializeMessage,
   EventHandler,
+  getWebSocketUrl,
   InternalRequestHandler,
   REGISTER_EVENT,
   REGISTER_METHOD,
@@ -22,7 +23,6 @@ import {
   sendPayloadToWebSocket,
   UNREGISTER_EVENT,
   UNREGISTER_METHOD,
-  WEBSOCKET_PORT,
 } from '@shared/data/rpc.model';
 import { createWebSocket } from '@client/services/web-socket.factory';
 import { AsyncVariable, getErrorMessage, Mutex, MutexMap } from 'platform-bible-utils';
@@ -93,7 +93,7 @@ export class RpcClient implements IRpcMethodRegistrar {
 
       try {
         this.connectionStatus = ConnectionStatus.Connecting;
-        this.ws = await createWebSocket(`ws://localhost:${WEBSOCKET_PORT}`);
+        this.ws = await createWebSocket(getWebSocketUrl());
         this.addEventListenersToWebSocket();
 
         // Wait for the socket to finish connecting before continuing (0 means connecting)

--- a/src/extension-host/global-this.model.ts
+++ b/src/extension-host/global-this.model.ts
@@ -18,6 +18,10 @@ const logLevel =
   // Assert the extracted type.
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   (getCommandLineArgument(CommandLineArgs.LogLevel) as LogLevel) ?? (isPackaged ? 'error' : 'info');
+// Main advertises the port its PAPI WebSocket server is actually listening on, which may differ
+// from the default port when the default was in use by another app. Leave undefined if absent or
+// invalid so consumers fall back to the default port
+const webSocketPort = parseInt(getCommandLineArgument(CommandLineArgs.WebSocketPort) ?? '', 10);
 globalThis.isNoisyDevModeEnabled = isNoisyDevModeEnvVariableSet();
 
 // #endregion
@@ -28,6 +32,7 @@ globalThis.processType = ProcessType.ExtensionHost;
 globalThis.isPackaged = isPackaged;
 globalThis.resourcesPath = resourcesPath;
 globalThis.logLevel = logLevel;
+globalThis.webSocketPort = Number.isNaN(webSocketPort) ? undefined : webSocketPort;
 
 // #endregion
 

--- a/src/extension-host/global-this.model.ts
+++ b/src/extension-host/global-this.model.ts
@@ -8,6 +8,7 @@ import {
   getCommandLineSwitch,
 } from '@node/utils/command-line.util';
 import { ProcessType } from '@shared/global-this.model';
+import { parseWebSocketPort } from '@shared/data/platform.data';
 import { isNoisyDevModeEnvVariableSet } from '@node/utils/util';
 
 // #region command-line arguments
@@ -21,7 +22,7 @@ const logLevel =
 // Main advertises the port its PAPI WebSocket server is actually listening on, which may differ
 // from the default port when the default was in use by another app. Leave undefined if absent or
 // invalid so consumers fall back to the default port
-const webSocketPort = parseInt(getCommandLineArgument(CommandLineArgs.WebSocketPort) ?? '', 10);
+const webSocketPort = parseWebSocketPort(getCommandLineArgument(CommandLineArgs.WebSocketPort));
 globalThis.isNoisyDevModeEnabled = isNoisyDevModeEnvVariableSet();
 
 // #endregion
@@ -32,7 +33,7 @@ globalThis.processType = ProcessType.ExtensionHost;
 globalThis.isPackaged = isPackaged;
 globalThis.resourcesPath = resourcesPath;
 globalThis.logLevel = logLevel;
-globalThis.webSocketPort = Number.isNaN(webSocketPort) ? undefined : webSocketPort;
+globalThis.webSocketPort = webSocketPort;
 
 // #endregion
 

--- a/src/extension-host/services/__tests__/local-oauth.service.test.ts
+++ b/src/extension-host/services/__tests__/local-oauth.service.test.ts
@@ -1,0 +1,79 @@
+import { createServer, Server } from 'http';
+import { AddressInfo } from 'net';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '@shared/services/logger.service';
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+vi.mock('@shared/services/network.service', () => ({
+  request: vi.fn(),
+}));
+
+function listenOnFreePort(): Promise<Server> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once('error', reject);
+    server.listen(0, 'localhost', () => resolve(server));
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+/** Import a fresh instance of the service module configured to use the given port */
+async function importLocalOAuthService(port: number) {
+  vi.resetModules();
+  vi.stubEnv('LOCAL_OAUTH_SERVER_PORT', `${port}`);
+  return import('@extension-host/services/local-oauth.service');
+}
+
+describe('startLocalOAuthServer', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  /**
+   * The local OAuth server always uses its one fixed (Auth0-registered) port, so when two dev
+   * instances run at once (supported since PT-4109), the second instance cannot bind it. That must
+   * degrade gracefully — extension host startup awaits this service, and a rejection would abort
+   * extension loading entirely.
+   */
+  it('resolves with a warning instead of rejecting when the port is already in use', async () => {
+    globalThis.isPackaged = false;
+    const occupyingServer = await listenOnFreePort();
+    // Assert the type: address() returns AddressInfo for TCP listeners
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    const occupiedPort = (occupyingServer.address() as AddressInfo).port;
+
+    const { startLocalOAuthServer, stopLocalOAuthServer } =
+      await importLocalOAuthService(occupiedPort);
+    try {
+      await expect(startLocalOAuthServer()).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('OAuth'));
+    } finally {
+      stopLocalOAuthServer();
+      await closeServer(occupyingServer);
+    }
+  });
+
+  it('listens successfully when the port is free', async () => {
+    globalThis.isPackaged = false;
+    const probeServer = await listenOnFreePort();
+    // Assert the type: address() returns AddressInfo for TCP listeners
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    const freePort = (probeServer.address() as AddressInfo).port;
+    await closeServer(probeServer);
+
+    const { startLocalOAuthServer, stopLocalOAuthServer } = await importLocalOAuthService(freePort);
+    try {
+      await expect(startLocalOAuthServer()).resolves.toBeUndefined();
+      expect(logger.info).toHaveBeenCalledWith(expect.stringContaining(`${freePort}`));
+    } finally {
+      stopLocalOAuthServer();
+    }
+  });
+});

--- a/src/extension-host/services/local-oauth.service.ts
+++ b/src/extension-host/services/local-oauth.service.ts
@@ -17,7 +17,7 @@ export async function startLocalOAuthServer(): Promise<void> {
   // We only need this for development and testing purposes. Don't run it in production.
   if (globalThis.isPackaged) return;
 
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     localServer = createServer(async (req, res) => {
       if (!req.url) {
         res.writeHead(StatusCodes.BAD_REQUEST, { 'Content-Type': 'text/plain' });
@@ -61,8 +61,16 @@ export async function startLocalOAuthServer(): Promise<void> {
     });
 
     localServer.on('error', (err) => {
-      logger.error(`Local OAuth server error: ${getErrorMessage(err)}`);
-      reject(err);
+      // Don't reject: extension host startup awaits this dev-only service, and a rejection would
+      // abort extension loading entirely. The port cannot be moved automatically because the OAuth
+      // provider only redirects to the registered port, so just run without OAuth callbacks. This
+      // is expected when another dev instance is already running (supported since PT-4109) - the
+      // instance that owns the port receives the callbacks.
+      logger.warn(
+        `Local OAuth server could not start, so this instance will not receive OAuth callbacks: ${getErrorMessage(err)}. If another dev instance is running, it owns port ${localServerPort}. You can override the port with the LOCAL_OAUTH_SERVER_PORT environment variable if your OAuth configuration allows it.`,
+      );
+      stopLocalOAuthServer();
+      resolve();
     });
   });
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6,7 +6,15 @@
  * using webpack. This gives us some performance wins.
  */
 
-import { app, BrowserWindow, ipcMain, RenderProcessGoneDetails, session, shell } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  RenderProcessGoneDetails,
+  session,
+  shell,
+} from 'electron';
 import os from 'os';
 import path from 'path';
 // Removed until we have a release. See https://github.com/paranext/paranext-core/issues/83
@@ -43,8 +51,9 @@ import {
   LOG_LEVEL_QUERY_PARAMETER,
   MAX_ZOOM_FACTOR,
   MIN_ZOOM_FACTOR,
+  WEBSOCKET_PORT_QUERY_PARAMETER,
 } from '@shared/data/platform.data';
-import { GET_METHODS } from '@shared/data/rpc.model';
+import { GET_METHODS, getWebSocketPort, getWebSocketUrl } from '@shared/data/rpc.model';
 import { PROJECT_INTERFACE_PLATFORM_BASE } from '@shared/models/project-data-provider.model';
 import * as commandService from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
@@ -196,7 +205,17 @@ async function openExternal(url: string) {
 
 async function main() {
   // The network service has to start first, and it uses the shared store after initialization
-  await networkService.initialize();
+  try {
+    await networkService.initialize();
+  } catch (e) {
+    // Without its own PAPI network, none of this app's services or UI can work, so fail loudly
+    // instead of presenting a half-initialized app (PT-4109)
+    const errorMessage = `The PAPI WebSocket server could not start, so ${APP_NAME} cannot run: ${getErrorMessage(e)}`;
+    logger.error(errorMessage);
+    dialog.showErrorBox(`${APP_NAME} cannot start`, errorMessage);
+    app.exit(1);
+    return;
+  }
   await initializeSharedStoreService(networkService);
 
   // The network object status service relies on seeing everything else start up later
@@ -605,6 +624,9 @@ async function main() {
     // Built URL search parameters for use in `src/renderer/global-this.model.ts`
     const searchParamsObject: Record<string, string> = {
       [LOG_LEVEL_QUERY_PARAMETER]: globalThis.logLevel,
+      // Advertise the PAPI WebSocket server's port so the renderer connects to this app's own
+      // network even when the default port was in use by another app
+      [WEBSOCKET_PORT_QUERY_PARAMETER]: `${getWebSocketPort()}`,
     };
 
     if (globalThis.isNoisyDevModeEnabled) searchParamsObject[DEV_MODE_QUERY_PARAMETER] = '';
@@ -933,7 +955,7 @@ async function main() {
     },
   );
 
-  const liveDocsUrl = `https://playground.open-rpc.org/?transport=websocket&schemaUrl=${encodeURIComponent('ws://localhost:8876\n')}&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:transports]=false&uiSchema[appBar][ui:darkMode]=true&uiSchema[appBar][ui:title]=PAPI`;
+  const liveDocsUrl = `https://playground.open-rpc.org/?transport=websocket&schemaUrl=${encodeURIComponent(`${getWebSocketUrl()}\n`)}&uiSchema[appBar][ui:splitView]=false&uiSchema[appBar][ui:input]=false&uiSchema[appBar][ui:examplesDropdown]=false&uiSchema[appBar][ui:transports]=false&uiSchema[appBar][ui:darkMode]=true&uiSchema[appBar][ui:title]=PAPI`;
   commandService.registerCommand(
     'platform.openDeveloperDocumentationUrl',
     async () => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -24,6 +24,7 @@ import '@node/utils/log-archiver.util';
 import { subscribeCurrentMacosMenubar } from '@main/platform-macos-menubar.util';
 import chroma from 'chroma-js';
 import {
+  APP_DISPLAY_NAME,
   APP_NAME,
   APP_URI_SCHEME,
   APP_VERSION,
@@ -209,10 +210,16 @@ async function main() {
     await networkService.initialize();
   } catch (e) {
     // Without its own PAPI network, none of this app's services or UI can work, so fail loudly
-    // instead of presenting a half-initialized app (PT-4109)
-    const errorMessage = `The PAPI WebSocket server could not start, so ${APP_NAME} cannot run: ${getErrorMessage(e)}`;
-    logger.error(errorMessage);
-    dialog.showErrorBox(`${APP_NAME} cannot start`, errorMessage);
+    // instead of presenting a half-initialized app (PT-4109). These strings are intentionally not
+    // localized: the localization service runs over the very PAPI network that just failed to
+    // start, so it is provably unavailable here
+    logger.error(
+      `The PAPI WebSocket server could not start, so ${APP_NAME} cannot run: ${getErrorMessage(e)}`,
+    );
+    dialog.showErrorBox(
+      `${APP_DISPLAY_NAME} cannot start`,
+      `${APP_DISPLAY_NAME} could not set up the internal services it needs to run. Technical details: ${getErrorMessage(e)}`,
+    );
     app.exit(1);
     return;
   }

--- a/src/main/services/__tests__/web-socket-server.factory.test.ts
+++ b/src/main/services/__tests__/web-socket-server.factory.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { WebSocketServer } from 'ws';
 import {
   createPapiWebSocketServer,
@@ -70,8 +70,18 @@ describe('createPapiWebSocketServer', () => {
 });
 
 describe('getPreferredWebSocketPort', () => {
+  let originalPortEnv: string | undefined;
+
+  beforeEach(() => {
+    // The machine running the tests may have the variable exported; make sure it does not leak in
+    originalPortEnv = process.env[WEBSOCKET_PORT_ENV_VAR];
+    delete process.env[WEBSOCKET_PORT_ENV_VAR];
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
+    if (originalPortEnv === undefined) delete process.env[WEBSOCKET_PORT_ENV_VAR];
+    else process.env[WEBSOCKET_PORT_ENV_VAR] = originalPortEnv;
   });
 
   it('returns the default port when no override is specified', () => {
@@ -98,6 +108,21 @@ describe('getPreferredWebSocketPort', () => {
     ];
     try {
       expect(getPreferredWebSocketPort()).toBe(9456);
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+
+  it('uses a valid environment variable when the command-line argument is invalid', () => {
+    vi.stubEnv(WEBSOCKET_PORT_ENV_VAR, '9123');
+    const originalArgv = process.argv;
+    process.argv = [
+      ...originalArgv,
+      commandLineArgumentsAliases[CommandLineArgs.WebSocketPort][0],
+      'not-a-port',
+    ];
+    try {
+      expect(getPreferredWebSocketPort()).toBe(9123);
     } finally {
       process.argv = originalArgv;
     }

--- a/src/main/services/__tests__/web-socket-server.factory.test.ts
+++ b/src/main/services/__tests__/web-socket-server.factory.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { WebSocketServer } from 'ws';
+import {
+  createPapiWebSocketServer,
+  getPreferredWebSocketPort,
+  WEBSOCKET_PORT_ENV_VAR,
+} from '@main/services/web-socket-server.factory';
+import { WEBSOCKET_PORT } from '@shared/data/rpc.model';
+import { CommandLineArgs, commandLineArgumentsAliases } from '@node/utils/command-line.util';
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+/** Start a WebSocketServer directly (no fallback logic) for test setup purposes */
+function listenOnPort(port: number): Promise<WebSocketServer> {
+  return new Promise((resolve, reject) => {
+    const webSocketServer = new WebSocketServer({ port });
+    webSocketServer.once('listening', () => resolve(webSocketServer));
+    webSocketServer.once('error', reject);
+  });
+}
+
+function getListeningPort(webSocketServer: WebSocketServer): number {
+  const address = webSocketServer.address();
+  if (typeof address === 'object' && address) return address.port;
+  throw new Error('Test WebSocketServer is not listening on a TCP port');
+}
+
+function closeServer(webSocketServer: WebSocketServer): Promise<void> {
+  return new Promise((resolve) => {
+    webSocketServer.close(() => resolve());
+  });
+}
+
+describe('createPapiWebSocketServer', () => {
+  it('listens on the preferred port when it is available', async () => {
+    // Find a port that is currently free by binding to an OS-assigned port and releasing it
+    const probeServer = await listenOnPort(0);
+    const freePort = getListeningPort(probeServer);
+    await closeServer(probeServer);
+
+    const { webSocketServer, port } = await createPapiWebSocketServer(freePort);
+    try {
+      expect(port).toBe(freePort);
+      expect(getListeningPort(webSocketServer)).toBe(freePort);
+    } finally {
+      await closeServer(webSocketServer);
+    }
+  });
+
+  it('falls back to an automatically assigned port when the preferred port is in use', async () => {
+    // Occupy a port to simulate another paranext-based app owning the preferred port
+    const occupyingServer = await listenOnPort(0);
+    const occupiedPort = getListeningPort(occupyingServer);
+
+    try {
+      const { webSocketServer, port } = await createPapiWebSocketServer(occupiedPort);
+      try {
+        expect(port).not.toBe(occupiedPort);
+        expect(port).toBeGreaterThan(0);
+        expect(getListeningPort(webSocketServer)).toBe(port);
+      } finally {
+        await closeServer(webSocketServer);
+      }
+    } finally {
+      await closeServer(occupyingServer);
+    }
+  });
+});
+
+describe('getPreferredWebSocketPort', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('returns the default port when no override is specified', () => {
+    expect(getPreferredWebSocketPort()).toBe(WEBSOCKET_PORT);
+  });
+
+  it('returns the port from the environment variable when set', () => {
+    vi.stubEnv(WEBSOCKET_PORT_ENV_VAR, '9123');
+    expect(getPreferredWebSocketPort()).toBe(9123);
+  });
+
+  it('returns the default port when the environment variable is not a valid port', () => {
+    vi.stubEnv(WEBSOCKET_PORT_ENV_VAR, 'not-a-port');
+    expect(getPreferredWebSocketPort()).toBe(WEBSOCKET_PORT);
+  });
+
+  it('prefers the command-line argument over the environment variable', () => {
+    vi.stubEnv(WEBSOCKET_PORT_ENV_VAR, '9123');
+    const originalArgv = process.argv;
+    process.argv = [
+      ...originalArgv,
+      commandLineArgumentsAliases[CommandLineArgs.WebSocketPort][0],
+      '9456',
+    ];
+    try {
+      expect(getPreferredWebSocketPort()).toBe(9456);
+    } finally {
+      process.argv = originalArgv;
+    }
+  });
+});

--- a/src/main/services/app.service-host.ts
+++ b/src/main/services/app.service-host.ts
@@ -11,6 +11,13 @@ import buildInfo from '../../../release/app/buildInfo.json';
 /** Same as {@link AppInfo.name} */
 export const APP_NAME: string = packageInfo.name;
 
+/**
+ * User-facing display name of this app, e.g. `Platform.Bible`. Not localized; intended for the rare
+ * user-facing surfaces where the localization service is unavailable (it runs over the PAPI
+ * network, so it cannot serve strings before the network is up)
+ */
+export const APP_DISPLAY_NAME: string = packageInfo.displayName;
+
 // Construct the app version according to the SemVer specification (pre-release ID already included)
 const { build } = buildInfo;
 /** Same as {@link AppInfo.version} */

--- a/src/main/services/dotnet-data-provider.service.ts
+++ b/src/main/services/dotnet-data-provider.service.ts
@@ -1,5 +1,7 @@
 import { ChildProcessWithoutNullStreams, SpawnOptionsWithoutStdio, spawn } from 'child_process';
 import path from 'path';
+import { getWebSocketPort } from '@shared/data/rpc.model';
+import { WEBSOCKET_PORT_ENV_VAR } from '@main/services/web-socket-server.factory';
 import { logger } from '@shared/services/logger.service';
 import { waitForDuration } from 'platform-bible-utils';
 import { formatLog } from '@shared/utils/logger.utils';
@@ -113,6 +115,13 @@ function startDotnetDataProvider() {
     }
     options = { cwd: dotnetPath };
   }
+
+  // Advertise the PAPI WebSocket server's port so the data provider connects to this app's own
+  // network even when the default port was in use by another app
+  options = {
+    ...options,
+    env: { ...process.env, [WEBSOCKET_PORT_ENV_VAR]: `${getWebSocketPort()}` },
+  };
 
   dotnet = spawn(command, args, options);
 

--- a/src/main/services/extension-host.service.ts
+++ b/src/main/services/extension-host.service.ts
@@ -5,6 +5,7 @@ import {
   CommandLineArgs,
   commandLineArgumentsAliases,
 } from '@node/utils/command-line.util';
+import { getWebSocketPort } from '@shared/data/rpc.model';
 import { logger } from '@shared/services/logger.service';
 import { AsyncVariable, debounce, waitForDuration } from 'platform-bible-utils';
 import { ChildProcess, ChildProcessByStdio, fork } from 'child_process';
@@ -187,6 +188,10 @@ async function startExtensionHost(maxWaitTimeInMS: number, isRestarting = false)
     globalThis.resourcesPath,
     commandLineArgumentsAliases[CommandLineArgs.LogLevel][0],
     globalThis.logLevel,
+    // Advertise the PAPI WebSocket server's port so the extension host connects to this app's own
+    // network even when the default port was in use by another app
+    commandLineArgumentsAliases[CommandLineArgs.WebSocketPort][0],
+    `${getWebSocketPort()}`,
     ...getCommandLineArgumentsToForward(),
   ];
   if (isRestarting) sharedArgs.push(commandLineArgumentsAliases[CommandLineArgs.DidRestart][0]);

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -12,7 +12,6 @@ import {
   requestWithRetry,
   UNREGISTER_EVENT,
   UNREGISTER_METHOD,
-  WEBSOCKET_PORT,
 } from '@shared/data/rpc.model';
 import { IRpcMethodRegistrar, RegisteredRpcMethodDetails } from '@shared/models/rpc.interface';
 import {
@@ -31,6 +30,7 @@ import { WebSocketServer } from 'ws';
 import { logger } from '@shared/services/logger.service';
 import { JSONRPCErrorCode, JSONRPCResponse } from 'json-rpc-2.0';
 import { bindClassMethods, SerializedRequestType } from '@shared/utils/util';
+import { createPapiWebSocketServer } from '@main/services/web-socket-server.factory';
 import { RpcServer } from './rpc-server';
 // RpcEventRegistry was extracted to its own file to satisfy max-classes-per-file
 import { RpcEventRegistry } from './rpc-event-registry';
@@ -81,7 +81,7 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
   }
 
   connect(localEventHandler: EventHandler): Promise<boolean> {
-    return this.connectionMutex.runExclusive(() => {
+    return this.connectionMutex.runExclusive(async () => {
       if (this.connectionStatus !== ConnectionStatus.Disconnected) return false;
       this.localEventHandler = localEventHandler;
       this.registerMethod(GET_METHODS, this.generateOpenRpcSchema, {
@@ -97,7 +97,14 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
         },
       });
 
-      this.webSocketServer = new WebSocketServer({ port: WEBSOCKET_PORT });
+      // Prefer the default port, but fall back to a free port when it is already in use so this
+      // app runs its own isolated PAPI network (e.g. another paranext-based app is running)
+      const { webSocketServer, port } = await createPapiWebSocketServer();
+      this.webSocketServer = webSocketServer;
+      // Advertise the port to the rest of main and to the processes main spawns (renderer,
+      // extension host, .NET data provider) so this app's clients connect to this app's server
+      globalThis.webSocketPort = port;
+      logger.info(`PAPI WebSocket server is listening on port ${port}`);
       this.webSocketServer.addListener('connection', this.onClientConnect);
       this.webSocketServer.addListener('close', this.disconnect);
 

--- a/src/main/services/web-socket-server.factory.ts
+++ b/src/main/services/web-socket-server.factory.ts
@@ -9,6 +9,7 @@
  */
 
 import { CommandLineArgs, getCommandLineArgument } from '@node/utils/command-line.util';
+import { parseWebSocketPort } from '@shared/data/platform.data';
 import { WEBSOCKET_PORT } from '@shared/data/rpc.model';
 import { logger } from '@shared/services/logger.service';
 import { getErrorMessage } from 'platform-bible-utils';
@@ -20,28 +21,29 @@ import { WebSocketServer } from 'ws';
  */
 export const WEBSOCKET_PORT_ENV_VAR = 'PAPI_WEBSOCKET_PORT';
 
-interface PapiWebSocketServerInfo {
+/** The WebSocketServer hosting this app's PAPI network and where it can be reached */
+export interface PapiWebSocketServerInfo {
+  /** The listening WebSocket server */
   webSocketServer: WebSocketServer;
   /** Port the WebSocket server is actually listening on */
   port: number;
 }
 
 /**
- * Determine which port this app should try first for its PAPI WebSocket server: the
- * `--webSocketPort` command-line argument, then the {@link WEBSOCKET_PORT_ENV_VAR} environment
- * variable, then {@link WEBSOCKET_PORT}
+ * Determine which port this app should try first for its PAPI WebSocket server: the first valid
+ * port among the `--webSocketPort` command-line argument, then the {@link WEBSOCKET_PORT_ENV_VAR}
+ * environment variable, then {@link WEBSOCKET_PORT}
  */
 export function getPreferredWebSocketPort(): number {
-  const portString =
-    getCommandLineArgument(CommandLineArgs.WebSocketPort) ?? process.env[WEBSOCKET_PORT_ENV_VAR];
-  if (portString === undefined) return WEBSOCKET_PORT;
+  const portStringArgument = getCommandLineArgument(CommandLineArgs.WebSocketPort);
+  const portStringEnv = process.env[WEBSOCKET_PORT_ENV_VAR];
+  const port = parseWebSocketPort(portStringArgument) ?? parseWebSocketPort(portStringEnv);
+  if (port !== undefined) return port;
 
-  const port = Number(portString);
-  if (Number.isInteger(port) && port > 0 && port <= 65535) return port;
-
-  logger.warn(
-    `Ignoring invalid PAPI WebSocket port "${portString}" from the command line or ${WEBSOCKET_PORT_ENV_VAR}. Using default port ${WEBSOCKET_PORT}`,
-  );
+  if (portStringArgument !== undefined || portStringEnv !== undefined)
+    logger.warn(
+      `Ignoring invalid PAPI WebSocket port "${portStringArgument ?? portStringEnv}" from the command line or ${WEBSOCKET_PORT_ENV_VAR}. Using default port ${WEBSOCKET_PORT}`,
+    );
   return WEBSOCKET_PORT;
 }
 
@@ -88,15 +90,22 @@ function getListeningPort(webSocketServer: WebSocketServer): number {
 export async function createPapiWebSocketServer(
   preferredPort: number = getPreferredWebSocketPort(),
 ): Promise<PapiWebSocketServerInfo> {
+  let webSocketServer: WebSocketServer | undefined;
   try {
-    const webSocketServer = await startWebSocketServerOnPort(preferredPort);
-    return { webSocketServer, port: preferredPort };
+    webSocketServer = await startWebSocketServerOnPort(preferredPort);
   } catch (error) {
     logger.warn(
       `PAPI WebSocket server could not listen on port ${preferredPort}: ${getErrorMessage(error)}. The port is probably in use by another paranext-based app or a leftover instance of this app. Falling back to an automatically assigned port so this app runs its own isolated PAPI network.`,
     );
   }
 
-  const webSocketServer = await startWebSocketServerOnPort(0);
+  if (!webSocketServer) webSocketServer = await startWebSocketServerOnPort(0);
+
+  // Log rare post-startup server errors instead of letting them become uncaught exceptions
+  webSocketServer.on('error', (error: Error) => {
+    logger.error(`PAPI WebSocket server error: ${getErrorMessage(error)}`);
+  });
+
+  // Read the bound port from the server so this is correct even when `preferredPort` is 0
   return { webSocketServer, port: getListeningPort(webSocketServer) };
 }

--- a/src/main/services/web-socket-server.factory.ts
+++ b/src/main/services/web-socket-server.factory.ts
@@ -1,0 +1,102 @@
+/**
+ * Creates the WebSocketServer that hosts this app's PAPI network.
+ *
+ * All paranext-based apps prefer the same default port, so the preferred port may already be taken
+ * — e.g. Paratext 10 Studio and Platform.Bible running side by side, or a leftover dev instance. In
+ * that case, fall back to an automatically assigned free port so this app runs its own fully
+ * isolated PAPI network instead of its clients silently attaching to the other app's network. See
+ * https://paratextstudio.atlassian.net/browse/PT-4109
+ */
+
+import { CommandLineArgs, getCommandLineArgument } from '@node/utils/command-line.util';
+import { WEBSOCKET_PORT } from '@shared/data/rpc.model';
+import { logger } from '@shared/services/logger.service';
+import { getErrorMessage } from 'platform-bible-utils';
+import { WebSocketServer } from 'ws';
+
+/**
+ * Environment variable that specifies which port to prefer for this app's PAPI WebSocket server.
+ * The {@link CommandLineArgs.WebSocketPort} command-line argument takes precedence over this.
+ */
+export const WEBSOCKET_PORT_ENV_VAR = 'PAPI_WEBSOCKET_PORT';
+
+interface PapiWebSocketServerInfo {
+  webSocketServer: WebSocketServer;
+  /** Port the WebSocket server is actually listening on */
+  port: number;
+}
+
+/**
+ * Determine which port this app should try first for its PAPI WebSocket server: the
+ * `--webSocketPort` command-line argument, then the {@link WEBSOCKET_PORT_ENV_VAR} environment
+ * variable, then {@link WEBSOCKET_PORT}
+ */
+export function getPreferredWebSocketPort(): number {
+  const portString =
+    getCommandLineArgument(CommandLineArgs.WebSocketPort) ?? process.env[WEBSOCKET_PORT_ENV_VAR];
+  if (portString === undefined) return WEBSOCKET_PORT;
+
+  const port = Number(portString);
+  if (Number.isInteger(port) && port > 0 && port <= 65535) return port;
+
+  logger.warn(
+    `Ignoring invalid PAPI WebSocket port "${portString}" from the command line or ${WEBSOCKET_PORT_ENV_VAR}. Using default port ${WEBSOCKET_PORT}`,
+  );
+  return WEBSOCKET_PORT;
+}
+
+/** Start a WebSocketServer listening on the given port. Rejects if the server fails to start */
+function startWebSocketServerOnPort(port: number): Promise<WebSocketServer> {
+  return new Promise((resolve, reject) => {
+    const webSocketServer = new WebSocketServer({ port });
+
+    function removeStartupListeners() {
+      webSocketServer.removeListener('listening', onListening);
+      webSocketServer.removeListener('error', onError);
+    }
+    function onListening() {
+      removeStartupListeners();
+      resolve(webSocketServer);
+    }
+    function onError(error: Error) {
+      removeStartupListeners();
+      webSocketServer.close();
+      reject(error);
+    }
+
+    webSocketServer.on('listening', onListening);
+    webSocketServer.on('error', onError);
+  });
+}
+
+/** Get the port a listening WebSocketServer is bound to */
+function getListeningPort(webSocketServer: WebSocketServer): number {
+  const address = webSocketServer.address();
+  // address() only returns a string for servers listening on a pipe/unix socket, which we never do
+  if (typeof address === 'object' && address) return address.port;
+  throw new Error(`Could not determine PAPI WebSocket server port from address "${address}"`);
+}
+
+/**
+ * Create the WebSocketServer that hosts this app's PAPI network, listening on `preferredPort` if it
+ * is available or an automatically assigned free port otherwise
+ *
+ * @param preferredPort Port to try first. Defaults to {@link getPreferredWebSocketPort}
+ * @returns The listening server and the port it is actually listening on
+ * @throws If a server could not be started even on an automatically assigned port
+ */
+export async function createPapiWebSocketServer(
+  preferredPort: number = getPreferredWebSocketPort(),
+): Promise<PapiWebSocketServerInfo> {
+  try {
+    const webSocketServer = await startWebSocketServerOnPort(preferredPort);
+    return { webSocketServer, port: preferredPort };
+  } catch (error) {
+    logger.warn(
+      `PAPI WebSocket server could not listen on port ${preferredPort}: ${getErrorMessage(error)}. The port is probably in use by another paranext-based app or a leftover instance of this app. Falling back to an automatically assigned port so this app runs its own isolated PAPI network.`,
+    );
+  }
+
+  const webSocketServer = await startWebSocketServerOnPort(0);
+  return { webSocketServer, port: getListeningPort(webSocketServer) };
+}

--- a/src/node/services/node-web-socket.service.ts
+++ b/src/node/services/node-web-socket.service.ts
@@ -2,7 +2,7 @@
 // Once tested, this code should probably be added to src/extension-host/services/papi-backend.service.ts as PapiNodeWebSocket.
 // This is the equivalent of PapiRendererWebSocket but for the extension host process instead of the renderer process.
 
-import { WEBSOCKET_PORT } from '@shared/data/rpc.model';
+import { getWebSocketPort } from '@shared/data/rpc.model';
 import { logger } from '@shared/services/logger.service';
 import { ClientRequest, ClientRequestArgs, IncomingMessage } from 'http';
 import {
@@ -27,7 +27,7 @@ function isPotentialConnectionToPapiNetwork(url: string | URL): boolean {
   }
 
   const { port } = urlObj;
-  return parseInt(port, 10) === parseInt(`${WEBSOCKET_PORT}`, 10);
+  return parseInt(port, 10) === getWebSocketPort();
 }
 
 // The following block is copied verbatim from the `ws` package type definitions, which use `any`,

--- a/src/node/services/node-web-socket.service.ts
+++ b/src/node/services/node-web-socket.service.ts
@@ -2,7 +2,7 @@
 // Once tested, this code should probably be added to src/extension-host/services/papi-backend.service.ts as PapiNodeWebSocket.
 // This is the equivalent of PapiRendererWebSocket but for the extension host process instead of the renderer process.
 
-import { getWebSocketPort } from '@shared/data/rpc.model';
+import { isPotentialConnectionToPapiNetwork } from '@shared/data/rpc.model';
 import { logger } from '@shared/services/logger.service';
 import { ClientRequest, ClientRequestArgs, IncomingMessage } from 'http';
 import {
@@ -16,19 +16,6 @@ import {
   WebSocket,
   WebSocketEventMap,
 } from 'ws';
-
-// We are just filtering by port number on purpose to allow other connections to localhost
-function isPotentialConnectionToPapiNetwork(url: string | URL): boolean {
-  let urlObj: URL;
-  if (typeof url === 'string') {
-    urlObj = new URL(url);
-  } else {
-    urlObj = url;
-  }
-
-  const { port } = urlObj;
-  return parseInt(port, 10) === getWebSocketPort();
-}
 
 // The following block is copied verbatim from the `ws` package type definitions, which use `any`,
 // omit blank lines between overloads, have unused overload stubs, and duplicate class members.

--- a/src/node/utils/command-line.util.ts
+++ b/src/node/utils/command-line.util.ts
@@ -30,6 +30,10 @@ type CommandLineArgumentAliases = {
  *   1920x1080). Overrides the saved window state dimensions.
  * - Maximize - Command-line switch that specifies that the renderer should be maximized on launch.
  *   Only on main process
+ * - WebSocketPort - Command-line argument that specifies which port to use for the PAPI WebSocket. On
+ *   main, this is the preferred port for the WebSocket server (falls back to a free port if it is
+ *   in use). On the extension host, main passes this to advertise the port the server is actually
+ *   listening on
  */
 export enum CommandLineArgs {
   Extensions = 'extensions',
@@ -41,6 +45,7 @@ export enum CommandLineArgs {
   DidRestart = 'didRestart',
   WindowSize = 'window_size',
   Maximize = 'maximize',
+  WebSocketPort = 'web_socket_port',
 }
 
 /**
@@ -57,6 +62,7 @@ export const commandLineArgumentsAliases: CommandLineArgumentAliases = {
   [CommandLineArgs.DidRestart]: ['--didRestart'],
   [CommandLineArgs.WindowSize]: ['--windowSize', '--window-size'],
   [CommandLineArgs.Maximize]: ['--maximize'],
+  [CommandLineArgs.WebSocketPort]: ['--webSocketPort', '--web-socket-port'],
 };
 
 /** Get the index of the next command-line argument after the startIndex */

--- a/src/renderer/global-this.model.ts
+++ b/src/renderer/global-this.model.ts
@@ -1,7 +1,11 @@
 /** Module to set up globalThis and polyfills in the renderer */
 
 import { ProcessType } from '@shared/global-this.model';
-import { DEV_MODE_QUERY_PARAMETER, LOG_LEVEL_QUERY_PARAMETER } from '@shared/data/platform.data';
+import {
+  DEV_MODE_QUERY_PARAMETER,
+  LOG_LEVEL_QUERY_PARAMETER,
+  WEBSOCKET_PORT_QUERY_PARAMETER,
+} from '@shared/data/platform.data';
 import type { LogLevel } from 'electron-log';
 
 // #region webpack DefinePlugin types setup - these should be from the renderer webpack DefinePlugin
@@ -32,5 +36,11 @@ globalThis.logLevel = (searchParams.get(LOG_LEVEL_QUERY_PARAMETER) as LogLevel) 
 // null is used in this API meaning the param is not present
 // eslint-disable-next-line no-null/no-null
 globalThis.isNoisyDevModeEnabled = searchParams.get(DEV_MODE_QUERY_PARAMETER) !== null;
+
+// Main advertises the port its PAPI WebSocket server is actually listening on, which may differ
+// from the default port when the default was in use by another app. Leave undefined if absent or
+// invalid so consumers fall back to the default port
+const webSocketPortParam = parseInt(searchParams.get(WEBSOCKET_PORT_QUERY_PARAMETER) ?? '', 10);
+globalThis.webSocketPort = Number.isNaN(webSocketPortParam) ? undefined : webSocketPortParam;
 
 // #endregion

--- a/src/renderer/global-this.model.ts
+++ b/src/renderer/global-this.model.ts
@@ -4,6 +4,7 @@ import { ProcessType } from '@shared/global-this.model';
 import {
   DEV_MODE_QUERY_PARAMETER,
   LOG_LEVEL_QUERY_PARAMETER,
+  parseWebSocketPort,
   WEBSOCKET_PORT_QUERY_PARAMETER,
 } from '@shared/data/platform.data';
 import type { LogLevel } from 'electron-log';
@@ -40,7 +41,8 @@ globalThis.isNoisyDevModeEnabled = searchParams.get(DEV_MODE_QUERY_PARAMETER) !=
 // Main advertises the port its PAPI WebSocket server is actually listening on, which may differ
 // from the default port when the default was in use by another app. Leave undefined if absent or
 // invalid so consumers fall back to the default port
-const webSocketPortParam = parseInt(searchParams.get(WEBSOCKET_PORT_QUERY_PARAMETER) ?? '', 10);
-globalThis.webSocketPort = Number.isNaN(webSocketPortParam) ? undefined : webSocketPortParam;
+globalThis.webSocketPort = parseWebSocketPort(
+  searchParams.get(WEBSOCKET_PORT_QUERY_PARAMETER) ?? undefined,
+);
 
 // #endregion

--- a/src/renderer/services/renderer-web-socket.service.ts
+++ b/src/renderer/services/renderer-web-socket.service.ts
@@ -1,4 +1,4 @@
-import { WEBSOCKET_PORT } from '@shared/data/rpc.model';
+import { getWebSocketPort } from '@shared/data/rpc.model';
 
 // Allow system networking components to create web sockets that connect back to localhost at first
 let allowWebSocketsBackToPapiNetwork: boolean = true;
@@ -18,7 +18,7 @@ function isPotentialConnectionToPapiNetwork(url: string | URL): boolean {
   }
 
   const { port } = urlObj;
-  return parseInt(port, 10) === parseInt(`${WEBSOCKET_PORT}`, 10);
+  return parseInt(port, 10) === getWebSocketPort();
 }
 
 /**

--- a/src/renderer/services/renderer-web-socket.service.ts
+++ b/src/renderer/services/renderer-web-socket.service.ts
@@ -1,4 +1,4 @@
-import { getWebSocketPort } from '@shared/data/rpc.model';
+import { isPotentialConnectionToPapiNetwork } from '@shared/data/rpc.model';
 
 // Allow system networking components to create web sockets that connect back to localhost at first
 let allowWebSocketsBackToPapiNetwork: boolean = true;
@@ -7,19 +7,6 @@ let allowWebSocketsBackToPapiNetwork: boolean = true;
 export const blockWebSocketsToPapiNetwork = (): void => {
   allowWebSocketsBackToPapiNetwork = false;
 };
-
-// We are just filtering by port number on purpose to allow other connections to localhost
-function isPotentialConnectionToPapiNetwork(url: string | URL): boolean {
-  let urlObj: URL;
-  if (typeof url === 'string') {
-    urlObj = new URL(url);
-  } else {
-    urlObj = url;
-  }
-
-  const { port } = urlObj;
-  return parseInt(port, 10) === getWebSocketPort();
-}
 
 /**
  * JSDOC SOURCE PapiRendererWebSocket This wraps the browser's WebSocket implementation to provide

--- a/src/shared/data/platform.data.ts
+++ b/src/shared/data/platform.data.ts
@@ -16,6 +16,25 @@ export const DEV_MODE_QUERY_PARAMETER = 'noisyDevMode';
  */
 export const WEBSOCKET_PORT_QUERY_PARAMETER = 'webSocketPort';
 
+/**
+ * Parse a string that should contain a WebSocket port number
+ *
+ * Note: this lives here rather than in `rpc.model.ts` because it is used in each process's
+ * `global-this.model.ts`, which must not (transitively) import `logger.service` — the logger reads
+ * `globalThis` variables at module initialization, before `global-this.model.ts` sets them.
+ *
+ * @param portString String to parse, e.g. from a command-line argument, environment variable, or
+ *   query parameter
+ * @returns The port number, or `undefined` if the string is missing or is not a valid port number
+ *   (an integer from 1 to 65535)
+ */
+export function parseWebSocketPort(portString: string | undefined): number | undefined {
+  if (portString === undefined) return undefined;
+  const port = Number(portString);
+  if (Number.isInteger(port) && port > 0 && port <= 65535) return port;
+  return undefined;
+}
+
 /** ID of the default theme family for use in the application */
 export const DEFAULT_THEME_FAMILY = '';
 /** Type of the default theme for use in the application */

--- a/src/shared/data/platform.data.ts
+++ b/src/shared/data/platform.data.ts
@@ -10,6 +10,12 @@ export const LOG_LEVEL_QUERY_PARAMETER = 'logLevel';
 /** Query parameter passed to the renderer. Determines if it should enable noisy dev mode */
 export const DEV_MODE_QUERY_PARAMETER = 'noisyDevMode';
 
+/**
+ * Query parameter passed to the renderer. Advertises the port this app's PAPI WebSocket server is
+ * listening on
+ */
+export const WEBSOCKET_PORT_QUERY_PARAMETER = 'webSocketPort';
+
 /** ID of the default theme family for use in the application */
 export const DEFAULT_THEME_FAMILY = '';
 /** Type of the default theme for use in the application */

--- a/src/shared/data/rpc.model.ts
+++ b/src/shared/data/rpc.model.ts
@@ -35,6 +35,27 @@ export function getWebSocketUrl(): string {
   return `ws://localhost:${getWebSocketPort()}`;
 }
 
+/**
+ * Determine whether a WebSocket URL might connect to a PAPI network so such connections can be
+ * blocked. Checks against this app's own PAPI port ({@link getWebSocketPort}) and also the default
+ * PAPI port ({@link WEBSOCKET_PORT}): when this app is running on a fallback port, a raw web socket
+ * to the default port could reach another paranext-based app's PAPI network.
+ *
+ * We are just filtering by port number on purpose to allow other connections to localhost.
+ */
+export function isPotentialConnectionToPapiNetwork(url: string | URL): boolean {
+  let urlObj: URL;
+  if (typeof url === 'string') {
+    urlObj = new URL(url);
+  } else {
+    urlObj = url;
+  }
+
+  const { port } = urlObj;
+  const portNumber = parseInt(port, 10);
+  return portNumber === getWebSocketPort() || portNumber === WEBSOCKET_PORT;
+}
+
 /** How many times to try sending a request before giving up if the request is not yet registered */
 const MAX_REQUEST_ATTEMPTS = 10;
 /** How long in ms to wait between request attempts if the request is not yet registered */

--- a/src/shared/data/rpc.model.ts
+++ b/src/shared/data/rpc.model.ts
@@ -10,8 +10,30 @@ import {
 } from 'json-rpc-2.0';
 import { deserialize, getErrorMessage, serialize, wait } from 'platform-bible-utils';
 
-/** Port to use for the WebSocket */
+/**
+ * Default port to use for the WebSocket. The port actually used may differ - see
+ * {@link getWebSocketPort}
+ */
 export const WEBSOCKET_PORT = 8876;
+
+/**
+ * Get the port this app's PAPI WebSocket network is using.
+ *
+ * Each app instance runs its own isolated PAPI network. The main process starts the WebSocket
+ * server on {@link WEBSOCKET_PORT} (or the port specified by the `--webSocketPort` command-line
+ * argument or `PAPI_WEBSOCKET_PORT` environment variable) and falls back to an automatically
+ * assigned free port when that port is already in use, e.g. when another paranext-based app is
+ * running. Main advertises the port it is actually listening on to the processes it spawns, and
+ * each process records it in `globalThis.webSocketPort`.
+ */
+export function getWebSocketPort(): number {
+  return globalThis.webSocketPort ?? WEBSOCKET_PORT;
+}
+
+/** Get the URL of this app's PAPI WebSocket server. See {@link getWebSocketPort} */
+export function getWebSocketUrl(): string {
+  return `ws://localhost:${getWebSocketPort()}`;
+}
 
 /** How many times to try sending a request before giving up if the request is not yet registered */
 const MAX_REQUEST_ATTEMPTS = 10;

--- a/src/shared/data/rpc.model.web-socket-port.test.ts
+++ b/src/shared/data/rpc.model.web-socket-port.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  getWebSocketPort,
+  getWebSocketUrl,
+  isPotentialConnectionToPapiNetwork,
+  WEBSOCKET_PORT,
+} from '@shared/data/rpc.model';
+import { parseWebSocketPort } from '@shared/data/platform.data';
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+afterEach(() => {
+  globalThis.webSocketPort = undefined;
+});
+
+describe('getWebSocketPort', () => {
+  it('falls back to the default port when no port has been advertised', () => {
+    globalThis.webSocketPort = undefined;
+    expect(getWebSocketPort()).toBe(WEBSOCKET_PORT);
+    expect(getWebSocketUrl()).toBe(`ws://localhost:${WEBSOCKET_PORT}`);
+  });
+
+  it('returns the advertised port when set', () => {
+    globalThis.webSocketPort = 55251;
+    expect(getWebSocketPort()).toBe(55251);
+    expect(getWebSocketUrl()).toBe('ws://localhost:55251');
+  });
+});
+
+describe('parseWebSocketPort', () => {
+  it('parses a valid port', () => {
+    expect(parseWebSocketPort('9123')).toBe(9123);
+    expect(parseWebSocketPort('1')).toBe(1);
+    expect(parseWebSocketPort('65535')).toBe(65535);
+  });
+
+  // Mirrors the invalid values covered for C# in PapiClientConnectionUriTests.cs
+  it.each(['not-a-port', '0', '-1', '70000', '9123garbage', '12.5', ''])(
+    'returns undefined for invalid value "%s"',
+    (invalidPort) => {
+      expect(parseWebSocketPort(invalidPort)).toBeUndefined();
+    },
+  );
+
+  it('returns undefined when the string is missing', () => {
+    expect(parseWebSocketPort(undefined)).toBeUndefined();
+  });
+});
+
+describe('isPotentialConnectionToPapiNetwork', () => {
+  it('blocks the default PAPI port even when this app is on a fallback port', () => {
+    globalThis.webSocketPort = 55251;
+    expect(isPotentialConnectionToPapiNetwork(`ws://localhost:${WEBSOCKET_PORT}`)).toBe(true);
+  });
+
+  it("blocks this app's actual PAPI port", () => {
+    globalThis.webSocketPort = 55251;
+    expect(isPotentialConnectionToPapiNetwork('ws://localhost:55251')).toBe(true);
+    expect(isPotentialConnectionToPapiNetwork(new URL('ws://localhost:55251/some/path'))).toBe(
+      true,
+    );
+  });
+
+  it('allows other ports', () => {
+    globalThis.webSocketPort = 55251;
+    expect(isPotentialConnectionToPapiNetwork('ws://localhost:9000')).toBe(false);
+    expect(isPotentialConnectionToPapiNetwork('wss://example.com/socket')).toBe(false);
+  });
+});

--- a/src/shared/global-this.model.ts
+++ b/src/shared/global-this.model.ts
@@ -69,6 +69,17 @@ declare global {
   var updateWebViewDefinition: UpdateWebViewDefinition;
   /** Indicates whether test code meant just for developers to see should be run */
   var isNoisyDevModeEnabled: boolean;
+  /**
+   * Port this app's PAPI WebSocket server is listening on. Each app instance runs its own isolated
+   * PAPI network, and the port may differ from the default when the default port is already in use
+   * (e.g. another paranext-based app is running). `undefined` means the port is not (yet) known,
+   * and consumers should fall back to the default port.
+   *
+   * - Main: set when the WebSocket server starts listening
+   * - Renderer: set from the query parameter provided by main
+   * - Extension host: set from the command-line argument provided by main
+   */
+  var webSocketPort: number | undefined;
 }
 /* eslint-enable */
 

--- a/src/shared/models/openrpc.model.ts
+++ b/src/shared/models/openrpc.model.ts
@@ -1,7 +1,7 @@
 // The OpenRPC schema types are hand-translated from JSON Schema and inherently require `any` for
 // fields that accept arbitrary JSON values (e.g., schema examples, default values, extensions).
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { WEBSOCKET_PORT } from '@shared/data/rpc.model';
+import { getWebSocketUrl } from '@shared/data/rpc.model';
 import type { JSONSchema7 } from 'json-schema';
 
 // #region OpenRPC types translated from JSON Schema to TypeScript
@@ -244,7 +244,7 @@ export function createEmptyOpenRpc(papiVersion: string): OpenRpc {
       },
       {
         name: 'PAPI websocket',
-        url: `ws://localhost:${WEBSOCKET_PORT}`,
+        url: getWebSocketUrl(),
       },
     ],
     methods: [],


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-4109-multi-port

**Base**: origin/main

**Date**: 2026-07-02

**Review model**: Claude Fable 5

**Files changed**: 21 at analysis time (27 after in-review fixes)

## Overview

Fixes PT-4109: when another paranext-based app (or a leftover dev instance) owned websocket port 8876, a newly launched app's clients silently attached to the foreign server, cross-registering services and leaving the app half-initialized (dead project picker, no resource/model-text selection). Main now binds its PAPI WebSocket server to the preferred port (default 8876; `--webSocketPort` / `PAPI_WEBSOCKET_PORT` overrides) and falls back to an OS-assigned free port when taken, advertising the actual port to the renderer (query parameter), extension host (`--webSocketPort` argument), and .NET data provider (`PAPI_WEBSOCKET_PORT` env var). If no server can start at all, the app fails loudly with an error dialog instead of presenting a dead UI.

This review ran four antagonistic analysis passes (api, style, compliance, ux). The author instructed that findings be applied as improvements directly; all Critical/Important findings were fixed in-review except the e2e-harness port hardcoding, which is documented as a follow-up (see below). The review also drove one scope addition: the extension host's dev-only local OAuth server (fixed port 5000) rejected on `EADDRINUSE` inside the startup `Promise.all`, which aborted extension loading entirely in a second dev instance — the same disease on a different port. It now degrades gracefully with a warning.

## API Changes

No changes to `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `@papi/` modules, or extensions' type declaration files. All `papi.d.ts` changes are in non-`@papi/` internal modules and are additive:

- `shared/data/rpc.model`: Added `getWebSocketPort()`, `getWebSocketUrl()`, `isPotentialConnectionToPapiNetwork()`; `WEBSOCKET_PORT` retained unchanged (docs now call it the default)
- `shared/data/platform.data`: Added `WEBSOCKET_PORT_QUERY_PARAMETER` and `parseWebSocketPort()`
- `shared/global-this.model`: Added `var webSocketPort: number | undefined` (additive, consistent with existing globals)
- New transitive module declarations: `node/utils/command-line.util` (`CommandLineArgs.WebSocketPort`) and `main/services/web-socket-server.factory` (`WEBSOCKET_PORT_ENV_VAR`, `getPreferredWebSocketPort`, `createPapiWebSocketServer`, `PapiWebSocketServerInfo`)
- C# (not public API): `PapiClient` adds `internal` constants `DEFAULT_WEBSOCKET_PORT`, `WEBSOCKET_PORT_ENV_VAR` and `internal static GetConnectionUri()`
- `main/services/app.service-host`: Added `APP_DISPLAY_NAME` (from new `displayName` field in `release/app/package.json`)

No deleted or narrowed exports anywhere.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **Port-parsing logic written four times with inconsistent strictness; renderer/EH copies accepted `"0"`/`"70000"`/`"9123garbage"` despite comments claiming invalid values are dropped** _(fixed during review: single strict `parseWebSocketPort()` (integer 1–65535) in `platform.data.ts`, used by the factory and both `global-this.model.ts` files; placed there rather than `rpc.model.ts` because global-this modules must not transitively import `logger.service`, which reads `globalThis` at module init)_
- [ ] **E2E harness hardcodes port 8876** (`helpers.ts`, `papi.fixture.ts`, `papi-live.fixture.ts`, `global-setup.ts`, `comment-test-helpers.ts`, `dialog-rendering.spec.ts`): an e2e-launched app that finds 8876 occupied now starts successfully on a hidden fallback port, so fixtures waiting on 8876 could drive the wrong instance. Mitigations today: `global-setup.ts` fails fast when 8876 is in use, and isolated specs run serialized, so the silent-wrong-app window is narrow. Proper fix: pin a unique `PAPI_WEBSOCKET_PORT` per `launchElectronApp` call and thread the port through fixtures (the launch helper already supports `envOverrides`). Left open deliberately — e2e changes could not be verified in this session (verification would require a full e2e cycle, and 8876 was held by a live Paratext 10 Studio). File a follow-up ticket before/at merge.
- [x] **`isPotentialConnectionToPapiNetwork` is security-relevant, changed twice on this branch, duplicated in two files, and untested** _(fixed during review: moved to shared `rpc.model.ts` (removing the renderer/node duplication) and unit-tested, including the dual-port policy: blocks this app's actual port AND the default port so a fallback-port app's WebViews cannot raw-connect to another app's network on 8876)_
- [x] **TS invalid-port test coverage lags the C# twin; invalid CLI value silently skipped a valid env var** _(fixed during review: `parseWebSocketPort` tests mirror C#'s `"0"`/`"-1"`/`"70000"`/garbage cases; `getPreferredWebSocketPort` now takes the first valid source — a valid env var wins over an invalid CLI arg — with a pinning test)_
- [x] **Fatal-startup dialog: hardcoded English not documented as a deliberate localization exception** _(fixed during review: comment states the localization service runs over the very PAPI network that just failed, so it is provably unavailable)_
- [x] **Fatal-startup dialog shows machine identifier ("platform-bible") instead of product name** _(fixed during review: added `"displayName": "Platform.Bible"` to `release/app/package.json` and `APP_DISPLAY_NAME` export; deliberately did NOT use Electron `productName`, which would change `userData` paths for released apps. Downstream note: products that replace `release/app/package.json` (e.g. Paratext 10 Studio) must add their own `displayName` — a compile error will surface it)_
- [x] **C# client didn't log its connection URI; a manually started data provider (`npm run start:data`) defaults to 8876 and can silently attach to another app's network** _(fixed during review: `PapiClient` logs the URI on connect; CLAUDE.md dev workflow documents setting `PAPI_WEBSOCKET_PORT` when the app instance fell back to another port)_

### Minor — Consider

- [x] **`createPapiWebSocketServer(0)` would report port 0 instead of the bound port** _(fixed during review: reads the bound port from the server in both paths)_
- [x] **No persistent `'error'` listener after startup — rare post-listen server errors became uncaught exceptions (pre-existing)** _(fixed during review: factory attaches a logging handler)_
- [x] **Factory test suite fails on machines with `PAPI_WEBSOCKET_PORT` exported in the shell** _(fixed during review: `beforeEach` deletes and `afterEach` restores the variable)_
- [x] **`PapiWebSocketServerInfo` unexported/undocumented while appearing in an exported signature** _(fixed during review: exported with TSDoc)_
- [x] **`getWebSocketPort()`/`getWebSocketUrl()` fallback contract untested** _(fixed during review: `rpc.model.web-socket-port.test.ts`)_
- [ ] ~~Rename `WEBSOCKET_PORT` to `DEFAULT_WEBSOCKET_PORT` to match C#~~ _(dismissed: it is public API in papi.d.ts; renaming breaks external consumers for marginal gain. TSDoc marks it as the default and the C# comment now says "must match the value of the default port constant")_
- [ ] ~~Test helper `getListeningPort` duplicates the factory's private helper~~ _(dismissed: 4-line test-local helper; keeping the factory's exported surface minimal is worth the duplication)_
- [ ] ~~`shot.mjs` stray untracked file at repo root~~ _(dismissed: pre-existing untracked file unrelated to this branch; deliberately left untouched and uncommitted)_
- [ ] ~~Integration chain (listener sets global → main advertises → children connect) has no automated end-to-end test~~ _(dismissed: Electron-multi-process-heavy; verified live twice — with Paratext 10 Studio holding 8876, the dev app started on a fallback port with all three clients connected, `dialog:showDialog` registered, and zero registration collisions)_
- [ ] ~~Factory test "preferred port available" has a probe-then-bind TOCTOU window~~ _(dismissed: vanishingly rare on CI; would fail loudly, not silently)_
- [ ] `refresh.sh` "is the app up" probe checks `http://localhost:8876` and reports UP for the wrong app when another paranext app owns it — same class as the e2e follow-up; fold into that ticket.
- [ ] Cross-repo coordination: isolation is only complete once downstream apps (Paratext 10 Studio) pick up this change; an unpatched app started second still collides on 8876. Confirm the downstream merge path.
- [ ] ~~`dialog.showErrorBox` presents a bare OK button (guideline prefers outcome-communicating labels)~~ _(dismissed: `showErrorBox` is the only dialog documented safe at any point during startup, and this is a fatal single-path dialog — no decision is being made)_
- [x] **Dialog copy led with internal jargon ("The PAPI WebSocket server…")** _(fixed during review: plain-language headline — "could not set up the internal services it needs to run" — with the raw error retained as "Technical details" for support)_

### Additional in-review scope (driven by the author's multi-instance question)

- [x] **Extension host's dev-only local OAuth server (fixed port 5000) rejected on `EADDRINUSE` inside the startup `Promise.all`, aborting `extensionService.initialize()` — a second dev instance would load zero extensions** _(fixed during review: warns and resolves instead of rejecting; the port cannot move automatically because the OAuth provider only redirects to the registered port; `LOCAL_OAUTH_SERVER_PORT` override documented in the warning; regression-tested for both the collision and free-port paths)_

### Template Propagation

#### Shared Regions Modified

None (verified: no `#region shared with` markers in any changed file).

#### Extension Config Changes

None (no files under `extensions/` changed).

## Positive Observations

- Fallback design avoids TOCTOU entirely (bind, don't probe); binding is atomic so two apps racing for 8876 cannot both win. Catching non-EADDRINUSE bind failures (e.g. Windows Hyper-V reserved-range EACCES) is a robustness win over the old unguarded `new WebSocketServer(...)` with no error listener.
- Startup ordering verified end-to-end by the api pass: the port is known before any child process spawns or the renderer URL is built; EH restarts recompute args; a user-supplied `--webSocketPort` to main can never shadow the advertised one in the EH's argv; fail-loud happens before children spawn, so no orphans.
- Deterministic sweep found zero leftover hardcoded `8876` / `ws://localhost` in `src/`, `c-sharp/`, `extensions/src` outside the canonical constants.
- Tests use real sockets (no over-mocking), clean up in `finally`; C# fixture is correctly `[NonParallelizable]` with env save/restore.
- Docs updated in lockstep (`Architecture.md`, `CLAUDE.md`) including "always resolve via `getWebSocketPort()`" guidance; `papi.d.ts` regenerated, not hand-edited.

## Interview Notes

- The author (Alex) pre-answered the interview: run an antagonistic review and apply the findings as improvements directly. All fixes above were made under that instruction.
- Author's stated scope decisions: keep `WEBSOCKET_PORT` name for public-API compatibility; leave the e2e harness fix as a follow-up rather than land unverifiable changes; extend scope to the OAuth port 5000 collision because it blocks the author's stated goal of running multiple dev instances alongside installed apps.
- Design note recorded for reviewers: `parseWebSocketPort` lives in `platform.data.ts` rather than `rpc.model.ts` because each process's `global-this.model.ts` needs it, and those modules must not transitively import `logger.service` (the logger reads `globalThis.logLevel`/`isPackaged` at module initialization, before global-this sets them). This constraint is documented in the code.
- Verified live during development (not just analysis): with Paratext 10 Studio 0.4.0-alpha.0 running and holding 8876, a dev instance started on fallback port 55251; renderer, extension host, and .NET data provider all connected to it; `rpc.discover` listed 568 methods including `dialog:showDialog`; Studio was unaffected.

## In-Review Quality Check

- `npm run typecheck`: pass
- `npm run lint`: pass — zero errors; three prettier warnings introduced by review fixes were auto-fixed; the only remaining warnings are two pre-existing `no-console` warnings in `platform-scripture-editor` untouched by this branch
- `npm run build:types`: papi.d.ts regenerated after the API-surface changes
- `npm test`: all suites pass except one Storybook browser test (`dropdown-menu.stories.tsx > Interactive`, platform-bible-react) that timed out under load and passes in isolation — unrelated to this branch (no platform-bible-react changes)
- `dotnet test`: 1295 passed, 6 skipped
- `dotnet csharpier`: applied
- Observation for a future ticket: running the full TS suite while a paranext app owns 8876 shows some tests connecting to the live app's PAPI network (`Websocket connected to ws://localhost:8876`) — pre-existing test-hygiene issue, same family as the e2e follow-up

## Suggested Review Focus

- [ ] E2E follow-up scope: pin a unique `PAPI_WEBSOCKET_PORT` per `launchElectronApp` and thread it through fixtures; fold in the `refresh.sh` probe and the unit-test-suite 8876 connections. Should this block merge or ride a follow-up ticket?
- [ ] Downstream coordination: Paratext 10 Studio needs (a) this change merged for full isolation and (b) its own `displayName` in `release/app/package.json` (compile error will surface it).
- [ ] Security stance: WebSocket wrappers now block the app's actual port and the default port; a foreign app's *fallback* port is unknowable and remains reachable by WebView raw sockets — acceptable, given the PAPI network has no authentication generally?
- [ ] Same-app multi-instance (two copies of Platform.Bible) remains blocked by the PT-2198 single-instance lock and shared userData — intentional. A "second instance — launch anyway?" flow with per-instance profiles would be a separate product decision/ticket.
<!-- review-paratext:summary:end -->

---

## Summary

Fixes [PT-4109](https://paratextstudio.atlassian.net/browse/PT-4109): apps silently break when another process holds websocket port 8876.

Running Paratext 10 Studio and Platform.Bible simultaneously is a supported goal, so this implements the larger fix from the ticket: per-app/dynamic ports plus isolating each app's PAPI network. When the preferred port (default 8876) is already in use, main falls back to an automatically assigned free port and advertises the actual port to every process it spawns, so a second paranext-based app now stands up its own fully isolated backend instead of silently attaching to a foreign server (dead project picker, `dialog:showDialog` timeouts, `already registered` collisions).

## Changes

- **`src/main/services/web-socket-server.factory.ts`** (new): starts the `WebSocketServer` on the preferred port — `--webSocketPort` arg, then `PAPI_WEBSOCKET_PORT` env var, then default 8876 — and falls back to an OS-assigned free port when it is in use. Binding is atomic, so two apps racing for 8876 cannot both win.
- **Port advertisement** from main to each client process:
  - Renderer: `webSocketPort` query parameter (same pattern as `logLevel`)
  - Extension host: forwarded `--webSocketPort` argument
  - .NET data provider: `PAPI_WEBSOCKET_PORT` environment variable (read in `PapiClient.GetConnectionUri()`)
- **`getWebSocketPort()` / `getWebSocketUrl()`** in `shared/data/rpc.model.ts` resolve the actual port everywhere it was previously hardcoded: `rpc-client`, the renderer/node WebSocket wrappers' PAPI-port blocking, the OpenRPC schema server URL, and the live-docs playground URL.
- **Fail loud, not silent**: if no server can be started at all, main logs, shows an error dialog, and exits instead of presenting a half-initialized UI.
- Docs updated (`CLAUDE.md`, `Architecture.md`); `papi.d.ts` regenerated via `npm run build:types`.

`WEBSOCKET_PORT` is kept as the (default) port constant, so the public PAPI surface is only extended, not broken.

## AI Involvement

AI-assisted (generated with Claude Code and reviewed by the author). AI drafted the implementation, tests, and this PR description; the approach follows the implementation ideas already written in the ticket.

## Testing

- [x] TDD: new `web-socket-server.factory.test.ts` (preferred-port use, fallback when occupied, port-override precedence) and `PapiClientConnectionUriTests.cs` (env var present/absent/invalid)
- [x] `npm run typecheck`, `npm run lint`, `npm test` (all suites green), `dotnet test` (1295 passed)
- [x] Live verification of the exact ticket scenario: with Paratext 10 Studio running and holding 8876, the dev app started on a fallback port (55251); renderer, extension host, and .NET data provider all connected to it; `rpc.discover` listed 568 methods including `dialog:showDialog`; no `already registered` / `Service(s) failed to initialize` log entries; Studio's own network was unaffected
- [x] Regression: with 8876 free, the server still binds 8876 (dev tooling on the default port keeps working)

## Risk Level

Medium - touches the startup path of every process, but behavior is unchanged whenever port 8876 is free (the overwhelmingly common case), and the fallback path was verified live against a running Paratext 10 Studio.

[PT-4109]: https://paratextstudio.atlassian.net/browse/PT-4109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2503)
<!-- Reviewable:end -->

