### PR TITLE
Remove ineffective Claude Code permission deny rules

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -38,9 +38,7 @@
       "Bash(git commit -n:*)",
       "Bash(HUSKY=0:*)",
       "Edit(.claude/settings.json)",
-      "Write(.claude/settings.json)",
       "Edit(.claude/settings.local.json)",
-      "Write(.claude/settings.local.json)",
       "Read(./.env)",
       "Read(./.env.*)",
       "Read(./secrets/**)",
@@ -52,9 +50,7 @@
       "Read(**/dist/**)",
       "Read(**/*.min.js)",
       "Read(**/*.min.css)",
-      "Read(**/*.map)",
-      "Glob(**/dist/**)",
-      "Grep(**/dist/**)"
+      "Read(**/*.map)"
     ],
     "ask": [
       "Bash(rm -rf:*)",


### PR DESCRIPTION
## Summary

Four permission `deny` rules in `.claude/settings.json` were ignored by Claude Code and emitted a warning on every launch. This removes them without weakening any protection.

Claude Code applies file-permission checks only through `Read(...)` and `Edit(...)` rules, which already cover their sibling file tools (`Write`/`NotebookEdit` fall under `Edit`; `Glob`/`Grep` fall under `Read`). So these four rules never did anything:

- `Write(.claude/settings.json)` — covered by the existing `Edit(.claude/settings.json)`
- `Write(.claude/settings.local.json)` — covered by the existing `Edit(.claude/settings.local.json)`
- `Glob(**/dist/**)` — covered by the existing `Read(**/dist/**)`
- `Grep(**/dist/**)` — covered by the existing `Read(**/dist/**)`

The startup warnings explicitly recommended this fix (e.g. *"Write(.claude/settings.json) is not matched by file permission checks — only Edit(path) rules are"*).

## Changes

- Remove the two ineffective `Write(...)` deny rules for the settings files
- Remove the ineffective `Glob(**/dist/**)` and `Grep(**/dist/**)` deny rules

### Why review this

Not part of current epic. Tooling/config cleanup — the removed rules were dead and produced noisy warnings on every Claude Code startup in this repo; protection is unchanged.

## AI Involvement

AI-assisted. Claude Code diagnosed the ineffective rules from the startup warnings, proposed the exact deletions, and drafted the commit/PR. The human developer made the edits (the settings file is protected by its own deny rule) and reviewed the diff.

## Testing

- [x] Config-only change; no code affected
- [x] Verified warnings no longer appear on Claude Code restart
- [x] Pre-commit hooks (secret scan, lint) pass

## Risk Level

Low — removes dead permission rules only; equivalent protection retained via existing `Edit(...)`/`Read(...)` rules.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2604)
<!-- Reviewable:end -->
