### PR TITLE
docs: update Window terminology for multi-window (UX review)

### DIFF
--- a/lib/platform-bible-react/src/stories/guidelines/terms.mdx
+++ b/lib/platform-bible-react/src/stories/guidelines/terms.mdx
@@ -4,14 +4,14 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 # Terminology
 
-- `Window`: An operating system window that contains some interface. We currently support having only one of these in Platform.Bible (and therefore Paratext 10 Studio) right now. We call it the app window.
+- `Window`: An operating system window that contains some interface. Platform.Bible supports having more than one open at a time. Actions you start — opening settings, a dialog, a notification — happen in the window you are working in.
 - `App title bar`: The horizontal bar at the top of the application, holding the [App Menu](https://github.com/paranext/paranext-core/blob/main/lib/platform-bible-react/src/stories/guidelines/application-interactions.mdx#menus), other controls (e.g. for [Scripture Reference Selection](https://github.com/paranext/paranext-core/blob/main/lib/platform-bible-react/src/stories/guidelines/application-interactions.mdx#scripture-reference-selection) and the OS window controls.
 - `Dock layout`: A feature of an interface that lets you have multiple independent sub-interfaces that share space within it and can be laid out together, dragged around, popped out to floating so they don't share space with the others anymore, etc. We use a significantly customized [rc-dock](https://ticlo.github.io/rc-dock/) for this in Platform.Bible.
 - `Tab`: The combination of a `tab content` and a `tab header`
 - `Tab header`: Holds a title for the tab and represents that tab, can be used for dragging and has a [Context Menu](https://paranext.github.io/paranext-core/platform-bible-react-storybook/?path=/docs/shadcn-contextmenu--docs).
 - `Tab content`: The sub-interface of a tab in the dock layout (basically, a rectangle that is resizeable and in which you can put some UI)
 - `Tab group`: A set of tabs that are sharing the same space in the dock layout, so you can see all of their tab headers but only one tab content at a time
-- `Floating tab group`: A tab group that is not within the shared space of the dock layout but is popped out of that shared space and is instead in front of the other tabs. It kinda feels like a separate window in that it has its own independent rectangle, but it's not literally a separate window; it's still in the same app window.
+- `Floating tab group`: A tab group that is not within the shared space of the dock layout but is popped out of that shared space and is instead in front of the other tabs. It kinda feels like a separate window in that it has its own independent rectangle, but it's not literally a separate window; it's still inside the same `Window`.
 - `WebView`: A specific type of tab content whose contents are wrapped in an iframe. You can generally think of all extension-provided UI as a WebView.
 - `webViewType`: ID indicating what type of content a WebView has and from where it gets that content. There may be multiple WebViews with the same webViewType.
 - `WebView Provider`: An object registered with the PAPI that the PAPI calls to get the content of a WebView of a particular webViewType. Right now (and possibly forever), all WebViews are provided by extensions' WebView Providers. There is one WebView Provider for each webViewType.


### PR DESCRIPTION
Two-line terminology update split out of the multi-window PR (#2621) so the UX team can review its guidelines change on its own — `lib/platform-bible-react/src/stories/guidelines/` is UX-team-owned per `.claude/rules/where-to-add-guidance.md`.

- `Window`: no longer claims only one OS window is supported; describes that actions land in the window you are working in.
- `Floating tab group`: closing clause references the `Window` term instead of the retired "app window" phrasing.

**Merge after #2621** — the new wording describes behavior that ships there. Content was verified against the delivered multi-window code; this PR exists purely so the UX-ownership review happens where the rule says it should.

AI-assisted — [session](https://claude.ai/code/session_01Lf3XmoA9StqLNDiMBqZVTy)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2646)
<!-- Reviewable:end -->
