### PR TITLE
docs: reconcile Kbd/KbdGroup keyboard-shortcut rendering guidance

### DIFF
--- a/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
@@ -61,35 +61,12 @@ The `KbdGroup` is only needed when a shortcut combines **more than one key**. A 
 The per-OS separator carries over from the string conventions above: **macOS** places its symbols adjacent with no separator, while **Windows** and **Linux** put a literal `+` between keys, rendered as a plain `<span>` between the `Kbd` boxes (per the [shadcn Kbd docs](https://ui.shadcn.com/docs/components/base/kbd)).
 
 <ExampleBlockGroup>
-  <ExampleBlock variant="avoid" preview={<Kbd>Ctrl+Z</Kbd>} code={`<Kbd>{isMac ? '⌘Z' : 'Ctrl+Z'}</Kbd>`}>
+  <ExampleBlock variant="avoid" preview={<Kbd>Ctrl+Z</Kbd>} code="<Kbd>Ctrl+Z</Kbd>">
     The whole combination is stuffed into one <code>Kbd</code>, so it renders as a single keycap
-    with the separator baked into text. Individual keys can't be spaced or styled as keycaps.
+    with the separator baked into the text. Individual keys can't be spaced or styled as keycaps.
   </ExampleBlock>
 
-  <ExampleBlock
-    variant="prefer"
-    preview={
-<KbdGroup>
-<Kbd>Ctrl</Kbd>
-<span>+</span>
-<Kbd>Z</Kbd>
-</KbdGroup>
-}
-    code={`<KbdGroup>
-{isMac ? (
-<>
-  <Kbd>⌘</Kbd>
-  <Kbd>Z</Kbd>
-</>
-) : (
-<>
-  <Kbd>Ctrl</Kbd>
-  <span>+</span>
-  <Kbd>Z</Kbd>
-</>
-)}
-</KbdGroup>`}
-  >
+  <ExampleBlock variant="prefer" preview={<KbdGroup><Kbd>Ctrl</Kbd><span>+</span><Kbd>Z</Kbd></KbdGroup>} code="<KbdGroup><Kbd>Ctrl</Kbd><span>+</span><Kbd>Z</Kbd></KbdGroup>">
     One <code>Kbd</code> per key inside a <code>KbdGroup</code>: macOS symbols sit adjacent,
     Windows/Linux get a <code>+</code> separator as a plain <code>span</code>.
   </ExampleBlock>

--- a/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx
@@ -1,4 +1,6 @@
 import { Meta } from '@storybook/addon-docs/blocks';
+import { Kbd, KbdGroup } from '@/components/shadcn-ui/kbd';
+import { ExampleBlock, ExampleBlockGroup } from '@/storybook/example-block.component';
 
 <Meta title="Guidelines/Keyboard shortcuts" />
 
@@ -8,37 +10,43 @@ When displaying a keyboard shortcut in the UI, write it the way the user's opera
 
 For the catalog of which shortcuts the application actually uses (and where in code), see **Reference → Keyboard shortcuts** in the main Platform.Bible Storybook.
 
+For background on keyboard shortcuts as *accelerators* — what they are for, when they help, and the vocabulary around them — see [Nielsen Norman Group: UI Accelerators](https://www.nngroup.com/articles/ui-accelerators/).
+
 The conventions to know:
 
 - **macOS** uses **symbols** for modifier and special keys, written together with no separator (e.g. `⇧⌘Z`). Modifier order is Control, Option, Shift, Command ([Apple HIG](https://developer.apple.com/design/human-interface-guidelines/keyboards)).
 - **Windows** uses **words** joined with `+` (e.g. `Ctrl+Shift+Z`). Modifier order is Ctrl, Shift, Alt ([Microsoft](https://support.microsoft.com/en-us/windows/keyboard-shortcuts-in-windows-dcc61a57-8ff0-cffe-9796-cb9706c75eec)).
 - **Linux** uses **words** joined with `+`. Modifier order varies by desktop environment; on GNOME and Ubuntu, the typical order is Ctrl, Alt, Shift ([Ubuntu](https://help.ubuntu.com/stable/ubuntu-help/shell-keyboard-shortcuts.html.en) / [GNOME HIG](https://developer.gnome.org/hig/guidelines/keyboard.html)).
 
-For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, parentheses vs. no parentheses), see [Design Principles → Keyboard shortcuts in tooltips](./design-principles.mdx).
+For rendering shortcuts in the UI (the `Kbd` component, parentheses vs. no parentheses), see [Tooltips → Keyboard shortcuts in tooltips](./tooltips.mdx).
+
+> **Heads up:** Throughout this codebase and its docs, a lowercase `<kbd>` written in prose or pseudocode is often just shorthand for the `Kbd` React component, not the raw HTML `<kbd>` element. `Kbd` renders an HTML `<kbd>` under the hood, so the two are easy to conflate — unless the context is specifically about raw HTML, read `<kbd>` as the `Kbd` component.
 
 ---
 
 ## Preferred representations by OS
 
-| Key             | macOS              | Windows           | Linux             |
-| --------------- | ------------------ | ----------------- | ----------------- |
-| Command         | `⌘`                | — (no equivalent) | — (no equivalent) |
-| Windows / Super | — (no equivalent)  | `Win` or `⊞`      | `Super`           |
-| Option / Alt    | `⌥`                | `Alt`             | `Alt`             |
-| Control         | `⌃`                | `Ctrl`            | `Ctrl`            |
-| Shift           | `⇧`                | `Shift`           | `Shift`           |
-| Caps Lock       | `⇪`                | `Caps Lock`       | `Caps Lock`       |
-| Tab             | `⇥`                | `Tab`             | `Tab`             |
-| Return / Enter  | `⏎` (or `Return`)  | `Enter`           | `Enter`           |
-| Backspace       | `⌫` (or `Delete`)  | `Backspace`       | `Backspace`       |
-| Forward Delete  | `⌦`                | `Delete`          | `Delete`          |
-| Escape          | `⎋` (or `Esc`)     | `Esc`             | `Esc`             |
-| Space           | `Space` (or `␣`)   | `Space`           | `Space`           |
-| Arrow keys      | `↑` `↓` `←` `→`    | `↑` `↓` `←` `→`   | `↑` `↓` `←` `→`   |
-| Page Up / Down  | `⇞` / `⇟`          | `Page Up` / `Page Down` | `Page Up` / `Page Down` |
-| Home / End      | `↖` / `↘`          | `Home` / `End`    | `Home` / `End`    |
+| Key             | macOS             | Windows                 | Linux                   |
+| --------------- | ----------------- | ----------------------- | ----------------------- |
+| Command         | `⌘`               | — (no equivalent)       | — (no equivalent)       |
+| Windows / Super | — (no equivalent) | `Win` or `⊞`            | `Super`                 |
+| Option / Alt    | `⌥`               | `Alt`                   | `Alt`                   |
+| Control         | `⌃`               | `Ctrl`                  | `Ctrl`                  |
+| Shift           | `⇧`               | `Shift`                 | `Shift`                 |
+| Caps Lock       | `⇪`               | `Caps Lock`             | `Caps Lock`             |
+| Tab             | `⇥`               | `Tab`                   | `Tab`                   |
+| Return / Enter  | `⏎` (or `Return`) | `Enter`                 | `Enter`                 |
+| Backspace       | `⌫` (or `Delete`) | `Backspace`             | `Backspace`             |
+| Forward Delete  | `⌦`               | `Delete`                | `Delete`                |
+| Escape          | `⎋` (or `Esc`)    | `Esc`                   | `Esc`                   |
+| Space           | `Space` (or `␣`)  | `Space`                 | `Space`                 |
+| Arrow keys      | `↑` `↓` `←` `→`   | `↑` `↓` `←` `→`         | `↑` `↓` `←` `→`         |
+| Page Up / Down  | `⇞` / `⇟`         | `Page Up` / `Page Down` | `Page Up` / `Page Down` |
+| Home / End      | `↖` / `↘`         | `Home` / `End`          | `Home` / `End`          |
 
 ## Combining keys
+
+These rules describe the **plain-text string** form of a combination — what you write in a menu accelerator, a plain-text hint, or the `src/stories/keyboard-shortcuts.data.ts` catalog. When you render a shortcut in React UI, do **not** emit this joined string into a single `Kbd`; put each key in its own `Kbd` inside a `KbdGroup` (see [Detecting the platform](#detecting-the-platform) below). The per-OS symbol/word choice and modifier order still apply to each key either way.
 
 - **macOS:** concatenate the symbols with no separator and no spaces. Order: Control, Option, Shift, Command, then the key. Example: `⌃⌥⇧⌘T`.
 - **Windows:** join with `+` and no spaces. Order: Ctrl, Shift, Alt, then the key. Example: `Ctrl+Shift+T`.
@@ -46,13 +54,46 @@ For rendering shortcuts in the UI (the `<kbd>` element, the `Kbd` component, par
 
 ## Detecting the platform
 
-For shortcuts rendered at runtime, branch on the user's OS rather than hardcoding one convention:
+For shortcuts rendered at runtime, branch on the user's OS rather than hardcoding one convention. Render **one `Kbd` per key inside a `KbdGroup`** — never a single `Kbd` wrapping the whole combination — matching [Keyboard shortcuts in tooltips](./tooltips.mdx).
 
-```tsx
-import { Kbd } from 'platform-bible-react';
+The `KbdGroup` is only needed when a shortcut combines **more than one key**. A single-key shortcut — for example, `\` to open the marker menu — is just a naked `Kbd` with no group.
 
-<Kbd>{isMac ? '⌘Z' : 'Ctrl+Z'}</Kbd>
-```
+The per-OS separator carries over from the string conventions above: **macOS** places its symbols adjacent with no separator, while **Windows** and **Linux** put a literal `+` between keys, rendered as a plain `<span>` between the `Kbd` boxes (per the [shadcn Kbd docs](https://ui.shadcn.com/docs/components/base/kbd)).
+
+<ExampleBlockGroup>
+  <ExampleBlock variant="avoid" preview={<Kbd>Ctrl+Z</Kbd>} code={`<Kbd>{isMac ? '⌘Z' : 'Ctrl+Z'}</Kbd>`}>
+    The whole combination is stuffed into one <code>Kbd</code>, so it renders as a single keycap
+    with the separator baked into text. Individual keys can't be spaced or styled as keycaps.
+  </ExampleBlock>
+
+  <ExampleBlock
+    variant="prefer"
+    preview={
+<KbdGroup>
+<Kbd>Ctrl</Kbd>
+<span>+</span>
+<Kbd>Z</Kbd>
+</KbdGroup>
+}
+    code={`<KbdGroup>
+{isMac ? (
+<>
+  <Kbd>⌘</Kbd>
+  <Kbd>Z</Kbd>
+</>
+) : (
+<>
+  <Kbd>Ctrl</Kbd>
+  <span>+</span>
+  <Kbd>Z</Kbd>
+</>
+)}
+</KbdGroup>`}
+  >
+    One <code>Kbd</code> per key inside a <code>KbdGroup</code>: macOS symbols sit adjacent,
+    Windows/Linux get a <code>+</code> separator as a plain <code>span</code>.
+  </ExampleBlock>
+</ExampleBlockGroup>
 
 ## Why this matters
 


### PR DESCRIPTION
## Summary

The **Guidelines → Keyboard shortcuts** and **Guidelines → Tooltips** Storybook pages (both in `lib/platform-bible-react/src/stories/guidelines/`) disagreed on how to render a keyboard shortcut with the `Kbd` component:

- **Tooltips** (and the [shadcn Kbd docs](https://ui.shadcn.com/docs/components/base/kbd)) put **one `<Kbd>` per key inside a `<KbdGroup>`**.
- **Keyboard shortcuts** wrapped the whole combination in a **single `<Kbd>`**.

This surfaced from a Discord question about whether to use `Kbd` in menus/tooltips; the two articles gave conflicting answers. This PR makes Keyboard shortcuts consistent with Tooltips (docs-only, no component code changed).

## Changes

All in `lib/platform-bible-react/src/stories/guidelines/keyboard-shortcuts.mdx`:

- Convert the **"Detecting the platform"** code block into a prefer/avoid `ExampleBlock` pair with live previews — single-`Kbd` anti-pattern vs. one `Kbd` per key in a `KbdGroup`.
- Render the per-OS separator explicitly: macOS symbols sit adjacent (no separator); Windows/Linux get a literal `+` as a plain `<span>` between `Kbd` boxes, per the shadcn Kbd docs.
- Add nuance: `KbdGroup` is only needed for **multi-key** combinations. A single-key shortcut (e.g. `\` to open the marker menu) is a naked `Kbd` with no group.
- Clarify that the "Combining keys" string rules describe the **plain-text** form (menu accelerators, the `keyboard-shortcuts.data.ts` catalog), not the rendered-component form.
- Fix a stale cross-reference: it pointed at `design-principles.mdx`, but the "Keyboard shortcuts in tooltips" section now lives in `tooltips.mdx`.
- Add a heads-up that a lowercase `<kbd>` in prose/pseudocode is usually shorthand for the `Kbd` component.
- Cite [NN/g: UI Accelerators](https://www.nngroup.com/articles/ui-accelerators/) for background on shortcuts-as-accelerators and their vocabulary.

## AI Involvement

AI-assisted (Claude Code): drafted the MDX edits and the prefer/avoid example blocks, verified the rendered output in the platform-bible-react Storybook, and ran remark formatting. Reviewed by the author.

## Testing

- [x] `remark` MDX format check clean
- [x] Verified the rendered page (prefer/avoid blocks and per-OS keycaps) in the platform-bible-react Storybook
- [ ] No runtime/component code changed

## Risk Level

Low — documentation only; no shipped component or app behavior changes.

## Note for reviewers

These guideline pages are UX-team-owned (`lib/platform-bible-react/src/stories/guidelines/`), so this is for UX-team review per `.claude/rules/where-to-add-guidance.md`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2583)
<!-- Reviewable:end -->
