### PR TITLE
Remove deprecated platform.verseRef setting

### DIFF
--- a/assets/localization/en.json
+++ b/assets/localization/en.json
@@ -373,8 +373,6 @@
   "%settings_platform_ptxUtilsMementoData_label%": "PtxUtils Memento Data",
   "%settings_platform_requestTimeout_description%": "Number of seconds to allow internal requests to resolve. Requests that take longer than this will be aborted. Set to 0 to never abort requests.",
   "%settings_platform_requestTimeout_label%": "Request Timeout",
-  "%settings_platform_verseRef_description%": "Current Verse Reference for Scroll Group A. Deprecated - please use `papi.scrollGroups` and `useWebViewScrollGroupScrRef`",
-  "%settings_platform_verseRef_label%": "Current Verse Reference for Scroll Group A (Deprecated)",
   "%settings_platform_zoomFactor_description%": "Applies to the entire application. 1.0 is the default. Allowed range is 0.5 to 3.0.",
   "%settings_platform_zoomFactor_errorMessage%": "Allowed range is {lowerLimit} to {upperLimit}.",
   "%settings_platform_zoomFactor_label%": "Zoom factor",

--- a/assets/localization/es.json
+++ b/assets/localization/es.json
@@ -491,8 +491,6 @@
   "%settings_platform_ptxUtilsMementoData_label%": "PtxUtils Memento Data (oculto - sin traducir intencionalmente)",
   "%settings_platform_requestTimeout_description%": "Número de segundos que se permite para que las solicitudes internas se completen. Las solicitudes que tarden más de este tiempo serán abortadas. Establezca en 0 para nunca abortar solicitudes.",
   "%settings_platform_requestTimeout_label%": "Tiempo de espera de la solicitud",
-  "%settings_platform_verseRef_description%": "Referencia de Versículo actual para el grupo de desplazamiento A. (obsoleto)",
-  "%settings_platform_verseRef_label%": "Referencia para el grupo de desplazamiento A (obsoleto)",
   "%settings_platform_zoomFactor_description%": "Se aplica a toda la aplicación. El valor predeterminado es 1. El rango permitido es de 0,5 a 3.",
   "%settings_platform_zoomFactor_errorMessage%": "El rango permitido es de {lowerLimit} a {upperLimit}.",
   "%settings_platform_zoomFactor_label%": "Zoom",

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4205,7 +4205,6 @@ declare module 'papi-shared-types' {
     UpdateWebViewEvent,
   } from 'shared/services/web-view.service-model';
   import { WebViewId } from 'shared/models/web-view.model';
-  import { SerializedVerseRef } from '@sillsdev/scripture';
   /**
    * Function types for each command available on the papi. Each extension can extend this interface
    * to add commands that it registers on the papi with `papi.commands.registerCommand`.
@@ -4313,11 +4312,6 @@ declare module 'papi-shared-types' {
    */
   interface SettingTypes {
     /**
-     * Current Verse Reference for Scroll Group A. Deprecated - please use `papi.scrollGroups` and
-     * `useWebViewScrollGroupScrRef`
-     */
-    'platform.verseRef': SerializedVerseRef;
-    /**
      * List of locales to use when localizing the interface. First in the list receives highest
      * priority. Please always add 'en' (English) at the end when using this setting so everything
      * localizes to English if it does not have a localization in a higher-priority locale.
@@ -4367,7 +4361,7 @@ declare module 'papi-shared-types' {
    *
    * Automatically includes all extensions' user settings that are added to {@link SettingTypes}.
    *
-   * @example 'platform.verseRef'
+   * @example 'platform.interfaceLanguage'
    */
   type SettingNames = keyof SettingTypes;
   /**
@@ -7795,6 +7789,140 @@ declare module 'renderer/hooks/papi-hooks/use-data.hook' {
   export const useData: UseDataHook;
   export default useData;
 }
+declare module 'renderer/services/scroll-group.service-host' {
+  import { ScrollGroupUpdateInfo } from 'shared/services/scroll-group.service-model';
+  import { SerializedVerseRef } from '@sillsdev/scripture';
+  import { type PlatformEvent, ScrollGroupId } from 'platform-bible-utils';
+  /**
+   * All Scroll Group IDs that are intended to be shown in scroll group selectors. This is a
+   * placeholder and will be refactored significantly in
+   * https://github.com/paranext/paranext-core/issues/788
+   */
+  export const availableScrollGroupIds: (number | undefined)[];
+  /**
+   * Event that emits with information about a changed Scripture Reference for a scroll group. Note it
+   * also fires on a source-only change — a same-numbered reference set by a different-versification
+   * project (the `sourceProjectId` changes while the verse numbers do not) — so consumers must not
+   * assume it fires only when the verse numbers change; use the payload's `sourceProjectId` to tell a
+   * frame change from a verse change.
+   */
+  export const onDidUpdateScrRef: PlatformEvent<ScrollGroupUpdateInfo>;
+  /**
+   * Event that emits when a tracked project's versification changes mid-session (see
+   * {@link ensureVersificationSubscribed}). Does NOT emit for the initial subscription load — only for
+   * a genuine change.
+   */
+  export const onDidChangeVersification: PlatformEvent<{
+    projectId: string;
+  }>;
+  /** See {@link IScrollGroupRemoteService.getScrRef} */
+  export function getScrRefSync(scrollGroupId?: ScrollGroupId): SerializedVerseRef;
+  /**
+   * Get the id of the project whose versification the scroll group's stored `scrRef` is expressed in.
+   *
+   * @param scrollGroupId Scroll group whose source project id to read. If `undefined`, defaults to 0
+   * @returns The source project id, or `undefined` when the source frame is unknown — e.g. the group
+   *   was never set with a source, or its ref came from an external writer whose versification is not
+   *   known
+   */
+  export function getScrRefSourceProjectIdSync(scrollGroupId?: ScrollGroupId): string | undefined;
+  /**
+   * Synchronous, best-effort companion to {@link getScrRefForProject}: returns the already-computed
+   * conversion into `projectId`'s versification if one is cached, otherwise the raw stored reference.
+   * Never fires a round-trip. Used for the initial displayed value and when detaching a web view so
+   * callers never block on the async conversion. Returns the raw reference when no conversion is
+   * needed (source frame unknown or already `projectId`) or when a conversion has not been computed
+   * yet.
+   *
+   * @param scrollGroupId Scroll group whose reference to read. If `undefined`, defaults to 0
+   * @param projectId Project into whose versification the reference should be converted
+   * @returns The cached converted reference, or the raw reference when none is available
+   */
+  export function getScrRefForProjectSync(
+    scrollGroupId: ScrollGroupId | undefined,
+    projectId: string,
+  ): SerializedVerseRef;
+  /**
+   * Get the scroll group's Scripture reference converted into the versification of `projectId`.
+   *
+   * The group stores its reference in the versification of whichever project last set it (see
+   * {@link getScrRefSourceProjectIdSync}); this resolves that frame and converts to `projectId`'s
+   * versification via the `platformScripture.mapVerseRefBetweenProjects` command, so every consumer —
+   * in any process — gets a reference it can use directly. Returns the raw stored reference unchanged
+   * when no conversion is needed: the source frame is unknown, or already matches `projectId`. On any
+   * conversion failure it falls back to the raw reference (and does not permanently suppress the
+   * project — the failure may be transient).
+   *
+   * @param scrollGroupId Scroll group whose reference to convert. If `undefined`, defaults to 0
+   * @param projectId Project into whose versification to convert the reference
+   * @returns The reference in `projectId`'s versification
+   */
+  export function getScrRefForProject(
+    scrollGroupId: ScrollGroupId | undefined,
+    projectId: string,
+  ): Promise<SerializedVerseRef>;
+  /**
+   * See {@link IScrollGroupRemoteService.setScrRef}
+   *
+   * @param sourceProjectId Project whose versification `scrRef` is expressed in. `undefined` =
+   *   unknown / canonical English.
+   */
+  export function setScrRefSync(
+    scrollGroupId: ScrollGroupId | undefined,
+    scrRef: SerializedVerseRef,
+    sourceProjectId?: string,
+  ): boolean;
+  /** Register the network object that backs the scroll group service */
+  export function startScrollGroupService(): Promise<void>;
+}
+declare module 'renderer/hooks/papi-hooks/use-scroll-group-scr-ref.hook' {
+  import { ScrollGroupScrRef } from 'shared/services/scroll-group.service-model';
+  import { SerializedVerseRef } from '@sillsdev/scripture';
+  import { ScrollGroupId } from 'platform-bible-utils';
+  /**
+   * React hook for working with a {@link ScrollGroupScrRef}. Returns a value and a function to set the
+   * value for both the SerializedVerseRef and the {@link ScrollGroupId} for the provided
+   * `scrollGroupScrRef`. Use similarly to `useState`.
+   *
+   * @param scrollGroupScrRef {@link ScrollGroupScrRef} representing a scroll group and/or Scripture
+   *   reference. Defaults to 0 meaning synced with scroll group 0 (A in English)
+   *
+   *   WARNING: MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not be
+   *   updated every render
+   * @param setScrollGroupScrRef Function to run to set `scrollGroupScrRef`. Should return `true` if
+   *   actually updated any properties; `false` otherwise
+   *
+   *   Note: this parameter is internally assigned to a `ref`, so changing it will not cause any hooks
+   *   to re-run with its new value. This means that updating this parameter will not cause a new
+   *   callback to be returned. However, because this is just used when needed and doesn't have any
+   *   reason to render changes, this has no adverse effect on the functionality of this hook. It will
+   *   always set using the latest value of this callback
+   * @param projectId Optional project id for the consuming web view. When provided, the returned
+   *   `scrRef` is converted into this project's versification for display. `setScrRef` stamps the
+   *   scroll group with this project as the source.
+   * @returns `[scrRef, setScrRef, scrollGroupId, setScrollGroupId]`
+   *
+   *   - `scrRef`: The current value for the Scripture reference this `scrollGroupScrRef` represents,
+   *       converted into `projectId`'s versification when a `projectId` is provided
+   *   - `setScrRef`: Function to use to update the Scripture reference this `scrollGroupScrRef`
+   *       represents. If it is synced to a scroll group, sets the scroll group's Scripture reference
+   *   - `scrollGroupId`: The current value for the scroll group this `scrollGroupScrRef` is synced with.
+   *       If not synced to a scroll group, this is `undefined`
+   *   - `setScrollGroupId`: Function to use to update the scroll group with which this
+   *       `scrollGroupScrRef` is synced
+   */
+  export function useScrollGroupScrRef(
+    scrollGroupScrRef: ScrollGroupScrRef | undefined,
+    setScrollGroupScrRef: (scrollGroupScrRef: ScrollGroupScrRef) => boolean,
+    projectId?: string,
+  ): [
+    scrRef: SerializedVerseRef,
+    setScrRef: (newScrRef: SerializedVerseRef) => void,
+    scrollGroupId: ScrollGroupId | undefined,
+    setScrollGroupId: (newScrollGroupId: ScrollGroupId | undefined) => void,
+  ];
+  export default useScrollGroupScrRef;
+}
 declare module 'shared/data/platform.data' {
   /**
    * Namespace to use for features like commands, settings, etc. on the PAPI that are provided by
@@ -8165,144 +8293,6 @@ declare module 'shared/services/settings.service' {
   import { ISettingsService } from 'shared/services/settings.service-model';
   export const settingsService: ISettingsService;
   export default settingsService;
-}
-declare module 'renderer/services/scroll-group.service-host' {
-  import { ScrollGroupUpdateInfo } from 'shared/services/scroll-group.service-model';
-  import { SerializedVerseRef } from '@sillsdev/scripture';
-  import { type PlatformEvent, ScrollGroupId } from 'platform-bible-utils';
-  /**
-   * All Scroll Group IDs that are intended to be shown in scroll group selectors. This is a
-   * placeholder and will be refactored significantly in
-   * https://github.com/paranext/paranext-core/issues/788
-   */
-  export const availableScrollGroupIds: (number | undefined)[];
-  /**
-   * Event that emits with information about a changed Scripture Reference for a scroll group. Note it
-   * also fires on a source-only change — a same-numbered reference set by a different-versification
-   * project (the `sourceProjectId` changes while the verse numbers do not) — so consumers must not
-   * assume it fires only when the verse numbers change; use the payload's `sourceProjectId` to tell a
-   * frame change from a verse change.
-   */
-  export const onDidUpdateScrRef: PlatformEvent<ScrollGroupUpdateInfo>;
-  /**
-   * Event that emits when a tracked project's versification changes mid-session (see
-   * {@link ensureVersificationSubscribed}). Does NOT emit for the initial subscription load — only for
-   * a genuine change.
-   */
-  export const onDidChangeVersification: PlatformEvent<{
-    projectId: string;
-  }>;
-  /** See {@link IScrollGroupRemoteService.getScrRef} */
-  export function getScrRefSync(scrollGroupId?: ScrollGroupId): SerializedVerseRef;
-  /**
-   * Get the id of the project whose versification the scroll group's stored `scrRef` is expressed in.
-   *
-   * @param scrollGroupId Scroll group whose source project id to read. If `undefined`, defaults to 0
-   * @returns The source project id, or `undefined` when the source frame is unknown — e.g. the group
-   *   was never set with a source, or its ref came from the `platform.verseRef` setting / an external
-   *   writer whose versification is not known
-   */
-  export function getScrRefSourceProjectIdSync(scrollGroupId?: ScrollGroupId): string | undefined;
-  /**
-   * Synchronous, best-effort companion to {@link getScrRefForProject}: returns the already-computed
-   * conversion into `projectId`'s versification if one is cached, otherwise the raw stored reference.
-   * Never fires a round-trip. Used for the initial displayed value and when detaching a web view so
-   * callers never block on the async conversion. Returns the raw reference when no conversion is
-   * needed (source frame unknown or already `projectId`) or when a conversion has not been computed
-   * yet.
-   *
-   * @param scrollGroupId Scroll group whose reference to read. If `undefined`, defaults to 0
-   * @param projectId Project into whose versification the reference should be converted
-   * @returns The cached converted reference, or the raw reference when none is available
-   */
-  export function getScrRefForProjectSync(
-    scrollGroupId: ScrollGroupId | undefined,
-    projectId: string,
-  ): SerializedVerseRef;
-  /**
-   * Get the scroll group's Scripture reference converted into the versification of `projectId`.
-   *
-   * The group stores its reference in the versification of whichever project last set it (see
-   * {@link getScrRefSourceProjectIdSync}); this resolves that frame and converts to `projectId`'s
-   * versification via the `platformScripture.mapVerseRefBetweenProjects` command, so every consumer —
-   * in any process — gets a reference it can use directly. Returns the raw stored reference unchanged
-   * when no conversion is needed: the source frame is unknown, or already matches `projectId`. On any
-   * conversion failure it falls back to the raw reference (and does not permanently suppress the
-   * project — the failure may be transient).
-   *
-   * @param scrollGroupId Scroll group whose reference to convert. If `undefined`, defaults to 0
-   * @param projectId Project into whose versification to convert the reference
-   * @returns The reference in `projectId`'s versification
-   */
-  export function getScrRefForProject(
-    scrollGroupId: ScrollGroupId | undefined,
-    projectId: string,
-  ): Promise<SerializedVerseRef>;
-  /**
-   * See {@link IScrollGroupRemoteService.setScrRef}
-   *
-   * @param sourceProjectId Project whose versification `scrRef` is expressed in. `undefined` =
-   *   unknown / canonical English.
-   * @param shouldSetVerseRefSetting If `true`: if scroll group 0's reference changes, update the
-   *   `platform.verseRef` setting to keep it in sync for backwards compatibility. Defaults to `true`.
-   *   Only set to `false` when running this from subscription to updates to the setting
-   */
-  export function setScrRefSync(
-    scrollGroupId: ScrollGroupId | undefined,
-    scrRef: SerializedVerseRef,
-    sourceProjectId?: string,
-    shouldSetVerseRefSetting?: boolean,
-  ): boolean;
-  /** Register the network object that backs the scroll group service */
-  export function startScrollGroupService(): Promise<void>;
-}
-declare module 'renderer/hooks/papi-hooks/use-scroll-group-scr-ref.hook' {
-  import { ScrollGroupScrRef } from 'shared/services/scroll-group.service-model';
-  import { SerializedVerseRef } from '@sillsdev/scripture';
-  import { ScrollGroupId } from 'platform-bible-utils';
-  /**
-   * React hook for working with a {@link ScrollGroupScrRef}. Returns a value and a function to set the
-   * value for both the SerializedVerseRef and the {@link ScrollGroupId} for the provided
-   * `scrollGroupScrRef`. Use similarly to `useState`.
-   *
-   * @param scrollGroupScrRef {@link ScrollGroupScrRef} representing a scroll group and/or Scripture
-   *   reference. Defaults to 0 meaning synced with scroll group 0 (A in English)
-   *
-   *   WARNING: MUST BE STABLE - const or wrapped in useState, useMemo, etc. The reference must not be
-   *   updated every render
-   * @param setScrollGroupScrRef Function to run to set `scrollGroupScrRef`. Should return `true` if
-   *   actually updated any properties; `false` otherwise
-   *
-   *   Note: this parameter is internally assigned to a `ref`, so changing it will not cause any hooks
-   *   to re-run with its new value. This means that updating this parameter will not cause a new
-   *   callback to be returned. However, because this is just used when needed and doesn't have any
-   *   reason to render changes, this has no adverse effect on the functionality of this hook. It will
-   *   always set using the latest value of this callback
-   * @param projectId Optional project id for the consuming web view. When provided, the returned
-   *   `scrRef` is converted into this project's versification for display. `setScrRef` stamps the
-   *   scroll group with this project as the source.
-   * @returns `[scrRef, setScrRef, scrollGroupId, setScrollGroupId]`
-   *
-   *   - `scrRef`: The current value for the Scripture reference this `scrollGroupScrRef` represents,
-   *       converted into `projectId`'s versification when a `projectId` is provided
-   *   - `setScrRef`: Function to use to update the Scripture reference this `scrollGroupScrRef`
-   *       represents. If it is synced to a scroll group, sets the scroll group's Scripture reference
-   *   - `scrollGroupId`: The current value for the scroll group this `scrollGroupScrRef` is synced with.
-   *       If not synced to a scroll group, this is `undefined`
-   *   - `setScrollGroupId`: Function to use to update the scroll group with which this
-   *       `scrollGroupScrRef` is synced
-   */
-  export function useScrollGroupScrRef(
-    scrollGroupScrRef: ScrollGroupScrRef | undefined,
-    setScrollGroupScrRef: (scrollGroupScrRef: ScrollGroupScrRef) => boolean,
-    projectId?: string,
-  ): [
-    scrRef: SerializedVerseRef,
-    setScrRef: (newScrRef: SerializedVerseRef) => void,
-    scrollGroupId: ScrollGroupId | undefined,
-    setScrollGroupId: (newScrollGroupId: ScrollGroupId | undefined) => void,
-  ];
-  export default useScrollGroupScrRef;
 }
 declare module 'renderer/hooks/papi-hooks/use-setting.hook' {
   import { PlatformError } from 'platform-bible-utils';

--- a/src/declarations/papi-shared-types.ts
+++ b/src/declarations/papi-shared-types.ts
@@ -34,7 +34,6 @@ declare module 'papi-shared-types' {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   import type { IWebViewProvider } from '@shared/models/web-view-provider.model';
   import { WebViewId } from '@shared/models/web-view.model';
-  import { SerializedVerseRef } from '@sillsdev/scripture';
 
   // #region Commands
 
@@ -159,11 +158,6 @@ declare module 'papi-shared-types' {
    */
   export interface SettingTypes {
     /**
-     * Current Verse Reference for Scroll Group A. Deprecated - please use `papi.scrollGroups` and
-     * `useWebViewScrollGroupScrRef`
-     */
-    'platform.verseRef': SerializedVerseRef;
-    /**
      * List of locales to use when localizing the interface. First in the list receives highest
      * priority. Please always add 'en' (English) at the end when using this setting so everything
      * localizes to English if it does not have a localization in a higher-priority locale.
@@ -210,7 +204,7 @@ declare module 'papi-shared-types' {
    *
    * Automatically includes all extensions' user settings that are added to {@link SettingTypes}.
    *
-   * @example 'platform.verseRef'
+   * @example 'platform.interfaceLanguage'
    */
   export type SettingNames = keyof SettingTypes;
 

--- a/src/extension-host/data/core-settings-info.data.ts
+++ b/src/extension-host/data/core-settings-info.data.ts
@@ -2,7 +2,6 @@ import { localization } from '@extension-host/services/papi-backend.service';
 import { DEFAULT_ZOOM_FACTOR, MAX_ZOOM_FACTOR, MIN_ZOOM_FACTOR } from '@shared/data/platform.data';
 import { localizationService } from '@shared/services/localization.service';
 import { AllSettingsValidators, SettingValidator } from '@shared/services/settings.service-model';
-import { Canon, SerializedVerseRef } from '@sillsdev/scripture';
 import { formatReplacementString, isString, SettingsContribution } from 'platform-bible-utils';
 
 /** Contribution of all settings built into core. Does not contain info for extensions' settings */
@@ -11,12 +10,6 @@ export const platformSettings: SettingsContribution = [
     label: '%settings_platform_group1_label_alternative%',
     description: '%settings_platform_group1_description%',
     properties: {
-      'platform.verseRef': {
-        label: '%settings_platform_verseRef_label%',
-        description: '%settings_platform_verseRef_description%',
-        default: { book: 'GEN', chapterNum: 1, verseNum: 1 },
-        isHidden: true,
-      },
       'platform.interfaceLanguage': {
         label: '%settings_platform_interfaceLanguage_label%',
         description: '%settings_platform_interfaceLanguage_description%',
@@ -50,23 +43,6 @@ export const platformSettings: SettingsContribution = [
     },
   },
 ];
-
-// TODO: Add range checking of BCV numbers given the current versification
-export const verseRefSettingsValidator: SettingValidator<'platform.verseRef'> = async (
-  newValue: SerializedVerseRef,
-): Promise<boolean> => {
-  return (
-    'book' in newValue &&
-    'chapterNum' in newValue &&
-    'verseNum' in newValue &&
-    typeof newValue.book === 'string' &&
-    typeof newValue.chapterNum === 'number' &&
-    typeof newValue.verseNum === 'number' &&
-    Canon.isBookIdValid(newValue.book) &&
-    newValue.chapterNum >= 0 &&
-    newValue.verseNum >= 0
-  );
-};
 
 // TODO: Validate that strings in the array match BCP 47 values once the i18n code is ready. Or maybe
 // now that we're validating against actual locales read in by the localization service, that check
@@ -138,7 +114,6 @@ const interfaceModeValidator: SettingValidator<'platform.interfaceMode'> = async
 };
 
 export const coreSettingsValidators: Partial<AllSettingsValidators> = {
-  'platform.verseRef': verseRefSettingsValidator,
   'platform.interfaceLanguage': interfaceLanguageValidator,
   'platform.ptxUtilsMementoData': serializableStringDictionarySettingValidator,
   'platform.paratextDataLastRegistryDataCachedTimes': serializableStringDictionarySettingValidator,

--- a/src/extension-host/services/settings.service-host.test.ts
+++ b/src/extension-host/services/settings.service-host.test.ts
@@ -9,7 +9,7 @@ const MOCK_SETTINGS_DATA = {
   'settingsTest.valueIsUndefined': undefined,
 };
 
-const VERSE_REF_DEFAULT = { default: { book: 'GEN', chapterNum: 1, verseNum: 1 } };
+const REQUEST_TIMEOUT_DEFAULT = { default: 30 };
 const NEW_INTERFACE_LANGUAGE = ['spa'];
 
 let settingsProviderEngine: ReturnType<
@@ -23,7 +23,7 @@ beforeEach(() => {
 
 vi.mock('@node/services/node-file-system.service', () => ({
   readFileText: () => {
-    return JSON.stringify(VERSE_REF_DEFAULT);
+    return JSON.stringify(REQUEST_TIMEOUT_DEFAULT);
   },
   writeFile: () => {
     return Promise.resolve();
@@ -40,9 +40,9 @@ vi.mock('@extension-host/data/core-settings-info.data', async () => ({
         label: '%settings_platform_name_label%',
         default: '%missing%',
       },
-      'platform.verseRef': {
-        label: '%settings_platform_verseRef_label%',
-        default: { book: 'GEN', chapterNum: 1, verseNum: 1 },
+      'platform.requestTimeout': {
+        label: '%settings_platform_requestTimeout_label%',
+        default: 30,
       },
       'platform.interfaceLanguage': {
         label: '%settings_platform_interfaceLanguage_label%',
@@ -51,8 +51,8 @@ vi.mock('@extension-host/data/core-settings-info.data', async () => ({
     },
   },
   coreSettingsValidators: {
-    'platform.verseRef': async (): Promise<boolean> => {
-      // Reject all attempts to set the verse ref
+    'platform.requestTimeout': async (): Promise<boolean> => {
+      // Reject all attempts to set the request timeout
       return false;
     },
     'platform.interfaceLanguage': async (): Promise<boolean> => {
@@ -77,9 +77,9 @@ vi.mock('@extension-host/services/contribution.service', async () => ({
   waitForResyncContributions: async () => {},
 }));
 
-test('Get verseRef returns default value', async () => {
-  const result = await settingsProviderEngine.get('platform.verseRef');
-  expect(result).toEqual(VERSE_REF_DEFAULT.default);
+test('Get requestTimeout returns default value', async () => {
+  const result = await settingsProviderEngine.get('platform.requestTimeout');
+  expect(result).toEqual(REQUEST_TIMEOUT_DEFAULT.default);
 });
 
 test('Get interfaceLanguage returns stored value', async () => {
@@ -122,18 +122,14 @@ test('Reset interfaceLanguage returns true', async () => {
   expect(result).toBe(true);
 });
 
-test('Reset verseRef returns false', async () => {
-  const result = await settingsProviderEngine.reset('platform.verseRef');
+test('Reset requestTimeout returns false', async () => {
+  const result = await settingsProviderEngine.reset('platform.requestTimeout');
   expect(result).toBe(false);
 });
 
-test('Set verseRef throws', async () => {
-  const result = settingsProviderEngine.set('platform.verseRef', {
-    book: 'EXO',
-    chapterNum: 1,
-    verseNum: 1,
-  });
+test('Set requestTimeout throws', async () => {
+  const result = settingsProviderEngine.set('platform.requestTimeout', 60);
   await expect(result).rejects.toThrow(
-    "Error setting value for key 'platform.verseRef': validation failed",
+    "Error setting value for key 'platform.requestTimeout': validation failed",
   );
 });

--- a/src/renderer/services/scroll-group.service-host.test.ts
+++ b/src/renderer/services/scroll-group.service-host.test.ts
@@ -19,10 +19,6 @@ vi.mock('@shared/services/network.service', () => ({
 vi.mock('@shared/services/network-object.service', () => ({
   networkObjectService: { set: vi.fn() },
 }));
-const settingsSet = vi.fn();
-vi.mock('@shared/services/settings.service', () => ({
-  settingsService: { set: (...args: unknown[]) => settingsSet(...args), subscribe: vi.fn() },
-}));
 vi.mock('@shared/services/logger.service', () => ({ logger: { warn: vi.fn(), error: vi.fn() } }));
 
 const sendCommand = vi.fn();
@@ -47,7 +43,6 @@ describe('scroll-group.service-host source project tracking', () => {
     localStorage.clear();
     vi.resetModules();
     sendCommand.mockReset();
-    settingsSet.mockReset();
     Object.keys(projectVersifications).forEach((key) => {
       delete projectVersifications[key];
     });
@@ -95,7 +90,7 @@ describe('scroll-group.service-host source project tracking', () => {
     expect(host.getScrRefSourceProjectIdSync(1)).toBe('projB');
   });
 
-  it('does not clobber a known source when a same-numbered ref is set with no source (verseRef echo)', async () => {
+  it('does not clobber a known source when a same-numbered ref is set with no source', async () => {
     const host = await import('@renderer/services/scroll-group.service-host');
     const ref = { book: 'PSA', chapterNum: 3, verseNum: 1 };
     host.setScrRefSync(1, ref, 'projA');
@@ -288,35 +283,6 @@ describe('scroll-group.service-host source project tracking', () => {
       ...refForIndex(CAP),
       versificationStr: 'converted',
     });
-  });
-
-  it('rewrites the platform.verseRef setting when the verse numbers change on group 0', async () => {
-    const host = await import('@renderer/services/scroll-group.service-host');
-    settingsSet.mockClear();
-
-    host.setScrRefSync(0, { book: 'PSA', chapterNum: 23, verseNum: 1 }, 'projA');
-
-    // The write happens synchronously inside setScrRefSync (no await before settingsService.set).
-    expect(settingsSet).toHaveBeenCalledWith('platform.verseRef', {
-      book: 'PSA',
-      chapterNum: 23,
-      verseNum: 1,
-    });
-  });
-
-  it('does NOT rewrite platform.verseRef on a source-only change to group 0', async () => {
-    const host = await import('@renderer/services/scroll-group.service-host');
-    const ref = { book: 'PSA', chapterNum: 23, verseNum: 1 };
-    host.setScrRefSync(0, ref, 'projA');
-    settingsSet.mockClear();
-
-    // Same numbers, different source: must still emit for followers (changed === true) but must not
-    // rewrite the frame-blind setting, which would fan out an identical-value notification app-wide.
-    const changed = host.setScrRefSync(0, { ...ref }, 'projB');
-
-    expect(changed).toBe(true);
-    expect(host.getScrRefSourceProjectIdSync(0)).toBe('projB');
-    expect(settingsSet).not.toHaveBeenCalled();
   });
 
   it('emits a versification-changed event only when a tracked versification actually changes', async () => {

--- a/src/renderer/services/scroll-group.service-host.ts
+++ b/src/renderer/services/scroll-group.service-host.ts
@@ -13,7 +13,6 @@ import {
   NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE,
   ScrollGroupUpdateInfo,
 } from '@shared/services/scroll-group.service-model';
-import { settingsService } from '@shared/services/settings.service';
 import { Canon, SerializedVerseRef } from '@sillsdev/scripture';
 import {
   compareScrRefs,
@@ -186,8 +185,8 @@ export function getScrRefSync(scrollGroupId: ScrollGroupId = 0): SerializedVerse
  *
  * @param scrollGroupId Scroll group whose source project id to read. If `undefined`, defaults to 0
  * @returns The source project id, or `undefined` when the source frame is unknown — e.g. the group
- *   was never set with a source, or its ref came from the `platform.verseRef` setting / an external
- *   writer whose versification is not known
+ *   was never set with a source, or its ref came from an external writer whose versification is not
+ *   known
  */
 export function getScrRefSourceProjectIdSync(scrollGroupId: ScrollGroupId = 0): string | undefined {
   return scrRefSourceProjectIds[scrollGroupId];
@@ -476,15 +475,11 @@ async function getScrRef(scrollGroupScrRef: ScrollGroupId = 0): Promise<Serializ
  *
  * @param sourceProjectId Project whose versification `scrRef` is expressed in. `undefined` =
  *   unknown / canonical English.
- * @param shouldSetVerseRefSetting If `true`: if scroll group 0's reference changes, update the
- *   `platform.verseRef` setting to keep it in sync for backwards compatibility. Defaults to `true`.
- *   Only set to `false` when running this from subscription to updates to the setting
  */
 export function setScrRefSync(
   scrollGroupId: ScrollGroupId | undefined,
   scrRef: SerializedVerseRef,
   sourceProjectId?: string,
-  shouldSetVerseRefSetting = true,
 ): boolean {
   if (
     !scrRef ||
@@ -499,9 +494,8 @@ export function setScrRefSync(
 
   // compareScrRefs is versification-blind (book/chapter/verse only), so a same-numbered ref set by a
   // different source project still changes the versification frame and must NOT be treated as a
-  // no-op. Skip only when the numbers are unchanged AND the write carries no new source info — the
-  // `undefined`-source clause also covers the platform.verseRef echo (the setting-sync subscription
-  // re-sets the same ref with no source), which must not clobber a known source.
+  // no-op. Skip only when the numbers are unchanged AND the write carries no new source info — a
+  // same-numbered write with no source (`undefined`) must not clobber a known source.
   const scrRefUnchanged =
     compareScrRefs(scrRefs[scrollGroupIdDefaulted] ?? DEFAULT_SCR_REF, scrRefClone) === 0;
   if (
@@ -517,9 +511,9 @@ export function setScrRefSync(
   scrRefs[scrollGroupIdDefaulted] = scrRefClone;
   // A numbers-changed write with no source project (`sourceProjectId === undefined`) intentionally
   // CLEARS the stored source frame. This is by design: a driver with no associated project (e.g. a
-  // data model that does not track versification, or the platform.verseRef echo below) has an
-  // unknown versification, so followers must take the raw reference rather than mis-frame it under
-  // the previous source. This is not a lost-frame bug — an unknown frame is honestly unknown.
+  // data model that does not track versification) has an unknown versification, so followers must
+  // take the raw reference rather than mis-frame it under the previous source. This is not a
+  // lost-frame bug — an unknown frame is honestly unknown.
   scrRefSourceProjectIds[scrollGroupIdDefaulted] = sourceProjectId;
   saveScrRefs(sourceProjectIdChanged);
   onDidUpdateScrRefBufferedEmitter.emit({
@@ -527,22 +521,6 @@ export function setScrRefSync(
     scrRef: scrRefClone,
     sourceProjectId,
   });
-
-  // Only mirror into the backwards-compat platform.verseRef setting when the verse numbers actually
-  // changed. A source-only change (same numbers, different source project) still emits the scroll
-  // event above so followers re-convert, but must NOT rewrite the setting: platform.verseRef tracks
-  // the verse, not the frame, and settingsService.set fans out to every settings subscriber — an
-  // identical-value write would be a needless app-wide notification.
-  if (shouldSetVerseRefSetting && scrollGroupIdDefaulted === 0 && !scrRefUnchanged)
-    (async () => {
-      try {
-        settingsService.set('platform.verseRef', scrRefClone);
-      } catch (e) {
-        logger.warn(
-          `Failed to update platform.verseRef to ${serialize(scrRefClone)} to keep in sync with scroll group 0! ${getErrorMessage(e)}`,
-        );
-      }
-    })();
 
   return true;
 }
@@ -564,23 +542,4 @@ const scrollGroupService: IScrollGroupRemoteService = {
 /** Register the network object that backs the scroll group service */
 export async function startScrollGroupService(): Promise<void> {
   await networkObjectService.set(NETWORK_OBJECT_NAME_SCROLL_GROUP_SERVICE, scrollGroupService);
-
-  // Keep scroll group 0 in sync with the verse ref setting for backwards compatibility
-  await settingsService.subscribe('platform.verseRef', (newScrRef) => {
-    if (isPlatformError(newScrRef)) {
-      logger.warn(
-        `Scroll group service failed to get platform.verseRef setting to keep in sync! ${getErrorMessage(newScrRef)}`,
-      );
-      return;
-    }
-    // Pass `undefined` for the source: the setting carries no source-project frame, so a restored /
-    // external platform.verseRef value has an unknown versification and must NOT be assumed to be in
-    // the previous source project's frame. When the numbers match the stored ref this is a harmless
-    // no-op (the no-op guard in setScrRefSync preserves any known source); when they differ it is a
-    // genuine external change whose frame we honestly don't know, so the followers pass it through
-    // unconverted rather than mis-framing it.
-    // (See the source-assignment note in setScrRefSync: a numbers-changed write with no source
-    // deliberately clears the frame so followers use the raw reference.)
-    setScrRefSync(0, newScrRef, undefined, false);
-  });
 }

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -870,11 +870,11 @@ export function registerDockLayout(dockLayout: PapiDockLayout): Unsubscriber {
             return;
           }
           // All settings share one data provider data type, so the settings service notifies every
-          // settings subscriber on any setting write (e.g. `platform.verseRef` syncing on the first
-          // BCV navigation), not just when `platform.interfaceMode` changes. Only reload when the
-          // mode actually changed; otherwise an unrelated first settings write needlessly reloads
-          // the entire dock layout. `currentInterfaceMode` was seeded by the `loadLayout()` call in
-          // `registerDockLayout`, so it reflects the real mode by the time this fires.
+          // settings subscriber on any setting write, not just when `platform.interfaceMode`
+          // changes. Only reload when the mode actually changed; otherwise an unrelated settings
+          // write needlessly reloads the entire dock layout. `currentInterfaceMode` was seeded by
+          // the `loadLayout()` call in `registerDockLayout`, so it reflects the real mode by the
+          // time this fires.
           if (newMode === currentInterfaceMode) return;
           // Update the cache synchronously with the notification so any `saveLayout` racing the
           // switch reads the new mode immediately (before `loadLayout`'s own read resolves).

--- a/src/shared/utils/settings-document-combiner.test.ts
+++ b/src/shared/utils/settings-document-combiner.test.ts
@@ -24,9 +24,9 @@ const platformSettings: SettingsContribution = {
   label: '%platform_group1%',
   description: '%platform_group1_description%',
   properties: {
-    'platform.verseRef': {
-      label: '%settings_platform_verseRef_label%',
-      default: { book: 'GEN', chapterNum: 1, verseNum: 1 },
+    'platform.requestTimeout': {
+      label: '%settings_platform_requestTimeout_label%',
+      default: 30,
     },
     'platform.interfaceLanguage': {
       label: '%settings_platform_interfaceLanguage_label%',
@@ -38,9 +38,9 @@ const platformSettingsLocalized: Localized<SettingsContribution> = {
   label: 'platform_group1',
   description: 'platform_group1_description',
   properties: {
-    'platform.verseRef': {
-      label: 'settings_platform_verseRef_label',
-      default: { book: 'GEN', chapterNum: 1, verseNum: 1 },
+    'platform.requestTimeout': {
+      label: 'settings_platform_requestTimeout_label',
+      default: 30,
     },
     'platform.interfaceLanguage': {
       label: 'settings_platform_interfaceLanguage_label',


### PR DESCRIPTION
## Summary

Removes the `platform.verseRef` setting, deprecated since August 2024 in favor of `papi.scrollGroups` and `useWebViewScrollGroupScrRef`.

Beyond being long-deprecated, the setting was actively causing bugs: the scroll group service host mirrored every group-0 verse change into the setting, and its own subscription echoed the value back with `sourceProjectId: undefined`. Under rapid navigation a stale echo could land after the ref moved on, dodge the no-op guard, wrongly clear the versification frame, and resurrect a stale/verse-0 ref. Removing the setting deletes the loop instead of suppressing symptoms (an alternative fix for one symptom class was drafted on `pt-2602-toolbar-follows-active-tab`; with this removal that suppressor becomes unnecessary).

## Changes

- Remove the `platform.verseRef` entry from `SettingTypes`, the platform settings contribution, and its validator
- Remove the scroll group service host's setting mirror, setting subscription, and the `shouldSetVerseRefSetting` parameter of `setScrRefSync`
- Remove the `%settings_platform_verseRef_*%` localized strings (en, es) — their text has carried a deprecation notice since August 2024, so they are removed rather than deprecated per our localization policy window
- Swap test fixtures that used `platform.verseRef` as an arbitrary setting key to `platform.requestTimeout`
- Regenerate `lib/papi-dts/papi.d.ts`

## Compatibility notes

- A stale `platform.verseRef` value persisted in users' `settings.json` is harmless: the settings host only rejects unknown keys on explicit get/set, not at load.
- Third-party extensions still reading the setting will get a runtime "no setting exists" error; the TSDoc has pointed at `papi.scrollGroups` / `useWebViewScrollGroupScrRef` for ~2 years and no bundled or known extension uses it.
- Paratext 10 Studio's `repo-patches/paranext-core.patch` has diff context adjacent to the removed validator lines and will need regenerating after this merges (it is not a consumer of the setting).

## AI Involvement

AI-assisted (Claude Code): the removal was implemented by Claude Code based on a prior human-reviewed analysis of all consumers; changes reviewed by the developer.

## Testing

- [x] `npm run typecheck` — clean except two pre-existing failures in `platform-scripture-editor` / `platform-enhanced-resources` that reproduce identically on clean `main` (missing yalc-linked `@eten-tech-foundation/platform-editor` dev build in the verification environment)
- [x] `npm run lint` — clean (exit 0)
- [x] `npm test` — 776/777 pass; the one failure is a pre-existing cold-start timeout in `tools/pt9-css-converter` that passes in isolation
- [x] No C# changes (zero C# references to the setting), so `dotnet test` not required
- [ ] Manual verification in the running app

## Risk Level

Low — the setting had no in-repo readers besides the scroll group host's own sync loop; removal is mechanical and behavior for all scroll-group consumers is unchanged.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2518)
<!-- Reviewable:end -->
