### PR TITLE
fix(project-selector): move row tooltip to right side; simplify content

### DIFF
--- a/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.component.tsx
@@ -429,38 +429,63 @@ function ProjectRowView({ row, mode, strings, onClick, onOpen, selectedRowRef }:
   const letter =
     row.scrollGroupId !== undefined ? scrollGroupLetterFromMap(row.scrollGroupId) : undefined;
 
-  const tooltipBoundBut =
-    row.isBoundButClosed && letter
-      ? strings.boundButClosedTooltip.replace('{group}', letter)
-      : undefined;
+  // Single scroll-group tooltip line covering every case the row can be in. Bound-but-closed
+  // rows use the caller's `boundButClosedTooltip` template (with the letter substituted in) and
+  // render italic. Open-tab rows show `{scrRefLabel} ({letter})` when a ref label is available,
+  // otherwise just the letter. `project`-mode rows aggregate multiple open scroll groups into a
+  // comma-joined list to mirror the chip strip on the right side of the row.
+  let scrollGroupLine: string | undefined;
+  let scrollGroupLineIsItalic = false;
+  if (row.isBoundButClosed && letter) {
+    scrollGroupLine = strings.boundButClosedTooltip.replace('{group}', letter);
+    scrollGroupLineIsItalic = true;
+  } else if (letter) {
+    scrollGroupLine = row.scrollGroupScrRefLabel
+      ? `${row.scrollGroupScrRefLabel} (${letter})`
+      : letter;
+  } else if (row.openGroups.length > 0) {
+    scrollGroupLine = row.openGroups.map(scrollGroupLetterFromMap).join(', ');
+  }
+
+  // Compose the language line as a single string so it renders as one row (with the code, when
+  // present, muted in parentheses). Handles both partial-data cases (only language, only code)
+  // without emitting a stray parenthesis.
+  let languageLine: ReactNode;
+  if (row.language && row.languageCode) {
+    languageLine = (
+      <>
+        {row.language}
+        <span className="tw:text-muted-foreground"> ({row.languageCode})</span>
+      </>
+    );
+  } else if (row.language) {
+    languageLine = row.language;
+  } else if (row.languageCode) {
+    languageLine = row.languageCode;
+  }
 
   return (
     <Tooltip open={isHovered} delayDuration={400}>
       <TooltipTrigger asChild>{rowNode}</TooltipTrigger>
       <TooltipContent
-        side="top"
-        align="center"
+        // side="right" — hovered rows sit inside the selector's popover; a top-side tooltip
+        // frequently overlapped the row above (or the search bar for the topmost row). Right-side
+        // places the tooltip clear of the popover's content column and reads as a canonical
+        // "row-details" affordance.
+        side="right"
+        align="start"
         sideOffset={8}
         collisionPadding={16}
-        className="tw:max-w-xs tw:text-center"
+        className="tw:max-w-xs tw:text-start"
         style={{ zIndex: Z_INDEX_OVERLAY }}
       >
         <div className="tw:font-semibold">{row.fullName}</div>
-        {tooltipHasLanguage && (
-          <div className="tw:text-sm">
-            {row.language}
-            {row.languageCode && (
-              <span className="tw:text-muted-foreground"> ({row.languageCode})</span>
-            )}
+        {languageLine && <div className="tw:text-sm">{languageLine}</div>}
+        {scrollGroupLine && (
+          <div className={cn('tw:text-sm', scrollGroupLineIsItalic && 'tw:italic')}>
+            {scrollGroupLine}
           </div>
         )}
-        {!row.isBoundButClosed && row.scrollGroupScrRefLabel && letter && (
-          <div className="tw:text-sm">
-            {row.scrollGroupScrRefLabel}
-            <span className="tw:text-muted-foreground"> ({letter})</span>
-          </div>
-        )}
-        {tooltipBoundBut && <div className="tw:text-sm tw:italic">{tooltipBoundBut}</div>}
         {row.isDisabled && row.disabledReason && (
           <div className="tw:text-sm tw:italic tw:text-muted-foreground">{row.disabledReason}</div>
         )}

--- a/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.component.tsx
+++ b/lib/platform-bible-react/src/components/advanced/project-selector/project-selector.component.tsx
@@ -476,7 +476,18 @@ function ProjectRowView({ row, mode, strings, onClick, onOpen, selectedRowRef }:
         align="start"
         sideOffset={8}
         collisionPadding={16}
-        className="tw:max-w-xs tw:text-start"
+        // `flex-col items-start` overrides shadcn TooltipContent's base `inline-flex items-center
+        // gap-1.5` so the info lines stack vertically instead of laying out as columns. `gap-0.5`
+        // gives them modest breathing room. See `shadcn-ui/tooltip.tsx` for the base classes.
+        className="tw:max-w-xs tw:flex-col tw:items-start tw:gap-0.5 tw:text-start"
+        // `showArrow={false}` — shadcn's TooltipContent arrow renders as an unclipped rotated
+        // square (a diamond) on `side="left"`/`"right"`. The tooltip file explicitly documents
+        // this: top/bottom get a clip-path that reduces the diamond to a triangle, but left/right
+        // deliberately keep the plain diamond ("no consumer today needs a bordered left/right
+        // arrow"). That renders as a small rectangle poking out of the tooltip — not the pointer
+        // shape we want. Suppressing the arrow entirely is the pragmatic fix; the tooltip's
+        // relationship to the hovered row is clear from position and hover-open behaviour.
+        showArrow={false}
         style={{ zIndex: Z_INDEX_OVERLAY }}
       >
         <div className="tw:font-semibold">{row.fullName}</div>


### PR DESCRIPTION
## Summary

Two changes to the row tooltip inside `<ProjectSelector>`'s popover:

### 1. Anchor moves from top to right

`side=\"top\"` frequently overlapped the row directly above (or the search bar for the topmost row). `side=\"right\"` puts the tooltip clear of the popover's content column and reads as a canonical row-details affordance. Alignment shifts from `text-center` to `text-start` to match side-anchored tooltip convention.

### 2. Content is restructured into three simple rows

Old content was a bold full name, then a couple of case-specific conditional lines. New content is a fixed three-row layout (with an optional fourth row for a disabled reason):

- **Full name** — bold, first row.
- **Language** — with `(languageCode)` muted in parentheses when both are present. Handles partial data (`language`-only or `languageCode`-only rows still render sensibly with no stray parenthesis).
- **Scroll group** — one line that covers every case the row can be in:
  - bound-but-closed rows: caller's `boundButClosedTooltip` template with the letter substituted, rendered italic.
  - open-tab rows (`project-multi` / `projectScrollGroup` modes with a `scrollGroupId`): `{scrRefLabel} ({letter})` when the caller supplied a scripture-ref label, else just the letter.
  - `project`-mode rows: comma-joined letters of all open scroll groups (`A, B`), mirroring the chip strip on the row.
- **Disabled reason** — retained as a muted-italic fourth row when present. Surfaces information not otherwise visible on the row.

## Test plan

- [ ] Storybook → **Advanced/Project Selector**: hover rows in every story (`SingleProject`, `MultiProject`, `ScrollGroupBinding`, `PerRowDisabled`, `NoProjects`). Tooltip anchors right of the row, doesn't overlap the row above.
- [ ] `SingleProject`: hover a row whose language and languageCode are both set → tooltip shows `English (en-US)`. Hover a row with a scroll group open → tooltip shows the letter list. Truncate the container so the row text clips — tooltip still opens on hover (unchanged truncation-open behaviour).
- [ ] `ScrollGroupBinding`: close a tab to force a bound-but-closed row → its tooltip's scroll-group line renders italic with the caller's `boundButClosedTooltip` string.
- [ ] `PerRowDisabled`: hover a disabled row → the muted italic `disabledReason` still surfaces on its own line under the scroll-group line.
- [ ] `npm --workspace lib/platform-bible-react run test -- --run src/components/advanced/project-selector/` — 53 tests pass.
- [ ] `npm --workspace lib/platform-bible-react run lint` — clean.

## Relation to other in-flight PRs

Touches the same file as [#2672](https://github.com/paranext/paranext-core/pull/2672) (z-index fix) and [#2673](https://github.com/paranext/paranext-core/pull/2673) (grouping options). Based on `main`, so this PR is independent and can merge in any order — expect a small mechanical rebase against whichever of those merges last.

AI-assisted.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2675)
<!-- Reviewable:end -->

before
<img width="633" height="710" alt="image" src="https://github.com/user-attachments/assets/90966b57-bbeb-4b68-8a0b-d871660d1806" />


after

<img width="703" height="487" alt="Screenshot 2026-08-13 193528" src="https://github.com/user-attachments/assets/9ce05503-3fbc-4959-a442-6f6441062287" />
<img width="702" height="490" alt="Screenshot 2026-08-13 193517" src="https://github.com/user-attachments/assets/a62aa54e-7042-4644-b507-505dfceb5f42" />
<img width="714" height="486" alt="Screenshot 2026-08-13 193511" src="https://github.com/user-attachments/assets/60fea639-66b9-4147-a45f-ee841805ba83" />
