### PR TITLE
PT-4214: blocked-state UI reflection — Comments panel + project settings (E2E defect 4)

### DIFF
--- a/assets/localization/en.json
+++ b/assets/localization/en.json
@@ -398,6 +398,7 @@
   "%settings_platform_zoomFactor_description%": "Applies to the entire application. 1.0 is the default. Allowed range is 0.5 to 3.0.",
   "%settings_platform_zoomFactor_errorMessage%": "Allowed range is {lowerLimit} to {upperLimit}.",
   "%settings_platform_zoomFactor_label%": "Zoom factor",
+  "%settings_projectSyncBlocked_notice%": "Editing paused — an automatic Send/Receive is in progress for this project. Settings are read-only until it finishes.",
   "%settings_sidebar_generalSettingsLabel%": "General Settings",
   "%settings_sidebar_projectsComboBoxPlaceholder%": "Select project",
   "%settings_sidebar_projectSettingsLabel%": "Project Settings",

--- a/assets/localization/es.json
+++ b/assets/localization/es.json
@@ -498,6 +498,7 @@
   "%settings_platform_zoomFactor_description%": "Se aplica a toda la aplicación. El valor predeterminado es 1. El rango permitido es de 0,5 a 3.",
   "%settings_platform_zoomFactor_errorMessage%": "El rango permitido es de {lowerLimit} a {upperLimit}.",
   "%settings_platform_zoomFactor_label%": "Zoom",
+  "%settings_projectSyncBlocked_notice%": "Edición pausada — se está realizando un Enviar/Recibir automático para este proyecto. La configuración es de solo lectura hasta que finalice.",
   "%settings_sidebar_generalSettingsLabel%": "Configuración general",
   "%settings_sidebar_projectsComboBoxPlaceholder%": "Seleccionar proyecto",
   "%settings_sidebar_projectSettingsLabel%": "Configuración del proyecto",

--- a/cspell.json
+++ b/cspell.json
@@ -37,6 +37,7 @@
     "autonym",
     "bbbcccvvv",
     "biblionexus",
+    "blockable",
     "camelcase",
     "consts",
     "cooldown",

--- a/extensions/src/legacy-comment-manager/contributions/localizedStrings.json
+++ b/extensions/src/legacy-comment-manager/contributions/localizedStrings.json
@@ -77,6 +77,8 @@
       "%no_comments_match_filter%": "No comments match your filter settings.",
       "%webView_legacyCommentManager_commentList_title%": "Comments",
       "%webView_legacyCommentManager_commentListPanel_title%": "Comments",
+      "%webView_legacyCommentManager_error_syncEditBlocked%": "Editing is paused while an automatic Send/Receive is in progress. Your change was not saved.",
+      "%webView_legacyCommentManager_syncEditBlocked_notice%": "Editing paused — Send/Receive in progress",
       "%webView_legacyCommentManager_openComments%": "Open Comments"
     },
     "es": {
@@ -142,6 +144,8 @@
       "%no_comments_match_filter%": "No hay comentarios que coincidan con sus parámetros de filtros.",
       "%webView_legacyCommentManager_commentList_title%": "Comentarios",
       "%webView_legacyCommentManager_commentListPanel_title%": "Comentarios de proyecto",
+      "%webView_legacyCommentManager_error_syncEditBlocked%": "La edición está pausada mientras se realiza un Enviar/Recibir automático. Su cambio no se guardó.",
+      "%webView_legacyCommentManager_syncEditBlocked_notice%": "Edición pausada — Enviar/Recibir en curso",
       "%webView_legacyCommentManager_openComments%": "Abrir Comentarios"
     }
   }

--- a/extensions/src/legacy-comment-manager/src/comment-list-capability-gating.util.test.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-capability-gating.util.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  CommentWriteCapabilities,
+  gateCommentWriteCapabilities,
+} from './comment-list-capability-gating.util';
+
+/** Builds a fresh set of "always allow" capabilities, with spies so calls can be asserted. */
+function allowingCapabilities(): CommentWriteCapabilities {
+  return {
+    canUserAddCommentToThread: true,
+    canUserAssignThreadCallback: vi.fn(async () => true),
+    canUserResolveThreadCallback: vi.fn(async () => true),
+    canUserEditOrDeleteCommentCallback: vi.fn(async () => true),
+  };
+}
+
+describe('gateCommentWriteCapabilities', () => {
+  describe('not blocked', () => {
+    it('returns the exact same object (no wrapping) when isSyncBlocked is false', () => {
+      const capabilities = allowingCapabilities();
+      expect(gateCommentWriteCapabilities(false, capabilities)).toBe(capabilities);
+    });
+
+    it('passes the boolean capability through unchanged', async () => {
+      const capabilities = allowingCapabilities();
+      const gated = gateCommentWriteCapabilities(false, capabilities);
+      expect(gated.canUserAddCommentToThread).toBe(true);
+    });
+
+    it('the async capabilities delegate to (are) the original callbacks', async () => {
+      const capabilities = allowingCapabilities();
+      const gated = gateCommentWriteCapabilities(false, capabilities);
+
+      // Literally the same function references — a real delegation, not a lookalike wrapper.
+      expect(gated.canUserAssignThreadCallback).toBe(capabilities.canUserAssignThreadCallback);
+      expect(gated.canUserResolveThreadCallback).toBe(capabilities.canUserResolveThreadCallback);
+      expect(gated.canUserEditOrDeleteCommentCallback).toBe(
+        capabilities.canUserEditOrDeleteCommentCallback,
+      );
+
+      await expect(gated.canUserAssignThreadCallback('thread-1')).resolves.toBe(true);
+      await expect(gated.canUserResolveThreadCallback('thread-1')).resolves.toBe(true);
+      await expect(gated.canUserEditOrDeleteCommentCallback('comment-1')).resolves.toBe(true);
+      expect(capabilities.canUserAssignThreadCallback).toHaveBeenCalledWith('thread-1');
+      expect(capabilities.canUserResolveThreadCallback).toHaveBeenCalledWith('thread-1');
+      expect(capabilities.canUserEditOrDeleteCommentCallback).toHaveBeenCalledWith('comment-1');
+    });
+  });
+
+  describe('blocked', () => {
+    it('denies the boolean capability regardless of the original value', () => {
+      const capabilities = allowingCapabilities();
+      const gated = gateCommentWriteCapabilities(true, capabilities);
+      expect(gated.canUserAddCommentToThread).toBe(false);
+    });
+
+    it('every async capability resolves false without invoking the original', async () => {
+      const capabilities = allowingCapabilities();
+      const gated = gateCommentWriteCapabilities(true, capabilities);
+
+      await expect(gated.canUserAssignThreadCallback('thread-1')).resolves.toBe(false);
+      await expect(gated.canUserResolveThreadCallback('thread-1')).resolves.toBe(false);
+      await expect(gated.canUserEditOrDeleteCommentCallback('comment-1')).resolves.toBe(false);
+
+      // No PDP round-trip should occur while blocked — the answer is definitionally "no".
+      expect(capabilities.canUserAssignThreadCallback).not.toHaveBeenCalled();
+      expect(capabilities.canUserResolveThreadCallback).not.toHaveBeenCalled();
+      expect(capabilities.canUserEditOrDeleteCommentCallback).not.toHaveBeenCalled();
+    });
+
+    it('denies even when the original would reject', async () => {
+      const capabilities: CommentWriteCapabilities = {
+        canUserAddCommentToThread: true,
+        canUserAssignThreadCallback: vi.fn(async () => {
+          throw new Error('PDP unavailable');
+        }),
+        canUserResolveThreadCallback: vi.fn(async () => true),
+        canUserEditOrDeleteCommentCallback: vi.fn(async () => true),
+      };
+      const gated = gateCommentWriteCapabilities(true, capabilities);
+      await expect(gated.canUserAssignThreadCallback('thread-1')).resolves.toBe(false);
+    });
+  });
+});

--- a/extensions/src/legacy-comment-manager/src/comment-list-capability-gating.util.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-capability-gating.util.ts
@@ -1,9 +1,9 @@
 /**
- * Pure gating decision behind the comment list's write-affordance capability props (PT-4214 Stage
- * U). Extracted from `comment-list.web-view.tsx` so the deny-while-blocked / pass-through-when-not
- * decision is unit-testable without mounting the full web view (which needs a live PDP, project
- * data subscription, and papi frontend — none of which are available to this extension's plain
- * `vitest` `node` environment).
+ * Pure gating decision behind the comment list's write-affordance capability props. Extracted from
+ * `comment-list.web-view.tsx` so the deny-while-blocked / pass-through-when-not decision is
+ * unit-testable without mounting the full web view (which needs a live PDP, project data
+ * subscription, and papi frontend — none of which are available to this extension's plain `vitest`
+ * `node` environment).
  *
  * Platform-bible-react's `CommentList` exposes no `disabled`/`readOnly` prop; these four capability
  * props ARE its mechanism for hiding/disabling the reply box, assign, resolve, and edit/delete, so

--- a/extensions/src/legacy-comment-manager/src/comment-list-capability-gating.util.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-capability-gating.util.ts
@@ -1,0 +1,51 @@
+/**
+ * Pure gating decision behind the comment list's write-affordance capability props (PT-4214 Stage
+ * U). Extracted from `comment-list.web-view.tsx` so the deny-while-blocked / pass-through-when-not
+ * decision is unit-testable without mounting the full web view (which needs a live PDP, project
+ * data subscription, and papi frontend — none of which are available to this extension's plain
+ * `vitest` `node` environment).
+ *
+ * Platform-bible-react's `CommentList` exposes no `disabled`/`readOnly` prop; these four capability
+ * props ARE its mechanism for hiding/disabling the reply box, assign, resolve, and edit/delete, so
+ * gating them here is the real disable path — not a cosmetic no-op. The web view's write handlers
+ * additionally catch the backend write-gate rejection as defense-in-depth (see
+ * `sync-edit-blocked.util.ts`).
+ */
+
+/** The comment list's four write-affordance capability props, ungated. */
+export type CommentWriteCapabilities = {
+  /** Whether the current user can add a comment to any thread. */
+  canUserAddCommentToThread: boolean;
+  /** Whether the current user can assign the given thread. */
+  canUserAssignThreadCallback: (threadId: string) => Promise<boolean>;
+  /** Whether the current user can resolve/reopen the given thread. */
+  canUserResolveThreadCallback: (threadId: string) => Promise<boolean>;
+  /** Whether the current user can edit or delete the given comment. */
+  canUserEditOrDeleteCommentCallback: (commentId: string) => Promise<boolean>;
+};
+
+/**
+ * Gates `capabilities` for this render: while `isSyncBlocked` is true, every capability denies —
+ * the boolean is forced to `false` and each async callback resolves `false` WITHOUT invoking the
+ * original (no PDP round-trip is made; the answer is definitionally "no" until the sync ends).
+ *
+ * While not blocked, `capabilities` is returned unchanged — the very same object and function
+ * references — so the caller (and any memoization keyed on the originals' identity) is unaffected
+ * when this project isn't sync-blocked.
+ *
+ * @param isSyncBlocked Whether this project's automatic Send/Receive currently blocks edits.
+ * @param capabilities The ungated capability props to gate.
+ * @returns The gated capability props.
+ */
+export function gateCommentWriteCapabilities(
+  isSyncBlocked: boolean,
+  capabilities: CommentWriteCapabilities,
+): CommentWriteCapabilities {
+  if (!isSyncBlocked) return capabilities;
+  return {
+    canUserAddCommentToThread: false,
+    canUserAssignThreadCallback: async () => false,
+    canUserResolveThreadCallback: async () => false,
+    canUserEditOrDeleteCommentCallback: async () => false,
+  };
+}

--- a/extensions/src/legacy-comment-manager/src/comment-list-panel-web-view.factory.ts
+++ b/extensions/src/legacy-comment-manager/src/comment-list-panel-web-view.factory.ts
@@ -71,6 +71,14 @@ export class CommentListPanelWebViewFactory extends WebViewFactory<
 
     return {
       ...savedWebView,
+      state: {
+        ...savedWebView.state,
+        // Always rebuild un-blocked. `isSyncBlocked` is transient runtime state owned by the core
+        // auto-sync edit-block driver; forcing it false here means a crash/reload mid-sync can never
+        // restore a read-only panel from the saved layout (mirrors the scripture editor's scrub in
+        // platform-scripture-editor main.ts). The driver re-flags it if a sync is still in flight.
+        isSyncBlocked: false,
+      },
       title,
       projectId,
       content: commentListWebView,

--- a/extensions/src/legacy-comment-manager/src/comment-list.component.test.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.component.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+import type { LanguageStrings } from 'platform-bible-utils';
+import { CommentListPanel, CommentListPanelProps } from './comment-list.component';
+import { DEFAULT_COMMENT_FILTERS, UNFILTERED } from './comment-list-filters.model';
+
+const SYNC_BLOCKED_NOTICE_KEY = '%webView_legacyCommentManager_syncEditBlocked_notice%';
+const SYNC_BLOCKED_NOTICE_TEXT = 'Editing is paused while this project syncs.';
+
+// Only the notice's own key needs a real value; every other lookup (toolbar aria-labels, dropdown
+// option labels) is exercised elsewhere (e.g. comment-list.stories.tsx) and simply renders blank
+// here, which is harmless for this notice-focused test.
+const STRINGS: LanguageStrings = {
+  [SYNC_BLOCKED_NOTICE_KEY]: SYNC_BLOCKED_NOTICE_TEXT,
+};
+
+/**
+ * Renders CommentListPanel with an empty thread list. This keeps the render lean — the empty-state
+ * branch skips platform-bible-react's full CommentList tree (comment-list.component.tsx ~222-231) —
+ * while still exercising the toolbar and the sync-blocked notice above it (~256-268), which render
+ * regardless of the list content.
+ */
+function renderPanel(overrides: Partial<CommentListPanelProps> = {}) {
+  render(
+    <CommentListPanel
+      localizedStrings={STRINGS}
+      isLoading={false}
+      threads={[]}
+      currentUser="Tester"
+      filters={DEFAULT_COMMENT_FILTERS}
+      onFiltersChange={vi.fn()}
+      scopeFilter={UNFILTERED}
+      onScopeFilterChange={vi.fn()}
+      handleAddCommentToThread={vi.fn()}
+      handleUpdateComment={vi.fn()}
+      handleDeleteComment={vi.fn()}
+      handleReadStatusChange={vi.fn()}
+      {...overrides}
+    />,
+  );
+}
+
+describe('CommentListPanel sync-blocked notice (PT-4214)', () => {
+  it('renders the notice when isSyncBlocked is true', () => {
+    renderPanel({ isSyncBlocked: true });
+    expect(screen.getByRole('status')).toHaveTextContent(SYNC_BLOCKED_NOTICE_TEXT);
+  });
+
+  it('omits the notice when isSyncBlocked is false', () => {
+    renderPanel({ isSyncBlocked: false });
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('omits the notice when isSyncBlocked is not passed (defaults to false)', () => {
+    renderPanel();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/extensions/src/legacy-comment-manager/src/comment-list.component.test.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.component.test.tsx
@@ -43,7 +43,7 @@ function renderPanel(overrides: Partial<CommentListPanelProps> = {}) {
   );
 }
 
-describe('CommentListPanel sync-blocked notice (PT-4214)', () => {
+describe('CommentListPanel sync-blocked notice', () => {
   it('renders the notice when isSyncBlocked is true', () => {
     renderPanel({ isSyncBlocked: true });
     expect(screen.getByRole('status')).toHaveTextContent(SYNC_BLOCKED_NOTICE_TEXT);

--- a/extensions/src/legacy-comment-manager/src/comment-list.component.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.component.tsx
@@ -204,7 +204,7 @@ export function CommentListPanel({
   const noFiltersActive = areCommentFiltersAtDefault(filters) && scopeFilter === UNFILTERED;
 
   // The list area swaps between skeletons (loading), an empty-state message, and the list — but the
-  // toolbar below always renders, so isLoading only governs this region (see PT-4070).
+  // toolbar below always renders, so isLoading only governs this region.
   let listContent: ReactNode;
   if (isLoading) {
     listContent = (
@@ -255,11 +255,9 @@ export function CommentListPanel({
 
   return (
     <div className="tw:flex tw:flex-col tw:h-full">
-      {/* Sticky header: the editing-paused notice (when blocking) and the filter toolbar both stay
-          pinned to the top of whichever ancestor scrolls (PT-4070), so neither scrolls out of view
-          as the comments list scrolls. Previously only the toolbar was sticky, so the notice
-          scrolled away once the list was scrolled down — unlike the Scripture editor's fixed
-          banner. Keeping them in one sticky container pins both together. */}
+      {/* Sticky header: the editing-paused notice (when blocking) and the filter toolbar share one
+          sticky container so both stay pinned to the top of whichever ancestor scrolls and neither
+          scrolls out of view as the comments list scrolls. */}
       <div className="tw:sticky tw:top-0 tw:z-10 tw:shrink-0">
         {/* Slim, non-covering notice shown while this project's automatic Send/Receive is blocking
             edits. Only the write affordances are disabled (by the web view's gated capability
@@ -275,7 +273,7 @@ export function CommentListPanel({
         {/* Filter toolbar — orthogonal filter dropdowns plus the scope dropdown. Rendered regardless
             of the loading state: it must stay mounted across filter changes (each of which briefly
             flips `isLoading` true while the query resubscribes), or the control the user is
-            interacting with would unmount from under them — the strobe PT-4070 exists to prevent. */}
+            interacting with would unmount from under them, causing a visible strobe. */}
         <div className="tw:border-b tw:bg-background tw:flex tw:flex-row tw:flex-wrap tw:gap-1 tw:items-center tw:pb-2 tw:px-4 tw:pt-4">
           <FilterDropdown
             value={filters.resolved}

--- a/extensions/src/legacy-comment-manager/src/comment-list.component.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.component.tsx
@@ -52,7 +52,14 @@ export const COMMENT_LIST_PANEL_EXTRA_STRING_KEYS = [
   '%comment_filter_type_conflicts%',
   '%no_comments%',
   '%no_comments_match_filter%',
+  '%webView_legacyCommentManager_syncEditBlocked_notice%',
 ] as const;
+
+/**
+ * Slim "editing paused during Send/Receive" notice text shown while this project's sync blocks
+ * edits.
+ */
+const SYNC_BLOCKED_NOTICE_KEY = '%webView_legacyCommentManager_syncEditBlocked_notice%';
 
 // Reuse the underlying CommentList prop types so this panel stays in sync with platform-bible-react.
 type CommentListProps = ComponentProps<typeof CommentList>;
@@ -94,6 +101,12 @@ export type CommentListPanelProps = Pick<
    * "current chapter" scope option is hidden. Defaults to `true`.
    */
   canScopeToCurrentChapter?: boolean;
+  /**
+   * Whether this project's automatic Send/Receive is currently blocking edits. When true, a slim
+   * "editing paused" notice is shown above the list; the write affordances are disabled separately
+   * by the web view via the capability callbacks. Defaults to `false`.
+   */
+  isSyncBlocked?: boolean;
 };
 
 /**
@@ -173,6 +186,7 @@ export function CommentListPanel({
   scopeFilter,
   onScopeFilterChange,
   canScopeToCurrentChapter = true,
+  isSyncBlocked = false,
   handleAddCommentToThread,
   handleUpdateComment,
   handleDeleteComment,
@@ -241,6 +255,17 @@ export function CommentListPanel({
 
   return (
     <div className="tw:flex tw:flex-col tw:h-full">
+      {/* Slim, non-covering notice shown while this project's automatic Send/Receive is blocking
+          edits. Stays above the sticky toolbar so filtering/reading comments remains fully usable;
+          only the write affordances are disabled (by the web view's gated capability callbacks). */}
+      {isSyncBlocked && (
+        <div
+          role="status"
+          className="tw:shrink-0 tw:border-b tw:border-border tw:bg-muted tw:px-4 tw:py-1.5 tw:text-sm tw:font-medium"
+        >
+          {localizedStrings[SYNC_BLOCKED_NOTICE_KEY]}
+        </div>
+      )}
       {/* Filter toolbar — orthogonal filter dropdowns plus the scope dropdown. Sticky so it stays
           pinned to the top of whichever ancestor scrolls (PT-4070). Rendered regardless of the
           loading state: it must stay mounted across filter changes (each of which briefly flips

--- a/extensions/src/legacy-comment-manager/src/comment-list.component.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.component.tsx
@@ -255,65 +255,71 @@ export function CommentListPanel({
 
   return (
     <div className="tw:flex tw:flex-col tw:h-full">
-      {/* Slim, non-covering notice shown while this project's automatic Send/Receive is blocking
-          edits. Stays above the sticky toolbar so filtering/reading comments remains fully usable;
-          only the write affordances are disabled (by the web view's gated capability callbacks). */}
-      {isSyncBlocked && (
-        <div
-          role="status"
-          className="tw:shrink-0 tw:border-b tw:border-border tw:bg-muted tw:px-4 tw:py-1.5 tw:text-sm tw:font-medium"
-        >
-          {localizedStrings[SYNC_BLOCKED_NOTICE_KEY]}
+      {/* Sticky header: the editing-paused notice (when blocking) and the filter toolbar both stay
+          pinned to the top of whichever ancestor scrolls (PT-4070), so neither scrolls out of view
+          as the comments list scrolls. Previously only the toolbar was sticky, so the notice
+          scrolled away once the list was scrolled down — unlike the Scripture editor's fixed
+          banner. Keeping them in one sticky container pins both together. */}
+      <div className="tw:sticky tw:top-0 tw:z-10 tw:shrink-0">
+        {/* Slim, non-covering notice shown while this project's automatic Send/Receive is blocking
+            edits. Only the write affordances are disabled (by the web view's gated capability
+            callbacks); filtering/reading comments stays fully usable. */}
+        {isSyncBlocked && (
+          <div
+            role="status"
+            className="tw:border-b tw:border-border tw:bg-muted tw:px-4 tw:py-1.5 tw:text-sm tw:font-medium"
+          >
+            {localizedStrings[SYNC_BLOCKED_NOTICE_KEY]}
+          </div>
+        )}
+        {/* Filter toolbar — orthogonal filter dropdowns plus the scope dropdown. Rendered regardless
+            of the loading state: it must stay mounted across filter changes (each of which briefly
+            flips `isLoading` true while the query resubscribes), or the control the user is
+            interacting with would unmount from under them — the strobe PT-4070 exists to prevent. */}
+        <div className="tw:border-b tw:bg-background tw:flex tw:flex-row tw:flex-wrap tw:gap-1 tw:items-center tw:pb-2 tw:px-4 tw:pt-4">
+          <FilterDropdown
+            value={filters.resolved}
+            labelKeys={resolvedFilterToLabelKey}
+            isValue={isResolvedFilter}
+            onChange={(resolved) => onFiltersChange({ ...filters, resolved })}
+            localizedStrings={localizedStrings}
+            ariaLabel={localizedStrings['%comment_filter_aria_resolved%']}
+          />
+          <FilterDropdown
+            value={filters.read}
+            labelKeys={readFilterToLabelKey}
+            isValue={isReadFilter}
+            onChange={(read) => onFiltersChange({ ...filters, read })}
+            localizedStrings={localizedStrings}
+            ariaLabel={localizedStrings['%comment_filter_aria_read%']}
+          />
+          <FilterDropdown
+            value={filters.type}
+            labelKeys={typeFilterToLabelKey}
+            isValue={isTypeFilter}
+            onChange={(type) => onFiltersChange({ ...filters, type })}
+            localizedStrings={localizedStrings}
+            ariaLabel={localizedStrings['%comment_filter_aria_type%']}
+          />
+          <FilterDropdown
+            value={filters.assignment}
+            labelKeys={assignmentFilterToLabelKey}
+            isValue={isAssignmentFilter}
+            onChange={(assignment) => onFiltersChange({ ...filters, assignment })}
+            localizedStrings={localizedStrings}
+            ariaLabel={localizedStrings['%comment_filter_aria_assignment%']}
+          />
+          <FilterDropdown
+            value={scopeFilter}
+            labelKeys={scopeFilterToLabelKey}
+            isValue={isScopeFilter}
+            onChange={onScopeFilterChange}
+            localizedStrings={localizedStrings}
+            ariaLabel={localizedStrings['%comment_filter_aria_scope%']}
+            hiddenValues={canScopeToCurrentChapter ? undefined : [SCOPE_FILTER_CURRENT_CHAPTER]}
+            testId="comment-scope-filter"
+          />
         </div>
-      )}
-      {/* Filter toolbar — orthogonal filter dropdowns plus the scope dropdown. Sticky so it stays
-          pinned to the top of whichever ancestor scrolls (PT-4070). Rendered regardless of the
-          loading state: it must stay mounted across filter changes (each of which briefly flips
-          `isLoading` true while the query resubscribes), or the control the user is interacting with
-          would unmount from under them — the exact strobe PT-4070 exists to prevent. */}
-      <div className="tw:sticky tw:top-0 tw:z-10 tw:shrink-0 tw:border-b tw:bg-background tw:flex tw:flex-row tw:flex-wrap tw:gap-1 tw:items-center tw:pb-2 tw:px-4 tw:pt-4">
-        <FilterDropdown
-          value={filters.resolved}
-          labelKeys={resolvedFilterToLabelKey}
-          isValue={isResolvedFilter}
-          onChange={(resolved) => onFiltersChange({ ...filters, resolved })}
-          localizedStrings={localizedStrings}
-          ariaLabel={localizedStrings['%comment_filter_aria_resolved%']}
-        />
-        <FilterDropdown
-          value={filters.read}
-          labelKeys={readFilterToLabelKey}
-          isValue={isReadFilter}
-          onChange={(read) => onFiltersChange({ ...filters, read })}
-          localizedStrings={localizedStrings}
-          ariaLabel={localizedStrings['%comment_filter_aria_read%']}
-        />
-        <FilterDropdown
-          value={filters.type}
-          labelKeys={typeFilterToLabelKey}
-          isValue={isTypeFilter}
-          onChange={(type) => onFiltersChange({ ...filters, type })}
-          localizedStrings={localizedStrings}
-          ariaLabel={localizedStrings['%comment_filter_aria_type%']}
-        />
-        <FilterDropdown
-          value={filters.assignment}
-          labelKeys={assignmentFilterToLabelKey}
-          isValue={isAssignmentFilter}
-          onChange={(assignment) => onFiltersChange({ ...filters, assignment })}
-          localizedStrings={localizedStrings}
-          ariaLabel={localizedStrings['%comment_filter_aria_assignment%']}
-        />
-        <FilterDropdown
-          value={scopeFilter}
-          labelKeys={scopeFilterToLabelKey}
-          isValue={isScopeFilter}
-          onChange={onScopeFilterChange}
-          localizedStrings={localizedStrings}
-          ariaLabel={localizedStrings['%comment_filter_aria_scope%']}
-          hiddenValues={canScopeToCurrentChapter ? undefined : [SCOPE_FILTER_CURRENT_CHAPTER]}
-          testId="comment-scope-filter"
-        />
       </div>
 
       {/* Comments list (or skeletons while loading / empty state). Only this region swaps on load,

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -81,7 +81,7 @@ global.webViewComponent = function CommentListWebView({
   );
   const [scrRef, setScrRef] = useWebViewScrollGroupScrRef();
   const [editorWebViewId] = useWebViewState<string | undefined>('editorWebViewId', undefined);
-  // Set on this web view's state by the core auto-sync edit-block driver (PT-4214 Stage U) while an
+  // Set on this web view's state by the core auto-sync edit-block driver while an
   // automatic (scheduled or session) Send/Receive is syncing this project. When true, comment
   // writing is paused: the write affordances below are disabled and a slim notice is shown. Transient
   // runtime state — the provider scrubs it to false on every rehydrate, and the driver re-flags it if
@@ -538,7 +538,7 @@ global.webViewComponent = function CommentListWebView({
     [setScrRef, editorWebViewId, editorWebViewController, recordSelfInitiatedNavigation],
   );
 
-  // PT-4214 Stage U: while this project's automatic Send/Receive is blocking edits (isSyncBlocked),
+  // While this project's automatic Send/Receive is blocking edits (isSyncBlocked),
   // disable every comment write affordance by forcing its capability gate to `false`.
   // platform-bible-react's CommentList exposes no `disabled`/`readOnly` prop; these per-capability
   // callbacks ARE its existing mechanism for hiding/disabling the reply box, assign, edit/delete, and

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -36,6 +36,7 @@ import {
 import type { CommentListScrollTarget } from './comment-list-scroll.utils';
 import { useBcvSyncScroll } from './use-bcv-sync-scroll.hook';
 import { COMMENT_LIST_PANEL_WEB_VIEW_TYPE } from './comment-list-panel.utils';
+import { isSyncEditBlockedError, notifySyncEditBlocked } from './sync-edit-blocked.util';
 
 const DEFAULT_LEGACY_COMMENT_THREADS: LegacyCommentThread[] = [];
 
@@ -79,6 +80,12 @@ global.webViewComponent = function CommentListWebView({
   );
   const [scrRef, setScrRef] = useWebViewScrollGroupScrRef();
   const [editorWebViewId] = useWebViewState<string | undefined>('editorWebViewId', undefined);
+  // Set on this web view's state by the core auto-sync edit-block driver (PT-4214 Stage U) while an
+  // automatic (scheduled or session) Send/Receive is syncing this project. When true, comment
+  // writing is paused: the write affordances below are disabled and a slim notice is shown. Transient
+  // runtime state — the provider scrubs it to false on every rehydrate, and the driver re-flags it if
+  // a sync is still in flight.
+  const [isSyncBlocked] = useWebViewState<boolean>('isSyncBlocked', false);
   // The Column 3 comment-list panel follows the active project's scroll group, so it always has a
   // current chapter even though no editor is wired to it. Both comment-list web view types share
   // this component, so its own `webViewType` prop distinguishes the panel — no extra state channel
@@ -410,7 +417,11 @@ global.webViewComponent = function CommentListWebView({
           });
           return newCommentId;
         } catch (error) {
-          logger.error(`Failed to add comment to thread ${options.threadId}:`, error);
+          // A write-gate rejection (an automatic Send/Receive is syncing this project) is an
+          // expected paused state, not an error: show the shared "editing paused" notice instead of
+          // logging + surfacing a raw failure. Defense-in-depth behind the disabled reply affordance.
+          if (isSyncEditBlockedError(error)) notifySyncEditBlocked();
+          else logger.error(`Failed to add comment to thread ${options.threadId}:`, error);
           return undefined;
         }
       }),
@@ -424,10 +435,18 @@ global.webViewComponent = function CommentListWebView({
           await pdp.resolveConflict(threadId, resolution);
           return true;
         } catch (error) {
-          logger.error(`Failed to resolve conflict thread ${threadId}:`, error);
-          sonner.error(
-            localizedStrings['%conflict_note_resolve_failed%'] ?? 'Could not resolve the conflict.',
-          );
+          // A write-gate rejection (an automatic Send/Receive is syncing this project) gets the
+          // shared "editing paused" notice rather than the generic resolve-failed toast. Defense-in-
+          // depth behind the disabled resolve affordance.
+          if (isSyncEditBlockedError(error)) {
+            notifySyncEditBlocked();
+          } else {
+            logger.error(`Failed to resolve conflict thread ${threadId}:`, error);
+            sonner.error(
+              localizedStrings['%conflict_note_resolve_failed%'] ??
+                'Could not resolve the conflict.',
+            );
+          }
           return false;
         }
       }),
@@ -452,7 +471,11 @@ global.webViewComponent = function CommentListWebView({
             logger.warn(`Update of comment ${commentId} was rejected and not saved.`);
           return updateSucceeded;
         } catch (error) {
-          logger.error(`Failed to update comment ${commentId}:`, error);
+          // A write-gate rejection (an automatic Send/Receive is syncing this project) is an
+          // expected paused state: show the shared "editing paused" notice. Defense-in-depth behind
+          // the disabled edit affordance.
+          if (isSyncEditBlockedError(error)) notifySyncEditBlocked();
+          else logger.error(`Failed to update comment ${commentId}:`, error);
           return false;
         }
       }),
@@ -466,7 +489,11 @@ global.webViewComponent = function CommentListWebView({
           await pdp.deleteComment(commentId);
           return true;
         } catch (error) {
-          logger.error(`Failed to delete comment ${commentId}:`, error);
+          // A write-gate rejection (an automatic Send/Receive is syncing this project) is an
+          // expected paused state: show the shared "editing paused" notice. Defense-in-depth behind
+          // the disabled delete affordance.
+          if (isSyncEditBlockedError(error)) notifySyncEditBlocked();
+          else logger.error(`Failed to delete comment ${commentId}:`, error);
           return false;
         }
       }),
@@ -510,6 +537,29 @@ global.webViewComponent = function CommentListWebView({
     [setScrRef, editorWebViewId, editorWebViewController, recordSelfInitiatedNavigation],
   );
 
+  // PT-4214 Stage U: while this project's automatic Send/Receive is blocking edits (isSyncBlocked),
+  // disable every comment write affordance by forcing its capability gate to `false`.
+  // platform-bible-react's CommentList exposes no `disabled`/`readOnly` prop; these per-capability
+  // callbacks ARE its existing mechanism for hiding/disabling the reply box, assign, edit/delete, and
+  // conflict-resolve, so gating them here is the real disable path (not a cosmetic no-op). The write
+  // handlers above additionally catch the backend write-gate rejection as defense-in-depth.
+  const gatedCanUserAddCommentToThread = isSyncBlocked ? false : canUserAddCommentToThread;
+  const gatedCanUserAssignThreadCallback = useCallback(
+    async (threadId: string): Promise<boolean> =>
+      isSyncBlocked ? false : canUserAssignThreadCallback(threadId),
+    [isSyncBlocked, canUserAssignThreadCallback],
+  );
+  const gatedCanUserResolveThreadCallback = useCallback(
+    async (threadId: string): Promise<boolean> =>
+      isSyncBlocked ? false : canUserResolveThreadCallback(threadId),
+    [isSyncBlocked, canUserResolveThreadCallback],
+  );
+  const gatedCanUserEditOrDeleteCommentCallback = useCallback(
+    async (commentId: string): Promise<boolean> =>
+      isSyncBlocked ? false : canUserEditOrDeleteCommentCallback(commentId),
+    [isSyncBlocked, canUserEditOrDeleteCommentCallback],
+  );
+
   return (
     <>
       <CommentListPanel
@@ -526,15 +576,18 @@ global.webViewComponent = function CommentListWebView({
         // When false (a cross-project open with no live reference), the "current chapter" option
         // stays hidden rather than scoping to an unrelated ref.
         canScopeToCurrentChapter={canScopeToCurrentChapter}
+        // While an automatic Send/Receive is syncing this project, show a slim "editing paused"
+        // notice and disable the write affordances (via the gated capability callbacks below).
+        isSyncBlocked={isSyncBlocked}
         handleAddCommentToThread={handleAddCommentToThread}
         handleUpdateComment={handleUpdateComment}
         handleDeleteComment={handleDeleteComment}
         handleReadStatusChange={handleReadStatusChange}
         assignableUsers={assignableUsers}
-        canUserAddCommentToThread={canUserAddCommentToThread}
-        canUserAssignThreadCallback={canUserAssignThreadCallback}
-        canUserResolveThreadCallback={canUserResolveThreadCallback}
-        canUserEditOrDeleteCommentCallback={canUserEditOrDeleteCommentCallback}
+        canUserAddCommentToThread={gatedCanUserAddCommentToThread}
+        canUserAssignThreadCallback={gatedCanUserAssignThreadCallback}
+        canUserResolveThreadCallback={gatedCanUserResolveThreadCallback}
+        canUserEditOrDeleteCommentCallback={gatedCanUserEditOrDeleteCommentCallback}
         selectedThreadId={selectedThreadId}
         onSelectedThreadChange={setSelectedThreadId}
         onVerseRefClick={handleVerseRefClick}

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -37,6 +37,7 @@ import type { CommentListScrollTarget } from './comment-list-scroll.utils';
 import { useBcvSyncScroll } from './use-bcv-sync-scroll.hook';
 import { COMMENT_LIST_PANEL_WEB_VIEW_TYPE } from './comment-list-panel.utils';
 import { isSyncEditBlockedError, notifySyncEditBlocked } from './sync-edit-blocked.util';
+import { gateCommentWriteCapabilities } from './comment-list-capability-gating.util';
 
 const DEFAULT_LEGACY_COMMENT_THREADS: LegacyCommentThread[] = [];
 
@@ -542,22 +543,26 @@ global.webViewComponent = function CommentListWebView({
   // platform-bible-react's CommentList exposes no `disabled`/`readOnly` prop; these per-capability
   // callbacks ARE its existing mechanism for hiding/disabling the reply box, assign, edit/delete, and
   // conflict-resolve, so gating them here is the real disable path (not a cosmetic no-op). The write
-  // handlers above additionally catch the backend write-gate rejection as defense-in-depth.
-  const gatedCanUserAddCommentToThread = isSyncBlocked ? false : canUserAddCommentToThread;
-  const gatedCanUserAssignThreadCallback = useCallback(
-    async (threadId: string): Promise<boolean> =>
-      isSyncBlocked ? false : canUserAssignThreadCallback(threadId),
-    [isSyncBlocked, canUserAssignThreadCallback],
-  );
-  const gatedCanUserResolveThreadCallback = useCallback(
-    async (threadId: string): Promise<boolean> =>
-      isSyncBlocked ? false : canUserResolveThreadCallback(threadId),
-    [isSyncBlocked, canUserResolveThreadCallback],
-  );
-  const gatedCanUserEditOrDeleteCommentCallback = useCallback(
-    async (commentId: string): Promise<boolean> =>
-      isSyncBlocked ? false : canUserEditOrDeleteCommentCallback(commentId),
-    [isSyncBlocked, canUserEditOrDeleteCommentCallback],
+  // handlers above additionally catch the backend write-gate rejection as defense-in-depth. The
+  // deny-while-blocked / pass-through-when-not decision itself lives in
+  // gateCommentWriteCapabilities (unit tested in comment-list-capability-gating.util.test.ts); this
+  // component only memoizes the result so unrelated re-renders don't churn the props CommentList
+  // sees.
+  const gatedCapabilities = useMemo(
+    () =>
+      gateCommentWriteCapabilities(isSyncBlocked, {
+        canUserAddCommentToThread,
+        canUserAssignThreadCallback,
+        canUserResolveThreadCallback,
+        canUserEditOrDeleteCommentCallback,
+      }),
+    [
+      isSyncBlocked,
+      canUserAddCommentToThread,
+      canUserAssignThreadCallback,
+      canUserResolveThreadCallback,
+      canUserEditOrDeleteCommentCallback,
+    ],
   );
 
   return (
@@ -584,10 +589,10 @@ global.webViewComponent = function CommentListWebView({
         handleDeleteComment={handleDeleteComment}
         handleReadStatusChange={handleReadStatusChange}
         assignableUsers={assignableUsers}
-        canUserAddCommentToThread={gatedCanUserAddCommentToThread}
-        canUserAssignThreadCallback={gatedCanUserAssignThreadCallback}
-        canUserResolveThreadCallback={gatedCanUserResolveThreadCallback}
-        canUserEditOrDeleteCommentCallback={gatedCanUserEditOrDeleteCommentCallback}
+        canUserAddCommentToThread={gatedCapabilities.canUserAddCommentToThread}
+        canUserAssignThreadCallback={gatedCapabilities.canUserAssignThreadCallback}
+        canUserResolveThreadCallback={gatedCapabilities.canUserResolveThreadCallback}
+        canUserEditOrDeleteCommentCallback={gatedCapabilities.canUserEditOrDeleteCommentCallback}
         selectedThreadId={selectedThreadId}
         onSelectedThreadChange={setSelectedThreadId}
         onVerseRefClick={handleVerseRefClick}

--- a/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
+++ b/extensions/src/legacy-comment-manager/src/comment-list.web-view.tsx
@@ -542,8 +542,13 @@ global.webViewComponent = function CommentListWebView({
   // disable every comment write affordance by forcing its capability gate to `false`.
   // platform-bible-react's CommentList exposes no `disabled`/`readOnly` prop; these per-capability
   // callbacks ARE its existing mechanism for hiding/disabling the reply box, assign, edit/delete, and
-  // conflict-resolve, so gating them here is the real disable path (not a cosmetic no-op). The write
-  // handlers above additionally catch the backend write-gate rejection as defense-in-depth. The
+  // thread-resolve, so gating them here is the real disable path (not a cosmetic no-op). NOTE: the
+  // verse-text conflict-resolution card (the `conflictResolution` prop / `useConflictResolution`,
+  // whose Accept/Reject/Merge controls derive from an ungated `getOptions` read, not
+  // `canUserResolveThreadCallback`) is NOT gated by these callbacks — during a block those controls
+  // stay live and rely on the backend `(SR_EDIT_BLOCKED)` rejection surfaced as the shared "editing
+  // paused" notice (click-then-paused, no data harm). The write handlers above additionally catch
+  // that rejection as defense-in-depth. The
   // deny-while-blocked / pass-through-when-not decision itself lives in
   // gateCommentWriteCapabilities (unit tested in comment-list-capability-gating.util.test.ts); this
   // component only memoizes the result so unrelated re-renders don't churn the props CommentList

--- a/extensions/src/legacy-comment-manager/src/localized-strings.test.ts
+++ b/extensions/src/legacy-comment-manager/src/localized-strings.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, it } from 'vitest';
 const PANEL_TITLE_KEY = '%webView_legacyCommentManager_commentListPanel_title%';
 const COMMENTARIES_TAB_TITLE_KEY = '%webView_resourcePanel_commentaries_title%';
 
-// The strings backing the Send/Receive edit-block surfaces in the comments panel (PT-4214): the slim
+// The strings backing the Send/Receive edit-block surfaces in the comments panel: the slim
 // "editing paused" notice and the "your change was not saved" error toast. Both must stay defined in
 // every shipped language so a future edit that drops one language fails here.
 const SYNC_BLOCKED_KEYS = [

--- a/extensions/src/legacy-comment-manager/src/localized-strings.test.ts
+++ b/extensions/src/legacy-comment-manager/src/localized-strings.test.ts
@@ -5,6 +5,14 @@ import { describe, expect, it } from 'vitest';
 const PANEL_TITLE_KEY = '%webView_legacyCommentManager_commentListPanel_title%';
 const COMMENTARIES_TAB_TITLE_KEY = '%webView_resourcePanel_commentaries_title%';
 
+// The strings backing the Send/Receive edit-block surfaces in the comments panel (PT-4214): the slim
+// "editing paused" notice and the "your change was not saved" error toast. Both must stay defined in
+// every shipped language so a future edit that drops one language fails here.
+const SYNC_BLOCKED_KEYS = [
+  '%webView_legacyCommentManager_syncEditBlocked_notice%',
+  '%webView_legacyCommentManager_error_syncEditBlocked%',
+];
+
 type LocalizedStringsFile = {
   localizedStrings: Record<string, Record<string, string>>;
 };
@@ -54,5 +62,20 @@ describe('legacyCommentManager comment list panel tab title', () => {
     const es = localizedStrings.es[PANEL_TITLE_KEY];
     expect(es.charAt(0)).toMatch(/[A-ZÁÉÍÓÚÜÑ]/);
     expect(es.slice(1)).toBe(es.slice(1).toLowerCase());
+  });
+});
+
+describe('legacyCommentManager sync-blocked strings', () => {
+  // Enforce en/es parity for the two Send/Receive edit-block strings: both languages must define
+  // both keys, so dropping (or renaming) one in a single language fails here rather than silently
+  // shipping a missing or untranslated string.
+  SYNC_BLOCKED_KEYS.forEach((key) => {
+    it(`has an English label for ${key}`, () => {
+      expect(localizedStrings.en[key]).toBeTruthy();
+    });
+
+    it(`has a Spanish label for ${key}`, () => {
+      expect(localizedStrings.es[key]).toBeTruthy();
+    });
   });
 });

--- a/extensions/src/legacy-comment-manager/src/main.ts
+++ b/extensions/src/legacy-comment-manager/src/main.ts
@@ -106,6 +106,12 @@ class CommentListWebViewFactory extends WebViewFactory<typeof commentListWebView
       scrollGroupScrRef: getWebViewOptions.editorScrollGroupId,
       state: {
         ...savedWebView.state,
+        // Always rebuild un-blocked. `isSyncBlocked` is transient runtime state owned by the core
+        // auto-sync edit-block driver; forcing it false here means a crash/reload mid-sync can never
+        // restore a read-only comment view from the saved layout (mirrors the scripture editor's
+        // scrub in platform-scripture-editor main.ts). The driver re-flags it if a sync is still in
+        // flight.
+        isSyncBlocked: false,
         editorWebViewId: getWebViewOptions.editorWebViewId ?? savedWebView.state?.editorWebViewId,
         // Seeded only when opening a new view (undefined otherwise, which clears any persisted
         // value). Deliberately NOT persisted across restarts: a restored view has these undefined

--- a/extensions/src/legacy-comment-manager/src/sync-edit-blocked.util.ts
+++ b/extensions/src/legacy-comment-manager/src/sync-edit-blocked.util.ts
@@ -1,0 +1,53 @@
+import papi, { logger } from '@papi/frontend';
+import { getErrorMessage } from 'platform-bible-utils';
+
+/**
+ * Sentinel that paranext-core's C# write-gate (`SendReceiveWriteLock`) appends to the message of
+ * any project write it rejects because an automatic Send/Receive is syncing that project. Comment
+ * mutations (add/reply, edit, delete, resolve-conflict) that reach `ParatextData` while a sync
+ * holds the gate reject with a message ending in this sentinel.
+ *
+ * Duplicated per extension — mirrors `platform-scripture/src/sync-edit-blocked.util.ts` (and the
+ * scripture editor's own `SYNC_EDIT_BLOCKED_REGEX`) — so each extension's handling stays
+ * self-contained with no cross-extension imports (see AGENTS.md: extensions are not patched
+ * together).
+ */
+export const SYNC_EDIT_BLOCKED_REGEX = /\(SR_EDIT_BLOCKED\)/;
+
+/**
+ * Localization key for the shared "editing is paused during Send/Receive" warning shown when one of
+ * this extension's comment mutations is rejected by the write-gate. Contributed in this extension's
+ * `contributions/localizedStrings.json`.
+ */
+export const SYNC_EDIT_BLOCKED_MESSAGE_KEY = '%webView_legacyCommentManager_error_syncEditBlocked%';
+
+/**
+ * Whether `error` was thrown by the write-gate because an automatic Send/Receive is in progress
+ * (its message carries {@link SYNC_EDIT_BLOCKED_REGEX}). Lets each mutating handler show the shared
+ * "editing paused" notification instead of surfacing a raw technical error or leaking an unhandled
+ * promise rejection.
+ *
+ * @param error Error, thrown value, or message string to inspect.
+ * @returns `true` if the error is a Send/Receive write-gate rejection, `false` otherwise.
+ */
+export function isSyncEditBlockedError(error: unknown): boolean {
+  return SYNC_EDIT_BLOCKED_REGEX.test(getErrorMessage(error));
+}
+
+/**
+ * Shows the shared "editing is paused during Send/Receive" warning notification (the write-gate
+ * rejection detected by {@link isSyncEditBlockedError} surfaced to the user). Extracted so the
+ * severity/message cannot drift across the several call sites that report it, and self-catching so
+ * fire-and-forget callers never surface an unhandled promise rejection from the notification
+ * service. The legacy-comment-manager twin of `platform-scripture`'s `notifySyncEditBlocked`.
+ */
+export async function notifySyncEditBlocked(): Promise<void> {
+  try {
+    await papi.notifications.send({
+      message: SYNC_EDIT_BLOCKED_MESSAGE_KEY,
+      severity: 'warning',
+    });
+  } catch (e) {
+    logger.warn(`Failed to send the sync-edit-blocked notification: ${getErrorMessage(e)}`);
+  }
+}

--- a/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.scss
+++ b/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.scss
@@ -9,15 +9,3 @@
 .card-content {
   margin-bottom: 1rem;
 }
-
-/* Slim "editing paused during Send/Receive" notice shown above a project settings list while that
-   project's automatic sync is blocking edits. Non-covering; the editors below are disabled. */
-.sync-blocked-notice {
-  margin-bottom: 1rem;
-  padding: 0.375rem 0.75rem;
-  border: 1px solid hsl(var(--border));
-  border-radius: var(--radius);
-  background-color: hsl(var(--muted));
-  color: hsl(var(--muted-foreground));
-  font-size: 0.875rem;
-}

--- a/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.scss
+++ b/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.scss
@@ -9,3 +9,15 @@
 .card-content {
   margin-bottom: 1rem;
 }
+
+/* Slim "editing paused during Send/Receive" notice shown above a project settings list while that
+   project's automatic sync is blocking edits. Non-covering; the editors below are disabled. */
+.sync-blocked-notice {
+  margin-bottom: 1rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background-color: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-size: 0.875rem;
+}

--- a/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.test.tsx
@@ -8,7 +8,7 @@ import { ProjectOrOtherSettingsList } from './project-or-other-settings-list.com
 // parent SettingsTab computes it once from the auto-sync-blocking store and passes it down, and also
 // renders the single sync-blocked NOTICE above all of a project's groups (see
 // settings-tab.component.test.tsx). A project can have several of these lists (one per settings
-// group), so a per-list store subscription would stack listeners and duplicate the banner (PT-4214).
+// group), so a per-list store subscription would stack listeners and duplicate the banner.
 // This unit just forwards `disabled` to each project setting; the leaf forwarding into
 // platform-bible-react's Input/Switch is covered in setting.component.test.tsx.
 vi.mock('./project-setting.component', () => ({

--- a/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.test.tsx
@@ -73,7 +73,7 @@ describe('ProjectOrOtherSettingsList sync-block disabled wiring', () => {
     expect(screen.getByTestId('other-setting')).toBeInTheDocument();
   });
 
-  it('never renders a notice itself, regardless of disabled (moved to the settings-tab level)', () => {
+  it('never renders a notice itself, regardless of disabled (the notice lives at the settings-tab level)', () => {
     render(
       <ProjectOrOtherSettingsList
         settingProperties={PROJECT_SETTING_PROPERTIES}

--- a/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.test.tsx
@@ -9,17 +9,13 @@ vi.mock('@renderer/hooks/use-is-project-auto-sync-blocked.hook', () => ({
   useIsProjectAutoSyncBlocked: vi.fn(),
 }));
 
-// Return the notice text for its key; other keys pass through as their own key string.
-vi.mock('@renderer/hooks/papi-hooks', () => ({
-  useLocalizedStrings: vi.fn(() => [
-    { '%settings_projectSyncBlocked_notice%': 'Editing paused for Send/Receive' },
-  ]),
-}));
-
 // Stub the leaf setting components to capture the `disabled` prop the list drives, without dragging
 // in useProjectSetting / useData / localizationService. The list is the unit under test: it consumes
-// the hook, renders one notice, and disables each setting editor. The leaf forwarding of `disabled`
-// into platform-bible-react's Input/Switch is a direct, type-checked prop pass (see setting.component).
+// the hook and disables each setting editor. The sync-blocked NOTICE itself moved up to render once
+// at the settings-tab level (SettingsTab, see settings-tab.component.test.tsx) — a project can have
+// several of these lists (one per settings group), which used to each stack an identical banner
+// (PT-4214). The leaf forwarding of `disabled` into platform-bible-react's Input/Switch is a direct,
+// type-checked prop pass (see setting.component.test.tsx).
 vi.mock('./project-setting.component', () => ({
   ProjectSetting: ({ label, disabled }: { label: string; disabled?: boolean }) => (
     <div data-testid="project-setting" data-disabled={String(Boolean(disabled))}>
@@ -40,13 +36,13 @@ const PROJECT_SETTING_PROPERTIES = {
   },
 };
 
-describe('ProjectOrOtherSettingsList sync-block reflection', () => {
+describe('ProjectOrOtherSettingsList sync-block disabled wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);
   });
 
-  it('shows the notice and disables the setting editors when the project is sync-blocked', () => {
+  it('disables the setting editors when the project is sync-blocked', () => {
     vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(true);
     render(
       <ProjectOrOtherSettingsList
@@ -57,11 +53,10 @@ describe('ProjectOrOtherSettingsList sync-block reflection', () => {
     );
 
     expect(useIsProjectAutoSyncBlocked).toHaveBeenCalledWith('projA');
-    expect(screen.getByText('Editing paused for Send/Receive')).toBeInTheDocument();
     expect(screen.getByTestId('project-setting')).toHaveAttribute('data-disabled', 'true');
   });
 
-  it('hides the notice and leaves the setting editors enabled when the project is not blocked', () => {
+  it('leaves the setting editors enabled when the project is not blocked', () => {
     vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);
     render(
       <ProjectOrOtherSettingsList
@@ -71,11 +66,10 @@ describe('ProjectOrOtherSettingsList sync-block reflection', () => {
       />,
     );
 
-    expect(screen.queryByText('Editing paused for Send/Receive')).not.toBeInTheDocument();
     expect(screen.getByTestId('project-setting')).toHaveAttribute('data-disabled', 'false');
   });
 
-  it('never shows the notice for a user/general settings list (no projectId)', () => {
+  it('never renders a project-only notice or disables editors for a user/general settings list (no projectId)', () => {
     // The hook treats an undefined project id as never blocked; asserted here at the list level.
     vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);
     render(
@@ -86,7 +80,20 @@ describe('ProjectOrOtherSettingsList sync-block reflection', () => {
     );
 
     expect(useIsProjectAutoSyncBlocked).toHaveBeenCalledWith(undefined);
-    expect(screen.queryByText('Editing paused for Send/Receive')).not.toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
     expect(screen.getByTestId('other-setting')).toBeInTheDocument();
+  });
+
+  it('never renders a notice itself, regardless of block state (moved to the settings-tab level)', () => {
+    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(true);
+    render(
+      <ProjectOrOtherSettingsList
+        settingProperties={PROJECT_SETTING_PROPERTIES}
+        projectId="projA"
+        groupLabel="Group"
+      />,
+    );
+
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.test.tsx
@@ -1,21 +1,16 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { useIsProjectAutoSyncBlocked } from '@renderer/hooks/use-is-project-auto-sync-blocked.hook';
 import { ProjectOrOtherSettingsList } from './project-or-other-settings-list.component';
 
-// The hook under wiring test — controlled per test to simulate a blocked / unblocked project.
-vi.mock('@renderer/hooks/use-is-project-auto-sync-blocked.hook', () => ({
-  useIsProjectAutoSyncBlocked: vi.fn(),
-}));
-
-// Stub the leaf setting components to capture the `disabled` prop the list drives, without dragging
-// in useProjectSetting / useData / localizationService. The list is the unit under test: it consumes
-// the hook and disables each setting editor. The sync-blocked NOTICE itself moved up to render once
-// at the settings-tab level (SettingsTab, see settings-tab.component.test.tsx) — a project can have
-// several of these lists (one per settings group), which used to each stack an identical banner
-// (PT-4214). The leaf forwarding of `disabled` into platform-bible-react's Input/Switch is a direct,
-// type-checked prop pass (see setting.component.test.tsx).
+// Stub the leaf setting components to capture the `disabled` prop the list forwards, without dragging
+// in useProjectSetting / useData / localizationService. The list takes `disabled` as a PROP: the
+// parent SettingsTab computes it once from the auto-sync-blocking store and passes it down, and also
+// renders the single sync-blocked NOTICE above all of a project's groups (see
+// settings-tab.component.test.tsx). A project can have several of these lists (one per settings
+// group), so a per-list store subscription would stack listeners and duplicate the banner (PT-4214).
+// This unit just forwards `disabled` to each project setting; the leaf forwarding into
+// platform-bible-react's Input/Switch is covered in setting.component.test.tsx.
 vi.mock('./project-setting.component', () => ({
   ProjectSetting: ({ label, disabled }: { label: string; disabled?: boolean }) => (
     <div data-testid="project-setting" data-disabled={String(Boolean(disabled))}>
@@ -39,25 +34,22 @@ const PROJECT_SETTING_PROPERTIES = {
 describe('ProjectOrOtherSettingsList sync-block disabled wiring', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);
   });
 
-  it('disables the setting editors when the project is sync-blocked', () => {
-    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(true);
+  it('forwards disabled to the project setting editors when disabled is passed', () => {
     render(
       <ProjectOrOtherSettingsList
         settingProperties={PROJECT_SETTING_PROPERTIES}
         projectId="projA"
         groupLabel="Group"
+        disabled
       />,
     );
 
-    expect(useIsProjectAutoSyncBlocked).toHaveBeenCalledWith('projA');
     expect(screen.getByTestId('project-setting')).toHaveAttribute('data-disabled', 'true');
   });
 
-  it('leaves the setting editors enabled when the project is not blocked', () => {
-    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);
+  it('leaves the setting editors enabled when disabled is not passed', () => {
     render(
       <ProjectOrOtherSettingsList
         settingProperties={PROJECT_SETTING_PROPERTIES}
@@ -69,9 +61,7 @@ describe('ProjectOrOtherSettingsList sync-block disabled wiring', () => {
     expect(screen.getByTestId('project-setting')).toHaveAttribute('data-disabled', 'false');
   });
 
-  it('never renders a project-only notice or disables editors for a user/general settings list (no projectId)', () => {
-    // The hook treats an undefined project id as never blocked; asserted here at the list level.
-    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);
+  it('renders a user/general settings list (no projectId) without a notice', () => {
     render(
       <ProjectOrOtherSettingsList
         settingProperties={PROJECT_SETTING_PROPERTIES}
@@ -79,18 +69,17 @@ describe('ProjectOrOtherSettingsList sync-block disabled wiring', () => {
       />,
     );
 
-    expect(useIsProjectAutoSyncBlocked).toHaveBeenCalledWith(undefined);
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
     expect(screen.getByTestId('other-setting')).toBeInTheDocument();
   });
 
-  it('never renders a notice itself, regardless of block state (moved to the settings-tab level)', () => {
-    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(true);
+  it('never renders a notice itself, regardless of disabled (moved to the settings-tab level)', () => {
     render(
       <ProjectOrOtherSettingsList
         settingProperties={PROJECT_SETTING_PROPERTIES}
         projectId="projA"
         groupLabel="Group"
+        disabled
       />,
     );
 

--- a/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useIsProjectAutoSyncBlocked } from '@renderer/hooks/use-is-project-auto-sync-blocked.hook';
+import { ProjectOrOtherSettingsList } from './project-or-other-settings-list.component';
+
+// The hook under wiring test — controlled per test to simulate a blocked / unblocked project.
+vi.mock('@renderer/hooks/use-is-project-auto-sync-blocked.hook', () => ({
+  useIsProjectAutoSyncBlocked: vi.fn(),
+}));
+
+// Return the notice text for its key; other keys pass through as their own key string.
+vi.mock('@renderer/hooks/papi-hooks', () => ({
+  useLocalizedStrings: vi.fn(() => [
+    { '%settings_projectSyncBlocked_notice%': 'Editing paused for Send/Receive' },
+  ]),
+}));
+
+// Stub the leaf setting components to capture the `disabled` prop the list drives, without dragging
+// in useProjectSetting / useData / localizationService. The list is the unit under test: it consumes
+// the hook, renders one notice, and disables each setting editor. The leaf forwarding of `disabled`
+// into platform-bible-react's Input/Switch is a direct, type-checked prop pass (see setting.component).
+vi.mock('./project-setting.component', () => ({
+  ProjectSetting: ({ label, disabled }: { label: string; disabled?: boolean }) => (
+    <div data-testid="project-setting" data-disabled={String(Boolean(disabled))}>
+      {label}
+    </div>
+  ),
+}));
+vi.mock('./other-setting.component', () => ({
+  OtherSetting: ({ label }: { label: string }) => <div data-testid="other-setting">{label}</div>,
+}));
+
+// Minimal Localized<ProjectSettingProperties>: one setting entry with a label the stub renders.
+const PROJECT_SETTING_PROPERTIES = {
+  'testExtension.aSetting': {
+    label: 'A Project Setting',
+    description: 'desc',
+    default: 'value',
+  },
+};
+
+describe('ProjectOrOtherSettingsList sync-block reflection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);
+  });
+
+  it('shows the notice and disables the setting editors when the project is sync-blocked', () => {
+    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(true);
+    render(
+      <ProjectOrOtherSettingsList
+        settingProperties={PROJECT_SETTING_PROPERTIES}
+        projectId="projA"
+        groupLabel="Group"
+      />,
+    );
+
+    expect(useIsProjectAutoSyncBlocked).toHaveBeenCalledWith('projA');
+    expect(screen.getByText('Editing paused for Send/Receive')).toBeInTheDocument();
+    expect(screen.getByTestId('project-setting')).toHaveAttribute('data-disabled', 'true');
+  });
+
+  it('hides the notice and leaves the setting editors enabled when the project is not blocked', () => {
+    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);
+    render(
+      <ProjectOrOtherSettingsList
+        settingProperties={PROJECT_SETTING_PROPERTIES}
+        projectId="projA"
+        groupLabel="Group"
+      />,
+    );
+
+    expect(screen.queryByText('Editing paused for Send/Receive')).not.toBeInTheDocument();
+    expect(screen.getByTestId('project-setting')).toHaveAttribute('data-disabled', 'false');
+  });
+
+  it('never shows the notice for a user/general settings list (no projectId)', () => {
+    // The hook treats an undefined project id as never blocked; asserted here at the list level.
+    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);
+    render(
+      <ProjectOrOtherSettingsList
+        settingProperties={PROJECT_SETTING_PROPERTIES}
+        groupLabel="Group"
+      />,
+    );
+
+    expect(useIsProjectAutoSyncBlocked).toHaveBeenCalledWith(undefined);
+    expect(screen.queryByText('Editing paused for Send/Receive')).not.toBeInTheDocument();
+    expect(screen.getByTestId('other-setting')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.tsx
@@ -1,10 +1,25 @@
 import { ProjectSettingNames, SettingNames } from 'papi-shared-types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from 'platform-bible-react';
-import { Localized, ProjectSettingProperties, SettingProperties } from 'platform-bible-utils';
+import {
+  Localized,
+  LocalizeKey,
+  ProjectSettingProperties,
+  SettingProperties,
+} from 'platform-bible-utils';
+import { useMemo } from 'react';
+import { useLocalizedStrings } from '@renderer/hooks/papi-hooks';
+import { useIsProjectAutoSyncBlocked } from '@renderer/hooks/use-is-project-auto-sync-blocked.hook';
 import { OtherSetting } from './other-setting.component';
 import './project-or-other-settings-list.component.scss';
 import { ProjectSetting } from './project-setting.component';
 import { OtherSettingValues, ProjectSettingValues } from './setting.component';
+
+/**
+ * Slim notice shown per project settings list while that project's automatic Send/Receive blocks
+ * edits.
+ */
+const SYNC_BLOCKED_NOTICE_KEY: LocalizeKey = '%settings_projectSyncBlocked_notice%';
+const LOCALIZE_KEYS: LocalizeKey[] = [SYNC_BLOCKED_NOTICE_KEY];
 
 /** Properties for a settings list component that displays either project or user settings */
 type ProjectOrOtherSettingsListProps = {
@@ -31,6 +46,11 @@ export function ProjectOrOtherSettingsList({
   groupDescription,
   className,
 }: ProjectOrOtherSettingsListProps) {
+  const [localizedStrings] = useLocalizedStrings(useMemo(() => LOCALIZE_KEYS, []));
+  // Only project settings (projectId defined) can be edit-blocked; user/general settings never are
+  // (the hook treats an undefined project id as never blocked).
+  const isSyncBlocked = useIsProjectAutoSyncBlocked(projectId);
+
   if (Object.entries(settingProperties).length === 0) return undefined;
 
   return (
@@ -40,6 +60,13 @@ export function ProjectOrOtherSettingsList({
         {groupDescription && <CardDescription>{groupDescription}</CardDescription>}
       </CardHeader>
       <CardContent>
+        {/* One slim, non-covering notice per project settings list while this project's automatic
+            Send/Receive is blocking edits. The individual setting editors are disabled below. */}
+        {isSyncBlocked && (
+          <div role="status" className="sync-blocked-notice">
+            {localizedStrings[SYNC_BLOCKED_NOTICE_KEY]}
+          </div>
+        )}
         {Object.entries(settingProperties)
           .filter(([, property]) => !property.isHidden)
           .map(([key, property]) =>
@@ -56,6 +83,7 @@ export function ProjectOrOtherSettingsList({
                 // eslint-disable-next-line no-type-assertion/no-type-assertion
                 defaultSetting={property.default as ProjectSettingValues}
                 className="card-content"
+                disabled={isSyncBlocked}
               />
             ) : (
               <OtherSetting

--- a/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.tsx
@@ -1,25 +1,11 @@
 import { ProjectSettingNames, SettingNames } from 'papi-shared-types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from 'platform-bible-react';
-import {
-  Localized,
-  LocalizeKey,
-  ProjectSettingProperties,
-  SettingProperties,
-} from 'platform-bible-utils';
-import { useMemo } from 'react';
-import { useLocalizedStrings } from '@renderer/hooks/papi-hooks';
+import { Localized, ProjectSettingProperties, SettingProperties } from 'platform-bible-utils';
 import { useIsProjectAutoSyncBlocked } from '@renderer/hooks/use-is-project-auto-sync-blocked.hook';
 import { OtherSetting } from './other-setting.component';
 import './project-or-other-settings-list.component.scss';
 import { ProjectSetting } from './project-setting.component';
 import { OtherSettingValues, ProjectSettingValues } from './setting.component';
-
-/**
- * Slim notice shown per project settings list while that project's automatic Send/Receive blocks
- * edits.
- */
-const SYNC_BLOCKED_NOTICE_KEY: LocalizeKey = '%settings_projectSyncBlocked_notice%';
-const LOCALIZE_KEYS: LocalizeKey[] = [SYNC_BLOCKED_NOTICE_KEY];
 
 /** Properties for a settings list component that displays either project or user settings */
 type ProjectOrOtherSettingsListProps = {
@@ -46,9 +32,12 @@ export function ProjectOrOtherSettingsList({
   groupDescription,
   className,
 }: ProjectOrOtherSettingsListProps) {
-  const [localizedStrings] = useLocalizedStrings(useMemo(() => LOCALIZE_KEYS, []));
   // Only project settings (projectId defined) can be edit-blocked; user/general settings never are
-  // (the hook treats an undefined project id as never blocked).
+  // (the hook treats an undefined project id as never blocked). The blocked NOTICE itself is no
+  // longer rendered here — a project can have several of these lists (one per settings group), which
+  // used to stack one identical banner per group. It now renders once at the settings-tab level
+  // (SettingsTab, using the same hook with the tab's projectId), above all of a project's groups
+  // (PT-4214). This component keeps only the per-editor `disabled` wiring below.
   const isSyncBlocked = useIsProjectAutoSyncBlocked(projectId);
 
   if (Object.entries(settingProperties).length === 0) return undefined;
@@ -60,13 +49,6 @@ export function ProjectOrOtherSettingsList({
         {groupDescription && <CardDescription>{groupDescription}</CardDescription>}
       </CardHeader>
       <CardContent>
-        {/* One slim, non-covering notice per project settings list while this project's automatic
-            Send/Receive is blocking edits. The individual setting editors are disabled below. */}
-        {isSyncBlocked && (
-          <div role="status" className="sync-blocked-notice">
-            {localizedStrings[SYNC_BLOCKED_NOTICE_KEY]}
-          </div>
-        )}
         {Object.entries(settingProperties)
           .filter(([, property]) => !property.isHidden)
           .map(([key, property]) =>

--- a/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.tsx
@@ -21,8 +21,7 @@ type ProjectOrOtherSettingsListProps = {
   /**
    * When true, each project setting's editor is rendered read-only. Only meaningful for project
    * settings (projectId defined). Computed once by the parent SettingsTab and passed down, so a
-   * project's several setting groups don't each subscribe to the auto-sync-blocking store
-   * (PT-4214).
+   * project's several setting groups don't each subscribe to the auto-sync-blocking store.
    */
   disabled?: boolean;
 };
@@ -42,7 +41,7 @@ export function ProjectOrOtherSettingsList({
   // Only project settings (projectId defined) can be edit-blocked. `disabled` is computed ONCE by
   // the parent SettingsTab (which also renders the single blocked notice above all of a project's
   // groups) and passed down, so a project's several setting groups don't each subscribe to the
-  // auto-sync-blocking store (PT-4214). This component just forwards it to each project setting.
+  // auto-sync-blocking store. This component just forwards it to each project setting.
 
   if (Object.entries(settingProperties).length === 0) return undefined;
 

--- a/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-or-other-settings-list.component.tsx
@@ -1,7 +1,6 @@
 import { ProjectSettingNames, SettingNames } from 'papi-shared-types';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from 'platform-bible-react';
 import { Localized, ProjectSettingProperties, SettingProperties } from 'platform-bible-utils';
-import { useIsProjectAutoSyncBlocked } from '@renderer/hooks/use-is-project-auto-sync-blocked.hook';
 import { OtherSetting } from './other-setting.component';
 import './project-or-other-settings-list.component.scss';
 import { ProjectSetting } from './project-setting.component';
@@ -19,6 +18,13 @@ type ProjectOrOtherSettingsListProps = {
   groupDescription?: string;
   /** Additional css classes to help with unique styling of the ProjectOrOtherSettingsList */
   className?: string;
+  /**
+   * When true, each project setting's editor is rendered read-only. Only meaningful for project
+   * settings (projectId defined). Computed once by the parent SettingsTab and passed down, so a
+   * project's several setting groups don't each subscribe to the auto-sync-blocking store
+   * (PT-4214).
+   */
+  disabled?: boolean;
 };
 
 /**
@@ -31,14 +37,12 @@ export function ProjectOrOtherSettingsList({
   groupLabel,
   groupDescription,
   className,
+  disabled = false,
 }: ProjectOrOtherSettingsListProps) {
-  // Only project settings (projectId defined) can be edit-blocked; user/general settings never are
-  // (the hook treats an undefined project id as never blocked). The blocked NOTICE itself is no
-  // longer rendered here — a project can have several of these lists (one per settings group), which
-  // used to stack one identical banner per group. It now renders once at the settings-tab level
-  // (SettingsTab, using the same hook with the tab's projectId), above all of a project's groups
-  // (PT-4214). This component keeps only the per-editor `disabled` wiring below.
-  const isSyncBlocked = useIsProjectAutoSyncBlocked(projectId);
+  // Only project settings (projectId defined) can be edit-blocked. `disabled` is computed ONCE by
+  // the parent SettingsTab (which also renders the single blocked notice above all of a project's
+  // groups) and passed down, so a project's several setting groups don't each subscribe to the
+  // auto-sync-blocking store (PT-4214). This component just forwards it to each project setting.
 
   if (Object.entries(settingProperties).length === 0) return undefined;
 
@@ -65,7 +69,7 @@ export function ProjectOrOtherSettingsList({
                 // eslint-disable-next-line no-type-assertion/no-type-assertion
                 defaultSetting={property.default as ProjectSettingValues}
                 className="card-content"
-                disabled={isSyncBlocked}
+                disabled={disabled}
               />
             ) : (
               <OtherSetting

--- a/src/renderer/components/settings-tabs/settings-components/project-setting.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/project-setting.component.tsx
@@ -14,6 +14,7 @@ export function ProjectSetting({
   defaultSetting,
   projectId,
   className,
+  disabled,
 }: ProjectSettingProps) {
   const [setting, setSetting, , isLoading] = useProjectSetting<keyof ProjectSettingTypes>(
     projectId,
@@ -39,6 +40,7 @@ export function ProjectSetting({
       label={label}
       description={description}
       className={className}
+      disabled={disabled}
     />
   );
 }

--- a/src/renderer/components/settings-tabs/settings-components/setting.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/setting.component.test.tsx
@@ -72,4 +72,40 @@ describe('Setting disabled forwarding (PT-4214)', () => {
     );
     expect(screen.getByRole('switch')).not.toBeDisabled();
   });
+
+  // An object-valued project setting (typeof setting === 'object', and not the
+  // platform.interfaceLanguage UiLanguageSelector special case) renders the JSON-editor Input — a
+  // distinct branch from the string/number Input above. Confirm `disabled` reaches that Input too so
+  // a blocked project's object settings are also read-only during its Send/Receive.
+  // platformScripture.modelTexts is a real ResourceReferenceList-typed project setting.
+  const modelTextsValue = { dataVersion: '1.1.0', items: [] };
+
+  it('forwards disabled to the JSON-editor Input for an object setting', () => {
+    render(
+      <Setting
+        settingKey="platformScripture.modelTexts"
+        setting={modelTextsValue}
+        setSetting={vi.fn()}
+        isLoading={false}
+        validateProjectSetting={vi.fn()}
+        label="Model texts"
+        disabled
+      />,
+    );
+    expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  it('leaves the JSON-editor Input enabled when disabled is not passed for an object setting', () => {
+    render(
+      <Setting
+        settingKey="platformScripture.modelTexts"
+        setting={modelTextsValue}
+        setSetting={vi.fn()}
+        isLoading={false}
+        validateProjectSetting={vi.fn()}
+        label="Model texts"
+      />,
+    );
+    expect(screen.getByRole('textbox')).not.toBeDisabled();
+  });
 });

--- a/src/renderer/components/settings-tabs/settings-components/setting.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/setting.component.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { Setting } from './setting.component';
 
 // Setting pulls in useData (only for the UI-language-selector fallback, unused by the string/
@@ -13,15 +13,29 @@ vi.mock('@renderer/hooks/papi-hooks', () => ({
   useLocalizedStrings: vi.fn(() => [{}]),
 }));
 
+// Props shared by every case below; only settingKey/setting/label (and `disabled`) differ per test,
+// so each spreads this and passes just those (same idea as the renderPanel helper in
+// comment-list.component.test.tsx). Kept as a shared spread rather than a wrapper fn because
+// Setting's project/user union props make a single-typed render helper awkward, and spreading at
+// each call site keeps the inline settingKey/setting that discriminates the union. Mocks are cleared
+// between tests so the shared no-op fns can't leak call state.
+const baseProps = {
+  setSetting: vi.fn(),
+  isLoading: false,
+  validateProjectSetting: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
 describe('Setting disabled forwarding (PT-4214)', () => {
   it('forwards disabled to the rendered Input for a string setting', () => {
     render(
       <Setting
+        {...baseProps}
         settingKey="platform.language"
         setting="English"
-        setSetting={vi.fn()}
-        isLoading={false}
-        validateProjectSetting={vi.fn()}
         label="Language"
         disabled
       />,
@@ -31,29 +45,14 @@ describe('Setting disabled forwarding (PT-4214)', () => {
 
   it('leaves the Input enabled when disabled is not passed for a string setting', () => {
     render(
-      <Setting
-        settingKey="platform.language"
-        setting="English"
-        setSetting={vi.fn()}
-        isLoading={false}
-        validateProjectSetting={vi.fn()}
-        label="Language"
-      />,
+      <Setting {...baseProps} settingKey="platform.language" setting="English" label="Language" />,
     );
     expect(screen.getByRole('textbox')).not.toBeDisabled();
   });
 
   it('forwards disabled to the rendered Switch for a boolean setting', () => {
     render(
-      <Setting
-        settingKey="platform.isEditable"
-        setting
-        setSetting={vi.fn()}
-        isLoading={false}
-        validateProjectSetting={vi.fn()}
-        label="Editable"
-        disabled
-      />,
+      <Setting {...baseProps} settingKey="platform.isEditable" setting label="Editable" disabled />,
     );
     expect(screen.getByRole('switch')).toBeDisabled();
   });
@@ -61,11 +60,9 @@ describe('Setting disabled forwarding (PT-4214)', () => {
   it('leaves the Switch enabled when disabled is false for a boolean setting', () => {
     render(
       <Setting
+        {...baseProps}
         settingKey="platform.isEditable"
         setting
-        setSetting={vi.fn()}
-        isLoading={false}
-        validateProjectSetting={vi.fn()}
         label="Editable"
         disabled={false}
       />,
@@ -83,11 +80,9 @@ describe('Setting disabled forwarding (PT-4214)', () => {
   it('forwards disabled to the JSON-editor Input for an object setting', () => {
     render(
       <Setting
+        {...baseProps}
         settingKey="platformScripture.modelTexts"
         setting={modelTextsValue}
-        setSetting={vi.fn()}
-        isLoading={false}
-        validateProjectSetting={vi.fn()}
         label="Model texts"
         disabled
       />,
@@ -98,11 +93,9 @@ describe('Setting disabled forwarding (PT-4214)', () => {
   it('leaves the JSON-editor Input enabled when disabled is not passed for an object setting', () => {
     render(
       <Setting
+        {...baseProps}
         settingKey="platformScripture.modelTexts"
         setting={modelTextsValue}
-        setSetting={vi.fn()}
-        isLoading={false}
-        validateProjectSetting={vi.fn()}
         label="Model texts"
       />,
     );

--- a/src/renderer/components/settings-tabs/settings-components/setting.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/setting.component.test.tsx
@@ -29,7 +29,7 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('Setting disabled forwarding (PT-4214)', () => {
+describe('Setting disabled forwarding', () => {
   it('forwards disabled to the rendered Input for a string setting', () => {
     render(
       <Setting

--- a/src/renderer/components/settings-tabs/settings-components/setting.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/setting.component.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { Setting } from './setting.component';
+
+// Setting pulls in useData (only for the UI-language-selector fallback, unused by the string/
+// boolean cases below) and useLocalizedStrings; stub both so the component renders without a live
+// papi backend. Nothing under test reads their values.
+vi.mock('@renderer/hooks/papi-hooks', () => ({
+  useData: vi.fn(() => ({
+    AvailableInterfaceLanguages: () => [{}, vi.fn(), false],
+  })),
+  useLocalizedStrings: vi.fn(() => [{}]),
+}));
+
+describe('Setting disabled forwarding (PT-4214)', () => {
+  it('forwards disabled to the rendered Input for a string setting', () => {
+    render(
+      <Setting
+        settingKey="platform.language"
+        setting="English"
+        setSetting={vi.fn()}
+        isLoading={false}
+        validateProjectSetting={vi.fn()}
+        label="Language"
+        disabled
+      />,
+    );
+    expect(screen.getByRole('textbox')).toBeDisabled();
+  });
+
+  it('leaves the Input enabled when disabled is not passed for a string setting', () => {
+    render(
+      <Setting
+        settingKey="platform.language"
+        setting="English"
+        setSetting={vi.fn()}
+        isLoading={false}
+        validateProjectSetting={vi.fn()}
+        label="Language"
+      />,
+    );
+    expect(screen.getByRole('textbox')).not.toBeDisabled();
+  });
+
+  it('forwards disabled to the rendered Switch for a boolean setting', () => {
+    render(
+      <Setting
+        settingKey="platform.isEditable"
+        setting
+        setSetting={vi.fn()}
+        isLoading={false}
+        validateProjectSetting={vi.fn()}
+        label="Editable"
+        disabled
+      />,
+    );
+    expect(screen.getByRole('switch')).toBeDisabled();
+  });
+
+  it('leaves the Switch enabled when disabled is false for a boolean setting', () => {
+    render(
+      <Setting
+        settingKey="platform.isEditable"
+        setting
+        setSetting={vi.fn()}
+        isLoading={false}
+        validateProjectSetting={vi.fn()}
+        label="Editable"
+        disabled={false}
+      />,
+    );
+    expect(screen.getByRole('switch')).not.toBeDisabled();
+  });
+});

--- a/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
@@ -46,8 +46,8 @@ type BaseSettingProps<TSettingKey, TSettingValue> = {
   className?: string;
   /**
    * When true, the setting's editor is rendered read-only (disabled). Used to make a project's
-   * settings read-only while an automatic Send/Receive is blocking edits on that project (PT-4214).
-   * Defaults to `false`.
+   * settings read-only while an automatic Send/Receive is blocking edits on that project. Defaults
+   * to `false`.
    */
   disabled?: boolean;
 };
@@ -82,8 +82,8 @@ export type OtherSettingValues = SettingTypes[keyof SettingTypes];
 
 /**
  * Props for the UserSetting component. `disabled` is omitted from `BaseSettingProps`: only project
- * settings go read-only during an automatic Send/Receive (PT-4214), and `OtherSetting` does not
- * forward `disabled` — so the type must not advertise a capability the component silently drops.
+ * settings go read-only during an automatic Send/Receive, and `OtherSetting` does not forward
+ * `disabled` — so the type must not advertise a capability the component silently drops.
  */
 export type OtherSettingProps = Omit<
   BaseSettingProps<SettingNames, OtherSettingValues>,

--- a/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
@@ -44,6 +44,12 @@ type BaseSettingProps<TSettingKey, TSettingValue> = {
   defaultSetting: TSettingValue;
   /** Additional css classes to help with unique styling of the Settings component */
   className?: string;
+  /**
+   * When true, the setting's editor is rendered read-only (disabled). Used to make a project's
+   * settings read-only while an automatic Send/Receive is blocking edits on that project (PT-4214).
+   * Defaults to `false`.
+   */
+  disabled?: boolean;
 };
 
 /**
@@ -137,6 +143,7 @@ export function Setting({
   label,
   className,
   description,
+  disabled = false,
 }: CombinedSettingProps) {
   const validateSetting = validateOtherSetting || validateProjectSetting;
 
@@ -242,14 +249,26 @@ export function Setting({
 
     if (typeof setting === 'string' || typeof setting === 'number')
       component = (
-        <Input key={settingKey} onChange={debouncedHandleChange} defaultValue={setting} />
+        <Input
+          key={settingKey}
+          onChange={debouncedHandleChange}
+          defaultValue={setting}
+          disabled={disabled}
+        />
       );
     else if (typeof setting === 'boolean')
       component = (
-        <Switch key={settingKey} onCheckedChange={debouncedHandleChange} defaultChecked={setting} />
+        <Switch
+          key={settingKey}
+          onCheckedChange={debouncedHandleChange}
+          defaultChecked={setting}
+          disabled={disabled}
+        />
       );
     else if (typeof setting === 'object')
       if (Array.isArray(setting) && settingKey === 'platform.interfaceLanguage') {
+        // interfaceLanguage is a user (not project) setting, so it is never subject to per-project
+        // Send/Receive edit-blocking; UiLanguageSelector exposes no `disabled` prop, so none is passed.
         component = (
           <UiLanguageSelector
             className="language-selector"
@@ -267,6 +286,7 @@ export function Setting({
             key={settingKey}
             onChange={debouncedHandleChange}
             defaultValue={JSON.stringify(setting, undefined, 2)}
+            disabled={disabled}
           />
         );
       }
@@ -296,6 +316,7 @@ export function Setting({
     errorMessage,
     languages,
     defaultLanguages,
+    disabled,
   ]);
 
   return (

--- a/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-components/setting.component.tsx
@@ -80,8 +80,15 @@ type ProjectSettingsControls = {
 /** Values of SettingTypes */
 export type OtherSettingValues = SettingTypes[keyof SettingTypes];
 
-/** Props for the UserSetting component */
-export type OtherSettingProps = BaseSettingProps<SettingNames, OtherSettingValues>;
+/**
+ * Props for the UserSetting component. `disabled` is omitted from `BaseSettingProps`: only project
+ * settings go read-only during an automatic Send/Receive (PT-4214), and `OtherSetting` does not
+ * forward `disabled` — so the type must not advertise a capability the component silently drops.
+ */
+export type OtherSettingProps = Omit<
+  BaseSettingProps<SettingNames, OtherSettingValues>,
+  'disabled'
+>;
 
 /** Values from the useSetting hook to manage the setting */
 type OtherSettingsControls = {
@@ -108,7 +115,10 @@ type CombinedSettingProps =
       never
     >
   | SettingProps<
-      Omit<OtherSettingProps, 'defaultSetting'>,
+      // `disabled` is re-added here (it is omitted from the public `OtherSettingProps` so the
+      // OtherSetting wrapper doesn't advertise a prop it drops) because the shared `Setting`
+      // renderer reads `disabled` uniformly for both variants; only ProjectSetting ever passes it.
+      Omit<OtherSettingProps, 'defaultSetting'> & { disabled?: boolean },
       OtherSettingsControls,
       never,
       // Necessary for flexibility in handleChangeSetting, couldn't use unknown

--- a/src/renderer/components/settings-tabs/settings-tab.component.scss
+++ b/src/renderer/components/settings-tabs/settings-tab.component.scss
@@ -32,6 +32,23 @@
   max-width: 100%;
 }
 
+/* Slim "editing paused during Send/Receive" notice shown once above a project's settings groups
+   while that project's automatic sync is blocking edits. Non-covering; the individual setting
+   editors below are disabled instead (see ProjectOrOtherSettingsList / Setting `disabled` wiring).
+   Sized to match the 600px settings cards (.card) it sits above so it lines up with them in both
+   the single-project tab and the sidebar-selected-project view. */
+.sync-blocked-notice {
+  width: 600px;
+  max-width: 100%;
+  margin-bottom: 1rem;
+  padding: 0.375rem 0.75rem;
+  border: 1px solid hsl(var(--border));
+  border-radius: var(--radius);
+  background-color: hsl(var(--muted));
+  color: hsl(var(--muted-foreground));
+  font-size: 0.875rem;
+}
+
 .zero-search-results {
   display: flex;
   flex-grow: 1;

--- a/src/renderer/components/settings-tabs/settings-tab.component.scss
+++ b/src/renderer/components/settings-tabs/settings-tab.component.scss
@@ -42,10 +42,10 @@
   max-width: 100%;
   margin-bottom: 1rem;
   padding: 0.375rem 0.75rem;
-  border: 1px solid hsl(var(--border));
+  border: 1px solid var(--border);
   border-radius: var(--radius);
-  background-color: hsl(var(--muted));
-  color: hsl(var(--muted-foreground));
+  background-color: var(--muted);
+  color: var(--muted-foreground);
   font-size: 0.875rem;
 }
 

--- a/src/renderer/components/settings-tabs/settings-tab.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-tab.component.test.tsx
@@ -1,0 +1,128 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useIsProjectAutoSyncBlocked } from '@renderer/hooks/use-is-project-auto-sync-blocked.hook';
+import { SettingsTab } from './settings-tab.component';
+
+const SYNC_BLOCKED_NOTICE_KEY = '%settings_projectSyncBlocked_notice%';
+const SYNC_BLOCKED_NOTICE_TEXT = 'Editing paused for Send/Receive';
+
+// The hook under wiring test — controlled per test to simulate a blocked / unblocked project.
+vi.mock('@renderer/hooks/use-is-project-auto-sync-blocked.hook', () => ({
+  useIsProjectAutoSyncBlocked: vi.fn(),
+}));
+
+vi.mock('@renderer/hooks/papi-hooks', () => ({
+  useLocalizedStrings: vi.fn(() => [{ [SYNC_BLOCKED_NOTICE_KEY]: SYNC_BLOCKED_NOTICE_TEXT }]),
+}));
+
+// This test only exercises SettingsTab's own render structure (one notice above N groups) — the
+// leaf list rendering (properties, disabled wiring) is covered by
+// project-or-other-settings-list.component.test.tsx and setting.component.test.tsx. Stub it to a
+// simple marker so a fake project-settings shape can drive multiple groups without wiring up real
+// setting values.
+vi.mock('./settings-components/project-or-other-settings-list.component', () => ({
+  ProjectOrOtherSettingsList: ({
+    groupLabel,
+    projectId,
+  }: {
+    groupLabel: string;
+    projectId?: string;
+  }) => (
+    <div data-testid="settings-group" data-project-id={projectId}>
+      {groupLabel}
+    </div>
+  ),
+}));
+
+// projectId-scoped project settings (used by the projectIdToLimitSettings tab mode): two
+// extensions contributing three groups total, so the "one notice, not one per group" fix has
+// something to actually dedupe against.
+const PROJECT_SETTINGS_GROUPS = {
+  ext1: [
+    { label: 'Group A', properties: { 'ext1.settingA': { label: 'Setting A', default: 'x' } } },
+    { label: 'Group B', properties: { 'ext1.settingB': { label: 'Setting B', default: 'x' } } },
+  ],
+  ext2: [
+    { label: 'Group C', properties: { 'ext2.settingC': { label: 'Setting C', default: 'x' } } },
+  ],
+};
+
+vi.mock('@shared/services/project-settings.service', () => ({
+  projectSettingsService: {
+    getLocalizedContributionInfo: vi.fn(async () => ({ contributions: PROJECT_SETTINGS_GROUPS })),
+  },
+  // Interface filtering is exercised elsewhere; pass every group through unchanged here.
+  filterProjectSettingsContributionsByProjectInterfaces: vi.fn((contributions) => contributions),
+}));
+
+// General/user settings (used by the sidebar's default "no project selected" mode).
+const GENERAL_SETTINGS_GROUPS = {
+  generalExt: [
+    {
+      label: 'General Group',
+      properties: { 'generalExt.settingA': { label: 'General Setting', default: 'y' } },
+    },
+  ],
+};
+
+vi.mock('@shared/services/settings.service', () => ({
+  settingsService: {
+    getLocalizedSettingsContributionInfo: vi.fn(async () => ({
+      contributions: GENERAL_SETTINGS_GROUPS,
+    })),
+  },
+}));
+
+vi.mock('@shared/services/project-lookup.service', () => ({
+  projectLookupService: {
+    getMetadataForProject: vi.fn(async () => ({ projectInterfaces: [] })),
+    // Empty so the sidebar's project list stays empty and getProjectName (which needs a live
+    // papi-frontend project data provider) is never reached.
+    getMetadataForAllProjects: vi.fn(async () => []),
+  },
+}));
+
+vi.mock('@renderer/services/papi-frontend.service', () => ({
+  projectDataProviders: { get: vi.fn() },
+}));
+
+describe('SettingsTab sync-blocked notice dedup (PT-4214)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);
+  });
+
+  it('renders exactly one notice above all of a blocked project’s settings groups, not one per group', async () => {
+    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(true);
+    render(<SettingsTab projectIdToLimitSettings="projA" />);
+
+    await waitFor(() => expect(screen.getAllByTestId('settings-group')).toHaveLength(3));
+
+    expect(useIsProjectAutoSyncBlocked).toHaveBeenCalledWith('projA');
+    const notices = screen.getAllByRole('status');
+    expect(notices).toHaveLength(1);
+    expect(notices[0]).toHaveTextContent(SYNC_BLOCKED_NOTICE_TEXT);
+  });
+
+  it('renders no notice when the project is not sync-blocked, while still rendering all groups', async () => {
+    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);
+    render(<SettingsTab projectIdToLimitSettings="projA" />);
+
+    await waitFor(() => expect(screen.getAllByTestId('settings-group')).toHaveLength(3));
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  it('never renders a notice for the general/user settings view (no project)', async () => {
+    // Even mocked to report "blocked", the notice must not appear: the general-settings branch
+    // never reaches the notice-rendering code at all (it is structurally inside the
+    // selectedSidebarItem.projectId branch), unlike the per-list version this replaces which
+    // called the hook unconditionally.
+    vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(true);
+    render(<SettingsTab />);
+
+    await waitFor(() => expect(screen.getAllByTestId('settings-group')).toHaveLength(1));
+    expect(useIsProjectAutoSyncBlocked).toHaveBeenCalledWith(undefined);
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/components/settings-tabs/settings-tab.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-tab.component.test.tsx
@@ -87,7 +87,7 @@ vi.mock('@renderer/services/papi-frontend.service', () => ({
   projectDataProviders: { get: vi.fn() },
 }));
 
-describe('SettingsTab sync-blocked notice dedup (PT-4214)', () => {
+describe('SettingsTab sync-blocked notice dedup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(false);

--- a/src/renderer/components/settings-tabs/settings-tab.component.test.tsx
+++ b/src/renderer/components/settings-tabs/settings-tab.component.test.tsx
@@ -115,9 +115,9 @@ describe('SettingsTab sync-blocked notice dedup', () => {
 
   it('never renders a notice for the general/user settings view (no project)', async () => {
     // Even mocked to report "blocked", the notice must not appear: the general-settings branch
-    // never reaches the notice-rendering code at all (it is structurally inside the
-    // selectedSidebarItem.projectId branch), unlike the per-list version this replaces which
-    // called the hook unconditionally.
+    // never reaches the notice-rendering code at all — it is structurally inside the
+    // selectedSidebarItem.projectId branch, so a "blocked" hook result can't leak a notice into the
+    // no-project view.
     vi.mocked(useIsProjectAutoSyncBlocked).mockReturnValue(true);
     render(<SettingsTab />);
 

--- a/src/renderer/components/settings-tabs/settings-tab.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-tab.component.tsx
@@ -14,12 +14,21 @@ import './settings-tab.component.scss';
 import { projectLookupService } from '@shared/services/project-lookup.service';
 import { projectDataProviders } from '@renderer/services/papi-frontend.service';
 import { useLocalizedStrings } from '@renderer/hooks/papi-hooks';
+import { useIsProjectAutoSyncBlocked } from '@renderer/hooks/use-is-project-auto-sync-blocked.hook';
 import { formatReplacementString, Localized, LocalizeKey } from 'platform-bible-utils';
 import { SettingsContributionInfo } from '@shared/utils/settings-document-combiner-base';
 import { ProjectSettingsContributionInfo } from '@shared/utils/project-settings-document-combiner';
 import { ProjectOrOtherSettingsList } from './settings-components/project-or-other-settings-list.component';
 
 export const TAB_TYPE_SETTINGS_TAB = 'settings-tab';
+
+/**
+ * Slim notice shown once above a project's settings groups while that project's automatic
+ * Send/Receive blocks edits. Rendered here at the tab level — not per settings-group list — because
+ * a project's settings are split across several `ProjectOrOtherSettingsList` groups, which used to
+ * each render their own identical banner (PT-4214).
+ */
+const SYNC_BLOCKED_NOTICE_KEY: LocalizeKey = '%settings_projectSyncBlocked_notice%';
 
 type SettingsTabProps = {
   /** Optional project Id, when passed in, will only show settings for that project */
@@ -47,6 +56,7 @@ const LOCALIZE_SETTING_KEYS: LocalizeKey[] = [
   '%settings_defaultMessage_noSettings%',
   '%settings_defaultMessage_noSettingsFound%',
   '%settings_defaultMessage_noSettingsFoundDetails%',
+  SYNC_BLOCKED_NOTICE_KEY,
 ];
 
 const filterSettingsContributions = (
@@ -85,6 +95,12 @@ export function SettingsTab({ projectIdToLimitSettings }: SettingsTabProps) {
     projectId: undefined,
   });
   const [searchQuery, setSearchQuery] = useState<string>('');
+
+  // The tab's current project, whichever of the two modes below is active: pinned to one project
+  // (projectIdToLimitSettings) or a project picked in the sidebar (selectedSidebarItem.projectId).
+  // Undefined (general/user settings) is never blocked — see the hook's own doc comment.
+  const tabProjectId = projectIdToLimitSettings ?? selectedSidebarItem.projectId;
+  const isProjectSyncBlocked = useIsProjectAutoSyncBlocked(tabProjectId);
 
   const handleSearchInput = (newSearchTerm: string) => {
     setSearchQuery(newSearchTerm);
@@ -230,7 +246,14 @@ export function SettingsTab({ projectIdToLimitSettings }: SettingsTabProps) {
     return (
       <div className="project-settings-tab">
         {filteredProjectSettingsContributions ? (
-          renderProjectSettingsList(projectIdToLimitSettings)
+          <>
+            {isProjectSyncBlocked && (
+              <div role="status" className="sync-blocked-notice">
+                {localizedStrings[SYNC_BLOCKED_NOTICE_KEY]}
+              </div>
+            )}
+            {renderProjectSettingsList(projectIdToLimitSettings)}
+          </>
         ) : (
           <div>{localizedStrings['%settings_defaultMessage_loadingSettings%']}</div>
         )}
@@ -277,18 +300,27 @@ export function SettingsTab({ projectIdToLimitSettings }: SettingsTabProps) {
           buttonPlaceholderText={localizedStrings['%settings_sidebar_projectsComboBoxPlaceholder%']}
         >
           <div className="project-or-settings-list-container">
-            {selectedSidebarItem.projectId
-              ? renderProjectSettingsList(selectedSidebarItem.projectId)
-              : matchedSettingsContributions &&
-                matchedSettingsContributions[selectedSidebarItem.label]?.map((group) => (
-                  <ProjectOrOtherSettingsList
-                    key={group.label}
-                    groupLabel={group.label}
-                    groupDescription={group.description}
-                    settingProperties={group.properties}
-                    className="project-or-settings-list"
-                  />
-                ))}
+            {selectedSidebarItem.projectId ? (
+              <>
+                {isProjectSyncBlocked && (
+                  <div role="status" className="sync-blocked-notice">
+                    {localizedStrings[SYNC_BLOCKED_NOTICE_KEY]}
+                  </div>
+                )}
+                {renderProjectSettingsList(selectedSidebarItem.projectId)}
+              </>
+            ) : (
+              matchedSettingsContributions &&
+              matchedSettingsContributions[selectedSidebarItem.label]?.map((group) => (
+                <ProjectOrOtherSettingsList
+                  key={group.label}
+                  groupLabel={group.label}
+                  groupDescription={group.description}
+                  settingProperties={group.properties}
+                  className="project-or-settings-list"
+                />
+              ))
+            )}
 
             {showZeroResultsState && (
               <div className="zero-search-results">

--- a/src/renderer/components/settings-tabs/settings-tab.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-tab.component.tsx
@@ -209,12 +209,13 @@ export function SettingsTab({ projectIdToLimitSettings }: SettingsTabProps) {
                   groupLabel={settingsGroup.label}
                   groupDescription={settingsGroup.description}
                   className="project-or-settings-list"
+                  disabled={isProjectSyncBlocked}
                 />
               ))
             : [],
       );
     },
-    [filteredAndMatchedProjectSettingsContributions, localizedStrings],
+    [filteredAndMatchedProjectSettingsContributions, localizedStrings, isProjectSyncBlocked],
   );
 
   const showZeroResultsState = useMemo(() => {
@@ -242,16 +243,21 @@ export function SettingsTab({ projectIdToLimitSettings }: SettingsTabProps) {
     selectedSidebarItem,
   ]);
 
+  // Single blocked notice for the tab's current project, reused in both render branches below so the
+  // two copies can't drift (PT-4214). Falsy (renders nothing) when the project isn't blocked or for
+  // general/user settings.
+  const syncBlockedNotice = isProjectSyncBlocked && (
+    <div role="status" className="sync-blocked-notice">
+      {localizedStrings[SYNC_BLOCKED_NOTICE_KEY]}
+    </div>
+  );
+
   if (projectIdToLimitSettings) {
     return (
       <div className="project-settings-tab">
         {filteredProjectSettingsContributions ? (
           <>
-            {isProjectSyncBlocked && (
-              <div role="status" className="sync-blocked-notice">
-                {localizedStrings[SYNC_BLOCKED_NOTICE_KEY]}
-              </div>
-            )}
+            {syncBlockedNotice}
             {renderProjectSettingsList(projectIdToLimitSettings)}
           </>
         ) : (
@@ -302,11 +308,7 @@ export function SettingsTab({ projectIdToLimitSettings }: SettingsTabProps) {
           <div className="project-or-settings-list-container">
             {selectedSidebarItem.projectId ? (
               <>
-                {isProjectSyncBlocked && (
-                  <div role="status" className="sync-blocked-notice">
-                    {localizedStrings[SYNC_BLOCKED_NOTICE_KEY]}
-                  </div>
-                )}
+                {syncBlockedNotice}
                 {renderProjectSettingsList(selectedSidebarItem.projectId)}
               </>
             ) : (

--- a/src/renderer/components/settings-tabs/settings-tab.component.tsx
+++ b/src/renderer/components/settings-tabs/settings-tab.component.tsx
@@ -25,8 +25,8 @@ export const TAB_TYPE_SETTINGS_TAB = 'settings-tab';
 /**
  * Slim notice shown once above a project's settings groups while that project's automatic
  * Send/Receive blocks edits. Rendered here at the tab level — not per settings-group list — because
- * a project's settings are split across several `ProjectOrOtherSettingsList` groups, which used to
- * each render their own identical banner (PT-4214).
+ * a project's settings are split across several `ProjectOrOtherSettingsList` groups; rendering it
+ * per-list would show one identical banner per group.
  */
 const SYNC_BLOCKED_NOTICE_KEY: LocalizeKey = '%settings_projectSyncBlocked_notice%';
 
@@ -244,7 +244,7 @@ export function SettingsTab({ projectIdToLimitSettings }: SettingsTabProps) {
   ]);
 
   // Single blocked notice for the tab's current project, reused in both render branches below so the
-  // two copies can't drift (PT-4214). Falsy (renders nothing) when the project isn't blocked or for
+  // two copies can't drift. Falsy (renders nothing) when the project isn't blocked or for
   // general/user settings.
   const syncBlockedNotice = isProjectSyncBlocked && (
     <div role="status" className="sync-blocked-notice">

--- a/src/renderer/hooks/use-is-project-auto-sync-blocked.hook.test.ts
+++ b/src/renderer/hooks/use-is-project-auto-sync-blocked.hook.test.ts
@@ -1,0 +1,68 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  isProjectBlocked,
+  subscribeToAutoSyncBlocking,
+} from '@renderer/services/auto-sync-blocking-store';
+import { useIsProjectAutoSyncBlocked } from './use-is-project-auto-sync-blocked.hook';
+
+vi.mock('@renderer/services/auto-sync-blocking-store', () => ({
+  isProjectBlocked: vi.fn(),
+  subscribeToAutoSyncBlocking: vi.fn(),
+}));
+
+describe('useIsProjectAutoSyncBlocked', () => {
+  /** The store listener the hook registers, captured so tests can drive a change. */
+  let storeListener: (() => void) | undefined;
+  let unsub: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    storeListener = undefined;
+    unsub = vi.fn();
+    vi.mocked(subscribeToAutoSyncBlocking).mockImplementation((listener) => {
+      storeListener = listener;
+      return unsub;
+    });
+    vi.mocked(isProjectBlocked).mockReturnValue(false);
+  });
+
+  it('returns true when the given project is blocked', () => {
+    vi.mocked(isProjectBlocked).mockImplementation((id) => id === 'projA');
+    const { result } = renderHook(() => useIsProjectAutoSyncBlocked('projA'));
+    expect(result.current).toBe(true);
+    expect(isProjectBlocked).toHaveBeenCalledWith('projA');
+  });
+
+  it('returns false for a project that is not blocked', () => {
+    vi.mocked(isProjectBlocked).mockImplementation((id) => id === 'projA');
+    const { result } = renderHook(() => useIsProjectAutoSyncBlocked('projB'));
+    expect(result.current).toBe(false);
+  });
+
+  it('returns false for an undefined project id', () => {
+    const { result } = renderHook(() => useIsProjectAutoSyncBlocked(undefined));
+    expect(result.current).toBe(false);
+  });
+
+  it('reactively updates when the store notifies a change', () => {
+    vi.mocked(isProjectBlocked).mockReturnValue(false);
+    const { result } = renderHook(() => useIsProjectAutoSyncBlocked('projA'));
+    expect(result.current).toBe(false);
+
+    // The project becomes blocked; the store fires its listener → the hook re-reads the snapshot.
+    vi.mocked(isProjectBlocked).mockReturnValue(true);
+    act(() => {
+      if (!storeListener) throw new Error('store listener not registered');
+      storeListener();
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('unsubscribes from the store on unmount', () => {
+    const { unmount } = renderHook(() => useIsProjectAutoSyncBlocked('projA'));
+    expect(subscribeToAutoSyncBlocking).toHaveBeenCalledTimes(1);
+    unmount();
+    expect(unsub).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/hooks/use-is-project-auto-sync-blocked.hook.ts
+++ b/src/renderer/hooks/use-is-project-auto-sync-blocked.hook.ts
@@ -6,8 +6,8 @@ import { useCallback, useSyncExternalStore } from 'react';
 
 /**
  * Returns whether the given project's edits are currently blocked by an automatic (scheduled or
- * session) Send/Receive (PT-4214 Stage U), updating reactively as the auto-sync-blocking store's
- * visible set changes. An `undefined` project id is never blocked.
+ * session) Send/Receive, updating reactively as the auto-sync-blocking store's visible set changes.
+ * An `undefined` project id is never blocked.
  *
  * Uses `useSyncExternalStore`, which re-reads the current value when it subscribes — a
  * block/unblock emitted between the initial render and the subscription cannot be missed. The

--- a/src/renderer/hooks/use-is-project-auto-sync-blocked.hook.ts
+++ b/src/renderer/hooks/use-is-project-auto-sync-blocked.hook.ts
@@ -4,11 +4,6 @@ import {
 } from '@renderer/services/auto-sync-blocking-store';
 import { useCallback, useSyncExternalStore } from 'react';
 
-/** Subscribe function for {@link useSyncExternalStore} — module-level so its identity is stable. */
-function subscribe(onStoreChange: () => void): () => void {
-  return subscribeToAutoSyncBlocking(onStoreChange);
-}
-
 /**
  * Returns whether the given project's edits are currently blocked by an automatic (scheduled or
  * session) Send/Receive (PT-4214 Stage U), updating reactively as the auto-sync-blocking store's
@@ -21,7 +16,9 @@ function subscribe(onStoreChange: () => void): () => void {
  */
 export function useIsProjectAutoSyncBlocked(projectId: string | undefined): boolean {
   const getSnapshot = useCallback(() => isProjectBlocked(projectId), [projectId]);
-  return useSyncExternalStore(subscribe, getSnapshot);
+  // `subscribeToAutoSyncBlocking` already matches the `useSyncExternalStore` subscribe signature and
+  // is a stable module-level reference, so it can be passed directly (no wrapper needed).
+  return useSyncExternalStore(subscribeToAutoSyncBlocking, getSnapshot);
 }
 
 export default useIsProjectAutoSyncBlocked;

--- a/src/renderer/hooks/use-is-project-auto-sync-blocked.hook.ts
+++ b/src/renderer/hooks/use-is-project-auto-sync-blocked.hook.ts
@@ -1,0 +1,27 @@
+import {
+  isProjectBlocked,
+  subscribeToAutoSyncBlocking,
+} from '@renderer/services/auto-sync-blocking-store';
+import { useCallback, useSyncExternalStore } from 'react';
+
+/** Subscribe function for {@link useSyncExternalStore} — module-level so its identity is stable. */
+function subscribe(onStoreChange: () => void): () => void {
+  return subscribeToAutoSyncBlocking(onStoreChange);
+}
+
+/**
+ * Returns whether the given project's edits are currently blocked by an automatic (scheduled or
+ * session) Send/Receive (PT-4214 Stage U), updating reactively as the auto-sync-blocking store's
+ * visible set changes. An `undefined` project id is never blocked.
+ *
+ * Uses `useSyncExternalStore`, which re-reads the current value when it subscribes — a
+ * block/unblock emitted between the initial render and the subscription cannot be missed. The
+ * snapshot is a primitive boolean (compared by value), so it never triggers the infinite-loop
+ * guard.
+ */
+export function useIsProjectAutoSyncBlocked(projectId: string | undefined): boolean {
+  const getSnapshot = useCallback(() => isProjectBlocked(projectId), [projectId]);
+  return useSyncExternalStore(subscribe, getSnapshot);
+}
+
+export default useIsProjectAutoSyncBlocked;

--- a/src/renderer/services/auto-sync-edit-block-driver.test.ts
+++ b/src/renderer/services/auto-sync-edit-block-driver.test.ts
@@ -29,6 +29,12 @@ vi.mock('@shared/services/logger.service', () => ({
 }));
 
 const EDITOR_TYPE = 'platformScriptureEditor.react';
+/**
+ * Legacy-comment-manager web view types the driver also edit-blocks (see
+ * EDIT_BLOCKABLE_WEB_VIEW_TYPES).
+ */
+const COMMENT_LIST_TYPE = 'legacyCommentManager.commentList';
+const COMMENT_LIST_PANEL_TYPE = 'legacyCommentManager.commentListPanel';
 
 /**
  * Tracks every definition object handed out by `makeDefinition`, keyed by id, so the
@@ -65,6 +71,16 @@ function editor(
 
 function nonEditor(id: string): SavedWebViewDefinition {
   return makeDefinition(id, 'some.other.webView');
+}
+
+/** A legacy-comment-manager comment web view (editor-anchored list or Column 3 panel). */
+function commentView(
+  id: string,
+  webViewType: string,
+  projectId?: string,
+  state?: Record<string, unknown>,
+): SavedWebViewDefinition {
+  return makeDefinition(id, webViewType, projectId, state);
 }
 
 describe('initAutoSyncEditBlockDriver', () => {
@@ -499,6 +515,79 @@ describe('initAutoSyncEditBlockDriver', () => {
     expect(storeUnsub).toHaveBeenCalledTimes(1);
     expect(openUnsub).toHaveBeenCalledTimes(1);
     expect(updateUnsub).toHaveBeenCalledTimes(1);
+  });
+
+  it(
+    "flags a blocked project's legacy-comment-manager comment views (editor-anchored list and " +
+      "Column 3 panel), leaving another project's comment view editable",
+    () => {
+      vi.mocked(getAllOpenWebViewDefinitionsSync).mockReturnValue([
+        commentView('cl-a', COMMENT_LIST_TYPE, 'projA'), // syncing project's comment list
+        commentView('panel-a', COMMENT_LIST_PANEL_TYPE, 'projA'), // syncing project's Column 3 panel
+        commentView('cl-b', COMMENT_LIST_TYPE, 'projB'), // a different, NOT-syncing project
+      ]);
+      initAutoSyncEditBlockDriver();
+
+      setBlockedProjects('projA');
+      if (!storeListener) throw new Error('store listener not registered');
+      storeListener();
+
+      expect(updateWebViewDefinitionSync).toHaveBeenCalledWith('cl-a', {
+        state: { isSyncBlocked: true },
+      });
+      expect(updateWebViewDefinitionSync).toHaveBeenCalledWith('panel-a', {
+        state: { isSyncBlocked: true },
+      });
+      expect(updateWebViewDefinitionSync).not.toHaveBeenCalledWith('cl-b', expect.anything());
+      expect(updateWebViewDefinitionSync).toHaveBeenCalledTimes(2);
+    },
+  );
+
+  it('re-flags a legacy-comment-manager comment view of a blocked project rebuilt mid-block that came back unblocked', () => {
+    initAutoSyncEditBlockDriver();
+    if (!storeListener) throw new Error('store listener not registered');
+
+    setBlockedProjects('projA');
+    storeListener();
+    if (!updateHandler) throw new Error('update handler not registered');
+
+    // A rebuilt comment panel of projA comes back with isSyncBlocked forced to false (its provider
+    // scrubs it on rehydrate) → the driver re-flags it to true.
+    updateHandler({
+      webView: commentView('panel-rebuilt', COMMENT_LIST_PANEL_TYPE, 'projA', {
+        isSyncBlocked: false,
+      }),
+    });
+    expect(updateWebViewDefinitionSync).toHaveBeenCalledWith('panel-rebuilt', {
+      state: { isSyncBlocked: true },
+    });
+
+    // A rebuilt comment view of a NON-blocked project is not re-flagged.
+    vi.mocked(updateWebViewDefinitionSync).mockClear();
+    updateHandler({
+      webView: commentView('cl-other', COMMENT_LIST_TYPE, 'projB', { isSyncBlocked: false }),
+    });
+    expect(updateWebViewDefinitionSync).not.toHaveBeenCalled();
+  });
+
+  it('flags a legacy-comment-manager comment view opened mid-block only for a blocked project', () => {
+    initAutoSyncEditBlockDriver();
+    if (!storeListener) throw new Error('store listener not registered');
+
+    setBlockedProjects('projA');
+    storeListener();
+    if (!openHandler) throw new Error('open handler not registered');
+
+    // A comment list of the blocked project opened mid-block gets flagged.
+    openHandler({ webView: commentView('cl-opened', COMMENT_LIST_TYPE, 'projA') });
+    expect(updateWebViewDefinitionSync).toHaveBeenCalledWith('cl-opened', {
+      state: { isSyncBlocked: true },
+    });
+
+    // A comment panel of a DIFFERENT project opened mid-block is not flagged.
+    vi.mocked(updateWebViewDefinitionSync).mockClear();
+    openHandler({ webView: commentView('panel-other', COMMENT_LIST_PANEL_TYPE, 'projB') });
+    expect(updateWebViewDefinitionSync).not.toHaveBeenCalled();
   });
 
   it('does not throw if the dock layout is not ready when enumerating web views', () => {

--- a/src/renderer/services/auto-sync-edit-block-driver.ts
+++ b/src/renderer/services/auto-sync-edit-block-driver.ts
@@ -39,7 +39,27 @@ import {
   updateWebViewDefinitionSync,
 } from '@renderer/services/web-view.service-host';
 
-/** Web view state key the Scripture editor reads to know it is edit-blocked by an automatic sync. */
+/**
+ * Web view types this driver edit-blocks while their project is syncing.
+ * `SCRIPTURE_EDITOR_WEBVIEW_TYPE` is a core shared-model constant; the two legacy-comment-manager
+ * comment views are hard-coded string literals because core must NOT import from an extension. This
+ * intentionally duplicates the type strings the way each extension duplicates its own
+ * sync-edit-blocked handling (no cross-boundary imports); if those extension web-view types are
+ * ever renamed, update them here to match. Each of these web views reads `isSyncBlocked` from its
+ * own web view state and folds it into a read-only / write-disabled mode.
+ */
+const EDIT_BLOCKABLE_WEB_VIEW_TYPES: ReadonlySet<string> = new Set([
+  SCRIPTURE_EDITOR_WEBVIEW_TYPE,
+  // legacy-comment-manager `commentListWebViewType` (editor-anchored comment list).
+  'legacyCommentManager.commentList',
+  // legacy-comment-manager `COMMENT_LIST_PANEL_WEB_VIEW_TYPE` (fixed Column 3 comment panel).
+  'legacyCommentManager.commentListPanel',
+]);
+
+/**
+ * Web view state key edit-blockable web views read to know they are edit-blocked by an automatic
+ * sync.
+ */
 const IS_SYNC_BLOCKED_STATE_KEY = 'isSyncBlocked';
 
 /** True when a Scripture editor definition's project is in the blocked set. No project → never. */
@@ -100,7 +120,7 @@ function applyBlockedSetToAllEditors(blockedProjectIds: ReadonlySet<string>): bo
     return false;
   }
   definitions.forEach((definition) => {
-    if (definition.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE)
+    if (EDIT_BLOCKABLE_WEB_VIEW_TYPES.has(definition.webViewType))
       setEditorSyncBlocked(definition, isEditorBlocked(definition, blockedProjectIds));
   });
   return true;
@@ -136,7 +156,7 @@ export function initAutoSyncEditBlockDriver(): () => void {
   const setupHandlers = (blockedProjectIds: ReadonlySet<string>) => {
     const openUnsub = onDidOpenWebView(({ webView }) => {
       if (
-        webView.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE &&
+        EDIT_BLOCKABLE_WEB_VIEW_TYPES.has(webView.webViewType) &&
         isEditorBlocked(webView, blockedProjectIds)
       )
         setEditorSyncBlocked(webView, true);
@@ -147,7 +167,7 @@ export function initAutoSyncEditBlockDriver(): () => void {
     };
 
     const updateUnsub = onDidUpdateWebView(({ webView }) => {
-      if (webView.webViewType !== SCRIPTURE_EDITOR_WEBVIEW_TYPE) return;
+      if (!EDIT_BLOCKABLE_WEB_VIEW_TYPES.has(webView.webViewType)) return;
       // Only re-flag editors whose project is blocked; a rebuilt editor of a non-synced project must
       // stay editable.
       if (!isEditorBlocked(webView, blockedProjectIds)) return;

--- a/src/renderer/services/auto-sync-edit-block-driver.ts
+++ b/src/renderer/services/auto-sync-edit-block-driver.ts
@@ -1,25 +1,27 @@
 /**
  * Headless driver that translates the auto-sync-blocking store's visible blocked-project set into a
- * per-editor `isSyncBlocked` flag on the open Scripture editor web views whose project is syncing.
+ * per-web-view `isSyncBlocked` flag on the open edit-blockable web views whose project is syncing —
+ * the Scripture editor plus the legacy-comment-manager comment views (the editor-anchored comment
+ * list and the fixed Column 3 comment panel).
  *
  * This replaces the earlier full-workspace blocking overlay: instead of covering the whole
  * workspace and trapping focus, an automatic (scheduled or session) Send/Receive now blocks only
- * _editing_, and only of the projects actually being synced. The Scripture editor web view reads
+ * _editing_, and only of the projects actually being synced. Each edit-blockable web view reads
  * `isSyncBlocked` from its own web view state (via `useWebViewState`), folds it into its read-only
- * computation, and shows a slim non-covering banner — the rest of the UI (menus, dialogs,
- * navigation) and every editor of a project that is NOT syncing stays fully usable.
+ * computation, and shows a slim non-covering notice — the rest of the UI (menus, dialogs,
+ * navigation) and every web view of a project that is NOT syncing stays fully usable.
  *
- * An editor is flagged iff its `projectId` is in the store's blocked set; editors with no
+ * A web view is flagged iff its `projectId` is in the store's blocked set; web views with no
  * `projectId` are never flagged. The driver reacts to SET CHANGES (backend snapshots), not a
  * boolean raise/clear: on each store notification it re-applies the current blocked set to every
- * open editor. The store (see auto-sync-blocking-store.ts) provides the 200 ms show-grace, so this
- * driver just mirrors the store's derived visible set onto the editors.
+ * open web view. The store (see auto-sync-blocking-store.ts) provides the 200 ms show-grace, so
+ * this driver just mirrors the store's derived visible set onto the web views.
  *
- * While a set is blocking it also flags editors opened mid-block (via `onDidOpenWebView`) and
- * re-flags editors rebuilt mid-block (via `onDidUpdateWebView`) whose project is in the blocked set
- * — the Scripture editor factory forces `isSyncBlocked: false` on every rebuild (e.g.
- * `reloadWebView`, an interface-mode switch, or `loadLayout`), so without this a rebuild during a
- * sustained block would come back editable with the banner gone.
+ * While a set is blocking it also flags web views opened mid-block (via `onDidOpenWebView`) and
+ * re-flags web views rebuilt mid-block (via `onDidUpdateWebView`) whose project is in the blocked
+ * set — both the Scripture editor factory and the comment-view providers force `isSyncBlocked:
+ * false` on every rebuild (e.g. `reloadWebView`, an interface-mode switch, or `loadLayout`), so
+ * without this a rebuild during a sustained block would come back editable with the notice gone.
  */
 
 import { logger } from '@shared/services/logger.service';
@@ -62,8 +64,8 @@ const EDIT_BLOCKABLE_WEB_VIEW_TYPES: ReadonlySet<string> = new Set([
  */
 const IS_SYNC_BLOCKED_STATE_KEY = 'isSyncBlocked';
 
-/** True when a Scripture editor definition's project is in the blocked set. No project → never. */
-function isEditorBlocked(
+/** True when an edit-blockable web view's project is in the blocked set. No project → never. */
+function isWebViewBlocked(
   definition: SavedWebViewDefinition,
   blockedProjectIds: ReadonlySet<string>,
 ): boolean {
@@ -76,15 +78,15 @@ function isEditorBlocked(
 }
 
 /**
- * Sets `isSyncBlocked` on a single Scripture editor's saved definition, but only when it differs
- * from the current value — `updateWebViewDefinitionSync` always emits an update event when `state`
- * is present (it is compared by reference), so the equality guard keeps a no-op from rippling
- * through every editor's update subscribers.
+ * Sets `isSyncBlocked` on a single edit-blockable web view's saved definition, but only when it
+ * differs from the current value — `updateWebViewDefinitionSync` always emits an update event when
+ * `state` is present (it is compared by reference), so the equality guard keeps a no-op from
+ * rippling through every web view's update subscribers.
  */
-function setEditorSyncBlocked(definition: SavedWebViewDefinition, isBlocked: boolean): void {
+function setWebViewSyncBlocked(definition: SavedWebViewDefinition, isBlocked: boolean): void {
   const currentState = definition.state ?? {};
-  // Normalize a missing flag to false so init and unblock never write false onto an editor that is
-  // already (implicitly) unblocked.
+  // Normalize a missing flag to false so init and unblock never write false onto a web view that
+  // is already (implicitly) unblocked.
   if (Boolean(currentState[IS_SYNC_BLOCKED_STATE_KEY]) === isBlocked) return;
   try {
     updateWebViewDefinitionSync(definition.id, {
@@ -92,22 +94,23 @@ function setEditorSyncBlocked(definition: SavedWebViewDefinition, isBlocked: boo
     });
   } catch (e) {
     logger.warn(
-      `auto-sync edit-block driver failed to update editor ${definition.id}: ${getErrorMessage(e)}`,
+      `auto-sync edit-block driver failed to update web view ${definition.id}: ${getErrorMessage(e)}`,
     );
   }
 }
 
 /**
- * Applies the blocked set to every currently open Scripture editor: each editor whose project is in
- * the set is flagged, every other editor is unflagged. The per-editor equality guard turns this
- * into a diff — unchanged editors get no write (and thus emit no update event).
+ * Applies the blocked set to every currently open edit-blockable web view: each one whose project
+ * is in the set is flagged, every other is unflagged. The per-web-view equality guard turns this
+ * into a diff — unchanged web views get no write (and thus emit no update event).
  *
  * Returns `true` when the enumeration succeeded and the set was applied, `false` when
  * `getAllOpenWebViewDefinitionsSync` threw and nothing was applied. The caller uses this to avoid
- * recording a set it did not actually apply (see `syncState`): an open-but-unenumerable editor must
- * not be treated as flagged, or the equality guard would short-circuit and leave it unflagged.
+ * recording a set it did not actually apply (see `syncState`): an open-but-unenumerable web view
+ * must not be treated as flagged, or the equality guard would short-circuit and leave it
+ * unflagged.
  */
-function applyBlockedSetToAllEditors(blockedProjectIds: ReadonlySet<string>): boolean {
+function applyBlockedSetToAllWebViews(blockedProjectIds: ReadonlySet<string>): boolean {
   let definitions: SavedWebViewDefinition[];
   try {
     definitions = getAllOpenWebViewDefinitionsSync();
@@ -121,22 +124,22 @@ function applyBlockedSetToAllEditors(blockedProjectIds: ReadonlySet<string>): bo
   }
   definitions.forEach((definition) => {
     if (EDIT_BLOCKABLE_WEB_VIEW_TYPES.has(definition.webViewType))
-      setEditorSyncBlocked(definition, isEditorBlocked(definition, blockedProjectIds));
+      setWebViewSyncBlocked(definition, isWebViewBlocked(definition, blockedProjectIds));
   });
   return true;
 }
 
 /**
  * Starts the driver: mirrors the auto-sync-blocking store's visible blocked-project set onto every
- * open Scripture editor's `isSyncBlocked` state, and — while a set is blocking — onto editors
- * opened or rebuilt mid-block whose project is in the set. Call once at app startup. Returns a
- * cleanup function that stops the driver (it does NOT clear any flags it set; the store clearing to
- * empty is what unblocks the editors).
+ * open edit-blockable web view's `isSyncBlocked` state, and — while a set is blocking — onto web
+ * views opened or rebuilt mid-block whose project is in the set. Call once at app startup. Returns
+ * a cleanup function that stops the driver (it does NOT clear any flags it set; the store clearing
+ * to empty is what unblocks the web views).
  */
 export function initAutoSyncEditBlockDriver(): () => void {
   let unsubscribeOpen: (() => void) | undefined;
   let unsubscribeUpdate: (() => void) | undefined;
-  /** The blocked set we last applied to the editors; lets us skip a no-op notification. */
+  /** The blocked set we last applied to the web views; lets us skip a no-op notification. */
   let appliedBlockedProjectIds: ReadonlySet<string> = new Set();
 
   const teardownHandlers = () => {
@@ -157,9 +160,9 @@ export function initAutoSyncEditBlockDriver(): () => void {
     const openUnsub = onDidOpenWebView(({ webView }) => {
       if (
         EDIT_BLOCKABLE_WEB_VIEW_TYPES.has(webView.webViewType) &&
-        isEditorBlocked(webView, blockedProjectIds)
+        isWebViewBlocked(webView, blockedProjectIds)
       )
-        setEditorSyncBlocked(webView, true);
+        setWebViewSyncBlocked(webView, true);
     });
     // Wrapped because a network-event unsubscriber returns a boolean; keep our own type void.
     unsubscribeOpen = () => {
@@ -168,14 +171,14 @@ export function initAutoSyncEditBlockDriver(): () => void {
 
     const updateUnsub = onDidUpdateWebView(({ webView }) => {
       if (!EDIT_BLOCKABLE_WEB_VIEW_TYPES.has(webView.webViewType)) return;
-      // Only re-flag editors whose project is blocked; a rebuilt editor of a non-synced project must
-      // stay editable.
-      if (!isEditorBlocked(webView, blockedProjectIds)) return;
+      // Only re-flag web views whose project is blocked; a rebuilt web view of a non-synced project
+      // must stay editable.
+      if (!isWebViewBlocked(webView, blockedProjectIds)) return;
       // Guard against self-triggering: our own re-flag below calls updateWebViewDefinitionSync, which
       // fires another onDidUpdateWebView. Only act when the definition came back unblocked; once we
       // set it back to true the next event is a no-op, so this cannot loop.
       if (webView.state?.[IS_SYNC_BLOCKED_STATE_KEY]) return;
-      setEditorSyncBlocked(webView, true);
+      setWebViewSyncBlocked(webView, true);
     });
     unsubscribeUpdate = () => {
       updateUnsub();
@@ -185,7 +188,7 @@ export function initAutoSyncEditBlockDriver(): () => void {
   const syncState = () => {
     const next = getBlockedProjectIds();
     // No content change → nothing to do. This keeps overlapping identical notifications from
-    // needlessly rewriting editors or re-subscribing the handlers.
+    // needlessly rewriting web views or re-subscribing the handlers.
     if (deepEqual(appliedBlockedProjectIds, next)) return;
 
     // ORDERING IS LOAD-BEARING: tear the mid-block handlers down BEFORE applying the diff below.
@@ -193,20 +196,20 @@ export function initAutoSyncEditBlockDriver(): () => void {
     // blocked set, and `updateWebViewDefinitionSync` fires `onDidUpdateWebView` SYNCHRONOUSLY (the
     // buffered emitter and this subscription resolve to the same underlying PapiNetworkEventEmitter,
     // so a local emit dispatches inline, not on a later tick). A still-live re-flag handler would
-    // observe its own unflag write, pass its "came back unblocked" guard, and set the editor straight
-    // back to `true` — permanently blocking it. Tearing down first also drops handlers that closed
+    // observe its own unflag write, pass its "came back unblocked" guard, and set the web view
+    // straight back to `true` — permanently blocking it. Tearing down first also drops handlers that closed
     // over the STALE set, so the rebuild below re-subscribes over the new one. This is correct for
-    // PARTIAL transitions too: on {A,B} → {A}, B's editors unflag with no live handler to bounce
-    // them, A's editors keep their flag (the equality guard skips them), and the rebuilt {A} handlers
-    // still protect A.
+    // PARTIAL transitions too: on {A,B} → {A}, B's web views unflag with no live handler to bounce
+    // them, A's web views keep their flag (the equality guard skips them), and the rebuilt {A}
+    // handlers still protect A.
     teardownHandlers();
 
     // Only advance the applied-set snapshot when the apply actually succeeded. If enumeration threw
-    // (open-but-unenumerable editors), applyBlockedSetToAllEditors returns false having applied
+    // (open-but-unenumerable web views), applyBlockedSetToAllWebViews returns false having applied
     // nothing; recording `next` anyway would let the equality guard above short-circuit the next
-    // notification and leave those editors unflagged for the rest of this block. Leaving the snapshot
+    // notification and leave those web views unflagged for the rest of this block. Leaving the snapshot
     // unchanged lets the next real transition (or the open/update handlers) re-apply.
-    if (applyBlockedSetToAllEditors(next))
+    if (applyBlockedSetToAllWebViews(next))
       // Snapshot a copy so a later store reassignment can never alias what we think we applied.
       appliedBlockedProjectIds = new Set(next);
 


### PR DESCRIPTION
## What

Blocked-state UI reflection for the two project-data surfaces Rolf's 2026-07-16 E2E round showed
still interactive during a Send/Receive (defect 4): the **Comments panel** and **project
settings**. Both now visibly lock for exactly the project being synced, driven by the same
per-project backend signal as the scripture editor (base PR).

## Comments panel (legacy-comment-manager)

- The auto-sync edit-block driver now flags `legacyCommentManager.commentList` and
  `.commentListPanel` webviews alongside scripture editors (both carry definition-level
  `projectId`; verified). The lcm provider scrubs `isSyncBlocked: false` on rehydrate — mirror
  of the scripture-editor factory scrub, so a crash mid-block can never persist a read-only
  panel; the driver re-flags live ones.
- `comment-list.web-view.tsx`: when blocked, the four capability callbacks
  (add-to-thread / assign / resolve / edit-or-delete) are forced to deny — that's CommentList's
  real affordance-hiding mechanism, not cosmetic no-ops — and a slim notice renders
  ("Editing paused — Send/Receive in progress", en + es).
- Reactive backstop: the four write handlers catch ` (SR_EDIT_BLOCKED)` rejections via a
  per-extension copy of `sync-edit-blocked.util.ts` (platform-scripture precedent — no
  cross-extension imports) and show the friendly warning.
- Thread read/unread marking stays allowed — it's per-user state, deliberately not gated
  backend-side (see the PT-4210 Task 4 verdict).

## Project settings (core renderer)

- New `useIsProjectAutoSyncBlocked(projectId)` hook over the base PR's per-project store.
- The settings tab shows a single notice for the blocked project (deduped across setting
  groups after review) and `ProjectOrOtherSettingsList` passes `disabled` through
  `ProjectSetting` → `Setting` → Input/Switch. User/app settings are never affected. New key
  `%settings_projectSyncBlocked_notice%` (en + es).

## Verification

Full core TS suite 1038/0 (94 files); legacy-comment-manager suite 83/0 (8 files); full
extensions suite green. Gating and notice behavior is mutation-verified (capability-gate
inversion → 6 tests fail; dropped notice → 2 fail; duplicated tab notice → 1 fails). lcm
typecheck proven to cover the web-view file (deliberate error injection detected, then clean);
eslint/prettier/stylelint clean on all touched files. Ground-truth audited by a second agent plus
an adversarial finder→refuter review pass; both review findings (comments-side test gap, stacked
notices) fixed in `d63511d` / `649779b` (SHAs after the round-4 rebase).

## Notes

- Round 4 (2026-07-17): rebased onto the base PR's new tip (`756d33e`, central-registry event
  registration — no overlap with this diff). The round-4 E2E item “comments panel shows no
  visual blocked state” is already covered here (slim notice banner + capability-gated write
  affordances, which CommentList hides pre-emptively); a whole-panel gray-out was deliberately
  NOT added so reading, filtering, and read/unread marking stay usable during a sync.

- Stacked on the per-project block-signal PR; same runtime pairing caveat (signal fires once
  studio #164 arms the gate).
- ManageBooks / Inventory / Checks dialogs keep their existing reactive-only handling
  (self-catching helper from #2571); pre-emptive disabling for those is Stage U follow-on
  (PT-4214), same mechanism as here if wanted.

## Rebase note (2026-07-17) — re-seated on the rebased #2574

Rebased (zero conflicts) onto #2574's new tip `08d0d3d31ac`, which itself sits on #2571's
19-finding review-fix round. The only file shared with that round, `setting.component.tsx`,
merged cleanly: #2571's fix (the setter prop declares its real promise type and
`handleChangeSetting` awaits it, so write-gate rejections surface in the existing catch)
coexists with this branch's `disabled` forwarding. Post-rebase verification: settings/hook/services
suites 366 passed, legacy-comment-manager suite 83 passed, full typecheck clean (all workspaces),
stack linearity verified (#2571 → #2574 → #2575).


**Follow-up rebase (2026-07-17):** rebased onto `22081b9ad96` (papi.d.ts regen fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VkhEPs8ocAzX4117dtfWLA

## Self-review — 2026-07-17 (review-paratext methodology)

No Critical/Important defects; ready to merge (inert until studio #164 arms the gate). Four analysis passes (api / style / compliance / ux) per `.claude/agents/review-analyzer.md`, run by a review-lead agent; author interview substituted with the PR body + PRD design records; every finding adversarially verified against code and tests.

| # | severity | finding | disposition |
|---|----------|---------|--------------|
| 1 | minor | Cancel-affordance asymmetry: comments/settings notices are static text vs the Scripture editor's banner (progress + Cancel) | author-context: addressed (PR body — deliberate, avoids heavier panel treatment) |
| 2 | minor | hardcoded `width: 600px` in `.sync-blocked-notice` SCSS; `role="status"` may not announce when a panel opens mid-block | accepted (precedent-consistent, documented/low-risk) |
| 3 | minor | `auto-sync-edit-block-driver.ts` hard-codes the two lcm web-view type strings (core can't import from an extension) | accepted (precedent-consistent, documented duplication pattern) |
| 4 | minor | `legacy-comment-manager/localized-strings.test.ts` en/es parity test doesn't cover the 2 new sync-blocked strings | fixed in ebd5912 |
| 5 | minor | `setting.component.test.tsx` doesn't unit-test the object/array project-setting `disabled` path | fixed in ebd5912 |

Gates: legacy-comment-manager vitest 83/83, core-renderer targeted vitest 36/36 (5 files), prettier clean on all 23 changed files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2575)
<!-- Reviewable:end -->




