### PR TITLE
docs(claude): align /investigate-prd context files with Claude-5 context guidance

### DIFF
--- a/.claude/agents/pt10-reuse-scout.md
+++ b/.claude/agents/pt10-reuse-scout.md
@@ -143,7 +143,7 @@ Recommendation: {choice} — Rationale: {why}
 Anchor the recommendation in `Architecture.md`: name the documented pattern the feature should
 follow (a shared/main/extension-host service, a data provider, a network object, an extension
 contribution) and check the placement honors the process/import boundaries and security model it
-defines. If you recommend a **new top-level folder / service / extension**, you MUST (per the
+defines. If you recommend a **new top-level folder / service / extension**, you must (per the
 `discover-before-implementing` rule) state specific reasons no existing folder fits and name the
 existing code that will be **reused (called, not duplicated)** — and flag that a new top-level
 structure needs explicit human approval.

--- a/.claude/commands/investigate-prd.md
+++ b/.claude/commands/investigate-prd.md
@@ -257,7 +257,9 @@ standalone command, so this can happen days later in a fresh session:
 `/prd-to-jira .context/research/investigations/$SLUG/brief.md`.
 
 Per-work-item design and implementation planning (e.g. `superpowers:writing-plans`) happen
-**after** Jira creation, one work item at a time — not in this command.
+**after** Jira creation, one work item at a time — not in this command. As each plan is executed,
+record deviations from the approved plan in the plan doc itself — it doubles as the
+implementation's deviation log.
 
 ## Error handling
 

--- a/.claude/rules/agent-authoring-link-dont-paraphrase.md
+++ b/.claude/rules/agent-authoring-link-dont-paraphrase.md
@@ -1,3 +1,10 @@
+---
+paths:
+  - ".claude/agents/**"
+  - ".claude/commands/**"
+  - ".claude/skills/**"
+---
+
 ## Agent/Command/Skill Authoring: Link, Don't Paraphrase
 
 When writing or editing files in `.claude/agents/`, `.claude/commands/`, or `.claude/skills/`, prefer generic patterns over content that goes stale. Ask: "If a standard changes, would this text need to be hand-updated?" If yes, link to the source instead of restating it.


### PR DESCRIPTION
## Motivation

Applies the Claude-5 context-engineering guidance already applied to the rest of the instruction-file family (#2614, paratext-10-studio #169) to the new context files #2438 introduces: lightweight always-loaded content, path-scoped rules, bold-the-fact phrasing.

**Stacked on #2438** (`ai/investigate-prd-command`). After #2438 squash-merges, this branch gets rebased onto main and the PR retargeted, per our stacked-PR discipline.

## Changes

| Item | Outcome |
|---|---|
| Scope `agent-authoring-link-dont-paraphrase.md` | Added `paths: .claude/{agents,commands,skills}/**` — the rule's entire subject is authoring those files; it no longer loads in every session (52 lines off the always-on budget) |
| Caps/modality style pass over the 3 commands + 4 agents | Measured: 6 of 7 files have **zero** ALL-CAPS directives. `pt10-reuse-scout.md` had 5 — four are structural `(ALWAYS)` step-labels distinguishing unconditional sweep steps (kept), one was modality shouting (`you MUST`) → softened to `you must`; the surrounding bolded facts carry the emphasis |
| Deviations-log convention | One line added to `investigate-prd.md`'s per-work-item planning note: executed plans record deviations in the plan doc itself |

## Verified no-ops (checked, nothing to do)

- **CLAUDE.md Feature-Inventory pointer**: already present in #2438's diff (`| PT9 Feature Inventory | paratext-9-features/README.md |` row). It looked missing because `gh pr view --json files` truncates at 100 files and the 74 bundled research files pushed CLAUDE.md off the list.
- **`no-secrets.md`**: #2438's edit is a strict superset of main's canonical version (adds a PT9-porting subsection; drops nothing), so it remains a valid canonical copy after #2614's CLAUDE.md secrets-section cut.

Prettier clean on all three changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qu9i2XxnVHwSHrc4W5vTic

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2615)
<!-- Reviewable:end -->


> **Folded into #2438** (commit 08904a76470 fast-forwarded onto `ai/investigate-prd-command`, 2026-07-27) — the diff was small enough to not warrant a separate review cycle. Closed without merging.
