### PR TITLE
PT-4021: Sync \li/\lim gutter indent CSS into _usj-nodes.scss + coverage test

### DIFF
--- a/extensions/src/platform-scripture-editor/src/_usj-nodes.scss
+++ b/extensions/src/platform-scripture-editor/src/_usj-nodes.scss
@@ -2569,14 +2569,16 @@ span.read img {
 }
 
 /* Indent compensation — mirrors the margin-left values above.
-   Only active when .text-spacing is present (same condition as the source rules). */
+   Only active when .text-spacing is present (same condition as the source rules).
+   pi2 and pi3 use the same primary-indent value in both LTR and RTL (10vw and 15vw
+   respectively), so no direction restriction is needed here. */
 .psc-gutter-markers.text-spacing .usfm_io,
 .psc-gutter-markers.text-spacing .usfm_io1,
 .psc-gutter-markers.text-spacing .usfm_ili,
 .psc-gutter-markers.text-spacing .usfm_ili1,
 .psc-gutter-markers.text-spacing .usfm_li,
 .psc-gutter-markers.text-spacing .usfm_li1,
-.psc-gutter-markers.text-spacing[dir='ltr'] .usfm_pi2 {
+.psc-gutter-markers.text-spacing .usfm_pi2 {
   --para-indent: 10vw;
 }
 .psc-gutter-markers.text-spacing .usfm_q,
@@ -2589,7 +2591,7 @@ span.read img {
 .psc-gutter-markers.text-spacing .usfm_li2,
 .psc-gutter-markers.text-spacing .usfm_lim,
 .psc-gutter-markers.text-spacing .usfm_lim1,
-.psc-gutter-markers.text-spacing[dir='ltr'] .usfm_pi3 {
+.psc-gutter-markers.text-spacing .usfm_pi3 {
   --para-indent: 15vw;
 }
 .psc-gutter-markers.text-spacing .usfm_qm,

--- a/extensions/src/platform-scripture-editor/src/_usj-nodes.scss
+++ b/extensions/src/platform-scripture-editor/src/_usj-nodes.scss
@@ -1,4 +1,7 @@
-/* Copied from https://github.com/eten-tech-foundation/scripture-editors/blob/ba0e846b3f11bea5720c4aa1a3486b69feb6b7e0/packages/platform/src/usj-nodes.css */
+/* Based on https://github.com/eten-tech-foundation/scripture-editors/packages/platform/src/usj-nodes.css
+   (originally synced from commit ba0e846b3f1). Local additions: li/lim --para-indent and
+   --verse-text-start entries in .psc-gutter-markers.text-spacing, mirroring scripture-editors
+   commit 846ad99 (PT-4021 \li/\lim gutter overlap fix). */
 
 /* stylelint-disable */
 
@@ -2567,6 +2570,8 @@ span.read img {
 .psc-gutter-markers.text-spacing .usfm_io1,
 .psc-gutter-markers.text-spacing .usfm_ili,
 .psc-gutter-markers.text-spacing .usfm_ili1,
+.psc-gutter-markers.text-spacing .usfm_li,
+.psc-gutter-markers.text-spacing .usfm_li1,
 .psc-gutter-markers.text-spacing[dir='ltr'] .usfm_pi2 {
   --para-indent: 10vw;
 }
@@ -2577,16 +2582,26 @@ span.read img {
 .psc-gutter-markers.text-spacing .usfm_q4,
 .psc-gutter-markers.text-spacing .usfm_io2,
 .psc-gutter-markers.text-spacing .usfm_ili2,
+.psc-gutter-markers.text-spacing .usfm_li2,
+.psc-gutter-markers.text-spacing .usfm_lim,
+.psc-gutter-markers.text-spacing .usfm_lim1,
 .psc-gutter-markers.text-spacing[dir='ltr'] .usfm_pi3 {
   --para-indent: 15vw;
 }
 .psc-gutter-markers.text-spacing .usfm_qm,
 .psc-gutter-markers.text-spacing .usfm_qm1,
-.psc-gutter-markers.text-spacing .usfm_io3 {
+.psc-gutter-markers.text-spacing .usfm_io3,
+.psc-gutter-markers.text-spacing .usfm_li3,
+.psc-gutter-markers.text-spacing .usfm_lim2 {
   --para-indent: 20vw;
 }
-.psc-gutter-markers.text-spacing .usfm_io4 {
+.psc-gutter-markers.text-spacing .usfm_io4,
+.psc-gutter-markers.text-spacing .usfm_li4,
+.psc-gutter-markers.text-spacing .usfm_lim3 {
   --para-indent: 25vw;
+}
+.psc-gutter-markers.text-spacing .usfm_lim4 {
+  --para-indent: 30vw;
 }
 .psc-gutter-markers.text-spacing .usfm_ipi,
 .psc-gutter-markers.text-spacing .usfm_imi,
@@ -2629,7 +2644,17 @@ span.read img {
 }
 .psc-gutter-markers.text-spacing .usfm_ili,
 .psc-gutter-markers.text-spacing .usfm_ili1,
-.psc-gutter-markers.text-spacing .usfm_ili2 {
+.psc-gutter-markers.text-spacing .usfm_ili2,
+.psc-gutter-markers.text-spacing .usfm_li,
+.psc-gutter-markers.text-spacing .usfm_li1,
+.psc-gutter-markers.text-spacing .usfm_li2,
+.psc-gutter-markers.text-spacing .usfm_li3,
+.psc-gutter-markers.text-spacing .usfm_li4,
+.psc-gutter-markers.text-spacing .usfm_lim,
+.psc-gutter-markers.text-spacing .usfm_lim1,
+.psc-gutter-markers.text-spacing .usfm_lim2,
+.psc-gutter-markers.text-spacing .usfm_lim3,
+.psc-gutter-markers.text-spacing .usfm_lim4 {
   --verse-text-start: -7.5vw;
 }
 .psc-gutter-markers.text-spacing .usfm_iq,

--- a/extensions/src/platform-scripture-editor/src/_usj-nodes.scss
+++ b/extensions/src/platform-scripture-editor/src/_usj-nodes.scss
@@ -1,7 +1,11 @@
-/* Based on https://github.com/eten-tech-foundation/scripture-editors/packages/platform/src/usj-nodes.css
-   (originally synced from commit ba0e846b3f1). Local additions: li/lim --para-indent and
-   --verse-text-start entries in .psc-gutter-markers.text-spacing, mirroring scripture-editors
-   commit 846ad99 (PT-4021 \li/\lim gutter overlap fix). */
+/* Based on scripture-editors' packages/platform/src/usj-nodes.css:
+   https://github.com/eten-tech-foundation/scripture-editors/blob/main/packages/platform/src/usj-nodes.css
+   (originally synced from commit ba0e846b3f1:
+   https://github.com/eten-tech-foundation/scripture-editors/commit/ba0e846b3f1).
+   Local additions: li/lim --para-indent and --verse-text-start entries in
+   .psc-gutter-markers.text-spacing, mirroring scripture-editors commit 846ad99
+   (https://github.com/eten-tech-foundation/scripture-editors/commit/846ad99,
+   \li/\lim gutter overlap fix). */
 
 /* stylelint-disable */
 

--- a/extensions/src/platform-scripture-editor/src/usj-nodes-scss-coverage.test.ts
+++ b/extensions/src/platform-scripture-editor/src/usj-nodes-scss-coverage.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// `_usj-nodes.scss` is a hand-maintained copy of scripture-editors'
+// packages/platform/src/usj-nodes.css. That upstream file has its own coverage test
+// (usj-nodes.test.ts); this is the equivalent guard for the downstream copy that actually
+// ships in Platform.Bible, so the two can't silently drift (which reintroduced the \li/\lim
+// gutter overlap once already). Keep the marker lists below in sync with the upstream test.
+
+const dir = dirname(fileURLToPath(import.meta.url));
+// Strip CSS comments so their text can't be mistaken for selectors or declarations.
+const css = readFileSync(resolve(dir, '_usj-nodes.scss'), 'utf-8').replace(/\/\*[\s\S]*?\*\//g, '');
+
+/**
+ * Collects all `.usfm_<marker>` names that appear in a `.psc-gutter-markers` rule block that SETS
+ * `property` (a `${property}:` declaration, not a `var(--property)` read).
+ */
+function getGutterMarkers(property: string): Set<string> {
+  const markers = new Set<string>();
+  const ruleBlock = /([^{}]+)\{([^}]+)\}/g;
+  let match;
+  // eslint-disable-next-line no-cond-assign
+  while ((match = ruleBlock.exec(css)) !== null) {
+    const [, selectors, declarations] = match;
+    if (!selectors.includes('psc-gutter-markers') || !declarations.includes(`${property}:`))
+      continue;
+    const markerName = /\.usfm_([a-z0-9]+)/g;
+    let m;
+    // eslint-disable-next-line no-cond-assign
+    while ((m = markerName.exec(selectors)) !== null) markers.add(m[1]);
+  }
+  return markers;
+}
+
+// USFM standard LeftMargin values -> vw (formula: inches x 20).
+// Source: https://github.com/ubsicap/usfm/blob/master/sty/usfm.sty
+// Every marker here must have a --para-indent entry in .psc-gutter-markers.text-spacing.
+const PARA_INDENT_MARKERS = new Set([
+  // 0.25" -> 5vw
+  'ipi',
+  'imi',
+  'pmo',
+  'pm',
+  'pmc',
+  'pmr',
+  'pi',
+  'pi1',
+  'mi',
+  // 0.5" -> 10vw
+  'io',
+  'io1',
+  'ili',
+  'ili1',
+  'li',
+  'li1',
+  'pi2',
+  // 0.75" -> 15vw
+  'q',
+  'q1',
+  'q2',
+  'q3',
+  'q4',
+  'io2',
+  'ili2',
+  'li2',
+  'lim',
+  'lim1',
+  'pi3',
+  // 1.0" -> 20vw
+  'qm',
+  'qm1',
+  'io3',
+  'li3',
+  'lim2',
+  // 1.25" -> 25vw
+  'io4',
+  'li4',
+  'lim3',
+  // 1.5" -> 30vw
+  'lim4',
+]);
+
+// Markers with a negative FirstLineIndent (hanging indent) -> --verse-text-start.
+// Source: https://github.com/ubsicap/usfm/blob/master/sty/usfm.sty
+const VERSE_TEXT_START_MARKERS = new Set([
+  'q',
+  'q1',
+  'q2',
+  'q3',
+  'q4',
+  'qm',
+  'qm1',
+  'qm2',
+  'qm3',
+  'iq',
+  'iq1',
+  'iq2',
+  'iq3',
+  'ili',
+  'ili1',
+  'ili2',
+  'li',
+  'li1',
+  'li2',
+  'li3',
+  'li4',
+  'lim',
+  'lim1',
+  'lim2',
+  'lim3',
+  'lim4',
+]);
+
+describe('_usj-nodes.scss .psc-gutter-markers.text-spacing coverage', () => {
+  it('every USFM indented marker has a --para-indent entry', () => {
+    const covered = getGutterMarkers('--para-indent');
+    // Guard against a silently-broken parser (no matches -> every marker would look "missing").
+    expect(covered.size, 'no --para-indent gutter markers parsed').toBeGreaterThan(0);
+    const missing = [...PARA_INDENT_MARKERS].filter((m) => !covered.has(m));
+    expect(
+      missing,
+      `Add --para-indent entries to .psc-gutter-markers.text-spacing for: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+
+  it('every hanging-indent marker has a --verse-text-start entry', () => {
+    const covered = getGutterMarkers('--verse-text-start');
+    // Guard against a silently-broken parser (no matches -> every marker would look "missing").
+    expect(covered.size, 'no --verse-text-start gutter markers parsed').toBeGreaterThan(0);
+    const missing = [...VERSE_TEXT_START_MARKERS].filter((m) => !covered.has(m));
+    expect(
+      missing,
+      `Add --verse-text-start entries to .psc-gutter-markers.text-spacing for: ${missing.join(', ')}`,
+    ).toEqual([]);
+  });
+});

--- a/extensions/src/platform-scripture-editor/src/usj-nodes-scss-coverage.test.ts
+++ b/extensions/src/platform-scripture-editor/src/usj-nodes-scss-coverage.test.ts
@@ -5,14 +5,17 @@ import { fileURLToPath } from 'node:url';
 import { describe, expect, it } from 'vitest';
 
 // `_usj-nodes.scss` is a hand-maintained copy of scripture-editors'
-// packages/platform/src/usj-nodes.css. That upstream file has its own coverage test
-// (usj-nodes.test.ts); this is the equivalent guard for the downstream copy that actually
-// ships in Platform.Bible, so the two can't silently drift (which reintroduced the \li/\lim
-// gutter overlap once already). Keep the marker lists below in sync with the upstream test.
+// packages/platform/src/usj-nodes.css. The downstream copy had no guard against drifting from
+// upstream, which is how the \li/\lim gutter entries went missing and the overlap regressed. This
+// test is that guard: keep the marker lists below in sync with upstream usj-nodes.css.
 
 const dir = dirname(fileURLToPath(import.meta.url));
-// Strip CSS comments so their text can't be mistaken for selectors or declarations.
-const css = readFileSync(resolve(dir, '_usj-nodes.scss'), 'utf-8').replace(/\/\*[\s\S]*?\*\//g, '');
+// Strip comments so their text can't be mistaken for selectors or declarations. Block comments
+// first (that also removes the `//` inside the header's URLs), then SCSS `//` line comments — so a
+// commented-out `// --para-indent: 10vw;` in a hand-edited SCSS block isn't read as a live setter.
+const css = readFileSync(resolve(dir, '_usj-nodes.scss'), 'utf-8')
+  .replace(/\/\*[\s\S]*?\*\//g, '')
+  .replace(/\/\/.*$/gm, '');
 
 // The stylesheet is parsed as a flat list of `selector { declarations }` blocks. This regex cannot
 // reliably read a rule nested inside another block (an @media query, @keyframes, or SCSS nesting),

--- a/extensions/src/platform-scripture-editor/src/usj-nodes-scss-coverage.test.ts
+++ b/extensions/src/platform-scripture-editor/src/usj-nodes-scss-coverage.test.ts
@@ -14,122 +14,134 @@ const dir = dirname(fileURLToPath(import.meta.url));
 // Strip CSS comments so their text can't be mistaken for selectors or declarations.
 const css = readFileSync(resolve(dir, '_usj-nodes.scss'), 'utf-8').replace(/\/\*[\s\S]*?\*\//g, '');
 
+// The stylesheet is parsed as a flat list of `selector { declarations }` blocks. This regex cannot
+// reliably read a rule nested inside another block (an @media query, @keyframes, or SCSS nesting),
+// so a gutter rule wrapped in one could be mis-parsed and its markers silently uncovered.
+// `nestingProblems()` catches that by brace depth before the coverage checks run.
+const RULE_BLOCK = /([^{}]+)\{([^}]+)\}/g;
+const blocks = [...css.matchAll(RULE_BLOCK)].map(([, selectors, declarations]) => ({
+  selectors,
+  declarations,
+}));
+
+/** Brace nesting depth at a character offset: 1 inside a top-level rule, >1 inside a nested one. */
+function braceDepthAt(index: number): number {
+  const before = css.slice(0, index);
+  return (before.match(/\{/g) ?? []).length - (before.match(/\}/g) ?? []).length;
+}
+
 /**
- * Collects all `.usfm_<marker>` names that appear in a `.psc-gutter-markers` rule block that SETS
- * `property` (a `${property}:` declaration, not a `var(--property)` read).
+ * Reports `property` setters that sit deeper than one block — i.e. nested inside an at-rule/SCSS
+ * block, where a browser would scope them away but the flat block parser below cannot reliably see
+ * them. A setter declaration normally lives at depth 1 (inside its own rule); depth >1 means a rule
+ * was nested and the coverage checks can no longer be trusted. (Unrelated pre-existing media-query
+ * and keyframes at-rules don't contain these setters, so they don't trip this.)
  */
-function getGutterMarkers(property: string): Set<string> {
-  const markers = new Set<string>();
-  const ruleBlock = /([^{}]+)\{([^}]+)\}/g;
-  for (let match = ruleBlock.exec(css); match; match = ruleBlock.exec(css)) {
-    const [, selectors, declarations] = match;
-    // `${property}:` matches a rule that SETS the custom property, not one that only reads it
-    // via var(--property).
-    if (selectors.includes('psc-gutter-markers') && declarations.includes(`${property}:`)) {
-      const markerName = /\.usfm_([a-z0-9]+)/g;
-      for (let m = markerName.exec(selectors); m; m = markerName.exec(selectors)) markers.add(m[1]);
-    }
-  }
-  return markers;
+function nestingProblems(property: string): string[] {
+  const setter = new RegExp(`${property}\\s*:`, 'g');
+  const nested = [...css.matchAll(setter)].filter((match) => braceDepthAt(match.index ?? 0) > 1);
+  return nested.length === 0
+    ? []
+    : [
+        `${property}: ${nested.length} setter(s) are nested inside an @media/@keyframes/SCSS ` +
+          `block; the flat parser below cannot reliably see them. Update the parser.`,
+      ];
+}
+
+/**
+ * Maps each `.usfm_<marker>` to the value it is given for `property`, but only within a rule whose
+ * selector carries BOTH `.psc-gutter-markers` and `.text-spacing` — the exact scope where the real
+ * indent overrides live. A `${property}:` setter (not a `var(--property)` read) is required.
+ * Requiring `.text-spacing` means a marker whose setter was moved out of that group reads as
+ * uncovered rather than silently passing.
+ */
+function getGutterMarkerValues(property: string): Map<string, string> {
+  const declaration = new RegExp(`${property}\\s*:\\s*([^;]+)`);
+  const values = new Map<string, string>();
+  blocks
+    .filter(
+      (block) =>
+        block.selectors.includes('psc-gutter-markers') && block.selectors.includes('text-spacing'),
+    )
+    .forEach((block) => {
+      const match = declaration.exec(block.declarations);
+      if (!match) return;
+      const value = match[1].trim();
+      [...block.selectors.matchAll(/\.usfm_([a-z0-9]+)/g)].forEach(([, marker]) =>
+        values.set(marker, value),
+      );
+    });
+  return values;
+}
+
+/** Flattens a `value -> markers` grouping into a `marker -> value` lookup. */
+function markersByValue(grouped: Record<string, string[]>): Map<string, string> {
+  const map = new Map<string, string>();
+  Object.entries(grouped).forEach(([value, markers]) =>
+    markers.forEach((marker) => map.set(marker, value)),
+  );
+  return map;
+}
+
+/** Reports each expected marker whose actual `property` value is missing or wrong. */
+function valueMismatches(property: string, expected: Map<string, string>): string[] {
+  const actual = getGutterMarkerValues(property);
+  return [...expected]
+    .filter(([marker, value]) => actual.get(marker) !== value)
+    .map(
+      ([marker, value]) =>
+        `.usfm_${marker}: expected ${value}, got ${actual.get(marker) ?? 'none'}`,
+    );
 }
 
 // USFM standard LeftMargin values -> vw (formula: inches x 20).
 // Source: https://github.com/ubsicap/usfm/blob/master/sty/usfm.sty
-// Every marker here must have a --para-indent entry in .psc-gutter-markers.text-spacing.
-const PARA_INDENT_MARKERS = new Set([
-  // 0.25" -> 5vw
-  'ipi',
-  'imi',
-  'pmo',
-  'pm',
-  'pmc',
-  'pmr',
-  'pi',
-  'pi1',
-  'mi',
-  // 0.5" -> 10vw
-  'io',
-  'io1',
-  'ili',
-  'ili1',
-  'li',
-  'li1',
-  'pi2',
-  // 0.75" -> 15vw
-  'q',
-  'q1',
-  'q2',
-  'q3',
-  'q4',
-  'io2',
-  'ili2',
-  'li2',
-  'lim',
-  'lim1',
-  'pi3',
-  // 1.0" -> 20vw
-  'qm',
-  'qm1',
-  'io3',
-  'li3',
-  'lim2',
-  // 1.25" -> 25vw
-  'io4',
-  'li4',
-  'lim3',
-  // 1.5" -> 30vw
-  'lim4',
-]);
+// Every marker must set --para-indent to the listed value in .psc-gutter-markers.text-spacing.
+const EXPECTED_PARA_INDENT = markersByValue({
+  '5vw': ['ipi', 'imi', 'pmo', 'pm', 'pmc', 'pmr', 'pi', 'pi1', 'mi'], // 0.25"
+  '10vw': ['io', 'io1', 'ili', 'ili1', 'li', 'li1', 'pi2'], // 0.5"
+  '15vw': ['q', 'q1', 'q2', 'q3', 'q4', 'io2', 'ili2', 'li2', 'lim', 'lim1', 'pi3'], // 0.75"
+  '20vw': ['qm', 'qm1', 'io3', 'li3', 'lim2'], // 1.0"
+  '25vw': ['io4', 'li4', 'lim3'], // 1.25"
+  '30vw': ['lim4'], // 1.5"
+});
 
 // Markers with a negative FirstLineIndent (hanging indent) -> --verse-text-start.
 // Source: https://github.com/ubsicap/usfm/blob/master/sty/usfm.sty
-const VERSE_TEXT_START_MARKERS = new Set([
-  'q',
-  'q1',
-  'q2',
-  'q3',
-  'q4',
-  'qm',
-  'qm1',
-  'qm2',
-  'qm3',
-  'iq',
-  'iq1',
-  'iq2',
-  'iq3',
-  'ili',
-  'ili1',
-  'ili2',
-  'li',
-  'li1',
-  'li2',
-  'li3',
-  'li4',
-  'lim',
-  'lim1',
-  'lim2',
-  'lim3',
-  'lim4',
-]);
+const EXPECTED_VERSE_TEXT_START = markersByValue({
+  '-15vw': ['qm', 'qm1', 'iq', 'iq1'],
+  '-10vw': ['q', 'q1', 'qm2', 'iq2'],
+  '-7.5vw': [
+    'q2',
+    'ili',
+    'ili1',
+    'ili2',
+    'li',
+    'li1',
+    'li2',
+    'li3',
+    'li4',
+    'lim',
+    'lim1',
+    'lim2',
+    'lim3',
+    'lim4',
+  ],
+  '-5vw': ['q3', 'qm3', 'iq3'],
+  '-2.5vw': ['q4'],
+});
 
 describe('_usj-nodes.scss .psc-gutter-markers.text-spacing coverage', () => {
-  it('every USFM indented marker has a --para-indent entry', () => {
-    const covered = getGutterMarkers('--para-indent');
-    // Guard against a silently-broken parser (no matches -> every marker would look "missing").
-    expect(covered.size).toBeGreaterThan(0);
-    // Any USFM indented marker lacking a --para-indent entry in .psc-gutter-markers.text-spacing;
-    // the toEqual diff names them on failure.
-    const missing = [...PARA_INDENT_MARKERS].filter((m) => !covered.has(m));
-    expect(missing).toEqual([]);
+  it('every USFM indented marker sets the expected --para-indent', () => {
+    // Fails loudly if a gutter rule was nested where the flat parser can't see it.
+    expect(nestingProblems('--para-indent')).toEqual([]);
+    // Names each marker whose --para-indent is missing or wrong (an empty actual map surfaces here
+    // too, since every expected marker then reports "got none").
+    expect(valueMismatches('--para-indent', EXPECTED_PARA_INDENT)).toEqual([]);
   });
 
-  it('every hanging-indent marker has a --verse-text-start entry', () => {
-    const covered = getGutterMarkers('--verse-text-start');
-    // Guard against a silently-broken parser (no matches -> every marker would look "missing").
-    expect(covered.size).toBeGreaterThan(0);
-    // Any hanging-indent marker lacking a --verse-text-start entry in .psc-gutter-markers.text-spacing;
-    // the toEqual diff names them on failure.
-    const missing = [...VERSE_TEXT_START_MARKERS].filter((m) => !covered.has(m));
-    expect(missing).toEqual([]);
+  it('every hanging-indent marker sets the expected --verse-text-start', () => {
+    expect(nestingProblems('--verse-text-start')).toEqual([]);
+    expect(valueMismatches('--verse-text-start', EXPECTED_VERSE_TEXT_START)).toEqual([]);
   });
 });

--- a/extensions/src/platform-scripture-editor/src/usj-nodes-scss-coverage.test.ts
+++ b/extensions/src/platform-scripture-editor/src/usj-nodes-scss-coverage.test.ts
@@ -21,16 +21,14 @@ const css = readFileSync(resolve(dir, '_usj-nodes.scss'), 'utf-8').replace(/\/\*
 function getGutterMarkers(property: string): Set<string> {
   const markers = new Set<string>();
   const ruleBlock = /([^{}]+)\{([^}]+)\}/g;
-  let match;
-  // eslint-disable-next-line no-cond-assign
-  while ((match = ruleBlock.exec(css)) !== null) {
+  for (let match = ruleBlock.exec(css); match; match = ruleBlock.exec(css)) {
     const [, selectors, declarations] = match;
-    if (!selectors.includes('psc-gutter-markers') || !declarations.includes(`${property}:`))
-      continue;
-    const markerName = /\.usfm_([a-z0-9]+)/g;
-    let m;
-    // eslint-disable-next-line no-cond-assign
-    while ((m = markerName.exec(selectors)) !== null) markers.add(m[1]);
+    // `${property}:` matches a rule that SETS the custom property, not one that only reads it
+    // via var(--property).
+    if (selectors.includes('psc-gutter-markers') && declarations.includes(`${property}:`)) {
+      const markerName = /\.usfm_([a-z0-9]+)/g;
+      for (let m = markerName.exec(selectors); m; m = markerName.exec(selectors)) markers.add(m[1]);
+    }
   }
   return markers;
 }
@@ -118,22 +116,20 @@ describe('_usj-nodes.scss .psc-gutter-markers.text-spacing coverage', () => {
   it('every USFM indented marker has a --para-indent entry', () => {
     const covered = getGutterMarkers('--para-indent');
     // Guard against a silently-broken parser (no matches -> every marker would look "missing").
-    expect(covered.size, 'no --para-indent gutter markers parsed').toBeGreaterThan(0);
+    expect(covered.size).toBeGreaterThan(0);
+    // Any USFM indented marker lacking a --para-indent entry in .psc-gutter-markers.text-spacing;
+    // the toEqual diff names them on failure.
     const missing = [...PARA_INDENT_MARKERS].filter((m) => !covered.has(m));
-    expect(
-      missing,
-      `Add --para-indent entries to .psc-gutter-markers.text-spacing for: ${missing.join(', ')}`,
-    ).toEqual([]);
+    expect(missing).toEqual([]);
   });
 
   it('every hanging-indent marker has a --verse-text-start entry', () => {
     const covered = getGutterMarkers('--verse-text-start');
     // Guard against a silently-broken parser (no matches -> every marker would look "missing").
-    expect(covered.size, 'no --verse-text-start gutter markers parsed').toBeGreaterThan(0);
+    expect(covered.size).toBeGreaterThan(0);
+    // Any hanging-indent marker lacking a --verse-text-start entry in .psc-gutter-markers.text-spacing;
+    // the toEqual diff names them on failure.
     const missing = [...VERSE_TEXT_START_MARKERS].filter((m) => !covered.has(m));
-    expect(
-      missing,
-      `Add --verse-text-start entries to .psc-gutter-markers.text-spacing for: ${missing.join(', ')}`,
-    ).toEqual([]);
+    expect(missing).toEqual([]);
   });
 });

--- a/extensions/src/platform-scripture-editor/src/usj-nodes-scss-coverage.test.ts
+++ b/extensions/src/platform-scripture-editor/src/usj-nodes-scss-coverage.test.ts
@@ -13,9 +13,12 @@ const dir = dirname(fileURLToPath(import.meta.url));
 // Strip comments so their text can't be mistaken for selectors or declarations. Block comments
 // first (that also removes the `//` inside the header's URLs), then SCSS `//` line comments — so a
 // commented-out `// --para-indent: 10vw;` in a hand-edited SCSS block isn't read as a live setter.
+// The line-comment strip only fires at line start or after whitespace, so a `//` inside a value
+// (a future `url(https://…)` or protocol-relative `url(//…)`) is left intact rather than deleting
+// the rest of that declaration's line and silently shifting brace depth.
 const css = readFileSync(resolve(dir, '_usj-nodes.scss'), 'utf-8')
   .replace(/\/\*[\s\S]*?\*\//g, '')
-  .replace(/\/\/.*$/gm, '');
+  .replace(/(^|\s)\/\/.*$/gm, '$1');
 
 // The stylesheet is parsed as a flat list of `selector { declarations }` blocks. This regex cannot
 // reliably read a rule nested inside another block (an @media query, @keyframes, or SCSS nesting),
@@ -97,6 +100,39 @@ function valueMismatches(property: string, expected: Map<string, string>): strin
     );
 }
 
+/**
+ * Reports gutter markers that set `property` but aren't in the expected map — the reverse of
+ * `valueMismatches`. This makes the drift guard symmetric: an indent that the USFM spec doesn't
+ * call for, or a stale entry left behind after upstream removes a marker, is flagged rather than
+ * silently passing because the expected list never mentioned it.
+ */
+function unexpectedMarkers(property: string, expected: Map<string, string>): string[] {
+  const actual = getGutterMarkerValues(property);
+  return [...actual]
+    .filter(([marker]) => !expected.has(marker))
+    .map(([marker, value]) => `.usfm_${marker}: sets ${property} ${value} but is not expected`);
+}
+
+/**
+ * Reports gutter `property` rules qualified by writing direction (`[dir=…]`). Upstream keeps the
+ * gutter --para-indent/--verse-text-start values identical for LTR and RTL, so a `[dir=…]`
+ * qualifier would leave one direction with no indent compensation while the coverage filter — which
+ * matches on the `psc-gutter-markers` and `text-spacing` substrings and ignores the qualifier —
+ * still counted the marker as covered. This keeps that asymmetry from slipping back in silently.
+ */
+function directionQualifiedGutterRules(property: string): string[] {
+  const setter = new RegExp(`${property}\\s*:`);
+  return blocks
+    .filter(
+      (block) =>
+        block.selectors.includes('psc-gutter-markers') &&
+        block.selectors.includes('text-spacing') &&
+        setter.test(block.declarations) &&
+        block.selectors.includes('[dir='),
+    )
+    .map((block) => `${property}: direction-qualified selector "${block.selectors.trim()}"`);
+}
+
 // USFM standard LeftMargin values -> vw (formula: inches x 20).
 // Source: https://github.com/ubsicap/usfm/blob/master/sty/usfm.sty
 // Every marker must set --para-indent to the listed value in .psc-gutter-markers.text-spacing.
@@ -138,13 +174,20 @@ describe('_usj-nodes.scss .psc-gutter-markers.text-spacing coverage', () => {
   it('every USFM indented marker sets the expected --para-indent', () => {
     // Fails loudly if a gutter rule was nested where the flat parser can't see it.
     expect(nestingProblems('--para-indent')).toEqual([]);
+    // Fails loudly if a gutter --para-indent rule is direction-qualified (LTR/RTL must match).
+    expect(directionQualifiedGutterRules('--para-indent')).toEqual([]);
     // Names each marker whose --para-indent is missing or wrong (an empty actual map surfaces here
     // too, since every expected marker then reports "got none").
     expect(valueMismatches('--para-indent', EXPECTED_PARA_INDENT)).toEqual([]);
+    // Names any gutter marker that sets --para-indent but isn't expected (drift in the other
+    // direction: an unexpected indent or a stale entry after upstream removes a marker).
+    expect(unexpectedMarkers('--para-indent', EXPECTED_PARA_INDENT)).toEqual([]);
   });
 
   it('every hanging-indent marker sets the expected --verse-text-start', () => {
     expect(nestingProblems('--verse-text-start')).toEqual([]);
+    expect(directionQualifiedGutterRules('--verse-text-start')).toEqual([]);
     expect(valueMismatches('--verse-text-start', EXPECTED_VERSE_TEXT_START)).toEqual([]);
+    expect(unexpectedMarkers('--verse-text-start', EXPECTED_VERSE_TEXT_START)).toEqual([]);
   });
 });


### PR DESCRIPTION

<img width="908" height="481" alt="image" src="https://github.com/user-attachments/assets/ca707e76-10eb-40b7-bca1-d8e36bcb0515" />

## Summary

`extensions/src/platform-scripture-editor/src/_usj-nodes.scss` is a hand-maintained copy of scripture-editors' `packages/platform/src/usj-nodes.css`. It had drifted and was missing the `--para-indent` / `--verse-text-start` entries for the entire `\li`/`\lim` family, so those hanging-indent markers rendered with the gutter marker overlapping the paragraph text in Platform.Bible.

This PR:
1. **Adds the missing `\li`/`\lim` gutter entries**, mirroring scripture-editors commit `846ad99` (PT-4021).
2. **Adds a coverage test** so the copy can't silently drift again — the upstream file already has an equivalent test, but the downstream copy that actually ships in Platform.Bible had none, which is exactly how it drifted.

## Reviewer orientation (two commits)

- **`_usj-nodes.scss`** — the CSS: `\li`/`\li1` → `10vw`, `\li2`/`\lim`/`\lim1` → `15vw`, `\li3`/`\lim2` → `20vw`, `\li4`/`\lim3` → `25vw`, `\lim4` → `30vw` (new block), and all `\li*`/`\lim*` → `--verse-text-start: -7.5vw`. Values come from the USFM LeftMargin spec (inches × 20), matching the upstream fix. The entries were slotted into the existing `.psc-gutter-markers.text-spacing` value-groups (this copy has a small pre-existing divergence — a `[dir='ltr']` variant on the `pi2`/`pi3` selectors — so it isn't a byte-copy of upstream).
- **`usj-nodes-scss-coverage.test.ts`** — the guard: parses the SCSS and asserts every USFM indented/hanging marker has the corresponding custom-property **setter** (it strips comments, ignores `var()` reads, and fails loudly if it parses nothing). Runs under the extensions vitest config.

## Relationship to the editor-side fix

The Lexical cursor fix and the editor-side CSS for PT-4021 live in **scripture-editors** (separate PR). This is the **paranext-core consuming side**: the `platform-scripture-editor` extension uses its own copy of the stylesheet, so the fix has to be synced here too. Longer term, generating or otherwise auto-syncing this file from the editor package would remove the manual-copy drift risk entirely — out of scope here.

## Testing

```
npx vitest run --config extensions/vitest.config.ts usj-nodes-scss-coverage
```
→ both assertions pass against the updated stylesheet.

Linked to https://github.com/eten-tech-foundation/scripture-editors/pull/518

AI-assisted (Claude Code).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2629)
<!-- Reviewable:end -->
