### PR TITLE
PT-4084: Show translator-comment annotations in the scripture editor

### DIFF
--- a/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
@@ -268,3 +268,20 @@ button {
     background-color: currentColor;
   }
 }
+
+// Translator Comment annotations (PT-4804): editor-typed-mark-external-translator-comment
+// comes from ANNOTATION_TYPE_TRANSLATOR_COMMENT in platform-scripture-editor.web-view.tsx.
+// _editor.scss (upstream mirror) has no rule for it, so inserted comments rendered with
+// no visible marking. Styled as a dashed underline (matching Paratext 9) rather than a
+// persistent background highlight so it stays legible against the .verse-selected highlight.
+// On hover, a background tint and solid border give a clearer, transient affordance that
+// it's clickable, without competing with the current-verse highlight the rest of the time.
+.editor-typed-mark-external-translator-comment {
+  border-bottom: 1px dashed var(--muted-foreground);
+  cursor: pointer;
+}
+
+.editor-typed-mark-external-translator-comment:hover {
+  background-color: var(--accent);
+  border-bottom: 2px solid var(--foreground);
+}

--- a/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
@@ -269,8 +269,8 @@ button {
   }
 }
 
-// Translator Comment annotations (PT-4804): editor-typed-mark-external-translator-comment
-// comes from ANNOTATION_TYPE_TRANSLATOR_COMMENT in platform-scripture-editor.web-view.tsx.
+// Translator Comment annotations: editor-typed-mark-external-translator-comment comes
+// from ANNOTATION_TYPE_TRANSLATOR_COMMENT in platform-scripture-editor.web-view.tsx.
 // _editor.scss (upstream mirror) has no rule for it, so inserted comments rendered with
 // no visible marking. Styled as a dashed underline (matching Paratext 9) rather than a
 // persistent background highlight, so it stays visually distinct from whatever other

--- a/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
@@ -273,15 +273,16 @@ button {
 // comes from ANNOTATION_TYPE_TRANSLATOR_COMMENT in platform-scripture-editor.web-view.tsx.
 // _editor.scss (upstream mirror) has no rule for it, so inserted comments rendered with
 // no visible marking. Styled as a dashed underline (matching Paratext 9) rather than a
-// persistent background highlight so it stays legible against the .verse-selected highlight.
-// On hover, a background tint and solid border give a clearer, transient affordance that
-// it's clickable, without competing with the current-verse highlight the rest of the time.
+// persistent background highlight, so it stays visually distinct from whatever other
+// highlight (selection, verse markers, etc.) might be applied at the same time. On hover, a
+// background tint and solid underline give a clearer, transient affordance that it's clickable.
 .editor-typed-mark-external-translator-comment {
   border-bottom: 1px dashed var(--muted-foreground);
   cursor: pointer;
-}
 
-.editor-typed-mark-external-translator-comment:hover {
-  background-color: var(--accent);
-  border-bottom: 2px solid var(--foreground);
+  &:hover {
+    background-color: var(--accent);
+    color: var(--accent-foreground);
+    border-bottom: 2px solid var(--foreground);
+  }
 }


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-4804-comment-annotation-styling

**Base**: origin/main

**Date**: 2026-07-21

**Review model**: Claude Sonnet 5

**Files changed**: 1

## Overview

Translator-comment annotations (created via "Insert comment at selection" in the main Scripture editor) were rendering with no visible marking once inserted. Root cause: the editor applies the CSS class `editor-typed-mark-external-translator-comment` to these annotations (derived from `ANNOTATION_TYPE_TRANSLATOR_COMMENT` in `platform-scripture-editor.web-view.tsx`), but `_editor.scss` — a verbatim mirror of the upstream `scripture-editors` package's stylesheet — has no rule for it. A styled copy existed only in the unrelated Enhanced Resources pane, which isn't where comments are created.

The fix adds the missing rule to `_editor-overrides.scss` (the file `_editor.scss` itself designates for local additions), styling the annotation as a 1px dashed `var(--muted-foreground)` underline — matching Paratext 9's treatment for this concept — rather than a persistent background highlight, so it stays visually distinct from whatever other highlight might be applied at the same time. A hover state (`var(--accent)` background, `var(--accent-foreground)` text, solid 2px `var(--foreground)` border) gives a clearer, transient affordance that the annotation is clickable (it opens/selects the comment thread via existing PT-4204 wiring).

## API Changes

None. The only changed file is `extensions/src/platform-scripture-editor/src/_editor-overrides.scss`, a stylesheet not part of any public API surface.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [x] **`:hover` written as a separate top-level selector instead of nested `&:hover`, inconsistent with this file's own convention (e.g. `.Button__root`, `.CommentPlugin_AddCommentBox_button`)** _(fixed during review: nested `&:hover` inside the base `.editor-typed-mark-external-translator-comment` rule)_
- [x] **Hover rule set `background-color: var(--accent)` without pairing `color: var(--accent-foreground)`, per the documented semantic-pairing convention and this file's own `.toolbar-item:hover` pattern** _(fixed during review: added `color: var(--accent-foreground);` to the hover state)_
- [x] **Design-rationale comment cited `.verse-selected` as the highlight being avoided, but that class is actually the transient Backspace/Delete-confirmation marker (PT-4020), not an ongoing "current verse" indicator — the premise didn't hold** _(fixed during review: reworded to the general intent — stay visually distinct from whatever other highlight, e.g. selection or verse markers, might be applied at the same time — without citing a specific, incorrect class)_
- [ ] **The dashed underline is visually hidden when a native text selection covers it** (`::selection`'s background paints over the `border-bottom`). Raised by the author during interview, not by automated analysis. Not fixed in this PR: `::selection` cannot style `border-bottom` (browsers only permit `color`/`background-color`/`text-decoration-*` on it), so a real fix would mean switching the base style from `border-bottom` to `text-decoration-line`/`text-decoration-style: dashed`, a larger change needing visual verification before landing. Author considers the current behavior acceptable for now; filed as a follow-up.

Author accepted the nesting and color-pairing fixes as straightforward, corrected the rationale comment's premise once the discrepancy was pointed out, and made a deliberate call to defer the selection-visibility follow-up rather than risk an unverified change.

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None. — the changed file is a WebView source stylesheet, not a config/build file.

## Positive Observations

- The inline comment is unusually thorough for a CSS change: it cites the ticket (PT-4804), names the exact constant and source file the class name comes from, explains why the upstream-mirror file has no rule for it, and gives a real design rationale.
- Minimal, precisely scoped change — only the one selector needed to fix the described problem, no unrelated modifications bundled in.
- Uses theme CSS custom properties (`--muted-foreground`, `--accent`, `--accent-foreground`, `--foreground`) throughout rather than hardcoded colors, consistent with the rest of `_editor-overrides.scss` and in contrast with the hardcoded `rgba(255, 212, 0, ...)` values still used in the un-mirrored Enhanced Resources copy.
- Correctly added to `_editor-overrides.scss` (the designated local-changes file) rather than hand-editing the upstream-mirror `_editor.scss`.
- Verified no reuse violation against the existing `AnnotationStyleDataProviderEngine.registerAnnotationStyle()` mechanism — that path is for extension-registered custom annotation types at runtime; built-in types (spelling/grammar/other, and now translator-comment) are correctly styled statically, matching existing precedent.
- Choosing a dashed underline (vs. the wavy underline used for automated spelling/grammar/other checks) sensibly keeps a human-authored comment annotation visually distinct from automated-check annotations.
- `border-bottom` is direction-agnostic, so there's no RTL/bidi concern with this change.

## Interview Notes

Author's stated purpose: fix translator-comment annotations rendering with no visible marking in the main Scripture editor, per PT-4804.

The author drove several precise, well-reasoned design decisions across the session: matching Paratext 9's dashed-underline treatment instead of a background highlight (specifically to avoid competing with other highlights that might be present), choosing `--muted-foreground` over a `--warning` token because "comments might need attention, but they aren't warnings," and requesting an obvious hover affordance (background + bolder border) after finding the initial hover-only border-color change too subtle. No areas of author non-understanding were observed — explanations were specific and technically grounded throughout.

Two things worth surfacing to the reviewer:

1. The rationale comment initially cited the wrong CSS class (`.verse-selected`, the delete-confirmation marker) instead of the general concept the author actually meant (avoid clashing with "whatever other highlight might be applied"). This was caught by the UX analysis pass and corrected during the interview — a good example of the automated review catching a documentation-accuracy issue the author hadn't noticed.
2. After the two straightforward review fixes were applied, the author made a manual edit to the design comment and, in doing so, introduced a temporary mismatch (comment said "dashed" hover underline, CSS said "solid"). This was caught and the author corrected the comment's wording to "solid" — while noting they're not fully confident the UX team will agree with a solid border on hover, but preferred to at least make the current state internally consistent and revisit the visual design later if needed.

**Unresolved / deferred by author's explicit choice** (not a gap in understanding): the underline-hidden-under-selection issue described in Findings above. The author judged the current behavior acceptable and declined to pursue an unverified `text-decoration-line` rewrite within this PR.

## In-Review Quality Check

- **`npm run typecheck`** — PASS, clean across all workspaces.
- **`npm run lint`** — PASS, no errors introduced (2 pre-existing unrelated warnings in a different, untouched file).
- **Format (changed files only)** — no diff; the change was already prettier-conformant.
- **`npm test`** — 1041/1042 passed. One unrelated test (`tools/pt9-css-converter/src/convert.test.ts`, a prettier-conformance check for a different tool) timed out under full-suite parallel load; re-ran in isolation and it passed in 1541ms. Pre-existing flake, unrelated to this change — not fixed.

## Suggested Review Focus

- [ ] Confirm the hover treatment (solid 2px `border-bottom`, `--accent` background) is the desired final visual design — the author flagged uncertainty about whether this matches UX expectations.
- [ ] Underline-hidden-under-native-selection is a known, deliberately deferred limitation (see Findings) — confirm whether it's acceptable to ship as-is or should block merge.
- [ ] Visual appearance was only manually spot-checked in Simple mode during this session (light theme, then confirmed hover via DevTools forced-state); worth a quick pass in dark theme and Power mode before merge.
<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2584)
<!-- Reviewable:end -->
