### PR TITLE
PT-3558: Fix scripture editor scrolling by BCV

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,7 +416,10 @@ All `test:e2e:*` scripts are there for running variations of the playwright end-
 
 - `test:e2e:smoke` runs a single instance of the application, and all tests share that instance
 - `test:e2e:smoke-wsl` runs the same smoke tests using a "hidden UI" on Linux instead of a visible UI
-- `test:e2e:isolated` runs tests that require a separate application instance for each test
+- `test:e2e:isolated` runs tests that require a separate application instance for each test. These
+  tests are organized into feature subsets under `e2e-tests/tests/isolated/`; run
+  `npm run test:e2e:isolated all` for every test, `npm run test:e2e:isolated <subset>` for one
+  feature, or pass no arguments to list the available subsets (no tests are run in that case)
 - `test:e2e-cdp` runs tests that require the application UI to be open already
 - `test:e2e:all` runs all configured tests
 

--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -62,12 +62,20 @@ internal class LocalParatextProjects
 
     public LocalParatextProjects()
     {
-        ProjectRootFolder = Path.Join(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".platform.bible",
-            "projects",
-            "Paratext 9 Projects"
+        // E2E tests (and other tooling) can point the app at an isolated projects folder so runs
+        // don't touch the user's real projects; Initialize() installs the bundled sample WEB
+        // project into an empty root. See e2e-tests/fixtures/helpers.ts (isolatedProjectRoot).
+        string? projectRootOverride = Environment.GetEnvironmentVariable(
+            "PLATFORM_BIBLE_PROJECT_ROOT_FOLDER"
         );
+        ProjectRootFolder = !string.IsNullOrWhiteSpace(projectRootOverride)
+            ? projectRootOverride
+            : Path.Join(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".platform.bible",
+                "projects",
+                "Paratext 9 Projects"
+            );
     }
 
     #endregion

--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -68,18 +68,22 @@ internal class LocalParatextProjects
         string? projectRootOverride = Environment.GetEnvironmentVariable(
             "PLATFORM_BIBLE_PROJECT_ROOT_FOLDER"
         );
-        if (!string.IsNullOrWhiteSpace(projectRootOverride))
-            Console.WriteLine(
-                $"PLATFORM_BIBLE_PROJECT_ROOT_FOLDER is set; overriding project root folder to: {projectRootOverride}"
-            );
-        ProjectRootFolder = !string.IsNullOrWhiteSpace(projectRootOverride)
-            ? projectRootOverride
-            : Path.Join(
+        if (string.IsNullOrWhiteSpace(projectRootOverride))
+        {
+            ProjectRootFolder = Path.Join(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                 ".platform.bible",
                 "projects",
                 "Paratext 9 Projects"
             );
+        }
+        else
+        {
+            Console.WriteLine(
+                $"PLATFORM_BIBLE_PROJECT_ROOT_FOLDER is set; overriding project root folder to: {projectRootOverride}"
+            );
+            ProjectRootFolder = projectRootOverride;
+        }
     }
 
     #endregion

--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -68,6 +68,10 @@ internal class LocalParatextProjects
         string? projectRootOverride = Environment.GetEnvironmentVariable(
             "PLATFORM_BIBLE_PROJECT_ROOT_FOLDER"
         );
+        if (!string.IsNullOrWhiteSpace(projectRootOverride))
+            Console.WriteLine(
+                $"PLATFORM_BIBLE_PROJECT_ROOT_FOLDER is set; overriding project root folder to: {projectRootOverride}"
+            );
         ProjectRootFolder = !string.IsNullOrWhiteSpace(projectRootOverride)
             ? projectRootOverride
             : Path.Join(

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -90,6 +90,13 @@ export interface LaunchElectronAppOptions {
    * defaults. Keys present here override the defaults (e.g. `{ DEV_NOISY: 'false' }`).
    */
   envOverrides?: Record<string, string>;
+  /**
+   * When true, point the app's Paratext project root at an empty temp folder inside the isolated
+   * user-data dir (via the PLATFORM_BIBLE_PROJECT_ROOT_FOLDER env var). The C# backend installs the
+   * bundled sample WEB project into an empty root, so tests get an identical project on any
+   * developer's machine and never read or write the developer's real projects.
+   */
+  isolatedProjectRoot?: boolean;
 }
 
 /**
@@ -102,6 +109,10 @@ export async function launchElectronApp(
   const rootDir = path.resolve(__dirname, '../..');
 
   console.log(`Launching Electron app from project root: ${rootDir}`);
+
+  // Use an isolated user-data directory so the singleton instance lock does not
+  // conflict with any already-running Platform.Bible instance.
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'paranext-e2e-'));
 
   // VSCode/Claude Code set ELECTRON_RUN_AS_NODE=1 which forces the Electron
   // binary to run as plain Node.js. We must omit it (do not set it to undefined:
@@ -116,13 +127,13 @@ export async function launchElectronApp(
     // Enable noisy dev mode so test extensions (helloRock3, helloSomeone, etc.) are loaded.
     // Only set if not already defined, so other E2E suites can override.
     DEV_NOISY: process.env.DEV_NOISY ?? 'true',
+    // Placing the project root inside userDataDir means the existing teardown rmSync cleans it up.
+    ...(opts.isolatedProjectRoot
+      ? { PLATFORM_BIBLE_PROJECT_ROOT_FOLDER: path.join(userDataDir, 'projects') }
+      : {}),
     // Caller-supplied overrides take precedence over all defaults above.
     ...opts.envOverrides,
   };
-
-  // Use an isolated user-data directory so the singleton instance lock does not
-  // conflict with any already-running Platform.Bible instance.
-  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'paranext-e2e-'));
 
   let electronApp: ElectronApplication;
   try {

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -119,8 +119,11 @@ export async function launchElectronApp(
   // Playwright's env type is Record<string, string>).
   // NODE_ENV=development so the renderer loads from the webpack dev server.
   // Omit ELECTRON_RUN_AS_NODE so the Electron child does not inherit it.
+  // Also strip PLATFORM_BIBLE_PROJECT_ROOT_FOLDER: the C# backend honors it, so an ambient value
+  // from the dev/CI shell would silently redirect the project root of suites that did not opt into
+  // isolatedProjectRoot. Only the isolatedProjectRoot branch (or an explicit envOverride) below sets it.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { ELECTRON_RUN_AS_NODE, ...restEnv } = process.env;
+  const { ELECTRON_RUN_AS_NODE, PLATFORM_BIBLE_PROJECT_ROOT_FOLDER, ...restEnv } = process.env;
   const env = {
     ...restEnv,
     NODE_ENV: 'development',

--- a/e2e-tests/fixtures/isolated.fixture.ts
+++ b/e2e-tests/fixtures/isolated.fixture.ts
@@ -5,7 +5,7 @@ import {
   TestInfo,
   ConsoleMessage,
 } from '@playwright/test';
-import { launchElectronApp, teardownElectronApp } from './helpers';
+import { launchElectronApp, LaunchElectronAppOptions, teardownElectronApp } from './helpers';
 
 export { expect } from '@playwright/test';
 
@@ -30,16 +30,24 @@ export { expect } from '@playwright/test';
  * inherit stale module state, which prevents dock tabs from rendering correctly.
  */
 export interface IsolatedFixtures {
+  /**
+   * Per-suite launch options; set with `test.use({ electronLaunchOptions: { ... } })`. Named
+   * `electronLaunchOptions` (not `launchOptions`) because Playwright's base `test` already
+   * registers a worker-scoped `launchOptions` option fixture (browser launch options); reusing that
+   * name throws "Fixture ... has already been registered as a { scope: 'worker' } fixture".
+   */
+  electronLaunchOptions: LaunchElectronAppOptions;
   electronApp: ElectronApplication;
   mainPage: Page;
 }
 
 export const test = base.extend<IsolatedFixtures>({
+  // Option fixture: suites override via test.use(); default launches with no special options.
+  electronLaunchOptions: [{}, { option: true }],
+
   // Test-scoped fixture: Playwright launches one Electron instance per test() block.
-  // Playwright fixtures require destructured parameter even when no dependencies are needed
-  // eslint-disable-next-line no-empty-pattern
-  electronApp: async ({}, use) => {
-    const ctx = await launchElectronApp();
+  electronApp: async ({ electronLaunchOptions }, use) => {
+    const ctx = await launchElectronApp(electronLaunchOptions);
 
     await use(ctx.electronApp);
 

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -35,6 +35,9 @@ const config = defineConfig({
       testDir: './tests/smoke',
     },
     {
+      // The common set of locally-runnable tests, organized in subdirectories by feature.
+      // `npm run test:e2e:isolated` (via e2e-tests/run-isolated.mjs) lists the subsets;
+      // `npm run test:e2e:isolated <subset>` runs one; `... all` runs everything.
       name: 'isolated',
       testDir: './tests/isolated',
     },

--- a/e2e-tests/run-isolated.mjs
+++ b/e2e-tests/run-isolated.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Runner for the `isolated` e2e suite — the common set of locally-runnable tests, organized in
+// subdirectories by feature under `e2e-tests/tests/isolated/`.
+//
+//   npm run test:e2e:isolated                     List the available subsets and usage
+//   npm run test:e2e:isolated all                 Run every isolated test
+//   npm run test:e2e:isolated <subset>            Run one subdirectory (e.g. scroll-groups)
+//   npm run test:e2e:isolated <subset> -- --debug Extra args after `--` go to Playwright
+//   npm run test:e2e:isolated -- --list           Flags go straight to Playwright (all subsets)
+import { spawnSync } from 'child_process';
+import { readdirSync } from 'fs';
+import { createRequire } from 'module';
+import { dirname, join, relative } from 'path';
+import { fileURLToPath } from 'url';
+
+const e2eDir = dirname(fileURLToPath(import.meta.url));
+const repoRoot = join(e2eDir, '..');
+const isolatedDir = join(e2eDir, 'tests', 'isolated');
+
+const subsets = readdirSync(isolatedDir, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name)
+  .sort();
+
+function printUsage() {
+  console.log('Isolated e2e subsets (each test launches its own Electron instance):\n');
+  subsets.forEach((subset) => console.log(`  ${subset}`));
+  console.log(`
+Usage:
+  npm run test:e2e:isolated all                  Run every isolated test
+  npm run test:e2e:isolated <subset>             Run one subset (e.g. ${subsets[0]})
+  npm run test:e2e:isolated <subset> -- --debug  Extra args after -- go to Playwright
+  npm run test:e2e:isolated -- --list            Enumerate individual tests`);
+}
+
+const [first, ...rest] = process.argv.slice(2);
+
+if (!first) {
+  printUsage();
+  process.exit(0);
+}
+
+const playwrightArgs = [
+  'test',
+  '--config',
+  relative(repoRoot, join(e2eDir, 'playwright.config.ts')),
+  '--project=isolated',
+];
+
+if (first.startsWith('-')) {
+  // Flags only (e.g. --list, --grep): pass straight through, no subset filter
+  playwrightArgs.push(first, ...rest);
+} else if (first === 'all') {
+  playwrightArgs.push(...rest);
+} else if (subsets.includes(first)) {
+  // Playwright treats positional args as path filters; the subdirectory name selects the subset
+  playwrightArgs.push(first, ...rest);
+} else {
+  console.error(`Unknown subset '${first}'.\n`);
+  printUsage();
+  process.exit(1);
+}
+
+const require = createRequire(import.meta.url);
+const playwrightCli = require.resolve('@playwright/test/cli');
+const result = spawnSync(process.execPath, [playwrightCli, ...playwrightArgs], {
+  stdio: 'inherit',
+  cwd: repoRoot,
+});
+process.exit(result.status ?? 1);

--- a/e2e-tests/run-isolated.mjs
+++ b/e2e-tests/run-isolated.mjs
@@ -2,9 +2,10 @@
 // Runner for the `isolated` e2e suite — the common set of locally-runnable tests, organized in
 // subdirectories by feature under `e2e-tests/tests/isolated/`.
 //
-//   npm run test:e2e:isolated                     List the available subsets and usage
+//   npm run test:e2e:isolated                     List the available subsets (exits non-zero; runs nothing)
 //   npm run test:e2e:isolated all                 Run every isolated test
 //   npm run test:e2e:isolated <subset>            Run one subdirectory (e.g. scroll-groups)
+//   npm run test:e2e:isolated <path>              Run a path filter (e.g. tests/isolated/scroll-groups/)
 //   npm run test:e2e:isolated <subset> -- --debug Extra args after `--` go to Playwright
 //   npm run test:e2e:isolated -- --list           Flags go straight to Playwright (all subsets)
 import { spawnSync } from 'child_process';
@@ -36,8 +37,10 @@ Usage:
 const [first, ...rest] = process.argv.slice(2);
 
 if (!first) {
+  // No subset given: list what's available but exit non-zero — nothing ran, so a scripted caller
+  // (or muscle memory expecting the old run-everything script) does not get a false green.
   printUsage();
-  process.exit(0);
+  process.exit(1);
 }
 
 const playwrightArgs = [
@@ -47,13 +50,16 @@ const playwrightArgs = [
   '--project=isolated',
 ];
 
-if (first.startsWith('-')) {
-  // Flags only (e.g. --list, --grep): pass straight through, no subset filter
-  playwrightArgs.push(first, ...rest);
-} else if (first === 'all') {
+// A path (contains a separator) is passed straight to Playwright as a path filter, preserving the
+// old `test:e2e:isolated -- <path>` behavior alongside the bare subset-name shorthand.
+const isPath = first.includes('/') || first.includes('\\');
+
+if (first === 'all') {
+  // No path filter: run every isolated test
   playwrightArgs.push(...rest);
-} else if (subsets.includes(first)) {
-  // Playwright treats positional args as path filters; the subdirectory name selects the subset
+} else if (first.startsWith('-') || subsets.includes(first) || isPath) {
+  // A flag (e.g. --list, --grep), a subset directory name, or a path. Playwright treats a positional
+  // arg as a path filter, so the subdirectory name selects that subset.
   playwrightArgs.push(first, ...rest);
 } else {
   console.error(`Unknown subset '${first}'.\n`);

--- a/e2e-tests/tests/isolated/scroll-groups/scroll-group-sync.spec.ts
+++ b/e2e-tests/tests/isolated/scroll-groups/scroll-group-sync.spec.ts
@@ -1,0 +1,172 @@
+/**
+ * Scroll-group synchronization e2e tests.
+ *
+ * Regression guard for the scroll-into-view defect diagnosed 2026-07-09: a reference change from
+ * another source must scroll the scripture editor's content, not just update the BCV controls (the
+ * scroll utilities used to target `.editor-container`, which layout wrappers had made
+ * non-scrollable, so every programmatic scroll silently no-oped).
+ *
+ * Runs against an isolated project root, so the only project is the bundled sample WEB (installed
+ * by the C# backend into the empty root). Any developer can run this suite: `npm run
+ * test:e2e:isolated scroll-groups`. No machine-local projects are read or written.
+ *
+ * Both scenarios run in ONE test() on purpose: the isolated fixture is test-scoped, and a SECOND
+ * Electron instance launched against the shared webpack renderer dev server has a documented
+ * failure mode where new dock tabs never render (see comment.fixture.ts and isolated.fixture.ts).
+ * One test = one Electron instance per spec file, matching every other isolated-fixture suite.
+ *
+ * Book choice: Obadiah — single chapter (21 verses, ~2 screens tall in the 1280x800 test window),
+ * so the tested navigations (1:1 -> 1:21 external change, 1:1 -> 1:15 click-follow) never cross a
+ * chapter/book boundary and no document reload races with the scroll.
+ */
+import { Page } from '@playwright/test';
+import { test, expect } from '../../../fixtures/isolated.fixture';
+import {
+  sendPapiRequestOnce,
+  waitForAtLeastOneProjectMetadata,
+  waitForPapiMethodRegistered,
+} from '../../../fixtures/helpers';
+
+/** Fixed GUID of the bundled sample WEB project (c-sharp/assets/WEB/Settings.xml <Guid>). */
+const SAMPLE_WEB_PROJECT_ID = '32664dc3288a28df2e2bb75ded887fc8f17a15fb';
+const WEBSOCKET_PORT = 8876;
+const COMMAND_TIMEOUT_MS = 30_000;
+
+// DEVIATION from task brief (required, per Task 3 fixture rename): the option fixture is named
+// `electronLaunchOptions`, not `launchOptions` — Playwright's base `test` already registers a
+// worker-scoped `launchOptions` option fixture (browser launch options), so reusing that name
+// throws "Fixture ... has already been registered as a { scope: 'worker' } fixture". See
+// e2e-tests/fixtures/isolated.fixture.ts.
+//
+// DEV_NOISY=false (fixture default is true): in noisy dev mode the renderer uses the test layout
+// (src/renderer/testing/test-layout.data.ts), which has NO Home tab — app-ready detection and a
+// clean single-pane layout for the viewport assertions both need the normal Home layout. Same
+// approach as comment.fixture.ts.
+test.use({
+  electronLaunchOptions: { isolatedProjectRoot: true, envOverrides: { DEV_NOISY: 'false' } },
+});
+
+/** Send one PAPI command over a short-lived WebSocket JSON-RPC connection. */
+async function sendPapiCommandWhenRegistered(
+  commandName: string,
+  ...args: unknown[]
+): Promise<unknown> {
+  // The extension host can still be activating extensions when the app shell renders; wait for
+  // this exact command to be registered so the request cannot fail with method-not-found.
+  await waitForPapiMethodRegistered(`command:${commandName}`, WEBSOCKET_PORT, 60_000);
+  return sendPapiRequestOnce(`command:${commandName}`, args, WEBSOCKET_PORT, COMMAND_TIMEOUT_MS);
+}
+
+/**
+ * Make the installed sample WEB project editable. Its Settings.xml ships `<Editable>F</Editable>`,
+ * so `openScriptureEditor` would silently fall back to a read-only editor (main.ts overrides
+ * isReadOnly from `platform.isEditable`) — and a read-only Lexical editor never moves the caret on
+ * click, so click-follow cannot be exercised without this. Flipping the setting through the PDP
+ * (same write path as the Project Settings UI) keeps the change inside the isolated temp project
+ * root.
+ */
+async function makeSampleProjectEditable(): Promise<void> {
+  // Wait until the sample project is installed and advertised by the Paratext PDP factory.
+  await waitForAtLeastOneProjectMetadata(WEBSOCKET_PORT, 60_000);
+  const pdpId = await sendPapiRequestOnce<string>(
+    'object:platform.Paratext-pdpf.getProjectDataProviderId',
+    [SAMPLE_WEB_PROJECT_ID],
+    WEBSOCKET_PORT,
+    COMMAND_TIMEOUT_MS,
+  );
+  await sendPapiRequestOnce<boolean>(
+    `object:${pdpId}.setSetting`,
+    ['platform.isEditable', true],
+    WEBSOCKET_PORT,
+    COMMAND_TIMEOUT_MS,
+  );
+}
+
+/** Navigate the main toolbar's book-chapter-verse control (drives scroll group A). */
+async function navigateToolbarBcv(mainPage: Page, reference: string): Promise<void> {
+  await mainPage.locator('button[aria-label="book-chapter-trigger"]').first().click();
+  const input = mainPage.locator('[data-radix-popper-content-wrapper] input');
+  await input.fill(reference);
+  await input.press('Enter');
+}
+
+/**
+ * Wait for the Home dock tab so PAPI commands land in a ready app. (Not the canonical
+ * `waitForAppReady` from fixtures/helpers.ts — this additionally proves the normal Home layout
+ * rendered, which the DEV_NOISY=false launch depends on.)
+ */
+async function waitForHomeTab(mainPage: Page): Promise<void> {
+  await mainPage.locator('.dock-tab', { hasText: 'Home' }).first().waitFor({ timeout: 90_000 });
+}
+
+test.describe('scroll group sync', () => {
+  test('an external BCV change scrolls the verse into view, and clicking a verse reports it to the scroll group (PT9-style click-follow)', async ({
+    mainPage,
+  }) => {
+    await waitForHomeTab(mainPage);
+
+    // ── Scenario 1: an external BCV change scrolls the verse into view ──────────────────────
+
+    // Open the sample WEB project read-only; the new tab becomes the active, visible one.
+    await sendPapiCommandWhenRegistered(
+      'platformScriptureEditor.openResourceViewer',
+      SAMPLE_WEB_PROJECT_ID,
+    );
+    const resourceFrame = mainPage.frameLocator('iframe[title*="WEB"]:not([title*="Editable"])');
+    await resourceFrame.locator('.editor-container').waitFor({ timeout: 60_000 });
+
+    // Load Obadiah at its top; wait for the chapter content (last verse marker attached).
+    await navigateToolbarBcv(mainPage, 'Obadiah 1:1');
+    const lastVerse = resourceFrame.locator('span[data-marker="v"][data-number="21"]');
+    await expect(lastVerse).toBeAttached({ timeout: 60_000 });
+
+    // Falsifiability precondition: the target verse starts outside the visible pane. Target the
+    // LAST verse (21), a full screen below the fold at 1280x800 — verse 15 (the design doc's
+    // first pick) sits exactly at the fold and flakes on pixel-level layout differences.
+    await expect(lastVerse).not.toBeInViewport();
+
+    // The regression under test: a same-book reference change from another source (the main
+    // toolbar drives scroll group A) must scroll the content, not just the BCV controls.
+    await navigateToolbarBcv(mainPage, 'Obadiah 1:21');
+    await expect(lastVerse).toBeInViewport({ timeout: 15_000 });
+
+    // ── Scenario 2: clicking a verse reports it to the scroll group ─────────────────────────
+
+    // Click-follow requires a truly editable editor (read-only Lexical ignores caret placement).
+    await makeSampleProjectEditable();
+
+    // Opens a second, editable view of the project as a new dock tab (power mode never reuses a
+    // tab whose read-only mode differs); the new tab becomes the active, visible one.
+    await sendPapiCommandWhenRegistered(
+      'platformScriptureEditor.openScriptureEditor',
+      SAMPLE_WEB_PROJECT_ID,
+    );
+    const editorFrame = mainPage.frameLocator('iframe[title*="Editable"]');
+    await editorFrame.locator('.editor-container').waitFor({ timeout: 60_000 });
+
+    // Return to the book's top and wait for the scroll to settle there (verse 1 visible) so the
+    // content cannot shift under the pointer between the manual scroll below and the click.
+    await navigateToolbarBcv(mainPage, 'Obadiah 1:1');
+    await expect(editorFrame.locator('span[data-marker="v"][data-number="21"]')).toBeAttached({
+      timeout: 60_000,
+    });
+    await expect(editorFrame.locator('span[data-marker="v"][data-number="1"]')).toBeInViewport({
+      timeout: 15_000,
+    });
+
+    // Manually bring verse 15 on screen WITHOUT changing the reference, then click it. The
+    // editor must report the caret move so the shared scroll group (main toolbar BCV) follows.
+    // Click the verse TEXT, not the verse number: the number is an immutable Lexical node, so
+    // clicking it does not move the caret — the PT9-style gesture is clicking in the verse's
+    // text anyway. The `+ span` selector assumes the marker's immediate element sibling is the
+    // verse's Lexical text span, i.e. no footnote/xref decorator sits directly after the marker —
+    // verified for the pinned Obadiah 1:15 in the bundled sample WEB text.
+    const verse15Text = editorFrame.locator('span[data-marker="v"][data-number="15"] + span');
+    await verse15Text.scrollIntoViewIfNeeded();
+    await verse15Text.click();
+
+    await expect(
+      mainPage.locator('button[aria-label="book-chapter-trigger"]').first(),
+    ).toContainText('Obadiah 1:15', { timeout: 15_000 });
+  });
+});

--- a/e2e-tests/tests/isolated/scroll-groups/scroll-group-sync.spec.ts
+++ b/e2e-tests/tests/isolated/scroll-groups/scroll-group-sync.spec.ts
@@ -32,11 +32,10 @@ const SAMPLE_WEB_PROJECT_ID = '32664dc3288a28df2e2bb75ded887fc8f17a15fb';
 const WEBSOCKET_PORT = 8876;
 const COMMAND_TIMEOUT_MS = 30_000;
 
-// DEVIATION from task brief (required, per Task 3 fixture rename): the option fixture is named
-// `electronLaunchOptions`, not `launchOptions` — Playwright's base `test` already registers a
-// worker-scoped `launchOptions` option fixture (browser launch options), so reusing that name
-// throws "Fixture ... has already been registered as a { scope: 'worker' } fixture". See
-// e2e-tests/fixtures/isolated.fixture.ts.
+// The option fixture is named `electronLaunchOptions`, not `launchOptions` — Playwright's base
+// `test` already registers a worker-scoped `launchOptions` option fixture (browser launch
+// options), so reusing that name throws "Fixture ... has already been registered as a
+// { scope: 'worker' } fixture". See e2e-tests/fixtures/isolated.fixture.ts.
 //
 // DEV_NOISY=false (fixture default is true): in noisy dev mode the renderer uses the test layout
 // (src/renderer/testing/test-layout.data.ts), which has NO Home tab — app-ready detection and a

--- a/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
@@ -5,6 +5,11 @@
 
 // Platform.Bible modifications
 
+// NOTE: `height: 100%` / `overflow-y: auto` below are currently inert. Wrapper divs between the
+// web view's sized flex column and this element (EditorKeyboardShortcuts, the paragraph-marker
+// tooltip overlay) leave it auto-height, so it grows to its content and the web view's outer
+// `tw:overflow-auto` wrapper is what actually scrolls. Scroll code must not assume this element
+// scrolls — editor-dom.util.ts discovers the scroll container dynamically (findScrollContainer).
 .editor-container {
   height: 100%;
   max-width: none;

--- a/extensions/src/platform-scripture-editor/src/editor-dom.util.test.ts
+++ b/extensions/src/platform-scripture-editor/src/editor-dom.util.test.ts
@@ -12,12 +12,26 @@
  * per element. `overflow-y` is set via inline styles, which jsdom's getComputedStyle reflects.
  */
 
-import { afterEach, describe, expect, it, vi, Mock } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi, Mock } from 'vitest';
 import { findScrollContainer, scrollToAnnotation, scrollToVerse } from './editor-dom.util';
 
 vi.mock('@papi/frontend', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
+
+// jsdom doesn't provide CSS.escape; polyfill for tests (same approach as
+// src/renderer/services/overlays/overlay-coordinates.test.ts). scrollToAnnotation escapes the
+// annotation class token before querySelector, so the tests need CSS.escape to exist.
+// eslint-disable-next-line no-type-assertion/no-type-assertion
+const cssPolyfill = {
+  escape: (value: string) => value.replace(/[!"#$%&'()*+,./:;<=>?@[\\\]^`{|}~]/g, '\\$&'),
+} as typeof CSS;
+
+beforeAll(() => {
+  if (typeof CSS === 'undefined' || !CSS.escape) {
+    globalThis.CSS = cssPolyfill;
+  }
+});
 
 interface GeometryOptions {
   scrollHeight: number;
@@ -226,6 +240,19 @@ describe('scrollToVerse', () => {
     expect(wrapperScrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 1420 });
   });
 
+  it('subtracts the scroll container top offset when the container is not at the viewport top', () => {
+    const { wrapper, wrapperScrollTo } = buildEditorDom();
+    // The scroll container sits 100px below the viewport top (e.g. below the app toolbar/tab bar),
+    // so the container-top term in getTopWithinScrollContainer is load-bearing here (unlike the
+    // other cases where the container rect top is 0).
+    stubRect(wrapper, 100, VIEWPORT_HEIGHT);
+
+    scrollToVerse({ book: 'OBA', chapterNum: 1, verseNum: 15 });
+
+    // scrollTop (0) + verseRect.top (1500) - containerRect.top (100) - offset (80) = 1320
+    expect(wrapperScrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 1320 });
+  });
+
   it('scrolls .editor-container when it is the real scroll container', () => {
     const { wrapperScrollTo, editorContainerScrollTo } = buildEditorDom({
       editorContainerScrolls: true,
@@ -309,6 +336,33 @@ describe('scrollToAnnotation', () => {
 
     // bottom-edge target = 3010 - 900 + 80 = 2190 > maxScrollTop (3000 - 900 = 2100) -> clamp
     expect(wrapperScrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 2100 });
+  });
+
+  it('clamps a negative top-aligned target up to 0', () => {
+    const { wrapper, annotation, wrapperScrollTo } = buildAnnotationDom();
+    wrapper.scrollTop = 100;
+    stubRect(annotation, -70, 20);
+
+    scrollToAnnotation('thread1');
+
+    // annotationTop = 100 + (-70) - 0 = 30, above viewport [100, 1000) -> top edge
+    // top-aligned target = 30 - 80 = -50 -> clamped up to 0
+    expect(wrapperScrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 0 });
+  });
+
+  it('escapes CSS-special characters in the annotation id (a raw id would throw a SyntaxError)', () => {
+    const dom = buildEditorDom({ verseNumbers: [] });
+    const annotation = document.createElement('span');
+    // Real annotation/comment ids can contain ':'; the applied class is `annotationId-<id>`.
+    annotation.className = 'annotationId-thread:1';
+    stubRect(annotation, 400, 20); // fully visible -> resolves the element, no scroll
+    dom.editorContainer.append(annotation);
+
+    // Without CSS.escape, `.annotationId-thread:1` is an invalid selector and querySelector throws.
+    const annotationElement = scrollToAnnotation('thread:1');
+
+    expect(annotationElement).toBe(annotation);
+    expect(dom.wrapperScrollTo).not.toHaveBeenCalled();
   });
 
   it('returns undefined and does not scroll when the annotation does not exist', () => {

--- a/extensions/src/platform-scripture-editor/src/editor-dom.util.test.ts
+++ b/extensions/src/platform-scripture-editor/src/editor-dom.util.test.ts
@@ -180,6 +180,24 @@ describe('findScrollContainer', () => {
 
     expect(findScrollContainer(wrapper)).toBe(wrapper);
   });
+
+  it('matches a styled-scrollable ancestor that does not overflow when requireOverflow is false', () => {
+    const { editorContainer } = buildEditorDom();
+    const verse = editorContainer.querySelector<HTMLElement>('span[data-marker="v"]');
+    if (!verse) throw new Error('test setup failed: no verse span');
+
+    // .editor-container is styled overflow-y: auto but does not overflow -> still matches
+    expect(findScrollContainer(verse, { requireOverflow: false })).toBe(editorContainer);
+  });
+
+  it('returns undefined when nothing is even styled scrollable and requireOverflow is false', () => {
+    const orphan = document.createElement('div');
+    const child = document.createElement('span');
+    orphan.append(child);
+    document.body.append(orphan);
+
+    expect(findScrollContainer(child, { requireOverflow: false })).toBeUndefined();
+  });
 });
 
 describe('scrollToVerse', () => {

--- a/extensions/src/platform-scripture-editor/src/editor-dom.util.test.ts
+++ b/extensions/src/platform-scripture-editor/src/editor-dom.util.test.ts
@@ -1,0 +1,304 @@
+// @vitest-environment jsdom
+
+/**
+ * Tests for the scroll utilities in editor-dom.util.ts.
+ *
+ * Regression context (2026-07-09): `.editor-container` styles suggest it scrolls (`overflow-y:
+ * auto`), but unconstrained wrapper divs let it grow to its content height, so the web view's outer
+ * wrapper is what actually scrolls. Scroll code must discover the real scroll container instead of
+ * assuming `.editor-container`.
+ *
+ * Jsdom has no layout engine, so geometry (scrollHeight/clientHeight/scrollTop/rects) is stubbed
+ * per element. `overflow-y` is set via inline styles, which jsdom's getComputedStyle reflects.
+ */
+
+import { afterEach, describe, expect, it, vi, Mock } from 'vitest';
+import { findScrollContainer, scrollToAnnotation, scrollToVerse } from './editor-dom.util';
+
+vi.mock('@papi/frontend', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+interface GeometryOptions {
+  scrollHeight: number;
+  clientHeight: number;
+  scrollTop?: number;
+}
+
+/** Stub the scroll geometry jsdom cannot compute. Returns the element's scrollTo spy. */
+function stubGeometry(
+  element: HTMLElement,
+  { scrollHeight, clientHeight, scrollTop = 0 }: GeometryOptions,
+): Mock {
+  Object.defineProperty(element, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(element, 'clientHeight', { value: clientHeight, configurable: true });
+  let currentScrollTop = scrollTop;
+  Object.defineProperty(element, 'scrollTop', {
+    get: () => currentScrollTop,
+    set: (value: number) => {
+      currentScrollTop = value;
+    },
+    configurable: true,
+  });
+  const scrollToSpy = vi.fn();
+  Object.defineProperty(element, 'scrollTo', { value: scrollToSpy, configurable: true });
+  return scrollToSpy;
+}
+
+/** Stub an element's viewport-relative rect (only `top` and `height` matter to the utils). */
+function stubRect(element: HTMLElement, top: number, height: number): void {
+  Object.defineProperty(element, 'getBoundingClientRect', {
+    value: () => new DOMRect(0, top, 100, height),
+    configurable: true,
+  });
+}
+
+interface EditorDomOptions {
+  /** Whether `.editor-container` actually overflows (the intended, pre-regression layout) */
+  editorContainerScrolls?: boolean;
+  /** Whether the outer wrapper actually overflows (today's real layout) */
+  wrapperScrolls?: boolean;
+  /** Verse numbers to render as `span[data-marker="v"]` markers */
+  verseNumbers?: number[];
+  /** Viewport-relative top of each verse span, keyed by verse number (default 1500) */
+  verseTops?: Record<number, number>;
+}
+
+interface EditorDom {
+  wrapper: HTMLElement;
+  editorContainer: HTMLElement;
+  wrapperScrollTo: Mock;
+  editorContainerScrollTo: Mock;
+}
+
+const CONTENT_HEIGHT = 3000;
+const VIEWPORT_HEIGHT = 900;
+
+/**
+ * Build the essential DOM shape of the editor web view:
+ *
+ *     wrapper (tw:overflow-auto)            <- scrolls in today's layout
+ *       passthrough (plain div)             <- the unconstrained wrapper that broke the chain
+ *         .editor-container (overflow-y)    <- styled to scroll, but grown to content height
+ *           <p> <span data-marker="v"/> ... </p>
+ */
+function buildEditorDom({
+  editorContainerScrolls = false,
+  wrapperScrolls = true,
+  verseNumbers = [15],
+  verseTops = {},
+}: EditorDomOptions = {}): EditorDom {
+  const wrapper = document.createElement('div');
+  wrapper.style.overflowY = 'auto';
+  const wrapperScrollTo = stubGeometry(wrapper, {
+    scrollHeight: CONTENT_HEIGHT,
+    clientHeight: wrapperScrolls ? VIEWPORT_HEIGHT : CONTENT_HEIGHT,
+  });
+  stubRect(wrapper, 0, wrapperScrolls ? VIEWPORT_HEIGHT : CONTENT_HEIGHT);
+
+  const passthrough = document.createElement('div');
+
+  const editorContainer = document.createElement('div');
+  editorContainer.className = 'editor-container';
+  editorContainer.style.overflowY = 'auto';
+  const editorContainerScrollTo = stubGeometry(editorContainer, {
+    scrollHeight: CONTENT_HEIGHT,
+    clientHeight: editorContainerScrolls ? VIEWPORT_HEIGHT : CONTENT_HEIGHT,
+  });
+  stubRect(editorContainer, 0, editorContainerScrolls ? VIEWPORT_HEIGHT : CONTENT_HEIGHT);
+
+  const paragraph = document.createElement('p');
+  verseNumbers.forEach((verseNumber) => {
+    const verse = document.createElement('span');
+    verse.setAttribute('data-marker', 'v');
+    verse.setAttribute('data-number', `${verseNumber}`);
+    stubRect(verse, verseTops[verseNumber] ?? 1500, 20);
+    paragraph.append(verse);
+  });
+
+  editorContainer.append(paragraph);
+  passthrough.append(editorContainer);
+  wrapper.append(passthrough);
+  document.body.append(wrapper);
+
+  return { wrapper, editorContainer, wrapperScrollTo, editorContainerScrollTo };
+}
+
+function buildAnnotationDom(options: EditorDomOptions = {}): EditorDom & {
+  annotation: HTMLElement;
+} {
+  const dom = buildEditorDom({ ...options, verseNumbers: [] });
+  const annotation = document.createElement('span');
+  annotation.className = 'annotationId-thread1';
+  stubRect(annotation, 1500, 20);
+  dom.editorContainer.append(annotation);
+  return { ...dom, annotation };
+}
+
+afterEach(() => {
+  document.body.innerHTML = '';
+  vi.clearAllMocks();
+});
+
+describe('findScrollContainer', () => {
+  it('returns the nearest ancestor that is styled scrollable AND actually overflows', () => {
+    const { wrapper, editorContainer } = buildEditorDom();
+    const verse = editorContainer.querySelector<HTMLElement>('span[data-marker="v"]');
+    if (!verse) throw new Error('test setup failed: no verse span');
+
+    // .editor-container is styled overflow-y: auto but does not overflow -> skipped
+    expect(findScrollContainer(verse)).toBe(wrapper);
+  });
+
+  it('prefers .editor-container when it genuinely overflows (restored-layout world)', () => {
+    const { editorContainer } = buildEditorDom({ editorContainerScrolls: true });
+    const verse = editorContainer.querySelector<HTMLElement>('span[data-marker="v"]');
+    if (!verse) throw new Error('test setup failed: no verse span');
+
+    expect(findScrollContainer(verse)).toBe(editorContainer);
+  });
+
+  it('returns undefined when nothing scrollable exists', () => {
+    const { editorContainer } = buildEditorDom({ wrapperScrolls: false });
+    const verse = editorContainer.querySelector<HTMLElement>('span[data-marker="v"]');
+    if (!verse) throw new Error('test setup failed: no verse span');
+
+    expect(findScrollContainer(verse)).toBeUndefined();
+  });
+
+  it('finds an overflowing ancestor styled overflow-y: scroll (not just auto)', () => {
+    const { wrapper, editorContainer } = buildEditorDom();
+    wrapper.style.overflowY = 'scroll';
+    const verse = editorContainer.querySelector<HTMLElement>('span[data-marker="v"]');
+    if (!verse) throw new Error('test setup failed: no verse span');
+
+    expect(findScrollContainer(verse)).toBe(wrapper);
+  });
+
+  it('returns the starting element itself when it already qualifies', () => {
+    const { wrapper } = buildEditorDom();
+
+    expect(findScrollContainer(wrapper)).toBe(wrapper);
+  });
+});
+
+describe('scrollToVerse', () => {
+  it('REGRESSION: scrolls the element that actually scrolls, not .editor-container', () => {
+    // Mirrors the shipped bug: .editor-container styled scrollable but grown to content height.
+    const { wrapperScrollTo, editorContainerScrollTo } = buildEditorDom();
+
+    const verseElement = scrollToVerse({ book: 'OBA', chapterNum: 1, verseNum: 15 });
+
+    expect(verseElement).toBeDefined();
+    expect(editorContainerScrollTo).not.toHaveBeenCalled();
+    expect(wrapperScrollTo).toHaveBeenCalledWith({
+      behavior: 'smooth',
+      // scrollTop (0) + verseRect.top (1500) - containerRect.top (0) - offset (80)
+      top: 1420,
+    });
+  });
+
+  it('accounts for the container already being scrolled', () => {
+    const { wrapper, wrapperScrollTo } = buildEditorDom({ verseTops: { 15: 300 } });
+    wrapper.scrollTop = 1200;
+
+    scrollToVerse({ book: 'OBA', chapterNum: 1, verseNum: 15 });
+
+    // scrollTop (1200) + verseRect.top (300) - containerRect.top (0) - offset (80)
+    expect(wrapperScrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 1420 });
+  });
+
+  it('scrolls .editor-container when it is the real scroll container', () => {
+    const { wrapperScrollTo, editorContainerScrollTo } = buildEditorDom({
+      editorContainerScrolls: true,
+    });
+
+    scrollToVerse({ book: 'OBA', chapterNum: 1, verseNum: 15 });
+
+    expect(wrapperScrollTo).not.toHaveBeenCalled();
+    expect(editorContainerScrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 1420 });
+  });
+
+  it('scrolls to the top for a chapter-start reference with no verse marker', () => {
+    const { wrapperScrollTo } = buildEditorDom({ verseNumbers: [] });
+
+    const verseElement = scrollToVerse({ book: 'OBA', chapterNum: 1, verseNum: 0 });
+
+    expect(verseElement).toBeUndefined();
+    expect(wrapperScrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 0 });
+  });
+
+  it('does not scroll and returns undefined when the verse marker is missing (verseNum > 1)', () => {
+    const { wrapperScrollTo, editorContainerScrollTo } = buildEditorDom({ verseNumbers: [3] });
+
+    const verseElement = scrollToVerse({ book: 'OBA', chapterNum: 1, verseNum: 15 });
+
+    expect(verseElement).toBeUndefined();
+    expect(wrapperScrollTo).not.toHaveBeenCalled();
+    expect(editorContainerScrollTo).not.toHaveBeenCalled();
+  });
+
+  it('does nothing (without throwing) when no scrollable ancestor exists', () => {
+    const { wrapperScrollTo, editorContainerScrollTo } = buildEditorDom({ wrapperScrolls: false });
+
+    const verseElement = scrollToVerse({ book: 'OBA', chapterNum: 1, verseNum: 15 });
+
+    expect(verseElement).toBeDefined();
+    expect(wrapperScrollTo).not.toHaveBeenCalled();
+    expect(editorContainerScrollTo).not.toHaveBeenCalled();
+  });
+});
+
+describe('scrollToAnnotation', () => {
+  it('does not scroll when the annotation is already fully visible', () => {
+    const { annotation, wrapperScrollTo } = buildAnnotationDom();
+    stubRect(annotation, 400, 20); // within [0, 900) viewport band, scrollTop 0
+
+    const annotationElement = scrollToAnnotation('thread1');
+
+    expect(annotationElement).toBe(annotation);
+    expect(wrapperScrollTo).not.toHaveBeenCalled();
+  });
+
+  it('aligns to the bottom edge when the annotation is below the viewport (closer edge)', () => {
+    const { wrapperScrollTo } = buildAnnotationDom(); // annotation rect top 1500, height 20
+
+    scrollToAnnotation('thread1');
+
+    // annotationTop = 0 + 1500 - 0 = 1500; bottom = 1520
+    // distanceToTop = 1500, distanceToBottom = |0 + 900 - 1520| = 620 -> bottom edge
+    // targetTop = 1520 - 900 + 80 = 700
+    expect(wrapperScrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 700 });
+  });
+
+  it('aligns to the top edge when the annotation is above the viewport (closer edge)', () => {
+    const { wrapper, annotation, wrapperScrollTo } = buildAnnotationDom();
+    wrapper.scrollTop = 2000;
+    stubRect(annotation, -1500, 20);
+
+    scrollToAnnotation('thread1');
+
+    // annotationTop = 2000 + (-1500) - 0 = 500 -> above viewport [2000, 2900)
+    // distanceToTop = 1500, distanceToBottom = 2380 -> top edge; targetTop = 500 - 80 = 420
+    expect(wrapperScrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 420 });
+  });
+
+  it('clamps the target to the valid scroll range', () => {
+    const { annotation, wrapperScrollTo } = buildAnnotationDom();
+    stubRect(annotation, 2990, 20); // annotationTop 2990, bottom 3010 (content is 3000 tall)
+
+    scrollToAnnotation('thread1');
+
+    // bottom-edge target = 3010 - 900 + 80 = 2190 > maxScrollTop (3000 - 900 = 2100) -> clamp
+    expect(wrapperScrollTo).toHaveBeenCalledWith({ behavior: 'smooth', top: 2100 });
+  });
+
+  it('returns undefined and does not scroll when the annotation does not exist', () => {
+    const { wrapperScrollTo } = buildAnnotationDom();
+
+    const annotationElement = scrollToAnnotation('no-such-thread');
+
+    expect(annotationElement).toBeUndefined();
+    expect(wrapperScrollTo).not.toHaveBeenCalled();
+  });
+});

--- a/extensions/src/platform-scripture-editor/src/editor-dom.util.ts
+++ b/extensions/src/platform-scripture-editor/src/editor-dom.util.ts
@@ -94,17 +94,22 @@ export function findScrollContainer(
 }
 
 /**
- * Computes the element's top edge in the scroll container's scroll coordinate space, i.e. the
- * `scrollTop` value at which the element's top edge sits at the container's top edge.
+ * Computes the top edge of the element with the given bounding rect in the scroll container's
+ * scroll coordinate space, i.e. the `scrollTop` value at which that top edge sits at the
+ * container's content top edge.
  *
  * Rect math instead of an offsetParent walk: the scroll container is not necessarily positioned, so
- * it may not appear in the offsetParent chain at all.
+ * it may not appear in the offsetParent chain at all. Takes the element's already-measured rect so
+ * a caller that also needs the element's height reads `getBoundingClientRect()` only once.
+ * Subtracting the container's `clientTop` (its top border width) targets the content edge rather
+ * than the border edge, so the math stays correct if the container ever gains a top border.
  */
-function getTopWithinScrollContainer(element: HTMLElement, scrollContainer: HTMLElement): number {
+function getTopWithinScrollContainer(elementRect: DOMRect, scrollContainer: HTMLElement): number {
   return (
     scrollContainer.scrollTop +
-    element.getBoundingClientRect().top -
-    scrollContainer.getBoundingClientRect().top
+    elementRect.top -
+    scrollContainer.getBoundingClientRect().top -
+    scrollContainer.clientTop
   );
 }
 
@@ -122,27 +127,33 @@ export function scrollToVerse(verseRef: SerializedVerseRef): HTMLElement | undef
           `.editor-container span[data-marker="v"][data-number="${verseRef.verseNum}"]`,
         ) ?? undefined);
 
-  // Fall back to the editor container for the chapter-start case where no verse marker exists
-  const scrollStartElement =
-    verseElement ?? document.querySelector<HTMLElement>('.editor-container') ?? undefined;
-  const scrollContainerElement = scrollStartElement
-    ? findScrollContainer(scrollStartElement)
-    : undefined;
+  // Scroll if we find the verse or we're at the start of the chapter. Discovering the scroll
+  // container (a getComputedStyle + reflow ancestor walk) is deferred until inside this guard so the
+  // rAF retry loop in model-text-panel does no layout work on frames where the verse marker has not
+  // painted yet (verseNum > 1, no marker).
+  if (verseElement || verseRef.verseNum <= 1) {
+    // Fall back to the editor container for the chapter-start case where no verse marker exists
+    const scrollStartElement =
+      verseElement ?? document.querySelector<HTMLElement>('.editor-container') ?? undefined;
+    const scrollContainerElement = scrollStartElement
+      ? findScrollContainer(scrollStartElement)
+      : undefined;
 
-  // Scroll if we find the verse or we're at the start of the chapter
-  if (scrollContainerElement && (verseElement || verseRef.verseNum <= 1)) {
-    let verseOffsetTop = 0;
-    if (verseElement) {
-      // Scroll a bit above the verse so you can see a bit of context
-      verseOffsetTop =
-        getTopWithinScrollContainer(verseElement, scrollContainerElement) -
-        VERSE_NUMBER_SCROLL_OFFSET;
+    if (scrollContainerElement) {
+      // Scroll a bit above the verse so you can see a bit of context; the chapter-start case (no
+      // verse marker) scrolls to the top.
+      const verseOffsetTop = verseElement
+        ? getTopWithinScrollContainer(
+            verseElement.getBoundingClientRect(),
+            scrollContainerElement,
+          ) - VERSE_NUMBER_SCROLL_OFFSET
+        : 0;
+
+      scrollContainerElement.scrollTo({
+        behavior: 'smooth',
+        top: verseOffsetTop,
+      });
     }
-
-    scrollContainerElement.scrollTo({
-      behavior: 'smooth',
-      top: verseOffsetTop,
-    });
   }
 
   return verseElement;
@@ -155,8 +166,13 @@ export function scrollToVerse(verseRef: SerializedVerseRef): HTMLElement | undef
  * @returns The DOM element of the annotation if found; otherwise undefined
  */
 export function scrollToAnnotation(id: string): HTMLElement | undefined {
+  // annotation/comment ids can contain CSS metacharacters (":", ".", etc.); escaping the whole
+  // class token via CSS.escape keeps the selector valid (same approach as selectorForAnnotationIds
+  // in platform-enhanced-resources' scripture-pane.component.tsx).
+  const escapedAnnotationClass = CSS.escape(`annotationId-${id}`);
   const annotationElement =
-    document.querySelector<HTMLElement>(`.editor-container .annotationId-${id}`) ?? undefined;
+    document.querySelector<HTMLElement>(`.editor-container .${escapedAnnotationClass}`) ??
+    undefined;
 
   const scrollContainerElement = annotationElement
     ? findScrollContainer(annotationElement)
@@ -167,8 +183,10 @@ export function scrollToAnnotation(id: string): HTMLElement | undefined {
     const containerScrollTop = scrollContainerElement.scrollTop;
     const containerHeight = scrollContainerElement.clientHeight;
 
-    const annotationTop = getTopWithinScrollContainer(annotationElement, scrollContainerElement);
-    const annotationBottom = annotationTop + annotationElement.getBoundingClientRect().height;
+    // Read the annotation's rect once; both its top-within-container and its height derive from it.
+    const annotationRect = annotationElement.getBoundingClientRect();
+    const annotationTop = getTopWithinScrollContainer(annotationRect, scrollContainerElement);
+    const annotationBottom = annotationTop + annotationRect.height;
 
     // If the annotation is fully visible, don't scroll
     if (

--- a/extensions/src/platform-scripture-editor/src/editor-dom.util.ts
+++ b/extensions/src/platform-scripture-editor/src/editor-dom.util.ts
@@ -58,7 +58,39 @@ export function runOnFirstLoad(callback: () => void): Unsubscriber {
 }
 
 /**
- * Scrolls to the verse marker at the specified verse ref within the editor container.
+ * Finds the element that actually scrolls the given element's content: the nearest ancestor
+ * (starting with the element itself) that is styled scrollable (`overflow-y: auto | scroll`) AND
+ * actually overflows (`scrollHeight > clientHeight`).
+ *
+ * The scroll container is discovered, not assumed: wrapper elements between the web view's sized
+ * flex column and `.editor-container` leave `.editor-container` auto-height, so it grows to its
+ * content height and scrolling it is a silent no-op — the web view's outer `tw:overflow-auto`
+ * wrapper is what actually scrolls (regression diagnosed 2026-07-09). If a future layout change
+ * re-constrains `.editor-container`, discovery resolves there instead — correct either way.
+ *
+ * Note: `ParagraphMarkerTooltipOverlay` keeps its own style-only walk-up (no overflow check) — it
+ * attaches its scroll listener once on mount, possibly before content has loaded and made anything
+ * overflow, so "actually overflowing right now" would be the wrong criterion there.
+ *
+ * @param fromElement Element whose scroll container to find
+ * @returns The scroll container, or undefined if nothing scrollable exists (nothing to scroll)
+ */
+export function findScrollContainer(fromElement: HTMLElement): HTMLElement | undefined {
+  let candidate: HTMLElement | undefined = fromElement;
+  while (candidate) {
+    const { overflowY } = window.getComputedStyle(candidate);
+    if (
+      (overflowY === 'auto' || overflowY === 'scroll') &&
+      candidate.scrollHeight > candidate.clientHeight
+    )
+      return candidate;
+    candidate = candidate.parentElement ?? undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Scrolls to the verse marker at the specified verse ref within the editor content.
  *
  * @param verseRef The verse ref whose matching verse marker to scroll to
  * @returns The verse marker's DOM element if found; otherwise undefined
@@ -71,28 +103,30 @@ export function scrollToVerse(verseRef: SerializedVerseRef): HTMLElement | undef
           `.editor-container span[data-marker="v"][data-number="${verseRef.verseNum}"]`,
         ) ?? undefined);
 
-  const scrollContainerElement =
-    document.querySelector<HTMLElement>('.editor-container') ?? undefined;
+  // Fall back to the editor container for the chapter-start case where no verse marker exists
+  const scrollStartElement =
+    verseElement ?? document.querySelector<HTMLElement>('.editor-container') ?? undefined;
+  const scrollContainerElement = scrollStartElement
+    ? findScrollContainer(scrollStartElement)
+    : undefined;
 
   // Scroll if we find the verse or we're at the start of the chapter
   if (scrollContainerElement && (verseElement || verseRef.verseNum <= 1)) {
-    // Get the scroll position all the way up to the scroll container
-    let offsetElement = verseElement;
     let verseOffsetTop = 0;
-    if (verseRef.verseNum >= 1) {
-      // Find the y offset from the scrolling container
-      while (offsetElement && offsetElement !== scrollContainerElement) {
-        verseOffsetTop += offsetElement.offsetTop;
-        offsetElement =
-          offsetElement.offsetParent instanceof HTMLElement
-            ? offsetElement.offsetParent
-            : undefined;
-      }
+    if (verseElement) {
+      // Rect math instead of an offsetParent walk: the scroll container is not necessarily
+      // positioned, so it may not appear in the offsetParent chain at all
+      const verseRect = verseElement.getBoundingClientRect();
+      const containerRect = scrollContainerElement.getBoundingClientRect();
       // Scroll a bit above the verse so you can see a bit of context
-      verseOffsetTop -= VERSE_NUMBER_SCROLL_OFFSET;
+      verseOffsetTop =
+        scrollContainerElement.scrollTop +
+        verseRect.top -
+        containerRect.top -
+        VERSE_NUMBER_SCROLL_OFFSET;
     }
 
-    scrollContainerElement?.scrollTo({
+    scrollContainerElement.scrollTo({
       behavior: 'smooth',
       top: verseOffsetTop,
     });
@@ -102,7 +136,7 @@ export function scrollToVerse(verseRef: SerializedVerseRef): HTMLElement | undef
 }
 
 /**
- * Scrolls to the annotation with the given ID within the editor container.
+ * Scrolls to the annotation with the given ID within the editor content.
  *
  * @param id The ID of the annotation to scroll to
  * @returns The DOM element of the annotation if found; otherwise undefined
@@ -111,26 +145,21 @@ export function scrollToAnnotation(id: string): HTMLElement | undefined {
   const annotationElement =
     document.querySelector<HTMLElement>(`.editor-container .annotationId-${id}`) ?? undefined;
 
-  const scrollContainerElement =
-    document.querySelector<HTMLElement>('.editor-container') ?? undefined;
+  const scrollContainerElement = annotationElement
+    ? findScrollContainer(annotationElement)
+    : undefined;
 
   // Scroll if we find the annotation
   if (scrollContainerElement && annotationElement) {
-    // Compute the annotation's offset relative to the scrolling container
-    let offsetElement: HTMLElement | undefined = annotationElement;
-    let annotationOffsetTop = 0;
-    while (offsetElement && offsetElement !== scrollContainerElement) {
-      annotationOffsetTop += offsetElement.offsetTop;
-      offsetElement =
-        offsetElement.offsetParent instanceof HTMLElement ? offsetElement.offsetParent : undefined;
-    }
+    // Rect math instead of an offsetParent walk — see scrollToVerse
+    const annotationRect = annotationElement.getBoundingClientRect();
+    const containerRect = scrollContainerElement.getBoundingClientRect();
 
     const containerScrollTop = scrollContainerElement.scrollTop;
     const containerHeight = scrollContainerElement.clientHeight;
-    const annotationHeight = annotationElement.offsetHeight;
 
-    const annotationTop = annotationOffsetTop;
-    const annotationBottom = annotationTop + annotationHeight;
+    const annotationTop = containerScrollTop + annotationRect.top - containerRect.top;
+    const annotationBottom = annotationTop + annotationRect.height;
 
     // If the annotation is fully visible, don't scroll
     if (

--- a/extensions/src/platform-scripture-editor/src/editor-dom.util.ts
+++ b/extensions/src/platform-scripture-editor/src/editor-dom.util.ts
@@ -59,8 +59,8 @@ export function runOnFirstLoad(callback: () => void): Unsubscriber {
 
 /**
  * Finds the element that actually scrolls the given element's content: the nearest ancestor
- * (starting with the element itself) that is styled scrollable (`overflow-y: auto | scroll`) AND
- * actually overflows (`scrollHeight > clientHeight`).
+ * (starting with the element itself) that is styled scrollable (`overflow-y: auto | scroll`) and —
+ * unless `requireOverflow` is `false` — actually overflows (`scrollHeight > clientHeight`).
  *
  * The scroll container is discovered, not assumed: wrapper elements between the web view's sized
  * flex column and `.editor-container` leave `.editor-container` auto-height, so it grows to its
@@ -68,25 +68,44 @@ export function runOnFirstLoad(callback: () => void): Unsubscriber {
  * wrapper is what actually scrolls (regression diagnosed 2026-07-09). If a future layout change
  * re-constrains `.editor-container`, discovery resolves there instead — correct either way.
  *
- * Note: `ParagraphMarkerTooltipOverlay` keeps its own style-only walk-up (no overflow check) — it
- * attaches its scroll listener once on mount, possibly before content has loaded and made anything
- * overflow, so "actually overflowing right now" would be the wrong criterion there.
- *
  * @param fromElement Element whose scroll container to find
- * @returns The scroll container, or undefined if nothing scrollable exists (nothing to scroll)
+ * @param options `requireOverflow` (default `true`) also requires the candidate to actually
+ *   overflow right now. Pass `false` when the lookup runs before content has loaded (e.g. once on
+ *   mount, as in `ParagraphMarkerTooltipOverlay`), where "actually overflowing right now" would be
+ *   the wrong criterion
+ * @returns The scroll container, or undefined if no qualifying ancestor exists
  */
-export function findScrollContainer(fromElement: HTMLElement): HTMLElement | undefined {
+export function findScrollContainer(
+  fromElement: HTMLElement,
+  options?: { requireOverflow?: boolean },
+): HTMLElement | undefined {
+  const requireOverflow = options?.requireOverflow ?? true;
   let candidate: HTMLElement | undefined = fromElement;
   while (candidate) {
     const { overflowY } = window.getComputedStyle(candidate);
     if (
       (overflowY === 'auto' || overflowY === 'scroll') &&
-      candidate.scrollHeight > candidate.clientHeight
+      (!requireOverflow || candidate.scrollHeight > candidate.clientHeight)
     )
       return candidate;
     candidate = candidate.parentElement ?? undefined;
   }
   return undefined;
+}
+
+/**
+ * Computes the element's top edge in the scroll container's scroll coordinate space, i.e. the
+ * `scrollTop` value at which the element's top edge sits at the container's top edge.
+ *
+ * Rect math instead of an offsetParent walk: the scroll container is not necessarily positioned, so
+ * it may not appear in the offsetParent chain at all.
+ */
+function getTopWithinScrollContainer(element: HTMLElement, scrollContainer: HTMLElement): number {
+  return (
+    scrollContainer.scrollTop +
+    element.getBoundingClientRect().top -
+    scrollContainer.getBoundingClientRect().top
+  );
 }
 
 /**
@@ -114,15 +133,9 @@ export function scrollToVerse(verseRef: SerializedVerseRef): HTMLElement | undef
   if (scrollContainerElement && (verseElement || verseRef.verseNum <= 1)) {
     let verseOffsetTop = 0;
     if (verseElement) {
-      // Rect math instead of an offsetParent walk: the scroll container is not necessarily
-      // positioned, so it may not appear in the offsetParent chain at all
-      const verseRect = verseElement.getBoundingClientRect();
-      const containerRect = scrollContainerElement.getBoundingClientRect();
       // Scroll a bit above the verse so you can see a bit of context
       verseOffsetTop =
-        scrollContainerElement.scrollTop +
-        verseRect.top -
-        containerRect.top -
+        getTopWithinScrollContainer(verseElement, scrollContainerElement) -
         VERSE_NUMBER_SCROLL_OFFSET;
     }
 
@@ -151,15 +164,11 @@ export function scrollToAnnotation(id: string): HTMLElement | undefined {
 
   // Scroll if we find the annotation
   if (scrollContainerElement && annotationElement) {
-    // Rect math instead of an offsetParent walk — see scrollToVerse
-    const annotationRect = annotationElement.getBoundingClientRect();
-    const containerRect = scrollContainerElement.getBoundingClientRect();
-
     const containerScrollTop = scrollContainerElement.scrollTop;
     const containerHeight = scrollContainerElement.clientHeight;
 
-    const annotationTop = containerScrollTop + annotationRect.top - containerRect.top;
-    const annotationBottom = annotationTop + annotationRect.height;
+    const annotationTop = getTopWithinScrollContainer(annotationElement, scrollContainerElement);
+    const annotationBottom = annotationTop + annotationElement.getBoundingClientRect().height;
 
     // If the annotation is fully visible, don't scroll
     if (

--- a/extensions/src/platform-scripture-editor/src/paragraph-marker-tooltip/paragraph-marker-tooltip-overlay.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/paragraph-marker-tooltip/paragraph-marker-tooltip-overlay.component.tsx
@@ -115,6 +115,12 @@ export function ParagraphMarkerTooltipOverlay({ children }: Props) {
     // an element with overflow-y: auto or scroll. The editor's scroll container is an ancestor
     // of positionAnchor — walking DOWN into children never reaches it.
     // Falls back to positionAnchor if no scrolling ancestor is found.
+    //
+    // Intentionally style-only (no scrollHeight > clientHeight check): this walk runs once on
+    // mount, possibly before content has loaded and made anything overflow, so "actually
+    // overflowing right now" would be the wrong criterion here. Contrast with findScrollContainer
+    // in ../editor-dom.util.ts, which requires actual overflow because it runs at scroll time,
+    // after content has loaded.
     let scrollContainer: HTMLElement = positionAnchor;
     // parentElement is typed as HTMLElement | null; null terminates the walk
     // eslint-disable-next-line no-type-assertion/no-type-assertion

--- a/extensions/src/platform-scripture-editor/src/paragraph-marker-tooltip/paragraph-marker-tooltip-overlay.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/paragraph-marker-tooltip/paragraph-marker-tooltip-overlay.component.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useLocalizedStrings } from '@papi/frontend/react';
 import { cn, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from 'platform-bible-react';
 import { LocalizeKey } from 'platform-bible-utils';
+import { findScrollContainer } from '../editor-dom.util';
 import { blockMarkerToBlockNames } from '../platform-scripture-editor.utils';
 import { computePosition, extractMarker, TooltipPosition } from './paragraph-marker-tooltip.utils';
 
@@ -17,7 +18,7 @@ export function ParagraphMarkerTooltipOverlay({ children }: Props) {
   // eslint-disable-next-line no-null/no-null
   const positionAnchorRef = useRef<HTMLDivElement>(null);
   // scrollContainerRef: the ancestor element whose scroll causes content to move.
-  // Assigned in useEffect by walking parentElement ancestors until overflow-y: auto/scroll is found.
+  // Assigned in useEffect via findScrollContainer (style-only mode).
   const scrollContainerRef = useRef<HTMLElement | undefined>(undefined);
   const currentParaRef = useRef<HTMLElement | undefined>(undefined);
   const rafIdRef = useRef<number>(0);
@@ -111,28 +112,13 @@ export function ParagraphMarkerTooltipOverlay({ children }: Props) {
     const positionAnchor = positionAnchorRef.current;
     if (!positionAnchor) return;
 
-    // Find the scroll container by walking UP through parentElement ancestors until we reach
-    // an element with overflow-y: auto or scroll. The editor's scroll container is an ancestor
-    // of positionAnchor — walking DOWN into children never reaches it.
-    // Falls back to positionAnchor if no scrolling ancestor is found.
-    //
-    // Intentionally style-only (no scrollHeight > clientHeight check): this walk runs once on
+    // The editor's scroll container is an ancestor of positionAnchor — walking DOWN into children
+    // never reaches it. Style-only matching (requireOverflow: false): this lookup runs once on
     // mount, possibly before content has loaded and made anything overflow, so "actually
-    // overflowing right now" would be the wrong criterion here. Contrast with findScrollContainer
-    // in ../editor-dom.util.ts, which requires actual overflow because it runs at scroll time,
-    // after content has loaded.
-    let scrollContainer: HTMLElement = positionAnchor;
-    // parentElement is typed as HTMLElement | null; null terminates the walk
-    // eslint-disable-next-line no-type-assertion/no-type-assertion
-    let candidate: HTMLElement | null = positionAnchor.parentElement;
-    while (candidate) {
-      const { overflowY } = window.getComputedStyle(candidate);
-      if (overflowY === 'auto' || overflowY === 'scroll') {
-        scrollContainer = candidate;
-        break;
-      }
-      candidate = candidate.parentElement;
-    }
+    // overflowing right now" would be the wrong criterion here.
+    // Falls back to positionAnchor if no scrolling ancestor is found.
+    const scrollContainer =
+      findScrollContainer(positionAnchor, { requireOverflow: false }) ?? positionAnchor;
     scrollContainerRef.current = scrollContainer;
 
     const handleKeyDown = () => {

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "test:core": "vitest",
     "test:e2e-cdp": "playwright test --config e2e-tests/playwright-cdp.config.ts",
     "test:e2e:all": "playwright test --config e2e-tests/playwright.config.ts",
-    "test:e2e:isolated": "playwright test --config e2e-tests/playwright.config.ts --project=isolated",
+    "test:e2e:isolated": "node e2e-tests/run-isolated.mjs",
     "test:e2e:smoke": "playwright test --config e2e-tests/playwright.config.ts --project=smoke",
     "test:e2e:smoke-wsl": "e2e-tests/run-e2e-wsl.sh",
     "typecheck": "npm run typecheck:core && npm run typecheck --workspaces --if-present",


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: fix/scroll-group-scroll-into-view

**Base**: origin/main

**Date**: 2026-07-10

**Review model**: Claude Fable 5

**Files changed**: 11 (plus README.md updated during the review)

## Overview

Fixes scrolling by BCV (book/chapter/verse) in the scripture editor, completing the fix for [PT-3558](https://paratextstudio.atlassian.net/browse/PT-3558). The root cause: the scroll code assumed `.editor-container` is the scrolling element, but unconstrained wrapper divs leave it auto-height, so it grows to its content height and scrolling it is a silent no-op — the web view's outer `tw:overflow-auto` wrapper is what actually scrolls. The fix discovers the real scroll container at scroll time (`findScrollContainer`) instead of assuming a selector, and switches the offset math from an `offsetParent` walk to `getBoundingClientRect` differences (an unpositioned scroll container may not appear in the offsetParent chain). The author chose runtime discovery deliberately as a durable fix: editor restyling has broken automatic scrolling twice this year, and discovery always lands on whatever container is actually vertically scrollable.

The branch also adds regression protection at two levels: a 21-test jsdom unit suite for the scroll utilities (including an explicit regression test mirroring the shipped bug) and a new isolated e2e spec (`scroll-group-sync.spec.ts`). Supporting e2e infrastructure: a `PLATFORM_BIBLE_PROJECT_ROOT_FOLDER` env override in `LocalParatextProjects.cs` so e2e runs use an isolated project root instead of the developer's real projects, fixture plumbing (`electronLaunchOptions` option fixture), and a subset runner (`e2e-tests/run-isolated.mjs`) behind `npm run test:e2e:isolated`.

## Round 2 — Follow-up fixes (commit f9bfb78c8bf)

A second, max-effort review pass surfaced a few defects in the tooling/e2e changes plus some hardening opportunities in the scroll utilities. These were fixed on top of the original branch. (The `PLATFORM_BIBLE_PROJECT_ROOT_FOLDER` production-gating discussed under Minor findings was deliberately left as-is per the author.)

- **`run-isolated.mjs`** — the earlier change dropped Playwright's positional path-filter passthrough, which broke the documented `npm run test:e2e:isolated -- <path>` invocation in `comment-test-helpers.ts` (it errored `Unknown subset`). Path passthrough is restored; a bare no-arg invocation now **exits non-zero** (was `0`) so it cannot report a false green; the duplicate arg-dispatch branches were merged.
- **`scrollToVerse` (`editor-dom.util.ts`)** — scroll-container discovery (a `getComputedStyle` + reflow ancestor walk) is now deferred inside the scroll guard, so `model-text-panel`'s per-frame rAF retry loop does no layout work on frames where the target verse marker has not painted yet.
- **`helpers.ts`** — an ambient `PLATFORM_BIBLE_PROJECT_ROOT_FOLDER` from the shell/CI is now stripped from the inherited env, so it can no longer leak into non-isolated e2e suites; only the `isolatedProjectRoot` opt-in sets it.
- **`scrollToAnnotation`** — the annotation id is `CSS.escape`d before interpolation into the class selector (matching `scripture-pane.component.tsx`), preventing a `SyntaxError` on ids containing CSS metacharacters.
- **`getTopWithinScrollContainer`** — subtracts the container's `clientTop` (top border) and takes the element rect as a parameter so `scrollToAnnotation` reads `getBoundingClientRect()` once.
- **`LocalParatextProjects.cs`** — the project-root override predicate is evaluated once (if/else) instead of twice.
- **Tests** — three new unit tests (**21** total, up from 18) cover the container-top offset, the negative-target clamp, and id escaping (with a jsdom `CSS.escape` polyfill matching `overlay-coordinates.test.ts`).

Round-2 verification: the 21-test `editor-dom.util` unit suite passes; extension + e2e ESLint clean (prettier-formatted); `dotnet build` succeeds with 0 errors and the C# file is csharpier-clean; pre-commit hooks (gitleaks, lint-staged) ran on commit.

## API Changes

None. No public API surface files changed:

- `lib/papi-dts/papi.d.ts` — untouched
- `lib/platform-bible-react/`, `lib/platform-bible-utils/` — untouched
- Extension type declaration files (`extensions/src/*/src/types/*.d.ts`) — untouched

The only new export is `findScrollContainer` in `extensions/src/platform-scripture-editor/src/editor-dom.util.ts`, an extension-internal module (not part of any declared API surface; consumed only within the extension and its tests).

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **`package.json:101` / `e2e-tests/run-isolated.mjs`: bare `npm run test:e2e:isolated` changed behavior — it now prints the subset list and exits 0 without running any tests, while `README.md` still documented the old run-everything behavior; a scripted caller following the README would get a green exit code having run nothing.** _(fixed during review: README bullet updated to document the new usage — `all` runs every test, `<subset>` runs one feature, bare invocation lists subsets and runs nothing. Author confirmed the bare-invocation behavior change itself is intentional. CI is unaffected; workflows only run `test:e2e:smoke`. **Round 2:** the bare invocation now exits **non-zero** (not `0`) so it can't report a false green, and Playwright path-filter passthrough was restored — see the Round 2 section.)_

Author response: The behavior change was intentional; the author asked for the README to be updated, which was done in-review.

### Minor — Consider

- [x] **`c-sharp/Projects/LocalParatextProjects.cs:65-78`: the new `PLATFORM_BIBLE_PROJECT_ROOT_FOLDER` env override is active in production builds (not gated to dev/test), and was only documented in a code comment — a stray environment value silently redirects the app away from the real `Paratext 9 Projects` folder.** _(fixed during review: added a `Console.WriteLine` announcing the override and its path whenever the env var is set, so it shows up in the log. Author is explicitly comfortable shipping the override ungated in production builds.)_
- [x] **`editor-dom.util.ts:78-90`: `findScrollContainer` duplicated the ancestor walk in `paragraph-marker-tooltip-overlay.component.tsx` (same computed-style overflow loop, differing only in the `scrollHeight > clientHeight` check), with cross-referencing comments explaining the divergence.** _(fixed during review: `findScrollContainer` gained an optional `{ requireOverflow?: boolean }` parameter (default `true`); the tooltip overlay now imports it with `requireOverflow: false` instead of its hand-rolled walk, which also removed two `no-type-assertion` eslint-disables. Two new unit tests cover the style-only mode; all 21 tests pass (18 at review time, +3 in round 2).)_
- [x] **`e2e-tests/tests/isolated/scroll-groups/scroll-group-sync.spec.ts:35-39`: comment referenced a gitignored task brief ("DEVIATION from task brief... Task 3"), meaningless to future readers of the repo.** _(fixed during review: comment trimmed to the substantive rationale — Playwright's base `test` already registers a worker-scoped `launchOptions` fixture, hence the `electronLaunchOptions` name.)_
- [x] **`editor-dom.util.ts`: `scrollToVerse` and `scrollToAnnotation` each repeated the same rect-difference computation (`scrollTop + elementRect.top - containerRect.top`) with a "see scrollToVerse" cross-reference.** _(fixed during review: extracted a private `getTopWithinScrollContainer` helper that both functions share; the offsetParent-vs-rect rationale comment now lives in one place.)_

Author response: Author requested fixes for all four minor findings; all were implemented and verified during the review.

### Template Propagation

#### Shared Regions Modified

None. (Verified by grep: no changed file contains a `#region shared with` marker.)

#### Extension Config Changes

- [n/a] All extension changes are source files under `extensions/src/platform-scripture-editor/src/` — extension-specific, no config/build files touched, no propagation needed.
- [n/a] `package.json` (repo root), `e2e-tests/**` — not extension template files.

## Positive Observations

- The fix addresses the actual root cause and is applied consistently to both `scrollToVerse` and `scrollToAnnotation`, not just the BCV path named in the purpose; the chapter-start edge case (`verseNum <= 1`, no verse marker) preserves prior effective behavior (scroll to top).
- Two-level regression protection: a 21-test jsdom unit suite (including an explicit `REGRESSION:` test mirroring the shipped bug and an already-scrolled-container case) plus an e2e guard with a falsifiability precondition (`expect(lastVerse).not.toBeInViewport()` before the navigation under test).
- The isolated-project-root design keeps e2e runs off developers' real Paratext projects, reuses the existing `userDataDir` teardown for cleanup, and the C# env-var read follows the existing `DEV_NOISY` precedent rather than inventing a new configuration pattern.
- The e2e spec reuses existing fixture helpers (`sendPapiRequestOnce`, `waitForPapiMethodRegistered`, `waitForAtLeastOneProjectMetadata`) instead of reimplementing WebSocket plumbing, and its hardcoded sample-project GUID matches `c-sharp/assets/WEB/Settings.xml`.
- `run-isolated.mjs` is cross-platform (`process.execPath` + `require.resolve('@playwright/test/cli')`, no hardcoded paths) and exits non-zero on unknown subsets or a signal-killed child.
- Comments consistently explain _why_: the `_editor-overrides.scss` note documenting that its scroll styles are currently inert, the TSDoc on discovery-not-assumption, and the fixture-collision rationale at the definition site.
- UX-wise the change restores the documented BCV-navigation guideline ("Tabs... automatically follow the selected new scripture reference"); smooth scrolling and the `VERSE_NUMBER_SCROLL_OFFSET` context margin are preserved, and the rect math is vertical-only, so no RTL concerns.
- No user-visible strings added anywhere in the diff, so no localization obligations arise.

## Interview Notes

- **Stated purpose**: Fix scrolling by BCV; completes the fix for PT-3558.
- **Design rationale (runtime scroll-container discovery)**: The author explained this clearly — editor restyling silently broke automatic scrolling twice this year because the scroll code chased a specific selector. Discovering the scroll container at scroll time is a durable fix: it always lands on whatever container is actually vertically scrollable for the verse, so future layout changes resolve correctly either way.
- **Offset math (`offsetParent` walk → rect differences)**: The author deferred to the in-code comments rather than restating the reasoning. The comments do document it (an unpositioned scroll container may not appear in the offsetParent chain, so rect differences are used instead); the reviewer may want a quick walkthrough of that math in the meeting to confirm shared understanding.
- **`test:e2e:isolated` bare invocation**: Intentional design — it lists available subsets and runs nothing. The README was updated in-review to match.
- **Production env override**: The author is comfortable with `PLATFORM_BIBLE_PROJECT_ROOT_FOLDER` being active in production builds and chose a startup `Console.WriteLine` (visible in the log) over gating it to dev/test.
- All four minor findings were fixed at the author's request during the review. Nothing else was flagged in wrap-up.

## In-Review Quality Check

- `npm run typecheck` — passed cleanly.
- `npm run lint` — passed with 0 errors. Two prettier warnings in `editor-dom.util.ts` (from the in-review refactor) were resolved by the scoped format step; two pre-existing `no-console` warnings in `use-effective-resource-reference-list.hook.ts` are untouched by this branch and were left alone.
- Scoped prettier format — one TSDoc line-reflow in `editor-dom.util.ts`; no other branch files needed changes.
- `npm test` — all 783 TypeScript tests pass (round 2 later adds 3 unit tests → 786; see the Round 2 section). Two of three full-suite runs exited 1 due to a **pre-existing** load-dependent teardown flake (unhandled `document is not defined` rejection in `overlay.service-host.ts:150` surfacing from `overlay.service-host.contribution.test.ts`, code last touched in PRs #2173/#2106); the test file passes in isolation and a clean full-suite run completed. Unrelated to this branch; reported, not fixed.
- `dotnet test` (c-sharp-tests) — 1393 passed, 0 failed, 6 skipped. Note: the new `Console.WriteLine` is visible in C# test output when the env override is set — harmless, but a reviewer may notice the extra line.

## Suggested Review Focus

Prioritized areas for the author-reviewer meeting:

- [ ] The core design: `findScrollContainer` runtime discovery (including the new `requireOverflow` option now shared with `ParagraphMarkerTooltipOverlay`) — is the team comfortable standardizing on discovery over selector assumptions for editor scrolling?
- [ ] The rect-based offset math — the author deferred to the in-code comments for the rationale; worth a two-minute walkthrough to confirm shared understanding.
- [ ] `PLATFORM_BIBLE_PROJECT_ROOT_FOLDER` active in production builds — author's deliberate choice (with startup logging); confirm the team accepts the tradeoff versus gating it. (Round 2 stops an ambient value from leaking into non-isolated e2e suites, but the production gating itself is unchanged.)
- [ ] `npm run test:e2e:isolated` bare invocation lists subsets and — as of round 2 — exits non-zero (was `0`), with Playwright path-filter passthrough restored; the false-green concern is resolved. Confirm no scripted caller depended on the old run-everything behavior.
<!-- review-paratext:summary:end -->

AI-assisted — [session](https://claude.ai/code/session_58813d30-de77-4c40-b920-2b73b2524901)


[PT-3558]: https://paratextstudio.atlassian.net/browse/PT-3558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2533)
<!-- Reviewable:end -->

