### PR TITLE
Add --wrap to run-e2e-wsl.sh and correct the e2e run recipes

### DIFF
--- a/.claude/skills/test-runner/SKILL.md
+++ b/.claude/skills/test-runner/SKILL.md
@@ -143,7 +143,7 @@ Prerequisite: App running with `--remote-debugging-port=9223` (the `app-runner` 
 ```bash
 npm stop  # Port 8876 must be free
 npm run test:e2e:smoke                 # the CI smoke project
-npm run test:e2e:isolated [subset]     # per-test isolated Electron suite
+npm run test:e2e:isolated [subset]     # isolated Electron suite (per test or per worker)
 # raw invocation, if needed: npx playwright test --config=e2e-tests/playwright.config.ts --project=smoke
 ```
 

--- a/.claude/skills/test-runner/SKILL.md
+++ b/.claude/skills/test-runner/SKILL.md
@@ -20,7 +20,7 @@ Run and analyze tests for Platform.Bible (paranext-core) with structured output.
 | C# by category | `dotnet test c-sharp-tests/ --filter "Category=Contract"` |
 | Watch mode | `npm run test:core -- path/to/dir` (vitest watches by default) |
 | E2E (CDP, running app) | `npx playwright test --config=e2e-tests/playwright-cdp.config.ts` |
-| E2E (standalone) | `npm run test:e2e:smoke` (CI project) or `npm run test:e2e:isolated [subset]` |
+| E2E (standalone) | `npm run test:e2e:smoke` (CI project) or `npm run test:e2e:isolated <subset>` |
 
 ## TypeScript Tests (Vitest)
 
@@ -143,7 +143,11 @@ Prerequisite: App running with `--remote-debugging-port=9223` (the `app-runner` 
 ```bash
 npm stop  # Port 8876 must be free
 npm run test:e2e:smoke                 # the CI smoke project
-npm run test:e2e:isolated [subset]     # isolated Electron suite (per test or per worker)
+npm run test:e2e:isolated <subset>     # isolated Electron suite (per test or per worker). The
+                                       # bare form and `all` do not run: the bare form lists the
+                                       # subsets and exits 1, and `all` includes title-bar/ and
+                                       # navigation-history/, which need an app this project's
+                                       # global setup refuses to start alongside
 # raw invocation, if needed: npx playwright test --config=e2e-tests/playwright.config.ts --project=smoke
 ```
 

--- a/.context/standards/Testing-Guide.md
+++ b/.context/standards/Testing-Guide.md
@@ -1329,7 +1329,9 @@ npx playwright show-report e2e-tests/playwright-report
 # `npm run test:e2e:smoke`), `enhanced-resources` → tests/enhanced-resources/**.
 npx playwright test e2e-tests/tests/isolated/{feature}/ --config=e2e-tests/playwright.config.ts --project=isolated --reporter=list
 
-# WSL2: wrap any of the above so Electron windows do not take over the Windows desktop.
+# WSL2: wrap a standalone-mode run so its Electron windows do not take over the Windows desktop.
+# Only works when the app is launched inside the wrap — CDP mode attaches to an app started by
+# ./.erb/scripts/refresh.sh, which on Linux already runs it under its own Xvfb.
 # A bare Xvfb has no window manager, so compositor-dependent suites can behave differently.
 e2e-tests/run-e2e-wsl.sh --wrap npx playwright test e2e-tests/tests/isolated/{feature}/ --config=e2e-tests/playwright.config.ts --project=isolated
 ```

--- a/.context/standards/Testing-Guide.md
+++ b/.context/standards/Testing-Guide.md
@@ -1328,6 +1328,10 @@ npx playwright show-report e2e-tests/playwright-report
 # tests/isolated/** (most feature tests), `smoke` → tests/smoke/** (what CI runs, via
 # `npm run test:e2e:smoke`), `enhanced-resources` → tests/enhanced-resources/**.
 npx playwright test e2e-tests/tests/isolated/{feature}/ --config=e2e-tests/playwright.config.ts --project=isolated --reporter=list
+
+# WSL2: wrap any of the above so Electron windows do not take over the Windows desktop.
+# A bare Xvfb has no window manager, so compositor-dependent suites can behave differently.
+e2e-tests/run-e2e-wsl.sh --wrap npx playwright test e2e-tests/tests/isolated/{feature}/ --config=e2e-tests/playwright.config.ts --project=isolated
 ```
 
 ### Failure Analysis

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,11 +165,12 @@ jobs:
       - name: npm unit tests
         run: npm test
 
-      # No --server-args, so this runs at Xvfb's 1280x1024x8 default, unlike
-      # e2e-tests/run-e2e-wsl.sh which pins 1920x1080x24. That is fine for the smoke suite
-      # (it does not use cdp.fixture), but fixtures/cdp.fixture.ts hard-fails screenshots below
-      # Full HD — add --server-args="-screen 0 1920x1080x24" here before running any
-      # cdp.fixture-based project in CI.
+      # No --server-args, so this runs at Xvfb's 1280x1024x8 default. Fine here: the smoke
+      # suite launches its own Electron and does not use cdp.fixture. A cdp.fixture-based job
+      # cannot be added by putting --server-args on this step — that fixture attaches over port
+      # 9223 to an app started elsewhere, so this xvfb-run would never govern that app's window.
+      # Such a job has to start the app and Playwright under one Xvfb at 1920x1080x24, which is
+      # what fixtures/cdp.fixture.ts requires for screenshots.
       - name: E2E tests (Linux)
         if: ${{ matrix.os == env.OS_LINUX }}
         run: xvfb-run --auto-servernum npm run test:e2e:smoke

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,6 +165,11 @@ jobs:
       - name: npm unit tests
         run: npm test
 
+      # No --server-args, so this runs at Xvfb's 1280x1024x8 default, unlike
+      # e2e-tests/run-e2e-wsl.sh which pins 1920x1080x24. That is fine for the smoke suite
+      # (it does not use cdp.fixture), but fixtures/cdp.fixture.ts hard-fails screenshots below
+      # Full HD — add --server-args="-screen 0 1920x1080x24" here before running any
+      # cdp.fixture-based project in CI.
       - name: E2E tests (Linux)
         if: ${{ matrix.os == env.OS_LINUX }}
         run: xvfb-run --auto-servernum npm run test:e2e:smoke

--- a/README.md
+++ b/README.md
@@ -463,7 +463,10 @@ All `test:e2e:*` scripts are there for running variations of the playwright end-
   the `title-bar` and `navigation-history` subsets attach to a running app over CDP, which the
   project's own global setup refuses to start alongside
 - `test:e2e-cdp` runs tests that require the application UI to be open already
-- `test:e2e:all` runs all configured tests
+- `test:e2e:all` runs every project in `e2e-tests/playwright.config.ts`. Like
+  `test:e2e:isolated all` it cannot currently pass: `enhanced-resources`, `title-bar` and
+  `navigation-history` all attach to a running app, which that config's global setup refuses to
+  start alongside
 
 ## Storybook
 

--- a/README.md
+++ b/README.md
@@ -456,12 +456,12 @@ All `test:e2e:*` scripts are there for running variations of the playwright end-
 - `test:e2e:smoke-wsl` runs the same smoke tests using a "hidden UI" on Linux instead of a visible
   UI. Its script also takes `--wrap <command>` to run any other e2e command the same way, e.g.
   `e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated multi-window`
-- `test:e2e:isolated` runs tests that mostly require a separate application instance for each
-  test. These tests are organized into feature subsets under `e2e-tests/tests/isolated/`; run
-  `npm run test:e2e:isolated all` for every test, `npm run test:e2e:isolated <subset>` for one
-  feature, or pass no arguments to list the available subsets (no tests are run in that case).
-  `all` needs the app already running via `./.erb/scripts/refresh.sh`, because the `title-bar`
-  and `navigation-history` subsets attach to it over CDP instead of launching their own
+- `test:e2e:isolated` runs tests that need their own application instance rather than sharing
+  one. These tests are organized into feature subsets under `e2e-tests/tests/isolated/`; run
+  `npm run test:e2e:isolated <subset>` for one feature, or pass no arguments to list the available
+  subsets (no tests are run in that case). `npm run test:e2e:isolated all` does not currently pass:
+  the `title-bar` and `navigation-history` subsets attach to a running app over CDP, which the
+  project's own global setup refuses to start alongside
 - `test:e2e-cdp` runs tests that require the application UI to be open already
 - `test:e2e:all` runs all configured tests
 

--- a/README.md
+++ b/README.md
@@ -456,10 +456,12 @@ All `test:e2e:*` scripts are there for running variations of the playwright end-
 - `test:e2e:smoke-wsl` runs the same smoke tests using a "hidden UI" on Linux instead of a visible
   UI. Its script also takes `--wrap <command>` to run any other e2e command the same way, e.g.
   `e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated multi-window`
-- `test:e2e:isolated` runs tests that require a separate application instance for each test. These
-  tests are organized into feature subsets under `e2e-tests/tests/isolated/`; run
+- `test:e2e:isolated` runs tests that mostly require a separate application instance for each
+  test. These tests are organized into feature subsets under `e2e-tests/tests/isolated/`; run
   `npm run test:e2e:isolated all` for every test, `npm run test:e2e:isolated <subset>` for one
-  feature, or pass no arguments to list the available subsets (no tests are run in that case)
+  feature, or pass no arguments to list the available subsets (no tests are run in that case).
+  `all` needs the app already running via `./.erb/scripts/refresh.sh`, because the `title-bar`
+  and `navigation-history` subsets attach to it over CDP instead of launching their own
 - `test:e2e-cdp` runs tests that require the application UI to be open already
 - `test:e2e:all` runs all configured tests
 

--- a/README.md
+++ b/README.md
@@ -453,7 +453,9 @@ npm run test:e2e:smoke
 All `test:e2e:*` scripts are there for running variations of the playwright end-to-end tests.
 
 - `test:e2e:smoke` runs a single instance of the application, and all tests share that instance
-- `test:e2e:smoke-wsl` runs the same smoke tests using a "hidden UI" on Linux instead of a visible UI
+- `test:e2e:smoke-wsl` runs the same smoke tests using a "hidden UI" on Linux instead of a visible
+  UI. Its script also takes `--wrap <command>` to run any other e2e command the same way, e.g.
+  `e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated multi-window`
 - `test:e2e:isolated` runs tests that require a separate application instance for each test. These
   tests are organized into feature subsets under `e2e-tests/tests/isolated/`; run
   `npm run test:e2e:isolated all` for every test, `npm run test:e2e:isolated <subset>` for one

--- a/e2e-tests/CLAUDE.md
+++ b/e2e-tests/CLAUDE.md
@@ -6,7 +6,10 @@
 |---|---|---|
 | Core happy path (app launch, basic nav) | `tests/smoke/` | `npm run test:e2e:smoke` (also CI) |
 | Feature tests, state-mutating flows | `tests/isolated/` | `npm run test:e2e:isolated` |
-| Tests needing real Marble resources | `tests/enhanced-resources/` | `npm run test:e2e:enhanced-resources` |
+| Tests needing real Marble resources | `tests/enhanced-resources/` | `npx playwright test --config e2e-tests/playwright.config.ts --project=enhanced-resources` |
+
+On WSL2, prefix any of these with `e2e-tests/run-e2e-wsl.sh --wrap` to keep the Electron windows
+off the Windows desktop — e.g. `e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated find`.
 
 **Feature-specific isolated tests belong in `tests/isolated/`** — not in their own directory.
 The `isolated` project covers the whole `tests/isolated/` tree, so a new spec file there is
@@ -14,8 +17,9 @@ immediately discoverable and runnable without any config changes.
 
 Only create a new top-level directory under `tests/` if the tests genuinely cannot share a
 project entry with `isolated/` (e.g., they need a completely different fixture or launch
-strategy). If you do, register a named project in `playwright.config.ts` and add a
-`test:e2e:<name>` npm script — see `enhanced-resources` as the template.
+strategy). If you do, register a named project in `playwright.config.ts` — see
+`enhanced-resources` as the template — and add a `test:e2e:<name>` npm script if the suite is
+meant to be run routinely.
 
 ## What NOT to do
 

--- a/e2e-tests/CLAUDE.md
+++ b/e2e-tests/CLAUDE.md
@@ -6,16 +6,22 @@
 |---|---|---|
 | Core happy path (app launch, basic nav) | `tests/smoke/` | `npm run test:e2e:smoke` (also CI) |
 | Feature tests, state-mutating flows | `tests/isolated/` | `npm run test:e2e:isolated all` (the bare form lists the subsets and exits 1) |
-| Tests needing real Marble resources | `tests/enhanced-resources/` | `npx playwright test --config e2e-tests/playwright.config.ts --project=enhanced-resources` |
+| Tests needing real Marble resources | `tests/enhanced-resources/` | app running, then `npx playwright test --config e2e-tests/playwright-cdp.config.ts tests/enhanced-resources/` |
 
 On WSL2, prefix a suite that launches its own Electron with `e2e-tests/run-e2e-wsl.sh --wrap` to
 keep its windows off the Windows desktop — e.g.
 `e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated find`.
 
 This does nothing for suites built on `fixtures/cdp.fixture.ts`, which attach over port 9223 to an
-app you started separately: all of `tests/enhanced-resources/`, plus the `title-bar/` and
-`navigation-history/` isolated subsets. Start those with `./.erb/scripts/refresh.sh`, which on
-Linux already runs the app under its own Xvfb.
+app you started separately: all of `tests/enhanced-resources/`, `tests/manage-books/` and
+`tests/markers-checklist/`, plus the `title-bar/` and `navigation-history/` isolated subsets. Start
+the app with `./.erb/scripts/refresh.sh` — on Linux that already runs it under its own Xvfb — and
+run those suites through `playwright-cdp.config.ts`, which has no globalSetup.
+
+`title-bar/` and `navigation-history/` are the exception to the exception: they sit under
+`tests/isolated/`, which `playwright-cdp.config.ts` ignores, while the `isolated` project's
+globalSetup refuses to start while an app holds port 8876. Until they move or globalSetup gains an
+opt-out, there is no way to run them.
 
 **Feature-specific isolated tests belong in `tests/isolated/`** — not in their own directory.
 The `isolated` project covers the whole `tests/isolated/` tree, so a new spec file there is

--- a/e2e-tests/CLAUDE.md
+++ b/e2e-tests/CLAUDE.md
@@ -8,8 +8,14 @@
 | Feature tests, state-mutating flows | `tests/isolated/` | `npm run test:e2e:isolated` |
 | Tests needing real Marble resources | `tests/enhanced-resources/` | `npx playwright test --config e2e-tests/playwright.config.ts --project=enhanced-resources` |
 
-On WSL2, prefix any of these with `e2e-tests/run-e2e-wsl.sh --wrap` to keep the Electron windows
-off the Windows desktop — e.g. `e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated find`.
+On WSL2, prefix a suite that launches its own Electron with `e2e-tests/run-e2e-wsl.sh --wrap` to
+keep its windows off the Windows desktop — e.g.
+`e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated find`.
+
+This does nothing for suites built on `fixtures/cdp.fixture.ts`, which attach over port 9223 to an
+app you started separately: all of `tests/enhanced-resources/`, plus the `title-bar/` and
+`navigation-history/` isolated subsets. Start those with `./.erb/scripts/refresh.sh`, which on
+Linux already runs the app under its own Xvfb.
 
 **Feature-specific isolated tests belong in `tests/isolated/`** — not in their own directory.
 The `isolated` project covers the whole `tests/isolated/` tree, so a new spec file there is

--- a/e2e-tests/CLAUDE.md
+++ b/e2e-tests/CLAUDE.md
@@ -12,8 +12,9 @@ On WSL2, prefix a suite that launches its own Electron with `e2e-tests/run-e2e-w
 keep its windows off the Windows desktop — e.g.
 `e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated find`.
 
-This does nothing for suites built on `fixtures/cdp.fixture.ts`, which attach over port 9223 to an
-app you started separately: all of `tests/enhanced-resources/`, `tests/manage-books/` and
+This does nothing for suites that attach to an app you started separately — `fixtures/cdp.fixture.ts`
+over port 9223, and the two `*-commands.spec.ts` files' `fixtures/papi-live.fixture.ts` over port
+8876. Between them that is all of `tests/enhanced-resources/`, `tests/manage-books/` and
 `tests/markers-checklist/`, plus the `title-bar/` and `navigation-history/` isolated subsets. Start
 the app with `./.erb/scripts/refresh.sh` — on Linux that already runs it under its own Xvfb — and
 run those suites through `playwright-cdp.config.ts`, which has no globalSetup.

--- a/e2e-tests/CLAUDE.md
+++ b/e2e-tests/CLAUDE.md
@@ -5,7 +5,7 @@
 | What you're testing | Where it goes | How to run |
 |---|---|---|
 | Core happy path (app launch, basic nav) | `tests/smoke/` | `npm run test:e2e:smoke` (also CI) |
-| Feature tests, state-mutating flows | `tests/isolated/` | `npm run test:e2e:isolated all` (the bare form lists the subsets and exits 1) |
+| Feature tests, state-mutating flows | `tests/isolated/` | `npm run test:e2e:isolated <subset>` (`all` does not currently pass — see below; the bare form lists the subsets and exits 1) |
 | Tests needing real Marble resources | `tests/enhanced-resources/` | app running, then `npx playwright test --config e2e-tests/playwright-cdp.config.ts tests/enhanced-resources/` |
 
 On WSL2, prefix a suite that launches its own Electron with `e2e-tests/run-e2e-wsl.sh --wrap` to

--- a/e2e-tests/CLAUDE.md
+++ b/e2e-tests/CLAUDE.md
@@ -5,7 +5,7 @@
 | What you're testing | Where it goes | How to run |
 |---|---|---|
 | Core happy path (app launch, basic nav) | `tests/smoke/` | `npm run test:e2e:smoke` (also CI) |
-| Feature tests, state-mutating flows | `tests/isolated/` | `npm run test:e2e:isolated` |
+| Feature tests, state-mutating flows | `tests/isolated/` | `npm run test:e2e:isolated all` (the bare form lists the subsets and exits 1) |
 | Tests needing real Marble resources | `tests/enhanced-resources/` | `npx playwright test --config e2e-tests/playwright.config.ts --project=enhanced-resources` |
 
 On WSL2, prefix a suite that launches its own Electron with `e2e-tests/run-e2e-wsl.sh --wrap` to

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -4,7 +4,9 @@ import { defineConfig } from '@playwright/test';
  * Playwright configuration for paranext-core E2E tests.
  *
  * - `smoke` (default): tests share a single Electron instance per worker — fast, for CI.
- * - `isolated`: each test gets a fresh Electron restart — for state-mutating tests.
+ * - `isolated`: most tests get a fresh Electron restart — for state-mutating tests. The `title-bar/`
+ *   and `navigation-history/` subsets are the exception: they use `fixtures/cdp.fixture.ts` and
+ *   attach to an app started separately.
  */
 const config = defineConfig({
   testDir: './tests',
@@ -46,6 +48,8 @@ const config = defineConfig({
       // The common set of locally-runnable tests, organized in subdirectories by feature.
       // `npm run test:e2e:isolated` (via e2e-tests/run-isolated.mjs) lists the subsets;
       // `npm run test:e2e:isolated <subset>` runs one; `... all` runs everything.
+      // `... all` needs the app already running (./.erb/scripts/refresh.sh): the `title-bar/`
+      // and `navigation-history/` subsets attach over CDP rather than launching Electron.
       name: 'isolated',
       testDir: './tests/isolated',
     },

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -68,6 +68,8 @@ const config = defineConfig({
       // rejects the very app they need to attach to:
       //   ./.erb/scripts/refresh.sh
       //   npx playwright test --config e2e-tests/playwright-cdp.config.ts tests/enhanced-resources/
+      // The entry below therefore only registers the directory with this config; its practical
+      // effect is that `test:e2e:all` (this config, no --project) cannot pass either.
       name: 'enhanced-resources',
       testDir: './tests/enhanced-resources',
     },

--- a/e2e-tests/playwright.config.ts
+++ b/e2e-tests/playwright.config.ts
@@ -4,9 +4,11 @@ import { defineConfig } from '@playwright/test';
  * Playwright configuration for paranext-core E2E tests.
  *
  * - `smoke` (default): tests share a single Electron instance per worker — fast, for CI.
- * - `isolated`: most tests get a fresh Electron restart — for state-mutating tests. The `title-bar/`
- *   and `navigation-history/` subsets are the exception: they use `fixtures/cdp.fixture.ts` and
- *   attach to an app started separately.
+ * - `isolated`: each suite gets its own Electron, but how varies by fixture —
+ *   `fixtures/isolated.fixture.ts` launches one per test, `comment.fixture`/`find.fixture` one per
+ *   worker, and the `title-bar/` and `navigation-history/` subsets launch nothing at all: they use
+ *   `fixtures/cdp.fixture.ts` and attach to an app started separately. See the note on that project
+ *   below.
  */
 const config = defineConfig({
   testDir: './tests',
@@ -47,18 +49,25 @@ const config = defineConfig({
     {
       // The common set of locally-runnable tests, organized in subdirectories by feature.
       // `npm run test:e2e:isolated` (via e2e-tests/run-isolated.mjs) lists the subsets;
-      // `npm run test:e2e:isolated <subset>` runs one; `... all` runs everything.
-      // `... all` needs the app already running (./.erb/scripts/refresh.sh): the `title-bar/`
-      // and `navigation-history/` subsets attach over CDP rather than launching Electron.
+      // `npm run test:e2e:isolated <subset>` runs one; `... all` runs every subset.
+      //
+      // `... all` cannot currently pass. The `title-bar/` and `navigation-history/` subsets use
+      // fixtures/cdp.fixture.ts, which attaches to an already-running app, but this config's
+      // globalSetup aborts when port 8876 is bound — so there is no state in which both they and
+      // their launch-based neighbours run. playwright-cdp.config.ts cannot run them either; it
+      // testIgnores **/isolated/**. Run the other subsets individually until those two move out
+      // of this project or globalSetup grows an opt-out.
       name: 'isolated',
       testDir: './tests/isolated',
     },
     {
       // Local-only - NOT wired into CI's `test:e2e:smoke`. The ER tests need real
       // Marble resources (e.g., ESV16UK+) which are not available in CI. There is no dedicated
-      // npm script; run the project directly (after booting the app once with CDP enabled):
+      // npm script. These specs use fixtures/cdp.fixture.ts, so run them through the CDP config,
+      // which has no globalSetup; running them through THIS config fails, because its globalSetup
+      // rejects the very app they need to attach to:
       //   ./.erb/scripts/refresh.sh
-      //   npx playwright test --config e2e-tests/playwright.config.ts --project=enhanced-resources
+      //   npx playwright test --config e2e-tests/playwright-cdp.config.ts tests/enhanced-resources/
       name: 'enhanced-resources',
       testDir: './tests/enhanced-resources',
     },

--- a/e2e-tests/run-e2e-wsl.sh
+++ b/e2e-tests/run-e2e-wsl.sh
@@ -1,10 +1,15 @@
 #!/bin/bash
-# Run Playwright E2E tests with virtual display for WSL2/headless Linux
+# Run Playwright E2E tests with virtual display for WSL2/headless Linux.
+#
+# Rendering through WSLg pops Electron windows onto the Windows desktop for the whole run;
+# the virtual display keeps them off-screen with identical results.
 #
 # Usage:
-#   ./run-e2e-wsl.sh              # Run all tests
-#   ./run-e2e-wsl.sh --grep "smoke" # Run filtered tests
-#   ./run-e2e-wsl.sh --debug      # Run in debug mode
+#   ./run-e2e-wsl.sh                                # Run the smoke tests (default)
+#   ./run-e2e-wsl.sh --grep "smoke"                 # Args are passed to the smoke run
+#   ./run-e2e-wsl.sh --debug                        # Run the smoke tests in debug mode
+#   ./run-e2e-wsl.sh npx playwright test ...        # Wrap ANY e2e command in the virtual
+#   ./run-e2e-wsl.sh npm run test:e2e -- ...        #   display instead of the smoke default
 
 set -e
 
@@ -25,5 +30,11 @@ fi
 cd "$(dirname "$0")/.."
 
 echo "Running E2E tests with virtual display (Xvfb)..."
-xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
-    npm run test:e2e:smoke -- "$@"
+# A first argument that is a command name means "wrap this command"; anything else keeps the
+# original behavior of forwarding the arguments to the smoke run
+if [ $# -gt 0 ] && command -v "$1" &> /dev/null; then
+    xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" "$@"
+else
+    xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
+        npm run test:e2e:smoke -- "$@"
+fi

--- a/e2e-tests/run-e2e-wsl.sh
+++ b/e2e-tests/run-e2e-wsl.sh
@@ -1,40 +1,69 @@
 #!/bin/bash
-# Run Playwright E2E tests with virtual display for WSL2/headless Linux.
+# Run Playwright E2E tests with a virtual display for WSL2/headless Linux.
 #
-# Rendering through WSLg pops Electron windows onto the Windows desktop for the whole run;
-# the virtual display keeps them off-screen with identical results.
+# Rendering through WSLg pops every Electron window the suite launches onto the Windows desktop
+# for the whole run; the virtual display keeps them off-screen. Note this is not the same
+# environment as WSLg: a bare Xvfb has no window manager and a different default window size
+# (fixtures/isolated.fixture.ts force-resizes for exactly that reason), so suites that depend on
+# compositor behavior can legitimately differ.
 #
 # Usage:
-#   ./run-e2e-wsl.sh                                # Run the smoke tests (default)
-#   ./run-e2e-wsl.sh --grep "smoke"                 # Args are passed to the smoke run
-#   ./run-e2e-wsl.sh --debug                        # Run the smoke tests in debug mode
-#   ./run-e2e-wsl.sh npx playwright test ...        # Wrap ANY e2e command in the virtual
-#   ./run-e2e-wsl.sh npm run test:e2e -- ...        #   display instead of the smoke default
+#   ./run-e2e-wsl.sh                            # Smoke tests (default)
+#   ./run-e2e-wsl.sh --grep "smoke"             # Arguments are forwarded to the smoke run
+#   ./run-e2e-wsl.sh --wrap <command> [args…]   # Run ANY command inside the virtual display
+#
+# --wrap is an explicit opt-in, and it is deliberately not inferred from the first argument:
+# guessing (e.g. probing PATH) silently turns `run-e2e-wsl.sh find` into a run of GNU find that
+# exits 0 having run no tests, which is the false green run-isolated.mjs also guards against.
+#
+#   ./run-e2e-wsl.sh --wrap npm run test:e2e:isolated multi-window
+#   ./run-e2e-wsl.sh --wrap npx playwright test --config e2e-tests/playwright.config.ts \
+#       --project=isolated
+#
+# Two things to know about wrapped commands:
+#   * npm eats flags, so an npm script needs its own `--` before Playwright flags:
+#     `--wrap npm run test:e2e:smoke -- --grep foo`. The default form (no `--wrap`) inserts
+#     that `--` for you.
+#   * Playwright needs `--config`; this script cd's to the repo root, where there is no config.
+#
+# Not for CDP runs: playwright-cdp.config.ts attaches to an app you already started, and this
+# would hand it a second, empty display.
 
 set -e
 
-# Check if xvfb-run is available
-if ! command -v xvfb-run &> /dev/null; then
-    echo "Error: xvfb-run not found."
-    echo ""
-    echo "Install Xvfb and required dependencies:"
-    echo "  sudo apt update"
-    echo "  sudo apt install -y xvfb libxss1 libnss3 libatk1.0-0 libatk-bridge2.0-0 \\"
-    echo "    libcups2 libdrm2 libgbm1 libgtk-3-0 libasound2t64"
-    echo ""
-    echo "Then run: npx playwright install --with-deps chromium"
+if ! command -v xvfb-run >/dev/null 2>&1; then
+    echo "Error: xvfb-run not found. Install it, or run the tests directly on a visible" >&2
+    echo "display with 'npm run test:e2e:smoke'." >&2
+    echo "" >&2
+    echo "Install Xvfb and required dependencies:" >&2
+    echo "  sudo apt update" >&2
+    echo "  sudo apt install -y xvfb libxss1 libnss3 libatk1.0-0 libatk-bridge2.0-0 \\" >&2
+    echo "    libcups2 libdrm2 libgbm1 libgtk-3-0 libasound2t64" >&2
+    echo "" >&2
+    echo "Then run: npx playwright install --with-deps chromium" >&2
     exit 1
 fi
 
-# Change to repo root
+# Change to repo root. Relative paths in a wrapped command resolve from here, not from where you
+# invoked the script.
 cd "$(dirname "$0")/.."
 
-echo "Running E2E tests with virtual display (Xvfb)..."
-# A first argument that is a command name means "wrap this command"; anything else keeps the
-# original behavior of forwarding the arguments to the smoke run
-if [ $# -gt 0 ] && command -v "$1" &> /dev/null; then
-    xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" "$@"
+if [ "${1-}" = "--wrap" ]; then
+    shift
+    if [ $# -eq 0 ]; then
+        echo "Error: --wrap needs a command to run." >&2
+        exit 2
+    fi
 else
-    xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" \
-        npm run test:e2e:smoke -- "$@"
+    set -- npm run test:e2e:smoke -- "$@"
 fi
+
+# Report what actually runs, after the mode is decided, on stderr so a wrapped command's stdout
+# stays consumable (e.g. --reporter=json redirected to a file).
+echo "Running with virtual display (Xvfb): $*" >&2
+
+# 1920x1080x24 is load-bearing: fixtures/cdp.fixture.ts fails a screenshot below Full HD.
+# exec so that Ctrl-C reaches xvfb-run directly instead of orphaning it behind this shell.
+# If Xvfb itself fails to start, xvfb-run only says so; add --error-file=/dev/stderr for the
+# detail. It is not on by default because it also prints Xvfb's normal startup chatter.
+exec xvfb-run --auto-servernum --server-args="-screen 0 1920x1080x24" "$@"

--- a/e2e-tests/run-e2e-wsl.sh
+++ b/e2e-tests/run-e2e-wsl.sh
@@ -26,8 +26,12 @@
 #     that `--` for you.
 #   * Playwright needs `--config`; this script cd's to the repo root, where there is no config.
 #
-# Not for CDP runs: playwright-cdp.config.ts attaches to an app you already started, and this
-# would hand it a second, empty display.
+# The wrap only helps when the Electron app is launched INSIDE it. Suites built on
+# fixtures/cdp.fixture.ts attach over port 9223 to an app you started separately
+# (all of tests/enhanced-resources/, plus isolated/title-bar/ and isolated/navigation-history/),
+# so wrapping the Playwright process alone changes nothing for them. On Linux
+# .erb/scripts/refresh.sh already starts that app under its own Xvfb, so those runs are off the
+# desktop without this script.
 
 set -e
 
@@ -62,7 +66,10 @@ fi
 # stays consumable (e.g. --reporter=json redirected to a file).
 echo "Running with virtual display (Xvfb): $*" >&2
 
-# 1920x1080x24 is load-bearing: fixtures/cdp.fixture.ts fails a screenshot below Full HD.
+# Xvfb's 1280x1024 default would do for the suites this script launches itself (isolated.fixture
+# sizes its window to 1280x800). Full HD is here to match .erb/scripts/refresh.sh, so that a
+# wrapped command which starts the app AND Playwright together still satisfies
+# fixtures/cdp.fixture.ts, which fails a screenshot below Full HD.
 # exec so that Ctrl-C reaches xvfb-run directly instead of orphaning it behind this shell.
 # If Xvfb itself fails to start, xvfb-run only says so; add --error-file=/dev/stderr for the
 # detail. It is not on by default because it also prints Xvfb's normal startup chatter.

--- a/e2e-tests/run-isolated.mjs
+++ b/e2e-tests/run-isolated.mjs
@@ -33,6 +33,10 @@ function printUsage() {
 Usage:
   npm run test:e2e:isolated all                  Every subset (does not currently pass)
   npm run test:e2e:isolated <subset>             Run one subset (e.g. ${subsets[0]})
+  npm run test:e2e:isolated <path>               Run a path filter. The specs directly under
+                                                 tests/isolated/ belong to no subset, so this is
+                                                 the only way to reach them, e.g.
+                                                 tests/isolated/comments-tab.spec.ts
   npm run test:e2e:isolated <subset> -- --debug  Extra args after -- go to Playwright
   npm run test:e2e:isolated -- --list            Enumerate individual tests`);
 }

--- a/e2e-tests/run-isolated.mjs
+++ b/e2e-tests/run-isolated.mjs
@@ -3,7 +3,7 @@
 // subdirectories by feature under `e2e-tests/tests/isolated/`.
 //
 //   npm run test:e2e:isolated                     List the available subsets (exits non-zero; runs nothing)
-//   npm run test:e2e:isolated all                 Run every isolated test
+//   npm run test:e2e:isolated all                 Every subset (does not currently pass)
 //   npm run test:e2e:isolated <subset>            Run one subdirectory (e.g. scroll-groups)
 //   npm run test:e2e:isolated <path>              Run a path filter (e.g. tests/isolated/scroll-groups/)
 //   npm run test:e2e:isolated <subset> -- --debug Extra args after `--` go to Playwright
@@ -31,7 +31,7 @@ function printUsage() {
   subsets.forEach((subset) => console.log(`  ${subset}`));
   console.log(`
 Usage:
-  npm run test:e2e:isolated all                  Run every isolated test
+  npm run test:e2e:isolated all                  Every subset (does not currently pass)
   npm run test:e2e:isolated <subset>             Run one subset (e.g. ${subsets[0]})
   npm run test:e2e:isolated <subset> -- --debug  Extra args after -- go to Playwright
   npm run test:e2e:isolated -- --list            Enumerate individual tests`);

--- a/e2e-tests/run-isolated.mjs
+++ b/e2e-tests/run-isolated.mjs
@@ -33,9 +33,9 @@ function printUsage() {
 Usage:
   npm run test:e2e:isolated all                  Every subset (does not currently pass)
   npm run test:e2e:isolated <subset>             Run one subset (e.g. ${subsets[0]})
-  npm run test:e2e:isolated <path>               Run a path filter. The specs directly under
-                                                 tests/isolated/ belong to no subset, so this is
-                                                 the only way to reach them, e.g.
+  npm run test:e2e:isolated <path>               Run a path filter. This is how you select the
+                                                 specs directly under tests/isolated/, which
+                                                 belong to no subset, e.g.
                                                  tests/isolated/comments-tab.spec.ts
   npm run test:e2e:isolated <subset> -- --debug  Extra args after -- go to Playwright
   npm run test:e2e:isolated -- --list            Enumerate individual tests`);

--- a/e2e-tests/run-isolated.mjs
+++ b/e2e-tests/run-isolated.mjs
@@ -24,7 +24,10 @@ const subsets = readdirSync(isolatedDir, { withFileTypes: true })
   .sort();
 
 function printUsage() {
-  console.log('Isolated e2e subsets (each test launches its own Electron instance):\n');
+  console.log(
+    'Isolated e2e subsets (most launch their own Electron; title-bar and navigation-history attach\n' +
+      'over CDP to an app started by ./.erb/scripts/refresh.sh):\n',
+  );
   subsets.forEach((subset) => console.log(`  ${subset}`));
   console.log(`
 Usage:

--- a/e2e-tests/run-isolated.mjs
+++ b/e2e-tests/run-isolated.mjs
@@ -25,8 +25,8 @@ const subsets = readdirSync(isolatedDir, { withFileTypes: true })
 
 function printUsage() {
   console.log(
-    'Isolated e2e subsets (most launch their own Electron; title-bar and navigation-history attach\n' +
-      'over CDP to an app started by ./.erb/scripts/refresh.sh):\n',
+    'Isolated e2e subsets (most launch their own Electron; title-bar and navigation-history\n' +
+      'instead attach to a running app over CDP, and cannot be run from this project today):\n',
   );
   subsets.forEach((subset) => console.log(`  ${subset}`));
   console.log(`

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -41,10 +41,10 @@ These belong to no subset; run them by path (see "How to run").
 
 - `comment-assignment/` (one Electron per worker) — tests for assigning comments to users
 - `find/` (one Electron per worker) — tests for the find/replace flow
-- `first-run/` — tests for the first-run wizard (PT-4175 / PT-4179)
-- `multi-window/` — tests for multi-window lifecycle (second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit), window layout persistence (windows, layouts, and bounds surviving relaunches; a deliberately closed window staying closed; the pre-multi-window single-window upgrade path), and per-window UI isolation (overlays, dialogs, notifications, navigation targets, and web-view placement staying in their own window; scroll groups deliberately app-global)
+- `first-run/` (one Electron per test) — tests for the first-run wizard (PT-4175 / PT-4179)
+- `multi-window/` (one Electron per test) — tests for multi-window lifecycle (second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit), window layout persistence (windows, layouts, and bounds surviving relaunches; a deliberately closed window staying closed; the pre-multi-window single-window upgrade path), and per-window UI isolation (overlays, dialogs, notifications, navigation targets, and web-view placement staying in their own window; scroll groups deliberately app-global)
 - `navigation-history/` (attaches over CDP; see "How to run") — tests for back/forward reference history navigation
-- `overlay/` — tests for the project-switch transition overlay
-- `scroll-groups/` — tests for scroll-group synchronization between scripture editors
+- `overlay/` (one Electron per test) — tests for the project-switch transition overlay
+- `scroll-groups/` (one Electron per test) — tests for scroll-group synchronization between scripture editors
 - `title-bar/` (attaches over CDP; see "How to run") — tests for title bar layout, e.g. reserved space for native window controls
 - `verse-navigation/` (one Electron per worker) — tests for verse navigation keyboard shortcuts

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -16,11 +16,15 @@ npm run test:e2e:isolated
 
 # A single file
 npx playwright test --config e2e-tests/playwright.config.ts --project=isolated e2e-tests/tests/isolated/<file>.spec.ts
+
+# On WSL2, wrap any of the above to keep Electron windows off the Windows desktop
+e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated <subset>
 ```
 
 ## Subdirectories
 
 - `comment-assignment/` — tests for assigning comments to users
+- `find/` — tests for the find/replace flow
 - `first-run/` — tests for the first-run wizard (PT-4175 / PT-4179)
 - `multi-window/` — tests for multi-window lifecycle (second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit), window layout persistence (windows, layouts, and bounds surviving relaunches; a deliberately closed window staying closed; the pre-multi-window single-window upgrade path), and per-window UI isolation (overlays, dialogs, notifications, navigation targets, and web-view placement staying in their own window; scroll groups deliberately app-global)
 - `navigation-history/` — tests for back/forward reference history navigation

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -1,6 +1,7 @@
 # isolated E2E Tests
 
-Feature and state-mutating E2E tests that each run against their own Electron instance.
+Feature and state-mutating E2E tests, most of which run against their own Electron instance. The
+exceptions are noted under "How to run" below.
 
 ## What belongs here
 
@@ -11,8 +12,8 @@ Feature and state-mutating E2E tests that each run against their own Electron in
 ## How to run
 
 ```bash
-# All isolated tests
-npm run test:e2e:isolated
+# All isolated tests. The bare form runs nothing: it lists the subsets and exits 1.
+npm run test:e2e:isolated all
 
 # A single file
 npx playwright test --config e2e-tests/playwright.config.ts --project=isolated e2e-tests/tests/isolated/<file>.spec.ts

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -12,7 +12,9 @@ exceptions are noted under "How to run" below.
 ## How to run
 
 ```bash
-# All isolated tests. The bare form runs nothing: it lists the subsets and exits 1.
+# All isolated tests. Needs ./.erb/scripts/refresh.sh running first, because title-bar/ and
+# navigation-history/ attach over CDP. The bare form runs nothing: it lists the subsets and
+# exits 1.
 npm run test:e2e:isolated all
 
 # A single file

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -42,7 +42,8 @@ These belong to no subset; run them by path (see "How to run").
 - `comment-assignment/` (one Electron per worker) — tests for assigning comments to users
 - `find/` (one Electron per worker) — tests for the find/replace flow
 - `first-run/` (one Electron per test) — tests for the first-run wizard (PT-4175 / PT-4179)
-- `multi-window/` (one Electron per test) — tests for multi-window lifecycle (second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit), window layout persistence (windows, layouts, and bounds surviving relaunches; a deliberately closed window staying closed; the pre-multi-window single-window upgrade path), and per-window UI isolation (overlays, dialogs, notifications, navigation targets, and web-view placement staying in their own window; scroll groups deliberately app-global)
+- `multi-window/` (one Electron per test, except `window-layout-persistence.spec.ts`, which drives
+  `fixtures/helpers` directly and launches several per test to exercise relaunch) — tests for multi-window lifecycle (second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit), window layout persistence (windows, layouts, and bounds surviving relaunches; a deliberately closed window staying closed; the pre-multi-window single-window upgrade path), and per-window UI isolation (overlays, dialogs, notifications, navigation targets, and web-view placement staying in their own window; scroll groups deliberately app-global)
 - `navigation-history/` (attaches over CDP; see "How to run") — tests for back/forward reference history navigation
 - `overlay/` (one Electron per test) — tests for the project-switch transition overlay
 - `scroll-groups/` (one Electron per test) — tests for scroll-group synchronization between scripture editors

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -1,7 +1,7 @@
 # isolated E2E Tests
 
-Feature and state-mutating E2E tests, most of which run against their own Electron instance. The
-exceptions are noted under "How to run" below.
+Feature and state-mutating E2E tests that do not share an Electron instance with other suites.
+How each subset gets its app differs — see "Subdirectories" below.
 
 ## What belongs here
 
@@ -12,9 +12,10 @@ exceptions are noted under "How to run" below.
 ## How to run
 
 ```bash
-# All isolated tests. Needs ./.erb/scripts/refresh.sh running first, because title-bar/ and
-# navigation-history/ attach over CDP. The bare form runs nothing: it lists the subsets and
-# exits 1.
+# Every subset. Does not currently pass end to end — title-bar/ and navigation-history/ attach
+# to a running app, which this project's global setup refuses to start alongside (it aborts when
+# port 8876 is bound). Run the other subsets individually.
+# The bare form runs nothing: it lists the subsets and exits 1.
 npm run test:e2e:isolated all
 
 # A single file
@@ -28,12 +29,12 @@ e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated <subset>
 
 ## Subdirectories
 
-- `comment-assignment/` — tests for assigning comments to users
-- `find/` — tests for the find/replace flow
+- `comment-assignment/` (one Electron per worker) — tests for assigning comments to users
+- `find/` (one Electron per worker) — tests for the find/replace flow
 - `first-run/` — tests for the first-run wizard (PT-4175 / PT-4179)
 - `multi-window/` — tests for multi-window lifecycle (second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit), window layout persistence (windows, layouts, and bounds surviving relaunches; a deliberately closed window staying closed; the pre-multi-window single-window upgrade path), and per-window UI isolation (overlays, dialogs, notifications, navigation targets, and web-view placement staying in their own window; scroll groups deliberately app-global)
-- `navigation-history/` — tests for back/forward reference history navigation
+- `navigation-history/` (attaches over CDP; see "How to run") — tests for back/forward reference history navigation
 - `overlay/` — tests for the project-switch transition overlay
 - `scroll-groups/` — tests for scroll-group synchronization between scripture editors
-- `title-bar/` — tests for title bar layout, e.g. reserved space for native window controls
-- `verse-navigation/` — tests for verse navigation keyboard shortcuts
+- `title-bar/` (attaches over CDP; see "How to run") — tests for title bar layout, e.g. reserved space for native window controls
+- `verse-navigation/` (one Electron per worker) — tests for verse navigation keyboard shortcuts

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -17,7 +17,9 @@ npm run test:e2e:isolated
 # A single file
 npx playwright test --config e2e-tests/playwright.config.ts --project=isolated e2e-tests/tests/isolated/<file>.spec.ts
 
-# On WSL2, wrap any of the above to keep Electron windows off the Windows desktop
+# On WSL2, wrap a subset that launches its own Electron to keep its windows off the desktop.
+# Not title-bar/ or navigation-history/ — those use fixtures/cdp.fixture.ts and attach to an app
+# started separately by ./.erb/scripts/refresh.sh, which already runs it under its own Xvfb.
 e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated <subset>
 ```
 

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -18,7 +18,9 @@ How each subset gets its app differs — see "Subdirectories" below.
 # The bare form runs nothing: it lists the subsets and exits 1.
 npm run test:e2e:isolated all
 
-# A single file
+# A single file, or any path — this also reaches the specs directly under tests/isolated/, which
+# belong to no subset because run-isolated.mjs derives subsets from directories only
+npm run test:e2e:isolated tests/isolated/comments-tab.spec.ts
 npx playwright test --config e2e-tests/playwright.config.ts --project=isolated e2e-tests/tests/isolated/<file>.spec.ts
 
 # On WSL2, wrap a subset that launches its own Electron to keep its windows off the desktop.
@@ -26,6 +28,14 @@ npx playwright test --config e2e-tests/playwright.config.ts --project=isolated e
 # started separately by ./.erb/scripts/refresh.sh, which already runs it under its own Xvfb.
 e2e-tests/run-e2e-wsl.sh --wrap npm run test:e2e:isolated <subset>
 ```
+
+## Spec files directly under `tests/isolated/`
+
+These belong to no subset; run them by path (see "How to run").
+
+- `comments-tab.spec.ts` (one Electron per worker)
+- `first-run-wizard.spec.ts` (one Electron per test)
+- `internet-settings.spec.ts` (one Electron per test)
 
 ## Subdirectories
 

--- a/e2e-tests/tests/isolated/README.md
+++ b/e2e-tests/tests/isolated/README.md
@@ -42,8 +42,8 @@ These belong to no subset; run them by path (see "How to run").
 - `comment-assignment/` (one Electron per worker) — tests for assigning comments to users
 - `find/` (one Electron per worker) — tests for the find/replace flow
 - `first-run/` (one Electron per test) — tests for the first-run wizard (PT-4175 / PT-4179)
-- `multi-window/` (one Electron per test, except `window-layout-persistence.spec.ts`, which drives
-  `fixtures/helpers` directly and launches several per test to exercise relaunch) — tests for multi-window lifecycle (second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit), window layout persistence (windows, layouts, and bounds surviving relaunches; a deliberately closed window staying closed; the pre-multi-window single-window upgrade path), and per-window UI isolation (overlays, dialogs, notifications, navigation targets, and web-view placement staying in their own window; scroll groups deliberately app-global)
+- `multi-window/` (one Electron per test, except `window-layout-persistence.spec.ts`, which uses no
+  fixture and calls `launchElectronApp` itself — several launches per test to exercise relaunch) — tests for multi-window lifecycle (second-window startup, focus routing, app-global service hosting takeover, single shutdown-task run on quit), window layout persistence (windows, layouts, and bounds surviving relaunches; a deliberately closed window staying closed; the pre-multi-window single-window upgrade path), and per-window UI isolation (overlays, dialogs, notifications, navigation targets, and web-view placement staying in their own window; scroll groups deliberately app-global)
 - `navigation-history/` (attaches over CDP; see "How to run") — tests for back/forward reference history navigation
 - `overlay/` (one Electron per test) — tests for the project-switch transition overlay
 - `scroll-groups/` (one Electron per test) — tests for scroll-group synchronization between scripture editors

--- a/e2e-tests/tests/isolated/find/find-replace.spec.ts
+++ b/e2e-tests/tests/isolated/find/find-replace.spec.ts
@@ -5,9 +5,9 @@
  * the suite runs. testWEB is a programmatic copy of the WEB asset with a unique project ID and
  * Editable=T, reset to a clean state before each worker run to prevent test pollution.
  *
- * Run via: `npm run test:e2e:isolated`
+ * Run via: `npm run test:e2e:isolated find`
  *
- * OR more specifically `npm run test:e2e:isolated -- find-replace.spec.ts`
+ * OR by path: `npm run test:e2e:isolated tests/isolated/find/find-replace.spec.ts`
  */
 
 import { Frame, FrameLocator, Locator, Page } from '@playwright/test';


### PR DESCRIPTION
## Summary

`e2e-tests/run-e2e-wsl.sh` exists to keep local e2e runs off the Windows desktop (WSLg renders
every Electron window the suite launches straight onto it), but it hardcoded the smoke suite — so
any other invocation, like the isolated multi-window suite, had to call `npx playwright` directly
and take over the desktop for the whole run.

The script now runs any command in the virtual display when you ask for it with `--wrap`. The
no-command form keeps its original behaviour: the smoke suite, with arguments forwarded.

### Why review this

Not part of the current epic — local-tooling quality of life, explicitly requested by Rolf
(2026-08-12) after desktop-rendered e2e runs kept interrupting him. Worth reviewer time now because
it changes a script other developers may share, and because the review turned up a set of
documented e2e recipes that do not work.

## Changes

**`run-e2e-wsl.sh`**

- `--wrap <command>` selects passthrough; anything else goes to the smoke run. The first version
  inferred this by asking whether the first argument was a command on `PATH`, which answers the
  wrong question: `run-e2e-wsl.sh find` ran GNU `find` from the repo root and exited 0 having run
  no tests, and a first word that was *not* on `PATH` (a typo, `pnpm`, `playwright` without `npx`)
  fell through to the smoke suite with its words injected as path filters. Both were silent. An
  explicit opt-in also matches `run-isolated.mjs`, which dispatches on a closed vocabulary and
  fails loudly.
- The banner now prints after the mode is decided, names the resolved command, and goes to stderr,
  so a wrapped run's stdout stays consumable.
- `exec xvfb-run`, so Ctrl-C reaches it rather than orphaning it behind this shell; and the
  duplicated `xvfb-run` literal is gone.
- Usage comment corrected: it named an npm script that does not exist, omitted `--config`, omitted
  the extra `--` that npm requires before Playwright flags, advertised `--debug` (unusable on an
  invisible display), and claimed results identical to WSLg (a bare Xvfb has no window manager).

**Docs and config** — correcting e2e run recipes that do not work, found while establishing which
suites the wrap actually helps:

- `npm run test:e2e:isolated all` and `npm run test:e2e:all` cannot pass, and are no longer
  presented as if they can. `tests/isolated/title-bar/` and `tests/isolated/navigation-history/`
  use `fixtures/cdp.fixture.ts`, which attaches to a running app, while the `isolated` project's
  `globalSetup` aborts when port 8876 is bound — the port `refresh.sh` waits on. No app and the
  attach fails; an app and global setup aborts before any test runs. `playwright-cdp.config.ts`
  cannot run them either: it `testIgnore`s `**/isolated/**`.
- The `enhanced-resources` instructions had the same problem and now route through
  `playwright-cdp.config.ts`, which has no `globalSetup`.
- `find-replace.spec.ts` documented two recipes that do not work (the bare form runs nothing; the
  other exits 1 with `Unknown subset`).
- Each isolated subset now records how it gets its Electron — per test, per worker, or by attaching
  — instead of the blanket "each test launches its own instance", which was false for four of them.
- The usage banner gained the path form, the only route to the three spec files directly under
  `tests/isolated/` that belong to no subset.
- A comment on the CI Linux e2e step explains why its Xvfb geometry differs, and why adding
  `--server-args` there would not enable a `cdp.fixture` job. CI's runtime arguments are unchanged.

## Testing

- Every misfire from the review re-run against the fixed script: `find`, `true`, `--`, `-p` and an
  unknown first word all route to the smoke suite, where a non-matching filter fails loudly.
- `--wrap` runs the given command inside the display with stdout clean; `--wrap` with no command
  exits 2.
- The default no-argument form is unchanged.
- Corrected recipes checked by collecting their tests rather than by inspection.

## Follow-up, not in this PR

`title-bar/` and `navigation-history/` remain unrunnable. Fixing that means moving them out of the
`isolated` project or giving `globalSetup` a narrow opt-out — a structural decision, so this PR
documents the behaviour rather than changing it.

## Risk Level

Low — local developer tooling and documentation. CI's behaviour is unchanged; the script's default
path behaves as before.

AI-assisted — [session 1](https://claude.ai/code/session_01Lf3XmoA9StqLNDiMBqZVTy), [session 2](https://claude.ai/code/session_01QyoVc1Cd9L2RcuDGE3T3FT)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2669)
<!-- Reviewable:end -->
