### PR TITLE
Keep the Button press nudge from clobbering caller translates

### DIFF
--- a/lib/platform-bible-react/src/components/shadcn-ui/button.test.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/button.test.tsx
@@ -5,32 +5,27 @@ import '@testing-library/jest-dom';
 import { Button } from '@/components/shadcn-ui/button';
 
 describe('Button', () => {
-  // Callers position icon buttons with translate utilities — `tw:-translate-y-1/2` to center one
-  // inside an input's end padding, for example. Every Tailwind translate utility writes the same
-  // `--tw-translate-y` custom property, so a pressed-state translate replaces the caller's
-  // centering rather than adding to it, and `:active` outranks the caller's unprefixed utility:
-  // the button drops half its own height for as long as it is held. Keeping the nudge on
-  // `transform` lets the two compose, since the browser applies `translate` before `transform`.
-  //
-  // jsdom cannot enter `:active` and computes no Tailwind CSS, so these pin the class rather than
-  // the rendered geometry. That is enough to fail if a future `shadcn apply` reverts the utility,
-  // which is the regression worth catching. `PressNudgeWithCallerTranslate` in `button.stories.tsx`
-  // is the manual check for the geometry itself.
+  // jsdom computes no Tailwind CSS and cannot enter `:active`, so these pin the class strings a
+  // `shadcn apply` would revert. `PressNudgeWithCallerTranslate` in `button.stories.tsx` is the
+  // manual check for the geometry they stand in for.
+
   it('puts the pressed-state nudge on transform, not on a translate utility', () => {
     render(<Button>Press me</Button>);
 
     const { className } = screen.getByRole('button');
 
-    expect(className).toContain('tw:active:not-aria-[haspopup]:transform-[translateY(1px)]');
+    expect(className).toMatch(/active:\S*transform-\[translateY/);
+    // The trailing hyphen is load-bearing: it matches the reverted `translate-y-px` and not
+    // `translateY(1px)`.
     expect(className).not.toMatch(/active:\S*translate-/);
   });
 
-  it('keeps a caller translate alongside the pressed-state nudge', () => {
-    render(<Button className="tw:-translate-y-1/2">Press me</Button>);
+  it('keeps the prefixed radius variable on the sizes that clamp their radius', () => {
+    render(<Button size="xs">Press me</Button>);
 
     const { className } = screen.getByRole('button');
 
-    expect(className).toContain('tw:-translate-y-1/2');
-    expect(className).toContain('tw:active:not-aria-[haspopup]:transform-[translateY(1px)]');
+    expect(className).toContain('var(--tw-radius-md)');
+    expect(className).not.toMatch(/var\(--radius-md\)/);
   });
 });

--- a/lib/platform-bible-react/src/components/shadcn-ui/button.test.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/button.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { Button } from '@/components/shadcn-ui/button';
+
+describe('Button', () => {
+  // Callers position icon buttons with translate utilities — `tw:-translate-y-1/2` to center one
+  // inside an input's end padding, for example. Every Tailwind translate utility writes the same
+  // `--tw-translate-y` custom property, so a pressed-state translate replaces the caller's
+  // centering rather than adding to it, and `:active` outranks the caller's unprefixed utility:
+  // the button drops half its own height for as long as it is held. Keeping the nudge on
+  // `transform` lets the two compose, since the browser applies `translate` before `transform`.
+  //
+  // jsdom cannot enter `:active` and computes no Tailwind CSS, so these pin the class rather than
+  // the rendered geometry. That is enough to fail if a future `shadcn apply` reverts the utility,
+  // which is the regression worth catching. `PressNudgeWithCallerTranslate` in `button.stories.tsx`
+  // is the manual check for the geometry itself.
+  it('puts the pressed-state nudge on transform, not on a translate utility', () => {
+    render(<Button>Press me</Button>);
+
+    const { className } = screen.getByRole('button');
+
+    expect(className).toContain('tw:active:not-aria-[haspopup]:transform-[translateY(1px)]');
+    expect(className).not.toMatch(/active:\S*translate-/);
+  });
+
+  it('keeps a caller translate alongside the pressed-state nudge', () => {
+    render(<Button className="tw:-translate-y-1/2">Press me</Button>);
+
+    const { className } = screen.getByRole('button');
+
+    expect(className).toContain('tw:-translate-y-1/2');
+    expect(className).toContain('tw:active:not-aria-[haspopup]:transform-[translateY(1px)]');
+  });
+});

--- a/lib/platform-bible-react/src/components/shadcn-ui/button.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/button.tsx
@@ -37,6 +37,11 @@ const buttonVariants = cva(
       size: {
         default:
           'tw:h-8 tw:gap-1.5 tw:px-2.5 tw:has-data-[icon=inline-end]:pe-2 tw:has-data-[icon=inline-start]:ps-2',
+        // CUSTOM: Renamed 'var(--radius-md)' to 'var(--tw-radius-md)' in the rounding utilities for
+        // the 'xs', 'sm', 'icon-xs', and 'icon-sm' sizes. 'src/index.css' imports Tailwind with
+        // 'prefix(tw)', which emits every '@theme' variable under a 'tw' prefix, so the
+        // boilerplate's unprefixed name resolves to nothing. That invalidates the whole 'min()' and
+        // leaves those four sizes with square corners.
         xs: 'tw:h-6 tw:gap-1 tw:rounded-[min(var(--tw-radius-md),10px)] tw:px-2 tw:text-xs tw:in-data-[slot=button-group]:rounded-lg tw:has-data-[icon=inline-end]:pe-1.5 tw:has-data-[icon=inline-start]:ps-1.5 tw:[&_svg:not([class*=size-])]:size-3',
         sm: 'tw:h-7 tw:gap-1 tw:rounded-[min(var(--tw-radius-md),12px)] tw:px-2.5 tw:text-[0.8rem] tw:in-data-[slot=button-group]:rounded-lg tw:has-data-[icon=inline-end]:pe-1.5 tw:has-data-[icon=inline-start]:ps-1.5 tw:[&_svg:not([class*=size-])]:size-3.5',
         lg: 'tw:h-9 tw:gap-1.5 tw:px-2.5 tw:has-data-[icon=inline-end]:pe-2 tw:has-data-[icon=inline-start]:ps-2',

--- a/lib/platform-bible-react/src/components/shadcn-ui/button.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/button.tsx
@@ -13,12 +13,12 @@ import { cn } from '@/utils/shadcn-ui/utils';
 const buttonVariants = cva(
   // CUSTOM: Added 'pr-twp' at the front of the base class string to apply Platform.Bible's
   // Tailwind CSS scope isolation. All Button instances inherit this via buttonVariants.
-  // CUSTOM: Changed the pressed-state nudge from 'tw:active:not-aria-[haspopup]:translate-y-px' to
-  // 'tw:active:not-aria-[haspopup]:transform-[translateY(1px)]' so it composes with caller
-  // positioning. Every Tailwind translate utility writes the same '--tw-translate-y' custom
-  // property, so the nudge replaced rather than added to a caller's translate: a Button centered
-  // with 'tw:-translate-y-1/2' jumped down half its own height while held. 'transform' is a separate
-  // property that the browser applies after 'translate', so the two now stack.
+  // CUSTOM: Moved the pressed-state nudge off 'tw:active:not-aria-[haspopup]:translate-y-px' onto
+  // 'transform'. Every Tailwind translate utility writes the same '--tw-translate-y', so the nudge
+  // replaced a caller's centering translate rather than adding to it. The browser applies
+  // 'translate', 'rotate' and 'scale' before 'transform', so those compose (a caller 'rotate-*' or
+  // 'scale-*' does rotate or scale the 1px); caller 'skew-*', 'rotate-x/y/z-*', 'transform*'
+  // utilities and inline style transforms still override it.
   'pr-twp tw:group/button tw:inline-flex tw:shrink-0 tw:items-center tw:justify-center tw:rounded-lg tw:border tw:border-transparent tw:bg-clip-padding tw:text-sm tw:font-medium tw:whitespace-nowrap tw:transition-all tw:outline-none tw:select-none tw:focus-visible:border-ring tw:focus-visible:ring-3 tw:focus-visible:ring-ring/50 tw:active:not-aria-[haspopup]:transform-[translateY(1px)] tw:disabled:pointer-events-none tw:disabled:opacity-50 tw:aria-invalid:border-destructive tw:aria-invalid:ring-3 tw:aria-invalid:ring-destructive/20 tw:dark:aria-invalid:border-destructive/50 tw:dark:aria-invalid:ring-destructive/40 tw:[&_svg]:pointer-events-none tw:[&_svg]:shrink-0 tw:[&_svg:not([class*=size-])]:size-4',
   {
     variants: {
@@ -38,10 +38,10 @@ const buttonVariants = cva(
         default:
           'tw:h-8 tw:gap-1.5 tw:px-2.5 tw:has-data-[icon=inline-end]:pe-2 tw:has-data-[icon=inline-start]:ps-2',
         // CUSTOM: Renamed 'var(--radius-md)' to 'var(--tw-radius-md)' in the rounding utilities for
-        // the 'xs', 'sm', 'icon-xs', and 'icon-sm' sizes. 'src/index.css' imports Tailwind with
-        // 'prefix(tw)', which emits every '@theme' variable under a 'tw' prefix, so the
-        // boilerplate's unprefixed name resolves to nothing. That invalidates the whole 'min()' and
-        // leaves those four sizes with square corners.
+        // the sizes that clamp their radius. 'src/index.css' imports Tailwind with 'prefix(tw)',
+        // which emits every '@theme' variable under a 'tw' prefix, so the boilerplate's unprefixed
+        // name resolves to nothing. That invalidates the whole 'min()' and leaves those sizes with
+        // square corners.
         xs: 'tw:h-6 tw:gap-1 tw:rounded-[min(var(--tw-radius-md),10px)] tw:px-2 tw:text-xs tw:in-data-[slot=button-group]:rounded-lg tw:has-data-[icon=inline-end]:pe-1.5 tw:has-data-[icon=inline-start]:ps-1.5 tw:[&_svg:not([class*=size-])]:size-3',
         sm: 'tw:h-7 tw:gap-1 tw:rounded-[min(var(--tw-radius-md),12px)] tw:px-2.5 tw:text-[0.8rem] tw:in-data-[slot=button-group]:rounded-lg tw:has-data-[icon=inline-end]:pe-1.5 tw:has-data-[icon=inline-start]:ps-1.5 tw:[&_svg:not([class*=size-])]:size-3.5',
         lg: 'tw:h-9 tw:gap-1.5 tw:px-2.5 tw:has-data-[icon=inline-end]:pe-2 tw:has-data-[icon=inline-start]:ps-2',

--- a/lib/platform-bible-react/src/components/shadcn-ui/button.tsx
+++ b/lib/platform-bible-react/src/components/shadcn-ui/button.tsx
@@ -13,7 +13,13 @@ import { cn } from '@/utils/shadcn-ui/utils';
 const buttonVariants = cva(
   // CUSTOM: Added 'pr-twp' at the front of the base class string to apply Platform.Bible's
   // Tailwind CSS scope isolation. All Button instances inherit this via buttonVariants.
-  'pr-twp tw:group/button tw:inline-flex tw:shrink-0 tw:items-center tw:justify-center tw:rounded-lg tw:border tw:border-transparent tw:bg-clip-padding tw:text-sm tw:font-medium tw:whitespace-nowrap tw:transition-all tw:outline-none tw:select-none tw:focus-visible:border-ring tw:focus-visible:ring-3 tw:focus-visible:ring-ring/50 tw:active:not-aria-[haspopup]:translate-y-px tw:disabled:pointer-events-none tw:disabled:opacity-50 tw:aria-invalid:border-destructive tw:aria-invalid:ring-3 tw:aria-invalid:ring-destructive/20 tw:dark:aria-invalid:border-destructive/50 tw:dark:aria-invalid:ring-destructive/40 tw:[&_svg]:pointer-events-none tw:[&_svg]:shrink-0 tw:[&_svg:not([class*=size-])]:size-4',
+  // CUSTOM: Changed the pressed-state nudge from 'tw:active:not-aria-[haspopup]:translate-y-px' to
+  // 'tw:active:not-aria-[haspopup]:transform-[translateY(1px)]' so it composes with caller
+  // positioning. Every Tailwind translate utility writes the same '--tw-translate-y' custom
+  // property, so the nudge replaced rather than added to a caller's translate: a Button centered
+  // with 'tw:-translate-y-1/2' jumped down half its own height while held. 'transform' is a separate
+  // property that the browser applies after 'translate', so the two now stack.
+  'pr-twp tw:group/button tw:inline-flex tw:shrink-0 tw:items-center tw:justify-center tw:rounded-lg tw:border tw:border-transparent tw:bg-clip-padding tw:text-sm tw:font-medium tw:whitespace-nowrap tw:transition-all tw:outline-none tw:select-none tw:focus-visible:border-ring tw:focus-visible:ring-3 tw:focus-visible:ring-ring/50 tw:active:not-aria-[haspopup]:transform-[translateY(1px)] tw:disabled:pointer-events-none tw:disabled:opacity-50 tw:aria-invalid:border-destructive tw:aria-invalid:ring-3 tw:aria-invalid:ring-destructive/20 tw:dark:aria-invalid:border-destructive/50 tw:dark:aria-invalid:ring-destructive/40 tw:[&_svg]:pointer-events-none tw:[&_svg]:shrink-0 tw:[&_svg:not([class*=size-])]:size-4',
   {
     variants: {
       variant: {

--- a/lib/platform-bible-react/src/stories/shadcn-ui/button.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/button.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn } from 'storybook/test';
+import { X } from 'lucide-react';
 import { Button } from '@/components/shadcn-ui/button';
 
 const meta: Meta<typeof Button> = {
@@ -296,5 +297,34 @@ export const ComplexInteraction: Story = {
       await expect(button).toBeInTheDocument();
       await expect(args.onClick).toHaveBeenCalledTimes(3);
     });
+  },
+};
+
+export const PressNudgeWithCallerTranslate: Story = {
+  render: () => (
+    <div className="tw:relative tw:w-64">
+      <input
+        aria-label="Search"
+        className="tw:h-8 tw:w-full tw:rounded-lg tw:border tw:border-border tw:bg-background tw:ps-2 tw:pe-8 tw:text-sm"
+        defaultValue="Search term"
+        readOnly
+      />
+      <Button
+        aria-label="Clear search"
+        className="tw:absolute tw:end-1 tw:top-1/2 tw:-translate-y-1/2"
+        size="icon-xs"
+        variant="ghost"
+      >
+        <X />
+      </Button>
+    </div>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The clear button is positioned by the caller with `tw:-translate-y-1/2`, the standard way to center an icon button inside an input. Hold it down: it should nudge 1px and stay vertically centered. The pressed nudge lives on `transform` rather than on a translate utility precisely so it composes with caller positioning instead of overwriting `--tw-translate-y`. No play function asserts the pressed geometry: it needs a held press and `tw:transition-all` animates it, so this story is the manual check. `button.test.tsx` pins the class instead.',
+      },
+    },
   },
 };

--- a/lib/platform-bible-react/src/stories/shadcn-ui/button.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/button.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { expect, fn } from 'storybook/test';
 import { X } from 'lucide-react';
 import { Button } from '@/components/shadcn-ui/button';
+import { Input } from '@/components/shadcn-ui/input';
 
 const meta: Meta<typeof Button> = {
   title: 'Shadcn/Button',
@@ -303,15 +304,11 @@ export const ComplexInteraction: Story = {
 export const PressNudgeWithCallerTranslate: Story = {
   render: () => (
     <div className="tw:relative tw:w-64">
-      <input
-        aria-label="Search"
-        className="tw:h-8 tw:w-full tw:rounded-lg tw:border tw:border-border tw:bg-background tw:ps-2 tw:pe-8 tw:text-sm"
-        defaultValue="Search term"
-        readOnly
-      />
+      <Input aria-label="Search" className="tw:w-full tw:ps-2 tw:pe-8" defaultValue="Search term" />
       <Button
         aria-label="Clear search"
-        className="tw:absolute tw:end-1 tw:top-1/2 tw:-translate-y-1/2"
+        className="tw:absolute tw:inset-e-1 tw:top-1/2 tw:-translate-y-1/2"
+        onClick={fn()}
         size="icon-xs"
         variant="ghost"
       >
@@ -323,7 +320,7 @@ export const PressNudgeWithCallerTranslate: Story = {
     docs: {
       description: {
         story:
-          'The clear button is positioned by the caller with `tw:-translate-y-1/2`, the standard way to center an icon button inside an input. Hold it down: it should nudge 1px and stay vertically centered. The pressed nudge lives on `transform` rather than on a translate utility precisely so it composes with caller positioning instead of overwriting `--tw-translate-y`. No play function asserts the pressed geometry: it needs a held press and `tw:transition-all` animates it, so this story is the manual check. `button.test.tsx` pins the class instead.',
+          'Hold the clear button down: it should nudge 1px and stay vertically centered. Centering it with `tw:-translate-y-1/2` is one common way to place an icon button inside an input, and it is the case the pressed-state nudge used to break.',
       },
     },
   },

--- a/lib/platform-bible-react/src/stories/shadcn-ui/button.stories.tsx
+++ b/lib/platform-bible-react/src/stories/shadcn-ui/button.stories.tsx
@@ -307,7 +307,7 @@ export const PressNudgeWithCallerTranslate: Story = {
       <Input aria-label="Search" className="tw:w-full tw:ps-2 tw:pe-8" defaultValue="Search term" />
       <Button
         aria-label="Clear search"
-        className="tw:absolute tw:inset-e-1 tw:top-1/2 tw:-translate-y-1/2"
+        className="tw:absolute tw:end-1 tw:top-1/2 tw:-translate-y-1/2"
         onClick={fn()}
         size="icon-xs"
         variant="ghost"


### PR DESCRIPTION
## Summary

`Button`'s pressed style nudges the button down 1px with `tw:active:not-aria-[haspopup]:translate-y-px`. Every Tailwind v4 translate utility writes the same `--tw-translate-y` custom property and then sets the `translate` shorthand from it, so the nudge *replaces* a caller's translate rather than adding to it — and `:active` outranks the caller's unprefixed utility. A `Button` centered with `tw:top-1/2 tw:-translate-y-1/2` — a common way to place an icon button inside an input — therefore jumps down half its own height for as long as it is held.

Compiled both utilities with this repo's Tailwind to confirm the collision:

```css
.tw\:-translate-y-1\/2 {
  --tw-translate-y: calc(calc(1 / 2 * 100%) * -1);
  translate: var(--tw-translate-x) var(--tw-translate-y);
}
.tw\:active\:not-aria-\[haspopup\]\:translate-y-px {
  &:active { &:not(*[aria-haspopup]) {
    --tw-translate-y: 1px;
    translate: var(--tw-translate-x) var(--tw-translate-y);
  } }
}
```

Moving the nudge to the `transform` property fixes it for every caller at once: per css-transforms-2 the browser applies `translate`, `rotate` and `scale` first and `transform` after, so the two compose instead of one overwriting the other. Callers get centering-plus-press with no workaround and no comment explaining one. `tw:transition-all` is already in the same base string, so the press animation is unchanged.

### Why review this

Not part of the current epic. Found while reviewing sillsdev/interlinearizer-extension#214, where two icon buttons jumped mid-click and were worked around downstream — the cause is here, and every consumer that centers a `Button` with a translate will hit it independently. `lib/platform-bible-react/src/stories/shadcn-ui/tooltip.stories.tsx:989` is a live instance in our own Storybook, so we currently demonstrate the broken idiom to anyone copying the pattern.

## Changes

- `button.tsx` — `tw:active:not-aria-[haspopup]:translate-y-px` → `tw:active:not-aria-[haspopup]:transform-[translateY(1px)]`, with a `// CUSTOM:` annotation that names what still collides (see the tradeoff note below). The original line arrived unannotated with the preset apply in a61ca3b913c, so without the annotation the next `shadcn apply` would silently revert this.
- `button.tsx` — annotated the pre-existing `--radius-md` → `--tw-radius-md` renames in the `xs`/`sm`/`icon-xs`/`icon-sm` variants, which came in unannotated with 55256831f97. `src/index.css` imports the theme with `prefix(tw)`, which emits `@theme` variables prefixed, so the boilerplate's unprefixed name resolves to nothing and those sizes lose their rounding entirely. Same reasoning as above: unannotated, so a preset apply reverts them silently.
- `button.test.tsx` (new) — two tests, one per silently-revertible customization: the nudge stays on `transform` and is not an `active:`-modified translate utility, and the clamped sizes keep `var(--tw-radius-md)`. Both fail when the corresponding customization is reverted (checked).
- `button.stories.tsx` — new `PressNudgeWithCallerTranslate` story: an icon button centered with `tw:-translate-y-1/2` inside the package's own `Input`, the exact idiom the old nudge broke.

No call sites needed changing: callers that center with translate utilities are fixed by this, and the one `-translate-y-1/2` clear-button in `platform-scripture`'s find component is a raw `<button>`, not this one.

## Testing

- [x] `npm run typecheck` in `lib/platform-bible-react` — passes
- [x] `prettier --check` on the changed files — passes (`shadcn-ui/` is ESLint-ignored)
- [x] Recompiled the prefixed class with the repo's Tailwind and confirmed it emits `transform: translateY(1px)` and no longer touches `--tw-translate-y`
- [x] `vitest --project=unit button.test.tsx` — 2 passed; re-run with both customizations reverted to confirm both fail
- [x] `vitest --project=storybook button.stories.tsx` — 17 passed, including the new story
- [ ] Visual check still wanted: open `Shadcn/Button` → `PressNudgeWithCallerTranslate`, hold the clear button, confirm it stays vertically centered and still nudges 1px

## Notes for the reviewer

- **The tradeoff this makes.** Compiling against the repo's Tailwind: `translate-*` writes `translate`, `scale-*` writes `scale`, and plain `rotate-*` writes `rotate` — all separate properties, so all three now compose with the nudge. What writes `transform` itself, and so still collides with it, is `skew-*`, `rotate-x/y/z-*`, the `transform`/`transform-gpu`/`transform-[…]` utilities, and inline `style={{ transform }}` (which now wins, since inline styles beat classes). No `Button` in this repo carries any of those. That is the right way round — the common idiom composes and the rare one loses — and the `// CUSTOM:` block records it. One second-order effect: because the individual properties are applied first, the 1px is measured in the button's own space, so a caller `rotate-*` or `scale-*` would rotate or scale the nudge.
- Not rebuilding `dist/` here; happy to add a rebuild if the PT team wants this out to consumers with this PR rather than the next build.
- interlinearizer's `ArcOverlay` works around the old behavior downstream and should move back to translate utilities once this lands.

## Why the tests are unit tests and not a play function

The pressed geometry is the thing worth testing, and a browser play function looks like where it could run for real — the `storybook` vitest project runs stories in Chromium and this file is already in it. It cannot work: Storybook's play-context `userEvent` dispatches synthetic events, and `:active` is a browser input state that untrusted events do not set. Measured it — a `[MouseLeft>]` press in that project leaves `button.matches(':active') === false` and the position delta at exactly `0`, with or without the fix, so the assertion would be non-falsifiable in the direction that matters. (`@storybook/addon-vitest` imports only `server` from `@vitest/browser/context`, not its CDP-backed `userEvent`.) Real geometry coverage would need a browser-mode test outside the storybook project, which is a new vitest project and out of scope.

What is left to assert deterministically is the class itself, and jsdom does that faster and without Playwright. So the split is: unit tests pin the classes, story is the human check for the geometry.

## Risk Level

Low — one utility class, no API change. Worst case is the 1px press nudge not rendering for some caller, which is cosmetic and visible in Storybook.

## AI Involvement

AI-assisted. Claude diagnosed the custom-property collision, verified it by compiling both utilities against the repo's own Tailwind, wrote the class change and the `// CUSTOM:` annotations, and added the tests and story. Opened as a draft pending my own review of the diagnosis and the visual check above.

Devin review: https://app.devin.ai/review/paranext/paranext-core/pull/2667

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2667)
<!-- Reviewable:end -->
