### PR TITLE
Warm Intl.* lazy ICU init in vitest setup to fix first-use CI flake

### DIFF
--- a/.context/standards/Testing-Guide.md
+++ b/.context/standards/Testing-Guide.md
@@ -319,11 +319,18 @@ export default defineConfig(async () => {
     test: {
       globals: true,
       environment: 'jsdom',
+      // Warms the lazy one-time ICU init behind Intl.* so it never lands inside a test's
+      // timeout window on a slow CI worker. See vitest.setup.ts for the rationale.
+      setupFiles: ['./vitest.setup.ts'],
       include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     },
   };
 });
 ```
+
+> The workspace configs (`extensions/vitest.config.ts`, `lib/platform-bible-utils/vite.config.ts`,
+> `lib/platform-bible-react/vitest.config.ts`) reference this same repo-root `vitest.setup.ts` via a
+> relative `setupFiles` path, so every vitest worker warms Intl once before any timed test.
 
 ### Key Dependencies
 

--- a/extensions/vitest.config.ts
+++ b/extensions/vitest.config.ts
@@ -7,6 +7,9 @@ const config = defineConfig({
   test: {
     globals: true,
     environment: 'node',
+    // Warm the lazy one-time ICU init behind Intl.* so it never lands inside a test's timeout
+    // window on a slow CI worker. Shares the repo-root setup file. See vitest.setup.ts for rationale.
+    setupFiles: [path.resolve(__dirname, '../vitest.setup.ts')],
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'lib/**/*.test.ts', 'lib/**/*.test.tsx'],
   },
   resolve: {

--- a/lib/platform-bible-react/vitest.config.ts
+++ b/lib/platform-bible-react/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from 'path';
 import { defineConfig } from 'vitest/config';
 import { storybookTest } from '@storybook/addon-vitest/vitest-plugin';
 import config from './vite.config';
+
+// Warm the lazy one-time ICU init behind Intl.* (e.g. the extension-marketplace footer's
+// Intl.DisplayNames) so it never lands inside a test's timeout window on a slow CI worker.
+// Shares the repo-root setup file. See ../../vitest.setup.ts for the full rationale.
+const intlWarmupSetup = path.resolve(__dirname, '../../vitest.setup.ts');
 
 const workspace = defineConfig({
   ...config,
@@ -17,6 +23,7 @@ const workspace = defineConfig({
           exclude: ['src/**/*.stories.{js,ts,jsx,tsx}', 'src/components/shadcn-ui-old/*'],
           globals: true,
           environment: 'jsdom',
+          setupFiles: [intlWarmupSetup],
         },
       },
       // Node.js tests for build scripts
@@ -25,6 +32,7 @@ const workspace = defineConfig({
           name: 'scripts',
           include: ['scripts/**/*.test.ts'],
           environment: 'node',
+          setupFiles: [intlWarmupSetup],
         },
       },
       // Browser tests for Storybook

--- a/lib/platform-bible-utils/vite.config.ts
+++ b/lib/platform-bible-utils/vite.config.ts
@@ -40,6 +40,10 @@ const config = defineConfig({
   },
   test: {
     globals: true,
+    // Warm the lazy one-time ICU init behind Intl.* so it never lands inside a test's timeout window
+    // on a slow CI worker. This workspace's intl/* tests construct Intl.NumberFormat/DateTimeFormat/
+    // Collator directly. Shares the repo-root setup file. See vitest.setup.ts for rationale.
+    setupFiles: [path.resolve(__dirname, '../../vitest.setup.ts')],
   },
 });
 export default config;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,9 @@ const config = defineConfig(async () => {
     test: {
       globals: true,
       environment: 'jsdom',
+      // Warms the lazy one-time ICU init behind Intl.* so it never lands inside a test's timeout
+      // window on a slow CI worker. See vitest.setup.ts for the full rationale.
+      setupFiles: ['./vitest.setup.ts'],
       include: [
         'src/**/*.test.ts',
         'src/**/*.test.tsx',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -1,0 +1,24 @@
+// Vitest global setup: warm the lazy, one-time ICU initialization behind the Intl.* constructors.
+//
+// The first construction of each Intl formatter type in a worker process loads that formatter's
+// ICU dataset. Measured cold first-use cost is ~8-20ms per type (Intl.DisplayNames with
+// type:'language' is the worst at ~20ms) versus ~0.03ms once warm - a ~500x difference. On a cold,
+// memory-pressured CI worker that first-touch initialization can spike into the seconds, and when it
+// happens to run inside a test's timeout window it flakes that test.
+//
+// This is exactly what made src/renderer/hooks/use-project-picker-data.hook.test.ts time out only on
+// its "first open Scripture Editor web view" case: that was the sole test whose code path constructs
+// Intl.DisplayNames (via resolveLanguage), so it alone paid the one-time init inside its timed
+// window while every sibling ran warm.
+//
+// Paying the init here - once per worker, before any timed test - moves the cost out of every test
+// window and removes the whole class of flake. We warm exactly the Intl constructors the codebase
+// uses. Each statement is a construct-and-use call so the formatter's dataset actually loads.
+const locale = typeof navigator !== 'undefined' && navigator.language ? navigator.language : 'en';
+
+new Intl.DisplayNames([locale], { type: 'language' }).of('en');
+new Intl.NumberFormat(locale).format(1);
+new Intl.DateTimeFormat(locale).format(0);
+new Intl.Collator(locale).compare('a', 'b');
+new Intl.RelativeTimeFormat(locale).format(1, 'day');
+new Intl.ListFormat(locale).format(['a', 'b']);


### PR DESCRIPTION
## Summary

Fixes an intermittent CI timeout in `src/renderer/hooks/use-project-picker-data.hook.test.ts`. The test **"returns currentProject from the first open Scripture Editor web view"** would occasionally fail on `windows-latest` with `Error: Test timed out in 5000ms`, while its six sibling tests in the same file passed in ~14ms each.

### Root cause (measured, not the settle logic)

That test is the **only** one in the file whose code path constructs `Intl.DisplayNames` — via `resolveLanguage`, reached only when a project with a real language value is open. The **first** construction of an `Intl` formatter type in a worker process performs a one-time lazy ICU dataset load. Measured cold vs warm first-use cost (fresh process each):

| Constructor | Cold | Warm |
| --- | --- | --- |
| `Intl.DisplayNames({type:'language'})` | **20.3 ms** | 0.035 ms |
| `Intl.NumberFormat` | 11.2 ms | 0.048 ms |
| `Intl.Collator` | 9.7 ms | 0.017 ms |
| `Intl.DateTimeFormat` | 9.5 ms | 0.054 ms |
| `Intl.RelativeTimeFormat` | 8.9 ms | 0.034 ms |
| `Intl.ListFormat` | 7.9 ms | 0.014 ms |

Every `Intl.*` constructor carries an ~8–20 ms cold first-use cost (~500× its warm cost). On a cold, memory-pressured CI worker that first-touch initialization can spike into the seconds, and it runs **synchronously inside the test's timeout window** — so only the one test that first-constructs `Intl.DisplayNames` flaked, while siblings ran warm. (Instrumentation confirmed the first in-test construction costs ~20 ms and every later one ~0.04 ms.)

This is why prior fixes did not stick: they targeted the `settle()` / `waitFor` / `testTimeout` layer, which was never the cause.

## Changes

- **`vitest.setup.ts`** (new): a global setup that warms the `Intl.*` constructors the codebase uses (once per worker, before any timed test), so the one-time ICU init happens outside every test window.
- **`vitest.config.ts`**: wire it via `test.setupFiles`.

Test-infrastructure only — **no production code change**. The ~20 ms one-time cost is irrelevant in production (it happens once, on the first real project fetch).

## AI Involvement

AI-assisted. I (Matt Lyons) directed the investigation and reviewed every step. Claude Code was used to: pull and parse the failing CI logs, form and then **empirically disprove** several hypotheses (React scheduler nondeterminism, dynamic-import cost, worker starvation) via instrumented probes under simulated CPU starvation, isolate the actual differentiator (first-use `Intl.DisplayNames` construction) by timing per-test constructor cost, and verify the fix end-to-end. All measurements above are reproducible; the fix and its rationale were human-reviewed.

## Testing

- [x] `npm run typecheck` — clean
- [x] `eslint vitest.setup.ts vitest.config.ts` — clean
- [x] Flaky file passes: `use-project-picker-data.hook.test.ts` 7/7
- [x] Broad slice unaffected: all `src/renderer` tests — 357/357
- [x] Verified the warm-up works: with `setupFiles` active, the first in-test `Intl.DisplayNames` construction dropped from ~20 ms to **0.044 ms**
- [ ] N/A — no C# changes (dotnet tests not affected)

## Risk Level

**Low** — additive, test-infrastructure only; runs a handful of `Intl.*` warm-up calls once per worker at setup; no production code path touched; no behavior change to any test's assertions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2513)
<!-- Reviewable:end -->
