### PR TITLE
Mark ResultChangeStatus and resultStatuses as @experimental

### DIFF
--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -62,6 +62,8 @@ declare module 'paratext-bible-send-receive' {
    * - `receivedChanges` = S/R received ≥1 revision (RevisionsReceived.Count > 0)
    * - `noChangesToSend` = S/R sent no non-merge revisions
    * - `noChangesReceived` = S/R received no revisions (RevisionsReceived is empty)
+   *
+   * @experimental The set of values in this type may change
    */
   export type ResultChangeStatus =
     | 'sentChanges'
@@ -208,6 +210,8 @@ declare module 'paratext-bible-send-receive' {
     /**
      * Granular change-tracking statuses ({@link ResultChangeStatus}); multiple can apply, e.g., sent
      * AND received
+     *
+     * @experimental The set of possible statuses may change
      */
     resultStatuses?: ResultChangeStatus[];
     /** Total conflict count computed by C# */


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: worktree-experimental-result-change-status

**Base**: origin/main

**Date**: 2026-07-23

**Review model**: Claude Sonnet 4.6

**Files changed**: 1

## Overview

This change adds `@experimental` JSDoc tags to `ResultChangeStatus` (the type itself) and `ResultInfo.resultStatuses` (the property that exposes it) in `src/@types/paratext-bible-send-receive/index.d.ts`. The motivation is that the set of possible S/R change-tracking status values is likely to evolve, and extension developers should be warned not to treat the current set as stable. The tags were also given brief explanatory phrases during the review to match the more explicit `@experimental` annotation style already present in the same file.

The change is minimal and surgical — no runtime code, no test changes, no build config touched. No existing callers of `ResultChangeStatus` or `resultStatuses` exist anywhere in the repo outside the declaration file itself.

## API Changes

None. The changed file (`src/@types/paratext-bible-send-receive/index.d.ts`) is an ambient type declaration seam for the closed-source `paratext-bible-send-receive` extension, not a standard API surface (`lib/platform-bible-react/`, `lib/platform-bible-utils/`, `@papi/` modules, or extension type declaration files).

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [x] **`src/@types/paratext-bible-send-receive/index.d.ts:66` — Bare `@experimental` tags lacked explanatory text** _(fixed during review: added "The set of values in this type may change" to `ResultChangeStatus` and "The set of possible statuses may change" to `resultStatuses`, consistent with the more explicit `@experimental` annotation already present in the same file)_

[Author response: Author requested the fix immediately.]

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- `@experimental` tags are placed correctly: on a blank JSDoc line preceded by an empty `*` line, consistent with the style used throughout the codebase.
- The pattern matches the documented convention in `Paranext-Core-Patterns.md` § "Experimental APIs": tag applied to both the type declaration and the property that uses it — marking the type alone would leave the property unmarked for IDE consumers scanning `ResultInfo`.
- The change is minimal and precisely scoped; no unrelated code was touched.
- No existing callers of `ResultChangeStatus` or `resultStatuses` exist outside the declaration file, so there is no risk of compile errors or behavioral regressions.

## Interview Notes

Author's stated purpose: the set of S/R change-tracking status values is expected to evolve, and extension developers should not treat the current values as stable. Applying `@experimental` at both the type and property level ensures IDE consumers see the warning at both the definition and usage sites. The author immediately approved adding explanatory text to the tags when the minor finding was surfaced.

## In-Review Quality Check

Changes were made during the interview (explanatory text added to both `@experimental` tags).

- **TypeCheck**: PASSED. Two pre-existing errors in `src/main/main.ts` and `src/main/services/app.service-host.ts` exist on the base commit and are unrelated to this change.
- **Lint**: PASSED. No auto-fixes needed.
- **Prettier**: PASSED. File was already correctly formatted; no changes made.
- **Tests**: PASSED. 933 tests pass. 21 pre-existing failures from a React version conflict originating in another worktree's `.yalc` directory — identical on the base commit and unrelated to this pure type-declaration change.

## Suggested Review Focus

- [ ] Confirm the phrasing of the `@experimental` descriptions ("The set of values in this type may change" / "The set of possible statuses may change") is clear and consistent with how the team wants to communicate this instability to extension developers.
<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2601)
<!-- Reviewable:end -->
