### PR TITLE
PT-4080: Comments tab scrolls to follow BCV navigation

### DIFF
--- a/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.test.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.test.ts
@@ -52,6 +52,11 @@ describe('findScrollTarget', () => {
     expect(findScrollTarget(threads, MRK_11_13)).toBeUndefined();
   });
 
+  it('returns bottom when unparseable threads are mixed with parseable ones all before the reference', () => {
+    const threads = [thread('junk', 'not a reference'), thread('a', 'MRK 11:1')];
+    expect(findScrollTarget(threads, MRK_11_13)).toEqual({ type: 'bottom' });
+  });
+
   it('resolves same-verse ties to the first thread in list order', () => {
     const threads = [thread('first', 'MRK 11:13'), thread('second', 'MRK 11:13')];
     expect(findScrollTarget(threads, MRK_11_13)).toEqual({ type: 'thread', threadId: 'first' });

--- a/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.test.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { findScrollTarget, ScrollRankableThread } from './comment-list-scroll.utils';
+import {
+  findScrollTarget,
+  ScrollRankableThread,
+  shouldArmSyncScroll,
+  toNavigationRecord,
+} from './comment-list-scroll.utils';
 
 function thread(id: string, verseRef: string): ScrollRankableThread {
   return { id, verseRef };
@@ -60,5 +65,51 @@ describe('findScrollTarget', () => {
   it('returns undefined when the current book is not a valid book id', () => {
     const threads = [thread('a', 'MRK 11:1')];
     expect(findScrollTarget(threads, { book: 'NOPE', chapterNum: 1, verseNum: 1 })).toBeUndefined();
+  });
+});
+
+describe('toNavigationRecord', () => {
+  it('parses a simple reference into book/chapter/verse', () => {
+    expect(toNavigationRecord('MRK 11:13')).toEqual({ book: 'MRK', chapterNum: 11, verseNum: 13 });
+  });
+
+  it('records the start verse of a verse range', () => {
+    expect(toNavigationRecord('MRK 11:13-14')).toEqual({
+      book: 'MRK',
+      chapterNum: 11,
+      verseNum: 13,
+    });
+  });
+
+  it('returns undefined for unparseable text', () => {
+    expect(toNavigationRecord('not a reference')).toBeUndefined();
+  });
+
+  it('returns undefined for undefined input', () => {
+    expect(toNavigationRecord(undefined)).toBeUndefined();
+  });
+});
+
+describe('shouldArmSyncScroll', () => {
+  it('arms when no self-initiated navigation is recorded', () => {
+    expect(shouldArmSyncScroll(undefined, MRK_11_13)).toBe(true);
+  });
+
+  it('does not arm when the change matches the recorded self-initiated navigation', () => {
+    expect(shouldArmSyncScroll({ book: 'MRK', chapterNum: 11, verseNum: 13 }, MRK_11_13)).toBe(
+      false,
+    );
+  });
+
+  it('arms when the change differs from the recorded navigation in any field', () => {
+    expect(shouldArmSyncScroll({ book: 'MRK', chapterNum: 11, verseNum: 14 }, MRK_11_13)).toBe(
+      true,
+    );
+    expect(shouldArmSyncScroll({ book: 'MRK', chapterNum: 12, verseNum: 13 }, MRK_11_13)).toBe(
+      true,
+    );
+    expect(shouldArmSyncScroll({ book: 'LUK', chapterNum: 11, verseNum: 13 }, MRK_11_13)).toBe(
+      true,
+    );
   });
 });

--- a/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.test.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { findScrollTarget, ScrollRankableThread } from './comment-list-scroll.utils';
+
+function thread(id: string, verseRef: string): ScrollRankableThread {
+  return { id, verseRef };
+}
+
+const MRK_11_13 = { book: 'MRK', chapterNum: 11, verseNum: 13 };
+
+describe('findScrollTarget', () => {
+  it('returns the thread at the current verse when one exists', () => {
+    const threads = [thread('a', 'MRK 11:1'), thread('b', 'MRK 11:13'), thread('c', 'MRK 11:20')];
+    expect(findScrollTarget(threads, MRK_11_13)).toEqual({ type: 'thread', threadId: 'b' });
+  });
+
+  it('returns the next thread in the chapter when the current verse has none', () => {
+    const threads = [thread('a', 'MRK 11:1'), thread('c', 'MRK 11:20')];
+    expect(findScrollTarget(threads, MRK_11_13)).toEqual({ type: 'thread', threadId: 'c' });
+  });
+
+  it('skips to a later book when nothing at/after the reference exists in this book', () => {
+    const threads = [thread('a', 'MRK 11:1'), thread('d', 'LUK 2:1')];
+    expect(findScrollTarget(threads, MRK_11_13)).toEqual({ type: 'thread', threadId: 'd' });
+  });
+
+  it('does not depend on the input order of threads', () => {
+    const threads = [thread('d', 'LUK 2:1'), thread('c', 'MRK 11:20'), thread('a', 'MRK 11:1')];
+    expect(findScrollTarget(threads, MRK_11_13)).toEqual({ type: 'thread', threadId: 'c' });
+  });
+
+  it('returns bottom when every thread is before the current reference', () => {
+    const threads = [thread('a', 'GEN 1:1'), thread('b', 'MRK 11:1')];
+    expect(findScrollTarget(threads, MRK_11_13)).toEqual({ type: 'bottom' });
+  });
+
+  it('returns undefined for an empty list', () => {
+    expect(findScrollTarget([], MRK_11_13)).toBeUndefined();
+  });
+
+  it('skips threads whose verseRef cannot be parsed', () => {
+    const threads = [thread('junk', 'not a reference'), thread('c', 'MRK 11:20')];
+    expect(findScrollTarget(threads, MRK_11_13)).toEqual({ type: 'thread', threadId: 'c' });
+  });
+
+  it('returns undefined when no thread has a parseable verseRef', () => {
+    const threads = [thread('junk1', ''), thread('junk2', 'not a reference')];
+    expect(findScrollTarget(threads, MRK_11_13)).toBeUndefined();
+  });
+
+  it('resolves same-verse ties to the first thread in list order', () => {
+    const threads = [thread('first', 'MRK 11:13'), thread('second', 'MRK 11:13')];
+    expect(findScrollTarget(threads, MRK_11_13)).toEqual({ type: 'thread', threadId: 'first' });
+  });
+
+  it('ranks a verse-range reference by its start verse', () => {
+    const threads = [thread('range', 'MRK 11:13-14')];
+    expect(findScrollTarget(threads, MRK_11_13)).toEqual({ type: 'thread', threadId: 'range' });
+  });
+
+  it('returns undefined when the current book is not a valid book id', () => {
+    const threads = [thread('a', 'MRK 11:1')];
+    expect(findScrollTarget(threads, { book: 'NOPE', chapterNum: 1, verseNum: 1 })).toBeUndefined();
+  });
+});

--- a/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.ts
@@ -37,6 +37,7 @@ export function findScrollTarget(
 ): CommentListScrollTarget {
   // Guard before calling scrRefToBBBCCCVVV, which assumes a known book id.
   if (Canon.bookIdToNumber(scrRef.book) <= 0) return undefined;
+
   const currentPosition = scrRefToBBBCCCVVV(scrRef);
 
   let bestThreadId: string | undefined;
@@ -46,10 +47,12 @@ export function findScrollTarget(
   threads.forEach((thread) => {
     const { success, verseRef } = VerseRef.tryParse(thread.verseRef ?? '');
     if (!success || verseRef.bookNum <= 0) return;
+
     hasRankableThread = true;
     // For a verse range, verseNum is the start verse, so ranges rank by where they begin.
     const threadPosition = verseRef.BBBCCCVVV;
     if (threadPosition < currentPosition) return;
+
     // Strict < keeps the FIRST thread in list order when several share a verse.
     if (threadPosition < bestPosition) {
       bestPosition = threadPosition;
@@ -77,6 +80,7 @@ export type NavigationRecord = Pick<SerializedVerseRef, 'book' | 'chapterNum' | 
 export function toNavigationRecord(verseRefText: string | undefined): NavigationRecord | undefined {
   const { verseRef } = VerseRef.tryParse(verseRefText ?? '');
   if (!verseRef.valid) return undefined;
+
   return { book: verseRef.book, chapterNum: verseRef.chapterNum, verseNum: verseRef.verseNum };
 }
 
@@ -94,6 +98,7 @@ export function shouldArmSyncScroll(
   scrRef: SerializedVerseRef,
 ): boolean {
   if (!selfInitiatedNavigation) return true;
+
   return (
     selfInitiatedNavigation.book !== scrRef.book ||
     selfInitiatedNavigation.chapterNum !== scrRef.chapterNum ||

--- a/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.ts
@@ -1,4 +1,6 @@
 import { Canon, VerseRef } from '@sillsdev/scripture';
+import type { SerializedVerseRef } from '@sillsdev/scripture';
+import { scrRefToBBBCCCVVV } from 'platform-bible-utils';
 import type { LegacyCommentThread } from 'platform-bible-utils';
 
 // Finds where the comment list should scroll when the scroll-group BCV reference changes
@@ -18,10 +20,6 @@ export type CommentListScrollTarget =
   | { type: 'bottom' }
   | undefined;
 
-function toBbbCccVvv(bookNum: number, chapterNum: number, verseNum: number): number {
-  return bookNum * 1_000_000 + chapterNum * 1_000 + verseNum;
-}
-
 /**
  * Finds the thread the comment list should scroll to for the current scripture reference: the
  * thread with the smallest reference at or after `scrRef`, compared at verse granularity. A
@@ -35,11 +33,11 @@ function toBbbCccVvv(bookNum: number, chapterNum: number, verseNum: number): num
  */
 export function findScrollTarget(
   threads: readonly ScrollRankableThread[],
-  scrRef: { book: string; chapterNum: number; verseNum: number },
+  scrRef: SerializedVerseRef,
 ): CommentListScrollTarget {
-  const currentBookNum = Canon.bookIdToNumber(scrRef.book);
-  if (currentBookNum <= 0) return undefined;
-  const currentPosition = toBbbCccVvv(currentBookNum, scrRef.chapterNum, scrRef.verseNum);
+  // Guard before calling scrRefToBBBCCCVVV, which assumes a known book id.
+  if (Canon.bookIdToNumber(scrRef.book) <= 0) return undefined;
+  const currentPosition = scrRefToBBBCCCVVV(scrRef);
 
   let bestThreadId: string | undefined;
   let bestPosition = Number.POSITIVE_INFINITY;
@@ -61,4 +59,44 @@ export function findScrollTarget(
 
   if (bestThreadId !== undefined) return { type: 'thread', threadId: bestThreadId };
   return hasRankableThread ? { type: 'bottom' } : undefined;
+}
+
+/**
+ * A book/chapter/verse position recorded when the comment list itself initiates navigation
+ * (clicking a thread's verse reference, or the editor's "go to comment" selecting a thread).
+ */
+export type NavigationRecord = Pick<SerializedVerseRef, 'book' | 'chapterNum' | 'verseNum'>;
+
+/**
+ * Parses a thread's verse reference into a {@link NavigationRecord} for self-initiated-navigation
+ * tracking. A verse range records its start verse.
+ *
+ * @param verseRefText The thread's verse reference text
+ * @returns The parsed record, or `undefined` when the reference cannot be parsed
+ */
+export function toNavigationRecord(verseRefText: string | undefined): NavigationRecord | undefined {
+  const { verseRef } = VerseRef.tryParse(verseRefText ?? '');
+  if (!verseRef.valid) return undefined;
+  return { book: verseRef.book, chapterNum: verseRef.chapterNum, verseNum: verseRef.verseNum };
+}
+
+/**
+ * Whether a scroll-group reference change should arm a BCV-sync scroll. A change matching the
+ * reference this view itself navigated to must NOT arm one — a click inside the comment list must
+ * never scroll the comment list.
+ *
+ * @param selfInitiatedNavigation The one-shot record of the view's own navigation, if any
+ * @param scrRef The incoming scroll-group scripture reference
+ * @returns `true` when the sync scroll should be armed
+ */
+export function shouldArmSyncScroll(
+  selfInitiatedNavigation: NavigationRecord | undefined,
+  scrRef: SerializedVerseRef,
+): boolean {
+  if (!selfInitiatedNavigation) return true;
+  return (
+    selfInitiatedNavigation.book !== scrRef.book ||
+    selfInitiatedNavigation.chapterNum !== scrRef.chapterNum ||
+    selfInitiatedNavigation.verseNum !== scrRef.verseNum
+  );
 }

--- a/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-scroll.utils.ts
@@ -1,0 +1,64 @@
+import { Canon, VerseRef } from '@sillsdev/scripture';
+import type { LegacyCommentThread } from 'platform-bible-utils';
+
+// Finds where the comment list should scroll when the scroll-group BCV reference changes
+// (PT-4080). Pure and DOM-free so the ranking rules are unit-testable; the web view maps the
+// returned target to actual DOM scrolling.
+
+/** The subset of comment-thread data the scroll-target search needs. */
+export type ScrollRankableThread = Pick<LegacyCommentThread, 'id' | 'verseRef'>;
+
+/**
+ * Where the comment list should scroll after a BCV change: a specific thread (scrolled to the top
+ * of the list), the bottom of the list (the reference is past every loaded thread), or nowhere
+ * (`undefined` — nothing rankable to scroll to).
+ */
+export type CommentListScrollTarget =
+  | { type: 'thread'; threadId: string }
+  | { type: 'bottom' }
+  | undefined;
+
+function toBbbCccVvv(bookNum: number, chapterNum: number, verseNum: number): number {
+  return bookNum * 1_000_000 + chapterNum * 1_000 + verseNum;
+}
+
+/**
+ * Finds the thread the comment list should scroll to for the current scripture reference: the
+ * thread with the smallest reference at or after `scrRef`, compared at verse granularity. A
+ * verse-range reference (e.g. `MRK 11:13-14`) ranks by its start verse. Same-verse ties resolve to
+ * the earliest thread in list order. Threads whose `verseRef` cannot be parsed are skipped.
+ *
+ * @param threads The currently loaded (already filtered) comment threads, in list render order
+ * @param scrRef The current scroll-group scripture reference
+ * @returns The target thread, `{ type: 'bottom' }` when rankable threads exist but all are before
+ *   `scrRef`, or `undefined` when there is nothing rankable (or `scrRef.book` is unknown)
+ */
+export function findScrollTarget(
+  threads: readonly ScrollRankableThread[],
+  scrRef: { book: string; chapterNum: number; verseNum: number },
+): CommentListScrollTarget {
+  const currentBookNum = Canon.bookIdToNumber(scrRef.book);
+  if (currentBookNum <= 0) return undefined;
+  const currentPosition = toBbbCccVvv(currentBookNum, scrRef.chapterNum, scrRef.verseNum);
+
+  let bestThreadId: string | undefined;
+  let bestPosition = Number.POSITIVE_INFINITY;
+  let hasRankableThread = false;
+
+  threads.forEach((thread) => {
+    const { success, verseRef } = VerseRef.tryParse(thread.verseRef ?? '');
+    if (!success || verseRef.bookNum <= 0) return;
+    hasRankableThread = true;
+    // For a verse range, verseNum is the start verse, so ranges rank by where they begin.
+    const threadPosition = verseRef.BBBCCCVVV;
+    if (threadPosition < currentPosition) return;
+    // Strict < keeps the FIRST thread in list order when several share a verse.
+    if (threadPosition < bestPosition) {
+      bestPosition = threadPosition;
+      bestThreadId = thread.id;
+    }
+  });
+
+  if (bestThreadId !== undefined) return { type: 'thread', threadId: bestThreadId };
+  return hasRankableThread ? { type: 'bottom' } : undefined;
+}

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -122,7 +122,7 @@ global.webViewComponent = function CommentListWebView({
     selfInitiatedNavigationRef.current = undefined;
     if (
       !shouldArmSyncScroll(selfInitiatedNavigation, {
-        // TODO: Handle versification
+        // TODO (PT-4031): Handle versification
         book: scrRef.book,
         chapterNum: scrRef.chapterNum,
         verseNum: scrRef.verseNum,

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -29,6 +29,7 @@ import {
   ScopeFilter,
   UNFILTERED,
 } from './comment-list-filters.model';
+import { findScrollTarget } from './comment-list-scroll.utils';
 
 const DEFAULT_LEGACY_COMMENT_THREADS: LegacyCommentThread[] = [];
 
@@ -84,6 +85,24 @@ global.webViewComponent = function CommentListWebView({
   const [pendingThreadIdToSelect, setPendingThreadIdToSelect] = useState<string | undefined>(
     undefined,
   );
+
+  /**
+   * Scroll behavior for a due BCV-sync scroll (PT-4080). `'instant'` initially so the list opens
+   * already positioned at the current reference; `'smooth'` for subsequent scroll-group navigation.
+   * `undefined` means no sync scroll is due. Consumed only when thread data is not loading, so a
+   * chapter-scope requery finishes before the scroll runs.
+   */
+  const [pendingSyncScrollBehavior, setPendingSyncScrollBehavior] = useState<
+    ScrollBehavior | undefined
+  >('instant');
+
+  // Arm a sync scroll whenever the scroll-group reference changes. This also runs on mount, where
+  // `?? ` preserves the initial 'instant' behavior instead of downgrading it to 'smooth'. Note this
+  // deliberately does NOT unfreeze the all-books selector: the query inputs stay frozen (see
+  // usesChapterScope below); a verse move only scrolls the already-loaded list.
+  useEffect(() => {
+    setPendingSyncScrollBehavior((previous) => previous ?? 'smooth');
+  }, [scrRef.book, scrRef.chapterNum, scrRef.verseNum]);
 
   // Initial filter/scope axes passed by openCommentList when opening a NEW comment list (e.g. the
   // S/R conflict link). Read from web view state so a new view mounts already-filtered — avoiding the
@@ -153,6 +172,8 @@ global.webViewComponent = function CommentListWebView({
         // the current loading state synchronously here. The pending thread will be processed
         // by the effect below once loading completes.
         trySelectThread(data.threadId, true);
+        // The explicit "go to comment" navigation wins over any due BCV-sync scroll (PT-4080).
+        setPendingSyncScrollBehavior(undefined);
       }
 
       if (data?.method === 'setFilters') {
@@ -241,6 +262,35 @@ global.webViewComponent = function CommentListWebView({
     }
     return undefined;
   }, [isLoadingCommentThreads, pendingThreadIdToSelect, trySelectThread]);
+
+  // Consume the pending BCV-sync scroll once thread data has settled. Scroll only — selection and
+  // expansion are never changed here. An explicit selectThread navigation (the editor's "go to
+  // comment" flow) is the more specific intent, so it wins and the sync scroll is dropped.
+  useEffect(() => {
+    if (pendingSyncScrollBehavior === undefined || isLoadingCommentThreads) return;
+    if (pendingThreadIdToSelect) {
+      setPendingSyncScrollBehavior(undefined);
+      return;
+    }
+    const target = findScrollTarget(safeCommentThreads, scrRef);
+    if (target?.type === 'thread') {
+      document
+        .getElementById(target.threadId)
+        ?.scrollIntoView({ behavior: pendingSyncScrollBehavior, block: 'start' });
+    } else if (target?.type === 'bottom') {
+      // Past every loaded thread: show the end of the list (the user can scroll up).
+      document
+        .getElementById('comment-list')
+        ?.lastElementChild?.scrollIntoView({ behavior: pendingSyncScrollBehavior, block: 'end' });
+    }
+    setPendingSyncScrollBehavior(undefined);
+  }, [
+    pendingSyncScrollBehavior,
+    isLoadingCommentThreads,
+    pendingThreadIdToSelect,
+    safeCommentThreads,
+    scrRef,
+  ]);
 
   const fetchAssignableUsers = useCallback(
     async () =>

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -318,14 +318,22 @@ global.webViewComponent = function CommentListWebView({
     }
     const target = findScrollTarget(safeCommentThreads, scrRef);
     if (target?.type === 'thread') {
-      document
-        .getElementById(target.threadId)
-        ?.scrollIntoView({ behavior: pendingSyncScrollBehavior, block: 'start' });
+      const threadElement = document.getElementById(target.threadId);
+      if (threadElement)
+        threadElement.scrollIntoView({ behavior: pendingSyncScrollBehavior, block: 'start' });
+      else logger.debug(`BCV-sync scroll: thread element not found: ${target.threadId}`);
     } else if (target?.type === 'bottom') {
-      // Past every loaded thread: show the end of the list (the user can scroll up).
-      document
-        .getElementById('comment-list')
-        ?.lastElementChild?.scrollIntoView({ behavior: pendingSyncScrollBehavior, block: 'end' });
+      // Past every loaded thread: show the end of the list (the user can scroll up). A 'bottom'
+      // target guarantees at least one loaded thread, so the list and its children should exist;
+      // either miss below means the DOM contract with platform-bible-react's CommentList broke.
+      const listElement = document.getElementById('comment-list');
+      const lastThreadElement = listElement?.lastElementChild;
+      if (lastThreadElement)
+        lastThreadElement.scrollIntoView({ behavior: pendingSyncScrollBehavior, block: 'end' });
+      else
+        logger.debug(
+          `BCV-sync scroll: #comment-list ${listElement ? 'has no children to scroll to' : 'element not found'}`,
+        );
     }
     setPendingSyncScrollBehavior(undefined);
   }, [

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -10,7 +10,7 @@ import {
   sonner,
   usePromise,
 } from 'platform-bible-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   useLocalizedStrings,
   useProjectData,
@@ -29,7 +29,12 @@ import {
   ScopeFilter,
   UNFILTERED,
 } from './comment-list-filters.model';
-import { findScrollTarget } from './comment-list-scroll.utils';
+import {
+  findScrollTarget,
+  NavigationRecord,
+  shouldArmSyncScroll,
+  toNavigationRecord,
+} from './comment-list-scroll.utils';
 
 const DEFAULT_LEGACY_COMMENT_THREADS: LegacyCommentThread[] = [];
 
@@ -96,11 +101,34 @@ global.webViewComponent = function CommentListWebView({
     ScrollBehavior | undefined
   >('instant');
 
+  /**
+   * One-shot record of the scripture reference this view itself navigated to — by clicking a
+   * thread's verse reference, or via the editor's "go to comment" selecting a thread. The matching
+   * incoming scroll-group change is consumed without arming a sync scroll: a click inside the
+   * comment list must never scroll the comment list. Any other scrRef change clears the record.
+   */
+  const selfInitiatedNavigationRef = useRef<NavigationRecord | undefined>(undefined);
+
+  /** Latest loaded threads, readable from the stable message listener without re-subscribing it. */
+  const commentThreadsRef = useRef<LegacyCommentThread[]>([]);
+
   // Arm a sync scroll whenever the scroll-group reference changes. This also runs on mount, where
   // `?? ` preserves the initial 'instant' behavior instead of downgrading it to 'smooth'. Note this
   // deliberately does NOT unfreeze the all-books selector: the query inputs stay frozen (see
-  // usesChapterScope below); a verse move only scrolls the already-loaded list.
+  // usesChapterScope below); a verse move only scrolls the already-loaded list. A change this view
+  // itself initiated (see selfInitiatedNavigationRef) is swallowed instead of armed.
   useEffect(() => {
+    const selfInitiatedNavigation = selfInitiatedNavigationRef.current;
+    selfInitiatedNavigationRef.current = undefined;
+    if (
+      !shouldArmSyncScroll(selfInitiatedNavigation, {
+        // TODO: Handle versification
+        book: scrRef.book,
+        chapterNum: scrRef.chapterNum,
+        verseNum: scrRef.verseNum,
+      })
+    )
+      return;
     setPendingSyncScrollBehavior((previous) => previous ?? 'smooth');
   }, [scrRef.book, scrRef.chapterNum, scrRef.verseNum]);
 
@@ -174,6 +202,13 @@ global.webViewComponent = function CommentListWebView({
         trySelectThread(data.threadId, true);
         // The explicit "go to comment" navigation wins over any due BCV-sync scroll (PT-4080).
         setPendingSyncScrollBehavior(undefined);
+        // The editor's caret move for this navigation may deliver its scroll-group change AFTER
+        // this message; record the thread's reference so that late change doesn't scroll the list
+        // away from the selection either.
+        const selectedThread = commentThreadsRef.current.find(
+          (thread) => thread.id === data.threadId,
+        );
+        selfInitiatedNavigationRef.current = toNavigationRecord(selectedThread?.verseRef);
       }
 
       if (data?.method === 'setFilters') {
@@ -250,6 +285,11 @@ global.webViewComponent = function CommentListWebView({
     if (!commentThreads || isPlatformError(commentThreads)) return [];
     return commentThreads;
   }, [commentThreads]);
+
+  // Mirror the loaded threads into the ref the stable message listener reads.
+  useEffect(() => {
+    commentThreadsRef.current = safeCommentThreads;
+  }, [safeCommentThreads]);
 
   // Process any pending thread selection once data finishes loading
   useEffect(() => {
@@ -438,6 +478,10 @@ global.webViewComponent = function CommentListWebView({
     (thread: LegacyCommentThread) => {
       const { verseRef } = VerseRef.tryParse(thread.verseRef ?? '');
       if (!verseRef.valid) return;
+
+      // This view is causing the upcoming scroll-group change; a click inside the list must never
+      // scroll the list, so record the reference for the arm effect to swallow.
+      selfInitiatedNavigationRef.current = toNavigationRecord(thread.verseRef);
 
       if (editorWebViewId && editorWebViewController) {
         papi.window.setFocus({ focusType: 'webView', id: editorWebViewId });

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -129,6 +129,7 @@ global.webViewComponent = function CommentListWebView({
       })
     )
       return;
+
     setPendingSyncScrollBehavior((previous) => previous ?? 'smooth');
   }, [scrRef.book, scrRef.chapterNum, scrRef.verseNum]);
 
@@ -176,6 +177,13 @@ global.webViewComponent = function CommentListWebView({
       setSelectedThreadId(threadId);
       threadElement.scrollIntoView({ behavior: 'smooth', block: 'center' });
       setPendingThreadIdToSelect(undefined);
+      // The editor's caret move for this navigation may deliver its scroll-group change after
+      // this point; record the thread's reference so that late change doesn't scroll the list
+      // away from the selection. Recording here (not in the message handler) covers the deferred
+      // path too: when the message arrived before thread data loaded, the data is loaded by the
+      // time this success branch runs, so the lookup cannot miss.
+      const selectedThread = commentThreadsRef.current.find((thread) => thread.id === threadId);
+      selfInitiatedNavigationRef.current = toNavigationRecord(selectedThread?.verseRef);
       return true;
     }
 
@@ -201,14 +209,9 @@ global.webViewComponent = function CommentListWebView({
         // by the effect below once loading completes.
         trySelectThread(data.threadId, true);
         // The explicit "go to comment" navigation wins over any due BCV-sync scroll (PT-4080).
+        // (trySelectThread records the thread's reference as self-initiated navigation when the
+        // selection succeeds, guarding against the editor's caret move arriving after it.)
         setPendingSyncScrollBehavior(undefined);
-        // The editor's caret move for this navigation may deliver its scroll-group change AFTER
-        // this message; record the thread's reference so that late change doesn't scroll the list
-        // away from the selection either.
-        const selectedThread = commentThreadsRef.current.find(
-          (thread) => thread.id === data.threadId,
-        );
-        selfInitiatedNavigationRef.current = toNavigationRecord(selectedThread?.verseRef);
       }
 
       if (data?.method === 'setFilters') {
@@ -308,6 +311,7 @@ global.webViewComponent = function CommentListWebView({
   // comment" flow) is the more specific intent, so it wins and the sync scroll is dropped.
   useEffect(() => {
     if (pendingSyncScrollBehavior === undefined || isLoadingCommentThreads) return;
+
     if (pendingThreadIdToSelect) {
       setPendingSyncScrollBehavior(undefined);
       return;


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-4080-comments-tab-syncs-to-bcv

**Base**: origin/main

**Date**: 2026-07-13

**Review model**: Claude Fable 5

**Files changed**: 3

## Overview

Implements PT-4080: the Comments tab now follows Book/Chapter/Verse navigation. On any scroll-group reference change, the list scrolls the first thread at-or-after the current reference to the top of the list (scroll only — selection, expansion, and focus are never touched). If threads exist but all precede the reference, the list scrolls to the bottom; an empty (filtered) list shows the existing empty-state message. In "All books" scope the query stays frozen (verse moves never re-run the C# query — the list only scrolls); in "Current chapter" scope the existing requery completes before the scroll runs. The list opens already positioned (instant) and animates (smooth) on subsequent navigation.

The ranking logic lives in a pure, DOM-free utility (`findScrollTarget`) with 18 unit tests, wired into the web view via a small armed/consumed effect pair. During this review, an origin-tracking guard was added so the list never scrolls itself in response to navigation the user initiated by clicking inside the list (verse-ref click, editor "go to comment").

## API Changes

None. All three changed files are internal to the `legacy-comment-manager` extension (`comment-list-scroll.utils.ts`, its test, and `comment-list.web-view.tsx`). No changes to `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `papi.d.ts`, or any extension type declaration file. The new exports (`findScrollTarget`, `shouldArmSyncScroll`, `toNavigationRecord`, and their types) are extension-internal, not public API surface.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **The list scrolled itself in response to its own verse-ref navigation** — `handleVerseRefClick` propagates a scroll-group change straight back into the view, and the arm effect had no origin check _(fixed during review: added a one-shot `selfInitiatedNavigationRef` record set by `handleVerseRefClick`; the arm effect swallows the matching incoming change — a click inside the comment list never scrolls the comment list)_
- [x] **The `selectThread` precedence guard was ordering-dependent** — a caret-driven scrRef update landing after the editor's "go to comment" message could re-arm the sync scroll and override the selection's centered scroll _(fixed during review: the `selectThread` handler also records the selected thread's reference in the same one-shot record, closing the late-arrival path)_

Author response: The author drove the fix design — he first proposed suppressing when the selected thread matches the incoming reference and is already visible, then chose origin tracking after learning that the verse-ref click does not select the thread (its `onClick` stops propagation), so a selection-based check would miss the most common case. The decision logic was extracted into pure, unit-tested helpers (`shouldArmSyncScroll`, `toNavigationRecord`) at his request.

### Minor — Consider

- [ ] ~~`findScrollTarget` could rank an all-deleted thread that `CommentList` drops, making the scroll a silent no-op~~ _(author: the C# provider always filters all-deleted threads before returning — `ParatextProjectDataProvider.GetCommentThreads` — so this is unreachable; no change needed)_
- [x] **Local `toBbbCccVvv` duplicated `scrRefToBBBCCCVVV` from platform-bible-utils** _(fixed during review: the utils now use `scrRefToBBBCCCVVV` and type references as `SerializedVerseRef`; the `Canon.bookIdToNumber` guard remains in front since the shared util assumes a known book)_
- [ ] **Hardcoded `#comment-list` DOM-id coupling across the package boundary** (defined in platform-bible-react; a rename there silently breaks the scroll-to-bottom branch). Author decision: defer to a small follow-on PR — either export the id as a constant from platform-bible-react, or expose scrolling on the `CommentList` component itself (imperative `scrollToThread`/`scrollToEnd` handle; preferred if the existing `selectThread` scroll migrates too). Kept out of this PR to avoid platform-bible-react churn holding up the feature.
- [ ] ~~No automated coverage of the DOM scroll wiring~~ _(author: Playwright e2e tests are deliberately deferred to a follow-up PR — required by PT-4080's Definition of Done, so the ticket stays open until that lands)_
- [ ] ~~Two scroll alignments coexist: "go to comment" centers the thread; BCV sync aligns to top~~ _(author: plausibly intentional; UX asked to confirm in the Jira issue — will change later if UX wants, not holding this PR)_
- [ ] ~~`behavior: 'smooth'` ignores `prefers-reduced-motion`~~ _(author: platform-wide concern, matches the pre-existing selectThread scroll; tracked as [PT-4172](https://paratextstudio.atlassian.net/browse/PT-4172))_
- [ ] ~~A BCV change while composing a comment scrolls the viewport away from the open composer~~ _(author: composing comments should stay on screen — checking with UX; deferred to a follow-up PR with a local evaluation spec written (recommended approach: an `onComposingChange` prop on the comment components, with the web view dropping the sync scroll while composing))_

Author response: Author dispositioned every minor finding explicitly — one fixed in-review, one dismissed on the provider contract, and the rest deferred with concrete follow-up homes (follow-on PR, Jira PT-4172, UX confirmation).

### Template Propagation

#### Shared Regions Modified

None. (The extension's `tailwind.css` and `webpack-env.d.ts` contain shared-region markers but were not changed; the three changed files contain none.)

#### Extension Config Changes

None. Only extension source/test files changed.

## Positive Observations

- Ranking logic extracted into a pure, DOM-free module with 18 behavior-focused unit tests (exact match, next-in-chapter, next-book fallthrough, order independence, past-end → bottom, empty list, unparseable refs, same-verse ties, verse ranges, invalid book, and the origin-tracking swallow decision) — matching the extension's established `*.utils.ts` + `*.utils.test.ts` pattern.
- Implements exactly the documented interaction pattern for scripture-related list tabs (`application-interactions.mdx`: Comments follows the scroll group "on Scripture reference change").
- Scroll-only by design: selection, expansion, focus, and the listbox `aria-activedescendant` state are untouched, so the sync never steals keyboard focus or disrupts an in-progress interaction.
- The all-books selector freeze is preserved — verse moves scroll the already-loaded list without tearing down the C# subscription — and the `'instant'`-on-open vs `'smooth'`-thereafter distinction avoids an animation flourish on load.
- DOM contract verified real, not assumed: thread cards carry `id={threadId}` and the container `id="comment-list"`; the filter toolbar sits outside the scroll container so `block: 'start'` cannot hide the target under it.
- Intent comments throughout the web view explain the non-obvious invariants (why the arm effect depends on three primitives, why explicit navigation wins, why the query inputs stay frozen).

## Interview Notes

- **Purpose**: PT-4080 — Comments tab content follows BCV navigation (scroll the next comment at/after the current reference to the top of the list; bottom when past everything; chapter-scope empty state already existed).
- **Key decisions**: scroll-only (no selection/highlight change); scroll-to-bottom when past the last comment; same-verse re-selection and clicks within the current verse must never scroll (arm-effect deps are deliberately the three primitive values, not the `scrRef` object); e2e tests deferred to a follow-up PR per pragmatic sequencing (author noted the existing e2e suite's flakiness).
- **Origin-tracking design** (the in-review fix): author probed the one-shot record's staleness semantics before approving — the record is cleared unconditionally on every scrRef change, and a navigation *to* the recorded verse requires an intervening navigation *away* that already cleared it, so a stale record cannot swallow a later genuine move.
- **Known narrow exception (author asked that reviewers see this)**: if two rapid navigations (away and back to the recorded verse) batch into a single React commit, the arm effect sees only the final value, which matches the record, and one genuine sync scroll is swallowed. It self-heals immediately (the record is consumed on use), and the author judged that a user navigating that fast likely wouldn't want the scroll anyway — but it was considered, not overlooked.
- **Versification**: the author added a `TODO: Handle versification` comment at the arm effect's reference construction — reference comparison currently uses raw book/chapter/verse numbers without versification mapping, consistent with how `handleVerseRefClick` already treats these refs.
- The author demonstrated thorough understanding throughout — he identified the staleness question and the unit-testability gap himself, and directed the extraction of the pure helpers. No areas of uncertainty or AI-deferral to flag.

## In-Review Quality Check

All checks passed with no fixes required: `npm run typecheck` clean across all workspaces; `npm run lint` zero errors (two pre-existing unrelated warnings in platform-scripture-editor); targeted extensions-workspace lint of the three changed files clean; Prettier reported all three files already formatted; full `npm test` passed (core 82 test files plus all workspaces); direct extension run 5 files / 58 tests passed. (Pre-existing stderr noise in `legacy-comment-manager-usj-pdpe.test.ts` about USJ versions is unrelated to this change.)

## Suggested Review Focus

Prioritized areas for the author-reviewer meeting:

- [ ] The origin-tracking one-shot record (`selfInitiatedNavigationRef` + `shouldArmSyncScroll`): confirm the read-and-clear semantics and the documented narrow batching exception are acceptable.
- [ ] Scroll alignment split — BCV sync uses `block: 'start'` while "go to comment" centers; UX confirmation pending in the Jira issue.
- [ ] The deferred Playwright e2e tests are required by PT-4080's Definition of Done — agree on the follow-up PR plan before closing the ticket.
- [ ] The `TODO: Handle versification` at the arm effect — decide whether versification mapping needs a ticket or is acceptable as-is for comment refs.
<!-- review-paratext:summary:end -->

AI-assisted — [session](https://claude.ai/code/session_08bca135-054e-484e-a30e-90b94db3e5db)


[PT-4172]: https://paratextstudio.atlassian.net/browse/PT-4172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2543)
<!-- Reviewable:end -->
