### PR TITLE
Correct open* command declarations: parameter is the triggering web view id, not a project id

### DIFF
--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -593,8 +593,8 @@ export async function activate(context: ExecutionActivationContext) {
         ],
         result: {
           name: 'return value',
-          summary: 'The ID of the opened markers checklist web view',
-          schema: { type: 'string' },
+          summary: 'The ID of the opened markers checklist web view, or undefined if not opened',
+          schema: { type: ['string', 'null'] },
         },
       },
     },
@@ -642,8 +642,8 @@ export async function activate(context: ExecutionActivationContext) {
         ],
         result: {
           name: 'return value',
-          summary: 'The id of the opened Manage Books web view',
-          schema: { type: 'string' },
+          summary: 'The ID of the opened Manage Books web view, or undefined if not opened',
+          schema: { type: ['string', 'null'] },
         },
       },
     },

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -187,6 +187,11 @@ async function openMarkersChecklist(webViewId: string | undefined): Promise<stri
     projectId = webViewDefinition?.projectId;
   }
 
+  if (!projectId) {
+    logger.debug('No project!');
+    return undefined;
+  }
+
   const options: ChecklistWebViewOptions = { projectId };
   return papi.webViews.openWebView(
     markersChecklistWebViewType,

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -659,9 +659,10 @@ export async function activate(context: ExecutionActivationContext) {
       summary: 'Open the find UI',
       params: [
         {
-          name: 'webViewId',
+          name: 'editorWebViewId',
           required: false,
-          summary: 'The ID of the web view tied to the project that we are searching in',
+          summary:
+            'The ID of the triggering editor web view; the project to search in is resolved from it',
           schema: { type: 'string' },
         },
       ],

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -417,8 +417,8 @@ export async function activate(context: ExecutionActivationContext) {
         ],
         result: {
           name: 'return value',
-          summary: 'The ID of the opened characters inventory web view',
-          schema: { type: 'string' },
+          summary: 'The ID of the opened characters inventory web view, or undefined if not opened',
+          schema: { type: ['string', 'null'] },
         },
       },
     },
@@ -452,8 +452,9 @@ export async function activate(context: ExecutionActivationContext) {
         ],
         result: {
           name: 'return value',
-          summary: 'The ID of the opened repeated words inventory web view',
-          schema: { type: 'string' },
+          summary:
+            'The ID of the opened repeated words inventory web view, or undefined if not opened',
+          schema: { type: ['string', 'null'] },
         },
       },
     },
@@ -488,8 +489,8 @@ export async function activate(context: ExecutionActivationContext) {
         ],
         result: {
           name: 'return value',
-          summary: 'The ID of the new open markers inventory web view',
-          schema: { type: 'string' },
+          summary: 'The ID of the opened markers inventory web view, or undefined if not opened',
+          schema: { type: ['string', 'null'] },
         },
       },
     },
@@ -535,8 +536,9 @@ export async function activate(context: ExecutionActivationContext) {
         ],
         result: {
           name: 'return value',
-          summary: 'The ID of the opened punctuation inventory web view',
-          schema: { type: 'string' },
+          summary:
+            'The ID of the opened punctuation inventory web view, or undefined if not opened',
+          schema: { type: ['string', 'null'] },
         },
       },
     },
@@ -562,8 +564,8 @@ export async function activate(context: ExecutionActivationContext) {
         ],
         result: {
           name: 'return value',
-          summary: 'The ID of the new checks side panel web view',
-          schema: { type: 'string' },
+          summary: 'The ID of the opened checks side panel web view, or undefined if not opened',
+          schema: { type: ['string', 'null'] },
         },
       },
     },
@@ -631,7 +633,7 @@ export async function activate(context: ExecutionActivationContext) {
         summary: 'Open the unified Manage Books dialog (FN-008)',
         params: [
           {
-            name: 'projectIdOrWebViewId',
+            name: 'webViewIdOrProjectId',
             required: false,
             summary:
               'Either the active editor web view id (resolves its project) or a literal project id; omit to open with the project picker visible.',
@@ -668,8 +670,8 @@ export async function activate(context: ExecutionActivationContext) {
       ],
       result: {
         name: 'return value',
-        summary: 'The ID of the new find web view',
-        schema: { type: 'string' },
+        summary: 'The ID of the find web view, or undefined if not opened',
+        schema: { type: ['string', 'null'] },
       },
     },
   });

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -410,7 +410,8 @@ export async function activate(context: ExecutionActivationContext) {
           {
             name: 'webViewId',
             required: false,
-            summary: 'The ID of the web view tied to the project that the inventory is for',
+            summary:
+              'The ID of the triggering web view; the project the inventory is for is resolved from it',
             schema: { type: 'string' },
           },
         ],
@@ -444,7 +445,8 @@ export async function activate(context: ExecutionActivationContext) {
           {
             name: 'webViewId',
             required: false,
-            summary: 'The ID of the web view tied to the project that the inventory is for',
+            summary:
+              'The ID of the triggering web view; the project the inventory is for is resolved from it',
             schema: { type: 'string' },
           },
         ],
@@ -479,7 +481,8 @@ export async function activate(context: ExecutionActivationContext) {
           {
             name: 'webViewId',
             required: false,
-            summary: 'The ID of the web view tied to the project that the inventory is for',
+            summary:
+              'The ID of the triggering web view; the project the inventory is for is resolved from it',
             schema: { type: 'string' },
           },
         ],
@@ -518,6 +521,25 @@ export async function activate(context: ExecutionActivationContext) {
   const openPunctuationInventoryPromise = papi.commands.registerCommand(
     'platformScripture.openPunctuationInventory',
     openPlatformPunctuationInventory,
+    {
+      method: {
+        summary: 'Open the punctuation inventory',
+        params: [
+          {
+            name: 'webViewId',
+            required: false,
+            summary:
+              'The ID of the triggering web view; the project the inventory is for is resolved from it',
+            schema: { type: 'string' },
+          },
+        ],
+        result: {
+          name: 'return value',
+          summary: 'The ID of the opened punctuation inventory web view',
+          schema: { type: 'string' },
+        },
+      },
+    },
   );
   const punctuationInventoryWebViewProviderPromise = papi.webViewProviders.registerWebViewProvider(
     punctuationInventoryWebViewType,
@@ -531,9 +553,10 @@ export async function activate(context: ExecutionActivationContext) {
         summary: 'Open the checks side panel',
         params: [
           {
-            name: 'webViewId',
+            name: 'editorWebViewId',
             required: false,
-            summary: 'The ID of the web view tied to the project that the checks are for',
+            summary:
+              'The ID of the editor web view the checks side panel is opened for; the project and scroll group are resolved from it',
             schema: { type: 'string' },
           },
         ],

--- a/extensions/src/platform-scripture/src/main.ts
+++ b/extensions/src/platform-scripture/src/main.ts
@@ -221,11 +221,12 @@ async function openMarkersChecklistSettings(): Promise<void> {
 }
 
 /**
- * FN-008 (2026-05-01): Open the unified Manage Books dialog as a tab web view. The optional
- * argument is either an editor's `webViewId` (from a scripture-editor menu) or a literal project id
- * — we probe with `papi.webViews.getOpenWebViewDefinition` and fall back to treating the value as a
- * project id when the probe returns `undefined`. When the caller provides no id (e.g. main-menu
- * invocation) the dialog opens with the project picker visible.
+ * FN-008 (2026-05-01): Open the unified Manage Books dialog as a centered floating window. The
+ * optional argument is either an editor's `webViewId` (from a scripture-editor menu) or a literal
+ * project id — we probe with `papi.webViews.getOpenWebViewDefinition`, and if it doesn't resolve to
+ * a web view with a project (it throws, finds nothing, or finds a web view with no project), we
+ * fall back to treating the value as a literal project id. When the caller provides no id (e.g.
+ * main-menu invocation) the dialog opens with the project picker visible.
  */
 async function openManageBooks(
   webViewIdOrProjectId: string | undefined,

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2391,24 +2391,52 @@ declare module 'papi-shared-types' {
 
     'platformScripture.invalidateCheckResults': (details: CheckResultsInvalidated) => Promise<void>;
 
+    /**
+     * Open the characters inventory web view. The single optional argument is the **triggering web
+     * view's id** (e.g. the editor tab the command was invoked from) — not a project id. The
+     * handler resolves the project internally via `papi.webViews.getOpenWebViewDefinition`; if no
+     * web view id is provided or the web view has no project, the command resolves to `undefined`
+     * without opening anything.
+     */
     'platformScripture.openCharactersInventory': (
-      projectId?: string | undefined,
+      webViewId?: string | undefined,
     ) => Promise<string | undefined>;
 
+    /**
+     * Open the repeated-words inventory web view. Argument semantics are identical to
+     * {@link 'platformScripture.openCharactersInventory'}: the triggering web view's id, from which
+     * the project is resolved internally.
+     */
     'platformScripture.openRepeatedWordsInventory': (
-      projectId?: string | undefined,
+      webViewId?: string | undefined,
     ) => Promise<string | undefined>;
 
+    /**
+     * Open the markers inventory web view. Argument semantics are identical to
+     * {@link 'platformScripture.openCharactersInventory'}: the triggering web view's id, from which
+     * the project is resolved internally.
+     */
     'platformScripture.openMarkersInventory': (
-      projectId?: string | undefined,
+      webViewId?: string | undefined,
     ) => Promise<string | undefined>;
 
+    /**
+     * Open the punctuation inventory web view. Argument semantics are identical to
+     * {@link 'platformScripture.openCharactersInventory'}: the triggering web view's id, from which
+     * the project is resolved internally.
+     */
     'platformScripture.openPunctuationInventory': (
-      projectId?: string | undefined,
+      webViewId?: string | undefined,
     ) => Promise<string | undefined>;
 
+    /**
+     * Open the checks side panel next to a scripture editor. The single optional argument is the
+     * **triggering editor's web view id** — not a project id. The handler resolves the editor's
+     * project and scroll group internally via `papi.webViews.getOpenWebViewDefinition` and places
+     * the panel relative to that editor tab.
+     */
     'platformScripture.openChecksSidePanel': (
-      projectId?: string | undefined,
+      editorWebViewId?: string | undefined,
     ) => Promise<string | undefined>;
 
     /**

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2458,9 +2458,13 @@ declare module 'papi-shared-types' {
     ) => Promise<string | undefined>;
 
     /**
-     * Open the Find / Replace UI for a project. The single optional argument is the calling
-     * editor's `webViewId` (when invoked from an editor's menu, so the Find UI can inherit the
-     * editor's project + scroll group). Pass `undefined` to open without an editor context.
+     * Open the Find / Replace UI for a project.
+     *
+     * @param editorWebViewId Id of the triggering editor's web view — not a project id. When
+     *   invoked from an editor's menu, the Find UI inherits that editor's project and scroll group,
+     *   resolved from it internally via `papi.webViews.getOpenWebViewDefinition`.
+     * @returns Id of the find web view, or `undefined` if no editor web view id was provided or the
+     *   web view has no project (nothing is opened in that case).
      */
     'platformScripture.openFind': (
       editorWebViewId?: string | undefined,

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2458,13 +2458,15 @@ declare module 'papi-shared-types' {
     ) => Promise<string | undefined>;
 
     /**
-     * Open the Find / Replace UI for a project.
+     * Open the Find / Replace UI for a project. Reuses an existing find web view rather than
+     * opening a new one when possible, reloading it if the resolved project differs from the
+     * existing web view's project, and brings the web view to front.
      *
-     * @param editorWebViewId Id of the triggering editor's web view — not a project id. When
-     *   invoked from an editor's menu, the Find UI inherits that editor's project and scroll group,
-     *   resolved from it internally via `papi.webViews.getOpenWebViewDefinition`.
-     * @returns Id of the find web view, or `undefined` if no editor web view id was provided or the
-     *   web view has no project (nothing is opened in that case).
+     * @param editorWebViewId Id of the triggering editor's web view — not a project id. The project
+     *   and scroll group for the Find / Replace UI are resolved from it internally via
+     *   `papi.webViews.getOpenWebViewDefinition`.
+     * @returns Id of the find web view (existing or newly opened), or `undefined` if no editor web
+     *   view id was provided or the web view has no project (nothing is opened in that case).
      */
     'platformScripture.openFind': (
       editorWebViewId?: string | undefined,

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2392,48 +2392,66 @@ declare module 'papi-shared-types' {
     'platformScripture.invalidateCheckResults': (details: CheckResultsInvalidated) => Promise<void>;
 
     /**
-     * Open the characters inventory web view. The single optional argument is the **triggering web
-     * view's id** (e.g. the editor tab the command was invoked from) — not a project id. The
-     * handler resolves the project internally via `papi.webViews.getOpenWebViewDefinition`; if no
-     * web view id is provided or the web view has no project, the command resolves to `undefined`
-     * without opening anything.
+     * Open the characters inventory web view.
+     *
+     * @param webViewId Id of the triggering web view (e.g. the editor tab the command was invoked
+     *   from) — not a project id. The project is resolved from it internally via
+     *   `papi.webViews.getOpenWebViewDefinition`.
+     * @returns Id of the newly opened characters inventory web view, or `undefined` if no web view
+     *   id was provided or the web view has no project (nothing is opened in that case).
      */
     'platformScripture.openCharactersInventory': (
       webViewId?: string | undefined,
     ) => Promise<string | undefined>;
 
     /**
-     * Open the repeated-words inventory web view. Argument semantics are identical to
-     * {@link 'platformScripture.openCharactersInventory'}: the triggering web view's id, from which
-     * the project is resolved internally.
+     * Open the repeated-words inventory web view.
+     *
+     * @param webViewId Id of the triggering web view (e.g. the editor tab the command was invoked
+     *   from) — not a project id. The project is resolved from it internally via
+     *   `papi.webViews.getOpenWebViewDefinition`.
+     * @returns Id of the newly opened repeated-words inventory web view, or `undefined` if no web
+     *   view id was provided or the web view has no project (nothing is opened in that case).
      */
     'platformScripture.openRepeatedWordsInventory': (
       webViewId?: string | undefined,
     ) => Promise<string | undefined>;
 
     /**
-     * Open the markers inventory web view. Argument semantics are identical to
-     * {@link 'platformScripture.openCharactersInventory'}: the triggering web view's id, from which
-     * the project is resolved internally.
+     * Open the markers inventory web view.
+     *
+     * @param webViewId Id of the triggering web view (e.g. the editor tab the command was invoked
+     *   from) — not a project id. The project is resolved from it internally via
+     *   `papi.webViews.getOpenWebViewDefinition`.
+     * @returns Id of the newly opened markers inventory web view, or `undefined` if no web view id
+     *   was provided or the web view has no project (nothing is opened in that case).
      */
     'platformScripture.openMarkersInventory': (
       webViewId?: string | undefined,
     ) => Promise<string | undefined>;
 
     /**
-     * Open the punctuation inventory web view. Argument semantics are identical to
-     * {@link 'platformScripture.openCharactersInventory'}: the triggering web view's id, from which
-     * the project is resolved internally.
+     * Open the punctuation inventory web view.
+     *
+     * @param webViewId Id of the triggering web view (e.g. the editor tab the command was invoked
+     *   from) — not a project id. The project is resolved from it internally via
+     *   `papi.webViews.getOpenWebViewDefinition`.
+     * @returns Id of the newly opened punctuation inventory web view, or `undefined` if no web view
+     *   id was provided or the web view has no project (nothing is opened in that case).
      */
     'platformScripture.openPunctuationInventory': (
       webViewId?: string | undefined,
     ) => Promise<string | undefined>;
 
     /**
-     * Open the checks side panel next to a scripture editor. The single optional argument is the
-     * **triggering editor's web view id** — not a project id. The handler resolves the editor's
-     * project and scroll group internally via `papi.webViews.getOpenWebViewDefinition` and places
-     * the panel relative to that editor tab.
+     * Open the checks side panel next to a scripture editor.
+     *
+     * @param editorWebViewId Id of the triggering editor's web view — not a project id. The
+     *   editor's project and scroll group are resolved from it internally via
+     *   `papi.webViews.getOpenWebViewDefinition`, and the panel is placed relative to that editor
+     *   tab.
+     * @returns Id of the newly opened checks side panel web view, or `undefined` if no editor web
+     *   view id was provided or the web view has no project (nothing is opened in that case).
      */
     'platformScripture.openChecksSidePanel': (
       editorWebViewId?: string | undefined,

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2473,9 +2473,14 @@ declare module 'papi-shared-types' {
     ) => Promise<string | undefined>;
 
     /**
-     * Open the Markers Checklist web view. Resolves the target project from the supplied
-     * `webViewId` (of an editor tab) when provided.
+     * Open the Markers Checklist web view.
      *
+     * @param webViewId Id of the triggering web view (e.g. the editor tab the command was invoked
+     *   from) — not a project id. When provided, the target project is resolved from it internally
+     *   via `papi.webViews.getOpenWebViewDefinition`; the checklist opens regardless of whether a
+     *   project could be resolved.
+     * @returns Id of the opened markers checklist web view, or `undefined` if the provider did not
+     *   create one.
      * @experimental
      */
     'platformScripture.openMarkersChecklist': (
@@ -2491,18 +2496,20 @@ declare module 'papi-shared-types' {
     'platformScripture.openMarkersChecklistSettings': () => Promise<void>;
 
     /**
-     * Open the unified Manage Books dialog (FN-008, 2026-05-01) for the active scripture project.
-     * Opens the dialog as a tab web view; the dialog itself supports View / Create / Delete / Copy
-     * / Import action modes and an inline book-chooser grid.
+     * Open the unified Manage Books dialog (FN-008, 2026-05-01) as a centered floating window. The
+     * dialog supports View / Create / Delete / Copy / Import action modes and an inline
+     * book-chooser grid. Only one Manage Books dialog is open at a time (FN-003): if one is already
+     * open, it is reloaded with the newly resolved project and brought to front instead of opening
+     * a second window.
      *
-     * The single optional argument is either an editor's `webViewId` (when invoked from a
-     * scripture-editor menu) or a literal project id (when invoked from the main menu or from
-     * another extension). The handler probes the value with
-     * `papi.webViews.getOpenWebViewDefinition` — if it resolves, the dialog opens pre-targeted at
-     * that web view's project; otherwise the value is treated as a project id and the dialog opens
-     * for that project directly. Pass `undefined` to open the dialog with the project picker
-     * visible.
-     *
+     * @param webViewIdOrProjectId Either an editor's `webViewId` (when invoked from a
+     *   scripture-editor menu) or a literal project id (when invoked from the main menu or from
+     *   another extension). The handler probes the value with
+     *   `papi.webViews.getOpenWebViewDefinition` — if it resolves to a web view with a project, the
+     *   dialog opens pre-targeted at that project; otherwise the value itself is treated as the
+     *   project id. Omit to open the dialog with the project picker visible.
+     * @returns Id of the Manage Books web view — the existing one if reused, or a newly opened one
+     *   — or `undefined` if the provider did not create one.
      * @experimental
      */
     'platformScripture.openManageBooks': (

--- a/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
+++ b/extensions/src/platform-scripture/src/types/platform-scripture.d.ts
@@ -2476,11 +2476,11 @@ declare module 'papi-shared-types' {
      * Open the Markers Checklist web view.
      *
      * @param webViewId Id of the triggering web view (e.g. the editor tab the command was invoked
-     *   from) — not a project id. When provided, the target project is resolved from it internally
-     *   via `papi.webViews.getOpenWebViewDefinition`; the checklist opens regardless of whether a
-     *   project could be resolved.
-     * @returns Id of the opened markers checklist web view, or `undefined` if the provider did not
-     *   create one.
+     *   from) — not a project id. The target project is resolved from it internally via
+     *   `papi.webViews.getOpenWebViewDefinition`.
+     * @returns Id of the opened markers checklist web view, or `undefined` if no web view id was
+     *   provided or the web view has no project (nothing is opened in that case), or if the
+     *   provider did not create one.
      * @experimental
      */
     'platformScripture.openMarkersChecklist': (


### PR DESCRIPTION
## Summary

The `platform-scripture.d.ts` declarations for the four inventory commands (`openCharactersInventory`, `openRepeatedWordsInventory`, `openMarkersInventory`, `openPunctuationInventory`) and `openChecksSidePanel` documented a `projectId` parameter. Every implementation actually takes the **triggering web view's id** and resolves the project internally via `papi.webViews.getOpenWebViewDefinition` — an integrator following the declared contract would pass a project id and get a silent no-op (the handler probes it as a web view id, finds nothing, and resolves `undefined`).

This renames the type-literal parameters to match the implementations (`webViewId` / `editorWebViewId`) and adds TSDoc stating the resolution semantics for each. `openManageBooks` (genuinely dual-purpose) and `openFind` were already documented correctly and are untouched.

Doc-only change: parameter names in TypeScript type literals carry no type-level meaning, so no caller can break; no runtime change; no new API items (so no new `@experimental` tags per convention).

## Origin

Identified in the PR #2438 review as the likely source of a wrong signature in that PR's authoring rule (since fixed there): https://github.com/paranext/paranext-core/pull/2438#discussion_r3693310158

This PR intentionally trails #2438 (which corrected the rule text) but merges independently of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qu9i2XxnVHwSHrc4W5vTic

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2626)
<!-- Reviewable:end -->


## Fix round (2026-08-04)

All five review notes addressed (`ce02eaeefab` + `7060e6fdcad`):

1-3. The five declaration blocks now carry full `@param`/`@returns` TSDoc per the Code-Style-Guide API-surface requirements; the quoted-string `{@link}` references are inlined; the `openChecksSidePanel` block states its failure mode like its siblings.
4. `openChecksSidePanel`'s runtime metadata param renamed to `editorWebViewId` — following the implementation and the `.d.ts` rather than the siblings, since the handler specifically needs an *editor* web view (scroll-group resolution). Verified the metadata feeds OpenRPC introspection only; invocation is positional.
5. `openPunctuationInventory` now registers the same `method` metadata block as its three siblings.

Bonus: the five `open*` param summaries no longer describe the argument as tied to a project — same ambiguity, same fix. (The equivalent summaries on `openMarkersChecklist` and `openFind` were left alone as out of this PR's five-command scope.)

Typecheck verified: identical error sets before/after the commits (280 pre-existing environment/branch errors, zero new).



**Addendum (2026-08-04, `959d00f9e89`):** `openFind` carried the same metadata param-name mismatch as item 4 (implementation `editorWebViewId`, metadata `webViewId`) — swept in to complete the set. Only `openMarkersChecklist`'s old-style summary now remains untouched (no name mismatch there).
