### PR TITLE
fix(flaky): wrap vi.runAllTimers() in act() in notification-display test

### DIFF
--- a/src/renderer/components/notification-display.test.tsx
+++ b/src/renderer/components/notification-display.test.tsx
@@ -101,12 +101,17 @@ describe('NotificationDisplay with real Sonner', () => {
 
   afterEach(() => {
     // toast.dismiss() marks toasts as removed, but Sonner then schedules a new setTimeout for the
-    // exit animation that calls removeToast (which accesses window). vi.runAllTimers() flushes that
-    // timer now, while jsdom is still up.
+    // exit animation that calls removeToast (which accesses window). The first act() flushes the
+    // dismiss re-render and Sonner's useEffect (which schedules the exit timer). The second act()
+    // fires all fake timers AND flushes the React MessageChannel update those callbacks post —
+    // without act() wrapping runAllTimers(), the MessageChannel message escapes into real-time and
+    // fires after jsdom tears down, producing "window is not defined".
     act(() => {
       toast.dismiss();
     });
-    vi.runAllTimers();
+    act(() => {
+      vi.runAllTimers();
+    });
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
## Problem

`notification-display.test.tsx` produced a post-teardown `ReferenceError: window is not defined` on Windows CI ([run 30332467804](https://github.com/paranext/paranext-core/actions/runs/30332467804), 2026-07-28). All 1268 test assertions passed — the error surfaced in Vitest's unhandled-exception bucket after jsdom was destroyed:

```
ReferenceError: window is not defined
  ❯ resolveUpdatePriority  react-dom-client.development.js:1308
  ❯ requestUpdateLane      react-dom-client.development.js:16345
  ❯ setToasts              react-dom-client.development.js:9126
  ❯ removeToast            sonner/src/index.tsx:641
  ❯ Timeout._onTimeout     sonner/src/index.tsx:194
```

## Root Cause

React 18 uses **`MessageChannel`** (not `setTimeout`) for its update scheduler. The existing `afterEach` called `vi.runAllTimers()` **outside `act()`**:

```ts
act(() => { toast.dismiss(); });  // ✅ flushes dismiss re-render + Sonner useEffect (schedules exit timer)
vi.runAllTimers();                // ❌ fires exit timer → removeToast → setToasts → React posts to MessageChannel
vi.useRealTimers();               // MessageChannel message still pending…
// jsdom tears down → MessageChannel fires → window is not defined
```

`vi.runAllTimers()` flushes fake `setTimeout` timers, but **does not flush `MessageChannel`**. So the `setToasts` call scheduled a React update via MessageChannel that escaped the test lifecycle.

## Fix

Wrap `vi.runAllTimers()` in its own `act()` call. `act()` is the tool React provides for exactly this purpose — it flushes the internal scheduler, including `MessageChannel` messages:

```ts
act(() => { toast.dismiss(); });  // flush dismiss + Sonner useEffect → exit timer scheduled
act(() => { vi.runAllTimers(); }); // fire exit timer + flush resulting MessageChannel update
vi.useRealTimers();               // no pending React work
```

Two separate `act()` calls are needed: the first flushes `toast.dismiss()` and Sonner's `useEffect` (which schedules the exit timer), the second fires the timer and flushes the `setToasts` update it triggers.

## Files Changed

- `src/renderer/components/notification-display.test.tsx` — `afterEach`: wrap `vi.runAllTimers()` in `act()`; update comment to explain the two-act pattern and the MessageChannel mechanism

## Flaky report context

This was identified by the automated weekly flaky-routine scan (2026-07-31). The failure appeared once in 25 runs on `main` over the past 7 days (4% flake rate on Windows). The root cause is a deterministic race between React's `MessageChannel` scheduler and jsdom teardown — not timing-sensitive, so the fix eliminates the condition entirely rather than reducing its probability.

AI-assisted — [session](https://claude.ai/code/session_01RhPP1qr5upt2sjW6RE5oqi)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhPP1qr5upt2sjW6RE5oqi)_

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2625)
<!-- Reviewable:end -->
