### PR TITLE
PT-4050: Rename resource-reference flags to "text collection" vocabulary

### DIFF
--- a/c-sharp-tests/Projects/ParatextProjectDataProviderTextCollectionTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderTextCollectionTests.cs
@@ -10,9 +10,9 @@ namespace TestParanextDataProvider.Projects;
 
 [TestFixture]
 [ExcludeFromCodeCoverage]
-internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
+internal class ParatextProjectDataProviderTextCollectionTests : PapiTestBase
 {
-    private const string PdpName = "shownByDefaultTestProject";
+    private const string PdpName = "textCollectionTestProject";
 
     private DummyScrText _scrText = null!;
     private ProjectDetails _projectDetails = null!;
@@ -78,7 +78,7 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
     [Test]
     public void SetProjectSetting_NonAdmin_ReferencedList_Rejected()
     {
-        // Only the referenced-resources list carries the admin-only shown-by-default default, so it
+        // Only the referenced-resources list carries the admin-only text-collection default, so it
         // is the only project-scope write gated to administrators.
         var nonAdmin = BuildNonAdminProvider(out var scrText);
         try
@@ -100,7 +100,7 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
     [Test]
     public void SetProjectSetting_NonAdmin_ModelTexts_Allowed()
     {
-        // Model texts do NOT participate in shown-by-default and keep their pre-existing ungated
+        // Model texts do NOT participate in text-collection and keep their pre-existing ungated
         // behavior, so a non-admin write must succeed (not throw).
         var nonAdmin = BuildNonAdminProvider(out var scrText);
         try
@@ -172,7 +172,7 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
     [Test]
     public void Overlay_Get_WhenUnset_ReturnsEmptyMap()
     {
-        var overlay = _provider.GetShownByDefaultOverlay();
+        var overlay = _provider.GetTextCollectionOverlay();
         Assert.That(overlay, Is.Empty);
     }
 
@@ -180,9 +180,9 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
     public void Overlay_SetThenGet_RoundTrips()
     {
         var input = new Dictionary<string, bool> { ["aabbcc"] = true, ["ddeeff"] = false };
-        Assert.That(_provider.SetShownByDefaultOverlay(input.SerializeToJson()), Is.True);
+        Assert.That(_provider.SetTextCollectionOverlay(input.SerializeToJson()), Is.True);
 
-        var overlay = _provider.GetShownByDefaultOverlay();
+        var overlay = _provider.GetTextCollectionOverlay();
         Assert.That(overlay["aabbcc"], Is.True);
         Assert.That(overlay["ddeeff"], Is.False);
     }
@@ -191,11 +191,11 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
     public void Overlay_Get_WithIncompatibleMajorVersion_Throws()
     {
         // Seed the overlay setting directly with a future major version the current build cannot
-        // read. "ShownByDefaultOverlay" mirrors ParatextProjectDataProvider.OverlaySettingName
-        // (a private const). GetShownByDefaultOverlay must reject it rather than deserialize blindly.
+        // read. "TextCollectionOverlay" mirrors ParatextProjectDataProvider.OverlaySettingName
+        // (a private const). GetTextCollectionOverlay must reject it rather than deserialize blindly.
         var userSettings = new UserProjectSettings(_scrText.Directory, _scrText.User.Name);
         userSettings.SetSetting(
-            "ShownByDefaultOverlay",
+            "TextCollectionOverlay",
             "2.0.0",
             new XElement(
                 "Items",
@@ -203,7 +203,7 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
             )
         );
 
-        Assert.Throws<InvalidDataException>(() => _provider.GetShownByDefaultOverlay());
+        Assert.Throws<InvalidDataException>(() => _provider.GetTextCollectionOverlay());
     }
 
     [TestCase("null")] // JSON null literal -> deserializes to null
@@ -214,20 +214,20 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
     [TestCase("{ not json")] // malformed JSON
     public void Overlay_Set_WithNonMapValue_Throws(string json)
     {
-        // SetShownByDefaultOverlay must reject any value that does not yield a { id -> bool } map
+        // SetTextCollectionOverlay must reject any value that does not yield a { id -> bool } map
         // with a consistent InvalidDataException — whether it is null/empty (deserializes to null) or
         // a wrong-shape/malformed value (System.Text.Json throws, which the setter wraps).
-        Assert.Throws<InvalidDataException>(() => _provider.SetShownByDefaultOverlay(json));
+        Assert.Throws<InvalidDataException>(() => _provider.SetTextCollectionOverlay(json));
     }
 
     [Test]
     public void Overlay_Reset_ClearsMap()
     {
-        _provider.SetShownByDefaultOverlay(
+        _provider.SetTextCollectionOverlay(
             new Dictionary<string, bool> { ["aabbcc"] = true }.SerializeToJson()
         );
-        Assert.That(_provider.ResetShownByDefaultOverlay(), Is.True);
-        Assert.That(_provider.GetShownByDefaultOverlay(), Is.Empty);
+        Assert.That(_provider.ResetTextCollectionOverlay(), Is.True);
+        Assert.That(_provider.GetTextCollectionOverlay(), Is.Empty);
     }
 
     [Test]
@@ -240,20 +240,20 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
                 {
                     Name = "P",
                     Id = "aabbcc",
-                    IsResourceShownByDefault = true,
+                    InTextCollection = true,
                 },
                 new DblResourceReference
                 {
                     Name = "D",
                     Id = "112233445566",
-                    IsResourceShownByDefault = false,
+                    InTextCollection = false,
                 }
             )
         );
 
-        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.True);
+        Assert.That(_provider.InitializeTextCollectionOverlay(), Is.True);
 
-        var overlay = _provider.GetShownByDefaultOverlay();
+        var overlay = _provider.GetTextCollectionOverlay();
         Assert.That(overlay["aabbcc"], Is.True);
         Assert.That(overlay["112233445566"], Is.False);
     }
@@ -269,9 +269,9 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
             )
         );
 
-        _provider.InitializeShownByDefaultOverlay();
+        _provider.InitializeTextCollectionOverlay();
 
-        Assert.That(_provider.GetShownByDefaultOverlay(), Is.Empty);
+        Assert.That(_provider.GetTextCollectionOverlay(), Is.Empty);
     }
 
     [Test]
@@ -284,20 +284,20 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
                 {
                     Name = "P",
                     Id = "aabbcc",
-                    IsResourceShownByDefault = true,
+                    InTextCollection = true,
                 }
             )
         );
-        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.True);
+        Assert.That(_provider.InitializeTextCollectionOverlay(), Is.True);
 
         // User un-checks the resource in their overlay.
-        _provider.SetShownByDefaultOverlay(
+        _provider.SetTextCollectionOverlay(
             new Dictionary<string, bool> { ["aabbcc"] = false }.SerializeToJson()
         );
 
         // A later open must NOT re-init (must not re-check the user's un-check).
-        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.False);
-        Assert.That(_provider.GetShownByDefaultOverlay()["aabbcc"], Is.False);
+        Assert.That(_provider.InitializeTextCollectionOverlay(), Is.False);
+        Assert.That(_provider.GetTextCollectionOverlay()["aabbcc"], Is.False);
     }
 
     [Test]
@@ -310,21 +310,21 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
                 {
                     Name = "P",
                     Id = "aabbcc",
-                    IsResourceShownByDefault = true,
+                    InTextCollection = true,
                 }
             )
         );
-        _provider.InitializeShownByDefaultOverlay();
-        _provider.ResetShownByDefaultOverlay();
+        _provider.InitializeTextCollectionOverlay();
+        _provider.ResetTextCollectionOverlay();
 
-        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.True);
-        Assert.That(_provider.GetShownByDefaultOverlay()["aabbcc"], Is.True);
+        Assert.That(_provider.InitializeTextCollectionOverlay(), Is.True);
+        Assert.That(_provider.GetTextCollectionOverlay()["aabbcc"], Is.True);
     }
 
     [Test]
     public void Initialize_IgnoresModelTextFlags()
     {
-        // Model texts are decoupled from shown-by-default: a flag set on the model-texts list must
+        // Model texts are decoupled from text-collection: a flag set on the model-texts list must
         // NOT seed the overlay. Only PB_REFERENCED_PROJECTS_AND_RESOURCES feeds first-open init.
         _provider.SetProjectSetting(
             ProjectSettingsNames.PB_MODEL_TEXTS,
@@ -333,13 +333,13 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
                 {
                     Name = "D",
                     Id = "112233445566",
-                    IsResourceShownByDefault = true,
+                    InTextCollection = true,
                 }
             )
         );
 
-        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.True);
-        Assert.That(_provider.GetShownByDefaultOverlay(), Is.Empty);
+        Assert.That(_provider.InitializeTextCollectionOverlay(), Is.True);
+        Assert.That(_provider.GetTextCollectionOverlay(), Is.Empty);
     }
 
     [Test]
@@ -353,12 +353,12 @@ internal class ParatextProjectDataProviderShownByDefaultTests : PapiTestBase
                 {
                     Name = "D",
                     Id = "112233445566",
-                    IsResourceShownByDefault = true,
+                    InTextCollection = true,
                 }
             )
         );
 
-        Assert.That(_provider.InitializeShownByDefaultOverlay(), Is.True);
-        Assert.That(_provider.GetShownByDefaultOverlay()["112233445566"], Is.True);
+        Assert.That(_provider.InitializeTextCollectionOverlay(), Is.True);
+        Assert.That(_provider.GetTextCollectionOverlay()["112233445566"], Is.True);
     }
 }

--- a/c-sharp-tests/Projects/ParatextProjectDataProviderTextCollectionTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderTextCollectionTests.cs
@@ -240,13 +240,13 @@ internal class ParatextProjectDataProviderTextCollectionTests : PapiTestBase
                 {
                     Name = "P",
                     Id = "aabbcc",
-                    InTextCollection = true,
+                    IsInTextCollection = true,
                 },
                 new DblResourceReference
                 {
                     Name = "D",
                     Id = "112233445566",
-                    InTextCollection = false,
+                    IsInTextCollection = false,
                 }
             )
         );
@@ -284,7 +284,7 @@ internal class ParatextProjectDataProviderTextCollectionTests : PapiTestBase
                 {
                     Name = "P",
                     Id = "aabbcc",
-                    InTextCollection = true,
+                    IsInTextCollection = true,
                 }
             )
         );
@@ -310,7 +310,7 @@ internal class ParatextProjectDataProviderTextCollectionTests : PapiTestBase
                 {
                     Name = "P",
                     Id = "aabbcc",
-                    InTextCollection = true,
+                    IsInTextCollection = true,
                 }
             )
         );
@@ -333,7 +333,7 @@ internal class ParatextProjectDataProviderTextCollectionTests : PapiTestBase
                 {
                     Name = "D",
                     Id = "112233445566",
-                    InTextCollection = true,
+                    IsInTextCollection = true,
                 }
             )
         );
@@ -353,7 +353,7 @@ internal class ParatextProjectDataProviderTextCollectionTests : PapiTestBase
                 {
                     Name = "D",
                     Id = "112233445566",
-                    InTextCollection = true,
+                    IsInTextCollection = true,
                 }
             )
         );

--- a/c-sharp-tests/Projects/ResourceReferenceListSettingTests.cs
+++ b/c-sharp-tests/Projects/ResourceReferenceListSettingTests.cs
@@ -354,8 +354,8 @@ internal class ResourceReferenceListSettingTests : PapiTestBase
         var list = (ResourceReferenceList)_provider.GetProjectSetting(pbSettingName)!;
         var item = (ProjectReference)list.Items[0];
 
-        Assert.That(item.InTextCollection, Is.Null);
-        Assert.That(item.InTextCollectionForUser, Is.Null);
+        Assert.That(item.IsInTextCollection, Is.Null);
+        Assert.That(item.IsInTextCollectionForUser, Is.Null);
     }
 
     [TestCase(ProjectSettingsNames.PB_MODEL_TEXTS)]
@@ -396,7 +396,7 @@ internal class ResourceReferenceListSettingTests : PapiTestBase
 
         Assert.That(third.Items, Has.Count.EqualTo(1));
         Assert.That(((ProjectReference)third.Items[0]).Id, Is.EqualTo("aabbcc"));
-        Assert.That(((ProjectReference)third.Items[0]).InTextCollection, Is.Null);
+        Assert.That(((ProjectReference)third.Items[0]).IsInTextCollection, Is.Null);
     }
 
     #endregion

--- a/c-sharp-tests/Projects/ResourceReferenceListSettingTests.cs
+++ b/c-sharp-tests/Projects/ResourceReferenceListSettingTests.cs
@@ -354,8 +354,8 @@ internal class ResourceReferenceListSettingTests : PapiTestBase
         var list = (ResourceReferenceList)_provider.GetProjectSetting(pbSettingName)!;
         var item = (ProjectReference)list.Items[0];
 
-        Assert.That(item.IsResourceShownByDefault, Is.Null);
-        Assert.That(item.IsResourceShownForUser, Is.Null);
+        Assert.That(item.InTextCollection, Is.Null);
+        Assert.That(item.InTextCollectionForUser, Is.Null);
     }
 
     [TestCase(ProjectSettingsNames.PB_MODEL_TEXTS)]
@@ -396,7 +396,7 @@ internal class ResourceReferenceListSettingTests : PapiTestBase
 
         Assert.That(third.Items, Has.Count.EqualTo(1));
         Assert.That(((ProjectReference)third.Items[0]).Id, Is.EqualTo("aabbcc"));
-        Assert.That(((ProjectReference)third.Items[0]).IsResourceShownByDefault, Is.Null);
+        Assert.That(((ProjectReference)third.Items[0]).InTextCollection, Is.Null);
     }
 
     #endregion

--- a/c-sharp-tests/Projects/ResourceReferenceListTests.cs
+++ b/c-sharp-tests/Projects/ResourceReferenceListTests.cs
@@ -125,7 +125,7 @@ public class ResourceReferenceListTests
     }
 
     [Test]
-    public void ProjectReference_IsResourceShownByDefaultTrue_SerializesAndDeserializesCorrectly()
+    public void ProjectReference_InTextCollectionTrue_SerializesAndDeserializesCorrectly()
     {
         var list = new ResourceReferenceList
         {
@@ -135,7 +135,7 @@ public class ResourceReferenceListTests
                 {
                     Name = "My Project",
                     Id = "aabbcc",
-                    IsResourceShownByDefault = true,
+                    InTextCollection = true,
                 },
             ],
         };
@@ -145,11 +145,11 @@ public class ResourceReferenceListTests
         Assert.That(result, Is.Not.Null);
         var item = result!.Items[0] as ProjectReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.IsResourceShownByDefault, Is.EqualTo(true));
+        Assert.That(item!.InTextCollection, Is.EqualTo(true));
     }
 
     [Test]
-    public void ProjectReference_IsResourceShownByDefaultAbsent_DeserializesAsNull()
+    public void ProjectReference_InTextCollectionAbsent_DeserializesAsNull()
     {
         const string json =
             """{"dataVersion":"1.0.0","items":[{"type":"project","name":"My Project","id":"aabbcc"}]}""";
@@ -157,22 +157,22 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as ProjectReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.IsResourceShownByDefault, Is.Null);
+        Assert.That(item!.InTextCollection, Is.Null);
     }
 
     [Test]
-    public void ProjectReference_IsResourceShownByDefaultNull_NotPresentInSerializedJson()
+    public void ProjectReference_InTextCollectionNull_NotPresentInSerializedJson()
     {
         var list = new ResourceReferenceList
         {
             Items = [new ProjectReference { Name = "P", Id = "abc" }],
         };
         string json = list.SerializeToJson();
-        Assert.That(json, Does.Not.Contain("isResourceShownByDefault"));
+        Assert.That(json, Does.Not.Contain("inTextCollection"));
     }
 
     [Test]
-    public void DblResourceReference_IsResourceShownByDefaultFalse_SerializesAndDeserializesCorrectly()
+    public void DblResourceReference_InTextCollectionFalse_SerializesAndDeserializesCorrectly()
     {
         var list = new ResourceReferenceList
         {
@@ -182,7 +182,7 @@ public class ResourceReferenceListTests
                 {
                     Name = "Web English",
                     Id = "aabbccddeeff00112233445566778899aabbccddeeff0011",
-                    IsResourceShownByDefault = false,
+                    InTextCollection = false,
                 },
             ],
         };
@@ -191,17 +191,17 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as DblResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.IsResourceShownByDefault, Is.EqualTo(false));
+        Assert.That(item!.InTextCollection, Is.EqualTo(false));
     }
 
     [Test]
-    public void EnhancedResourceReference_IsResourceShownByDefaultTrue_SerializesAndDeserializesCorrectly()
+    public void EnhancedResourceReference_InTextCollectionTrue_SerializesAndDeserializesCorrectly()
     {
         var list = new ResourceReferenceList
         {
             Items =
             [
-                new EnhancedResourceReference { Name = "BDAG", IsResourceShownByDefault = true },
+                new EnhancedResourceReference { Name = "BDAG", InTextCollection = true },
             ],
         };
         string json = list.SerializeToJson();
@@ -209,17 +209,17 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as EnhancedResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.IsResourceShownByDefault, Is.EqualTo(true));
+        Assert.That(item!.InTextCollection, Is.EqualTo(true));
     }
 
     [Test]
-    public void XmlResourceReference_IsResourceShownByDefaultFalse_SerializesAndDeserializesCorrectly()
+    public void XmlResourceReference_InTextCollectionFalse_SerializesAndDeserializesCorrectly()
     {
         var list = new ResourceReferenceList
         {
             Items =
             [
-                new XmlResourceReference { Name = "SomeXml", IsResourceShownByDefault = false },
+                new XmlResourceReference { Name = "SomeXml", InTextCollection = false },
             ],
         };
         string json = list.SerializeToJson();
@@ -227,11 +227,11 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as XmlResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.IsResourceShownByDefault, Is.EqualTo(false));
+        Assert.That(item!.InTextCollection, Is.EqualTo(false));
     }
 
     [Test]
-    public void SourceLanguageResourceReference_IsResourceShownByDefaultTrue_SerializesAndDeserializesCorrectly()
+    public void SourceLanguageResourceReference_InTextCollectionTrue_SerializesAndDeserializesCorrectly()
     {
         var list = new ResourceReferenceList
         {
@@ -240,7 +240,7 @@ public class ResourceReferenceListTests
                 new SourceLanguageResourceReference
                 {
                     Name = "Greek",
-                    IsResourceShownByDefault = true,
+                    InTextCollection = true,
                 },
             ],
         };
@@ -249,7 +249,7 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as SourceLanguageResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.IsResourceShownByDefault, Is.EqualTo(true));
+        Assert.That(item!.InTextCollection, Is.EqualTo(true));
     }
 
     #endregion
@@ -365,16 +365,16 @@ public class ResourceReferenceListTests
                 {
                     Name = "P",
                     Id = "aabbcc",
-                    IsResourceShownByDefault = true,
-                    IsResourceShownForUser = false,
+                    InTextCollection = true,
+                    InTextCollectionForUser = false,
                 },
             ],
         };
         var result = list.SerializeToJson().DeserializeFromJson<ResourceReferenceList>();
 
         var item = result!.Items[0] as ProjectReference;
-        Assert.That(item!.IsResourceShownByDefault, Is.True);
-        Assert.That(item.IsResourceShownForUser, Is.False);
+        Assert.That(item!.InTextCollection, Is.True);
+        Assert.That(item.InTextCollectionForUser, Is.False);
     }
 
     [Test]
@@ -387,8 +387,8 @@ public class ResourceReferenceListTests
         string json = list.SerializeToJson();
 
         // Old-build files must stay clean: unset flags are absent, not `false`.
-        Assert.That(json, Does.Not.Contain("isResourceShownByDefault"));
-        Assert.That(json, Does.Not.Contain("isResourceShownForUser"));
+        Assert.That(json, Does.Not.Contain("inTextCollection"));
+        Assert.That(json, Does.Not.Contain("inTextCollectionForUser"));
     }
 
     [Test]
@@ -400,8 +400,8 @@ public class ResourceReferenceListTests
         var result = json.DeserializeFromJson<ResourceReferenceList>();
 
         var item = result!.Items[0] as ProjectReference;
-        Assert.That(item!.IsResourceShownByDefault, Is.Null);
-        Assert.That(item.IsResourceShownForUser, Is.Null);
+        Assert.That(item!.InTextCollection, Is.Null);
+        Assert.That(item.InTextCollectionForUser, Is.Null);
     }
 
     [Test]
@@ -429,8 +429,8 @@ public class ResourceReferenceListTests
                 {
                     Name = "D",
                     Id = "112233445566",
-                    IsResourceShownByDefault = false,
-                    IsResourceShownForUser = true,
+                    InTextCollection = false,
+                    InTextCollectionForUser = true,
                 },
             ],
         };
@@ -438,8 +438,8 @@ public class ResourceReferenceListTests
         var result = ResourceReferenceList.FromXml(xml, ResourceReferenceList.CurrentDataVersion);
 
         var item = result.Items[0] as DblResourceReference;
-        Assert.That(item!.IsResourceShownByDefault, Is.False);
-        Assert.That(item.IsResourceShownForUser, Is.True);
+        Assert.That(item!.InTextCollection, Is.False);
+        Assert.That(item.InTextCollectionForUser, Is.True);
     }
 
     [Test]
@@ -452,8 +452,8 @@ public class ResourceReferenceListTests
         var xml = ResourceReferenceList.ToXml(list);
         var itemEl = xml.Elements("Item").First();
 
-        Assert.That(itemEl.Attribute("isResourceShownByDefault"), Is.Null);
-        Assert.That(itemEl.Attribute("isResourceShownForUser"), Is.Null);
+        Assert.That(itemEl.Attribute("inTextCollection"), Is.Null);
+        Assert.That(itemEl.Attribute("inTextCollectionForUser"), Is.Null);
     }
 
     [Test]
@@ -465,8 +465,8 @@ public class ResourceReferenceListTests
         var result = ResourceReferenceList.FromXml(xml, "1.0.0");
 
         var item = result.Items[0] as ProjectReference;
-        Assert.That(item!.IsResourceShownByDefault, Is.Null);
-        Assert.That(item.IsResourceShownForUser, Is.Null);
+        Assert.That(item!.InTextCollection, Is.Null);
+        Assert.That(item.InTextCollectionForUser, Is.Null);
     }
 
     [Test]
@@ -499,19 +499,19 @@ public class ResourceReferenceListTests
     [Test]
     public void NamedOnlyType_PreservesBibleTextOnlyProperties_OnJsonRoundTrip()
     {
-        // A name-only type (enhancedResource) never natively handles "id" or "isResourceShownForUser"
+        // A name-only type (enhancedResource) never natively handles "id" or "inTextCollectionForUser"
         // (both are Bible-text-only). A future build that attaches them must not have them silently
         // dropped: they flow through ExtraData (captured against the narrower
-        // KnownNamedOnlyPropertyNames set) and are re-emitted. isResourceShownByDefault, by contrast,
+        // KnownNamedOnlyPropertyNames set) and are re-emitted. inTextCollection, by contrast,
         // is understood on every type, so it is a real field rather than a passthrough.
         const string json =
-            """{"dataVersion":"1.1.0","items":[{"type":"enhancedResource","name":"Enh","id":"keep-id","isResourceShownForUser":true}]}""";
+            """{"dataVersion":"1.1.0","items":[{"type":"enhancedResource","name":"Enh","id":"keep-id","inTextCollectionForUser":true}]}""";
         var result = json.DeserializeFromJson<ResourceReferenceList>();
         Assert.That(result!.Items[0], Is.InstanceOf<EnhancedResourceReference>());
 
         string reSerialized = result.SerializeToJson();
         Assert.That(reSerialized, Does.Contain("keep-id"));
-        Assert.That(reSerialized, Does.Contain("isResourceShownForUser"));
+        Assert.That(reSerialized, Does.Contain("inTextCollectionForUser"));
     }
 
     [Test]

--- a/c-sharp-tests/Projects/ResourceReferenceListTests.cs
+++ b/c-sharp-tests/Projects/ResourceReferenceListTests.cs
@@ -125,7 +125,7 @@ public class ResourceReferenceListTests
     }
 
     [Test]
-    public void ProjectReference_InTextCollectionTrue_SerializesAndDeserializesCorrectly()
+    public void ProjectReference_IsInTextCollectionTrue_SerializesAndDeserializesCorrectly()
     {
         var list = new ResourceReferenceList
         {
@@ -135,7 +135,7 @@ public class ResourceReferenceListTests
                 {
                     Name = "My Project",
                     Id = "aabbcc",
-                    InTextCollection = true,
+                    IsInTextCollection = true,
                 },
             ],
         };
@@ -145,11 +145,11 @@ public class ResourceReferenceListTests
         Assert.That(result, Is.Not.Null);
         var item = result!.Items[0] as ProjectReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.InTextCollection, Is.EqualTo(true));
+        Assert.That(item!.IsInTextCollection, Is.EqualTo(true));
     }
 
     [Test]
-    public void ProjectReference_InTextCollectionAbsent_DeserializesAsNull()
+    public void ProjectReference_IsInTextCollectionAbsent_DeserializesAsNull()
     {
         const string json =
             """{"dataVersion":"1.0.0","items":[{"type":"project","name":"My Project","id":"aabbcc"}]}""";
@@ -157,22 +157,22 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as ProjectReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.InTextCollection, Is.Null);
+        Assert.That(item!.IsInTextCollection, Is.Null);
     }
 
     [Test]
-    public void ProjectReference_InTextCollectionNull_NotPresentInSerializedJson()
+    public void ProjectReference_IsInTextCollectionNull_NotPresentInSerializedJson()
     {
         var list = new ResourceReferenceList
         {
             Items = [new ProjectReference { Name = "P", Id = "abc" }],
         };
         string json = list.SerializeToJson();
-        Assert.That(json, Does.Not.Contain("inTextCollection"));
+        Assert.That(json, Does.Not.Contain("isInTextCollection"));
     }
 
     [Test]
-    public void DblResourceReference_InTextCollectionFalse_SerializesAndDeserializesCorrectly()
+    public void DblResourceReference_IsInTextCollectionFalse_SerializesAndDeserializesCorrectly()
     {
         var list = new ResourceReferenceList
         {
@@ -182,7 +182,7 @@ public class ResourceReferenceListTests
                 {
                     Name = "Web English",
                     Id = "aabbccddeeff00112233445566778899aabbccddeeff0011",
-                    InTextCollection = false,
+                    IsInTextCollection = false,
                 },
             ],
         };
@@ -191,17 +191,17 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as DblResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.InTextCollection, Is.EqualTo(false));
+        Assert.That(item!.IsInTextCollection, Is.EqualTo(false));
     }
 
     [Test]
-    public void EnhancedResourceReference_InTextCollectionTrue_SerializesAndDeserializesCorrectly()
+    public void EnhancedResourceReference_IsInTextCollectionTrue_SerializesAndDeserializesCorrectly()
     {
         var list = new ResourceReferenceList
         {
             Items =
             [
-                new EnhancedResourceReference { Name = "BDAG", InTextCollection = true },
+                new EnhancedResourceReference { Name = "BDAG", IsInTextCollection = true },
             ],
         };
         string json = list.SerializeToJson();
@@ -209,17 +209,17 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as EnhancedResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.InTextCollection, Is.EqualTo(true));
+        Assert.That(item!.IsInTextCollection, Is.EqualTo(true));
     }
 
     [Test]
-    public void XmlResourceReference_InTextCollectionFalse_SerializesAndDeserializesCorrectly()
+    public void XmlResourceReference_IsInTextCollectionFalse_SerializesAndDeserializesCorrectly()
     {
         var list = new ResourceReferenceList
         {
             Items =
             [
-                new XmlResourceReference { Name = "SomeXml", InTextCollection = false },
+                new XmlResourceReference { Name = "SomeXml", IsInTextCollection = false },
             ],
         };
         string json = list.SerializeToJson();
@@ -227,11 +227,11 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as XmlResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.InTextCollection, Is.EqualTo(false));
+        Assert.That(item!.IsInTextCollection, Is.EqualTo(false));
     }
 
     [Test]
-    public void SourceLanguageResourceReference_InTextCollectionTrue_SerializesAndDeserializesCorrectly()
+    public void SourceLanguageResourceReference_IsInTextCollectionTrue_SerializesAndDeserializesCorrectly()
     {
         var list = new ResourceReferenceList
         {
@@ -240,7 +240,7 @@ public class ResourceReferenceListTests
                 new SourceLanguageResourceReference
                 {
                     Name = "Greek",
-                    InTextCollection = true,
+                    IsInTextCollection = true,
                 },
             ],
         };
@@ -249,7 +249,7 @@ public class ResourceReferenceListTests
 
         var item = result!.Items[0] as SourceLanguageResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.InTextCollection, Is.EqualTo(true));
+        Assert.That(item!.IsInTextCollection, Is.EqualTo(true));
     }
 
     #endregion
@@ -365,16 +365,16 @@ public class ResourceReferenceListTests
                 {
                     Name = "P",
                     Id = "aabbcc",
-                    InTextCollection = true,
-                    InTextCollectionForUser = false,
+                    IsInTextCollection = true,
+                    IsInTextCollectionForUser = false,
                 },
             ],
         };
         var result = list.SerializeToJson().DeserializeFromJson<ResourceReferenceList>();
 
         var item = result!.Items[0] as ProjectReference;
-        Assert.That(item!.InTextCollection, Is.True);
-        Assert.That(item.InTextCollectionForUser, Is.False);
+        Assert.That(item!.IsInTextCollection, Is.True);
+        Assert.That(item.IsInTextCollectionForUser, Is.False);
     }
 
     [Test]
@@ -387,8 +387,8 @@ public class ResourceReferenceListTests
         string json = list.SerializeToJson();
 
         // Old-build files must stay clean: unset flags are absent, not `false`.
-        Assert.That(json, Does.Not.Contain("inTextCollection"));
-        Assert.That(json, Does.Not.Contain("inTextCollectionForUser"));
+        Assert.That(json, Does.Not.Contain("isInTextCollection"));
+        Assert.That(json, Does.Not.Contain("isInTextCollectionForUser"));
     }
 
     [Test]
@@ -400,8 +400,8 @@ public class ResourceReferenceListTests
         var result = json.DeserializeFromJson<ResourceReferenceList>();
 
         var item = result!.Items[0] as ProjectReference;
-        Assert.That(item!.InTextCollection, Is.Null);
-        Assert.That(item.InTextCollectionForUser, Is.Null);
+        Assert.That(item!.IsInTextCollection, Is.Null);
+        Assert.That(item.IsInTextCollectionForUser, Is.Null);
     }
 
     [Test]
@@ -429,8 +429,8 @@ public class ResourceReferenceListTests
                 {
                     Name = "D",
                     Id = "112233445566",
-                    InTextCollection = false,
-                    InTextCollectionForUser = true,
+                    IsInTextCollection = false,
+                    IsInTextCollectionForUser = true,
                 },
             ],
         };
@@ -438,8 +438,8 @@ public class ResourceReferenceListTests
         var result = ResourceReferenceList.FromXml(xml, ResourceReferenceList.CurrentDataVersion);
 
         var item = result.Items[0] as DblResourceReference;
-        Assert.That(item!.InTextCollection, Is.False);
-        Assert.That(item.InTextCollectionForUser, Is.True);
+        Assert.That(item!.IsInTextCollection, Is.False);
+        Assert.That(item.IsInTextCollectionForUser, Is.True);
     }
 
     [Test]
@@ -452,8 +452,8 @@ public class ResourceReferenceListTests
         var xml = ResourceReferenceList.ToXml(list);
         var itemEl = xml.Elements("Item").First();
 
-        Assert.That(itemEl.Attribute("inTextCollection"), Is.Null);
-        Assert.That(itemEl.Attribute("inTextCollectionForUser"), Is.Null);
+        Assert.That(itemEl.Attribute("isInTextCollection"), Is.Null);
+        Assert.That(itemEl.Attribute("isInTextCollectionForUser"), Is.Null);
     }
 
     [Test]
@@ -465,8 +465,8 @@ public class ResourceReferenceListTests
         var result = ResourceReferenceList.FromXml(xml, "1.0.0");
 
         var item = result.Items[0] as ProjectReference;
-        Assert.That(item!.InTextCollection, Is.Null);
-        Assert.That(item.InTextCollectionForUser, Is.Null);
+        Assert.That(item!.IsInTextCollection, Is.Null);
+        Assert.That(item.IsInTextCollectionForUser, Is.Null);
     }
 
     [Test]
@@ -499,19 +499,19 @@ public class ResourceReferenceListTests
     [Test]
     public void NamedOnlyType_PreservesBibleTextOnlyProperties_OnJsonRoundTrip()
     {
-        // A name-only type (enhancedResource) never natively handles "id" or "inTextCollectionForUser"
+        // A name-only type (enhancedResource) never natively handles "id" or "isInTextCollectionForUser"
         // (both are Bible-text-only). A future build that attaches them must not have them silently
         // dropped: they flow through ExtraData (captured against the narrower
-        // KnownNamedOnlyPropertyNames set) and are re-emitted. inTextCollection, by contrast,
+        // KnownNamedOnlyPropertyNames set) and are re-emitted. isInTextCollection, by contrast,
         // is understood on every type, so it is a real field rather than a passthrough.
         const string json =
-            """{"dataVersion":"1.1.0","items":[{"type":"enhancedResource","name":"Enh","id":"keep-id","inTextCollectionForUser":true}]}""";
+            """{"dataVersion":"1.1.0","items":[{"type":"enhancedResource","name":"Enh","id":"keep-id","isInTextCollectionForUser":true}]}""";
         var result = json.DeserializeFromJson<ResourceReferenceList>();
         Assert.That(result!.Items[0], Is.InstanceOf<EnhancedResourceReference>());
 
         string reSerialized = result.SerializeToJson();
         Assert.That(reSerialized, Does.Contain("keep-id"));
-        Assert.That(reSerialized, Does.Contain("inTextCollectionForUser"));
+        Assert.That(reSerialized, Does.Contain("isInTextCollectionForUser"));
     }
 
     [Test]

--- a/c-sharp-tests/Projects/ResourceReferenceListXmlTests.cs
+++ b/c-sharp-tests/Projects/ResourceReferenceListXmlTests.cs
@@ -188,25 +188,25 @@ public class ResourceReferenceListXmlTests
         Assert.That(result.Items[4], Is.InstanceOf<SourceLanguageResourceReference>());
     }
 
-    // --- IsResourceShownByDefault XML round-trip ---
+    // --- InTextCollection XML round-trip ---
 
     [Test]
-    public void ToXml_FromXml_ProjectReference_IsResourceShownByDefaultTrue_RoundTripsCorrectly()
+    public void ToXml_FromXml_ProjectReference_InTextCollectionTrue_RoundTripsCorrectly()
     {
         var list = new ResourceReferenceList
         {
-            Items = [new ProjectReference { Name = "My Project", Id = "aabbcc", IsResourceShownByDefault = true }],
+            Items = [new ProjectReference { Name = "My Project", Id = "aabbcc", InTextCollection = true }],
         };
         var xml = ResourceReferenceList.ToXml(list);
         var result = ResourceReferenceList.FromXml(xml, list.DataVersion);
 
         var item = result.Items[0] as ProjectReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.IsResourceShownByDefault, Is.EqualTo(true));
+        Assert.That(item!.InTextCollection, Is.EqualTo(true));
     }
 
     [Test]
-    public void ToXml_FromXml_ProjectReference_IsResourceShownByDefaultNull_RoundTripsAsNull()
+    public void ToXml_FromXml_ProjectReference_InTextCollectionNull_RoundTripsAsNull()
     {
         var list = new ResourceReferenceList
         {
@@ -217,11 +217,11 @@ public class ResourceReferenceListXmlTests
 
         var item = result.Items[0] as ProjectReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.IsResourceShownByDefault, Is.Null);
+        Assert.That(item!.InTextCollection, Is.Null);
     }
 
     [Test]
-    public void ToXml_ProjectReference_IsResourceShownByDefaultNull_NoAttributeInXml()
+    public void ToXml_ProjectReference_InTextCollectionNull_NoAttributeInXml()
     {
         var list = new ResourceReferenceList
         {
@@ -229,52 +229,52 @@ public class ResourceReferenceListXmlTests
         };
         var xml = ResourceReferenceList.ToXml(list);
         var itemEl = xml.Elements("Item").First();
-        Assert.That(itemEl.Attribute("isResourceShownByDefault"), Is.Null);
+        Assert.That(itemEl.Attribute("inTextCollection"), Is.Null);
     }
 
     [Test]
-    public void ToXml_FromXml_EnhancedResourceReference_IsResourceShownByDefaultTrue_RoundTripsCorrectly()
+    public void ToXml_FromXml_EnhancedResourceReference_InTextCollectionTrue_RoundTripsCorrectly()
     {
         var list = new ResourceReferenceList
         {
-            Items = [new EnhancedResourceReference { Name = "BDAG", IsResourceShownByDefault = true }],
+            Items = [new EnhancedResourceReference { Name = "BDAG", InTextCollection = true }],
         };
         var xml = ResourceReferenceList.ToXml(list);
         var result = ResourceReferenceList.FromXml(xml, list.DataVersion);
 
         var item = result.Items[0] as EnhancedResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.IsResourceShownByDefault, Is.EqualTo(true));
+        Assert.That(item!.InTextCollection, Is.EqualTo(true));
     }
 
     [Test]
-    public void ToXml_FromXml_XmlResourceReference_IsResourceShownByDefaultFalse_RoundTripsCorrectly()
+    public void ToXml_FromXml_XmlResourceReference_InTextCollectionFalse_RoundTripsCorrectly()
     {
         var list = new ResourceReferenceList
         {
-            Items = [new XmlResourceReference { Name = "SomeXml", IsResourceShownByDefault = false }],
+            Items = [new XmlResourceReference { Name = "SomeXml", InTextCollection = false }],
         };
         var xml = ResourceReferenceList.ToXml(list);
         var result = ResourceReferenceList.FromXml(xml, list.DataVersion);
 
         var item = result.Items[0] as XmlResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.IsResourceShownByDefault, Is.EqualTo(false));
+        Assert.That(item!.InTextCollection, Is.EqualTo(false));
     }
 
     [Test]
-    public void ToXml_FromXml_SourceLanguageResourceReference_IsResourceShownByDefaultTrue_RoundTripsCorrectly()
+    public void ToXml_FromXml_SourceLanguageResourceReference_InTextCollectionTrue_RoundTripsCorrectly()
     {
         var list = new ResourceReferenceList
         {
-            Items = [new SourceLanguageResourceReference { Name = "Greek", IsResourceShownByDefault = true }],
+            Items = [new SourceLanguageResourceReference { Name = "Greek", InTextCollection = true }],
         };
         var xml = ResourceReferenceList.ToXml(list);
         var result = ResourceReferenceList.FromXml(xml, list.DataVersion);
 
         var item = result.Items[0] as SourceLanguageResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.IsResourceShownByDefault, Is.EqualTo(true));
+        Assert.That(item!.InTextCollection, Is.EqualTo(true));
     }
 
     [Test]

--- a/c-sharp-tests/Projects/ResourceReferenceListXmlTests.cs
+++ b/c-sharp-tests/Projects/ResourceReferenceListXmlTests.cs
@@ -188,25 +188,25 @@ public class ResourceReferenceListXmlTests
         Assert.That(result.Items[4], Is.InstanceOf<SourceLanguageResourceReference>());
     }
 
-    // --- InTextCollection XML round-trip ---
+    // --- IsInTextCollection XML round-trip ---
 
     [Test]
-    public void ToXml_FromXml_ProjectReference_InTextCollectionTrue_RoundTripsCorrectly()
+    public void ToXml_FromXml_ProjectReference_IsInTextCollectionTrue_RoundTripsCorrectly()
     {
         var list = new ResourceReferenceList
         {
-            Items = [new ProjectReference { Name = "My Project", Id = "aabbcc", InTextCollection = true }],
+            Items = [new ProjectReference { Name = "My Project", Id = "aabbcc", IsInTextCollection = true }],
         };
         var xml = ResourceReferenceList.ToXml(list);
         var result = ResourceReferenceList.FromXml(xml, list.DataVersion);
 
         var item = result.Items[0] as ProjectReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.InTextCollection, Is.EqualTo(true));
+        Assert.That(item!.IsInTextCollection, Is.EqualTo(true));
     }
 
     [Test]
-    public void ToXml_FromXml_ProjectReference_InTextCollectionNull_RoundTripsAsNull()
+    public void ToXml_FromXml_ProjectReference_IsInTextCollectionNull_RoundTripsAsNull()
     {
         var list = new ResourceReferenceList
         {
@@ -217,11 +217,11 @@ public class ResourceReferenceListXmlTests
 
         var item = result.Items[0] as ProjectReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.InTextCollection, Is.Null);
+        Assert.That(item!.IsInTextCollection, Is.Null);
     }
 
     [Test]
-    public void ToXml_ProjectReference_InTextCollectionNull_NoAttributeInXml()
+    public void ToXml_ProjectReference_IsInTextCollectionNull_NoAttributeInXml()
     {
         var list = new ResourceReferenceList
         {
@@ -229,52 +229,52 @@ public class ResourceReferenceListXmlTests
         };
         var xml = ResourceReferenceList.ToXml(list);
         var itemEl = xml.Elements("Item").First();
-        Assert.That(itemEl.Attribute("inTextCollection"), Is.Null);
+        Assert.That(itemEl.Attribute("isInTextCollection"), Is.Null);
     }
 
     [Test]
-    public void ToXml_FromXml_EnhancedResourceReference_InTextCollectionTrue_RoundTripsCorrectly()
+    public void ToXml_FromXml_EnhancedResourceReference_IsInTextCollectionTrue_RoundTripsCorrectly()
     {
         var list = new ResourceReferenceList
         {
-            Items = [new EnhancedResourceReference { Name = "BDAG", InTextCollection = true }],
+            Items = [new EnhancedResourceReference { Name = "BDAG", IsInTextCollection = true }],
         };
         var xml = ResourceReferenceList.ToXml(list);
         var result = ResourceReferenceList.FromXml(xml, list.DataVersion);
 
         var item = result.Items[0] as EnhancedResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.InTextCollection, Is.EqualTo(true));
+        Assert.That(item!.IsInTextCollection, Is.EqualTo(true));
     }
 
     [Test]
-    public void ToXml_FromXml_XmlResourceReference_InTextCollectionFalse_RoundTripsCorrectly()
+    public void ToXml_FromXml_XmlResourceReference_IsInTextCollectionFalse_RoundTripsCorrectly()
     {
         var list = new ResourceReferenceList
         {
-            Items = [new XmlResourceReference { Name = "SomeXml", InTextCollection = false }],
+            Items = [new XmlResourceReference { Name = "SomeXml", IsInTextCollection = false }],
         };
         var xml = ResourceReferenceList.ToXml(list);
         var result = ResourceReferenceList.FromXml(xml, list.DataVersion);
 
         var item = result.Items[0] as XmlResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.InTextCollection, Is.EqualTo(false));
+        Assert.That(item!.IsInTextCollection, Is.EqualTo(false));
     }
 
     [Test]
-    public void ToXml_FromXml_SourceLanguageResourceReference_InTextCollectionTrue_RoundTripsCorrectly()
+    public void ToXml_FromXml_SourceLanguageResourceReference_IsInTextCollectionTrue_RoundTripsCorrectly()
     {
         var list = new ResourceReferenceList
         {
-            Items = [new SourceLanguageResourceReference { Name = "Greek", InTextCollection = true }],
+            Items = [new SourceLanguageResourceReference { Name = "Greek", IsInTextCollection = true }],
         };
         var xml = ResourceReferenceList.ToXml(list);
         var result = ResourceReferenceList.FromXml(xml, list.DataVersion);
 
         var item = result.Items[0] as SourceLanguageResourceReference;
         Assert.That(item, Is.Not.Null);
-        Assert.That(item!.InTextCollection, Is.EqualTo(true));
+        Assert.That(item!.IsInTextCollection, Is.EqualTo(true));
     }
 
     [Test]

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -78,7 +78,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     private string? _cachedUserId;
 
     // Reference the shared data-type constant so the storage key and the data-type name can't drift.
-    private const string OverlaySettingName = ProjectDataType.SHOWN_BY_DEFAULT_OVERLAY;
+    private const string OverlaySettingName = ProjectDataType.TEXT_COLLECTION_OVERLAY;
     private const string OverlayInitializedMarkerName = OverlaySettingName + "Initialized";
     private const string OverlaySchemaVersion = "1.0.0";
 
@@ -155,10 +155,10 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         retVal.Add(
             ("resetUserReferencedProjectsAndResources", ResetUserReferencedProjectsAndResources)
         );
-        retVal.Add(("getShownByDefaultOverlay", GetShownByDefaultOverlay));
-        retVal.Add(("setShownByDefaultOverlay", SetShownByDefaultOverlay));
-        retVal.Add(("resetShownByDefaultOverlay", ResetShownByDefaultOverlay));
-        retVal.Add(("initializeShownByDefaultOverlay", InitializeShownByDefaultOverlay));
+        retVal.Add(("getTextCollectionOverlay", GetTextCollectionOverlay));
+        retVal.Add(("setTextCollectionOverlay", SetTextCollectionOverlay));
+        retVal.Add(("resetTextCollectionOverlay", ResetTextCollectionOverlay));
+        retVal.Add(("initializeTextCollectionOverlay", InitializeTextCollectionOverlay));
         retVal.Add(
             ("canUserWriteProjectTextConnectionSettings", CanUserWriteProjectTextConnectionSettings)
         );
@@ -1730,11 +1730,11 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             ProjectSettingsNames.GetParatextSettingNameFromPlatformBibleSettingName(settingName)
             ?? settingName;
 
-        // The referenced-projects-and-resources list carries the admin-only isResourceShownByDefault
-        // flag (the shared shown-by-default default for the Scripture Text Grid), so its writes are
+        // The referenced-projects-and-resources list carries the admin-only inTextCollection
+        // flag (the shared text-collection default for the Scripture Text Grid), so its writes are
         // gated to project administrators server-side (the UI-facing query is
         // canUserWriteProjectTextConnectionSettings()). Model texts do NOT participate in
-        // shown-by-default and keep their pre-existing ungated behavior. USER-scope writes (user
+        // text-collection and keep their pre-existing ungated behavior. USER-scope writes (user
         // lists, overlay, init) are intentionally UNGATED.
         if (
             paratextSettingName == ProjectSettingsNames.PT_REFERENCED_PROJECTS_AND_RESOURCES
@@ -2088,7 +2088,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         return true;
     }
 
-    public Dictionary<string, bool> GetShownByDefaultOverlay(object? param = null)
+    public Dictionary<string, bool> GetTextCollectionOverlay(object? param = null)
     {
         var (schemaVersion, content) = GetUserProjectSettings().GetSetting(OverlaySettingName);
         if (content == null || string.IsNullOrEmpty(content.Value))
@@ -2100,7 +2100,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         return content.Value.DeserializeFromJson<Dictionary<string, bool>>() ?? [];
     }
 
-    public bool SetShownByDefaultOverlay(object? value)
+    public bool SetTextCollectionOverlay(object? value)
     {
         string? json = value?.ToString();
         Dictionary<string, bool>? map;
@@ -2117,56 +2117,56 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         catch (JsonException ex)
         {
             throw new InvalidDataException(
-                "ShownByDefaultOverlay value must be a JSON object map",
+                "TextCollectionOverlay value must be a JSON object map",
                 ex
             );
         }
         if (map is null)
-            throw new InvalidDataException("ShownByDefaultOverlay value must be a JSON object map");
+            throw new InvalidDataException("TextCollectionOverlay value must be a JSON object map");
         WriteOverlay(map);
         SendDataUpdateEvent(
-            ProjectDataType.SHOWN_BY_DEFAULT_OVERLAY,
-            "shown-by-default overlay update event"
+            ProjectDataType.TEXT_COLLECTION_OVERLAY,
+            "text-collection overlay update event"
         );
         return true;
     }
 
-    public bool ResetShownByDefaultOverlay()
+    public bool ResetTextCollectionOverlay()
     {
         // Full reset: forget the overlay AND the initialized marker so the next first-open re-inits
         // from the current admin defaults.
         GetUserProjectSettings().RemoveSetting(OverlaySettingName);
         GetUserProjectSettings().RemoveSetting(OverlayInitializedMarkerName);
         SendDataUpdateEvent(
-            ProjectDataType.SHOWN_BY_DEFAULT_OVERLAY,
-            "shown-by-default overlay reset event"
+            ProjectDataType.TEXT_COLLECTION_OVERLAY,
+            "text-collection overlay reset event"
         );
         return true;
     }
 
     /// <summary>
-    /// First-open initialization of the current user's shown-by-default overlay for this project.
+    /// First-open initialization of the current user's text-collection overlay for this project.
     /// For each Bible-text reference in <c>PT_REFERENCED_PROJECTS_AND_RESOURCES</c> whose
-    /// <c>IsResourceShownByDefault</c> is set, records overlay[resourceId] = that value. Idempotent:
+    /// <c>InTextCollection</c> is set, records overlay[resourceId] = that value. Idempotent:
     /// a per-user-per-project marker prevents re-initialization, so later opens (and user un-checks)
     /// are preserved. Returns <c>false</c> when already initialized. Model texts do NOT participate
-    /// in shown-by-default and are intentionally not read here.
+    /// in text-collection and are intentionally not read here.
     /// </summary>
-    public bool InitializeShownByDefaultOverlay(object? param = null)
+    public bool InitializeTextCollectionOverlay(object? param = null)
     {
         var settings = GetUserProjectSettings();
         var (_, marker) = settings.GetSetting(OverlayInitializedMarkerName);
         if (marker != null)
             return false;
 
-        var overlay = GetShownByDefaultOverlay();
+        var overlay = GetTextCollectionOverlay();
         if (
             GetProjectSetting(ProjectSettingsNames.PB_REFERENCED_PROJECTS_AND_RESOURCES)
             is ResourceReferenceList list
         )
             foreach (var item in list.Items)
                 if (
-                    item.IsResourceShownByDefault is bool shown
+                    item.InTextCollection is bool shown
                     && TryGetBibleTextKey(item) is (_, string id)
                 )
                     // Overlay is keyed by resource id only (matching the TS `{ [id]: boolean }`
@@ -2182,8 +2182,8 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             new XElement("Items", "true")
         );
         SendDataUpdateEvent(
-            ProjectDataType.SHOWN_BY_DEFAULT_OVERLAY,
-            "shown-by-default overlay first-open init event"
+            ProjectDataType.TEXT_COLLECTION_OVERLAY,
+            "text-collection overlay first-open init event"
         );
         return true;
     }
@@ -2228,7 +2228,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     }
 
     /// <summary>
-    /// Validates the schema version stored alongside the shown-by-default overlay. The overlay has
+    /// Validates the schema version stored alongside the text-collection overlay. The overlay has
     /// its own version line (<see cref="OverlaySchemaVersion"/>), independent of the S/R'd resource
     /// lists, so it is validated against that rather than
     /// <see cref="ResourceReferenceList.CurrentMajorVersion"/>.
@@ -2238,11 +2238,11 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         int expectedMajor = new Version(OverlaySchemaVersion).Major;
         if (!Version.TryParse(schemaVersion, out Version? parsed))
             throw new InvalidDataException(
-                $"Shown-by-default overlay has invalid version format: '{schemaVersion}'"
+                $"Text-collection overlay has invalid version format: '{schemaVersion}'"
             );
         if (parsed.Major != expectedMajor)
             throw new InvalidDataException(
-                $"Shown-by-default overlay has incompatible major version {parsed.Major}; "
+                $"Text-collection overlay has incompatible major version {parsed.Major}; "
                     + $"expected {expectedMajor}"
             );
     }

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -1730,7 +1730,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
             ProjectSettingsNames.GetParatextSettingNameFromPlatformBibleSettingName(settingName)
             ?? settingName;
 
-        // The referenced-projects-and-resources list carries the admin-only inTextCollection
+        // The referenced-projects-and-resources list carries the admin-only isInTextCollection
         // flag (the shared text-collection default for the Scripture Text Grid), so its writes are
         // gated to project administrators server-side (the UI-facing query is
         // canUserWriteProjectTextConnectionSettings()). Model texts do NOT participate in
@@ -2147,7 +2147,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     /// <summary>
     /// First-open initialization of the current user's text-collection overlay for this project.
     /// For each Bible-text reference in <c>PT_REFERENCED_PROJECTS_AND_RESOURCES</c> whose
-    /// <c>InTextCollection</c> is set, records overlay[resourceId] = that value. Idempotent:
+    /// <c>IsInTextCollection</c> is set, records overlay[resourceId] = that value. Idempotent:
     /// a per-user-per-project marker prevents re-initialization, so later opens (and user un-checks)
     /// are preserved. Returns <c>false</c> when already initialized. Model texts do NOT participate
     /// in text-collection and are intentionally not read here.
@@ -2166,7 +2166,7 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         )
             foreach (var item in list.Items)
                 if (
-                    item.InTextCollection is bool shown
+                    item.IsInTextCollection is bool shown
                     && TryGetBibleTextKey(item) is (_, string id)
                 )
                     // Overlay is keyed by resource id only (matching the TS `{ [id]: boolean }`

--- a/c-sharp/Projects/ProjectDataType.cs
+++ b/c-sharp/Projects/ProjectDataType.cs
@@ -10,7 +10,7 @@ public static class ProjectDataType
     public const string COMMENT_THREADS = "CommentThreads";
     public const string EXTENSION_DATA = "ExtensionData";
     public const string SETTING = "Setting";
-    public const string SHOWN_BY_DEFAULT_OVERLAY = "ShownByDefaultOverlay";
+    public const string TEXT_COLLECTION_OVERLAY = "TextCollectionOverlay";
     public const string USER_MODEL_TEXTS = "UserModelTexts";
     public const string USER_REFERENCED_PROJECTS_AND_RESOURCES =
         "UserReferencedProjectsAndResources";

--- a/c-sharp/Projects/ResourceReferenceConverter.cs
+++ b/c-sharp/Projects/ResourceReferenceConverter.cs
@@ -22,47 +22,47 @@ internal sealed class ResourceReferenceConverter : JsonConverter<ResourceReferen
                 ? typeEl.GetString()
                 : null;
 
-        bool? shown = GetBool(root, "isResourceShownByDefault");
-        bool? shownForUser = GetBool(root, "isResourceShownForUser");
+        bool? shown = GetBool(root, "inTextCollection");
+        bool? shownForUser = GetBool(root, "inTextCollectionForUser");
 
         // Capture extras against the per-type known-name set so name-only types don't silently
-        // swallow (and drop) a Bible-text-only property such as "id" or "isResourceShownForUser" —
+        // swallow (and drop) a Bible-text-only property such as "id" or "inTextCollectionForUser" —
         // those flow through ExtraData instead. See ResourceReferenceList.Known*PropertyNames.
-        // isResourceShownByDefault is understood on every type (see PT-4040), so it is in both sets.
+        // inTextCollection is understood on every type (see PT-4040), so it is in both sets.
         return type switch
         {
             "project" => new ProjectReference
             {
                 Name = GetString(root, "name"),
                 Id = GetString(root, "id"),
-                IsResourceShownByDefault = shown,
-                IsResourceShownForUser = shownForUser,
+                InTextCollection = shown,
+                InTextCollectionForUser = shownForUser,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownBibleTextPropertyNames),
             },
             "dblResource" => new DblResourceReference
             {
                 Name = GetString(root, "name"),
                 Id = GetString(root, "id"),
-                IsResourceShownByDefault = shown,
-                IsResourceShownForUser = shownForUser,
+                InTextCollection = shown,
+                InTextCollectionForUser = shownForUser,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownBibleTextPropertyNames),
             },
             "enhancedResource" => new EnhancedResourceReference
             {
                 Name = GetString(root, "name"),
-                IsResourceShownByDefault = shown,
+                InTextCollection = shown,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownNamedOnlyPropertyNames),
             },
             "xmlResource" => new XmlResourceReference
             {
                 Name = GetString(root, "name"),
-                IsResourceShownByDefault = shown,
+                InTextCollection = shown,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownNamedOnlyPropertyNames),
             },
             "sourceLanguageResource" => new SourceLanguageResourceReference
             {
                 Name = GetString(root, "name"),
-                IsResourceShownByDefault = shown,
+                InTextCollection = shown,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownNamedOnlyPropertyNames),
             },
             _ => CreateUnknown(root),
@@ -145,10 +145,10 @@ internal sealed class ResourceReferenceConverter : JsonConverter<ResourceReferen
             writer.WriteString("id", dbl.Id);
 
         // Emit the two flags only when set, so old-build files stay clean.
-        if (value.IsResourceShownByDefault is bool shownVal)
-            writer.WriteBoolean("isResourceShownByDefault", shownVal);
-        if (value.IsResourceShownForUser is bool shownForUserVal)
-            writer.WriteBoolean("isResourceShownForUser", shownForUserVal);
+        if (value.InTextCollection is bool shownVal)
+            writer.WriteBoolean("inTextCollection", shownVal);
+        if (value.InTextCollectionForUser is bool shownForUserVal)
+            writer.WriteBoolean("inTextCollectionForUser", shownForUserVal);
 
         // Forward-compat: re-emit unknown properties captured on read.
         if (value.ExtraData is not null)

--- a/c-sharp/Projects/ResourceReferenceConverter.cs
+++ b/c-sharp/Projects/ResourceReferenceConverter.cs
@@ -22,47 +22,47 @@ internal sealed class ResourceReferenceConverter : JsonConverter<ResourceReferen
                 ? typeEl.GetString()
                 : null;
 
-        bool? shown = GetBool(root, "inTextCollection");
-        bool? shownForUser = GetBool(root, "inTextCollectionForUser");
+        bool? shown = GetBool(root, "isInTextCollection");
+        bool? shownForUser = GetBool(root, "isInTextCollectionForUser");
 
         // Capture extras against the per-type known-name set so name-only types don't silently
-        // swallow (and drop) a Bible-text-only property such as "id" or "inTextCollectionForUser" —
+        // swallow (and drop) a Bible-text-only property such as "id" or "isInTextCollectionForUser" —
         // those flow through ExtraData instead. See ResourceReferenceList.Known*PropertyNames.
-        // inTextCollection is understood on every type (see PT-4040), so it is in both sets.
+        // isInTextCollection is understood on every type (see PT-4040), so it is in both sets.
         return type switch
         {
             "project" => new ProjectReference
             {
                 Name = GetString(root, "name"),
                 Id = GetString(root, "id"),
-                InTextCollection = shown,
-                InTextCollectionForUser = shownForUser,
+                IsInTextCollection = shown,
+                IsInTextCollectionForUser = shownForUser,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownBibleTextPropertyNames),
             },
             "dblResource" => new DblResourceReference
             {
                 Name = GetString(root, "name"),
                 Id = GetString(root, "id"),
-                InTextCollection = shown,
-                InTextCollectionForUser = shownForUser,
+                IsInTextCollection = shown,
+                IsInTextCollectionForUser = shownForUser,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownBibleTextPropertyNames),
             },
             "enhancedResource" => new EnhancedResourceReference
             {
                 Name = GetString(root, "name"),
-                InTextCollection = shown,
+                IsInTextCollection = shown,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownNamedOnlyPropertyNames),
             },
             "xmlResource" => new XmlResourceReference
             {
                 Name = GetString(root, "name"),
-                InTextCollection = shown,
+                IsInTextCollection = shown,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownNamedOnlyPropertyNames),
             },
             "sourceLanguageResource" => new SourceLanguageResourceReference
             {
                 Name = GetString(root, "name"),
-                InTextCollection = shown,
+                IsInTextCollection = shown,
                 ExtraData = CaptureExtras(root, ResourceReferenceList.KnownNamedOnlyPropertyNames),
             },
             _ => CreateUnknown(root),
@@ -145,10 +145,10 @@ internal sealed class ResourceReferenceConverter : JsonConverter<ResourceReferen
             writer.WriteString("id", dbl.Id);
 
         // Emit the two flags only when set, so old-build files stay clean.
-        if (value.InTextCollection is bool shownVal)
-            writer.WriteBoolean("inTextCollection", shownVal);
-        if (value.InTextCollectionForUser is bool shownForUserVal)
-            writer.WriteBoolean("inTextCollectionForUser", shownForUserVal);
+        if (value.IsInTextCollection is bool shownVal)
+            writer.WriteBoolean("isInTextCollection", shownVal);
+        if (value.IsInTextCollectionForUser is bool shownForUserVal)
+            writer.WriteBoolean("isInTextCollectionForUser", shownForUserVal);
 
         // Forward-compat: re-emit unknown properties captured on read.
         if (value.ExtraData is not null)

--- a/c-sharp/Projects/ResourceReferenceList.cs
+++ b/c-sharp/Projects/ResourceReferenceList.cs
@@ -16,14 +16,14 @@ public abstract record ResourceReference
     /// Understood on every reference type; null/absent means no admin preference. Serialized only
     /// when non-null.
     /// </summary>
-    public bool? InTextCollection { get; init; }
+    public bool? IsInTextCollection { get; init; }
 
     /// <summary>
     /// User-scope (NOT Send/Receive'd) flag: whether the current user has included this resource
     /// from their personal list in the text collection. Nullable/absent by default; meaningful only
     /// for Bible-text references. Serialized only when non-null.
     /// </summary>
-    public bool? InTextCollectionForUser { get; init; }
+    public bool? IsInTextCollectionForUser { get; init; }
 
     /// <summary>
     /// Forward-compat passthrough for JSON/XML properties this build does not recognize, so a
@@ -82,8 +82,8 @@ public record ResourceReferenceList
         "type",
         "name",
         "id",
-        "inTextCollection",
-        "inTextCollectionForUser",
+        "isInTextCollection",
+        "isInTextCollectionForUser",
     };
 
     /// <summary>
@@ -91,15 +91,15 @@ public record ResourceReferenceList
     /// (<see cref="EnhancedResourceReference"/>, <see cref="XmlResourceReference"/>,
     /// <see cref="SourceLanguageResourceReference"/>). Narrower than
     /// <see cref="KnownBibleTextPropertyNames"/> because these types never carry <c>id</c> or
-    /// <c>inTextCollectionForUser</c>; properties outside this set flow through
-    /// <see cref="ResourceReference.ExtraData"/>. Includes <c>inTextCollection</c>, which is
+    /// <c>isInTextCollectionForUser</c>; properties outside this set flow through
+    /// <see cref="ResourceReference.ExtraData"/>. Includes <c>isInTextCollection</c>, which is
     /// understood on every reference type (see PT-4040).
     /// </summary>
     internal static readonly IReadOnlySet<string> KnownNamedOnlyPropertyNames = new HashSet<string>
     {
         "type",
         "name",
-        "inTextCollection",
+        "isInTextCollection",
     };
 
     /// <summary>
@@ -153,11 +153,11 @@ public record ResourceReferenceList
                 // Write the two flags only when set, so old-build files stay clean. XML attributes
                 // are untyped strings; booleans are emitted lowercase and parsed back with
                 // bool.TryParse (the JSON path uses a native JSON boolean instead).
-                if (item.InTextCollection is bool shown)
-                    element.Add(new XAttribute("inTextCollection", shown ? "true" : "false"));
-                if (item.InTextCollectionForUser is bool shownForUser)
+                if (item.IsInTextCollection is bool shown)
+                    element.Add(new XAttribute("isInTextCollection", shown ? "true" : "false"));
+                if (item.IsInTextCollectionForUser is bool shownForUser)
                     element.Add(
-                        new XAttribute("inTextCollectionForUser", shownForUser ? "true" : "false")
+                        new XAttribute("isInTextCollectionForUser", shownForUser ? "true" : "false")
                     );
 
                 AddExtraDataAttributes(element, item.ExtraData);
@@ -213,7 +213,7 @@ public record ResourceReferenceList
 
                 // Capture unknown attributes against the per-type known-name set (everything else ->
                 // ExtraData). Name-only types use the narrower set so a Bible-text-only attribute such
-                // as "id" or "inTextCollectionForUser" round-trips instead of being silently dropped.
+                // as "id" or "isInTextCollectionForUser" round-trips instead of being silently dropped.
                 static Dictionary<string, JsonElement>? CaptureExtras(
                     XElement el,
                     IReadOnlySet<string> known
@@ -235,34 +235,34 @@ public record ResourceReferenceList
                         {
                             Name = name,
                             Id = el.Attribute("id")?.Value ?? "",
-                            InTextCollection = ParseFlag(el, "inTextCollection"),
-                            InTextCollectionForUser = ParseFlag(el, "inTextCollectionForUser"),
+                            IsInTextCollection = ParseFlag(el, "isInTextCollection"),
+                            IsInTextCollectionForUser = ParseFlag(el, "isInTextCollectionForUser"),
                             ExtraData = CaptureExtras(el, KnownBibleTextPropertyNames),
                         },
                         "dblResource" => new DblResourceReference
                         {
                             Name = name,
                             Id = el.Attribute("id")?.Value ?? "",
-                            InTextCollection = ParseFlag(el, "inTextCollection"),
-                            InTextCollectionForUser = ParseFlag(el, "inTextCollectionForUser"),
+                            IsInTextCollection = ParseFlag(el, "isInTextCollection"),
+                            IsInTextCollectionForUser = ParseFlag(el, "isInTextCollectionForUser"),
                             ExtraData = CaptureExtras(el, KnownBibleTextPropertyNames),
                         },
                         "enhancedResource" => new EnhancedResourceReference
                         {
                             Name = name,
-                            InTextCollection = ParseFlag(el, "inTextCollection"),
+                            IsInTextCollection = ParseFlag(el, "isInTextCollection"),
                             ExtraData = CaptureExtras(el, KnownNamedOnlyPropertyNames),
                         },
                         "xmlResource" => new XmlResourceReference
                         {
                             Name = name,
-                            InTextCollection = ParseFlag(el, "inTextCollection"),
+                            IsInTextCollection = ParseFlag(el, "isInTextCollection"),
                             ExtraData = CaptureExtras(el, KnownNamedOnlyPropertyNames),
                         },
                         "sourceLanguageResource" => new SourceLanguageResourceReference
                         {
                             Name = name,
-                            InTextCollection = ParseFlag(el, "inTextCollection"),
+                            IsInTextCollection = ParseFlag(el, "isInTextCollection"),
                             ExtraData = CaptureExtras(el, KnownNamedOnlyPropertyNames),
                         },
                         _ => new UnknownResourceReference

--- a/c-sharp/Projects/ResourceReferenceList.cs
+++ b/c-sharp/Projects/ResourceReferenceList.cs
@@ -10,19 +10,20 @@ public abstract record ResourceReference
     public string Name { get; init; } = string.Empty;
 
     /// <summary>
-    /// Project-scope (Send/Receive'd) admin flag: when set, this resource is shown by default.
-    /// Consumed by the shared layout (PT-4040) and, for Bible-text resources, by the Scripture Text
-    /// Grid, where it also seeds new users' per-user overlay on first open (PT-4050). Understood on
-    /// every reference type; null/absent means no admin preference. Serialized only when non-null.
+    /// Project-scope (Send/Receive'd) admin flag: when set, this resource is in the text collection
+    /// by default. Consumed by the shared layout (PT-4040) and, for Bible-text resources, by the
+    /// Scripture Text Grid, where it also seeds new users' per-user overlay on first open (PT-4050).
+    /// Understood on every reference type; null/absent means no admin preference. Serialized only
+    /// when non-null.
     /// </summary>
-    public bool? IsResourceShownByDefault { get; init; }
+    public bool? InTextCollection { get; init; }
 
     /// <summary>
-    /// User-scope (NOT Send/Receive'd) per-resource checkbox state on the current user's personal
-    /// resources list. Nullable/absent by default; meaningful only for Bible-text references.
-    /// Serialized only when non-null.
+    /// User-scope (NOT Send/Receive'd) flag: whether the current user has included this resource
+    /// from their personal list in the text collection. Nullable/absent by default; meaningful only
+    /// for Bible-text references. Serialized only when non-null.
     /// </summary>
-    public bool? IsResourceShownForUser { get; init; }
+    public bool? InTextCollectionForUser { get; init; }
 
     /// <summary>
     /// Forward-compat passthrough for JSON/XML properties this build does not recognize, so a
@@ -81,8 +82,8 @@ public record ResourceReferenceList
         "type",
         "name",
         "id",
-        "isResourceShownByDefault",
-        "isResourceShownForUser",
+        "inTextCollection",
+        "inTextCollectionForUser",
     };
 
     /// <summary>
@@ -90,15 +91,15 @@ public record ResourceReferenceList
     /// (<see cref="EnhancedResourceReference"/>, <see cref="XmlResourceReference"/>,
     /// <see cref="SourceLanguageResourceReference"/>). Narrower than
     /// <see cref="KnownBibleTextPropertyNames"/> because these types never carry <c>id</c> or
-    /// <c>isResourceShownForUser</c>; properties outside this set flow through
-    /// <see cref="ResourceReference.ExtraData"/>. Includes <c>isResourceShownByDefault</c>, which is
+    /// <c>inTextCollectionForUser</c>; properties outside this set flow through
+    /// <see cref="ResourceReference.ExtraData"/>. Includes <c>inTextCollection</c>, which is
     /// understood on every reference type (see PT-4040).
     /// </summary>
     internal static readonly IReadOnlySet<string> KnownNamedOnlyPropertyNames = new HashSet<string>
     {
         "type",
         "name",
-        "isResourceShownByDefault",
+        "inTextCollection",
     };
 
     /// <summary>
@@ -152,13 +153,11 @@ public record ResourceReferenceList
                 // Write the two flags only when set, so old-build files stay clean. XML attributes
                 // are untyped strings; booleans are emitted lowercase and parsed back with
                 // bool.TryParse (the JSON path uses a native JSON boolean instead).
-                if (item.IsResourceShownByDefault is bool shown)
+                if (item.InTextCollection is bool shown)
+                    element.Add(new XAttribute("inTextCollection", shown ? "true" : "false"));
+                if (item.InTextCollectionForUser is bool shownForUser)
                     element.Add(
-                        new XAttribute("isResourceShownByDefault", shown ? "true" : "false")
-                    );
-                if (item.IsResourceShownForUser is bool shownForUser)
-                    element.Add(
-                        new XAttribute("isResourceShownForUser", shownForUser ? "true" : "false")
+                        new XAttribute("inTextCollectionForUser", shownForUser ? "true" : "false")
                     );
 
                 AddExtraDataAttributes(element, item.ExtraData);
@@ -214,7 +213,7 @@ public record ResourceReferenceList
 
                 // Capture unknown attributes against the per-type known-name set (everything else ->
                 // ExtraData). Name-only types use the narrower set so a Bible-text-only attribute such
-                // as "id" or "isResourceShownForUser" round-trips instead of being silently dropped.
+                // as "id" or "inTextCollectionForUser" round-trips instead of being silently dropped.
                 static Dictionary<string, JsonElement>? CaptureExtras(
                     XElement el,
                     IReadOnlySet<string> known
@@ -236,34 +235,34 @@ public record ResourceReferenceList
                         {
                             Name = name,
                             Id = el.Attribute("id")?.Value ?? "",
-                            IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
-                            IsResourceShownForUser = ParseFlag(el, "isResourceShownForUser"),
+                            InTextCollection = ParseFlag(el, "inTextCollection"),
+                            InTextCollectionForUser = ParseFlag(el, "inTextCollectionForUser"),
                             ExtraData = CaptureExtras(el, KnownBibleTextPropertyNames),
                         },
                         "dblResource" => new DblResourceReference
                         {
                             Name = name,
                             Id = el.Attribute("id")?.Value ?? "",
-                            IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
-                            IsResourceShownForUser = ParseFlag(el, "isResourceShownForUser"),
+                            InTextCollection = ParseFlag(el, "inTextCollection"),
+                            InTextCollectionForUser = ParseFlag(el, "inTextCollectionForUser"),
                             ExtraData = CaptureExtras(el, KnownBibleTextPropertyNames),
                         },
                         "enhancedResource" => new EnhancedResourceReference
                         {
                             Name = name,
-                            IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
+                            InTextCollection = ParseFlag(el, "inTextCollection"),
                             ExtraData = CaptureExtras(el, KnownNamedOnlyPropertyNames),
                         },
                         "xmlResource" => new XmlResourceReference
                         {
                             Name = name,
-                            IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
+                            InTextCollection = ParseFlag(el, "inTextCollection"),
                             ExtraData = CaptureExtras(el, KnownNamedOnlyPropertyNames),
                         },
                         "sourceLanguageResource" => new SourceLanguageResourceReference
                         {
                             Name = name,
-                            IsResourceShownByDefault = ParseFlag(el, "isResourceShownByDefault"),
+                            InTextCollection = ParseFlag(el, "inTextCollection"),
                             ExtraData = CaptureExtras(el, KnownNamedOnlyPropertyNames),
                         },
                         _ => new UnknownResourceReference

--- a/e2e-tests/tests/enhanced-resources/scripture-text-grid.spec.ts
+++ b/e2e-tests/tests/enhanced-resources/scripture-text-grid.spec.ts
@@ -149,7 +149,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project',
         name: 'STG renderer smoke',
         id: SYNTHETIC_BAD_ID,
-        inTextCollection: true,
+        isInTextCollection: true,
       },
     ]);
 
@@ -171,7 +171,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project',
         name: 'STG renderer split',
         id: SYNTHETIC_BAD_ID,
-        inTextCollection: true,
+        isInTextCollection: true,
       },
     ]);
 
@@ -203,7 +203,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project',
         name: 'STG renderer esc',
         id: SYNTHETIC_BAD_ID,
-        inTextCollection: true,
+        isInTextCollection: true,
       },
     ]);
 
@@ -226,8 +226,8 @@ test.describe('Scripture Text Grid renderer', () => {
     warnAndSkip(!projectId, 'No admin-writable text-connection project found locally');
 
     await flagResourcesAndOpenScriptureTextGrid(mainPage, projectId, [
-      { type: 'project', name: 'WEB', id: 'rtl001', inTextCollection: true },
-      { type: 'project', name: 'KJV', id: 'rtl002', inTextCollection: true },
+      { type: 'project', name: 'WEB', id: 'rtl001', isInTextCollection: true },
+      { type: 'project', name: 'KJV', id: 'rtl002', isInTextCollection: true },
     ]);
 
     const frame = await openScriptureTextGrid(mainPage);
@@ -264,13 +264,13 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project' as const,
         name: `Valid ${index + 1}`,
         id,
-        inTextCollection: true,
+        isInTextCollection: true,
       })),
       {
         type: 'project',
         name: 'Bad resource',
         id: SYNTHETIC_BAD_ID,
-        inTextCollection: true,
+        isInTextCollection: true,
       },
     ]);
 
@@ -301,7 +301,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project' as const,
         name: `Sync ${index + 1}`,
         id,
-        inTextCollection: true,
+        isInTextCollection: true,
       })),
     );
 
@@ -351,7 +351,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project' as const,
         name: `Perf ${index + 1}`,
         id,
-        inTextCollection: true,
+        isInTextCollection: true,
       })),
     );
 
@@ -383,8 +383,8 @@ test.describe('Scripture Text Grid renderer', () => {
     warnAndSkip(!projectId, 'No admin-writable text-connection project found locally');
 
     await flagResourcesAndOpenScriptureTextGrid(mainPage, projectId, [
-      { type: 'project', name: 'WEB', id: 'chap001', inTextCollection: true },
-      { type: 'project', name: 'KJV', id: 'chap002', inTextCollection: true },
+      { type: 'project', name: 'WEB', id: 'chap001', isInTextCollection: true },
+      { type: 'project', name: 'KJV', id: 'chap002', isInTextCollection: true },
     ]);
 
     const frame = await openScriptureTextGrid(mainPage);
@@ -420,7 +420,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project' as const,
         name: `ChapSync ${index + 1}`,
         id,
-        inTextCollection: true,
+        isInTextCollection: true,
       })),
     );
 
@@ -456,7 +456,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project' as const,
         name: `ChapPerf ${index + 1}`,
         id,
-        inTextCollection: true,
+        isInTextCollection: true,
       })),
     );
 
@@ -496,8 +496,8 @@ test.describe('Scripture Text Grid renderer', () => {
     warnAndSkip(!projectId, 'No admin-writable text-connection project found locally');
 
     await flagResourcesAndOpenScriptureTextGrid(mainPage, projectId, [
-      { type: 'project', name: 'WEB', id: 'chaprtl1', inTextCollection: true },
-      { type: 'project', name: 'KJV', id: 'chaprtl2', inTextCollection: true },
+      { type: 'project', name: 'WEB', id: 'chaprtl1', isInTextCollection: true },
+      { type: 'project', name: 'KJV', id: 'chaprtl2', isInTextCollection: true },
     ]);
 
     const frame = await openScriptureTextGrid(mainPage);

--- a/e2e-tests/tests/enhanced-resources/scripture-text-grid.spec.ts
+++ b/e2e-tests/tests/enhanced-resources/scripture-text-grid.spec.ts
@@ -135,7 +135,7 @@ test.describe('Scripture Text Grid renderer', () => {
     await restoreScriptureTextGridProjectSettings(mainPage);
   });
 
-  test('non-negotiable #1: a shown resource renders a list item (no blank-out, no empty toolbar)', async ({
+  test('a shown resource renders a list item (no blank-out, no empty toolbar)', async ({
     mainPage,
   }) => {
     test.skip(!!process.env.CI, 'Mutates real project settings — local runs only');
@@ -149,7 +149,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project',
         name: 'STG renderer smoke',
         id: SYNTHETIC_BAD_ID,
-        isResourceShownByDefault: true,
+        inTextCollection: true,
       },
     ]);
 
@@ -171,7 +171,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project',
         name: 'STG renderer split',
         id: SYNTHETIC_BAD_ID,
-        isResourceShownByDefault: true,
+        inTextCollection: true,
       },
     ]);
 
@@ -203,7 +203,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project',
         name: 'STG renderer esc',
         id: SYNTHETIC_BAD_ID,
-        isResourceShownByDefault: true,
+        inTextCollection: true,
       },
     ]);
 
@@ -226,8 +226,8 @@ test.describe('Scripture Text Grid renderer', () => {
     warnAndSkip(!projectId, 'No admin-writable text-connection project found locally');
 
     await flagResourcesAndOpenScriptureTextGrid(mainPage, projectId, [
-      { type: 'project', name: 'WEB', id: 'rtl001', isResourceShownByDefault: true },
-      { type: 'project', name: 'KJV', id: 'rtl002', isResourceShownByDefault: true },
+      { type: 'project', name: 'WEB', id: 'rtl001', inTextCollection: true },
+      { type: 'project', name: 'KJV', id: 'rtl002', inTextCollection: true },
     ]);
 
     const frame = await openScriptureTextGrid(mainPage);
@@ -264,13 +264,13 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project' as const,
         name: `Valid ${index + 1}`,
         id,
-        isResourceShownByDefault: true,
+        inTextCollection: true,
       })),
       {
         type: 'project',
         name: 'Bad resource',
         id: SYNTHETIC_BAD_ID,
-        isResourceShownByDefault: true,
+        inTextCollection: true,
       },
     ]);
 
@@ -301,7 +301,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project' as const,
         name: `Sync ${index + 1}`,
         id,
-        isResourceShownByDefault: true,
+        inTextCollection: true,
       })),
     );
 
@@ -351,7 +351,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project' as const,
         name: `Perf ${index + 1}`,
         id,
-        isResourceShownByDefault: true,
+        inTextCollection: true,
       })),
     );
 
@@ -383,8 +383,8 @@ test.describe('Scripture Text Grid renderer', () => {
     warnAndSkip(!projectId, 'No admin-writable text-connection project found locally');
 
     await flagResourcesAndOpenScriptureTextGrid(mainPage, projectId, [
-      { type: 'project', name: 'WEB', id: 'chap001', isResourceShownByDefault: true },
-      { type: 'project', name: 'KJV', id: 'chap002', isResourceShownByDefault: true },
+      { type: 'project', name: 'WEB', id: 'chap001', inTextCollection: true },
+      { type: 'project', name: 'KJV', id: 'chap002', inTextCollection: true },
     ]);
 
     const frame = await openScriptureTextGrid(mainPage);
@@ -420,7 +420,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project' as const,
         name: `ChapSync ${index + 1}`,
         id,
-        isResourceShownByDefault: true,
+        inTextCollection: true,
       })),
     );
 
@@ -456,7 +456,7 @@ test.describe('Scripture Text Grid renderer', () => {
         type: 'project' as const,
         name: `ChapPerf ${index + 1}`,
         id,
-        isResourceShownByDefault: true,
+        inTextCollection: true,
       })),
     );
 
@@ -496,8 +496,8 @@ test.describe('Scripture Text Grid renderer', () => {
     warnAndSkip(!projectId, 'No admin-writable text-connection project found locally');
 
     await flagResourcesAndOpenScriptureTextGrid(mainPage, projectId, [
-      { type: 'project', name: 'WEB', id: 'chaprtl1', isResourceShownByDefault: true },
-      { type: 'project', name: 'KJV', id: 'chaprtl2', isResourceShownByDefault: true },
+      { type: 'project', name: 'WEB', id: 'chaprtl1', inTextCollection: true },
+      { type: 'project', name: 'KJV', id: 'chaprtl2', inTextCollection: true },
     ]);
 
     const frame = await openScriptureTextGrid(mainPage);

--- a/e2e-tests/tests/enhanced-resources/test-helpers.ts
+++ b/e2e-tests/tests/enhanced-resources/test-helpers.ts
@@ -62,7 +62,7 @@ export type FlaggedResourceItem = {
   type: 'project';
   name: string;
   id: string;
-  inTextCollection: boolean;
+  isInTextCollection: boolean;
 };
 
 type ScriptureTextGridRestorePayload = {

--- a/e2e-tests/tests/enhanced-resources/test-helpers.ts
+++ b/e2e-tests/tests/enhanced-resources/test-helpers.ts
@@ -44,8 +44,8 @@ export type ScriptureTextGridPapiWindow = {
         setSetting: (key: string, value: unknown) => Promise<boolean>;
         getSetting: (key: string) => Promise<{ items: unknown[] }>;
         canUserWriteProjectTextConnectionSettings: () => Promise<boolean>;
-        resetShownByDefaultOverlay: () => Promise<boolean>;
-        initializeShownByDefaultOverlay: () => Promise<boolean>;
+        resetTextCollectionOverlay: () => Promise<boolean>;
+        initializeTextCollectionOverlay: () => Promise<boolean>;
       }>;
     };
     webViews: {
@@ -62,7 +62,7 @@ export type FlaggedResourceItem = {
   type: 'project';
   name: string;
   id: string;
-  isResourceShownByDefault: boolean;
+  inTextCollection: boolean;
 };
 
 type ScriptureTextGridRestorePayload = {
@@ -106,7 +106,7 @@ export async function discoverAdminTextConnectionProject(
 }
 
 /**
- * Flag resources shown-by-default, seed the overlay, and open the Scripture Text Grid web view.
+ * Flag resources text-collection, seed the overlay, and open the Scripture Text Grid web view.
  * Restores the project's pre-test settings in a `finally` block.
  */
 export async function flagResourcesAndOpenScriptureTextGrid(
@@ -130,13 +130,13 @@ export async function flagResourcesAndOpenScriptureTextGrid(
           dataVersion: '1.1.0',
           items: modelItems,
         });
-        await pdp.resetShownByDefaultOverlay();
-        await pdp.initializeShownByDefaultOverlay();
+        await pdp.resetTextCollectionOverlay();
+        await pdp.initializeTextCollectionOverlay();
         await papi.webViews.openWebView(webViewType, undefined, { existingId: '?' });
         return { projectId: testProjectId, modelTexts: originalModelTexts };
       } catch (error) {
         await pdp.setSetting('platformScripture.modelTexts', originalModelTexts);
-        await pdp.resetShownByDefaultOverlay();
+        await pdp.resetTextCollectionOverlay();
         throw error;
       }
     },
@@ -160,7 +160,7 @@ export async function restoreScriptureTextGridProjectSettings(page: Page): Promi
           payload.projectId,
         );
         await pdp.setSetting('platformScripture.modelTexts', payload.modelTexts);
-        await pdp.resetShownByDefaultOverlay();
+        await pdp.resetTextCollectionOverlay();
         await papi.webViews.openWebView(webViewType, undefined, { existingId: '?' });
       },
       { payload: restore, webViewType: SCRIPTURE_TEXT_GRID_WEBVIEW_TYPE },

--- a/e2e-tests/tests/enhanced-resources/text-collection-schema.spec.ts
+++ b/e2e-tests/tests/enhanced-resources/text-collection-schema.spec.ts
@@ -6,11 +6,11 @@
  * nowhere in the repo. To run it locally, boot the app with CDP enabled, set `E2E_TEST_PROJECT_ID`
  * to a known editable admin project, and run the `enhanced-resources` project (see the run command
  * in `e2e-tests/playwright.config.ts`). Regression protection for this feature comes from the C#
- * unit tests (ParatextProjectDataProviderShownByDefaultTests); this spec is a manual smoke check.
+ * unit tests (ParatextProjectDataProviderTextCollectionTests); this spec is a manual smoke check.
  *
  * Scope — vanilla-core-observable only:
  *
- * - `isResourceShownByDefault` persists through the referenced-resources setting round-trip.
+ * - `inTextCollection` persists through the referenced-resources setting round-trip.
  * - First-open init writes the per-user overlay to match the project's flags.
  * - The admin gate on the referenced-resources write is enforced server-side; it is covered by the C#
  *   unit tests, not asserted here — this fixture runs as the default (admin) user.
@@ -30,7 +30,7 @@ import { waitForAppReady } from '../../fixtures/helpers';
 // The env-var + test.skip guard is therefore the correct pattern here.
 const TEST_PROJECT_ID = process.env.E2E_TEST_PROJECT_ID ?? '';
 
-test.describe('Scripture Text Grid shown-by-default schema (A2)', () => {
+test.describe('Scripture Text Grid text collection schema (A2)', () => {
   test('project flag persists and first-open init seeds the overlay', async ({ mainPage }) => {
     test.skip(!TEST_PROJECT_ID, 'No editable admin test project configured for this run');
     await waitForAppReady(mainPage);
@@ -50,10 +50,10 @@ test.describe('Scripture Text Grid shown-by-default schema (A2)', () => {
               // the return here to that shape. This lets the assertions below avoid a type assertion.
               getSetting: (
                 key: string,
-              ) => Promise<{ items: { id?: string; isResourceShownByDefault?: boolean }[] }>;
-              resetShownByDefaultOverlay: () => Promise<boolean>;
-              initializeShownByDefaultOverlay: () => Promise<boolean>;
-              getShownByDefaultOverlay: () => Promise<Record<string, boolean>>;
+              ) => Promise<{ items: { id?: string; inTextCollection?: boolean }[] }>;
+              resetTextCollectionOverlay: () => Promise<boolean>;
+              initializeTextCollectionOverlay: () => Promise<boolean>;
+              getTextCollectionOverlay: () => Promise<Record<string, boolean>>;
             }>;
           };
         };
@@ -72,7 +72,7 @@ test.describe('Scripture Text Grid shown-by-default schema (A2)', () => {
             type: 'project',
             name: 'P',
             id: 'aabbccddeeff00112233',
-            isResourceShownByDefault: true,
+            inTextCollection: true,
           },
         ],
       });
@@ -80,9 +80,9 @@ test.describe('Scripture Text Grid shown-by-default schema (A2)', () => {
       const stored = await pdp.getSetting('platformScripture.referencedProjectsAndResources');
 
       // First open initializes the overlay to match the project's flags.
-      await pdp.resetShownByDefaultOverlay();
-      const didInit = await pdp.initializeShownByDefaultOverlay();
-      const overlay = await pdp.getShownByDefaultOverlay();
+      await pdp.resetTextCollectionOverlay();
+      const didInit = await pdp.initializeTextCollectionOverlay();
+      const overlay = await pdp.getTextCollectionOverlay();
 
       return { stored, didInit, overlay };
     }, TEST_PROJECT_ID);
@@ -92,7 +92,7 @@ test.describe('Scripture Text Grid shown-by-default schema (A2)', () => {
     expect(result.stored).toBeTruthy();
 
     const flaggedItem = result.stored.items.find((i) => i.id === 'aabbccddeeff00112233');
-    expect(flaggedItem?.isResourceShownByDefault).toBe(true);
+    expect(flaggedItem?.inTextCollection).toBe(true);
     expect(result.didInit).toBe(true);
     expect(result.overlay.aabbccddeeff00112233).toBe(true);
   });

--- a/e2e-tests/tests/enhanced-resources/text-collection-schema.spec.ts
+++ b/e2e-tests/tests/enhanced-resources/text-collection-schema.spec.ts
@@ -10,7 +10,7 @@
  *
  * Scope — vanilla-core-observable only:
  *
- * - `inTextCollection` persists through the referenced-resources setting round-trip.
+ * - `isInTextCollection` persists through the referenced-resources setting round-trip.
  * - First-open init writes the per-user overlay to match the project's flags.
  * - The admin gate on the referenced-resources write is enforced server-side; it is covered by the C#
  *   unit tests, not asserted here — this fixture runs as the default (admin) user.
@@ -50,7 +50,7 @@ test.describe('Scripture Text Grid text collection schema (A2)', () => {
               // the return here to that shape. This lets the assertions below avoid a type assertion.
               getSetting: (
                 key: string,
-              ) => Promise<{ items: { id?: string; inTextCollection?: boolean }[] }>;
+              ) => Promise<{ items: { id?: string; isInTextCollection?: boolean }[] }>;
               resetTextCollectionOverlay: () => Promise<boolean>;
               initializeTextCollectionOverlay: () => Promise<boolean>;
               getTextCollectionOverlay: () => Promise<Record<string, boolean>>;
@@ -72,7 +72,7 @@ test.describe('Scripture Text Grid text collection schema (A2)', () => {
             type: 'project',
             name: 'P',
             id: 'aabbccddeeff00112233',
-            inTextCollection: true,
+            isInTextCollection: true,
           },
         ],
       });
@@ -92,7 +92,7 @@ test.describe('Scripture Text Grid text collection schema (A2)', () => {
     expect(result.stored).toBeTruthy();
 
     const flaggedItem = result.stored.items.find((i) => i.id === 'aabbccddeeff00112233');
-    expect(flaggedItem?.inTextCollection).toBe(true);
+    expect(flaggedItem?.isInTextCollection).toBe(true);
     expect(result.didInit).toBe(true);
     expect(result.overlay.aabbccddeeff00112233).toBe(true);
   });

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
@@ -50,7 +50,7 @@ const ids = (refs: ResourceReference[]): string[] =>
 /** Reads a Bible-text flag off a reference without a type assertion. */
 const flagOf = (
   ref: ResourceReference | undefined,
-  key: 'inTextCollection' | 'inTextCollectionForUser',
+  key: 'isInTextCollection' | 'isInTextCollectionForUser',
 ): boolean | undefined =>
   ref && (isProjectReference(ref) || isDblResourceReference(ref)) ? ref[key] : undefined;
 
@@ -71,7 +71,7 @@ describe('getScriptureTextGridContents', () => {
       label: 'admin flagged true, overlay true → shown',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { inTextCollection: true })]),
+          adminReferenced: list([project('a', { isInTextCollection: true })]),
           overlay: { a: true },
         }),
       expected: ['a'],
@@ -80,7 +80,7 @@ describe('getScriptureTextGridContents', () => {
       label: 'admin flagged true, overlay false (user hid it) → hidden',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { inTextCollection: true })]),
+          adminReferenced: list([project('a', { isInTextCollection: true })]),
           overlay: { a: false },
         }),
       expected: [],
@@ -89,7 +89,7 @@ describe('getScriptureTextGridContents', () => {
       label: 'admin flagged true, overlay absent → shown (falls back to flag)',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { inTextCollection: true })]),
+          adminReferenced: list([project('a', { isInTextCollection: true })]),
           overlay: {},
         }),
       expected: ['a'],
@@ -107,7 +107,7 @@ describe('getScriptureTextGridContents', () => {
       label: 'admin flag false, no overlay → hidden (admin opted it out)',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { inTextCollection: false })]),
+          adminReferenced: list([project('a', { isInTextCollection: false })]),
           overlay: {},
         }),
       expected: [],
@@ -116,21 +116,21 @@ describe('getScriptureTextGridContents', () => {
       label: 'admin flag false, overlay true (user re-enabled) → shown',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { inTextCollection: false })]),
+          adminReferenced: list([project('a', { isInTextCollection: false })]),
           overlay: { a: true },
         }),
       expected: ['a'],
     },
     {
-      label: 'user entry inTextCollectionForUser true → shown',
+      label: 'user entry isInTextCollectionForUser true → shown',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { inTextCollectionForUser: true })]) }),
+        makeSources({ userReferenced: list([dbl('u', { isInTextCollectionForUser: true })]) }),
       expected: ['u'],
     },
     {
-      label: 'user entry inTextCollectionForUser false → hidden',
+      label: 'user entry isInTextCollectionForUser false → hidden',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { inTextCollectionForUser: false })]) }),
+        makeSources({ userReferenced: list([dbl('u', { isInTextCollectionForUser: false })]) }),
       expected: [],
     },
     {
@@ -145,8 +145,8 @@ describe('getScriptureTextGridContents', () => {
   it('dedupes an id present in both admin and user lists, keeping the admin entry', () => {
     const contents = getScriptureTextGridContents(
       makeSources({
-        adminReferenced: list([project('x', { inTextCollection: true })]),
-        userReferenced: list([project('x', { inTextCollectionForUser: true })]),
+        adminReferenced: list([project('x', { isInTextCollection: true })]),
+        userReferenced: list([project('x', { isInTextCollectionForUser: true })]),
         overlay: { x: true },
       }),
     );
@@ -158,10 +158,10 @@ describe('getScriptureTextGridContents', () => {
     const contents = getScriptureTextGridContents(
       makeSources({
         adminReferenced: list([
-          project('m', { inTextCollection: true }),
-          dbl('r', { inTextCollection: true }),
+          project('m', { isInTextCollection: true }),
+          dbl('r', { isInTextCollection: true }),
         ]),
-        userReferenced: list([project('u', { inTextCollectionForUser: true })]),
+        userReferenced: list([project('u', { isInTextCollectionForUser: true })]),
         overlay: {},
       }),
     );
@@ -172,8 +172,8 @@ describe('getScriptureTextGridContents', () => {
     const contents = getScriptureTextGridContents(
       makeSources({
         adminReferenced: list([
-          { type: 'enhancedResource', name: 'Enhanced', inTextCollection: true },
-          project('a', { inTextCollection: true }),
+          { type: 'enhancedResource', name: 'Enhanced', isInTextCollection: true },
+          project('a', { isInTextCollection: true }),
         ]),
         overlay: { a: true },
       }),
@@ -186,7 +186,7 @@ describe('getScriptureTextGridContents', () => {
       makeSources({
         userReferenced: list([
           { type: 'enhancedResource', name: 'Enhanced' },
-          dbl('u', { inTextCollectionForUser: true }),
+          dbl('u', { isInTextCollectionForUser: true }),
         ]),
       }),
     );
@@ -199,7 +199,7 @@ describe('getScriptureTextGridContents', () => {
     const contents = getScriptureTextGridContents(
       makeSources({
         adminReferenced: list([project('x')]),
-        userReferenced: list([project('x', { inTextCollectionForUser: true })]),
+        userReferenced: list([project('x', { isInTextCollectionForUser: true })]),
         overlay: {},
       }),
     );
@@ -209,8 +209,8 @@ describe('getScriptureTextGridContents', () => {
   it('does not mutate its inputs', () => {
     const sources = deepFreeze(
       makeSources({
-        adminReferenced: list([project('a', { inTextCollection: true })]),
-        userReferenced: list([dbl('u', { inTextCollectionForUser: true })]),
+        adminReferenced: list([project('a', { isInTextCollection: true })]),
+        userReferenced: list([dbl('u', { isInTextCollectionForUser: true })]),
         overlay: { a: true },
       }),
     );
@@ -224,7 +224,7 @@ describe('getViewOptionsTexts', () => {
       label: 'admin flagged true, overlay true → top, checked, locked',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { inTextCollection: true })]),
+          adminReferenced: list([project('a', { isInTextCollection: true })]),
           overlay: { a: true },
         }),
       section: 'top' as const,
@@ -236,7 +236,7 @@ describe('getViewOptionsTexts', () => {
       label: 'admin flagged true, overlay false → top, unchecked, locked',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { inTextCollection: true })]),
+          adminReferenced: list([project('a', { isInTextCollection: true })]),
           overlay: { a: false },
         }),
       section: 'top' as const,
@@ -248,7 +248,7 @@ describe('getViewOptionsTexts', () => {
       label: 'admin flagged true, overlay absent → top, checked (fallback), locked',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { inTextCollection: true })]),
+          adminReferenced: list([project('a', { isInTextCollection: true })]),
           overlay: {},
         }),
       section: 'top' as const,
@@ -272,7 +272,7 @@ describe('getViewOptionsTexts', () => {
       label: 'admin flag false, no overlay → bottom, unchecked, not locked, not removable',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { inTextCollection: false })]),
+          adminReferenced: list([project('a', { isInTextCollection: false })]),
           overlay: {},
         }),
       section: 'bottom' as const,
@@ -284,7 +284,7 @@ describe('getViewOptionsTexts', () => {
       label: 'admin flag false, overlay true → bottom, checked, not locked, not removable',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { inTextCollection: false })]),
+          adminReferenced: list([project('a', { isInTextCollection: false })]),
           overlay: { a: true },
         }),
       section: 'bottom' as const,
@@ -293,18 +293,18 @@ describe('getViewOptionsTexts', () => {
       isUserRemovable: false,
     },
     {
-      label: 'user entry inTextCollectionForUser true → bottom, checked, removable',
+      label: 'user entry isInTextCollectionForUser true → bottom, checked, removable',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { inTextCollectionForUser: true })]) }),
+        makeSources({ userReferenced: list([dbl('u', { isInTextCollectionForUser: true })]) }),
       section: 'bottom' as const,
       checked: true,
       isAdminLocked: false,
       isUserRemovable: true,
     },
     {
-      label: 'user entry inTextCollectionForUser false → bottom, unchecked, removable',
+      label: 'user entry isInTextCollectionForUser false → bottom, unchecked, removable',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { inTextCollectionForUser: false })]) }),
+        makeSources({ userReferenced: list([dbl('u', { isInTextCollectionForUser: false })]) }),
       section: 'bottom' as const,
       checked: false,
       isAdminLocked: false,
@@ -337,12 +337,12 @@ describe('getViewOptionsTexts', () => {
     const { top, bottom } = getViewOptionsTexts(
       makeSources({
         adminReferenced: list([
-          project('m', { inTextCollection: true }),
-          dbl('r', { inTextCollection: true }),
+          project('m', { isInTextCollection: true }),
+          dbl('r', { isInTextCollection: true }),
         ]),
         userReferenced: list([
-          project('u1', { inTextCollectionForUser: true }),
-          dbl('u2', { inTextCollectionForUser: false }),
+          project('u1', { isInTextCollectionForUser: true }),
+          dbl('u2', { isInTextCollectionForUser: false }),
         ]),
         overlay: {},
       }),
@@ -354,8 +354,8 @@ describe('getViewOptionsTexts', () => {
   it('does not duplicate an admin-flagged id into the bottom section', () => {
     const { top, bottom } = getViewOptionsTexts(
       makeSources({
-        adminReferenced: list([project('x', { inTextCollection: true })]),
-        userReferenced: list([project('x', { inTextCollectionForUser: true })]),
+        adminReferenced: list([project('x', { isInTextCollection: true })]),
+        userReferenced: list([project('x', { isInTextCollectionForUser: true })]),
         overlay: { x: true },
       }),
     );
@@ -367,7 +367,7 @@ describe('getViewOptionsTexts', () => {
     const { top, bottom } = getViewOptionsTexts(
       makeSources({
         adminReferenced: list([project('x')]),
-        userReferenced: list([project('x', { inTextCollectionForUser: true })]),
+        userReferenced: list([project('x', { isInTextCollectionForUser: true })]),
         overlay: {},
       }),
     );
@@ -381,7 +381,7 @@ describe('getViewOptionsTexts', () => {
 describe('setUserDisplay', () => {
   it('flips the overlay for an admin entry, leaving the admin flag and user list untouched', () => {
     const sources = makeSources({
-      adminReferenced: list([project('a', { inTextCollection: true })]),
+      adminReferenced: list([project('a', { isInTextCollection: true })]),
       overlay: { a: true },
     });
     const { overlay, userReferenced } = setUserDisplay('a', false, sources);
@@ -389,24 +389,24 @@ describe('setUserDisplay', () => {
     expect(overlay).not.toBe(sources.overlay); // returns a fresh overlay, not the input
     expect(userReferenced.items).toEqual([]);
     // input admin flag unchanged
-    expect(flagOf(sources.adminReferenced.items[0], 'inTextCollection')).toBe(true);
+    expect(flagOf(sources.adminReferenced.items[0], 'isInTextCollection')).toBe(true);
     expect(sources.overlay.a).toBe(true);
   });
 
   it('routes a user-added, unflagged (download-only) admin id to the user entry, not the overlay', () => {
     const sources = makeSources({
       adminReferenced: list([project('x')]),
-      userReferenced: list([project('x', { inTextCollectionForUser: true })]),
+      userReferenced: list([project('x', { isInTextCollectionForUser: true })]),
       overlay: {},
     });
     const { overlay, userReferenced } = setUserDisplay('x', false, sources);
     expect(overlay).toEqual({}); // not admin-owned, so the overlay is untouched
-    expect(flagOf(userReferenced.items[0], 'inTextCollectionForUser')).toBe(false);
+    expect(flagOf(userReferenced.items[0], 'isInTextCollectionForUser')).toBe(false);
   });
 
   it('routes an explicitly-disabled (flag false) admin entry to the overlay', () => {
     const sources = makeSources({
-      adminReferenced: list([project('a', { inTextCollection: false })]),
+      adminReferenced: list([project('a', { isInTextCollection: false })]),
       overlay: {},
     });
     const { overlay, userReferenced } = setUserDisplay('a', true, sources);
@@ -421,21 +421,21 @@ describe('setUserDisplay', () => {
     expect(userReferenced.items).toEqual([]);
   });
 
-  it('flips inTextCollectionForUser for a user entry, leaving the overlay untouched', () => {
+  it('flips isInTextCollectionForUser for a user entry, leaving the overlay untouched', () => {
     const sources = makeSources({
-      userReferenced: list([dbl('u', { inTextCollectionForUser: false })]),
+      userReferenced: list([dbl('u', { isInTextCollectionForUser: false })]),
       overlay: { z: true },
     });
     const { overlay, userReferenced } = setUserDisplay('u', true, sources);
-    expect(flagOf(userReferenced.items[0], 'inTextCollectionForUser')).toBe(true);
+    expect(flagOf(userReferenced.items[0], 'isInTextCollectionForUser')).toBe(true);
     expect(overlay).toEqual({ z: true });
-    expect(flagOf(sources.userReferenced.items[0], 'inTextCollectionForUser')).toBe(false);
+    expect(flagOf(sources.userReferenced.items[0], 'isInTextCollectionForUser')).toBe(false);
   });
 
   it('is a no-op for an unknown id', () => {
     const sources = makeSources({
-      adminReferenced: list([project('a', { inTextCollection: true })]),
-      userReferenced: list([dbl('u', { inTextCollectionForUser: true })]),
+      adminReferenced: list([project('a', { isInTextCollection: true })]),
+      userReferenced: list([dbl('u', { isInTextCollectionForUser: true })]),
       overlay: { a: true },
     });
     const { overlay, userReferenced } = setUserDisplay('missing', true, sources);
@@ -446,8 +446,8 @@ describe('setUserDisplay', () => {
   it('does not mutate its inputs', () => {
     const sources = deepFreeze(
       makeSources({
-        adminReferenced: list([project('a', { inTextCollection: true })]),
-        userReferenced: list([dbl('u', { inTextCollectionForUser: false })]),
+        adminReferenced: list([project('a', { isInTextCollection: true })]),
+        userReferenced: list([dbl('u', { isInTextCollectionForUser: false })]),
         overlay: { a: true },
       }),
     );
@@ -459,8 +459,8 @@ describe('setUserDisplay', () => {
 describe('removeFromUserResources', () => {
   it('removes a matching user entry', () => {
     const userReferenced = list([
-      dbl('u1', { inTextCollectionForUser: true }),
-      project('u2', { inTextCollectionForUser: true }),
+      dbl('u1', { isInTextCollectionForUser: true }),
+      project('u2', { isInTextCollectionForUser: true }),
     ]);
     const result = removeFromUserResources('u1', userReferenced);
     expect(ids(result.items)).toEqual(['u2']);
@@ -468,34 +468,34 @@ describe('removeFromUserResources', () => {
   });
 
   it('is a no-op when the id is not in the user list (defense-in-depth on admin entries)', () => {
-    const userReferenced = list([dbl('u1', { inTextCollectionForUser: true })]);
+    const userReferenced = list([dbl('u1', { isInTextCollectionForUser: true })]);
     const result = removeFromUserResources('adminOnlyId', userReferenced);
     expect(ids(result.items)).toEqual(['u1']);
   });
 
   it('does not mutate its input', () => {
-    const userReferenced = deepFreeze(list([dbl('u1', { inTextCollectionForUser: true })]));
+    const userReferenced = deepFreeze(list([dbl('u1', { isInTextCollectionForUser: true })]));
     expect(() => removeFromUserResources('u1', userReferenced)).not.toThrow();
   });
 });
 
 describe('addToUserResources', () => {
-  it('appends a new reference with inTextCollectionForUser true', () => {
-    const userReferenced = list([dbl('u1', { inTextCollectionForUser: true })]);
+  it('appends a new reference with isInTextCollectionForUser true', () => {
+    const userReferenced = list([dbl('u1', { isInTextCollectionForUser: true })]);
     const result = addToUserResources(project('new'), userReferenced);
     expect(ids(result.items)).toEqual(['u1', 'new']);
-    expect(flagOf(result.items[1], 'inTextCollectionForUser')).toBe(true);
+    expect(flagOf(result.items[1], 'isInTextCollectionForUser')).toBe(true);
     expect(result.dataVersion).toBe(CURRENT_DATA_VERSION);
   });
 
   it('is idempotent when the id is already present', () => {
-    const userReferenced = list([dbl('u1', { inTextCollectionForUser: true })]);
+    const userReferenced = list([dbl('u1', { isInTextCollectionForUser: true })]);
     const result = addToUserResources(dbl('u1'), userReferenced);
     expect(ids(result.items)).toEqual(['u1']);
   });
 
   it('does not mutate its input', () => {
-    const userReferenced = deepFreeze(list([dbl('u1', { inTextCollectionForUser: true })]));
+    const userReferenced = deepFreeze(list([dbl('u1', { isInTextCollectionForUser: true })]));
     expect(() => addToUserResources(project('new'), userReferenced)).not.toThrow();
   });
 });

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.test.ts
@@ -50,7 +50,7 @@ const ids = (refs: ResourceReference[]): string[] =>
 /** Reads a Bible-text flag off a reference without a type assertion. */
 const flagOf = (
   ref: ResourceReference | undefined,
-  key: 'isResourceShownByDefault' | 'isResourceShownForUser',
+  key: 'inTextCollection' | 'inTextCollectionForUser',
 ): boolean | undefined =>
   ref && (isProjectReference(ref) || isDblResourceReference(ref)) ? ref[key] : undefined;
 
@@ -71,7 +71,7 @@ describe('getScriptureTextGridContents', () => {
       label: 'admin flagged true, overlay true → shown',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          adminReferenced: list([project('a', { inTextCollection: true })]),
           overlay: { a: true },
         }),
       expected: ['a'],
@@ -80,7 +80,7 @@ describe('getScriptureTextGridContents', () => {
       label: 'admin flagged true, overlay false (user hid it) → hidden',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          adminReferenced: list([project('a', { inTextCollection: true })]),
           overlay: { a: false },
         }),
       expected: [],
@@ -89,7 +89,7 @@ describe('getScriptureTextGridContents', () => {
       label: 'admin flagged true, overlay absent → shown (falls back to flag)',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          adminReferenced: list([project('a', { inTextCollection: true })]),
           overlay: {},
         }),
       expected: ['a'],
@@ -107,7 +107,7 @@ describe('getScriptureTextGridContents', () => {
       label: 'admin flag false, no overlay → hidden (admin opted it out)',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
+          adminReferenced: list([project('a', { inTextCollection: false })]),
           overlay: {},
         }),
       expected: [],
@@ -116,21 +116,21 @@ describe('getScriptureTextGridContents', () => {
       label: 'admin flag false, overlay true (user re-enabled) → shown',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
+          adminReferenced: list([project('a', { inTextCollection: false })]),
           overlay: { a: true },
         }),
       expected: ['a'],
     },
     {
-      label: 'user entry isResourceShownForUser true → shown',
+      label: 'user entry inTextCollectionForUser true → shown',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { isResourceShownForUser: true })]) }),
+        makeSources({ userReferenced: list([dbl('u', { inTextCollectionForUser: true })]) }),
       expected: ['u'],
     },
     {
-      label: 'user entry isResourceShownForUser false → hidden',
+      label: 'user entry inTextCollectionForUser false → hidden',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { isResourceShownForUser: false })]) }),
+        makeSources({ userReferenced: list([dbl('u', { inTextCollectionForUser: false })]) }),
       expected: [],
     },
     {
@@ -145,8 +145,8 @@ describe('getScriptureTextGridContents', () => {
   it('dedupes an id present in both admin and user lists, keeping the admin entry', () => {
     const contents = getScriptureTextGridContents(
       makeSources({
-        adminReferenced: list([project('x', { isResourceShownByDefault: true })]),
-        userReferenced: list([project('x', { isResourceShownForUser: true })]),
+        adminReferenced: list([project('x', { inTextCollection: true })]),
+        userReferenced: list([project('x', { inTextCollectionForUser: true })]),
         overlay: { x: true },
       }),
     );
@@ -158,10 +158,10 @@ describe('getScriptureTextGridContents', () => {
     const contents = getScriptureTextGridContents(
       makeSources({
         adminReferenced: list([
-          project('m', { isResourceShownByDefault: true }),
-          dbl('r', { isResourceShownByDefault: true }),
+          project('m', { inTextCollection: true }),
+          dbl('r', { inTextCollection: true }),
         ]),
-        userReferenced: list([project('u', { isResourceShownForUser: true })]),
+        userReferenced: list([project('u', { inTextCollectionForUser: true })]),
         overlay: {},
       }),
     );
@@ -172,8 +172,8 @@ describe('getScriptureTextGridContents', () => {
     const contents = getScriptureTextGridContents(
       makeSources({
         adminReferenced: list([
-          { type: 'enhancedResource', name: 'Enhanced', isResourceShownByDefault: true },
-          project('a', { isResourceShownByDefault: true }),
+          { type: 'enhancedResource', name: 'Enhanced', inTextCollection: true },
+          project('a', { inTextCollection: true }),
         ]),
         overlay: { a: true },
       }),
@@ -186,7 +186,7 @@ describe('getScriptureTextGridContents', () => {
       makeSources({
         userReferenced: list([
           { type: 'enhancedResource', name: 'Enhanced' },
-          dbl('u', { isResourceShownForUser: true }),
+          dbl('u', { inTextCollectionForUser: true }),
         ]),
       }),
     );
@@ -194,12 +194,12 @@ describe('getScriptureTextGridContents', () => {
   });
 
   it('shows a user-added resource that is only an unflagged (download-only) admin entry', () => {
-    // `x` sits in the admin referenced (download) list with no shown-by-default flag, and the user
+    // `x` sits in the admin referenced (download) list with no text-collection flag, and the user
     // added it to their own list. It is not admin-owned, so the user's choice drives display.
     const contents = getScriptureTextGridContents(
       makeSources({
         adminReferenced: list([project('x')]),
-        userReferenced: list([project('x', { isResourceShownForUser: true })]),
+        userReferenced: list([project('x', { inTextCollectionForUser: true })]),
         overlay: {},
       }),
     );
@@ -209,8 +209,8 @@ describe('getScriptureTextGridContents', () => {
   it('does not mutate its inputs', () => {
     const sources = deepFreeze(
       makeSources({
-        adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
-        userReferenced: list([dbl('u', { isResourceShownForUser: true })]),
+        adminReferenced: list([project('a', { inTextCollection: true })]),
+        userReferenced: list([dbl('u', { inTextCollectionForUser: true })]),
         overlay: { a: true },
       }),
     );
@@ -224,7 +224,7 @@ describe('getViewOptionsTexts', () => {
       label: 'admin flagged true, overlay true → top, checked, locked',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          adminReferenced: list([project('a', { inTextCollection: true })]),
           overlay: { a: true },
         }),
       section: 'top' as const,
@@ -236,7 +236,7 @@ describe('getViewOptionsTexts', () => {
       label: 'admin flagged true, overlay false → top, unchecked, locked',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          adminReferenced: list([project('a', { inTextCollection: true })]),
           overlay: { a: false },
         }),
       section: 'top' as const,
@@ -248,7 +248,7 @@ describe('getViewOptionsTexts', () => {
       label: 'admin flagged true, overlay absent → top, checked (fallback), locked',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+          adminReferenced: list([project('a', { inTextCollection: true })]),
           overlay: {},
         }),
       section: 'top' as const,
@@ -272,7 +272,7 @@ describe('getViewOptionsTexts', () => {
       label: 'admin flag false, no overlay → bottom, unchecked, not locked, not removable',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
+          adminReferenced: list([project('a', { inTextCollection: false })]),
           overlay: {},
         }),
       section: 'bottom' as const,
@@ -284,7 +284,7 @@ describe('getViewOptionsTexts', () => {
       label: 'admin flag false, overlay true → bottom, checked, not locked, not removable',
       sources: () =>
         makeSources({
-          adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
+          adminReferenced: list([project('a', { inTextCollection: false })]),
           overlay: { a: true },
         }),
       section: 'bottom' as const,
@@ -293,18 +293,18 @@ describe('getViewOptionsTexts', () => {
       isUserRemovable: false,
     },
     {
-      label: 'user entry isResourceShownForUser true → bottom, checked, removable',
+      label: 'user entry inTextCollectionForUser true → bottom, checked, removable',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { isResourceShownForUser: true })]) }),
+        makeSources({ userReferenced: list([dbl('u', { inTextCollectionForUser: true })]) }),
       section: 'bottom' as const,
       checked: true,
       isAdminLocked: false,
       isUserRemovable: true,
     },
     {
-      label: 'user entry isResourceShownForUser false → bottom, unchecked, removable',
+      label: 'user entry inTextCollectionForUser false → bottom, unchecked, removable',
       sources: () =>
-        makeSources({ userReferenced: list([dbl('u', { isResourceShownForUser: false })]) }),
+        makeSources({ userReferenced: list([dbl('u', { inTextCollectionForUser: false })]) }),
       section: 'bottom' as const,
       checked: false,
       isAdminLocked: false,
@@ -337,12 +337,12 @@ describe('getViewOptionsTexts', () => {
     const { top, bottom } = getViewOptionsTexts(
       makeSources({
         adminReferenced: list([
-          project('m', { isResourceShownByDefault: true }),
-          dbl('r', { isResourceShownByDefault: true }),
+          project('m', { inTextCollection: true }),
+          dbl('r', { inTextCollection: true }),
         ]),
         userReferenced: list([
-          project('u1', { isResourceShownForUser: true }),
-          dbl('u2', { isResourceShownForUser: false }),
+          project('u1', { inTextCollectionForUser: true }),
+          dbl('u2', { inTextCollectionForUser: false }),
         ]),
         overlay: {},
       }),
@@ -354,8 +354,8 @@ describe('getViewOptionsTexts', () => {
   it('does not duplicate an admin-flagged id into the bottom section', () => {
     const { top, bottom } = getViewOptionsTexts(
       makeSources({
-        adminReferenced: list([project('x', { isResourceShownByDefault: true })]),
-        userReferenced: list([project('x', { isResourceShownForUser: true })]),
+        adminReferenced: list([project('x', { inTextCollection: true })]),
+        userReferenced: list([project('x', { inTextCollectionForUser: true })]),
         overlay: { x: true },
       }),
     );
@@ -367,7 +367,7 @@ describe('getViewOptionsTexts', () => {
     const { top, bottom } = getViewOptionsTexts(
       makeSources({
         adminReferenced: list([project('x')]),
-        userReferenced: list([project('x', { isResourceShownForUser: true })]),
+        userReferenced: list([project('x', { inTextCollectionForUser: true })]),
         overlay: {},
       }),
     );
@@ -381,7 +381,7 @@ describe('getViewOptionsTexts', () => {
 describe('setUserDisplay', () => {
   it('flips the overlay for an admin entry, leaving the admin flag and user list untouched', () => {
     const sources = makeSources({
-      adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
+      adminReferenced: list([project('a', { inTextCollection: true })]),
       overlay: { a: true },
     });
     const { overlay, userReferenced } = setUserDisplay('a', false, sources);
@@ -389,24 +389,24 @@ describe('setUserDisplay', () => {
     expect(overlay).not.toBe(sources.overlay); // returns a fresh overlay, not the input
     expect(userReferenced.items).toEqual([]);
     // input admin flag unchanged
-    expect(flagOf(sources.adminReferenced.items[0], 'isResourceShownByDefault')).toBe(true);
+    expect(flagOf(sources.adminReferenced.items[0], 'inTextCollection')).toBe(true);
     expect(sources.overlay.a).toBe(true);
   });
 
   it('routes a user-added, unflagged (download-only) admin id to the user entry, not the overlay', () => {
     const sources = makeSources({
       adminReferenced: list([project('x')]),
-      userReferenced: list([project('x', { isResourceShownForUser: true })]),
+      userReferenced: list([project('x', { inTextCollectionForUser: true })]),
       overlay: {},
     });
     const { overlay, userReferenced } = setUserDisplay('x', false, sources);
     expect(overlay).toEqual({}); // not admin-owned, so the overlay is untouched
-    expect(flagOf(userReferenced.items[0], 'isResourceShownForUser')).toBe(false);
+    expect(flagOf(userReferenced.items[0], 'inTextCollectionForUser')).toBe(false);
   });
 
   it('routes an explicitly-disabled (flag false) admin entry to the overlay', () => {
     const sources = makeSources({
-      adminReferenced: list([project('a', { isResourceShownByDefault: false })]),
+      adminReferenced: list([project('a', { inTextCollection: false })]),
       overlay: {},
     });
     const { overlay, userReferenced } = setUserDisplay('a', true, sources);
@@ -421,21 +421,21 @@ describe('setUserDisplay', () => {
     expect(userReferenced.items).toEqual([]);
   });
 
-  it('flips isResourceShownForUser for a user entry, leaving the overlay untouched', () => {
+  it('flips inTextCollectionForUser for a user entry, leaving the overlay untouched', () => {
     const sources = makeSources({
-      userReferenced: list([dbl('u', { isResourceShownForUser: false })]),
+      userReferenced: list([dbl('u', { inTextCollectionForUser: false })]),
       overlay: { z: true },
     });
     const { overlay, userReferenced } = setUserDisplay('u', true, sources);
-    expect(flagOf(userReferenced.items[0], 'isResourceShownForUser')).toBe(true);
+    expect(flagOf(userReferenced.items[0], 'inTextCollectionForUser')).toBe(true);
     expect(overlay).toEqual({ z: true });
-    expect(flagOf(sources.userReferenced.items[0], 'isResourceShownForUser')).toBe(false);
+    expect(flagOf(sources.userReferenced.items[0], 'inTextCollectionForUser')).toBe(false);
   });
 
   it('is a no-op for an unknown id', () => {
     const sources = makeSources({
-      adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
-      userReferenced: list([dbl('u', { isResourceShownForUser: true })]),
+      adminReferenced: list([project('a', { inTextCollection: true })]),
+      userReferenced: list([dbl('u', { inTextCollectionForUser: true })]),
       overlay: { a: true },
     });
     const { overlay, userReferenced } = setUserDisplay('missing', true, sources);
@@ -446,8 +446,8 @@ describe('setUserDisplay', () => {
   it('does not mutate its inputs', () => {
     const sources = deepFreeze(
       makeSources({
-        adminReferenced: list([project('a', { isResourceShownByDefault: true })]),
-        userReferenced: list([dbl('u', { isResourceShownForUser: false })]),
+        adminReferenced: list([project('a', { inTextCollection: true })]),
+        userReferenced: list([dbl('u', { inTextCollectionForUser: false })]),
         overlay: { a: true },
       }),
     );
@@ -459,8 +459,8 @@ describe('setUserDisplay', () => {
 describe('removeFromUserResources', () => {
   it('removes a matching user entry', () => {
     const userReferenced = list([
-      dbl('u1', { isResourceShownForUser: true }),
-      project('u2', { isResourceShownForUser: true }),
+      dbl('u1', { inTextCollectionForUser: true }),
+      project('u2', { inTextCollectionForUser: true }),
     ]);
     const result = removeFromUserResources('u1', userReferenced);
     expect(ids(result.items)).toEqual(['u2']);
@@ -468,34 +468,34 @@ describe('removeFromUserResources', () => {
   });
 
   it('is a no-op when the id is not in the user list (defense-in-depth on admin entries)', () => {
-    const userReferenced = list([dbl('u1', { isResourceShownForUser: true })]);
+    const userReferenced = list([dbl('u1', { inTextCollectionForUser: true })]);
     const result = removeFromUserResources('adminOnlyId', userReferenced);
     expect(ids(result.items)).toEqual(['u1']);
   });
 
   it('does not mutate its input', () => {
-    const userReferenced = deepFreeze(list([dbl('u1', { isResourceShownForUser: true })]));
+    const userReferenced = deepFreeze(list([dbl('u1', { inTextCollectionForUser: true })]));
     expect(() => removeFromUserResources('u1', userReferenced)).not.toThrow();
   });
 });
 
 describe('addToUserResources', () => {
-  it('appends a new reference with isResourceShownForUser true', () => {
-    const userReferenced = list([dbl('u1', { isResourceShownForUser: true })]);
+  it('appends a new reference with inTextCollectionForUser true', () => {
+    const userReferenced = list([dbl('u1', { inTextCollectionForUser: true })]);
     const result = addToUserResources(project('new'), userReferenced);
     expect(ids(result.items)).toEqual(['u1', 'new']);
-    expect(flagOf(result.items[1], 'isResourceShownForUser')).toBe(true);
+    expect(flagOf(result.items[1], 'inTextCollectionForUser')).toBe(true);
     expect(result.dataVersion).toBe(CURRENT_DATA_VERSION);
   });
 
   it('is idempotent when the id is already present', () => {
-    const userReferenced = list([dbl('u1', { isResourceShownForUser: true })]);
+    const userReferenced = list([dbl('u1', { inTextCollectionForUser: true })]);
     const result = addToUserResources(dbl('u1'), userReferenced);
     expect(ids(result.items)).toEqual(['u1']);
   });
 
   it('does not mutate its input', () => {
-    const userReferenced = deepFreeze(list([dbl('u1', { isResourceShownForUser: true })]));
+    const userReferenced = deepFreeze(list([dbl('u1', { inTextCollectionForUser: true })]));
     expect(() => addToUserResources(project('new'), userReferenced)).not.toThrow();
   });
 });

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
@@ -3,29 +3,28 @@ import type {
   ProjectReference,
   ResourceReference,
   ResourceReferenceList,
-  ShownByDefaultOverlay,
+  TextCollectionOverlay,
 } from 'platform-scripture';
 import { isDblResourceReference, isProjectReference } from './resource-reference.utils';
 import { CURRENT_DATA_VERSION } from './resource-reference-list.const';
 
-/** A Bible-text reference — the only reference types that carry `id` and `isResourceShownForUser`. */
+/** A Bible-text reference — the only reference types that carry `id` and `inTextCollectionForUser`. */
 type BibleTextReference = ProjectReference | DblResourceReference;
 
 /**
  * The three data sources that together determine what a given user sees in the Text Collection.
  *
- * The admin's shown-by-default opinions live solely on `referencedProjectsAndResources`: model
- * texts are decoupled from the shown-by-default feature (they carry no `isResourceShownByDefault`
- * flag and the overlay is initialized only from the referenced list), so they are not a source
- * here.
+ * The admin's text-collection opinions live solely on `referencedProjectsAndResources`: model texts
+ * are decoupled from the text-collection feature (they carry no `inTextCollection` flag and the
+ * overlay is initialized only from the referenced list), so they are not a source here.
  */
 export type TextCollectionSources = {
   /** Admin project-scope `platformScripture.referencedProjectsAndResources` list. */
   adminReferenced: ResourceReferenceList;
   /** The current user's per-user `UserReferencedProjectsAndResources` list. */
   userReferenced: ResourceReferenceList;
-  /** The current user's per-user shown-by-default overlay (keyed by resource id). */
-  overlay: ShownByDefaultOverlay;
+  /** The current user's per-user text-collection overlay (keyed by resource id). */
+  overlay: TextCollectionOverlay;
 };
 
 /** A single row in the View Options TEXTS list. */
@@ -58,21 +57,21 @@ function getBibleTextId(reference: unknown): string | undefined {
 
 /**
  * The Bible-text resources the admin owns for the Text Collection, decided per referenced-list
- * item: a resource is owned when the admin has an opinion on it (`isResourceShownByDefault` set to
- * `true` or `false`) or the user still has an overlay slot for it from a prior admin selection.
+ * item: a resource is owned when the admin has an opinion on it (`inTextCollection` set to `true`
+ * or `false`) or the user still has an overlay slot for it from a prior admin selection.
  * Deduplicated by `id`, referenced-list order.
  *
  * Only the admin `referencedProjectsAndResources` list is read — model texts are decoupled from the
- * shown-by-default feature. A resource merely present in the referenced list with no flag (e.g.
+ * text-collection feature. A resource merely present in the referenced list with no flag (e.g.
  * downloaded for another feature) is NOT owned — the user can add it to their own list like any
  * other resource. An overlay slot whose id is no longer in the referenced list is ignored: there is
  * no reference left to render.
  *
- * `adminFlagged` is `true` when the resource is currently shown-by-default in the referenced list.
+ * `adminFlagged` is `true` when the resource is currently text-collection in the referenced list.
  */
 function getAdminOwnedEntries(
   adminReferenced: ResourceReferenceList,
-  overlay: ShownByDefaultOverlay,
+  overlay: TextCollectionOverlay,
 ): AdminOwnedEntry[] {
   const byId = new Map<string, AdminOwnedEntry>();
   const entries: AdminOwnedEntry[] = [];
@@ -80,10 +79,10 @@ function getAdminOwnedEntries(
   const consider = (item: ResourceReference) => {
     if (!isProjectReference(item) && !isDblResourceReference(item)) return;
 
-    const isFlagSet = item.isResourceShownByDefault !== undefined;
+    const isFlagSet = item.inTextCollection !== undefined;
     if (!isFlagSet && !Object.hasOwn(overlay, item.id)) return;
 
-    const flagged = item.isResourceShownByDefault === true;
+    const flagged = item.inTextCollection === true;
     const existing = byId.get(item.id);
     if (existing) {
       if (flagged) existing.adminFlagged = true;
@@ -103,7 +102,7 @@ function getAdminOwnedEntries(
  * The user's effective shown-state for an admin-owned entry: their overlay choice, else the admin
  * flag.
  */
-function isAdminEntryShown(overlay: ShownByDefaultOverlay, entry: AdminOwnedEntry): boolean {
+function isAdminEntryShown(overlay: TextCollectionOverlay, entry: AdminOwnedEntry): boolean {
   return Object.hasOwn(overlay, entry.reference.id)
     ? overlay[entry.reference.id]
     : entry.adminFlagged;
@@ -123,7 +122,7 @@ function isAdminOwnedId(resourceId: string, sources: TextCollectionSources): boo
 /**
  * Computes the Bible-text references that render in the Scripture Text Grid for the current user:
  * admin-owned entries the user has shown (overlay choice, falling back to the admin flag), followed
- * by the user's own list entries with `isResourceShownForUser === true`. Deduplicated by `id` with
+ * by the user's own list entries with `inTextCollectionForUser === true`. Deduplicated by `id` with
  * admin precedence; admin entries keep referenced-list order, user entries keep user-list order.
  */
 export function getScriptureTextGridContents(sources: TextCollectionSources): BibleTextReference[] {
@@ -141,7 +140,7 @@ export function getScriptureTextGridContents(sources: TextCollectionSources): Bi
     if (!isProjectReference(item) && !isDblResourceReference(item)) return;
     if (seen.has(item.id)) return;
     seen.add(item.id);
-    if (item.isResourceShownForUser === true) contents.push(item);
+    if (item.inTextCollectionForUser === true) contents.push(item);
   });
 
   return contents;
@@ -150,12 +149,12 @@ export function getScriptureTextGridContents(sources: TextCollectionSources): Bi
 /**
  * Splits the View Options TEXTS list into two ordered sections:
  *
- * - `top` — the admin's current selection (`isResourceShownByDefault === true`). Always visible and
- *   locked from removal (`isAdminLocked: true`); the user may only uncheck to hide from the grid.
+ * - `top` — the admin's current selection (`inTextCollection === true`). Always visible and locked
+ *   from removal (`isAdminLocked: true`); the user may only uncheck to hide from the grid.
  * - `bottom` — resources the user can freely toggle and remove (`isAdminLocked: false`): other
  *   admin-owned entries (opted out, or shown before) followed by the user's own list additions.
  *
- * Checkbox state comes from the overlay for admin-owned entries and from `isResourceShownForUser`
+ * Checkbox state comes from the overlay for admin-owned entries and from `inTextCollectionForUser`
  * for the user's own entries. An admin-owned id never also appears as a user entry (admin
  * precedence).
  */
@@ -185,7 +184,7 @@ export function getViewOptionsTexts(sources: TextCollectionSources): {
     if (adminIds.has(item.id)) return; // admin-owned ids are rendered by the loop above
     bottom.push({
       reference: item,
-      checked: item.isResourceShownForUser === true,
+      checked: item.inTextCollectionForUser === true,
       isAdminLocked: false,
       isUserRemovable: true,
     });
@@ -197,14 +196,14 @@ export function getViewOptionsTexts(sources: TextCollectionSources): {
 /**
  * Records the user's shown/hidden choice for a resource, returning the next state (callers
  * persist). Routes by ownership: an admin-owned entry writes the per-user overlay (the admin's flag
- * is untouched); a user-list entry writes that item's `isResourceShownForUser`. Unknown ids are a
+ * is untouched); a user-list entry writes that item's `inTextCollectionForUser`. Unknown ids are a
  * no-op.
  */
 export function setUserDisplay(
   resourceId: string,
   shown: boolean,
   sources: TextCollectionSources,
-): { userReferenced: ResourceReferenceList; overlay: ShownByDefaultOverlay } {
+): { userReferenced: ResourceReferenceList; overlay: TextCollectionOverlay } {
   const { userReferenced, overlay } = sources;
 
   if (isAdminOwnedId(resourceId, sources))
@@ -214,7 +213,7 @@ export function setUserDisplay(
   if (index < 0) return { userReferenced, overlay };
 
   const items = userReferenced.items.map((item, itemIndex) =>
-    itemIndex === index ? { ...item, isResourceShownForUser: shown } : item,
+    itemIndex === index ? { ...item, inTextCollectionForUser: shown } : item,
   );
   return { userReferenced: { dataVersion: CURRENT_DATA_VERSION, items }, overlay };
 }
@@ -239,8 +238,9 @@ export function removeFromUserResources(
 }
 
 /**
- * Appends a Bible-text reference to the user's per-user list with `isResourceShownForUser === true`
- * (the Get Resources flow). Idempotent: returns the list unchanged when the id is already present.
+ * Appends a Bible-text reference to the user's per-user list with `inTextCollectionForUser ===
+ * true` (the Get Resources flow). Idempotent: returns the list unchanged when the id is already
+ * present.
  *
  * Precondition: `reference` must not be an admin-owned resource. Admin-owned resources are
  * overlay-driven — toggle them with {@link setUserDisplay}; a user-list entry for one is ignored by
@@ -256,6 +256,6 @@ export function addToUserResources(
   }
   return {
     dataVersion: CURRENT_DATA_VERSION,
-    items: [...userReferenced.items, { ...reference, isResourceShownForUser: true }],
+    items: [...userReferenced.items, { ...reference, inTextCollectionForUser: true }],
   };
 }

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-contents.utils.ts
@@ -8,14 +8,17 @@ import type {
 import { isDblResourceReference, isProjectReference } from './resource-reference.utils';
 import { CURRENT_DATA_VERSION } from './resource-reference-list.const';
 
-/** A Bible-text reference — the only reference types that carry `id` and `inTextCollectionForUser`. */
+/**
+ * A Bible-text reference — the only reference types that carry `id` and
+ * `isInTextCollectionForUser`.
+ */
 type BibleTextReference = ProjectReference | DblResourceReference;
 
 /**
  * The three data sources that together determine what a given user sees in the Text Collection.
  *
  * The admin's text-collection opinions live solely on `referencedProjectsAndResources`: model texts
- * are decoupled from the text-collection feature (they carry no `inTextCollection` flag and the
+ * are decoupled from the text-collection feature (they carry no `isInTextCollection` flag and the
  * overlay is initialized only from the referenced list), so they are not a source here.
  */
 export type TextCollectionSources = {
@@ -57,7 +60,7 @@ function getBibleTextId(reference: unknown): string | undefined {
 
 /**
  * The Bible-text resources the admin owns for the Text Collection, decided per referenced-list
- * item: a resource is owned when the admin has an opinion on it (`inTextCollection` set to `true`
+ * item: a resource is owned when the admin has an opinion on it (`isInTextCollection` set to `true`
  * or `false`) or the user still has an overlay slot for it from a prior admin selection.
  * Deduplicated by `id`, referenced-list order.
  *
@@ -79,10 +82,10 @@ function getAdminOwnedEntries(
   const consider = (item: ResourceReference) => {
     if (!isProjectReference(item) && !isDblResourceReference(item)) return;
 
-    const isFlagSet = item.inTextCollection !== undefined;
+    const isFlagSet = item.isInTextCollection !== undefined;
     if (!isFlagSet && !Object.hasOwn(overlay, item.id)) return;
 
-    const flagged = item.inTextCollection === true;
+    const flagged = item.isInTextCollection === true;
     const existing = byId.get(item.id);
     if (existing) {
       if (flagged) existing.adminFlagged = true;
@@ -122,8 +125,9 @@ function isAdminOwnedId(resourceId: string, sources: TextCollectionSources): boo
 /**
  * Computes the Bible-text references that render in the Scripture Text Grid for the current user:
  * admin-owned entries the user has shown (overlay choice, falling back to the admin flag), followed
- * by the user's own list entries with `inTextCollectionForUser === true`. Deduplicated by `id` with
- * admin precedence; admin entries keep referenced-list order, user entries keep user-list order.
+ * by the user's own list entries with `isInTextCollectionForUser === true`. Deduplicated by `id`
+ * with admin precedence; admin entries keep referenced-list order, user entries keep user-list
+ * order.
  */
 export function getScriptureTextGridContents(sources: TextCollectionSources): BibleTextReference[] {
   const { adminReferenced, userReferenced, overlay } = sources;
@@ -140,7 +144,7 @@ export function getScriptureTextGridContents(sources: TextCollectionSources): Bi
     if (!isProjectReference(item) && !isDblResourceReference(item)) return;
     if (seen.has(item.id)) return;
     seen.add(item.id);
-    if (item.inTextCollectionForUser === true) contents.push(item);
+    if (item.isInTextCollectionForUser === true) contents.push(item);
   });
 
   return contents;
@@ -149,14 +153,14 @@ export function getScriptureTextGridContents(sources: TextCollectionSources): Bi
 /**
  * Splits the View Options TEXTS list into two ordered sections:
  *
- * - `top` — the admin's current selection (`inTextCollection === true`). Always visible and locked
+ * - `top` — the admin's current selection (`isInTextCollection === true`). Always visible and locked
  *   from removal (`isAdminLocked: true`); the user may only uncheck to hide from the grid.
  * - `bottom` — resources the user can freely toggle and remove (`isAdminLocked: false`): other
  *   admin-owned entries (opted out, or shown before) followed by the user's own list additions.
  *
- * Checkbox state comes from the overlay for admin-owned entries and from `inTextCollectionForUser`
- * for the user's own entries. An admin-owned id never also appears as a user entry (admin
- * precedence).
+ * Checkbox state comes from the overlay for admin-owned entries and from
+ * `isInTextCollectionForUser` for the user's own entries. An admin-owned id never also appears as a
+ * user entry (admin precedence).
  */
 export function getViewOptionsTexts(sources: TextCollectionSources): {
   top: ViewOptionsTextEntry[];
@@ -184,7 +188,7 @@ export function getViewOptionsTexts(sources: TextCollectionSources): {
     if (adminIds.has(item.id)) return; // admin-owned ids are rendered by the loop above
     bottom.push({
       reference: item,
-      checked: item.inTextCollectionForUser === true,
+      checked: item.isInTextCollectionForUser === true,
       isAdminLocked: false,
       isUserRemovable: true,
     });
@@ -196,8 +200,8 @@ export function getViewOptionsTexts(sources: TextCollectionSources): {
 /**
  * Records the user's shown/hidden choice for a resource, returning the next state (callers
  * persist). Routes by ownership: an admin-owned entry writes the per-user overlay (the admin's flag
- * is untouched); a user-list entry writes that item's `inTextCollectionForUser`. Unknown ids are a
- * no-op.
+ * is untouched); a user-list entry writes that item's `isInTextCollectionForUser`. Unknown ids are
+ * a no-op.
  */
 export function setUserDisplay(
   resourceId: string,
@@ -213,7 +217,7 @@ export function setUserDisplay(
   if (index < 0) return { userReferenced, overlay };
 
   const items = userReferenced.items.map((item, itemIndex) =>
-    itemIndex === index ? { ...item, inTextCollectionForUser: shown } : item,
+    itemIndex === index ? { ...item, isInTextCollectionForUser: shown } : item,
   );
   return { userReferenced: { dataVersion: CURRENT_DATA_VERSION, items }, overlay };
 }
@@ -238,7 +242,7 @@ export function removeFromUserResources(
 }
 
 /**
- * Appends a Bible-text reference to the user's per-user list with `inTextCollectionForUser ===
+ * Appends a Bible-text reference to the user's per-user list with `isInTextCollectionForUser ===
  * true` (the Get Resources flow). Idempotent: returns the list unchanged when the id is already
  * present.
  *
@@ -256,6 +260,6 @@ export function addToUserResources(
   }
   return {
     dataVersion: CURRENT_DATA_VERSION,
-    items: [...userReferenced.items, { ...reference, inTextCollectionForUser: true }],
+    items: [...userReferenced.items, { ...reference, isInTextCollectionForUser: true }],
   };
 }

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-persistence.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-persistence.utils.test.ts
@@ -32,16 +32,16 @@ const makeSources = (overrides?: Partial<TextCollectionSources>): TextCollection
 /** A stub writer whose setters resolve; each test asserts which one was called and with what. */
 const makeWriter = (): UserResourceWriter => ({
   setUserReferencedProjectsAndResources: vi.fn().mockResolvedValue(true),
-  setShownByDefaultOverlay: vi.fn().mockResolvedValue(true),
+  setTextCollectionOverlay: vi.fn().mockResolvedValue(true),
 });
 
-/** Reads `isResourceShownForUser` off a reference without a type assertion. */
+/** Reads `inTextCollectionForUser` off a reference without a type assertion. */
 const userFlagOf = (refList: ResourceReferenceList, id: string): boolean | undefined => {
   const ref = refList.items.find(
     (item) => (isProjectReference(item) || isDblResourceReference(item)) && item.id === id,
   );
   return ref && (isProjectReference(ref) || isDblResourceReference(ref))
-    ? ref.isResourceShownForUser
+    ? ref.inTextCollectionForUser
     : undefined;
 };
 
@@ -55,24 +55,24 @@ describe('persistUserDisplay', () => {
   it('routes an admin-owned entry to the overlay only (not the user list)', () => {
     const writer = makeWriter();
     const sources = makeSources({
-      adminReferenced: list([dbl('esv', { isResourceShownByDefault: true })]),
+      adminReferenced: list([dbl('esv', { inTextCollection: true })]),
     });
 
     persistUserDisplay(writer, 'esv', false, sources);
 
-    expect(writer.setShownByDefaultOverlay).toHaveBeenCalledWith({ esv: false });
+    expect(writer.setTextCollectionOverlay).toHaveBeenCalledWith({ esv: false });
     expect(writer.setUserReferencedProjectsAndResources).not.toHaveBeenCalled();
   });
 
   it('routes a user entry to the user list only (not the overlay)', () => {
     const writer = makeWriter();
     const sources = makeSources({
-      userReferenced: list([dbl('web', { isResourceShownForUser: true })]),
+      userReferenced: list([dbl('web', { inTextCollectionForUser: true })]),
     });
 
     persistUserDisplay(writer, 'web', false, sources);
 
-    expect(writer.setShownByDefaultOverlay).not.toHaveBeenCalled();
+    expect(writer.setTextCollectionOverlay).not.toHaveBeenCalled();
     expect(writer.setUserReferencedProjectsAndResources).toHaveBeenCalledTimes(1);
     const persisted = vi.mocked(writer.setUserReferencedProjectsAndResources).mock.calls[0][0];
     expect(userFlagOf(persisted, 'web')).toBe(false);
@@ -84,14 +84,14 @@ describe('persistUserDisplay', () => {
 
     expect(writes).toHaveLength(0);
     expect(writer.setUserReferencedProjectsAndResources).not.toHaveBeenCalled();
-    expect(writer.setShownByDefaultOverlay).not.toHaveBeenCalled();
+    expect(writer.setTextCollectionOverlay).not.toHaveBeenCalled();
   });
 });
 
 describe('persistUserRemoval', () => {
   it('persists the user list without the removed entry', () => {
     const writer = makeWriter();
-    const userReferenced = list([dbl('web', { isResourceShownForUser: true }), dbl('kjv')]);
+    const userReferenced = list([dbl('web', { inTextCollectionForUser: true }), dbl('kjv')]);
 
     const result = persistUserRemoval(writer, 'web', userReferenced);
 
@@ -110,7 +110,7 @@ describe('persistUserRemoval', () => {
 });
 
 describe('persistUserAddition', () => {
-  it('appends the reference with isResourceShownForUser and persists', () => {
+  it('appends the reference with inTextCollectionForUser and persists', () => {
     const writer = makeWriter();
     const result = persistUserAddition(writer, dbl('niv'), list());
 

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-persistence.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-persistence.utils.test.ts
@@ -35,13 +35,13 @@ const makeWriter = (): UserResourceWriter => ({
   setTextCollectionOverlay: vi.fn().mockResolvedValue(true),
 });
 
-/** Reads `inTextCollectionForUser` off a reference without a type assertion. */
+/** Reads `isInTextCollectionForUser` off a reference without a type assertion. */
 const userFlagOf = (refList: ResourceReferenceList, id: string): boolean | undefined => {
   const ref = refList.items.find(
     (item) => (isProjectReference(item) || isDblResourceReference(item)) && item.id === id,
   );
   return ref && (isProjectReference(ref) || isDblResourceReference(ref))
-    ? ref.inTextCollectionForUser
+    ? ref.isInTextCollectionForUser
     : undefined;
 };
 
@@ -55,7 +55,7 @@ describe('persistUserDisplay', () => {
   it('routes an admin-owned entry to the overlay only (not the user list)', () => {
     const writer = makeWriter();
     const sources = makeSources({
-      adminReferenced: list([dbl('esv', { inTextCollection: true })]),
+      adminReferenced: list([dbl('esv', { isInTextCollection: true })]),
     });
 
     persistUserDisplay(writer, 'esv', false, sources);
@@ -67,7 +67,7 @@ describe('persistUserDisplay', () => {
   it('routes a user entry to the user list only (not the overlay)', () => {
     const writer = makeWriter();
     const sources = makeSources({
-      userReferenced: list([dbl('web', { inTextCollectionForUser: true })]),
+      userReferenced: list([dbl('web', { isInTextCollectionForUser: true })]),
     });
 
     persistUserDisplay(writer, 'web', false, sources);
@@ -91,7 +91,7 @@ describe('persistUserDisplay', () => {
 describe('persistUserRemoval', () => {
   it('persists the user list without the removed entry', () => {
     const writer = makeWriter();
-    const userReferenced = list([dbl('web', { inTextCollectionForUser: true }), dbl('kjv')]);
+    const userReferenced = list([dbl('web', { isInTextCollectionForUser: true }), dbl('kjv')]);
 
     const result = persistUserRemoval(writer, 'web', userReferenced);
 
@@ -110,7 +110,7 @@ describe('persistUserRemoval', () => {
 });
 
 describe('persistUserAddition', () => {
-  it('appends the reference with inTextCollectionForUser and persists', () => {
+  it('appends the reference with isInTextCollectionForUser and persists', () => {
     const writer = makeWriter();
     const result = persistUserAddition(writer, dbl('niv'), list());
 

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid-persistence.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid-persistence.utils.ts
@@ -1,4 +1,4 @@
-import type { ResourceReferenceList, ShownByDefaultOverlay } from 'platform-scripture';
+import type { ResourceReferenceList, TextCollectionOverlay } from 'platform-scripture';
 import {
   addToUserResources,
   removeFromUserResources,
@@ -12,7 +12,7 @@ import {
  */
 export interface UserResourceWriter {
   setUserReferencedProjectsAndResources: (list: ResourceReferenceList) => Promise<unknown>;
-  setShownByDefaultOverlay: (overlay: ShownByDefaultOverlay) => Promise<unknown>;
+  setTextCollectionOverlay: (overlay: TextCollectionOverlay) => Promise<unknown>;
 }
 
 /**
@@ -30,7 +30,7 @@ export function persistUserDisplay(
   const writes: Promise<unknown>[] = [];
   if (next.userReferenced !== sources.userReferenced)
     writes.push(writer.setUserReferencedProjectsAndResources(next.userReferenced));
-  if (next.overlay !== sources.overlay) writes.push(writer.setShownByDefaultOverlay(next.overlay));
+  if (next.overlay !== sources.overlay) writes.push(writer.setTextCollectionOverlay(next.overlay));
   return writes;
 }
 

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid.web-view.tsx
@@ -193,10 +193,10 @@ globalThis.webViewComponent = function ScriptureTextGridWebView({
     if (!effectiveProjectId || !textConnectionPdp) return;
     if (initializedProjectIds.current.has(effectiveProjectId)) return;
     initializedProjectIds.current.add(effectiveProjectId);
-    textConnectionPdp.initializeShownByDefaultOverlay().catch((error) => {
+    textConnectionPdp.initializeTextCollectionOverlay().catch((error) => {
       initializedProjectIds.current.delete(effectiveProjectId);
       logger.error(
-        `Failed to initialize shown-by-default overlay for ${effectiveProjectId}: ${error}`,
+        `Failed to initialize text-collection overlay for ${effectiveProjectId}: ${error}`,
       );
     });
   }, [effectiveProjectId, textConnectionPdp]);

--- a/extensions/src/platform-scripture-editor/src/use-text-collection-sources.hook.test.ts
+++ b/extensions/src/platform-scripture-editor/src/use-text-collection-sources.hook.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import type {
   ResourceReferenceList,
-  ShownByDefaultOverlay,
+  TextCollectionOverlay,
   ITextConnectionSettingsProjectDataProvider,
 } from 'platform-scripture';
 import { useProjectSetting, useProjectDataProvider } from '@papi/frontend/react';
@@ -48,7 +48,7 @@ function settingTuple(
 /**
  * Configures `useProjectSetting` to answer with the admin `referencedProjectsAndResources` tuple.
  * That is the only project setting the hook reads (model texts are decoupled from the
- * shown-by-default feature, so they are no longer a source).
+ * text-collection feature, so they are no longer a source).
  */
 function mockSettings(referenced: ReturnType<typeof useProjectSetting>) {
   mockUseProjectSetting.mockImplementation(() => referenced);
@@ -64,7 +64,7 @@ function makeControllablePdp() {
   const unsubOverlay = vi.fn(() => Promise.resolve(true));
 
   let deliverUserReferenced: (value: ResourceReferenceList | object) => void = () => {};
-  let deliverOverlay: (value: ShownByDefaultOverlay | object) => void = () => {};
+  let deliverOverlay: (value: TextCollectionOverlay | object) => void = () => {};
 
   // Resolvers for the subscribe promises themselves — left pending until a test resolves them,
   // which is what lets us simulate the dispose-before-subscribe race.
@@ -79,8 +79,8 @@ function makeControllablePdp() {
       });
     },
   );
-  const subscribeShownByDefaultOverlay = vi.fn(
-    (_selector: undefined, callback: (value: ShownByDefaultOverlay | object) => void) => {
+  const subscribeTextCollectionOverlay = vi.fn(
+    (_selector: undefined, callback: (value: TextCollectionOverlay | object) => void) => {
       deliverOverlay = callback;
       return new Promise<() => Promise<boolean>>((resolve) => {
         resolveOverlaySub = resolve;
@@ -92,7 +92,7 @@ function makeControllablePdp() {
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   const pdp = {
     subscribeUserReferencedProjectsAndResources,
-    subscribeShownByDefaultOverlay,
+    subscribeTextCollectionOverlay,
   } as unknown as ITextConnectionSettingsProjectDataProvider;
 
   return {
@@ -108,7 +108,7 @@ function makeControllablePdp() {
         return Promise.resolve();
       }),
     /** Fire both subscription callbacks with values (data delivery is synchronous in the PDP). */
-    deliver: (userReferenced: ResourceReferenceList | object, overlay: ShownByDefaultOverlay) =>
+    deliver: (userReferenced: ResourceReferenceList | object, overlay: TextCollectionOverlay) =>
       act(() => {
         deliverUserReferenced(userReferenced);
         deliverOverlay(overlay);
@@ -117,7 +117,7 @@ function makeControllablePdp() {
       act(() => {
         deliverUserReferenced(userReferenced);
       }),
-    deliverOverlayOnly: (overlay: ShownByDefaultOverlay) =>
+    deliverOverlayOnly: (overlay: TextCollectionOverlay) =>
       act(() => {
         deliverOverlay(overlay);
       }),
@@ -163,7 +163,7 @@ describe('useTextCollectionSources', () => {
 
     await controller.resolveSubscriptions();
     const userReferenced = list('user-v');
-    const overlay: ShownByDefaultOverlay = { 'res-1': true };
+    const overlay: TextCollectionOverlay = { 'res-1': true };
     await controller.deliver(userReferenced, overlay);
 
     expect(result.current.sources).toEqual({

--- a/extensions/src/platform-scripture-editor/src/use-text-collection-sources.hook.ts
+++ b/extensions/src/platform-scripture-editor/src/use-text-collection-sources.hook.ts
@@ -1,22 +1,22 @@
 import { useEffect, useMemo, useState } from 'react';
 import { logger } from '@papi/frontend';
 import { getErrorMessage, isPlatformError } from 'platform-bible-utils';
-import type { ResourceReferenceList, ShownByDefaultOverlay } from 'platform-scripture';
+import type { ResourceReferenceList, TextCollectionOverlay } from 'platform-scripture';
 import { useProjectDataProvider, useProjectSetting } from '@papi/frontend/react';
 import type { TextCollectionSources } from './scripture-text-grid-contents.utils';
 import { DEFAULT_RESOURCE_REFERENCE_LIST as DEFAULT_LIST } from './resource-reference-list.const';
 
 /** A user with no recorded checkbox interactions has an empty overlay. */
-const DEFAULT_OVERLAY: ShownByDefaultOverlay = {};
+const DEFAULT_OVERLAY: TextCollectionOverlay = {};
 
 /**
  * Assembles the three data sources the View Options helpers read — the admin project-scope
- * `referencedProjectsAndResources` list, the per-user list, and the per-user shown-by-default
+ * `referencedProjectsAndResources` list, the per-user list, and the per-user text-collection
  * overlay — into a single {@link TextCollectionSources} object, and returns the
  * `platformScripture.textConnectionSettings` data provider so callers can persist mutations via its
- * `setUserReferencedProjectsAndResources` / `setShownByDefaultOverlay` setters.
+ * `setUserReferencedProjectsAndResources` / `setTextCollectionOverlay` setters.
  *
- * Model texts are decoupled from the shown-by-default feature (they carry no admin flag and the
+ * Model texts are decoupled from the text-collection feature (they carry no admin flag and the
  * overlay is initialized only from the referenced list), so they are not read here. The View
  * Options panel reads the admin list but never writes it (admin sharing lives in a separate
  * dialog). `sources` is `undefined` while any source is still loading.
@@ -36,7 +36,7 @@ export function useTextCollectionSources(projectId: string | undefined) {
   const [userReferenced, setUserReferenced] = useState<ResourceReferenceList | undefined>(
     undefined,
   );
-  const [overlay, setOverlay] = useState<ShownByDefaultOverlay | undefined>(undefined);
+  const [overlay, setOverlay] = useState<TextCollectionOverlay | undefined>(undefined);
 
   useEffect(() => {
     if (!textConnectionPdp) {
@@ -67,10 +67,10 @@ export function useTextCollectionSources(projectId: string | undefined) {
       'user referenced projects and resources',
     );
     track(
-      textConnectionPdp.subscribeShownByDefaultOverlay(undefined, (value) => {
+      textConnectionPdp.subscribeTextCollectionOverlay(undefined, (value) => {
         setOverlay(isPlatformError(value) ? DEFAULT_OVERLAY : value);
       }),
-      'shown-by-default overlay',
+      'text-collection overlay',
     );
 
     return () => {

--- a/extensions/src/platform-scripture/src/resource-reference-list.utils.test.ts
+++ b/extensions/src/platform-scripture/src/resource-reference-list.utils.test.ts
@@ -73,30 +73,30 @@ describe('isValidResourceReference', () => {
         type: 'project',
         name: 'P',
         id: 'aabbcc',
-        isResourceShownByDefault: true,
-        isResourceShownForUser: false,
+        inTextCollection: true,
+        inTextCollectionForUser: false,
       }),
     ).toBe(true);
   });
 
-  it('rejects a project reference with a non-boolean isResourceShownByDefault', () => {
+  it('rejects a project reference with a non-boolean inTextCollection', () => {
     expect(
       isValidResourceReference({
         type: 'project',
         name: 'P',
         id: 'aabbcc',
-        isResourceShownByDefault: 'yes',
+        inTextCollection: 'yes',
       }),
     ).toBe(false);
   });
 
-  it('rejects a dblResource reference with a non-boolean isResourceShownForUser', () => {
+  it('rejects a dblResource reference with a non-boolean inTextCollectionForUser', () => {
     expect(
       isValidResourceReference({
         type: 'dblResource',
         name: 'D',
         id: '112233445566',
-        isResourceShownForUser: 3,
+        inTextCollectionForUser: 3,
       }),
     ).toBe(false);
   });
@@ -111,13 +111,13 @@ describe('isValidResourceReference', () => {
     ).toBe(true);
   });
 
-  it('rejects a dblResource reference with a non-boolean isResourceShownByDefault', () => {
+  it('rejects a dblResource reference with a non-boolean inTextCollection', () => {
     expect(
       isValidResourceReference({
         type: 'dblResource',
         name: 'D',
         id: '112233445566',
-        isResourceShownByDefault: 'no',
+        inTextCollection: 'no',
       }),
     ).toBe(false);
   });

--- a/extensions/src/platform-scripture/src/resource-reference-list.utils.test.ts
+++ b/extensions/src/platform-scripture/src/resource-reference-list.utils.test.ts
@@ -73,30 +73,30 @@ describe('isValidResourceReference', () => {
         type: 'project',
         name: 'P',
         id: 'aabbcc',
-        inTextCollection: true,
-        inTextCollectionForUser: false,
+        isInTextCollection: true,
+        isInTextCollectionForUser: false,
       }),
     ).toBe(true);
   });
 
-  it('rejects a project reference with a non-boolean inTextCollection', () => {
+  it('rejects a project reference with a non-boolean isInTextCollection', () => {
     expect(
       isValidResourceReference({
         type: 'project',
         name: 'P',
         id: 'aabbcc',
-        inTextCollection: 'yes',
+        isInTextCollection: 'yes',
       }),
     ).toBe(false);
   });
 
-  it('rejects a dblResource reference with a non-boolean inTextCollectionForUser', () => {
+  it('rejects a dblResource reference with a non-boolean isInTextCollectionForUser', () => {
     expect(
       isValidResourceReference({
         type: 'dblResource',
         name: 'D',
         id: '112233445566',
-        inTextCollectionForUser: 3,
+        isInTextCollectionForUser: 3,
       }),
     ).toBe(false);
   });
@@ -111,13 +111,13 @@ describe('isValidResourceReference', () => {
     ).toBe(true);
   });
 
-  it('rejects a dblResource reference with a non-boolean inTextCollection', () => {
+  it('rejects a dblResource reference with a non-boolean isInTextCollection', () => {
     expect(
       isValidResourceReference({
         type: 'dblResource',
         name: 'D',
         id: '112233445566',
-        inTextCollection: 'no',
+        isInTextCollection: 'no',
       }),
     ).toBe(false);
   });

--- a/extensions/src/platform-scripture/src/resource-reference-list.utils.ts
+++ b/extensions/src/platform-scripture/src/resource-reference-list.utils.ts
@@ -9,8 +9,12 @@ export const isValidResourceReference = (item: unknown): boolean => {
       if (!('name' in item) || !('id' in item)) return false;
       if (typeof item.name !== 'string' || typeof item.id !== 'string') return false;
       // Optional flags, when present, must be booleans.
-      if ('inTextCollection' in item && typeof item.inTextCollection !== 'boolean') return false;
-      if ('inTextCollectionForUser' in item && typeof item.inTextCollectionForUser !== 'boolean')
+      if ('isInTextCollection' in item && typeof item.isInTextCollection !== 'boolean')
+        return false;
+      if (
+        'isInTextCollectionForUser' in item &&
+        typeof item.isInTextCollectionForUser !== 'boolean'
+      )
         return false;
       return true;
     }

--- a/extensions/src/platform-scripture/src/resource-reference-list.utils.ts
+++ b/extensions/src/platform-scripture/src/resource-reference-list.utils.ts
@@ -9,9 +9,8 @@ export const isValidResourceReference = (item: unknown): boolean => {
       if (!('name' in item) || !('id' in item)) return false;
       if (typeof item.name !== 'string' || typeof item.id !== 'string') return false;
       // Optional flags, when present, must be booleans.
-      if ('isResourceShownByDefault' in item && typeof item.isResourceShownByDefault !== 'boolean')
-        return false;
-      if ('isResourceShownForUser' in item && typeof item.isResourceShownForUser !== 'boolean')
+      if ('inTextCollection' in item && typeof item.inTextCollection !== 'boolean') return false;
+      if ('inTextCollectionForUser' in item && typeof item.inTextCollectionForUser !== 'boolean')
         return false;
       return true;
     }

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -784,11 +784,11 @@ declare module 'platform-scripture' {
       ResourceReferenceList,
       ResourceReferenceList
     >;
-    /** Gets/sets the current user's shown-by-default overlay for this project */
-    ShownByDefaultOverlay: DataProviderDataType<
+    /** Gets/sets the current user's text-collection overlay for this project */
+    TextCollectionOverlay: DataProviderDataType<
       undefined,
-      ShownByDefaultOverlay,
-      ShownByDefaultOverlay
+      TextCollectionOverlay,
+      TextCollectionOverlay
     >;
   };
 
@@ -851,18 +851,18 @@ declare module 'platform-scripture' {
       ): Promise<UnsubscriberAsync>;
       /** Determines whether the current user can write to text connection project settings. */
       canUserWriteProjectTextConnectionSettings(): Promise<boolean>;
-      /** Gets the current user's shown-by-default overlay (resourceId -> checkbox state) */
-      getShownByDefaultOverlay(): Promise<ShownByDefaultOverlay>;
-      /** Sets the current user's shown-by-default overlay */
-      setShownByDefaultOverlay(
-        value: ShownByDefaultOverlay,
+      /** Gets the current user's text-collection overlay (resourceId -> checkbox state) */
+      getTextCollectionOverlay(): Promise<TextCollectionOverlay>;
+      /** Sets the current user's text-collection overlay */
+      setTextCollectionOverlay(
+        value: TextCollectionOverlay,
       ): Promise<
         DataProviderUpdateInstructions<UserTextConnectionSettingsProjectInterfaceDataTypes>
       >;
-      /** Resets (removes) the current user's shown-by-default overlay and its initialized marker */
-      resetShownByDefaultOverlay(): Promise<boolean>;
+      /** Resets (removes) the current user's text-collection overlay and its initialized marker */
+      resetTextCollectionOverlay(): Promise<boolean>;
       /**
-       * Subscribe to run a callback when the current user's shown-by-default overlay changes
+       * Subscribe to run a callback when the current user's text-collection overlay changes
        *
        * @param selector Tells the provider what changes to listen for
        * @param callback Function to run with the updated overlay, or a {@link PlatformError} on
@@ -870,18 +870,18 @@ declare module 'platform-scripture' {
        * @param options Various options to adjust how the subscriber emits updates
        * @returns Unsubscriber function
        */
-      subscribeShownByDefaultOverlay(
+      subscribeTextCollectionOverlay(
         selector: undefined,
-        callback: (value: ShownByDefaultOverlay | undefined | PlatformError) => void,
+        callback: (value: TextCollectionOverlay | undefined | PlatformError) => void,
         options?: DataProviderSubscriberOptions,
       ): Promise<UnsubscriberAsync>;
       /**
-       * Initializes the current user's shown-by-default overlay on first open of the Scripture Text
+       * Initializes the current user's text-collection overlay on first open of the Scripture Text
        * Grid for this project: sets each admin-flagged Bible-text resource's overlay value to the
-       * project's current `isResourceShownByDefault`. Idempotent — a per-user-per-project marker
-       * prevents re-initialization on later opens (returns `false` when already initialized).
+       * project's current `inTextCollection`. Idempotent — a per-user-per-project marker prevents
+       * re-initialization on later opens (returns `false` when already initialized).
        */
-      initializeShownByDefaultOverlay(): Promise<boolean>;
+      initializeTextCollectionOverlay(): Promise<boolean>;
     };
 
   // #endregion User Text Connection Settings Types
@@ -1945,16 +1945,18 @@ declare module 'platform-scripture' {
     /** 20-byte (40-char) hex ID that uniquely identifies the project */
     id: string;
     /**
-     * Project-scope (Send/Receive'd) admin flag: when set, this resource is shown by default —
-     * consumed by the shared layout and, for Bible-text resources, by the Scripture Text Grid,
-     * where it also seeds new users' overlay on first open. `undefined` means no admin preference.
+     * Project-scope (Send/Receive'd) admin flag: when set, this resource is in the text collection
+     * by default — consumed by the shared layout and, for Bible-text resources, by the Scripture
+     * Text Grid, where it also seeds new users' overlay on first open. `undefined` means no admin
+     * preference.
      */
-    isResourceShownByDefault?: boolean;
+    inTextCollection?: boolean;
     /**
-     * User-scope (NOT Send/Receive'd) per-resource checkbox state on the current user's personal
-     * resources list. Absent by default; only meaningful on Bible-text references.
+     * User-scope (NOT Send/Receive'd) flag: whether the current user has included this resource
+     * from their personal list in the text collection. Absent by default; only meaningful on
+     * Bible-text references.
      */
-    isResourceShownForUser?: boolean;
+    inTextCollectionForUser?: boolean;
   };
 
   /** A reference to a DBL resource, identified by its 24-byte (48-char) hex ID */
@@ -1969,16 +1971,18 @@ declare module 'platform-scripture' {
     /** 24-byte (48-char) hex ID that uniquely identifies the resource */
     id: string;
     /**
-     * Project-scope (Send/Receive'd) admin flag: when set, this resource is shown by default —
-     * consumed by the shared layout and, for Bible-text resources, by the Scripture Text Grid,
-     * where it also seeds new users' overlay on first open. `undefined` means no admin preference.
+     * Project-scope (Send/Receive'd) admin flag: when set, this resource is in the text collection
+     * by default — consumed by the shared layout and, for Bible-text resources, by the Scripture
+     * Text Grid, where it also seeds new users' overlay on first open. `undefined` means no admin
+     * preference.
      */
-    isResourceShownByDefault?: boolean;
+    inTextCollection?: boolean;
     /**
-     * User-scope (NOT Send/Receive'd) per-resource checkbox state on the current user's personal
-     * resources list. Absent by default; only meaningful on Bible-text references.
+     * User-scope (NOT Send/Receive'd) flag: whether the current user has included this resource
+     * from their personal list in the text collection. Absent by default; only meaningful on
+     * Bible-text references.
      */
-    isResourceShownForUser?: boolean;
+    inTextCollectionForUser?: boolean;
   };
 
   /** A reference to an Enhanced resource, identified by name */
@@ -1988,10 +1992,10 @@ declare module 'platform-scripture' {
     /** Name that uniquely identifies the resource */
     name: string;
     /**
-     * When set by a project admin, indicates this resource should be shown by default when the
-     * shared layout is applied. When `undefined`, no admin preference has been set.
+     * When set by a project admin, indicates this resource is in the text collection by default
+     * when the shared layout is applied. When `undefined`, no admin preference has been set.
      */
-    isResourceShownByDefault?: boolean;
+    inTextCollection?: boolean;
   };
 
   /** A reference to an XML resource, identified by name */
@@ -2001,10 +2005,10 @@ declare module 'platform-scripture' {
     /** Name that uniquely identifies the resource */
     name: string;
     /**
-     * When set by a project admin, indicates this resource should be shown by default when the
-     * shared layout is applied. When `undefined`, no admin preference has been set.
+     * When set by a project admin, indicates this resource is in the text collection by default
+     * when the shared layout is applied. When `undefined`, no admin preference has been set.
      */
-    isResourceShownByDefault?: boolean;
+    inTextCollection?: boolean;
   };
 
   /** A reference to a Source Language resource, identified by name */
@@ -2014,10 +2018,10 @@ declare module 'platform-scripture' {
     /** Name that uniquely identifies the resource */
     name: string;
     /**
-     * When set by a project admin, indicates this resource should be shown by default when the
-     * shared layout is applied. When `undefined`, no admin preference has been set.
+     * When set by a project admin, indicates this resource is in the text collection by default
+     * when the shared layout is applied. When `undefined`, no admin preference has been set.
      */
-    isResourceShownByDefault?: boolean;
+    inTextCollection?: boolean;
   };
 
   /**
@@ -2056,8 +2060,11 @@ declare module 'platform-scripture' {
      * breaking changes.
      *
      * Current version is `1.1.0`: the `1.1.0` minor bump added the optional Bible-text flags
-     * `isResourceShownByDefault` (project-scope) and `isResourceShownForUser` (user-scope). Both
-     * are additive and backwards-compatible — files lacking them read cleanly.
+     * `inTextCollection` (project-scope) and `inTextCollectionForUser` (user-scope). Both are
+     * additive and backwards-compatible — files lacking them read cleanly. (These two keys were
+     * renamed pre-release from `isResourceTextCollection`/`isResourceShownForUser` under this same,
+     * still-unreleased `1.1.0`, so a pre-rename `1.1.0` file carrying the old keys does not read
+     * back into these fields.)
      */
     dataVersion: string;
     /** Ordered list of project and resource references */
@@ -2088,12 +2095,12 @@ declare module 'platform-scripture' {
   };
 
   /**
-   * Per-user (NOT Send/Receive'd) overlay recording the current user's shown-by-default checkbox
+   * Per-user (NOT Send/Receive'd) overlay recording the current user's text-collection checkbox
    * state for admin-flagged Bible-text resources, keyed by resource id. Initialized on first open
-   * of the Scripture Text Grid to match the project's `isResourceShownByDefault` values, then
-   * diverges independently.
+   * of the Scripture Text Grid to match the project's `inTextCollection` values, then diverges
+   * independently.
    */
-  export type ShownByDefaultOverlay = { [resourceId: string]: boolean };
+  export type TextCollectionOverlay = { [resourceId: string]: boolean };
 
   // #endregion Resource Reference Types
 

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -878,7 +878,7 @@ declare module 'platform-scripture' {
       /**
        * Initializes the current user's text-collection overlay on first open of the Scripture Text
        * Grid for this project: sets each admin-flagged Bible-text resource's overlay value to the
-       * project's current `inTextCollection`. Idempotent — a per-user-per-project marker prevents
+       * project's current `isInTextCollection`. Idempotent — a per-user-per-project marker prevents
        * re-initialization on later opens (returns `false` when already initialized).
        */
       initializeTextCollectionOverlay(): Promise<boolean>;
@@ -1950,13 +1950,13 @@ declare module 'platform-scripture' {
      * Text Grid, where it also seeds new users' overlay on first open. `undefined` means no admin
      * preference.
      */
-    inTextCollection?: boolean;
+    isInTextCollection?: boolean;
     /**
      * User-scope (NOT Send/Receive'd) flag: whether the current user has included this resource
      * from their personal list in the text collection. Absent by default; only meaningful on
      * Bible-text references.
      */
-    inTextCollectionForUser?: boolean;
+    isInTextCollectionForUser?: boolean;
   };
 
   /** A reference to a DBL resource, identified by its 24-byte (48-char) hex ID */
@@ -1976,13 +1976,13 @@ declare module 'platform-scripture' {
      * Text Grid, where it also seeds new users' overlay on first open. `undefined` means no admin
      * preference.
      */
-    inTextCollection?: boolean;
+    isInTextCollection?: boolean;
     /**
      * User-scope (NOT Send/Receive'd) flag: whether the current user has included this resource
      * from their personal list in the text collection. Absent by default; only meaningful on
      * Bible-text references.
      */
-    inTextCollectionForUser?: boolean;
+    isInTextCollectionForUser?: boolean;
   };
 
   /** A reference to an Enhanced resource, identified by name */
@@ -1995,7 +1995,7 @@ declare module 'platform-scripture' {
      * When set by a project admin, indicates this resource is in the text collection by default
      * when the shared layout is applied. When `undefined`, no admin preference has been set.
      */
-    inTextCollection?: boolean;
+    isInTextCollection?: boolean;
   };
 
   /** A reference to an XML resource, identified by name */
@@ -2008,7 +2008,7 @@ declare module 'platform-scripture' {
      * When set by a project admin, indicates this resource is in the text collection by default
      * when the shared layout is applied. When `undefined`, no admin preference has been set.
      */
-    inTextCollection?: boolean;
+    isInTextCollection?: boolean;
   };
 
   /** A reference to a Source Language resource, identified by name */
@@ -2021,7 +2021,7 @@ declare module 'platform-scripture' {
      * When set by a project admin, indicates this resource is in the text collection by default
      * when the shared layout is applied. When `undefined`, no admin preference has been set.
      */
-    inTextCollection?: boolean;
+    isInTextCollection?: boolean;
   };
 
   /**
@@ -2060,7 +2060,7 @@ declare module 'platform-scripture' {
      * breaking changes.
      *
      * Current version is `1.1.0`: the `1.1.0` minor bump added the optional Bible-text flags
-     * `inTextCollection` (project-scope) and `inTextCollectionForUser` (user-scope). Both are
+     * `isInTextCollection` (project-scope) and `isInTextCollectionForUser` (user-scope). Both are
      * additive and backwards-compatible — files lacking them read cleanly. (These two keys were
      * renamed pre-release from `isResourceTextCollection`/`isResourceShownForUser` under this same,
      * still-unreleased `1.1.0`, so a pre-rename `1.1.0` file carrying the old keys does not read
@@ -2097,7 +2097,7 @@ declare module 'platform-scripture' {
   /**
    * Per-user (NOT Send/Receive'd) overlay recording the current user's text-collection checkbox
    * state for admin-flagged Bible-text resources, keyed by resource id. Initialized on first open
-   * of the Scripture Text Grid to match the project's `inTextCollection` values, then diverges
+   * of the Scripture Text Grid to match the project's `isInTextCollection` values, then diverges
    * independently.
    */
   export type TextCollectionOverlay = { [resourceId: string]: boolean };


### PR DESCRIPTION
## Summary

**Pure rename, no behavior change.** Moves the resource-reference feature from "shown by default"
vocabulary to "text collection", across TypeScript + C# + tests. The feature is **unreleased**
(`dataVersion` 1.1.0, PT-4040/PT-4050), so this is a hard rename with **no on-disk backward
compatibility** — no shipped settings file carries the old keys.

## What changed

| Old | New | What it is |
| --- | --- | --- |
| `isResourceShownByDefault` | `isInTextCollection` | Project/admin flag on a resource reference — is this resource in the text collection by default |
| `isResourceShownForUser` | `isInTextCollectionForUser` | User-scope flag — did the user add this resource to their text collection |
| `ShownByDefaultOverlay` | `TextCollectionOverlay` | The per-user overlay: type, PAPI data-type name, the `get/set/reset/initialize/subscribe…` methods, and the registered command names |
| `SHOWN_BY_DEFAULT_OVERLAY` = `"ShownByDefaultOverlay"` | `TEXT_COLLECTION_OVERLAY` = `"TextCollectionOverlay"` | C# const + its on-disk setting key / wire data-type value |

These names cross the TS↔C# boundary, so the JSON/XML keys, the PAPI data-type name, and the command
names all move together.

## Where to look (start here)

**The contract** — read these to see the whole renamed surface:
- **`extensions/src/platform-scripture/src/types/platform-scripture.d.ts`** — the TS type declarations (both flags, the overlay type, and the PDP methods). The single best file to review first.
- **`c-sharp/Projects/ResourceReferenceList.cs`** + **`ResourceReferenceConverter.cs`** — the C# record and JSON/XML (de)serialization; the wire keys here must match the TS names.
- **`c-sharp/Projects/ParatextProjectDataProvider.cs`** + **`ProjectDataType.cs`** — the overlay PDP methods, the `TEXT_COLLECTION_OVERLAY` data-type/setting key, `SendDataUpdateEvent`, and the registered command names (the TS↔C# boundary).

**Consumers** (mechanical, follow from the contract): `scripture-text-grid-contents.utils.ts`,
`scripture-text-grid-persistence.utils.ts`, `use-text-collection-sources.hook.ts`,
`scripture-text-grid.web-view.tsx`, `resource-reference-list.utils.ts`.

**Tests** (updated in lockstep, incl. two file renames): C# `ResourceReferenceList*Tests` +
`ParatextProjectDataProviderTextCollectionTests.cs` (renamed); the matching TS `*.test.ts`; e2e
`text-collection-schema.spec.ts` (renamed) + `scripture-text-grid.spec.ts` + `test-helpers.ts`.

## How to review fast

It's a complete, mechanical rename — **zero** old tokens remain anywhere in the repo, and it's
verified green (C# 356 tests, extension 96 tests, typecheck clean). So skip the churn and spend your
time on the three judgment calls:

1. **Naming reversal** — this reverses the earlier decision on PR #2507 (Tom's review) that moved
   *away* from "in text collection". The team has since changed its mind; confirm we're aligned.
2. **Hard rename, no on-disk back-compat** — fine because 1.1.0 is unreleased. Confirm nothing
   carrying the old keys has shipped to a real environment.
3. **Cross-boundary overlay rename** — the data-type name, on-disk setting key, and command names
   all moved together across TS↔C#. Verified by the passing C# overlay tests; worth a spot-check.

<details>
<summary><b>Full review report</b> — findings, verification, complete API surface, interview notes</summary>

<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: worktree-rename-in-text-collection

**Base**: origin/main

**Date**: 2026-07-13

**Review model**: Claude Opus 4.8

**Files changed**: 21

## Overview

Renames the resource-reference setting flags and their per-user overlay to "text collection"
vocabulary, replacing the earlier "shown by default" naming. The project/admin flag
`isResourceShownByDefault` → `isInTextCollection`, the user-scope flag `isResourceShownForUser` →
`isInTextCollectionForUser`, and the per-user overlay family `ShownByDefaultOverlay` →
`TextCollectionOverlay` (type, PAPI data-type name, the `get/set/reset/initialize/subscribe`
methods, the C# `TEXT_COLLECTION_OVERLAY` const and its on-disk/wire value, and all prose). The
change spans TypeScript types + logic, the C# record/converter/PDP, and tests (TS, C#, e2e), keeping
the TS↔C# JSON/XML keys, data-type name, and registered command names aligned.

This is an intentional **hard rename with no on-disk backward compatibility**: the feature
(`dataVersion` 1.1.0, PT-4040/PT-4050) is unreleased, so no shipped settings file carries the old
keys. Pre-rename 1.1.0 files (dev environments only) would route the old keys to `ExtraData` rather
than the renamed fields.

## API Changes

Extension-local `platform-scripture` type declarations only — no `@papi/` surface changed, so
`lib/papi-dts/papi.d.ts` is untouched.

- `ProjectReference`, `DblResourceReference`: `isResourceShownByDefault?` → `isInTextCollection?`;
  `isResourceShownForUser?` → `isInTextCollectionForUser?`.
- `EnhancedResourceReference`, `XmlResourceReference`, `SourceLanguageResourceReference`:
  `isResourceShownByDefault?` → `isInTextCollection?`.
- `UserTextConnectionSettingsProjectInterfaceDataTypes`: data type `ShownByDefaultOverlay` →
  `TextCollectionOverlay`; exported type `ShownByDefaultOverlay` → `TextCollectionOverlay`.
- `ITextConnectionSettingsProjectDataProvider`: methods `getShownByDefaultOverlay` /
  `setShownByDefaultOverlay` / `resetShownByDefaultOverlay` / `subscribeShownByDefaultOverlay` /
  `initializeShownByDefaultOverlay` → `*TextCollectionOverlay`.
- C# (matching wire contract): `ResourceReference.IsResourceShownByDefault` → `IsInTextCollection`,
  `IsResourceShownForUser` → `IsInTextCollectionForUser`; `ProjectDataType.SHOWN_BY_DEFAULT_OVERLAY`
  (`"ShownByDefaultOverlay"`) → `TEXT_COLLECTION_OVERLAY` (`"TextCollectionOverlay"`); the four
  registered overlay command names and the `Get/Set/Reset/InitializeTextCollectionOverlay` methods.
- No exports added or removed; all affected types remain exported.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [x] **Mixed vocabulary on the public surface**: the `ShownByDefaultOverlay` type and
  `initialize/reset/…ShownByDefaultOverlay` methods retained "shown-by-default" wording while the
  flags they mirror became `isInTextCollection*`. _(fixed during review: swept the entire overlay
  family to `TextCollectionOverlay` vocabulary — type, PAPI data-type name, all five PDP methods,
  the `TEXT_COLLECTION_OVERLAY` const + its wire/setting value, comments, and renamed the C# test
  file → `ParatextProjectDataProviderTextCollectionTests.cs` and the e2e spec →
  `text-collection-schema.spec.ts`. Zero "shown-by-default" tokens remain repo-wide.)_
- [x] **`dataVersion` TSDoc wording**: the comment still called the 1.1.0 flags "additive and
  backwards-compatible — files lacking them read cleanly," which is misleading after a key rename
  within the same version. _(fixed during review: added a note that the 1.1.0 keys were renamed
  pre-release, so a pre-rename 1.1.0 file carrying the old keys does not read back into these
  fields.)_

[Author response: Both minor findings were fixed during the interview. Finding 1 was escalated by
the author from "leave as deliberate scope" to a full overlay sweep so no mixed vocabulary remains;
finding 2's one-line clarification was accepted.]

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- Complete and self-consistent rename across every layer: TS types, TS logic/validators, C# record
  properties, JSON keys, XML attribute names, the `Known*PropertyNames` sets, the PAPI data-type
  name, registered command names, and all TS + C# + e2e tests. Repo-wide grep for the old
  identifiers/tokens returns zero hits.
- Cross-boundary contract stays aligned: the C# JSON/XML keys, the `TextCollectionOverlay`
  data-type name (`SendDataUpdateEvent`), the on-disk setting key, and the overlay command names all
  match their TS counterparts exactly.
- Test coverage preserved, not dropped — all C# and TS test files were updated in lockstep with the
  production code; C# (356) and extension (96) suites pass.
- TSDoc/comments were meaningfully rewritten to the new "text collection" semantics rather than
  find-replaced, keeping the project-scope vs user-scope distinction and the `ExtraData`
  round-trip rationale clear.
- `lib/papi-dts/papi.d.ts` correctly left untouched (extension-local types, not `@papi/` exports).
- No user-facing strings or i18n keys touched; no UI/WebView components changed.

## Interview Notes

- **Purpose**: rename the resource-reference flags + overlay to "text collection" vocabulary across
  TS + C#, plus documentation cleanup.
- **Naming reversal (context for reviewer)**: an earlier commit on this feature (PT-4050, per Tom's
  review on PR #2507) deliberately renamed `inTextCollectionUser` → `isResourceShownForUser` because
  "in text collection" was judged to imply a text collection would necessarily result, and to mirror
  `isResourceShownByDefault`. The team has since changed its mind and standardized on "text
  collection"; this PR moves both flags (and the overlay) to that vocabulary. The author directed
  this reversal knowingly.
- **Decisions the author made**: keep `isInTextCollection`; rename the user-scope sibling to
  `isInTextCollectionForUser` for symmetry (it is the existing user-scope mechanism for choosing which
  resources appear in the text collection); perform a full overlay sweep so no mixed vocabulary
  remains; accept a hard rename with no on-disk back-compat because 1.1.0 is unreleased.
- **Understanding**: the author drove every naming decision and the scope boundaries; no items were
  deferred to AI and none were left unexplained.

## In-Review Quality Check

Changes were made during the interview (the overlay sweep and the `dataVersion` doc note).

- **Typecheck** (`tsc -p extensions/tsconfig.json`): zero errors in any changed file. (Remaining
  output is pre-existing, unrelated environmental noise — `webpack-env.d.ts`, `tailwind.config.ts`,
  dependency `@types`.)
- **C# tests** (`dotnet test --filter Projects`): 356 passed, 0 failed.
- **Extension tests** (vitest, 4 affected suites): 96 passed, 0 failed.
- **Formatting**: `prettier --write` (changed TS) and `dotnet csharpier` (C#) applied.
- **ESLint**: could **not** run locally — this worktree is nested under the parent repo, so ESLint
  finds two `@typescript-eslint` plugin installs and refuses to start (environmental, not a code
  issue). CI runs lint in a clean checkout and is the authoritative gate. The change only shortens
  or same-lengths identifiers and adds no new constructs, so lint risk is low.

## Suggested Review Focus

- [ ] **Naming reversal**: this PR reverses the PT-4050 decision (Tom's review on PR #2507) that
  moved away from "in text collection" wording. Confirm the team is aligned on the new vocabulary
  before merge.
- [ ] **Hard rename, no on-disk back-compat**: predicated on `dataVersion` 1.1.0 being unreleased.
  Confirm no build carrying the old keys has shipped to any real environment.
- [ ] **Cross-boundary overlay rename**: the PAPI data-type name, the on-disk setting key
  (`TextCollectionOverlay` + `…Initialized` marker), and the four registered command names all moved
  together. Verified by passing C# overlay tests + TS typecheck; worth a spot-check of the TS↔C#
  alignment.
<!-- review-paratext:summary:end -->

</details>

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2546)
<!-- Reviewable:end -->
