### PR TITLE
Scope Simple-mode sync to the project the picker actually opens

### DIFF
--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -1026,6 +1026,41 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     expect(mockWarn).not.toHaveBeenCalled();
   });
 
+  it('fires a scoped sync for the S/R-fallback project it opens', async () => {
+    // Same rationale as the recents-path case: the picker knows exactly which project it just
+    // opened, so it (not some upstream guesser) is the right place to trigger a scoped sync.
+    const { papi, mockGetSetting, mockGetAllOpenWebViewDefinitions, mockSendCommand } =
+      createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'paratextBibleSendReceive.getSharedProjects') {
+        return {
+          proj1: {
+            id: 'proj1',
+            name: 'P1',
+            fullName: 'Project 1',
+            language: 'en',
+            editedStatus: 'edited',
+            lastSendReceiveDate: '2025-06-01T00:00:00Z',
+          },
+        };
+      }
+      if (commandName === 'platformScriptureEditor.openScriptureEditor') return 'opened-webview-id';
+      if (commandName === 'paratextBibleSendReceive.syncProjects') return undefined;
+      return undefined;
+    });
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('filled');
+    expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.syncProjects', [
+      'proj1',
+    ]);
+  });
+
   it('picks the editable project even when an Observer-only project has a newer lastSendReceiveDate', async () => {
     const {
       papi,
@@ -1717,6 +1752,7 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     setRecentProjects(['proj-recent']);
     mockSendCommand.mockImplementation(async (commandName: string) => {
       if (commandName === 'platformScriptureEditor.openScriptureEditor') return undefined;
+      if (commandName === 'paratextBibleSendReceive.syncProjects') return undefined;
       throw new Error(`Unexpected command in test: ${commandName}`);
     });
 
@@ -1729,6 +1765,36 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     );
     expect(mockSendCommand).not.toHaveBeenCalledWith('paratextBibleSendReceive.getSharedProjects');
     expect(mockRecordProjectOpened).toHaveBeenCalledWith('proj-recent');
+  });
+
+  it('fires a scoped sync for the project opened from recents', async () => {
+    // The picker knows, with certainty, exactly which project just became Simple mode's active
+    // project — so it should sync exactly that one, the same way syncOnProjectSwitch does for an
+    // interactive project switch, rather than a caller upstream guessing from a candidate list.
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      setRecentProjects,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    setRecentProjects(['proj-recent']);
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'platformScriptureEditor.openScriptureEditor') return undefined;
+      if (commandName === 'paratextBibleSendReceive.syncProjects') return undefined;
+      throw new Error(`Unexpected command in test: ${commandName}`);
+    });
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('filled');
+    expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.syncProjects', [
+      'proj-recent',
+    ]);
   });
 
   it('tries each recent project in order and opens the first one that succeeds', async () => {
@@ -1750,13 +1816,16 @@ describe('openDefaultActiveProjectIfApplicable', () => {
         if (projectId === 'proj-gone') throw new Error('Project not found');
         return undefined;
       }
+      if (commandName === 'paratextBibleSendReceive.syncProjects') return undefined;
       throw new Error(`Unexpected command in test: ${commandName}`);
     });
 
     const outcome = await openDefaultActiveProjectIfApplicable(papi);
 
     expect(outcome).toBe('filled');
-    expect(mockSendCommand).toHaveBeenCalledTimes(2);
+    // Two openScriptureEditor attempts (proj-gone fails, proj-alive succeeds) plus one scoped sync
+    // for the project that actually opened.
+    expect(mockSendCommand).toHaveBeenCalledTimes(3);
     expect(mockSendCommand).toHaveBeenCalledWith(
       'platformScriptureEditor.openScriptureEditor',
       'proj-gone',
@@ -1862,6 +1931,7 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     setRecentProjects(['proj-recent']);
     mockSendCommand.mockImplementation(async (commandName: string) => {
       if (commandName === 'platformScriptureEditor.openScriptureEditor') return undefined;
+      if (commandName === 'paratextBibleSendReceive.syncProjects') return undefined;
       throw new Error(`Unexpected command in test: ${commandName}`);
     });
     mockRecordProjectOpened.mockRejectedValue(new Error('Storage write failed'));

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -1014,6 +1014,41 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     expect(mockWarn).not.toHaveBeenCalled();
   });
 
+  it('fires a scoped sync for the S/R-fallback project it opens', async () => {
+    // Same rationale as the recents-path case: the picker knows exactly which project it just
+    // opened, so it (not some upstream guesser) is the right place to trigger a scoped sync.
+    const { papi, mockGetSetting, mockGetAllOpenWebViewDefinitions, mockSendCommand } =
+      createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'paratextBibleSendReceive.getSharedProjects') {
+        return {
+          proj1: {
+            id: 'proj1',
+            name: 'P1',
+            fullName: 'Project 1',
+            language: 'en',
+            editedStatus: 'edited',
+            lastSendReceiveDate: '2025-06-01T00:00:00Z',
+          },
+        };
+      }
+      if (commandName === 'platformScriptureEditor.openScriptureEditor') return 'opened-webview-id';
+      if (commandName === 'paratextBibleSendReceive.syncProjects') return undefined;
+      return undefined;
+    });
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('filled');
+    expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.syncProjects', [
+      'proj1',
+    ]);
+  });
+
   it('picks the editable project even when an Observer-only project has a newer lastSendReceiveDate', async () => {
     const {
       papi,
@@ -1705,6 +1740,7 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     setRecentProjects(['proj-recent']);
     mockSendCommand.mockImplementation(async (commandName: string) => {
       if (commandName === 'platformScriptureEditor.openScriptureEditor') return undefined;
+      if (commandName === 'paratextBibleSendReceive.syncProjects') return undefined;
       throw new Error(`Unexpected command in test: ${commandName}`);
     });
 
@@ -1717,6 +1753,36 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     );
     expect(mockSendCommand).not.toHaveBeenCalledWith('paratextBibleSendReceive.getSharedProjects');
     expect(mockRecordProjectOpened).toHaveBeenCalledWith('proj-recent');
+  });
+
+  it('fires a scoped sync for the project opened from recents', async () => {
+    // The picker knows, with certainty, exactly which project just became Simple mode's active
+    // project — so it should sync exactly that one, the same way syncOnProjectSwitch does for an
+    // interactive project switch, rather than a caller upstream guessing from a candidate list.
+    const {
+      papi,
+      mockGetSetting,
+      mockGetAllOpenWebViewDefinitions,
+      mockSendCommand,
+      setRecentProjects,
+    } = createPickerMocks();
+    mockGetSetting.mockResolvedValue('simple');
+    mockGetAllOpenWebViewDefinitions.mockResolvedValue(
+      asWebViews([{ webViewType: SCRIPTURE_EDITOR_WEBVIEW_TYPE, projectId: undefined }]),
+    );
+    setRecentProjects(['proj-recent']);
+    mockSendCommand.mockImplementation(async (commandName: string) => {
+      if (commandName === 'platformScriptureEditor.openScriptureEditor') return undefined;
+      if (commandName === 'paratextBibleSendReceive.syncProjects') return undefined;
+      throw new Error(`Unexpected command in test: ${commandName}`);
+    });
+
+    const outcome = await openDefaultActiveProjectIfApplicable(papi);
+
+    expect(outcome).toBe('filled');
+    expect(mockSendCommand).toHaveBeenCalledWith('paratextBibleSendReceive.syncProjects', [
+      'proj-recent',
+    ]);
   });
 
   it('tries each recent project in order and opens the first one that succeeds', async () => {
@@ -1738,13 +1804,16 @@ describe('openDefaultActiveProjectIfApplicable', () => {
         if (projectId === 'proj-gone') throw new Error('Project not found');
         return undefined;
       }
+      if (commandName === 'paratextBibleSendReceive.syncProjects') return undefined;
       throw new Error(`Unexpected command in test: ${commandName}`);
     });
 
     const outcome = await openDefaultActiveProjectIfApplicable(papi);
 
     expect(outcome).toBe('filled');
-    expect(mockSendCommand).toHaveBeenCalledTimes(2);
+    // Two openScriptureEditor attempts (proj-gone fails, proj-alive succeeds) plus one scoped sync
+    // for the project that actually opened.
+    expect(mockSendCommand).toHaveBeenCalledTimes(3);
     expect(mockSendCommand).toHaveBeenCalledWith(
       'platformScriptureEditor.openScriptureEditor',
       'proj-gone',
@@ -1850,6 +1919,7 @@ describe('openDefaultActiveProjectIfApplicable', () => {
     setRecentProjects(['proj-recent']);
     mockSendCommand.mockImplementation(async (commandName: string) => {
       if (commandName === 'platformScriptureEditor.openScriptureEditor') return undefined;
+      if (commandName === 'paratextBibleSendReceive.syncProjects') return undefined;
       throw new Error(`Unexpected command in test: ${commandName}`);
     });
     mockRecordProjectOpened.mockRejectedValue(new Error('Storage write failed'));

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -677,6 +677,9 @@ async function tryOpenFromRecentlyOpened(
               `Default active project picker: failed to record recently-opened project ${projectId}: ${getErrorMessage(e)}`,
             );
           }
+          // Fire-and-forget, mirroring the project-switch call site in main.ts. No outgoing
+          // project — nothing was previously active in Simple mode this session.
+          syncOnProjectSwitch(papi, projectId, undefined);
           return 'filled' as const;
         } catch (e) {
           papi.logger.debug(
@@ -834,6 +837,9 @@ export async function openDefaultActiveProjectIfApplicable(
         `Default active project picker: failed to record recently-opened project ${top.id}: ${getErrorMessage(e)}`,
       );
     }
+    // Fire-and-forget, mirroring the project-switch call site in main.ts. No outgoing project —
+    // nothing was previously active in Simple mode this session.
+    syncOnProjectSwitch(papi, top.id, undefined);
   }
 
   return hasFailed ? 'failed' : 'filled';

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -716,6 +716,9 @@ async function tryOpenFromRecentlyOpened(
               `Default active project picker: failed to record recently-opened project ${projectId}: ${getErrorMessage(e)}`,
             );
           }
+          // Fire-and-forget, mirroring the project-switch call site in main.ts. No outgoing
+          // project — nothing was previously active in Simple mode this session.
+          syncOnProjectSwitch(papi, projectId, undefined);
           return 'filled' as const;
         } catch (e) {
           papi.logger.debug(
@@ -875,6 +878,9 @@ export async function openDefaultActiveProjectIfApplicable(
         `Default active project picker: failed to record recently-opened project ${top.id}: ${getErrorMessage(e)}`,
       );
     }
+    // Fire-and-forget, mirroring the project-switch call site in main.ts. No outgoing project —
+    // nothing was previously active in Simple mode this session.
+    syncOnProjectSwitch(papi, top.id, undefined);
   }
 
   return hasFailed ? 'failed' : 'filled';

--- a/src/main/startup-tasks.test.ts
+++ b/src/main/startup-tasks.test.ts
@@ -10,6 +10,7 @@ import { settingsService } from '@shared/services/settings.service';
 import * as commandService from '@shared/services/command.service';
 import * as networkService from '@shared/services/network.service';
 import { logger } from '@shared/services/logger.service';
+import { getRecentlyOpenedProjectIds } from '@shared/utils/recently-opened-project.util';
 import { performStartupTasks, STARTUP_SYNC_RETRY_BUDGET_MS } from './startup-tasks';
 
 vi.mock('@shared/services/settings.service', () => ({
@@ -28,11 +29,16 @@ vi.mock('@shared/services/logger.service', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock('@shared/utils/recently-opened-project.util', () => ({
+  getRecentlyOpenedProjectIds: vi.fn(),
+}));
+
 const mockSettingsGet = vi.mocked(settingsService.get);
 const mockSendCommand = vi.mocked(commandService.sendCommand);
 const mockRequestNoRetry = vi.mocked(networkService.requestNoRetry);
 const mockLoggerDebug = vi.mocked(logger.debug);
 const mockLoggerWarn = vi.mocked(logger.warn);
+const mockGetRecentlyOpenedProjectIds = vi.mocked(getRecentlyOpenedProjectIds);
 
 /**
  * Builds a rejection shaped like what `networkService`'s request plumbing actually throws for a
@@ -67,6 +73,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockSendCommand.mockResolvedValue(undefined);
   mockRequestNoRetry.mockResolvedValue(undefined);
+  // Zero-state default (no recently-opened project) so every existing test's "fires the broad
+  // bootstrap sync" expectation stays valid unless a test explicitly overrides this to exercise
+  // the steady-state (picker handles it) path.
+  mockGetRecentlyOpenedProjectIds.mockResolvedValue([]);
 });
 
 describe('performStartupTasks', () => {
@@ -80,13 +90,22 @@ describe('performStartupTasks', () => {
     expect(mockSendCommand).not.toHaveBeenCalled();
   });
 
-  it('fires syncProjects with no project IDs when interface mode is simple', async () => {
+  it('fires the broad bootstrap sync when no project has been opened in simple mode yet (zero-state)', async () => {
     stubSettings({ mode: 'simple', firstRunComplete: true });
+    mockGetRecentlyOpenedProjectIds.mockResolvedValue([]);
     await performStartupTasks();
     expect(mockSendCommand).toHaveBeenCalledWith(
       'paratextBibleSendReceive.syncProjects',
       undefined,
     );
+    expect(mockRequestNoRetry).not.toHaveBeenCalled();
+  });
+
+  it('does NOT fire a startup sync when a recent project exists (the picker syncs it once it opens)', async () => {
+    stubSettings({ mode: 'simple', firstRunComplete: true });
+    mockGetRecentlyOpenedProjectIds.mockResolvedValue(['project-a']);
+    await performStartupTasks();
+    expect(mockSendCommand).not.toHaveBeenCalled();
     expect(mockRequestNoRetry).not.toHaveBeenCalled();
   });
 

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -16,6 +16,7 @@ import {
 import { JSONRPCErrorCode } from 'json-rpc-2.0';
 import type { SettingTypes } from 'papi-shared-types';
 import { getErrorMessage, wait } from 'platform-bible-utils';
+import { getRecentlyOpenedProjectIds } from '@shared/utils/recently-opened-project.util';
 
 /**
  * How long (ms) to keep retrying `runScheduledSessionSync` while it's still unregistered before
@@ -106,10 +107,12 @@ type StartupSyncTriggerOutcome = ScheduledSessionSyncResult | 'skipped-stale' | 
  * Runs initialization tasks (currently: triggering an initial project sync) shortly after the app
  * finishes starting up.
  *
- * In Simple mode: requests a sync of all locally-known shared projects so the user sees the latest
- * content as soon as they open the app. All errors are swallowed — the S/R extension may not be
- * installed (e.g. Platform.Bible), the command may not yet be registered, or the sync may fail.
- * Startup must never be blocked or visibly affected by this.
+ * In Simple mode: only fires a bootstrap sync of every locally-known shared project when no project
+ * has been opened in Simple mode yet (zero-state) — otherwise this is a no-op, because the Default
+ * Active Project Picker syncs exactly the project it resolves and opens once it does. All errors
+ * are swallowed — the S/R extension may not be installed (e.g. Platform.Bible), the command may not
+ * yet be registered, or the sync may fail. Startup must never be blocked or visibly affected by
+ * this.
  *
  * In Power mode: requests a sync of just the projects scheduled "On startup/shutdown" via the S/R
  * extension's `runScheduledSessionSync` command. Same error-swallowing contract as Simple mode — if
@@ -191,12 +194,21 @@ async function performStartupTasksInternal(signals?: StartupTasksSignals): Promi
     return;
   }
 
-  // Simple mode: sync all locally-known shared projects (no project IDs = "sync all" per the
-  // C# `String[]? projectIds` contract). The C# S/R command registers asynchronously during
-  // startup; `sendCommand` will wait (with retry on missing handler) until it's available or
-  // times out. `undefined` as the single arg serializes as `null` in the JSON-RPC params array
-  // — matching the "sync all" sentinel on the C# side.
-  logger.debug('Startup sync starting');
+  // Simple mode: only bootstrap-sync here when no project has been opened yet (zero-state) — the
+  // Default Active Project Picker syncs exactly the project it resolves and opens once it does
+  // (see syncOnProjectSwitch calls in platform-scripture-editor.utils.ts), so guessing a scope
+  // here would either duplicate that sync or sync projects that aren't actually becoming active.
+  const recentProjectIds = await getRecentlyOpenedProjectIds();
+  if (recentProjectIds.length > 0) {
+    logger.debug('Startup sync skipped: a recent project exists; the picker will sync it');
+    return;
+  }
+
+  // Zero-state: no project IDs = "sync all" per the C# `String[]? projectIds` contract, so a
+  // brand-new user can discover a project they already have via Paratext 9. The C# S/R command
+  // registers asynchronously during startup; `sendCommand` will wait (with retry on missing
+  // handler) until it's available or times out.
+  logger.debug('Startup sync starting (zero-state bootstrap)');
   try {
     await commandService.sendCommand('paratextBibleSendReceive.syncProjects', undefined);
     logger.debug('Startup sync complete');

--- a/src/shared/utils/recently-opened-project.util.test.ts
+++ b/src/shared/utils/recently-opened-project.util.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { dataProviderService } from '@shared/services/data-provider.service';
+import { logger } from '@shared/services/logger.service';
+import { getRecentlyOpenedProjectIds } from '@shared/utils/recently-opened-project.util';
+
+vi.mock('@shared/services/data-provider.service', () => ({
+  dataProviderService: { get: vi.fn() },
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const mockGet = vi.mocked(dataProviderService.get);
+const mockLoggerWarn = vi.mocked(logger.warn);
+
+describe('getRecentlyOpenedProjectIds', () => {
+  it('returns the recents list from the data provider, most-recent first', async () => {
+    // The mock returns a minimal stand-in for the full data provider — only the method this
+    // helper calls needs to be present.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    mockGet.mockResolvedValue({
+      getRecentProjects: vi.fn().mockResolvedValue(['project-a', 'project-b']),
+    } as never);
+
+    const result = await getRecentlyOpenedProjectIds();
+
+    expect(result).toEqual(['project-a', 'project-b']);
+  });
+
+  it('returns an empty array when the data provider is unavailable', async () => {
+    mockGet.mockResolvedValue(undefined);
+
+    const result = await getRecentlyOpenedProjectIds();
+
+    expect(result).toEqual([]);
+  });
+
+  it('returns an empty array and logs a warning when the data provider read throws', async () => {
+    // A read failure must be distinguishable in logs from the genuine zero-state (no project ever
+    // opened) — both currently resolve to [], but callers treat that as "no active project yet",
+    // and a silently-swallowed failure would be indistinguishable from a real zero-state.
+    mockGet.mockRejectedValue(new Error('network object not registered'));
+
+    const result = await getRecentlyOpenedProjectIds();
+
+    expect(result).toEqual([]);
+    expect(mockLoggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('network object not registered'),
+    );
+  });
+});

--- a/src/shared/utils/recently-opened-project.util.ts
+++ b/src/shared/utils/recently-opened-project.util.ts
@@ -1,0 +1,28 @@
+import { dataProviderService } from '@shared/services/data-provider.service';
+import { logger } from '@shared/services/logger.service';
+import { getErrorMessage } from 'platform-bible-utils';
+
+/**
+ * Reads the ordered list of project ids the user has most recently opened as their main/active
+ * project in Simple mode (most-recent first; see `platformScripture.recentlyOpenedProjects`).
+ * Process-agnostic — `dataProviderService` resolves the same underlying data provider whether
+ * called from the renderer or the main process.
+ *
+ * @returns The recents list, or an empty array if the data provider is unavailable or the read
+ *   fails for any reason (e.g. not yet registered during cold boot). A read failure is logged
+ *   (unlike an unavailable provider, which is a routine early-startup state) so it stays
+ *   distinguishable from a genuine zero-state in logs.
+ */
+export async function getRecentlyOpenedProjectIds(): Promise<string[]> {
+  try {
+    const recentsProvider = await dataProviderService.get(
+      'platformScripture.recentlyOpenedProjects',
+    );
+    if (!recentsProvider) return [];
+    const recents = await recentsProvider.getRecentProjects(undefined);
+    return Array.isArray(recents) ? recents : [];
+  } catch (e) {
+    logger.warn(`Could not read recentlyOpenedProjects; treating as empty: ${getErrorMessage(e)}`);
+    return [];
+  }
+}


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: scope-sync-to-picker-decision

**Base**: origin/main

**Date**: 2026-08-28

**Review model**: Claude Sonnet 5

**Files changed**: 6

## Overview

This branch scopes the automatic Send/Receive sync that runs when Simple mode starts up so it targets exactly the project that is actually becoming active, instead of syncing every project the user's account has access to. Previously, `src/main/startup-tasks.ts` unconditionally called `syncProjects(undefined)` on every Simple-mode cold start, which (via the companion, already-merged paratext-10-studio PR #171) triggered a server-side "modification status" check across the user's entire account. Now, `startup-tasks.ts` only fires that broad bootstrap sync in the true zero-state case (no project ever opened in Simple mode). Everywhere else, the Default Active Project Picker (`platform-scripture-editor.utils.ts`) fires a precisely-scoped `syncOnProjectSwitch(papi, projectId, undefined)` at the exact moment it resolves and opens a project — whether from the recents list (`tryOpenFromRecentlyOpened`) or the Send/Receive fallback candidate (`openDefaultActiveProjectIfApplicable`). A new shared helper, `getRecentlyOpenedProjectIds()`, gives `startup-tasks.ts` a process-agnostic way to check whether any project has ever been opened, reusing the same underlying data provider the picker already reads.

This PR's scoping only has full effect together with the private paratext-10-studio patch (PR #171, merged) that narrows the C# `GetSharedProjects`/`ResolveSharedProjects` implementation to actually honor a restricted project-id set — without that companion change, each individual sync call would still be expensive even when scoped to one project.

## API Changes

None. No files under `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `papi.d.ts`, or any extension `src/types/*.d.ts` are touched by this diff. All six changed files are internal implementation; `getRecentlyOpenedProjectIds` is not re-exported from any `@papi/` module or public barrel, and the data provider it consumes (`platformScripture.recentlyOpenedProjects`) is pre-existing and unmodified.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [ ] ~~`src/shared/utils/recently-opened-project.util.ts:16-27` / `src/main/startup-tasks.ts:201-205`: The new zero-state gate has no bounded retry for the `platformScripture.recentlyOpenedProjects` data provider becoming available, unlike this same file's own `STARTUP_SYNC_RETRY_BUDGET_MS` mechanism (120s), which exists specifically because live E2E testing (2026-07-16) observed extension-host activation sometimes exceed the shared `networkService.request` retry ceiling (~9-10s, `MAX_REQUEST_ATTEMPTS` × `REQUEST_ATTEMPT_WAIT_TIME_MS`). Verified: `dataProviderService.get` → `networkObjectService.get` → `getRemoteNetworkObjectFunctions` → `networkService.request`, the exact same short-ceiling path. On a slow cold boot where the extension host isn't ready within ~9s, `getRecentlyOpenedProjectIds()` returns `[]` even for a returning user with real history, and the zero-state branch fires the old broad `syncProjects(undefined)`.~~ _(Author's explanation: confirmed as a real race, but not a regression — the fallback is exactly the pre-existing behavior, so the worst case is "PR's optimization doesn't apply this boot," never "broken." Deliberately not extending the `STARTUP_SYNC_RETRY_BUDGET_MS` pattern to this new gate in this PR, to keep the change minimal and reviewable; flagged below as a suggested fast-follow rather than a blocker.)_
- [ ] ~~`src/main/startup-tasks.ts:201-205`: Architectural consequence of the same gate — a returning user with recent-project history no longer has a session-long fallback broad sync if the Default Active Project Picker never manages to open any of them (e.g. every locally-known shared project is still `'new'`/`'unregistered'`, or Send/Receive never activates that session). Previously the unconditional startup sync could resolve exactly this kind of stuck state.~~ _(Author's explanation: known and intentional — this is the same edge case already tracked separately as PT-4307 ("picker finds nothing to load"), deliberately deferred out of this PR's scope during earlier design discussion.)_
- [ ] ~~`src/shared/utils/recently-opened-project.util.ts:16-27`: Duplicates the fetch idiom (`dataProviderService.get('platformScripture.recentlyOpenedProjects')` → `getRecentProjects(undefined)` → array-check → catch-and-log) already present in `getMostRecentUsableProjectId` at `src/renderer/services/web-view.service-shard.ts:1764-1771` (added in already-merged PR #2425).~~ _(Author's explanation: acknowledged minor duplication. Consolidating would mean modifying already-merged PR #2425 code that's outside this PR's stated scope (picker sync scoping); deferred as optional cleanup rather than done as a drive-by refactor here.)_

[Author response: all three Important findings were reviewed and explained by the author (with independent verification of the technical claims in finding 1) rather than fixed in this pass — see explanations above and Suggested Review Focus below.]

### Minor — Consider

None.

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- The gating logic in `startup-tasks.ts` is well-commented and correctly ordered relative to the existing mode/first-run/consent checks.
- `syncOnProjectSwitch` is reused as-is (not modified) at both new call sites in `platform-scripture-editor.utils.ts`, correctly gated behind a successful `openScriptureEditor`/recent-project-open before firing, matching the existing `main.ts` project-switch call site's fire-and-forget, error-isolated contract.
- Test coverage is thorough and directly verifies the new behavior: `startup-tasks.test.ts` covers both the zero-state (fires) and steady-state (skips) branches; `recently-opened-project.util.test.ts` covers the happy path, provider-unavailable, and provider-throws branches; `platform-scripture-editor.utils.test.ts` verifies the scoped `syncProjects` call fires with exactly the opened project ID from both the recents-path and S/R-fallback-path, including an updated call-count assertion with a clear explanatory comment.
- `src/shared/utils/recently-opened-project.util.ts` is named and organized consistently with sibling files in the same directory, and correctly uses `@shared/services/data-provider.service` (the established cross-process pattern) rather than crossing a process boundary improperly.
- No new UI-facing strings, no new components, and no build/config files were touched, so localization, Storybook, and build-config compliance are not applicable.
- No backward-facing dev-history comments (in-PR ticket refs, dated notes) were introduced.
- Prettier and ESLint both pass clean on all six changed/added files.

## Interview Notes

**Stated purpose**: Scope the automatic Simple-mode startup/project-switch Send/Receive sync to the specific project actually being opened, instead of running an account-wide sync — cutting Simple-mode cold-start time.

**Key design decisions**:
- The sync trigger point moves from a single unconditional call in `startup-tasks.ts` to the Default Active Project Picker itself, since the picker is the only place that actually knows, at the moment it opens a project, which single project is becoming active. `startup-tasks.ts` is narrowed to a pure zero-state bootstrap.
- This is deliberately distinct from `finalizeProjectSwitch` (added by already-merged PR #2425), which only fires from a live Power→Simple mode switch (`handleSwitchToSimpleMode` in `web-view.service-shard.ts`) during an already-running session — it never runs during cold boot, so it does not overlap with or obviate the two new picker-triggered `syncOnProjectSwitch` calls added here.
- This branch was rebased (force-pushed) onto latest `main` after PR #2425 merged; the rebase was a clean zero-conflict rebase with no code changes needed, confirming the two pieces of work are complementary rather than overlapping.
- The companion C#-side scoping fix (paratext-10-studio PR #171, merged) is required for this PR's project-id narrowing to actually reduce sync cost — that patch narrows `GetSharedProjects`/`ResolveSharedProjects` in `ParatextProjectSendReceiveService.cs` to honor a restricted project-id set before the expensive per-project modification-status check runs, not just filter results afterward.

**Findings resolution**: all three Important findings were explained rather than fixed in this pass; see the Findings section above. None were flagged as unresolved — the author (with independent code verification for finding 1) provided a specific technical rationale for each.

**Manual verification** (from earlier testing this session, prior to this specific rebase): `PT_STARTUP_MARKS=true` + `npm run startup-waterfall` on a packaged release build, cross-referenced against direct PAPI RPC calls and toast inspection, showed Simple-mode startup time improve from an initial ~55s baseline to under 29s, and confirmed unrelated Paratext-9-only projects no longer appear in the startup toast stream.

## Suggested Review Focus

- [ ] Finding 1 (slow-boot fallback race in `getRecentlyOpenedProjectIds`): agree the fallback-to-broad-sync behavior is acceptable to ship as-is (never worse than pre-PR), or require a bounded-retry fix (mirroring `STARTUP_SYNC_RETRY_BUDGET_MS`) before merge?
- [ ] Finding 2 (lost safety-net sync when the picker can't resolve any recent project): confirm PT-4307 fully covers this scope, or whether a distinct ticket is warranted.
- [ ] Finding 3 (duplicate recents-fetch idiom vs. `getMostRecentUsableProjectId`): optional follow-up consolidation, not blocking.
- [ ] Confirm the two-repo dependency (this PR + paratext-10-studio PR #171) is acceptable — this PR alone changes *which* project(s) get synced, but the per-sync cost reduction depends on the separate, already-merged private patch.
<!-- review-paratext:summary:end -->

---

## Summary

Supersedes #2636 with a better-founded design (see discussion there for why).

- The Default Active Project Picker (`openDefaultActiveProjectIfApplicable` /
  `tryOpenFromRecentlyOpened`) now fires the existing `syncOnProjectSwitch` helper for exactly the
  project it resolves and opens — whether that's the top `recentlyOpenedProjects` entry or the
  Send/Receive-fallback candidate. This reuses the same fire-and-forget sync path already used on
  interactive project switches, so it inherits its existing behavior (and, combined with
  [paratext-10-studio#171](https://github.com/paranext/paratext-10-studio/pull/171)'s C#-side
  `GetSharedProjects` scoping, its speed) for free.
- `src/main/startup-tasks.ts`'s Simple-mode branch is narrowed to only run the broad,
  account-wide bootstrap sync in the genuine zero-state case (no project ever recorded in
  `platformScripture.recentlyOpenedProjects`). Whenever a recent project is already recorded, the
  picker owns firing a correctly-scoped sync once it knows which project it's actually opening —
  no more guessing at up to 5 candidate ids up front.
- Added `src/shared/utils/recently-opened-project.util.ts`, a small process-agnostic helper
  (`dataProviderService.get(...)` works the same from main or renderer) so `startup-tasks.ts`
  doesn't duplicate the recents lookup the picker already does.

## Why this design over #2636

The previous approach had `startup-tasks.ts` pass its own guess at up to 5 recent project ids into
`syncProjects`. That still risked syncing several projects instead of exactly the one about to be
opened, and had no reliable signal in the main process for which project is "the" active one. This
version instead defers to the one place that *does* know: the picker, at the exact moment it
resolves and opens a project.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (core suite)
- [x] `cd extensions && npx vitest run src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts`
- [x] Manual: verified in a Paratext 10 Studio release build that startup no longer syncs
      unrelated Paratext-9-only projects and Simple-mode project switching still syncs correctly.

Follow-on (deliberately out of scope here, tracked separately): if every recorded recent project
turns out missing/inaccessible on disk, the picker currently has nothing to open and no automatic
recovery sync fires. Tracked as a lower-priority follow-up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2640)
<!-- Reviewable:end -->

