### PR TITLE
PT-3216: Pass the editor tab-menu selection to Find

### DIFF
--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -1264,3 +1264,57 @@ step, no automation. Just a record.
   answer would have wiped that selection permanently — `useProjectSetting` reports an error as
   loaded, so the error branch has to be recognized on its own.
 - **Source:** PT-3299, review of #2708.
+
+## ADR-0026: A tab’s own web view supplies its selection to Find, rather than a shared selection store
+
+- **Date:** 2026-08-16
+- **Status:** Accepted
+- **Source:** PT-3216 (pass editor text selection to Find), PR #2692; builds on the shared Ctrl+F
+  hook from ADR-0015 / PT-4341.
+- **Context:** Opening Find from a scripture editor tab's menu needed that tab's text selection. The
+  work item proposed publishing the selection into the platform's shared store so a command handler
+  could read it. Two facts made that unnecessary and unavailable: (a) the scripture editor sets
+  `shouldShowToolbar: false` (`extensions/src/platform-scripture-editor/src/main.ts`) and instead
+  renders its own `TabToolbar` *inside* its web view
+  (`extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx`), so its
+  menu handler already runs in the document that owns the selection; (b) `sharedStoreService`
+  (`src/shared/services/shared-store.service.ts`) is explicitly not part of the public API and is not
+  reachable from extensions.
+- **Decision:** Find takes the selection of the tab it was triggered from, read in that tab's own web
+  view via `window.getSelection()` and passed through the existing `platformScripture.openFind`
+  `selectedText` parameter. No cross-tab selection state. `resolveFindSelectionText`
+  (`extensions/src/platform-scripture-editor/src/find-trigger.util.ts`) is the single normalizer
+  every trigger goes through, so all of them apply the same two rules: trim (a double-click word
+  selection often carries a trailing space), and reject anything spanning lines (Find's search box is
+  a single-line input, so a Ctrl+A selection cannot be shown honestly and must not be flattened into
+  a run-on term). The two trigger paths deliberately
+  differ in one respect: the tab menu additionally consults a capture-phase pointer-press snapshot
+  (`use-selection-snapshot.hook.ts`), because the click that opens the dropdown is itself what
+  collapses the selection; Ctrl+F (`use-open-find-shortcut.hook.ts`, ADR-0015) reads only the live
+  selection, because a keystroke destroys nothing, and a fallback there would let a long-abandoned
+  selection pre-fill and immediately re-run a search over whatever term an open Find panel already
+  held.
+- **Alternatives:** (a) Shared store — rejected: not extension-accessible, and unnecessary once the
+  menu handler's location is understood. (b) A global "last selection" registry in the editor
+  extension built on the existing `platformScriptureEditor.onDidSelectionChange` event — deferred:
+  every Find entry point today is tab-scoped, so the triggering tab *is* the focused editor; a
+  registry would add cross-tab state with no current consumer. (c) Deriving the text from the
+  existing `PlatformScriptureEditorWebViewController.getSelection()` — rejected: that carries USJ
+  document offsets, not text, so it would mean re-reading and slicing USJ to recover a string the
+  triggering document already has.
+- **Consequences:** The selection path stays inside one file per tab type and needs no new
+  cross-process state. The snapshot is deliberately narrow, because a remembered selection that
+  outlives the interaction that produced it would pre-fill — and immediately re-run — a search over
+  whatever term the user had since typed into an open Find panel. Three bounds keep it honest: it
+  only remembers selections anchored inside the tab's text content (chrome has its own selectable
+  text — a reference input, a search box — that is not scripture); a press inside that content clears
+  it; and reading it consumes it, so it bridges exactly the one pointer press it exists for.
+  **Revisit** if a Find entry point ever lives outside a tab (a top-toolbar or application-menu Find,
+  or an extension asking "what is selected right now" to enable/disable menu items) — that is the
+  point where alternative (b) becomes the right answer. The snapshot is load-bearing, not defensive: in Chromium, a menu item's `click` handler
+  reads an empty `window.getSelection()` even though the same selection is still live at the
+  capture-phase `pointerdown` on that item — the collapse lands between the two, which is exactly the
+  window the snapshot covers. The end-to-end test written to prove this inside the real editor could
+  not be run in this development environment, and `test:e2e:isolated` (the only runner that reaches
+  `e2e-tests/tests/isolated/find/`) appears in no CI workflow, so that verification gap is closed by
+  a manual pass rather than by automation.

--- a/e2e-tests/tests/isolated/find/find-replace.spec.ts
+++ b/e2e-tests/tests/isolated/find/find-replace.spec.ts
@@ -43,6 +43,18 @@ const NO_MATCH_TERM = 'ZZZQQQXXX_NORESULT_12345';
 /** History debounce delay (ms). Must match HISTORY_DEBOUNCE_DELAY_MS in find.web-view.tsx. */
 const HISTORY_DEBOUNCE_MS = 5_000;
 
+/**
+ * The paragraph Find renders once a search has finished — the results summary, the no-results
+ * message, or the search error.
+ *
+ * The `:not([role="status"])` is load-bearing: the idle / no-open-projects / invalid-query
+ * placeholders are `EmptyState`, which carries the same `tw:text-center tw:font-light` classes the
+ * caller passes it plus `role="status"`. Without the exclusion this selector also matches a panel
+ * that has never run a search, so every "wait until the search finished" gate below would resolve
+ * immediately.
+ */
+const SEARCH_OUTCOME_MESSAGE_SELECTOR = 'p.tw\\:font-light.tw\\:text-center:not([role="status"])';
+
 // ---------------------------------------------------------------------------
 // Worker-level setup — runs once before any test in this file.
 // Opens a scripture editor so the hamburger menu is available throughout
@@ -128,7 +140,7 @@ test.beforeAll(async ({ electronApp }) => {
   const hamburger = editorFrame.locator('button[aria-label="Project"]');
   await expect(hamburger).toBeVisible({ timeout: 15_000 });
   await hamburger.click();
-  const findMenuItem = editorFrame.getByRole('menuitem', { name: /find\.\.\./i });
+  const findMenuItem = editorFrame.getByRole('menuitem', { name: /^find$/i });
   await expect(findMenuItem).toBeVisible({ timeout: 5_000 });
   await findMenuItem.click();
 
@@ -142,8 +154,8 @@ test.beforeAll(async ({ electronApp }) => {
   // Wait up to 90 s for either the counter (results found) or the results/no-results paragraph.
   await expect(
     findFrame
-      .locator('.tw-tabular-nums')
-      .or(findFrame.locator('p.tw-font-light.tw-text-center'))
+      .locator('.tw\\:tabular-nums')
+      .or(findFrame.locator(SEARCH_OUTCOME_MESSAGE_SELECTOR))
       .first(),
   ).toBeVisible({ timeout: 90_000 });
 
@@ -224,8 +236,8 @@ async function openFindPanel(mainPage: Page): Promise<FrameLocator> {
   await expect(hamburger).toBeVisible({ timeout: 15_000 });
   await hamburger.click();
 
-  // Click "Find..." from the dropdown (the Radix DropdownMenuContent portals into the iframe body)
-  const findMenuItem = editorFrame.getByRole('menuitem', { name: /find\.\.\./i });
+  // Click "Find" from the dropdown (the Radix DropdownMenuContent portals into the iframe body)
+  const findMenuItem = editorFrame.getByRole('menuitem', { name: /^find$/i });
   await expect(findMenuItem).toBeVisible({ timeout: 5_000 });
   await findMenuItem.click();
 
@@ -260,7 +272,7 @@ async function fillSearchAndWaitForResults(frame: FrameLocator, term: string): P
   // can take 60–120 s on a cold start while the C# backend loads project data.  Even on a warm
   // engine, a fresh web-view instance re-awaits the PDP resolution hook, so the first search in
   // each new Find panel can still take > 90 s.
-  await expect(frame.locator('.tw-tabular-nums')).toBeVisible({ timeout: 150_000 });
+  await expect(frame.locator('.tw\\:tabular-nums')).toBeVisible({ timeout: 150_000 });
 }
 
 /** Click the X (clear search) button in the search input. */
@@ -291,6 +303,73 @@ async function switchToReplaceMode(frame: FrameLocator): Promise<void> {
  */
 function firstResultCard(frame: FrameLocator): Locator {
   return frame.locator('[role="button"][aria-pressed]').first();
+}
+
+/**
+ * Select the first word in the editor's text that is long enough to be distinctive and is not one
+ * of `excludedWords`, and return the selected text. A programmatic Range keeps the setup
+ * deterministic — a positional double-click can land on a verse number or whitespace — while still
+ * producing the real DOM selection the Find triggers read.
+ *
+ * Why exclusions at all: the Find panel restores the project's last search term into an empty
+ * search box when it mounts, so a word equal to a term an earlier test already searched would let
+ * the test pass without the selection ever reaching Find. With today's constants the 6+ letter rule
+ * already rules that out on its own — `excludedWords` is what keeps that true if a shorter search
+ * term is ever replaced with a long one.
+ */
+async function selectDistinctiveWordInEditor(
+  editorFrame: Frame,
+  excludedWords: string[],
+): Promise<string> {
+  return editorFrame.evaluate((excluded: string[]) => {
+    const content = document.querySelector('.editor-input');
+    if (!content) throw new Error('Editor content (.editor-input) not found');
+    const isExcluded = (word: string) =>
+      excluded.some((candidate) => candidate.toLowerCase() === word.toLowerCase());
+    const walker = document.createTreeWalker(content, NodeFilter.SHOW_TEXT);
+    const wordPattern = /\p{L}{6,}/gu;
+    let node = walker.nextNode();
+    while (node) {
+      const text = node.textContent ?? '';
+      wordPattern.lastIndex = 0;
+      let match = wordPattern.exec(text);
+      while (match) {
+        if (!isExcluded(match[0])) {
+          const range = document.createRange();
+          range.setStart(node, match.index);
+          range.setEnd(node, match.index + match[0].length);
+          const selection = window.getSelection();
+          if (!selection) throw new Error('No selection object available in the editor frame');
+          selection.removeAllRanges();
+          selection.addRange(range);
+          // Collapsed footnotes live inside `.editor-input` but are `display: none`, and
+          // `Selection.toString()` is empty over hidden content. Keep walking rather than handing
+          // back a word the user could not have selected.
+          if (selection.toString().trim()) return selection.toString();
+          selection.removeAllRanges();
+        }
+        match = wordPattern.exec(text);
+      }
+      node = walker.nextNode();
+    }
+    throw new Error(
+      'No distinctive word (6+ letters, visible, not an excluded search term) found in the editor',
+    );
+  }, excludedWords);
+}
+
+/**
+ * Undo {@link selectDistinctiveWordInEditor} so no selection leaks into later tests: drop the
+ * document selection, and press inside the editor's text content, which is what clears the tab's
+ * pointer-press selection snapshot.
+ */
+async function clearEditorSelection(editorFrame: Frame): Promise<void> {
+  await editorFrame.evaluate(() => {
+    window.getSelection()?.removeAllRanges();
+    document
+      .querySelector('.editor-input')
+      ?.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -350,6 +429,60 @@ test.describe('Find Panel Basics', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Tests: Selection carried into Find
+// ---------------------------------------------------------------------------
+
+test.describe('Editor selection to Find', () => {
+  // The test body waits ~60 s for editor text, then openFindPanel (~90 s worst case), then the
+  // results counter (~150 s worst case) — sum to ~300 s, so give the block extra headroom above
+  // that worst case.
+  test.describe.configure({ timeout: 360_000 });
+
+  test('pre-fills and searches the editor selection when Find is opened from the tab menu', async ({
+    mainPage,
+  }) => {
+    const editorFrame = await findScriptureEditorFrame(mainPage);
+    // Wait for verse text to populate, not just for the container to exist — the helper needs real
+    // words to select.
+    await expect(editorFrame.locator('.editor-input')).toContainText(/\p{L}{6,}/u, {
+      timeout: 60_000,
+    });
+
+    const excludedTerms = [COMMON_SEARCH_TERM, REPLACE_SEARCH_TERM];
+    const selectedText = (await selectDistinctiveWordInEditor(editorFrame, excludedTerms)).trim();
+    // A word rendered inside a collapsed footnote is `display: none`, and `Selection.toString()`
+    // returns '' over hidden content. Assert the selection is real before using it, or the
+    // `toHaveValue(selectedText)` check below passes vacuously against an empty search box.
+    expect(selectedText).not.toBe('');
+    // The Find panel restores the project's last search term into an empty box on mount, so a word
+    // colliding with a term another test searched would make this test pass without the selection
+    // ever reaching Find.
+    expect(excludedTerms.map((term) => term.toLowerCase())).not.toContain(
+      selectedText.toLowerCase(),
+    );
+
+    try {
+      const frame = await openFindPanel(mainPage);
+
+      await expect(frame.locator('#search-term')).toHaveValue(selectedText, { timeout: 15_000 });
+      // The panel searches the pre-filled term immediately; the results counter proves it ran.
+      // Generous timeout: the findInScripture PDP factory initializes lazily and can take 60-120 s
+      // on a cold start.
+      await expect(frame.locator('.tw\\:tabular-nums')).toBeVisible({ timeout: 150_000 });
+
+      await closeFindPanel(mainPage);
+    } finally {
+      // Leave no selection behind, including when an assertion above threw. `closeFindPanel` clicks
+      // the dock tab on the main page, which never reaches the editor iframe, so without this the
+      // selection — and the pointer-press snapshot built from it — would pre-fill every later
+      // `openFindPanel` call in this file and kick off an unintended search before those tests type
+      // their own term.
+      await clearEditorSelection(editorFrame);
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Tests: Search Results
 // ---------------------------------------------------------------------------
 
@@ -371,7 +504,7 @@ test.describe('Search Results', () => {
     await expect(frame.locator('#search-term')).toBeVisible({ timeout: 10_000 });
 
     await fillSearchAndWaitForResults(frame, COMMON_SEARCH_TERM);
-    const counterFirst = await frame.locator('.tw-tabular-nums').textContent();
+    const counterFirst = await frame.locator('.tw\\:tabular-nums').textContent();
 
     // Switch to a rare term: "Bartholomew" (4 occurrences) stays under the 100-result batch
     // cap, so its counter must differ — another common word would cap at "1 of 100" like the
@@ -386,14 +519,14 @@ test.describe('Search Results', () => {
     // Use isVisible() for non-blocking checks so the predicate never hangs waiting for an
     // element that may never reappear (counter disappears when results are cleared).
     await expect(async () => {
-      const counterVisible = await frame.locator('.tw-tabular-nums').isVisible();
+      const counterVisible = await frame.locator('.tw\\:tabular-nums').isVisible();
       if (counterVisible) {
         // Counter is visible — verify it changed from the original 'the' search
         const counterSecond = await frame
-          .locator('.tw-tabular-nums')
+          .locator('.tw\\:tabular-nums')
           .textContent({ timeout: 1_000 });
         expect(counterSecond).not.toBe(counterFirst);
-      } else if (await frame.locator('p.tw-font-light.tw-text-center').isVisible()) {
+      } else if (await frame.locator(SEARCH_OUTCOME_MESSAGE_SELECTOR).isVisible()) {
         // No-results paragraph appeared — search completed with 0 results (results changed)
       } else {
         // Neither visible yet — search still in progress, keep waiting
@@ -415,7 +548,7 @@ test.describe('Search Results', () => {
     await clickClearSearch(frame);
 
     // Results and counter should disappear; input should be empty
-    await expect(frame.locator('.tw-tabular-nums')).not.toBeVisible({ timeout: 5_000 });
+    await expect(frame.locator('.tw\\:tabular-nums')).not.toBeVisible({ timeout: 5_000 });
     await expect(frame.locator('#search-term')).toHaveValue('');
     await expect(firstResultCard(frame)).not.toBeVisible({ timeout: 5_000 });
 
@@ -843,7 +976,10 @@ test.describe('Search Filters', () => {
     // updates (different result count) or the no-results paragraph appears — either confirms
     // both filters are honoured without a crash.
     await expect(
-      frame.locator('.tw-tabular-nums').or(frame.locator('p.tw-font-light.tw-text-center')).first(),
+      frame
+        .locator('.tw\\:tabular-nums')
+        .or(frame.locator(SEARCH_OUTCOME_MESSAGE_SELECTOR))
+        .first(),
     ).toBeVisible({ timeout: 30_000 });
 
     await closeFindPanel(mainPage);
@@ -891,9 +1027,9 @@ test.describe('Scope Switching', () => {
       expect(newScopeText).not.toBe(initialScopeText);
 
       // A search should have completed with results or no-results
-      const counterVisible = await frame.locator('.tw-tabular-nums').isVisible();
+      const counterVisible = await frame.locator('.tw\\:tabular-nums').isVisible();
       if (counterVisible) return;
-      if (await frame.locator('p.tw-font-light.tw-text-center').isVisible()) return;
+      if (await frame.locator(SEARCH_OUTCOME_MESSAGE_SELECTOR).isVisible()) return;
       throw new Error('Waiting for scope-change search to complete');
     }).toPass({ timeout: 30_000 });
 

--- a/extensions/src/platform-scripture-editor/src/find-trigger.util.test.ts
+++ b/extensions/src/platform-scripture-editor/src/find-trigger.util.test.ts
@@ -1,5 +1,42 @@
 import { describe, it, expect } from 'vitest';
-import { getOpenFindTriggerArgs } from './find-trigger.util';
+import { getOpenFindTriggerArgs, resolveFindSelectionText } from './find-trigger.util';
+
+describe('resolveFindSelectionText', () => {
+  it('prefers the live selection', () => {
+    expect(resolveFindSelectionText('grace', 'mercy')).toBe('grace');
+  });
+
+  it('falls back to the pre-press snapshot when the live selection is gone', () => {
+    // Opening a dropdown can collapse the document selection before the menu item is chosen.
+    expect(resolveFindSelectionText('', 'mercy')).toBe('mercy');
+  });
+
+  it('treats a whitespace-only live selection as no selection', () => {
+    expect(resolveFindSelectionText('   \n', 'mercy')).toBe('mercy');
+  });
+
+  it('trims the chosen text so a double-click trailing space does not join the search term', () => {
+    expect(resolveFindSelectionText('grace ', undefined)).toBe('grace');
+    expect(resolveFindSelectionText(undefined, ' mercy\n')).toBe('mercy');
+  });
+
+  it('rejects a selection that spans lines — Find’s search box is a single line', () => {
+    // Ctrl+A, or a drag across verses. Flattening a passage into one run-on term would run a doomed
+    // search and push it into the shared search history.
+    expect(resolveFindSelectionText('grace\nand mercy', undefined)).toBe('');
+    expect(resolveFindSelectionText('grace\r\nand mercy', undefined)).toBe('');
+    expect(resolveFindSelectionText(undefined, 'grace\nand mercy')).toBe('');
+  });
+
+  it('falls back to the snapshot when the live selection spans lines', () => {
+    expect(resolveFindSelectionText('grace\nand mercy', 'mercy')).toBe('mercy');
+  });
+
+  it('returns an empty string when nothing is or was selected', () => {
+    expect(resolveFindSelectionText(undefined, undefined)).toBe('');
+    expect(resolveFindSelectionText('', '   ')).toBe('');
+  });
+});
 
 describe('getOpenFindTriggerArgs', () => {
   it('returns args when the tab has scripture to search', () => {
@@ -16,6 +53,15 @@ describe('getOpenFindTriggerArgs', () => {
       selectedText: '',
       sourceProjectId: 'res-proj',
     });
+  });
+
+  it('normalizes the selection, so no caller can hand Find a raw one', () => {
+    // A double-click on a word usually takes the trailing space with it, and searching "dog "
+    // finds far less than "dog".
+    expect(getOpenFindTriggerArgs('wv-1', 'res-proj', 'dog ')?.selectedText).toBe('dog');
+    expect(getOpenFindTriggerArgs('wv-1', 'res-proj', undefined)?.selectedText).toBe('');
+    // Find's search box is a single line, so a selection spanning lines is not a search term.
+    expect(getOpenFindTriggerArgs('wv-1', 'res-proj', 'dog\ncat')?.selectedText).toBe('');
   });
 
   it('is a no-op (undefined) when no scripture is resolved yet', () => {

--- a/extensions/src/platform-scripture-editor/src/find-trigger.util.ts
+++ b/extensions/src/platform-scripture-editor/src/find-trigger.util.ts
@@ -1,4 +1,42 @@
 /**
+ * Normalize one candidate selection into something Find can search for, or `''` if it is not a
+ * search term at all.
+ *
+ * Trimming matters because a double-click word selection often carries a trailing space, and
+ * searching for `"grace "` finds far less than `"grace"`. Selections that span lines are rejected
+ * outright: Find's search box is a single-line input, so a multi-line selection (Ctrl+A, or a drag
+ * across verses) cannot be shown honestly, and pre-filling one would flatten a whole passage into a
+ * run-on term, run a doomed search, and push it into the shared search history.
+ */
+function toSearchTerm(selectionText: string | undefined): string {
+  const trimmed = (selectionText ?? '').trim();
+  return /[\r\n]/.test(trimmed) ? '' : trimmed;
+}
+
+/**
+ * Choose the text a Find trigger should search for.
+ *
+ * The live document selection wins when there is one. It can be gone by the time a tab-menu item is
+ * chosen — the pointer press that opens the dropdown collapses the selection — so a snapshot taken
+ * immediately before that press is the fallback. Every Find trigger goes through here, so all of
+ * them normalize identically; see {@link toSearchTerm} for what that means.
+ *
+ * @param liveSelectionText Text currently selected in the document, if any.
+ * @param selectionTextBeforePointerPress Text that was selected immediately before the most recent
+ *   pointer press outside the tab's text content. Pass `undefined` from any trigger that does not
+ *   destroy the selection it acts on — a keystroke, for instance.
+ * @returns The search text, or an empty string when nothing usable is or was selected. An empty
+ *   string means "open Find without pre-filling" — it leaves an already-open panel's search box
+ *   alone.
+ */
+export function resolveFindSelectionText(
+  liveSelectionText: string | undefined,
+  selectionTextBeforePointerPress: string | undefined,
+): string {
+  return toSearchTerm(liveSelectionText) || toSearchTerm(selectionTextBeforePointerPress);
+}
+
+/**
  * Arguments for the `platformScripture.openFind` command when Ctrl+F is pressed in a scripture tab:
  * the triggering tab's web view id, the current text selection, and the project id of the scripture
  * the tab is showing (the search source).
@@ -14,17 +52,29 @@ export interface OpenFindTriggerArgs {
  * `undefined` (a no-op) when the tab has no scripture resolved yet — Find must never fall back to
  * searching a reference panel's container project, which is not what the panel is showing.
  *
+ * The selection is normalized here rather than by the caller, so no Ctrl+F trigger can hand Find a
+ * raw selection: a trailing space from a double-click would silently narrow the search, and the
+ * only thing standing between the user and that is this call. See {@link resolveFindSelectionText}.
+ *
  * @param webViewId The triggering tab's own web view id (always supplied by `WebViewProps`).
  * @param sourceProjectId Project id of the scripture the tab is showing — the editor's own project
  *   for a Scripture editor tab, the displayed resource's project for a reference panel — or
  *   `undefined` while none is resolved.
- * @param selectedText The tab's current text selection, used to pre-fill Find. May be empty.
+ * @param selectedText The tab's raw current text selection. Normalized here; may be empty or
+ *   `undefined`.
  */
 export function getOpenFindTriggerArgs(
   webViewId: string,
   sourceProjectId: string | undefined,
-  selectedText: string,
+  selectedText: string | undefined,
 ): OpenFindTriggerArgs | undefined {
   if (!sourceProjectId) return undefined;
-  return { webViewId, selectedText, sourceProjectId };
+  // No pointer-press snapshot: a keystroke destroys nothing, so the live selection is always the
+  // honest answer. The tab menu differs — see `getMenuFindSelectionText` in
+  // `platform-scripture-editor.web-view.tsx`.
+  return {
+    webViewId,
+    selectedText: resolveFindSelectionText(selectedText, undefined),
+    sourceProjectId,
+  };
 }

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -113,7 +113,9 @@ import {
   removeDecorations,
 } from './decorations.util';
 import { runOnFirstLoad, scrollToAnnotation, scrollToVerse } from './editor-dom.util';
+import { resolveFindSelectionText } from './find-trigger.util';
 import { useOpenFindShortcut } from './use-open-find-shortcut.hook';
+import { useSelectionSnapshot } from './use-selection-snapshot.hook';
 import { useEditorPdpSync } from './use-editor-pdp-sync.hook';
 import { FootnotesLayout } from './platform-scripture-editor-footnotes.component';
 import {
@@ -1285,6 +1287,26 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
   // panels so there is a single Ctrl+F→openFind implementation across every scripture tab type.
   useOpenFindShortcut(webViewId, projectId);
 
+  // `.editor-input` is the Lexical content element (the same selector the marker-menu handler uses).
+  const getSelectionBeforePointerPress = useSelectionSnapshot('.editor-input');
+
+  /**
+   * The text the tab menu's Find item should search for: the live selection, or — when the click
+   * that opened the menu has already collapsed it — what was selected just before that click.
+   *
+   * Only the menu path consults the snapshot, because only a pointer press destroys the selection
+   * it is about to act on. Ctrl+F (`useOpenFindShortcut`) reads the live selection directly and
+   * deliberately does NOT fall back here: a keystroke destroys nothing, so the live value is always
+   * the honest answer. Falling back would let a selection made much earlier pre-fill and
+   * immediately re-run a search, overwriting whatever term the user already had in an open Find
+   * panel.
+   */
+  const getMenuFindSelectionText = useCallback(
+    () =>
+      resolveFindSelectionText(window.getSelection()?.toString(), getSelectionBeforePointerPress()),
+    [getSelectionBeforePointerPress],
+  );
+
   // Listen for the marker menu trigger to open the marker menu, and for
   // Cmd+Alt+M (macOS) or Ctrl+Alt+M / Ctrl+Shift+N (Windows/Linux) to insert comment at selection
   useEffect(() => {
@@ -2040,11 +2062,29 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
 
   const menuCommandHandler = useCallback<SelectMenuItemHandler>(
     (projectMenuCommand) => {
+      // Find is the one menu command that needs more than the tab id: it carries this tab's current
+      // text selection so the Find panel pre-fills and searches it, matching Ctrl+F. The source
+      // project is deliberately left off — `openFind` resolves it from this editor's own web view
+      // definition, which is the same project this component renders. (When neither yields a
+      // project, `openFind` fronts an already-open Find as-is and creates nothing, so the selection
+      // is dropped on that path rather than pre-filling a panel pointed at some other project.)
+      // Hidden-target case: the Find panel may be an inactive (display:none) tab when this fires.
+      // Nothing here is layout-dependent — the text travels as web view state (findSearchTerm) and
+      // openFind brings the panel to front — so a hidden Find catches up on activation by
+      // construction, with no deferred side effect to replay.
+      if (projectMenuCommand.command === 'platformScripture.openFind') {
+        papi.commands
+          .sendCommand('platformScripture.openFind', webViewId, getMenuFindSelectionText())
+          .catch((e) =>
+            logger.warn(`Failed to open Find from the editor tab menu: ${getErrorMessage(e)}`),
+          );
+        return;
+      }
       // Assuming that the project menu command is one of the registered command handlers in papi
       // eslint-disable-next-line no-type-assertion/no-type-assertion
       papi.commands.sendCommand(projectMenuCommand.command as keyof CommandHandlers, webViewId);
     },
-    [webViewId],
+    [getMenuFindSelectionText, webViewId],
   );
 
   function renderEditor() {

--- a/extensions/src/platform-scripture-editor/src/use-open-find-shortcut.hook.test.ts
+++ b/extensions/src/platform-scripture-editor/src/use-open-find-shortcut.hook.test.ts
@@ -74,4 +74,22 @@ describe('useOpenFindShortcut', () => {
     pressKey('f');
     expect(sendCommand).not.toHaveBeenCalled();
   });
+
+  it('trims the selection so a double-click trailing space does not narrow the search', () => {
+    // This hook is the single Ctrl+F implementation for every scripture tab type, so trimming here
+    // covers the Scripture editor as well as the read-only reference panels.
+    // Only toString() is exercised by the hook; a full Selection cannot be constructed here.
+    // eslint-disable-next-line no-type-assertion/no-type-assertion
+    const fakeSelection = { toString: () => 'grace ' } as unknown as Selection;
+    vi.spyOn(window, 'getSelection').mockReturnValue(fakeSelection);
+    renderHook(() => useOpenFindShortcut('wv-1', 'resource-proj'));
+    pressKey('f');
+    expect(sendCommand).toHaveBeenCalledWith(
+      'platformScripture.openFind',
+      'wv-1',
+      'grace',
+      'resource-proj',
+    );
+    vi.restoreAllMocks();
+  });
 });

--- a/extensions/src/platform-scripture-editor/src/use-open-find-shortcut.hook.ts
+++ b/extensions/src/platform-scripture-editor/src/use-open-find-shortcut.hook.ts
@@ -26,10 +26,11 @@ export function useOpenFindShortcut(webViewId: string, sourceProjectId: string |
       // them app-wide. Ctrl rather than Cmd on macOS is deliberate; see the doc comment above.
       if (event.shiftKey || event.altKey || event.metaKey) return;
       if (!event.ctrlKey || event.key.toLowerCase() !== 'f') return;
+      // `getOpenFindTriggerArgs` normalizes the selection, so the raw value goes in here.
       const args = getOpenFindTriggerArgs(
         webViewId,
         sourceProjectId,
-        window.getSelection()?.toString() ?? '',
+        window.getSelection()?.toString(),
       );
       if (!args) {
         logger.debug(

--- a/extensions/src/platform-scripture-editor/src/use-selection-snapshot.hook.test.ts
+++ b/extensions/src/platform-scripture-editor/src/use-selection-snapshot.hook.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, it, expect } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useSelectionSnapshot } from './use-selection-snapshot.hook';
+
+const CONTENT_SELECTOR = '.editor-input';
+
+let content: HTMLDivElement;
+let contentWord: HTMLSpanElement;
+let chrome: HTMLDivElement;
+let chromeButton: HTMLButtonElement;
+let chromeText: HTMLSpanElement;
+
+/** Put a real document selection over `element`'s text — the same thing the hook reads in a tab. */
+function select(element: Element) {
+  const range = document.createRange();
+  range.selectNodeContents(element);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+/**
+ * Put a document selection over part of `element`'s text, so the selection anchors on a **Text**
+ * node rather than an element. This is what a real drag or double-click in the editor produces, so
+ * it is the containment path that actually runs in the app.
+ */
+function selectInsideTextNode(element: Element, start: number, end: number) {
+  const textNode = element.firstChild;
+  if (!textNode) throw new Error('Element has no text node to select inside');
+  const range = document.createRange();
+  range.setStart(textNode, start);
+  range.setEnd(textNode, end);
+  const selection = window.getSelection();
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+}
+
+function clearSelection() {
+  window.getSelection()?.removeAllRanges();
+}
+
+function pressOn(target: Element) {
+  target.dispatchEvent(new Event('pointerdown', { bubbles: true }));
+}
+
+beforeEach(() => {
+  content = document.createElement('div');
+  content.className = 'editor-input';
+  contentWord = document.createElement('span');
+  contentWord.textContent = 'grace';
+  content.append(contentWord);
+
+  // The tab's chrome: a button to press, plus its own selectable text (stands in for the reference
+  // input / a search box rendered in the same toolbar).
+  chrome = document.createElement('div');
+  chromeButton = document.createElement('button');
+  chromeText = document.createElement('span');
+  chromeText.textContent = 'GEN 1:1';
+  chrome.append(chromeButton, chromeText);
+
+  document.body.append(content, chrome);
+  clearSelection();
+});
+
+afterEach(() => {
+  clearSelection();
+  document.body.replaceChildren();
+});
+
+describe('useSelectionSnapshot', () => {
+  it('starts with no remembered selection', () => {
+    const { result } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    expect(result.current()).toBe('');
+  });
+
+  it('remembers the selection when a press lands outside the text content', () => {
+    const { result } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    select(contentWord);
+    pressOn(chromeButton);
+    expect(result.current()).toBe('grace');
+  });
+
+  it('forgets the selection when a press lands inside the text content', () => {
+    const { result } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    select(contentWord);
+    pressOn(chromeButton);
+    pressOn(contentWord);
+    expect(result.current()).toBe('');
+  });
+
+  it('preserves the remembered selection when a later outside press finds nothing selected', () => {
+    const { result } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    select(contentWord);
+    pressOn(chromeButton);
+    clearSelection();
+    pressOn(chromeButton);
+    expect(result.current()).toBe('grace');
+  });
+
+  it('replaces the remembered selection when a later outside press finds a new selection', () => {
+    const { result } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    select(contentWord);
+    pressOn(chromeButton);
+    contentWord.textContent = 'mercy';
+    select(contentWord);
+    pressOn(chromeButton);
+    expect(result.current()).toBe('mercy');
+  });
+
+  it('remembers a selection anchored on a text node inside the content', () => {
+    // A drag or double-click in the editor anchors the selection on the Text node, not on the
+    // element, so containment has to resolve through the text node's parent. Without that step the
+    // hook would never record anything in the real editor while every element-anchored test here
+    // stayed green.
+    const { result } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    selectInsideTextNode(contentWord, 0, 4);
+    pressOn(chromeButton);
+    expect(result.current()).toBe('grac');
+  });
+
+  it('ignores a text-node selection anchored in the tab’s chrome', () => {
+    const { result } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    selectInsideTextNode(chromeText, 0, 3);
+    pressOn(chromeButton);
+    expect(result.current()).toBe('');
+  });
+
+  it('ignores a selection anchored in the tab’s chrome rather than the text content', () => {
+    // Text selected in a toolbar control (a reference input, a search box) is not scripture and must
+    // never reach Find as if the user had selected it in the editor.
+    const { result } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    select(chromeText);
+    pressOn(chromeButton);
+    expect(result.current()).toBe('');
+  });
+
+  it('hands the remembered selection out once, then forgets it', () => {
+    // The snapshot bridges one pointer press. Keeping it would let a selection made long ago
+    // pre-fill — and immediately re-run — a search over a term the user had since typed into Find.
+    const { result } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    select(contentWord);
+    pressOn(chromeButton);
+    expect(result.current()).toBe('grace');
+    expect(result.current()).toBe('');
+  });
+
+  it('returns a stable getter across renders', () => {
+    const { result, rerender } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+
+  it('stops listening after unmount', () => {
+    const { result, unmount } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    const getSnapshot = result.current;
+    unmount();
+    select(contentWord);
+    pressOn(chromeButton);
+    expect(getSnapshot()).toBe('');
+  });
+
+  it('captures during the capture phase, before a handler that stops propagation', () => {
+    const { result } = renderHook(() => useSelectionSnapshot(CONTENT_SELECTOR));
+    chrome.addEventListener('pointerdown', (event) => {
+      event.stopPropagation();
+    });
+    select(contentWord);
+    pressOn(chromeButton);
+    expect(result.current()).toBe('grace');
+  });
+});

--- a/extensions/src/platform-scripture-editor/src/use-selection-snapshot.hook.ts
+++ b/extensions/src/platform-scripture-editor/src/use-selection-snapshot.hook.ts
@@ -1,0 +1,70 @@
+import { useCallback, useEffect, useRef } from 'react';
+
+/** The element a node lives in — the node itself when it is already an element. */
+function elementOf(node: Node | null | undefined): Element | undefined {
+  if (node instanceof Element) return node;
+  return node?.parentElement ?? undefined;
+}
+
+/**
+ * Remembers the text that was selected in this web view's text content immediately before the most
+ * recent pointer press on the tab's chrome (toolbar buttons, menus).
+ *
+ * Why this exists: choosing a menu item is a pointer press, and a pointer press collapses the
+ * document selection. In Chromium the collapse lands between the press and the resulting `click`,
+ * so a menu item's click handler reads an empty `window.getSelection()` even though the selection
+ * was still live when the press arrived. A menu command that wants "what the user had selected"
+ * needs the value from just before the press. The listener runs in the capture phase so it observes
+ * the selection before any component handler moves focus and before the browser's default selection
+ * change.
+ *
+ * Three rules keep the remembered value honest:
+ *
+ * - Only selections anchored **inside** the text content are remembered. Everything outside it counts
+ *   as chrome, and chrome contains its own selectable text (a reference input, a search box) that
+ *   is not scripture and must never be handed to the caller as if it were.
+ * - A press _outside_ the text content records the live selection when there is one, and otherwise
+ *   leaves the previously remembered value alone — a press on chrome (e.g. a toolbar button) can
+ *   collapse the selection as its default action, and a later press to open a menu must not let
+ *   that collapse erase what was already captured. Only a press _inside_ the text content clears
+ *   the snapshot: pressing in the text is the user deliberately re-placing the caret, and that
+ *   discarded selection must not resurface.
+ * - **Reading consumes.** The snapshot exists to bridge one pointer press, so it is handed out once
+ *   and then forgotten. Without this it would survive every interaction that is not a press in the
+ *   text, and a selection made long ago could pre-fill — and immediately re-run — a search over
+ *   whatever term the user had since typed into an open Find panel.
+ *
+ * @param contentSelector CSS selector for the tab's text content. A selection anchored inside it is
+ *   remembered; a press inside it clears the snapshot. Anything else counts as chrome.
+ * @returns A stable getter that returns the remembered selection text (`''` when there is none) and
+ *   clears it.
+ */
+export function useSelectionSnapshot(contentSelector: string): () => string {
+  const snapshotRef = useRef('');
+
+  useEffect(() => {
+    const captureSelection = (event: Event) => {
+      const target = event.target instanceof Element ? event.target : undefined;
+      if (target?.closest(contentSelector)) {
+        snapshotRef.current = '';
+        return;
+      }
+      const selection = window.getSelection();
+      // Only a selection sitting in the text content is scripture; one anchored in the tab's chrome
+      // belongs to whatever control owns it.
+      const liveText = elementOf(selection?.anchorNode)?.closest(contentSelector)
+        ? (selection?.toString() ?? '')
+        : '';
+      snapshotRef.current = liveText.trim() || snapshotRef.current;
+    };
+
+    window.addEventListener('pointerdown', captureSelection, true);
+    return () => window.removeEventListener('pointerdown', captureSelection, true);
+  }, [contentSelector]);
+
+  return useCallback(() => {
+    const snapshot = snapshotRef.current;
+    snapshotRef.current = '';
+    return snapshot;
+  }, []);
+}


### PR DESCRIPTION
> **Rebased onto current `main`**, squashed to **one commit**. The stacked-PR note is gone — the whole diff is PT-3216. The new ADR renumbered to **0026** (ADR-0024 and ADR-0025 landed on `main` in the meantime).

## Summary

Selecting **Find…** from a scripture editor tab's hamburger menu now carries that tab's selected text into the Find panel, which pre-fills the search box and searches it. Ctrl+F already did this (#2677); the menu item didn't.

| | Before | After |
|---|---|---|
| Ctrl+F with text selected | pre-fills ✅ | pre-fills ✅ (now normalized — see below) |
| Tab menu → **Find…** with text selected | opens empty ❌ | pre-fills ✅ |

**Why it's small:** the work item proposed publishing the selection into the platform's shared store. That turned out to be unnecessary *and* impossible — `sharedStoreService` isn't extension-accessible, and the editor renders its own `TabToolbar` **inside its web view**, so the menu handler already runs in the document that owns the DOM selection. It just needed to read it. ([ADR-0026](.context/standards/Architecture-Decisions.md) records this so the shared-store idea isn't re-derived from the ticket.)

## Where to look

| File | What it does |
|---|---|
| `platform-scripture-editor.web-view.tsx` | **The wiring.** The `platformScripture.openFind` branch in `menuCommandHandler`. |
| `use-selection-snapshot.hook.ts` *(new)* | **The one clever bit.** Remembers the selection a chrome click is about to destroy. See below. |
| `find-trigger.util.ts` | `resolveFindSelectionText` — the single normalizer **every** Find trigger goes through. |
| `use-open-find-shortcut.hook.ts` | Ctrl+F (all scripture tab types) now routes its selection through that normalizer. One line. |
| `find-replace.spec.ts` | New e2e test **+ an incidental repair** — see Notes. |
| `Architecture-Decisions.md` | ADR-0026. |

## The one subtle bit

Choosing a menu item is a pointer press, and a pointer press collapses the selection. A capture-phase `pointerdown` listener snapshots the selection just before that press.

Three bounds keep the remembered value honest (`use-selection-snapshot.hook.ts`):

| Rule | Why |
|---|---|
| Only selections **anchored inside** `.editor-input` are remembered | The chrome has its own selectable text — the reference input, a search box. That isn't scripture and must never reach Find as though the user had selected it in the editor. |
| A press **inside** the editor text **clears** it | They're re-placing the caret — that selection is abandoned, don't resurrect it. (A press on chrome with nothing selected *keeps* it, so a toolbar click before opening the menu doesn't wipe it.) |
| **Reading consumes** it | It exists to bridge one pointer press. Without this, a selection made ten minutes ago could pre-fill — and immediately re-run — a search over whatever term the user had since typed into an open Find panel. |

**Ctrl+F deliberately does not use the snapshot** — only the tab menu does. A keystroke destroys nothing, so the live selection is always the honest answer. The asymmetry is intentional and commented at both call sites so it doesn't get "tidied up" later.

## Verification

- ✅ `format:check`, `typecheck`, `lint` (0 errors), `dotnet test c-sharp-tests/` (1580 passed / 0 failed) — all clean on current `main`.
- ✅ `extensions` **1041/1041** across `platform-scripture-editor` + `platform-scripture/find` — that's where this change lives, and the root `npm test` doesn't reach it (`extensions` has no `test` script).
- ℹ️ Full-suite runs on my Windows box produce a **shifting** set of timeout failures — 18 tests one run, 15 the next, in different files each time (`web-view.service-host`, `window-layout-persistence`, `theme.service-host`, `dialog.service-host`, `network-object-status`, `pt9-css-converter`). All 7 pass together in isolation (129/129), and `platform-bible-react`'s `storybook (chromium)` project times out en masse under its own browser parallelism. This PR touches **no file under `lib/`, `src/`, or `tools/`** — the whole diff is `extensions/`, `e2e-tests/`, and one doc. Flagging it rather than burying it.
- ✅ **The premise behind the snapshot is now confirmed empirically**, in Chromium with trusted pointer events on a stand-in page (contenteditable + a menu that focuses its content on open, like Radix). Instrumented log from the real click sequence:

  ```
  capture pointerdown on #trigger    -> live: "beginning"   snapshot now "beginning"
  trigger click handler              -> live: "beginning"
  capture pointerdown on #menuitem   -> live: "beginning"   snapshot now "beginning"
  MENU ITEM click handler            -> live: ""            snapshot available here: "beginning"
  ```

  The collapse lands between the menu item's `pointerdown` and its `click` — exactly the window the capture-phase listener covers. **The hook is load-bearing, not defensive:** without it the menu handler reads `""`. Inserting a toolbar click before opening the menu behaves identically.
- ✅ Unit tests include ones that fail if the listener moves from capture to bubble phase, if the trim is dropped, if the chrome-anchor rule is removed, or if reading stops consuming.
- ⚠️ **Still unproven inside the real app.** The new e2e test has never executed here, and `test:e2e:isolated` — the only runner reaching `tests/isolated/find/` — is in no CI workflow. The probe above is plain Chromium, not Lexical + Radix.
- ⚠️ **Manual UI check not done** — `refresh.sh`'s CDP path is Linux-only, so the UI couldn't be driven on Windows.

If you can spare two minutes in a running app:
1. Select a word → click a toolbar button → open tab menu → **Find…** → should pre-fill the word.
2. Select a word → open tab menu → **Find…** → should pre-fill the word.

<details>
<summary><b>Notes</b> — incidental scope, and behavior changes to existing paths</summary>

**Incidental repair (12 sites in `find-replace.spec.ts`).** The spec waited on `.tw-tabular-nums` and `p.tw-font-light.tw-text-center` — Tailwind **v3** dash-prefix selectors. This repo builds Tailwind v4 with `prefix(tw)`, so the rendered tokens are `tw:tabular-nums` / `tw:font-light`; the old selectors could never match. This broke the suite's shared `beforeAll`, hence every test in the file. Fixed to the escaped v4 form, confirmed against the components that render them. Happy to split this out if you'd rather.

**Two intentional behavior changes to the already-shipped Ctrl+F path**, both because `resolveFindSelectionText` is now the one place every trigger normalizes:

- **Trimmed.** A double-click word selection in Chromium often grabs a trailing space, and searching `"grace "` finds far less than `"grace"`. Previously the tab menu and the reference panels trimmed but editor Ctrl+F did not.
- **Selections spanning lines are rejected** (Find opens without pre-filling). Find's search box is a single-line `<input>`, so Ctrl+A → Ctrl+F would otherwise flatten a whole chapter into one run-on term, run a doomed project-wide search, push it into the shared search history, and remount an already-open Find panel to do it. This one is a judgment call on a path that shipped in #2677 — say the word and I'll drop it.

**Read-only Resource Viewer** shares this web view and is covered: platform-editor renders `className="editor-input …"` unconditionally, so the rules behave identically there.

**One question raised by the rebase, not acted on.** ADR-0017 (new on `main`, from #2691) says a launch parameter must be written into web view state by *unconditional* assignment, and explicitly rejects "conditionally spreading the key only when present" because it lets a stale value survive a layout restore. Its Source line cites `openFind`'s `selectedText` as the pattern it generalizes — but `buildFindWebViewState` conditionally spreads `initialSearchText`, and three tests in `find-web-view-state.utils.test.ts` pin that behavior on purpose ("does NOT write findSearchTerm for an empty selection (leaves the saved term intact)"). Find seems to genuinely want its term to survive a restore, unlike Manage Books' `intent`. Left alone here — it predates this PR and flipping it would change Find's restore behavior — but worth deciding whether the ADR needs a carve-out or the code needs a change.

**Deferred:** a global "last selection" registry (for a Find entry point that isn't tab-scoped). Not needed today — every Find trigger is tab-scoped, so the triggering tab *is* the focused editor. Recorded in ADR-0026 with the trigger for revisiting.

</details>

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2692)
<!-- Reviewable:end -->



