### PR TITLE
Add 'Why review this' section to pr-creator skill

### DIFF
--- a/.claude/skills/pr-creator/SKILL.md
+++ b/.claude/skills/pr-creator/SKILL.md
@@ -97,11 +97,6 @@ Key code steward areas:
 
 ## PR Templates
 
-For PRs that are not part of the current epic, insert a `## Why review this`
-section immediately after `## Summary` in whichever template you use — see
-["Why review this" Section (Non-Epic PRs)](#why-review-this-section-non-epic-prs)
-below.
-
 ### Minimal Template (Simple Changes)
 
 ```bash
@@ -111,6 +106,14 @@ gh pr create \
 ## Summary
 
 [Brief description of what this PR does]
+
+### Why review this
+
+[Only when this PR is not part of the current epic (side fixes, tooling,
+refactors, dependency bumps, cleanup) — otherwise delete this section.
+Start with "Not part of the current epic." then 1–2 sentences: what
+prompted this change and why it is worth reviewer time now. What the
+current epic is: .context/standards/Current-Epic.md]
 
 ## Changes
 
@@ -134,6 +137,14 @@ gh pr create \
 ## Summary
 
 [Description of what this PR does and why]
+
+### Why review this
+
+[Only when this PR is not part of the current epic (side fixes, tooling,
+refactors, dependency bumps, cleanup) — otherwise delete this section.
+Start with "Not part of the current epic." then 1–2 sentences: what
+prompted this change and why it is worth reviewer time now. What the
+current epic is: .context/standards/Current-Epic.md]
 
 ## Changes
 
@@ -186,33 +197,6 @@ Merge latest changes from paranext-extension-template.
 EOF
 )"
 ```
-
-### "Why review this" Section (Non-Epic PRs)
-
-If the PR is not directly part of the current epic (side fixes, tooling,
-refactors, dependency bumps, cleanup), add a `Why review this` section
-immediately after `## Summary` so reviewers can prioritize it against epic
-work. Use this exact format:
-
-```markdown
-## Why review this
-
-Not part of the current epic. [1–2 sentences: what prompted this change and
-why it is worth reviewer time now — e.g., unblocks PT-1234, fixes recurring
-CI flake, five-minute review.]
-```
-
-Skip this section when the PR's JIRA ticket belongs to the current epic.
-
-The current epic is articulated in the
-[Paratext Roadmap](https://docs.google.com/spreadsheets/d/1DP9WcoTwzYQbGzKyOaULeotHRotyBFsrrHNngP1qyVI/edit?gid=1711193079#gid=1711193079)
-and on the JIRA
-[Dev Current Sprint board](https://paratextstudio.atlassian.net/jira/software/c/projects/PT/boards/63)
-(both show the same info), and is discussed in the 🔹-marked threads in the
-[#teamwide-epic-discussions](https://discord.com/channels/892072317436448768/1503454586432782407)
-channel on the Paratext Discord. Epic membership is the PR author's
-judgment: if it is unclear whether the ticket belongs to the current epic,
-ask the author rather than deciding from the ticket alone.
 
 ## AI Transparency
 
@@ -307,6 +291,7 @@ git push
 
 ## See Also
 
+- [Current-Epic.md](../../../.context/standards/Current-Epic.md) - What the current epic is and where it is articulated
 - [Git-Guide.md](../../../.context/standards/Git-Guide.md) - Branch naming, merge practices
 - [Code-Review-Guide.md](../../../.context/standards/Code-Review-Guide.md) - Review workflow
 - [test-runner skill](../test-runner/SKILL.md) - Run tests before PR

--- a/.claude/skills/pr-creator/SKILL.md
+++ b/.claude/skills/pr-creator/SKILL.md
@@ -182,6 +182,23 @@ EOF
 )"
 ```
 
+### "Why Review This" Section (Non-Epic PRs)
+
+If the PR is not directly part of the current epic (side fixes, tooling,
+refactors, dependency bumps, cleanup), add a `Why review this` section
+immediately after `## Summary` so reviewers can prioritize it against epic
+work. Use this exact format:
+
+```markdown
+## Why review this
+
+Not part of the current epic. [1–2 sentences: what prompted this change and
+why it is worth reviewer time now — e.g., unblocks PT-1234, fixes recurring
+CI flake, five-minute review.]
+```
+
+Skip this section when the PR's JIRA ticket belongs to the current epic.
+
 ## AI Transparency
 
 When AI was involved in creating code, disclose it according to the

--- a/.claude/skills/pr-creator/SKILL.md
+++ b/.claude/skills/pr-creator/SKILL.md
@@ -109,9 +109,9 @@ gh pr create \
 
 ### Why review this
 
-[Only when this PR is not part of the current epic (side fixes, tooling,
-refactors, dependency bumps, cleanup) — otherwise delete this section.
-Start with "Not part of the current epic." then 1–2 sentences: what
+[Either: (a) which current epic (side fixes, tooling,
+refactors, dependency bumps, cleanup) this PR part of, xor
+(b) "Not part of current epic." then 1–2 sentences: what
 prompted this change and why it is worth reviewer time now. What the
 current epic is: .context/standards/Current-Epic.md]
 

--- a/.claude/skills/pr-creator/SKILL.md
+++ b/.claude/skills/pr-creator/SKILL.md
@@ -97,6 +97,11 @@ Key code steward areas:
 
 ## PR Templates
 
+For PRs that are not part of the current epic, insert a `## Why review this`
+section immediately after `## Summary` in whichever template you use — see
+["Why review this" Section (Non-Epic PRs)](#why-review-this-section-non-epic-prs)
+below.
+
 ### Minimal Template (Simple Changes)
 
 ```bash
@@ -182,7 +187,7 @@ EOF
 )"
 ```
 
-### "Why Review This" Section (Non-Epic PRs)
+### "Why review this" Section (Non-Epic PRs)
 
 If the PR is not directly part of the current epic (side fixes, tooling,
 refactors, dependency bumps, cleanup), add a `Why review this` section
@@ -198,6 +203,16 @@ CI flake, five-minute review.]
 ```
 
 Skip this section when the PR's JIRA ticket belongs to the current epic.
+
+The current epic is articulated in the
+[Paratext Roadmap](https://docs.google.com/spreadsheets/d/1DP9WcoTwzYQbGzKyOaULeotHRotyBFsrrHNngP1qyVI/edit?gid=1711193079#gid=1711193079)
+and on the JIRA
+[Dev Current Sprint board](https://paratextstudio.atlassian.net/jira/software/c/projects/PT/boards/63)
+(both show the same info), and is discussed in the 🔹-marked threads in the
+[#teamwide-epic-discussions](https://discord.com/channels/892072317436448768/1503454586432782407)
+channel on the Paratext Discord. Epic membership is the PR author's
+judgment: if it is unclear whether the ticket belongs to the current epic,
+ask the author rather than deciding from the ticket alone.
 
 ## AI Transparency
 

--- a/.claude/skills/pr-creator/SKILL.md
+++ b/.claude/skills/pr-creator/SKILL.md
@@ -105,15 +105,7 @@ gh pr create \
   --body "$(cat <<'EOF'
 ## Summary
 
-[Brief description of what this PR does]
-
-### Why review this
-
-[Either: (a) which current epic (side fixes, tooling,
-refactors, dependency bumps, cleanup) this PR part of, xor
-(b) "Not part of current epic." then 1–2 sentences: what
-prompted this change and why it is worth reviewer time now. What the
-current epic is: .context/standards/Current-Epic.md]
+[Brief description of what this PR does. Why review this.]
 
 ## Changes
 
@@ -136,15 +128,7 @@ gh pr create \
   --body "$(cat <<'EOF'
 ## Summary
 
-[Description of what this PR does and why]
-
-### Why review this
-
-[Only when this PR is not part of the current epic (side fixes, tooling,
-refactors, dependency bumps, cleanup) — otherwise delete this section.
-Start with "Not part of the current epic." then 1–2 sentences: what
-prompted this change and why it is worth reviewer time now. What the
-current epic is: .context/standards/Current-Epic.md]
+[Description of what this PR does and why. Why review this.]
 
 ## Changes
 
@@ -184,7 +168,7 @@ gh pr create \
 
 ## Summary
 
-Merge latest changes from paranext-extension-template.
+Merge latest changes from paranext-extension-template. [Why review this.]
 
 ## Changes
 
@@ -197,6 +181,19 @@ Merge latest changes from paranext-extension-template.
 EOF
 )"
 ```
+
+### Template for `Why review this`
+
+```
+### Why review this
+
+[Either: (a) which current epic (side fixes, tooling,
+refactors, dependency bumps, cleanup) this PR part of, xor
+(b) "Not part of current epic." then 1–2 sentences: what
+prompted this change and why it is worth reviewer time now. What the
+current epic is: .context/standards/Current-Epic.md]
+```
+
 
 ## AI Transparency
 

--- a/.context/standards/Current-Epic.md
+++ b/.context/standards/Current-Epic.md
@@ -1,0 +1,28 @@
+---
+title: Current Epic
+description: What the "current epic" is and where it is articulated, for prioritizing work and PRs against epic work.
+version: 1.0.0
+status: active
+created: 2026-07-07
+last_updated: 2026-07-07
+---
+
+# Current Epic
+
+Each sprint the team commits to an **epic** — the main body of work everything else is prioritized against. The "current epic" is the one in progress this sprint. For example, non-epic PRs add a `### Why review this` note under `## Summary` (see the [pr-creator skill](../../.claude/skills/pr-creator/SKILL.md)) so reviewers can rank them against epic work.
+
+## Where It Is Articulated
+
+- [Paratext Roadmap](https://docs.google.com/spreadsheets/d/1DP9WcoTwzYQbGzKyOaULeotHRotyBFsrrHNngP1qyVI/edit?gid=1711193079#gid=1711193079)
+- [Dev Current Sprint board](https://paratextstudio.atlassian.net/jira/software/c/projects/PT/boards/63) (JIRA) — same info as the roadmap
+- 🔹-marked threads in [#teamwide-epic-discussions](https://discord.com/channels/892072317436448768/1503454586432782407) on the Paratext Discord
+
+## Deciding Whether Work Belongs to the Current Epic
+
+Epic membership is the author's judgment. If it is unclear whether a ticket or PR belongs to the current epic, ask the author — do not decide from the ticket alone.
+
+## Version Log
+
+| Version | Date       | Change          |
+| ------- | ---------- | --------------- |
+| 1.0.0   | 2026-07-07 | Initial version |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Read these when you need depth on a topic. Keep them in mind when writing or rev
 | Localization            | [Localization-Guide.md](.context/standards/Localization-Guide.md)         | i18n store/APIs, fallback chain, RTL, immutable strings, C# localization |
 | Git and GitHub          | [Git-Guide.md](.context/standards/Git-Guide.md)                           | Branch structure, squash-merge, template merges              |
 | Code Review             | [Code-Review-Guide.md](.context/standards/Code-Review-Guide.md)           | Reviewable, code-steward, review workflow, auto-merge        |
+| Current Epic            | [Current-Epic.md](.context/standards/Current-Epic.md)                     | What the current epic is, where it is articulated (roadmap, JIRA sprint board, Discord), epic-membership judgment |
 | Security                | [Security-Guide.md](.context/standards/Security-Guide.md)                 | CSP, module import restrictions, extension sandboxing        |
 
 ## Terminology

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ Read these when you need depth on a topic. Keep them in mind when writing or rev
 | Localization            | [Localization-Guide.md](.context/standards/Localization-Guide.md)         | i18n store/APIs, fallback chain, RTL, immutable strings, C# localization |
 | Git and GitHub          | [Git-Guide.md](.context/standards/Git-Guide.md)                           | Branch structure, squash-merge, template merges              |
 | Code Review             | [Code-Review-Guide.md](.context/standards/Code-Review-Guide.md)           | Reviewable, code-steward, review workflow, auto-merge        |
-| Current Epic            | [Current-Epic.md](.context/standards/Current-Epic.md)                     | What the current epic is, where it is articulated (roadmap, JIRA sprint board, Discord), epic-membership judgment |
+| Current Epic            | [Current-Epic.md](.context/standards/Current-Epic.md)                     | What the current epic is, where it is articulated (roadmap, JIRA sprint board, Discord), is work item in epic? |
 | Security                | [Security-Guide.md](.context/standards/Security-Guide.md)                 | CSP, module import restrictions, extension sandboxing        |
 
 ## Terminology


### PR DESCRIPTION
## Summary

Sprint retro action item (2026-06-30): PRs that aren't directly part of the current epic now get a `Why review this` section so reviewers can prioritize them against epic work. The rule lives in the pr-creator skill's PR templates as a conditional `### Why review this` child of `## Summary`, backed by a shared standards doc defining what the current epic is.

### Why review this

Not part of the current epic. [Retro action item from last week's sprint retro](https://www.figma.com/board/In9Pe9Gv4hRg7Gri1RCspx/New-Simple-Retro?node-id=616-154&t=k2RwJuBUdJ3zZw9V-4) — it changes the PR template every non-epic PR uses from now on, and it's a small docs review (~5 minutes).

## Changes

- Minimal and Full templates in `.claude/skills/pr-creator/SKILL.md` now include a conditional `### Why review this` section under `## Summary` — filled in for non-epic PRs, deleted for epic work
- Added `.context/standards/Current-Epic.md`: what the current epic is, where it is articulated (Paratext Roadmap, JIRA Dev Current Sprint board, 🔹-marked threads in #teamwide-epic-discussions on Discord), and that epic membership is the PR author's judgment — ask the author when unclear
- Indexed the new doc in CLAUDE.md's reference-documentation table so other skills and docs can point to it

## AI Involvement

AI-assisted (Claude Code) — Claude drafted the skill section and this PR under direction from the retro action item; reviewed and edited by Alex.

## Testing

- [x] Docs-only change; pre-commit hooks (gitleaks, lint-staged) pass
- [x] Rendered markdown verified

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2511)
<!-- Reviewable:end -->
