### PR TITLE
PT-4224: Remove racy startup registration prompt from paratext-registration

### DIFF
--- a/extensions/src/paratext-registration/contributions/localizedStrings.json
+++ b/extensions/src/paratext-registration/contributions/localizedStrings.json
@@ -62,14 +62,38 @@
         "message": "Changed the value of this locale to just be \"Paratext Registration\". The new key is %paratextRegistration_webView_title_2%.",
         "date": "2025-09-15"
       }
+    },
+    "%settings_paratextRegistration_registration_internet_group_description%": {
+      "deprecationInfo": {
+        "message": "Removed in PT-4224 when the paratextRegistration.shouldShowOnStartup setting was removed. The startup registration prompt this settings group described is now handled by the first-run gating overlay (PT-4175).",
+        "date": "2026-07-22"
+      }
+    },
+    "%settings_paratextRegistration_registration_internet_group_label%": {
+      "deprecationInfo": {
+        "message": "Removed in PT-4224 when the paratextRegistration.shouldShowOnStartup setting was removed. The startup registration prompt this settings group labeled is now handled by the first-run gating overlay (PT-4175).",
+        "date": "2026-07-22"
+      }
+    },
+    "%settings_paratextRegistration_shouldShowOnStartup_description%": {
+      "deprecationInfo": {
+        "message": "Removed in PT-4224. The paratextRegistration.shouldShowOnStartup setting was removed because the startup registration prompt it controlled is now handled by the first-run gating overlay (PT-4175).",
+        "date": "2026-07-22"
+      }
+    },
+    "%settings_paratextRegistration_shouldShowOnStartup_label%": {
+      "deprecationInfo": {
+        "message": "Removed in PT-4224. The paratextRegistration.shouldShowOnStartup setting was removed because the startup registration prompt it controlled is now handled by the first-run gating overlay (PT-4175).",
+        "date": "2026-07-22"
+      }
     }
   },
   "localizedStrings": {
     "en": {
       "%internetSettings_webView_title%": "Internet Settings",
       "%internetSettings_webView_tooltip%": "Enter your Paratext Registration Internet Settings into this form.",
-      "%mainMenu_openInternetSettings%": "Internet Settings...",
-      "%mainMenu_openParatextRegistration%": "Paratext Registration Information...",
+      "%mainMenu_openInternetSettings%": "Internet Settings…",
+      "%mainMenu_openParatextRegistration%": "Paratext Registration Information…",
       "%paratextRegistration_alert_invalidRegistration%": "Registration information not found",
       "%paratextRegistration_alert_invalidRegistration_description%": "Check to make sure that the registration name and code you received are accurately entered here.",
       "%paratextRegistration_alert_unchangedRegistration%": "Unchanged registration information",
@@ -120,17 +144,13 @@
       "%paratextRegistration_webView_title_2%": "Paratext Registration",
       "%paratextRegistration_webView_tooltip%": "Enter your Paratext Registration Information into this form.",
       "%paratextRegistrationProfile_webView_title%": "Account",
-      "%paratextRegistrationProfile_webView_tooltip%": "Adjust your Paratext Registration Account Information here.",
-      "%settings_paratextRegistration_registration_internet_group_description%": "Settings related to the user's Paratext Registry connection and some Internet access controls",
-      "%settings_paratextRegistration_registration_internet_group_label%": "Registration and Internet",
-      "%settings_paratextRegistration_shouldShowOnStartup_description%": "Whether to show the form to enter Paratext Registration information when the application starts if it has not been entered previously",
-      "%settings_paratextRegistration_shouldShowOnStartup_label%": "Show “Paratext Registration Information” on startup"
+      "%paratextRegistrationProfile_webView_tooltip%": "Adjust your Paratext Registration Account Information here."
     },
     "es": {
       "%internetSettings_webView_title%": "Configuración de Internet",
       "%internetSettings_webView_tooltip%": "Ingrese su configuración de Internet de Registro de Paratext en este formulario.",
-      "%mainMenu_openInternetSettings%": "Configuración de Internet...",
-      "%mainMenu_openParatextRegistration%": "Información de Registro Paratext...",
+      "%mainMenu_openInternetSettings%": "Configuración de Internet…",
+      "%mainMenu_openParatextRegistration%": "Información de Registro Paratext…",
       "%paratextRegistration_alert_invalidRegistration%": "Información de registro no encontrada",
       "%paratextRegistration_alert_invalidRegistration_description%": "Verifique que el nombre y el código de registro que recibió estén ingresados correctamente aquí.",
       "%paratextRegistration_alert_unchangedRegistration%": "Información de registro sin cambios",
@@ -177,11 +197,7 @@
       "%paratextRegistration_webView_title_2%": "Registro de Paratext",
       "%paratextRegistration_webView_tooltip%": "Ingrese su información de Registro de Paratext en este formulario.",
       "%paratextRegistrationProfile_webView_title%": "Cuenta",
-      "%paratextRegistrationProfile_webView_tooltip%": "Ajuste aquí la información de su cuenta de Registro de Paratext.",
-      "%settings_paratextRegistration_registration_internet_group_description%": "Configuraciones relacionadas con la conexión del Registro de Paratext del usuario y algunos controles de acceso a Internet",
-      "%settings_paratextRegistration_registration_internet_group_label%": "Registro de Paratext y Configuración de Internet",
-      "%settings_paratextRegistration_shouldShowOnStartup_description%": "Mostrar el formulario de Registro de Paratext al iniciar si aún no ha ingresado sus credenciales",
-      "%settings_paratextRegistration_shouldShowOnStartup_label%": "Mostrar “Información de Registro de Paratext” al iniciar"
+      "%paratextRegistrationProfile_webView_tooltip%": "Ajuste aquí la información de su cuenta de Registro de Paratext."
     }
   }
 }

--- a/extensions/src/paratext-registration/contributions/localizedStrings.json
+++ b/extensions/src/paratext-registration/contributions/localizedStrings.json
@@ -65,25 +65,25 @@
     },
     "%settings_paratextRegistration_registration_internet_group_description%": {
       "deprecationInfo": {
-        "message": "The startup registration prompt settings group was removed. Registration is now handled by the first-run gating overlay.",
+        "message": "Removed when the paratextRegistration.shouldShowOnStartup setting was removed.",
         "date": "2026-07-22"
       }
     },
     "%settings_paratextRegistration_registration_internet_group_label%": {
       "deprecationInfo": {
-        "message": "The startup registration prompt settings group was removed. Registration is now handled by the first-run gating overlay.",
+        "message": "Removed when the paratextRegistration.shouldShowOnStartup setting was removed.",
         "date": "2026-07-22"
       }
     },
     "%settings_paratextRegistration_shouldShowOnStartup_description%": {
       "deprecationInfo": {
-        "message": "The paratextRegistration.shouldShowOnStartup setting was removed. The startup registration prompt it controlled is now handled by the first-run gating overlay.",
+        "message": "Removed when the paratextRegistration.shouldShowOnStartup setting was removed.",
         "date": "2026-07-22"
       }
     },
     "%settings_paratextRegistration_shouldShowOnStartup_label%": {
       "deprecationInfo": {
-        "message": "The paratextRegistration.shouldShowOnStartup setting was removed. The startup registration prompt it controlled is now handled by the first-run gating overlay.",
+        "message": "Removed when the paratextRegistration.shouldShowOnStartup setting was removed.",
         "date": "2026-07-22"
       }
     }

--- a/extensions/src/paratext-registration/contributions/localizedStrings.json
+++ b/extensions/src/paratext-registration/contributions/localizedStrings.json
@@ -65,25 +65,25 @@
     },
     "%settings_paratextRegistration_registration_internet_group_description%": {
       "deprecationInfo": {
-        "message": "Removed in PT-4224 when the paratextRegistration.shouldShowOnStartup setting was removed. The startup registration prompt this settings group described is now handled by the first-run gating overlay (PT-4175).",
+        "message": "The startup registration prompt settings group was removed. Registration is now handled by the first-run gating overlay.",
         "date": "2026-07-22"
       }
     },
     "%settings_paratextRegistration_registration_internet_group_label%": {
       "deprecationInfo": {
-        "message": "Removed in PT-4224 when the paratextRegistration.shouldShowOnStartup setting was removed. The startup registration prompt this settings group labeled is now handled by the first-run gating overlay (PT-4175).",
+        "message": "The startup registration prompt settings group was removed. Registration is now handled by the first-run gating overlay.",
         "date": "2026-07-22"
       }
     },
     "%settings_paratextRegistration_shouldShowOnStartup_description%": {
       "deprecationInfo": {
-        "message": "Removed in PT-4224. The paratextRegistration.shouldShowOnStartup setting was removed because the startup registration prompt it controlled is now handled by the first-run gating overlay (PT-4175).",
+        "message": "The paratextRegistration.shouldShowOnStartup setting was removed. The startup registration prompt it controlled is now handled by the first-run gating overlay.",
         "date": "2026-07-22"
       }
     },
     "%settings_paratextRegistration_shouldShowOnStartup_label%": {
       "deprecationInfo": {
-        "message": "Removed in PT-4224. The paratextRegistration.shouldShowOnStartup setting was removed because the startup registration prompt it controlled is now handled by the first-run gating overlay (PT-4175).",
+        "message": "The paratextRegistration.shouldShowOnStartup setting was removed. The startup registration prompt it controlled is now handled by the first-run gating overlay.",
         "date": "2026-07-22"
       }
     }
@@ -92,8 +92,8 @@
     "en": {
       "%internetSettings_webView_title%": "Internet Settings",
       "%internetSettings_webView_tooltip%": "Enter your Paratext Registration Internet Settings into this form.",
-      "%mainMenu_openInternetSettings%": "Internet Settings…",
-      "%mainMenu_openParatextRegistration%": "Paratext Registration Information…",
+      "%mainMenu_openInternetSettings%": "Internet Settings...",
+      "%mainMenu_openParatextRegistration%": "Paratext Registration Information...",
       "%paratextRegistration_alert_invalidRegistration%": "Registration information not found",
       "%paratextRegistration_alert_invalidRegistration_description%": "Check to make sure that the registration name and code you received are accurately entered here.",
       "%paratextRegistration_alert_unchangedRegistration%": "Unchanged registration information",
@@ -144,13 +144,17 @@
       "%paratextRegistration_webView_title_2%": "Paratext Registration",
       "%paratextRegistration_webView_tooltip%": "Enter your Paratext Registration Information into this form.",
       "%paratextRegistrationProfile_webView_title%": "Account",
-      "%paratextRegistrationProfile_webView_tooltip%": "Adjust your Paratext Registration Account Information here."
+      "%paratextRegistrationProfile_webView_tooltip%": "Adjust your Paratext Registration Account Information here.",
+      "%settings_paratextRegistration_registration_internet_group_description%": "Settings related to the user's Paratext Registry connection and some Internet access controls",
+      "%settings_paratextRegistration_registration_internet_group_label%": "Registration and Internet",
+      "%settings_paratextRegistration_shouldShowOnStartup_description%": "Whether to show the form to enter Paratext Registration information when the application starts if it has not been entered previously",
+      "%settings_paratextRegistration_shouldShowOnStartup_label%": "Show “Paratext Registration Information” on startup"
     },
     "es": {
       "%internetSettings_webView_title%": "Configuración de Internet",
       "%internetSettings_webView_tooltip%": "Ingrese su configuración de Internet de Registro de Paratext en este formulario.",
-      "%mainMenu_openInternetSettings%": "Configuración de Internet…",
-      "%mainMenu_openParatextRegistration%": "Información de Registro Paratext…",
+      "%mainMenu_openInternetSettings%": "Configuración de Internet...",
+      "%mainMenu_openParatextRegistration%": "Información de Registro Paratext...",
       "%paratextRegistration_alert_invalidRegistration%": "Información de registro no encontrada",
       "%paratextRegistration_alert_invalidRegistration_description%": "Verifique que el nombre y el código de registro que recibió estén ingresados correctamente aquí.",
       "%paratextRegistration_alert_unchangedRegistration%": "Información de registro sin cambios",
@@ -197,7 +201,11 @@
       "%paratextRegistration_webView_title_2%": "Registro de Paratext",
       "%paratextRegistration_webView_tooltip%": "Ingrese su información de Registro de Paratext en este formulario.",
       "%paratextRegistrationProfile_webView_title%": "Cuenta",
-      "%paratextRegistrationProfile_webView_tooltip%": "Ajuste aquí la información de su cuenta de Registro de Paratext."
+      "%paratextRegistrationProfile_webView_tooltip%": "Ajuste aquí la información de su cuenta de Registro de Paratext.",
+      "%settings_paratextRegistration_registration_internet_group_description%": "Configuraciones relacionadas con la conexión del Registro de Paratext del usuario y algunos controles de acceso a Internet",
+      "%settings_paratextRegistration_registration_internet_group_label%": "Registro de Paratext y Configuración de Internet",
+      "%settings_paratextRegistration_shouldShowOnStartup_description%": "Mostrar el formulario de Registro de Paratext al iniciar si aún no ha ingresado sus credenciales",
+      "%settings_paratextRegistration_shouldShowOnStartup_label%": "Mostrar “Información de Registro de Paratext” al iniciar"
     }
   }
 }

--- a/extensions/src/paratext-registration/contributions/settings.json
+++ b/extensions/src/paratext-registration/contributions/settings.json
@@ -1,13 +1,1 @@
-[
-  {
-    "label": "%settings_paratextRegistration_registration_internet_group_label%",
-    "description": "%settings_paratextRegistration_registration_internet_group_description%",
-    "properties": {
-      "paratextRegistration.shouldShowOnStartup": {
-        "label": "%settings_paratextRegistration_shouldShowOnStartup_label%",
-        "description": "%settings_paratextRegistration_shouldShowOnStartup_description%",
-        "default": false
-      }
-    }
-  }
-]
+[]

--- a/extensions/src/paratext-registration/src/main.ts
+++ b/extensions/src/paratext-registration/src/main.ts
@@ -25,47 +25,12 @@ async function showInternetSettings(): Promise<string | undefined> {
   );
 }
 
-/**
- * Shows the registration info pane if there isn't any registration info yet. Used to help people
- * get signed in at startup
- *
- * Handles its own errors. No need to await
- */
-async function showParatextRegistrationIfNoRegistrationData(): Promise<string | undefined> {
-  try {
-    if (!(await papi.settings.get('paratextRegistration.shouldShowOnStartup'))) return undefined;
-
-    const registrationData = await papi.commands.sendCommand(
-      'paratextRegistration.getParatextRegistrationData',
-    );
-
-    if (
-      registrationData.name ||
-      registrationData.code ||
-      registrationData.email ||
-      registrationData.supporterName
-    )
-      return undefined;
-
-    return await showParatextRegistration();
-  } catch (e) {
-    logger.warn(
-      `Error while trying to determine if we need to pull up the Paratext registration info web view on startup: ${e}`,
-    );
-  }
-  return undefined;
-}
-
+// Startup registration is handled by the renderer-side first-run overlay (PT-4175) — opening WebViews here races WebViewService.
 export async function activate(context: ExecutionActivationContext) {
   logger.debug('Paratext Registration is activating!');
 
   const paratextRegistrationWebViewProvider = new ParatextRegistrationWebViewProvider();
   const internetSettingsWebViewProvider = new InternetSettingsWebViewProvider();
-
-  const shouldShowOnStartupValidatorPromise = papi.settings.registerValidator(
-    'paratextRegistration.shouldShowOnStartup',
-    async (newValue) => typeof newValue === 'boolean',
-  );
 
   const showParatextRegistrationPromise = papi.commands.registerCommand(
     'paratextRegistration.showParatextRegistration',
@@ -86,11 +51,7 @@ export async function activate(context: ExecutionActivationContext) {
     internetSettingsWebViewProvider,
   );
 
-  // No need to wait for this; it will do its thing and handle its own errors
-  showParatextRegistrationIfNoRegistrationData();
-
   context.registrations.add(
-    await shouldShowOnStartupValidatorPromise,
     await showParatextRegistrationPromise,
     await showParatextRegistrationWebViewProviderPromise,
     await showInternetSettingsPromise,

--- a/extensions/src/paratext-registration/src/main.ts
+++ b/extensions/src/paratext-registration/src/main.ts
@@ -25,7 +25,6 @@ async function showInternetSettings(): Promise<string | undefined> {
   );
 }
 
-// Startup registration is handled by the renderer-side first-run overlay — opening WebViews here races WebViewService.
 export async function activate(context: ExecutionActivationContext) {
   logger.debug('Paratext Registration is activating!');
 
@@ -57,6 +56,8 @@ export async function activate(context: ExecutionActivationContext) {
     await showInternetSettingsPromise,
     await showInternetSettingsWebViewProviderPromise,
   );
+  // Startup registration is handled by the renderer-side first-run overlay —
+  // opening WebViews here races WebViewService.
 }
 
 export async function deactivate() {

--- a/extensions/src/paratext-registration/src/main.ts
+++ b/extensions/src/paratext-registration/src/main.ts
@@ -25,7 +25,7 @@ async function showInternetSettings(): Promise<string | undefined> {
   );
 }
 
-// Startup registration is handled by the renderer-side first-run overlay (PT-4175) — opening WebViews here races WebViewService.
+// Startup registration is handled by the renderer-side first-run overlay — opening WebViews here races WebViewService.
 export async function activate(context: ExecutionActivationContext) {
   logger.debug('Paratext Registration is activating!');
 

--- a/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
+++ b/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
@@ -129,12 +129,4 @@ declare module 'papi-shared-types' {
       registrationData: RegistrationData,
     ) => Promise<boolean>;
   }
-
-  export interface SettingTypes {
-    /**
-     * Whether to show the form to enter Paratext Registration information when the application
-     * starts if it has not been entered previously
-     */
-    'paratextRegistration.shouldShowOnStartup': boolean;
-  }
 }

--- a/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
+++ b/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
@@ -129,4 +129,12 @@ declare module 'papi-shared-types' {
       registrationData: RegistrationData,
     ) => Promise<boolean>;
   }
+
+  export interface SettingTypes {
+    /**
+     * @deprecated 22 July 2026. The startup registration prompt this controlled was replaced by the
+     *   first-run gating overlay.
+     */
+    'paratextRegistration.shouldShowOnStartup': boolean;
+  }
 }


### PR DESCRIPTION
## What and why

`paratext-registration/activate()` called `papi.webViews.openWebView()` as a fire-and-forget before `WebViewService` had registered — causing a PAPI timeout whose error was swallowed, leaving the first-run registration prompt silently absent (PT-4224).

**Fix**: delete the broken path entirely. PT-4175 landed a renderer-side first-run gating overlay (`src/renderer/services/first-run-store.ts`) that handles startup registration with proper sequencing — it waits for the C# backend's `doesUserHaveValidRegistration` command before deciding what to show. The extension's duplicate was both broken and redundant.

## What changed

| File | Change |
|------|--------|
| `src/main.ts` | Removed `showParatextRegistrationIfNoRegistrationData()` and its fire-and-forget call. Added a one-line comment pointing to PT-4175 as the correct home for this check. |
| `contributions/settings.json` | Removed the `shouldShowOnStartup` settings group → now `[]`. |
| `contributions/localizedStrings.json` | Removed 4 setting-label strings (kept as `deprecationInfo` metadata per the established pattern). Also corrected `"..."` → `"…"` in two menu labels. |
| `src/types/paratext-registration.d.ts` | Removed `SettingTypes['paratextRegistration.shouldShowOnStartup']` from the `papi-shared-types` augmentation. `CommandHandlers` is unchanged. |

## Things worth verifying

- **PT-4175 coverage** — Does the first-run overlay handle the "no registration data on first launch" case? Yes: `first-run.reducer.ts` returns `waitForRegistration` when `doesUserHaveValidRegistration` is false, which gates the app behind the registration dialog. Worth a second look.
- **`shouldShowOnStartup` consumers** — No external consumers found in `paratext-10-studio`. All 6 references were internal to this extension. Removing from `SettingTypes` is safe.
- **`settings.json` as `[]`** — Is empty-array the right convention, or should the file be removed and `manifest.json` updated?

---

<details>
<summary>Pre-PR review findings (Claude Sonnet 4.6)</summary>

<!-- review-paratext:summary:start -->
### Critical

- [x] **`localizedStrings.json`: Trailing commas on last entry of both `en` and `es` objects made the file invalid JSON** _(fixed: removed trailing commas)_

### Important

- [ ] ~~**Removing `SettingTypes['paratextRegistration.shouldShowOnStartup']` could break external extensions**~~ _(no external consumers — search confirmed all 6 references are internal to this extension)_
- [ ] ~~**Persisted `shouldShowOnStartup` key in user settings could cause errors on next launch**~~ _(researched `settings.service-host.ts`: unknown keys from disk are silently absorbed; nothing reads this key anymore so it's harmless)_
- [x] **Four setting-label keys deleted outright instead of following the `deprecationInfo` pattern** _(fixed: added 4 deprecation metadata entries; no meaningful external exposure confirmed)_
- [x] **`package-lock.json` name field changed to branch name — worktree artifact** _(fixed: reverted)_

### Minor

- [x] **`main.ts`: No explanation for why the startup prompt was removed** _(fixed: added one-line comment)_
- [x] **Menu labels used `"..."` instead of `"…"` in `en` and `es`** _(fixed: corrected all 4 instances)_
- [ ] ~~**`settings.json` is now `[]` — should it be removed?**~~ _(`manifest.json` references it by path; `[]` is valid and explicit)_
<!-- review-paratext:summary:end -->

</details>

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2592)
<!-- Reviewable:end -->
