### PR TITLE
PT-4050 (A2): two-flag schema, admin gate, auto-promote, overlay init

### DIFF
--- a/c-sharp-tests/DummyPapiClient.cs
+++ b/c-sharp-tests/DummyPapiClient.cs
@@ -47,6 +47,14 @@ namespace TestParanextDataProvider
         public OpenRpcSingleMethodDocumentation? GetDocumentationFor(string requestType) =>
             _documentationByRequestType.GetValueOrDefault(requestType);
 
+        /// <summary>
+        /// Test-only helper to unregister a request handler so a test can replace one a shared
+        /// <c>SetUp</c> registered (<see cref="RegisterRequestHandlerAsync"/> uses
+        /// <c>TryAdd</c> and will not overwrite an existing key).
+        /// </summary>
+        public void RemoveRequestHandler(string requestType) =>
+            _localMethods.TryRemove(requestType, out _);
+
         public override Task SendEventAsync(string eventType, object? eventParameters)
         {
             _sentEvents.Enqueue((eventType, eventParameters));

--- a/c-sharp-tests/Projects/ParatextProjectDataProviderShownByDefaultTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderShownByDefaultTests.cs
@@ -208,11 +208,15 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
 
     [TestCase("null")] // JSON null literal -> deserializes to null
     [TestCase("")] // empty value -> treated as nothing to store
-    public void Overlay_Set_WithNullOrEmptyValue_Throws(string json)
+    [TestCase("[1,2,3]")] // JSON array, not an object map
+    [TestCase("\"hello\"")] // JSON string, not an object map
+    [TestCase("42")] // JSON number, not an object map
+    [TestCase("{ not json")] // malformed JSON
+    public void Overlay_Set_WithNonMapValue_Throws(string json)
     {
-        // SetShownByDefaultOverlay must reject a value that does not yield a { id -> bool } map
-        // rather than storing garbage. (Wrong-shape JSON such as an array or number throws a
-        // JsonException earlier in deserialization; this covers the explicit null-map guard.)
+        // SetShownByDefaultOverlay must reject any value that does not yield a { id -> bool } map
+        // with a consistent InvalidDataException — whether it is null/empty (deserializes to null) or
+        // a wrong-shape/malformed value (System.Text.Json throws, which the setter wraps).
         Assert.Throws<InvalidDataException>(() => _provider.SetShownByDefaultOverlay(json));
     }
 

--- a/c-sharp-tests/Projects/ParatextProjectDataProviderShownByDefaultTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderShownByDefaultTests.cs
@@ -137,7 +137,7 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
         Assert.That(promoted.Name, Is.EqualTo("D"));
         // The promoted copy exists only to drive download; it does not carry the flags.
         Assert.That(promoted.IsResourceShownByDefault, Is.Null);
-        Assert.That(promoted.InTextCollectionUser, Is.Null);
+        Assert.That(promoted.IsResourceShownForUser, Is.Null);
     }
 
     [Test]

--- a/c-sharp-tests/Projects/ParatextProjectDataProviderShownByDefaultTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderShownByDefaultTests.cs
@@ -75,19 +75,42 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
         );
     }
 
-    [TestCase(ProjectSettingsNames.PB_MODEL_TEXTS)]
-    [TestCase(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES)]
-    public void SetProjectSetting_NonAdmin_Rejected(string pbSettingName)
+    [Test]
+    public void SetProjectSetting_NonAdmin_ReferencedList_Rejected()
     {
+        // Only the referenced-resources list carries the admin-only shown-by-default default, so it
+        // is the only project-scope write gated to administrators.
         var nonAdmin = BuildNonAdminProvider(out var scrText);
         try
         {
             Assert.Throws<UnauthorizedAccessException>(
                 () =>
                     nonAdmin.SetProjectSetting(
-                        pbSettingName,
+                        ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
                         Json(new ProjectReference { Name = "P", Id = "aabbcc" })
                     )
+            );
+        }
+        finally
+        {
+            scrText.Dispose();
+        }
+    }
+
+    [Test]
+    public void SetProjectSetting_NonAdmin_ModelTexts_Allowed()
+    {
+        // Model texts do NOT participate in shown-by-default and keep their pre-existing ungated
+        // behavior, so a non-admin write must succeed (not throw).
+        var nonAdmin = BuildNonAdminProvider(out var scrText);
+        try
+        {
+            Assert.That(
+                nonAdmin.SetProjectSetting(
+                    ProjectSettingsNames.PB_MODEL_TEXTS,
+                    Json(new ProjectReference { Name = "P", Id = "aabbcc" })
+                ),
+                Is.True
             );
         }
         finally
@@ -110,112 +133,41 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
         );
     }
 
+    [Test]
+    public void SetProjectSetting_NonAdmin_ReferencedList_GateRunsBeforeValidation()
+    {
+        // The admin gate is enforced ahead of the ProjectSettingsService.isValid round-trip, so an
+        // unauthorized write is rejected even when validation would fail. Stub isValid -> false and
+        // assert the UnauthorizedAccessException (not an InvalidDataException) surfaces.
+        Client.RemoveRequestHandler("object:ProjectSettingsService.isValid");
+        Client
+            .RegisterRequestHandlerAsync(
+                "object:ProjectSettingsService.isValid",
+                new Func<string, object?, object?, object?, bool>((k, n, c, a) => false),
+                null
+            )
+            .GetAwaiter()
+            .GetResult();
+
+        var nonAdmin = BuildNonAdminProvider(out var scrText);
+        try
+        {
+            Assert.Throws<UnauthorizedAccessException>(
+                () =>
+                    nonAdmin.SetProjectSetting(
+                        ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
+                        Json(new ProjectReference { Name = "P", Id = "aabbcc" })
+                    )
+            );
+        }
+        finally
+        {
+            scrText.Dispose();
+        }
+    }
+
     private ResourceReferenceList GetList(string pbSettingName) =>
         (ResourceReferenceList)_provider.GetProjectSetting(pbSettingName)!;
-
-    [Test]
-    public void AutoPromote_FlaggedModelText_NotInReferenced_IsAppendedToReferenced()
-    {
-        // Admin flags a model text shown-by-default that is not yet a referenced resource.
-        _provider.SetProjectSetting(
-            ProjectSettingsNames.PB_MODEL_TEXTS,
-            Json(
-                new DblResourceReference
-                {
-                    Name = "D",
-                    Id = "112233445566",
-                    IsResourceShownByDefault = true,
-                }
-            )
-        );
-
-        var referenced = GetList(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES);
-        Assert.That(referenced.Items, Has.Count.EqualTo(1));
-        var promoted = referenced.Items[0] as DblResourceReference;
-        Assert.That(promoted!.Id, Is.EqualTo("112233445566"));
-        // The promoted copy preserves the original display name.
-        Assert.That(promoted.Name, Is.EqualTo("D"));
-        // The promoted copy exists only to drive download; it does not carry the flags.
-        Assert.That(promoted.IsResourceShownByDefault, Is.Null);
-        Assert.That(promoted.IsResourceShownForUser, Is.Null);
-    }
-
-    [Test]
-    public void AutoPromote_FlaggedResourceAlreadyInReferenced_IsNoOp()
-    {
-        _provider.SetProjectSetting(
-            ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
-            Json(new DblResourceReference { Name = "D", Id = "112233445566" })
-        );
-
-        // Flag the same resource in model texts; it is already referenced -> no duplicate.
-        _provider.SetProjectSetting(
-            ProjectSettingsNames.PB_MODEL_TEXTS,
-            Json(
-                new DblResourceReference
-                {
-                    Name = "D",
-                    Id = "112233445566",
-                    IsResourceShownByDefault = true,
-                }
-            )
-        );
-
-        var referenced = GetList(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES);
-        Assert.That(referenced.Items, Has.Count.EqualTo(1));
-    }
-
-    [Test]
-    public void AutoPromote_UnflaggedResources_AreNotPromoted()
-    {
-        _provider.SetProjectSetting(
-            ProjectSettingsNames.PB_MODEL_TEXTS,
-            Json(new DblResourceReference { Name = "D", Id = "112233445566" })
-        );
-
-        var referenced = GetList(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES);
-        Assert.That(referenced.Items, Is.Empty);
-    }
-
-    [Test]
-    public void AutoPromote_WritingReferencedListWithFlaggedEntry_DoesNotDuplicate()
-    {
-        // The flagged entry is in the very list being written -> already present -> no-op.
-        _provider.SetProjectSetting(
-            ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
-            Json(
-                new ProjectReference
-                {
-                    Name = "P",
-                    Id = "aabbcc",
-                    IsResourceShownByDefault = true,
-                }
-            )
-        );
-
-        var referenced = GetList(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES);
-        Assert.That(referenced.Items, Has.Count.EqualTo(1));
-    }
-
-    [Test]
-    public void AutoPromote_IsIdempotentAcrossRepeatedWrites()
-    {
-        for (int i = 0; i < 3; i++)
-            _provider.SetProjectSetting(
-                ProjectSettingsNames.PB_MODEL_TEXTS,
-                Json(
-                    new DblResourceReference
-                    {
-                        Name = "D",
-                        Id = "112233445566",
-                        IsResourceShownByDefault = true,
-                    }
-                )
-            );
-
-        var referenced = GetList(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES);
-        Assert.That(referenced.Items, Has.Count.EqualTo(1));
-    }
 
     [Test]
     public void Overlay_Get_WhenUnset_ReturnsEmptyMap()
@@ -254,6 +206,16 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
         Assert.Throws<InvalidDataException>(() => _provider.GetShownByDefaultOverlay());
     }
 
+    [TestCase("null")] // JSON null literal -> deserializes to null
+    [TestCase("")] // empty value -> treated as nothing to store
+    public void Overlay_Set_WithNullOrEmptyValue_Throws(string json)
+    {
+        // SetShownByDefaultOverlay must reject a value that does not yield a { id -> bool } map
+        // rather than storing garbage. (Wrong-shape JSON such as an array or number throws a
+        // JsonException earlier in deserialization; this covers the explicit null-map guard.)
+        Assert.Throws<InvalidDataException>(() => _provider.SetShownByDefaultOverlay(json));
+    }
+
     [Test]
     public void Overlay_Reset_ClearsMap()
     {
@@ -268,7 +230,7 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
     public void Initialize_FirstOpen_SeedsOverlayFromProjectFlags()
     {
         _provider.SetProjectSetting(
-            ProjectSettingsNames.PB_MODEL_TEXTS,
+            ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
             Json(
                 new ProjectReference
                 {
@@ -296,7 +258,7 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
     public void Initialize_IgnoresUnflaggedAndNonBibleTextEntries()
     {
         _provider.SetProjectSetting(
-            ProjectSettingsNames.PB_MODEL_TEXTS,
+            ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
             Json(
                 new ProjectReference { Name = "P", Id = "aabbcc" }, // unflagged -> skipped
                 new EnhancedResourceReference { Name = "Enh" } // non-Bible-text -> skipped
@@ -312,7 +274,7 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
     public void Initialize_SubsequentOpen_IsNoOp_AndDoesNotClobber()
     {
         _provider.SetProjectSetting(
-            ProjectSettingsNames.PB_MODEL_TEXTS,
+            ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
             Json(
                 new ProjectReference
                 {
@@ -338,7 +300,7 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
     public void Initialize_AfterReset_ReInitializes()
     {
         _provider.SetProjectSetting(
-            ProjectSettingsNames.PB_MODEL_TEXTS,
+            ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
             Json(
                 new ProjectReference
                 {
@@ -356,14 +318,10 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
     }
 
     [Test]
-    public void AutoPromote_UnparseableReferencedList_IsLeftUntouched()
+    public void Initialize_IgnoresModelTextFlags()
     {
-        // A future-major or corrupted stored value must never be clobbered by auto-promote
-        // (the downstream private S/R reader keys on the major version).
-        _scrText.Settings.ParametersDictionary[
-            ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES
-        ] = """2.0.0 {"dataVersion":"2.0.0","items":[{"type":"futureType","name":"F"}]}""";
-
+        // Model texts are decoupled from shown-by-default: a flag set on the model-texts list must
+        // NOT seed the overlay. Only PB_REFERENCED_PROJECTS_AND_RESOURCES feeds first-open init.
         _provider.SetProjectSetting(
             ProjectSettingsNames.PB_MODEL_TEXTS,
             Json(
@@ -376,17 +334,14 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
             )
         );
 
-        string stored = _scrText.Settings.ParametersDictionary[
-            ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES
-        ];
-        Assert.That(stored, Does.StartWith("2.0.0 "));
-        Assert.That(stored, Does.Contain("futureType"));
+        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.True);
+        Assert.That(_provider.GetShownByDefaultOverlay(), Is.Empty);
     }
 
     [Test]
     public void Initialize_ReadsFlagsFromReferencedProjectsAndResources()
     {
-        // Regression guard: the init loop must read BOTH project-scope lists, not just ModelTexts.
+        // Regression guard: the init loop reads the referenced-projects-and-resources list.
         _provider.SetProjectSetting(
             ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
             Json(

--- a/c-sharp-tests/Projects/ParatextProjectDataProviderShownByDefaultTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderShownByDefaultTests.cs
@@ -1,0 +1,405 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Xml.Linq;
+using Paranext.DataProvider.JsonUtils;
+using Paranext.DataProvider.Projects;
+using Paranext.DataProvider.Services;
+using Paratext.Data;
+using Paratext.Data.Users;
+
+namespace TestParanextDataProvider.Projects;
+
+[TestFixture]
+[ExcludeFromCodeCoverage]
+internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
+{
+    private const string PdpName = "shownByDefaultTestProject";
+
+    private DummyScrText _scrText = null!;
+    private ProjectDetails _projectDetails = null!;
+    private DummyParatextProjectDataProvider _provider = null!;
+
+    [SetUp]
+    public override async Task TestSetupAsync()
+    {
+        await base.TestSetupAsync();
+
+        await Client.RegisterRequestHandlerAsync(
+            "object:ProjectSettingsService.isValid",
+            new Func<string, object?, object?, object?, bool>((k, n, c, a) => true),
+            null
+        );
+
+        _scrText = CreateDummyProject();
+        _projectDetails = CreateProjectDetails(_scrText);
+        ParatextProjects.FakeAddProject(_projectDetails, _scrText);
+
+        _provider = new DummyParatextProjectDataProvider(
+            PdpName,
+            Client,
+            _projectDetails,
+            ParatextProjects
+        );
+    }
+
+    [TearDown]
+    public void TearDown() => _scrText?.Dispose();
+
+    private static string Json(params ResourceReference[] items) =>
+        new ResourceReferenceList { Items = [.. items] }.SerializeToJson();
+
+    // A shared project where the current user is NOT an administrator. Non-null Data makes
+    // HasPermissionsDefined = true (so IsProjectShared = true) and AmAdministrator = false, so the
+    // production IsUserProjectAdministrator() check fires naturally.
+    private sealed class NonAdminScrText : DummyScrText
+    {
+        private readonly NonAdminPermissionManager _permissions = new();
+        public override PermissionManager Permissions => _permissions;
+
+        private sealed class NonAdminPermissionManager : PermissionManager
+        {
+            protected override InternalProjectUserAccessData Data { get; set; } = new();
+            public override bool AmAdministrator => false;
+        }
+    }
+
+    private DummyParatextProjectDataProvider BuildNonAdminProvider(out DummyScrText scrText)
+    {
+        scrText = new NonAdminScrText();
+        var details = CreateProjectDetails(scrText);
+        ParatextProjects.FakeAddProject(details, scrText);
+        return new DummyParatextProjectDataProvider(
+            "nonAdminProject",
+            Client,
+            details,
+            ParatextProjects
+        );
+    }
+
+    [TestCase(ProjectSettingsNames.PB_MODEL_TEXTS)]
+    [TestCase(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES)]
+    public void SetProjectSetting_NonAdmin_Rejected(string pbSettingName)
+    {
+        var nonAdmin = BuildNonAdminProvider(out var scrText);
+        try
+        {
+            Assert.Throws<UnauthorizedAccessException>(
+                () =>
+                    nonAdmin.SetProjectSetting(
+                        pbSettingName,
+                        Json(new ProjectReference { Name = "P", Id = "aabbcc" })
+                    )
+            );
+        }
+        finally
+        {
+            scrText.Dispose();
+        }
+    }
+
+    [TestCase(ProjectSettingsNames.PB_MODEL_TEXTS)]
+    [TestCase(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES)]
+    public void SetProjectSetting_Admin_Succeeds(string pbSettingName)
+    {
+        // Default DummyScrText is administrator via the unshared fallback path.
+        Assert.That(
+            _provider.SetProjectSetting(
+                pbSettingName,
+                Json(new ProjectReference { Name = "P", Id = "aabbcc" })
+            ),
+            Is.True
+        );
+    }
+
+    private ResourceReferenceList GetList(string pbSettingName) =>
+        (ResourceReferenceList)_provider.GetProjectSetting(pbSettingName)!;
+
+    [Test]
+    public void AutoPromote_FlaggedModelText_NotInReferenced_IsAppendedToReferenced()
+    {
+        // Admin flags a model text shown-by-default that is not yet a referenced resource.
+        _provider.SetProjectSetting(
+            ProjectSettingsNames.PB_MODEL_TEXTS,
+            Json(
+                new DblResourceReference
+                {
+                    Name = "D",
+                    Id = "112233445566",
+                    IsResourceShownByDefault = true,
+                }
+            )
+        );
+
+        var referenced = GetList(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES);
+        Assert.That(referenced.Items, Has.Count.EqualTo(1));
+        var promoted = referenced.Items[0] as DblResourceReference;
+        Assert.That(promoted!.Id, Is.EqualTo("112233445566"));
+        // The promoted copy preserves the original display name.
+        Assert.That(promoted.Name, Is.EqualTo("D"));
+        // The promoted copy exists only to drive download; it does not carry the flags.
+        Assert.That(promoted.IsResourceShownByDefault, Is.Null);
+        Assert.That(promoted.InTextCollectionUser, Is.Null);
+    }
+
+    [Test]
+    public void AutoPromote_FlaggedResourceAlreadyInReferenced_IsNoOp()
+    {
+        _provider.SetProjectSetting(
+            ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
+            Json(new DblResourceReference { Name = "D", Id = "112233445566" })
+        );
+
+        // Flag the same resource in model texts; it is already referenced -> no duplicate.
+        _provider.SetProjectSetting(
+            ProjectSettingsNames.PB_MODEL_TEXTS,
+            Json(
+                new DblResourceReference
+                {
+                    Name = "D",
+                    Id = "112233445566",
+                    IsResourceShownByDefault = true,
+                }
+            )
+        );
+
+        var referenced = GetList(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES);
+        Assert.That(referenced.Items, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void AutoPromote_UnflaggedResources_AreNotPromoted()
+    {
+        _provider.SetProjectSetting(
+            ProjectSettingsNames.PB_MODEL_TEXTS,
+            Json(new DblResourceReference { Name = "D", Id = "112233445566" })
+        );
+
+        var referenced = GetList(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES);
+        Assert.That(referenced.Items, Is.Empty);
+    }
+
+    [Test]
+    public void AutoPromote_WritingReferencedListWithFlaggedEntry_DoesNotDuplicate()
+    {
+        // The flagged entry is in the very list being written -> already present -> no-op.
+        _provider.SetProjectSetting(
+            ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
+            Json(
+                new ProjectReference
+                {
+                    Name = "P",
+                    Id = "aabbcc",
+                    IsResourceShownByDefault = true,
+                }
+            )
+        );
+
+        var referenced = GetList(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES);
+        Assert.That(referenced.Items, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void AutoPromote_IsIdempotentAcrossRepeatedWrites()
+    {
+        for (int i = 0; i < 3; i++)
+            _provider.SetProjectSetting(
+                ProjectSettingsNames.PB_MODEL_TEXTS,
+                Json(
+                    new DblResourceReference
+                    {
+                        Name = "D",
+                        Id = "112233445566",
+                        IsResourceShownByDefault = true,
+                    }
+                )
+            );
+
+        var referenced = GetList(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES);
+        Assert.That(referenced.Items, Has.Count.EqualTo(1));
+    }
+
+    [Test]
+    public void Overlay_Get_WhenUnset_ReturnsEmptyMap()
+    {
+        var overlay = _provider.GetShownByDefaultOverlay();
+        Assert.That(overlay, Is.Empty);
+    }
+
+    [Test]
+    public void Overlay_SetThenGet_RoundTrips()
+    {
+        var input = new Dictionary<string, bool> { ["aabbcc"] = true, ["ddeeff"] = false };
+        Assert.That(_provider.SetShownByDefaultOverlay(input.SerializeToJson()), Is.True);
+
+        var overlay = _provider.GetShownByDefaultOverlay();
+        Assert.That(overlay["aabbcc"], Is.True);
+        Assert.That(overlay["ddeeff"], Is.False);
+    }
+
+    [Test]
+    public void Overlay_Get_WithIncompatibleMajorVersion_Throws()
+    {
+        // Seed the overlay setting directly with a future major version the current build cannot
+        // read. "ShownByDefaultOverlay" mirrors ParatextProjectDataProvider.OverlaySettingName
+        // (a private const). GetShownByDefaultOverlay must reject it rather than deserialize blindly.
+        var userSettings = new UserProjectSettings(_scrText.Directory, _scrText.User.Name);
+        userSettings.SetSetting(
+            "ShownByDefaultOverlay",
+            "2.0.0",
+            new XElement(
+                "Items",
+                new Dictionary<string, bool> { ["aabbcc"] = true }.SerializeToJson()
+            )
+        );
+
+        Assert.Throws<InvalidDataException>(() => _provider.GetShownByDefaultOverlay());
+    }
+
+    [Test]
+    public void Overlay_Reset_ClearsMap()
+    {
+        _provider.SetShownByDefaultOverlay(
+            new Dictionary<string, bool> { ["aabbcc"] = true }.SerializeToJson()
+        );
+        Assert.That(_provider.ResetShownByDefaultOverlay(), Is.True);
+        Assert.That(_provider.GetShownByDefaultOverlay(), Is.Empty);
+    }
+
+    [Test]
+    public void Initialize_FirstOpen_SeedsOverlayFromProjectFlags()
+    {
+        _provider.SetProjectSetting(
+            ProjectSettingsNames.PB_MODEL_TEXTS,
+            Json(
+                new ProjectReference
+                {
+                    Name = "P",
+                    Id = "aabbcc",
+                    IsResourceShownByDefault = true,
+                },
+                new DblResourceReference
+                {
+                    Name = "D",
+                    Id = "112233445566",
+                    IsResourceShownByDefault = false,
+                }
+            )
+        );
+
+        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.True);
+
+        var overlay = _provider.GetShownByDefaultOverlay();
+        Assert.That(overlay["aabbcc"], Is.True);
+        Assert.That(overlay["112233445566"], Is.False);
+    }
+
+    [Test]
+    public void Initialize_IgnoresUnflaggedAndNonBibleTextEntries()
+    {
+        _provider.SetProjectSetting(
+            ProjectSettingsNames.PB_MODEL_TEXTS,
+            Json(
+                new ProjectReference { Name = "P", Id = "aabbcc" }, // unflagged -> skipped
+                new EnhancedResourceReference { Name = "Enh" } // non-Bible-text -> skipped
+            )
+        );
+
+        _provider.InitializeShownByDefaultOverlay();
+
+        Assert.That(_provider.GetShownByDefaultOverlay(), Is.Empty);
+    }
+
+    [Test]
+    public void Initialize_SubsequentOpen_IsNoOp_AndDoesNotClobber()
+    {
+        _provider.SetProjectSetting(
+            ProjectSettingsNames.PB_MODEL_TEXTS,
+            Json(
+                new ProjectReference
+                {
+                    Name = "P",
+                    Id = "aabbcc",
+                    IsResourceShownByDefault = true,
+                }
+            )
+        );
+        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.True);
+
+        // User un-checks the resource in their overlay.
+        _provider.SetShownByDefaultOverlay(
+            new Dictionary<string, bool> { ["aabbcc"] = false }.SerializeToJson()
+        );
+
+        // A later open must NOT re-init (must not re-check the user's un-check).
+        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.False);
+        Assert.That(_provider.GetShownByDefaultOverlay()["aabbcc"], Is.False);
+    }
+
+    [Test]
+    public void Initialize_AfterReset_ReInitializes()
+    {
+        _provider.SetProjectSetting(
+            ProjectSettingsNames.PB_MODEL_TEXTS,
+            Json(
+                new ProjectReference
+                {
+                    Name = "P",
+                    Id = "aabbcc",
+                    IsResourceShownByDefault = true,
+                }
+            )
+        );
+        _provider.InitializeShownByDefaultOverlay();
+        _provider.ResetShownByDefaultOverlay();
+
+        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.True);
+        Assert.That(_provider.GetShownByDefaultOverlay()["aabbcc"], Is.True);
+    }
+
+    [Test]
+    public void AutoPromote_UnparseableReferencedList_IsLeftUntouched()
+    {
+        // A future-major or corrupted stored value must never be clobbered by auto-promote
+        // (the downstream private S/R reader keys on the major version).
+        _scrText.Settings.ParametersDictionary[
+            ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES
+        ] = """2.0.0 {"dataVersion":"2.0.0","items":[{"type":"futureType","name":"F"}]}""";
+
+        _provider.SetProjectSetting(
+            ProjectSettingsNames.PB_MODEL_TEXTS,
+            Json(
+                new DblResourceReference
+                {
+                    Name = "D",
+                    Id = "112233445566",
+                    IsResourceShownByDefault = true,
+                }
+            )
+        );
+
+        string stored = _scrText.Settings.ParametersDictionary[
+            ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES
+        ];
+        Assert.That(stored, Does.StartWith("2.0.0 "));
+        Assert.That(stored, Does.Contain("futureType"));
+    }
+
+    [Test]
+    public void Initialize_ReadsFlagsFromReferencedProjectsAndResources()
+    {
+        // Regression guard: the init loop must read BOTH project-scope lists, not just ModelTexts.
+        _provider.SetProjectSetting(
+            ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
+            Json(
+                new DblResourceReference
+                {
+                    Name = "D",
+                    Id = "112233445566",
+                    IsResourceShownByDefault = true,
+                }
+            )
+        );
+
+        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.True);
+        Assert.That(_provider.GetShownByDefaultOverlay()["112233445566"], Is.True);
+    }
+}

--- a/c-sharp-tests/Projects/ResourceReferenceListSettingTests.cs
+++ b/c-sharp-tests/Projects/ResourceReferenceListSettingTests.cs
@@ -334,4 +334,70 @@ internal class ResourceReferenceListSettingTests : PapiTestBase
     }
 
     #endregion
+
+    #region Migration — old version reads, new version written back (PT-4050)
+
+    [TestCase(ProjectSettingsNames.PB_MODEL_TEXTS)]
+    [TestCase(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES)]
+    public void GetProjectSetting_OldVersionFileWithoutFlags_ReadsWithNullFlags(
+        string pbSettingName
+    )
+    {
+        string ptSettingName =
+            ProjectSettingsNames.GetParatextSettingNameFromPlatformBibleSettingName(pbSettingName)!;
+        // A 1.0.0 file with no flag keys — as written by an old build.
+        SetRawSetting(
+            ptSettingName,
+            """1.0.0 {"dataVersion":"1.0.0","items":[{"type":"project","name":"P","id":"aabbcc"}]}"""
+        );
+
+        var list = (ResourceReferenceList)_provider.GetProjectSetting(pbSettingName)!;
+        var item = (ProjectReference)list.Items[0];
+
+        Assert.That(item.IsResourceShownByDefault, Is.Null);
+        Assert.That(item.InTextCollectionUser, Is.Null);
+    }
+
+    [TestCase(ProjectSettingsNames.PB_MODEL_TEXTS)]
+    [TestCase(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES)]
+    public void SetProjectSetting_WritesBackCurrentFormatVersion(string pbSettingName)
+    {
+        string ptSettingName =
+            ProjectSettingsNames.GetParatextSettingNameFromPlatformBibleSettingName(pbSettingName)!;
+        SetRawSetting(
+            ptSettingName,
+            """1.0.0 {"dataVersion":"1.0.0","items":[{"type":"project","name":"P","id":"aabbcc"}]}"""
+        );
+
+        // Read the old file, then write it back unchanged.
+        var list = (ResourceReferenceList)_provider.GetProjectSetting(pbSettingName)!;
+        _provider.SetProjectSetting(pbSettingName, list.SerializeToJson());
+
+        string stored = _scrText.Settings.ParametersDictionary[ptSettingName];
+        Assert.That(stored, Does.StartWith("1.1.0 "));
+    }
+
+    [TestCase(ProjectSettingsNames.PB_MODEL_TEXTS)]
+    [TestCase(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES)]
+    public void SetThenGet_IsIdempotent_AcrossMigration(string pbSettingName)
+    {
+        string ptSettingName =
+            ProjectSettingsNames.GetParatextSettingNameFromPlatformBibleSettingName(pbSettingName)!;
+        SetRawSetting(
+            ptSettingName,
+            """1.0.0 {"dataVersion":"1.0.0","items":[{"type":"project","name":"P","id":"aabbcc"}]}"""
+        );
+
+        var first = (ResourceReferenceList)_provider.GetProjectSetting(pbSettingName)!;
+        _provider.SetProjectSetting(pbSettingName, first.SerializeToJson());
+        var second = (ResourceReferenceList)_provider.GetProjectSetting(pbSettingName)!;
+        _provider.SetProjectSetting(pbSettingName, second.SerializeToJson());
+        var third = (ResourceReferenceList)_provider.GetProjectSetting(pbSettingName)!;
+
+        Assert.That(third.Items, Has.Count.EqualTo(1));
+        Assert.That(((ProjectReference)third.Items[0]).Id, Is.EqualTo("aabbcc"));
+        Assert.That(((ProjectReference)third.Items[0]).IsResourceShownByDefault, Is.Null);
+    }
+
+    #endregion
 }

--- a/c-sharp-tests/Projects/ResourceReferenceListSettingTests.cs
+++ b/c-sharp-tests/Projects/ResourceReferenceListSettingTests.cs
@@ -355,7 +355,7 @@ internal class ResourceReferenceListSettingTests : PapiTestBase
         var item = (ProjectReference)list.Items[0];
 
         Assert.That(item.IsResourceShownByDefault, Is.Null);
-        Assert.That(item.InTextCollectionUser, Is.Null);
+        Assert.That(item.IsResourceShownForUser, Is.Null);
     }
 
     [TestCase(ProjectSettingsNames.PB_MODEL_TEXTS)]

--- a/c-sharp-tests/Projects/ResourceReferenceListTests.cs
+++ b/c-sharp-tests/Projects/ResourceReferenceListTests.cs
@@ -366,7 +366,7 @@ public class ResourceReferenceListTests
                     Name = "P",
                     Id = "aabbcc",
                     IsResourceShownByDefault = true,
-                    InTextCollectionUser = false,
+                    IsResourceShownForUser = false,
                 },
             ],
         };
@@ -374,7 +374,7 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as ProjectReference;
         Assert.That(item!.IsResourceShownByDefault, Is.True);
-        Assert.That(item.InTextCollectionUser, Is.False);
+        Assert.That(item.IsResourceShownForUser, Is.False);
     }
 
     [Test]
@@ -388,7 +388,7 @@ public class ResourceReferenceListTests
 
         // Old-build files must stay clean: unset flags are absent, not `false`.
         Assert.That(json, Does.Not.Contain("isResourceShownByDefault"));
-        Assert.That(json, Does.Not.Contain("inTextCollectionUser"));
+        Assert.That(json, Does.Not.Contain("isResourceShownForUser"));
     }
 
     [Test]
@@ -401,7 +401,7 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as ProjectReference;
         Assert.That(item!.IsResourceShownByDefault, Is.Null);
-        Assert.That(item.InTextCollectionUser, Is.Null);
+        Assert.That(item.IsResourceShownForUser, Is.Null);
     }
 
     [Test]
@@ -430,7 +430,7 @@ public class ResourceReferenceListTests
                     Name = "D",
                     Id = "112233445566",
                     IsResourceShownByDefault = false,
-                    InTextCollectionUser = true,
+                    IsResourceShownForUser = true,
                 },
             ],
         };
@@ -439,7 +439,7 @@ public class ResourceReferenceListTests
 
         var item = result.Items[0] as DblResourceReference;
         Assert.That(item!.IsResourceShownByDefault, Is.False);
-        Assert.That(item.InTextCollectionUser, Is.True);
+        Assert.That(item.IsResourceShownForUser, Is.True);
     }
 
     [Test]
@@ -453,7 +453,7 @@ public class ResourceReferenceListTests
         var itemEl = xml.Elements("Item").First();
 
         Assert.That(itemEl.Attribute("isResourceShownByDefault"), Is.Null);
-        Assert.That(itemEl.Attribute("inTextCollectionUser"), Is.Null);
+        Assert.That(itemEl.Attribute("isResourceShownForUser"), Is.Null);
     }
 
     [Test]
@@ -466,7 +466,7 @@ public class ResourceReferenceListTests
 
         var item = result.Items[0] as ProjectReference;
         Assert.That(item!.IsResourceShownByDefault, Is.Null);
-        Assert.That(item.InTextCollectionUser, Is.Null);
+        Assert.That(item.IsResourceShownForUser, Is.Null);
     }
 
     [Test]
@@ -499,19 +499,19 @@ public class ResourceReferenceListTests
     [Test]
     public void NamedOnlyType_PreservesBibleTextOnlyProperties_OnJsonRoundTrip()
     {
-        // A name-only type (enhancedResource) never natively handles "id" or "inTextCollectionUser"
+        // A name-only type (enhancedResource) never natively handles "id" or "isResourceShownForUser"
         // (both are Bible-text-only). A future build that attaches them must not have them silently
         // dropped: they flow through ExtraData (captured against the narrower
         // KnownNamedOnlyPropertyNames set) and are re-emitted. isResourceShownByDefault, by contrast,
         // is understood on every type, so it is a real field rather than a passthrough.
         const string json =
-            """{"dataVersion":"1.1.0","items":[{"type":"enhancedResource","name":"Enh","id":"keep-id","inTextCollectionUser":true}]}""";
+            """{"dataVersion":"1.1.0","items":[{"type":"enhancedResource","name":"Enh","id":"keep-id","isResourceShownForUser":true}]}""";
         var result = json.DeserializeFromJson<ResourceReferenceList>();
         Assert.That(result!.Items[0], Is.InstanceOf<EnhancedResourceReference>());
 
         string reSerialized = result.SerializeToJson();
         Assert.That(reSerialized, Does.Contain("keep-id"));
-        Assert.That(reSerialized, Does.Contain("inTextCollectionUser"));
+        Assert.That(reSerialized, Does.Contain("isResourceShownForUser"));
     }
 
     [Test]

--- a/c-sharp-tests/Projects/ResourceReferenceListTests.cs
+++ b/c-sharp-tests/Projects/ResourceReferenceListTests.cs
@@ -129,7 +129,15 @@ public class ResourceReferenceListTests
     {
         var list = new ResourceReferenceList
         {
-            Items = [new ProjectReference { Name = "My Project", Id = "aabbcc", IsResourceShownByDefault = true }],
+            Items =
+            [
+                new ProjectReference
+                {
+                    Name = "My Project",
+                    Id = "aabbcc",
+                    IsResourceShownByDefault = true,
+                },
+            ],
         };
         string json = list.SerializeToJson();
         var result = json.DeserializeFromJson<ResourceReferenceList>();
@@ -191,7 +199,10 @@ public class ResourceReferenceListTests
     {
         var list = new ResourceReferenceList
         {
-            Items = [new EnhancedResourceReference { Name = "BDAG", IsResourceShownByDefault = true }],
+            Items =
+            [
+                new EnhancedResourceReference { Name = "BDAG", IsResourceShownByDefault = true },
+            ],
         };
         string json = list.SerializeToJson();
         var result = json.DeserializeFromJson<ResourceReferenceList>();
@@ -206,7 +217,10 @@ public class ResourceReferenceListTests
     {
         var list = new ResourceReferenceList
         {
-            Items = [new XmlResourceReference { Name = "SomeXml", IsResourceShownByDefault = false }],
+            Items =
+            [
+                new XmlResourceReference { Name = "SomeXml", IsResourceShownByDefault = false },
+            ],
         };
         string json = list.SerializeToJson();
         var result = json.DeserializeFromJson<ResourceReferenceList>();
@@ -221,7 +235,14 @@ public class ResourceReferenceListTests
     {
         var list = new ResourceReferenceList
         {
-            Items = [new SourceLanguageResourceReference { Name = "Greek", IsResourceShownByDefault = true }],
+            Items =
+            [
+                new SourceLanguageResourceReference
+                {
+                    Name = "Greek",
+                    IsResourceShownByDefault = true,
+                },
+            ],
         };
         string json = list.SerializeToJson();
         var result = json.DeserializeFromJson<ResourceReferenceList>();
@@ -318,6 +339,195 @@ public class ResourceReferenceListTests
         Assert.That(result.Items[0], Is.InstanceOf<ProjectReference>());
         Assert.That(result.Items[1], Is.InstanceOf<EnhancedResourceReference>());
         Assert.That(result.Items[2], Is.InstanceOf<SourceLanguageResourceReference>());
+    }
+
+    #endregion
+
+    #region Serialization — two-flag schema (PT-4050)
+
+    [Test]
+    public void CurrentFormatAndDataVersion_AreMinor1_1()
+    {
+        Assert.That(ResourceReferenceList.CurrentFormatVersion, Is.EqualTo("1.1.0"));
+        Assert.That(ResourceReferenceList.CurrentDataVersion, Is.EqualTo("1.1.0"));
+        // Major MUST stay 1 — a downstream private S/R reader keys on it.
+        Assert.That(ResourceReferenceList.CurrentMajorVersion, Is.EqualTo(1));
+    }
+
+    [Test]
+    public void ProjectReference_WithBothFlags_RoundTripsThroughJson()
+    {
+        var list = new ResourceReferenceList
+        {
+            Items =
+            [
+                new ProjectReference
+                {
+                    Name = "P",
+                    Id = "aabbcc",
+                    IsResourceShownByDefault = true,
+                    InTextCollectionUser = false,
+                },
+            ],
+        };
+        var result = list.SerializeToJson().DeserializeFromJson<ResourceReferenceList>();
+
+        var item = result!.Items[0] as ProjectReference;
+        Assert.That(item!.IsResourceShownByDefault, Is.True);
+        Assert.That(item.InTextCollectionUser, Is.False);
+    }
+
+    [Test]
+    public void ResourceReference_WithNullFlags_OmitsAttributesFromJson()
+    {
+        var list = new ResourceReferenceList
+        {
+            Items = [new ProjectReference { Name = "P", Id = "aabbcc" }],
+        };
+        string json = list.SerializeToJson();
+
+        // Old-build files must stay clean: unset flags are absent, not `false`.
+        Assert.That(json, Does.Not.Contain("isResourceShownByDefault"));
+        Assert.That(json, Does.Not.Contain("inTextCollectionUser"));
+    }
+
+    [Test]
+    public void OldJson_WithoutFlags_DeserializesWithNullFlags()
+    {
+        // A file written by an old build (1.0.0, no flag keys) must read cleanly.
+        const string json =
+            """{"dataVersion":"1.0.0","items":[{"type":"project","name":"P","id":"aabbcc"}]}""";
+        var result = json.DeserializeFromJson<ResourceReferenceList>();
+
+        var item = result!.Items[0] as ProjectReference;
+        Assert.That(item!.IsResourceShownByDefault, Is.Null);
+        Assert.That(item.InTextCollectionUser, Is.Null);
+    }
+
+    [Test]
+    public void KnownType_PreservesUnknownJsonFields_OnReSerialize()
+    {
+        // Forward-compat: a build that doesn't know "futureFlag" must not drop it.
+        const string json =
+            """{"dataVersion":"1.1.0","items":[{"type":"project","name":"P","id":"aabbcc","futureFlag":123}]}""";
+        var result = json.DeserializeFromJson<ResourceReferenceList>();
+        string reSerialized = result!.SerializeToJson();
+
+        Assert.That(reSerialized, Does.Contain("futureFlag"));
+        Assert.That(reSerialized, Does.Contain("123"));
+    }
+
+    [Test]
+    public void ProjectReference_WithFlags_RoundTripsThroughXml()
+    {
+        var list = new ResourceReferenceList
+        {
+            DataVersion = ResourceReferenceList.CurrentDataVersion,
+            Items =
+            [
+                new DblResourceReference
+                {
+                    Name = "D",
+                    Id = "112233445566",
+                    IsResourceShownByDefault = false,
+                    InTextCollectionUser = true,
+                },
+            ],
+        };
+        var xml = ResourceReferenceList.ToXml(list);
+        var result = ResourceReferenceList.FromXml(xml, ResourceReferenceList.CurrentDataVersion);
+
+        var item = result.Items[0] as DblResourceReference;
+        Assert.That(item!.IsResourceShownByDefault, Is.False);
+        Assert.That(item.InTextCollectionUser, Is.True);
+    }
+
+    [Test]
+    public void Xml_WithNullFlags_OmitsAttributes()
+    {
+        var list = new ResourceReferenceList
+        {
+            Items = [new ProjectReference { Name = "P", Id = "aabbcc" }],
+        };
+        var xml = ResourceReferenceList.ToXml(list);
+        var itemEl = xml.Elements("Item").First();
+
+        Assert.That(itemEl.Attribute("isResourceShownByDefault"), Is.Null);
+        Assert.That(itemEl.Attribute("inTextCollectionUser"), Is.Null);
+    }
+
+    [Test]
+    public void OldXml_WithoutFlags_ParsesWithNullFlags()
+    {
+        var xml = System.Xml.Linq.XElement.Parse(
+            """<Items><Item type="project" name="P" id="aabbcc" /></Items>"""
+        );
+        var result = ResourceReferenceList.FromXml(xml, "1.0.0");
+
+        var item = result.Items[0] as ProjectReference;
+        Assert.That(item!.IsResourceShownByDefault, Is.Null);
+        Assert.That(item.InTextCollectionUser, Is.Null);
+    }
+
+    [Test]
+    public void KnownXmlItem_PreservesUnknownAttributes_OnXmlRoundTrip()
+    {
+        // Forward-compat: a build that doesn't know "futureAttr" must not drop it from XML.
+        var xml = System.Xml.Linq.XElement.Parse(
+            """<Items><Item type="project" name="P" id="aabbcc" futureAttr="keep-me" /></Items>"""
+        );
+        var list = ResourceReferenceList.FromXml(xml, "1.1.0");
+        var rewritten = ResourceReferenceList.ToXml(list);
+        var itemEl = rewritten.Elements("Item").First();
+
+        Assert.That(itemEl.Attribute("futureAttr")?.Value, Is.EqualTo("keep-me"));
+    }
+
+    [Test]
+    public void KnownJsonItem_WithBooleanExtra_EmitsLowercaseJsonTextInXml()
+    {
+        // A JSON-sourced boolean extra must not degrade to "True" on a JSON->XML transition.
+        const string json =
+            """{"dataVersion":"1.1.0","items":[{"type":"project","name":"P","id":"aabbcc","futureFlag":true}]}""";
+        var list = json.DeserializeFromJson<ResourceReferenceList>()!;
+        var xml = ResourceReferenceList.ToXml(list);
+        var itemEl = xml.Elements("Item").First();
+
+        Assert.That(itemEl.Attribute("futureFlag")?.Value, Is.EqualTo("true"));
+    }
+
+    [Test]
+    public void NamedOnlyType_PreservesBibleTextOnlyProperties_OnJsonRoundTrip()
+    {
+        // A name-only type (enhancedResource) never natively handles "id" or "inTextCollectionUser"
+        // (both are Bible-text-only). A future build that attaches them must not have them silently
+        // dropped: they flow through ExtraData (captured against the narrower
+        // KnownNamedOnlyPropertyNames set) and are re-emitted. isResourceShownByDefault, by contrast,
+        // is understood on every type, so it is a real field rather than a passthrough.
+        const string json =
+            """{"dataVersion":"1.1.0","items":[{"type":"enhancedResource","name":"Enh","id":"keep-id","inTextCollectionUser":true}]}""";
+        var result = json.DeserializeFromJson<ResourceReferenceList>();
+        Assert.That(result!.Items[0], Is.InstanceOf<EnhancedResourceReference>());
+
+        string reSerialized = result.SerializeToJson();
+        Assert.That(reSerialized, Does.Contain("keep-id"));
+        Assert.That(reSerialized, Does.Contain("inTextCollectionUser"));
+    }
+
+    [Test]
+    public void NamedOnlyType_PreservesBibleTextOnlyAttributes_OnXmlRoundTrip()
+    {
+        // Same passthrough guarantee for XML: an xmlResource carrying an "id" attribute (which this
+        // type does not natively handle) must survive an XML round-trip via ExtraData.
+        var xml = System.Xml.Linq.XElement.Parse(
+            """<Items><Item type="xmlResource" name="X" id="keep-id" /></Items>"""
+        );
+        var list = ResourceReferenceList.FromXml(xml, "1.1.0");
+        Assert.That(list.Items[0], Is.InstanceOf<XmlResourceReference>());
+
+        var rewritten = ResourceReferenceList.ToXml(list);
+        var itemEl = rewritten.Elements("Item").First();
+        Assert.That(itemEl.Attribute("id")?.Value, Is.EqualTo("keep-id"));
     }
 
     #endregion

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -2085,15 +2085,26 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     public bool SetShownByDefaultOverlay(object? value)
     {
         string? json = value?.ToString();
-        var map =
-            (
-                string.IsNullOrEmpty(json)
-                    ? null
-                    : json.DeserializeFromJson<Dictionary<string, bool>>()
-            )
-            ?? throw new InvalidDataException(
-                "ShownByDefaultOverlay value must be a JSON object map"
+        Dictionary<string, bool>? map;
+        try
+        {
+            // Deserialize inside try/catch so a wrong-SHAPE value (JSON array/number/string) surfaces
+            // the same InvalidDataException as a null/empty value, rather than leaking a raw
+            // JsonException. System.Text.Json throws for a shape mismatch and returns null only for a
+            // literal JSON null, so both failure modes must be funneled to one contract.
+            map = string.IsNullOrEmpty(json)
+                ? null
+                : json.DeserializeFromJson<Dictionary<string, bool>>();
+        }
+        catch (JsonException ex)
+        {
+            throw new InvalidDataException(
+                "ShownByDefaultOverlay value must be a JSON object map",
+                ex
             );
+        }
+        if (map is null)
+            throw new InvalidDataException("ShownByDefaultOverlay value must be a JSON object map");
         WriteOverlay(map);
         SendDataUpdateEvent(
             ProjectDataType.SHOWN_BY_DEFAULT_OVERLAY,

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1711,15 +1711,15 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             ProjectSettingsNames.GetParatextSettingNameFromPlatformBibleSettingName(settingName)
             ?? settingName;
 
-        // PROJECT-scope resource-reference-list settings carry the admin-only
-        // isResourceShownByDefault flag and drive auto-promote. Enforce the admin gate server-side
-        // (the UI-facing query is canUserWriteProjectTextConnectionSettings()). USER-scope writes
-        // (user lists, overlay, init) are intentionally UNGATED.
+        // The referenced-projects-and-resources list carries the admin-only isResourceShownByDefault
+        // flag (the shared shown-by-default default for the Scripture Text Grid), so its writes are
+        // gated to project administrators server-side (the UI-facing query is
+        // canUserWriteProjectTextConnectionSettings()). Model texts do NOT participate in
+        // shown-by-default and keep their pre-existing ungated behavior. USER-scope writes (user
+        // lists, overlay, init) are intentionally UNGATED.
         if (
-            (
-                paratextSettingName == ProjectSettingsNames.PT_MODEL_TEXTS
-                || paratextSettingName == ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES
-            ) && !IsUserProjectAdministrator()
+            paratextSettingName == ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES
+            && !IsUserProjectAdministrator()
         )
             throw new UnauthorizedAccessException(
                 $"Only project administrators may write '{settingName}'."
@@ -1832,11 +1832,6 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                                 $"{ResourceReferenceList.CurrentFormatVersion} {parsedList.SerializeToJson()}"
                             );
                             scrText.Settings.Save(false);
-                            AutoPromoteShownByDefaultResources(
-                                scrText,
-                                paratextSettingName,
-                                parsedList
-                            );
                             // Return here; SendDataUpdateEvent fires after the lock releases below.
                             return;
                         }
@@ -1968,7 +1963,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                 item with
                 {
                     IsResourceShownByDefault = null,
-                    InTextCollectionUser = null,
+                    IsResourceShownForUser = null,
                 }
             );
 

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -77,6 +77,10 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     private UserProjectSettings? _userProjectSettings;
     private string? _cachedUserId;
 
+    private const string OverlaySettingName = "ShownByDefaultOverlay";
+    private const string OverlayInitializedMarkerName = "ShownByDefaultOverlayInitialized";
+    private const string OverlaySchemaVersion = "1.0.0";
+
     #endregion
 
     #region Constructors
@@ -150,6 +154,10 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         retVal.Add(
             ("resetUserReferencedProjectsAndResources", ResetUserReferencedProjectsAndResources)
         );
+        retVal.Add(("getShownByDefaultOverlay", GetShownByDefaultOverlay));
+        retVal.Add(("setShownByDefaultOverlay", SetShownByDefaultOverlay));
+        retVal.Add(("resetShownByDefaultOverlay", ResetShownByDefaultOverlay));
+        retVal.Add(("initializeShownByDefaultOverlay", InitializeShownByDefaultOverlay));
         retVal.Add(
             ("canUserWriteProjectTextConnectionSettings", CanUserWriteProjectTextConnectionSettings)
         );
@@ -1697,6 +1705,26 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                 $"{ProjectSettingsNames.PB_IS_PUBLISHED} is a read-only computed setting."
             );
 
+        // Figure out which setting name to use (resolved early so the admin gate below can use it
+        // before the IsValid network round-trip — unauthorized writes are rejected immediately).
+        var paratextSettingName =
+            ProjectSettingsNames.GetParatextSettingNameFromPlatformBibleSettingName(settingName)
+            ?? settingName;
+
+        // PROJECT-scope resource-reference-list settings carry the admin-only
+        // isResourceShownByDefault flag and drive auto-promote. Enforce the admin gate server-side
+        // (the UI-facing query is canUserWriteProjectTextConnectionSettings()). USER-scope writes
+        // (user lists, overlay, init) are intentionally UNGATED.
+        if (
+            (
+                paratextSettingName == ProjectSettingsNames.PT_MODEL_TEXTS
+                || paratextSettingName == ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES
+            ) && !IsUserProjectAdministrator()
+        )
+            throw new UnauthorizedAccessException(
+                $"Only project administrators may write '{settingName}'."
+            );
+
         // If there is no Paratext setting for the name given, we'll create one lower down
         object? currentValue = null;
         try
@@ -1708,11 +1736,6 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         // Make sure the value we're planning to set is valid
         if (!ProjectSettingsService.IsValid(PapiClient, value, currentValue, settingName, ""))
             throw new InvalidDataException($"Validation failed for {settingName}");
-
-        // Figure out which setting name to use
-        var paratextSettingName =
-            ProjectSettingsNames.GetParatextSettingNameFromPlatformBibleSettingName(settingName)
-            ?? settingName;
 
         // Text direction comes from the project's ldml file, not from Settings.xml
         // We may add an LDML projectInterface one day where you can edit the LDML in the UI
@@ -1796,13 +1819,26 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
                                 ?? throw new InvalidDataException(
                                     $"Value for {settingName} could not be converted to a string"
                                 );
-                            var list =
+                            var parsedList =
                                 serialized.DeserializeFromJson<ResourceReferenceList>()
                                 ?? throw new InvalidDataException(
                                     $"Value for {settingName} could not be deserialized as a ResourceReferenceList"
                                 );
-                            value =
-                                $"{ResourceReferenceList.CurrentFormatVersion} {list.SerializeToJson()}";
+                            // Preserve the client-provided parsedList.DataVersion rather than
+                            // stamping CurrentDataVersion here — deliberate forward-compat: stamping
+                            // would silently minor-downgrade a newer body version from a future client.
+                            scrText.Settings.SetSetting(
+                                paratextSettingName,
+                                $"{ResourceReferenceList.CurrentFormatVersion} {parsedList.SerializeToJson()}"
+                            );
+                            scrText.Settings.Save(false);
+                            AutoPromoteShownByDefaultResources(
+                                scrText,
+                                paratextSettingName,
+                                parsedList
+                            );
+                            // Return here; SendDataUpdateEvent fires after the lock releases below.
+                            return;
                         }
                         else if (
                             ProjectSettingsNames.IsParatextSettingABoolean(paratextSettingName)
@@ -1859,6 +1895,153 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             ProjectSettingsService.GetDefault(PapiClient, settingName)
             ?? throw new InvalidDataException($"Default value for {settingName} was null");
         return SetProjectSetting(settingName, defaultValue);
+    }
+
+    /// <summary>
+    /// When <paramref name="writtenList"/> contains Bible-text references flagged
+    /// <c>IsResourceShownByDefault == true</c> that are not already present (by reference type + Id)
+    /// in PT_REFERENCED_PROJECTS_AND_RESOURCES, appends them to that list so the existing (private)
+    /// download path installs them. Idempotent; the appended copy carries no flags (it exists only to
+    /// drive download) and preserves the original <c>Name</c> (and any <c>ExtraData</c>).
+    /// <para>
+    /// Guard contract: if PT_REFERENCED_PROJECTS_AND_RESOURCES is present-but-unparseable (wrong
+    /// major version, missing version prefix, or corrupt JSON) the promote is skipped entirely with a
+    /// warning and the stored value is left untouched. Absent/empty stored values still mean "empty
+    /// list, proceed" (the normal first-promote case). This lenient-with-guard contract is
+    /// intentionally distinct from <see cref="GetProjectSetting"/>'s strict throwing contract —
+    /// promote is a best-effort background operation, while GetProjectSetting is a user-visible read
+    /// that must surface errors.
+    /// </para>
+    /// </summary>
+    private void AutoPromoteShownByDefaultResources(
+        ScrText scrText,
+        string writtenPtSettingName,
+        ResourceReferenceList writtenList
+    )
+    {
+        // Carry the full ResourceReference items (not just keys) so the promoted copy can preserve Name.
+        var flaggedItems = writtenList
+            .Items.Where(i =>
+                i.IsResourceShownByDefault == true && TryGetBibleTextKey(i) is not null
+            )
+            .ToList();
+        if (flaggedItems.Count == 0)
+            return;
+
+        if (
+            !TryReadRawResourceReferenceList(
+                scrText,
+                ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES,
+                out var referenced
+            )
+        )
+        {
+            Console.WriteLine(
+                $"AutoPromote skipped: {ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES} "
+                    + "is present but has an unrecognized major version or could not be deserialized. "
+                    + "The stored value has been left untouched."
+            );
+            return;
+        }
+
+        // Present = all items currently stored in PT_REFERENCED_PROJECTS_AND_RESOURCES.
+        // "referenced" already reflects the just-written value when writtenPtSettingName is
+        // PT_REFERENCED_PROJECTS_AND_RESOURCES (SetSetting+Save ran before this helper).
+        var present = new HashSet<(string, string)>();
+        foreach (var i in referenced.Items)
+        {
+            var key = TryGetBibleTextKey(i);
+            if (key is not null)
+                present.Add(key.Value);
+        }
+
+        var toAppend = flaggedItems
+            .Where(i => TryGetBibleTextKey(i) is (string, string) k && !present.Contains(k))
+            .ToList();
+        if (toAppend.Count == 0)
+            return;
+
+        var appended = referenced.Items.ToList();
+        foreach (var item in toAppend)
+            // Strip flags from the promoted copy: it exists only to drive download.
+            appended.Add(
+                item with
+                {
+                    IsResourceShownByDefault = null,
+                    InTextCollectionUser = null,
+                }
+            );
+
+        var updated = referenced with
+        {
+            Items = appended,
+            DataVersion = ResourceReferenceList.CurrentDataVersion,
+        };
+        scrText.Settings.SetSetting(
+            ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES,
+            $"{ResourceReferenceList.CurrentFormatVersion} {updated.SerializeToJson()}"
+        );
+        scrText.Settings.Save(false);
+    }
+
+    /// <summary>
+    /// Returns the (discriminant, Id) match key for a Bible-text reference
+    /// (<see cref="ProjectReference"/> = "project", <see cref="DblResourceReference"/> =
+    /// "dblResource"); <c>null</c> for all other reference types.
+    /// </summary>
+    private static (string type, string id)? TryGetBibleTextKey(ResourceReference item) =>
+        item switch
+        {
+            ProjectReference p => ("project", p.Id),
+            DblResourceReference d => ("dblResource", d.Id),
+            _ => null,
+        };
+
+    /// <summary>
+    /// Reads a project-scope resource-reference-list setting straight from ScrText settings.
+    /// Returns <c>true</c> with an empty list when absent/empty (normal first-promote case).
+    /// Returns <c>false</c> (leaving <paramref name="list"/> as <c>default</c>) when the stored
+    /// value is non-empty but (a) has no space-separated version prefix, (b) has an unparseable
+    /// version, (c) has a major version != <see cref="ResourceReferenceList.CurrentMajorVersion"/>,
+    /// or (d) fails JSON deserialization — so the caller can skip rather than clobber.
+    /// </summary>
+    private static bool TryReadRawResourceReferenceList(
+        ScrText scrText,
+        string ptSettingName,
+        out ResourceReferenceList list
+    )
+    {
+        if (
+            !scrText.Settings.ParametersDictionary.TryGetValue(ptSettingName, out string? stored)
+            || string.IsNullOrEmpty(stored)
+        )
+        {
+            list = new ResourceReferenceList();
+            return true;
+        }
+        int spaceIndex = stored.IndexOf(' ');
+        if (spaceIndex < 0)
+        {
+            list = default!;
+            return false;
+        }
+        string versionStr = stored[..spaceIndex];
+        if (
+            !System.Version.TryParse(versionStr, out var parsedVersion)
+            || parsedVersion.Major != ResourceReferenceList.CurrentMajorVersion
+        )
+        {
+            list = default!;
+            return false;
+        }
+        var deserialized = stored[(spaceIndex + 1)..].DeserializeFromJson<ResourceReferenceList>();
+        if (deserialized is null)
+        {
+            list = default!;
+            return false;
+        }
+        list = deserialized;
+        return true;
     }
 
     /// <summary>
@@ -2025,6 +2208,109 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         return true;
     }
 
+    public Dictionary<string, bool> GetShownByDefaultOverlay(object? param = null)
+    {
+        var (schemaVersion, content) = GetUserProjectSettings().GetSetting(OverlaySettingName);
+        if (content == null || string.IsNullOrEmpty(content.Value))
+            return [];
+        // Reject an overlay written by a future/incompatible build rather than silently
+        // deserializing it into the current shape (mirrors ValidateUserSettingVersion on the
+        // S/R'd lists). Absent/empty overlays above still mean "nothing stored, proceed".
+        ValidateOverlaySchemaVersion(schemaVersion);
+        return content.Value.DeserializeFromJson<Dictionary<string, bool>>() ?? [];
+    }
+
+    public bool SetShownByDefaultOverlay(object? value)
+    {
+        string? json = value?.ToString();
+        var map =
+            (
+                string.IsNullOrEmpty(json)
+                    ? null
+                    : json.DeserializeFromJson<Dictionary<string, bool>>()
+            )
+            ?? throw new InvalidDataException(
+                "ShownByDefaultOverlay value must be a JSON object map"
+            );
+        WriteOverlay(map);
+        SendDataUpdateEvent(
+            ProjectDataType.SHOWN_BY_DEFAULT_OVERLAY,
+            "shown-by-default overlay update event"
+        );
+        return true;
+    }
+
+    public bool ResetShownByDefaultOverlay()
+    {
+        // Full reset: forget the overlay AND the initialized marker so the next first-open re-inits
+        // from the current admin defaults.
+        GetUserProjectSettings().RemoveSetting(OverlaySettingName);
+        GetUserProjectSettings().RemoveSetting(OverlayInitializedMarkerName);
+        SendDataUpdateEvent(
+            ProjectDataType.SHOWN_BY_DEFAULT_OVERLAY,
+            "shown-by-default overlay reset event"
+        );
+        return true;
+    }
+
+    /// <summary>
+    /// First-open initialization of the current user's shown-by-default overlay for this project.
+    /// For each project-scope Bible-text reference whose <c>IsResourceShownByDefault</c> is set,
+    /// records overlay[resourceId] = that value. Idempotent: a per-user-per-project marker prevents
+    /// re-initialization, so later opens (and user un-checks) are preserved. Returns <c>false</c>
+    /// when already initialized. When a resource is flagged in both
+    /// <c>PT_MODEL_TEXTS</c> and <c>PT_REFERENCED_PROJECTS_AND_RESOURCES</c> with different values,
+    /// the <c>PT_REFERENCED_PROJECTS_AND_RESOURCES</c> value wins (iteration order).
+    /// </summary>
+    public bool InitializeShownByDefaultOverlay(object? param = null)
+    {
+        var settings = GetUserProjectSettings();
+        var (_, marker) = settings.GetSetting(OverlayInitializedMarkerName);
+        if (marker != null)
+            return false;
+
+        var overlay = GetShownByDefaultOverlay();
+        foreach (
+            var pbSettingName in new[]
+            {
+                ProjectSettingsNames.PB_MODEL_TEXTS,
+                ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
+            }
+        )
+        {
+            if (GetProjectSetting(pbSettingName) is not ResourceReferenceList list)
+                continue;
+            foreach (var item in list.Items)
+                if (
+                    item.IsResourceShownByDefault is bool shown
+                    && TryGetBibleTextKey(item) is (_, string id)
+                )
+                    overlay[id] = shown;
+        }
+
+        WriteOverlay(overlay);
+        settings.SetSetting(
+            OverlayInitializedMarkerName,
+            OverlaySchemaVersion,
+            new XElement("Items", "true")
+        );
+        SendDataUpdateEvent(
+            ProjectDataType.SHOWN_BY_DEFAULT_OVERLAY,
+            "shown-by-default overlay first-open init event"
+        );
+        return true;
+    }
+
+    private void WriteOverlay(Dictionary<string, bool> map)
+    {
+        GetUserProjectSettings()
+            .SetSetting(
+                OverlaySettingName,
+                OverlaySchemaVersion,
+                new XElement("Items", map.SerializeToJson())
+            );
+    }
+
     private UserProjectSettings GetUserProjectSettings()
     {
         var scrText = LocalParatextProjects.GetParatextProject(ProjectDetails.Metadata.Id);
@@ -2047,6 +2333,26 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             throw new InvalidDataException(
                 $"User setting '{settingName}' has incompatible major version {parsed.Major}; "
                     + $"expected {ResourceReferenceList.CurrentMajorVersion}"
+            );
+    }
+
+    /// <summary>
+    /// Validates the schema version stored alongside the shown-by-default overlay. The overlay has
+    /// its own version line (<see cref="OverlaySchemaVersion"/>), independent of the S/R'd resource
+    /// lists, so it is validated against that rather than
+    /// <see cref="ResourceReferenceList.CurrentMajorVersion"/>.
+    /// </summary>
+    private static void ValidateOverlaySchemaVersion(string? schemaVersion)
+    {
+        int expectedMajor = new Version(OverlaySchemaVersion).Major;
+        if (!Version.TryParse(schemaVersion, out Version? parsed))
+            throw new InvalidDataException(
+                $"Shown-by-default overlay has invalid version format: '{schemaVersion}'"
+            );
+        if (parsed.Major != expectedMajor)
+            throw new InvalidDataException(
+                $"Shown-by-default overlay has incompatible major version {parsed.Major}; "
+                    + $"expected {expectedMajor}"
             );
     }
 

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -77,8 +77,9 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     private UserProjectSettings? _userProjectSettings;
     private string? _cachedUserId;
 
-    private const string OverlaySettingName = "ShownByDefaultOverlay";
-    private const string OverlayInitializedMarkerName = "ShownByDefaultOverlayInitialized";
+    // Reference the shared data-type constant so the storage key and the data-type name can't drift.
+    private const string OverlaySettingName = ProjectDataType.SHOWN_BY_DEFAULT_OVERLAY;
+    private const string OverlayInitializedMarkerName = OverlaySettingName + "Initialized";
     private const string OverlaySchemaVersion = "1.0.0";
 
     #endregion
@@ -1893,93 +1894,6 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     }
 
     /// <summary>
-    /// When <paramref name="writtenList"/> contains Bible-text references flagged
-    /// <c>IsResourceShownByDefault == true</c> that are not already present (by reference type + Id)
-    /// in PT_REFERENCED_PROJECTS_AND_RESOURCES, appends them to that list so the existing (private)
-    /// download path installs them. Idempotent; the appended copy carries no flags (it exists only to
-    /// drive download) and preserves the original <c>Name</c> (and any <c>ExtraData</c>).
-    /// <para>
-    /// Guard contract: if PT_REFERENCED_PROJECTS_AND_RESOURCES is present-but-unparseable (wrong
-    /// major version, missing version prefix, or corrupt JSON) the promote is skipped entirely with a
-    /// warning and the stored value is left untouched. Absent/empty stored values still mean "empty
-    /// list, proceed" (the normal first-promote case). This lenient-with-guard contract is
-    /// intentionally distinct from <see cref="GetProjectSetting"/>'s strict throwing contract —
-    /// promote is a best-effort background operation, while GetProjectSetting is a user-visible read
-    /// that must surface errors.
-    /// </para>
-    /// </summary>
-    private void AutoPromoteShownByDefaultResources(
-        ScrText scrText,
-        string writtenPtSettingName,
-        ResourceReferenceList writtenList
-    )
-    {
-        // Carry the full ResourceReference items (not just keys) so the promoted copy can preserve Name.
-        var flaggedItems = writtenList
-            .Items.Where(i =>
-                i.IsResourceShownByDefault == true && TryGetBibleTextKey(i) is not null
-            )
-            .ToList();
-        if (flaggedItems.Count == 0)
-            return;
-
-        if (
-            !TryReadRawResourceReferenceList(
-                scrText,
-                ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES,
-                out var referenced
-            )
-        )
-        {
-            Console.WriteLine(
-                $"AutoPromote skipped: {ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES} "
-                    + "is present but has an unrecognized major version or could not be deserialized. "
-                    + "The stored value has been left untouched."
-            );
-            return;
-        }
-
-        // Present = all items currently stored in PT_REFERENCED_PROJECTS_AND_RESOURCES.
-        // "referenced" already reflects the just-written value when writtenPtSettingName is
-        // PT_REFERENCED_PROJECTS_AND_RESOURCES (SetSetting+Save ran before this helper).
-        var present = new HashSet<(string, string)>();
-        foreach (var i in referenced.Items)
-        {
-            var key = TryGetBibleTextKey(i);
-            if (key is not null)
-                present.Add(key.Value);
-        }
-
-        var toAppend = flaggedItems
-            .Where(i => TryGetBibleTextKey(i) is (string, string) k && !present.Contains(k))
-            .ToList();
-        if (toAppend.Count == 0)
-            return;
-
-        var appended = referenced.Items.ToList();
-        foreach (var item in toAppend)
-            // Strip flags from the promoted copy: it exists only to drive download.
-            appended.Add(
-                item with
-                {
-                    IsResourceShownByDefault = null,
-                    IsResourceShownForUser = null,
-                }
-            );
-
-        var updated = referenced with
-        {
-            Items = appended,
-            DataVersion = ResourceReferenceList.CurrentDataVersion,
-        };
-        scrText.Settings.SetSetting(
-            ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES,
-            $"{ResourceReferenceList.CurrentFormatVersion} {updated.SerializeToJson()}"
-        );
-        scrText.Settings.Save(false);
-    }
-
-    /// <summary>
     /// Returns the (discriminant, Id) match key for a Bible-text reference
     /// (<see cref="ProjectReference"/> = "project", <see cref="DblResourceReference"/> =
     /// "dblResource"); <c>null</c> for all other reference types.
@@ -1991,53 +1905,6 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             DblResourceReference d => ("dblResource", d.Id),
             _ => null,
         };
-
-    /// <summary>
-    /// Reads a project-scope resource-reference-list setting straight from ScrText settings.
-    /// Returns <c>true</c> with an empty list when absent/empty (normal first-promote case).
-    /// Returns <c>false</c> (leaving <paramref name="list"/> as <c>default</c>) when the stored
-    /// value is non-empty but (a) has no space-separated version prefix, (b) has an unparseable
-    /// version, (c) has a major version != <see cref="ResourceReferenceList.CurrentMajorVersion"/>,
-    /// or (d) fails JSON deserialization — so the caller can skip rather than clobber.
-    /// </summary>
-    private static bool TryReadRawResourceReferenceList(
-        ScrText scrText,
-        string ptSettingName,
-        out ResourceReferenceList list
-    )
-    {
-        if (
-            !scrText.Settings.ParametersDictionary.TryGetValue(ptSettingName, out string? stored)
-            || string.IsNullOrEmpty(stored)
-        )
-        {
-            list = new ResourceReferenceList();
-            return true;
-        }
-        int spaceIndex = stored.IndexOf(' ');
-        if (spaceIndex < 0)
-        {
-            list = default!;
-            return false;
-        }
-        string versionStr = stored[..spaceIndex];
-        if (
-            !System.Version.TryParse(versionStr, out var parsedVersion)
-            || parsedVersion.Major != ResourceReferenceList.CurrentMajorVersion
-        )
-        {
-            list = default!;
-            return false;
-        }
-        var deserialized = stored[(spaceIndex + 1)..].DeserializeFromJson<ResourceReferenceList>();
-        if (deserialized is null)
-        {
-            list = default!;
-            return false;
-        }
-        list = deserialized;
-        return true;
-    }
 
     /// <summary>
     /// Determines if the current user can write the project settings for "text connections"
@@ -2250,12 +2117,11 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
 
     /// <summary>
     /// First-open initialization of the current user's shown-by-default overlay for this project.
-    /// For each project-scope Bible-text reference whose <c>IsResourceShownByDefault</c> is set,
-    /// records overlay[resourceId] = that value. Idempotent: a per-user-per-project marker prevents
-    /// re-initialization, so later opens (and user un-checks) are preserved. Returns <c>false</c>
-    /// when already initialized. When a resource is flagged in both
-    /// <c>PT_MODEL_TEXTS</c> and <c>PT_REFERENCED_PROJECTS_AND_RESOURCES</c> with different values,
-    /// the <c>PT_REFERENCED_PROJECTS_AND_RESOURCES</c> value wins (iteration order).
+    /// For each Bible-text reference in <c>PT_REFERENCED_PROJECTS_AND_RESOURCES</c> whose
+    /// <c>IsResourceShownByDefault</c> is set, records overlay[resourceId] = that value. Idempotent:
+    /// a per-user-per-project marker prevents re-initialization, so later opens (and user un-checks)
+    /// are preserved. Returns <c>false</c> when already initialized. Model texts do NOT participate
+    /// in shown-by-default and are intentionally not read here.
     /// </summary>
     public bool InitializeShownByDefaultOverlay(object? param = null)
     {
@@ -2265,23 +2131,20 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             return false;
 
         var overlay = GetShownByDefaultOverlay();
-        foreach (
-            var pbSettingName in new[]
-            {
-                ProjectSettingsNames.PB_MODEL_TEXTS,
-                ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES,
-            }
+        if (
+            GetProjectSetting(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES)
+            is ResourceReferenceList list
         )
-        {
-            if (GetProjectSetting(pbSettingName) is not ResourceReferenceList list)
-                continue;
             foreach (var item in list.Items)
                 if (
                     item.IsResourceShownByDefault is bool shown
                     && TryGetBibleTextKey(item) is (_, string id)
                 )
+                    // Overlay is keyed by resource id only (matching the TS `{ [id]: boolean }`
+                    // shape), while Bible-text refs are dedup-keyed by (type, id). Safe because
+                    // project ids are 40-char hex and DBL ids 48-char hex, so ids never collide
+                    // across the two types; revisit this if a future ref type reuses id strings.
                     overlay[id] = shown;
-        }
 
         WriteOverlay(overlay);
         settings.SetSetting(
@@ -2296,6 +2159,10 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         return true;
     }
 
+    // The overlay is a flat { id -> bool } map, so it is stored as a JSON blob inside <Items> rather
+    // than as the structured XML the sibling user-list settings use (ResourceReferenceList.ToXml).
+    // Structured XML earns its keep for the resource-reference lists (nested, typed items); for a
+    // flat map it would add ceremony without benefit, and JSON round-trips the map directly.
     private void WriteOverlay(Dictionary<string, bool> map)
     {
         GetUserProjectSettings()

--- a/c-sharp/Projects/ProjectDataType.cs
+++ b/c-sharp/Projects/ProjectDataType.cs
@@ -10,10 +10,10 @@ public static class ProjectDataType
     public const string COMMENT_THREADS = "CommentThreads";
     public const string EXTENSION_DATA = "ExtensionData";
     public const string SETTING = "Setting";
+    public const string SHOWN_BY_DEFAULT_OVERLAY = "ShownByDefaultOverlay";
     public const string USER_MODEL_TEXTS = "UserModelTexts";
     public const string USER_REFERENCED_PROJECTS_AND_RESOURCES =
         "UserReferencedProjectsAndResources";
-    public const string SHOWN_BY_DEFAULT_OVERLAY = "ShownByDefaultOverlay";
     public const string USER_STRUCTURE_PROTECTED = "UserStructureProtected";
     public const string VERSE_USFM = "VerseUSFM";
     public const string VERSE_USX = "VerseUSX";

--- a/c-sharp/Projects/ProjectDataType.cs
+++ b/c-sharp/Projects/ProjectDataType.cs
@@ -13,6 +13,7 @@ public static class ProjectDataType
     public const string USER_MODEL_TEXTS = "UserModelTexts";
     public const string USER_REFERENCED_PROJECTS_AND_RESOURCES =
         "UserReferencedProjectsAndResources";
+    public const string SHOWN_BY_DEFAULT_OVERLAY = "ShownByDefaultOverlay";
     public const string USER_STRUCTURE_PROTECTED = "UserStructureProtected";
     public const string VERSE_USFM = "VerseUSFM";
     public const string VERSE_USX = "VerseUSX";

--- a/c-sharp/Projects/ResourceReferenceConverter.cs
+++ b/c-sharp/Projects/ResourceReferenceConverter.cs
@@ -22,34 +22,48 @@ internal sealed class ResourceReferenceConverter : JsonConverter<ResourceReferen
                 ? typeEl.GetString()
                 : null;
 
+        bool? shown = GetBool(root, "isResourceShownByDefault");
+        bool? inCollection = GetBool(root, "inTextCollectionUser");
+
+        // Capture extras against the per-type known-name set so name-only types don't silently
+        // swallow (and drop) a Bible-text-only property such as "id" or "inTextCollectionUser" —
+        // those flow through ExtraData instead. See ResourceReferenceList.Known*PropertyNames.
+        // isResourceShownByDefault is understood on every type (see PT-4040), so it is in both sets.
         return type switch
         {
             "project" => new ProjectReference
             {
                 Name = GetString(root, "name"),
                 Id = GetString(root, "id"),
-                IsResourceShownByDefault = GetNullableBool(root, "isResourceShownByDefault"),
+                IsResourceShownByDefault = shown,
+                InTextCollectionUser = inCollection,
+                ExtraData = CaptureExtras(root, ResourceReferenceList.KnownBibleTextPropertyNames),
             },
             "dblResource" => new DblResourceReference
             {
                 Name = GetString(root, "name"),
                 Id = GetString(root, "id"),
-                IsResourceShownByDefault = GetNullableBool(root, "isResourceShownByDefault"),
+                IsResourceShownByDefault = shown,
+                InTextCollectionUser = inCollection,
+                ExtraData = CaptureExtras(root, ResourceReferenceList.KnownBibleTextPropertyNames),
             },
             "enhancedResource" => new EnhancedResourceReference
             {
                 Name = GetString(root, "name"),
-                IsResourceShownByDefault = GetNullableBool(root, "isResourceShownByDefault"),
+                IsResourceShownByDefault = shown,
+                ExtraData = CaptureExtras(root, ResourceReferenceList.KnownNamedOnlyPropertyNames),
             },
             "xmlResource" => new XmlResourceReference
             {
                 Name = GetString(root, "name"),
-                IsResourceShownByDefault = GetNullableBool(root, "isResourceShownByDefault"),
+                IsResourceShownByDefault = shown,
+                ExtraData = CaptureExtras(root, ResourceReferenceList.KnownNamedOnlyPropertyNames),
             },
             "sourceLanguageResource" => new SourceLanguageResourceReference
             {
                 Name = GetString(root, "name"),
-                IsResourceShownByDefault = GetNullableBool(root, "isResourceShownByDefault"),
+                IsResourceShownByDefault = shown,
+                ExtraData = CaptureExtras(root, ResourceReferenceList.KnownNamedOnlyPropertyNames),
             },
             _ => CreateUnknown(root),
         };
@@ -60,16 +74,22 @@ internal sealed class ResourceReferenceConverter : JsonConverter<ResourceReferen
             ? prop.GetString() ?? ""
             : "";
 
-    private static bool? GetNullableBool(JsonElement element, string propertyName)
+    private static bool? GetBool(JsonElement element, string propertyName) =>
+        element.TryGetProperty(propertyName, out var prop)
+        && prop.ValueKind is JsonValueKind.True or JsonValueKind.False
+            ? prop.GetBoolean()
+            : null;
+
+    private static Dictionary<string, JsonElement>? CaptureExtras(
+        JsonElement root,
+        IReadOnlySet<string> knownProps
+    )
     {
-        if (!element.TryGetProperty(propertyName, out var prop))
-            return null;
-        return prop.ValueKind switch
-        {
-            JsonValueKind.True => true,
-            JsonValueKind.False => false,
-            _ => null,
-        };
+        var extras = new Dictionary<string, JsonElement>();
+        foreach (var prop in root.EnumerateObject())
+            if (!knownProps.Contains(prop.Name))
+                extras[prop.Name] = prop.Value.Clone();
+        return extras.Count > 0 ? extras : null;
     }
 
     private static UnknownResourceReference CreateUnknown(JsonElement root)
@@ -97,39 +117,46 @@ internal sealed class ResourceReferenceConverter : JsonConverter<ResourceReferen
             // ExtraData holds all original properties; write them back verbatim to avoid
             // injecting properties (e.g. "name":"") that were absent in the original JSON.
             if (unknown.ExtraData is not null)
-            {
                 foreach (var kvp in unknown.ExtraData)
                 {
                     writer.WritePropertyName(kvp.Key);
                     kvp.Value.WriteTo(writer);
                 }
-            }
+            writer.WriteEndObject();
+            return;
         }
-        else
+
+        string discriminant = value switch
         {
-            string discriminant = value switch
+            ProjectReference => "project",
+            DblResourceReference => "dblResource",
+            EnhancedResourceReference => "enhancedResource",
+            XmlResourceReference => "xmlResource",
+            SourceLanguageResourceReference => "sourceLanguageResource",
+            _ => throw new JsonException(
+                $"Unhandled ResourceReference type: {value.GetType().Name}"
+            ),
+        };
+        writer.WriteString("type", discriminant);
+        writer.WriteString("name", value.Name);
+        if (value is ProjectReference proj)
+            writer.WriteString("id", proj.Id);
+        else if (value is DblResourceReference dbl)
+            writer.WriteString("id", dbl.Id);
+
+        // Emit the two flags only when set, so old-build files stay clean.
+        if (value.IsResourceShownByDefault is bool shownVal)
+            writer.WriteBoolean("isResourceShownByDefault", shownVal);
+        if (value.InTextCollectionUser is bool inCollectionVal)
+            writer.WriteBoolean("inTextCollectionUser", inCollectionVal);
+
+        // Forward-compat: re-emit unknown properties captured on read.
+        if (value.ExtraData is not null)
+            foreach (var kvp in value.ExtraData)
             {
-                ProjectReference => "project",
-                DblResourceReference => "dblResource",
-                EnhancedResourceReference => "enhancedResource",
-                XmlResourceReference => "xmlResource",
-                SourceLanguageResourceReference => "sourceLanguageResource",
-                _ => throw new JsonException(
-                    $"Unhandled ResourceReference type: {value.GetType().Name}"
-                ),
-            };
-            writer.WriteString("type", discriminant);
-            writer.WriteString("name", value.Name);
-            if (value is ProjectReference proj)
-                writer.WriteString("id", proj.Id);
-            else if (value is DblResourceReference dbl)
-                writer.WriteString("id", dbl.Id);
-            if (value.IsResourceShownByDefault.HasValue)
-                writer.WriteBoolean(
-                    "isResourceShownByDefault",
-                    value.IsResourceShownByDefault.Value
-                );
-        }
+                writer.WritePropertyName(kvp.Key);
+                kvp.Value.WriteTo(writer);
+            }
 
         writer.WriteEndObject();
     }

--- a/c-sharp/Projects/ResourceReferenceConverter.cs
+++ b/c-sharp/Projects/ResourceReferenceConverter.cs
@@ -23,10 +23,10 @@ internal sealed class ResourceReferenceConverter : JsonConverter<ResourceReferen
                 : null;
 
         bool? shown = GetBool(root, "isResourceShownByDefault");
-        bool? inCollection = GetBool(root, "inTextCollectionUser");
+        bool? shownForUser = GetBool(root, "isResourceShownForUser");
 
         // Capture extras against the per-type known-name set so name-only types don't silently
-        // swallow (and drop) a Bible-text-only property such as "id" or "inTextCollectionUser" —
+        // swallow (and drop) a Bible-text-only property such as "id" or "isResourceShownForUser" —
         // those flow through ExtraData instead. See ResourceReferenceList.Known*PropertyNames.
         // isResourceShownByDefault is understood on every type (see PT-4040), so it is in both sets.
         return type switch
@@ -36,7 +36,7 @@ internal sealed class ResourceReferenceConverter : JsonConverter<ResourceReferen
                 Name = GetString(root, "name"),
                 Id = GetString(root, "id"),
                 IsResourceShownByDefault = shown,
-                InTextCollectionUser = inCollection,
+                IsResourceShownForUser = shownForUser,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownBibleTextPropertyNames),
             },
             "dblResource" => new DblResourceReference
@@ -44,7 +44,7 @@ internal sealed class ResourceReferenceConverter : JsonConverter<ResourceReferen
                 Name = GetString(root, "name"),
                 Id = GetString(root, "id"),
                 IsResourceShownByDefault = shown,
-                InTextCollectionUser = inCollection,
+                IsResourceShownForUser = shownForUser,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownBibleTextPropertyNames),
             },
             "enhancedResource" => new EnhancedResourceReference
@@ -147,8 +147,8 @@ internal sealed class ResourceReferenceConverter : JsonConverter<ResourceReferen
         // Emit the two flags only when set, so old-build files stay clean.
         if (value.IsResourceShownByDefault is bool shownVal)
             writer.WriteBoolean("isResourceShownByDefault", shownVal);
-        if (value.InTextCollectionUser is bool inCollectionVal)
-            writer.WriteBoolean("inTextCollectionUser", inCollectionVal);
+        if (value.IsResourceShownForUser is bool shownForUserVal)
+            writer.WriteBoolean("isResourceShownForUser", shownForUserVal);
 
         // Forward-compat: re-emit unknown properties captured on read.
         if (value.ExtraData is not null)

--- a/c-sharp/Projects/ResourceReferenceList.cs
+++ b/c-sharp/Projects/ResourceReferenceList.cs
@@ -22,7 +22,7 @@ public abstract record ResourceReference
     /// resources list. Nullable/absent by default; meaningful only for Bible-text references.
     /// Serialized only when non-null.
     /// </summary>
-    public bool? InTextCollectionUser { get; init; }
+    public bool? IsResourceShownForUser { get; init; }
 
     /// <summary>
     /// Forward-compat passthrough for JSON/XML properties this build does not recognize, so a
@@ -82,7 +82,7 @@ public record ResourceReferenceList
         "name",
         "id",
         "isResourceShownByDefault",
-        "inTextCollectionUser",
+        "isResourceShownForUser",
     };
 
     /// <summary>
@@ -90,7 +90,7 @@ public record ResourceReferenceList
     /// (<see cref="EnhancedResourceReference"/>, <see cref="XmlResourceReference"/>,
     /// <see cref="SourceLanguageResourceReference"/>). Narrower than
     /// <see cref="KnownBibleTextPropertyNames"/> because these types never carry <c>id</c> or
-    /// <c>inTextCollectionUser</c>; properties outside this set flow through
+    /// <c>isResourceShownForUser</c>; properties outside this set flow through
     /// <see cref="ResourceReference.ExtraData"/>. Includes <c>isResourceShownByDefault</c>, which is
     /// understood on every reference type (see PT-4040).
     /// </summary>
@@ -156,9 +156,9 @@ public record ResourceReferenceList
                     element.Add(
                         new XAttribute("isResourceShownByDefault", shown ? "true" : "false")
                     );
-                if (item.InTextCollectionUser is bool inCollection)
+                if (item.IsResourceShownForUser is bool shownForUser)
                     element.Add(
-                        new XAttribute("inTextCollectionUser", inCollection ? "true" : "false")
+                        new XAttribute("isResourceShownForUser", shownForUser ? "true" : "false")
                     );
 
                 AddExtraDataAttributes(element, item.ExtraData);
@@ -214,7 +214,7 @@ public record ResourceReferenceList
 
                 // Capture unknown attributes against the per-type known-name set (everything else ->
                 // ExtraData). Name-only types use the narrower set so a Bible-text-only attribute such
-                // as "id" or "inTextCollectionUser" round-trips instead of being silently dropped.
+                // as "id" or "isResourceShownForUser" round-trips instead of being silently dropped.
                 static Dictionary<string, JsonElement>? CaptureExtras(
                     XElement el,
                     IReadOnlySet<string> known
@@ -237,7 +237,7 @@ public record ResourceReferenceList
                             Name = name,
                             Id = el.Attribute("id")?.Value ?? "",
                             IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
-                            InTextCollectionUser = ParseFlag(el, "inTextCollectionUser"),
+                            IsResourceShownForUser = ParseFlag(el, "isResourceShownForUser"),
                             ExtraData = CaptureExtras(el, KnownBibleTextPropertyNames),
                         },
                         "dblResource" => new DblResourceReference
@@ -245,7 +245,7 @@ public record ResourceReferenceList
                             Name = name,
                             Id = el.Attribute("id")?.Value ?? "",
                             IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
-                            InTextCollectionUser = ParseFlag(el, "inTextCollectionUser"),
+                            IsResourceShownForUser = ParseFlag(el, "isResourceShownForUser"),
                             ExtraData = CaptureExtras(el, KnownBibleTextPropertyNames),
                         },
                         "enhancedResource" => new EnhancedResourceReference

--- a/c-sharp/Projects/ResourceReferenceList.cs
+++ b/c-sharp/Projects/ResourceReferenceList.cs
@@ -10,10 +10,32 @@ public abstract record ResourceReference
     public string Name { get; init; } = string.Empty;
 
     /// <summary>
-    /// When set by a project admin, indicates this resource should be shown by default
-    /// when the shared layout is applied. Null means no admin preference is set.
+    /// Project-scope (Send/Receive'd) admin flag: when set, this resource is shown by default.
+    /// Consumed by the shared layout (PT-4040) and, for Bible-text resources, by the Scripture Text
+    /// Grid, where it also seeds new users' per-user overlay on first open (PT-4050). Understood on
+    /// every reference type; null/absent means no admin preference. Serialized only when non-null.
     /// </summary>
     public bool? IsResourceShownByDefault { get; init; }
+
+    /// <summary>
+    /// User-scope (NOT Send/Receive'd) per-resource checkbox state on the current user's personal
+    /// resources list. Nullable/absent by default; meaningful only for Bible-text references.
+    /// Serialized only when non-null.
+    /// </summary>
+    public bool? InTextCollectionUser { get; init; }
+
+    /// <summary>
+    /// Forward-compat passthrough for JSON/XML properties this build does not recognize, so a
+    /// re-serialize preserves them instead of dropping them. Because <see cref="ResourceReference"/>
+    /// uses a custom <see cref="ResourceReferenceConverter"/>, <c>[JsonExtensionData]</c> is not
+    /// honored automatically — the converter captures/rewrites these manually.
+    /// </summary>
+    /// <remarks>
+    /// TRANSITION-WINDOW RISK: builds released before this field existed have no passthrough, so
+    /// during a mixed-version rollout an old build can still drop the new flags on write-back. This
+    /// is inherent to introducing passthrough and cannot be fixed in already-shipped builds.
+    /// </remarks>
+    public Dictionary<string, JsonElement>? ExtraData { get; init; }
 }
 
 public record ProjectReference : ResourceReference
@@ -37,10 +59,7 @@ public record SourceLanguageResourceReference : ResourceReference { }
 /// of the software. All JSON properties are preserved via <c>ExtraData</c> so the item
 /// can be round-tripped back to storage without data loss.
 /// </summary>
-public record UnknownResourceReference : ResourceReference
-{
-    public Dictionary<string, JsonElement>? ExtraData { get; init; }
-}
+public record UnknownResourceReference : ResourceReference { }
 
 public record ResourceReferenceList
 {
@@ -52,10 +71,41 @@ public record ResourceReferenceList
     public const int CurrentMajorVersion = 1;
 
     /// <summary>
-    /// Full storage format version written as a prefix before the JSON body when saving
-    /// (e.g. <c>1.0.0 {"dataVersion":"1.0.0","items":[...]}</c>). Not serialized into the JSON body.
+    /// JSON/XML property names that this build explicitly handles for Bible-text reference types
+    /// (<see cref="ProjectReference"/> and <see cref="DblResourceReference"/>). Any property NOT in
+    /// this set flows through to <see cref="ResourceReference.ExtraData"/> for forward-compat
+    /// round-tripping.
     /// </summary>
-    public const string CurrentFormatVersion = "1.0.0";
+    internal static readonly IReadOnlySet<string> KnownBibleTextPropertyNames = new HashSet<string>
+    {
+        "type",
+        "name",
+        "id",
+        "isResourceShownByDefault",
+        "inTextCollectionUser",
+    };
+
+    /// <summary>
+    /// JSON/XML property names that this build explicitly handles for name-only reference types
+    /// (<see cref="EnhancedResourceReference"/>, <see cref="XmlResourceReference"/>,
+    /// <see cref="SourceLanguageResourceReference"/>). Narrower than
+    /// <see cref="KnownBibleTextPropertyNames"/> because these types never carry <c>id</c> or
+    /// <c>inTextCollectionUser</c>; properties outside this set flow through
+    /// <see cref="ResourceReference.ExtraData"/>. Includes <c>isResourceShownByDefault</c>, which is
+    /// understood on every reference type (see PT-4040).
+    /// </summary>
+    internal static readonly IReadOnlySet<string> KnownNamedOnlyPropertyNames = new HashSet<string>
+    {
+        "type",
+        "name",
+        "isResourceShownByDefault",
+    };
+
+    /// <summary>
+    /// Full storage format version written as a prefix before the JSON body when saving
+    /// (e.g. <c>1.1.0 {"dataVersion":"1.1.0","items":[...]}</c>). Not serialized into the JSON body.
+    /// </summary>
+    public const string CurrentFormatVersion = "1.1.0";
 
     /// <summary>
     /// Current data schema version written into the JSON body alongside <c>items</c>. Distinct from
@@ -63,7 +113,7 @@ public record ResourceReferenceList
     /// version describes the semantics of the <c>items</c> content. The patch digit may be
     /// downgraded; major and minor downgrades are rejected by the TypeScript validator.
     /// </summary>
-    public const string CurrentDataVersion = "1.0.0";
+    public const string CurrentDataVersion = "1.1.0";
 
     [JsonPropertyName("dataVersion")]
     public string DataVersion { get; init; } = CurrentDataVersion;
@@ -80,13 +130,10 @@ public record ResourceReferenceList
             {
                 if (item is UnknownResourceReference unknown)
                 {
-                    // Rebuild all original attributes from ExtraData to avoid data loss
-                    var attrs =
-                        unknown.ExtraData?.Select(kvp => new XAttribute(
-                            kvp.Key,
-                            kvp.Value.ToString() ?? ""
-                        )) ?? [];
-                    return new XElement("Item", attrs);
+                    // Rebuild all original attributes from ExtraData to avoid data loss.
+                    var unknownElement = new XElement("Item");
+                    AddExtraDataAttributes(unknownElement, unknown.ExtraData);
+                    return unknownElement;
                 }
 
                 string type = GetXmlType(item);
@@ -102,21 +149,48 @@ public record ResourceReferenceList
                 else if (item is DblResourceReference dbl)
                     element.Add(new XAttribute("id", dbl.Id));
 
-                // XML attributes are untyped strings; booleans are emitted as "true"/"false"
-                // (lowercase) and parsed back with bool.TryParse. The JSON path uses a native
-                // JSON boolean via WriteBoolean/JsonValueKind — the difference is inherent to
-                // the respective serialization formats.
-                if (item.IsResourceShownByDefault.HasValue)
+                // Write the two flags only when set, so old-build files stay clean. XML attributes
+                // are untyped strings; booleans are emitted lowercase and parsed back with
+                // bool.TryParse (the JSON path uses a native JSON boolean instead).
+                if (item.IsResourceShownByDefault is bool shown)
                     element.Add(
-                        new XAttribute(
-                            "isResourceShownByDefault",
-                            item.IsResourceShownByDefault.Value.ToString().ToLowerInvariant()
-                        )
+                        new XAttribute("isResourceShownByDefault", shown ? "true" : "false")
                     );
+                if (item.InTextCollectionUser is bool inCollection)
+                    element.Add(
+                        new XAttribute("inTextCollectionUser", inCollection ? "true" : "false")
+                    );
+
+                AddExtraDataAttributes(element, item.ExtraData);
 
                 return element;
             })
         );
+    }
+
+    /// <summary>
+    /// Appends each <paramref name="extraData"/> entry to <paramref name="element"/> as an
+    /// <see cref="XAttribute"/>. Strings emit their raw value; other JSON kinds emit their JSON text
+    /// (e.g. <c>true</c>, <c>123</c>) so casing survives a JSON-&gt;XML transition. XML attributes
+    /// carry no type info, so non-string extras still become strings on the next
+    /// <see cref="FromXml"/> read (same limitation documented on <see cref="FromXml"/>).
+    /// </summary>
+    private static void AddExtraDataAttributes(
+        XElement element,
+        IReadOnlyDictionary<string, JsonElement>? extraData
+    )
+    {
+        if (extraData is null)
+            return;
+        foreach (var kvp in extraData)
+            element.Add(
+                new XAttribute(
+                    kvp.Key,
+                    kvp.Value.ValueKind == JsonValueKind.String
+                        ? kvp.Value.GetString() ?? ""
+                        : kvp.Value.GetRawText()
+                )
+            );
     }
 
     /// <summary>Deserializes a <see cref="ResourceReferenceList"/> from an <c>&lt;Items&gt;</c> XElement.</summary>
@@ -135,6 +209,26 @@ public record ResourceReferenceList
                 string type = el.Attribute("type")?.Value ?? "";
                 string name = el.Attribute("name")?.Value ?? "";
 
+                static bool? ParseFlag(XElement el, string attr) =>
+                    bool.TryParse(el.Attribute(attr)?.Value, out bool v) ? v : null;
+
+                // Capture unknown attributes against the per-type known-name set (everything else ->
+                // ExtraData). Name-only types use the narrower set so a Bible-text-only attribute such
+                // as "id" or "inTextCollectionUser" round-trips instead of being silently dropped.
+                static Dictionary<string, JsonElement>? CaptureExtras(
+                    XElement el,
+                    IReadOnlySet<string> known
+                )
+                {
+                    var extras = el.Attributes()
+                        .Where(a => !known.Contains(a.Name.LocalName))
+                        .ToDictionary(
+                            a => a.Name.LocalName,
+                            a => JsonSerializer.SerializeToElement(a.Value)
+                        );
+                    return extras.Count > 0 ? extras : null;
+                }
+
                 return (ResourceReference)(
                     type switch
                     {
@@ -142,43 +236,35 @@ public record ResourceReferenceList
                         {
                             Name = name,
                             Id = el.Attribute("id")?.Value ?? "",
-                            IsResourceShownByDefault = GetNullableBoolAttribute(
-                                el,
-                                "isResourceShownByDefault"
-                            ),
+                            IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
+                            InTextCollectionUser = ParseFlag(el, "inTextCollectionUser"),
+                            ExtraData = CaptureExtras(el, KnownBibleTextPropertyNames),
                         },
                         "dblResource" => new DblResourceReference
                         {
                             Name = name,
                             Id = el.Attribute("id")?.Value ?? "",
-                            IsResourceShownByDefault = GetNullableBoolAttribute(
-                                el,
-                                "isResourceShownByDefault"
-                            ),
+                            IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
+                            InTextCollectionUser = ParseFlag(el, "inTextCollectionUser"),
+                            ExtraData = CaptureExtras(el, KnownBibleTextPropertyNames),
                         },
                         "enhancedResource" => new EnhancedResourceReference
                         {
                             Name = name,
-                            IsResourceShownByDefault = GetNullableBoolAttribute(
-                                el,
-                                "isResourceShownByDefault"
-                            ),
+                            IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
+                            ExtraData = CaptureExtras(el, KnownNamedOnlyPropertyNames),
                         },
                         "xmlResource" => new XmlResourceReference
                         {
                             Name = name,
-                            IsResourceShownByDefault = GetNullableBoolAttribute(
-                                el,
-                                "isResourceShownByDefault"
-                            ),
+                            IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
+                            ExtraData = CaptureExtras(el, KnownNamedOnlyPropertyNames),
                         },
                         "sourceLanguageResource" => new SourceLanguageResourceReference
                         {
                             Name = name,
-                            IsResourceShownByDefault = GetNullableBoolAttribute(
-                                el,
-                                "isResourceShownByDefault"
-                            ),
+                            IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
+                            ExtraData = CaptureExtras(el, KnownNamedOnlyPropertyNames),
                         },
                         _ => new UnknownResourceReference
                         {
@@ -186,7 +272,7 @@ public record ResourceReferenceList
                             ExtraData = el.Attributes()
                                 .ToDictionary(
                                     a => a.Name.LocalName,
-                                    a => System.Text.Json.JsonSerializer.SerializeToElement(a.Value)
+                                    a => JsonSerializer.SerializeToElement(a.Value)
                                 ),
                         },
                     }
@@ -196,9 +282,6 @@ public record ResourceReferenceList
 
         return new ResourceReferenceList { Items = items, DataVersion = dataVersion };
     }
-
-    private static bool? GetNullableBoolAttribute(XElement el, string name) =>
-        bool.TryParse(el.Attribute(name)?.Value, out var value) ? value : null;
 
     private static string GetXmlType(ResourceReference item) =>
         item switch

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -40,9 +40,10 @@ const config = defineConfig({
     },
     {
       // Local-only - NOT wired into CI's `test:e2e:smoke`. The ER tests need real
-      // Marble resources (e.g., ESV16UK+) which are not available in CI. Run locally:
-      //   ./.erb/scripts/refresh.sh    # boot the app once with CDP enabled
-      //   npm run test:e2e:enhanced-resources
+      // Marble resources (e.g., ESV16UK+) which are not available in CI. There is no dedicated
+      // npm script; run the project directly (after booting the app once with CDP enabled):
+      //   ./.erb/scripts/refresh.sh
+      //   npx playwright test --config e2e-tests/playwright.config.ts --project=enhanced-resources
       name: 'enhanced-resources',
       testDir: './tests/enhanced-resources',
     },

--- a/e2e-tests/tests/enhanced-resources/shown-by-default-schema.spec.ts
+++ b/e2e-tests/tests/enhanced-resources/shown-by-default-schema.spec.ts
@@ -1,17 +1,19 @@
 /**
  * E2E checks for the PT-4050 (A2) two-flag schema + overlay init + admin gate.
  *
+ * MANUAL-ONLY: this spec does not run in CI. It lives in the `enhanced-resources` Playwright
+ * project (not the CI `smoke` run) and is `test.skip`-gated on `E2E_TEST_PROJECT_ID`, which is set
+ * nowhere in the repo. To run it locally, boot the app with CDP enabled, set `E2E_TEST_PROJECT_ID`
+ * to a known editable admin project, and run the `enhanced-resources` project (see the run command
+ * in `e2e-tests/playwright.config.ts`). Regression protection for this feature comes from the C#
+ * unit tests (ParatextProjectDataProviderShownByDefaultTests); this spec is a manual smoke check.
+ *
  * Scope — vanilla-core-observable only:
  *
- * - `isResourceShownByDefault` persists through the project setting round-trip.
+ * - `isResourceShownByDefault` persists through the referenced-resources setting round-trip.
  * - First-open init writes the per-user overlay to match the project's flags.
- * - The admin gate on the project-scope write is enforced server-side; it is covered by C# unit tests
- *   (ParatextProjectDataProviderShownByDefaultTests), not asserted here — this fixture runs as the
- *   default (admin) user.
- *
- * NOT covered here (requires the PRIVATE Send/Receive auto-download patch, which vanilla core does
- * not include — verified manually in the Studio build): the real DBL auto-download that the
- * auto-promoted Referenced entry triggers. See PT-4050 DoD "verified in the Studio build".
+ * - The admin gate on the referenced-resources write is enforced server-side; it is covered by the C#
+ *   unit tests, not asserted here — this fixture runs as the default (admin) user.
  */
 import { test, expect } from '../../fixtures/cdp.fixture';
 import { waitForAppReady } from '../../fixtures/helpers';
@@ -44,8 +46,8 @@ test.describe('Scripture Text Grid shown-by-default schema (A2)', () => {
               projectId: string,
             ) => Promise<{
               setSetting: (key: string, value: unknown) => Promise<boolean>;
-              // This test only reads `platformScripture.modelTexts`, so narrow the return here
-              // to that shape. This lets the assertions below avoid a type assertion on `unknown`.
+              // This test only reads `platformScripture.referencedProjectsAndResources`, so narrow
+              // the return here to that shape. This lets the assertions below avoid a type assertion.
               getSetting: (
                 key: string,
               ) => Promise<{ items: { id?: string; isResourceShownByDefault?: boolean }[] }>;
@@ -62,8 +64,8 @@ test.describe('Scripture Text Grid shown-by-default schema (A2)', () => {
         projectId,
       );
 
-      // Admin writes the project-scope model-texts list with a flagged Bible text.
-      await pdp.setSetting('platformScripture.modelTexts', {
+      // Admin writes the project-scope referenced-resources list with a flagged Bible text.
+      await pdp.setSetting('platformScripture.referencedProjectsAndResources', {
         dataVersion: '1.1.0',
         items: [
           {
@@ -75,7 +77,7 @@ test.describe('Scripture Text Grid shown-by-default schema (A2)', () => {
         ],
       });
 
-      const stored = await pdp.getSetting('platformScripture.modelTexts');
+      const stored = await pdp.getSetting('platformScripture.referencedProjectsAndResources');
 
       // First open initializes the overlay to match the project's flags.
       await pdp.resetShownByDefaultOverlay();

--- a/e2e-tests/tests/enhanced-resources/shown-by-default-schema.spec.ts
+++ b/e2e-tests/tests/enhanced-resources/shown-by-default-schema.spec.ts
@@ -44,7 +44,11 @@ test.describe('Scripture Text Grid shown-by-default schema (A2)', () => {
               projectId: string,
             ) => Promise<{
               setSetting: (key: string, value: unknown) => Promise<boolean>;
-              getSetting: (key: string) => Promise<unknown>;
+              // This test only reads `platformScripture.modelTexts`, so narrow the return here
+              // to that shape. This lets the assertions below avoid a type assertion on `unknown`.
+              getSetting: (
+                key: string,
+              ) => Promise<{ items: { id?: string; isResourceShownByDefault?: boolean }[] }>;
               resetShownByDefaultOverlay: () => Promise<boolean>;
               initializeShownByDefaultOverlay: () => Promise<boolean>;
               getShownByDefaultOverlay: () => Promise<Record<string, boolean>>;
@@ -81,16 +85,13 @@ test.describe('Scripture Text Grid shown-by-default schema (A2)', () => {
       return { stored, didInit, overlay };
     }, TEST_PROJECT_ID);
 
-    // Guard before the cast so a null/absent setting fails with a clear assertion,
+    // Guard so a null/absent setting fails with a clear assertion,
     // not a confusing TypeError during the .find() below.
     expect(result.stored).toBeTruthy();
 
-    const storedList = result.stored as {
-      items: { id?: string; isResourceShownByDefault?: boolean }[];
-    };
-    const flaggedItem = storedList.items.find((i) => i.id === 'aabbccddeeff00112233');
+    const flaggedItem = result.stored.items.find((i) => i.id === 'aabbccddeeff00112233');
     expect(flaggedItem?.isResourceShownByDefault).toBe(true);
     expect(result.didInit).toBe(true);
-    expect(result.overlay['aabbccddeeff00112233']).toBe(true);
+    expect(result.overlay.aabbccddeeff00112233).toBe(true);
   });
 });

--- a/e2e-tests/tests/enhanced-resources/shown-by-default-schema.spec.ts
+++ b/e2e-tests/tests/enhanced-resources/shown-by-default-schema.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * E2E checks for the PT-4050 (A2) two-flag schema + overlay init + admin gate.
+ *
+ * Scope — vanilla-core-observable only:
+ *
+ * - `isResourceShownByDefault` persists through the project setting round-trip.
+ * - First-open init writes the per-user overlay to match the project's flags.
+ * - The admin gate on the project-scope write is enforced server-side; it is covered by C# unit tests
+ *   (ParatextProjectDataProviderShownByDefaultTests), not asserted here — this fixture runs as the
+ *   default (admin) user.
+ *
+ * NOT covered here (requires the PRIVATE Send/Receive auto-download patch, which vanilla core does
+ * not include — verified manually in the Studio build): the real DBL auto-download that the
+ * auto-promoted Referenced entry triggers. See PT-4050 DoD "verified in the Studio build".
+ */
+import { test, expect } from '../../fixtures/cdp.fixture';
+import { waitForAppReady } from '../../fixtures/helpers';
+
+// A stable test project id available in the e2e fixture data. Adjust to the fixture's known
+// editable, admin project id if this constant differs in the harness.
+//
+// Investigation: the enhanced-resources test suite (test-helpers.ts and sibling specs) does not
+// expose a known fixture project id constant — it only operates on UI elements (tabs, iframes).
+// The markers-checklist suite discovers a Paratext (USFM) project dynamically from
+// ProjectLookupService.getMetadataForAllProjects, but that returns whatever projects happen to be
+// installed on the CI runner; it does not guarantee admin access. Because the overlay PDP write
+// (`setSetting`) is admin-gated, we cannot reliably pick any arbitrary project from the lookup.
+// The env-var + test.skip guard is therefore the correct pattern here.
+const TEST_PROJECT_ID = process.env.E2E_TEST_PROJECT_ID ?? '';
+
+test.describe('Scripture Text Grid shown-by-default schema (A2)', () => {
+  test('project flag persists and first-open init seeds the overlay', async ({ mainPage }) => {
+    test.skip(!TEST_PROJECT_ID, 'No editable admin test project configured for this run');
+    await waitForAppReady(mainPage);
+
+    const result = await mainPage.evaluate(async (projectId) => {
+      // The renderer sets `globalThis.papi`; it is untyped in the Playwright context.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      const { papi } = window as unknown as {
+        papi: {
+          projectDataProviders: {
+            get: (
+              pdpType: string,
+              projectId: string,
+            ) => Promise<{
+              setSetting: (key: string, value: unknown) => Promise<boolean>;
+              getSetting: (key: string) => Promise<unknown>;
+              resetShownByDefaultOverlay: () => Promise<boolean>;
+              initializeShownByDefaultOverlay: () => Promise<boolean>;
+              getShownByDefaultOverlay: () => Promise<Record<string, boolean>>;
+            }>;
+          };
+        };
+      };
+
+      const pdp = await papi.projectDataProviders.get(
+        'platformScripture.textConnectionSettings',
+        projectId,
+      );
+
+      // Admin writes the project-scope model-texts list with a flagged Bible text.
+      await pdp.setSetting('platformScripture.modelTexts', {
+        dataVersion: '1.1.0',
+        items: [
+          {
+            type: 'project',
+            name: 'P',
+            id: 'aabbccddeeff00112233',
+            isResourceShownByDefault: true,
+          },
+        ],
+      });
+
+      const stored = await pdp.getSetting('platformScripture.modelTexts');
+
+      // First open initializes the overlay to match the project's flags.
+      await pdp.resetShownByDefaultOverlay();
+      const didInit = await pdp.initializeShownByDefaultOverlay();
+      const overlay = await pdp.getShownByDefaultOverlay();
+
+      return { stored, didInit, overlay };
+    }, TEST_PROJECT_ID);
+
+    // Guard before the cast so a null/absent setting fails with a clear assertion,
+    // not a confusing TypeError during the .find() below.
+    expect(result.stored).toBeTruthy();
+
+    const storedList = result.stored as {
+      items: { id?: string; isResourceShownByDefault?: boolean }[];
+    };
+    const flaggedItem = storedList.items.find((i) => i.id === 'aabbccddeeff00112233');
+    expect(flaggedItem?.isResourceShownByDefault).toBe(true);
+    expect(result.didInit).toBe(true);
+    expect(result.overlay['aabbccddeeff00112233']).toBe(true);
+  });
+});

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -869,28 +869,35 @@ const modelTextPanelWebViewProvider: IWebViewProvider = {
 };
 
 const scriptureTextGridWebViewProvider: IWebViewProvider = {
-  async getWebView(savedWebView: SavedWebViewDefinition): Promise<WebViewDefinition | undefined> {
+  async getWebView(
+    savedWebView: SavedWebViewDefinition,
+    openWebViewOptions: OpenWebViewOptions & { projectId?: string },
+  ): Promise<WebViewDefinition | undefined> {
     if (savedWebView.webViewType !== SCRIPTURE_TEXT_GRID_WEBVIEW_TYPE)
       throw new Error(
         `${SCRIPTURE_TEXT_GRID_WEBVIEW_TYPE} provider received request to provide a ${savedWebView.webViewType} web view`,
       );
+    // A2 seam: the grid is project-bound so it can fire first-open overlay init and (in A3+) select
+    // its contents. The PT10 default-layout open passes no projectId (dormant until A3).
+    const projectId = openWebViewOptions?.projectId ?? savedWebView.projectId ?? undefined;
     return {
       ...savedWebView,
       // A1 stubs the title as the single-cell form; the web view flips it to "Text Collection"
       // via updateWebViewDefinition once 2+ cells are displayed.
       title: '%webView_scriptureTextGrid_title_single%',
-      // Part of the default PT10 Studio layout and must always stay open, so the tab is non-closable
-      // (PT-4049 subsumes A8). No X-button and no keyboard close shortcut, so both paths are covered.
+      // Part of the default PT10 Studio layout and must always remain open, so the tab is
+      // non-closable (PT-4049 subsumes A8). The X-button is omitted and there is no keyboard
+      // close shortcut in the app, so this covers both close paths.
       isClosable: false,
       // No top toolbar in this view; the View Options icon button comes in A5.
       shouldShowToolbar: false,
+      projectId,
       content: scriptureTextGridWebView,
       // Lucide "Library" glyph (books on a shelf) for the tab icon.
       iconUrl: 'papi-extension://platformScriptureEditor/assets/library.svg',
     };
   },
 };
-
 /**
  * Pending projectIds to apply during the next resource panel getWebView call, keyed by web view
  * type. A Map entry present (even with value `undefined`) means a reload is in progress and the

--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -871,7 +871,7 @@ const modelTextPanelWebViewProvider: IWebViewProvider = {
 const scriptureTextGridWebViewProvider: IWebViewProvider = {
   async getWebView(
     savedWebView: SavedWebViewDefinition,
-    openWebViewOptions: OpenWebViewOptions & { projectId?: string },
+    openWebViewOptions: ResourceViewerOptions,
   ): Promise<WebViewDefinition | undefined> {
     if (savedWebView.webViewType !== SCRIPTURE_TEXT_GRID_WEBVIEW_TYPE)
       throw new Error(
@@ -879,7 +879,7 @@ const scriptureTextGridWebViewProvider: IWebViewProvider = {
       );
     // A2 seam: the grid is project-bound so it can fire first-open overlay init and (in A3+) select
     // its contents. The PT10 default-layout open passes no projectId (dormant until A3).
-    const projectId = openWebViewOptions?.projectId ?? savedWebView.projectId ?? undefined;
+    const projectId = openWebViewOptions.projectId ?? savedWebView.projectId;
     return {
       ...savedWebView,
       // A1 stubs the title as the single-cell form; the web view flips it to "Text Collection"
@@ -898,6 +898,7 @@ const scriptureTextGridWebViewProvider: IWebViewProvider = {
     };
   },
 };
+
 /**
  * Pending projectIds to apply during the next resource panel getWebView call, keyed by web view
  * type. A Map entry present (even with value `undefined`) means a reload is in progress and the

--- a/extensions/src/platform-scripture-editor/src/model-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/model-text-panel.web-view.tsx
@@ -23,7 +23,7 @@ import type {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useEffectiveResourceReferenceList } from './use-effective-resource-reference-list.hook';
 import { isDblResourceReference } from './resource-reference.utils';
-import { DEFAULT_RESOURCE_REFERENCE_LIST } from './select-dbl-resource';
+import { DEFAULT_RESOURCE_REFERENCE_LIST } from './resource-reference-list.const';
 import { ModelTextPanel, MODEL_TEXT_PANEL_STRING_KEYS } from './model-text-panel.component';
 
 const DEFAULT_TEXT_DIRECTION = 'ltr';

--- a/extensions/src/platform-scripture-editor/src/resource-reference-list.const.ts
+++ b/extensions/src/platform-scripture-editor/src/resource-reference-list.const.ts
@@ -1,0 +1,13 @@
+import type { ResourceReferenceList } from 'platform-scripture';
+
+/** Current data-version written into the JSON body of a stored ResourceReferenceList. */
+export const CURRENT_DATA_VERSION = '1.1.0';
+
+/**
+ * Canonical empty ResourceReferenceList used as a default/fallback value. Frozen so it can be
+ * shared as a module-level reference without risk of mutation.
+ */
+export const DEFAULT_RESOURCE_REFERENCE_LIST: ResourceReferenceList = Object.freeze({
+  dataVersion: CURRENT_DATA_VERSION,
+  items: [],
+});

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -40,7 +40,8 @@ import type {
 import { useEffectiveResourceReferenceList } from './use-effective-resource-reference-list.hook';
 import { useCommentaryMarkerStyles } from './use-commentary-marker-styles.hook';
 import { isDblResourceReference, isProjectReference } from './resource-reference.utils';
-import { DEFAULT_RESOURCE_REFERENCE_LIST, selectTextConnection } from './select-dbl-resource';
+import { DEFAULT_RESOURCE_REFERENCE_LIST } from './resource-reference-list.const';
+import { selectTextConnection } from './select-dbl-resource';
 
 const DEFAULT_TEXT_DIRECTION = 'ltr';
 

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid.web-view.tsx
@@ -1,7 +1,8 @@
 import type { WebViewProps } from '@papi/core';
-import { useLocalizedStrings } from '@papi/frontend/react';
+import { logger } from '@papi/frontend';
+import { useLocalizedStrings, useProjectDataProvider } from '@papi/frontend/react';
 import { LocalizeKey } from 'platform-bible-utils';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { selectScriptureTextGridTitle } from './scripture-text-grid.utils';
 
 // Tab-title localized keys. The label is count-driven: "Scripture text" when 0-1 cells are
@@ -11,12 +12,17 @@ const TITLE_MULTIPLE_KEY = '%webView_scriptureTextGrid_title_multiple%';
 const ALL_STRING_KEYS: LocalizeKey[] = [TITLE_SINGLE_KEY, TITLE_MULTIPLE_KEY];
 
 /**
- * Scripture Text Grid web view (PT-4049 / A1 scaffold).
+ * Scripture Text Grid web view (PT-4049 / A1 scaffold; PT-4050 / A2 first-open trigger).
  *
- * For A1 this is an empty shell: no toolbar, a placeholder body, and a dynamic tab title driven by
- * the number of displayed cells. The `VerseCell` row renderer lands in A4 (PT-4052).
+ * A1 shell: no toolbar, a placeholder body, and a dynamic tab title driven by the number of
+ * displayed cells (the `VerseCell` row renderer lands in A4 / PT-4052). A2 adds a minimal
+ * first-open trigger that initializes the per-user shown-by-default overlay once per project.
+ * Correctness (no double-init) is enforced server-side by an idempotent per-user-per-project
+ * marker; this effect is a thin trigger. Richer UI wiring (contents selector, project selection)
+ * lands in A3/A5.
  */
 globalThis.webViewComponent = function ScriptureTextGridWebView({
+  projectId,
   updateWebViewDefinition,
   useWebViewState,
 }: WebViewProps) {
@@ -30,6 +36,25 @@ globalThis.webViewComponent = function ScriptureTextGridWebView({
   // round-trips across app restart). Replace this state with the A3 selector when it lands.
   const [gridContentsIds] = useWebViewState<string[]>('gridContentsIds', []);
   const displayedCellCount = gridContentsIds.length;
+
+  const textConnectionPdp = useProjectDataProvider(
+    'platformScripture.textConnectionSettings',
+    projectId,
+  );
+
+  // Fire first-open overlay init once per resolved projectId. The server-side marker makes repeated
+  // calls safe; this guard just avoids redundant round-trips within a single web-view lifetime.
+  const initializedProjectIds = useRef(new Set<string>());
+  useEffect(() => {
+    if (!projectId || !textConnectionPdp) return;
+    if (initializedProjectIds.current.has(projectId)) return;
+    initializedProjectIds.current.add(projectId);
+    textConnectionPdp.initializeShownByDefaultOverlay().catch((error) => {
+      // Non-fatal: drop the id from the local guard so a later open can retry; the server-side marker was never written.
+      initializedProjectIds.current.delete(projectId);
+      logger.error(`Failed to initialize shown-by-default overlay for ${projectId}: ${error}`);
+    });
+  }, [projectId, textConnectionPdp]);
 
   // Dynamic tab title: flips to "Text Collection" at 2+ displayed cells, "Scripture text" otherwise.
   useEffect(() => {

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid.web-view.tsx
@@ -44,6 +44,11 @@ globalThis.webViewComponent = function ScriptureTextGridWebView({
 
   // Fire first-open overlay init once per resolved projectId. The server-side marker makes repeated
   // calls safe; this guard just avoids redundant round-trips within a single web-view lifetime.
+  //
+  // NOTE (test coverage): the .catch retry path below is not exercised end-to-end in A2. The grid
+  // opens in the PT10 default layout with no projectId, so this effect returns early and the retry
+  // handler never runs until A3 wires real project selection. The path is deliberately left untested
+  // here and should get a partial-failure/network-error test in A3 when it is actually driven.
   const initializedProjectIds = useRef(new Set<string>());
   useEffect(() => {
     if (!projectId || !textConnectionPdp) return;

--- a/extensions/src/platform-scripture-editor/src/select-dbl-resource.test.ts
+++ b/extensions/src/platform-scripture-editor/src/select-dbl-resource.test.ts
@@ -1,6 +1,7 @@
 import type { ResourceReferenceList } from 'platform-scripture';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
-import { DEFAULT_RESOURCE_REFERENCE_LIST, selectTextConnection } from './select-dbl-resource';
+import { DEFAULT_RESOURCE_REFERENCE_LIST } from './resource-reference-list.const';
+import { selectTextConnection } from './select-dbl-resource';
 
 const RESOURCE_A = {
   dblEntryUid: 'uid-a',

--- a/extensions/src/platform-scripture-editor/src/select-dbl-resource.ts
+++ b/extensions/src/platform-scripture-editor/src/select-dbl-resource.ts
@@ -1,12 +1,7 @@
 import type { DblResourceReference, ResourceReferenceList } from 'platform-scripture';
 import { DblResourceData } from 'platform-bible-utils';
 import { isDblResourceReference } from './resource-reference.utils';
-import {
-  CURRENT_DATA_VERSION,
-  DEFAULT_RESOURCE_REFERENCE_LIST,
-} from './resource-reference-list.const';
-
-export { CURRENT_DATA_VERSION, DEFAULT_RESOURCE_REFERENCE_LIST };
+import { DEFAULT_RESOURCE_REFERENCE_LIST } from './resource-reference-list.const';
 
 /**
  * Adds a DBL resource to the project's text connections.

--- a/extensions/src/platform-scripture-editor/src/select-dbl-resource.ts
+++ b/extensions/src/platform-scripture-editor/src/select-dbl-resource.ts
@@ -1,12 +1,12 @@
 import type { DblResourceReference, ResourceReferenceList } from 'platform-scripture';
 import { DblResourceData } from 'platform-bible-utils';
 import { isDblResourceReference } from './resource-reference.utils';
+import {
+  CURRENT_DATA_VERSION,
+  DEFAULT_RESOURCE_REFERENCE_LIST,
+} from './resource-reference-list.const';
 
-export const CURRENT_DATA_VERSION = '1.0.0';
-export const DEFAULT_RESOURCE_REFERENCE_LIST: ResourceReferenceList = {
-  dataVersion: CURRENT_DATA_VERSION,
-  items: [],
-};
+export { CURRENT_DATA_VERSION, DEFAULT_RESOURCE_REFERENCE_LIST };
 
 /**
  * Adds a DBL resource to the project's text connections.

--- a/extensions/src/platform-scripture-editor/src/use-effective-resource-reference-list.hook.ts
+++ b/extensions/src/platform-scripture-editor/src/use-effective-resource-reference-list.hook.ts
@@ -7,10 +7,10 @@ import type {
   ResourceReferenceList,
 } from 'platform-scripture';
 import { useProjectSetting, useProjectDataProvider } from '@papi/frontend/react';
-
-const CURRENT_DATA_VERSION = '1.0.0';
-// Module-level constant avoids a useMemo with [] deps inside the hook
-const DEFAULT_LIST: ResourceReferenceList = { dataVersion: CURRENT_DATA_VERSION, items: [] };
+import {
+  CURRENT_DATA_VERSION,
+  DEFAULT_RESOURCE_REFERENCE_LIST as DEFAULT_LIST,
+} from './resource-reference-list.const';
 
 const KNOWN_RESOURCE_TYPES = new Set([
   'project',

--- a/extensions/src/platform-scripture/src/resource-reference-list.utils.test.ts
+++ b/extensions/src/platform-scripture/src/resource-reference-list.utils.test.ts
@@ -74,7 +74,7 @@ describe('isValidResourceReference', () => {
         name: 'P',
         id: 'aabbcc',
         isResourceShownByDefault: true,
-        inTextCollectionUser: false,
+        isResourceShownForUser: false,
       }),
     ).toBe(true);
   });
@@ -90,13 +90,13 @@ describe('isValidResourceReference', () => {
     ).toBe(false);
   });
 
-  it('rejects a dblResource reference with a non-boolean inTextCollectionUser', () => {
+  it('rejects a dblResource reference with a non-boolean isResourceShownForUser', () => {
     expect(
       isValidResourceReference({
         type: 'dblResource',
         name: 'D',
         id: '112233445566',
-        inTextCollectionUser: 3,
+        isResourceShownForUser: 3,
       }),
     ).toBe(false);
   });

--- a/extensions/src/platform-scripture/src/resource-reference-list.utils.test.ts
+++ b/extensions/src/platform-scripture/src/resource-reference-list.utils.test.ts
@@ -66,6 +66,61 @@ describe('isValidResourceReference', () => {
   it('rejects an item where type is not a string', () => {
     expect(isValidResourceReference({ type: 42 })).toBe(false);
   });
+
+  it('accepts a project reference with valid optional boolean flags', () => {
+    expect(
+      isValidResourceReference({
+        type: 'project',
+        name: 'P',
+        id: 'aabbcc',
+        isResourceShownByDefault: true,
+        inTextCollectionUser: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects a project reference with a non-boolean isResourceShownByDefault', () => {
+    expect(
+      isValidResourceReference({
+        type: 'project',
+        name: 'P',
+        id: 'aabbcc',
+        isResourceShownByDefault: 'yes',
+      }),
+    ).toBe(false);
+  });
+
+  it('rejects a dblResource reference with a non-boolean inTextCollectionUser', () => {
+    expect(
+      isValidResourceReference({
+        type: 'dblResource',
+        name: 'D',
+        id: '112233445566',
+        inTextCollectionUser: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it('accepts a dblResource reference with both flags absent', () => {
+    expect(
+      isValidResourceReference({
+        type: 'dblResource',
+        name: 'D',
+        id: '112233445566',
+      }),
+    ).toBe(true);
+  });
+
+  it('rejects a dblResource reference with a non-boolean isResourceShownByDefault', () => {
+    expect(
+      isValidResourceReference({
+        type: 'dblResource',
+        name: 'D',
+        id: '112233445566',
+        isResourceShownByDefault: 'no',
+      }),
+    ).toBe(false);
+  });
 });
 
 describe('resourceReferenceListValidator', () => {

--- a/extensions/src/platform-scripture/src/resource-reference-list.utils.ts
+++ b/extensions/src/platform-scripture/src/resource-reference-list.utils.ts
@@ -11,7 +11,7 @@ export const isValidResourceReference = (item: unknown): boolean => {
       // Optional flags, when present, must be booleans.
       if ('isResourceShownByDefault' in item && typeof item.isResourceShownByDefault !== 'boolean')
         return false;
-      if ('inTextCollectionUser' in item && typeof item.inTextCollectionUser !== 'boolean')
+      if ('isResourceShownForUser' in item && typeof item.isResourceShownForUser !== 'boolean')
         return false;
       return true;
     }

--- a/extensions/src/platform-scripture/src/resource-reference-list.utils.ts
+++ b/extensions/src/platform-scripture/src/resource-reference-list.utils.ts
@@ -7,7 +7,13 @@ export const isValidResourceReference = (item: unknown): boolean => {
     case 'project':
     case 'dblResource': {
       if (!('name' in item) || !('id' in item)) return false;
-      return typeof item.name === 'string' && typeof item.id === 'string';
+      if (typeof item.name !== 'string' || typeof item.id !== 'string') return false;
+      // Optional flags, when present, must be booleans.
+      if ('isResourceShownByDefault' in item && typeof item.isResourceShownByDefault !== 'boolean')
+        return false;
+      if ('inTextCollectionUser' in item && typeof item.inTextCollectionUser !== 'boolean')
+        return false;
+      return true;
     }
     case 'enhancedResource':
     case 'xmlResource':

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -1954,7 +1954,7 @@ declare module 'platform-scripture' {
      * User-scope (NOT Send/Receive'd) per-resource checkbox state on the current user's personal
      * resources list. Absent by default; only meaningful on Bible-text references.
      */
-    inTextCollectionUser?: boolean;
+    isResourceShownForUser?: boolean;
   };
 
   /** A reference to a DBL resource, identified by its 24-byte (48-char) hex ID */
@@ -1978,7 +1978,7 @@ declare module 'platform-scripture' {
      * User-scope (NOT Send/Receive'd) per-resource checkbox state on the current user's personal
      * resources list. Absent by default; only meaningful on Bible-text references.
      */
-    inTextCollectionUser?: boolean;
+    isResourceShownForUser?: boolean;
   };
 
   /** A reference to an Enhanced resource, identified by name */
@@ -2056,8 +2056,8 @@ declare module 'platform-scripture' {
      * breaking changes.
      *
      * Current version is `1.1.0`: the `1.1.0` minor bump added the optional Bible-text flags
-     * `isResourceShownByDefault` (project-scope) and `inTextCollectionUser` (user-scope). Both are
-     * additive and backwards-compatible — files lacking them read cleanly.
+     * `isResourceShownByDefault` (project-scope) and `isResourceShownForUser` (user-scope). Both
+     * are additive and backwards-compatible — files lacking them read cleanly.
      */
     dataVersion: string;
     /** Ordered list of project and resource references */

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -784,6 +784,12 @@ declare module 'platform-scripture' {
       ResourceReferenceList,
       ResourceReferenceList
     >;
+    /** Gets/sets the current user's shown-by-default overlay for this project */
+    ShownByDefaultOverlay: DataProviderDataType<
+      undefined,
+      ShownByDefaultOverlay,
+      ShownByDefaultOverlay
+    >;
   };
 
   /** Provides user-specific text connection settings (model texts and referenced projects/resources) */
@@ -845,6 +851,37 @@ declare module 'platform-scripture' {
       ): Promise<UnsubscriberAsync>;
       /** Determines whether the current user can write to text connection project settings. */
       canUserWriteProjectTextConnectionSettings(): Promise<boolean>;
+      /** Gets the current user's shown-by-default overlay (resourceId -> checkbox state) */
+      getShownByDefaultOverlay(): Promise<ShownByDefaultOverlay>;
+      /** Sets the current user's shown-by-default overlay */
+      setShownByDefaultOverlay(
+        value: ShownByDefaultOverlay,
+      ): Promise<
+        DataProviderUpdateInstructions<UserTextConnectionSettingsProjectInterfaceDataTypes>
+      >;
+      /** Resets (removes) the current user's shown-by-default overlay and its initialized marker */
+      resetShownByDefaultOverlay(): Promise<boolean>;
+      /**
+       * Subscribe to run a callback when the current user's shown-by-default overlay changes
+       *
+       * @param selector Tells the provider what changes to listen for
+       * @param callback Function to run with the updated overlay, or a {@link PlatformError} on
+       *   error
+       * @param options Various options to adjust how the subscriber emits updates
+       * @returns Unsubscriber function
+       */
+      subscribeShownByDefaultOverlay(
+        selector: undefined,
+        callback: (value: ShownByDefaultOverlay | undefined | PlatformError) => void,
+        options?: DataProviderSubscriberOptions,
+      ): Promise<UnsubscriberAsync>;
+      /**
+       * Initializes the current user's shown-by-default overlay on first open of the Scripture Text
+       * Grid for this project: sets each admin-flagged Bible-text resource's overlay value to the
+       * project's current `isResourceShownByDefault`. Idempotent — a per-user-per-project marker
+       * prevents re-initialization on later opens (returns `false` when already initialized).
+       */
+      initializeShownByDefaultOverlay(): Promise<boolean>;
     };
 
   // #endregion User Text Connection Settings Types
@@ -1908,10 +1945,16 @@ declare module 'platform-scripture' {
     /** 20-byte (40-char) hex ID that uniquely identifies the project */
     id: string;
     /**
-     * When set by a project admin, indicates this resource should be shown by default when the
-     * shared layout is applied. When `undefined`, no admin preference has been set.
+     * Project-scope (Send/Receive'd) admin flag: when set, this resource is shown by default —
+     * consumed by the shared layout and, for Bible-text resources, by the Scripture Text Grid,
+     * where it also seeds new users' overlay on first open. `undefined` means no admin preference.
      */
     isResourceShownByDefault?: boolean;
+    /**
+     * User-scope (NOT Send/Receive'd) per-resource checkbox state on the current user's personal
+     * resources list. Absent by default; only meaningful on Bible-text references.
+     */
+    inTextCollectionUser?: boolean;
   };
 
   /** A reference to a DBL resource, identified by its 24-byte (48-char) hex ID */
@@ -1926,10 +1969,16 @@ declare module 'platform-scripture' {
     /** 24-byte (48-char) hex ID that uniquely identifies the resource */
     id: string;
     /**
-     * When set by a project admin, indicates this resource should be shown by default when the
-     * shared layout is applied. When `undefined`, no admin preference has been set.
+     * Project-scope (Send/Receive'd) admin flag: when set, this resource is shown by default —
+     * consumed by the shared layout and, for Bible-text resources, by the Scripture Text Grid,
+     * where it also seeds new users' overlay on first open. `undefined` means no admin preference.
      */
     isResourceShownByDefault?: boolean;
+    /**
+     * User-scope (NOT Send/Receive'd) per-resource checkbox state on the current user's personal
+     * resources list. Absent by default; only meaningful on Bible-text references.
+     */
+    inTextCollectionUser?: boolean;
   };
 
   /** A reference to an Enhanced resource, identified by name */
@@ -2005,6 +2054,10 @@ declare module 'platform-scripture' {
      * silently lost with no harmful consequences (e.g., cosmetic ordering, non-critical display
      * hints). Use minor bumps for additive, backwards-compatible changes. Use major bumps for
      * breaking changes.
+     *
+     * Current version is `1.1.0`: the `1.1.0` minor bump added the optional Bible-text flags
+     * `isResourceShownByDefault` (project-scope) and `inTextCollectionUser` (user-scope). Both are
+     * additive and backwards-compatible — files lacking them read cleanly.
      */
     dataVersion: string;
     /** Ordered list of project and resource references */
@@ -2033,6 +2086,14 @@ declare module 'platform-scripture' {
     dataVersion: string;
     items: EffectiveResourceReference[];
   };
+
+  /**
+   * Per-user (NOT Send/Receive'd) overlay recording the current user's shown-by-default checkbox
+   * state for admin-flagged Bible-text resources, keyed by resource id. Initialized on first open
+   * of the Scripture Text Grid to match the project's `isResourceShownByDefault` values, then
+   * diverges independently.
+   */
+  export type ShownByDefaultOverlay = { [resourceId: string]: boolean };
 
   // #endregion Resource Reference Types
 


### PR DESCRIPTION
## Summary

The Scripture Text Grid needs to know which resources to show. This PR answers that question with **two separate on/off flags**, because "should this resource show?" actually has two different owners:

- A **project administrator** sets a shared default — "in this project, this resource shows by default for everyone." That default is Send/Received, so it travels with the project to every user.
- Each **individual user** then has their own checkbox that overrides the default for themselves. That choice is local — it is *not* Send/Received and never affects anyone else.

So the two flags are:

| Flag | Whose setting is it? | Does it travel with the project (Send/Received)? |
| --- | --- | --- |
| `isResourceShownByDefault` | The project admin's shared default | **Yes** — shared with everyone on the project |
| `inTextCollectionUser` | This one user's personal choice | **No** — stays on this user's machine |

Beyond the two flags, the PR includes everything needed to make them work end to end: a permission check so only admins can change the shared default, an auto-download path so a newly-flagged resource actually gets installed, the per-user storage ("overlay") that holds each user's personal choices, and the Scripture Text Grid wiring that reads all of it.

The stored file's data/format version moves to `1.1.0`; the **major version deliberately stays `1`** (see [Design notes](#design-notes) for why).

---

## Reviewer's guide

### Start here: the one idea to hold onto

There are **two independent pieces of state**, and almost everything in this PR is about keeping them straight:

1. **The shared admin default** — one value per resource, set by an admin, Send/Received to everyone.
2. **Each user's personal choice** — one value per resource *per user*, local only.

They connect at exactly one moment. The **first time a user opens the Scripture Text Grid**, we copy ("seed") the admin defaults into that user's personal storage as their starting point. From then on the two are independent: the admin can change the shared default and the user can change their own checkboxes without stepping on each other. If you understand that first-open seeding step, the rest of the PR follows naturally.

### Suggested reading order

The pieces build on each other, so reading them in this order avoids backtracking — the flags are **declared** first, then **saved/loaded** (serialized), then **acted on**, then **exposed** to TypeScript, and finally **used** by the UI.

1. **[ResourceReferenceList.cs](c-sharp/Projects/ResourceReferenceList.cs) — where the flags are defined.** Declares the two new flags and the `ExtraData` catch-all, and handles reading/writing them in both JSON and XML. *Look closely at:* how a flag that is `null` is left out of the file entirely (so files from older builds don't change), and how any property the code doesn't recognize is stashed in `ExtraData` instead of being thrown away.
2. **[ResourceReferenceConverter.cs](c-sharp/Projects/ResourceReferenceConverter.cs) — the JSON reader/writer.** Handles the different resource types. *Look closely at:* unrecognized JSON properties being routed into `ExtraData` rather than dropped.
3. **[ParatextProjectDataProvider.cs](c-sharp/Projects/ParatextProjectDataProvider.cs) — where the behavior lives.** This is the heart of the PR: the admin permission check, the auto-download ("auto-promote") logic, and the create/read/update/clear lifecycle for each user's personal storage. *Look closely at:* `AutoPromoteShownByDefaultResources` (it must be safe to run repeatedly and must bail out on a file it can't understand), the first-open seeding and its "already done" marker, and the admin check guarding shared-default writes.
4. **[platform-scripture.d.ts](extensions/src/platform-scripture/src/types/platform-scripture.d.ts) — the TypeScript-facing contract.** Declares the new fields and the overlay methods for the front end. *Look closely at:* that these signatures match the C# side.
5. **[scripture-text-grid.web-view.tsx](extensions/src/platform-scripture-editor/src/scripture-text-grid.web-view.tsx) — the UI that consumes it.** Reads the flags, picks the tab title based on how many resources are shown, and triggers the first-open seeding.

### A few terms you'll run into

- **Scope (project vs. user).** Both flags sit on the same list of resources, but they answer to different owners: the project-scope flag (`isResourceShownByDefault`) is shared and Send/Received; the user-scope flag (`inTextCollectionUser`) and each user's personal storage are local.
- **Forward-compatibility / `ExtraData`.** The stored list is a versioned document that a *newer* build might add fields to. When this build encounters a field it doesn't recognize, it keeps it verbatim (in `ExtraData` for JSON, rebuilt attributes for XML) so opening and re-saving the file never silently drops data.
- **"Auto-promote" = the auto-download step.** Marking a Bible-text resource as shown isn't enough on its own — the resource may not be installed yet. Auto-promote appends a copy of that resource (with the flags stripped, but its `Name` kept) to the project's *Referenced* list, which is the list the existing download machinery already knows how to install from. It's deduped by `(type, id)` and safe to run repeatedly.
- **"Overlay" = each user's personal storage.** It's the per-user record of which resources that user has shown/hidden. It's created ("seeded") once on first open from the admin defaults, marked as done so it isn't re-seeded, and can be cleared with `reset`.

---

## What changed

- **Schema** — two nullable flags + an `ExtraData` passthrough on `ResourceReference`; per-type known-property sets; JSON and XML (de)serialization. Null flags are omitted, so files written by older builds stay byte-clean.
- **Admin gate** — project-scope writes (`isResourceShownByDefault`) require project-admin; user-scope writes are ungated.
- **Auto-promote** — flagging a Bible-text resource appends a flag-stripped copy to the Referenced list so the download path installs it. Idempotent, deduped by `(type, id)`, and leaves an unparseable or future-major list untouched.
- **Per-user overlay** — `get` / `set` / `reset` / `initialize` methods. First-open init seeds from the admin flags and is idempotent; reads validate the overlay schema version.
- **Grid web view** — count-driven "Scripture text" / "Text collection" tab title; triggers first-open init; new `enableScriptureTextGrid` setting (default on, restart-required).

## Design notes

Decisions a reviewer may want to confirm — pulled out of the main flow so the diff reads cleanly.

- **Major version stays `1`.** The data/format version is `1.1.0`, but the major version is deliberately unchanged: a downstream private Send/Receive reader keys on the major version, and bumping it would break that reader. New fields are additive and nullable to keep the bump minor.
- **Naming.** The ticket proposed `inTextCollection` for the project-scope flag. It's implemented as `isResourceShownByDefault` to distinguish the admin *default* from the user-scope `inTextCollectionUser` *checkbox state*.
- **Reconciled with PT-4040 (#2488).** That PR had already merged its own `isResourceShownByDefault` (all types, for shared layout). This treats it as the same flag: reuse main's declaration and layer A2's additions on top. The flag is now understood on all types; `id` / `inTextCollectionUser` stay Bible-text-only and round-trip via `ExtraData` on other types. **→ Confirm with Tom that this single-flag merge matches intent.**

## Testing

- [x] C# 1343 · extensions 633 · docking 34 · e2e `tsc` clean · CSharpier + Prettier clean
- [x] Round-trip verified **manually in a Paratext 10 Studio (private-patch) build** (2026-07-06) against real projects:
  - **Schema** reads/writes at `dataVersion 1.1.0`; `CurrentMajorVersion` unchanged at `1`.
  - **Admin gate**, both directions — project-scope write allowed on an admin project, rejected on a non-admin one.
  - **First-open overlay init** seeds from the admin flags and is idempotent (second call no-ops via the marker; `reset` clears it).
  - **Auto-promote** — flagging a DBL Bible-text resource appended a flag-stripped copy to the Referenced list (deduped; the project's other refs untouched).
  - **End-to-end auto-download** — after Send/Receive (`syncProjects`), the auto-promoted resource installed (`installed: false → true`).

> Automated e2e stays CI-skipped: it needs an env-specific admin project id (infra follow-up).

## AI involvement

AI-assisted: subagent-driven against a written plan, then a `/review-paratext` pass with fixes. Katherine authored and drove all design decisions; AI generated code and tests under review. Full findings ledger: `.review/summary.md`.

## Risk: Medium

Two layers of state plus serialization across the TS↔C# boundary. Covered by unit tests (admin gate, auto-promote idempotency + guard, overlay lifecycle, omit-when-null, passthrough) and the major-version invariant. Pair-review recommended.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2507)
<!-- Reviewable:end -->
