### PR TITLE
docs: distill Spanish localization decisions into Localization-Guide.md

### DIFF
--- a/.context/standards/Localization-Guide.md
+++ b/.context/standards/Localization-Guide.md
@@ -1,10 +1,10 @@
 ---
 title: Localization Guide
 description: Mandatory localization patterns for all user-facing text in paranext-core — UI web views (TS) and C# backend services.
-version: 1.4.0
+version: 1.5.0
 status: active
 created: 2026-03-04
-last_updated: 2026-06-17
+last_updated: 2026-07-16
 toc: true
 ---
 
@@ -27,6 +27,8 @@ This guide documents localization patterns for paranext-core. All user-facing te
 <!-- | [Reusing Existing Strings (IMPORTANT)](#reusing-existing-strings-important) | -->
 <!-- | [Existing Strings Are Immutable (CRITICAL)](#existing-strings-are-immutable-critical) | -->
 <!-- | [Dynamic Values with formatReplacementString](#dynamic-values-with-formatreplacementstring) | -->
+<!-- | [Embedding JSX in Localized Text with formatReplacementStringToArray](#embedding-jsx-in-localized-text-with-formatreplacementstringtoarray) | -->
+<!-- | [Spanish (es) Localization Decisions](#spanish-es-localization-decisions) | -->
 <!-- | [Localization Checklist](#localization-checklist) | -->
 <!-- | [Blocking Issues](#blocking-issues) | -->
 <!-- | [C# Backend Localization](#c-backend-localization) | -->
@@ -217,6 +219,46 @@ Add `...` to labels that open dialogs:
 
 ---
 
+## Spanish (es) Localization Decisions
+
+Distilled from the team's "Localization decisions - Paratext 10 Studio" Google Doc (Spanish tab — the doc's French tab is not yet fleshed out enough to be authoritative, so no French guidance is captured here yet). Apply these when writing or reviewing `es` strings; if using an AI-assisted translator, feed it these decisions as context.
+
+### Priority and regional variant
+
+- Prioritize industry best practices first, Paratext 9 precedent second.
+- Target broadly-understood **Latin American Spanish** rather than defaulting to a European "standard" — Platform.Bible's localization strategy supports regional variants layered on top of a general one. If no single term covers all regions well, use the best general term and add region-specific strings only if truly needed.
+- Prefer simple vocabulary and sentence structure — many users run the software in a non-native language.
+- Translations don't need to be literal. Prioritize clarity: if the English string is vague or leaves something implicit, make it explicit in Spanish. Consider where the string appears in the UI so the translation makes sense in context.
+- Watch for length: long strings can break layouts (e.g. menus). Test in-app where possible; if a translation must be shortened, put the fuller explanation in a tooltip/description instead, or flag it to the dev team so the UI can accommodate it.
+
+### Formality
+
+Always use formal **usted** — never *tú*, *vos*, or *vosotros*. Keep the tone respectful and professional but not cold or distant; avoid colloquialisms or the joking tone sometimes seen in other apps' error messages.
+
+### Error and exception messages
+
+Two templates:
+- **"No se pudo…"** ("Could not…") — the action did not complete (e.g. failed save, failed project open).
+- **"Se produjo un error al…"** ("An error occurred while…") — a system-level failure where the action started but failed mid-process.
+
+Never blame the user. Use neutral phrasing and, where possible, briefly suggest how to resolve the issue.
+
+### Capitalization
+
+Sentence case only — capitalize just the first word of a sentence/instruction plus proper nouns. Do not mirror English title case, even for tab/window/section names (e.g. "Show Recent Searches" → "Mostrar búsquedas recientes"). Exceptions that stay capitalized: proper nouns (*Internet*, *Paratext*), single letters identifying scroll groups/additional books/etc., and acronyms (*ISO*, *JSON*).
+
+### Verb mood
+
+- **Infinitive** for actions the user invokes — buttons, menus, commands: *Guardar*, *Abrir proyecto*, *Cancelar*, *Aceptar*.
+- **Conjugated imperative** only when the software is directly telling the user what to do — messages/alerts: *Inténtelo de nuevo*.
+- Courtesy phrasing is **"Por favor, + imperative"** (e.g. *Por favor, cierre otras ventanas antes de continuar*) — avoid the non-standard "Favor de + infinitive" construction.
+
+### Revising an existing decision
+
+If a later localizer disagrees with a decision here, document the new decision and its rationale (in this section), then update the existing `es` strings to match the revised guideline. This is a narrow, deliberate exception to [Existing Strings Are Immutable](#existing-strings-are-immutable-critical): it applies only to bringing old translations in line with a revised style rule, not to casual rewording.
+
+---
+
 ## Text Direction (RTL/LTR)
 
 **Per-content text direction MUST come from the `platform.textDirection` project setting.** Read it via:
@@ -342,6 +384,35 @@ In `localizedStrings.json`:
 
 ---
 
+## Embedding JSX in Localized Text with formatReplacementStringToArray
+
+`formatReplacementString` only produces a plain string, so it can't carry a React element (a link, an icon, a `<kbd>`) embedded mid-sentence. For that case, use its sibling `formatReplacementStringToArray` from `platform-bible-utils`: it tokenizes the same `{placeholder}` syntax but returns an array of strings interleaved with whatever replacer values you pass — including JSX — which you render directly as children.
+
+```tsx
+import { formatReplacementStringToArray } from 'platform-bible-utils';
+
+// localized string: "{intro} {websiteLink} ({license})"
+<p>
+  {formatReplacementStringToArray(introFormat, {
+    intro: introText,
+    websiteLink: (
+      <a target="_blank" rel="noreferrer" href={WEBSITE_LINK}>
+        {WEBSITE_NAME}
+      </a>
+    ),
+    license: licenseText,
+  })}
+</p>
+```
+
+**Why this matters:** embedding a non-text element (a `<kbd>`, an icon, a link) by string-concatenating it before or after a localized string — e.g. `<kbd>Backspace</kbd> {message}` — bakes in an assumption about word order and spacing that not every language shares, and forces the element into a fixed position the string can't control. Letting the *localized string itself* place the `{placeholder}` fixes both problems: each translation decides where the embedded element goes, and any surrounding punctuation/spacing lives in the translated string, not in code.
+
+**Reference implementation:** `src/renderer/components/dialogs/about-dialog.component.tsx` (the `%about_db_ip_attribution_format%` string interpolates two `<a>` links this way).
+
+**Don't reimplement this.** A second, parallel `{placeholder}`-splitting helper (`interleavePlaceholders`) exists in `extensions/src/platform-enhanced-resources/src/components/guide/marble-guide.component.tsx` because that code didn't find `formatReplacementStringToArray` first. Reuse the shared utility instead of writing a local one.
+
+---
+
 ## Localization Checklist
 
 Before completing any UI work:
@@ -459,6 +530,7 @@ Alternative design: use a dedicated `xxxKey` field (e.g. `ErrorMessageKey`) alon
 
 | Version | Date       | Change          |
 | ------- | ---------- | --------------- |
+| 1.5.0   | 2026-07-16 | Added "Embedding JSX in Localized Text with formatReplacementStringToArray" section (mid-sentence JSX interpolation, e.g. links/kbd elements, via the existing `formatReplacementStringToArray` utility — was previously undocumented and had already been reimplemented once as a local helper). Added "Spanish (es) Localization Decisions" section distilled from the team's "Localization decisions - Paratext 10 Studio" Google Doc (Spanish tab): regional-variant/priority guidance, formal `usted` register, error-message templates, capitalization rules, and verb-mood rules (infinitive for controls, conjugated imperative for messages/alerts). French tab exists but is not yet authoritative, so not captured. |
 | 1.4.0   | 2026-06-17 | Added "Localizing Shared Library Components (`lib/platform-bible-react/`)" section: process-agnostic library components must not call `useLocalizedStrings`/PAPI; they expose a frozen `STRING_KEYS` tuple + a `Partial<Record<…>>` type + an optional `localizedStrings?` prop with English-fallback reads, and the consumer resolves and passes strings down. Named the hardcoded-string enforcer as the real ESLint rule `paranext/no-hardcoded-jsx-strings`. Added a "one key-prefix convention per feature namespace" subsection under Conventions › Key Format (prefer camelCase feature-prefix with `_` subsegments; don't mix camelCase and snake_case variants of the same prefix). Grounded against `book-chapter-control`, `book-selector`, and `marker-menu`. |
 | 1.3.0   | 2026-04-29 | Added "Text Direction (RTL/LTR)" section codifying per-content direction via `useProjectSetting('platform.textDirection', defaultTextDirection)`. Forbids hardcoded language-code equality checks (`x === 'he' \|\| x === 'ar'`). References `platform-scripture-editor.web-view.tsx` (the `defaultTextDirection` constant and the `OHEBGRK` branch) as the canonical pattern. Clarifies separation between global UI direction (`readDirection()`) and per-content direction. Sourced from markers-checklist PR feedback (RTL-hardcoding comment). |
 | 1.2.0   | 2026-04-21 | Added `toc: true` + machine-readable TOC block now that the guide has grown past the stub-patterns.md threshold. No content changes. |

--- a/.context/standards/Localization-Guide.md
+++ b/.context/standards/Localization-Guide.md
@@ -1,10 +1,10 @@
 ---
 title: Localization Guide
 description: Mandatory localization patterns for all user-facing text in paranext-core — UI web views (TS) and C# backend services.
-version: 1.5.0
+version: 1.6.0
 status: active
 created: 2026-03-04
-last_updated: 2026-07-27
+last_updated: 2026-07-28
 toc: true
 ---
 
@@ -23,12 +23,12 @@ This guide documents localization patterns for paranext-core. All user-facing te
 <!-- | [Localization Pattern](#localization-pattern) | -->
 <!-- | [Localizing Shared Library Components (lib/platform-bible-react/)](#localizing-shared-library-components-libplatform-bible-react) | -->
 <!-- | [Conventions](#conventions) | -->
+<!-- | [Spanish (es) Localization Decisions](#spanish-es-localization-decisions) | -->
 <!-- | [Text Direction (RTL/LTR)](#text-direction-rtlltr) | -->
 <!-- | [Reusing Existing Strings (IMPORTANT)](#reusing-existing-strings-important) | -->
 <!-- | [Existing Strings Are Immutable (CRITICAL)](#existing-strings-are-immutable-critical) | -->
 <!-- | [Dynamic Values with formatReplacementString](#dynamic-values-with-formatreplacementstring) | -->
 <!-- | [Embedding JSX in Localized Text with formatReplacementStringToArray](#embedding-jsx-in-localized-text-with-formatreplacementstringtoarray) | -->
-<!-- | [Spanish (es) Localization Decisions](#spanish-es-localization-decisions) | -->
 <!-- | [Localization Checklist](#localization-checklist) | -->
 <!-- | [Blocking Issues](#blocking-issues) | -->
 <!-- | [C# Backend Localization](#c-backend-localization) | -->
@@ -142,6 +142,12 @@ In `contributions/localizedStrings.json`:
 }
 ```
 
+### 4. Flag Unclear or Non-Standard English Source Text
+
+Before translating, check whether the English string itself is clear and grammatically standard. If it's ambiguous, idiomatic, or likely to trip up a non-native English speaker, don't just translate around the problem — flag it to the developer and suggest clearer alternatives for the English string.
+
+This is advisory, not a [blocking issue](#blocking-issues) — raise it, don't hold up the PR over it. There's a real tension between brevity and grammatical completeness (e.g. "Save project" vs. "Save the project" vs. "Save your project"); UX is aware of this tradeoff, but call it out when the terseness is likely to confuse non-native speakers.
+
 ---
 
 ## Localizing Shared Library Components (`lib/platform-bible-react/`)
@@ -217,45 +223,57 @@ Add `...` to labels that open dialogs:
 
 **Always provide both `en` AND `es` translations.** Both are required for the build to pass.
 
+### Translation Style (All Languages)
+
+Apply these regardless of target language:
+
+- Prioritize industry best practices first, Paratext 9 precedent second, when choosing terminology or phrasing.
+- Prefer simple vocabulary and sentence structure — many users run the software in a non-native language.
+- Translations don't need to be literal. Prioritize clarity: if the English string is vague or leaves something implicit, make it explicit in the target language. Consider where the string appears in the UI so the translation makes sense in context.
+- Watch for length: long strings can break layouts (e.g. menus). Test in-app where possible; if a translation must be shortened, put the fuller explanation in a tooltip/description instead, or flag it to the dev team so the UI can accommodate it.
+- Error and exception messages: never blame the user. Use neutral phrasing and, where possible, briefly suggest how to resolve the issue.
+- Capitalization: sentence case only — capitalize just the first word of a sentence/instruction plus proper nouns. Do not mirror English title case, even for tab/window/section names (e.g. "Show Recent Searches" → "Mostrar búsquedas recientes"). Exceptions that stay capitalized: proper nouns (*Internet*, *Paratext*), single letters identifying scroll groups/additional books/etc., and acronyms (*ISO*, *JSON*).
+- Not every string maps neatly to an "interactive control" (button/menu/command) or an "alert/message" — tooltips, status bar text, placeholder text, and progress labels are common ambiguous cases. Classify by function first: an ongoing process (e.g. "Saving…", "Loading…") reads differently from a completed/current state (e.g. "Saved", "Connected") or a static description (a control's purpose, a tooltip). Apply your language's convention for each case; when it's still unclear, default to the same tone as static interactive-control labels.
+- Placeholder text depends on what it's a placeholder for — it is not one category. A field expecting a specific value (e.g. a name or email field) is typically a noun phrase naming the expected content, with no verb at all. A field that suggests an action (e.g. a search box) should match the register/tone used for other interactive-control action labels in your language.
+
+### Revising an Existing Localization Decision
+
+If a later localizer disagrees with a documented style decision (here or in a per-language section below), see [Exception: Fixing Errors or Applying a Revised Style Rule](#exception-fixing-errors-or-applying-a-revised-style-rule) under Existing Strings Are Immutable for how to update it without breaking the immutability rule.
+
 ---
 
 ## Spanish (es) Localization Decisions
 
-Distilled from the team's "Localization decisions - Paratext 10 Studio" Google Doc (Spanish tab — the doc's French tab is not yet fleshed out enough to be authoritative, so no French guidance is captured here yet). Apply these when writing or reviewing `es` strings; if using an AI-assisted translator, feed it these decisions as context.
+Distilled from the team's ["Localization decisions - Paratext 10 Studio"](https://docs.google.com/document/d/1eczM9NS_ErRGR00WrPnThLn17POuYDLufF_tVukTHnU/edit?tab=t.sxfosibwx6hc#heading=h.errty21z3k1k) Google Doc (Spanish tab — the doc's French tab is not yet fleshed out enough to be authoritative, so no French guidance is captured here yet). These decisions apply on top of the [general translation style principles](#translation-style-all-languages) above — apply both when writing or reviewing `es` strings; if using an AI-assisted translator, feed it both as context.
 
-### Priority and regional variant
+**Last synced:** 2026-07-28. This section is a snapshot, not a live mirror — if the Google Doc has been updated since this date, re-check it and update this section accordingly before treating it as authoritative.
 
-- Prioritize industry best practices first, Paratext 9 precedent second.
-- Target broadly-understood **Latin American Spanish** rather than defaulting to a European "standard" — Platform.Bible's localization strategy supports regional variants layered on top of a general one. If no single term covers all regions well, use the best general term and add region-specific strings only if truly needed.
-- Prefer simple vocabulary and sentence structure — many users run the software in a non-native language.
-- Translations don't need to be literal. Prioritize clarity: if the English string is vague or leaves something implicit, make it explicit in Spanish. Consider where the string appears in the UI so the translation makes sense in context.
-- Watch for length: long strings can break layouts (e.g. menus). Test in-app where possible; if a translation must be shortened, put the fuller explanation in a tooltip/description instead, or flag it to the dev team so the UI can accommodate it.
+To revise a decision below, see [Exception: Fixing Errors or Applying a Revised Style Rule](#exception-fixing-errors-or-applying-a-revised-style-rule) — update the Google Doc first, then sync this section.
+
+### Regional variant
+
+Target broadly-understood **Latin American Spanish** rather than defaulting to a European "standard" — Platform.Bible's localization strategy supports regional variants layered on top of a general one. If no single term covers all regions well, use the best general term and add region-specific strings only if truly needed.
 
 ### Formality
 
 Always use formal **usted** — never *tú*, *vos*, or *vosotros*. Keep the tone respectful and professional but not cold or distant; avoid colloquialisms or the joking tone sometimes seen in other apps' error messages.
 
-### Error and exception messages
+### Error message templates
 
-Two templates:
+Two templates (in addition to the general "never blame the user" guidance above):
 - **"No se pudo…"** ("Could not…") — the action did not complete (e.g. failed save, failed project open).
 - **"Se produjo un error al…"** ("An error occurred while…") — a system-level failure where the action started but failed mid-process.
-
-Never blame the user. Use neutral phrasing and, where possible, briefly suggest how to resolve the issue.
-
-### Capitalization
-
-Sentence case only — capitalize just the first word of a sentence/instruction plus proper nouns. Do not mirror English title case, even for tab/window/section names (e.g. "Show Recent Searches" → "Mostrar búsquedas recientes"). Exceptions that stay capitalized: proper nouns (*Internet*, *Paratext*), single letters identifying scroll groups/additional books/etc., and acronyms (*ISO*, *JSON*).
 
 ### Verb mood
 
 - **Infinitive** for actions the user invokes — buttons, menus, commands: *Guardar*, *Abrir proyecto*, *Cancelar*, *Aceptar*.
 - **Conjugated imperative** only when the software is directly telling the user what to do — messages/alerts: *Inténtelo de nuevo*.
-- Courtesy phrasing is **"Por favor, + imperative"** (e.g. *Por favor, cierre otras ventanas antes de continuar*) — avoid the non-standard "Favor de + infinitive" construction.
-
-### Revising an existing decision
-
-If a later localizer disagrees with a decision here, document the new decision and its rationale (in this section), then update the existing `es` strings to match the revised guideline. This is a narrow, deliberate exception to [Existing Strings Are Immutable](#existing-strings-are-immutable-critical): it applies only to bringing old translations in line with a revised style rule, not to casual rewording.
+- Courtesy phrasing: prefer **"Por favor, + imperative"** (e.g. *Por favor, cierre otras ventanas antes de continuar*). **"Favor de + infinitive"** is common in formal Mexican and other Latin American contexts, but is not the team's preferred style.
+- **Progress indicators for an ongoing process** → **gerund**: *Guardando…*, *Cargando…*, *Sincronizando…*.
+- **Completed/current-state labels** (often in the status bar) → **past participle**, used adjectivally rather than as a verb mood: *Guardado*, *Sincronizado*, *Conectado*, *Desconectado*.
+- **Placeholder text** (see general placeholder-text guidance above): a field expecting a specific value takes a plain noun phrase, no verb at all — *Nombre del proyecto*, *Correo electrónico*. A field that suggests an action (e.g. a search box) takes the **infinitive**, same as buttons: *Buscar…*.
+- Tooltips and other static descriptive labels → **infinitive**, same as buttons/menus (e.g. a tooltip on a save icon reads *Guardar cambios*).
+- **When in doubt, default to the infinitive.**
 
 ---
 
@@ -355,6 +373,21 @@ If a string needs to be replaced with a different value:
 - New code uses the new key directly
 - No breaking changes to existing translations
 
+### Exception: Fixing Errors or Applying a Revised Style Rule
+
+The immutability rule above protects a key's **meaning** — not the exact characters of its value. It's fine to correct a string's value in place, without a new key or `fallbackKey`, when the fix does not change what the string means:
+- Spelling, grammar, or punctuation corrections.
+- Bringing an existing string in line with a style rule that was revised or newly clarified after the string shipped (e.g. a capitalization or verb-mood rule changed).
+
+**If the meaning changes at all** — including a "clarification" that changes what the user understands, not just how it's phrased — that's not a correction. Treat it as a replacement and follow [If a String Needs Replacement](#if-a-string-needs-replacement) above (new key + `fallbackKey`) instead of editing in place. In-place edits are invisible to anyone (a downstream consumer, a third-party translator working from an old export) holding a reference to the old value; only a meaning-preserving fix is safe to make silently.
+
+**Process for revising a documented decision:**
+1. For a language whose decisions are sourced from an external document (e.g. the [Spanish tab of the Localization Decisions Google Doc](#spanish-es-localization-decisions)), update the source document first — it is the authoritative record, and this guide is a synced snapshot of it.
+2. Update this guide to match, including bumping any "Last synced" date, so the guide doesn't silently drift from the source.
+3. Update the shipped strings to match the revised rule.
+
+For decisions that live directly in this guide — the language-agnostic rules under [Translation Style (All Languages)](#translation-style-all-languages) — skip step 1: change the rule here directly and record the change in the [Version Log](#version-log). Note that some of the language-agnostic rules may be appropriate to call out in the (English) Explanation page of the Localization Decisions Google Doc, so review that document and consider whether that may be the case for any new decisions.
+
 ---
 
 ## Dynamic Values with formatReplacementString
@@ -388,10 +421,13 @@ In `localizedStrings.json`:
 
 `formatReplacementString` only produces a plain string, so it can't carry a React element (a link, an icon, a `Kbd`) embedded mid-sentence. For that case, use its sibling `formatReplacementStringToArray` from `platform-bible-utils`: it tokenizes the same `{placeholder}` syntax but returns an array of strings interleaved with whatever replacer values you pass — including JSX — which you render directly as children.
 
+Because the result is an array, each item needs a `key` when rendered — wrap it with `.map` into `Fragment`s keyed by index (safe here since the array is static and never reordered):
+
 ```tsx
+import { Fragment } from 'react';
 import { formatReplacementStringToArray } from 'platform-bible-utils';
 
-// localized string: "{intro} {websiteLink} ({license})"
+// localized string: "{intro} {websiteLink} ({license}, {terms})"
 <p>
   {formatReplacementStringToArray(introFormat, {
     intro: introText,
@@ -401,17 +437,30 @@ import { formatReplacementStringToArray } from 'platform-bible-utils';
       </a>
     ),
     license: licenseText,
-  })}
+    terms: (
+      <a target="_blank" rel="noreferrer" href={TERMS_LINK}>
+        {termsText}
+      </a>
+    ),
+  }).map((contribution, index) => (
+    // We can use index as key here because the array is static and will not change.
+    // eslint-disable-next-line react/no-array-index-key
+    <Fragment key={`key-${index}`}>{contribution}</Fragment>
+  ))}
 </p>
 ```
 
 **Why this matters:** embedding a non-text element (a `Kbd`, an icon, a link) by string-concatenating it before or after a localized string — e.g. `<Kbd>{key}</Kbd> {message}` — bakes in an assumption about word order and spacing that not every language shares, and forces the element into a fixed position the string can't control. Letting the *localized string itself* place the `{placeholder}` fixes both problems: each translation decides where the embedded element goes, and any surrounding punctuation/spacing lives in the translated string, not in code.
 
-For key names specifically, use the `Kbd`/`KbdGroup` components exported from `platform-bible-react` rather than a raw `<kbd>` element, per the [Tooltips guideline](../../lib/platform-bible-react/src/stories/guidelines/tooltips.mdx). And don't hardcode a key's display word (`"Backspace"`, `"Delete"`) — once merged, `getLocalizeKeyForPhysicalKey` (`platform-bible-utils/keyboard-util.ts`, added in [#2590](https://github.com/paranext/paranext-core/pull/2590)) resolves a `NameablePhysicalKey` to its localized key, so the key label goes through the same localization pipeline as everything else instead of being hardcoded per caller.
+For key names specifically, use the `Kbd`/`KbdGroup` components exported from `platform-bible-react` rather than a raw `<kbd>` element, per the [Tooltips guideline](../../lib/platform-bible-react/src/stories/guidelines/tooltips.mdx). And don't hardcode a key's display word (`"Backspace"`, `"Delete"`) — once merged, `getLocalizeKeyForPhysicalKey(key: NameablePhysicalKey): LocalizeKey` (`platform-bible-utils/keyboard-util.ts`, added in [#2590](https://github.com/paranext/paranext-core/pull/2590)) resolves a `NameablePhysicalKey` to its localized key, so the key label goes through the same localization pipeline as everything else instead of being hardcoded per caller. If a key you need to display isn't already in `NameablePhysicalKey`, add it there (with a corresponding `localizedStrings.json` entry) rather than falling back to a hardcoded string.
+
+**Which key names to actually translate:** whether a language's `getLocalizeKeyForPhysicalKey` entries should translate a key's label, rather than keep it in English, depends on that language's physical-keyboard landscape, not on whether a plausible translation exists:
+- If physical keyboards commonly used for that language print localized key names/abbreviations, translate to match what's printed on those keyboards — even though some users of that locale may still be typing on an English-labeled keyboard.
+- If localized physical keyboards are rare or don't exist for that language, keep the English key name, even if a plausible translation exists — unless industry-standard software conventions for that language dictate otherwise.
 
 **Reference implementation:** `src/renderer/components/dialogs/about-dialog.component.tsx` (the `%about_db_ip_attribution_format%` string interpolates two `<a>` links this way).
 
-**Don't reimplement this.** A second, parallel `{placeholder}`-splitting helper (`interleavePlaceholders`) exists in `extensions/src/platform-enhanced-resources/src/components/guide/marble-guide.component.tsx` because that code didn't find `formatReplacementStringToArray` first. Reuse the shared utility instead of writing a local one.
+**Don't reimplement this.** A second, parallel `{placeholder}`-splitting helper (`interleavePlaceholders`) exists in `extensions/src/platform-enhanced-resources/src/components/guide/marble-guide.component.tsx` because that code didn't find `formatReplacementStringToArray` first. Reuse the shared utility instead of writing a local one — this isn't just duplication: `interleavePlaceholders` tokenizes with `/\{(\w+)\}/g`, so a hyphenated placeholder name (e.g. `{color-word}`) doesn't match and is silently left in the rendered UI as literal `{color-word}` text; `formatReplacementStringToArray` doesn't have this defect. Tracked in [PT-4269](https://paratextstudio.atlassian.net/browse/PT-4269) — once that's fixed (marble-guide migrated to `formatReplacementStringToArray`), remove this paragraph.
 
 ---
 
@@ -532,6 +581,7 @@ Alternative design: use a dedicated `xxxKey` field (e.g. `ErrorMessageKey`) alon
 
 | Version | Date       | Change          |
 | ------- | ---------- | --------------- |
+| 1.6.0   | 2026-07-28 | Code-review pass on the 1.5.0 additions. Fixed TOC section order (Spanish now listed before Text Direction, matching the body). Added the source Google Doc link and a "Last synced" date to the Spanish section. Split out language-agnostic content into a new "Translation Style (All Languages)" subsection under Conventions (terminology priority, plain vocabulary, non-literal clarity, length, neutral error tone, sentence-case capitalization, classifying ambiguous UI text, placeholder-text categorization) so it's not scoped to Spanish only. Closed a gap in Spanish verb-mood rules for tooltips/placeholders/progress indicators/status-bar labels (gerund for in-progress, past participle for current-state, infinitive as the default fallback), with Spanish examples. Reworded the "Favor de + infinitive" guidance from "non-standard" to a regional-preference note, since it's a well-established Mexican/Latin American variant the team simply isn't adopting. Added a "Flag Unclear or Non-Standard English Source Text" step to the Localization Pattern. Documented `getLocalizeKeyForPhysicalKey`/`NameablePhysicalKey` (not yet merged, see [#2590](https://github.com/paranext/paranext-core/pull/2590)) and the per-language policy for translating vs. preserving physical key names. Moved "Revising an Existing Localization Decision" under "Existing Strings Are Immutable" as a named, meaning-preservation-scoped exception (`Exception: Fixing Errors or Applying a Revised Style Rule`), and clarified the sync direction (Google Doc first, then this guide, then shipped strings). Fixed the `formatReplacementStringToArray` example's placeholder count to match its cited reference implementation and added the missing `.map`/`Fragment` key-wrapping it also uses. Documented a real correctness defect in the `interleavePlaceholders` duplicate helper (its `\w+` regex silently drops hyphenated placeholder names) and filed [PT-4269](https://paratextstudio.atlassian.net/browse/PT-4269) to track migrating it to the shared utility. |
 | 1.5.0   | 2026-07-27 | Added "Embedding JSX in Localized Text with formatReplacementStringToArray" section (mid-sentence JSX interpolation, e.g. links/`Kbd` elements, via the existing `formatReplacementStringToArray` utility — was previously undocumented and had already been reimplemented once as a local helper; also notes to use the shadcn `Kbd`/`KbdGroup` components and, once merged, `getLocalizeKeyForPhysicalKey` for key names rather than hardcoding them). Added "Spanish (es) Localization Decisions" section distilled from the team's "Localization decisions - Paratext 10 Studio" Google Doc (Spanish tab): regional-variant/priority guidance, formal `usted` register, error-message templates, capitalization rules, and verb-mood rules (infinitive for controls, conjugated imperative for messages/alerts). French tab exists but is not yet authoritative, so not captured. |
 | 1.4.0   | 2026-06-17 | Added "Localizing Shared Library Components (`lib/platform-bible-react/`)" section: process-agnostic library components must not call `useLocalizedStrings`/PAPI; they expose a frozen `STRING_KEYS` tuple + a `Partial<Record<…>>` type + an optional `localizedStrings?` prop with English-fallback reads, and the consumer resolves and passes strings down. Named the hardcoded-string enforcer as the real ESLint rule `paranext/no-hardcoded-jsx-strings`. Added a "one key-prefix convention per feature namespace" subsection under Conventions › Key Format (prefer camelCase feature-prefix with `_` subsegments; don't mix camelCase and snake_case variants of the same prefix). Grounded against `book-chapter-control`, `book-selector`, and `marker-menu`. |
 | 1.3.0   | 2026-04-29 | Added "Text Direction (RTL/LTR)" section codifying per-content direction via `useProjectSetting('platform.textDirection', defaultTextDirection)`. Forbids hardcoded language-code equality checks (`x === 'he' \|\| x === 'ar'`). References `platform-scripture-editor.web-view.tsx` (the `defaultTextDirection` constant and the `OHEBGRK` branch) as the canonical pattern. Clarifies separation between global UI direction (`readDirection()`) and per-content direction. Sourced from markers-checklist PR feedback (RTL-hardcoding comment). |

--- a/.context/standards/Localization-Guide.md
+++ b/.context/standards/Localization-Guide.md
@@ -4,7 +4,7 @@ description: Mandatory localization patterns for all user-facing text in paranex
 version: 1.5.0
 status: active
 created: 2026-03-04
-last_updated: 2026-07-16
+last_updated: 2026-07-27
 toc: true
 ---
 
@@ -386,7 +386,7 @@ In `localizedStrings.json`:
 
 ## Embedding JSX in Localized Text with formatReplacementStringToArray
 
-`formatReplacementString` only produces a plain string, so it can't carry a React element (a link, an icon, a `<kbd>`) embedded mid-sentence. For that case, use its sibling `formatReplacementStringToArray` from `platform-bible-utils`: it tokenizes the same `{placeholder}` syntax but returns an array of strings interleaved with whatever replacer values you pass — including JSX — which you render directly as children.
+`formatReplacementString` only produces a plain string, so it can't carry a React element (a link, an icon, a `Kbd`) embedded mid-sentence. For that case, use its sibling `formatReplacementStringToArray` from `platform-bible-utils`: it tokenizes the same `{placeholder}` syntax but returns an array of strings interleaved with whatever replacer values you pass — including JSX — which you render directly as children.
 
 ```tsx
 import { formatReplacementStringToArray } from 'platform-bible-utils';
@@ -405,7 +405,9 @@ import { formatReplacementStringToArray } from 'platform-bible-utils';
 </p>
 ```
 
-**Why this matters:** embedding a non-text element (a `<kbd>`, an icon, a link) by string-concatenating it before or after a localized string — e.g. `<kbd>Backspace</kbd> {message}` — bakes in an assumption about word order and spacing that not every language shares, and forces the element into a fixed position the string can't control. Letting the *localized string itself* place the `{placeholder}` fixes both problems: each translation decides where the embedded element goes, and any surrounding punctuation/spacing lives in the translated string, not in code.
+**Why this matters:** embedding a non-text element (a `Kbd`, an icon, a link) by string-concatenating it before or after a localized string — e.g. `<Kbd>{key}</Kbd> {message}` — bakes in an assumption about word order and spacing that not every language shares, and forces the element into a fixed position the string can't control. Letting the *localized string itself* place the `{placeholder}` fixes both problems: each translation decides where the embedded element goes, and any surrounding punctuation/spacing lives in the translated string, not in code.
+
+For key names specifically, use the `Kbd`/`KbdGroup` components exported from `platform-bible-react` rather than a raw `<kbd>` element, per the [Tooltips guideline](../../lib/platform-bible-react/src/stories/guidelines/tooltips.mdx). And don't hardcode a key's display word (`"Backspace"`, `"Delete"`) — once merged, `getLocalizeKeyForPhysicalKey` (`platform-bible-utils/keyboard-util.ts`, added in [#2590](https://github.com/paranext/paranext-core/pull/2590)) resolves a `NameablePhysicalKey` to its localized key, so the key label goes through the same localization pipeline as everything else instead of being hardcoded per caller.
 
 **Reference implementation:** `src/renderer/components/dialogs/about-dialog.component.tsx` (the `%about_db_ip_attribution_format%` string interpolates two `<a>` links this way).
 
@@ -530,7 +532,7 @@ Alternative design: use a dedicated `xxxKey` field (e.g. `ErrorMessageKey`) alon
 
 | Version | Date       | Change          |
 | ------- | ---------- | --------------- |
-| 1.5.0   | 2026-07-16 | Added "Embedding JSX in Localized Text with formatReplacementStringToArray" section (mid-sentence JSX interpolation, e.g. links/kbd elements, via the existing `formatReplacementStringToArray` utility — was previously undocumented and had already been reimplemented once as a local helper). Added "Spanish (es) Localization Decisions" section distilled from the team's "Localization decisions - Paratext 10 Studio" Google Doc (Spanish tab): regional-variant/priority guidance, formal `usted` register, error-message templates, capitalization rules, and verb-mood rules (infinitive for controls, conjugated imperative for messages/alerts). French tab exists but is not yet authoritative, so not captured. |
+| 1.5.0   | 2026-07-27 | Added "Embedding JSX in Localized Text with formatReplacementStringToArray" section (mid-sentence JSX interpolation, e.g. links/`Kbd` elements, via the existing `formatReplacementStringToArray` utility — was previously undocumented and had already been reimplemented once as a local helper; also notes to use the shadcn `Kbd`/`KbdGroup` components and, once merged, `getLocalizeKeyForPhysicalKey` for key names rather than hardcoding them). Added "Spanish (es) Localization Decisions" section distilled from the team's "Localization decisions - Paratext 10 Studio" Google Doc (Spanish tab): regional-variant/priority guidance, formal `usted` register, error-message templates, capitalization rules, and verb-mood rules (infinitive for controls, conjugated imperative for messages/alerts). French tab exists but is not yet authoritative, so not captured. |
 | 1.4.0   | 2026-06-17 | Added "Localizing Shared Library Components (`lib/platform-bible-react/`)" section: process-agnostic library components must not call `useLocalizedStrings`/PAPI; they expose a frozen `STRING_KEYS` tuple + a `Partial<Record<…>>` type + an optional `localizedStrings?` prop with English-fallback reads, and the consumer resolves and passes strings down. Named the hardcoded-string enforcer as the real ESLint rule `paranext/no-hardcoded-jsx-strings`. Added a "one key-prefix convention per feature namespace" subsection under Conventions › Key Format (prefer camelCase feature-prefix with `_` subsegments; don't mix camelCase and snake_case variants of the same prefix). Grounded against `book-chapter-control`, `book-selector`, and `marker-menu`. |
 | 1.3.0   | 2026-04-29 | Added "Text Direction (RTL/LTR)" section codifying per-content direction via `useProjectSetting('platform.textDirection', defaultTextDirection)`. Forbids hardcoded language-code equality checks (`x === 'he' \|\| x === 'ar'`). References `platform-scripture-editor.web-view.tsx` (the `defaultTextDirection` constant and the `OHEBGRK` branch) as the canonical pattern. Clarifies separation between global UI direction (`readDirection()`) and per-content direction. Sourced from markers-checklist PR feedback (RTL-hardcoding comment). |
 | 1.2.0   | 2026-04-21 | Added `toc: true` + machine-readable TOC block now that the guide has grown past the stub-patterns.md threshold. No content changes. |


### PR DESCRIPTION
## Summary

Distills the team's "Localization decisions - Paratext 10 Studio" Google Doc (Spanish tab) into a new "Spanish (es) Localization Decisions" section in `Localization-Guide.md`, so the decisions (register/formality, verb mood, error-message templates, capitalization, regional-variant targeting) are checked into the repo and available to the whole team — including as context for AI-assisted translation — instead of living only in a Google Doc. The French tab isn't mature enough yet to include.

Also documents `formatReplacementStringToArray` (embedding JSX like links/`<kbd>` mid-sentence in localized strings), which existed but was undocumented and had already been silently reimplemented once elsewhere.

### Why review this

Not part of the current epic. This closes a gap where binding localization decisions existed only in a Google Doc the team (and AI assistants) had no durable access to — it's docs-only and low risk.

## Changes

- Add "Spanish (es) Localization Decisions" section to `.context/standards/Localization-Guide.md`
- Add "Embedding JSX in Localized Text with formatReplacementStringToArray" section
- Bump guide to v1.5.0 with changelog entry

## AI Involvement

Both new sections were drafted by Claude Code from the team's Google Doc content and existing codebase patterns (`about-dialog.component.tsx`, `marble-guide.component.tsx`), then reviewed by the author.

## Testing

- [x] Docs-only change; no build/test impact

## Risk Level

Low - documentation only, no code changes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2616)
<!-- Reviewable:end -->
