### PR TITLE
PT-4214/PT-4210 cleanup: declare the sync-block seam (getAutoSyncBlocking, onSyncWriteLockChanged) + public breakSyncLock stub

### DIFF
--- a/c-sharp-tests/Projects/LocalParatextProjectsNotifyTests.cs
+++ b/c-sharp-tests/Projects/LocalParatextProjectsNotifyTests.cs
@@ -4,10 +4,13 @@ using Paranext.DataProvider.Projects;
 namespace TestParanextDataProvider.Projects
 {
     /// <summary>
-    /// Verifies <see cref="LocalParatextProjects.NotifyProjectsChanged"/> debounces: a burst of calls
+    /// Verifies the notify plumbing of <see cref="LocalParatextProjects"/>:
+    /// <see cref="LocalParatextProjects.NotifyProjectsChanged"/> debounces — a burst of calls
     /// (e.g. an inline setting-write notify plus the watcher catching that same on-disk write, or a
     /// run of display-setting writes) must collapse into a single emitted
-    /// <c>platform.onDidChangeProjects</c> event, since each event drives a full metadata refetch.
+    /// <c>platform.onDidChangeProjects</c> event, since each event drives a full metadata refetch —
+    /// and the watcher path funnels through the shared
+    /// <see cref="LocalParatextProjects.RefreshAndNotifyProjectsChanged"/>.
     /// </summary>
     [ExcludeFromCodeCoverage]
     internal class LocalParatextProjectsNotifyTests
@@ -15,6 +18,39 @@ namespace TestParanextDataProvider.Projects
         // Generous so a slow CI box (the 500ms debounce plus scheduling jitter) doesn't flake.
         private const int SettleTimeoutMs = 5000;
         private const int PollIntervalMs = 50;
+
+        /// <summary>
+        /// Substitutes <see cref="LocalParatextProjects.RefreshAndNotifyProjectsChanged"/> with a
+        /// counter and exposes the protected watcher callback, so the funnel test below can pin the
+        /// delegation without touching the global <c>ScrTextCollection</c> (via RefreshScrTexts) or
+        /// the real PAPI event.
+        /// </summary>
+        private sealed class FunnelObservingProjects(DummyPapiClient papiClient)
+            : LocalParatextProjects(papiClient)
+        {
+            public int RefreshAndNotifyCallCount { get; private set; }
+
+            public override void RefreshAndNotifyProjectsChanged() => RefreshAndNotifyCallCount++;
+
+            public void FireOnProjectDirectoriesChanged() => OnProjectDirectoriesChanged();
+        }
+
+        [Test]
+        public void OnProjectDirectoriesChanged_DelegatesToRefreshAndNotifyProjectsChanged()
+        {
+            // The watcher path must funnel through the shared refresh-then-notify method so its
+            // best-effort contract (a refresh throw must not suppress the notify) and any test
+            // substitution of the refresh apply to the inline and watcher paths alike.
+            using var projects = new FunnelObservingProjects(new DummyPapiClient());
+
+            projects.FireOnProjectDirectoriesChanged();
+
+            Assert.That(
+                projects.RefreshAndNotifyCallCount,
+                Is.EqualTo(1),
+                "the watcher callback must delegate to RefreshAndNotifyProjectsChanged"
+            );
+        }
 
         [Test]
         public void NotifyProjectsChanged_CoalescesRapidCallsIntoOneEvent()

--- a/c-sharp-tests/Projects/LocalParatextProjectsNotifyTests.cs
+++ b/c-sharp-tests/Projects/LocalParatextProjectsNotifyTests.cs
@@ -10,7 +10,9 @@ namespace TestParanextDataProvider.Projects
     /// run of display-setting writes) must collapse into a single emitted
     /// <c>platform.onDidChangeProjects</c> event, since each event drives a full metadata refetch —
     /// and the watcher path funnels through the shared
-    /// <see cref="LocalParatextProjects.RefreshAndNotifyProjectsChanged"/>.
+    /// <see cref="LocalParatextProjects.RefreshAndNotifyProjectsChanged"/>, which itself no-ops
+    /// before <see cref="LocalParatextProjects.Initialize"/> (an early writer must not broadcast
+    /// a bogus project-list change off an uninitialised <c>ScrTextCollection</c>).
     /// </summary>
     [ExcludeFromCodeCoverage]
     internal class LocalParatextProjectsNotifyTests
@@ -18,6 +20,10 @@ namespace TestParanextDataProvider.Projects
         // Generous so a slow CI box (the 500ms debounce plus scheduling jitter) doesn't flake.
         private const int SettleTimeoutMs = 5000;
         private const int PollIntervalMs = 50;
+
+        // Window to prove an event does NOT arrive: comfortably past the 500ms notify debounce
+        // (3x), so a wrongly-scheduled emit would land inside it.
+        private static readonly TimeSpan NoEventSettleWindow = TimeSpan.FromMilliseconds(1500);
 
         /// <summary>
         /// Substitutes <see cref="LocalParatextProjects.RefreshAndNotifyProjectsChanged"/> with a
@@ -70,6 +76,35 @@ namespace TestParanextDataProvider.Projects
             Assert.That(
                 client.NextSentEvent.eventType,
                 Is.EqualTo(LocalParatextProjects.PROJECTS_CHANGED_EVENT_TYPE)
+            );
+        }
+
+        [Test]
+        public void RefreshAndNotifyProjectsChanged_BeforeInitialize_DoesNotNotify()
+        {
+            // A writer can land before startup initialization completes (e.g. a sync finishing
+            // before Initialize() has set up the ScrTextCollection). Refreshing then would scan
+            // an uninitialised collection and broadcast a bogus project-list change, so the
+            // funnel must no-op until Initialize completes.
+            var client = new DummyPapiClient();
+            using var projects = new LocalParatextProjects(client);
+
+            projects.RefreshAndNotifyProjectsChanged();
+
+            Assert.That(
+                SpinWait.SpinUntil(() => client.SentEventCount > 0, NoEventSettleWindow),
+                Is.False,
+                "RefreshAndNotifyProjectsChanged before Initialize must not emit a project-list change"
+            );
+
+            // Control: the direct notify path has no initialization guard (it never touches the
+            // ScrTextCollection), so an emit still arrives — proving the zero above pinned the
+            // guard rather than a client that records nothing.
+            projects.NotifyProjectsChanged();
+            Assert.That(
+                () => client.SentEventCount,
+                Is.EqualTo(1).After(SettleTimeoutMs, PollIntervalMs),
+                "NotifyProjectsChanged must still emit pre-Initialize"
             );
         }
     }

--- a/c-sharp-tests/Projects/SendReceive/ParatextProjectSendReceiveServiceStubDocsTests.cs
+++ b/c-sharp-tests/Projects/SendReceive/ParatextProjectSendReceiveServiceStubDocsTests.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics.CodeAnalysis;
+using Paranext.DataProvider;
+using Paranext.DataProvider.Projects;
+using Paranext.DataProvider.Projects.SendReceive;
+
+namespace TestParanextDataProvider.Projects.SendReceive
+{
+    /// <summary>
+    /// Registration-documentation tests for the open-source
+    /// <see cref="ParatextProjectSendReceiveService"/> stub: breakSyncLock is @experimental (see
+    /// the TS declaration), so its registration must carry experimental OpenRPC documentation
+    /// (<c>x-experimental: true</c>) surfaced by <c>rpc.discover</c> — the same doc-assertion
+    /// pattern as <c>VersificationConversionServiceTests</c>. Deliberately NOT named
+    /// <c>ParatextProjectSendReceiveServiceTests</c> (or any of the per-feature
+    /// <c>ParatextProjectSendReceiveService*Tests</c> names the Paratext 10 Studio overlay adds),
+    /// so the stub's tests and the overlay's tests can coexist.
+    /// </summary>
+    [TestFixture]
+    [ExcludeFromCodeCoverage]
+    internal class ParatextProjectSendReceiveServiceStubDocsTests : PapiTestBase
+    {
+        [Test]
+        public async Task InitializeAsync_RegistersBreakSyncLockWithExperimentalDocs()
+        {
+            const string wireName = "command:paratextBibleSendReceive.breakSyncLock";
+            var service = new ParatextProjectSendReceiveService(
+                Client,
+                new ParatextProjectDataProviderFactory(Client, ParatextProjects),
+                new AppInfo("test", "1.0.0", "test"),
+                ParatextProjects
+            );
+
+            await service.InitializeAsync();
+
+            Assert.That(
+                Client.IsHandlerRegistered(wireName),
+                Is.True,
+                "breakSyncLock handler registered under its exact wire name"
+            );
+            var docs = Client.GetDocumentationFor(wireName);
+            Assert.That(docs, Is.Not.Null, "breakSyncLock registered with OpenRPC documentation");
+            Assert.That(docs!.Method.Experimental, Is.True, "breakSyncLock marked experimental");
+            Assert.That(
+                docs.Method.Params.Select(p => p.Name),
+                Is.EqualTo(new[] { "projectIds" }),
+                "documents the single projectIds parameter"
+            );
+        }
+    }
+}

--- a/c-sharp-tests/Projects/SendReceive/SendReceiveBlockNotifierServiceTests.cs
+++ b/c-sharp-tests/Projects/SendReceive/SendReceiveBlockNotifierServiceTests.cs
@@ -32,6 +32,10 @@ namespace TestParanextDataProvider.Projects.SendReceive
             SendReceiveWriteLock.ResetForTests();
             _service = new SendReceiveBlockNotifierService(Client);
             await _service.InitializeAsync();
+            // InitializeAsync emits the current gate snapshot once (the restart re-baseline emit —
+            // see the dedicated tests below); drain it so each test's event assertions see only the
+            // transitions that test drives.
+            _ = Client.NextSentEvent;
         }
 
         [TearDown]
@@ -90,6 +94,9 @@ namespace TestParanextDataProvider.Projects.SendReceive
             {
                 Console.SetError(originalError);
             }
+            // Drain the init-time current-snapshot emit so the assertions below see only the
+            // transition push.
+            _ = client.NextSentEvent;
 
             Assert.Multiple(() =>
             {
@@ -142,6 +149,9 @@ namespace TestParanextDataProvider.Projects.SendReceive
             {
                 Console.SetError(originalError);
             }
+            // Drain the init-time current-snapshot emit so the assertions below see only the
+            // transition push.
+            _ = client.NextSentEvent;
 
             Assert.Multiple(() =>
             {
@@ -175,9 +185,69 @@ namespace TestParanextDataProvider.Projects.SendReceive
         }
 
         [Test]
+        public async Task InitializeAsync_EmitsTheCurrentSnapshotOnce()
+        {
+            // Restart re-baseline emit: after initialization the service pushes the gate's CURRENT
+            // snapshot once, so a subscriber that was already listening across a backend restart
+            // converges on the fresh process's state instead of keeping its stale last-seen state.
+            // Fresh gate + client so only the service under test here is subscribed (the base SetUp
+            // already initialized and drained its own init emit).
+            SendReceiveWriteLock.ResetForTests();
+            using var client = new DummyPapiClient();
+            var service = new SendReceiveBlockNotifierService(client);
+
+            await service.InitializeAsync();
+
+            Assert.That(
+                client.SentEventCount,
+                Is.EqualTo(1),
+                "InitializeAsync must emit the current snapshot exactly once"
+            );
+            var (eventType, payload) = client.NextSentEvent;
+            Assert.That(eventType, Is.EqualTo(BlockStateChangedEvent));
+            var state = (SendReceiveBlockState)payload!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(
+                    state.IsBlocking,
+                    Is.False,
+                    "an idle gate re-baselines as not blocking"
+                );
+                Assert.That(state.ProjectIds, Is.Empty);
+            });
+        }
+
+        [Test]
+        public async Task InitializeAsync_GateAlreadyArmed_EmitsTheArmedSnapshot()
+        {
+            // The init emit is the gate's CURRENT snapshot, not a hard-coded not-blocking one: a
+            // service initializing while the gate is already armed must report the armed state.
+            SendReceiveWriteLock.ResetForTests();
+            SendReceiveWriteLock.SetSyncing(["projectA"]);
+            using var client = new DummyPapiClient();
+            var service = new SendReceiveBlockNotifierService(client);
+
+            await service.InitializeAsync();
+
+            Assert.That(client.SentEventCount, Is.EqualTo(1));
+            var (eventType, payload) = client.NextSentEvent;
+            Assert.That(eventType, Is.EqualTo(BlockStateChangedEvent));
+            var state = (SendReceiveBlockState)payload!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(state.IsBlocking, Is.True);
+                Assert.That(state.ProjectIds, Is.EquivalentTo(new[] { "projectA" }));
+            });
+        }
+
+        [Test]
         public void GateArm_PushesOnSyncWriteLockChangedEventWithBlockingSnapshot()
         {
-            Assert.That(Client.SentEventCount, Is.Zero, "no events before any transition");
+            Assert.That(
+                Client.SentEventCount,
+                Is.Zero,
+                "no events before any transition (SetUp drained the init emit)"
+            );
 
             SendReceiveWriteLock.SetSyncing(["projectA", "projectB"]);
 

--- a/c-sharp-tests/Projects/SendReceive/SendReceiveBlockNotifierServiceTests.cs
+++ b/c-sharp-tests/Projects/SendReceive/SendReceiveBlockNotifierServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json;
 using Paranext.DataProvider.JsonUtils;
+using Paranext.DataProvider.NetworkObjects.Documentation;
 using Paranext.DataProvider.Projects.SendReceive;
 
 namespace TestParanextDataProvider.Projects.SendReceive
@@ -65,10 +66,39 @@ namespace TestParanextDataProvider.Projects.SendReceive
                 Assert.That(requestType, Is.EqualTo("network:registerEvent"));
                 Assert.That(
                     requestContents,
-                    Is.EqualTo(new object?[] { BlockStateChangedEvent }),
+                    Has.Count.EqualTo(2),
+                    "the registration must carry the event name and its documentation"
+                );
+                Assert.That(
+                    requestContents![0],
+                    Is.EqualTo(BlockStateChangedEvent),
                     "the registration must name the onSyncWriteLockChanged event"
                 );
+                Assert.That(
+                    requestContents[1],
+                    Is.InstanceOf<OpenRpcSingleNotificationDocumentation>(),
+                    "the second argument must be the notification documentation"
+                );
             });
+            // The event is @experimental (TS declaration), so its registration must carry the
+            // x-experimental wire marker for rpc.discover.
+            var documentation = (OpenRpcSingleNotificationDocumentation)requestContents![1]!;
+            Assert.That(
+                documentation.Notification.Experimental,
+                Is.True,
+                "the event documentation must carry the x-experimental wire marker"
+            );
+        }
+
+        [Test]
+        public void InitializeAsync_RegistersGetAutoSyncBlockingWithExperimentalDocs()
+        {
+            // The command is @experimental (TS declaration), so its registration must carry
+            // experimental OpenRPC documentation for rpc.discover (the same doc-assertion pattern as
+            // VersificationConversionServiceTests).
+            var docs = Client.GetDocumentationFor(GetAutoSyncBlockingCommand);
+            Assert.That(docs, Is.Not.Null, "command registered with OpenRPC documentation");
+            Assert.That(docs!.Method.Experimental, Is.True, "command marked experimental");
         }
 
         [Test]

--- a/c-sharp/NetworkObjects/Documentation/OpenRpcNotificationDocumentation.cs
+++ b/c-sharp/NetworkObjects/Documentation/OpenRpcNotificationDocumentation.cs
@@ -1,0 +1,33 @@
+using System.Text.Json.Serialization;
+
+namespace Paranext.DataProvider.NetworkObjects.Documentation;
+
+/// <summary>
+/// OpenRPC documentation for a single network event (the inner <c>notification</c> object of
+/// <see cref="OpenRpcSingleNotificationDocumentation"/>). Same shape as
+/// <see cref="OpenRpcMethodDocumentation"/> minus the result — per the OpenRPC convention, a
+/// notification has no result. Set <see cref="Experimental"/> to mark the event experimental; it
+/// surfaces as <c>x-experimental: true</c> in the live OpenRPC document returned by
+/// <c>rpc.discover</c>. Informational only — it does not change runtime behavior.
+/// </summary>
+public record OpenRpcNotificationDocumentation
+{
+    /// <summary>
+    /// Marks the notification experimental in the OpenRPC document. Mirrors the TypeScript
+    /// <c>notification['x-experimental']</c> field. Informational only.
+    /// </summary>
+    [JsonPropertyName("x-experimental")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public bool? Experimental { get; set; }
+
+    /// <summary>A short summary of what the notification carries and when it fires.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Summary { get; set; }
+
+    /// <summary>A verbose explanation of the notification behavior.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? Description { get; set; }
+
+    /// <summary>The notification's parameters (its payload), in positional order.</summary>
+    public IReadOnlyList<OpenRpcContentDescriptor> Params { get; set; } = [];
+}

--- a/c-sharp/NetworkObjects/Documentation/OpenRpcSingleNotificationDocumentation.cs
+++ b/c-sharp/NetworkObjects/Documentation/OpenRpcSingleNotificationDocumentation.cs
@@ -1,0 +1,15 @@
+namespace Paranext.DataProvider.NetworkObjects.Documentation;
+
+/// <summary>
+/// Wire shape sent as the optional second argument to <c>network:registerEvent</c>. Mirrors the
+/// TypeScript <c>SingleNotificationDocumentation</c> type (<c>{ notification }</c>) — the
+/// notification counterpart of <see cref="OpenRpcSingleMethodDocumentation"/>. The main process
+/// stores it and emits it into the OpenRPC document returned by <c>rpc.discover</c>, so
+/// C#-registered network events can carry the same documentation (including
+/// <c>x-experimental</c>) as TypeScript-registered ones.
+/// </summary>
+public record OpenRpcSingleNotificationDocumentation
+{
+    /// <summary>The notification documentation.</summary>
+    public OpenRpcNotificationDocumentation Notification { get; set; } = new();
+}

--- a/c-sharp/Program.cs
+++ b/c-sharp/Program.cs
@@ -90,7 +90,8 @@ public static class Program
             var paratextSendReceiveService = new ParatextProjectSendReceiveService(
                 papi,
                 paratextFactory,
-                appInfo
+                appInfo,
+                paratextProjects
             );
             var inventoryDataProvider = new InventoryDataProvider(papi, paratextProjects);
             var checkRunner = new CheckRunner(papi, inventoryDataProvider);

--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -55,7 +55,11 @@ internal class LocalParatextProjects : IDisposable
 
     // Set first in Dispose (before the watcher/timer teardown it guards), so an in-flight
     // AttachContainerWatcher/event-handler thread racing the Dispose sees it and backs off instead
-    // of registering a watcher into (or touching a timer of) an already-disposed instance.
+    // of registering a watcher into (or touching a timer of) an already-disposed instance. The
+    // debounce-timer schedulers read it INSIDE their debounce lock — the same lock Dispose tears
+    // the timer down under — so check-then-schedule is atomic with the teardown; a bare read
+    // before the lock would leave a window to Change a disposed timer, or to construct a new
+    // timer after Dispose that nothing ever disposes.
     private volatile bool _disposed;
 
     private Timer? _projectChangeDebounceTimer;
@@ -212,9 +216,10 @@ internal class LocalParatextProjects : IDisposable
     /// </summary>
     public virtual void RefreshAndNotifyProjectsChanged()
     {
-        // A racing post-Dispose call must not touch the notify debounce timer (same guard as
-        // NotifyProjectsChanged / ScheduleProjectDirectoriesChanged); skip the refresh too — there
-        // is no consumer left to serve.
+        // Post-Dispose there is no consumer left to serve, so skip the refresh. Best-effort
+        // early-out only: the notify debounce timer itself is guarded atomically inside
+        // NotifyProjectsChanged (checked under _notifyLock), so a call racing Dispose past this
+        // check is still safe.
         if (_disposed)
             return;
         try
@@ -243,12 +248,16 @@ internal class LocalParatextProjects : IDisposable
     {
         if (_papiClient == null)
             return;
-        // Symmetric with ScheduleProjectDirectoriesChanged: a racing post-Dispose call must not
-        // touch a debounce timer that may already be disposed.
-        if (_disposed)
-            return;
         lock (_notifyLock)
         {
+            // Read under the lock — Dispose tears the timer down under this same lock — so
+            // check-then-schedule is atomic with the teardown. Checked before the lock, a call
+            // racing Dispose could Change an already-disposed timer (ObjectDisposedException)
+            // or, if no notify had ever been scheduled, construct a brand-new timer AFTER
+            // Dispose that nothing ever disposes and that later emits against a disposing
+            // PapiClient.
+            if (_disposed)
+                return;
             _notifyDebounceTimer ??= new Timer(_ => EmitProjectsChanged());
             _notifyDebounceTimer.Change(s_notifyDebounce, Timeout.InfiniteTimeSpan);
         }
@@ -256,6 +265,11 @@ internal class LocalParatextProjects : IDisposable
 
     private void EmitProjectsChanged()
     {
+        // Second line of defence for a callback already in flight when Dispose ran —
+        // Timer.Dispose() does not wait for in-flight callbacks — so a dying timer does not
+        // emit against a disposing PapiClient.
+        if (_disposed)
+            return;
         if (_papiClient == null)
             return;
         ThreadingUtils.ObserveTaskLoggingErrorsToStderr(
@@ -471,13 +485,14 @@ internal class LocalParatextProjects : IDisposable
 
     private void ScheduleProjectDirectoriesChanged()
     {
-        // A watcher event/error can race Dispose (see Dispose's comment); back off rather than
-        // touching a debounce timer that may already be disposed.
-        if (_disposed)
-            return;
         // Debounce: a clone/install fires a burst of events; collapse them into one refresh+notify.
         lock (_projectChangeLock)
         {
+            // A watcher event/error can race Dispose; read under the lock — Dispose tears this
+            // timer down under this same lock — so check-then-schedule is atomic with the
+            // teardown. Same shape and rationale as NotifyProjectsChanged.
+            if (_disposed)
+                return;
             _projectChangeDebounceTimer ??= new Timer(_ => OnProjectDirectoriesChanged());
             _projectChangeDebounceTimer.Change(s_projectChangeDebounce, Timeout.InfiniteTimeSpan);
         }
@@ -491,6 +506,13 @@ internal class LocalParatextProjects : IDisposable
     /// </summary>
     protected virtual void OnProjectDirectoriesChanged() => RefreshAndNotifyProjectsChanged();
 
+    /// <summary>
+    /// Tear down the watchers and debounce timers. Safe to race with watcher events and notify
+    /// calls: <see cref="_disposed"/> is set first, and each debounce timer is disposed under the
+    /// same lock its scheduler checks <see cref="_disposed"/> under, so a racing scheduler either
+    /// backs off or completes its schedule entirely before the teardown — it can never Change a
+    /// disposed timer nor construct a new one after disposal.
+    /// </summary>
     public virtual void Dispose()
     {
         // Set first (before any teardown below) so a racing AttachContainerWatcher/Register or a
@@ -505,8 +527,15 @@ internal class LocalParatextProjects : IDisposable
             _watchers.Clear();
             _watchedContainerPaths.Clear();
         }
-        _projectChangeDebounceTimer?.Dispose();
-        _notifyDebounceTimer?.Dispose();
+        // Each timer's teardown happens under the same lock its scheduler checks _disposed under
+        // (see the summary above). Deadlock-free: no timer callback holds either lock while
+        // waiting on Dispose (EmitProjectsChanged takes no locks; OnProjectDirectoriesChanged only
+        // briefly re-takes _notifyLock inside NotifyProjectsChanged), and Timer.Dispose() does not
+        // block on in-flight callbacks.
+        lock (_projectChangeLock)
+            _projectChangeDebounceTimer?.Dispose();
+        lock (_notifyLock)
+            _notifyDebounceTimer?.Dispose();
         GC.SuppressFinalize(this);
     }
 

--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -205,12 +205,28 @@ internal class LocalParatextProjects : IDisposable
     /// invisible to the project-directory watcher — the watcher is non-recursive, so an in-place
     /// <c>Settings.xml</c> rewrite or a mid-clone state landing during a Send/Receive never
     /// reaches it (see <see cref="StartWatchingProjectDirectory"/>) — and that therefore must both
-    /// re-read the project set and notify inline themselves. Virtual so tests can substitute the
-    /// ParatextData refresh.
+    /// re-read the project set and notify inline themselves. Also the funnel for the watcher path
+    /// (<see cref="OnProjectDirectoriesChanged"/> delegates here). Best-effort: a refresh failure
+    /// must not suppress the notify (a stale collection is better than a permanently stale list).
+    /// Virtual so tests can substitute the ParatextData refresh.
     /// </summary>
     public virtual void RefreshAndNotifyProjectsChanged()
     {
-        ScrTextCollection.RefreshScrTexts();
+        // A racing post-Dispose call must not touch the notify debounce timer (same guard as
+        // NotifyProjectsChanged / ScheduleProjectDirectoriesChanged); skip the refresh too — there
+        // is no consumer left to serve.
+        if (_disposed)
+            return;
+        try
+        {
+            ScrTextCollection.RefreshScrTexts();
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"RefreshScrTexts failed during a project-list refresh; notifying consumers anyway: {ex}"
+            );
+        }
         NotifyProjectsChanged();
     }
 
@@ -468,26 +484,12 @@ internal class LocalParatextProjects : IDisposable
     }
 
     /// <summary>
-    /// Run (debounced, on a timer thread) when a project was added/removed on disk. Refreshes
-    /// ParatextData's collection so the change is reflected, then notifies consumers. Best-effort: a
-    /// refresh failure must not suppress the notify (a stale collection is better than a permanently
-    /// stale list). Virtual so tests can observe firings without mutating the global
-    /// <c>ScrTextCollection</c>.
+    /// Run (debounced, on a timer thread) when a project was added/removed on disk. Delegates to
+    /// <see cref="RefreshAndNotifyProjectsChanged"/> — the shared refresh-then-notify funnel,
+    /// including its best-effort contract (a refresh failure must not suppress the notify). Virtual
+    /// so tests can observe firings without mutating the global <c>ScrTextCollection</c>.
     /// </summary>
-    protected virtual void OnProjectDirectoriesChanged()
-    {
-        try
-        {
-            ScrTextCollection.RefreshScrTexts();
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine(
-                $"RefreshScrTexts failed after a project directory change: {ex}"
-            );
-        }
-        NotifyProjectsChanged();
-    }
+    protected virtual void OnProjectDirectoriesChanged() => RefreshAndNotifyProjectsChanged();
 
     public virtual void Dispose()
     {

--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -199,6 +199,22 @@ internal class LocalParatextProjects : IDisposable
     }
 
     /// <summary>
+    /// Refresh ParatextData's in-memory project list from disk
+    /// (<see cref="ScrTextCollection.RefreshScrTexts()"/>) and then ask project-list consumers to
+    /// refetch via <see cref="NotifyProjectsChanged"/>. For writers whose on-disk changes are
+    /// invisible to the project-directory watcher — the watcher is non-recursive, so an in-place
+    /// <c>Settings.xml</c> rewrite or a mid-clone state landing during a Send/Receive never
+    /// reaches it (see <see cref="StartWatchingProjectDirectory"/>) — and that therefore must both
+    /// re-read the project set and notify inline themselves. Virtual so tests can substitute the
+    /// ParatextData refresh.
+    /// </summary>
+    public virtual void RefreshAndNotifyProjectsChanged()
+    {
+        ScrTextCollection.RefreshScrTexts();
+        NotifyProjectsChanged();
+    }
+
+    /// <summary>
     /// Ask project-list consumers to refetch their cheap metadata by emitting
     /// <see cref="PROJECTS_CHANGED_EVENT_TYPE"/>. Call after a project is added/removed or after one
     /// of its display-backing settings changes. Debounced (see <see cref="s_notifyDebounce"/>) so a

--- a/c-sharp/Projects/LocalParatextProjects.cs
+++ b/c-sharp/Projects/LocalParatextProjects.cs
@@ -212,6 +212,8 @@ internal class LocalParatextProjects : IDisposable
     /// re-read the project set and notify inline themselves. Also the funnel for the watcher path
     /// (<see cref="OnProjectDirectoriesChanged"/> delegates here). Best-effort: a refresh failure
     /// must not suppress the notify (a stale collection is better than a permanently stale list).
+    /// No-op until <see cref="Initialize"/> completes — refreshing an uninitialised
+    /// <see cref="ScrTextCollection"/> would broadcast a bogus project-list change.
     /// Virtual so tests can substitute the ParatextData refresh.
     /// </summary>
     public virtual void RefreshAndNotifyProjectsChanged()
@@ -221,6 +223,13 @@ internal class LocalParatextProjects : IDisposable
         // NotifyProjectsChanged (checked under _notifyLock), so a call racing Dispose past this
         // check is still safe.
         if (_disposed)
+            return;
+        // Pre-Initialize there is nothing to refresh yet: the ScrTextCollection is only set up
+        // once Initialize() runs (ParatextGlobals.Initialize), so a caller landing early (e.g. a
+        // sync completing before startup initialization finishes) would refresh an uninitialised
+        // collection and broadcast a bogus project-list change. Initialize's own scan supersedes
+        // any call skipped here. Lock-free read matches Initialize's own fast-path check.
+        if (!_isInitialized)
             return;
         try
         {

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -16,12 +16,17 @@ internal class ParatextProjectSendReceiveService(
     #region Constructors, consts, and fields
 
     /// <summary>
-    /// Request timeout for the long-running Send/Receive commands: a Send/Receive is a multi-minute
-    /// server operation (clone/pull/push round-trips per project), so the papi request timeout must
-    /// outlive it — with the default 30s timeout the caller would give up while the operation is
-    /// still running (and succeeding) on the backend. Inert in plain Platform.Bible since the stub
-    /// bodies below throw immediately, but the registration already carries it so the Paratext 10
-    /// Studio patch (which fills in the real implementations) inherits the correct timeout.
+    /// Request timeout for the long-running Send/Receive commands, carried on both the syncProjects
+    /// and breakSyncLock registrations: a whole-project sync is a multi-minute server operation
+    /// (clone/pull/push round-trips per project), and a lock break makes one potentially ~100s
+    /// server call per project (N projects in sequence), so either can outlive the default 30s papi
+    /// request timeout — with that default the caller would give up while the operation is still
+    /// running (and succeeding) on the backend. 0 = deliberately unbounded: no finite budget fits
+    /// every project count/size, and the only request a timeout would rescue is a lost response on
+    /// an otherwise-live socket — a risk every S/R command shares. Inert in plain Platform.Bible
+    /// since the stub bodies below throw immediately, but the registrations already carry it so the
+    /// Paratext 10 Studio patch (which fills in the real implementations) inherits the correct
+    /// timeout.
     /// </summary>
     internal static readonly TimeSpan s_sendReceiveTimeout = TimeSpan.FromSeconds(0); // 0 = no timeout
     #endregion
@@ -42,7 +47,8 @@ internal class ParatextProjectSendReceiveService(
             ),
             PapiClient.RegisterRequestHandlerAsync(
                 "command:paratextBibleSendReceive.syncProjects",
-                SyncProjects
+                SyncProjects,
+                s_sendReceiveTimeout
             ),
             PapiClient.RegisterRequestHandlerAsync(
                 "command:paratextBibleSendReceive.cancelSync",

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -37,6 +37,10 @@ internal class ParatextProjectSendReceiveService(
             PapiClient.RegisterRequestHandlerAsync(
                 "command:paratextBibleSendReceive.cancelSync",
                 CancelSync
+            ),
+            PapiClient.RegisterRequestHandlerAsync(
+                "command:paratextBibleSendReceive.breakSyncLock",
+                BreakSyncLock
             )
         );
     }
@@ -127,6 +131,22 @@ internal class ParatextProjectSendReceiveService(
     {
         throw new PlatformUnimplementedException(
             $"Command '{nameof(CancelSync)}' is not implemented in Platform.Bible. Must be running Paratext 10 Studio to use this command."
+        );
+    }
+
+    /// <summary>
+    /// Breaks (releases) the Send/Receive server lock for each given project and reports
+    /// per-project success. Recovery for a project whose lock is held by the current user
+    /// THEMSELVES (this same person on another computer, or a previous interrupted sync). The
+    /// server only permits breaking a lock you own, so this can never break another user's lock.
+    /// Exception is thrown if this function is not implemented in the current application.
+    /// </summary>
+    /// <param name="projectIds">Ids of the projects whose server lock to break.</param>
+    /// <returns>Map of (upper-cased) project id → whether that project's lock was broken.</returns>
+    protected Task<Dictionary<string, bool>> BreakSyncLock(List<string> projectIds)
+    {
+        throw new PlatformUnimplementedException(
+            $"Command '{nameof(BreakSyncLock)}' is not implemented in Platform.Bible. Must be running Paratext 10 Studio to use this command."
         );
     }
 

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -1,4 +1,5 @@
 using Paranext.DataProvider.Services;
+using static Paranext.DataProvider.NetworkObjects.Documentation.ExperimentalMethodDocumentation;
 
 namespace Paranext.DataProvider.Projects.SendReceive;
 
@@ -38,9 +39,30 @@ internal class ParatextProjectSendReceiveService(
                 "command:paratextBibleSendReceive.cancelSync",
                 CancelSync
             ),
+            // breakSyncLock is @experimental (see the TS declaration), so its registration also
+            // carries the x-experimental wire marker per the Experimental APIs standard.
             PapiClient.RegisterRequestHandlerAsync(
                 "command:paratextBibleSendReceive.breakSyncLock",
-                BreakSyncLock
+                BreakSyncLock,
+                null,
+                Create(
+                    "Breaks (releases) the Send/Receive server-side repository lock for each given "
+                        + "project and reports per-project success. Unrelated to the local "
+                        + "in-process sync write gate reported by onSyncWriteLockChanged / "
+                        + "getAutoSyncBlocking.",
+                    [
+                        Param(
+                            "projectIds",
+                            "Ids of the projects whose server lock to break. An empty array is a "
+                                + "no-op (empty result, server not contacted).",
+                            "array"
+                        ),
+                    ],
+                    ResultOf(
+                        "object",
+                        "Map of (upper-cased) project id → whether that project's lock was broken"
+                    )
+                )
             )
         );
     }
@@ -139,9 +161,13 @@ internal class ParatextProjectSendReceiveService(
     /// per-project success. Recovery for a project whose lock is held by the current user
     /// THEMSELVES (this same person on another computer, or a previous interrupted sync). The
     /// server only permits breaking a lock you own, so this can never break another user's lock.
+    /// This is the <b>server-side repository lock</b> held on the S/R server — unrelated to the
+    /// local in-process write gate (<see cref="SendReceiveWriteLock"/>) reported by the
+    /// neighboring onSyncWriteLockChanged event / getAutoSyncBlocking command.
     /// Exception is thrown if this function is not implemented in the current application.
     /// </summary>
-    /// <param name="projectIds">Ids of the projects whose server lock to break.</param>
+    /// <param name="projectIds">Ids of the projects whose server lock to break. An empty list is
+    /// a no-op: the result is an empty map and the server is never contacted.</param>
     /// <returns>Map of (upper-cased) project id → whether that project's lock was broken.</returns>
     protected Task<Dictionary<string, bool>> BreakSyncLock(List<string> projectIds)
     {

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -6,14 +6,16 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// <summary>
 /// Commands on the papi that handle Send/Receive-related operations
 /// </summary>
-// pdpFactory and appInfo are unread in this open-source implementation, but the closed-source
-// Paratext 10 Studio overlay patch binds them into properties, so the constructor signature must
-// keep them. Suppress the unread-parameter warning rather than removing the parameters.
+// pdpFactory, appInfo, and paratextProjects are unread in this open-source implementation, but the
+// closed-source Paratext 10 Studio overlay patch binds them into properties, so the constructor
+// signature must keep them. Suppress the unread-parameter warning rather than removing the
+// parameters.
 #pragma warning disable CS9113
 internal class ParatextProjectSendReceiveService(
     PapiClient papiClient,
     ParatextProjectDataProviderFactory pdpFactory,
-    AppInfo appInfo
+    AppInfo appInfo,
+    LocalParatextProjects paratextProjects
 )
 #pragma warning restore CS9113
 {

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -6,26 +6,12 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// <summary>
 /// Commands on the papi that handle Send/Receive-related operations
 /// </summary>
-// pdpFactory, appInfo, and paratextProjects are unread in this open-source implementation, but the
-// closed-source Paratext 10 Studio overlay patch binds them into properties, so the constructor
-// signature must keep them. Suppress the unread-parameter warning rather than removing the
-// parameters.
-//
-// paratextProjects in particular is here for the patch's shared sync wrapper (the single helper
-// both the manual and the scheduled sync command paths funnel through): core's project-directory
-// watcher is non-recursive and cannot see an in-place Settings.xml metadata rewrite
-// (name/language/editable) landing during a receive, so after a sync that can change the project
-// set or its display metadata the patch must call
-// paratextProjects.RefreshAndNotifyProjectsChanged() for Home / New Tab / the project picker to
-// refresh (see that method's doc).
-#pragma warning disable CS9113
 internal class ParatextProjectSendReceiveService(
     PapiClient papiClient,
     ParatextProjectDataProviderFactory pdpFactory,
     AppInfo appInfo,
     LocalParatextProjects paratextProjects
 )
-#pragma warning restore CS9113
 {
     #region Constructors, consts, and fields
 
@@ -92,7 +78,24 @@ internal class ParatextProjectSendReceiveService(
     #endregion
 
     #region Protected properties and methods
+
     protected PapiClient PapiClient { get; } = papiClient;
+
+    // The three properties below are read only by the closed-source Paratext 10 Studio patch,
+    // which replaces this class's stub bodies with real implementations. Do not remove them —
+    // removing them breaks the patch.
+    protected ParatextProjectDataProviderFactory PdpFactory { get; } = pdpFactory;
+
+    protected AppInfo AppInfo { get; } = appInfo;
+
+    // ParatextProjects in particular exists for the patch's shared sync wrapper (the single helper
+    // both the manual and the scheduled sync command paths funnel through): core's
+    // project-directory watcher is non-recursive and cannot see an in-place Settings.xml metadata
+    // rewrite (name/language/editable) landing during a receive, so after a sync that can change
+    // the project set or its display metadata the patch must call
+    // ParatextProjects.RefreshAndNotifyProjectsChanged() for Home / New Tab / the project picker
+    // to refresh (see that method's doc).
+    protected LocalParatextProjects ParatextProjects { get; } = paratextProjects;
 
     #endregion
 

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -62,17 +62,16 @@ internal class ParatextProjectSendReceiveService(
                 "command:paratextBibleSendReceive.cancelSync",
                 CancelSync
             ),
-            // breakSyncLock is @experimental (see the TS declaration), so its registration also
-            // carries the x-experimental wire marker per the Experimental APIs standard.
             PapiClient.RegisterRequestHandlerAsync(
                 "command:paratextBibleSendReceive.breakSyncLock",
                 BreakSyncLock,
                 s_sendReceiveTimeout,
-                Create(
+                documentation: Create(
                     "Breaks (releases) the Send/Receive server-side repository lock for each given "
                         + "project and reports per-project success. Unrelated to the local "
                         + "in-process sync write gate reported by onSyncWriteLockChanged / "
-                        + "getAutoSyncBlocking.",
+                        + "getAutoSyncBlocking. Only implemented in Paratext 10 Studio; throws "
+                        + "PlatformUnimplementedException elsewhere.",
                     [
                         Param(
                             "projectIds",

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -143,7 +143,7 @@ internal class ParatextProjectSendReceiveService(
 #if DEBUG
         // Dev-only placeholder: paranext-core has no S/R impl. PT10 patches the whole method.
         NotificationService.Send(
-            papiClient,
+            PapiClient,
             new("Syncing projects… (dev placeholder)", NotificationSeverity.Info)
             {
                 Duration = 3000,
@@ -189,8 +189,13 @@ internal class ParatextProjectSendReceiveService(
     /// <returns>Map of (upper-cased) project id → whether that project's lock was broken.</returns>
     protected Task<Dictionary<string, bool>> BreakSyncLock(List<string> projectIds)
     {
-        throw new PlatformUnimplementedException(
-            $"Command '{nameof(BreakSyncLock)}' is not implemented in Platform.Bible. Must be running Paratext 10 Studio to use this command."
+        // Deliver the fault through the returned task rather than throwing synchronously, so the
+        // stub's fault mode matches the async Paratext 10 Studio implementation that replaces this
+        // body (and the method stays async-free, avoiding CS1998).
+        return Task.FromException<Dictionary<string, bool>>(
+            new PlatformUnimplementedException(
+                $"Command '{nameof(BreakSyncLock)}' is not implemented in Platform.Bible. Must be running Paratext 10 Studio to use this command."
+            )
         );
     }
 

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -10,6 +10,14 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 // closed-source Paratext 10 Studio overlay patch binds them into properties, so the constructor
 // signature must keep them. Suppress the unread-parameter warning rather than removing the
 // parameters.
+//
+// paratextProjects in particular is here for the patch's shared sync wrapper (the single helper
+// both the manual and the scheduled sync command paths funnel through): core's project-directory
+// watcher is non-recursive and cannot see an in-place Settings.xml metadata rewrite
+// (name/language/editable) landing during a receive, so after a sync that can change the project
+// set or its display metadata the patch must call
+// paratextProjects.RefreshAndNotifyProjectsChanged() for Home / New Tab / the project picker to
+// refresh (see that method's doc).
 #pragma warning disable CS9113
 internal class ParatextProjectSendReceiveService(
     PapiClient papiClient,
@@ -19,6 +27,19 @@ internal class ParatextProjectSendReceiveService(
 )
 #pragma warning restore CS9113
 {
+    #region Constructors, consts, and fields
+
+    /// <summary>
+    /// Request timeout for the long-running Send/Receive commands: a Send/Receive is a multi-minute
+    /// server operation (clone/pull/push round-trips per project), so the papi request timeout must
+    /// outlive it — with the default 30s timeout the caller would give up while the operation is
+    /// still running (and succeeding) on the backend. Inert in plain Platform.Bible since the stub
+    /// bodies below throw immediately, but the registration already carries it so the Paratext 10
+    /// Studio patch (which fills in the real implementations) inherits the correct timeout.
+    /// </summary>
+    internal static readonly TimeSpan s_sendReceiveTimeout = TimeSpan.FromSeconds(0); // 0 = no timeout
+    #endregion
+
     #region Public properties and methods
 
     public async Task InitializeAsync()
@@ -46,7 +67,7 @@ internal class ParatextProjectSendReceiveService(
             PapiClient.RegisterRequestHandlerAsync(
                 "command:paratextBibleSendReceive.breakSyncLock",
                 BreakSyncLock,
-                null,
+                s_sendReceiveTimeout,
                 Create(
                     "Breaks (releases) the Send/Receive server-side repository lock for each given "
                         + "project and reports per-project success. Unrelated to the local "
@@ -119,11 +140,6 @@ internal class ParatextProjectSendReceiveService(
     /// </param>
     protected void SyncProjects(String[]? projectIds)
     {
-        // PT10 integration note: paranext-core's project-directory watcher is non-recursive and
-        // does NOT catch an in-place Settings.xml metadata rewrite (name/language/editable) landing
-        // during a Send/Receive receive. PT10's patched implementation of this method must call
-        // LocalParatextProjects.NotifyProjectsChanged() after a sync that can change the project set
-        // or display metadata, so Home / New Tab / the project picker refresh.
 #if DEBUG
         // Dev-only placeholder: paranext-core has no S/R impl. PT10 patches the whole method.
         NotificationService.Send(

--- a/c-sharp/Projects/SendReceive/SendReceiveBlockNotifierService.cs
+++ b/c-sharp/Projects/SendReceive/SendReceiveBlockNotifierService.cs
@@ -1,3 +1,5 @@
+using static Paranext.DataProvider.NetworkObjects.Documentation.ExperimentalMethodDocumentation;
+
 namespace Paranext.DataProvider.Projects.SendReceive;
 
 /// <summary>
@@ -104,10 +106,19 @@ internal class SendReceiveBlockNotifierService(PapiClient papiClient)
 
         // Register the pull command so a renderer can read the current snapshot on demand instead of
         // waiting for the next transition. GetBlockState returns the snapshot the handler serializes
-        // straight back to the caller.
+        // straight back to the caller. The command is @experimental (see the TS declaration), so its
+        // registration also carries the x-experimental wire marker per the Experimental APIs
+        // standard.
         await PapiClient.RegisterRequestHandlerAsync(
             GetAutoSyncBlockingCommand,
-            SendReceiveWriteLock.GetBlockState
+            SendReceiveWriteLock.GetBlockState,
+            null,
+            Create(
+                "Returns the S/R write gate's current block-state snapshot ({ isBlocking, "
+                    + "projectIds }) so a renderer can seed its blocking state on demand instead of "
+                    + "waiting for the next onSyncWriteLockChanged transition.",
+                result: ResultOf("object", "The write gate's current block-state snapshot")
+            )
         );
     }
 

--- a/c-sharp/Projects/SendReceive/SendReceiveBlockNotifierService.cs
+++ b/c-sharp/Projects/SendReceive/SendReceiveBlockNotifierService.cs
@@ -24,9 +24,12 @@ namespace Paranext.DataProvider.Projects.SendReceive;
 /// </list>
 /// </para>
 /// <para>
-/// <b>Inert in open-source Platform.Bible.</b> Nothing arms <see cref="SendReceiveWriteLock"/> in
-/// public core, so <see cref="SendReceiveWriteLock.BlockStateChanged"/> never fires and the command
-/// always returns a not-blocking snapshot. The service is truthful either way — it just has nothing
+/// <b>The gate never arms in open-source Platform.Bible.</b> Nothing arms
+/// <see cref="SendReceiveWriteLock"/> in public core, so
+/// <see cref="SendReceiveWriteLock.BlockStateChanged"/> never fires there and the command always
+/// returns a not-blocking snapshot. Every build — plain Platform.Bible included — still emits the
+/// event exactly once per backend (re)start: the not-blocking baseline snapshot at the end of
+/// <see cref="InitializeAsync"/>. The service is truthful either way — it just has nothing further
 /// to report until the Paratext 10 Studio patch brackets a sync with the gate (PT-4210).
 /// </para>
 /// <para>
@@ -98,6 +101,11 @@ internal class SendReceiveBlockNotifierService(PapiClient papiClient)
 
     private PapiClient PapiClient { get; } = papiClient;
 
+    /// <summary>
+    /// Registers both wire surfaces and then emits the gate's baseline snapshot, awaited, so once
+    /// the startup barrier (Program.cs's critical <c>Task.WhenAll</c>) completes, the baseline
+    /// emit is guaranteed to have gone out before any command-driven gate arm can emit.
+    /// </summary>
     public async Task InitializeAsync()
     {
         // Subscribe to the gate FIRST, before the registration round-trips below, so no transition
@@ -159,8 +167,25 @@ internal class SendReceiveBlockNotifierService(PapiClient papiClient)
 
         // Emit the current gate snapshot once now that both surfaces are up, so a subscriber that
         // was already listening across a backend restart converges on the fresh process's state
-        // instead of keeping whatever stale state it last saw.
-        OnBlockStateChanged(SendReceiveWriteLock.GetBlockState());
+        // instead of keeping whatever stale state it last saw. AWAITED — unlike the event-driven
+        // forwards through OnBlockStateChanged, which must never delay the gate's raise — so the
+        // startup barrier (see this method's doc) guarantees this baseline emit precedes any
+        // command-driven gate arm's event. Still best-effort like the registration above: a failed
+        // emit is logged, not thrown, because the next gate transition re-converges the subscriber
+        // and startup must never break over a notify.
+        try
+        {
+            await PapiClient.SendEventAsync(
+                BlockStateChangedEvent,
+                SendReceiveWriteLock.GetBlockState()
+            );
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"Failed to emit the baseline {BlockStateChangedEvent} snapshot: {ex}"
+            );
+        }
     }
 
     /// <summary>

--- a/c-sharp/Projects/SendReceive/SendReceiveBlockNotifierService.cs
+++ b/c-sharp/Projects/SendReceive/SendReceiveBlockNotifierService.cs
@@ -102,9 +102,19 @@ internal class SendReceiveBlockNotifierService(PapiClient papiClient)
     private PapiClient PapiClient { get; } = papiClient;
 
     /// <summary>
-    /// Registers both wire surfaces and then emits the gate's baseline snapshot, awaited, so once
-    /// the startup barrier (Program.cs's critical <c>Task.WhenAll</c>) completes, the baseline
-    /// emit is guaranteed to have gone out before any command-driven gate arm can emit.
+    /// Registers both wire surfaces and then emits the gate's baseline snapshot, awaited, so the
+    /// emit attempt completes before this method — and therefore before the startup barrier
+    /// (Program.cs's critical <c>Task.WhenAll</c>) — returns. That is deliberately NOT a
+    /// baseline-before-any-arm guarantee: the S/R command registrations are members of the SAME
+    /// barrier, and <c>Task.WhenAll</c> does not order its members, so a command dispatched
+    /// mid-barrier can arm the gate and emit before the baseline goes out. That ordering is safe
+    /// without being prevented, because the baseline is a LIVE read —
+    /// <see cref="SendReceiveWriteLock.GetBlockState"/> evaluated at emit time — so a baseline that
+    /// loses the race carries the armed state rather than overwriting it with a stale not-blocking
+    /// snapshot. What the await does buy: any arm AFTER the barrier emits strictly behind the
+    /// already-transmitted baseline (one connection, FIFO delivery) for every subscriber connected
+    /// throughout. A subscriber that connects later gets no replay either way — it seeds via
+    /// <c>getAutoSyncBlocking</c>.
     /// </summary>
     public async Task InitializeAsync()
     {
@@ -169,10 +179,13 @@ internal class SendReceiveBlockNotifierService(PapiClient papiClient)
         // was already listening across a backend restart converges on the fresh process's state
         // instead of keeping whatever stale state it last saw. AWAITED — unlike the event-driven
         // forwards through OnBlockStateChanged, which must never delay the gate's raise — so the
-        // startup barrier (see this method's doc) guarantees this baseline emit precedes any
-        // command-driven gate arm's event. Still best-effort like the registration above: a failed
-        // emit is logged, not thrown, because the next gate transition re-converges the subscriber
-        // and startup must never break over a notify.
+        // emit attempt completes before InitializeAsync (and so the startup barrier) returns, and
+        // any gate arm AFTER the barrier emits strictly behind it (one connection, FIFO). An arm
+        // DURING the barrier can still emit first — see this method's doc for why that ordering is
+        // safe (the GetBlockState() below is a live read at emit time, so a baseline that loses
+        // that race reports the armed state, not a stale not-blocking one). Still best-effort like
+        // the registration above: a failed emit is logged, not thrown, because the next gate
+        // transition re-converges the subscriber and startup must never break over a notify.
         try
         {
             await PapiClient.SendEventAsync(

--- a/c-sharp/Projects/SendReceive/SendReceiveBlockNotifierService.cs
+++ b/c-sharp/Projects/SendReceive/SendReceiveBlockNotifierService.cs
@@ -120,6 +120,11 @@ internal class SendReceiveBlockNotifierService(PapiClient papiClient)
                 result: ResultOf("object", "The write gate's current block-state snapshot")
             )
         );
+
+        // Emit the current gate snapshot once now that both surfaces are up, so a subscriber that
+        // was already listening across a backend restart converges on the fresh process's state
+        // instead of keeping whatever stale state it last saw.
+        OnBlockStateChanged(SendReceiveWriteLock.GetBlockState());
     }
 
     /// <summary>

--- a/c-sharp/Projects/SendReceive/SendReceiveBlockNotifierService.cs
+++ b/c-sharp/Projects/SendReceive/SendReceiveBlockNotifierService.cs
@@ -1,3 +1,4 @@
+using Paranext.DataProvider.NetworkObjects.Documentation;
 using static Paranext.DataProvider.NetworkObjects.Documentation.ExperimentalMethodDocumentation;
 
 namespace Paranext.DataProvider.Projects.SendReceive;
@@ -67,11 +68,39 @@ internal class SendReceiveBlockNotifierService(PapiClient papiClient)
     /// </summary>
     private const string RegisterEventMethod = "network:registerEvent";
 
+    /// <summary>
+    /// OpenRPC documentation sent along with the <see cref="BlockStateChangedEvent"/> registration
+    /// (the C# counterpart of the TypeScript <c>SingleNotificationDocumentation</c> second argument
+    /// to <c>network:registerEvent</c>). The event is @experimental (see the TS declaration), so
+    /// this carries the <c>x-experimental</c> wire marker.
+    /// </summary>
+    private static readonly OpenRpcSingleNotificationDocumentation s_blockStateChangedEventDocumentation =
+        new()
+        {
+            Notification = new()
+            {
+                Experimental = true,
+                Summary =
+                    "Emitted whenever the S/R write gate arms or disarms, carrying the gate's "
+                    + "full current block-state snapshot ({ isBlocking, projectIds }).",
+                Params =
+                [
+                    new()
+                    {
+                        Name = "state",
+                        Summary = "The write gate's current block-state snapshot",
+                        Required = true,
+                        Schema = new() { Type = "object" },
+                    },
+                ],
+            },
+        };
+
     private PapiClient PapiClient { get; } = papiClient;
 
     public async Task InitializeAsync()
     {
-        // Subscribe to the gate FIRST, before the registration round-trip below, so no transition
+        // Subscribe to the gate FIRST, before the registration round-trips below, so no transition
         // can slip through unsubscribed while the network:registerEvent request is in flight. A
         // transition that beats registration just announces unregistered (main logs its once-per-name
         // deprecation warning), which is the right trade for the single block-state signal — a missed
@@ -83,41 +112,48 @@ internal class SendReceiveBlockNotifierService(PapiClient papiClient)
         // Register the event with main's central event registry (best-effort — on rejection or
         // failure, log and continue; emitting unregistered still works, and startup must never break
         // over this). We accept that a transition arriving during this await may announce before the
-        // registration completes; see the subscribe-first rationale above.
-        try
+        // registration completes; see the subscribe-first rationale above. A local function so the
+        // try/catch travels with the request into the Task.WhenAll below.
+        async Task RegisterEventBestEffortAsync()
         {
-            bool accepted = await PapiClient.SendRequestAsync<bool>(
-                RegisterEventMethod,
-                [BlockStateChangedEvent]
-            );
-            if (!accepted)
-                Console.Error.WriteLine(
-                    $"Central registry rejected network event '{BlockStateChangedEvent}' (already "
-                        + "registered by another process?); announcements will warn as unregistered"
+            try
+            {
+                bool accepted = await PapiClient.SendRequestAsync<bool>(
+                    RegisterEventMethod,
+                    [BlockStateChangedEvent, s_blockStateChangedEventDocumentation]
                 );
-        }
-        catch (Exception ex)
-        {
-            Console.Error.WriteLine(
-                $"Failed to register network event '{BlockStateChangedEvent}' with the central "
-                    + $"registry; announcements will warn as unregistered. {ex}"
-            );
+                if (!accepted)
+                    Console.Error.WriteLine(
+                        $"Central registry rejected network event '{BlockStateChangedEvent}' (already "
+                            + "registered by another process?); announcements will warn as unregistered"
+                    );
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine(
+                    $"Failed to register network event '{BlockStateChangedEvent}' with the central "
+                        + $"registry; announcements will warn as unregistered. {ex}"
+                );
+            }
         }
 
-        // Register the pull command so a renderer can read the current snapshot on demand instead of
-        // waiting for the next transition. GetBlockState returns the snapshot the handler serializes
-        // straight back to the caller. The command is @experimental (see the TS declaration), so its
-        // registration also carries the x-experimental wire marker per the Experimental APIs
-        // standard.
-        await PapiClient.RegisterRequestHandlerAsync(
-            GetAutoSyncBlockingCommand,
-            SendReceiveWriteLock.GetBlockState,
-            null,
-            Create(
-                "Returns the S/R write gate's current block-state snapshot ({ isBlocking, "
-                    + "projectIds }) so a renderer can seed its blocking state on demand instead of "
-                    + "waiting for the next onSyncWriteLockChanged transition.",
-                result: ResultOf("object", "The write gate's current block-state snapshot")
+        // The command registration serves the pull surface: a renderer reads the current snapshot on
+        // demand instead of waiting for the next transition (GetBlockState returns the snapshot the
+        // handler serializes straight back to the caller). Run both registrations in parallel — each
+        // is an independent round-trip to main, and awaiting them serially would let one stalled
+        // response stack a second full request timeout onto the startup barrier.
+        await Task.WhenAll(
+            RegisterEventBestEffortAsync(),
+            PapiClient.RegisterRequestHandlerAsync(
+                GetAutoSyncBlockingCommand,
+                SendReceiveWriteLock.GetBlockState,
+                null,
+                Create(
+                    "Returns the S/R write gate's current block-state snapshot ({ isBlocking, "
+                        + "projectIds }) so a renderer can seed its blocking state on demand instead of "
+                        + "waiting for the next onSyncWriteLockChanged transition.",
+                    result: ResultOf("object", "The write gate's current block-state snapshot")
+                )
             )
         );
 

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -441,7 +441,8 @@ declare module 'papi-shared-types' {
      *
      * @param projectIds Ids of the projects whose server lock to break. An empty array is a no-op:
      *   it resolves to an empty map without contacting the server. Null/blank ids are skipped and
-     *   omitted from the result map
+     *   omitted from the result map. Ids are trimmed, and case-variant duplicates collapse to a
+     *   single upper-cased key (first occurrence wins)
      * @returns Map of project id → whether that project's lock was broken. Keys are upper-cased —
      *   index the map with upper-cased ids. `false` means "not broken", not "attempt failed": an
      *   attempt may not have been made at all (e.g. the request was refused while a sync was in

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -481,8 +481,9 @@ declare module 'papi-shared-types' {
     /**
      * Emitted by the dotnet process whenever the S/R write gate arms or disarms, carrying the
      * gate's full current {@link SyncWriteLockSnapshot}. Fires for ALL sync types (manual +
-     * scheduled + session). Only fires in Paratext 10 Studio builds where the gate gets armed;
-     * plain Platform.Bible never emits it.
+     * scheduled + session). The gate only ever arms in Paratext 10 Studio builds — never in plain
+     * Platform.Bible, where the only emission is a single not-blocking baseline snapshot each time
+     * the backend (re)starts (every build emits that baseline).
      *
      * @experimental This event is unstable and may change or disappear without notice
      */

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -455,7 +455,10 @@ declare module 'papi-shared-types' {
      * Note: this command is served from the dotnet process. Unlike most Send/Receive commands it is
      * registered by core's own `SendReceiveBlockNotifierService` rather than the extension, so it
      * is answered on plain Platform.Bible too (always not-blocking there — only Paratext 10 Studio
-     * arms the gate). Older cores lack it entirely and requests reject.
+     * arms the gate). The realistic failure mode is a cold-start race: if the dotnet process has
+     * not registered the command within main's retry budget (~9s), the request rejects — callers
+     * should keep their fail-safe not-blocking default, and there is no re-query until PT-4265
+     * lands.
      *
      * @returns The write gate's current snapshot
      * @experimental This command is unstable and may change or disappear without notice

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -429,9 +429,15 @@ declare module 'papi-shared-types' {
      * person on another computer, or a previous interrupted sync). The server only permits breaking
      * a lock you own, so this can never break another user's lock.
      *
+     * This is the **server-side repository lock** held on the S/R server — unrelated to the local
+     * in-process sync write gate reported by the neighboring
+     * `paratextBibleSendReceive.onSyncWriteLockChanged` event /
+     * `paratextBibleSendReceive.getAutoSyncBlocking` command.
+     *
      * Note: this command is served from the dotnet process.
      *
-     * @param projectIds Ids of the projects whose server lock to break
+     * @param projectIds Ids of the projects whose server lock to break. An empty array is a no-op:
+     *   it resolves to an empty map without contacting the server
      * @returns Map of (upper-cased) project id → whether that project's lock was broken
      * @throws `PlatformUnimplementedException` if not running in an application that implements
      *   this command (e.g., Paratext 10 Studio)

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -424,6 +424,24 @@ declare module 'papi-shared-types' {
     'paratextBibleSendReceive.cancelSync': (notificationId?: string | number) => Promise<void>;
 
     /**
+     * Breaks (releases) the Send/Receive server lock for each given project and reports per-project
+     * success. Recovery for a project whose lock is held by the current user THEMSELVES (this same
+     * person on another computer, or a previous interrupted sync). The server only permits breaking
+     * a lock you own, so this can never break another user's lock.
+     *
+     * Note: this command is served from the dotnet process.
+     *
+     * @param projectIds Ids of the projects whose server lock to break
+     * @returns Map of (upper-cased) project id → whether that project's lock was broken
+     * @throws `PlatformUnimplementedException` if not running in an application that implements
+     *   this command (e.g., Paratext 10 Studio)
+     * @experimental This command is unstable and may change or disappear without notice
+     */
+    'paratextBibleSendReceive.breakSyncLock': (
+      projectIds: string[],
+    ) => Promise<{ [projectId: string]: boolean }>;
+
+    /**
      * Returns the S/R write gate's current {@link SyncWriteLockSnapshot} so subscribers can seed
      * their blocking state on init instead of assuming unblocked (e.g. after a renderer reload
      * during an in-flight sync).

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -267,6 +267,21 @@ declare module 'paratext-bible-send-receive' {
     /** 0–1 fraction; null/undefined ⇒ indeterminate. */
     progressValue?: number | null;
   };
+
+  /**
+   * Backend-authoritative snapshot of which projects an automatic Send/Receive is blocking edits on
+   * (the wire shape of the C# `SendReceiveBlockState`). Carried identically by both the
+   * `paratextBibleSendReceive.onSyncWriteLockChanged` network event and the
+   * `paratextBibleSendReceive.getAutoSyncBlocking` command return.
+   *
+   * @experimental This type is unstable and may change shape or disappear without notice
+   */
+  export type SyncWriteLockSnapshot = {
+    /** Whether the S/R write gate is currently blocking edits on any project */
+    isBlocking: boolean;
+    /** Ids of the blocked projects. `isBlocking` false always pairs with an empty array. */
+    projectIds: string[];
+  };
 }
 
 declare module 'papi-shared-types' {
@@ -274,6 +289,7 @@ declare module 'papi-shared-types' {
     ResultsData,
     SyncProgressDetail,
     SyncProgressEvent,
+    SyncWriteLockSnapshot,
   } from 'paratext-bible-send-receive';
   import type { SharedProjectsInfo } from 'platform-scripture';
 
@@ -406,6 +422,21 @@ declare module 'papi-shared-types' {
      *   this command (e.g., Paratext 10 Studio)
      */
     'paratextBibleSendReceive.cancelSync': (notificationId?: string | number) => Promise<void>;
+
+    /**
+     * Returns the S/R write gate's current {@link SyncWriteLockSnapshot} so subscribers can seed
+     * their blocking state on init instead of assuming unblocked (e.g. after a renderer reload
+     * during an in-flight sync).
+     *
+     * Note: this command is served from the dotnet process. Unlike most Send/Receive commands it is
+     * registered by core's own `SendReceiveBlockNotifierService` rather than the extension, so it
+     * is answered on plain Platform.Bible too (always not-blocking there — only Paratext 10 Studio
+     * arms the gate). Older cores lack it entirely and requests reject.
+     *
+     * @returns The write gate's current snapshot
+     * @experimental This command is unstable and may change or disappear without notice
+     */
+    'paratextBibleSendReceive.getAutoSyncBlocking': () => Promise<SyncWriteLockSnapshot>;
   }
 
   export interface NetworkEvents {
@@ -413,5 +444,14 @@ declare module 'papi-shared-types' {
     'paratextBibleSendReceive.onSyncStateChanged': SyncProgressEvent;
     /** Emitted repeatedly during a sync with the current project name or reconnect status */
     'paratextBibleSendReceive.onSyncProgress': SyncProgressDetail;
+    /**
+     * Emitted by the dotnet process whenever the S/R write gate arms or disarms, carrying the
+     * gate's full current {@link SyncWriteLockSnapshot}. Fires for ALL sync types (manual +
+     * scheduled + session). Only fires in Paratext 10 Studio builds where the gate gets armed;
+     * plain Platform.Bible never emits it.
+     *
+     * @experimental This event is unstable and may change or disappear without notice
+     */
+    'paratextBibleSendReceive.onSyncWriteLockChanged': SyncWriteLockSnapshot;
   }
 }

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -440,9 +440,10 @@ declare module 'papi-shared-types' {
      * Note: this command is served from the dotnet process.
      *
      * @param projectIds Ids of the projects whose server lock to break. An empty array is a no-op:
-     *   it resolves to an empty map without contacting the server. Null/blank ids are skipped and
-     *   omitted from the result map. Ids are trimmed, and case-variant duplicates collapse to a
-     *   single upper-cased key (first occurrence wins)
+     *   it resolves to an empty map without contacting the server. A null array is out of contract
+     *   (the type is `string[]`); implementations treat it like the empty array. Null/blank ids are
+     *   skipped and omitted from the result map. Ids are trimmed, and case-variant duplicates
+     *   collapse to a single upper-cased key (first occurrence wins)
      * @returns Map of project id → whether that project's lock was broken. Keys are upper-cased —
      *   index the map with upper-cased ids. `false` means "not broken", not "attempt failed": an
      *   attempt may not have been made at all (e.g. the request was refused while a sync was in

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -9,6 +9,9 @@
 // When the Send/Receive contract changes, re-sync the parts declared here from that file.
 // NOTE: Preserve any types that exist here but not in the upstream file (structural refinements
 // added in core before the upstream adopts them). Do not replace the module block wholesale.
+// Likewise for declarations that exist in BOTH copies: a re-sync must not downgrade a richer
+// declaration here (extra doc detail or type refinements) to a poorer upstream one — merge the
+// two, and upstream the improvement instead.
 //
 // Why this lives in `src/@types` and not under an extension's `src/types`:
 //
@@ -437,8 +440,12 @@ declare module 'papi-shared-types' {
      * Note: this command is served from the dotnet process.
      *
      * @param projectIds Ids of the projects whose server lock to break. An empty array is a no-op:
-     *   it resolves to an empty map without contacting the server
-     * @returns Map of (upper-cased) project id → whether that project's lock was broken
+     *   it resolves to an empty map without contacting the server. Null/blank ids are skipped and
+     *   omitted from the result map
+     * @returns Map of project id → whether that project's lock was broken. Keys are upper-cased —
+     *   index the map with upper-cased ids. `false` means "not broken", not "attempt failed": an
+     *   attempt may not have been made at all (e.g. the request was refused while a sync was in
+     *   progress), and a later retry can succeed
      * @throws `PlatformUnimplementedException` if not running in an application that implements
      *   this command (e.g., Paratext 10 Studio)
      * @experimental This command is unstable and may change or disappear without notice

--- a/src/renderer/services/auto-sync-blocking-service.test.ts
+++ b/src/renderer/services/auto-sync-blocking-service.test.ts
@@ -23,6 +23,7 @@ vi.mock('@shared/services/logger.service', () => ({
 
 const SYNC_WRITE_LOCK_CHANGED_EVENT = 'paratextBibleSendReceive.onSyncWriteLockChanged';
 const LEGACY_BLOCKING_CHANGED_EVENT = 'paratextBibleSendReceive.onAutoSyncBlockingChanged';
+const GET_AUTO_SYNC_BLOCKING_COMMAND = 'paratextBibleSendReceive.getAutoSyncBlocking';
 
 /** Flushes the service's fire-and-forget seeding chain (await + then-callbacks). */
 async function flushSeeding(): Promise<void> {
@@ -105,8 +106,30 @@ describe('initAutoSyncBlockingService', () => {
       expect(vi.mocked(setBlockedProjects)).toHaveBeenCalledTimes(2);
       expect(vi.mocked(setBlockedProjects)).toHaveBeenNthCalledWith(1, []);
       expect(vi.mocked(setBlockedProjects)).toHaveBeenNthCalledWith(2, []);
-      // Warn once per service lifetime, not once per malformed event.
+      // Warn once per source per service lifetime, not once per malformed event — and the message
+      // must name the source that produced the malformed payload.
       expect(vi.mocked(logger.warn)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        expect.stringContaining(`the ${SYNC_WRITE_LOCK_CHANGED_EVENT} event`),
+      );
+    });
+
+    it('latches the malformed warning per source — init query and event each warn once', async () => {
+      vi.mocked(sendCommand).mockResolvedValue('malformed');
+      initAutoSyncBlockingService();
+      await flushSeeding(); // the malformed init-query snapshot warns, latching the query source
+      if (!capturedHandler) throw new Error('capturedHandler not set');
+      capturedHandler(undefined); // a malformed event still warns on its own latch
+      capturedHandler(undefined); // …but only once
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(logger.warn)).toHaveBeenNthCalledWith(
+        1,
+        expect.stringContaining(`the ${GET_AUTO_SYNC_BLOCKING_COMMAND} init query`),
+      );
+      expect(vi.mocked(logger.warn)).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining(`the ${SYNC_WRITE_LOCK_CHANGED_EVENT} event`),
+      );
     });
 
     it('fails safe to block-none when projectIds contains a non-string', () => {
@@ -143,18 +166,28 @@ describe('initAutoSyncBlockingService', () => {
       expect(vi.mocked(setBlockedProjects)).not.toHaveBeenCalled();
     });
 
-    it('does not seed when the query result is malformed', async () => {
+    it('does not seed when the query result is malformed, and warns naming the query', async () => {
       vi.mocked(sendCommand).mockResolvedValue('yes');
       initAutoSyncBlockingService();
       await flushSeeding();
       expect(vi.mocked(setBlockedProjects)).not.toHaveBeenCalled();
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        expect.stringContaining(`the ${GET_AUTO_SYNC_BLOCKING_COMMAND} init query`),
+      );
     });
 
-    it('swallows a failed query and keeps the assume-unblocked default', async () => {
-      vi.mocked(sendCommand).mockRejectedValue(new Error('extension absent'));
+    it('swallows a failed query, keeps the assume-unblocked default, and warns', async () => {
+      vi.mocked(sendCommand).mockRejectedValue(new Error('backend not up yet'));
       initAutoSyncBlockingService();
       await flushSeeding();
       expect(vi.mocked(setBlockedProjects)).not.toHaveBeenCalled();
+      // Warn (not debug): the command is registered by core's own backend, so a rejection is
+      // anomalous — realistically the cold-start race — and there is no re-query until PT-4265.
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(logger.warn)).toHaveBeenCalledWith(
+        expect.stringContaining('could not read the initial blocking state'),
+      );
     });
 
     it('lets a live event win over the snapshot — no seeding after an event arrived', async () => {

--- a/src/renderer/services/auto-sync-blocking-service.test.ts
+++ b/src/renderer/services/auto-sync-blocking-service.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { getNetworkEvent, requestNoRetry } from '@shared/services/network.service';
+import { sendCommand } from '@shared/services/command.service';
+import { getNetworkEvent } from '@shared/services/network.service';
 import { setBlockedProjects } from '@renderer/services/auto-sync-blocking-store';
 import { logger } from '@shared/services/logger.service';
 import { initAutoSyncBlockingService } from './auto-sync-blocking-service';
 
+vi.mock('@shared/services/command.service', () => ({
+  sendCommand: vi.fn(),
+}));
+
 vi.mock('@shared/services/network.service', () => ({
   getNetworkEvent: vi.fn(),
-  requestNoRetry: vi.fn(),
 }));
 
 vi.mock('@renderer/services/auto-sync-blocking-store', () => ({
@@ -57,7 +61,7 @@ describe('initAutoSyncBlockingService', () => {
     );
 
     // Default: no core serves the initial-state command (an older core / absent extension).
-    vi.mocked(requestNoRetry).mockRejectedValue(new Error('command not registered'));
+    vi.mocked(sendCommand).mockRejectedValue(new Error('command not registered'));
   });
 
   describe('event source', () => {
@@ -119,13 +123,13 @@ describe('initAutoSyncBlockingService', () => {
     it('queries the current blocking state on init', async () => {
       initAutoSyncBlockingService();
       await flushSeeding();
-      expect(vi.mocked(requestNoRetry)).toHaveBeenCalledWith(
-        'command:paratextBibleSendReceive.getAutoSyncBlocking',
+      expect(vi.mocked(sendCommand)).toHaveBeenCalledWith(
+        'paratextBibleSendReceive.getAutoSyncBlocking',
       );
     });
 
     it('seeds the blocked projects when the query reports an in-flight sync (reload mid-sync)', async () => {
-      vi.mocked(requestNoRetry).mockResolvedValue({ isBlocking: true, projectIds: ['p1'] });
+      vi.mocked(sendCommand).mockResolvedValue({ isBlocking: true, projectIds: ['p1'] });
       initAutoSyncBlockingService();
       await flushSeeding();
       expect(vi.mocked(setBlockedProjects)).toHaveBeenCalledTimes(1);
@@ -133,21 +137,21 @@ describe('initAutoSyncBlockingService', () => {
     });
 
     it('does not seed when the query reports no sync in flight', async () => {
-      vi.mocked(requestNoRetry).mockResolvedValue({ isBlocking: false, projectIds: [] });
+      vi.mocked(sendCommand).mockResolvedValue({ isBlocking: false, projectIds: [] });
       initAutoSyncBlockingService();
       await flushSeeding();
       expect(vi.mocked(setBlockedProjects)).not.toHaveBeenCalled();
     });
 
     it('does not seed when the query result is malformed', async () => {
-      vi.mocked(requestNoRetry).mockResolvedValue('yes');
+      vi.mocked(sendCommand).mockResolvedValue('yes');
       initAutoSyncBlockingService();
       await flushSeeding();
       expect(vi.mocked(setBlockedProjects)).not.toHaveBeenCalled();
     });
 
     it('swallows a failed query and keeps the assume-unblocked default', async () => {
-      vi.mocked(requestNoRetry).mockRejectedValue(new Error('extension absent'));
+      vi.mocked(sendCommand).mockRejectedValue(new Error('extension absent'));
       initAutoSyncBlockingService();
       await flushSeeding();
       expect(vi.mocked(setBlockedProjects)).not.toHaveBeenCalled();
@@ -155,7 +159,7 @@ describe('initAutoSyncBlockingService', () => {
 
     it('lets a live event win over the snapshot — no seeding after an event arrived', async () => {
       let resolveQuery: ((snapshot: unknown) => void) | undefined;
-      vi.mocked(requestNoRetry).mockImplementation(
+      vi.mocked(sendCommand).mockImplementation(
         async () =>
           new Promise((resolve) => {
             resolveQuery = resolve;
@@ -175,7 +179,7 @@ describe('initAutoSyncBlockingService', () => {
 
     it('does not seed after cleanup', async () => {
       let resolveQuery: ((snapshot: unknown) => void) | undefined;
-      vi.mocked(requestNoRetry).mockImplementation(
+      vi.mocked(sendCommand).mockImplementation(
         async () =>
           new Promise((resolve) => {
             resolveQuery = resolve;

--- a/src/renderer/services/auto-sync-blocking-service.test.ts
+++ b/src/renderer/services/auto-sync-blocking-service.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { SyncWriteLockSnapshot } from 'paratext-bible-send-receive';
 import { sendCommand } from '@shared/services/command.service';
 import { getNetworkEvent } from '@shared/services/network.service';
 import { setBlockedProjects } from '@renderer/services/auto-sync-blocking-store';
@@ -152,7 +153,12 @@ describe('initAutoSyncBlockingService', () => {
     });
 
     it('seeds the blocked projects when the query reports an in-flight sync (reload mid-sync)', async () => {
-      vi.mocked(sendCommand).mockResolvedValue({ isBlocking: true, projectIds: ['p1'] });
+      // `satisfies` pins the well-formed mocks to the seam's wire shape, so a contract change
+      // breaks these tests at compile time (deliberately-malformed mocks stay untyped).
+      vi.mocked(sendCommand).mockResolvedValue({
+        isBlocking: true,
+        projectIds: ['p1'],
+      } satisfies SyncWriteLockSnapshot);
       initAutoSyncBlockingService();
       await flushSeeding();
       expect(vi.mocked(setBlockedProjects)).toHaveBeenCalledTimes(1);
@@ -160,7 +166,10 @@ describe('initAutoSyncBlockingService', () => {
     });
 
     it('does not seed when the query reports no sync in flight', async () => {
-      vi.mocked(sendCommand).mockResolvedValue({ isBlocking: false, projectIds: [] });
+      vi.mocked(sendCommand).mockResolvedValue({
+        isBlocking: false,
+        projectIds: [],
+      } satisfies SyncWriteLockSnapshot);
       initAutoSyncBlockingService();
       await flushSeeding();
       expect(vi.mocked(setBlockedProjects)).not.toHaveBeenCalled();

--- a/src/renderer/services/auto-sync-blocking-service.ts
+++ b/src/renderer/services/auto-sync-blocking-service.ts
@@ -4,10 +4,8 @@ import { getNetworkEvent } from '@shared/services/network.service';
 import { getErrorMessage, isString } from 'platform-bible-utils';
 import { setBlockedProjects } from './auto-sync-blocking-store';
 
-// The `SyncWriteLockSnapshot` payload both signal surfaces below carry is declared in the
-// `paratext-bible-send-receive` type seam (`src/@types/paratext-bible-send-receive/index.d.ts`):
-// a backend-authoritative snapshot of which projects an automatic Send/Receive is blocking edits
-// on. `isBlocking` false always pairs with an empty `projectIds`.
+// Payload types (`SyncWriteLockSnapshot`) come from the `paratext-bible-send-receive` seam
+// declarations in `src/@types/paratext-bible-send-receive/index.d.ts`.
 
 // Backend-authoritative network event (declared in the seam's `NetworkEvents`): the C# write gate
 // emits a full snapshot on every arm/disarm, for ALL sync types (manual + scheduled + session).
@@ -75,6 +73,8 @@ export function initAutoSyncBlockingService(): () => void {
 
   const unsubscribe = getNetworkEvent(SYNC_WRITE_LOCK_CHANGED_EVENT)((event) => {
     hasReceivedEvent = true;
+    // `event` is typed by the seam declaration, but it is untrusted wire data — keep the runtime
+    // validation.
     setBlockedProjects(readBlockedProjectIds(event, `the ${SYNC_WRITE_LOCK_CHANGED_EVENT} event`));
   });
 
@@ -86,10 +86,15 @@ export function initAutoSyncBlockingService(): () => void {
   // on PT-4265; until that lands, this one-shot seed is the only recovery.
   (async () => {
     try {
+      // Plain `sendCommand` — with main's retry-on-timeout — is deliberate now that the command is
+      // declared in the seam; the `requestNoRetry` this call once used was only a workaround for
+      // the missing declaration.
       const snapshot = await sendCommand(GET_AUTO_SYNC_BLOCKING_COMMAND);
       // Only seed if nothing live has spoken: an event that arrived while the request was in flight
       // (either direction) supersedes this snapshot and must win, so we never clobber it here.
       if (!hasReceivedEvent && !isDisposed) {
+        // `snapshot` is typed by the seam declaration, but it is untrusted wire data — keep the
+        // runtime validation.
         const blockedProjectIds = readBlockedProjectIds(
           snapshot,
           `the ${GET_AUTO_SYNC_BLOCKING_COMMAND} init query`,

--- a/src/renderer/services/auto-sync-blocking-service.ts
+++ b/src/renderer/services/auto-sync-blocking-service.ts
@@ -19,9 +19,11 @@ const SYNC_WRITE_LOCK_CHANGED_EVENT = 'paratextBibleSendReceive.onSyncWriteLockC
 /**
  * Command served by the C# backend (the emitter of {@link SYNC_WRITE_LOCK_CHANGED_EVENT}) returning
  * the current snapshot, so this service can seed the store on init instead of assuming unblocked.
- * Declared in the seam's `CommandHandlers`, so it is sent through the typed `sendCommand`. Served
- * on Paratext 10 Studio (returns not-blocking on plain Platform.Bible); older cores lack it
- * entirely and the request rejects, leaving the assume-unblocked default.
+ * Declared in the seam's `CommandHandlers`, so it is sent through the typed `sendCommand`. Core's
+ * own backend registers it, so it is answered on plain Platform.Bible too (always not-blocking
+ * there). The realistic failure is a cold-start race: the backend has not registered the command
+ * within main's retry budget (~9s), the request rejects, and the assume-unblocked default stands —
+ * with no re-query until PT-4265 lands.
  */
 const GET_AUTO_SYNC_BLOCKING_COMMAND = 'paratextBibleSendReceive.getAutoSyncBlocking';
 
@@ -39,15 +41,15 @@ const GET_AUTO_SYNC_BLOCKING_COMMAND = 'paratextBibleSendReceive.getAutoSyncBloc
 export function initAutoSyncBlockingService(): () => void {
   let hasReceivedEvent = false;
   let isDisposed = false;
-  let hasWarnedMalformed = false;
+  const warnedMalformedSources = new Set<string>();
 
   /**
    * Extracts the project ids to block from an untrusted snapshot payload. A well-formed
    * not-blocking snapshot yields `[]`; a malformed/missing-field payload also yields `[]`
-   * (fail-safe assume-unblocked) and warns once per service lifetime, consistent with the
-   * assume-unblocked init philosophy — a broken signal must never leave the workspace blocked.
+   * (fail-safe assume-unblocked) and warns once per `source` per service lifetime, consistent with
+   * the assume-unblocked init philosophy — a broken signal must never leave the workspace blocked.
    */
-  const readBlockedProjectIds = (payload: unknown): string[] => {
+  const readBlockedProjectIds = (payload: unknown, source: string): string[] => {
     if (
       typeof payload === 'object' &&
       payload &&
@@ -55,15 +57,17 @@ export function initAutoSyncBlockingService(): () => void {
       'projectIds' in payload
     ) {
       const { isBlocking, projectIds } = payload;
-      if (typeof isBlocking === 'boolean' && Array.isArray(projectIds)) {
-        const stringIds = projectIds.filter(isString);
-        if (stringIds.length === projectIds.length) return isBlocking ? stringIds : [];
-      }
+      if (
+        typeof isBlocking === 'boolean' &&
+        Array.isArray(projectIds) &&
+        projectIds.every(isString)
+      )
+        return isBlocking ? projectIds : [];
     }
-    if (!hasWarnedMalformed) {
-      hasWarnedMalformed = true;
+    if (!warnedMalformedSources.has(source)) {
+      warnedMalformedSources.add(source);
       logger.warn(
-        `auto-sync blocking service received a malformed ${SYNC_WRITE_LOCK_CHANGED_EVENT} snapshot; assuming not blocking`,
+        `auto-sync blocking service received a malformed snapshot from ${source}; assuming not blocking`,
       );
     }
     return [];
@@ -71,7 +75,7 @@ export function initAutoSyncBlockingService(): () => void {
 
   const unsubscribe = getNetworkEvent(SYNC_WRITE_LOCK_CHANGED_EVENT)((event) => {
     hasReceivedEvent = true;
-    setBlockedProjects(readBlockedProjectIds(event));
+    setBlockedProjects(readBlockedProjectIds(event, `the ${SYNC_WRITE_LOCK_CHANGED_EVENT} event`));
   });
 
   // LIMITATION: this init consult is the only backend re-seed — there is no re-query on websocket
@@ -86,13 +90,19 @@ export function initAutoSyncBlockingService(): () => void {
       // Only seed if nothing live has spoken: an event that arrived while the request was in flight
       // (either direction) supersedes this snapshot and must win, so we never clobber it here.
       if (!hasReceivedEvent && !isDisposed) {
-        const blockedProjectIds = readBlockedProjectIds(snapshot);
+        const blockedProjectIds = readBlockedProjectIds(
+          snapshot,
+          `the ${GET_AUTO_SYNC_BLOCKING_COMMAND} init query`,
+        );
         if (blockedProjectIds.length > 0) setBlockedProjects(blockedProjectIds);
       }
     } catch (e) {
-      // Command not served (older core) or the extension is absent — keep the assume-unblocked
-      // default. Debug, not warn: this is the expected path on plain Platform.Bible and older cores.
-      logger.debug(
+      // The seam is in-repo-only (core's own backend registers the command and ships with this
+      // service), so any rejection here is anomalous — realistically the cold-start race: the
+      // backend had not registered the command within main's retry budget. Keep the
+      // assume-unblocked default, but warn: with no re-query until PT-4265, a lost seed is worth
+      // noticing.
+      logger.warn(
         `auto-sync blocking service could not read the initial blocking state: ${getErrorMessage(e)}`,
       );
     }

--- a/src/renderer/services/auto-sync-blocking-service.ts
+++ b/src/renderer/services/auto-sync-blocking-service.ts
@@ -1,30 +1,27 @@
-import { CATEGORY_COMMAND } from '@shared/data/rpc.model';
+import { sendCommand } from '@shared/services/command.service';
 import { logger } from '@shared/services/logger.service';
-import { getNetworkEvent, requestNoRetry } from '@shared/services/network.service';
-import { serializeRequestType } from '@shared/utils/util';
+import { getNetworkEvent } from '@shared/services/network.service';
 import { getErrorMessage, isString } from 'platform-bible-utils';
 import { setBlockedProjects } from './auto-sync-blocking-store';
 
-/**
- * Backend-authoritative snapshot of which projects an automatic Send/Receive is blocking edits on.
- * Carried identically by both the change event and the init-consult command (see the C#
- * `SendReceiveBlockState`). `isBlocking` false always pairs with an empty `projectIds`.
- */
-type SyncWriteLockSnapshot = { isBlocking: boolean; projectIds: string[] };
+// The `SyncWriteLockSnapshot` payload both signal surfaces below carry is declared in the
+// `paratext-bible-send-receive` type seam (`src/@types/paratext-bible-send-receive/index.d.ts`):
+// a backend-authoritative snapshot of which projects an automatic Send/Receive is blocking edits
+// on. `isBlocking` false always pairs with an empty `projectIds`.
 
-// Backend-authoritative network event: the C# write gate emits a full snapshot on every arm/disarm,
-// for ALL sync types (manual + scheduled + session). This is the single signal source for blocking
-// — the store never combines it with any other opinion. Only fires in Paratext 10 Studio builds
-// where the patch arms the gate; plain Platform.Bible never emits it.
+// Backend-authoritative network event (declared in the seam's `NetworkEvents`): the C# write gate
+// emits a full snapshot on every arm/disarm, for ALL sync types (manual + scheduled + session).
+// This is the single signal source for blocking — the store never combines it with any other
+// opinion. Only fires in Paratext 10 Studio builds where the patch arms the gate; plain
+// Platform.Bible never emits it.
 const SYNC_WRITE_LOCK_CHANGED_EVENT = 'paratextBibleSendReceive.onSyncWriteLockChanged';
 
 /**
  * Command served by the C# backend (the emitter of {@link SYNC_WRITE_LOCK_CHANGED_EVENT}) returning
- * the current {@link SyncWriteLockSnapshot}, so this service can seed the store on init instead of
- * assuming unblocked. Requested untyped (the same pattern as `paratextBibleSendReceive.cancelSync`
- * in shutdown-tasks) because the copied `paratext-bible-send-receive.d.ts` command contract does
- * not declare it. Served on Paratext 10 Studio (returns not-blocking on plain Platform.Bible);
- * older cores lack it entirely and the request rejects, leaving the assume-unblocked default.
+ * the current snapshot, so this service can seed the store on init instead of assuming unblocked.
+ * Declared in the seam's `CommandHandlers`, so it is sent through the typed `sendCommand`. Served
+ * on Paratext 10 Studio (returns not-blocking on plain Platform.Bible); older cores lack it
+ * entirely and the request rejects, leaving the assume-unblocked default.
  */
 const GET_AUTO_SYNC_BLOCKING_COMMAND = 'paratextBibleSendReceive.getAutoSyncBlocking';
 
@@ -72,9 +69,7 @@ export function initAutoSyncBlockingService(): () => void {
     return [];
   };
 
-  const unsubscribe = getNetworkEvent<SyncWriteLockSnapshot>(SYNC_WRITE_LOCK_CHANGED_EVENT)((
-    event,
-  ) => {
+  const unsubscribe = getNetworkEvent(SYNC_WRITE_LOCK_CHANGED_EVENT)((event) => {
     hasReceivedEvent = true;
     setBlockedProjects(readBlockedProjectIds(event));
   });
@@ -87,9 +82,7 @@ export function initAutoSyncBlockingService(): () => void {
   // on PT-4214; until that lands, this one-shot seed is the only recovery.
   (async () => {
     try {
-      const snapshot = await requestNoRetry<[], unknown>(
-        serializeRequestType(CATEGORY_COMMAND, GET_AUTO_SYNC_BLOCKING_COMMAND),
-      );
+      const snapshot = await sendCommand(GET_AUTO_SYNC_BLOCKING_COMMAND);
       // Only seed if nothing live has spoken: an event that arrived while the request was in flight
       // (either direction) supersedes this snapshot and must win, so we never clobber it here.
       if (!hasReceivedEvent && !isDisposed) {

--- a/src/renderer/services/auto-sync-blocking-service.ts
+++ b/src/renderer/services/auto-sync-blocking-service.ts
@@ -79,7 +79,7 @@ export function initAutoSyncBlockingService(): () => void {
   // fire-and-forget SendEventAsync, an off-contract raise reorder, or a provider that restarts
   // disarmed without re-emitting), the visible blocked set stays stale until the next real
   // transition or a full renderer reload. Closing that gap needs an editor-mount re-query, tracked
-  // on PT-4214; until that lands, this one-shot seed is the only recovery.
+  // on PT-4265; until that lands, this one-shot seed is the only recovery.
   (async () => {
     try {
       const snapshot = await sendCommand(GET_AUTO_SYNC_BLOCKING_COMMAND);

--- a/src/renderer/services/auto-sync-blocking-service.ts
+++ b/src/renderer/services/auto-sync-blocking-service.ts
@@ -10,8 +10,9 @@ import { setBlockedProjects } from './auto-sync-blocking-store';
 // Backend-authoritative network event (declared in the seam's `NetworkEvents`): the C# write gate
 // emits a full snapshot on every arm/disarm, for ALL sync types (manual + scheduled + session).
 // This is the single signal source for blocking — the store never combines it with any other
-// opinion. Only fires in Paratext 10 Studio builds where the patch arms the gate; plain
-// Platform.Bible never emits it.
+// opinion. The gate only ever arms in Paratext 10 Studio builds (the patch arms it); in plain
+// Platform.Bible the only emission is a single not-blocking baseline snapshot each time the
+// backend (re)starts.
 const SYNC_WRITE_LOCK_CHANGED_EVENT = 'paratextBibleSendReceive.onSyncWriteLockChanged';
 
 /**


### PR DESCRIPTION
Post-merge-window cleanup from the PT-4158 triage (2026-07-27). Two stacked commits:

**1. Declare the held-back sync-block seam (PT-4214)**
`getAutoSyncBlocking` (command), `onSyncWriteLockChanged` (event) and their `SyncWriteLockSnapshot` payload type are now declared in `src/@types/paratext-bible-send-receive/index.d.ts`. They shipped in #2574 served from C#, but were deliberately left undeclared to avoid colliding with #2570's seam re-home; #2570 has merged, so the reason is gone (flagged in the 2026-07-24 PT-4214 code-state audit). The renderer's `auto-sync-blocking-service` drops its local type duplicate and its untyped `requestNoRetry` workaround in favor of the typed `sendCommand` / non-deprecated `getNetworkEvent` overload; its fail-safe unknown-payload validation is unchanged. All new declarations carry `@experimental`.

**2. Public `breakSyncLock` stub (PT-4210 Task 3)**
`paratextBibleSendReceive.breakSyncLock` existed only in the Paratext 10 Studio patch, deviating from the public/private seam convention `cancelSync`/`syncProjects` follow. This adds the public C# stub (`PlatformUnimplementedException`, sibling-identical phrasing) and the `@experimental` d.ts declaration, wire-signature-matched to the real implementation (`(projectIds: string[]) => Promise<{ [projectId: string]: boolean }>`). Two deliberate deviations from the patch: the stub is non-`async` (an async throw-only body would emit CS1998; the private body-fill re-adds `async`), and the indefinite-timeout registration arg stays patch-side (it is a patch-only constant, as for `syncProjects`).

**Pairing:** paranext/paratext-10-studio#168 converts the patch from command-registration to stub body-fill and must merge only after this PR. No behavior change in plain Platform.Bible — the stub throws exactly like its siblings.

**Verification:** typecheck 0 errors (core + all workspaces); vitest auto-sync-blocking suites 35/35; `dotnet build` 0 errors, no new warnings; `dotnet test --filter SendReceive` 69/69; papi.d.ts regen run → zero diff (the ambient seam is not part of generation); eslint/prettier/csharpier/cspell clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019MhYcp1XVTQ7JHiA4n2qaV

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2612)
<!-- Reviewable:end -->



---

**Review fix round (2026-07-27, tip `d12946c999b`):** self-review (/review-paratext, 4 passes) found 0 critical findings. Applied: wire-side experimental docs (`ExperimentalMethodDocumentation.Create`) on the `breakSyncLock` and `getAutoSyncBlocking` registrations; `breakSyncLock` docs now state it targets the *server* repository lock (not the local write gate) and that an empty array is a no-op (verified against the private implementation); the stale PT-4214 tracking comment in `auto-sync-blocking-service.ts` now points at PT-4265. Re-verified: build 0 errors, 69/69 filtered C# tests, typecheck clean, 14/14 renderer tests.


---

**Follow-up (2026-07-27, tip `4fcaa9f7e96`):** adds a `LocalParatextProjects` constructor parameter (patch-bound per the documented CS9113 convention in this class) so the Paratext 10 Studio patch can notify project-list consumers after a sync completes — in-place `Settings.xml` rewrites and mid-clone states are invisible to the non-recursive directory watcher (per its own doc comment), leaving the app-lifetime toolbar picker and open New Tab views stale. No behavior change in plain Platform.Bible (the stub never uses it). The paired patch-side call lands in paranext/paratext-10-studio#168. Build 0 errors, 69/69 filtered C# tests.


---

**Review round 2 (2026-07-28, tip `1159cb1de06`):** all 26 inline findings + review notes processed (verified-then-acted). Highlights: stub-side indefinite timeout (kills the patch's fragile registration hunk); public virtual `LocalParatextProjects.RefreshAndNotifyProjectsChanged()` + retargeted stub instruction; init-time snapshot emit; wire `x-experimental` on the event via new notification-doc records; `Task.FromException` stub; per-source payload-validation latch; cold-start-race doc rewrite (+warn); doc-assertion tests (new stub-docs test file); contract docs (upper-cased keys, skipped ids, `false` = not-broken); seam-header re-sync guard; CS9124 eliminated; and D2(b) — core-declared patch-bound properties replacing the CS9113 pragma. Build 0 errors, 73/73 filtered C#, 57/57 renderer tests.
