### PR TITLE
feat: persist window layouts, bounds and displays (PT-4285)

### DIFF
--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -229,7 +229,16 @@ export async function teardownElectronApp(ctx: ElectronAppContext): Promise<void
 
   // Teardown: kill the OS process and wait for Playwright to passively detect
   // the disconnection via the 'close' event registered above.
-  const electronProcess = electronApp.process();
+  // After a graceful quit, Playwright may have fully disposed the ElectronApplication by the time
+  // teardown runs — on Windows its stdio closes promptly (no .NET watcher child holds the pipe
+  // write-ends open, unlike Linux), and `process()` on the disposed object throws. Treat that as
+  // "process already exited" and fall through to profile cleanup.
+  let electronProcess: ReturnType<ElectronApplication['process']> | undefined;
+  try {
+    electronProcess = electronApp.process();
+  } catch {
+    electronProcess = undefined;
+  }
   console.log(
     `[teardown] Closing Electron app... pid=${electronProcess?.pid} exitCode=${electronProcess?.exitCode} signalCode=${electronProcess?.signalCode}`,
   );

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -48,6 +48,13 @@ export interface ElectronAppContext {
   /** Resolves when the Electron process closes (registered before yielding to tests). */
   appClosed: Promise<void>;
   /**
+   * OS pid of the Electron process, captured at launch time while `electronApp.process()` is
+   * guaranteed to work. Teardown falls back to it when Playwright has already disposed the
+   * ElectronApplication (where `process()` throws) — disposal usually means the process exited, but
+   * that must be verified against the OS rather than assumed.
+   */
+  appPid?: number;
+  /**
    * When true, {@link teardownElectronApp} leaves {@link userDataDir} on disk so a later launch can
    * reuse it. Carried over from {@link LaunchElectronAppOptions.preserveUserDataDir}.
    */
@@ -217,7 +224,13 @@ export async function launchElectronApp(
     });
   });
 
-  return { electronApp, userDataDir, appClosed, preserveUserDataDir: opts.preserveUserDataDir };
+  return {
+    electronApp,
+    userDataDir,
+    appClosed,
+    appPid: electronApp.process().pid,
+    preserveUserDataDir: opts.preserveUserDataDir,
+  };
 }
 
 /**
@@ -225,22 +238,24 @@ export async function launchElectronApp(
  * user-data directory.
  */
 export async function teardownElectronApp(ctx: ElectronAppContext): Promise<void> {
-  const { electronApp, userDataDir, appClosed, preserveUserDataDir } = ctx;
+  const { electronApp, userDataDir, appClosed, appPid, preserveUserDataDir } = ctx;
 
   // Teardown: kill the OS process and wait for Playwright to passively detect
   // the disconnection via the 'close' event registered above.
   // After a graceful quit, Playwright may have fully disposed the ElectronApplication by the time
   // teardown runs — on Windows its stdio closes promptly (no .NET watcher child holds the pipe
-  // write-ends open, unlike Linux), and `process()` on the disposed object throws. Treat that as
-  // "process already exited" and fall through to profile cleanup.
+  // write-ends open, unlike Linux), and `process()` on the disposed object throws. Disposal
+  // usually means the process exited, but not always — so fall back to the pid captured at launch
+  // and ask the OS whether the process is still alive rather than assuming.
   let electronProcess: ReturnType<ElectronApplication['process']> | undefined;
   try {
     electronProcess = electronApp.process();
   } catch {
     electronProcess = undefined;
   }
+  const pid = electronProcess?.pid ?? appPid;
   console.log(
-    `[teardown] Closing Electron app... pid=${electronProcess?.pid} exitCode=${electronProcess?.exitCode} signalCode=${electronProcess?.signalCode}`,
+    `[teardown] Closing Electron app... pid=${pid} exitCode=${electronProcess?.exitCode} signalCode=${electronProcess?.signalCode}`,
   );
 
   // On Linux, processLauncher.js spawns Electron with `detached: true`, making
@@ -252,22 +267,41 @@ export async function teardownElectronApp(ctx: ElectronAppContext): Promise<void
   // config has no node environment, so it cannot see the global.
   // eslint-disable-next-line no-undef
   const killGroup = (sig: NodeJS.Signals) => {
-    if (!electronProcess?.pid) return;
+    if (!pid) return;
     try {
-      process.kill(-electronProcess.pid, sig);
+      process.kill(-pid, sig);
     } catch {
       // Process group may already be gone — fall back to single-process kill
       try {
-        electronProcess.kill(sig);
+        process.kill(pid, sig);
       } catch {
         /* already dead */
       }
     }
   };
 
-  // Node.js ChildProcess.exitCode/signalCode are null until the process exits
-  // eslint-disable-next-line no-null/no-null
-  if (electronProcess && electronProcess.exitCode === null && electronProcess.signalCode === null) {
+  /** Whether the Electron OS process is still running, per the best signal available. */
+  const isProcessAlive = (): boolean => {
+    if (electronProcess)
+      // Node.js ChildProcess.exitCode/signalCode are null until the process exits
+      // eslint-disable-next-line no-null/no-null
+      return electronProcess.exitCode === null && electronProcess.signalCode === null;
+    if (pid === undefined) return false;
+    // No child-process handle (Playwright disposed it) — probe the OS directly. Signal 0 performs
+    // only an existence/permission check and delivers nothing.
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  if (isProcessAlive()) {
+    if (!electronProcess)
+      console.log(
+        `[teardown] Playwright handle already disposed but pid ${pid} is still alive — killing anyway...`,
+      );
     console.log('[teardown] Sending SIGKILL to process group...');
     killGroup('SIGKILL');
     console.log('[teardown] Waiting for appClosed after SIGKILL (up to 3s)...');
@@ -278,6 +312,8 @@ export async function teardownElectronApp(ctx: ElectronAppContext): Promise<void
       }),
     ]);
     console.log('[teardown] Done waiting after SIGKILL');
+  } else if (!electronProcess) {
+    console.log('[teardown] Playwright handle already disposed and the OS process has exited.');
   }
 
   // A preserved profile stays on disk so a later launch can relaunch into it (see

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -47,6 +47,11 @@ export interface ElectronAppContext {
   userDataDir: string;
   /** Resolves when the Electron process closes (registered before yielding to tests). */
   appClosed: Promise<void>;
+  /**
+   * When true, {@link teardownElectronApp} leaves {@link userDataDir} on disk so a later launch can
+   * reuse it. Carried over from {@link LaunchElectronAppOptions.preserveUserDataDir}.
+   */
+  preserveUserDataDir?: boolean;
 }
 
 /** Wait for the WebSocket server to be ready on the specified port. */
@@ -103,11 +108,28 @@ export interface LaunchElectronAppOptions {
    * developer's machine and never read or write the developer's real projects.
    */
   isolatedProjectRoot?: boolean;
+  /**
+   * Absolute path of an existing user-data directory to launch into, instead of creating a fresh
+   * temp one. For relaunch tests: pass the `userDataDir` a previous {@link launchElectronApp}
+   * returned (launched with {@link LaunchElectronAppOptions.preserveUserDataDir}) so the new
+   * instance starts from the profile state the previous one persisted. Launches must be sequential
+   * — the fixed WebSocket port and Electron's per-profile singleton lock forbid overlapping
+   * instances — so only pass this after the previous instance's process has fully exited.
+   */
+  userDataDir?: string;
+  /**
+   * When true, {@link teardownElectronApp} (and the cleanup that runs when the launch itself fails)
+   * leaves the user-data directory on disk so a later launch can reuse it via
+   * {@link LaunchElectronAppOptions.userDataDir}. The LAST launch of a relaunch chain must leave
+   * this unset so its teardown deletes the directory — otherwise the temp directory leaks.
+   */
+  preserveUserDataDir?: boolean;
 }
 
 /**
- * Launch a fresh Electron instance with an isolated user-data directory. Returns the app handle,
- * the temp directory path, and a promise that resolves when the app closes.
+ * Launch a fresh Electron instance with an isolated user-data directory (or, for relaunch tests, an
+ * existing one via {@link LaunchElectronAppOptions.userDataDir}). Returns the app handle, the
+ * user-data directory path, and a promise that resolves when the app closes.
  */
 export async function launchElectronApp(
   opts: LaunchElectronAppOptions = {},
@@ -117,8 +139,9 @@ export async function launchElectronApp(
   console.log(`Launching Electron app from project root: ${rootDir}`);
 
   // Use an isolated user-data directory so the singleton instance lock does not
-  // conflict with any already-running Platform.Bible instance.
-  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'paranext-e2e-'));
+  // conflict with any already-running Platform.Bible instance. A caller-supplied directory (a
+  // relaunch into a preserved profile) is used as-is.
+  const userDataDir = opts.userDataDir ?? fs.mkdtempSync(path.join(os.tmpdir(), 'paranext-e2e-'));
 
   // VSCode/Claude Code set ELECTRON_RUN_AS_NODE=1 which forces the Electron
   // binary to run as plain Node.js. We must omit it (do not set it to undefined:
@@ -154,8 +177,9 @@ export async function launchElectronApp(
     });
   } catch (error) {
     console.error('Failed to launch Electron:', error);
-    // Clean up the temp directory created above — launch never succeeded
-    fs.rmSync(userDataDir, { recursive: true, force: true });
+    // Clean up the temp directory created above — launch never succeeded. Preserved profiles are
+    // kept even here so a failed relaunch does not destroy the state under investigation.
+    if (!opts.preserveUserDataDir) fs.rmSync(userDataDir, { recursive: true, force: true });
     throw error;
   }
 
@@ -179,7 +203,7 @@ export async function launchElectronApp(
         }
       }
     }
-    fs.rmSync(userDataDir, { recursive: true, force: true });
+    if (!opts.preserveUserDataDir) fs.rmSync(userDataDir, { recursive: true, force: true });
     throw error;
   }
   console.log('WebSocket server is ready');
@@ -193,7 +217,7 @@ export async function launchElectronApp(
     });
   });
 
-  return { electronApp, userDataDir, appClosed };
+  return { electronApp, userDataDir, appClosed, preserveUserDataDir: opts.preserveUserDataDir };
 }
 
 /**
@@ -201,7 +225,7 @@ export async function launchElectronApp(
  * user-data directory.
  */
 export async function teardownElectronApp(ctx: ElectronAppContext): Promise<void> {
-  const { electronApp, userDataDir, appClosed } = ctx;
+  const { electronApp, userDataDir, appClosed, preserveUserDataDir } = ctx;
 
   // Teardown: kill the OS process and wait for Playwright to passively detect
   // the disconnection via the 'close' event registered above.
@@ -245,6 +269,15 @@ export async function teardownElectronApp(ctx: ElectronAppContext): Promise<void
       }),
     ]);
     console.log('[teardown] Done waiting after SIGKILL');
+  }
+
+  // A preserved profile stays on disk so a later launch can relaunch into it (see
+  // LaunchElectronAppOptions.preserveUserDataDir). The last teardown of a relaunch chain runs with
+  // the flag unset and deletes the directory below.
+  if (preserveUserDataDir) {
+    console.log(`[teardown] Preserving user data dir for relaunch: ${userDataDir}`);
+    console.log('[teardown] Complete');
+    return;
   }
 
   console.log('[teardown] Cleaning up user data dir...');

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -46,6 +46,39 @@ function waitForPort(port: number, timeout: number): Promise<void> {
   });
 }
 
+/**
+ * Newest file modification time (ms since epoch) under `dir`, recursively. Used to detect a stale
+ * dev main bundle. `node_modules` is skipped — dependency changes are reflected in package.json.
+ */
+function newestMtimeMs(dir: string): number {
+  return fs.readdirSync(dir, { withFileTypes: true }).reduce((newest, entry) => {
+    if (entry.name === 'node_modules') return newest;
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) return Math.max(newest, newestMtimeMs(entryPath));
+    if (entry.isFile()) return Math.max(newest, fs.statSync(entryPath).mtimeMs);
+    return newest;
+  }, 0);
+}
+
+/**
+ * Whether the dev main bundle is older than the main-process sources it was built from. Playwright
+ * launches Electron against this prebuilt bundle (there is no webpack watcher in an E2E run), so a
+ * bundle from before the current checkout's changes would silently test STALE main-process code —
+ * the renderer, served fresh by the dev server, would be new while main stayed old.
+ */
+function isDevMainBundleStale(rootDir: string, devMainPath: string): boolean {
+  const bundleMtime = fs.statSync(devMainPath).mtimeMs;
+  // The bundle's inputs: the main-process entry tree (src/main plus the src/shared and src/node
+  // code it imports; src/extension-host and src/renderer run from source/dev-server and cannot go
+  // stale this way) and package.json (dependency changes).
+  const sourceDirs = ['src/main', 'src/shared', 'src/node'];
+  const newestSource = Math.max(
+    ...sourceDirs.map((dir) => newestMtimeMs(path.join(rootDir, dir))),
+    fs.statSync(path.join(rootDir, 'package.json')).mtimeMs,
+  );
+  return newestSource > bundleMtime;
+}
+
 // Playwright global setup requires this signature even though config is unused
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default async function globalSetup(_config: FullConfig): Promise<void> {
@@ -84,13 +117,17 @@ export default async function globalSetup(_config: FullConfig): Promise<void> {
     },
   );
 
-  // Ensure the dev main bundle exists
+  // Ensure the dev main bundle exists and is at least as new as the main-process sources — a
+  // stale bundle would run OLD main-process code against the fresh dev-server renderer.
   const devMainPath = path.join(rootDir, '.erb/dll/main.bundle.dev.js');
   if (!fs.existsSync(devMainPath)) {
     console.log('Development main bundle not found. Building...');
     execSync('npm run prestart', { cwd: rootDir, stdio: 'inherit' });
+  } else if (isDevMainBundleStale(rootDir, devMainPath)) {
+    console.log('Development main bundle is older than main-process sources. Rebuilding...');
+    execSync('npm run prestart', { cwd: rootDir, stdio: 'inherit' });
   } else {
-    console.log('Development main bundle found.');
+    console.log('Development main bundle found and up to date.');
   }
 
   // Start the webpack dev server for the renderer if not already running

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -70,8 +70,16 @@ function isDevMainBundleStale(rootDir: string, devMainPath: string): boolean {
   const bundleMtime = fs.statSync(devMainPath).mtimeMs;
   // The bundle's inputs: the main-process entry tree (src/main plus the src/shared and src/node
   // code it imports; src/extension-host and src/renderer run from source/dev-server and cannot go
-  // stale this way) and package.json (dependency changes).
-  const sourceDirs = ['src/main', 'src/shared', 'src/node'];
+  // stale this way), the workspace library the bundle compiles in (platform-bible-utils; the
+  // platform-bible-react import in src/shared is types-only and never reaches the bundle), the
+  // webpack configs that shape the bundle, and package.json (dependency changes).
+  const sourceDirs = [
+    'src/main',
+    'src/shared',
+    'src/node',
+    'lib/platform-bible-utils/src',
+    '.erb/configs',
+  ];
   const newestSource = Math.max(
     ...sourceDirs.map((dir) => newestMtimeMs(path.join(rootDir, dir))),
     fs.statSync(path.join(rootDir, 'package.json')).mtimeMs,

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -22,7 +22,7 @@ npx playwright test --config e2e-tests/playwright.config.ts --project=isolated e
 
 - `comment-assignment/` — tests for assigning comments to users
 - `first-run/` — tests for the first-run wizard (PT-4175 / PT-4179)
-- `multi-window/` — tests for multi-window lifecycle (second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit) and window layout persistence (windows, layouts, and bounds surviving relaunches; a deliberately closed window staying closed)
+- `multi-window/` — tests for multi-window lifecycle (second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit) and window layout persistence (windows, layouts, and bounds surviving relaunches; a deliberately closed window staying closed; the pre-multi-window single-window upgrade path)
 - `navigation-history/` — tests for back/forward reference history navigation
 - `overlay/` — tests for the project-switch transition overlay
 - `scroll-groups/` — tests for scroll-group synchronization between scripture editors

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -22,7 +22,7 @@ npx playwright test --config e2e-tests/playwright.config.ts --project=isolated e
 
 - `comment-assignment/` — tests for assigning comments to users
 - `first-run/` — tests for the first-run wizard (PT-4175 / PT-4179)
-- `multi-window/` — tests for multi-window lifecycle: second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit
+- `multi-window/` — tests for multi-window lifecycle (second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit) and window layout persistence (windows, layouts, and bounds surviving relaunches; a deliberately closed window staying closed)
 - `navigation-history/` — tests for back/forward reference history navigation
 - `overlay/` — tests for the project-switch transition overlay
 - `scroll-groups/` — tests for scroll-group synchronization between scripture editors

--- a/e2e-tests/tests/isolated/multi-window/multi-window.spec.ts
+++ b/e2e-tests/tests/isolated/multi-window/multi-window.spec.ts
@@ -10,13 +10,18 @@
  * Three tests, each launching its own Electron instance (the isolated fixture is test-scoped and
  * each launch costs 30+ seconds, so related assertions are grouped into one instance):
  *
- * 1. Second-window lifecycle: a second window starts clean (its web views get window-scoped ids, no
- *    duplicate-registration errors), generic window-service calls route to whichever window has
- *    focus, and closing the secondary window neither quits the app nor runs shutdown tasks.
+ * 1. Second-window lifecycle: a window created mid-session starts EMPTY — an empty dock with no tabs
+ *    (it must not clone the first window's layout or load a default layout) — while its per-window
+ *    services register under scoped names with no collisions, generic window-service calls route to
+ *    whichever window has focus, and closing the secondary window neither quits the app nor runs
+ *    shutdown tasks.
  * 2. Hosting takeover: window 1 hosts the app-global theme and scroll-group services; closing it hands
  *    hosting to window 2, proven by live PAPI reads AND a write round-trip against the survivor.
  * 3. Quit with two windows: the shutdown tasks run exactly once (not once per window, not zero times)
  *    and the process exits cleanly.
+ *
+ * Shared plumbing (output capture, window helpers, the graceful-quit pattern) lives in
+ * `multi-window.util.ts`, which `window-layout-persistence.spec.ts` also uses.
  *
  * ## App configuration
  *
@@ -33,9 +38,11 @@
  *   intercept every click.
  * - `platform.interfaceLanguage: ['en']` — locale determinism.
  *
- * With `DEV_NOISY=false` and no saved layout (fresh user-data dir per test), every window loads the
- * single-Home-tab layout from `src/renderer/testing/test-layout.data.ts`, whose fixed web view id
- * makes the per-window `-w{windowId}` scoping suffix directly observable.
+ * With `DEV_NOISY=false` and no saved layout (fresh user-data dir per test), the FIRST window loads
+ * the single-Home-tab layout from `src/renderer/testing/test-layout.data.ts` (the fallback for a
+ * profile with no saved window structure), whose fixed web view id makes the per-window
+ * `-w{windowId}` scoping suffix directly observable. A window created mid-session starts with an
+ * EMPTY dock layout — no tabs — by design, so window 2 in these tests renders no content.
  *
  * ## Log capture
  *
@@ -55,24 +62,30 @@ import {
   preConfigureSettings,
   sendPapiRequestOnce,
   waitForAppReady,
-  waitForPapiMethodRegistered,
+  waitForOverlayGone,
 } from '../../../fixtures/helpers';
-
-const WEBSOCKET_PORT = 8876;
-
-/**
- * Fixed web view id of the Home tab in the non-noisy dev layout. Source:
- * `src/renderer/testing/test-layout.data.ts` (the `DEV_NOISY=false` branch). The renderer suffixes
- * every web view id from a shared layout with the window it loads into (`-w1`, `-w2`, …; see
- * `src/renderer/components/docking/window-scoped-web-view-ids.util.ts`), so the rendered
- * `data-web-view-id` is this UUID plus that suffix.
- */
-const HOME_TAB_UUID = '7fc0e34a-d601-4995-fadc-92daa9ef713f';
+import {
+  DUPLICATE_REGISTRATION_PATTERN,
+  FAULT_MARKERS,
+  HOME_TAB_UUID,
+  WEBSOCKET_PORT,
+  captureAppOutput,
+  countOccurrences,
+  createSecondWindow,
+  createStepLogger,
+  expectWindowDockEmpty,
+  getWindowIdOfPage,
+  homeTabTitle,
+  pollUntil,
+  quitAppAndWaitForExit,
+  waitForRendererRegistered,
+} from './multi-window.util';
 
 // #region log markers
 // Exact substrings of log lines this suite keys on, each with the file that emits it. These are
 // behaviour-describing lines (outcomes a user/support person reads in a log), not internal symbol
-// names, so they are fair game for behaviour-level assertions.
+// names, so they are fair game for behaviour-level assertions. Markers shared with the
+// persistence spec live in multi-window.util.ts.
 
 /**
  * A renderer that lost the theme-hosting race attaches instead.
@@ -116,85 +129,6 @@ const APP_QUITTING_LOG = 'Main process is quitting';
  */
 const SHUTDOWN_MODE_UNREADABLE_LOG = 'Could not read platform.interfaceMode';
 
-/**
- * Faults that must never appear during any of the exercised flows: an unhandled rejection or
- * exception surfacing in the main process (`src/main/main.ts` process-level handlers), or an event
- * being emitted through an already-disposed emitter (`platform-bible-utils`), which past
- * multi-window handover defects surfaced as.
- */
-const FAULT_MARKERS = [
-  'Unhandled promise rejection',
-  'Unhandled exception in main process',
-  'Emitter is disposed',
-];
-
-/**
- * A warn/error-severity line reporting a name collision in the central registry. The same phrases
- * appear at debug severity on the EXPECTED step-aside paths (a second window losing the app-global
- * hosting race logs "… already registered" as debug), so severity is part of the pattern: only
- * warn/error occurrences indicate a window failing to scope its per-window services.
- */
-const DUPLICATE_REGISTRATION_PATTERN =
-  /\[(warn|error)\][^\n]*(already registered|rejected by the central registry)/;
-
-// #endregion
-
-// #region app output capture
-
-/** Accumulated stdout+stderr of the Electron process, with offset-based slicing. */
-interface AppOutputCapture {
-  /** Everything captured so far (ANSI color codes stripped). */
-  text(): string;
-  /** Opaque offset marking "now"; pass to {@link textFrom} to read only later output. */
-  mark(): number;
-  /** Everything captured after the given {@link mark} (ANSI color codes stripped). */
-  textFrom(offset: number): string;
-}
-
-/**
- * Start capturing the Electron process's stdout and stderr. Captures from the moment of the call —
- * output that was already flushed before (early startup) is not included, which every assertion in
- * this suite accounts for by marking an offset before triggering the behaviour it asserts on.
- *
- * Listeners are intentionally not detached: the process (and its stdio streams) is torn down with
- * the test-scoped fixture right after the test body, so there is nothing to leak into.
- */
-function captureAppOutput(electronApp: ElectronApplication): AppOutputCapture {
-  let buffer = '';
-  const append = (chunk: Buffer | string) => {
-    buffer += chunk.toString();
-  };
-  const proc = electronApp.process();
-  proc.stdout?.on('data', append);
-  proc.stderr?.on('data', append);
-  const stripAnsi = (raw: string) =>
-    // Terminal color escape sequences (from chalk in the app's console log transport) would break
-    // plain-substring matching, so strip them. The escape character is the point of the pattern.
-    // eslint-disable-next-line no-control-regex
-    raw.replace(/\u001b\[[0-9;]*m/g, '');
-  return {
-    text: () => stripAnsi(buffer),
-    mark: () => buffer.length,
-    textFrom: (offset: number) => stripAnsi(buffer.slice(offset)),
-  };
-}
-
-/** Number of times `needle` occurs in `haystack` (non-overlapping). */
-function countOccurrences(haystack: string, needle: string): number {
-  return haystack.split(needle).length - 1;
-}
-
-/**
- * Per-test elapsed-time step logger, so the runner output records how long each phase actually took
- * — the evidence for judging whether a pass exercised the intended waits (e.g. a hosting takeover
- * that includes an unreachability probe) or short-circuited.
- */
-function createStepLogger(): (label: string) => void {
-  const start = Date.now();
-  return (label: string) =>
-    console.log(`[multi-window +${((Date.now() - start) / 1000).toFixed(1)}s] ${label}`);
-}
-
 // #endregion
 
 // #region PAPI helpers (one-shot WebSocket JSON-RPC against the main process, port 8876)
@@ -225,6 +159,20 @@ type ThemeLike = { type?: string; cssVariables?: Record<string, string> } | unde
 async function getGenericWindowFocus(): Promise<FocusSubjectLike> {
   return sendPapiRequestOnce<FocusSubjectLike>(
     'object:platform.windowServiceDataProvider-data.getFocus',
+    [],
+    WEBSOCKET_PORT,
+    PAPI_ATTEMPT_TIMEOUT_MS,
+  );
+}
+
+/**
+ * Ask a SPECIFIC window's scoped window service for its own current focus subject, bypassing the
+ * routing proxy. This is the ground truth of what that window would answer if the generic call were
+ * routed to it.
+ */
+async function getScopedWindowFocus(windowId: number): Promise<FocusSubjectLike> {
+  return sendPapiRequestOnce<FocusSubjectLike>(
+    `object:platform.windowServiceDataProvider-${windowId}-data.getFocus`,
     [],
     WEBSOCKET_PORT,
     PAPI_ATTEMPT_TIMEOUT_MS,
@@ -289,93 +237,9 @@ function isVerseRefShaped(ref: VerseRefLike): boolean {
   return typeof ref?.book === 'string' && typeof ref.chapterNum === 'number';
 }
 
-/**
- * Repeatedly run `attempt` until `isAcceptable` accepts its value or `deadlineMs` elapses.
- * Rejections from `attempt` count as "not yet" (the service may legitimately be unreachable
- * mid-handover), so the last error is folded into the timeout message for diagnosis.
- */
-async function pollUntil<T>(
-  attempt: () => Promise<T>,
-  isAcceptable: (value: T) => boolean,
-  deadlineMs: number,
-  label: string,
-  intervalMs = 1_000,
-): Promise<T> {
-  const deadline = Date.now() + deadlineMs;
-  let lastFailure = 'no attempt settled';
-  for (;;) {
-    try {
-      // Sequential polling: each attempt must settle before the next; parallel attempts would
-      // hammer a service that is mid-handover.
-      // eslint-disable-next-line no-await-in-loop
-      const value = await attempt();
-      if (isAcceptable(value)) return value;
-      lastFailure = `last value was not acceptable: ${JSON.stringify(value)}`;
-    } catch (e) {
-      lastFailure = `last attempt rejected: ${e instanceof Error ? e.message : String(e)}`;
-    }
-    if (Date.now() >= deadline)
-      throw new Error(`Timed out after ${deadlineMs} ms waiting for ${label}; ${lastFailure}`);
-    // Sequential polling: wait between attempts (see above).
-    // eslint-disable-next-line no-await-in-loop
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, intervalMs);
-    });
-  }
-}
-
 // #endregion
 
-// #region window helpers
-
-/**
- * The window's Electron BrowserWindow id, read from the `windowId` query parameter the main process
- * puts in every renderer URL (`WINDOW_ID` in `src/shared/data/platform.data.ts`).
- */
-function getWindowIdOfPage(page: Page): number {
-  const rawId = new URL(page.url()).searchParams.get('windowId');
-  const id = Number(rawId);
-  if (!Number.isInteger(id) || id <= 0)
-    throw new Error(`Page URL ${page.url()} has no usable windowId query parameter`);
-  return id;
-}
-
-/**
- * Create a second application window through the public `platform.createWindow` command and return
- * its Page. The window event listener is armed BEFORE the command is sent, so the new window cannot
- * be missed. The predicate skips any non-app page (e.g. a detached devtools window) by requiring
- * the renderer URL's `windowId` query parameter.
- */
-async function createSecondWindow(electronApp: ElectronApplication): Promise<Page> {
-  const windowPromise = electronApp.waitForEvent('window', {
-    predicate: (page: Page) => page.url().includes('windowId='),
-    timeout: 60_000,
-  });
-  await sendPapiRequestOnce('command:platform.createWindow', [], WEBSOCKET_PORT, 30_000);
-  const page = await windowPromise;
-  await page.waitForLoadState('domcontentloaded');
-  await page.waitForSelector('#root', { state: 'attached', timeout: 60_000 });
-  return page;
-}
-
-/**
- * Wait until a window's renderer has registered its window-scoped services with the main process:
- * its scoped `platform.about-{windowId}` command (the last of the renderer's command registrations)
- * and its scoped window service (what the routing proxies forward to). Only then can generic-name
- * calls be routed to this window.
- */
-async function waitForRendererRegistered(windowId: number, timeoutMs: number): Promise<void> {
-  await waitForPapiMethodRegistered(
-    new RegExp(`^command:platform\\.about-${windowId}$`),
-    WEBSOCKET_PORT,
-    timeoutMs,
-  );
-  await waitForPapiMethodRegistered(
-    new RegExp(`^object:platform\\.windowServiceDataProvider-${windowId}-data\\.`),
-    WEBSOCKET_PORT,
-    timeoutMs,
-  );
-}
+// #region window focus helpers
 
 /**
  * How long {@link focusWindowAndWaitForRouting} keeps asking the display server to activate the
@@ -432,11 +296,6 @@ async function focusWindowAndWaitForRouting(
   );
 }
 
-/** Locator for a window's Home tab title, which carries the window-scoped web view id. */
-function homeTabTitle(page: Page, windowId: number) {
-  return page.locator(`.platform-tab-title[data-web-view-id="${HOME_TAB_UUID}-w${windowId}"]`);
-}
-
 /**
  * Click into a window's Home web view so that window's focus subject becomes the Home web view.
  * Clicking inside the iframe focuses the iframe element in the window document, which the window
@@ -478,7 +337,8 @@ test.use({
   //
   // DEV_NOISY=false: the noisy-dev layout has no stable single web view to key on and loads
   // test-only extensions; the quiet layout is a single Home tab with a fixed web view id (see
-  // HOME_TAB_UUID) in every window, which is exactly what the scoping assertions need.
+  // HOME_TAB_UUID) in the first window, which is exactly what the scoping and focus assertions
+  // need. Mid-session windows start empty regardless of the dev layout.
   electronLaunchOptions: { isolatedProjectRoot: true, envOverrides: { DEV_NOISY: 'false' } },
 });
 
@@ -503,18 +363,29 @@ test.describe('multi-window lifecycle', () => {
     restoreSettings?.();
   });
 
-  test('second window starts clean, focus routing follows the focused window, and closing the secondary window does not shut the app down', async ({
+  test('second window starts empty, focus routing follows the focused window, and closing the secondary window does not shut the app down', async ({
     electronApp,
     mainPage,
   }) => {
-    const logStep = createStepLogger();
+    const logStep = createStepLogger('multi-window');
     const output = captureAppOutput(electronApp);
     await waitForAppReady(mainPage, 180_000);
     const window1Id = getWindowIdOfPage(mainPage);
     logStep(`window ${window1Id} ready`);
 
-    // Window 1's own Home web view id carries its window suffix.
+    // Window 1 — the profile's first window, which loads the single-Home-tab fallback layout —
+    // renders its Home web view id with its own window suffix.
     await expect(homeTabTitle(mainPage, window1Id)).toBeAttached({ timeout: 60_000 });
+
+    // Pin the generic window service's focus answer to a window-1 subject BEFORE the second window
+    // exists: click into window 1's Home web view so window 1's focus subject is that web view.
+    // The routing assertion after window 2 takes focus hinges on this baseline — the generic
+    // answer must CHANGE away from this subject, which it can only do by being routed elsewhere.
+    await focusWindowAndWaitForRouting(electronApp, window1Id);
+    await clickIntoHomeWebView(mainPage, window1Id);
+    const baselineFocus = await waitForGenericFocusToReportWindow(window1Id);
+    expect(baselineFocus?.id).toBe(`${HOME_TAB_UUID}-w${window1Id}`);
+    logStep(`generic getFocus pinned to window ${window1Id}'s Home web view`);
 
     // Create the second window through the public command, with the window listener armed first.
     const beforeCreateMark = output.mark();
@@ -524,10 +395,12 @@ test.describe('multi-window lifecycle', () => {
     await waitForRendererRegistered(window2Id, 120_000);
     logStep(`window ${window2Id} created and registered`);
 
-    // The second renderer renders the app UI with ITS OWN window-scoped web view ids: same layout,
-    // same fixed UUID, different window suffix. If id scoping regressed, both windows would hold
-    // the same id and the second window's messages/state would collide with the first's.
-    await expect(homeTabTitle(page2, window2Id)).toBeAttached({ timeout: 120_000 });
+    // A window created mid-session starts EMPTY: its dock renders with zero tabs and zero web view
+    // iframes. This is decided product behaviour; the failure modes it locks out are a new window
+    // cloning window 1's layout or loading a default layout, either of which would render tabs
+    // here.
+    await expectWindowDockEmpty(page2);
+    logStep(`window ${window2Id} rendered an empty dock`);
 
     // The second renderer must start clean: its per-window services register under scoped names,
     // so nothing may collide with window 1's registrations. Expected step-aside lines for the
@@ -535,11 +408,28 @@ test.describe('multi-window lifecycle', () => {
     const window2StartupLog = output.textFrom(beforeCreateMark);
     expect(window2StartupLog).not.toMatch(DUPLICATE_REGISTRATION_PATTERN);
 
-    // Focus routing: with window 2 focused, generic window-service calls answer for window 2.
+    // Focus routing: with window 2 focused, generic window-service calls must be answered by
+    // window 2. A tab-less window has no tab or web view to focus, so its genuine focus report is
+    // the tab-less subject `{ focusType: 'other' }` (the window's focus rests on the document
+    // body, which belongs to no tab). Reaching that answer proves the routing proxy re-pointed to
+    // window 2: window 1's subject remains the Home web view pinned above (`focusType: 'webView'`
+    // with a `-w1` id), which can never satisfy this poll.
     await focusWindowAndWaitForRouting(electronApp, window2Id);
-    await clickIntoHomeWebView(page2, window2Id);
-    const focusInWindow2 = await waitForGenericFocusToReportWindow(window2Id);
-    expect(focusInWindow2?.id).toBe(`${HOME_TAB_UUID}-w${window2Id}`);
+    const focusInWindow2 = await pollUntil(
+      getGenericWindowFocus,
+      (focus) => focus?.focusType === 'other',
+      30_000,
+      `generic getFocus to report window ${window2Id}'s tab-less focus subject`,
+    );
+    // The exact shape a tab-less window reports: 'other' with no id — in particular NOT window 1's
+    // Home web view id.
+    expect(focusInWindow2).toEqual({ focusType: 'other' });
+    // Discriminate "routed to window 2" from "still answering window 1": window 1's own scoped
+    // service must still hold its Home web view subject (a background window's focused element is
+    // retained while the window is inactive), so the 'other' answer above cannot have come from
+    // window 1 — only from the routing proxy genuinely forwarding to window 2.
+    const window1OwnFocus = await getScopedWindowFocus(window1Id);
+    expect(window1OwnFocus?.id).toBe(`${HOME_TAB_UUID}-w${window1Id}`);
     logStep(`generic getFocus answered for window ${window2Id}`);
 
     // …and it follows focus back to window 1.
@@ -594,7 +484,7 @@ test.describe('multi-window lifecycle', () => {
     electronApp,
     mainPage,
   }) => {
-    const logStep = createStepLogger();
+    const logStep = createStepLogger('multi-window');
     const output = captureAppOutput(electronApp);
     await waitForAppReady(mainPage, 180_000);
     logStep('window 1 ready');
@@ -620,9 +510,11 @@ test.describe('multi-window lifecycle', () => {
     const page2 = await createSecondWindow(electronApp);
     const window2Id = getWindowIdOfPage(page2);
     await waitForRendererRegistered(window2Id, 120_000);
-    // Window 2 must also have its UI up (not just its services registered) so it is a genuinely
-    // live survivor when window 1 goes away.
-    await expect(homeTabTitle(page2, window2Id)).toBeAttached({ timeout: 120_000 });
+    // Window 2 must also have its UI genuinely up (not just its services registered) so it is a
+    // live survivor when window 1 goes away. A mid-session window has no tabs, so "up" means its
+    // dock container rendered and its startup overlay cleared.
+    await expect(page2.locator('div[class*="dock-layout"]')).toBeAttached({ timeout: 120_000 });
+    await waitForOverlayGone(page2, 120_000);
 
     // Window 1 hosts both app-global services, so window 2 steps aside for each — the log records
     // that explicitly. Renderer log lines reach the captured stream asynchronously, hence the poll.
@@ -699,7 +591,7 @@ test.describe('multi-window lifecycle', () => {
     electronApp,
     mainPage,
   }) => {
-    const logStep = createStepLogger();
+    const logStep = createStepLogger('multi-window');
     const output = captureAppOutput(electronApp);
     await waitForAppReady(mainPage, 180_000);
 
@@ -709,57 +601,15 @@ test.describe('multi-window lifecycle', () => {
     await waitForRendererRegistered(window2Id, 120_000);
     logStep('both windows up; quitting');
 
-    // Watch the OS process itself, not Playwright's ElectronApplication `close` event. That event
-    // additionally waits for the process's stdio streams to close, and a graceful dev-mode quit
-    // leaves the .NET data provider watcher child alive holding the inherited pipe write-ends — so
-    // the event can stay unfired long after Electron has exited cleanly. The child process `exit`
-    // event fires on the exit itself, which is the behaviour under test. Armed before quitting.
-    const electronProcess = electronApp.process();
-    const processExit = new Promise<{ code: number | undefined; signal: string | undefined }>(
-      (resolve) => {
-        electronProcess.once('exit', (code, signal) =>
-          resolve({ code: code ?? undefined, signal: signal ?? undefined }),
-        );
-      },
-    );
-
-    // Trigger a REAL quit, exactly what File > Exit or Cmd+Q does. app.quit() is scheduled rather
-    // than called inline so the evaluate round-trip completes before teardown begins.
-    await electronApp.evaluate(({ app }) => {
-      setTimeout(() => app.quit(), 0);
-    });
-
-    // Budget: the quit path is a bounded shutdown-sync attempt (which rejects immediately here —
-    // no S/R extension is registered) plus bounded child-process waits of a few seconds, so a
-    // healthy quit lands well under a minute; 120 seconds is slow-machine headroom. A quit that
-    // exceeds it means shutdown hung, which is exactly a failure of the behaviour under test.
-    const exitResult = await Promise.race([
-      processExit,
-      new Promise<never>((_resolve, reject) => {
-        setTimeout(
-          () => reject(new Error('Electron process did not exit within 120 s of app.quit()')),
-          120_000,
-        );
-      }),
-    ]);
+    // Trigger a REAL quit and watch the OS process itself — see quitAppAndWaitForExit for why the
+    // process `exit` event (not Playwright's `close` event) is the right signal and why the
+    // leftover process group is reaped afterwards.
+    const exitResult = await quitAppAndWaitForExit(electronApp);
     logStep(`process exited with code ${exitResult.code} signal ${exitResult.signal}`);
 
     // The process must exit cleanly (exit code 0), not by signal.
     expect(exitResult.signal).toBeUndefined();
     expect(exitResult.code).toBe(0);
-
-    // Reap what the graceful quit leaves behind: in dev mode the .NET watcher child survives its
-    // Electron parent, holding the inherited stdio pipes open. Kill the leftover process group so
-    // nothing leaks into later tests and the runner's own cleanup (which waits on those pipes)
-    // cannot stall on it. The group leader is already gone, so any error just means the group is
-    // fully dead — the desired state.
-    if (electronProcess.pid) {
-      try {
-        process.kill(-electronProcess.pid, 'SIGKILL');
-      } catch {
-        /* process group already gone */
-      }
-    }
 
     const log = output.text();
 

--- a/e2e-tests/tests/isolated/multi-window/multi-window.util.ts
+++ b/e2e-tests/tests/isolated/multi-window/multi-window.util.ts
@@ -1,0 +1,354 @@
+/**
+ * Shared helpers for the multi-window e2e specs (`multi-window.spec.ts` and
+ * `window-layout-persistence.spec.ts`): Electron process output capture, PAPI wrappers for creating
+ * windows and waiting for renderer registration, dock-content probes, and the graceful-quit pattern
+ * that watches the OS process itself.
+ *
+ * Everything here follows the suites' shared philosophy: assert only what an outside observer can
+ * see — PAPI responses over the WebSocket, page content, process exits, and log lines describing
+ * user-visible outcomes — so the implementation underneath can be refactored while the tests keep
+ * guarding the behaviour.
+ */
+import { ElectronApplication, Page, expect } from '@playwright/test';
+import {
+  sendPapiRequestOnce,
+  waitForOverlayGone,
+  waitForPapiMethodRegistered,
+} from '../../../fixtures/helpers';
+
+export const WEBSOCKET_PORT = 8876;
+
+/**
+ * Fixed web view id of the Home tab in the non-noisy dev layout. Source:
+ * `src/renderer/testing/test-layout.data.ts` (the `DEV_NOISY=false` branch). The renderer suffixes
+ * every web view id from a shared layout with the window it loads into (`-w1`, `-w2`, …; see
+ * `src/renderer/components/docking/window-scoped-web-view-ids.util.ts`), so the rendered
+ * `data-web-view-id` is this UUID plus that suffix.
+ */
+export const HOME_TAB_UUID = '7fc0e34a-d601-4995-fadc-92daa9ef713f';
+
+// #region log markers shared by both specs
+
+/**
+ * Faults that must never appear during any of the exercised flows: an unhandled rejection or
+ * exception surfacing in the main process (`src/main/main.ts` process-level handlers), or an event
+ * being emitted through an already-disposed emitter (`platform-bible-utils`), which multi-window
+ * handover defects surface as.
+ */
+export const FAULT_MARKERS = [
+  'Unhandled promise rejection',
+  'Unhandled exception in main process',
+  'Emitter is disposed',
+];
+
+/**
+ * A warn/error-severity line reporting a name collision in the central registry. The same phrases
+ * appear at debug severity on the EXPECTED step-aside paths (a second window losing the app-global
+ * hosting race logs "… already registered" as debug), so severity is part of the pattern: only
+ * warn/error occurrences indicate a window failing to scope its per-window services.
+ */
+export const DUPLICATE_REGISTRATION_PATTERN =
+  /\[(warn|error)\][^\n]*(already registered|rejected by the central registry)/;
+
+// #endregion
+
+// #region app output capture
+
+/** Accumulated stdout+stderr of the Electron process, with offset-based slicing. */
+export interface AppOutputCapture {
+  /** Everything captured so far (ANSI color codes stripped). */
+  text(): string;
+  /** Opaque offset marking "now"; pass to {@link textFrom} to read only later output. */
+  mark(): number;
+  /** Everything captured after the given {@link mark} (ANSI color codes stripped). */
+  textFrom(offset: number): string;
+}
+
+/**
+ * Start capturing the Electron process's stdout and stderr. Captures from the moment of the call —
+ * output that was already flushed before (early startup) is not included, which every assertion in
+ * these suites accounts for by marking an offset before triggering the behaviour it asserts on.
+ *
+ * Listeners are intentionally not detached: the process (and its stdio streams) is torn down with
+ * its Electron instance right after the assertions that read the capture, so there is nothing to
+ * leak into.
+ */
+export function captureAppOutput(electronApp: ElectronApplication): AppOutputCapture {
+  let buffer = '';
+  const append = (chunk: Buffer | string) => {
+    buffer += chunk.toString();
+  };
+  const proc = electronApp.process();
+  proc.stdout?.on('data', append);
+  proc.stderr?.on('data', append);
+  const stripAnsi = (raw: string) =>
+    // Terminal color escape sequences (from chalk in the app's console log transport) would break
+    // plain-substring matching, so strip them. The escape character is the point of the pattern.
+    // eslint-disable-next-line no-control-regex
+    raw.replace(/\u001b\[[0-9;]*m/g, '');
+  return {
+    text: () => stripAnsi(buffer),
+    mark: () => buffer.length,
+    textFrom: (offset: number) => stripAnsi(buffer.slice(offset)),
+  };
+}
+
+/** Number of times `needle` occurs in `haystack` (non-overlapping). */
+export function countOccurrences(haystack: string, needle: string): number {
+  return haystack.split(needle).length - 1;
+}
+
+/**
+ * Per-test elapsed-time step logger, so the runner output records how long each phase actually took
+ * — the evidence for judging whether a pass exercised the intended waits (e.g. a hosting takeover
+ * that includes an unreachability probe) or short-circuited.
+ */
+export function createStepLogger(prefix: string): (label: string) => void {
+  const start = Date.now();
+  return (label: string) =>
+    console.log(`[${prefix} +${((Date.now() - start) / 1000).toFixed(1)}s] ${label}`);
+}
+
+// #endregion
+
+// #region polling
+
+/**
+ * Repeatedly run `attempt` until `isAcceptable` accepts its value or `deadlineMs` elapses.
+ * Rejections from `attempt` count as "not yet" (the service may legitimately be unreachable
+ * mid-handover), so the last error is folded into the timeout message for diagnosis.
+ */
+export async function pollUntil<T>(
+  attempt: () => Promise<T>,
+  isAcceptable: (value: T) => boolean,
+  deadlineMs: number,
+  label: string,
+  intervalMs = 1_000,
+): Promise<T> {
+  const deadline = Date.now() + deadlineMs;
+  let lastFailure = 'no attempt settled';
+  for (;;) {
+    try {
+      // Sequential polling: each attempt must settle before the next; parallel attempts would
+      // hammer a service that is mid-handover.
+      // eslint-disable-next-line no-await-in-loop
+      const value = await attempt();
+      if (isAcceptable(value)) return value;
+      lastFailure = `last value was not acceptable: ${JSON.stringify(value)}`;
+    } catch (e) {
+      lastFailure = `last attempt rejected: ${e instanceof Error ? e.message : String(e)}`;
+    }
+    if (Date.now() >= deadline)
+      throw new Error(`Timed out after ${deadlineMs} ms waiting for ${label}; ${lastFailure}`);
+    // Sequential polling: wait between attempts (see above).
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, intervalMs);
+    });
+  }
+}
+
+// #endregion
+
+// #region window helpers
+
+/**
+ * The window's Electron BrowserWindow id, read from the `windowId` query parameter the main process
+ * puts in every renderer URL (`WINDOW_ID` in `src/shared/data/platform.data.ts`).
+ */
+export function getWindowIdOfPage(page: Page): number {
+  const rawId = new URL(page.url()).searchParams.get('windowId');
+  const id = Number(rawId);
+  if (!Number.isInteger(id) || id <= 0)
+    throw new Error(`Page URL ${page.url()} has no usable windowId query parameter`);
+  return id;
+}
+
+/**
+ * The app's renderer pages (windows), sorted by their BrowserWindow id. Filters out any non-app
+ * page (e.g. a detached devtools window) by requiring the renderer URL's `windowId` query
+ * parameter. BrowserWindow ids increase in creation order within one app session, so the sort puts
+ * the earliest-created window first — at startup that is the main window, which the app creates
+ * before any secondary window.
+ */
+export function getAppPages(electronApp: ElectronApplication): Page[] {
+  return electronApp
+    .windows()
+    .filter((page) => !page.isClosed() && page.url().includes('windowId='))
+    .sort((a, b) => getWindowIdOfPage(a) - getWindowIdOfPage(b));
+}
+
+/**
+ * Wait until the app has at least `count` open windows (renderer pages), then return them sorted by
+ * BrowserWindow id (see {@link getAppPages}), each with its React root attached. For asserting
+ * "exactly N windows", follow this with a settle period and a {@link getAppPages} length check —
+ * this only waits for the count to be reached.
+ */
+export async function waitForAppPages(
+  electronApp: ElectronApplication,
+  count: number,
+  timeoutMs: number,
+): Promise<Page[]> {
+  const pages = await pollUntil(
+    async () => getAppPages(electronApp),
+    (candidate) => candidate.length >= count,
+    timeoutMs,
+    `${count} app window(s) to be open`,
+  );
+  await Promise.all(
+    pages.map(async (page) => {
+      await page.waitForLoadState('domcontentloaded');
+      await page.waitForSelector('#root', { state: 'attached', timeout: 60_000 });
+    }),
+  );
+  return pages;
+}
+
+/**
+ * Create a second application window through the public `platform.createWindow` command and return
+ * its Page. The window event listener is armed BEFORE the command is sent, so the new window cannot
+ * be missed. The predicate skips any non-app page (e.g. a detached devtools window) by requiring
+ * the renderer URL's `windowId` query parameter.
+ */
+export async function createSecondWindow(electronApp: ElectronApplication): Promise<Page> {
+  const windowPromise = electronApp.waitForEvent('window', {
+    predicate: (page: Page) => page.url().includes('windowId='),
+    timeout: 60_000,
+  });
+  await sendPapiRequestOnce('command:platform.createWindow', [], WEBSOCKET_PORT, 30_000);
+  const page = await windowPromise;
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForSelector('#root', { state: 'attached', timeout: 60_000 });
+  return page;
+}
+
+/**
+ * Wait until a window's renderer has registered its window-scoped services with the main process:
+ * its scoped `platform.about-{windowId}` command (the last of the renderer's command registrations)
+ * and its scoped window service (what the routing proxies forward to). Only then can generic-name
+ * calls be routed to this window.
+ */
+export async function waitForRendererRegistered(
+  windowId: number,
+  timeoutMs: number,
+): Promise<void> {
+  await waitForPapiMethodRegistered(
+    new RegExp(`^command:platform\\.about-${windowId}$`),
+    WEBSOCKET_PORT,
+    timeoutMs,
+  );
+  await waitForPapiMethodRegistered(
+    new RegExp(`^object:platform\\.windowServiceDataProvider-${windowId}-data\\.`),
+    WEBSOCKET_PORT,
+    timeoutMs,
+  );
+}
+
+/** Locator for a window's Home tab title, which carries the window-scoped web view id. */
+export function homeTabTitle(page: Page, windowId: number) {
+  return page.locator(`.platform-tab-title[data-web-view-id="${HOME_TAB_UUID}-w${windowId}"]`);
+}
+
+/**
+ * How long {@link expectWindowDockEmpty} waits after the window's UI is up before asserting
+ * emptiness. An empty dock and a dock about to load tabs look identical for a moment — the dock
+ * container renders before any layout content arrives — so asserting zero tabs immediately could
+ * pass vacuously while a wrongly-loaded layout (a clone of another window's, or a default) is still
+ * on its way. The window's startup overlay clearing already signals initialization is done; this
+ * settle is headroom on top of that for stragglers.
+ */
+const EMPTY_DOCK_SETTLE_MS = 5_000;
+
+/**
+ * Assert that a window's dock UI is genuinely up and renders NO content: zero dock tabs, zero tab
+ * titles, zero web view iframes. This is the observable shape of a window that starts (or is
+ * restored) with an empty layout.
+ *
+ * Fails if the window renders any tab — which is exactly what a regression to loading a default
+ * layout, or to cloning another window's layout into this one, would produce.
+ */
+export async function expectWindowDockEmpty(page: Page): Promise<void> {
+  // The dock container itself must render — "no tabs because the UI never came up" must fail, not
+  // pass. Then the startup overlay must clear, signalling async initialization (settings, theme,
+  // layout load) finished.
+  await expect(page.locator('div[class*="dock-layout"]')).toBeAttached({ timeout: 120_000 });
+  await waitForOverlayGone(page, 120_000);
+  // Give a wrongly-loaded layout time to become observable before asserting absence.
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, EMPTY_DOCK_SETTLE_MS);
+  });
+  await expect(page.locator('.dock-tab')).toHaveCount(0);
+  await expect(page.locator('.platform-tab-title')).toHaveCount(0);
+  await expect(page.locator('iframe[data-web-view-id]')).toHaveCount(0);
+}
+
+// #endregion
+
+// #region graceful quit
+
+/** Exit report of the Electron OS process. */
+export interface AppExitResult {
+  code: number | undefined;
+  signal: string | undefined;
+}
+
+/**
+ * Trigger a REAL app quit — exactly what File > Exit or Cmd+Q does — and wait for the Electron OS
+ * process to exit, then reap the leftover process group. Returns the exit code/signal for the
+ * caller to assert on (a clean quit exits with code 0 and no signal).
+ *
+ * Watches the OS process itself, not Playwright's ElectronApplication `close` event. That event
+ * additionally waits for the process's stdio streams to close, and a graceful dev-mode quit leaves
+ * the .NET data provider watcher child alive holding the inherited pipe write-ends — so the event
+ * can stay unfired long after Electron has exited cleanly. The child process `exit` event fires on
+ * the exit itself, which is the behaviour under test. Armed before quitting.
+ *
+ * `app.quit()` is scheduled rather than called inline so the evaluate round-trip completes before
+ * teardown begins.
+ *
+ * Budget: the quit path is a bounded shutdown-sync attempt (which rejects immediately when no S/R
+ * extension is registered) plus bounded child-process waits of a few seconds, so a healthy quit
+ * lands well under a minute; 120 seconds is slow-machine headroom. A quit that exceeds it means
+ * shutdown hung, which is exactly a failure of the behaviour under test.
+ *
+ * Reaping: in dev mode the .NET watcher child survives its Electron parent, holding the inherited
+ * stdio pipes open. Killing the leftover process group means nothing leaks into later launches and
+ * the runner's own cleanup (which waits on those pipes) cannot stall on it. The group leader is
+ * already gone, so any error just means the group is fully dead — the desired state.
+ */
+export async function quitAppAndWaitForExit(
+  electronApp: ElectronApplication,
+): Promise<AppExitResult> {
+  const electronProcess = electronApp.process();
+  const processExit = new Promise<AppExitResult>((resolve) => {
+    electronProcess.once('exit', (code, signal) =>
+      resolve({ code: code ?? undefined, signal: signal ?? undefined }),
+    );
+  });
+
+  await electronApp.evaluate(({ app }) => {
+    setTimeout(() => app.quit(), 0);
+  });
+
+  const exitResult = await Promise.race([
+    processExit,
+    new Promise<never>((_resolve, reject) => {
+      setTimeout(
+        () => reject(new Error('Electron process did not exit within 120 s of app.quit()')),
+        120_000,
+      );
+    }),
+  ]);
+
+  if (electronProcess.pid) {
+    try {
+      process.kill(-electronProcess.pid, 'SIGKILL');
+    } catch {
+      /* process group already gone */
+    }
+  }
+
+  return exitResult;
+}
+
+// #endregion

--- a/e2e-tests/tests/isolated/multi-window/window-layout-persistence.spec.ts
+++ b/e2e-tests/tests/isolated/multi-window/window-layout-persistence.spec.ts
@@ -1,16 +1,15 @@
 /**
- * Window layout persistence e2e test.
+ * Window layout persistence e2e tests.
  *
- * Locks the across-restart behaviour of the window set: every window open at quit comes back on
- * relaunch — the main window with its dock layout, a deliberately-empty secondary window empty —
- * each at its saved bounds, while a window the user deliberately closed mid-session does NOT come
- * back.
+ * Two tests, each running sequential launches into its own preserved user-data profile (the launch
+ * helpers accept an existing `userDataDir` and can preserve it across teardowns — see
+ * `LaunchElectronAppOptions`). Launches are strictly sequential: the fixed WebSocket port and
+ * Electron's per-profile singleton lock forbid overlap, so each phase quits gracefully (and its
+ * leftover process group is reaped) before the next launches.
  *
- * One test, three sequential launches into the SAME user-data profile (the launch helpers accept an
- * existing `userDataDir` and can preserve it across teardowns — see `LaunchElectronAppOptions`).
- * Launches are strictly sequential: the fixed WebSocket port and Electron's per-profile singleton
- * lock forbid overlap, so each phase quits gracefully (and its leftover process group is reaped)
- * before the next launches.
+ * TEST 1 — the window set across restarts: every window open at quit comes back on relaunch — the
+ * main window with its dock layout, a deliberately-empty secondary window empty — each at its saved
+ * bounds, while a window the user deliberately closed mid-session does NOT come back.
  *
  * - Phase 1 (fresh profile): the first window shows the single-Home-tab fallback layout; a second
  *   window is created mid-session (it starts empty); both windows are placed at known,
@@ -21,18 +20,32 @@
  * - Phase 3 (second relaunch): exactly ONE window comes back (the deliberately closed window stays
  *   closed), still with its Home tab; graceful quit. The final teardown deletes the profile.
  *
+ * TEST 2 — the pre-multi-window upgrade path: a profile from before the window-layouts structure
+ * existed (a legacy dock layout under the renderer's unprefixed localStorage key, the old
+ * bounds-keeper file, and NO structure file) upgrades to exactly one window that loads the legacy
+ * layout and honors the keeper's window size — and a window created mid-session in that upgraded
+ * session still starts empty rather than cloning the legacy layout.
+ *
+ * - Launch A (fresh profile): the app runs normally; the layout it persists for the main window is
+ *   harvested from the structure file, extended with a SECOND web view tab (a Home clone under a
+ *   distinct id), and written to the legacy localStorage key from inside the renderer; graceful
+ *   quit.
+ * - Between launches (no app running): the structure file is deleted and an old-style keeper file
+ *   with a known window size is written — the profile now looks exactly like a pre-multi-window
+ *   install.
+ * - Launch B: exactly one window; it renders BOTH seeded tabs (the discriminator — no fallback layout
+ *   has two tabs, so a pass cannot come from the fresh-profile default); its size is the keeper
+ *   file's; a newly created second window starts empty; graceful quit; the final teardown deletes
+ *   the profile.
+ *
  * ## App configuration
  *
  * Same pre-configuration as `multi-window.spec.ts` (power mode, first-run complete, English) — and
- * here `platform.interfaceMode: 'power'` is additionally REQUIRED for phase 2's both-windows
+ * here `platform.interfaceMode: 'power'` is additionally REQUIRED for test 1 phase 2's both-windows
  * assertion, because simple mode is single-window and restores only the main window.
  *
  * ## Not covered here (and why)
  *
- * - The single-window legacy upgrade path (a profile holding only the previous bounds-keeper file and
- *   a pre-multi-window localStorage layout): needs a pre-multi-window profile fixture to be
- *   authored; the legacy-read behaviour is unit-covered in the main process's persistence service
- *   tests.
  * - Multi-monitor behaviour (restoring a window whose saved display is gone): this environment has a
  *   single virtual display; the monitor-gone re-placement is a pure function with its own unit
  *   tests.
@@ -255,6 +268,88 @@ function readSavedWindowEntries(userDataDir: string): SavedWindowEntry[] {
       bounds,
     };
   });
+}
+
+/**
+ * The legacy `localStorage` key the dock layout was saved under before per-window persistence moved
+ * layouts into the main process's window-layouts structure. The renderer still READS this key
+ * (never writes it) for the one window of a legacy pre-multi-window startup — see
+ * `getLegacySavedLayout` in `src/renderer/services/web-view.service-host.ts`.
+ */
+const LEGACY_DOCK_LAYOUT_STORAGE_KEY = 'dock-saved-layout';
+
+/**
+ * File the pre-multi-window bounds keeper maintained in the profile, holding the single window's
+ * placement as top-level `x`/`y`/`width`/`height` plus state flags. The main process reads it once
+ * for upgrade placement when no window-layouts structure exists — see
+ * `src/main/services/window-layout-persistence.service.ts`.
+ */
+const LEGACY_WINDOW_STATE_FILE_NAME = 'window-state.json';
+
+/**
+ * Web view id of the SECOND tab the upgrade test seeds into the legacy layout: a clone of the Home
+ * tab under this distinct id. Two tabs are the upgrade test's discriminator — the fresh-profile
+ * fallback layout has exactly one tab and an empty layout has none, so only the seeded legacy blob
+ * can produce a tab with this id.
+ */
+const LEGACY_SECOND_TAB_UUID = 'ada6a781-10bf-46f3-a2f9-a1bb0e2fa221';
+
+/**
+ * Window size the upgrade test writes into the legacy keeper file. Deliberately different from the
+ * app's fallback size ({@link FALLBACK_WINDOW_SIZE}), so an upgrade that ignores the keeper file
+ * (and falls back to the default size) is distinguishable from one that honors it.
+ */
+const LEGACY_KEEPER_SIZE = { width: 1000, height: 640 };
+
+/**
+ * Build the legacy two-tab layout for the upgrade test from the layout the app itself persisted:
+ * find the panel holding the Home tab and append a clone of that tab under
+ * {@link LEGACY_SECOND_TAB_UUID}. Cloning the app's own saved tab (rather than authoring a layout by
+ * hand) keeps the blob's shape exactly what a real pre-multi-window profile held. The clone's saved
+ * web view definition mirrors the new id the way every saved web view tab's does — the tab loader
+ * enforces that match.
+ *
+ * @param mainLayoutJson The main entry's layout from the persisted structure, as JSON text
+ * @returns The two-tab layout object, ready to serialize under the legacy localStorage key
+ */
+function buildTwoTabLegacyLayout(mainLayoutJson: string): Record<string, unknown> {
+  const layout = asRecord(JSON.parse(mainLayoutJson));
+  if (!layout) throw new Error('main entry layout is not object-shaped');
+
+  const insertCloneTab = (node: Record<string, unknown>): boolean => {
+    const { tabs } = node;
+    if (Array.isArray(tabs)) {
+      const homeTab = tabs
+        .map((tab: unknown) => asRecord(tab))
+        .find((tab) => typeof tab?.id === 'string' && tab.id.includes(HOME_TAB_UUID));
+      if (homeTab && typeof homeTab.id === 'string') {
+        // Derive the clone id from the Home tab id so any window-scoping suffix carries over
+        // unchanged (loading re-scopes ids to the loading window anyway)
+        const cloneId = homeTab.id.split(HOME_TAB_UUID).join(LEGACY_SECOND_TAB_UUID);
+        const homeTabData = asRecord(homeTab.data);
+        tabs.push({
+          ...homeTab,
+          id: cloneId,
+          ...(homeTabData ? { data: { ...homeTabData, id: cloneId } } : {}),
+        });
+        return true;
+      }
+    }
+    const { children } = node;
+    if (Array.isArray(children))
+      return children.some((child: unknown) => {
+        const childRecord = asRecord(child);
+        return childRecord ? insertCloneTab(childRecord) : false;
+      });
+    return false;
+  };
+
+  const dockbox = asRecord(layout.dockbox);
+  if (!dockbox || !insertCloneTab(dockbox))
+    throw new Error(
+      `could not find the Home tab to clone in the persisted layout: ${mainLayoutJson}`,
+    );
+  return layout;
 }
 
 test.describe('window layout persistence', () => {
@@ -509,6 +604,180 @@ test.describe('window layout persistence', () => {
     } finally {
       // On any failure above: kill whatever instance is still up, then remove the preserved
       // profile directory so a failed run leaks nothing. Both are no-ops after a clean phase 3.
+      if (ctx) await teardownElectronApp(ctx);
+      if (profileDir) fs.rmSync(profileDir, { recursive: true, force: true });
+    }
+  });
+
+  test('a pre-multi-window profile upgrades to one window with its legacy layout, and new windows still start empty', async () => {
+    const logStep = createStepLogger('window-layout-upgrade');
+    let ctx: ElectronAppContext | undefined;
+    let profileDir: string | undefined;
+
+    try {
+      // #region Launch A — build a genuine pre-multi-window profile with the app itself
+
+      ctx = await launchElectronApp({ ...BASE_LAUNCH_OPTIONS, preserveUserDataDir: true });
+      const { userDataDir } = ctx;
+      profileDir = userDataDir;
+      const outputA = captureAppOutput(ctx.electronApp);
+      const pageA = await ctx.electronApp.firstWindow({ timeout: 90_000 });
+      await pageA.waitForLoadState('domcontentloaded');
+      await pageA.waitForSelector('#root', { state: 'attached', timeout: 60_000 });
+      await waitForAppReady(pageA, 180_000);
+      const windowAId = getWindowIdOfPage(pageA);
+      await expect(homeTabTitle(pageA, windowAId)).toBeAttached({ timeout: 60_000 });
+      logStep(`launch A: window ${windowAId} ready with its Home tab`);
+
+      // Harvest the layout the app itself persists for the main window (the renderer pushes the
+      // loaded layout and the main process's write is debounced, so poll for the file) — the base
+      // for the legacy blob, so its shape is exactly what the app saves, not a hand-authored
+      // approximation.
+      let mainLayoutJson: string | undefined;
+      await expect(() => {
+        const mainEntry = readSavedWindowEntries(userDataDir).find((entry) => entry.isMain);
+        expect(mainEntry?.layoutJson ?? '').toContain(HOME_TAB_UUID);
+        mainLayoutJson = mainEntry?.layoutJson;
+      }).toPass({ timeout: 30_000, intervals: [500] });
+      if (!mainLayoutJson) throw new Error('unreachable: poll passed without a main entry layout');
+
+      // Write the two-tab legacy blob under the legacy localStorage key, from inside the renderer
+      // — the same storage a real pre-multi-window install left behind.
+      const legacyLayout = buildTwoTabLegacyLayout(mainLayoutJson);
+      await pageA.evaluate(
+        ([storageKey, serializedLayout]) => localStorage.setItem(storageKey, serializedLayout),
+        [LEGACY_DOCK_LAYOUT_STORAGE_KEY, JSON.stringify(legacyLayout)] as const,
+      );
+      logStep('launch A: seeded the legacy dock layout (Home tab + cloned second tab)');
+
+      // The keeper bounds written below sit at the primary display's origin, so the upgrade's
+      // on-display validation is guaranteed to accept them (this compositor honors requested
+      // sizes, which is the half the assertion uses).
+      const primaryDisplayBounds = await ctx.electronApp.evaluate(
+        ({ screen }) => screen.getPrimaryDisplay().bounds,
+      );
+
+      const exitA = await quitAppAndWaitForExit(ctx.electronApp);
+      logStep(`launch A: exited with code ${exitA.code} signal ${exitA.signal}`);
+      expect(exitA.signal).toBeUndefined();
+      expect(exitA.code).toBe(0);
+
+      const logA = outputA.text();
+      FAULT_MARKERS.forEach((marker) => expect(logA).not.toContain(marker));
+      expect(logA).not.toMatch(DUPLICATE_REGISTRATION_PATTERN);
+
+      await teardownElectronApp(ctx);
+      ctx = undefined;
+
+      // #endregion
+
+      // #region Between launches — make the profile look pre-multi-window
+
+      // No structure file (the marker of the new persistence), a legacy layout in localStorage
+      // (seeded above, and retained by the quit), and an old-style keeper file with a known
+      // placement: exactly the state an install from before the window-layouts structure holds.
+      fs.rmSync(path.join(userDataDir, 'window-layouts.json'), { force: true });
+      expect(fs.existsSync(path.join(userDataDir, 'window-layouts.json'))).toBe(false);
+      fs.writeFileSync(
+        path.join(userDataDir, LEGACY_WINDOW_STATE_FILE_NAME),
+        JSON.stringify({
+          x: primaryDisplayBounds.x,
+          y: primaryDisplayBounds.y,
+          ...LEGACY_KEEPER_SIZE,
+          isMaximized: false,
+          isFullScreen: false,
+          displayBounds: primaryDisplayBounds,
+        }),
+      );
+      logStep('between launches: structure file removed, legacy keeper file written');
+
+      // #endregion
+
+      // #region Launch B — the upgrade
+
+      // No preserveUserDataDir: this launch's teardown must delete the profile directory.
+      ctx = await launchElectronApp({ ...BASE_LAUNCH_OPTIONS, userDataDir });
+      const outputB = captureAppOutput(ctx.electronApp);
+      const pagesB = await waitForAppPages(ctx.electronApp, 1, 180_000);
+      const pageB = pagesB[0];
+      const windowBId = getWindowIdOfPage(pageB);
+      await waitForAppReady(pageB, 180_000);
+      logStep(`launch B: window ${windowBId} ready`);
+
+      // Premise check on the harness itself: the seeded blob must have survived the quit (the
+      // renderer only reads this key, never writes or clears it). Failing here means the SEEDING
+      // did not persist — a test-harness problem — so the layout assertions below can only fail
+      // for product reasons.
+      const storedLegacyBlob = await pageB.evaluate(
+        (storageKey) => localStorage.getItem(storageKey),
+        LEGACY_DOCK_LAYOUT_STORAGE_KEY,
+      );
+      expect(storedLegacyBlob ?? '').toContain(LEGACY_SECOND_TAB_UUID);
+
+      // The discriminator: BOTH seeded tabs must render. A pass cannot be vacuous through some
+      // other layout source — the fresh-profile fallback layout has exactly ONE tab (Home) and an
+      // empty layout has none, so a tab with the seeded clone id can only have come from the
+      // legacy localStorage blob itself. An upgrade that lost the legacy layout would show one
+      // Home tab (fallback) or an empty dock, and fail here.
+      await expect(homeTabTitle(pageB, windowBId)).toBeAttached({ timeout: 60_000 });
+      await expect(
+        pageB.locator(
+          `.platform-tab-title[data-web-view-id="${LEGACY_SECOND_TAB_UUID}-w${windowBId}"]`,
+        ),
+      ).toBeAttached({ timeout: 60_000 });
+      await expect(pageB.locator('.platform-tab-title')).toHaveCount(2);
+      logStep('launch B: legacy layout loaded — Home tab and seeded second tab both render');
+
+      // Exactly ONE window: the upgrade rule is one window, not two, not zero. Give a wrongly
+      // created extra window time to appear before asserting the count (secondary windows are
+      // created late in startup, once the interface mode becomes readable).
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 10_000);
+      });
+      expect(getAppPages(ctx.electronApp)).toHaveLength(1);
+      logStep('launch B: exactly one window restored');
+
+      // The keeper file's size must be honored (its placement is on-display by construction, so
+      // the app's off-display fallback cannot legitimately apply). An upgrade that ignores the
+      // keeper file would come up at the default size instead — which the keeper size deliberately
+      // differs from.
+      const upgradedBounds = await getWindowBounds(ctx.electronApp, windowBId);
+      expect(upgradedBounds.width, 'upgraded window: width from the keeper file').toBe(
+        LEGACY_KEEPER_SIZE.width,
+      );
+      expect(upgradedBounds.height, 'upgraded window: height from the keeper file').toBe(
+        LEGACY_KEEPER_SIZE.height,
+      );
+      logStep('launch B: keeper-file window size honored');
+
+      // A window created mid-session in the upgraded session must START EMPTY even though a legacy
+      // blob exists in localStorage — the kill-shot for the fallback that cloned the legacy layout
+      // into every new window. A regression to that behaviour would render the two seeded tabs
+      // here.
+      const page2B = await createSecondWindow(ctx.electronApp);
+      const window2BId = getWindowIdOfPage(page2B);
+      await waitForRendererRegistered(window2BId, 120_000);
+      await expectWindowDockEmpty(page2B);
+      logStep(`launch B: mid-session window ${window2BId} started empty despite the legacy blob`);
+
+      const exitB = await quitAppAndWaitForExit(ctx.electronApp);
+      logStep(`launch B: exited with code ${exitB.code} signal ${exitB.signal}`);
+      expect(exitB.signal).toBeUndefined();
+      expect(exitB.code).toBe(0);
+
+      const logB = outputB.text();
+      FAULT_MARKERS.forEach((marker) => expect(logB).not.toContain(marker));
+      expect(logB).not.toMatch(DUPLICATE_REGISTRATION_PATTERN);
+
+      // The final teardown (launched without preserveUserDataDir) deletes the profile directory.
+      await teardownElectronApp(ctx);
+      ctx = undefined;
+      expect(fs.existsSync(userDataDir)).toBe(false);
+
+      // #endregion
+    } finally {
+      // On any failure above: kill whatever instance is still up, then remove the preserved
+      // profile directory so a failed run leaks nothing. Both are no-ops after a clean launch B.
       if (ctx) await teardownElectronApp(ctx);
       if (profileDir) fs.rmSync(profileDir, { recursive: true, force: true });
     }

--- a/e2e-tests/tests/isolated/multi-window/window-layout-persistence.spec.ts
+++ b/e2e-tests/tests/isolated/multi-window/window-layout-persistence.spec.ts
@@ -1,0 +1,516 @@
+/**
+ * Window layout persistence e2e test.
+ *
+ * Locks the across-restart behaviour of the window set: every window open at quit comes back on
+ * relaunch — the main window with its dock layout, a deliberately-empty secondary window empty —
+ * each at its saved bounds, while a window the user deliberately closed mid-session does NOT come
+ * back.
+ *
+ * One test, three sequential launches into the SAME user-data profile (the launch helpers accept an
+ * existing `userDataDir` and can preserve it across teardowns — see `LaunchElectronAppOptions`).
+ * Launches are strictly sequential: the fixed WebSocket port and Electron's per-profile singleton
+ * lock forbid overlap, so each phase quits gracefully (and its leftover process group is reaped)
+ * before the next launches.
+ *
+ * - Phase 1 (fresh profile): the first window shows the single-Home-tab fallback layout; a second
+ *   window is created mid-session (it starts empty); both windows are placed at known,
+ *   different-sized bounds; graceful quit.
+ * - Phase 2 (relaunch): BOTH windows come back — the main window with its Home tab, the second one
+ *   EMPTY — each at its saved bounds; the second window is then deliberately closed; graceful
+ *   quit.
+ * - Phase 3 (second relaunch): exactly ONE window comes back (the deliberately closed window stays
+ *   closed), still with its Home tab; graceful quit. The final teardown deletes the profile.
+ *
+ * ## App configuration
+ *
+ * Same pre-configuration as `multi-window.spec.ts` (power mode, first-run complete, English) — and
+ * here `platform.interfaceMode: 'power'` is additionally REQUIRED for phase 2's both-windows
+ * assertion, because simple mode is single-window and restores only the main window.
+ *
+ * ## Not covered here (and why)
+ *
+ * - The single-window legacy upgrade path (a profile holding only the previous bounds-keeper file and
+ *   a pre-multi-window localStorage layout): needs a pre-multi-window profile fixture to be
+ *   authored; the legacy-read behaviour is unit-covered in the main process's persistence service
+ *   tests.
+ * - Multi-monitor behaviour (restoring a window whose saved display is gone): this environment has a
+ *   single virtual display; the monitor-gone re-placement is a pure function with its own unit
+ *   tests.
+ * - Tab-bearing SECONDARY windows round-tripping their content: putting a tab into a second window
+ *   needs the move-web-views-between-windows feature; until then only the main window's layout has
+ *   content to round-trip.
+ * - Window POSITION restore at the window level: this environment's compositor (WSLg) assigns
+ *   positions itself, in host-desktop coordinates that can lie outside the virtual display Electron
+ *   reports, so a restored window's position never observably matches what the app requested.
+ *   Position is covered on the SAVE side only (the persisted file must hold the pre-quit placement
+ *   exactly). The live restore assertion is on SIZE, per the app's own decision rule: a saved
+ *   placement on the display must come back at its saved size, and one off the display must come
+ *   back at the default size (see expectRestoredSizeForSavedPlacement).
+ *
+ * ## How to run
+ *
+ * `npm run test:e2e:isolated multi-window`
+ */
+import { expect, test, type ElectronApplication } from '@playwright/test';
+import fs from 'fs';
+import path from 'path';
+import {
+  ElectronAppContext,
+  LaunchElectronAppOptions,
+  launchElectronApp,
+  preConfigureSettings,
+  teardownElectronApp,
+  waitForAppReady,
+} from '../../../fixtures/helpers';
+import {
+  DUPLICATE_REGISTRATION_PATTERN,
+  FAULT_MARKERS,
+  HOME_TAB_UUID,
+  captureAppOutput,
+  createSecondWindow,
+  createStepLogger,
+  expectWindowDockEmpty,
+  getAppPages,
+  getWindowIdOfPage,
+  homeTabTitle,
+  quitAppAndWaitForExit,
+  waitForAppPages,
+  waitForRendererRegistered,
+} from './multi-window.util';
+
+/**
+ * Launch options shared by all three phases — the same configuration `multi-window.spec.ts` uses
+ * (see the `test.use` comment there for the rationale). Every phase must launch identically so a
+ * phase-2/3 difference in what appears on screen can only come from the persisted profile state.
+ */
+const BASE_LAUNCH_OPTIONS: LaunchElectronAppOptions = {
+  isolatedProjectRoot: true,
+  envOverrides: { DEV_NOISY: 'false' },
+};
+
+/** Position and size of a window, as reported by `BrowserWindow.getBounds()`. */
+type Rectangle = { x: number; y: number; width: number; height: number };
+
+/** Read a window's current bounds from the main process. */
+async function getWindowBounds(
+  electronApp: ElectronApplication,
+  windowId: number,
+): Promise<Rectangle> {
+  return electronApp.evaluate(({ BrowserWindow }, id) => {
+    const win = BrowserWindow.fromId(id);
+    if (!win) throw new Error(`No BrowserWindow with id ${id}`);
+    return win.getBounds();
+  }, windowId);
+}
+
+/** Whether `bounds` lies fully within a single one of `displays` — the app's "visible" rule. */
+function isContainedInSomeDisplay(bounds: Rectangle, displays: readonly Rectangle[]): boolean {
+  return displays.some(
+    (display) =>
+      bounds.x >= display.x &&
+      bounds.y >= display.y &&
+      bounds.x + bounds.width <= display.x + display.width &&
+      bounds.y + bounds.height <= display.y + display.height,
+  );
+}
+
+/** Bounds of all connected displays, as the app itself sees them (`screen.getAllDisplays()`). */
+async function getDisplayBounds(electronApp: ElectronApplication): Promise<Rectangle[]> {
+  return electronApp.evaluate(({ screen }) => screen.getAllDisplays().map((d) => d.bounds));
+}
+
+/**
+ * Put a window into its normal state at the given bounds and wait until `getBounds` reports the
+ * requested SIZE, then return the full settled placement. The settled read — not the requested
+ * rectangle — is the reference for everything downstream: the app can only persist what the window
+ * really reports.
+ *
+ * Size only, deliberately: this environment's compositor (WSLg) assigns window POSITIONS itself in
+ * the host desktop's coordinate space, which spans the host's physical monitors — so the settled
+ * x/y regularly differs from the request and can even lie outside the single virtual display
+ * Electron reports. Sizes, in contrast, are honored exactly. Whatever position the compositor did
+ * assign still round-trips into the persisted file (asserted in phase 1), and what it means for the
+ * restore is decided per placement by {@link expectRestoredSizeForSavedPlacement}.
+ */
+async function placeWindowAndSettle(
+  electronApp: ElectronApplication,
+  windowId: number,
+  targetBounds: Rectangle,
+): Promise<Rectangle> {
+  let settled: Rectangle | undefined;
+  await expect(async () => {
+    await electronApp.evaluate(
+      ({ BrowserWindow }, { id, bounds }) => {
+        const win = BrowserWindow.fromId(id);
+        if (!win) throw new Error(`No BrowserWindow with id ${id}`);
+        // Normal-state placement is what gets persisted, so leave any special state first, and
+        // re-show a window the host may have minimized (an unmapped window reads back at a
+        // far-off-screen position).
+        if (win.isFullScreen()) win.setFullScreen(false);
+        if (win.isMaximized()) win.unmaximize();
+        if (win.isMinimized()) win.restore();
+        win.show();
+        win.setBounds(bounds);
+      },
+      { id: windowId, bounds: targetBounds },
+    );
+    // Let the compositor apply the placement and the app's debounced bounds capture observe it
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, 1_500);
+    });
+    const readBack = await getWindowBounds(electronApp, windowId);
+    expect(readBack.width, 'settled width').toBe(targetBounds.width);
+    expect(readBack.height, 'settled height').toBe(targetBounds.height);
+    settled = readBack;
+  }).toPass({ timeout: 30_000, intervals: [1_000] });
+  if (!settled) throw new Error('placement settled without recording bounds');
+  return settled;
+}
+
+/**
+ * The window size the app falls back to when a saved placement is unusable. Keep in sync with
+ * `DEFAULT_WINDOW_WIDTH`/`DEFAULT_WINDOW_HEIGHT` in `src/main/window-bounds.util.ts` (not imported
+ * here because the e2e project cannot resolve the app's path aliases).
+ */
+const FALLBACK_WINDOW_SIZE = { width: 1024, height: 728 };
+
+/**
+ * Assert a restored window honors its saved placement the way the app specifies, and return a
+ * description of which rule applied (for the runner log, so a pass records which branch it
+ * exercised):
+ *
+ * - Saved bounds fully on a connected display: the restored window's SIZE must equal the saved size
+ *   exactly. (Position is compositor-assigned in this environment — see the file header's
+ *   not-covered list — so only size is checkable live.)
+ * - Saved bounds off-display (this compositor parks windows in host-desktop coordinates beyond the
+ *   virtual display): the app must NOT apply them — the window must come back at the default size
+ *   ({@link FALLBACK_WINDOW_SIZE}), the same re-placement rule that recovers a window whose monitor
+ *   went away. Both windows' test sizes differ from the default size, so a restore that wrongly
+ *   applies off-display bounds fails this branch.
+ */
+function expectRestoredSizeForSavedPlacement(
+  actual: Rectangle,
+  saved: Rectangle,
+  displays: readonly Rectangle[],
+  label: string,
+): string {
+  if (isContainedInSomeDisplay(saved, displays)) {
+    expect(actual.width, `${label}: width (saved placement on-display)`).toBe(saved.width);
+    expect(actual.height, `${label}: height (saved placement on-display)`).toBe(saved.height);
+    return `${label}: saved placement was on-display; restored at its saved size`;
+  }
+  expect(actual.width, `${label}: width (saved placement off-display, expect default)`).toBe(
+    FALLBACK_WINDOW_SIZE.width,
+  );
+  expect(actual.height, `${label}: height (saved placement off-display, expect default)`).toBe(
+    FALLBACK_WINDOW_SIZE.height,
+  );
+  return `${label}: saved placement was off-display; re-placed at the default size`;
+}
+
+/** Minimal view of one saved window entry from the persisted window-layouts structure. */
+type SavedWindowEntry = {
+  isMain: boolean;
+  layoutJson: string | undefined;
+  bounds: Rectangle | undefined;
+};
+
+/** View parsed JSON as an indexable record if it is object-shaped at all. */
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  // Parsed JSON data; crossing from `object` to the indexable shape only adds property reads that
+  // are each validated by the caller
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  return value as Record<string, unknown>;
+}
+
+/**
+ * Read the window-layouts structure the app persists in the profile's user-data folder, reduced to
+ * what the assertions here need: entry count/order, which entry is the main window's, and each
+ * entry's layout as JSON text (for content probes). This file is the contract between one session
+ * and the next, so asserting on it after a quit separates save-side failures from restore-side
+ * ones. Throws when the file is missing or not structure-shaped — after a quit it must exist and
+ * parse.
+ */
+function readSavedWindowEntries(userDataDir: string): SavedWindowEntry[] {
+  const raw = fs.readFileSync(path.join(userDataDir, 'window-layouts.json'), 'utf8');
+  const record = asRecord(JSON.parse(raw));
+  const windowsValue: unknown = record?.windows;
+  if (!Array.isArray(windowsValue))
+    throw new Error(`window-layouts.json does not hold a windows list: ${raw}`);
+  return windowsValue.map((entryValue: unknown) => {
+    const entry = asRecord(entryValue) ?? {};
+    const boundsRecord = asRecord(entry.bounds);
+    const { x, y, width, height } = boundsRecord ?? {};
+    const bounds =
+      typeof x === 'number' &&
+      typeof y === 'number' &&
+      typeof width === 'number' &&
+      typeof height === 'number'
+        ? { x, y, width, height }
+        : undefined;
+    return {
+      isMain: entry.isMain === true,
+      layoutJson: entry.layout === undefined ? undefined : JSON.stringify(entry.layout),
+      bounds,
+    };
+  });
+}
+
+test.describe('window layout persistence', () => {
+  // Three full app launches (each can cost 30–180 s), three graceful quits, and several settle
+  // periods share this one test.
+  test.setTimeout(900_000);
+
+  let restoreSettings: (() => void) | undefined;
+
+  test.beforeAll(() => {
+    // Written before any launch and restored after the test so the developer's own settings
+    // survive the suite. Power mode is REQUIRED here: simple mode restores only the main window,
+    // which would make phase 2's both-windows assertion fail for configuration reasons.
+    restoreSettings = preConfigureSettings({
+      'platform.firstRunComplete': true,
+      'platform.interfaceLanguage': ['en'],
+      'platform.interfaceMode': 'power',
+    });
+  });
+
+  test.afterAll(() => {
+    restoreSettings?.();
+  });
+
+  test('windows, layouts, and bounds survive relaunch; a deliberately closed window stays closed', async () => {
+    const logStep = createStepLogger('window-layout-persistence');
+    let ctx: ElectronAppContext | undefined;
+    let profileDir: string | undefined;
+
+    try {
+      // #region Phase 1 — fresh profile: two windows at known bounds, then a graceful quit
+
+      ctx = await launchElectronApp({ ...BASE_LAUNCH_OPTIONS, preserveUserDataDir: true });
+      const { userDataDir } = ctx;
+      profileDir = userDataDir;
+      const output1 = captureAppOutput(ctx.electronApp);
+      const mainPage1 = await ctx.electronApp.firstWindow({ timeout: 90_000 });
+      await mainPage1.waitForLoadState('domcontentloaded');
+      await mainPage1.waitForSelector('#root', { state: 'attached', timeout: 60_000 });
+      await waitForAppReady(mainPage1, 180_000);
+      const window1Id = getWindowIdOfPage(mainPage1);
+      logStep(`phase 1: window ${window1Id} ready`);
+
+      // The first window of a fresh profile shows the Home tab (from the single-Home-tab fallback
+      // layout) — the layout content whose round-trip phase 2 asserts.
+      await expect(homeTabTitle(mainPage1, window1Id)).toBeAttached({ timeout: 60_000 });
+
+      // Known placements, requested inside the primary display's work area. The two windows get
+      // DIFFERENT sizes — both also different from the app's fallback size — so the phase-2 size
+      // comparison can tell the windows' saved entries apart (a swap changes both) and can tell a
+      // restored entry from a fallback re-placement.
+      const workArea = await ctx.electronApp.evaluate(
+        ({ screen }) => screen.getPrimaryDisplay().workArea,
+      );
+      const placedMainBounds = await placeWindowAndSettle(ctx.electronApp, window1Id, {
+        x: workArea.x + 40,
+        y: workArea.y + 40,
+        width: Math.min(1_100, workArea.width - 80),
+        height: Math.min(700, workArea.height - 80),
+      });
+      logStep(`phase 1: window ${window1Id} placed at ${JSON.stringify(placedMainBounds)}`);
+
+      const page2 = await createSecondWindow(ctx.electronApp);
+      const window2Id = getWindowIdOfPage(page2);
+      await waitForRendererRegistered(window2Id, 120_000);
+      // The mid-session window starts empty (that behaviour is locked by multi-window.spec.ts);
+      // asserting it here too makes phase 2's "restored EMPTY" meaningful — it restores what was
+      // genuinely an empty window.
+      await expectWindowDockEmpty(page2);
+      const placedSecondBounds = await placeWindowAndSettle(ctx.electronApp, window2Id, {
+        x: workArea.x + 120,
+        y: workArea.y + 100,
+        width: Math.min(940, workArea.width - 200),
+        height: Math.min(620, workArea.height - 160),
+      });
+      logStep(
+        `phase 1: window ${window2Id} created empty and placed at ${JSON.stringify(placedSecondBounds)}`,
+      );
+
+      // The compositor may re-place a window at any time after it settles (a host-side minimize
+      // reads back far off-screen), so read each window's placement one final time immediately
+      // before quitting. These reads are what the quit flush captures, so they — not the earlier
+      // settled reads — are the reference for the persisted file and for the phase-2 restore.
+      const savedMainBounds = await getWindowBounds(ctx.electronApp, window1Id);
+      const savedSecondBounds = await getWindowBounds(ctx.electronApp, window2Id);
+      logStep(
+        `phase 1: pre-quit placements main=${JSON.stringify(savedMainBounds)} second=${JSON.stringify(savedSecondBounds)}`,
+      );
+
+      // Guard the discriminator the phase-2 assertions rely on: with equal sizes, the two windows'
+      // entries swapping would be invisible to the size comparison.
+      expect(savedSecondBounds.width).not.toBe(savedMainBounds.width);
+      expect(savedSecondBounds.height).not.toBe(savedMainBounds.height);
+
+      const exit1 = await quitAppAndWaitForExit(ctx.electronApp);
+      logStep(`phase 1: exited with code ${exit1.code} signal ${exit1.signal}`);
+      expect(exit1.signal).toBeUndefined();
+      expect(exit1.code).toBe(0);
+
+      const log1 = output1.text();
+      FAULT_MARKERS.forEach((marker) => expect(log1).not.toContain(marker));
+      expect(log1).not.toMatch(DUPLICATE_REGISTRATION_PATTERN);
+
+      // The persisted structure must hold both windows: exactly one main entry, whose layout
+      // carries the Home web view — and the second entry must NOT carry it (an empty window's
+      // entry with the main window's layout cloned in would restore tabs in phase 2). Each entry
+      // must also hold its window's pre-quit placement EXACTLY, position included — this is the
+      // save half of the bounds round trip, and the only place position is checkable in this
+      // environment (see expectRestoredSizeForSavedPlacement). Asserting the save side here means
+      // a phase-2 failure can be attributed to the restore side.
+      const entriesAfterPhase1 = readSavedWindowEntries(userDataDir);
+      expect(entriesAfterPhase1).toHaveLength(2);
+      const mainEntriesAfterPhase1 = entriesAfterPhase1.filter((entry) => entry.isMain);
+      expect(mainEntriesAfterPhase1).toHaveLength(1);
+      expect(mainEntriesAfterPhase1[0].layoutJson).toContain(HOME_TAB_UUID);
+      expect(mainEntriesAfterPhase1[0].bounds).toEqual(savedMainBounds);
+      const secondEntriesAfterPhase1 = entriesAfterPhase1.filter((entry) => !entry.isMain);
+      secondEntriesAfterPhase1.forEach((entry) =>
+        expect(entry.layoutJson ?? '').not.toContain(HOME_TAB_UUID),
+      );
+      expect(secondEntriesAfterPhase1[0].bounds).toEqual(savedSecondBounds);
+      logStep('phase 1: persisted structure holds both windows with their settled bounds');
+
+      await teardownElectronApp(ctx);
+      ctx = undefined;
+
+      // #endregion
+
+      // #region Phase 2 — relaunch: both windows return; deliberately close the second
+
+      ctx = await launchElectronApp({
+        ...BASE_LAUNCH_OPTIONS,
+        userDataDir,
+        preserveUserDataDir: true,
+      });
+      const output2 = captureAppOutput(ctx.electronApp);
+      // Both windows must come back. Secondary windows are created only once startup can read the
+      // interface mode (which waits on the extension host), hence the long budget. The windows are
+      // identified order-independently through their windowId URL parameter: the app creates the
+      // main entry's window first, so the lower id is the main window (getAppPages sorts by id).
+      const pagesPhase2 = await waitForAppPages(ctx.electronApp, 2, 240_000);
+      expect(pagesPhase2).toHaveLength(2);
+      const [mainPage2, secondPage2] = pagesPhase2;
+      const mainId2 = getWindowIdOfPage(mainPage2);
+      const secondId2 = getWindowIdOfPage(secondPage2);
+      await waitForAppReady(mainPage2, 180_000);
+      await waitForRendererRegistered(secondId2, 120_000);
+      logStep(`phase 2: windows ${mainId2} and ${secondId2} restored`);
+
+      // Layout round-trip: the main window still shows its Home tab…
+      await expect(homeTabTitle(mainPage2, mainId2)).toBeAttached({ timeout: 120_000 });
+      // …and the deliberately-empty second window is restored EMPTY: neither a copy of the main
+      // window's layout nor any default layout may appear in it.
+      await expectWindowDockEmpty(secondPage2);
+      // The restore created exactly the saved windows — no duplicates (expectWindowDockEmpty's
+      // settle has already given a straggler window time to appear).
+      expect(getAppPages(ctx.electronApp)).toHaveLength(2);
+      logStep('phase 2: main window has its Home tab; second window restored empty');
+
+      // Bounds round-trip, per window, against what was saved at quit. Which live expectation
+      // applies depends on whether the compositor left the saved placement on the virtual display
+      // — see expectRestoredSizeForSavedPlacement; the position half of the SAVE side was already
+      // asserted exactly against the persisted file in phase 1. The sizes differ between the
+      // windows (guarded in phase 1), so the on-display branch also fails if the two entries
+      // swapped windows across the restart.
+      const displaysPhase2 = await getDisplayBounds(ctx.electronApp);
+      logStep(
+        `phase 2: ${expectRestoredSizeForSavedPlacement(
+          await getWindowBounds(ctx.electronApp, mainId2),
+          savedMainBounds,
+          displaysPhase2,
+          'restored main window',
+        )}`,
+      );
+      logStep(
+        `phase 2: ${expectRestoredSizeForSavedPlacement(
+          await getWindowBounds(ctx.electronApp, secondId2),
+          savedSecondBounds,
+          displaysPhase2,
+          'restored second window',
+        )}`,
+      );
+
+      // Deliberately close the second window the way a user does…
+      const secondClosed = secondPage2.waitForEvent('close', { timeout: 30_000 });
+      // window.close() tears the page's execution context down, so schedule it instead of calling
+      // it inline — an inline call can destroy the context before the evaluate call returns.
+      await secondPage2.evaluate(() => {
+        setTimeout(() => window.close(), 0);
+      });
+      await secondClosed;
+      logStep(`phase 2: window ${secondId2} deliberately closed`);
+
+      // …and wait until the persisted structure drops its entry: a deliberate close must leave no
+      // trace of the window. (Phase 3 is the end-to-end proof; this pins the save side and
+      // sequences the quit after the rewrite.)
+      await expect(() => {
+        expect(readSavedWindowEntries(userDataDir)).toHaveLength(1);
+      }).toPass({ timeout: 30_000, intervals: [500] });
+
+      const exit2 = await quitAppAndWaitForExit(ctx.electronApp);
+      logStep(`phase 2: exited with code ${exit2.code} signal ${exit2.signal}`);
+      expect(exit2.signal).toBeUndefined();
+      expect(exit2.code).toBe(0);
+
+      const log2 = output2.text();
+      FAULT_MARKERS.forEach((marker) => expect(log2).not.toContain(marker));
+      expect(log2).not.toMatch(DUPLICATE_REGISTRATION_PATTERN);
+
+      await teardownElectronApp(ctx);
+      ctx = undefined;
+
+      // #endregion
+
+      // #region Phase 3 — second relaunch: the deliberately closed window stays closed
+
+      // No preserveUserDataDir: this phase's teardown must delete the profile directory.
+      ctx = await launchElectronApp({ ...BASE_LAUNCH_OPTIONS, userDataDir });
+      const output3 = captureAppOutput(ctx.electronApp);
+      const pagesPhase3 = await waitForAppPages(ctx.electronApp, 1, 180_000);
+      const mainPage3 = pagesPhase3[0];
+      const mainId3 = getWindowIdOfPage(mainPage3);
+      await waitForAppReady(mainPage3, 180_000);
+      await expect(homeTabTitle(mainPage3, mainId3)).toBeAttached({ timeout: 60_000 });
+      logStep(`phase 3: window ${mainId3} restored with its Home tab`);
+
+      // Exactly ONE window: the deliberately closed window must not come back. Secondary windows
+      // are created late in startup (once the interface mode becomes readable), so give a
+      // wrongly-resurrected window time to appear before asserting the count.
+      await new Promise<void>((resolve) => {
+        setTimeout(resolve, 10_000);
+      });
+      expect(getAppPages(ctx.electronApp)).toHaveLength(1);
+      logStep('phase 3: the deliberately closed window did not return');
+
+      const exit3 = await quitAppAndWaitForExit(ctx.electronApp);
+      logStep(`phase 3: exited with code ${exit3.code} signal ${exit3.signal}`);
+      expect(exit3.signal).toBeUndefined();
+      expect(exit3.code).toBe(0);
+
+      const log3 = output3.text();
+      FAULT_MARKERS.forEach((marker) => expect(log3).not.toContain(marker));
+      expect(log3).not.toMatch(DUPLICATE_REGISTRATION_PATTERN);
+
+      // The final teardown (launched without preserveUserDataDir) deletes the profile directory —
+      // a relaunch chain must not leak temp directories.
+      await teardownElectronApp(ctx);
+      ctx = undefined;
+      expect(fs.existsSync(userDataDir)).toBe(false);
+
+      // #endregion
+    } finally {
+      // On any failure above: kill whatever instance is still up, then remove the preserved
+      // profile directory so a failed run leaks nothing. Both are no-ops after a clean phase 3.
+      if (ctx) await teardownElectronApp(ctx);
+      if (profileDir) fs.rmSync(profileDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,6 @@
         "electron-debug": "^3.2.0",
         "electron-log": "^5.4.1",
         "electron-updater": "^6.3.9",
-        "electron-window-state": "^5.0.3",
         "fast-equals": "^5.2.2",
         "http-status-codes": "^2.3.0",
         "json-rpc-2.0": "^1.7.0",
@@ -15992,24 +15991,6 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/electron-window-state": {
-      "version": "5.0.3",
-      "license": "MIT",
-      "dependencies": {
-        "jsonfile": "^4.0.0",
-        "mkdirp": "^0.5.1"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
-    "node_modules/electron-window-state/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "dev": true,
@@ -23276,6 +23257,7 @@
     },
     "node_modules/minimist": {
       "version": "1.2.8",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -23302,6 +23284,7 @@
     },
     "node_modules/mkdirp": {
       "version": "0.5.6",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "minimist": "^1.2.6"

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "electron-debug": "^3.2.0",
     "electron-log": "^5.4.1",
     "electron-updater": "^6.3.9",
-    "electron-window-state": "^5.0.3",
     "fast-equals": "^5.2.2",
     "http-status-codes": "^2.3.0",
     "json-rpc-2.0": "^1.7.0",

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -693,8 +693,14 @@ async function main() {
     // Feed this window's placement to layout persistence as it changes, debounced since
     // resize/move fire continuously during a drag
     let boundsCaptureTimeout: ReturnType<typeof setTimeout> | undefined;
+    const cancelPendingBoundsCapture = () => {
+      if (boundsCaptureTimeout) {
+        clearTimeout(boundsCaptureTimeout);
+        boundsCaptureTimeout = undefined;
+      }
+    };
     const captureBoundsSoon = () => {
-      if (boundsCaptureTimeout) clearTimeout(boundsCaptureTimeout);
+      cancelPendingBoundsCapture();
       boundsCaptureTimeout = setTimeout(() => {
         boundsCaptureTimeout = undefined;
         if (newWindow.isDestroyed()) return;
@@ -935,10 +941,7 @@ async function main() {
           // does the same, so the last flush holds everyone's.
           // Only on this path: a window closing while the app stays up is leaving the structure,
           // and its `closed` handler below rewrites the structure without it.
-          if (boundsCaptureTimeout) {
-            clearTimeout(boundsCaptureTimeout);
-            boundsCaptureTimeout = undefined;
-          }
+          cancelPendingBoundsCapture();
           updateWindowBounds(windowId, captureWindowBoundsState());
           await writeNow(windows.map((window) => window.id));
 
@@ -1020,10 +1023,7 @@ async function main() {
       // After the announcement above, which is synchronous and must not wait on a disk write, and
       // before the unsubscribers below, which spend the network service's whole registration retry
       // failing against a renderer that is already gone.
-      if (boundsCaptureTimeout) {
-        clearTimeout(boundsCaptureTimeout);
-        boundsCaptureTimeout = undefined;
-      }
+      cancelPendingBoundsCapture();
       handleWindowRemoved(windowId);
       if (!isAppGoingDown) await writeNow(windows.map((window) => window.id));
 
@@ -1389,12 +1389,22 @@ async function main() {
         logger.error(`Failed to restore windows at startup: ${getErrorMessage(e)}`);
       }
 
+      // Collapse overlapping restores: 'activate' can fire again (rapid dock clicks) while a
+      // previous restore is still creating windows — and before the first window exists, the
+      // no-windows guard below does not catch that. A second concurrent restoreWindows run would
+      // reset the layout persistence tracking mid-restore and create duplicate windows, so late
+      // callers await the in-flight run instead of starting their own.
+      let restoreWindowsInFlight: Promise<void> | undefined;
       app.on('activate', async () => {
         // On macOS it's common to re-create windows in the app when the
         // dock icon is clicked and there are no other windows open.
         if (windows.length !== 0) return;
         try {
-          await restoreWindows();
+          if (!restoreWindowsInFlight)
+            restoreWindowsInFlight = restoreWindows().finally(() => {
+              restoreWindowsInFlight = undefined;
+            });
+          await restoreWindowsInFlight;
         } catch (e) {
           logger.error(`Failed to restore windows on activate: ${getErrorMessage(e)}`);
         }

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -6,7 +6,15 @@
  * using webpack. This gives us some performance wins.
  */
 
-import { app, BrowserWindow, ipcMain, RenderProcessGoneDetails, session, shell } from 'electron';
+import {
+  app,
+  BrowserWindow,
+  ipcMain,
+  RenderProcessGoneDetails,
+  screen,
+  session,
+  shell,
+} from 'electron';
 import os from 'os';
 import path from 'path';
 // Removed until we have a release. See https://github.com/paranext/paranext-core/issues/83
@@ -54,6 +62,26 @@ import {
   removeWindow,
   setFocusedWindowId,
 } from '@main/services/window-state.service';
+import {
+  assignEntryToWindow,
+  handleWindowRemoved,
+  initializeWindowLayoutPersistence,
+  loadWindowLayouts,
+  setMainWindowId,
+  trackLegacyWindow,
+  trackNewWindow,
+  updateWindowBounds,
+  writeNow,
+} from '@main/services/window-layout-persistence.service';
+import {
+  DEFAULT_WINDOW_HEIGHT,
+  DEFAULT_WINDOW_WIDTH,
+  ensureBoundsVisibleOnSomeDisplay,
+} from '@main/window-bounds.util';
+import type {
+  WindowBoundsState,
+  WindowLayoutEntry,
+} from '@shared/data/window-layout-persistence.model';
 import { HANDLE_URI_REQUEST_TYPE } from '@node/services/extension.service-model';
 import {
   CommandLineArgs,
@@ -87,8 +115,7 @@ import { settingsService } from '@shared/services/settings.service';
 import { initialize as initializeSharedStoreService } from '@shared/services/shared-store.service';
 import { markStartup, markStartupOnce } from '@shared/utils/startup-timing.util';
 import { SerializedRequestType } from '@shared/utils/util';
-import windowStateKeeper from 'electron-window-state';
-import { CommandNames, NetworkEventTypes } from 'papi-shared-types';
+import { CommandNames, NetworkEventTypes, SettingTypes } from 'papi-shared-types';
 import {
   getErrorMessage,
   isPlatformError,
@@ -204,6 +231,19 @@ const PROCESS_CLOSE_TIME_OUT_MS = 2000;
  */
 const WINDOW_CLOSE_TIME_OUT_MS = 10000;
 
+/** How long to coalesce a window's resize/move events before capturing its bounds */
+const BOUNDS_CAPTURE_DEBOUNCE_MS = 100;
+
+/**
+ * How a window being created relates to the persisted window-layouts structure: it restores a saved
+ * entry, it is the single window of a legacy startup (no structure — its renderer falls back to the
+ * pre-multi-window saved layout, placed at the previous bounds keeper's state), or — when omitted —
+ * it is a new mid-session window that starts empty.
+ */
+type WindowRestoreInfo =
+  | { kind: 'entry'; entryIndex: number; entry: WindowLayoutEntry }
+  | { kind: 'legacy'; boundsState?: WindowBoundsState };
+
 /** Height of the custom title bar buttons on Windows */
 const TITLE_BAR_BUTTON_HEIGHT = 47;
 /** Background color of the window buttons in the custom title bar on Windows */
@@ -314,6 +354,10 @@ async function main() {
     throw new Error(
       `Could not start the multi-window routing proxies: ${failedRoutingServiceNames.join(', ')}. Each failure is logged above.`,
     );
+
+  // Window layout persistence must register its request handlers before any window exists so a
+  // renderer's layout load can never race the registration
+  await initializeWindowLayoutPersistence();
 
   // A window is tracked and takes OS focus the moment it is shown, but it cannot serve a routed
   // call until its renderer has registered. Its scoped window service appearing is that signal, and
@@ -519,7 +563,7 @@ async function main() {
   }
 
   /** Sets up the electron BrowserWindow renderer process */
-  const createWindow = async () => {
+  const createWindow = async (restoreInfo?: WindowRestoreInfo): Promise<BrowserWindow> => {
     // The menu and the `platform.createWindow` command stay live through a quit, because every
     // window sits in `preventDefault()` waiting on the shared shutdown run for as long as that run
     // takes. Opening a window in that gap would start a session the app is in no position to serve:
@@ -536,19 +580,26 @@ async function main() {
     // without this the second and every later session would come down without syncing.
     resetShutdownLatchesForNewSession();
 
-    // Load the previous state with fallback to defaults.
-    // Only use windowStateKeeper for the first window; subsequent windows are not managed by it, so
-    // their size and position are not persisted (per-window bounds persistence is PT-4285's scope).
     const isFirstWindow = windows.length === 0;
-    const mainWindowState = isFirstWindow
-      ? windowStateKeeper({ defaultWidth: 1024, defaultHeight: 728 })
+
+    // This window's saved placement — its entry's, or the previous single-window keeper's for a
+    // legacy startup — validated against the displays connected right now so a window can never
+    // come back on a monitor that is gone. A window with no saved placement gets defaults.
+    const savedBoundsState =
+      restoreInfo?.kind === 'entry' ? restoreInfo.entry : restoreInfo?.boundsState;
+    const boundsState = savedBoundsState
+      ? ensureBoundsVisibleOnSomeDisplay(
+          savedBoundsState,
+          screen.getAllDisplays(),
+          screen.getPrimaryDisplay(),
+        )
       : undefined;
 
     // If --window-size (or --windowSize) is specified, use those dimensions instead of the saved
     // window state. Useful for automation/headless runs on Windows where xvfb is unavailable.
     const windowSizeArg = getCommandLineArgument(CommandLineArgs.WindowSize);
-    let windowWidth = mainWindowState?.width ?? 1024;
-    let windowHeight = mainWindowState?.height ?? 728;
+    let windowWidth = boundsState?.bounds?.width ?? DEFAULT_WINDOW_WIDTH;
+    let windowHeight = boundsState?.bounds?.height ?? DEFAULT_WINDOW_HEIGHT;
     let sizeMatch: RegExpExecArray | undefined;
     if (windowSizeArg) {
       sizeMatch = /^([1-9]\d*)[x,]([1-9]\d*)$/i.exec(windowSizeArg) ?? undefined;
@@ -564,7 +615,7 @@ async function main() {
 
     const newWindow = new BrowserWindow({
       show: true,
-      ...(mainWindowState ? { x: mainWindowState.x, y: mainWindowState.y } : {}),
+      ...(boundsState?.bounds ? { x: boundsState.bounds.x, y: boundsState.bounds.y } : {}),
       width: windowWidth,
       height: windowHeight,
       minWidth: 800, // TODO: Remove this temporary enforcement when https://paratextstudio.atlassian.net/browse/PT-2333 is implemented
@@ -598,6 +649,11 @@ async function main() {
     // Track this window immediately
     addWindow(newWindow);
 
+    // Tie the window to its persisted identity so layout persistence can serve and save it
+    if (restoreInfo?.kind === 'entry') assignEntryToWindow(windowId, restoreInfo.entryIndex);
+    else if (restoreInfo?.kind === 'legacy') trackLegacyWindow(windowId);
+    else trackNewWindow(windowId);
+
     // Track which window is focused for multi-window command routing
     newWindow.on('focus', () => {
       setFocusedWindowId(windowId);
@@ -609,18 +665,44 @@ async function main() {
     // Set our custom protocol handler to load Enhanced Resources binary assets (papi-er://)
     enhancedResourceProtocolService.initialize();
 
-    // Register listeners on the window, so the state is updated automatically
-    // (the listeners will be removed when the window is closed)
-    // and restore the maximized or full screen state
-    if (mainWindowState) mainWindowState.manage(newWindow);
-
-    // If a valid window size was specified, override any maximized/fullscreen state that manage() restored.
-    // setSize() is ignored on a maximized/fullscreen window, so explicitly exit those states first.
-    if (windowSizeArg && sizeMatch && windowWidth && windowHeight) {
-      if (newWindow.isFullScreen()) newWindow.setFullScreen(false);
-      if (newWindow.isMaximized()) newWindow.unmaximize();
-      newWindow.setSize(windowWidth, windowHeight);
+    // Restore the saved maximized/full-screen state — unless a valid --window-size was given,
+    // which takes precedence and means "exactly this size, in the normal state"
+    if (!(windowSizeArg && sizeMatch)) {
+      if (boundsState?.isFullScreen) newWindow.setFullScreen(true);
+      else if (boundsState?.isMaximized) newWindow.maximize();
     }
+
+    /**
+     * This window's current placement for persistence. Mirrors the previous window-state keeper:
+     * the normal bounds (and the display they are on) are captured only while the window is in its
+     * normal state, so maximizing/minimizing/full-screening cannot overwrite the last normal
+     * placement — only flip the flags.
+     */
+    const captureWindowBoundsState = (): WindowBoundsState => {
+      const isMaximized = newWindow.isMaximized();
+      const isFullScreen = newWindow.isFullScreen();
+      const capturedState: WindowBoundsState = { isMaximized, isFullScreen };
+      if (!isMaximized && !isFullScreen && !newWindow.isMinimized()) {
+        const { x, y, width, height } = newWindow.getBounds();
+        capturedState.bounds = { x, y, width, height };
+        capturedState.displayBounds = { ...screen.getDisplayMatching(capturedState.bounds).bounds };
+      }
+      return capturedState;
+    };
+
+    // Feed this window's placement to layout persistence as it changes, debounced since
+    // resize/move fire continuously during a drag
+    let boundsCaptureTimeout: ReturnType<typeof setTimeout> | undefined;
+    const captureBoundsSoon = () => {
+      if (boundsCaptureTimeout) clearTimeout(boundsCaptureTimeout);
+      boundsCaptureTimeout = setTimeout(() => {
+        boundsCaptureTimeout = undefined;
+        if (newWindow.isDestroyed()) return;
+        updateWindowBounds(windowId, captureWindowBoundsState());
+      }, BOUNDS_CAPTURE_DEBOUNCE_MS);
+    };
+    newWindow.on('resize', captureBoundsSoon);
+    newWindow.on('move', captureBoundsSoon);
 
     // Add several listeners to the window to log events
     newWindow.webContents.on('unresponsive', () => logger.warn(`Window ${windowId} unresponsive`));
@@ -802,6 +884,17 @@ async function main() {
     // event, superseding the app:`before-quit` event and this process needs to be able to hang
     // the window until the sync completes.
     let isWindowClosing = false;
+    /**
+     * Whether this window's close is the app going down, decided on the first pass through the
+     * close handler below.
+     *
+     * Read again in the `closed` handler, which has to tell a deliberate close — rewrite the
+     * persisted window-layouts structure without this window — from a quit, where the structure was
+     * already flushed with this window still in it and must not be rewritten smaller. It cannot
+     * decide that for itself: by then the window is out of the tracked list, so the quit test below
+     * would no longer give the same answer.
+     */
+    let isAppGoingDown = false;
     newWindow.on('close', async (event) => {
       // A second close click while the first close is still working falls through to Electron's
       // default close on purpose: with the sync's request timeout disabled by the extension, the
@@ -821,7 +914,7 @@ async function main() {
       // quit (Cmd+Q, menu Quit, OS logout) — which does NOT show up as a last-window close, since
       // Electron closes every window and `isAppQuitRequested` is set from `before-quit`, which
       // fires ahead of any `close`.
-      const isAppGoingDown = isAppQuitRequested() || areAllWindowsClosing();
+      isAppGoingDown = isAppQuitRequested() || areAllWindowsClosing();
 
       // Prevents the window from initially closing
       event.preventDefault();
@@ -833,6 +926,22 @@ async function main() {
           // startup sync after this shutdown sync, or reach a network connection that is about to
           // be torn down.
           startupTasksAbort.abort();
+
+          // Flush the window-layouts structure with every still-tracked window in it, before any
+          // `closed` handler trims the list — a window that is not live at save time is not
+          // written, so this is what preserves the closing windows' entries across a quit (and the
+          // final window's entry on a last-window close). Capture this window's placement first so
+          // the flush holds its freshest bounds; on a multi-window quit each window's close handler
+          // does the same, so the last flush holds everyone's.
+          // Only on this path: a window closing while the app stays up is leaving the structure,
+          // and its `closed` handler below rewrites the structure without it.
+          if (boundsCaptureTimeout) {
+            clearTimeout(boundsCaptureTimeout);
+            boundsCaptureTimeout = undefined;
+          }
+          updateWindowBounds(windowId, captureWindowBoundsState());
+          await writeNow(windows.map((window) => window.id));
+
           // On a multi-window quit every window reaches this line, so the tasks are shared rather
           // than run once per window — each window waits on the same run before destroying itself.
           await runShutdownTasksOnce(performShutdownTasks);
@@ -903,6 +1012,20 @@ async function main() {
           `A subscriber threw while being told window ${windowId} closed, so the rest of them were not told: ${getErrorMessage(e)}`,
         );
       }
+
+      // Stop persisting this window. When the close was deliberate — the app stays up — rewrite the
+      // structure without it so the window does not come back next session. During a quit the
+      // structure was already flushed with this window still in it, and must NOT be rewritten
+      // smaller here.
+      // After the announcement above, which is synchronous and must not wait on a disk write, and
+      // before the unsubscribers below, which spend the network service's whole registration retry
+      // failing against a renderer that is already gone.
+      if (boundsCaptureTimeout) {
+        clearTimeout(boundsCaptureTimeout);
+        boundsCaptureTimeout = undefined;
+      }
+      handleWindowRemoved(windowId);
+      if (!isAppGoingDown) await writeNow(windows.map((window) => window.id));
 
       try {
         await windowCloseUnsubscribers.runAllUnsubscribers();
@@ -1121,6 +1244,62 @@ async function main() {
     // eslint-disable-next-line
     // Removed until we have a release. See https://github.com/paranext/paranext-core/issues/83
     // new AppUpdater();
+
+    return newWindow;
+  };
+
+  /**
+   * Create the app's windows from the persisted window-layouts structure: one window per saved
+   * entry, in entry order — except in simple interface mode, which is single-window, so only the
+   * main entry's window is created and the other entries stay preserved in the structure. With no
+   * usable structure (first run, or an upgrade from the single-window keeper), one legacy window is
+   * created whose renderer falls back to the pre-multi-window saved layout.
+   *
+   * Runs at startup and again on macOS re-activation after the last window closed (the quit-like
+   * close path flushed the structure when that window went down).
+   */
+  const restoreWindows = async () => {
+    const plan = await loadWindowLayouts();
+    if (plan.kind === 'legacy') {
+      const legacyWindow = await createWindow({ kind: 'legacy', boundsState: plan.boundsState });
+      setMainWindowId(legacyWindow.id);
+      return;
+    }
+
+    // The main entry's window is created first — before the interface-mode read below, which can
+    // block on the extension host early in startup — so the first window never waits on it. The
+    // saved structure keeps entry order regardless of window creation order.
+    const { entries, mainEntryIndex } = plan;
+    const mainWindow = await createWindow({
+      kind: 'entry',
+      entryIndex: mainEntryIndex,
+      entry: entries[mainEntryIndex],
+    });
+    setMainWindowId(mainWindow.id);
+    if (entries.length <= 1) return;
+
+    // Simple mode is single-window: restore only the main window no matter how many entries the
+    // structure holds. Same when the mode cannot be read — restoring too few is recoverable
+    // because an entry not assigned to a window this session is preserved in the structure, while
+    // restoring too many would put a Power user's secondary windows on a Simple user's screen.
+    let interfaceMode: SettingTypes['platform.interfaceMode'] | undefined;
+    try {
+      interfaceMode = await settingsService.get('platform.interfaceMode');
+    } catch (e) {
+      logger.warn(
+        `Could not read platform.interfaceMode; restoring only the main window: ${getErrorMessage(e)}`,
+      );
+    }
+    if (interfaceMode !== 'power') return;
+
+    for (let entryIndex = 0; entryIndex < entries.length; entryIndex += 1) {
+      if (entryIndex !== mainEntryIndex) {
+        // Sequential on purpose: creating windows one at a time keeps the tracked window order
+        // (and so the focus fallback and save order) deterministic
+        // eslint-disable-next-line no-await-in-loop
+        await createWindow({ kind: 'entry', entryIndex, entry: entries[entryIndex] });
+      }
+    }
   };
 
   app.on('window-all-closed', () => {
@@ -1200,23 +1379,25 @@ async function main() {
         }
       }
 
-      // Neither call below is awaited — startup carries on and the `activate` handler is
-      // synchronous — so a refusal or failure is reported here rather than becoming an unhandled
-      // rejection
-      const createWindowReportingFailures = async (occasion: string) => {
-        try {
-          await createWindow();
-        } catch (e) {
-          logger.error(`Failed to create a window ${occasion}: ${getErrorMessage(e)}`);
-        }
-      };
+      // Caught here rather than left to reject this chain: `createWindow` refuses outright during a
+      // quit and the restore reads from disk, so this can fail — and a rejection would skip the
+      // `activate` registration below, which is the only thing that brings windows back on macOS
+      // after the last one closes.
+      try {
+        await restoreWindows();
+      } catch (e) {
+        logger.error(`Failed to restore windows at startup: ${getErrorMessage(e)}`);
+      }
 
-      createWindowReportingFailures('at startup');
-
-      app.on('activate', () => {
-        // On macOS it's common to re-create a window in the app when the
+      app.on('activate', async () => {
+        // On macOS it's common to re-create windows in the app when the
         // dock icon is clicked and there are no other windows open.
-        if (windows.length === 0) createWindowReportingFailures('on activate');
+        if (windows.length !== 0) return;
+        try {
+          await restoreWindows();
+        } catch (e) {
+          logger.error(`Failed to restore windows on activate: ${getErrorMessage(e)}`);
+        }
       });
 
       return undefined;

--- a/src/main/services/__tests__/window-layout-persistence.service.test.ts
+++ b/src/main/services/__tests__/window-layout-persistence.service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import path from 'path';
 import type { LayoutInfo } from '@shared/models/docking-framework.model';
 import type {
   WindowBoundsState,
@@ -217,11 +218,14 @@ describe('window layout persistence service', () => {
     // No trace anywhere in the file, not just no entry
     const lastWriteCall = mocks.writeFile.mock.calls.at(-1);
     expect(String(lastWriteCall?.[1])).not.toContain('two');
-    // Written safely: temp file first, then renamed over the real one
-    expect(String(lastWriteCall?.[0])).toBe('/mock-user-data/window-layouts.json.tmp');
+    // Written safely: temp file first, then renamed over the real one. Expectations are built with
+    // path.join because the service joins paths, so separators differ per platform.
+    expect(String(lastWriteCall?.[0])).toBe(
+      path.join('/mock-user-data', 'window-layouts.json.tmp'),
+    );
     expect(mocks.rename).toHaveBeenCalledWith(
-      '/mock-user-data/window-layouts.json.tmp',
-      '/mock-user-data/window-layouts.json',
+      path.join('/mock-user-data', 'window-layouts.json.tmp'),
+      path.join('/mock-user-data', 'window-layouts.json'),
     );
   });
 

--- a/src/main/services/__tests__/window-layout-persistence.service.test.ts
+++ b/src/main/services/__tests__/window-layout-persistence.service.test.ts
@@ -1,0 +1,520 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { LayoutInfo } from '@shared/models/docking-framework.model';
+import type {
+  WindowBoundsState,
+  WindowLayoutEntry,
+  WindowLayoutStructure,
+} from '@shared/data/window-layout-persistence.model';
+import { reconcileSavedLayout } from '@shared/utils/saved-layout-reconciliation.util';
+
+// NOTE: `globalThis.processType` is deliberately left unset (the logger warns per call but works).
+// Setting it to `Main` would make the shared logger run electron-log's main-process initialization
+// at import time, which requires the real electron runtime this test replaces with a mock.
+
+// Left untyped (behaviors are wired in beforeEach) so `mock.calls` stays destructurable
+const mocks = vi.hoisted(() => ({
+  getPath: vi.fn(),
+  readFile: vi.fn(),
+  writeFile: vi.fn(),
+  rename: vi.fn(),
+  registerRequestHandler: vi.fn(),
+}));
+
+vi.mock('electron', () => ({ app: { getPath: mocks.getPath } }));
+vi.mock('fs/promises', () => {
+  const mocked = {
+    readFile: mocks.readFile,
+    writeFile: mocks.writeFile,
+    rename: mocks.rename,
+  };
+  // Other modules in the import graph (e.g. the logger) default-import fs/promises
+  return { ...mocked, default: mocked };
+});
+vi.mock('@shared/services/network.service', () => ({
+  registerRequestHandler: mocks.registerRequestHandler,
+}));
+
+/** Missing-file rejection shaped the way fs delivers it (the service detects the `code`) */
+function enoent(filePath: string): Error {
+  return Object.assign(new Error(`ENOENT: no such file, open '${filePath}'`), { code: 'ENOENT' });
+}
+
+/** Put the given file contents on the mocked disk; anything not given does not exist */
+function seedFiles(files: { structure?: unknown; legacyWindowState?: unknown } = {}): void {
+  mocks.readFile.mockImplementation(async (filePath: string) => {
+    if (filePath.endsWith('window-layouts.json') && files.structure !== undefined)
+      return typeof files.structure === 'string'
+        ? files.structure
+        : JSON.stringify(files.structure);
+    if (filePath.endsWith('window-state.json') && files.legacyWindowState !== undefined)
+      return JSON.stringify(files.legacyWindowState);
+    throw enoent(filePath);
+  });
+}
+
+/** The structure most recently written to disk */
+function writtenStructure(): WindowLayoutStructure {
+  const lastWriteCall = mocks.writeFile.mock.calls.at(-1);
+  if (!lastWriteCall) throw new Error('nothing was written');
+  return JSON.parse(String(lastWriteCall[1]));
+}
+
+/** The request handler the service registered for the given request type */
+function registeredHandler(requestType: string): (...args: unknown[]) => Promise<unknown> {
+  const registration = mocks.registerRequestHandler.mock.calls.find(
+    ([type]) => type === requestType,
+  );
+  if (!registration) throw new Error(`no handler registered for ${requestType}`);
+  return registration[1];
+}
+
+/** A minimal saved layout holding one viewable tab */
+function layoutWithTab(tabId: string): LayoutInfo {
+  return {
+    dockbox: { mode: 'horizontal', children: [{ tabs: [{ id: tabId, tabType: 'webView' }] }] },
+  };
+}
+
+/** A saved layout whose only tab could never render (no id) — a phantom-only layout */
+function phantomOnlyLayout(): LayoutInfo {
+  return { dockbox: { mode: 'horizontal', children: [{ tabs: [{ tabType: 'webView' }] }] } };
+}
+
+/** The id of the first tab in an entry's layout, for order assertions */
+function firstTabIdOf(layout: LayoutInfo | undefined): string | undefined {
+  // Walking a deliberately opaque saved-layout fixture
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  const dockbox = layout?.dockbox as { children?: { tabs?: { id?: string }[] }[] } | undefined;
+  return dockbox?.children?.[0]?.tabs?.[0]?.id;
+}
+
+type ServiceModule = typeof import('@main/services/window-layout-persistence.service');
+
+/** Fresh service instance (module state reset) with its request handlers registered */
+async function startService(): Promise<ServiceModule> {
+  const service = await import('@main/services/window-layout-persistence.service');
+  await service.initializeWindowLayoutPersistence();
+  return service;
+}
+
+/** Load the given entries and assign one window per entry, in order, starting at `firstWindowId` */
+async function loadAndAssignAll(
+  service: ServiceModule,
+  entries: WindowLayoutEntry[],
+  firstWindowId: number,
+): Promise<void> {
+  seedFiles({ structure: { windows: entries } });
+  const plan = await service.loadWindowLayouts();
+  if (plan.kind !== 'restore') throw new Error('expected a restore plan');
+  plan.entries.forEach((_, index) => service.assignEntryToWindow(firstWindowId + index, index));
+}
+
+describe('window layout persistence service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mocks.getPath.mockReturnValue('/mock-user-data');
+    mocks.writeFile.mockResolvedValue(undefined);
+    mocks.rename.mockResolvedValue(undefined);
+    mocks.registerRequestHandler.mockResolvedValue(async () => true);
+    seedFiles();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  test('reports the legacy single-window plan when no structure file exists', async () => {
+    seedFiles({
+      legacyWindowState: {
+        x: 5,
+        y: 6,
+        width: 700,
+        height: 500,
+        isMaximized: true,
+        displayBounds: { x: 0, y: 0, width: 1920, height: 1080 },
+      },
+    });
+    const service = await startService();
+
+    const plan = await service.loadWindowLayouts();
+
+    expect(plan).toEqual({
+      kind: 'legacy',
+      boundsState: {
+        bounds: { x: 5, y: 6, width: 700, height: 500 },
+        isMaximized: true,
+        displayBounds: { x: 0, y: 0, width: 1920, height: 1080 },
+      },
+    });
+  });
+
+  test('reports the legacy plan with no bounds when the previous keeper file is missing too', async () => {
+    const service = await startService();
+
+    const plan = await service.loadWindowLayouts();
+
+    expect(plan).toEqual({ kind: 'legacy', boundsState: undefined });
+  });
+
+  test('falls back to the legacy plan when the structure file is corrupt or empty', async () => {
+    const service = await startService();
+
+    seedFiles({ structure: 'this is not json' });
+    expect((await service.loadWindowLayouts()).kind).toBe('legacy');
+
+    seedFiles({ structure: { windows: [] } });
+    expect((await service.loadWindowLayouts()).kind).toBe('legacy');
+  });
+
+  test('hands out the saved entries in file order as windows are assigned', async () => {
+    seedFiles({
+      structure: {
+        windows: [
+          { layout: layoutWithTab('one'), isMain: true },
+          { layout: layoutWithTab('two') },
+          { layout: layoutWithTab('three') },
+        ],
+      },
+    });
+    const service = await startService();
+
+    const plan = await service.loadWindowLayouts();
+
+    if (plan.kind !== 'restore') throw new Error('expected a restore plan');
+    expect(plan.entries.map((entry) => firstTabIdOf(entry.layout))).toEqual([
+      'one',
+      'two',
+      'three',
+    ]);
+    expect(plan.mainEntryIndex).toBe(0);
+
+    service.assignEntryToWindow(11, 0);
+    service.assignEntryToWindow(12, 1);
+    service.assignEntryToWindow(13, 2);
+    const getLayout = registeredHandler('windowLayout:get');
+    await expect(getLayout(12)).resolves.toEqual({ kind: 'entry', layout: layoutWithTab('two') });
+    await expect(getLayout(13)).resolves.toEqual({ kind: 'entry', layout: layoutWithTab('three') });
+  });
+
+  test('writes exactly the live windows in order; a removed window leaves no trace', async () => {
+    const service = await startService();
+    await loadAndAssignAll(
+      service,
+      [
+        { layout: layoutWithTab('one'), isMain: true },
+        { layout: layoutWithTab('two') },
+        { layout: layoutWithTab('three') },
+      ],
+      11,
+    );
+
+    service.handleWindowRemoved(12);
+    await service.writeNow([11, 13]);
+
+    const written = writtenStructure();
+    expect(written.windows.map((entry) => firstTabIdOf(entry.layout))).toEqual(['one', 'three']);
+    // No trace anywhere in the file, not just no entry
+    const lastWriteCall = mocks.writeFile.mock.calls.at(-1);
+    expect(String(lastWriteCall?.[1])).not.toContain('two');
+    // Written safely: temp file first, then renamed over the real one
+    expect(String(lastWriteCall?.[0])).toBe('/mock-user-data/window-layouts.json.tmp');
+    expect(mocks.rename).toHaveBeenCalledWith(
+      '/mock-user-data/window-layouts.json.tmp',
+      '/mock-user-data/window-layouts.json',
+    );
+  });
+
+  test('marks exactly one entry as main, following the tracked main window', async () => {
+    const service = await startService();
+    await loadAndAssignAll(
+      service,
+      [
+        { layout: layoutWithTab('one'), isMain: true },
+        { layout: layoutWithTab('two') },
+        { layout: layoutWithTab('three') },
+      ],
+      11,
+    );
+    service.setMainWindowId(12);
+
+    await service.writeNow([11, 12, 13]);
+
+    expect(writtenStructure().windows.map((entry) => entry.isMain)).toEqual([
+      undefined,
+      true,
+      undefined,
+    ]);
+  });
+
+  test('falls back to marking the first entry as main when the main window is gone', async () => {
+    const service = await startService();
+    await loadAndAssignAll(
+      service,
+      [
+        { layout: layoutWithTab('one'), isMain: true },
+        { layout: layoutWithTab('two') },
+        { layout: layoutWithTab('three') },
+      ],
+      11,
+    );
+    service.setMainWindowId(11);
+
+    service.handleWindowRemoved(11);
+    await service.writeNow([12, 13]);
+
+    expect(writtenStructure().windows.map((entry) => entry.isMain)).toEqual([true, undefined]);
+  });
+
+  test('a session that never pushes a layout cannot clobber saved layouts or shrink the list', async () => {
+    // A simple-mode session: only the main entry's window is created, and the renderer never
+    // pushes a layout. The write must keep every entry, layouts untouched, only bounds moving.
+    seedFiles({
+      structure: {
+        windows: [
+          {
+            layout: layoutWithTab('one'),
+            bounds: { x: 1, y: 2, width: 300, height: 400 },
+            isMain: true,
+          },
+          { layout: layoutWithTab('two') },
+          { layout: layoutWithTab('three') },
+        ],
+      },
+    });
+    const service = await startService();
+    const plan = await service.loadWindowLayouts();
+    if (plan.kind !== 'restore') throw new Error('expected a restore plan');
+    service.assignEntryToWindow(21, plan.mainEntryIndex);
+    service.setMainWindowId(21);
+
+    const movedBounds = { x: 50, y: 60, width: 800, height: 600 };
+    service.updateWindowBounds(21, { bounds: movedBounds });
+    await service.writeNow([21]);
+
+    expect(writtenStructure().windows).toEqual([
+      { layout: layoutWithTab('one'), bounds: movedBounds, isMain: true },
+      { layout: layoutWithTab('two') },
+      { layout: layoutWithTab('three') },
+    ]);
+  });
+
+  test('coalesces rapid updates into one debounced write; writeNow flushes immediately', async () => {
+    vi.useFakeTimers();
+    const service = await startService();
+    await loadAndAssignAll(service, [{ layout: layoutWithTab('one'), isMain: true }], 31);
+
+    service.updateWindowBounds(31, { bounds: { x: 1, y: 1, width: 500, height: 500 } });
+    service.updateWindowBounds(31, { bounds: { x: 2, y: 2, width: 500, height: 500 } });
+    service.updateWindowBounds(31, { bounds: { x: 3, y: 3, width: 500, height: 500 } });
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mocks.writeFile).toHaveBeenCalledTimes(1);
+    expect(writtenStructure().windows[0].bounds).toEqual({ x: 3, y: 3, width: 500, height: 500 });
+
+    service.updateWindowBounds(31, { bounds: { x: 4, y: 4, width: 500, height: 500 } });
+    await service.writeNow([31]);
+    expect(mocks.writeFile).toHaveBeenCalledTimes(2);
+
+    // The pending debounced write was absorbed by writeNow rather than firing again later
+    await vi.advanceTimersByTimeAsync(10000);
+    expect(mocks.writeFile).toHaveBeenCalledTimes(2);
+  });
+
+  test('drops a phantom-only entry so it cannot resurrect a window', async () => {
+    seedFiles({
+      structure: {
+        windows: [
+          { layout: phantomOnlyLayout() },
+          { layout: layoutWithTab('keeper'), isMain: true },
+        ],
+      },
+    });
+    const service = await startService();
+
+    const plan = await service.loadWindowLayouts();
+
+    if (plan.kind !== 'restore') throw new Error('expected a restore plan');
+    expect(plan.entries).toHaveLength(1);
+    expect(firstTabIdOf(plan.entries[0].layout)).toBe('keeper');
+    expect(plan.mainEntryIndex).toBe(0);
+  });
+
+  test('an entry saved tab-less restores a window — a deliberately empty window comes back', async () => {
+    // Quitting with a second, empty window open and relaunching must bring that window back.
+    // Tab-less-as-saved is the signature of a live, legitimately empty window; only an entry whose
+    // tabs all turn out to be phantoms is junk (previous test).
+    const emptyLayout: LayoutInfo = { dockbox: { mode: 'horizontal', children: [] } };
+    seedFiles({
+      structure: {
+        windows: [{ layout: layoutWithTab('one'), isMain: true }, { layout: emptyLayout }],
+      },
+    });
+    const service = await startService();
+
+    const plan = await service.loadWindowLayouts();
+
+    if (plan.kind !== 'restore') throw new Error('expected a restore plan');
+    expect(plan.entries).toHaveLength(2);
+    service.assignEntryToWindow(11, 0);
+    service.assignEntryToWindow(12, 1);
+    await expect(registeredHandler('windowLayout:get')(12)).resolves.toEqual({
+      kind: 'entry',
+      layout: emptyLayout,
+    });
+  });
+
+  test('an entry with no saved layout restores an empty window, not the legacy layout', async () => {
+    // An untouched empty window never pushes a layout, so its entry is written with no layout key.
+    // It must come back as an empty window; answering 'legacy' here would clone the
+    // pre-multi-window layout into it.
+    seedFiles({
+      structure: {
+        windows: [
+          { layout: layoutWithTab('one'), isMain: true },
+          { bounds: { x: 2, y: 2, width: 200, height: 200 } },
+        ],
+      },
+    });
+    const service = await startService();
+
+    const plan = await service.loadWindowLayouts();
+
+    if (plan.kind !== 'restore') throw new Error('expected a restore plan');
+    expect(plan.entries).toHaveLength(2);
+    service.assignEntryToWindow(11, 0);
+    service.assignEntryToWindow(12, 1);
+    await expect(registeredHandler('windowLayout:get')(12)).resolves.toEqual({ kind: 'empty' });
+  });
+
+  test('the exact shape an emptied dock pushes round-trips as a restorable empty window', async () => {
+    // What the renderer pushes for a window whose user closed every tab: `saveLayout` runs the
+    // dock's layout through reconcileSavedLayout before pushing, so derive the pushed shape the
+    // same way instead of hardcoding it. The load filter must classify this exact shape as
+    // "already empty" (keep and restore) rather than phantom junk (drop), or quitting with an
+    // emptied window would silently lose it.
+    const pushedEmptyShape = reconcileSavedLayout({
+      dockbox: { mode: 'horizontal', children: [{ tabs: [] }] },
+    });
+    seedFiles({
+      structure: {
+        windows: [{ layout: layoutWithTab('one'), isMain: true }, { layout: pushedEmptyShape }],
+      },
+    });
+    const service = await startService();
+
+    const plan = await service.loadWindowLayouts();
+
+    if (plan.kind !== 'restore') throw new Error('expected a restore plan');
+    expect(plan.entries).toHaveLength(2);
+    service.assignEntryToWindow(11, 0);
+    service.assignEntryToWindow(12, 1);
+    await expect(registeredHandler('windowLayout:get')(12)).resolves.toEqual({
+      kind: 'entry',
+      layout: pushedEmptyShape,
+    });
+  });
+
+  test('answers a main entry that never captured a layout with the legacy fallback', async () => {
+    // An upgrade can create the structure file from bounds alone (a simple-mode session writes
+    // bounds but never a layout). The pre-multi-window layout still lives in the renderer's
+    // unprefixed localStorage, so this window must keep falling back to it.
+    seedFiles({
+      structure: { windows: [{ bounds: { x: 1, y: 2, width: 300, height: 400 } }] },
+    });
+    const service = await startService();
+
+    const plan = await service.loadWindowLayouts();
+
+    if (plan.kind !== 'restore') throw new Error('expected a restore plan');
+    service.assignEntryToWindow(41, 0);
+    await expect(registeredHandler('windowLayout:get')(41)).resolves.toEqual({ kind: 'legacy' });
+  });
+
+  test('answers the legacy window with the legacy fallback and any other window with empty', async () => {
+    const service = await startService();
+    await service.loadWindowLayouts();
+    service.trackLegacyWindow(51);
+    service.trackNewWindow(52);
+
+    const getLayout = registeredHandler('windowLayout:get');
+    await expect(getLayout(51)).resolves.toEqual({ kind: 'legacy' });
+    await expect(getLayout(52)).resolves.toEqual({ kind: 'empty' });
+    await expect(getLayout(999)).resolves.toEqual({ kind: 'empty' });
+  });
+
+  test('a pushed layout is served back and persisted', async () => {
+    const service = await startService();
+    await service.loadWindowLayouts();
+    service.trackLegacyWindow(61);
+    service.setMainWindowId(61);
+
+    const pushed = layoutWithTab('pushed');
+    await registeredHandler('windowLayout:save')(61, pushed);
+
+    await expect(registeredHandler('windowLayout:get')(61)).resolves.toEqual({
+      kind: 'entry',
+      layout: pushed,
+    });
+    await service.writeNow([61]);
+    expect(writtenStructure().windows).toEqual([{ layout: pushed, isMain: true }]);
+  });
+
+  test('a mid-session window is appended after the restored entries when written', async () => {
+    const service = await startService();
+    await loadAndAssignAll(
+      service,
+      [{ layout: layoutWithTab('one'), isMain: true }, { layout: layoutWithTab('two') }],
+      11,
+    );
+    service.setMainWindowId(11);
+    service.trackNewWindow(99);
+    await registeredHandler('windowLayout:save')(99, layoutWithTab('fresh'));
+
+    await service.writeNow([11, 12, 99]);
+
+    expect(writtenStructure().windows.map((entry) => firstTabIdOf(entry.layout))).toEqual([
+      'one',
+      'two',
+      'fresh',
+    ]);
+  });
+
+  test('a failed disk write is swallowed so persistence can never break the app', async () => {
+    mocks.writeFile.mockRejectedValue(new Error('disk full'));
+    const service = await startService();
+    await loadAndAssignAll(service, [{ layout: layoutWithTab('one'), isMain: true }], 71);
+
+    await expect(service.writeNow([71])).resolves.toBeUndefined();
+  });
+
+  test('a bounds update for one window leaves the other windows’ entries alone', async () => {
+    const service = await startService();
+    await loadAndAssignAll(
+      service,
+      [
+        {
+          layout: layoutWithTab('one'),
+          bounds: { x: 1, y: 1, width: 100, height: 100 },
+          isMain: true,
+        },
+        { layout: layoutWithTab('two'), bounds: { x: 2, y: 2, width: 200, height: 200 } },
+      ],
+      11,
+    );
+    service.setMainWindowId(11);
+
+    const boundsUpdate: WindowBoundsState = {
+      bounds: { x: 9, y: 9, width: 900, height: 900 },
+      isMaximized: true,
+    };
+    service.updateWindowBounds(12, boundsUpdate);
+    await service.writeNow([11, 12]);
+
+    const written = writtenStructure();
+    expect(written.windows[0].bounds).toEqual({ x: 1, y: 1, width: 100, height: 100 });
+    expect(written.windows[1].bounds).toEqual({ x: 9, y: 9, width: 900, height: 900 });
+    expect(written.windows[1].isMaximized).toBe(true);
+  });
+});

--- a/src/main/services/__tests__/window-layout-persistence.service.test.ts
+++ b/src/main/services/__tests__/window-layout-persistence.service.test.ts
@@ -493,6 +493,203 @@ describe('window layout persistence service', () => {
     await expect(service.writeNow([71])).resolves.toBeUndefined();
   });
 
+  test('removing a window cancels its pending debounced write so the flush stays the last write', async () => {
+    vi.useFakeTimers();
+    const service = await startService();
+    await loadAndAssignAll(
+      service,
+      [{ layout: layoutWithTab('one'), isMain: true }, { layout: layoutWithTab('two') }],
+      11,
+    );
+    service.setMainWindowId(11);
+
+    // The app is going down: the structure is flushed with both windows still tracked…
+    await service.writeNow([11, 12]);
+    expect(mocks.writeFile).toHaveBeenCalledTimes(1);
+
+    // …then a bounds update lands (the window was dragged during the shutdown wait), scheduling a
+    // debounced write, and the window is torn down before the debounce fires.
+    service.updateWindowBounds(12, { bounds: { x: 9, y: 9, width: 900, height: 900 } });
+    service.handleWindowRemoved(12);
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    // The flush must remain the last write: a debounced write firing after the removal would
+    // rewrite the structure without the removed window, losing its entry.
+    expect(mocks.writeFile).toHaveBeenCalledTimes(1);
+    expect(writtenStructure().windows.map((entry) => firstTabIdOf(entry.layout))).toEqual([
+      'one',
+      'two',
+    ]);
+  });
+
+  test('a layout pushed while a flush waits behind an in-flight write still lands in the flush', async () => {
+    const service = await startService();
+    await loadAndAssignAll(service, [{ layout: layoutWithTab('one'), isMain: true }], 11);
+    service.setMainWindowId(11);
+
+    // The first write blocks on the disk, holding the write chain open
+    let releaseFirstWrite: (() => void) | undefined;
+    mocks.writeFile.mockImplementationOnce(
+      async () =>
+        new Promise<void>((resolve) => {
+          releaseFirstWrite = resolve;
+        }),
+    );
+    const firstWrite = service.writeNow([11]);
+    await vi.waitFor(() => expect(mocks.writeFile).toHaveBeenCalledTimes(1));
+
+    // The flush queues behind it, and a last-moment layout push lands before the flush executes
+    const flush = service.writeNow([11]);
+    await registeredHandler('windowLayout:save')(11, layoutWithTab('late'));
+
+    if (!releaseFirstWrite) throw new Error('the first write never reached the disk');
+    releaseFirstWrite();
+    await firstWrite;
+    await flush;
+
+    expect(writtenStructure().windows.map((entry) => firstTabIdOf(entry.layout))).toEqual(['late']);
+    // Defuse the debounced write the late push scheduled so it cannot leak into another test
+    service.handleWindowRemoved(11);
+  });
+
+  test('loading waits for an in-flight write so the plan reflects the newest structure', async () => {
+    const service = await startService();
+    await loadAndAssignAll(service, [{ layout: layoutWithTab('one'), isMain: true }], 11);
+    service.setMainWindowId(11);
+    await registeredHandler('windowLayout:save')(11, layoutWithTab('two'));
+
+    // Block the write on the disk, and only surface its content to reads once it completes — the
+    // mocked disk serves the old structure until the write lands, like a real file would
+    let releaseWrite: (() => void) | undefined;
+    let flushedRaw: string | undefined;
+    mocks.writeFile.mockImplementation(
+      async (_filePath: string, content: string) =>
+        new Promise<void>((resolve) => {
+          releaseWrite = () => {
+            flushedRaw = content;
+            resolve();
+          };
+        }),
+    );
+    mocks.readFile.mockImplementation(async (filePath: string) => {
+      if (filePath.endsWith('window-layouts.json'))
+        return flushedRaw ?? JSON.stringify({ windows: [{ layout: layoutWithTab('one') }] });
+      throw enoent(filePath);
+    });
+
+    const write = service.writeNow([11]);
+    await vi.waitFor(() => expect(mocks.writeFile).toHaveBeenCalled());
+    const planPromise = service.loadWindowLayouts();
+    if (!releaseWrite) throw new Error('the write never reached the disk');
+    releaseWrite();
+    await write;
+    const plan = await planPromise;
+
+    if (plan.kind !== 'restore') throw new Error('expected a restore plan');
+    expect(firstTabIdOf(plan.entries[0].layout)).toBe('two');
+  });
+
+  test('a pushed layout is reconciled before it is stored, served, or persisted', async () => {
+    const service = await startService();
+    await service.loadWindowLayouts();
+    service.trackLegacyWindow(61);
+    service.setMainWindowId(61);
+
+    // A duplicated tab, which reconciliation collapses to one occurrence. The renderer reconciles
+    // before pushing, but the handler must not depend on every pusher doing so.
+    const pushed: LayoutInfo = {
+      dockbox: {
+        mode: 'horizontal',
+        children: [
+          { tabs: [{ id: 'kept', tabType: 'webView' }] },
+          { tabs: [{ id: 'kept', tabType: 'webView' }] },
+        ],
+      },
+    };
+    await registeredHandler('windowLayout:save')(61, pushed);
+
+    const reconciled = reconcileSavedLayout(pushed);
+    await expect(registeredHandler('windowLayout:get')(61)).resolves.toEqual({
+      kind: 'entry',
+      layout: reconciled,
+    });
+    await service.writeNow([61]);
+    expect(writtenStructure().windows).toEqual([{ layout: reconciled, isMain: true }]);
+  });
+
+  test('assigning to a missing entry index tracks the window as new instead', async () => {
+    const service = await startService();
+    await loadAndAssignAll(service, [{ layout: layoutWithTab('one'), isMain: true }], 11);
+    service.setMainWindowId(11);
+
+    service.assignEntryToWindow(99, 5);
+
+    // The window is tracked (it appears in writes) but received no entry layout
+    await expect(registeredHandler('windowLayout:get')(99)).resolves.toEqual({ kind: 'empty' });
+    await service.writeNow([11, 99]);
+    const written = writtenStructure();
+    expect(written.windows).toHaveLength(2);
+    expect(firstTabIdOf(written.windows[0].layout)).toBe('one');
+    expect(written.windows[1].layout).toBeUndefined();
+  });
+
+  test('assigning a window to an already-assigned slot tracks it as a new window', async () => {
+    const service = await startService();
+    await loadAndAssignAll(service, [{ layout: layoutWithTab('one'), isMain: true }], 11);
+
+    service.assignEntryToWindow(12, 0);
+
+    // Window 12 must not receive entry 0's layout — that slot belongs to window 11
+    await expect(registeredHandler('windowLayout:get')(12)).resolves.toEqual({ kind: 'empty' });
+    await expect(registeredHandler('windowLayout:get')(11)).resolves.toEqual({
+      kind: 'entry',
+      layout: layoutWithTab('one'),
+    });
+  });
+
+  test('assigning an already-tracked window again leaves its original assignment intact', async () => {
+    const service = await startService();
+    seedFiles({
+      structure: {
+        windows: [{ layout: layoutWithTab('one'), isMain: true }, { layout: layoutWithTab('two') }],
+      },
+    });
+    const plan = await service.loadWindowLayouts();
+    if (plan.kind !== 'restore') throw new Error('expected a restore plan');
+    service.assignEntryToWindow(11, 0);
+    service.setMainWindowId(11);
+
+    service.assignEntryToWindow(11, 1);
+
+    await expect(registeredHandler('windowLayout:get')(11)).resolves.toEqual({
+      kind: 'entry',
+      layout: layoutWithTab('one'),
+    });
+    // Entry 'two' survives as a preserved, unassigned slot
+    await service.writeNow([11]);
+    expect(writtenStructure().windows.map((entry) => firstTabIdOf(entry.layout))).toEqual([
+      'one',
+      'two',
+    ]);
+  });
+
+  test('save requests with a bad id, a bad layout, or an untracked window change nothing', async () => {
+    vi.useFakeTimers();
+    const service = await startService();
+    await service.loadWindowLayouts();
+    service.trackLegacyWindow(61);
+
+    const save = registeredHandler('windowLayout:save');
+    await save('61', layoutWithTab('pushed')); // id must be a number
+    await save(61, 'not-a-layout'); // layout must be object-shaped
+    await save(999, layoutWithTab('pushed')); // window 999 is not tracked
+
+    // None of the bad pushes may schedule a write or alter the tracked window's layout
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(mocks.writeFile).not.toHaveBeenCalled();
+    await expect(registeredHandler('windowLayout:get')(61)).resolves.toEqual({ kind: 'legacy' });
+  });
+
   test('a bounds update for one window leaves the other windows’ entries alone', async () => {
     const service = await startService();
     await loadAndAssignAll(

--- a/src/main/services/window-layout-persistence.service.ts
+++ b/src/main/services/window-layout-persistence.service.ts
@@ -1,0 +1,478 @@
+/**
+ * Owns the persisted window-layouts structure: which windows exist, each window's dock layout, and
+ * each window's bounds. The structure lives in `window-layouts.json` in the app's user data folder
+ * and is read and written ONLY by the main process — renderers get and push their layout through
+ * the `windowLayout:get`/`windowLayout:save` request handlers registered here.
+ *
+ * Identity model: a window's position in the structure's list IS its identity across sessions;
+ * Electron window ids are runtime-only and are never persisted. At startup the caller assigns file
+ * entries to freshly created windows in order; at save time the live windows are written back out.
+ * A file entry that was never assigned to a window (e.g. a power-mode secondary window while the
+ * app runs in simple mode, which restores only the main window) is preserved in place, so a session
+ * that restores fewer windows than the file holds can never destroy the other windows' entries.
+ */
+
+import path from 'path';
+import { readFile, rename, writeFile } from 'fs/promises';
+import { app } from 'electron';
+import {
+  GET_WINDOW_LAYOUT_REQUEST_TYPE,
+  SAVE_WINDOW_LAYOUT_REQUEST_TYPE,
+  WindowBoundsState,
+  WindowLayoutEntry,
+  WindowLayoutGetResponse,
+  WindowLayoutStructure,
+  WindowRectangle,
+} from '@shared/data/window-layout-persistence.model';
+import type { LayoutInfo } from '@shared/models/docking-framework.model';
+import { logger } from '@shared/services/logger.service';
+import * as networkService from '@shared/services/network.service';
+import {
+  reconcileSavedLayout,
+  savedLayoutHasAnyTabs,
+  savedLayoutHasViewableTabs,
+} from '@shared/utils/saved-layout-reconciliation.util';
+import { getErrorMessage } from 'platform-bible-utils';
+
+/** File holding the persisted structure, in the app's user data folder */
+const WINDOW_LAYOUTS_FILE_NAME = 'window-layouts.json';
+
+/**
+ * File the previous single-window bounds keeper (electron-window-state) maintained. Read once so an
+ * upgrade keeps the user's window placement; never written or deleted by this service.
+ */
+const LEGACY_WINDOW_STATE_FILE_NAME = 'window-state.json';
+
+/** How long to coalesce updates before writing the structure to disk */
+const WRITE_DEBOUNCE_MS = 500;
+
+/**
+ * What startup (or macOS re-activation) should create:
+ *
+ * - `restore`: one window per entry — or only the `mainEntryIndex` entry's window in simple interface
+ *   mode, leaving the other entries preserved in the file.
+ * - `legacy`: no usable structure exists — one window whose renderer falls back to the
+ *   pre-multi-window saved layout, placed at the previous keeper's bounds if it left any.
+ */
+export type StartupWindowsPlan =
+  | { kind: 'restore'; entries: readonly WindowLayoutEntry[]; mainEntryIndex: number }
+  | { kind: 'legacy'; boundsState?: WindowBoundsState };
+
+/** A file entry and, once startup assigns it, the runtime window living in it */
+type FileSlot = { entry: WindowLayoutEntry; windowId?: number };
+
+/** Live state of one tracked window, written out at save time */
+type TrackedWindow = {
+  windowId: number;
+  layout?: LayoutInfo;
+  boundsState: WindowBoundsState;
+  /**
+   * Whether this window should fall back to the legacy (pre-multi-window) saved layout when it has
+   * no layout of its own: the single window of a legacy startup, or the MAIN entry when it has
+   * never captured a layout (a structure file created by bounds updates alone — e.g. simple-mode
+   * sessions — while the user's power layout still lives only in the renderer's unprefixed
+   * localStorage). Never a secondary entry: layout-less there means a deliberately empty window,
+   * which must stay empty rather than cloning the legacy layout.
+   */
+  usesLegacyLayout: boolean;
+};
+
+/** File entries in file order; unassigned slots are preserved verbatim at save time */
+let fileSlots: FileSlot[] = [];
+/** Index into {@link fileSlots} of the main entry, so only that entry may use the legacy fallback */
+let mainSlotIndex: number | undefined;
+/** Live windows in creation order */
+let trackedWindows: TrackedWindow[] = [];
+/** Window whose entry the save walk marks `isMain` */
+let mainWindowId: number | undefined;
+/** Bounds the previous keeper saved, seeded into the legacy window so an upgrade keeps placement */
+let legacyBoundsState: WindowBoundsState | undefined;
+/** Pending debounced write, if any */
+let writeTimeout: ReturnType<typeof setTimeout> | undefined;
+/** Serializes disk writes so a debounced write and a writeNow can never interleave on the file */
+let writeChain: Promise<void> = Promise.resolve();
+
+function getWindowLayoutsFilePath(): string {
+  return path.join(app.getPath('userData'), WINDOW_LAYOUTS_FILE_NAME);
+}
+
+function isFileNotFound(error: unknown): boolean {
+  return !!error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT';
+}
+
+/** View parsed JSON as an indexable record if it is object-shaped at all */
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  // Parsed JSON data; crossing from `object` to the indexable shape only adds property reads that
+  // are each validated below
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  return value as Record<string, unknown>;
+}
+
+function parseRectangle(value: unknown): WindowRectangle | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  const { x, y, width, height } = record;
+  if (
+    typeof x !== 'number' ||
+    typeof y !== 'number' ||
+    typeof width !== 'number' ||
+    typeof height !== 'number'
+  )
+    return undefined;
+  return { x, y, width, height };
+}
+
+/** Read the bounds-state fields off a parsed record. Falsy/absent flags are omitted, not `false` */
+function parseBoundsState(
+  record: Record<string, unknown>,
+  boundsSource: unknown,
+): WindowBoundsState {
+  return {
+    bounds: parseRectangle(boundsSource),
+    isMaximized: record.isMaximized === true ? true : undefined,
+    isFullScreen: record.isFullScreen === true ? true : undefined,
+    displayBounds: parseRectangle(record.displayBounds),
+  };
+}
+
+/**
+ * A parsed file entry plus whether its layout structurally held any tabs BEFORE reconciliation —
+ * the discriminator between a legitimately empty window (no tabs as saved: restore it) and junk
+ * (tabs saved but none viewable: drop it). See the filter in {@link loadWindowLayouts}.
+ */
+type ParsedEntry = { entry: WindowLayoutEntry; layoutHadTabs: boolean };
+
+function parseEntry(value: unknown): ParsedEntry | undefined {
+  const record = asRecord(value);
+  if (!record) return undefined;
+  const layout = asRecord(record.layout);
+  return {
+    entry: {
+      ...parseBoundsState(record, record.bounds),
+      // Reconcile at load so phantom content in a saved layout never reaches a window
+      layout: layout ? reconcileSavedLayout(layout) : undefined,
+      isMain: record.isMain === true ? true : undefined,
+    },
+    layoutHadTabs: layout ? savedLayoutHasAnyTabs(layout) : false,
+  };
+}
+
+/** Entries from the structure file, or undefined when it is unreadable */
+function parseStructure(raw: string): ParsedEntry[] | undefined {
+  try {
+    const record = asRecord(JSON.parse(raw));
+    if (!record || !Array.isArray(record.windows)) return undefined;
+    return record.windows
+      .map(parseEntry)
+      .filter((parsed): parsed is ParsedEntry => parsed !== undefined);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Bounds the previous single-window keeper saved, if its file exists and is readable */
+async function readLegacyWindowState(): Promise<WindowBoundsState | undefined> {
+  try {
+    const raw = await readFile(
+      path.join(app.getPath('userData'), LEGACY_WINDOW_STATE_FILE_NAME),
+      'utf8',
+    );
+    const record = asRecord(JSON.parse(raw));
+    if (!record) return undefined;
+    // The keeper stored the window bounds as top-level x/y/width/height
+    return parseBoundsState(record, record);
+  } catch (error) {
+    if (!isFileNotFound(error))
+      logger.warn(
+        `Could not read legacy ${LEGACY_WINDOW_STATE_FILE_NAME}: ${getErrorMessage(error)}`,
+      );
+    return undefined;
+  }
+}
+
+function findTrackedWindow(windowId: number): TrackedWindow | undefined {
+  return trackedWindows.find((tracked) => tracked.windowId === windowId);
+}
+
+/**
+ * Read the persisted structure and report what startup should create. Resets all in-memory
+ * tracking, so call it only while no windows are open (app startup, or macOS re-activation after
+ * the last window closed).
+ *
+ * Entries whose saved layout HAD tabs but has none viewable after reconciliation are dropped here —
+ * such phantom-only junk must not resurrect a window. An entry saved with no tabs at all (or no
+ * layout) is different: that is a window that was legitimately open and empty when the structure
+ * was written, and it IS restored — quitting with an empty second window open must bring it back.
+ * The main entry is always kept, since the app always opens at least one window.
+ */
+export async function loadWindowLayouts(): Promise<StartupWindowsPlan> {
+  if (writeTimeout) {
+    clearTimeout(writeTimeout);
+    writeTimeout = undefined;
+  }
+  fileSlots = [];
+  mainSlotIndex = undefined;
+  trackedWindows = [];
+  mainWindowId = undefined;
+  legacyBoundsState = undefined;
+
+  let raw: string | undefined;
+  try {
+    raw = await readFile(getWindowLayoutsFilePath(), 'utf8');
+  } catch (error) {
+    if (!isFileNotFound(error))
+      logger.warn(`Could not read ${WINDOW_LAYOUTS_FILE_NAME}: ${getErrorMessage(error)}`);
+  }
+  if (raw !== undefined) {
+    const parsedEntries = parseStructure(raw);
+    if (parsedEntries && parsedEntries.length > 0) {
+      const flaggedMainIndex = parsedEntries.findIndex(({ entry }) => entry.isMain === true);
+      const mainIndex = flaggedMainIndex >= 0 ? flaggedMainIndex : 0;
+      const keptParsedEntries = parsedEntries.filter(
+        ({ entry, layoutHadTabs }, index) =>
+          index === mainIndex ||
+          !layoutHadTabs ||
+          (entry.layout !== undefined && savedLayoutHasViewableTabs(entry.layout)),
+      );
+      const keptEntries = keptParsedEntries.map(({ entry }) => entry);
+      mainSlotIndex = keptParsedEntries.indexOf(parsedEntries[mainIndex]);
+      fileSlots = keptEntries.map((entry) => ({ entry }));
+      return {
+        kind: 'restore',
+        entries: keptEntries,
+        mainEntryIndex: mainSlotIndex,
+      };
+    }
+    logger.warn(
+      `${WINDOW_LAYOUTS_FILE_NAME} is unreadable or holds no windows; restoring a single legacy window`,
+    );
+  }
+
+  legacyBoundsState = await readLegacyWindowState();
+  return { kind: 'legacy', boundsState: legacyBoundsState };
+}
+
+/** The bounds-state slice of a file entry, seeding a freshly assigned window's live state */
+function boundsStateOfEntry(entry: WindowLayoutEntry): WindowBoundsState {
+  return {
+    bounds: entry.bounds,
+    isMaximized: entry.isMaximized,
+    isFullScreen: entry.isFullScreen,
+    displayBounds: entry.displayBounds,
+  };
+}
+
+/**
+ * Tie a freshly created window to the file entry it restores. The window's live state seeds from
+ * the entry, so a session that never updates it writes the entry back out unchanged.
+ */
+export function assignEntryToWindow(windowId: number, entryIndex: number): void {
+  const slot = fileSlots[entryIndex];
+  if (!slot || slot.windowId !== undefined || findTrackedWindow(windowId)) {
+    logger.warn(
+      `Cannot assign window ${windowId} to window-layout entry ${entryIndex}; tracking it as a new window instead`,
+    );
+    trackNewWindow(windowId);
+    return;
+  }
+  slot.windowId = windowId;
+  trackedWindows.push({
+    windowId,
+    layout: slot.entry.layout,
+    boundsState: boundsStateOfEntry(slot.entry),
+    // Only the MAIN entry may fall back to the legacy saved layout when it never captured one —
+    // see TrackedWindow.usesLegacyLayout. A layout-less secondary entry is an empty window and
+    // must stay empty: falling back would clone the pre-multi-window layout into it.
+    usesLegacyLayout: slot.entry.layout === undefined && entryIndex === mainSlotIndex,
+  });
+}
+
+/**
+ * Track the single window of a legacy startup (no structure file). Its renderer falls back to the
+ * pre-multi-window saved layout, and its bounds seed from the previous keeper's file so an upgrade
+ * keeps the user's window placement.
+ */
+export function trackLegacyWindow(windowId: number): void {
+  if (findTrackedWindow(windowId)) return;
+  trackedWindows.push({
+    windowId,
+    boundsState: legacyBoundsState ? { ...legacyBoundsState } : {},
+    usesLegacyLayout: true,
+  });
+}
+
+/** Track a window created mid-session. It has no saved entry, so it starts with an empty layout */
+export function trackNewWindow(windowId: number): void {
+  if (findTrackedWindow(windowId)) return;
+  trackedWindows.push({ windowId, boundsState: {}, usesLegacyLayout: false });
+}
+
+/** Record which window's entry the save walk should mark `isMain` */
+export function setMainWindowId(windowId: number): void {
+  mainWindowId = windowId;
+}
+
+/** Merge captured bounds into a window's live state and schedule a write */
+export function updateWindowBounds(windowId: number, boundsState: WindowBoundsState): void {
+  const tracked = findTrackedWindow(windowId);
+  if (!tracked) {
+    logger.warn(`Ignoring bounds update for untracked window ${windowId}`);
+    return;
+  }
+  tracked.boundsState = {
+    // Bounds are captured only while the window is in its normal state; a maximized/minimized/
+    // full-screen capture carries no bounds and must keep the last normal placement
+    bounds: boundsState.bounds ?? tracked.boundsState.bounds,
+    displayBounds: boundsState.displayBounds ?? tracked.boundsState.displayBounds,
+    isMaximized: boundsState.isMaximized ?? tracked.boundsState.isMaximized,
+    isFullScreen: boundsState.isFullScreen ?? tracked.boundsState.isFullScreen,
+  };
+  scheduleWrite();
+}
+
+/**
+ * Stop tracking a window that is gone. This alone does not write — the caller decides whether the
+ * close was deliberate (rewrite without the window) or part of app shutdown (the structure was
+ * already flushed with the window still in it, and must not be rewritten smaller).
+ */
+export function handleWindowRemoved(windowId: number): void {
+  trackedWindows = trackedWindows.filter((tracked) => tracked.windowId !== windowId);
+  fileSlots = fileSlots.filter((slot) => slot.windowId !== windowId);
+}
+
+/** A window's live state as a file entry */
+function entryForTrackedWindow(tracked: TrackedWindow): WindowLayoutEntry {
+  return { layout: tracked.layout, ...tracked.boundsState };
+}
+
+/**
+ * The structure as it should be written right now: every file slot in file order — a slot's live
+ * window state when its window is live, the preserved entry when the slot was never assigned this
+ * session, nothing when its window was removed — then every live window that has no slot (opened
+ * mid-session), in the given order. Exactly one entry ends up marked `isMain`: the tracked main
+ * window's, falling back to the first entry when the main window is gone.
+ */
+function buildStructure(windowIdsInOrder: readonly number[]): WindowLayoutStructure {
+  const liveIds = new Set(windowIdsInOrder);
+  const built: { entry: WindowLayoutEntry; windowId?: number }[] = [];
+  fileSlots.forEach((slot) => {
+    if (slot.windowId === undefined) {
+      built.push({ entry: { ...slot.entry } });
+      return;
+    }
+    if (!liveIds.has(slot.windowId)) return;
+    const tracked = findTrackedWindow(slot.windowId);
+    if (tracked) built.push({ entry: entryForTrackedWindow(tracked), windowId: slot.windowId });
+  });
+  const slottedWindowIds = new Set(
+    fileSlots.map((slot) => slot.windowId).filter((id) => id !== undefined),
+  );
+  windowIdsInOrder.forEach((windowId) => {
+    if (slottedWindowIds.has(windowId)) return;
+    const tracked = findTrackedWindow(windowId);
+    if (tracked) built.push({ entry: entryForTrackedWindow(tracked), windowId });
+  });
+
+  built.forEach(({ entry }) => {
+    delete entry.isMain;
+  });
+  const mainBuilt =
+    built.find(({ windowId }) => windowId !== undefined && windowId === mainWindowId) ?? built[0];
+  if (mainBuilt) mainBuilt.entry.isMain = true;
+
+  return { windows: built.map(({ entry }) => entry) };
+}
+
+/** Write the structure to disk, never throwing — persistence must not be able to break the app */
+async function writeStructureToDisk(structure: WindowLayoutStructure): Promise<void> {
+  try {
+    const filePath = getWindowLayoutsFilePath();
+    // Write to a temp file and rename over the real one so a crash mid-write cannot leave a
+    // torn (unparseable) structure behind
+    const tempPath = `${filePath}.tmp`;
+    await writeFile(tempPath, JSON.stringify(structure), 'utf8');
+    await rename(tempPath, filePath);
+  } catch (error) {
+    logger.warn(`Failed to write ${WINDOW_LAYOUTS_FILE_NAME}: ${getErrorMessage(error)}`);
+  }
+}
+
+/** Snapshot the structure now and queue it behind any write already in flight */
+function enqueueWrite(windowIdsInOrder: readonly number[]): Promise<void> {
+  const structure = buildStructure(windowIdsInOrder);
+  writeChain = writeChain.then(() => writeStructureToDisk(structure));
+  return writeChain;
+}
+
+/** Schedule a debounced write of the currently tracked windows */
+function scheduleWrite(): void {
+  if (writeTimeout) clearTimeout(writeTimeout);
+  writeTimeout = setTimeout(() => {
+    writeTimeout = undefined;
+    enqueueWrite(trackedWindows.map((tracked) => tracked.windowId));
+  }, WRITE_DEBOUNCE_MS);
+}
+
+/**
+ * Write the structure for the given live windows immediately, absorbing any pending debounced
+ * write. Callers pass the windows that should survive in the file: all still-tracked windows when
+ * the app is going down, or the remaining windows after one was deliberately closed.
+ */
+export async function writeNow(windowIdsInOrder: readonly number[]): Promise<void> {
+  if (writeTimeout) {
+    clearTimeout(writeTimeout);
+    writeTimeout = undefined;
+  }
+  return enqueueWrite(windowIdsInOrder);
+}
+
+function handleGetLayoutRequest(windowId: unknown): WindowLayoutGetResponse {
+  if (typeof windowId !== 'number') {
+    logger.warn(`${GET_WINDOW_LAYOUT_REQUEST_TYPE} called without a window id`);
+    return { kind: 'empty' };
+  }
+  const tracked = findTrackedWindow(windowId);
+  if (!tracked) {
+    logger.warn(`${GET_WINDOW_LAYOUT_REQUEST_TYPE} called for untracked window ${windowId}`);
+    return { kind: 'empty' };
+  }
+  if (tracked.layout) return { kind: 'entry', layout: tracked.layout };
+  if (tracked.usesLegacyLayout) return { kind: 'legacy' };
+  return { kind: 'empty' };
+}
+
+function handleSaveLayoutRequest(windowId: unknown, layout: unknown): void {
+  if (typeof windowId !== 'number') {
+    logger.warn(`${SAVE_WINDOW_LAYOUT_REQUEST_TYPE} called without a window id`);
+    return;
+  }
+  const layoutRecord = asRecord(layout);
+  if (!layoutRecord) {
+    logger.warn(`${SAVE_WINDOW_LAYOUT_REQUEST_TYPE} called without a layout (window ${windowId})`);
+    return;
+  }
+  const tracked = findTrackedWindow(windowId);
+  if (!tracked) {
+    logger.warn(`Ignoring layout push from untracked window ${windowId}`);
+    return;
+  }
+  tracked.layout = layoutRecord;
+  scheduleWrite();
+}
+
+/**
+ * Register the `windowLayout:get`/`windowLayout:save` request handlers renderers use to load and
+ * push their dock layouts. Must be called during main process startup, before any window is
+ * created, so a renderer can never race the registration.
+ */
+export async function initializeWindowLayoutPersistence(): Promise<void> {
+  await Promise.all([
+    networkService.registerRequestHandler(GET_WINDOW_LAYOUT_REQUEST_TYPE, async (...args) =>
+      handleGetLayoutRequest(args[0]),
+    ),
+    networkService.registerRequestHandler(SAVE_WINDOW_LAYOUT_REQUEST_TYPE, async (...args) =>
+      handleSaveLayoutRequest(args[0], args[1]),
+    ),
+  ]);
+}

--- a/src/main/services/window-layout-persistence.service.ts
+++ b/src/main/services/window-layout-persistence.service.ts
@@ -195,6 +195,14 @@ function findTrackedWindow(windowId: number): TrackedWindow | undefined {
   return trackedWindows.find((tracked) => tracked.windowId === windowId);
 }
 
+/** Cancel the pending debounced write, if any */
+function cancelScheduledWrite(): void {
+  if (writeTimeout) {
+    clearTimeout(writeTimeout);
+    writeTimeout = undefined;
+  }
+}
+
 /**
  * Read the persisted structure and report what startup should create. Resets all in-memory
  * tracking, so call it only while no windows are open (app startup, or macOS re-activation after
@@ -207,10 +215,11 @@ function findTrackedWindow(windowId: number): TrackedWindow | undefined {
  * The main entry is always kept, since the app always opens at least one window.
  */
 export async function loadWindowLayouts(): Promise<StartupWindowsPlan> {
-  if (writeTimeout) {
-    clearTimeout(writeTimeout);
-    writeTimeout = undefined;
-  }
+  cancelScheduledWrite();
+  // A flush can still be draining when this runs (macOS: re-activation right after the last
+  // window's quit-like close flushed the structure); read only after it lands, or the plan would
+  // be built from the previous file contents.
+  await writeChain;
   fileSlots = [];
   mainSlotIndex = undefined;
   trackedWindows = [];
@@ -337,6 +346,11 @@ export function updateWindowBounds(windowId: number, boundsState: WindowBoundsSt
  * already flushed with the window still in it, and must not be rewritten smaller).
  */
 export function handleWindowRemoved(windowId: number): void {
+  // A write scheduled before the removal would capture the shrunken window list when its debounce
+  // fires — after a quit-time flush that would rewrite the structure without the removed window,
+  // losing its entry — so any pending write dies with the window. A caller that wants the smaller
+  // structure written (a deliberate close) calls writeNow itself.
+  cancelScheduledWrite();
   trackedWindows = trackedWindows.filter((tracked) => tracked.windowId !== windowId);
   fileSlots = fileSlots.filter((slot) => slot.windowId !== windowId);
 }
@@ -398,10 +412,16 @@ async function writeStructureToDisk(structure: WindowLayoutStructure): Promise<v
   }
 }
 
-/** Snapshot the structure now and queue it behind any write already in flight */
+/**
+ * Queue a write of the structure behind any write already in flight. The structure is built when
+ * the write EXECUTES, not when it is enqueued, so state that changes while earlier writes drain —
+ * e.g. a layout pushed while a quit-time flush waits its turn — still lands in the write. Only the
+ * window list is pinned at enqueue time: which windows a write covers is the caller's decision (see
+ * {@link writeNow}), while their state should be the freshest available.
+ */
 function enqueueWrite(windowIdsInOrder: readonly number[]): Promise<void> {
-  const structure = buildStructure(windowIdsInOrder);
-  writeChain = writeChain.then(() => writeStructureToDisk(structure));
+  const windowIds = [...windowIdsInOrder];
+  writeChain = writeChain.then(() => writeStructureToDisk(buildStructure(windowIds)));
   return writeChain;
 }
 
@@ -420,10 +440,7 @@ function scheduleWrite(): void {
  * the app is going down, or the remaining windows after one was deliberately closed.
  */
 export async function writeNow(windowIdsInOrder: readonly number[]): Promise<void> {
-  if (writeTimeout) {
-    clearTimeout(writeTimeout);
-    writeTimeout = undefined;
-  }
+  cancelScheduledWrite();
   return enqueueWrite(windowIdsInOrder);
 }
 
@@ -457,7 +474,9 @@ function handleSaveLayoutRequest(windowId: unknown, layout: unknown): void {
     logger.warn(`Ignoring layout push from untracked window ${windowId}`);
     return;
   }
-  tracked.layout = layoutRecord;
+  // Reconcile on arrival so phantom content (duplicate or orphaned tabs, empty panels) cannot
+  // enter the persisted structure even when a pusher skipped its own reconciliation
+  tracked.layout = reconcileSavedLayout(layoutRecord);
   scheduleWrite();
 }
 

--- a/src/main/window-bounds.util.test.ts
+++ b/src/main/window-bounds.util.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from 'vitest';
+import {
+  DEFAULT_WINDOW_HEIGHT,
+  DEFAULT_WINDOW_WIDTH,
+  ensureBoundsVisibleOnSomeDisplay,
+} from '@main/window-bounds.util';
+
+const PRIMARY = { bounds: { x: 0, y: 0, width: 1920, height: 1080 } };
+const SECONDARY = { bounds: { x: 1920, y: 0, width: 1280, height: 1024 } };
+
+describe('ensureBoundsVisibleOnSomeDisplay', () => {
+  test('leaves bounds fully inside a display untouched', () => {
+    const savedState = {
+      bounds: { x: 100, y: 50, width: 800, height: 600 },
+      isMaximized: false,
+      isFullScreen: false,
+      displayBounds: { ...PRIMARY.bounds },
+    };
+
+    expect(ensureBoundsVisibleOnSomeDisplay(savedState, [PRIMARY, SECONDARY], PRIMARY)).toEqual(
+      savedState,
+    );
+  });
+
+  test('leaves bounds fully inside a secondary display untouched', () => {
+    const savedState = { bounds: { x: 2000, y: 100, width: 800, height: 600 } };
+
+    expect(ensureBoundsVisibleOnSomeDisplay(savedState, [PRIMARY, SECONDARY], PRIMARY)).toEqual(
+      savedState,
+    );
+  });
+
+  test('re-places bounds from a departed display onto the primary display at default size', () => {
+    // The window was on SECONDARY, which is no longer connected
+    const savedState = { bounds: { x: 2000, y: 100, width: 800, height: 600 } };
+
+    const result = ensureBoundsVisibleOnSomeDisplay(savedState, [PRIMARY], PRIMARY);
+
+    expect(result.bounds).toEqual({
+      x: PRIMARY.bounds.x,
+      y: PRIMARY.bounds.y,
+      width: DEFAULT_WINDOW_WIDTH,
+      height: DEFAULT_WINDOW_HEIGHT,
+    });
+    expect(result.displayBounds).toEqual(PRIMARY.bounds);
+  });
+
+  test('keeps a maximized window maximized while re-placing it off a departed display', () => {
+    const savedState = {
+      bounds: { x: 2000, y: 100, width: 800, height: 600 },
+      isMaximized: true,
+      isFullScreen: false,
+      displayBounds: { ...SECONDARY.bounds },
+    };
+
+    const result = ensureBoundsVisibleOnSomeDisplay(savedState, [PRIMARY], PRIMARY);
+
+    expect(result.isMaximized).toBe(true);
+    expect(result.bounds).toEqual({
+      x: PRIMARY.bounds.x,
+      y: PRIMARY.bounds.y,
+      width: DEFAULT_WINDOW_WIDTH,
+      height: DEFAULT_WINDOW_HEIGHT,
+    });
+    expect(result.displayBounds).toEqual(PRIMARY.bounds);
+  });
+
+  test('re-places a partially offscreen window (containment must be within a single display)', () => {
+    // Hangs off the bottom-right of the primary display; also straddling two displays counts as
+    // not contained. Same containment rule as the previous window-state keeper.
+    const savedState = { bounds: { x: 1500, y: 800, width: 800, height: 600 } };
+
+    const result = ensureBoundsVisibleOnSomeDisplay(savedState, [PRIMARY, SECONDARY], PRIMARY);
+
+    expect(result.bounds).toEqual({
+      x: PRIMARY.bounds.x,
+      y: PRIMARY.bounds.y,
+      width: DEFAULT_WINDOW_WIDTH,
+      height: DEFAULT_WINDOW_HEIGHT,
+    });
+  });
+
+  test('gives a maximized state with no normal bounds a default placement, still maximized', () => {
+    const savedState = { isMaximized: true };
+
+    const result = ensureBoundsVisibleOnSomeDisplay(savedState, [PRIMARY, SECONDARY], PRIMARY);
+
+    expect(result.isMaximized).toBe(true);
+    expect(result.bounds).toEqual({
+      x: PRIMARY.bounds.x,
+      y: PRIMARY.bounds.y,
+      width: DEFAULT_WINDOW_WIDTH,
+      height: DEFAULT_WINDOW_HEIGHT,
+    });
+  });
+
+  test('does not mutate the saved state it is given', () => {
+    const savedState = { bounds: { x: 9999, y: 9999, width: 800, height: 600 } };
+    const original = JSON.parse(JSON.stringify(savedState));
+
+    ensureBoundsVisibleOnSomeDisplay(savedState, [PRIMARY], PRIMARY);
+
+    expect(savedState).toEqual(original);
+  });
+});

--- a/src/main/window-bounds.util.ts
+++ b/src/main/window-bounds.util.ts
@@ -1,0 +1,63 @@
+/**
+ * Keeps restored window bounds on a display that still exists. Pure — the caller passes the current
+ * display list in — so monitor-gone recovery is unit-testable without Electron.
+ */
+
+import type {
+  WindowBoundsState,
+  WindowRectangle,
+} from '@shared/data/window-layout-persistence.model';
+
+/** Width a window falls back to when its saved placement is unusable */
+export const DEFAULT_WINDOW_WIDTH = 1024;
+/** Height a window falls back to when its saved placement is unusable */
+export const DEFAULT_WINDOW_HEIGHT = 728;
+
+/** The one property of an Electron `Display` this module needs, so tests can pass plain objects */
+export type DisplayLike = { bounds: WindowRectangle };
+
+/** Whether `bounds` lies fully within `display` — the containment rule for "visible" */
+function isContainedIn(bounds: WindowRectangle, display: DisplayLike): boolean {
+  return (
+    bounds.x >= display.bounds.x &&
+    bounds.y >= display.bounds.y &&
+    bounds.x + bounds.width <= display.bounds.x + display.bounds.width &&
+    bounds.y + bounds.height <= display.bounds.y + display.bounds.height
+  );
+}
+
+/**
+ * Ensure a saved window placement is usable on the displays connected right now.
+ *
+ * Bounds fully contained in some display are returned unchanged. Anything else — bounds on a
+ * display that is gone, bounds partially offscreen or straddling two displays (containment must be
+ * within a single display, the same rule the previous window-state keeper used), or a
+ * maximized/full-screen state with no normal bounds at all — is re-placed at default size at the
+ * primary display's origin. `isMaximized`/`isFullScreen` survive re-placement, so a maximized
+ * window whose display departed comes back maximized on the primary display.
+ *
+ * Never mutates `savedState`.
+ *
+ * @param savedState Persisted placement to validate
+ * @param displays Displays connected right now (`screen.getAllDisplays()`)
+ * @param primaryDisplay Display to fall back to (`screen.getPrimaryDisplay()`)
+ * @returns A placement guaranteed to be on a connected display
+ */
+export function ensureBoundsVisibleOnSomeDisplay(
+  savedState: WindowBoundsState,
+  displays: readonly DisplayLike[],
+  primaryDisplay: DisplayLike,
+): WindowBoundsState {
+  const { bounds } = savedState;
+  if (bounds && displays.some((display) => isContainedIn(bounds, display))) return savedState;
+  return {
+    ...savedState,
+    bounds: {
+      x: primaryDisplay.bounds.x,
+      y: primaryDisplay.bounds.y,
+      width: DEFAULT_WINDOW_WIDTH,
+      height: DEFAULT_WINDOW_HEIGHT,
+    },
+    displayBounds: { ...primaryDisplay.bounds },
+  };
+}

--- a/src/renderer/services/web-view.service-host.test.ts
+++ b/src/renderer/services/web-view.service-host.test.ts
@@ -17,7 +17,12 @@ const SUPPLEMENT_TAB_ID = 'supplement-tab';
 
 const mocks = vi.hoisted(() => ({
   settingsGet: vi.fn(),
-  settingsSubscribe: vi.fn(async () => async () => true),
+  settingsSubscribe: vi.fn<
+    (
+      key: string,
+      callback: (newSetting: unknown) => Promise<void>,
+    ) => Promise<() => Promise<boolean>>
+  >(async () => async () => true),
   networkRequest: vi.fn(),
 }));
 
@@ -282,6 +287,31 @@ describe('loadLayout restores this window’s layout from the main process', () 
     expect(tabIdsIn(loaded)).toEqual(['legacy-tab-w2']);
   });
 
+  test('a legacy window prefers a window-prefixed legacy key over the stale unprefixed one', async () => {
+    // Builds that scoped localStorage per window (before layouts moved into the main process's
+    // structure) wrote the dock layout only under prefixed keys, so when one exists the unprefixed
+    // key is the older layout
+    localStorage.setItem('dock-saved-layout', serialize(layoutWithTab('stale-tab')));
+    localStorage.setItem('1_dock-saved-layout', serialize(layoutWithTab('prefixed-tab')));
+    respondToGetLayout({ kind: 'legacy' });
+
+    const loaded = await loadLayoutInWindow(layoutWithAnchor());
+
+    expect(tabIdsIn(loaded)).toEqual(['prefixed-tab-w2']);
+  });
+
+  test('with several window-prefixed legacy keys, the lowest window id wins', async () => {
+    // The lowest id was the earliest-created (main) window of the session that wrote the keys —
+    // and notably NOT this window's own id (this harness runs as window 2)
+    localStorage.setItem('3_dock-saved-layout', serialize(layoutWithTab('higher-tab')));
+    localStorage.setItem('1_dock-saved-layout', serialize(layoutWithTab('lowest-tab')));
+    respondToGetLayout({ kind: 'legacy' });
+
+    const loaded = await loadLayoutInWindow(layoutWithAnchor());
+
+    expect(tabIdsIn(loaded)).toEqual(['lowest-tab-w2']);
+  });
+
   test('a second window never receives the legacy layout — the clone fallback is gone', async () => {
     // The legacy layout is present, but main says this window has no entry: it must start empty
     // instead of cloning window 1's legacy layout
@@ -311,6 +341,103 @@ describe('loadLayout restores this window’s layout from the main process', () 
     // The dev-fresh-profile behavior: no saved entry and no legacy layout loads testLayout (which
     // here holds the anchor tab; the supplement then merges onto that anchor as usual)
     expect(tabIdsIn(loaded)).toContain('anchor-tab-w2');
+  });
+});
+
+describe('loadLayout when the saved-layout request fails', () => {
+  beforeEach(() => {
+    mocks.settingsGet.mockImplementation(async (key: string) =>
+      key === 'platform.interfaceMode' ? 'power' : false,
+    );
+    // A legacy layout is present throughout: a request FAILURE must never read it — only a
+    // main-process 'legacy' answer may (otherwise the shared legacy layout would be cloned into
+    // whichever window hit the failure)
+    localStorage.setItem('dock-saved-layout', serialize(layoutWithTab('legacy-tab')));
+  });
+
+  /** Register a dock layout under fake timers and drive the retry delays until the load lands */
+  async function registerWindowThroughRetries(simpleLayout: LayoutInfo) {
+    vi.useFakeTimers();
+    const { registerDockLayout } = await import('@renderer/services/web-view.service-host');
+    const { dockLayout, loadedLayouts } = makeDockLayout(simpleLayout);
+    registerDockLayout(dockLayout);
+    await vi.advanceTimersByTimeAsync(60_000);
+    vi.useRealTimers();
+    expect(loadedLayouts.length).toBeGreaterThan(0);
+    return { dockLayout, loadedLayouts };
+  }
+
+  test('retries a failed request and uses the answer a later attempt brings', async () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem');
+    let getLayoutCalls = 0;
+    mocks.networkRequest.mockImplementation(async (requestType: string) => {
+      if (requestType !== 'windowLayout:get') return undefined;
+      getLayoutCalls += 1;
+      if (getLayoutCalls < 3) throw new Error('transport not up yet');
+      return { kind: 'entry', layout: layoutWithTab('saved-tab') };
+    });
+
+    const { dockLayout, loadedLayouts } = await registerWindowThroughRetries(layoutWithAnchor());
+
+    expect(tabIdsIn(loadedLayouts[loadedLayouts.length - 1])).toEqual(['saved-tab-w2']);
+    expect(getItemSpy).not.toHaveBeenCalledWith('dock-saved-layout');
+    // Pushes work normally — the load succeeded, just not on the first attempt
+    await dockLayout.onLayoutChangeRef.current?.(layoutWithTab('changed'), undefined, undefined);
+    expect(layoutPushes()).toHaveLength(1);
+  });
+
+  test('when every attempt fails, the window starts empty and layout pushes are held', async () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, 'getItem');
+    mocks.networkRequest.mockImplementation(async (requestType: string) => {
+      if (requestType === 'windowLayout:get') throw new Error('transport is down');
+      return undefined;
+    });
+
+    const { dockLayout, loadedLayouts } = await registerWindowThroughRetries(layoutWithAnchor());
+
+    // Empty — not the legacy layout and not the harness's testLayout (which holds the anchor tab)
+    expect(tabIdsIn(loadedLayouts[loadedLayouts.length - 1])).toEqual([]);
+    expect(getItemSpy).not.toHaveBeenCalledWith('dock-saved-layout');
+
+    // A layout change must NOT be pushed: what the dock holds is a fallback, and pushing it would
+    // overwrite the user's real saved entry in the main process's structure
+    await dockLayout.onLayoutChangeRef.current?.(
+      layoutWithTab('fallback-era'),
+      undefined,
+      undefined,
+    );
+    expect(layoutPushes()).toEqual([]);
+  });
+
+  test('a later successful load lifts the push hold', async () => {
+    let interfaceModeCallback: ((newMode: unknown) => Promise<void>) | undefined;
+    mocks.settingsSubscribe.mockImplementation(
+      async (_key: string, callback: (newMode: unknown) => Promise<void>) => {
+        interfaceModeCallback = callback;
+        return async () => true;
+      },
+    );
+    mocks.networkRequest.mockImplementation(async (requestType: string) => {
+      if (requestType === 'windowLayout:get') throw new Error('transport is down');
+      return undefined;
+    });
+
+    const { dockLayout } = await registerWindowThroughRetries(layoutWithAnchor());
+    await dockLayout.onLayoutChangeRef.current?.(layoutWithTab('held'), undefined, undefined);
+    expect(layoutPushes()).toEqual([]);
+
+    // The transport recovers, and an interface-mode round trip reloads the layout
+    respondToGetLayout({ kind: 'entry', layout: layoutWithTab('saved-tab') });
+    if (!interfaceModeCallback) throw new Error('interface mode subscription never registered');
+    await interfaceModeCallback('simple');
+    await interfaceModeCallback('power');
+
+    await dockLayout.onLayoutChangeRef.current?.(
+      layoutWithTab('after-recovery'),
+      undefined,
+      undefined,
+    );
+    expect(layoutPushes()).toHaveLength(1);
   });
 });
 

--- a/src/renderer/services/web-view.service-host.test.ts
+++ b/src/renderer/services/web-view.service-host.test.ts
@@ -18,7 +18,7 @@ const SUPPLEMENT_TAB_ID = 'supplement-tab';
 const mocks = vi.hoisted(() => ({
   settingsGet: vi.fn(),
   settingsSubscribe: vi.fn(async () => async () => true),
-  storageGetItem: vi.fn((): string | undefined => undefined),
+  networkRequest: vi.fn(),
 }));
 
 // The supplement is product-specific data; supply our own so these tests describe the merge
@@ -46,15 +46,13 @@ vi.mock('@renderer/components/docking/default-layout-supplement.json', () => ({
 vi.mock('@shared/services/settings.service', () => ({
   settingsService: { get: mocks.settingsGet, subscribe: mocks.settingsSubscribe },
 }));
-vi.mock('@renderer/services/local-storage.service', () => ({
-  default: { getItem: mocks.storageGetItem, setItem: vi.fn() },
-}));
 
 // Everything below is module-load or startup machinery the layout path does not exercise; stub it
 // so importing the service host in a test does not stand up the whole renderer service graph.
 vi.mock('@shared/services/network.service', () => ({
   createBufferedNetworkEventEmitter: () => ({ emit: vi.fn(), dispose: vi.fn() }),
   getNetworkEvent: () => vi.fn(),
+  request: mocks.networkRequest,
 }));
 vi.mock('@shared/services/network-object.service', () => ({
   networkObjectService: { set: vi.fn() },
@@ -103,6 +101,26 @@ function layoutWithAnchor(extraTabs: SavedTabInfo[] = []): LayoutInfo {
   } as unknown as LayoutInfo;
 }
 
+/** Layout with one panel holding one web view tab with the given id */
+function layoutWithTab(tabId: string): LayoutInfo {
+  return {
+    dockbox: {
+      mode: 'horizontal',
+      children: [
+        {
+          tabs: [
+            {
+              id: tabId,
+              tabType: TAB_TYPE_WEBVIEW,
+              data: { id: tabId, webViewType: 'test.type', state: {} },
+            },
+          ],
+        },
+      ],
+    },
+  } as unknown as LayoutInfo;
+}
+
 /** Every tab id anywhere in a layout, in order */
 function tabIdsIn(layout: LayoutInfo): string[] {
   const ids: string[] = [];
@@ -136,20 +154,44 @@ function makeDockLayout(simpleLayout: LayoutInfo) {
 }
 
 /** Register a dock layout and wait for the fire-and-forget initial `loadLayout` to land */
-async function loadLayoutInWindow(simpleLayout: LayoutInfo) {
+async function registerWindow(simpleLayout: LayoutInfo) {
   const { registerDockLayout } = await import('@renderer/services/web-view.service-host');
   const { dockLayout, loadedLayouts } = makeDockLayout(simpleLayout);
   registerDockLayout(dockLayout);
   await vi.waitFor(() => expect(loadedLayouts.length).toBeGreaterThan(0));
+  return { dockLayout, loadedLayouts };
+}
+
+/** Register a dock layout and return the layout the initial load landed on */
+async function loadLayoutInWindow(simpleLayout: LayoutInfo) {
+  const { loadedLayouts } = await registerWindow(simpleLayout);
   return loadedLayouts[loadedLayouts.length - 1];
 }
 
+/** Answer `windowLayout:get` with the given response; every other request resolves undefined */
+function respondToGetLayout(response: unknown) {
+  mocks.networkRequest.mockImplementation(async (requestType: string) =>
+    requestType === 'windowLayout:get' ? response : undefined,
+  );
+}
+
+/** All `windowLayout:save` pushes made so far, as [windowId, layout] pairs */
+function layoutPushes() {
+  return mocks.networkRequest.mock.calls
+    .filter(([requestType]) => requestType === 'windowLayout:save')
+    .map(([, windowId, layout]) => [windowId, layout]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  localStorage.clear();
+  globalThis.windowId = '2';
+  respondToGetLayout({ kind: 'empty' });
+});
+
 describe('loadLayout scopes web view ids to this window', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    vi.resetModules();
-    globalThis.windowId = '2';
-    mocks.storageGetItem.mockReturnValue(undefined);
     mocks.settingsGet.mockImplementation(async (key: string) =>
       key === 'platform.interfaceMode' ? 'simple' : true,
     );
@@ -194,7 +236,7 @@ describe('loadLayout scopes web view ids to this window', () => {
   });
 
   test('re-scopes a restored supplement tab instead of adding a second copy', async () => {
-    // Power mode persists the merged layout, so the next load restores a supplement tab that is
+    // Power mode restores the merged layout, so the next load restores a supplement tab that is
     // already scoped — to another window's id, since window ids are not stable across restarts
     const savedSupplementTab: SavedTabInfo = {
       id: `${SUPPLEMENT_TAB_ID}-w1`,
@@ -204,12 +246,117 @@ describe('loadLayout scopes web view ids to this window', () => {
     mocks.settingsGet.mockImplementation(async (key: string) =>
       key === 'platform.interfaceMode' ? 'power' : true,
     );
-    mocks.storageGetItem.mockReturnValue(serialize(layoutWithAnchor([savedSupplementTab])));
+    respondToGetLayout({ kind: 'entry', layout: layoutWithAnchor([savedSupplementTab]) });
 
     const loaded = await loadLayoutInWindow(layoutWithAnchor());
 
     expect(tabIdsIn(loaded).filter((id) => id.startsWith(SUPPLEMENT_TAB_ID))).toEqual([
       `${SUPPLEMENT_TAB_ID}-w2`,
     ]);
+  });
+});
+
+describe('loadLayout restores this window’s layout from the main process', () => {
+  beforeEach(() => {
+    // Power mode with the supplement flag off, so these tests see exactly the restored layout
+    mocks.settingsGet.mockImplementation(async (key: string) =>
+      key === 'platform.interfaceMode' ? 'power' : false,
+    );
+  });
+
+  test('a window assigned an entry loads it, ids scoped to this window', async () => {
+    respondToGetLayout({ kind: 'entry', layout: layoutWithTab('saved-tab-w1') });
+
+    const loaded = await loadLayoutInWindow(layoutWithAnchor());
+
+    expect(mocks.networkRequest).toHaveBeenCalledWith('windowLayout:get', 2);
+    expect(tabIdsIn(loaded)).toEqual(['saved-tab-w2']);
+  });
+
+  test('a legacy window loads the unprefixed legacy layout from localStorage', async () => {
+    localStorage.setItem('dock-saved-layout', serialize(layoutWithTab('legacy-tab')));
+    respondToGetLayout({ kind: 'legacy' });
+
+    const loaded = await loadLayoutInWindow(layoutWithAnchor());
+
+    expect(tabIdsIn(loaded)).toEqual(['legacy-tab-w2']);
+  });
+
+  test('a second window never receives the legacy layout — the clone fallback is gone', async () => {
+    // The legacy layout is present, but main says this window has no entry: it must start empty
+    // instead of cloning window 1's legacy layout
+    localStorage.setItem('dock-saved-layout', serialize(layoutWithTab('legacy-tab')));
+    respondToGetLayout({ kind: 'empty' });
+
+    const loaded = await loadLayoutInWindow(layoutWithAnchor());
+
+    expect(tabIdsIn(loaded)).toEqual([]);
+  });
+
+  test('a window with no entry loads an empty layout — neither testLayout nor simpleLayout', async () => {
+    respondToGetLayout({ kind: 'empty' });
+
+    // The harness's simpleLayout and testLayout both hold the anchor tab, so any tab at all would
+    // mean one of them leaked in
+    const loaded = await loadLayoutInWindow(layoutWithAnchor());
+
+    expect(tabIdsIn(loaded)).toEqual([]);
+  });
+
+  test('falls back to testLayout only when legacy storage is empty too', async () => {
+    respondToGetLayout({ kind: 'legacy' });
+
+    const loaded = await loadLayoutInWindow(layoutWithAnchor());
+
+    // The dev-fresh-profile behavior: no saved entry and no legacy layout loads testLayout (which
+    // here holds the anchor tab; the supplement then merges onto that anchor as usual)
+    expect(tabIdsIn(loaded)).toContain('anchor-tab-w2');
+  });
+});
+
+describe('saveLayout pushes this window’s layout to the main process', () => {
+  beforeEach(() => {
+    mocks.settingsGet.mockImplementation(async (key: string) =>
+      key === 'platform.interfaceMode' ? 'power' : false,
+    );
+  });
+
+  test('a power-mode layout change pushes the reconciled layout with this window’s id', async () => {
+    const { dockLayout } = await registerWindow(layoutWithAnchor());
+
+    // A duplicated tab proves the layout is reconciled on the way out
+    const changedLayout = {
+      dockbox: {
+        mode: 'horizontal',
+        children: [
+          { tabs: [{ id: 'kept', tabType: TAB_TYPE_WEBVIEW }] },
+          { tabs: [{ id: 'kept', tabType: TAB_TYPE_WEBVIEW }] },
+        ],
+      },
+    } as unknown as LayoutInfo;
+    await dockLayout.onLayoutChangeRef.current?.(changedLayout, undefined, undefined);
+
+    expect(layoutPushes()).toEqual([
+      [
+        2,
+        {
+          dockbox: {
+            mode: 'horizontal',
+            children: [{ tabs: [{ id: 'kept', tabType: TAB_TYPE_WEBVIEW }] }],
+          },
+        },
+      ],
+    ]);
+  });
+
+  test('a simple-mode layout change pushes nothing', async () => {
+    mocks.settingsGet.mockImplementation(async (key: string) =>
+      key === 'platform.interfaceMode' ? 'simple' : false,
+    );
+    const { dockLayout } = await registerWindow(layoutWithAnchor());
+
+    await dockLayout.onLayoutChangeRef.current?.(layoutWithTab('ephemeral'), undefined, undefined);
+
+    expect(layoutPushes()).toEqual([]);
   });
 });

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -88,6 +88,7 @@ import {
   THEME_STYLE_ELEMENT_ID,
   Unsubscriber,
   UnsubscriberAsync,
+  wait,
 } from 'platform-bible-utils';
 import withWindowScopedWebViewIds, {
   withWindowScopedWebViewIdInTab,
@@ -591,6 +592,14 @@ function removeForbiddenElements(mutationList: MutationRecord[]) {
 const DOCK_LAYOUT_KEY = 'dock-saved-layout';
 
 /**
+ * A per-window prefixed copy of {@link DOCK_LAYOUT_KEY} (`{windowId}_dock-saved-layout` — the prefix
+ * scheme of `localStorage.service.ts`). Builds that scoped `localStorage` per window before layouts
+ * moved into the main process's structure wrote the dock layout ONLY under such keys; the capture
+ * group is the window id of the window that wrote the copy.
+ */
+const PREFIXED_DOCK_LAYOUT_KEY_PATTERN = new RegExp(`^(\\d+)_${DOCK_LAYOUT_KEY}$`);
+
+/**
  * Layout a window with no saved entry starts from: nothing docked. Deliberately neither the dev
  * `testLayout` nor `simpleLayout` — a window opened mid-session starts empty.
  */
@@ -910,42 +919,99 @@ async function loadLayout(layout?: LayoutInfo): Promise<void> {
 }
 
 /**
- * The pre-multi-window saved layout, read from the UNPREFIXED `localStorage` key — the raw
- * `localStorage`, not `localWindowStorage`, whose per-window prefixed copies of this key are dead:
- * the main process's window-layouts structure replaced them, and reading through that migration
- * path would clone the legacy layout into every window. Falls back to `defaultLayout` when there is
- * no legacy layout either (a fresh profile).
+ * The pre-multi-window saved layout, read from raw `localStorage` (not `localWindowStorage`, whose
+ * migration path would clone the legacy layout into every window). Builds that scoped
+ * `localStorage` per window wrote the dock layout only under prefixed keys
+ * ({@link PREFIXED_DOCK_LAYOUT_KEY_PATTERN}), leaving the unprefixed key stale — so when any
+ * prefixed copy exists, the one with the lowest window id (the earliest-created, main window of the
+ * session that wrote them) is the newest saved layout and wins; the unprefixed
+ * {@link DOCK_LAYOUT_KEY} is the fallback. Falls back to `defaultLayout` when there is no legacy
+ * layout at all (a fresh profile).
  *
  * @param defaultLayout Layout to fall back to when no legacy layout is stored
  */
 function getLegacySavedLayout(defaultLayout: LayoutInfo): LayoutInfo {
-  const saved = localStorage.getItem(DOCK_LAYOUT_KEY);
+  let lowestPrefixedWindowId: number | undefined;
+  for (let keyIndex = 0; keyIndex < localStorage.length; keyIndex += 1) {
+    const match = localStorage.key(keyIndex)?.match(PREFIXED_DOCK_LAYOUT_KEY_PATTERN);
+    if (match) {
+      const prefixWindowId = Number(match[1]);
+      if (lowestPrefixedWindowId === undefined || prefixWindowId < lowestPrefixedWindowId)
+        lowestPrefixedWindowId = prefixWindowId;
+    }
+  }
+  const saved =
+    lowestPrefixedWindowId !== undefined
+      ? localStorage.getItem(`${lowestPrefixedWindowId}_${DOCK_LAYOUT_KEY}`)
+      : localStorage.getItem(DOCK_LAYOUT_KEY);
   const savedLayout: LayoutInfo | undefined = saved ? deserialize(saved) : undefined;
   return savedLayout || defaultLayout;
 }
 
 /**
+ * How many times {@link getPersistedLayout} asks the main process for this window's saved layout
+ * before giving up. The main process registers the handler before it creates any window, so a
+ * failure can only be transient transport trouble, not a missing handler — worth a few retries.
+ */
+const GET_PERSISTED_LAYOUT_ATTEMPTS = 3;
+
+/** How long {@link getPersistedLayout} waits between attempts */
+const GET_PERSISTED_LAYOUT_RETRY_DELAY_MS = 2_000;
+
+/**
+ * Whether this window is running on a fallback layout because every `windowLayout:get` attempt
+ * failed. While set, {@link saveLayout} holds its pushes: what the dock holds is NOT the user's
+ * saved layout, and pushing it would overwrite the real saved entry in the main process's
+ * structure. Cleared when a later {@link getPersistedLayout} gets an answer (e.g. the reload on an
+ * interface-mode change).
+ */
+let isRunningOnFallbackLayout = false;
+
+/** Whether the held-pushes situation has been logged — once per session, not per layout change */
+let hasLoggedHeldLayoutPushes = false;
+
+/**
  * The layout this window should restore, per the main process's window-layouts structure: this
  * window's saved entry, an empty layout for a window with no entry, or — for the one window a
- * legacy startup restores — the pre-multi-window layout from `localStorage`. Falls back to the
- * legacy path when the request itself fails, which is also what a fresh profile needs.
+ * legacy startup restores — the pre-multi-window layout from `localStorage`. Only that explicit
+ * `legacy` answer may trigger the legacy read: when the request itself fails (after retries), the
+ * window starts EMPTY instead — falling back to the shared legacy layout would clone it into
+ * whichever window hit the failure — and pushes are held so the fallback cannot replace the user's
+ * real saved entry (see {@link isRunningOnFallbackLayout}).
  *
- * @param defaultLayout Layout to fall back to when even the legacy path has nothing
+ * @param defaultLayout Layout to fall back to when the legacy path has nothing
  */
 async function getPersistedLayout(defaultLayout: LayoutInfo): Promise<LayoutInfo> {
   let response: WindowLayoutGetResponse | undefined;
-  try {
-    response = await sendNetworkRequest<[number], WindowLayoutGetResponse>(
-      GET_WINDOW_LAYOUT_REQUEST_TYPE,
-      getWindowIdOrThrow(),
-    );
-  } catch (e) {
-    logger.warn(
-      `Could not get this window's saved layout from main; falling back to the legacy saved layout: ${getErrorMessage(e)}`,
-    );
+  for (let attempt = 1; attempt <= GET_PERSISTED_LAYOUT_ATTEMPTS; attempt += 1) {
+    try {
+      // Sequential retries: each attempt must settle before the next may start
+      // eslint-disable-next-line no-await-in-loop
+      response = await sendNetworkRequest<[number], WindowLayoutGetResponse>(
+        GET_WINDOW_LAYOUT_REQUEST_TYPE,
+        getWindowIdOrThrow(),
+      );
+      break;
+    } catch (e) {
+      logger.warn(
+        `Could not get this window's saved layout from main (attempt ${attempt} of ${GET_PERSISTED_LAYOUT_ATTEMPTS}): ${getErrorMessage(e)}`,
+      );
+      if (attempt < GET_PERSISTED_LAYOUT_ATTEMPTS)
+        // Sequential retries (see above)
+        // eslint-disable-next-line no-await-in-loop
+        await wait(GET_PERSISTED_LAYOUT_RETRY_DELAY_MS);
+    }
   }
-  if (response?.kind === 'entry') return response.layout;
-  if (response?.kind === 'empty') return EMPTY_DOCK_LAYOUT;
+  if (!response) {
+    isRunningOnFallbackLayout = true;
+    logger.warn(
+      `Could not get this window's saved layout after ${GET_PERSISTED_LAYOUT_ATTEMPTS} attempts; starting empty and holding layout pushes until a load succeeds`,
+    );
+    return EMPTY_DOCK_LAYOUT;
+  }
+  isRunningOnFallbackLayout = false;
+  if (response.kind === 'entry') return response.layout;
+  if (response.kind === 'empty') return EMPTY_DOCK_LAYOUT;
   return getLegacySavedLayout(defaultLayout);
 }
 
@@ -966,6 +1032,17 @@ async function saveLayout(layout: LayoutInfo): Promise<void> {
   const interfaceMode =
     currentInterfaceMode ?? (await settingsService.get('platform.interfaceMode'));
   if (interfaceMode === 'simple') return;
+  if (isRunningOnFallbackLayout) {
+    // The dock holds a fallback, not the user's saved layout (see getPersistedLayout); pushing it
+    // would replace the real saved entry in the main process's structure
+    if (!hasLoggedHeldLayoutPushes) {
+      hasLoggedHeldLayoutPushes = true;
+      logger.warn(
+        'Not pushing dock layout changes: this window is running on a fallback layout because its saved layout could not be loaded',
+      );
+    }
+    return;
+  }
   try {
     // Reconcile before pushing so phantom content (duplicate or orphaned tabs, empty panels) never
     // enters the persisted structure

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -52,6 +52,7 @@ import { networkObjectService } from '@shared/services/network-object.service';
 import {
   createBufferedNetworkEventEmitter,
   getNetworkEvent,
+  request as sendNetworkRequest,
 } from '@shared/services/network.service';
 import { settingsService } from '@shared/services/settings.service';
 import { webViewProviderService } from '@shared/services/web-view-provider.service';
@@ -81,7 +82,6 @@ import {
   isSerializable,
   isString,
   newGuid,
-  serialize,
   split,
   startsWith,
   substring,
@@ -97,6 +97,12 @@ import {
   RendererHostedCommandHandlers,
 } from '@renderer/services/renderer-hosted-command-registry';
 import {
+  GET_WINDOW_LAYOUT_REQUEST_TYPE,
+  SAVE_WINDOW_LAYOUT_REQUEST_TYPE,
+  WindowLayoutGetResponse,
+} from '@shared/data/window-layout-persistence.model';
+import { reconcileSavedLayout } from '@shared/utils/saved-layout-reconciliation.util';
+import {
   closeOpenUsersnapForm,
   isUsersnapFormCurrentlyOpen,
   openUsersnapForm,
@@ -107,7 +113,6 @@ import {
   buildLegacyColorVarsLogMessage,
   transformLegacyColorVars,
 } from './web-views/web-view-legacy-color-vars.util';
-import localWindowStorage from './local-storage.service';
 
 // These web view lifecycle emitters are created at module load as buffered emitters so they're
 // usable immediately. Sync paths like `onLayoutChange` and `updateWebViewDefinitionSync` can run
@@ -578,8 +583,30 @@ function removeForbiddenElements(mutationList: MutationRecord[]) {
 
 // #region Dock layouts
 
-/** `localstorage` key for saving and loading the dock layout */
+/**
+ * Legacy `localStorage` key the dock layout was saved under before per-window persistence moved
+ * layouts into the main process's window-layouts structure. Only read (never written) anymore, and
+ * only when the main process says this window should fall back to it — see `getLegacySavedLayout`.
+ */
 const DOCK_LAYOUT_KEY = 'dock-saved-layout';
+
+/**
+ * Layout a window with no saved entry starts from: nothing docked. Deliberately neither the dev
+ * `testLayout` nor `simpleLayout` — a window opened mid-session starts empty.
+ */
+const EMPTY_DOCK_LAYOUT: LayoutInfo = { dockbox: { mode: 'horizontal', children: [] } };
+
+/**
+ * This window's id as a number, for addressing the main process's window layout persistence
+ *
+ * @throws If the window id is not set
+ */
+function getWindowIdOrThrow(): number {
+  const windowId = Number.parseInt(globalThis.windowId ?? '', 10);
+  if (Number.isNaN(windowId))
+    throw new Error('windowId is not set. Check that the URL includes the windowId parameter.');
+  return windowId;
+}
 
 /**
  * Cached value of the `platform.interfaceMode` setting.
@@ -832,22 +859,22 @@ async function loadLayout(layout?: LayoutInfo): Promise<void> {
 
   // Pick the layout by interface mode (runs at startup and on every `platform.interfaceMode` change;
   // see the subscription in `registerDockLayout`):
-  // - Power mode: the user's saved layout from `DOCK_LAYOUT_KEY`, or `testLayout` if none.
+  // - Power mode: this window's saved layout from the main process's window-layouts structure (see
+  //   `getPersistedLayout` for the legacy and empty fallbacks).
   // - Simple mode: always the static `simpleLayout`. `saveLayout` no-ops in simple mode, so changes
   //   there are ephemeral and never clobber the saved power layout.
   const interfaceMode = await settingsService.get('platform.interfaceMode');
   // Seed/refresh the cache before loading so any `onLayoutChange` that the load triggers (and every
   // subsequent `saveLayout`) sees the current mode without another settings round-trip.
   currentInterfaceMode = interfaceMode;
-  // Every layout gets its web view ids scoped to this window, including one restored from storage:
-  // `localWindowStorage` migrates a pre-multi-window layout from its unprefixed key WITHOUT
-  // deleting it, so two windows can each migrate the same legacy blob and end up holding the same
-  // unscoped ids. Re-scoping replaces the suffix rather than stacking another one, so this is safe
-  // to run on a layout this window already scoped and saved.
+  // Every layout gets its web view ids scoped to this window, including one restored from
+  // persistence: a saved entry's ids carry the window id of the session that saved them (window
+  // ids are not stable across restarts), and the legacy pre-multi-window layout carries unscoped
+  // ids. Re-scoping replaces the suffix rather than stacking another one, so it is safe on both.
   const layoutToLoad = withWindowScopedWebViewIds(
     interfaceMode === 'simple'
       ? dockLayoutVar.simpleLayout
-      : getStorageValue(DOCK_LAYOUT_KEY, dockLayoutVar.testLayout),
+      : await getPersistedLayout(dockLayoutVar.testLayout),
   );
   // Supplement tabs join the layout below, after the scoping pass above has already run over it, so
   // scope each supplement tab itself — its id comes from a build-baked file and would otherwise be
@@ -883,22 +910,50 @@ async function loadLayout(layout?: LayoutInfo): Promise<void> {
 }
 
 /**
- * Safely load a value from local storage.
+ * The pre-multi-window saved layout, read from the UNPREFIXED `localStorage` key — the raw
+ * `localStorage`, not `localWindowStorage`, whose per-window prefixed copies of this key are dead:
+ * the main process's window-layouts structure replaced them, and reading through that migration
+ * path would clone the legacy layout into every window. Falls back to `defaultLayout` when there is
+ * no legacy layout either (a fresh profile).
  *
- * @param key Of the value.
- * @param defaultValue To return if the key is not found.
- * @returns The value of the key fetched from local storage, or the default value if not found.
+ * @param defaultLayout Layout to fall back to when no legacy layout is stored
  */
-function getStorageValue<T>(key: string, defaultValue: T): T {
-  const saved = localWindowStorage.getItem(key);
-  const initial = saved ? deserialize(saved) : undefined;
-  return initial || defaultValue;
+function getLegacySavedLayout(defaultLayout: LayoutInfo): LayoutInfo {
+  const saved = localStorage.getItem(DOCK_LAYOUT_KEY);
+  const savedLayout: LayoutInfo | undefined = saved ? deserialize(saved) : undefined;
+  return savedLayout || defaultLayout;
 }
 
 /**
- * Persists the current dock layout information to `DOCK_LAYOUT_KEY` — but only when the user is in
- * power mode. Simple mode always reloads the static `simpleLayout` (see `loadLayout`), so we
- * deliberately skip writing in simple mode to avoid clobbering the user's saved power-mode layout.
+ * The layout this window should restore, per the main process's window-layouts structure: this
+ * window's saved entry, an empty layout for a window with no entry, or — for the one window a
+ * legacy startup restores — the pre-multi-window layout from `localStorage`. Falls back to the
+ * legacy path when the request itself fails, which is also what a fresh profile needs.
+ *
+ * @param defaultLayout Layout to fall back to when even the legacy path has nothing
+ */
+async function getPersistedLayout(defaultLayout: LayoutInfo): Promise<LayoutInfo> {
+  let response: WindowLayoutGetResponse | undefined;
+  try {
+    response = await sendNetworkRequest<[number], WindowLayoutGetResponse>(
+      GET_WINDOW_LAYOUT_REQUEST_TYPE,
+      getWindowIdOrThrow(),
+    );
+  } catch (e) {
+    logger.warn(
+      `Could not get this window's saved layout from main; falling back to the legacy saved layout: ${getErrorMessage(e)}`,
+    );
+  }
+  if (response?.kind === 'entry') return response.layout;
+  if (response?.kind === 'empty') return EMPTY_DOCK_LAYOUT;
+  return getLegacySavedLayout(defaultLayout);
+}
+
+/**
+ * Pushes the current dock layout to the main process, which persists it in this window's entry of
+ * the window-layouts structure — but only when the user is in power mode. Simple mode always
+ * reloads the static `simpleLayout` (see `loadLayout`), so we deliberately skip pushing in simple
+ * mode to avoid clobbering the user's saved power-mode layout.
  *
  * Reads the mode from the `currentInterfaceMode` cache (kept current by `loadLayout` and the
  * `platform.interfaceMode` subscription) so this stays synchronous on the hot path and avoids the
@@ -911,7 +966,17 @@ async function saveLayout(layout: LayoutInfo): Promise<void> {
   const interfaceMode =
     currentInterfaceMode ?? (await settingsService.get('platform.interfaceMode'));
   if (interfaceMode === 'simple') return;
-  localWindowStorage.setItem(DOCK_LAYOUT_KEY, serialize(layout));
+  try {
+    // Reconcile before pushing so phantom content (duplicate or orphaned tabs, empty panels) never
+    // enters the persisted structure
+    await sendNetworkRequest(
+      SAVE_WINDOW_LAYOUT_REQUEST_TYPE,
+      getWindowIdOrThrow(),
+      reconcileSavedLayout(layout),
+    );
+  } catch (e) {
+    logger.warn(`Could not push the dock layout to main for persistence: ${getErrorMessage(e)}`);
+  }
 }
 
 /**

--- a/src/shared/data/window-layout-persistence.model.ts
+++ b/src/shared/data/window-layout-persistence.model.ts
@@ -1,0 +1,68 @@
+/**
+ * Request types and data shapes for persisting window layouts and bounds.
+ *
+ * INTERNAL PLUMBING between the main process (which owns the persisted structure on disk) and the
+ * renderer's web view service host (which loads and pushes this window's dock layout). This module
+ * must only be imported by those two places — nothing here is part of the public `@papi/*` surface,
+ * and importing it from anything that feeds `papi.d.ts` would leak it there.
+ */
+
+import type { LayoutInfo } from '@shared/models/docking-framework.model';
+import { serializeRequestType } from '@shared/utils/util';
+
+/** Prefix on requests related to window layout persistence */
+const CATEGORY_WINDOW_LAYOUT = 'windowLayout';
+
+/**
+ * Request a window's saved dock layout from the main process. Takes the requesting window's id;
+ * returns a {@link WindowLayoutGetResponse}.
+ */
+export const GET_WINDOW_LAYOUT_REQUEST_TYPE = serializeRequestType(CATEGORY_WINDOW_LAYOUT, 'get');
+
+/**
+ * Push a window's current dock layout to the main process for persistence. Takes the pushing
+ * window's id and its serialized layout.
+ */
+export const SAVE_WINDOW_LAYOUT_REQUEST_TYPE = serializeRequestType(CATEGORY_WINDOW_LAYOUT, 'save');
+
+/** Position and size of a window or display, in screen coordinates */
+export type WindowRectangle = { x: number; y: number; width: number; height: number };
+
+/**
+ * Sizing and position state persisted for one window. `bounds` is the window's normal (unmaximized)
+ * placement; `displayBounds` records the display those bounds were on, so a restore can tell when
+ * that display is gone.
+ */
+export type WindowBoundsState = {
+  bounds?: WindowRectangle;
+  isMaximized?: boolean;
+  isFullScreen?: boolean;
+  displayBounds?: WindowRectangle;
+};
+
+/**
+ * One window's saved state in the persisted structure. Position in the structure's list is the
+ * window's identity across sessions — window ids stay runtime-only. Exactly one entry carries
+ * `isMain` (the window with the top-level menu and close-quits behavior).
+ */
+export type WindowLayoutEntry = WindowBoundsState & {
+  layout?: LayoutInfo;
+  isMain?: boolean;
+};
+
+/** The whole persisted structure: every window's saved state, in creation order */
+export type WindowLayoutStructure = { windows: WindowLayoutEntry[] };
+
+/**
+ * What a window should restore, per the main process:
+ *
+ * - `entry`: the layout saved for this window.
+ * - `legacy`: no layout has ever been captured for this window's entry — fall back to the
+ *   pre-multi-window layout under the unprefixed localStorage key.
+ * - `empty`: start with an empty dock layout (a window opened mid-session, or one whose saved layout
+ *   is unusable).
+ */
+export type WindowLayoutGetResponse =
+  | { kind: 'entry'; layout: LayoutInfo }
+  | { kind: 'legacy' }
+  | { kind: 'empty' };

--- a/src/shared/utils/saved-layout-reconciliation.util.test.ts
+++ b/src/shared/utils/saved-layout-reconciliation.util.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from 'vitest';
+import type { LayoutInfo } from '@shared/models/docking-framework.model';
+import {
+  reconcileSavedLayout,
+  savedLayoutHasAnyTabs,
+  savedLayoutHasViewableTabs,
+} from '@shared/utils/saved-layout-reconciliation.util';
+
+/** A well-formed saved tab, the way rc-dock serializes one */
+function tab(id: string): Record<string, unknown> {
+  return { id, tabType: 'webView', data: { id, webViewType: 'test.type', state: {} } };
+}
+
+describe('reconcileSavedLayout', () => {
+  test('returns a normal layout unchanged and does not mutate its input', () => {
+    const layout: LayoutInfo = {
+      dockbox: {
+        mode: 'horizontal',
+        children: [
+          { tabs: [tab('alpha'), tab('beta')], activeId: 'alpha', group: 'default' },
+          { mode: 'vertical', children: [{ tabs: [tab('gamma')] }] },
+        ],
+      },
+      floatbox: {
+        mode: 'float',
+        children: [{ tabs: [tab('delta')], x: 10, y: 20, w: 300, h: 200 }],
+      },
+    };
+    const original = JSON.parse(JSON.stringify(layout));
+
+    const reconciled = reconcileSavedLayout(layout);
+
+    expect(reconciled).toEqual(original);
+    expect(layout).toEqual(original);
+  });
+
+  test('drops every occurrence of a duplicated tab id after the first', () => {
+    const layout: LayoutInfo = {
+      dockbox: {
+        mode: 'horizontal',
+        children: [{ tabs: [tab('alpha'), tab('alpha'), tab('beta')] }],
+      },
+    };
+
+    const reconciled = reconcileSavedLayout(layout);
+
+    const { dockbox } = reconciled;
+    expect(dockbox).toEqual({
+      mode: 'horizontal',
+      children: [{ tabs: [tab('alpha'), tab('beta')] }],
+    });
+  });
+
+  test('resolves a duplicate across boxes in favor of the docked copy', () => {
+    const layout: LayoutInfo = {
+      dockbox: { mode: 'horizontal', children: [{ tabs: [tab('alpha')] }] },
+      floatbox: { mode: 'float', children: [{ tabs: [tab('alpha'), tab('floaty')] }] },
+    };
+
+    const reconciled = reconcileSavedLayout(layout);
+
+    expect(reconciled.dockbox).toEqual({
+      mode: 'horizontal',
+      children: [{ tabs: [tab('alpha')] }],
+    });
+    expect(reconciled.floatbox).toEqual({ mode: 'float', children: [{ tabs: [tab('floaty')] }] });
+  });
+
+  test('drops tabs with no usable id', () => {
+    const layout: LayoutInfo = {
+      dockbox: {
+        mode: 'horizontal',
+        children: [{ tabs: [{ tabType: 'webView' }, { id: '' }, tab('alpha')] }],
+      },
+    };
+
+    const reconciled = reconcileSavedLayout(layout);
+
+    expect(reconciled.dockbox).toEqual({
+      mode: 'horizontal',
+      children: [{ tabs: [tab('alpha')] }],
+    });
+  });
+
+  test('drops a tab placed directly in a box instead of inside a panel', () => {
+    // A tab is only reachable through a panel's `tabs` array; one that ends up as a direct child of
+    // a box would never render
+    const layout: LayoutInfo = {
+      dockbox: {
+        mode: 'horizontal',
+        children: [tab('stray'), { tabs: [tab('alpha')] }],
+      },
+    };
+
+    const reconciled = reconcileSavedLayout(layout);
+
+    expect(reconciled.dockbox).toEqual({
+      mode: 'horizontal',
+      children: [{ tabs: [tab('alpha')] }],
+    });
+  });
+
+  test('removes panels and boxes that end up empty', () => {
+    const layout: LayoutInfo = {
+      dockbox: {
+        mode: 'horizontal',
+        children: [
+          { tabs: [] },
+          { mode: 'vertical', children: [{ tabs: [{ tabType: 'webView' }] }] },
+          { tabs: [tab('alpha')] },
+        ],
+      },
+    };
+
+    const reconciled = reconcileSavedLayout(layout);
+
+    expect(reconciled.dockbox).toEqual({
+      mode: 'horizontal',
+      children: [{ tabs: [tab('alpha')] }],
+    });
+  });
+
+  test('removes an emptied floatbox entirely but keeps an emptied dockbox', () => {
+    const layout: LayoutInfo = {
+      dockbox: { mode: 'horizontal', children: [{ tabs: [] }] },
+      floatbox: { mode: 'float', children: [{ tabs: [] }] },
+    };
+
+    const reconciled = reconcileSavedLayout(layout);
+
+    expect(reconciled.dockbox).toEqual({ mode: 'horizontal', children: [] });
+    expect('floatbox' in reconciled).toBe(false);
+  });
+});
+
+describe('savedLayoutHasViewableTabs', () => {
+  test('sees a docked tab', () => {
+    expect(
+      savedLayoutHasViewableTabs({
+        dockbox: { mode: 'horizontal', children: [{ tabs: [tab('alpha')] }] },
+      }),
+    ).toBe(true);
+  });
+
+  test('sees a tab that only exists floated', () => {
+    expect(
+      savedLayoutHasViewableTabs({
+        dockbox: { mode: 'horizontal', children: [] },
+        floatbox: { mode: 'float', children: [{ tabs: [tab('floaty')] }] },
+      }),
+    ).toBe(true);
+  });
+
+  test('reports an empty layout as having none', () => {
+    expect(savedLayoutHasViewableTabs({ dockbox: { mode: 'horizontal', children: [] } })).toBe(
+      false,
+    );
+  });
+
+  test('does not count tabs that lack ids', () => {
+    expect(
+      savedLayoutHasViewableTabs({
+        dockbox: { mode: 'horizontal', children: [{ tabs: [{ tabType: 'webView' }] }] },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('savedLayoutHasAnyTabs', () => {
+  test('reports a layout saved with no tabs anywhere as tab-less', () => {
+    expect(savedLayoutHasAnyTabs({ dockbox: { mode: 'horizontal', children: [] } })).toBe(false);
+    expect(
+      savedLayoutHasAnyTabs({ dockbox: { mode: 'horizontal', children: [{ tabs: [] }] } }),
+    ).toBe(false);
+  });
+
+  test('counts a phantom tab (no usable id) as structurally present', () => {
+    // This is the discriminator against savedLayoutHasViewableTabs: tabs present but none
+    // viewable means junk, whereas no tabs at all means a legitimately empty window
+    expect(
+      savedLayoutHasAnyTabs({
+        dockbox: { mode: 'horizontal', children: [{ tabs: [{ tabType: 'webView' }] }] },
+      }),
+    ).toBe(true);
+  });
+
+  test('sees a real tab wherever it lives', () => {
+    expect(
+      savedLayoutHasAnyTabs({
+        dockbox: { mode: 'horizontal', children: [] },
+        floatbox: { mode: 'float', children: [{ tabs: [tab('floaty')] }] },
+      }),
+    ).toBe(true);
+  });
+});

--- a/src/shared/utils/saved-layout-reconciliation.util.ts
+++ b/src/shared/utils/saved-layout-reconciliation.util.ts
@@ -95,20 +95,28 @@ export function reconcileSavedLayout(layout: LayoutInfo): LayoutInfo {
 }
 
 /**
+ * Whether a saved layout holds, anywhere in its root boxes, at least one tab that `isCountedTab`
+ * accepts. The one walker behind both exported has-tabs checks, which differ only in which tabs
+ * count.
+ */
+function layoutHasTabs(layout: LayoutInfo, isCountedTab: (tab: unknown) => boolean): boolean {
+  const nodeHasTabs = (value: unknown): boolean => {
+    const node = asLayoutNode(value);
+    if (!node) return false;
+    if (Array.isArray(node.tabs) && node.tabs.some(isCountedTab)) return true;
+    if (Array.isArray(node.children)) return node.children.some(nodeHasTabs);
+    return false;
+  };
+  return ROOT_BOX_KEYS.some((key) => nodeHasTabs(layout[key]));
+}
+
+/**
  * Whether a saved layout holds at least one tab that could actually render — one with a usable id,
  * reachable through a panel in one of the root boxes. A layout without any is not worth restoring a
  * window for.
  */
 export function savedLayoutHasViewableTabs(layout: LayoutInfo): boolean {
-  const nodeHasViewableTabs = (value: unknown): boolean => {
-    const node = asLayoutNode(value);
-    if (!node) return false;
-    if (Array.isArray(node.tabs) && node.tabs.some((tab) => getTabId(tab) !== undefined))
-      return true;
-    if (Array.isArray(node.children)) return node.children.some(nodeHasViewableTabs);
-    return false;
-  };
-  return ROOT_BOX_KEYS.some((key) => nodeHasViewableTabs(layout[key]));
+  return layoutHasTabs(layout, (tab) => getTabId(tab) !== undefined);
 }
 
 /**
@@ -120,12 +128,5 @@ export function savedLayoutHasViewableTabs(layout: LayoutInfo): boolean {
  * that must not resurrect a window).
  */
 export function savedLayoutHasAnyTabs(layout: LayoutInfo): boolean {
-  const nodeHasAnyTabs = (value: unknown): boolean => {
-    const node = asLayoutNode(value);
-    if (!node) return false;
-    if (Array.isArray(node.tabs) && node.tabs.length > 0) return true;
-    if (Array.isArray(node.children)) return node.children.some(nodeHasAnyTabs);
-    return false;
-  };
-  return ROOT_BOX_KEYS.some((key) => nodeHasAnyTabs(layout[key]));
+  return layoutHasTabs(layout, () => true);
 }

--- a/src/shared/utils/saved-layout-reconciliation.util.ts
+++ b/src/shared/utils/saved-layout-reconciliation.util.ts
@@ -1,0 +1,131 @@
+/**
+ * Cleans phantom content out of saved dock layouts before they are persisted or restored.
+ *
+ * Implemented as a structural walk over the plain saved-layout data (`dockbox` / `floatbox` /
+ * `maxbox` / `windowbox`, each holding `children` boxes and `tabs` panels) rather than through
+ * rc-dock's types, so the main process can use it on persisted layouts without importing rc-dock.
+ */
+
+import type { LayoutInfo } from '@shared/models/docking-framework.model';
+
+/** The rc-dock root boxes a saved layout may carry; only content inside these can ever render */
+const ROOT_BOX_KEYS = ['dockbox', 'floatbox', 'maxbox', 'windowbox'] as const;
+
+/** Loose shape of one saved-layout node: a panel (`tabs`), a box (`children`), or both */
+type LayoutNode = { tabs?: unknown[]; children?: unknown[] } & Record<string, unknown>;
+
+/** View a value as a {@link LayoutNode} if it is object-shaped at all */
+function asLayoutNode(value: unknown): LayoutNode | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  // Saved layouts are plain JSON data; crossing from `object` to the indexable node shape only
+  // adds optional property reads that are re-checked below (`Array.isArray`)
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  return value as LayoutNode;
+}
+
+/** A tab's id when the tab could actually render (an object carrying a non-empty string id) */
+function getTabId(value: unknown): string | undefined {
+  const node = asLayoutNode(value);
+  if (!node || typeof node.id !== 'string' || node.id.length === 0) return undefined;
+  return node.id;
+}
+
+/**
+ * Reconcile one node of a saved layout: keep only tabs with usable, not-yet-seen ids, recurse into
+ * child boxes, and report an emptied (or never-valid) node as `undefined` so the parent drops it.
+ */
+function reconcileNode(value: unknown, seenTabIds: Set<string>): LayoutNode | undefined {
+  const node = asLayoutNode(value);
+  if (!node) return undefined;
+  const tabs = Array.isArray(node.tabs) ? node.tabs : undefined;
+  const children = Array.isArray(node.children) ? node.children : undefined;
+  // Neither a panel nor a box — e.g. a tab that ended up directly in a box's children
+  if (!tabs && !children) return undefined;
+
+  const result: LayoutNode = { ...node };
+  let keptCount = 0;
+  if (tabs) {
+    const keptTabs = tabs.filter((tab) => {
+      const tabId = getTabId(tab);
+      if (!tabId || seenTabIds.has(tabId)) return false;
+      seenTabIds.add(tabId);
+      return true;
+    });
+    keptCount += keptTabs.length;
+    result.tabs = keptTabs;
+  }
+  if (children) {
+    const keptChildren = children
+      .map((child) => reconcileNode(child, seenTabIds))
+      .filter((child): child is LayoutNode => child !== undefined);
+    keptCount += keptChildren.length;
+    result.children = keptChildren;
+  }
+  return keptCount > 0 ? result : undefined;
+}
+
+/** Rebuild a root box that lost all content, preserving its own properties (e.g. `mode`) */
+function emptiedBox(value: unknown): LayoutNode {
+  const result: LayoutNode = { ...(asLayoutNode(value) ?? {}) };
+  delete result.tabs;
+  result.children = [];
+  return result;
+}
+
+/**
+ * Returns a copy of a saved layout with phantom content removed: duplicate tab ids (the first
+ * occurrence wins, walking `dockbox` before the floating/maximized/windowed boxes so a duplicate
+ * resolves in favor of the docked copy), tabs with no usable id, tabs not reachable through a
+ * panel, and panels or boxes left empty by those removals. An emptied `dockbox` is kept (a layout
+ * must have one); the other root boxes are removed entirely when emptied.
+ *
+ * A layout with none of those problems round-trips unchanged. The input is never mutated.
+ */
+export function reconcileSavedLayout(layout: LayoutInfo): LayoutInfo {
+  const result: LayoutInfo = { ...layout };
+  const seenTabIds = new Set<string>();
+  ROOT_BOX_KEYS.forEach((key) => {
+    if (!(key in result)) return;
+    const reconciled = reconcileNode(result[key], seenTabIds);
+    if (reconciled) result[key] = reconciled;
+    else if (key === 'dockbox') result[key] = emptiedBox(result[key]);
+    else delete result[key];
+  });
+  return result;
+}
+
+/**
+ * Whether a saved layout holds at least one tab that could actually render — one with a usable id,
+ * reachable through a panel in one of the root boxes. A layout without any is not worth restoring a
+ * window for.
+ */
+export function savedLayoutHasViewableTabs(layout: LayoutInfo): boolean {
+  const nodeHasViewableTabs = (value: unknown): boolean => {
+    const node = asLayoutNode(value);
+    if (!node) return false;
+    if (Array.isArray(node.tabs) && node.tabs.some((tab) => getTabId(tab) !== undefined))
+      return true;
+    if (Array.isArray(node.children)) return node.children.some(nodeHasViewableTabs);
+    return false;
+  };
+  return ROOT_BOX_KEYS.some((key) => nodeHasViewableTabs(layout[key]));
+}
+
+/**
+ * Whether a saved layout structurally holds any tab at all — viewable or not — in its root boxes.
+ *
+ * Together with {@link savedLayoutHasViewableTabs} this distinguishes a layout that was saved
+ * legitimately empty (no tabs anywhere: a live window that simply had nothing open, and should be
+ * restored) from one whose tabs all turn out to be phantoms (tabs present but none viewable: junk
+ * that must not resurrect a window).
+ */
+export function savedLayoutHasAnyTabs(layout: LayoutInfo): boolean {
+  const nodeHasAnyTabs = (value: unknown): boolean => {
+    const node = asLayoutNode(value);
+    if (!node) return false;
+    if (Array.isArray(node.tabs) && node.tabs.length > 0) return true;
+    if (Array.isArray(node.children)) return node.children.some(nodeHasAnyTabs);
+    return false;
+  };
+  return ROOT_BOX_KEYS.some((key) => nodeHasAnyTabs(layout[key]));
+}


### PR DESCRIPTION
> **Consolidated 2026-08-07:** this PR's commits now ride #2639 (see its body for the combined record). Closed unmerged; branch retained so per-step diffs stay linkable.

---

Implements PT-4285: every window's dock layout, bounds, and display persist across restarts, using the storage design decided on the ticket — **one structure holding all window layouts in order** (`window-layouts.json` in `userData`), owned and written only by the main process. Position in the list is the identity; window ids stay runtime-only.

### How it works

- At startup, main reads the structure and creates one window per entry in order, handing each window its entry. In **Simple mode only the main window is restored** (Simple is single-window per the epic's mode-switching spec); unrestored entries are preserved in the structure untouched, so a Simple session can never destroy a Power user's secondary windows.
- Renderers load their layout from their window's entry and **push** reconciled layout changes to main over internal (non-public) request handlers; main aggregates and debounces disk writes (temp-file + rename). At quit, each window's close handler flushes the full structure before shutdown tasks run; a **deliberate** window close instead rewrites the structure without that window, so it does not come back.
- Bounds are captured per window keeper-style (normal-state only, debounced) and restored through a visibility check against the currently connected displays — a window whose monitor went away comes back somewhere visible. **`electron-window-state` is removed**; the old `window-state.json` is still read once so an upgrade keeps the user's window placement.
- Legacy rule: with no structure file, exactly one window is restored from the pre-multi-window `localStorage` layout. This replaces the per-window prefixed-key persistence this branch previously carried (which cloned window 1's layout into every new window via its legacy-migration fallback) — per the ticket's "Note for PR #2621", the keyed model is now fully superseded.
- A window created mid-session starts **empty** (decided on the ticket); a deliberately-empty window open at quit is restored (empty). Phantom protection: layouts are reconciled on push (duplicate/orphaned tabs, empty panels stripped), and at load an entry whose tabs were *all* phantoms is dropped — it cannot resurrect a window — while an entry saved tab-less legitimately restores one.

### Verification

- **52 new unit tests** (persistence service 19, renderer host 12, bounds util 7, layout reconciliation 14), all behaviour-level; full suite green; typecheck green; `npm run build:types` produces an **empty `papi.d.ts` diff** — nothing new reaches the public API.
- **Live e2e**: new `window-layout-persistence.spec.ts` runs three sequential launches into one preserved profile — quit with two windows → both restored (main with its layout, secondary empty) at saved sizes with the persisted file holding exact pre-quit placements → deliberately close the secondary → relaunch restores exactly one. The existing multi-window spec was adapted to lock the empty-start behaviour explicitly. Both specs green in two consecutive full runs each, no retries.
- Also fixed en route: the e2e global setup only built the dev main-process bundle when missing, so e2e runs could silently test a **stale main process** against a fresh renderer; it now rebuilds on staleness (own commit).

### Notes for reviewers

- Consciously started despite the ticket's declared PT-4278/PT-4281 dependencies (rationale on the ticket): PT-4278 only moves *where* the orchestration lives later; PT-4281 is when secondary windows gain content to round-trip. Until then secondary windows persist existence/bounds/display.
- Not covered live, with reasons in the spec header: legacy single-window upgrade (unit-covered), monitor-gone re-placement (pure function, unit-covered), window *position* restore (WSLg assigns positions itself; position is asserted exactly on the save side, size on the restore side per the app's own on/off-display rule), tab-bearing secondary windows (needs PT-4281).
- The `activate` (macOS) path re-runs the full restore; not verifiable on this machine.

**Stacked on #2637** (`pt-4287-multi-window-e2e-fixtures`) → #2621 (`pt-1891-multi-window`). Do not merge before them; rebases onto main as the stack merges.

AI-assisted — [session](https://claude.ai/code/session_01Lf3XmoA9StqLNDiMBqZVTy)

### Windows-native verification (2026-08-04)

The branch was additionally verified on native Windows (fresh clone in a Windows-side folder, win32 Node, real windowing): full unit suite and typecheck green, and the persistence e2e passed twice — with **exact position restore** (settled placement == requested; the persisted file held both windows' exact pre-quit bounds, position included) and both windows exercising the **on-display exact-saved-size restore branch** that WSLg cannot reach. The upgrade test honored the legacy keeper-file size. Two Windows-only defects surfaced and are fixed on this branch: POSIX separators hardcoded in a unit-test expectation, and e2e teardown crashing on a disposed `ElectronApplication` after a graceful quit. Run at 100% DPI only; >100% scaling remains for the epic's manual mixed-DPI matrix (PT-4287).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2638)
<!-- Reviewable:end -->

---

<!-- deep-review:start -->
## Deep review (2026-08-05)

**What ran:** a 25-agent adversarially-verified `/code-review` at high effort, plus four `/review-paratext` analyzers (api, style, compliance, ux) — over the full #2637→#2638→#2639 stack range.

**Analyzer verdicts:** zero critical/important issues across all four analyzers; minors only, all addressed or consciously acknowledged (see below).

**Workflow findings relevant to this PR:**

- CONFIRMED data-loss: a debounced write scheduled after the quit flush survived window removal and could rewrite `window-layouts.json` with closed windows trimmed.
- CONFIRMED data-loss: any failed `windowLayout:get` fell back to the shared legacy `localStorage` layout, cloning it into secondary/mid-session windows.
- CONFIRMED durability regression: the written structure was snapshotted at enqueue time, dropping a layout pushed while the quit flush waited behind an in-flight write.
- PLAUSIBLE race: rapid macOS dock re-activations could run `restoreWindows` concurrently and duplicate the restored window set.
- PLAUSIBLE stale read: `loadWindowLayouts` read the file without draining the in-flight write chain.
- CONFIRMED upgrade gap: layouts saved under the base branch's per-window prefixed `localStorage` keys were ignored.
- CONFIRMED e2e-infra defect: the stale-bundle check in `global-setup.ts` missed bundle inputs (`lib/platform-bible-utils/src`, `.erb/configs`).
- PLAUSIBLE e2e-infra defect: the teardown catch in `helpers.ts` treated any `process()` throw as "already exited", skipping the kill escalation.
- Cleanup: two copy-pasted saved-layout tab walkers consolidated into one.
- Minor (analyzer): pushed layouts were stored verbatim, relying on renderer-side reconciliation — now reconciled server-side too.
- Minor (analyzer): defensive branches (`assignEntryToWindow` guards; save-request invalid args) were untested — four new tests pin them.
- Minor (analyzer): duplicated 4-line bounds-capture cancel blocks — consolidated into one closure.

**Fixing commit:** 840c086e560021b8ba371e79666b5b8c4fd9621c — "fix: close quit-time persistence races found in deep review" (PT-4285).

**Verification:** 14 new unit tests (6 written red-first), full suite + typecheck + lint green, 6/6 multi-window e2e tests green in one run with zero retries, and an empty `papi.d.ts` diff.

**Author interview:** Interview self-answered from session context by the AI assistant under the author's instruction; no questions required escalation. Deliberate decisions on record: empty-start windows, Simple-mode single-window restore, log-marker shutdown assertions, storage design per the ticket.
<!-- deep-review:end -->
