### PR TITLE
PT-4159: Rebuild S/R write gate without thread affinity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,13 +172,12 @@ armed/queued automatic Send/Receive rejects the write fail-fast (the `(SR_EDIT_B
 while a starting sync waits, bounded, for open write scopes to drain before it replaces files on
 disk.
 
-The gated method MUST hold that scope **synchronously**: no `await` or `Task.Run` between
-`EnterWrite` and its dispose. The lock is a thread-affine `ReaderWriterLockSlim`, so the read lock
-must be released on the very thread that took it — an `await` could resume on a different pool thread
-and release a lock it never held. (Several gated methods are named `...Async` but are synchronous
-today; if one ever needs real asynchrony, `await` OUTSIDE the scope, never across it.) The same
-single-thread rule applies to the sync side: `SetSyncing`/`Clear` must be called on one thread for
-the whole arm→clear bracket.
+The gate has **no thread affinity** (its state is a single atomic word — an armed flag plus an
+in-flight write count — not an OS lock): a scope may be disposed on a different thread, holding one
+across an `await` is safe, nested `EnterWrite` calls are benign, and `SetSyncing`/`Clear` may run on
+any threads (`Clear` is idempotent and doubles as crash recovery). Still, keep scopes **tight** —
+the mutation and nothing else — because every open scope delays a starting sync's bounded drain
+toward its timeout.
 
 This is an **in-process** gate, distinct from the S/R server-side repository lock
 (`lockrepo`/`unlockrepo` between clients) — do not conflate the two. `SendReceiveWriteLockCoverageTests`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,16 +168,20 @@ Any new C# code path that **mutates project data** (`ScrText` writes — `PutTex
 extension data) MUST wrap the mutation in `using var _ = SendReceiveWriteLock.EnterWrite(projectId);`
 as the first statement of its entry-point method (see
 `c-sharp/Projects/SendReceive/SendReceiveWriteLock.cs`). The gate works in both directions: an
-armed/queued automatic Send/Receive rejects the write fail-fast (the `(SR_EDIT_BLOCKED)` sentinel),
+armed automatic Send/Receive rejects the write fail-fast (the `(SR_EDIT_BLOCKED)` sentinel),
 while a starting sync waits, bounded, for open write scopes to drain before it replaces files on
 disk.
 
-The gate has **no thread affinity** (its state is a single atomic word — an armed flag plus an
-in-flight write count — not an OS lock): a scope may be disposed on a different thread, holding one
-across an `await` is safe, nested `EnterWrite` calls are benign, and `SetSyncing`/`Clear` may run on
-any threads (`Clear` is idempotent and doubles as crash recovery). Still, keep scopes **tight** —
-the mutation and nothing else — because every open scope delays a starting sync's bounded drain
-toward its timeout.
+The gate has **no thread affinity** (its state is a single atomic word — an armed flag, an
+in-flight write count, and an arm generation — not an OS lock): a scope may be disposed on a
+different thread, holding one across an `await` is safe, and `SetSyncing`/`Clear` may run on any
+threads. `SetSyncing` returns a token; end the bracket with `Clear(token)` (a stale token is a
+logged no-op, so a late Clear can never disarm a newer sync) and keep parameterless `Clear()` for
+crash recovery — it force-disarms unconditionally and is idempotent. Nested `EnterWrite` calls do
+not crash, but they are NOT safe: if a sync arms while the outer scope is open, the inner call
+throws the sentinel mid-mutation — keep one scope per mutation (delegate to an un-gated core
+inside a single scope, as `SetBookUsfmInScope` does). Keep scopes **tight** — the mutation and
+nothing else — because every open scope delays a starting sync's bounded drain toward its timeout.
 
 This is an **in-process** gate, distinct from the S/R server-side repository lock
 (`lockrepo`/`unlockrepo` between clients) — do not conflate the two. `SendReceiveWriteLockCoverageTests`

--- a/c-sharp-tests/Projects/SendReceiveWriteLockTests.cs
+++ b/c-sharp-tests/Projects/SendReceiveWriteLockTests.cs
@@ -14,18 +14,19 @@ namespace TestParanextDataProvider.Projects
 {
     /// <summary>
     /// Unit tests for the process-wide <see cref="SendReceiveWriteLock"/> write-gate. Every test
-    /// clears the (static) gate before and after so state never leaks between tests or to other
-    /// fixtures. The fixture runs single-threaded (no NUnit parallelism), so the shared static lock is
-    /// never touched concurrently across tests.
+    /// fully resets the (static) gate before and after — including the in-flight count, which a
+    /// production <c>Clear</c> deliberately leaves alone — so a test that leaks a scope cannot
+    /// poison later tests with full-DrainTimeout drains. The fixture runs single-threaded (no
+    /// NUnit parallelism), so the shared static gate is never touched concurrently across tests.
     /// </summary>
     [ExcludeFromCodeCoverage]
     internal class SendReceiveWriteLockTests
     {
         [SetUp]
-        public void SetUp() => SendReceiveWriteLock.Clear();
+        public void SetUp() => SendReceiveWriteLock.ResetForTests();
 
         [TearDown]
-        public void TearDown() => SendReceiveWriteLock.Clear();
+        public void TearDown() => SendReceiveWriteLock.ResetForTests();
 
         // ---- IsBlocked (pure per-project data) ----
 
@@ -106,30 +107,37 @@ namespace TestParanextDataProvider.Projects
         {
             var scope = SendReceiveWriteLock.EnterWrite("projectA");
             Assert.That(scope, Is.Not.Null);
+            Assert.That(SendReceiveWriteLock.InFlightWriteCount, Is.EqualTo(1));
 
             scope.Dispose();
 
-            // Re-entering proves the in-flight write was released on dispose.
-            Assert.DoesNotThrow(() =>
-            {
-                using var _ = SendReceiveWriteLock.EnterWrite("projectA");
-            });
+            // The count — the exact value a sync's drain waits on — proves the release.
+            // (Re-entering would prove nothing: EnterWrite only consults the armed flag.)
+            Assert.That(
+                SendReceiveWriteLock.InFlightWriteCount,
+                Is.Zero,
+                "dispose must release the in-flight write"
+            );
         }
 
         [Test]
         public void EnterWrite_DoubleDispose_IsSafe()
         {
+            // Hold a SECOND scope open so a broken double-dispose (decrementing twice) shows up in
+            // the count instead of being absorbed by the underflow guard at count zero.
             var scope = SendReceiveWriteLock.EnterWrite("projectA");
+            using var otherScope = SendReceiveWriteLock.EnterWrite("projectB");
+            Assert.That(SendReceiveWriteLock.InFlightWriteCount, Is.EqualTo(2));
+
             scope.Dispose();
 
             // Second dispose must be a no-op (never decrement the in-flight count twice).
             Assert.DoesNotThrow(scope.Dispose);
-
-            // The scope is fully released — a fresh scope still works.
-            Assert.DoesNotThrow(() =>
-            {
-                using var _ = SendReceiveWriteLock.EnterWrite("projectA");
-            });
+            Assert.That(
+                SendReceiveWriteLock.InFlightWriteCount,
+                Is.EqualTo(1),
+                "the second dispose must not release the OTHER scope's in-flight count"
+            );
         }
 
         [Test]
@@ -179,15 +187,42 @@ namespace TestParanextDataProvider.Projects
         [Test]
         public void EnterWrite_NestedOnSameThread_BothScopesSucceed()
         {
-            // A gated method that (directly or via refactor) calls another gated method must not
-            // crash: the gate is re-entrant, because the outer scope already provides the
-            // sync-exclusion guarantee the inner one would.
+            // While nothing is armed, a nested EnterWrite must not crash or deadlock (there is no
+            // recursion policy) — the inner scope just counts as one more in-flight write. See
+            // EnterWrite_NestedWhileSyncArmed_InnerThrowsSentinel for why nesting is still NOT a
+            // safe pattern around a live sync.
             using var outer = SendReceiveWriteLock.EnterWrite("projectA");
 
             Assert.DoesNotThrow(() =>
             {
                 using var inner = SendReceiveWriteLock.EnterWrite("projectB");
             });
+        }
+
+        [Test]
+        public void EnterWrite_NestedWhileSyncArmed_InnerThrowsSentinel()
+        {
+            // Pins the nesting hazard the docs warn about: the gate tracks no ownership, so once a
+            // sync arms — here on the degraded path, since the outer scope on this thread can
+            // never drain — a nested EnterWrite inside an open outer scope is rejected
+            // MID-mutation. This is why delegating methods must call an un-gated core inside one
+            // scope (see SetBookUsfmInScope) instead of nesting gated entry points.
+            var previousTimeout = SendReceiveWriteLock.DrainTimeout;
+            SendReceiveWriteLock.DrainTimeout = TimeSpan.FromMilliseconds(50);
+            try
+            {
+                using var outer = SendReceiveWriteLock.EnterWrite("projectA");
+                SendReceiveWriteLock.SetSyncing(["projectA"]); // degrades: outer cannot drain
+
+                var ex = Assert.Throws<InvalidOperationException>(
+                    () => SendReceiveWriteLock.EnterWrite("projectB")
+                );
+                Assert.That(ex!.Message, Does.EndWith(SendReceiveWriteLock.EditBlockedSentinel));
+            }
+            finally
+            {
+                SendReceiveWriteLock.DrainTimeout = previousTimeout;
+            }
         }
 
         [Test]
@@ -208,6 +243,11 @@ namespace TestParanextDataProvider.Projects
                 "worker should finish arming"
             );
 
+            // Assert the premise before acting on it: the worker's arm must be observable from
+            // this thread, or the disarm assertions below would pass vacuously.
+            Assert.That(SendReceiveWriteLock.IsArmed, Is.True, "the worker's arm must be visible");
+            Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.True);
+
             Assert.DoesNotThrow(SendReceiveWriteLock.Clear);
 
             Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.False);
@@ -226,9 +266,15 @@ namespace TestParanextDataProvider.Projects
             var scope = SendReceiveWriteLock.EnterWrite("projectA");
 
             var disposeTask = Task.Run(scope.Dispose);
-            Assert.DoesNotThrow(
-                () => disposeTask.Wait(TimeSpan.FromSeconds(10)),
-                "disposing on another thread must release cleanly"
+            Assert.That(
+                disposeTask.Wait(TimeSpan.FromSeconds(10)),
+                Is.True,
+                "disposing on another thread must complete promptly"
+            );
+            Assert.That(
+                SendReceiveWriteLock.InFlightWriteCount,
+                Is.Zero,
+                "the cross-thread dispose must have released the in-flight write"
             );
 
             var stopwatch = Stopwatch.StartNew();
@@ -252,8 +298,14 @@ namespace TestParanextDataProvider.Projects
 
             Assert.Multiple(() =>
             {
+                // Assert on the stored set itself: IsBlocked("") could never return true (its own
+                // null/empty guard short-circuits), so it cannot falsify the ignore-filter.
+                Assert.That(
+                    SendReceiveWriteLock.ArmedProjectIds,
+                    Is.EquivalentTo(new[] { "projectA" }),
+                    "only the valid id may enter the armed set"
+                );
                 Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.True);
-                Assert.That(SendReceiveWriteLock.IsBlocked(""), Is.False);
             });
 
             SendReceiveWriteLock.Clear();
@@ -378,6 +430,71 @@ namespace TestParanextDataProvider.Projects
         }
 
         [Test]
+        public void SetSyncing_DrainTimesOut_WithThrowOption_RollsBackArmAndThrows()
+        {
+            var previousTimeout = SendReceiveWriteLock.DrainTimeout;
+            SendReceiveWriteLock.DrainTimeout = TimeSpan.FromMilliseconds(300);
+            var opened = new ManualResetEventSlim(false);
+            var release = new ManualResetEventSlim(false);
+            Task? stuck = null;
+            try
+            {
+                stuck = Task.Run(() =>
+                {
+                    using var scope = SendReceiveWriteLock.EnterWrite("projectA");
+                    opened.Set();
+                    release.Wait(TimeSpan.FromSeconds(15));
+                });
+                Assert.That(opened.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+                // Opting into throw-on-timeout aborts the sync start instead of degrading...
+                Assert.Throws<TimeoutException>(
+                    () => SendReceiveWriteLock.SetSyncing(["projectA"], throwOnDrainTimeout: true)
+                );
+
+                // ...and the throw means "arm rolled back, no cleanup owed": nothing stays armed,
+                // writes flow again, and the stuck write's own count is untouched.
+                Assert.Multiple(() =>
+                {
+                    Assert.That(SendReceiveWriteLock.IsArmed, Is.False, "the arm must roll back");
+                    Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.False);
+                    Assert.That(SendReceiveWriteLock.InFlightWriteCount, Is.EqualTo(1));
+                    Assert.DoesNotThrow(() =>
+                    {
+                        using var _ = SendReceiveWriteLock.EnterWrite("projectA");
+                    });
+                });
+            }
+            finally
+            {
+                release.Set();
+                stuck?.Wait(TimeSpan.FromSeconds(10));
+                SendReceiveWriteLock.DrainTimeout = previousTimeout;
+            }
+        }
+
+        [Test]
+        public void SetSyncing_CleanDrain_WithThrowOption_ArmsNormally()
+        {
+            // The throw option changes ONLY the drain-timeout outcome: with nothing in flight the
+            // call must arm and return a usable token exactly like the default path.
+            long token = 0;
+            Assert.DoesNotThrow(
+                () =>
+                    token = SendReceiveWriteLock.SetSyncing(["projectA"], throwOnDrainTimeout: true)
+            );
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(SendReceiveWriteLock.IsArmed, Is.True);
+                Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.True);
+            });
+
+            SendReceiveWriteLock.Clear(token);
+            Assert.That(SendReceiveWriteLock.IsArmed, Is.False);
+        }
+
+        [Test]
         public void Clear_WhileAWriteIsStillStuck_RecoversNewWritesImmediately()
         {
             // Recovery must not depend on the stuck write ever completing: Clear disarms the gate,
@@ -404,6 +521,20 @@ namespace TestParanextDataProvider.Projects
                 {
                     using var _ = SendReceiveWriteLock.EnterWrite("projectA");
                 });
+
+                // The third clause of the recovery contract: the straggler's eventual dispose must
+                // land as its own harmless decrement (not vanish, not eat another scope's count).
+                release.Set();
+                Assert.That(
+                    stuck.Wait(TimeSpan.FromSeconds(10)),
+                    Is.True,
+                    "the straggler should finish once released"
+                );
+                Assert.That(
+                    SendReceiveWriteLock.InFlightWriteCount,
+                    Is.Zero,
+                    "the straggler's dispose after Clear must release its own in-flight count"
+                );
             }
             finally
             {
@@ -411,6 +542,100 @@ namespace TestParanextDataProvider.Projects
                 stuck?.Wait(TimeSpan.FromSeconds(10));
                 SendReceiveWriteLock.DrainTimeout = previousTimeout;
                 SendReceiveWriteLock.Clear();
+            }
+        }
+
+        // ---- Clear(token): stale-bracket protection ----
+
+        [Test]
+        public void ClearWithToken_CurrentBracket_Disarms()
+        {
+            var token = SendReceiveWriteLock.SetSyncing(["projectA"]);
+
+            SendReceiveWriteLock.Clear(token);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(SendReceiveWriteLock.IsArmed, Is.False);
+                Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.False);
+            });
+        }
+
+        [Test]
+        public void ClearWithToken_StaleAfterNewerSetSyncing_DoesNotDisarmTheNewerSync()
+        {
+            // Sync A ends late: its Clear(tokenA) must be a logged no-op once sync B owns the
+            // slot, instead of silently disarming the gate in the middle of B's run.
+            var tokenA = SendReceiveWriteLock.SetSyncing(["projectA"]);
+            var tokenB = SendReceiveWriteLock.SetSyncing(["projectB"]);
+
+            SendReceiveWriteLock.Clear(tokenA);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(SendReceiveWriteLock.IsArmed, Is.True, "sync B must stay armed");
+                Assert.That(SendReceiveWriteLock.IsBlocked("projectB"), Is.True);
+            });
+
+            SendReceiveWriteLock.Clear(tokenB);
+            Assert.That(SendReceiveWriteLock.IsArmed, Is.False);
+        }
+
+        [Test]
+        public void ClearWithToken_WhenAlreadyCleared_IsSafeNoOp()
+        {
+            var token = SendReceiveWriteLock.SetSyncing(["projectA"]);
+            SendReceiveWriteLock.Clear(token);
+
+            // A duplicate bracket-end (e.g. a finally after an explicit Clear) must stay a no-op.
+            Assert.DoesNotThrow(() => SendReceiveWriteLock.Clear(token));
+            Assert.That(SendReceiveWriteLock.IsArmed, Is.False);
+        }
+
+        [Test]
+        public void SetSyncing_ClearedMidDrain_ReturnsPromptlyInsteadOfBurningTheTimeout()
+        {
+            // A Clear that lands while SetSyncing is still draining removes the drain's premise
+            // (the gate is disarmed, so writes may enter again and the count may never settle).
+            // The drain must notice the disarm and return promptly instead of spinning out its
+            // full DrainTimeout — here the DEFAULT 10s timeout, so a prompt return is clearly
+            // distinguishable from a burned timeout.
+            var opened = new ManualResetEventSlim(false);
+            var release = new ManualResetEventSlim(false);
+            Task? stuck = null;
+            Task? sync = null;
+            try
+            {
+                // A stuck write pins the count so the drain cannot finish on its own.
+                stuck = Task.Run(() =>
+                {
+                    using var scope = SendReceiveWriteLock.EnterWrite("projectA");
+                    opened.Set();
+                    release.Wait(TimeSpan.FromSeconds(15));
+                });
+                Assert.That(opened.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+                sync = Task.Run(() => SendReceiveWriteLock.SetSyncing(["projectA"]));
+                Assert.That(
+                    SpinWait.SpinUntil(() => SendReceiveWriteLock.IsArmed, TimeSpan.FromSeconds(5)),
+                    Is.True,
+                    "SetSyncing should arm before draining"
+                );
+
+                SendReceiveWriteLock.Clear();
+
+                Assert.That(
+                    sync.Wait(TimeSpan.FromSeconds(3)),
+                    Is.True,
+                    "a Clear during the drain must end the wait promptly, not burn the full DrainTimeout"
+                );
+                Assert.That(SendReceiveWriteLock.IsArmed, Is.False);
+            }
+            finally
+            {
+                release.Set();
+                stuck?.Wait(TimeSpan.FromSeconds(10));
+                sync?.Wait(TimeSpan.FromSeconds(15));
             }
         }
 
@@ -465,9 +690,10 @@ namespace TestParanextDataProvider.Projects
         /// Hammers <see cref="SendReceiveWriteLock.EnterWrite"/> from several threads while a "sync"
         /// repeatedly arms (draining in-flight writes), simulates a file-replacement window, and
         /// clears. Asserts the invariant the whole mechanism exists to guarantee: a project write
-        /// NEVER executes inside its scope while the sync holds the write lock (its file-replacement
-        /// window). A broken gate — one that granted the read lock while the writer held it, or failed
-        /// to drain before returning — would let a write slip in and violate this.
+        /// NEVER executes inside its scope during the sync's file-replacement window. A broken gate —
+        /// one that let <c>EnterWrite</c> open a scope while armed, or that let <c>SetSyncing</c>
+        /// return with in-flight writes still open (a broken drain) — would let a write slip in and
+        /// violate this.
         /// </summary>
         [Test]
         public void ConcurrentWrites_NeverExecuteDuringSyncFileReplacement()
@@ -567,7 +793,7 @@ namespace TestParanextDataProvider.Projects
         public override async Task TestSetupAsync()
         {
             await base.TestSetupAsync();
-            SendReceiveWriteLock.Clear();
+            SendReceiveWriteLock.ResetForTests();
 
             _scrText = CreateDummyProject();
             _projectDetails = CreateProjectDetails(_scrText);
@@ -598,7 +824,7 @@ namespace TestParanextDataProvider.Projects
         [TearDown]
         public void TearDown()
         {
-            SendReceiveWriteLock.Clear();
+            SendReceiveWriteLock.ResetForTests();
             _scrText?.Dispose();
         }
 

--- a/c-sharp-tests/Projects/SendReceiveWriteLockTests.cs
+++ b/c-sharp-tests/Projects/SendReceiveWriteLockTests.cs
@@ -401,6 +401,11 @@ namespace TestParanextDataProvider.Projects
                 {
                     Assert.That(
                         stopwatch.Elapsed,
+                        Is.GreaterThanOrEqualTo(TimeSpan.FromMilliseconds(250)),
+                        "the degraded path must actually wait out the DrainTimeout, not skip the drain"
+                    );
+                    Assert.That(
+                        stopwatch.Elapsed,
                         Is.LessThan(TimeSpan.FromSeconds(5)),
                         "SetSyncing must not hang past its bounded DrainTimeout"
                     );
@@ -593,6 +598,30 @@ namespace TestParanextDataProvider.Projects
         }
 
         [Test]
+        public void SetSyncing_GenerationWrap_SkipsTokenZero()
+        {
+            // Token 0 is reserved as a natural "no arm" default for callers (e.g.
+            // `long token = 0; ... if (token != 0) Clear(token);`), so the arm at the wrap
+            // boundary must skip it — and its bracket must still round-trip.
+            SendReceiveWriteLock.ResetForTests(generation: SendReceiveWriteLock.MaxGeneration);
+
+            var wrappedToken = SendReceiveWriteLock.SetSyncing(["projectA"]);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(wrappedToken, Is.Not.Zero, "token 0 must never be issued");
+                Assert.That(SendReceiveWriteLock.IsArmed, Is.True);
+            });
+
+            SendReceiveWriteLock.Clear(wrappedToken);
+            Assert.That(
+                SendReceiveWriteLock.IsArmed,
+                Is.False,
+                "the wrapped token must still end its own bracket"
+            );
+        }
+
+        [Test]
         public void SetSyncing_ClearedMidDrain_ReturnsPromptlyInsteadOfBurningTheTimeout()
         {
             // A Clear that lands while SetSyncing is still draining removes the drain's premise
@@ -706,6 +735,7 @@ namespace TestParanextDataProvider.Projects
             var syncReplacing = 0; // 1 while the "sync" is in its file-replacement window
             var violations = 0; // a write ran while syncReplacing == 1
             var writesObserved = 0; // sanity: writers actually got through
+            var rejectionsDuringReplacement = 0; // sanity: writers CONTENDED during the windows
 
             var writers = Enumerable
                 .Range(0, writerCount)
@@ -723,7 +753,12 @@ namespace TestParanextDataProvider.Projects
                             }
                             catch (InvalidOperationException)
                             {
-                                // Fail-fast rejection while a sync is armed — expected; keep trying.
+                                // Fail-fast rejection while a sync is armed — expected; keep
+                                // trying. Rejections inside the replacement window prove writers
+                                // were actively contending exactly when it matters (see the
+                                // vacuity assert below).
+                                if (Volatile.Read(ref syncReplacing) == 1)
+                                    Interlocked.Increment(ref rejectionsDuringReplacement);
                             }
                         }
                     })
@@ -732,16 +767,22 @@ namespace TestParanextDataProvider.Projects
 
             for (var i = 0; i < iterations; i++)
             {
-                Thread.SpinWait(300); // unarmed window so writers make progress
+                // Yielding sleeps (NOT Thread.SpinWait, which monopolizes the core on a 1-2 vCPU
+                // CI runner so writers never get scheduled inside the windows that matter).
+                Thread.Sleep(1); // unarmed window so writers make progress
                 SendReceiveWriteLock.SetSyncing([project]); // arm + drain in-flight writes
                 Volatile.Write(ref syncReplacing, 1);
-                Thread.SpinWait(300); // "file replacement" window
+                Thread.Sleep(1); // "file replacement" window
                 Volatile.Write(ref syncReplacing, 0);
                 SendReceiveWriteLock.Clear();
             }
 
             Volatile.Write(ref stop, true);
-            Task.WaitAll(writers, TimeSpan.FromSeconds(30));
+            Assert.That(
+                Task.WaitAll(writers, TimeSpan.FromSeconds(30)),
+                Is.True,
+                "writer tasks must finish before the counters are inspected"
+            );
 
             Assert.Multiple(() =>
             {
@@ -754,6 +795,12 @@ namespace TestParanextDataProvider.Projects
                     writesObserved,
                     Is.GreaterThan(0),
                     "writers never succeeded; the test would be vacuous"
+                );
+                Assert.That(
+                    rejectionsDuringReplacement,
+                    Is.GreaterThan(0),
+                    "no writer ever attempted a write during a replacement window; violations == 0 "
+                        + "would be vacuous"
                 );
             });
         }
@@ -831,7 +878,7 @@ namespace TestParanextDataProvider.Projects
         /// <summary>
         /// Arms this fixture's project as syncing, invokes <paramref name="write"/>, and asserts it
         /// is rejected with the sentinel-suffixed exception (before any mutation can happen). The
-        /// TearDown Clear disarms afterward.
+        /// TearDown gate reset disarms afterward.
         /// </summary>
         private void AssertWriteBlocked(TestDelegate write)
         {

--- a/c-sharp-tests/Projects/SendReceiveWriteLockTests.cs
+++ b/c-sharp-tests/Projects/SendReceiveWriteLockTests.cs
@@ -13,65 +13,6 @@ using SIL.Scripture;
 namespace TestParanextDataProvider.Projects
 {
     /// <summary>
-    /// Test helper that simulates an automatic Send/Receive holding the write-gate. It runs
-    /// <see cref="SendReceiveWriteLock.SetSyncing"/> on a dedicated background thread (matching
-    /// production, where the sync worker — not a PAPI write thread — arms and later clears the gate),
-    /// waits until it has armed and acquired the write lock, and on <see cref="Dispose"/> runs
-    /// <see cref="SendReceiveWriteLock.Clear"/> on that SAME thread (the RWLS is thread-affine) and
-    /// joins.
-    ///
-    /// <para>A separate thread is REQUIRED: because the read lock is thread-affine, a gated write run
-    /// on the test thread must see the write lock held by ANOTHER thread to be rejected with the
-    /// sentinel. A same-thread hold would instead raise <see cref="LockRecursionException"/> under the
-    /// gate's <c>NoRecursion</c> policy.</para>
-    /// </summary>
-    [ExcludeFromCodeCoverage]
-    internal sealed class FakeSync : IDisposable
-    {
-        private readonly Thread _thread;
-        private readonly ManualResetEventSlim _armed = new(false);
-        private readonly ManualResetEventSlim _release = new(false);
-        private Exception? _armException;
-
-        public FakeSync(params string[] projectIds)
-        {
-            _thread = new Thread(() =>
-            {
-                try
-                {
-                    SendReceiveWriteLock.SetSyncing(projectIds);
-                }
-                catch (Exception ex)
-                {
-                    _armException = ex;
-                    _armed.Set();
-                    return;
-                }
-                _armed.Set();
-                _release.Wait();
-                SendReceiveWriteLock.Clear();
-            })
-            {
-                IsBackground = true,
-                Name = "FakeSyncWorker",
-            };
-            _thread.Start();
-            if (!_armed.Wait(TimeSpan.FromSeconds(10)))
-                throw new TimeoutException("FakeSync did not arm within 10 seconds");
-            if (_armException is not null)
-                throw new InvalidOperationException("FakeSync arming threw", _armException);
-        }
-
-        public void Dispose()
-        {
-            _release.Set();
-            _thread.Join(TimeSpan.FromSeconds(10));
-            _armed.Dispose();
-            _release.Dispose();
-        }
-    }
-
-    /// <summary>
     /// Unit tests for the process-wide <see cref="SendReceiveWriteLock"/> write-gate. Every test
     /// clears the (static) gate before and after so state never leaks between tests or to other
     /// fixtures. The fixture runs single-threaded (no NUnit parallelism), so the shared static lock is
@@ -134,8 +75,7 @@ namespace TestParanextDataProvider.Projects
         [Test]
         public void SetSyncing_CalledAgain_ReplacesPreviousSet()
         {
-            // Re-arming on the same thread must not re-acquire the (already held) write lock — the
-            // NoRecursion guard in SetSyncing handles this — it just swaps the armed set.
+            // Re-arming while already armed just swaps the armed set (one global sync slot).
             SendReceiveWriteLock.SetSyncing(["projectA"]);
             SendReceiveWriteLock.SetSyncing(["projectB"]);
 
@@ -159,7 +99,7 @@ namespace TestParanextDataProvider.Projects
             });
         }
 
-        // ---- EnterWrite scope (the RWLS "reader" side) ----
+        // ---- EnterWrite scope (the in-flight write side) ----
 
         [Test]
         public void EnterWrite_NotArmed_ReturnsScope_AndReleasesOnDispose()
@@ -169,7 +109,7 @@ namespace TestParanextDataProvider.Projects
 
             scope.Dispose();
 
-            // Re-entering proves the read lock was released on dispose.
+            // Re-entering proves the in-flight write was released on dispose.
             Assert.DoesNotThrow(() =>
             {
                 using var _ = SendReceiveWriteLock.EnterWrite("projectA");
@@ -182,10 +122,10 @@ namespace TestParanextDataProvider.Projects
             var scope = SendReceiveWriteLock.EnterWrite("projectA");
             scope.Dispose();
 
-            // Second dispose must be a no-op (never call ExitReadLock twice).
+            // Second dispose must be a no-op (never decrement the in-flight count twice).
             Assert.DoesNotThrow(scope.Dispose);
 
-            // The lock is fully released — a fresh scope still works.
+            // The scope is fully released — a fresh scope still works.
             Assert.DoesNotThrow(() =>
             {
                 using var _ = SendReceiveWriteLock.EnterWrite("projectA");
@@ -201,8 +141,9 @@ namespace TestParanextDataProvider.Projects
         [Test]
         public void EnterWrite_Armed_ThrowsWithSentinel()
         {
-            // A sync is armed and holds the write lock on another thread.
-            using var sync = new FakeSync("projectA");
+            // A sync is armed (the gate has no thread affinity, so arming on the test thread is
+            // exactly what production writes would observe from any thread).
+            SendReceiveWriteLock.SetSyncing(["projectA"]);
 
             var ex = Assert.Throws<InvalidOperationException>(
                 () => SendReceiveWriteLock.EnterWrite("projectA")
@@ -213,11 +154,11 @@ namespace TestParanextDataProvider.Projects
         [Test]
         public void EnterWrite_WhileAnotherProjectSyncs_RejectsAllProjects_GlobalGate()
         {
-            // The write gate is GLOBAL (a single process-wide lock): while a sync holds the write
-            // lock, writes to EVERY project fail fast, not just the syncing one. This is the intended
-            // coarse exclusion (a sync is globally exclusive). IsBlocked stays per-project pure data,
-            // so it is deliberately narrower than the gate.
-            using var sync = new FakeSync("projectA");
+            // The write gate is GLOBAL (a single process-wide gate): while a sync is armed, writes
+            // to EVERY project fail fast, not just the syncing one. This is the intended coarse
+            // exclusion (a sync is globally exclusive). IsBlocked stays per-project pure data, so it
+            // is deliberately narrower than the gate.
+            SendReceiveWriteLock.SetSyncing(["projectA"]);
 
             Assert.Multiple(() =>
             {
@@ -233,20 +174,92 @@ namespace TestParanextDataProvider.Projects
             });
         }
 
+        // ---- Forgiving lifecycle contract (no thread affinity, no recursion policy) ----
+
         [Test]
-        public void EnterWrite_NestedOnSameThread_ThrowsLockRecursion_DocumentingNoRecursionPolicy()
+        public void EnterWrite_NestedOnSameThread_BothScopesSucceed()
         {
-            // Documents the NoRecursion policy. No gated write path re-enters the gate on one thread
-            // (a delegating method calls an un-gated core inside its single outer scope), so an
-            // accidental nested EnterWrite is a loud LockRecursionException, not a silent deadlock.
+            // A gated method that (directly or via refactor) calls another gated method must not
+            // crash: the gate is re-entrant, because the outer scope already provides the
+            // sync-exclusion guarantee the inner one would.
             using var outer = SendReceiveWriteLock.EnterWrite("projectA");
 
-            Assert.Throws<LockRecursionException>(
-                () => SendReceiveWriteLock.EnterWrite("projectB")
-            );
+            Assert.DoesNotThrow(() =>
+            {
+                using var inner = SendReceiveWriteLock.EnterWrite("projectB");
+            });
         }
 
-        // ---- SetSyncing drains in-flight writes (the RWLS "writer" side) ----
+        [Test]
+        public void Clear_FromDifferentThreadThanSetSyncing_DisarmsAndUnblocks()
+        {
+            // Arm on a worker thread that then goes away (as an async sync worker's pool thread
+            // might). Clear from ANY other thread must fully disarm — recovery must never depend on
+            // the arming thread still existing.
+            var worker = new Thread(() => SendReceiveWriteLock.SetSyncing(["projectA"]))
+            {
+                IsBackground = true,
+                Name = "ArmingWorker",
+            };
+            worker.Start();
+            Assert.That(
+                worker.Join(TimeSpan.FromSeconds(10)),
+                Is.True,
+                "worker should finish arming"
+            );
+
+            Assert.DoesNotThrow(SendReceiveWriteLock.Clear);
+
+            Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.False);
+            Assert.DoesNotThrow(() =>
+            {
+                using var _ = SendReceiveWriteLock.EnterWrite("projectA");
+            });
+        }
+
+        [Test]
+        public void WriteScope_DisposedOnDifferentThread_ReleasesTheInFlightWrite()
+        {
+            // A write scope that crosses an await can resume — and dispose — on a different pool
+            // thread. The release must work from any thread, and a subsequent sync must then see
+            // zero in-flight writes (drain immediately rather than wait for the DrainTimeout).
+            var scope = SendReceiveWriteLock.EnterWrite("projectA");
+
+            var disposeTask = Task.Run(scope.Dispose);
+            Assert.DoesNotThrow(
+                () => disposeTask.Wait(TimeSpan.FromSeconds(10)),
+                "disposing on another thread must release cleanly"
+            );
+
+            var stopwatch = Stopwatch.StartNew();
+            SendReceiveWriteLock.SetSyncing(["projectA"]);
+            stopwatch.Stop();
+            Assert.That(
+                stopwatch.Elapsed,
+                Is.LessThan(TimeSpan.FromSeconds(2)),
+                "the released write must not count as in-flight during the sync's drain"
+            );
+
+            SendReceiveWriteLock.Clear();
+        }
+
+        [Test]
+        public void SetSyncing_NullOrEmptyIdsInBatch_AreIgnored()
+        {
+            // A defective batch must not crash the arming thread or leave a torn arm state; the
+            // valid ids must still be armed.
+            Assert.DoesNotThrow(() => SendReceiveWriteLock.SetSyncing(["projectA", null!, ""]));
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.True);
+                Assert.That(SendReceiveWriteLock.IsBlocked(""), Is.False);
+            });
+
+            SendReceiveWriteLock.Clear();
+        }
+
+        // ---- SetSyncing drains in-flight writes ----
 
         [Test]
         public void SetSyncing_WaitsForInFlightWriteOnAnotherThread_ToDrain()
@@ -255,8 +268,8 @@ namespace TestParanextDataProvider.Projects
             var release = new ManualResetEventSlim(false);
             const int holdMs = 500;
 
-            // An in-flight write held on ANOTHER thread. The RWLS read lock is thread-affine, so
-            // SetSyncing (on the test thread) must WAIT for this thread's scope to dispose.
+            // An in-flight write held on another thread. SetSyncing (on the test thread) must WAIT
+            // for the scope to dispose before returning.
             var writer = Task.Run(() =>
             {
                 using var scope = SendReceiveWriteLock.EnterWrite("projectA");
@@ -291,17 +304,22 @@ namespace TestParanextDataProvider.Projects
                     "SetSyncing should have blocked until the in-flight write on the other thread drained"
                 );
                 Assert.That(
-                    SendReceiveWriteLock.WriteLockHeld,
+                    SendReceiveWriteLock.InFlightWriteCount,
+                    Is.Zero,
+                    "after draining, no write scopes remain open"
+                );
+                Assert.That(
+                    SendReceiveWriteLock.IsArmed,
                     Is.True,
-                    "after draining, SetSyncing holds the write lock"
+                    "after draining, the sync is armed"
                 );
             });
 
-            SendReceiveWriteLock.Clear(); // release the write lock now held by THIS (test) thread
+            SendReceiveWriteLock.Clear();
         }
 
         [Test]
-        public void SetSyncing_DrainTimesOut_ProceedsUnheld_AndBeltCheckStillRejects()
+        public void SetSyncing_DrainTimesOut_ProceedsDegraded_AndNewWritesStayRejected()
         {
             var previousTimeout = SendReceiveWriteLock.DrainTimeout;
             SendReceiveWriteLock.DrainTimeout = TimeSpan.FromMilliseconds(300);
@@ -335,16 +353,56 @@ namespace TestParanextDataProvider.Projects
                         "SetSyncing must not hang past its bounded DrainTimeout"
                     );
                     Assert.That(
-                        SendReceiveWriteLock.WriteLockHeld,
-                        Is.False,
-                        "on drain timeout the sync proceeds WITHOUT holding the write lock"
+                        SendReceiveWriteLock.InFlightWriteCount,
+                        Is.EqualTo(1),
+                        "the stuck write is still in flight on the degraded path"
                     );
 
-                    // Belt check: writes stay rejected while armed, even though no write lock is held.
+                    // New writes stay rejected while armed, even though the drain timed out.
                     var ex = Assert.Throws<InvalidOperationException>(
                         () => SendReceiveWriteLock.EnterWrite("projectA")
                     );
-                    Assert.That(ex!.Message, Does.EndWith(SendReceiveWriteLock.EditBlockedSentinel));
+                    Assert.That(
+                        ex!.Message,
+                        Does.EndWith(SendReceiveWriteLock.EditBlockedSentinel)
+                    );
+                });
+            }
+            finally
+            {
+                release.Set();
+                stuck?.Wait(TimeSpan.FromSeconds(10));
+                SendReceiveWriteLock.DrainTimeout = previousTimeout;
+                SendReceiveWriteLock.Clear();
+            }
+        }
+
+        [Test]
+        public void Clear_WhileAWriteIsStillStuck_RecoversNewWritesImmediately()
+        {
+            // Recovery must not depend on the stuck write ever completing: Clear disarms the gate,
+            // new writes flow again, and the straggler's eventual dispose is a harmless decrement.
+            var previousTimeout = SendReceiveWriteLock.DrainTimeout;
+            SendReceiveWriteLock.DrainTimeout = TimeSpan.FromMilliseconds(300);
+            var opened = new ManualResetEventSlim(false);
+            var release = new ManualResetEventSlim(false);
+            Task? stuck = null;
+            try
+            {
+                stuck = Task.Run(() =>
+                {
+                    using var scope = SendReceiveWriteLock.EnterWrite("projectA");
+                    opened.Set();
+                    release.Wait(TimeSpan.FromSeconds(15));
+                });
+                Assert.That(opened.Wait(TimeSpan.FromSeconds(5)), Is.True);
+
+                SendReceiveWriteLock.SetSyncing(["projectA"]); // degraded (stuck write never drains)
+                SendReceiveWriteLock.Clear();
+
+                Assert.DoesNotThrow(() =>
+                {
+                    using var _ = SendReceiveWriteLock.EnterWrite("projectA");
                 });
             }
             finally
@@ -359,11 +417,11 @@ namespace TestParanextDataProvider.Projects
         // ---- Clear / round-trip ----
 
         [Test]
-        public void Clear_WhenWriteLockNeverHeld_IsSafeNoOp()
+        public void Clear_WhenNeverArmed_IsSafeNoOp()
         {
-            // No SetSyncing → the write lock was never taken. Clear must not throw (it only disarms).
+            // No SetSyncing → nothing armed. Clear must not throw (it only disarms).
             Assert.DoesNotThrow(SendReceiveWriteLock.Clear);
-            Assert.That(SendReceiveWriteLock.WriteLockHeld, Is.False);
+            Assert.That(SendReceiveWriteLock.IsArmed, Is.False);
 
             // And a subsequent write still works.
             Assert.DoesNotThrow(() =>
@@ -373,16 +431,16 @@ namespace TestParanextDataProvider.Projects
         }
 
         [Test]
-        public void SetSyncing_ThenClear_SameThread_RoundTrips()
+        public void SetSyncing_ThenClear_RoundTrips()
         {
-            // Both on the test thread (RWLS thread affinity). No in-flight writes → acquires at once.
+            // No in-flight writes → SetSyncing returns at once, armed.
             SendReceiveWriteLock.SetSyncing(["projectA"]);
             Assert.Multiple(() =>
             {
                 Assert.That(
-                    SendReceiveWriteLock.WriteLockHeld,
+                    SendReceiveWriteLock.IsArmed,
                     Is.True,
-                    "SetSyncing should hold the write lock when there is nothing to drain"
+                    "SetSyncing should arm the gate when there is nothing to drain"
                 );
                 Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.True);
             });
@@ -390,60 +448,15 @@ namespace TestParanextDataProvider.Projects
             SendReceiveWriteLock.Clear();
             Assert.Multiple(() =>
             {
-                Assert.That(
-                    SendReceiveWriteLock.WriteLockHeld,
-                    Is.False,
-                    "Clear should release the write lock"
-                );
+                Assert.That(SendReceiveWriteLock.IsArmed, Is.False, "Clear should disarm the gate");
                 Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.False);
             });
 
-            // The lock is reusable after a clean same-thread round-trip.
+            // The gate is reusable after a clean round-trip.
             Assert.DoesNotThrow(() =>
             {
                 using var _ = SendReceiveWriteLock.EnterWrite("projectA");
             });
-        }
-
-        [Test]
-        public void Clear_OnDifferentThreadThanSetSyncing_ThrowsAndLeavesStateIntact()
-        {
-            // Defends the single-thread contract: a sync armed on one thread must be cleared on THAT
-            // thread. A cross-thread Clear must fail fast (InvalidOperationException) and — crucially —
-            // NOT touch the armed set or the still-held write lock, so the owning thread can still
-            // clean up correctly. Without the owner-thread guard the degraded path would slip through
-            // silently (nothing is held for the RWLS to reject).
-            var armed = new ManualResetEventSlim(false);
-            var release = new ManualResetEventSlim(false);
-            var worker = new Thread(() =>
-            {
-                SendReceiveWriteLock.SetSyncing(["projectA"]);
-                armed.Set();
-                release.Wait(TimeSpan.FromSeconds(10));
-                SendReceiveWriteLock.Clear(); // proper cleanup on the OWNING thread
-            })
-            {
-                IsBackground = true,
-                Name = "CrossThreadClearWorker",
-            };
-            worker.Start();
-            Assert.That(armed.Wait(TimeSpan.FromSeconds(10)), Is.True, "worker should have armed");
-
-            // Clear on the TEST thread (not the arming thread) is rejected...
-            Assert.Throws<InvalidOperationException>(SendReceiveWriteLock.Clear);
-            // ...and left the sync intact for the owner to clean up.
-            Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.True);
-
-            release.Set();
-            Assert.That(
-                worker.Join(TimeSpan.FromSeconds(10)),
-                Is.True,
-                "worker should have cleared"
-            );
-            Assert.That(SendReceiveWriteLock.IsBlocked("projectA"), Is.False);
-
-            armed.Dispose();
-            release.Dispose();
         }
 
         // ---- Concurrency stress: the core safety invariant ----
@@ -534,10 +547,9 @@ namespace TestParanextDataProvider.Projects
     /// direct wiring test; the gate call itself is the same one-line <c>EnterWrite</c> scope covered
     /// by <see cref="SendReceiveWriteLockTests"/>.
     ///
-    /// <para>Each test arms the sync via <see cref="FakeSync"/> (on a background thread) rather than
-    /// calling <see cref="SendReceiveWriteLock.SetSyncing"/> on the test thread: the RWLS read lock is
-    /// thread-affine, so a gated write on the test thread must see the write lock held by ANOTHER
-    /// thread to be rejected with the sentinel.</para>
+    /// <para>Each test arms the sync with <see cref="SendReceiveWriteLock.SetSyncing"/> directly on
+    /// the test thread — the gate has no thread affinity, so a gated write observes the armed state
+    /// identically from any thread.</para>
     /// </summary>
     [ExcludeFromCodeCoverage]
     internal class SendReceiveWriteLockGateTests : PapiTestBase
@@ -591,13 +603,13 @@ namespace TestParanextDataProvider.Projects
         }
 
         /// <summary>
-        /// Arms this fixture's project as syncing (on a background thread, via <see cref="FakeSync"/>),
-        /// invokes <paramref name="write"/> on the test thread, and asserts it is rejected with the
-        /// sentinel-suffixed exception (before any mutation can happen).
+        /// Arms this fixture's project as syncing, invokes <paramref name="write"/>, and asserts it
+        /// is rejected with the sentinel-suffixed exception (before any mutation can happen). The
+        /// TearDown Clear disarms afterward.
         /// </summary>
         private void AssertWriteBlocked(TestDelegate write)
         {
-            using var sync = new FakeSync(ProjectId);
+            SendReceiveWriteLock.SetSyncing([ProjectId]);
 
             var ex = Assert.Throws<InvalidOperationException>(write);
             Assert.That(ex!.Message, Does.EndWith(SendReceiveWriteLock.EditBlockedSentinel));
@@ -613,15 +625,14 @@ namespace TestParanextDataProvider.Projects
         {
             var verseRef = new VerseRef(1, 2, 0);
 
-            using (new FakeSync(ProjectId))
-            {
-                var ex = Assert.Throws<InvalidOperationException>(
-                    () => _provider.SetChapterUsfm(verseRef, @"\c 2 \p \v 2 New chapter text.")
-                );
-                Assert.That(ex!.Message, Does.EndWith(SendReceiveWriteLock.EditBlockedSentinel));
-            }
+            SendReceiveWriteLock.SetSyncing([ProjectId]);
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => _provider.SetChapterUsfm(verseRef, @"\c 2 \p \v 2 New chapter text.")
+            );
+            Assert.That(ex!.Message, Does.EndWith(SendReceiveWriteLock.EditBlockedSentinel));
 
-            // Sync ended (FakeSync disposed → Clear ran on its thread → write lock released).
+            // Sync ended (Clear disarms the gate).
+            SendReceiveWriteLock.Clear();
             Assert.That(
                 _provider.SetChapterUsfm(verseRef, @"\c 2 \p \v 2 New chapter text."),
                 Is.True,
@@ -746,7 +757,7 @@ namespace TestParanextDataProvider.Projects
                     BindingFlags.NonPublic | BindingFlags.Instance
                 ) ?? throw new MissingMethodException(nameof(CheckRunner), methodName);
 
-            using var sync = new FakeSync(ProjectId);
+            SendReceiveWriteLock.SetSyncing([ProjectId]);
 
             var tie = Assert.Throws<TargetInvocationException>(
                 () =>

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -2419,8 +2419,9 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     /// The body of <see cref="SetBookUsfm"/> WITHOUT opening its own sync-write scope. Callers MUST
     /// already hold one (via <see cref="EnterSyncWriteScope"/>). This exists so a gated method that
     /// delegates to the book-USFM write (<see cref="SetBookUsx"/>) can reuse it inside a single
-    /// outer scope. (Nesting a second <see cref="SendReceiveWriteLock.EnterWrite"/> would be benign
-    /// — the gate is re-entrant — but one scope per mutation keeps the gating easy to reason about.)
+    /// outer scope. (Nesting a second <see cref="SendReceiveWriteLock.EnterWrite"/> is NOT a safe
+    /// alternative: if a sync armed while the outer scope was open, the nested call would throw
+    /// mid-mutation and tear the write. One scope per mutation is required, not stylistic.)
     /// </summary>
     private bool SetBookUsfmInScope(VerseRef verseRef, string data)
     {
@@ -2588,10 +2589,10 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
         // Open ONE sync-write scope for the whole convert-then-write mutation. Rejecting here also
         // skips the USX→USFM conversion when sync-blocked. We then call the un-gated
         // SetBookUsfmInScope (NOT the public SetBookUsfm) so the whole mutation sits under a single
-        // scope — nesting would be benign (the gate is re-entrant), but one scope per mutation
-        // keeps the gating easy to reason about. Inert in public core.
+        // scope — nesting is unsafe under an arm race; see SetBookUsfmInScope. Inert in public core.
         using var _ = EnterSyncWriteScope();
-        // Don't need to take a write lock in this function because SetBookUsfmInScope will do it
+        // The ParatextData project write lock (RunWithinLock) is taken inside SetBookUsfmInScope —
+        // unrelated to the S/R gate scope above, despite the similar name.
         var scrText = LocalParatextProjects.GetParatextProject(ProjectDetails.Metadata.Id);
         string usfm = ConvertUsxToUsfm(scrText, verseRef, data);
         return SetBookUsfmInScope(verseRef, usfm);

--- a/c-sharp/Projects/ParatextProjectDataProvider.cs
+++ b/c-sharp/Projects/ParatextProjectDataProvider.cs
@@ -2418,10 +2418,9 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     /// <summary>
     /// The body of <see cref="SetBookUsfm"/> WITHOUT opening its own sync-write scope. Callers MUST
     /// already hold one (via <see cref="EnterSyncWriteScope"/>). This exists so a gated method that
-    /// delegates to the book-USFM write (<see cref="SetBookUsx"/>) can reuse it inside a single outer
-    /// scope instead of nesting a second <see cref="SendReceiveWriteLock.EnterWrite"/> on the same
-    /// thread — which the write-gate's <c>NoRecursion</c> policy forbids (it would throw
-    /// <see cref="System.Threading.LockRecursionException"/>).
+    /// delegates to the book-USFM write (<see cref="SetBookUsx"/>) can reuse it inside a single
+    /// outer scope. (Nesting a second <see cref="SendReceiveWriteLock.EnterWrite"/> would be benign
+    /// — the gate is re-entrant — but one scope per mutation keeps the gating easy to reason about.)
     /// </summary>
     private bool SetBookUsfmInScope(VerseRef verseRef, string data)
     {
@@ -2588,8 +2587,9 @@ internal class ParatextProjectDataProvider : ProjectDataProvider
     {
         // Open ONE sync-write scope for the whole convert-then-write mutation. Rejecting here also
         // skips the USX→USFM conversion when sync-blocked. We then call the un-gated
-        // SetBookUsfmInScope (NOT the public SetBookUsfm) so we do not nest a second EnterWrite on
-        // this thread — the write-gate's NoRecursion policy would throw. Inert in public core.
+        // SetBookUsfmInScope (NOT the public SetBookUsfm) so the whole mutation sits under a single
+        // scope — nesting would be benign (the gate is re-entrant), but one scope per mutation
+        // keeps the gating easy to reason about. Inert in public core.
         using var _ = EnterSyncWriteScope();
         // Don't need to take a write lock in this function because SetBookUsfmInScope will do it
         var scrText = LocalParatextProjects.GetParatextProject(ProjectDetails.Metadata.Id);

--- a/c-sharp/Projects/SendReceive/SendReceiveWriteLock.cs
+++ b/c-sharp/Projects/SendReceive/SendReceiveWriteLock.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace Paranext.DataProvider.Projects.SendReceive;
 
@@ -9,146 +10,108 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// </summary>
 /// <remarks>
 /// <para>
-/// <b>A specialized reader-writer coordination, with the roles deliberately inverted.</b> This is
-/// built on a <see cref="ReaderWriterLockSlim"/>, but call sites never see that: they use only the
-/// domain API (<see cref="EnterWrite"/>). Think of it as the user's own analogy — many people can
-/// read a shared document at once, but a writer needs everyone else out. Here the mapping is
-/// inverted relative to the words "read"/"write":
-/// <list type="bullet">
-/// <item>
-/// <description>
-/// <b>A project write is a "reader".</b> Many PAPI threads mutate different projects concurrently;
-/// they are the <i>shared/concurrent</i> side, so each mutation takes the RWLS <b>read</b> lock
-/// (many can be held at once). They are "readers" only with respect to <i>this</i> coordination —
-/// they are of course real writes to their projects.
-/// </description>
-/// </item>
-/// <item>
-/// <description>
-/// <b>Send/Receive is the "writer".</b> A starting sync needs <i>exclusive</i> access (it replaces
-/// files on disk underneath the editor), so it takes the RWLS <b>write</b> lock — which, by
-/// definition, waits for every in-flight read (project write) to finish and excludes new ones.
-/// </description>
-/// </item>
-/// </list>
-/// The coordination therefore works in <b>both directions</b>:
+/// <b>The coordination works in both directions:</b>
 /// <list type="number">
 /// <item>
 /// <description>
-/// <b>An armed/queued sync rejects new writes (fail-fast).</b> <see cref="EnterWrite"/> takes the
-/// read lock with <c>TryEnterReadLock(0)</c>: if a sync holds (or, being writer-preferring, has
-/// queued for) the write lock, the zero-timeout call returns immediately and we throw (message
-/// ending in <see cref="EditBlockedSentinel"/>) rather than blocking. This is <b>deviation #1</b>
-/// from a textbook reader-writer lock, where a reader would <i>block</i> until the writer released.
-/// We fail fast on purpose: a user's keystroke must never hang waiting on a background sync — the
-/// editor catches the sentinel, shows an "editing paused during Send/Receive" notice, and reverts
-/// the un-saved change.
+/// <b>An armed sync rejects new writes (fail-fast).</b> While a sync is armed, every
+/// <see cref="EnterWrite"/> throws immediately (message ending in
+/// <see cref="EditBlockedSentinel"/>) rather than queueing — a user's keystroke must never hang
+/// behind a background sync. The editor catches the sentinel, shows an "editing paused during
+/// Send/Receive" notice, and reverts the un-saved change.
 /// </description>
 /// </item>
 /// <item>
 /// <description>
 /// <b>A starting sync WAITS (bounded) for in-flight writes to drain.</b> <see cref="SetSyncing"/>
-/// arms the project-id set, then acquires the write lock with a <b>bounded</b> timeout
-/// (<see cref="DrainTimeout"/>). That acquisition <i>is</i> the drain: RWLS is writer-preferring, so
-/// from the moment the writer queues no new read lock is granted (arm-first for free), and it blocks
-/// until existing readers (writes) exit. This is <b>deviation #2</b>: a textbook writer waits
-/// unboundedly; here the wait is bounded so a single stuck/slow write can never deadlock a sync
-/// start — on timeout we log a warning and <b>proceed UNHELD</b> (see the degraded path below).
+/// arms the gate, then waits up to <see cref="DrainTimeout"/> for already-open write scopes to
+/// close before returning. The wait is bounded so a single stuck write can never deadlock a sync
+/// start — on timeout it logs a warning and proceeds anyway (see the degraded path below).
 /// </description>
 /// </item>
 /// </list>
 /// </para>
 /// <para>
-/// <b>Why not just expose the raw <see cref="ReaderWriterLockSlim"/>?</b> Three reasons this wrapper
-/// exists rather than handing callers the primitive:
+/// <b>How it works — one atomic word.</b> All gate state that synchronization depends on lives in a
+/// single <see cref="long"/> (<c>_state</c>): an "armed" flag bit plus the count of in-flight write
+/// scopes. Every transition — enter a write, exit a write, arm, disarm — is a single interlocked
+/// read-modify-write on that one word, so all transitions are totally ordered and each one sees the
+/// exact state it replaces. The safety invariant falls out directly: a write scope can only open by
+/// atomically observing "not armed" while incrementing the count, and arming atomically sets the
+/// flag, so after the arming operation NO new write scope can open, and the in-flight count the
+/// drain then waits on can only fall. Because a write's mutation happens entirely between its enter
+/// and exit operations (both full fences), a drained count also means every finished write's
+/// effects are visible to the sync. No mutual exclusion depends on any other field:
+/// <c>_blockedProjectIds</c> is pure data (it only feeds <see cref="IsBlocked"/> queries), and
+/// there is deliberately no "is the lock held" bookkeeping to fall out of step with reality.
+/// </para>
+/// <para>
+/// <b>Forgiving lifecycle contract (deliberate).</b> The arm→clear bracket is activated by code
+/// that lives outside this repository (see activation below) and whose threading model this class
+/// cannot see or test, so the gate assumes as little as possible:
 /// <list type="bullet">
 /// <item>
 /// <description>
-/// Its <b>thread-affinity rules</b> (the thread that enters a lock must exit it) are easy to violate
-/// and would leak into every call site; here they are confined to <see cref="SetSyncing"/> /
-/// <see cref="Clear"/> and to the single-method <c>using</c> scope of <see cref="EnterWrite"/>.
+/// <see cref="SetSyncing"/> and <see cref="Clear"/> may run on ANY thread, including different
+/// threads — an <c>await</c> between them (which resumes on a different pool thread) is fine.
 /// </description>
 /// </item>
 /// <item>
 /// <description>
-/// Raw readers <b>block by default</b>, which conflicts with our fail-fast requirement (deviation
-/// #1). The wrapper encodes the zero-timeout + sentinel-throw so no call site can accidentally
-/// block a user write on a sync.
+/// A write scope may be disposed on a different thread than the one that opened it, so a gated
+/// method that comes to hold its scope across an <c>await</c> stays correct. (Still, hold scopes
+/// tightly: a long-held scope delays a sync's drain toward its timeout.)
 /// </description>
 /// </item>
 /// <item>
 /// <description>
-/// A bare "take the <i>read</i> lock in order to perform a <i>write</i>" reads confusingly at the
-/// call site. <c>EnterWrite</c> names the caller's intent; the inversion is documented once, here.
+/// Nested <see cref="EnterWrite"/> calls are benign (a gated method may call another gated method);
+/// the inner scope simply counts as one more in-flight write until disposed.
+/// </description>
+/// </item>
+/// <item>
+/// <description>
+/// <see cref="Clear"/> is idempotent and safe to call when nothing is armed, so it can serve as
+/// crash recovery: if a sync worker dies without clearing, ANY thread (e.g. a watchdog or the next
+/// sync) can call <see cref="Clear"/> to recover. Double-disposing a scope and over-releasing are
+/// guarded no-ops. No call sequence, on any combination of threads, can wedge the gate permanently.
 /// </description>
 /// </item>
 /// </list>
 /// </para>
 /// <para>
-/// <b>The armed set is pure data.</b> <c>_blockedProjectIds</c> carries no synchronization role (the
-/// RWLS does all mutual exclusion); it exists only so <see cref="IsBlocked"/> can answer per-project
-/// queries and so rejection messages can name projects. It is still <c>volatile</c> for safe
-/// publication across the many threads that read it.
+/// <b>Degraded (drain-timed-out) path.</b> If in-flight writes do not drain within
+/// <see cref="DrainTimeout"/>, <see cref="SetSyncing"/> logs a warning and returns anyway — a sync
+/// start must never hang forever behind a stuck write. The armed flag keeps rejecting NEW writes
+/// exactly as on the normal path; only the already-stuck write(s) may still overlap the sync. This
+/// is an accepted residual risk, traded against deadlocking every future sync.
 /// </para>
 /// <para>
-/// <b>Degraded (write-lock-not-held) path, and the belt check.</b> When
-/// <c>TryEnterWriteLock(DrainTimeout)</c> times out, the sync proceeds without holding the write lock
-/// (we never deadlock a sync). In that window the RWLS would <i>not</i> block readers, so
-/// <see cref="EnterWrite"/> has a second, belt-and-suspenders check: after a successful
-/// <c>TryEnterReadLock(0)</c> it consults the armed set and, if any project is armed, releases the
-/// read lock and throws anyway. So writes stay rejected while a sync is armed even if the writer
-/// timed out. <c>_writeLockHeld</c> records whether the write lock was actually taken, so
-/// <see cref="Clear"/> only calls <c>ExitWriteLock</c> when it is really held.
-/// </para>
-/// <para>
-/// <b>Thread-affinity contract — IMPORTANT.</b> <see cref="ReaderWriterLockSlim"/> is thread-affine:
-/// the thread that enters a lock must be the one that exits it. Two consequences:
-/// <list type="bullet">
-/// <item>
-/// <description>
-/// <b><see cref="SetSyncing"/> and <see cref="Clear"/> MUST run on the same thread.</b>
-/// <see cref="SetSyncing"/> enters the write lock; <see cref="Clear"/> exits it. The Paratext 10
-/// Studio patch activation (Jira PT-4210) satisfies this: both are called from the sync worker's own
-/// <c>try</c>/<c>finally</c>. A violation surfaces loudly as a
-/// <see cref="SynchronizationLockException"/> — which is the <i>desired</i> fail-fast behavior, not
-/// something to swallow.
-/// </description>
-/// </item>
-/// <item>
-/// <description>
-/// A write scope is entered and disposed within a single synchronous method
-/// (<c>using var _ = EnterWrite(id);</c>), so its read lock is always released on the entering
-/// thread.
-/// </description>
-/// </item>
-/// </list>
-/// The lock uses <see cref="LockRecursionPolicy.NoRecursion"/>: a thread must not take the read lock
-/// while already holding it (nor mix read and write on one thread). No gated write path nests a
-/// second <see cref="EnterWrite"/> on the same thread — where one gated method delegates to another
-/// (e.g. <c>SetBookUsx</c> converts then writes a book), the callee's un-gated core is invoked inside
-/// the single outer scope rather than re-entering the gate — and the sync's file replacement uses
-/// <c>ParatextData</c> directly, not the gated PAPI write methods. NoRecursion is deliberate: because
-/// no path ever legitimately re-enters, any accidental re-entrancy is an immediate, loud
-/// <see cref="LockRecursionException"/> instead of a subtle deadlock.
+/// <b>One global sync slot; overlap semantics.</b> The gate is global: while ANY sync is armed, ALL
+/// project writes are rejected (automatic syncs are globally exclusive by design), which is why
+/// rejection does not consult the per-project set. A repeat <see cref="SetSyncing"/> while armed
+/// replaces the armed project-id set (call it once per sync batch with the full set), and any
+/// <see cref="Clear"/> fully disarms. Overlapping arm→clear brackets from two concurrent syncs are
+/// therefore not meaningful — the scheduler must serialize sync runs — but no interleaving of calls
+/// can corrupt the gate; the worst outcome of an overlap is disarming earlier than one of the two
+/// syncs expected. <see cref="IsBlocked"/> answers per-project queries from the pure-data set and is
+/// deliberately narrower than the global gate.
 /// </para>
 /// <para>
 /// <b>Distinct from the Send/Receive server-side repository lock.</b> This class is an
 /// <i>in-process</i> gate between local editing and a local sync run. It is <b>not</b> the S/R
-/// server's repository lock (the <c>lockrepo</c>/<c>unlockrepo</c> REST calls the sync makes against
-/// the Send/Receive server to exclude <i>other clients</i> from pushing concurrently). Different
-/// mechanism (an in-memory <see cref="ReaderWriterLockSlim"/> vs. a server-held lock), different
-/// scope (this process vs. all clients of a shared repo), and different failure modes (a timed-out
-/// drain here vs. an orphaned server lock returning HTTP 403 there). Do not conflate the two.
+/// server's repository lock (the <c>lockrepo</c>/<c>unlockrepo</c> REST calls the sync makes
+/// against the Send/Receive server to exclude <i>other clients</i> from pushing concurrently).
+/// Different mechanism, different scope (this process vs. all clients of a shared repo), different
+/// failure modes. Do not conflate the two.
 /// </para>
 /// <para>
 /// <b>Inert in open-source Platform.Bible.</b> Nothing in public core ever calls
-/// <see cref="SetSyncing"/>, so the write lock is never taken, <see cref="IsBlocked"/> always returns
+/// <see cref="SetSyncing"/>, so the gate is never armed, <see cref="IsBlocked"/> always returns
 /// <c>false</c>, every <see cref="EnterWrite"/> scope succeeds, and no write is ever rejected —
 /// public behavior is unchanged by this class. The Paratext 10 Studio closed-source patch brackets
 /// each automatic sync with <see cref="SetSyncing"/> / <see cref="Clear"/> (Jira PT-4210), which is
-/// what activates the gate. This class is the public seam; the activation lives in the patch. The
-/// activation API (<see cref="SetSyncing"/> / <see cref="Clear"/>) is unchanged by this RWLS-backed
-/// upgrade.
+/// what activates the gate. This class is the public seam; the activation lives in the patch.
 /// </para>
 /// </remarks>
 internal static class SendReceiveWriteLock
@@ -158,44 +121,34 @@ internal static class SendReceiveWriteLock
     // generic permissions message) and revert the un-saved change.
     public const string EditBlockedSentinel = "(SR_EDIT_BLOCKED)";
 
-    // Reader = project write; Writer = Send/Receive. NoRecursion is intentional (see the
-    // thread-affinity remarks): no gated write path re-enters the gate on one thread, so accidental
-    // re-entrancy should throw loudly rather than deadlock.
-    private static readonly ReaderWriterLockSlim _lock = new(LockRecursionPolicy.NoRecursion);
+    // The single atomic word all mutual exclusion rests on (see the class remarks): bit 32 is the
+    // "a sync is armed" flag, bits 0–31 count in-flight write scopes. Mutate ONLY via Interlocked
+    // operations; read via Volatile.Read (a long read is not atomic on 32-bit without it).
+    private const long ArmedFlag = 1L << 32;
+    private const long InFlightCountMask = 0xFFFF_FFFFL;
+    private static long _state;
 
-    // Pure data (no synchronization role — the RWLS does all exclusion): drives IsBlocked, the belt
-    // check in EnterWrite, and the project names in rejection messages. volatile for safe publication
-    // across the many threads that read it.
-    private static volatile IImmutableSet<string> _blockedProjectIds =
-        ImmutableHashSet<string>.Empty;
+    // Pure data (no synchronization role — the atomic word does all exclusion): drives IsBlocked
+    // per-project queries. Published (volatile) before the armed flag is set and replaced wholesale,
+    // never mutated. Case-insensitive because project ID casing varies across call sites.
+    private static volatile IImmutableSet<string> _blockedProjectIds = EmptyProjectIds;
 
-    // Whether SetSyncing actually acquired the write lock (false after a drain timeout — the degraded
-    // path). Only ever read/written by the sync worker thread that owns SetSyncing/Clear, so it needs
-    // no synchronization of its own. Guards Clear so it never calls ExitWriteLock on a lock it does
-    // not hold.
-    private static bool _writeLockHeld;
+    private static IImmutableSet<string> EmptyProjectIds =>
+        ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase);
 
-    // The managed-thread id that armed the current sync (via SetSyncing), or 0 when no sync is armed.
-    // SetSyncing/Clear MUST run on the same thread (RWLS thread affinity + the plain-bool _writeLockHeld
-    // has no cross-thread synchronization). This records the owner so Clear can DEFEND that contract:
-    // a cross-thread Clear throws a clear InvalidOperationException instead of silently corrupting the
-    // held-flag (on the degraded path the RWLS itself would not catch it — nothing is held to exit).
-    // Managed-thread ids are always positive, so 0 is an unambiguous "no owner". volatile for safe
-    // publication of the id to whatever thread calls Clear.
-    private static volatile int _ownerThreadId;
-
-    // How long SetSyncing waits (via TryEnterWriteLock) for in-flight writes to drain before giving
-    // up. BOUNDED on purpose: a sync start must never be able to deadlock behind a write scope that
-    // (through a bug, a stuck ParatextData call, or an editor that forgot to dispose) never
-    // completes. On timeout we log and proceed unheld, accepting a small residual race rather than
-    // hanging the sync forever. Internal setter exists ONLY so tests can shorten it; production
-    // always uses the default.
+    // How long SetSyncing waits for in-flight writes to drain before giving up. BOUNDED on purpose:
+    // a sync start must never be able to deadlock behind a write scope that (through a bug, a stuck
+    // ParatextData call, or an editor that forgot to dispose) never completes. On timeout we log
+    // and proceed (degraded path), accepting a small residual race rather than hanging the sync
+    // forever. Internal setter exists ONLY so tests can shorten it; production always uses the
+    // default.
     internal static TimeSpan DrainTimeout { get; set; } = TimeSpan.FromSeconds(10);
 
-    /// <summary>Whether the write lock is currently held by a sync. For tests only.</summary>
-    internal static bool WriteLockHeld => _writeLockHeld;
+    /// <summary>Whether a sync is currently armed. For tests only.</summary>
+    internal static bool IsArmed => (Volatile.Read(ref _state) & ArmedFlag) != 0;
 
-    private static string Normalize(string projectId) => projectId.ToLowerInvariant();
+    /// <summary>The number of write scopes currently open. For tests only.</summary>
+    internal static long InFlightWriteCount => Volatile.Read(ref _state) & InFlightCountMask;
 
     private static InvalidOperationException EditBlocked(string projectId) =>
         new(
@@ -204,169 +157,156 @@ internal static class SendReceiveWriteLock
         );
 
     /// <summary>
-    /// Marks the given projects as being synced (the exclusive "writer" side), then acquires the
-    /// write lock — which drains any already-in-flight writes — before returning. After it returns,
-    /// new <see cref="EnterWrite"/> calls for any project fail fast (whether because the write lock is
-    /// held or, on the degraded path, because the belt check sees the armed set). Replaces any
-    /// previously set list; call once per sync batch with the full set of projects. The drain is
-    /// bounded (<see cref="DrainTimeout"/>); on timeout it logs a warning and proceeds UNHELD so a
-    /// sync start can never deadlock.
+    /// Marks the given projects as being synced, then waits (bounded by <see cref="DrainTimeout"/>)
+    /// for any already-in-flight writes to drain before returning. From the moment this arms the
+    /// gate, new <see cref="EnterWrite"/> calls for ANY project fail fast; after it returns, either
+    /// no write scopes remain open (normal path) or the drain timed out and it has logged a warning
+    /// and proceeded anyway (degraded path — new writes are still rejected either way). Replaces any
+    /// previously set project list; call once per sync batch with the full set of projects. Null or
+    /// empty ids in the batch are ignored.
     /// <para>
-    /// <b>Single-thread contract.</b> <see cref="SetSyncing"/> and <see cref="Clear"/> MUST be
-    /// serialized on ONE thread — the sync worker's — for the whole arm→clear bracket (the Paratext 10
-    /// Studio PT-4210 patch does exactly this in a <c>try</c>/<c>finally</c>). Two reasons: the RWLS is
-    /// thread-affine (the thread that enters the write lock must exit it), and <c>_writeLockHeld</c> is
-    /// a plain bool with no cross-thread synchronization. This method records the arming thread so
-    /// <see cref="Clear"/> can defend the contract with a clear exception on a cross-thread call.
+    /// May be called from any thread; <see cref="Clear"/> may later run on a different thread (an
+    /// <c>await</c> between them is fine). Do not call while holding an open <see cref="EnterWrite"/>
+    /// scope this call would wait for — the drain cannot finish and will time out into the degraded
+    /// path. Overlapping sync brackets are not meaningful (see the class remarks); the scheduler
+    /// must serialize sync runs.
     /// </para>
     /// </summary>
     public static void SetSyncing(IEnumerable<string> projectIds)
     {
         ArgumentNullException.ThrowIfNull(projectIds);
 
-        // Record the owning thread so Clear can enforce the single-thread contract (see the field and
-        // Clear). On a same-thread re-arm this simply re-stamps the same id.
-        _ownerThreadId = Environment.CurrentManagedThreadId;
+        // Build the set BEFORE touching any state, so an exception while enumerating (or a
+        // defective batch) can never leave a torn arm.
+        var armedProjectIds = projectIds
+            .Where(projectId => !string.IsNullOrEmpty(projectId))
+            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
 
-        // FIRST swap the armed set (pure data). Publishing this before acquiring the lock means the
-        // belt check in EnterWrite already rejects writes even during the write-lock acquisition
-        // below (and on the degraded path where that acquisition times out).
-        _blockedProjectIds = projectIds.Select(Normalize).ToImmutableHashSet();
+        // Publish the pure data first, then arm. Arming is a single interlocked bit-set on the
+        // state word: every write that enters afterward must observe the flag (all transitions on
+        // the word are totally ordered) and is rejected.
+        _blockedProjectIds = armedProjectIds;
+        Interlocked.Or(ref _state, ArmedFlag);
 
-        // If this thread already holds the write lock (a repeat SetSyncing without an intervening
-        // Clear — e.g. re-arming a batch), don't re-acquire: NoRecursion would throw
-        // LockRecursionException, and there are no in-flight readers to drain while the write lock is
-        // already held. The set swap above is enough to update which projects are armed.
-        if (_writeLockHeld)
-            return;
-
-        // THEN acquire the write lock = drain in-flight writes, bounded. Writer-preferring RWLS
-        // blocks new readers (writes) from the moment we queue here.
-        if (_lock.TryEnterWriteLock(DrainTimeout))
+        // Drain: wait (bounded) until no write scopes remain open. New writes can no longer enter,
+        // so the count only falls. SpinWait escalates spin → yield → sleep, so a long drain does
+        // not burn a core.
+        var spinner = new SpinWait();
+        var stopwatch = Stopwatch.StartNew();
+        while ((Volatile.Read(ref _state) & InFlightCountMask) != 0)
         {
-            _writeLockHeld = true;
-        }
-        else
-        {
-            // Degraded: proceed without the lock so we never deadlock a sync. The belt check in
-            // EnterWrite keeps rejecting writes while the armed set is non-empty, so correctness
-            // holds; only the (already stuck) in-flight write we couldn't drain may still overlap.
-            _writeLockHeld = false;
-            Console.Error.WriteLine(
-                "[SendReceiveWriteLock] Warning: in-flight project write(s) did not drain within "
-                    + $"{DrainTimeout.TotalSeconds:0.#}s; proceeding with Send/Receive without the "
-                    + "write lock (writes stay blocked via the armed-set check)."
-            );
+            if (stopwatch.Elapsed >= DrainTimeout)
+            {
+                // Degraded: proceed rather than deadlock the sync. The armed flag keeps rejecting
+                // new writes; only the already-stuck write(s) we couldn't drain may still overlap.
+                Console.Error.WriteLine(
+                    "[SendReceiveWriteLock] Warning: in-flight project write(s) did not drain "
+                        + $"within {DrainTimeout.TotalSeconds:0.#}s; proceeding with Send/Receive "
+                        + "anyway (new writes stay blocked while the sync is armed)."
+                );
+                return;
+            }
+            spinner.SpinOnce();
         }
     }
 
     /// <summary>
-    /// Ends the sync: disarms all projects and releases the write lock if it was held. Safe to call
-    /// when the lock was never taken (the degraded path) or when no sync is active at all — it simply
-    /// disarms. MUST run on the same thread that called <see cref="SetSyncing"/> (RWLS thread affinity,
-    /// and <c>_writeLockHeld</c> is an unsynchronized bool — see the class remarks and the
-    /// single-thread contract on <see cref="SetSyncing"/>). Defends that contract: if a sync is armed
-    /// and this runs on a DIFFERENT thread, it throws <see cref="InvalidOperationException"/> rather
-    /// than silently mismanaging the held-flag (on the degraded path the RWLS would not otherwise catch
-    /// it — nothing is held to exit).
+    /// Ends the sync: disarms the gate and clears the armed project set, so writes are accepted
+    /// again. May be called from ANY thread (not just the one that called <see cref="SetSyncing"/>),
+    /// is idempotent, and is safe to call when no sync is active at all — so it doubles as the
+    /// recovery path if a sync worker dies without clearing.
     /// </summary>
     public static void Clear()
     {
-        // Enforce the single-thread contract. Only fires when a sync is actually armed (owner id is 0
-        // otherwise), so a plain no-op Clear — no prior SetSyncing — stays safe on any thread.
-        var owner = _ownerThreadId;
-        if (owner != 0 && owner != Environment.CurrentManagedThreadId)
-            throw new InvalidOperationException(
-                $"SendReceiveWriteLock.Clear() called on thread {Environment.CurrentManagedThreadId} "
-                    + $"but the sync was armed on thread {owner}. SetSyncing/Clear must run on the same "
-                    + "thread (see SetSyncing's single-thread contract)."
-            );
-
-        _blockedProjectIds = ImmutableHashSet<string>.Empty;
-        _ownerThreadId = 0;
-        if (_writeLockHeld)
-        {
-            _writeLockHeld = false;
-            _lock.ExitWriteLock();
-        }
+        _blockedProjectIds = EmptyProjectIds;
+        Interlocked.And(ref _state, ~ArmedFlag);
     }
 
     /// <summary>
     /// Whether writes to <paramref name="projectId"/> are currently blocked by an in-progress
     /// automatic Send/Receive. Always <c>false</c> in public core (see the class remarks). Kept for
     /// read-only consumers (e.g. status queries); write paths must use <see cref="EnterWrite"/> so
-    /// their mutation is what the sync's write-lock acquisition drains. Note this pure-data answer is
-    /// per-project, whereas <see cref="EnterWrite"/> is a global gate (any active sync rejects all
-    /// writes).
+    /// their mutation is what the sync's drain waits for. Note this pure-data answer is per-project,
+    /// whereas <see cref="EnterWrite"/> is a global gate (any armed sync rejects all writes).
     /// </summary>
     public static bool IsBlocked(string? projectId)
     {
-        return !string.IsNullOrEmpty(projectId)
-            && _blockedProjectIds.Contains(Normalize(projectId));
+        return !string.IsNullOrEmpty(projectId) && _blockedProjectIds.Contains(projectId);
     }
 
     /// <summary>
-    /// Opens a write scope for <paramref name="projectId"/> (the shared "reader" side). Use as the
-    /// FIRST statement of any method that mutates the project, so the scope brackets the whole
-    /// mutation:
+    /// Opens a write scope for <paramref name="projectId"/>. Use as the FIRST statement of any
+    /// method that mutates the project, so the scope brackets the whole mutation:
     /// <code>using var _ = SendReceiveWriteLock.EnterWrite(projectId);</code>
     /// Throws immediately (message ending in <see cref="EditBlockedSentinel"/>) if a Send/Receive is
-    /// in progress — it NEVER queues or blocks the caller. Otherwise it holds the RWLS read lock for
-    /// the life of the scope, so a sync starting via <see cref="SetSyncing"/> waits for this write to
-    /// finish before it replaces files. Dispose the returned scope (via <c>using</c>, on the same
-    /// thread) to release the read lock. A no-op gate in public core (nothing arms the lock there).
+    /// armed — it NEVER queues or blocks the caller. Otherwise the open scope counts as an in-flight
+    /// write until disposed, and a sync starting via <see cref="SetSyncing"/> waits for it to close
+    /// before replacing files. A no-op gate in public core (nothing arms the gate there).
     /// <para>
-    /// <b>Hold the scope synchronously — NO <c>await</c>.</b> The RWLS read lock is thread-affine: it
-    /// must be released on the thread that took it. A gated method must therefore run from
-    /// <see cref="EnterWrite"/> to the scope's dispose synchronously on ONE thread — do NOT
-    /// <c>await</c> or hand off to <c>Task.Run</c> between opening the scope and disposing it (an
-    /// <c>await</c> can resume the continuation on a different pool thread, which would then release a
-    /// lock it never took). Several gated methods are named <c>...Async</c> but are synchronous today;
-    /// if one ever needs real asynchrony, do the awaiting OUTSIDE the scope, not across it.
+    /// The scope is forgiving: it may be disposed on a different thread (holding it across an
+    /// <c>await</c> is safe, though scopes should stay tight — a long-held scope delays a sync's
+    /// drain toward its timeout), double-dispose is a no-op, and nesting (a gated method calling
+    /// another gated method) is benign.
     /// </para>
-    /// Because any active sync holds the global write lock, this is a global gate: while ANY project
-    /// is syncing, ALL project writes are rejected (syncs are globally exclusive by design).
+    /// Because arming is global, this is a global gate: while ANY project is syncing, ALL project
+    /// writes are rejected (syncs are globally exclusive by design).
     /// </summary>
     public static IDisposable EnterWrite(string projectId)
     {
         ArgumentNullException.ThrowIfNull(projectId);
 
-        // Fail fast: a zero timeout means we never queue behind a sync's write lock. If a sync holds
-        // (or, RWLS being writer-preferring, has queued for) the write lock, this returns false
-        // immediately and we reject the write rather than blocking a user's keystroke.
-        if (!_lock.TryEnterReadLock(0))
-            throw EditBlocked(projectId);
-
-        // Belt for the degraded window: if the sync timed out draining and proceeded UNHELD, the read
-        // lock above would have been granted even though a sync is active. Consult the armed set
-        // (pure data) and reject if any project is armed. (Also closes the tiny window inside Clear
-        // between disarming the set and releasing the write lock harmlessly: there the set is already
-        // empty so this passes, but the still-held write lock already made TryEnterReadLock(0) fail.)
-        if (_blockedProjectIds.Count != 0)
+        // Atomically "observe not-armed AND count myself in-flight" in one read-modify-write on the
+        // state word. This is the load-bearing step: arming is also a single operation on the same
+        // word, so this either happens entirely before the arm (the sync's drain then waits for the
+        // scope to close) or entirely after it (rejected here). There is no interleaving in which a
+        // write slips past an armed sync.
+        while (true)
         {
-            _lock.ExitReadLock();
-            throw EditBlocked(projectId);
+            long state = Volatile.Read(ref _state);
+            if ((state & ArmedFlag) != 0)
+                throw EditBlocked(projectId);
+            if (Interlocked.CompareExchange(ref _state, state + 1, state) == state)
+                return new WriteScope();
         }
-
-        return new WriteScope();
     }
 
     /// <summary>
-    /// The disposable returned by <see cref="EnterWrite"/>. Releases the RWLS read lock exactly once
-    /// on dispose (guarded so a double-dispose can't call <c>ExitReadLock</c> twice). Must be disposed
-    /// on the thread that opened it (RWLS thread affinity) — guaranteed by the
-    /// <c>using var _ = EnterWrite(...)</c> usage inside a single synchronous method.
+    /// Closes a write scope: atomically decrements the in-flight count. Guarded against underflow
+    /// (a release with no matching open scope is logged and ignored) so no caller bug can corrupt
+    /// the armed flag stored in the same word.
+    /// </summary>
+    private static void ExitWrite()
+    {
+        while (true)
+        {
+            long state = Volatile.Read(ref _state);
+            if ((state & InFlightCountMask) == 0)
+            {
+                Console.Error.WriteLine(
+                    "[SendReceiveWriteLock] Error: a write scope was released with no write "
+                        + "in flight (unbalanced Dispose); ignoring."
+                );
+                return;
+            }
+            if (Interlocked.CompareExchange(ref _state, state - 1, state) == state)
+                return;
+        }
+    }
+
+    /// <summary>
+    /// The disposable returned by <see cref="EnterWrite"/>. Releases its in-flight count exactly
+    /// once, from whatever thread disposes it (an interlocked guard makes cross-thread double-
+    /// dispose safe).
     /// </summary>
     private sealed class WriteScope : IDisposable
     {
-        private bool _disposed;
+        private int _disposed;
 
         public void Dispose()
         {
-            if (_disposed)
+            if (Interlocked.Exchange(ref _disposed, 1) != 0)
                 return;
-            _disposed = true;
-            _lock.ExitReadLock();
+            ExitWrite();
         }
     }
 }

--- a/c-sharp/Projects/SendReceive/SendReceiveWriteLock.cs
+++ b/c-sharp/Projects/SendReceive/SendReceiveWriteLock.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace Paranext.DataProvider.Projects.SendReceive;
 
@@ -40,13 +41,13 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// flag, so after the arming operation NO new write scope can open, and the in-flight count the
 /// drain then waits on can only fall. Because a write's mutation happens entirely between its enter
 /// and exit operations (both full fences), a drained count also means every finished write's
-/// effects are visible to the sync. The word also carries an 8-bit arm generation — the token
+/// effects are visible to the sync. The word also carries an arm generation — the token
 /// <see cref="SetSyncing"/> returns — so <see cref="Clear(long)"/> can check-and-disarm in the
 /// same single CAS (see the overlap remarks below). No mutual exclusion depends on any other
 /// field: <c>_blockedProjectIds</c> is pure data (it only feeds <see cref="IsBlocked"/> queries,
-/// and can transiently disagree with the gate while racing arm/clear calls overlap — rejection
-/// never consults it), and there is deliberately no "is the lock held" bookkeeping to fall out of
-/// step with reality.
+/// and can disagree with the gate while racing arm/clear calls overlap — potentially for that
+/// whole bracket, not just momentarily; rejection never consults it), and there is deliberately
+/// no "is the lock held" bookkeeping to fall out of step with reality.
 /// </para>
 /// <para>
 /// <b>Forgiving lifecycle contract (deliberate).</b> The arm→clear bracket is activated by code
@@ -114,8 +115,9 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// of silently disarming a newer sync. Overlapping arm→clear brackets are still not meaningful —
 /// the scheduler must serialize sync runs — but no interleaving of calls can corrupt the state
 /// word; the worst outcome of an overlap is now an early disarm via a force-<see cref="Clear()"/>
-/// (or a transiently stale pure-data set — see above). <see cref="IsBlocked"/> answers per-project
-/// queries from the pure-data set and is deliberately narrower than the global gate.
+/// (or a stale pure-data set, possibly for that whole bracket — see above).
+/// <see cref="IsBlocked"/> answers per-project queries from the pure-data set and is deliberately
+/// narrower than the global gate.
 /// </para>
 /// <para>
 /// <b>Distinct from the Send/Receive server-side repository lock.</b> This class is an
@@ -130,8 +132,9 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// <see cref="SetSyncing"/>, so the gate is never armed, <see cref="IsBlocked"/> always returns
 /// <c>false</c>, every <see cref="EnterWrite"/> scope succeeds, and no write is ever rejected —
 /// public behavior is unchanged by this class. The Paratext 10 Studio closed-source patch brackets
-/// each automatic sync with <see cref="SetSyncing"/> / <see cref="Clear"/> (Jira PT-4210), which is
-/// what activates the gate. This class is the public seam; the activation lives in the patch.
+/// each automatic sync with <see cref="SetSyncing"/> / <see cref="Clear(long)"/> (Jira PT-4210),
+/// which is what activates the gate. This class is the public seam; the activation lives in the
+/// patch.
 /// </para>
 /// </remarks>
 internal static class SendReceiveWriteLock
@@ -142,25 +145,36 @@ internal static class SendReceiveWriteLock
     public const string EditBlockedSentinel = "(SR_EDIT_BLOCKED)";
 
     // The single atomic word all mutual exclusion rests on (see the class remarks): bits 0–31
-    // count in-flight write scopes, bit 32 is the "a sync is armed" flag, and bits 33–40 hold the
-    // 8-bit arm generation — the token SetSyncing returns and Clear(token) checks, riding in the
-    // same word so the check-and-disarm stays one CAS. It wraps mod 256; a stale token could only
-    // false-match after 256 intervening arms, and even then the damage is just a disarm-early
-    // (the pre-token status quo). Mutate ONLY via Interlocked operations; read via Volatile.Read
-    // (a long read is not atomic on 32-bit without it).
+    // count in-flight write scopes, bit 32 is the "a sync is armed" flag, and bits 33–62 hold the
+    // 30-bit arm generation — the token SetSyncing returns and Clear(token) checks, riding in the
+    // same word so the check-and-disarm stays one CAS. Token 0 is never issued (it is skipped on
+    // wrap) so callers can safely treat default(long) as "no arm"; at 30 bits a stale token could
+    // only false-match after ~10^9 intervening arms. Mutate ONLY via Interlocked operations; read
+    // via Volatile.Read — it gives acquire ordering, and the BCL implements the long overload with
+    // an interlocked read on 32-bit runtimes, so (unlike a plain long read, which can tear there)
+    // it is also atomic. The shipping targets are 64-bit; that is defense for ports.
     private const long ArmedFlag = 1L << 32;
     private const long InFlightCountMask = 0xFFFF_FFFFL;
     private const int GenerationShift = 33;
-    private const long GenerationMask = 0xFFL << GenerationShift;
+    private const long GenerationMask = 0x3FFF_FFFFL << GenerationShift;
     private static long _state;
+
+    private static long CountOf(long state) => state & InFlightCountMask;
+
+    private static long GenerationOf(long state) => (state & GenerationMask) >> GenerationShift;
+
+    // Cached empty set: the non-default comparer defeats ImmutableHashSet's Empty singleton, so a
+    // computed property would allocate on every access. MUST stay declared ABOVE _blockedProjectIds
+    // (static field initializers run in textual order, and _blockedProjectIds reads this one — the
+    // other way around it would silently initialize to null).
+    private static readonly IImmutableSet<string> EmptyProjectIds = ImmutableHashSet.Create<string>(
+        StringComparer.OrdinalIgnoreCase
+    );
 
     // Pure data (no synchronization role — the atomic word does all exclusion): drives IsBlocked
     // per-project queries. Published (volatile) before the armed flag is set and replaced wholesale,
     // never mutated. Case-insensitive because project ID casing varies across call sites.
     private static volatile IImmutableSet<string> _blockedProjectIds = EmptyProjectIds;
-
-    private static IImmutableSet<string> EmptyProjectIds =>
-        ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase);
 
     // How long SetSyncing waits for in-flight writes to drain before giving up. BOUNDED on purpose:
     // a sync start must never be able to deadlock behind a write scope that (through a bug, a stuck
@@ -174,22 +188,28 @@ internal static class SendReceiveWriteLock
     internal static bool IsArmed => (Volatile.Read(ref _state) & ArmedFlag) != 0;
 
     /// <summary>The number of write scopes currently open. For tests only.</summary>
-    internal static long InFlightWriteCount => Volatile.Read(ref _state) & InFlightCountMask;
+    internal static long InFlightWriteCount => CountOf(Volatile.Read(ref _state));
 
     /// <summary>The armed project-id set exactly as stored. For tests only.</summary>
     internal static IImmutableSet<string> ArmedProjectIds => _blockedProjectIds;
+
+    /// <summary>The largest value the arm generation can hold before wrapping. For tests only
+    /// (lets a test park the generation at the wrap boundary via
+    /// <see cref="ResetForTests"/>).</summary>
+    internal static long MaxGeneration => GenerationMask >> GenerationShift;
 
     /// <summary>
     /// Resets ALL gate state, INCLUDING the in-flight count that <see cref="Clear()"/> deliberately
     /// leaves alone. For tests only: contains the blast radius of a test that leaked a write scope
     /// (otherwise every later <see cref="SetSyncing"/> in the run would burn its full
-    /// <see cref="DrainTimeout"/>). Never call in production — a straggler scope disposed after
-    /// this reset would decrement a newer scope's count.
+    /// <see cref="DrainTimeout"/>). Optionally seeds the arm generation (e.g. to
+    /// <see cref="MaxGeneration"/>, to exercise the wrap). Never call in production — a straggler
+    /// scope disposed after this reset would decrement a newer scope's count.
     /// </summary>
-    internal static void ResetForTests()
+    internal static void ResetForTests(long generation = 0)
     {
         _blockedProjectIds = EmptyProjectIds;
-        Volatile.Write(ref _state, 0);
+        Volatile.Write(ref _state, (generation << GenerationShift) & GenerationMask);
     }
 
     private static InvalidOperationException EditBlocked(string projectId) =>
@@ -255,16 +275,19 @@ internal static class SendReceiveWriteLock
             );
 
         // Publish the pure data first, then arm. Arming is a single CAS on the state word that
-        // sets the flag AND advances the 8-bit generation (the returned token): every write that
-        // enters afterward must observe the flag (all transitions on the word are totally ordered)
-        // and is rejected, and every earlier token goes stale in the same atomic step.
+        // sets the flag AND advances the generation (the returned token): every write that enters
+        // afterward must observe the flag (all transitions on the word are totally ordered) and is
+        // rejected, and every earlier token goes stale in the same atomic step. Token 0 is skipped
+        // on wrap — it stays reserved as a natural "no arm" default for callers.
         _blockedProjectIds = armedProjectIds;
         long token;
         while (true)
         {
             long state = Volatile.Read(ref _state);
-            token = (((state & GenerationMask) >> GenerationShift) + 1) & 0xFF;
-            long armedState = (state & InFlightCountMask) | ArmedFlag | (token << GenerationShift);
+            token = (GenerationOf(state) + 1) & (GenerationMask >> GenerationShift);
+            if (token == 0)
+                token = 1;
+            long armedState = CountOf(state) | ArmedFlag | (token << GenerationShift);
             if (Interlocked.CompareExchange(ref _state, armedState, state) == state)
                 break;
         }
@@ -272,24 +295,26 @@ internal static class SendReceiveWriteLock
         // Drain: wait (bounded) until no write scopes remain open — or until this arm is ended by
         // a concurrent Clear (without that second condition the loop's premise would be gone: once
         // disarmed, writes enter again and the count may never settle, so the wait would just burn
-        // the whole timeout for nothing). SpinUntil escalates spin → yield → sleep, so a long
-        // drain does not burn a core.
-        SpinWait.SpinUntil(
-            static () =>
-            {
-                long state = Volatile.Read(ref _state);
-                return (state & InFlightCountMask) == 0 || (state & ArmedFlag) == 0;
-            },
-            DrainTimeout
-        );
+        // the whole timeout for nothing). Poll with SpinWait.SpinOnce(), which escalates
+        // spin → yield → Sleep(1): after the first ~20 iterations the loop wakes ~once per ms and
+        // uses negligible CPU. (Deliberately NOT SpinWait.SpinUntil — it never escalates to
+        // Sleep(1), so it would busy-burn a core for the whole drain.)
+        var spinner = new SpinWait();
+        var stopwatch = Stopwatch.StartNew();
+        while (true)
+        {
+            long current = Volatile.Read(ref _state);
+            if (CountOf(current) == 0 || (current & ArmedFlag) == 0)
+                break;
+            if (stopwatch.Elapsed >= DrainTimeout)
+                break;
+            spinner.SpinOnce();
+        }
 
-        // Triage on a fresh read (the authority), not SpinUntil's return value: the state may have
-        // settled between the last poll and here.
+        // Triage on a fresh read (the authority — the state may have settled between the last poll
+        // and here).
         long observed = Volatile.Read(ref _state);
-        if (
-            (observed & ArmedFlag) == 0
-            || ((observed & GenerationMask) >> GenerationShift) != token
-        )
+        if ((observed & ArmedFlag) == 0 || GenerationOf(observed) != token)
         {
             Console.Error.WriteLine(
                 "[SendReceiveWriteLock] Warning: this arm was ended (Clear) or replaced (a newer "
@@ -298,9 +323,12 @@ internal static class SendReceiveWriteLock
             );
             return token;
         }
-        long stillInFlight = observed & InFlightCountMask;
+        long stillInFlight = CountOf(observed);
         if (stillInFlight != 0)
         {
+            string drainFailure =
+                $"{stillInFlight} in-flight project write(s) did not drain within "
+                + $"{DrainTimeout.TotalSeconds:0.#}s";
             if (throwOnDrainTimeout)
             {
                 // Roll this arm back BEFORE throwing (own-token disarm — a safe no-op if something
@@ -308,18 +336,16 @@ internal static class SendReceiveWriteLock
                 // "nothing armed on this bracket's behalf, writes flow again, no cleanup owed".
                 Clear(token);
                 throw new TimeoutException(
-                    $"{stillInFlight} in-flight project write(s) did not drain within "
-                        + $"{DrainTimeout.TotalSeconds:0.#}s; the Send/Receive arm was rolled "
-                        + "back and the sync must not proceed."
+                    $"{drainFailure}; the Send/Receive arm was rolled back and the sync must "
+                        + "not proceed."
                 );
             }
 
             // Degraded: proceed rather than deadlock the sync. The armed flag keeps rejecting
             // new writes; only the already-stuck write(s) we couldn't drain may still overlap.
             Console.Error.WriteLine(
-                $"[SendReceiveWriteLock] Warning: {stillInFlight} in-flight project write(s) did "
-                    + $"not drain within {DrainTimeout.TotalSeconds:0.#}s; proceeding with "
-                    + "Send/Receive anyway (new writes stay rejected while the sync is armed)."
+                $"[SendReceiveWriteLock] Warning: {drainFailure}; proceeding with Send/Receive "
+                    + "anyway (new writes stay rejected while the sync is armed)."
             );
         }
         return token;
@@ -353,7 +379,7 @@ internal static class SendReceiveWriteLock
             long state = Volatile.Read(ref _state);
             if ((state & ArmedFlag) == 0)
                 return; // Idempotent: nothing armed (this bracket was already cleared).
-            if (((state & GenerationMask) >> GenerationShift) != token)
+            if (GenerationOf(state) != token)
             {
                 Console.Error.WriteLine(
                     "[SendReceiveWriteLock] Warning: Clear(token) ignored a stale token — a newer "
@@ -429,7 +455,7 @@ internal static class SendReceiveWriteLock
         while (true)
         {
             long state = Volatile.Read(ref _state);
-            if ((state & InFlightCountMask) == 0)
+            if (CountOf(state) == 0)
             {
                 Console.Error.WriteLine(
                     "[SendReceiveWriteLock] Error: a write scope was released with no write "

--- a/c-sharp/Projects/SendReceive/SendReceiveWriteLock.cs
+++ b/c-sharp/Projects/SendReceive/SendReceiveWriteLock.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Diagnostics;
 
 namespace Paranext.DataProvider.Projects.SendReceive;
 
@@ -41,9 +40,13 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// flag, so after the arming operation NO new write scope can open, and the in-flight count the
 /// drain then waits on can only fall. Because a write's mutation happens entirely between its enter
 /// and exit operations (both full fences), a drained count also means every finished write's
-/// effects are visible to the sync. No mutual exclusion depends on any other field:
-/// <c>_blockedProjectIds</c> is pure data (it only feeds <see cref="IsBlocked"/> queries), and
-/// there is deliberately no "is the lock held" bookkeeping to fall out of step with reality.
+/// effects are visible to the sync. The word also carries an 8-bit arm generation — the token
+/// <see cref="SetSyncing"/> returns — so <see cref="Clear(long)"/> can check-and-disarm in the
+/// same single CAS (see the overlap remarks below). No mutual exclusion depends on any other
+/// field: <c>_blockedProjectIds</c> is pure data (it only feeds <see cref="IsBlocked"/> queries,
+/// and can transiently disagree with the gate while racing arm/clear calls overlap — rejection
+/// never consults it), and there is deliberately no "is the lock held" bookkeeping to fall out of
+/// step with reality.
 /// </para>
 /// <para>
 /// <b>Forgiving lifecycle contract (deliberate).</b> The arm→clear bracket is activated by code
@@ -52,8 +55,9 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// <list type="bullet">
 /// <item>
 /// <description>
-/// <see cref="SetSyncing"/> and <see cref="Clear"/> may run on ANY thread, including different
-/// threads — an <c>await</c> between them (which resumes on a different pool thread) is fine.
+/// <see cref="SetSyncing"/> and <see cref="Clear()"/>/<see cref="Clear(long)"/> may run on ANY
+/// thread, including different threads — an <c>await</c> between them (which resumes on a
+/// different pool thread) is fine.
 /// </description>
 /// </item>
 /// <item>
@@ -65,16 +69,26 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// </item>
 /// <item>
 /// <description>
-/// Nested <see cref="EnterWrite"/> calls are benign (a gated method may call another gated method);
-/// the inner scope simply counts as one more in-flight write until disposed.
+/// Nested <see cref="EnterWrite"/> calls do not crash or deadlock (there is no recursion policy) —
+/// while nothing is armed, an inner scope simply counts as one more in-flight write. They are NOT
+/// rejection-safe, though: the gate tracks no ownership, so if a sync arms while the outer scope
+/// is open (the normal drain window), the inner call throws the sentinel MID-mutation and tears
+/// the outer write. Keep one scope per mutation — a method that delegates to another write must
+/// call an un-gated core inside its single outer scope (see <c>SetBookUsfmInScope</c>), never a
+/// second gated entry point.
 /// </description>
 /// </item>
 /// <item>
 /// <description>
-/// <see cref="Clear"/> is idempotent and safe to call when nothing is armed, so it can serve as
+/// <see cref="Clear()"/> is idempotent and safe to call when nothing is armed, so it can serve as
 /// crash recovery: if a sync worker dies without clearing, ANY thread (e.g. a watchdog or the next
-/// sync) can call <see cref="Clear"/> to recover. Double-disposing a scope and over-releasing are
-/// guarded no-ops. No call sequence, on any combination of threads, can wedge the gate permanently.
+/// sync) can call it to recover. Bracket code should prefer <see cref="Clear(long)"/> with the
+/// token its <see cref="SetSyncing"/> returned — a newer arm turns that into a logged no-op, so a
+/// late or duplicate Clear cannot disarm a sync it does not own. Double-disposing a scope and
+/// over-releasing are guarded no-ops. No SetSyncing/Clear/Dispose sequence, on any combination of
+/// threads, can leave writes permanently rejected. (A write scope that is never disposed is the
+/// one durable failure: its count is deliberately NOT reset by Clear, so every later sync waits
+/// out the full <see cref="DrainTimeout"/> and proceeds degraded.)
 /// </description>
 /// </item>
 /// </list>
@@ -84,18 +98,24 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// <see cref="DrainTimeout"/>, <see cref="SetSyncing"/> logs a warning and returns anyway — a sync
 /// start must never hang forever behind a stuck write. The armed flag keeps rejecting NEW writes
 /// exactly as on the normal path; only the already-stuck write(s) may still overlap the sync. This
-/// is an accepted residual risk, traded against deadlocking every future sync.
+/// is an accepted residual risk, traded against deadlocking every future sync. A caller that must
+/// not run concurrently with even a stuck write can opt out per call: <see cref="SetSyncing"/>
+/// with <c>throwOnDrainTimeout: true</c> rolls the arm back and throws
+/// <see cref="TimeoutException"/> instead, leaving the retry/defer decision to the scheduler.
 /// </para>
 /// <para>
 /// <b>One global sync slot; overlap semantics.</b> The gate is global: while ANY sync is armed, ALL
 /// project writes are rejected (automatic syncs are globally exclusive by design), which is why
 /// rejection does not consult the per-project set. A repeat <see cref="SetSyncing"/> while armed
-/// replaces the armed project-id set (call it once per sync batch with the full set), and any
-/// <see cref="Clear"/> fully disarms. Overlapping arm→clear brackets from two concurrent syncs are
-/// therefore not meaningful — the scheduler must serialize sync runs — but no interleaving of calls
-/// can corrupt the gate; the worst outcome of an overlap is disarming earlier than one of the two
-/// syncs expected. <see cref="IsBlocked"/> answers per-project queries from the pure-data set and is
-/// deliberately narrower than the global gate.
+/// takes over the slot: it replaces the armed project-id set and returns a NEW token, invalidating
+/// every earlier one (call it once per sync batch with the full set, and Clear with the latest
+/// token). A parameterless <see cref="Clear()"/> always disarms; <see cref="Clear(long)"/> disarms
+/// only the bracket that owns the slot, so a stale bracket's late Clear is a logged no-op instead
+/// of silently disarming a newer sync. Overlapping arm→clear brackets are still not meaningful —
+/// the scheduler must serialize sync runs — but no interleaving of calls can corrupt the state
+/// word; the worst outcome of an overlap is now an early disarm via a force-<see cref="Clear()"/>
+/// (or a transiently stale pure-data set — see above). <see cref="IsBlocked"/> answers per-project
+/// queries from the pure-data set and is deliberately narrower than the global gate.
 /// </para>
 /// <para>
 /// <b>Distinct from the Send/Receive server-side repository lock.</b> This class is an
@@ -121,11 +141,17 @@ internal static class SendReceiveWriteLock
     // generic permissions message) and revert the un-saved change.
     public const string EditBlockedSentinel = "(SR_EDIT_BLOCKED)";
 
-    // The single atomic word all mutual exclusion rests on (see the class remarks): bit 32 is the
-    // "a sync is armed" flag, bits 0–31 count in-flight write scopes. Mutate ONLY via Interlocked
-    // operations; read via Volatile.Read (a long read is not atomic on 32-bit without it).
+    // The single atomic word all mutual exclusion rests on (see the class remarks): bits 0–31
+    // count in-flight write scopes, bit 32 is the "a sync is armed" flag, and bits 33–40 hold the
+    // 8-bit arm generation — the token SetSyncing returns and Clear(token) checks, riding in the
+    // same word so the check-and-disarm stays one CAS. It wraps mod 256; a stale token could only
+    // false-match after 256 intervening arms, and even then the damage is just a disarm-early
+    // (the pre-token status quo). Mutate ONLY via Interlocked operations; read via Volatile.Read
+    // (a long read is not atomic on 32-bit without it).
     private const long ArmedFlag = 1L << 32;
     private const long InFlightCountMask = 0xFFFF_FFFFL;
+    private const int GenerationShift = 33;
+    private const long GenerationMask = 0xFFL << GenerationShift;
     private static long _state;
 
     // Pure data (no synchronization role — the atomic word does all exclusion): drives IsBlocked
@@ -150,6 +176,22 @@ internal static class SendReceiveWriteLock
     /// <summary>The number of write scopes currently open. For tests only.</summary>
     internal static long InFlightWriteCount => Volatile.Read(ref _state) & InFlightCountMask;
 
+    /// <summary>The armed project-id set exactly as stored. For tests only.</summary>
+    internal static IImmutableSet<string> ArmedProjectIds => _blockedProjectIds;
+
+    /// <summary>
+    /// Resets ALL gate state, INCLUDING the in-flight count that <see cref="Clear()"/> deliberately
+    /// leaves alone. For tests only: contains the blast radius of a test that leaked a write scope
+    /// (otherwise every later <see cref="SetSyncing"/> in the run would burn its full
+    /// <see cref="DrainTimeout"/>). Never call in production — a straggler scope disposed after
+    /// this reset would decrement a newer scope's count.
+    /// </summary>
+    internal static void ResetForTests()
+    {
+        _blockedProjectIds = EmptyProjectIds;
+        Volatile.Write(ref _state, 0);
+    }
+
     private static InvalidOperationException EditBlocked(string projectId) =>
         new(
             $"Cannot write to project '{projectId}' while an automatic Send/Receive is in "
@@ -160,19 +202,38 @@ internal static class SendReceiveWriteLock
     /// Marks the given projects as being synced, then waits (bounded by <see cref="DrainTimeout"/>)
     /// for any already-in-flight writes to drain before returning. From the moment this arms the
     /// gate, new <see cref="EnterWrite"/> calls for ANY project fail fast; after it returns, either
-    /// no write scopes remain open (normal path) or the drain timed out and it has logged a warning
-    /// and proceeded anyway (degraded path — new writes are still rejected either way). Replaces any
+    /// no write scopes remain open (normal path), or the drain timed out and it has logged a
+    /// warning and proceeded anyway (degraded path — new writes are still rejected either way; or,
+    /// with <paramref name="throwOnDrainTimeout"/>, it rolled this arm back and threw instead), or
+    /// a concurrent <see cref="Clear()"/> / newer <see cref="SetSyncing"/> ended this arm mid-drain
+    /// (logged — the gate is then no longer rejecting on behalf of THIS sync). Replaces any
     /// previously set project list; call once per sync batch with the full set of projects. Null or
-    /// empty ids in the batch are ignored.
+    /// empty ids in the batch are ignored (an all-invalid batch still arms the global gate, with a
+    /// logged warning).
     /// <para>
-    /// May be called from any thread; <see cref="Clear"/> may later run on a different thread (an
-    /// <c>await</c> between them is fine). Do not call while holding an open <see cref="EnterWrite"/>
-    /// scope this call would wait for — the drain cannot finish and will time out into the degraded
-    /// path. Overlapping sync brackets are not meaningful (see the class remarks); the scheduler
+    /// May be called from any thread; the bracket-ending Clear may later run on a different thread
+    /// (an <c>await</c> between them is fine). End the bracket with <see cref="Clear(long)"/> and
+    /// the returned token — a stale token is a logged no-op, so a late Clear can never disarm a
+    /// newer sync's arm. Do not call while holding an open <see cref="EnterWrite"/> scope this
+    /// call would wait for — the drain cannot finish and will time out into the degraded path.
+    /// Overlapping sync brackets are still not meaningful (see the class remarks); the scheduler
     /// must serialize sync runs.
     /// </para>
     /// </summary>
-    public static void SetSyncing(IEnumerable<string> projectIds)
+    /// <param name="projectIds">The full set of project ids in this sync batch (null or empty
+    /// entries are ignored).</param>
+    /// <param name="throwOnDrainTimeout">When <c>true</c>, a drain timeout aborts the sync start
+    /// instead of degrading: this arm is rolled back (nothing stays armed on this bracket's
+    /// behalf, so writes flow again and the caller has NO cleanup obligation) and a
+    /// <see cref="TimeoutException"/> is thrown — the sync must not proceed; the caller decides
+    /// whether to retry, defer, or notify. When <c>false</c> (the default), the degraded path
+    /// applies (see the class remarks). This affects ONLY the drain-timeout outcome — an arm
+    /// ended or replaced mid-drain still returns normally with a logged warning.</param>
+    /// <returns>The arm token identifying this bracket; pass it to <see cref="Clear(long)"/>.</returns>
+    /// <exception cref="TimeoutException">The drain timed out and
+    /// <paramref name="throwOnDrainTimeout"/> was <c>true</c>; the arm has been rolled back.
+    /// </exception>
+    public static long SetSyncing(IEnumerable<string> projectIds, bool throwOnDrainTimeout = false)
     {
         ArgumentNullException.ThrowIfNull(projectIds);
 
@@ -182,44 +243,131 @@ internal static class SendReceiveWriteLock
             .Where(projectId => !string.IsNullOrEmpty(projectId))
             .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
 
-        // Publish the pure data first, then arm. Arming is a single interlocked bit-set on the
-        // state word: every write that enters afterward must observe the flag (all transitions on
-        // the word are totally ordered) and is rejected.
-        _blockedProjectIds = armedProjectIds;
-        Interlocked.Or(ref _state, ArmedFlag);
+        // An all-invalid batch is almost certainly a caller bug (e.g. a failed project lookup).
+        // Still arm — fail-safe: an armed gate with an empty set rejects writes exactly like any
+        // other arm — but say so, because IsBlocked will report false for every project while
+        // every write is rejected, which is otherwise baffling to diagnose.
+        if (armedProjectIds.Count == 0)
+            Console.Error.WriteLine(
+                "[SendReceiveWriteLock] Warning: SetSyncing was called with no valid project ids; "
+                    + "the global gate is armed anyway (all writes rejected), but IsBlocked will "
+                    + "report false for every project."
+            );
 
-        // Drain: wait (bounded) until no write scopes remain open. New writes can no longer enter,
-        // so the count only falls. SpinWait escalates spin → yield → sleep, so a long drain does
-        // not burn a core.
-        var spinner = new SpinWait();
-        var stopwatch = Stopwatch.StartNew();
-        while ((Volatile.Read(ref _state) & InFlightCountMask) != 0)
+        // Publish the pure data first, then arm. Arming is a single CAS on the state word that
+        // sets the flag AND advances the 8-bit generation (the returned token): every write that
+        // enters afterward must observe the flag (all transitions on the word are totally ordered)
+        // and is rejected, and every earlier token goes stale in the same atomic step.
+        _blockedProjectIds = armedProjectIds;
+        long token;
+        while (true)
         {
-            if (stopwatch.Elapsed >= DrainTimeout)
-            {
-                // Degraded: proceed rather than deadlock the sync. The armed flag keeps rejecting
-                // new writes; only the already-stuck write(s) we couldn't drain may still overlap.
-                Console.Error.WriteLine(
-                    "[SendReceiveWriteLock] Warning: in-flight project write(s) did not drain "
-                        + $"within {DrainTimeout.TotalSeconds:0.#}s; proceeding with Send/Receive "
-                        + "anyway (new writes stay blocked while the sync is armed)."
-                );
-                return;
-            }
-            spinner.SpinOnce();
+            long state = Volatile.Read(ref _state);
+            token = (((state & GenerationMask) >> GenerationShift) + 1) & 0xFF;
+            long armedState = (state & InFlightCountMask) | ArmedFlag | (token << GenerationShift);
+            if (Interlocked.CompareExchange(ref _state, armedState, state) == state)
+                break;
         }
+
+        // Drain: wait (bounded) until no write scopes remain open — or until this arm is ended by
+        // a concurrent Clear (without that second condition the loop's premise would be gone: once
+        // disarmed, writes enter again and the count may never settle, so the wait would just burn
+        // the whole timeout for nothing). SpinUntil escalates spin → yield → sleep, so a long
+        // drain does not burn a core.
+        SpinWait.SpinUntil(
+            static () =>
+            {
+                long state = Volatile.Read(ref _state);
+                return (state & InFlightCountMask) == 0 || (state & ArmedFlag) == 0;
+            },
+            DrainTimeout
+        );
+
+        // Triage on a fresh read (the authority), not SpinUntil's return value: the state may have
+        // settled between the last poll and here.
+        long observed = Volatile.Read(ref _state);
+        if (
+            (observed & ArmedFlag) == 0
+            || ((observed & GenerationMask) >> GenerationShift) != token
+        )
+        {
+            Console.Error.WriteLine(
+                "[SendReceiveWriteLock] Warning: this arm was ended (Clear) or replaced (a newer "
+                    + "SetSyncing) while its drain was still waiting; proceeding, but the gate is "
+                    + "no longer rejecting writes on behalf of THIS sync."
+            );
+            return token;
+        }
+        long stillInFlight = observed & InFlightCountMask;
+        if (stillInFlight != 0)
+        {
+            if (throwOnDrainTimeout)
+            {
+                // Roll this arm back BEFORE throwing (own-token disarm — a safe no-op if something
+                // else already took or cleared the slot in the meantime), so a throw always means
+                // "nothing armed on this bracket's behalf, writes flow again, no cleanup owed".
+                Clear(token);
+                throw new TimeoutException(
+                    $"{stillInFlight} in-flight project write(s) did not drain within "
+                        + $"{DrainTimeout.TotalSeconds:0.#}s; the Send/Receive arm was rolled "
+                        + "back and the sync must not proceed."
+                );
+            }
+
+            // Degraded: proceed rather than deadlock the sync. The armed flag keeps rejecting
+            // new writes; only the already-stuck write(s) we couldn't drain may still overlap.
+            Console.Error.WriteLine(
+                $"[SendReceiveWriteLock] Warning: {stillInFlight} in-flight project write(s) did "
+                    + $"not drain within {DrainTimeout.TotalSeconds:0.#}s; proceeding with "
+                    + "Send/Receive anyway (new writes stay rejected while the sync is armed)."
+            );
+        }
+        return token;
     }
 
     /// <summary>
-    /// Ends the sync: disarms the gate and clears the armed project set, so writes are accepted
-    /// again. May be called from ANY thread (not just the one that called <see cref="SetSyncing"/>),
-    /// is idempotent, and is safe to call when no sync is active at all — so it doubles as the
-    /// recovery path if a sync worker dies without clearing.
+    /// Ends the sync UNCONDITIONALLY: disarms the gate (whichever bracket armed it) and clears the
+    /// armed project set, so writes are accepted again. May be called from ANY thread, is
+    /// idempotent, and is safe to call when no sync is active at all — this is the force/crash
+    /// recovery path (e.g. a watchdog, or the next sync finding a dead worker's arm still set).
+    /// Normal bracket code should prefer <see cref="Clear(long)"/>, which cannot disarm a sync it
+    /// does not own.
     /// </summary>
     public static void Clear()
     {
         _blockedProjectIds = EmptyProjectIds;
         Interlocked.And(ref _state, ~ArmedFlag);
+    }
+
+    /// <summary>
+    /// Ends the sync bracket identified by <paramref name="token"/> (returned by
+    /// <see cref="SetSyncing"/>): disarms only if that bracket still owns the sync slot. A stale
+    /// token — a newer <see cref="SetSyncing"/> has taken the slot — is a logged no-op, so a late
+    /// or duplicate Clear can never disarm a newer sync's arm. When nothing is armed at all this
+    /// is a silent no-op (idempotent). Runs on any thread.
+    /// </summary>
+    public static void Clear(long token)
+    {
+        while (true)
+        {
+            long state = Volatile.Read(ref _state);
+            if ((state & ArmedFlag) == 0)
+                return; // Idempotent: nothing armed (this bracket was already cleared).
+            if (((state & GenerationMask) >> GenerationShift) != token)
+            {
+                Console.Error.WriteLine(
+                    "[SendReceiveWriteLock] Warning: Clear(token) ignored a stale token — a newer "
+                        + "SetSyncing owns the sync slot (late Clear from an overlapping bracket?)."
+                );
+                return;
+            }
+            if (Interlocked.CompareExchange(ref _state, state & ~ArmedFlag, state) == state)
+            {
+                // The disarm won atomically against the token check; now drop the pure-data set.
+                _blockedProjectIds = EmptyProjectIds;
+                return;
+            }
+        }
     }
 
     /// <summary>
@@ -245,8 +393,9 @@ internal static class SendReceiveWriteLock
     /// <para>
     /// The scope is forgiving: it may be disposed on a different thread (holding it across an
     /// <c>await</c> is safe, though scopes should stay tight — a long-held scope delays a sync's
-    /// drain toward its timeout), double-dispose is a no-op, and nesting (a gated method calling
-    /// another gated method) is benign.
+    /// drain toward its timeout), and double-dispose is a no-op. Nesting does not crash, but it is
+    /// NOT safe around a live sync — if a sync arms while the outer scope is open, the inner call
+    /// throws mid-mutation (see the class remarks); keep one scope per mutation.
     /// </para>
     /// Because arming is global, this is a global gate: while ANY project is syncing, ALL project
     /// writes are rejected (syncs are globally exclusive by design).


### PR DESCRIPTION
[PT-4159](https://paratextstudio.atlassian.net/browse/PT-4159) — proposed follow-up to #2555, targeting that PR's branch so the diff shows only the write-gate rewrite.

## Summary

Rebuilds `SendReceiveWriteLock` from a `ReaderWriterLockSlim` wrapper into a single-atomic-word design: an armed flag, an in-flight write count, and a 30-bit arm generation packed into one `long`, with every transition (enter/exit write, arm, disarm) a single `Interlocked` read-modify-write on that word. The exclusion invariant — no project write can overlap a sync's file-replacement window — now follows from single-location total ordering: a write can only enter by atomically observing *not armed* while incrementing the count, and arming atomically sets the flag, so every write either drains before the sync proceeds or is rejected with the `(SR_EDIT_BLOCKED)` sentinel. `SetSyncing` returns the generation as an arm token (never `0`, so `default` is a safe no-arm sentinel): `Clear(token)` ends only the bracket that owns the sync slot (a stale token is a logged no-op, so a late or duplicate Clear cannot disarm a newer sync), while parameterless `Clear()` remains the unconditional crash-recovery path.

### Why review this

Part of epic PT-4158 (automatic Send/Receive). A concurrency deep dive on #2555's gate found that its correctness rests on a thread-affinity contract — `SetSyncing`/`Clear` on one thread, no `await` across the bracket or a write scope — that is documented but unenforceable, must be honored by the closed-source PT-4210 activation this repo cannot see or test, and whose every violation ends in a permanently held write lock (process-wide edit rejection until restart). See the discussion threads on #2555, especially the [design-level question on `SetSyncing`](https://github.com/paranext/paranext-core/pull/2555#discussion_r3590592171), plus findings [4](https://github.com/paranext/paranext-core/pull/2555#discussion_r3590182932), [5](https://github.com/paranext/paranext-core/pull/2555#discussion_r3590182939), [6](https://github.com/paranext/paranext-core/pull/2555#discussion_r3590182940), [11](https://github.com/paranext/paranext-core/pull/2555#discussion_r3590182963), [20](https://github.com/paranext/paranext-core/pull/2555#discussion_r3590182992), the [`_writeLockHeld` redundancy thread](https://github.com/paranext/paranext-core/pull/2555#discussion_r3590590361), and the [`NoRecursion` trap thread](https://github.com/paranext/paranext-core/pull/2555#discussion_r3590591297) — all structurally addressed here.

## Changes


- **`SendReceiveWriteLock.cs`**: the rewrite. Unchanged semantics: fail-fast sentinel rejection, bounded 10 s drain, degraded proceed-on-timeout by default (new writes still rejected), global gate, per-project `IsBlocked`, inert in public core. The activation API keeps its `SetSyncing`/`Clear` shape (`SetSyncing` now returns the arm token; `Clear(token)` is the bracket-scoped variant). The contract:
  - `SetSyncing`/`Clear` may run on any threads; an `await` across the bracket is safe; `Clear()` is idempotent and doubles as crash recovery (a watchdog is now *possible* — RWLS thread affinity forbade one); `Clear(token)` makes a late bracket-end a logged no-op instead of a silent disarm of a newer sync
  - write scopes may cross an `await` and dispose on another thread; double-dispose and over-release are guarded no-ops
  - nested `EnterWrite` does not crash (no `NoRecursion` trap), but it is NOT rejection-safe — a sync arming while the outer scope is open rejects the inner call mid-mutation — so one scope per mutation (the `SetBookUsfmInScope` delegation pattern) is the required shape for delegating writes
  - the drain waits via `SpinWait.SpinUntil` and ends early (with a warning) if the arm is cleared or replaced mid-drain; the timeout warning reports the stuck in-flight count; optional `SetSyncing(ids, throwOnDrainTimeout: true)` rolls the arm back and throws `TimeoutException` instead of proceeding degraded, so a scheduler can retry/defer/notify
  - armed-ness is an explicit flag (closes the empty-batch degraded-path hole); the project set is built before any state is touched (no torn arm); null/empty ids are ignored, and a batch with no valid ids arms fail-safe with a logged warning; `StringComparer.OrdinalIgnoreCase` replaces hand-rolled case folding
  - no "is the lock held" bookkeeping bool exists to fall out of step with reality
- **`SendReceiveWriteLockTests.cs`**: new-contract tests, written first wherever a red was observable (nesting while unarmed and while armed, cross-thread `Clear` with the armed premise asserted, cross-thread scope dispose, null-id tolerance, token round-trip / stale-token no-op / idempotent re-Clear, prompt return when a `Clear` lands mid-drain, throw-on-timeout rollback, recovery while a write is stuck including the straggler's own decrement). Assertions target `InFlightWriteCount`/`ArmedProjectIds` so release, double-dispose, and id-filter regressions are directly falsifiable, and the fixtures reset the gate's full state (including the in-flight count) between tests. Two old-contract tests removed, `FakeSync` helper deleted (no thread affinity → tests arm directly). The concurrency stress test passes unmodified.
- **`CLAUDE.md`**: the "Send/Receive Write Gate" thread-affinity rules replaced with the new contract — token-ended brackets, the nesting hazard, and keep-scopes-tight guidance.
- **`ParatextProjectDataProvider.cs`**: comments updated to the new contract (single-scope delegation is required, not stylistic; the ParatextData write lock is named explicitly to avoid confusion with the gate's scope). Code unchanged.

## AI Involvement


AI-assisted — [session](https://claude.ai/code/session_01K7mGuL6RtKen6Rm94KWRP6); an earlier session's URL was not captured. The concurrency analysis, the design, the implementation, and the tests were AI-generated with my direction and review; the TDD red/green evidence and full-suite runs were verified in-session. Commits carry `Co-authored-by` trailers.

## Testing


- [x] TDD: new-contract tests were observed failing for the expected reasons before the implementation made them pass — against the RWLS design (`LockRecursionException` on nesting, cross-thread `Clear` `InvalidOperationException`, `SynchronizationLockException` on cross-thread dispose, NRE on a null id) and against the unpatched drain (a `Clear` mid-drain burned the full `DrainTimeout`)
- [x] Full `dotnet test` c-sharp suite: **1511 passed / 0 failed / 6 skipped** (baseline 1500; delta is exactly the net new tests); includes the untouched `SendReceiveWriteLockCoverageTests` enforcement scan and all gate wiring tests
- [x] csharpier clean; no TypeScript changes
- [ ] PT-4210 activation review: confirm the patch's bracket usage — end brackets with `Clear(token)`; nothing enforces this, and parameterless `Clear()` force-disarms any live sync (it is the crash-recovery hammer). Decide whether the scheduler opts into `throwOnDrainTimeout: true`, and double-check the overlap semantics (one global sync slot; the scheduler must serialize sync runs)

## Risk Level


Low–Medium — the gate is inert in public core (nothing calls `SetSyncing`), so public behavior is unchanged; the risk is confined to the PT-4210-activated path, where the forgiving contract widens what the activation may safely do and token-checked Clears make late bracket-ends harmless.

## Merge note

Targets `pt-4159-auto-sync-edit-block` (#2555). If #2555 squash-merges first, retarget this PR to `main` and rebase. Squash-merge is fine for this PR (no template changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PT-4159]: https://paratextstudio.atlassian.net/browse/PT-4159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2564)
<!-- Reviewable:end -->



