### PR TITLE
fix(platform-bible-react): stop ResultsCard from hijacking child-button keys (PT-4100)

### DIFF
--- a/lib/platform-bible-react/src/components/basics/results-card.component.test.tsx
+++ b/lib/platform-bible-react/src/components/basics/results-card.component.test.tsx
@@ -1,0 +1,85 @@
+import { render, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+import { ResultsCard } from './results-card.component';
+
+/**
+ * Regression tests for PT-4100: keyboard events on interactive children of a ResultsCard (e.g. the
+ * Replace button or the dropdown trigger) must not be hijacked by the card's own Enter/Space
+ * selection handler. Before the fix, the card's onKeyDown fired onSelect (and preventDefault) for
+ * any Enter/Space that bubbled up from a child button, so those buttons could never be activated
+ * from the keyboard.
+ */
+describe('ResultsCard keyboard handling (PT-4100)', () => {
+  it('does not select the card when Enter is pressed on a child button', () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(
+      <ResultsCard
+        cardKey="1"
+        isSelected
+        onSelect={onSelect}
+        selectedButtons={<button type="button">Replace</button>}
+      >
+        Result content
+      </ResultsCard>,
+    );
+
+    fireEvent.keyDown(getByRole('button', { name: 'Replace' }), { key: 'Enter' });
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('does not select the card when Space is pressed on a child button', () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(
+      <ResultsCard
+        cardKey="1"
+        isSelected
+        onSelect={onSelect}
+        selectedButtons={<button type="button">Replace</button>}
+      >
+        Result content
+      </ResultsCard>,
+    );
+
+    fireEvent.keyDown(getByRole('button', { name: 'Replace' }), { key: ' ' });
+
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('selects the card when Enter is pressed on the card itself', () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(
+      <ResultsCard
+        cardKey="1"
+        isSelected
+        onSelect={onSelect}
+        selectedButtons={<button type="button">Replace</button>}
+      >
+        Result content
+      </ResultsCard>,
+    );
+
+    fireEvent.keyDown(getByRole('button', { pressed: true }), { key: 'Enter' });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+
+  it('selects the card when Space is pressed on the card itself', () => {
+    const onSelect = vi.fn();
+    const { getByRole } = render(
+      <ResultsCard
+        cardKey="1"
+        isSelected
+        onSelect={onSelect}
+        selectedButtons={<button type="button">Replace</button>}
+      >
+        Result content
+      </ResultsCard>,
+    );
+
+    fireEvent.keyDown(getByRole('button', { pressed: true }), { key: ' ' });
+
+    expect(onSelect).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/platform-bible-react/src/components/basics/results-card.component.tsx
+++ b/lib/platform-bible-react/src/components/basics/results-card.component.tsx
@@ -55,6 +55,10 @@ export function ResultsCard({
   showDropdownOnHover = false,
 }: ResultsCardProps) {
   const handleKeyDown = (event: React.KeyboardEvent) => {
+    // Only handle Enter/Space that targets the card itself. Without this guard, keystrokes
+    // bubbling up from interactive children (e.g. the Replace button or the dropdown trigger)
+    // are hijacked here, preventing those children from being activated via the keyboard.
+    if (event.target !== event.currentTarget) return;
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault();
       onSelect();


### PR DESCRIPTION
## Summary

Fixes **[PT-4100](https://paratext.atlassian.net/browse/PT-4100)** — "Result list buttons are not keyboard accessible."

`ResultsCard` (`lib/platform-bible-react/src/components/basics/results-card.component.tsx`) renders its content inside a `role="button"` div whose `onKeyDown` fired `event.preventDefault()` + `onSelect()` for **any** Enter/Space. Interactive children of the card — the Find **Replace** button and the ellipsis (⋮) dropdown trigger — are DOM descendants, so pressing Enter/Space while focused on one of them bubbled up to the card handler, which prevented the button's native activation and selected the card instead. Result: those buttons could not be activated from the keyboard.

## Fix

Guard `handleKeyDown` so it only acts when the keydown targets the card itself:

```ts
if (event.target !== event.currentTarget) return;
```

`currentTarget` is always the card div (the handler is bound there); `target` is the element that dispatched the event. A card-level keystroke has `target === currentTarget` and still selects the card; a keystroke originating on a descendant now falls through to that descendant's own handler. 4-line change (guard + explanatory comment), no refactor.

## Reproduction evidence (regression test: RED → GREEN)

New RTL test `results-card.component.test.tsx` asserts child-button Enter/Space must **not** select the card, and card-level Enter/Space still must.

**Before the fix (RED):**
```
 × does not select the card when Enter is pressed on a child button
 × does not select the card when Space is pressed on a child button
 ✓ selects the card when Enter is pressed on the card itself
 ✓ selects the card when Space is pressed on the card itself
 Tests  2 failed | 2 passed (4)
```

**After the fix (GREEN):**
```
 ✓ results-card.component.test.tsx (4 tests)
 Tests  4 passed (4)
```

## Self-review summary

Reviewed at maximum rigor (adversarial pass); **no blockers**:
- **Correctness:** `target !== currentTarget` is the right guard — no path leaves the card keyboard-selectable while focus is on a descendant, and no legitimate card-level selection is wrongly ignored.
- **Blast radius:** the only two consumers — `checks-side-panel/check-card.component.tsx` and `find/search-result.component.tsx` — were read in full. Neither relied on Enter/Space bubbling from a child to select the card; both benefit (their action buttons / dropdown trigger become keyboard-activatable). Dropdown-menu items render in a Radix portal, so they are not DOM descendants of the card and are unaffected.
- **Tests:** behavior-focused and falsifiable (verified they fail against the pre-fix handler).

## Scope note

This PR fixes the primary reported symptom (result-list **buttons** not keyboard-activatable), which lives entirely in the shared `ResultsCard`. PT-4100 also mentions a secondary symptom — arrow keys leaking from an *open* dropdown menu into the results-list navigation — which lives in a different handler (`find.component.tsx` `handleResultsKeyDown`) and is intentionally left out of this minimal fix; it warrants a separate change.

## Impact & confidence

- **Impact:** user-visible keyboard-accessibility defect in the Find/Replace results list (severity 2 × frequency 2, user-visible → score 4). Keyboard-only users cannot activate result actions.
- **Confidence:** ~0.8. Clean, mechanically-verified root cause; minimal guard; regression test proven RED→GREEN; consumers audited.

## Provenance

Found and fixed by the automated **quality-sweep** run (`qs-2026-07-03`), seeded from open unassigned Jira bugs.

AI-assisted — generated by an automated quality-sweep agent (Claude). Human review requested before merge.


[PT-4100]: https://paratextstudio.atlassian.net/browse/PT-4100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2505)
<!-- Reviewable:end -->
