### PR TITLE
Add /verify-standards mechanical doc-claim checker

### DIFF
--- a/.claude/commands/investigate-prd.md
+++ b/.claude/commands/investigate-prd.md
@@ -79,17 +79,27 @@ unreachable, **stop and warn the user before investigating**:
 
 **Preflight — standards freshness.** The stamped docs this investigation leans on carry
 `Verified against paranext-core origin/main` stamps. Find the **oldest** stamp date (the weakest
-link is what governs risk):
+link is what governs risk) **and** the surfaces that carry no stamp at all:
 
 ```bash
+# Oldest stamp date across the surfaces that have stamps
 grep -rh "Verified against paranext-core" .context/standards/ .claude/skills/ .claude/rules/ .claude/agents/ .claude/commands/ CLAUDE.md 2>/dev/null | grep -oE '20[0-9]{2}-[0-9]{2}-[0-9]{2}' | sort | head -1
+# Surfaces with no stamp at all - they contribute no date, so the line above cannot reveal them.
+# The date anchor is deliberate: it ignores prose that merely quotes the stamp phrase (this file does).
+for d in .context/standards .claude/skills .claude/rules .claude/agents .claude/commands CLAUDE.md; do
+  grep -rqE "Verified against paranext-core.*20[0-9]{2}-[0-9]{2}-[0-9]{2}" "$d" 2>/dev/null || echo "UNSTAMPED: $d"
+done
 ```
 
-If it is older than ~30 days, tell the user in one line — "standards last verified {date};
-consider running `/verify-standards` first" — and proceed. If the grep returns **nothing**, that
-is a warning, not a pass: say "no verification stamps found; treat the standards as unverified
-and consider running `/verify-standards` first" — and proceed. Don't run the verification
-yourself; it's a separate, deliberate pass ([`/verify-standards`](verify-standards.md)).
+Report **both** results in the same one-line message — an unstamped surface has never been
+verified, and averaging it away behind a fresh date is exactly the false confidence this probe
+exists to prevent: "standards last verified {date}; {list of UNSTAMPED surfaces} carry no stamps"
+(drop the second clause when nothing is unstamped). Add "consider running `/verify-standards`
+first" when the date is older than ~30 days **or** any surface is unstamped, then proceed. If the
+date grep returns **nothing**, that is a warning, not a pass: say "no verification stamps found;
+treat the standards as unverified and consider running `/verify-standards` first" — and proceed.
+Don't run the verification yourself; it's a separate, deliberate pass
+([`/verify-standards`](verify-standards.md)).
 
 An unreachable **PT10** repo degrades `pt10-reuse-scout` (affects every PRD — it always runs);
 an unreachable **`{ROOT}/Paratext`** degrades `pt9-archaeologist` (only matters if the PRD ports

--- a/.claude/commands/investigate-prd.md
+++ b/.claude/commands/investigate-prd.md
@@ -77,6 +77,13 @@ unreachable, **stop and warn the user before investigating**:
 > coverage shrinks — I'll fall back to the bundled inventory and flag the gaps. Continue
 > anyway, or fix and rerun?
 
+**Preflight — standards freshness.** The standards and skills this investigation leans on carry
+`Verified against paranext-core origin/main` stamps. Check the newest one
+(`grep -rh "Verified against paranext-core" .context/standards/ .claude/skills/ | sort | tail -1`).
+If it is older than ~30 days, tell the user in one line — "standards last verified {date};
+consider running `/verify-standards` first" — and proceed. Don't run the verification yourself;
+it's a separate, deliberate pass ([`/verify-standards`](verify-standards.md)).
+
 An unreachable **PT10** repo degrades `pt10-reuse-scout` (affects every PRD — it always runs);
 an unreachable **`{ROOT}/Paratext`** degrades `pt9-archaeologist` (only matters if the PRD ports
 PT9 features). Wait for the user. If they choose to proceed, continue and let the agents degrade

--- a/.claude/commands/investigate-prd.md
+++ b/.claude/commands/investigate-prd.md
@@ -77,12 +77,19 @@ unreachable, **stop and warn the user before investigating**:
 > coverage shrinks — I'll fall back to the bundled inventory and flag the gaps. Continue
 > anyway, or fix and rerun?
 
-**Preflight — standards freshness.** The standards and skills this investigation leans on carry
-`Verified against paranext-core origin/main` stamps. Check the newest one
-(`grep -rh "Verified against paranext-core" .context/standards/ .claude/skills/ | sort | tail -1`).
+**Preflight — standards freshness.** The stamped docs this investigation leans on carry
+`Verified against paranext-core origin/main` stamps. Find the **oldest** stamp date (the weakest
+link is what governs risk):
+
+```bash
+grep -rh "Verified against paranext-core" .context/standards/ .claude/skills/ .claude/rules/ .claude/agents/ .claude/commands/ CLAUDE.md 2>/dev/null | grep -oE '20[0-9]{2}-[0-9]{2}-[0-9]{2}' | sort | head -1
+```
+
 If it is older than ~30 days, tell the user in one line — "standards last verified {date};
-consider running `/verify-standards` first" — and proceed. Don't run the verification yourself;
-it's a separate, deliberate pass ([`/verify-standards`](verify-standards.md)).
+consider running `/verify-standards` first" — and proceed. If the grep returns **nothing**, that
+is a warning, not a pass: say "no verification stamps found; treat the standards as unverified
+and consider running `/verify-standards` first" — and proceed. Don't run the verification
+yourself; it's a separate, deliberate pass ([`/verify-standards`](verify-standards.md)).
 
 An unreachable **PT10** repo degrades `pt10-reuse-scout` (affects every PRD — it always runs);
 an unreachable **`{ROOT}/Paratext`** degrades `pt9-archaeologist` (only matters if the PRD ports

--- a/.claude/commands/verify-standards.md
+++ b/.claude/commands/verify-standards.md
@@ -26,10 +26,17 @@ frozen records or pinned-snapshot corpora with their own provenance rules.
 ## Exemptions
 
 - **Frozen records**: any in-scope file whose first 30 lines contain `Status: frozen record` or a
-  provenance fence (a blockquote naming itself a historical/point-in-time record) is skipped
-  entirely; the report lists it as skipped.
-- **Aspirational claims**: a line ending in `<!-- aspirational: not yet in repo -->` (or prose
-  saying so) is exempt from identifier/path resolution — it documents intent, not current code.
+  provenance fence — a blockquote starting `**Frozen record**` or naming itself a
+  historical/point-in-time record — is skipped entirely; the report lists each skip with the
+  marker text it matched, so an accidental freeze is visible.
+- **Aspirational claims**: a line **ending in** `<!-- aspirational: not yet in repo -->` is exempt
+  from that line's checks — it documents intent, not current code. The marker is the only
+  recognized form; prose saying "aspirational" does not exempt anything (a mechanical gate can't
+  honor prose).
+- **Fenced code blocks**: localization-key and path checks are suppressed inside ``` fences
+  (example keys and illustrative paths are legitimate there), but identifier, npm-script, dotnet
+  category, and playwright project checks stay live — a fenced command or code sample presents
+  itself as real and readers execute it, so a nonexistent name in one is a finding, not noise.
 
 ## Step 1: Refresh reference state
 
@@ -38,13 +45,17 @@ git fetch origin main --quiet
 git -C "$(git rev-parse --show-toplevel)/../Paratext" rev-parse --short HEAD 2>/dev/null || echo "PT9 checkout absent — PT9-path checks will be skipped"
 ```
 
-All existence checks below run against `origin/main` (not the working tree), so results are
-meaningful on any branch.
+The sweep reads the **doc text from the working tree** (so a PR branch's added or edited content
+is what gets gated — run it from the branch you're gating) while all **existence checks** (paths,
+scripts, identifiers, keys) run against `origin/main`, so "does this exist" answers don't depend
+on your branch state.
 
 ## Step 2: Run the mechanical sweep
 
 Run this from the repo root. It is self-contained and read-only; it prints one `findings:` line
-per candidate issue, grouped by file at the end.
+per candidate issue, grouped by file at the end. **If the sweep prints `FATAL`, stop and report
+the failure to the caller — do not triage, do not tick checklist boxes; a failed run verifies
+nothing.**
 
 ```bash
 python3 - <<'EOF'
@@ -55,8 +66,13 @@ PT9 = os.path.normpath(os.path.join(REPO, "..", "Paratext"))
 SCOPE = [".context/standards", ".claude/rules", ".claude/skills", ".claude/agents", ".claude/commands", "CLAUDE.md"]
 
 def sh(args): return subprocess.run(args, capture_output=True, text=True).stdout
+def sh_ck(args):
+    r = subprocess.run(args, capture_output=True, text=True)
+    if r.returncode != 0: raise SystemExit(f"FATAL: {' '.join(args)} failed: {r.stderr.strip()[:200]}")
+    return r.stdout
 
-main_files = set(sh(["git", "-C", REPO, "ls-tree", "-r", "--name-only", "origin/main"]).splitlines())
+main_files = set(sh_ck(["git", "-C", REPO, "ls-tree", "-r", "--name-only", "origin/main"]).splitlines())
+if not main_files: raise SystemExit("FATAL: could not read origin/main - run `git fetch origin main` (check the remote name) and rerun")
 suffix = collections.defaultdict(list)
 for p in main_files: suffix[p.rsplit("/", 1)[-1]].append(p)
 pt9_files = set()
@@ -66,7 +82,7 @@ pt9_suffix = collections.defaultdict(list)
 for p in pt9_files: pt9_suffix[p.rsplit("/", 1)[-1]].append(p)
 
 scripts = set()
-for pkg in ["package.json", "extensions/package.json"] + [p for p in main_files if p.startswith("lib/") and p.endswith("/package.json") and p.count("/") == 2]:
+for pkg in ["package.json", "extensions/package.json"] + [p for p in main_files if p.startswith("lib/") and p.endswith("/package.json") and p.count("/") == 2] + [p for p in main_files if p.startswith("extensions/src/") and p.endswith("/package.json") and p.count("/") == 3]:
     if pkg in main_files:
         try: scripts |= set(json.loads(sh(["git", "-C", REPO, "show", f"origin/main:{pkg}"])).get("scripts", {}).keys())
         except Exception: pass
@@ -88,22 +104,31 @@ RE_LOC = re.compile(r'(%[A-Za-z0-9_.]+%)')
 RE_INFLIGHT = re.compile(r'not yet merged|in[- ]flight|unmerged|awaiting merge|pending merge', re.I)
 RE_PRREF = re.compile(r'(?:\bPR\s*#|pull/|[A-Za-z][A-Za-z0-9-]*#)(\d{2,5})\b')
 RE_DATE = re.compile(r'\b20\d\d-\d\d(?:-\d\d)?\b')
-RE_ASPIRATIONAL = re.compile(r'aspirational', re.I)
-RE_FROZEN = re.compile(r'Status:\s*frozen record|historical record|point-in-time (?:record|plan)', re.I)
+RE_ASPIRATIONAL = re.compile(r'<!--\s*aspirational:[^>]*-->\s*$')
+RE_FROZEN = re.compile(r'^\s*(?:>.*)?Status:\s*frozen record|^\s*>\s*\**(?:Frozen record|.*historical record|.*point-in-time (?:record|plan))', re.I | re.M)
 SKIP_TOKENS = {"TODO", "README", "LICENSE", "ROOT", "ARGUMENTS", "SLUG", "HEAD", "PATH", "URL", "PT9_MAP", "PT9_REFERENCES", "PRD_PATH", "ASPECTS", "PT9_CLAIMS", "DEPTH", "PT_REPOS_ROOT"}
 
-def is_frozen(text): return bool(RE_FROZEN.search("\n".join(text.splitlines()[:30])))
+def frozen_marker(text):
+    m = RE_FROZEN.search("\n".join(text.splitlines()[:30]))
+    return m.group(0).strip()[:60] if m else None
 
 findings, skipped = collections.defaultdict(list), []
-targets = [f for f in main_files if any(f == s or f.startswith(s + "/") for s in SCOPE) and f.endswith(".md")]
+wt_files = sh_ck(["git", "-C", REPO, "ls-files"]).splitlines()
+targets = [f for f in wt_files if any(f == s or f.startswith(s + "/") for s in SCOPE) and f.endswith(".md")]
+if not targets: raise SystemExit(f"FATAL: no in-scope .md files found under {SCOPE}")
+pr_refs = set()
 for rel in sorted(targets):
-    text = sh(["git", "-C", REPO, "show", f"origin/main:{rel}"])
-    if is_frozen(text): skipped.append(rel); continue
+    with open(os.path.join(REPO, rel), encoding="utf-8") as fh: text = fh.read()
+    fm = frozen_marker(text)
+    if fm: skipped.append(f'{rel} - matched "{fm}"'); continue
+    pr_refs |= set(int(n) for n in RE_PRREF.findall(text))
     in_fence = False
     for i, ln in enumerate(text.splitlines(), 1):
-        if ln.strip().startswith("```"): in_fence = not in_fence
+        if ln.strip().startswith("```"):
+            in_fence = not in_fence
+            continue
         if RE_ASPIRATIONAL.search(ln): continue
-        for m in RE_PATHTOK.finditer(ln):
+        for m in RE_PATHTOK.finditer(ln) if not in_fence else []:
             p = m.group(1).lstrip("./")
             if "*" in p or "{" in p or p.startswith("http"): continue
             if "path/to" in p or "hello-world" in p or p.startswith("foo/"): continue
@@ -116,16 +141,17 @@ for rel in sorted(targets):
         for m in RE_NPM.finditer(ln):
             if m.group(1) not in scripts:
                 findings[rel].append(f":{i} [npm] `npm run {m.group(1)}` not in any package.json")
-        for m in RE_LOC.finditer(ln):
+        for m in RE_LOC.finditer(ln) if not in_fence else []:
             if m.group(1) not in loc_keys:
                 findings[rel].append(f":{i} [l10n] key `{m.group(1)}` not in en.json or contributions")
-        if RE_INFLIGHT.search(ln) and not RE_DATE.search(ln):
+        if RE_INFLIGHT.search(ln) and RE_PRREF.search(ln) and not RE_DATE.search(ln):
             findings[rel].append(f":{i} [status] undated in-flight claim: {ln.strip()[:90]}")
         for m in RE_TICK.finditer(ln):
             tok = m.group(1).strip()
             if tok in SKIP_TOKENS or tok.islower() or len(tok) < 4: continue
             if tok.startswith("$") or re.fullmatch(r'[A-Z0-9_]+', tok): continue  # shell/template placeholders
-            if re.match(r'(Foo|Bar|Baz|Old|Other|Some|My|Example|Variant|Root)[A-Z]?', tok.rsplit(".", 1)[-1].rstrip("()")) and tok.rsplit(".", 1)[-1].rstrip("()") not in ("Root",): continue  # example-name convention
+            bare_tok = tok.rsplit(".", 1)[-1].rstrip("()")
+            if bare_tok in {"Old", "Other", "Some", "My", "Example", "Variant", "Root"} or re.fullmatch(r'(Foo|Bar|Baz)[A-Za-z]*', bare_tok): continue  # example-name convention
             if not RE_IDENT.match(tok): continue
             bare = tok.rstrip("()").rsplit(".", 1)[-1]
             if len(bare) < 4 or bare.islower(): continue
@@ -140,8 +166,7 @@ for rel in sorted(targets):
                 findings[rel].append(f":{i} [playwright] project `{m}` not in playwright-cdp.config.ts")
 
 print(f"scanned {len(targets)} files; skipped {len(skipped)} frozen records: {skipped}")
-prs = sorted({m for rel in targets for m in RE_PRREF.findall(sh(['git','-C',REPO,'show',f'origin/main:{rel}'])) if not is_frozen(sh(['git','-C',REPO,'show',f'origin/main:{rel}']))})
-print(f"PR refs to spot-check with gh (state vs claim): {prs}")
+print(f"PR refs to spot-check with gh (state vs claim): {sorted(pr_refs)}")
 for rel in sorted(findings):
     print(f"\n{rel}")
     for f in findings[rel]: print(f"  {f}")
@@ -175,7 +200,8 @@ The sweep favors precision but still produces noise. For each candidate:
 
 ## Completion checklist
 
-- [ ] `git fetch origin main` ran; checks were against `origin/main`, not the working tree
+- [ ] `git fetch origin main` ran; doc text was read from the working tree, existence checks ran
+      against `origin/main`
 - [ ] Sweep script ran to completion; frozen-record skips listed
 - [ ] Every PR reference spot-checked with `gh`
 - [ ] Findings triaged into misleads-agent / wrong-detail / cosmetic with evidence

--- a/.claude/commands/verify-standards.md
+++ b/.claude/commands/verify-standards.md
@@ -34,9 +34,13 @@ frozen records or pinned-snapshot corpora with their own provenance rules.
   recognized form; prose saying "aspirational" does not exempt anything (a mechanical gate can't
   honor prose).
 - **Fenced code blocks**: localization-key and path checks are suppressed inside ``` fences
-  (example keys and illustrative paths are legitimate there), but identifier, npm-script, dotnet
-  category, and playwright project checks stay live — a fenced command or code sample presents
-  itself as real and readers execute it, so a nonexistent name in one is a finding, not noise.
+  (example keys and illustrative paths are legitimate there). The **command** checks — npm script,
+  dotnet test category, and playwright project — match raw line text, so they stay live inside
+  fences: a fenced command presents itself as runnable and readers execute it, so a nonexistent
+  script, category, or project in one is a finding, not noise. The **identifier** check works
+  differently: it only fires on backticked tokens, and code inside a fence is not backticked, so
+  identifiers are checked wherever they are backticked — in practice, prose. An identifier that
+  appears only inside a fenced code sample is not checked at all.
 
 ## Step 1: Refresh reference state
 
@@ -96,9 +100,13 @@ for lf in [p for p in main_files if p == "assets/localization/en.json" or p.ends
     try: loc_keys |= set(re.findall(r'"(%[^"%]+%)"', sh(["git", "-C", REPO, "show", f"origin/main:{lf}"])))
     except Exception: pass
 
-pw_cfg = sh(["git", "-C", REPO, "show", "origin/main:e2e-tests/playwright-cdp.config.ts"])
+pw_cfg = sh_ck(["git", "-C", REPO, "show", "origin/main:e2e-tests/playwright.config.ts"])
 pw_projects = set(re.findall(r"name:\s*['\"]([^'\"]+)['\"]", pw_cfg))
 cats = set(re.findall(r'\[Category\("([^"]+)"\)\]', sh(["git", "-C", REPO, "grep", "-h", r"\[Category(", "origin/main", "--", "c-sharp-tests"])))
+# Both inventories gate their own check (`if cats and ...` / `if pw_projects and ...`), so an empty
+# one would silently disable it. Say so instead.
+for label, inv in (("dotnet test categories (c-sharp-tests)", cats), ("playwright projects (playwright.config.ts)", pw_projects)):
+    if not inv: print(f"WARN: {label} inventory is empty - that check is disabled this run")
 
 RE_PATHTOK = re.compile(r'(?<![\w/.])((?:[A-Za-z0-9_@-]+/)+[A-Za-z0-9_@.-]+\.[A-Za-z]{1,5})(?![\w/])')
 RE_TICK = re.compile(r'`([^`\n]{2,80})`')
@@ -122,7 +130,10 @@ targets = [f for f in wt_files if any(f == s or f.startswith(s + "/") for s in S
 if not targets: raise SystemExit(f"FATAL: no in-scope .md files found under {SCOPE}")
 pr_refs = set()
 for rel in sorted(targets):
-    with open(os.path.join(REPO, rel), encoding="utf-8") as fh: text = fh.read()
+    try:
+        with open(os.path.join(REPO, rel), encoding="utf-8") as fh: text = fh.read()
+    except FileNotFoundError:
+        raise SystemExit(f"FATAL: {rel} is tracked but missing from the working tree - commit, restore, or stash before running the gate")
     fm = frozen_marker(text)
     if fm: skipped.append(f'{rel} - matched "{fm}"'); continue
     pr_refs |= set(int(n) for n in RE_PRREF.findall(text))
@@ -165,9 +176,11 @@ for rel in sorted(targets):
         for cat in re.findall(r'--filter[= ]"?Category=([A-Za-z0-9]+)', ln):
             if cats and cat not in cats:
                 findings[rel].append(f":{i} [dotnet] test category `{cat}` not found in c-sharp-tests")
-        for m in re.findall(r'--project[= ]([A-Za-z0-9-]+)', ln):
-            if pw_projects and m not in pw_projects:
-                findings[rel].append(f":{i} [playwright] project `{m}` not in playwright-cdp.config.ts")
+        if "playwright test" in ln:  # `--project` is also tsc's and dotnet's flag - don't match those
+            for m in re.findall(r'--project[= ]([A-Za-z0-9-]+)', ln):
+                if pw_projects and m not in pw_projects:
+                    findings[rel].append(f":{i} [playwright] project `{m}` not in playwright.config.ts")
+    if in_fence: print(f"WARN: {rel} ends inside an unclosed fence - path/l10n checks were suppressed from the last ``` onward")
 
 print(f"scanned {len(targets)} files; skipped {len(skipped)} frozen records: {skipped}")
 print(f"PR refs to spot-check with gh (state vs claim): {sorted(pr_refs)}")

--- a/.claude/commands/verify-standards.md
+++ b/.claude/commands/verify-standards.md
@@ -1,0 +1,182 @@
+---
+description: Mechanically verify the repo's Claude-facing docs (.context/standards, .claude rules/skills/agents/commands, CLAUDE.md) against the live code — cited paths, identifiers, npm scripts, localization keys, status claims. Read-only; prints a findings report. Run before each epic's investigation phase and on any PR that adds standards content.
+---
+
+# Verify Standards
+
+Mechanically check every externally-verifiable claim in the repo's Claude-facing documentation
+against the live repo, and report what no longer (or never did) hold. **This command is read-only
+by design**: it never edits files, never posts to GitHub or Jira, and its output is a console
+report for the caller to act on.
+
+Why it exists: a staleness audit of this content found three rot classes — status claims that
+expire in days ("PR #x in flight"), line/identifier cites that drift with refactors, and claims
+that were never true at all. The first two need a re-verification cadence; the third needs a
+**generation-time gate**: new standards claims must pass this command, or carry an explicit
+aspirational marker (see "Exemptions").
+
+## Scope
+
+Checked: `.context/standards/**`, `.claude/rules/**`, `.claude/skills/**`, `.claude/agents/**`,
+`.claude/commands/**`, and the root `CLAUDE.md`.
+
+Not checked: `.context/research/**`, `.context/designs/**`, `.context/plans/**` — these are
+frozen records or pinned-snapshot corpora with their own provenance rules.
+
+## Exemptions
+
+- **Frozen records**: any in-scope file whose first 30 lines contain `Status: frozen record` or a
+  provenance fence (a blockquote naming itself a historical/point-in-time record) is skipped
+  entirely; the report lists it as skipped.
+- **Aspirational claims**: a line ending in `<!-- aspirational: not yet in repo -->` (or prose
+  saying so) is exempt from identifier/path resolution — it documents intent, not current code.
+
+## Step 1: Refresh reference state
+
+```bash
+git fetch origin main --quiet
+git -C "$(git rev-parse --show-toplevel)/../Paratext" rev-parse --short HEAD 2>/dev/null || echo "PT9 checkout absent — PT9-path checks will be skipped"
+```
+
+All existence checks below run against `origin/main` (not the working tree), so results are
+meaningful on any branch.
+
+## Step 2: Run the mechanical sweep
+
+Run this from the repo root. It is self-contained and read-only; it prints one `findings:` line
+per candidate issue, grouped by file at the end.
+
+```bash
+python3 - <<'EOF'
+import json, os, re, subprocess, collections
+
+REPO = subprocess.run(["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True).stdout.strip()
+PT9 = os.path.normpath(os.path.join(REPO, "..", "Paratext"))
+SCOPE = [".context/standards", ".claude/rules", ".claude/skills", ".claude/agents", ".claude/commands", "CLAUDE.md"]
+
+def sh(args): return subprocess.run(args, capture_output=True, text=True).stdout
+
+main_files = set(sh(["git", "-C", REPO, "ls-tree", "-r", "--name-only", "origin/main"]).splitlines())
+suffix = collections.defaultdict(list)
+for p in main_files: suffix[p.rsplit("/", 1)[-1]].append(p)
+pt9_files = set()
+if os.path.isdir(PT9):
+    pt9_files = set(sh(["git", "-C", PT9, "ls-files"]).splitlines())
+pt9_suffix = collections.defaultdict(list)
+for p in pt9_files: pt9_suffix[p.rsplit("/", 1)[-1]].append(p)
+
+scripts = set()
+for pkg in ["package.json", "extensions/package.json"] + [p for p in main_files if p.startswith("lib/") and p.endswith("/package.json") and p.count("/") == 2]:
+    if pkg in main_files:
+        try: scripts |= set(json.loads(sh(["git", "-C", REPO, "show", f"origin/main:{pkg}"])).get("scripts", {}).keys())
+        except Exception: pass
+
+loc_keys = set()
+for lf in [p for p in main_files if p == "assets/localization/en.json" or p.endswith("/contributions/localizedStrings.json")]:
+    try: loc_keys |= set(re.findall(r'"(%[^"%]+%)"', sh(["git", "-C", REPO, "show", f"origin/main:{lf}"])))
+    except Exception: pass
+
+pw_cfg = sh(["git", "-C", REPO, "show", "origin/main:e2e-tests/playwright-cdp.config.ts"])
+pw_projects = set(re.findall(r"name:\s*['\"]([^'\"]+)['\"]", pw_cfg))
+cats = set(re.findall(r'\[Category\("([^"]+)"\)\]', sh(["git", "-C", REPO, "grep", "-h", r"\[Category(", "origin/main", "--", "c-sharp-tests"])))
+
+RE_PATHTOK = re.compile(r'(?<![\w/.])((?:[A-Za-z0-9_@-]+/)+[A-Za-z0-9_@.-]+\.[A-Za-z]{1,5})(?![\w/])')
+RE_TICK = re.compile(r'`([^`\n]{2,80})`')
+RE_IDENT = re.compile(r'^[A-Za-z_$][A-Za-z0-9_$]*(?:\(\))?$|^[A-Za-z_$][A-Za-z0-9_$]*(?:\.[A-Za-z_$][A-Za-z0-9_$]*)+$')
+RE_NPM = re.compile(r'\bnpm run ([A-Za-z0-9:_-]+)')
+RE_LOC = re.compile(r'(%[A-Za-z0-9_.]+%)')
+RE_INFLIGHT = re.compile(r'not yet merged|in[- ]flight|unmerged|awaiting merge|pending merge', re.I)
+RE_PRREF = re.compile(r'(?:\bPR\s*#|pull/|[A-Za-z][A-Za-z0-9-]*#)(\d{2,5})\b')
+RE_DATE = re.compile(r'\b20\d\d-\d\d(?:-\d\d)?\b')
+RE_ASPIRATIONAL = re.compile(r'aspirational', re.I)
+RE_FROZEN = re.compile(r'Status:\s*frozen record|historical record|point-in-time (?:record|plan)', re.I)
+SKIP_TOKENS = {"TODO", "README", "LICENSE", "ROOT", "ARGUMENTS", "SLUG", "HEAD", "PATH", "URL", "PT9_MAP", "PT9_REFERENCES", "PRD_PATH", "ASPECTS", "PT9_CLAIMS", "DEPTH", "PT_REPOS_ROOT"}
+
+def is_frozen(text): return bool(RE_FROZEN.search("\n".join(text.splitlines()[:30])))
+
+findings, skipped = collections.defaultdict(list), []
+targets = [f for f in main_files if any(f == s or f.startswith(s + "/") for s in SCOPE) and f.endswith(".md")]
+for rel in sorted(targets):
+    text = sh(["git", "-C", REPO, "show", f"origin/main:{rel}"])
+    if is_frozen(text): skipped.append(rel); continue
+    in_fence = False
+    for i, ln in enumerate(text.splitlines(), 1):
+        if ln.strip().startswith("```"): in_fence = not in_fence
+        if RE_ASPIRATIONAL.search(ln): continue
+        for m in RE_PATHTOK.finditer(ln):
+            p = m.group(1).lstrip("./")
+            if "*" in p or "{" in p or p.startswith("http"): continue
+            if "path/to" in p or "hello-world" in p or p.startswith("foo/"): continue
+            base = p.rsplit("/", 1)[-1]
+            if any(seg in p for seg in ("Paratext/", "ParatextData/", "ParatextBase/", "PtxUtils/")) and pt9_files:
+                if p not in pt9_files and base not in pt9_suffix:
+                    findings[rel].append(f":{i} [path/PT9] `{p}` not in PT9 checkout")
+            elif p not in main_files and base not in suffix and not p.startswith(("temp-", "node_modules", "release/", "dist/")):
+                findings[rel].append(f":{i} [path] `{p}` not on origin/main")
+        for m in RE_NPM.finditer(ln):
+            if m.group(1) not in scripts:
+                findings[rel].append(f":{i} [npm] `npm run {m.group(1)}` not in any package.json")
+        for m in RE_LOC.finditer(ln):
+            if m.group(1) not in loc_keys:
+                findings[rel].append(f":{i} [l10n] key `{m.group(1)}` not in en.json or contributions")
+        if RE_INFLIGHT.search(ln) and not RE_DATE.search(ln):
+            findings[rel].append(f":{i} [status] undated in-flight claim: {ln.strip()[:90]}")
+        for m in RE_TICK.finditer(ln):
+            tok = m.group(1).strip()
+            if tok in SKIP_TOKENS or tok.islower() or len(tok) < 4: continue
+            if tok.startswith("$") or re.fullmatch(r'[A-Z0-9_]+', tok): continue  # shell/template placeholders
+            if re.match(r'(Foo|Bar|Baz|Old|Other|Some|My|Example|Variant|Root)[A-Z]?', tok.rsplit(".", 1)[-1].rstrip("()")) and tok.rsplit(".", 1)[-1].rstrip("()") not in ("Root",): continue  # example-name convention
+            if not RE_IDENT.match(tok): continue
+            bare = tok.rstrip("()").rsplit(".", 1)[-1]
+            if len(bare) < 4 or bare.islower(): continue
+            hits = subprocess.run(["git", "-C", REPO, "grep", "-l", "-m", "1", bare, "origin/main", "--", "src", "lib", "extensions/src", "c-sharp", "c-sharp-tests", "e2e-tests"], capture_output=True, text=True)
+            if hits.returncode != 0 and (not pt9_files or subprocess.run(["git", "-C", PT9, "grep", "-l", "-m", "1", bare], capture_output=True).returncode != 0):
+                findings[rel].append(f":{i} [ident] `{tok}` grep-resolves nowhere")
+        for cat in re.findall(r'--filter[= ]"?Category=([A-Za-z0-9]+)', ln):
+            if cats and cat not in cats:
+                findings[rel].append(f":{i} [dotnet] test category `{cat}` not found in c-sharp-tests")
+        for m in re.findall(r'--project[= ]([A-Za-z0-9-]+)', ln):
+            if pw_projects and m not in pw_projects:
+                findings[rel].append(f":{i} [playwright] project `{m}` not in playwright-cdp.config.ts")
+
+print(f"scanned {len(targets)} files; skipped {len(skipped)} frozen records: {skipped}")
+prs = sorted({m for rel in targets for m in RE_PRREF.findall(sh(['git','-C',REPO,'show',f'origin/main:{rel}'])) if not is_frozen(sh(['git','-C',REPO,'show',f'origin/main:{rel}']))})
+print(f"PR refs to spot-check with gh (state vs claim): {prs}")
+for rel in sorted(findings):
+    print(f"\n{rel}")
+    for f in findings[rel]: print(f"  {f}")
+total = sum(len(v) for v in findings.values())
+print(f"\n{total} candidate findings")
+EOF
+```
+
+## Step 3: Triage the candidates
+
+The sweep favors precision but still produces noise. For each candidate:
+
+1. Read the cited line in context. Discard prose false-positives (a backticked English word, a
+   deliberately hypothetical path in an example) — but if an example *presents itself as real
+   code*, a nonexistent identifier is a finding, not noise.
+2. For each PR reference the sweep lists, check the claimed state against reality with
+   `gh pr view <n> --repo paranext/paranext-core --json state,mergedAt` — a doc saying
+   "in flight"/"not yet merged" about a merged PR is a finding.
+3. Classify each surviving finding: **misleads-agent** (an agent following the doc does the wrong
+   thing), **wrong-detail** (factually off, recoverable), or **cosmetic**.
+4. Report the findings grouped by file, most severe first, with the live-code evidence per
+   finding. **Do not edit any files** — hand the report to the caller to decide fixes.
+
+## Cadence (the generation-time gate)
+
+- Run this before each epic's investigation phase (`/investigate-prd` consumes these docs — stale
+  standards produce confidently wrong briefs).
+- Run it on any PR that adds or edits standards/rules/skills content: **new claims must come out
+  clean, or carry the aspirational marker**. Never-true claims are the one rot class no
+  maintenance cadence can catch later.
+
+## Completion checklist
+
+- [ ] `git fetch origin main` ran; checks were against `origin/main`, not the working tree
+- [ ] Sweep script ran to completion; frozen-record skips listed
+- [ ] Every PR reference spot-checked with `gh`
+- [ ] Findings triaged into misleads-agent / wrong-detail / cosmetic with evidence
+- [ ] No files modified, nothing posted

--- a/.claude/commands/verify-standards.md
+++ b/.claude/commands/verify-standards.md
@@ -1,5 +1,5 @@
 ---
-description: Mechanically verify the repo's Claude-facing docs (.context/standards, .claude rules/skills/agents/commands, CLAUDE.md) against the live code — cited paths, identifiers, npm scripts, localization keys, status claims. Read-only; prints a findings report. Run before each epic's investigation phase and on any PR that adds standards content.
+description: Mechanically verify the repo's Claude-facing docs (.context/standards, .claude rules/skills/agents/commands, CLAUDE.md) against the live code — cited paths, identifiers, npm scripts, dotnet test categories, playwright projects, localization keys, status claims. Read-only; prints a findings report. Run before each epic's investigation phase and on any PR that adds standards content.
 ---
 
 # Verify Standards
@@ -33,14 +33,16 @@ frozen records or pinned-snapshot corpora with their own provenance rules.
   from that line's checks — it documents intent, not current code. The marker is the only
   recognized form; prose saying "aspirational" does not exempt anything (a mechanical gate can't
   honor prose).
-- **Fenced code blocks**: localization-key and path checks are suppressed inside ``` fences
-  (example keys and illustrative paths are legitimate there). The **command** checks — npm script,
-  dotnet test category, and playwright project — match raw line text, so they stay live inside
-  fences: a fenced command presents itself as runnable and readers execute it, so a nonexistent
-  script, category, or project in one is a finding, not noise. The **identifier** check works
-  differently: it only fires on backticked tokens, and code inside a fence is not backticked, so
-  identifiers are checked wherever they are backticked — in practice, prose. An identifier that
-  appears only inside a fenced code sample is not checked at all.
+- **Fenced code blocks**: inside ``` fences only the localization-key and path checks are
+  suppressed (example keys and illustrative paths are legitimate there); every other check is
+  fence-blind. The **command** checks — npm script, dotnet test category, playwright project — and
+  the **undated in-flight status** check match raw line text, so they stay live inside fences: a
+  fenced command presents itself as runnable and readers execute it, so a nonexistent script,
+  category, or project in one is a finding, not noise. The **identifier** check is not
+  fence-suppressed either, but it fires only on **backticked** tokens, so what it actually sees is
+  prose *and* backticks nested inside a fence — report templates, checklists, and code comments
+  that quote a symbol are checked exactly like prose. Plain unbackticked code inside a fence is the
+  one thing it never sees.
 
 ## Step 1: Refresh reference state
 
@@ -60,10 +62,14 @@ on your branch state.
 
 ## Step 2: Run the mechanical sweep
 
-Run this from the repo root. It is self-contained and read-only; it prints one `findings:` line
-per candidate issue, grouped by file at the end. **If the sweep prints `FATAL`, stop and report
-the failure to the caller — do not triage, do not tick checklist boxes; a failed run verifies
-nothing.**
+Run this from the repo root. It is self-contained and read-only: it prints a scan summary and the
+PR references to spot-check, then one indented `:line [check] message` entry per candidate grouped
+under its file, then a total count. **If the sweep prints `FATAL`, stop and report the failure to
+the caller — do not triage, do not tick checklist boxes; a failed run verifies nothing.** **If it
+prints a `WARN:` line, carry that warning into the report** — a warning means an inventory came
+back empty and its check was disabled for this run, or a file ended inside an unclosed fence and
+its path/l10n checks were suppressed from that point on. The sweep still finishes and exits 0, but
+it did not cover everything it claims to, so a run with warnings is not a clean pass.
 
 ```bash
 python3 - <<'EOF'
@@ -220,6 +226,8 @@ The sweep favors precision but still produces noise. For each candidate:
 - [ ] `git fetch origin main` succeeded (or its staleness WARN is carried into the report); doc
       text was read from the working tree, existence checks ran against `origin/main`
 - [ ] Sweep script ran to completion; frozen-record skips listed
+- [ ] No `WARN:` lines — or each one (disabled check, file left inside an unclosed fence) is
+      carried into the report as a coverage gap, not silently passed
 - [ ] Every PR reference spot-checked with `gh`
 - [ ] Findings triaged into misleads-agent / wrong-detail / cosmetic with evidence
 - [ ] No files modified, nothing posted

--- a/.claude/commands/verify-standards.md
+++ b/.claude/commands/verify-standards.md
@@ -41,9 +41,13 @@ frozen records or pinned-snapshot corpora with their own provenance rules.
 ## Step 1: Refresh reference state
 
 ```bash
-git fetch origin main --quiet
+git fetch origin main --quiet \
+  || echo "WARN: fetch failed — existence checks will run against the last-fetched origin/main from $(git log -1 --format=%cs origin/main 2>/dev/null || echo 'unknown date'); results may be stale"
 git -C "$(git rev-parse --show-toplevel)/../Paratext" rev-parse --short HEAD 2>/dev/null || echo "PT9 checkout absent — PT9-path checks will be skipped"
 ```
+
+If the fetch prints its WARN, carry that caveat into the final report — the sweep still runs,
+but every existence check is only as fresh as that date.
 
 The sweep reads the **doc text from the working tree** (so a PR branch's added or edited content
 is what gets gated — run it from the branch you're gating) while all **existence checks** (paths,
@@ -200,8 +204,8 @@ The sweep favors precision but still produces noise. For each candidate:
 
 ## Completion checklist
 
-- [ ] `git fetch origin main` ran; doc text was read from the working tree, existence checks ran
-      against `origin/main`
+- [ ] `git fetch origin main` succeeded (or its staleness WARN is carried into the report); doc
+      text was read from the working tree, existence checks ran against `origin/main`
 - [ ] Sweep script ran to completion; frozen-record skips listed
 - [ ] Every PR reference spot-checked with `gh`
 - [ ] Findings triaged into misleads-agent / wrong-detail / cosmetic with evidence

--- a/.context/standards/Testing-Guide.md
+++ b/.context/standards/Testing-Guide.md
@@ -1330,8 +1330,11 @@ npx playwright test e2e-tests/tests/{feature}/ --config=e2e-tests/playwright-cdp
 npx playwright test e2e-tests/tests/{feature}/ --config=e2e-tests/playwright-cdp.config.ts --reporter=html
 npx playwright show-report e2e-tests/playwright-report
 
-# Standalone mode (CI — launches own Electron, port 8876 must be free)
-npx playwright test e2e-tests/tests/{feature}/ --config=e2e-tests/playwright.config.ts --project=development --reporter=list
+# Standalone mode (launches its own Electron, port 8876 must be free). Each project in
+# playwright.config.ts has its own testDir, so path-filter inside it: `isolated` →
+# tests/isolated/** (most feature tests), `smoke` → tests/smoke/** (what CI runs, via
+# `npm run test:e2e:smoke`), `enhanced-resources` → tests/enhanced-resources/**.
+npx playwright test e2e-tests/tests/isolated/{feature}/ --config=e2e-tests/playwright.config.ts --project=isolated --reporter=list
 ```
 
 ### Failure Analysis

--- a/.context/standards/Testing-Guide.md
+++ b/.context/standards/Testing-Guide.md
@@ -952,16 +952,11 @@ For more thorough invariant verification with random input generation, see [Prop
 
 ## Test Categorization
 
-Test categorization enables fast feedback during development by running subsets of tests based on speed requirements.
+Test categorization enables fast feedback during development: run the subset of tests that covers what you just changed instead of the whole suite.
 
 ### Categories
 
-| Category        | Time Budget | When to Run     | Scope               |
-| --------------- | ----------- | --------------- | ------------------- |
-| **Smoke**       | < 10s       | After each edit | Core functionality  |
-| **Critical**    | < 60s       | Every 3–5 edits | Feature tests       |
-| **Full**        | < 5 min     | Before commit   | Complete suite      |
-| **Integration** | No limit    | CI only         | Cross-process tests |
+C# categories describe **what a test verifies**, not a speed tier. The ones that exist in `c-sharp-tests/` are `Contract` (API/behavior contracts — the bulk of the suite), `Acceptance`, `GoldenMaster`, `Integration`, `Critical`, `Invariant`, `Regression`, `EdgeCase`, `Infrastructure`, `ErrorPath`, and `DiskVerification`. There is no `Smoke`, `Full`, `Unit`, `Fast`, or `Slow` category — confirm a name with `git grep '\[Category(' c-sharp-tests/` before filtering on it. `.claude/skills/test-runner/categories.md` documents what each category covers and the full filter syntax; during TDD the useful order is `Contract`, then `Integration`, then `Acceptance`, then the whole suite.
 
 ### Tagging Tests
 
@@ -969,7 +964,7 @@ Test categorization enables fast feedback during development by running subsets 
 
 ```csharp
 [Test]
-[Category("Smoke")]
+[Category("Contract")]
 public void BasicOperation_Works() { }
 
 [Test]
@@ -990,11 +985,11 @@ describe.concurrent('Smoke tests', () => {
 ### Running by Category
 
 ```bash
-# C# — run only smoke tests
-dotnet test --filter "Category=Smoke"
+# C# — run one category (there is no root solution, so name the test project)
+dotnet test c-sharp-tests/ --filter "Category=Critical"
 
 # TypeScript — run a specific test name pattern
-npm test -- --testNamePattern="Smoke"
+npm run test:core -- --run -t "Smoke"
 ```
 
 ---

--- a/.context/standards/Testing-Guide.md
+++ b/.context/standards/Testing-Guide.md
@@ -978,8 +978,6 @@ public void ImportantFeature_HandlesEdgeCase() { }
 describe.concurrent('Smoke tests', () => {
   test('basic operation works', () => {});
 });
-
-// Or use file naming: feature.smoke.test.ts, feature.critical.test.ts
 ```
 
 ### Running by Category


### PR DESCRIPTION
## Motivation

A staleness audit of #2438's content (153 files, ~5,700 externally-verifiable claims) found three distinct rot classes:

1. **Status claims** ("PR #x in flight") — 100% of tracked instances had already expired
2. **Line/identifier cites** — drift with every refactor (42% of the PT9 inventory's line-cites already point into changed files)
3. **Never-true claims** — fabricated tooling/keys/thresholds that no maintenance cadence can catch later

This command is the enforcement engine for all three: a read-only mechanical sweep verifying cited repo paths, backticked code identifiers, `npm run` scripts, `%localization%` keys, in-flight status phrases, and playwright/dotnet test-config names against `origin/main` — with exemptions for frozen-record files and explicitly-aspirational claims.

**Cadence:** run before each epic's investigation phase (stale standards produce confidently wrong briefs), and on any PR adding standards content — the generation-time gate that keeps never-true claims from landing.

Test-run output re-finds the audit's confirmed fabrications (Stryker config, `test:mutation` scripts, phantom `%general_save%` keys, renamed `s_paratextProjectInterfaces`) with low noise.

Stacked on #2438 (`ai/investigate-prd-command`); rebases onto main after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qu9i2XxnVHwSHrc4W5vTic

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2627)
<!-- Reviewable:end -->


## Fix round (2026-08-04)

All 11 review items addressed in `45217b6d6d0` + `106d290bee5`:

- **1 (gate reads origin/main)** — fixed: doc text now reads from the working tree (`git ls-files` + file reads), existence checks stay on `origin/main`; Step 1 prose and the completion checklist now state this split, plus a "run from the branch you're gating" note. Verified: the sweep now scans this branch's own files (75 vs main's 74).
- **2 (silent failure)** — fixed: checked `sh_ck` for reference lookups, `FATAL` + exit 1 on unresolvable `origin/main` or empty scope (reproduced in test), and Step 2 instructs the runner to stop and report on `FATAL` rather than triaging.
- **3 (dead fence guard)** — fixed with the narrower policy, now documented in Exemptions: localization-key and path checks are suppressed inside fences; identifier, npm, dotnet, and playwright checks stay live (fenced commands are recipes readers execute, per Step 3's own instruction).
- **4 (hash sort)** — fixed: the probe extracts dates and takes the **oldest** stamp (weakest-link risk), not the newest.
- **5 (empty grep undefined)** — fixed: scope widened to all stamped surfaces + `CLAUDE.md`, and an empty result is a spelled-out "treat as unverified" warning.
- **6 (aspirational too broad)** — fixed: trailing `<!-- aspirational: … -->` marker only; the "(or prose saying so)" escape removed from the contract.
- **7 (unanchored example filter)** — fixed: exact-set match (`Old/Other/Some/My/Example/Variant/Root`) + `fullmatch` on `Foo|Bar|Baz` stems.
- **8 (in-flight prose FP)** — fixed: a status finding now requires a PR reference on the line; the `CLAUDE.md` write-gate false positive is gone.
- **9 (npm inventory)** — fixed: `extensions/src/*/package.json` included.
- **10 (frozen regex)** — fixed **with one deviation from the suggested patch**: the alternation also anchors the repo's actual canonical fence form (`> **Frozen record** — …`, the form `docs-durability.md` prescribes), which the suggested regex missed; skips now print the matched marker text.
- **11 (double-read + string sort)** — fixed: PR refs are collected from the in-hand text in the main loop and int-sorted; no per-match re-reads.

Measured on identical main-scope input: 150 → 91 candidates (fence/prose false-positive classes eliminated); wall-clock ~unchanged (identifier greps dominate — the eliminated per-ref re-reads were not the bottleneck).




**Addendum (2026-08-04, `f72b24307e5`):** the fetch line's exit status (the second half of review item 2) is now surfaced — a failed fetch over an existing stale `origin/main` prints a dated staleness WARN carried into the report and checklist.


## Squash message

Curated per `/squash-message` (review item 7/7) — paste over GitHub's pre-filled text when squash-merging. The retracted runtime claim is excluded; the fix-round "150 → 91 candidates" measurement is also left out as journey-not-merged-state (say the word to restore it as a bullet).

```text
Add /verify-standards, a read-only mechanical sweep that gates the
working tree's standards corpus — cited repo paths, backticked code
identifiers, npm scripts, dotnet test-category names, playwright
project names, localization keys, and undated in-flight status
claims — against origin/main. Existence checks (does this
path/identifier/config name actually exist) run against origin/main;
the doc text being checked is read from the working tree, so a PR's
own edits get gated, not just main. Cadence: before each epic's
investigation phase, and as the generation-time gate on PRs that add
standards content.

/investigate-prd gains a companion standards-freshness preflight
probe: it surfaces the oldest verification stamp across all stamped
surfaces (not the newest, and not a raw commit-hash sort) and
separately names any surface — .claude/rules, .claude/agents,
.claude/commands, CLAUDE.md — that has never been stamped at all,
so one fresh-looking date can't hide an unchecked surface. It
suggests running /verify-standards once the oldest stamp is older
than ~30 days.

A few invariants maintainers should know:
- An unresolvable reference or an empty verification scope FATALs
  the run and stops rather than reporting a false-clean pass; a
  disabled or empty check (no dotnet categories found, no playwright
  projects found) WARNs and announces itself instead of silently
  turning off, and the runner protocol carries WARNs as coverage
  gaps rather than clean passes. A failed fetch against a stale
  origin/main also WARNs, dated to the ref's last-fetched time.
- A fence guard suppresses localization-key and path checks inside
  fenced code blocks (those are recipes, not prose claims) while
  the npm-script, dotnet-category, playwright-project, and
  status checks stay live there; the identifier check fires on
  backticked tokens wherever they appear, including inside fences.
- Frozen-record files and explicitly-aspirational claims (marked
  with a trailing HTML comment) are exempted; an in-flight status
  claim is only flagged when its line lacks a PR reference.

Running the sweep against the standards corpus itself caught live
rot in Testing-Guide.md, fixed here:
- a playwright invocation citing `--project=development`, which has
  never existed in e2e-tests/playwright.config.ts — corrected to
  `isolated`, the standalone per-feature project the example
  actually describes.
- an invented Smoke/Critical/Full/Integration C# test-category
  scheme with time budgets nothing ever measured — replaced with the
  11 categories that actually exist in c-sharp-tests, pointing at
  .claude/skills/test-runner/categories.md instead of duplicating
  it, with corrected `dotnet test` / `npm run test:core` invocations
  and an invented feature.smoke.test.ts file-naming convention
  (consumed by nothing on main) removed.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qu9i2XxnVHwSHrc4W5vTic
```
