### PR TITLE
PT-4301: Convert Internet Settings commands to a data provider

### DIFF
--- a/c-sharp-tests/Users/InternetSettingsLogicTests.cs
+++ b/c-sharp-tests/Users/InternetSettingsLogicTests.cs
@@ -1,0 +1,197 @@
+using Paranext.DataProvider.Users;
+using Paratext.Data;
+
+namespace TestParanextDataProvider.Users;
+
+[TestFixture]
+public class InternetSettingsLogicTests
+{
+    // ----- MaskSecret -----
+
+    [Test]
+    public void MaskSecret_NonEmptyValue_ReturnsPlaceholder()
+    {
+        var result = InternetSettingsLogic.MaskSecret("s3cr3t");
+        Assert.That(result, Is.EqualTo(InternetSettingsLogic.PLACEHOLDER_PASSWORD));
+    }
+
+    [Test]
+    public void MaskSecret_EmptyString_ReturnsNull()
+    {
+        var result = InternetSettingsLogic.MaskSecret("");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void MaskSecret_NullValue_ReturnsNull()
+    {
+        var result = InternetSettingsLogic.MaskSecret(null);
+        Assert.That(result, Is.Null);
+    }
+
+    // ----- EmptyToNull -----
+
+    [Test]
+    public void EmptyToNull_EmptyString_ReturnsNull()
+    {
+        var result = InternetSettingsLogic.EmptyToNull("");
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void EmptyToNull_NonEmptyString_ReturnsSameValue()
+    {
+        var result = InternetSettingsLogic.EmptyToNull("hello");
+        Assert.That(result, Is.EqualTo("hello"));
+    }
+
+    [Test]
+    public void EmptyToNull_NullValue_ReturnsNull()
+    {
+        var result = InternetSettingsLogic.EmptyToNull(null);
+        Assert.That(result, Is.Null);
+    }
+
+    // ----- ResolveSecret -----
+
+    [Test]
+    public void ResolveSecret_PlaceholderSubmitted_ReturnsCurrentValue()
+    {
+        var result = InternetSettingsLogic.ResolveSecret(
+            InternetSettingsLogic.PLACEHOLDER_PASSWORD,
+            "storedSecret"
+        );
+        Assert.That(result, Is.EqualTo("storedSecret"));
+    }
+
+    [Test]
+    public void ResolveSecret_RealValueSubmitted_ReturnsSubmitted()
+    {
+        var result = InternetSettingsLogic.ResolveSecret("newSecret", "storedSecret");
+        Assert.That(result, Is.EqualTo("newSecret"));
+    }
+
+    [Test]
+    public void ResolveSecret_NullSubmitted_ReturnsNull()
+    {
+        var result = InternetSettingsLogic.ResolveSecret(null, "storedSecret");
+        Assert.That(result, Is.Null);
+    }
+
+    // ----- IsSecretChanged -----
+
+    [Test]
+    public void IsSecretChanged_PlaceholderSubmitted_ReturnsFalse()
+    {
+        var result = InternetSettingsLogic.IsSecretChanged(
+            InternetSettingsLogic.PLACEHOLDER_PASSWORD
+        );
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void IsSecretChanged_RealValueSubmitted_ReturnsTrue()
+    {
+        var result = InternetSettingsLogic.IsSecretChanged("actualPassword");
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void IsSecretChanged_NullSubmitted_ReturnsTrue()
+    {
+        var result = InternetSettingsLogic.IsSecretChanged(null);
+        Assert.That(result, Is.True);
+    }
+
+    // ----- ShouldClearProxyHost -----
+
+    [Test]
+    public void ShouldClearProxyHost_ProxyOnly_ReturnsFalse()
+    {
+        var result = InternetSettingsLogic.ShouldClearProxyHost(InternetUse.ProxyOnly);
+        Assert.That(result, Is.False);
+    }
+
+    [Test]
+    public void ShouldClearProxyHost_Enabled_ReturnsTrue()
+    {
+        var result = InternetSettingsLogic.ShouldClearProxyHost(InternetUse.Enabled);
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ShouldClearProxyHost_VpnRequired_ReturnsTrue()
+    {
+        var result = InternetSettingsLogic.ShouldClearProxyHost(InternetUse.VpnRequired);
+        Assert.That(result, Is.True);
+    }
+
+    [Test]
+    public void ShouldClearProxyHost_Disabled_ReturnsTrue()
+    {
+        var result = InternetSettingsLogic.ShouldClearProxyHost(InternetUse.Disabled);
+        Assert.That(result, Is.True);
+    }
+
+    // ----- ReassertedRawStatus -----
+
+    [Test]
+    public void ReassertedRawStatus_DisabledCurrentAndEnabledRequested_ReturnsEnabled()
+    {
+        var result = InternetSettingsLogic.ReassertedRawStatus(
+            InternetUse.Disabled,
+            InternetUse.Enabled
+        );
+        Assert.That(result, Is.EqualTo(InternetUse.Enabled));
+    }
+
+    [Test]
+    public void ReassertedRawStatus_DisabledCurrentAndVpnRequiredRequested_ReturnsVpnRequired()
+    {
+        var result = InternetSettingsLogic.ReassertedRawStatus(
+            InternetUse.Disabled,
+            InternetUse.VpnRequired
+        );
+        Assert.That(result, Is.EqualTo(InternetUse.VpnRequired));
+    }
+
+    [Test]
+    public void ReassertedRawStatus_DisabledCurrentAndDisabledRequested_ReturnsNull()
+    {
+        var result = InternetSettingsLogic.ReassertedRawStatus(
+            InternetUse.Disabled,
+            InternetUse.Disabled
+        );
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ReassertedRawStatus_DisabledCurrentAndProxyOnlyRequested_ReturnsNull()
+    {
+        var result = InternetSettingsLogic.ReassertedRawStatus(
+            InternetUse.Disabled,
+            InternetUse.ProxyOnly
+        );
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ReassertedRawStatus_EnabledCurrentAndEnabledRequested_ReturnsNull()
+    {
+        var result = InternetSettingsLogic.ReassertedRawStatus(
+            InternetUse.Enabled,
+            InternetUse.Enabled
+        );
+        Assert.That(result, Is.Null);
+    }
+
+    [Test]
+    public void ReassertedRawStatus_EnabledCurrentAndDisabledRequested_ReturnsNull()
+    {
+        var result = InternetSettingsLogic.ReassertedRawStatus(
+            InternetUse.Enabled,
+            InternetUse.Disabled
+        );
+        Assert.That(result, Is.Null);
+    }
+}

--- a/c-sharp/Program.cs
+++ b/c-sharp/Program.cs
@@ -97,7 +97,10 @@ public static class Program
             var checkRunner = new CheckRunner(papi, inventoryDataProvider);
             var internetSettingsDataProvider = new InternetSettingsDataProvider(papi);
             var dblResources = new DblResourcesDataProvider(papi, paratextProjects);
-            var paratextRegistrationService = new ParatextRegistrationService(papi);
+            var paratextRegistrationService = new ParatextRegistrationService(
+                papi,
+                internetSettingsDataProvider
+            );
             var checklistNetworkObject = new ChecklistNetworkObject(papi);
             var manageBooksService = new ManageBooksService(
                 papi,

--- a/c-sharp/Program.cs
+++ b/c-sharp/Program.cs
@@ -95,6 +95,7 @@ public static class Program
             );
             var inventoryDataProvider = new InventoryDataProvider(papi, paratextProjects);
             var checkRunner = new CheckRunner(papi, inventoryDataProvider);
+            var internetSettingsDataProvider = new InternetSettingsDataProvider(papi);
             var dblResources = new DblResourcesDataProvider(papi, paratextProjects);
             var paratextRegistrationService = new ParatextRegistrationService(papi);
             var checklistNetworkObject = new ChecklistNetworkObject(papi);
@@ -130,7 +131,8 @@ public static class Program
                     Task.Run(() => checkRunner.RegisterDataProviderAsync()),
                     Task.Run(() => checklistNetworkObject.InitializeAsync()),
                     Task.Run(() => manageBooksService.RegisterNetworkObjectAsync()),
-                    Task.Run(() => enhancedResourceFactory.InitializeAsync())
+                    Task.Run(() => enhancedResourceFactory.InitializeAsync()),
+                    Task.Run(() => internetSettingsDataProvider.RegisterDataProviderAsync())
                 ),
                 "Background service registration"
             );

--- a/c-sharp/Users/InternetSettingsDataProvider.cs
+++ b/c-sharp/Users/InternetSettingsDataProvider.cs
@@ -127,7 +127,7 @@ internal sealed class InternetSettingsDataProvider(PapiClient papiClient)
         catch (Exception e)
         {
             Console.WriteLine($"Setting ParatextData InternetSettings failed! {e}");
-            throw new Exception($"Setting Paratext Registration data failed! {e.Message}");
+            throw new Exception($"Setting ParatextData InternetSettings failed! {e.Message}");
         }
 
         SendDataUpdateEvent(DATA_TYPE_INTERNET_SETTINGS, "updated internet settings");

--- a/c-sharp/Users/InternetSettingsDataProvider.cs
+++ b/c-sharp/Users/InternetSettingsDataProvider.cs
@@ -1,0 +1,136 @@
+using System.Text.Json;
+using Paratext.Data;
+using Paratext.Data.Users;
+
+namespace Paranext.DataProvider.Users;
+
+/// <summary>
+/// PAPI data provider for the ParatextData.dll internet settings. Replaces the former
+/// `getParatextDataInternetSettings` / `setParatextDataInternetSettings` PAPI commands so consumers
+/// can gate on `useDataProvider` availability (no cold-start race) and receive live updates.
+/// </summary>
+internal sealed class InternetSettingsDataProvider(PapiClient papiClient)
+    : NetworkObjects.DataProvider("paratextRegistration.internetSettingsDataProvider", papiClient)
+{
+    /// <summary>
+    /// Placeholder to show instead of real passwords so we aren't giving out real passwords
+    /// </summary>
+    private const string PLACEHOLDER_PASSWORD = "********";
+
+    private const string DATA_TYPE_INTERNET_SETTINGS = "InternetSettings";
+
+    protected override List<(string functionName, Delegate function)> GetFunctions()
+    {
+        return
+        [
+            ("getInternetSettings", GetInternetSettings),
+            ("setInternetSettings", SetInternetSettings),
+        ];
+    }
+
+    protected override Task StartDataProviderAsync() => Task.CompletedTask;
+
+    /// <summary>
+    /// Returns information about the user's current ParatextData.dll internet settings.
+    /// </summary>
+    /// <param name="_selector">Data provider selector; unused (there is a single settings object).</param>
+    private InternetAccess.InternetSettingsMemento GetInternetSettings(JsonElement _selector)
+    {
+        try
+        {
+            var internetSettings = new InternetAccess.InternetSettingsMemento
+            {
+                SelectedServer = InternetAccess.SelectedServers,
+                PermittedInternetUse = InternetAccess.RawStatus,
+                ProxyHost = InternetAccess.ProxyHost,
+                ProxyPort = InternetAccess.ProxyPort,
+                ProxyUsername = InternetAccess.ProxyUsername,
+                ProxyPassword = !string.IsNullOrEmpty(InternetAccess.ProxyPassword)
+                    ? PLACEHOLDER_PASSWORD
+                    : null,
+                ProxyMode = InternetAccess.ProxyMode,
+                OverrideDBLServer = InternetAccess.OverrideDBLServer,
+                OverrideDBLApiServer = InternetAccess.OverrideDBLApiServer,
+                OverrideGbcServer = InternetAccess.OverrideGbcServer,
+                DBLEmail = InternetAccess.DBLEmail,
+                DBLPassword = !string.IsNullOrEmpty(InternetAccess.DBLPassword)
+                    ? PLACEHOLDER_PASSWORD
+                    : null,
+            };
+            return internetSettings;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"Getting ParatextData InternetSettings failed! {e}");
+            throw new Exception($"Getting ParatextData InternetSettings failed! {e.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Sets the user's ParatextData.dll internet settings, then notifies subscribers.
+    /// </summary>
+    /// <param name="_selector">Data provider selector; unused (there is a single settings object).</param>
+    /// <param name="newInternetSettings">Internet settings to persist.</param>
+    private bool SetInternetSettings(
+        JsonElement _selector,
+        InternetAccess.InternetSettingsMemento newInternetSettings
+    )
+    {
+        try
+        {
+            // Set empty strings to null (except proxy-related settings since they are handled by
+            // SetProxy) so they are removed from `InternetSettings.xml` as it happens in PT9
+            if (newInternetSettings.OverrideDBLServer == "")
+                newInternetSettings.OverrideDBLServer = null;
+            if (newInternetSettings.OverrideDBLApiServer == "")
+                newInternetSettings.OverrideDBLApiServer = null;
+            if (newInternetSettings.OverrideGbcServer == "")
+                newInternetSettings.OverrideGbcServer = null;
+            if (newInternetSettings.DBLEmail == "")
+                newInternetSettings.DBLEmail = null;
+            if (newInternetSettings.DBLPassword == "")
+                newInternetSettings.DBLPassword = null;
+
+            // Unfortunately, `InternetAccess.SetProxy` is the only way to set proxy properties, and
+            // it does some weird stuff. Make sure `ProxyHost` is `null` if not using a proxy. Then
+            // `InternetAccess.SetProxy` will set the proxy properties to `null`. But it will also
+            // set `RawStatus` to `InternetUse.Disabled`, so set that back to whatever the user
+            // selected if they selected something that is not `InternetUse.ProxyOnly`. But we want
+            // to leave it disabled if they selected `InternetUse.ProxyOnly` but provided no host
+            if (newInternetSettings.PermittedInternetUse != InternetUse.ProxyOnly)
+                newInternetSettings.ProxyHost = null;
+            InternetAccess.SetProxy(
+                newInternetSettings.ProxyHost,
+                newInternetSettings.ProxyPort,
+                newInternetSettings.ProxyUsername,
+                newInternetSettings.ProxyPassword != PLACEHOLDER_PASSWORD
+                    ? newInternetSettings.ProxyPassword
+                    : InternetAccess.ProxyPassword,
+                newInternetSettings.ProxyMode
+            );
+            if (
+                InternetAccess.RawStatus == InternetUse.Disabled
+                && newInternetSettings.PermittedInternetUse != InternetUse.Disabled
+                && newInternetSettings.PermittedInternetUse != InternetUse.ProxyOnly
+            )
+                InternetAccess.RawStatus = newInternetSettings.PermittedInternetUse;
+
+            InternetAccess.SelectedServers = newInternetSettings.SelectedServer;
+
+            InternetAccess.OverrideDBLServer = newInternetSettings.OverrideDBLServer;
+            InternetAccess.OverrideDBLApiServer = newInternetSettings.OverrideDBLApiServer;
+            InternetAccess.OverrideGbcServer = newInternetSettings.OverrideGbcServer;
+            InternetAccess.DBLEmail = newInternetSettings.DBLEmail;
+            if (newInternetSettings.DBLPassword != PLACEHOLDER_PASSWORD)
+                InternetAccess.DBLPassword = newInternetSettings.DBLPassword;
+        }
+        catch (Exception e)
+        {
+            Console.WriteLine($"Setting ParatextData InternetSettings failed! {e}");
+            throw new Exception($"Setting Paratext Registration data failed! {e.Message}");
+        }
+
+        SendDataUpdateEvent(DATA_TYPE_INTERNET_SETTINGS, "updated internet settings");
+        return true;
+    }
+}

--- a/c-sharp/Users/InternetSettingsDataProvider.cs
+++ b/c-sharp/Users/InternetSettingsDataProvider.cs
@@ -12,29 +12,30 @@ namespace Paranext.DataProvider.Users;
 internal sealed class InternetSettingsDataProvider(PapiClient papiClient)
     : NetworkObjects.DataProvider("paratextRegistration.internetSettingsDataProvider", papiClient)
 {
-    /// <summary>
-    /// Placeholder to show instead of real passwords so we aren't giving out real passwords
-    /// </summary>
-    private const string PLACEHOLDER_PASSWORD = "********";
-
     private const string DATA_TYPE_INTERNET_SETTINGS = "InternetSettings";
 
     protected override List<(string functionName, Delegate function)> GetFunctions()
     {
         return
         [
-            ("getInternetSettings", GetInternetSettings),
-            ("setInternetSettings", SetInternetSettings),
+            ("getInternetSettings", (JsonElement _selector) => GetInternetSettings()),
+            (
+                "setInternetSettings",
+                (
+                    JsonElement _selector,
+                    InternetAccess.InternetSettingsMemento newInternetSettings
+                ) => SetInternetSettings(newInternetSettings)
+            ),
         ];
     }
 
     protected override Task StartDataProviderAsync() => Task.CompletedTask;
 
     /// <summary>
-    /// Returns information about the user's current ParatextData.dll internet settings.
+    /// Returns information about the user's current ParatextData.dll internet settings. Also backs
+    /// the deprecated <c>paratextRegistration.getParatextDataInternetSettings</c> command.
     /// </summary>
-    /// <param name="_selector">Data provider selector; unused (there is a single settings object).</param>
-    private InternetAccess.InternetSettingsMemento GetInternetSettings(JsonElement _selector)
+    public InternetAccess.InternetSettingsMemento GetInternetSettings()
     {
         try
         {
@@ -45,17 +46,13 @@ internal sealed class InternetSettingsDataProvider(PapiClient papiClient)
                 ProxyHost = InternetAccess.ProxyHost,
                 ProxyPort = InternetAccess.ProxyPort,
                 ProxyUsername = InternetAccess.ProxyUsername,
-                ProxyPassword = !string.IsNullOrEmpty(InternetAccess.ProxyPassword)
-                    ? PLACEHOLDER_PASSWORD
-                    : null,
+                ProxyPassword = InternetSettingsLogic.MaskSecret(InternetAccess.ProxyPassword),
                 ProxyMode = InternetAccess.ProxyMode,
                 OverrideDBLServer = InternetAccess.OverrideDBLServer,
                 OverrideDBLApiServer = InternetAccess.OverrideDBLApiServer,
                 OverrideGbcServer = InternetAccess.OverrideGbcServer,
                 DBLEmail = InternetAccess.DBLEmail,
-                DBLPassword = !string.IsNullOrEmpty(InternetAccess.DBLPassword)
-                    ? PLACEHOLDER_PASSWORD
-                    : null,
+                DBLPassword = InternetSettingsLogic.MaskSecret(InternetAccess.DBLPassword),
             };
             return internetSettings;
         }
@@ -67,29 +64,31 @@ internal sealed class InternetSettingsDataProvider(PapiClient papiClient)
     }
 
     /// <summary>
-    /// Sets the user's ParatextData.dll internet settings, then notifies subscribers.
+    /// Sets the user's ParatextData.dll internet settings, then notifies subscribers. Also backs
+    /// the deprecated <c>paratextRegistration.setParatextDataInternetSettings</c> command.
     /// </summary>
-    /// <param name="_selector">Data provider selector; unused (there is a single settings object).</param>
     /// <param name="newInternetSettings">Internet settings to persist.</param>
-    private bool SetInternetSettings(
-        JsonElement _selector,
-        InternetAccess.InternetSettingsMemento newInternetSettings
-    )
+    public bool SetInternetSettings(InternetAccess.InternetSettingsMemento newInternetSettings)
     {
         try
         {
             // Set empty strings to null (except proxy-related settings since they are handled by
             // SetProxy) so they are removed from `InternetSettings.xml` as it happens in PT9
-            if (newInternetSettings.OverrideDBLServer == "")
-                newInternetSettings.OverrideDBLServer = null;
-            if (newInternetSettings.OverrideDBLApiServer == "")
-                newInternetSettings.OverrideDBLApiServer = null;
-            if (newInternetSettings.OverrideGbcServer == "")
-                newInternetSettings.OverrideGbcServer = null;
-            if (newInternetSettings.DBLEmail == "")
-                newInternetSettings.DBLEmail = null;
-            if (newInternetSettings.DBLPassword == "")
-                newInternetSettings.DBLPassword = null;
+            newInternetSettings.OverrideDBLServer = InternetSettingsLogic.EmptyToNull(
+                newInternetSettings.OverrideDBLServer
+            );
+            newInternetSettings.OverrideDBLApiServer = InternetSettingsLogic.EmptyToNull(
+                newInternetSettings.OverrideDBLApiServer
+            );
+            newInternetSettings.OverrideGbcServer = InternetSettingsLogic.EmptyToNull(
+                newInternetSettings.OverrideGbcServer
+            );
+            newInternetSettings.DBLEmail = InternetSettingsLogic.EmptyToNull(
+                newInternetSettings.DBLEmail
+            );
+            newInternetSettings.DBLPassword = InternetSettingsLogic.EmptyToNull(
+                newInternetSettings.DBLPassword
+            );
 
             // Unfortunately, `InternetAccess.SetProxy` is the only way to set proxy properties, and
             // it does some weird stuff. Make sure `ProxyHost` is `null` if not using a proxy. Then
@@ -97,23 +96,26 @@ internal sealed class InternetSettingsDataProvider(PapiClient papiClient)
             // set `RawStatus` to `InternetUse.Disabled`, so set that back to whatever the user
             // selected if they selected something that is not `InternetUse.ProxyOnly`. But we want
             // to leave it disabled if they selected `InternetUse.ProxyOnly` but provided no host
-            if (newInternetSettings.PermittedInternetUse != InternetUse.ProxyOnly)
+            if (
+                InternetSettingsLogic.ShouldClearProxyHost(newInternetSettings.PermittedInternetUse)
+            )
                 newInternetSettings.ProxyHost = null;
             InternetAccess.SetProxy(
                 newInternetSettings.ProxyHost,
                 newInternetSettings.ProxyPort,
                 newInternetSettings.ProxyUsername,
-                newInternetSettings.ProxyPassword != PLACEHOLDER_PASSWORD
-                    ? newInternetSettings.ProxyPassword
-                    : InternetAccess.ProxyPassword,
+                InternetSettingsLogic.ResolveSecret(
+                    newInternetSettings.ProxyPassword,
+                    InternetAccess.ProxyPassword
+                ),
                 newInternetSettings.ProxyMode
             );
-            if (
-                InternetAccess.RawStatus == InternetUse.Disabled
-                && newInternetSettings.PermittedInternetUse != InternetUse.Disabled
-                && newInternetSettings.PermittedInternetUse != InternetUse.ProxyOnly
-            )
-                InternetAccess.RawStatus = newInternetSettings.PermittedInternetUse;
+            var reassertedRawStatus = InternetSettingsLogic.ReassertedRawStatus(
+                InternetAccess.RawStatus,
+                newInternetSettings.PermittedInternetUse
+            );
+            if (reassertedRawStatus.HasValue)
+                InternetAccess.RawStatus = reassertedRawStatus.Value;
 
             InternetAccess.SelectedServers = newInternetSettings.SelectedServer;
 
@@ -121,7 +123,7 @@ internal sealed class InternetSettingsDataProvider(PapiClient papiClient)
             InternetAccess.OverrideDBLApiServer = newInternetSettings.OverrideDBLApiServer;
             InternetAccess.OverrideGbcServer = newInternetSettings.OverrideGbcServer;
             InternetAccess.DBLEmail = newInternetSettings.DBLEmail;
-            if (newInternetSettings.DBLPassword != PLACEHOLDER_PASSWORD)
+            if (InternetSettingsLogic.IsSecretChanged(newInternetSettings.DBLPassword))
                 InternetAccess.DBLPassword = newInternetSettings.DBLPassword;
         }
         catch (Exception e)

--- a/c-sharp/Users/InternetSettingsLogic.cs
+++ b/c-sharp/Users/InternetSettingsLogic.cs
@@ -1,0 +1,52 @@
+using Paratext.Data;
+using Paratext.Data.Users;
+
+namespace Paranext.DataProvider.Users;
+
+/// <summary>
+/// Pure, side-effect-free helpers for the InternetSettings get/set transformations, extracted from
+/// InternetSettingsDataProvider so the non-obvious rules (proxy-host clearing, the RawStatus
+/// re-assertion after SetProxy, secret masking/resolution) can be unit-tested without the static
+/// ParatextData InternetAccess dependency.
+/// </summary>
+internal static class InternetSettingsLogic
+{
+    /// <summary>Placeholder shown in place of a real secret so we never hand out real passwords.</summary>
+    public const string PLACEHOLDER_PASSWORD = "********";
+
+    /// <summary>Mask a secret for display: the placeholder when a value is present, otherwise null.</summary>
+    public static string? MaskSecret(string? value) =>
+        !string.IsNullOrEmpty(value) ? PLACEHOLDER_PASSWORD : null;
+
+    /// <summary>Normalize an empty string to null so the setting is removed from InternetSettings.xml (as in PT9).</summary>
+    public static string? EmptyToNull(string? value) => value == "" ? null : value;
+
+    /// <summary>
+    /// Resolve a submitted secret against the stored one: if the caller echoed back the placeholder
+    /// (i.e. "unchanged"), keep the current stored value; otherwise use what was submitted.
+    /// </summary>
+    public static string? ResolveSecret(string? submitted, string? current) =>
+        submitted != PLACEHOLDER_PASSWORD ? submitted : current;
+
+    /// <summary>Whether a submitted secret is an actual change (not the unchanged-placeholder).</summary>
+    public static bool IsSecretChanged(string? submitted) => submitted != PLACEHOLDER_PASSWORD;
+
+    /// <summary>The proxy host is only meaningful for ProxyOnly; every other mode clears it.</summary>
+    public static bool ShouldClearProxyHost(InternetUse requested) =>
+        requested != InternetUse.ProxyOnly;
+
+    /// <summary>
+    /// Compute the RawStatus to apply after InternetAccess.SetProxy (which forces Disabled). Returns
+    /// the requested status to re-assert it only when SetProxy disabled it and the user asked for
+    /// something that is neither Disabled nor ProxyOnly; otherwise null (leave as-is).
+    /// </summary>
+    public static InternetUse? ReassertedRawStatus(
+        InternetUse currentRawStatus,
+        InternetUse requested
+    ) =>
+        currentRawStatus == InternetUse.Disabled
+        && requested != InternetUse.Disabled
+        && requested != InternetUse.ProxyOnly
+            ? requested
+            : null;
+}

--- a/c-sharp/Users/ParatextRegistrationService.cs
+++ b/c-sharp/Users/ParatextRegistrationService.cs
@@ -9,7 +9,10 @@ namespace Paranext.DataProvider.Users;
 /// <summary>
 /// Commands on the papi that handle Send/Receive-related operations
 /// </summary>
-internal class ParatextRegistrationService(PapiClient papiClient)
+internal class ParatextRegistrationService(
+    PapiClient papiClient,
+    InternetSettingsDataProvider internetSettingsDataProvider
+)
 {
     #region Constructors, consts, and fields
 
@@ -43,6 +46,22 @@ internal class ParatextRegistrationService(PapiClient papiClient)
             ValidateParatextRegistrationData
         );
 
+        // Deprecated: retained as thin wrappers that delegate to InternetSettingsDataProvider so
+        // out-of-repo extensions still calling these commands keep working. New code should use the
+        // paratextRegistration.internetSettingsDataProvider data provider. Remove after a deprecation
+        // period (TODO).
+        await PapiClient.RegisterRequestHandlerAsync(
+            "command:paratextRegistration.getParatextDataInternetSettings",
+            InternetSettingsDataProvider.GetInternetSettings
+        );
+        await PapiClient.RegisterRequestHandlerAsync(
+            "command:paratextRegistration.setParatextDataInternetSettings",
+            (InternetAccess.InternetSettingsMemento newInternetSettings) =>
+            {
+                InternetSettingsDataProvider.SetInternetSettings(newInternetSettings);
+            }
+        );
+
         // Lookup localized strings where they may be needed by callers without access to PapiClient
         RegistrationRequiredException.ExceptionMessage = LocalizationService.GetLocalizedString(
             PapiClient,
@@ -56,6 +75,8 @@ internal class ParatextRegistrationService(PapiClient papiClient)
     #region Private properties and methods
 
     private PapiClient PapiClient { get; } = papiClient;
+    private InternetSettingsDataProvider InternetSettingsDataProvider { get; } =
+        internetSettingsDataProvider;
 
     /// <summary>
     /// Returns information about user's current Paratext Registry user information in ParatextData.dll

--- a/c-sharp/Users/ParatextRegistrationService.cs
+++ b/c-sharp/Users/ParatextRegistrationService.cs
@@ -19,11 +19,6 @@ internal class ParatextRegistrationService(PapiClient papiClient)
     /// </summary>
     private const string PLACEHOLDER_CODE = "******-******-******-******-******";
 
-    /// <summary>
-    /// Placeholder to show instead of real passwords so we aren't giving out real passwords
-    /// </summary>
-    private const string PLACEHOLDER_PASSWORD = "********";
-
     #endregion
 
     #region Public properties and methods
@@ -42,14 +37,6 @@ internal class ParatextRegistrationService(PapiClient papiClient)
         await PapiClient.RegisterRequestHandlerAsync(
             "command:paratextRegistration.doesUserHaveValidRegistration",
             () => RegistrationInfo.DefaultUser.IsValid
-        );
-        await PapiClient.RegisterRequestHandlerAsync(
-            "command:paratextRegistration.getParatextDataInternetSettings",
-            GetParatextDataInternetSettings
-        );
-        await PapiClient.RegisterRequestHandlerAsync(
-            "command:paratextRegistration.setParatextDataInternetSettings",
-            SetParatextDataInternetSettings
         );
         await PapiClient.RegisterRequestHandlerAsync(
             "command:paratextRegistration.validateParatextRegistrationData",
@@ -214,106 +201,6 @@ internal class ParatextRegistrationService(PapiClient papiClient)
                     ? e.Message
                     : $"Setting Paratext Registration data failed! {e.Message}"
             );
-        }
-    }
-
-    /// <summary>
-    /// Returns information about user's current ParatextData.dll internet settings
-    /// </summary>
-    /// <param name="requestContents">Contents of command request. No contents expected</param>
-    /// <returns>Paratext registration information</returns>
-    private InternetAccess.InternetSettingsMemento GetParatextDataInternetSettings()
-    {
-        try
-        {
-            var internetSettings = new InternetAccess.InternetSettingsMemento
-            {
-                SelectedServer = InternetAccess.SelectedServers,
-                PermittedInternetUse = InternetAccess.RawStatus,
-                ProxyHost = InternetAccess.ProxyHost,
-                ProxyPort = InternetAccess.ProxyPort,
-                ProxyUsername = InternetAccess.ProxyUsername,
-                ProxyPassword = !string.IsNullOrEmpty(InternetAccess.ProxyPassword)
-                    ? PLACEHOLDER_PASSWORD
-                    : null,
-                ProxyMode = InternetAccess.ProxyMode,
-                OverrideDBLServer = InternetAccess.OverrideDBLServer,
-                OverrideDBLApiServer = InternetAccess.OverrideDBLApiServer,
-                OverrideGbcServer = InternetAccess.OverrideGbcServer,
-                DBLEmail = InternetAccess.DBLEmail,
-                DBLPassword = !string.IsNullOrEmpty(InternetAccess.DBLPassword)
-                    ? PLACEHOLDER_PASSWORD
-                    : null,
-            };
-            return internetSettings;
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine($"Getting ParatextData InternetSettings failed! {e}");
-            throw new Exception($"Getting ParatextData InternetSettings failed! {e.Message}");
-        }
-    }
-
-    /// <summary>
-    /// Sets information about user's current ParatextData.dll internet settings
-    /// </summary>
-    /// <param name="newInternetSettings">internet settings object for updating ParatextData.dll internet settings</param>
-    private void SetParatextDataInternetSettings(
-        InternetAccess.InternetSettingsMemento newInternetSettings
-    )
-    {
-        try
-        {
-            // Set empty strings to null (except proxy-related settings since they are handled by
-            // SetProxy) so they are removed from `InternetSettings.xml` as it happens in PT9
-            if (newInternetSettings.OverrideDBLServer == "")
-                newInternetSettings.OverrideDBLServer = null;
-            if (newInternetSettings.OverrideDBLApiServer == "")
-                newInternetSettings.OverrideDBLApiServer = null;
-            if (newInternetSettings.OverrideGbcServer == "")
-                newInternetSettings.OverrideGbcServer = null;
-            if (newInternetSettings.DBLEmail == "")
-                newInternetSettings.DBLEmail = null;
-            if (newInternetSettings.DBLPassword == "")
-                newInternetSettings.DBLPassword = null;
-
-            // Unfortunately, `InternetAccess.SetProxy` is the only way to set proxy properties, and
-            // it does some weird stuff. Make sure `ProxyHost` is `null` if not using a proxy. Then
-            // `InternetAccess.SetProxy` will set the proxy properties to `null`. But it will also
-            // set `RawStatus` to `InternetUse.Disabled`, so set that back to whatever the user
-            // selected if they selected something that is not `InternetUse.ProxyOnly`. But we want
-            // to leave it disabled if they selected `InternetUse.ProxyOnly` but provided no host
-            if (newInternetSettings.PermittedInternetUse != InternetUse.ProxyOnly)
-                newInternetSettings.ProxyHost = null;
-            InternetAccess.SetProxy(
-                newInternetSettings.ProxyHost,
-                newInternetSettings.ProxyPort,
-                newInternetSettings.ProxyUsername,
-                newInternetSettings.ProxyPassword != PLACEHOLDER_PASSWORD
-                    ? newInternetSettings.ProxyPassword
-                    : InternetAccess.ProxyPassword,
-                newInternetSettings.ProxyMode
-            );
-            if (
-                InternetAccess.RawStatus == InternetUse.Disabled
-                && newInternetSettings.PermittedInternetUse != InternetUse.Disabled
-                && newInternetSettings.PermittedInternetUse != InternetUse.ProxyOnly
-            )
-                InternetAccess.RawStatus = newInternetSettings.PermittedInternetUse;
-
-            InternetAccess.SelectedServers = newInternetSettings.SelectedServer;
-
-            InternetAccess.OverrideDBLServer = newInternetSettings.OverrideDBLServer;
-            InternetAccess.OverrideDBLApiServer = newInternetSettings.OverrideDBLApiServer;
-            InternetAccess.OverrideGbcServer = newInternetSettings.OverrideGbcServer;
-            InternetAccess.DBLEmail = newInternetSettings.DBLEmail;
-            if (newInternetSettings.DBLPassword != PLACEHOLDER_PASSWORD)
-                InternetAccess.DBLPassword = newInternetSettings.DBLPassword;
-        }
-        catch (Exception e)
-        {
-            Console.WriteLine($"Setting ParatextData InternetSettings failed! {e}");
-            throw new Exception($"Setting Paratext Registration data failed! {e.Message}");
         }
     }
 

--- a/extensions/src/paratext-registration/src/internet-settings.stories.tsx
+++ b/extensions/src/paratext-registration/src/internet-settings.stories.tsx
@@ -62,7 +62,10 @@ function createDecorator(config: DecoratorConfig) {
           saveState: config.saveState ?? SaveState.HasNotSaved,
           saveError: config.saveError ?? '',
           onSaveAndRestart: () =>
-            alertCommand('paratextRegistration.setParatextDataInternetSettings', internetSettings),
+            alertCommand(
+              'paratextRegistration.internetSettingsDataProvider → setInternetSettings',
+              internetSettings,
+            ),
         }}
       />
     );

--- a/extensions/src/paratext-registration/src/internet-settings.web-view.tsx
+++ b/extensions/src/paratext-registration/src/internet-settings.web-view.tsx
@@ -1,6 +1,6 @@
 import { WebViewProps } from '@papi/core';
 import papi, { logger } from '@papi/frontend';
-import { useData, useDataProvider, useLocalizedStrings } from '@papi/frontend/react';
+import { useData, useLocalizedStrings } from '@papi/frontend/react';
 import { InternetSettings } from 'paratext-registration';
 import { getErrorMessage, isPlatformError, wait } from 'platform-bible-utils';
 import { useEffect, useRef, useState } from 'react';
@@ -12,6 +12,9 @@ const INTERNET_SETTINGS_RESTART_DELAY_MS = 5 * 1000;
 
 const INTERNET_SETTINGS_DATA_PROVIDER = 'paratextRegistration.internetSettingsDataProvider';
 
+// Intentionally duplicated in the first-run wizard (internet-settings-step.component.tsx): the two
+// consumers sit on opposite sides of the core/extension boundary and `paratext-registration` is a
+// types-only module, so there is no shared runtime module to hoist this into.
 const DEFAULT_INTERNET_SETTINGS: InternetSettings = {
   permittedInternetUse: 'VpnRequired',
   selectedServer: 'Production',
@@ -64,19 +67,21 @@ globalThis.webViewComponent = function InternetSettingsComponent({
     InternetSettings | undefined
   >();
 
-  const provider = useDataProvider(INTERNET_SETTINGS_DATA_PROVIDER);
   const [dpValue, setData, isLoadingSettings] = useData(
     INTERNET_SETTINGS_DATA_PROVIDER,
   ).InternetSettings(undefined, DEFAULT_INTERNET_SETTINGS);
 
-  // Guard against overwriting an in-progress user edit if the callback were ever replaced.
+  // Once the staged draft + saved baseline have been synced from the first successful read.
   const hasSyncedFetch = useRef(false);
 
-  // Treat as unresolved while the provider is registering or the first read is in flight; surface a
-  // load error via saveError; otherwise sync the staged + saved baselines (guarding an in-progress
-  // user edit with hasSyncedFetch).
+  // `setData` is undefined until the provider resolves, so it doubles as the readiness signal (no
+  // separate useDataProvider needed). While unresolved or the first read is in flight, defer. On a
+  // load error, surface it via saveError. Otherwise sync the staged draft AND the saved baseline
+  // exactly once: this is a stage-then-commit dialog, so the Reset target and dirty-state must stay
+  // anchored to what was loaded (or last saved locally, via handleSaveAndRestart) rather than
+  // shifting under the user when another window changes settings via a live provider push.
   useEffect(() => {
-    if (provider === undefined || isLoadingSettings) return;
+    if (!setData || isLoadingSettings) return;
     if (isPlatformError(dpValue)) {
       if (isMounted.current) setSaveError(getErrorMessage(dpValue));
       return;
@@ -84,9 +89,9 @@ globalThis.webViewComponent = function InternetSettingsComponent({
     if (!hasSyncedFetch.current) {
       hasSyncedFetch.current = true;
       setInternetSettings(dpValue);
+      setSavedInternetSettings(dpValue);
     }
-    setSavedInternetSettings(dpValue);
-  }, [provider, isLoadingSettings, dpValue, setInternetSettings]);
+  }, [setData, isLoadingSettings, dpValue, setInternetSettings]);
 
   const isFormDisabled =
     savedInternetSettings === undefined ||
@@ -95,12 +100,10 @@ globalThis.webViewComponent = function InternetSettingsComponent({
 
   const handleSaveAndRestart = async () => {
     if (!setData) {
-      // Provider not registered yet — do not mark saved or restart without persisting.
-      setSaveError(
-        getErrorMessage(
-          new Error('Internet settings are not available yet. Please try again in a moment.'),
-        ),
-      );
+      // Defensive: the Save button is disabled (isFormDisabled) until the provider is ready, so this
+      // is unreachable via the UI. Bail without restarting or marking saved rather than persisting
+      // nothing; log for the theoretical programmatic caller.
+      logger.warn('Internet settings provider unavailable; ignoring Save and restart.');
       setSaveState(SaveState.HasNotSaved);
       return;
     }

--- a/extensions/src/paratext-registration/src/internet-settings.web-view.tsx
+++ b/extensions/src/paratext-registration/src/internet-settings.web-view.tsx
@@ -65,10 +65,9 @@ globalThis.webViewComponent = function InternetSettingsComponent({
   >();
 
   const provider = useDataProvider(INTERNET_SETTINGS_DATA_PROVIDER);
-  const [dpValue, setData, isLoadingSettings] = useData(provider).InternetSettings(
-    undefined,
-    DEFAULT_INTERNET_SETTINGS,
-  );
+  const [dpValue, setData, isLoadingSettings] = useData(
+    INTERNET_SETTINGS_DATA_PROVIDER,
+  ).InternetSettings(undefined, DEFAULT_INTERNET_SETTINGS);
 
   // Guard against overwriting an in-progress user edit if the callback were ever replaced.
   const hasSyncedFetch = useRef(false);

--- a/extensions/src/paratext-registration/src/internet-settings.web-view.tsx
+++ b/extensions/src/paratext-registration/src/internet-settings.web-view.tsx
@@ -95,10 +95,20 @@ globalThis.webViewComponent = function InternetSettingsComponent({
     saveState === SaveState.IsRestarting;
 
   const handleSaveAndRestart = async () => {
+    if (!setData) {
+      // Provider not registered yet — do not mark saved or restart without persisting.
+      setSaveError(
+        getErrorMessage(
+          new Error('Internet settings are not available yet. Please try again in a moment.'),
+        ),
+      );
+      setSaveState(SaveState.HasNotSaved);
+      return;
+    }
     setSaveState(SaveState.IsSaving);
     setSaveError('');
     try {
-      await setData?.(internetSettings);
+      await setData(internetSettings);
       // Update the saved baseline so Reset reflects the just-persisted state.
       if (isMounted.current) setSavedInternetSettings(internetSettings);
       // Queue restart asynchronously so the UI can update first.

--- a/extensions/src/paratext-registration/src/internet-settings.web-view.tsx
+++ b/extensions/src/paratext-registration/src/internet-settings.web-view.tsx
@@ -1,30 +1,22 @@
 import { WebViewProps } from '@papi/core';
 import papi, { logger } from '@papi/frontend';
-import { useLocalizedStrings } from '@papi/frontend/react';
+import { useData, useDataProvider, useLocalizedStrings } from '@papi/frontend/react';
 import { InternetSettings } from 'paratext-registration';
-import { usePromise } from 'platform-bible-react';
-import { getErrorMessage, wait } from 'platform-bible-utils';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { getErrorMessage, isPlatformError, wait } from 'platform-bible-utils';
+import { useEffect, useRef, useState } from 'react';
 import { INTERNET_SETTINGS_STRING_KEYS, InternetSettingsForm } from './internet-settings.component';
 import { SaveState } from './utils';
 
 /** Time in milliseconds to wait before restarting the application after changing internet settings. */
 const INTERNET_SETTINGS_RESTART_DELAY_MS = 5 * 1000;
 
-// #region PAPI helpers
+const INTERNET_SETTINGS_DATA_PROVIDER = 'paratextRegistration.internetSettingsDataProvider';
 
-async function getInternetSettings() {
-  return papi.commands.sendCommand('paratextRegistration.getParatextDataInternetSettings');
-}
-
-async function saveInternetSettings(internetSettings: InternetSettings) {
-  return papi.commands.sendCommand(
-    'paratextRegistration.setParatextDataInternetSettings',
-    internetSettings,
-  );
-}
-
-// #endregion
+const DEFAULT_INTERNET_SETTINGS: InternetSettings = {
+  permittedInternetUse: 'VpnRequired',
+  selectedServer: 'Production',
+  proxyPort: 0,
+};
 
 // Run once per renderer-process session. Ensures the post-restart detection in the mount
 // effect does not misfire when the panel is reopened while a restart countdown is in progress.
@@ -64,7 +56,7 @@ globalThis.webViewComponent = function InternetSettingsComponent({
   // Staged settings: what the user has edited in the form (persisted in web view state).
   const [internetSettings, setInternetSettings] = useWebViewState<InternetSettings>(
     'internetSettings',
-    { permittedInternetUse: 'VpnRequired', selectedServer: 'Production', proxyPort: 0 },
+    DEFAULT_INTERNET_SETTINGS,
   );
 
   // Last-persisted settings from PAPI: undefined while the fetch is in flight.
@@ -72,32 +64,30 @@ globalThis.webViewComponent = function InternetSettingsComponent({
     InternetSettings | undefined
   >();
 
-  // Stable wrapper so usePromise fires exactly once. Catches PAPI command errors and surfaces
-  // them via saveError so the user sees an actionable message instead of a silent locked form.
-  const getInternetSettingsSafe = useCallback(async () => {
-    try {
-      return await getInternetSettings();
-    } catch (err: unknown) {
-      if (isMounted.current) setSaveError(getErrorMessage(err));
-      return undefined;
-    }
-  }, []); // stable: isMounted is a ref, setSaveError is a useState setter, getInternetSettings is module-level
-
-  // Fetch current settings from PAPI on mount; undefined until resolved or on error.
-  const [fetchedInternetSettings] = usePromise(getInternetSettingsSafe, undefined);
+  const provider = useDataProvider(INTERNET_SETTINGS_DATA_PROVIDER);
+  const [dpValue, setData, isLoadingSettings] = useData(provider).InternetSettings(
+    undefined,
+    DEFAULT_INTERNET_SETTINGS,
+  );
 
   // Guard against overwriting an in-progress user edit if the callback were ever replaced.
   const hasSyncedFetch = useRef(false);
 
-  // When fetch resolves, update both staged and saved baselines.
+  // Treat as unresolved while the provider is registering or the first read is in flight; surface a
+  // load error via saveError; otherwise sync the staged + saved baselines (guarding an in-progress
+  // user edit with hasSyncedFetch).
   useEffect(() => {
-    if (fetchedInternetSettings === undefined) return;
+    if (provider === undefined || isLoadingSettings) return;
+    if (isPlatformError(dpValue)) {
+      if (isMounted.current) setSaveError(getErrorMessage(dpValue));
+      return;
+    }
     if (!hasSyncedFetch.current) {
       hasSyncedFetch.current = true;
-      setInternetSettings(fetchedInternetSettings);
+      setInternetSettings(dpValue);
     }
-    setSavedInternetSettings(fetchedInternetSettings);
-  }, [fetchedInternetSettings, setInternetSettings]);
+    setSavedInternetSettings(dpValue);
+  }, [provider, isLoadingSettings, dpValue, setInternetSettings]);
 
   const isFormDisabled =
     savedInternetSettings === undefined ||
@@ -108,7 +98,7 @@ globalThis.webViewComponent = function InternetSettingsComponent({
     setSaveState(SaveState.IsSaving);
     setSaveError('');
     try {
-      await saveInternetSettings(internetSettings);
+      await setData?.(internetSettings);
       // Update the saved baseline so Reset reflects the just-persisted state.
       if (isMounted.current) setSavedInternetSettings(internetSettings);
       // Queue restart asynchronously so the UI can update first.

--- a/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
+++ b/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
@@ -1,4 +1,6 @@
 declare module 'paratext-registration' {
+  import { DataProviderDataType, IDataProvider } from '@papi/core';
+
   /**
    * Paratext registry user information as used in `ParatextData.dll`
    *
@@ -50,10 +52,25 @@ declare module 'paratext-registration' {
     dblEmail?: string;
     dblPassword?: string;
   };
+
+  /** Data types served by the Internet Settings data provider. Selector is unused (single object). */
+  export type InternetSettingsDataTypes = {
+    InternetSettings: DataProviderDataType<undefined, InternetSettings, InternetSettings>;
+  };
+
+  /**
+   * Data provider for the ParatextData.dll internet settings. `useDataProvider` returns `undefined`
+   * until it registers (a natural loading signal); `subscribeInternetSettings` is auto-generated.
+   *
+   * Note: these settings only apply to operations ParatextData.dll performs, not the whole app.
+   * Note: passwords are returned masked as `********`, and the app must be restarted for changes to
+   * fully take effect.
+   */
+  export type IInternetSettingsDataProvider = IDataProvider<InternetSettingsDataTypes>;
 }
 
 declare module 'papi-shared-types' {
-  import type { RegistrationData, InternetSettings } from 'paratext-registration';
+  import type { RegistrationData, IInternetSettingsDataProvider } from 'paratext-registration';
 
   export interface CommandHandlers {
     /**
@@ -91,30 +108,6 @@ declare module 'papi-shared-types' {
       newRegistrationData: RegistrationData,
     ) => Promise<void>;
     /**
-     * Gets information about user's current ParatextData.dll internet settings
-     *
-     * Note: These settings only apply to operations that ParatextData.dll performs, not everything
-     * in the whole application.
-     *
-     * Note that this does not return the passwords in internet settings as they are secure
-     * information. Instead, it returns `********` in their place.
-     */
-    'paratextRegistration.getParatextDataInternetSettings': () => Promise<InternetSettings>;
-    /**
-     * Sets information about user's current ParatextData.dll internet settings
-     *
-     * Note: These settings only apply to operations that ParatextData.dll performs, not everything
-     * in the whole application.
-     *
-     * Note: The application must be restarted after running this to properly reflect changes.
-     *
-     * @returns If successfully changed ParatextData.dll internet settings
-     * @throws If did not successfully change ParatextData.dll internet settings
-     */
-    'paratextRegistration.setParatextDataInternetSettings': (
-      newRegistrationData: InternetSettings,
-    ) => Promise<void>;
-    /**
      * Gets the validity status of the user's Paratext registration
      *
      * @returns True if the user has a valid Paratext registration, false otherwise
@@ -128,6 +121,10 @@ declare module 'papi-shared-types' {
     'paratextRegistration.validateParatextRegistrationData': (
       registrationData: RegistrationData,
     ) => Promise<boolean>;
+  }
+
+  export interface DataProviders {
+    'paratextRegistration.internetSettingsDataProvider': IInternetSettingsDataProvider;
   }
 
   export interface SettingTypes {

--- a/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
+++ b/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
@@ -77,7 +77,11 @@ declare module 'paratext-registration' {
 }
 
 declare module 'papi-shared-types' {
-  import type { RegistrationData, IInternetSettingsDataProvider } from 'paratext-registration';
+  import type {
+    RegistrationData,
+    InternetSettings,
+    IInternetSettingsDataProvider,
+  } from 'paratext-registration';
 
   export interface CommandHandlers {
     /**
@@ -128,6 +132,29 @@ declare module 'papi-shared-types' {
     'paratextRegistration.validateParatextRegistrationData': (
       registrationData: RegistrationData,
     ) => Promise<boolean>;
+    /**
+     * @deprecated Use the `paratextRegistration.internetSettingsDataProvider` data provider's
+     *   `getInternetSettings` instead. Retained as a thin wrapper for backward compatibility and
+     *   will be removed in a future release.
+     *
+     *   Gets information about the user's current ParatextData.dll internet settings.
+     *
+     *   Note: these settings only apply to operations ParatextData.dll performs, not the whole app.
+     *   Note that passwords are returned masked as `********`.
+     */
+    'paratextRegistration.getParatextDataInternetSettings': () => Promise<InternetSettings>;
+    /**
+     * @deprecated Use the `paratextRegistration.internetSettingsDataProvider` data provider's
+     *   `setInternetSettings` instead. Retained as a thin wrapper for backward compatibility and
+     *   will be removed in a future release.
+     *
+     *   Sets the user's ParatextData.dll internet settings.
+     *
+     *   Note: the application must be restarted after this to fully reflect changes.
+     */
+    'paratextRegistration.setParatextDataInternetSettings': (
+      newInternetSettings: InternetSettings,
+    ) => Promise<void>;
   }
 
   export interface DataProviders {

--- a/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
+++ b/extensions/src/paratext-registration/src/types/paratext-registration.d.ts
@@ -1,5 +1,12 @@
 declare module 'paratext-registration' {
-  import { DataProviderDataType, IDataProvider } from '@papi/core';
+  import type {
+    DataProviderDataType,
+    IDataProvider,
+    // @ts-ignore: TS2307 - Cannot find module '@papi/core' or its corresponding type declarations
+    // The root tsconfig uses ./extensions/src as a typeRoot but doesn't include ./lib, so @papi/core
+    // is unresolvable in the root context. The extensions workspace resolves it via ../../../lib.
+    // This inline suppression matches the pattern in platform-scripture.d.ts, legacy-comment-manager.d.ts, etc.
+  } from '@papi/core';
 
   /**
    * Paratext registry user information as used in `ParatextData.dll`

--- a/src/renderer/components/first-run/steps/internet-settings-step.component.test.tsx
+++ b/src/renderer/components/first-run/steps/internet-settings-step.component.test.tsx
@@ -51,6 +51,7 @@ vi.mock('platform-bible-react', () => ({
     </button>
   ),
   Spinner: () => <div data-testid="spinner" />,
+  cn: (...classes: unknown[]) => classes.filter(Boolean).join(' '),
 }));
 
 vi.mock('platform-bible-react/experimental', () => ({

--- a/src/renderer/components/first-run/steps/internet-settings-step.component.test.tsx
+++ b/src/renderer/components/first-run/steps/internet-settings-step.component.test.tsx
@@ -1,49 +1,32 @@
 // @vitest-environment jsdom
 
 import React from 'react';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
-import {
-  getJsonRpcRequestErrorMessagePrefix,
-  JSON_RPC_REQUEST_TIMED_OUT_MESSAGE_PREFIX,
-} from '@shared/data/rpc.model';
-import { JSONRPCErrorCode } from 'json-rpc-2.0';
-import { wait } from 'platform-bible-utils';
+import { useDataProvider, useData } from '@renderer/hooks/papi-hooks';
+import { newPlatformError } from 'platform-bible-utils';
 import type { FirstRunStepProps } from '../first-run-step-props.model';
 import { InternetSettingsStep } from './internet-settings-step.component';
 
-// Return resolved strings so the Retry button and the "connecting" message have accessible
-// text — avoids getByRole('/retry/i') failing because an empty map yields undefined content.
+// vi.mock is hoisted by vitest to before all imports, so these mocks are active when the
+// imports above are evaluated — even though the import of useDataProvider/useData appears
+// before the vi.mock call in source order.
 vi.mock('@renderer/hooks/papi-hooks', () => ({
   useLocalizedStrings: vi.fn(() => [
     {
       '%internetSettings_button_retry%': 'Retry',
-      '%firstRun_step_internetSettings_connecting%':
-        'Setting things up for the first time. This can take a few moments…',
+      '%firstRun_step_internetSettings_connecting%': 'Getting things ready…',
       '%firstRun_step_internetSettings_loadError%':
-        'Setup is taking longer than expected. Please try again — it usually works right away.',
+        "We couldn't get things ready. Please try again in a moment.",
     },
     false,
   ]),
+  useDataProvider: vi.fn(),
+  useData: vi.fn(),
 }));
 
-const mockSendCommand = vi.fn();
-vi.mock('@shared/services/command.service', () => ({
-  sendCommand: (...args: unknown[]) => mockSendCommand(...args),
-}));
-
-// The load-failure path shows a friendly message but logs the raw RPC error — capture warns to assert it.
-const mockLoggerWarn = vi.fn();
-vi.mock('@shared/services/logger.service', () => ({
-  logger: { warn: (...args: unknown[]) => mockLoggerWarn(...args) },
-}));
-
-// Targeted stubs — do NOT use importOriginal spread here. Spreading the whole
-// platform-bible-react barrel evaluates shadcn/Radix components that require
-// ResizeObserver and a CSS import, which jsdom doesn't provide. Stub only what
-// InternetSettingsStep actually uses.
 vi.mock('platform-bible-react', () => ({
   Alert: ({ children, variant }: { children: React.ReactNode; variant?: string }) => (
     <div role="alert" data-variant={variant}>
@@ -63,7 +46,6 @@ vi.mock('platform-bible-react', () => ({
     </button>
   ),
   Spinner: () => <div data-testid="spinner" />,
-  cn: (...classes: unknown[]) => classes.filter(Boolean).join(' '),
 }));
 
 vi.mock('platform-bible-react/experimental', () => ({
@@ -87,20 +69,33 @@ const MOCK_SETTINGS = {
   proxyPort: 0,
 };
 
-// The exact "method not found" message sendCommand throws while the handler is still registering —
-// built from the same producer the RPC layer uses (network.service.ts), so the fixture stays faithful
-// to production and can't silently drift from what the component actually matches.
-const methodNotFoundError = () =>
-  new Error(
-    `${getJsonRpcRequestErrorMessagePrefix(JSONRPCErrorCode.MethodNotFound)}: command:paratextRegistration.getParatextDataInternetSettings not found`,
-  );
+const PROVIDER = { __brand: 'internetSettingsDataProvider' };
 
-// A method-not-found rejection that arrives after `ms` of (faked) time — models a real attempt
-// blocking on the command layer's ~10 s retry before -32601 propagates, so a test can span more than
-// one window instead of rejecting instantly.
-async function rejectAsUnregisteredAfter(ms: number): Promise<never> {
-  await wait(ms);
-  throw methodNotFoundError();
+/**
+ * Configure the mocked hooks. `provider === undefined` simulates not-yet-registered; `value` is the
+ * `useData` first element (settings or a PlatformError); `isLoading` is the third; `setData` is the
+ * write fn (defaults to a resolving spy).
+ */
+function configureHooks(opts: {
+  provider?: unknown;
+  value?: unknown;
+  isLoading?: boolean;
+  setData?: ReturnType<typeof vi.fn>;
+}) {
+  const setData = opts.setData ?? vi.fn().mockResolvedValue(undefined);
+  vi.mocked(useDataProvider).mockReturnValue(
+    // opts.provider is `unknown` by design so the helper can accept both undefined and a branded
+    // object; typing this precisely would require a complex generic that adds no test value.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion -- necessary for mock helper flexibility
+    'provider' in opts ? (opts.provider as never) : (PROVIDER as never),
+  );
+  // The curried useData return type is a deeply-generic object; its shape is tested in
+  // papi-hooks tests. Replicating it here would create brittle coupling.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion -- necessary for mock helper flexibility
+  vi.mocked(useData).mockReturnValue({
+    InternetSettings: () => [opts.value ?? MOCK_SETTINGS, setData, opts.isLoading ?? false],
+  } as never);
+  return { setData };
 }
 
 function renderStep(setCanProceed = vi.fn()) {
@@ -113,225 +108,75 @@ describe('InternetSettingsStep', () => {
     vi.clearAllMocks();
   });
 
-  it('disables Next during the initial fetch then enables it after fetch resolves', async () => {
-    mockSendCommand.mockResolvedValue(MOCK_SETTINGS);
+  it('shows a spinner and no error while the provider is undefined', () => {
+    configureHooks({ provider: undefined });
     const { setCanProceed } = renderStep();
 
-    // Mount must call setCanProceed(false) before the async fetch
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
     expect(setCanProceed).toHaveBeenCalledWith(false);
+  });
+
+  it('shows a spinner while the provider is available but data is still loading', () => {
+    configureHooks({ isLoading: true });
+    renderStep();
+
+    expect(screen.getByTestId('spinner')).toBeInTheDocument();
+    expect(screen.queryByTestId('option-list')).not.toBeInTheDocument();
+  });
+
+  it('renders the settings form and enables Next once data has loaded', async () => {
+    configureHooks({ value: MOCK_SETTINGS, isLoading: false });
+    const { setCanProceed } = renderStep();
+
+    expect(screen.getByTestId('option-list')).toBeInTheDocument();
     await waitFor(() => expect(setCanProceed).toHaveBeenCalledWith(true));
   });
 
-  it('shows a friendly error alert and retry button when the initial fetch fails', async () => {
-    mockSendCommand.mockRejectedValue(new Error('network error'));
+  it('calls setData with the new value immediately when a selection changes', async () => {
+    const { setData } = configureHooks({ value: MOCK_SETTINGS });
     renderStep();
 
-    await waitFor(() =>
-      expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument(),
-    );
-    expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
-    // Raw error is logged, not shown.
-    expect(screen.queryByText(/network error/i)).not.toBeInTheDocument();
-    expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining('network error'));
-  });
-
-  it('clears the error and enables Next when retry succeeds', async () => {
-    mockSendCommand
-      .mockRejectedValueOnce(new Error('network error'))
-      .mockResolvedValue(MOCK_SETTINGS);
-    const { setCanProceed } = renderStep();
-
-    await waitFor(() => expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument());
-    await userEvent.click(screen.getByRole('button', { name: /retry/i }));
-
-    await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument());
-    expect(setCanProceed).toHaveBeenCalledWith(true);
-  });
-
-  it('calls setParatextDataInternetSettings immediately when a selection changes', async () => {
-    mockSendCommand.mockResolvedValue(MOCK_SETTINGS);
-    renderStep();
-
-    await waitFor(() => expect(screen.getByTestId('option-list')).toBeInTheDocument());
     await userEvent.click(screen.getByTestId('option-list'));
 
-    expect(mockSendCommand).toHaveBeenCalledWith(
-      'paratextRegistration.setParatextDataInternetSettings',
+    expect(setData).toHaveBeenCalledWith(
       expect.objectContaining({ permittedInternetUse: 'Enabled' }),
     );
   });
 
-  it('shows a save error alert and disables Next when a save fails', async () => {
-    mockSendCommand
-      .mockResolvedValueOnce(MOCK_SETTINGS) // initial fetch succeeds
-      .mockRejectedValue(new Error('save failed')); // all saves fail
+  it('shows a save-error alert and disables Next when setData rejects', async () => {
+    const setData = vi.fn().mockRejectedValue(new Error('save failed'));
+    configureHooks({ value: MOCK_SETTINGS, setData });
     const { setCanProceed } = renderStep();
 
-    await waitFor(() => expect(screen.getByTestId('option-list')).toBeInTheDocument());
     await userEvent.click(screen.getByTestId('option-list'));
 
     await waitFor(() => expect(screen.getByText(/save failed/i)).toBeInTheDocument());
-    // setCanProceed(false) must be called after the failed save
     const calls = setCanProceed.mock.calls.map((c) => c[0]);
     expect(calls.at(-1)).toBe(false);
   });
 
-  it('clears the save error and re-enables Next when the next save succeeds', async () => {
-    mockSendCommand
-      .mockResolvedValueOnce(MOCK_SETTINGS) // initial fetch
-      .mockRejectedValueOnce(new Error('save failed')) // first save fails
-      .mockResolvedValue(MOCK_SETTINGS); // subsequent saves succeed
-    const { setCanProceed } = renderStep();
-
-    await waitFor(() => expect(screen.getByTestId('option-list')).toBeInTheDocument());
-    await userEvent.click(screen.getByTestId('option-list')); // triggers failing save
-    await waitFor(() => expect(screen.getByText(/save failed/i)).toBeInTheDocument());
-
-    await userEvent.click(screen.getByTestId('dev-section')); // triggers succeeding save
-    await waitFor(() => expect(screen.queryByText(/save failed/i)).not.toBeInTheDocument());
-    expect(setCanProceed).toHaveBeenLastCalledWith(true);
-  });
-
-  describe('startup race with the .NET data provider', () => {
-    beforeEach(() => {
-      vi.useFakeTimers();
-    });
-
-    afterEach(() => {
-      vi.useRealTimers();
-    });
-
-    // Wraps timer advancement in act(...) so the retry loop's state updates flush cleanly.
-    const advance = (ms: number) => act(() => vi.advanceTimersByTimeAsync(ms));
-
-    it('retries while the handler is unregistered, then shows settings without flashing an error', async () => {
-      mockSendCommand
-        .mockRejectedValueOnce(methodNotFoundError())
-        .mockRejectedValueOnce(methodNotFoundError())
-        .mockResolvedValue(MOCK_SETTINGS);
-      const { setCanProceed } = renderStep();
-
-      // While retrying, the spinner stays and no error/Retry surfaces.
-      expect(screen.getByTestId('spinner')).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
-
-      await advance(1500); // two 500 ms backoffs, then the resolving attempt
-
-      expect(screen.getByTestId('option-list')).toBeInTheDocument();
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-      expect(setCanProceed).toHaveBeenCalledWith(true);
-    });
-
-    it('shows the connecting message once the load passes the wall-clock delay', async () => {
-      mockSendCommand.mockRejectedValue(methodNotFoundError());
-      renderStep();
-
-      await advance(1500); // before the 2 s connecting-message delay
-      expect(screen.queryByText(/setting things up/i)).not.toBeInTheDocument();
-
-      await advance(1000); // now past 2 s
-      expect(screen.getByText(/setting things up/i)).toBeInTheDocument();
-      // Still within budget — no error yet.
-      expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
-    });
-
-    it('retries a client request timeout like a startup miss (not just method-not-found)', async () => {
-      // An overloaded provider mid-cold-start can blow the client timeout instead of replying
-      // method-not-found; that's still transient and should be retried within the budget.
-      mockSendCommand
-        .mockRejectedValueOnce(
-          new Error(`${JSON_RPC_REQUEST_TIMED_OUT_MESSAGE_PREFIX} getInternet`),
-        )
-        .mockResolvedValue(MOCK_SETTINGS);
-      const { setCanProceed } = renderStep();
-
-      await advance(1_000); // one 500 ms backoff, then the resolving attempt
-      expect(screen.getByTestId('option-list')).toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
-      expect(setCanProceed).toHaveBeenCalledWith(true);
-    });
-
-    it('re-issues across more than one command-layer window, then loads once registration completes', async () => {
-      // Two attempts that each block ~9 s (like the command layer's own retry) before failing, then
-      // success. This is the actual bug scenario: registration outlasts a single ~10 s window.
-      mockSendCommand
-        .mockImplementationOnce(() => rejectAsUnregisteredAfter(9_000))
-        .mockImplementationOnce(() => rejectAsUnregisteredAfter(9_000))
-        .mockResolvedValue(MOCK_SETTINGS);
-      const { setCanProceed } = renderStep();
-
-      // One ~9 s window is not enough — still retrying, no error.
-      await advance(9_500);
-      expect(screen.queryByTestId('option-list')).not.toBeInTheDocument();
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-
-      // A second window later, registration completes and the settings load.
-      await advance(10_000);
-      expect(screen.getByTestId('option-list')).toBeInTheDocument();
-      expect(setCanProceed).toHaveBeenCalledWith(true);
-    });
-
-    it('clears the connecting message once a later attempt succeeds', async () => {
-      mockSendCommand
-        .mockImplementationOnce(() => rejectAsUnregisteredAfter(9_000)) // keeps attempt pending past 2 s
-        .mockResolvedValue(MOCK_SETTINGS);
-      renderStep();
-
-      await advance(2_500); // connecting message shows while the first attempt is still pending
-      expect(screen.getByText(/setting things up/i)).toBeInTheDocument();
-
-      await advance(7_500); // first attempt fails (~9 s), the retry resolves
-      expect(screen.getByTestId('option-list')).toBeInTheDocument();
-      expect(screen.queryByText(/setting things up/i)).not.toBeInTheDocument();
-    });
-
-    it('surfaces the real method-not-found error and Retry once the startup budget is spent', async () => {
-      mockSendCommand.mockRejectedValue(methodNotFoundError());
-      renderStep();
-
-      // Still retrying just before the budget expires — no error yet.
-      await advance(29_000);
-      expect(screen.queryByRole('button', { name: /retry/i })).not.toBeInTheDocument();
-
-      // Just past the ~30 s budget the friendly error surfaces and the connecting message clears.
-      await advance(2_000);
-      expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
-      expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument();
-      expect(screen.queryByText(/setting things up/i)).not.toBeInTheDocument();
-      // The raw -32601 is logged for debugging, not shown to the user.
-      expect(screen.queryByText(/-32601/)).not.toBeInTheDocument();
-      expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining('-32601'));
-    });
-
-    it('ignores a superseded load — a stale attempt cannot clobber a newer one', async () => {
-      // First load blocks then fails; a prop change starts a second load that resolves.
-      mockSendCommand
-        .mockImplementationOnce(() => rejectAsUnregisteredAfter(5_000))
-        .mockResolvedValue(MOCK_SETTINGS);
-      const { rerender } = render(
-        <InternetSettingsStep onNext={vi.fn()} setCanProceed={vi.fn()} />,
-      );
-
-      // Changing setCanProceed identity re-runs load() (a new generation) while the first is pending.
-      await act(async () => {
-        rerender(<InternetSettingsStep onNext={vi.fn()} setCanProceed={vi.fn()} />);
-      });
-
-      // The second load resolves; the first load's late rejection must NOT surface an error.
-      await advance(6_000);
-      expect(screen.getByTestId('option-list')).toBeInTheDocument();
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-    });
-  });
-
-  it('surfaces a non-method-not-found error immediately without retrying', async () => {
-    mockSendCommand.mockRejectedValue(new Error('network error'));
+  it('shows a friendly error and a Retry button when the read is a PlatformError', () => {
+    configureHooks({ value: newPlatformError('boom'), isLoading: false });
     renderStep();
 
-    await waitFor(() =>
-      expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument(),
-    );
+    expect(screen.getByText(/couldn't get things ready/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
-    expect(mockSendCommand).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/boom/i)).not.toBeInTheDocument();
+  });
+
+  it('recovers when Retry remounts the subscription and the read then succeeds', async () => {
+    // First render errors.
+    configureHooks({ value: newPlatformError('boom'), isLoading: false });
+    renderStep();
+
+    // Reconfigure the mock BEFORE clicking Retry so the remounted InternetSettingsLoaded
+    // picks up MOCK_SETTINGS on its first render. (The mock is synchronous; it takes effect
+    // on the next call to useData, which happens when the component remounts.)
+    configureHooks({ value: MOCK_SETTINGS, isLoading: false });
+    await userEvent.click(screen.getByRole('button', { name: /retry/i }));
+
+    await waitFor(() => expect(screen.getByTestId('option-list')).toBeInTheDocument());
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
   });
 });

--- a/src/renderer/components/first-run/steps/internet-settings-step.component.test.tsx
+++ b/src/renderer/components/first-run/steps/internet-settings-step.component.test.tsx
@@ -6,6 +6,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import userEvent from '@testing-library/user-event';
 import { useDataProvider, useData } from '@renderer/hooks/papi-hooks';
+import { logger } from '@shared/services/logger.service';
 import { newPlatformError } from 'platform-bible-utils';
 import type { FirstRunStepProps } from '../first-run-step-props.model';
 import { InternetSettingsStep } from './internet-settings-step.component';
@@ -25,6 +26,10 @@ vi.mock('@renderer/hooks/papi-hooks', () => ({
   ]),
   useDataProvider: vi.fn(),
   useData: vi.fn(),
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { warn: vi.fn() },
 }));
 
 vi.mock('platform-bible-react', () => ({
@@ -49,8 +54,19 @@ vi.mock('platform-bible-react', () => ({
 }));
 
 vi.mock('platform-bible-react/experimental', () => ({
-  InternetAccessOptionList: ({ onChange }: { onChange: (value: string) => void }) => (
-    <button data-testid="option-list" type="button" onClick={() => onChange('Enabled')}>
+  InternetAccessOptionList: ({
+    value,
+    onChange,
+  }: {
+    value: string;
+    onChange: (value: string) => void;
+  }) => (
+    <button
+      data-testid="option-list"
+      data-value={value}
+      type="button"
+      onClick={() => onChange('Enabled')}
+    >
       option list
     </button>
   ),
@@ -82,7 +98,9 @@ function configureHooks(opts: {
   isLoading?: boolean;
   setData?: ReturnType<typeof vi.fn>;
 }) {
-  const setData = opts.setData ?? vi.fn().mockResolvedValue(undefined);
+  // `'setData' in opts` so a caller can force setData === undefined (provider not yet resolved);
+  // omitting it defaults to a resolving spy.
+  const setData = 'setData' in opts ? opts.setData : vi.fn().mockResolvedValue(undefined);
   vi.mocked(useDataProvider).mockReturnValue(
     // opts.provider is `unknown` by design so the helper can accept both undefined and a branded
     // object; typing this precisely would require a complex generic that adds no test value.
@@ -117,12 +135,14 @@ describe('InternetSettingsStep', () => {
     expect(setCanProceed).toHaveBeenCalledWith(false);
   });
 
-  it('shows a spinner while the provider is available but data is still loading', () => {
+  it('shows a spinner and keeps Next disabled while the provider is available but data is still loading', () => {
     configureHooks({ isLoading: true });
-    renderStep();
+    const { setCanProceed } = renderStep();
 
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
     expect(screen.queryByTestId('option-list')).not.toBeInTheDocument();
+    // Next must NOT be enabled while the first read is still loading and the spinner is showing.
+    expect(setCanProceed).not.toHaveBeenCalledWith(true);
   });
 
   it('renders the settings form and enables Next once data has loaded', async () => {
@@ -156,13 +176,44 @@ describe('InternetSettingsStep', () => {
     expect(calls.at(-1)).toBe(false);
   });
 
-  it('shows a friendly error and a Retry button when the read is a PlatformError', () => {
-    configureHooks({ value: newPlatformError('boom'), isLoading: false });
+  it('reverts the displayed selection to the last-good value when a save fails', async () => {
+    const setData = vi.fn().mockRejectedValue(new Error('save failed'));
+    configureHooks({ value: MOCK_SETTINGS, setData });
     renderStep();
+
+    // Loaded value is VpnRequired; the click optimistically switches to Enabled, then the failed
+    // save must revert the displayed value back to VpnRequired (lastGood).
+    expect(screen.getByTestId('option-list')).toHaveAttribute('data-value', 'VpnRequired');
+    await userEvent.click(screen.getByTestId('option-list'));
+
+    await waitFor(() =>
+      expect(screen.getByTestId('option-list')).toHaveAttribute('data-value', 'VpnRequired'),
+    );
+  });
+
+  it('bails without persisting or reporting success when setData is unavailable', async () => {
+    // A defined provider whose useData has not yet produced a setter (setData === undefined).
+    configureHooks({ value: MOCK_SETTINGS, setData: undefined });
+    renderStep();
+
+    await userEvent.click(screen.getByTestId('option-list'));
+
+    // The guard warns and returns before the optimistic update, so the selection does not change and
+    // no false "saved" state is reported.
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('unavailable'));
+    expect(screen.getByTestId('option-list')).toHaveAttribute('data-value', 'VpnRequired');
+  });
+
+  it('shows a friendly error, a Retry button, and keeps Next disabled when the read is a PlatformError', () => {
+    configureHooks({ value: newPlatformError('boom'), isLoading: false });
+    const { setCanProceed } = renderStep();
 
     expect(screen.getByText(/couldn't get things ready/i)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
     expect(screen.queryByText(/boom/i)).not.toBeInTheDocument();
+    // Next must be disabled on the error screen so the wizard can't advance past an unloaded step.
+    expect(setCanProceed).toHaveBeenCalledWith(false);
+    expect(setCanProceed).not.toHaveBeenCalledWith(true);
   });
 
   it('recovers when Retry remounts the subscription and the read then succeeds', async () => {

--- a/src/renderer/components/first-run/steps/internet-settings-step.component.tsx
+++ b/src/renderer/components/first-run/steps/internet-settings-step.component.tsx
@@ -8,7 +8,12 @@ import {
 } from 'platform-bible-react/experimental';
 import { useData, useDataProvider, useLocalizedStrings } from '@renderer/hooks/papi-hooks';
 import { useDelayedFlag } from '@renderer/hooks/use-delayed-flag.hook';
-import { getErrorMessage, isPlatformError, type LocalizeKey } from 'platform-bible-utils';
+import {
+  getErrorMessage,
+  isPlatformError,
+  type LanguageStrings,
+  type LocalizeKey,
+} from 'platform-bible-utils';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FirstRunStepProps } from '../first-run-step-props.model';
 import { StepLoading } from '../step-loading.component';
@@ -85,7 +90,7 @@ export function InternetSettingsStep(props: FirstRunStepProps) {
 
 type LoadedProps = {
   provider: NonNullable<ReturnType<typeof useDataProvider<typeof INTERNET_SETTINGS_DATA_PROVIDER>>>;
-  localizedStrings: Record<string, string>;
+  localizedStrings: LanguageStrings;
   setCanProceed: FirstRunStepProps['setCanProceed'];
   onRetry: () => void;
 };
@@ -111,7 +116,7 @@ function InternetSettingsLoaded({
   const [isSaving, setIsSaving] = useState(false);
   const isMounted = useRef(false);
   // Last value we successfully displayed, so a failed optimistic save can revert to it.
-  const lastGood = useRef<InternetSettings | undefined>();
+  const lastGood = useRef<InternetSettings | undefined>(undefined);
 
   const showConnectingMessage = useDelayedFlag(
     isLoading && !isPlatformError(value),

--- a/src/renderer/components/first-run/steps/internet-settings-step.component.tsx
+++ b/src/renderer/components/first-run/steps/internet-settings-step.component.tsx
@@ -1,4 +1,4 @@
-import type { InternetSettings } from 'paratext-registration';
+import type { InternetSettings, IInternetSettingsDataProvider } from 'paratext-registration';
 import { Alert, AlertDescription, Button } from 'platform-bible-react';
 import {
   DeveloperSection,
@@ -8,6 +8,7 @@ import {
 } from 'platform-bible-react/experimental';
 import { useData, useDataProvider, useLocalizedStrings } from '@renderer/hooks/papi-hooks';
 import { useDelayedFlag } from '@renderer/hooks/use-delayed-flag.hook';
+import { logger } from '@shared/services/logger.service';
 import {
   getErrorMessage,
   isPlatformError,
@@ -31,8 +32,10 @@ const STRING_KEYS: LocalizeKey[] = [
 ];
 
 // `useData`'s defaultValue is typed as the data type's getData (InternetSettings), so it cannot be
-// undefined. This value is never shown to the user — the spinner covers the load. Mirrors the
-// standalone dialog's default.
+// undefined. This value is never shown to the user — the spinner covers the load. Intentionally
+// duplicated in the standalone dialog (internet-settings.web-view.tsx): the two consumers sit on
+// opposite sides of the core/extension boundary and `paratext-registration` is a types-only module,
+// so there is no shared runtime module to hoist this into.
 const DEFAULT_INTERNET_SETTINGS: InternetSettings = {
   permittedInternetUse: 'VpnRequired',
   selectedServer: 'Production',
@@ -89,7 +92,7 @@ export function InternetSettingsStep(props: FirstRunStepProps) {
 }
 
 type LoadedProps = {
-  provider: NonNullable<ReturnType<typeof useDataProvider<typeof INTERNET_SETTINGS_DATA_PROVIDER>>>;
+  provider: IInternetSettingsDataProvider;
   localizedStrings: LanguageStrings;
   setCanProceed: FirstRunStepProps['setCanProceed'];
   onRetry: () => void;
@@ -118,10 +121,8 @@ function InternetSettingsLoaded({
   // Last value we successfully displayed, so a failed optimistic save can revert to it.
   const lastGood = useRef<InternetSettings | undefined>(undefined);
 
-  const showConnectingMessage = useDelayedFlag(
-    isLoading && !isPlatformError(value),
-    CONNECTING_MESSAGE_DELAY_MS,
-  );
+  // When loading, value is the default placeholder, never a PlatformError — so gate on isLoading alone.
+  const showConnectingMessage = useDelayedFlag(isLoading, CONNECTING_MESSAGE_DELAY_MS);
 
   useEffect(() => {
     isMounted.current = true;
@@ -130,23 +131,36 @@ function InternetSettingsLoaded({
     };
   }, []);
 
-  // Sync the local mirror from the provider value whenever it changes and no save is pending/failed.
+  // Sync the local mirror from the provider value. While loading (value is still the default) or
+  // while a save is pending/failed, handleChange and the loading render own the state — defer. Once
+  // a real value is in, enable Next; if the read is an error, keep Next disabled so the wizard can't
+  // advance past an unloaded step.
   useEffect(() => {
-    if (isPlatformError(value) || isSaving || saveError) return;
+    if (isLoading || isSaving || saveError) return;
+    if (isPlatformError(value)) {
+      setCanProceed?.(false);
+      return;
+    }
     setSettings(value);
     lastGood.current = value;
     setCanProceed?.(true);
-  }, [value, isSaving, saveError, setCanProceed]);
+  }, [value, isLoading, isSaving, saveError, setCanProceed]);
 
   const handleChange = useCallback(
     async (next: InternetSettings) => {
       if (isSaving) return;
+      if (!setData) {
+        // Defensive: InternetSettingsLoaded renders only once `provider` is defined, so `setData` is
+        // always defined here. Bail rather than reporting a save that never actually persisted.
+        logger.warn('Internet settings provider unavailable; ignoring selection change.');
+        return;
+      }
       setSettings(next); // optimistic
       setSaveError('');
       setIsSaving(true);
       setCanProceed?.(false);
       try {
-        await setData?.(next);
+        await setData(next);
         if (!isMounted.current) return;
         lastGood.current = next;
         setIsSaving(false);

--- a/src/renderer/components/first-run/steps/internet-settings-step.component.tsx
+++ b/src/renderer/components/first-run/steps/internet-settings-step.component.tsx
@@ -6,23 +6,17 @@ import {
   InternetAccessOptionList,
   INTERNET_ACCESS_OPTION_LIST_STRING_KEYS,
 } from 'platform-bible-react/experimental';
-import { useLocalizedStrings } from '@renderer/hooks/papi-hooks';
+import { useData, useDataProvider, useLocalizedStrings } from '@renderer/hooks/papi-hooks';
 import { useDelayedFlag } from '@renderer/hooks/use-delayed-flag.hook';
-import { sendCommand } from '@shared/services/command.service';
-import {
-  getJsonRpcRequestErrorMessagePrefix,
-  JSON_RPC_REQUEST_TIMED_OUT_MESSAGE_PREFIX,
-} from '@shared/data/rpc.model';
-import { logger } from '@shared/services/logger.service';
-import { JSONRPCErrorCode } from 'json-rpc-2.0';
-import { getErrorMessage, wait, type LocalizeKey } from 'platform-bible-utils';
+import { getErrorMessage, isPlatformError, type LocalizeKey } from 'platform-bible-utils';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { FirstRunStepProps } from '../first-run-step-props.model';
 import { StepLoading } from '../step-loading.component';
 
-// `%internetSettings_button_retry%` is localized by the paratext-registration extension itself; the
-// `%firstRun_*%` keys live in core's assets/localization. The combiner merges both sets at runtime,
-// so this step doesn't need to add the extension's key to core's localization.
+const INTERNET_SETTINGS_DATA_PROVIDER = 'paratextRegistration.internetSettingsDataProvider';
+
+// `internetSettings_*` keys come from the paratext-registration extension, `firstRun_*` from core
+// (assets/localization). Both merge in the combiner, so the extension keys need no en.json entry.
 const STRING_KEYS: LocalizeKey[] = [
   '%internetSettings_button_retry%',
   '%firstRun_step_internetSettings_connecting%',
@@ -31,67 +25,98 @@ const STRING_KEYS: LocalizeKey[] = [
   ...DEVELOPER_SECTION_STRING_KEYS,
 ];
 
-// A first-run cold start can mount this step before the paratext-registration handlers register, so
-// fetchInternetSettings() rejects with JSON-RPC "method not found". The command layer already retries
-// that (~10 s per call, rpc.model.ts); registration can outlast one call, so we re-issue until the
-// budget is spent. Matched via the shared producer so it can't drift from the RPC error format.
-const METHOD_NOT_FOUND_MESSAGE_PREFIX = getJsonRpcRequestErrorMessagePrefix(
-  JSONRPCErrorCode.MethodNotFound,
-);
-// Wall-clock budget for the whole retry loop below. A method-not-found rejection returns in ~10 s
-// (the command layer's own retry), so roughly two or three outer re-issues fit within this budget;
-// a call that instead hits the full ~30 s client timeout consumes the budget in a single attempt.
-// Generous on purpose. Compare the sibling resolve-registration-validity.ts
-// (REGISTRATION_RESOLVE_TIMEOUT_MS).
-const SERVICE_STARTUP_BUDGET_MS = 30_000;
-// Backoff between re-issues; only bites when a call rejects fast (a real method-not-found call already
-// spent ~10 s upstream).
-const SERVICE_STARTUP_RETRY_DELAY_MS = 500;
+// `useData`'s defaultValue is typed as the data type's getData (InternetSettings), so it cannot be
+// undefined. This value is never shown to the user — the spinner covers the load. Mirrors the
+// standalone dialog's default.
+const DEFAULT_INTERNET_SETTINGS: InternetSettings = {
+  permittedInternetUse: 'VpnRequired',
+  selectedServer: 'Production',
+  proxyPort: 0,
+};
 
-/**
- * A failure worth retrying within the startup budget: the handler isn't registered yet, or the
- * request timed out client-side (an overloaded provider mid-cold-start). Any other error is a real
- * failure that a retry won't fix.
- */
-function isTransientStartupError(errorMessage: string): boolean {
-  return (
-    errorMessage.includes(METHOD_NOT_FOUND_MESSAGE_PREFIX) ||
-    errorMessage.includes(JSON_RPC_REQUEST_TIMED_OUT_MESSAGE_PREFIX)
-  );
-}
-
-async function fetchInternetSettings() {
-  return sendCommand('paratextRegistration.getParatextDataInternetSettings');
-}
-
-async function persistInternetSettings(settings: InternetSettings) {
-  return sendCommand('paratextRegistration.setParatextDataInternetSettings', settings);
-}
+// Show the "getting ready" message after this much elapsed loading time.
+const CONNECTING_MESSAGE_DELAY_MS = 2_000;
 
 /**
  * First-run wizard step that lets the user configure internet access before registration. Saves
  * immediately on each selection change (immediate-apply model). The identify step's restart applies
  * the chosen setting — no second restart is needed here.
  *
- * Save concurrency: only one save is in flight at a time. A second selection while a save is
- * pending is ignored (the control is disabled). This prevents out-of-order saves from leaving
- * persisted state inconsistent with the displayed state.
+ * Availability: `useDataProvider` returns `undefined` until the C# InternetSettingsDataProvider
+ * registers, giving a natural spinner without any startup-race retry heuristics.
  */
-export function InternetSettingsStep({ setCanProceed }: FirstRunStepProps) {
+export function InternetSettingsStep(props: FirstRunStepProps) {
+  const { setCanProceed } = props;
+  const provider = useDataProvider(INTERNET_SETTINGS_DATA_PROVIDER);
+  // Bumped by Retry to remount the loaded subcomponent and re-subscribe from scratch.
+  const [retryCount, setRetryCount] = useState(0);
+
+  // While the provider is not yet registered, show the loading panel. Disable Next here so the
+  // wizard can't advance before settings are readable.
+  const showConnectingMessage = useDelayedFlag(provider === undefined, CONNECTING_MESSAGE_DELAY_MS);
   const [localizedStrings] = useLocalizedStrings(STRING_KEYS);
+
+  useEffect(() => {
+    if (provider === undefined) setCanProceed?.(false);
+  }, [provider, setCanProceed]);
+
+  if (provider === undefined) {
+    return (
+      <StepLoading
+        message={
+          showConnectingMessage
+            ? localizedStrings['%firstRun_step_internetSettings_connecting%']
+            : undefined
+        }
+      />
+    );
+  }
+
+  return (
+    <InternetSettingsLoaded
+      key={retryCount}
+      provider={provider}
+      localizedStrings={localizedStrings}
+      setCanProceed={setCanProceed}
+      onRetry={() => setRetryCount((c) => c + 1)}
+    />
+  );
+}
+
+type LoadedProps = {
+  provider: NonNullable<ReturnType<typeof useDataProvider<typeof INTERNET_SETTINGS_DATA_PROVIDER>>>;
+  localizedStrings: Record<string, string>;
+  setCanProceed: FirstRunStepProps['setCanProceed'];
+  onRetry: () => void;
+};
+
+/**
+ * Rendered only once the provider is available. Reads via `useData` (live cross-window updates) and
+ * keeps a thin local mirror so the radio responds instantly on selection (optimistic apply), while
+ * the actual persist goes through `setData`.
+ */
+function InternetSettingsLoaded({
+  provider,
+  localizedStrings,
+  setCanProceed,
+  onRetry,
+}: LoadedProps) {
+  const [value, setData, isLoading] = useData(provider).InternetSettings(
+    undefined,
+    DEFAULT_INTERNET_SETTINGS,
+  );
+
   const [settings, setSettings] = useState<InternetSettings | undefined>();
-  const [loadFailed, setLoadFailed] = useState(false);
   const [saveError, setSaveError] = useState('');
   const [isSaving, setIsSaving] = useState(false);
   const isMounted = useRef(false);
-  // Bumped on each load() so a stale run (e.g. a superseded retry) can't write state over a newer one.
-  const loadGeneration = useRef(0);
+  // Last value we successfully displayed, so a failed optimistic save can revert to it.
+  const lastGood = useRef<InternetSettings | undefined>();
 
-  // Reveal the "getting ready" message only once the load has been slow for a beat (the hook's
-  // default delay) — active whenever we're still loading (no settings yet, not failed). This is
-  // elapsed time, not attempt count; a single attempt can block ~10 s. Declarative timer; no manual
-  // setTimeout here.
-  const showConnectingMessage = useDelayedFlag(!settings && !loadFailed);
+  const showConnectingMessage = useDelayedFlag(
+    isLoading && !isPlatformError(value),
+    CONNECTING_MESSAGE_DELAY_MS,
+  );
 
   useEffect(() => {
     isMounted.current = true;
@@ -100,71 +125,39 @@ export function InternetSettingsStep({ setCanProceed }: FirstRunStepProps) {
     };
   }, []);
 
-  const load = useCallback(async () => {
-    loadGeneration.current += 1;
-    const generation = loadGeneration.current;
-    const isStale = () => !isMounted.current || loadGeneration.current !== generation;
-
-    setCanProceed?.(false);
-    setLoadFailed(false);
-
-    const deadline = Date.now() + SERVICE_STARTUP_BUDGET_MS;
-    let lastErrorMessage = '';
-    while (Date.now() < deadline) {
-      try {
-        // Attempts are inherently sequential — each must finish before we decide to retry.
-        // eslint-disable-next-line no-await-in-loop
-        const loaded = await fetchInternetSettings();
-        if (isStale()) return;
-        setSettings(loaded);
-        setCanProceed?.(true);
-        return;
-      } catch (err: unknown) {
-        if (isStale()) return;
-        lastErrorMessage = getErrorMessage(err);
-        if (!isTransientStartupError(lastErrorMessage)) break;
-        // Small backoff so a fast-rejecting handler can't spin the loop.
-        // eslint-disable-next-line no-await-in-loop
-        await wait(SERVICE_STARTUP_RETRY_DELAY_MS);
-      }
-    }
-    // Fell through: a non-transient error, or the budget ran out while still unregistered.
-    if (isStale()) return;
-    // Show a friendly message; keep the raw RPC error in the log for debugging. A generic message is
-    // right here: GetParatextDataInternetSettings (ParatextRegistrationService.cs) only reads local
-    // config, so it can't surface the actionable internet-blocked / auth-failure errors other data
-    // loads classify — its failures are startup/internal, and a Retry is the right affordance.
-    logger.warn(`Could not load internet settings: ${lastErrorMessage}`);
-    setLoadFailed(true);
-  }, [setCanProceed]);
-
+  // Sync the local mirror from the provider value whenever it changes and no save is pending/failed.
   useEffect(() => {
-    load();
-  }, [load]);
+    if (isPlatformError(value) || isSaving || saveError) return;
+    setSettings(value);
+    lastGood.current = value;
+    setCanProceed?.(true);
+  }, [value, isSaving, saveError, setCanProceed]);
 
   const handleChange = useCallback(
     async (next: InternetSettings) => {
       if (isSaving) return;
-      setSettings(next);
+      setSettings(next); // optimistic
       setSaveError('');
       setIsSaving(true);
       setCanProceed?.(false);
       try {
-        await persistInternetSettings(next);
+        await setData?.(next);
         if (!isMounted.current) return;
+        lastGood.current = next;
         setIsSaving(false);
         setCanProceed?.(true);
       } catch (err: unknown) {
         if (!isMounted.current) return;
+        setSettings(lastGood.current); // revert
         setIsSaving(false);
         setSaveError(getErrorMessage(err));
         setCanProceed?.(false);
       }
     },
-    [setCanProceed, isSaving],
+    [isSaving, setData, setCanProceed],
   );
 
-  if (loadFailed) {
+  if (isPlatformError(value)) {
     return (
       <div className="tw:flex tw:flex-col tw:gap-4">
         <Alert variant="destructive">
@@ -172,14 +165,14 @@ export function InternetSettingsStep({ setCanProceed }: FirstRunStepProps) {
             {localizedStrings['%firstRun_step_internetSettings_loadError%']}
           </AlertDescription>
         </Alert>
-        <Button variant="outline" onClick={load}>
+        <Button variant="outline" onClick={onRetry}>
           {localizedStrings['%internetSettings_button_retry%']}
         </Button>
       </div>
     );
   }
 
-  if (!settings) {
+  if (isLoading || !settings) {
     return (
       <StepLoading
         message={

--- a/src/renderer/components/first-run/steps/internet-settings-step.component.tsx
+++ b/src/renderer/components/first-run/steps/internet-settings-step.component.tsx
@@ -42,9 +42,6 @@ const DEFAULT_INTERNET_SETTINGS: InternetSettings = {
   proxyPort: 0,
 };
 
-// Show the "getting ready" message after this much elapsed loading time.
-const CONNECTING_MESSAGE_DELAY_MS = 2_000;
-
 /**
  * First-run wizard step that lets the user configure internet access before registration. Saves
  * immediately on each selection change (immediate-apply model). The identify step's restart applies
@@ -61,7 +58,7 @@ export function InternetSettingsStep(props: FirstRunStepProps) {
 
   // While the provider is not yet registered, show the loading panel. Disable Next here so the
   // wizard can't advance before settings are readable.
-  const showConnectingMessage = useDelayedFlag(provider === undefined, CONNECTING_MESSAGE_DELAY_MS);
+  const showConnectingMessage = useDelayedFlag(provider === undefined);
   const [localizedStrings] = useLocalizedStrings(STRING_KEYS);
 
   useEffect(() => {
@@ -122,7 +119,7 @@ function InternetSettingsLoaded({
   const lastGood = useRef<InternetSettings | undefined>(undefined);
 
   // When loading, value is the default placeholder, never a PlatformError — so gate on isLoading alone.
-  const showConnectingMessage = useDelayedFlag(isLoading, CONNECTING_MESSAGE_DELAY_MS);
+  const showConnectingMessage = useDelayedFlag(isLoading);
 
   useEffect(() => {
     isMounted.current = true;

--- a/src/renderer/components/first-run/steps/internet-settings-step.stories.tsx
+++ b/src/renderer/components/first-run/steps/internet-settings-step.stories.tsx
@@ -1,8 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { spyOn, restoreAllMocks } from 'storybook/test';
-import * as commandService from '@shared/services/command.service';
-import { getJsonRpcRequestErrorMessagePrefix } from '@shared/data/rpc.model';
-import { JSONRPCErrorCode } from 'json-rpc-2.0';
+import { newPlatformError } from 'platform-bible-utils';
+import * as papiHooks from '@renderer/hooks/papi-hooks';
 import { InternetSettingsStep } from './internet-settings-step.component';
 
 const MOCK_SETTINGS = {
@@ -10,6 +9,32 @@ const MOCK_SETTINGS = {
   selectedServer: 'Production' as const,
   proxyPort: 0,
 };
+
+// Stands in for the resolved data-provider object; the component only forwards it to useData, which
+// is mocked here and ignores it.
+const PROVIDER = { __brand: 'internetSettingsDataProvider' };
+
+/**
+ * Point useDataProvider/useData at a chosen state, mirroring how the component consumes them.
+ * `provider: undefined` simulates the provider not yet registered (the outer spinner); otherwise
+ * useData yields `[value, setData, isLoading]`. Returns a cleanup that restores the spies.
+ */
+function mockHooks(config: { provider?: unknown; value?: unknown; isLoading?: boolean } = {}) {
+  // `'provider' in config` so a story can force provider === undefined (not-yet-registered).
+  const provider = 'provider' in config ? config.provider : PROVIDER;
+  const value = config.value ?? MOCK_SETTINGS;
+  const isLoading = config.isLoading ?? false;
+  // Storybook mock stand-ins; the precise curried useDataProvider/useData types add no value here
+  // and would couple the story to internal hook shapes.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion -- Storybook mock stand-in
+  spyOn(papiHooks, 'useDataProvider').mockReturnValue(provider as never);
+  // Same rationale as the useDataProvider mock above.
+  // eslint-disable-next-line no-type-assertion/no-type-assertion -- Storybook mock stand-in
+  spyOn(papiHooks, 'useData').mockReturnValue({
+    InternetSettings: () => [value, async () => undefined, isLoading],
+  } as never);
+  return () => restoreAllMocks();
+}
 
 const meta: Meta<typeof InternetSettingsStep> = {
   title: 'First Run/InternetSettingsStep',
@@ -20,40 +45,29 @@ const meta: Meta<typeof InternetSettingsStep> = {
     setCanProceed: () => {},
   },
   beforeEach() {
-    // Default: fetch resolves with production/vpn-required settings.
-    spyOn(commandService, 'sendCommand').mockResolvedValue(MOCK_SETTINGS);
-    return () => restoreAllMocks();
+    // Default: provider available, settings loaded (VPN Required).
+    return mockHooks();
   },
 };
 export default meta;
 
 type Story = StoryObj<typeof InternetSettingsStep>;
 
-/** Spinner is shown while settings are loading; Next is disabled. */
-export const Loading: Story = {
+/**
+ * The data provider hasn't registered yet (`useDataProvider` returns `undefined`) — the natural
+ * availability signal. The spinner shows and Next is disabled; after a short delay the "Getting
+ * things ready…" message appears below it.
+ */
+export const ProviderRegistering: Story = {
   beforeEach() {
-    spyOn(commandService, 'sendCommand').mockImplementation(
-      () => new Promise(() => {}), // never resolves — keeps component in loading state
-    );
-    return () => restoreAllMocks();
+    return mockHooks({ provider: undefined });
   },
 };
 
-/**
- * Startup race: the data provider hasn't registered its handlers yet, so the fetch keeps failing
- * with JSON-RPC "method not found". After the wall-clock delay the "Setting things up for the first
- * time…" message appears below the spinner. (Retries continue in the background until they succeed
- * or the startup budget is spent, after which the error + Retry is shown.)
- */
-export const ConnectingToService: Story = {
+/** Provider registered but the first read is still in flight (`isLoading`): spinner, Next disabled. */
+export const Loading: Story = {
   beforeEach() {
-    spyOn(commandService, 'sendCommand').mockRejectedValue(
-      // Same message shape the RPC layer actually throws, built from its own producer.
-      new Error(
-        `${getJsonRpcRequestErrorMessagePrefix(JSONRPCErrorCode.MethodNotFound)}: not found`,
-      ),
-    );
-    return () => restoreAllMocks();
+    return mockHooks({ isLoading: true });
   },
 };
 
@@ -63,18 +77,13 @@ export const Default: Story = {};
 /** Enabled (unrestricted internet) option pre-selected. */
 export const Enabled: Story = {
   beforeEach() {
-    spyOn(commandService, 'sendCommand').mockResolvedValue({
-      ...MOCK_SETTINGS,
-      permittedInternetUse: 'Enabled',
-    });
-    return () => restoreAllMocks();
+    return mockHooks({ value: { ...MOCK_SETTINGS, permittedInternetUse: 'Enabled' } });
   },
 };
 
-/** Error alert shown and Retry button visible when the initial fetch fails. */
-export const FetchError: Story = {
+/** The read failed (a `PlatformError` from the provider): friendly error alert and a Retry button. */
+export const LoadError: Story = {
   beforeEach() {
-    spyOn(commandService, 'sendCommand').mockRejectedValue(new Error('Connection refused'));
-    return () => restoreAllMocks();
+    return mockHooks({ value: newPlatformError('Connection refused') });
   },
 };


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# PT-4301: Internet Settings command pair → PAPI data provider

> **TL;DR** — Turns two PAPI commands into a data provider so the UI shows a spinner via `useDataProvider` instead of the PT-4300 retry loop, and gets live updates via `useData`. The `InternetAccess` read/write logic is unchanged (moved verbatim). Old commands are kept as `@deprecated` wrappers.

**Branch**: `pt-4301-internet-settings-data-provider` · **Base**: `pt-4300-internet-bug` (stacked — retarget to `main` after PT-4300 merges) · **Files**: 11 · **Reviewed with**: `/review-paratext` (Claude Opus 4.8)

## What changed

- **New C# data provider** `InternetSettingsDataProvider` (`get`/`set` + `SendDataUpdateEvent`); settings logic moved out of `ParatextRegistrationService`.
- **Two commands deprecated, not removed** — thin `@deprecated` wrappers delegate to the provider (out-of-repo extensions keep working).
- **Pure C# logic extracted** into `InternetSettingsLogic` + **22 new unit tests** (that branching was previously untested).
- **Both consumers migrated** — first-run wizard step and standalone dialog now use `useDataProvider`/`useData`.
- **PT-4300 retry loop deleted** (`StepLoading` + `useDelayedFlag` kept; Retry button kept for genuine load errors).

## How to review this quickly

**You can skip:** the `Get`/`Set` bodies in `InternetSettingsDataProvider.cs` are a **verbatim move** of existing, working logic — no need to re-review them line-by-line.

**Suggested order (the actual new logic):**

1. `…/types/paratext-registration.d.ts` — the contract: new `DataProviders` entry + the two now-`@deprecated` commands.
2. `c-sharp/Users/InternetSettingsLogic.cs` (+ its test) — the extracted rules, now tested.
3. **`…/first-run/steps/internet-settings-step.component.tsx`** — the real behavioral change; read this closest.
4. Skim the rest via the file guide below.

## File guide

| File | What it does |
| --- | --- |
| **`…/first-run/steps/internet-settings-step.component.tsx`** | **Main change.** Outer `useDataProvider` spinner; inner `useData`/`setData` with an optimistic local mirror (reverts on save failure) and Retry-on-error. |
| `c-sharp/Users/InternetSettingsDataProvider.cs` _(new)_ | The data provider. `Get/SetInternetSettings` (logic moved verbatim) + `SendDataUpdateEvent` on set so `useData` refreshes. |
| `c-sharp/Users/InternetSettingsLogic.cs` _(new)_ | Pure helpers extracted for testability: secret masking, empty→null, proxy-host clearing, `RawStatus` re-assertion. |
| `c-sharp-tests/Users/InternetSettingsLogicTests.cs` _(new)_ | 22 NUnit tests for the helper (incl. `ProxyOnly`/`Disabled` edge cases). |
| `c-sharp/Users/ParatextRegistrationService.cs` | Removed the settings logic; re-registers the two commands as `@deprecated` wrappers delegating to the provider. |
| `c-sharp/Program.cs` | Builds + background-registers the provider; passes it to `ParatextRegistrationService`. |
| `…/types/paratext-registration.d.ts` | New `DataProviders` entry + provider types; the two commands marked `@deprecated`. |
| `…/internet-settings.web-view.tsx` | Standalone dialog migrated to the provider; stage-then-commit + "Save and restart" unchanged. |
| `…component.test.tsx` / `…stories.tsx` | Wizard tests (9) + Storybook, rewritten to the new hooks. |

## Worth a closer look

- **Wizard gating** — `setCanProceed` keys off `isLoading`/`isPlatformError` so Next can't be enabled during the spinner or on an error screen (the subtlest bit).
- **Deprecation vs removal** — confirm keeping the `@deprecated` wrappers is right, and agree a release to remove them.
- **Dialog Reset baseline is one-shot** — a live cross-window change won't move the dialog's Reset target until it's reopened (deliberate, to preserve stage-then-commit).

## Verified

`typecheck` ✓ · `lint` ✓ · wizard tests **9/9** · `dotnet build` ✓ + `InternetSettingsLogic` **22/22**. (One pre-existing flaky-timeout test in an unrelated suite.) Not unit-tested — worth a runtime smoke: cold-start wizard shows spinner→form (no `-32601`/`-32602`), dialog Save-and-restart works, `.set()` in one surface live-updates the other.

---

<details>
<summary><b>Full review detail</b> — findings, API changes, interview notes, quality-check output</summary>

### API changes

- `paratext-registration` module: **added** `InternetSettingsDataTypes`, `IInternetSettingsDataProvider`. `InternetSettings`, `ServerType`, `InternetUse`, `RegistrationData` unchanged.
- `papi-shared-types`: **added** `DataProviders['paratextRegistration.internetSettingsDataProvider']`.
- `papi-shared-types`: the two `CommandHandlers` entries are **retained but `@deprecated`** (delegating to the provider). No public command was removed — the originally-planned breaking removal was reverted to a deprecation during this review.
- No changes to `lib/platform-bible-react/`, `lib/platform-bible-utils/`, or `lib/papi-dts/papi.d.ts`.

### Findings

`[x] … (fixed during review)` = addressed with a code change; `[ ] ~~…~~ (reason)` = dismissed by the author.

**Critical**

- [x] **Breaking change: the two internet-settings PAPI commands were removed from the public `CommandHandlers`** _(fixed during review: re-added as `@deprecated` wrappers delegating to `InternetSettingsDataProvider.GetInternetSettings()` / `SetInternetSettings(...)`; `ParatextRegistrationService` takes the provider and re-registers them; `.d.ts` re-adds them with `@deprecated` JSDoc. No logic duplicated.)_ — Author confirmed these are probably used by out-of-repo extensions and chose deprecation over removal.

**Important**

- [x] **The C# `Get`/`Set` logic (proxy / `ProxyOnly` / `RawStatus` branching, empty→null, password masking) had no unit tests** _(fixed during review: extracted into `InternetSettingsLogic` + `InternetSettingsLogicTests` (22 passing NUnit tests); provider delegates to the helper and keeps the `InternetAccess` side effects. Behavior verified equivalent, incl. the DBLPassword empty→null edge case.)_ — Author chose to extract + cover now rather than defer.

**Minor** (all dismissed)

- [ ] ~~(UX) Raw `getErrorMessage(err)` shown in the failure alert.~~ _(Pre-existing; load-error path already uses a friendly localized message.)_
- [ ] ~~(API) `// @ts-ignore` vs `@ts-expect-error` on the `@papi/core` import.~~ _(Deliberate: matches every sibling `.d.ts`; `@ts-expect-error` would error in the extensions workspace where the module resolves.)_
- [ ] ~~(Style) Provider-ID string repeated in both consumers + the `.d.ts` key.~~ _(Small DRY nit, unavoidable across the core/extension boundary — same as the documented `DEFAULT_INTERNET_SETTINGS` duplication.)_
- [ ] ~~(Compliance) Localization.~~ _(All keys resolve; no hardcoded UI text.)_

### Template propagation

None. No `#region shared with` markers overlap the changes; no extension config/build files changed.

### Positive observations

- C# provider cleanly follows the data-provider contract (`internal sealed`, `GetFunctions()`, `get*`/`set*` → `InternetSettings` data type, `SendDataUpdateEvent` on set) — matches `InventoryDataProvider`.
- `InternetAccess` logic moved verbatim (no behavioral drift); no dead code left (retry mechanism, `usePromise` wrapper, duplicate `PLACEHOLDER_PASSWORD` all removed).
- Both apply-models preserved: dialog = explicit stage-then-commit; wizard = immediate/optimistic apply, now with an explicit revert-to-`lastGood` on save failure.
- Loading UX preserved (spinner + delayed message via natural readiness signals); `setCanProceed(false)` blocks advancing past an unloaded/errored step.
- Microcopy untouched and fully localized; all keys resolve. First-run logic thoroughly covered by behavior-focused tests; Storybook updated to the new surface.
- Non-obvious control-flow (readiness gating on `setData`, stage-then-commit sync-once, optimistic apply + `lastGood` revert, defensive `!setData` bail-outs) is well-commented; the intentional cross-boundary `DEFAULT_INTERNET_SETTINGS` duplication is documented at both sites.

### Interview notes

- **Purpose** (author): convert the commands to a data provider so consumers gate on `useDataProvider`, remove the PT-4300 retry workaround (keep `StepLoading`/`useDelayedFlag` + Retry for genuine errors), and gain live cross-window updates.
- **Base**: stacked on `pt-4300-internet-bug` (PR #2634, unmerged); review scoped to the PT-4301 commits by diffing against that base. Retarget to `main` after PT-4300 merges.
- **In-review decisions**: (1) deprecate rather than remove the commands; (2) extract + test the C# logic now. Author reasoned through both clearly; no design walk-through needed, no unresolved items, nothing deferred to AI as unexplained.

### In-review quality check

- `npm run typecheck` — passed (all 12 workspaces, incl. the re-added `@deprecated` command types).
- `npm run lint` — passed (only pre-existing warnings in unrelated files).
- Prettier (changed files only) — reformatted JSDoc lines in `paratext-registration.d.ts`; committed.
- `npm test` — `internet-settings-step.component.test.tsx` **9/9**; full suite 1406 passed with **1 pre-existing flaky-timeout** (`network-object-status.service.test.ts`, unrelated).
- `dotnet build` — succeeded (0/0); `InternetSettingsLogicTests` **22/22**.

</details>
<!-- review-paratext:summary:end -->

AI-assisted — Claude Opus 4.8 via Claude Code (VS Code extension; no shareable session URL).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2643)
<!-- Reviewable:end -->
