### PR TITLE
Auto-sync edit-block follow-ups from #2555 review (PT-4159 / PT-4214 Stage T)

### DIFF
--- a/extensions/src/platform-scripture-editor/src/main.ts
+++ b/extensions/src/platform-scripture-editor/src/main.ts
@@ -10,6 +10,7 @@ import {
   AsyncVariable,
   deepEqual,
   getErrorMessage,
+  newGuid,
   PlatformEventEmitter,
   ResourceType,
   serialize,
@@ -89,13 +90,18 @@ const PROJECT_SWITCH_WILL_START_EVENT = 'platformScriptureEditor.onWillSwitchPro
 const PROJECT_SWITCH_DID_FINISH_EVENT = 'platformScriptureEditor.onDidSwitchProject';
 
 /**
- * Event emitter fired before a project switch. Created lazily on the first call to open() to avoid
- * network initialization races during extension activation.
+ * Event emitter fired before a project switch. Payload carries the switch's unique `switchId`, so
+ * the renderer's workspace-updating service can pair each finish with exactly the switch that
+ * started it. Created lazily on the first call to open() to avoid network initialization races
+ * during extension activation.
  */
-let projectSwitchWillStartEmitter: PlatformEventEmitter<Record<string, never>> | undefined;
+let projectSwitchWillStartEmitter: PlatformEventEmitter<{ switchId: string }> | undefined;
 
-/** Event emitter fired after a project switch completes. Created lazily on the first call to open(). */
-let projectSwitchDidFinishEmitter: PlatformEventEmitter<Record<string, never>> | undefined;
+/**
+ * Event emitter fired after a project switch completes, with the `switchId` of the will-start event
+ * that began it. Created lazily on the first call to open().
+ */
+let projectSwitchDidFinishEmitter: PlatformEventEmitter<{ switchId: string }> | undefined;
 
 // #endregion Project Switch Events
 
@@ -297,18 +303,21 @@ async function open(
     // The transition overlay and project-switch sync only apply in simple mode when the tab
     // content is actually being replaced (not on new-tab opens or focus-existing navigations).
     const needsOverlay = interfaceMode === 'simple' && dispatch.kind === 'replace-tab';
+    // Pairs this switch's will-start and did-finish events, so the renderer releases exactly this
+    // switch when it finishes — never an unrelated concurrent one.
+    const switchId = newGuid();
 
     if (needsOverlay) {
       // Create emitters lazily on first use, after full activation, to avoid network init races.
       if (!projectSwitchWillStartEmitter)
-        projectSwitchWillStartEmitter = papi.network.createNetworkEventEmitter<
-          Record<string, never>
-        >(PROJECT_SWITCH_WILL_START_EVENT);
+        projectSwitchWillStartEmitter = papi.network.createNetworkEventEmitter<{
+          switchId: string;
+        }>(PROJECT_SWITCH_WILL_START_EVENT);
       if (!projectSwitchDidFinishEmitter)
-        projectSwitchDidFinishEmitter = papi.network.createNetworkEventEmitter<
-          Record<string, never>
-        >(PROJECT_SWITCH_DID_FINISH_EVENT);
-      projectSwitchWillStartEmitter.emit({});
+        projectSwitchDidFinishEmitter = papi.network.createNetworkEventEmitter<{
+          switchId: string;
+        }>(PROJECT_SWITCH_DID_FINISH_EVENT);
+      projectSwitchWillStartEmitter.emit({ switchId });
 
       const outgoing = allScriptureEditors.find((e) => e.id === dispatch.targetTabId);
       // Skip outgoing S/R for read-only viewers — no local changes are possible.
@@ -321,7 +330,7 @@ async function open(
 
     const emitDidFinish = () => {
       if (!needsOverlay) return;
-      if (projectSwitchDidFinishEmitter) projectSwitchDidFinishEmitter.emit({});
+      if (projectSwitchDidFinishEmitter) projectSwitchDidFinishEmitter.emit({ switchId });
       else
         logger.warn(
           'projectSwitchDidFinishEmitter was disposed before the project switch completed — workspace-updating overlay may be stuck',

--- a/extensions/src/platform-scripture-editor/src/types/platform-scripture-editor.d.ts
+++ b/extensions/src/platform-scripture-editor/src/types/platform-scripture-editor.d.ts
@@ -692,6 +692,20 @@ declare module 'papi-shared-types' {
      * `papi.network.getNetworkEvent('platformScriptureEditor.onSharedLayoutApply')`.
      */
     'platformScriptureEditor.onSharedLayoutApply': { projectId: string };
+    /**
+     * Emitted just before a scripture editor web view is opened or replaced with a new project.
+     * `switchId` uniquely identifies this switch and pairs it with the matching
+     * `platformScriptureEditor.onDidSwitchProject` event. Subscribe with
+     * `papi.network.getNetworkEvent('platformScriptureEditor.onWillSwitchProject')`.
+     */
+    'platformScriptureEditor.onWillSwitchProject': { switchId: string };
+    /**
+     * Emitted after the scripture editor web view open/replace call resolves. Carries the
+     * `switchId` of the `platformScriptureEditor.onWillSwitchProject` event that started the
+     * switch. Subscribe with
+     * `papi.network.getNetworkEvent('platformScriptureEditor.onDidSwitchProject')`.
+     */
+    'platformScriptureEditor.onDidSwitchProject': { switchId: string };
   }
 
   export interface SettingTypes {

--- a/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
+++ b/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
@@ -626,14 +626,13 @@ global.webViewComponent = function ChecksSidePanelWebView({
           result.checkResultUniqueId,
         );
       } catch (error) {
-        // The deny/allow buttons are fire-and-forget, so without this catch a write-gate rejection
-        // during an automatic Send/Receive becomes an unhandled promise rejection with no UI. Show
-        // the shared "editing paused" warning; re-throw anything else so real errors still surface.
-        if (isSyncEditBlockedError(error)) {
-          notifySyncEditBlocked();
-          return false;
-        }
-        throw error;
+        // The deny/allow buttons are fire-and-forget, so without this catch any rejection becomes
+        // an unhandled promise rejection with no UI. Show the shared "editing paused" warning for a
+        // write-gate rejection during an automatic Send/Receive; log everything else (rethrowing
+        // would land in the void — no caller awaits these handlers).
+        if (isSyncEditBlockedError(error)) notifySyncEditBlocked();
+        else logger.warn(`Could not deny check result: ${getErrorMessage(error)}`);
+        return false;
       }
       if (!isMountedRef.current) return false;
       if (denyResultSuccess) setDeniedStatusForResult(result, true);
@@ -658,14 +657,13 @@ global.webViewComponent = function ChecksSidePanelWebView({
           result.checkResultUniqueId,
         );
       } catch (error) {
-        // The deny/allow buttons are fire-and-forget, so without this catch a write-gate rejection
-        // during an automatic Send/Receive becomes an unhandled promise rejection with no UI. Show
-        // the shared "editing paused" warning; re-throw anything else so real errors still surface.
-        if (isSyncEditBlockedError(error)) {
-          notifySyncEditBlocked();
-          return false;
-        }
-        throw error;
+        // The deny/allow buttons are fire-and-forget, so without this catch any rejection becomes
+        // an unhandled promise rejection with no UI. Show the shared "editing paused" warning for a
+        // write-gate rejection during an automatic Send/Receive; log everything else (rethrowing
+        // would land in the void — no caller awaits these handlers).
+        if (isSyncEditBlockedError(error)) notifySyncEditBlocked();
+        else logger.warn(`Could not allow check result: ${getErrorMessage(error)}`);
+        return false;
       }
       if (!isMountedRef.current) return false;
       if (allowResultStatus) setDeniedStatusForResult(result, false);

--- a/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
+++ b/extensions/src/platform-scripture/src/checks-side-panel.web-view.tsx
@@ -34,7 +34,7 @@ import {
   CHECKS_SIDE_PANEL_STRING_KEYS,
 } from './checks/checks-side-panel/checks-side-panel.component';
 import { useOpenProjectTabs } from './hooks/use-open-project-tabs';
-import { SYNC_EDIT_BLOCKED_MESSAGE_KEY, isSyncEditBlockedError } from './sync-edit-blocked.util';
+import { isSyncEditBlockedError, notifySyncEditBlocked } from './sync-edit-blocked.util';
 
 /**
  * Gets the short and full names of a project from its ID. Kept in the webview (not the shared,
@@ -630,7 +630,7 @@ global.webViewComponent = function ChecksSidePanelWebView({
         // during an automatic Send/Receive becomes an unhandled promise rejection with no UI. Show
         // the shared "editing paused" warning; re-throw anything else so real errors still surface.
         if (isSyncEditBlockedError(error)) {
-          papi.notifications.send({ message: SYNC_EDIT_BLOCKED_MESSAGE_KEY, severity: 'warning' });
+          notifySyncEditBlocked();
           return false;
         }
         throw error;
@@ -662,7 +662,7 @@ global.webViewComponent = function ChecksSidePanelWebView({
         // during an automatic Send/Receive becomes an unhandled promise rejection with no UI. Show
         // the shared "editing paused" warning; re-throw anything else so real errors still surface.
         if (isSyncEditBlockedError(error)) {
-          papi.notifications.send({ message: SYNC_EDIT_BLOCKED_MESSAGE_KEY, severity: 'warning' });
+          notifySyncEditBlocked();
           return false;
         }
         throw error;

--- a/extensions/src/platform-scripture/src/inventory.web-view.tsx
+++ b/extensions/src/platform-scripture/src/inventory.web-view.tsx
@@ -1,5 +1,5 @@
 import { WebViewProps } from '@papi/core';
-import papi, { logger } from '@papi/frontend';
+import { logger } from '@papi/frontend';
 import { useLocalizedStrings, useProjectData, useProjectSetting } from '@papi/frontend/react';
 import { Canon, SerializedVerseRef } from '@sillsdev/scripture';
 import { INVENTORY_STRING_KEYS, Scope } from 'platform-bible-react';
@@ -23,7 +23,7 @@ import {
   REPEATED_WORDS_INVENTORY_STRING_KEYS,
 } from './checks/inventories/repeated-words-inventory.component';
 import { useInventory } from './hooks/use-inventory';
-import { SYNC_EDIT_BLOCKED_MESSAGE_KEY, isSyncEditBlockedError } from './sync-edit-blocked.util';
+import { isSyncEditBlockedError, notifySyncEditBlocked } from './sync-edit-blocked.util';
 
 const VALID_ITEMS_DEFAULT = '';
 const INVALID_ITEMS_DEFAULT = '';
@@ -313,12 +313,15 @@ global.webViewComponent = function InventoryWebView({
   const handleApprovedItemsChange = useCallback(
     async (items: string[]) => {
       try {
-        await setValidItems?.(items.join(' '));
+        // `useProjectSetting`'s declared setter type erases the promise the setter actually
+        // returns at runtime; adopt it via Promise.resolve so this await genuinely waits and the
+        // catch below sees a write-gate rejection.
+        await Promise.resolve(setValidItems?.(items.join(' ')));
       } catch (error) {
         // The write-gate rejects this settings write while an automatic Send/Receive is syncing.
         // Show the shared "editing paused" warning instead of only logging (which is invisible).
         if (isSyncEditBlockedError(error)) {
-          papi.notifications.send({ message: SYNC_EDIT_BLOCKED_MESSAGE_KEY, severity: 'warning' });
+          notifySyncEditBlocked();
           return;
         }
         logger.error(`Error updating approved items: ${getErrorMessage(error)}`);
@@ -331,12 +334,14 @@ global.webViewComponent = function InventoryWebView({
   const handleUnapprovedItemsChange = useCallback(
     async (items: string[]) => {
       try {
-        await setInvalidItems?.(items.join(' '));
+        // Same promise-adoption as handleApprovedItemsChange above — the declared setter type
+        // erases the runtime promise.
+        await Promise.resolve(setInvalidItems?.(items.join(' ')));
       } catch (error) {
         // The write-gate rejects this settings write while an automatic Send/Receive is syncing.
         // Show the shared "editing paused" warning instead of only logging (which is invisible).
         if (isSyncEditBlockedError(error)) {
-          papi.notifications.send({ message: SYNC_EDIT_BLOCKED_MESSAGE_KEY, severity: 'warning' });
+          notifySyncEditBlocked();
           return;
         }
         logger.error(`Error updating unapproved items: ${getErrorMessage(error)}`);

--- a/extensions/src/platform-scripture/src/inventory.web-view.tsx
+++ b/extensions/src/platform-scripture/src/inventory.web-view.tsx
@@ -313,10 +313,7 @@ global.webViewComponent = function InventoryWebView({
   const handleApprovedItemsChange = useCallback(
     async (items: string[]) => {
       try {
-        // `useProjectSetting`'s declared setter type erases the promise the setter actually
-        // returns at runtime; adopt it via Promise.resolve so this await genuinely waits and the
-        // catch below sees a write-gate rejection.
-        await Promise.resolve(setValidItems?.(items.join(' ')));
+        await setValidItems?.(items.join(' '));
       } catch (error) {
         // The write-gate rejects this settings write while an automatic Send/Receive is syncing.
         // Show the shared "editing paused" warning instead of only logging (which is invisible).
@@ -334,9 +331,7 @@ global.webViewComponent = function InventoryWebView({
   const handleUnapprovedItemsChange = useCallback(
     async (items: string[]) => {
       try {
-        // Same promise-adoption as handleApprovedItemsChange above — the declared setter type
-        // erases the runtime promise.
-        await Promise.resolve(setInvalidItems?.(items.join(' ')));
+        await setInvalidItems?.(items.join(' '));
       } catch (error) {
         // The write-gate rejects this settings write while an automatic Send/Receive is syncing.
         // Show the shared "editing paused" warning instead of only logging (which is invisible).

--- a/extensions/src/platform-scripture/src/manage-books.web-view.tsx
+++ b/extensions/src/platform-scripture/src/manage-books.web-view.tsx
@@ -49,7 +49,7 @@ import {
   GreekEstherTemplatePicker,
   GreekEstherTemplatePickerLocalizedStrings,
 } from './greek-esther-template-picker.component';
-import { SYNC_EDIT_BLOCKED_MESSAGE_KEY, isSyncEditBlockedError } from './sync-edit-blocked.util';
+import { isSyncEditBlockedError, notifySyncEditBlocked } from './sync-edit-blocked.util';
 
 const NETWORK_OBJECT_ID = 'platformScripture.manageBooks';
 const BOOKS_PRESENT_DEFAULT = '0'.repeat(123);
@@ -866,25 +866,28 @@ global.webViewComponent = function ManageBooksWebView({
   const onMutationResult = useCallback((result: MutationResult) => {
     const entries: AlertEntry[] = [...result.errors, ...result.warnings];
     entries.forEach((entry) => {
-      try {
-        // notificationService is exposed on @papi/frontend; per
-        // ui-spec-manage-books.md:118 toasts are the canonical surface. A write-gate rejection
-        // reaches here as an error entry whose text carries the `(SR_EDIT_BLOCKED)` sentinel (the
-        // dialog turns a thrown backend error into a MutationResult error) — show the shared
-        // "editing paused" warning instead of leaking the raw technical message at error severity.
-        papi.notifications.send(
-          isSyncEditBlockedError(entry.text)
-            ? { message: SYNC_EDIT_BLOCKED_MESSAGE_KEY, severity: 'warning' }
-            : {
-                message: entry.caption ? `${entry.caption}: ${entry.text}` : entry.text,
-                severity: alertLevelToSeverity(entry.level),
-              },
-        );
-      } catch (e) {
-        logger.warn(
-          `manage-books: notifications.send failed for AlertEntry: ${e instanceof Error ? e.message : String(e)}`,
-        );
+      // A write-gate rejection reaches here as an error entry whose text carries the
+      // `(SR_EDIT_BLOCKED)` sentinel (the dialog turns a thrown backend error into a
+      // MutationResult error) — show the shared "editing paused" warning (self-catching) instead
+      // of leaking the raw technical message at error severity.
+      if (isSyncEditBlockedError(entry.text)) {
+        notifySyncEditBlocked();
+        return;
       }
+      // notificationService is exposed on @papi/frontend; per ui-spec-manage-books.md:118 toasts
+      // are the canonical surface. `.catch` rather than try/catch: the send is fire-and-forget
+      // (this callback cannot await inside forEach), so a try/catch would only ever see
+      // synchronous throws and a rejection would leak as an unhandled promise rejection.
+      papi.notifications
+        .send({
+          message: entry.caption ? `${entry.caption}: ${entry.text}` : entry.text,
+          severity: alertLevelToSeverity(entry.level),
+        })
+        .catch((e) => {
+          logger.warn(
+            `manage-books: notifications.send failed for AlertEntry: ${getErrorMessage(e)}`,
+          );
+        });
     });
   }, []);
 

--- a/extensions/src/platform-scripture/src/sync-edit-blocked.util.test.ts
+++ b/extensions/src/platform-scripture/src/sync-edit-blocked.util.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import {
-  SYNC_EDIT_BLOCKED_MESSAGE_KEY,
-  isSyncEditBlockedError,
-  notifySyncEditBlocked,
-} from './sync-edit-blocked.util';
+import { isSyncEditBlockedError, notifySyncEditBlocked } from './sync-edit-blocked.util';
 
 const mockSend = vi.fn<(notification: unknown) => Promise<number | undefined>>();
 const mockLoggerWarn = vi.fn<(message: string) => void>();
@@ -24,8 +20,20 @@ describe('isSyncEditBlockedError', () => {
     expect(isSyncEditBlockedError(new Error('Cannot save now (SR_EDIT_BLOCKED)'))).toBe(true);
   });
 
+  it('detects the sentinel in a bare message string (manage-books passes AlertEntry.text)', () => {
+    // getErrorMessage wraps a bare string as `new Error(JSON.stringify(string))`, so the message
+    // arrives quote-wrapped: `"Cannot create book (SR_EDIT_BLOCKED)"`. The regex is deliberately
+    // unanchored so the sentinel still matches inside the wrapping quotes — anchoring it to the
+    // end of the message would silently kill this path while the Error path stayed green.
+    expect(isSyncEditBlockedError('Cannot create book (SR_EDIT_BLOCKED)')).toBe(true);
+  });
+
   it('returns false for an unrelated error', () => {
     expect(isSyncEditBlockedError(new Error('Something else went wrong'))).toBe(false);
+  });
+
+  it('returns false for an unrelated bare string', () => {
+    expect(isSyncEditBlockedError('Something else went wrong')).toBe(false);
   });
 });
 
@@ -40,8 +48,10 @@ describe('notifySyncEditBlocked', () => {
     await notifySyncEditBlocked();
 
     expect(mockSend).toHaveBeenCalledTimes(1);
+    // The literal key (not the util's own constant) so this fails if the key ever drifts from
+    // the entry contributed in contributions/localizedStrings.json.
     expect(mockSend).toHaveBeenCalledWith({
-      message: SYNC_EDIT_BLOCKED_MESSAGE_KEY,
+      message: '%webView_platformScripture_error_syncEditBlocked%',
       severity: 'warning',
     });
     expect(mockLoggerWarn).not.toHaveBeenCalled();

--- a/extensions/src/platform-scripture/src/sync-edit-blocked.util.test.ts
+++ b/extensions/src/platform-scripture/src/sync-edit-blocked.util.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  SYNC_EDIT_BLOCKED_MESSAGE_KEY,
+  isSyncEditBlockedError,
+  notifySyncEditBlocked,
+} from './sync-edit-blocked.util';
+
+const mockSend = vi.fn<(notification: unknown) => Promise<number | undefined>>();
+const mockLoggerWarn = vi.fn<(message: string) => void>();
+
+vi.mock('@papi/frontend', () => ({
+  default: {
+    notifications: {
+      send: (notification: unknown) => mockSend(notification),
+    },
+  },
+  logger: {
+    warn: (message: string) => mockLoggerWarn(message),
+  },
+}));
+
+describe('isSyncEditBlockedError', () => {
+  it('detects the write-gate sentinel in an Error message', () => {
+    expect(isSyncEditBlockedError(new Error('Cannot save now (SR_EDIT_BLOCKED)'))).toBe(true);
+  });
+
+  it('returns false for an unrelated error', () => {
+    expect(isSyncEditBlockedError(new Error('Something else went wrong'))).toBe(false);
+  });
+});
+
+describe('notifySyncEditBlocked', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sends the shared warning notification', async () => {
+    mockSend.mockResolvedValue(undefined);
+
+    await notifySyncEditBlocked();
+
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    expect(mockSend).toHaveBeenCalledWith({
+      message: SYNC_EDIT_BLOCKED_MESSAGE_KEY,
+      severity: 'warning',
+    });
+    expect(mockLoggerWarn).not.toHaveBeenCalled();
+  });
+
+  it('swallows and logs a rejected send so fire-and-forget callers cannot leak a rejection', async () => {
+    mockSend.mockRejectedValue(new Error('notification service unavailable'));
+
+    // Must resolve (not reject) even though the send rejected
+    await expect(notifySyncEditBlocked()).resolves.toBeUndefined();
+
+    expect(mockLoggerWarn).toHaveBeenCalledTimes(1);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('notification service unavailable'),
+    );
+  });
+});

--- a/extensions/src/platform-scripture/src/sync-edit-blocked.util.ts
+++ b/extensions/src/platform-scripture/src/sync-edit-blocked.util.ts
@@ -17,9 +17,10 @@ export const SYNC_EDIT_BLOCKED_REGEX = /\(SR_EDIT_BLOCKED\)/;
 /**
  * Localization key for the shared "editing is paused during Send/Receive" warning shown when one of
  * this extension's mutations is rejected by the write-gate. Contributed in this extension's
- * `contributions/localizedStrings.json`.
+ * `contributions/localizedStrings.json`. Deliberately not exported: every caller goes through
+ * {@link notifySyncEditBlocked} so the severity/message pair cannot drift across call sites.
  */
-export const SYNC_EDIT_BLOCKED_MESSAGE_KEY = '%webView_platformScripture_error_syncEditBlocked%';
+const SYNC_EDIT_BLOCKED_MESSAGE_KEY = '%webView_platformScripture_error_syncEditBlocked%';
 
 /**
  * Whether `error` was thrown by the write-gate because an automatic Send/Receive is in progress

--- a/extensions/src/platform-scripture/src/sync-edit-blocked.util.ts
+++ b/extensions/src/platform-scripture/src/sync-edit-blocked.util.ts
@@ -1,3 +1,4 @@
+import papi, { logger } from '@papi/frontend';
 import { getErrorMessage } from 'platform-bible-utils';
 
 /**
@@ -31,4 +32,23 @@ export const SYNC_EDIT_BLOCKED_MESSAGE_KEY = '%webView_platformScripture_error_s
  */
 export function isSyncEditBlockedError(error: unknown): boolean {
   return SYNC_EDIT_BLOCKED_REGEX.test(getErrorMessage(error));
+}
+
+/**
+ * Shows the shared "editing is paused during Send/Receive" warning notification (the write-gate
+ * rejection detected by {@link isSyncEditBlockedError} surfaced to the user). Extracted so the
+ * severity/message cannot drift across the several call sites that report it, and self-catching so
+ * fire-and-forget callers (the ones that cannot `await`) never surface an unhandled promise
+ * rejection from the notification service. The platform-scripture twin of the scripture editor's
+ * own `notifySyncEditBlocked`.
+ */
+export async function notifySyncEditBlocked(): Promise<void> {
+  try {
+    await papi.notifications.send({
+      message: SYNC_EDIT_BLOCKED_MESSAGE_KEY,
+      severity: 'warning',
+    });
+  } catch (e) {
+    logger.warn(`Failed to send the sync-edit-blocked notification: ${getErrorMessage(e)}`);
+  }
 }

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -8383,12 +8383,10 @@ declare module 'shared/data/platform.data' {
   export const MIN_ZOOM_FACTOR = 0.5;
   export const MAX_ZOOM_FACTOR = 3;
   /**
-   * Upper bound (10 minutes) for how long an automatic Send/Receive is allowed to run before we stop
-   * waiting on it. Used as the shutdown-sync timeout in the main process and as the auto-sync
-   * edit-block safety leash in the renderer. A scheduled sync of a large repo can run for minutes, so
-   * this is deliberately long.
+   * Upper bound (10 minutes) on how long a single automatic Send/Receive is allowed to run. A
+   * scheduled sync of a large repo can run for minutes, so this is deliberately long.
    */
-  export const SHUTDOWN_SYNC_TIME_OUT_MS: number;
+  export const AUTO_SYNC_MAX_DURATION_MS: number;
 }
 declare module 'shared/log-error.model' {
   /** Error that force logs the error message before throwing. Useful for debugging in some situations. */

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -8390,8 +8390,8 @@ declare module 'shared/data/platform.data' {
   export const MIN_ZOOM_FACTOR = 0.5;
   export const MAX_ZOOM_FACTOR = 3;
   /**
-   * Upper bound (10 minutes) on how long a single app-driven ("automatic") Send/Receive is allowed
-   * to run — one the app starts itself rather than the user driving it from the Send/Receive dialog
+   * Upper bound (10 minutes) on how long a single app-driven ("automatic") Send/Receive is allowed to
+   * run — one the app starts itself rather than the user driving it from the Send/Receive dialog
    * (which has its own progress and Cancel). A sync of a large repo can run for minutes, so this is
    * deliberately long.
    *

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -2199,6 +2199,13 @@ declare module 'shared/services/network.service' {
    * requests where immediate failure is preferable to waiting, such as commands sent during app
    * shutdown.
    *
+   * WARNING: the no-retry flag only holds in the main process (whose `RpcServer` /
+   * `RpcWebSocketListener` honor it). From any other process the flag does not cross the wire:
+   * `RpcClient.request` drops it, and main re-dispatches the incoming request through its
+   * registration-race retry loop (up to 10 attempts, 1 s apart) before failing. So a renderer-side
+   * `requestNoRetry` to an unregistered handler still costs ~9 s and 10 warning logs in main before
+   * it rejects.
+   *
    * @param requestType The type of request
    * @param args Arguments to send in the request (put in request.contents)
    * @returns Promise that resolves with the response message
@@ -8383,8 +8390,19 @@ declare module 'shared/data/platform.data' {
   export const MIN_ZOOM_FACTOR = 0.5;
   export const MAX_ZOOM_FACTOR = 3;
   /**
-   * Upper bound (10 minutes) on how long a single automatic Send/Receive is allowed to run. A
-   * scheduled sync of a large repo can run for minutes, so this is deliberately long.
+   * Upper bound (10 minutes) on how long a single app-driven ("automatic") Send/Receive is allowed
+   * to run — one the app starts itself rather than the user driving it from the Send/Receive dialog
+   * (which has its own progress and Cancel). A sync of a large repo can run for minutes, so this is
+   * deliberately long.
+   *
+   * Two different consumers share this value and must never diverge:
+   *
+   * - The main process (`shutdown-tasks.ts`) bounds how long app shutdown waits on its final sync.
+   * - The renderer (`auto-sync-blocking-store.ts`) bounds each edit-block safety leash — how long a
+   *   single blocker may block editing if its clearing event never arrives.
+   *
+   * If they diverged, a shutdown sync could outlive the renderer's opinion of it (or vice versa);
+   * tune this value knowing it retimes both.
    */
   export const AUTO_SYNC_MAX_DURATION_MS: number;
 }
@@ -8943,9 +8961,15 @@ declare module 'renderer/hooks/papi-hooks/use-project-data.hook' {
 }
 declare module 'renderer/hooks/papi-hooks/use-project-setting.hook' {
   import { PlatformError } from 'platform-bible-utils';
-  import { DataProviderSubscriberOptions } from 'shared/models/data-provider.model';
+  import {
+    DataProviderSubscriberOptions,
+    DataProviderUpdateInstructions,
+  } from 'shared/models/data-provider.model';
+  import { ExtractDataProviderDataTypes } from 'shared/models/extract-data-provider-data-types.model';
+  import { PROJECT_INTERFACE_PLATFORM_BASE } from 'shared/models/project-data-provider.model';
   import {
     IBaseProjectDataProvider,
+    ProjectInterfaceDataTypes,
     ProjectSettingNames,
     ProjectSettingTypes,
   } from 'papi-shared-types';
@@ -8979,11 +9003,14 @@ declare module 'renderer/hooks/papi-hooks/use-project-setting.hook' {
    *       {@link PlatformError} if the Project Data Provider throws an error. You can call
    *       {@link isPlatformError} on this value to check if it is an error.
    *   - `setSetting`: asynchronous function to request that the Project Data Provider update the project
-   *       setting with the specified key. Returns `true` if successful. Note that this function does
-   *       not update the data. The Project Data Provider sends out an update to this subscription if
-   *       it successfully updates data.
+   *       setting with the specified key. Returns a promise that resolves to the update instructions
+   *       once the write completes, and rejects if the write is rejected (e.g. by the Send/Receive
+   *       write-gate) — await it (or attach a `.catch`) to observe write failures. Note that this
+   *       function does not update the data. The Project Data Provider sends out an update to this
+   *       subscription if it successfully updates data.
    *   - `resetSetting`: asynchronous function to request that the Project Data Provider reset the project
-   *       setting
+   *       setting. Returns a promise that resolves to `true` if successfully reset, and rejects if
+   *       the reset is rejected.
    *   - `isLoading`: whether the setting value is awaiting retrieval from the Project Data Provider
    *
    * @throws When subscription callback function is called with an update that has an unexpected
@@ -8996,8 +9023,18 @@ declare module 'renderer/hooks/papi-hooks/use-project-setting.hook' {
     subscriberOptions?: DataProviderSubscriberOptions,
   ) => [
     setting: ProjectSettingTypes[ProjectSettingName] | PlatformError,
-    setSetting: ((newSetting: ProjectSettingTypes[ProjectSettingName]) => void) | undefined,
-    resetSetting: (() => void) | undefined,
+    setSetting:
+      | ((
+          newSetting: ProjectSettingTypes[ProjectSettingName],
+        ) => Promise<
+          DataProviderUpdateInstructions<
+            ExtractDataProviderDataTypes<
+              ProjectInterfaceDataTypes[typeof PROJECT_INTERFACE_PLATFORM_BASE]
+            >
+          >
+        >)
+      | undefined,
+    resetSetting: (() => Promise<boolean>) | undefined,
     isLoading: boolean,
   ];
   export default useProjectSetting;

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -8403,6 +8403,8 @@ declare module 'shared/data/platform.data' {
    *
    * If they diverged, a shutdown sync could outlive the renderer's opinion of it (or vice versa);
    * tune this value knowing it retimes both.
+   *
+   * @experimental
    */
   export const AUTO_SYNC_MAX_DURATION_MS: number;
 }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -577,7 +577,7 @@ async function main() {
     mainWindow.on('close', async (event) => {
       // A second close click while the first shutdown is still running falls through to Electron's
       // default close on purpose: with the shutdown sync's request timeout disabled by the
-      // extension, the bounded wait below can hold the window up to SHUTDOWN_SYNC_TIME_OUT_MS with
+      // extension, the bounded wait below can hold the window up to AUTO_SYNC_MAX_DURATION_MS with
       // no feedback, and this fall-through is the user's only escape hatch until a real
       // feedback/cancel UX exists (tracked on the shutdown-cancel follow-up ticket). It abandons
       // the in-flight sync mid-flight — same risk profile as force-quitting the app.

--- a/src/main/shutdown-tasks.test.ts
+++ b/src/main/shutdown-tasks.test.ts
@@ -1,5 +1,5 @@
 import { vi } from 'vitest';
-import { SHUTDOWN_SYNC_TIME_OUT_MS } from '@shared/data/platform.data';
+import { AUTO_SYNC_MAX_DURATION_MS } from '@shared/data/platform.data';
 import { settingsService } from '@shared/services/settings.service';
 import * as networkService from '@shared/services/network.service';
 import { networkObjectService } from '@shared/services/network-object.service';
@@ -100,13 +100,13 @@ describe('performShutdownTasks', () => {
     mockSettingsGet.mockResolvedValue('power');
     // Never-resolving promise: simulates a genuinely hung sync. `performSync` never settles, so the
     // AsyncVariable's timeout rejects `syncComplete.promise` and runBoundedShutdownSync takes its
-    // `timedOut` branch — the one path SHUTDOWN_SYNC_TIME_OUT_MS exists to bound. (An unregistered
+    // `timedOut` branch — the one path AUTO_SYNC_MAX_DURATION_MS exists to bound. (An unregistered
     // command does NOT reach here; it rejects fast and settles as `failed`, covered above.)
     mockRequestNoRetry.mockImplementation(() => new Promise(() => {}));
     vi.useFakeTimers();
     try {
       const shutdownPromise = performShutdownTasks();
-      await vi.advanceTimersByTimeAsync(SHUTDOWN_SYNC_TIME_OUT_MS);
+      await vi.advanceTimersByTimeAsync(AUTO_SYNC_MAX_DURATION_MS);
       await expect(shutdownPromise).resolves.toBeUndefined();
     } finally {
       vi.useRealTimers();

--- a/src/main/shutdown-tasks.ts
+++ b/src/main/shutdown-tasks.ts
@@ -1,4 +1,4 @@
-import { SHUTDOWN_SYNC_TIME_OUT_MS } from '@shared/data/platform.data';
+import { AUTO_SYNC_MAX_DURATION_MS } from '@shared/data/platform.data';
 import { CATEGORY_COMMAND } from '@shared/data/rpc.model';
 import { logger } from '@shared/services/logger.service';
 import { networkObjectService } from '@shared/services/network-object.service';
@@ -29,7 +29,7 @@ import { AsyncVariable, getErrorMessage } from 'platform-bible-utils';
  * - `skipped`: nothing ran — nothing scheduled, not due, or already syncing (Power: `'skipped'`).
  * - `unreachable`: the S/R call rejected before the timeout (e.g. the command isn't registered). The
  *   failure detail was already warned inside {@link runBoundedShutdownSync}.
- * - `timed-out`: neither settled within {@link SHUTDOWN_SYNC_TIME_OUT_MS} (also already warned there).
+ * - `timed-out`: neither settled within {@link AUTO_SYNC_MAX_DURATION_MS} (also already warned there).
  */
 type ShutdownSyncOutcome = 'synced' | 'failed' | 'skipped' | 'unreachable' | 'timed-out';
 
@@ -163,7 +163,7 @@ async function performSimpleModeShutdownSync(): Promise<void> {
  * retrying would only fight the window hang below, since the window is already held open waiting on
  * this one sync.
  *
- * {@link SHUTDOWN_SYNC_TIME_OUT_MS} is the ONLY real bound on this call: the S/R extension registers
+ * {@link AUTO_SYNC_MAX_DURATION_MS} is the ONLY real bound on this call: the S/R extension registers
  * `runScheduledSessionSync` with its per-request timeout disabled (a scheduled sync can
  * legitimately run long), so `requestNoRetry` has no client-side timeout of its own here. If the
  * extension ever stopped disabling that timeout, this would silently become a ~30 s truncation that
@@ -212,7 +212,7 @@ function logShutdownSyncOutcome(outcome: ShutdownSyncOutcome): void {
 
 /**
  * Runs `performSync` in the background and waits for it to settle, bounded by
- * {@link SHUTDOWN_SYNC_TIME_OUT_MS} so a genuinely hung sync can never wedge shutdown open forever.
+ * {@link AUTO_SYNC_MAX_DURATION_MS} so a genuinely hung sync can never wedge shutdown open forever.
  * The timeout is load-bearing for a _hung_ sync specifically: an unregistered command does NOT hang
  * — it rejects fast with MethodNotFound, which surfaces as a `failed` settlement (this is exactly
  * what startup's retry loop is built on). What the bound actually guards against is that the S/R
@@ -231,7 +231,7 @@ async function runBoundedShutdownSync<T>(
 ): Promise<BoundedSyncSettlement<T>> {
   const syncComplete = new AsyncVariable<BoundedSyncSettlement<T>>(
     variableName,
-    SHUTDOWN_SYNC_TIME_OUT_MS,
+    AUTO_SYNC_MAX_DURATION_MS,
   );
   (async () => {
     let settlement: BoundedSyncSettlement<T>;
@@ -253,7 +253,7 @@ async function runBoundedShutdownSync<T>(
     // mislabelled as a 10-minute timeout.
     if (syncComplete.hasTimedOut) {
       logger.warn(
-        `${variableName} timed out after ${SHUTDOWN_SYNC_TIME_OUT_MS} ms; continuing shutdown`,
+        `${variableName} timed out after ${AUTO_SYNC_MAX_DURATION_MS} ms; continuing shutdown`,
       );
       return { status: 'timedOut' };
     }

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -30,7 +30,7 @@ import { getErrorMessage, wait } from 'platform-bible-utils';
  * budget locally instead of changing the shared default.
  *
  * Exported so the retry tests can drive fake timers by the exact same duration rather than
- * duplicating the literal (mirrors `SHUTDOWN_SYNC_TIME_OUT_MS` in `shutdown-tasks.ts`).
+ * duplicating the literal (mirrors `AUTO_SYNC_MAX_DURATION_MS` in `shutdown-tasks.ts`).
  */
 export const STARTUP_SYNC_RETRY_BUDGET_MS = 120_000;
 

--- a/src/renderer/components/overlays/overlay-workspace-updating.component.test.tsx
+++ b/src/renderer/components/overlays/overlay-workspace-updating.component.test.tsx
@@ -2,7 +2,7 @@ import { render, screen, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi, beforeEach } from 'vitest';
 import {
-  setWorkspaceUpdating,
+  startWorkspaceUpdate,
   resetWorkspaceUpdating,
 } from '@renderer/services/workspace-updating-store';
 import { WorkspaceUpdatingOverlay } from './overlay-workspace-updating.component';
@@ -29,7 +29,7 @@ describe('WorkspaceUpdatingOverlay', () => {
   it('renders spinner and localized text when workspace is updating', () => {
     render(<WorkspaceUpdatingOverlay />);
     act(() => {
-      setWorkspaceUpdating(true);
+      startWorkspaceUpdate();
     });
     expect(screen.getByText('Updating workspace...')).toBeInTheDocument();
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
@@ -37,11 +37,12 @@ describe('WorkspaceUpdatingOverlay', () => {
 
   it('hides the overlay when workspace finishes updating', () => {
     render(<WorkspaceUpdatingOverlay />);
+    let release: (() => void) | undefined;
     act(() => {
-      setWorkspaceUpdating(true);
+      release = startWorkspaceUpdate();
     });
     act(() => {
-      setWorkspaceUpdating(false);
+      release?.();
     });
     expect(screen.queryByText('Updating workspace...')).not.toBeInTheDocument();
   });

--- a/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
@@ -67,7 +67,7 @@ type ProjectSettingsControls = {
   // Necessary for flexibility in handleChangeSetting, ProjectSettingValues and
   // UserSettingValues are not the same so it couldn't assign
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  setSetting: ((newSetting: any) => void) | undefined;
+  setSetting: ((newSetting: any) => Promise<unknown>) | undefined;
   isLoading: boolean;
 };
 
@@ -224,7 +224,9 @@ export function Setting({
     try {
       if (validateSetting && (await validateSetting(settingKey, newValue, setting))) {
         setErrorMessage(undefined);
-        if (setSetting) setSetting(newValue);
+        // Await so a rejected write (e.g. the Send/Receive write-gate) reaches the catch below
+        // and surfaces as an error message instead of vanishing as an unhandled rejection.
+        if (setSetting) await setSetting(newValue);
       } else {
         setErrorMessage(localizedStrings['%settings_errorMessages_invalidValue%']);
       }

--- a/src/renderer/hooks/papi-hooks/use-project-setting.hook.ts
+++ b/src/renderer/hooks/papi-hooks/use-project-setting.hook.ts
@@ -46,11 +46,14 @@ import { useMemo } from 'react';
  *       {@link PlatformError} if the Project Data Provider throws an error. You can call
  *       {@link isPlatformError} on this value to check if it is an error.
  *   - `setSetting`: asynchronous function to request that the Project Data Provider update the project
- *       setting with the specified key. Returns `true` if successful. Note that this function does
- *       not update the data. The Project Data Provider sends out an update to this subscription if
- *       it successfully updates data.
+ *       setting with the specified key. Returns a promise that resolves to the update instructions
+ *       once the write completes, and rejects if the write is rejected (e.g. by the Send/Receive
+ *       write-gate) — await it (or attach a `.catch`) to observe write failures. Note that this
+ *       function does not update the data. The Project Data Provider sends out an update to this
+ *       subscription if it successfully updates data.
  *   - `resetSetting`: asynchronous function to request that the Project Data Provider reset the project
- *       setting
+ *       setting. Returns a promise that resolves to `true` if successfully reset, and rejects if
+ *       the reset is rejected.
  *   - `isLoading`: whether the setting value is awaiting retrieval from the Project Data Provider
  *
  * @throws When subscription callback function is called with an update that has an unexpected
@@ -65,8 +68,18 @@ export const useProjectSetting = <ProjectSettingName extends ProjectSettingNames
   subscriberOptions?: DataProviderSubscriberOptions,
 ): [
   setting: ProjectSettingTypes[ProjectSettingName] | PlatformError,
-  setSetting: ((newSetting: ProjectSettingTypes[ProjectSettingName]) => void) | undefined,
-  resetSetting: (() => void) | undefined,
+  setSetting:
+    | ((
+        newSetting: ProjectSettingTypes[ProjectSettingName],
+      ) => Promise<
+        DataProviderUpdateInstructions<
+          ExtractDataProviderDataTypes<
+            ProjectInterfaceDataTypes[typeof PROJECT_INTERFACE_PLATFORM_BASE]
+          >
+        >
+      >)
+    | undefined,
+  resetSetting: (() => Promise<boolean>) | undefined,
   isLoading: boolean,
 ] => {
   const projectDataProvider = useProjectDataProvider(
@@ -107,12 +120,7 @@ export const useProjectSetting = <ProjectSettingName extends ProjectSettingNames
   /* eslint-enable */
 
   const resetSetting = useMemo(
-    () =>
-      projectDataProvider
-        ? () => {
-            projectDataProvider.resetSetting(key);
-          }
-        : undefined,
+    () => (projectDataProvider ? () => projectDataProvider.resetSetting(key) : undefined),
     [projectDataProvider, key],
   );
 

--- a/src/renderer/services/auto-sync-blocking-integration.test.ts
+++ b/src/renderer/services/auto-sync-blocking-integration.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getNetworkEvent } from '@shared/services/network.service';
+import {
+  getAutoSyncBlocking,
+  resetAutoSyncBlocking,
+} from '@renderer/services/auto-sync-blocking-store';
+import { initAutoSyncBlockingService } from './auto-sync-blocking-service';
+
+vi.mock('@shared/services/network.service', () => ({
+  getNetworkEvent: vi.fn(),
+  requestNoRetry: vi.fn(),
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn(), warn: vi.fn() },
+}));
+
+const TEN_MINUTES_MS = 10 * 60 * 1000;
+
+/**
+ * Integration tests: real auto-sync-blocking store driven through the service by simulated blocking
+ * events, under fake timers. The blocking events are anonymous booleans, so the service pairs
+ * clears to raises oldest-first — but a raise whose own leash already fired must absorb its late
+ * clear as a no-op instead of releasing a newer, still-live blocker (the #2571 review's finding 1
+ * trace, in this store's 10-minute shape).
+ */
+describe('auto-sync blocking service + store integration', () => {
+  let blockingHandler: ((event: { isBlocking: boolean }) => void) | undefined;
+  let cleanup: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetAutoSyncBlocking();
+    blockingHandler = undefined;
+
+    vi.mocked(getNetworkEvent).mockImplementation(
+      // getNetworkEvent has a complex generic signature; cast is required for the mock
+      // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
+      ((eventName: string) => {
+        if (eventName === 'paratextBibleSendReceive.onAutoSyncBlockingChanged')
+          return (cb: (event: { isBlocking: boolean }) => void) => {
+            blockingHandler = cb;
+            return vi.fn();
+          };
+        return () => vi.fn();
+        // Same cast as above: closing the type assertion needed for the complex generic signature
+        // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
+      }) as any,
+    );
+
+    cleanup = initAutoSyncBlockingService();
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    resetAutoSyncBlocking();
+    vi.useRealTimers();
+  });
+
+  function emitBlocking(isBlocking: boolean): void {
+    if (!blockingHandler) throw new Error('blocking handler not subscribed');
+    blockingHandler({ isBlocking });
+  }
+
+  it('keeps a live blocker blocked when an older raise clears late, after its own leash fired (review finding 1 trace)', () => {
+    // A raises at t=0; B raises just before A's 10-minute leash fires.
+    emitBlocking(true);
+    vi.advanceTimersByTime(TEN_MINUTES_MS - 10_000);
+    emitBlocking(true);
+
+    // t=10min: A's leash fires. A is released; B is still blocking.
+    vi.advanceTimersByTime(10_000);
+    expect(getAutoSyncBlocking()).toBe(true);
+
+    // A's real clear arrives late. It must pair with A (already released by its own leash — a
+    // no-op), never with B: B's sync is still running, so blocking must stay on.
+    vi.advanceTimersByTime(30_000);
+    emitBlocking(false);
+    expect(getAutoSyncBlocking()).toBe(true);
+
+    // B's own leash fires (B never cleared) — now everything is released.
+    vi.advanceTimersByTime(TEN_MINUTES_MS);
+    expect(getAutoSyncBlocking()).toBe(false);
+  });
+});

--- a/src/renderer/services/auto-sync-blocking-service.test.ts
+++ b/src/renderer/services/auto-sync-blocking-service.test.ts
@@ -1,15 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getNetworkEvent } from '@shared/services/network.service';
+import { getNetworkEvent, requestNoRetry } from '@shared/services/network.service';
 import { setAutoSyncBlocking } from '@renderer/services/auto-sync-blocking-store';
 import { initAutoSyncBlockingService } from './auto-sync-blocking-service';
 
 vi.mock('@shared/services/network.service', () => ({
   getNetworkEvent: vi.fn(),
+  requestNoRetry: vi.fn(),
 }));
 
 vi.mock('@renderer/services/auto-sync-blocking-store', () => ({
   setAutoSyncBlocking: vi.fn(),
 }));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn() },
+}));
+
+/** Flushes the service's fire-and-forget seeding chain (await + then-callbacks). */
+async function flushSeeding(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
 
 describe('initAutoSyncBlockingService', () => {
   let capturedHandler: ((event: { isBlocking: boolean }) => void) | undefined;
@@ -34,6 +46,9 @@ describe('initAutoSyncBlockingService', () => {
         // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
       }) as any,
     );
+
+    // Default: the extension does not expose the initial-state command (the pre-PT-4214 reality)
+    vi.mocked(requestNoRetry).mockRejectedValue(new Error('command not registered'));
   });
 
   it('calls setAutoSyncBlocking(true) when the event fires with isBlocking true', () => {
@@ -56,5 +71,81 @@ describe('initAutoSyncBlockingService', () => {
     const cleanup = initAutoSyncBlockingService();
     cleanup();
     expect(unsub).toHaveBeenCalledTimes(1);
+  });
+
+  describe('seeding from the initial-state query', () => {
+    it('queries the current blocking state on init', async () => {
+      initAutoSyncBlockingService();
+      await flushSeeding();
+      expect(vi.mocked(requestNoRetry)).toHaveBeenCalledWith(
+        'command:paratextBibleSendReceive.getAutoSyncBlocking',
+      );
+    });
+
+    it('seeds a block when the query reports an in-flight sync (renderer reload mid-sync)', async () => {
+      vi.mocked(requestNoRetry).mockResolvedValue(true);
+      initAutoSyncBlockingService();
+      await flushSeeding();
+      expect(vi.mocked(setAutoSyncBlocking)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(setAutoSyncBlocking)).toHaveBeenCalledWith(true);
+    });
+
+    it('does not seed when the query reports no sync in flight', async () => {
+      vi.mocked(requestNoRetry).mockResolvedValue(false);
+      initAutoSyncBlockingService();
+      await flushSeeding();
+      expect(vi.mocked(setAutoSyncBlocking)).not.toHaveBeenCalled();
+    });
+
+    it('does not seed when the query result is not a boolean true', async () => {
+      vi.mocked(requestNoRetry).mockResolvedValue('yes');
+      initAutoSyncBlockingService();
+      await flushSeeding();
+      expect(vi.mocked(setAutoSyncBlocking)).not.toHaveBeenCalled();
+    });
+
+    it('swallows a failed query and keeps the assume-unblocked default', async () => {
+      vi.mocked(requestNoRetry).mockRejectedValue(new Error('extension absent'));
+      initAutoSyncBlockingService();
+      await flushSeeding();
+      expect(vi.mocked(setAutoSyncBlocking)).not.toHaveBeenCalled();
+    });
+
+    it('lets a live event win over the snapshot — no seeding after an event arrived', async () => {
+      let resolveQuery: ((isBlocking: boolean) => void) | undefined;
+      vi.mocked(requestNoRetry).mockImplementation(
+        async () =>
+          new Promise((resolve) => {
+            resolveQuery = resolve;
+          }),
+      );
+      initAutoSyncBlockingService();
+      expect(capturedHandler).toBeDefined();
+      if (!capturedHandler) throw new Error('capturedHandler not set');
+      // The sync the snapshot would report ends while the query is in flight
+      capturedHandler({ isBlocking: false });
+      if (!resolveQuery) throw new Error('resolveQuery not set');
+      resolveQuery(true); // stale snapshot arrives late
+      await flushSeeding();
+      // Only the event's call — the stale snapshot did not add a phantom block
+      expect(vi.mocked(setAutoSyncBlocking)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(setAutoSyncBlocking)).toHaveBeenCalledWith(false);
+    });
+
+    it('does not seed after cleanup', async () => {
+      let resolveQuery: ((isBlocking: boolean) => void) | undefined;
+      vi.mocked(requestNoRetry).mockImplementation(
+        async () =>
+          new Promise((resolve) => {
+            resolveQuery = resolve;
+          }),
+      );
+      const cleanup = initAutoSyncBlockingService();
+      cleanup();
+      if (!resolveQuery) throw new Error('resolveQuery not set');
+      resolveQuery(true);
+      await flushSeeding();
+      expect(vi.mocked(setAutoSyncBlocking)).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/renderer/services/auto-sync-blocking-service.test.ts
+++ b/src/renderer/services/auto-sync-blocking-service.test.ts
@@ -1,27 +1,15 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getNetworkEvent, requestNoRetry } from '@shared/services/network.service';
-import { setAutoSyncBlocking } from '@renderer/services/auto-sync-blocking-store';
+import { getNetworkEvent } from '@shared/services/network.service';
+import { raiseAutoSyncBlock } from '@renderer/services/auto-sync-blocking-store';
 import { initAutoSyncBlockingService } from './auto-sync-blocking-service';
 
 vi.mock('@shared/services/network.service', () => ({
   getNetworkEvent: vi.fn(),
-  requestNoRetry: vi.fn(),
 }));
 
 vi.mock('@renderer/services/auto-sync-blocking-store', () => ({
-  setAutoSyncBlocking: vi.fn(),
+  raiseAutoSyncBlock: vi.fn(),
 }));
-
-vi.mock('@shared/services/logger.service', () => ({
-  logger: { debug: vi.fn() },
-}));
-
-/** Flushes the service's fire-and-forget seeding chain (await + then-callbacks). */
-async function flushSeeding(): Promise<void> {
-  await Promise.resolve();
-  await Promise.resolve();
-  await Promise.resolve();
-}
 
 describe('initAutoSyncBlockingService', () => {
   let capturedHandler: ((event: { isBlocking: boolean }) => void) | undefined;
@@ -46,106 +34,63 @@ describe('initAutoSyncBlockingService', () => {
         // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
       }) as any,
     );
-
-    // Default: the extension does not expose the initial-state command (the pre-PT-4214 reality)
-    vi.mocked(requestNoRetry).mockRejectedValue(new Error('command not registered'));
   });
 
-  it('calls setAutoSyncBlocking(true) when the event fires with isBlocking true', () => {
+  function emit(isBlocking: boolean): void {
+    if (!capturedHandler) throw new Error('blocking handler not subscribed');
+    capturedHandler({ isBlocking });
+  }
+
+  it('raises a block when the event fires with isBlocking true', () => {
+    vi.mocked(raiseAutoSyncBlock).mockReturnValue(vi.fn());
     initAutoSyncBlockingService();
-    expect(capturedHandler).toBeDefined();
-    if (!capturedHandler) throw new Error('capturedHandler not set');
-    capturedHandler({ isBlocking: true });
-    expect(vi.mocked(setAutoSyncBlocking)).toHaveBeenCalledWith(true);
+    emit(true);
+    expect(vi.mocked(raiseAutoSyncBlock)).toHaveBeenCalledTimes(1);
   });
 
-  it('calls setAutoSyncBlocking(false) when the event fires with isBlocking false', () => {
+  it('pairs each false event with the oldest raise that has not consumed a clear', () => {
+    const clearA = vi.fn();
+    const clearB = vi.fn();
+    vi.mocked(raiseAutoSyncBlock).mockReturnValueOnce(clearA).mockReturnValueOnce(clearB);
     initAutoSyncBlockingService();
-    expect(capturedHandler).toBeDefined();
-    if (!capturedHandler) throw new Error('capturedHandler not set');
-    capturedHandler({ isBlocking: false });
-    expect(vi.mocked(setAutoSyncBlocking)).toHaveBeenCalledWith(false);
+    emit(true); // raise A
+    emit(true); // raise B
+    emit(false); // A's clear
+    expect(clearA).toHaveBeenCalledTimes(1);
+    expect(clearB).not.toHaveBeenCalled();
+    emit(false); // B's clear
+    expect(clearB).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a leash-released raise queued as a tombstone so its late clear cannot consume a newer raise', () => {
+    // Raise A's block gets released by the store's safety leash before its clear event arrives.
+    // The service must still hand A's late clear to A's (now no-op) token — never to B's.
+    const clearA = vi.fn();
+    const clearB = vi.fn();
+    vi.mocked(raiseAutoSyncBlock).mockReturnValueOnce(clearA).mockReturnValueOnce(clearB);
+    initAutoSyncBlockingService();
+    emit(true); // raise A (store leash-releases it later; the service cannot know)
+    emit(true); // raise B
+    emit(false); // A's late clear — consumes A's idempotent token
+    emit(false); // B's clear — pairs with B
+    expect(clearA).toHaveBeenCalledTimes(1);
+    expect(clearB).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a false event with no outstanding raise', () => {
+    const clear = vi.fn();
+    vi.mocked(raiseAutoSyncBlock).mockReturnValue(clear);
+    initAutoSyncBlockingService();
+    emit(false); // emitted before this subscription existed — nothing to release
+    expect(clear).not.toHaveBeenCalled();
+    emit(true);
+    emit(false); // pairs with the raise above, unaffected by the stray clear
+    expect(clear).toHaveBeenCalledTimes(1);
   });
 
   it('returns a cleanup function that unsubscribes the event', () => {
     const cleanup = initAutoSyncBlockingService();
     cleanup();
     expect(unsub).toHaveBeenCalledTimes(1);
-  });
-
-  describe('seeding from the initial-state query', () => {
-    it('queries the current blocking state on init', async () => {
-      initAutoSyncBlockingService();
-      await flushSeeding();
-      expect(vi.mocked(requestNoRetry)).toHaveBeenCalledWith(
-        'command:paratextBibleSendReceive.getAutoSyncBlocking',
-      );
-    });
-
-    it('seeds a block when the query reports an in-flight sync (renderer reload mid-sync)', async () => {
-      vi.mocked(requestNoRetry).mockResolvedValue(true);
-      initAutoSyncBlockingService();
-      await flushSeeding();
-      expect(vi.mocked(setAutoSyncBlocking)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(setAutoSyncBlocking)).toHaveBeenCalledWith(true);
-    });
-
-    it('does not seed when the query reports no sync in flight', async () => {
-      vi.mocked(requestNoRetry).mockResolvedValue(false);
-      initAutoSyncBlockingService();
-      await flushSeeding();
-      expect(vi.mocked(setAutoSyncBlocking)).not.toHaveBeenCalled();
-    });
-
-    it('does not seed when the query result is not a boolean true', async () => {
-      vi.mocked(requestNoRetry).mockResolvedValue('yes');
-      initAutoSyncBlockingService();
-      await flushSeeding();
-      expect(vi.mocked(setAutoSyncBlocking)).not.toHaveBeenCalled();
-    });
-
-    it('swallows a failed query and keeps the assume-unblocked default', async () => {
-      vi.mocked(requestNoRetry).mockRejectedValue(new Error('extension absent'));
-      initAutoSyncBlockingService();
-      await flushSeeding();
-      expect(vi.mocked(setAutoSyncBlocking)).not.toHaveBeenCalled();
-    });
-
-    it('lets a live event win over the snapshot — no seeding after an event arrived', async () => {
-      let resolveQuery: ((isBlocking: boolean) => void) | undefined;
-      vi.mocked(requestNoRetry).mockImplementation(
-        async () =>
-          new Promise((resolve) => {
-            resolveQuery = resolve;
-          }),
-      );
-      initAutoSyncBlockingService();
-      expect(capturedHandler).toBeDefined();
-      if (!capturedHandler) throw new Error('capturedHandler not set');
-      // The sync the snapshot would report ends while the query is in flight
-      capturedHandler({ isBlocking: false });
-      if (!resolveQuery) throw new Error('resolveQuery not set');
-      resolveQuery(true); // stale snapshot arrives late
-      await flushSeeding();
-      // Only the event's call — the stale snapshot did not add a phantom block
-      expect(vi.mocked(setAutoSyncBlocking)).toHaveBeenCalledTimes(1);
-      expect(vi.mocked(setAutoSyncBlocking)).toHaveBeenCalledWith(false);
-    });
-
-    it('does not seed after cleanup', async () => {
-      let resolveQuery: ((isBlocking: boolean) => void) | undefined;
-      vi.mocked(requestNoRetry).mockImplementation(
-        async () =>
-          new Promise((resolve) => {
-            resolveQuery = resolve;
-          }),
-      );
-      const cleanup = initAutoSyncBlockingService();
-      cleanup();
-      if (!resolveQuery) throw new Error('resolveQuery not set');
-      resolveQuery(true);
-      await flushSeeding();
-      expect(vi.mocked(setAutoSyncBlocking)).not.toHaveBeenCalled();
-    });
   });
 });

--- a/src/renderer/services/auto-sync-blocking-service.ts
+++ b/src/renderer/services/auto-sync-blocking-service.ts
@@ -1,4 +1,8 @@
-import { getNetworkEvent } from '@shared/services/network.service';
+import { CATEGORY_COMMAND } from '@shared/data/rpc.model';
+import { logger } from '@shared/services/logger.service';
+import { getNetworkEvent, requestNoRetry } from '@shared/services/network.service';
+import { serializeRequestType } from '@shared/utils/util';
+import { getErrorMessage } from 'platform-bible-utils';
 import { setAutoSyncBlocking } from './auto-sync-blocking-store';
 
 // String value must match the event emitted by the Send/Receive extension. The extension emits it
@@ -9,16 +13,59 @@ import { setAutoSyncBlocking } from './auto-sync-blocking-store';
 const AUTO_SYNC_BLOCKING_CHANGED_EVENT = 'paratextBibleSendReceive.onAutoSyncBlockingChanged';
 
 /**
+ * Command on the Send/Receive extension (the emitter of {@link AUTO_SYNC_BLOCKING_CHANGED_EVENT})
+ * that reports whether a scheduled sync is currently blocking, so this service can seed the store
+ * on init instead of assuming unblocked. Requested untyped (the same pattern as
+ * `paratextBibleSendReceive.cancelSync` in shutdown-tasks) because the copied
+ * `paratext-bible-send-receive.d.ts` command contract does not declare it; registering the command
+ * on the extension side (and declaring it in the contract) is tracked in PT-4214. Until then the
+ * request rejects and init keeps the assume-unblocked default — exactly the pre-seeding behavior.
+ */
+const GET_AUTO_SYNC_BLOCKING_COMMAND = 'paratextBibleSendReceive.getAutoSyncBlocking';
+
+/**
  * Subscribes to the auto-sync blocking network event and drives the auto-sync-blocking store. Call
  * once at app startup. Returns a cleanup function.
  *
- * Known limitation (deliberate): the protocol is event-only, so a renderer reload during an
- * in-flight scheduled sync misses the earlier raise and leaves the rest of that sync unblocked.
- * Upgrade path when PT-4163 lands is a queryable state on the emitter side (a command to read the
- * current blocking state, or a periodic re-emit) that this service consults on init.
+ * On init it also queries the emitter's current blocking state (best effort — see
+ * {@link GET_AUTO_SYNC_BLOCKING_COMMAND}) and seeds the store from it, so a renderer reload during
+ * an in-flight scheduled sync does not come up unblocked while the backend is still syncing (the
+ * raise event was emitted before this subscription existed). Any live event wins over the (possibly
+ * stale) snapshot, and the store's per-blocker safety leash bounds a seeded block whose clearing
+ * event never arrives.
  */
 export function initAutoSyncBlockingService(): () => void {
-  return getNetworkEvent<{ isBlocking: boolean }>(AUTO_SYNC_BLOCKING_CHANGED_EVENT)(
-    ({ isBlocking }) => setAutoSyncBlocking(isBlocking),
-  );
+  let hasReceivedEvent = false;
+  let isDisposed = false;
+
+  const unsubscribe = getNetworkEvent<{ isBlocking: boolean }>(AUTO_SYNC_BLOCKING_CHANGED_EVENT)(({
+    isBlocking,
+  }) => {
+    hasReceivedEvent = true;
+    setAutoSyncBlocking(isBlocking);
+  });
+
+  (async () => {
+    try {
+      const isBlocking = await requestNoRetry<[], unknown>(
+        serializeRequestType(CATEGORY_COMMAND, GET_AUTO_SYNC_BLOCKING_COMMAND),
+      );
+      // Only seed if nothing live has spoken: an event that arrived while the request was in
+      // flight (either direction) supersedes this snapshot, and seeding after it could double
+      // count the same sync's raise.
+      if (isBlocking === true && !hasReceivedEvent && !isDisposed) setAutoSyncBlocking(true);
+    } catch (e) {
+      // Extension absent or command not registered (see GET_AUTO_SYNC_BLOCKING_COMMAND) — keep the
+      // assume-unblocked default. Debug, not warn: this is the expected path on plain
+      // Platform.Bible and, until PT-4214 lands, on Paratext 10 Studio too.
+      logger.debug(
+        `auto-sync blocking service could not read the initial blocking state: ${getErrorMessage(e)}`,
+      );
+    }
+  })();
+
+  return () => {
+    isDisposed = true;
+    unsubscribe();
+  };
 }

--- a/src/renderer/services/auto-sync-blocking-service.ts
+++ b/src/renderer/services/auto-sync-blocking-service.ts
@@ -1,71 +1,43 @@
-import { CATEGORY_COMMAND } from '@shared/data/rpc.model';
-import { logger } from '@shared/services/logger.service';
-import { getNetworkEvent, requestNoRetry } from '@shared/services/network.service';
-import { serializeRequestType } from '@shared/utils/util';
-import { getErrorMessage } from 'platform-bible-utils';
-import { setAutoSyncBlocking } from './auto-sync-blocking-store';
+import { getNetworkEvent } from '@shared/services/network.service';
+import { raiseAutoSyncBlock } from './auto-sync-blocking-store';
 
 // String value must match the event emitted by the Send/Receive extension. The extension emits it
 // only around scheduled (unattended) syncs — the surface that blocks the workspace. Manual syncs
 // (driven from the Send/Receive dialog, which has its own progress and Cancel) never raise it.
-// `true` raises a block, `false` clears one; the store ref-counts so nested raises don't clear
-// early.
+// `true` raises a block, `false` clears one.
 const AUTO_SYNC_BLOCKING_CHANGED_EVENT = 'paratextBibleSendReceive.onAutoSyncBlockingChanged';
-
-/**
- * Command on the Send/Receive extension (the emitter of {@link AUTO_SYNC_BLOCKING_CHANGED_EVENT})
- * that reports whether a scheduled sync is currently blocking, so this service can seed the store
- * on init instead of assuming unblocked. Requested untyped (the same pattern as
- * `paratextBibleSendReceive.cancelSync` in shutdown-tasks) because the copied
- * `paratext-bible-send-receive.d.ts` command contract does not declare it; registering the command
- * on the extension side (and declaring it in the contract) is tracked in PT-4214. Until then the
- * request rejects and init keeps the assume-unblocked default — exactly the pre-seeding behavior.
- */
-const GET_AUTO_SYNC_BLOCKING_COMMAND = 'paratextBibleSendReceive.getAutoSyncBlocking';
 
 /**
  * Subscribes to the auto-sync blocking network event and drives the auto-sync-blocking store. Call
  * once at app startup. Returns a cleanup function.
  *
- * On init it also queries the emitter's current blocking state (best effort — see
- * {@link GET_AUTO_SYNC_BLOCKING_COMMAND}) and seeds the store from it, so a renderer reload during
- * an in-flight scheduled sync does not come up unblocked while the backend is still syncing (the
- * raise event was emitted before this subscription existed). Any live event wins over the (possibly
- * stale) snapshot, and the store's per-blocker safety leash bounds a seeded block whose clearing
- * event never arrives.
+ * The event payload is an anonymous boolean, so this service pairs each `false` with the oldest
+ * raise that has not yet consumed a clear. A raise whose own safety leash already fired absorbs its
+ * late clear as a no-op (the store's release tokens are idempotent), so a late clear can never
+ * release a newer, still-live blocker. What anonymous pairing cannot fix: a raise whose clear never
+ * arrives keeps consuming later raises' clears, shifting the unmatched block onto ever-newer raises
+ * — each still bounded by its own leash, but blocking can persist while syncs keep coming. The real
+ * fix is identity on the wire; PT-4214 replaces this event with a backend-authoritative per-project
+ * snapshot, which removes the pairing problem entirely.
+ *
+ * Known limitation (deliberate): this service only learns about blocking from live events, so a
+ * renderer reload during an in-flight scheduled sync comes up unblocked while the backend is still
+ * syncing (the raise event was emitted before this subscription existed). Seeding the initial state
+ * requires a backend query that does not exist yet; PT-4214 adds a C#-served
+ * `paratextBibleSendReceive.getAutoSyncBlocking` snapshot command and an init consult of it.
  */
 export function initAutoSyncBlockingService(): () => void {
-  let hasReceivedEvent = false;
-  let isDisposed = false;
+  // Clear functions for raises, oldest first, in raise order. A leash-released raise stays here as
+  // a tombstone until its (late) clear consumes it, keeping later clears paired with later raises.
+  const pendingClears: (() => void)[] = [];
 
   const unsubscribe = getNetworkEvent<{ isBlocking: boolean }>(AUTO_SYNC_BLOCKING_CHANGED_EVENT)(({
     isBlocking,
   }) => {
-    hasReceivedEvent = true;
-    setAutoSyncBlocking(isBlocking);
+    if (isBlocking) pendingClears.push(raiseAutoSyncBlock());
+    // A clear with no outstanding raise (emitted before this subscription existed) is ignored.
+    else pendingClears.shift()?.();
   });
 
-  (async () => {
-    try {
-      const isBlocking = await requestNoRetry<[], unknown>(
-        serializeRequestType(CATEGORY_COMMAND, GET_AUTO_SYNC_BLOCKING_COMMAND),
-      );
-      // Only seed if nothing live has spoken: an event that arrived while the request was in
-      // flight (either direction) supersedes this snapshot, and seeding after it could double
-      // count the same sync's raise.
-      if (isBlocking === true && !hasReceivedEvent && !isDisposed) setAutoSyncBlocking(true);
-    } catch (e) {
-      // Extension absent or command not registered (see GET_AUTO_SYNC_BLOCKING_COMMAND) — keep the
-      // assume-unblocked default. Debug, not warn: this is the expected path on plain
-      // Platform.Bible and, until PT-4214 lands, on Paratext 10 Studio too.
-      logger.debug(
-        `auto-sync blocking service could not read the initial blocking state: ${getErrorMessage(e)}`,
-      );
-    }
-  })();
-
-  return () => {
-    isDisposed = true;
-    unsubscribe();
-  };
+  return unsubscribe;
 }

--- a/src/renderer/services/auto-sync-blocking-store.test.ts
+++ b/src/renderer/services/auto-sync-blocking-store.test.ts
@@ -142,25 +142,46 @@ describe('auto-sync-blocking-store', () => {
       expect(listener).toHaveBeenCalledTimes(2); // shown, then auto-cleared
     });
 
-    it('re-arms the safety timer on every raise', () => {
-      setAutoSyncBlocking(true); // blocker A raises — safety armed
+    it('arms a leash per raise — a later blocker outlives an earlier raise expiring', () => {
+      setAutoSyncBlocking(true); // blocker A raises — A's leash armed
       vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2);
-      setAutoSyncBlocking(true); // blocker B raises — safety re-armed to 10 min from now
-      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2); // 10 min from A, but only 5 min from B
-      expect(getAutoSyncBlocking()).toBe(true); // B's raise re-armed the timer — still alive
-      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2); // 10 min from B — safety fires
+      setAutoSyncBlocking(true); // blocker B raises — B gets its own 10 min leash
+      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2); // 10 min from A (A's leash fires), 5 min from B
+      expect(getAutoSyncBlocking()).toBe(true); // B's own leash is still alive
+      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2); // 10 min from B — B's leash fires
       expect(getAutoSyncBlocking()).toBe(false);
     });
 
-    it('zeroes the count when it fires — a later single raise shows again', () => {
+    it('releases every expired block — a later single raise shows again', () => {
       setAutoSyncBlocking(true);
       setAutoSyncBlocking(true); // count is 2
-      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS);
+      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS); // both leashes expire
       expect(getAutoSyncBlocking()).toBe(false);
       setAutoSyncBlocking(true); // count 0→1, not 2→3
       vi.advanceTimersByTime(SHOW_GRACE_MS);
       expect(getAutoSyncBlocking()).toBe(true);
       setAutoSyncBlocking(false); // a single clear hides again
+      expect(getAutoSyncBlocking()).toBe(false);
+    });
+
+    it('releases only its own block when a stale leash expires — the newer blocker keeps blocking until it clears', () => {
+      setAutoSyncBlocking(true); // blocker A raises at t=0 and is abandoned
+      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2);
+      setAutoSyncBlocking(true); // blocker B raises at t=5min
+      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2); // t=10min — A's leash expires
+      expect(getAutoSyncBlocking()).toBe(true); // B still in flight — stays blocked
+      setAutoSyncBlocking(false); // B clears — the count stayed correct, so one clear fully unblocks
+      expect(getAutoSyncBlocking()).toBe(false);
+    });
+
+    it('pairs a clear with the oldest leash — the newest blocker keeps its own full leash', () => {
+      setAutoSyncBlocking(true); // blocker A raises at t=0
+      vi.advanceTimersByTime(60_000);
+      setAutoSyncBlocking(true); // blocker B raises at t=1min and is abandoned
+      setAutoSyncBlocking(false); // A clears — cancels the oldest leash (A's)
+      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS - 60_000); // t=10min — A's cancelled leash is silent
+      expect(getAutoSyncBlocking()).toBe(true); // B is still inside its own leash
+      vi.advanceTimersByTime(60_000); // t=11min — B's own leash expires
       expect(getAutoSyncBlocking()).toBe(false);
     });
 

--- a/src/renderer/services/auto-sync-blocking-store.test.ts
+++ b/src/renderer/services/auto-sync-blocking-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
-  setAutoSyncBlocking,
+  raiseAutoSyncBlock,
   getAutoSyncBlocking,
   subscribeToAutoSyncBlocking,
   resetAutoSyncBlocking,
@@ -30,12 +30,12 @@ describe('auto-sync-blocking-store', () => {
 
   describe('show grace', () => {
     it('is not visible immediately when blocking starts', () => {
-      setAutoSyncBlocking(true);
+      raiseAutoSyncBlock();
       expect(getAutoSyncBlocking()).toBe(false);
     });
 
     it('becomes visible once the 200 ms grace elapses', () => {
-      setAutoSyncBlocking(true);
+      raiseAutoSyncBlock();
       vi.advanceTimersByTime(SHOW_GRACE_MS);
       expect(getAutoSyncBlocking()).toBe(true);
     });
@@ -43,9 +43,9 @@ describe('auto-sync-blocking-store', () => {
     it('never becomes visible when blocking clears within the grace (sync finished fast)', () => {
       const listener = vi.fn();
       subscribeToAutoSyncBlocking(listener);
-      setAutoSyncBlocking(true);
+      const clear = raiseAutoSyncBlock();
       vi.advanceTimersByTime(150); // still inside the grace window
-      setAutoSyncBlocking(false);
+      clear();
       vi.advanceTimersByTime(SHOW_GRACE_MS); // well past when the grace would have fired
       expect(getAutoSyncBlocking()).toBe(false);
       expect(listener).not.toHaveBeenCalled(); // nothing ever showed, so nothing ever notified
@@ -54,7 +54,7 @@ describe('auto-sync-blocking-store', () => {
     it('does not notify listeners during the grace period', () => {
       const listener = vi.fn();
       subscribeToAutoSyncBlocking(listener);
-      setAutoSyncBlocking(true);
+      raiseAutoSyncBlock();
       vi.advanceTimersByTime(SHOW_GRACE_MS - 1);
       expect(listener).not.toHaveBeenCalled();
       vi.advanceTimersByTime(1);
@@ -62,50 +62,43 @@ describe('auto-sync-blocking-store', () => {
     });
   });
 
-  describe('ref counting', () => {
+  describe('overlapping blockers', () => {
     it('stays visible when a second raise arrives before the first clears', () => {
-      setAutoSyncBlocking(true); // blocker A raises
+      const clearA = raiseAutoSyncBlock();
       vi.advanceTimersByTime(SHOW_GRACE_MS);
-      setAutoSyncBlocking(true); // blocker B raises
-      setAutoSyncBlocking(false); // blocker A clears
+      const clearB = raiseAutoSyncBlock();
+      clearA();
       expect(getAutoSyncBlocking()).toBe(true); // blocker B still in flight
-      setAutoSyncBlocking(false); // blocker B clears
+      clearB();
       expect(getAutoSyncBlocking()).toBe(false);
     });
 
-    it('clamps at zero — extra false calls do not underflow', () => {
-      setAutoSyncBlocking(false); // extra call while already at zero — should be ignored
-      setAutoSyncBlocking(true);
+    it('clear is idempotent — clearing twice cannot release another blocker', () => {
+      const clearA = raiseAutoSyncBlock();
       vi.advanceTimersByTime(SHOW_GRACE_MS);
-      expect(getAutoSyncBlocking()).toBe(true); // count went 0→1, not -1→0
-      setAutoSyncBlocking(false);
-      expect(getAutoSyncBlocking()).toBe(false);
+      raiseAutoSyncBlock(); // blocker B, still in flight
+      clearA();
+      clearA(); // duplicate — must be a no-op, not release B
+      expect(getAutoSyncBlocking()).toBe(true);
     });
 
     it('does not notify listeners when visibility is unchanged (nested raises)', () => {
-      setAutoSyncBlocking(true);
+      raiseAutoSyncBlock();
       vi.advanceTimersByTime(SHOW_GRACE_MS);
       const listener = vi.fn();
       subscribeToAutoSyncBlocking(listener);
-      setAutoSyncBlocking(true); // second raise — count 1→2, visibility still true
-      expect(listener).not.toHaveBeenCalled();
-    });
-
-    it('does not notify listeners when value is unchanged (already false)', () => {
-      const listener = vi.fn();
-      subscribeToAutoSyncBlocking(listener);
-      setAutoSyncBlocking(false); // already at zero — no change
+      raiseAutoSyncBlock(); // second raise — set grows 1→2, visibility still true
       expect(listener).not.toHaveBeenCalled();
     });
   });
 
   describe('subscribeToAutoSyncBlocking', () => {
     it('notifies listeners when visibility flips to false', () => {
-      setAutoSyncBlocking(true);
+      const clear = raiseAutoSyncBlock();
       vi.advanceTimersByTime(SHOW_GRACE_MS);
       const listener = vi.fn();
       subscribeToAutoSyncBlocking(listener);
-      setAutoSyncBlocking(false);
+      clear();
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
@@ -113,7 +106,7 @@ describe('auto-sync-blocking-store', () => {
       const listener = vi.fn();
       const unsubscribe = subscribeToAutoSyncBlocking(listener);
       unsubscribe();
-      setAutoSyncBlocking(true);
+      raiseAutoSyncBlock();
       vi.advanceTimersByTime(SHOW_GRACE_MS);
       expect(listener).not.toHaveBeenCalled();
     });
@@ -123,18 +116,18 @@ describe('auto-sync-blocking-store', () => {
       const listener2 = vi.fn();
       subscribeToAutoSyncBlocking(listener1);
       subscribeToAutoSyncBlocking(listener2);
-      setAutoSyncBlocking(true);
+      raiseAutoSyncBlock();
       vi.advanceTimersByTime(SHOW_GRACE_MS);
       expect(listener1).toHaveBeenCalledTimes(1);
       expect(listener2).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('safety timer', () => {
+  describe('safety leash', () => {
     it('auto-clears after 10 minutes if the blocker never clears', () => {
       const listener = vi.fn();
       subscribeToAutoSyncBlocking(listener);
-      setAutoSyncBlocking(true);
+      raiseAutoSyncBlock();
       vi.advanceTimersByTime(SHOW_GRACE_MS);
       expect(getAutoSyncBlocking()).toBe(true);
       vi.advanceTimersByTime(SAFETY_TIMEOUT_MS);
@@ -143,54 +136,69 @@ describe('auto-sync-blocking-store', () => {
     });
 
     it('arms a leash per raise — a later blocker outlives an earlier raise expiring', () => {
-      setAutoSyncBlocking(true); // blocker A raises — A's leash armed
+      raiseAutoSyncBlock(); // blocker A raises — A's leash armed
       vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2);
-      setAutoSyncBlocking(true); // blocker B raises — B gets its own 10 min leash
-      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2); // 10 min from A (A's leash fires), 5 min from B
+      raiseAutoSyncBlock(); // blocker B raises — B gets its own 10 min leash
+      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2); // 10 min from A (its leash fires), 5 min from B
       expect(getAutoSyncBlocking()).toBe(true); // B's own leash is still alive
       vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2); // 10 min from B — B's leash fires
       expect(getAutoSyncBlocking()).toBe(false);
     });
 
     it('releases every expired block — a later single raise shows again', () => {
-      setAutoSyncBlocking(true);
-      setAutoSyncBlocking(true); // count is 2
+      raiseAutoSyncBlock();
+      raiseAutoSyncBlock(); // two blockers in flight
       vi.advanceTimersByTime(SAFETY_TIMEOUT_MS); // both leashes expire
       expect(getAutoSyncBlocking()).toBe(false);
-      setAutoSyncBlocking(true); // count 0→1, not 2→3
+      const clear = raiseAutoSyncBlock(); // a fresh raise blocks again
       vi.advanceTimersByTime(SHOW_GRACE_MS);
       expect(getAutoSyncBlocking()).toBe(true);
-      setAutoSyncBlocking(false); // a single clear hides again
+      clear(); // its own clear hides again
       expect(getAutoSyncBlocking()).toBe(false);
     });
 
     it('releases only its own block when a stale leash expires — the newer blocker keeps blocking until it clears', () => {
-      setAutoSyncBlocking(true); // blocker A raises at t=0 and is abandoned
+      raiseAutoSyncBlock(); // blocker A raises at t=0 and is abandoned
       vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2);
-      setAutoSyncBlocking(true); // blocker B raises at t=5min
+      const clearB = raiseAutoSyncBlock(); // blocker B raises at t=5min
       vi.advanceTimersByTime(SAFETY_TIMEOUT_MS / 2); // t=10min — A's leash expires
       expect(getAutoSyncBlocking()).toBe(true); // B still in flight — stays blocked
-      setAutoSyncBlocking(false); // B clears — the count stayed correct, so one clear fully unblocks
+      clearB();
       expect(getAutoSyncBlocking()).toBe(false);
     });
 
-    it('pairs a clear with the oldest leash — the newest blocker keeps its own full leash', () => {
-      setAutoSyncBlocking(true); // blocker A raises at t=0
-      vi.advanceTimersByTime(60_000);
-      setAutoSyncBlocking(true); // blocker B raises at t=1min and is abandoned
-      setAutoSyncBlocking(false); // A clears — cancels the oldest leash (A's)
-      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS - 60_000); // t=10min — A's cancelled leash is silent
-      expect(getAutoSyncBlocking()).toBe(true); // B is still inside its own leash
-      vi.advanceTimersByTime(60_000); // t=11min — B's own leash expires
+    it('a late clear after the leash already fired is a no-op — it cannot release another blocker (review finding 1)', () => {
+      const clearA = raiseAutoSyncBlock(); // blocker A raises at t=0
+      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS - 10_000);
+      raiseAutoSyncBlock(); // blocker B raises just before A's leash fires
+      vi.advanceTimersByTime(10_000); // t=10min — A's leash fires, releasing A
+      expect(getAutoSyncBlocking()).toBe(true); // B still in flight
+      clearA(); // A's real clear arrives late — must be a no-op, never release B
+      expect(getAutoSyncBlocking()).toBe(true);
+      vi.advanceTimersByTime(SAFETY_TIMEOUT_MS); // B's own leash fires
       expect(getAutoSyncBlocking()).toBe(false);
     });
 
-    it('cancels the safety timer when blocking clears normally', () => {
+    it('an abandoned blocker is released by its own leash despite other blockers clearing (review finding 2)', () => {
+      raiseAutoSyncBlock(); // blocker X raises at t=0 and is abandoned
+      // Ordinary syncs keep raising and clearing by their own tokens — they must never cancel X's
+      // leash, so X is released at t=10min and blocking does not persist indefinitely.
+      for (let i = 0; i < 24; i += 1) {
+        const clear = raiseAutoSyncBlock();
+        vi.advanceTimersByTime(30_000);
+        clear();
+        vi.advanceTimersByTime(4.5 * 60 * 1000);
+      }
+      // Two hours in, between syncs: X's own leash fired at t=10min, so nothing is blocking.
+      expect(getAutoSyncBlocking()).toBe(false);
+    });
+
+    it('cancels the safety leash when blocking clears normally', () => {
       const listener = vi.fn();
       subscribeToAutoSyncBlocking(listener);
-      setAutoSyncBlocking(true);
+      const clear = raiseAutoSyncBlock();
       vi.advanceTimersByTime(SHOW_GRACE_MS);
-      setAutoSyncBlocking(false); // normal completion
+      clear(); // normal completion
       vi.advanceTimersByTime(SAFETY_TIMEOUT_MS);
       expect(getAutoSyncBlocking()).toBe(false);
       expect(listener).toHaveBeenCalledTimes(2); // shown, then cleared — no extra firing
@@ -201,7 +209,7 @@ describe('auto-sync-blocking-store', () => {
     it('clears state and pending timers', () => {
       const listener = vi.fn();
       subscribeToAutoSyncBlocking(listener);
-      setAutoSyncBlocking(true);
+      raiseAutoSyncBlock();
       resetAutoSyncBlocking();
       vi.advanceTimersByTime(SAFETY_TIMEOUT_MS); // neither grace nor safety should fire
       expect(getAutoSyncBlocking()).toBe(false);

--- a/src/renderer/services/auto-sync-blocking-store.ts
+++ b/src/renderer/services/auto-sync-blocking-store.ts
@@ -8,8 +8,9 @@
  * grace timer is armed, and listeners only ever see `true` if blocking is still in flight when it
  * fires. A sync that finishes within the grace never shows anything.
  *
- * A 10-minute safety timer re-arms on every raise and auto-clears the state if a blocker never
- * clears (e.g. the extension deactivates mid-sync and the clearing event is never emitted).
+ * Each raise arms its own one-shot 10-minute safety leash that releases just that block if it never
+ * clears (e.g. the extension deactivates mid-sync and the clearing event is never emitted), so one
+ * stale expiry can never wipe newer in-flight blockers.
  */
 
 import { AUTO_SYNC_MAX_DURATION_MS } from '@shared/data/platform.data';
@@ -30,7 +31,12 @@ const SAFETY_TIMEOUT_MS = AUTO_SYNC_MAX_DURATION_MS;
 let blockCount = 0;
 let isBlockingVisible = false;
 let graceTimer: ReturnType<typeof setTimeout> | undefined;
-let safetyTimer: ReturnType<typeof setTimeout> | undefined;
+/**
+ * One outstanding safety leash per in-flight blocker, oldest first. Every raise arms its own
+ * one-shot leash and every clear cancels the oldest outstanding one, so the array's length always
+ * equals `blockCount` and each block is released exactly once — by its clear or by its own leash.
+ */
+const safetyTimers: ReturnType<typeof setTimeout>[] = [];
 
 const listeners = new Set<() => void>();
 
@@ -45,18 +51,29 @@ function setBlockingVisible(value: boolean): void {
   notifyListeners();
 }
 
+/** Releases one in-flight block, updating the derived visibility when the last one goes. */
+function releaseOneBlock(): void {
+  blockCount = Math.max(0, blockCount - 1);
+  if (blockCount === 0) {
+    // Cancel a pending grace timer — blocking cleared inside the grace, so nothing ever shows.
+    clearTimeout(graceTimer);
+    graceTimer = undefined;
+    setBlockingVisible(false);
+  }
+}
+
 export function setAutoSyncBlocking(value: boolean): void {
   if (value) {
     blockCount += 1;
-    // Re-arm the safety timer on each raise, giving 10 min from the latest start.
-    clearTimeout(safetyTimer);
-    safetyTimer = setTimeout(() => {
-      blockCount = 0;
-      safetyTimer = undefined;
-      clearTimeout(graceTimer);
-      graceTimer = undefined;
-      setBlockingVisible(false);
+    // Arm this block's own one-shot safety leash, 10 min from this raise. When it fires it
+    // releases only this block — never the whole count — so a stale expiry cannot wipe newer
+    // in-flight blockers.
+    const leash = setTimeout(() => {
+      const index = safetyTimers.indexOf(leash);
+      if (index !== -1) safetyTimers.splice(index, 1);
+      releaseOneBlock();
     }, SAFETY_TIMEOUT_MS);
+    safetyTimers.push(leash);
     // On 0→1, arm the show grace; visibility only turns on if blocking survives the grace.
     if (blockCount === 1) {
       graceTimer = setTimeout(() => {
@@ -65,15 +82,13 @@ export function setAutoSyncBlocking(value: boolean): void {
       }, SHOW_GRACE_MS);
     }
   } else {
-    blockCount = Math.max(0, blockCount - 1);
-    if (blockCount === 0) {
-      // Cancel a pending grace timer — blocking cleared inside the grace, so nothing ever shows.
-      clearTimeout(graceTimer);
-      graceTimer = undefined;
-      clearTimeout(safetyTimer);
-      safetyTimer = undefined;
-      setBlockingVisible(false);
-    }
+    // Cancel the oldest outstanding leash so the block this clear releases cannot be released a
+    // second time when its leash fires. Blockers are anonymous, so oldest-first is a pairing
+    // heuristic — and the conservative one: the still-open blocks keep the newest (longest
+    // remaining) leashes.
+    const oldestLeash = safetyTimers.shift();
+    if (oldestLeash !== undefined) clearTimeout(oldestLeash);
+    releaseOneBlock();
   }
 }
 
@@ -99,7 +114,7 @@ export function resetAutoSyncBlocking(): void {
   isBlockingVisible = false;
   clearTimeout(graceTimer);
   graceTimer = undefined;
-  clearTimeout(safetyTimer);
-  safetyTimer = undefined;
+  safetyTimers.forEach((leash) => clearTimeout(leash));
+  safetyTimers.length = 0;
   listeners.clear();
 }

--- a/src/renderer/services/auto-sync-blocking-store.ts
+++ b/src/renderer/services/auto-sync-blocking-store.ts
@@ -1,16 +1,19 @@
 /**
  * Store tracking whether an automatic (scheduled) Send/Receive is currently blocking the workspace.
  *
- * Uses a reference counter so overlapping blockers don't prematurely hide the overlay: the visible
- * state (isBlocking) only flips to false once every in-flight blocker has cleared.
+ * Tracks one entry per in-flight blocker so overlapping blockers don't prematurely hide the
+ * overlay: the visible state (isBlocking) only flips to false once every in-flight blocker has been
+ * released.
+ *
+ * Each block is identified by the token {@link raiseAutoSyncBlock} returns, and is released exactly
+ * once — by its own clear (calling the token) or by its own one-shot 10-minute safety leash if it
+ * never clears (e.g. the extension deactivates mid-sync and the clearing event is never emitted).
+ * Identity pairing means a clear can never release a different block and a stale leash can never
+ * wipe newer in-flight blockers.
  *
  * Visibility has a 200 ms show-grace matching PT9's automatic-sync surface: on the first raise a
  * grace timer is armed, and listeners only ever see `true` if blocking is still in flight when it
  * fires. A sync that finishes within the grace never shows anything.
- *
- * Each raise arms its own one-shot 10-minute safety leash that releases just that block if it never
- * clears (e.g. the extension deactivates mid-sync and the clearing event is never emitted), so one
- * stale expiry can never wipe newer in-flight blockers.
  */
 
 import { AUTO_SYNC_MAX_DURATION_MS } from '@shared/data/platform.data';
@@ -28,15 +31,21 @@ const SHOW_GRACE_MS = 200;
  */
 const SAFETY_TIMEOUT_MS = AUTO_SYNC_MAX_DURATION_MS;
 
-let blockCount = 0;
+/** One in-flight blocker: its own safety leash. */
+type InFlightBlock = {
+  leash: ReturnType<typeof setTimeout>;
+};
+
+/**
+ * Every in-flight (not yet released) blocker. The raw blocking state is exactly "this set is
+ * non-empty", so there is no separate counter to keep in lockstep. (Same pattern as
+ * workspace-updating-store; extracting a shared abstraction is deliberately deferred — PT-4214
+ * Stage U.)
+ */
+const inFlightBlocks = new Set<InFlightBlock>();
+
 let isBlockingVisible = false;
 let graceTimer: ReturnType<typeof setTimeout> | undefined;
-/**
- * One outstanding safety leash per in-flight blocker, oldest first. Every raise arms its own
- * one-shot leash and every clear cancels the oldest outstanding one, so the array's length always
- * equals `blockCount` and each block is released exactly once — by its clear or by its own leash.
- */
-const safetyTimers: ReturnType<typeof setTimeout>[] = [];
 
 const listeners = new Set<() => void>();
 
@@ -51,10 +60,12 @@ function setBlockingVisible(value: boolean): void {
   notifyListeners();
 }
 
-/** Releases one in-flight block, updating the derived visibility when the last one goes. */
-function releaseOneBlock(): void {
-  blockCount = Math.max(0, blockCount - 1);
-  if (blockCount === 0) {
+/** Releases one block. A no-op if it was already released (identity — released exactly once). */
+function releaseBlock(block: InFlightBlock): void {
+  if (!inFlightBlocks.has(block)) return;
+  inFlightBlocks.delete(block);
+  clearTimeout(block.leash);
+  if (inFlightBlocks.size === 0) {
     // Cancel a pending grace timer — blocking cleared inside the grace, so nothing ever shows.
     clearTimeout(graceTimer);
     graceTimer = undefined;
@@ -62,34 +73,25 @@ function releaseOneBlock(): void {
   }
 }
 
-export function setAutoSyncBlocking(value: boolean): void {
-  if (value) {
-    blockCount += 1;
-    // Arm this block's own one-shot safety leash, 10 min from this raise. When it fires it
-    // releases only this block — never the whole count — so a stale expiry cannot wipe newer
-    // in-flight blockers.
-    const leash = setTimeout(() => {
-      const index = safetyTimers.indexOf(leash);
-      if (index !== -1) safetyTimers.splice(index, 1);
-      releaseOneBlock();
-    }, SAFETY_TIMEOUT_MS);
-    safetyTimers.push(leash);
-    // On 0→1, arm the show grace; visibility only turns on if blocking survives the grace.
-    if (blockCount === 1) {
-      graceTimer = setTimeout(() => {
-        graceTimer = undefined;
-        if (blockCount > 0) setBlockingVisible(true);
-      }, SHOW_GRACE_MS);
-    }
-  } else {
-    // Cancel the oldest outstanding leash so the block this clear releases cannot be released a
-    // second time when its leash fires. Blockers are anonymous, so oldest-first is a pairing
-    // heuristic — and the conservative one: the still-open blocks keep the newest (longest
-    // remaining) leashes.
-    const oldestLeash = safetyTimers.shift();
-    if (oldestLeash !== undefined) clearTimeout(oldestLeash);
-    releaseOneBlock();
+/**
+ * Registers one in-flight blocker and returns its clear function. Call the returned function when
+ * the blocker's sync finishes; it is idempotent and releases only this block. If the block never
+ * clears, its own safety leash releases it after {@link SAFETY_TIMEOUT_MS} — a stale leash can never
+ * release a newer in-flight blocker.
+ */
+export function raiseAutoSyncBlock(): () => void {
+  const block: InFlightBlock = {
+    leash: setTimeout(() => releaseBlock(block), SAFETY_TIMEOUT_MS),
+  };
+  inFlightBlocks.add(block);
+  // On the first raise, arm the show grace; visibility only turns on if blocking survives it.
+  if (inFlightBlocks.size === 1) {
+    graceTimer = setTimeout(() => {
+      graceTimer = undefined;
+      if (inFlightBlocks.size > 0) setBlockingVisible(true);
+    }, SHOW_GRACE_MS);
   }
+  return () => releaseBlock(block);
 }
 
 export function getAutoSyncBlocking(): boolean {
@@ -110,11 +112,10 @@ export function subscribeToAutoSyncBlocking(listener: () => void): () => void {
  * WARNING: Test-only. @internal
  */
 export function resetAutoSyncBlocking(): void {
-  blockCount = 0;
+  inFlightBlocks.forEach((block) => clearTimeout(block.leash));
+  inFlightBlocks.clear();
   isBlockingVisible = false;
   clearTimeout(graceTimer);
   graceTimer = undefined;
-  safetyTimers.forEach((leash) => clearTimeout(leash));
-  safetyTimers.length = 0;
   listeners.clear();
 }

--- a/src/renderer/services/auto-sync-blocking-store.ts
+++ b/src/renderer/services/auto-sync-blocking-store.ts
@@ -12,7 +12,7 @@
  * clears (e.g. the extension deactivates mid-sync and the clearing event is never emitted).
  */
 
-import { SHUTDOWN_SYNC_TIME_OUT_MS } from '@shared/data/platform.data';
+import { AUTO_SYNC_MAX_DURATION_MS } from '@shared/data/platform.data';
 
 /**
  * How long blocking must persist before it becomes visible; a sync finishing inside this window
@@ -22,11 +22,10 @@ const SHOW_GRACE_MS = 200;
 
 /**
  * Heuristic upper bound; if a blocker never clears (e.g. extension deactivates mid-sync),
- * auto-clear after this long. Tracks SHUTDOWN_SYNC_TIME_OUT_MS (the shutdown-sync timeout) because
- * both bound the same operation — a single automatic Send/Receive — so they should never diverge; a
- * scheduled sync of a large repo can run minutes, so the leash is deliberately long.
+ * auto-clear after this long. Each blocker leash bounds a single automatic Send/Receive — exactly
+ * what {@link AUTO_SYNC_MAX_DURATION_MS} is.
  */
-const SAFETY_TIMEOUT_MS = SHUTDOWN_SYNC_TIME_OUT_MS;
+const SAFETY_TIMEOUT_MS = AUTO_SYNC_MAX_DURATION_MS;
 
 let blockCount = 0;
 let isBlockingVisible = false;

--- a/src/renderer/services/workspace-updating-integration.test.ts
+++ b/src/renderer/services/workspace-updating-integration.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { getNetworkEvent } from '@shared/services/network.service';
+import {
+  getWorkspaceUpdating,
+  resetWorkspaceUpdating,
+} from '@renderer/services/workspace-updating-store';
+import { initWorkspaceUpdatingService } from './workspace-updating-service';
+
+vi.mock('@shared/services/network.service', () => ({
+  getNetworkEvent: vi.fn(),
+}));
+
+/**
+ * Integration tests: real workspace-updating store driven through the service by simulated switch
+ * events, under fake timers. These pin the identity pairing between a switch's leash and its own
+ * finish — the two regression traces from the #2571 review (findings 1 and 2).
+ */
+describe('workspace updating service + store integration', () => {
+  let willHandler: ((event: { switchId: string }) => void) | undefined;
+  let didHandler: ((event: { switchId: string }) => void) | undefined;
+  let cleanup: (() => void) | undefined;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    resetWorkspaceUpdating();
+    willHandler = undefined;
+    didHandler = undefined;
+
+    vi.mocked(getNetworkEvent).mockImplementation(
+      // getNetworkEvent has a complex generic signature; cast is required for the mock
+      // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
+      ((eventName: string) => {
+        if (eventName === 'platformScriptureEditor.onWillSwitchProject')
+          return (cb: (event: { switchId: string }) => void) => {
+            willHandler = cb;
+            return vi.fn();
+          };
+        if (eventName === 'platformScriptureEditor.onDidSwitchProject')
+          return (cb: (event: { switchId: string }) => void) => {
+            didHandler = cb;
+            return vi.fn();
+          };
+        return () => vi.fn();
+        // Same cast as above: closing the type assertion needed for the complex generic signature
+        // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
+      }) as any,
+    );
+
+    cleanup = initWorkspaceUpdatingService();
+  });
+
+  afterEach(() => {
+    cleanup?.();
+    resetWorkspaceUpdating();
+    vi.useRealTimers();
+  });
+
+  function startSwitch(switchId: string): void {
+    if (!willHandler) throw new Error('will-switch handler not subscribed');
+    willHandler({ switchId });
+  }
+
+  function finishSwitch(switchId: string): void {
+    if (!didHandler) throw new Error('did-switch handler not subscribed');
+    didHandler({ switchId });
+  }
+
+  it('keeps a live switch blocked when an older switch finishes late, after its own leash fired (review finding 1 trace)', () => {
+    // A starts at t=0; B starts at t=29s.
+    startSwitch('a');
+    vi.advanceTimersByTime(29_000);
+    startSwitch('b');
+
+    // t=30s: A's leash fires. A is released; B is still switching.
+    vi.advanceTimersByTime(1_000);
+    expect(getWorkspaceUpdating()).toBe(true);
+
+    // t=30.5s: A's real finish arrives late. It must pair with A (already released — a no-op),
+    // never with B: B is still switching, so the overlay must stay up.
+    vi.advanceTimersByTime(500);
+    finishSwitch('a');
+    expect(getWorkspaceUpdating()).toBe(true);
+
+    // t=59s: B's own leash fires (B never finished) — now everything is released.
+    vi.advanceTimersByTime(28_500);
+    expect(getWorkspaceUpdating()).toBe(false);
+  });
+
+  it('releases an abandoned switch by its own leash despite ongoing switch traffic (review finding 2 trace)', () => {
+    // X starts at t=0 and is abandoned — its finish never arrives.
+    startSwitch('x');
+
+    // Ordinary switches keep happening faster than the leash interval: one every 20s, each
+    // finishing after 5s. Their finishes must pair with their own switch, never cancel X's leash
+    // — so X's leash still fires at t=30s and the overlay is not stuck for the rest of the
+    // session. (With oldest-first pairing every finish cancels the leash nearest to firing, so
+    // the abandoned switch inherits an ever-newer leash and the overlay never comes down.)
+    for (let i = 0; i < 30; i += 1) {
+      startSwitch(`y${i}`);
+      vi.advanceTimersByTime(5_000);
+      finishSwitch(`y${i}`);
+      vi.advanceTimersByTime(15_000);
+    }
+
+    // ~10 minutes in, nothing is switching: X was released by its own leash at t=30s and every
+    // ordinary switch by its own finish.
+    expect(getWorkspaceUpdating()).toBe(false);
+  });
+
+  it('pairs out-of-order finishes with their own switch', () => {
+    // A starts, then B; B finishes first. Both must end up released exactly once, and the
+    // overlay must stay up until A (still switching) is done.
+    startSwitch('a');
+    vi.advanceTimersByTime(1_000);
+    startSwitch('b');
+    vi.advanceTimersByTime(1_000);
+    finishSwitch('b');
+    expect(getWorkspaceUpdating()).toBe(true);
+    finishSwitch('a');
+    expect(getWorkspaceUpdating()).toBe(false);
+  });
+
+  it('ignores a finish for a switch it never saw start', () => {
+    startSwitch('a');
+    // A finish from before this service subscribed (or a duplicate) must not release anything.
+    finishSwitch('unknown');
+    expect(getWorkspaceUpdating()).toBe(true);
+    finishSwitch('a');
+    expect(getWorkspaceUpdating()).toBe(false);
+  });
+});

--- a/src/renderer/services/workspace-updating-service.test.ts
+++ b/src/renderer/services/workspace-updating-service.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { getNetworkEvent } from '@shared/services/network.service';
-import { setWorkspaceUpdating } from '@renderer/services/workspace-updating-store';
+import { startWorkspaceUpdate } from '@renderer/services/workspace-updating-store';
 import { initWorkspaceUpdatingService } from './workspace-updating-service';
 
 vi.mock('@shared/services/network.service', () => ({
@@ -8,12 +8,12 @@ vi.mock('@shared/services/network.service', () => ({
 }));
 
 vi.mock('@renderer/services/workspace-updating-store', () => ({
-  setWorkspaceUpdating: vi.fn(),
+  startWorkspaceUpdate: vi.fn(),
 }));
 
 describe('initWorkspaceUpdatingService', () => {
-  let capturedWillHandler: (() => void) | undefined;
-  let capturedDidHandler: (() => void) | undefined;
+  let capturedWillHandler: ((event: { switchId: string }) => void) | undefined;
+  let capturedDidHandler: ((event: { switchId: string }) => void) | undefined;
   let willUnsub: ReturnType<typeof vi.fn>;
   let didUnsub: ReturnType<typeof vi.fn>;
 
@@ -29,12 +29,12 @@ describe('initWorkspaceUpdatingService', () => {
       // eslint-disable-next-line no-type-assertion/no-type-assertion, @typescript-eslint/no-explicit-any
       ((eventName: string) => {
         if (eventName === 'platformScriptureEditor.onWillSwitchProject')
-          return (cb: () => void) => {
+          return (cb: (event: { switchId: string }) => void) => {
             capturedWillHandler = cb;
             return willUnsub;
           };
         if (eventName === 'platformScriptureEditor.onDidSwitchProject')
-          return (cb: () => void) => {
+          return (cb: (event: { switchId: string }) => void) => {
             capturedDidHandler = cb;
             return didUnsub;
           };
@@ -45,20 +45,55 @@ describe('initWorkspaceUpdatingService', () => {
     );
   });
 
-  it('calls setWorkspaceUpdating(true) when the will-switch event fires', () => {
+  it('starts a workspace update when the will-switch event fires', () => {
+    vi.mocked(startWorkspaceUpdate).mockReturnValue(vi.fn());
     initWorkspaceUpdatingService();
     expect(capturedWillHandler).toBeDefined();
     if (!capturedWillHandler) throw new Error('capturedWillHandler not set');
-    capturedWillHandler();
-    expect(vi.mocked(setWorkspaceUpdating)).toHaveBeenCalledWith(true);
+    capturedWillHandler({ switchId: 'switch-1' });
+    expect(vi.mocked(startWorkspaceUpdate)).toHaveBeenCalledTimes(1);
   });
 
-  it('calls setWorkspaceUpdating(false) when the did-switch event fires', () => {
+  it('releases exactly the switch named by the did-switch event', () => {
+    const release1 = vi.fn();
+    const release2 = vi.fn();
+    vi.mocked(startWorkspaceUpdate).mockReturnValueOnce(release1).mockReturnValueOnce(release2);
     initWorkspaceUpdatingService();
-    expect(capturedDidHandler).toBeDefined();
-    if (!capturedDidHandler) throw new Error('capturedDidHandler not set');
-    capturedDidHandler();
-    expect(vi.mocked(setWorkspaceUpdating)).toHaveBeenCalledWith(false);
+    if (!capturedWillHandler || !capturedDidHandler) throw new Error('handlers not set');
+    capturedWillHandler({ switchId: 'switch-1' });
+    capturedWillHandler({ switchId: 'switch-2' });
+    capturedDidHandler({ switchId: 'switch-2' });
+    expect(release2).toHaveBeenCalledTimes(1);
+    expect(release1).not.toHaveBeenCalled();
+    capturedDidHandler({ switchId: 'switch-1' });
+    expect(release1).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a did-switch event for a switch it never saw start', () => {
+    const release = vi.fn();
+    vi.mocked(startWorkspaceUpdate).mockReturnValue(release);
+    initWorkspaceUpdatingService();
+    if (!capturedWillHandler || !capturedDidHandler) throw new Error('handlers not set');
+    capturedWillHandler({ switchId: 'switch-1' });
+    capturedDidHandler({ switchId: 'not-a-switch' });
+    expect(release).not.toHaveBeenCalled();
+  });
+
+  it('drops its release entry when the store reports the switch released, so a reused id starts fresh', () => {
+    const release = vi.fn();
+    let onReleased: (() => void) | undefined;
+    vi.mocked(startWorkspaceUpdate).mockImplementation((onReleasedArg) => {
+      onReleased = onReleasedArg;
+      return release;
+    });
+    initWorkspaceUpdatingService();
+    if (!capturedWillHandler || !capturedDidHandler) throw new Error('handlers not set');
+    capturedWillHandler({ switchId: 'switch-1' });
+    // The store releases the switch (e.g. its safety leash fired) and notifies the service…
+    onReleased?.();
+    // …so a later did-finish for it finds no entry (release itself would be a no-op anyway).
+    capturedDidHandler({ switchId: 'switch-1' });
+    expect(release).not.toHaveBeenCalled();
   });
 
   it('returns a cleanup function that unsubscribes both events', () => {

--- a/src/renderer/services/workspace-updating-service.ts
+++ b/src/renderer/services/workspace-updating-service.ts
@@ -1,22 +1,35 @@
 import { getNetworkEvent } from '@shared/services/network.service';
-import { setWorkspaceUpdating } from './workspace-updating-store';
+import { startWorkspaceUpdate } from './workspace-updating-store';
 
 // String values must match PROJECT_SWITCH_WILL_START_EVENT / PROJECT_SWITCH_DID_FINISH_EVENT in
-// extensions/src/platform-scripture-editor/src/main.ts
+// extensions/src/platform-scripture-editor/src/main.ts. Payload types come from the
+// `NetworkEvents` declarations in that extension's `platform-scripture-editor.d.ts`.
 const PROJECT_SWITCH_WILL_START_EVENT = 'platformScriptureEditor.onWillSwitchProject';
 const PROJECT_SWITCH_DID_FINISH_EVENT = 'platformScriptureEditor.onDidSwitchProject';
 
 /**
  * Subscribes to project-switch network events and drives the workspace-updating store. Call once at
  * app startup. Returns a cleanup function.
+ *
+ * Both events carry the emitting switch's `switchId`, so each did-finish releases exactly the
+ * switch that started it — a late finish for a switch whose safety leash already fired is a no-op,
+ * and a finish can never release a different, still-running switch. A finish whose start this
+ * service never saw (e.g. emitted before startup subscription) is ignored.
  */
 export function initWorkspaceUpdatingService(): () => void {
-  const unsubWill = getNetworkEvent(PROJECT_SWITCH_WILL_START_EVENT)(() =>
-    setWorkspaceUpdating(true),
-  );
-  const unsubDid = getNetworkEvent(PROJECT_SWITCH_DID_FINISH_EVENT)(() =>
-    setWorkspaceUpdating(false),
-  );
+  // One release function per in-flight switch. Entries are removed when the switch is released by
+  // either path (its finish or its safety leash), so abandoned switches don't accumulate here.
+  const releaseBySwitchId = new Map<string, () => void>();
+
+  const unsubWill = getNetworkEvent(PROJECT_SWITCH_WILL_START_EVENT)(({ switchId }) => {
+    releaseBySwitchId.set(
+      switchId,
+      startWorkspaceUpdate(() => releaseBySwitchId.delete(switchId)),
+    );
+  });
+  const unsubDid = getNetworkEvent(PROJECT_SWITCH_DID_FINISH_EVENT)(({ switchId }) => {
+    releaseBySwitchId.get(switchId)?.();
+  });
   return () => {
     unsubWill();
     unsubDid();

--- a/src/renderer/services/workspace-updating-store.test.ts
+++ b/src/renderer/services/workspace-updating-store.test.ts
@@ -125,13 +125,34 @@ describe('workspace-updating-store', () => {
       expect(listener).toHaveBeenCalledTimes(2); // true, then false — no extra firing
     });
 
-    it('resets the safety timer when a new switch starts while one is in flight', () => {
+    it('arms a leash per switch — a later switch outlives an earlier start expiring', () => {
       setWorkspaceUpdating(true);
       vi.advanceTimersByTime(20_000);
-      setWorkspaceUpdating(true); // second switch — timer resets to 30 s from now
-      vi.advanceTimersByTime(10_000); // 30 s from first start, but only 10 s from second
-      expect(getWorkspaceUpdating()).toBe(true); // second switch reset the timer — still alive
-      vi.advanceTimersByTime(20_000); // 30 s from second switch — safety fires
+      setWorkspaceUpdating(true); // second switch — gets its own 30 s leash
+      vi.advanceTimersByTime(10_000); // 30 s from first start (its leash fires), 10 s from second
+      expect(getWorkspaceUpdating()).toBe(true); // second switch's own leash is still alive
+      vi.advanceTimersByTime(20_000); // 30 s from second switch — its leash fires
+      expect(getWorkspaceUpdating()).toBe(false);
+    });
+
+    it('releases only its own switch when a stale leash expires — the newer switch stays visible until it finishes', () => {
+      setWorkspaceUpdating(true); // switch A starts at t=0 and is abandoned
+      vi.advanceTimersByTime(15_000);
+      setWorkspaceUpdating(true); // switch B starts at t=15s
+      vi.advanceTimersByTime(15_000); // t=30s — A's leash expires
+      expect(getWorkspaceUpdating()).toBe(true); // B still in flight — stays visible
+      setWorkspaceUpdating(false); // B finishes — the count stayed correct, so one finish clears
+      expect(getWorkspaceUpdating()).toBe(false);
+    });
+
+    it('pairs a finish with the oldest leash — the newest switch keeps its own full leash', () => {
+      setWorkspaceUpdating(true); // switch A starts at t=0
+      vi.advanceTimersByTime(5_000);
+      setWorkspaceUpdating(true); // switch B starts at t=5s and is abandoned
+      setWorkspaceUpdating(false); // A finishes — cancels the oldest leash (A's)
+      vi.advanceTimersByTime(25_000); // t=30s — A's cancelled leash is silent
+      expect(getWorkspaceUpdating()).toBe(true); // B is still inside its own leash
+      vi.advanceTimersByTime(5_000); // t=35s — B's own leash expires
       expect(getWorkspaceUpdating()).toBe(false);
     });
   });

--- a/src/renderer/services/workspace-updating-store.test.ts
+++ b/src/renderer/services/workspace-updating-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
-  setWorkspaceUpdating,
+  startWorkspaceUpdate,
   getWorkspaceUpdating,
   subscribeToWorkspaceUpdating,
   resetWorkspaceUpdating,
@@ -17,62 +17,65 @@ describe('workspace-updating-store', () => {
     });
   });
 
-  describe('setWorkspaceUpdating', () => {
+  describe('startWorkspaceUpdate', () => {
     it('sets state to true', () => {
-      setWorkspaceUpdating(true);
+      startWorkspaceUpdate();
       expect(getWorkspaceUpdating()).toBe(true);
     });
 
-    it('sets state back to false', () => {
-      setWorkspaceUpdating(true);
-      setWorkspaceUpdating(false);
+    it('sets state back to false when the switch is released', () => {
+      const release = startWorkspaceUpdate();
+      release();
       expect(getWorkspaceUpdating()).toBe(false);
     });
 
     it('stays true when a second switch starts before the first finishes', () => {
-      setWorkspaceUpdating(true); // switch A starts
-      setWorkspaceUpdating(true); // switch B starts
-      setWorkspaceUpdating(false); // switch A finishes
+      const releaseA = startWorkspaceUpdate();
+      const releaseB = startWorkspaceUpdate();
+      releaseA();
       expect(getWorkspaceUpdating()).toBe(true); // switch B still in flight
-      setWorkspaceUpdating(false); // switch B finishes
+      releaseB();
       expect(getWorkspaceUpdating()).toBe(false);
     });
 
-    it('clamps at zero — extra false calls do not underflow', () => {
-      setWorkspaceUpdating(true);
-      setWorkspaceUpdating(false);
-      setWorkspaceUpdating(false); // extra call — should be ignored
-      expect(getWorkspaceUpdating()).toBe(false);
+    it('release is idempotent — releasing twice cannot release another switch', () => {
+      const releaseA = startWorkspaceUpdate();
+      startWorkspaceUpdate(); // switch B, still in flight
+      releaseA();
+      releaseA(); // duplicate — must be a no-op, not release B
+      expect(getWorkspaceUpdating()).toBe(true);
     });
 
     it('notifies listeners when state changes to true', () => {
       const listener = vi.fn();
       subscribeToWorkspaceUpdating(listener);
-      setWorkspaceUpdating(true);
+      startWorkspaceUpdate();
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
     it('notifies listeners when state changes to false', () => {
-      setWorkspaceUpdating(true);
+      const release = startWorkspaceUpdate();
       const listener = vi.fn();
       subscribeToWorkspaceUpdating(listener);
-      setWorkspaceUpdating(false);
+      release();
       expect(listener).toHaveBeenCalledTimes(1);
     });
 
     it('does not notify listeners when visible state is unchanged (concurrent switches)', () => {
-      setWorkspaceUpdating(true);
+      startWorkspaceUpdate();
       const listener = vi.fn();
       subscribeToWorkspaceUpdating(listener);
-      setWorkspaceUpdating(true); // second switch — count 1→2, boolean still true
+      startWorkspaceUpdate(); // second switch — set grows 1→2, boolean still true
       expect(listener).not.toHaveBeenCalled();
     });
 
-    it('does not notify listeners when value is unchanged (already false)', () => {
-      const listener = vi.fn();
-      subscribeToWorkspaceUpdating(listener);
-      setWorkspaceUpdating(false); // already false — no change
-      expect(listener).not.toHaveBeenCalled();
+    it('calls onReleased exactly once when released by the release function', () => {
+      const onReleased = vi.fn();
+      const release = startWorkspaceUpdate(onReleased);
+      expect(onReleased).not.toHaveBeenCalled();
+      release();
+      release(); // duplicate release must not re-fire it
+      expect(onReleased).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -81,7 +84,7 @@ describe('workspace-updating-store', () => {
       const listener = vi.fn();
       const unsubscribe = subscribeToWorkspaceUpdating(listener);
       unsubscribe();
-      setWorkspaceUpdating(true);
+      startWorkspaceUpdate();
       expect(listener).not.toHaveBeenCalled();
     });
 
@@ -90,13 +93,13 @@ describe('workspace-updating-store', () => {
       const listener2 = vi.fn();
       subscribeToWorkspaceUpdating(listener1);
       subscribeToWorkspaceUpdating(listener2);
-      setWorkspaceUpdating(true);
+      startWorkspaceUpdate();
       expect(listener1).toHaveBeenCalledTimes(1);
       expect(listener2).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('safety timer', () => {
+  describe('safety leash', () => {
     beforeEach(() => {
       vi.useFakeTimers();
     });
@@ -108,27 +111,27 @@ describe('workspace-updating-store', () => {
     it('auto-clears after 30 s if the switch never resolves', () => {
       const listener = vi.fn();
       subscribeToWorkspaceUpdating(listener);
-      setWorkspaceUpdating(true);
+      startWorkspaceUpdate();
       expect(getWorkspaceUpdating()).toBe(true);
       vi.advanceTimersByTime(30_000);
       expect(getWorkspaceUpdating()).toBe(false);
       expect(listener).toHaveBeenCalledTimes(2); // true, then auto-clear
     });
 
-    it('cancels the safety timer when the switch completes normally', () => {
+    it('cancels the safety leash when the switch completes normally', () => {
       const listener = vi.fn();
       subscribeToWorkspaceUpdating(listener);
-      setWorkspaceUpdating(true);
-      setWorkspaceUpdating(false); // normal completion
+      const release = startWorkspaceUpdate();
+      release(); // normal completion
       vi.advanceTimersByTime(30_000);
       expect(getWorkspaceUpdating()).toBe(false);
       expect(listener).toHaveBeenCalledTimes(2); // true, then false — no extra firing
     });
 
     it('arms a leash per switch — a later switch outlives an earlier start expiring', () => {
-      setWorkspaceUpdating(true);
+      startWorkspaceUpdate();
       vi.advanceTimersByTime(20_000);
-      setWorkspaceUpdating(true); // second switch — gets its own 30 s leash
+      startWorkspaceUpdate(); // second switch — gets its own 30 s leash
       vi.advanceTimersByTime(10_000); // 30 s from first start (its leash fires), 10 s from second
       expect(getWorkspaceUpdating()).toBe(true); // second switch's own leash is still alive
       vi.advanceTimersByTime(20_000); // 30 s from second switch — its leash fires
@@ -136,24 +139,44 @@ describe('workspace-updating-store', () => {
     });
 
     it('releases only its own switch when a stale leash expires — the newer switch stays visible until it finishes', () => {
-      setWorkspaceUpdating(true); // switch A starts at t=0 and is abandoned
+      startWorkspaceUpdate(); // switch A starts at t=0 and is abandoned
       vi.advanceTimersByTime(15_000);
-      setWorkspaceUpdating(true); // switch B starts at t=15s
+      const releaseB = startWorkspaceUpdate(); // switch B starts at t=15s
       vi.advanceTimersByTime(15_000); // t=30s — A's leash expires
       expect(getWorkspaceUpdating()).toBe(true); // B still in flight — stays visible
-      setWorkspaceUpdating(false); // B finishes — the count stayed correct, so one finish clears
+      releaseB();
       expect(getWorkspaceUpdating()).toBe(false);
     });
 
-    it('pairs a finish with the oldest leash — the newest switch keeps its own full leash', () => {
-      setWorkspaceUpdating(true); // switch A starts at t=0
-      vi.advanceTimersByTime(5_000);
-      setWorkspaceUpdating(true); // switch B starts at t=5s and is abandoned
-      setWorkspaceUpdating(false); // A finishes — cancels the oldest leash (A's)
-      vi.advanceTimersByTime(25_000); // t=30s — A's cancelled leash is silent
-      expect(getWorkspaceUpdating()).toBe(true); // B is still inside its own leash
-      vi.advanceTimersByTime(5_000); // t=35s — B's own leash expires
+    it('a late release after the leash already fired is a no-op — it cannot release another switch (review finding 1)', () => {
+      const releaseA = startWorkspaceUpdate(); // switch A starts at t=0
+      vi.advanceTimersByTime(29_000);
+      startWorkspaceUpdate(); // switch B starts at t=29s
+      vi.advanceTimersByTime(1_000); // t=30s — A's leash fires, releasing A
+      expect(getWorkspaceUpdating()).toBe(true); // B still in flight
+      vi.advanceTimersByTime(500);
+      releaseA(); // A's real finish arrives late — must be a no-op, never release B
+      expect(getWorkspaceUpdating()).toBe(true);
+      vi.advanceTimersByTime(28_500); // t=59s — B's own leash fires
       expect(getWorkspaceUpdating()).toBe(false);
+    });
+
+    it('an abandoned switch is released by its own leash despite other switches finishing (review finding 2)', () => {
+      startWorkspaceUpdate(); // switch X starts at t=0 and is abandoned
+      vi.advanceTimersByTime(5_000);
+      const releaseA = startWorkspaceUpdate(); // switch A starts at t=5s
+      releaseA(); // and finishes immediately — must not cancel X's leash
+      vi.advanceTimersByTime(25_000); // t=30s — X's own leash fires
+      expect(getWorkspaceUpdating()).toBe(false); // not stuck: X was released by its own leash
+    });
+
+    it('calls onReleased when released by the leash', () => {
+      const onReleased = vi.fn();
+      const release = startWorkspaceUpdate(onReleased);
+      vi.advanceTimersByTime(30_000);
+      expect(onReleased).toHaveBeenCalledTimes(1);
+      release(); // late release after the leash — no second call
+      expect(onReleased).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/renderer/services/workspace-updating-store.ts
+++ b/src/renderer/services/workspace-updating-store.ts
@@ -1,12 +1,15 @@
 /**
  * Store tracking whether the workspace is currently switching projects.
  *
- * Uses a reference counter so concurrent switches don't prematurely hide the overlay: the visible
- * state (isUpdating) only flips to false once every in-flight switch has finished.
+ * Tracks one entry per in-flight switch so concurrent switches don't prematurely hide the overlay:
+ * the visible state (isUpdating) only flips to false once every in-flight switch has been
+ * released.
  *
- * Each switch arms its own one-shot 30-second safety leash that releases just that switch if it
- * never resolves (e.g. the extension deactivates mid-switch and the did-finish event is never
- * emitted), so one stale expiry can never wipe newer in-flight switches.
+ * Each switch is identified by the token {@link startWorkspaceUpdate} returns, and is released
+ * exactly once — by its own finish (calling the token) or by its own one-shot 30-second safety
+ * leash if it never resolves (e.g. the extension deactivates mid-switch and the did-finish event is
+ * never emitted). Identity pairing means a finish can never release a different switch and a stale
+ * leash can never wipe newer in-flight switches.
  */
 
 /**
@@ -15,15 +18,19 @@
  */
 const SWITCH_SAFETY_TIMEOUT_MS = 30_000;
 
-let switchCount = 0;
+/** One in-flight switch: its own safety leash plus the caller's release notification. */
+type InFlightSwitch = {
+  leash: ReturnType<typeof setTimeout>;
+  onReleased: (() => void) | undefined;
+};
+
 /**
- * One outstanding safety leash per in-flight switch, oldest first. Every start arms its own
- * one-shot leash and every finish cancels the oldest outstanding one, so the array's length always
- * equals `switchCount` and each switch is released exactly once — by its finish or by its own
- * leash. (Same pattern as auto-sync-blocking-store; extracting a shared abstraction is deliberately
- * deferred — PT-4214 Stage U.)
+ * Every in-flight (not yet released) switch. `getWorkspaceUpdating()` is exactly "this set is
+ * non-empty", so there is no separate counter to keep in lockstep. (Same pattern as
+ * auto-sync-blocking-store; extracting a shared abstraction is deliberately deferred — PT-4214
+ * Stage U.)
  */
-const safetyTimers: ReturnType<typeof setTimeout>[] = [];
+const inFlightSwitches = new Set<InFlightSwitch>();
 
 const listeners = new Set<() => void>();
 
@@ -31,35 +38,38 @@ function notifyListeners(): void {
   listeners.forEach((listener) => listener());
 }
 
-export function setWorkspaceUpdating(value: boolean): void {
-  const wasUpdating = switchCount > 0;
-  if (value) {
-    switchCount += 1;
-    // Arm this switch's own one-shot safety leash, 30 s from this start. When it fires it releases
-    // only this switch — never the whole count — so a stale expiry cannot wipe newer in-flight
-    // switches.
-    const leash = setTimeout(() => {
-      const index = safetyTimers.indexOf(leash);
-      if (index !== -1) safetyTimers.splice(index, 1);
-      switchCount = Math.max(0, switchCount - 1);
-      if (switchCount === 0) notifyListeners();
-    }, SWITCH_SAFETY_TIMEOUT_MS);
-    safetyTimers.push(leash);
-  } else {
-    // Cancel the oldest outstanding leash so the switch this finish releases cannot be released a
-    // second time when its leash fires. Switches are anonymous, so oldest-first is a pairing
-    // heuristic — and the conservative one: the still-open switches keep the newest (longest
-    // remaining) leashes.
-    const oldestLeash = safetyTimers.shift();
-    if (oldestLeash !== undefined) clearTimeout(oldestLeash);
-    switchCount = Math.max(0, switchCount - 1);
-  }
-  const isNowUpdating = switchCount > 0;
-  if (wasUpdating !== isNowUpdating) notifyListeners();
+/** Releases one switch. A no-op if it was already released (identity — released exactly once). */
+function releaseSwitch(inFlightSwitch: InFlightSwitch): void {
+  if (!inFlightSwitches.has(inFlightSwitch)) return;
+  inFlightSwitches.delete(inFlightSwitch);
+  clearTimeout(inFlightSwitch.leash);
+  inFlightSwitch.onReleased?.();
+  if (inFlightSwitches.size === 0) notifyListeners();
+}
+
+/**
+ * Registers the start of a project switch and returns its release function. Call the returned
+ * function when the switch finishes; it is idempotent and releases only this switch. If the switch
+ * never finishes, its own safety leash releases it after {@link SWITCH_SAFETY_TIMEOUT_MS} — a stale
+ * leash can never release a newer in-flight switch.
+ *
+ * @param onReleased Called exactly once when this switch is released, by either path (its finish or
+ *   its leash). Lets the caller drop its own bookkeeping for the switch without leaking entries for
+ *   abandoned switches.
+ */
+export function startWorkspaceUpdate(onReleased?: () => void): () => void {
+  const wasUpdating = inFlightSwitches.size > 0;
+  const inFlightSwitch: InFlightSwitch = {
+    leash: setTimeout(() => releaseSwitch(inFlightSwitch), SWITCH_SAFETY_TIMEOUT_MS),
+    onReleased,
+  };
+  inFlightSwitches.add(inFlightSwitch);
+  if (!wasUpdating) notifyListeners();
+  return () => releaseSwitch(inFlightSwitch);
 }
 
 export function getWorkspaceUpdating(): boolean {
-  return switchCount > 0;
+  return inFlightSwitches.size > 0;
 }
 
 /** Subscribe to state changes. Returns an unsubscribe function. */
@@ -76,8 +86,7 @@ export function subscribeToWorkspaceUpdating(listener: () => void): () => void {
  * WARNING: Test-only. @internal
  */
 export function resetWorkspaceUpdating(): void {
-  switchCount = 0;
-  safetyTimers.forEach((leash) => clearTimeout(leash));
-  safetyTimers.length = 0;
+  inFlightSwitches.forEach((inFlightSwitch) => clearTimeout(inFlightSwitch.leash));
+  inFlightSwitches.clear();
   listeners.clear();
 }

--- a/src/renderer/services/workspace-updating-store.ts
+++ b/src/renderer/services/workspace-updating-store.ts
@@ -4,8 +4,9 @@
  * Uses a reference counter so concurrent switches don't prematurely hide the overlay: the visible
  * state (isUpdating) only flips to false once every in-flight switch has finished.
  *
- * A 30-second safety timer resets on every new switch and auto-clears the state if a switch never
- * resolves (e.g. the extension deactivates mid-switch and the did-finish event is never emitted).
+ * Each switch arms its own one-shot 30-second safety leash that releases just that switch if it
+ * never resolves (e.g. the extension deactivates mid-switch and the did-finish event is never
+ * emitted), so one stale expiry can never wipe newer in-flight switches.
  */
 
 /**
@@ -15,7 +16,14 @@
 const SWITCH_SAFETY_TIMEOUT_MS = 30_000;
 
 let switchCount = 0;
-let safetyTimer: ReturnType<typeof setTimeout> | undefined;
+/**
+ * One outstanding safety leash per in-flight switch, oldest first. Every start arms its own
+ * one-shot leash and every finish cancels the oldest outstanding one, so the array's length always
+ * equals `switchCount` and each switch is released exactly once — by its finish or by its own
+ * leash. (Same pattern as auto-sync-blocking-store; extracting a shared abstraction is deliberately
+ * deferred — PT-4214 Stage U.)
+ */
+const safetyTimers: ReturnType<typeof setTimeout>[] = [];
 
 const listeners = new Set<() => void>();
 
@@ -27,19 +35,24 @@ export function setWorkspaceUpdating(value: boolean): void {
   const wasUpdating = switchCount > 0;
   if (value) {
     switchCount += 1;
-    // Reset the safety timer on each new switch, giving 30 s from the latest start.
-    clearTimeout(safetyTimer);
-    safetyTimer = setTimeout(() => {
-      switchCount = 0;
-      safetyTimer = undefined;
-      notifyListeners();
+    // Arm this switch's own one-shot safety leash, 30 s from this start. When it fires it releases
+    // only this switch — never the whole count — so a stale expiry cannot wipe newer in-flight
+    // switches.
+    const leash = setTimeout(() => {
+      const index = safetyTimers.indexOf(leash);
+      if (index !== -1) safetyTimers.splice(index, 1);
+      switchCount = Math.max(0, switchCount - 1);
+      if (switchCount === 0) notifyListeners();
     }, SWITCH_SAFETY_TIMEOUT_MS);
+    safetyTimers.push(leash);
   } else {
+    // Cancel the oldest outstanding leash so the switch this finish releases cannot be released a
+    // second time when its leash fires. Switches are anonymous, so oldest-first is a pairing
+    // heuristic — and the conservative one: the still-open switches keep the newest (longest
+    // remaining) leashes.
+    const oldestLeash = safetyTimers.shift();
+    if (oldestLeash !== undefined) clearTimeout(oldestLeash);
     switchCount = Math.max(0, switchCount - 1);
-    if (switchCount === 0) {
-      clearTimeout(safetyTimer);
-      safetyTimer = undefined;
-    }
   }
   const isNowUpdating = switchCount > 0;
   if (wasUpdating !== isNowUpdating) notifyListeners();
@@ -64,7 +77,7 @@ export function subscribeToWorkspaceUpdating(listener: () => void): () => void {
  */
 export function resetWorkspaceUpdating(): void {
   switchCount = 0;
-  clearTimeout(safetyTimer);
-  safetyTimer = undefined;
+  safetyTimers.forEach((leash) => clearTimeout(leash));
+  safetyTimers.length = 0;
   listeners.clear();
 }

--- a/src/shared/data/platform.data.ts
+++ b/src/shared/data/platform.data.ts
@@ -21,7 +21,18 @@ export const MIN_ZOOM_FACTOR = 0.5;
 export const MAX_ZOOM_FACTOR = 3.0;
 
 /**
- * Upper bound (10 minutes) on how long a single automatic Send/Receive is allowed to run. A
- * scheduled sync of a large repo can run for minutes, so this is deliberately long.
+ * Upper bound (10 minutes) on how long a single app-driven ("automatic") Send/Receive is allowed to
+ * run — one the app starts itself rather than the user driving it from the Send/Receive dialog
+ * (which has its own progress and Cancel). A sync of a large repo can run for minutes, so this is
+ * deliberately long.
+ *
+ * Two different consumers share this value and must never diverge:
+ *
+ * - The main process (`shutdown-tasks.ts`) bounds how long app shutdown waits on its final sync.
+ * - The renderer (`auto-sync-blocking-store.ts`) bounds each edit-block safety leash — how long a
+ *   single blocker may block editing if its clearing event never arrives.
+ *
+ * If they diverged, a shutdown sync could outlive the renderer's opinion of it (or vice versa);
+ * tune this value knowing it retimes both.
  */
 export const AUTO_SYNC_MAX_DURATION_MS = 10 * 60 * 1000;

--- a/src/shared/data/platform.data.ts
+++ b/src/shared/data/platform.data.ts
@@ -21,9 +21,7 @@ export const MIN_ZOOM_FACTOR = 0.5;
 export const MAX_ZOOM_FACTOR = 3.0;
 
 /**
- * Upper bound (10 minutes) for how long an automatic Send/Receive is allowed to run before we stop
- * waiting on it. Used as the shutdown-sync timeout in the main process and as the auto-sync
- * edit-block safety leash in the renderer. A scheduled sync of a large repo can run for minutes, so
- * this is deliberately long.
+ * Upper bound (10 minutes) on how long a single automatic Send/Receive is allowed to run. A
+ * scheduled sync of a large repo can run for minutes, so this is deliberately long.
  */
-export const SHUTDOWN_SYNC_TIME_OUT_MS = 10 * 60 * 1000;
+export const AUTO_SYNC_MAX_DURATION_MS = 10 * 60 * 1000;

--- a/src/shared/data/platform.data.ts
+++ b/src/shared/data/platform.data.ts
@@ -34,5 +34,7 @@ export const MAX_ZOOM_FACTOR = 3.0;
  *
  * If they diverged, a shutdown sync could outlive the renderer's opinion of it (or vice versa);
  * tune this value knowing it retimes both.
+ *
+ * @experimental
  */
 export const AUTO_SYNC_MAX_DURATION_MS = 10 * 60 * 1000;

--- a/src/shared/services/network.service.ts
+++ b/src/shared/services/network.service.ts
@@ -302,6 +302,13 @@ export const request = async <TParam extends Array<unknown>, TReturn>(
  * requests where immediate failure is preferable to waiting, such as commands sent during app
  * shutdown.
  *
+ * WARNING: the no-retry flag only holds in the main process (whose `RpcServer` /
+ * `RpcWebSocketListener` honor it). From any other process the flag does not cross the wire:
+ * `RpcClient.request` drops it, and main re-dispatches the incoming request through its
+ * registration-race retry loop (up to 10 attempts, 1 s apart) before failing. So a renderer-side
+ * `requestNoRetry` to an unregistered handler still costs ~9 s and 10 warning logs in main before
+ * it rejects.
+ *
  * @param requestType The type of request
  * @param args Arguments to send in the request (put in request.contents)
  * @returns Promise that resolves with the response message


### PR DESCRIPTION
Follow-up PR agreed in #2555's approval ("we'll have a small, follow up PR for any remaining concerns").

## 1. Self-catching sync-edit-blocked notification helper (re-review N1)

Thread: https://github.com/paranext/paranext-core/pull/2555#discussion_r3596354123

#2555 gave the scripture editor a self-catching `notifySyncEditBlocked()`, but the finding-9 call sites added in the same round still did bare `papi.notifications.send(...)` — a rejection from the notification service would surface as an unhandled promise rejection. This adds the platform-scripture twin of that helper next to `isSyncEditBlockedError` in `sync-edit-blocked.util.ts` and routes all five call sites through it, so the shared "editing paused" message/severity cannot drift per call site:

- `checks-side-panel.web-view.tsx` (deny/allow catch paths)
- `inventory.web-view.tsx` (approved/unapproved items catch paths)
- `manage-books.web-view.tsx` (mutation-result toast routing — the pre-existing same-shape exposure; its non-blocked generic toast now handles rejections with `.catch` for the same reason)

Rider: inventory's two `await setValidItems?.(...)` / `await setInvalidItems?.(...)` awaits now adopt the runtime promise via `Promise.resolve(...)` — `useProjectSetting`'s declared setter type erases the promise the setter actually returns, so the bare `await` had no effect on the type and looked like a dead catch.

Unit tests cover the helper's happy path and that a rejected send is swallowed and logged.

## 2. Rename `SHUTDOWN_SYNC_TIME_OUT_MS` → `AUTO_SYNC_MAX_DURATION_MS` (re-review N2)

Thread: https://github.com/paranext/paranext-core/pull/2555#discussion_r3596357624

Since the finding-21 hoist, the constant bounds both the shutdown-sync wait and the renderer's edit-block safety leash — the "shutdown" name no longer fit half its uses and the doc comment had to reconcile that. Renamed for what it bounds (the maximum duration of a single automatic Send/Receive), doc comments simplified at both consumers, `papi.d.ts` regenerated and committed.

## 3. Blocking-store hardening (PT-4214 Stage T; original findings 7/8)

> **Superseded in the fix round below:** lyonsil's 2026-07-16 review proved the oldest-first clear-to-leash pairing described here wrong in both directions (his findings 1–3), and the seeding seam inert. The stores now use identity release tokens and the seeding is cut at this tip (it returns for real in #2574, served from C#). This section is kept for review history.

**Finding 8** — the store's safety timer hard-reset `blockCount = 0` when it fired, so under overlapping blocks one stale expiry wiped newer in-flight blockers. Each raise now arms its own one-shot leash that releases only its own block, exactly once; a clear cancels the oldest outstanding leash so a cleared block's leash can never fire later. Same flaw, same fix in the near-twin `workspace-updating-store.ts` (30 s leash). The two fixes are deliberately symmetrical **without** a shared abstraction — that extraction is deferred to PT-4214 Stage U (reviewer-agreed).

**Finding 7 (mitigation)** — implements the upgrade path documented in `auto-sync-blocking-service.ts` ("a command to read the current blocking state … that this service consults on init"): on init the service queries `paratextBibleSendReceive.getAutoSyncBlocking` (untyped `requestNoRetry`, the same pattern as `cancelSync` in shutdown-tasks) and seeds the store, so a renderer reload during an in-flight scheduled sync no longer comes up unblocked while the backend is still syncing. Best-effort by design: a live event always wins over the snapshot, a failed request keeps the assume-unblocked default (the expected path on plain Platform.Bible), and the per-blocker leash bounds a seeded block whose clearing event never arrives. **Remaining for PT-4214:** registering `getAutoSyncBlocking` on the Send/Receive extension side and declaring it in the copied `paratext-bible-send-receive.d.ts` command contract — the core-side seam here is inert until then.

Tests: overlapping blockers where a stale leash expires while a newer block is active (count stays correct, UI stays blocked until the newer one clears), clear-pairs-with-oldest-leash (both stores), and all seeding paths (seeds on `true`, skips `false`/non-boolean/failure, event wins over snapshot, no seeding after cleanup).

## Verification

- `npm run typecheck` — clean across all workspaces
- `npm run lint` — clean
- `npm test` — 3,599 passed, 1 skipped (all workspaces; includes the new/updated tests for the notification helper, blocking store, workspace-updating store, blocking service, shutdown/startup tasks)
- `npm run build:types` — regen committed with the rename; re-run after the final commit with zero drift

## Fix round — lyonsil's 2026-07-16 full-diff review (19 findings, review 4718215827)

Per-finding replies go on the inline threads. Findings 18/20 (message sentinel → coded error; a single interception point for gate rejections) are deferred to **PT-4214** — recorded in that ticket's description with the comment ids, including the design note that `FAILED_PRECONDITION` alone cannot discriminate the gate. Finding 4 (#2560 collision over the constant rename) stays on the documented whichever-merges-second-rebases plan. Finding 17 (deferral cost) acknowledged — the record is accurate.

- `532739cc891` — **findings 1/2/3 (blocking) + 14/15 + 5/6/13**: leash pairing reworked to *identity* — each switch/block gets a release token, released exactly once by its own clear or its own leash; a late clear after a fired leash is a no-op and can never release a newer live blocker. The project-switch events now carry a `switchId` (typed via `NetworkEvents`) so the workspace pipeline pairs exactly end-to-end; the anonymous auto-sync boolean keeps oldest-first-with-tombstones and documents honestly what anonymous pairing cannot fix (resolved by #2574's snapshots). Both review traces are pinned by integration tests that fail on the pre-fix code. The dual counters and timer-array scans dissolve (14/15). The inert `getAutoSyncBlocking` seeding is cut (registered nowhere at this tip; its doomed consult cost ~9 s of main-process retry churn per renderer launch — `requestNoRetry`'s renderer-side behavior is now documented on the function), the `Known limitation` reload note is restored pointing at PT-4214, and `initAutoSyncBlockingService` is synchronous again so the index.tsx comment is accurate (13).
- `a759690ac2e` — **findings 9/19**: `useProjectSetting` declares its real types — `setSetting` returns the update-instructions promise, `resetSetting` returns `Promise<boolean>` (the wrapper no longer swallows it). Inventory's two no-op `await Promise.resolve(...)` workarounds deleted; the generic Setting component awaits the setter so write-gate rejections reach its existing catch. Typecheck clean across all workspaces — zero consumer fallout. `papi.d.ts` regenerated.
- `56b9934560a` — **findings 7/8/12/16**: checks-side-panel no longer rethrows non-sentinel errors into a fire-and-forget void (logs + returns false); bare-string tests pin `isSyncEditBlockedError`'s quote-wrapped manage-books path and why the regex must stay unanchored; `SYNC_EDIT_BLOCKED_MESSAGE_KEY` unexported and the test asserts the literal key; `AUTO_SYNC_MAX_DURATION_MS` doc names both consumers again with the never-diverge rule and pins "automatic" = app-driven.

**Fix-round verification:** `npm test` all workspaces green (includes the new trace/integration tests), `npm run typecheck` clean across all workspaces, eslint clean on changed files, `npm run build:types` drift committed. #2574 rebased onto this tip (its snapshot rewrite supersedes the auto-sync store/service changes here — expected churn, reconciled in its `08d0d3d31ac`) and #2575 rebased on top; stack verified linear; #2574's C# suite green (1530 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2571)
<!-- Reviewable:end -->

