### PR TITLE
PT-4156: Show resource long name in View Options TEXTS list

### DIFF
--- a/extensions/src/platform-scripture-editor/src/resource-collection-options/resource-collection-options.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-collection-options/resource-collection-options.component.test.tsx
@@ -249,6 +249,27 @@ describe('ResourceCollectionOptions — truncated names', () => {
     renderComponent({ bottom: [row('u1', longName)] });
     expect(screen.getByText(longName)).toHaveAttribute('title', longName);
   });
+
+  it('renders the short name and long name when longName is set', () => {
+    renderComponent({
+      bottom: [row('niv', 'NIV', { longName: 'New International Version' })],
+    });
+    expect(screen.getByText('NIV')).toBeInTheDocument();
+    expect(screen.getByText('— New International Version')).toBeInTheDocument();
+  });
+
+  it('exposes the full "short — long" label via the title attribute', () => {
+    renderComponent({
+      bottom: [row('niv', 'NIV', { longName: 'New International Version' })],
+    });
+    expect(screen.getByTitle('NIV — New International Version')).toBeInTheDocument();
+  });
+
+  it('renders only the short name (no separator) when longName is absent', () => {
+    renderComponent({ bottom: [row('niv', 'NIV')] });
+    expect(screen.getByText('NIV')).toBeInTheDocument();
+    expect(screen.queryByText(/—/)).not.toBeInTheDocument();
+  });
 });
 
 describe('ResourceCollectionOptions locked-admin indicator', () => {

--- a/extensions/src/platform-scripture-editor/src/resource-collection-options/resource-collection-options.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-collection-options/resource-collection-options.component.tsx
@@ -84,19 +84,39 @@ export function ResourceCollectionOptions({
 
   const renderRow = (row: ViewOptionsTextEntry) => {
     const { id, name } = row.reference;
+    const { longName } = row;
+    // Composed in JS (not a raw JSX text node) so the em-dash separator does not trip
+    // no-hardcoded-jsx-strings.
+    const fullLabel = longName ? `${name} — ${longName}` : name;
     return (
-      <div key={id} className="tw:group tw:flex tw:items-center tw:gap-2 tw:py-1">
-        <Label className="tw:flex tw:flex-1 tw:items-center tw:gap-2 tw:font-normal">
+      <div key={id} className="tw:group tw:flex tw:min-w-0 tw:items-center tw:gap-2 tw:py-1">
+        <Label className="tw:flex tw:min-w-0 tw:flex-1 tw:items-center tw:gap-2 tw:font-normal">
           <Checkbox
             checked={row.checked}
             disabled={disabled}
             onCheckedChange={(checked) => onCheckedChange(id, checked === true)}
           />
-          {/* `title` carries the untruncated name so long DBL names stay readable in the narrow panel
-              (native tooltip on overflow — same read path as project-selector). */}
-          <span className="tw:flex-1 tw:truncate" title={name}>
-            {name}
-          </span>
+          {/* `title` carries the untruncated label so long DBL names stay readable in the narrow
+              panel (native tooltip on overflow). `dir="auto"` per name span keeps each name's
+              direction (and the separator) correct for RTL resources. */}
+          {longName ? (
+            <span className="tw:flex tw:min-w-0 tw:flex-1 tw:items-baseline" title={fullLabel}>
+              {/* Short name never truncates; only the long name ellipsizes when the row is tight.
+                  `dir="auto"` per name span keeps each name's direction (and the separator) correct
+                  for RTL resources. */}
+              <span className="tw:shrink-0" dir="auto">
+                {name}
+              </span>
+              <span
+                className="tw:min-w-0 tw:flex-1 tw:truncate"
+                dir="auto"
+              >{` — ${longName}`}</span>
+            </span>
+          ) : (
+            <span className="tw:min-w-0 tw:flex-1 tw:truncate" title={name} dir="auto">
+              {name}
+            </span>
+          )}
         </Label>
         {row.isUserRemovable && (
           <Button
@@ -107,7 +127,7 @@ export function ResourceCollectionOptions({
               localize(localizedStrings, RESOURCE_COLLECTION_OPTIONS_KEYS.removeFromList),
               { resourceName: name },
             )}
-            className="tw:opacity-0 tw:transition-opacity tw:group-hover:opacity-100 tw:focus-visible:opacity-100"
+            className="tw:shrink-0 tw:opacity-0 tw:transition-opacity tw:group-hover:opacity-100 tw:focus-visible:opacity-100"
             onClick={() => onRemoveFromList(id)}
           >
             <X className="tw:h-4 tw:w-4" />

--- a/extensions/src/platform-scripture-editor/src/resource-collection-options/resource-collection-options.stories.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-collection-options/resource-collection-options.stories.tsx
@@ -58,6 +58,24 @@ const USER_ROWS: ViewOptionsTextEntry[] = [
   },
 ];
 
+/** DBL rows carrying long names — the B9 (PT-4156) display: `short — long`. */
+const LONG_NAME_ROWS: ViewOptionsTextEntry[] = [
+  {
+    reference: dblRef('niv', 'NIV'),
+    checked: true,
+    isAdminLocked: true,
+    isUserRemovable: false,
+    longName: 'New International Version',
+  },
+  {
+    reference: dblRef('web', 'WEB'),
+    checked: true,
+    isAdminLocked: false,
+    isUserRemovable: true,
+    longName: 'World English Bible',
+  },
+];
+
 /** Interactive harness: holds the view mode + row checked-state locally. */
 function Harness({
   initialTop,
@@ -129,4 +147,59 @@ export const Installing: Story = {
 /** With Chapter enabled (the state a later chapter renderer unlocks) — both modes selectable. */
 export const ChapterEnabled: Story = {
   render: () => <Harness initialTop={ADMIN_ROWS} initialBottom={USER_ROWS} isChapterEnabled />,
+};
+
+/** Long names shown after the short name (`NIV — New International Version`) at the normal width. */
+export const LongNames: Story = {
+  render: () => <Harness initialTop={[LONG_NAME_ROWS[0]]} initialBottom={[LONG_NAME_ROWS[1]]} />,
+};
+
+/**
+ * The same rows constrained to a narrow container: the short name stays visible and the long name
+ * truncates with an ellipsis (pure CSS).
+ */
+export const LongNamesNarrow: Story = {
+  render: () => (
+    <div className="tw:w-48">
+      <Harness initialTop={[LONG_NAME_ROWS[0]]} initialBottom={[LONG_NAME_ROWS[1]]} />
+    </div>
+  ),
+};
+
+/**
+ * A realistic mix: one row has a long name, another has none — the latter renders its short name
+ * alone.
+ */
+export const MixedLongAndShort: Story = {
+  render: () => (
+    <Harness
+      initialTop={[LONG_NAME_ROWS[0]]}
+      initialBottom={[
+        {
+          reference: dblRef('esv', 'ESV'),
+          checked: true,
+          isAdminLocked: false,
+          isUserRemovable: true,
+        },
+      ]}
+    />
+  ),
+};
+
+/** RTL: a Hebrew resource name. `dir="auto"` flips the row to right-to-left from the name's script. */
+export const RightToLeftLongName: Story = {
+  render: () => (
+    <Harness
+      initialTop={[]}
+      initialBottom={[
+        {
+          reference: dblRef('wlc', 'תנ״ך'),
+          checked: true,
+          isAdminLocked: false,
+          isUserRemovable: true,
+          longName: 'כתבי הקודש העבריים',
+        },
+      ]}
+    />
+  ),
 };

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
@@ -377,6 +377,50 @@ describe('getViewOptionsTexts', () => {
     expect(bottom[0].checked).toBe(true);
     expect(bottom[0].isAdminLocked).toBe(false);
   });
+
+  it('stamps longName from the resolver onto rows', () => {
+    const { top } = getViewOptionsTexts(
+      makeSources({
+        adminReferenced: list([dbl('niv', { isInTextCollection: true })]),
+        overlay: { niv: true },
+      }),
+      (reference) => (reference.id === 'niv' ? 'New International Version' : undefined),
+    );
+    expect(top).toHaveLength(1);
+    expect(top[0].longName).toBe('New International Version');
+  });
+
+  it('omits longName entirely when the resolver returns undefined', () => {
+    const { top } = getViewOptionsTexts(
+      makeSources({
+        adminReferenced: list([dbl('niv', { isInTextCollection: true })]),
+        overlay: { niv: true },
+      }),
+      () => undefined,
+    );
+    expect(top[0]).not.toHaveProperty('longName');
+  });
+
+  it('leaves rows without a longName when no resolver is passed (backward compatible)', () => {
+    const { top } = getViewOptionsTexts(
+      makeSources({
+        adminReferenced: list([dbl('niv', { isInTextCollection: true })]),
+        overlay: { niv: true },
+      }),
+    );
+    expect(top[0]).not.toHaveProperty('longName');
+  });
+
+  it('stamps longName onto a user-referenced (bottom) row when the resolver returns one', () => {
+    const { bottom } = getViewOptionsTexts(
+      makeSources({
+        userReferenced: list([dbl('esv', { isInTextCollectionForUser: true })]),
+      }),
+      (reference) => (reference.id === 'esv' ? 'English Standard Version' : undefined),
+    );
+    expect(bottom).toHaveLength(1);
+    expect(bottom[0].longName).toBe('English Standard Version');
+  });
 });
 
 describe('setUserDisplay', () => {

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
@@ -10,9 +10,10 @@ import { CURRENT_DATA_VERSION } from './resource-reference-list.const';
 
 /**
  * A Bible-text reference — the only reference types that carry `id` and
- * `isInTextCollectionForUser`.
+ * `isInTextCollectionForUser`. Shared union used by both the grid-contents logic and the View
+ * Options long-name helpers.
  */
-type BibleTextReference = ProjectReference | DblResourceReference;
+export type BibleTextReference = ProjectReference | DblResourceReference;
 
 /**
  * The three data sources that together determine what a given user sees in the Text Collection.
@@ -49,6 +50,12 @@ export type ViewOptionsTextEntry = {
    * removed.
    */
   isUserRemovable: boolean;
+  /**
+   * The resource's long/full name, rendered after the short `name` (as `NIV — New International
+   * Version`) when present. Populated only for DBL resources whose cached `fullName` is available
+   * and differs from the short name; absent for project rows and uncached resources.
+   */
+  longName?: string;
 };
 
 /** An admin-owned entry: one Bible-text reference plus whether the admin currently flags it shown. */
@@ -164,7 +171,10 @@ export function getScriptureTextGridContents(sources: TextCollectionSources): Bi
  * `isInTextCollectionForUser` for the user's own entries. An admin-owned id never also appears as a
  * user entry (admin precedence).
  */
-export function getViewOptionsTexts(sources: TextCollectionSources): {
+export function getViewOptionsTexts(
+  sources: TextCollectionSources,
+  resolveLongName?: (reference: BibleTextReference) => string | undefined,
+): {
   top: ViewOptionsTextEntry[];
   bottom: ViewOptionsTextEntry[];
 } {
@@ -176,11 +186,13 @@ export function getViewOptionsTexts(sources: TextCollectionSources): {
 
   adminOwned.forEach((entry) => {
     adminIds.add(entry.reference.id);
-    const row = {
+    const longName = resolveLongName?.(entry.reference);
+    const row: ViewOptionsTextEntry = {
       reference: entry.reference,
       checked: isAdminEntryShown(overlay, entry),
       isAdminLocked: entry.adminFlagged,
       isUserRemovable: false,
+      ...(longName ? { longName } : {}),
     };
     (entry.adminFlagged ? top : bottom).push(row);
   });
@@ -188,11 +200,13 @@ export function getViewOptionsTexts(sources: TextCollectionSources): {
   userReferenced.items.forEach((item) => {
     if (!isProjectReference(item) && !isDblResourceReference(item)) return;
     if (adminIds.has(item.id)) return; // admin-owned ids are rendered by the loop above
+    const longName = resolveLongName?.(item);
     bottom.push({
       reference: item,
       checked: item.isInTextCollectionForUser === true,
       isAdminLocked: false,
       isUserRemovable: true,
+      ...(longName ? { longName } : {}),
     });
   });
 

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid.web-view.tsx
@@ -29,6 +29,7 @@ import {
   reorderShownIds,
   reconcileCellOrder,
 } from './scripture-text-grid-order.utils';
+import { resolveDblLongName } from './scripture-text-grid/view-options-long-name.utils';
 import {
   persistCellOrder,
   persistUserAddition,
@@ -205,16 +206,22 @@ globalThis.webViewComponent = function ScriptureTextGridWebView({
     return () => window.removeEventListener('keydown', handleKeyDown, true);
   }, [chapterContext, handleCloseChapterContext]);
 
-  const { top, bottom } = useMemo(
-    () => (sources ? getViewOptionsTexts(sources) : { top: [], bottom: [] }),
-    [sources],
-  );
-
   // The cached DBL resource list resolves DBL references (whose `id` is a DBL entry UID) to the
-  // installed project id the cell fetches chapter text with; project references need no lookup.
+  // installed project id the cell fetches chapter text with; project references need no lookup. It
+  // also supplies the DBL `fullName` shown as the long name in the View Options list.
   const [cachedResources, isLoadingCachedResources] = usePromise(
     useCallback(() => papi.commands.sendCommand('platformGetResources.getCachedResources'), []),
     undefined,
+  );
+
+  const { top, bottom } = useMemo(
+    () =>
+      sources
+        ? getViewOptionsTexts(sources, (reference) =>
+            resolveDblLongName(reference, cachedResources ?? []),
+          )
+        : { top: [], bottom: [] },
+    [sources, cachedResources],
   );
 
   // The grid body's cells: the `getOrderedScriptureTextGridContents` selector over the Text

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/dbl-resource-lookup.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/dbl-resource-lookup.utils.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import type { DblResourceData } from 'platform-bible-utils';
+import type { DblResourceReference } from 'platform-scripture';
+import { findCachedDblResource } from './dbl-resource-lookup.utils';
+
+const cached = (over: Partial<DblResourceData> & { dblEntryUid: string }): DblResourceData => ({
+  displayName: '',
+  fullName: '',
+  bestLanguageName: '',
+  type: 'ScriptureResource',
+  projectId: '',
+  installed: true,
+  size: 0,
+  updateAvailable: false,
+  ...over,
+});
+
+const dblRef = (id: string): DblResourceReference => ({ type: 'dblResource', name: 'x', id });
+
+describe('findCachedDblResource', () => {
+  it('returns the entry whose dblEntryUid matches the reference id', () => {
+    const entry = cached({ dblEntryUid: 'niv', fullName: 'New International Version' });
+    expect(findCachedDblResource(dblRef('niv'), [cached({ dblEntryUid: 'esv' }), entry])).toBe(
+      entry,
+    );
+  });
+
+  it('returns undefined when no cached entry matches', () => {
+    expect(findCachedDblResource(dblRef('niv'), [cached({ dblEntryUid: 'esv' })])).toBeUndefined();
+  });
+});

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/dbl-resource-lookup.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/dbl-resource-lookup.utils.ts
@@ -1,0 +1,15 @@
+import type { DblResourceData } from 'platform-bible-utils';
+import type { DblResourceReference } from 'platform-scripture';
+
+/**
+ * Finds the cached DBL resource entry a reference points to, matched by `dblEntryUid`. Callers
+ * guard `isDblResourceReference` and pass the narrowed reference; returns `undefined` when the
+ * resource is not in the cached list. Centralizes the match key so the grid-cell and long-name
+ * lookups stay in sync.
+ */
+export function findCachedDblResource(
+  reference: DblResourceReference,
+  cachedResources: DblResourceData[],
+): DblResourceData | undefined {
+  return cachedResources.find((resource) => resource.dblEntryUid === reference.id);
+}

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/grid-resources.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/grid-resources.utils.ts
@@ -1,10 +1,8 @@
 import type { DblResourceData } from 'platform-bible-utils';
-import type { DblResourceReference, ProjectReference } from 'platform-scripture';
 import { isDblResourceReference } from '../resource-reference.utils';
+import type { BibleTextReference } from '../scripture-text-grid-contents.utils';
+import { findCachedDblResource } from './dbl-resource-lookup.utils';
 import type { GridResource } from './resource-cell.component';
-
-/** The Bible-text references the grid can render — the reference types that carry a resource `id`. */
-type BibleTextReference = ProjectReference | DblResourceReference;
 
 /**
  * Maps the Bible-text references chosen for display to renderable grid cells. A cell fetches its
@@ -26,7 +24,7 @@ export function toGridResources(
   return references.flatMap((reference) => {
     let projectId: string | undefined;
     if (isDblResourceReference(reference)) {
-      const match = dblResources.find((resource) => resource.dblEntryUid === reference.id);
+      const match = findCachedDblResource(reference, dblResources);
       projectId = match?.installed ? match.projectId : undefined;
     } else {
       projectId = reference.id;

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/view-options-long-name.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/view-options-long-name.utils.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import type { DblResourceData } from 'platform-bible-utils';
+import type { DblResourceReference, ProjectReference } from 'platform-scripture';
+import { resolveDblLongName } from './view-options-long-name.utils';
+
+const cached = (over: Partial<DblResourceData> & { dblEntryUid: string }): DblResourceData => ({
+  displayName: '',
+  fullName: '',
+  bestLanguageName: '',
+  type: 'ScriptureResource',
+  size: 0,
+  installed: true,
+  updateAvailable: false,
+  projectId: '',
+  ...over,
+});
+
+const dblRef = (id: string, name: string): DblResourceReference => ({
+  type: 'dblResource',
+  name,
+  id,
+});
+const projectRef = (id: string, name: string): ProjectReference => ({ type: 'project', name, id });
+
+describe('resolveDblLongName', () => {
+  it('returns the DBL fullName when a cached entry matches and differs from the short name', () => {
+    const list = [
+      cached({ dblEntryUid: 'niv', displayName: 'NIV', fullName: 'New International Version' }),
+    ];
+    expect(resolveDblLongName(dblRef('niv', 'NIV'), list)).toBe('New International Version');
+  });
+
+  it('returns undefined for a project reference', () => {
+    // The cache entry intentionally shares the same id as the projectRef to prove that the
+    // isDblResourceReference type guard rejects the reference before any cache lookup runs —
+    // the matching cache hit is never consulted.
+    const list = [cached({ dblEntryUid: 'p1', displayName: 'P1', fullName: 'Project One' })];
+    expect(resolveDblLongName(projectRef('p1', 'P1'), list)).toBeUndefined();
+  });
+
+  it('returns undefined when no cached entry matches the id', () => {
+    expect(resolveDblLongName(dblRef('niv', 'NIV'), [])).toBeUndefined();
+  });
+
+  it('returns undefined when the cached fullName is empty', () => {
+    const list = [cached({ dblEntryUid: 'niv', displayName: 'NIV', fullName: '' })];
+    expect(resolveDblLongName(dblRef('niv', 'NIV'), list)).toBeUndefined();
+  });
+
+  it('returns undefined when the fullName equals the short name (no redundant "NIV — NIV")', () => {
+    const list = [cached({ dblEntryUid: 'niv', displayName: 'NIV', fullName: 'NIV' })];
+    expect(resolveDblLongName(dblRef('niv', 'NIV'), list)).toBeUndefined();
+  });
+});

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/view-options-long-name.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/view-options-long-name.utils.ts
@@ -1,0 +1,23 @@
+import type { DblResourceData } from 'platform-bible-utils';
+import type { BibleTextReference } from '../scripture-text-grid-contents.utils';
+import { isDblResourceReference } from '../resource-reference.utils';
+import { findCachedDblResource } from './dbl-resource-lookup.utils';
+
+/**
+ * Resolves the long/full name shown after a row's short name in the View Options TEXTS list.
+ *
+ * DBL resources only: finds the reference in the cached DBL resource list and returns its
+ * `fullName`. Returns `undefined` for project references, when no cached entry matches, when the
+ * cached `fullName` is empty, or when it equals the short `name` (which would render a redundant
+ * "NIV — NIV"). The short `name` on a DBL reference is the resource's `displayName` (see
+ * `selectTextConnection`), so this comparison is effectively `fullName !== displayName`.
+ */
+export function resolveDblLongName(
+  reference: BibleTextReference,
+  cachedResources: DblResourceData[],
+): string | undefined {
+  if (!isDblResourceReference(reference)) return undefined;
+  const fullName = findCachedDblResource(reference, cachedResources)?.fullName;
+  if (!fullName || fullName === reference.name) return undefined;
+  return fullName;
+}


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
## Summary

The **View Options panel's TEXTS list** (the resource checkbox list in the Scripture Text Grid) now shows a DBL resource's **full name after its short name** — e.g. `NIV — New International Version`. The short name is always visible; the full name truncates with an ellipsis when the row is narrow, and the full label is available on hover (`title`). DBL resources only — project rows are unchanged.

**No backend or data-model changes.** The full name is the DBL resource's existing `fullName`, read from the DBL resource list already cached in the grid web view.

**Scope:** ~11 files, all inside the `platform-scripture-editor` extension. No public API / `papi.d.ts` / `lib/` changes.

| Before | After (wide) | After (narrow) |
| --- | --- | --- |
| `NIV` | `NIV — New International Version` | `NIV — New Internati…` |

## What changed — files to review (in reading order)

| # | File | What it does |
| --- | --- | --- |
| 1 | `scripture-text-grid/view-options-long-name.utils.ts` **(new)** | `resolveDblLongName(ref, cached)` — the core rule. Returns the DBL `fullName`, or `undefined` for non-DBL / uncached / empty / when it equals the short name. Pure function, fully unit-tested. |
| 2 | `scripture-text-grid/dbl-resource-lookup.utils.ts` **(new)** | `findCachedDblResource` — one shared "find the cached DBL entry by `dblEntryUid`" lookup, so the grid-cell and long-name paths can't drift on the match key. |
| 3 | `scripture-text-grid-contents.utils.ts` | `getViewOptionsTexts` gains an **optional** `resolveLongName` param and stamps an **optional** `longName` onto each row (omitted when absent → backward compatible). Also exports the shared `BibleTextReference` type. |
| 4 | `scripture-text-grid.web-view.tsx` | Wires it up: passes a resolver over the already-cached DBL list. The one behavioral subtlety — `cachedResources` is declared **before** the rows `useMemo` and is in its dependency array, so long names appear once the cache resolves. |
| 5 | `resource-collection-options/resource-collection-options.component.tsx` | Renders the row: short name in a non-shrinking span + full name in a truncating span; `title` carries the whole label; `dir="auto"` per name span for RTL. Unchanged single-span path when there's no long name. |
| 6 | `scripture-text-grid/grid-resources.utils.ts` | Refactored to use the shared `findCachedDblResource` (no behavior change). |
| — | `*.test.ts(x)` + `resource-collection-options.stories.tsx` | Tests for every branch; 4 Storybook stories (normal, narrow, mixed long/short, RTL). |

**Fastest way to review:** read file **1** (the rule), then **5** (how it's shown). Everything else is wiring and tests.

## How to verify

- **Storybook:** `Bundled Extensions/platform-scripture-editor/ResourceCollectionOptions` → `LongNames`, `LongNamesNarrow`, `MixedLongAndShort`, `RightToLeftLongName`.
- **Tests:** `platform-scripture-editor` workspace — 385 passing. Typecheck + lint clean on all changed files.

## Notes for the reviewer

- **No Critical/Important findings.** All minor findings were fixed or dismissed (details below).
- **Label order** is intentionally `SHORT — Full Name` here, vs the resource dropdown's `Full Name (SHORT)` — short-first so the identifier survives truncation. Flagging in case the team wants a future consistency pass.
- **One untested seam:** the web-view wiring (file 4) has no automated test by design — the logic lives in the tested pure units. Worth a glance.
- **AI-assisted** implementation (design decisions were author-directed); please sanity-check the resolver's guards and the two-span rendering rather than assuming author-level familiarity.

<details>
<summary>Full review detail (findings, quality-gate output, accepted limitations)</summary>

### Findings

**Critical:** None. **Important:** None.

**Minor — all resolved:**
- ✅ **Fixed:** `package-lock.json` name-field churn reverted (an `npm install`-in-worktree artifact, not a dependency change).
- ✅ **Fixed:** DBL-lookup duplication → extracted shared `findCachedDblResource` + shared `BibleTextReference`.
- ✅ **Fixed:** new util relocated into `scripture-text-grid/` beside its siblings.
- ✅ **Fixed:** RTL bidi — `dir="auto"` moved onto each name span for deterministic separator placement.
- ⚪️ **Dismissed:** native `title` isn't keyboard-focusable — compliant with the Responsiveness guideline (full text is in the DOM + `title`; matches the pre-existing pattern).
- ⚪️ **Dismissed:** the new optional `resolveLongName` param — verified additive/non-breaking (noted for completeness).

### Backward compatibility

`resolveLongName` is optional and `longName` is omitted (not `undefined`) when absent; both the no-resolver and resolver-returns-undefined paths are regression-tested. The no-long-name row renders exactly as before.

### In-review quality gate (after the fixes above)

- **Typecheck:** clean (the only error is a pre-existing, unrelated `release/app/buildInfo.json` module error in `src/main/services/app.service-host.ts`).
- **Lint:** zero errors/warnings in all changed files.
- **Tests:** 22 files, 385 passing.

### Accepted limitations (documented, cosmetic)

- A DBL resource not yet in the cache shows just its short name until cached.
- One-frame short-name-only render before the cache resolves, then the long name appends.
- "Installing…" rows show no long name (separate render path with only a name string).

</details>
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2539)
<!-- Reviewable:end -->
