### PR TITLE
docs(jira): populate PT description template on issue create

### DIFF
--- a/.claude/commands/prd-to-jira.md
+++ b/.claude/commands/prd-to-jira.md
@@ -47,8 +47,16 @@ connected, say so and stop.
    don't thin them out; the PT-4025…PT-4030 tickets are the level of detail to match.
 3. **Dry-run gate (required — never skip).** Show the user the complete drafts and get explicit
    approval before creating anything. These are posted to the team's Jira under the user's name.
-4. **Create** the parent, then each child with the parent set. Create one at a time and keep the
-   created keys.
+4. **Create, then populate each description in a second pass.** Creating an issue in `PT` replaces
+   your description with the work-item type's default template, so follow
+   [`.claude/rules/jira-issue-creation.md`](../rules/jira-issue-creation.md) (create → read the
+   live template off the created issue → fit your content into its sections → push the edit →
+   verify). Create the parent, then each child with the parent set — one at a time, keeping the
+   created keys. The child sections this command drafts (User Story, Description, Implementation
+   Ideas, Testing Ideas, Definition of Done, Dependencies) are written to line up with a typical
+   task template — map them onto whatever headings each issue actually shows, carrying any extras
+   (e.g. **Dependencies**) under the closest section. For the parent, place the problem statement /
+   PRD link / non-negotiables table under the closest headings rather than dropping the scaffold.
 5. **Back-fill the mapping**: update the parent's description so each non-negotiable row lists
    the created ticket URL(s) in its "Jira Ticket(s)" cell.
 6. **Report and sync the brief**: list the parent + child keys, and offer to update the brief's

--- a/.claude/rules/jira-issue-creation.md
+++ b/.claude/rules/jira-issue-creation.md
@@ -1,0 +1,44 @@
+## Creating Jira Issues — Fill the Template, Don't Overwrite It
+
+Platform.Bible work is tracked in the **Paratext (`PT`) Jira project** on
+`paratextstudio.atlassian.net`, reached through the Atlassian MCP server (OAuth — no API token, and
+issues are created under the signed-in user's own account and permissions).
+
+When you create an issue there, the project applies **that work-item type's default description
+template**, and it **replaces whatever description you passed in the create call**. Each work-item
+type (Combined, Dev Task, Sub-task, Bug, …) has its own template and the templates change over
+time, so never assume their shape or hard-code their sections — read the live template off the
+issue you just created.
+
+### Process for the description
+
+1. **Create the issue first** with the summary (and type/parent). Don't rely on the description you
+   pass to the create call — it won't survive.
+2. **Read the created issue's description back.** That is the current, authoritative template for
+   that work-item type.
+3. **Fit your content into the template's sections** — keep its headings and scaffold, and fill
+   each section with the relevant part of what you wrote. Put anything that doesn't map cleanly
+   under the closest section rather than deleting a heading. Populate the template; don't replace it
+   with a different shape.
+4. **Push the filled-in description** with an edit call — a post-create edit overrides the template
+   reliably.
+5. **Re-read and verify** the sections now hold your content instead of the empty placeholders. If
+   they're still empty or unchanged, the edit didn't take — stop and report rather than leaving a
+   blank templated stub.
+
+The template you read back might look something like the following — this is only an illustration of
+the *shape*, not the sections to expect:
+
+```
+### User Story
+...
+### Definition of Done
+...
+```
+
+### Also worth knowing
+
+- Resolve the site's `cloudId` at call time (you can pass the hostname `paratextstudio.atlassian.net`
+  as `cloudId`); don't hard-code it.
+- The Atlassian MCP toolset can create / edit / comment / transition but **cannot delete** issues —
+  test or mistaken issues must be deleted by hand or transitioned to a closed state.


### PR DESCRIPTION
## What

Creating an issue in the Paratext (`PT`) Jira project applies that work-item type's **default description template**, which replaces any description passed in the create call. This documents the correct process so descriptions are **populated into the template's sections** rather than silently lost.

## Changes

- **New** `.claude/rules/jira-issue-creation.md` — a shared, repo-tracked rule so every Claude session (not just the Jira commands) follows the same process when creating PT issues: create → read the live template off the created issue → fit content into its sections → push the edit → re-read and verify. It describes the *process*, not a fixed template (each work-item type has its own template and they change over time), with only a tiny illustrative snippet.
- **Update** `/prd-to-jira` Step 4 — points at the new rule instead of restating the mechanism (per the repo's "link, don't paraphrase" rule), keeping only the command-specific section mapping.

## Verification

Confirmed against a throwaway PT Dev Task: on create, the description was replaced by the default template; a follow-up `editJiraIssue` saved the intended description correctly. (Test issue has since been deleted.)

## Notes

- Base branch is `ai/investigate-prd-command` (per request), not `main`.
- Docs-only change under `.claude/`; pre-commit hooks (gitleaks, lint:staged, AI-branch validations) passed.

AI-assisted (Claude Code, Opus 4.8).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2549)
<!-- Reviewable:end -->
