### PR TITLE
docs: trim always-loaded Claude context, scope rules by path

### DIFF
--- a/.claude/rules/code-quality/eslint-disable-discipline.md
+++ b/.claude/rules/code-quality/eslint-disable-discipline.md
@@ -1,3 +1,12 @@
+---
+paths:
+  - **/*.ts
+  - **/*.tsx
+  - **/*.js
+  - **/*.jsx
+  - **/*.scss
+---
+
 ## Fix Code, Don't Suppress Warnings
 
 When you encounter any code quality error — ESLint, TypeScript, Prettier, Stylelint, or other tooling — pause and reconsider before suppressing it:

--- a/.claude/rules/code-quality/eslint-disable-discipline.md
+++ b/.claude/rules/code-quality/eslint-disable-discipline.md
@@ -1,3 +1,12 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.scss"
+---
+
 ## Fix Code, Don't Suppress Warnings
 
 When you encounter any code quality error — ESLint, TypeScript, Prettier, Stylelint, or other tooling — pause and reconsider before suppressing it:

--- a/.claude/rules/code-quality/lint-sweep-verification.md
+++ b/.claude/rules/code-quality/lint-sweep-verification.md
@@ -1,3 +1,12 @@
+---
+paths:
+  - **/*.ts
+  - **/*.tsx
+  - **/*.js
+  - **/*.jsx
+  - **/*.scss
+---
+
 ## Lint-Sweep Verification
 
 When you make a "lint-fix sweep" commit (one whose stated purpose is to clear lint errors across multiple files), the commit MUST include a final repo-wide verification step, not just per-file `eslint --fix` runs.

--- a/.claude/rules/code-quality/lint-sweep-verification.md
+++ b/.claude/rules/code-quality/lint-sweep-verification.md
@@ -1,3 +1,12 @@
+---
+paths:
+  - "**/*.ts"
+  - "**/*.tsx"
+  - "**/*.js"
+  - "**/*.jsx"
+  - "**/*.scss"
+---
+
 ## Lint-Sweep Verification
 
 When you make a "lint-fix sweep" commit (one whose stated purpose is to clear lint errors across multiple files), the commit MUST include a final repo-wide verification step, not just per-file `eslint --fix` runs.

--- a/.claude/rules/code-quality/no-secrets.md
+++ b/.claude/rules/code-quality/no-secrets.md
@@ -13,4 +13,4 @@ If a feature needs a secret at runtime, use environment variables or Platform.Bi
 
 When porting PT9 features that involve encryption, decryption, or secrets, document the _mechanism_ (e.g., "uses AES-256 decryption with a key from user config") but never copy actual keys, passwords, or secret values into PT10 artifacts, test fixtures, or code. Use placeholder values like `"<encryption-key-from-user-config>"` in specifications and contracts.
 
-If you suspect you've staged a file containing secrets, unstage it before committing.
+Never skip pre-commit hooks (`--no-verify`, `-n`, `HUSKY=0`) — they run the secret-detection linters. If a hook fails, fix the underlying issue. If you suspect you've staged a file containing secrets, unstage it before committing.

--- a/.claude/rules/code-quality/shadcn-discipline.md
+++ b/.claude/rules/code-quality/shadcn-discipline.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - lib/platform-bible-react/src/components/shadcn-ui/**
+---
+
 ## shadcn/ui Edit Discipline
 
 Every change to any file in `lib/platform-bible-react/src/components/shadcn-ui/`

--- a/.claude/rules/code-quality/shadcn-discipline.md
+++ b/.claude/rules/code-quality/shadcn-discipline.md
@@ -1,3 +1,8 @@
+---
+paths:
+  - "lib/platform-bible-react/src/components/shadcn-ui/**"
+---
+
 ## shadcn/ui Edit Discipline
 
 Every change to any file in `lib/platform-bible-react/src/components/shadcn-ui/`

--- a/.claude/rules/cross-view-sync-hidden-views.md
+++ b/.claude/rules/cross-view-sync-hidden-views.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - src/renderer/**
+  - extensions/src/**
+  - lib/platform-bible-react/src/**
+  - **/*.web-view.tsx
+---
+
 # Cross-View Sync Must Handle Hidden Views
 
 When implementing or modifying anything that synchronizes behavior across views/tabs/panes —

--- a/.claude/rules/cross-view-sync-hidden-views.md
+++ b/.claude/rules/cross-view-sync-hidden-views.md
@@ -1,3 +1,11 @@
+---
+paths:
+  - "src/renderer/**"
+  - "extensions/src/**"
+  - "lib/platform-bible-react/src/**"
+  - "**/*.web-view.tsx"
+---
+
 # Cross-View Sync Must Handle Hidden Views
 
 When implementing or modifying anything that synchronizes behavior across views/tabs/panes —

--- a/.claude/rules/keyboard-shortcuts-catalog.md
+++ b/.claude/rules/keyboard-shortcuts-catalog.md
@@ -1,3 +1,12 @@
+---
+paths:
+  - src/main/**
+  - src/renderer/**
+  - src/stories/**
+  - extensions/src/**
+  - lib/platform-bible-react/src/**
+---
+
 ## Keep the Keyboard Shortcuts Catalog Current
 
 Platform.Bible documents every keyboard shortcut used anywhere in the application — main process,

--- a/.claude/rules/keyboard-shortcuts-catalog.md
+++ b/.claude/rules/keyboard-shortcuts-catalog.md
@@ -1,3 +1,12 @@
+---
+paths:
+  - "src/main/**"
+  - "src/renderer/**"
+  - "src/stories/**"
+  - "extensions/src/**"
+  - "lib/platform-bible-react/src/**"
+---
+
 ## Keep the Keyboard Shortcuts Catalog Current
 
 Platform.Bible documents every keyboard shortcut used anywhere in the application — main process,

--- a/.claude/rules/send-receive-write-gate.md
+++ b/.claude/rules/send-receive-write-gate.md
@@ -1,0 +1,35 @@
+---
+paths:
+  - c-sharp/**
+  - c-sharp-tests/**
+---
+
+## Send/Receive Write Gate — Full Semantics
+
+The invariant (root `CLAUDE.md` → "Send/Receive Write Gate"): any new C# code path that mutates
+project data wraps the mutation in `using var _ = SendReceiveWriteLock.EnterWrite(projectId);` as
+the first statement of its entry-point method
+(`c-sharp/Projects/SendReceive/SendReceiveWriteLock.cs`). Details below.
+
+The gate has **no thread affinity** (its state is a single atomic word — an armed flag, an
+in-flight write count, and an arm generation — not an OS lock): a scope may be disposed on a
+different thread, holding one across an `await` is safe, and `SetSyncing`/`Clear` may run on any
+threads. `SetSyncing` returns a token; end the bracket with `Clear(token)` (a stale token is a
+logged no-op, so a late Clear can never disarm a newer sync) and keep parameterless `Clear()` for
+crash recovery — it force-disarms unconditionally and is idempotent. Nested `EnterWrite` calls do
+not crash, but they are **not safe**: if a sync arms while the outer scope is open, the inner call
+throws the sentinel mid-mutation — keep one scope per mutation (delegate to an un-gated core
+inside a single scope, as `SetBookUsfmInScope` does). Keep scopes **tight** — the mutation and
+nothing else — because every open scope delays a starting sync's bounded drain toward its timeout.
+
+This is an **in-process** gate, distinct from the S/R server-side repository lock
+(`lockrepo`/`unlockrepo` between clients) — do not conflate the two. `SendReceiveWriteLockCoverageTests`
+(`c-sharp-tests/Projects/SendReceive/`) scans the source tree (excluding `bin`/`obj`) for direct
+project-write call patterns (a general `.Save(` heuristic, `PutText`, comment `SaveUser`/`SaveEdits`,
+and `File`/`FileManager` deletes) and fails on any hit that isn't covered per site by one of: gate
+evidence (an `EnterWrite`/`EnterSyncWriteScope` call above it in the same method); an inline
+`// SR-write-gate: exempt — <reason>` marker on/above the write (for writes reached only through an
+already-gated caller — the un-gated `SetBookUsfmInScope` core and the ManageBooks orchestrators,
+each citing its gated caller + `TODO(PT-4210)`); or a whole-file entry on the test's exempt list,
+which is reserved for **not-project-data** files only. Per-site (not whole-file), so a new ungated
+write added to an already-gated file is still caught.

--- a/.claude/rules/send-receive-write-gate.md
+++ b/.claude/rules/send-receive-write-gate.md
@@ -1,0 +1,35 @@
+---
+paths:
+  - "c-sharp/**"
+  - "c-sharp-tests/**"
+---
+
+## Send/Receive Write Gate — Full Semantics
+
+The invariant (root `CLAUDE.md` → "Send/Receive Write Gate"): any new C# code path that mutates
+project data wraps the mutation in `using var _ = SendReceiveWriteLock.EnterWrite(projectId);` as
+the first statement of its entry-point method
+(`c-sharp/Projects/SendReceive/SendReceiveWriteLock.cs`). Details below.
+
+The gate has **no thread affinity** (its state is a single atomic word — an armed flag, an
+in-flight write count, and an arm generation — not an OS lock): a scope may be disposed on a
+different thread, holding one across an `await` is safe, and `SetSyncing`/`Clear` may run on any
+threads. `SetSyncing` returns a token; end the bracket with `Clear(token)` (a stale token is a
+logged no-op, so a late Clear can never disarm a newer sync) and keep parameterless `Clear()` for
+crash recovery — it force-disarms unconditionally and is idempotent. Nested `EnterWrite` calls do
+not crash, but they are **not safe**: if a sync arms while the outer scope is open, the inner call
+throws the sentinel mid-mutation — keep one scope per mutation (delegate to an un-gated core
+inside a single scope, as `SetBookUsfmInScope` does). Keep scopes **tight** — the mutation and
+nothing else — because every open scope delays a starting sync's bounded drain toward its timeout.
+
+This is an **in-process** gate, distinct from the S/R server-side repository lock
+(`lockrepo`/`unlockrepo` between clients) — do not conflate the two. `SendReceiveWriteLockCoverageTests`
+(`c-sharp-tests/Projects/SendReceive/`) scans the source tree (excluding `bin`/`obj`) for direct
+project-write call patterns (a general `.Save(` heuristic, `PutText`, comment `SaveUser`/`SaveEdits`,
+and `File`/`FileManager` deletes) and fails on any hit that isn't covered per site by one of: gate
+evidence (an `EnterWrite`/`EnterSyncWriteScope` call above it in the same method); an inline
+`// SR-write-gate: exempt — <reason>` marker on/above the write (for writes reached only through an
+already-gated caller — the un-gated `SetBookUsfmInScope` core and the ManageBooks orchestrators,
+each citing its gated caller + `TODO(PT-4210)`); or a whole-file entry on the test's exempt list,
+which is reserved for **not-project-data** files only. Per-site (not whole-file), so a new ungated
+write added to an already-gated file is still caught.

--- a/.context/standards/Security-Guide.md
+++ b/.context/standards/Security-Guide.md
@@ -7,7 +7,7 @@ description: CSP design, module import restrictions, extension sandboxing, and s
 
 This document covers security policies and restrictions for Platform.Bible development, with a focus on the extension sandbox.
 
-For secret-handling rules (no hardcoded credentials, no `.env` files, etc.), see the "Never Commit Secrets" section in root `CLAUDE.md`.
+For secret-handling rules (no hardcoded credentials, no `.env` files, etc.), see [.claude/rules/code-quality/no-secrets.md](../../.claude/rules/code-quality/no-secrets.md).
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,42 +34,11 @@ Read these when you need depth on a topic. Keep them in mind when writing or rev
 - **Data Provider**: A backend service (typically C#/.NET) that provides data to the frontend via PAPI
 - **WebView**: An extension-provided React UI that runs in an iframe within the renderer process
 
-## Tech Stack
-
-| Layer              | Technology                            |
-| ------------------ | ------------------------------------- |
-| Desktop Framework  | Electron                              |
-| Frontend           | React, TypeScript, SCSS, Tailwind CSS |
-| Backend (Node)     | TypeScript, WebSocket (JSON-RPC 2.0)  |
-| Backend (Data)     | .NET 8 / C#                           |
-| Build System       | Webpack                               |
-| Testing            | Vitest, Storybook                     |
-| Package Management | npm workspaces (monorepo)             |
-
 ## Architecture
 
-### Multi-Process Architecture
-
-The application runs as four separate processes that communicate via JSON-RPC over WebSocket:
-
-```
-┌─────────────────────────────────────────────────────────┐
-│                    Main Process (Electron)               │
-│  • Window management & app lifecycle                     │
-│  • Spawns and manages child processes                    │
-└────────────────┬────────────────────────────────────────┘
-                 │ JSON-RPC over WebSocket (port 8876)
-    ┌────────────┼────────────┬───────────────────┐
-    │            │            │                   │
-┌───▼────────┐ ┌─▼──────────┐ ┌▼────────────────┐
-│ Renderer   │ │ Extension  │ │ .NET Data       │
-│ (React UI) │ │ Host       │ │ Provider        │
-│            │ │            │ │                 │
-│ • Web UI   │ │ • Loads    │ │ • Project data  │
-│ • Dialogs  │ │  extensions│ │ • Paratext     │
-│ • WebViews │ │ • PAPI     │ │   integration   │
-└────────────┘ └────────────┘ └─────────────────┘
-```
+The app runs as four processes — Electron main, renderer (React UI), extension host, and the
+.NET data provider — communicating over JSON-RPC via WebSocket (port 8876). Diagram and details:
+[Architecture.md](.context/standards/Architecture.md).
 
 ### Key Codebase Locations
 
@@ -92,58 +61,16 @@ The application runs as four separate processes that communicate via JSON-RPC ov
 
 `@main/*` → `src/main/`, `@node/*` → `src/node/`, `@extension-host/*` → `src/extension-host/`, `@renderer/*` → `src/renderer/`, `@shared/*` → `src/shared/`
 
-## Common Commands
+## Commands
 
-### Development
+All scripts are defined in `package.json` — read it (or run `npm run`) for the full list (`npm start`, `npm test`, `npm run build` / `lint` / `format` / `typecheck`; C# tests via `dotnet test` in `c-sharp-tests/`). Two that are easy to miss:
 
 ```bash
-# Start development (headless with CDP enabled)
+# Start development headless with CDP enabled (for agent-driven and E2E runs)
 ./.erb/scripts/refresh.sh
 
-# Start development (visible window - for manual development)
-npm start
-
-# Build the entire project (TypeScript, extensions, .NET, types)
-npm run build
-```
-
-### Testing
-
-```bash
-# Run all TypeScript tests
-npm test
-
-# Run single TypeScript test with watch mode
-npm test -- path/to/test-file.test.ts --watch
-
-# Run C# unit tests
-cd c-sharp-tests
-dotnet test
-
-# Run C# tests with watch mode
-cd c-sharp-tests
-dotnet watch test
-```
-
-### Code Quality
-
-```bash
-# Format code (happens automatically on commit)
-npm run format
-
-# Lint TypeScript
-npm run lint
-
-# Fix linting issues automatically
-npm run lint-fix
-
-# Format C# code
-cd c-sharp
-dotnet tool restore
-dotnet csharpier .
-
-# Type checking
-npm run typecheck
+# Format C# — csharpier is a local dotnet tool and needs a restore first
+cd c-sharp && dotnet tool restore && dotnet csharpier .
 ```
 
 ## Development Workflow
@@ -155,11 +82,6 @@ npm run typecheck
 
 ## Coding Discipline
 
-- Read existing code before suggesting modifications.
-- If multiple interpretations of a task exist, present them — do not pick silently.
-- Frame tasks as verifiable goals: "Fix the bug" → "Write a test that reproduces it, then make it pass."
-- When any code quality tool flags your code (ESLint, TypeScript, Prettier, Stylelint), fix the code first. Only suppress warnings if the fix would be significantly worse.
-- Don't add features, refactor code, or make "improvements" beyond what was asked.
 - Avoid indecipherable [initialisms and abbreviations](.context/standards/Code-Style-Guide.md#initialisms-and-abbreviations).
 
 ## Send/Receive Write Gate
@@ -173,41 +95,10 @@ armed automatic Send/Receive rejects the write fail-fast (the `(SR_EDIT_BLOCKED)
 while a starting sync waits, bounded, for open write scopes to drain before it replaces files on
 disk.
 
-The gate has **no thread affinity** (its state is a single atomic word — an armed flag, an
-in-flight write count, and an arm generation — not an OS lock): a scope may be disposed on a
-different thread, holding one across an `await` is safe, and `SetSyncing`/`Clear` may run on any
-threads. `SetSyncing` returns a token; end the bracket with `Clear(token)` (a stale token is a
-logged no-op, so a late Clear can never disarm a newer sync) and keep parameterless `Clear()` for
-crash recovery — it force-disarms unconditionally and is idempotent. Nested `EnterWrite` calls do
-not crash, but they are NOT safe: if a sync arms while the outer scope is open, the inner call
-throws the sentinel mid-mutation — keep one scope per mutation (delegate to an un-gated core
-inside a single scope, as `SetBookUsfmInScope` does). Keep scopes **tight** — the mutation and
-nothing else — because every open scope delays a starting sync's bounded drain toward its timeout.
-
-This is an **in-process** gate, distinct from the S/R server-side repository lock
-(`lockrepo`/`unlockrepo` between clients) — do not conflate the two. `SendReceiveWriteLockCoverageTests`
-(`c-sharp-tests/Projects/SendReceive/`) scans the source tree (excluding `bin`/`obj`) for direct
-project-write call patterns (a general `.Save(` heuristic, `PutText`, comment `SaveUser`/`SaveEdits`,
-and `File`/`FileManager` deletes) and fails on any hit that isn't covered per site by ONE of: gate
-evidence (an `EnterWrite`/`EnterSyncWriteScope` call above it in the same method); an inline
-`// SR-write-gate: exempt — <reason>` marker on/above the write (for writes reached only through an
-already-gated caller — the un-gated `SetBookUsfmInScope` core and the ManageBooks orchestrators,
-each citing its gated caller + `TODO(PT-4210)`); or a whole-file entry on the test's exempt list,
-which is reserved for **not-project-data** files only. Per-site (not whole-file), so a NEW ungated
-write added to an already-gated file is still caught.
-
-## Never Commit Secrets
-
-This is an open-source repository. Never introduce secrets into the codebase:
-
-- **No hardcoded credentials**: API keys, tokens, passwords, connection strings, private keys.
-- **No secret files**: `.env`, `.env.*`, `*.pem`, `*.key`, `*.pfx`, `*.p12`, `credentials.json`, `service-account.json`.
-- **No secrets in commit messages or PR descriptions.**
-- **No base64-encoded or obfuscated secrets** — encoding is not encryption.
-
-If a feature needs a secret at runtime, use environment variables or Platform.Bible's settings system. Never provide a default value that is an actual secret.
-
-Never skip pre-commit hooks (`--no-verify`, `-n`, `HUSKY=0`) — they run the secret-detection linters. If a hook fails, fix the underlying issue. If you suspect you've staged a file containing secrets, unstage it before committing.
+The full gate semantics — thread affinity, the `SetSyncing`/`Clear(token)` protocol,
+nested-scope hazards, and the `SendReceiveWriteLockCoverageTests` exemption markers — live in
+[send-receive-write-gate.md](.claude/rules/send-receive-write-gate.md), which auto-loads when you
+work in `c-sharp/`.
 
 ## Git & PR Conventions
 
@@ -237,15 +128,3 @@ Never skip pre-commit hooks (`--no-verify`, `-n`, `HUSKY=0`) — they run the se
 **macOS**: Requires MacPorts with icu4c libraries. The .NET build automatically copies dylibs to output directory.
 
 **Windows**: Use WSL2 for cross-platform testing.
-
-## Version Management
-
-- Use Node.js version specified in `package.json` → `volta.node` (recommend using Volta)
-- Requires .NET 8 SDK
-
-## Links
-
-- [PAPI Documentation](https://paranext.github.io/paranext-core/papi-dts)
-- [React Components Docs](https://paranext.github.io/paranext-core/platform-bible-react)
-- [Utilities Docs](https://paranext.github.io/paranext-core/platform-bible-utils)
-- [Extension Template](https://github.com/paranext/paranext-extension-template/wiki)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,42 +38,11 @@ Read these when you need depth on a topic. Keep them in mind when writing or rev
 - **Data Provider**: A backend service (typically C#/.NET) that provides data to the frontend via PAPI
 - **WebView**: An extension-provided React UI that runs in an iframe within the renderer process
 
-## Tech Stack
-
-| Layer              | Technology                            |
-| ------------------ | ------------------------------------- |
-| Desktop Framework  | Electron                              |
-| Frontend           | React, TypeScript, SCSS, Tailwind CSS |
-| Backend (Node)     | TypeScript, WebSocket (JSON-RPC 2.0)  |
-| Backend (Data)     | .NET 8 / C#                           |
-| Build System       | Webpack                               |
-| Testing            | Vitest, Storybook                     |
-| Package Management | npm workspaces (monorepo)             |
-
 ## Architecture
 
-### Multi-Process Architecture
-
-The application runs as four separate processes that communicate via JSON-RPC over WebSocket:
-
-```
-┌─────────────────────────────────────────────────────────┐
-│                    Main Process (Electron)               │
-│  • Window management & app lifecycle                     │
-│  • Spawns and manages child processes                    │
-└────────────────┬────────────────────────────────────────┘
-                 │ JSON-RPC over WebSocket (port 8876)
-    ┌────────────┼────────────┬───────────────────┐
-    │            │            │                   │
-┌───▼────────┐ ┌─▼──────────┐ ┌▼────────────────┐
-│ Renderer   │ │ Extension  │ │ .NET Data       │
-│ (React UI) │ │ Host       │ │ Provider        │
-│            │ │            │ │                 │
-│ • Web UI   │ │ • Loads    │ │ • Project data  │
-│ • Dialogs  │ │  extensions│ │ • Paratext     │
-│ • WebViews │ │ • PAPI     │ │   integration   │
-└────────────┘ └────────────┘ └─────────────────┘
-```
+The app runs as four processes — Electron main, renderer (React UI), extension host, and the
+.NET data provider — communicating over JSON-RPC via WebSocket (port 8876). Diagram and details:
+[Architecture.md](.context/standards/Architecture.md).
 
 ### Key Codebase Locations
 
@@ -96,58 +65,16 @@ The application runs as four separate processes that communicate via JSON-RPC ov
 
 `@main/*` → `src/main/`, `@node/*` → `src/node/`, `@extension-host/*` → `src/extension-host/`, `@renderer/*` → `src/renderer/`, `@shared/*` → `src/shared/`
 
-## Common Commands
+## Commands
 
-### Development
+All scripts are defined in `package.json` — read it (or run `npm run`) for the full list (`npm start`, `npm test`, `npm run build` / `lint` / `format` / `typecheck`; C# tests via `dotnet test` in `c-sharp-tests/`). Two that are easy to miss:
 
 ```bash
-# Start development (headless with CDP enabled)
+# Start development headless with CDP enabled (for agent-driven and E2E runs)
 ./.erb/scripts/refresh.sh
 
-# Start development (visible window - for manual development)
-npm start
-
-# Build the entire project (TypeScript, extensions, .NET, types)
-npm run build
-```
-
-### Testing
-
-```bash
-# Run all TypeScript tests
-npm test
-
-# Run single TypeScript test with watch mode
-npm test -- path/to/test-file.test.ts --watch
-
-# Run C# unit tests
-cd c-sharp-tests
-dotnet test
-
-# Run C# tests with watch mode
-cd c-sharp-tests
-dotnet watch test
-```
-
-### Code Quality
-
-```bash
-# Format code (happens automatically on commit)
-npm run format
-
-# Lint TypeScript
-npm run lint
-
-# Fix linting issues automatically
-npm run lint-fix
-
-# Format C# code
-cd c-sharp
-dotnet tool restore
-dotnet csharpier .
-
-# Type checking
-npm run typecheck
+# Format C# — csharpier is a local dotnet tool and needs a restore first
+cd c-sharp && dotnet tool restore && dotnet csharpier .
 ```
 
 ## Development Workflow
@@ -159,11 +86,6 @@ npm run typecheck
 
 ## Coding Discipline
 
-- Read existing code before suggesting modifications.
-- If multiple interpretations of a task exist, present them — do not pick silently.
-- Frame tasks as verifiable goals: "Fix the bug" → "Write a test that reproduces it, then make it pass."
-- When any code quality tool flags your code (ESLint, TypeScript, Prettier, Stylelint), fix the code first. Only suppress warnings if the fix would be significantly worse.
-- Don't add features, refactor code, or make "improvements" beyond what was asked.
 - Avoid indecipherable [initialisms and abbreviations](.context/standards/Code-Style-Guide.md#initialisms-and-abbreviations).
 - Write forward-facing comments, not backward-facing ones. Strip the PR/development context: if a comment only explains how the code reached its current state during this PR — a ticket/PR ID for in-PR work, a review-finding ID, a stage/epic tag, a dated dev note, or bare change narration with no ID ("previously", "used to", "the review found") — cut it and put it in the commit message instead. See [forward-facing-comments.md](.claude/rules/code-quality/forward-facing-comments.md).
 
@@ -178,60 +100,24 @@ armed automatic Send/Receive rejects the write fail-fast (the `(SR_EDIT_BLOCKED)
 while a starting sync waits, bounded, for open write scopes to drain before it replaces files on
 disk.
 
-The gate has **no thread affinity** (its state is a single atomic word — an armed flag, an
-in-flight write count, and an arm generation — not an OS lock): a scope may be disposed on a
-different thread, holding one across an `await` is safe, and `SetSyncing`/`Clear` may run on any
-threads. `SetSyncing` returns a token; end the bracket with `Clear(token)` (a stale token is a
-logged no-op, so a late Clear can never disarm a newer sync) and keep parameterless `Clear()` for
-crash recovery — it force-disarms unconditionally and is idempotent. Nested `EnterWrite` calls do
-not crash, but they are NOT safe: if a sync arms while the outer scope is open, the inner call
-throws the sentinel mid-mutation — keep one scope per mutation (delegate to an un-gated core
-inside a single scope, as `SetBookUsfmInScope` does). Keep scopes **tight** — the mutation and
-nothing else — because every open scope delays a starting sync's bounded drain toward its timeout.
-
-This is an **in-process** gate, distinct from the S/R server-side repository lock
-(`lockrepo`/`unlockrepo` between clients) — do not conflate the two. `SendReceiveWriteLockCoverageTests`
-(`c-sharp-tests/Projects/SendReceive/`) scans the source tree (excluding `bin`/`obj`) for direct
-project-write call patterns (a general `.Save(` heuristic, `PutText`, comment `SaveUser`/`SaveEdits`,
-and `File`/`FileManager` deletes) and fails on any hit that isn't covered per site by ONE of: gate
-evidence (an `EnterWrite`/`EnterSyncWriteScope` call above it in the same method); an inline
-`// SR-write-gate: exempt — <reason>` marker on/above the write (for writes reached only through an
-already-gated caller — the un-gated `SetBookUsfmInScope` core and the ManageBooks orchestrators,
-each citing its gated caller + `TODO(PT-4210)`); or a whole-file entry on the test's exempt list,
-which is reserved for **not-project-data** files only. Per-site (not whole-file), so a NEW ungated
-write added to an already-gated file is still caught.
+The full gate semantics — thread affinity, the `SetSyncing`/`Clear(token)` protocol,
+nested-scope hazards, and the `SendReceiveWriteLockCoverageTests` exemption markers — live in
+[send-receive-write-gate.md](.claude/rules/send-receive-write-gate.md), which auto-loads when you
+work in `c-sharp/`.
 
 ## Recording Architecture Decisions
 
-When any code work surfaces a **significant architecture decision** — choosing among viable
-approaches, introducing a new pattern or top-level structure, deferring a platform capability, or
-deciding where a feature lives — record it in
-[`Architecture-Decisions.md`](.context/standards/Architecture-Decisions.md). This applies to **all**
-work, not just `/investigate-prd`.
-
-- **Capture the decision** as an append-only entry (date · status · context · decision · alternatives
-  · consequences). Mark superseded decisions rather than deleting them — with the one carve-out the
-  log itself states: delete a superseded entry when leaving it would keep a dead approach readable as
-  available prior art, retire its number instead of reusing it, and leave a stub explaining the gap.
-- **Promote settled conventions:** when a decision hardens into a rule everyone should follow, also
-  fold it into the relevant standard (`Architecture.md`, `Paranext-Core-Patterns.md`) or a
-  `.claude/rules/` file — that is what the agents read and enforce on the next feature. The log keeps
-  the *why* and the history; the standards keep the *current rule*.
-- **Don't over-record:** skip routine/local choices; capture the cross-cutting ones that would
-  otherwise be re-litigated or re-derived on the next PRD.
+When code work surfaces a **significant architecture decision** — a new pattern, a deferred
+capability, where a feature lives, or a choice among viable approaches — record it in
+[Architecture-Decisions.md](.context/standards/Architecture-Decisions.md); when a decision hardens
+into a rule, also fold it into the relevant standard or a `.claude/rules/` file. See that file's
+"How to use it" for the entry format and conventions.
 
 ## Never Commit Secrets
 
-This is an open-source repository. Never introduce secrets into the codebase:
-
-- **No hardcoded credentials**: API keys, tokens, passwords, connection strings, private keys.
-- **No secret files**: `.env`, `.env.*`, `*.pem`, `*.key`, `*.pfx`, `*.p12`, `credentials.json`, `service-account.json`.
-- **No secrets in commit messages or PR descriptions.**
-- **No base64-encoded or obfuscated secrets** — encoding is not encryption.
-
-If a feature needs a secret at runtime, use environment variables or Platform.Bible's settings system. Never provide a default value that is an actual secret.
-
-Never skip pre-commit hooks (`--no-verify`, `-n`, `HUSKY=0`) — they run the secret-detection linters. If a hook fails, fix the underlying issue. If you suspect you've staged a file containing secrets, unstage it before committing.
+Never introduce secrets into this open-source repo — see
+[no-secrets.md](.claude/rules/code-quality/no-secrets.md) for what's forbidden and the
+pre-commit-hook enforcement.
 
 ## Git & PR Conventions
 
@@ -261,15 +147,3 @@ Never skip pre-commit hooks (`--no-verify`, `-n`, `HUSKY=0`) — they run the se
 **macOS**: Requires MacPorts with icu4c libraries. The .NET build automatically copies dylibs to output directory.
 
 **Windows**: Use WSL2 for cross-platform testing.
-
-## Version Management
-
-- Use Node.js version specified in `package.json` → `volta.node` (recommend using Volta)
-- Requires .NET 8 SDK
-
-## Links
-
-- [PAPI Documentation](https://paranext.github.io/paranext-core/papi-dts)
-- [React Components Docs](https://paranext.github.io/paranext-core/platform-bible-react)
-- [Utilities Docs](https://paranext.github.io/paranext-core/platform-bible-utils)
-- [Extension Template](https://github.com/paranext/paranext-extension-template/wiki)


### PR DESCRIPTION
## Summary

Applies Anthropic's Claude 5 context-engineering guidance to this repo's agent-instruction files: keep always-loaded context lightweight (repo gotchas, not derivable boilerplate), use progressive disclosure (path-scoped rules that load only when relevant files are touched), and prefer machine-enforced or on-demand guidance over standing prose. Follows an audit of the instruction files across the Paratext 10 repo family.

**Always-loaded context: CLAUDE.md 275 → 149 lines (18,085 → 11,602 bytes); always-on rules 8 files/14,314 bytes → 3 files/5,587 bytes** (the other 5 rule files still exist, unchanged in substance, but now load only for matching paths instead of every session) — with no substance deleted — everything cut either already exists elsewhere or moved to a path-scoped rule.

### Why review this

Not part of the current epic. Prompted by Anthropic's published context-engineering guidance for Claude 5-generation models: instruction files written for earlier models carry boilerplate the new models derive themselves, and always-on rules cost context in every session. Worth reviewer time now because it touches the files every agent session in this repo loads.

## Changes

| What | Where it went |
|---|---|
| Tech Stack, Common Commands (all but 2 of 53 lines), Version Management, Links | Cut — derivable from `package.json` in one read; kept the two non-obvious commands (`./.erb/scripts/refresh.sh` headless+CDP, `dotnet tool restore` before `csharpier`) |
| Multi-process ASCII diagram | Cut — duplicates [Architecture.md](.context/standards/Architecture.md), already linked in the reference table |
| Coding Discipline: "read existing code", "present alternatives", "frame as verifiable goals", "no unrequested scope" bullets | Cut — restates default model behavior. Checked for a hidden duplicate elsewhere (`grep -ri` across `.claude/` and `.context/` for each bullet's key phrase) before cutting: the only hit was an unrelated Testing-Guide.md bullet about escalating edge-case ambiguity in test design, not a match |
| Coding Discipline: "fix ESLint/TypeScript/Prettier/Stylelint findings first" bullet | Duplicated [eslint-disable-discipline.md](.claude/rules/code-quality/eslint-disable-discipline.md) (already an always-on rule) — cut from CLAUDE.md |
| Send/Receive Write Gate: thread-affinity / `SetSyncing`/`Clear(token)` protocol / coverage-test exemption-marker paragraphs | Moved verbatim to new path-scoped rule [send-receive-write-gate.md](.claude/rules/send-receive-write-gate.md) (`c-sharp/**`, `c-sharp-tests/**`); the one-paragraph invariant + a 4-line pointer stay in CLAUDE.md |
| Recording Architecture Decisions: entry-format / supersede-and-carve-out / promote-settled-conventions / don't-over-record bullets | Already existed verbatim in [Architecture-Decisions.md](.context/standards/Architecture-Decisions.md) § "How to use it" (added to CLAUDE.md after this PR was first opened, once main gained that section) — and that copy is more current than CLAUDE.md's would-be duplicate (it already uses the slug-based supersede language from the ADR-numbering→slug change; CLAUDE.md's copy still said "retire its number"). Trimmed CLAUDE.md to a 4-line pointer; nothing needed moving, it was already there |
| Never Commit Secrets: credential/secret-file/base64 bullets + "use env vars at runtime" sentence | Already existed verbatim in [no-secrets.md](.claude/rules/code-quality/no-secrets.md); CLAUDE.md trimmed to a one-line pointer |
| Never Commit Secrets: "never skip pre-commit hooks (`--no-verify`/`-n`/`HUSKY=0`)" sentence | Did **not** already exist in no-secrets.md — moved there verbatim so it isn't lost |
| Security-Guide.md's secrets pointer | Retargeted from "see CLAUDE.md" to [no-secrets.md](.claude/rules/code-quality/no-secrets.md) directly, removing the CLAUDE.md ↔ Security-Guide circular reference |
| 5 always-on rules (`cross-view-sync-hidden-views`, `keyboard-shortcuts-catalog`, `shadcn-discipline`, `eslint-disable-discipline`, `lint-sweep-verification`) | Content unchanged; now carry `paths:` frontmatter so they load only when matching files are touched, instead of every session |
| `grep-safety-net.md`, `forward-facing-comments.md`, `no-secrets.md` | Deliberately stay global/always-on — process-wide discipline and the machine-enforced (husky) secrets rule |

### Refreshed onto main 2026-09-03

Rebased from the original July 27 commit onto today's main (~97 commits of drift). Main had independently grown a "Send/Receive Write Gate" deep-dive, a "Recording Architecture Decisions" section, and several Reference Documentation rows since this PR was opened; re-derived the trim against that current content rather than picking a side, per the table above.

Caught and fixed during the refresh: the `paths:` globs added to `eslint-disable-discipline.md`, `lint-sweep-verification.md`, and `cross-view-sync-hidden-views.md` had unquoted entries starting with `**` (e.g. `**/*.ts`) — YAML parses a leading `*` as an alias-node marker, so those frontmatter blocks failed to parse. Quoted every glob in all six touched rule files' `paths:` lists, matching the quoting convention already used by the repo's pre-existing scoped rules (`architecture/react-patterns.md`, `architecture/csharp-patterns.md`, etc.). Verified with a YAML parse of each file's frontmatter after the fix.

## AI Involvement

AI-assisted — [session 1](https://claude.ai/code/session_01Qu9i2XxnVHwSHrc4W5vTic) (original trim), session 2 — local Claude Code background job on 2026-09-03, no claude.ai session URL (rebase refresh onto main, YAML-quoting fix). The trim plan came from an AI audit of the instruction files; all edits are AI-generated and mechanically verified (prettier passes; fence counts even; YAML frontmatter parses; content diffed to confirm nothing cut without a surviving home; roborev's automated per-commit review found no issues). Human review requested on: the chosen `paths:` globs, and whether any cut section was load-bearing for a workflow the audit missed.

## Testing

- [x] `prettier --check` passes on all changed files (the applicable gate for a docs-only diff; cspell is not wired into any script, hook, or workflow in this repo)
- [x] Fence-pair count even in every changed Markdown file (prettier/lint don't catch fence damage)
- [x] Every `paths:` block parses as valid YAML
- [x] roborev automated per-commit review: no issues found
- [ ] Reviewer sanity-check of the `paths:` globs

## Risk Level

Low — docs/agent-config only; no source, build, or CI changes. Worst case is a rule loading less often than intended, reverted by removing frontmatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qu9i2XxnVHwSHrc4W5vTic

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2614)
<!-- Reviewable:end -->
