### PR TITLE
PT-4051 (A3): Text Collection effective-filter + View Options helpers

### DIFF
--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
@@ -239,6 +239,7 @@ describe('getViewOptionsTexts', () => {
       section: 'top' as const,
       checked: true,
       isAdminLocked: true,
+      isUserRemovable: false,
     },
     {
       label: 'admin flagged true, overlay false → top, unchecked, locked',
@@ -250,6 +251,7 @@ describe('getViewOptionsTexts', () => {
       section: 'top' as const,
       checked: false,
       isAdminLocked: true,
+      isUserRemovable: false,
     },
     {
       label: 'admin flagged true, overlay absent → top, checked (fallback), locked',
@@ -261,6 +263,7 @@ describe('getViewOptionsTexts', () => {
       section: 'top' as const,
       checked: true,
       isAdminLocked: true,
+      isUserRemovable: false,
     },
     {
       label: 'flagged true only on modelTexts → top (proves union)',
@@ -273,9 +276,10 @@ describe('getViewOptionsTexts', () => {
       section: 'top' as const,
       checked: true,
       isAdminLocked: true,
+      isUserRemovable: false,
     },
     {
-      label: 'admin unflagged but overlay present → bottom (past-admin), not locked',
+      label: 'admin unflagged but overlay present → bottom (past-admin), not locked, not removable',
       sources: () =>
         makeSources({
           adminReferenced: list([project('a')]),
@@ -284,9 +288,10 @@ describe('getViewOptionsTexts', () => {
       section: 'bottom' as const,
       checked: true,
       isAdminLocked: false,
+      isUserRemovable: false,
     },
     {
-      label: 'admin flag false, no overlay → bottom, unchecked, not locked',
+      label: 'admin flag false, no overlay → bottom, unchecked, not locked, not removable',
       sources: () =>
         makeSources({
           adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
@@ -295,9 +300,10 @@ describe('getViewOptionsTexts', () => {
       section: 'bottom' as const,
       checked: false,
       isAdminLocked: false,
+      isUserRemovable: false,
     },
     {
-      label: 'admin flag false, overlay true → bottom, checked, not locked',
+      label: 'admin flag false, overlay true → bottom, checked, not locked, not removable',
       sources: () =>
         makeSources({
           adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
@@ -306,6 +312,7 @@ describe('getViewOptionsTexts', () => {
       section: 'bottom' as const,
       checked: true,
       isAdminLocked: false,
+      isUserRemovable: false,
     },
     {
       label: 'user entry inTextCollectionUser true → bottom, checked, removable',
@@ -314,6 +321,7 @@ describe('getViewOptionsTexts', () => {
       section: 'bottom' as const,
       checked: true,
       isAdminLocked: false,
+      isUserRemovable: true,
     },
     {
       label: 'user entry inTextCollectionUser false → bottom, unchecked, removable',
@@ -322,8 +330,9 @@ describe('getViewOptionsTexts', () => {
       section: 'bottom' as const,
       checked: false,
       isAdminLocked: false,
+      isUserRemovable: true,
     },
-  ])('$label', ({ sources, section, checked, isAdminLocked }) => {
+  ])('$label', ({ sources, section, checked, isAdminLocked, isUserRemovable }) => {
     const { top, bottom } = getViewOptionsTexts(sources());
     const entries = section === 'top' ? top : bottom;
     const other = section === 'top' ? bottom : top;
@@ -331,6 +340,7 @@ describe('getViewOptionsTexts', () => {
     expect(entries).toHaveLength(1);
     expect(entries[0].checked).toBe(checked);
     expect(entries[0].isAdminLocked).toBe(isAdminLocked);
+    expect(entries[0].isUserRemovable).toBe(isUserRemovable);
   });
 
   it('omits a resource that is in no list from both sections', () => {

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
@@ -1,0 +1,511 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  DblResourceReference,
+  ProjectReference,
+  ResourceReference,
+  ResourceReferenceList,
+} from 'platform-scripture';
+import { isDblResourceReference, isProjectReference } from './resource-reference.utils';
+import { CURRENT_DATA_VERSION } from './resource-reference-list.const';
+import {
+  addToUserResources,
+  getScriptureTextGridContents,
+  getViewOptionsTexts,
+  removeFromUserResources,
+  setUserDisplay,
+  type TextCollectionSources,
+} from './scripture-text-grid-contents.utils';
+
+// #region fixtures
+
+const project = (id: string, overrides?: Partial<ProjectReference>): ProjectReference => ({
+  type: 'project',
+  name: `Project ${id}`,
+  id,
+  ...overrides,
+});
+
+const dbl = (id: string, overrides?: Partial<DblResourceReference>): DblResourceReference => ({
+  type: 'dblResource',
+  name: `DBL ${id}`,
+  id,
+  ...overrides,
+});
+
+const list = (items: ResourceReference[] = []): ResourceReferenceList => ({
+  dataVersion: CURRENT_DATA_VERSION,
+  items,
+});
+
+const makeSources = (overrides?: Partial<TextCollectionSources>): TextCollectionSources => ({
+  adminModelTexts: list(),
+  adminReferenced: list(),
+  userReferenced: list(),
+  overlay: {},
+  ...overrides,
+});
+
+const ids = (refs: ResourceReference[]): string[] =>
+  refs.map((ref) => ('id' in ref && typeof ref.id === 'string' ? ref.id : ref.type));
+
+/** Reads a Bible-text flag off a reference without a type assertion. */
+const flagOf = (
+  ref: ResourceReference | undefined,
+  key: 'isResourceShownByDefault' | 'inTextCollectionUser',
+): boolean | undefined =>
+  ref && (isProjectReference(ref) || isDblResourceReference(ref)) ? ref[key] : undefined;
+
+/** Deep-freeze so any in-place mutation throws in strict mode. */
+const deepFreeze = <T>(value: T): T => {
+  if (value && typeof value === 'object') {
+    Object.values(value).forEach(deepFreeze);
+    Object.freeze(value);
+  }
+  return value;
+};
+
+// #endregion
+
+describe('getScriptureTextGridContents', () => {
+  it.each([
+    {
+      label: 'admin flagged true, overlay true → shown',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          overlay: { a: true },
+        }),
+      expected: ['a'],
+    },
+    {
+      label: 'admin flagged true, overlay false (user hid it) → hidden',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          overlay: { a: false },
+        }),
+      expected: [],
+    },
+    {
+      label: 'admin flagged true, overlay absent → shown (falls back to flag)',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          overlay: {},
+        }),
+      expected: ['a'],
+    },
+    {
+      label: 'flagged true only on modelTexts (proves union), overlay absent → shown',
+      sources: () =>
+        makeSources({
+          adminModelTexts: list([project('m', { isResourceShownByDefault: true })]),
+          adminReferenced: list([project('m')]), // flag-stripped download copy
+          overlay: {},
+        }),
+      expected: ['m'],
+    },
+    {
+      label: 'admin unflagged but overlay true (past-admin, still checked) → shown',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('p')]),
+          overlay: { p: true },
+        }),
+      expected: ['p'],
+    },
+    {
+      label: 'admin flag false, no overlay → hidden (admin opted it out)',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
+          overlay: {},
+        }),
+      expected: [],
+    },
+    {
+      label: 'admin flag false, overlay true (user re-enabled) → shown',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
+          overlay: { a: true },
+        }),
+      expected: ['a'],
+    },
+    {
+      label: 'user entry inTextCollectionUser true → shown',
+      sources: () =>
+        makeSources({ userReferenced: list([dbl('u', { inTextCollectionUser: true })]) }),
+      expected: ['u'],
+    },
+    {
+      label: 'user entry inTextCollectionUser false → hidden',
+      sources: () =>
+        makeSources({ userReferenced: list([dbl('u', { inTextCollectionUser: false })]) }),
+      expected: [],
+    },
+    {
+      label: 'not in any list → hidden',
+      sources: () => makeSources(),
+      expected: [],
+    },
+  ])('$label', ({ sources, expected }) => {
+    expect(ids(getScriptureTextGridContents(sources()))).toEqual(expected);
+  });
+
+  it('dedupes an id present in both admin and user lists, keeping the admin entry', () => {
+    const contents = getScriptureTextGridContents(
+      makeSources({
+        adminReferenced: list([project('x', { isResourceShownByDefault: true })]),
+        userReferenced: list([project('x', { inTextCollectionUser: true })]),
+        overlay: { x: true },
+      }),
+    );
+    expect(ids(contents)).toEqual(['x']);
+    expect(contents[0].name).toBe('Project x'); // admin metadata, not user copy
+  });
+
+  it('orders admin entries (model-texts then referenced) before user entries', () => {
+    const contents = getScriptureTextGridContents(
+      makeSources({
+        adminModelTexts: list([project('m', { isResourceShownByDefault: true })]),
+        adminReferenced: list([project('m'), dbl('r', { isResourceShownByDefault: true })]),
+        userReferenced: list([project('u', { inTextCollectionUser: true })]),
+        overlay: {},
+      }),
+    );
+    expect(ids(contents)).toEqual(['m', 'r', 'u']);
+  });
+
+  it('excludes non-Bible-text references even when flagged', () => {
+    const contents = getScriptureTextGridContents(
+      makeSources({
+        adminReferenced: list([
+          { type: 'enhancedResource', name: 'Enhanced', isResourceShownByDefault: true },
+          project('a', { isResourceShownByDefault: true }),
+        ]),
+        overlay: { a: true },
+      }),
+    );
+    expect(ids(contents)).toEqual(['a']);
+  });
+
+  it('excludes non-Bible-text references sitting in the user list', () => {
+    const contents = getScriptureTextGridContents(
+      makeSources({
+        userReferenced: list([
+          { type: 'enhancedResource', name: 'Enhanced' },
+          dbl('u', { inTextCollectionUser: true }),
+        ]),
+      }),
+    );
+    expect(ids(contents)).toEqual(['u']);
+  });
+
+  it('shows a user-added resource that is only an unflagged (download-only) admin entry', () => {
+    // `x` sits in the admin referenced (download) list with no shown-by-default flag, and the user
+    // added it to their own list. It is not admin-owned, so the user's choice drives display.
+    const contents = getScriptureTextGridContents(
+      makeSources({
+        adminReferenced: list([project('x')]),
+        userReferenced: list([project('x', { inTextCollectionUser: true })]),
+        overlay: {},
+      }),
+    );
+    expect(ids(contents)).toEqual(['x']);
+  });
+
+  it('does not mutate its inputs', () => {
+    const sources = deepFreeze(
+      makeSources({
+        adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+        userReferenced: list([dbl('u', { inTextCollectionUser: true })]),
+        overlay: { a: true },
+      }),
+    );
+    expect(() => getScriptureTextGridContents(sources)).not.toThrow();
+  });
+});
+
+describe('getViewOptionsTexts', () => {
+  it.each([
+    {
+      label: 'admin flagged true, overlay true → top, checked, locked',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          overlay: { a: true },
+        }),
+      section: 'top' as const,
+      checked: true,
+      isAdminLocked: true,
+    },
+    {
+      label: 'admin flagged true, overlay false → top, unchecked, locked',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          overlay: { a: false },
+        }),
+      section: 'top' as const,
+      checked: false,
+      isAdminLocked: true,
+    },
+    {
+      label: 'admin flagged true, overlay absent → top, checked (fallback), locked',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          overlay: {},
+        }),
+      section: 'top' as const,
+      checked: true,
+      isAdminLocked: true,
+    },
+    {
+      label: 'flagged true only on modelTexts → top (proves union)',
+      sources: () =>
+        makeSources({
+          adminModelTexts: list([project('a', { isResourceShownByDefault: true })]),
+          adminReferenced: list([project('a')]),
+          overlay: {},
+        }),
+      section: 'top' as const,
+      checked: true,
+      isAdminLocked: true,
+    },
+    {
+      label: 'admin unflagged but overlay present → bottom (past-admin), not locked',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('a')]),
+          overlay: { a: true },
+        }),
+      section: 'bottom' as const,
+      checked: true,
+      isAdminLocked: false,
+    },
+    {
+      label: 'admin flag false, no overlay → bottom, unchecked, not locked',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
+          overlay: {},
+        }),
+      section: 'bottom' as const,
+      checked: false,
+      isAdminLocked: false,
+    },
+    {
+      label: 'admin flag false, overlay true → bottom, checked, not locked',
+      sources: () =>
+        makeSources({
+          adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
+          overlay: { a: true },
+        }),
+      section: 'bottom' as const,
+      checked: true,
+      isAdminLocked: false,
+    },
+    {
+      label: 'user entry inTextCollectionUser true → bottom, checked, removable',
+      sources: () =>
+        makeSources({ userReferenced: list([dbl('u', { inTextCollectionUser: true })]) }),
+      section: 'bottom' as const,
+      checked: true,
+      isAdminLocked: false,
+    },
+    {
+      label: 'user entry inTextCollectionUser false → bottom, unchecked, removable',
+      sources: () =>
+        makeSources({ userReferenced: list([dbl('u', { inTextCollectionUser: false })]) }),
+      section: 'bottom' as const,
+      checked: false,
+      isAdminLocked: false,
+    },
+  ])('$label', ({ sources, section, checked, isAdminLocked }) => {
+    const { top, bottom } = getViewOptionsTexts(sources());
+    const entries = section === 'top' ? top : bottom;
+    const other = section === 'top' ? bottom : top;
+    expect(other).toHaveLength(0);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].checked).toBe(checked);
+    expect(entries[0].isAdminLocked).toBe(isAdminLocked);
+  });
+
+  it('omits a resource that is in no list from both sections', () => {
+    const { top, bottom } = getViewOptionsTexts(makeSources());
+    expect(top).toHaveLength(0);
+    expect(bottom).toHaveLength(0);
+  });
+
+  it('ignores an orphan overlay id that is no longer in any list (nothing to render)', () => {
+    const { top, bottom } = getViewOptionsTexts(makeSources({ overlay: { gone: true } }));
+    expect(top).toHaveLength(0);
+    expect(bottom).toHaveLength(0);
+  });
+
+  it('preserves order: top in union order, bottom in user-list order', () => {
+    const { top, bottom } = getViewOptionsTexts(
+      makeSources({
+        adminModelTexts: list([project('m', { isResourceShownByDefault: true })]),
+        adminReferenced: list([project('m'), dbl('r', { isResourceShownByDefault: true })]),
+        userReferenced: list([
+          project('u1', { inTextCollectionUser: true }),
+          dbl('u2', { inTextCollectionUser: false }),
+        ]),
+        overlay: {},
+      }),
+    );
+    expect(top.map((entry) => entry.reference.id)).toEqual(['m', 'r']);
+    expect(bottom.map((entry) => entry.reference.id)).toEqual(['u1', 'u2']);
+  });
+
+  it('does not duplicate an admin-flagged id into the bottom section', () => {
+    const { top, bottom } = getViewOptionsTexts(
+      makeSources({
+        adminReferenced: list([project('x', { isResourceShownByDefault: true })]),
+        userReferenced: list([project('x', { inTextCollectionUser: true })]),
+        overlay: { x: true },
+      }),
+    );
+    expect(top.map((entry) => entry.reference.id)).toEqual(['x']);
+    expect(bottom).toHaveLength(0);
+  });
+
+  it('lists a user-added resource that is only an unflagged (download-only) admin entry in the bottom', () => {
+    const { top, bottom } = getViewOptionsTexts(
+      makeSources({
+        adminReferenced: list([project('x')]),
+        userReferenced: list([project('x', { inTextCollectionUser: true })]),
+        overlay: {},
+      }),
+    );
+    expect(top).toHaveLength(0);
+    expect(bottom.map((entry) => entry.reference.id)).toEqual(['x']);
+    expect(bottom[0].checked).toBe(true);
+    expect(bottom[0].isAdminLocked).toBe(false);
+  });
+});
+
+describe('setUserDisplay', () => {
+  it('flips the overlay for an admin entry, leaving the admin flag and user list untouched', () => {
+    const sources = makeSources({
+      adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+      overlay: { a: true },
+    });
+    const { overlay, userReferenced } = setUserDisplay('a', false, sources);
+    expect(overlay.a).toBe(false);
+    expect(overlay).not.toBe(sources.overlay); // returns a fresh overlay, not the input
+    expect(userReferenced.items).toEqual([]);
+    // input admin flag unchanged
+    expect(flagOf(sources.adminReferenced.items[0], 'isResourceShownByDefault')).toBe(true);
+    expect(sources.overlay.a).toBe(true);
+  });
+
+  it('routes a user-added, unflagged (download-only) admin id to the user entry, not the overlay', () => {
+    const sources = makeSources({
+      adminReferenced: list([project('x')]),
+      userReferenced: list([project('x', { inTextCollectionUser: true })]),
+      overlay: {},
+    });
+    const { overlay, userReferenced } = setUserDisplay('x', false, sources);
+    expect(overlay).toEqual({}); // not admin-owned, so the overlay is untouched
+    expect(flagOf(userReferenced.items[0], 'inTextCollectionUser')).toBe(false);
+  });
+
+  it('routes an explicitly-disabled (flag false) admin entry to the overlay', () => {
+    const sources = makeSources({
+      adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
+      overlay: {},
+    });
+    const { overlay, userReferenced } = setUserDisplay('a', true, sources);
+    expect(overlay).toEqual({ a: true }); // admin-owned (flag is set), so it writes the overlay
+    expect(userReferenced.items).toEqual([]);
+  });
+
+  it('is a no-op for an orphan overlay id that is in no list', () => {
+    const sources = makeSources({ overlay: { gone: true } });
+    const { overlay, userReferenced } = setUserDisplay('gone', false, sources);
+    expect(overlay).toEqual({ gone: true });
+    expect(userReferenced.items).toEqual([]);
+  });
+
+  it('flips inTextCollectionUser for a user entry, leaving the overlay untouched', () => {
+    const sources = makeSources({
+      userReferenced: list([dbl('u', { inTextCollectionUser: false })]),
+      overlay: { z: true },
+    });
+    const { overlay, userReferenced } = setUserDisplay('u', true, sources);
+    expect(flagOf(userReferenced.items[0], 'inTextCollectionUser')).toBe(true);
+    expect(overlay).toEqual({ z: true });
+    expect(flagOf(sources.userReferenced.items[0], 'inTextCollectionUser')).toBe(false);
+  });
+
+  it('is a no-op for an unknown id', () => {
+    const sources = makeSources({
+      adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+      userReferenced: list([dbl('u', { inTextCollectionUser: true })]),
+      overlay: { a: true },
+    });
+    const { overlay, userReferenced } = setUserDisplay('missing', true, sources);
+    expect(overlay).toEqual({ a: true });
+    expect(userReferenced.items).toEqual(sources.userReferenced.items);
+  });
+
+  it('does not mutate its inputs', () => {
+    const sources = deepFreeze(
+      makeSources({
+        adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+        userReferenced: list([dbl('u', { inTextCollectionUser: false })]),
+        overlay: { a: true },
+      }),
+    );
+    expect(() => setUserDisplay('a', false, sources)).not.toThrow();
+    expect(() => setUserDisplay('u', true, sources)).not.toThrow();
+  });
+});
+
+describe('removeFromUserResources', () => {
+  it('removes a matching user entry', () => {
+    const userReferenced = list([
+      dbl('u1', { inTextCollectionUser: true }),
+      project('u2', { inTextCollectionUser: true }),
+    ]);
+    const result = removeFromUserResources('u1', userReferenced);
+    expect(ids(result.items)).toEqual(['u2']);
+    expect(result.dataVersion).toBe(CURRENT_DATA_VERSION);
+  });
+
+  it('is a no-op when the id is not in the user list (defense-in-depth on admin entries)', () => {
+    const userReferenced = list([dbl('u1', { inTextCollectionUser: true })]);
+    const result = removeFromUserResources('adminOnlyId', userReferenced);
+    expect(ids(result.items)).toEqual(['u1']);
+  });
+
+  it('does not mutate its input', () => {
+    const userReferenced = deepFreeze(list([dbl('u1', { inTextCollectionUser: true })]));
+    expect(() => removeFromUserResources('u1', userReferenced)).not.toThrow();
+  });
+});
+
+describe('addToUserResources', () => {
+  it('appends a new reference with inTextCollectionUser true', () => {
+    const userReferenced = list([dbl('u1', { inTextCollectionUser: true })]);
+    const result = addToUserResources(project('new'), userReferenced);
+    expect(ids(result.items)).toEqual(['u1', 'new']);
+    expect(flagOf(result.items[1], 'inTextCollectionUser')).toBe(true);
+    expect(result.dataVersion).toBe(CURRENT_DATA_VERSION);
+  });
+
+  it('is idempotent when the id is already present', () => {
+    const userReferenced = list([dbl('u1', { inTextCollectionUser: true })]);
+    const result = addToUserResources(dbl('u1'), userReferenced);
+    expect(ids(result.items)).toEqual(['u1']);
+  });
+
+  it('does not mutate its input', () => {
+    const userReferenced = deepFreeze(list([dbl('u1', { inTextCollectionUser: true })]));
+    expect(() => addToUserResources(project('new'), userReferenced)).not.toThrow();
+  });
+});

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
@@ -38,7 +38,6 @@ const list = (items: ResourceReference[] = []): ResourceReferenceList => ({
 });
 
 const makeSources = (overrides?: Partial<TextCollectionSources>): TextCollectionSources => ({
-  adminModelTexts: list(),
   adminReferenced: list(),
   userReferenced: list(),
   overlay: {},
@@ -51,7 +50,7 @@ const ids = (refs: ResourceReference[]): string[] =>
 /** Reads a Bible-text flag off a reference without a type assertion. */
 const flagOf = (
   ref: ResourceReference | undefined,
-  key: 'isResourceShownByDefault' | 'inTextCollectionUser',
+  key: 'isResourceShownByDefault' | 'isResourceShownForUser',
 ): boolean | undefined =>
   ref && (isProjectReference(ref) || isDblResourceReference(ref)) ? ref[key] : undefined;
 
@@ -96,16 +95,6 @@ describe('getScriptureTextGridContents', () => {
       expected: ['a'],
     },
     {
-      label: 'flagged true only on modelTexts (proves union), overlay absent → shown',
-      sources: () =>
-        makeSources({
-          adminModelTexts: list([project('m', { isResourceShownByDefault: true })]),
-          adminReferenced: list([project('m')]), // flag-stripped download copy
-          overlay: {},
-        }),
-      expected: ['m'],
-    },
-    {
       label: 'admin unflagged but overlay true (past-admin, still checked) → shown',
       sources: () =>
         makeSources({
@@ -133,15 +122,15 @@ describe('getScriptureTextGridContents', () => {
       expected: ['a'],
     },
     {
-      label: 'user entry inTextCollectionUser true → shown',
+      label: 'user entry isResourceShownForUser true → shown',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { inTextCollectionUser: true })]) }),
+        makeSources({ userReferenced: list([dbl('u', { isResourceShownForUser: true })]) }),
       expected: ['u'],
     },
     {
-      label: 'user entry inTextCollectionUser false → hidden',
+      label: 'user entry isResourceShownForUser false → hidden',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { inTextCollectionUser: false })]) }),
+        makeSources({ userReferenced: list([dbl('u', { isResourceShownForUser: false })]) }),
       expected: [],
     },
     {
@@ -157,7 +146,7 @@ describe('getScriptureTextGridContents', () => {
     const contents = getScriptureTextGridContents(
       makeSources({
         adminReferenced: list([project('x', { isResourceShownByDefault: true })]),
-        userReferenced: list([project('x', { inTextCollectionUser: true })]),
+        userReferenced: list([project('x', { isResourceShownForUser: true })]),
         overlay: { x: true },
       }),
     );
@@ -165,12 +154,14 @@ describe('getScriptureTextGridContents', () => {
     expect(contents[0].name).toBe('Project x'); // admin metadata, not user copy
   });
 
-  it('orders admin entries (model-texts then referenced) before user entries', () => {
+  it('orders admin (referenced) entries before user entries', () => {
     const contents = getScriptureTextGridContents(
       makeSources({
-        adminModelTexts: list([project('m', { isResourceShownByDefault: true })]),
-        adminReferenced: list([project('m'), dbl('r', { isResourceShownByDefault: true })]),
-        userReferenced: list([project('u', { inTextCollectionUser: true })]),
+        adminReferenced: list([
+          project('m', { isResourceShownByDefault: true }),
+          dbl('r', { isResourceShownByDefault: true }),
+        ]),
+        userReferenced: list([project('u', { isResourceShownForUser: true })]),
         overlay: {},
       }),
     );
@@ -195,7 +186,7 @@ describe('getScriptureTextGridContents', () => {
       makeSources({
         userReferenced: list([
           { type: 'enhancedResource', name: 'Enhanced' },
-          dbl('u', { inTextCollectionUser: true }),
+          dbl('u', { isResourceShownForUser: true }),
         ]),
       }),
     );
@@ -208,7 +199,7 @@ describe('getScriptureTextGridContents', () => {
     const contents = getScriptureTextGridContents(
       makeSources({
         adminReferenced: list([project('x')]),
-        userReferenced: list([project('x', { inTextCollectionUser: true })]),
+        userReferenced: list([project('x', { isResourceShownForUser: true })]),
         overlay: {},
       }),
     );
@@ -219,7 +210,7 @@ describe('getScriptureTextGridContents', () => {
     const sources = deepFreeze(
       makeSources({
         adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
-        userReferenced: list([dbl('u', { inTextCollectionUser: true })]),
+        userReferenced: list([dbl('u', { isResourceShownForUser: true })]),
         overlay: { a: true },
       }),
     );
@@ -266,19 +257,6 @@ describe('getViewOptionsTexts', () => {
       isUserRemovable: false,
     },
     {
-      label: 'flagged true only on modelTexts → top (proves union)',
-      sources: () =>
-        makeSources({
-          adminModelTexts: list([project('a', { isResourceShownByDefault: true })]),
-          adminReferenced: list([project('a')]),
-          overlay: {},
-        }),
-      section: 'top' as const,
-      checked: true,
-      isAdminLocked: true,
-      isUserRemovable: false,
-    },
-    {
       label: 'admin unflagged but overlay present → bottom (past-admin), not locked, not removable',
       sources: () =>
         makeSources({
@@ -315,18 +293,18 @@ describe('getViewOptionsTexts', () => {
       isUserRemovable: false,
     },
     {
-      label: 'user entry inTextCollectionUser true → bottom, checked, removable',
+      label: 'user entry isResourceShownForUser true → bottom, checked, removable',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { inTextCollectionUser: true })]) }),
+        makeSources({ userReferenced: list([dbl('u', { isResourceShownForUser: true })]) }),
       section: 'bottom' as const,
       checked: true,
       isAdminLocked: false,
       isUserRemovable: true,
     },
     {
-      label: 'user entry inTextCollectionUser false → bottom, unchecked, removable',
+      label: 'user entry isResourceShownForUser false → bottom, unchecked, removable',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { inTextCollectionUser: false })]) }),
+        makeSources({ userReferenced: list([dbl('u', { isResourceShownForUser: false })]) }),
       section: 'bottom' as const,
       checked: false,
       isAdminLocked: false,
@@ -355,14 +333,16 @@ describe('getViewOptionsTexts', () => {
     expect(bottom).toHaveLength(0);
   });
 
-  it('preserves order: top in union order, bottom in user-list order', () => {
+  it('preserves order: top in referenced-list order, bottom in user-list order', () => {
     const { top, bottom } = getViewOptionsTexts(
       makeSources({
-        adminModelTexts: list([project('m', { isResourceShownByDefault: true })]),
-        adminReferenced: list([project('m'), dbl('r', { isResourceShownByDefault: true })]),
+        adminReferenced: list([
+          project('m', { isResourceShownByDefault: true }),
+          dbl('r', { isResourceShownByDefault: true }),
+        ]),
         userReferenced: list([
-          project('u1', { inTextCollectionUser: true }),
-          dbl('u2', { inTextCollectionUser: false }),
+          project('u1', { isResourceShownForUser: true }),
+          dbl('u2', { isResourceShownForUser: false }),
         ]),
         overlay: {},
       }),
@@ -375,7 +355,7 @@ describe('getViewOptionsTexts', () => {
     const { top, bottom } = getViewOptionsTexts(
       makeSources({
         adminReferenced: list([project('x', { isResourceShownByDefault: true })]),
-        userReferenced: list([project('x', { inTextCollectionUser: true })]),
+        userReferenced: list([project('x', { isResourceShownForUser: true })]),
         overlay: { x: true },
       }),
     );
@@ -387,7 +367,7 @@ describe('getViewOptionsTexts', () => {
     const { top, bottom } = getViewOptionsTexts(
       makeSources({
         adminReferenced: list([project('x')]),
-        userReferenced: list([project('x', { inTextCollectionUser: true })]),
+        userReferenced: list([project('x', { isResourceShownForUser: true })]),
         overlay: {},
       }),
     );
@@ -416,12 +396,12 @@ describe('setUserDisplay', () => {
   it('routes a user-added, unflagged (download-only) admin id to the user entry, not the overlay', () => {
     const sources = makeSources({
       adminReferenced: list([project('x')]),
-      userReferenced: list([project('x', { inTextCollectionUser: true })]),
+      userReferenced: list([project('x', { isResourceShownForUser: true })]),
       overlay: {},
     });
     const { overlay, userReferenced } = setUserDisplay('x', false, sources);
     expect(overlay).toEqual({}); // not admin-owned, so the overlay is untouched
-    expect(flagOf(userReferenced.items[0], 'inTextCollectionUser')).toBe(false);
+    expect(flagOf(userReferenced.items[0], 'isResourceShownForUser')).toBe(false);
   });
 
   it('routes an explicitly-disabled (flag false) admin entry to the overlay', () => {
@@ -441,21 +421,21 @@ describe('setUserDisplay', () => {
     expect(userReferenced.items).toEqual([]);
   });
 
-  it('flips inTextCollectionUser for a user entry, leaving the overlay untouched', () => {
+  it('flips isResourceShownForUser for a user entry, leaving the overlay untouched', () => {
     const sources = makeSources({
-      userReferenced: list([dbl('u', { inTextCollectionUser: false })]),
+      userReferenced: list([dbl('u', { isResourceShownForUser: false })]),
       overlay: { z: true },
     });
     const { overlay, userReferenced } = setUserDisplay('u', true, sources);
-    expect(flagOf(userReferenced.items[0], 'inTextCollectionUser')).toBe(true);
+    expect(flagOf(userReferenced.items[0], 'isResourceShownForUser')).toBe(true);
     expect(overlay).toEqual({ z: true });
-    expect(flagOf(sources.userReferenced.items[0], 'inTextCollectionUser')).toBe(false);
+    expect(flagOf(sources.userReferenced.items[0], 'isResourceShownForUser')).toBe(false);
   });
 
   it('is a no-op for an unknown id', () => {
     const sources = makeSources({
       adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
-      userReferenced: list([dbl('u', { inTextCollectionUser: true })]),
+      userReferenced: list([dbl('u', { isResourceShownForUser: true })]),
       overlay: { a: true },
     });
     const { overlay, userReferenced } = setUserDisplay('missing', true, sources);
@@ -467,7 +447,7 @@ describe('setUserDisplay', () => {
     const sources = deepFreeze(
       makeSources({
         adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
-        userReferenced: list([dbl('u', { inTextCollectionUser: false })]),
+        userReferenced: list([dbl('u', { isResourceShownForUser: false })]),
         overlay: { a: true },
       }),
     );
@@ -479,8 +459,8 @@ describe('setUserDisplay', () => {
 describe('removeFromUserResources', () => {
   it('removes a matching user entry', () => {
     const userReferenced = list([
-      dbl('u1', { inTextCollectionUser: true }),
-      project('u2', { inTextCollectionUser: true }),
+      dbl('u1', { isResourceShownForUser: true }),
+      project('u2', { isResourceShownForUser: true }),
     ]);
     const result = removeFromUserResources('u1', userReferenced);
     expect(ids(result.items)).toEqual(['u2']);
@@ -488,34 +468,34 @@ describe('removeFromUserResources', () => {
   });
 
   it('is a no-op when the id is not in the user list (defense-in-depth on admin entries)', () => {
-    const userReferenced = list([dbl('u1', { inTextCollectionUser: true })]);
+    const userReferenced = list([dbl('u1', { isResourceShownForUser: true })]);
     const result = removeFromUserResources('adminOnlyId', userReferenced);
     expect(ids(result.items)).toEqual(['u1']);
   });
 
   it('does not mutate its input', () => {
-    const userReferenced = deepFreeze(list([dbl('u1', { inTextCollectionUser: true })]));
+    const userReferenced = deepFreeze(list([dbl('u1', { isResourceShownForUser: true })]));
     expect(() => removeFromUserResources('u1', userReferenced)).not.toThrow();
   });
 });
 
 describe('addToUserResources', () => {
-  it('appends a new reference with inTextCollectionUser true', () => {
-    const userReferenced = list([dbl('u1', { inTextCollectionUser: true })]);
+  it('appends a new reference with isResourceShownForUser true', () => {
+    const userReferenced = list([dbl('u1', { isResourceShownForUser: true })]);
     const result = addToUserResources(project('new'), userReferenced);
     expect(ids(result.items)).toEqual(['u1', 'new']);
-    expect(flagOf(result.items[1], 'inTextCollectionUser')).toBe(true);
+    expect(flagOf(result.items[1], 'isResourceShownForUser')).toBe(true);
     expect(result.dataVersion).toBe(CURRENT_DATA_VERSION);
   });
 
   it('is idempotent when the id is already present', () => {
-    const userReferenced = list([dbl('u1', { inTextCollectionUser: true })]);
+    const userReferenced = list([dbl('u1', { isResourceShownForUser: true })]);
     const result = addToUserResources(dbl('u1'), userReferenced);
     expect(ids(result.items)).toEqual(['u1']);
   });
 
   it('does not mutate its input', () => {
-    const userReferenced = deepFreeze(list([dbl('u1', { inTextCollectionUser: true })]));
+    const userReferenced = deepFreeze(list([dbl('u1', { isResourceShownForUser: true })]));
     expect(() => addToUserResources(project('new'), userReferenced)).not.toThrow();
   });
 });

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
@@ -111,6 +111,17 @@ function isAdminEntryShown(overlay: ShownByDefaultOverlay, entry: AdminOwnedEntr
 }
 
 /**
+ * Whether `resourceId` is an admin-owned entry for the given sources (see
+ * {@link getAdminOwnedEntries}).
+ */
+function isAdminOwnedId(resourceId: string, sources: TextCollectionSources): boolean {
+  const { adminModelTexts, adminReferenced, overlay } = sources;
+  return getAdminOwnedEntries(adminModelTexts, adminReferenced, overlay).some(
+    (entry) => entry.reference.id === resourceId,
+  );
+}
+
+/**
  * Computes the Bible-text references that render in the Scripture Text Grid for the current user:
  * admin-owned entries the user has shown (overlay choice, falling back to the admin flag), followed
  * by the user's own list entries with `inTextCollectionUser === true`. Deduplicated by `id` with
@@ -194,12 +205,10 @@ export function setUserDisplay(
   shown: boolean,
   sources: TextCollectionSources,
 ): { userReferenced: ResourceReferenceList; overlay: ShownByDefaultOverlay } {
-  const { adminModelTexts, adminReferenced, userReferenced, overlay } = sources;
-  const isAdminOwned = getAdminOwnedEntries(adminModelTexts, adminReferenced, overlay).some(
-    (entry) => entry.reference.id === resourceId,
-  );
+  const { userReferenced, overlay } = sources;
 
-  if (isAdminOwned) return { userReferenced, overlay: { ...overlay, [resourceId]: shown } };
+  if (isAdminOwnedId(resourceId, sources))
+    return { userReferenced, overlay: { ...overlay, [resourceId]: shown } };
 
   const index = userReferenced.items.findIndex((item) => getBibleTextId(item) === resourceId);
   if (index < 0) return { userReferenced, overlay };

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
@@ -14,8 +14,8 @@ type BibleTextReference = ProjectReference | DblResourceReference;
 /**
  * The four data sources that together determine what a given user sees in the Text Collection.
  *
- * Two admin lists are read, not one: A2's auto-promote strips the `isResourceShownByDefault` flag
- * off the download copy it adds to `referencedProjectsAndResources`, so the flag survives on
+ * Two admin lists are read, not one: the auto-promote step strips the `isResourceShownByDefault`
+ * flag off the download copy it adds to `referencedProjectsAndResources`, so the flag survives on
  * `modelTexts`.
  */
 export type TextCollectionSources = {
@@ -211,8 +211,14 @@ export function setUserDisplay(
 }
 
 /**
- * Removes a resource from the user's per-user list entirely (the A5 hover-X). No-op when the id is
- * not in the user list — including admin entries, which never live there (defense-in-depth).
+ * Removes a resource from the user's per-user list entirely (the hover-X remove affordance). No-op
+ * when the id is not in the user list — including admin entries, which never live there
+ * (defense-in-depth).
+ *
+ * Only Bible-text references (project / DBL resource) can be removed: matching is by
+ * {@link getBibleTextId}, which returns `undefined` for non-Bible-text references (e.g.
+ * `enhancedResource`), so those never match `resourceId` and are left untouched. By design the Text
+ * Collection holds only Bible-text references, so this is not a gap.
  */
 export function removeFromUserResources(
   resourceId: string,
@@ -225,13 +231,12 @@ export function removeFromUserResources(
 
 /**
  * Appends a Bible-text reference to the user's per-user list with `inTextCollectionUser === true`
- * (the A5 Get Resources flow). Idempotent: returns the list unchanged when the id is already
- * present.
+ * (the Get Resources flow). Idempotent: returns the list unchanged when the id is already present.
  *
  * Precondition: `reference` must not be an admin-owned resource. Admin-owned resources are
  * overlay-driven — toggle them with {@link setUserDisplay}; a user-list entry for one is ignored by
- * the read helpers. A5 only adds resources the user picked that aren't already in the admin
- * selection.
+ * the read helpers. The Get Resources flow only adds resources the user picked that aren't already
+ * in the admin selection.
  */
 export function addToUserResources(
   reference: BibleTextReference,

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
@@ -8,19 +8,18 @@ import type {
 import { isDblResourceReference, isProjectReference } from './resource-reference.utils';
 import { CURRENT_DATA_VERSION } from './resource-reference-list.const';
 
-/** A Bible-text reference — the only reference types that carry `id` and `inTextCollectionUser`. */
+/** A Bible-text reference — the only reference types that carry `id` and `isResourceShownForUser`. */
 type BibleTextReference = ProjectReference | DblResourceReference;
 
 /**
- * The four data sources that together determine what a given user sees in the Text Collection.
+ * The three data sources that together determine what a given user sees in the Text Collection.
  *
- * Two admin lists are read, not one: the auto-promote step strips the `isResourceShownByDefault`
- * flag off the download copy it adds to `referencedProjectsAndResources`, so the flag survives on
- * `modelTexts`.
+ * The admin's shown-by-default opinions live solely on `referencedProjectsAndResources`: model
+ * texts are decoupled from the shown-by-default feature (they carry no `isResourceShownByDefault`
+ * flag and the overlay is initialized only from the referenced list), so they are not a source
+ * here.
  */
 export type TextCollectionSources = {
-  /** Admin project-scope `platformScripture.modelTexts` list. */
-  adminModelTexts: ResourceReferenceList;
   /** Admin project-scope `platformScripture.referencedProjectsAndResources` list. */
   adminReferenced: ResourceReferenceList;
   /** The current user's per-user `UserReferencedProjectsAndResources` list. */
@@ -58,19 +57,20 @@ function getBibleTextId(reference: unknown): string | undefined {
 }
 
 /**
- * The Bible-text resources the admin owns for the Text Collection, decided per admin-list item: a
- * resource is owned when the admin has an opinion on it (`isResourceShownByDefault` set to `true`
- * or `false`) or the user still has an overlay slot for it from a prior admin selection.
- * Deduplicated by `id`, `modelTexts` order first.
+ * The Bible-text resources the admin owns for the Text Collection, decided per referenced-list
+ * item: a resource is owned when the admin has an opinion on it (`isResourceShownByDefault` set to
+ * `true` or `false`) or the user still has an overlay slot for it from a prior admin selection.
+ * Deduplicated by `id`, referenced-list order.
  *
- * A resource merely present in an admin list with no flag (e.g. downloaded for another feature) is
- * NOT owned — the user can add it to their own list like any other resource. An overlay slot whose
- * id is no longer in either admin list is ignored: there is no reference left to render.
+ * Only the admin `referencedProjectsAndResources` list is read — model texts are decoupled from the
+ * shown-by-default feature. A resource merely present in the referenced list with no flag (e.g.
+ * downloaded for another feature) is NOT owned — the user can add it to their own list like any
+ * other resource. An overlay slot whose id is no longer in the referenced list is ignored: there is
+ * no reference left to render.
  *
- * `adminFlagged` is `true` when the resource is currently shown-by-default in either admin list.
+ * `adminFlagged` is `true` when the resource is currently shown-by-default in the referenced list.
  */
 function getAdminOwnedEntries(
-  adminModelTexts: ResourceReferenceList,
   adminReferenced: ResourceReferenceList,
   overlay: ShownByDefaultOverlay,
 ): AdminOwnedEntry[] {
@@ -95,7 +95,6 @@ function getAdminOwnedEntries(
     entries.push(entry);
   };
 
-  adminModelTexts.items.forEach(consider);
   adminReferenced.items.forEach(consider);
   return entries;
 }
@@ -115,8 +114,8 @@ function isAdminEntryShown(overlay: ShownByDefaultOverlay, entry: AdminOwnedEntr
  * {@link getAdminOwnedEntries}).
  */
 function isAdminOwnedId(resourceId: string, sources: TextCollectionSources): boolean {
-  const { adminModelTexts, adminReferenced, overlay } = sources;
-  return getAdminOwnedEntries(adminModelTexts, adminReferenced, overlay).some(
+  const { adminReferenced, overlay } = sources;
+  return getAdminOwnedEntries(adminReferenced, overlay).some(
     (entry) => entry.reference.id === resourceId,
   );
 }
@@ -124,12 +123,12 @@ function isAdminOwnedId(resourceId: string, sources: TextCollectionSources): boo
 /**
  * Computes the Bible-text references that render in the Scripture Text Grid for the current user:
  * admin-owned entries the user has shown (overlay choice, falling back to the admin flag), followed
- * by the user's own list entries with `inTextCollectionUser === true`. Deduplicated by `id` with
- * admin precedence; admin entries keep project-list order, user entries keep user-list order.
+ * by the user's own list entries with `isResourceShownForUser === true`. Deduplicated by `id` with
+ * admin precedence; admin entries keep referenced-list order, user entries keep user-list order.
  */
 export function getScriptureTextGridContents(sources: TextCollectionSources): BibleTextReference[] {
-  const { adminModelTexts, adminReferenced, userReferenced, overlay } = sources;
-  const adminOwned = getAdminOwnedEntries(adminModelTexts, adminReferenced, overlay);
+  const { adminReferenced, userReferenced, overlay } = sources;
+  const adminOwned = getAdminOwnedEntries(adminReferenced, overlay);
   const seen = new Set<string>();
   const contents: BibleTextReference[] = [];
 
@@ -142,7 +141,7 @@ export function getScriptureTextGridContents(sources: TextCollectionSources): Bi
     if (!isProjectReference(item) && !isDblResourceReference(item)) return;
     if (seen.has(item.id)) return;
     seen.add(item.id);
-    if (item.inTextCollectionUser === true) contents.push(item);
+    if (item.isResourceShownForUser === true) contents.push(item);
   });
 
   return contents;
@@ -156,15 +155,16 @@ export function getScriptureTextGridContents(sources: TextCollectionSources): Bi
  * - `bottom` — resources the user can freely toggle and remove (`isAdminLocked: false`): other
  *   admin-owned entries (opted out, or shown before) followed by the user's own list additions.
  *
- * Checkbox state comes from the overlay for admin-owned entries and from `inTextCollectionUser` for
- * the user's own entries. An admin-owned id never also appears as a user entry (admin precedence).
+ * Checkbox state comes from the overlay for admin-owned entries and from `isResourceShownForUser`
+ * for the user's own entries. An admin-owned id never also appears as a user entry (admin
+ * precedence).
  */
 export function getViewOptionsTexts(sources: TextCollectionSources): {
   top: ViewOptionsTextEntry[];
   bottom: ViewOptionsTextEntry[];
 } {
-  const { adminModelTexts, adminReferenced, userReferenced, overlay } = sources;
-  const adminOwned = getAdminOwnedEntries(adminModelTexts, adminReferenced, overlay);
+  const { adminReferenced, userReferenced, overlay } = sources;
+  const adminOwned = getAdminOwnedEntries(adminReferenced, overlay);
   const top: ViewOptionsTextEntry[] = [];
   const bottom: ViewOptionsTextEntry[] = [];
   const adminIds = new Set<string>();
@@ -185,7 +185,7 @@ export function getViewOptionsTexts(sources: TextCollectionSources): {
     if (adminIds.has(item.id)) return; // admin-owned ids are rendered by the loop above
     bottom.push({
       reference: item,
-      checked: item.inTextCollectionUser === true,
+      checked: item.isResourceShownForUser === true,
       isAdminLocked: false,
       isUserRemovable: true,
     });
@@ -197,7 +197,7 @@ export function getViewOptionsTexts(sources: TextCollectionSources): {
 /**
  * Records the user's shown/hidden choice for a resource, returning the next state (callers
  * persist). Routes by ownership: an admin-owned entry writes the per-user overlay (the admin's flag
- * is untouched); a user-list entry writes that item's `inTextCollectionUser`. Unknown ids are a
+ * is untouched); a user-list entry writes that item's `isResourceShownForUser`. Unknown ids are a
  * no-op.
  */
 export function setUserDisplay(
@@ -214,7 +214,7 @@ export function setUserDisplay(
   if (index < 0) return { userReferenced, overlay };
 
   const items = userReferenced.items.map((item, itemIndex) =>
-    itemIndex === index ? { ...item, inTextCollectionUser: shown } : item,
+    itemIndex === index ? { ...item, isResourceShownForUser: shown } : item,
   );
   return { userReferenced: { dataVersion: CURRENT_DATA_VERSION, items }, overlay };
 }
@@ -239,7 +239,7 @@ export function removeFromUserResources(
 }
 
 /**
- * Appends a Bible-text reference to the user's per-user list with `inTextCollectionUser === true`
+ * Appends a Bible-text reference to the user's per-user list with `isResourceShownForUser === true`
  * (the Get Resources flow). Idempotent: returns the list unchanged when the id is already present.
  *
  * Precondition: `reference` must not be an admin-owned resource. Admin-owned resources are
@@ -256,6 +256,6 @@ export function addToUserResources(
   }
   return {
     dataVersion: CURRENT_DATA_VERSION,
-    items: [...userReferenced.items, { ...reference, inTextCollectionUser: true }],
+    items: [...userReferenced.items, { ...reference, isResourceShownForUser: true }],
   };
 }

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
@@ -1,0 +1,236 @@
+import type {
+  DblResourceReference,
+  ProjectReference,
+  ResourceReference,
+  ResourceReferenceList,
+  ShownByDefaultOverlay,
+} from 'platform-scripture';
+import { isDblResourceReference, isProjectReference } from './resource-reference.utils';
+import { CURRENT_DATA_VERSION } from './resource-reference-list.const';
+
+/** A Bible-text reference — the only reference types that carry `id` and `inTextCollectionUser`. */
+type BibleTextReference = ProjectReference | DblResourceReference;
+
+/**
+ * The four data sources that together determine what a given user sees in the Text Collection.
+ *
+ * Two admin lists are read, not one: A2's auto-promote strips the `isResourceShownByDefault` flag
+ * off the download copy it adds to `referencedProjectsAndResources`, so the flag survives on
+ * `modelTexts`.
+ */
+export type TextCollectionSources = {
+  /** Admin project-scope `platformScripture.modelTexts` list. */
+  adminModelTexts: ResourceReferenceList;
+  /** Admin project-scope `platformScripture.referencedProjectsAndResources` list. */
+  adminReferenced: ResourceReferenceList;
+  /** The current user's per-user `UserReferencedProjectsAndResources` list. */
+  userReferenced: ResourceReferenceList;
+  /** The current user's per-user shown-by-default overlay (keyed by resource id). */
+  overlay: ShownByDefaultOverlay;
+};
+
+/** A single row in the View Options TEXTS list. */
+export type ViewOptionsTextEntry = {
+  /** The Bible-text reference this row represents. */
+  reference: BibleTextReference;
+  /** Whether the row's checkbox is checked (i.e. the text shows in the grid for this user). */
+  checked: boolean;
+  /**
+   * `true` for admin-selected (top-section) rows: the user may uncheck them to hide the text from
+   * the grid, but the row stays in the list and has no remove (hover-X) affordance.
+   */
+  isAdminLocked: boolean;
+};
+
+/** An admin-owned entry: one Bible-text reference plus whether the admin currently flags it shown. */
+type AdminOwnedEntry = { reference: BibleTextReference; adminFlagged: boolean };
+
+/** Narrows any reference to a Bible-text reference and returns its id, else `undefined`. */
+function getBibleTextId(reference: unknown): string | undefined {
+  if (isProjectReference(reference) || isDblResourceReference(reference)) return reference.id;
+  return undefined;
+}
+
+/**
+ * The Bible-text resources the admin owns for the Text Collection, decided per admin-list item: a
+ * resource is owned when the admin has an opinion on it (`isResourceShownByDefault` set to `true`
+ * or `false`) or the user still has an overlay slot for it from a prior admin selection.
+ * Deduplicated by `id`, `modelTexts` order first.
+ *
+ * A resource merely present in an admin list with no flag (e.g. downloaded for another feature) is
+ * NOT owned — the user can add it to their own list like any other resource. An overlay slot whose
+ * id is no longer in either admin list is ignored: there is no reference left to render.
+ *
+ * `adminFlagged` is `true` when the resource is currently shown-by-default in either admin list.
+ */
+function getAdminOwnedEntries(
+  adminModelTexts: ResourceReferenceList,
+  adminReferenced: ResourceReferenceList,
+  overlay: ShownByDefaultOverlay,
+): AdminOwnedEntry[] {
+  const byId = new Map<string, AdminOwnedEntry>();
+  const entries: AdminOwnedEntry[] = [];
+
+  const consider = (item: ResourceReference) => {
+    if (!isProjectReference(item) && !isDblResourceReference(item)) return;
+    const isFlagSet = item.isResourceShownByDefault !== undefined;
+    if (!isFlagSet && !Object.hasOwn(overlay, item.id)) return;
+    const flagged = item.isResourceShownByDefault === true;
+    const existing = byId.get(item.id);
+    if (existing) {
+      if (flagged) existing.adminFlagged = true;
+      return;
+    }
+    const entry: AdminOwnedEntry = { reference: item, adminFlagged: flagged };
+    byId.set(item.id, entry);
+    entries.push(entry);
+  };
+
+  adminModelTexts.items.forEach(consider);
+  adminReferenced.items.forEach(consider);
+  return entries;
+}
+
+/**
+ * The user's effective shown-state for an admin-owned entry: their overlay choice, else the admin
+ * flag.
+ */
+function isAdminEntryShown(overlay: ShownByDefaultOverlay, entry: AdminOwnedEntry): boolean {
+  return Object.hasOwn(overlay, entry.reference.id)
+    ? overlay[entry.reference.id]
+    : entry.adminFlagged;
+}
+
+/**
+ * Computes the Bible-text references that render in the Scripture Text Grid for the current user:
+ * admin-owned entries the user has shown (overlay choice, falling back to the admin flag), followed
+ * by the user's own list entries with `inTextCollectionUser === true`. Deduplicated by `id` with
+ * admin precedence; admin entries keep project-list order, user entries keep user-list order.
+ */
+export function getScriptureTextGridContents(sources: TextCollectionSources): BibleTextReference[] {
+  const { adminModelTexts, adminReferenced, userReferenced, overlay } = sources;
+  const adminOwned = getAdminOwnedEntries(adminModelTexts, adminReferenced, overlay);
+  const seen = new Set<string>();
+  const contents: BibleTextReference[] = [];
+
+  adminOwned.forEach((entry) => {
+    seen.add(entry.reference.id);
+    if (isAdminEntryShown(overlay, entry)) contents.push(entry.reference);
+  });
+
+  userReferenced.items.forEach((item) => {
+    if (!isProjectReference(item) && !isDblResourceReference(item)) return;
+    if (seen.has(item.id)) return;
+    seen.add(item.id);
+    if (item.inTextCollectionUser === true) contents.push(item);
+  });
+
+  return contents;
+}
+
+/**
+ * Splits the View Options TEXTS list into two ordered sections:
+ *
+ * - `top` — the admin's current selection (`isResourceShownByDefault === true`). Always visible and
+ *   locked from removal (`isAdminLocked: true`); the user may only uncheck to hide from the grid.
+ * - `bottom` — resources the user can freely toggle and remove (`isAdminLocked: false`): other
+ *   admin-owned entries (opted out, or shown before) followed by the user's own list additions.
+ *
+ * Checkbox state comes from the overlay for admin-owned entries and from `inTextCollectionUser` for
+ * the user's own entries. An admin-owned id never also appears as a user entry (admin precedence).
+ */
+export function getViewOptionsTexts(sources: TextCollectionSources): {
+  top: ViewOptionsTextEntry[];
+  bottom: ViewOptionsTextEntry[];
+} {
+  const { adminModelTexts, adminReferenced, userReferenced, overlay } = sources;
+  const adminOwned = getAdminOwnedEntries(adminModelTexts, adminReferenced, overlay);
+  const top: ViewOptionsTextEntry[] = [];
+  const bottom: ViewOptionsTextEntry[] = [];
+  const adminIds = new Set<string>();
+
+  adminOwned.forEach((entry) => {
+    adminIds.add(entry.reference.id);
+    const row = {
+      reference: entry.reference,
+      checked: isAdminEntryShown(overlay, entry),
+      isAdminLocked: entry.adminFlagged,
+    };
+    (entry.adminFlagged ? top : bottom).push(row);
+  });
+
+  userReferenced.items.forEach((item) => {
+    if (!isProjectReference(item) && !isDblResourceReference(item)) return;
+    if (adminIds.has(item.id)) return; // admin-owned ids are rendered by the loop above
+    bottom.push({
+      reference: item,
+      checked: item.inTextCollectionUser === true,
+      isAdminLocked: false,
+    });
+  });
+
+  return { top, bottom };
+}
+
+/**
+ * Records the user's shown/hidden choice for a resource, returning the next state (callers
+ * persist). Routes by ownership: an admin-owned entry writes the per-user overlay (the admin's flag
+ * is untouched); a user-list entry writes that item's `inTextCollectionUser`. Unknown ids are a
+ * no-op.
+ */
+export function setUserDisplay(
+  resourceId: string,
+  shown: boolean,
+  sources: TextCollectionSources,
+): { userReferenced: ResourceReferenceList; overlay: ShownByDefaultOverlay } {
+  const { adminModelTexts, adminReferenced, userReferenced, overlay } = sources;
+  const isAdminOwned = getAdminOwnedEntries(adminModelTexts, adminReferenced, overlay).some(
+    (entry) => entry.reference.id === resourceId,
+  );
+
+  if (isAdminOwned) return { userReferenced, overlay: { ...overlay, [resourceId]: shown } };
+
+  const index = userReferenced.items.findIndex((item) => getBibleTextId(item) === resourceId);
+  if (index < 0) return { userReferenced, overlay };
+
+  const items = userReferenced.items.map((item, itemIndex) =>
+    itemIndex === index ? { ...item, inTextCollectionUser: shown } : item,
+  );
+  return { userReferenced: { dataVersion: CURRENT_DATA_VERSION, items }, overlay };
+}
+
+/**
+ * Removes a resource from the user's per-user list entirely (the A5 hover-X). No-op when the id is
+ * not in the user list — including admin entries, which never live there (defense-in-depth).
+ */
+export function removeFromUserResources(
+  resourceId: string,
+  userReferenced: ResourceReferenceList,
+): ResourceReferenceList {
+  const items = userReferenced.items.filter((item) => getBibleTextId(item) !== resourceId);
+  if (items.length === userReferenced.items.length) return userReferenced;
+  return { dataVersion: CURRENT_DATA_VERSION, items };
+}
+
+/**
+ * Appends a Bible-text reference to the user's per-user list with `inTextCollectionUser === true`
+ * (the A5 Get Resources flow). Idempotent: returns the list unchanged when the id is already
+ * present.
+ *
+ * Precondition: `reference` must not be an admin-owned resource. Admin-owned resources are
+ * overlay-driven — toggle them with {@link setUserDisplay}; a user-list entry for one is ignored by
+ * the read helpers. A5 only adds resources the user picked that aren't already in the admin
+ * selection.
+ */
+export function addToUserResources(
+  reference: BibleTextReference,
+  userReferenced: ResourceReferenceList,
+): ResourceReferenceList {
+  if (userReferenced.items.some((item) => getBibleTextId(item) === reference.id)) {
+    return userReferenced;
+  }
+  return {
+    dataVersion: CURRENT_DATA_VERSION,
+    items: [...userReferenced.items, { ...reference, inTextCollectionUser: true }],
+  };
+}

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
@@ -40,6 +40,12 @@ export type ViewOptionsTextEntry = {
    * the grid, but the row stays in the list and has no remove (hover-X) affordance.
    */
   isAdminLocked: boolean;
+  /**
+   * `true` only for genuine user-list entries — the only rows that show a remove (hover-X)
+   * affordance; `false` for every admin-owned row (top or bottom), which can be unchecked but never
+   * removed.
+   */
+  isUserRemovable: boolean;
 };
 
 /** An admin-owned entry: one Bible-text reference plus whether the admin currently flags it shown. */
@@ -158,6 +164,7 @@ export function getViewOptionsTexts(sources: TextCollectionSources): {
       reference: entry.reference,
       checked: isAdminEntryShown(overlay, entry),
       isAdminLocked: entry.adminFlagged,
+      isUserRemovable: false,
     };
     (entry.adminFlagged ? top : bottom).push(row);
   });
@@ -169,6 +176,7 @@ export function getViewOptionsTexts(sources: TextCollectionSources): {
       reference: item,
       checked: item.inTextCollectionUser === true,
       isAdminLocked: false,
+      isUserRemovable: true,
     });
   });
 

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
@@ -73,14 +73,17 @@ function getAdminOwnedEntries(
 
   const consider = (item: ResourceReference) => {
     if (!isProjectReference(item) && !isDblResourceReference(item)) return;
+
     const isFlagSet = item.isResourceShownByDefault !== undefined;
     if (!isFlagSet && !Object.hasOwn(overlay, item.id)) return;
+
     const flagged = item.isResourceShownByDefault === true;
     const existing = byId.get(item.id);
     if (existing) {
       if (flagged) existing.adminFlagged = true;
       return;
     }
+
     const entry: AdminOwnedEntry = { reference: item, adminFlagged: flagged };
     byId.set(item.id, entry);
     entries.push(entry);


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-4051-effective-filter

**Base**: origin/pt-4050-two-flag-schema (stacked on A2 / PT-4050, which is not yet merged to `main`)

**Date**: 2026-07-07

**Review model**: Claude Opus 4.8 (1M context)

**Files changed**: 2

## Overview

A3 (PT-4051) adds the pure logic layer for the Scripture Text Grid ("Text Collection"), built on A2's two-flag schema. It ships two read helpers (`getScriptureTextGridContents`, `getViewOptionsTexts`) and three pure next-state mutation transforms (`setUserDisplay`, `removeFromUserResources`, `addToUserResources`) in `scripture-text-grid-contents.utils.ts`, with 43 colocated table-driven tests. The layer is logic-only — no UI, no PAPI surface, no persistence; A4/A5/A6 wire these into the grid, View Options panel, and empty state, and A5 owns persistence.

The central concept is admin-ownership: a resource is admin-owned when `isResourceShownByDefault` is set (`true` or `false`) in either admin list (`modelTexts` / `referencedProjectsAndResources`) or the user still has an overlay slot for it; effective per-user display resolves to the overlay choice if present, else the admin flag. Both admin lists are read because A2's auto-promote strips the flag off the download copy it appends to `referencedProjectsAndResources`, so the flag survives on `modelTexts`.

## API Changes

None. The new file's exports (`TextCollectionSources`, `ViewOptionsTextEntry`, and the five helpers) are internal to the `platform-scripture-editor` extension — not `@papi/` exports. No `lib/*`, `papi.d.ts`, or extension type-declaration files changed. The consumed types (`ProjectReference`, `DblResourceReference`, `ResourceReferenceList`, `ShownByDefaultOverlay`) were already exported from the `platform-scripture` module in A2.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [x] **Guard-clause blank lines** — `scripture-text-grid-contents.utils.ts` `getAdminOwnedEntries`/`consider`: early-return guards were not followed by a blank line, unlike the guards in `setUserDisplay`. _(fixed during review: added blank lines after the early-return guards to match the style guide's guard-clause convention)_
- [ ] ~~Modest duplication between `getScriptureTextGridContents` and `getViewOptionsTexts` (both build `getAdminOwnedEntries` then iterate admin + user with similar dedup/narrowing scaffolding).~~ _(author: the two helpers return genuinely different shapes — references vs. rows with `checked`/`isAdminLocked` — so extracting a shared iterator adds indirection without clear benefit; leaving as-is, and both analysis passes agreed this is defensible)_
- [ ] ~~`addToUserResources` documents a precondition ("reference must not be admin-owned") it cannot enforce from its signature.~~ _(author: intentional for a pure helper; the precondition is documented in its TSDoc and in the A5 ticket, and the read helpers ignore a stray admin-owned user-list entry, so a violation is non-destructive — verified by the dedup test)_

Author response: The single style nit was fixed in-review. The two remaining minors were reviewed and consciously left with the reasoning above; neither is a defect.

### Template Propagation

#### Shared Regions Modified

None. (The `#region` markers in the changed files are plain code-organization regions, not `#region shared with <url>` markers.)

#### Extension Config Changes

None. Both changed files are `.ts` source/test files; no config/build files changed.

## Positive Observations

- Delivers exactly the described 2 read + 3 mutation helpers on A2's two-flag schema; no UI/persistence, matching the logic-only scope. No breaking changes, stubs, TODOs, or dead code.
- All mutation helpers return next-state and never mutate inputs; immutability is explicitly guarded by `deepFreeze` "does not mutate its inputs" tests on every mutating helper.
- Thorough behavioral coverage (43 tests): the admin-flag × overlay × user-flag matrix, model-texts-vs-referenced union, admin-precedence dedup, ordering, non-Bible-text exclusion (in both admin and user lists), orphan-overlay handling, `flag:false`, idempotency, and no-op paths.
- Honest test fixtures: the `flagOf` helper reads flags through the real `isProjectReference`/`isDblResourceReference` guards rather than type assertions, keeping tests aligned with the actual narrowing.
- Good reuse: leans on existing `isProjectReference`/`isDblResourceReference` guards and `CURRENT_DATA_VERSION` rather than re-implementing them; the narrower `getBibleTextId` helper is a justified distinction, not duplication.
- TSDoc on every exported symbol explains the *why* (two-admin-list rationale, auto-promote flag-stripping, overlay-vs-user-list routing); clear naming and no indecipherable abbreviations.

## Interview Notes

- **Purpose:** the pure logic layer for the Text Collection — 2 read + 3 mutation helpers on A2's two-flag schema, consumed by A4/A5/A6; logic-only, A5 owns persistence.
- The change went through two adversarial review passes before this run. Those passes changed the ownership model (from "present in an admin list" to "flag-set-or-overlay-present"), replaced type-invisible `overlay[id] ?? fallback` with explicit `Object.hasOwn` presence checks, renamed the mutation helpers from persona-based (`*SarojList`) to domain terms, and added edge-case coverage (`flag:false`, orphan overlay, admin∩user overlap, non-Bible-text in the user list).
- No areas of author non-understanding: the author drove the design decisions and the review passes. No items were left unresolved.

## In-Review Quality Check

One change was made during review (the guard-clause blank-line fix). After staging it: the 43-test Vitest suite passes and `eslint` is clean (0 errors). Typecheck was not re-run because the change is whitespace-only (blank lines) with no possible type impact. Note: the full extension webpack build could not be run in this worktree (missing `copy-webpack-plugin` in the worktree's `node_modules`), so CI is the first full-build gate — this is an environment detail, not a defect.

## Suggested Review Focus

Prioritized topics for the author–reviewer meeting (the code itself is clean; these are the judgment calls worth a second opinion):

- [ ] **`flag:false` View Options behavior** — a resource the admin explicitly set `isResourceShownByDefault: false` (with no user overlay) now appears in the bottom section unchecked (so the user can opt in). This is a UX/product decision, not a correctness one; worth confirming with the A5 UX owner (Alex).
- [ ] **`addToUserResources` precondition / A5 contract** — A5 must only add resources that aren't admin-owned. Confirm the A5 flow honors this (documented, non-destructive if violated).
- [ ] **`dataVersion` lockstep assumption** — the mutation helpers stamp `CURRENT_DATA_VERSION` (`1.1.0`); a future higher schema version would be downgraded and rejected by A5's setter validator. Bump these helpers in lockstep with the schema.
- [ ] **Stacked base** — retarget the PR from `pt-4050-two-flag-schema` to `main` once A2 merges.
<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2515)
<!-- Reviewable:end -->
