### PR TITLE
PT-4200: catalog Ctrl+T / Ctrl+Shift+T scripture-editor shortcuts

### DIFF
--- a/src/stories/keyboard-shortcuts.data.ts
+++ b/src/stories/keyboard-shortcuts.data.ts
@@ -204,6 +204,30 @@ export const rootKeyboardShortcuts: KeyboardShortcutEntry[] = [
     ],
   },
   {
+    id: 'scripture-insert-footnote',
+    purpose: 'Insert a footnote at the selection (Standard view, editable)',
+    category: 'Editing',
+    context: 'Scripture editor web view',
+    // macOS intentionally uses ⌃T (not ⌘T) to match the handler in
+    // platform-scripture-editor.web-view.tsx (`event.ctrlKey`), like the find dialog's ⌃F.
+    keys: { macOS: '⌃T', windows: 'Ctrl+T', linux: 'Ctrl+T' },
+    locations: [
+      'extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx',
+    ],
+  },
+  {
+    id: 'scripture-insert-cross-reference',
+    purpose: 'Insert a cross-reference at the selection (Standard view, editable)',
+    category: 'Editing',
+    context: 'Scripture editor web view',
+    // macOS intentionally uses ⌃⇧T (not ⌘⇧T) to match the handler in
+    // platform-scripture-editor.web-view.tsx (`event.ctrlKey`), like the find dialog's ⌃F.
+    keys: { macOS: '⌃⇧T', windows: 'Ctrl+Shift+T', linux: 'Ctrl+Shift+T' },
+    locations: [
+      'extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx',
+    ],
+  },
+  {
     id: 'scripture-text-grid-open-chapter-context',
     purpose: 'Open the chapter-context view for the focused cell',
     category: 'View',


### PR DESCRIPTION
## Summary

WI-13 pre-merge readiness (PT-4200, child of PT-4186): the `standard-view` branch adds Ctrl+T (insert footnote) and Ctrl+Shift+T (insert cross-reference) handlers in `platform-scripture-editor.web-view.tsx`, but the keyboard-shortcuts catalog — which the repo rule requires to land with any shortcut change — has no entries for them. This PR adds the two missing catalog entries so the catalog is compliant before the Standard-view merge (WI-6).

### Why review this

Part of the current epic ("Donna edits text using Standard view", PT-4186): PT-4200 is the Phase A pre-merge-readiness work item that blocks the WI-6 merge train.

## Changes

- Add `scripture-insert-footnote` (⌃T / Ctrl+T) and `scripture-insert-cross-reference` (⌃⇧T / Ctrl+Shift+T) entries to `src/stories/keyboard-shortcuts.data.ts`, following the existing scripture-editor web-view entry pattern.
- macOS keys are deliberately Control-based (not ⌘) to mirror the handler's `event.ctrlKey` check — same intentional deviation as the find dialog's ⌃F entry, noted in comments.

## Conflict check (recorded per PT-4200)

Checked Ctrl+T / Ctrl+Shift+T against every key claimed by the app-global `before-input-event` handlers in `src/main` (F12, Ctrl±Shift+Tab, F8/F9 ± Ctrl/⌘, Ctrl/⌘+Up/Down, Ctrl/⌘+B, ⌘[/⌘], Alt+←/→, zoom chords, Ctrl+PgUp/PgDn, ⌘⇧[/], ⌘⌥↑/↓) via deterministic grep of `input.key` matches: **no handler claims the T key on any platform — no collision.**

## AI Involvement

AI-assisted — generated with Claude Code (Fable 5); reviewed and verified by the developer. The change is data-only (two catalog entries); verification below was run end-to-end in the session.

## Testing

- [x] `npx eslint` + `prettier --check` clean on the changed file; repo `typecheck:core` clean
- [x] `keyboard-shortcuts-catalog` component tests pass (7/7)
- [x] Cold-start activation smoke on a clean profile (PT-4200 item 3): platform-scripture-editor imports and activates with no errors; Standard view opens as Power default; Ctrl+T inserts `\f + \fr 1:3 \fr*\ft \ft*\f*` at the caret and Ctrl+Shift+T inserts `\x - \xo 1:3 \xo*\xt \xt*\x*`; popover X-cancel removes the new note; SFM on disk verified pristine after QA

## Risk Level

Low — data-only addition to the Storybook shortcuts catalog; no runtime code touched.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2559)
<!-- Reviewable:end -->
