### PR TITLE
PT-4025: openCommentList project targeting + filter pre-apply

### DIFF
--- a/extensions/src/legacy-comment-manager/src/comment-list-filters.model.test.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-filters.model.test.ts
@@ -148,4 +148,12 @@ describe('applyFilterOverrides', () => {
     applyFilterOverrides({ type: 'conflicts' });
     expect(DEFAULT_COMMENT_FILTERS.type).toBe('all');
   });
+
+  it('resets a present-but-null axis to its default (null survives the JSON command bus)', () => {
+    // `undefined` is stripped over the command bus, but `null` survives. A null axis must reset to
+    // its default — leaking it would blank the dropdown while the query still behaves as 'all'. The
+    // web view's setFilters handler applies exactly these semantics via applyFilterOverrides.
+    const overridesWithNull: Partial<CommentFilters> = JSON.parse('{ "type": null }');
+    expect(applyFilterOverrides(overridesWithNull)).toEqual(DEFAULT_COMMENT_FILTERS);
+  });
 });

--- a/extensions/src/legacy-comment-manager/src/comment-list-filters.model.test.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-filters.model.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import type { CommentFilters, ScopeFilter } from './comment-list-filters.model';
 import {
   areCommentFiltersAtDefault,
+  applyFilterOverrides,
   buildCommentThreadSelector,
   DEFAULT_COMMENT_FILTERS,
   isAssignmentFilter,
@@ -113,5 +114,38 @@ describe('areCommentFiltersAtDefault', () => {
     expect(areCommentFiltersAtDefault({ ...DEFAULT_COMMENT_FILTERS, assignment: 'team' })).toBe(
       false,
     );
+  });
+});
+
+describe('applyFilterOverrides', () => {
+  it('returns the defaults when given no overrides', () => {
+    expect(applyFilterOverrides()).toEqual(DEFAULT_COMMENT_FILTERS);
+    expect(applyFilterOverrides(undefined)).toEqual(DEFAULT_COMMENT_FILTERS);
+    expect(applyFilterOverrides({})).toEqual(DEFAULT_COMMENT_FILTERS);
+  });
+
+  it('applies the given axes over the defaults', () => {
+    expect(applyFilterOverrides({ type: 'conflicts', resolved: 'unresolved' })).toEqual({
+      resolved: 'unresolved',
+      read: 'all',
+      type: 'conflicts',
+      assignment: 'all',
+    });
+  });
+
+  it('resets unspecified axes to "all" rather than merging with a prior selection', () => {
+    // The whole point: overrides are applied onto DEFAULT, not onto the caller's current filters,
+    // so a programmatic open shows exactly the requested view.
+    expect(applyFilterOverrides({ read: 'unread' })).toEqual({
+      resolved: 'all',
+      read: 'unread',
+      type: 'all',
+      assignment: 'all',
+    });
+  });
+
+  it('does not mutate DEFAULT_COMMENT_FILTERS', () => {
+    applyFilterOverrides({ type: 'conflicts' });
+    expect(DEFAULT_COMMENT_FILTERS.type).toBe('all');
   });
 });

--- a/extensions/src/legacy-comment-manager/src/comment-list-filters.model.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-filters.model.ts
@@ -115,7 +115,16 @@ export function areCommentFiltersAtDefault(filters: CommentFilters): boolean {
  * both apply the same merge semantics.
  */
 export function applyFilterOverrides(overrides?: Partial<CommentFilters>): CommentFilters {
-  return { ...DEFAULT_COMMENT_FILTERS, ...overrides };
+  // Build from the known axes rather than spreading `overrides`, so a present-but-nullish axis
+  // (e.g. `{ type: null }` surviving the JSON bus) resets to its default instead of leaking a null
+  // that would blank the dropdown while the query still behaves as 'all'. A new axis on
+  // CommentFilters forces a compile error here, which is the intended safety net.
+  return {
+    resolved: overrides?.resolved ?? DEFAULT_COMMENT_FILTERS.resolved,
+    read: overrides?.read ?? DEFAULT_COMMENT_FILTERS.read,
+    type: overrides?.type ?? DEFAULT_COMMENT_FILTERS.type,
+    assignment: overrides?.assignment ?? DEFAULT_COMMENT_FILTERS.assignment,
+  };
 }
 
 // Paratext 9's literal "assigned to the whole team" token (UserFilter/CommentTags): threads assigned

--- a/extensions/src/legacy-comment-manager/src/comment-list-filters.model.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-filters.model.ts
@@ -107,6 +107,17 @@ export function areCommentFiltersAtDefault(filters: CommentFilters): boolean {
   return deepEqual(filters, DEFAULT_COMMENT_FILTERS);
 }
 
+/**
+ * Applies partial filter overrides onto {@link DEFAULT_COMMENT_FILTERS}. Any axis not present in
+ * `overrides` is reset to its `'all'` default — the overrides are NOT merged with the user's
+ * current selection — so a programmatic open (e.g. the S/R conflict link) shows exactly the
+ * requested view. Shared by the web view's initial state and its `setFilters` message handler so
+ * both apply the same merge semantics.
+ */
+export function applyFilterOverrides(overrides?: Partial<CommentFilters>): CommentFilters {
+  return { ...DEFAULT_COMMENT_FILTERS, ...overrides };
+}
+
 // Paratext 9's literal "assigned to the whole team" token (UserFilter/CommentTags): threads assigned
 // to the team carry this exact `AssignedUser` value.
 export const TEAM_ASSIGNED_USER = 'Team';

--- a/extensions/src/legacy-comment-manager/src/comment-list-filters.model.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-filters.model.ts
@@ -1,5 +1,23 @@
-import type { LegacyCommentThreadSelector } from 'legacy-comment-manager';
+import type {
+  LegacyCommentThreadSelector,
+  ResolvedFilter,
+  ReadFilter,
+  TypeFilter,
+  AssignmentFilter,
+  CommentFilters,
+  ScopeFilter,
+} from 'legacy-comment-manager';
 import { deepEqual } from 'platform-bible-utils';
+import type { LocalizeKey } from 'platform-bible-utils';
+
+export type {
+  ResolvedFilter,
+  ReadFilter,
+  TypeFilter,
+  AssignmentFilter,
+  CommentFilters,
+  ScopeFilter,
+};
 
 // Filter constants, types, and the selector mapping — shared between the presentational panel (which
 // renders the filter toolbar) and the web view (which uses the values to build its comment-thread
@@ -18,9 +36,7 @@ export const SCOPE_FILTER_CURRENT_CHAPTER = 'current-chapter';
 export const scopeFilterToLabelKey = {
   [SCOPE_FILTER_CURRENT_CHAPTER]: '%comment_filter_scope_current_chapter%',
   [UNFILTERED]: '%comment_filter_scope_all_books%',
-} as const;
-
-export type ScopeFilter = keyof typeof scopeFilterToLabelKey;
+} as const satisfies Record<ScopeFilter, LocalizeKey>;
 
 export function isScopeFilter(value: string): value is ScopeFilter {
   return Object.hasOwn(scopeFilterToLabelKey, value);
@@ -32,9 +48,7 @@ export const resolvedFilterToLabelKey = {
   all: '%comment_filter_resolved_all%',
   unresolved: '%comment_filter_resolved_unresolved%',
   resolved: '%comment_filter_resolved_resolved%',
-} as const;
-
-export type ResolvedFilter = keyof typeof resolvedFilterToLabelKey;
+} as const satisfies Record<ResolvedFilter, LocalizeKey>;
 
 export function isResolvedFilter(value: string): value is ResolvedFilter {
   return Object.hasOwn(resolvedFilterToLabelKey, value);
@@ -46,9 +60,7 @@ export const readFilterToLabelKey = {
   all: '%comment_filter_read_all%',
   unread: '%comment_filter_read_unread%',
   read: '%comment_filter_read_read%',
-} as const;
-
-export type ReadFilter = keyof typeof readFilterToLabelKey;
+} as const satisfies Record<ReadFilter, LocalizeKey>;
 
 export function isReadFilter(value: string): value is ReadFilter {
   return Object.hasOwn(readFilterToLabelKey, value);
@@ -60,9 +72,7 @@ export const typeFilterToLabelKey = {
   all: '%comment_filter_type_all%',
   conflicts: '%comment_filter_type_conflicts%',
   comments: '%comment_filter_type_comments%',
-} as const;
-
-export type TypeFilter = keyof typeof typeFilterToLabelKey;
+} as const satisfies Record<TypeFilter, LocalizeKey>;
 
 export function isTypeFilter(value: string): value is TypeFilter {
   return Object.hasOwn(typeFilterToLabelKey, value);
@@ -75,21 +85,11 @@ export const assignmentFilterToLabelKey = {
   'assigned-to-me': '%comment_filter_assignment_me%',
   team: '%comment_filter_assignment_team%',
   unassigned: '%comment_filter_assignment_unassigned%',
-} as const;
-
-export type AssignmentFilter = keyof typeof assignmentFilterToLabelKey;
+} as const satisfies Record<AssignmentFilter, LocalizeKey>;
 
 export function isAssignmentFilter(value: string): value is AssignmentFilter {
   return Object.hasOwn(assignmentFilterToLabelKey, value);
 }
-
-/** The four orthogonal comment-filter axis selections. Each defaults to `'all'` (no filtering). */
-export type CommentFilters = {
-  resolved: ResolvedFilter;
-  read: ReadFilter;
-  type: TypeFilter;
-  assignment: AssignmentFilter;
-};
 
 export const DEFAULT_COMMENT_FILTERS: CommentFilters = {
   resolved: 'all',

--- a/extensions/src/legacy-comment-manager/src/comment-list-messages.model.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-messages.model.ts
@@ -1,8 +1,19 @@
+import type { CommentFilters, ScopeFilter } from 'legacy-comment-manager';
+
 /** Tell the comment list to scroll to a specific thread */
 type CommentListMessageSelectThread = {
   method: 'selectThread';
   threadId: string;
 };
 
+/** Tell the comment list to apply filter axes and/or scope */
+type CommentListMessageSetFilters = {
+  method: 'setFilters';
+  filters?: Partial<CommentFilters>;
+  scopeFilter?: ScopeFilter;
+};
+
 /** Message types that can be received from the Comment List web view controller */
-export type CommentListWebViewMessage = CommentListMessageSelectThread;
+export type CommentListWebViewMessage =
+  | CommentListMessageSelectThread
+  | CommentListMessageSetFilters;

--- a/extensions/src/legacy-comment-manager/src/comment-list.component.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.component.tsx
@@ -22,6 +22,7 @@ import {
   readFilterToLabelKey,
   resolvedFilterToLabelKey,
   ScopeFilter,
+  SCOPE_FILTER_CURRENT_CHAPTER,
   scopeFilterToLabelKey,
   typeFilterToLabelKey,
   UNFILTERED,
@@ -80,6 +81,12 @@ export type CommentListPanelProps = Pick<
   scopeFilter: ScopeFilter;
   /** Called when the scope filter changes. */
   onScopeFilterChange: (filter: ScopeFilter) => void;
+  /**
+   * Whether an editor is wired to this list. When false (e.g. a cross-project open), the "current
+   * chapter" scope option is hidden because there is no editor to derive the chapter from. Defaults
+   * to `true`.
+   */
+  hasEditorContext?: boolean;
 };
 
 /**
@@ -93,12 +100,15 @@ function FilterDropdown<T extends string>({
   isValue,
   onChange,
   localizedStrings,
+  hiddenValues,
 }: {
   value: T;
   labelKeys: Readonly<Record<T, LocalizeKey>>;
   isValue: (value: string) => value is T;
   onChange: (value: T) => void;
   localizedStrings: LanguageStrings;
+  /** Option values to omit from the list (e.g. a scope that doesn't apply without editor context). */
+  hiddenValues?: readonly T[];
 }) {
   return (
     <Select
@@ -117,6 +127,7 @@ function FilterDropdown<T extends string>({
       <SelectContent className="tw:max-w-sm" align="start">
         {Object.keys(labelKeys)
           .filter(isValue)
+          .filter((option) => !hiddenValues?.includes(option))
           .map((option) => (
             <SelectItem key={option} value={option}>
               {localizedStrings[labelKeys[option]]}
@@ -144,6 +155,7 @@ export function CommentListPanel({
   onFiltersChange,
   scopeFilter,
   onScopeFilterChange,
+  hasEditorContext = true,
   handleAddCommentToThread,
   handleUpdateComment,
   handleDeleteComment,
@@ -212,6 +224,7 @@ export function CommentListPanel({
           isValue={isScopeFilter}
           onChange={onScopeFilterChange}
           localizedStrings={localizedStrings}
+          hiddenValues={hasEditorContext ? undefined : [SCOPE_FILTER_CURRENT_CHAPTER]}
         />
       </div>
 

--- a/extensions/src/legacy-comment-manager/src/comment-list.stories.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.stories.tsx
@@ -168,6 +168,7 @@ type DecoratorConfig = {
   isLoading?: boolean;
   threads?: LegacyCommentThread[];
   initialFilters?: Partial<CommentFilters>;
+  hasEditorContext?: boolean;
 };
 
 /**
@@ -203,6 +204,7 @@ function createDecorator(config: DecoratorConfig) {
             onFiltersChange: setFilters,
             scopeFilter,
             onScopeFilterChange: setScopeFilter,
+            hasEditorContext: config.hasEditorContext,
             assignableUsers: ['', 'Alice', 'Bob', 'Charlie', CURRENT_USER],
             canUserAddCommentToThread: true,
             canUserAssignThreadCallback: resolveTrue,
@@ -301,4 +303,12 @@ export const Empty: Story = {
 /** No comments match the active filter — shows the "no comments match filter" message. */
 export const EmptyFiltered: Story = {
   decorators: [createDecorator({ threads: [], initialFilters: { type: 'conflicts' } })],
+};
+
+/**
+ * Opened without an editor (e.g. a cross-project open from the Send/Receive results link): the
+ * scope dropdown omits "current chapter" because there is no editor to derive the chapter from.
+ */
+export const NoEditorContext: Story = {
+  decorators: [createDecorator({ hasEditorContext: false })],
 };

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -128,7 +128,7 @@ global.webViewComponent = function CommentListWebView({
   // Listen for messages from the web view controller
   useEffect(() => {
     const messageListener = ({ data }: MessageEvent<CommentListWebViewMessage>) => {
-      if (data.method === 'selectThread') {
+      if (data?.method === 'selectThread') {
         logger.debug(`Comment list received selectThread message: ${serialize(data)}`);
         // Note: We pass `true` for isDataLoading as a conservative default since we can't access
         // the current loading state synchronously here. The pending thread will be processed
@@ -136,7 +136,7 @@ global.webViewComponent = function CommentListWebView({
         trySelectThread(data.threadId, true);
       }
 
-      if (data.method === 'setFilters') {
+      if (data?.method === 'setFilters') {
         logger.debug(`Comment list received setFilters message: ${serialize(data)}`);
         // A setFilters message sets the ENTIRE view deterministically, exactly like a fresh open:
         // unspecified filter axes reset to 'all' and an omitted scope resets to UNFILTERED, so the
@@ -151,7 +151,8 @@ global.webViewComponent = function CommentListWebView({
     return () => {
       window.removeEventListener('message', messageListener);
     };
-  }, [trySelectThread, setFilters, setScopeFilter]);
+    // setFilters / setScopeFilter are stable useState setters, so they don't belong in the deps.
+  }, [trySelectThread]);
 
   // Fetch current user's registration data on mount
   useEffect(() => {

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -80,11 +80,11 @@ global.webViewComponent = function CommentListWebView({
   // S/R conflict link). Read from web view state so a new view mounts already-filtered — avoiding the
   // race where a setFilters message could arrive before this view's message listener attaches. An
   // already-open (reused) view keeps its state and is updated via the setFilters message instead.
-  const [initialFilters] = useWebViewState<Partial<CommentFilters> | undefined>(
+  const [initialFilters, setInitialFilters] = useWebViewState<Partial<CommentFilters> | undefined>(
     'initialFilters',
     undefined,
   );
-  const [initialScopeFilter] = useWebViewState<ScopeFilter | undefined>(
+  const [initialScopeFilter, setInitialScopeFilter] = useWebViewState<ScopeFilter | undefined>(
     'initialScopeFilter',
     undefined,
   );
@@ -93,6 +93,16 @@ global.webViewComponent = function CommentListWebView({
     applyFilterOverrides(initialFilters),
   );
   const [scopeFilter, setScopeFilter] = useState<ScopeFilter>(initialScopeFilter ?? UNFILTERED);
+
+  // Consume the one-shot seed exactly once. The useState initializers above already read it
+  // synchronously on first render, so clear it from persistent web view state now. Otherwise an
+  // in-session remount that re-runs this component (e.g. dragging the tab to another dock region)
+  // would re-read the stale seed and snap the user's live filter changes back to the original
+  // programmatic request.
+  useEffect(() => {
+    if (initialFilters !== undefined) setInitialFilters(undefined);
+    if (initialScopeFilter !== undefined) setInitialScopeFilter(undefined);
+  }, [initialFilters, initialScopeFilter, setInitialFilters, setInitialScopeFilter]);
 
   const commentsPdp = useProjectDataProvider('legacyCommentManager.comments', projectId);
 
@@ -353,6 +363,9 @@ global.webViewComponent = function CommentListWebView({
       onFiltersChange={setFilters}
       scopeFilter={scopeFilter}
       onScopeFilterChange={setScopeFilter}
+      // No editor wired (e.g. a cross-project open) means there is no "current chapter" to scope to,
+      // so the panel hides that option rather than filtering against an unrelated scroll-group ref.
+      hasEditorContext={!!editorWebViewId}
       handleAddCommentToThread={handleAddCommentToThread}
       handleUpdateComment={handleUpdateComment}
       handleDeleteComment={handleDeleteComment}

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -18,9 +18,9 @@ import type { LegacyCommentThreadSelector } from 'legacy-comment-manager';
 import { CommentListWebViewMessage } from './comment-list-messages.model';
 import { CommentListPanel, COMMENT_LIST_PANEL_EXTRA_STRING_KEYS } from './comment-list.component';
 import {
+  applyFilterOverrides,
   buildCommentThreadSelector,
   CommentFilters,
-  DEFAULT_COMMENT_FILTERS,
   ScopeFilter,
   UNFILTERED,
 } from './comment-list-filters.model';
@@ -76,8 +76,23 @@ global.webViewComponent = function CommentListWebView({
     undefined,
   );
 
-  const [filters, setFilters] = useState<CommentFilters>(DEFAULT_COMMENT_FILTERS);
-  const [scopeFilter, setScopeFilter] = useState<ScopeFilter>(UNFILTERED);
+  // Initial filter/scope axes passed by openCommentList when opening a NEW comment list (e.g. the
+  // S/R conflict link). Read from web view state so a new view mounts already-filtered — avoiding the
+  // race where a setFilters message could arrive before this view's message listener attaches. An
+  // already-open (reused) view keeps its state and is updated via the setFilters message instead.
+  const [initialFilters] = useWebViewState<Partial<CommentFilters> | undefined>(
+    'initialFilters',
+    undefined,
+  );
+  const [initialScopeFilter] = useWebViewState<ScopeFilter | undefined>(
+    'initialScopeFilter',
+    undefined,
+  );
+
+  const [filters, setFilters] = useState<CommentFilters>(() =>
+    applyFilterOverrides(initialFilters),
+  );
+  const [scopeFilter, setScopeFilter] = useState<ScopeFilter>(initialScopeFilter ?? UNFILTERED);
 
   const commentsPdp = useProjectDataProvider('legacyCommentManager.comments', projectId);
 
@@ -125,7 +140,7 @@ global.webViewComponent = function CommentListWebView({
         logger.debug(`Comment list received setFilters message: ${serialize(data)}`);
         // Merge onto DEFAULT (not current state) so a programmatic open shows exactly the requested
         // view; unspecified axes reset to 'all'.
-        if (data.filters) setFilters({ ...DEFAULT_COMMENT_FILTERS, ...data.filters });
+        if (data.filters) setFilters(applyFilterOverrides(data.filters));
         if (data.scopeFilter) setScopeFilter(data.scopeFilter);
       }
     };

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -138,10 +138,12 @@ global.webViewComponent = function CommentListWebView({
 
       if (data.method === 'setFilters') {
         logger.debug(`Comment list received setFilters message: ${serialize(data)}`);
-        // Merge onto DEFAULT (not current state) so a programmatic open shows exactly the requested
-        // view; unspecified axes reset to 'all'.
-        if (data.filters) setFilters(applyFilterOverrides(data.filters));
-        if (data.scopeFilter) setScopeFilter(data.scopeFilter);
+        // A setFilters message sets the ENTIRE view deterministically, exactly like a fresh open:
+        // unspecified filter axes reset to 'all' and an omitted scope resets to UNFILTERED, so the
+        // programmatic open (e.g. the S/R conflict link) shows exactly the requested view — nothing
+        // carries over from prior state.
+        setFilters(applyFilterOverrides(data.filters));
+        setScopeFilter(data.scopeFilter ?? UNFILTERED);
       }
     };
 

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -120,13 +120,21 @@ global.webViewComponent = function CommentListWebView({
         // by the effect below once loading completes.
         trySelectThread(data.threadId, true);
       }
+
+      if (data.method === 'setFilters') {
+        logger.debug(`Comment list received setFilters message: ${serialize(data)}`);
+        // Merge onto DEFAULT (not current state) so a programmatic open shows exactly the requested
+        // view; unspecified axes reset to 'all'.
+        if (data.filters) setFilters({ ...DEFAULT_COMMENT_FILTERS, ...data.filters });
+        if (data.scopeFilter) setScopeFilter(data.scopeFilter);
+      }
     };
 
     window.addEventListener('message', messageListener);
     return () => {
       window.removeEventListener('message', messageListener);
     };
-  }, [trySelectThread]);
+  }, [trySelectThread, setFilters, setScopeFilter]);
 
   // Fetch current user's registration data on mount
   useEffect(() => {

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -154,7 +154,7 @@ async function openCommentList(
   webViewId: string | undefined,
   options: OpenCommentListWebViewOptions = {},
 ): Promise<string | undefined> {
-  let projectId: CommentListWebViewOptions['projectId'];
+  let triggerProjectId: string | undefined;
   let tabIdFromWebViewId: string | undefined;
   let editorScrollGroupId: CommentListWebViewOptions['editorScrollGroupId'];
   /** The ID of the comment list WebView that was opened or focused */
@@ -164,14 +164,21 @@ async function openCommentList(
 
   if (webViewId) {
     const webViewDefinition = await papi.webViews.getOpenWebViewDefinition(webViewId);
-    projectId = webViewDefinition?.projectId;
+    triggerProjectId = webViewDefinition?.projectId;
     tabIdFromWebViewId = webViewDefinition?.id;
     editorScrollGroupId = webViewDefinition?.scrollGroupScrRef;
   }
 
   // A caller that isn't the project's own web view (e.g. the S/R results dialog) can target a
   // project directly. Takes precedence over the web-view-derived project.
-  projectId = options.projectId ?? projectId;
+  const projectId = options.projectId ?? triggerProjectId;
+
+  // If the caller targeted a different project than the triggering web view, that web view's editor
+  // context (scroll group + id) belongs to another project, so it must not wire this comment list to
+  // the wrong editor. The trigger's tab id is still used purely for docking placement.
+  const editorContextApplies = !options.projectId || options.projectId === triggerProjectId;
+  const editorWebViewId = editorContextApplies ? webViewId : undefined;
+  if (!editorContextApplies) editorScrollGroupId = undefined;
 
   if (!projectId) {
     logger.debug('No project!');
@@ -209,7 +216,7 @@ async function openCommentList(
     const webViewOptions: CommentListWebViewOptions = {
       projectId,
       editorScrollGroupId,
-      editorWebViewId: webViewId,
+      editorWebViewId,
       initialFilters: options.filtersToSet,
       initialScopeFilter: options.scopeFilterToSet,
     };
@@ -220,36 +227,29 @@ async function openCommentList(
     );
   }
 
-  // Scroll to the specified thread in the comment list
-  if (commentListWebViewId && options.threadIdToSelect) {
-    // Get the comment list controller and select the thread
+  // Apply post-open controller actions (select a thread, pre-apply filters) with a single
+  // controller lookup.
+  if (
+    commentListWebViewId &&
+    (options.threadIdToSelect || options.filtersToSet || options.scopeFilterToSet)
+  ) {
     const commentListController = await papi.webViews.getWebViewController(
       commentListWebViewType,
       commentListWebViewId,
     );
-    if (commentListController) {
-      await commentListController.selectThread(options.threadIdToSelect);
-    } else {
+    if (!commentListController)
       throw new Error(
-        `Could not get WebView Controller for comment list WebView ${commentListWebViewId} to scroll to thread ${options.threadIdToSelect}`,
+        `Could not get WebView Controller for comment list WebView ${commentListWebViewId}`,
       );
-    }
-  }
 
-  // Pre-apply filter axes / scope if requested (e.g. the S/R link opens the unresolved-conflicts
-  // view). Deterministic: unspecified axes reset to default (see setFilters docs).
-  if (commentListWebViewId && (options.filtersToSet || options.scopeFilterToSet)) {
-    const commentListController = await papi.webViews.getWebViewController(
-      commentListWebViewType,
-      commentListWebViewId,
-    );
-    if (commentListController) {
+    // Scroll to the specified thread in the comment list
+    if (options.threadIdToSelect)
+      await commentListController.selectThread(options.threadIdToSelect);
+
+    // Pre-apply filter axes / scope if requested (e.g. the S/R link opens the unresolved-conflicts
+    // view). Deterministic: unspecified axes reset to default (see setFilters docs).
+    if (options.filtersToSet || options.scopeFilterToSet)
       await commentListController.setFilters(options.filtersToSet, options.scopeFilterToSet);
-    } else {
-      throw new Error(
-        `Could not get WebView Controller for comment list WebView ${commentListWebViewId} to set filters`,
-      );
-    }
   }
 
   return commentListWebViewId;

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -17,6 +17,7 @@ import { serialize } from 'platform-bible-utils';
 import commentListWebView from './comment-list.web-view?inline';
 import tailwindStyles from './tailwind.css?inline';
 import { CommentListWebViewMessage } from './comment-list-messages.model';
+import { SCOPE_FILTER_CURRENT_CHAPTER, UNFILTERED } from './comment-list-filters.model';
 import {
   LEGACY_COMMENT_USJ_PDPF_ID,
   LegacyCommentManagerUsjProjectDataProviderEngineFactory,
@@ -63,15 +64,16 @@ class CommentListWebViewFactory extends WebViewFactory<typeof commentListWebView
       activeCommentListsByProject.set(projectId, savedWebView.id);
     }
 
-    const baseTitle = await papi.localization.getLocalizedString({
+    // Kick off the (independent) title localization now so it runs concurrently with the
+    // project-name lookup below instead of serially before it.
+    const baseTitlePromise = papi.localization.getLocalizedString({
       localizeKey: '%webView_legacyCommentManager_commentList_title%',
     });
 
     // A caller-supplied projectId may be invalid or not yet loaded; a rejection here would fail the
     // whole open, so guard the lookup and fall back to the id rather than let the title throw.
-    let title = baseTitle;
+    let projectName: string | undefined;
     if (projectId) {
-      let projectName: string | undefined;
       try {
         const baseProjectPdp = await papi.projectDataProviders.get('platform.base', projectId);
         projectName = await baseProjectPdp.getSetting('platform.name');
@@ -81,8 +83,12 @@ class CommentListWebViewFactory extends WebViewFactory<typeof commentListWebView
           error,
         );
       }
-      title = `${baseTitle}: ${projectName ?? projectId}`;
     }
+
+    const baseTitle = await baseTitlePromise;
+    // Fall back to the id when the name is missing OR empty (`||`, not `??`, so an empty-string
+    // project name doesn't render a blank "Comments: " suffix).
+    const title = projectId ? `${baseTitle}: ${projectName || projectId}` : baseTitle;
 
     return {
       ...savedWebView,
@@ -181,13 +187,16 @@ async function openCommentList(
   if (!editorContextApplies) editorScrollGroupId = undefined;
 
   // A cross-project target has no editor to derive "current chapter" from, so a current-chapter
-  // scope would filter against a stale/blank ref. Fall back to all-books in that case.
+  // scope would filter against a stale/blank ref. Fall back to all-books (UNFILTERED) in that case.
+  // UNFILTERED rather than undefined keeps the new-view and reused-view paths consistent: on a reused
+  // view it makes needsSetFilters true so an actual setFilters is sent (undefined would leave a
+  // reused view stale while a new view mounted at all-books — the same call diverging by view state).
   let effectiveScopeFilterToSet = options.scopeFilterToSet;
-  if (!editorContextApplies && effectiveScopeFilterToSet === 'current-chapter') {
+  if (!editorContextApplies && effectiveScopeFilterToSet === SCOPE_FILTER_CURRENT_CHAPTER) {
     logger.warn(
       'openCommentList: dropping current-chapter scope for a cross-project target (no editor context); using all-books',
     );
-    effectiveScopeFilterToSet = undefined;
+    effectiveScopeFilterToSet = UNFILTERED;
   }
 
   if (!projectId) {
@@ -252,10 +261,23 @@ async function openCommentList(
       commentListWebViewType,
       commentListWebViewId,
     );
-    if (!commentListController)
+    if (!commentListController) {
+      // Name the pending action(s) so a controller-lookup miss is diagnosable in logs.
+      const pendingActions: string[] = [];
+      if (needsSetFilters)
+        pendingActions.push(
+          `apply filters ${serialize({
+            filters: options.filtersToSet,
+            scopeFilter: effectiveScopeFilterToSet,
+          })}`,
+        );
+      if (needsSelectThread) pendingActions.push(`select thread ${options.threadIdToSelect}`);
       throw new Error(
-        `Could not get WebView Controller for comment list WebView ${commentListWebViewId}`,
+        `Could not get WebView Controller for comment list WebView ${commentListWebViewId} to ${pendingActions.join(
+          ' and ',
+        )}`,
       );
+    }
 
     // setFilters BEFORE selectThread so the selection lands within the final filtered view rather
     // than being filtered out by a subsequent re-query.

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -67,13 +67,22 @@ class CommentListWebViewFactory extends WebViewFactory<typeof commentListWebView
       localizeKey: '%webView_legacyCommentManager_commentList_title%',
     });
 
-    const title = projectId
-      ? `${baseTitle}: ${
-          (await (
-            await papi.projectDataProviders.get('platform.base', projectId)
-          ).getSetting('platform.name')) ?? projectId
-        }`
-      : baseTitle;
+    // A caller-supplied projectId may be invalid or not yet loaded; a rejection here would fail the
+    // whole open, so guard the lookup and fall back to the id rather than let the title throw.
+    let title = baseTitle;
+    if (projectId) {
+      let projectName: string | undefined;
+      try {
+        const baseProjectPdp = await papi.projectDataProviders.get('platform.base', projectId);
+        projectName = await baseProjectPdp.getSetting('platform.name');
+      } catch (error) {
+        logger.warn(
+          `Could not resolve a name for project ${projectId}; using the id in the title`,
+          error,
+        );
+      }
+      title = `${baseTitle}: ${projectName ?? projectId}`;
+    }
 
     return {
       ...savedWebView,
@@ -98,21 +107,17 @@ class CommentListWebViewFactory extends WebViewFactory<typeof commentListWebView
     webViewDefinition: WebViewDefinition,
     webViewNonce: string,
   ): Promise<CommentListWebViewController> {
+    // Single message channel for this controller, closing over the id/nonce so the two methods
+    // can't drift on the plumbing.
+    const postToWebView = (message: CommentListWebViewMessage) =>
+      papi.webViewProviders.postMessageToWebView(webViewDefinition.id, webViewNonce, message);
+
     return {
       async selectThread(threadId: string): Promise<void> {
         logger.debug(
           `Comment List WebView Controller ${webViewDefinition.id} received request to selectThread ${threadId}`,
         );
-
-        const message: CommentListWebViewMessage = {
-          method: 'selectThread',
-          threadId,
-        };
-        await papi.webViewProviders.postMessageToWebView(
-          webViewDefinition.id,
-          webViewNonce,
-          message,
-        );
+        await postToWebView({ method: 'selectThread', threadId });
       },
       async setFilters(
         filters?: Partial<CommentFilters>,
@@ -121,12 +126,7 @@ class CommentListWebViewFactory extends WebViewFactory<typeof commentListWebView
         logger.debug(
           `Comment List WebView Controller ${webViewDefinition.id} received setFilters ${serialize({ filters, scopeFilter })}`,
         );
-        const message: CommentListWebViewMessage = { method: 'setFilters', filters, scopeFilter };
-        await papi.webViewProviders.postMessageToWebView(
-          webViewDefinition.id,
-          webViewNonce,
-          message,
-        );
+        await postToWebView({ method: 'setFilters', filters, scopeFilter });
       },
       async dispose(): Promise<boolean> {
         return true;
@@ -180,6 +180,16 @@ async function openCommentList(
   const editorWebViewId = editorContextApplies ? webViewId : undefined;
   if (!editorContextApplies) editorScrollGroupId = undefined;
 
+  // A cross-project target has no editor to derive "current chapter" from, so a current-chapter
+  // scope would filter against a stale/blank ref. Fall back to all-books in that case.
+  let effectiveScopeFilterToSet = options.scopeFilterToSet;
+  if (!editorContextApplies && effectiveScopeFilterToSet === 'current-chapter') {
+    logger.warn(
+      'openCommentList: dropping current-chapter scope for a cross-project target (no editor context); using all-books',
+    );
+    effectiveScopeFilterToSet = undefined;
+  }
+
   if (!projectId) {
     logger.debug('No project!');
     return undefined;
@@ -211,14 +221,17 @@ async function openCommentList(
     }
   }
 
+  let createdNew = false;
   if (!commentListWebViewId) {
-    // No existing comment list, so create a new one
+    // No existing comment list, so create a new one. The initial filters/scope are seeded into the
+    // web view state so the view mounts already-filtered — no post-open setFilters is needed.
+    createdNew = true;
     const webViewOptions: CommentListWebViewOptions = {
       projectId,
       editorScrollGroupId,
       editorWebViewId,
       initialFilters: options.filtersToSet,
-      initialScopeFilter: options.scopeFilterToSet,
+      initialScopeFilter: effectiveScopeFilterToSet,
     };
     commentListWebViewId = await papi.webViews.openWebView(
       commentListWebViewType,
@@ -227,12 +240,14 @@ async function openCommentList(
     );
   }
 
-  // Apply post-open controller actions (select a thread, pre-apply filters) with a single
-  // controller lookup.
-  if (
-    commentListWebViewId &&
-    (options.threadIdToSelect || options.filtersToSet || options.scopeFilterToSet)
-  ) {
+  // Post-open controller actions. A newly-created view already has its filters seeded, so it only
+  // needs a thread selection; a reused view needs setFilters to apply the requested view. Only fetch
+  // the controller when there is actually something to send — so a filters-only open of a NEW view
+  // skips it entirely and can't fail on a transient controller-lookup miss.
+  const needsSetFilters =
+    !createdNew && (!!options.filtersToSet || effectiveScopeFilterToSet !== undefined);
+  const needsSelectThread = !!options.threadIdToSelect;
+  if (commentListWebViewId && (needsSetFilters || needsSelectThread)) {
     const commentListController = await papi.webViews.getWebViewController(
       commentListWebViewType,
       commentListWebViewId,
@@ -242,15 +257,14 @@ async function openCommentList(
         `Could not get WebView Controller for comment list WebView ${commentListWebViewId}`,
       );
 
-    // Scroll to the specified thread in the comment list
+    // setFilters BEFORE selectThread so the selection lands within the final filtered view rather
+    // than being filtered out by a subsequent re-query.
+    if (needsSetFilters)
+      await commentListController.setFilters(options.filtersToSet, effectiveScopeFilterToSet);
+
+    // Scroll to the specified thread in the comment list.
     if (options.threadIdToSelect)
       await commentListController.selectThread(options.threadIdToSelect);
-
-    // Pre-apply the requested filter axes / scope (e.g. the S/R link opens the unresolved-conflicts
-    // view). Deterministic: this sets the whole view — unspecified filter axes reset to 'all' and an
-    // omitted scope resets to all-books (see the setFilters controller docs).
-    if (options.filtersToSet || options.scopeFilterToSet)
-      await commentListController.setFilters(options.filtersToSet, options.scopeFilterToSet);
   }
 
   return commentListWebViewId;
@@ -320,11 +334,17 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
               filtersToSet: {
                 type: 'object',
                 description: 'Comment-filter axes to pre-apply; unspecified axes reset to all',
+                // These enums duplicate the axis unions (ResolvedFilter / ReadFilter / TypeFilter /
+                // AssignmentFilter in legacy-comment-manager.d.ts). Keep them in sync by hand until a
+                // codegen step derives this schema from the types.
                 properties: {
                   resolved: { type: 'string', enum: ['all', 'unresolved', 'resolved'] },
                   read: { type: 'string', enum: ['all', 'unread', 'read'] },
                   type: { type: 'string', enum: ['all', 'conflicts', 'comments'] },
-                  assignment: { type: 'string', enum: ['all', 'assigned-to-me', 'team'] },
+                  assignment: {
+                    type: 'string',
+                    enum: ['all', 'assigned-to-me', 'team', 'unassigned'],
+                  },
                 },
               },
               scopeFilterToSet: {

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -31,6 +31,11 @@ interface CommentListWebViewOptions extends OpenWebViewOptions {
   projectId: string | undefined;
   editorScrollGroupId: ScrollGroupScrRef | undefined;
   editorWebViewId: string | undefined;
+  // One-shot initial filter/scope for a NEW view, seeded into web view state so the view mounts
+  // already-filtered instead of relying on a post-open setFilters message (which could race the
+  // view's message listener). Only set when creating a new view; undefined on reuse/restore.
+  initialFilters: Partial<CommentFilters> | undefined;
+  initialScopeFilter: ScopeFilter | undefined;
 }
 
 /** Map of projectId to comment list web view id for reusing existing web views */
@@ -80,6 +85,11 @@ class CommentListWebViewFactory extends WebViewFactory<typeof commentListWebView
       state: {
         ...savedWebView.state,
         editorWebViewId: getWebViewOptions.editorWebViewId ?? savedWebView.state?.editorWebViewId,
+        // Seeded only when opening a new view (undefined otherwise, which clears any persisted
+        // value). Deliberately NOT persisted across restarts: a restored view has these undefined
+        // and so mounts with default filters rather than re-applying a stale one-shot request.
+        initialFilters: getWebViewOptions.initialFilters,
+        initialScopeFilter: getWebViewOptions.initialScopeFilter,
       },
     };
   }
@@ -200,6 +210,8 @@ async function openCommentList(
       projectId,
       editorScrollGroupId,
       editorWebViewId: webViewId,
+      initialFilters: options.filtersToSet,
+      initialScopeFilter: options.scopeFilterToSet,
     };
     commentListWebViewId = await papi.webViews.openWebView(
       commentListWebViewType,

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -246,8 +246,9 @@ async function openCommentList(
     if (options.threadIdToSelect)
       await commentListController.selectThread(options.threadIdToSelect);
 
-    // Pre-apply filter axes / scope if requested (e.g. the S/R link opens the unresolved-conflicts
-    // view). Deterministic: unspecified axes reset to default (see setFilters docs).
+    // Pre-apply the requested filter axes / scope (e.g. the S/R link opens the unresolved-conflicts
+    // view). Deterministic: this sets the whole view — unspecified filter axes reset to 'all' and an
+    // omitted scope resets to all-books (see the setFilters controller docs).
     if (options.filtersToSet || options.scopeFilterToSet)
       await commentListController.setFilters(options.filtersToSet, options.scopeFilterToSet);
   }
@@ -329,7 +330,8 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
               scopeFilterToSet: {
                 type: 'string',
                 enum: ['unfiltered', 'current-chapter'],
-                description: 'Scope to pre-apply (e.g. unfiltered for all books)',
+                description:
+                  'Scope to pre-apply; omitting it resets scope to all-books (unfiltered)',
               },
             },
           },

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -8,9 +8,12 @@ import type {
   WebViewDefinition,
 } from '@papi/core';
 import type {
+  CommentFilters,
   CommentListWebViewController,
   OpenCommentListWebViewOptions,
+  ScopeFilter,
 } from 'legacy-comment-manager';
+import { serialize } from 'platform-bible-utils';
 import commentListWebView from './comment-list.web-view?inline';
 import tailwindStyles from './tailwind.css?inline';
 import { CommentListWebViewMessage } from './comment-list-messages.model';
@@ -101,6 +104,20 @@ class CommentListWebViewFactory extends WebViewFactory<typeof commentListWebView
           message,
         );
       },
+      async setFilters(
+        filters?: Partial<CommentFilters>,
+        scopeFilter?: ScopeFilter,
+      ): Promise<void> {
+        logger.debug(
+          `Comment List WebView Controller ${webViewDefinition.id} received setFilters ${serialize({ filters, scopeFilter })}`,
+        );
+        const message: CommentListWebViewMessage = { method: 'setFilters', filters, scopeFilter };
+        await papi.webViewProviders.postMessageToWebView(
+          webViewDefinition.id,
+          webViewNonce,
+          message,
+        );
+      },
       async dispose(): Promise<boolean> {
         return true;
       },
@@ -141,6 +158,10 @@ async function openCommentList(
     tabIdFromWebViewId = webViewDefinition?.id;
     editorScrollGroupId = webViewDefinition?.scrollGroupScrRef;
   }
+
+  // A caller that isn't the project's own web view (e.g. the S/R results dialog) can target a
+  // project directly. Takes precedence over the web-view-derived project.
+  projectId = options.projectId ?? projectId;
 
   if (!projectId) {
     logger.debug('No project!');
@@ -203,6 +224,22 @@ async function openCommentList(
     }
   }
 
+  // Pre-apply filter axes / scope if requested (e.g. the S/R link opens the unresolved-conflicts
+  // view). Deterministic: unspecified axes reset to default (see setFilters docs).
+  if (commentListWebViewId && (options.filtersToSet || options.scopeFilterToSet)) {
+    const commentListController = await papi.webViews.getWebViewController(
+      commentListWebViewType,
+      commentListWebViewId,
+    );
+    if (commentListController) {
+      await commentListController.setFilters(options.filtersToSet, options.scopeFilterToSet);
+    } else {
+      throw new Error(
+        `Could not get WebView Controller for comment list WebView ${commentListWebViewId} to set filters`,
+      );
+    }
+  }
+
   return commentListWebViewId;
 }
 
@@ -261,6 +298,26 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
               threadIdToSelect: {
                 type: 'string',
                 description: 'ID of the thread to select and scroll to in the comment list',
+              },
+              projectId: {
+                type: 'string',
+                description:
+                  'Project whose comments to show (overrides the webViewId-derived project)',
+              },
+              filtersToSet: {
+                type: 'object',
+                description: 'Comment-filter axes to pre-apply; unspecified axes reset to all',
+                properties: {
+                  resolved: { type: 'string', enum: ['all', 'unresolved', 'resolved'] },
+                  read: { type: 'string', enum: ['all', 'unread', 'read'] },
+                  type: { type: 'string', enum: ['all', 'conflicts', 'comments'] },
+                  assignment: { type: 'string', enum: ['all', 'assigned-to-me', 'team'] },
+                },
+              },
+              scopeFilterToSet: {
+                type: 'string',
+                enum: ['unfiltered', 'current-chapter'],
+                description: 'Scope to pre-apply (e.g. unfiltered for all books)',
               },
             },
           },

--- a/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
+++ b/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
@@ -429,9 +429,13 @@ declare module 'legacy-comment-manager' {
 
   // #region Comment filter axis types (shared with comment-list-filters.model.ts)
 
+  /** Resolved-status filter axis: all threads, only unresolved, or only resolved. */
   export type ResolvedFilter = 'all' | 'unresolved' | 'resolved';
+  /** Read-status filter axis: all threads, only unread, or only read (for the current user). */
   export type ReadFilter = 'all' | 'unread' | 'read';
+  /** Note-type filter axis: all notes, only conflict notes, or only regular comments. */
   export type TypeFilter = 'all' | 'conflicts' | 'comments';
+  /** Assignment filter axis: all threads, assigned to me, assigned to the team, or unassigned. */
   export type AssignmentFilter = 'all' | 'assigned-to-me' | 'team' | 'unassigned';
 
   /** The four orthogonal comment-filter axis selections. Each defaults to `'all'` (no filtering). */
@@ -463,6 +467,9 @@ declare module 'legacy-comment-manager' {
      * merged with the user's current selection — and an omitted `scopeFilter` resets scope to
      * 'unfiltered' (all books). The result is the requested view with nothing carried over from
      * prior state.
+     *
+     * @param filters Comment-filter axes to apply; unspecified axes reset to 'all'.
+     * @param scopeFilter Scope to apply; omitting it resets scope to 'unfiltered' (all books).
      */
     setFilters(filters?: Partial<CommentFilters>, scopeFilter?: ScopeFilter): Promise<void>;
   }>;

--- a/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
+++ b/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
@@ -458,9 +458,11 @@ declare module 'legacy-comment-manager' {
      */
     selectThread(threadId: string): Promise<void>;
     /**
-     * Set the comment-list filter axes and/or scope. Axes given in `filters` are applied on top of
-     * the default (all) filters — unspecified axes reset to 'all', they are NOT merged with the
-     * user's current selection. `scopeFilter` is set only when provided.
+     * Set the comment-list view deterministically, exactly as a fresh open would. `filters` is
+     * applied on top of the default (all) filters — unspecified axes reset to 'all', they are NOT
+     * merged with the user's current selection — and an omitted `scopeFilter` resets scope to
+     * 'unfiltered' (all books). The result is the requested view with nothing carried over from
+     * prior state.
      */
     setFilters(filters?: Partial<CommentFilters>, scopeFilter?: ScopeFilter): Promise<void>;
   }>;
@@ -475,7 +477,7 @@ declare module 'legacy-comment-manager' {
     projectId?: string | undefined;
     /** Comment-filter axes to pre-apply (unspecified axes reset to 'all'). */
     filtersToSet?: Partial<CommentFilters> | undefined;
-    /** Scope to pre-apply (e.g. `'unfiltered'` for all books). */
+    /** Scope to pre-apply; an omitted value resets scope to `'unfiltered'` (all books). */
     scopeFilterToSet?: ScopeFilter | undefined;
   };
 

--- a/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
+++ b/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
@@ -507,7 +507,8 @@ declare module 'papi-shared-types' {
      *   `options.scopeFilterToSet` pre-apply comment-filter axes/scope on open or focus.
      * @returns The ID of the comment list WebView that was opened or focused, or `undefined` if no
      *   project ID could be determined
-     * @throws If something goes wrong with selecting the provided thread ID
+     * @throws If the comment list WebView controller cannot be obtained to apply the requested
+     *   thread selection or filters
      */
     'legacyCommentManager.openCommentList': (
       webViewId?: string | undefined,

--- a/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
+++ b/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
@@ -457,11 +457,26 @@ declare module 'legacy-comment-manager' {
      * @param threadId The ID of the thread to scroll to and select
      */
     selectThread(threadId: string): Promise<void>;
+    /**
+     * Set the comment-list filter axes and/or scope. Axes given in `filters` are applied on top of
+     * the default (all) filters — unspecified axes reset to 'all', they are NOT merged with the
+     * user's current selection. `scopeFilter` is set only when provided.
+     */
+    setFilters(filters?: Partial<CommentFilters>, scopeFilter?: ScopeFilter): Promise<void>;
   }>;
 
   export type OpenCommentListWebViewOptions = {
     /** ID of the thread to select and scroll to in the comment list */
     threadIdToSelect?: string | undefined;
+    /**
+     * Project whose comments to show. Use when the caller is not the project's own web view (e.g.
+     * the S/R results dialog). Takes precedence over the project derived from `webViewId`.
+     */
+    projectId?: string | undefined;
+    /** Comment-filter axes to pre-apply (unspecified axes reset to 'all'). */
+    filtersToSet?: Partial<CommentFilters> | undefined;
+    /** Scope to pre-apply (e.g. `'unfiltered'` for all books). */
+    scopeFilterToSet?: ScopeFilter | undefined;
   };
 
   // #endregion Comment list WebView types
@@ -486,7 +501,10 @@ declare module 'papi-shared-types' {
      * WebView ID
      *
      * @param webViewId The ID of the WebView whose project comments to display
-     * @param options Additional options for opening the comment list WebView
+     * @param options Additional options for opening the comment list WebView. `options.projectId`
+     *   targets a project directly, taking precedence over the project derived from `webViewId`
+     *   (e.g. for callers that are not that project's own web view). `options.filtersToSet` and
+     *   `options.scopeFilterToSet` pre-apply comment-filter axes/scope on open or focus.
      * @returns The ID of the comment list WebView that was opened or focused, or `undefined` if no
      *   project ID could be determined
      * @throws If something goes wrong with selecting the provided thread ID

--- a/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
+++ b/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
@@ -427,6 +427,26 @@ declare module 'legacy-comment-manager' {
 
   // #endregion
 
+  // #region Comment filter axis types (shared with comment-list-filters.model.ts)
+
+  export type ResolvedFilter = 'all' | 'unresolved' | 'resolved';
+  export type ReadFilter = 'all' | 'unread' | 'read';
+  export type TypeFilter = 'all' | 'conflicts' | 'comments';
+  export type AssignmentFilter = 'all' | 'assigned-to-me' | 'team' | 'unassigned';
+
+  /** The four orthogonal comment-filter axis selections. Each defaults to `'all'` (no filtering). */
+  export type CommentFilters = {
+    resolved: ResolvedFilter;
+    read: ReadFilter;
+    type: TypeFilter;
+    assignment: AssignmentFilter;
+  };
+
+  /** Scope axis: current chapter vs all books. */
+  export type ScopeFilter = 'unfiltered' | 'current-chapter';
+
+  // #endregion
+
   // #region Comment list WebView types
 
   /** Web view controller for the Comment List web view */


### PR DESCRIPTION
## What

The **paranext-core half** of PT-4025: generalize the `legacyCommentManager.openCommentList` command so a caller can (a) target a project it isn't the web view for, and (b) pre-apply comment-filter axes + scope.

- Promote the comment-filter axis types (`ResolvedFilter` / `ReadFilter` / `TypeFilter` / `AssignmentFilter` / `CommentFilters` / `ScopeFilter`) into the public `legacy-comment-manager.d.ts`; the model imports + re-exports them, with each label map `satisfies Record<Union, LocalizeKey>` (drift fails compile).
- `OpenCommentListWebViewOptions` gains `projectId`, `filtersToSet` (raw axes), and `scopeFilterToSet`.
- New `setFilters` web-view controller method + `setFilters` message, mirroring the existing `selectThread` plumbing. The web view applies filters by merging onto the default (deterministic — unspecified axes reset to `all`).
- Command metadata schema updated for the new options.

## Stacked on #2508

Base is `pt-4027-conflict-filters` (#2508), which introduced the orthogonal filter axes this builds on. **Retarget to `main` after #2508 merges.** This branch is currently 1 commit behind #2508's tip (its latest review-fix) and will be rebased onto the settled base before merge.

## Consumer deferred (by design)

The user-facing consumer — the Send/Receive results-dialog "Merge conflicts" link — lives in `paratext-bible-internal-extensions` (bundled into PT10 via `paratext-10-studio`), **not** paranext-core. It lands as a follow-up after this core plumbing merges. This PR is intentionally provider-only; the raw-axes surface (chosen over a named preset) keeps the S/R-specific meaning — *"unresolved conflicts" = `{ type: 'conflicts', resolved: 'unresolved' }`* — in the caller, so core stays generic.

## Verification

- `tsc --noEmit` clean; `comment-list-filters.model` tests 6/6 (existing filter behavior preserved — the type move is byte-identical at runtime).
- No `main.ts` / web-view unit harness exists (mocking `@papi/backend` here would be over-mocking); typecheck + review is the gate for the wiring.

AI-assisted — [session](https://claude.ai/code/session_01AzT8SMKLTiNFJJ6Rjwg6LC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2517)
<!-- Reviewable:end -->

---

<!-- review-paratext:summary:start -->
## Automated review summary

# Code Review Summary

**Branch**: pt-4025-sr-conflict-link

**Base**: pt-4027-conflict-filters (#2508)

**Date**: 2026-07-08

**Review model**: Claude Opus 4.8

**Files changed**: 6

## Overview

PT-4025 (paranext-core half) generalizes the `legacyCommentManager.openCommentList` command so a
caller can (a) target a project it isn't the web view for and (b) pre-apply comment-filter axes +
scope — the plumbing the Send/Receive results-dialog "Merge conflicts" link will call (that consumer
lives in `paratext-bible-internal-extensions` and lands separately). It promotes the filter-axis
types into the public `legacy-comment-manager.d.ts`, adds `projectId` / `filtersToSet` /
`scopeFilterToSet` to `OpenCommentListWebViewOptions`, and adds a `setFilters` web-view controller
method + message mirroring the existing `selectThread` plumbing.

Four `/review-paratext` passes (API/correctness, style/patterns, coverage/compliance, UX) plus a
deeper `/code-review high` correctness pass found **no critical issues**, **two important**, and a
handful of minors. All important findings and the low-risk minors were fixed during review; the
remaining items are deferred with rationale below.

## API Changes

- `extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts`:
  - `OpenCommentListWebViewOptions` gains `projectId`, `filtersToSet` (raw axes), `scopeFilterToSet`.
  - New `setFilters(filters?, scopeFilter?)` method on `CommentListWebViewController`.
  - Filter-axis types (`ResolvedFilter` / `ReadFilter` / `TypeFilter` / `AssignmentFilter` /
    `CommentFilters` / `ScopeFilter`) promoted to the public surface; the model imports + re-exports
    them, each label map `satisfies Record<Union, LocalizeKey>` so drift fails compile.
  - `openCommentList` command-handler TSDoc + metadata schema updated for the new options.
- No change to `lib/platform-bible-react`, `lib/platform-bible-utils`, or `lib/papi-dts/papi.d.ts`.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **I-1 — Initial filters could be lost to a first-open race.** For a brand-new comment list, the
  initial filter/scope was applied by a `setFilters` message posted immediately after `openWebView`;
  that message can arrive before the new view's `window` message listener mounts, silently dropping
  the requested view.
  _(fixed during review — option (a): the initial filter/scope is seeded into web-view **state**, and
  the view lazy-initializes `useState(() => applyFilterOverrides(initialFilters))` /
  `initialScopeFilter ?? UNFILTERED` from it, so a new view mounts already-filtered — no message
  needed. The state is one-shot: not persisted across restarts. The reuse path is unchanged and still
  uses the `setFilters` message.)_
- [x] **I-2 — Filter-merge contract duplicated and undocumented.** The non-obvious
  "unspecified axes reset to `all`, NOT merged with the user's current selection"
  (`{ ...DEFAULT_COMMENT_FILTERS, ...overrides }`) logic lived inline in two places and could drift.
  _(fixed during review: extracted an exported, documented `applyFilterOverrides(overrides?)` helper
  shared by the initial state and the `setFilters` handler; added 4 unit tests, incl. reset-not-merge
  and no-mutation — revert-tested.)_

### Minor — Consider

- [x] **Scope-axis asymmetry.** Filter axes reset to `all` when unspecified, but an omitted scope was
  left unchanged, contradicting the "deterministic view" intent (a reused view could keep a stale
  current-chapter scope).
  _(fixed during review — author chose full determinism: a `setFilters` open now resets scope to
  `UNFILTERED` when omitted, matching filter axes, so the whole view is deterministic. Controller /
  options / command-schema docs updated to match.)_
- [x] **Wrong-project editor context.** When `options.projectId` targets a project other than the
  triggering web view's, the trigger's editor context (scroll group + web view id) was still passed,
  which would wire the comment list to another project's editor.
  _(fixed during review: a guard drops the editor context on project mismatch; the trigger's tab id
  is still used purely for docking placement. Provably a no-op for every current caller.)_
- [x] **Duplicated controller lookup.** `openCommentList` fetched the web-view controller twice — once
  for select-thread, once for set-filters.
  _(fixed during review: a single lookup drives both post-open actions.)_
- [ ] **Command-schema enum duplication.** The `filtersToSet` enums in the command metadata are
  hand-kept in sync with the TS union types.
  _(deferred: inherent to papi's hand-written command schemas across the repo; a real fix needs
  codegen, out of scope for this PR.)_
- [x] **Filter-type import source.** Checked for inconsistent import origins of the filter types.
  _(no change needed: consistent by role — value/helper consumers import from the local
  `comment-list-filters.model` hub; type-only consumers import from the ambient `legacy-comment-manager`
  module, which those files already depend on for other types.)_

## Verification

- Extension `tsc -p` clean; eslint clean (real run, plugin resolution pinned — the review worktree is
  nested inside the main checkout); prettier clean.
- `comment-list-filters.model` tests **10/10** (4 new for `applyFilterOverrides`; the 3 behavioral
  ones confirmed falsifiable via revert).
- No `main.ts` / web-view unit harness exists (mocking `@papi/backend` here would be over-mocking);
  typecheck + review is the gate for the wiring.
<!-- review-paratext:summary:end -->

AI-assisted review — [session](https://claude.ai/code/session_015hfnmegSuB5vVmfNCvAtqk)
