### PR TITLE
Hold layout pushes while a layout load is in flight

### DIFF
--- a/src/renderer/services/web-view.service-host.test.ts
+++ b/src/renderer/services/web-view.service-host.test.ts
@@ -180,6 +180,27 @@ function respondToGetLayout(response: unknown) {
   );
 }
 
+/**
+ * Hold every `windowLayout:get` open the way a slow main process would, so a test can act while a
+ * load is mid-flight. Returns a function that answers the request made so far.
+ */
+function holdGetLayout() {
+  let answer: ((response: unknown) => void) | undefined;
+  mocks.networkRequest.mockImplementation(async (requestType: string) => {
+    if (requestType !== 'windowLayout:get') return undefined;
+    return new Promise((resolve) => {
+      answer = resolve;
+    });
+  });
+  return {
+    hasRequest: () => answer !== undefined,
+    answerWith: (response: unknown) => {
+      if (!answer) throw new Error('the saved-layout request was never made');
+      answer(response);
+    },
+  };
+}
+
 /** All `windowLayout:save` pushes made so far, as [windowId, layout] pairs */
 function layoutPushes() {
   return mocks.networkRequest.mock.calls
@@ -664,18 +685,12 @@ describe('saveLayout pushes this window’s layout to the main process', () => {
     // this window's. Pushing that would replace the saved entry with an empty layout — and an entry
     // that HAS a layout is no longer eligible for the legacy fallback, so the window would start
     // empty from then on.
-    let answerGet: ((response: unknown) => void) | undefined;
-    mocks.networkRequest.mockImplementation(async (requestType: string) => {
-      if (requestType !== 'windowLayout:get') return undefined;
-      return new Promise((resolve) => {
-        answerGet = resolve;
-      });
-    });
+    const heldGet = holdGetLayout();
 
     const { registerDockLayout } = await import('@renderer/services/web-view.service-host');
     const { dockLayout, loadedLayouts } = makeDockLayout(layoutWithAnchor());
     registerDockLayout(dockLayout);
-    await vi.waitFor(() => expect(answerGet).toBeDefined());
+    await vi.waitFor(() => expect(heldGet.hasRequest()).toBe(true));
 
     await dockLayout.onLayoutChangeRef.current?.(
       layoutWithTab('rc-dock-default'),
@@ -685,8 +700,7 @@ describe('saveLayout pushes this window’s layout to the main process', () => {
     expect(layoutPushes()).toEqual([]);
 
     // Once the saved layout lands, pushes resume from there
-    if (!answerGet) throw new Error('the saved-layout request was never made');
-    answerGet({ kind: 'entry', layout: layoutWithTab('saved-tab') });
+    heldGet.answerWith({ kind: 'entry', layout: layoutWithTab('saved-tab') });
     await vi.waitFor(() => expect(loadedLayouts.length).toBeGreaterThan(0));
 
     await dockLayout.onLayoutChangeRef.current?.(layoutWithTab('after'), undefined, undefined);
@@ -711,20 +725,14 @@ describe('saveLayout pushes this window’s layout to the main process', () => {
       },
     );
     // Hold the power-mode load's saved-layout request open the way a slow main process would
-    let answerGet: ((response: unknown) => void) | undefined;
-    mocks.networkRequest.mockImplementation(async (requestType: string) => {
-      if (requestType !== 'windowLayout:get') return undefined;
-      return new Promise((resolve) => {
-        answerGet = resolve;
-      });
-    });
+    const heldGet = holdGetLayout();
 
     const { dockLayout, loadedLayouts } = await registerWindow(layoutWithAnchor());
     if (!interfaceModeCallback) throw new Error('interface mode subscription never registered');
 
     interfaceMode = 'power';
     const switchToPower = interfaceModeCallback('power');
-    await vi.waitFor(() => expect(answerGet).toBeDefined());
+    await vi.waitFor(() => expect(heldGet.hasRequest()).toBe(true));
 
     // The dock still holds the simple layout at this point
     await dockLayout.onLayoutChangeRef.current?.(
@@ -735,12 +743,90 @@ describe('saveLayout pushes this window’s layout to the main process', () => {
     expect(layoutPushes()).toEqual([]);
 
     // Once the saved power layout lands, it is what the dock gets — and pushes resume from there
-    if (!answerGet) throw new Error('the saved-layout request was never made');
-    answerGet({ kind: 'entry', layout: layoutWithTab('saved-power-tab') });
+    heldGet.answerWith({ kind: 'entry', layout: layoutWithTab('saved-power-tab') });
     await switchToPower;
     expect(tabIdsIn(loadedLayouts[loadedLayouts.length - 1])).toEqual(['saved-power-tab-w2']);
 
     await dockLayout.onLayoutChangeRef.current?.(layoutWithTab('after'), undefined, undefined);
     expect(layoutPushes()).toHaveLength(1);
+  });
+
+  test('a layout change after a load throws pushes nothing', async () => {
+    // A load that throws leaves the dock exactly where the hold exists to protect it: holding the
+    // old mode's layout, with pushes armed under the new mode. Releasing on the way out — the
+    // obvious way to keep a failure from wedging persistence for the session — would resume pushes
+    // into precisely that state, so the marker stays behind instead and the next load that reaches
+    // the dock is what lifts the hold.
+    // Switching TO power, so the push that follows is one simple mode would not have blocked anyway
+    let failModeRead = false;
+    mocks.settingsGet.mockImplementation(async (key: string) => {
+      if (key !== 'platform.interfaceMode') return false;
+      if (failModeRead) throw new Error('settings service is down');
+      return 'simple';
+    });
+    let interfaceModeCallback: ((newMode: unknown) => Promise<void>) | undefined;
+    mocks.settingsSubscribe.mockImplementation(
+      async (_key: string, callback: (newMode: unknown) => Promise<void>) => {
+        interfaceModeCallback = callback;
+        return async () => true;
+      },
+    );
+    respondToGetLayout({ kind: 'entry', layout: layoutWithTab('saved-tab') });
+
+    const { dockLayout } = await registerWindow(layoutWithAnchor());
+    if (!interfaceModeCallback) throw new Error('interface mode subscription never registered');
+
+    // The switch's own load cannot even read the mode, so it never reaches the dock — but the mode
+    // cache is already on 'power', so `saveLayout` is armed
+    failModeRead = true;
+    await interfaceModeCallback('power');
+
+    await dockLayout.onLayoutChangeRef.current?.(
+      layoutWithTab('after-throw'),
+      undefined,
+      undefined,
+    );
+    expect(layoutPushes()).toEqual([]);
+  });
+
+  test('an abandoned load must not hold pushes once a newer load has reached the dock', async () => {
+    // The hold tracks which load's layout is IN the dock, not how many loads are running. A load
+    // that is superseded can sit in its saved-layout request for a long time (it retries, and the
+    // request itself may never settle), and it ends without ever writing the dock — so once a newer
+    // load HAS written the dock, the abandoned one must not keep layout changes from being saved.
+    // Counting loads in flight instead would silently stop persisting for the rest of the session.
+    let interfaceMode = 'power';
+    mocks.settingsGet.mockImplementation(async (key: string) =>
+      key === 'platform.interfaceMode' ? interfaceMode : false,
+    );
+    let interfaceModeCallback: ((newMode: unknown) => Promise<void>) | undefined;
+    mocks.settingsSubscribe.mockImplementation(
+      async (_key: string, callback: (newMode: unknown) => Promise<void>) => {
+        interfaceModeCallback = callback;
+        return async () => true;
+      },
+    );
+    // The initial power load parks on a saved-layout request that never comes back
+    const abandonedGet = holdGetLayout();
+    const { registerDockLayout } = await import('@renderer/services/web-view.service-host');
+    const { dockLayout } = makeDockLayout(layoutWithAnchor());
+    registerDockLayout(dockLayout);
+    await vi.waitFor(() => expect(abandonedGet.hasRequest()).toBe(true));
+
+    // The user round-trips through simple and back; this time the power load gets an answer and
+    // reaches the dock, superseding the parked one
+    if (!interfaceModeCallback) throw new Error('interface mode subscription never registered');
+    interfaceMode = 'simple';
+    await interfaceModeCallback('simple');
+    interfaceMode = 'power';
+    respondToGetLayout({ kind: 'entry', layout: layoutWithTab('saved-power-tab') });
+    await interfaceModeCallback('power');
+
+    // The abandoned load is still parked, but the dock holds this window's layout — pushes must work
+    await dockLayout.onLayoutChangeRef.current?.(layoutWithTab('after'), undefined, undefined);
+    expect(layoutPushes()).toHaveLength(1);
+
+    // Keep the dangling dock-layout registration from leaking into the next test
+    dockLayout.onLayoutChangeRef.current = undefined;
   });
 });

--- a/src/renderer/services/web-view.service-host.test.ts
+++ b/src/renderer/services/web-view.service-host.test.ts
@@ -658,4 +658,89 @@ describe('saveLayout pushes this window’s layout to the main process', () => {
 
     expect(layoutPushes()).toEqual([]);
   });
+
+  test('a layout change before the initial load lands pushes nothing', async () => {
+    // Until the initial load lands, the dock holds rc-dock's empty default rather than anything of
+    // this window's. Pushing that would replace the saved entry with an empty layout — and an entry
+    // that HAS a layout is no longer eligible for the legacy fallback, so the window would start
+    // empty from then on.
+    let answerGet: ((response: unknown) => void) | undefined;
+    mocks.networkRequest.mockImplementation(async (requestType: string) => {
+      if (requestType !== 'windowLayout:get') return undefined;
+      return new Promise((resolve) => {
+        answerGet = resolve;
+      });
+    });
+
+    const { registerDockLayout } = await import('@renderer/services/web-view.service-host');
+    const { dockLayout, loadedLayouts } = makeDockLayout(layoutWithAnchor());
+    registerDockLayout(dockLayout);
+    await vi.waitFor(() => expect(answerGet).toBeDefined());
+
+    await dockLayout.onLayoutChangeRef.current?.(
+      layoutWithTab('rc-dock-default'),
+      undefined,
+      undefined,
+    );
+    expect(layoutPushes()).toEqual([]);
+
+    // Once the saved layout lands, pushes resume from there
+    if (!answerGet) throw new Error('the saved-layout request was never made');
+    answerGet({ kind: 'entry', layout: layoutWithTab('saved-tab') });
+    await vi.waitFor(() => expect(loadedLayouts.length).toBeGreaterThan(0));
+
+    await dockLayout.onLayoutChangeRef.current?.(layoutWithTab('after'), undefined, undefined);
+    expect(layoutPushes()).toHaveLength(1);
+  });
+
+  test('a layout change while the switch to power is still loading pushes nothing', async () => {
+    // The switch to power flips the mode cache before the saved power layout can reach the dock, so
+    // for the length of that load the dock still holds the SIMPLE layout while pushes are armed. A
+    // web view writing state or focus moving in that window (both run through the dock's
+    // onLayoutChange) would push the simple layout as this window's power layout, destroying the
+    // saved one for good.
+    let interfaceMode = 'simple';
+    mocks.settingsGet.mockImplementation(async (key: string) =>
+      key === 'platform.interfaceMode' ? interfaceMode : false,
+    );
+    let interfaceModeCallback: ((newMode: unknown) => Promise<void>) | undefined;
+    mocks.settingsSubscribe.mockImplementation(
+      async (_key: string, callback: (newMode: unknown) => Promise<void>) => {
+        interfaceModeCallback = callback;
+        return async () => true;
+      },
+    );
+    // Hold the power-mode load's saved-layout request open the way a slow main process would
+    let answerGet: ((response: unknown) => void) | undefined;
+    mocks.networkRequest.mockImplementation(async (requestType: string) => {
+      if (requestType !== 'windowLayout:get') return undefined;
+      return new Promise((resolve) => {
+        answerGet = resolve;
+      });
+    });
+
+    const { dockLayout, loadedLayouts } = await registerWindow(layoutWithAnchor());
+    if (!interfaceModeCallback) throw new Error('interface mode subscription never registered');
+
+    interfaceMode = 'power';
+    const switchToPower = interfaceModeCallback('power');
+    await vi.waitFor(() => expect(answerGet).toBeDefined());
+
+    // The dock still holds the simple layout at this point
+    await dockLayout.onLayoutChangeRef.current?.(
+      layoutWithTab('still-the-simple-layout'),
+      undefined,
+      undefined,
+    );
+    expect(layoutPushes()).toEqual([]);
+
+    // Once the saved power layout lands, it is what the dock gets — and pushes resume from there
+    if (!answerGet) throw new Error('the saved-layout request was never made');
+    answerGet({ kind: 'entry', layout: layoutWithTab('saved-power-tab') });
+    await switchToPower;
+    expect(tabIdsIn(loadedLayouts[loadedLayouts.length - 1])).toEqual(['saved-power-tab-w2']);
+
+    await dockLayout.onLayoutChangeRef.current?.(layoutWithTab('after'), undefined, undefined);
+    expect(layoutPushes()).toHaveLength(1);
+  });
 });

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -888,6 +888,12 @@ let layoutLoadGeneration = 0;
  * landed, so it cannot lift the hold on a dock it never wrote; and it cannot extend the hold
  * either, since the load that DOES reach the dock sets the marker to the current generation and
  * pushes resume immediately, however long the abandoned one takes to settle.
+ *
+ * That holds only because EVERY site that writes the dock checks `isSuperseded()` first, so this
+ * can only ever move to the generation whose layout is actually in the dock — never backwards to a
+ * load a newer one already replaced. A write site without that check would regress the marker below
+ * `layoutLoadGeneration` and hold every push from then on, with nothing scheduled to reconcile the
+ * dock. Keep the checkpoint if you add another write site.
  */
 let layoutLoadGenerationInDock = 0;
 
@@ -908,12 +914,21 @@ async function loadLayout(layout?: LayoutInfo): Promise<void> {
   const webViewsBeforeLoad = dockLayoutVar.getAllWebViewDefinitions();
   if (layout) {
     // Explicit layout change. `loadLayout` doesn't run `onLayoutChange`, so run it manually.
-    // Applied unconditionally: the caller handed us the layout, so there is nothing here that a
-    // later load could make stale — and bumping the generation above is what lets this call cancel
-    // an in-flight no-argument load that would otherwise land on top of it.
+    // Bumping the generation above is what lets this call cancel an in-flight no-argument load that
+    // would otherwise land on top of it — when THIS is the newer load, the checkpoint below passes
+    // and the older one drops its answer instead.
     // NOTE: we intentionally do NOT apply the default-layout supplement here — a caller passing an
     // explicit layout owns its full contents. If a future "reset to default layout" path routes
     // through here and should include supplement tabs, merge `getEnabledSupplementEntries()` in too.
+    if (isSuperseded()) {
+      // The reverse ordering: a newer load reached the dock while this one was still awaiting it.
+      // Writing now would replace the dock with content the user has already moved past AND regress
+      // `layoutLoadGenerationInDock` below `layoutLoadGeneration`, which holds every subsequent
+      // push with nothing scheduled to reconcile the dock. The caller owning this layout does not
+      // make it current; only being the newest load does.
+      logger.debug('Dropping an explicit layout load that a newer one superseded');
+      return;
+    }
     dockLayoutVar.loadLayout(layout);
     layoutLoadGenerationInDock = thisGeneration;
     emitCloseEventsForWebViewsRemovedByLayoutLoad(webViewsBeforeLoad, layout);

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -631,6 +631,37 @@ function getWindowIdOrThrow(): number {
  */
 let currentInterfaceMode: 'simple' | 'power' | undefined;
 
+/**
+ * How many no-argument {@link loadLayout} calls have started but not yet put their layout in the
+ * dock. While this is above zero, {@link saveLayout} holds its pushes: the dock does not yet hold
+ * the layout this window is supposed to be showing, so pushing what it DOES hold overwrites the
+ * user's real saved entry in the main process's structure.
+ *
+ * Such a load takes a while — it reads the interface mode, asks the main process for this window's
+ * saved layout (a round trip that retries, so seconds), and reads the supplement flags — and every
+ * ordinary layout change runs through `onLayoutChange` into `saveLayout` meanwhile: a web view
+ * writing state, focus moving into a tab, a tab being activated. Two loads are exposed:
+ *
+ * - The INTERFACE-MODE SWITCH, which flips {@link currentInterfaceMode} the instant the setting
+ *   changes (so a `saveLayout` racing the switch can't push under the mode the user just left)
+ *   while the dock still holds the OLD mode's layout. Switching TO simple that is harmless, since
+ *   simple mode never pushes. Switching to POWER it persisted the static simple layout as this
+ *   window's power layout — permanently. Every later power-mode load then restored the simple
+ *   layout (headless columns and all, so two of its tab groups render with no tab bar in power
+ *   mode), and neither switching back and forth nor restarting recovered it, because the clobbered
+ *   entry is what the main process answers with from then on.
+ * - The INITIAL LOAD in `registerDockLayout`, before which the dock holds rc-dock's empty default
+ *   layout rather than anything of this window's. Pushing that replaces the saved entry with an
+ *   empty one — and an entry that HAS a layout is not eligible for the legacy fallback either (see
+ *   `TrackedWindow.usesLegacyLayout` in `window-layout-persistence.service.ts`), so the window then
+ *   starts empty from then on.
+ *
+ * A counter rather than a flag so a load starting before an earlier one finishes keeps the hold up
+ * until BOTH are done, and released in a `finally` (see {@link loadLayoutHoldingPushes}) so a load
+ * that throws can never latch it on for the rest of the session.
+ */
+let layoutLoadsInFlight = 0;
+
 /** Create a new dock layout promise variable */
 function createDockLayoutAsyncVar(): AsyncVariable<PapiDockLayout> {
   return new AsyncVariable<PapiDockLayout>('web-view.service-host.platformDockLayout');
@@ -962,6 +993,21 @@ async function loadLayout(layout?: LayoutInfo): Promise<void> {
 }
 
 /**
+ * Runs a no-argument {@link loadLayout} with layout pushes held until the layout it loads is in the
+ * dock. EVERY no-argument load must go through here — see {@link layoutLoadsInFlight} for what a
+ * push during one of them destroys. (The one-argument form is deliberately not covered: that caller
+ * hands us the layout it wants and `loadLayout` persists it on purpose.)
+ */
+async function loadLayoutHoldingPushes(): Promise<void> {
+  layoutLoadsInFlight += 1;
+  try {
+    await loadLayout();
+  } finally {
+    layoutLoadsInFlight -= 1;
+  }
+}
+
+/**
  * The pre-multi-window saved layout, read from raw `localStorage` (not `localWindowStorage`, whose
  * migration path would clone the legacy layout into every window). Builds that scoped
  * `localStorage` per window wrote the dock layout only under prefixed keys
@@ -1090,6 +1136,11 @@ async function saveLayout(layout: LayoutInfo): Promise<void> {
   const interfaceMode =
     currentInterfaceMode ?? (await settingsService.get('platform.interfaceMode'));
   if (interfaceMode === 'simple') return;
+  // A load is still fetching the layout this window should be showing, so what the dock holds is
+  // something else — the layout of the mode the user just left, or rc-dock's empty default at
+  // startup. Persisting that overwrites the real saved entry; see `layoutLoadsInFlight`. Nothing is
+  // lost by holding: the load on its way replaces the dock's whole contents anyway.
+  if (layoutLoadsInFlight > 0) return;
   if (isRunningOnFallbackLayout) {
     // The dock holds a fallback, not the user's saved layout (see getPersistedLayout); pushing it
     // would replace the real saved entry in the main process's structure
@@ -1134,7 +1185,9 @@ export function registerDockLayout(dockLayout: PapiDockLayout): Unsubscriber {
   // Fire-and-forget so `registerDockLayout` can stay sync. Guard the rejection, though: `loadLayout`
   // awaits settings reads (supplement flags), and an unhandled rejection here would leave the dock
   // unloaded (blank window).
-  loadLayout().catch((err) => logger.warn(`Initial loadLayout failed: ${getErrorMessage(err)}`));
+  loadLayoutHoldingPushes().catch((err) =>
+    logger.warn(`Initial loadLayout failed: ${getErrorMessage(err)}`),
+  );
 
   // Reload the layout whenever `platform.interfaceMode` changes so the user-facing mode switcher
   // (see `UserProfilePopover`) can swap layouts live without a restart. Use
@@ -1169,7 +1222,11 @@ export function registerDockLayout(dockLayout: PapiDockLayout): Unsubscriber {
           // switch reads the new mode immediately (before `loadLayout`'s own read resolves).
           currentInterfaceMode = newMode;
           try {
-            await loadLayout();
+            // Holds layout pushes until the new mode's layout is actually in the dock. Until then
+            // the dock still holds the old mode's layout, and pushing that under the new mode is
+            // what destroyed saved power layouts on a simple->power switch — see
+            // `layoutLoadsInFlight`.
+            await loadLayoutHoldingPushes();
           } catch (err) {
             logger.warn(`Dock layout failed to reload after interface mode change: ${err}`);
           }

--- a/src/renderer/services/web-view.service-host.ts
+++ b/src/renderer/services/web-view.service-host.ts
@@ -631,37 +631,6 @@ function getWindowIdOrThrow(): number {
  */
 let currentInterfaceMode: 'simple' | 'power' | undefined;
 
-/**
- * How many no-argument {@link loadLayout} calls have started but not yet put their layout in the
- * dock. While this is above zero, {@link saveLayout} holds its pushes: the dock does not yet hold
- * the layout this window is supposed to be showing, so pushing what it DOES hold overwrites the
- * user's real saved entry in the main process's structure.
- *
- * Such a load takes a while — it reads the interface mode, asks the main process for this window's
- * saved layout (a round trip that retries, so seconds), and reads the supplement flags — and every
- * ordinary layout change runs through `onLayoutChange` into `saveLayout` meanwhile: a web view
- * writing state, focus moving into a tab, a tab being activated. Two loads are exposed:
- *
- * - The INTERFACE-MODE SWITCH, which flips {@link currentInterfaceMode} the instant the setting
- *   changes (so a `saveLayout` racing the switch can't push under the mode the user just left)
- *   while the dock still holds the OLD mode's layout. Switching TO simple that is harmless, since
- *   simple mode never pushes. Switching to POWER it persisted the static simple layout as this
- *   window's power layout — permanently. Every later power-mode load then restored the simple
- *   layout (headless columns and all, so two of its tab groups render with no tab bar in power
- *   mode), and neither switching back and forth nor restarting recovered it, because the clobbered
- *   entry is what the main process answers with from then on.
- * - The INITIAL LOAD in `registerDockLayout`, before which the dock holds rc-dock's empty default
- *   layout rather than anything of this window's. Pushing that replaces the saved entry with an
- *   empty one — and an entry that HAS a layout is not eligible for the legacy fallback either (see
- *   `TrackedWindow.usesLegacyLayout` in `window-layout-persistence.service.ts`), so the window then
- *   starts empty from then on.
- *
- * A counter rather than a flag so a load starting before an earlier one finishes keeps the hold up
- * until BOTH are done, and released in a `finally` (see {@link loadLayoutHoldingPushes}) so a load
- * that throws can never latch it on for the rest of the session.
- */
-let layoutLoadsInFlight = 0;
-
 /** Create a new dock layout promise variable */
 function createDockLayoutAsyncVar(): AsyncVariable<PapiDockLayout> {
   return new AsyncVariable<PapiDockLayout>('web-view.service-host.platformDockLayout');
@@ -889,6 +858,40 @@ async function getEnabledSupplementEntries(): Promise<DefaultLayoutSupplementEnt
 let layoutLoadGeneration = 0;
 
 /**
+ * The {@link layoutLoadGeneration} of the load whose layout the dock actually holds. Set at each
+ * point {@link loadLayout} hands a layout to the dock, so while it trails `layoutLoadGeneration` a
+ * load is still on its way and the dock holds something OTHER than the layout this window should be
+ * showing. {@link saveLayout} holds its pushes until the two agree, because pushing what the dock
+ * holds in that stretch overwrites the user's real saved entry in the main process's structure.
+ *
+ * A load takes a while — it reads the interface mode, asks the main process for this window's saved
+ * layout (a round trip that retries, so seconds), and reads the supplement flags — and every
+ * ordinary layout change runs through `onLayoutChange` into `saveLayout` meanwhile: a web view
+ * writing state, focus moving into a tab, a tab being activated. Two loads leave the dock holding
+ * the wrong thing:
+ *
+ * - An INTERFACE-MODE SWITCH flips {@link currentInterfaceMode} the instant the setting changes (so a
+ *   `saveLayout` racing the switch cannot push under the mode the user just left) while the dock
+ *   still holds the OLD mode's layout. Going to simple that is harmless, since simple mode never
+ *   pushes. Going to POWER, a push would persist the static simple layout as this window's power
+ *   layout — permanently, since every later power-mode load restores that entry (headless columns
+ *   and all, so two of its tab groups would render with no tab bar in power mode) and the legacy
+ *   fallback is never consulted again.
+ * - The INITIAL LOAD in `registerDockLayout` starts with the dock on rc-dock's empty default rather
+ *   than anything of this window's. A push there would replace the saved entry with an empty layout
+ *   — and an entry that HAS a layout is not eligible for the legacy fallback either (see
+ *   `TrackedWindow.usesLegacyLayout` in `window-layout-persistence.service.ts`), so the window
+ *   would start empty from then on.
+ *
+ * Comparing generations rather than counting loads in flight is what keeps the hold matched to
+ * reality in both directions. A load that is superseded — or that throws — never marks itself
+ * landed, so it cannot lift the hold on a dock it never wrote; and it cannot extend the hold
+ * either, since the load that DOES reach the dock sets the marker to the current generation and
+ * pushes resume immediately, however long the abandoned one takes to settle.
+ */
+let layoutLoadGenerationInDock = 0;
+
+/**
  * Loads layout information into the dock layout.
  *
  * @param layout If this parameter is provided, loads that layout information. If not provided, gets
@@ -912,6 +915,7 @@ async function loadLayout(layout?: LayoutInfo): Promise<void> {
     // explicit layout owns its full contents. If a future "reset to default layout" path routes
     // through here and should include supplement tabs, merge `getEnabledSupplementEntries()` in too.
     dockLayoutVar.loadLayout(layout);
+    layoutLoadGenerationInDock = thisGeneration;
     emitCloseEventsForWebViewsRemovedByLayoutLoad(webViewsBeforeLoad, layout);
     await onLayoutChange(layout);
     return;
@@ -971,6 +975,7 @@ async function loadLayout(layout?: LayoutInfo): Promise<void> {
   if (enabledEntries.length === 0) {
     // Nothing to merge (the common/vanilla case) — load the base layout directly and skip the clone.
     dockLayoutVar.loadLayout(layoutToLoad);
+    layoutLoadGenerationInDock = thisGeneration;
     emitCloseEventsForWebViewsRemovedByLayoutLoad(webViewsBeforeLoad, layoutToLoad);
     return;
   }
@@ -988,23 +993,9 @@ async function loadLayout(layout?: LayoutInfo): Promise<void> {
   // eslint-disable-next-line no-type-assertion/no-type-assertion
   const supplementedLayoutInfo = supplementedLayout as unknown as LayoutInfo;
   dockLayoutVar.loadLayout(supplementedLayoutInfo);
+  layoutLoadGenerationInDock = thisGeneration;
   // Emit close events for pre-existing web views the (supplemented) layout dropped
   emitCloseEventsForWebViewsRemovedByLayoutLoad(webViewsBeforeLoad, supplementedLayoutInfo);
-}
-
-/**
- * Runs a no-argument {@link loadLayout} with layout pushes held until the layout it loads is in the
- * dock. EVERY no-argument load must go through here — see {@link layoutLoadsInFlight} for what a
- * push during one of them destroys. (The one-argument form is deliberately not covered: that caller
- * hands us the layout it wants and `loadLayout` persists it on purpose.)
- */
-async function loadLayoutHoldingPushes(): Promise<void> {
-  layoutLoadsInFlight += 1;
-  try {
-    await loadLayout();
-  } finally {
-    layoutLoadsInFlight -= 1;
-  }
 }
 
 /**
@@ -1136,11 +1127,11 @@ async function saveLayout(layout: LayoutInfo): Promise<void> {
   const interfaceMode =
     currentInterfaceMode ?? (await settingsService.get('platform.interfaceMode'));
   if (interfaceMode === 'simple') return;
-  // A load is still fetching the layout this window should be showing, so what the dock holds is
-  // something else — the layout of the mode the user just left, or rc-dock's empty default at
-  // startup. Persisting that overwrites the real saved entry; see `layoutLoadsInFlight`. Nothing is
-  // lost by holding: the load on its way replaces the dock's whole contents anyway.
-  if (layoutLoadsInFlight > 0) return;
+  // A load is still on its way, so what the dock holds is not the layout this window should be
+  // showing — the layout of the mode the user just left, or rc-dock's empty default at startup.
+  // Persisting that would overwrite the real saved entry; see `layoutLoadGenerationInDock`. Nothing
+  // is lost by holding: the load on its way replaces the dock's whole contents anyway.
+  if (layoutLoadGenerationInDock !== layoutLoadGeneration) return;
   if (isRunningOnFallbackLayout) {
     // The dock holds a fallback, not the user's saved layout (see getPersistedLayout); pushing it
     // would replace the real saved entry in the main process's structure
@@ -1185,9 +1176,7 @@ export function registerDockLayout(dockLayout: PapiDockLayout): Unsubscriber {
   // Fire-and-forget so `registerDockLayout` can stay sync. Guard the rejection, though: `loadLayout`
   // awaits settings reads (supplement flags), and an unhandled rejection here would leave the dock
   // unloaded (blank window).
-  loadLayoutHoldingPushes().catch((err) =>
-    logger.warn(`Initial loadLayout failed: ${getErrorMessage(err)}`),
-  );
+  loadLayout().catch((err) => logger.warn(`Initial loadLayout failed: ${getErrorMessage(err)}`));
 
   // Reload the layout whenever `platform.interfaceMode` changes so the user-facing mode switcher
   // (see `UserProfilePopover`) can swap layouts live without a restart. Use
@@ -1222,11 +1211,10 @@ export function registerDockLayout(dockLayout: PapiDockLayout): Unsubscriber {
           // switch reads the new mode immediately (before `loadLayout`'s own read resolves).
           currentInterfaceMode = newMode;
           try {
-            // Holds layout pushes until the new mode's layout is actually in the dock. Until then
-            // the dock still holds the old mode's layout, and pushing that under the new mode is
-            // what destroyed saved power layouts on a simple->power switch — see
-            // `layoutLoadsInFlight`.
-            await loadLayoutHoldingPushes();
+            // Layout pushes stay held until this load reaches the dock — until then the dock holds
+            // the old mode's layout, and persisting that under the new mode is what would destroy
+            // the saved power layout on a simple->power switch. See `layoutLoadGenerationInDock`.
+            await loadLayout();
           } catch (err) {
             logger.warn(`Dock layout failed to reload after interface mode change: ${err}`);
           }


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: fix-layout-clobbered-during-load

**Base**: origin/main

**Date**: 2026-08-14

**Review model**: Claude Opus 5

**Files changed**: 2

## Overview

Switching Power → Simple → Power did not restore the Power layout: the dock came back showing Simple's three columns, two of them with no tab bar at all, and restarting did not help. The cause is that `saveLayout` was armed during the stretch in which the dock does not yet hold the layout it is supposed to be showing, so an ordinary layout change in that stretch persisted the *wrong* layout as this window's saved entry — permanently, since `windowLayout:get` answers with that entry from then on and the legacy fallback is never consulted again.

Two loads were exposed. An interface-mode switch flips `currentInterfaceMode` the instant the setting changes, but the new mode's layout does not reach the dock until `loadLayout` has read the mode, round-tripped to main for the saved layout (with retries, so seconds), and read the supplement flags — so going to Power, any layout change in that window persisted the static simple layout as the power layout. Separately, before the initial load in `registerDockLayout` lands, the dock holds rc-dock's empty default, and a push there replaced the saved entry with an empty layout.

The fix records which load's layout the dock actually holds (`layoutLoadGenerationInDock`, set at each of the three points `loadLayout` hands a layout to the dock) and has `saveLayout` hold its pushes while that marker trails `layoutLoadGeneration`.

## API Changes

None. The branch touches only `src/renderer/services/web-view.service-host.ts` and its test. No changes to `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `lib/papi-dts/papi.d.ts`, or any `extensions/src/*/src/types/*.d.ts`. The one exported symbol in the changed file, `registerDockLayout`, has an unchanged signature; everything added is module-private.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **A no-argument load that rejects released the hold without ever putting a layout in the dock, so pushes resumed against exactly the state the change exists to protect against.** Reachable, not theoretical: `settingsService.get('platform.interfaceMode')` throws when the settings data provider isn't up yet — precisely the startup window `registerDockLayout` runs in — and `getDockLayout()` is an `AsyncVariable` with a 10 s reject timeout. _(fixed during review: the original `finally`-released counter was replaced with a generation marker set only where a layout actually reaches the dock, so a throwing load never marks itself landed and the hold stays up until some load does. Pinned by the new test `a layout change after a load throws pushes nothing`.)_
- [x] **A superseded load kept holding pushes until its own request settled, even though the dock already held the newer load's layout.** `sendNetworkRequest` in `getPersistedLayout` has no timeout, so a request that never settles would have held pushes for the rest of the session — silently dropping real user layout changes while protecting nothing. This is the same hazard the file already guards for `isRunningOnFallbackLayout` (`if (isSuperseded()) return undefined;`, with a dedicated test at `web-view.service-host.test.ts:557`). _(fixed during review: the generation comparison lifts the hold as soon as any load reaches the dock, however long an abandoned one takes to settle. Pinned by the new test `an abandoned load must not hold pushes once a newer load has reached the dock`, which was verified to fail against the previous counter-based implementation.)_
- [x] **The invariant "EVERY no-argument load must go through here" was enforced only by a TSDoc sentence** — a future third `loadLayout()` call site would have silently reintroduced the permanent saved-layout clobber, with no test or lint to catch it. _(fixed during review: the wrapper was deleted and the marker moved inside `loadLayout` itself, at the points where the dock is written. There is no longer a bypassable path — the invariant is structural.)_
- [x] **The counter-vs-flag invariant was documented but untested.** _(fixed during review: the counter is gone; the generation semantics it was standing in for are now pinned by two tests, one of which was confirmed to fail against the counter design.)_

### Minor — Consider

- [x] **TSDoc claimed the one-argument `loadLayout` form is "deliberately not covered", which was not what the code did** — `saveLayout` checked the module-global counter unconditionally, so an explicit load running while a no-argument load was in flight would have had its deliberate persist silently held too. _(fixed during review: the one-argument branch now sets the marker itself, so it persists as documented.)_
- [x] **Comments narrated the defect in past tense** ("it persisted", "then restored", "is what destroyed"), against Code-Style-Guide → *Comments describe the code, not its history*; the surrounding comments in this file use the conditional voice for the same kind of rationale. _(fixed during review: recast to conditional — "a push would persist…", "would replace…".)_
- [x] **The same rationale was restated in five places** (the TSDoc, both call-site comments, both test comments). _(fixed during review: the wrapper and its duplicate comment are gone; one TSDoc carries the detail and the single remaining call-site comment is one line plus a pointer.)_
- [x] **The `holdGetLayout` mock was duplicated verbatim between the new tests.** _(fixed during review: extracted a `holdGetLayout()` helper alongside the file's existing `respondToGetLayout`/`registerWindow`/`makeDockLayout` convention; all three new tests use it. The pre-existing 4× duplication of the `settingsSubscribe` capture block was left alone to keep the diff scoped.)_
- [ ] ~~The new hold returns silently, unlike its sibling `isRunningOnFallbackLayout` guard which logs once per session so a "my layout isn't saving" report is diagnosable.~~ _(Dismissed: with the generation design the hold is now the normal path on every load, including the one at startup, so a once-per-session warning would fire in every session and carry no signal. The sibling guard logs because it marks a genuinely abnormal state. A future "held for an unexpectedly long time" warning would be the useful version of this, but it needs a duration threshold, not a first-hit latch.)_
- [ ] ~~`hasLoggedHeldLayoutPushes` now reads as if it covers all hold reasons but only gates the fallback warning; consider renaming.~~ _(Dismissed: pre-existing name, and since the new hold deliberately does not log (above), there is no second logged hold for it to be confused with. Renaming it here would be unrelated churn in a bugfix branch.)_
- [ ] ~~No blank line after the new early return in `saveLayout`, per Code-Style-Guide → *Code Patterns We Use*.~~ _(Dismissed: the two adjacent pre-existing guards in `saveLayout` are formatted identically; matching the immediate neighbors reads better than being the one guard that differs. The analyzer flagged this for completeness and noted the same.)_
- [ ] **A failed layout reload after a mode switch is invisible to the user** — the setting is written and `currentInterfaceMode` has moved on, but the dock keeps showing the old mode's layout with only a `logger.warn`. Applying Changes' Feedback table requires an error toast or inline message on failure. Pre-existing, and this branch edits that exact call site. _(Left open deliberately: adding a user-facing error surface to the mode switcher is a UX change needing design input, not something to slip into a data-integrity bugfix. Flagged for the reviewer to route.)_

### Template Propagation

#### Shared Regions Modified

None. Neither changed file contains a `#region shared with` marker.

#### Extension Config Changes

None. No files under `extensions/` were changed.

## Positive Observations

- The ordering in the interface-mode subscription is the crux of the fix and it is right: `currentInterfaceMode = newMode` and the generation bump happen in the same synchronous tick, so there is no window in which pushes are armed under the new mode while the dock still holds the old mode's layout.
- Release timing is sound: `PapiDockLayout.loadLayout` forwards straight to rc-dock's `loadLayout`, which does not fire `onLayoutChange`, so nothing can slip a push in between the dock load and the marker being set.
- All four new tests assert the *resume* side as well as the suppression, so a hold that never released would fail them — the failure mode a suppression-only test would miss.
- The tests drive the realistic shape of the race (holding the `windowLayout:get` request open the way a slow main process would) rather than reaching into module state.
- This is a UX-guideline repair, not just a data-integrity fix: Applying Changes exempts "a control that is its own undo — panel/layout toggle" from needing a separate recovery path, and that carve-out only holds if re-operating the control really does restore the prior state. It did not; this change is what makes it true.
- Well scoped — no public API surface touched, no unrelated refactoring bundled in.

## Interview Notes

This review was run autonomously at the user's request; the author role was answered from the investigation that produced the branch, not by a separate human.

Design rationale for the redesign made during the review: the two Important findings pointed at the same mechanism from opposite sides — the original counter released the hold too eagerly (on a throw) and held it too long (while a superseded load was still settling). Both are symptoms of counting *loads running* when the question is *whose layout is in the dock*. Comparing `layoutLoadGenerationInDock` against `layoutLoadGeneration` answers that question directly, which is why one change closes both, plus the "enforced only by a comment" concern (the marker lives inside `loadLayout` at the write sites, so no call site can bypass it) and the untested-invariant concern.

Deliberate tradeoff, flagged for the reviewer: a load that throws now leaves pushes held until some later load reaches the dock. That is unbounded in principle. It was chosen over releasing on error because the failure it prevents is permanent and silent (a destroyed saved layout) while the failure it risks is transient and self-healing (layout changes not persisted until the next mode switch or restart). The file already accepts this exact shape in `isRunningOnFallbackLayout`, which is likewise only cleared by a later successful load.

No areas were deferred without understanding; every finding was traced to the code before being accepted or dismissed. The four dismissals above each state their reasoning rather than being waved off.

## In-Review Quality Check

All checks run after the in-review changes:

- `npm run typecheck` — clean (0 TS errors)
- `npm run lint` — 0 errors repo-wide. The 4 remaining warnings are pre-existing in `extensions/src/platform-scripture-editor/` (`import/no-duplicates`, `no-console`), untouched by this branch.
- Prettier — required two `--write` passes on the changed files after comment edits; both files now pass `--check`.
- `npm test` — all workspaces green (141 + 16 + 131 + 29 + 8 + 1 + 12 + 1 + 5 + 11 + 54 test files); `web-view.service-host.test.ts` is 24/24.
- Falsification: all three "hold" tests fail with the guard disabled, and `an abandoned load must not hold pushes once a newer load has reached the dock` was run against the previous counter-based implementation and failed there with the predicted symptom (`expected [] to have a length of 1`).
- `dotnet test c-sharp-tests/` not run — no C# changed.

## Suggested Review Focus

- [ ] **The unbounded-hold tradeoff.** A load that throws holds pushes until a later load lands. Is the precedent (`isRunningOnFallbackLayout` behaves the same way) good enough, or does this want a bounded escape hatch?
- [ ] **Overlap with `improve_simple-power_switching`.** That branch reworks this same file and adds a `switchGeneration` counter for a related-but-distinct failure (a *superseded* switch's tail). Its `saveLayout` guard is content-based — it refuses layouts containing a `SIMPLE_LAYOUT_TAB_IDS` id — but those are the **unscoped** UUIDs from `simpleLayout`, while the layout coming out of the dock has been through `withWindowScopedWebViewIds` and carries a `-w<N>` suffix, so the `.has(id)` check looks like it would miss. Worth checking on that branch. Content sniffing also cannot cover the initial-load case (an empty layout contains no Simple tab ids). Decide which mechanism survives; expect conflicts either way.
- [ ] **Silent failure on a failed mode-switch reload** (open Minor finding above) — route to UX, or accept as out of scope for this branch.
- [ ] **Recovery for users already hit by this.** The fix prevents recurrence but does not restore a clobbered entry. Is a one-time migration warranted, or is "delete `window-layouts.json`" acceptable guidance?
<!-- review-paratext:summary:end -->

---

## Summary

Switching Power → Simple → Power did not restore the Power layout: the dock came back showing Simple's three columns, with two tab groups missing their tab bars entirely. Restarting did not help, and toggling modes again did not help — because the user's saved Power layout had already been **destroyed on disk**.

`saveLayout` was armed during the window in which the dock does not yet hold the layout it is supposed to be showing, so an ordinary layout change in that window persisted the *wrong* layout as this window's saved entry. Two loads were exposed:

- **The interface-mode switch.** The subscription flips `currentInterfaceMode` the instant the setting changes, but the new mode's layout does not reach the dock until `loadLayout` has read the mode, round-tripped to main for the saved layout (with retries, so seconds), and read the supplement flags. Switching to **Power**, any layout change in that gap — a web view writing state (`setWebViewStateSync` → `updateWebViewDefinitionSync`), focus landing in a tab (`web-view.component.tsx:338`), a tab being activated — pushed the static simple layout as the window's power layout. Permanently: `windowLayout:get` answers with the clobbered entry from then on. The missing tab bars are the tell — `simple-layout.data.ts` panels carry `group: HEADLESS_GROUP`, and `dock-layout-wrapper.simple-mode.scss:56` hides `.dock-style-headless .dock-bar` by group class rather than by `[data-interface-mode='simple']`, so Simple's layout data renders headless in Power too.

  The direction matters: Power → Simple is harmless, since simple mode never pushes. Only Simple → Power destroys. The existing comment on `currentInterfaceMode` reasons about the first direction only.

- **The initial load** in `registerDockLayout`. Before it lands, the dock holds rc-dock's empty default rather than anything of this window's. Pushing that replaced the saved entry with an empty layout — and an entry that *has* a layout is not eligible for the legacy fallback either (`TrackedWindow.usesLegacyLayout`), so the window then started empty from then on. Narrower trigger than the first, same consequence.

### Why review this

Not part of the current epic. Found while manually exercising the mode switcher on a build off `main`: this silently and irreversibly destroys a user's saved Power layout, with no error and no recovery short of hand-editing `window-layouts.json`. Worth reviewer time now because it is live on `main` and every Simple → Power switch is a chance to hit it.

## Changes

- Added `layoutLoadsInFlight` and `loadLayoutHoldingPushes`; every no-argument `loadLayout` now routes through it, and `saveLayout` holds its pushes while it is above zero. A counter (not a flag) so overlapping loads keep the hold up until both finish, released in a `finally` so a load that throws cannot latch it on for the session. The one-argument form is deliberately not covered — that caller hands us the layout it wants and `loadLayout` persists it on purpose.
- Two tests, both verified to fail without the guard.

Nothing is lost by holding: the load on its way replaces the dock's whole contents anyway.

## Heads-up: overlaps `improve_simple-power_switching`

That branch reworks this same file and adds a `switchGeneration` counter for a related-but-distinct failure (a *superseded* switch's tail persisting after `currentInterfaceMode` moved on). This PR is about the *current, non-superseded* switch's own load window. Two things for whoever reconciles them:

- That branch's `saveLayout` guard is content-based — it refuses layouts containing a `SIMPLE_LAYOUT_TAB_IDS` id. Those ids are the **unscoped** UUIDs from `simpleLayout`, but the layout coming out of the dock has been through `withWindowScopedWebViewIds`, so its ids carry the `-w<N>` suffix and the `.has(id)` check looks like it would miss. Worth checking on that branch.
- Content sniffing also cannot cover the initial-load case here, since an empty layout contains no Simple tab ids.

Expect conflicts; happy to rebase onto whichever lands first.

## AI Involvement

AI-assisted (Claude Opus 5 via Claude Code). Claude did the investigation — traced the clobber to the `currentInterfaceMode` flip preceding the load, and confirmed it with a red test before writing any fix — then wrote the guard and both tests. I reviewed the diff and the reasoning.

## Testing

- [x] `npm test` — all workspaces green (`web-view.service-host.test.ts`: 22/22, including the pre-existing supersede/race tests)
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean (repo-wide)
- [x] Revert test: both new tests fail with the guard disabled, pass with it
- [ ] No C# changed, so `dotnet test c-sharp-tests/` not run
- [ ] Not manually re-verified in the app — the destructive path needs an already-clobbered profile to observe

## Risk Level

Low — one added early-return in `saveLayout`, gated on a counter that is only non-zero for the duration of a no-argument `loadLayout`. It can only *suppress* pushes, never redirect one, and the `finally` bounds how long it can suppress.

## Note for anyone already hit by this

Your saved Power layout is gone; this fix prevents recurrence but does not restore it. If `dock-saved-layout` is still in `localStorage`, quitting and deleting `window-layouts.json` from the userData folder makes the window fall back to it on the next Power-mode start (at the cost of saved window bounds and any secondary-window entries).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2681)
<!-- Reviewable:end -->

