### PR TITLE
Scope Simple-mode startup sync to the active project

### DIFF
--- a/src/main/startup-tasks.test.ts
+++ b/src/main/startup-tasks.test.ts
@@ -10,6 +10,7 @@ import { settingsService } from '@shared/services/settings.service';
 import * as commandService from '@shared/services/command.service';
 import * as networkService from '@shared/services/network.service';
 import { logger } from '@shared/services/logger.service';
+import { getRecentlyOpenedProjectIds } from '@shared/utils/recently-opened-project.util';
 import { performStartupTasks, STARTUP_SYNC_RETRY_BUDGET_MS } from './startup-tasks';
 
 vi.mock('@shared/services/settings.service', () => ({
@@ -28,11 +29,16 @@ vi.mock('@shared/services/logger.service', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock('@shared/utils/recently-opened-project.util', () => ({
+  getRecentlyOpenedProjectIds: vi.fn(),
+}));
+
 const mockSettingsGet = vi.mocked(settingsService.get);
 const mockSendCommand = vi.mocked(commandService.sendCommand);
 const mockRequestNoRetry = vi.mocked(networkService.requestNoRetry);
 const mockLoggerDebug = vi.mocked(logger.debug);
 const mockLoggerWarn = vi.mocked(logger.warn);
+const mockGetRecentlyOpenedProjectIds = vi.mocked(getRecentlyOpenedProjectIds);
 
 /**
  * Builds a rejection shaped like what `networkService`'s request plumbing actually throws for a
@@ -67,6 +73,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockSendCommand.mockResolvedValue(undefined);
   mockRequestNoRetry.mockResolvedValue(undefined);
+  // Zero-state default (no recently-opened project) so every existing test's "called with
+  // undefined" expectation stays valid unless a test explicitly overrides this to exercise the
+  // scoped (steady-state) path.
+  mockGetRecentlyOpenedProjectIds.mockResolvedValue([]);
 });
 
 describe('performStartupTasks', () => {
@@ -80,13 +90,25 @@ describe('performStartupTasks', () => {
     expect(mockSendCommand).not.toHaveBeenCalled();
   });
 
-  it('fires syncProjects with no project IDs when interface mode is simple', async () => {
+  it('fires syncProjects with no project IDs when interface mode is simple and no project has been opened yet (zero-state)', async () => {
     stubSettings({ mode: 'simple', firstRunComplete: true });
+    mockGetRecentlyOpenedProjectIds.mockResolvedValue([]);
     await performStartupTasks();
     expect(mockSendCommand).toHaveBeenCalledWith(
       'paratextBibleSendReceive.syncProjects',
       undefined,
     );
+    expect(mockRequestNoRetry).not.toHaveBeenCalled();
+  });
+
+  it('scopes the sync to the recently-opened project ids when interface mode is simple and at least one exists (steady-state)', async () => {
+    stubSettings({ mode: 'simple', firstRunComplete: true });
+    mockGetRecentlyOpenedProjectIds.mockResolvedValue(['project-a', 'project-b']);
+    await performStartupTasks();
+    expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.syncProjects', [
+      'project-a',
+      'project-b',
+    ]);
     expect(mockRequestNoRetry).not.toHaveBeenCalled();
   });
 

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -16,6 +16,7 @@ import {
 import { JSONRPCErrorCode } from 'json-rpc-2.0';
 import type { SettingTypes } from 'papi-shared-types';
 import { getErrorMessage, wait } from 'platform-bible-utils';
+import { getRecentlyOpenedProjectIds } from '@shared/utils/recently-opened-project.util';
 
 /**
  * How long (ms) to keep retrying `runScheduledSessionSync` while it's still unregistered before
@@ -106,10 +107,14 @@ type StartupSyncTriggerOutcome = ScheduledSessionSyncResult | 'skipped-stale' | 
  * Runs initialization tasks (currently: triggering an initial project sync) shortly after the app
  * finishes starting up.
  *
- * In Simple mode: requests a sync of all locally-known shared projects so the user sees the latest
- * content as soon as they open the app. All errors are swallowed — the S/R extension may not be
- * installed (e.g. Platform.Bible), the command may not yet be registered, or the sync may fail.
- * Startup must never be blocked or visibly affected by this.
+ * In Simple mode: requests a sync scoped to the project(s) in `recentlyOpenedProjects` — the same
+ * signal the default-active-project picker uses — so a returning user's active project is synced
+ * without paying the cost of checking every locally-known shared project. Falls back to a sync of
+ * everything (today's original behavior) when that list is empty (zero-state: no project opened in
+ * Simple mode yet), so a brand-new user can still discover a project they already have via Paratext
+ * 9. All errors are swallowed — the S/R extension may not be installed (e.g. Platform.Bible), the
+ * command may not yet be registered, or the sync may fail. Startup must never be blocked or visibly
+ * affected by this.
  *
  * In Power mode: requests a sync of just the projects scheduled "On startup/shutdown" via the S/R
  * extension's `runScheduledSessionSync` command. Same error-swallowing contract as Simple mode — if
@@ -191,14 +196,26 @@ async function performStartupTasksInternal(signals?: StartupTasksSignals): Promi
     return;
   }
 
-  // Simple mode: sync all locally-known shared projects (no project IDs = "sync all" per the
-  // C# `String[]? projectIds` contract). The C# S/R command registers asynchronously during
-  // startup; `sendCommand` will wait (with retry on missing handler) until it's available or
-  // times out. `undefined` as the single arg serializes as `null` in the JSON-RPC params array
-  // — matching the "sync all" sentinel on the C# side.
-  logger.debug('Startup sync starting');
+  // Simple mode: scope the sync to the project(s) the user has actually opened before (steady
+  // state) rather than syncing every locally-known shared project. `recentlyOpenedProjects` is the
+  // same durable, race-safe signal the Simple-mode default-active-project picker already uses to
+  // decide which project to open, so this stays consistent with what actually gets displayed.
+  // Passing the whole (small, capped) list rather than just the top entry means a stale/removed
+  // entry there doesn't block scoping this run — the C# side silently ignores ids that no longer
+  // resolve to a real shared project. An empty list (zero-state: no project has ever been opened
+  // in Simple mode yet) falls back to `undefined` — "sync all" per the C# `String[]? projectIds`
+  // contract — so a brand-new user can still discover a project they already have via Paratext 9.
+  // The C# S/R command registers asynchronously during startup; `sendCommand` will wait (with
+  // retry on missing handler) until it's available or times out.
+  const recentProjectIds = await getRecentlyOpenedProjectIds();
+  const syncProjectIds = recentProjectIds.length > 0 ? recentProjectIds : undefined;
+  logger.debug(
+    syncProjectIds
+      ? `Startup sync starting (scoped to ${syncProjectIds.join(', ')})`
+      : 'Startup sync starting (broad: zero-state or unresolved)',
+  );
   try {
-    await commandService.sendCommand('paratextBibleSendReceive.syncProjects', undefined);
+    await commandService.sendCommand('paratextBibleSendReceive.syncProjects', syncProjectIds);
     logger.debug('Startup sync complete');
   } catch (e) {
     logger.warn(

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -48,7 +48,6 @@ import {
   WebViewType,
 } from '@shared/models/web-view.model';
 import { registerCommand } from '@shared/services/command.service';
-import { dataProviderService } from '@shared/services/data-provider.service';
 import { logger } from '@shared/services/logger.service';
 import { projectLookupService } from '@shared/services/project-lookup.service';
 import { startWorkspaceUpdate } from '@renderer/services/workspace-updating-store';
@@ -75,6 +74,7 @@ import {
   OpenWebViewEvent,
   WebViewServiceType,
 } from '@shared/services/web-view.service-model';
+import { getRecentlyOpenedProjectIds } from '@shared/utils/recently-opened-project.util';
 import { markStartupOnce } from '@shared/utils/startup-timing.util';
 import { newNonce } from '@shared/utils/util';
 import cloneDeep from 'lodash/cloneDeep';
@@ -1153,16 +1153,8 @@ function waitForNextPaint(): Promise<void> {
 }
 
 async function getMostRecentProjectId(): Promise<string | undefined> {
-  try {
-    const recentsProvider = await dataProviderService.get(
-      'platformScripture.recentlyOpenedProjects',
-    );
-    if (!recentsProvider) return undefined;
-    const recents = await recentsProvider.getRecentProjects(undefined);
-    return Array.isArray(recents) ? recents[0] : undefined;
-  } catch {
-    return undefined;
-  }
+  const recents = await getRecentlyOpenedProjectIds();
+  return recents[0];
 }
 
 // #endregion Dock layouts

--- a/src/shared/utils/recently-opened-project.util.test.ts
+++ b/src/shared/utils/recently-opened-project.util.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+import { dataProviderService } from '@shared/services/data-provider.service';
+import { getRecentlyOpenedProjectIds } from '@shared/utils/recently-opened-project.util';
+
+vi.mock('@shared/services/data-provider.service', () => ({
+  dataProviderService: { get: vi.fn() },
+}));
+
+const mockGet = vi.mocked(dataProviderService.get);
+
+describe('getRecentlyOpenedProjectIds', () => {
+  it('returns the recents list from the data provider, most-recent first', async () => {
+    // The mock returns a minimal stand-in for the full data provider — only the method this
+    // helper calls needs to be present.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    mockGet.mockResolvedValue({
+      getRecentProjects: vi.fn().mockResolvedValue(['project-a', 'project-b']),
+    } as never);
+
+    const result = await getRecentlyOpenedProjectIds();
+
+    expect(result).toEqual(['project-a', 'project-b']);
+  });
+
+  it('returns an empty array when the data provider is unavailable', async () => {
+    mockGet.mockResolvedValue(undefined);
+
+    const result = await getRecentlyOpenedProjectIds();
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array when the data provider read throws', async () => {
+    mockGet.mockRejectedValue(new Error('network object not registered'));
+
+    const result = await getRecentlyOpenedProjectIds();
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/shared/utils/recently-opened-project.util.ts
+++ b/src/shared/utils/recently-opened-project.util.ts
@@ -1,0 +1,23 @@
+import { dataProviderService } from '@shared/services/data-provider.service';
+
+/**
+ * Reads the ordered list of project ids the user has most recently opened as their main/active
+ * project in Simple mode (most-recent first; see `platformScripture.recentlyOpenedProjects`).
+ * Process-agnostic — `dataProviderService` resolves the same underlying data provider whether
+ * called from the renderer or the main process.
+ *
+ * @returns The recents list, or an empty array if the data provider is unavailable or the read
+ *   fails for any reason (e.g. not yet registered during cold boot).
+ */
+export async function getRecentlyOpenedProjectIds(): Promise<string[]> {
+  try {
+    const recentsProvider = await dataProviderService.get(
+      'platformScripture.recentlyOpenedProjects',
+    );
+    if (!recentsProvider) return [];
+    const recents = await recentsProvider.getRecentProjects(undefined);
+    return Array.isArray(recents) ? recents : [];
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

- Simple-mode startup sync currently calls `syncProjects` with `undefined` `projectIds`, which the C# side treats as "sync every shared project the account has ever touched anywhere on this machine" - not scoped to this app's own project set. On a machine that also has other Paratext 9 projects checked out, those get swept into the same startup sync, adding real time to the sequential per-project modification-status check the C# side runs (confirmed via a captured startup waterfall: this sync was ~60% of a ~55s cold start).
- Startup now resolves `platformScripture.recentlyOpenedProjects` (the same signal the Simple-mode default-active-project picker already uses) and scopes the sync to that list when it's non-empty (steady-state: the user already has an active project). Falls back to today's broad "sync everything" behavior when the list is empty (zero-state: no project opened in Simple mode yet), preserving the "discover a project already synced via Paratext 9" behavior for a brand-new user.
- `getMostRecentProjectId()` is refactored to share a new `recently-opened-project.util.ts` helper instead of duplicating the data-provider read, so this resolution and the Power->Simple layout fast-path's resolution can't drift apart.

This targets `improve_simple-power_switching` (#2425) rather than `main` since it builds on that branch's Simple-mode work and should be reviewed on its own merits, but will most likely land after #2425 merges.

Companion change: a small patch to `paratext-10-studio`'s private fork threads this same `projectIds` scoping into the C# `GetSharedProjects()`/`SyncProjectsCore` call (using an existing but previously-unused `SRProjectSelectionOptions.ForcedSelectedProjectIds` mechanism) - without it, the C# side still enumerates and status-checks every account-wide project regardless of what TS passes. Verified manually end-to-end in a paratext-10-studio release build: startup no longer status-checks unrelated projects, and is meaningfully faster.

## Test plan

- [x] `npm run typecheck:core` clean
- [x] Targeted `eslint` clean on all changed files
- [x] Full `npm test`: 39 files / 572 tests pass (both before and after rebasing onto the latest `improve_simple-power_switching`)
- [x] New tests: `recently-opened-project.util.test.ts` (3 cases), 2 new cases in `startup-tasks.test.ts` (steady-state scoped call, zero-state fallback preserved)
- [x] Manual end-to-end verification against a real `paratext-10-studio` release build (see companion patch PR)

AI-assisted — built with Claude Code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2636)
<!-- Reviewable:end -->
