### PR TITLE
Stop the BookChapterControl reopen test flaking on slow CI workers

### DIFF
--- a/lib/platform-bible-react/src/components/advanced/book-chapter-control/book-chapter-control.component.test.tsx
+++ b/lib/platform-bible-react/src/components/advanced/book-chapter-control/book-chapter-control.component.test.tsx
@@ -69,6 +69,10 @@ describe('BookChapterControl imperative handle', () => {
     });
   });
 
+  // This is the only test here that drives the whole popover through userEvent — opening the
+  // book list, drilling into chapters, closing, then reopening. In jsdom that is heavy enough
+  // to overrun the 5s default on a contended CI worker (observed at ~5.4s on Windows), so it
+  // gets explicit headroom rather than being left to flake.
   test('open() resets a stale chapters view back to books view and focuses the search input', async () => {
     const handleRef = createRef<BookChapterControlHandle>();
     // Radix popovers rely on PointerEvent sequences that jsdom lays out poorly;
@@ -109,7 +113,7 @@ describe('BookChapterControl imperative handle', () => {
       expect(input).not.toBeNull();
       expect(input).toHaveFocus();
     });
-  });
+  }, 30_000);
 
   test('disabled prop disables the trigger button', () => {
     render(


### PR DESCRIPTION
## Summary

One test in `book-chapter-control.component.test.tsx` timed out on a Windows CI worker and failed the build on `main` ([run 32267047403](https://github.com/paranext/paranext-core/actions/runs/32267047403/job/96113970076)). It is the only test in that file that drives the whole popover through `userEvent` — open the book list, drill into chapters, escape, reopen — and it overran vitest's 5s default at ~5.4s. Everything else in that run passed.

It is not a regression. The merge it landed on (#2683, Sync button in Simple mode) touches the toolbar, extension service, and `platform-get-resources` — nothing near this component. The same test passed on Linux in the same run, and locally the whole file runs in ~3.4s with this test at ~1.5s. The runner was heavily contended (vitest reported `prepare 6957s`).

### Why review this

Not part of the current epic. CI hygiene: `main` went red on a flaky timeout with no code cause, so the next person to push had a red baseline to explain away. Small and self-contained.

## Changes

- Raise the timeout for that single test to 30s, with a comment explaining why it is the expensive one.

Deliberately per-test rather than a suite-wide `testTimeout` in `vitest.config.ts`, so a genuine hang anywhere else in `platform-bible-react` still fails fast instead of hanging for 30s.

## AI Involvement

AI-assisted. Claude diagnosed the CI failure, confirmed the merged PR did not touch the component, and wrote the one-line timeout change and its comment. Reviewed by me before pushing.

## Testing

- [x] `book-chapter-control.component.test.tsx` passes locally (7/7)
- [x] Prettier clean
- [ ] Full CI on this PR

## Risk Level

Low - test-only change; no production code touched, no assertions altered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2694)
<!-- Reviewable:end -->
