### PR TITLE
PT-4061: show verse 1 at a verse-0 reference in the Text Collection

### DIFF
--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -760,3 +760,66 @@ step, no automation. Just a record.
   should not be assumed to remount anything.
 - **Source:** PT-4111 `/review-paratext` code review. Withdrawn after PR #2691 review traced
   `srcNonce` to its use site.
+
+## ADR-0013: Verse 0 resolves to verse 1 on single-verse display surfaces (display-only)
+
+- **Date:** 2026-08-05
+- **Status:** Accepted
+- **Context:** A verse-0 reference means "everything preceding verse 1" — book/chapter intros,
+  titles, outlines, Psalm `\d` superscriptions. It is reachable three ways: placing the cursor in
+  pre-verse-1 editor content (`usj-reader-writer.ts` reports `verseNum: 0`); the toolbar
+  previous-verse button, which calls `getPreviousVerseRef` **without** `bounds`
+  (`book-chapter-control.navigation.ts`), so its no-versification branch floors at verse 0 in any
+  chapter, not just chapter 1; and typing a `C:0` reference. A one-verse-tall surface has no useful
+  way to render that content, so the Text Collection showed an empty cell at Luke 1:0 —
+  [PT-3133](https://paratextstudio.atlassian.net/browse/PT-3133). PT9's
+  Text Collection shows verse 1 there instead. A4/PT-4052 (PR #2509) shipped a "No text for this
+  verse" ghost-text state, contradicting PT-3133's written acceptance (display verse 1); the
+  divergence went unflagged until PT-4061.
+- **Decision:** Single-verse display surfaces resolve a verse-0 reference to verse 1 via
+  `resolveDisplayVerseNum` (`extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.ts`),
+  confirmed by Ian Hewerdine 2026-08-05. Three constraints make this safe:
+  - **Display-only, and it needs an explicit guard.** The resolved verse is never written back to
+    the scroll group — writing it back would yank the Scripture Editor off the intro the user came
+    from. This does not happen for free: `Editorial`'s `ScriptureReferencePlugin` mounts even when
+    `isReadonly` is set (gated only on `scrRef && onScrRefChange`) and reports any selection whose
+    verse differs from `scrRef`. Fall-forward makes that mismatch permanent, so `ResourceCell`
+    swallows the echo. Without the guard one click writes verse 1 — and, because the slice drops
+    chapter chrome, chapter 1, turning Luke 5:0 into Luke 1:1.
+  - **Chapter surfaces are exempt.** Anything rendering a whole chapter shows verse-0 front matter
+    directly: the Text Collection's chapter mode, its chapter-context split, its single-resource
+    path (`ScriptureTextGrid` renders one shown resource as `viewMode="chapter"`, so verse-0
+    behavior differs between one and several resources), and the Resource Viewer
+    (`resource-text-panel.web-view.tsx`). Correct behavior, signed off by Ian on PT-3133.
+  - **Genuinely-missing verses keep the ghost text.** Fall-forward applies only to verse 0. A verse
+    absent from a resource (an NT-only resource at an OT reference, an untranslated verse) still
+    renders "No text for this verse".
+  Accessible names resolve the same way, so the announcement names the verse the cells display. It
+  names the row, not its contents: a resource lacking verse 1 shows the empty state under the same
+  label, and a combined opener renders a "1-3" verse number under a label saying "1".
+- **Alternatives:** (a) *Keep the ghost-text empty state* — rejected: it blanks every cell at once
+  exactly when the user crosses a chapter or book boundary, so the tool reads as broken at the
+  moment it should be most useful; it also contradicts PT-3133's written acceptance. (b) *Normalize
+  the reference — forbid verse 0 in the Text Collection, or write verse 1 back to the scroll group*
+  (Todd Hoatson's suggestion on PT-3133) — rejected: the scroll group is shared, so it would move
+  every other view off the intro. (c) *Put the rule inside `sliceUsjToVerse`* — rejected: the
+  decision is about the **reference**, not the USJ, and the accessible-name site needs it without
+  having any USJ; burying a copy there would centralize nothing while making
+  `sliceUsjToVerse(usj, 0)` silently return verse 1.
+- **Consequences:** verse-0 content is not shown in verse view — deliberately. It stays one click
+  away via the chapter-context split, which renders the chapter unsliced; that escape hatch is what
+  makes the trade acceptable, so **revisit if the chapter-context split is ever removed or made
+  non-obvious**. Verse 0 and verse 1 now render identically and carry the same accessible name, so
+  stepping backward across that boundary produces no visible or announced change — accepted, since
+  the alternative is a row of ghost text at every chapter boundary. Note this is not one silent step
+  but a **silent dead end**: with no `bounds`, `getPreviousVerseRef` returns the same
+  `{chapterNum, verseNum: 0}` ref every time, so once the toolbar's previous-verse button lands on
+  verse 0 in a chapter > 1 it is inert, and fall-forward removes its last remaining cue. The pin
+  predates this decision; fixing it means passing `bounds` at that call site
+  (`book-chapter-control.navigation.ts`), which is out of scope here. Any future single-verse surface
+  must call `resolveDisplayVerseNum` — `sliceUsjToVerse` is deliberately mechanical and slices a raw
+  verse 0 to nothing (pinned by a test). Note the helper is currently private to
+  `platform-scripture-editor`; a surface in another extension cannot import it, so **promote it to
+  `lib/platform-bible-utils/src/scripture/` (which already owns `getPreviousVerseRef`, the producer
+  of verse-0 refs) at the second consumer** rather than re-typing the rule.
+- **Source:** PT-4061 (B3), which resolves PT-3133; Ian Hewerdine confirmed parity 2026-08-05.

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -782,10 +782,27 @@ step, no automation. Just a record.
   - **Display-only, and it needs an explicit guard.** The resolved verse is never written back to
     the scroll group — writing it back would yank the Scripture Editor off the intro the user came
     from. This does not happen for free: `Editorial`'s `ScriptureReferencePlugin` mounts even when
-    `isReadonly` is set (gated only on `scrRef && onScrRefChange`) and reports any selection whose
-    verse differs from `scrRef`. Fall-forward makes that mismatch permanent, so `ResourceCell`
-    swallows the echo. Without the guard one click writes verse 1 — and, because the slice drops
-    chapter chrome, chapter 1, turning Luke 5:0 into Luke 1:1.
+    `isReadonly` is set (`Editor.tsx` gates it on `scrRef && onScrRefChange` only) and reports any
+    selection whose verse differs from `scrRef`. Fall-forward makes that mismatch permanent, so
+    `ResourceCell` swallows the echo. Without the guard one click writes verse 1 — and, because the
+    slice drops chapter chrome, `$findAndSetChapterAndVerse`'s
+    `parseInt(chapterNode?.getNumber() ?? '1', 10)` yields chapter 1, turning Luke 5:0 into
+    Luke 1:1.
+
+    **The guard belongs in the consumer, not upstream in the plugin** (raised in review of #2663;
+    verified against `@eten-tech-foundation/platform-editor` ~0.8.14). Gating the plugin on
+    `isReadonly` was considered and is rejected on the merits, not merely deferred: the plugin is
+    **bidirectional** — `$moveCursorToVerseStart` applies `scrRef` to the caret, and
+    `$findAndSetChapterAndVerse` reports the caret back — and read-only surfaces need both halves.
+    Not mounting it when read-only would break navigation-to-verse in every read-only editor (the
+    Resource Viewer, this grid's chapter mode) and would break read-only click-to-sync, which
+    **these very cells rely on at every normal verse**. `isReadonly` is therefore the wrong
+    predicate: a read-only editor reporting its caret position is correct behavior, not the bug.
+    The bug is narrower and entirely host-made — *we* hand the editor verse 1's USJ while telling it
+    verse 0, so the only component that knows the reference is a deliberate lie is the one that told
+    it. Whoever creates the mismatch owns swallowing it. The generalizable fix, if a third surface
+    ever wants one, is not an `isReadonly` gate but for the promoted helper to carry the guard with
+    it (see Consequences) — the rule and its guard are one unit.
   - **Chapter surfaces are exempt.** Anything rendering a whole chapter shows verse-0 front matter
     directly: the Text Collection's chapter mode, its chapter-context split, its single-resource
     path (`ScriptureTextGrid` renders one shown resource as `viewMode="chapter"`, so verse-0
@@ -805,21 +822,57 @@ step, no automation. Just a record.
   every other view off the intro. (c) *Put the rule inside `sliceUsjToVerse`* — rejected: the
   decision is about the **reference**, not the USJ, and the accessible-name site needs it without
   having any USJ; burying a copy there would centralize nothing while making
-  `sliceUsjToVerse(usj, 0)` silently return verse 1.
+  `sliceUsjToVerse(usj, 0)` silently return verse 1. (d) *Fall forward only when verse 0 has no
+  content of its own* — a content-aware rule (raised in review of #2663). The distinction it draws is
+  real in the source: a `\d` superscription is one short line that a one-verse-tall cell renders
+  fine, whereas book/chapter intros and outlines are what genuinely cannot be rendered there. Under
+  it, PT9 parity would hold where it actually matters (the intro case), `<` from Psalms verse 1 would
+  produce a visible change instead of a silent one, and no real Scripture would be hidden in verse
+  view. Rejected on cost and consistency: the helper would need the chapter USJ, and the
+  accessible-name site in `ScriptureTextGrid` has none — it names the row before any resource has
+  fetched anything — which is exactly why the rule is reference-only. Making it content-aware would
+  either force a USJ through the naming path or split the rule in two (a USJ-aware version for cells,
+  a reference-only version for labels), and per-resource content-awareness would make the *same*
+  reference fall forward in one cell and not in its neighbor, so a row of cells would disagree about
+  which verse they are showing. Worth revisiting if the superscription case draws real complaints,
+  since it is the one place this decision hides genuine content.
 - **Consequences:** verse-0 content is not shown in verse view — deliberately. It stays one click
   away via the chapter-context split, which renders the chapter unsliced; that escape hatch is what
   makes the trade acceptable, so **revisit if the chapter-context split is ever removed or made
   non-obvious**. Verse 0 and verse 1 now render identically and carry the same accessible name, so
-  stepping backward across that boundary produces no visible or announced change — accepted, since
-  the alternative is a row of ghost text at every chapter boundary. Note this is not one silent step
-  but a **silent dead end**: with no `bounds`, `getPreviousVerseRef` returns the same
-  `{chapterNum, verseNum: 0}` ref every time, so once the toolbar's previous-verse button lands on
-  verse 0 in a chapter > 1 it is inert, and fall-forward removes its last remaining cue. The pin
-  predates this decision; fixing it means passing `bounds` at that call site
-  (`book-chapter-control.navigation.ts`), which is out of scope here. Any future single-verse surface
-  must call `resolveDisplayVerseNum` — `sliceUsjToVerse` is deliberately mechanical and slices a raw
-  verse 0 to nothing (pinned by a test). Note the helper is currently private to
-  `platform-scripture-editor`; a surface in another extension cannot import it, so **promote it to
+  stepping backward across that boundary produces no visible or announced change **within the grid**
+  — accepted, since the alternative is a row of ghost text at every chapter boundary.
+
+  **Verse 0 becomes unobservable inside the Text Collection, including to assistive tech** (raised
+  in review of #2663). At a verse-0 reference the row label announces "MAT 5:1", the cells render
+  verse 1, and nothing in the grid states that the shared reference is actually 5:0 — so a
+  screen-reader user has no in-grid signal that they are at the boundary. This is a genuine accepted
+  cost of naming the row after what it displays, not an oversight: the alternative is a label that
+  announces a verse the cells demonstrably do not show, which is worse. Two things keep it from
+  being a true silent dead end, and both live outside the grid: the BCV control still displays the
+  real reference (`5:0`), and its **previous-verse button is disabled** at verse 0, which is an
+  announced state change rather than an inert control — `isNoOpNavigation` in
+  `book-chapter-control.navigation.ts` disables a step that would return the same ref, pinned by the
+  `'Is disabled when at verse 0'` test in `book-chapter-control.navigation.test.ts`. (An earlier
+  draft of this ADR called the button "inert" and claimed fall-forward removed its "last remaining
+  cue"; that was wrong on both counts and is corrected here.) What the button cannot do is roll
+  backward to the previous chapter's last verse: with no `bounds`, `getPreviousVerseRef` floors at
+  `{chapterNum, verseNum: 0}` in every chapter rather than only chapter 1, so the reference dead-ends
+  there. That pin predates this decision and is now tracked as
+  [PT-4379](https://paratextstudio.atlassian.net/browse/PT-4379) — out of scope here because the fix
+  is not passing an argument but threading an async, PAPI-built `ScriptureBounds` through a
+  `platform-bible-react` component into every consumer of the BCV control.
+
+  Any future single-verse surface must call `resolveDisplayVerseNum` — `sliceUsjToVerse` is
+  deliberately mechanical and slices a raw verse 0 to nothing (pinned by a test) — and must carry the
+  write-back guard with it. The helper is currently private to `platform-scripture-editor`, so a
+  surface in another extension cannot import it; **promote it to
   `lib/platform-bible-utils/src/scripture/` (which already owns `getPreviousVerseRef`, the producer
-  of verse-0 refs) at the second consumer** rather than re-typing the rule.
+  of verse-0 refs) at the second consumer _of this rule_** rather than re-typing it. The qualifier is
+  load-bearing: "second consumer" counted as surfaces would be wrong, because other surfaces already
+  handle verse-0 references under deliberately different rules — review of #2663 cites the
+  interlinearizer extension, which treats verse 0 as tokenizable content to be kept rather than
+  routed around, because it renders a whole chapter. A whole-chapter surface should look like the
+  chapter-surface exemption above, not like this rule. Promoting on a surface count would turn a
+  deliberate single-verse-vs-whole-chapter difference into apparent drift from a shared util.
 - **Source:** PT-4061 (B3), which resolves PT-3133; Ian Hewerdine confirmed parity 2026-08-05.

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -782,21 +782,36 @@ step, no automation. Just a record.
   - **Display-only, and it needs an explicit guard.** The resolved verse is never written back to
     the scroll group — writing it back would yank the Scripture Editor off the intro the user came
     from. This does not happen for free: `Editorial`'s `ScriptureReferencePlugin` mounts even when
-    `isReadonly` is set (`Editor.tsx` gates it on `scrRef && onScrRefChange` only) and reports any
-    selection whose verse differs from `scrRef`. Fall-forward makes that mismatch permanent, so
-    `ResourceCell` swallows the echo. Without the guard one click writes verse 1 — and, because the
-    slice drops chapter chrome, `$findAndSetChapterAndVerse`'s
-    `parseInt(chapterNode?.getNumber() ?? '1', 10)` yields chapter 1, turning Luke 5:0 into
-    Luke 1:1.
+    `isReadonly` is set (`Editor.tsx` gates it on `scrRef && onScrRefChange` only) and
+    `$findAndSetChapterAndVerse` reports any selection whose **chapter or verse** disagrees with
+    `scrRef` — a chapter mismatch when the document has a chapter node, or a `scrRef` verse outside
+    the selected verse marker's range. Fall-forward makes that disagreement permanent
+    (`isVerseInRange(0, '1')` is false on every click), so `ResourceCell` swallows the echo. Without
+    the guard one click writes verse 1 — and, because the slice drops chapter chrome,
+    `parseInt(chapterNode?.getNumber() ?? '1', 10)` yields chapter 1, turning Luke 5:0 into Luke 1:1.
 
-    **The guard belongs in the consumer, not upstream in the plugin** (raised in review of #2663;
-    verified against `@eten-tech-foundation/platform-editor` ~0.8.14). Gating the plugin on
+    **Version-pinned:** traced against `@eten-tech-foundation/platform-editor` **0.8.14**, which is
+    what `package-lock.json` resolves and npm's current `latest` (as of 2026-08-16; 0.8.15 is not
+    published). This matters because upstream `main` in `eten-tech-foundation/scripture-editors` has
+    since rewritten the plugin around a `$resolvePosition` / `onSelectionSettled` / `report` machine
+    whose `$resolvePosition` returns `undefined` for a document with no `BookNode` and no
+    `ChapterNode` (pinned upstream as invariant I5). A verse-mode slice is exactly that document, so
+    **on the release that lands, the plugin will report nothing here and this guard becomes
+    defense-in-depth** rather than a live fix. Neither the guard nor this ADR changes at that point;
+    re-verify at the next version bump. (Raised in review of #2663 against an unreleased build.)
+
+    **The guard belongs in the consumer, not upstream in the plugin.** Gating the plugin on
     `isReadonly` was considered and is rejected on the merits, not merely deferred: the plugin is
     **bidirectional** — `$moveCursorToVerseStart` applies `scrRef` to the caret, and
-    `$findAndSetChapterAndVerse` reports the caret back — and read-only surfaces need both halves.
-    Not mounting it when read-only would break navigation-to-verse in every read-only editor (the
-    Resource Viewer, this grid's chapter mode) and would break read-only click-to-sync, which
-    **these very cells rely on at every normal verse**. `isReadonly` is therefore the wrong
+    `$findAndSetChapterAndVerse` reports the caret back (`$moveCaretToVerseStart` and
+    `$resolvePosition` after the upstream rewrite) — and read-only surfaces need both halves. Not
+    mounting it when read-only would break navigation-to-verse in every read-only editor and would
+    break read-only click-to-sync, which **this grid's chapter mode and the Resource Viewer rely on**.
+    (Scoped deliberately: click-to-sync is *not* load-bearing in verse mode. There the slice holds
+    exactly the verse `scrRef` names, so a click resolves to that same verse, the plugin finds no
+    disagreement, and nothing is reported — a verse cell has nowhere to sync TO. That predates this
+    decision: `sliceUsjToVerse` has dropped chapter chrome since #2509. It is not a lost capability
+    and is deliberately not filed.) `isReadonly` is therefore the wrong
     predicate: a read-only editor reporting its caret position is correct behavior, not the bug.
     The bug is narrower and entirely host-made — *we* hand the editor verse 1's USJ while telling it
     verse 0, so the only component that knows the reference is a deliberate lie is the one that told
@@ -870,9 +885,14 @@ step, no automation. Just a record.
   `lib/platform-bible-utils/src/scripture/` (which already owns `getPreviousVerseRef`, the producer
   of verse-0 refs) at the second consumer _of this rule_** rather than re-typing it. The qualifier is
   load-bearing: "second consumer" counted as surfaces would be wrong, because other surfaces already
-  handle verse-0 references under deliberately different rules — review of #2663 cites the
-  interlinearizer extension, which treats verse 0 as tokenizable content to be kept rather than
-  routed around, because it renders a whole chapter. A whole-chapter surface should look like the
-  chapter-surface exemption above, not like this rule. Promoting on a surface count would turn a
-  deliberate single-verse-vs-whole-chapter difference into apparent drift from a shared util.
+  handle verse-0 references under deliberately different rules. The worked example is the
+  interlinearizer extension (`sillsdev/interlinearizer-extension`, `InterlinearizerLoader.tsx`, the
+  `activeScrRef` memo): it renders a whole chapter and treats verse 0 as tokenizable content, so it
+  **keeps** verse 0 whenever a segment covers it — its USJ extractor emits a synthetic verse-0 scope
+  with SID `"<book> <chapter>:0"` for pre-verse-1 content — and falls back to verse 1 only when the
+  loaded book has no verse-0 segment for that chapter. That is content-awareness this rule
+  deliberately rejects (alternative (d) above), affordable there precisely because the whole book is
+  already parsed into segments before a reference is resolved. A whole-chapter surface should look
+  like the chapter-surface exemption above, not like this rule. Promoting on a surface count would
+  turn a deliberate single-verse-vs-whole-chapter difference into apparent drift from a shared util.
 - **Source:** PT-4061 (B3), which resolves PT-3133; Ian Hewerdine confirmed parity 2026-08-05.

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -790,15 +790,23 @@ step, no automation. Just a record.
     the guard one click writes verse 1 — and, because the slice drops chapter chrome,
     `parseInt(chapterNode?.getNumber() ?? '1', 10)` yields chapter 1, turning Luke 5:0 into Luke 1:1.
 
-    **Version-pinned:** traced against `@eten-tech-foundation/platform-editor` **0.8.14**, which is
-    what `package-lock.json` resolves and npm's current `latest` (as of 2026-08-16; 0.8.15 is not
-    published). This matters because upstream `main` in `eten-tech-foundation/scripture-editors` has
-    since rewritten the plugin around a `$resolvePosition` / `onSelectionSettled` / `report` machine
-    whose `$resolvePosition` returns `undefined` for a document with no `BookNode` and no
-    `ChapterNode` (pinned upstream as invariant I5). A verse-mode slice is exactly that document, so
-    **on the release that lands, the plugin will report nothing here and this guard becomes
-    defense-in-depth** rather than a live fix. Neither the guard nor this ADR changes at that point;
-    re-verify at the next version bump. (Raised in review of #2663 against an unreleased build.)
+    **Which editor build this describes (as of 2026-08-16).** The trace above is against
+    `@eten-tech-foundation/platform-editor` **0.8.14** — what `package-lock.json` resolves, what npm
+    serves as `latest`, and what is installed locally. But 0.8.14 was published 2026-04-14 and this
+    repo's `main` already imports editor APIs it does not export (`PARAGRAPH_STRUCTURE_VIEW_MODE`,
+    `StructureProtectionMode`, `ViewOptions.hasGutterParaMarkers`, `EditorRef.removeCharacterMarker`),
+    so **the effective target is a newer build than the lockfile pins** and the lockfile should not be
+    read as authoritative here.
+
+    In that newer build the plugin is rewritten around a `$resolvePosition` / `onSelectionSettled` /
+    `report` machine whose `$resolvePosition` returns `undefined` for a document with no `BookNode`
+    and no `ChapterNode` (upstream invariant I5). A verse-mode slice is exactly that document, so
+    there the plugin reports **nothing** here. Both states are recorded deliberately, because the
+    guard is right under either: a live fix against 0.8.14's `$findAndSetChapterAndVerse`, and
+    defense-in-depth against the rewrite — the thing that keeps the write-back closed if a future
+    editor makes chrome-free slices addressable again. Re-verify at the next version bump; do not
+    delete the guard on the strength of the rewrite alone. (Both mechanisms surfaced in review of
+    #2663.)
 
     **The guard belongs in the consumer, not upstream in the plugin.** Gating the plugin on
     `isReadonly` was considered and is rejected on the merits, not merely deferred: the plugin is

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -761,7 +761,7 @@ step, no automation. Just a record.
 - **Source:** PT-4111 `/review-paratext` code review. Withdrawn after PR #2691 review traced
   `srcNonce` to its use site.
 
-## ADR-0013: Verse 0 resolves to verse 1 on single-verse display surfaces (display-only)
+## ADR-0019: Verse 0 resolves to verse 1 on single-verse display surfaces (display-only)
 
 - **Date:** 2026-08-05
 - **Status:** Accepted

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -813,13 +813,13 @@ step, no automation. Just a record.
     where the slice is unaddressable and no click reports anything. That predates this decision —
     `sliceUsjToVerse` has dropped chapter chrome since #2509 — and is not a lost capability, since a
     verse cell holds only the verse you are already on and so has nowhere to sync TO. Deliberately
-    not filed.) `isReadonly` is therefore the wrong
-    predicate: a read-only editor reporting its caret position is correct behavior, not the bug.
-    The bug is narrower and entirely host-made — *we* hand the editor verse 1's USJ while telling it
-    verse 0, so the only component that knows the reference is a deliberate lie is the one that told
-    it. Whoever creates the mismatch owns swallowing it. The generalizable fix, if a third surface
-    ever wants one, is not an `isReadonly` gate but for the promoted helper to carry the guard with
-    it (see Consequences) — the rule and its guard are one unit.
+    not filed.) `isReadonly` is therefore the wrong predicate: a read-only editor reporting its
+    caret position is correct behavior, not the bug. The bug is narrower and entirely host-made —
+    *we* hand the editor verse 1's USJ while telling it verse 0, so the only component that knows
+    the reference is a deliberate lie is the one that told it. Whoever creates the mismatch owns
+    swallowing it. The generalizable fix, if a third surface ever wants one, is not an `isReadonly`
+    gate but for the promoted helper to carry the guard with it (see Consequences) — the rule and
+    its guard are one unit.
   - **Chapter surfaces are exempt.** Anything rendering a whole chapter shows verse-0 front matter
     directly: the Text Collection's chapter mode, its chapter-context split, its single-resource
     path (`ScriptureTextGrid` renders one shown resource as `viewMode="chapter"`, so verse-0

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -787,15 +787,20 @@ step, no automation. Just a record.
 
     **The guard is defense-in-depth, not a fix for a live report.** `$resolvePosition` refuses to
     describe a position in a document with no `BookNode` and no `ChapterNode` (upstream invariant I5),
-    and `sliceUsjToVerse` drops both — so today the plugin is silent in verse mode, and the
+    and `sliceUsjToVerse` drops both — so the plugin is silent in verse mode, and the
     `viewMode === 'verse'` branch of `handleScrRefChange` is unreachable. It is kept because it costs
     nothing and is the right shape if a future editor makes slices addressable; do not read it as
-    evidence that a write-back currently occurs. Verified against the editor this repo actually
-    builds: `dev-packages/scripture-editors` `packages/platform` at **0.8.15**, which `postinstall` →
-    `link-dev-packages` builds and yalc-links over `node_modules`. (The npm-published 0.8.14 that
-    `package-lock.json` names is a placeholder the link replaces; an earlier draft of this ADR
-    described 0.8.14's `$findAndSetChapterAndVerse` and its chapter-1 fallback as the live mechanism,
-    which was wrong — that plugin is not what runs here. Corrected in review of #2663.)
+    evidence that a write-back currently occurs.
+
+    Verified 2026-08-16 against `@eten-tech-foundation/platform-editor` **0.8.15**, in both places it
+    can be read: the published npm package, and `dev-packages/scripture-editors` `packages/platform`,
+    which `postinstall` → `link-dev-packages` builds and yalc-links over `node_modules`. They agree
+    on this mechanism (the vendored copy trails published 0.8.15 by one caret-placement line in
+    `$moveCaretToVerseStart`). **Verify against the linked build, not `package-lock.json`** — the lock
+    still named 0.8.14 when this was written, and reading that stale tarball is exactly how an earlier
+    draft of this ADR came to describe `$findAndSetChapterAndVerse` and its chapter-1 fallback as the
+    live mechanism. That was wrong; that plugin does not exist in 0.8.15. Corrected in review of
+    #2663.
 
     **The guard belongs in the consumer, not upstream in the plugin.** Gating the plugin on
     `isReadonly` was considered and is rejected on the merits, not merely deferred: the plugin is

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -779,47 +779,36 @@ step, no automation. Just a record.
 - **Decision:** Single-verse display surfaces resolve a verse-0 reference to verse 1 via
   `resolveDisplayVerseNum` (`extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.ts`),
   confirmed by Ian Hewerdine 2026-08-05. Three constraints make this safe:
-  - **Display-only, and it needs an explicit guard.** The resolved verse is never written back to
+  - **Display-only, and it carries an explicit guard.** The resolved verse is never written back to
     the scroll group — writing it back would yank the Scripture Editor off the intro the user came
-    from. This does not happen for free: `Editorial`'s `ScriptureReferencePlugin` mounts even when
-    `isReadonly` is set (`Editor.tsx` gates it on `scrRef && onScrRefChange` only) and
-    `$findAndSetChapterAndVerse` reports any selection whose **chapter or verse** disagrees with
-    `scrRef` — a chapter mismatch when the document has a chapter node, or a `scrRef` verse outside
-    the selected verse marker's range. Fall-forward makes that disagreement permanent
-    (`isVerseInRange(0, '1')` is false on every click), so `ResourceCell` swallows the echo. Without
-    the guard one click writes verse 1 — and, because the slice drops chapter chrome,
-    `parseInt(chapterNode?.getNumber() ?? '1', 10)` yields chapter 1, turning Luke 5:0 into Luke 1:1.
+    from. `Editorial`'s `ScriptureReferencePlugin` mounts even when `isReadonly` is set (`Editor.tsx`
+    gates it on `scrRef && onScrRefChange` only) and reports a selection whose book, chapter, or
+    verse disagrees with `scrRef`, so `ResourceCell` swallows the echo.
 
-    **Which editor build this describes (as of 2026-08-16).** The trace above is against
-    `@eten-tech-foundation/platform-editor` **0.8.14** — what `package-lock.json` resolves, what npm
-    serves as `latest`, and what is installed locally. But 0.8.14 was published 2026-04-14 and this
-    repo's `main` already imports editor APIs it does not export (`PARAGRAPH_STRUCTURE_VIEW_MODE`,
-    `StructureProtectionMode`, `ViewOptions.hasGutterParaMarkers`, `EditorRef.removeCharacterMarker`),
-    so **the effective target is a newer build than the lockfile pins** and the lockfile should not be
-    read as authoritative here.
-
-    In that newer build the plugin is rewritten around a `$resolvePosition` / `onSelectionSettled` /
-    `report` machine whose `$resolvePosition` returns `undefined` for a document with no `BookNode`
-    and no `ChapterNode` (upstream invariant I5). A verse-mode slice is exactly that document, so
-    there the plugin reports **nothing** here. Both states are recorded deliberately, because the
-    guard is right under either: a live fix against 0.8.14's `$findAndSetChapterAndVerse`, and
-    defense-in-depth against the rewrite — the thing that keeps the write-back closed if a future
-    editor makes chrome-free slices addressable again. Re-verify at the next version bump; do not
-    delete the guard on the strength of the rewrite alone. (Both mechanisms surfaced in review of
-    #2663.)
+    **The guard is defense-in-depth, not a fix for a live report.** `$resolvePosition` refuses to
+    describe a position in a document with no `BookNode` and no `ChapterNode` (upstream invariant I5),
+    and `sliceUsjToVerse` drops both — so today the plugin is silent in verse mode, and the
+    `viewMode === 'verse'` branch of `handleScrRefChange` is unreachable. It is kept because it costs
+    nothing and is the right shape if a future editor makes slices addressable; do not read it as
+    evidence that a write-back currently occurs. Verified against the editor this repo actually
+    builds: `dev-packages/scripture-editors` `packages/platform` at **0.8.15**, which `postinstall` →
+    `link-dev-packages` builds and yalc-links over `node_modules`. (The npm-published 0.8.14 that
+    `package-lock.json` names is a placeholder the link replaces; an earlier draft of this ADR
+    described 0.8.14's `$findAndSetChapterAndVerse` and its chapter-1 fallback as the live mechanism,
+    which was wrong — that plugin is not what runs here. Corrected in review of #2663.)
 
     **The guard belongs in the consumer, not upstream in the plugin.** Gating the plugin on
     `isReadonly` was considered and is rejected on the merits, not merely deferred: the plugin is
-    **bidirectional** — `$moveCursorToVerseStart` applies `scrRef` to the caret, and
-    `$findAndSetChapterAndVerse` reports the caret back (`$moveCaretToVerseStart` and
-    `$resolvePosition` after the upstream rewrite) — and read-only surfaces need both halves. Not
-    mounting it when read-only would break navigation-to-verse in every read-only editor and would
-    break read-only click-to-sync, which **this grid's chapter mode and the Resource Viewer rely on**.
-    (Scoped deliberately: click-to-sync is *not* load-bearing in verse mode. There the slice holds
-    exactly the verse `scrRef` names, so a click resolves to that same verse, the plugin finds no
-    disagreement, and nothing is reported — a verse cell has nowhere to sync TO. That predates this
-    decision: `sliceUsjToVerse` has dropped chapter chrome since #2509. It is not a lost capability
-    and is deliberately not filed.) `isReadonly` is therefore the wrong
+    **bidirectional** — `$moveCaretToVerseStart` applies `scrRef` to the caret, and `$resolvePosition`
+    → `onSelectionSettled` → `report` reports the caret back — and read-only surfaces need both
+    halves. Not mounting it when read-only would break navigation-to-verse in every read-only editor
+    and would break read-only click-to-sync, which **this grid's chapter mode and the Resource Viewer
+    rely on** — those feed a whole chapter, so the document carries the book and chapter nodes
+    `$resolvePosition` needs. (Scoped deliberately: click-to-sync is *not* load-bearing in verse mode,
+    where the slice is unaddressable and no click reports anything. That predates this decision —
+    `sliceUsjToVerse` has dropped chapter chrome since #2509 — and is not a lost capability, since a
+    verse cell holds only the verse you are already on and so has nowhere to sync TO. Deliberately
+    not filed.) `isReadonly` is therefore the wrong
     predicate: a read-only editor reporting its caret position is correct behavior, not the bug.
     The bug is narrower and entirely host-made — *we* hand the editor verse 1's USJ while telling it
     verse 0, so the only component that knows the reference is a deliberate lie is the one that told

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -415,3 +415,65 @@ step, no automation. Just a record.
   than inlining a fourth copy.
 - **Source:** Review of PR #2665 (`remove-character-marker`) — reuse findings on duplicated snapshot
   and sync-notice blocks.
+## ADR-0013: Verse 0 resolves to verse 1 on single-verse display surfaces (display-only)
+
+- **Date:** 2026-08-05
+- **Status:** Accepted
+- **Context:** A verse-0 reference means "everything preceding verse 1" — book/chapter intros,
+  titles, outlines, Psalm `\d` superscriptions. It is reachable three ways: placing the cursor in
+  pre-verse-1 editor content (`usj-reader-writer.ts` reports `verseNum: 0`); the toolbar
+  previous-verse button, which calls `getPreviousVerseRef` **without** `bounds`
+  (`book-chapter-control.navigation.ts`), so its no-versification branch floors at verse 0 in any
+  chapter, not just chapter 1; and typing a `C:0` reference. A one-verse-tall surface has no useful
+  way to render that content, so the Text Collection showed an empty cell at Luke 1:0 —
+  [PT-3133](https://paratextstudio.atlassian.net/browse/PT-3133). PT9's
+  Text Collection shows verse 1 there instead. A4/PT-4052 (PR #2509) shipped a "No text for this
+  verse" ghost-text state, contradicting PT-3133's written acceptance (display verse 1); the
+  divergence went unflagged until PT-4061.
+- **Decision:** Single-verse display surfaces resolve a verse-0 reference to verse 1 via
+  `resolveDisplayVerseNum` (`extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.ts`),
+  confirmed by Ian Hewerdine 2026-08-05. Three constraints make this safe:
+  - **Display-only, and it needs an explicit guard.** The resolved verse is never written back to
+    the scroll group — writing it back would yank the Scripture Editor off the intro the user came
+    from. This does not happen for free: `Editorial`'s `ScriptureReferencePlugin` mounts even when
+    `isReadonly` is set (gated only on `scrRef && onScrRefChange`) and reports any selection whose
+    verse differs from `scrRef`. Fall-forward makes that mismatch permanent, so `ResourceCell`
+    swallows the echo. Without the guard one click writes verse 1 — and, because the slice drops
+    chapter chrome, chapter 1, turning Luke 5:0 into Luke 1:1.
+  - **Chapter surfaces are exempt.** Anything rendering a whole chapter shows verse-0 front matter
+    directly: the Text Collection's chapter mode, its chapter-context split, its single-resource
+    path (`ScriptureTextGrid` renders one shown resource as `viewMode="chapter"`, so verse-0
+    behavior differs between one and several resources), and the Resource Viewer
+    (`resource-text-panel.web-view.tsx`). Correct behavior, signed off by Ian on PT-3133.
+  - **Genuinely-missing verses keep the ghost text.** Fall-forward applies only to verse 0. A verse
+    absent from a resource (an NT-only resource at an OT reference, an untranslated verse) still
+    renders "No text for this verse".
+  Accessible names resolve the same way, so the announcement names the verse the cells display. It
+  names the row, not its contents: a resource lacking verse 1 shows the empty state under the same
+  label, and a combined opener renders a "1-3" verse number under a label saying "1".
+- **Alternatives:** (a) *Keep the ghost-text empty state* — rejected: it blanks every cell at once
+  exactly when the user crosses a chapter or book boundary, so the tool reads as broken at the
+  moment it should be most useful; it also contradicts PT-3133's written acceptance. (b) *Normalize
+  the reference — forbid verse 0 in the Text Collection, or write verse 1 back to the scroll group*
+  (Todd Hoatson's suggestion on PT-3133) — rejected: the scroll group is shared, so it would move
+  every other view off the intro. (c) *Put the rule inside `sliceUsjToVerse`* — rejected: the
+  decision is about the **reference**, not the USJ, and the accessible-name site needs it without
+  having any USJ; burying a copy there would centralize nothing while making
+  `sliceUsjToVerse(usj, 0)` silently return verse 1.
+- **Consequences:** verse-0 content is not shown in verse view — deliberately. It stays one click
+  away via the chapter-context split, which renders the chapter unsliced; that escape hatch is what
+  makes the trade acceptable, so **revisit if the chapter-context split is ever removed or made
+  non-obvious**. Verse 0 and verse 1 now render identically and carry the same accessible name, so
+  stepping backward across that boundary produces no visible or announced change — accepted, since
+  the alternative is a row of ghost text at every chapter boundary. Note this is not one silent step
+  but a **silent dead end**: with no `bounds`, `getPreviousVerseRef` returns the same
+  `{chapterNum, verseNum: 0}` ref every time, so once the toolbar's previous-verse button lands on
+  verse 0 in a chapter > 1 it is inert, and fall-forward removes its last remaining cue. The pin
+  predates this decision; fixing it means passing `bounds` at that call site
+  (`book-chapter-control.navigation.ts`), which is out of scope here. Any future single-verse surface
+  must call `resolveDisplayVerseNum` — `sliceUsjToVerse` is deliberately mechanical and slices a raw
+  verse 0 to nothing (pinned by a test). Note the helper is currently private to
+  `platform-scripture-editor`; a surface in another extension cannot import it, so **promote it to
+  `lib/platform-bible-utils/src/scripture/` (which already owns `getPreviousVerseRef`, the producer
+  of verse-0 refs) at the second consumer** rather than re-typing the rule.
+- **Source:** PT-4061 (B3), which resolves PT-3133; Ian Hewerdine confirmed parity 2026-08-05.

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -1252,9 +1252,12 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
 
   const setScrRefNoScroll = useCallback(
     (newVerseLocation: SerializedVerseRef) => {
-      // Preserve versificationStr: ScriptureReferencePlugin returns {book, chapterNum, verseNum}
-      // without versificationStr, so falling back to scrRef keeps the versification consistent and
-      // prevents the PDP selector from changing on every click.
+      // Preserve versificationStr so the PDP selector doesn't change on every click. As of
+      // platform-editor 0.8.15 this fallback is a no-op: `positionToScrRef` rides the host's
+      // `versificationStr` along on every position report (a document states no versification of
+      // its own), and the sole caller of this handler is that plugin. Kept as a cheap belt-and-
+      // braces against the contract changing back. Do NOT cite it as evidence that the plugin
+      // strips versification — it did before 0.8.15, and that stale rationale was corrected here.
       const preservedLocation: SerializedVerseRef = {
         ...newVerseLocation,
         versificationStr: newVerseLocation.versificationStr ?? scrRef.versificationStr,

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -1252,12 +1252,11 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
 
   const setScrRefNoScroll = useCallback(
     (newVerseLocation: SerializedVerseRef) => {
-      // Preserve versificationStr so the PDP selector doesn't change on every click. As of
-      // platform-editor 0.8.15 this fallback is a no-op: `positionToScrRef` rides the host's
-      // `versificationStr` along on every position report (a document states no versification of
-      // its own), and the sole caller of this handler is that plugin. Kept as a cheap belt-and-
-      // braces against the contract changing back. Do NOT cite it as evidence that the plugin
-      // strips versification — it did before 0.8.15, and that stale rationale was corrected here.
+      // Preserve versificationStr so the PDP selector doesn't change on every click. Against
+      // platform-editor 0.8.15 the fallback is a no-op: `positionToScrRef` carries the host's
+      // `versificationStr` on every position report (a document states no versification of its
+      // own), and that plugin is the sole caller of this handler. Kept as cheap insurance in case
+      // that contract changes — versions before 0.8.15 reported positions without it.
       const preservedLocation: SerializedVerseRef = {
         ...newVerseLocation,
         versificationStr: newVerseLocation.versificationStr ?? scrRef.versificationStr,

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -396,6 +396,10 @@ globalThis.webViewComponent = function ResourceTextPanel({
 
   // #region USJ Fetch
 
+  // Chapter view: the whole chapter goes to Editorial, which navigates to scrRef. Deliberately NOT
+  // sliced by scripture-text-grid/verse-display.utils — slicing would blank the verse-0 front matter
+  // (intros, Psalm superscriptions) this view exists to show. PT-3133 was a Text Collection bug
+  // only; showing front matter here is the approved behavior. See PT-4061.
   const [usjPossiblyError] = useProjectData(
     'platformScripture.USJ_Chapter',
     resourceProjectId,

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -405,6 +405,10 @@ globalThis.webViewComponent = function ResourceTextPanel({
 
   // #region USJ Fetch
 
+  // Chapter view: the whole chapter goes to Editorial, which navigates to scrRef. Deliberately NOT
+  // sliced by scripture-text-grid/verse-display.utils — slicing would blank the verse-0 front matter
+  // (intros, Psalm superscriptions) this view exists to show. PT-3133 was a Text Collection bug
+  // only; showing front matter here is the approved behavior. See PT-4061.
   const [usjPossiblyError] = useProjectData(
     'platformScripture.USJ_Chapter',
     resourceProjectId,

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -407,8 +407,8 @@ globalThis.webViewComponent = function ResourceTextPanel({
 
   // Chapter view: the whole chapter goes to Editorial, which navigates to scrRef. Deliberately NOT
   // sliced by scripture-text-grid/verse-display.utils — slicing would blank the verse-0 front matter
-  // (intros, Psalm superscriptions) this view exists to show. PT-3133 was a Text Collection bug
-  // only; showing front matter here is the approved behavior. See PT-4061.
+  // (intros, Psalm superscriptions) this view exists to show. Single-verse surfaces resolve verse 0
+  // to verse 1; whole-chapter surfaces like this one must not (see ADR-0019).
   const [usjPossiblyError] = useProjectData(
     'platformScripture.USJ_Chapter',
     resourceProjectId,

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell-view.component.stories.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell-view.component.stories.tsx
@@ -196,7 +196,7 @@ export const VerseReady: Story = {
   ),
 };
 
-/** Verse mode, empty — no text for the focused verse (e.g. verse 0). */
+/** Verse mode, empty — this resource has no text for the focused verse. */
 export const VerseEmpty: Story = {
   render: () => (
     <CellBox>

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -6,15 +6,31 @@ import { render, screen, waitFor } from '@testing-library/react';
 import { usxStringToUsj } from '@eten-tech-foundation/scripture-utilities';
 import { ResourceCell } from './resource-cell.component';
 
-const { mockUseProjectData, mockUseProjectSetting, setUsjSpy, capturedEditorOptions } = vi.hoisted(
-  () => ({
+const {
+  mockUseProjectData,
+  mockUseProjectSetting,
+  setUsjSpy,
+  capturedEditorOptions,
+  capturedEditorScrRef,
+  captureEditorScrRefChange,
+  getEditorScrRefChange,
+} = vi.hoisted(() => {
+  /** The live `onScrRefChange` Editorial was handed, so tests can drive the write-back channel. */
+  let onScrRefChange: ((scrRef: unknown) => void) | undefined;
+  return {
     mockUseProjectData: vi.fn(),
     mockUseProjectSetting: vi.fn(),
     setUsjSpy: vi.fn(),
     /** Collects the `options` prop passed to each Editorial render. */
     capturedEditorOptions: vi.fn(),
-  }),
-);
+    /** Collects the `scrRef` prop passed to each Editorial render. */
+    capturedEditorScrRef: vi.fn(),
+    captureEditorScrRefChange: (handler: ((scrRef: unknown) => void) | undefined) => {
+      onScrRefChange = handler;
+    },
+    getEditorScrRefChange: () => onScrRefChange,
+  };
+});
 
 vi.mock('@papi/frontend', () => ({ logger: { warn: vi.fn(), info: vi.fn() } }));
 vi.mock('@papi/frontend/react', () => ({
@@ -32,9 +48,17 @@ vi.mock('@papi/frontend/react', () => ({
   ],
 }));
 vi.mock('@eten-tech-foundation/platform-editor', () => {
+  // Just the props ResourceCell passes, typed so the captured handler stays callable without a cast.
+  type EditorialMockProps = {
+    options?: unknown;
+    scrRef?: unknown;
+    onScrRefChange?: (scrRef: unknown) => void;
+  };
   return {
-    Editorial: React.forwardRef((props: Record<string, unknown>, ref: React.Ref<unknown>) => {
+    Editorial: React.forwardRef((props: EditorialMockProps, ref: React.Ref<unknown>) => {
       capturedEditorOptions(props.options);
+      capturedEditorScrRef(props.scrRef);
+      captureEditorScrRefChange(props.onScrRefChange);
       React.useImperativeHandle(ref, () => ({ setUsj: setUsjSpy }));
       return <div data-testid="editorial" />;
     }),
@@ -93,9 +117,49 @@ const twoVerseChapterUsj = usxStringToUsj(`<?xml version="1.0" encoding="utf-8"?
 </usx>
 `);
 
+// Chapter whose verses start at 2 — fall-forward to verse 1 finds nothing here.
+const noVerseOneChapterUsj = usxStringToUsj(`<?xml version="1.0" encoding="utf-8"?>
+<usx version="3.1">
+  <book code="GEN" style="id">Sample</book>
+  <chapter number="1" style="c" sid="GEN 1" />
+  <para style="p">
+    <verse number="2" style="v" sid="GEN 1:2" />verse two<verse eid="GEN 1:2" /></para>
+</usx>
+`);
+
+// The shape the feature exists for: real verse-0 front matter (intro + superscription + heading)
+// ahead of verse 1. None of it may leak into the one-verse-tall cell.
+const frontMatterChapterUsj = usxStringToUsj(`<?xml version="1.0" encoding="utf-8"?>
+<usx version="3.1">
+  <book code="PSA" style="id">Sample</book>
+  <para style="ip">Book introduction prose.</para>
+  <chapter number="3" style="c" sid="PSA 3" />
+  <para style="d">A Psalm of David, when he fled.</para>
+  <para style="s">Morning Prayer</para>
+  <para style="p">
+    <verse number="1" style="v" sid="PSA 3:1" />verse one<verse eid="PSA 3:1" /></para>
+</usx>
+`);
+
+// Chapter whose opening verse is a combined range, so verse 1 resolves into "1-3".
+const combinedOpeningChapterUsj = usxStringToUsj(`<?xml version="1.0" encoding="utf-8"?>
+<usx version="3.1">
+  <book code="GEN" style="id">Sample</book>
+  <chapter number="1" style="c" sid="GEN 1" />
+  <para style="p">
+    <verse number="1-3" style="v" sid="GEN 1:1-3" />combined opening<verse eid="GEN 1:1-3" /></para>
+</usx>
+`);
+
 // 3-tuple [data, setData, isLoading].
 function setUsjResult(value: unknown, isLoading = false) {
   mockUseProjectData.mockReturnValue({ ChapterUSJ: () => [value, vi.fn(), isLoading] });
+}
+
+/** Serialized USJ most recently handed to the editor, or '' if it was never fed. */
+function lastFedUsjText(): string {
+  const [fedUsj] = setUsjSpy.mock.lastCall ?? [];
+  return JSON.stringify(fedUsj) ?? '';
 }
 
 // Renders ResourceCell with the given chapter USJ wired through useProjectData, mirroring the
@@ -114,6 +178,10 @@ function renderResourceCell(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // The captured handler lives in a plain hoisted closure, which `clearAllMocks` does not reset.
+  // Without this, a test that drives the write-back channel without rendering Editorial would fire
+  // the PREVIOUS test's handler and pass vacuously.
+  captureEditorScrRefChange(undefined);
   mockUseProjectSetting.mockReturnValue(['ltr', vi.fn(), vi.fn(), false]);
 });
 
@@ -184,11 +252,8 @@ describe('ResourceCell viewMode', () => {
       chapterUsj: twoVerseChapterUsj,
     });
     await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
-    // mock.lastCall (rather than a non-null-asserted array index) avoids no-type-assertion.
-    const [fedUsj] = setUsjSpy.mock.lastCall ?? [];
-    const text = JSON.stringify(fedUsj);
-    expect(text).toContain('verse two');
-    expect(text).not.toContain('verse one'); // sliced, not whole chapter
+    expect(lastFedUsjText()).toContain('verse two');
+    expect(lastFedUsjText()).not.toContain('verse one'); // sliced, not whole chapter
   });
 
   it('chapter mode is unchanged: feeds the whole chapter', async () => {
@@ -198,20 +263,121 @@ describe('ResourceCell viewMode', () => {
       chapterUsj: twoVerseChapterUsj,
     });
     await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
-    const [fedUsj] = setUsjSpy.mock.lastCall ?? [];
-    expect(JSON.stringify(fedUsj)).toContain('verse one'); // whole chapter present
+    expect(lastFedUsjText()).toContain('verse one'); // whole chapter present
   });
 
   it('verse mode with no text for the verse shows the empty state, not the editor or "loading…"', async () => {
     renderResourceCell({
       viewMode: 'verse',
-      scrRef: { book: 'GEN', chapterNum: 1, verseNum: 0 }, // verse 0 → empty slice
+      // A verse this resource does not have (the chapter stops at verse 2) — the genuinely-missing
+      // case, which keeps the ghost text. Verse 0 no longer reaches here; it falls forward below.
+      scrRef: { book: 'GEN', chapterNum: 1, verseNum: 99 },
       chapterUsj: twoVerseChapterUsj,
     });
     // The empty label is rendered; the editor is not.
     expect(await screen.findByText(/no text for this verse/i)).toBeInTheDocument();
     expect(setUsjSpy).not.toHaveBeenCalled();
     expect(screen.queryByTestId('editorial')).not.toBeInTheDocument();
+  });
+});
+
+// Verse 0 is everything preceding verse 1, which a one-verse-tall cell cannot render usefully, so a
+// verse-0 reference displays verse 1 (Paratext 9 parity — PT-3133).
+describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
+  const verse0 = { book: 'GEN', chapterNum: 1, verseNum: 0 };
+
+  it('verse mode at verse 0 displays verse 1, not the empty state', async () => {
+    renderResourceCell({ viewMode: 'verse', scrRef: verse0, chapterUsj: twoVerseChapterUsj });
+    await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
+    expect(lastFedUsjText()).toContain('verse one');
+    expect(lastFedUsjText()).not.toContain('verse two'); // still a single-verse slice
+    expect(screen.queryByText(/no text for this verse/i)).not.toBeInTheDocument();
+  });
+
+  it('falls back to the empty state when the chapter has no verse 1 either', async () => {
+    renderResourceCell({ viewMode: 'verse', scrRef: verse0, chapterUsj: noVerseOneChapterUsj });
+    expect(await screen.findByText(/no text for this verse/i)).toBeInTheDocument();
+    // Must not scan forward to the next available verse — verse 2 is not what 1:0 means.
+    expect(lastFedUsjText()).not.toContain('verse two');
+  });
+
+  it('shows only verse 1, never the intro, superscription, or heading above it', async () => {
+    renderResourceCell({
+      viewMode: 'verse',
+      scrRef: { book: 'PSA', chapterNum: 3, verseNum: 0 },
+      chapterUsj: frontMatterChapterUsj,
+    });
+    await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
+    // Front matter leaking in would blow out a one-verse-tall row — the whole point of the fix.
+    expect(lastFedUsjText()).toContain('verse one');
+    expect(lastFedUsjText()).not.toContain('Book introduction');
+    expect(lastFedUsjText()).not.toContain('A Psalm of David');
+    expect(lastFedUsjText()).not.toContain('Morning Prayer');
+  });
+
+  it('emits the combined verse marker once when verse 1 opens a range', async () => {
+    renderResourceCell({
+      viewMode: 'verse',
+      scrRef: verse0,
+      chapterUsj: combinedOpeningChapterUsj,
+    });
+    await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
+    // Count the MARKER, not the text: a PT-3495 regression duplicates the opener, not the content.
+    expect(lastFedUsjText().match(/"number":"1-3"/g)).toHaveLength(1);
+  });
+
+  it('hands the editor the unresolved reference — only the displayed text falls forward', async () => {
+    renderResourceCell({ viewMode: 'verse', scrRef: verse0, chapterUsj: twoVerseChapterUsj });
+    await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
+    expect(capturedEditorScrRef).toHaveBeenLastCalledWith(expect.objectContaining({ verseNum: 0 }));
+  });
+
+  // Editorial's reference plugin runs even when read-only and reports any selection whose verse
+  // doesn't match scrRef. Under fall-forward that mismatch is permanent, so without a guard a click
+  // writes verse 1 — and, because the slice drops chapter chrome, chapter 1 — into the scroll group.
+  it('swallows the editor write-back at verse 0 so a click cannot move the scroll group', async () => {
+    const setScrRef = vi.fn();
+    setUsjResult(twoVerseChapterUsj, false);
+    render(
+      <ResourceCell
+        {...props}
+        setScrRef={setScrRef}
+        viewMode="verse"
+        scrRef={{ ...verse0, chapterNum: 5 }}
+      />,
+    );
+    await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
+    // What the real plugin reports for a click on verse-1 text in a chapter-chrome-free slice.
+    getEditorScrRefChange()?.({ book: 'GEN', chapterNum: 1, verseNum: 1 });
+    expect(setScrRef).not.toHaveBeenCalled();
+  });
+
+  it('still reports editor selection changes when the verse did not fall forward', async () => {
+    const setScrRef = vi.fn();
+    setUsjResult(twoVerseChapterUsj, false);
+    render(
+      <ResourceCell
+        {...props}
+        setScrRef={setScrRef}
+        viewMode="verse"
+        scrRef={{ book: 'GEN', chapterNum: 1, verseNum: 2 }}
+      />,
+    );
+    await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
+    const reported = { book: 'GEN', chapterNum: 1, verseNum: 2 };
+    getEditorScrRefChange()?.(reported);
+    expect(setScrRef).toHaveBeenCalledWith(reported);
+  });
+
+  it('chapter mode keeps verse-0 front matter — it is exempt from fall-forward', async () => {
+    renderResourceCell({
+      viewMode: 'chapter',
+      scrRef: { book: 'PSA', chapterNum: 3, verseNum: 0 },
+      chapterUsj: frontMatterChapterUsj,
+    });
+    await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
+    expect(lastFedUsjText()).toContain('A Psalm of David');
+    expect(lastFedUsjText()).toContain('Morning Prayer');
   });
 });
 

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -158,7 +158,11 @@ function setUsjResult(value: unknown, isLoading = false) {
 
 /** Serialized USJ most recently handed to the editor, or '' if it was never fed. */
 function lastFedUsjText(): string {
-  const [fedUsj] = setUsjSpy.mock.lastCall ?? [];
+  // Throws rather than returning '' when nothing was fed: an empty string silently satisfies every
+  // `.not.toContain(...)`, which is how a vacuous assertion slipped in here once. If the editor was
+  // never fed, assert `expect(setUsjSpy).not.toHaveBeenCalled()` instead of inspecting content.
+  if (!setUsjSpy.mock.lastCall) throw new Error('setUsj was never called — nothing was fed');
+  const [fedUsj] = setUsjSpy.mock.lastCall;
   return JSON.stringify(fedUsj) ?? '';
 }
 
@@ -297,8 +301,10 @@ describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
   it('falls back to the empty state when the chapter has no verse 1 either', async () => {
     renderResourceCell({ viewMode: 'verse', scrRef: verse0, chapterUsj: noVerseOneChapterUsj });
     expect(await screen.findByText(/no text for this verse/i)).toBeInTheDocument();
-    // Must not scan forward to the next available verse — verse 2 is not what 1:0 means.
-    expect(lastFedUsjText()).not.toContain('verse two');
+    // Must not scan forward to the next available verse — verse 2 is not what 1:0 means. Asserted as
+    // "never fed" rather than "fed text lacking verse two": once the empty state renders the effect
+    // has early-returned, so any content assertion would be inspecting a feed that never happened.
+    expect(setUsjSpy).not.toHaveBeenCalled();
   });
 
   it('shows only verse 1, never the intro, superscription, or heading above it', async () => {

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -166,7 +166,7 @@ function setUsjResult(value: unknown, isLoading = false) {
 function lastFedUsjText(): string {
   if (!setUsjSpy.mock.lastCall) throw new Error('setUsj was never called — nothing was fed');
   const [fedUsj] = setUsjSpy.mock.lastCall;
-  return JSON.stringify(fedUsj) ?? '';
+  return JSON.stringify(fedUsj);
 }
 
 // Renders ResourceCell with the given chapter USJ wired through useProjectData, mirroring the

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -156,11 +156,14 @@ function setUsjResult(value: unknown, isLoading = false) {
   mockUseProjectData.mockReturnValue({ ChapterUSJ: () => [value, vi.fn(), isLoading] });
 }
 
-/** Serialized USJ most recently handed to the editor, or '' if it was never fed. */
+/**
+ * Serialized USJ most recently handed to the editor.
+ *
+ * Throws rather than returning '' when nothing was fed: an empty string silently satisfies every
+ * `.not.toContain(...)`, which is how a vacuous assertion slipped in here once. If the editor was
+ * never fed, assert `expect(setUsjSpy).not.toHaveBeenCalled()` instead of inspecting content.
+ */
 function lastFedUsjText(): string {
-  // Throws rather than returning '' when nothing was fed: an empty string silently satisfies every
-  // `.not.toContain(...)`, which is how a vacuous assertion slipped in here once. If the editor was
-  // never fed, assert `expect(setUsjSpy).not.toHaveBeenCalled()` instead of inspecting content.
   if (!setUsjSpy.mock.lastCall) throw new Error('setUsj was never called — nothing was fed');
   const [fedUsj] = setUsjSpy.mock.lastCall;
   return JSON.stringify(fedUsj) ?? '';

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -375,6 +375,28 @@ describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
     expect(setScrRef).toHaveBeenCalledWith(reported);
   });
 
+  // The `viewMode` half of the guard. Chapter mode is where click-to-sync is genuinely load-bearing
+  // (the document carries real chapter chrome, so the plugin resolves and reports), and verse 0 is
+  // a perfectly ordinary reference there — the cell shows the front matter. Dropping `viewMode`
+  // from the guard would leave the grid's chapter mode and the Resource Viewer unable to sync at
+  // any chapter's verse 0, which no other test here would catch.
+  it('does not swallow the write-back in chapter mode at verse 0 — the guard is verse-mode only', async () => {
+    const setScrRef = vi.fn();
+    setUsjResult(frontMatterChapterUsj, false);
+    render(
+      <ResourceCell
+        {...props}
+        setScrRef={setScrRef}
+        viewMode="chapter"
+        scrRef={{ book: 'PSA', chapterNum: 3, verseNum: 0 }}
+      />,
+    );
+    await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
+    const reported = { book: 'PSA', chapterNum: 3, verseNum: 1 };
+    getEditorScrRefChange()?.(reported);
+    expect(setScrRef).toHaveBeenCalledWith(reported);
+  });
+
   it('chapter mode keeps verse-0 front matter — it is exempt from fall-forward', async () => {
     renderResourceCell({
       viewMode: 'chapter',

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -332,9 +332,12 @@ describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
     expect(capturedEditorScrRef).toHaveBeenLastCalledWith(expect.objectContaining({ verseNum: 0 }));
   });
 
-  // Editorial's reference plugin runs even when read-only and reports any selection whose verse
-  // doesn't match scrRef. Under fall-forward that mismatch is permanent, so without a guard a click
-  // writes verse 1 — and, because the slice drops chapter chrome, chapter 1 — into the scroll group.
+  // `Editorial` is mocked, so these two exercise ResourceCell's own write-back channel directly:
+  // they pin OUR side of the contract (which reports we forward and which we swallow), not the
+  // plugin's behavior — a mocked plugin cannot be evidence about the real one. The payload below is
+  // modeled on what platform-editor 0.8.14's `$findAndSetChapterAndVerse` emits for this case rather
+  // than invented, so the guard is pinned against a realistic input; see the comment in
+  // `resource-cell.component.tsx` for that trace and for why the payload changes shape upstream.
   it('swallows the editor write-back at verse 0 so a click cannot move the scroll group', async () => {
     const setScrRef = vi.fn();
     setUsjResult(twoVerseChapterUsj, false);
@@ -347,11 +350,14 @@ describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
       />,
     );
     await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
-    // What the real plugin reports for a click on verse-1 text in a chapter-chrome-free slice.
     getEditorScrRefChange()?.({ book: 'GEN', chapterNum: 1, verseNum: 1 });
     expect(setScrRef).not.toHaveBeenCalled();
   });
 
+  // The other half of the same contract: the guard is scoped to fall-forward, not to verse mode. In
+  // verse mode the real plugin has nothing to report (the slice holds exactly the verse `scrRef`
+  // names), so this pins that the guard would not swallow a report if one arrived — it is about
+  // reachability of OUR branch, not a claim that the plugin fires here.
   it('still reports editor selection changes when the verse did not fall forward', async () => {
     const setScrRef = vi.fn();
     setUsjResult(twoVerseChapterUsj, false);

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -402,6 +402,36 @@ describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
     expect(setScrRef).toHaveBeenCalledWith(reported);
   });
 
+  // Leaving the empty state, which two tests enter but none previously left. `ResourceCellView`
+  // swaps the editor out entirely for the ghost-text label while `isVerseEmpty`, so `Editorial`
+  // unmounts and `editorRef.current` goes null; navigating to a verse the resource HAS remounts it
+  // and the effect must refeed. That only works because React assigns refs during commit, before
+  // effects run — an ordering dependency nothing else here guards. Fall-forward makes this
+  // transition reachable at chapter boundaries more often than before.
+  it('refeeds the slice when navigating out of the empty state into a verse that exists', async () => {
+    setUsjResult(twoVerseChapterUsj, false);
+    const { rerender } = render(
+      <ResourceCell
+        {...props}
+        viewMode="verse"
+        scrRef={{ book: 'GEN', chapterNum: 1, verseNum: 99 }}
+      />,
+    );
+    expect(await screen.findByText(/no text for this verse/i)).toBeInTheDocument();
+    expect(setUsjSpy).not.toHaveBeenCalled(); // editor is unmounted; nothing fed
+
+    rerender(
+      <ResourceCell
+        {...props}
+        viewMode="verse"
+        scrRef={{ book: 'GEN', chapterNum: 1, verseNum: 2 }}
+      />,
+    );
+    await waitFor(() => expect(setUsjSpy).toHaveBeenCalled());
+    expect(lastFedUsjText()).toContain('verse two');
+    expect(screen.queryByText(/no text for this verse/i)).not.toBeInTheDocument();
+  });
+
   it('chapter mode keeps verse-0 front matter — it is exempt from fall-forward', async () => {
     renderResourceCell({
       viewMode: 'chapter',

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -332,12 +332,13 @@ describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
     expect(capturedEditorScrRef).toHaveBeenLastCalledWith(expect.objectContaining({ verseNum: 0 }));
   });
 
-  // `Editorial` is mocked, so these two exercise ResourceCell's own write-back channel directly:
-  // they pin OUR side of the contract (which reports we forward and which we swallow), not the
-  // plugin's behavior — a mocked plugin cannot be evidence about the real one. The payload below is
-  // modeled on what platform-editor 0.8.14's `$findAndSetChapterAndVerse` emits for this case rather
-  // than invented, so the guard is pinned against a realistic input; newer editor builds report
-  // nothing here instead. See the comment in `resource-cell.component.tsx` for both traces.
+  // `Editorial` is mocked, so these exercise ResourceCell's own write-back channel directly: they
+  // pin OUR side of the contract — which reports we forward and which we swallow. They are NOT
+  // evidence about the plugin, and the payloads are constructed, not observed. With the editor this
+  // repo builds (dev-packages 0.8.15) the plugin reports nothing at all in verse mode, because
+  // `$resolvePosition` will not describe a position in a document with no BookNode and no
+  // ChapterNode and `sliceUsjToVerse` drops both. These stay because they pin the guard's shape for
+  // the day slices become addressable — see `resource-cell.component.tsx`.
   it('swallows the editor write-back at verse 0 so a click cannot move the scroll group', async () => {
     const setScrRef = vi.fn();
     setUsjResult(twoVerseChapterUsj, false);
@@ -354,10 +355,8 @@ describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
     expect(setScrRef).not.toHaveBeenCalled();
   });
 
-  // The other half of the same contract: the guard is scoped to fall-forward, not to verse mode. In
-  // verse mode the real plugin has nothing to report (the slice holds exactly the verse `scrRef`
-  // names), so this pins that the guard would not swallow a report if one arrived — it is about
-  // reachability of OUR branch, not a claim that the plugin fires here.
+  // The other half of the same contract: the guard keys on fall-forward, not on verse mode alone.
+  // Again about OUR branch, not a claim that the plugin fires here.
   it('still reports editor selection changes when the verse did not fall forward', async () => {
     const setScrRef = vi.fn();
     setUsjResult(twoVerseChapterUsj, false);
@@ -375,11 +374,11 @@ describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
     expect(setScrRef).toHaveBeenCalledWith(reported);
   });
 
-  // The `viewMode` half of the guard. Chapter mode is where click-to-sync is genuinely load-bearing
-  // (the document carries real chapter chrome, so the plugin resolves and reports), and verse 0 is
-  // a perfectly ordinary reference there — the cell shows the front matter. Dropping `viewMode`
-  // from the guard would leave the grid's chapter mode and the Resource Viewer unable to sync at
-  // any chapter's verse 0, which no other test here would catch.
+  // The `viewMode` half of the guard, and the one case here that is NOT hypothetical: chapter mode
+  // feeds a whole chapter, so the document is addressable and the plugin really does report. Verse 0
+  // is an ordinary reference there — the cell shows the front matter. Dropping `viewMode` from the
+  // guard would leave the grid's chapter mode and the Resource Viewer unable to sync at any
+  // chapter's verse 0, which no other test here would catch.
   it('does not swallow the write-back in chapter mode at verse 0 — the guard is verse-mode only', async () => {
     const setScrRef = vi.fn();
     setUsjResult(frontMatterChapterUsj, false);

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -336,8 +336,8 @@ describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
   // they pin OUR side of the contract (which reports we forward and which we swallow), not the
   // plugin's behavior — a mocked plugin cannot be evidence about the real one. The payload below is
   // modeled on what platform-editor 0.8.14's `$findAndSetChapterAndVerse` emits for this case rather
-  // than invented, so the guard is pinned against a realistic input; see the comment in
-  // `resource-cell.component.tsx` for that trace and for why the payload changes shape upstream.
+  // than invented, so the guard is pinned against a realistic input; newer editor builds report
+  // nothing here instead. See the comment in `resource-cell.component.tsx` for both traces.
   it('swallows the editor write-back at verse 0 so a click cannot move the scroll group', async () => {
     const setScrRef = vi.fn();
     setUsjResult(twoVerseChapterUsj, false);

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -160,8 +160,8 @@ function setUsjResult(value: unknown, isLoading = false) {
  * Serialized USJ most recently handed to the editor.
  *
  * Throws rather than returning '' when nothing was fed: an empty string silently satisfies every
- * `.not.toContain(...)`, which is how a vacuous assertion slipped in here once. If the editor was
- * never fed, assert `expect(setUsjSpy).not.toHaveBeenCalled()` instead of inspecting content.
+ * `.not.toContain(...)`, so a vacuous assertion would pass unnoticed. If the editor was never fed,
+ * assert `expect(setUsjSpy).not.toHaveBeenCalled()` instead of inspecting content.
  */
 function lastFedUsjText(): string {
   if (!setUsjSpy.mock.lastCall) throw new Error('setUsj was never called — nothing was fed');
@@ -277,7 +277,7 @@ describe('ResourceCell viewMode', () => {
     renderResourceCell({
       viewMode: 'verse',
       // A verse this resource does not have (the chapter stops at verse 2) — the genuinely-missing
-      // case, which keeps the ghost text. Verse 0 no longer reaches here; it falls forward below.
+      // case, which keeps the ghost text. Verse 0 does not reach here; it falls forward below.
       scrRef: { book: 'GEN', chapterNum: 1, verseNum: 99 },
       chapterUsj: twoVerseChapterUsj,
     });
@@ -289,7 +289,7 @@ describe('ResourceCell viewMode', () => {
 });
 
 // Verse 0 is everything preceding verse 1, which a one-verse-tall cell cannot render usefully, so a
-// verse-0 reference displays verse 1 (Paratext 9 parity — PT-3133).
+// verse-0 reference displays verse 1, matching Paratext 9.
 describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
   const verse0 = { book: 'GEN', chapterNum: 1, verseNum: 0 };
 
@@ -405,12 +405,12 @@ describe('ResourceCell verse-0 fall-forward (PT-3133)', () => {
     expect(setScrRef).toHaveBeenCalledWith(reported);
   });
 
-  // Leaving the empty state, which two tests enter but none previously left. `ResourceCellView`
-  // swaps the editor out entirely for the ghost-text label while `isVerseEmpty`, so `Editorial`
-  // unmounts and `editorRef.current` goes null; navigating to a verse the resource HAS remounts it
-  // and the effect must refeed. That only works because React assigns refs during commit, before
+  // Leaving the empty state, which the tests above only ever enter. `ResourceCellView` swaps the
+  // editor out entirely for the ghost-text label while `isVerseEmpty`, so `Editorial` unmounts
+  // and `editorRef.current` goes null; navigating to a verse the resource HAS remounts it and
+  // the effect must refeed. That only works because React assigns refs during commit, before
   // effects run — an ordering dependency nothing else here guards. Fall-forward makes this
-  // transition reachable at chapter boundaries more often than before.
+  // transition reachable at every chapter boundary, so the refeed matters.
   it('refeeds the slice when navigating out of the empty state into a verse that exists', async () => {
     setUsjResult(twoVerseChapterUsj, false);
     const { rerender } = render(

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
@@ -168,6 +168,13 @@ export function ResourceCell({
   // group, dragging the Scripture Editor off the intro the user came from. Worse, the slice carries
   // no chapter marker, so the plugin defaults to chapter 1 and Luke 5:0 would report Luke 1:1.
   // Swallow that echo: fall-forward is display-only. Non-fallen-forward cells report normally.
+  //
+  // This guard belongs here, not upstream in `ScriptureReferencePlugin`. Gating that plugin on
+  // `isReadonly` would break the read-only surfaces that need it: it is bidirectional (it also moves
+  // the caret to `scrRef`), and these very cells depend on its reporting for click-to-sync at every
+  // normal verse. A read-only editor reporting its caret is correct; the bug is that WE told it a
+  // reference we then contradicted, so the component that created the mismatch is the one that owns
+  // it. Full reasoning, and what a future single-verse surface must copy: ADR-0013.
   const handleScrRefChange = useCallback(
     (nextScrRef: SerializedVerseRef) => {
       if (viewMode === 'verse' && isFallenForward) return;

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
@@ -162,37 +162,29 @@ export function ResourceCell({
   const displayVerseNum = resolveDisplayVerseNum(scrRef.verseNum);
   const isFallenForward = displayVerseNum !== scrRef.verseNum;
 
-  // Editorial's reference plugin is active even when read-only, and `$findAndSetChapterAndVerse`
-  // reports a selection whose CHAPTER or VERSE disagrees with `scrRef` (a chapter mismatch when the
-  // document has a chapter node, or a `scrRef` verse outside the selected verse marker's range) —
-  // not the verse alone. Under fall-forward that disagreement is permanent: we hand the editor verse
-  // 1's text while telling it verse 0, so `isVerseInRange(0, '1')` is false on every click. A single
-  // click would therefore push verse 1 into the shared scroll group, dragging the Scripture Editor
-  // off the intro the user came from. Worse, the slice carries no chapter marker, so
-  // `parseInt(chapterNode?.getNumber() ?? '1', 10)` yields chapter 1 and Luke 5:0 reports Luke 1:1 —
-  // a chapter jump. Swallow that echo: fall-forward is display-only.
+  // Fall-forward is display-only: we hand the editor verse 1's text while telling it verse 0, and
+  // that resolved verse must never reach the shared scroll group — it would drag the Scripture
+  // Editor off the intro the user came from. `Editorial`'s reference plugin stays mounted when
+  // read-only (`Editor.tsx` gates it on `scrRef && onScrRefChange` only) and reports selections that
+  // disagree with `scrRef`, so this swallows any such echo in a fallen-forward verse cell.
   //
-  // Non-fallen-forward cells report normally, but note what that means per mode. In CHAPTER mode the
-  // document carries real chapter chrome, so click-to-sync works. In VERSE mode the slice holds
-  // exactly the verse `scrRef` names, so a click resolves to that same verse, the plugin finds no
-  // disagreement, and nothing is reported — clicking a verse cell has nowhere to sync TO. That is
-  // pre-existing (the slice has dropped chapter chrome since #2509) and is not a lost capability.
+  // DEFENSE-IN-DEPTH, NOT A FIX FOR A LIVE REPORT. `$resolvePosition` refuses to describe a position
+  // in a document with no BookNode and no ChapterNode (upstream invariant I5), and `sliceUsjToVerse`
+  // drops both — so today the plugin is silent in verse mode and this branch is unreachable. It is
+  // kept because it costs nothing and is the right shape if slices ever become addressable. Don't
+  // read it as evidence that a write-back currently happens; the next person to touch this should
+  // not reason from a mechanism that isn't there. Verified against the editor this repo actually
+  // builds: `dev-packages/scripture-editors` `packages/platform` 0.8.15, which `postinstall` ->
+  // `link-dev-packages` yalc-links over `node_modules` (the 0.8.14 in `package-lock.json` is a
+  // placeholder the link replaces — don't verify against it).
   //
-  // The trace above is against `@eten-tech-foundation/platform-editor` 0.8.14 (lockfile-resolved and
-  // installed). Treat that as the floor, not the target: this repo's `main` already imports editor
-  // APIs 0.8.14 does not export, so the build we actually run is newer. In the newer build the
-  // plugin is rewritten around `$resolvePosition`, which refuses to describe a position in a
-  // document with no BookNode and no ChapterNode — a chrome-free slice is exactly that, so it
-  // reports nothing here. The guard is correct either way: a live fix against 0.8.14,
-  // defense-in-depth against the rewrite. Don't delete it on the strength of the rewrite alone.
-  //
-  // This guard belongs here, not upstream in `ScriptureReferencePlugin`. Gating that plugin on
+  // The guard belongs here, not upstream in `ScriptureReferencePlugin`. Gating that plugin on
   // `isReadonly` would break the read-only surfaces that need it: it is bidirectional (it also moves
   // the caret to `scrRef`), and read-only click-to-sync — which this grid's CHAPTER mode and the
-  // Resource Viewer depend on — would go with it. A read-only editor reporting its caret is correct;
-  // the bug is that WE told it a reference we then contradicted, so the component that created the
-  // mismatch is the one that owns it. Full reasoning, and what a future single-verse surface must
-  // copy: ADR-0013.
+  // Resource Viewer depend on, both feeding a whole chapter so the document is addressable — would
+  // go with it. A read-only editor reporting its caret is correct; the bug would be ours, since WE
+  // told it a reference we then contradicted. Full reasoning, and what a future single-verse surface
+  // must copy: ADR-0013.
   const handleScrRefChange = useCallback(
     (nextScrRef: SerializedVerseRef) => {
       if (viewMode === 'verse' && isFallenForward) return;

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
@@ -185,7 +185,7 @@ export function ResourceCell({
   // Resource Viewer depend on, both feeding a whole chapter so the document is addressable — would
   // go with it. A read-only editor reporting its caret is correct; the bug would be ours, since WE
   // told it a reference we then contradicted. Full reasoning, and what a future single-verse surface
-  // must copy: ADR-0013.
+  // must copy: ADR-0019.
   const handleScrRefChange = useCallback(
     (nextScrRef: SerializedVerseRef) => {
       if (viewMode === 'verse' && isFallenForward) return;

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
@@ -173,11 +173,10 @@ export function ResourceCell({
   // drops both — so today the plugin is silent in verse mode and this branch is unreachable. It is
   // kept because it costs nothing and is the right shape if slices ever become addressable. Don't
   // read it as evidence that a write-back currently happens; the next person to touch this should
-  // not reason from a mechanism that isn't there. Verified 2026-08-16 against platform-editor 0.8.15
-  // — both the published package and `dev-packages/scripture-editors`, which `postinstall` ->
-  // `link-dev-packages` yalc-links over `node_modules`. Read the LINKED build, not whatever
-  // `package-lock.json` names; a stale 0.8.14 tarball there is how this comment previously came to
-  // describe a chapter-1 write-back that cannot occur.
+  // not reason from a mechanism that isn't there. Holds against platform-editor 0.8.15 — both the
+  // published package and `dev-packages/scripture-editors`, which `postinstall` ->
+  // `link-dev-packages` yalc-links over `node_modules`. Read the LINKED build when checking this,
+  // not whatever version `package-lock.json` names; the two can disagree.
   //
   // The guard belongs here, not upstream in `ScriptureReferencePlugin`. Gating that plugin on
   // `isReadonly` would break the read-only surfaces that need it: it is bidirectional (it also moves

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
@@ -162,19 +162,36 @@ export function ResourceCell({
   const displayVerseNum = resolveDisplayVerseNum(scrRef.verseNum);
   const isFallenForward = displayVerseNum !== scrRef.verseNum;
 
-  // Editorial's reference plugin is active even when read-only, and it reports any selection whose
-  // verse doesn't match `scrRef`. Under fall-forward that mismatch is permanent — we hand it verse
-  // 1's text while telling it verse 0 — so a single click would push verse 1 into the shared scroll
-  // group, dragging the Scripture Editor off the intro the user came from. Worse, the slice carries
-  // no chapter marker, so the plugin defaults to chapter 1 and Luke 5:0 would report Luke 1:1.
-  // Swallow that echo: fall-forward is display-only. Non-fallen-forward cells report normally.
+  // Editorial's reference plugin is active even when read-only, and `$findAndSetChapterAndVerse`
+  // reports a selection whose CHAPTER or VERSE disagrees with `scrRef` (a chapter mismatch when the
+  // document has a chapter node, or a `scrRef` verse outside the selected verse marker's range) —
+  // not the verse alone. Under fall-forward that disagreement is permanent: we hand the editor verse
+  // 1's text while telling it verse 0, so `isVerseInRange(0, '1')` is false on every click. A single
+  // click would therefore push verse 1 into the shared scroll group, dragging the Scripture Editor
+  // off the intro the user came from. Worse, the slice carries no chapter marker, so
+  // `parseInt(chapterNode?.getNumber() ?? '1', 10)` yields chapter 1 and Luke 5:0 reports Luke 1:1 —
+  // a chapter jump. Swallow that echo: fall-forward is display-only.
+  //
+  // Non-fallen-forward cells report normally, but note what that means per mode. In CHAPTER mode the
+  // document carries real chapter chrome, so click-to-sync works. In VERSE mode the slice holds
+  // exactly the verse `scrRef` names, so a click resolves to that same verse, the plugin finds no
+  // disagreement, and nothing is reported — clicking a verse cell has nowhere to sync TO. That is
+  // pre-existing (the slice has dropped chapter chrome since #2509) and is not a lost capability.
+  //
+  // Traced against `@eten-tech-foundation/platform-editor` 0.8.14 — what `package-lock.json` pins
+  // and npm's current `latest`. Upstream `main` has since rewritten this plugin around
+  // `$resolvePosition`, which refuses to describe a position in a document with no BookNode and no
+  // ChapterNode; a chrome-free slice is exactly that, so on the release that lands the plugin goes
+  // silent here and this guard becomes defense-in-depth rather than a live fix. Re-check at the next
+  // version bump.
   //
   // This guard belongs here, not upstream in `ScriptureReferencePlugin`. Gating that plugin on
   // `isReadonly` would break the read-only surfaces that need it: it is bidirectional (it also moves
-  // the caret to `scrRef`), and these very cells depend on its reporting for click-to-sync at every
-  // normal verse. A read-only editor reporting its caret is correct; the bug is that WE told it a
-  // reference we then contradicted, so the component that created the mismatch is the one that owns
-  // it. Full reasoning, and what a future single-verse surface must copy: ADR-0013.
+  // the caret to `scrRef`), and read-only click-to-sync — which this grid's CHAPTER mode and the
+  // Resource Viewer depend on — would go with it. A read-only editor reporting its caret is correct;
+  // the bug is that WE told it a reference we then contradicted, so the component that created the
+  // mismatch is the one that owns it. Full reasoning, and what a future single-verse surface must
+  // copy: ADR-0013.
   const handleScrRefChange = useCallback(
     (nextScrRef: SerializedVerseRef) => {
       if (viewMode === 'verse' && isFallenForward) return;

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
@@ -173,10 +173,11 @@ export function ResourceCell({
   // drops both — so today the plugin is silent in verse mode and this branch is unreachable. It is
   // kept because it costs nothing and is the right shape if slices ever become addressable. Don't
   // read it as evidence that a write-back currently happens; the next person to touch this should
-  // not reason from a mechanism that isn't there. Verified against the editor this repo actually
-  // builds: `dev-packages/scripture-editors` `packages/platform` 0.8.15, which `postinstall` ->
-  // `link-dev-packages` yalc-links over `node_modules` (the 0.8.14 in `package-lock.json` is a
-  // placeholder the link replaces — don't verify against it).
+  // not reason from a mechanism that isn't there. Verified 2026-08-16 against platform-editor 0.8.15
+  // — both the published package and `dev-packages/scripture-editors`, which `postinstall` ->
+  // `link-dev-packages` yalc-links over `node_modules`. Read the LINKED build, not whatever
+  // `package-lock.json` names; a stale 0.8.14 tarball there is how this comment previously came to
+  // describe a chapter-1 write-back that cannot occur.
   //
   // The guard belongs here, not upstream in `ScriptureReferencePlugin`. Gating that plugin on
   // `isReadonly` would break the read-only surfaces that need it: it is bidirectional (it also moves

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
@@ -178,12 +178,13 @@ export function ResourceCell({
   // disagreement, and nothing is reported — clicking a verse cell has nowhere to sync TO. That is
   // pre-existing (the slice has dropped chapter chrome since #2509) and is not a lost capability.
   //
-  // Traced against `@eten-tech-foundation/platform-editor` 0.8.14 — what `package-lock.json` pins
-  // and npm's current `latest`. Upstream `main` has since rewritten this plugin around
-  // `$resolvePosition`, which refuses to describe a position in a document with no BookNode and no
-  // ChapterNode; a chrome-free slice is exactly that, so on the release that lands the plugin goes
-  // silent here and this guard becomes defense-in-depth rather than a live fix. Re-check at the next
-  // version bump.
+  // The trace above is against `@eten-tech-foundation/platform-editor` 0.8.14 (lockfile-resolved and
+  // installed). Treat that as the floor, not the target: this repo's `main` already imports editor
+  // APIs 0.8.14 does not export, so the build we actually run is newer. In the newer build the
+  // plugin is rewritten around `$resolvePosition`, which refuses to describe a position in a
+  // document with no BookNode and no ChapterNode — a chrome-free slice is exactly that, so it
+  // reports nothing here. The guard is correct either way: a live fix against 0.8.14,
+  // defense-in-depth against the rewrite. Don't delete it on the strength of the rewrite alone.
   //
   // This guard belongs here, not upstream in `ScriptureReferencePlugin`. Gating that plugin on
   // `isReadonly` would break the read-only surfaces that need it: it is bidirectional (it also moves

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.tsx
@@ -14,7 +14,7 @@ import {
 } from './resource-cell-view.component';
 import { DEFAULT_ZOOM_FACTOR, MAX_ZOOM_FACTOR, MIN_ZOOM_FACTOR } from './resource-zoom.utils';
 import type { ResourceZoomController } from './use-resource-zoom.hook';
-import { sliceUsjToVerse } from './verse-display.utils';
+import { resolveDisplayVerseNum, sliceUsjToVerse } from './verse-display.utils';
 
 const DEFAULT_TEXT_DIRECTION = 'ltr';
 const STRING_KEYS: LocalizeKey[] = [...RESOURCE_CELL_STRING_KEYS];
@@ -52,8 +52,9 @@ type ResourceCellProps = {
 /**
  * One resource, the focused chapter or verse. Reuses the resource-text-panel render path: fetch the
  * chapter, feed it to Editorial, which navigates to `scrRef`. In verse mode, feeds Editorial only
- * the slice for `scrRef.verseNum` (via `sliceUsjToVerse`) instead of the whole chapter. Delegates
- * layout and the downloading/failed visuals to `ResourceCellView`.
+ * that verse's slice instead of the whole chapter — a verse-0 reference shows verse 1
+ * ({@link resolveDisplayVerseNum}). Delegates layout and the downloading/failed visuals to
+ * `ResourceCellView`.
  */
 export function ResourceCell({
   resourceRef,
@@ -155,13 +156,33 @@ export function ResourceCell({
     }),
     [textDirection, extraValidMarkers],
   );
-  // Slice depends on scrRef.verseNum (unlike the chapter fetch memo above, which intentionally
-  // omits it — the chapter is identical across verses, but the slice is not).
+  // Only the USJ fed to the editor is resolved — `scrRef` passes through untouched. Keying the memo
+  // on the resolved verse (not scrRef.verseNum) also keeps 1:0 -> 1:1 from re-feeding identical
+  // content.
+  const displayVerseNum = resolveDisplayVerseNum(scrRef.verseNum);
+  const isFallenForward = displayVerseNum !== scrRef.verseNum;
+
+  // Editorial's reference plugin is active even when read-only, and it reports any selection whose
+  // verse doesn't match `scrRef`. Under fall-forward that mismatch is permanent — we hand it verse
+  // 1's text while telling it verse 0 — so a single click would push verse 1 into the shared scroll
+  // group, dragging the Scripture Editor off the intro the user came from. Worse, the slice carries
+  // no chapter marker, so the plugin defaults to chapter 1 and Luke 5:0 would report Luke 1:1.
+  // Swallow that echo: fall-forward is display-only. Non-fallen-forward cells report normally.
+  const handleScrRefChange = useCallback(
+    (nextScrRef: SerializedVerseRef) => {
+      if (viewMode === 'verse' && isFallenForward) return;
+      setScrRef(nextScrRef);
+    },
+    [viewMode, isFallenForward, setScrRef],
+  );
+
+  // Slice depends on the verse, unlike the chapter fetch memo above, which intentionally omits it —
+  // the chapter is identical across verses, but the slice is not.
   const verseSlice = useMemo(() => {
     if (viewMode !== 'verse') return undefined;
     if (!usjPossiblyError || isPlatformError(usjPossiblyError)) return undefined;
-    return sliceUsjToVerse(usjPossiblyError, scrRef.verseNum);
-  }, [viewMode, usjPossiblyError, scrRef.verseNum]);
+    return sliceUsjToVerse(usjPossiblyError, displayVerseNum);
+  }, [viewMode, usjPossiblyError, displayVerseNum]);
 
   useEffect(() => {
     if (state !== 'ready' || !usjPossiblyError || isPlatformError(usjPossiblyError)) return;
@@ -198,7 +219,7 @@ export function ResourceCell({
         <Editorial
           ref={editorRef}
           scrRef={scrRef}
-          onScrRefChange={setScrRef}
+          onScrRefChange={handleScrRefChange}
           options={options}
           logger={logger}
         />

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/scripture-text-grid.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/scripture-text-grid.component.test.tsx
@@ -122,6 +122,22 @@ describe('ScriptureTextGrid', () => {
       'עברית, MAT 5:3',
     ]);
   });
+  it('announces verse 1 at a verse-0 reference, matching what the cells render (PT-3133)', () => {
+    render(
+      <ScriptureTextGrid
+        resources={resources}
+        scrRef={{ ...scrRef, verseNum: 0 }}
+        setScrRef={setScrRef}
+        cellAccessibleNameTemplate="{resourceName}, {reference}"
+      />,
+    );
+    // Cells fall forward to verse 1, so announcing "5:0" would contradict the rendered verse number.
+    expect(screen.getAllByRole('listitem').map((c) => c.getAttribute('aria-label'))).toEqual([
+      'WEB, MAT 5:1',
+      'KJV, MAT 5:1',
+      'עברית, MAT 5:1',
+    ]);
+  });
   it('feeds the same scrRef to every cell', () => {
     render(<ScriptureTextGrid resources={resources} scrRef={scrRef} setScrRef={setScrRef} />);
     expect(screen.getByText('WEB@3')).toBeInTheDocument();

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/scripture-text-grid.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/scripture-text-grid.component.tsx
@@ -333,7 +333,7 @@ export function ScriptureTextGrid({
   // at a verse-0 reference they show verse 1. This names the row, not its contents — a resource that
   // lacks verse 1 shows the empty state under the same label.
   //
-  // Accepted a11y cost (ADR-0013): this makes verse 0 unobservable inside the grid. At MAT 5:0 the
+  // Accepted a11y cost (ADR-0019): this makes verse 0 unobservable inside the grid. At MAT 5:0 the
   // label announces "MAT 5:1" and the cells show verse 1, so a screen-reader user gets no in-grid
   // signal that the shared reference is 5:0. Naming the row after a verse the cells demonstrably do
   // not show would be worse. The boundary cues live outside the grid: the BCV control shows the real

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/scripture-text-grid.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/scripture-text-grid.component.tsx
@@ -7,6 +7,7 @@ import { ResourceCell, GridResource } from './resource-cell.component';
 import type { ZoomMenuLabels } from './resource-cell-view.component';
 import { useResourceZoomInput } from './use-resource-zoom-input.hook';
 import type { ResourceZoomController } from './use-resource-zoom.hook';
+import { resolveDisplayVerseNum } from './verse-display.utils';
 import { moveId } from '../scripture-text-grid-order.utils';
 
 export type ChapterContextResource = GridResource;
@@ -326,8 +327,10 @@ export function ScriptureTextGrid({
   // control (ArrowUp/ArrowDown) — the grip stops click/key propagation so reordering never triggers
   // the listitem's chapter-context activation. The Scripture reference is constant across rows in a
   // render, so format it once for the accessible name (`"{name}, {ref}"`, or just the name when no
-  // template is provided).
-  const reference = formatScrRef(scrRef);
+  // template is provided). Resolved so the announcement names the verse the cells actually display:
+  // at a verse-0 reference they show verse 1. This names the row, not its contents — a resource that
+  // lacks verse 1 shows the empty state under the same label.
+  const reference = formatScrRef({ ...scrRef, verseNum: resolveDisplayVerseNum(scrRef.verseNum) });
   const verseItemName = (label: string) =>
     cellAccessibleNameTemplate
       ? formatReplacementString(cellAccessibleNameTemplate, { resourceName: label, reference })

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/scripture-text-grid.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/scripture-text-grid.component.tsx
@@ -332,6 +332,13 @@ export function ScriptureTextGrid({
   // template is provided). Resolved so the announcement names the verse the cells actually display:
   // at a verse-0 reference they show verse 1. This names the row, not its contents — a resource that
   // lacks verse 1 shows the empty state under the same label.
+  //
+  // Accepted a11y cost (ADR-0013): this makes verse 0 unobservable inside the grid. At MAT 5:0 the
+  // label announces "MAT 5:1" and the cells show verse 1, so a screen-reader user gets no in-grid
+  // signal that the shared reference is 5:0. Naming the row after a verse the cells demonstrably do
+  // not show would be worse. The boundary cues live outside the grid: the BCV control shows the real
+  // reference, and its previous-verse button is disabled there (an announced state, not an inert
+  // control). What that button cannot do is roll back to the previous chapter — tracked in PT-4379.
   const reference = formatScrRef({ ...scrRef, verseNum: resolveDisplayVerseNum(scrRef.verseNum) });
   const verseItemName = (label: string) =>
     cellAccessibleNameTemplate

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/scripture-text-grid.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/scripture-text-grid.component.tsx
@@ -7,6 +7,7 @@ import { ResourceCell, GridResource } from './resource-cell.component';
 import type { ZoomMenuLabels } from './resource-cell-view.component';
 import { useResourceZoomInput } from './use-resource-zoom-input.hook';
 import type { ResourceZoomController } from './use-resource-zoom.hook';
+import { resolveDisplayVerseNum } from './verse-display.utils';
 import { moveId } from '../scripture-text-grid-order.utils';
 
 export type ChapterContextResource = GridResource;
@@ -328,8 +329,10 @@ export function ScriptureTextGrid({
   // control (ArrowUp/ArrowDown) — the grip stops click/key propagation so reordering never triggers
   // the listitem's chapter-context activation. The Scripture reference is constant across rows in a
   // render, so format it once for the accessible name (`"{name}, {ref}"`, or just the name when no
-  // template is provided).
-  const reference = formatScrRef(scrRef);
+  // template is provided). Resolved so the announcement names the verse the cells actually display:
+  // at a verse-0 reference they show verse 1. This names the row, not its contents — a resource that
+  // lacks verse 1 shows the empty state under the same label.
+  const reference = formatScrRef({ ...scrRef, verseNum: resolveDisplayVerseNum(scrRef.verseNum) });
   const verseItemName = (label: string) =>
     cellAccessibleNameTemplate
       ? formatReplacementString(cellAccessibleNameTemplate, { resourceName: label, reference })

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.test.ts
@@ -1,6 +1,22 @@
 import { describe, it, expect } from 'vitest';
 import { usxStringToUsj, Usj, MarkerObject } from '@eten-tech-foundation/scripture-utilities';
-import { parseVerseRange, verseRangeIncludes, sliceUsjToVerse } from './verse-display.utils';
+import {
+  parseVerseRange,
+  verseRangeIncludes,
+  sliceUsjToVerse,
+  resolveDisplayVerseNum,
+} from './verse-display.utils';
+
+describe('resolveDisplayVerseNum', () => {
+  it('resolves verse 0 to verse 1 (PT-3133 / Paratext 9 parity)', () => {
+    expect(resolveDisplayVerseNum(0)).toBe(1);
+  });
+  it('leaves every other verse alone', () => {
+    expect(resolveDisplayVerseNum(1)).toBe(1);
+    expect(resolveDisplayVerseNum(5)).toBe(5);
+    expect(resolveDisplayVerseNum(176)).toBe(176);
+  });
+});
 
 describe('parseVerseRange', () => {
   it('parses a single verse number', () => {
@@ -223,7 +239,9 @@ describe('sliceUsjToVerse — boundaries and empty', () => {
     expect(paragraphs(usj).some((p) => p.text.includes('Genealogy'))).toBe(false);
   });
 
-  it('is empty for a verse-0 request with no renderable text (PT-3133)', () => {
+  // Load-bearing: resolveDisplayVerseNum exists because sliceUsjToVerse stays mechanical. If someone
+  // moves the fall-forward in here, callers double-apply it and this test is what catches them.
+  it('slices a raw verse 0 to nothing — the fall-forward rule lives in the caller, not here', () => {
     const { usj, isEmpty } = sliceUsjToVerse(usjHeading, 0);
     expect(isEmpty).toBe(true);
     expect(paragraphs(usj)).toEqual([]);

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.ts
@@ -5,8 +5,9 @@ import { Usj, MarkerObject, MarkerContent } from '@eten-tech-foundation/scriptur
  * 1, everything else shows itself.
  *
  * Verse 0 is everything preceding verse 1 (intros, titles, Psalm superscriptions), which a
- * one-verse-tall cell cannot render usefully — so Paratext 9 shows verse 1 there and PT-3133 adopts
- * that. Display-only: callers must not write the resolved verse back to the scroll group.
+ * one-verse-tall cell cannot render usefully — so Paratext 9 shows verse 1 there and single-verse
+ * surfaces here match it. Display-only: callers must not write the resolved verse back to the
+ * scroll group.
  *
  * Chapter surfaces must NOT call this — they show verse-0 front matter directly. Full rationale and
  * rejected alternatives: ADR-0019.

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.ts
@@ -9,13 +9,13 @@ import { Usj, MarkerObject, MarkerContent } from '@eten-tech-foundation/scriptur
  * that. Display-only: callers must not write the resolved verse back to the scroll group.
  *
  * Chapter surfaces must NOT call this — they show verse-0 front matter directly. Full rationale and
- * rejected alternatives: ADR-0013.
+ * rejected alternatives: ADR-0019.
  *
  * @param verseNum Non-negative integer verse number, as carried by `SerializedVerseRef`. Only `0`
  *   is special-cased; anything else is returned unchanged, so a negative or fractional value passes
  *   through and then slices to nothing, surfacing as the empty state rather than as an error. That
  *   is unreachable through today's callers, but matters if this is promoted to
- *   `lib/platform-bible-utils` (see ADR-0013), where callers lose that guarantee.
+ *   `lib/platform-bible-utils` (see ADR-0019), where callers lose that guarantee.
  */
 export function resolveDisplayVerseNum(verseNum: number): number {
   return verseNum === 0 ? 1 : verseNum;

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.ts
@@ -10,6 +10,12 @@ import { Usj, MarkerObject, MarkerContent } from '@eten-tech-foundation/scriptur
  *
  * Chapter surfaces must NOT call this — they show verse-0 front matter directly. Full rationale and
  * rejected alternatives: ADR-0013.
+ *
+ * @param verseNum Non-negative integer verse number, as carried by `SerializedVerseRef`. Only `0`
+ *   is special-cased; anything else is returned unchanged, so a negative or fractional value passes
+ *   through and then slices to nothing, surfacing as the empty state rather than as an error. That
+ *   is unreachable through today's callers, but matters if this is promoted to
+ *   `lib/platform-bible-utils` (see ADR-0013), where callers lose that guarantee.
  */
 export function resolveDisplayVerseNum(verseNum: number): number {
   return verseNum === 0 ? 1 : verseNum;

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/verse-display.utils.ts
@@ -1,6 +1,21 @@
 import { Usj, MarkerObject, MarkerContent } from '@eten-tech-foundation/scripture-utilities';
 
 /**
+ * The verse a SINGLE-VERSE display surface should show for a focused reference: verse 0 shows verse
+ * 1, everything else shows itself.
+ *
+ * Verse 0 is everything preceding verse 1 (intros, titles, Psalm superscriptions), which a
+ * one-verse-tall cell cannot render usefully — so Paratext 9 shows verse 1 there and PT-3133 adopts
+ * that. Display-only: callers must not write the resolved verse back to the scroll group.
+ *
+ * Chapter surfaces must NOT call this — they show verse-0 front matter directly. Full rationale and
+ * rejected alternatives: ADR-0013.
+ */
+export function resolveDisplayVerseNum(verseNum: number): number {
+  return verseNum === 0 ? 1 : verseNum;
+}
+
+/**
  * Parses a (possibly combined/partial) verse marker into a numeric range. `"5"` → `{5,5}`,
  * `"14-15"` → `{14,15}`, `"1-3a"` → `{1,3}`, `"3a"` → `{3,3}`. Non-numeric → `{NaN,NaN}`.
  */
@@ -59,8 +74,13 @@ function isVerseOpener(node: MarkerContent): node is MarkerObject {
  * paragraphs). `usxStringToUsj` (the only USJ producer we consume) drops eid-only verse closers, so
  * there is no closer marker to look for; collection for a verse ends when the next verse opener is
  * hit or a structural/heading paragraph is reached; drops `book`/`chapter` chrome. Emits a
- * combined-verse marker (e.g. `"14-15"`) exactly once (PT-3495). `isEmpty` is true when the verse
- * has no renderable text — e.g. verse-0 or a verse missing from this resource (PT-3133).
+ * combined-verse marker (e.g. `"14-15"`) exactly once (PT-3495). `isEmpty` is true when the slice
+ * has no renderable text — the verse is absent from this resource, or present but whitespace-only —
+ * which callers render as an empty state rather than blanking the row.
+ *
+ * Purely mechanical: slices the verse you ask for. Surfaces taking their verse from a focused
+ * reference must pass it through {@link resolveDisplayVerseNum} first — a raw verse 0 slices to
+ * nothing.
  */
 export function sliceUsjToVerse(usj: Usj, verseNum: number): { usj: Usj; isEmpty: boolean } {
   const resultContent: MarkerContent[] = [];

--- a/lib/platform-bible-react/src/components/advanced/book-chapter-control/book-chapter-control.navigation.ts
+++ b/lib/platform-bible-react/src/components/advanced/book-chapter-control/book-chapter-control.navigation.ts
@@ -39,8 +39,7 @@ export function useQuickNavButtons(
   // boundaries the way the keyboard commands do) but intentionally pass no ScriptureBounds — there
   // is no versification source here, so verse navigation keeps its pre-versification
   // floor-at-0 / unbounded-increment behavior within a book. Making the buttons versification-aware
-  // to match the keyboard commands is tracked in PT-4379. (This previously cited PT-4143, which is
-  // actually about global keyboard shortcuts overriding context-sensitive ones.)
+  // to match the keyboard commands is tracked in PT-4379.
   //
   // Each target ref is computed once and reused for both the click handler and the disabled state,
   // so the button is disabled exactly when the step would be a no-op (no target, or the same ref).

--- a/lib/platform-bible-react/src/components/advanced/book-chapter-control/book-chapter-control.navigation.ts
+++ b/lib/platform-bible-react/src/components/advanced/book-chapter-control/book-chapter-control.navigation.ts
@@ -39,7 +39,8 @@ export function useQuickNavButtons(
   // boundaries the way the keyboard commands do) but intentionally pass no ScriptureBounds — there
   // is no versification source here, so verse navigation keeps its pre-versification
   // floor-at-0 / unbounded-increment behavior within a book. Making the buttons versification-aware
-  // to match the keyboard commands is tracked in PT-4143.
+  // to match the keyboard commands is tracked in PT-4379. (This previously cited PT-4143, which is
+  // actually about global keyboard shortcuts overriding context-sensitive ones.)
   //
   // Each target ref is computed once and reused for both the click handler and the disabled state,
   // so the button is disabled exactly when the step would be a no-op (no target, or the same ref).


### PR DESCRIPTION
Resolves [PT-3133](https://paratextstudio.atlassian.net/browse/PT-3133). Jira: [PT-4061](https://paratextstudio.atlassian.net/browse/PT-4061).

AI-assisted — session link to be added.

## What and why

A verse-0 reference means "everything preceding verse 1" — intros, titles, Psalm `\d` superscriptions — which a one-verse-tall Text Collection cell cannot render usefully. Paratext 9 shows verse 1 there, and PT-3133's written acceptance adopts that.

A4 (#2509) had shipped a "No text for this verse" empty state instead. That was Todd's suggestion on PT-3133, which Ian had called reasonable but explicitly "a different use case" from this one. Nobody flagged the divergence, so PT-3133 sat looking fixed while contradicting its own acceptance. **Ian re-confirmed PT9 parity on 2026-08-05** before this reversal was written.

Fall-forward is **display-only**: the scroll group stays at verse 0, so the Scripture Editor is not pulled off the intro the user clicked into to get here.

## Please scrutinize this part

**The editor write-back guard** (`resource-cell.component.tsx`). It is the subtlest thing in the diff, and the reasoning around it was wrong twice before landing here — see round 3.

Where it ended up: the guard is **defense-in-depth, not a fix for a live report**. Against the editor this repo actually builds (`dev-packages/scripture-editors` `packages/platform` 0.8.15, yalc-linked by `postinstall` → `link-dev-packages`), `$resolvePosition` refuses to describe a position in a document with no `BookNode` and no `ChapterNode` — upstream invariant I5 — and `sliceUsjToVerse` drops both. So the plugin is silent in verse mode and the `viewMode === 'verse'` branch is unreachable today.

It is kept because it costs nothing and is the right shape if slices ever become addressable, and because the mismatch is genuinely ours to own: we hand the editor verse 1's text while telling it verse 0. What it is **not** is evidence that a write-back currently occurs.

## Changes

- **`resolveDisplayVerseNum`** — verse 0 → verse 1, every other verse unchanged. `sliceUsjToVerse` stays deliberately mechanical: the rule is about the *reference*, not the USJ, and the accessible-name site needs it without having any USJ.
- **Write-back guard** — described above.
- **Grid accessible name** resolves the same way, so the announcement names the verse actually displayed. It names the row, not its contents (a resource lacking verse 1 shows the empty state under the same label).
- **Chapter surfaces stay exempt by design** — chapter mode, the chapter-context split, the single-resource grid path, and the Resource Viewer all show verse-0 front matter directly. A comment at the Resource Viewer's chapter fetch records why it must **not** consume the slice; wiring it up would blank the intro and was the original ticket's (incorrect) instruction.
- **ADR-0019** records the decision, the rejected alternatives, and the condition to revisit.

## Three accepted trade-offs

All are inherent to the decision rather than defects, and are documented in ADR-0019 rather than fixed:

1. Verse 0 and verse 1 now render identically with the same accessible name, so stepping across that boundary produces no perceptible change. The alternative is a row of ghost text at every chapter boundary.
2. Verse-0 content is not shown in verse view. It stays one click away via the chapter-context split, which renders the chapter unsliced — that escape hatch is what makes the trade acceptable.

3. **Verse 0 becomes unobservable inside the grid, including to assistive tech.** At MAT 5:0 the row label announces "MAT 5:1" and the cells show verse 1, so a screen-reader user gets no in-grid signal that the shared reference is 5:0. Naming the row after a verse the cells demonstrably do not show would be worse. The boundary cues live outside the grid: the BCV control still displays `5:0`, and its previous-verse button is **disabled** there (an announced state, not an inert control — pinned by `'Is disabled when at verse 0'` in `book-chapter-control.navigation.test.ts`).

## Testing

705 unit tests pass. Typecheck and lint clean on all changed files.

New coverage: `resolveDisplayVerseNum` (0→1, identity otherwise); verse 0 displays verse 1; front matter (intro + superscription + heading) never leaks into the cell; empty state when verse 1 is absent too, without scanning forward to verse 2; combined opener emits its marker once; the editor receives the unresolved reference; the write-back is swallowed at verse 0 but still reported for normal verses; chapter mode keeps front matter. The `sliceUsjToVerse(usj, 0) → empty` contract is pinned, since `resolveDisplayVerseNum` exists only because the slicer stays mechanical.

**Verified in the running app (2026-08-11).** Full manual pass, 10/10. Most importantly, clicking inside a cell at Luke 1:0 leaves the reference at 1:0, and the Luke 5:0 chapter-jump case holds — those two are the defect review caught, which no unit test could reach. Also confirmed: Psalm 3:0 shows only verse 1 with no superscription or heading leaking in, missing verses still show the ghost text, and the chapter surfaces (chapter view, single-resource path, Resource Viewer) are unchanged.


## Review round 2 (2026-08-13)

Five inline comments from @imnasnainaec, all addressed. Four are documentation-only; one is a one-line comment correction in `platform-bible-react`.

- **Content-aware fall-forward** is now in ADR-0019's rejected alternatives as **(d)**, with the reasoning: it would need the chapter USJ that the accessible-name site does not have, and per-resource content-awareness would make the same reference fall forward in one cell but not its neighbor.
- **Why the write-back guard is not upstream.** ADR-0019 now states this was considered and rejected on the merits, not deferred. `ScriptureReferencePlugin` is bidirectional (it also moves the caret to `scrRef`), and these cells depend on its reporting for click-to-sync at every normal verse — so an `isReadonly` gate would break read-only navigation *and* our own click-to-sync. The mismatch is host-made, so the host owns it. Verified against `@eten-tech-foundation/platform-editor` ~0.8.14.
- **The a11y cost is now stated** as accepted rather than implied — see trade-off 3 above, recorded in both ADR-0019 and a comment at the accessible-name site.
- **The `bounds` dead end is filed:** [PT-4379](https://paratextstudio.atlassian.net/browse/PT-4379), linked from ADR-0019. It is not a one-line fix — `ScriptureBounds` is built async over PAPI, and `BookChapterControl` lives in `platform-bible-react` with no PAPI access, so it must be threaded as a prop through every consumer of the BCV control.
- **"Second consumer" → "second consumer _of this rule_"**, with the reason: whole-chapter surfaces handle verse 0 under a deliberately different rule, so promoting on a surface count would turn an intentional difference into apparent drift.

**One correction to my own earlier text:** ADR-0019 previously called the previous-verse button "inert" at verse 0 and said fall-forward removed its "last remaining cue." Both were wrong — `isNoOpNavigation` disables the button there, and a test pins it. The ADR now says so and notes the correction. Separately, the comment at `book-chapter-control.navigation.ts` attributed this gap to PT-4143, which is actually about global keyboard shortcuts overriding context-sensitive ones; that citation now points at PT-4379.

[PT-3133]: https://paratextstudio.atlassian.net/browse/PT-3133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PT-4061]: https://paratextstudio.atlassian.net/browse/PT-4061?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


## Review round 3 (2026-08-16)

Five inline comments from @imnasnainaec on the editor mechanism this PR cited, plus one ⛏️. **He was right and I was wrong**, for a reason worth recording.

**I had the wrong editor.** My local `node_modules` held a stale npm 0.8.14 tarball, so I traced `$findAndSetChapterAndVerse` and its `parseInt(chapterNode?.getNumber() ?? "1", 10)` chapter-1 fallback and wrote them up as the live mechanism — in the ADR, the guard comment, the test comments, and this description. That plugin is not what runs. `postinstall` → `link-dev-packages` builds `dev-packages/scripture-editors` `packages/platform` at **0.8.15** and yalc-links it over `node_modules`; the 0.8.14 in `package-lock.json` is a placeholder that link replaces. CI does the same thing on every run.

I spent a while arguing the opposite from npm metadata (0.8.15 isn't published, `latest` is 0.8.14, and `main` imports four APIs 0.8.14 doesn't export). All true, and all beside the point — the repo consumes the editor from source, so the registry never enters into it. The four "missing" APIs were just my stale link.

**So, corrected throughout:**

- The guard is **defense-in-depth**, not a fix for a live report — `$resolvePosition` won't describe an unaddressable document (I5), the slice is exactly that, and the `viewMode === 'verse'` branch is unreachable today. **Luke 5:0 never becomes Luke 1:1.** Wording follows Ian's suggested replacement closely.
- Bidirectionality now cites `$moveCaretToVerseStart` and `$resolvePosition` → `onSelectionSettled` → `report`.
- **"relies on at every normal verse" was wrong**, now scoped to this grid's chapter mode and the Resource Viewer — both feed a whole chapter, so the document is addressable.
- The two write-back tests no longer claim to describe plugin behavior. `Editorial` is mocked; they pin *our* side of the channel, with constructed payloads, and say so.
- The version-comparison passage built on the same error is gone.

**Verified against the right source this time:** `dev-packages/.../ScriptureReferencePlugin.tsx` differs from upstream `main` only by a caret-placement tweak in `$moveCaretToVerseStart` — exactly as Ian said.

**Also in this round:** rebased onto latest `main`; dropped a diff-justifying parenthetical from `book-chapter-control.navigation.ts`; and added `'does not swallow the write-back in chapter mode at verse 0'`, which pins the one part of the guard that is *not* hypothetical — chapter mode is addressable, so the plugin really does report there, and every prior test held `viewMode` at `'verse'`. Verified falsifiable by reverting the check.

**Not taken:** the ⛏️ on `platform-scripture-editor.web-view.tsx`'s stale `versificationStr` comment. Confirmed correct (`positionToScrRef` carries the host's `versificationStr`), but it is outside this diff and Ian noted nothing needs changing. Happy to take it here if preferred.

**Correction to my own earlier text:** the round-2 testing note claimed a manual pass confirmed "normal-verse click-to-sync still works (so the guard is not too broad)." Wrong for verse mode — nothing reports there at all. What the manual pass actually covered is chapter mode, and the not-too-broad property is now pinned by the test above instead.

## Review round 4 (2026-08-19)

Two ⛏️ nitpicks from @imnasnainaec, both taken in one comment-only commit. No behavior change; 24 tests in the touched test file pass and Prettier is clean on both files.

- **ADR paragraph reflowed.** The `isReadonly` sub-bullet had a half-length line ending mid-sentence — leftover from an edit that cut the sentence's opening and never rewrapped the tail. Wrapped to the file's width end to end.
- **`lastFedUsjText`'s comments folded into its doc block** — and the doc line was indeed stale: it still promised `''` when nothing was fed, which stopped being true when the throw went in last round. The explanation of the throw is now the doc block's second paragraph, and the summary line no longer contradicts the code.

## Rebase (2026-08-22)

Rebased onto `main` three times over the course of this round; the two ⛏️ nitpicks from round 4 are in, plus one follow-up and one piece of bookkeeping.

- **`lastFedUsjText` no longer ends `?? ''`.** The throw already covers the never-fed case, so the fallback could only mask `JSON.stringify(undefined)` — which nothing feeds. Returning `undefined` there makes `.toContain`/`.not.toContain` fail loudly instead of passing vacuously, which is what the doc block promises.
- **The ADR is now ADR-0019, not ADR-0013.** `main` landed ADR-0013 through ADR-0018 while this branch was in review (`InstalledExtensions.packaged`, the analytics layer, per-web-view Ctrl+F, shadcn `Empty`, launch parameters, and the withdrawn launch token). Renumbered to the next free slot; the four citations in the grid's source comments and every reference in this description move with it. The ADR text itself is unchanged.
- **Three files this branch touches were also touched by PT-4341 and PT-4111** (`platform-scripture-editor.web-view.tsx`, `resource-text-panel.web-view.tsx`, `scripture-text-grid.component.tsx`). All auto-merged; verified the `versificationStr` comment, the Resource Viewer chapter-fetch comment, and the a11y comment plus `resolveDisplayVerseNum` call all survived intact.

**Verified on the final base:** `npm run typecheck` clean repo-wide; `npm run lint` 0 errors (4 pre-existing warnings, none in this diff); 159 tests in `scripture-text-grid/` and 21 in `book-chapter-control.navigation.test.ts` pass. Diff vs `main` is unchanged in shape — 11 files, 518 insertions.

**Comment sweep for #2586's rule.** `.claude/rules/code-quality/forward-facing-comments.md` landed after this branch was written, so every comment this branch adds or changes got the strip-the-PR-context test. Seven sites were narrating development history; a keyword grep over the added comment lines caught four that a read-through missed.

Cut: the "that stale rationale was corrected here" clause and the dated "Verified 2026-08-16" note; how a stale 0.8.14 tarball made an earlier version of that comment wrong; the `PT-3133`/`PT-4061` citations in `resource-text-panel.web-view.tsx` (tickets this PR closes — the constraint they carried now reads "single-verse surfaces resolve verse 0 to verse 1; whole-chapter surfaces like this one must not (see ADR-0019)"); "which is how a vacuous assertion slipped in here once"; "Verse 0 **no longer** reaches here"; "which two tests enter but none **previously** left"; and "more often **than before**".

Kept, because they point forward: the ADR-0019 pointers, the open PT-4379 follow-up, the PT-3495 regression an assertion guards, and the version constraint explaining why the `versificationStr` fallback exists at all. Test titles are untouched — the rule covers comments, and `PT-3133` in a `describe` reads as requirement traceability rather than development history. Say the word if you'd rather those go too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2663)
<!-- Reviewable:end -->




[PT-4379]: https://paratextstudio.atlassian.net/browse/PT-4379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ




