### PR TITLE
Remove quotes from --extension* args

### DIFF
--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -240,6 +240,23 @@ function parseManifest(extensionManifestJson: string): ExtensionManifest {
 }
 
 /**
+ * Strip a single matching pair of wrapping quote characters (`'...'` or `"..."`) from a raw path
+ * argument.
+ *
+ * Some dev workflows use process managers (e.g., `concurrently` on Windows) that quote
+ * `--extensions`/`--extensionDirs` arguments for a POSIX shell but then execute them via `cmd.exe`,
+ * which does not strip the quotes. The literal quotes then end up as part of the path, and
+ * `path.resolve` silently treats the whole thing as a relative path instead of failing loudly.
+ */
+function stripWrappingQuotes(rawPath: string): string {
+  if (rawPath.length < 2) return rawPath;
+  const first = rawPath[0];
+  if ((first === '"' || first === "'") && rawPath[rawPath.length - 1] === first)
+    return rawPath.slice(1, -1);
+  return rawPath;
+}
+
+/**
  * The directory for extensions bundled into the application
  *
  * - In development: `paranext-core/extensions/dist`
@@ -265,7 +282,7 @@ const bundledExtensionDir = `resources://extensions${globalThis.isPackaged ? '' 
 const extensionRootDirectories: Uri[] = [
   // 1. `--extensionDirs`-provided directories
   ...getCommandLineArgumentsGroup(CommandLineArgs.ExtensionsDir).map(
-    (extensionDirPath) => `${FILE_PROTOCOL}${path.resolve(extensionDirPath)}`,
+    (extensionDirPath) => `${FILE_PROTOCOL}${path.resolve(stripWrappingQuotes(extensionDirPath))}`,
   ),
   // 2. Installed extensions directory
   installedExtensionsUri,
@@ -291,7 +308,7 @@ if (getCommandLineSwitch(CommandLineArgs.Portable)) {
 /** Individual extension folders and/or zips to load as provided by command-line `--extensions` */
 const commandLineExtensionDirectories: string[] = getCommandLineArgumentsGroup(
   CommandLineArgs.Extensions,
-).map((extensionPath) => `${FILE_PROTOCOL}${path.resolve(extensionPath)}`);
+).map((extensionPath) => `${FILE_PROTOCOL}${path.resolve(stripWrappingQuotes(extensionPath))}`);
 
 /**
  * Contents of `nodeFS.readDir()` for all parent folders of extensions. This is expected to be a

--- a/src/extension-host/services/extension.service.ts
+++ b/src/extension-host/services/extension.service.ts
@@ -25,6 +25,7 @@ import {
   CommandLineArgs,
   getCommandLineArgumentsGroup,
   getCommandLineSwitch,
+  stripWrappingQuotes,
 } from '@node/utils/command-line.util';
 import { setExtensionUris } from '@extension-host/services/extension-storage.service';
 import papi, { fetch as papiFetch } from '@extension-host/services/papi-backend.service';
@@ -237,23 +238,6 @@ function parseManifest(extensionManifestJson: string): ExtensionManifest {
     extensionManifest.main = `${extensionManifest.main.slice(0, -3)}.js`;
 
   return extensionManifest;
-}
-
-/**
- * Strip a single matching pair of wrapping quote characters (`'...'` or `"..."`) from a raw path
- * argument.
- *
- * Some dev workflows use process managers (e.g., `concurrently` on Windows) that quote
- * `--extensions`/`--extensionDirs` arguments for a POSIX shell but then execute them via `cmd.exe`,
- * which does not strip the quotes. The literal quotes then end up as part of the path, and
- * `path.resolve` silently treats the whole thing as a relative path instead of failing loudly.
- */
-function stripWrappingQuotes(rawPath: string): string {
-  if (rawPath.length < 2) return rawPath;
-  const first = rawPath[0];
-  if ((first === '"' || first === "'") && rawPath[rawPath.length - 1] === first)
-    return rawPath.slice(1, -1);
-  return rawPath;
 }
 
 /**

--- a/src/node/utils/command-line.util.test.ts
+++ b/src/node/utils/command-line.util.test.ts
@@ -2,6 +2,7 @@ import {
   CommandLineArgs,
   getCommandLineArgument,
   getCommandLineArgumentsGroup,
+  stripWrappingQuotes,
 } from './command-line.util';
 
 describe('getCommandLineArgumentsGroup', () => {
@@ -32,5 +33,44 @@ describe('getCommandLineArgument', () => {
     process.argv = ['node', 'app.js'];
 
     expect(getCommandLineArgument(CommandLineArgs.WindowSize)).toBeUndefined();
+  });
+});
+
+describe('stripWrappingQuotes', () => {
+  test('should strip a matching pair of double quotes', () => {
+    expect(stripWrappingQuotes('"C:\\foo"')).toBe('C:\\foo');
+  });
+
+  test('should strip a matching pair of single quotes', () => {
+    expect(stripWrappingQuotes("'C:\\foo'")).toBe('C:\\foo');
+  });
+
+  test('should return the value unchanged when it has no wrapping quotes', () => {
+    expect(stripWrappingQuotes('C:\\foo')).toBe('C:\\foo');
+  });
+
+  test('should return the value unchanged when the quote characters do not match', () => {
+    expect(stripWrappingQuotes('\'C:\\foo"')).toBe('\'C:\\foo"');
+  });
+
+  test('should return the value unchanged when only the left side is quoted', () => {
+    expect(stripWrappingQuotes('"C:\\foo')).toBe('"C:\\foo');
+  });
+
+  test('should return the value unchanged when only the right side is quoted', () => {
+    expect(stripWrappingQuotes("C:\\foo'")).toBe("C:\\foo'");
+  });
+
+  test('should return an empty string when the value is an empty matching quote pair', () => {
+    expect(stripWrappingQuotes('""')).toBe('');
+  });
+
+  test('should only strip the outermost pair when quotes are nested', () => {
+    expect(stripWrappingQuotes('"\'C:\\foo\'"')).toBe("'C:\\foo'");
+  });
+
+  test('should return the value unchanged when shorter than two characters', () => {
+    expect(stripWrappingQuotes('"')).toBe('"');
+    expect(stripWrappingQuotes('')).toBe('');
   });
 });

--- a/src/node/utils/command-line.util.ts
+++ b/src/node/utils/command-line.util.ts
@@ -166,3 +166,29 @@ export function getCommandLineSwitch(argName: CommandLineArgs) {
   const argNames: string[] = commandLineArgumentsAliases[argName];
   return argNames.some((alias) => process.argv.includes(alias));
 }
+
+/**
+ * Strip a single matching pair of wrapping quote characters (`'...'` or `"..."`) from a raw
+ * command-line argument.
+ *
+ * Some dev workflows use process managers (e.g., `concurrently` on Windows) that quote arguments
+ * for a POSIX shell but then execute them via `cmd.exe`, which does not strip the quotes. The
+ * literal quotes then end up as part of the value instead of being removed.
+ *
+ * @param rawArg Raw command-line argument value, possibly wrapped in a single matching pair of
+ *   quote characters
+ * @returns `rawArg` with a single matching pair of wrapping quotes removed, or `rawArg` unchanged
+ *   if it is not wrapped in a matching pair of quotes
+ *
+ *   Ex: `stripWrappingQuotes('"C:\\foo"')` returns `'C:\\foo'`
+ *
+ *   Ex: `stripWrappingQuotes('C:\\foo')` returns `'C:\\foo'`
+ */
+export function stripWrappingQuotes(rawArg: string): string {
+  if (rawArg.length < 2) return rawArg;
+  const first = rawArg[0];
+  if ((first === '"' || first === "'") && rawArg[rawArg.length - 1] === first)
+    return rawArg.slice(1, -1);
+
+  return rawArg;
+}


### PR DESCRIPTION
## Issue

On Windows, running `npm start` in an extension repo's dev workflow can fail to load the extension, logging something like:

```
Error: Extension folder ... failed to load. Reason: ENOENT: no such file or directory, open '...\manifest.json'
```

Dev-mode start scripts thread `--extensions <path>` through `concurrently`'s `{@}` placeholder, which uses `shell-quote` to quote the argument for a POSIX shell. On Windows, `concurrently` then executes the resulting command via `cmd.exe`, which does not strip those quotes — so the literal quote characters end up embedded in the path. `path.resolve` silently treats the quoted string as a relative path instead of failing loudly, producing a bogus path (e.g. `<resourcesPath>\'<real path>'`) that doesn't exist.

## Solution

Strip a single matching pair of wrapping quote characters (`'...'` or `"..."`) from `--extensions`/`--extensionDirs` command-line path arguments before resolving them in `extension.service.ts`.

Drafted with Claude Sonnet 5.

---

<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: unquote

**Base**: origin/main

**Date**: 2026-07-27

**Review model**: Claude Sonnet 5

**Files changed**: 3

## Overview

This branch fixes a Windows dev-mode bug where `--extensions`/`--extensionDirs` command-line path arguments get wrapped in literal quote characters when `concurrently`'s shell-quote-quoted args are executed via `cmd.exe`, which doesn't strip POSIX-style quoting. `path.resolve` then silently treats the quoted string as a relative path instead of failing loudly, producing a bogus path and causing extensions to fail to load (`ENOENT ... manifest.json`). The fix strips a single matching pair of wrapping quote characters from these arguments before resolving them.

## API Changes

None.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

None.

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None. — no files under `extensions/` were touched.

## Positive Observations

- The fix is minimal, self-contained, and precisely scoped to the two call sites that consume raw CLI path arguments (`--extensionDirs` and `--extensions`), with no unrelated changes.
- The JSDoc explains the *why* (concurrently + cmd.exe not stripping POSIX-style shell quoting, causing `path.resolve` to silently mis-resolve instead of failing loudly) rather than just the *what* — matches the project's comment conventions well.
- Clear naming (`stripWrappingQuotes`, `rawArg`) with no cryptic abbreviations.
- No dead code, stubs, or TODOs introduced; unquoted-path behavior is unchanged since the helper is a no-op when there's no matching quote pair.

## Interview Notes

Author's stated purpose: fix the Windows `ENOENT ... manifest.json` extension-load failure caused by `concurrently`/`cmd.exe` not stripping quotes from `--extensions`/`--extensionDirs` path arguments.

When asked about moving `stripWrappingQuotes` out of `extension.service.ts` (the state of this pr after the first commit), the author asked a clarifying question first — whether other functions from `command-line.util.ts` were already used within `services/` folders — rather than answering blind. This confirmed there was existing precedent (both `extension.service.ts` itself and `src/main/services/extension-host.service.ts` already import from that util module), which the author then used to approve the move. This is a small, low-complexity change (originally 1 file, 3 after review fixes) with no non-obvious design decisions, so the Step 3.3 design-explanation question was skipped — the author demonstrated clear understanding throughout via a well-targeted clarifying question and by independently catching and fixing a test-coverage gap.

No unresolved items. No areas of author uncertainty or AI-deferral were expressed.

## In-Review Quality Check

Quality checks run against the three touched files:

- **Typecheck** (`tsc -p ./tsconfig.json`): no errors in touched file.
- **Lint** 0 issues, clean exit.
- **Format** (`prettier --write` on the touched files): all already compliant, no changes needed.
- **Tests** (`vitest run src/node/utils/command-line.util.test.ts`): 13/13 passing.

Scoped to the touched files rather than the full monorepo lint/test pipeline, given the small, well-isolated nature of the change. No unfixable failures.

## Suggested Review Focus

- [ ] Confirm the location of `stripWrappingQuotes` in `command-line.util.ts` reads as the right architectural home (author and reviewer both agreed on this during the interview, based on existing import precedent).
- [ ] Spot-check the new edge-case tests in `command-line.util.test.ts` (particularly the empty-matching-pair `""` case, which resolves to an empty string that `path.resolve` would turn into `cwd` — worth confirming that's genuinely benign given no code path currently passes an empty CLI arg here).
<!-- review-paratext:summary:end -->

---

Devin review: https://app.devin.ai/review/paranext/paranext-core/pull/2606

<!-- Reviewable:start -->
This change is [![Reviewable](https://reviewable.io/review_button.svg)](https://reviewable.io/reviews/paranext/paranext-core/2606)
<!-- Reviewable:end -->
