### PR TITLE
PT-4386: Stop the startup sync from locking the project picker

### DIFF
--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -2359,14 +2359,31 @@ step, no automation. Just a record.
   `paratextBibleSendReceive` activates *after* `platform-scripture`, so if it goes first its
   self-trigger starves the same factory — the identical bug, relocated into a repo core cannot test.
   Paratext 10 Studio also *removed* its own `Task.Run(SyncProjects)` self-trigger precisely so core
-  would be the single trigger owner ("that would double-sync", per the `paratext-10-studio` repo's
-  `repo-patches/paranext-core.patch`); self-triggering would undo that. **Defer until an existing
+  would be the single trigger owner; self-triggering would undo that. The evidence is in the
+  `paranext/paratext-10-studio` repo at `repo-patches/paranext-core.patch` (lines 5334–5336 as of
+  commit `f779810`), in the hunk that patches
+  `c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs`: *"NOTE: startup auto-sync is
+  triggered by paranext-core itself (src/main/startup-tasks.ts, "Conditional autosync on startup"),
+  which calls the syncProjects papi command — so the patch no longer kicks off its own
+  Task.Run(SyncProjects) here (that would double-sync)."* **Defer until an existing
   "workspace ready" signal** — rejected: none exists. `all-extensions-activated` is a performance
   mark emitted only under `PT_STARTUP_MARKS`, at the end of `activateExtensions` in
   `src/extension-host/services/extension.service.ts`, not a network event.
   **Gate on factory registration alone** — rejected as insufficient: the Scripture Extender is a
   layering factory whose `getAvailableProjects` fans out to the .NET base factories, so it can be
   registered while still unable to answer; hence the second, metadata-probe phase.
+  **Treat any phase-1 rejection as the end of the gate** — rejected: `waitForNetworkObject` rejects
+  both when the budget it was given expires (genuine exhaustion) and when the status service is
+  unreachable, and the latter can land with nearly the whole budget unspent. Ending there would
+  collapse a 120 s gate into seconds and fire the sync early — the original bug, reintroduced
+  invisibly, since the cause is logged only at debug while the caller warns "syncing anyway". A
+  non-exhaustion rejection therefore falls through to phase 2, which tests the stronger condition
+  and already tolerates throws; with no factory registered it sees empty results and polls to the
+  deadline, so the worst case degrades to the same `'timed-out'`. This is insurance, not a fix for
+  an observed failure: from main the path is currently unreachable (the status service is hosted in
+  main, `startNetworkObjectStatusService()` is awaited long before the startup tasks run, and a
+  same-process `get` returns the local proxy, making the call a synchronous in-memory read). It is
+  written this way so the guarantee does not silently depend on that arrangement holding.
 - **Consequences:** Core is the single owner of startup-sync ordering, and the gate is
   mechanism-agnostic — it holds regardless of which contention inside the .NET provider is
   responsible, which matters because that contention is not fully pinned down (the obvious
@@ -2380,5 +2397,24 @@ step, no automation. Just a record.
   just before — a setting changed mid-wait now re-gates the sync rather than firing on stale
   settings. On a real quit (`isAppQuitRequested()`) the wait is aborted and the sync is skipped; a
   macOS last-window close that leaves the app resident deliberately does NOT abort it, since the app
-  is still going to want its startup sync.
+  is still going to want its startup sync. That exception is carried on its own abort signal
+  (`startupReadinessAbort` in `main.ts`, `StartupTasksSignals.readinessAbortSignal`) rather than on
+  the shared one, so it applies to the Simple readiness wait ALONE — Power mode's boot-race retry
+  loop keeps aborting on every shutdown, on every platform, exactly as before. The Simple path then
+  has to run on that signal *throughout*, including its post-wait abort check: a last-window close
+  makes `isAppShuttingDown()` true via `areAllWindowsClosing()`, so the shared signal aborts on
+  precisely the close the carve-out exists to survive, and re-checking it after the wait would make
+  the carve-out unreachable — the wait would outlive the close only to be discarded as "quitting".
+  Simple mode's hard stop is therefore the live predicate rather than a latched signal, which is
+  strictly better anyway: it is evaluated at fire time and covers both ways the app can be
+  un-syncable (shutting down, and resident but windowless). A surviving wait is
+  still not licence to fire: `canStartupSyncFireNow` is re-checked immediately before the command
+  goes out and skips when the app is resident but windowless, which is the state a macOS last-window
+  close leaves behind. It distinguishes that from having no window YET — the app still coming up —
+  which stays allowed, since treating it as disqualifying would silently drop the sync on any boot
+  whose readiness landed before the first window did. Without the check a wait parked for the full
+  budget could resolve minutes later and run a whole-workspace Send/Receive after the shutdown sync
+  already ran, with no UI to report progress or failure into. The exception therefore pays off in
+  exactly one case — a dock reactivation brings a window back before readiness lands — which is the
+  case it was added for.
 - **Source:** PT-4386.

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -2333,7 +2333,7 @@ step, no automation. Just a record.
 - **Source:** PT-2626 review (PR #2727), finding 7 — "the current standard tells the next author to
   do the opposite of what this PR establishes."
 
-## ADR-0027: Core owns startup-sync ordering and gates it on project-data-provider readiness
+## adr-startup-sync-readiness-gate: Core owns startup-sync ordering and gates it on project-data-provider readiness
 
 - **Date:** 2026-08-16
 - **Status:** Accepted

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -2332,3 +2332,53 @@ step, no automation. Just a record.
   writing it is deferred rather than done.
 - **Source:** PT-2626 review (PR #2727), finding 7 — "the current standard tells the next author to
   do the opposite of what this PR establishes."
+
+## ADR-0027: Core owns startup-sync ordering and gates it on project-data-provider readiness
+
+- **Date:** 2026-08-16
+- **Status:** Accepted
+- **Context:** In Simple mode, `performStartupTasks` fired `paratextBibleSendReceive.syncProjects`
+  ("sync every locally-known shared project") as soon as its settings gates passed
+  (`src/main/startup-tasks.ts`). In Paratext 10 Studio that command is served by the .NET data
+  provider; its Mercurial and DBL work saturates that process before the scripture PDP factories
+  finish initializing. Because extensions activate strictly sequentially (the awaited loop inside
+  `activateExtensions` in `src/extension-host/services/extension.service.ts`), any extension awaiting
+  the busy provider stalls `platform-scripture` behind it — and `platform-scripture` registers the Scripture
+  Extender layering PDPF, the only factory advertising `platformScripture.USJ_Chapter`, which the
+  project picker waits on. The picker's wait timed out and it stayed locked. The Power-mode path was
+  already gated, but on a different signal — the S/R command's registration, plus a freshness window
+  — never on project-data-provider readiness; the Simple-mode branch had no ordering gate of any kind.
+- **Decision:** Core keeps ownership of the startup-sync trigger and gates it on workspace
+  readiness, in the main process. `src/main/startup-readiness.util.ts` waits — bounded by
+  `STARTUP_SYNC_READINESS_BUDGET_MS` (120 s) — first for the scripture PDP factory network object to
+  register, then for a scripture-metadata probe to answer non-empty, and only then fires the sync.
+  On timeout it fires anyway (delayed, never suppressed); on abort it skips.
+- **Alternatives:** **Have the Send/Receive extension self-trigger at the end of its own
+  activation** (the shape PT-4386 named as preferred, and the one sketched in `startup-tasks.ts`'s
+  own TSDoc) — rejected: sequential activation gives no guarantee that
+  `paratextBibleSendReceive` activates *after* `platform-scripture`, so if it goes first its
+  self-trigger starves the same factory — the identical bug, relocated into a repo core cannot test.
+  Paratext 10 Studio also *removed* its own `Task.Run(SyncProjects)` self-trigger precisely so core
+  would be the single trigger owner ("that would double-sync", per the `paratext-10-studio` repo's
+  `repo-patches/paranext-core.patch`); self-triggering would undo that. **Defer until an existing
+  "workspace ready" signal** — rejected: none exists. `all-extensions-activated` is a performance
+  mark emitted only under `PT_STARTUP_MARKS`, at the end of `activateExtensions` in
+  `src/extension-host/services/extension.service.ts`, not a network event.
+  **Gate on factory registration alone** — rejected as insufficient: the Scripture Extender is a
+  layering factory whose `getAvailableProjects` fans out to the .NET base factories, so it can be
+  registered while still unable to answer; hence the second, metadata-probe phase.
+- **Consequences:** Core is the single owner of startup-sync ordering, and the gate is
+  mechanism-agnostic — it holds regardless of which contention inside the .NET provider is
+  responsible, which matters because that contention is not fully pinned down (the obvious
+  read-loop-blocking explanation was real but was already fixed in Studio, verified 2026-08-16). The
+  startup sync can now be delayed by up to 120 s on a pathological boot. **Power mode is knowingly
+  left ungated** and retains the same latent race: its freshness window is anchored to
+  window-interactive time, so charging a readiness wait against it could silently *drop* a legitimate
+  startup sync — trading a visible bug for an invisible one. Revisit when the freshness anchor is
+  reworked. Because the wait can park for up to 120 s, the three Simple-mode settings gates
+  (interface mode, first-run, sync-on-startup) are re-read and re-evaluated immediately after it, not
+  just before — a setting changed mid-wait now re-gates the sync rather than firing on stale
+  settings. On a real quit (`isAppQuitRequested()`) the wait is aborted and the sync is skipped; a
+  macOS last-window close that leaves the app resident deliberately does NOT abort it, since the app
+  is still going to want its startup sync.
+- **Source:** PT-4386.

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -72,6 +72,7 @@ import {
   markQuitRequested,
   resetShutdownLatchesForNewSession,
   runShutdownTasksOnce,
+  shouldWindowCloseAbortStartupTasks,
 } from '@main/services/shutdown-latch.service';
 import { setAppShutdownSignal } from '@main/services/rpc-server';
 import { startWebViewServiceRouter } from '@main/services/web-view.service-router';
@@ -403,10 +404,11 @@ async function main() {
   // TODO (maybe): Wait for signal from the extension host process that it is ready (except 'getWebView')
   // We could then wait for the renderer to be ready and signal the extension host
 
-  // Signals for the fire-and-forget startup tasks: an abort controller so the Power-mode boot-race
-  // retry loop stops the moment the app begins quitting (wired below), and a window-interactive
-  // clock so a startup sync that only registers late isn't fired onto an editor the user is already
-  // using (see performStartupTasks / STARTUP_SYNC_FRESHNESS_WINDOW_MS).
+  // Signals for the fire-and-forget startup tasks: an abort controller so either mode's startup-sync
+  // wait — Power's boot-race retry loop or Simple's readiness gate — stops the moment a real quit
+  // begins (wired below), and a window-interactive clock so a Power-mode startup sync that only
+  // registers late isn't fired onto an editor the user is already using (see performStartupTasks /
+  // STARTUP_SYNC_FRESHNESS_WINDOW_MS).
   const startupTasksAbort = new AbortController();
   let mainWindowInteractiveAt: number | undefined;
 
@@ -1010,10 +1012,12 @@ async function main() {
         isAppGoingDown = isAppShuttingDown();
 
         if (isAppGoingDown) {
-          // The app is on its way down: stop the startup boot-race retry loop so it can't fire a
-          // startup sync after this shutdown sync, or reach a network connection that is about to
-          // be torn down.
-          startupTasksAbort.abort();
+          // Stop the startup tasks' bounded waits so they can't fire a startup sync after this
+          // shutdown sync, or reach a network connection that is about to be torn down. The one
+          // exception is a macOS last-window close, where the app stays resident and a later dock
+          // reactivation still wants its startup sync — the predicate explains why the platform,
+          // and not the quit flag alone, has to decide that.
+          if (shouldWindowCloseAbortStartupTasks(process.platform)) startupTasksAbort.abort();
 
           // Flush the window-layouts structure with every still-tracked window in it, before any
           // `closed` handler trims the list — a window that is not live at save time is not

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -67,12 +67,13 @@ import {
   startWindowServiceRouter,
 } from '@main/services/window.service-router';
 import {
+  canStartupSyncFireNow,
   isAppQuitRequested,
   isAppShuttingDown,
   markQuitRequested,
   resetShutdownLatchesForNewSession,
   runShutdownTasksOnce,
-  shouldWindowCloseAbortStartupTasks,
+  shouldWindowCloseAbortReadinessWait,
 } from '@main/services/shutdown-latch.service';
 import { setAppShutdownSignal } from '@main/services/rpc-server';
 import { startWebViewServiceRouter } from '@main/services/web-view.service-router';
@@ -404,12 +405,20 @@ async function main() {
   // TODO (maybe): Wait for signal from the extension host process that it is ready (except 'getWebView')
   // We could then wait for the renderer to be ready and signal the extension host
 
-  // Signals for the fire-and-forget startup tasks: an abort controller so either mode's startup-sync
-  // wait — Power's boot-race retry loop or Simple's readiness gate — stops the moment a real quit
-  // begins (wired below), and a window-interactive clock so a Power-mode startup sync that only
-  // registers late isn't fired onto an editor the user is already using (see performStartupTasks /
-  // STARTUP_SYNC_FRESHNESS_WINDOW_MS).
+  // Signals for the fire-and-forget startup tasks:
+  //
+  // - `startupTasksAbort` stops the startup tasks the moment the app starts going down by either
+  //   route, quit or last-window close. This is the long-standing behavior and is what Power mode's
+  //   boot-race retry loop runs on; nothing about the Simple-mode readiness gate changes it.
+  // - `startupReadinessAbort` stops only Simple mode's readiness wait, and is deliberately NOT
+  //   aborted by a macOS last-window close: there the app stays resident, the startup tasks run once
+  //   per process, and a dock reactivation still wants that session's startup sync. Kept separate so
+  //   that exception cannot leak into Power mode's loop.
+  // - a window-interactive clock, so a Power-mode startup sync that only registers late isn't fired
+  //   onto an editor the user is already using (see performStartupTasks /
+  //   STARTUP_SYNC_FRESHNESS_WINDOW_MS).
   const startupTasksAbort = new AbortController();
+  const startupReadinessAbort = new AbortController();
   let mainWindowInteractiveAt: number | undefined;
 
   /**
@@ -430,6 +439,13 @@ async function main() {
     try {
       await performStartupTasks({
         abortSignal: startupTasksAbort.signal,
+        readinessAbortSignal: startupReadinessAbort.signal,
+        // Answers the state neither abort signal can describe: resident, not quitting, no windows —
+        // where macOS leaves the app after its last window closes. `getWindows` already filters out
+        // destroyed windows, so a window mid-teardown does not keep this true; the latch is what
+        // keeps "no window YET" (the app still coming up) from reading as "went windowless".
+        canFireStartupSync: () =>
+          canStartupSyncFireNow(getWindows().length, hasCreatedWindowThisProcess),
         getWindowInteractiveElapsedMs: () =>
           mainWindowInteractiveAt === undefined
             ? undefined
@@ -1012,12 +1028,19 @@ async function main() {
         isAppGoingDown = isAppShuttingDown();
 
         if (isAppGoingDown) {
-          // Stop the startup tasks' bounded waits so they can't fire a startup sync after this
-          // shutdown sync, or reach a network connection that is about to be torn down. The one
-          // exception is a macOS last-window close, where the app stays resident and a later dock
-          // reactivation still wants its startup sync — the predicate explains why the platform,
-          // and not the quit flag alone, has to decide that.
-          if (shouldWindowCloseAbortStartupTasks(process.platform)) startupTasksAbort.abort();
+          // The app is on its way down: stop the startup tasks so they can't fire a startup sync
+          // after this shutdown sync, or reach a network connection that is about to be torn down.
+          // Unconditional, as it has always been — Power mode's boot-race retry loop in particular
+          // must stop here on every platform.
+          startupTasksAbort.abort();
+
+          // Simple mode's readiness wait is the one thing that may outlive this close: on macOS the
+          // app stays resident and the startup tasks run once per PROCESS, so aborting here would
+          // drop the startup sync for good even though a dock reactivation still wants it. The
+          // predicate explains why the platform, and not the quit flag alone, has to decide. A wait
+          // that does survive still cannot fire into a windowless app — `canFireStartupSync` above
+          // is re-checked immediately before the sync goes out.
+          if (shouldWindowCloseAbortReadinessWait(process.platform)) startupReadinessAbort.abort();
 
           // Flush the window-layouts structure with every still-tracked window in it, before any
           // `closed` handler trims the list — a window that is not live at save time is not
@@ -1429,6 +1452,10 @@ async function main() {
       // Stop the startup boot-race retry loop before networkService.shutdown() tears down the
       // connection, so a late retry can't resurrect it (a no-op if the window close already aborted).
       startupTasksAbort.abort();
+      // A real quit ends the Simple-mode readiness wait too, including the macOS last-window-close
+      // case the window handler deliberately let through — that exception exists for an app that
+      // stays resident, and this one is not.
+      startupReadinessAbort.abort();
 
       // Prevent closing before graceful shutdown is complete.
       // Also, in the future, this should allow a "are you sure?" dialog to display.

--- a/src/main/services/__tests__/shutdown-latch.service.test.ts
+++ b/src/main/services/__tests__/shutdown-latch.service.test.ts
@@ -6,6 +6,7 @@ import {
   markQuitRequested,
   resetShutdownLatchesForNewSession,
   runShutdownTasksOnce,
+  shouldWindowCloseAbortStartupTasks,
 } from '@main/services/shutdown-latch.service';
 import {
   addWindow,
@@ -39,6 +40,27 @@ describe('shutdown latches', () => {
     markQuitRequested();
 
     expect(isAppQuitRequested()).toBe(true);
+  });
+
+  test('leaves the startup tasks running when macOS closes its last window without quitting', () => {
+    // The app stays resident and a dock reactivation starts a fresh session, but the startup tasks
+    // run once per process — so aborting here would drop that session's startup sync permanently.
+    expect(shouldWindowCloseAbortStartupTasks('darwin')).toBe(false);
+
+    markQuitRequested();
+
+    // A real quit on macOS still has to stop them.
+    expect(shouldWindowCloseAbortStartupTasks('darwin')).toBe(true);
+  });
+
+  test('stops the startup tasks off macOS even before a quit is flagged', () => {
+    // Off macOS the last window closing always ends in a quit, but `window-all-closed` calls
+    // `app.quit()` only after the close handlers have run — so the quit flag is still false while
+    // the shutdown tasks this guard protects are already running. The platform has to decide.
+    expect(isAppQuitRequested()).toBe(false);
+
+    expect(shouldWindowCloseAbortStartupTasks('win32')).toBe(true);
+    expect(shouldWindowCloseAbortStartupTasks('linux')).toBe(true);
   });
 
   test('shares one run across every window closing as part of the same quit', async () => {

--- a/src/main/services/__tests__/shutdown-latch.service.test.ts
+++ b/src/main/services/__tests__/shutdown-latch.service.test.ts
@@ -1,12 +1,13 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import type { BrowserWindow } from 'electron';
 import {
+  canStartupSyncFireNow,
   isAppQuitRequested,
   isAppShuttingDown,
   markQuitRequested,
   resetShutdownLatchesForNewSession,
   runShutdownTasksOnce,
-  shouldWindowCloseAbortStartupTasks,
+  shouldWindowCloseAbortReadinessWait,
 } from '@main/services/shutdown-latch.service';
 import {
   addWindow,
@@ -42,25 +43,63 @@ describe('shutdown latches', () => {
     expect(isAppQuitRequested()).toBe(true);
   });
 
-  test('leaves the startup tasks running when macOS closes its last window without quitting', () => {
+  test('leaves the readiness wait running when macOS closes its last window without quitting', () => {
     // The app stays resident and a dock reactivation starts a fresh session, but the startup tasks
     // run once per process — so aborting here would drop that session's startup sync permanently.
-    expect(shouldWindowCloseAbortStartupTasks('darwin')).toBe(false);
+    expect(shouldWindowCloseAbortReadinessWait('darwin')).toBe(false);
 
     markQuitRequested();
 
-    // A real quit on macOS still has to stop them.
-    expect(shouldWindowCloseAbortStartupTasks('darwin')).toBe(true);
+    // A real quit on macOS still has to stop it.
+    expect(shouldWindowCloseAbortReadinessWait('darwin')).toBe(true);
   });
 
-  test('stops the startup tasks off macOS even before a quit is flagged', () => {
+  test('stops the readiness wait off macOS even before a quit is flagged', () => {
     // Off macOS the last window closing always ends in a quit, but `window-all-closed` calls
     // `app.quit()` only after the close handlers have run — so the quit flag is still false while
     // the shutdown tasks this guard protects are already running. The platform has to decide.
     expect(isAppQuitRequested()).toBe(false);
 
-    expect(shouldWindowCloseAbortStartupTasks('win32')).toBe(true);
-    expect(shouldWindowCloseAbortStartupTasks('linux')).toBe(true);
+    expect(shouldWindowCloseAbortReadinessWait('win32')).toBe(true);
+    expect(shouldWindowCloseAbortReadinessWait('linux')).toBe(true);
+  });
+
+  describe('whether the startup sync may still fire', () => {
+    test('allows firing while the app is up with a window', () => {
+      addWindow(fakeWindow(1));
+
+      expect(canStartupSyncFireNow(1, true)).toBe(true);
+    });
+
+    test('blocks firing once the app has had a window and no longer has one', () => {
+      // The macOS last-window-close state the readiness wait deliberately survives: resident, not
+      // quitting, windowless. The shutdown sync has already run and there is no UI to report into.
+      expect(canStartupSyncFireNow(0, true)).toBe(false);
+    });
+
+    test('allows firing before this process has created its first window', () => {
+      // No window YET is the app coming UP, not going down — the same distinction
+      // `areAllWindowsClosing` draws. Reading it as "went windowless" would silently drop the
+      // startup sync of any boot whose readiness landed before the first window did, which is the
+      // invisible failure the readiness gate exists to avoid.
+      expect(canStartupSyncFireNow(0, false)).toBe(true);
+    });
+
+    test('blocks firing once a quit has been requested, window or not', () => {
+      markQuitRequested();
+
+      expect(canStartupSyncFireNow(1, true)).toBe(false);
+      expect(canStartupSyncFireNow(0, false)).toBe(false);
+    });
+
+    test('blocks firing while every tracked window is closing', () => {
+      // Off macOS this is how the app goes down, and the quit flag is still false throughout it.
+      addWindow(fakeWindow(1));
+      markWindowClosing(1);
+
+      expect(isAppQuitRequested()).toBe(false);
+      expect(canStartupSyncFireNow(1, true)).toBe(false);
+    });
   });
 
   test('shares one run across every window closing as part of the same quit', async () => {

--- a/src/main/services/shutdown-latch.service.ts
+++ b/src/main/services/shutdown-latch.service.ts
@@ -47,7 +47,12 @@ export function isAppShuttingDown(): boolean {
 }
 
 /**
- * Whether a window's `close` handler should stop the startup tasks' bounded waits.
+ * Whether a window's `close` handler should stop the Simple-mode startup-sync READINESS WAIT.
+ *
+ * Scoped to that one wait on purpose. Everything else the startup tasks are doing — notably Power
+ * mode's boot-race retry loop — is aborted unconditionally whenever the app starts going down, the
+ * behavior it has always had; `main.ts` keeps a separate signal for that. Widening this exception
+ * to cover both would silently change Power mode too, which nothing here intends.
  *
  * Aborting is right whenever the app is really going away: a startup sync firing after the shutdown
  * sync has already run would sync the same projects twice, and a late one can reach a network
@@ -58,6 +63,12 @@ export function isAppShuttingDown(): boolean {
  * run once per PROCESS — so aborting drops that session's startup sync for the rest of the
  * process's life. Hence the quit flag decides on macOS.
  *
+ * Letting the wait survive is NOT on its own a licence to fire: while the app sits resident with no
+ * windows, the shutdown sync has already run and there is no UI to report into. The wait continuing
+ * only buys the chance to fire if a dock reactivation brings a window back before readiness lands;
+ * `performStartupTasks` re-checks that immediately before it sends the command (its signals'
+ * `canFireStartupSync`), and skips when the app is windowless.
+ *
  * Every other platform quits once its last window closes, but `window-all-closed` calls
  * `app.quit()` only after the close handlers have already run — so the quit flag is still false
  * throughout the very window this guard protects. Off macOS the platform alone therefore decides,
@@ -65,9 +76,39 @@ export function isAppShuttingDown(): boolean {
  *
  * @param platform The OS platform, i.e. `process.platform`. A parameter rather than a direct read
  *   so both branches stay testable without stubbing the global.
+ * @returns `true` when the close should abort the readiness wait
  */
-export function shouldWindowCloseAbortStartupTasks(platform: typeof process.platform): boolean {
+export function shouldWindowCloseAbortReadinessWait(platform: typeof process.platform): boolean {
   return isAppQuitRequested() || platform !== 'darwin';
+}
+
+/**
+ * Whether the Simple-mode startup sync may still fire, asked immediately before the command goes
+ * out rather than when the wait started.
+ *
+ * The readiness wait can park for up to its whole budget, and
+ * {@link shouldWindowCloseAbortReadinessWait} deliberately lets it survive a macOS last-window
+ * close. That leaves a state no abort signal describes: resident, not quitting, and WINDOWLESS.
+ * Firing there would run a whole-workspace Send/Receive after the shutdown sync already ran, into a
+ * process with no UI to report progress or failure into.
+ *
+ * Windowless is only disqualifying once this process has actually had a window, though. No window
+ * YET is the app coming up, not going down — the same distinction {@link areAllWindowsClosing} draws
+ * for the same reason — and treating it as disqualifying would silently drop the startup sync of
+ * any boot whose readiness landed before the first window did. That is the invisible failure this
+ * whole gate is meant to avoid, so it is guarded explicitly rather than left to window-creation
+ * timing.
+ *
+ * @param windowCount How many live windows are tracked right now, i.e. `getWindows().length`
+ * @param hasCreatedWindowThisProcess Whether this process has ever created a window
+ * @returns `true` when the sync should be allowed to go out
+ */
+export function canStartupSyncFireNow(
+  windowCount: number,
+  hasCreatedWindowThisProcess: boolean,
+): boolean {
+  if (isAppShuttingDown()) return false;
+  return windowCount > 0 || !hasCreatedWindowThisProcess;
 }
 
 /**

--- a/src/main/services/shutdown-latch.service.ts
+++ b/src/main/services/shutdown-latch.service.ts
@@ -47,6 +47,30 @@ export function isAppShuttingDown(): boolean {
 }
 
 /**
+ * Whether a window's `close` handler should stop the startup tasks' bounded waits.
+ *
+ * Aborting is right whenever the app is really going away: a startup sync firing after the shutdown
+ * sync has already run would sync the same projects twice, and a late one can reach a network
+ * connection `will-quit` is about to tear down.
+ *
+ * The one case where aborting is wrong is macOS closing its last window without a quit. There the
+ * app stays resident and a later dock reactivation starts a fresh session, but the startup tasks
+ * run once per PROCESS — so aborting drops that session's startup sync for the rest of the
+ * process's life. Hence the quit flag decides on macOS.
+ *
+ * Every other platform quits once its last window closes, but `window-all-closed` calls
+ * `app.quit()` only after the close handlers have already run — so the quit flag is still false
+ * throughout the very window this guard protects. Off macOS the platform alone therefore decides,
+ * rather than a flag that arrives too late to help.
+ *
+ * @param platform The OS platform, i.e. `process.platform`. A parameter rather than a direct read
+ *   so both branches stay testable without stubbing the global.
+ */
+export function shouldWindowCloseAbortStartupTasks(platform: typeof process.platform): boolean {
+  return isAppQuitRequested() || platform !== 'darwin';
+}
+
+/**
  * Run the shutdown tasks, sharing one run across every window that closes as part of the same quit.
  *
  * @param performShutdownTasks Work to run once for this session

--- a/src/main/startup-readiness.util.test.ts
+++ b/src/main/startup-readiness.util.test.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest';
+import { MAX_REQUEST_ATTEMPTS, REQUEST_ATTEMPT_WAIT_TIME_MS } from '@shared/data/rpc.model';
 import { networkObjectStatusService } from '@shared/services/network-object-status.service';
 import { projectLookupService } from '@shared/services/project-lookup.service';
 import { logger } from '@shared/services/logger.service';
@@ -29,7 +30,11 @@ const mockLoggerDebug = vi.mocked(logger.debug);
  * never its contents, so the fields are deliberately empty rather than realistic — building a
  * lifelike project here would imply the probe inspects it.
  */
-const A_PROJECT = { id: 'PROJ1', projectInterfaces: [], pdpFactoryInfo: {} };
+const A_PROJECT = {
+  id: 'PROJ1',
+  projectInterfaces: [],
+  pdpFactoryInfo: {},
+} satisfies ProjectMetadata;
 
 /** The network object details `waitForNetworkObject` resolves with when the factory is up. */
 const FACTORY_DETAILS = {
@@ -97,17 +102,67 @@ describe('waitForScriptureWorkspaceReady', () => {
   });
 
   it('resolves "timed-out" when the factory never registers within the budget', async () => {
-    mockWaitForNetworkObject.mockRejectedValue(
-      new Error('Timeout reached when waiting for wait-for-net-obj to settle'),
-    );
-    await expect(waitForScriptureWorkspaceReady({ timeoutMs: 5_000 })).resolves.toEqual({
-      outcome: 'timed-out',
-      detail: expect.stringContaining(
-        'Timeout reached when waiting for wait-for-net-obj to settle',
-      ),
+    // Production shape: the same remaining budget is handed to `waitForNetworkObject`, so its own
+    // `AsyncVariable` expires at the deadline and it rejects having consumed everything. Rejecting
+    // INSTANTLY is a different case — budget left over — which is deliberately not terminal (see
+    // the two fall-through tests below).
+    //
+    // The surfaced detail is the generic one rather than the underlying timeout message, and that
+    // is correct: with the budget spent, `settleWithin` short-circuits on its own `remainingMs <= 0`
+    // guard and reports `TIMED_OUT` without ever observing the rejection. Asserting the underlying
+    // message here would be asserting a path production cannot take.
+    mockWaitForNetworkObject.mockImplementation(async () => {
+      vi.advanceTimersByTime(5_000);
+      throw new Error('Timeout reached when waiting for wait-for-net-obj to settle');
     });
-    // Phase 2 must not run once Phase 1 gave up — there is nothing to probe.
+
+    await withFakeTimers(async () => {
+      await expect(waitForScriptureWorkspaceReady({ timeoutMs: 5_000 })).resolves.toEqual({
+        outcome: 'timed-out',
+        detail:
+          'the scripture project data provider factory did not register within the readiness budget',
+      });
+    });
+
+    // Phase 2 must not run once the budget is genuinely spent — there is nothing left to probe with.
     expect(mockGetMetadata).not.toHaveBeenCalled();
+  });
+
+  it('continues to the metadata probe when the registration wait fails with budget remaining', async () => {
+    // A rejection is not the same thing as an exhausted budget. `waitForNetworkObject` also rejects
+    // when the status service is unreachable, which can land with nearly the whole budget unspent;
+    // treating that as terminal would collapse the gate and fire the whole-workspace sync early,
+    // reintroducing the starvation this module exists to prevent — and invisibly, since the cause
+    // is only logged at debug. Phase 2 tests the stronger condition anyway, so the gate goes on.
+    mockWaitForNetworkObject.mockRejectedValue(
+      new Error('NetworkObjectStatusService is not available as a network object'),
+    );
+    mockGetMetadata.mockResolvedValue([A_PROJECT]);
+
+    await expect(waitForScriptureWorkspaceReady({ timeoutMs: 5_000 })).resolves.toEqual({
+      outcome: 'ready',
+    });
+    expect(mockGetMetadata).toHaveBeenCalled();
+  });
+
+  it('still resolves "timed-out" when the registration wait fails and the probe cannot answer either', async () => {
+    // The other half of the fall-through: continuing past phase 1 must not turn a workspace that
+    // genuinely cannot list projects into a false 'ready'. The outcome degrades to the same
+    // 'timed-out' phase 1 would have returned, just after spending the budget it was given.
+    mockWaitForNetworkObject.mockRejectedValue(
+      new Error('NetworkObjectStatusService is not available as a network object'),
+    );
+    mockGetMetadata.mockResolvedValue([]);
+
+    await withFakeTimers(async () => {
+      const readinessPromise = waitForScriptureWorkspaceReady({ timeoutMs: 5_000 });
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(readinessPromise).resolves.toEqual({
+        outcome: 'timed-out',
+        detail: expect.any(String),
+      });
+    });
+    expect(mockGetMetadata).toHaveBeenCalled();
   });
 
   it('abandons a registration wait that never settles once the deadline passes, yielding "timed-out"', async () => {
@@ -133,20 +188,19 @@ describe('waitForScriptureWorkspaceReady', () => {
     expect(mockGetMetadata).not.toHaveBeenCalled();
   });
 
-  it('resolves "timed-out" and logs distinguishably when the status service itself is unavailable', async () => {
+  it('logs the real cause distinguishably when the status service itself is unavailable', async () => {
     // Not a timeout: `networkObjectStatusService.initialize()` throws when the status service
-    // network object cannot be reached. The outcome is the same (fire anyway) but the cause is
-    // different, so both the log and the returned detail must carry the real message — asserting
-    // only the shared "could not wait for..." prefix (common to both causes) would pass even if the
+    // network object cannot be reached. The cause has to survive into the log — asserting only the
+    // shared "could not wait for..." prefix (common to both causes) would pass even if the
     // distinguishing text were dropped, which is why this asserts on that text specifically.
+    // The OUTCOME is covered by the two fall-through tests above; this one is about the log.
     mockWaitForNetworkObject.mockRejectedValue(
       new Error('NetworkObjectStatusService is not available as a network object'),
     );
     const distinguishingText = 'NetworkObjectStatusService is not available as a network object';
-    await expect(waitForScriptureWorkspaceReady({ timeoutMs: 5_000 })).resolves.toEqual({
-      outcome: 'timed-out',
-      detail: expect.stringContaining(distinguishingText),
-    });
+
+    await waitForScriptureWorkspaceReady({ timeoutMs: 5_000 });
+
     expect(mockLoggerDebug).toHaveBeenCalledWith(expect.stringContaining(distinguishingText));
   });
 
@@ -192,11 +246,11 @@ describe('waitForScriptureWorkspaceReady', () => {
   });
 
   it('resolves "aborted", not "timed-out", when a quit lands in the same tick as the registration promise rejecting', async () => {
-    // Exercises the catch's abort recheck: `Promise.race` settles on whichever settles first, so if
-    // the rejection is scheduled before the abort listener's resolution, the raw rejection wins the
-    // race and lands in the catch — which must still report 'aborted' when a quit landed in that
-    // same tick, not misreport 'timed-out' (which would make the caller warn "syncing anyway"
-    // during shutdown).
+    // Exercises the catch's abort recheck. `settleWithin`'s gate resolves on whichever outcome
+    // reaches it first, so if the rejection is scheduled before the abort listener's resolution the
+    // raw rejection wins that internal race and lands in the catch — which must still report
+    // 'aborted' when a quit landed in that same tick, not misreport 'timed-out' (which would make
+    // the caller warn "syncing anyway" during shutdown).
     const abort = new AbortController();
     const registration = deferred<typeof FACTORY_DETAILS>();
     mockWaitForNetworkObject.mockReturnValue(registration.promise);
@@ -344,5 +398,47 @@ describe('waitForScriptureWorkspaceReady', () => {
     });
 
     expect(mockGetMetadata).toHaveBeenCalledTimes(1);
+  });
+
+  it('pins the two-phase probe backoff and the attempt-log sampling', async () => {
+    // Poll cadence (see startup-readiness.util.ts): the first INITIAL_READINESS_POLL_ATTEMPTS waits
+    // are INITIAL_READINESS_POLL_INTERVAL_MS, every wait after that is
+    // EXTENDED_READINESS_POLL_INTERVAL_MS. Nothing else crosses that transition, so without this
+    // test dropping the backoff or inverting the two phases stays green. Mirrors the sibling
+    // Power-mode cadence test in `startup-tasks.test.ts`, including deriving the initial phase from
+    // the shared rpc.model constants this module aliases rather than re-typing the literals.
+    const INITIAL_POLL_ATTEMPTS = MAX_REQUEST_ATTEMPTS;
+    const INITIAL_POLL_INTERVAL_MS = REQUEST_ATTEMPT_WAIT_TIME_MS;
+    const EXTENDED_POLL_INTERVAL_MS = 2000;
+    // Answer on a deliberately NON-symmetric attempt so the two-phase cadence is observable: 10
+    // waits @1s + 4 waits @2s before the 15th probe = 18s. Flattening the backoff (all @1s = 14s)
+    // or inverting the phases (@2s then @1s = 22s) both change this elapsed time and fail below.
+    const ANSWER_ON_PROBE = 15;
+    const EXPECTED_ELAPSED_MS =
+      INITIAL_POLL_ATTEMPTS * INITIAL_POLL_INTERVAL_MS +
+      (ANSWER_ON_PROBE - 1 - INITIAL_POLL_ATTEMPTS) * EXTENDED_POLL_INTERVAL_MS; // 18_000
+    let probeCount = 0;
+    mockGetMetadata.mockImplementation(async () => {
+      probeCount += 1;
+      return probeCount < ANSWER_ON_PROBE ? [] : [A_PROJECT];
+    });
+
+    await withFakeTimers(async () => {
+      const readinessPromise = waitForScriptureWorkspaceReady();
+      // 1ms before the expected time the answering probe has not fired yet.
+      await vi.advanceTimersByTimeAsync(EXPECTED_ELAPSED_MS - 1);
+      expect(probeCount).toBe(ANSWER_ON_PROBE - 1);
+      // Crossing the expected elapsed time triggers exactly the answering probe.
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(readinessPromise).resolves.toEqual({ outcome: 'ready' });
+    });
+
+    expect(probeCount).toBe(ANSWER_ON_PROBE);
+    // Sampling: 14 empty probes, logged on the 1st and every 10th. The answering probe returns
+    // before it can log. Pinned to the literal attempt numbers so widening the sampling (or logging
+    // every attempt, which is what would bury the surrounding startup logs) fails here.
+    expect(mockLoggerDebug).toHaveBeenCalledTimes(2);
+    expect(mockLoggerDebug).toHaveBeenCalledWith(expect.stringContaining('(attempt 1)'));
+    expect(mockLoggerDebug).toHaveBeenCalledWith(expect.stringContaining('(attempt 10)'));
   });
 });

--- a/src/main/startup-readiness.util.test.ts
+++ b/src/main/startup-readiness.util.test.ts
@@ -1,0 +1,348 @@
+import { vi } from 'vitest';
+import { networkObjectStatusService } from '@shared/services/network-object-status.service';
+import { projectLookupService } from '@shared/services/project-lookup.service';
+import { logger } from '@shared/services/logger.service';
+import { type ProjectMetadata } from '@shared/models/project-metadata.model';
+import { waitForScriptureWorkspaceReady } from './startup-readiness.util';
+
+vi.mock('@shared/services/network-object-status.service', () => ({
+  networkObjectStatusService: {
+    waitForNetworkObject: vi.fn(),
+    getAllNetworkObjectDetails: vi.fn(),
+  },
+}));
+
+vi.mock('@shared/services/project-lookup.service', () => ({
+  projectLookupService: { getMetadataForAllProjectsWithoutRetries: vi.fn() },
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+const mockWaitForNetworkObject = vi.mocked(networkObjectStatusService.waitForNetworkObject);
+const mockGetMetadata = vi.mocked(projectLookupService.getMetadataForAllProjectsWithoutRetries);
+const mockLoggerDebug = vi.mocked(logger.debug);
+
+/**
+ * A minimal valid `ProjectMetadata`. The readiness probe only checks that the array is non-empty,
+ * never its contents, so the fields are deliberately empty rather than realistic — building a
+ * lifelike project here would imply the probe inspects it.
+ */
+const A_PROJECT = { id: 'PROJ1', projectInterfaces: [], pdpFactoryInfo: {} };
+
+/** The network object details `waitForNetworkObject` resolves with when the factory is up. */
+const FACTORY_DETAILS = {
+  id: 'pdpf-scripture-extender',
+  objectType: 'pdpFactory',
+  functionNames: [],
+  attributes: { projectInterfaces: ['platformScripture.USJ_Chapter'] },
+};
+
+/** Runs `body` with fake timers installed, restoring real timers even if it throws. */
+async function withFakeTimers(body: () => Promise<void>): Promise<void> {
+  vi.useFakeTimers({ toFake: ['performance', 'setTimeout', 'clearTimeout'] });
+  try {
+    await body();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
+/** A promise plus its resolve/reject, for driving a call that is deliberately left in flight. */
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolveFn: (value: T) => void = () => {};
+  let rejectFn: (reason: unknown) => void = () => {};
+  const promise = new Promise<T>((resolve, reject) => {
+    resolveFn = resolve;
+    rejectFn = reject;
+  });
+  return { promise, resolve: resolveFn, reject: rejectFn };
+}
+
+beforeEach(() => {
+  // resetAllMocks (not clearAllMocks): clearAllMocks does not drain mockResolvedValueOnce /
+  // mockRejectedValueOnce queues, so an under-consumed queue from one test can leak into the next
+  // and make an unrelated test fail. resetAllMocks also clears implementations, so the defaults
+  // below are re-established every time.
+  vi.resetAllMocks();
+  mockWaitForNetworkObject.mockResolvedValue(FACTORY_DETAILS);
+  mockGetMetadata.mockResolvedValue([A_PROJECT]);
+});
+
+describe('waitForScriptureWorkspaceReady', () => {
+  it('resolves "ready" when the factory is registered and metadata is non-empty', async () => {
+    await expect(waitForScriptureWorkspaceReady()).resolves.toEqual({ outcome: 'ready' });
+    expect(mockWaitForNetworkObject).toHaveBeenCalledWith(
+      {
+        objectType: 'pdpFactory',
+        attributes: { projectInterfaces: ['platformScripture.USJ_Chapter'] },
+      },
+      expect.any(Number),
+    );
+  });
+
+  it('passes the remaining budget — not -1 (no-timeout) or 0 — as the timeout to waitForNetworkObject', async () => {
+    // Today nothing pins this number: mutating it to -1 (AsyncVariable's documented no-timeout
+    // sentinel) would make phase 1 wait forever with an otherwise-green suite. Fake timers make the
+    // computed remaining budget deterministic so the exact number can be pinned.
+    await withFakeTimers(async () => {
+      await waitForScriptureWorkspaceReady({ timeoutMs: 5_000 });
+    });
+    expect(mockWaitForNetworkObject).toHaveBeenCalledWith(expect.anything(), 5_000);
+  });
+
+  it('resolves "timed-out" when the factory never registers within the budget', async () => {
+    mockWaitForNetworkObject.mockRejectedValue(
+      new Error('Timeout reached when waiting for wait-for-net-obj to settle'),
+    );
+    await expect(waitForScriptureWorkspaceReady({ timeoutMs: 5_000 })).resolves.toEqual({
+      outcome: 'timed-out',
+      detail: expect.stringContaining(
+        'Timeout reached when waiting for wait-for-net-obj to settle',
+      ),
+    });
+    // Phase 2 must not run once Phase 1 gave up — there is nothing to probe.
+    expect(mockGetMetadata).not.toHaveBeenCalled();
+  });
+
+  it('abandons a registration wait that never settles once the deadline passes, yielding "timed-out"', async () => {
+    // This, not the rejection above, is the ordinary production timeout for phase 1. The same
+    // remaining budget is handed to both `waitForNetworkObject` and `settleWithin`, and
+    // `settleWithin` starts its timer a moment later — so its deadline almost always fires first
+    // and the underlying wait never gets to reject. Without this test that whole path is unpinned,
+    // and only the rarer rejection path is covered. Mirrors the phase-2 equivalent below.
+    const registration = deferred<typeof FACTORY_DETAILS>();
+    mockWaitForNetworkObject.mockReturnValue(registration.promise);
+
+    await withFakeTimers(async () => {
+      const readinessPromise = waitForScriptureWorkspaceReady({ timeoutMs: 5_000 });
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(readinessPromise).resolves.toEqual({
+        outcome: 'timed-out',
+        // Asserting the phase-1 reason specifically: a generic string would also pass if the gate
+        // wrongly fell through to phase 2 and timed out there instead.
+        detail: expect.stringContaining('did not register'),
+      });
+    });
+
+    expect(mockGetMetadata).not.toHaveBeenCalled();
+  });
+
+  it('resolves "timed-out" and logs distinguishably when the status service itself is unavailable', async () => {
+    // Not a timeout: `networkObjectStatusService.initialize()` throws when the status service
+    // network object cannot be reached. The outcome is the same (fire anyway) but the cause is
+    // different, so both the log and the returned detail must carry the real message — asserting
+    // only the shared "could not wait for..." prefix (common to both causes) would pass even if the
+    // distinguishing text were dropped, which is why this asserts on that text specifically.
+    mockWaitForNetworkObject.mockRejectedValue(
+      new Error('NetworkObjectStatusService is not available as a network object'),
+    );
+    const distinguishingText = 'NetworkObjectStatusService is not available as a network object';
+    await expect(waitForScriptureWorkspaceReady({ timeoutMs: 5_000 })).resolves.toEqual({
+      outcome: 'timed-out',
+      detail: expect.stringContaining(distinguishingText),
+    });
+    expect(mockLoggerDebug).toHaveBeenCalledWith(expect.stringContaining(distinguishingText));
+  });
+
+  it('resolves "timed-out" immediately when the budget is already exhausted, without calling waitForNetworkObject', async () => {
+    // A zero remaining budget must fail fast rather than pass through: `AsyncVariable` only arms
+    // its timeout for a strictly positive value, so an unguarded `0` would mean "no timeout" and
+    // wait unbounded. The second assertion is the one that matters — it fails if the zero is ever
+    // forwarded to `waitForNetworkObject` instead of being caught first.
+    await expect(waitForScriptureWorkspaceReady({ timeoutMs: 0 })).resolves.toEqual({
+      outcome: 'timed-out',
+      detail: expect.any(String),
+    });
+    expect(mockWaitForNetworkObject).not.toHaveBeenCalled();
+  });
+
+  it('resolves "aborted" immediately when the signal is already aborted', async () => {
+    const abort = new AbortController();
+    abort.abort();
+    await expect(waitForScriptureWorkspaceReady({ abortSignal: abort.signal })).resolves.toEqual({
+      outcome: 'aborted',
+    });
+    expect(mockWaitForNetworkObject).not.toHaveBeenCalled();
+  });
+
+  it('resolves "aborted" when the app quits while still waiting for the factory to register', async () => {
+    // The case the abort race exists for, and the one a boot-time quit actually hits.
+    // `waitForNetworkObject` takes a timeout but NO AbortSignal, so an implementation that simply
+    // awaits it would ignore the quit for the full budget and still pass every other test here.
+    const abort = new AbortController();
+    const registration = deferred<typeof FACTORY_DETAILS>();
+    mockWaitForNetworkObject.mockReturnValue(registration.promise);
+
+    const readinessPromise = waitForScriptureWorkspaceReady({ abortSignal: abort.signal });
+    abort.abort();
+
+    await expect(readinessPromise).resolves.toEqual({ outcome: 'aborted' });
+    expect(mockGetMetadata).not.toHaveBeenCalled();
+
+    // Settle the abandoned wait the way the real one eventually does — its AsyncVariable rejects at
+    // its own timeout long after we stopped listening. This is a smoke check only: a missing
+    // rejection handler would surface as an unhandled-rejection warning, not a failed expectation.
+    registration.reject(new Error('Timeout reached when waiting for wait-for-net-obj to settle'));
+  });
+
+  it('resolves "aborted", not "timed-out", when a quit lands in the same tick as the registration promise rejecting', async () => {
+    // Exercises the catch's abort recheck: `Promise.race` settles on whichever settles first, so if
+    // the rejection is scheduled before the abort listener's resolution, the raw rejection wins the
+    // race and lands in the catch — which must still report 'aborted' when a quit landed in that
+    // same tick, not misreport 'timed-out' (which would make the caller warn "syncing anyway"
+    // during shutdown).
+    const abort = new AbortController();
+    const registration = deferred<typeof FACTORY_DETAILS>();
+    mockWaitForNetworkObject.mockReturnValue(registration.promise);
+
+    const readinessPromise = waitForScriptureWorkspaceReady({ abortSignal: abort.signal });
+    await vi.waitFor(() => expect(mockWaitForNetworkObject).toHaveBeenCalled());
+    // Order matters: reject before abort, so the rejection wins the internal race instead of the
+    // abort listener.
+    registration.reject(
+      new Error('NetworkObjectStatusService is not available as a network object'),
+    );
+    abort.abort();
+
+    await expect(readinessPromise).resolves.toEqual({ outcome: 'aborted' });
+  });
+
+  it('polls until metadata answers non-empty, then resolves "ready"', async () => {
+    mockGetMetadata.mockResolvedValueOnce([]).mockResolvedValueOnce([A_PROJECT]);
+
+    await withFakeTimers(async () => {
+      const readinessPromise = waitForScriptureWorkspaceReady();
+      // One poll interval must elapse before the second probe fires.
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(readinessPromise).resolves.toEqual({ outcome: 'ready' });
+    });
+
+    expect(mockGetMetadata).toHaveBeenCalledTimes(2);
+    expect(mockGetMetadata).toHaveBeenCalledWith({
+      // Escaped: includeProjectInterfaces is matched as an unanchored RegExp, so the literal `.`
+      // must be escaped or the match becomes a wildcard/substring match.
+      includeProjectInterfaces: ['platformScripture\\.USJ_Chapter'],
+    });
+  });
+
+  it('resolves "timed-out" when the factory registers but metadata stays empty past the budget', async () => {
+    // The case that distinguishes Phase 2 from Phase 1: registration succeeded, so an
+    // implementation with no Phase 2 would wrongly report "ready" here.
+    mockGetMetadata.mockResolvedValue([]);
+
+    await withFakeTimers(async () => {
+      const readinessPromise = waitForScriptureWorkspaceReady({ timeoutMs: 5_000 });
+      await vi.advanceTimersByTimeAsync(6_000);
+      await expect(readinessPromise).resolves.toEqual({
+        outcome: 'timed-out',
+        detail: expect.any(String),
+      });
+    });
+  });
+
+  it('abandons a metadata probe that never settles once the deadline passes, yielding "timed-out"', async () => {
+    // The budget is a real ceiling: a probe that hangs (the .NET provider saturated, no response
+    // ever arriving) must still be abandoned at the deadline rather than holding the whole gate
+    // open indefinitely.
+    const probe = deferred<ProjectMetadata[]>();
+    mockGetMetadata.mockReturnValue(probe.promise);
+
+    await withFakeTimers(async () => {
+      const readinessPromise = waitForScriptureWorkspaceReady({ timeoutMs: 5_000 });
+      await vi.advanceTimersByTimeAsync(5_000);
+      await expect(readinessPromise).resolves.toEqual({
+        outcome: 'timed-out',
+        detail: expect.any(String),
+      });
+    });
+  });
+
+  it('retries a throwing metadata probe rather than treating it as fatal', async () => {
+    mockGetMetadata
+      .mockRejectedValueOnce(new Error('data provider not answering'))
+      .mockResolvedValueOnce([A_PROJECT]);
+
+    await withFakeTimers(async () => {
+      const readinessPromise = waitForScriptureWorkspaceReady();
+      await vi.advanceTimersByTimeAsync(1_000);
+      await expect(readinessPromise).resolves.toEqual({ outcome: 'ready' });
+    });
+
+    expect(mockGetMetadata).toHaveBeenCalledTimes(2);
+  });
+
+  it('resolves "aborted" when the app quits mid-poll and issues no further probes', async () => {
+    mockGetMetadata.mockResolvedValue([]);
+    const abort = new AbortController();
+
+    await withFakeTimers(async () => {
+      const readinessPromise = waitForScriptureWorkspaceReady({ abortSignal: abort.signal });
+      // Let the first probe run and the poll wait begin.
+      await vi.advanceTimersByTimeAsync(0);
+      abort.abort();
+      await expect(readinessPromise).resolves.toEqual({ outcome: 'aborted' });
+      // Pinned to the literal, not read from the mock: reading the expected count from the mock
+      // itself would make this assertion pass vacuously even if the implementation made zero probes.
+      expect(mockGetMetadata).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('resolves "aborted" when the app quits while a metadata probe is in flight, even though the probe later resolves non-empty', async () => {
+    // The bug this pins down: the loop previously re-checked the abort signal only at the TOP of
+    // each iteration, so an abort landing while this probe was in flight was missed if the probe
+    // went on to resolve non-empty — the loop returned 'ready' instead of 'aborted'.
+    const abort = new AbortController();
+    const probe = deferred<ProjectMetadata[]>();
+    mockGetMetadata.mockReturnValue(probe.promise);
+
+    const readinessPromise = waitForScriptureWorkspaceReady({ abortSignal: abort.signal });
+    await vi.waitFor(() => expect(mockGetMetadata).toHaveBeenCalled());
+    abort.abort();
+    probe.resolve([A_PROJECT]);
+
+    await expect(readinessPromise).resolves.toEqual({ outcome: 'aborted' });
+  });
+
+  it('resolves "aborted", not "timed-out", when a quit lands in the same tick as an in-flight probe rejecting', async () => {
+    // Distinct from the test above: this exercises the probe's catch path (a rejection), not its
+    // resolved-array path. Order matters here too, for the same reason as phase 1's equivalent
+    // test: reject before abort, so the rejection wins the internal race and lands in the catch,
+    // which must still report 'aborted' rather than falling through to a stale 'timed-out'.
+    const abort = new AbortController();
+    const probe = deferred<ProjectMetadata[]>();
+    mockGetMetadata.mockReturnValue(probe.promise);
+
+    const readinessPromise = waitForScriptureWorkspaceReady({ abortSignal: abort.signal });
+    await vi.waitFor(() => expect(mockGetMetadata).toHaveBeenCalled());
+    probe.reject(new Error('data provider not answering'));
+    abort.abort();
+
+    await expect(readinessPromise).resolves.toEqual({ outcome: 'aborted' });
+  });
+
+  it('probes at least once even when registration consumed the whole budget', async () => {
+    // A factory that registers right at the deadline must still be asked whether it works, rather
+    // than falling straight through to "timed-out". Advances to just under the deadline (not
+    // exactly onto it): landing exactly on the deadline would make the already-resolved
+    // registration and settleWithin's own freshly-computed deadline timer for the NEXT await a
+    // genuine tie, which is not what this test means to exercise.
+    mockWaitForNetworkObject.mockImplementation(async () => {
+      vi.advanceTimersByTime(4_999);
+      return FACTORY_DETAILS;
+    });
+
+    await withFakeTimers(async () => {
+      await expect(waitForScriptureWorkspaceReady({ timeoutMs: 5_000 })).resolves.toEqual({
+        outcome: 'ready',
+      });
+    });
+
+    expect(mockGetMetadata).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/startup-readiness.util.ts
+++ b/src/main/startup-readiness.util.ts
@@ -34,7 +34,17 @@ const INITIAL_READINESS_POLL_INTERVAL_MS = REQUEST_ATTEMPT_WAIT_TIME_MS;
  */
 const INITIAL_READINESS_POLL_ATTEMPTS = MAX_REQUEST_ATTEMPTS;
 
-/** Cadence (ms) for phase-2 probes once {@link INITIAL_READINESS_POLL_ATTEMPTS} is exhausted. */
+/**
+ * Cadence (ms) for phase-2 probes once {@link INITIAL_READINESS_POLL_ATTEMPTS} is exhausted.
+ *
+ * Numerically equal to `EXTENDED_RETRY_INTERVAL_MS` in `startup-tasks.ts`, and deliberately not
+ * shared with it for the same reason {@link STARTUP_SYNC_READINESS_BUDGET_MS} is not aliased to that
+ * file's budget: the two back off different waits — that one paces "how long until the S/R command
+ * registers", this one paces "how long until the workspace can list scripture projects" — and
+ * should stay free to be retuned apart. Unlike the `INITIAL_*` constants above, which alias shared
+ * `requestWithRetry` values and so cannot drift, this is the one number here that can silently
+ * drift from its sibling. That is accepted, not overlooked.
+ */
 const EXTENDED_READINESS_POLL_INTERVAL_MS = 2000;
 
 /**
@@ -48,6 +58,10 @@ const EXTENDED_READINESS_POLL_INTERVAL_MS = 2000;
  * generated `papi.d.ts` public surface permanently, and the two answer different questions (that
  * one is the picker's display filter; this one is a startup readiness gate). They coincide today;
  * nothing requires them to. If you change one, consider the other.
+ *
+ * The coupling is therefore intentionally left unenforced: no test asserts the two literals are
+ * equal, because they are allowed to diverge. The cross-reference comment on each is the whole
+ * mechanism, by design.
  */
 const SCRIPTURE_READINESS_PROJECT_INTERFACE = 'platformScripture.USJ_Chapter';
 
@@ -174,17 +188,57 @@ const FACTORY_NOT_REPORTING_PROJECTS_DETAIL =
   'the scripture project data provider factory registered but never reported any projects';
 
 /**
+ * What phase 1 concluded.
+ *
+ * Deliberately not {@link WorkspaceReadinessResult}: phase 1 has one answer the gate as a whole does
+ * not, `'inconclusive'` — it failed to learn anything, but the budget still has room, so giving up
+ * would be wrong.
+ *
+ * - `'registered'` — the factory network object is up; go on to phase 2.
+ * - `'inconclusive'` — the registration wait failed for a reason that is not budget exhaustion. Go on
+ *   to phase 2 anyway; see {@link waitForScriptureFactoryRegistration}.
+ * - `'stopped'` — the gate is finished, for better or worse; `result` is what to report.
+ */
+type FactoryRegistrationResult =
+  | { kind: 'registered' }
+  | { kind: 'inconclusive'; detail: string }
+  | { kind: 'stopped'; result: WorkspaceReadinessResult };
+
+/**
  * Phase 1: waits for the scripture PDP factory network object to register. This mirrors the wait
  * `getMetadataForProject` performs for a single project in `project-lookup.service-model.ts`, and
  * is the same factory registration the project picker ultimately depends on — but it is NOT the
  * picker's own call: the picker's list comes from `getMetadataForAllProjects`, which performs no
  * `waitForNetworkObject` at all and instead has its own grace loop bounded by
  * `LOAD_TIME_GRACE_PERIOD_MS`, measured from process start.
+ *
+ * A rejection here is NOT treated as the end of the gate unless the budget is actually spent.
+ * `waitForNetworkObject` rejects for two quite different reasons: its own `AsyncVariable` expiring
+ * at the remaining budget we handed it (genuine exhaustion — nothing left to spend), or the status
+ * service being unreachable, which `networkObjectStatusService.initialize()` surfaces as a throw.
+ * The second can land with almost the entire budget unspent, and treating it as terminal would
+ * collapse a 120 s gate into a few seconds and fire the whole-workspace sync early — reintroducing
+ * exactly the starvation this module exists to prevent, invisibly (the cause is logged at debug,
+ * and the caller's warn just says "syncing anyway").
+ *
+ * So a non-exhaustion rejection falls through to phase 2 instead. That is safe and cheap: phase 1
+ * is only a fast path, while phase 2 tests the STRONGER condition — that the factory actually
+ * answers, not merely that it registered — and already tolerates throws by retrying within the same
+ * budget. With no factory registered, phase 2 simply sees empty results, treats them as not-ready,
+ * and polls to the deadline, so the worst case degrades to the same `'timed-out'` it would have
+ * returned here, just having used the budget it was given.
+ *
+ * Note this path is currently unreachable from the main process, and the fall-through is insurance
+ * rather than a fix for an observed failure: the status service is hosted in main
+ * (`network-object-status.service-host.ts`), `main.ts` awaits `startNetworkObjectStatusService()`
+ * well before the startup tasks run, and a same-process `networkObjectService.get` returns the
+ * local proxy — so the call is a synchronous in-memory Map read with no RPC to fail. It is written
+ * this way so the guarantee does not quietly depend on that arrangement staying true.
  */
 async function waitForScriptureFactoryRegistration(
   deadline: number,
   abortSignal?: AbortSignal,
-): Promise<WorkspaceReadinessResult> {
+): Promise<FactoryRegistrationResult> {
   const remainingMs = Math.max(0, deadline - performance.now());
   // A zero (already-elapsed) budget must fail fast, not pass through: `AsyncVariable` only arms
   // its timeout for a strictly positive value (see `rejectIfNotSettledWithinMS > 0` in
@@ -194,7 +248,11 @@ async function waitForScriptureFactoryRegistration(
   // contract. `settleWithin` guards this too, but keeping the guard here documents the coupling at
   // the one call site that depends on it (`remainingMs` is also what we pass to
   // `waitForNetworkObject` as its own documented bound).
-  if (remainingMs <= 0) return { outcome: 'timed-out', detail: FACTORY_NOT_REGISTERED_DETAIL };
+  if (remainingMs <= 0)
+    return {
+      kind: 'stopped',
+      result: { outcome: 'timed-out', detail: FACTORY_NOT_REGISTERED_DETAIL },
+    };
   try {
     const settled = await settleWithin(
       networkObjectStatusService.waitForNetworkObject(
@@ -207,21 +265,31 @@ async function waitForScriptureFactoryRegistration(
       deadline,
       abortSignal,
     );
-    if (settled === ABORTED) return { outcome: 'aborted' };
+    if (settled === ABORTED) return { kind: 'stopped', result: { outcome: 'aborted' } };
     if (settled === TIMED_OUT)
-      return { outcome: 'timed-out', detail: FACTORY_NOT_REGISTERED_DETAIL };
-    return { outcome: 'ready' };
+      return {
+        kind: 'stopped',
+        result: { outcome: 'timed-out', detail: FACTORY_NOT_REGISTERED_DETAIL },
+      };
+    return { kind: 'registered' };
   } catch (e) {
     // Re-check abort FIRST: the gate settles on whichever outcome reaches it first, so a quit
     // landing in the same tick as the underlying rejection would otherwise be reported as
     // 'timed-out' — which makes the caller warn "syncing anyway" during shutdown.
-    if (abortSignal?.aborted) return { outcome: 'aborted' };
-    // Any rejection means the same thing to the caller — we could not confirm readiness — but the
-    // causes differ (budget elapsed vs. the status service itself being unreachable), so log the
-    // message rather than asserting which one it was.
+    if (abortSignal?.aborted) return { kind: 'stopped', result: { outcome: 'aborted' } };
+    // The causes differ (budget elapsed vs. the status service itself being unreachable), so log
+    // the message rather than asserting which one it was.
     const detail = `could not wait for the scripture project data provider factory: ${getErrorMessage(e)}`;
-    logger.debug(`Startup sync readiness: ${detail}`);
-    return { outcome: 'timed-out', detail };
+    // The budget, not the rejection, decides whether the gate is over. Checked AFTER the await, so
+    // it reflects the time the wait actually consumed rather than the time it started.
+    if (performance.now() >= deadline) {
+      logger.debug(`Startup sync readiness: ${detail}`);
+      return { kind: 'stopped', result: { outcome: 'timed-out', detail } };
+    }
+    logger.debug(
+      `Startup sync readiness: ${detail}; budget remains, so continuing to the metadata probe (which tests the stronger condition anyway)`,
+    );
+    return { kind: 'inconclusive', detail };
   }
 }
 
@@ -254,6 +322,15 @@ function shouldLogProbeAttempt(attempt: number): boolean {
  * no-op. When there genuinely are no local scripture projects, though, it typically has nothing to
  * do.
  *
+ * Uses the WITHOUT-RETRIES lookup even though its TSDoc names layering PDP factories as the
+ * intended caller and points most callers at `getMetadataForAllProjects`. That default is rejected
+ * here deliberately: the retrying variant absorbs startup unreadiness internally, on its own
+ * schedule and against `LOAD_TIME_GRACE_PERIOD_MS` measured from process start — which is the very
+ * thing this module has to observe and bound itself. Nesting that loop inside this one would make
+ * every probe a multi-second blocking call, blur the budget this module promises to keep, and hide
+ * the not-ready signal the loop exists to read. The retry policy lives here, in the bounded loop
+ * below, for the same reason the TSDoc gives layering factories: one retry loop, not two.
+ *
  * The polling itself is not free even in that case: `includeProjectInterfaces` is applied only
  * AFTER `getMetadataForAllProjectsWithoutRetries` fans out, so every probe still calls
  * `getAvailableProjects` on every registered factory. A workspace with no projects yet therefore
@@ -270,8 +347,12 @@ function shouldLogProbeAttempt(attempt: number): boolean {
  * fires anyway (the same fallback as any other unconfirmed readiness), and the same exposure the
  * project picker itself has via its own unscoped `getMetadataForAllProjects` call.
  *
- * The probe runs BEFORE the deadline check so it always gets at least one attempt, even if phase 1
- * consumed the entire budget.
+ * The loop issues its first probe BEFORE checking the deadline, so a factory that registered right
+ * at the deadline is still asked whether it can answer rather than being written off unasked. The
+ * guarantee is only that the request is ISSUED, though: if phase 1 consumed the whole budget,
+ * `settleWithin`'s own `remainingMs <= 0` guard returns `TIMED_OUT` at once and the in-flight
+ * result is discarded — the fan-out is paid for, but the answer cannot be used. The attempt is
+ * therefore decisive only while some budget remains.
  */
 async function pollUntilScriptureMetadataAnswers(
   deadline: number,
@@ -291,10 +372,14 @@ async function pollUntilScriptureMetadataAnswers(
       // eslint-disable-next-line no-await-in-loop
       const settled = await settleWithin(
         projectLookupService.getMetadataForAllProjectsWithoutRetries({
-          // Escaped because `includeProjectInterfaces` compiles to an unanchored `RegExp` matched
-          // with `.test()` — an unescaped literal would match as a wildcard/substring rather than
-          // exactly. Mirrors `getMetadataForProject`'s own `escapeStringRegexp` use for this same
-          // field, so both phases key off the same exact-match predicate.
+          // Escaped because `includeProjectInterfaces` compiles to UNANCHORED `RegExp`s applied
+          // with `.test()` (`areProjectInterfacesIncluded` in `project-lookup.service-model.ts`),
+          // so an unescaped literal would let each `.` match any character. Escaping buys a literal
+          // SUBSTRING match, not an exact one — a hypothetical `x.platformScripture.USJ_Chapter2`
+          // would still match. That is precise enough for a readiness probe, whose question is only
+          // "can anything scripture-shaped be listed yet", and it mirrors `getMetadataForProject`'s
+          // own `escapeStringRegexp` use on this same field, so both phases key off the same
+          // predicate.
           includeProjectInterfaces: [escapeStringRegexp(SCRIPTURE_READINESS_PROJECT_INTERFACE)],
         }),
         deadline,
@@ -352,6 +437,10 @@ async function pollUntilScriptureMetadataAnswers(
  *
  * Never throws and never waits unbounded. Callers treat `'timed-out'` as "proceed anyway"; its
  * `detail` names a short, log-safe cause (safe at info/warn, including in packaged builds).
+ *
+ * @param options Abort signal and budget override; see {@link WorkspaceReadinessOptions}. Both are
+ *   optional — with neither, the wait uses the default budget and cannot be aborted.
+ * @returns How the wait ended, plus a log-safe `detail` when the outcome is `'timed-out'`
  */
 export async function waitForScriptureWorkspaceReady(
   options: WorkspaceReadinessOptions = {},
@@ -364,7 +453,10 @@ export async function waitForScriptureWorkspaceReady(
   if (abortSignal?.aborted) return { outcome: 'aborted' };
 
   const registration = await waitForScriptureFactoryRegistration(deadline, abortSignal);
-  if (registration.outcome !== 'ready') return registration;
+  // 'registered' and 'inconclusive' both continue: the first because the fast path succeeded, the
+  // second because phase 1 could not tell us anything and phase 2 tests the stronger condition
+  // regardless. Only 'stopped' ends the gate here.
+  if (registration.kind === 'stopped') return registration.result;
 
   return pollUntilScriptureMetadataAnswers(deadline, abortSignal);
 }

--- a/src/main/startup-readiness.util.ts
+++ b/src/main/startup-readiness.util.ts
@@ -1,0 +1,370 @@
+import { MAX_REQUEST_ATTEMPTS, REQUEST_ATTEMPT_WAIT_TIME_MS } from '@shared/data/rpc.model';
+import { PDP_FACTORY_OBJECT_TYPE } from '@shared/models/project-data-provider-factory.interface';
+import { logger } from '@shared/services/logger.service';
+import { networkObjectStatusService } from '@shared/services/network-object-status.service';
+import { projectLookupService } from '@shared/services/project-lookup.service';
+import { AsyncVariable, escapeStringRegexp, getErrorMessage, wait } from 'platform-bible-utils';
+
+/**
+ * How long (ms) the Simple-mode startup Send/Receive waits for the workspace to be able to list
+ * scripture projects before firing anyway.
+ *
+ * Deliberately its own constant rather than an alias of `STARTUP_SYNC_RETRY_BUDGET_MS` in
+ * `startup-tasks.ts`: same boot-appropriate magnitude and rationale, but a different measured thing
+ * — that one bounds "how long until the S/R command registers", this one bounds "how long until the
+ * workspace can list scripture projects". Aliasing would couple two budgets that should be free to
+ * move apart.
+ */
+const STARTUP_SYNC_READINESS_BUDGET_MS = 120_000;
+
+/**
+ * Cadence (ms) for the first {@link INITIAL_READINESS_POLL_ATTEMPTS} phase-2 metadata probes.
+ * Aliased from the shared `requestWithRetry` cadence ({@link REQUEST_ATTEMPT_WAIT_TIME_MS}) rather
+ * than re-declared, mirroring `INITIAL_RETRY_INTERVAL_MS` in `startup-tasks.ts`'s sibling boot-race
+ * loop: the common case (the factory answers within the first few seconds) polls at the shared
+ * cadence, and only the long tail backs off further.
+ */
+const INITIAL_READINESS_POLL_INTERVAL_MS = REQUEST_ATTEMPT_WAIT_TIME_MS;
+
+/**
+ * Number of phase-2 probes at {@link INITIAL_READINESS_POLL_INTERVAL_MS} before backing off to the
+ * gentler {@link EXTENDED_READINESS_POLL_INTERVAL_MS} cadence for the remainder of
+ * {@link STARTUP_SYNC_READINESS_BUDGET_MS}. Aliased from the shared {@link MAX_REQUEST_ATTEMPTS} for
+ * the same stay-in-lockstep reason as {@link INITIAL_READINESS_POLL_INTERVAL_MS}.
+ */
+const INITIAL_READINESS_POLL_ATTEMPTS = MAX_REQUEST_ATTEMPTS;
+
+/** Cadence (ms) for phase-2 probes once {@link INITIAL_READINESS_POLL_ATTEMPTS} is exhausted. */
+const EXTENDED_READINESS_POLL_INTERVAL_MS = 2000;
+
+/**
+ * The `projectInterface` whose PDP factory must be up before the workspace can show a project
+ * picker. Provided by the Scripture Extender layering PDPF that `platform-scripture` registers
+ * (`extensions/src/platform-scripture/src/main.ts`), NOT by the .NET data provider.
+ *
+ * Intentionally a local copy of `PICKER_PROJECT_INTERFACE` in
+ * `src/renderer/hooks/use-project-picker-data.hook.ts` rather than a shared constant: hoisting it
+ * into `src/shared` would publish an extension-specific `platformScripture.*` literal into the
+ * generated `papi.d.ts` public surface permanently, and the two answer different questions (that
+ * one is the picker's display filter; this one is a startup readiness gate). They coincide today;
+ * nothing requires them to. If you change one, consider the other.
+ */
+const SCRIPTURE_READINESS_PROJECT_INTERFACE = 'platformScripture.USJ_Chapter';
+
+/**
+ * Why {@link waitForScriptureWorkspaceReady} stopped:
+ *
+ * - `'ready'` — the scripture PDP factory is registered AND answering; safe to start heavy work.
+ * - `'timed-out'` — readiness was not reached within the budget. Callers should proceed anyway rather
+ *   than suppress their work; this is a "we could not confirm", not a "do not run".
+ * - `'aborted'` — the app began quitting while waiting.
+ */
+export type WorkspaceReadinessOutcome = 'ready' | 'timed-out' | 'aborted';
+
+export interface WorkspaceReadinessResult {
+  outcome: WorkspaceReadinessOutcome;
+  /** Human-readable cause, present when `outcome` is `'timed-out'`. Safe to log at info/warn. */
+  detail?: string;
+}
+
+export interface WorkspaceReadinessOptions {
+  /** Stops the wait once the app has begun quitting. */
+  abortSignal?: AbortSignal;
+  /**
+   * Overall budget in ms, shared by both phases. Defaults to
+   * {@link STARTUP_SYNC_READINESS_BUDGET_MS}; a parameter only so tests can drive a short budget.
+   */
+  timeoutMs?: number;
+}
+
+/** Resolution value meaning the abort signal fired before the raced promise settled. */
+const ABORTED = Symbol('aborted');
+/** Resolution value meaning the readiness deadline passed before the raced promise settled. */
+const TIMED_OUT = Symbol('timed out');
+
+/**
+ * How `promise` settled inside {@link settleWithin}. Both of its outcomes are funnelled into
+ * RESOLUTIONS of the gate so that the gate's own timeout stays the only thing that can reject it.
+ */
+type SettledWithin<T> =
+  | { kind: 'value'; value: T }
+  | { kind: 'error'; error: unknown }
+  | { kind: 'aborted' };
+
+/**
+ * Awaits `promise`, giving up as soon as `abortSignal` fires or `deadline` passes — whichever comes
+ * first.
+ *
+ * Both phases route every await through here so the budget is a real ceiling. Neither of the calls
+ * this module makes can be cancelled and neither takes an `AbortSignal`, so without this a single
+ * slow call would overrun the budget by its own timeout (up to `platform.requestTimeout`), or never
+ * return at all when that setting is `0` — which the network layer accepts and treats as "no
+ * timeout".
+ *
+ * The bound comes from `AsyncVariable` rather than a raw `Promise.race` plus `setTimeout`, per the
+ * async-coordination convention in the code style guide; `shared-store.service.ts` bridges an
+ * in-flight promise into a bounded gate the same way. Funnelling both of `promise`'s outcomes into
+ * resolutions is what keeps the timeout unambiguous — the gate's own timeout is then the only thing
+ * that can reject it, so telling the two apart needs no message matching. `AsyncVariable` clears
+ * its timer as it settles, so the repeated calls phase 2 makes leave nothing behind.
+ *
+ * Giving up only stops us awaiting; the abandoned call keeps running and settles on its own later.
+ * A no-op rejection handler is attached first so that late settlement can never surface as an
+ * unhandled rejection.
+ */
+async function settleWithin<T>(
+  promise: Promise<T>,
+  deadline: number,
+  abortSignal?: AbortSignal,
+): Promise<T | typeof ABORTED | typeof TIMED_OUT> {
+  promise.catch(() => undefined);
+  if (abortSignal?.aborted) return ABORTED;
+  const remainingMs = deadline - performance.now();
+  if (remainingMs <= 0) return TIMED_OUT;
+
+  const gate = new AsyncVariable<SettledWithin<T>>('startup readiness wait', remainingMs);
+  const cleanup = new AbortController();
+  // Each resolution is guarded on `hasSettled` because the losing path still runs — an abort that
+  // lands just after the promise settled, say — and `resolveToValue` logs a line every time it is
+  // called on a settled variable. Same guard `network-object-status.service.ts` puts around its gate.
+  promise
+    .then(
+      (value) => {
+        if (!gate.hasSettled) gate.resolveToValue({ kind: 'value', value });
+        return undefined;
+      },
+      (error) => {
+        if (!gate.hasSettled) gate.resolveToValue({ kind: 'error', error });
+        return undefined;
+      },
+    )
+    .catch(() => undefined);
+  abortSignal?.addEventListener(
+    'abort',
+    () => {
+      if (!gate.hasSettled) gate.resolveToValue({ kind: 'aborted' });
+    },
+    { signal: cleanup.signal },
+  );
+
+  let settled: SettledWithin<T>;
+  try {
+    settled = await gate.promise;
+  } catch {
+    // Only the gate's own timeout can reject it, since every settlement of `promise` resolves it.
+    return TIMED_OUT;
+  } finally {
+    cleanup.abort();
+  }
+
+  if (settled.kind === 'aborted') return ABORTED;
+  if (settled.kind === 'error') throw settled.error;
+  return settled.value;
+}
+
+/** Detail for a `'timed-out'` outcome reached because the factory never registered at all. */
+const FACTORY_NOT_REGISTERED_DETAIL =
+  'the scripture project data provider factory did not register within the readiness budget';
+
+/**
+ * Detail for a `'timed-out'` outcome reached because the factory registered but never answered a
+ * metadata probe with any projects.
+ */
+const FACTORY_NOT_REPORTING_PROJECTS_DETAIL =
+  'the scripture project data provider factory registered but never reported any projects';
+
+/**
+ * Phase 1: waits for the scripture PDP factory network object to register. This mirrors the wait
+ * `getMetadataForProject` performs for a single project in `project-lookup.service-model.ts`, and
+ * is the same factory registration the project picker ultimately depends on — but it is NOT the
+ * picker's own call: the picker's list comes from `getMetadataForAllProjects`, which performs no
+ * `waitForNetworkObject` at all and instead has its own grace loop bounded by
+ * `LOAD_TIME_GRACE_PERIOD_MS`, measured from process start.
+ */
+async function waitForScriptureFactoryRegistration(
+  deadline: number,
+  abortSignal?: AbortSignal,
+): Promise<WorkspaceReadinessResult> {
+  const remainingMs = Math.max(0, deadline - performance.now());
+  // A zero (already-elapsed) budget must fail fast, not pass through: `AsyncVariable` only arms
+  // its timeout for a strictly positive value (see `rejectIfNotSettledWithinMS > 0` in
+  // `lib/platform-bible-utils/src/promises/async-variable.ts`) — `-1` is its documented
+  // "no timeout" sentinel, but an unguarded `0` hits that same false branch and would wait
+  // unbounded instead of expiring instantly, violating this module's "never waits unbounded"
+  // contract. `settleWithin` guards this too, but keeping the guard here documents the coupling at
+  // the one call site that depends on it (`remainingMs` is also what we pass to
+  // `waitForNetworkObject` as its own documented bound).
+  if (remainingMs <= 0) return { outcome: 'timed-out', detail: FACTORY_NOT_REGISTERED_DETAIL };
+  try {
+    const settled = await settleWithin(
+      networkObjectStatusService.waitForNetworkObject(
+        {
+          objectType: PDP_FACTORY_OBJECT_TYPE,
+          attributes: { projectInterfaces: [SCRIPTURE_READINESS_PROJECT_INTERFACE] },
+        },
+        remainingMs,
+      ),
+      deadline,
+      abortSignal,
+    );
+    if (settled === ABORTED) return { outcome: 'aborted' };
+    if (settled === TIMED_OUT)
+      return { outcome: 'timed-out', detail: FACTORY_NOT_REGISTERED_DETAIL };
+    return { outcome: 'ready' };
+  } catch (e) {
+    // Re-check abort FIRST: the gate settles on whichever outcome reaches it first, so a quit
+    // landing in the same tick as the underlying rejection would otherwise be reported as
+    // 'timed-out' — which makes the caller warn "syncing anyway" during shutdown.
+    if (abortSignal?.aborted) return { outcome: 'aborted' };
+    // Any rejection means the same thing to the caller — we could not confirm readiness — but the
+    // causes differ (budget elapsed vs. the status service itself being unreachable), so log the
+    // message rather than asserting which one it was.
+    const detail = `could not wait for the scripture project data provider factory: ${getErrorMessage(e)}`;
+    logger.debug(`Startup sync readiness: ${detail}`);
+    return { outcome: 'timed-out', detail };
+  }
+}
+
+/**
+ * Whether a phase-2 probe attempt should be logged. Logging every attempt in a workspace that
+ * legitimately has no local scripture projects would run for the life of the readiness budget and
+ * bury the surrounding startup logs. Sampling — the first attempt, then every tenth — tells the
+ * same story at a fraction of the volume, without asserting how many attempts a given boot actually
+ * makes: the backoff cadence below, and probes serializing behind the network layer's request
+ * timeout when the provider is saturated, both push the real count around.
+ */
+function shouldLogProbeAttempt(attempt: number): boolean {
+  return attempt === 1 || attempt % 10 === 0;
+}
+
+/**
+ * Phase 2: polls until the workspace actually answers a scripture-metadata request.
+ *
+ * Registration alone is not enough. The Scripture Extender is a LAYERING factory: its
+ * `getAvailableProjects` fans out to the .NET base factories, so it can be registered while still
+ * unable to answer. Starting a whole-workspace Send/Receive in that window puts the sync's load
+ * back on the .NET provider while the renderer's own metadata fetch is still outstanding — the same
+ * failure one layer later.
+ *
+ * An empty result counts as not-ready, not ready-with-no-projects. A workspace that genuinely has
+ * no local scripture projects therefore waits the full budget. Note this probe and the eventual
+ * sync measure different things: the probe checks for projects visible via
+ * `SCRIPTURE_READINESS_PROJECT_INTERFACE`, while `syncProjects(undefined)` means "all shared
+ * projects already present locally" — those sets can differ, so the delayed sync is not always a
+ * no-op. When there genuinely are no local scripture projects, though, it typically has nothing to
+ * do.
+ *
+ * The polling itself is not free even in that case: `includeProjectInterfaces` is applied only
+ * AFTER `getMetadataForAllProjectsWithoutRetries` fans out, so every probe still calls
+ * `getAvailableProjects` on every registered factory. A workspace with no projects yet therefore
+ * pays one fan-out per probe for the life of the budget, at the backoff cadence below.
+ *
+ * Deliberately uses the unscoped lookup (no `includePdpFactoryIds`) rather than narrowing the probe
+ * to just the scripture factory: the Scripture Extender is a layering factory whose
+ * `getAvailableProjects` needs to see its base (.NET) factories to answer at all, and
+ * `internalGetMetadata` (`project-lookup.service-model.ts`) forwards `includePdpFactoryIds` to the
+ * factory it calls AND adds that factory's own id to `excludePdpFactoryIds` — so scoping the probe
+ * to the scripture factory would ask it to layer over `{itself} ∧ ¬{itself}`, i.e. nothing, and it
+ * would report zero projects forever. The consequence: any OTHER, persistently-failing factory also
+ * keeps this probe from ever confirming readiness — bounded by the budget, after which the sync
+ * fires anyway (the same fallback as any other unconfirmed readiness), and the same exposure the
+ * project picker itself has via its own unscoped `getMetadataForAllProjects` call.
+ *
+ * The probe runs BEFORE the deadline check so it always gets at least one attempt, even if phase 1
+ * consumed the entire budget.
+ */
+async function pollUntilScriptureMetadataAnswers(
+  deadline: number,
+  abortSignal?: AbortSignal,
+): Promise<WorkspaceReadinessResult> {
+  let attempt = 0;
+  for (;;) {
+    if (abortSignal?.aborted) return { outcome: 'aborted' };
+    attempt += 1;
+
+    // Carries this attempt's cause into the deadline branch below, so a deadline reached right after
+    // a throwing attempt reports the underlying error instead of the generic "no projects" detail.
+    let attemptDetail: string = FACTORY_NOT_REPORTING_PROJECTS_DETAIL;
+
+    try {
+      // Intentionally awaiting inside the loop so we probe once at a time.
+      // eslint-disable-next-line no-await-in-loop
+      const settled = await settleWithin(
+        projectLookupService.getMetadataForAllProjectsWithoutRetries({
+          // Escaped because `includeProjectInterfaces` compiles to an unanchored `RegExp` matched
+          // with `.test()` — an unescaped literal would match as a wildcard/substring rather than
+          // exactly. Mirrors `getMetadataForProject`'s own `escapeStringRegexp` use for this same
+          // field, so both phases key off the same exact-match predicate.
+          includeProjectInterfaces: [escapeStringRegexp(SCRIPTURE_READINESS_PROJECT_INTERFACE)],
+        }),
+        deadline,
+        abortSignal,
+      );
+      if (settled === ABORTED) return { outcome: 'aborted' };
+      if (settled === TIMED_OUT)
+        return { outcome: 'timed-out', detail: FACTORY_NOT_REPORTING_PROJECTS_DETAIL };
+      // A quit can land while the probe above was in flight: re-check right after it settles so a
+      // late quit is honored instead of reporting a stale 'ready' the app is already shutting down.
+      if (abortSignal?.aborted) return { outcome: 'aborted' };
+      if (settled.length > 0) return { outcome: 'ready' };
+      if (shouldLogProbeAttempt(attempt))
+        logger.debug(
+          `Startup sync readiness: scripture factory is registered but reports no projects yet (attempt ${attempt}); retrying`,
+        );
+    } catch (e) {
+      // Re-check abort first, for the same reason as phase 1's catch: a quit landing in the same
+      // tick as the probe's rejection must be honored as 'aborted', not reported as 'timed-out'.
+      if (abortSignal?.aborted) return { outcome: 'aborted' };
+      // A probe that throws this early in boot means "not answering yet", not "broken" — the
+      // factory's fan-out to the .NET provider can legitimately fail or time out while that
+      // process is still coming up. Retry within the budget rather than giving up.
+      attemptDetail = getErrorMessage(e);
+      if (shouldLogProbeAttempt(attempt))
+        logger.debug(
+          `Startup sync readiness: project metadata probe failed on attempt ${attempt}; retrying: ${attemptDetail}`,
+        );
+    }
+
+    // Same reasoning as the re-check above, for the deadline branch: a quit landing while a probe
+    // was in flight (whether it resolved empty or threw) must be honored as 'aborted', not reported
+    // as a stale 'timed-out'.
+    if (abortSignal?.aborted) return { outcome: 'aborted' };
+    if (performance.now() >= deadline) return { outcome: 'timed-out', detail: attemptDetail };
+
+    // Backs off the same way `requestSessionSyncWithBootRetry` does in `startup-tasks.ts`: the
+    // common case (the factory answers within the first few seconds) polls at the shared cadence,
+    // and only the long tail backs off further.
+    const intervalMs =
+      attempt <= INITIAL_READINESS_POLL_ATTEMPTS
+        ? INITIAL_READINESS_POLL_INTERVAL_MS
+        : EXTENDED_READINESS_POLL_INTERVAL_MS;
+    // Intentionally awaiting inside the loop so we wait a bit before probing again.
+    // eslint-disable-next-line no-await-in-loop
+    const raced = await settleWithin(wait(intervalMs), deadline, abortSignal);
+    if (raced === ABORTED) return { outcome: 'aborted' };
+    if (raced === TIMED_OUT) return { outcome: 'timed-out', detail: attemptDetail };
+  }
+}
+
+/**
+ * Waits, bounded, until this workspace can list scripture projects — i.e. until the scripture PDP
+ * factory has registered and answers a metadata request.
+ *
+ * Never throws and never waits unbounded. Callers treat `'timed-out'` as "proceed anyway"; its
+ * `detail` names a short, log-safe cause (safe at info/warn, including in packaged builds).
+ */
+export async function waitForScriptureWorkspaceReady(
+  options: WorkspaceReadinessOptions = {},
+): Promise<WorkspaceReadinessResult> {
+  const { abortSignal, timeoutMs = STARTUP_SYNC_READINESS_BUDGET_MS } = options;
+  // Monotonic, not wall-clock: this runs during OS cold boot, exactly when the wall clock gets
+  // stepped (fresh boot, dual-boot RTC skew, VM resume).
+  const deadline = performance.now() + timeoutMs;
+
+  if (abortSignal?.aborted) return { outcome: 'aborted' };
+
+  const registration = await waitForScriptureFactoryRegistration(deadline, abortSignal);
+  if (registration.outcome !== 'ready') return registration;
+
+  return pollUntilScriptureMetadataAnswers(deadline, abortSignal);
+}

--- a/src/main/startup-tasks.test.ts
+++ b/src/main/startup-tasks.test.ts
@@ -10,6 +10,7 @@ import { settingsService } from '@shared/services/settings.service';
 import * as commandService from '@shared/services/command.service';
 import * as networkService from '@shared/services/network.service';
 import { logger } from '@shared/services/logger.service';
+import { waitForScriptureWorkspaceReady } from '@main/startup-readiness.util';
 import { performStartupTasks, STARTUP_SYNC_RETRY_BUDGET_MS } from './startup-tasks';
 
 vi.mock('@shared/services/settings.service', () => ({
@@ -28,11 +29,16 @@ vi.mock('@shared/services/logger.service', () => ({
   logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
 }));
 
+vi.mock('@main/startup-readiness.util', () => ({
+  waitForScriptureWorkspaceReady: vi.fn(),
+}));
+
 const mockSettingsGet = vi.mocked(settingsService.get);
 const mockSendCommand = vi.mocked(commandService.sendCommand);
 const mockRequestNoRetry = vi.mocked(networkService.requestNoRetry);
 const mockLoggerDebug = vi.mocked(logger.debug);
 const mockLoggerWarn = vi.mocked(logger.warn);
+const mockWaitForReady = vi.mocked(waitForScriptureWorkspaceReady);
 
 /**
  * Builds a rejection shaped like what `networkService`'s request plumbing actually throws for a
@@ -63,10 +69,46 @@ function stubSettings({ mode = 'simple', firstRunComplete = true, syncOnStartup 
   });
 }
 
+/** The settings snapshot a Simple-mode startup sync needs before anything else can skip it. */
+const SIMPLE_MODE_SETTINGS = { mode: 'simple', firstRunComplete: true, syncOnStartup: true };
+
+/**
+ * Drives a Simple-mode startup whose readiness gate parks, swapping the settings the gates read
+ * from `before` to `after` while it is parked.
+ *
+ * This is the only way to exercise the post-wait re-read: the gate can sit for up to the readiness
+ * budget, so what the user wanted when it started may not be what they want when it finishes.
+ */
+async function startupWithSettingsChangedDuringReadinessWait(
+  before: typeof SIMPLE_MODE_SETTINGS,
+  after: typeof SIMPLE_MODE_SETTINGS,
+): Promise<void> {
+  let current = before;
+  mockSettingsGet.mockImplementation(async (key: string) => {
+    if (key === 'platform.interfaceMode') return current.mode;
+    if (key === 'platform.firstRunComplete') return current.firstRunComplete;
+    if (key === 'platform.syncOnStartup') return current.syncOnStartup;
+    throw new Error(`Unexpected settings key in test stub: ${key}`);
+  });
+  let resolveReadiness: (result: { outcome: 'ready' }) => void = () => {};
+  mockWaitForReady.mockReturnValue(
+    new Promise((resolve) => {
+      resolveReadiness = resolve;
+    }),
+  );
+
+  const startupPromise = performStartupTasks();
+  await vi.waitFor(() => expect(mockWaitForReady).toHaveBeenCalled());
+  current = after;
+  resolveReadiness({ outcome: 'ready' });
+  await startupPromise;
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockSendCommand.mockResolvedValue(undefined);
   mockRequestNoRetry.mockResolvedValue(undefined);
+  mockWaitForReady.mockResolvedValue({ outcome: 'ready' });
 });
 
 describe('performStartupTasks', () => {
@@ -339,4 +381,190 @@ describe('performStartupTasks', () => {
   });
 
   // #endregion
+
+  describe('simple-mode readiness gate', () => {
+    it('does not fire the sync until readiness resolves', async () => {
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      let resolveReadiness: (result: { outcome: 'ready' }) => void = () => {};
+      mockWaitForReady.mockReturnValue(
+        new Promise((resolve) => {
+          resolveReadiness = resolve;
+        }),
+      );
+
+      const startupPromise = performStartupTasks();
+      // Wait until we are demonstrably PARKED on the readiness gate — past all three settings
+      // gates — before asserting nothing was sent. Flushing a fixed number of microtasks instead
+      // would make this test pass even with no gate at all: `sendCommand` simply would not have
+      // been reached yet, and the assertion would be vacuously true.
+      await vi.waitFor(() => expect(mockWaitForReady).toHaveBeenCalled());
+      expect(mockSendCommand).not.toHaveBeenCalled();
+
+      resolveReadiness({ outcome: 'ready' });
+      await startupPromise;
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        'paratextBibleSendReceive.syncProjects',
+        undefined,
+      );
+    });
+
+    it('fires the sync anyway (and warns) when readiness times out', async () => {
+      // The sync is delayed, never permanently suppressed.
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      mockWaitForReady.mockResolvedValue({
+        outcome: 'timed-out',
+        detail:
+          'the scripture project data provider factory did not register within the readiness budget',
+      });
+
+      await performStartupTasks();
+
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        'paratextBibleSendReceive.syncProjects',
+        undefined,
+      );
+      expect(mockLoggerWarn).toHaveBeenCalledWith(expect.stringContaining('did not become ready'));
+    });
+
+    it('includes the returned detail in the readiness warn', async () => {
+      // Packaged builds log at info; every `logger.debug` this feature emits is invisible there, so
+      // the warn itself must carry the real cause rather than pointing at a debug log the caller
+      // can't see.
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      mockWaitForReady.mockResolvedValue({
+        outcome: 'timed-out',
+        detail:
+          'the scripture project data provider factory registered but never reported any projects',
+      });
+
+      await performStartupTasks();
+
+      expect(mockLoggerWarn).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'the scripture project data provider factory registered but never reported any projects',
+        ),
+      );
+    });
+
+    it('does not fire the sync when the app is quitting during the readiness wait', async () => {
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      mockWaitForReady.mockResolvedValue({ outcome: 'aborted' });
+
+      await performStartupTasks();
+
+      expect(mockSendCommand).not.toHaveBeenCalled();
+      expect(mockLoggerWarn).not.toHaveBeenCalled();
+      expect(mockLoggerDebug).toHaveBeenCalledWith(expect.stringContaining('quitting'));
+    });
+
+    it('does not fire (or warn) when readiness times out but the app is already quitting', async () => {
+      // Pins the merged, reordered abort check: without it, a 'timed-out' outcome would reach the
+      // warn below before the abort recheck ran, logging "syncing anyway" for a sync that is then
+      // skipped.
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      const abort = new AbortController();
+      abort.abort();
+      mockWaitForReady.mockResolvedValue({ outcome: 'timed-out', detail: 'some cause' });
+
+      await performStartupTasks({ abortSignal: abort.signal });
+
+      expect(mockSendCommand).not.toHaveBeenCalled();
+      expect(mockLoggerWarn).not.toHaveBeenCalled();
+      expect(mockLoggerDebug).toHaveBeenCalledWith(expect.stringContaining('quitting'));
+    });
+
+    it('passes the abort signal through to the readiness wait', async () => {
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      const abort = new AbortController();
+
+      await performStartupTasks({ abortSignal: abort.signal });
+
+      expect(mockWaitForReady).toHaveBeenCalledWith({ abortSignal: abort.signal });
+    });
+
+    it('never consults readiness in power mode', async () => {
+      // Pins "Power mode unchanged" against a future refactor that routes both modes through the
+      // gate — which would charge readiness time against Power's freshness window and silently
+      // drop legitimate startup syncs.
+      mockSettingsGet.mockResolvedValue('power');
+
+      await performStartupTasks();
+
+      expect(mockWaitForReady).not.toHaveBeenCalled();
+    });
+
+    it('does not wait for readiness when a settings gate already skipped the sync', async () => {
+      // Ordering guard: a session that will not sync must not pay the readiness wait.
+      stubSettings({ mode: 'simple', firstRunComplete: true, syncOnStartup: false });
+
+      await performStartupTasks();
+
+      expect(mockWaitForReady).not.toHaveBeenCalled();
+      expect(mockSendCommand).not.toHaveBeenCalled();
+    });
+
+    it('does not wait for readiness when first run is not complete', async () => {
+      stubSettings({ mode: 'simple', firstRunComplete: false });
+
+      await performStartupTasks();
+
+      expect(mockWaitForReady).not.toHaveBeenCalled();
+    });
+
+    it('does not fire the sync when readiness resolves "ready" but the app began quitting while waiting', async () => {
+      // Defense-in-depth guard at the call site: readiness settling with a non-'aborted' outcome
+      // does not guarantee the app wasn't already quitting by the time it resolved — e.g. a quit
+      // landing while the readiness gate's own probe was in flight.
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      const abort = new AbortController();
+      abort.abort();
+      mockWaitForReady.mockResolvedValue({ outcome: 'ready' });
+
+      await performStartupTasks({ abortSignal: abort.signal });
+
+      expect(mockSendCommand).not.toHaveBeenCalled();
+      expect(mockLoggerDebug).toHaveBeenCalledWith(expect.stringContaining('quitting'));
+    });
+
+    // One case per gate. The gates share an implementation, but only the post-wait CALL is under
+    // test here, and an early return that skipped just one of them would still pass the other two.
+    it('does not fire the sync when the interface mode changes to power during the readiness wait', async () => {
+      await startupWithSettingsChangedDuringReadinessWait(SIMPLE_MODE_SETTINGS, {
+        ...SIMPLE_MODE_SETTINGS,
+        mode: 'power',
+      });
+
+      // Neither mode's sync: not Simple's (the user is no longer in Simple) and not Power's either,
+      // since this session already committed to the Simple path before the mode changed.
+      expect(mockSendCommand).not.toHaveBeenCalled();
+      expect(mockRequestNoRetry).not.toHaveBeenCalled();
+      expect(mockLoggerDebug).toHaveBeenCalledWith(
+        expect.stringContaining('Startup sync skipped after the readiness wait'),
+      );
+    });
+
+    it('does not fire the sync when automatic sync is turned off during the readiness wait', async () => {
+      await startupWithSettingsChangedDuringReadinessWait(SIMPLE_MODE_SETTINGS, {
+        ...SIMPLE_MODE_SETTINGS,
+        syncOnStartup: false,
+      });
+
+      expect(mockSendCommand).not.toHaveBeenCalled();
+      expect(mockLoggerDebug).toHaveBeenCalledWith(
+        expect.stringContaining('Startup sync skipped after the readiness wait'),
+      );
+    });
+
+    it('does not fire the sync when first run becomes incomplete during the readiness wait', async () => {
+      await startupWithSettingsChangedDuringReadinessWait(SIMPLE_MODE_SETTINGS, {
+        ...SIMPLE_MODE_SETTINGS,
+        firstRunComplete: false,
+      });
+
+      expect(mockSendCommand).not.toHaveBeenCalled();
+      expect(mockLoggerDebug).toHaveBeenCalledWith(
+        expect.stringContaining('Startup sync skipped after the readiness wait'),
+      );
+    });
+  });
 });

--- a/src/main/startup-tasks.test.ts
+++ b/src/main/startup-tasks.test.ts
@@ -473,13 +473,157 @@ describe('performStartupTasks', () => {
       expect(mockLoggerDebug).toHaveBeenCalledWith(expect.stringContaining('quitting'));
     });
 
-    it('passes the abort signal through to the readiness wait', async () => {
+    it('falls back to the general abort signal when no readiness signal is supplied', async () => {
       stubSettings({ mode: 'simple', firstRunComplete: true });
       const abort = new AbortController();
 
       await performStartupTasks({ abortSignal: abort.signal });
 
-      expect(mockWaitForReady).toHaveBeenCalledWith({ abortSignal: abort.signal });
+      // By identity, for the same reason as the test below: structural comparison cannot tell two
+      // unaborted `AbortSignal`s apart, so it would also pass against `undefined`-turned-anything.
+      expect(mockWaitForReady.mock.calls[0]?.[0]?.abortSignal).toBe(abort.signal);
+    });
+
+    it('waits on the readiness signal rather than the general one when they differ', async () => {
+      // The two diverge on exactly one path: a macOS last-window close aborts the general signal
+      // (Power's loop must stop on every platform) while deliberately leaving the readiness wait
+      // running, because the app stays resident and the startup tasks run once per process. Waiting
+      // on the general signal here would collapse that distinction and drop the sync.
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      const general = new AbortController();
+      const readiness = new AbortController();
+
+      await performStartupTasks({
+        abortSignal: general.signal,
+        readinessAbortSignal: readiness.signal,
+      });
+
+      // Asserted by IDENTITY, not with `toHaveBeenCalledWith`. That matcher compares structurally,
+      // and two unaborted `AbortSignal`s are structurally identical — so it would pass just as
+      // happily against the wrong signal, which is the entire thing this test exists to catch.
+      expect(mockWaitForReady.mock.calls[0]?.[0]?.abortSignal).toBe(readiness.signal);
+    });
+
+    it('still fires after a macOS window close once a window is back, though the general signal aborted', async () => {
+      // The exact combination production creates on a macOS last-window close, and the one that
+      // proves the carve-out is reachable at all: `isAppShuttingDown()` is true during that close
+      // (every tracked window is closing), so main aborts the GENERAL signal — while deliberately
+      // leaving the readiness signal alone. If this path also re-checked the general signal, the
+      // wait would survive the close only to be discarded as "quitting", and the readiness signal,
+      // the platform predicate, and the windowless guard could never change any outcome.
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      const general = new AbortController();
+      general.abort();
+      mockWaitForReady.mockResolvedValue({ outcome: 'ready' });
+
+      await performStartupTasks({
+        abortSignal: general.signal,
+        readinessAbortSignal: new AbortController().signal,
+        // A dock reactivation brought a window back before readiness landed.
+        canFireStartupSync: () => true,
+      });
+
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        'paratextBibleSendReceive.syncProjects',
+        undefined,
+      );
+    });
+
+    it('does not fire after a macOS window close while the app is still windowless', async () => {
+      // Same production combination, other branch: the wait outlived the close but nothing brought
+      // a window back, so the live guard — not the general signal — is what stops the sync.
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      const general = new AbortController();
+      general.abort();
+      mockWaitForReady.mockResolvedValue({ outcome: 'ready' });
+
+      await performStartupTasks({
+        abortSignal: general.signal,
+        readinessAbortSignal: new AbortController().signal,
+        canFireStartupSync: () => false,
+      });
+
+      expect(mockSendCommand).not.toHaveBeenCalled();
+      expect(mockLoggerDebug).toHaveBeenCalledWith(expect.stringContaining('no window'));
+    });
+
+    it('does not fire the sync when the readiness signal itself aborted', async () => {
+      // A real quit, or a last-window close off macOS: main aborts the readiness signal too, and
+      // that is what this path treats as "the app is quitting".
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      const readinessAbort = new AbortController();
+      readinessAbort.abort();
+      mockWaitForReady.mockResolvedValue({ outcome: 'ready' });
+
+      await performStartupTasks({
+        abortSignal: new AbortController().signal,
+        readinessAbortSignal: readinessAbort.signal,
+        canFireStartupSync: () => true,
+      });
+
+      expect(mockSendCommand).not.toHaveBeenCalled();
+      expect(mockLoggerDebug).toHaveBeenCalledWith(expect.stringContaining('quitting'));
+    });
+
+    it('does not fire the sync into a resident app that has no windows', async () => {
+      // The hazard the surviving readiness wait would otherwise open: on macOS the wait can park
+      // for the whole readiness budget past a last-window close, then resolve into a process that
+      // is resident, not quitting, and windowless — where the shutdown sync has already run and
+      // there is no UI to report progress or failure into. Neither abort signal describes that
+      // state, so the sync would fire without this check.
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      mockWaitForReady.mockResolvedValue({ outcome: 'ready' });
+
+      await performStartupTasks({ canFireStartupSync: () => false });
+
+      expect(mockSendCommand).not.toHaveBeenCalled();
+      expect(mockLoggerDebug).toHaveBeenCalledWith(expect.stringContaining('no window'));
+    });
+
+    it('fires the sync when a window is back by the time readiness resolves', async () => {
+      // The other half of the case above, and the whole reason the wait is allowed to survive a
+      // macOS last-window close: a dock reactivation brings a window back, so the startup sync that
+      // session never got still lands.
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      mockWaitForReady.mockResolvedValue({ outcome: 'ready' });
+
+      await performStartupTasks({ canFireStartupSync: () => true });
+
+      expect(mockSendCommand).toHaveBeenCalledWith(
+        'paratextBibleSendReceive.syncProjects',
+        undefined,
+      );
+    });
+
+    it('asks whether it may fire only after readiness resolves, not before the wait', async () => {
+      // Order matters: asked up front, the answer describes the app at process start rather than
+      // whenever the wait finally lands, which is the moment the guard is about to authorize.
+      stubSettings({ mode: 'simple', firstRunComplete: true });
+      const callOrder: string[] = [];
+      mockWaitForReady.mockImplementation(async () => {
+        callOrder.push('readiness');
+        return { outcome: 'ready' };
+      });
+
+      await performStartupTasks({
+        canFireStartupSync: () => {
+          callOrder.push('canFire');
+          return true;
+        },
+      });
+
+      expect(callOrder).toEqual(['readiness', 'canFire']);
+    });
+
+    it('never consults the windowless guard in power mode', async () => {
+      // Power mode has no readiness wait to outlive a window close, so it must not inherit the
+      // guard that exists to contain one.
+      mockSettingsGet.mockResolvedValue('power');
+      const canFireStartupSync = vi.fn(() => true);
+
+      await performStartupTasks({ canFireStartupSync });
+
+      expect(canFireStartupSync).not.toHaveBeenCalled();
     });
 
     it('never consults readiness in power mode', async () => {

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -72,25 +72,58 @@ const INITIAL_RETRY_ATTEMPTS = MAX_REQUEST_ATTEMPTS;
 const EXTENDED_RETRY_INTERVAL_MS = 2000;
 
 /**
- * Optional signals `performStartupTasks` receives from the main process. Both are omitted in unit
+ * Optional signals `performStartupTasks` receives from the main process. All are omitted in unit
  * tests that drive the sync logic directly, in which case behavior is unchanged (never aborts,
- * never goes stale). `getWindowInteractiveElapsedMs` only steers Power mode's freshness window —
- * Simple mode has no freshness concept — but `abortSignal` steers EITHER mode's wait.
+ * never goes stale, always allowed to fire). `getWindowInteractiveElapsedMs` steers only Power
+ * mode's freshness window — Simple mode has no freshness concept — and `readinessAbortSignal` and
+ * `canFireStartupSync` steer only Simple mode's readiness gate; `abortSignal` applies to both.
  */
 export interface StartupTasksSignals {
   /**
-   * Stops the wait once the app has begun quitting — either mode's:
+   * Stops the startup tasks once the app has begun going down by EITHER route — a quit, or the last
+   * window closing. Aborted unconditionally, which is the behavior this signal has always had.
    *
    * - The Power-mode boot-race retry loop. Stops it from (a) firing
    *   `runScheduledSessionSync('startup')` after `('shutdown')` already fired and (b) issuing a
    *   request that would resurrect the network connection `networkService.shutdown()` is tearing
-   *   down.
-   * - Simple mode's readiness wait ({@link waitForScriptureWorkspaceReady}). Stops it from firing a
-   *   no-ID `syncProjects` after shutdown has already begun, for the same two reasons.
+   *   down. Deliberately NOT consulted by Simple mode's post-readiness path. A macOS last-window
+   *   close makes `isAppShuttingDown()` true, so this signal aborts on exactly the close
+   *   {@link StartupTasksSignals.readinessAbortSignal} exists to survive; re-checking it after the
+   *   wait would make that carve-out unreachable. Simple mode's hard stop is
+   *   {@link StartupTasksSignals.canFireStartupSync}, evaluated live at fire time.
    *
    * Wired to `will-quit` and the window close in `main.ts`.
    */
   abortSignal?: AbortSignal;
+  /**
+   * Stops Simple mode's readiness wait ({@link waitForScriptureWorkspaceReady}) specifically.
+   *
+   * Separate from {@link StartupTasksSignals.abortSignal} because the two answer different
+   * questions. This one is aborted only when the app is really going away — on macOS, closing the
+   * last window leaves the app resident, and the startup tasks run once per PROCESS, so aborting
+   * there would drop the startup sync for the rest of the process's life even though a dock
+   * reactivation still wants it. See `shouldWindowCloseAbortReadinessWait` in
+   * `shutdown-latch.service.ts`. Keeping it separate is also what stops that macOS exception
+   * leaking into Power mode's loop, which must keep aborting on any shutdown.
+   *
+   * Omitted (or equal to {@link StartupTasksSignals.abortSignal}) is fine; it just means the wait
+   * has no separate escape hatch.
+   */
+  readinessAbortSignal?: AbortSignal;
+  /**
+   * Whether the app is still in a state where firing the Simple-mode startup sync makes sense,
+   * asked immediately before the command goes out.
+   *
+   * Needed because {@link StartupTasksSignals.readinessAbortSignal} deliberately survives a macOS
+   * last-window close: without this re-check, a wait parked for up to the readiness budget could
+   * resolve minutes later and fire a whole-workspace Send/Receive into a resident but WINDOWLESS
+   * app — after the shutdown sync already ran, with no UI to report progress or failure into. Main
+   * answers `false` in that state, so the sync survives only into a session that actually has a
+   * window (a dock reactivation), which is the only case the exception exists to serve.
+   *
+   * Omitted means "always allowed to fire", preserving today's behavior for tests.
+   */
+  canFireStartupSync?: () => boolean;
   /**
    * How long (ms) the main window has been interactive, or `undefined` if it has not been shown
    * yet. The freshness anchor for {@link STARTUP_SYNC_FRESHNESS_WINDOW_MS} — consulted only by Power
@@ -121,9 +154,12 @@ type StartupSyncTriggerOutcome = ScheduledSessionSyncResult | 'skipped-stale' | 
  * app. The wait exists because this sync saturates the .NET data provider and would otherwise
  * starve the very factory registration the project picker waits on, leaving the picker locked while
  * the rest of the UI looks loaded. On an exhausted readiness budget the sync still fires — it is
- * delayed, never suppressed. All errors are swallowed — the S/R extension may not be installed
- * (e.g. Platform.Bible), the command may not yet be registered, or the sync may fail. Startup must
- * never be blocked or visibly affected by this.
+ * delayed, never suppressed. The two exceptions are shutdown and a windowless app: a quit aborts
+ * the wait, and a wait that outlives a macOS last-window close (see
+ * {@link StartupTasksSignals.readinessAbortSignal}) is not allowed to fire into a resident app with
+ * no windows (see {@link StartupTasksSignals.canFireStartupSync}). All errors are swallowed — the
+ * S/R extension may not be installed (e.g. Platform.Bible), the command may not yet be registered,
+ * or the sync may fail. Startup must never be blocked or visibly affected by this.
  *
  * In Power mode: requests a sync of just the projects scheduled "On startup/shutdown" via the S/R
  * extension's `runScheduledSessionSync` command. Same error-swallowing contract as Simple mode — if
@@ -189,14 +225,29 @@ async function performStartupTasksInternal(signals?: StartupTasksSignals): Promi
   // scripture editor needs the very factory this gate waits on, so readiness necessarily resolves
   // before the user can be editing, and dropping the sync outright would contradict this task's
   // contract that the startup sync is delayed but never suppressed.
-  const readiness = await waitForScriptureWorkspaceReady({ abortSignal: signals?.abortSignal });
+  //
+  // This path runs on `readinessAbortSignal` throughout — the wait below AND the abort check after
+  // it — falling back to `abortSignal` only when main supplies no separate signal (unit tests).
+  //
+  // It must NOT also consult `abortSignal`: a macOS last-window close makes `isAppShuttingDown()`
+  // true via `areAllWindowsClosing()`, so main aborts that signal on exactly the close the readiness
+  // carve-out exists for. Re-checking it here would make the carve-out unreachable — the wait would
+  // survive the close and then be discarded as "quitting" anyway, and `readinessAbortSignal` /
+  // `canFireStartupSync` could never change any outcome.
+  //
+  // Dropping that check costs nothing, because the hard stop moved somewhere strictly better:
+  // `canFireStartupSync` below is evaluated live at fire time and answers `false` for BOTH ways the
+  // app can be un-syncable — shutting down (quit requested, or every window closing) and resident
+  // but windowless. A latched signal can only report a moment that has already passed.
+  const readinessAbortSignal = signals?.readinessAbortSignal ?? signals?.abortSignal;
+  const readiness = await waitForScriptureWorkspaceReady({ abortSignal: readinessAbortSignal });
 
-  // Covers both a gate that reported 'aborted' and a quit that landed while it was still resolving
+  // Covers a gate that reported 'aborted' and a quit that landed while it was still resolving
   // (readiness settling with a non-'aborted' outcome does not guarantee the app wasn't already
   // quitting by the time it resolved — e.g. a quit landing while the readiness gate's own probe was
   // in flight). Ordered before the 'timed-out' warn below so a sync that is about to be skipped
   // never gets logged as "syncing anyway".
-  if (readiness.outcome === 'aborted' || signals?.abortSignal?.aborted) {
+  if (readiness.outcome === 'aborted' || readinessAbortSignal?.aborted) {
     logger.debug('Startup sync skipped: app is quitting');
     return;
   }
@@ -212,6 +263,17 @@ async function performStartupTasksInternal(signals?: StartupTasksSignals): Promi
   const gatesAfterWait = await evaluateSimpleModeSyncGates();
   if (!gatesAfterWait.run) {
     logger.debug(`Startup sync skipped after the readiness wait: ${gatesAfterWait.reason}`);
+    return;
+  }
+
+  // Last check before the command goes out: is there still an app to sync FOR? The readiness wait
+  // deliberately survives a macOS last-window close (see `readinessAbortSignal`), which leaves one
+  // state that signal cannot describe — resident, not quitting, no windows. Firing here
+  // would run a whole-workspace Send/Receive after the shutdown sync already ran, into a process
+  // with no UI to report progress or failure into. Skip instead; the surviving wait then pays off
+  // only when a dock reactivation has brought a window back, which is the case it exists for.
+  if (signals?.canFireStartupSync && !signals.canFireStartupSync()) {
+    logger.debug('Startup sync skipped: the app has no window to sync for');
     return;
   }
 

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -493,10 +493,11 @@ function isRetryableBootRaceError(error: unknown): boolean {
  * readiness gate the Simple-mode path uses. Power mode is deliberately left ungated against that
  * readiness: charging a readiness wait against this path's window-interactive freshness window
  * could silently drop a legitimate startup sync, trading a visible bug for an invisible one. See
- * ADR-0027 for that trade-off, and for why having the S/R extension self-trigger at the end of its
- * own activation — once floated here as the cleaner long-term shape — was rejected: extensions
- * activate sequentially, so nothing guarantees it activates after the scripture extension, and if
- * it goes first its self-trigger starves the same factory.
+ * `adr-startup-sync-readiness-gate` in `.context/standards/Architecture-Decisions.md` for that
+ * trade-off, and for why having the S/R extension self-trigger at the end of its own activation —
+ * once floated here as the cleaner long-term shape — was rejected: extensions activate
+ * sequentially, so nothing guarantees it activates after the scripture extension, and if it goes
+ * first its self-trigger starves the same factory.
  *
  * Returns a {@link StartupSyncTriggerOutcome} for the cases the caller logs as non-failures (the
  * command ran and reported a result, the startup went stale, or the app is quitting), and throws

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -323,9 +323,22 @@ type SimpleModeSyncGateResult = { run: true } | { run: false; reason: string };
  *   silently suppress a sync the user never actually declined). Logged as a warning.
  */
 async function evaluateSimpleModeSyncGates(): Promise<SimpleModeSyncGateResult> {
-  // Re-reads the mode even though the caller already read one to pick this branch. Not redundant:
-  // that read asks "which mode, and can we tell at all?", this one asks "is it STILL simple?" — and
-  // the post-wait call exists precisely because the answer can change while the gate is parked.
+  // Re-reads the mode even though the caller already read one to pick this branch. That earns its
+  // place in the POST-wait call and not the pre-wait one, and the asymmetry is deliberate rather
+  // than overlooked:
+  //
+  // - Post-wait, the caller's value is genuinely stale — the gate may have been parked for the
+  //   whole readiness budget, and catching a mode switch that happened while parked is the entire
+  //   reason this runs a second time. An unreadable mode there really does mean "we can no longer
+  //   tell", which must not fall through to Simple's sync-everything.
+  // - Pre-wait, nothing awaits between the caller's read and this one, so the answer cannot have
+  //   changed. This read's only new outcome is a transient failure turning into a skipped sync.
+  //
+  // That surplus failure path is accepted rather than engineered away. Removing it means threading
+  // the already-read mode in as a parameter, supplied pre-wait and omitted post-wait — and a
+  // parameter whose misuse is "pass the cached mode to the post-wait call" would silently defeat
+  // the mid-wait re-check above, which is one of the guarantees this function exists to provide.
+  // A negligible, logged skip is the better trade against a permanent footgun aimed at that.
   let interfaceMode: SettingTypes['platform.interfaceMode'] | undefined;
   try {
     interfaceMode = await settingsService.get('platform.interfaceMode');

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -13,6 +13,7 @@ import {
   type ScheduledSessionSyncResult,
   type SessionSyncBoundary,
 } from '@main/scheduled-session-sync.util';
+import { waitForScriptureWorkspaceReady } from '@main/startup-readiness.util';
 import type { SettingTypes } from 'papi-shared-types';
 import { getErrorMessage, wait } from 'platform-bible-utils';
 
@@ -71,21 +72,30 @@ const INITIAL_RETRY_ATTEMPTS = MAX_REQUEST_ATTEMPTS;
 const EXTENDED_RETRY_INTERVAL_MS = 2000;
 
 /**
- * Optional signals `performStartupTasks` receives from the main process. Both are omitted where
- * there is no boot-race loop to steer (Simple mode) or in unit tests that drive the loop directly,
- * in which case behavior is unchanged (never aborts, never goes stale).
+ * Optional signals `performStartupTasks` receives from the main process. Both are omitted in unit
+ * tests that drive the sync logic directly, in which case behavior is unchanged (never aborts,
+ * never goes stale). `getWindowInteractiveElapsedMs` only steers Power mode's freshness window —
+ * Simple mode has no freshness concept — but `abortSignal` steers EITHER mode's wait.
  */
 export interface StartupTasksSignals {
   /**
-   * Aborts the Power-mode boot-race retry loop once the app has begun quitting. Stops it from (a)
-   * firing `runScheduledSessionSync('startup')` after `('shutdown')` already fired and (b) issuing
-   * a request that would resurrect the network connection `networkService.shutdown()` is tearing
-   * down. Wired to `will-quit` and the window close in `main.ts`.
+   * Stops the wait once the app has begun quitting — either mode's:
+   *
+   * - The Power-mode boot-race retry loop. Stops it from (a) firing
+   *   `runScheduledSessionSync('startup')` after `('shutdown')` already fired and (b) issuing a
+   *   request that would resurrect the network connection `networkService.shutdown()` is tearing
+   *   down.
+   * - Simple mode's readiness wait ({@link waitForScriptureWorkspaceReady}). Stops it from firing a
+   *   no-ID `syncProjects` after shutdown has already begun, for the same two reasons.
+   *
+   * Wired to `will-quit` and the window close in `main.ts`.
    */
   abortSignal?: AbortSignal;
   /**
    * How long (ms) the main window has been interactive, or `undefined` if it has not been shown
-   * yet. The freshness anchor for {@link STARTUP_SYNC_FRESHNESS_WINDOW_MS}.
+   * yet. The freshness anchor for {@link STARTUP_SYNC_FRESHNESS_WINDOW_MS} — consulted only by Power
+   * mode; Simple mode has no freshness window of its own (see the readiness gate's TSDoc on
+   * {@link performStartupTasks} for why).
    */
   getWindowInteractiveElapsedMs?: () => number | undefined;
 }
@@ -105,10 +115,15 @@ type StartupSyncTriggerOutcome = ScheduledSessionSyncResult | 'skipped-stale' | 
  * Runs initialization tasks (currently: triggering an initial project sync) shortly after the app
  * finishes starting up.
  *
- * In Simple mode: requests a sync of all locally-known shared projects so the user sees the latest
- * content as soon as they open the app. All errors are swallowed — the S/R extension may not be
- * installed (e.g. Platform.Bible), the command may not yet be registered, or the sync may fail.
- * Startup must never be blocked or visibly affected by this.
+ * In Simple mode: waits (bounded) for this workspace's scripture project data provider factories to
+ * be registered and answering — see {@link waitForScriptureWorkspaceReady} — then requests a sync of
+ * all locally-known shared projects so the user sees the latest content as soon as they open the
+ * app. The wait exists because this sync saturates the .NET data provider and would otherwise
+ * starve the very factory registration the project picker waits on, leaving the picker locked while
+ * the rest of the UI looks loaded. On an exhausted readiness budget the sync still fires — it is
+ * delayed, never suppressed. All errors are swallowed — the S/R extension may not be installed
+ * (e.g. Platform.Bible), the command may not yet be registered, or the sync may fail. Startup must
+ * never be blocked or visibly affected by this.
  *
  * In Power mode: requests a sync of just the projects scheduled "On startup/shutdown" via the S/R
  * extension's `runScheduledSessionSync` command. Same error-swallowing contract as Simple mode — if
@@ -159,34 +174,44 @@ async function performStartupTasksInternal(signals?: StartupTasksSignals): Promi
   // checked branch. A future third mode would be a compile error here (interfaceMode is typed from
   // the setting), not a silent no-sync.
 
-  // First-run gate: skip auto-sync until the simple-mode wizard completes, so a fresh user never
-  // syncs before consenting. On an unreadable flag, default to NOT syncing (consent-safe).
-  let firstRunComplete = false;
-  try {
-    firstRunComplete = (await settingsService.get('platform.firstRunComplete')) === true;
-  } catch (e) {
-    logger.warn(
-      `Could not read platform.firstRunComplete; skipping startup sync: ${getErrorMessage(e)}`,
-    );
-  }
-  if (!firstRunComplete) {
-    logger.debug('Startup sync skipped: first run not complete');
+  const gatesBeforeWait = await evaluateSimpleModeSyncGates();
+  if (!gatesBeforeWait.run) {
+    logger.debug(`Startup sync skipped: ${gatesBeforeWait.reason}`);
     return;
   }
 
-  // Sync-consent gate: if the user chose "Skip automatic sync" on the sync-consent step, honor that
-  // permanently. On an unreadable flag, default to syncing (consent-safe: the user likely never
-  // explicitly skipped — a read failure here should not silently suppress a legitimate sync).
-  let syncDisabled = false;
-  try {
-    syncDisabled = (await settingsService.get('platform.syncOnStartup')) === false;
-  } catch (e) {
-    logger.warn(
-      `Could not read platform.syncOnStartup; proceeding with sync: ${getErrorMessage(e)}`,
-    );
+  // Readiness gate: this is a whole-workspace Send/Receive served by the .NET data provider. Firing
+  // it before the scripture project data provider factories are up starves their registration — the
+  // project picker then waits on a factory that never appears and stays locked, with the rest of
+  // the UI looking loaded. Wait, bounded, for the workspace to be able to list scripture projects.
+  //
+  // Deliberately NOT freshness-gated the way Power mode is (STARTUP_SYNC_FRESHNESS_WINDOW_MS): the
+  // scripture editor needs the very factory this gate waits on, so readiness necessarily resolves
+  // before the user can be editing, and dropping the sync outright would contradict this task's
+  // contract that the startup sync is delayed but never suppressed.
+  const readiness = await waitForScriptureWorkspaceReady({ abortSignal: signals?.abortSignal });
+
+  // Covers both a gate that reported 'aborted' and a quit that landed while it was still resolving
+  // (readiness settling with a non-'aborted' outcome does not guarantee the app wasn't already
+  // quitting by the time it resolved — e.g. a quit landing while the readiness gate's own probe was
+  // in flight). Ordered before the 'timed-out' warn below so a sync that is about to be skipped
+  // never gets logged as "syncing anyway".
+  if (readiness.outcome === 'aborted' || signals?.abortSignal?.aborted) {
+    logger.debug('Startup sync skipped: app is quitting');
+    return;
   }
-  if (syncDisabled) {
-    logger.debug('Startup sync skipped: platform.syncOnStartup is false');
+  if (readiness.outcome === 'timed-out')
+    logger.warn(
+      `Startup sync: scripture project data providers did not become ready (${readiness.detail}); syncing anyway`,
+    );
+
+  // Settings can change during a wait that may park for up to the readiness budget (120 s): a user
+  // who switches to Power mode, or turns off automatic sync, while this was parked must not get a
+  // no-ID `syncProjects` anyway on the way out — that is exactly the harm the unreadable-mode guard
+  // above exists to prevent, just triggered by elapsed time instead of a read failure.
+  const gatesAfterWait = await evaluateSimpleModeSyncGates();
+  if (!gatesAfterWait.run) {
+    logger.debug(`Startup sync skipped after the readiness wait: ${gatesAfterWait.reason}`);
     return;
   }
 
@@ -204,6 +229,78 @@ async function performStartupTasksInternal(signals?: StartupTasksSignals): Promi
       `Startup sync failed or skipped (command absent / extension not yet activated): ${getErrorMessage(e)}`,
     );
   }
+}
+
+/** What {@link evaluateSimpleModeSyncGates} decided, and why when it decided not to run. */
+type SimpleModeSyncGateResult = { run: true } | { run: false; reason: string };
+
+/**
+ * Evaluates the three settings gates that must all pass before the Simple-mode startup sync fires:
+ * `platform.interfaceMode` must still be `'simple'`, `platform.firstRunComplete` must be `true`,
+ * and `platform.syncOnStartup` must not be `false`.
+ *
+ * Called twice by {@link performStartupTasksInternal} — once before the readiness wait and again
+ * immediately after it, since that wait can park for up to the readiness budget (120 s) and any of
+ * the three can change underneath it. Each call independently re-reads all three settings, so the
+ * second call reflects whatever the user did during the wait rather than a value cached from before
+ * it — this is what lets the post-wait call catch a mode switch or a sync-consent change that
+ * happened while parked.
+ *
+ * Preserves today's exact per-setting semantics:
+ *
+ * - An unreadable `platform.interfaceMode` never falls through to "sync everything": the read can
+ *   fail under the same slow-cold-boot conditions the Power retry budget exists to tolerate, and
+ *   Simple's no-ID `syncProjects` would S/R every locally-known shared project, overriding a Power
+ *   user's schedule. Logged as a warning (production-visible even in packaged builds).
+ * - A mode that has moved away from `'simple'` (e.g. to `'power'`, mid-wait) is also `run: false` —
+ *   this function only ever green-lights the Simple-mode sync.
+ * - An unreadable or `false` `platform.firstRunComplete` skips (consent-safe: a fresh user must not
+ *   sync before consenting, and an unreadable flag defaults to NOT syncing).
+ * - `platform.syncOnStartup === false` skips (the user explicitly opted out). An unreadable flag
+ *   defaults to PROCEEDING with sync instead (consent-safe the other way: a read failure should not
+ *   silently suppress a sync the user never actually declined). Logged as a warning.
+ */
+async function evaluateSimpleModeSyncGates(): Promise<SimpleModeSyncGateResult> {
+  // Re-reads the mode even though the caller already read one to pick this branch. Not redundant:
+  // that read asks "which mode, and can we tell at all?", this one asks "is it STILL simple?" — and
+  // the post-wait call exists precisely because the answer can change while the gate is parked.
+  let interfaceMode: SettingTypes['platform.interfaceMode'] | undefined;
+  try {
+    interfaceMode = await settingsService.get('platform.interfaceMode');
+  } catch (e) {
+    const reason = `could not read platform.interfaceMode: ${getErrorMessage(e)}`;
+    logger.warn(`Startup sync: ${reason}`);
+    return { run: false, reason };
+  }
+  if (interfaceMode !== 'simple')
+    return { run: false, reason: 'interface mode is no longer simple' };
+
+  // First-run gate: skip auto-sync until the simple-mode wizard completes, so a fresh user never
+  // syncs before consenting. On an unreadable flag, default to NOT syncing (consent-safe).
+  let firstRunComplete = false;
+  try {
+    firstRunComplete = (await settingsService.get('platform.firstRunComplete')) === true;
+  } catch (e) {
+    logger.warn(
+      `Could not read platform.firstRunComplete; skipping startup sync: ${getErrorMessage(e)}`,
+    );
+  }
+  if (!firstRunComplete) return { run: false, reason: 'first run not complete' };
+
+  // Sync-consent gate: if the user chose "Skip automatic sync" on the sync-consent step, honor that
+  // permanently. On an unreadable flag, default to syncing (consent-safe: the user likely never
+  // explicitly skipped — a read failure here should not silently suppress a legitimate sync).
+  let syncDisabled = false;
+  try {
+    syncDisabled = (await settingsService.get('platform.syncOnStartup')) === false;
+  } catch (e) {
+    logger.warn(
+      `Could not read platform.syncOnStartup; proceeding with sync: ${getErrorMessage(e)}`,
+    );
+  }
+  if (syncDisabled) return { run: false, reason: 'platform.syncOnStartup is false' };
+
+  return { run: true };
 }
 
 /**
@@ -315,11 +412,16 @@ function isRetryableBootRaceError(error: unknown): boolean {
  *
  * This is deliberately a narrow, local retry loop rather than a new per-call retry option on
  * `networkService.request`: it only serves this one boot-time race, and the shared retry policy
- * other callers rely on should stay as-is. The cleaner long-term shape would be the S/R extension
- * self-triggering its own startup sync at the end of its own activation, so core never has to race
- * extension-host startup at all; that is a larger cross-repo change and is out of scope here (core
- * has no signal today for "a method just registered" — the RPC registry set is not surfaced as an
- * event; see the standing `TODO (maybe): Wait for signal from the extension host` in `main.ts`).
+ * other callers rely on should stay as-is.
+ *
+ * Note this loop waits for the S/R _command_ to register; it is NOT the project-data-provider
+ * readiness gate the Simple-mode path uses. Power mode is deliberately left ungated against that
+ * readiness: charging a readiness wait against this path's window-interactive freshness window
+ * could silently drop a legitimate startup sync, trading a visible bug for an invisible one. See
+ * ADR-0027 for that trade-off, and for why having the S/R extension self-trigger at the end of its
+ * own activation — once floated here as the cleaner long-term shape — was rejected: extensions
+ * activate sequentially, so nothing guarantees it activates after the scripture extension, and if
+ * it goes first its self-trigger starves the same factory.
  *
  * Returns a {@link StartupSyncTriggerOutcome} for the cases the caller logs as non-failures (the
  * command ran and reported a result, the startup went stale, or the app is quitting), and throws

--- a/src/renderer/hooks/use-project-picker-data.hook.ts
+++ b/src/renderer/hooks/use-project-picker-data.hook.ts
@@ -43,6 +43,10 @@ const PDPF_REGISTRATION_DEBOUNCE_MS = 200;
  * before the layering PDPF that provides this interface registers). Published resources also carry
  * this interface via the Scripture Extender layering PDPF, so the current project and recent
  * projects (both always scripture or resource projects) resolve from the same filtered fetch.
+ *
+ * `src/main/startup-readiness.util.ts` deliberately keeps its own copy of this literal for its
+ * startup readiness gate (see that file's rationale for why it isn't shared). If you change this
+ * one, consider whether that one should change too.
  */
 const PICKER_PROJECT_INTERFACE = 'platformScripture.USJ_Chapter';
 const PICKER_METADATA_FILTER: ProjectMetadataFilterOptions = {


### PR DESCRIPTION
## The bug

In **Simple mode**, the project picker never unlocked at startup — while the rest of the UI looked fully loaded.

Core fired `syncProjects` with no project IDs ("Send/Receive every locally-known shared project") the instant its settings gates passed. In Paratext 10 Studio that command is served by the .NET data provider, and its Mercurial/DBL work saturates that process. Extensions activate **strictly sequentially**, so anything awaiting the busy provider stalls `platform-scripture` behind it — and `platform-scripture` registers the Scripture Extender PDPF, the only factory advertising `platformScripture.USJ_Chapter`, which is exactly what the picker waits on. Self-inflicted starvation.

## The fix

Core keeps ownership of the trigger and gates it on **workspace readiness** instead of firing blind:

```
performStartupTasks (fire-and-forget, Simple branch)
    evaluateSimpleModeSyncGates()        ← settings gates
    waitForScriptureWorkspaceReady()     ← NEW: phase 1 registered, phase 2 answering
    evaluateSimpleModeSyncGates()        ← again, settings can change during a 120 s wait
    sendCommand('…syncProjects', undefined)
```

Outcomes are `'ready' | 'timed-out' | 'aborted'`. **`'timed-out'` means "couldn't confirm", not "don't run"** — the sync is delayed, never suppressed. Power mode is deliberately untouched.

## Review round 2 (commit 2)

Everything below the fold describes the original commit; this section is what changed in response to @jolierabideau's review. **The blocking finding is addressed with both shapes suggested.**

| Finding | Resolution |
| --- | --- |
| **macOS abort reintroduces the hazard the abort prevented** (blocking) | `canStartupSyncFireNow` is re-checked live immediately before the command goes out and skips when the app is resident but windowless — so a wait that outlives a last-window close can only fire if a dock reactivation brought a window back. |
| **…and `startupTasksAbort` is shared with Power mode** | The shared abort is unconditional again, so Power mode's boot-race loop is exactly what it is on `main`, on every platform. The carve-out moved to `startupReadinessAbort` / `StartupTasksSignals.readinessAbortSignal`, which reaches only the Simple readiness wait. "Power mode unchanged" is now literally true. |
| Studio's removed `Task.Run(SyncProjects)` is a load-bearing cross-repo claim | Cited precisely in the ADR: `paranext/paratext-10-studio`, `repo-patches/paranext-core.patch` lines 5334–5336 at commit `f779810`, in the hunk patching `ParatextProjectSendReceiveService.cs`, quote included. |
| Backoff cadence and `shouldLogProbeAttempt` unpinned | One test pins both — answers on probe 15 (10 waits @1 s + 4 @2 s = 18 s), so flattening (14 s) or inverting (22 s) fails, and it asserts exactly two log lines, on attempts 1 and 10. |
| Two comments overstate the code | Both corrected. The probe-before-deadline guarantee is that the request is *issued*, not that it counts; `escapeStringRegexp` buys a literal **substring** match, not an exact one (`includeProjectInterfaces` compiles to unanchored `RegExp`s applied with `.test()`). |
| `getMetadataForAllProjectsWithoutRetries` used off-label | Rationale written down: the retrying variant absorbs startup unreadiness on its own schedule against `LOAD_TIME_GRACE_PERIOD_MS`, which is the very signal this loop exists to read. One retry loop, not two. |
| Duplicated `2000` and the duplicated `platformScripture.USJ_Chapter` literal | Both documented — the interval as the one number here that genuinely can drift, the literal as an intentionally unenforced coupling. |
| Stale `Promise.race` test comment, `satisfies ProjectMetadata`, missing `@param`/`@returns` | Fixed. |
| `waitForNetworkObject` leaks its subscription on timeout | Confirmed the reading (`unsub()` only runs from inside the callback). Pre-existing and out of scope; folding into the Power-mode follow-up ticket. |

**Also found while doing the above, and fixed here:** phase 1 treated *every* rejection as the end of the gate. `waitForNetworkObject` rejects both when its budget expires and when the status service is unreachable, and the second can land with nearly the whole budget unspent — collapsing a 120 s gate into seconds and firing the sync early, i.e. the original bug reintroduced invisibly. A non-exhaustion rejection now falls through to phase 2, which tests the stronger condition and already tolerates throws. From main that path is currently unreachable (the status service is hosted in main, awaited before the startup tasks run, and a same-process `get` returns the local proxy — a synchronous in-memory read), so this is insurance, not a fix for an observed failure; the ADR says so plainly.

**Rebased onto `main`** (`cbecad7f1cb`). The ADR entry is no longer numbered. `main` appended its own `ADR-0027` while this branch carried one, so this rebase landed two identical headings — precisely the collision the log's own guidance warns about and asks the second merger to fix by hand. The entry is now **`ADR-startup-sync-readiness-gate`**, and the log's guidance and entry template prescribe a kebab-case slug claimed at write time; entries written before this keep their `ADR-NNNN` headings. Note the *first* commit's message still says "Recorded in ADR-0013" — stale; worth fixing in the squash message.

## Files, in reading order

| File | ± | What it is |
| --- | --- | --- |
| **`src/main/startup-readiness.util.ts`** | +370 | **Start here.** The whole gate: two phases plus `settleWithin`, which bounds both against one monotonic deadline. |
| `src/main/startup-tasks.ts` | +180/−47 | Wires the gate into the Simple branch; extracts `evaluateSimpleModeSyncGates` so it can run before **and** after the wait. |
| `src/main/services/shutdown-latch.service.ts` | +65 | Two predicates: `shouldWindowCloseAbortReadinessWait(platform)` and `canStartupSyncFireNow(windowCount, hasCreatedWindowThisProcess)` (see focus #2). |
| `src/main/main.ts` | +20/−9 | One call site now uses that predicate instead of an inline check. |
| `.context/standards/Architecture-Decisions.md` | +100/-11 | `ADR-startup-sync-readiness-gate` — why core keeps the trigger, and what was deferred; plus the switch to slug-named entries. |
| `src/renderer/hooks/use-project-picker-data.hook.ts` | +4 | **Comment only.** Cross-reference for a deliberately duplicated literal. |
| `*.test.ts` (3 files) | +877 | 76 tests (20 + 40 + 16). |

## Where to focus (the rest is fairly mechanical)

1. **`settleWithin` race ordering** (`startup-readiness.util.ts:115`) — the highest-risk logic here. Neither underlying call is cancellable or takes an `AbortSignal`, so without it the 120 s budget is decorative. Six abort re-checks exist because **abort must win the *report* even when it loses the race**: `'timed-out'` means *proceed*, so a quit misread as a timeout would fire a whole-workspace S/R into a connection `networkService.shutdown()` is tearing down. Details in the collapsed section below.
2. **The macOS lifecycle carve-out, now on its own signal** (rewritten in response to review — see "Review round 2"). Three pieces that have to be read together: `startupTasksAbort` aborts unconditionally on any shutdown, so **Power mode's boot-race loop is byte-for-byte what it is on `main`**; `startupReadinessAbort` carries the macOS exception and reaches only the Simple readiness wait; and `canStartupSyncFireNow` is re-checked live immediately before the command goes out. The subtle part worth a second pair of eyes: the Simple path must run on the readiness signal *throughout*, including its post-wait abort check, because a last-window close makes `isAppShuttingDown()` true and therefore aborts the shared signal on precisely the close the carve-out exists to survive. Re-checking the shared signal afterwards makes the whole carve-out unreachable — that was the first attempt, and there is now a test that fails if it comes back.
3. **Policy call:** is a 120 s worst case acceptable, and is firing anyway on timeout right (vs. skipping)? Current answer: delayed, never suppressed.

## Testing

Rebased onto `main` (`cbecad7f1cb`). The only conflict was the ADR log (both sides append at the end); the branch's source diff is unchanged apart from the ADR heading's slug and its one citation in `startup-tasks.ts`. The branch's own suites (`startup-readiness.util`, `startup-tasks`, `shutdown-latch.service` — 76 tests) re-run green on the new base.

**`npm test` — 1864 passing.** Five suites time out under CPU contention (`window-layout-persistence`, `theme.service`, and the `theme`/`scroll-group`/`web-view` service-hosts); all 106 of their tests pass in isolation, none import anything this branch touches, and the pattern is the documented multi-window flake rather than a regression. **`dotnet test` — 1580 passing, 0 failed.** **`typecheck:core`, `eslint`, and `prettier --check` clean** on all 9 changed files.

The 76 tests here were mutation-checked rather than just run: reverting the phase-1 fall-through, the windowless guard, the "no window yet" latch, the signal split, the backoff cadence, or the log sampling each fails at least one test. Note `typecheck` needs `npx ts-node ./.erb/scripts/generate-dev-build-info.ts` run once first, or it stops on the gitignored `release/app/buildInfo.json` before reaching this branch's files.

> ⚠️ **This cannot be verified end-to-end in this repo.** Core's `syncProjects` is a stub that throws — Studio patches in the real implementation. **Manual verification in Paratext 10 Studio is required before merge:** Simple mode, `firstRunComplete` + `syncOnStartup` both true, several locally-checked-out shared projects (ideally with DBL resources so the sync is slow) → restart → picker unlocks, and the sync still runs afterward.

<details>
<summary><b>How the gate works, and the <code>settleWithin</code> ordering</b></summary>

One monotonic deadline (`performance.now() + 120 s` — not wall clock, because this runs during OS cold boot, exactly when the wall clock gets stepped). Both phases spend from it.

- **Phase 1 — registered.** `waitForNetworkObject` for the PDPF advertising `platformScripture.USJ_Chapter`.
- **Phase 2 — answering.** Poll `getMetadataForAllProjectsWithoutRetries` until non-empty. Registration alone is not enough: the Scripture Extender is a *layering* factory whose `getAvailableProjects` fans out to the .NET base factories, so it can be registered while still unable to answer. Backoff mirrors the sibling boot-race loop (shared cadence for the first few attempts, then 2 s).

**`settleWithin`'s core trick: only one thing can reject.** The inner promise's success *and* failure are both funnelled into gate resolutions, and abort resolves too — so the `AsyncVariable`'s own timeout is the only path that can reject it. That is what lets the catch return `TIMED_OUT` unconditionally, with no string-matching on a rejection message.

Five ordering facts, in the order they bite:

1. **`promise.catch(() => undefined)` is line 120 — above every early return.** Both early exits walk away from a promise that may reject seconds later; attach the no-op handler after them and you have built an unhandled-rejection generator. Giving up only stops us awaiting — the abandoned call keeps running.
2. **`remainingMs <= 0` must fail fast.** `AsyncVariable` arms its timer only when the value is `> 0`; `-1` is its documented "no timeout" sentinel, but an unguarded `0` hits the same false branch and waits forever. Guarded twice on purpose — `:123`, and again at `:197` where the same value is handed to `waitForNetworkObject` as its own bound.
3. **First settlement wins, and the losers still run.** Every resolve is wrapped in `if (!gate.hasSettled)` — not for correctness (`resolveToValue` is already a no-op once settled) but because it logs "Ignoring subsequent resolution…" every time. Phase 2 calls `settleWithin` twice per iteration for up to 120 s; unguarded, that is a log flood. Same guard `network-object-status.service.ts` puts on its own gate.
4. **The abort listener is torn down in `finally`**, via a second `AbortController` passed as `{ signal: cleanup.signal }` — otherwise hundreds of calls leak listeners onto the caller's long-lived signal. `AsyncVariable` clears its own timer as it settles.
5. **Abort must beat timeout on the report.** The gate settles on whichever signal physically arrives first, so a quit landing in the same tick as an underlying rejection can lose the race. Both catch blocks therefore re-check `abortSignal?.aborted` (`:308`, `:331`), and `startup-tasks.ts:200` re-checks a sixth time — ordered *above* the `'timed-out'` warn, so a sync about to be skipped never logs "syncing anyway" first.

`settleWithin` rethrows `settled.error` rather than swallowing it, so each phase decides what an underlying failure means. Phase 2 treats a throwing probe as "not answering yet" and retries (the fan-out to a still-booting .NET process legitimately fails), but carries the message forward in `attemptDetail`, so a deadline hit right after a throw reports the real cause instead of a generic "no projects".

**Gates are evaluated twice.** The wait can park for 120 s; a user who flips to Power mode or turns off auto-sync while it is parked must not get a no-ID sync anyway. Each call independently re-reads all three settings, preserving the consent asymmetry exactly: unreadable `interfaceMode` → don't sync (Simple's no-ID sync would override a Power user's schedule); unreadable `firstRunComplete` → don't sync; unreadable `syncOnStartup` → **do** sync (a read failure shouldn't silently suppress a sync the user never declined).

</details>

<details>
<summary><b>Decisions, rejected alternatives, and what's knowingly left alone</b></summary>

**Rejected — have the S/R extension self-trigger at the end of its own activation.** The obvious alternative, and the one the ticket named as preferred. Sequential activation gives no guarantee it activates *after* `platform-scripture`; if it goes first you get the identical bug relocated into a repo core cannot test. Studio had also deliberately *removed* its own `Task.Run(SyncProjects)` self-trigger to make core the single trigger owner. Recorded in ADR-startup-sync-readiness-gate.

**Rejected — scoping the phase-2 probe with `includePdpFactoryIds`.** Looks like the fix for "one failing third-party factory blocks the gate", but it breaks the gate outright: `internalGetMetadata` forwards that filter to the factory *and* adds the factory's own id to `excludePdpFactoryIds` (`project-lookup.service-model.ts:444-452`), so a layering factory scoped to itself layers over nothing and reports zero projects forever.

**Rejected — `waitForDuration` for bounding.** It is `Promise.any([timeout, fn()])`, which swallows a fast rejection and turns it into a full-timeout `undefined` — converting 1 s retries into 30 s stalls.

**Knowingly left alone — Power mode** stays ungated against PDP readiness. Its freshness window is anchored to window-interactive time, so charging a 120 s readiness wait against it could silently *drop* a legitimate startup sync — trading a visible bug for an invisible one. ADR-startup-sync-readiness-gate marks it revisit-when-the-anchor-is-reworked.

**Known consequence:** a workspace with no local scripture projects never satisfies the probe, so it waits the full budget and warns on every boot before firing a sync that typically has nothing to do.

**Root cause is documented as plausible, not verified.** The intuitive explanation — the synchronous S/R handler blocking StreamJsonRpc's single message-read loop — was real but is *already fixed* in Studio, which offloads those handlers via `Task.Run` and has a regression test asserting it. The likelier remaining candidate is contention with `LocalParatextProjects.Initialize()`'s `ScrTextCollection.RefreshScrTexts()` scan, but nobody has instrumented it. The gate is deliberately mechanism-agnostic — it holds regardless of which contention dominates, which is the main reason to prefer it over trying to make the two workloads coexist.

</details>

<details>
<summary><b>Pre-PR review log</b> — findings raised and resolved before this PR was opened</summary>

The sections below are the output of `/review-paratext`: findings from four parallel analysis passes, what was fixed, and what was dismissed with reasoning. Useful if you want to know what has already been checked; not required reading to review the diff.

<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-4386-simple-startup-sync-race

**Base**: origin/main

**Date**: 2026-08-18

**Review model**: Claude Opus 5

**Files changed**: 9 in the commit (10 changed on disk; `package-lock.json` is a pre-existing, unrelated modification deliberately left out)

## Overview

In Simple interface mode the project picker never unlocked at startup, while the rest of the UI looked fully loaded. Core fired a whole-workspace Send/Receive as soon as its settings gates passed; in Paratext 10 Studio that command is served by the .NET data provider, and its Mercurial/DBL work starved the scripture project-data-provider factory that the picker waits on. Because extensions activate strictly sequentially, an extension blocked on the busy provider stalls `platform-scripture` behind it — and `platform-scripture` registers the Scripture Extender layering PDPF, the only factory advertising `platformScripture.USJ_Chapter`.

This adds a bounded, two-phase readiness gate in the main process (`startup-readiness.util.ts`): wait for that factory's network object to register, then poll until it actually answers a metadata probe, and only then fire the sync. Registration alone is insufficient because the Extender is a layering factory whose `getAvailableProjects` fans out to the .NET base factories, so it can be registered while still unable to answer. On timeout the sync fires anyway — delayed, never suppressed — and on a real quit it is skipped. Power mode is deliberately untouched.

## API Changes

None. All changed files are main-process or renderer-internal. Nothing touches `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `papi.d.ts`, or any extension's `src/types/*.d.ts`. `papi.d.ts` correctly did not regenerate, because nothing in `src/shared` changed. No public API surface is affected.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **`main.ts`: narrowing the startup-task abort to `isAppQuitRequested()` fixed macOS but opened a gap on Windows/Linux.** Clicking X on the last window runs the entire shutdown Send/Receive (`main.ts:998`) while the abort is still un-fired, because `app.quit()` — and therefore the quit flag — only happens at `window-all-closed` (`main.ts:1357`), which runs afterward. A startup sync could fire concurrently with the shutdown sync. _(fixed during review: extracted `shouldWindowCloseAbortStartupTasks(platform)` into `shutdown-latch.service.ts`, returning `isAppQuitRequested() || platform !== 'darwin'`; non-darwin has no stay-resident behavior, so the unconditional abort was always correct there)_ — _superseded in round 2: that predicate is now `shouldWindowCloseAbortReadinessWait` and governs only the Simple readiness wait_
- [x] **That `main.ts` lifecycle conditional had no test coverage at all** — no `main.test.ts` exists and no e2e test touches the path, so an accidental inversion would silently regress either the macOS fix or the shutdown guard. _(fixed during review: the extracted predicate is unit-tested in `shutdown-latch.service.test.ts` with two cases pinning both directions — macOS-without-quit must NOT abort, non-macOS-without-quit must)_
- [x] **Phase 1 had no test for the case its deadline race actually exists for.** All three phase-1 "timed-out" tests went through an immediately-rejecting mock or the zero-budget guard; none drove a genuinely hung `waitForNetworkObject` to the deadline. Since the same remaining budget is handed to both `waitForNetworkObject` and `settleWithin`, and `settleWithin` starts its timer marginally later, its deadline almost always fires first — so the untested path was the *typical* production timeout, not an edge case. _(fixed during review: added a hung-registration test mirroring the phase-2 equivalent, asserting the phase-1 reason specifically so it cannot pass by falling through to phase 2)_
- [x] **`settleWithin` hand-rolled `Promise.race` plus `setTimeout` for a timeout, against an explicit house rule.** `Code-Style-Guide.md:85` says "Avoid: raw `Promise.race` for timeouts", and `shared-store.service.ts:271-277` already solves this exact shape by bridging into an `AsyncVariable`, citing that rule. _(fixed during review: reworked onto `AsyncVariable`. Both of the wrapped promise's outcomes are funnelled into resolutions, so the gate's own timeout is the only thing that can reject it — no message-matching needed. All 47 gate tests passed unchanged, which is the evidence it is a faithful swap. Resolutions are guarded on `hasSettled`, matching `network-object-status.service.ts:53,56,64`, to suppress the duplicate-resolution logging the swap introduced)_

### Minor — Consider

- [x] **Post-wait settings re-read was only tested for one of the three gates** (`interfaceMode`); `firstRunComplete` and `syncOnStartup` were not pinned on the post-wait call. _(fixed during review: replaced the single test with three, one per gate, driven by an extracted `startupWithSettingsChangedDuringReadinessWait` helper; assertions kept inline so `vitest/expect-expect` still sees them)_
- [ ] ~~The two-phase backoff loop now exists twice — `pollUntilScriptureMetadataAnswers` and the pre-existing `requestSessionSyncWithBootRetry`.~~ _(Author asked for deduplication only if it made sense; on inspection it does not. The loops share only the cadence ternary — one returns a result object, routes both awaits through `settleWithin`, re-checks abort at four points and accumulates a detail; the other throws on non-retryable errors and on deadline, has a freshness gate, and uses a bare `wait()`. A shared `backoffIntervalMs(attempt, initialAttempts, initialMs, extendedMs)` would replace a self-explanatory ternary with a four-argument call whose two adjacent number parameters can be silently transposed — worse to read and a new failure mode, to remove one line. The constants underneath are already shared: both alias `MAX_REQUEST_ATTEMPTS`/`REQUEST_ATTEMPT_WAIT_TIME_MS` from `rpc.model`.)_
- [x] **`platform.interfaceMode` is read twice on every Simple-mode startup** — once to branch power/simple, then again inside `evaluateSimpleModeSyncGates()`. _(Author asked for a recommendation; the recommendation was to keep it, because the two reads answer different questions: the first asks "which mode, and can we tell at all?" — an unreadable mode there skips the automatic sync for BOTH modes — while the second asks "is it STILL simple?", which must be fresh, since that is the entire point of the post-wait call. Sharing one read would require passing a pre-read value in and branching, making the pre- and post-wait calls asymmetric; that symmetry is what makes the post-wait check obviously correct. fixed during review: added a comment at the helper recording this, so it is not later "optimized" away)_

### Template Propagation

#### Shared Regions Modified

None. No `#region shared with` markers exist in any changed file.

#### Extension Config Changes

None. No files under `extensions/` were changed.

## Positive Observations

- The gate reuses proven idioms rather than inventing mechanisms: the same `waitForNetworkObject({ objectType, attributes: { projectInterfaces } })` shape `getMetadataForProject` already uses, `escapeStringRegexp` for the regex-matched `includeProjectInterfaces` field, and the `MAX_REQUEST_ATTEMPTS`/`REQUEST_ATTEMPT_WAIT_TIME_MS` constants aliased rather than re-declared.
- Comments were spot-checked against the code they cite — the lookup service's fan-out-then-filter ordering, its layering-filter behavior, `areProjectInterfacesIncluded`'s unanchored `.test()` matching, `activateExtensions`' sequential loop, and `main.ts`'s darwin `window-all-closed` behavior — and were accurate.
- `evaluateSimpleModeSyncGates` is a clean extraction that preserves the previous per-setting semantics exactly while enabling the before/after-wait re-evaluation without duplicating the three checks.
- Tests are behavior-focused and genuinely falsifiable: same-tick abort-vs-rejection ordering in both phases, the "at least one probe even if registration consumed the budget" guarantee, pinned backoff cadence, and `vi.waitFor` rather than fixed microtask flushes (which would have made the "does not fire until readiness resolves" assertion vacuously true).
- `settleWithin` correctly avoids leaking listeners on the long-lived shared `abortSignal` by registering with `{ signal: cleanup.signal }` and aborting the cleanup controller in `finally` — important because phase 2 calls it repeatedly against the same signal.
- The fix is applied at the right layer. The picker's existing spinner/empty-state (`project-picker.component.tsx:225-233`) and its own PDPF-registration refresh are left untouched; the change lets that existing affordance succeed rather than papering over a contention bug with new UI.
- ADR-startup-sync-readiness-gate records the decision with concrete rejected alternatives and an honest statement of what is still unresolved.

## Interview Notes

**Stated purpose (author-approved wording):** Fix the Simple-mode project picker never unlocking at startup (PT-4386), by making core wait — bounded — for the scripture project data provider factories to be registered and answering before firing the startup Send/Receive.

**Decisions the author made during this work:** the strength of the readiness gate (registered *and* answering, rather than registration alone); leaving Power mode knowingly ungated; the 120 s budget; folding the feature and review fixes into a single commit; excluding `package-lock.json` from the commit; and requiring that the ADR entry be justified rather than written by default — the author pushed back with "if we are adding something to the ADR, please make really sure it is the right call", which narrowed ADR-startup-sync-readiness-gate to the cross-repo and deferral decisions and moved mechanism detail into TSDoc.

**Author response to findings:** approved both `main.ts` fixes; approved the phase-1 test as "meaningful and not more work than it's worth"; approved the `AsyncVariable` rework; asked for the post-wait gate tests; delegated the backoff-deduplication judgment ("if it makes sense to") and asked for a recommendation on the double settings read. Nothing further flagged at wrap-up.

**Author's design walkthrough.** The author gave an unprompted, detailed walkthrough of the change in their own words, and it was verified against the code — the mechanisms, the rationale, and the cited line numbers all check out. It covered:

- The starvation chain end to end: no-ID `syncProjects` → saturated .NET provider → sequential extension activation stalling `platform-scripture` → the Scripture Extender PDPF (the only factory advertising `platformScripture.USJ_Chapter`) never registering → picker times out while the rest of the UI looks fine.
- Why the obvious alternative was rejected: sequential activation gives no guarantee `paratextBibleSendReceive` activates after `platform-scripture`, so a self-trigger relocates the identical bug into a repo core cannot test — and Studio had already removed its own self-trigger to make core the single owner.
- Why the deadline is monotonic (`performance.now()`): this runs during OS cold boot, precisely when the wall clock gets stepped.
- Why registration alone is insufficient: the Extender is a layering factory whose `getAvailableProjects` fans out to the .NET base factories, so it can be registered while still unable to answer — hence the second phase.
- **The five ordering facts in `settleWithin`** (`startup-readiness.util.ts:115`), which is the subtlest part of the change: (1) the no-op `promise.catch` at :120 must precede *every* early return, or the early exits become an unhandled-rejection generator; (2) `remainingMs <= 0` must fail fast because `AsyncVariable` only arms its timer for `> 0`, so an unguarded `0` waits forever — guarded twice, at :123 and again at :197 where the same value is handed to `waitForNetworkObject` as its own bound; (3) `hasSettled` guards exist for log noise, not correctness, because phase 2 calls `settleWithin` twice per iteration for up to 120 s; (4) the abort listener is torn down in `finally` via a second controller so hundreds of calls do not leak listeners onto the caller's long-lived signal; (5) **abort must beat timeout on the *report* even when it lost the race** — hence the re-checks at :308 and :331, and a sixth in `startup-tasks.ts:200` ordered above the `'timed-out'` warn. The author correctly identified why this is not cosmetic: `'timed-out'` means *proceed*, so a quit misread as a timeout fires a whole-workspace S/R into a connection `networkService.shutdown()` is tearing down.
- The funnel as the load-bearing trick: both of the wrapped promise's outcomes resolve the gate, so the `AsyncVariable`'s own timeout is the only path that can reject — which is what lets the catch return `TIMED_OUT` with no string matching on the rejection message.
- Why `settleWithin` rethrows rather than swallowing, so each phase decides what an underlying failure means, with `attemptDetail` carrying the real cause forward so a deadline hit right after a throw does not report the generic "no projects".
- The consent asymmetry preserved across both gate evaluations (unreadable `interfaceMode` → don't sync; unreadable `firstRunComplete` → don't sync; unreadable `syncOnStartup` → do sync).
- The `shouldWindowCloseAbortStartupTasks` wrinkle in both directions (renamed `shouldWindowCloseAbortReadinessWait` in round 2, and narrowed to the Simple readiness wait): on macOS the quit flag decides because the app stays resident and startup tasks run once per process; off macOS the platform decides because `window-all-closed` calls `app.quit()` only *after* the close handlers have run, so the flag arrives too late to protect the very window the guard covers.

**The honest caveat that remains:** the code was AI-generated, and several of the defects fixed during this review were introduced by that generation — including the Windows/Linux shutdown-race regression created by the first attempt at the macOS fix. What the walkthrough demonstrates is that the author has command of the design and its failure modes, not that the code was hand-written. Treat the review as a check on the implementation, not on whether the author understands it.

**Context a reviewer needs, which is not visible from the diff:**

- **This fix cannot be verified end-to-end in this repo.** Core's `syncProjects` is a stub that throws `PlatformUnimplementedException`; the real implementation is patched in by Paratext 10 Studio. No core unit test or e2e test can exercise the actual resource contention. Manual verification in Studio is required: Simple mode, `firstRunComplete` and `syncOnStartup` both true, several locally-checked-out shared projects (ideally with DBL resources so the sync is slow), restart, and confirm the picker unlocks and the sync still runs afterward.
- **The root-cause mechanism is recorded as plausible, not verified.** The intuitive explanation — the synchronous S/R handler blocking StreamJsonRpc's single message-read loop — was real but is already fixed in Studio, which offloads those handlers via `Task.Run` and has a regression test asserting it. The likelier remaining candidate is contention with `LocalParatextProjects.Initialize()`'s `ScrTextCollection.RefreshScrTexts()` scan, but nobody has instrumented it. The gate is deliberately mechanism-agnostic: it holds regardless of which contention dominates, which is the main reason to prefer it over trying to make the two workloads coexist.
- **Power mode keeps the same latent race, knowingly.** Applying the gate there would charge the wait against its window-interactive freshness window and could silently *drop* a legitimate startup sync — trading a visible bug for an invisible one. Recorded in ADR-startup-sync-readiness-gate; a follow-up ticket has not yet been filed.
- **Two review suggestions were deliberately NOT implemented, because they would have caused harm.** Scoping the phase-2 probe with `includePdpFactoryIds` would break the gate outright — the lookup service forwards that filter to the factory *and* adds the factory's own id to `excludePdpFactoryIds` (`project-lookup.service-model.ts:444-452`), so a layering factory scoped to itself layers over nothing and reports zero projects forever. And `waitForDuration` was rejected for bounding because it is `Promise.any([timeout, fn()])`, which swallows a fast rejection and turns it into a full-timeout `undefined`, converting 1 s retries into 30 s stalls.
- **A known consequence:** a workspace with no local scripture projects never satisfies the probe, so it waits the full budget and then warns on every boot before firing a sync that typically has nothing to do.

## In-Review Quality Check

Changes were made during the interview, so the full check was run afterward. **No fixes were required; nothing new needed staging.**

- **typecheck** — fails only with a known pre-existing, environmental error: `src/main/services/app.service-host.ts` cannot resolve `release/app/buildInfo.json`, a gitignored build artifact never generated in this worktree. Not in the changed-file set.
- **lint** — full repo-wide run completed, workspace lint exit code 0. The only error anywhere was the same pre-existing `buildInfo.json` unresolved-module error. All other output was pre-existing warnings in files this branch never touched. **None of the 9 changed files produced any lint output.**
- **format** — scoped prettier over the changed files reported all of them unchanged; `Architecture-Decisions.md` confirmed clean via `--check`. `package-lock.json` untouched.
- **test** — `src/main/` is 333 passing across 18 files. Full `test:core` matched the pre-existing baseline at 1804/1805; the single failure (`web-view.service-host.test.ts`, `Test timed out in 5000ms`) passed cleanly in isolation and is the documented flaky multi-window pattern, not a regression. A broader all-workspaces run was abandoned after severe machine-level CPU contention made even trivial shell commands stall; no failure in it was in a changed file or its dependents.

## Suggested Review Focus

Prioritized agenda for the author–reviewer meeting:

- [ ] **Scrutinize `settleWithin`'s race ordering** (`startup-readiness.util.ts:115`). It is the load-bearing primitive — it makes the 120 s budget a real ceiling over two uncancellable calls that take no `AbortSignal`. The author's walkthrough (see Interview Notes) already lays out the five ordering facts and they check out against the code, so this is not a knowledge gap to close; it is the highest-risk logic in the diff and deserves a second pair of eyes on the ordering itself — particularly the six abort re-checks and whether any path can still report `'timed-out'` (which means *proceed*) for what was actually a quit.
- [x] **The `main.ts` lifecycle change** — reworked in review round 2. The shared abort is unconditional again (Power mode unchanged), the macOS exception moved to `startupReadinessAbort`, and `canStartupSyncFireNow` stops a surviving wait firing into a windowless app. Still worth confirming: that the three-part interaction reads correctly, and that "no window yet" vs "went windowless" is the right distinction.
- [ ] **Is a 120 s worst-case delay to the startup sync acceptable?** And is firing anyway on timeout the right call versus skipping? The current answer is "delayed, never suppressed."
- [ ] **The empty-workspace cost.** A workspace with no local scripture projects burns the full budget and warns every boot. Is that acceptable, or should "no factories at all" be distinguished from "factories reporting nothing"?
- [ ] **Power mode is knowingly left with the same latent race.** Confirm the deferral, and agree who files the follow-up ticket. (Round 2 made "Power mode unchanged" literally true — the shared abort no longer branches on platform — but the *readiness* deferral still stands and still has no ticket.)
- [ ] **The empty-workspace probe cost, revisited.** Raised in review and deliberately not changed: capping probes, or treating registered-but-empty as ready after N attempts, would reintroduce the original race for exactly the slow workspaces that suffer it worst. The version worth considering later is distinguishing *answered-with-empty* from *did not answer* — a successful `[]` is an answer — but that changes the gate's core predicate and would need the Studio verification redone.
- [ ] **Manual verification in Paratext 10 Studio is mandatory before merge** — no automated test in this repo can exercise the real contention.
- [ ] **The root cause is documented as unverified.** Decide whether that is acceptable to merge on, given the fix is deliberately designed to hold regardless of which contention dominates.
<!-- review-paratext:summary:end -->

</details>

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2693)
<!-- Reviewable:end -->




