### PR TITLE
PT-4038: Document versification requirements for cross-project references

### DIFF
--- a/.context/standards/Paranext-Core-Patterns.md
+++ b/.context/standards/Paranext-Core-Patterns.md
@@ -1023,10 +1023,13 @@ scroll-group sync, cross-project navigation, showing one project's current refer
 project's editor or resource — the reference **must be converted into the target project's
 versification**. Never assume two projects share a versification.
 
-- **In React (renderer and web views), use the scroll-group hooks — they convert for you.**
-  `useScrollGroupScrRef(scrollGroupScrRef, setScrollGroupScrRef, projectId)` (and its web-view
-  counterpart `useWebViewScrollGroupScrRef()`) return the group's reference already converted into
-  the consuming project's versification. Prefer these over converting by hand.
+- **In React (renderer and web views), use the scroll-group hooks — they convert for you, given
+  your project.** `useScrollGroupScrRef(scrollGroupScrRef, setScrollGroupScrRef, projectId)` only
+  converts when you pass the consuming project's `projectId` as the third argument; omit it and the
+  hook returns the raw verse reference with no conversion and no error. Pass `projectId` whenever
+  conversion may be needed. Its web-view counterpart `useWebViewScrollGroupScrRef()` is unaffected —
+  it reads `projectId` from the web view definition automatically. Prefer these hooks over
+  converting by hand.
 - **Elsewhere (C#/Node, or non-React callers), use the PAPI command**
   `platformScripture.mapVerseRefBetweenProjects` directly. See its TSDoc/OpenRPC documentation for
   the exact contract.

--- a/.context/standards/Paranext-Core-Patterns.md
+++ b/.context/standards/Paranext-Core-Patterns.md
@@ -1014,6 +1014,30 @@ BookUSFM: DataProviderDataType<SerializedVerseRef, string | undefined, string>;
 
 ---
 
+## Scripture References Across Projects (Versification)
+
+A `SerializedVerseRef` is only meaningful in the **versification** of the project that produced it:
+the same book/chapter/verse numbers can point to a different verse — or to no verse — under another
+project's versification. **Any time a Scripture reference moves from one project to another** —
+scroll-group sync, cross-project navigation, showing one project's current reference in another
+project's editor or resource — the reference **must be converted into the target project's
+versification**. Never assume two projects share a versification.
+
+- **In React (renderer and web views), use the scroll-group hooks — they convert for you.**
+  `useScrollGroupScrRef(scrollGroupScrRef, setScrollGroupScrRef, projectId)` (and its web-view
+  counterpart `useWebViewScrollGroupScrRef()`) return the group's reference already converted into
+  the consuming project's versification. Prefer these over converting by hand.
+- **Elsewhere (C#/Node, or non-React callers), use the PAPI command**
+  `platformScripture.mapVerseRefBetweenProjects` directly. See its TSDoc/OpenRPC documentation for
+  the exact contract.
+
+**Do not skip the conversion just because both projects report the same
+`platformScripture.versification` setting.** That setting is only the base `ScrVersType` and does not
+capture `custom.vrs`, so two projects can report the same base type yet map differently. Let the
+hook or command decide with the real `ScrVers`; a genuinely identical versification is a cheap no-op.
+
+---
+
 ## Experimental APIs
 
 The `@experimental` marker applies to any PAPI surface — whether built into the platform or contributed by an extension. Mark an API experimental when it is not a confident, solid, general-purpose contract. Common cases:


### PR DESCRIPTION
## Summary

Docs-only. Documents that **any Scripture reference moving between projects** (scroll-group sync, cross-project navigation) must be converted into the target project's versification - never assume two projects share one. Fills the PT-4031 epic's Requirement #4 documentation gap (PT-4038).

### Why review this

Part of the current BCV-navigation epic (PT-4031, Requirement #4 "windows scroll together, versification-aware"). PT-4036 exposed the versification-mapping command and scroll-group sync now uses it; this records the rule so future cross-project reference code (navigation, sync, resource panes) does not silently drop versification. Please confirm the standards wording is accurate and lands in the right place.

## Changes

- **`.context/standards/Paranext-Core-Patterns.md`** - new "Scripture References Across Projects (Versification)" section:
  - the rule (a `SerializedVerseRef` is only valid in its source project's versification);
  - React callers use the scroll-group hooks `useScrollGroupScrRef` / `useWebViewScrollGroupScrRef`, which convert automatically;
  - other callers (C#/Node/non-React) use the `platformScripture.mapVerseRefBetweenProjects` PAPI command;
  - a warning not to skip conversion by comparing the base `platformScripture.versification` setting (it does not capture `custom.vrs`).
  - The exact command/hook contract is intentionally left to their TSDoc/OpenRPC docs.

## AI Involvement

AI-assisted. Content drafted by Claude Code from the merged PT-4036 implementation and the PT-4031/PT-4036 tickets; referenced hook and command names were verified to exist in the tree. Human-reviewed and trimmed.

## Testing

- [x] Docs-only - no code changed; `npx prettier --check` clean.

## Risk Level

**Low** - documentation only.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2534)
<!-- Reviewable:end -->
