### PR TITLE
PT-4223: Remove deprecated model text localization key

### DIFF
--- a/extensions/src/platform-scripture-editor/contributions/localizedStrings.json
+++ b/extensions/src/platform-scripture-editor/contributions/localizedStrings.json
@@ -12,12 +12,6 @@
     "%webView_platformScriptureEditor_switchScriptureView%": {
       "fallbackKey": "%Paratext.TextForm.nextViewToolStripMenuItem.Text%"
     },
-    "%webView_modelTextPanel_installing%": {
-      "deprecationInfo": {
-        "date": "2026-06-12",
-        "message": "The model text panel now uses the %webView_modelTextPanel_selecting%"
-      }
-    },
     "%webView_resourcePanel_installing%": {
       "deprecationInfo": {
         "date": "2026-06-12",
@@ -118,14 +112,13 @@
       "%webView_platformScriptureEditor_tools%": "Tools",
       "%webView_platformScriptureEditor_verseDelete_deleteSelection%": "Press {key} again to delete selection",
       "%webView_platformScriptureEditor_verseDelete_removeVerseMarker%": "Press {key} again to remove verse marker",
-      "%webView_modelTextPanel_installing%": "Installing resource…",
-      "%webView_modelTextPanel_selecting%": "Selecting resource…",
+      "%webView_modelTextPanel_emptyState_prompt%": "No model text selected. Pick one to display a reference translation alongside your project.",
       "%webView_modelTextPanel_noProject%": "No project selected.",
       "%webView_modelTextPanel_pickModelText%": "Pick model text…",
+      "%webView_modelTextPanel_selecting%": "Selecting resource…",
       "%webView_modelTextPanel_title%": "Model text",
       "%webView_modelTextPanel_title_withResource%": "Model text: {textName}",
       "%webView_modelTextPanel_unknownResource%": "The selected model text could not be found.",
-      "%webView_modelTextPanel_emptyState_prompt%": "No model text selected. Pick one to display a reference translation alongside your project.",
       "%webView_resourcePanel_bibleTexts_emptyState_prompt%": "No Bible texts selected. Pick one to display a reference translation alongside your project.",
       "%webView_resourcePanel_bibleTexts_pick%": "Pick Bible texts…",
       "%webView_resourcePanel_bibleTexts_title%": "Bible texts",
@@ -266,14 +259,13 @@
       "%webView_platformScriptureEditor_tools%": "Herramientas",
       "%webView_platformScriptureEditor_verseDelete_deleteSelection%": "Presione {key} de nuevo para eliminar la selección",
       "%webView_platformScriptureEditor_verseDelete_removeVerseMarker%": "Presione {key} de nuevo para quitar el marcador de versículo",
-      "%webView_modelTextPanel_installing%": "Instalando recurso…",
-      "%webView_modelTextPanel_selecting%": "Seleccionando recurso…",
+      "%webView_modelTextPanel_emptyState_prompt%": "Ningún texto modelo seleccionado. Elige uno para mostrar una traducción de referencia junto a tu proyecto.",
       "%webView_modelTextPanel_noProject%": "Ningún proyecto seleccionado.",
       "%webView_modelTextPanel_pickModelText%": "Elegir texto modelo…",
+      "%webView_modelTextPanel_selecting%": "Seleccionando recurso…",
       "%webView_modelTextPanel_title%": "Texto modelo",
       "%webView_modelTextPanel_title_withResource%": "Texto modelo: {textName}",
       "%webView_modelTextPanel_unknownResource%": "No se pudo encontrar el texto modelo seleccionado.",
-      "%webView_modelTextPanel_emptyState_prompt%": "Ningún texto modelo seleccionado. Elige uno para mostrar una traducción de referencia junto a tu proyecto.",
       "%webView_resourcePanel_bibleTexts_emptyState_prompt%": "Ningún texto bíblico seleccionado. Elige uno para mostrar una traducción de referencia junto a tu proyecto.",
       "%webView_resourcePanel_bibleTexts_pick%": "Elegir textos bíblicos…",
       "%webView_resourcePanel_bibleTexts_title%": "Textos bíblicos",

--- a/extensions/src/platform-scripture-editor/src/model-text-panel.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/model-text-panel.component.tsx
@@ -336,7 +336,7 @@ export function ModelTextPanel({
     );
   }
 
-  // Installing: resource found but not yet installed.
+  // Selecting: resource found but not yet installed.
   if (isSelecting) {
     return (
       <div className="tw:flex tw:h-screen tw:items-center tw:justify-center tw:gap-2 tw:p-8 tw:text-center">

--- a/extensions/src/platform-scripture-editor/src/model-text-panel.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/model-text-panel.component.tsx
@@ -35,8 +35,6 @@ const SCROLL_MAX_WAIT_MS = 2000;
  * prop.
  */
 export const MODEL_TEXT_PANEL_STRING_KEYS = Object.freeze([
-  /** @deprecated Use `%webView_modelTextPanel_selecting%` instead. */
-  '%webView_modelTextPanel_installing%',
   '%webView_modelTextPanel_selecting%',
   '%webView_modelTextPanel_noProject%',
   '%webView_modelTextPanel_pickModelText%',

--- a/extensions/src/platform-scripture-editor/src/model-text-panel.stories.tsx
+++ b/extensions/src/platform-scripture-editor/src/model-text-panel.stories.tsx
@@ -107,7 +107,7 @@ type DecoratorConfig = {
   hasProject?: boolean;
   /** Whether the user can write admin settings. */
   canWriteProjectSettings?: boolean;
-  /** Disable install so the Installing state is observable (otherwise it auto-completes). */
+  /** Disable install so the Selecting state is observable (otherwise it auto-completes). */
   disableInstall?: boolean;
 };
 
@@ -239,8 +239,8 @@ export const NoModelText: Story = {
   decorators: [createDecorator({})],
 };
 
-/** A configured resource that is still installing (install disabled so the state is observable). */
-export const Installing: Story = {
+/** A configured resource that is still being selected (install disabled so the state is observable). */
+export const Selecting: Story = {
   decorators: [createDecorator({ initialAdmin: [dblRef(seedResources[1])], disableInstall: true })],
 };
 


### PR DESCRIPTION
## Summary

`%webView_modelTextPanel_installing%` was deprecated in June when the model text panel renamed its "installing" state to "selecting." The render code was updated then, but the old key was left in the array that drives localization service requests — causing a repeated `[warn]` deprecation log on every panel load.

This PR removes the key and cleans up everything that referenced it. No functional changes.

## Files at a glance

| File | What changed |
|------|-------------|
| `model-text-panel.component.tsx` | Removed deprecated key from `MODEL_TEXT_PANEL_STRING_KEYS`; fixed stale `// Installing:` inline comment |
| `localizedStrings.json` | Removed the key's `deprecationInfo` metadata and `en`/`es` string values; corrected alphabetical ordering of `%webView_modelTextPanel_*` keys |
| `model-text-panel.stories.tsx` | Renamed stale `Installing` story export and docstring to `Selecting` |

The component already rendered `%webView_modelTextPanel_selecting%` in all code paths before this PR — this is purely removing the dead key from the request list.

<details>
<summary>More context</summary>

The resource panel went through the same cleanup correctly in June. This makes the model text panel consistent with it.

**Suggested follow-ups (out of scope here):**
- `%webView_resourcePanel_installing%` still has its deprecated metadata and string values in `localizedStrings.json`. The resource panel does not request it (no log noise), but the entries could be cleaned up similarly for consistency.
- The entire `%webView_modelTextPanel_*` block sits after `%webView_platformScriptureEditor_verseDelete_*` in the locale file (alphabetically `m` before `p`). Left out of scope — large line-shuffle with merge-conflict risk.
- The model text panel has no unit test coverage. A test asserting `MODEL_TEXT_PANEL_STRING_KEYS` contains no key that appears in `localizedStrings.json`'s `deprecationInfo` section would have caught this bug automatically.

</details>

---

<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-4223-fix-deprecated-model-text-localization-key

**Base**: origin/main

**Date**: 2026-07-22

**Review model**: Claude Sonnet 4.6

**Files changed**: 3

## Overview

This PR completes the deprecation cleanup for `%webView_modelTextPanel_installing%`, a localization key that was deprecated in the June commit (9c39c9e) when the model text panel's state was renamed from "installing" to "selecting." That commit correctly updated the component's render code and deprecated the old key with a `deprecationInfo` block in `localizedStrings.json`, but left the old key in the `MODEL_TEXT_PANEL_STRING_KEYS` array. Because that array feeds the localization service's string request on every panel load, the service logged a deprecation warning continuously — low-severity log noise with no functional impact.

The fix removes the deprecated key from `MODEL_TEXT_PANEL_STRING_KEYS`, removes its `deprecationInfo` metadata block and `en`/`es` string values from `localizedStrings.json`, corrects the alphabetical ordering of the remaining `%webView_modelTextPanel_*` keys in both locale blocks, updates the stale `Installing` Storybook story export and its docstrings to `Selecting`, and fixes a stale inline comment in the component. The resource panel went through this same cleanup correctly in June; this PR makes the model text panel consistent with it.

## API Changes

None. All changed files are internal to the `platform-scripture-editor` extension (`localizedStrings.json`, `model-text-panel.component.tsx`, `model-text-panel.stories.tsx`). No public API surfaces in `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `lib/papi-dts/papi.d.ts`, or extension type declaration files were touched.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [x] **`model-text-panel.component.tsx:339` — Stale inline comment** _(fixed during review: updated `// Installing: resource found but not yet installed.` to `// Selecting: resource found but not yet installed.` to match the renamed state variable, localized string key, and Storybook story)_

[All findings were addressed during the review.]

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None. All changed files are extension-specific application code, not shared build infrastructure.

## Positive Observations

- The deprecated key is fully removed with zero remaining references — verified by repo-wide grep. The cleanup is complete.
- The deprecation lifecycle was followed correctly: deprecate → migrate render code → clean up key registry and JSON. The model text panel now matches the treatment the resource panel received in June.
- The alphabetical reordering of `%webView_modelTextPanel_*` keys in both `en` and `es` locale blocks (`emptyState_prompt`, `noProject`, `pickModelText`, `selecting`, `title`, `title_withResource`, `unknownResource`) is consistent between the two locales.
- Removing the deprecated key from the `as const` array narrows the `ModelTextPanelLocalizedStringKey` type — a pure improvement that prevents callers from accidentally passing the old key.
- The `Selecting` Storybook story correctly uses `disableInstall: true` to hold the state observable; the rename does not affect that behavior.
- Correct ellipsis character (U+2026) used in all loading-state strings, consistent with the project ellipsis convention.
- The `MODEL_TEXT_PANEL_STRING_KEYS` array remains complete and consistent with the five keys actually rendered in the component's JSX paths.

## Interview Notes

**Stated purpose**: Fix the deprecated model text localization key.

**Author context**: The change was self-contained and the author had no additional tradeoffs or uncertainties to flag. The analysis found no critical or important issues. The one minor finding (stale inline comment) was fixed during the review at the author's request.

**No unresolved items.**

## In-Review Quality Check

One change was made during the review (stale inline comment fix in `model-text-panel.component.tsx`).

- **Typecheck**: Pre-existing failures only — `src/main/main.ts`, `app.service-host.ts` (missing build artifact `buildInfo.json`), `first-run-overlay.component.tsx` (PT-4175 type gap), `hello-rock3` and other extensions (worktree path resolution duplicates). None in any file touched by this PR.
- **Lint**: Full pipeline fails at `build:types` due to missing `@types/jest`/`@types/node` in the worktree's `lib/papi-dts` — known pre-existing worktree issue. Targeted ESLint on the changed file: **clean (exit 0)**.
- **Prettier**: No formatting changes needed (`model-text-panel.component.tsx` unchanged by prettier).
- **Tests (platform-scripture-editor workspace)**: **542/542 passed**. Four pre-existing timeouts in unrelated files — none related to this change.

No failures caused by the in-review change.

## Suggested Review Focus

- [ ] Confirm the deprecation cleanup is complete — the parallel `%webView_resourcePanel_installing%` key still has its `deprecationInfo` metadata and string values in `localizedStrings.json` (the resource panel was already fixed in June). Is it worth removing those as a follow-up, or leave them as a tombstone?
- [ ] The `%webView_modelTextPanel_*` key block sits after the `%webView_platformScriptureEditor_verseDelete_*` keys in the locale file, even though `m` comes before `p` alphabetically. This predates this PR and was intentionally left out of scope to avoid a large line-shuffle with merge-conflict risk — flag as a follow-up cleanup if the team wants full ordering.
- [ ] The model text panel component has no unit test coverage. A test asserting that `MODEL_TEXT_PANEL_STRING_KEYS` contains no key that also appears in `localizedStrings.json`'s `metadata.deprecationInfo` section would have caught this bug automatically. Consider adding as a follow-up.
<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2588)
<!-- Reviewable:end -->
