### PR TITLE
Scope the PAPI websocket to loopback only

### DIFF
--- a/src/main/services/__tests__/rpc-websocket-listener.binding.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.binding.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RpcWebSocketListener } from '@main/services/rpc-websocket-listener';
+import { WEBSOCKET_PORT } from '@shared/data/rpc.model';
+import { WebSocketServer } from 'ws';
+
+// Mock heavy dependencies so this test can run outside the Electron main process. The
+// WebSocketServer mock returns a listener-shaped stub because connect() wires handlers onto the
+// instance it constructs.
+vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
+vi.mock('ws', () => ({
+  WebSocketServer: vi.fn(() => ({ addListener: vi.fn(), removeListener: vi.fn(), close: vi.fn() })),
+}));
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+describe('the PAPI websocket listens on loopback only', () => {
+  let listener: RpcWebSocketListener;
+
+  beforeEach(() => {
+    vi.mocked(WebSocketServer).mockClear();
+    listener = new RpcWebSocketListener();
+  });
+
+  it('binds to a loopback host so off-machine clients cannot connect', async () => {
+    await listener.connect(vi.fn());
+
+    // Connections to the websocket are unauthenticated, so binding off loopback would expose every
+    // registered PAPI method to the network. Accept any loopback spelling — the security property
+    // is the address family-independent one, not the literal.
+    expect(WebSocketServer).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(WebSocketServer).mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        host: expect.stringMatching(/^(localhost|127\.0\.0\.1|::1)$/),
+        port: WEBSOCKET_PORT,
+      }),
+    );
+  });
+});

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -97,6 +97,11 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
         },
       });
 
+      // Bind to loopback so only clients on this machine can reach the PAPI websocket. Connections
+      // are unauthenticated and every registered method is callable over them, so the server must
+      // never accept traffic arriving on a non-loopback interface. Bind by name rather than a
+      // literal address: clients connect to `localhost` too, so both ends resolve through the same
+      // resolver and agree on the IP version, whichever the host prefers.
       this.webSocketServer = new WebSocketServer({ host: 'localhost', port: WEBSOCKET_PORT });
       this.webSocketServer.addListener('connection', this.onClientConnect);
       this.webSocketServer.addListener('close', this.disconnect);

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -97,7 +97,7 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
         },
       });
 
-      this.webSocketServer = new WebSocketServer({ port: WEBSOCKET_PORT });
+      this.webSocketServer = new WebSocketServer({ host: 'localhost', port: WEBSOCKET_PORT });
       this.webSocketServer.addListener('connection', this.onClientConnect);
       this.webSocketServer.addListener('close', this.disconnect);
 


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: websocket-scope

**Base**: origin/main

**Date**: 2026-07-31

**Review model**: Claude Opus 5

**Files changed**: 2 (1 at review start, plus a test file added during the review)

## Overview

This branch binds the PAPI JSON-RPC WebSocket server to the loopback interface instead of all
interfaces, so remote machines can no longer connect to it. Previously `new WebSocketServer({ port:
WEBSOCKET_PORT })` bound the wildcard address, meaning anything that could reach the host on port
8876 — another machine on the LAN, a container, a remote debugging harness — could open an
unauthenticated connection and call every registered PAPI method. The fix adds `host: 'localhost'`
to the server options.

The change required no client-side updates, which was verified rather than assumed: every in-repo
PAPI client already connects by name to `localhost` (`src/client/services/rpc-client.ts:96`,
`src/renderer/services/renderer-web-socket.service.ts`, `c-sharp/PapiClient.cs:17`,
`src/shared/models/openrpc.model.ts:247`, and the e2e fixtures). A repo-wide grep for a hardcoded
`127.0.0.1` found exactly one hit, in `e2e-tests/global-setup.ts:35`, which is only ever called with
`RENDERER_PORT` (1212) — never 8876. A check for other listening sockets that would undercut the
hardening found none in `src/main/`, `src/node/`, or `c-sharp/`. During the review, an explanatory
comment and a regression test were added so the control is documented and enforced.

## API Changes

- **No public API surfaces changed.** The branch touches only `src/main/services/rpc-websocket-listener.ts`
  (main-process internal) and adds a test file. Nothing changed in `lib/platform-bible-react/`,
  `lib/platform-bible-utils/`, `lib/papi-dts/papi.d.ts`, or any `extensions/src/*/src/types/*.d.ts`.
- Factual behavioral change to the PAPI websocket endpoint itself: the JSON-RPC WebSocket server on
  port 8876 now binds to the loopback address only, rather than all interfaces (`0.0.0.0`/`::`).
  `WEBSOCKET_PORT` (exported via `papi.d.ts:1030`) is unchanged.
- **Reachability is deliberately reduced.** Any out-of-repo tooling that connected to this host's
  LAN address on port 8876 — containers, a second machine, external debugging harnesses — will now
  be refused. This is the intent of the change, but it is a behavior change to the platform's most
  externally-facing contract and reviewers should be aware of it.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [ ] ~~`src/main/services/rpc-websocket-listener.ts:100` — `host: 'localhost'` binds one address
  family, and which one is environment-dependent. `ws` passes `options.host` to
  `http.Server.listen(port, host)`, and Node's `net.Server.listen` does a single `dns.lookup`
  (`all: false`), binding exactly one address. Verified empirically on Linux (Node 22.22.1, ws
  8.21.1): bound `127.0.0.1`, and `::1` returned `ECONNREFUSED`. On hosts where `localhost` resolves
  `::1` first (the default macOS/Windows `/etc/hosts` mapping), the same line binds IPv6 loopback
  only. `host: '127.0.0.1'` would make the bound family deterministic.~~ _(Author: pinning
  `127.0.0.1` would cause the opposite problem on an IPv6-focused stack; the version-independent
  option is smarter. This is correct and stronger than the finding allowed — because every in-repo
  client also connects by the **name** `localhost`, server and client resolve through the same
  resolver on the same machine and land on the same first address by construction. Hardcoding
  `127.0.0.1` would break that symmetry: an IPv6-first client resolving `localhost` → `::1` would
  then need cross-family fallback to reach a v4-pinned server. Repo precedent agrees —
  `src/extension-host/services/local-oauth.service.ts:58` also uses the hostname form.)_

- [x] **`src/main/services/rpc-websocket-listener.ts:100` — the security intent was invisible in the
  code.** The change was a bare `host: 'localhost'` in an options object with no comment, in a file
  that otherwise carries rationale comments for far less consequential choices (lines 167-170,
  195-196, 341, 351-356, 400-402, 482), and whose class TSDoc (lines 40-50) described the server's
  role without mentioning binding scope. A future refactor — e.g. making the port configurable —
  could drop the option, and the regression would be invisible in a diff. _(fixed during review:
  added a comment above the bind site stating that connections are unauthenticated and every
  registered method is callable over them, so the server must never accept non-loopback traffic, and
  recording why the hostname form is used rather than a literal address.)_

- [x] **`src/main/services/rpc-websocket-listener.ts:100` — no test guarded the binding.** That one
  line *is* the entire security control, and nothing asserted it. With the Windows/macOS e2e job
  non-blocking (below), a unit test is the only check that gates merge on all three platforms.
  _(fixed during review: added `src/main/services/__tests__/rpc-websocket-listener.binding.test.ts`,
  which constructs the listener, calls `connect()`, and asserts `WebSocketServer` was invoked with a
  loopback host and `WEBSOCKET_PORT`. The assertion accepts any loopback spelling
  (`localhost`/`127.0.0.1`/`::1`) so it locks in the security property without over-constraining the
  literal. Verified falsifiable by the revert test: with the `host` option removed the test fails;
  restored, it passes.)_

- [ ] ~~`.github/workflows/test.yml:179-183` — the only CI job that exercises the websocket
  end-to-end on Windows/macOS is `continue-on-error: true`, so a platform-specific binding
  regression surfaces as a warning annotation and never fails the build. Linux e2e is blocking, but
  Linux is the platform empirically confirmed to bind `127.0.0.1` — i.e. the platform least likely
  to expose a family-related problem is the only one gating merge. (Pre-existing configuration, not
  introduced by this branch.)~~ _(Author: leave as-is — the Windows and macOS CI runners cannot run
  e2e tests reliably and fail flakily too often. The blocking unit test added above now covers this
  specific regression risk on all three platforms via `npm test`.)_

Author response: The address-family concern was defended on sound technical grounds — name-based
resolution on both ends keeps server and client on the same IP version by construction. The two
findings about the control being undocumented and untested were accepted and fixed during the
interview. The CI finding was dismissed as pre-existing, with the flakiness rationale recorded.

### Minor — Consider

- [ ] ~~`src/main/services/rpc-websocket-listener.ts:100-110` — no `'error'` or `'listening'` handler
  on the WebSocketServer. `ws` re-emits the underlying HTTP server's `error` on the
  `WebSocketServer`, but `connect()` registers only `'connection'` and `'close'`; an `'error'`
  emission with no listener throws as an uncaught exception in the main process. `connectionStatus`
  is also set to `Connected` synchronously without waiting for `'listening'`. Both are pre-existing,
  but binding by hostname adds a new way to reach that path (a `dns.lookup` failure for `localhost`
  on a broken hosts file or unusual container config).~~ _(Author: leave it — pre-existing scope,
  out of bounds for a one-line security fix.)_

- [ ] ~~`.context/standards/Architecture.md:25` — the architecture diagram describes the "WebSocket
  server on port 8876" with no mention of interface scope, now that loopback-only is a deliberate
  security boundary rather than an accident of defaults.~~ _(Author: no — the application is never
  described as multi-machine, and the localhost nature has been so strongly implied that this issue
  was only recently caught.)_

- [ ] ~~`.context/standards/Security-Guide.md` — no network-exposure section exists; the guide covers
  CSP, module import restrictions, and extension sandboxing, and a grep for
  `websocket`/`localhost`/`loopback`/`8876` found nothing. Recording the loopback-only invariant
  there would give the constraint a home outside a single line of code.~~ _(Author: same reasoning —
  the loopback assumption was already implicit throughout the platform, so it does not need to be
  newly documented as a constraint.)_

- [ ] ~~`src/main/services/rpc-websocket-listener.ts:100` — DRY: the `'localhost'` literal is now
  hardcoded server-side while the same host/port pair is spelled out separately in
  `src/client/services/rpc-client.ts:96`, `src/shared/models/openrpc.model.ts:247`, and
  `c-sharp/PapiClient.cs:17`. A `WEBSOCKET_HOST` sibling to the shared `WEBSOCKET_PORT` constant
  (`src/shared/data/rpc.model.ts:14`) would keep the bind address and the connect addresses from
  drifting.~~ _(Author: leave the literal — `WEBSOCKET_PORT` is re-exported through
  `lib/papi-dts/papi.d.ts:1030`, so a sibling constant would likely land there too, and one extra
  usage is not worth widening the public API surface.)_

Author response: All four minor findings were reviewed one at a time and deliberately declined, each
with a stated rationale. None were left unexamined.

### Template Propagation

#### Shared Regions Modified

None. `src/main/services/rpc-websocket-listener.ts` contains no `#region shared with` markers
(verified by reading and grepping the file).

#### Extension Config Changes

None. The changed files are under `src/main/`, not `extensions/`. No `package.json`, `tsconfig*.json`,
`.eslintrc*`, or webpack config changed on this branch.

## Positive Observations

- Surgical diff: the fix is one line, uses the correct mechanism for the stated goal, and bundles no
  incidental refactoring — matching the Code Style Guide's "don't include tidying or unrelated
  refactors in a feature PR."
- The stated purpose is genuinely achieved. Binding to a loopback address means the listening socket
  cannot accept connections arriving on any non-loopback interface.
- No client-side changes were needed, and the author correctly identified that the fix is confined to
  the bind side. All analysis passes confirmed this independently against the actual client code.
- Reuses the shared `WEBSOCKET_PORT` constant rather than introducing a port literal.
- Consistent with the existing local-server binding pattern in `local-oauth.service.ts:58`, which also
  uses the hostname form.
- No other listening socket undercuts the hardening — none exist in `src/main/`, `src/node/`, or
  `c-sharp/`. (CDP on 9223 and the webpack dev server on 1212 are dev-script-only.)
- The e2e harness is unaffected: `e2e-tests/global-setup.ts:35`'s hardcoded `127.0.0.1` is only used
  with `RENDERER_PORT`, and its `isPortInUse` guard binds the wildcard address, which still collides
  with a specific-address listener on Linux, so the "already running" fail-fast check still works.

## Interview Notes

**Stated purpose**: Prevent remote machines from connecting to the PAPI websocket.

**Key decisions and reasoning**:

- **`localhost` over `127.0.0.1` was a deliberate choice, not a default.** The author's reasoning:
  pinning a v4 literal would cause the mirror-image problem on an IPv6-focused stack, so the
  version-independent option is the safer one. This holds up under scrutiny — because every PAPI
  client also connects by name, both ends resolve through the same resolver on the same machine and
  agree on the address family by construction. The author identified this tradeoff unprompted and
  articulated it precisely.
- **Documentation of the invariant was judged unnecessary** in `Architecture.md` and
  `Security-Guide.md`, because the platform is never described as multi-machine and the loopback
  assumption has been implicit all along — which the author noted is precisely why the gap went
  unnoticed for so long. The in-code comment added during the review is the durable record instead.
- **The CI gap on Windows/macOS is a known, accepted tradeoff.** Those runners cannot execute e2e
  tests reliably and fail flakily too often, so `continue-on-error` stays. The unit test added
  during the review covers the regression risk on all three platforms instead.
- **Two findings were accepted and fixed in-review**: the missing rationale comment and the missing
  regression test.

**Unresolved items**: None. Every Critical/Important and Minor finding reached a decision.

**Areas the author could not explain**: None. The author demonstrated clear, specific understanding
of the change and its tradeoffs, including the resolver-level detail behind the address-family
question, and did not defer to AI on any point. The design-understanding question (Step 3.3) was
skipped because the change is one line and the author's answers were substantive.

## In-Review Quality Check

All checks passed cleanly with no fixes required:

| Check | Result |
| --- | --- |
| `npm run typecheck` | Clean (root + all extension workspaces) |
| `npm run lint` | Exit 0; ESLint run directly against both changed files was also clean |
| `npx prettier --write` (two changed files only) | Both already correctly formatted (`unchanged`) |
| `npm test` (full suite) | Green across all workspaces — ~4,140 tests, 1 skipped, 0 failed |

Notes:

- The new `rpc-websocket-listener.binding.test.ts` passes, and was verified falsifiable by the revert
  test (removing the `host` option makes it fail).
- The first `npm test` invocation exited non-zero with no failing test visible in the output; two
  subsequent full runs both exited 0 with zero failures. It did not reproduce and nothing was
  traceable to the changed files.
- The known CI-flaky `use-project-picker-data.hook.test.ts` passed in both captured runs.
- Four pre-existing lint **warnings** (`no-console`, `import/no-duplicates`) remain in
  `extensions/src/platform-scripture-editor/`. Unrelated to this branch, warnings not errors, left
  untouched.
- No library rebuild was needed — nothing under `lib/platform-bible-react/` or
  `lib/platform-bible-utils/` was touched.

## Suggested Review Focus

- [ ] **Confirm the reachability change is acceptable for all consumers.** In-repo blast radius is
      zero (verified), but any out-of-repo tooling that connected to this host's LAN address on port
      8876 — containers, a second machine, an external debugging harness — will now be refused. Does
      anyone on the team rely on that?
- [ ] **Sanity-check the `localhost` vs `127.0.0.1` reasoning on Windows and macOS.** The symmetry
      argument (both ends resolve the same name, so they agree on the family) is sound, and Node's
      `ws` client was verified to fall back across families. Chromium's and .NET `ClientWebSocket`'s
      cross-family fallback were *not* empirically verified. Manual smoke on a macOS or Windows box —
      where `localhost` typically resolves `::1` first — would close the last gap, and matters more
      than usual because the Windows/macOS e2e job is non-blocking.
- [ ] **Agree on the documentation decision.** The author deliberately declined to record the
      loopback-only invariant in `Architecture.md` or `Security-Guide.md`, on the grounds that the
      assumption was already implicit. Worth a brief check that the in-code comment is a sufficient
      durable record, given the invariant went unnoticed until now precisely because it was implicit.
<!-- review-paratext:summary:end -->

_AI-assisted, with my guidance — reviewed with Claude Opus 5 via `/review-paratext`._

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2624)
<!-- Reviewable:end -->
