### PR TITLE
PT-4110: isolate per-note serialization failures in getCommentThreads

### DIFF
--- a/c-sharp-tests/JsonUtils/JsonConverterUtilsTests.cs
+++ b/c-sharp-tests/JsonUtils/JsonConverterUtilsTests.cs
@@ -1,3 +1,7 @@
+using System.Buffers;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Paranext.DataProvider.JsonUtils;
 using Paratext.Data.ProjectComments;
 using PtxUtils;
@@ -75,6 +79,20 @@ public class JsonConverterUtilsTests
     {
         var result = ConvertNoteTypeToCommentType(new Enum<NoteType>(input));
         Assert.That(result, Is.EqualTo(expected));
+    }
+
+    [Test]
+    public void ConvertNoteTypeToCommentType_EmptyInternalValue_DoesNotThrow()
+    {
+        // An unknown NoteType with an empty InternalValue (corrupt/legacy XML) must not throw
+        // IndexOutOfRangeException — mirrors the guard in the sibling ConvertNoteStatusToCommentStatus.
+        // Guarding matters because, unguarded, this throw would take down a whole thread during
+        // getCommentThreads serialization.
+        Assert.That(
+            () => ConvertNoteTypeToCommentType(new Enum<NoteType>("")),
+            Throws.Nothing,
+            "empty InternalValue must be handled gracefully, not indexed into"
+        );
     }
 
     #endregion
@@ -185,6 +203,94 @@ public class JsonConverterUtilsTests
                 $"Round-trip failed for NoteType '{original}'"
             );
         }
+    }
+
+    #endregion
+
+    #region WriteIsolatedArray Tests
+
+    /// <summary>
+    /// A string converter that lets a test make specific sentinel elements fail to serialize, so
+    /// <see cref="WriteIsolatedArray{T}"/>'s isolation can be exercised with no production seam.
+    /// </summary>
+    private sealed class SentinelStringConverter : JsonConverter<string>
+    {
+        public const string ThrowAfterPartialWrite = "<<throw-after-partial>>";
+        public const string ThrowWiringError = "<<throw-wiring>>";
+
+        public override string Read(
+            ref Utf8JsonReader reader,
+            Type typeToConvert,
+            JsonSerializerOptions options
+        ) => throw new NotSupportedException();
+
+        public override void Write(
+            Utf8JsonWriter writer,
+            string value,
+            JsonSerializerOptions options
+        )
+        {
+            switch (value)
+            {
+                case ThrowAfterPartialWrite:
+                    // Emit a partial object into the side buffer, THEN throw: proves a partially
+                    // written element is fully discarded, not half-copied into the output.
+                    writer.WriteStartObject();
+                    writer.WriteString("partial", "should-be-discarded");
+                    throw new InvalidOperationException("boom after partial write");
+                case ThrowWiringError:
+                    throw new CommentThreadContextMissingException("no thread");
+                default:
+                    writer.WriteStringValue(value);
+                    break;
+            }
+        }
+    }
+
+    private static string WriteIsolatedArrayToJson(IEnumerable<string> items)
+    {
+        var options = new JsonSerializerOptions();
+        options.Converters.Add(new SentinelStringConverter());
+        var buffer = new ArrayBufferWriter<byte>();
+        using (var writer = new Utf8JsonWriter(buffer))
+        {
+            WriteIsolatedArray(writer, items, options, s => $"item '{s}'");
+            writer.Flush();
+        }
+        return Encoding.UTF8.GetString(buffer.WrittenSpan);
+    }
+
+    [Test]
+    public void WriteIsolatedArray_HealthyItems_WritesAllInOrder()
+    {
+        Assert.That(WriteIsolatedArrayToJson(["a", "b", "c"]), Is.EqualTo("[\"a\",\"b\",\"c\"]"));
+    }
+
+    [Test]
+    public void WriteIsolatedArray_EmptyInput_WritesEmptyArray()
+    {
+        Assert.That(WriteIsolatedArrayToJson([]), Is.EqualTo("[]"));
+    }
+
+    [Test]
+    public void WriteIsolatedArray_OneItemThrowsMidWrite_DropsItAndKeepsSurvivorsInOrder()
+    {
+        // The middle item partially writes then throws; it must be fully discarded (no half-object)
+        // and the survivors kept in their original order.
+        Assert.That(
+            WriteIsolatedArrayToJson(["a", SentinelStringConverter.ThrowAfterPartialWrite, "b"]),
+            Is.EqualTo("[\"a\",\"b\"]")
+        );
+    }
+
+    [Test]
+    public void WriteIsolatedArray_WiringErrorPropagates_NotSwallowedAsDroppedItem()
+    {
+        // A CommentThreadContextMissingException is a programmer/wiring bug, not corrupt data, so it
+        // must surface rather than being silently dropped like a corrupt element.
+        Assert.Throws<CommentThreadContextMissingException>(
+            () => WriteIsolatedArrayToJson(["a", SentinelStringConverter.ThrowWiringError])
+        );
     }
 
     #endregion

--- a/c-sharp-tests/JsonUtils/PlatformCommentConverterTests.cs
+++ b/c-sharp-tests/JsonUtils/PlatformCommentConverterTests.cs
@@ -50,6 +50,97 @@ internal class PlatformCommentConverterTests : PapiTestBase
     }
 
     [Test]
+    public void Serialize_CommentWhoseBodyCannotRender_DegradesToPlaceholderAndKeepsMetadata()
+    {
+        // A wrapper with no thread makes ContentsHtml throw (the documented "Cannot get ContentsHtml
+        // without a valid thread" path) — a deterministic stand-in for any note whose stored content
+        // can't be rendered. In production the throw comes from corrupt content; the isolation is the same.
+        Comment testComment = CommentTestHelper.CreateBasicComment(); // Thread "4217dff8"
+        var wrapper = new PlatformCommentWrapper(testComment, null);
+
+        var json = JsonSerializer.Serialize<PlatformCommentWrapper>(wrapper, _serializationOptions);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.That(
+            doc.RootElement.GetProperty("contents").GetString(),
+            Is.EqualTo("<p>This note could not be displayed.</p>")
+        );
+        // The note is not lost — only its body is degraded; metadata still serializes.
+        Assert.That(doc.RootElement.GetProperty("thread").GetString(), Is.EqualTo("4217dff8"));
+        Assert.That(doc.RootElement.GetProperty("user").GetString(), Is.EqualTo("Tim Steenwyk"));
+        Assert.That(doc.RootElement.GetProperty("verseRef").GetString(), Is.EqualTo("GEN 1:24"));
+    }
+
+    [Test]
+    public void TryRender_WhenAConflictDecodeGetterThrows_ReturnsNullInsteadOfPropagating()
+    {
+        // Layer 1 routes the four conflict-decode getters (RejectedText/AcceptedText/
+        // ResultText/RejectedResultText) through TryRender so one that throws on corrupt content is
+        // omitted (null → field dropped by TryWriteString) rather than aborting the whole note.
+        // Exercised on the helper directly because ParatextData's decoders return empty rather than
+        // throwing on the malformed inputs available to a test, so a real getter throw can't be forced.
+        string? result = "sentinel";
+        Assert.That(
+            () =>
+                result = PlatformCommentConverter.TryRender(
+                    () => throw new InvalidOperationException("decode failed"),
+                    "comment-id",
+                    "acceptedText"
+                ),
+            Throws.Nothing
+        );
+        Assert.That(result, Is.Null);
+
+        // And a getter that succeeds is returned unchanged.
+        Assert.That(
+            PlatformCommentConverter.TryRender(() => "rendered", "comment-id", "acceptedText"),
+            Is.EqualTo("rendered")
+        );
+    }
+
+    [Test]
+    public void IsContentsUnavailablePlaceholder_MatchesExactAndReserializedVariants()
+    {
+        // The byte-exact placeholder is recognized.
+        Assert.That(
+            PlatformCommentConverter.IsContentsUnavailablePlaceholder(
+                PlatformCommentConverter.ContentsUnavailablePlaceholder
+            ),
+            Is.True
+        );
+
+        // Editor-reserialized variants (added attributes, span wrappers, extra whitespace) that
+        // preserve the text are still recognized — this is the hardening over an exact-HTML match,
+        // since the comment editor round-trips saved content through Lexical.
+        Assert.That(
+            PlatformCommentConverter.IsContentsUnavailablePlaceholder(
+                "<p dir=\"ltr\">This note could not be displayed.</p>"
+            ),
+            Is.True
+        );
+        Assert.That(
+            PlatformCommentConverter.IsContentsUnavailablePlaceholder(
+                "<p><span>This note could not be displayed.</span></p>"
+            ),
+            Is.True
+        );
+        Assert.That(
+            PlatformCommentConverter.IsContentsUnavailablePlaceholder(
+                "  <p>This note could not be displayed.</p>  "
+            ),
+            Is.True
+        );
+
+        // Real note content and empty input are not affected.
+        Assert.That(
+            PlatformCommentConverter.IsContentsUnavailablePlaceholder("<p>A real comment.</p>"),
+            Is.False
+        );
+        Assert.That(PlatformCommentConverter.IsContentsUnavailablePlaceholder(null), Is.False);
+        Assert.That(PlatformCommentConverter.IsContentsUnavailablePlaceholder(""), Is.False);
+    }
+
+    [Test]
     public void Serialize_CommentWithBasicFields_CorrectJsonProduced()
     {
         Comment testComment = CommentTestHelper.CreateBasicComment();

--- a/c-sharp-tests/JsonUtils/PlatformCommentConverterTests.cs
+++ b/c-sharp-tests/JsonUtils/PlatformCommentConverterTests.cs
@@ -50,25 +50,49 @@ internal class PlatformCommentConverterTests : PapiTestBase
     }
 
     [Test]
-    public void Serialize_CommentWhoseBodyCannotRender_DegradesToPlaceholderAndKeepsMetadata()
+    public void Serialize_CommentWithoutThread_ThrowsWiringErrorInsteadOfSilentlyDegrading()
     {
-        // A wrapper with no thread makes ContentsHtml throw (the documented "Cannot get ContentsHtml
-        // without a valid thread" path) — a deterministic stand-in for any note whose stored content
-        // can't be rendered. In production the throw comes from corrupt content; the isolation is the same.
+        // A wrapper with no thread is a wiring/programmer bug — a comment serialized in
+        // getCommentThreads always has a thread — not corrupt content. It must surface as a
+        // CommentThreadContextMissingException rather than being masked as a placeholder body, so a
+        // future regression that builds thread-less wrappers fails loudly instead of blanking notes.
         Comment testComment = CommentTestHelper.CreateBasicComment(); // Thread "4217dff8"
         var wrapper = new PlatformCommentWrapper(testComment, null);
 
-        var json = JsonSerializer.Serialize<PlatformCommentWrapper>(wrapper, _serializationOptions);
-
-        using var doc = JsonDocument.Parse(json);
-        Assert.That(
-            doc.RootElement.GetProperty("contents").GetString(),
-            Is.EqualTo("<p>This note could not be displayed.</p>")
+        Assert.Throws<CommentThreadContextMissingException>(
+            () => JsonSerializer.Serialize<PlatformCommentWrapper>(wrapper, _serializationOptions)
         );
-        // The note is not lost — only its body is degraded; metadata still serializes.
-        Assert.That(doc.RootElement.GetProperty("thread").GetString(), Is.EqualTo("4217dff8"));
-        Assert.That(doc.RootElement.GetProperty("user").GetString(), Is.EqualTo("Tim Steenwyk"));
-        Assert.That(doc.RootElement.GetProperty("verseRef").GetString(), Is.EqualTo("GEN 1:24"));
+    }
+
+    [Test]
+    public void TryRenderContents_GenuineRenderFailureDegrades_WiringErrorPropagates()
+    {
+        // A genuine render failure (corrupt content) degrades the body to the placeholder so one
+        // unrenderable note doesn't abort the whole response. Real ParatextData render throws can't
+        // be forced from a test (decoders return empty rather than throwing), so the contract is
+        // proven on the helper directly, mirroring the TryRender conflict-field test below.
+        Assert.That(
+            PlatformCommentConverter.TryRenderContents(
+                () => throw new InvalidOperationException("render failed"),
+                "comment-id"
+            ),
+            Is.EqualTo(PlatformCommentConverter.ContentsUnavailablePlaceholder)
+        );
+
+        // A missing-thread wiring error is NOT masked as a placeholder — it propagates.
+        Assert.Throws<CommentThreadContextMissingException>(
+            () =>
+                PlatformCommentConverter.TryRenderContents(
+                    () => throw new CommentThreadContextMissingException("no thread"),
+                    "comment-id"
+                )
+        );
+
+        // A successful render is returned unchanged.
+        Assert.That(
+            PlatformCommentConverter.TryRenderContents(() => "<p>real body</p>", "comment-id"),
+            Is.EqualTo("<p>real body</p>")
+        );
     }
 
     [Test]
@@ -127,6 +151,15 @@ internal class PlatformCommentConverterTests : PapiTestBase
         Assert.That(
             PlatformCommentConverter.IsContentsUnavailablePlaceholder(
                 "  <p>This note could not be displayed.</p>  "
+            ),
+            Is.True
+        );
+        // HTML-entity variant: a re-serialized &nbsp; between words decodes to the same text. This is
+        // the entity-decode hardening (strip tags, THEN HtmlDecode) over the previous tag-strip-only
+        // normalization, which would have left "&nbsp;" in place and failed to match.
+        Assert.That(
+            PlatformCommentConverter.IsContentsUnavailablePlaceholder(
+                "<p>This&nbsp;note could not be displayed.</p>"
             ),
             Is.True
         );

--- a/c-sharp-tests/JsonUtils/PlatformCommentThreadListConverterTests.cs
+++ b/c-sharp-tests/JsonUtils/PlatformCommentThreadListConverterTests.cs
@@ -30,24 +30,14 @@ internal class PlatformCommentThreadListConverterTests : PapiTestBase
         return new PlatformCommentThreadWrapper(_commentManager.FindThread(comment.Thread));
     }
 
-    /// <summary>A thread wrapper whose serialization always throws (via the virtual Id seam).</summary>
-    private sealed class ThrowingCommentThreadWrapper : PlatformCommentThreadWrapper
-    {
-        public ThrowingCommentThreadWrapper(CommentThread thread)
-            : base(thread) { }
-
-        public override string Id =>
-            throw new InvalidOperationException("simulated thread serialization failure");
-    }
-
     [Test]
     public void Serialize_ListWithOneUnserializableThread_DropsItAndKeepsTheRest()
     {
         PlatformCommentThreadWrapper goodThread = AddThread(CommentTestHelper.CreateBasicComment()); // 4217dff8
-        // A second real, distinct thread, wrapped so its serialization throws.
-        AddThread(CommentTestHelper.CreateConflictComment()); // 5f5ea40f
-        CommentThread realOther = _commentManager.FindThread("5f5ea40f");
-        var badThread = new ThrowingCommentThreadWrapper(realOther);
+        // An empty CommentThread (no comments) is a genuinely unserializable thread: reading its
+        // metadata (e.g. ModifiedDate, which indexes the last comment) throws mid-serialization. This
+        // exercises the real drop-and-discard path with no test-only production seam.
+        var badThread = new PlatformCommentThreadWrapper(new CommentThread { ScrText = _scrText });
 
         var list = new List<PlatformCommentThreadWrapper> { goodThread, badThread };
 
@@ -57,5 +47,34 @@ internal class PlatformCommentThreadListConverterTests : PapiTestBase
         Assert.That(doc.RootElement.ValueKind, Is.EqualTo(JsonValueKind.Array));
         Assert.That(doc.RootElement.GetArrayLength(), Is.EqualTo(1)); // bad thread dropped
         Assert.That(doc.RootElement[0].GetProperty("id").GetString(), Is.EqualTo("4217dff8"));
+    }
+
+    [Test]
+    public void Serialize_HealthyMultiThreadList_KeepsAllThreadsInOriginalOrder()
+    {
+        // Locks in the "byte-identical for a healthy list" claim at the structural level: every
+        // thread present, in the original order, and nothing dropped.
+        PlatformCommentThreadWrapper first = AddThread(CommentTestHelper.CreateBasicComment()); // 4217dff8
+        PlatformCommentThreadWrapper second = AddThread(CommentTestHelper.CreateConflictComment()); // 5f5ea40f
+
+        var list = new List<PlatformCommentThreadWrapper> { first, second };
+
+        var json = JsonSerializer.Serialize(list, _serializationOptions);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.That(doc.RootElement.GetArrayLength(), Is.EqualTo(2));
+        Assert.That(doc.RootElement[0].GetProperty("id").GetString(), Is.EqualTo("4217dff8"));
+        Assert.That(doc.RootElement[1].GetProperty("id").GetString(), Is.EqualTo("5f5ea40f"));
+    }
+
+    [Test]
+    public void Serialize_EmptyList_ProducesEmptyArray()
+    {
+        var json = JsonSerializer.Serialize(
+            new List<PlatformCommentThreadWrapper>(),
+            _serializationOptions
+        );
+
+        Assert.That(json, Is.EqualTo("[]"));
     }
 }

--- a/c-sharp-tests/JsonUtils/PlatformCommentThreadListConverterTests.cs
+++ b/c-sharp-tests/JsonUtils/PlatformCommentThreadListConverterTests.cs
@@ -1,0 +1,61 @@
+using System.Text.Json;
+using Paranext.DataProvider.JsonUtils;
+using Paratext.Data;
+using Paratext.Data.ProjectComments;
+
+namespace TestParanextDataProvider.JsonUtils;
+
+internal class PlatformCommentThreadListConverterTests : PapiTestBase
+{
+    private JsonSerializerOptions _serializationOptions = null!;
+    private ScrText _scrText = null!;
+    private CommentManager _commentManager = null!;
+
+    [SetUp]
+    public override async Task TestSetupAsync()
+    {
+        await base.TestSetupAsync();
+        _serializationOptions = SerializationOptions.CreateSerializationOptions();
+        _scrText = CreateDummyProject();
+        _commentManager = CommentManager.Get(_scrText);
+    }
+
+    [TearDown]
+    public void TearDown() => _scrText?.Dispose();
+
+    private PlatformCommentThreadWrapper AddThread(Comment comment)
+    {
+        _commentManager.AddComment(comment);
+        _commentManager.SaveUser(comment.User, false);
+        return new PlatformCommentThreadWrapper(_commentManager.FindThread(comment.Thread));
+    }
+
+    /// <summary>A thread wrapper whose serialization always throws (via the virtual Id seam).</summary>
+    private sealed class ThrowingCommentThreadWrapper : PlatformCommentThreadWrapper
+    {
+        public ThrowingCommentThreadWrapper(CommentThread thread)
+            : base(thread) { }
+
+        public override string Id =>
+            throw new InvalidOperationException("simulated thread serialization failure");
+    }
+
+    [Test]
+    public void Serialize_ListWithOneUnserializableThread_DropsItAndKeepsTheRest()
+    {
+        PlatformCommentThreadWrapper goodThread = AddThread(CommentTestHelper.CreateBasicComment()); // 4217dff8
+        // A second real, distinct thread, wrapped so its serialization throws.
+        AddThread(CommentTestHelper.CreateConflictComment()); // 5f5ea40f
+        CommentThread realOther = _commentManager.FindThread("5f5ea40f");
+        var badThread = new ThrowingCommentThreadWrapper(realOther);
+
+        var list = new List<PlatformCommentThreadWrapper> { goodThread, badThread };
+
+        var json = JsonSerializer.Serialize(list, _serializationOptions);
+
+        using var doc = JsonDocument.Parse(json);
+        Assert.That(doc.RootElement.ValueKind, Is.EqualTo(JsonValueKind.Array));
+        Assert.That(doc.RootElement.GetArrayLength(), Is.EqualTo(1)); // bad thread dropped
+        Assert.That(doc.RootElement[0].GetProperty("id").GetString(), Is.EqualTo("4217dff8"));
+    }
+}

--- a/c-sharp-tests/Projects/ParatextProjectDataProviderCommentTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderCommentTests.cs
@@ -1063,6 +1063,59 @@ namespace TestParanextDataProvider.Projects
             Assert.That(string.Equals(updatedComment.Thread, threadId), Is.True);
         }
 
+        [Test]
+        public void UpdateComment_WithUnrenderablePlaceholder_IsRejectedAndKeepsRealContent()
+        {
+            // A note whose content can't be rendered is served to the client as the
+            // "could not be displayed" placeholder. If the user opens that degraded note and saves,
+            // the frontend sends the placeholder back here — UpdateComment must reject it so the
+            // note's real (unrenderable but present) content is not silently overwritten.
+            var comment = CommentTestHelper.CreateBasicComment();
+            comment.Thread = null; // set in CreateComment
+            string commentId = _provider.CreateComment(new PlatformCommentWrapper(comment));
+
+            bool result = _provider.UpdateComment(
+                commentId,
+                PlatformCommentConverter.ContentsUnavailablePlaceholder
+            );
+
+            Assert.That(result, Is.False); // rejected — not persisted
+            var storedComment = _provider
+                .GetCommentThreads(new CommentThreadSelector())
+                .Single(t => t.Comments.Any(c => c.Id == commentId))
+                .Comments.Single(c => c.Id == commentId);
+            Assert.That(storedComment.Contents!.InnerText, Does.Contain("Test Comment"));
+            Assert.That(
+                storedComment.Contents.InnerText,
+                Does.Not.Contain("could not be displayed")
+            );
+        }
+
+        [Test]
+        public void UpdateComment_WithReserializedPlaceholder_IsAlsoRejected()
+        {
+            // The comment editor round-trips saved content through Lexical, which can re-serialize the
+            // placeholder with different markup (attributes, span wrappers, whitespace) while
+            // preserving its text. The guard matches on normalized text, so these variants must be
+            // rejected too — otherwise a corrupt note's real content could still be overwritten on an
+            // unedited save.
+            var comment = CommentTestHelper.CreateBasicComment();
+            comment.Thread = null; // set in CreateComment
+            string commentId = _provider.CreateComment(new PlatformCommentWrapper(comment));
+
+            bool result = _provider.UpdateComment(
+                commentId,
+                "<p dir=\"ltr\"><span>This note could not be displayed.</span></p>"
+            );
+
+            Assert.That(result, Is.False); // rejected — not persisted
+            var storedComment = _provider
+                .GetCommentThreads(new CommentThreadSelector())
+                .Single(t => t.Comments.Any(c => c.Id == commentId))
+                .Comments.Single(c => c.Id == commentId);
+            Assert.That(storedComment.Contents!.InnerText, Does.Contain("Test Comment"));
+        }
+
         // Note: The following test is a just a POC to make sure roundtripping works with an update.
         // You are not necessarily supposed to edit conflict comment contents like this in real
         // usage. It is possible; we just didn't look into getting the answer to this question.

--- a/c-sharp-tests/Projects/ParatextProjectDataProviderCommentTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderCommentTests.cs
@@ -309,6 +309,27 @@ namespace TestParanextDataProvider.Projects
         }
 
         [Test]
+        public void CreateComment_WithUnavailableContentPlaceholder_ThrowsInvalidOperationException()
+        {
+            // The "content could not be displayed" placeholder is served for a note whose content
+            // can't be rendered. It must never be storable as a note's real content — otherwise the
+            // note would be created and then permanently un-editable (UpdateComment rejects the same
+            // placeholder). Mirrors the UpdateComment guard.
+            var comment = CreateTestComment(
+                "GEN",
+                1,
+                1,
+                PlatformCommentConverter.ContentsUnavailablePlaceholder
+            );
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => _provider.CreateComment(new PlatformCommentWrapper(comment))
+            );
+
+            Assert.That(ex!.Message, Does.Contain("unavailable-content placeholder"));
+        }
+
+        [Test]
         public void CreateComment_AssignedUserNotAssignable_ThrowsInvalidOperationException()
         {
             // Arrange

--- a/c-sharp/JsonUtils/CommentThreadContextMissingException.cs
+++ b/c-sharp/JsonUtils/CommentThreadContextMissingException.cs
@@ -1,0 +1,15 @@
+namespace Paranext.DataProvider.JsonUtils;
+
+/// <summary>
+/// Thrown when an operation that needs thread context (e.g. rendering
+/// <see cref="PlatformCommentWrapper.ContentsHtml"/>) is attempted on a comment wrapper that has no
+/// thread. A comment serialized in the getCommentThreads response always has a thread, so this
+/// signals a wiring/programmer error rather than corrupt content. The serialization resilience
+/// layers deliberately let it propagate instead of degrading it to a placeholder or dropping the
+/// note, so a wiring regression surfaces loudly rather than silently blanking notes.
+/// </summary>
+public class CommentThreadContextMissingException : InvalidOperationException
+{
+    public CommentThreadContextMissingException(string message)
+        : base(message) { }
+}

--- a/c-sharp/JsonUtils/JsonConverterUtils.cs
+++ b/c-sharp/JsonUtils/JsonConverterUtils.cs
@@ -1,3 +1,4 @@
+using System.Buffers;
 using System.Text.Json;
 using Paratext.Data.ProjectComments;
 using PtxUtils;
@@ -69,8 +70,82 @@ public static class JsonConverterUtils
         if (noteTypeEnum == NoteType.Conflict)
             return PlatformCommentWrapper.Json.Type.CONFLICT;
 
-        return char.ToUpperInvariant(noteTypeEnum.InternalValue[0])
-            + noteTypeEnum.InternalValue[1..];
+        // Guard the index like the sibling ConvertNoteStatusToCommentStatus above: an unknown
+        // NoteType with an empty InternalValue (corrupt/legacy XML) would otherwise throw
+        // IndexOutOfRangeException here and, during getCommentThreads serialization, take down the
+        // whole thread.
+        return noteTypeEnum.InternalValue.Length > 0
+            ? char.ToUpperInvariant(noteTypeEnum.InternalValue[0]) + noteTypeEnum.InternalValue[1..]
+            : PlatformCommentWrapper.Json.Type.NORMAL;
+    }
+
+    /// <summary>
+    /// Serializes <paramref name="items"/> as a JSON array in which a single element that fails to
+    /// serialize is dropped (and logged) instead of aborting the whole array. Each element is
+    /// serialized into a reused side buffer first — <see cref="Utf8JsonWriter"/> is forward-only and
+    /// cannot roll back a partial write, so an element that throws mid-serialization must never reach
+    /// <paramref name="writer"/> — and only elements that serialize cleanly are copied out.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="CommentThreadContextMissingException"/> is a wiring/programmer error, not corrupt
+    /// data, so it is allowed to propagate rather than being swallowed as a dropped element — a
+    /// wiring regression should surface loudly. The side buffer is allocated once and reused across
+    /// all elements (one allocation per array, not per element).
+    /// </remarks>
+    internal static void WriteIsolatedArray<T>(
+        Utf8JsonWriter writer,
+        IEnumerable<T> items,
+        JsonSerializerOptions options,
+        Func<T, string> describe
+    )
+    {
+        writer.WriteStartArray();
+        var buffer = new ArrayBufferWriter<byte>();
+        using var itemWriter = new Utf8JsonWriter(
+            buffer,
+            new JsonWriterOptions { Encoder = options.Encoder, SkipValidation = true }
+        );
+        foreach (T item in items)
+        {
+            buffer.Clear();
+            itemWriter.Reset();
+            try
+            {
+                JsonSerializer.Serialize(itemWriter, item, options);
+                itemWriter.Flush();
+            }
+            catch (CommentThreadContextMissingException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                itemWriter.Reset();
+                Console.WriteLine(
+                    $"WARNING: dropping {SafeDescribe(item, describe)} from serialization; "
+                        + $"it could not be serialized. {e.Message}"
+                );
+                continue;
+            }
+            // The bytes came straight from Utf8JsonWriter above (already valid JSON), so skip
+            // WriteRawValue's redundant re-parse/validation.
+            writer.WriteRawValue(buffer.WrittenSpan, skipInputValidation: true);
+        }
+        writer.WriteEndArray();
+    }
+
+    /// <summary>Describes an item for a log message without throwing, so logging a failed item can't
+    /// itself throw.</summary>
+    private static string SafeDescribe<T>(T item, Func<T, string> describe)
+    {
+        try
+        {
+            return describe(item);
+        }
+        catch
+        {
+            return "<unknown>";
+        }
     }
 
     /// <summary>

--- a/c-sharp/JsonUtils/PlatformCommentConverter.cs
+++ b/c-sharp/JsonUtils/PlatformCommentConverter.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.RegularExpressions;
 using System.Xml;
 using Paratext.Data.ProjectComments;
 using Paratext.Data.Users;
@@ -41,6 +42,37 @@ public class PlatformCommentConverter : JsonConverter<PlatformCommentWrapper>
     private const string USER = "user";
     private const string VERSE = "verse";
     private const string VERSE_REF = "verseRef";
+
+    // Written into a note's body when its stored content can't be rendered, so one
+    // unrenderable note doesn't fail the whole getCommentThreads response. Deliberately a fixed
+    // English literal, NOT localized: this is a stateless JsonConverter with no access to the
+    // localization service or the caller's UI language, and localizing it would mean exposing a
+    // machine-readable "degraded" flag on the wire and rendering the message TS-side — not worth that
+    // coupling for this rare corrupt-note edge case. `internal` so
+    // ParatextProjectDataProvider.UpdateComment can refuse to persist this placeholder back over a
+    // note's real content.
+    internal const string ContentsUnavailablePlaceholder =
+        "<p>This note could not be displayed.</p>";
+
+    /// <summary>
+    /// Whether <paramref name="html"/> is the "content could not be displayed" placeholder
+    /// (see <see cref="ContentsUnavailablePlaceholder"/>). Compares on stripped, whitespace-collapsed
+    /// text rather than exact HTML: the comment editor round-trips saved content through Lexical,
+    /// which can re-serialize the placeholder with different markup (added attributes, span wrappers,
+    /// whitespace) while preserving the text. An exact-HTML match would miss those variants and let
+    /// the placeholder overwrite a note's real content.
+    /// </summary>
+    internal static bool IsContentsUnavailablePlaceholder(string? html) =>
+        NormalizeToComparableText(html)
+        == NormalizeToComparableText(ContentsUnavailablePlaceholder);
+
+    // Strips tags (replacing each with a space so words aren't glued across tag boundaries) and
+    // collapses whitespace. Deliberately a blunt comparison helper for the fixed placeholder above,
+    // not a general-purpose HTML sanitizer.
+    private static string NormalizeToComparableText(string? html) =>
+        html is null
+            ? string.Empty
+            : Regex.Replace(Regex.Replace(html, "<[^>]*>", " "), @"\s+", " ").Trim();
 
     /// <summary>
     /// Deserializes a <see cref="PlatformCommentWrapper"/> from JSON.
@@ -318,35 +350,78 @@ public class PlatformCommentConverter : JsonConverter<PlatformCommentWrapper>
             value.ExtraHeadingInfo.ToString()
         );
         writer.WriteBoolean(HIDE_IN_TEXT_WINDOW, value.HideInTextWindow);
-        writer.WriteString(CONTENTS, value.ContentsHtml);
-        // Conflict-note decode fields (verseText conflicts only; null for all other notes → skipped).
-        JsonConverterUtils.TryWriteString(writer, REJECTED_TEXT, value.RejectedText);
-        JsonConverterUtils.TryWriteString(writer, ACCEPTED_TEXT, value.AcceptedText);
-        JsonConverterUtils.TryWriteString(writer, RESULT_TEXT, value.ResultText);
-        JsonConverterUtils.TryWriteString(writer, REJECTED_RESULT_TEXT, value.RejectedResultText);
-        // MergedText is the only serialized field that runs the live USFM diff engine (GetMergedUsfm
-        // + DiffToken.GetDiffString + XmlDocument.LoadXml). An exception here would abort Write and
-        // drop the ENTIRE getCommentThreads response, not just this field, so contain it: log and
-        // omit the merge preview for the one bad conflict.
-        string? mergedText;
+        // Degrade rather than fail: a note whose stored content can't be rendered must not abort the
+        // whole getCommentThreads response. Body render failure → placeholder.
+        string contents;
         try
         {
-            mergedText = value.MergedText;
+            contents = value.ContentsHtml;
         }
         catch (Exception e)
         {
             Console.WriteLine(
-                $"Failed to compute MergedText for comment '{value.Id}'; omitting the merge preview: {e}"
+                $"WARNING: could not render contents for comment {value.Id}; using placeholder. {e}"
             );
-            mergedText = null;
+            contents = ContentsUnavailablePlaceholder;
         }
-        JsonConverterUtils.TryWriteString(writer, MERGED_TEXT, mergedText);
+        writer.WriteString(CONTENTS, contents);
+        // Conflict-note decode fields (verseText conflicts only; null for all other notes → skipped).
+        // An optional decode field that throws is omitted (same wire shape as null) rather than failing.
+        JsonConverterUtils.TryWriteString(
+            writer,
+            REJECTED_TEXT,
+            TryRender(() => value.RejectedText, value.Id, REJECTED_TEXT)
+        );
+        JsonConverterUtils.TryWriteString(
+            writer,
+            ACCEPTED_TEXT,
+            TryRender(() => value.AcceptedText, value.Id, ACCEPTED_TEXT)
+        );
+        JsonConverterUtils.TryWriteString(
+            writer,
+            RESULT_TEXT,
+            TryRender(() => value.ResultText, value.Id, RESULT_TEXT)
+        );
+        JsonConverterUtils.TryWriteString(
+            writer,
+            REJECTED_RESULT_TEXT,
+            TryRender(() => value.RejectedResultText, value.Id, REJECTED_RESULT_TEXT)
+        );
+        // MergedText runs the live USFM diff engine (GetMergedUsfm + DiffToken.GetDiffString), so
+        // route it through the same per-field isolation as the other decode getters.
+        JsonConverterUtils.TryWriteString(
+            writer,
+            MERGED_TEXT,
+            TryRender(() => value.MergedText, value.Id, MERGED_TEXT)
+        );
         JsonConverterUtils.TryWriteString(writer, BIBLICAL_TERM_ID, value.BiblicalTermId);
         if (value.TagsAdded != null)
             JsonConverterUtils.TryWriteString(writer, TAG_ADDED, TryJoin(",", value.TagsAdded));
         if (value.TagsRemoved != null)
             JsonConverterUtils.TryWriteString(writer, TAG_REMOVED, TryJoin(",", value.TagsRemoved));
         writer.WriteEndObject();
+    }
+
+    /// <summary>
+    /// Reads an optional rendered field, logging and returning null instead of throwing so one
+    /// unrenderable field can't abort serialization of the whole note.
+    /// </summary>
+    // `internal` for direct unit testing of the catch contract: reliably forcing the underlying
+    // ParatextData conflict-decode getters to throw on demand isn't readily available (they return
+    // empty rather than throwing on malformed input), so the isolation is verified on the helper.
+    internal static string? TryRender(Func<string?> get, string commentId, string field)
+    {
+        try
+        {
+            return get();
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(
+                $"WARNING: could not render {field} for comment {commentId}; omitting it. {e}"
+            );
+            return null;
+        }
     }
 
     private static string? TryJoin(string? separator, string[] stringArray)

--- a/c-sharp/JsonUtils/PlatformCommentConverter.cs
+++ b/c-sharp/JsonUtils/PlatformCommentConverter.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
@@ -54,25 +55,37 @@ public class PlatformCommentConverter : JsonConverter<PlatformCommentWrapper>
     internal const string ContentsUnavailablePlaceholder =
         "<p>This note could not be displayed.</p>";
 
+    private static readonly Regex CollapseWhitespaceRegex = new(@"\s+", RegexOptions.Compiled);
+
+    // The placeholder normalized once (not on every UpdateComment). Declared after the regex it
+    // depends on so static field initialization order is correct.
+    private static readonly string NormalizedPlaceholder = NormalizeToComparableText(
+        ContentsUnavailablePlaceholder
+    );
+
     /// <summary>
     /// Whether <paramref name="html"/> is the "content could not be displayed" placeholder
     /// (see <see cref="ContentsUnavailablePlaceholder"/>). Compares on stripped, whitespace-collapsed
     /// text rather than exact HTML: the comment editor round-trips saved content through Lexical,
     /// which can re-serialize the placeholder with different markup (added attributes, span wrappers,
-    /// whitespace) while preserving the text. An exact-HTML match would miss those variants and let
-    /// the placeholder overwrite a note's real content.
+    /// whitespace, HTML entities) while preserving the text. An exact-HTML match would miss those
+    /// variants and let the placeholder overwrite a note's real content.
     /// </summary>
     internal static bool IsContentsUnavailablePlaceholder(string? html) =>
-        NormalizeToComparableText(html)
-        == NormalizeToComparableText(ContentsUnavailablePlaceholder);
+        NormalizeToComparableText(html) == NormalizedPlaceholder;
 
-    // Strips tags (replacing each with a space so words aren't glued across tag boundaries) and
-    // collapses whitespace. Deliberately a blunt comparison helper for the fixed placeholder above,
-    // not a general-purpose HTML sanitizer.
+    // Strips tags with the codebase's canonical PasteUtils.RemoveHtmlTags, then decodes HTML entities
+    // (so a re-serialized "&nbsp;"/"&#39;" variant still compares equal), then collapses whitespace.
+    // Order matters: strip before decode — decoding first could turn "&lt;p&gt;" into "<p>", which the
+    // stripper would then eat, changing the compared text. Deliberately a blunt comparison helper for
+    // the fixed placeholder above, not a general-purpose HTML sanitizer (a "&gt;" inside an attribute
+    // value is not handled — acceptable for the fixed, attribute-free placeholder).
     private static string NormalizeToComparableText(string? html) =>
         html is null
             ? string.Empty
-            : Regex.Replace(Regex.Replace(html, "<[^>]*>", " "), @"\s+", " ").Trim();
+            : CollapseWhitespaceRegex
+                .Replace(WebUtility.HtmlDecode(PasteUtils.RemoveHtmlTags(html)), " ")
+                .Trim();
 
     /// <summary>
     /// Deserializes a <see cref="PlatformCommentWrapper"/> from JSON.
@@ -352,48 +365,44 @@ public class PlatformCommentConverter : JsonConverter<PlatformCommentWrapper>
         writer.WriteBoolean(HIDE_IN_TEXT_WINDOW, value.HideInTextWindow);
         // Degrade rather than fail: a note whose stored content can't be rendered must not abort the
         // whole getCommentThreads response. Body render failure → placeholder.
-        string contents;
-        try
-        {
-            contents = value.ContentsHtml;
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine(
-                $"WARNING: could not render contents for comment {value.Id}; using placeholder. {e}"
-            );
-            contents = ContentsUnavailablePlaceholder;
-        }
+        string contents = TryRenderContents(() => value.ContentsHtml, value.Id);
+        bool bodyDegraded = contents == ContentsUnavailablePlaceholder;
         writer.WriteString(CONTENTS, contents);
-        // Conflict-note decode fields (verseText conflicts only; null for all other notes → skipped).
-        // An optional decode field that throws is omitted (same wire shape as null) rather than failing.
-        JsonConverterUtils.TryWriteString(
-            writer,
-            REJECTED_TEXT,
-            TryRender(() => value.RejectedText, value.Id, REJECTED_TEXT)
-        );
-        JsonConverterUtils.TryWriteString(
-            writer,
-            ACCEPTED_TEXT,
-            TryRender(() => value.AcceptedText, value.Id, ACCEPTED_TEXT)
-        );
-        JsonConverterUtils.TryWriteString(
-            writer,
-            RESULT_TEXT,
-            TryRender(() => value.ResultText, value.Id, RESULT_TEXT)
-        );
-        JsonConverterUtils.TryWriteString(
-            writer,
-            REJECTED_RESULT_TEXT,
-            TryRender(() => value.RejectedResultText, value.Id, REJECTED_RESULT_TEXT)
-        );
-        // MergedText runs the live USFM diff engine (GetMergedUsfm + DiffToken.GetDiffString), so
-        // route it through the same per-field isolation as the other decode getters.
-        JsonConverterUtils.TryWriteString(
-            writer,
-            MERGED_TEXT,
-            TryRender(() => value.MergedText, value.Id, MERGED_TEXT)
-        );
+        // Conflict-note decode fields (verseText conflicts only). Gated on Type == Conflict so the
+        // common non-conflict note allocates none of the closures below. Also skipped when the body
+        // itself degraded, so a "could not be displayed" note never ships a placeholder body
+        // alongside populated conflict data. An optional decode field that throws is omitted (same
+        // wire shape as null) rather than failing.
+        if (!bodyDegraded && value.Type == NoteType.Conflict)
+        {
+            JsonConverterUtils.TryWriteString(
+                writer,
+                REJECTED_TEXT,
+                TryRender(() => value.RejectedText, value.Id, REJECTED_TEXT)
+            );
+            JsonConverterUtils.TryWriteString(
+                writer,
+                ACCEPTED_TEXT,
+                TryRender(() => value.AcceptedText, value.Id, ACCEPTED_TEXT)
+            );
+            JsonConverterUtils.TryWriteString(
+                writer,
+                RESULT_TEXT,
+                TryRender(() => value.ResultText, value.Id, RESULT_TEXT)
+            );
+            JsonConverterUtils.TryWriteString(
+                writer,
+                REJECTED_RESULT_TEXT,
+                TryRender(() => value.RejectedResultText, value.Id, REJECTED_RESULT_TEXT)
+            );
+            // MergedText runs the live USFM diff engine (GetMergedUsfm + DiffToken.GetDiffString), so
+            // route it through the same per-field isolation as the other decode getters.
+            JsonConverterUtils.TryWriteString(
+                writer,
+                MERGED_TEXT,
+                TryRender(() => value.MergedText, value.Id, MERGED_TEXT)
+            );
+        }
         JsonConverterUtils.TryWriteString(writer, BIBLICAL_TERM_ID, value.BiblicalTermId);
         if (value.TagsAdded != null)
             JsonConverterUtils.TryWriteString(writer, TAG_ADDED, TryJoin(",", value.TagsAdded));
@@ -418,9 +427,35 @@ public class PlatformCommentConverter : JsonConverter<PlatformCommentWrapper>
         catch (Exception e)
         {
             Console.WriteLine(
-                $"WARNING: could not render {field} for comment {commentId}; omitting it. {e}"
+                $"WARNING: could not render {field} for comment {commentId}; omitting it. {e.Message}"
             );
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Renders a note's body, degrading to <see cref="ContentsUnavailablePlaceholder"/> if the stored
+    /// content can't be rendered so one unrenderable note doesn't abort the whole getCommentThreads
+    /// response. A <see cref="CommentThreadContextMissingException"/> is a wiring error, not corrupt
+    /// content, so it is rethrown rather than masked as a placeholder — a comment without a thread is
+    /// a programmer bug that should surface, not silently blank every note.
+    /// </summary>
+    internal static string TryRenderContents(Func<string> renderContents, string commentId)
+    {
+        try
+        {
+            return renderContents();
+        }
+        catch (CommentThreadContextMissingException)
+        {
+            throw;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine(
+                $"WARNING: could not render contents for comment {commentId}; using placeholder. {e.Message}"
+            );
+            return ContentsUnavailablePlaceholder;
         }
     }
 

--- a/c-sharp/JsonUtils/PlatformCommentThreadConverter.cs
+++ b/c-sharp/JsonUtils/PlatformCommentThreadConverter.cs
@@ -45,9 +45,16 @@ public class PlatformCommentThreadConverter : JsonConverter<PlatformCommentThrea
         // Thread ID
         writer.WriteString(ID, value.Id);
 
-        // All comments in the thread
+        // All comments in the thread. Isolated per-comment: a single comment that can't be
+        // serialized is dropped (and logged) rather than taking down the whole thread of otherwise
+        // healthy comments.
         writer.WritePropertyName(COMMENTS);
-        JsonSerializer.Serialize(writer, value.Comments, options);
+        JsonConverterUtils.WriteIsolatedArray(
+            writer,
+            value.Comments,
+            options,
+            comment => $"comment {comment.Id}"
+        );
 
         // Status and Type - convert NoteStatus to CommentStatus for frontend
         string threadStatus = JsonConverterUtils.ConvertNoteStatusToCommentStatus(value.Status);

--- a/c-sharp/JsonUtils/PlatformCommentThreadListConverter.cs
+++ b/c-sharp/JsonUtils/PlatformCommentThreadListConverter.cs
@@ -1,0 +1,66 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Paranext.DataProvider.JsonUtils;
+
+/// <summary>
+/// Serializes the getCommentThreads response so a single thread that cannot be serialized does not
+/// abort the whole response. Each thread is serialized into its own buffer; only threads
+/// that serialize successfully are written to the output. A thread that throws is dropped and logged.
+/// </summary>
+public class PlatformCommentThreadListConverter : JsonConverter<List<PlatformCommentThreadWrapper>>
+{
+    public override List<PlatformCommentThreadWrapper> Read(
+        ref Utf8JsonReader reader,
+        Type typeToConvert,
+        JsonSerializerOptions options
+    ) =>
+        throw new NotSupportedException(
+            "Reading List<PlatformCommentThreadWrapper> from JSON is not supported."
+        );
+
+    public override void Write(
+        Utf8JsonWriter writer,
+        List<PlatformCommentThreadWrapper> value,
+        JsonSerializerOptions options
+    )
+    {
+        writer.WriteStartArray();
+        foreach (var thread in value)
+        {
+            byte[] bytes;
+            try
+            {
+                // Serialize into a separate buffer first: Utf8JsonWriter is forward-only and cannot
+                // roll back a partial write, so a thread that throws mid-serialization must never
+                // reach the output stream.
+                bytes = JsonSerializer.SerializeToUtf8Bytes(thread, options);
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine(
+                    $"WARNING: dropping comment thread {SafeId(thread)} from getCommentThreads; "
+                        + $"it could not be serialized. {e}"
+                );
+                continue;
+            }
+            // The bytes came straight from JsonSerializer.SerializeToUtf8Bytes above (already valid
+            // JSON), so skip WriteRawValue's redundant re-parse/validation on this hot path.
+            writer.WriteRawValue(bytes, skipInputValidation: true);
+        }
+        writer.WriteEndArray();
+    }
+
+    /// <summary>Reads the thread id without throwing, so logging a failed thread can't itself throw.</summary>
+    private static string SafeId(PlatformCommentThreadWrapper thread)
+    {
+        try
+        {
+            return thread.Id;
+        }
+        catch
+        {
+            return "<unknown>";
+        }
+    }
+}

--- a/c-sharp/JsonUtils/PlatformCommentThreadListConverter.cs
+++ b/c-sharp/JsonUtils/PlatformCommentThreadListConverter.cs
@@ -23,44 +23,11 @@ public class PlatformCommentThreadListConverter : JsonConverter<List<PlatformCom
         Utf8JsonWriter writer,
         List<PlatformCommentThreadWrapper> value,
         JsonSerializerOptions options
-    )
-    {
-        writer.WriteStartArray();
-        foreach (var thread in value)
-        {
-            byte[] bytes;
-            try
-            {
-                // Serialize into a separate buffer first: Utf8JsonWriter is forward-only and cannot
-                // roll back a partial write, so a thread that throws mid-serialization must never
-                // reach the output stream.
-                bytes = JsonSerializer.SerializeToUtf8Bytes(thread, options);
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine(
-                    $"WARNING: dropping comment thread {SafeId(thread)} from getCommentThreads; "
-                        + $"it could not be serialized. {e}"
-                );
-                continue;
-            }
-            // The bytes came straight from JsonSerializer.SerializeToUtf8Bytes above (already valid
-            // JSON), so skip WriteRawValue's redundant re-parse/validation on this hot path.
-            writer.WriteRawValue(bytes, skipInputValidation: true);
-        }
-        writer.WriteEndArray();
-    }
-
-    /// <summary>Reads the thread id without throwing, so logging a failed thread can't itself throw.</summary>
-    private static string SafeId(PlatformCommentThreadWrapper thread)
-    {
-        try
-        {
-            return thread.Id;
-        }
-        catch
-        {
-            return "<unknown>";
-        }
-    }
+    ) =>
+        JsonConverterUtils.WriteIsolatedArray(
+            writer,
+            value,
+            options,
+            thread => $"comment thread {thread.Id}"
+        );
 }

--- a/c-sharp/JsonUtils/PlatformCommentThreadWrapper.cs
+++ b/c-sharp/JsonUtils/PlatformCommentThreadWrapper.cs
@@ -33,7 +33,9 @@ public class PlatformCommentThreadWrapper
         _thread = thread;
     }
 
-    public string Id => _thread.Id;
+    // `Id` is virtual only so a test can subclass with a throwing override to exercise the per-thread
+    // serialization backstop (PlatformCommentThreadListConverter). No production subclass exists.
+    public virtual string Id => _thread.Id;
 
     /// <summary>
     /// Gets all comments in this thread, including any comments merged from duplicate threads

--- a/c-sharp/JsonUtils/PlatformCommentThreadWrapper.cs
+++ b/c-sharp/JsonUtils/PlatformCommentThreadWrapper.cs
@@ -33,9 +33,7 @@ public class PlatformCommentThreadWrapper
         _thread = thread;
     }
 
-    // `Id` is virtual only so a test can subclass with a throwing override to exercise the per-thread
-    // serialization backstop (PlatformCommentThreadListConverter). No production subclass exists.
-    public virtual string Id => _thread.Id;
+    public string Id => _thread.Id;
 
     /// <summary>
     /// Gets all comments in this thread, including any comments merged from duplicate threads

--- a/c-sharp/JsonUtils/PlatformCommentWrapper.cs
+++ b/c-sharp/JsonUtils/PlatformCommentWrapper.cs
@@ -182,7 +182,7 @@ public class PlatformCommentWrapper
     {
         get =>
             _thread?.ThreadInternal == null
-                ? throw new InvalidOperationException(
+                ? throw new CommentThreadContextMissingException(
                     "Cannot get ContentsHtml without a valid thread."
                 )
                 : _comment.GetContentsAsHtml(

--- a/c-sharp/JsonUtils/SerializationOptions.cs
+++ b/c-sharp/JsonUtils/SerializationOptions.cs
@@ -25,6 +25,8 @@ internal static class SerializationOptions
         options.Converters.Add(new CommentThreadSelectorConverter());
         options.Converters.Add(new PlatformCommentConverter());
         options.Converters.Add(new PlatformCommentThreadConverter());
+        // Isolates per-thread serialization failures in the getCommentThreads response.
+        options.Converters.Add(new PlatformCommentThreadListConverter());
         options.Converters.Add(new ConcurrentHashSetConverter<string>());
         options.Converters.Add(new InternetSettingsMementoConverter());
         options.Converters.Add(new InventoryOptionValueConverter());

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -510,6 +510,15 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     {
         VerifyUserCanCreateComments();
 
+        // Never let the "content could not be displayed" placeholder become a note's real content.
+        // A degraded note is served with PlatformCommentConverter.ContentsUnavailablePlaceholder;
+        // planting that text here would create a note that UpdateComment then permanently refuses to
+        // edit (it rejects the same placeholder). Mirrors the guard in UpdateComment.
+        if (PlatformCommentConverter.IsContentsUnavailablePlaceholder(comment.Contents?.OuterXml))
+            throw new InvalidOperationException(
+                "Cannot create a comment whose content is the unavailable-content placeholder."
+            );
+
         if (comment.SelectedText != null && comment.SelectedText.Contains('\\'))
         {
             throw new InvalidOperationException(

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1058,6 +1058,15 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             if (string.IsNullOrEmpty(commentId))
                 return false;
 
+            // Never persist the "content could not be displayed" placeholder back over a note's
+            // real stored content. A note whose content can't be rendered is served to the client as
+            // PlatformCommentConverter.ContentsUnavailablePlaceholder; if the user opens that degraded
+            // note and saves, the frontend sends the placeholder here, which would silently overwrite
+            // the (unrenderable but present) original. Matched on normalized text rather than exact
+            // HTML because the editor may re-serialize the placeholder markup on save. Reject that.
+            if (PlatformCommentConverter.IsContentsUnavailablePlaceholder(updatedContentHtml))
+                return false;
+
             // Find the comment by ID and its parent thread
             var (commentToUpdate, parentThread) = FindCommentByIdWithThread(commentId);
             if (commentToUpdate == null || parentThread == null)

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -260,8 +260,13 @@ global.webViewComponent = function CommentListWebView({
     async (commentId: string, contents: string): Promise<boolean> =>
       withPdp(commentsPdp, 'handleUpdateComment', false, async (pdp) => {
         try {
-          await pdp.updateComment(commentId, contents);
-          return true;
+          // `false` means the update was rejected (comment not found, or its content normalizes to
+          // the "content unavailable" placeholder, which is never persisted over real content).
+          // Surface it so the editor stays open instead of closing as if the edit had saved.
+          const updateSucceeded = (await pdp.updateComment(commentId, contents)) !== false;
+          if (!updateSucceeded)
+            logger.warn(`Update of comment ${commentId} was rejected and not saved.`);
+          return updateSucceeded;
         } catch (error) {
           logger.error(`Failed to update comment ${commentId}:`, error);
           return false;

--- a/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
+++ b/extensions/src/legacy-comment-manager/src/types/legacy-comment-manager.d.ts
@@ -374,7 +374,9 @@ declare module 'legacy-comment-manager' {
        * @param commentId The unique ID of the comment to update
        * @param updatedContent The new text content for the comment
        * @returns Promise that resolves to update instructions indicating which data types were
-       *   affected, or `false` if the comment was not found
+       *   affected, or `false` if the update was rejected — either the comment was not found, or
+       *   `updatedContent` normalizes to the "content unavailable" placeholder, which is never
+       *   persisted over a note's real content
        * @throws If an error occurs during the update, or if the comment is not owned by the current
        *   user
        */


### PR DESCRIPTION
## What

Make `getCommentThreads` resilient so **one un-renderable note can no longer fail the whole response**. Today serialization is all-or-nothing: `PlatformCommentThreadConverter` renders every comment of every thread in one pass, and a single note whose stored content can't be rendered (`ContentsHtml` → `GetContentsAsHtml`, or a conflict-decode getter) throws — which aborts the entire RPC. The comment-list web view maps that error to "no comments" (`isPlatformError → []`), so **one bad note silently blanks the whole comments panel**, hiding every valid note.

## Fix — two layers (backend/C# only)

1. **Degrade the note body** (`PlatformCommentConverter.Write`): the render getters are guarded. A body-render throw → a fixed placeholder `<p>This note could not be displayed.</p>` in `contents`; a conflict-decode getter throw → that optional field is omitted (same wire shape as `null`). **All other metadata (author, date, status, verse ref) still serializes** — the note stays visible, just with an unavailable body. Logged.
2. **Isolate per-thread** (new `PlatformCommentThreadListConverter`, registered in `SerializationOptions`): each thread is serialized into its own buffer and only written to the response on success (`Utf8JsonWriter` is forward-only — no rollback — so a thread that throws for any reason Layer 1 didn't handle is dropped, not left half-written). Logged.

Net: the response **always returns a valid array** — at worst thread-reduced and/or body-degraded — for any single corrupt note or thread.

## No frontend change

The placeholder is fixed English HTML emitted straight into `contents`, which the frontend already renders. No new wire field, no localization, no TypeScript change (a localized/flagged variant was considered and deliberately rejected as not worth the coupling for a rare edge case).

## Testing

- **Layer 1** proven deterministically: `new PlatformCommentWrapper(comment, null)` makes `ContentsHtml` throw (its documented no-thread path) — asserts the placeholder is emitted and the metadata survives. RED confirmed first.
- **Layer 2** proven via a one-line `virtual Id` test seam + a throwing test subclass: a list of `[good thread, throwing thread]` serializes to a valid array with the good thread kept and the bad one dropped. RED confirmed first.
- Full C# suite green (1343 passed, 6 skipped); `dotnet csharpier` clean; no regression to healthy-note serialization (byte-identical output).

## Review

Built via subagent-driven development (RED-first per task, task review after each, final whole-branch review). Final review: escape analysis confirmed a single bad note/thread cannot fail `getCommentThreads`; merge-ready, clean.

AI-assisted — [session](https://claude.ai/code/session_01AzT8SMKLTiNFJJ6Rjwg6LC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2524)
<!-- Reviewable:end -->



---

<!-- review-paratext:summary:start -->
## Code Review Summary

**Branch**: `pt-4110-isolate-note-serialization`
**Base**: `origin/main`
**Date**: 2026-07-09
**Review model**: Claude Opus 4.8 (1M context)
**Files changed**: 8 (5 under `c-sharp/`, 3 under `c-sharp-tests/`)

_Review run: `/review-paratext` (api, style, compliance passes; ux auto-skipped — no UI) combined with a high-effort `/code-review` workflow (17 agents, finder + adversarial verify). Findings below are the de-duplicated union. The code was authored in the same AI session, so "author" notes reflect design rationale captured during implementation — a human reviewer should still confirm the correctness-sensitive items._

## Overview

Makes `getCommentThreads` resilient so a single un-renderable note can no longer fail the whole response. Today one note whose stored content can't be rendered throws during JSON serialization, aborting the RPC — which the comment-list web view maps to "no comments", blanking the entire panel. Two C# serialization layers fix this: (1) `PlatformCommentConverter.Write` degrades an unrenderable note body to a fixed placeholder and omits a failed conflict-decode field while keeping all other metadata; (2) a new `PlatformCommentThreadListConverter` serializes each thread into its own buffer and drops (with a log) any thread that still throws. A one-line `virtual Id` test seam was added. Post-review, a guard was added so the placeholder can't be persisted back over a note's real content.

## API Changes

None. C#/.NET only; no TypeScript public-API surface change (`getCommentThreads`'s wire shape — `contents: string`, already-optional conflict fields — is unchanged).

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **Data-loss round-trip: the editable placeholder could overwrite a note's real content.** _(fixed during review: `UpdateComment` now rejects an update whose contents equal `PlatformCommentConverter.ContentsUnavailablePlaceholder`, so editing+saving a degraded note can't clobber the original; test added)_
- [x] **No test for the conflict-decode degrade path (`TryRender`).** _(fixed during review: `TryRender` made `internal` and unit-tested directly — a real conflict-getter throw couldn't be reliably forced, as ParatextData decoders return empty rather than throw on malformed input)_
- [ ] ~~**Unlocalized English placeholder violates the mandatory C# backend-localization guideline.**~~ _(author decision: deliberately not localized — the stateless converter has no `PapiClient`/locale access, and localizing would require a machine-readable "degraded" wire flag + TS-side rendering, not worth it for this rare corrupt-note edge case; rationale documented in a code comment)_

### Minor — Consider

- [ ] ~~**Silent thread-drop gives no user-visible signal (a dropped thread is invisible).**~~ _(author: accepted as a conscious tradeoff — still strictly better than today's whole-panel blank; a "N notes hidden" count is a genuine cross-cutting C#+TS+UI feature, deferred to a separate follow-up)_
- [ ] ~~**Partial conflict payload could mislead conflict resolution.**~~ _(author: accepted — rare, and better than the whole note failing)_
- [ ] ~~**A systemic render failure is masked as per-note placeholders.**~~ _(author: accepted — the WARNING logs are the signal)_
- [x] **`WriteRawValue` redundantly re-validates JSON it just produced.** _(fixed during review: `skipInputValidation: true`)_
- [ ] ~~**`TryRender`/`SafeId` helper similarity; per-call `Func` closure allocation; missing all-threads-fail edge test.**~~ _(reviewer-flagged awareness-only; left as-is)_

## Positive Observations

- Isolation is scoped precisely to where failures originate: only the five render-derived getters are guarded; the ~20 plain pass-through fields are left unguarded and covered by the per-thread backstop.
- Buffer-then-`WriteRawValue` is the correct and necessary technique for rollback-safety on the forward-only `Utf8JsonWriter` — verified as not over-engineering.
- The new list converter mirrors the existing `JsonConverter<T>` registration pattern; the `virtual Id` seam has clear precedent in the codebase and is documented.
- RED-first tests for both layers; the Layer-1 test triggers the real production throw path; the full C# suite runs green (1345 passed).
- Converter registered against the exact `List<PlatformCommentThreadWrapper>` return type of `GetCommentThreads` — resolution verified, no collision with other registered converters.

## In-Review Quality Check

Fixes applied during review: the data-loss guard, `skipInputValidation`, the localization rationale comment, and two tests. Full C# suite green afterward — **1345 passed, 6 skipped, 0 failed** (`dotnet test c-sharp-tests/`); `dotnet csharpier` clean. No TypeScript/frontend changes.

## Suggested Review Focus

- [ ] **Data-loss guard** — confirm the exact-string placeholder match is sufficient; the common unedited-save case is covered, but a frontend that reserializes the placeholder HTML could bypass it.
- [ ] **Accepted degrade tradeoffs** — explicit sign-off that silent thread-drop, partial conflict payloads, and systemic-failure masking are acceptable vs. today's blank-panel behavior.
- [ ] **Localization deviation** — sign-off that the hardcoded placeholder is acceptable for this edge case.
- [ ] **Follow-up** — a "N notes couldn't be shown" UI signal (separate ticket): decide if/when.
<!-- review-paratext:summary:end -->
