### PR TITLE
Don't let a startup settings-fetch timeout crash the whole data provider

### DIFF
--- a/c-sharp-tests/NetworkObjects/DummySettingsService.cs
+++ b/c-sharp-tests/NetworkObjects/DummySettingsService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using Paranext.DataProvider;
 using Paranext.DataProvider.NetworkObjects;
 using Paranext.DataProvider.Services;
@@ -23,6 +24,9 @@ internal class DummySettingsService : DataProvider
         _settingValues.Clear();
     }
 
+    /// <summary>Test-only accessor for what a "set" call actually persisted, if any.</summary>
+    public object? GetSettingValue(string key) => _settingValues.GetValueOrDefault(key);
+
     protected override Task StartDataProviderAsync()
     {
         return Task.CompletedTask;
@@ -46,7 +50,9 @@ internal class DummySettingsService : DataProvider
                 (string settingName, object settingValue) =>
                 {
                     _settingValues[settingName] = settingValue;
-                    return true;
+                    // SettingsService.SetSetting expects a JsonElement wire response (as a real
+                    // PAPI round trip would produce), not a raw bool.
+                    return JsonSerializer.SerializeToElement(true);
                 }
             ),
             (

--- a/c-sharp-tests/Services/PersistedParatextDataSettingsTests.cs
+++ b/c-sharp-tests/Services/PersistedParatextDataSettingsTests.cs
@@ -28,8 +28,7 @@ public class PersistedParatextDataSettingsTests
     public void Constructor_SettingLookupFails_FallsBackToEmptyInsteadOfThrowing()
     {
         // No AddSettingValue call, so DummySettingsService's "get" handler throws, mirroring how
-        // a real timeout surfaces as a thrown exception from SettingsService.GetSetting. If
-        // construction throws, this test fails with that exception.
+        // a real timeout surfaces as a thrown exception from SettingsService.GetSetting.
         var settings = new PersistedParatextDataSettings(_client);
 
         Assert.That(settings.LastRegistryDataCachedTimes, Is.Empty);

--- a/c-sharp-tests/Services/PersistedParatextDataSettingsTests.cs
+++ b/c-sharp-tests/Services/PersistedParatextDataSettingsTests.cs
@@ -68,26 +68,50 @@ public class PersistedParatextDataSettingsTests
     }
 
     [Test]
-    public void SafeSave_OnceReachableAfterAFailedLoad_PersistsAccumulatedChanges()
+    public void SafeSave_OnceReachableAfterAFailedLoad_MergesPersistedEntriesWithAccumulatedChanges()
     {
         // Initial load fails; changes accumulate in memory while the service is unreachable.
         var settings = new PersistedParatextDataSettings(_client);
-        settings.LastRegistryDataCachedTimes["someProject"] = "queued-before-service-available";
+        settings.LastRegistryDataCachedTimes["newProject"] = "queued-before-service-available";
         settings.SafeSave(); // still unreachable; skipped
 
-        // The service becomes reachable.
+        // The service becomes reachable, and it turns out it already had an entry from before
+        // this session that the failed initial load never got to see.
         _settingsService.AddSettingValue(
             Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES,
-            new SerializableStringDictionary()
+            new SerializableStringDictionary { ["existingProject"] = "2025-01-01" }
         );
 
-        settings.SafeSave(); // must retry, notice it's reachable now, and persist
+        settings.SafeSave(); // must retry, notice it's reachable now, merge, and persist
 
         var saved = (SerializableStringDictionary)
             _settingsService.GetSettingValue(
                 Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES
             )!;
-        Assert.That(saved["someProject"], Is.EqualTo("queued-before-service-available"));
+        Assert.That(saved["newProject"], Is.EqualTo("queued-before-service-available"));
+        Assert.That(saved["existingProject"], Is.EqualTo("2025-01-01"));
+    }
+
+    [Test]
+    public void SafeSave_OnceReachableAfterAFailedLoad_InMemoryValueWinsOnConflict()
+    {
+        var settings = new PersistedParatextDataSettings(_client);
+        settings.LastRegistryDataCachedTimes["someProject"] = "in-memory-value";
+        settings.SafeSave(); // still unreachable; skipped
+
+        // The persisted value for the same key differs from the in-memory one.
+        _settingsService.AddSettingValue(
+            Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES,
+            new SerializableStringDictionary { ["someProject"] = "stale-persisted-value" }
+        );
+
+        settings.SafeSave();
+
+        var saved = (SerializableStringDictionary)
+            _settingsService.GetSettingValue(
+                Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES
+            )!;
+        Assert.That(saved["someProject"], Is.EqualTo("in-memory-value"));
     }
 
     [Test]

--- a/c-sharp-tests/Services/PersistedParatextDataSettingsTests.cs
+++ b/c-sharp-tests/Services/PersistedParatextDataSettingsTests.cs
@@ -50,10 +50,10 @@ public class PersistedParatextDataSettingsTests
     }
 
     [Test]
-    public void SafeSave_AfterFailedLoad_DoesNotOverwritePersistedValue()
+    public void SafeSave_WhileStillUnreachable_DoesNotOverwritePersistedValue()
     {
         // Load fails (missing setting) and falls back to empty; SafeSave must skip the write so
-        // it can't clobber whatever is actually persisted.
+        // it can't clobber whatever is actually persisted, as long as it's still unreachable.
         var settings = new PersistedParatextDataSettings(_client);
         settings.LastRegistryDataCachedTimes["someProject"] = "mutated";
 
@@ -65,6 +65,29 @@ public class PersistedParatextDataSettingsTests
             ),
             Is.Null
         );
+    }
+
+    [Test]
+    public void SafeSave_OnceReachableAfterAFailedLoad_PersistsAccumulatedChanges()
+    {
+        // Initial load fails; changes accumulate in memory while the service is unreachable.
+        var settings = new PersistedParatextDataSettings(_client);
+        settings.LastRegistryDataCachedTimes["someProject"] = "queued-before-service-available";
+        settings.SafeSave(); // still unreachable; skipped
+
+        // The service becomes reachable.
+        _settingsService.AddSettingValue(
+            Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES,
+            new SerializableStringDictionary()
+        );
+
+        settings.SafeSave(); // must retry, notice it's reachable now, and persist
+
+        var saved = (SerializableStringDictionary)
+            _settingsService.GetSettingValue(
+                Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES
+            )!;
+        Assert.That(saved["someProject"], Is.EqualTo("queued-before-service-available"));
     }
 
     [Test]

--- a/c-sharp-tests/Services/PersistedParatextDataSettingsTests.cs
+++ b/c-sharp-tests/Services/PersistedParatextDataSettingsTests.cs
@@ -24,17 +24,18 @@ public class PersistedParatextDataSettingsTests
         _client.Dispose();
     }
 
-    [TestCase()]
+    [Test]
     public void Constructor_SettingLookupFails_FallsBackToEmptyInsteadOfThrowing()
     {
         // No AddSettingValue call, so DummySettingsService's "get" handler throws, mirroring how
-        // a real timeout surfaces as a thrown exception from SettingsService.GetSetting.
-        PersistedParatextDataSettings? settings = null;
-        Assert.DoesNotThrow(() => settings = new PersistedParatextDataSettings(_client));
-        Assert.That(settings!.LastRegistryDataCachedTimes, Is.Empty);
+        // a real timeout surfaces as a thrown exception from SettingsService.GetSetting. If
+        // construction throws, this test fails with that exception.
+        var settings = new PersistedParatextDataSettings(_client);
+
+        Assert.That(settings.LastRegistryDataCachedTimes, Is.Empty);
     }
 
-    [TestCase()]
+    [Test]
     public void Constructor_SettingPresent_ReturnsStoredValue()
     {
         var stored = new SerializableStringDictionary { ["someProject"] = "2026-01-01" };
@@ -46,5 +47,42 @@ public class PersistedParatextDataSettingsTests
         var settings = new PersistedParatextDataSettings(_client);
 
         Assert.That(settings.LastRegistryDataCachedTimes, Is.EqualTo(stored));
+    }
+
+    [Test]
+    public void SafeSave_AfterFailedLoad_DoesNotOverwritePersistedValue()
+    {
+        // Load fails (missing setting) and falls back to empty; SafeSave must skip the write so
+        // it can't clobber whatever is actually persisted.
+        var settings = new PersistedParatextDataSettings(_client);
+        settings.LastRegistryDataCachedTimes["someProject"] = "mutated";
+
+        settings.SafeSave();
+
+        Assert.That(
+            _settingsService.GetSettingValue(
+                Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES
+            ),
+            Is.Null
+        );
+    }
+
+    [Test]
+    public void SafeSave_AfterSuccessfulLoad_PersistsValue()
+    {
+        _settingsService.AddSettingValue(
+            Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES,
+            new SerializableStringDictionary()
+        );
+        var settings = new PersistedParatextDataSettings(_client);
+        settings.LastRegistryDataCachedTimes["someProject"] = "2026-01-01";
+
+        settings.SafeSave();
+
+        var saved = (SerializableStringDictionary)
+            _settingsService.GetSettingValue(
+                Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES
+            )!;
+        Assert.That(saved["someProject"], Is.EqualTo("2026-01-01"));
     }
 }

--- a/c-sharp-tests/Services/PersistedParatextDataSettingsTests.cs
+++ b/c-sharp-tests/Services/PersistedParatextDataSettingsTests.cs
@@ -1,0 +1,50 @@
+using System.Diagnostics.CodeAnalysis;
+using PtxUtils;
+using TestParanextDataProvider;
+
+namespace Paranext.DataProvider.Services.Tests;
+
+[ExcludeFromCodeCoverage]
+public class PersistedParatextDataSettingsTests
+{
+    private DummyPapiClient _client = null!;
+    private DummySettingsService _settingsService = null!;
+
+    [SetUp]
+    public async Task TestSetupAsync()
+    {
+        _client = new DummyPapiClient();
+        _settingsService = new DummySettingsService(_client);
+        await _settingsService.RegisterDataProviderAsync();
+    }
+
+    [TearDown]
+    public void TestTearDown()
+    {
+        _client.Dispose();
+    }
+
+    [TestCase()]
+    public void Constructor_SettingLookupFails_FallsBackToEmptyInsteadOfThrowing()
+    {
+        // No AddSettingValue call, so DummySettingsService's "get" handler throws, mirroring how
+        // a real timeout surfaces as a thrown exception from SettingsService.GetSetting.
+        PersistedParatextDataSettings? settings = null;
+        Assert.DoesNotThrow(() => settings = new PersistedParatextDataSettings(_client));
+        Assert.That(settings!.LastRegistryDataCachedTimes, Is.Empty);
+    }
+
+    [TestCase()]
+    public void Constructor_SettingPresent_ReturnsStoredValue()
+    {
+        var stored = new SerializableStringDictionary { ["someProject"] = "2026-01-01" };
+        _settingsService.AddSettingValue(
+            Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES,
+            stored
+        );
+
+        var settings = new PersistedParatextDataSettings(_client);
+
+        Assert.That(settings.LastRegistryDataCachedTimes, Is.EqualTo(stored));
+    }
+}

--- a/c-sharp-tests/Services/PersistedPtxUtilsSettingsTests.cs
+++ b/c-sharp-tests/Services/PersistedPtxUtilsSettingsTests.cs
@@ -60,24 +60,46 @@ public class PersistedPtxUtilsSettingsTests
     }
 
     [Test]
-    public void SafeSave_OnceReachableAfterAFailedLoad_PersistsAccumulatedChanges()
+    public void SafeSave_OnceReachableAfterAFailedLoad_MergesPersistedEntriesWithAccumulatedChanges()
     {
         // Initial load fails; changes accumulate in memory while the service is unreachable.
         var settings = new PersistedPtxUtilsSettings(_client);
-        settings.MementoData["someKey"] = "queued-before-service-available";
+        settings.MementoData["newKey"] = "queued-before-service-available";
         settings.SafeSave(); // still unreachable; skipped
 
-        // The service becomes reachable.
+        // The service becomes reachable, and it turns out it already had an entry from before
+        // this session that the failed initial load never got to see.
         _settingsService.AddSettingValue(
             Settings.PTX_UTILS_MEMENTO_DATA,
-            new SerializableStringDictionary()
+            new SerializableStringDictionary { ["existingKey"] = "existingValue" }
         );
 
-        settings.SafeSave(); // must retry, notice it's reachable now, and persist
+        settings.SafeSave(); // must retry, notice it's reachable now, merge, and persist
 
         var saved = (SerializableStringDictionary)
             _settingsService.GetSettingValue(Settings.PTX_UTILS_MEMENTO_DATA)!;
-        Assert.That(saved["someKey"], Is.EqualTo("queued-before-service-available"));
+        Assert.That(saved["newKey"], Is.EqualTo("queued-before-service-available"));
+        Assert.That(saved["existingKey"], Is.EqualTo("existingValue"));
+    }
+
+    [Test]
+    public void SafeSave_OnceReachableAfterAFailedLoad_InMemoryValueWinsOnConflict()
+    {
+        var settings = new PersistedPtxUtilsSettings(_client);
+        settings.MementoData["someKey"] = "in-memory-value";
+        settings.SafeSave(); // still unreachable; skipped
+
+        // The persisted value for the same key differs from the in-memory one.
+        _settingsService.AddSettingValue(
+            Settings.PTX_UTILS_MEMENTO_DATA,
+            new SerializableStringDictionary { ["someKey"] = "stale-persisted-value" }
+        );
+
+        settings.SafeSave();
+
+        var saved = (SerializableStringDictionary)
+            _settingsService.GetSettingValue(Settings.PTX_UTILS_MEMENTO_DATA)!;
+        Assert.That(saved["someKey"], Is.EqualTo("in-memory-value"));
     }
 
     [Test]

--- a/c-sharp-tests/Services/PersistedPtxUtilsSettingsTests.cs
+++ b/c-sharp-tests/Services/PersistedPtxUtilsSettingsTests.cs
@@ -1,0 +1,47 @@
+using System.Diagnostics.CodeAnalysis;
+using PtxUtils;
+using TestParanextDataProvider;
+
+namespace Paranext.DataProvider.Services.Tests;
+
+[ExcludeFromCodeCoverage]
+public class PersistedPtxUtilsSettingsTests
+{
+    private DummyPapiClient _client = null!;
+    private DummySettingsService _settingsService = null!;
+
+    [SetUp]
+    public async Task TestSetupAsync()
+    {
+        _client = new DummyPapiClient();
+        _settingsService = new DummySettingsService(_client);
+        await _settingsService.RegisterDataProviderAsync();
+    }
+
+    [TearDown]
+    public void TestTearDown()
+    {
+        _client.Dispose();
+    }
+
+    [TestCase()]
+    public void Constructor_SettingLookupFails_FallsBackToEmptyInsteadOfThrowing()
+    {
+        // No AddSettingValue call, so DummySettingsService's "get" handler throws, mirroring how
+        // a real timeout surfaces as a thrown exception from SettingsService.GetSetting.
+        PersistedPtxUtilsSettings? settings = null;
+        Assert.DoesNotThrow(() => settings = new PersistedPtxUtilsSettings(_client));
+        Assert.That(settings!.MementoData, Is.Empty);
+    }
+
+    [TestCase()]
+    public void Constructor_SettingPresent_ReturnsStoredValue()
+    {
+        var stored = new SerializableStringDictionary { ["someKey"] = "someValue" };
+        _settingsService.AddSettingValue(Settings.PTX_UTILS_MEMENTO_DATA, stored);
+
+        var settings = new PersistedPtxUtilsSettings(_client);
+
+        Assert.That(settings.MementoData, Is.EqualTo(stored));
+    }
+}

--- a/c-sharp-tests/Services/PersistedPtxUtilsSettingsTests.cs
+++ b/c-sharp-tests/Services/PersistedPtxUtilsSettingsTests.cs
@@ -24,17 +24,18 @@ public class PersistedPtxUtilsSettingsTests
         _client.Dispose();
     }
 
-    [TestCase()]
+    [Test]
     public void Constructor_SettingLookupFails_FallsBackToEmptyInsteadOfThrowing()
     {
         // No AddSettingValue call, so DummySettingsService's "get" handler throws, mirroring how
-        // a real timeout surfaces as a thrown exception from SettingsService.GetSetting.
-        PersistedPtxUtilsSettings? settings = null;
-        Assert.DoesNotThrow(() => settings = new PersistedPtxUtilsSettings(_client));
-        Assert.That(settings!.MementoData, Is.Empty);
+        // a real timeout surfaces as a thrown exception from SettingsService.GetSetting. If
+        // construction throws, this test fails with that exception.
+        var settings = new PersistedPtxUtilsSettings(_client);
+
+        Assert.That(settings.MementoData, Is.Empty);
     }
 
-    [TestCase()]
+    [Test]
     public void Constructor_SettingPresent_ReturnsStoredValue()
     {
         var stored = new SerializableStringDictionary { ["someKey"] = "someValue" };
@@ -43,5 +44,35 @@ public class PersistedPtxUtilsSettingsTests
         var settings = new PersistedPtxUtilsSettings(_client);
 
         Assert.That(settings.MementoData, Is.EqualTo(stored));
+    }
+
+    [Test]
+    public void SafeSave_AfterFailedLoad_DoesNotOverwritePersistedValue()
+    {
+        // Load fails (missing setting) and falls back to empty; SafeSave must skip the write so
+        // it can't reset the user's actual stored mementos.
+        var settings = new PersistedPtxUtilsSettings(_client);
+        settings.MementoData["someKey"] = "mutated";
+
+        settings.SafeSave();
+
+        Assert.That(_settingsService.GetSettingValue(Settings.PTX_UTILS_MEMENTO_DATA), Is.Null);
+    }
+
+    [Test]
+    public void SafeSave_AfterSuccessfulLoad_PersistsValue()
+    {
+        _settingsService.AddSettingValue(
+            Settings.PTX_UTILS_MEMENTO_DATA,
+            new SerializableStringDictionary()
+        );
+        var settings = new PersistedPtxUtilsSettings(_client);
+        settings.MementoData["someKey"] = "someValue";
+
+        settings.SafeSave();
+
+        var saved = (SerializableStringDictionary)
+            _settingsService.GetSettingValue(Settings.PTX_UTILS_MEMENTO_DATA)!;
+        Assert.That(saved["someKey"], Is.EqualTo("someValue"));
     }
 }

--- a/c-sharp-tests/Services/PersistedPtxUtilsSettingsTests.cs
+++ b/c-sharp-tests/Services/PersistedPtxUtilsSettingsTests.cs
@@ -28,8 +28,7 @@ public class PersistedPtxUtilsSettingsTests
     public void Constructor_SettingLookupFails_FallsBackToEmptyInsteadOfThrowing()
     {
         // No AddSettingValue call, so DummySettingsService's "get" handler throws, mirroring how
-        // a real timeout surfaces as a thrown exception from SettingsService.GetSetting. If
-        // construction throws, this test fails with that exception.
+        // a real timeout surfaces as a thrown exception from SettingsService.GetSetting.
         var settings = new PersistedPtxUtilsSettings(_client);
 
         Assert.That(settings.MementoData, Is.Empty);

--- a/c-sharp-tests/Services/PersistedPtxUtilsSettingsTests.cs
+++ b/c-sharp-tests/Services/PersistedPtxUtilsSettingsTests.cs
@@ -47,16 +47,37 @@ public class PersistedPtxUtilsSettingsTests
     }
 
     [Test]
-    public void SafeSave_AfterFailedLoad_DoesNotOverwritePersistedValue()
+    public void SafeSave_WhileStillUnreachable_DoesNotOverwritePersistedValue()
     {
         // Load fails (missing setting) and falls back to empty; SafeSave must skip the write so
-        // it can't reset the user's actual stored mementos.
+        // it can't reset the user's actual stored mementos, as long as it's still unreachable.
         var settings = new PersistedPtxUtilsSettings(_client);
         settings.MementoData["someKey"] = "mutated";
 
         settings.SafeSave();
 
         Assert.That(_settingsService.GetSettingValue(Settings.PTX_UTILS_MEMENTO_DATA), Is.Null);
+    }
+
+    [Test]
+    public void SafeSave_OnceReachableAfterAFailedLoad_PersistsAccumulatedChanges()
+    {
+        // Initial load fails; changes accumulate in memory while the service is unreachable.
+        var settings = new PersistedPtxUtilsSettings(_client);
+        settings.MementoData["someKey"] = "queued-before-service-available";
+        settings.SafeSave(); // still unreachable; skipped
+
+        // The service becomes reachable.
+        _settingsService.AddSettingValue(
+            Settings.PTX_UTILS_MEMENTO_DATA,
+            new SerializableStringDictionary()
+        );
+
+        settings.SafeSave(); // must retry, notice it's reachable now, and persist
+
+        var saved = (SerializableStringDictionary)
+            _settingsService.GetSettingValue(Settings.PTX_UTILS_MEMENTO_DATA)!;
+        Assert.That(saved["someKey"], Is.EqualTo("queued-before-service-available"));
     }
 
     [Test]

--- a/c-sharp-tests/Services/SettingsServiceTests.cs
+++ b/c-sharp-tests/Services/SettingsServiceTests.cs
@@ -49,4 +49,33 @@ public class SettingsServiceTests
         var retrievedSettingValue = SettingsService.GetSetting<int>(_client, settingKey);
         Assert.That(retrievedSettingValue, Is.EqualTo(settingValue));
     }
+
+    [TestCase()]
+    public void TryGetSetting_LegitimateNullValue_ReturnsTrue()
+    {
+        // A stored-but-null value is not a failure; only an exception (e.g. a timeout) is.
+        _settingsService.AddSettingValue("nullableSetting", null!);
+
+        bool succeeded = SettingsService.TryGetSetting<string>(
+            _client,
+            "nullableSetting",
+            out var value
+        );
+
+        Assert.That(succeeded, Is.True);
+        Assert.That(value, Is.Null);
+    }
+
+    [TestCase()]
+    public void TryGetSetting_LookupThrows_ReturnsFalse()
+    {
+        bool succeeded = SettingsService.TryGetSetting<string>(
+            _client,
+            "missingSetting",
+            out var value
+        );
+
+        Assert.That(succeeded, Is.False);
+        Assert.That(value, Is.Null);
+    }
 }

--- a/c-sharp-tests/Services/SettingsServiceTests.cs
+++ b/c-sharp-tests/Services/SettingsServiceTests.cs
@@ -28,7 +28,7 @@ public class SettingsServiceTests
     }
     #endregion
 
-    [TestCase()]
+    [Test]
     public void GetSettingValue_Boolean_ReturnsValue()
     {
         var settingKey = "isTest";
@@ -39,7 +39,7 @@ public class SettingsServiceTests
         Assert.That(retrievedSettingValue, Is.EqualTo(settingValue));
     }
 
-    [TestCase()]
+    [Test]
     public void GetSettingValue_Integer_ReturnsValue()
     {
         var settingKey = "testNum";
@@ -50,7 +50,7 @@ public class SettingsServiceTests
         Assert.That(retrievedSettingValue, Is.EqualTo(settingValue));
     }
 
-    [TestCase()]
+    [Test]
     public void TryGetSetting_LegitimateNullValue_ReturnsTrue()
     {
         // A stored-but-null value is not a failure; only an exception (e.g. a timeout) is.
@@ -66,7 +66,7 @@ public class SettingsServiceTests
         Assert.That(value, Is.Null);
     }
 
-    [TestCase()]
+    [Test]
     public void TryGetSetting_LookupThrows_ReturnsFalse()
     {
         bool succeeded = SettingsService.TryGetSetting<string>(

--- a/c-sharp/Services/PersistedParatextDataSettings.cs
+++ b/c-sharp/Services/PersistedParatextDataSettings.cs
@@ -7,10 +7,8 @@ internal class PersistedParatextDataSettings : IParatextDataSettings
 {
     private readonly PapiClient _papiClient;
 
-    // True until the settings service is confirmed reachable, so SafeSave doesn't overwrite the
-    // previously-persisted value with this instance's fallback-to-empty default. Re-checked (not
-    // permanent) so a transient startup-race timeout doesn't block saving for the rest of the
-    // session once the service comes up.
+    // SetSetting is a blind overwrite, so SafeSave must not save the fallback-to-empty default over
+    // real data. Re-checked, not latched: one startup timeout shouldn't kill saving the session.
     private bool _loadUnconfirmed;
 
     public PersistedParatextDataSettings(PapiClient papiClient)
@@ -40,7 +38,7 @@ internal class PersistedParatextDataSettings : IParatextDataSettings
                 return;
             _loadUnconfirmed = false;
 
-            // The confirming read may have found entries from before this session that our
+            // The confirming read may have found entries from before this session that the
             // fallback-to-empty default never saw. Keep them, but let in-memory changes win.
             if (persistedValue != null)
                 foreach (var (key, value) in persistedValue)

--- a/c-sharp/Services/PersistedParatextDataSettings.cs
+++ b/c-sharp/Services/PersistedParatextDataSettings.cs
@@ -3,37 +3,34 @@ using PtxUtils;
 
 namespace Paranext.DataProvider.Services;
 
-internal class PersistedParatextDataSettings(PapiClient papiClient) : IParatextDataSettings
+internal class PersistedParatextDataSettings : IParatextDataSettings
 {
-    public SerializableStringDictionary LastRegistryDataCachedTimes { get; set; } =
-        GetLastRegistryDataCachedTimes(papiClient);
+    private readonly PapiClient _papiClient;
 
-    // A timeout here must not crash the whole data provider at startup, so this mirrors the
-    // try/catch SettingsService.Initialize already uses around its own GetSetting call.
-    private static SerializableStringDictionary GetLastRegistryDataCachedTimes(
-        PapiClient papiClient
-    )
+    // Set when the initial load fails (e.g. times out), so SafeSave doesn't overwrite the
+    // previously-persisted value with this instance's fallback-to-empty default.
+    private readonly bool _loadFailed;
+
+    public PersistedParatextDataSettings(PapiClient papiClient)
     {
-        try
-        {
-            return SettingsService.GetSetting<SerializableStringDictionary>(
-                    papiClient,
-                    Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES
-                ) ?? [];
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine(
-                $"Error getting {Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES}: {ex}"
-            );
-            return [];
-        }
+        _papiClient = papiClient;
+        _loadFailed = !SettingsService.TryGetSetting(
+            papiClient,
+            Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES,
+            out SerializableStringDictionary? value
+        );
+        LastRegistryDataCachedTimes = value ?? [];
     }
+
+    public SerializableStringDictionary LastRegistryDataCachedTimes { get; set; }
 
     public void SafeSave()
     {
+        if (_loadFailed)
+            return;
+
         SettingsService.SetSetting(
-            papiClient,
+            _papiClient,
             Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES,
             LastRegistryDataCachedTimes
         );

--- a/c-sharp/Services/PersistedParatextDataSettings.cs
+++ b/c-sharp/Services/PersistedParatextDataSettings.cs
@@ -6,10 +6,29 @@ namespace Paranext.DataProvider.Services;
 internal class PersistedParatextDataSettings(PapiClient papiClient) : IParatextDataSettings
 {
     public SerializableStringDictionary LastRegistryDataCachedTimes { get; set; } =
-        SettingsService.GetSetting<SerializableStringDictionary>(
-            papiClient,
-            Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES
-        ) ?? [];
+        GetLastRegistryDataCachedTimes(papiClient);
+
+    // A timeout here must not crash the whole data provider at startup, so this mirrors the
+    // try/catch SettingsService.Initialize already uses around its own GetSetting call.
+    private static SerializableStringDictionary GetLastRegistryDataCachedTimes(
+        PapiClient papiClient
+    )
+    {
+        try
+        {
+            return SettingsService.GetSetting<SerializableStringDictionary>(
+                    papiClient,
+                    Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES
+                ) ?? [];
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine(
+                $"Error getting {Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES}: {ex}"
+            );
+            return [];
+        }
+    }
 
     public void SafeSave()
     {

--- a/c-sharp/Services/PersistedParatextDataSettings.cs
+++ b/c-sharp/Services/PersistedParatextDataSettings.cs
@@ -28,16 +28,25 @@ internal class PersistedParatextDataSettings : IParatextDataSettings
 
     public void SafeSave()
     {
-        if (
-            _loadUnconfirmed
-            && !SettingsService.TryGetSetting(
-                _papiClient,
-                Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES,
-                out SerializableStringDictionary? _
+        if (_loadUnconfirmed)
+        {
+            if (
+                !SettingsService.TryGetSetting(
+                    _papiClient,
+                    Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES,
+                    out SerializableStringDictionary? persistedValue
+                )
             )
-        )
-            return;
-        _loadUnconfirmed = false;
+                return;
+            _loadUnconfirmed = false;
+
+            // The confirming read may have found entries from before this session that our
+            // fallback-to-empty default never saw. Keep them, but let in-memory changes win.
+            if (persistedValue != null)
+                foreach (var (key, value) in persistedValue)
+                    if (!LastRegistryDataCachedTimes.ContainsKey(key))
+                        LastRegistryDataCachedTimes[key] = value;
+        }
 
         SettingsService.SetSetting(
             _papiClient,

--- a/c-sharp/Services/PersistedParatextDataSettings.cs
+++ b/c-sharp/Services/PersistedParatextDataSettings.cs
@@ -7,14 +7,16 @@ internal class PersistedParatextDataSettings : IParatextDataSettings
 {
     private readonly PapiClient _papiClient;
 
-    // Set when the initial load fails (e.g. times out), so SafeSave doesn't overwrite the
-    // previously-persisted value with this instance's fallback-to-empty default.
-    private readonly bool _loadFailed;
+    // True until the settings service is confirmed reachable, so SafeSave doesn't overwrite the
+    // previously-persisted value with this instance's fallback-to-empty default. Re-checked (not
+    // permanent) so a transient startup-race timeout doesn't block saving for the rest of the
+    // session once the service comes up.
+    private bool _loadUnconfirmed;
 
     public PersistedParatextDataSettings(PapiClient papiClient)
     {
         _papiClient = papiClient;
-        _loadFailed = !SettingsService.TryGetSetting(
+        _loadUnconfirmed = !SettingsService.TryGetSetting(
             papiClient,
             Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES,
             out SerializableStringDictionary? value
@@ -26,8 +28,16 @@ internal class PersistedParatextDataSettings : IParatextDataSettings
 
     public void SafeSave()
     {
-        if (_loadFailed)
+        if (
+            _loadUnconfirmed
+            && !SettingsService.TryGetSetting(
+                _papiClient,
+                Settings.PARATEXT_DATA_LAST_REGISTRY_DATA_CACHED_TIMES,
+                out SerializableStringDictionary? _
+            )
+        )
             return;
+        _loadUnconfirmed = false;
 
         SettingsService.SetSetting(
             _papiClient,

--- a/c-sharp/Services/PersistedPtxUtilsSettings.cs
+++ b/c-sharp/Services/PersistedPtxUtilsSettings.cs
@@ -6,10 +6,8 @@ internal class PersistedPtxUtilsSettings : IPtxUtilsSettings
 {
     private readonly PapiClient _papiClient;
 
-    // True until the settings service is confirmed reachable, so SafeSave doesn't overwrite the
-    // user's previously-persisted mementos with this instance's fallback-to-empty default.
-    // Re-checked (not permanent) so a transient startup-race timeout doesn't block saving for the
-    // rest of the session once the service comes up.
+    // SetSetting is a blind overwrite, so SafeSave must not save the fallback-to-empty default over
+    // real data. Re-checked, not latched: one startup timeout shouldn't kill saving the session.
     private bool _loadUnconfirmed;
 
     public PersistedPtxUtilsSettings(PapiClient papiClient)
@@ -51,7 +49,7 @@ internal class PersistedPtxUtilsSettings : IPtxUtilsSettings
                 return;
             _loadUnconfirmed = false;
 
-            // The confirming read may have found mementos from before this session that our
+            // The confirming read may have found mementos from before this session that the
             // fallback-to-empty default never saw. Keep them, but let in-memory changes win.
             if (persistedValue != null)
                 foreach (var (key, value) in persistedValue)

--- a/c-sharp/Services/PersistedPtxUtilsSettings.cs
+++ b/c-sharp/Services/PersistedPtxUtilsSettings.cs
@@ -39,16 +39,25 @@ internal class PersistedPtxUtilsSettings : IPtxUtilsSettings
 
     public void SafeSave()
     {
-        if (
-            _loadUnconfirmed
-            && !SettingsService.TryGetSetting(
-                _papiClient,
-                Settings.PTX_UTILS_MEMENTO_DATA,
-                out SerializableStringDictionary? _
+        if (_loadUnconfirmed)
+        {
+            if (
+                !SettingsService.TryGetSetting(
+                    _papiClient,
+                    Settings.PTX_UTILS_MEMENTO_DATA,
+                    out SerializableStringDictionary? persistedValue
+                )
             )
-        )
-            return;
-        _loadUnconfirmed = false;
+                return;
+            _loadUnconfirmed = false;
+
+            // The confirming read may have found mementos from before this session that our
+            // fallback-to-empty default never saw. Keep them, but let in-memory changes win.
+            if (persistedValue != null)
+                foreach (var (key, value) in persistedValue)
+                    if (!MementoData.ContainsKey(key))
+                        MementoData[key] = value;
+        }
 
         SettingsService.SetSetting(_papiClient, Settings.PTX_UTILS_MEMENTO_DATA, MementoData);
     }

--- a/c-sharp/Services/PersistedPtxUtilsSettings.cs
+++ b/c-sharp/Services/PersistedPtxUtilsSettings.cs
@@ -2,27 +2,26 @@ using PtxUtils;
 
 namespace Paranext.DataProvider.Services;
 
-internal class PersistedPtxUtilsSettings(PapiClient papiClient) : IPtxUtilsSettings
+internal class PersistedPtxUtilsSettings : IPtxUtilsSettings
 {
-    public SerializableStringDictionary MementoData { get; set; } = GetMementoData(papiClient);
+    private readonly PapiClient _papiClient;
 
-    // A timeout here must not crash the whole data provider at startup, so this mirrors the
-    // try/catch SettingsService.Initialize already uses around its own GetSetting call.
-    private static SerializableStringDictionary GetMementoData(PapiClient papiClient)
+    // Set when the initial load fails (e.g. times out), so SafeSave doesn't overwrite the user's
+    // previously-persisted mementos with this instance's fallback-to-empty default.
+    private readonly bool _loadFailed;
+
+    public PersistedPtxUtilsSettings(PapiClient papiClient)
     {
-        try
-        {
-            return SettingsService.GetSetting<SerializableStringDictionary>(
-                    papiClient,
-                    Settings.PTX_UTILS_MEMENTO_DATA
-                ) ?? [];
-        }
-        catch (Exception ex)
-        {
-            Console.WriteLine($"Error getting {Settings.PTX_UTILS_MEMENTO_DATA}: {ex}");
-            return [];
-        }
+        _papiClient = papiClient;
+        _loadFailed = !SettingsService.TryGetSetting(
+            papiClient,
+            Settings.PTX_UTILS_MEMENTO_DATA,
+            out SerializableStringDictionary? value
+        );
+        MementoData = value ?? [];
     }
+
+    public SerializableStringDictionary MementoData { get; set; }
 
     public bool UpgradeNeeded
     {
@@ -38,6 +37,9 @@ internal class PersistedPtxUtilsSettings(PapiClient papiClient) : IPtxUtilsSetti
 
     public void SafeSave()
     {
-        SettingsService.SetSetting(papiClient, Settings.PTX_UTILS_MEMENTO_DATA, MementoData);
+        if (_loadFailed)
+            return;
+
+        SettingsService.SetSetting(_papiClient, Settings.PTX_UTILS_MEMENTO_DATA, MementoData);
     }
 }

--- a/c-sharp/Services/PersistedPtxUtilsSettings.cs
+++ b/c-sharp/Services/PersistedPtxUtilsSettings.cs
@@ -6,14 +6,16 @@ internal class PersistedPtxUtilsSettings : IPtxUtilsSettings
 {
     private readonly PapiClient _papiClient;
 
-    // Set when the initial load fails (e.g. times out), so SafeSave doesn't overwrite the user's
-    // previously-persisted mementos with this instance's fallback-to-empty default.
-    private readonly bool _loadFailed;
+    // True until the settings service is confirmed reachable, so SafeSave doesn't overwrite the
+    // user's previously-persisted mementos with this instance's fallback-to-empty default.
+    // Re-checked (not permanent) so a transient startup-race timeout doesn't block saving for the
+    // rest of the session once the service comes up.
+    private bool _loadUnconfirmed;
 
     public PersistedPtxUtilsSettings(PapiClient papiClient)
     {
         _papiClient = papiClient;
-        _loadFailed = !SettingsService.TryGetSetting(
+        _loadUnconfirmed = !SettingsService.TryGetSetting(
             papiClient,
             Settings.PTX_UTILS_MEMENTO_DATA,
             out SerializableStringDictionary? value
@@ -37,8 +39,16 @@ internal class PersistedPtxUtilsSettings : IPtxUtilsSettings
 
     public void SafeSave()
     {
-        if (_loadFailed)
+        if (
+            _loadUnconfirmed
+            && !SettingsService.TryGetSetting(
+                _papiClient,
+                Settings.PTX_UTILS_MEMENTO_DATA,
+                out SerializableStringDictionary? _
+            )
+        )
             return;
+        _loadUnconfirmed = false;
 
         SettingsService.SetSetting(_papiClient, Settings.PTX_UTILS_MEMENTO_DATA, MementoData);
     }

--- a/c-sharp/Services/PersistedPtxUtilsSettings.cs
+++ b/c-sharp/Services/PersistedPtxUtilsSettings.cs
@@ -4,11 +4,25 @@ namespace Paranext.DataProvider.Services;
 
 internal class PersistedPtxUtilsSettings(PapiClient papiClient) : IPtxUtilsSettings
 {
-    public SerializableStringDictionary MementoData { get; set; } =
-        SettingsService.GetSetting<SerializableStringDictionary>(
-            papiClient,
-            Settings.PTX_UTILS_MEMENTO_DATA
-        ) ?? [];
+    public SerializableStringDictionary MementoData { get; set; } = GetMementoData(papiClient);
+
+    // A timeout here must not crash the whole data provider at startup, so this mirrors the
+    // try/catch SettingsService.Initialize already uses around its own GetSetting call.
+    private static SerializableStringDictionary GetMementoData(PapiClient papiClient)
+    {
+        try
+        {
+            return SettingsService.GetSetting<SerializableStringDictionary>(
+                    papiClient,
+                    Settings.PTX_UTILS_MEMENTO_DATA
+                ) ?? [];
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error getting {Settings.PTX_UTILS_MEMENTO_DATA}: {ex}");
+            return [];
+        }
+    }
 
     public bool UpgradeNeeded
     {

--- a/c-sharp/Services/SettingsService.cs
+++ b/c-sharp/Services/SettingsService.cs
@@ -54,6 +54,22 @@ internal static class SettingsService
         );
     }
 
+    /// <summary>Like <see cref="GetSetting{T}"/>, but returns false instead of throwing if the lookup fails.</summary>
+    public static bool TryGetSetting<T>(PapiClient papiClient, string key, out T? value)
+    {
+        try
+        {
+            value = GetSetting<T>(papiClient, key);
+            return value is not null;
+        }
+        catch (Exception ex)
+        {
+            Console.WriteLine($"Error getting {key}: {ex}");
+            value = default;
+            return false;
+        }
+    }
+
     public static bool SetSetting(PapiClient papiClient, string key, object? settingData)
     {
         string description = $"SettingService.SetSetting for {key}";

--- a/c-sharp/Services/SettingsService.cs
+++ b/c-sharp/Services/SettingsService.cs
@@ -54,13 +54,17 @@ internal static class SettingsService
         );
     }
 
-    /// <summary>Like <see cref="GetSetting{T}"/>, but returns false instead of throwing if the lookup fails.</summary>
+    /// <summary>
+    /// Like <see cref="GetSetting{T}"/>, but returns false instead of throwing if the lookup
+    /// fails. A legitimate null result (e.g. no value stored and no default declared) still
+    /// counts as success; only an exception (e.g. a timeout) counts as failure.
+    /// </summary>
     public static bool TryGetSetting<T>(PapiClient papiClient, string key, out T? value)
     {
         try
         {
             value = GetSetting<T>(papiClient, key);
-            return value is not null;
+            return true;
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Issue

A real dev-mode log showed `ParanextDataProvider` (the .NET backend) crashing shortly after startup:

```
System.TimeoutException: Task "SettingService.GetSetting for platform.paratextDataLastRegistryDataCachedTimes" did not complete quickly enough.
   at Paranext.DataProvider.ThreadingUtils.GetTaskResult[T](...)
   at Paranext.DataProvider.Services.SettingsService.GetSetting[T](...)
   at Paranext.DataProvider.Services.PersistedParatextDataSettings..ctor(PapiClient papiClient)
   at Paranext.DataProvider.Program.Main()
```

`PersistedParatextDataSettings.LastRegistryDataCachedTimes` and `PersistedPtxUtilsSettings.MementoData` each call `SettingsService.GetSetting` directly in a property initializer, with no try/catch. A timeout there (this call races the rest of Electron/webpack dev startup, using the hardcoded `ThreadingUtils.DefaultTimeout` rather than any configured timeout) propagates straight out of `Program.Main()` uncaught, killing the whole process. `dotnet watch` only restarts on a file change, not on an unexpected exit, so once this happens the backend is dead for the rest of the session.

## Solution

- Wrap the `GetSetting` calls in both classes' property initializers in the same catch-log-and-fall-back-to-empty pattern `SettingsService.Initialize` already uses around its own `GetSetting` call, via a new shared `SettingsService.TryGetSetting` helper (also used by both classes, replacing near-duplicate private helpers). `TryGetSetting` treats a legitimate null result as success — only an exception counts as failure.
- Guard `SafeSave()` against overwriting real persisted data with the empty fallback: while the load is unconfirmed, `SafeSave` re-checks reachability (not a one-time flag, so a transient startup-race timeout doesn't permanently block saving for the rest of the session) and merges the confirming read's value in as the base — in-memory changes win on key conflicts — instead of discarding it.
- Note: since the fallback starts empty, this merge can resurrect a persisted entry the app never loaded into memory (so a deliberate "drop this entry" can't be distinguished from "never saw it") — an accepted tradeoff, since the alternatives are crashing or clobbering everything.
- Regression tests for both classes and the shared helper, using the existing `DummyPapiClient`/`DummySettingsService` test harness (which needed a small fix itself: its "set" handler returned a raw `bool` instead of the `JsonElement` wire response `SetSetting` expects — never previously exercised by any test).

---

Drafted with Claude Sonnet 5.

---

Devin review: https://app.devin.ai/review/paranext/paranext-core/pull/2613

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2613)
<!-- Reviewable:end -->