### PR TITLE
PT-4299: heal project picker when layering PDPF registers after grace window

### DIFF
--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -2,7 +2,11 @@ import { renderHook, act } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 import { EVENT_NAME_ON_DID_UPDATE_WEB_VIEW } from '@shared/services/web-view.service-model';
-import { useProjectPickerData, type ProjectPickerData } from './use-project-picker-data.hook';
+import {
+  useProjectPickerData,
+  type ProjectPickerData,
+  MAX_METADATA_FETCH_RETRIES,
+} from './use-project-picker-data.hook';
 
 // --- Mocks ---
 
@@ -629,6 +633,88 @@ describe('useProjectPickerData', () => {
     expect(projectLookupService.getMetadataForAllProjects).toHaveBeenCalledTimes(2);
     expect(result.current.allProjects).toHaveLength(1);
     expect(result.current.allProjects[0].id).toBe('p1');
+  });
+
+  it('heals allProjects after a timed-out metadata fetch once the retry resolves (PT-4299 timeout recovery)', async () => {
+    // Reproduces the scenario observed in console logs where getAvailableProjects times out
+    // (JSON-RPC 30-second timeout) because the extension host is overloaded at startup. The
+    // late response is discarded ("Ignoring subsequent resolution"), leaving the picker empty.
+    // After METADATA_FETCH_RETRY_DELAY_MS the hook must issue a fresh fetch — by which time the
+    // extension host has drained its queue and responds quickly.
+    vi.useFakeTimers();
+    try {
+      const { projectLookupService } = await importMocks();
+      vi.mocked(projectLookupService.getMetadataForAllProjects)
+        .mockRejectedValueOnce(new Error('JSON-RPC Request timed out'))
+        .mockResolvedValue(
+          metadataList([
+            { id: 'p1', fullName: 'Full p1', name: 'Short p1', isEditable: true },
+          ]) as never,
+        );
+
+      const { result } = renderHook(() => useProjectPickerData());
+      await settle(result);
+
+      // First fetch timed out — picker is empty
+      expect(result.current.allProjects).toHaveLength(0);
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(1);
+
+      // Advance past the retry delay
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      await settle(result);
+
+      // Retry resolved — picker healed
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(2);
+      expect(result.current.allProjects).toHaveLength(1);
+      expect(result.current.allProjects[0].id).toBe('p1');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops retrying metadata after MAX_METADATA_FETCH_RETRIES consecutive failures', async () => {
+    // Guards against an infinite retry loop when the extension host is permanently unavailable.
+    // After MAX_METADATA_FETCH_RETRIES failures the hook must stop scheduling retries.
+    vi.useFakeTimers();
+    try {
+      const { projectLookupService } = await importMocks();
+      vi.mocked(projectLookupService.getMetadataForAllProjects).mockRejectedValue(
+        new Error('Persistent failure'),
+      );
+
+      const { result } = renderHook(() => useProjectPickerData());
+      await settle(result);
+
+      // Drive through all allowed retries
+      for (let i = 0; i < MAX_METADATA_FETCH_RETRIES; i += 1) {
+        // Each iteration must be sequential: advance the timer first, then drain the resulting
+        // async work before the next retry cycle starts.
+        // eslint-disable-next-line no-await-in-loop
+        await act(async () => {
+          await vi.runAllTimersAsync();
+        });
+        // Same reason as above: sequential drain after each timer advance.
+        // eslint-disable-next-line no-await-in-loop
+        await settle(result);
+      }
+
+      const callCountAfterExhaustion = vi.mocked(projectLookupService.getMetadataForAllProjects)
+        .mock.calls.length;
+      expect(callCountAfterExhaustion).toBe(1 + MAX_METADATA_FETCH_RETRIES);
+
+      // One more timer advance must NOT trigger an additional fetch
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      await settle(result);
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(
+        callCountAfterExhaustion,
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('does not re-fetch metadata when object:onDidCreateNetworkObject fires for a non-PDPF network object', async () => {

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -589,8 +589,8 @@ describe('useProjectPickerData', () => {
     expect(projectLookupService.getMetadataForAllProjects).toHaveBeenCalledTimes(2);
   });
 
-  it('re-fetches metadata when a PDP factory registers via object:onDidCreateNetworkObject (PT-4299 healing)', async () => {
-    // Reproduces the PT-4299 race: the 30-second startup grace window in
+  it('re-fetches metadata when a PDP factory registers via object:onDidCreateNetworkObject (healing)', async () => {
+    // Reproduces the race: the 30-second startup grace window in
     // internalGetMetadataWithRetries expires before the USJ-providing layering PDPF
     // (Scripture Extender) registers. The initial metadata fetch returns empty because no
     // factory providing platformScripture.USJ_Chapter has registered yet. When the PDPF
@@ -645,7 +645,7 @@ describe('useProjectPickerData', () => {
     }
   });
 
-  it('heals allProjects after a timed-out metadata fetch once the retry resolves (PT-4299 timeout recovery)', async () => {
+  it('heals allProjects after a timed-out metadata fetch once the retry resolves (timeout recovery)', async () => {
     // Reproduces the scenario observed in console logs where getAvailableProjects times out
     // (JSON-RPC 30-second timeout) because the extension host is overloaded at startup. The
     // late response is discarded ("Ignoring subsequent resolution"), leaving the picker empty.
@@ -759,7 +759,7 @@ describe('useProjectPickerData', () => {
     expect(projectLookupService.getMetadataForAllProjects).toHaveBeenCalledTimes(1);
   });
 
-  it('cancels the pending retry timer when a concurrent refresh heals the list (PT-4299 spurious Fetch C)', async () => {
+  it('cancels the pending retry timer when a concurrent refresh heals the list (spurious Fetch C)', async () => {
     // Reproduces the race where Fetch A fails (isRetryPending=true, 5-second timer scheduled),
     // then an external PDPF registration fires while the timer is still running. Fetch B (triggered
     // by the PDPF) succeeds and heals the list. The timer must be cancelled so it does not fire a
@@ -815,7 +815,7 @@ describe('useProjectPickerData', () => {
     }
   });
 
-  it('stale-generation success does not reset the retry budget for a newer failing generation (PT-4299 cap integrity)', async () => {
+  it('stale-generation success does not reset the retry budget for a newer failing generation (cap integrity)', async () => {
     // Reproduces the race where a slow in-flight Gen A promise (up to 30 s in the service's
     // startup retry loop) resolves after a newer Gen B+ has already exhausted part of its retry
     // budget. Gen A's unguarded .then() must NOT reset fetchRetryCountRef.current, or subsequent
@@ -899,7 +899,7 @@ describe('useProjectPickerData', () => {
     }
   });
 
-  it('multiple rapid PDPF registrations trigger only one getMetadataForAllProjects fan-out (PT-4299 debounce)', async () => {
+  it('multiple rapid PDPF registrations trigger only one getMetadataForAllProjects fan-out (debounce)', async () => {
     // When PDPFs re-register after extension reload they arrive as separate WebSocket messages,
     // so React cannot batch the resulting refreshMetadata() calls. Each would normally fan out
     // getMetadataForAllProjects to every registered PDPF; the fix debounces the PDPF-registration

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -597,42 +597,52 @@ describe('useProjectPickerData', () => {
     // later registers, the network object service emits object:onDidCreateNetworkObject.
     // The hook must subscribe to that event and refresh when the new object is a pdpFactory,
     // so the project list heals without waiting for an unrelated extension reload or
-    // project-list change event.
-    const { getNetworkEvent, projectLookupService } = await importMocks();
-    let pdpfRegistrationCallback: ((details: { objectType: string }) => void) | undefined;
-    vi.mocked(getNetworkEvent).mockImplementation(
-      (eventName: string) =>
-        vi.fn((cb: (details: { objectType: string }) => void) => {
-          if (eventName === 'object:onDidCreateNetworkObject') pdpfRegistrationCallback = cb;
-          return vi.fn();
-        }) as never,
-    );
-
-    // First fetch: grace window expired, USJ-providing layering PDPF not yet registered.
-    vi.mocked(projectLookupService.getMetadataForAllProjects)
-      .mockResolvedValueOnce([] as never)
-      // Second fetch after PDPF registers: project list now available.
-      .mockResolvedValue(
-        metadataList([
-          { id: 'p1', fullName: 'Full p1', name: 'Short p1', isEditable: true },
-        ]) as never,
+    // project-list change event. The refresh fires after PDPF_REGISTRATION_DEBOUNCE_MS so
+    // that a burst of registrations collapses to a single fan-out; fake timers advance past it.
+    vi.useFakeTimers();
+    try {
+      const { getNetworkEvent, projectLookupService } = await importMocks();
+      let pdpfRegistrationCallback: ((details: { objectType: string }) => void) | undefined;
+      vi.mocked(getNetworkEvent).mockImplementation(
+        (eventName: string) =>
+          vi.fn((cb: (details: { objectType: string }) => void) => {
+            if (eventName === 'object:onDidCreateNetworkObject') pdpfRegistrationCallback = cb;
+            return vi.fn();
+          }) as never,
       );
 
-    const { result } = renderHook(() => useProjectPickerData());
-    await settle(result);
-    // Initial state: empty because the layering PDPF providing USJ_Chapter has not
-    // registered yet (grace window already expired).
-    expect(result.current.allProjects).toHaveLength(0);
+      // First fetch: grace window expired, USJ-providing layering PDPF not yet registered.
+      vi.mocked(projectLookupService.getMetadataForAllProjects)
+        .mockResolvedValueOnce([] as never)
+        // Second fetch after PDPF registers: project list now available.
+        .mockResolvedValue(
+          metadataList([
+            { id: 'p1', fullName: 'Full p1', name: 'Short p1', isEditable: true },
+          ]) as never,
+        );
 
-    // The USJ-providing layering PDPF registers after the grace window.
-    expect(pdpfRegistrationCallback).toBeDefined();
-    act(() => pdpfRegistrationCallback!({ objectType: 'pdpFactory' }));
+      const { result } = renderHook(() => useProjectPickerData());
+      await settle(result);
+      // Initial state: empty because the layering PDPF providing USJ_Chapter has not
+      // registered yet (grace window already expired).
+      expect(result.current.allProjects).toHaveLength(0);
 
-    await settle(result);
-    // The hook must detect the PDPF registration and re-fetch metadata so the list heals.
-    expect(projectLookupService.getMetadataForAllProjects).toHaveBeenCalledTimes(2);
-    expect(result.current.allProjects).toHaveLength(1);
-    expect(result.current.allProjects[0].id).toBe('p1');
+      // The USJ-providing layering PDPF registers after the grace window.
+      expect(pdpfRegistrationCallback).toBeDefined();
+      act(() => pdpfRegistrationCallback!({ objectType: 'pdpFactory' }));
+
+      // Advance past the debounce delay so the buffered refresh fires.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(250);
+      });
+      await settle(result);
+      // The hook must detect the PDPF registration and re-fetch metadata so the list heals.
+      expect(projectLookupService.getMetadataForAllProjects).toHaveBeenCalledTimes(2);
+      expect(result.current.allProjects).toHaveLength(1);
+      expect(result.current.allProjects[0].id).toBe('p1');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('heals allProjects after a timed-out metadata fetch once the retry resolves (PT-4299 timeout recovery)', async () => {
@@ -747,6 +757,191 @@ describe('useProjectPickerData', () => {
 
     // Must NOT re-fetch: only PDPF registrations should invalidate the metadata cache.
     expect(projectLookupService.getMetadataForAllProjects).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the pending retry timer when a concurrent refresh heals the list (PT-4299 spurious Fetch C)', async () => {
+    // Reproduces the race where Fetch A fails (isRetryPending=true, 5-second timer scheduled),
+    // then an external PDPF registration fires while the timer is still running. Fetch B (triggered
+    // by the PDPF) succeeds and heals the list. The timer must be cancelled so it does not fire a
+    // spurious Fetch C after healing — the fix is setIsRetryPending(false) in the success path of
+    // getAllMetadata, which triggers the useEffect cleanup that calls clearTimeout.
+    vi.useFakeTimers();
+    try {
+      const { projectLookupService, getNetworkEvent } = await importMocks();
+      let pdpfCallback: ((d: { objectType: string }) => void) | undefined;
+      vi.mocked(getNetworkEvent).mockImplementation(
+        (eventName: string) =>
+          vi.fn((cb: (d: { objectType: string }) => void) => {
+            if (eventName === 'object:onDidCreateNetworkObject') pdpfCallback = cb;
+            return vi.fn();
+          }) as never,
+      );
+      vi.mocked(projectLookupService.getMetadataForAllProjects)
+        .mockRejectedValueOnce(new Error('JSON-RPC timed out')) // Fetch A fails
+        .mockResolvedValue(
+          metadataList([
+            { id: 'p1', fullName: 'Full p1', name: 'Short p1', isEditable: true },
+          ]) as never,
+        ); // Fetch B+ succeeds
+
+      const { result } = renderHook(() => useProjectPickerData());
+      await settle(result);
+      // Fetch A failed; isRetryPending=true, 5-second timer scheduled.
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(1);
+      expect(result.current.allProjects).toHaveLength(0);
+
+      // PDPF registers → schedules debounced Fetch B. Advance past the debounce delay to fire it.
+      expect(pdpfCallback).toBeDefined();
+      act(() => pdpfCallback!({ objectType: 'pdpFactory' }));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(250);
+      });
+      await settle(result);
+      // Fetch B healed the project list.
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(2);
+      expect(result.current.allProjects).toHaveLength(1);
+
+      // Advance remaining timers (retry timer from Fetch A should have been cancelled by Fetch B's
+      // success path setting isRetryPending=false).
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      await settle(result);
+
+      // No spurious Fetch C: the list healed in Fetch B; no unnecessary fan-out after.
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stale-generation success does not reset the retry budget for a newer failing generation (PT-4299 cap integrity)', async () => {
+    // Reproduces the race where a slow in-flight Gen A promise (up to 30 s in the service's
+    // startup retry loop) resolves after a newer Gen B+ has already exhausted part of its retry
+    // budget. Gen A's unguarded .then() must NOT reset fetchRetryCountRef.current, or subsequent
+    // Gen B+ failures get a fresh budget and can exceed MAX_METADATA_FETCH_RETRIES total retries.
+    vi.useFakeTimers();
+    try {
+      const { projectLookupService, getNetworkEvent } = await importMocks();
+
+      // Gen A: manually controlled — we will resolve it late, after Gen B+ has been retrying.
+      let resolveGenA: (v: never) => void = () => {};
+      const genAPromise = new Promise<never>((res) => {
+        resolveGenA = res;
+      });
+
+      let pdpfCallback: ((d: { objectType: string }) => void) | undefined;
+      vi.mocked(getNetworkEvent).mockImplementation(
+        (eventName: string) =>
+          vi.fn((cb: (d: { objectType: string }) => void) => {
+            if (eventName === 'object:onDidCreateNetworkObject') pdpfCallback = cb;
+            return vi.fn();
+          }) as never,
+      );
+
+      vi.mocked(projectLookupService.getMetadataForAllProjects)
+        .mockReturnValueOnce(genAPromise as never) // Gen A: in-flight, will resolve late
+        .mockRejectedValue(new Error('Timeout')); // All subsequent generations fail
+
+      const { result } = renderHook(() => useProjectPickerData());
+      await settle(result);
+      // Gen A is in-flight.
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(1);
+
+      // PDPF registers → schedules debounced Gen B. Advance past the debounce delay to fire it.
+      expect(pdpfCallback).toBeDefined();
+      act(() => pdpfCallback!({ objectType: 'pdpFactory' }));
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(250);
+      });
+      await settle(result);
+      // Gen B started and failed; isRetryPending=true.
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(2);
+
+      // Advance through 2 retries (Gen C, Gen D) so the counter is partway through the budget.
+      for (let i = 0; i < 2; i += 1) {
+        // Sequential: advance timer then drain before the next retry cycle.
+        // eslint-disable-next-line no-await-in-loop
+        await act(async () => {
+          await vi.runAllTimersAsync();
+        });
+        // eslint-disable-next-line no-await-in-loop
+        await settle(result);
+      }
+      // Calls so far: GenA(1) + GenB(1) + retry1(1) + retry2(1) = 4
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(4);
+
+      // Gen A resolves late (stale). Without the generation guard, its .then() resets the counter
+      // to 0, allowing more than MAX_METADATA_FETCH_RETRIES total retries. With the fix, the guard
+      // sees metadataFetchRef.current !== entry-A and skips the reset.
+      await act(async () => {
+        resolveGenA([] as never);
+      });
+      await settle(result);
+
+      // Advance through what should be the LAST retry (retry 3 = Gen E).
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      await settle(result);
+      // Calls: GenA + GenB + retry1 + retry2 + retry3(last) = 5
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(5);
+
+      // Budget exhausted — no more retries regardless of timer advances.
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      await settle(result);
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(5);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('multiple rapid PDPF registrations trigger only one getMetadataForAllProjects fan-out (PT-4299 debounce)', async () => {
+    // When PDPFs re-register after extension reload they arrive as separate WebSocket messages,
+    // so React cannot batch the resulting refreshMetadata() calls. Each would normally fan out
+    // getMetadataForAllProjects to every registered PDPF; the fix debounces the PDPF-registration
+    // listener so a burst collapses to a single re-fetch.
+    vi.useFakeTimers();
+    try {
+      const { projectLookupService, getNetworkEvent } = await importMocks();
+      let pdpfCallback: ((d: { objectType: string }) => void) | undefined;
+      vi.mocked(getNetworkEvent).mockImplementation(
+        (eventName: string) =>
+          vi.fn((cb: (d: { objectType: string }) => void) => {
+            if (eventName === 'object:onDidCreateNetworkObject') pdpfCallback = cb;
+            return vi.fn();
+          }) as never,
+      );
+      vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue([] as never);
+
+      const { result } = renderHook(() => useProjectPickerData());
+      await settle(result);
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(1);
+
+      // Fire 3 PDPF registrations synchronously within one act. Each callback cancels the
+      // previous debounce timer and schedules a new one; only the last timer survives.
+      // Using a single act ensures no timer fires between callbacks (async act can advance
+      // fake timers between awaits, which would defeat the debounce).
+      expect(pdpfCallback).toBeDefined();
+      act(() => {
+        pdpfCallback!({ objectType: 'pdpFactory' });
+        pdpfCallback!({ objectType: 'pdpFactory' });
+        pdpfCallback!({ objectType: 'pdpFactory' });
+      });
+
+      // Advance timers to fire the single surviving debounced refresh.
+      await act(async () => {
+        await vi.runAllTimersAsync();
+      });
+      await settle(result);
+
+      // With debouncing: initial(1) + debounced-refresh(1) = 2 total calls, not 4.
+      expect(vi.mocked(projectLookupService.getMetadataForAllProjects)).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });
 /* eslint-enable no-type-assertion/no-type-assertion */

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -826,8 +826,8 @@ describe('useProjectPickerData', () => {
 
       // Gen A: manually controlled — we will resolve it late, after Gen B+ has been retrying.
       let resolveGenA: (v: never) => void = () => {};
-      const genAPromise = new Promise<never>((res) => {
-        resolveGenA = res;
+      const genAPromise = new Promise<never>((resolve) => {
+        resolveGenA = resolve;
       });
 
       let pdpfCallback: ((d: { objectType: string }) => void) | undefined;
@@ -865,6 +865,7 @@ describe('useProjectPickerData', () => {
         await act(async () => {
           await vi.runAllTimersAsync();
         });
+        // Same reason as above: sequential drain after each timer advance.
         // eslint-disable-next-line no-await-in-loop
         await settle(result);
       }

--- a/src/renderer/hooks/use-project-picker-data.hook.test.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.test.ts
@@ -584,5 +584,83 @@ describe('useProjectPickerData', () => {
 
     expect(projectLookupService.getMetadataForAllProjects).toHaveBeenCalledTimes(2);
   });
+
+  it('re-fetches metadata when a PDP factory registers via object:onDidCreateNetworkObject (PT-4299 healing)', async () => {
+    // Reproduces the PT-4299 race: the 30-second startup grace window in
+    // internalGetMetadataWithRetries expires before the USJ-providing layering PDPF
+    // (Scripture Extender) registers. The initial metadata fetch returns empty because no
+    // factory providing platformScripture.USJ_Chapter has registered yet. When the PDPF
+    // later registers, the network object service emits object:onDidCreateNetworkObject.
+    // The hook must subscribe to that event and refresh when the new object is a pdpFactory,
+    // so the project list heals without waiting for an unrelated extension reload or
+    // project-list change event.
+    const { getNetworkEvent, projectLookupService } = await importMocks();
+    let pdpfRegistrationCallback: ((details: { objectType: string }) => void) | undefined;
+    vi.mocked(getNetworkEvent).mockImplementation(
+      (eventName: string) =>
+        vi.fn((cb: (details: { objectType: string }) => void) => {
+          if (eventName === 'object:onDidCreateNetworkObject') pdpfRegistrationCallback = cb;
+          return vi.fn();
+        }) as never,
+    );
+
+    // First fetch: grace window expired, USJ-providing layering PDPF not yet registered.
+    vi.mocked(projectLookupService.getMetadataForAllProjects)
+      .mockResolvedValueOnce([] as never)
+      // Second fetch after PDPF registers: project list now available.
+      .mockResolvedValue(
+        metadataList([
+          { id: 'p1', fullName: 'Full p1', name: 'Short p1', isEditable: true },
+        ]) as never,
+      );
+
+    const { result } = renderHook(() => useProjectPickerData());
+    await settle(result);
+    // Initial state: empty because the layering PDPF providing USJ_Chapter has not
+    // registered yet (grace window already expired).
+    expect(result.current.allProjects).toHaveLength(0);
+
+    // The USJ-providing layering PDPF registers after the grace window.
+    expect(pdpfRegistrationCallback).toBeDefined();
+    act(() => pdpfRegistrationCallback!({ objectType: 'pdpFactory' }));
+
+    await settle(result);
+    // The hook must detect the PDPF registration and re-fetch metadata so the list heals.
+    expect(projectLookupService.getMetadataForAllProjects).toHaveBeenCalledTimes(2);
+    expect(result.current.allProjects).toHaveLength(1);
+    expect(result.current.allProjects[0].id).toBe('p1');
+  });
+
+  it('does not re-fetch metadata when object:onDidCreateNetworkObject fires for a non-PDPF network object', async () => {
+    // Only PDP factory registrations should heal the project list. Registrations of other
+    // network object types (PDPs, services, etc.) must not trigger an unnecessary metadata
+    // fan-out, since those fan-outs are expensive (one PAPI round-trip per registered PDPF).
+    const { getNetworkEvent, projectLookupService } = await importMocks();
+    let networkObjectCallback: ((details: { objectType: string }) => void) | undefined;
+    vi.mocked(getNetworkEvent).mockImplementation(
+      (eventName: string) =>
+        vi.fn((cb: (details: { objectType: string }) => void) => {
+          if (eventName === 'object:onDidCreateNetworkObject') networkObjectCallback = cb;
+          return vi.fn();
+        }) as never,
+    );
+    vi.mocked(projectLookupService.getMetadataForAllProjects).mockResolvedValue(
+      metadataList([
+        { id: 'p1', fullName: 'Full p1', name: 'Short p1', isEditable: true },
+      ]) as never,
+    );
+
+    const { result } = renderHook(() => useProjectPickerData());
+    await settle(result);
+    expect(projectLookupService.getMetadataForAllProjects).toHaveBeenCalledTimes(1);
+
+    expect(networkObjectCallback).toBeDefined();
+    // A non-PDPF network object registers (e.g. a data provider or a service).
+    act(() => networkObjectCallback!({ objectType: 'networkObject' }));
+    await settle(result);
+
+    // Must NOT re-fetch: only PDPF registrations should invalidate the metadata cache.
+    expect(projectLookupService.getMetadataForAllProjects).toHaveBeenCalledTimes(1);
+  });
 });
 /* eslint-enable no-type-assertion/no-type-assertion */

--- a/src/renderer/hooks/use-project-picker-data.hook.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.ts
@@ -38,6 +38,8 @@ const METADATA_FETCH_RETRY_DELAY_MS = 5 * 1000;
  * reload or a PDPF registration).
  */
 export const MAX_METADATA_FETCH_RETRIES = 3;
+/** Debounce window that collapses rapid-fire PDPF registrations into a single metadata fan-out. */
+const PDPF_REGISTRATION_DEBOUNCE_MS = 200;
 
 const PICKER_PROJECT_INTERFACE = 'platformScripture.USJ_Chapter';
 const PICKER_METADATA_FILTER: ProjectMetadataFilterOptions = {
@@ -146,13 +148,21 @@ export function useProjectPickerData(): ProjectPickerData {
     () => getNetworkEvent('object:onDidCreateNetworkObject'),
     [],
   );
+  // Debounce to collapse N rapid-fire PDPF registrations (e.g. after extension reload) into a
+  // single getMetadataForAllProjects fan-out. Without debouncing, each registration arrives as a
+  // separate WebSocket message that React 18 cannot batch, producing N wasted fan-outs.
+  const pdpfRefreshTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const onPdpFactoryRegistered = useCallback(
     ({ objectType }: NetworkObjectDetails) => {
-      if (objectType === PDP_FACTORY_OBJECT_TYPE) refreshMetadata();
+      if (objectType !== PDP_FACTORY_OBJECT_TYPE) return;
+      clearTimeout(pdpfRefreshTimerRef.current);
+      pdpfRefreshTimerRef.current = setTimeout(refreshMetadata, PDPF_REGISTRATION_DEBOUNCE_MS);
     },
     [refreshMetadata],
   );
   useEvent(onDidCreateNetworkObject, onPdpFactoryRegistered);
+  // Cancel any pending debounced refresh on unmount to prevent state updates after teardown.
+  useEffect(() => () => clearTimeout(pdpfRefreshTimerRef.current), []);
   // After a failed metadata fetch, wait METADATA_FETCH_RETRY_DELAY_MS before trying again.
   // The timer is cancelled if the hook unmounts before it fires, preventing state updates on an
   // unmounted component and avoiding spurious fan-outs when the user closes the picker quickly.
@@ -193,23 +203,39 @@ export function useProjectPickerData(): ProjectPickerData {
       counter: metadataRefreshCounter,
       promise: projectLookupService.getMetadataForAllProjects(PICKER_METADATA_FILTER),
     };
-    // On success: reset the retry counter so a future transient failure gets its own retry budget.
-    // On failure (caught at the end of the chain): invalidate this generation's cache entry (so the
-    // next getAllMetadata call issues a fresh fetch rather than awaiting the poisoned promise), then
-    // schedule a retry if the budget allows.
+    // Attach success and failure handlers as the two arguments of .then() rather than as a
+    // .then().catch() chain. In the chained form, the .catch() sees both fetch rejections AND
+    // exceptions thrown by the success handler — silently mis-routing a future handler bug as a
+    // fetch failure. The two-argument form keeps the handlers independent: an exception in
+    // onFulfilled does not reach onRejected. The trailing .catch(() => undefined) satisfies the
+    // ESLint promise/catch-or-return rule (the plugin does not recognise the two-argument form
+    // as sufficient) and catches any exception from either handler; neither handler can throw in
+    // practice (ref reads + setState), so this is purely a safety net.
     entry.promise
-      .then(() => {
-        fetchRetryCountRef.current = 0;
-        return undefined;
-      })
-      .catch(() => {
-        if (metadataFetchRef.current === entry) {
-          metadataFetchRef.current = undefined;
-          if (fetchRetryCountRef.current < MAX_METADATA_FETCH_RETRIES) {
-            setIsRetryPending(true);
+      .then(
+        () => {
+          // Guard: only reset retry state for the current generation so a stale in-flight promise
+          // that resolves late cannot corrupt the retry budget or spuriously cancel the timer of
+          // the generation currently in the cache.
+          if (metadataFetchRef.current === entry) {
+            fetchRetryCountRef.current = 0;
+            // Cancels any pending retry timer: setIsRetryPending(false) triggers the useEffect
+            // cleanup (clearTimeout) so the timer does not fire a redundant fan-out after healing.
+            setIsRetryPending(false);
           }
-        }
-      });
+          return undefined;
+        },
+        () => {
+          if (metadataFetchRef.current === entry) {
+            metadataFetchRef.current = undefined;
+            if (fetchRetryCountRef.current < MAX_METADATA_FETCH_RETRIES) {
+              setIsRetryPending(true);
+            }
+          }
+          return undefined;
+        },
+      )
+      .catch(() => undefined);
     metadataFetchRef.current = entry;
     return entry.promise;
   }, [metadataRefreshCounter]);

--- a/src/renderer/hooks/use-project-picker-data.hook.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.ts
@@ -21,15 +21,6 @@ import { logger } from '@shared/services/logger.service';
 import { findFirstEditorWebViewDefinition } from '@shared/models/web-view.model';
 import { type ProjectItem } from '@renderer/components/projects/project-picker.component';
 
-/**
- * `projectInterface` a project must support to belong in the picker: it can be opened in the
- * scripture editor. This filter is applied service-side so the service's retry-until-non-empty
- * startup grace period keeps retrying until a factory that provides this interface has registered
- * (a bare unfiltered fetch settles as soon as any project - possibly a non-scripture one - appears,
- * before the layering PDPF that provides this interface registers). Published resources also carry
- * this interface via the Scripture Extender layering PDPF, so the current project and recent
- * projects (both always scripture or resource projects) resolve from the same filtered fetch.
- */
 /** How long to wait before retrying a failed metadata fetch. */
 const METADATA_FETCH_RETRY_DELAY_MS = 5 * 1000;
 /**
@@ -41,6 +32,15 @@ export const MAX_METADATA_FETCH_RETRIES = 3;
 /** Debounce window that collapses rapid-fire PDPF registrations into a single metadata fan-out. */
 const PDPF_REGISTRATION_DEBOUNCE_MS = 200;
 
+/**
+ * `projectInterface` a project must support to belong in the picker: it can be opened in the
+ * scripture editor. This filter is applied service-side so the service's retry-until-non-empty
+ * startup grace period keeps retrying until a factory that provides this interface has registered
+ * (a bare unfiltered fetch settles as soon as any project - possibly a non-scripture one - appears,
+ * before the layering PDPF that provides this interface registers). Published resources also carry
+ * this interface via the Scripture Extender layering PDPF, so the current project and recent
+ * projects (both always scripture or resource projects) resolve from the same filtered fetch.
+ */
 const PICKER_PROJECT_INTERFACE = 'platformScripture.USJ_Chapter';
 const PICKER_METADATA_FILTER: ProjectMetadataFilterOptions = {
   includeProjectInterfaces: [PICKER_PROJECT_INTERFACE],

--- a/src/renderer/hooks/use-project-picker-data.hook.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.ts
@@ -6,7 +6,11 @@ import { webViews } from '@renderer/services/papi-frontend.service';
 import { projectLookupService } from '@shared/services/project-lookup.service';
 import { normalizeProjectId } from '@shared/models/project-lookup.service-model';
 import { type ProjectMetadata } from '@shared/models/project-metadata.model';
-import { type ProjectMetadataFilterOptions } from '@shared/models/project-data-provider-factory.interface';
+import {
+  PDP_FACTORY_OBJECT_TYPE,
+  type ProjectMetadataFilterOptions,
+} from '@shared/models/project-data-provider-factory.interface';
+import { type NetworkObjectDetails } from '@shared/models/network-object.model';
 import {
   EVENT_NAME_ON_DID_CLOSE_WEB_VIEW,
   EVENT_NAME_ON_DID_OPEN_WEB_VIEW,
@@ -116,6 +120,23 @@ export function useProjectPickerData(): ProjectPickerData {
   // three sections refetch.
   const onDidChangeProjects = useMemo(() => getNetworkEvent('platform.onDidChangeProjects'), []);
   useEvent(onDidChangeProjects, refreshMetadata);
+  // Heal the project list when a PDP factory registers after the startup grace window expires
+  // (PT-4299). internalGetMetadataWithRetries only retries within 30 s of process start; if the
+  // USJ-providing layering PDPF (Scripture Extender) arrives after that window AND neither
+  // onDidReloadExtensions nor onDidChangeProjects fires, the picker stays empty until the user
+  // triggers an unrelated refresh. Subscribing here ensures a late-arriving PDPF always heals
+  // the list independent of the 30-second bound.
+  const onDidCreateNetworkObject = useMemo(
+    () => getNetworkEvent('object:onDidCreateNetworkObject'),
+    [],
+  );
+  const onPdpFactoryRegistered = useCallback(
+    ({ objectType }: NetworkObjectDetails) => {
+      if (objectType === PDP_FACTORY_OBJECT_TYPE) refreshMetadata();
+    },
+    [refreshMetadata],
+  );
+  useEvent(onDidCreateNetworkObject, onPdpFactoryRegistered);
 
   // Recent project IDs from the service — reactive, updates when user opens projects
   const [rawRecentIds, , isRecentIdsLoading] = useData(

--- a/src/renderer/hooks/use-project-picker-data.hook.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.ts
@@ -1,6 +1,6 @@
 import { useData } from '@renderer/hooks/papi-hooks';
 import { useEvent, usePromise } from 'platform-bible-react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { getNetworkEvent } from '@shared/services/network.service';
 import { webViews } from '@renderer/services/papi-frontend.service';
 import { projectLookupService } from '@shared/services/project-lookup.service';
@@ -30,6 +30,15 @@ import { type ProjectItem } from '@renderer/components/projects/project-picker.c
  * this interface via the Scripture Extender layering PDPF, so the current project and recent
  * projects (both always scripture or resource projects) resolve from the same filtered fetch.
  */
+/** How long to wait before retrying a failed metadata fetch. */
+const METADATA_FETCH_RETRY_DELAY_MS = 5 * 1000;
+/**
+ * Maximum number of consecutive metadata fetch failures before the hook stops retrying. After this
+ * many failures the picker stays empty until the next external refresh signal (e.g. an extension
+ * reload or a PDPF registration).
+ */
+export const MAX_METADATA_FETCH_RETRIES = 3;
+
 const PICKER_PROJECT_INTERFACE = 'platformScripture.USJ_Chapter';
 const PICKER_METADATA_FILTER: ProjectMetadataFilterOptions = {
   includeProjectInterfaces: [PICKER_PROJECT_INTERFACE],
@@ -102,6 +111,13 @@ export function useProjectPickerData(): ProjectPickerData {
   const [currentProjectError, setCurrentProjectError] = useState<string | undefined>(undefined);
   const refreshMetadata = useCallback(() => setMetadataRefreshCounter((n) => n + 1), []);
   const refreshActiveEditor = useCallback(() => setWebViewRefreshCounter((n) => n + 1), []);
+  // When getMetadataForAllProjects rejects (e.g. a PDPF's getAvailableProjects RPC times out
+  // during startup), isRetryPending becomes true and the effect below schedules a re-fetch after
+  // METADATA_FETCH_RETRY_DELAY_MS — by which time the extension host has typically drained its
+  // queue and responds quickly. fetchRetryCountRef caps consecutive retries so a permanently
+  // unavailable host does not loop forever.
+  const [isRetryPending, setIsRetryPending] = useState(false);
+  const fetchRetryCountRef = useRef(0);
 
   const onDidOpenWebView = useMemo(() => getNetworkEvent(EVENT_NAME_ON_DID_OPEN_WEB_VIEW), []);
   useEvent(onDidOpenWebView, refreshActiveEditor);
@@ -137,6 +153,18 @@ export function useProjectPickerData(): ProjectPickerData {
     [refreshMetadata],
   );
   useEvent(onDidCreateNetworkObject, onPdpFactoryRegistered);
+  // After a failed metadata fetch, wait METADATA_FETCH_RETRY_DELAY_MS before trying again.
+  // The timer is cancelled if the hook unmounts before it fires, preventing state updates on an
+  // unmounted component and avoiding spurious fan-outs when the user closes the picker quickly.
+  useEffect(() => {
+    if (!isRetryPending) return undefined;
+    const timeout = setTimeout(() => {
+      fetchRetryCountRef.current += 1;
+      setIsRetryPending(false);
+      refreshMetadata();
+    }, METADATA_FETCH_RETRY_DELAY_MS);
+    return () => clearTimeout(timeout);
+  }, [isRetryPending, refreshMetadata]);
 
   // Recent project IDs from the service — reactive, updates when user opens projects
   const [rawRecentIds, , isRecentIdsLoading] = useData(
@@ -165,11 +193,23 @@ export function useProjectPickerData(): ProjectPickerData {
       counter: metadataRefreshCounter,
       promise: projectLookupService.getMetadataForAllProjects(PICKER_METADATA_FILTER),
     };
-    // Invalidate this generation if its fetch rejects, but only if it's still the current entry so
-    // a newer generation isn't clobbered.
-    entry.promise.catch(() => {
-      if (metadataFetchRef.current === entry) metadataFetchRef.current = undefined;
-    });
+    // On success: reset the retry counter so a future transient failure gets its own retry budget.
+    // On failure (caught at the end of the chain): invalidate this generation's cache entry (so the
+    // next getAllMetadata call issues a fresh fetch rather than awaiting the poisoned promise), then
+    // schedule a retry if the budget allows.
+    entry.promise
+      .then(() => {
+        fetchRetryCountRef.current = 0;
+        return undefined;
+      })
+      .catch(() => {
+        if (metadataFetchRef.current === entry) {
+          metadataFetchRef.current = undefined;
+          if (fetchRetryCountRef.current < MAX_METADATA_FETCH_RETRIES) {
+            setIsRetryPending(true);
+          }
+        }
+      });
     metadataFetchRef.current = entry;
     return entry.promise;
   }, [metadataRefreshCounter]);

--- a/src/renderer/hooks/use-project-picker-data.hook.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.ts
@@ -138,8 +138,8 @@ export function useProjectPickerData(): ProjectPickerData {
   // three sections refetch.
   const onDidChangeProjects = useMemo(() => getNetworkEvent('platform.onDidChangeProjects'), []);
   useEvent(onDidChangeProjects, refreshMetadata);
-  // Heal the project list when a PDP factory registers after the startup grace window expires
-  // (PT-4299). internalGetMetadataWithRetries only retries within 30 s of process start; if the
+  // Heal the project list when a PDP factory registers after the startup grace window expires.
+  // internalGetMetadataWithRetries only retries within 30 s of process start; if the
   // USJ-providing layering PDPF (Scripture Extender) arrives after that window AND neither
   // onDidReloadExtensions nor onDidChangeProjects fires, the picker stays empty until the user
   // triggers an unrelated refresh. Subscribing here ensures a late-arriving PDPF always heals


### PR DESCRIPTION
## Summary

- **PT-4299**: Fixes the intermittent empty project picker after first-run. The setup wizard burns through the service's 30-second PDPF grace window, leaving the picker empty with no recovery path. Two new mechanisms in `useProjectPickerData` heal it: a debounced `onDidCreateNetworkObject` subscription (handles late factory registration) and a 5-second retry with a 3-failure cap (handles RPC timeout during startup congestion).
- **First-run wizard steps**: Adds sync consent (PT-4178) and sync progress (PT-4179) steps to the first-run wizard, and completes the shell/stepper navigation scaffolding (PT-4257).
- **New platform components**: `WizardStepper` and `DestructiveKeyConfirmation` added to `platform-bible-react`. Keyboard-name utility (`getLocalizeKeyForPhysicalKey`) added to `platform-bible-utils`.
- **Tab icon fix**: Selected Simple-mode tabs no longer show an invisible white icon on light backgrounds.

---

## Details

### PT-4299 — Empty project picker after first-run wizard

**Root cause**: The service retries `getMetadataForAllProjects` for 30 seconds after startup, waiting for the Scripture Extender PDPF (which provides the `USJ_Chapter` interface the picker filters by) to register. The first-run wizard is long enough to exhaust that window. When the user finally opens the picker, the grace period is over, and there is no signal to trigger a recovery fetch.

Two failure modes, two fixes:

| Failure mode | Mechanism | Key constants |
|---|---|---|
| RPC timeout (extension host overloaded) | 5 s retry, max 3 attempts | `METADATA_FETCH_RETRY_DELAY_MS`, `MAX_METADATA_FETCH_RETRIES` |
| Successful-but-stale empty fetch (PDPF registered late) | Subscribe `onDidCreateNetworkObject`, debounce 200 ms, re-fetch | `PDPF_REGISTRATION_DEBOUNCE_MS` |

**Key file**: `src/renderer/hooks/use-project-picker-data.hook.ts`  
**Tests**: `src/renderer/hooks/use-project-picker-data.hook.test.ts` (23 tests, 7 new)

---

### First-run wizard

| Commit | What it adds |
|---|---|
| PT-4178 | Sync consent step — asks user to consent to background data sync |
| PT-4179 | Sync progress step — shows sync progress during first run |
| PT-4257 | Wizard stepper + shell navigation — routes between steps, tracks completion state |

The auto-sync blocking service (`src/renderer/services/auto-sync-blocking-service.ts`) gates automatic sync during the wizard. `first-run-store.ts` / `first-run.model.ts` hold the wizard state.

---

### Platform components and utilities

| Addition | Location | Purpose |
|---|---|---|
| `WizardStepper` | `lib/platform-bible-react/…/wizard-stepper/` | Step indicator used by the first-run wizard |
| `DestructiveKeyConfirmation` | `lib/platform-bible-react/…/destructive-key-confirmation*` | Confirm-before-delete UX (used by the two-step verse-number delete tooltip) |
| `getLocalizeKeyForPhysicalKey`, `NameablePhysicalKey` | `lib/platform-bible-utils/src/keyboard-util.ts` | Map physical key names to localized display strings |
| Tab icon fix | `lib/platform-bible-react/src/hooks/use-tab-icon-selection.hook.ts` | `lightSelected` (white) was invisible on plain-light tab headers; `pickTabIconUrl` now returns `lightUnselected` regardless of selection state in light theme |

---

### Infrastructure / cleanup

- **PT-4214/PT-4210**: Declares the sync-block seam (`getAutoSyncBlocking`, `onSyncWriteLockChanged`) and adds a `breakSyncLock` stub as public API.
- **PT-4020**: Improved tooltip styling for the two-step "Delete Verse Number" confirmation.
- **C# `SendReceiveBlockNotifierService`**: New service notifying when send/receive is blocked.
- **jsdom CSS-parse fix**: Suppresses CSS-parse console dumps that were hanging Linux CI unit tests (`vitest.setup.ts`).
- **Spanish localization docs**: Decisions distilled into `Localization-Guide.md`.

---

## Test plan

- [x] 7 new tests for PT-4299 (PDPF healing, timeout retry, retry cap, debounce collapse, spurious-Fetch-C cancellation, stale-generation integrity) — all RED before fix, GREEN after
- [x] All 23 `use-project-picker-data.hook` tests pass
- [x] `WizardStepper` and `DestructiveKeyConfirmation` have co-located unit tests
- [x] E2E first-run wizard overlay smoke test (`e2e-tests/tests/isolated/first-run/`)
- [x] TypeScript and ESLint clean on changed files (pre-existing `buildInfo.json` dev-env error on baseline, unrelated)

<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-4299-project-picker-empty-race

**Base**: origin/main

**Date**: 2026-07-30

**Review model**: Claude Sonnet 4.6

**Files changed**: 89

## Overview

This branch fixes an intermittent empty/locked project picker that occurs when users work through the setup wizard on first run. The service has a 30-second startup grace period during which it retries `getMetadataForAllProjects` until the Scripture Extender PDPF (which provides the `USJ_Chapter` interface the picker filters by) registers. The setup wizard burns through that window — the user is clicking through onboarding steps while extensions load in the background. When they finally open the picker, the grace period has expired, Scripture Extender hasn't registered yet, and the filtered fetch returns empty with no way to recover.

Two mechanisms were added to `useProjectPickerData` to fix different failure modes: a debounced `onDidCreateNetworkObject` subscription that re-fetches when a PDPF eventually registers (heals a successful-but-stale empty fetch), and a 5-second retry with a cap of 3 attempts (heals a fetch that failed outright due to RPC timeout during startup congestion). The branch also includes the setup wizard UI work that exposed the race: first-run flow scaffolding, sync consent and sync progress steps, a `WizardStepper` component, a `DestructiveKeyConfirmation` component, keyboard utilities, C# SendReceive improvements, and e2e tests.

## API Changes

- `lib/platform-bible-react`: Added `DestructiveKeyConfirmation` (default export) and `DestructiveKeyConfirmationProps` type
- `lib/platform-bible-react`: Added `WizardStepper` (default export) and `WizardStepperProps` type
- `lib/platform-bible-react`: Modified `pickTabIconUrl` — for `isTabSelected === true` in light theme, the function now returns `urls.lightUnselected` rather than `urls.lightSelected`. The `lightSelected` field is retained in `TabIconUrls` for future hosts that give selected tabs a dark background, but is currently unused by the function. This is an intentional behavior change (commit `2d831dcd447 Fix white/invisible tab icon on selected Simple-mode tabs`) — `lightSelected` is white, which is invisible against the plain light background every current host gives the active tab.
- `lib/platform-bible-utils`: Added `getLocalizeKeyForPhysicalKey()` export
- `lib/platform-bible-utils`: Added `NameablePhysicalKey` type export
- `@papi/core` (via `papi.d.ts`): Added `'platform.syncOnStartup': boolean` to `SettingTypes`

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [ ] ~~`lib/platform-bible-react/src/hooks/use-tab-icon-selection.hook.ts` — `pickTabIconUrl` behavior change for `isTabSelected === true`: previously returned `urls.lightSelected`, now returns `urls.lightUnselected`. Three internal callers supply a `lightSelected` URL that is now dead.~~ _(Intentional: commit `2d831dcd447` explicitly fixed invisible white icons on selected tabs in light theme. Every current host keeps the active tab header on a plain light background, making `lightSelected` (white) invisible. Change is documented in JSDoc and covered by tests. Author noted external extension developers are unlikely to have been affected during this development window.)_
- [x] `src/renderer/hooks/use-project-picker-data.hook.ts:24–32` — JSDoc for `PICKER_PROJECT_INTERFACE` was orphaned: the three new retry/debounce constants were inserted between the JSDoc and the constant it documents, so the JSDoc no longer attached to anything and `PICKER_PROJECT_INTERFACE` was left undocumented. _(Fixed during review: moved the JSDoc block to sit immediately above `PICKER_PROJECT_INTERFACE`.)_

### Minor — Consider

- [ ] ~~`src/renderer/hooks/use-project-picker-data.hook.ts:40` — `MAX_METADATA_FETCH_RETRIES` is `export`ed from a renderer-internal hook file whose only consumer is the co-located test file. Could be unexported with a test-local constant instead.~~ _(Author chose to leave the export as-is — it makes the retry-cap test self-documenting without a magic number.)_

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- **Comprehensive test coverage for the race fix.** Seven new tests cover PDPF-registration healing, RPC-timeout recovery, retry cap, debounce collapse, spurious-Fetch-C cancellation, and stale-generation cap integrity — each named after the exact race scenario it defends and with a comment explaining the production race. Tests use fake timers and are fully deterministic.
- **Two-argument `.then(onFulfilled, onRejected)` form.** Replaces the `.then().catch()` chain to keep the handlers structurally independent — an exception in the success handler cannot be silently mis-routed to the rejection handler. The inline comment explaining why is excellent.
- **Generation guard on both promise paths.** The `if (metadataFetchRef.current === entry)` check in both the success and failure handlers prevents a slow in-flight promise from corrupting the retry budget or cancelling a newer generation's timer after the fact.
- **Clean separation of refresh signals.** Metadata cache invalidation (PDPF registration, extension reload, project list change) is decoupled from active-editor re-derivation (web view open/update/close), keeping the expensive `getMetadataForAllProjects` fan-out isolated.
- **Proper cleanup on unmount.** Both `useEffect` cleanups call `clearTimeout`, preventing state updates after teardown for both the retry timer and the debounce timer.
- **`settle()` helper pattern.** Replaces `waitFor` with a deterministic microtask drain, avoiding flaky CI timing dependencies.
- **New components have tests and accessibility consideration.** `DestructiveKeyConfirmation` includes a `role="status"` live region for screen readers. `WizardStepper` has a co-located test and Storybook story.
- **`papi.d.ts` is properly regenerated**, not hand-edited.

## Interview Notes

**Stated purpose**: Fix the intermittent empty/locked project picker that occurs specifically after users run through the setup wizard on first startup.

**Author's design explanation**: The setup wizard takes time — users click through onboarding steps while extensions load in the background. The service has a 30-second grace period after startup where it keeps retrying until the Scripture Extender PDPF (which provides the `USJ_Chapter` interface the picker filters by) registers. The wizard burns through that window before the user even opens the picker. When they finally do, the grace period is expired, Scripture Extender hasn't registered yet, and the filtered fetch returns empty with no way to recover.

The two mechanisms fix different flavors of that:
- **PDPF subscription**: when Scripture Extender eventually registers, the hook sees the `onDidCreateNetworkObject` event, waits 200 ms to batch any burst of registrations, then re-fetches. Late factory → healed list. (Fixes a successful-but-stale empty fetch.)
- **Retry**: handles the case where the RPC itself fails during startup congestion — the extension host queue is full, the call times out, and rather than staying empty forever the hook waits 5 seconds and tries again (up to 3 times). (Fixes a failed fetch.)

**On the `pickTabIconUrl` finding**: author initially thought it was a bad rebase, but after reviewing commit `2d831dcd447` and the updated tests, confirmed it was an intentional fix for invisible white icons on selected tabs in light theme.

**On `MAX_METADATA_FETCH_RETRIES` export**: author chose to leave it — it makes the retry-cap test self-documenting.

## In-Review Quality Check

One change was made during the review (JSDoc move in `use-project-picker-data.hook.ts`). Quality check results:

- **typecheck**: pre-existing failure (`Cannot find module '../../../release/app/buildInfo.json'` in `src/main/services/app.service-host.ts`) — build artifact not present in the worktree; reproduced identically on the base commit. Unrelated to this PR.
- **lint**: same pre-existing `buildInfo.json` resolution failure. Unrelated.
- **prettier**: clean — no formatting changes needed.
- **tests (23/23)**: all pass.

## Suggested Review Focus

- [ ] **The two-mechanism design**: why both PDPF subscription and retry were needed — they fix distinct failure modes (stale-successful vs. failed RPC). Worth confirming the reviewer understands the distinction so they can evaluate whether any third failure mode was missed.
- [ ] **Debounce timing (200 ms)**: was this value empirically determined or estimated? A burst of 3+ PDPF registrations needs to all land within the window for the debounce to collapse them.
- [ ] **Retry parameters (3 attempts, 5 s delay)**: are these calibrated against observed startup congestion durations, or conservative defaults? The reviewer may want to know if there's data behind them.
<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2623)
<!-- Reviewable:end -->
