### PR TITLE
fix: model-text panel follows the model resource's versification

### DIFF
--- a/extensions/src/platform-scripture-editor/src/model-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/model-text-panel.web-view.tsx
@@ -6,6 +6,7 @@ import {
   useLocalizedStrings,
   useProjectDataProvider,
   useProjectSetting,
+  useScrollGroupScrRef,
 } from '@papi/frontend/react';
 import { SerializedVerseRef } from '@sillsdev/scripture';
 import { usePromise } from 'platform-bible-react';
@@ -49,12 +50,10 @@ const ALL_STRING_KEYS: LocalizeKey[] = [
  */
 globalThis.webViewComponent = function ModelTextPanelWebView({
   projectId,
+  scrollGroupScrRef,
   updateWebViewDefinition,
-  useWebViewScrollGroupScrRef,
 }: WebViewProps) {
   const [localizedStrings] = useLocalizedStrings(useMemo(() => ALL_STRING_KEYS, []));
-
-  const [scrRef, setScrRef] = useWebViewScrollGroupScrRef();
 
   // --- Raw data sources ---
 
@@ -110,6 +109,28 @@ globalThis.webViewComponent = function ModelTextPanelWebView({
     ? dblResources.find((r) => r.dblEntryUid === dblRef.id && r.installed)
     : undefined;
   const modelTextSmallName = matchedInstalledResource?.displayName;
+
+  // Follow the scroll group in the RESOLVED MODEL RESOURCE's versification, not this panel's own
+  // (editable) project's. This web view's definition `projectId` is the editable project (it reads
+  // that project's `platformScripture.modelTexts` setting), but it renders the model resource — so
+  // passing the resource's id as the conversion project makes `scrRef` come back converted into the
+  // resource's versification and makes a verse click here stamp the resource as the scroll group's
+  // source project (other web views then convert FROM it). We call `useScrollGroupScrRef` directly
+  // (rather than the `useWebViewScrollGroupScrRef` prop) so we can pass that resource id instead of
+  // this web view's own `projectId`; the `scrollGroupScrRef` prop is kept live by the web-view host
+  // re-rendering the component on definition updates. `undefined` until a resource resolves — no
+  // conversion, and nothing is displayed yet anyway.
+  const modelResourceProjectId = matchedInstalledResource?.projectId;
+  const [scrRef, setScrRef] = useScrollGroupScrRef(
+    scrollGroupScrRef,
+    useCallback(
+      (newScrollGroupScrRef) =>
+        updateWebViewDefinition({ scrollGroupScrRef: newScrollGroupScrRef }),
+      [updateWebViewDefinition],
+    ),
+    modelResourceProjectId,
+  );
+
   useEffect(() => {
     const baseTitle = localizedStrings['%webView_modelTextPanel_title%'];
     if (!baseTitle) return;


### PR DESCRIPTION
## Problem

The model-text panel belongs to the **editable project** — its web-view definition `projectId` reads that project's `platformScripture.modelTexts` setting — but it renders a **different** project: the resolved model resource, which may use a different versification.

It followed the scroll group via the `useWebViewScrollGroupScrRef` prop, which converts the followed reference into the web view's **own** (editable-project) versification. So when the resource's versification differed from the editable project's (e.g. a VUL-based model resource next to a non-VUL project), the panel showed the wrong verse, and clicking a verse here stamped the *editable* project as the scroll group's source.

## Fix

Call `useScrollGroupScrRef` directly with the resolved resource's `projectId` as the conversion frame:

- `scrRef` now comes back converted into the **resource's** versification.
- A verse click stamps the **resource** as the scroll group's source project, so other web views convert *from* it.
- The `scrollGroupScrRef` prop stays live because the web-view host re-renders the component on definition updates, so nothing about the subscription is re-implemented.

`undefined` until a resource resolves — no conversion, and nothing is displayed yet anyway.

## Verification

Manually verified in Simple with a project and a model resource on different versifications (they now track to the correct, versification-mapped verse instead of the same numbers). Typecheck clean.

AI-assisted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2537)
<!-- Reviewable:end -->
