### PR TITLE
PT-4190: e2e interface-mode pinning + Standard-power-default coverage

### DIFF
--- a/e2e-tests/fixtures/isolated.fixture.ts
+++ b/e2e-tests/fixtures/isolated.fixture.ts
@@ -5,7 +5,12 @@ import {
   TestInfo,
   ConsoleMessage,
 } from '@playwright/test';
-import { launchElectronApp, LaunchElectronAppOptions, teardownElectronApp } from './helpers';
+import {
+  launchElectronApp,
+  LaunchElectronAppOptions,
+  preConfigureSettings,
+  teardownElectronApp,
+} from './helpers';
 
 export { expect } from '@playwright/test';
 
@@ -37,6 +42,22 @@ export interface IsolatedFixtures {
    * name throws "Fixture ... has already been registered as a { scope: 'worker' } fixture".
    */
   electronLaunchOptions: LaunchElectronAppOptions;
+  /**
+   * The `platform.interfaceMode` value seeded into the shared dev-appdata settings file before the
+   * app launches (restored after teardown); set with `test.use({ interfaceMode: 'simple' })`.
+   *
+   * Defaults to `'power'`: the isolated suite's specs are written against the power-mode layout —
+   * simple mode always loads the static `simpleLayout` (simple-layout.data.ts), which has NO Home
+   * tab, so power-layout patterns like `waitForHomeTab` and "close all non-Home tabs" sweeps can
+   * never succeed there. Before this option existed, these specs silently inherited whatever mode
+   * the developer's dev-appdata happened to hold (the app's own no-settings default is 'simple',
+   * under which they cannot pass); seeding makes the requirement explicit and deterministic.
+   *
+   * The mode also changes editor DOM that specs assert on: in power mode the scripture editor
+   * defaults to Standard view (inline, editable markers — PT-4190), while simple mode keeps the
+   * 'formatted' view.
+   */
+  interfaceMode: 'simple' | 'power';
   electronApp: ElectronApplication;
   mainPage: Page;
 }
@@ -45,14 +66,23 @@ export const test = base.extend<IsolatedFixtures>({
   // Option fixture: suites override via test.use(); default launches with no special options.
   electronLaunchOptions: [{}, { option: true }],
 
+  // Option fixture: see the IsolatedFixtures doc for why the default is 'power'.
+  interfaceMode: ['power', { option: true }],
+
   // Test-scoped fixture: Playwright launches one Electron instance per test() block.
-  electronApp: async ({ electronLaunchOptions }, use) => {
+  electronApp: async ({ electronLaunchOptions, interfaceMode }, use) => {
+    // Seed the interface mode BEFORE launch (the app reads dev-appdata settings at startup).
+    // workers=1 (playwright.config.ts) means no other test can race this shared file.
+    const restoreSettings = preConfigureSettings({ 'platform.interfaceMode': interfaceMode });
     const ctx = await launchElectronApp(electronLaunchOptions);
 
     await use(ctx.electronApp);
 
     console.log('[teardown] Test-scoped app teardown starting...');
     await teardownElectronApp(ctx);
+    // Restore the developer's settings file only after the app has fully closed so the app's own
+    // shutdown writes cannot clobber the restored contents (same ordering as comment.fixture.ts).
+    restoreSettings();
     console.log('[teardown] Test-scoped app teardown complete');
   },
 

--- a/e2e-tests/fixtures/isolated.fixture.ts
+++ b/e2e-tests/fixtures/isolated.fixture.ts
@@ -71,19 +71,33 @@ export const test = base.extend<IsolatedFixtures>({
 
   // Test-scoped fixture: Playwright launches one Electron instance per test() block.
   electronApp: async ({ electronLaunchOptions, interfaceMode }, use) => {
-    // Seed the interface mode BEFORE launch (the app reads dev-appdata settings at startup).
-    // workers=1 (playwright.config.ts) means no other test can race this shared file.
-    const restoreSettings = preConfigureSettings({ 'platform.interfaceMode': interfaceMode });
-    const ctx = await launchElectronApp(electronLaunchOptions);
-
-    await use(ctx.electronApp);
-
-    console.log('[teardown] Test-scoped app teardown starting...');
-    await teardownElectronApp(ctx);
-    // Restore the developer's settings file only after the app has fully closed so the app's own
-    // shutdown writes cannot clobber the restored contents (same ordering as comment.fixture.ts).
-    restoreSettings();
-    console.log('[teardown] Test-scoped app teardown complete');
+    // Seed settings BEFORE launch (the app reads dev-appdata settings at startup). Pin the
+    // interface mode (see the IsolatedFixtures doc) AND the interface language to English so specs
+    // that match English UI text — `waitForHomeTab`'s 'Home' tab (localized via %home_dialog_title%)
+    // and `navigateToolbarBcv`'s English book names (BookChapterControl matches localizedBookNames) —
+    // are deterministic regardless of the developer's saved locale. Same both-settings seeding as
+    // comment.fixture.ts. workers=1 (playwright.config.ts) means no other test can race this shared file.
+    const restoreSettings = preConfigureSettings({
+      'platform.interfaceMode': interfaceMode,
+      'platform.interfaceLanguage': ['en'],
+    });
+    try {
+      const ctx = await launchElectronApp(electronLaunchOptions);
+      try {
+        await use(ctx.electronApp);
+      } finally {
+        console.log('[teardown] Test-scoped app teardown starting...');
+        await teardownElectronApp(ctx);
+        console.log('[teardown] Test-scoped app teardown complete');
+      }
+    } finally {
+      // Restore the developer's settings file only after the app has fully closed so the app's own
+      // shutdown writes cannot clobber the restored contents (same ordering as comment.fixture.ts).
+      // In a `finally` so a launch/teardown failure cannot leak the seeded test settings into the
+      // developer's real dev-appdata — a stuck value would otherwise be captured as the "original"
+      // by the next test's preConfigureSettings and corrupt every later run.
+      restoreSettings();
+    }
   },
 
   mainPage: async ({ electronApp }, use, testInfo: TestInfo) => {

--- a/e2e-tests/fixtures/scripture-editor-helpers.ts
+++ b/e2e-tests/fixtures/scripture-editor-helpers.ts
@@ -1,6 +1,167 @@
 import { type Page } from '@playwright/test';
 import { sendPapiRequestOnce, waitForPapiMethodRegistered } from './helpers';
 
+/** Fixed GUID of the bundled sample WEB project (c-sharp/assets/WEB/Settings.xml <Guid>). */
+export const SAMPLE_WEB_PROJECT_ID = '32664dc3288a28df2e2bb75ded887fc8f17a15fb';
+const WEBSOCKET_PORT = 8876;
+const COMMAND_TIMEOUT_MS = 30_000;
+
+/**
+ * Poll until the ProjectLookupService advertises the bundled sample WEB project. The generic
+ * `waitForAtLeastOneProjectMetadata` is NOT sufficient here: other PDP factories (e.g. the lexical
+ * reference resources SDBG/SDBH) can satisfy "at least one project" before the Paratext factory has
+ * registered or finished installing the sample project into an empty isolated root — observed as a
+ * `-32601 'object:platform.Paratext-pdpf.…' not found` failure on cold first launches.
+ */
+async function waitForSampleProjectMetadata(timeoutMs = 60_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      // Sequential polling: each attempt must finish (or time out) before the next.
+      // eslint-disable-next-line no-await-in-loop
+      const result = await sendPapiRequestOnce<{ id?: string }[]>(
+        'object:ProjectLookupService.getMetadataForAllProjects',
+        [],
+        WEBSOCKET_PORT,
+        Math.min(10_000, Math.max(1_000, timeoutMs - (Date.now() - start))),
+      );
+      // Project ids are hex GUIDs whose casing differs between surfaces; compare caseless.
+      if (
+        Array.isArray(result) &&
+        result.some((project) => project?.id?.toLowerCase() === SAMPLE_WEB_PROJECT_ID)
+      )
+        return;
+    } catch {
+      /* ProjectLookupService or PDP factories not ready yet */
+    }
+    // Sequential polling: back off before the next attempt.
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 2_000);
+    });
+  }
+  throw new Error(`Sample WEB project metadata did not appear within ${timeoutMs}ms`);
+}
+
+/** Send one PAPI command over a short-lived WebSocket JSON-RPC connection. */
+export async function sendPapiCommandWhenRegistered(
+  commandName: string,
+  ...args: unknown[]
+): Promise<unknown> {
+  // The extension host can still be activating extensions when the app shell renders; wait for
+  // this exact command to be registered so the request cannot fail with method-not-found.
+  await waitForPapiMethodRegistered(`command:${commandName}`, WEBSOCKET_PORT, 60_000);
+  return sendPapiRequestOnce(`command:${commandName}`, args, WEBSOCKET_PORT, COMMAND_TIMEOUT_MS);
+}
+
+/**
+ * Make the installed sample WEB project editable. Its Settings.xml ships `<Editable>F</Editable>`,
+ * so `openScriptureEditor` would silently fall back to a read-only editor (main.ts overrides
+ * isReadOnly from `platform.isEditable`) — and a read-only Lexical editor never moves the caret on
+ * click, so caret-driven behavior cannot be exercised without this. Flipping the setting through
+ * the PDP (same write path as the Project Settings UI) keeps the change inside the isolated temp
+ * project root.
+ */
+export async function makeSampleProjectEditable(): Promise<void> {
+  // Wait until the Paratext factory has registered AND the sample project is installed and
+  // advertised — see waitForSampleProjectMetadata for why a generic any-project wait is racy.
+  await waitForPapiMethodRegistered(
+    'object:platform.Paratext-pdpf.getProjectDataProviderId',
+    WEBSOCKET_PORT,
+    60_000,
+  );
+  await waitForSampleProjectMetadata();
+  const pdpId = await sendPapiRequestOnce<string>(
+    'object:platform.Paratext-pdpf.getProjectDataProviderId',
+    [SAMPLE_WEB_PROJECT_ID],
+    WEBSOCKET_PORT,
+    COMMAND_TIMEOUT_MS,
+  );
+  await sendPapiRequestOnce<boolean>(
+    `object:${pdpId}.setSetting`,
+    ['platform.isEditable', true],
+    WEBSOCKET_PORT,
+    COMMAND_TIMEOUT_MS,
+  );
+}
+
+/**
+ * Opens the EDITABLE scripture editor for the given project, waits for its iframe to attach, and
+ * returns the editor's webViewId (usable as an `iframe[data-web-view-id="..."]` locator).
+ *
+ * Mirrors {@link openScriptureEditorForProject} (which opens the read-only resource viewer) and
+ * `openCommentList` Phase A in `comment-test-helpers.ts`, including the loadLayout-race guard and
+ * retry loop; see `openCommentList` for the full explanation of the race. The 60s per-request
+ * timeout follows `openCommentList`: under the simple-mode layout (five auto-loading webviews) a
+ * cold xvfb startup makes the command response slow enough that a 30s timeout flakes.
+ *
+ * @param mainPage The Electron main window page
+ * @param projectId The id of the project to open the editable Scripture editor for
+ * @returns The editor's webViewId
+ */
+export async function openEditableScriptureEditorForProject(
+  mainPage: Page,
+  projectId: string,
+): Promise<string> {
+  // Wait for the dock layout's initial loadLayout() to complete (signalled by the first iframe
+  // appearing) so loadLayout can't wipe the newly added editor tab.
+  await mainPage.waitForSelector('iframe', { state: 'attached', timeout: 30_000 });
+
+  await waitForPapiMethodRegistered(
+    'command:platformScriptureEditor.openScriptureEditor',
+    WEBSOCKET_PORT,
+    60_000,
+  );
+
+  // Sequential retry loop: each attempt must await the PAPI response and iframe appearance before
+  // deciding whether to retry (see openCommentList for the dock-layout race this covers).
+  /* eslint-disable no-await-in-loop, no-continue */
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    if (attempt > 0) {
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 1_000);
+      });
+    }
+
+    const editorId = await sendPapiRequestOnce<string | undefined>(
+      'command:platformScriptureEditor.openScriptureEditor',
+      [projectId],
+      WEBSOCKET_PORT,
+      60_000,
+    );
+    if (!editorId) continue;
+
+    const editorIframeFound = await mainPage
+      .locator(`iframe[data-web-view-id="${editorId}"]`)
+      .waitFor({ state: 'attached', timeout: attempt < 4 ? 8_000 : 20_000 })
+      .then(() => true)
+      .catch(() => false);
+    if (editorIframeFound) return editorId;
+  }
+  /* eslint-enable no-await-in-loop, no-continue */
+
+  throw new Error(
+    `Could not open an editable Scripture editor for project ${projectId} after 5 attempts`,
+  );
+}
+
+/** Navigate the main toolbar's book-chapter-verse control (drives scroll group A). */
+export async function navigateToolbarBcv(mainPage: Page, reference: string): Promise<void> {
+  await mainPage.locator('button[aria-label="book-chapter-trigger"]').first().click();
+  const input = mainPage.locator('[data-radix-popper-content-wrapper] input');
+  await input.fill(reference);
+  await input.press('Enter');
+}
+
+/**
+ * Wait for the Home dock tab so PAPI commands land in a ready app. (Not the canonical
+ * `waitForAppReady` from fixtures/helpers.ts — this additionally proves the normal Home layout
+ * rendered, which DEV_NOISY=false launches depend on.)
+ */
+export async function waitForHomeTab(mainPage: Page): Promise<void> {
+  await mainPage.locator('.dock-tab', { hasText: 'Home' }).first().waitFor({ timeout: 90_000 });
+}
+
 /**
  * Opens a Scripture editor (resource viewer) for the given project and waits for its iframe to
  * attach.

--- a/e2e-tests/fixtures/scripture-editor-helpers.ts
+++ b/e2e-tests/fixtures/scripture-editor-helpers.ts
@@ -86,32 +86,33 @@ export async function makeSampleProjectEditable(): Promise<void> {
 }
 
 /**
- * Opens the EDITABLE scripture editor for the given project, waits for its iframe to attach, and
- * returns the editor's webViewId (usable as an `iframe[data-web-view-id="..."]` locator).
+ * Shared engine for the open-editor helpers: waits for the dock layout's initial loadLayout() to
+ * finish (signalled by the first iframe — the Home webview — appearing) so loadLayout can't wipe
+ * the newly added editor tab, waits for `commandName` to register, then retries the open command up
+ * to 5 times, each attempt waiting for the returned web view's iframe to attach.
  *
- * Mirrors {@link openScriptureEditorForProject} (which opens the read-only resource viewer) and
- * `openCommentList` Phase A in `comment-test-helpers.ts`, including the loadLayout-race guard and
- * retry loop; see `openCommentList` for the full explanation of the race. The 60s per-request
- * timeout follows `openCommentList`: under the simple-mode layout (five auto-loading webviews) a
- * cold xvfb startup makes the command response slow enough that a 30s timeout flakes.
+ * Mirrors `openCommentList` in `comment-test-helpers.ts`, including its loadLayout-race guard and
+ * retry loop; see that helper for the full explanation of the race. The 60s per-request timeout
+ * also follows `openCommentList`: under the simple-mode layout (five auto-loading webviews) a cold
+ * xvfb startup makes the command response slow enough that a 30s timeout flakes.
  *
  * @param mainPage The Electron main window page
- * @param projectId The id of the project to open the editable Scripture editor for
- * @returns The editor's webViewId
+ * @param commandName The PAPI command that opens the editor, without the `command:` prefix
+ * @param projectId The id of the project to open the editor for
+ * @param editorDescription Human-readable editor name used in the "could not open" failure message
+ * @returns The opened editor's webViewId (usable as an `iframe[data-web-view-id="..."]` locator)
  */
-export async function openEditableScriptureEditorForProject(
+async function openEditorViaCommand(
   mainPage: Page,
+  commandName: string,
   projectId: string,
+  editorDescription: string,
 ): Promise<string> {
-  // Wait for the dock layout's initial loadLayout() to complete (signalled by the first iframe
-  // appearing) so loadLayout can't wipe the newly added editor tab.
+  // Wait for the dock layout's initial loadLayout() to complete (signalled by the first iframe —
+  // the Home webview — appearing) so loadLayout can't wipe the newly added editor tab.
   await mainPage.waitForSelector('iframe', { state: 'attached', timeout: 30_000 });
 
-  await waitForPapiMethodRegistered(
-    'command:platformScriptureEditor.openScriptureEditor',
-    WEBSOCKET_PORT,
-    60_000,
-  );
+  await waitForPapiMethodRegistered(`command:${commandName}`, WEBSOCKET_PORT, 60_000);
 
   // Sequential retry loop: each attempt must await the PAPI response and iframe appearance before
   // deciding whether to retry (see openCommentList for the dock-layout race this covers).
@@ -124,7 +125,7 @@ export async function openEditableScriptureEditorForProject(
     }
 
     const editorId = await sendPapiRequestOnce<string | undefined>(
-      'command:platformScriptureEditor.openScriptureEditor',
+      `command:${commandName}`,
       [projectId],
       WEBSOCKET_PORT,
       60_000,
@@ -140,8 +141,26 @@ export async function openEditableScriptureEditorForProject(
   }
   /* eslint-enable no-await-in-loop, no-continue */
 
-  throw new Error(
-    `Could not open an editable Scripture editor for project ${projectId} after 5 attempts`,
+  throw new Error(`Could not open ${editorDescription} for project ${projectId} after 5 attempts`);
+}
+
+/**
+ * Opens the EDITABLE scripture editor for the given project, waits for its iframe to attach, and
+ * returns the editor's webViewId (usable as an `iframe[data-web-view-id="..."]` locator).
+ *
+ * @param mainPage The Electron main window page
+ * @param projectId The id of the project to open the editable Scripture editor for
+ * @returns The editor's webViewId
+ */
+export async function openEditableScriptureEditorForProject(
+  mainPage: Page,
+  projectId: string,
+): Promise<string> {
+  return openEditorViaCommand(
+    mainPage,
+    'platformScriptureEditor.openScriptureEditor',
+    projectId,
+    'an editable Scripture editor',
   );
 }
 
@@ -170,9 +189,6 @@ export async function waitForHomeTab(mainPage: Page): Promise<void> {
  * (nothing to navigate), and a fresh test profile opens none on its own — so tests that exercise
  * the top control open an editor first, then assert the enabled state as a hard expectation.
  *
- * Mirrors `openCommentList` in `comment-test-helpers.ts`, including its loadLayout-race guard and
- * retry loop; see that helper for the full explanation of the race.
- *
  * @param mainPage The Electron main window page
  * @param projectId The id of the project to open a Scripture editor for
  */
@@ -180,38 +196,11 @@ export async function openScriptureEditorForProject(
   mainPage: Page,
   projectId: string,
 ): Promise<void> {
-  // Wait for the dock layout's initial loadLayout() to complete (signalled by the first iframe —
-  // the Home webview — appearing) so loadLayout can't wipe the newly added editor tab
-  await mainPage.waitForSelector('iframe', { state: 'attached', timeout: 30_000 });
-
-  await waitForPapiMethodRegistered('command:platformScriptureEditor.openResourceViewer');
-
-  // Sequential retry loop: each attempt must await the PAPI response and iframe appearance before
-  // deciding whether to retry (see openCommentList for the dock-layout race this covers).
-  /* eslint-disable no-await-in-loop, no-continue */
-  for (let attempt = 0; attempt < 5; attempt += 1) {
-    if (attempt > 0) {
-      await new Promise<void>((resolve) => {
-        setTimeout(resolve, 1_000);
-      });
-    }
-
-    const editorId = await sendPapiRequestOnce<string | undefined>(
-      'command:platformScriptureEditor.openResourceViewer',
-      [projectId],
-      undefined,
-      60_000,
-    );
-    if (!editorId) continue;
-
-    const editorIframeFound = await mainPage
-      .locator(`iframe[data-web-view-id="${editorId}"]`)
-      .waitFor({ state: 'attached', timeout: attempt < 4 ? 8_000 : 20_000 })
-      .then(() => true)
-      .catch(() => false);
-    if (editorIframeFound) return;
-  }
-  /* eslint-enable no-await-in-loop, no-continue */
-
-  throw new Error(`Could not open a Scripture editor for project ${projectId} after 5 attempts`);
+  // The resource viewer's webViewId is not needed by callers of this function; discard it.
+  await openEditorViaCommand(
+    mainPage,
+    'platformScriptureEditor.openResourceViewer',
+    projectId,
+    'a Scripture editor',
+  );
 }

--- a/e2e-tests/tests/isolated/scripture-editor/formatted-default-simple-mode.spec.ts
+++ b/e2e-tests/tests/isolated/scripture-editor/formatted-default-simple-mode.spec.ts
@@ -1,0 +1,54 @@
+/**
+ * Simple-mode default-view e2e (PT-4190 / NN-1 "nothing changes for Simple users" clause): a
+ * scripture editor opened with no previously saved view state keeps the pre-Standard-view
+ * 'formatted' default when `platform.interfaceMode` is 'simple' — the power-mode Standard default
+ * (see standard-default-power-mode.spec.ts) must not leak into Simple mode.
+ *
+ * The flow mirrors the power-mode spec exactly (same project, same open command, same navigation);
+ * the ONLY variable is `interfaceMode`, so a failure here isolates the interface-mode gating of the
+ * default rather than anything about how the editor was opened.
+ *
+ * ONE test() per spec file on purpose — see standard-default-power-mode.spec.ts.
+ */
+import { test, expect } from '../../../fixtures/isolated.fixture';
+import {
+  makeSampleProjectEditable,
+  navigateToolbarBcv,
+  openEditableScriptureEditorForProject,
+  SAMPLE_WEB_PROJECT_ID,
+} from '../../../fixtures/scripture-editor-helpers';
+
+// interfaceMode 'simple' overrides the fixture's 'power' default — this spec IS the guard that
+// Simple mode keeps the formatted view.
+// DEV_NOISY=false: the noisy dev test layout replaces the normal layouts (see
+// scroll-group-sync.spec.ts).
+test.use({
+  interfaceMode: 'simple',
+  electronLaunchOptions: { isolatedProjectRoot: true, envOverrides: { DEV_NOISY: 'false' } },
+});
+
+test.describe('scripture editor default view', () => {
+  test('a first-open editor keeps the formatted view in simple mode', async ({ mainPage }) => {
+    // No `waitForHomeTab` here: simple mode loads the static simpleLayout, which has NO Home tab
+    // (simple-layout.data.ts). The open helper below carries its own app-readiness gates (first
+    // iframe attached = initial loadLayout() done; PAPI command registration; retry loop).
+    await makeSampleProjectEditable();
+    const editorId = await openEditableScriptureEditorForProject(mainPage, SAMPLE_WEB_PROJECT_ID);
+    const editorFrame = mainPage.frameLocator(`iframe[data-web-view-id="${editorId}"]`);
+    await editorFrame.locator('.editor-container').waitFor({ timeout: 60_000 });
+
+    // Same book as the power-mode spec; the verse-number wait doubles as the positive control
+    // that chapter content finished rendering BEFORE the negative assertions below run (an
+    // empty editor would pass them vacuously).
+    await navigateToolbarBcv(mainPage, 'Obadiah 1:1');
+    await expect(editorFrame.locator('span[data-marker="v"][data-number="1"]')).toBeAttached({
+      timeout: 60_000,
+    });
+
+    // Formatted view: no editable-marker mode class on the contentEditable root, and no inline
+    // marker glyphs anywhere in the content (MarkerNodes exist only in Standard view's editable
+    // marker mode). The power-mode corrective effect must never fire in simple mode.
+    await expect(editorFrame.locator('.editor-input.marker-editable')).toHaveCount(0);
+    await expect(editorFrame.locator('span.opening[data-marker]')).toHaveCount(0);
+  });
+});

--- a/e2e-tests/tests/isolated/scripture-editor/formatted-default-simple-mode.spec.ts
+++ b/e2e-tests/tests/isolated/scripture-editor/formatted-default-simple-mode.spec.ts
@@ -29,6 +29,12 @@ test.use({
 
 test.describe('scripture editor default view', () => {
   test('a first-open editor keeps the formatted view in simple mode', async ({ mainPage }) => {
+    // Heavy isolated test: it launches its own Electron instance, installs the bundled sample
+    // project into a fresh root, opens the editor, and polls several backend-readiness gates. A cold
+    // first run measured ~84s against the default 120s budget (~70%), so a colder or
+    // memory-pressured machine could spuriously time out before the calibrated per-step timeouts
+    // fire. Give it Playwright's 3x "slow" budget for headroom (a passing run still exits in seconds).
+    test.slow();
     // No `waitForHomeTab` here: simple mode loads the static simpleLayout, which has NO Home tab
     // (simple-layout.data.ts). The open helper below carries its own app-readiness gates (first
     // iframe attached = initial loadLayout() done; PAPI command registration; retry loop).
@@ -45,9 +51,22 @@ test.describe('scripture editor default view', () => {
       timeout: 60_000,
     });
 
-    // Formatted view: no editable-marker mode class on the contentEditable root, and no inline
-    // marker glyphs anywhere in the content (MarkerNodes exist only in Standard view's editable
-    // marker mode). The power-mode corrective effect must never fire in simple mode.
+    // Formatted view POSITIVE signal, asserted with a wait so the view has actually SETTLED to
+    // formatted before the negative checks below (the two toHaveCount(0) checks alone are satisfied
+    // by the pre-settle DOM and could pass vacuously). The contentEditable root carries the
+    // formatted marker-mode class `marker-hidden`: non-power 'formatted' resolves to markerMode
+    // 'hidden' in getViewOptionsForType, which the editor maps onto `.editor-input.marker-hidden`
+    // (see _usj-nodes.scss), symmetric to the power spec's `.editor-input.marker-editable`. A
+    // Simple->Standard regression (the power-default corrective effect wrongly firing in simple
+    // mode) would flip this root class to `marker-editable`, failing HERE by construction instead of
+    // slipping past the count-0 checks.
+    await expect(editorFrame.locator('.editor-input.marker-hidden')).toBeAttached({
+      timeout: 60_000,
+    });
+
+    // And no editable-marker mode class or inline marker glyphs anywhere in the content (MarkerNodes
+    // exist only in Standard view's editable marker mode). The power-mode corrective effect must
+    // never fire in simple mode.
     await expect(editorFrame.locator('.editor-input.marker-editable')).toHaveCount(0);
     await expect(editorFrame.locator('span.opening[data-marker]')).toHaveCount(0);
   });

--- a/e2e-tests/tests/isolated/scripture-editor/standard-default-power-mode.spec.ts
+++ b/e2e-tests/tests/isolated/scripture-editor/standard-default-power-mode.spec.ts
@@ -1,0 +1,67 @@
+/**
+ * Power-mode default-view e2e (PT-4190 / NN-1 default clause): a scripture editor opened with no
+ * previously saved view state defaults to Standard view when `platform.interfaceMode` is 'power'.
+ *
+ * The default is applied by a corrective effect in platform-scripture-editor.web-view.tsx that
+ * fires only after the interface-mode setting resolves (the first frames may render 'formatted'),
+ * so the Standard-view assertions poll with generous timeouts rather than asserting immediately.
+ *
+ * Probes:
+ *
+ * - `.editor-input.marker-editable` — the editor library maps `ViewOptions.markerMode` onto a
+ *   `marker-<mode>` class on the contentEditable root (`getViewClassList` in shared-react), and
+ *   Standard view (STANDARD_VIEW_MODE) is the only view preset with markerMode 'editable'.
+ * - `span.opening[data-marker]` — a rendered inline marker glyph (MarkerNode; class from its
+ *   markerSyntax). Only the editable marker mode creates MarkerNodes, and their visible `\marker`
+ *   text is the user-facing substance of Standard view.
+ *
+ * ONE test() per spec file on purpose: the isolated fixture is test-scoped, and a SECOND Electron
+ * instance launched against the shared webpack renderer dev server has a documented failure mode
+ * where new dock tabs never render (see isolated.fixture.ts). The simple-mode counterpart lives in
+ * formatted-default-simple-mode.spec.ts for the same reason.
+ *
+ * Runs against an isolated project root, so the only project is the bundled sample WEB (installed
+ * by the C# backend into the empty root): `npm run test:e2e:isolated scripture-editor`.
+ */
+import { test, expect } from '../../../fixtures/isolated.fixture';
+import {
+  makeSampleProjectEditable,
+  navigateToolbarBcv,
+  openEditableScriptureEditorForProject,
+  SAMPLE_WEB_PROJECT_ID,
+  waitForHomeTab,
+} from '../../../fixtures/scripture-editor-helpers';
+
+// interfaceMode 'power' matches the fixture default but is stated explicitly — this spec IS the
+// power-default guard, so it must not drift if the fixture default ever changes.
+// DEV_NOISY=false: the noisy dev test layout has no Home tab (see scroll-group-sync.spec.ts).
+test.use({
+  interfaceMode: 'power',
+  electronLaunchOptions: { isolatedProjectRoot: true, envOverrides: { DEV_NOISY: 'false' } },
+});
+
+test.describe('scripture editor default view', () => {
+  test('a first-open editor defaults to Standard view in power mode', async ({ mainPage }) => {
+    await waitForHomeTab(mainPage);
+
+    // Open the EDITABLE editor — the mainline Standard-view surface (the sample project ships
+    // Editable=F, so openScriptureEditor would otherwise fall back to a read-only viewer).
+    await makeSampleProjectEditable();
+    const editorId = await openEditableScriptureEditorForProject(mainPage, SAMPLE_WEB_PROJECT_ID);
+    const editorFrame = mainPage.frameLocator(`iframe[data-web-view-id="${editorId}"]`);
+    await editorFrame.locator('.editor-container').waitFor({ timeout: 60_000 });
+
+    // Load a small single-chapter book (same choice as scroll-group-sync.spec.ts) so the marker
+    // glyph assertion below runs against real chapter content.
+    await navigateToolbarBcv(mainPage, 'Obadiah 1:1');
+
+    // The view settles on 'standard' once the corrective effect fires (see file header).
+    await expect(editorFrame.locator('.editor-input.marker-editable')).toBeAttached({
+      timeout: 60_000,
+    });
+    // And Standard view actually renders inline marker glyphs, not just the mode class.
+    await expect(
+      editorFrame.locator('.editor-input.marker-editable span.opening[data-marker]').first(),
+    ).toBeAttached({ timeout: 30_000 });
+  });
+});

--- a/e2e-tests/tests/isolated/scripture-editor/standard-default-power-mode.spec.ts
+++ b/e2e-tests/tests/isolated/scripture-editor/standard-default-power-mode.spec.ts
@@ -42,6 +42,12 @@ test.use({
 
 test.describe('scripture editor default view', () => {
   test('a first-open editor defaults to Standard view in power mode', async ({ mainPage }) => {
+    // Heavy isolated test: it launches its own Electron instance, installs the bundled sample
+    // project into a fresh root, opens the editor, and polls several backend-readiness gates. A cold
+    // first run measured ~84s against the default 120s budget (~70%), so a colder or
+    // memory-pressured machine could spuriously time out before the calibrated per-step timeouts
+    // fire. Give it Playwright's 3x "slow" budget for headroom (a passing run still exits in seconds).
+    test.slow();
     await waitForHomeTab(mainPage);
 
     // Open the EDITABLE editor — the mainline Standard-view surface (the sample project ships

--- a/e2e-tests/tests/isolated/scroll-groups/scroll-group-sync.spec.ts
+++ b/e2e-tests/tests/isolated/scroll-groups/scroll-group-sync.spec.ts
@@ -19,18 +19,14 @@
  * so the tested navigations (1:1 -> 1:21 external change, 1:1 -> 1:15 click-follow) never cross a
  * chapter/book boundary and no document reload races with the scroll.
  */
-import { Page } from '@playwright/test';
 import { test, expect } from '../../../fixtures/isolated.fixture';
 import {
-  sendPapiRequestOnce,
-  waitForAtLeastOneProjectMetadata,
-  waitForPapiMethodRegistered,
-} from '../../../fixtures/helpers';
-
-/** Fixed GUID of the bundled sample WEB project (c-sharp/assets/WEB/Settings.xml <Guid>). */
-const SAMPLE_WEB_PROJECT_ID = '32664dc3288a28df2e2bb75ded887fc8f17a15fb';
-const WEBSOCKET_PORT = 8876;
-const COMMAND_TIMEOUT_MS = 30_000;
+  makeSampleProjectEditable,
+  navigateToolbarBcv,
+  SAMPLE_WEB_PROJECT_ID,
+  sendPapiCommandWhenRegistered,
+  waitForHomeTab,
+} from '../../../fixtures/scripture-editor-helpers';
 
 // The option fixture is named `electronLaunchOptions`, not `launchOptions` — Playwright's base
 // `test` already registers a worker-scoped `launchOptions` option fixture (browser launch
@@ -41,62 +37,16 @@ const COMMAND_TIMEOUT_MS = 30_000;
 // (src/renderer/testing/test-layout.data.ts), which has NO Home tab — app-ready detection and a
 // clean single-pane layout for the viewport assertions both need the normal Home layout. Same
 // approach as comment.fixture.ts.
+//
+// The fixture's default `interfaceMode: 'power'` (required for the Home-tab layout this suite
+// waits on) now means the editor opens in Standard view by default (PT-4190). The verse selectors
+// below survive that: `VerseNode` renders `data-marker="v"`/`data-number` in every view, and in
+// Standard view the visible `\v N` marker text lives INSIDE the verse span (no separate glyph
+// element is inserted), so the `+ span` marker/text adjacency and the click-in-verse-text gesture
+// behave the same as in the formatted view.
 test.use({
   electronLaunchOptions: { isolatedProjectRoot: true, envOverrides: { DEV_NOISY: 'false' } },
 });
-
-/** Send one PAPI command over a short-lived WebSocket JSON-RPC connection. */
-async function sendPapiCommandWhenRegistered(
-  commandName: string,
-  ...args: unknown[]
-): Promise<unknown> {
-  // The extension host can still be activating extensions when the app shell renders; wait for
-  // this exact command to be registered so the request cannot fail with method-not-found.
-  await waitForPapiMethodRegistered(`command:${commandName}`, WEBSOCKET_PORT, 60_000);
-  return sendPapiRequestOnce(`command:${commandName}`, args, WEBSOCKET_PORT, COMMAND_TIMEOUT_MS);
-}
-
-/**
- * Make the installed sample WEB project editable. Its Settings.xml ships `<Editable>F</Editable>`,
- * so `openScriptureEditor` would silently fall back to a read-only editor (main.ts overrides
- * isReadOnly from `platform.isEditable`) — and a read-only Lexical editor never moves the caret on
- * click, so click-follow cannot be exercised without this. Flipping the setting through the PDP
- * (same write path as the Project Settings UI) keeps the change inside the isolated temp project
- * root.
- */
-async function makeSampleProjectEditable(): Promise<void> {
-  // Wait until the sample project is installed and advertised by the Paratext PDP factory.
-  await waitForAtLeastOneProjectMetadata(WEBSOCKET_PORT, 60_000);
-  const pdpId = await sendPapiRequestOnce<string>(
-    'object:platform.Paratext-pdpf.getProjectDataProviderId',
-    [SAMPLE_WEB_PROJECT_ID],
-    WEBSOCKET_PORT,
-    COMMAND_TIMEOUT_MS,
-  );
-  await sendPapiRequestOnce<boolean>(
-    `object:${pdpId}.setSetting`,
-    ['platform.isEditable', true],
-    WEBSOCKET_PORT,
-    COMMAND_TIMEOUT_MS,
-  );
-}
-
-/** Navigate the main toolbar's book-chapter-verse control (drives scroll group A). */
-async function navigateToolbarBcv(mainPage: Page, reference: string): Promise<void> {
-  await mainPage.locator('button[aria-label="book-chapter-trigger"]').first().click();
-  const input = mainPage.locator('[data-radix-popper-content-wrapper] input');
-  await input.fill(reference);
-  await input.press('Enter');
-}
-
-/**
- * Wait for the Home dock tab so PAPI commands land in a ready app. (Not the canonical
- * `waitForAppReady` from fixtures/helpers.ts — this additionally proves the normal Home layout
- * rendered, which the DEV_NOISY=false launch depends on.)
- */
-async function waitForHomeTab(mainPage: Page): Promise<void> {
-  await mainPage.locator('.dock-tab', { hasText: 'Home' }).first().waitFor({ timeout: 90_000 });
-}
 
 test.describe('scroll group sync', () => {
   test('an external BCV change scrolls the verse into view, and clicking a verse reports it to the scroll group (PT9-style click-follow)', async ({


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: standard-view-2

**Base**: standard-view

**Date**: 2026-07-14

**Review model**: Claude Opus 4.8

**Files changed**: 6 (5 e2e-test files under review + `dev-packages.json`, an intentional working change excluded from this review per author instruction)

## Overview

This branch prepares the `standard-view` work to merge to `main` without changing behavior for the Simple interface mode — Standard View is a Power-only feature, so the goal is to prove Simple users see no change while Power users get the new Standard default. The change is entirely e2e test infrastructure: it fixes the interface-mode dependency the existing tests were implicitly relying on and adds per-mode default-view coverage.

Concretely, it adds an `interfaceMode` option fixture (defaulting to `'power'`) to `isolated.fixture.ts`, lifts several previously-inline helpers out of `scroll-group-sync.spec.ts` into the shared `scripture-editor-helpers.ts` module, and adds two new specs asserting the editor's first-open default view per interface mode: `standard-default-power-mode.spec.ts` (Power ⇒ Standard view) and `formatted-default-simple-mode.spec.ts` (Simple ⇒ formatted/default view). The two specs faithfully encode the production default logic in `platform-scripture-editor.web-view.tsx` (`isPowerMode ? 'standard' : 'formatted'` plus a one-shot corrective effect that only writes `'standard'` when power mode is confirmed and no view was persisted). No product code changed.

## API Changes

None. All changed files are e2e test infrastructure (`e2e-tests/fixtures/` and `e2e-tests/tests/`). No public API surface was touched — nothing under `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `@papi/` modules in `papi.d.ts`, or extension `src/types/*.d.ts` declarations. The helpers added/changed in `scripture-editor-helpers.ts` are test-only utilities.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **`e2e-tests/fixtures/scripture-editor-helpers.ts`: DRY — `openEditableScriptureEditorForProject` was a near-verbatim copy of `openScriptureEditorForProject`** (same first-iframe wait, `waitForPapiMethodRegistered`, 5-attempt retry loop with identical `8_000/20_000` backoff, same eslint-disable block and "after 5 attempts" throw), differing only in command name, return value, and one explicit-vs-default port arg. _(fixed during review: extracted a private `openEditorViaCommand(mainPage, commandName, projectId, editorDescription)` engine holding the retry/timeout logic once; both public helpers now delegate to it. Verified behavior-preserving — `DEFAULT_WEBSOCKET_PORT === WEBSOCKET_PORT === 8876` and `waitForPapiMethodRegistered`'s default timeout is `60_000`, so unifying the resource-viewer path's reliance on defaults to explicit args changes nothing. Net −11 lines.)_

[Author response: Author confirmed the copy-paste was "the fastest way" to get the editable variant working, not a deliberate keep-them-independent choice, and asked for the extraction. Fixed in-review.]

### Minor — Consider

- [x] **`e2e-tests/fixtures/scripture-editor-helpers.ts`: inconsistent argument style** between the two open-editor helpers (one passed `WEBSOCKET_PORT`/`60_000` explicitly, the other relied on defaults). _(fixed during review: resolved by the same `openEditorViaCommand` extraction — both paths now pass uniform `WEBSOCKET_PORT, 60_000`.)_
- [ ] ~~**`e2e-tests/fixtures/scripture-editor-helpers.ts`: consolidation opportunity — migrate the still-inline toolbar-BCV and Home-tab gestures in other specs onto the new shared `navigateToolbarBcv` / `waitForHomeTab`.**~~ _(Investigated all call sites; no safe, in-scope, behavior-preserving target exists, so dropped by agreement. `waitForHomeTab`: every `.dock-tab`+Home site is either the opposite `hasNotText:'Home'` filter (`manage-books-*`, `navigation-history:63`), a `.click()` rather than a wait (`helpers.ts:607`, which would also create a **circular import** since `scripture-editor-helpers.ts` already imports from `helpers.ts`), or in a legacy `markers-checklist` dir. `navigateToolbarBcv`: `navigation-history`'s `navigateToRef` is deliberately more robust (waits for cmdk's `data-selected` top match before Enter to defeat a documented flake) so replacing it would regress; `verse-navigation-shortcuts` has the toolbar-BCV navigation as its subject-under-test with different locators/assertions; `scroll-group-sync` already uses the helper (its line-118 hit is an assertion, not a navigation); `smoke/ui-interaction` and `markers-checklist` are out of scope.)_

[Author response: Finding 1 was already handled by the Important-finding fix. For finding 2, author initially asked to refactor, then agreed to drop it after the per-site investigation showed no safe target.]

### Template Propagation

#### Shared Regions Modified

None. No `#region shared with` markers exist in any of the five changed files.

#### Extension Config Changes

None. The entire review surface is under `e2e-tests/`; no files in `extensions/` were touched, so no propagation to `paranext-extension-template` / `paranext-multi-extension-template` applies.

## Positive Observations

- **Genuine DRY win in the extraction**, not copy-paste: `SAMPLE_WEB_PROJECT_ID`, `sendPapiCommandWhenRegistered`, `makeSampleProjectEditable`, `navigateToolbarBcv`, and `waitForHomeTab` were lifted out of `scroll-group-sync.spec.ts` into the shared module and are now reused by three specs, with no leftover unused imports.
- **The `interfaceMode` option fixture is correctly ordered**: it seeds `platform.interfaceMode` via `preConfigureSettings` *before* launch and restores the settings file *after* `teardownElectronApp` completes — matching the documented `comment.fixture.ts` precedent so the app's shutdown writes cannot clobber the restore. Its `'simple' | 'power'` type matches the real setting type.
- **Deterministic mode dependency**: `scroll-group-sync.spec.ts` now inherits an explicit `'power'` default instead of silently depending on whatever the developer's dev-appdata held — a correctness improvement consistent with the branch purpose.
- **The two new specs accurately encode production behavior** and cannot pass vacuously: the power spec asserts a positive `marker-editable` presence *and* a real inline marker glyph; the simple spec includes a positive control (waits for `data-marker="v"` verse content) before its negative assertions.
- **Correct placement** under `tests/isolated/scripture-editor/` per `e2e-tests/CLAUDE.md` — a feature subdir, not a new top-level project, so it is immediately discoverable by the `isolated` project with no config changes.
- **Unusually high documentation quality**: the fixture doc block, the view-mode DOM-signal notes, and the `waitForSampleProjectMetadata` rationale (why the generic any-project wait is racy on cold launch) all explain the "why," not just the "what."
- **Disciplined eslint-disable usage**: `no-await-in-loop` and `no-continue` suppressions each carry a justification comment explaining the sequential-polling/retry intent.

## Interview Notes

- **Stated purpose**: Make the `standard-view` branch mergeable to `main` without affecting Simple mode (Standard View is a Power feature); fix the e2e tests and add coverage that the editor opens in the correct default view per interface mode.
- **Why the fixture defaults to `'power'`** (author's own reasoning, not deferred to AI): the e2e suite is almost exclusively written against Power and has only *happened* to mostly work under Simple so far; the branch deliberately diverges now because the new editor tests check mode-specific DOM detail that differs between the modes.
- **How the specs distinguish modes**: they check DOM signals for marker presence — the `marker-<mode>` class on the contentEditable root (`marker-editable` is unique to Standard view) plus rendered inline marker glyphs; the simple spec asserts their absence after a positive verse-content control.
- **Design understanding**: The author demonstrated clear, self-owned understanding of the change (the mode-divergence rationale and the DOM-signal strategy were explained in their own words). No areas were deferred to AI.
- **Robustness discussion (author chose to leave as-is)**: The simple-mode spec proves "not Standard" via negative `toHaveCount(0)` assertions, which pass the instant the count is zero. This is safe *today* by reasoning about production (the corrective effect never fires in Simple mode, so formatted is both the initial and final state), but it is safe by argument rather than by construction — a future regression where Simple mode flipped to Standard could still pass this test vacuously by checking count-0 before the flip. A more robust option would be to assert the *positive* formatted-view class symmetrically with the power spec's `marker-editable`. The author elected to leave it and record it as a review-meeting item (the exact formatted-view class name is bundled/minified inside the editor library and was not confirmed).
- **Wrap-up**: Author had nothing further to flag.

## In-Review Quality Check

Changes were made during the interview (the `openEditorViaCommand` extraction in `scripture-editor-helpers.ts`). Checks run against that change:

- **Prettier** (changed file): passed — already formatted, no changes.
- **ESLint** (changed file): passed clean.
- **TypeScript** (`tsc --noEmit -p e2e-tests/tsconfig.json`): passed clean. (The e2e project is not a workspace and not in the root tsconfig, so it is typechecked via its own config, which was run explicitly.)
- **Vitest `npm test`**: not run by design — the e2e helpers are not imported by any Vitest unit test, and e2e specs run under Playwright (outside `npm test`), so the suite cannot exercise this change. No behavioral risk to unit tests.

No unfixable failures.

## Suggested Review Focus

Prioritized agenda for the author–reviewer meeting:

- [ ] **Simple-mode absence-assertion robustness**: `formatted-default-simple-mode.spec.ts` proves "not Standard" via `toHaveCount(0)`, which can pass before a (regressed) corrective effect would fire. Discuss whether to add a positive formatted-view class assertion (symmetric with the power spec) to make the guard catch a Simple→Standard regression by construction.
- [ ] **Suite-wide `'power'` default flip**: the new `interfaceMode` option fixture defaults to `'power'`, so every spec using `isolated.fixture` now has `platform.interfaceMode` seeded. Confirm no other existing isolated spec silently depended on a different (unset/Simple-ish) default — `scroll-group-sync` is now explicitly pinned, but audit the rest of the `isolated` tree.
- [ ] **Corrective-effect default vs. persisted view state**: both new specs assume "no previously saved view state" on first open. Confirm the isolated fixture guarantees a clean per-test project root so a persisted view can never leak in and change the default the specs assert.
- [ ] **`DEV_NOISY=false` layout coupling**: both specs and the fixture rely on `DEV_NOISY=false` producing the normal Home/simple layouts (the noisy dev layout has no Home tab). Worth confirming this env dependency is stable for CI.
<!-- review-paratext:summary:end -->

AI-assisted — [session](https://claude.ai/code/session_fc5cb107-289e-456f-8e62-083b023ed995)

---

Implements [PT-4190](https://paratextstudio.atlassian.net/browse/PT-4190) (WI-5): keep Standard as
the Power-mode default view and verify nothing else on the branch changes behavior outside Standard
view. Targets `standard-view` per the Phase A merge-train plan.

### Why review this

Part of the current epic (PT-4186 "Donna edits text using Standard view"): this is WI-5 of the
Phase A merge train — it must land before WI-6 (merge execution) and unblocks the branch's default
flip shipping with confidence.

## Summary

**Default mechanism: no code change needed.** The branch's default mechanism
(`useWebViewState('viewType', isPowerMode ? 'standard' : 'formatted')` + the one-shot ref-guarded
corrective effect from `85586d3d07b`) is intact and verified live in the running app.

**The predicted e2e churn did not materialize.** `markers-checklist-*` is experimental and not
wired into any Playwright project; `scripture-text-grid*` targets the scriptureTextGrid webViewType
(mode-independent by design); CI's smoke suite never opens the editor. Details in the PT-4190
audit comment.

**What WAS wrong: the isolated suite's interface mode was nondeterministic.** Its specs are
authored against the power-mode layout (simple mode always loads the static `simpleLayout`, which
has no Home tab, so `waitForHomeTab` and non-Home tab sweeps cannot pass there), but nothing pinned
the mode — the suite silently inherited the developer's dev-appdata, and under the app's own
no-settings default (`'simple'`) it cannot pass at all.

## Changes

- `isolated.fixture.ts`: new `interfaceMode` option — seeds `platform.interfaceMode` around each
  launch (default `'power'`, restored after teardown).
- New `tests/isolated/scripture-editor/` subset covering the default itself:
  - `standard-default-power-mode.spec.ts` — Power mode: first-open editor settles on Standard view
    (`.editor-input.marker-editable` + rendered marker glyphs).
  - `formatted-default-simple-mode.spec.ts` — Simple mode (explicit override): identical flow keeps
    `formatted` — the NN-1 "nothing changes for Simple users" guard.
- `scripture-editor-helpers.ts`: sample-WEB helpers extracted from scroll-group-sync; new
  `openEditableScriptureEditorForProject` with the `openCommentList`-style loadLayout-race guard;
  project-readiness now waits for the Paratext PDP factory method and the sample project's own
  metadata (the generic any-project wait is satisfied early by the lexical-resource factory —
  observed as `-32601` on cold first launches).
- `scroll-group-sync.spec.ts`: imports the shared helpers; stale mode comments rewritten. Verified
  green under the new Standard power default — `VerseNode` keeps `data-marker`/`data-number` in
  every view and the visible `\v N` text lives inside the verse span, so the `+ span` adjacency and
  click-in-verse-text gesture hold unchanged.

## AI Involvement

AI-assisted (Claude Code, local CLI session): branch-diff audit, e2e analysis, spec/fixture
authoring, and live QA were AI-generated and human-directed; TJ reviewed the results. Commit
carries `Co-Authored-By: Claude Fable 5`.

## Testing

- [x] `npm run test:e2e:isolated scripture-editor` — 2 passed (first attempt, after fixing the two
      cold-start races found while iterating)
- [x] `npm run test:e2e:isolated scroll-groups` — 1 passed under the new power default
- [x] `npm run test:e2e:smoke` — 12 passed, 1 known-flaky About-dialog test passed on retry
- [x] `npm run typecheck` / `npm run lint` — clean
- [x] `npm test` — 408 passed; `dotnet test c-sharp-tests/` — 1472 passed
- [x] Manual QA (isolated project root): Simple default unchanged; Power default Standard; no lost
      keystrokes on rapid typing + immediate blur; explicit `:` separator respected; registered `.`
      default used for a fresh footnote insert

## Risk Level

Low — test-only changes (fixtures + specs); no product code touched.


[PT-4190]: https://paratextstudio.atlassian.net/browse/PT-4190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2552)
<!-- Reviewable:end -->

