### PR TITLE
PT-4233: Extract ResultChangeStatus from ResultStatus

### DIFF
--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -5,7 +5,10 @@
 //
 // Derived from
 // https://github.com/paranext/paratext-bible-internal-extensions/blob/b50ebb16505f8069fd517af39dea29de7d7569bb/src/paratext-bible-send-receive/src/types/paratext-bible-send-receive.d.ts
+// TODO(PT-4233): Update the SHA above to the companion PR's merged commit once it lands.
 // When the Send/Receive contract changes, re-sync the parts declared here from that file.
+// NOTE: Preserve any types that exist here but not in the upstream file (structural refinements
+// added in core before the upstream adopts them). Do not replace the module block wholesale.
 //
 // Why this lives in `src/@types` and not under an extension's `src/types`:
 //
@@ -35,6 +38,9 @@ declare module 'paratext-bible-send-receive' {
    *   administrator must upgrade it
    * - `projectVersionUpgraded` = S/R sort-of failed. The project was upgraded to a higher version of
    *   Paratext. You must update Paratext to open the project
+   *
+   * For granular detail about what was sent/received, see {@link ResultChangeStatus} and
+   * {@link ResultInfo.resultStatuses}.
    */
   export type ResultStatus =
     | 'succeeded'
@@ -45,8 +51,12 @@ declare module 'paratext-bible-send-receive' {
     | 'projectVersionUpgraded';
 
   /**
-   * Granular change-tracking status for a single S/R result. Multiple values can apply
-   * simultaneously (e.g., both `sentChanges` and `receivedChanges`).
+   * Granular change-tracking status for a single S/R result. Supplements (does not replace)
+   * {@link ResultStatus} on {@link ResultInfo.resultStatus}.
+   *
+   * Exactly one send-axis value applies (`sentChanges` or `noChangesToSend`) and exactly one
+   * receive-axis value applies (`receivedChanges` or `noChangesReceived`), so two values appear in
+   * {@link ResultInfo.resultStatuses} simultaneously when both axes are present.
    *
    * - `sentChanges` = S/R sent ≥1 non-merge revision
    * - `receivedChanges` = S/R received ≥1 revision (RevisionsReceived.Count > 0)
@@ -195,7 +205,7 @@ declare module 'paratext-bible-send-receive' {
     conflictsInfo: ConflictInfo[];
     /** Additional information provided in some cases when a S/R fails */
     failureMessage?: string;
-    /** Granular statuses that apply to this result (multiple can apply, e.g., sent AND received) */
+    /** Granular {@link ResultChangeStatus} statuses (multiple can apply, e.g., sent AND received) */
     resultStatuses?: ResultChangeStatus[];
     /** Total conflict count computed by C# */
     conflictCount?: number;

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -205,7 +205,10 @@ declare module 'paratext-bible-send-receive' {
     conflictsInfo: ConflictInfo[];
     /** Additional information provided in some cases when a S/R fails */
     failureMessage?: string;
-    /** Granular {@link ResultChangeStatus} statuses (multiple can apply, e.g., sent AND received) */
+    /**
+     * Granular change-tracking statuses ({@link ResultChangeStatus}); multiple can apply, e.g., sent
+     * AND received
+     */
     resultStatuses?: ResultChangeStatus[];
     /** Total conflict count computed by C# */
     conflictCount?: number;

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -35,10 +35,6 @@ declare module 'paratext-bible-send-receive' {
    *   administrator must upgrade it
    * - `projectVersionUpgraded` = S/R sort-of failed. The project was upgraded to a higher version of
    *   Paratext. You must update Paratext to open the project
-   * - `sentChanges` = S/R sent ≥1 non-merge revision
-   * - `receivedChanges` = S/R received ≥1 revision (RevisionsReceived.Count > 0)
-   * - `noChangesToSend` = S/R sent no non-merge revisions
-   * - `noChangesReceived` = S/R received no revisions (RevisionsReceived is empty)
    */
   export type ResultStatus =
     | 'succeeded'
@@ -46,7 +42,18 @@ declare module 'paratext-bible-send-receive' {
     | 'initialReceive'
     | 'failed'
     | 'notUpgraded'
-    | 'projectVersionUpgraded'
+    | 'projectVersionUpgraded';
+
+  /**
+   * Granular change-tracking status for a single S/R result. Multiple values can apply
+   * simultaneously (e.g., both `sentChanges` and `receivedChanges`).
+   *
+   * - `sentChanges` = S/R sent ≥1 non-merge revision
+   * - `receivedChanges` = S/R received ≥1 revision (RevisionsReceived.Count > 0)
+   * - `noChangesToSend` = S/R sent no non-merge revisions
+   * - `noChangesReceived` = S/R received no revisions (RevisionsReceived is empty)
+   */
+  export type ResultChangeStatus =
     | 'sentChanges'
     | 'receivedChanges'
     | 'noChangesToSend'
@@ -189,7 +196,7 @@ declare module 'paratext-bible-send-receive' {
     /** Additional information provided in some cases when a S/R fails */
     failureMessage?: string;
     /** Granular statuses that apply to this result (multiple can apply, e.g., sent AND received) */
-    resultStatuses?: ResultStatus[];
+    resultStatuses?: ResultChangeStatus[];
     /** Total conflict count computed by C# */
     conflictCount?: number;
   };


### PR DESCRIPTION
## What and why

`ResultStatus` was shared between two fields on `ResultInfo` that have non-overlapping value sets:

- `resultStatus` (singular) — overall S/R outcome: `succeeded`, `initialSend`, `initialReceive`, `failed`, `notUpgraded`, `projectVersionUpgraded`
- `resultStatuses` (plural) — granular change tracking: `sentChanges`, `receivedChanges`, `noChangesToSend`, `noChangesReceived`

These sets never overlap. Sharing a type was misleading (implied any value could appear in either field) and made the contract harder to understand. Flagged by TJ.

## What changed

**One file**: `src/@types/paratext-bible-send-receive/index.d.ts`

This is core's ambient copy of the type seam with the closed-source `paratext-bible-send-receive` extension — a `.d.ts` file that mirrors the authoritative declaration in `paratext-bible-internal-extensions`. No runtime code is touched.

- `ResultStatus` — 4 granular values removed; now contains only the 6 overall-outcome values
- `ResultChangeStatus` — new exported type containing the 4 extracted granular values, with JSDoc documenting the send-axis / receive-axis invariant
- `ResultInfo.resultStatuses` — field type narrowed from `ResultStatus[]` to `ResultChangeStatus[]`

## Companion PR

The authoritative declaration lives in `paratext-bible-internal-extensions`. Companion PR making the same change: https://github.com/paranext/paratext-bible-internal-extensions/pull/191

This PR can merge first — nothing in paranext-core consumes `resultStatuses` directly; the type error only surfaces in internal-extensions code. A `TODO(PT-4233)` in the file tracks updating the upstream SHA once the companion lands.

---

AI-assisted — [session 1](<session URL>)

Co-authored-by: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2587)
<!-- Reviewable:end -->
