### PR TITLE
Fix process cleanup on Windows 11; ignore local .claude files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,8 @@ docs/superpowers/
 docs/adr/
 .superpowers/
 .review
+/.claude/*.lock
+/.claude/settings.local.json
 
 # cursor
 .cursor/

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
       "node .erb/scripts/sort-cspell-words.js",
       "prettier --parser json --write --ignore-path .prettierignorerun"
     ],
-    "*.{cjs,js,jsx,ts,tsx}": ["prettier --write --ignore-path .prettierignorerun"],
+    "*.{cjs,mjs,js,jsx,cts,mts,ts,tsx}": ["prettier --write --ignore-path .prettierignorerun"],
     "!(cspell).json": ["prettier --parser json --write --ignore-path .prettierignorerun"],
     "*.{css,scss}": ["stylelint --fix --allow-empty-input"],
     "*.{html,md,yml}": ["prettier --single-quote --write --ignore-path .prettierignorerun"]

--- a/stop-processes.mjs
+++ b/stop-processes.mjs
@@ -23,8 +23,10 @@ function killProcessesWithSearchTerm() {
   let listCommand;
   if (process.platform === 'win32') {
     // WMIC was removed in Windows 11 22H2+. Use PowerShell's Get-CimInstance instead.
-    // Output format matches WMIC's CSV so the parsing below (firstIndex/lastIndex) works unchanged:
-    //   node,<CommandLine>,<ProcessId>
+    // Output matches WMIC's CSV so the parser below (firstIndex/lastIndex) is unchanged.
+    // Column 1 is an ignored placeholder (WMIC put the hostname there; the parser drops
+    // everything before the first comma), so we just emit a literal "node,":
+    //   <ignored>,<CommandLine>,<ProcessId>
     listCommand =
       'powershell -NoProfile -NonInteractive -Command "Write-Output \'Node,CommandLine,ProcessId\'; ' +
       'Get-CimInstance Win32_Process | ForEach-Object { \'node,\' + ' +

--- a/stop-processes.mjs
+++ b/stop-processes.mjs
@@ -22,7 +22,13 @@ function killProcessesWithSearchTerm() {
   // Different platforms have different ways to get running process info
   let listCommand;
   if (process.platform === 'win32') {
-    listCommand = 'WMIC path win32_process get Commandline,Processid /format:csv';
+    // WMIC was removed in Windows 11 22H2+. Use PowerShell's Get-CimInstance instead.
+    // Output format matches WMIC's CSV so the parsing below (firstIndex/lastIndex) works unchanged:
+    //   node,<CommandLine>,<ProcessId>
+    listCommand =
+      'powershell -NoProfile -NonInteractive -Command "Write-Output \'Node,CommandLine,ProcessId\'; ' +
+      'Get-CimInstance Win32_Process | ForEach-Object { \'node,\' + ' +
+      '$(if ($_.CommandLine) { $_.CommandLine } else { \'\' }) + \',\' + $_.ProcessId }"';
   } else if (process.platform === 'darwin' || process.platform === 'linux') {
     listCommand = 'ps -A -o pid,command';
   } else {

--- a/stop-processes.mjs
+++ b/stop-processes.mjs
@@ -28,9 +28,9 @@ function killProcessesWithSearchTerm() {
     // everything before the first comma), so we just emit a literal "node,":
     //   <ignored>,<CommandLine>,<ProcessId>
     listCommand =
-      'powershell -NoProfile -NonInteractive -Command "Write-Output \'Node,CommandLine,ProcessId\'; ' +
-      'Get-CimInstance Win32_Process | ForEach-Object { \'node,\' + ' +
-      '$(if ($_.CommandLine) { $_.CommandLine } else { \'\' }) + \',\' + $_.ProcessId }"';
+      "powershell -NoProfile -NonInteractive -Command \"Write-Output 'Node,CommandLine,ProcessId'; " +
+      "Get-CimInstance Win32_Process | ForEach-Object { 'node,' + " +
+      "$(if ($_.CommandLine) { $_.CommandLine } else { '' }) + ',' + $_.ProcessId }\"";
   } else if (process.platform === 'darwin' || process.platform === 'linux') {
     listCommand = 'ps -A -o pid,command';
   } else {


### PR DESCRIPTION
## Summary

Two small housekeeping fixes bundled into one PR:

1. **`stop-processes.mjs` no longer works on current Windows**: it shells out to WMIC, which Microsoft removed in Windows 11 22H2+, so the per-process search-term kill silently found nothing. Replaced with PowerShell `Get-CimInstance Win32_Process`, emitting the same CSV shape as WMIC (`node,<CommandLine>,<ProcessId>`) so the existing parsing logic is unchanged.
2. **Ignore Claude Code local working files** (`/.claude/*.lock`, `/.claude/settings.local.json`) that otherwise show up as untracked noise in `git status`. Tracked `.claude/` content (agents, commands, skills) is unaffected.

### Why review this

Not part of current epic. The `.gitignore` entries were pulled out of PR #2500 (PT-4068) during its `/review-paratext` pass as scope creep and moved here; the stop-processes fix unblocks `npm run stop` for developers on up-to-date Windows 11.

## Changes

- `stop-processes.mjs`: replace the WMIC list command with a PowerShell `Get-CimInstance` equivalent (Windows only; macOS/Linux paths unchanged)
- `.gitignore`: add `/.claude/*.lock` and `/.claude/settings.local.json`

## AI Involvement

AI-assisted — [session](https://claude.ai/code/a92ed8bf-d14e-48fa-af5a-0a7175c8f40d). The stop-processes fix was developed with AI assistance in an earlier session and carried here from the author's stash; AI assembled this branch/PR. Reviewed by the author.

## Testing

- [x] `node --check stop-processes.mjs` passes
- [x] The new PowerShell list command verified read-only on Windows 11: emits `node,<CommandLine>,<ProcessId>` rows matching the WMIC CSV shape the parser expects; processes with empty command lines are skipped by the existing `command &&` guard
- [x] Verified `.claude/scheduled_tasks.lock` no longer appears as untracked with the new ignore rules; tracked `.claude/` files unaffected

## Risk Level

Low — dev-tooling script and ignore rules only; no product code touched.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2521)
<!-- Reviewable:end -->
