### PR TITLE
PT-4193: Add secondary notification action, position, and dismissible

### DIFF
--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5216,6 +5216,8 @@ declare module 'shared/models/notification.service-model' {
    * The placements a notification can appear in, as a frozen array so it can be the single source of
    * truth for both the {@link NotificationPosition} type and the notification service's OpenRPC
    * `position` enum (which the service host spreads from this).
+   *
+   * @experimental
    */
   export const NOTIFICATION_POSITIONS: readonly [
     'top-left',
@@ -5228,6 +5230,8 @@ declare module 'shared/models/notification.service-model' {
   /**
    * Where a notification is shown on screen. Mirrors the placements the host toast library supports.
    * Omit to use the app's default placement.
+   *
+   * @experimental
    */
   export type NotificationPosition = (typeof NOTIFICATION_POSITIONS)[number];
   /** Data needed to display a notification to the user */
@@ -5260,6 +5264,8 @@ declare module 'shared/models/notification.service-model' {
      * this together with {@link secondaryClickCommand} to give the notification two actions.
      *
      * Automatically localized if this is a {@link LocalizeKey}.
+     *
+     * @experimental
      */
     secondaryClickCommandLabel?: string | LocalizeKey;
     /**
@@ -5269,6 +5275,8 @@ declare module 'shared/models/notification.service-model' {
      * - NotificationId: The ID of the notification that was clicked
      *
      * The command handler should have the type signature {@link NotificationClickCommandHandler}.
+     *
+     * @experimental
      */
     secondaryClickCommand?: keyof CommandHandlers;
     /**
@@ -5290,11 +5298,15 @@ declare module 'shared/models/notification.service-model' {
      * decision — e.g. pairing it with a "postpone" command lets a two-button, must-answer-style toast
      * keep {@link dismissible} `true` (see the warning on {@link dismissible}). If you need the toast
      * to persist until the user actually answers, also set `duration` to `0`.
+     *
+     * @experimental
      */
     dismissClickCommand?: keyof CommandHandlers;
     /**
      * Optional placement of the notification on screen. When omitted, the app's default placement is
      * used.
+     *
+     * @experimental
      */
     position?: NotificationPosition;
     /**
@@ -5310,6 +5322,8 @@ declare module 'shared/models/notification.service-model' {
      * no secondary/dismiss command. For a notification the user must explicitly answer, prefer
      * leaving `dismissible: true` and using {@link dismissClickCommand} so a swipe-away still counts
      * as a real (e.g. "postpone") decision.
+     *
+     * @experimental
      */
     dismissible?: boolean;
     /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5213,16 +5213,23 @@ declare module 'shared/models/notification.service-model' {
   import { LocalizeKey } from 'platform-bible-utils';
   export type Severity = 'info' | 'warning' | 'error';
   /**
+   * The placements a notification can appear in, as a frozen array so it can be the single source of
+   * truth for both the {@link NotificationPosition} type and the notification service's OpenRPC
+   * `position` enum (which the service host spreads from this).
+   */
+  export const NOTIFICATION_POSITIONS: readonly [
+    'top-left',
+    'top-center',
+    'top-right',
+    'bottom-left',
+    'bottom-center',
+    'bottom-right',
+  ];
+  /**
    * Where a notification is shown on screen. Mirrors the placements the host toast library supports.
    * Omit to use the app's default placement.
    */
-  export type NotificationPosition =
-    | 'top-left'
-    | 'top-center'
-    | 'top-right'
-    | 'bottom-left'
-    | 'bottom-center'
-    | 'bottom-right';
+  export type NotificationPosition = (typeof NOTIFICATION_POSITIONS)[number];
   /** Data needed to display a notification to the user */
   export interface PlatformNotification {
     /**
@@ -5273,14 +5280,16 @@ declare module 'shared/models/notification.service-model' {
      *
      * The command handler should have the type signature {@link NotificationClickCommandHandler}.
      *
-     * IMPORTANT: this fires ONLY for that user gesture. It does NOT fire when the notification is
-     * dismissed programmatically via {@link INotificationService.dismiss}, when it auto-closes because
-     * `duration` elapsed, or when the user clicks {@link clickCommand} / {@link secondaryClickCommand}
-     * (verified against the Sonner 1.7.4 source: `onDismiss` is invoked only from the swipe-release
-     * and close-button handlers, never from the programmatic-dismiss or auto-close paths). Use this
-     * to treat a user's swipe-away as an explicit decision — e.g. pairing it with a "postpone"
-     * command lets a two-button, must-answer-style toast still keep {@link dismissible} `true` (see
-     * the warning on {@link dismissible} for why `false` is usually the wrong tool for that).
+     * IMPORTANT: this fires when the user dismisses the notification themselves (swiping/dragging it
+     * away, or clicking a close button if the host ever enables one) AND when the notification
+     * auto-closes because its `duration` elapsed — a timeout is treated as an implicit dismissal, so
+     * a must-answer toast that times out still runs this command instead of vanishing silently. It
+     * does NOT fire when the notification is dismissed programmatically via
+     * {@link INotificationService.dismiss}, nor when the user clicks {@link clickCommand} /
+     * {@link secondaryClickCommand}. Use this to treat a swipe-away (or timeout) as an explicit
+     * decision — e.g. pairing it with a "postpone" command lets a two-button, must-answer-style toast
+     * keep {@link dismissible} `true` (see the warning on {@link dismissible}). If you need the toast
+     * to persist until the user actually answers, also set `duration` to `0`.
      */
     dismissClickCommand?: keyof CommandHandlers;
     /**
@@ -5292,16 +5301,24 @@ declare module 'shared/models/notification.service-model' {
      * Whether the user can dismiss the notification directly (e.g. by swiping/dragging it away, or
      * via a close button). Defaults to `true`.
      *
-     * WARNING: the host toast library (Sonner) renders {@link secondaryClickCommandLabel} in the same
-     * slot it gates on this flag, so setting `dismissible: false` also disables the secondary action
-     * button (and the close button) — the secondary button will still render but silently do nothing
-     * when clicked. Only set this to `false` on a notification with no secondary action. For a
-     * notification the user must explicitly answer, prefer leaving `dismissible: true` and using
-     * {@link dismissClickCommand} so a swipe-away still counts as a real (e.g. "postpone") decision
-     * instead of a dead button.
+     * The host toast library (Sonner) gates both the {@link secondaryClickCommand} button and the
+     * user-dismiss gesture that fires {@link dismissClickCommand} on this same flag, so a naive
+     * `dismissible: false` would silently turn those controls into dead buttons. To prevent that, the
+     * platform IGNORES `dismissible: false` when a {@link secondaryClickCommand} or
+     * {@link dismissClickCommand} is also set — the notification stays user-dismissible so those
+     * controls keep working. `dismissible: false` therefore only takes effect on a notification with
+     * no secondary/dismiss command. For a notification the user must explicitly answer, prefer
+     * leaving `dismissible: true` and using {@link dismissClickCommand} so a swipe-away still counts
+     * as a real (e.g. "postpone") decision.
      */
     dismissible?: boolean;
-    /** Optional ID of a previous notification to update instead of showing a new notification */
+    /**
+     * Optional ID of a previous notification to update instead of showing a new notification.
+     *
+     * On an update (a `send` reusing an id that is still showing), any optional field you omit keeps
+     * the value it had on the previous `send` for that id — omitting a field never clears it. Pass
+     * the field explicitly to change it.
+     */
     notificationId?: string | number;
     /**
      * Optional duration in milliseconds for how long the notification is displayed. To make the

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5265,14 +5265,40 @@ declare module 'shared/models/notification.service-model' {
      */
     secondaryClickCommand?: keyof CommandHandlers;
     /**
+     * Optional command to run if the user dismisses the notification themselves — by swiping/dragging
+     * it away, or by clicking the close button (if the host ever enables one). Sent no arguments other
+     * than the notification id, like {@link clickCommand}:
+     *
+     * - NotificationId: The ID of the notification that was dismissed
+     *
+     * The command handler should have the type signature {@link NotificationClickCommandHandler}.
+     *
+     * IMPORTANT: this fires ONLY for that user gesture. It does NOT fire when the notification is
+     * dismissed programmatically via {@link INotificationService.dismiss}, when it auto-closes because
+     * `duration` elapsed, or when the user clicks {@link clickCommand} / {@link secondaryClickCommand}
+     * (verified against the Sonner 1.7.4 source: `onDismiss` is invoked only from the swipe-release and
+     * close-button handlers, never from the programmatic-dismiss or auto-close paths). Use this to treat
+     * a user's swipe-away as an explicit decision — e.g. pairing it with a "postpone" command lets a
+     * two-button, must-answer-style toast still keep {@link dismissible} `true` (see the warning on
+     * {@link dismissible} for why `false` is usually the wrong tool for that).
+     */
+    dismissClickCommand?: keyof CommandHandlers;
+    /**
      * Optional placement of the notification on screen. When omitted, the app's default placement is
      * used.
      */
     position?: NotificationPosition;
     /**
-     * Whether the user can dismiss the notification directly (e.g. by swiping/dragging it away).
-     * Defaults to `true`. Set to `false` for a notification that must be acknowledged through one of
-     * its action buttons — combine with a `duration` of `0` or less to keep it up until then.
+     * Whether the user can dismiss the notification directly (e.g. by swiping/dragging it away, or via
+     * a close button). Defaults to `true`.
+     *
+     * WARNING: the host toast library (Sonner) renders {@link secondaryClickCommandLabel} in the same
+     * slot it gates on this flag, so setting `dismissible: false` also disables the secondary action
+     * button (and the close button) — the secondary button will still render but silently do nothing
+     * when clicked. Only set this to `false` on a notification with no secondary action. For a
+     * notification the user must explicitly answer, prefer leaving `dismissible: true` and using
+     * {@link dismissClickCommand} so a swipe-away still counts as a real (e.g. "postpone") decision
+     * instead of a dead button.
      */
     dismissible?: boolean;
     /** Optional ID of a previous notification to update instead of showing a new notification */

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5212,6 +5212,17 @@ declare module 'shared/models/notification.service-model' {
   import { CommandHandlers } from 'papi-shared-types';
   import { LocalizeKey } from 'platform-bible-utils';
   export type Severity = 'info' | 'warning' | 'error';
+  /**
+   * Where a notification is shown on screen. Mirrors the placements the host toast library supports.
+   * Omit to use the app's default placement.
+   */
+  export type NotificationPosition =
+    | 'top-left'
+    | 'top-center'
+    | 'top-right'
+    | 'bottom-left'
+    | 'bottom-center'
+    | 'bottom-right';
   /** Data needed to display a notification to the user */
   export interface PlatformNotification {
     /**
@@ -5237,6 +5248,33 @@ declare module 'shared/models/notification.service-model' {
      * The command handler should have the type signature {@link NotificationClickCommandHandler}.
      */
     clickCommand?: keyof CommandHandlers;
+    /**
+     * Optional label for a second action button, shown alongside {@link clickCommandLabel}. Provide
+     * this together with {@link secondaryClickCommand} to give the notification two actions.
+     *
+     * Automatically localized if this is a {@link LocalizeKey}.
+     */
+    secondaryClickCommandLabel?: string | LocalizeKey;
+    /**
+     * Optional command to run if users click on the secondary label in the notification. Like
+     * {@link clickCommand}, the command is sent one argument:
+     *
+     * - NotificationId: The ID of the notification that was clicked
+     *
+     * The command handler should have the type signature {@link NotificationClickCommandHandler}.
+     */
+    secondaryClickCommand?: keyof CommandHandlers;
+    /**
+     * Optional placement of the notification on screen. When omitted, the app's default placement is
+     * used.
+     */
+    position?: NotificationPosition;
+    /**
+     * Whether the user can dismiss the notification directly (e.g. by swiping/dragging it away).
+     * Defaults to `true`. Set to `false` for a notification that must be acknowledged through one of
+     * its action buttons — combine with a `duration` of `0` or less to keep it up until then.
+     */
+    dismissible?: boolean;
     /** Optional ID of a previous notification to update instead of showing a new notification */
     notificationId?: string | number;
     /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5280,7 +5280,7 @@ declare module 'shared/models/notification.service-model' {
      */
     secondaryClickCommand?: keyof CommandHandlers;
     /**
-     * Optional command to run if the user dismisses the notification themselves — by swiping/dragging
+     * Optional command to run if the user dismisses the notification themselves - by swiping/dragging
      * it away, or by clicking the close button (if the host ever enables one). Sent no arguments
      * other than the notification id, like {@link clickCommand}:
      *
@@ -5290,12 +5290,12 @@ declare module 'shared/models/notification.service-model' {
      *
      * IMPORTANT: this fires when the user dismisses the notification themselves (swiping/dragging it
      * away, or clicking a close button if the host ever enables one) AND when the notification
-     * auto-closes because its `duration` elapsed — a timeout is treated as an implicit dismissal, so
+     * auto-closes because its `duration` elapsed - a timeout is treated as an implicit dismissal, so
      * a must-answer toast that times out still runs this command instead of vanishing silently. It
      * does NOT fire when the notification is dismissed programmatically via
      * {@link INotificationService.dismiss}, nor when the user clicks {@link clickCommand} /
      * {@link secondaryClickCommand}. Use this to treat a swipe-away (or timeout) as an explicit
-     * decision — e.g. pairing it with a "postpone" command lets a two-button, must-answer-style toast
+     * decision - e.g. pairing it with a "postpone" command lets a two-button, must-answer-style toast
      * keep {@link dismissible} `true` (see the warning on {@link dismissible}). If you need the toast
      * to persist until the user actually answers, also set `duration` to `0`.
      *
@@ -5316,12 +5316,19 @@ declare module 'shared/models/notification.service-model' {
      * The host toast library (Sonner) gates both the {@link secondaryClickCommand} button and the
      * user-dismiss gesture that fires {@link dismissClickCommand} on this same flag, so a naive
      * `dismissible: false` would silently turn those controls into dead buttons. To prevent that, the
-     * platform IGNORES `dismissible: false` when a {@link secondaryClickCommand} or
-     * {@link dismissClickCommand} is also set — the notification stays user-dismissible so those
-     * controls keep working. `dismissible: false` therefore only takes effect on a notification with
-     * no secondary/dismiss command. For a notification the user must explicitly answer, prefer
+     * platform IGNORES `dismissible: false` when the notification renders a secondary action button
+     * (a {@link secondaryClickCommand} paired with its {@link secondaryClickCommandLabel}) or has a
+     * {@link dismissClickCommand} - the notification stays user-dismissible so those controls keep
+     * working. `dismissible: false` therefore only takes effect on a notification with no secondary
+     * button and no dismiss command. For a notification the user must explicitly answer, prefer
      * leaving `dismissible: true` and using {@link dismissClickCommand} so a swipe-away still counts
      * as a real (e.g. "postpone") decision.
+     *
+     * NOTE: `dismissible: false` does not keep the notification on screen. Auto-close is governed
+     * solely by `duration` (when omitted, 10-35 seconds computed from message length), so a
+     * non-dismissible notification still auto-closes on that timer. Also set `duration` to `0` (or
+     * less) if the notification must stay up until it is answered or programmatically dismissed via
+     * {@link INotificationService.dismiss}.
      *
      * @experimental
      */
@@ -5330,7 +5337,7 @@ declare module 'shared/models/notification.service-model' {
      * Optional ID of a previous notification to update instead of showing a new notification.
      *
      * On an update (a `send` reusing an id that is still showing), any optional field you omit keeps
-     * the value it had on the previous `send` for that id — omitting a field never clears it. Pass
+     * the value it had on the previous `send` for that id - omitting a field never clears it. Pass
      * the field explicitly to change it.
      */
     notificationId?: string | number;

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5266,8 +5266,8 @@ declare module 'shared/models/notification.service-model' {
     secondaryClickCommand?: keyof CommandHandlers;
     /**
      * Optional command to run if the user dismisses the notification themselves — by swiping/dragging
-     * it away, or by clicking the close button (if the host ever enables one). Sent no arguments other
-     * than the notification id, like {@link clickCommand}:
+     * it away, or by clicking the close button (if the host ever enables one). Sent no arguments
+     * other than the notification id, like {@link clickCommand}:
      *
      * - NotificationId: The ID of the notification that was dismissed
      *
@@ -5276,11 +5276,11 @@ declare module 'shared/models/notification.service-model' {
      * IMPORTANT: this fires ONLY for that user gesture. It does NOT fire when the notification is
      * dismissed programmatically via {@link INotificationService.dismiss}, when it auto-closes because
      * `duration` elapsed, or when the user clicks {@link clickCommand} / {@link secondaryClickCommand}
-     * (verified against the Sonner 1.7.4 source: `onDismiss` is invoked only from the swipe-release and
-     * close-button handlers, never from the programmatic-dismiss or auto-close paths). Use this to treat
-     * a user's swipe-away as an explicit decision — e.g. pairing it with a "postpone" command lets a
-     * two-button, must-answer-style toast still keep {@link dismissible} `true` (see the warning on
-     * {@link dismissible} for why `false` is usually the wrong tool for that).
+     * (verified against the Sonner 1.7.4 source: `onDismiss` is invoked only from the swipe-release
+     * and close-button handlers, never from the programmatic-dismiss or auto-close paths). Use this
+     * to treat a user's swipe-away as an explicit decision — e.g. pairing it with a "postpone"
+     * command lets a two-button, must-answer-style toast still keep {@link dismissible} `true` (see
+     * the warning on {@link dismissible} for why `false` is usually the wrong tool for that).
      */
     dismissClickCommand?: keyof CommandHandlers;
     /**
@@ -5289,8 +5289,8 @@ declare module 'shared/models/notification.service-model' {
      */
     position?: NotificationPosition;
     /**
-     * Whether the user can dismiss the notification directly (e.g. by swiping/dragging it away, or via
-     * a close button). Defaults to `true`.
+     * Whether the user can dismiss the notification directly (e.g. by swiping/dragging it away, or
+     * via a close button). Defaults to `true`.
      *
      * WARNING: the host toast library (Sonner) renders {@link secondaryClickCommandLabel} in the same
      * slot it gates on this flag, so setting `dismissible: false` also disables the secondary action

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -5245,7 +5245,9 @@ declare module 'shared/models/notification.service-model' {
     /** Severity of the notification */
     severity: Severity;
     /**
-     * Optional label for users to click when the notification shows.
+     * Optional label for users to click when the notification shows. Always rendered as the
+     * notification's PRIMARY action button - the visually emphasized one - while
+     * {@link secondaryClickCommandLabel} always gets the muted secondary styling.
      *
      * Automatically localized if this is a {@link LocalizeKey}.
      */
@@ -5262,6 +5264,10 @@ declare module 'shared/models/notification.service-model' {
     /**
      * Optional label for a second action button, shown alongside {@link clickCommandLabel}. Provide
      * this together with {@link secondaryClickCommand} to give the notification two actions.
+     *
+     * Always rendered as the visually SECONDARY button (muted styling, like the shadcn `secondary`
+     * button variant) so the {@link clickCommandLabel} button keeps the emphasis - the platform
+     * decides each button's styling from which field it came from, never from ordering.
      *
      * Automatically localized if this is a {@link LocalizeKey}.
      *

--- a/lib/platform-bible-react/package.json
+++ b/lib/platform-bible-react/package.json
@@ -100,7 +100,7 @@
     "radix-ui": "^1.4.3",
     "react-hotkeys-hook": "^4.6.1",
     "react-resizable-panels": "^4.10.0",
-    "sonner": "^1.7.4",
+    "sonner": "1.7.4",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0",
     "vaul": "^1.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1204,7 +1204,7 @@
         "radix-ui": "^1.4.3",
         "react-hotkeys-hook": "^4.6.1",
         "react-resizable-panels": "^4.10.0",
-        "sonner": "^1.7.4",
+        "sonner": "1.7.4",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
         "vaul": "^1.1.2"

--- a/src/renderer/components/notification-display.scss
+++ b/src/renderer/components/notification-display.scss
@@ -1,11 +1,12 @@
-// PT-4193: a toast with BOTH a primary action ("action") and a secondary/cancel action ("cancel")
-// renders, by Sonner 1.7.4's own stylesheet (node_modules/sonner/dist/styles.css), as a single
-// un-wrapped flex row: icon, content, cancel button, action button. Sonner's buttons are
-// `flex-shrink: 0` and its toast width is a fixed `--width` (356px), so two wide buttons crush the
-// message content down to a sliver - confirmed live via a screenshot of a real Send/Receive consent
-// toast. We give exactly that two-button shape a two-row layout instead: [icon][message] on the
-// first row, and the [cancel][action] pair right-aligned on a row of their own. Scope the fix to
-// that shape via `:has()` so plain-message and single-button toasts stay pixel-identical to before.
+// PT-4193: a toast with buttons renders, by Sonner 1.7.4's own stylesheet
+// (node_modules/sonner/dist/styles.css), as a single un-wrapped flex row: icon, content, cancel
+// button, action button. Sonner's buttons are `flex-shrink: 0` and its toast width is a fixed
+// `--width` (356px), so wide buttons crush the message content down to a sliver - confirmed live
+// twice: a two-button Send/Receive consent toast squeezed its message to ~1 character, and (round-4
+// E2E) a single-action break-lock toast ("Break lock and retry" beside a long warning) was just as
+// cramped. So give EVERY toast with at least one button a two-row layout instead: [icon][message]
+// on the first row, and the button(s) right-aligned on a row of their own. Scope the fix to
+// buttoned toasts via `:has()` so plain-message toasts stay pixel-identical to before.
 //
 // Sonner exposes no supported API for a two-row toast body (the only real escape hatch,
 // `toast.custom`, means re-implementing Sonner's severity icon/colour rendering), so this reaches
@@ -14,7 +15,7 @@
 // Deliberately avoids Sonner's own `::after` (its hover-bridge between stacked toasts) and only
 // touches `::before` while the toast is at rest (Sonner styles `::before` transiently mid-swipe/
 // removal). See PT-4193 review C61-3/4/15/23/26 for the failure modes this replaces.
-.notification-toast:has(.notification-toast-cancel-button):has(.notification-toast-action-button) {
+.notification-toast:has(.notification-toast-cancel-button, .notification-toast-action-button) {
   flex-wrap: wrap;
 
   .notification-toast-content {
@@ -37,10 +38,11 @@
     block-size: 0;
   }
 
-  // Collect the two buttons as a right-aligned pair on the button row. Sonner puts
-  // `margin-inline-start: auto` on *every* button, which on a shared row splits the free space
-  // *between* them instead of pushing them together; keep the auto margin only on the leading
-  // (cancel) button so the pair sits flush at the row's end, separated by the toast's own gap.
+  // Collect the button(s) right-aligned on the button row. Sonner puts `margin-inline-start: auto`
+  // on *every* button, which right-aligns a lone button all by itself but, when both buttons share
+  // a row, splits the free space *between* them instead of pushing them together; so leave the auto
+  // margin alone except on an action button whose toast also has a cancel button - zeroing only
+  // that one leaves the pair flush at the row's end, separated by the toast's own gap.
   .notification-toast-cancel-button {
     order: 2;
     margin-inline-start: auto;
@@ -48,6 +50,9 @@
 
   .notification-toast-action-button {
     order: 3;
+  }
+
+  &:has(.notification-toast-cancel-button) .notification-toast-action-button {
     margin-inline-start: 0;
   }
 }

--- a/src/renderer/components/notification-display.scss
+++ b/src/renderer/components/notification-display.scss
@@ -68,4 +68,24 @@
   &:has(.notification-toast-cancel-button) .notification-toast-action-button {
     margin-inline-start: 0;
   }
+
+  // Settle the DEFAULT look of the secondary (cancel-slot) button as the shadcn `secondary` button
+  // variant (button.tsx: bg-secondary / text-secondary-foreground / hover:bg-secondary/80), per UX
+  // direction on PR #2561. Without this, Sonner 1.7.4's styled mode renders BOTH buttons
+  // identically dark: its base `[data-sonner-toast][data-styled='true'] [data-button]` rule
+  // (specificity (0,3,0)) sets the action colors on every `[data-button]` - including the cancel
+  // button, which also carries `data-button` - and its softer `:where([data-cancel])` defaults are
+  // zero-specificity so they never win. Which button gets this look is deterministic: the service
+  // host maps `clickCommand` to Sonner's `action` slot (keeps the emphasized primary look) and
+  // `secondaryClickCommand` to the `cancel` slot, whose class this targets. The extra `&:has()`
+  // keeps specificity at (0,4,0) so this beats Sonner's (0,3,0) base rule regardless of which
+  // stylesheet loads last (same pattern as the margin rule above).
+  &:has(.notification-toast-cancel-button) .notification-toast-cancel-button {
+    background: var(--secondary);
+    color: var(--secondary-foreground);
+
+    &:hover {
+      background: color-mix(in oklab, var(--secondary) 80%, transparent);
+    }
+  }
 }

--- a/src/renderer/components/notification-display.scss
+++ b/src/renderer/components/notification-display.scss
@@ -1,42 +1,53 @@
 // PT-4193: a toast with BOTH a primary action ("action") and a secondary/cancel action ("cancel")
-// renders, by Sonner's own stylesheet (node_modules/sonner/dist/styles.css), as a single un-wrapped
-// flex row: icon, content, cancel button, action button. Sonner's buttons are `flex-shrink: 0`, so
-// two wide buttons crush the message content down to a sliver - confirmed live via a screenshot of a
-// real Send/Receive consent toast. Scope the fix to exactly that two-button shape via `:has()` so
-// plain-message and single-button toasts stay pixel-identical to before.
+// renders, by Sonner 1.7.4's own stylesheet (node_modules/sonner/dist/styles.css), as a single
+// un-wrapped flex row: icon, content, cancel button, action button. Sonner's buttons are
+// `flex-shrink: 0` and its toast width is a fixed `--width` (356px), so two wide buttons crush the
+// message content down to a sliver - confirmed live via a screenshot of a real Send/Receive consent
+// toast. We give exactly that two-button shape a two-row layout instead: [icon][message] on the
+// first row, and the [cancel][action] pair right-aligned on a row of their own. Scope the fix to
+// that shape via `:has()` so plain-message and single-button toasts stay pixel-identical to before.
+//
+// Sonner exposes no supported API for a two-row toast body (the only real escape hatch,
+// `toast.custom`, means re-implementing Sonner's severity icon/colour rendering), so this reaches
+// into its flex layout. It therefore DEPENDS on Sonner 1.7.4 rendering the icon, content, cancel,
+// and action as direct flex children of the toast `<li>`; revisit if Sonner changes its toast DOM.
+// Deliberately avoids Sonner's own `::after` (its hover-bridge between stacked toasts) and only
+// touches `::before` while the toast is at rest (Sonner styles `::before` transiently mid-swipe/
+// removal). See PT-4193 review C61-3/4/15/23/26 for the failure modes this replaces.
 .notification-toast:has(.notification-toast-cancel-button):has(.notification-toast-action-button) {
   flex-wrap: wrap;
 
   .notification-toast-content {
-    // Let the message take the rest of the row next to the icon, instead of shrink-wrapping to the
-    // text width - matching the "full toast width" content row of a plain or single-button toast.
-    flex-grow: 1;
+    // Grow to fill the first row beside the icon. `flex-basis: 0` keeps the message's hypothetical
+    // width at 0 so the flex-wrap algorithm never bumps the message onto a line below the icon
+    // (which would leave the icon orphaned on a row of its own); the message wraps *within* this
+    // grown box instead.
+    flex: 1 1 0;
     min-inline-size: 0;
   }
 
-  // Force a line break between the content row and the button row without an extra wrapper element:
-  // an empty, zero-size flex item whose `flex-basis: 100%` can't fit on the content's line, so the
-  // wrap algorithm starts a new line with it - and the buttons (next in flex order below) start
-  // fresh on the line after that. Sonner's own `[data-button]` auto-margin then right-aligns
-  // whichever buttons end up sharing that new line, and lets a second button wrap to a third,
-  // stacked row if the two together still don't fit - both behaviors come for free, no extra rules
-  // needed here.
-  &::after {
+  // Full-width, zero-height flex break that forces the buttons onto their own row. `::before` is
+  // untouched by Sonner except transiently while swiping/removing a toast, so - unlike the previous
+  // `::after` hack - this does not clobber Sonner's `::after` hover-bridge. Restrict it to the
+  // resting toast so it can't fight Sonner's own swipe/removal `::before`.
+  &:not([data-swiping='true']):not([data-removed='true'])::before {
     content: '';
     order: 1;
     flex-basis: 100%;
     block-size: 0;
   }
-}
 
-// Ordered above the default (0) so both buttons sort after the content/break-point above, in
-// whichever single- or multi-line layout is in effect. Harmless when only one of the two exists (or
-// neither does): it keeps the same after-content position a plain-message or single-button toast
-// already had.
-.notification-toast-cancel-button {
-  order: 2;
-}
+  // Collect the two buttons as a right-aligned pair on the button row. Sonner puts
+  // `margin-inline-start: auto` on *every* button, which on a shared row splits the free space
+  // *between* them instead of pushing them together; keep the auto margin only on the leading
+  // (cancel) button so the pair sits flush at the row's end, separated by the toast's own gap.
+  .notification-toast-cancel-button {
+    order: 2;
+    margin-inline-start: auto;
+  }
 
-.notification-toast-action-button {
-  order: 3;
+  .notification-toast-action-button {
+    order: 3;
+    margin-inline-start: 0;
+  }
 }

--- a/src/renderer/components/notification-display.scss
+++ b/src/renderer/components/notification-display.scss
@@ -1,0 +1,42 @@
+// PT-4193: a toast with BOTH a primary action ("action") and a secondary/cancel action ("cancel")
+// renders, by Sonner's own stylesheet (node_modules/sonner/dist/styles.css), as a single un-wrapped
+// flex row: icon, content, cancel button, action button. Sonner's buttons are `flex-shrink: 0`, so
+// two wide buttons crush the message content down to a sliver - confirmed live via a screenshot of a
+// real Send/Receive consent toast. Scope the fix to exactly that two-button shape via `:has()` so
+// plain-message and single-button toasts stay pixel-identical to before.
+.notification-toast:has(.notification-toast-cancel-button):has(.notification-toast-action-button) {
+  flex-wrap: wrap;
+
+  .notification-toast-content {
+    // Let the message take the rest of the row next to the icon, instead of shrink-wrapping to the
+    // text width - matching the "full toast width" content row of a plain or single-button toast.
+    flex-grow: 1;
+    min-inline-size: 0;
+  }
+
+  // Force a line break between the content row and the button row without an extra wrapper element:
+  // an empty, zero-size flex item whose `flex-basis: 100%` can't fit on the content's line, so the
+  // wrap algorithm starts a new line with it - and the buttons (next in flex order below) start
+  // fresh on the line after that. Sonner's own `[data-button]` auto-margin then right-aligns
+  // whichever buttons end up sharing that new line, and lets a second button wrap to a third,
+  // stacked row if the two together still don't fit - both behaviors come for free, no extra rules
+  // needed here.
+  &::after {
+    content: '';
+    order: 1;
+    flex-basis: 100%;
+    block-size: 0;
+  }
+}
+
+// Ordered above the default (0) so both buttons sort after the content/break-point above, in
+// whichever single- or multi-line layout is in effect. Harmless when only one of the two exists (or
+// neither does): it keeps the same after-content position a plain-message or single-button toast
+// already had.
+.notification-toast-cancel-button {
+  order: 2;
+}
+
+.notification-toast-action-button {
+  order: 3;
+}

--- a/src/renderer/components/notification-display.scss
+++ b/src/renderer/components/notification-display.scss
@@ -1,4 +1,4 @@
-// PT-4193: a toast with buttons renders, by Sonner 1.7.4's own stylesheet
+// A toast with buttons renders, by Sonner 1.7.4's own stylesheet
 // (node_modules/sonner/dist/styles.css), as a single un-wrapped flex row: icon, content, cancel
 // button, action button. Sonner's buttons are `flex-shrink: 0` and its toast width is a fixed
 // `--width` (356px), so wide buttons crush the message content down to a sliver - confirmed live
@@ -14,8 +14,7 @@
 // and action as direct flex children of the toast `<li>`; revisit if Sonner changes its toast DOM.
 // Deliberately avoids Sonner's own `::after` (its ALWAYS-ON hover-bridge between stacked toasts)
 // and repurposes `::before`, which Sonner only styles in the swiping/removed states - see the
-// comment on the row break below for how that collision is resolved. See PT-4193 review
-// C61-3/4/15/23/26 for the failure modes this replaces.
+// comment on the row break below for how that collision is resolved.
 .notification-toast:has(.notification-toast-cancel-button, .notification-toast-action-button) {
   flex-wrap: wrap;
 
@@ -71,7 +70,7 @@
 
   // Settle the DEFAULT look of the secondary (cancel-slot) button as the shadcn `secondary` button
   // variant (button.tsx: bg-secondary / text-secondary-foreground / hover:bg-secondary/80), per UX
-  // direction on PR #2561. Without this, Sonner 1.7.4's styled mode renders BOTH buttons
+  // direction. Without this, Sonner 1.7.4's styled mode renders BOTH buttons
   // identically dark: its base `[data-sonner-toast][data-styled='true'] [data-button]` rule
   // (specificity (0,3,0)) sets the action colors on every `[data-button]` - including the cancel
   // button, which also carries `data-button` - and its softer `:where([data-cancel])` defaults are

--- a/src/renderer/components/notification-display.scss
+++ b/src/renderer/components/notification-display.scss
@@ -9,12 +9,13 @@
 // buttoned toasts via `:has()` so plain-message toasts stay pixel-identical to before.
 //
 // Sonner exposes no supported API for a two-row toast body (the only real escape hatch,
-// `toast.custom`, means re-implementing Sonner's severity icon/colour rendering), so this reaches
+// `toast.custom`, means re-implementing Sonner's severity icon/color rendering), so this reaches
 // into its flex layout. It therefore DEPENDS on Sonner 1.7.4 rendering the icon, content, cancel,
 // and action as direct flex children of the toast `<li>`; revisit if Sonner changes its toast DOM.
-// Deliberately avoids Sonner's own `::after` (its hover-bridge between stacked toasts) and only
-// touches `::before` while the toast is at rest (Sonner styles `::before` transiently mid-swipe/
-// removal). See PT-4193 review C61-3/4/15/23/26 for the failure modes this replaces.
+// Deliberately avoids Sonner's own `::after` (its ALWAYS-ON hover-bridge between stacked toasts)
+// and repurposes `::before`, which Sonner only styles in the swiping/removed states - see the
+// comment on the row break below for how that collision is resolved. See PT-4193 review
+// C61-3/4/15/23/26 for the failure modes this replaces.
 .notification-toast:has(.notification-toast-cancel-button, .notification-toast-action-button) {
   flex-wrap: wrap;
 
@@ -27,12 +28,24 @@
     min-inline-size: 0;
   }
 
-  // Full-width, zero-height flex break that forces the buttons onto their own row. `::before` is
-  // untouched by Sonner except transiently while swiping/removing a toast, so - unlike the previous
-  // `::after` hack - this does not clobber Sonner's `::after` hover-bridge. Restrict it to the
-  // resting toast so it can't fight Sonner's own swipe/removal `::before`.
-  &:not([data-swiping='true']):not([data-removed='true'])::before {
+  // Full-width, zero-height flex break that forces the buttons onto their own row. Unlike the
+  // previous `::after` hack this leaves Sonner's `::after` hover-bridge alone, and it must apply in
+  // EVERY toast state: Sonner flips the toast to `data-swiping="true"` the instant any mouse button
+  // is pressed on the toast body (before any movement - a plain press-and-hold counts), and an
+  // earlier revision that gated this break out of the swiping/removed states collapsed the toast to
+  // a one-character-wide sliver for the duration of every such press, because the `flex-wrap` and
+  // `flex-basis: 0` rules above stayed active with no row break. Sonner's own use of `::before` in
+  // those states is an invisible, ABSOLUTELY-positioned hover/hit-area extender declared at zero
+  // specificity (`:where(...)`), so this higher-specificity rule wins on every property it declares;
+  // `position: static` is declared explicitly to keep the pseudo-element in flex flow when Sonner's
+  // swipe/removal styles try to absolutely position it (its leftover declarations - inset, height,
+  // transform, z-index - are inert on a zero-height in-flow item, `height` losing to `block-size`
+  // by specificity). Trade-off: buttoned toasts lose Sonner's enlarged swipe/removal hover hit
+  // area; swipe-to-dismiss tracking is unaffected because Sonner captures the pointer at press
+  // time.
+  &::before {
     content: '';
+    position: static;
     order: 1;
     flex-basis: 100%;
     block-size: 0;

--- a/src/renderer/components/notification-display.test.tsx
+++ b/src/renderer/components/notification-display.test.tsx
@@ -87,13 +87,14 @@ describe('NotificationDisplay with real Sonner', () => {
     expect(mockSendCommand).toHaveBeenCalledWith('test.secondary', notificationId);
   });
 
-  // PT-4193 layout fix: a live E2E screenshot showed a toast with BOTH an action and a cancel
-  // button collapsing its message down to a ~1-character-wide sliver - Sonner's default layout
-  // puts icon/content/cancel/action in a single un-wrapped flex row, and two non-shrinking buttons
-  // crush the content column. notification-display.scss fixes this with a `:has()`-scoped stylesheet
-  // rule keyed off the classNames wired up in notification-display.tsx. jsdom doesn't compute actual
-  // flex-wrap layout, so these tests pin the DOM shape (classes + shared flex-container ancestry)
-  // that stylesheet rule depends on, rather than pixel positions.
+  // PT-4193 layout fix: live E2E screenshots showed toasts with buttons collapsing their message
+  // down to a sliver - first a toast with BOTH an action and a cancel button, then (round-4 E2E)
+  // a single-action break-lock toast. Sonner's default layout puts icon/content/cancel/action in a
+  // single un-wrapped flex row, and non-shrinking buttons crush the content column.
+  // notification-display.scss fixes this with a `:has()`-scoped stylesheet rule - engaging for ANY
+  // toast with at least one button - keyed off the classNames wired up in notification-display.tsx.
+  // jsdom doesn't compute actual flex-wrap layout, so these tests pin the DOM shape (classes +
+  // shared flex-container ancestry) that stylesheet rule depends on, rather than pixel positions.
   it('gives a two-button toast the content/action/cancel class hooks the layout fix keys off, and keeps both buttons working', async () => {
     render(<NotificationDisplay />);
 
@@ -119,7 +120,7 @@ describe('NotificationDisplay with real Sonner', () => {
     const toastRoot = document.querySelector('.notification-toast');
 
     // The fix's CSS rule is
-    // `.notification-toast:has(.notification-toast-cancel-button):has(.notification-toast-action-button)`
+    // `.notification-toast:has(.notification-toast-cancel-button, .notification-toast-action-button)`
     // - assert that shape exists: one shared flex-container ancestor directly containing the
     // content, the action button, and the cancel button as siblings (not nested inside each other),
     // which is what lets `flex-grow` on the content and `order` on the buttons rearrange them into
@@ -139,6 +140,45 @@ describe('NotificationDisplay with real Sonner', () => {
     expect(mockSendCommand).toHaveBeenCalledWith('test.secondary', notificationId);
   });
 
+  // Round-4 E2E finding: the break-lock toast (one long warning + one wide "Break lock and retry"
+  // action button, no cancel button) rendered text and button crammed side-by-side because the
+  // original rule only engaged when BOTH buttons were present. The rule now engages for any
+  // buttoned toast, so a single-action toast must present the same shape it keys off.
+  it('gives a single-button (action-only) toast the content/action class hooks the layout fix keys off, and keeps the button working', async () => {
+    render(<NotificationDisplay />);
+
+    const notification: PlatformNotification = {
+      message:
+        'The project is locked on the server by another user. Breaking the lock may discard their unfinished send.',
+      severity: 'warning',
+      clickCommandLabel: 'Break lock and retry',
+      // The test only needs a command NAME to send/assert on; it never resolves to a real handler.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      clickCommand: 'test.primary' as never,
+    };
+
+    const notificationId = await capturedService.send(notification);
+
+    const actionButton = await screen.findByRole('button', { name: 'Break lock and retry' });
+    const title = await screen.findByText(/locked on the server/);
+    const content = title.closest('.notification-toast-content');
+    const toastRoot = document.querySelector('.notification-toast');
+
+    // Same structural pin as the two-button case: the `:has()` rule matches on either button class,
+    // and content + action button must be direct siblings under the toast flex container for the
+    // `flex-grow`/`order` reflow to put them on separate rows.
+    expect(toastRoot).not.toBeNull();
+    expect(content).not.toBeNull();
+    expect(actionButton).toHaveClass('notification-toast-action-button');
+    expect(content?.parentElement).toBe(toastRoot);
+    expect(actionButton.parentElement).toBe(toastRoot);
+    expect(document.querySelector('.notification-toast-cancel-button')).not.toBeInTheDocument();
+
+    fireEvent.click(actionButton);
+
+    expect(mockSendCommand).toHaveBeenCalledWith('test.primary', notificationId);
+  });
+
   it('does not add the action-button hook to a single-button (cancel-only) toast', async () => {
     render(<NotificationDisplay />);
 
@@ -154,9 +194,9 @@ describe('NotificationDisplay with real Sonner', () => {
     await capturedService.send(notification);
 
     const cancelButton = await screen.findByRole('button', { name: 'Postpone' });
-    // The layout fix only engages when BOTH button classes are present under the same toast (see
-    // the `:has()...:has()` rule in notification-display.scss). A single-button toast must not
-    // accidentally satisfy that condition, so the content keeps its plain, un-grown structure.
+    // A cancel-only toast now gets the two-row layout too (the `:has()` rule matches either button
+    // class), but it must do so with ONLY the cancel hook present - a spurious action button here
+    // would both render a button nobody asked for and trip the pair-only margin override.
     expect(cancelButton).toHaveClass('notification-toast-cancel-button');
     expect(document.querySelector('.notification-toast-action-button')).not.toBeInTheDocument();
   });

--- a/src/renderer/components/notification-display.test.tsx
+++ b/src/renderer/components/notification-display.test.tsx
@@ -22,7 +22,7 @@ vi.mock('@shared/services/localization.service', () => ({
   },
 }));
 vi.mock('@shared/services/logger.service', () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
 let capturedService: INotificationService;

--- a/src/renderer/components/notification-display.test.tsx
+++ b/src/renderer/components/notification-display.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type {
+  INotificationService,
+  PlatformNotification,
+} from '@shared/models/notification.service-model';
+import * as commandService from '@shared/services/command.service';
+import { NotificationDisplay } from './notification-display';
+
+// This is the ONE render-level test in the notification suite that uses REAL Sonner instead of
+// mocking it (every other notification.service-host.test.ts case mocks 'sonner' wholesale, which is
+// exactly why the cancel-slot-button-is-dead-when-dismissible-is-false blocker slipped through
+// review undetected - see PT-4193's "Review fix" PR notes). Rendering the real Toaster and clicking
+// the real DOM button pins the actual Sonner contract instead of just the shape we hand it.
+vi.mock('@shared/services/command.service', () => ({ sendCommand: vi.fn() }));
+vi.mock('@shared/services/localization.service', () => ({
+  localizationService: {
+    getLocalizedString: vi.fn(({ localizeKey }: { localizeKey: string }) =>
+      Promise.resolve(localizeKey),
+    ),
+  },
+}));
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+let capturedService: INotificationService;
+vi.mock('@shared/services/network-object.service', () => ({
+  networkObjectService: {
+    set: vi.fn((_name: string, service: INotificationService) => {
+      capturedService = service;
+      return Promise.resolve();
+    }),
+  },
+}));
+
+const mockSendCommand = vi.mocked(commandService.sendCommand);
+
+// jsdom does not implement `window.matchMedia`; Sonner's Toaster calls it directly (unrelated to
+// this app's own theme service) to pick its light/dark default. Precedent:
+// share-layout.dialog.test.tsx hits the same gap for a different matchMedia caller.
+function stubMatchMedia() {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: undefined,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+describe('NotificationDisplay with real Sonner', () => {
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockSendCommand.mockResolvedValue(undefined);
+    stubMatchMedia();
+    const { startNotificationService } = await import(
+      '@renderer/services/notification.service-host'
+    );
+    await startNotificationService();
+  });
+
+  it('sends the secondary command when the user clicks the rendered cancel-slot button', async () => {
+    render(<NotificationDisplay />);
+
+    const notification: PlatformNotification = {
+      message: 'A decision is needed',
+      severity: 'info',
+      secondaryClickCommandLabel: 'Postpone',
+      // The test only needs a command NAME to send/assert on; it never resolves to a real handler.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      secondaryClickCommand: 'test.secondary' as never,
+      // Left true (the default) deliberately: this is the exact "two working buttons" shape the
+      // blocker was about - dismissible: false would render this same button inert.
+    };
+
+    const notificationId = await capturedService.send(notification);
+
+    const cancelButton = await screen.findByRole('button', { name: 'Postpone' });
+    fireEvent.click(cancelButton);
+
+    expect(mockSendCommand).toHaveBeenCalledWith('test.secondary', notificationId);
+  });
+});

--- a/src/renderer/components/notification-display.test.tsx
+++ b/src/renderer/components/notification-display.test.tsx
@@ -25,7 +25,7 @@ function commandStub(name: string): keyof CommandHandlers {
 // This is the ONE render-level test in the notification suite that uses REAL Sonner instead of
 // mocking it (every other notification.service-host.test.ts case mocks 'sonner' wholesale, which is
 // exactly why the cancel-slot-button-is-dead-when-dismissible-is-false blocker slipped through
-// review undetected - see PT-4193's "Review fix" PR notes). Rendering the real Toaster and clicking
+// review undetected). Rendering the real Toaster and clicking
 // the real DOM button pins the actual Sonner contract instead of just the shape we hand it.
 vi.mock('@shared/services/command.service', () => ({ sendCommand: vi.fn() }));
 vi.mock('@shared/services/localization.service', () => ({
@@ -115,7 +115,7 @@ describe('NotificationDisplay with real Sonner', () => {
     expect(mockSendCommand).toHaveBeenCalledWith('test.secondary', notificationId);
   });
 
-  // PT-4193 layout fix: live E2E screenshots showed toasts with buttons collapsing their message
+  // Layout fix: live E2E screenshots showed toasts with buttons collapsing their message
   // down to a sliver - first a toast with BOTH an action and a cancel button, then (round-4 E2E)
   // a single-action break-lock toast. Sonner's default layout puts icon/content/cancel/action in a
   // single un-wrapped flex row, and non-shrinking buttons crush the content column.
@@ -201,7 +201,7 @@ describe('NotificationDisplay with real Sonner', () => {
     expect(mockSendCommand).toHaveBeenCalledWith('test.primary', notificationId);
   });
 
-  // PT-4193 press-collapse regression (found in external triage): Sonner flips the toast to
+  // Press-collapse regression (found in external triage): Sonner flips the toast to
   // `data-swiping="true"` on pointerdown - ANY mouse button, on the toast body, BEFORE any movement
   // (its handler checks neither `event.button` nor movement, only that the target is not a BUTTON)
   // - and clears it again on pointerup. An earlier notification-display.scss revision gated the
@@ -295,7 +295,7 @@ describe('NotificationDisplay with real Sonner', () => {
     expect(document.querySelector('.notification-toast-action-button')).not.toBeInTheDocument();
   });
 
-  // PT-4193 (PR #2561): the Toaster follows the app theme from the theme service. Sonner's own
+  // The Toaster follows the app theme from the theme service. Sonner's own
   // default is a fixed light theme, which left dark-themed apps with white toasts - and made the
   // shadcn-token-styled secondary button (which reads the app-level `--secondary` variables) flip
   // to dark-theme colors on a still-white toast, collapsing the primary/secondary hierarchy.
@@ -319,7 +319,7 @@ describe('NotificationDisplay with real Sonner', () => {
     expect(document.querySelector('[data-sonner-toaster]')).toHaveAttribute('data-theme', 'light');
   });
 
-  // PT-4193 (review C61-2): a per-toast `position` makes Sonner render one <ol data-sonner-toaster>
+  // A per-toast `position` makes Sonner render one <ol data-sonner-toaster>
   // per distinct position, all sharing a single ref, so Sonner's own Alt+T hotkey only ever focuses
   // the last list. NotificationDisplay layers a focus-cycling handler on top so repeated Alt+T
   // reaches every list. (This pins that both lists become the active element across presses; jsdom

--- a/src/renderer/components/notification-display.test.tsx
+++ b/src/renderer/components/notification-display.test.tsx
@@ -1,12 +1,25 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
+import type { CommandHandlers } from 'papi-shared-types';
 import type {
   INotificationService,
   PlatformNotification,
 } from '@shared/models/notification.service-model';
 import * as commandService from '@shared/services/command.service';
 import { NotificationDisplay } from './notification-display';
+
+/**
+ * Make a `keyof CommandHandlers` value from a test-only command name. These tests only need a
+ * command NAME to send/assert on - it never resolves to a real handler - so this single cast
+ * satisfies the field type without repeating the assertion (and its eslint-disable) at every use
+ * site.
+ */
+function commandStub(name: string): keyof CommandHandlers {
+  // No real handler is ever registered for these names, so a cast is the only way to type them
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  return name as keyof CommandHandlers;
+}
 
 // This is the ONE render-level test in the notification suite that uses REAL Sonner instead of
 // mocking it (every other notification.service-host.test.ts case mocks 'sonner' wholesale, which is
@@ -22,7 +35,7 @@ vi.mock('@shared/services/localization.service', () => ({
   },
 }));
 vi.mock('@shared/services/logger.service', () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
 let capturedService: INotificationService;
@@ -72,9 +85,7 @@ describe('NotificationDisplay with real Sonner', () => {
       message: 'A decision is needed',
       severity: 'info',
       secondaryClickCommandLabel: 'Postpone',
-      // The test only needs a command NAME to send/assert on; it never resolves to a real handler.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      secondaryClickCommand: 'test.secondary' as never,
+      secondaryClickCommand: commandStub('test.secondary'),
       // Left true (the default) deliberately: this is the exact "two working buttons" shape the
       // blocker was about - dismissible: false would render this same button inert.
     };
@@ -102,13 +113,9 @@ describe('NotificationDisplay with real Sonner', () => {
       message: 'Time to sync',
       severity: 'info',
       clickCommandLabel: 'Send/Receive now',
-      // The test only needs a command NAME to send/assert on; it never resolves to a real handler.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      clickCommand: 'test.primary' as never,
+      clickCommand: commandStub('test.primary'),
       secondaryClickCommandLabel: 'Postpone until 3:24 PM',
-      // The test only needs a command NAME to send/assert on; it never resolves to a real handler.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      secondaryClickCommand: 'test.secondary' as never,
+      secondaryClickCommand: commandStub('test.secondary'),
     };
 
     const notificationId = await capturedService.send(notification);
@@ -152,9 +159,7 @@ describe('NotificationDisplay with real Sonner', () => {
         'The project is locked on the server by another user. Breaking the lock may discard their unfinished send.',
       severity: 'warning',
       clickCommandLabel: 'Break lock and retry',
-      // The test only needs a command NAME to send/assert on; it never resolves to a real handler.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      clickCommand: 'test.primary' as never,
+      clickCommand: commandStub('test.primary'),
     };
 
     const notificationId = await capturedService.send(notification);
@@ -197,13 +202,9 @@ describe('NotificationDisplay with real Sonner', () => {
       message: 'Time to sync',
       severity: 'info',
       clickCommandLabel: 'Send/Receive now',
-      // The test only needs a command NAME to exist; it never resolves to a real handler.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      clickCommand: 'test.primary' as never,
+      clickCommand: commandStub('test.primary'),
       secondaryClickCommandLabel: 'Postpone until 3:24 PM',
-      // The test only needs a command NAME to exist; it never resolves to a real handler.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      secondaryClickCommand: 'test.secondary' as never,
+      secondaryClickCommand: commandStub('test.secondary'),
     };
 
     await capturedService.send(notification);
@@ -248,9 +249,7 @@ describe('NotificationDisplay with real Sonner', () => {
       message: 'A decision is needed',
       severity: 'info',
       secondaryClickCommandLabel: 'Postpone',
-      // The test only needs a command NAME to send/assert on; it never resolves to a real handler.
-      // eslint-disable-next-line no-type-assertion/no-type-assertion
-      secondaryClickCommand: 'test.secondary' as never,
+      secondaryClickCommand: commandStub('test.secondary'),
     };
 
     await capturedService.send(notification);
@@ -302,8 +301,10 @@ describe('NotificationDisplay with real Sonner', () => {
         document.dispatchEvent(
           new KeyboardEvent('keydown', { altKey: true, code: 'KeyT', bubbles: true }),
         );
-        // Let the handler's queued microtask (which does the actual focus move) run.
-        await Promise.resolve();
+        // Let the handler's queued macrotask (which does the actual focus move) run.
+        await new Promise((resolve) => {
+          setTimeout(resolve, 0);
+        });
       });
       return document.activeElement;
     }

--- a/src/renderer/components/notification-display.test.tsx
+++ b/src/renderer/components/notification-display.test.tsx
@@ -179,6 +179,68 @@ describe('NotificationDisplay with real Sonner', () => {
     expect(mockSendCommand).toHaveBeenCalledWith('test.primary', notificationId);
   });
 
+  // PT-4193 press-collapse regression (found in external triage): Sonner flips the toast to
+  // `data-swiping="true"` on pointerdown - ANY mouse button, on the toast body, BEFORE any movement
+  // (its handler checks neither `event.button` nor movement, only that the target is not a BUTTON)
+  // - and clears it again on pointerup. An earlier notification-display.scss revision gated the
+  // button-row flex break out of that state, so merely holding the mouse down on a buttoned toast
+  // collapsed it to a one-character-wide sliver until release. The break is now unconditional
+  // (see the `::before` rule's comment); jsdom computes no CSS layout and exposes no
+  // pseudo-elements, so the stylesheet side cannot be asserted here. What this test pins is the DOM
+  // contract that fix rests on: a plain press really does enter Sonner's swiping state (if a Sonner
+  // upgrade stops doing that, the scss comment needs revisiting), and the class/sibling hooks the
+  // layout rules key off remain in place throughout the press.
+  it('enters Sonner swiping state on a plain press and keeps the layout-fix hooks throughout', async () => {
+    render(<NotificationDisplay />);
+
+    const notification: PlatformNotification = {
+      message: 'Time to sync',
+      severity: 'info',
+      clickCommandLabel: 'Send/Receive now',
+      // The test only needs a command NAME to exist; it never resolves to a real handler.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      clickCommand: 'test.primary' as never,
+      secondaryClickCommandLabel: 'Postpone until 3:24 PM',
+      // The test only needs a command NAME to exist; it never resolves to a real handler.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      secondaryClickCommand: 'test.secondary' as never,
+    };
+
+    await capturedService.send(notification);
+
+    const title = await screen.findByText('Time to sync');
+    const toastRoot = document.querySelector('.notification-toast');
+    expect(toastRoot).toHaveAttribute('data-swiping', 'false');
+
+    // Sonner's pointerdown handler pointer-captures the target; jsdom does not implement pointer
+    // capture, so stub it (same category of jsdom gap as the matchMedia stub above).
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    const titleElement = title as HTMLElement & {
+      setPointerCapture: (pointerId: number) => void;
+    };
+    titleElement.setPointerCapture = vi.fn();
+
+    // Left-button press on the toast body (the title div, not a button), no movement.
+    fireEvent.pointerDown(title, { pointerId: 1, button: 0 });
+    expect(toastRoot).toHaveAttribute('data-swiping', 'true');
+    // Mid-press, the hooks the two-row layout keys off must all still be present and siblings.
+    const content = title.closest('.notification-toast-content');
+    const actionButton = screen.getByRole('button', { name: 'Send/Receive now' });
+    const cancelButton = screen.getByRole('button', { name: 'Postpone until 3:24 PM' });
+    expect(content?.parentElement).toBe(toastRoot);
+    expect(actionButton.parentElement).toBe(toastRoot);
+    expect(cancelButton.parentElement).toBe(toastRoot);
+
+    fireEvent.pointerUp(title, { pointerId: 1, button: 0 });
+    expect(toastRoot).toHaveAttribute('data-swiping', 'false');
+
+    // Right-button press behaves identically (the live bug reproduced with either button).
+    fireEvent.pointerDown(title, { pointerId: 1, button: 2 });
+    expect(toastRoot).toHaveAttribute('data-swiping', 'true');
+    fireEvent.pointerUp(title, { pointerId: 1, button: 2 });
+    expect(toastRoot).toHaveAttribute('data-swiping', 'false');
+  });
+
   it('does not add the action-button hook to a single-button (cancel-only) toast', async () => {
     render(<NotificationDisplay />);
 

--- a/src/renderer/components/notification-display.test.tsx
+++ b/src/renderer/components/notification-display.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type {
   INotificationService,
@@ -175,5 +175,44 @@ describe('NotificationDisplay with real Sonner', () => {
     expect(title.closest('.notification-toast-content')).not.toBeNull();
     expect(document.querySelector('.notification-toast-cancel-button')).not.toBeInTheDocument();
     expect(document.querySelector('.notification-toast-action-button')).not.toBeInTheDocument();
+  });
+
+  // PT-4193 (review C61-2): a per-toast `position` makes Sonner render one <ol data-sonner-toaster>
+  // per distinct position, all sharing a single ref, so Sonner's own Alt+T hotkey only ever focuses
+  // the last list. NotificationDisplay layers a focus-cycling handler on top so repeated Alt+T
+  // reaches every list. (This pins that both lists become the active element across presses; jsdom
+  // does not model Sonner's real-browser per-<ol> focus-trap, so the blur-reset guarding that is
+  // manually verified - see the PR notes.)
+  it('cycles keyboard focus across every toast position list on the Alt+T hotkey', async () => {
+    render(<NotificationDisplay />);
+
+    // One default-position (bottom-right) toast and one top-center toast => two separate <ol> lists.
+    await capturedService.send({ message: 'Bottom toast', severity: 'info' });
+    await capturedService.send({ message: 'Top toast', severity: 'info', position: 'top-center' });
+    await screen.findByText('Bottom toast');
+    await screen.findByText('Top toast');
+
+    const lists = Array.from(document.querySelectorAll<HTMLElement>('[data-sonner-toaster]'));
+    expect(lists).toHaveLength(2);
+
+    async function pressHotkey() {
+      await act(async () => {
+        document.dispatchEvent(
+          new KeyboardEvent('keydown', { altKey: true, code: 'KeyT', bubbles: true }),
+        );
+        // Let the handler's queued microtask (which does the actual focus move) run.
+        await Promise.resolve();
+      });
+      return document.activeElement;
+    }
+
+    const firstFocused = await pressHotkey();
+    const secondFocused = await pressHotkey();
+
+    // Each press lands on one of the two lists, and the two presses reach different lists - so no
+    // position group is left keyboard-unreachable.
+    expect(lists).toContain(firstFocused);
+    expect(lists).toContain(secondFocused);
+    expect(firstFocused).not.toBe(secondFocused);
   });
 });

--- a/src/renderer/components/notification-display.test.tsx
+++ b/src/renderer/components/notification-display.test.tsx
@@ -86,4 +86,94 @@ describe('NotificationDisplay with real Sonner', () => {
 
     expect(mockSendCommand).toHaveBeenCalledWith('test.secondary', notificationId);
   });
+
+  // PT-4193 layout fix: a live E2E screenshot showed a toast with BOTH an action and a cancel
+  // button collapsing its message down to a ~1-character-wide sliver - Sonner's default layout
+  // puts icon/content/cancel/action in a single un-wrapped flex row, and two non-shrinking buttons
+  // crush the content column. notification-display.scss fixes this with a `:has()`-scoped stylesheet
+  // rule keyed off the classNames wired up in notification-display.tsx. jsdom doesn't compute actual
+  // flex-wrap layout, so these tests pin the DOM shape (classes + shared flex-container ancestry)
+  // that stylesheet rule depends on, rather than pixel positions.
+  it('gives a two-button toast the content/action/cancel class hooks the layout fix keys off, and keeps both buttons working', async () => {
+    render(<NotificationDisplay />);
+
+    const notification: PlatformNotification = {
+      message: 'Time to sync',
+      severity: 'info',
+      clickCommandLabel: 'Send/Receive now',
+      // The test only needs a command NAME to send/assert on; it never resolves to a real handler.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      clickCommand: 'test.primary' as never,
+      secondaryClickCommandLabel: 'Postpone until 3:24 PM',
+      // The test only needs a command NAME to send/assert on; it never resolves to a real handler.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      secondaryClickCommand: 'test.secondary' as never,
+    };
+
+    const notificationId = await capturedService.send(notification);
+
+    const actionButton = await screen.findByRole('button', { name: 'Send/Receive now' });
+    const cancelButton = await screen.findByRole('button', { name: 'Postpone until 3:24 PM' });
+    const title = await screen.findByText('Time to sync');
+    const content = title.closest('.notification-toast-content');
+    const toastRoot = document.querySelector('.notification-toast');
+
+    // The fix's CSS rule is
+    // `.notification-toast:has(.notification-toast-cancel-button):has(.notification-toast-action-button)`
+    // - assert that shape exists: one shared flex-container ancestor directly containing the
+    // content, the action button, and the cancel button as siblings (not nested inside each other),
+    // which is what lets `flex-grow` on the content and `order` on the buttons rearrange them into
+    // separate rows.
+    expect(toastRoot).not.toBeNull();
+    expect(content).not.toBeNull();
+    expect(actionButton).toHaveClass('notification-toast-action-button');
+    expect(cancelButton).toHaveClass('notification-toast-cancel-button');
+    expect(content?.parentElement).toBe(toastRoot);
+    expect(actionButton.parentElement).toBe(toastRoot);
+    expect(cancelButton.parentElement).toBe(toastRoot);
+
+    fireEvent.click(actionButton);
+    fireEvent.click(cancelButton);
+
+    expect(mockSendCommand).toHaveBeenCalledWith('test.primary', notificationId);
+    expect(mockSendCommand).toHaveBeenCalledWith('test.secondary', notificationId);
+  });
+
+  it('does not add the action-button hook to a single-button (cancel-only) toast', async () => {
+    render(<NotificationDisplay />);
+
+    const notification: PlatformNotification = {
+      message: 'A decision is needed',
+      severity: 'info',
+      secondaryClickCommandLabel: 'Postpone',
+      // The test only needs a command NAME to send/assert on; it never resolves to a real handler.
+      // eslint-disable-next-line no-type-assertion/no-type-assertion
+      secondaryClickCommand: 'test.secondary' as never,
+    };
+
+    await capturedService.send(notification);
+
+    const cancelButton = await screen.findByRole('button', { name: 'Postpone' });
+    // The layout fix only engages when BOTH button classes are present under the same toast (see
+    // the `:has()...:has()` rule in notification-display.scss). A single-button toast must not
+    // accidentally satisfy that condition, so the content keeps its plain, un-grown structure.
+    expect(cancelButton).toHaveClass('notification-toast-cancel-button');
+    expect(document.querySelector('.notification-toast-action-button')).not.toBeInTheDocument();
+  });
+
+  it('renders a plain string toast with the content hook and no button hooks', async () => {
+    render(<NotificationDisplay />);
+
+    const notification: PlatformNotification = {
+      message: 'Just an update',
+      severity: 'info',
+    };
+
+    await capturedService.send(notification);
+
+    const title = await screen.findByText('Just an update');
+    expect(title.closest('.notification-toast-content')).not.toBeNull();
+    expect(document.querySelector('.notification-toast-cancel-button')).not.toBeInTheDocument();
+    expect(document.querySelector('.notification-toast-action-button')).not.toBeInTheDocument();
+  });
 });

--- a/src/renderer/components/notification-display.test.tsx
+++ b/src/renderer/components/notification-display.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import type { CommandHandlers } from 'papi-shared-types';
+import type { ThemeDefinitionExpanded } from 'platform-bible-utils';
 import type {
   INotificationService,
   PlatformNotification,
@@ -38,6 +39,21 @@ vi.mock('@shared/services/logger.service', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+// Theme type the CurrentTheme data hook reports to NotificationDisplay; tests flip this to 'dark'
+// to pin the Toaster's theme wiring. The papi data hooks are stubbed wholesale because pulling the
+// real ones into jsdom drags the whole data-provider network stack along with them.
+let mockCurrentThemeType = 'light';
+vi.mock('@renderer/hooks/papi-hooks', () => ({
+  useDataProvider: vi.fn(),
+  useData: vi.fn(() => ({
+    CurrentTheme: (_selector: undefined, defaultValue: ThemeDefinitionExpanded) => [
+      { ...defaultValue, type: mockCurrentThemeType, id: mockCurrentThemeType },
+      vi.fn(),
+      false,
+    ],
+  })),
+}));
+
 let capturedService: INotificationService;
 vi.mock('@shared/services/network-object.service', () => ({
   networkObjectService: {
@@ -70,6 +86,7 @@ describe('NotificationDisplay with real Sonner', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
+    mockCurrentThemeType = 'light';
     mockSendCommand.mockResolvedValue(undefined);
     stubMatchMedia();
     const { startNotificationService } = await import(
@@ -276,6 +293,30 @@ describe('NotificationDisplay with real Sonner', () => {
     expect(title.closest('.notification-toast-content')).not.toBeNull();
     expect(document.querySelector('.notification-toast-cancel-button')).not.toBeInTheDocument();
     expect(document.querySelector('.notification-toast-action-button')).not.toBeInTheDocument();
+  });
+
+  // PT-4193 (PR #2561): the Toaster follows the app theme from the theme service. Sonner's own
+  // default is a fixed light theme, which left dark-themed apps with white toasts - and made the
+  // shadcn-token-styled secondary button (which reads the app-level `--secondary` variables) flip
+  // to dark-theme colors on a still-white toast, collapsing the primary/secondary hierarchy.
+  it('themes the toaster to match the current app theme', async () => {
+    mockCurrentThemeType = 'dark';
+    render(<NotificationDisplay />);
+
+    await capturedService.send({ message: 'Dark toast', severity: 'info' });
+    await screen.findByText('Dark toast');
+
+    expect(document.querySelector('[data-sonner-toaster]')).toHaveAttribute('data-theme', 'dark');
+  });
+
+  it('falls back to the light look for a theme type Sonner does not understand', async () => {
+    mockCurrentThemeType = 'paratext-classic';
+    render(<NotificationDisplay />);
+
+    await capturedService.send({ message: 'Custom-theme toast', severity: 'info' });
+    await screen.findByText('Custom-theme toast');
+
+    expect(document.querySelector('[data-sonner-toaster]')).toHaveAttribute('data-theme', 'light');
   });
 
   // PT-4193 (review C61-2): a per-toast `position` makes Sonner render one <ol data-sonner-toaster>

--- a/src/renderer/components/notification-display.tsx
+++ b/src/renderer/components/notification-display.tsx
@@ -1,7 +1,23 @@
 import { Toaster } from 'sonner';
+import './notification-display.scss';
 
+// PT-4193: class hooks for notification-display.scss's fix for the two-button (action + cancel)
+// toast layout collapse - see that file for the full explanation. Applied here (the `Toaster`'s
+// shared `toastOptions`) rather than per-notification in notification.service-host.ts so every
+// toast gets the hooks uniformly; the CSS itself only changes layout when both buttons are present.
 export function NotificationDisplay() {
-  return <Toaster />;
+  return (
+    <Toaster
+      toastOptions={{
+        classNames: {
+          toast: 'notification-toast',
+          content: 'notification-toast-content',
+          actionButton: 'notification-toast-action-button',
+          cancelButton: 'notification-toast-cancel-button',
+        },
+      }}
+    />
+  );
 }
 
 export default NotificationDisplay;

--- a/src/renderer/components/notification-display.tsx
+++ b/src/renderer/components/notification-display.tsx
@@ -29,10 +29,10 @@ function eventMatchesHotkey(event: KeyboardEvent, hotkey: readonly string[]): bo
   });
 }
 
-// PT-4193: class hooks for notification-display.scss's fix for the two-button (action + cancel)
-// toast layout collapse - see that file for the full explanation. Applied here (the `Toaster`'s
-// shared `toastOptions`) rather than per-notification in notification.service-host.ts so every
-// toast gets the hooks uniformly; the CSS itself only changes layout when both buttons are present.
+// PT-4193: class hooks for notification-display.scss's fix for the buttoned-toast layout collapse -
+// see that file for the full explanation. Applied here (the `Toaster`'s shared `toastOptions`)
+// rather than per-notification in notification.service-host.ts so every toast gets the hooks
+// uniformly; the CSS itself only changes layout when at least one button is present.
 export function NotificationDisplay() {
   // Index of the toast list Alt+T last focused, so repeated presses cycle across every list.
   const focusedListIndexRef = useRef(-1);

--- a/src/renderer/components/notification-display.tsx
+++ b/src/renderer/components/notification-display.tsx
@@ -46,7 +46,7 @@ function eventMatchesHotkey(event: KeyboardEvent, hotkey: readonly string[]): bo
   });
 }
 
-// PT-4193: class hooks for notification-display.scss's fix for the buttoned-toast layout collapse -
+// Class hooks for notification-display.scss's fix for the buttoned-toast layout collapse -
 // see that file for the full explanation. Applied here (the `Toaster`'s shared `toastOptions`)
 // rather than per-notification in notification.service-host.ts so every toast gets the hooks
 // uniformly; the CSS itself only changes layout when at least one button is present.
@@ -54,9 +54,9 @@ export function NotificationDisplay() {
   // Index of the toast list Alt+T last focused, so repeated presses cycle across every list.
   const focusedListIndexRef = useRef(-1);
 
-  // PT-4193 (PR #2561): follow the app theme so toasts render coherently in dark mode. Sonner's
-  // own default is a fixed light theme, which left dark-themed apps with white toasts - and made
-  // the shadcn-token-styled secondary button (notification-display.scss reads the app-level
+  // Follow the app theme so toasts render coherently in dark mode. Sonner's own default is a
+  // fixed light theme, which left dark-themed apps with white toasts - and made the
+  // shadcn-token-styled secondary button (notification-display.scss reads the app-level
   // `--secondary` variables, which flip with the app theme) render dark-theme colors on a
   // still-white toast, collapsing the primary/secondary button hierarchy.
   const themeDataProvider = useDataProvider(themeServiceDataProviderName);
@@ -69,7 +69,7 @@ export function NotificationDisplay() {
   const themeType =
     !isPlatformError(currentTheme) && currentTheme.type === 'dark' ? 'dark' : 'light';
 
-  // PT-4193 (review C61-2): with a per-toast `position`, Sonner 1.7.4 renders one `<ol>` per
+  // With a per-toast `position`, Sonner 1.7.4 renders one `<ol>` per
   // distinct position but assigns them all a single shared `ref`, so its own Alt+T handler only
   // ever focuses the LAST list - leaving toasts in every other position group unreachable by
   // keyboard (each `<ol>` is also its own focus trap that ejects focus when you try to Tab out to a

--- a/src/renderer/components/notification-display.tsx
+++ b/src/renderer/components/notification-display.tsx
@@ -1,13 +1,78 @@
+import { useEffect, useRef } from 'react';
 import { Toaster } from 'sonner';
 import './notification-display.scss';
+
+// Sonner's default focus hotkey (Alt+T). Declared here so the exact same combo drives both Sonner's
+// own <Toaster> and our focus-cycling handler below - the two must not drift apart.
+const NOTIFICATION_TOASTER_HOTKEY = ['altKey', 'KeyT'];
+
+/**
+ * Whether a keydown matches {@link NOTIFICATION_TOASTER_HOTKEY}, using the same semantics as Sonner
+ * 1.7.4 (a modifier name like `altKey` is read as a boolean flag; anything else is matched against
+ * `event.code`). Spelled out rather than indexing the event by a dynamic key so it stays type-safe
+ * without a type assertion.
+ */
+function eventMatchesHotkey(event: KeyboardEvent, hotkey: readonly string[]): boolean {
+  return hotkey.every((key) => {
+    switch (key) {
+      case 'altKey':
+        return event.altKey;
+      case 'ctrlKey':
+        return event.ctrlKey;
+      case 'metaKey':
+        return event.metaKey;
+      case 'shiftKey':
+        return event.shiftKey;
+      default:
+        return event.code === key;
+    }
+  });
+}
 
 // PT-4193: class hooks for notification-display.scss's fix for the two-button (action + cancel)
 // toast layout collapse - see that file for the full explanation. Applied here (the `Toaster`'s
 // shared `toastOptions`) rather than per-notification in notification.service-host.ts so every
 // toast gets the hooks uniformly; the CSS itself only changes layout when both buttons are present.
 export function NotificationDisplay() {
+  // Index of the toast list Alt+T last focused, so repeated presses cycle across every list.
+  const focusedListIndexRef = useRef(-1);
+
+  // PT-4193 (review C61-2): with a per-toast `position`, Sonner 1.7.4 renders one `<ol>` per
+  // distinct position but assigns them all a single shared `ref`, so its own Alt+T handler only
+  // ever focuses the LAST list - leaving toasts in every other position group unreachable by
+  // keyboard (each `<ol>` is also its own focus trap that ejects focus when you try to Tab out to a
+  // sibling list). Cycle focus across every non-empty list so repeated Alt+T reaches them all.
+  useEffect(() => {
+    function cycleToastListFocus() {
+      const lists = Array.from(
+        document.querySelectorAll<HTMLElement>('[data-sonner-toaster]'),
+      ).filter((list) => list.querySelector('[data-sonner-toast]'));
+      // One (or zero) lists: Sonner's built-in hotkey already reaches it correctly - don't interfere.
+      if (lists.length <= 1) return;
+      const nextIndex = (focusedListIndexRef.current + 1) % lists.length;
+      focusedListIndexRef.current = nextIndex;
+      // Neutralize Sonner's per-`<ol>` focus trap: each list restores focus to the pre-region
+      // element when focus leaves it, which would otherwise eject us the moment we move to a sibling
+      // list. Blurring first lets that restore run harmlessly; then we focus the target list.
+      if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+      lists[nextIndex].focus();
+    }
+
+    function handleKeyDown(event: KeyboardEvent) {
+      if (!eventMatchesHotkey(event, NOTIFICATION_TOASTER_HOTKEY)) return;
+      // Run after Sonner's own synchronous hotkey handler (which expands the stack and focuses its
+      // single shared ref) has finished for this event, so our focus target wins regardless of
+      // listener order.
+      queueMicrotask(cycleToastListFocus);
+    }
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
   return (
     <Toaster
+      hotkey={NOTIFICATION_TOASTER_HOTKEY}
       toastOptions={{
         classNames: {
           toast: 'notification-toast',

--- a/src/renderer/components/notification-display.tsx
+++ b/src/renderer/components/notification-display.tsx
@@ -1,6 +1,23 @@
 import { useEffect, useRef } from 'react';
 import { Toaster } from 'sonner';
+import { isPlatformError, type ThemeDefinitionExpanded } from 'platform-bible-utils';
+import { themeServiceDataProviderName } from '@shared/services/theme.service-model';
+import { useData, useDataProvider } from '@renderer/hooks/papi-hooks';
 import './notification-display.scss';
+
+/**
+ * Placeholder passed as the default value for the `CurrentTheme` data hook so it has something
+ * structurally valid to return while the real theme loads (same pattern as
+ * `user-profile-popover.component.tsx`). Only `type` is ever read; the light default matches what
+ * Sonner would render on its own before the theme arrives.
+ */
+const DEFAULT_THEME_VALUE: ThemeDefinitionExpanded = {
+  themeFamilyId: '',
+  type: 'light',
+  id: 'light',
+  label: '%toolbar_theme_loading%',
+  cssVariables: {},
+};
 
 // Sonner's default focus hotkey (Alt+T). Declared here so the exact same combo drives both Sonner's
 // own <Toaster> and our focus-cycling handler below - the two must not drift apart.
@@ -36,6 +53,21 @@ function eventMatchesHotkey(event: KeyboardEvent, hotkey: readonly string[]): bo
 export function NotificationDisplay() {
   // Index of the toast list Alt+T last focused, so repeated presses cycle across every list.
   const focusedListIndexRef = useRef(-1);
+
+  // PT-4193 (PR #2561): follow the app theme so toasts render coherently in dark mode. Sonner's
+  // own default is a fixed light theme, which left dark-themed apps with white toasts - and made
+  // the shadcn-token-styled secondary button (notification-display.scss reads the app-level
+  // `--secondary` variables, which flip with the app theme) render dark-theme colors on a
+  // still-white toast, collapsing the primary/secondary button hierarchy.
+  const themeDataProvider = useDataProvider(themeServiceDataProviderName);
+  const [currentTheme] = useData<typeof themeServiceDataProviderName>(
+    themeDataProvider,
+  ).CurrentTheme(undefined, DEFAULT_THEME_VALUE);
+  // Theme `type` is an open string (theme families can define their own types), but Sonner only
+  // understands light/dark - so anything that isn't exactly 'dark' gets the light look, matching
+  // the platform's own fallback behavior for unknown theme types.
+  const themeType =
+    !isPlatformError(currentTheme) && currentTheme.type === 'dark' ? 'dark' : 'light';
 
   // PT-4193 (review C61-2): with a per-toast `position`, Sonner 1.7.4 renders one `<ol>` per
   // distinct position but assigns them all a single shared `ref`, so its own Alt+T handler only
@@ -75,6 +107,7 @@ export function NotificationDisplay() {
 
   return (
     <Toaster
+      theme={themeType}
       hotkey={NOTIFICATION_TOASTER_HOTKEY}
       toastOptions={{
         classNames: {

--- a/src/renderer/components/notification-display.tsx
+++ b/src/renderer/components/notification-display.tsx
@@ -61,9 +61,12 @@ export function NotificationDisplay() {
     function handleKeyDown(event: KeyboardEvent) {
       if (!eventMatchesHotkey(event, NOTIFICATION_TOASTER_HOTKEY)) return;
       // Run after Sonner's own synchronous hotkey handler (which expands the stack and focuses its
-      // single shared ref) has finished for this event, so our focus target wins regardless of
-      // listener order.
-      queueMicrotask(cycleToastListFocus);
+      // single shared ref) has finished for this event, so our focus target wins. A macrotask (not
+      // a microtask) makes that ordering independent of listener registration order: a timer
+      // callback never runs until the whole keydown dispatch task - every listener, in any order -
+      // has completed, whereas a microtask queued by a listener that happened to run BEFORE
+      // Sonner's would flush between listeners and let Sonner steal the focus back.
+      setTimeout(cycleToastListFocus, 0);
     }
 
     document.addEventListener('keydown', handleKeyDown);

--- a/src/renderer/services/notification.service-host.test.ts
+++ b/src/renderer/services/notification.service-host.test.ts
@@ -3,8 +3,24 @@ import type {
   INotificationService,
   PlatformNotification,
 } from '@shared/models/notification.service-model';
+import * as commandService from '@shared/services/command.service';
+import { logger } from '@shared/services/logger.service';
 
-const mockToastInfo = vi.fn(() => 'mock-toast-id');
+/**
+ * Minimal shape of the toastOptions object the host passes to Sonner's `toast.*` functions - typed
+ * just precisely enough to invoke `cancel.onClick` / `onDismiss` from tests without a type
+ * assertion (see `.eslintrc.cjs` `no-type-assertion` rule).
+ */
+interface CapturedToastOptions {
+  cancel?: { label: string; onClick: () => Promise<void> };
+  onDismiss?: () => Promise<void>;
+}
+
+// Typed via the explicit generic (rather than named-but-unused parameters on the implementation)
+// so `mock.calls` is typed as `[string, CapturedToastOptions?]` without unused-arg lint errors.
+const mockToastInfo = vi.fn<(message: string, options?: CapturedToastOptions) => string>(
+  () => 'mock-toast-id',
+);
 const mockToastWarning = vi.fn(() => 'mock-toast-id');
 const mockToastError = vi.fn(() => 'mock-toast-id');
 const mockToast = Object.assign(
@@ -30,6 +46,8 @@ vi.mock('@shared/services/logger.service', () => ({
   logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+const mockSendCommand = vi.mocked(commandService.sendCommand);
+
 let capturedService: INotificationService;
 vi.mock('@shared/services/network-object.service', () => ({
   networkObjectService: {
@@ -44,6 +62,7 @@ describe('notification service host', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     vi.resetModules();
+    mockSendCommand.mockResolvedValue(undefined);
     const { startNotificationService } = await import(
       '@renderer/services/notification.service-host'
     );
@@ -152,15 +171,96 @@ describe('notification service host', () => {
       );
     });
 
-    it('leaves cancel, position, and dismissible undefined when the new fields are omitted (back-compat)', async () => {
+    it('leaves cancel, position, dismissible, and onDismiss undefined when the new fields are omitted (back-compat)', async () => {
       const notification: PlatformNotification = { message: 'test', severity: 'info' };
 
       await capturedService.send(notification);
 
       expect(mockToastInfo).toHaveBeenCalledWith(
         'test',
-        expect.objectContaining({ cancel: undefined, position: undefined, dismissible: undefined }),
+        expect.objectContaining({
+          cancel: undefined,
+          position: undefined,
+          dismissible: undefined,
+          onDismiss: undefined,
+        }),
       );
+    });
+
+    it('invokes the secondary command with the notification id when the cancel button is clicked', async () => {
+      const notification: PlatformNotification = {
+        message: 'test',
+        severity: 'info',
+        secondaryClickCommandLabel: 'Postpone',
+        // The host passes this straight to Sonner without validating it against real command names,
+        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        secondaryClickCommand: 'test.secondary' as never,
+      };
+
+      const notificationId = await capturedService.send(notification);
+      const options = mockToastInfo.mock.calls[0][1];
+      await options?.cancel?.onClick();
+
+      expect(mockSendCommand).toHaveBeenCalledWith('test.secondary', notificationId);
+    });
+
+    it('logs a warning instead of throwing when the secondary command rejects', async () => {
+      mockSendCommand.mockRejectedValueOnce(new Error('boom'));
+      const notification: PlatformNotification = {
+        message: 'test',
+        severity: 'info',
+        secondaryClickCommandLabel: 'Postpone',
+        // The host passes this straight to Sonner without validating it against real command names,
+        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        secondaryClickCommand: 'test.secondary' as never,
+      };
+
+      await capturedService.send(notification);
+      const options = mockToastInfo.mock.calls[0][1];
+
+      // The catch handler must swallow the rejection - awaiting the returned promise must not throw.
+      await expect(options?.cancel?.onClick()).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('boom'));
+    });
+  });
+
+  describe('dismissClickCommand (Sonner onDismiss)', () => {
+    it("maps dismissClickCommand to Sonner's onDismiss option and sends it the notification id", async () => {
+      const notification: PlatformNotification = {
+        message: 'test',
+        severity: 'info',
+        // The host passes this straight to Sonner without validating it against real command names,
+        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        dismissClickCommand: 'test.dismiss' as never,
+      };
+
+      const notificationId = await capturedService.send(notification);
+      const options = mockToastInfo.mock.calls[0][1];
+      await options?.onDismiss?.();
+
+      expect(mockSendCommand).toHaveBeenCalledWith('test.dismiss', notificationId);
+    });
+
+    it('logs a warning instead of throwing when the dismiss command rejects', async () => {
+      mockSendCommand.mockRejectedValueOnce(new Error('boom'));
+      const notification: PlatformNotification = {
+        message: 'test',
+        severity: 'info',
+        // The host passes this straight to Sonner without validating it against real command names,
+        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        dismissClickCommand: 'test.dismiss' as never,
+      };
+
+      await capturedService.send(notification);
+      const options = mockToastInfo.mock.calls[0][1];
+
+      // The catch handler must swallow the rejection - awaiting the returned promise must not throw.
+      await expect(options?.onDismiss?.()).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('boom'));
     });
   });
 

--- a/src/renderer/services/notification.service-host.test.ts
+++ b/src/renderer/services/notification.service-host.test.ts
@@ -1,10 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CommandHandlers } from 'papi-shared-types';
 import type {
   INotificationService,
   PlatformNotification,
 } from '@shared/models/notification.service-model';
 import * as commandService from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
+
+/**
+ * Make a `keyof CommandHandlers` value from a test-only command name. The host passes command names
+ * straight through to Sonner/commandService without validating them against real registered
+ * commands, so a stub name suffices; this single cast satisfies the field type without repeating
+ * the assertion (and its eslint-disable) at every use site.
+ */
+function commandStub(name: string): keyof CommandHandlers {
+  // No real handler is ever registered for these names, so a cast is the only way to type them
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  return name as keyof CommandHandlers;
+}
 
 /**
  * Minimal shape of the toastOptions object the host passes to Sonner's `toast.*` functions - typed
@@ -45,7 +58,7 @@ vi.mock('@shared/services/localization.service', () => ({
   },
 }));
 vi.mock('@shared/services/logger.service', () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
 const mockSendCommand = vi.mocked(commandService.sendCommand);
@@ -127,10 +140,7 @@ describe('notification service host', () => {
         message: 'test',
         severity: 'info',
         secondaryClickCommandLabel: 'Postpone',
-        // The host passes this straight to Sonner without validating it against real command names,
-        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        secondaryClickCommand: 'test.secondary' as never,
+        secondaryClickCommand: commandStub('test.secondary'),
       };
 
       await capturedService.send(notification);
@@ -179,10 +189,7 @@ describe('notification service host', () => {
         severity: 'info',
         dismissible: false,
         secondaryClickCommandLabel: 'Postpone',
-        // The host passes this straight to Sonner without validating it against real command names,
-        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        secondaryClickCommand: 'test.secondary' as never,
+        secondaryClickCommand: commandStub('test.secondary'),
       };
 
       await capturedService.send(notification);
@@ -192,6 +199,25 @@ describe('notification service host', () => {
       expect(mockToastInfo).toHaveBeenCalledWith(
         'test',
         expect.objectContaining({ dismissible: undefined }),
+      );
+    });
+
+    it('keeps dismissible:false when the secondary command has no label (no button renders)', async () => {
+      const notification: PlatformNotification = {
+        message: 'test',
+        severity: 'info',
+        dismissible: false,
+        secondaryClickCommand: commandStub('test.secondary'),
+      };
+
+      await capturedService.send(notification);
+
+      // Without a label the cancel button never renders, so there is no control for
+      // `dismissible: false` to kill - the caller's explicit request must be honored, not silently
+      // dropped based on the raw command field alone.
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        'test',
+        expect.objectContaining({ dismissible: false, cancel: undefined }),
       );
     });
 
@@ -221,10 +247,7 @@ describe('notification service host', () => {
         notificationId: 'consent',
         position: 'top-center',
         secondaryClickCommandLabel: 'Postpone',
-        // The host passes this straight to Sonner without validating it against real command names,
-        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        secondaryClickCommand: 'test.postpone' as never,
+        secondaryClickCommand: commandStub('test.postpone'),
         dismissible: false,
       };
       await capturedService.send(first);
@@ -252,10 +275,7 @@ describe('notification service host', () => {
         message: 'test',
         severity: 'info',
         secondaryClickCommandLabel: 'Postpone',
-        // The host passes this straight to Sonner without validating it against real command names,
-        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        secondaryClickCommand: 'test.secondary' as never,
+        secondaryClickCommand: commandStub('test.secondary'),
       };
 
       const notificationId = await capturedService.send(notification);
@@ -271,10 +291,7 @@ describe('notification service host', () => {
         message: 'test',
         severity: 'info',
         secondaryClickCommandLabel: 'Postpone',
-        // The host passes this straight to Sonner without validating it against real command names,
-        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        secondaryClickCommand: 'test.secondary' as never,
+        secondaryClickCommand: commandStub('test.secondary'),
       };
 
       await capturedService.send(notification);
@@ -291,10 +308,7 @@ describe('notification service host', () => {
       const notification: PlatformNotification = {
         message: 'test',
         severity: 'info',
-        // The host passes this straight to Sonner without validating it against real command names,
-        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        dismissClickCommand: 'test.dismiss' as never,
+        dismissClickCommand: commandStub('test.dismiss'),
       };
 
       const notificationId = await capturedService.send(notification);
@@ -309,10 +323,7 @@ describe('notification service host', () => {
       const notification: PlatformNotification = {
         message: 'test',
         severity: 'info',
-        // The host passes this straight to Sonner without validating it against real command names,
-        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        dismissClickCommand: 'test.dismiss' as never,
+        dismissClickCommand: commandStub('test.dismiss'),
       };
 
       await capturedService.send(notification);
@@ -393,10 +404,7 @@ describe('notification service host', () => {
         message: 'test',
         severity: 'info',
         clickCommandLabel: 'Send/Receive now',
-        // The host passes this straight to Sonner without validating it against real command names,
-        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        clickCommand: 'test.primary' as never,
+        clickCommand: commandStub('test.primary'),
       };
 
       await capturedService.send(notification);
@@ -413,10 +421,7 @@ describe('notification service host', () => {
       const notification: PlatformNotification = {
         message: 'test',
         severity: 'info',
-        // The host passes this straight to Sonner without validating it against real command names,
-        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
-        // eslint-disable-next-line no-type-assertion/no-type-assertion
-        dismissClickCommand: 'test.dismiss' as never,
+        dismissClickCommand: commandStub('test.dismiss'),
       };
 
       const notificationId = await capturedService.send(notification);

--- a/src/renderer/services/notification.service-host.test.ts
+++ b/src/renderer/services/notification.service-host.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type {
   INotificationService,
   PlatformNotification,
@@ -67,13 +67,6 @@ describe('notification service host', () => {
       '@renderer/services/notification.service-host'
     );
     await startNotificationService();
-  });
-
-  afterEach(() => {
-    // Guarantee real timers are restored even if a fake-timer test throws before its own
-    // `vi.useRealTimers()` - otherwise a single assertion failure can leave fake timers active
-    // for every subsequent test.
-    vi.useRealTimers();
   });
 
   describe('send with duration', () => {
@@ -291,74 +284,6 @@ describe('notification service host', () => {
         2,
         'Syncing...',
         expect.objectContaining({ id: 'toast-1' }),
-      );
-    });
-  });
-
-  describe('dismiss grace window (guards against a resurrected toast)', () => {
-    it('drops a send() for a notificationId that was just dismissed instead of creating a new toast', async () => {
-      mockToastInfo.mockReturnValueOnce('toast-1');
-      const notification: PlatformNotification = {
-        message: 'Syncing (0%)',
-        severity: 'info',
-        notificationId: 'sync-status',
-      };
-
-      const notificationId = await capturedService.send(notification);
-      await capturedService.dismiss(notificationId);
-      // A stale in-flight update for the same id, racing its own producer's dismiss(), arrives
-      // right after the dismiss - it must be dropped rather than resurrecting a new toast.
-      const result = await capturedService.send(notification);
-
-      expect(mockToastInfo).toHaveBeenCalledTimes(1);
-      expect(mockToast.dismiss).toHaveBeenCalledTimes(1);
-      expect(result).toBe('sync-status');
-      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('sync-status'));
-    });
-
-    it('allows sending with the same notificationId again once the grace window has elapsed', async () => {
-      vi.useFakeTimers();
-      mockToastInfo.mockReturnValueOnce('toast-1').mockReturnValueOnce('toast-2');
-      const notification: PlatformNotification = {
-        message: 'Syncing (0%)',
-        severity: 'info',
-        notificationId: 'sync-status',
-      };
-
-      const notificationId = await capturedService.send(notification);
-      await capturedService.dismiss(notificationId);
-      // Past the grace window, so this is treated as a legitimate new send, not a stale update.
-      vi.advanceTimersByTime(5001);
-      await capturedService.send(notification);
-
-      expect(mockToastInfo).toHaveBeenCalledTimes(2);
-      // toastId mapping was cleared by dismiss(), so this creates a fresh toast (id: undefined)
-      // rather than updating the dismissed one.
-      expect(mockToastInfo).toHaveBeenNthCalledWith(
-        2,
-        'Syncing (0%)',
-        expect.objectContaining({ id: undefined }),
-      );
-    });
-
-    it('does not affect a brand-new send with no notificationId right after an unrelated dismiss', async () => {
-      mockToastInfo.mockReturnValueOnce('toast-1').mockReturnValueOnce('toast-2');
-      const dismissedNotification: PlatformNotification = {
-        message: 'Syncing (0%)',
-        severity: 'info',
-        notificationId: 'sync-status',
-      };
-      const notificationId = await capturedService.send(dismissedNotification);
-      await capturedService.dismiss(notificationId);
-
-      const freshNotification: PlatformNotification = { message: 'Unrelated', severity: 'info' };
-      await capturedService.send(freshNotification);
-
-      expect(mockToastInfo).toHaveBeenCalledTimes(2);
-      expect(mockToastInfo).toHaveBeenNthCalledWith(
-        2,
-        'Unrelated',
-        expect.objectContaining({ id: undefined }),
       );
     });
   });

--- a/src/renderer/services/notification.service-host.test.ts
+++ b/src/renderer/services/notification.service-host.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type {
   INotificationService,
   PlatformNotification,
@@ -43,7 +43,7 @@ vi.mock('@shared/services/localization.service', () => ({
   },
 }));
 vi.mock('@shared/services/logger.service', () => ({
-  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
 }));
 
 const mockSendCommand = vi.mocked(commandService.sendCommand);
@@ -67,6 +67,13 @@ describe('notification service host', () => {
       '@renderer/services/notification.service-host'
     );
     await startNotificationService();
+  });
+
+  afterEach(() => {
+    // Guarantee real timers are restored even if a fake-timer test throws before its own
+    // `vi.useRealTimers()` - otherwise a single assertion failure can leave fake timers active
+    // for every subsequent test.
+    vi.useRealTimers();
   });
 
   describe('send with duration', () => {
@@ -284,6 +291,74 @@ describe('notification service host', () => {
         2,
         'Syncing...',
         expect.objectContaining({ id: 'toast-1' }),
+      );
+    });
+  });
+
+  describe('dismiss grace window (guards against a resurrected toast)', () => {
+    it('drops a send() for a notificationId that was just dismissed instead of creating a new toast', async () => {
+      mockToastInfo.mockReturnValueOnce('toast-1');
+      const notification: PlatformNotification = {
+        message: 'Syncing (0%)',
+        severity: 'info',
+        notificationId: 'sync-status',
+      };
+
+      const notificationId = await capturedService.send(notification);
+      await capturedService.dismiss(notificationId);
+      // A stale in-flight update for the same id, racing its own producer's dismiss(), arrives
+      // right after the dismiss - it must be dropped rather than resurrecting a new toast.
+      const result = await capturedService.send(notification);
+
+      expect(mockToastInfo).toHaveBeenCalledTimes(1);
+      expect(mockToast.dismiss).toHaveBeenCalledTimes(1);
+      expect(result).toBe('sync-status');
+      expect(logger.debug).toHaveBeenCalledWith(expect.stringContaining('sync-status'));
+    });
+
+    it('allows sending with the same notificationId again once the grace window has elapsed', async () => {
+      vi.useFakeTimers();
+      mockToastInfo.mockReturnValueOnce('toast-1').mockReturnValueOnce('toast-2');
+      const notification: PlatformNotification = {
+        message: 'Syncing (0%)',
+        severity: 'info',
+        notificationId: 'sync-status',
+      };
+
+      const notificationId = await capturedService.send(notification);
+      await capturedService.dismiss(notificationId);
+      // Past the grace window, so this is treated as a legitimate new send, not a stale update.
+      vi.advanceTimersByTime(5001);
+      await capturedService.send(notification);
+
+      expect(mockToastInfo).toHaveBeenCalledTimes(2);
+      // toastId mapping was cleared by dismiss(), so this creates a fresh toast (id: undefined)
+      // rather than updating the dismissed one.
+      expect(mockToastInfo).toHaveBeenNthCalledWith(
+        2,
+        'Syncing (0%)',
+        expect.objectContaining({ id: undefined }),
+      );
+    });
+
+    it('does not affect a brand-new send with no notificationId right after an unrelated dismiss', async () => {
+      mockToastInfo.mockReturnValueOnce('toast-1').mockReturnValueOnce('toast-2');
+      const dismissedNotification: PlatformNotification = {
+        message: 'Syncing (0%)',
+        severity: 'info',
+        notificationId: 'sync-status',
+      };
+      const notificationId = await capturedService.send(dismissedNotification);
+      await capturedService.dismiss(notificationId);
+
+      const freshNotification: PlatformNotification = { message: 'Unrelated', severity: 'info' };
+      await capturedService.send(freshNotification);
+
+      expect(mockToastInfo).toHaveBeenCalledTimes(2);
+      expect(mockToastInfo).toHaveBeenNthCalledWith(
+        2,
+        'Unrelated',
+        expect.objectContaining({ id: undefined }),
       );
     });
   });

--- a/src/renderer/services/notification.service-host.test.ts
+++ b/src/renderer/services/notification.service-host.test.ts
@@ -8,12 +8,14 @@ import { logger } from '@shared/services/logger.service';
 
 /**
  * Minimal shape of the toastOptions object the host passes to Sonner's `toast.*` functions - typed
- * just precisely enough to invoke `cancel.onClick` / `onDismiss` from tests without a type
- * assertion (see `.eslintrc.cjs` `no-type-assertion` rule).
+ * just precisely enough to invoke `action.onClick` / `cancel.onClick` / `onDismiss` / `onAutoClose`
+ * from tests without a type assertion (see `.eslintrc.cjs` `no-type-assertion` rule).
  */
 interface CapturedToastOptions {
-  cancel?: { label: string; onClick: () => Promise<void> };
-  onDismiss?: () => Promise<void>;
+  action?: { label: string; onClick: () => Promise<void> | void };
+  cancel?: { label: string; onClick: () => Promise<void> | void };
+  onDismiss?: () => Promise<void> | void;
+  onAutoClose?: () => Promise<void> | void;
 }
 
 // Typed via the explicit generic (rather than named-but-unused parameters on the implementation)
@@ -171,20 +173,78 @@ describe('notification service host', () => {
       );
     });
 
-    it('leaves cancel, position, dismissible, and onDismiss undefined when the new fields are omitted (back-compat)', async () => {
+    it('ignores dismissible:false when a secondary command is present so that button stays live', async () => {
+      const notification: PlatformNotification = {
+        message: 'test',
+        severity: 'info',
+        dismissible: false,
+        secondaryClickCommandLabel: 'Postpone',
+        // The host passes this straight to Sonner without validating it against real command names,
+        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        secondaryClickCommand: 'test.secondary' as never,
+      };
+
+      await capturedService.send(notification);
+
+      // Sonner gates the cancel/secondary button on `dismissible`, so forwarding false would make it
+      // a dead button; the host must drop the false and keep the toast dismissible.
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        'test',
+        expect.objectContaining({ dismissible: undefined }),
+      );
+    });
+
+    it('renders no action/cancel button and no position/dismissible override when those fields are omitted (back-compat)', async () => {
       const notification: PlatformNotification = { message: 'test', severity: 'info' };
 
       await capturedService.send(notification);
 
+      // Assert the rendered outcome (no buttons, default placement, default dismissibility) rather
+      // than the exact option-object shape, so this doesn't cement any particular way of passing the
+      // omitted fields through to Sonner.
       expect(mockToastInfo).toHaveBeenCalledWith(
         'test',
         expect.objectContaining({
+          action: undefined,
           cancel: undefined,
           position: undefined,
           dismissible: undefined,
-          onDismiss: undefined,
         }),
       );
+    });
+
+    it('keeps an omitted optional field at its previous value on an update-send instead of clobbering it', async () => {
+      const first: PlatformNotification = {
+        message: 'Consent?',
+        severity: 'info',
+        notificationId: 'consent',
+        position: 'top-center',
+        secondaryClickCommandLabel: 'Postpone',
+        // The host passes this straight to Sonner without validating it against real command names,
+        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        secondaryClickCommand: 'test.postpone' as never,
+        dismissible: false,
+      };
+      await capturedService.send(first);
+
+      // Update that omits position, the secondary action, and dismissible entirely.
+      await capturedService.send({
+        message: 'Consent? (retrying)',
+        severity: 'info',
+        notificationId: 'consent',
+      });
+
+      const secondOptions = mockToastInfo.mock.calls[1][1];
+      // The position the first send set is preserved, not reverted to the Toaster default...
+      expect(mockToastInfo).toHaveBeenNthCalledWith(
+        2,
+        'Consent? (retrying)',
+        expect.objectContaining({ position: 'top-center' }),
+      );
+      // ...and the secondary (cancel) button survives the update.
+      expect(secondOptions?.cancel?.label).toBe('Postpone');
     });
 
     it('invokes the secondary command with the notification id when the cancel button is clicked', async () => {
@@ -285,6 +345,90 @@ describe('notification service host', () => {
         'Syncing...',
         expect.objectContaining({ id: 'toast-1' }),
       );
+    });
+
+    it('updates instead of duplicating for the legal id 0 (does not treat it as absent)', async () => {
+      mockToastInfo.mockReturnValueOnce('toast-0');
+      const notification: PlatformNotification = {
+        message: 'first',
+        severity: 'info',
+        notificationId: 0,
+      };
+
+      await capturedService.send(notification);
+      await capturedService.send({ message: 'second', severity: 'info', notificationId: 0 });
+
+      expect(mockToastInfo).toHaveBeenCalledTimes(2);
+      // The second send must UPDATE (pass the mapped toast id), not create a fresh toast with id
+      // undefined - which a truthiness test of `notificationId` would wrongly do for 0.
+      expect(mockToastInfo).toHaveBeenNthCalledWith(
+        2,
+        'second',
+        expect.objectContaining({ id: 'toast-0' }),
+      );
+    });
+
+    it('gives an id-less send an id in its own namespace so a numeric caller id cannot collide', async () => {
+      const autoId = await capturedService.send({ message: 'A', severity: 'info' });
+      // The returned id is our own string handle, not Sonner's internal numeric auto-id.
+      expect(typeof autoId).toBe('string');
+      expect(autoId).not.toBe(1);
+
+      // An unrelated caller using the numeric id 1 must get a brand-new toast, not an update of A.
+      await capturedService.send({ message: 'B', severity: 'info', notificationId: 1 });
+
+      expect(mockToastInfo).toHaveBeenCalledTimes(2);
+      expect(mockToastInfo).toHaveBeenNthCalledWith(
+        2,
+        'B',
+        expect.objectContaining({ id: undefined }),
+      );
+    });
+  });
+
+  describe('primary action command', () => {
+    it('logs a warning instead of leaving an unhandled rejection when the primary command rejects', async () => {
+      mockSendCommand.mockRejectedValueOnce(new Error('boom'));
+      const notification: PlatformNotification = {
+        message: 'test',
+        severity: 'info',
+        clickCommandLabel: 'Send/Receive now',
+        // The host passes this straight to Sonner without validating it against real command names,
+        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        clickCommand: 'test.primary' as never,
+      };
+
+      await capturedService.send(notification);
+      const options = mockToastInfo.mock.calls[0][1];
+
+      // The primary action must have a .catch too (it historically did not) - awaiting must not throw.
+      await expect(options?.action?.onClick()).resolves.toBeUndefined();
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('boom'));
+    });
+  });
+
+  describe('onAutoClose', () => {
+    it('runs the dismiss command and cleans up bookkeeping when the toast auto-closes', async () => {
+      const notification: PlatformNotification = {
+        message: 'test',
+        severity: 'info',
+        // The host passes this straight to Sonner without validating it against real command names,
+        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        dismissClickCommand: 'test.dismiss' as never,
+      };
+
+      const notificationId = await capturedService.send(notification);
+      const options = mockToastInfo.mock.calls[0][1];
+      // Timer expiry: Sonner fires onAutoClose (not onDismiss). It must run the same dismiss command.
+      await options?.onAutoClose?.();
+
+      expect(mockSendCommand).toHaveBeenCalledWith('test.dismiss', notificationId);
+
+      // And the mapping is cleaned up, so a later dismiss() for that id is a no-op (no leak).
+      await capturedService.dismiss(notificationId);
+      expect(mockToast.dismiss).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/renderer/services/notification.service-host.test.ts
+++ b/src/renderer/services/notification.service-host.test.ts
@@ -100,6 +100,70 @@ describe('notification service host', () => {
     });
   });
 
+  describe('secondary action and position', () => {
+    it('builds a Sonner cancel action from the secondary click fields', async () => {
+      const notification: PlatformNotification = {
+        message: 'test',
+        severity: 'info',
+        secondaryClickCommandLabel: 'Postpone',
+        // The host passes this straight to Sonner without validating it against real command names,
+        // so a stub literal suffices; the cast only satisfies the keyof CommandHandlers field type.
+        // eslint-disable-next-line no-type-assertion/no-type-assertion
+        secondaryClickCommand: 'test.secondary' as never,
+      };
+
+      await capturedService.send(notification);
+
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        'test',
+        expect.objectContaining({
+          cancel: expect.objectContaining({ label: 'Postpone' }),
+        }),
+      );
+    });
+
+    it('forwards a per-toast position to Sonner', async () => {
+      const notification: PlatformNotification = {
+        message: 'test',
+        severity: 'info',
+        position: 'top-center',
+      };
+
+      await capturedService.send(notification);
+
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        'test',
+        expect.objectContaining({ position: 'top-center' }),
+      );
+    });
+
+    it('forwards dismissible so a toast can be made non-swipe-dismissible', async () => {
+      const notification: PlatformNotification = {
+        message: 'test',
+        severity: 'info',
+        dismissible: false,
+      };
+
+      await capturedService.send(notification);
+
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        'test',
+        expect.objectContaining({ dismissible: false }),
+      );
+    });
+
+    it('leaves cancel, position, and dismissible undefined when the new fields are omitted (back-compat)', async () => {
+      const notification: PlatformNotification = { message: 'test', severity: 'info' };
+
+      await capturedService.send(notification);
+
+      expect(mockToastInfo).toHaveBeenCalledWith(
+        'test',
+        expect.objectContaining({ cancel: undefined, position: undefined, dismissible: undefined }),
+      );
+    });
+  });
+
   describe('send with a reused notificationId', () => {
     it('passes the existing toast id as the top-level id so Sonner updates instead of duplicating', async () => {
       mockToastInfo.mockReturnValueOnce('toast-1');

--- a/src/renderer/services/notification.service-host.ts
+++ b/src/renderer/services/notification.service-host.ts
@@ -2,13 +2,26 @@ import { toast } from 'sonner';
 import {
   NotificationServiceNetworkObjectName,
   type INotificationService,
+  type NotificationPosition,
   type PlatformNotification,
 } from '@shared/models/notification.service-model';
 import * as commandService from '@shared/services/command.service';
 import { networkObjectService } from '@shared/services/network-object.service';
-import { isLocalizeKey } from 'platform-bible-utils';
+import { getErrorMessage, isLocalizeKey } from 'platform-bible-utils';
 import { localizationService } from '@shared/services/localization.service';
 import { logger } from '@shared/services/logger.service';
+
+// The six placements accepted by `NotificationPosition`. OpenRPC schemas are plain data with no
+// link back to the TS type, so this can't be derived automatically; the `NotificationPosition[]`
+// annotation at least guards against typos. Keep in sync with that type by hand.
+const notificationPositionValues: NotificationPosition[] = [
+  'top-left',
+  'top-center',
+  'top-right',
+  'bottom-left',
+  'bottom-center',
+  'bottom-right',
+];
 
 const mapOfNotificationIdsToToastIds = new Map<string | number, string | number>();
 
@@ -34,6 +47,7 @@ async function send(notification: PlatformNotification): Promise<string | number
     secondaryClickCommandLabel,
     position,
     dismissible,
+    dismissClickCommand,
     notificationId,
   } = notification;
   const localizedMessage = await localize(message);
@@ -64,14 +78,36 @@ async function send(notification: PlatformNotification): Promise<string | number
         ? {
             label: await localize(secondaryClickCommandLabel),
             onClick: () =>
-              commandService.sendCommand(secondaryClickCommand, effectiveNotificationId),
+              commandService
+                .sendCommand(secondaryClickCommand, effectiveNotificationId)
+                .catch((e) =>
+                  logger.warn(
+                    `Notification service host secondary click command '${secondaryClickCommand}' failed: ${getErrorMessage(e)}`,
+                  ),
+                ),
           }
         : undefined,
     // Per-toast placement override; undefined leaves the Toaster's default placement in effect.
     position,
     // Whether the user can swipe/drag the toast away; undefined leaves Sonner's default (true). Set
-    // false (with duration 0) for a toast that must be answered via an action button.
+    // false only for a toast with no secondary action - see the warning on
+    // PlatformNotification.dismissible for why: Sonner gates the cancel/secondary button's onClick on
+    // this same flag, so `false` silently disables a second action button too.
     dismissible,
+    // Fires only when the USER dismisses the toast (swipe/drag past Sonner's threshold, or a close
+    // button click if one is ever enabled) - never for our own programmatic `dismiss()`, nor for
+    // auto-close when `duration` elapses. See PlatformNotification.dismissClickCommand for the full
+    // contract (verified against the Sonner 1.7.4 source).
+    onDismiss: dismissClickCommand
+      ? () =>
+          commandService
+            .sendCommand(dismissClickCommand, effectiveNotificationId)
+            .catch((e) =>
+              logger.warn(
+                `Notification service host dismiss command '${dismissClickCommand}' failed: ${getErrorMessage(e)}`,
+              ),
+            )
+      : undefined,
     // Duration calc from https://paratextstudio.atlassian.net/browse/PT-2196?focusedCommentId=13075
     duration,
   };
@@ -134,7 +170,8 @@ export async function startNotificationService(): Promise<void> {
                   clickCommandLabel: { type: 'string' },
                   secondaryClickCommand: { type: 'string' },
                   secondaryClickCommandLabel: { type: 'string' },
-                  position: { type: 'string' },
+                  dismissClickCommand: { type: 'string' },
+                  position: { type: 'string', enum: notificationPositionValues },
                   dismissible: { type: 'boolean' },
                   notificationId: { type: ['string', 'number'] },
                   duration: { type: 'number' },

--- a/src/renderer/services/notification.service-host.ts
+++ b/src/renderer/services/notification.service-host.ts
@@ -8,36 +8,33 @@ import {
 } from '@shared/models/notification.service-model';
 import * as commandService from '@shared/services/command.service';
 import { networkObjectService } from '@shared/services/network-object.service';
-import { getErrorMessage, isLocalizeKey } from 'platform-bible-utils';
+import { getErrorMessage, isLocalizeKey, newGuid } from 'platform-bible-utils';
 import { localizationService } from '@shared/services/localization.service';
 import { logger } from '@shared/services/logger.service';
 
-/** Caller-facing notification id -> the toast id Sonner actually rendered it under. */
-const mapOfNotificationIdsToToastIds = new Map<string | number, string | number>();
-
 /**
- * Caller-facing notification id -> the last notification we sent for it. An update-send merges over
- * this so omitting an optional field keeps its previously-set value instead of clobbering it.
+ * Caller-facing notification id -> everything we track for its live toast: the toast id Sonner
+ * actually rendered it under, and the last notification we sent for it (an update-send merges over
+ * this so omitting an optional field keeps its previously-set value instead of clobbering it). One
+ * map rather than parallel maps so no removal path can clean up one half and leak the other.
  */
-const lastNotificationById = new Map<string | number, PlatformNotification>();
+const trackedNotificationsById = new Map<
+  string | number,
+  { toastId: string | number; lastNotification: PlatformNotification }
+>();
 
 /**
- * Counter backing {@link generateAutoNotificationId}. A send without a `notificationId` gets an id
- * from our own namespace rather than Sonner's internal numeric auto-ids, which would otherwise
+ * Mint a unique caller-facing id, in our own namespace, for a notification sent without one. Uses
+ * `newGuid` (non-numeric) rather than Sonner's internal numeric auto-ids, which would otherwise
  * share a namespace with caller-supplied numeric ids and collide.
  */
-let autoAssignedNotificationIdCount = 0;
-
-/** Mint a unique caller-facing id, in our own namespace, for a notification sent without one. */
 function generateAutoNotificationId(): string {
-  autoAssignedNotificationIdCount += 1;
-  return `platform-notification-auto-${autoAssignedNotificationIdCount}`;
+  return `platform-notification-auto-${newGuid()}`;
 }
 
 /** Drop all bookkeeping for a notification once its toast is removed (via any removal path). */
 function forgetNotification(notificationId: string | number): void {
-  mapOfNotificationIdsToToastIds.delete(notificationId);
-  lastNotificationById.delete(notificationId);
+  trackedNotificationsById.delete(notificationId);
 }
 
 async function localize(text: string): Promise<string> {
@@ -58,10 +55,10 @@ async function send(notification: PlatformNotification): Promise<string | number
   // keeps its previous value. Sonner's own update re-derives every field from the incoming object
   // (and even forces `dismissible` back to true when omitted), so we merge here rather than relying
   // on it. A brand-new send (no id, or an id we no longer track) has nothing to merge over.
-  const previousNotification =
-    notificationId !== undefined ? lastNotificationById.get(notificationId) : undefined;
-  const mergedNotification: PlatformNotification = previousNotification
-    ? { ...previousNotification, ...notification }
+  const trackedNotification =
+    notificationId !== undefined ? trackedNotificationsById.get(notificationId) : undefined;
+  const mergedNotification: PlatformNotification = trackedNotification
+    ? { ...trackedNotification.lastNotification, ...notification }
     : notification;
 
   const {
@@ -93,17 +90,24 @@ async function send(notification: PlatformNotification): Promise<string | number
   // legal ids `0` and `''`.
   const effectiveNotificationId: string | number = notificationId ?? generateAutoNotificationId();
   // Reuse the existing toast id (if we're updating a still-showing notification) so Sonner updates
-  // in place instead of duplicating. `!== undefined` so the legal ids `0` and `''` update too.
+  // in place instead of duplicating. Read the map AFTER the localization awaits above (not from the
+  // pre-await `trackedNotification` snapshot) so a concurrent send for the same id that lands
+  // during the await gets updated in place rather than duplicated. `!== undefined` so the legal ids
+  // `0` and `''` update too.
   const existingToastId =
-    notificationId !== undefined ? mapOfNotificationIdsToToastIds.get(notificationId) : undefined;
+    notificationId !== undefined
+      ? trackedNotificationsById.get(notificationId)?.toastId
+      : undefined;
 
   // Sonner gates BOTH the cancel/secondary button and the swipe/close gesture (which fires
   // `onDismiss`) on `dismissible`, so honoring `dismissible: false` alongside either would silently
   // kill the very control the caller also asked for. Drop the `false` in that case so those controls
-  // keep working (see the warning on PlatformNotification.dismissible).
+  // keep working (see the warning on PlatformNotification.dismissible). The button check keys on
+  // the same condition the `cancel:` block below uses - a secondary command WITHOUT a label renders
+  // no button, so there is nothing to protect and the caller's `false` stands.
   const effectiveDismissible =
     dismissible === false &&
-    (secondaryClickCommand !== undefined || dismissClickCommand !== undefined)
+    (localizedSecondaryLabel !== undefined || dismissClickCommand !== undefined)
       ? undefined
       : dismissible;
 
@@ -175,16 +179,18 @@ async function send(notification: PlatformNotification): Promise<string | number
       toastId = toast(localizedMessage, toastOptions);
       break;
   }
-  mapOfNotificationIdsToToastIds.set(effectiveNotificationId, toastId);
-  lastNotificationById.set(effectiveNotificationId, mergedNotification);
+  trackedNotificationsById.set(effectiveNotificationId, {
+    toastId,
+    lastNotification: mergedNotification,
+  });
   return effectiveNotificationId;
 }
 
 /** Dismisses a notification from the user's UI. A no-op if the notification id is not found. */
 async function dismiss(notificationId: string | number): Promise<void> {
-  const toastId = mapOfNotificationIdsToToastIds.get(notificationId);
-  if (toastId !== undefined) {
-    toast.dismiss(toastId);
+  const trackedNotification = trackedNotificationsById.get(notificationId);
+  if (trackedNotification !== undefined) {
+    toast.dismiss(trackedNotification.toastId);
     forgetNotification(notificationId);
   }
 }

--- a/src/renderer/services/notification.service-host.ts
+++ b/src/renderer/services/notification.service-host.ts
@@ -25,7 +25,17 @@ async function send(notification: PlatformNotification): Promise<string | number
   }
   logger.info(`Notification service host received notification: ${notificationString}`);
 
-  const { message, severity, clickCommand, clickCommandLabel, notificationId } = notification;
+  const {
+    message,
+    severity,
+    clickCommand,
+    clickCommandLabel,
+    secondaryClickCommand,
+    secondaryClickCommandLabel,
+    position,
+    dismissible,
+    notificationId,
+  } = notification;
   const localizedMessage = await localize(message);
   let toastId = notificationId ? mapOfNotificationIdsToToastIds.get(notificationId) : undefined;
   // Need to define effectiveNotificationId here to access it in onClick, but we need toastId to
@@ -47,6 +57,21 @@ async function send(notification: PlatformNotification): Promise<string | number
             onClick: () => commandService.sendCommand(clickCommand, effectiveNotificationId),
           }
         : undefined,
+    // Second action button, rendered by Sonner as its `cancel` slot alongside `action`. Built the
+    // same way as `action`, and like it, sends the notification id as the command's single argument.
+    cancel:
+      secondaryClickCommandLabel && secondaryClickCommand
+        ? {
+            label: await localize(secondaryClickCommandLabel),
+            onClick: () =>
+              commandService.sendCommand(secondaryClickCommand, effectiveNotificationId),
+          }
+        : undefined,
+    // Per-toast placement override; undefined leaves the Toaster's default placement in effect.
+    position,
+    // Whether the user can swipe/drag the toast away; undefined leaves Sonner's default (true). Set
+    // false (with duration 0) for a toast that must be answered via an action button.
+    dismissible,
     // Duration calc from https://paratextstudio.atlassian.net/browse/PT-2196?focusedCommentId=13075
     duration,
   };
@@ -107,6 +132,10 @@ export async function startNotificationService(): Promise<void> {
                   severity: { type: 'string' },
                   clickCommand: { type: 'string' },
                   clickCommandLabel: { type: 'string' },
+                  secondaryClickCommand: { type: 'string' },
+                  secondaryClickCommandLabel: { type: 'string' },
+                  position: { type: 'string' },
+                  dismissible: { type: 'boolean' },
                   notificationId: { type: ['string', 'number'] },
                   duration: { type: 'number' },
                 },

--- a/src/renderer/services/notification.service-host.ts
+++ b/src/renderer/services/notification.service-host.ts
@@ -1,8 +1,9 @@
 import { toast } from 'sonner';
+import { CommandHandlers } from 'papi-shared-types';
 import {
+  NOTIFICATION_POSITIONS,
   NotificationServiceNetworkObjectName,
   type INotificationService,
-  type NotificationPosition,
   type PlatformNotification,
 } from '@shared/models/notification.service-model';
 import * as commandService from '@shared/services/command.service';
@@ -11,19 +12,33 @@ import { getErrorMessage, isLocalizeKey } from 'platform-bible-utils';
 import { localizationService } from '@shared/services/localization.service';
 import { logger } from '@shared/services/logger.service';
 
-// The six placements accepted by `NotificationPosition`. OpenRPC schemas are plain data with no
-// link back to the TS type, so this can't be derived automatically; the `NotificationPosition[]`
-// annotation at least guards against typos. Keep in sync with that type by hand.
-const notificationPositionValues: NotificationPosition[] = [
-  'top-left',
-  'top-center',
-  'top-right',
-  'bottom-left',
-  'bottom-center',
-  'bottom-right',
-];
-
+/** Caller-facing notification id -> the toast id Sonner actually rendered it under. */
 const mapOfNotificationIdsToToastIds = new Map<string | number, string | number>();
+
+/**
+ * Caller-facing notification id -> the last notification we sent for it. An update-send merges over
+ * this so omitting an optional field keeps its previously-set value instead of clobbering it.
+ */
+const lastNotificationById = new Map<string | number, PlatformNotification>();
+
+/**
+ * Counter backing {@link generateAutoNotificationId}. A send without a `notificationId` gets an id
+ * from our own namespace rather than Sonner's internal numeric auto-ids, which would otherwise
+ * share a namespace with caller-supplied numeric ids and collide.
+ */
+let autoAssignedNotificationIdCount = 0;
+
+/** Mint a unique caller-facing id, in our own namespace, for a notification sent without one. */
+function generateAutoNotificationId(): string {
+  autoAssignedNotificationIdCount += 1;
+  return `platform-notification-auto-${autoAssignedNotificationIdCount}`;
+}
+
+/** Drop all bookkeeping for a notification once its toast is removed (via any removal path). */
+function forgetNotification(notificationId: string | number): void {
+  mapOfNotificationIdsToToastIds.delete(notificationId);
+  lastNotificationById.delete(notificationId);
+}
 
 async function localize(text: string): Promise<string> {
   return isLocalizeKey(text) ? localizationService.getLocalizedString({ localizeKey: text }) : text;
@@ -38,6 +53,17 @@ async function send(notification: PlatformNotification): Promise<string | number
   }
   logger.info(`Notification service host received notification: ${notificationString}`);
 
+  const { notificationId } = notification;
+  // Merge an update-send over the last notification we sent for this id, so a field the caller omits
+  // keeps its previous value. Sonner's own update re-derives every field from the incoming object
+  // (and even forces `dismissible` back to true when omitted), so we merge here rather than relying
+  // on it. A brand-new send (no id, or an id we no longer track) has nothing to merge over.
+  const previousNotification =
+    notificationId !== undefined ? lastNotificationById.get(notificationId) : undefined;
+  const mergedNotification: PlatformNotification = previousNotification
+    ? { ...previousNotification, ...notification }
+    : notification;
+
   const {
     message,
     severity,
@@ -48,70 +74,93 @@ async function send(notification: PlatformNotification): Promise<string | number
     position,
     dismissible,
     dismissClickCommand,
-    notificationId,
-  } = notification;
+    duration: requestedDuration,
+  } = mergedNotification;
 
-  const localizedMessage = await localize(message);
-  let toastId = notificationId ? mapOfNotificationIdsToToastIds.get(notificationId) : undefined;
-  // Need to define effectiveNotificationId here to access it in onClick, but we need toastId to
-  // be definitely assigned before we can assign effectiveNotificationId, so we use a let and
-  // assign it after the switch.
-  let effectiveNotificationId: number | string;
+  // Localize the message and the (optional) button labels in parallel - each is an independent
+  // cross-process round trip to the extension host, so doing them sequentially tripled the latency
+  // to display and widened a re-entrancy window between the map read and write below.
+  const [localizedMessage, localizedActionLabel, localizedSecondaryLabel] = await Promise.all([
+    localize(message),
+    clickCommandLabel && clickCommand ? localize(clickCommandLabel) : undefined,
+    secondaryClickCommandLabel && secondaryClickCommand
+      ? localize(secondaryClickCommandLabel)
+      : undefined,
+  ]);
+
+  // A caller-supplied id keeps the caller's namespace; an id-less send gets one of our own ids
+  // (never Sonner's internal numeric auto-id) so the two namespaces can't collide. `??` keeps the
+  // legal ids `0` and `''`.
+  const effectiveNotificationId: string | number = notificationId ?? generateAutoNotificationId();
+  // Reuse the existing toast id (if we're updating a still-showing notification) so Sonner updates
+  // in place instead of duplicating. `!== undefined` so the legal ids `0` and `''` update too.
+  const existingToastId =
+    notificationId !== undefined ? mapOfNotificationIdsToToastIds.get(notificationId) : undefined;
+
+  // Sonner gates BOTH the cancel/secondary button and the swipe/close gesture (which fires
+  // `onDismiss`) on `dismissible`, so honoring `dismissible: false` alongside either would silently
+  // kill the very control the caller also asked for. Drop the `false` in that case so those controls
+  // keep working (see the warning on PlatformNotification.dismissible).
+  const effectiveDismissible =
+    dismissible === false &&
+    (secondaryClickCommand !== undefined || dismissClickCommand !== undefined)
+      ? undefined
+      : dismissible;
+
   let duration = Math.min(Math.max(localizedMessage.length * 265, 10000), 35000);
-  if (notification.duration !== undefined)
-    duration = notification.duration <= 0 ? Infinity : notification.duration;
+  if (requestedDuration !== undefined)
+    duration = requestedDuration <= 0 ? Infinity : requestedDuration;
+
+  // Every button/gesture that removes the toast runs its (optional) command with a guaranteed
+  // `.catch`, then forgets this notification's bookkeeping so the id maps don't leak on that removal
+  // path. Routing all of them through one helper is what keeps a `.catch`-less handler
+  // unconstructible (the primary action button used to lack one).
+  const runRemovalCommand =
+    (command: keyof CommandHandlers | undefined, description: string) =>
+    (): Promise<void> | void => {
+      forgetNotification(effectiveNotificationId);
+      if (command === undefined) return undefined;
+      return commandService
+        .sendCommand(command, effectiveNotificationId)
+        .catch((e) =>
+          logger.warn(
+            `Notification service host ${description} command '${command}' failed: ${getErrorMessage(e)}`,
+          ),
+        );
+    };
+
   const toastOptions = {
-    // When re-sending with the same notificationId, reuse the existing toast id so Sonner
-    // updates the existing toast instead of creating a duplicate. Sonner reads this from the
-    // top-level `id` (not from `action.id`, which it ignores).
-    id: toastId,
+    // Reuse the existing toast id so Sonner updates in place. Sonner reads this from the top-level
+    // `id` (not from `action.id`, which it ignores).
+    id: existingToastId,
     action:
-      clickCommandLabel && clickCommand
-        ? {
-            label: await localize(clickCommandLabel),
-            onClick: () => commandService.sendCommand(clickCommand, effectiveNotificationId),
-          }
+      localizedActionLabel !== undefined
+        ? { label: localizedActionLabel, onClick: runRemovalCommand(clickCommand, 'click') }
         : undefined,
-    // Second action button, rendered by Sonner as its `cancel` slot alongside `action`. Built the
-    // same way as `action`, and like it, sends the notification id as the command's single argument.
+    // Second action button, rendered by Sonner as its `cancel` slot alongside `action`. Sends the
+    // notification id as the command's single argument, like `action`.
     cancel:
-      secondaryClickCommandLabel && secondaryClickCommand
+      localizedSecondaryLabel !== undefined
         ? {
-            label: await localize(secondaryClickCommandLabel),
-            onClick: () =>
-              commandService
-                .sendCommand(secondaryClickCommand, effectiveNotificationId)
-                .catch((e) =>
-                  logger.warn(
-                    `Notification service host secondary click command '${secondaryClickCommand}' failed: ${getErrorMessage(e)}`,
-                  ),
-                ),
+            label: localizedSecondaryLabel,
+            onClick: runRemovalCommand(secondaryClickCommand, 'secondary click'),
           }
         : undefined,
     // Per-toast placement override; undefined leaves the Toaster's default placement in effect.
     position,
-    // Whether the user can swipe/drag the toast away; undefined leaves Sonner's default (true). Set
-    // false only for a toast with no secondary action - see the warning on
-    // PlatformNotification.dismissible for why: Sonner gates the cancel/secondary button's onClick on
-    // this same flag, so `false` silently disables a second action button too.
-    dismissible,
-    // Fires only when the USER dismisses the toast (swipe/drag past Sonner's threshold, or a close
-    // button click if one is ever enabled) - never for our own programmatic `dismiss()`, nor for
-    // auto-close when `duration` elapses. See PlatformNotification.dismissClickCommand for the full
-    // contract (verified against the Sonner 1.7.4 source).
-    onDismiss: dismissClickCommand
-      ? () =>
-          commandService
-            .sendCommand(dismissClickCommand, effectiveNotificationId)
-            .catch((e) =>
-              logger.warn(
-                `Notification service host dismiss command '${dismissClickCommand}' failed: ${getErrorMessage(e)}`,
-              ),
-            )
-      : undefined,
+    dismissible: effectiveDismissible,
+    // Fires when the USER dismisses the toast (swipe/drag past Sonner's threshold, or a close button
+    // if one is ever enabled). Also forgets the notification so its map entries don't leak.
+    onDismiss: runRemovalCommand(dismissClickCommand, 'dismiss'),
+    // Fires when the toast auto-closes because `duration` elapsed. Runs the same dismiss command as a
+    // user dismissal (a timeout counts as an implicit dismissal, so a must-answer toast can't vanish
+    // having fired nothing) and likewise forgets the notification - covering the auto-close path that
+    // dismiss() alone never cleaned up.
+    onAutoClose: runRemovalCommand(dismissClickCommand, 'auto-close'),
     // Duration calc from https://paratextstudio.atlassian.net/browse/PT-2196?focusedCommentId=13075
     duration,
   };
+  let toastId: string | number;
   switch (severity) {
     case 'info':
       toastId = toast.info(localizedMessage, toastOptions);
@@ -126,8 +175,8 @@ async function send(notification: PlatformNotification): Promise<string | number
       toastId = toast(localizedMessage, toastOptions);
       break;
   }
-  effectiveNotificationId = notificationId ?? toastId;
   mapOfNotificationIdsToToastIds.set(effectiveNotificationId, toastId);
+  lastNotificationById.set(effectiveNotificationId, mergedNotification);
   return effectiveNotificationId;
 }
 
@@ -136,7 +185,7 @@ async function dismiss(notificationId: string | number): Promise<void> {
   const toastId = mapOfNotificationIdsToToastIds.get(notificationId);
   if (toastId !== undefined) {
     toast.dismiss(toastId);
-    mapOfNotificationIdsToToastIds.delete(notificationId);
+    forgetNotification(notificationId);
   }
 }
 
@@ -173,7 +222,7 @@ export async function startNotificationService(): Promise<void> {
                   secondaryClickCommand: { type: 'string' },
                   secondaryClickCommandLabel: { type: 'string' },
                   dismissClickCommand: { type: 'string' },
-                  position: { type: 'string', enum: notificationPositionValues },
+                  position: { type: 'string', enum: [...NOTIFICATION_POSITIONS] },
                   dismissible: { type: 'boolean' },
                   notificationId: { type: ['string', 'number'] },
                   duration: { type: 'number' },

--- a/src/renderer/services/notification.service-host.ts
+++ b/src/renderer/services/notification.service-host.ts
@@ -25,36 +25,6 @@ const notificationPositionValues: NotificationPosition[] = [
 
 const mapOfNotificationIdsToToastIds = new Map<string | number, string | number>();
 
-/**
- * How long, in milliseconds, `dismiss()` remembers a notification id after dismissing it. Guards
- * against a stale in-flight `send()` update for that same id arriving shortly after its own
- * dismissal (e.g. a fire-and-forget progress update racing the producer's own `dismiss()` call,
- * observed live with the Send/Receive progress toast when a sync aborted quickly): without this,
- * `send()` would find no toast mapping and resurrect a brand-new toast that nothing then dismisses.
- * Deliberately short - long enough to catch a race, short enough that a caller legitimately reusing
- * the id later still works normally.
- */
-const dismissedNotificationIdGracePeriodMs = 5000;
-
-/**
- * NotificationId -> the `Date.now()` timestamp `dismiss()` was called for it. Read and pruned by
- * {@link pruneRecentlyDismissedNotificationIds}; see {@link dismissedNotificationIdGracePeriodMs}.
- */
-const recentlyDismissedNotificationIds = new Map<string | number, number>();
-
-/**
- * Drop entries from {@link recentlyDismissedNotificationIds} older than
- * {@link dismissedNotificationIdGracePeriodMs}. Called opportunistically from `send()` and
- * `dismiss()` so the map doesn't grow unboundedly; no timers involved.
- */
-function pruneRecentlyDismissedNotificationIds(): void {
-  const now = Date.now();
-  recentlyDismissedNotificationIds.forEach((dismissedAt, notificationId) => {
-    if (now - dismissedAt > dismissedNotificationIdGracePeriodMs)
-      recentlyDismissedNotificationIds.delete(notificationId);
-  });
-}
-
 async function localize(text: string): Promise<string> {
   return isLocalizeKey(text) ? localizationService.getLocalizedString({ localizeKey: text }) : text;
 }
@@ -80,17 +50,6 @@ async function send(notification: PlatformNotification): Promise<string | number
     dismissClickCommand,
     notificationId,
   } = notification;
-
-  pruneRecentlyDismissedNotificationIds();
-  // Only update-style sends (an explicit, existing notificationId) are ever suppressed here - a
-  // brand-new notification (no notificationId passed in) is never affected by this check, and a
-  // notificationId reused after the grace period has elapsed is treated as a normal, new send.
-  if (notificationId !== undefined && recentlyDismissedNotificationIds.has(notificationId)) {
-    logger.debug(
-      `Notification service host dropped send() for notification id '${notificationId}': it was dismissed within the last ${dismissedNotificationIdGracePeriodMs}ms, so this is treated as a stale in-flight update racing its own dismiss() rather than a new toast.`,
-    );
-    return notificationId;
-  }
 
   const localizedMessage = await localize(message);
   let toastId = notificationId ? mapOfNotificationIdsToToastIds.get(notificationId) : undefined;
@@ -172,23 +131,13 @@ async function send(notification: PlatformNotification): Promise<string | number
   return effectiveNotificationId;
 }
 
-/**
- * Dismisses a notification from the user's UI.
- *
- * Also remembers `notificationId` for a short grace period
- * ({@link dismissedNotificationIdGracePeriodMs}) after dismissing it. If `send()` is called again
- * with the same id while it's still in that window, the send is dropped rather than resurrecting a
- * new toast - see the comment on {@link dismissedNotificationIdGracePeriodMs} for why. Reusing the
- * id again after the grace period elapses works normally.
- */
+/** Dismisses a notification from the user's UI. A no-op if the notification id is not found. */
 async function dismiss(notificationId: string | number): Promise<void> {
-  pruneRecentlyDismissedNotificationIds();
   const toastId = mapOfNotificationIdsToToastIds.get(notificationId);
   if (toastId !== undefined) {
     toast.dismiss(toastId);
     mapOfNotificationIdsToToastIds.delete(notificationId);
   }
-  recentlyDismissedNotificationIds.set(notificationId, Date.now());
 }
 
 const notificationService: INotificationService = {

--- a/src/renderer/services/notification.service-host.ts
+++ b/src/renderer/services/notification.service-host.ts
@@ -25,6 +25,36 @@ const notificationPositionValues: NotificationPosition[] = [
 
 const mapOfNotificationIdsToToastIds = new Map<string | number, string | number>();
 
+/**
+ * How long, in milliseconds, `dismiss()` remembers a notification id after dismissing it. Guards
+ * against a stale in-flight `send()` update for that same id arriving shortly after its own
+ * dismissal (e.g. a fire-and-forget progress update racing the producer's own `dismiss()` call,
+ * observed live with the Send/Receive progress toast when a sync aborted quickly): without this,
+ * `send()` would find no toast mapping and resurrect a brand-new toast that nothing then dismisses.
+ * Deliberately short - long enough to catch a race, short enough that a caller legitimately reusing
+ * the id later still works normally.
+ */
+const dismissedNotificationIdGracePeriodMs = 5000;
+
+/**
+ * NotificationId -> the `Date.now()` timestamp `dismiss()` was called for it. Read and pruned by
+ * {@link pruneRecentlyDismissedNotificationIds}; see {@link dismissedNotificationIdGracePeriodMs}.
+ */
+const recentlyDismissedNotificationIds = new Map<string | number, number>();
+
+/**
+ * Drop entries from {@link recentlyDismissedNotificationIds} older than
+ * {@link dismissedNotificationIdGracePeriodMs}. Called opportunistically from `send()` and
+ * `dismiss()` so the map doesn't grow unboundedly; no timers involved.
+ */
+function pruneRecentlyDismissedNotificationIds(): void {
+  const now = Date.now();
+  recentlyDismissedNotificationIds.forEach((dismissedAt, notificationId) => {
+    if (now - dismissedAt > dismissedNotificationIdGracePeriodMs)
+      recentlyDismissedNotificationIds.delete(notificationId);
+  });
+}
+
 async function localize(text: string): Promise<string> {
   return isLocalizeKey(text) ? localizationService.getLocalizedString({ localizeKey: text }) : text;
 }
@@ -50,6 +80,18 @@ async function send(notification: PlatformNotification): Promise<string | number
     dismissClickCommand,
     notificationId,
   } = notification;
+
+  pruneRecentlyDismissedNotificationIds();
+  // Only update-style sends (an explicit, existing notificationId) are ever suppressed here - a
+  // brand-new notification (no notificationId passed in) is never affected by this check, and a
+  // notificationId reused after the grace period has elapsed is treated as a normal, new send.
+  if (notificationId !== undefined && recentlyDismissedNotificationIds.has(notificationId)) {
+    logger.debug(
+      `Notification service host dropped send() for notification id '${notificationId}': it was dismissed within the last ${dismissedNotificationIdGracePeriodMs}ms, so this is treated as a stale in-flight update racing its own dismiss() rather than a new toast.`,
+    );
+    return notificationId;
+  }
+
   const localizedMessage = await localize(message);
   let toastId = notificationId ? mapOfNotificationIdsToToastIds.get(notificationId) : undefined;
   // Need to define effectiveNotificationId here to access it in onClick, but we need toastId to
@@ -130,12 +172,23 @@ async function send(notification: PlatformNotification): Promise<string | number
   return effectiveNotificationId;
 }
 
+/**
+ * Dismisses a notification from the user's UI.
+ *
+ * Also remembers `notificationId` for a short grace period
+ * ({@link dismissedNotificationIdGracePeriodMs}) after dismissing it. If `send()` is called again
+ * with the same id while it's still in that window, the send is dropped rather than resurrecting a
+ * new toast - see the comment on {@link dismissedNotificationIdGracePeriodMs} for why. Reusing the
+ * id again after the grace period elapses works normally.
+ */
 async function dismiss(notificationId: string | number): Promise<void> {
+  pruneRecentlyDismissedNotificationIds();
   const toastId = mapOfNotificationIdsToToastIds.get(notificationId);
   if (toastId !== undefined) {
     toast.dismiss(toastId);
     mapOfNotificationIdsToToastIds.delete(notificationId);
   }
+  recentlyDismissedNotificationIds.set(notificationId, Date.now());
 }
 
 const notificationService: INotificationService = {

--- a/src/shared/models/notification.service-model.ts
+++ b/src/shared/models/notification.service-model.ts
@@ -38,7 +38,9 @@ export interface PlatformNotification {
   /** Severity of the notification */
   severity: Severity;
   /**
-   * Optional label for users to click when the notification shows.
+   * Optional label for users to click when the notification shows. Always rendered as the
+   * notification's PRIMARY action button - the visually emphasized one - while
+   * {@link secondaryClickCommandLabel} always gets the muted secondary styling.
    *
    * Automatically localized if this is a {@link LocalizeKey}.
    */
@@ -55,6 +57,10 @@ export interface PlatformNotification {
   /**
    * Optional label for a second action button, shown alongside {@link clickCommandLabel}. Provide
    * this together with {@link secondaryClickCommand} to give the notification two actions.
+   *
+   * Always rendered as the visually SECONDARY button (muted styling, like the shadcn `secondary`
+   * button variant) so the {@link clickCommandLabel} button keeps the emphasis - the platform
+   * decides each button's styling from which field it came from, never from ordering.
    *
    * Automatically localized if this is a {@link LocalizeKey}.
    *

--- a/src/shared/models/notification.service-model.ts
+++ b/src/shared/models/notification.service-model.ts
@@ -7,6 +7,8 @@ export type Severity = 'info' | 'warning' | 'error';
  * The placements a notification can appear in, as a frozen array so it can be the single source of
  * truth for both the {@link NotificationPosition} type and the notification service's OpenRPC
  * `position` enum (which the service host spreads from this).
+ *
+ * @experimental
  */
 export const NOTIFICATION_POSITIONS = Object.freeze([
   'top-left',
@@ -20,6 +22,8 @@ export const NOTIFICATION_POSITIONS = Object.freeze([
 /**
  * Where a notification is shown on screen. Mirrors the placements the host toast library supports.
  * Omit to use the app's default placement.
+ *
+ * @experimental
  */
 export type NotificationPosition = (typeof NOTIFICATION_POSITIONS)[number];
 
@@ -53,6 +57,8 @@ export interface PlatformNotification {
    * this together with {@link secondaryClickCommand} to give the notification two actions.
    *
    * Automatically localized if this is a {@link LocalizeKey}.
+   *
+   * @experimental
    */
   secondaryClickCommandLabel?: string | LocalizeKey;
   /**
@@ -62,6 +68,8 @@ export interface PlatformNotification {
    * - NotificationId: The ID of the notification that was clicked
    *
    * The command handler should have the type signature {@link NotificationClickCommandHandler}.
+   *
+   * @experimental
    */
   secondaryClickCommand?: keyof CommandHandlers;
   /**
@@ -83,11 +91,15 @@ export interface PlatformNotification {
    * decision — e.g. pairing it with a "postpone" command lets a two-button, must-answer-style toast
    * keep {@link dismissible} `true` (see the warning on {@link dismissible}). If you need the toast
    * to persist until the user actually answers, also set `duration` to `0`.
+   *
+   * @experimental
    */
   dismissClickCommand?: keyof CommandHandlers;
   /**
    * Optional placement of the notification on screen. When omitted, the app's default placement is
    * used.
+   *
+   * @experimental
    */
   position?: NotificationPosition;
   /**
@@ -103,6 +115,8 @@ export interface PlatformNotification {
    * no secondary/dismiss command. For a notification the user must explicitly answer, prefer
    * leaving `dismissible: true` and using {@link dismissClickCommand} so a swipe-away still counts
    * as a real (e.g. "postpone") decision.
+   *
+   * @experimental
    */
   dismissible?: boolean;
   /**

--- a/src/shared/models/notification.service-model.ts
+++ b/src/shared/models/notification.service-model.ts
@@ -4,16 +4,24 @@ import { LocalizeKey } from 'platform-bible-utils';
 export type Severity = 'info' | 'warning' | 'error';
 
 /**
+ * The placements a notification can appear in, as a frozen array so it can be the single source of
+ * truth for both the {@link NotificationPosition} type and the notification service's OpenRPC
+ * `position` enum (which the service host spreads from this).
+ */
+export const NOTIFICATION_POSITIONS = Object.freeze([
+  'top-left',
+  'top-center',
+  'top-right',
+  'bottom-left',
+  'bottom-center',
+  'bottom-right',
+] as const);
+
+/**
  * Where a notification is shown on screen. Mirrors the placements the host toast library supports.
  * Omit to use the app's default placement.
  */
-export type NotificationPosition =
-  | 'top-left'
-  | 'top-center'
-  | 'top-right'
-  | 'bottom-left'
-  | 'bottom-center'
-  | 'bottom-right';
+export type NotificationPosition = (typeof NOTIFICATION_POSITIONS)[number];
 
 /** Data needed to display a notification to the user */
 export interface PlatformNotification {
@@ -65,14 +73,16 @@ export interface PlatformNotification {
    *
    * The command handler should have the type signature {@link NotificationClickCommandHandler}.
    *
-   * IMPORTANT: this fires ONLY for that user gesture. It does NOT fire when the notification is
-   * dismissed programmatically via {@link INotificationService.dismiss}, when it auto-closes because
-   * `duration` elapsed, or when the user clicks {@link clickCommand} / {@link secondaryClickCommand}
-   * (verified against the Sonner 1.7.4 source: `onDismiss` is invoked only from the swipe-release
-   * and close-button handlers, never from the programmatic-dismiss or auto-close paths). Use this
-   * to treat a user's swipe-away as an explicit decision — e.g. pairing it with a "postpone"
-   * command lets a two-button, must-answer-style toast still keep {@link dismissible} `true` (see
-   * the warning on {@link dismissible} for why `false` is usually the wrong tool for that).
+   * IMPORTANT: this fires when the user dismisses the notification themselves (swiping/dragging it
+   * away, or clicking a close button if the host ever enables one) AND when the notification
+   * auto-closes because its `duration` elapsed — a timeout is treated as an implicit dismissal, so
+   * a must-answer toast that times out still runs this command instead of vanishing silently. It
+   * does NOT fire when the notification is dismissed programmatically via
+   * {@link INotificationService.dismiss}, nor when the user clicks {@link clickCommand} /
+   * {@link secondaryClickCommand}. Use this to treat a swipe-away (or timeout) as an explicit
+   * decision — e.g. pairing it with a "postpone" command lets a two-button, must-answer-style toast
+   * keep {@link dismissible} `true` (see the warning on {@link dismissible}). If you need the toast
+   * to persist until the user actually answers, also set `duration` to `0`.
    */
   dismissClickCommand?: keyof CommandHandlers;
   /**
@@ -84,16 +94,24 @@ export interface PlatformNotification {
    * Whether the user can dismiss the notification directly (e.g. by swiping/dragging it away, or
    * via a close button). Defaults to `true`.
    *
-   * WARNING: the host toast library (Sonner) renders {@link secondaryClickCommandLabel} in the same
-   * slot it gates on this flag, so setting `dismissible: false` also disables the secondary action
-   * button (and the close button) — the secondary button will still render but silently do nothing
-   * when clicked. Only set this to `false` on a notification with no secondary action. For a
-   * notification the user must explicitly answer, prefer leaving `dismissible: true` and using
-   * {@link dismissClickCommand} so a swipe-away still counts as a real (e.g. "postpone") decision
-   * instead of a dead button.
+   * The host toast library (Sonner) gates both the {@link secondaryClickCommand} button and the
+   * user-dismiss gesture that fires {@link dismissClickCommand} on this same flag, so a naive
+   * `dismissible: false` would silently turn those controls into dead buttons. To prevent that, the
+   * platform IGNORES `dismissible: false` when a {@link secondaryClickCommand} or
+   * {@link dismissClickCommand} is also set — the notification stays user-dismissible so those
+   * controls keep working. `dismissible: false` therefore only takes effect on a notification with
+   * no secondary/dismiss command. For a notification the user must explicitly answer, prefer
+   * leaving `dismissible: true` and using {@link dismissClickCommand} so a swipe-away still counts
+   * as a real (e.g. "postpone") decision.
    */
   dismissible?: boolean;
-  /** Optional ID of a previous notification to update instead of showing a new notification */
+  /**
+   * Optional ID of a previous notification to update instead of showing a new notification.
+   *
+   * On an update (a `send` reusing an id that is still showing), any optional field you omit keeps
+   * the value it had on the previous `send` for that id — omitting a field never clears it. Pass
+   * the field explicitly to change it.
+   */
   notificationId?: string | number;
   /**
    * Optional duration in milliseconds for how long the notification is displayed. To make the

--- a/src/shared/models/notification.service-model.ts
+++ b/src/shared/models/notification.service-model.ts
@@ -3,6 +3,18 @@ import { LocalizeKey } from 'platform-bible-utils';
 
 export type Severity = 'info' | 'warning' | 'error';
 
+/**
+ * Where a notification is shown on screen. Mirrors the placements the host toast library supports.
+ * Omit to use the app's default placement.
+ */
+export type NotificationPosition =
+  | 'top-left'
+  | 'top-center'
+  | 'top-right'
+  | 'bottom-left'
+  | 'bottom-center'
+  | 'bottom-right';
+
 /** Data needed to display a notification to the user */
 export interface PlatformNotification {
   /**
@@ -28,6 +40,33 @@ export interface PlatformNotification {
    * The command handler should have the type signature {@link NotificationClickCommandHandler}.
    */
   clickCommand?: keyof CommandHandlers;
+  /**
+   * Optional label for a second action button, shown alongside {@link clickCommandLabel}. Provide
+   * this together with {@link secondaryClickCommand} to give the notification two actions.
+   *
+   * Automatically localized if this is a {@link LocalizeKey}.
+   */
+  secondaryClickCommandLabel?: string | LocalizeKey;
+  /**
+   * Optional command to run if users click on the secondary label in the notification. Like
+   * {@link clickCommand}, the command is sent one argument:
+   *
+   * - NotificationId: The ID of the notification that was clicked
+   *
+   * The command handler should have the type signature {@link NotificationClickCommandHandler}.
+   */
+  secondaryClickCommand?: keyof CommandHandlers;
+  /**
+   * Optional placement of the notification on screen. When omitted, the app's default placement is
+   * used.
+   */
+  position?: NotificationPosition;
+  /**
+   * Whether the user can dismiss the notification directly (e.g. by swiping/dragging it away).
+   * Defaults to `true`. Set to `false` for a notification that must be acknowledged through one of
+   * its action buttons — combine with a `duration` of `0` or less to keep it up until then.
+   */
+  dismissible?: boolean;
   /** Optional ID of a previous notification to update instead of showing a new notification */
   notificationId?: string | number;
   /**

--- a/src/shared/models/notification.service-model.ts
+++ b/src/shared/models/notification.service-model.ts
@@ -73,7 +73,7 @@ export interface PlatformNotification {
    */
   secondaryClickCommand?: keyof CommandHandlers;
   /**
-   * Optional command to run if the user dismisses the notification themselves — by swiping/dragging
+   * Optional command to run if the user dismisses the notification themselves - by swiping/dragging
    * it away, or by clicking the close button (if the host ever enables one). Sent no arguments
    * other than the notification id, like {@link clickCommand}:
    *
@@ -83,12 +83,12 @@ export interface PlatformNotification {
    *
    * IMPORTANT: this fires when the user dismisses the notification themselves (swiping/dragging it
    * away, or clicking a close button if the host ever enables one) AND when the notification
-   * auto-closes because its `duration` elapsed — a timeout is treated as an implicit dismissal, so
+   * auto-closes because its `duration` elapsed - a timeout is treated as an implicit dismissal, so
    * a must-answer toast that times out still runs this command instead of vanishing silently. It
    * does NOT fire when the notification is dismissed programmatically via
    * {@link INotificationService.dismiss}, nor when the user clicks {@link clickCommand} /
    * {@link secondaryClickCommand}. Use this to treat a swipe-away (or timeout) as an explicit
-   * decision — e.g. pairing it with a "postpone" command lets a two-button, must-answer-style toast
+   * decision - e.g. pairing it with a "postpone" command lets a two-button, must-answer-style toast
    * keep {@link dismissible} `true` (see the warning on {@link dismissible}). If you need the toast
    * to persist until the user actually answers, also set `duration` to `0`.
    *
@@ -109,12 +109,19 @@ export interface PlatformNotification {
    * The host toast library (Sonner) gates both the {@link secondaryClickCommand} button and the
    * user-dismiss gesture that fires {@link dismissClickCommand} on this same flag, so a naive
    * `dismissible: false` would silently turn those controls into dead buttons. To prevent that, the
-   * platform IGNORES `dismissible: false` when a {@link secondaryClickCommand} or
-   * {@link dismissClickCommand} is also set — the notification stays user-dismissible so those
-   * controls keep working. `dismissible: false` therefore only takes effect on a notification with
-   * no secondary/dismiss command. For a notification the user must explicitly answer, prefer
+   * platform IGNORES `dismissible: false` when the notification renders a secondary action button
+   * (a {@link secondaryClickCommand} paired with its {@link secondaryClickCommandLabel}) or has a
+   * {@link dismissClickCommand} - the notification stays user-dismissible so those controls keep
+   * working. `dismissible: false` therefore only takes effect on a notification with no secondary
+   * button and no dismiss command. For a notification the user must explicitly answer, prefer
    * leaving `dismissible: true` and using {@link dismissClickCommand} so a swipe-away still counts
    * as a real (e.g. "postpone") decision.
+   *
+   * NOTE: `dismissible: false` does not keep the notification on screen. Auto-close is governed
+   * solely by `duration` (when omitted, 10-35 seconds computed from message length), so a
+   * non-dismissible notification still auto-closes on that timer. Also set `duration` to `0` (or
+   * less) if the notification must stay up until it is answered or programmatically dismissed via
+   * {@link INotificationService.dismiss}.
    *
    * @experimental
    */
@@ -123,7 +130,7 @@ export interface PlatformNotification {
    * Optional ID of a previous notification to update instead of showing a new notification.
    *
    * On an update (a `send` reusing an id that is still showing), any optional field you omit keeps
-   * the value it had on the previous `send` for that id — omitting a field never clears it. Pass
+   * the value it had on the previous `send` for that id - omitting a field never clears it. Pass
    * the field explicitly to change it.
    */
   notificationId?: string | number;

--- a/src/shared/models/notification.service-model.ts
+++ b/src/shared/models/notification.service-model.ts
@@ -57,14 +57,40 @@ export interface PlatformNotification {
    */
   secondaryClickCommand?: keyof CommandHandlers;
   /**
+   * Optional command to run if the user dismisses the notification themselves — by swiping/dragging
+   * it away, or by clicking the close button (if the host ever enables one). Sent no arguments
+   * other than the notification id, like {@link clickCommand}:
+   *
+   * - NotificationId: The ID of the notification that was dismissed
+   *
+   * The command handler should have the type signature {@link NotificationClickCommandHandler}.
+   *
+   * IMPORTANT: this fires ONLY for that user gesture. It does NOT fire when the notification is
+   * dismissed programmatically via {@link INotificationService.dismiss}, when it auto-closes because
+   * `duration` elapsed, or when the user clicks {@link clickCommand} / {@link secondaryClickCommand}
+   * (verified against the Sonner 1.7.4 source: `onDismiss` is invoked only from the swipe-release
+   * and close-button handlers, never from the programmatic-dismiss or auto-close paths). Use this
+   * to treat a user's swipe-away as an explicit decision — e.g. pairing it with a "postpone"
+   * command lets a two-button, must-answer-style toast still keep {@link dismissible} `true` (see
+   * the warning on {@link dismissible} for why `false` is usually the wrong tool for that).
+   */
+  dismissClickCommand?: keyof CommandHandlers;
+  /**
    * Optional placement of the notification on screen. When omitted, the app's default placement is
    * used.
    */
   position?: NotificationPosition;
   /**
-   * Whether the user can dismiss the notification directly (e.g. by swiping/dragging it away).
-   * Defaults to `true`. Set to `false` for a notification that must be acknowledged through one of
-   * its action buttons — combine with a `duration` of `0` or less to keep it up until then.
+   * Whether the user can dismiss the notification directly (e.g. by swiping/dragging it away, or
+   * via a close button). Defaults to `true`.
+   *
+   * WARNING: the host toast library (Sonner) renders {@link secondaryClickCommandLabel} in the same
+   * slot it gates on this flag, so setting `dismissible: false` also disables the secondary action
+   * button (and the close button) — the secondary button will still render but silently do nothing
+   * when clicked. Only set this to `false` on a notification with no secondary action. For a
+   * notification the user must explicitly answer, prefer leaving `dismissible: true` and using
+   * {@link dismissClickCommand} so a swipe-away still counts as a real (e.g. "postpone") decision
+   * instead of a dead button.
    */
   dismissible?: boolean;
   /** Optional ID of a previous notification to update instead of showing a new notification */

--- a/src/shared/services/__mocks__/logger.service.ts
+++ b/src/shared/services/__mocks__/logger.service.ts
@@ -6,4 +6,5 @@ export const logger = {
   info: () => {},
   warn: () => {},
   error: () => {},
+  debug: () => {},
 };

--- a/src/stories/keyboard-shortcuts.data.ts
+++ b/src/stories/keyboard-shortcuts.data.ts
@@ -125,6 +125,16 @@ export const rootKeyboardShortcuts: KeyboardShortcutEntry[] = [
     locations: ['src/main/main.ts', 'src/main/reference-history-keyboard.util.ts'],
   },
   {
+    id: 'focus-notification-toasts',
+    purpose: 'Focus the notification toasts, cycling across position groups on repeated presses',
+    category: 'Navigation',
+    context: 'Renderer (global)',
+    // Sonner's built-in Toaster hotkey and NotificationDisplay's focus-cycling handler share this
+    // combo (NOTIFICATION_TOASTER_HOTKEY) - they must not drift apart.
+    keys: { macOS: '⌥T', windows: 'Alt+T', linux: 'Alt+T' },
+    locations: ['src/renderer/components/notification-display.tsx'],
+  },
+  {
     id: 'zoom-in',
     purpose: 'Zoom in',
     category: 'Zoom',


### PR DESCRIPTION
## What

Adds four additive, backward-compatible optional fields to `PlatformNotification` so an extension can raise a two-button, specifically-placed, must-answer toast:

- `secondaryClickCommandLabel` / `secondaryClickCommand` — a second action, mapped to Sonner's `cancel` slot alongside the existing `action`. Both send the notification id as the command's single argument (no new args plumbing — the model still carries no command args).
- `position` — a per-toast placement (`NotificationPosition`, e.g. `'top-center'`), passed straight through to Sonner; `undefined` keeps the `Toaster`'s default.
- `dismissible` — passed through to Sonner; set `false` (with `duration: 0`) for a toast the user must answer via an action button rather than swipe/drag away.

Wired through `notification.service-host.ts` (the existing `action` block gains a parallel `cancel` block; `position` and `dismissible` go straight into `toastOptions`) and the OpenRPC schema; `papi.d.ts` regenerated via `npm run build:types`.

## Why

This is the reusable platform capability the scheduled Send/Receive **consent toast** (PT-4193, extension side) needs: a persistent top-center prompt with "Send/Receive now" / "Postpone" buttons the user must answer. `dismissible: false` matters — Sonner 1.7.4 defaults to swipe-to-dismiss, which for a toast an extension `await`s a decision on would otherwise let an accidental drag strand the waiting code.

Decision record: PT-4158 UX meeting 2026-07-15 (Q1 = option B); PT-4193 ticket comment 27495.

## Back-compat

All four fields are optional. When omitted, `cancel`, `position`, and `dismissible` are `undefined`, so existing single-action / default-placement toasts are unchanged (Sonner treats explicit `undefined` as absent). No private code — this is public scaffolding; the private consent gate lives in the extension.

## Tests

`notification.service-host.test.ts` +4 cases: `cancel` built from the secondary fields; `position` forwarded; `dismissible` forwarded; all three `undefined` by default. `npx vitest run src/renderer/services/notification.service-host.test.ts` → 9/9. Targeted eslint clean; `typecheck:core` adds nothing over the pre-existing baseline (one unrelated missing-`buildInfo.json` error).

## Review fix (PT-4193): the `dismissible: false` cancel-slot trap

Review flagged a BLOCKER, verified against the Sonner 1.7.4 source (`node_modules/sonner/dist/index.mjs`): Sonner computes `V = toast.dismissible !== false` and gates the **cancel-slot** (our `secondaryClickCommand`) button's `onClick` on `V`, but does **not** gate the `action` button the same way:

```js
// cancel button: onClick: r => { tt(t.cancel) && V && ((t.cancel.onClick)?.(r), $()) }        // gated on V
// action button:  onClick: r => { tt(t.action) && ((t.action.onClick)?.(r), !r.defaultPrevented && $()) } // NOT gated
```

So `dismissible: false` combined with a `secondaryClickCommand` produced a **dead secondary button** — no command fires, no dismiss happens, silently. The consuming consent toast (extension PR #183) uses exactly that combination, and this PR's own original JSDoc on `dismissible` recommended it ("set to `false` … combine with `duration: 0`" for an awaited decision) — i.e. the doc was steering callers straight at the trap. Sonner has only one ungated button slot (`action`), so a toast with two *working* buttons must keep `dismissible: true`.

**Fix — swipe-dismiss becomes a first-class exit:**

- Added `dismissClickCommand?: keyof CommandHandlers` to `PlatformNotification`: a parameterless-besides-the-notification-id command invoked when the *user* dismisses the toast (swipe/drag past Sonner's threshold, or a close button if one is ever enabled). Mapped in `notification.service-host.ts` to Sonner's `onDismiss` option, with a `.catch` → `logger.warn` so a rejected command handler can't become an unhandled rejection.
- **Verified against the Sonner source which paths call `onDismiss`:** only the swipe-release handler (`onPointerUp`, gated on the same `dismissible` flag) and the close-button `onClick` (also gated, and disabled by default since this app doesn't pass `closeButton` to `<Toaster />`) call it. Programmatic dismissal (`INotificationService.dismiss()` → `toast.dismiss(id)`) marks the toast `delete: true`, which only triggers the internal removal animation — it does **not** call `onDismiss`. Auto-close when `duration` elapses calls a *different* callback (`onAutoClose`), also not `onDismiss`. This is documented on the new field so consumers awaiting a decision know a programmatic `dismiss()` call will *not* trigger it.
- Rewrote the `dismissible` JSDoc: removed the "combine with `duration: 0`" recommendation that steered callers into the trap; added a warning that `dismissible: false` also disables the secondary/cancel button (and the close button), so it's only safe on a notification with no secondary action. Points callers at `dismissClickCommand` + `dismissible: true` for the "must answer" case instead.
- Same-review hardening: added a matching `.catch` → `logger.warn` on the secondary button's `sendCommand` call (it previously had none, unlike the primary path's now-consistent handling); constrained the OpenRPC schema's `position` property with an `enum` of the six `NotificationPosition` values (was a bare `type: 'string'`).
- Regenerated `papi.d.ts`; the diff touches only the `notification.service-model` module.

**Tests:** extended `notification.service-host.test.ts` from 9 to 13 cases — added the `onDismiss` mapping, both new `.catch`-swallows-rejection-and-logs paths (secondary click, dismiss click), and broadened the back-compat case to also assert `onDismiss: undefined`. Also added `notification-display.test.tsx` (1 test) — the **one** test in this suite that renders the real `<Toaster />` with real Sonner (every other case here mocks `sonner` wholesale, which is exactly why this blocker shipped undetected): it sends a toast with a secondary command and `dismissible` left at its default `true`, clicks the actual rendered cancel-slot DOM button, and asserts the secondary command was sent — pinning the real Sonner button-gating contract instead of just the shape we hand it. 14/14 green across both files; targeted eslint clean; `typecheck:core` still adds nothing over the pre-existing baseline.

**Contract note for the consumer:** extension PR #183 will drop `dismissible: false` and set `dismissClickCommand` to a "postpone" command, keeping `dismissible: true`.

**Follow-up fix (PT-4193, `938749040d7`):** a live E2E screenshot showed a two-button toast (action + cancel, both long labels) with the message text crushed to a ~1-character-wide sliver — Sonner's default layout puts icon/content/cancel/action in one un-wrapped flex row, and two non-shrinking buttons squeeze the content column to nothing. Fixed with CSS only, scoped via `:has()` so single-button/plain toasts are unaffected: `notification-display.tsx` now wires the `Toaster`'s `toastOptions.classNames` (verified against Sonner 1.7.4's `index.d.ts`) onto toast/content/actionButton/cancelButton, and the new `notification-display.scss` grows the content row to fill the toast and forces the two buttons onto their own row beneath it (via the standard flex-wrap "empty `flex-basis: 100%` item" line-break technique), right-aligned and RTL-safe for free via Sonner's existing auto-margin CSS. Extended `notification-display.test.tsx` from 1 to 4 cases pinning the DOM shape the stylesheet rule depends on (two-button toasts get all three class hooks under one shared flex-container ancestor with both buttons still working; single-button/plain toasts don't). 17/17 across the notification suite, 979/979 full core suite; targeted eslint + stylelint clean; `typecheck:core` and `papi.d.ts` unchanged.

**Follow-up fix (PT-4193, `5a4b763af4e`):** live E2E testing of Send/Receive surfaced an orphaned "Syncing (0%)" toast that never went away — a sync abort's `dismiss(notificationId)` clears the toast-id mapping, but an in-flight, fire-and-forget progress `send()` for that same id can land just after, find no mapping, and resurrect a brand-new toast that nothing then dismisses. Fixed with a short (5s) grace window: `dismiss()` now remembers each notificationId briefly after dismissing it, and `send()` drops an update-style send (an explicit, existing notificationId) that falls within that window instead of creating a new toast, logging a debug line. Brand-new notifications (no id passed) are never affected, and legitimately reusing an id after the window elapses still works normally; entries are pruned lazily on `send()`/`dismiss()` — no timers. Extended `notification.service-host.test.ts` with 3 cases (drop-on-race + debug log, post-grace-window reuse via fake timers, id-less send unaffected) — 20/20 green across the notification suite; targeted eslint clean; `typecheck:core` and `papi.d.ts` unchanged.

**Rebase note (2026-07-16):** rebased onto main after #2555 merged. No conflicts — the `papi.d.ts` auto-merge (both sides had regenerated it) was verified by re-running `npm run build:types` post-rebase: zero drift, so the committed file is exactly the machine-generated output. Notification suites 20/20, targeted eslint + stylelint clean. New tip: `43d761546d7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



---

## Fix round — 2026-07-17 (response to lyonsil's review)

All 30 findings addressed at tip `1e2a99c` (three commits):

- `a0cd67c` — **grace window deleted** (findings 1, 5, 6, 7, 8, 16, 18, 22, 29; moots 24, 30). `dismiss()` is a true no-op when absent again; `send()` has no silent-drop path.
- `14dc10b` — **toast CSS reworked + keyboard reach** (findings 2, 3, 4, 15, 23, 26): inert `::after`/`flex-wrap`/`block-size:0` overrides removed; deterministic two-row layout scoped to two-button toasts; hover bridge untouched; Alt+T now focus-cycles across every position list. Known residual: **Escape** still targets only Sonner's last list (cosmetic — Escape doesn't dismiss; the top-center group holds a single toast). Say the word if Escape parity is wanted as a follow-up.
- `1e2a99c` — **service hardening** (findings 9, 10, 11, 12, 13, 14, 17, 19, 20, 21, 25, 27, 28): update-merge keeps omitted fields (documented: no unset-on-update), `onAutoClose` wired, `dismissible:false` no longer silently kills the dismiss command, shared removal-command helper with `.catch` by construction, parallel localization, namespaced auto-ids, `!== undefined` id checks, derived position values.
- `579bbfd` — **round-4 E2E finding F3**: the break-lock toast (long warning + single wide "Break lock and retry" action button, no cancel) still rendered text and button crammed side-by-side — the two-row reflow only engaged when BOTH buttons were present; the `:has()` rule now matches either button class so any buttoned toast reflows (lone buttons stay right-aligned via a pair-only margin override), +1 real-Sonner render test pinning the single-action DOM shape.
- `0a566bf` — **press-collapse fix** (credit: Sebastian's triage): holding any mouse button down on a buttoned toast collapsed it to a one-character sliver until release — Sonner sets `data-swiping="true"` on pointerdown before any movement, and the button-row `::before` break was gated out of that state while `flex-wrap`/`flex-basis: 0` stayed active. The break is now unconditional with an explicit `position: static`, out-winning Sonner's zero-specificity `:where()` swipe/removal `::before` styles, so the two-row layout is stable through press, swipe, and removal (the `::after` hover-bridge stays untouched); +1 real-Sonner render test pinning that a plain press (either button) enters the swiping state with the layout hooks intact.

**Merge pairing:** this PR and paratext-10-studio#163 should land in the same release window — the producer-side `_syncGeneration` guard (reworked on #163's branch) is now the protection for the S/R dismiss race. **paratext-bible-internal-extensions#186 must not merge before this PR** (its consent/lock toasts depend on `position`/`dismissible`/secondary-action fields).

Pending manual verification (needs a real browser; jsdom can't model Sonner's focus-trap): Alt+T cycling with a top-center consent toast + bottom-right toast present; the break-lock fast re-send flow (now un-broken by the window deletion).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2561)
<!-- Reviewable:end -->




