### PR TITLE
docs(stories): flat-list ProjectSelector stories (no open tabs, no scroll groups)

### DIFF
--- a/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.stories.tsx
+++ b/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.stories.tsx
@@ -291,6 +291,88 @@ export const ScrollGroupBinding: Story = {
 
 // #endregion
 
+// #region flat list (no open tabs, no scroll groups)
+
+const sampleProjectsAndResources: ProjectSelectorProject[] = [
+  ...sampleProjects,
+  {
+    id: 'na28',
+    shortName: 'NA28',
+    fullName: 'Nestle-Aland 28th Edition (Greek NT)',
+    language: 'Greek',
+    languageCode: 'el',
+  },
+  {
+    id: 'bhs',
+    shortName: 'BHS',
+    fullName: 'Biblia Hebraica Stuttgartensia',
+    language: 'Hebrew',
+    languageCode: 'he',
+  },
+  {
+    id: 'lxx',
+    shortName: 'LXX',
+    fullName: 'Septuagint',
+    language: 'Greek',
+    languageCode: 'el',
+  },
+];
+
+export const SimpleFlatList: Story = {
+  render: () => {
+    const [projectId, setProjectId] = useState<string | undefined>('esvus16');
+    return (
+      <ProjectSelector
+        mode="project"
+        projects={sampleProjectsAndResources}
+        openTabs={[]}
+        selection={{ projectId }}
+        onChangeSelection={({ projectId: newId }) => setProjectId(newId)}
+        buttonPlaceholder="Select a project or resource"
+        ariaLabel="Project or resource"
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The simplest possible display: single-select with `mode="project"` and `openTabs={[]}`. No scroll-group chips render on any row, no "Opened project & resource tabs" section appears, and `partitionAndSort` collapses to a single flat, unheaded list. Sample data mixes projects (HPUX, TP1, SCHL1951) and resources (NA28, BHS, LXX) — note the component itself does not visually distinguish the two; they render identically. The "Group by open tabs" toggle is still present in the filter menu (no way to hide it) but has no visible effect while `openTabs` is empty.',
+      },
+    },
+  },
+};
+
+export const SimpleFlatMultiSelect: Story = {
+  render: () => {
+    const [pairs, setPairs] = useState<ProjectSelectorProjectPair[]>([
+      { projectId: 'esvus16' },
+      { projectId: 'bhs' },
+    ]);
+    return (
+      <ProjectSelector
+        mode="project-multi"
+        projects={sampleProjectsAndResources}
+        openTabs={[]}
+        selection={{ pairs }}
+        onChangeSelection={({ pairs: next }) => setPairs(next)}
+        buttonPlaceholder="Select projects and resources"
+        ariaLabel="Projects and resources"
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Multi-select without scroll groups: `mode="project-multi"` with `openTabs={[]}`. Every row corresponds to a single `{ projectId }` pair (no `scrollGroupId`), so no chips, no "Open" buttons, and no bound-but-closed synthetic rows appear. The trigger label reads "N: short1, short2, ..." driven by the default `getSelectedText`.',
+      },
+    },
+  },
+};
+
+// #endregion
+
 // #region no projects
 
 export const NoProjects: Story = {


### PR DESCRIPTION
## Summary

Adds two Storybook stories to `Advanced/Project Selector` that cover the simplest use case: displaying projects and resources without any opened tabs or scroll-group interactions.

- **SimpleFlatList** — `mode="project"` with `openTabs={[]}`. No chips, no "Opened project & resource tabs" section; `partitionAndSort` collapses to a single flat, unheaded list. Sample data mixes projects and resources.
- **SimpleFlatMultiSelect** — `mode="project-multi"` with `openTabs={[]}`. Multi-select over `{ projectId }`-only pairs — no chips, no Open button, no synthetic bound-but-closed rows.

Adds a `sampleProjectsAndResources` fixture (existing projects + NA28 / BHS / LXX) so the "projects & resources" wording in the picker's strings is reflected in the demo data.

## Notes on component limits (surfaced but not fixed here)

- `ProjectSelectorProject` has no `type` / `kind` field — projects and resources render identically; the distinction lives only in the localized strings.
- The `FilterMenu`'s "Group by open tabs" checkbox is always rendered (unless `groupByVersification` is set). It's harmless with `openTabs={[]}` but there is no prop to hide it.

Neither is changed in this PR; both are notable if a future PR wants a truly "picker-only" surface.

## Test plan

- [ ] `npm --workspace lib/platform-bible-react run storybook` — open `Advanced/Project Selector → Simple Flat List` and `Simple Flat Multi Select`, confirm no chips, no section headings, and rows include projects + resources side-by-side.
- [ ] Typecheck passes (`npx tsc --noEmit -p lib/platform-bible-react/tsconfig.json`).
- [ ] Lint passes (`npm --prefix lib/platform-bible-react run lint`).

AI-assisted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2671)
<!-- Reviewable:end -->

<img width="617" height="712" alt="image" src="https://github.com/user-attachments/assets/5fcf47e5-ff98-45ea-94f1-fd976a748412" />
