### PR TITLE
docs(pr-creator): use `claude --resume` when there's no session URL

### DIFF
--- a/.claude/skills/pr-creator/SKILL.md
+++ b/.claude/skills/pr-creator/SKILL.md
@@ -196,6 +196,24 @@ add a brief, honest note in the PR body describing what AI contributed
 (for example, which files or portions were AI-generated and how they were
 reviewed). The "Full Template" above leaves room for such a note.
 
+### When there's no session URL (e.g. Claude Code CLI)
+
+A Claude Code CLI session is a local transcript, not a hosted page, so there is no
+shareable URL to link. Do **not** silently drop the attribution or invent a URL —
+instead record the command that reopens the exact session, so future-you (or a
+reviewer) can pull up the full history later:
+
+```text
+AI-assisted (Claude Code). Resume this session: `claude --resume <session-id>`
+(run from the `<worktree-or-project-dir>`).
+```
+
+Find `<session-id>` (a UUID) in the transcript path
+`~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`. Resume is scoped to the working
+directory, so state which worktree/dir to run it from. Prefer a real shareable URL when
+one exists (e.g. a claude.ai web/desktop session); use the `--resume` command only as the
+fallback.
+
 ## Merge Strategy
 
 ### Default: Squash and Merge


### PR DESCRIPTION
## Summary

Small fix to the `pr-creator` skill's **AI Transparency** guidance. It assumed AI attribution could link a shareable session URL, but a **Claude Code CLI session is a local transcript with no hosted URL** — so there's nothing to link, and the guidance left the attribution incomplete.

## Change

`.claude/skills/pr-creator/SKILL.md` — add a subsection: when there's no session URL, record the **reopen command** instead of dropping attribution or fabricating a link:

> AI-assisted (Claude Code). Resume this session: `claude --resume <session-id>` (run from the `<worktree>`).

It notes where to find the `<session-id>` (the UUID in `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`), that resume is scoped to the working directory, and to prefer a real shareable URL when one exists.

## Why

This came up finalizing #2501 / #2502: the AI-attribution convention wanted a session link, but CLI sessions don't have one. The useful, honest substitute is the command that reopens the exact session for future reference.

## Risk

Low — skill/docs only.

## AI Involvement

AI-assisted (Claude Code). Resume this session: `claude --resume 63aed4b7-897a-4465-80ad-b0aa34d4a0c2` (run from the `fix-localisation-in-storybook-scope-selector` worktree).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2510)
<!-- Reviewable:end -->
