### PR TITLE
Suppress jsdom CSS-parse dumps that hang Linux CI unit tests

### DIFF
--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -93,3 +93,45 @@ configure({
     }
   },
 });
+
+// ---------------------------------------------------------------------------
+// Suppress jsdom's "Could not parse CSS stylesheet" errors.
+//
+// jsdom's CSS engine (rrweb-cssom) cannot parse Tailwind v4's modern syntax
+// (@layer, @property, @supports with oklch()/color-mix(), ...). Whenever a
+// component under test injects a <style> containing the Tailwind stylesheet
+// (e.g. the experimental scripture/footnote editor), jsdom fails to parse it
+// and reports a jsdomError whose `detail` property is the ENTIRE ~192 KB
+// stylesheet. jsdom's VirtualConsole forwards that to console.error, so every
+// such render dumps ~192 KB to the test output - roughly 50x per full run
+// (~9.6 MB, ~89% of the CI log).
+//
+// Beyond the log bloat, the sheer volume of these giant writes intermittently
+// deadlocked the vitest worker->main->runner output pipeline on the Linux CI
+// runner, hanging the "npm unit tests" step for hours (it froze mid-write of
+// the ~32nd dump every time). Windows and macOS drained the same output fine.
+//
+// jsdom cannot parse this CSS regardless, and no test relies on its computed
+// styles, so we drop these specific errors at the source - in the worker,
+// before vitest formats and serializes them - which removes both the log spam
+// and the writes that caused the hang. All other console.error output passes
+// through untouched. jsdom's VirtualConsole does a live property lookup on the
+// console object at emit time, so reassigning console.error here is honored.
+const CSS_PARSE_ERROR_MESSAGE = 'Could not parse CSS stylesheet';
+function isJsdomCssParseError(arg: unknown): boolean {
+  if (arg instanceof Error) {
+    if (arg.message.includes(CSS_PARSE_ERROR_MESSAGE)) return true;
+    return 'type' in arg && arg.type === 'css parsing';
+  }
+  return typeof arg === 'string' && arg.includes(CSS_PARSE_ERROR_MESSAGE);
+}
+// The no-console rule guards against stray logging in production code. This is a test-only
+// setup file that must wrap the global console.error to drop jsdom's CSS-parse noise (see the
+// block comment above), so the rule does not apply to the two references below.
+/* eslint-disable no-console */
+const originalConsoleError = console.error.bind(console);
+console.error = (...args: unknown[]) => {
+  if (args.some(isJsdomCssParseError)) return;
+  originalConsoleError(...args);
+};
+/* eslint-enable no-console */


### PR DESCRIPTION
## Summary

The `npm unit tests` step intermittently **hangs for hours on the Linux CI runner** (it does not just run slow), while Windows and macOS finish in ~3-4 min. Separately, every run's log is bloated with enormous single-line CSS strings. This PR shows both symptoms are the **same root cause** and fixes them at the source.

### Why review this

Not part of the current epic - this is CI infrastructure. It is worth reviewer time now because the hang is actively blocking PRs: a stalled Linux job holds the check "in progress" and, with no `timeout-minutes` set, can burn up to the default 360-minute (6 h) job budget before GitHub kills it.

## Diagnosis

- `platform-bible-react` component tests render components (e.g. the experimental scripture/footnote editor) that inject a `<style>` containing the full **Tailwind v4.2.2** stylesheet.
- **jsdom 26's** CSS engine (`rrweb-cssom`) cannot parse Tailwind v4's modern syntax (`@layer`, `@property`, `@supports` with `oklch()`/`color-mix()`). On failure jsdom raises a `jsdomError` whose `detail` is the **entire ~192 KB stylesheet**, and its `VirtualConsole` forwards that to `console.error`.
- That happens **~50x per run ≈ 9.6 MB, ~89% of the log** - identical on all three OSes.
- On **Linux only**, the volume of these giant writes intermittently **deadlocks the vitest worker→main→runner output pipeline**. Evidence: two independent stuck runs both froze at the byte-identical point - mid-write of the **32nd** dump - inside the first (core) suite; Windows/macOS drained the same output fine. The stall was invisible in "completed run" samples because a stalled run never completes.

## Changes

- `vitest.setup.ts` (shared by the root **core** suite and the **platform-bible-react** suite): wrap `console.error` to drop jsdom's `"Could not parse CSS stylesheet"` errors at the source - in the worker, before vitest formats/serializes them. jsdom cannot parse this CSS regardless and no test relies on its computed styles. All other `console.error` output passes through untouched.

Suppressing at the source removes both the log spam **and** the giant writes that caused the Linux deadlock. (An `onConsoleLog` reporter filter would hide the log text but still let the 192 KB cross the worker→main boundary, so it would not reliably fix the hang.)

## Testing

- [x] Core suite locally: **37 CSS dumps (~megabytes) → 0**, log for one representative test file **396 KB → 3.2 KB**, all **1151 tests still pass**.
- [x] `eslint`, `prettier --check`, and a strict `tsc` on the changed logic all clean.
- [ ] **CI is the real test** for the Linux hang (not locally reproducible - it is CI-pipeline-specific). This PR exists to confirm the Linux `npm unit tests` step stays green and fast.

## AI Involvement

Diagnosis and this one-file change were produced with Claude Code (Opus 4.8) under my guidance: it correlated the stuck in-progress runs, traced the jsdom/Tailwind parse failure, wrote the console filter, and verified the before/after locally. I reviewed the root-cause reasoning and the diff.

## Risk Level

Low - test-infra only, no production code. Worst case is that a genuine future CSS-parse error is not surfaced in test logs; that is acceptable since jsdom cannot parse this CSS and no assertion depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2600)
<!-- Reviewable:end -->
