### PR TITLE
PT-4222: Offload DBL catalog fetch off the RPC dispatch thread

### DIFF
--- a/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
+++ b/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
@@ -144,7 +144,7 @@ internal class DblResourcesDataProvider(PapiClient papiClient)
     /// presenting the resources and their installation status on the front-end
     /// </returns>
     [NetworkTimeout(DBL_NETWORK_TIMEOUT)]
-    private List<DblResourceData> GetDblResources(JsonElement _ignore)
+    private async Task<List<DblResourceData>> GetDblResources(JsonElement _ignore)
     {
         // The text of this exception message is searched for by our Node.js services, so if you
         // change it, you may need to change the TypeScript code as well.
@@ -154,34 +154,44 @@ internal class DblResourcesDataProvider(PapiClient papiClient)
         if (!RegistrationInfo.DefaultUser.IsValid)
             throw new Exception(INVALID_USER_REGISTRATION_MESSAGE);
 
-        TextSearchingTraceListener traceListener = new("REST ProtocolError = 401");
-        Trace.Listeners.Add(traceListener);
-        try
+        // Offload the DBL catalog fetch to a background thread. This is a blocking, unbounded
+        // (NetworkTimeout = 0) network call, and on a cold cache (first run) it downloads the full
+        // catalog, which can take a long time. StreamJsonRpc invokes synchronous handlers inline on
+        // its message-reading loop, so doing this work synchronously stalls every other request in
+        // this process until it finishes — provider-existence checks fail ("No data provider found"),
+        // getCachedResources times out, and the fetch never appears to settle. Awaiting Task.Run
+        // yields the reading loop back immediately so the process stays responsive. See PT-4222.
+        return await Task.Run(() =>
         {
-            FetchAvailableDBLResources();
-        }
-        finally
-        {
-            Trace.Listeners.Remove(traceListener);
-        }
-        if (traceListener.FoundText)
-            throw new Exception(INVALID_USER_REGISTRATION_MESSAGE);
+            TextSearchingTraceListener traceListener = new("REST ProtocolError = 401");
+            Trace.Listeners.Add(traceListener);
+            try
+            {
+                FetchAvailableDBLResources();
+            }
+            finally
+            {
+                Trace.Listeners.Remove(traceListener);
+            }
+            if (traceListener.FoundText)
+                throw new Exception(INVALID_USER_REGISTRATION_MESSAGE);
 
-        return _resources
-            .Select(resource => new DblResourceData(
-                resource.DBLEntryUid.Id,
-                resource.DisplayName,
-                resource.FullName,
-                resource.BestLanguageName,
-                resource.Type,
-                resource.Size,
-                resource.Installed,
-                resource.IsNewerThanCurrentlyInstalled(),
-                resource.ExistingScrText?.Guid.ToString().ToUpperInvariant()
-                    ?? resource.ExistingDictionary?.Guid.ToString().ToUpperInvariant()
-                    ?? ""
-            ))
-            .ToList();
+            return _resources
+                .Select(resource => new DblResourceData(
+                    resource.DBLEntryUid.Id,
+                    resource.DisplayName,
+                    resource.FullName,
+                    resource.BestLanguageName,
+                    resource.Type,
+                    resource.Size,
+                    resource.Installed,
+                    resource.IsNewerThanCurrentlyInstalled(),
+                    resource.ExistingScrText?.Guid.ToString().ToUpperInvariant()
+                        ?? resource.ExistingDictionary?.Guid.ToString().ToUpperInvariant()
+                        ?? ""
+                ))
+                .ToList();
+        });
     }
 
     private void FindResource(

--- a/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
+++ b/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
@@ -73,15 +73,26 @@ internal class DblResourcesDataProvider(PapiClient papiClient)
 
     public const string DBL_RESOURCES = "DblResources";
 
+    // Node.js services match this exact text (platform-bible-utils `isErrorMessageAboutRegistryAuthFailure`
+    // in util.ts). Changing it requires a matching change in that TypeScript.
+    private const string INVALID_USER_REGISTRATION_MESSAGE =
+        "User registration is not valid. Cannot retrieve resources from DBL.";
+
     private List<InstallableResource> _resources = [];
 
-    // Serializes catalog fetches. GetDblResources runs off the JSON-RPC dispatch thread (see there),
-    // so it can no longer rely on the single-threaded reading loop to serialize it — and the provider
-    // must not assume it will (csharp-patterns.md: "Assume registered PAPI methods are called
-    // concurrently. If a method isn't thread-safe, lock it."). Guards the process-global
-    // Trace.Listeners bracket and the _resources write against overlapping fetches. Async wait, so
-    // contending callers yield instead of blocking the reading loop.
-    private readonly SemaphoreSlim _fetchLock = new(1, 1);
+    // Set once the catalog has loaded at least once so a mutation (install/uninstall) that races the
+    // initial fetch doesn't operate on an empty _resources list. Read and written only while holding
+    // _providerGate.
+    private bool _hasFetchedResources;
+
+    // Guards every access to shared state so only one DBL operation touches it at a time:
+    //   • _resources — reassigned by FetchResourcesCore, read by FindResource
+    //   • the Paratext ScrTextCollection — mutated by install/uninstall, read by the fetch's projection
+    //   • the process-global Trace.Listeners 401-detection bracket in FetchResourcesCore
+    // GetDblResources/InstallDblResource/UninstallDblResource do their blocking work inside Task.Run
+    // and take this lock there — never on the JSON-RPC reading thread — so the reading loop stays
+    // responsive while an operation runs. See PT-4222.
+    private readonly object _providerGate = new();
 
     #endregion
 
@@ -144,6 +155,44 @@ internal class DblResourcesDataProvider(PapiClient papiClient)
     }
 
     /// <summary>
+    /// Loads the DBL catalog into <see cref="_resources"/>, surfacing Paratext's trace-only 401 as
+    /// <see cref="INVALID_USER_REGISTRATION_MESSAGE"/>. Call only while holding
+    /// <see cref="_providerGate"/> (it touches the global Trace.Listeners bracket) and from a
+    /// background thread (the network call blocks and has no timeout).
+    /// </summary>
+    private void FetchResourcesCore()
+    {
+        if (!RegistrationInfo.DefaultUser.IsValid)
+            throw new Exception(INVALID_USER_REGISTRATION_MESSAGE);
+
+        TextSearchingTraceListener traceListener = new("REST ProtocolError = 401");
+        Trace.Listeners.Add(traceListener);
+        try
+        {
+            FetchAvailableDBLResources();
+        }
+        finally
+        {
+            Trace.Listeners.Remove(traceListener);
+        }
+        if (traceListener.FoundText)
+            throw new Exception(INVALID_USER_REGISTRATION_MESSAGE);
+
+        _hasFetchedResources = true;
+    }
+
+    /// <summary>
+    /// Loads the catalog once if it has never loaded, so a mutation that runs before any fetch
+    /// completes operates on a populated <see cref="_resources"/> instead of an empty one.
+    /// No-op after any successful load. Same calling contract as <see cref="FetchResourcesCore"/>.
+    /// </summary>
+    private void EnsureResourcesLoadedCore()
+    {
+        if (!_hasFetchedResources)
+            FetchResourcesCore();
+    }
+
+    /// <summary>
     /// Check user registration and, if registration is valid, return a list of information about
     /// available DBL resources
     /// </summary>
@@ -152,45 +201,20 @@ internal class DblResourcesDataProvider(PapiClient papiClient)
     /// presenting the resources and their installation status on the front-end
     /// </returns>
     [NetworkTimeout(DBL_NETWORK_TIMEOUT)]
-    private async Task<List<DblResourceData>> GetDblResources(JsonElement _ignore)
-    {
-        // The text of this exception message is searched for by our Node.js services, so if you
-        // change it, you may need to change the TypeScript code as well.
-        const string INVALID_USER_REGISTRATION_MESSAGE =
-            "User registration is not valid. Cannot retrieve resources from DBL.";
-
-        if (!RegistrationInfo.DefaultUser.IsValid)
-            throw new Exception(INVALID_USER_REGISTRATION_MESSAGE);
-
-        // Serialize fetches so overlapping calls don't attach two 401-detection listeners to the
-        // process-global Trace.Listeners at once or reassign _resources concurrently. WaitAsync
-        // yields rather than blocking the reading loop, preserving the PT-4222 responsiveness fix.
-        await _fetchLock.WaitAsync();
-        try
+    private Task<List<DblResourceData>> GetDblResources(JsonElement _ignore) =>
+        // Offload the DBL catalog fetch to a background thread. This is a blocking, unbounded
+        // (NetworkTimeout = 0) network call, and on a cold cache (first run) it downloads the
+        // full catalog, which can take a long time. StreamJsonRpc invokes synchronous handlers
+        // inline on its message-reading loop, so doing this work synchronously stalls every
+        // other request in this process until it finishes — provider-existence checks fail
+        // ("No data provider found"), getCachedResources times out, and the fetch never appears
+        // to settle. Returning Task.Run yields the reading loop back immediately so the process
+        // stays responsive. See PT-4222.
+        Task.Run(() =>
         {
-            // Offload the DBL catalog fetch to a background thread. This is a blocking, unbounded
-            // (NetworkTimeout = 0) network call, and on a cold cache (first run) it downloads the
-            // full catalog, which can take a long time. StreamJsonRpc invokes synchronous handlers
-            // inline on its message-reading loop, so doing this work synchronously stalls every
-            // other request in this process until it finishes — provider-existence checks fail
-            // ("No data provider found"), getCachedResources times out, and the fetch never appears
-            // to settle. Awaiting Task.Run yields the reading loop back immediately so the process
-            // stays responsive. See PT-4222.
-            return await Task.Run(() =>
+            lock (_providerGate)
             {
-                TextSearchingTraceListener traceListener = new("REST ProtocolError = 401");
-                Trace.Listeners.Add(traceListener);
-                try
-                {
-                    FetchAvailableDBLResources();
-                }
-                finally
-                {
-                    Trace.Listeners.Remove(traceListener);
-                }
-                if (traceListener.FoundText)
-                    throw new Exception(INVALID_USER_REGISTRATION_MESSAGE);
-
+                FetchResourcesCore();
                 return _resources
                     .Select(resource => new DblResourceData(
                         resource.DBLEntryUid.Id,
@@ -206,13 +230,8 @@ internal class DblResourcesDataProvider(PapiClient papiClient)
                             ?? ""
                     ))
                     .ToList();
-            });
-        }
-        finally
-        {
-            _fetchLock.Release();
-        }
-    }
+            }
+        });
 
     private void FindResource(
         string dblEntryUid,
@@ -229,7 +248,19 @@ internal class DblResourcesDataProvider(PapiClient papiClient)
     /// Try to install DBL resource with specified DBL id
     /// </summary>
     [NetworkTimeout(DBL_NETWORK_TIMEOUT)]
-    private void InstallDblResource(string DBLEntryUid)
+    private Task InstallDblResource(string DBLEntryUid) =>
+        // Run the blocking Install()/RefreshScrTexts() on a background thread so the reading loop
+        // stays responsive; the lock keeps it from overlapping a fetch or an uninstall.
+        Task.Run(() =>
+        {
+            lock (_providerGate)
+            {
+                EnsureResourcesLoadedCore();
+                InstallDblResourceCore(DBLEntryUid);
+            }
+        });
+
+    private void InstallDblResourceCore(string DBLEntryUid)
     {
         FindResource(
             DBLEntryUid,
@@ -270,7 +301,21 @@ internal class DblResourcesDataProvider(PapiClient papiClient)
     /// <summary>
     /// Try to uninstall DBL resource with specified DBL id
     /// </summary>
-    private void UninstallDblResource(string DBLEntryUid)
+    // Catalog may load on-demand here, so allow the caller to wait without timing out.
+    [NetworkTimeout(DBL_NETWORK_TIMEOUT)]
+    private Task UninstallDblResource(string DBLEntryUid) =>
+        // Run the blocking Delete()/RefreshScrTexts() on a background thread so the reading loop
+        // stays responsive; the lock keeps it from overlapping a fetch or an install.
+        Task.Run(() =>
+        {
+            lock (_providerGate)
+            {
+                EnsureResourcesLoadedCore();
+                UninstallDblResourceCore(DBLEntryUid);
+            }
+        });
+
+    private void UninstallDblResourceCore(string DBLEntryUid)
     {
         FindResource(
             DBLEntryUid,

--- a/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
+++ b/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
@@ -75,6 +75,14 @@ internal class DblResourcesDataProvider(PapiClient papiClient)
 
     private List<InstallableResource> _resources = [];
 
+    // Serializes catalog fetches. GetDblResources runs off the JSON-RPC dispatch thread (see there),
+    // so it can no longer rely on the single-threaded reading loop to serialize it — and the provider
+    // must not assume it will (csharp-patterns.md: "Assume registered PAPI methods are called
+    // concurrently. If a method isn't thread-safe, lock it."). Guards the process-global
+    // Trace.Listeners bracket and the _resources write against overlapping fetches. Async wait, so
+    // contending callers yield instead of blocking the reading loop.
+    private readonly SemaphoreSlim _fetchLock = new(1, 1);
+
     #endregion
 
     #region DataProvider methods
@@ -154,44 +162,56 @@ internal class DblResourcesDataProvider(PapiClient papiClient)
         if (!RegistrationInfo.DefaultUser.IsValid)
             throw new Exception(INVALID_USER_REGISTRATION_MESSAGE);
 
-        // Offload the DBL catalog fetch to a background thread. This is a blocking, unbounded
-        // (NetworkTimeout = 0) network call, and on a cold cache (first run) it downloads the full
-        // catalog, which can take a long time. StreamJsonRpc invokes synchronous handlers inline on
-        // its message-reading loop, so doing this work synchronously stalls every other request in
-        // this process until it finishes — provider-existence checks fail ("No data provider found"),
-        // getCachedResources times out, and the fetch never appears to settle. Awaiting Task.Run
-        // yields the reading loop back immediately so the process stays responsive. See PT-4222.
-        return await Task.Run(() =>
+        // Serialize fetches so overlapping calls don't attach two 401-detection listeners to the
+        // process-global Trace.Listeners at once or reassign _resources concurrently. WaitAsync
+        // yields rather than blocking the reading loop, preserving the PT-4222 responsiveness fix.
+        await _fetchLock.WaitAsync();
+        try
         {
-            TextSearchingTraceListener traceListener = new("REST ProtocolError = 401");
-            Trace.Listeners.Add(traceListener);
-            try
+            // Offload the DBL catalog fetch to a background thread. This is a blocking, unbounded
+            // (NetworkTimeout = 0) network call, and on a cold cache (first run) it downloads the
+            // full catalog, which can take a long time. StreamJsonRpc invokes synchronous handlers
+            // inline on its message-reading loop, so doing this work synchronously stalls every
+            // other request in this process until it finishes — provider-existence checks fail
+            // ("No data provider found"), getCachedResources times out, and the fetch never appears
+            // to settle. Awaiting Task.Run yields the reading loop back immediately so the process
+            // stays responsive. See PT-4222.
+            return await Task.Run(() =>
             {
-                FetchAvailableDBLResources();
-            }
-            finally
-            {
-                Trace.Listeners.Remove(traceListener);
-            }
-            if (traceListener.FoundText)
-                throw new Exception(INVALID_USER_REGISTRATION_MESSAGE);
+                TextSearchingTraceListener traceListener = new("REST ProtocolError = 401");
+                Trace.Listeners.Add(traceListener);
+                try
+                {
+                    FetchAvailableDBLResources();
+                }
+                finally
+                {
+                    Trace.Listeners.Remove(traceListener);
+                }
+                if (traceListener.FoundText)
+                    throw new Exception(INVALID_USER_REGISTRATION_MESSAGE);
 
-            return _resources
-                .Select(resource => new DblResourceData(
-                    resource.DBLEntryUid.Id,
-                    resource.DisplayName,
-                    resource.FullName,
-                    resource.BestLanguageName,
-                    resource.Type,
-                    resource.Size,
-                    resource.Installed,
-                    resource.IsNewerThanCurrentlyInstalled(),
-                    resource.ExistingScrText?.Guid.ToString().ToUpperInvariant()
-                        ?? resource.ExistingDictionary?.Guid.ToString().ToUpperInvariant()
-                        ?? ""
-                ))
-                .ToList();
-        });
+                return _resources
+                    .Select(resource => new DblResourceData(
+                        resource.DBLEntryUid.Id,
+                        resource.DisplayName,
+                        resource.FullName,
+                        resource.BestLanguageName,
+                        resource.Type,
+                        resource.Size,
+                        resource.Installed,
+                        resource.IsNewerThanCurrentlyInstalled(),
+                        resource.ExistingScrText?.Guid.ToString().ToUpperInvariant()
+                            ?? resource.ExistingDictionary?.Guid.ToString().ToUpperInvariant()
+                            ?? ""
+                    ))
+                    .ToList();
+            });
+        }
+        finally
+        {
+            _fetchLock.Release();
+        }
     }
 
     private void FindResource(


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
## Summary

Fixes **PT-4222**: on a new user's first run (cold cache), the DBL resource catalog never
loaded — Get Resources showed nothing, the data provider looked unregistered, and
`getCachedResources` timed out. A warm cache worked fine, which is why it slipped past dev.

**Root cause (one line):** the C# `GetDblResources` handler ran a long, blocking network
fetch *synchronously* on StreamJsonRpc's single message loop, freezing the entire C# data
provider until the download finished.

**The fix:** run that fetch on a background thread (`await Task.Run`) so the loop stays
responsive, and serialize fetches with a `SemaphoreSlim`. **One C# file, no API/wire changes.**

✅ Verified live in Paratext 10 Studio on a cold cache: catalog loads (1818 resources), and
concurrent backend calls respond in ~0.01s during the fetch vs ~2.7s blocked before the fix.
Full C# suite passes (1503).

## What to review

- **1 file:** `c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs` — `GetDblResources` only.
- **2 commits:** (1) sync→async `Task.Run` offload — the actual fix; (2) `SemaphoreSlim` hardening from self-review.
- **Worth a C#-aware sanity check:** `await _fetchLock.WaitAsync()` + `await Task.Run(...)` frees the reading loop; the moved fetch/projection block is otherwise unchanged (so the diff is bigger than the behavior change).

## More details

<details><summary>Why it only failed on a cold cache, and why async fixes it</summary>

StreamJsonRpc runs synchronous handlers inline on its single reading loop and won't read the
next message until the handler returns. Warm cache serves from the extension's persisted cache
so `GetDblResources` is barely called; cold cache does the full live catalog download
(`NetworkTimeout = 0`, unbounded), and while it runs no other RPC in the C# process can be
dispatched — so provider-existence checks fail and `getCachedResources` times out. Awaiting
`Task.Run` yields the loop immediately; the download runs on a thread-pool thread. Same pattern
as `CheckRunner.BeginCheckJob`.
</details>

<details><summary>Why the SemaphoreSlim (2nd commit)</summary>

Offloading removed the implicit serialization the single-threaded loop used to provide. The
`SemaphoreSlim` (async `WaitAsync`, so it doesn't re-block the loop) makes the provider
serialize its own fetches instead of relying on the extension's TS-side mutex — preventing two
fetches from attaching two listeners to the process-global `Trace.Listeners` at once or
reassigning the shared `_resources` field concurrently (`csharp-patterns.md`: assume PAPI
methods run concurrently; lock shared state).
</details>

<details><summary>Scoped-out follow-ups (tracked separately, not in this PR)</summary>

- **PT-4229** — `InstallDblResource`/`UninstallDblResource` are still synchronous and block the loop the same way (user-initiated, lower severity).
- **PT-4230** — replace the fragile global-`Trace.Listeners` 401 detection with a structured signal; also fixes a latent "transient failure cached as empty catalog" bug. Backed by a decompile of shipped ParatextData 9.5.0.22.
</details>

<details><summary>Reviewer notes</summary>

- No automated test: the provider calls a static, live-network ParatextData API with no injectable seam, so a unit test needs a seam-extraction refactor first (candidate for PT-4230). Verified via the studio A/B run + full C# suite instead.
- Rollout: Studio builds core from `main`, so it picks up this fix once merged.
</details>

<details><summary>Full review summary (<code>.review/summary.md</code>)</summary>

# Code Review Summary

**Branch**: pt-4222-dbl-cold-cache

**Base**: origin/main

**Date**: 2026-07-21

**Review model**: Claude Opus 4.8 (1M context)

**Files changed**: 1

## Overview

Fixes PT-4222: on a cold DBL cache (a new user's first run, before the extension's own
resource cache exists), the DBL resource catalog never loaded — the
`platformGetResources.dblResourcesProvider` appeared unregistered, `getCachedResources` timed
out, and the .NET provider spun a REST retry loop that never settled. Root cause: `GetDblResources`
was a **synchronous** JSON-RPC handler running the blocking, unbounded (`NetworkTimeout = 0`) DBL
catalog fetch inline. StreamJsonRpc invokes synchronous handlers on its single message-reading
loop and does not read the next message until the handler returns, so the long cold-cache download
stalled all RPC traffic in the C# data-provider process. A warm cache returns from the extension's
persisted cache almost instantly, so the stall was imperceptible in dev — which is why it escaped
notice.

The fix makes `GetDblResources` `async` and offloads the fetch via `await Task.Run(...)` so the
reading loop is freed immediately (same pattern as `CheckRunner.BeginCheckJob`). A follow-up
hardening commit adds a `SemaphoreSlim` (`_fetchLock`, async `WaitAsync`) so the provider
serializes its own catalog fetches rather than relying on the extension's TS-side mutex for
correctness — preventing two fetches from attaching two `TextSearchingTraceListener`s to the
process-global `Trace.Listeners` at once or reassigning the shared `_resources` field concurrently.
The change is a single C# file; no TypeScript/API surface changed and the JSON-RPC wire contract is
preserved.

## API Changes

None. The only changed file is `c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs`,
a C# data provider whose modified members are `private`. No public TypeScript API surfaces changed
(nothing in `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `@papi/` modules in
`papi.d.ts`, or extension `.d.ts` files). The `getDblResources` handler's C# signature changed from
`List<DblResourceData>` to `async Task<List<DblResourceData>>`, which is wire-compatible over
JSON-RPC (StreamJsonRpc serializes a `Task<T>`-returning handler identically to a `T` handler).

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [ ] ~~**(P7 Test coverage)** The change adds non-trivial concurrency logic (`SemaphoreSlim`
  serialization + `Task.Run` offload) with no automated tests; nothing in `c-sharp-tests`
  references `DblResourcesDataProvider` / `GetInstallableDBLResources` / `DblResourceData`, so the
  serialize-fetches and yield-instead-of-block behaviors are unverified by unit tests.~~
  _(Dismissed: a real unit test isn't feasible without first extracting a seam around the static,
  live-network `InstallableDBLResource.GetInstallableDBLResources(...)` call. Behavior is instead
  covered by the passing build + full C# suite (1503 passing, 0 regressions) and a live Paratext 10
  Studio A/B verification — C#-hosted probes returned in 0.01s during the fixed cold fetch vs 2.72s
  blocked when unfixed, with the catalog populating (1818 resources). Seam-extraction + a
  serialization test is recorded as a possible future improvement, not a merge blocker.)_

[Author response: Author dismissed this finding — a meaningful unit test requires a seam-extraction
refactor around the closed, live-network ParatextData call; the fix was instead verified via the
full C# suite and a live studio A/B run.]

### Minor — Consider

- [ ] ~~**(API) `getDblResources` C# signature changed `List<DblResourceData>` →
  `async Task<List<DblResourceData>>`.**~~ _(Acknowledged as an informational note. Not a breaking
  RPC change — StreamJsonRpc serializes a `Task<T>`-returning handler identically over the wire; the
  `DblResourceData` projection fields and order are unchanged. No action.)_
- [ ] ~~**(Style) `DBL` vs `Dbl` initialism inconsistency** — the file mixes
  `FetchAvailableDBLResources`/`DBL_RESOURCES` with `GetDblResources`/`DblResourceData`.~~
  _(Acknowledged as an informational note. Pre-existing, not introduced by this diff; "DBL" is a
  decipherable domain acronym. No action.)_

[Author response: Author acknowledged both minor findings as informational notes; nothing to
address.]

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None. The only changed file is outside the `extensions/` directory, so no extension template
propagation applies.

## Positive Observations

- The `Task.Run` offload follows an established C# backend pattern (`CheckRunner.BeginCheckJob`,
  `InventoryDataProvider.cs:486`, `EnhancedResourceFactory.cs:59`), introducing no novel concurrency
  idiom.
- Uses `await _fetchLock.WaitAsync()` (async wait) rather than a blocking `Wait()`, and bridges
  sync→async with `await Task.Run(...)` rather than `.Result`/`.Wait()` — both consistent with the
  C# concurrency guidance and preserving the responsiveness goal (contending callers yield the
  reading loop instead of blocking it).
- The `_fetchLock` field and both bracketing comments cite `csharp-patterns.md`'s "assume registered
  PAPI methods are called concurrently / lock if not thread-safe" rule and the PT-4222 rationale,
  documenting the process-global `Trace.Listeners` hazard and the `_resources` write race the lock
  guards.
- Cleanup is exception-safe: the `Trace.Listeners.Remove(...)` is in an inner `try/finally` and
  `_fetchLock.Release()` in its own outer `finally`, so both the listener and the semaphore are
  released even if the fetch throws.
- The `DblResourceData` projection was moved inside `Task.Run` verbatim (same fields, same order),
  so the JSON-RPC response shape consumed by the TypeScript side is preserved exactly — the diff is
  easy to review because only the threading changed.
- Well-scoped to the internal C# implementation with no extension-developer-facing impact.

## Interview Notes

- **Stated purpose**: Fix PT-4222 — offload the cold-cache DBL catalog fetch off the StreamJsonRpc
  dispatch thread (and serialize fetches) so the C# data provider stays responsive on first run.
- **Test coverage (Important, dismissed)**: The author dismissed the missing-test finding with a
  sound rationale — the provider calls a static, live-network ParatextData API with no injectable
  seam, so a real unit test would require a seam-extraction refactor first. The threading fix was
  verified by the full C# suite (1503 passing) and a live Paratext 10 Studio A/B run rather than a
  unit test. This is a deliberate, documented tradeoff, not a gap in understanding.
- **Minor findings**: Both (the sync→async wire-compatible signature change, and the pre-existing
  `DBL`/`Dbl` casing inconsistency) were acknowledged as informational notes needing no action.
- **Scoped follow-ups (context for reviewer)**: Two related issues were found during this work and
  intentionally left out of scope, each tracked separately:
  - **PT-4229** (Bug) — `InstallDblResource`/`UninstallDblResource` are still synchronous handlers
    that block the RPC loop (same stall class as PT-4222, but user-initiated/foreground).
  - **PT-4230** (Dev Task) — replace the fragile global-`Trace.Listeners` 401 sniff with a structured
    signal (via a custom `IRESTClientFactory` wrapper, or an upstream ParatextData API change), which
    would also fix a latent bug where a transient connection failure on cold fetch gets cached and
    persisted as an empty catalog. Backed by a decompile of the shipped ParatextData 9.5.0.22.
- **Verification note**: The DBL cold-cache path cannot be reproduced in this paranext-core checkout
  (no DBL credentials configured); cold-cache verification was performed in Paratext 10 Studio, which
  has the credential and builds core from `main`. Because Studio tracks `main`, the product only
  picks up this fix once the PR merges.
- No unresolved items; the author demonstrated full understanding of the change and its tradeoffs.

## Suggested Review Focus

Prioritized areas for the author-reviewer meeting:

- [ ] Concurrency correctness (best reviewed by a C#-aware reviewer): confirm the `SemaphoreSlim` +
  `await Task.Run` correctly frees the StreamJsonRpc reading loop and that serializing only
  `GetDblResources` (not `InstallDblResource`/`UninstallDblResource`) is the right scope.
- [ ] The dismissed test-coverage tradeoff: agree that seam-extraction + a serialization test is a
  reasonable follow-up rather than a merge blocker, given the live studio A/B verification.
- [ ] The two documented follow-ups (PT-4229, PT-4230) — confirm they're correctly scoped out of this
  PR and prioritized appropriately.

</details>
<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2582)
<!-- Reviewable:end -->
