### PR TITLE
Fix vitest browser-mode hang: bound Playwright temp-profile cleanup

### DIFF
--- a/patches/playwright-core+1.58.2.patch
+++ b/patches/playwright-core+1.58.2.patch
@@ -1,0 +1,50 @@
+diff --git a/node_modules/playwright-core/lib/server/utils/fileUtils.js b/node_modules/playwright-core/lib/server/utils/fileUtils.js
+index 1891d37..47e1491 100644
+--- a/node_modules/playwright-core/lib/server/utils/fileUtils.js
++++ b/node_modules/playwright-core/lib/server/utils/fileUtils.js
+@@ -48,9 +48,42 @@ async function mkdirIfNeeded(filePath) {
+   });
+ }
+ async function removeFolders(dirs) {
+-  return await Promise.all(dirs.map(
+-    (dir) => import_fs.default.promises.rm(dir, { recursive: true, force: true, maxRetries: 10 }).catch((e) => e)
+-  ));
++  return await Promise.all(dirs.map((dir) => removeFolderBounded(dir)));
++}
++async function removeFolderBounded(dir) {
++  // PATCH(paranext-core): node's recursive fs.rm retries "retryable" errors (EPERM,
++  // EBUSY, ENOTEMPTY, ...) at EVERY level of the tree it walks, so a non-zero
++  // `maxRetries` multiplies out to roughly retries^depth attempts with backoff.
++  //
++  // On Windows, Chromium leaves `Default/Shared Dictionary/cache` inside its temp
++  // profile with an AppContainer (LPAC) DACL that grants access only to a capability
++  // SID -- the owning user cannot even list it, so scandir on it always fails with
++  // EPERM and no amount of waiting will change that. With the original
++  // `maxRetries: 10` that turns cleanup into an effectively infinite retry loop:
++  // fs.rm never settles, its pending timers keep the event loop referenced, and the
++  // node process never exits. That is what hangs `vitest --project=storybook` (and
++  // therefore `npm test`) forever after every test has already passed.
++  //
++  // Use `maxRetries: 0` so node fails fast instead of recursing into that loop, and
++  // do our own bounded, linear retry to keep the resilience the original intended
++  // for genuinely transient locks (a browser process still releasing its handles).
++  // A permission denial is returned rather than retried -- it cannot become
++  // permitted by waiting, and callers already treat a returned Error as non-fatal.
++  const maxAttempts = 5;
++  const retryDelayMs = 150;
++  let lastError;
++  for (let attempt = 0; attempt < maxAttempts; attempt++) {
++    try {
++      await import_fs.default.promises.rm(dir, { recursive: true, force: true, maxRetries: 0 });
++      return void 0;
++    } catch (error) {
++      lastError = error;
++      if (error && (error.code === "EPERM" || error.code === "EACCES"))
++        return error;
++      await new Promise((resolve) => setTimeout(resolve, retryDelayMs * (attempt + 1)));
++    }
++  }
++  return lastError;
+ }
+ function canAccessFile(file) {
+   if (!file)


### PR DESCRIPTION
## Summary

`npm test` never exited on Windows. Every test passed and the summary printed, but the
vitest process sat forever — most visibly in the `platform-bible-react` `storybook`
project, which runs in Playwright/Chromium browser mode. Killing it was the only way out,
so browser-mode tests could not be run locally at all.

This adds a `patch-package` patch to `playwright-core` that makes its temp-directory
cleanup fail fast instead of retrying forever.

### Why review this

Not part of the current epic — local developer-environment fix. It is worth reviewer time
now because it currently blocks running the full test suite locally on Windows: the only
workaround is to skip the `storybook` project, which means browser-mode tests get no local
coverage before pushing. CI was unaffected and stayed green throughout.

## Root cause

Traced with `async_hooks` handle instrumentation. After tests finish, the vitest main
thread holds no sockets, no server and no child process — only ref'd timers, whose
creation stacks point into `node:internal/fs/rimraf`, reached from playwright's
`removeFolders()`:

```js
fs.promises.rm(dir, { recursive: true, force: true, maxRetries: 10 })
```

The directory is Chromium's temp profile. Inside it, Chromium creates
`Default/Shared Dictionary/cache` with an AppContainer (LPAC) DACL that grants access only
to a capability SID — the owning user is not in the ACL, so `scandir` on it fails with
`EPERM` **permanently**, not transiently. Even `Remove-Item -Recurse -Force` cannot delete it.

Node's recursive `rm` retries retryable errors (`EPERM`, `EBUSY`, `ENOTEMPTY`, ...) at
*every level* of the tree it walks, so `maxRetries` multiplies out to roughly
`retries^depth` attempts with backoff. Measured against that directory:

| `maxRetries` | Result |
| --- | --- |
| 0 | rejects in 5 ms |
| 1 | rejects in 1.7 s |
| 3 | still pending at 12 s |
| 10 (playwright's value) | effectively never settles |

Because `fs.rm` never settles, its pending timers keep the event loop referenced and node
can never exit.

This is not specific to any test. It reproduces with zero test files — a plain script that
launches Chromium and closes it hangs, and so does a plain `fs.rm()` on a leftover temp
profile with no browser involved.

## Changes

- `patches/playwright-core+1.58.2.patch` — `removeFolders()` now uses `maxRetries: 0` and
  performs its own bounded, linear retry (5 attempts, fixed delays). Transient locks are
  still retried; a permission denial returns immediately. The undeletable directory is left
  on disk, which is already the status quo — these temp profiles leak on every run today,
  they just used to hang the process on the way out.

## AI Involvement

AI-assisted — [session 1](https://claude.ai/code/session_01GefezahRQrPKXiLcxYwG7L)

Claude Code performed the root-cause investigation (handle/timer instrumentation, minimal
repro reduction, `maxRetries` measurements) and drafted the patch. All findings were
reproduced from logged evidence, and the diagnosis was verified end-to-end before and after
the change. Reviewed by the author.

## Testing

- [x] Minimal Playwright launch/close harness: exits in ~1s (previously killed at 45s)
- [x] `vitest run --project=storybook`: 89 files / 528 tests pass, exit 0, ~3 min
- [x] Full `npm test`: runs to completion in ~6 min (comparable to CI's 5m04s)
- [x] `npm run lint`: 0 errors
- [x] All 5 patches apply cleanly to pristine source via `postinstall`

Not fixed here, and pre-existing/unrelated: `npm test` still exits 1 locally because 15
`eslint-plugin-paranext` rule tests time out at 5000 ms under parallel load. They pass
16/16 in isolation on unpatched `main`, and CI is green.

Rejected alternatives: Chromium flags (`--no-sandbox`,
`--disable-features=NetworkServiceSandbox`, `--disable-features=CompressionDictionaryTransport`)
were each tested and **all still hung** — the ACL'd directory is created regardless.
Force-exiting vitest was rejected as masking the problem.

## Risk Level

Low — the patch touches only temp-directory cleanup, whose errors callers already swallow
as non-fatal. The behavioural difference is that a transient lock now gets ~1.5 s of linear
retries instead of playwright's longer compounding backoff; worst case is a leaked temp
directory, which already happens today.

Upstream reports to Playwright (and possibly Node) are drafted separately; this patch can
be dropped once a fixed `playwright-core` ships.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2628)
<!-- Reviewable:end -->
