### PR TITLE
PT-3780: Put the insertion point inside a marker added in a footnote

### DIFF
--- a/extensions/src/platform-scripture-editor/package.json
+++ b/extensions/src/platform-scripture-editor/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@dreamsicle.io/stylelint-config-tailwindcss": "^1.2.2",
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
-    "@eten-tech-foundation/platform-editor": "~0.8.14",
+    "@eten-tech-foundation/platform-editor": "~0.8.15",
     "@eten-tech-foundation/scripture-utilities": "~0.1.6",
     "@stylistic/eslint-plugin-ts": "^2.13.0",
     "@swc/core": "1.13.3",

--- a/extensions/src/platform-scripture-editor/src/character-marker-bar/use-remove-character-marker.hook.ts
+++ b/extensions/src/platform-scripture-editor/src/character-marker-bar/use-remove-character-marker.hook.ts
@@ -102,9 +102,10 @@ export function useRemoveCharacterMarker({
       // only part of a NESTED marker whose OUTER marker is the target. That case still takes a
       // snapshot for an edit that does not happen, and still reports nothing to the user. It is
       // reachable only in theory today (`isMarkerRowInert` disables the row that would ask for it),
-      // which is why it is documented rather than defended against: the defense needs an outcome
-      // signal the editor does not expose — either a return value from `removeCharacterMarker`, or
-      // the discrete-update-plus-inline-re-derive that `applyUpdate` does elsewhere in this feature.
+      // which is why it is documented rather than defended against: the defense needs this hook to
+      // consume an outcome signal — either the boolean `removeCharacterMarker` returns, which the
+      // call above discards, or the discrete-update-plus-inline-re-derive that `applyUpdate` does
+      // elsewhere in this feature.
       //
       // A before/after `getUsj()` comparison cannot stand in for either: `getUsj()` returns
       // `editedUsjRef.current`, a cached ref, and the

--- a/extensions/src/platform-scripture-editor/src/character-marker-bar/use-remove-character-marker.hook.ts
+++ b/extensions/src/platform-scripture-editor/src/character-marker-bar/use-remove-character-marker.hook.ts
@@ -102,17 +102,14 @@ export function useRemoveCharacterMarker({
       // only part of a NESTED marker whose OUTER marker is the target. That case still takes a
       // snapshot for an edit that does not happen, and still reports nothing to the user. It is
       // reachable only in theory today (`isMarkerRowInert` disables the row that would ask for it),
-      // which is why it is documented rather than defended against: the defense needs this hook to
-      // consume an outcome signal — either the boolean `removeCharacterMarker` returns, which the
-      // call above discards, or the discrete-update-plus-inline-re-derive that `applyUpdate` does
-      // elsewhere in this feature.
+      // which is why it is documented rather than defended against.
       //
-      // A before/after `getUsj()` comparison cannot stand in for either: `getUsj()` returns
-      // `editedUsjRef.current`, a cached ref, and the
-      // `editor.update()` inside `removeCharacterMarker` runs without `{ discrete: true }`, so
-      // Lexical defers the commit and that ref is not refreshed synchronously — a before/after
-      // comparison would read the same stale object and report "unchanged" for every successful
-      // removal, not just the declined ones.
+      // The signal to defend with is already there: `removeCharacterMarker` returns `true` only when
+      // a marker was actually removed, and the call above discards it. The return is trustworthy —
+      // the editor runs its `update()` with `{ discrete: true }` precisely so the boolean cannot
+      // report `false` for a removal that happened. Consuming it means moving the snapshot after the
+      // call (or rolling it back), so it is a restructure of this handler, not a one-line change.
+      // TODO(PT-4394): consume the outcome and skip/undo the empty restore point.
     },
     [editorRef, projectId, isSyncBlocked, localizedStrings],
   );

--- a/extensions/src/platform-scripture-editor/src/character-marker-menu.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/character-marker-menu.utils.test.ts
@@ -139,12 +139,12 @@ describe('generateCharacterMarkerMenuListItems', () => {
     expect(close).toHaveBeenCalledTimes(1);
   });
 
-  it('does not add the marker when one is applied but change is not available yet', () => {
-    // `EditorRef` exposes no replace-character-marker operation, so a caller has no
-    // `changeCharacterMarker` to pass. Picking a marker must NOT fall back to `insertMarker`:
-    // inserting over an existing character marker nests it (verified against the editor package —
-    // `getUsjMarkerAction('bd')` over a selection inside a `\nd` CharNode yields
-    // `char:nd > char:bd`), and nesting survives into the saved USJ. Inert is the safe behavior.
+  it('does not add the marker when one is applied but no change operation was supplied', () => {
+    // `changeCharacterMarker` is optional, and the production caller omits it. Picking a marker in
+    // that state must NOT fall back to `insertMarker`: inserting over an existing character marker
+    // nests it (verified against the editor package — `getUsjMarkerAction('bd')` over a selection
+    // inside a `\nd` CharNode yields `char:nd > char:bd`), and nesting survives into the saved USJ.
+    // Inert is the safe behavior.
     const { ref, insertMarker } = makeMockEditorRef();
     const close = vi.fn();
     const items = generateCharacterMarkerMenuListItems(ref, close, {}, PARENT, {

--- a/extensions/src/platform-scripture-editor/src/character-marker-menu.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/character-marker-menu.utils.test.ts
@@ -360,7 +360,7 @@ describe('generateCharacterMarkerMenuListItems', () => {
     expect(changeCharacterMarker).not.toHaveBeenCalled();
   });
 
-  it('leaves a partially-covering marker row inert (extend is not an editor operation yet)', () => {
+  it('leaves a partially-covering marker row inert (this menu has no extend operation)', () => {
     const { ref, insertMarker } = makeMockEditorRef();
     const close = vi.fn();
     const removeCharacterMarker = vi.fn();

--- a/extensions/src/platform-scripture-editor/src/character-marker-menu.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/character-marker-menu.utils.ts
@@ -67,10 +67,11 @@ function isMarkerRowInert(
   canRemove: boolean,
   canChange: boolean,
 ): boolean {
-  // Extending a partially-covering marker over the rest of the selection needs an extend operation
-  // the editor does not expose yet.
+  // Extending a partially-covering marker over the rest of the selection needs the editor's extend
+  // operation. The editor exposes one, but nothing here supplies it yet, so the row stays inert.
   if (selectionState === 'partial') return true;
-  // Covers everything, so the action is a toggle-off — inert only if removal does not exist yet.
+  // Covers everything, so the action is a toggle-off — inert only if no remove operation was
+  // supplied.
   if (selectionState === 'all') return !canRemove;
   // Nothing applied: picking a marker adds it, which always works.
   if (!currentCharacterMarker) return false;
@@ -98,7 +99,7 @@ function isMarkerRowInert(
  *   marker.
  * @param characterMarkerOptions The character marker applied at the current selection, the
  *   selection's per-marker coverage, plus the optional editor operations for acting on them. Each
- *   operation is optional because the editor does not expose all of them yet; omit an operation to
+ *   operation is optional because not every caller wires up all of them; omit an operation to
  *   disable the actions that need it. With no `changeCharacterMarker`, picking a marker while one
  *   is applied does nothing — it never falls back to adding, because adding nests.
  * @returns The list of character marker menu items, sorted by marker code. Empty when
@@ -125,15 +126,15 @@ export function generateCharacterMarkerMenuListItems(
      * menu is closed, and when the selection cannot be resolved against the editor's USJ.
      *
      * It decides both what each row DOES and what it shows: a row whose marker covers the whole
-     * selection removes it, a partially-covering row is inert (extending it needs an editor
-     * operation that does not exist yet), and a mixed selection swaps the single remove row for a
-     * remove-all row. Both halves of that live here rather than being stamped on afterwards, so one
-     * decision is not split across two files.
+     * selection removes it, a partially-covering row is inert (extending it needs the editor's
+     * extend operation, which nothing here supplies yet), and a mixed selection swaps the single
+     * remove row for a remove-all row. Both halves of that live here rather than being stamped on
+     * afterwards, so one decision is not split across two files.
      */
     coverage?: CharacterMarkerCoverage;
     /**
-     * Replaces the applied character marker with the picked one. `EditorRef` exposes no
-     * replace-character-marker operation yet, so supply this only once it does; while it is absent,
+     * Replaces the applied character marker with the picked one. `EditorRef` exposes a
+     * replace-character-marker operation, but no caller wires this to it yet; while this is absent,
      * every marker row is inert whenever a character marker is applied. It does **not** fall back
      * to `insertMarker`, because inserting over an existing character marker nests it rather than
      * replacing it (verified against the editor package — see the comment at the call site).
@@ -221,8 +222,8 @@ export function generateCharacterMarkerMenuListItems(
             // selection state is excluded by default rather than falling into the insert path.
             //
             // The two states it excludes, and why: 'partial' — extending the marker over the rest of
-            // the selection needs an editor operation that does not exist yet, and `insertMarker`
-            // would nest rather than extend. 'all' — handled above, but without a
+            // the selection needs the editor's extend operation, which nothing here supplies yet,
+            // and `insertMarker` would nest rather than extend. 'all' — handled above, but without a
             // `removeCharacterMarker` (the option is typed optional) it would otherwise fall through
             // here and nest a duplicate marker.
             else if (selectionState === 'none' || selectionState === undefined) {

--- a/extensions/src/platform-scripture-editor/src/character-marker-menu.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/character-marker-menu.utils.ts
@@ -68,7 +68,11 @@ function isMarkerRowInert(
   canChange: boolean,
 ): boolean {
   // Extending a partially-covering marker over the rest of the selection needs the editor's extend
-  // operation. The editor exposes one, but nothing here supplies it yet, so the row stays inert.
+  // operation. The editor exposes one, but nothing here reaches it: `characterMarkerOptions` has no
+  // extend entry and this function takes no `canExtend`, so the row is inert unconditionally and no
+  // caller can make it live.
+  // TODO(PT-4394): add an extend option and a `canExtend` branch, wired to
+  // `EditorRef.extendCharacterMarker`.
   if (selectionState === 'partial') return true;
   // Covers everything, so the action is a toggle-off — inert only if no remove operation was
   // supplied.
@@ -99,9 +103,10 @@ function isMarkerRowInert(
  *   marker.
  * @param characterMarkerOptions The character marker applied at the current selection, the
  *   selection's per-marker coverage, plus the optional editor operations for acting on them. Each
- *   operation is optional because not every caller wires up all of them; omit an operation to
- *   disable the actions that need it. With no `changeCharacterMarker`, picking a marker while one
- *   is applied does nothing — it never falls back to adding, because adding nests.
+ *   operation is optional so a caller can offer only the actions it supports; omit an operation to
+ *   disable the actions that need it. The one production caller supplies `removeCharacterMarker`
+ *   only, so with no `changeCharacterMarker`, picking a marker while one is applied does nothing —
+ *   it never falls back to adding, because adding nests.
  * @returns The list of character marker menu items, sorted by marker code. Empty when
  *   `parentMarker` is absent or contributes no character markers — whether it has no children at
  *   all (e.g. `c`) or only non-character children (e.g. `mt`). That wins over the remove row, so
@@ -127,17 +132,21 @@ export function generateCharacterMarkerMenuListItems(
      *
      * It decides both what each row DOES and what it shows: a row whose marker covers the whole
      * selection removes it, a partially-covering row is inert (extending it needs the editor's
-     * extend operation, which nothing here supplies yet), and a mixed selection swaps the single
+     * extend operation, which this menu has no option for), and a mixed selection swaps the single
      * remove row for a remove-all row. Both halves of that live here rather than being stamped on
      * afterwards, so one decision is not split across two files.
      */
     coverage?: CharacterMarkerCoverage;
     /**
      * Replaces the applied character marker with the picked one. `EditorRef` exposes a
-     * replace-character-marker operation, but no caller wires this to it yet; while this is absent,
+     * replace-character-marker operation, but no caller wires this to it; while this is absent,
      * every marker row is inert whenever a character marker is applied. It does **not** fall back
      * to `insertMarker`, because inserting over an existing character marker nests it rather than
      * replacing it (verified against the editor package — see the comment at the call site).
+     *
+     * TODO(PT-4394): wire this to `EditorRef.replaceCharacterMarker`. Note that operation throws in
+     * readonly mode and on unsupported markers, so the caller needs the same error handling the
+     * remove path has.
      */
     changeCharacterMarker?: (fromMarker: string, toMarker: string) => void;
     /**
@@ -222,7 +231,7 @@ export function generateCharacterMarkerMenuListItems(
             // selection state is excluded by default rather than falling into the insert path.
             //
             // The two states it excludes, and why: 'partial' — extending the marker over the rest of
-            // the selection needs the editor's extend operation, which nothing here supplies yet,
+            // the selection needs the editor's extend operation, which this menu has no option for,
             // and `insertMarker` would nest rather than extend. 'all' — handled above, but without a
             // `removeCharacterMarker` (the option is typed optional) it would otherwise fall through
             // here and nest a duplicate marker.

--- a/extensions/src/platform-scripture-editor/src/editor-character-marker-contract.test.ts
+++ b/extensions/src/platform-scripture-editor/src/editor-character-marker-contract.test.ts
@@ -32,8 +32,8 @@ const REQUIRED_EDITOR_REF_MEMBERS = [
   'removeCharacterMarker(marker?: string): boolean;',
   // The operation `changeCharacterMarker` adapts. NOTE THE ARGUMENT ORDER — see below.
   'replaceCharacterMarker(toMarker: string, fromMarker?: string): boolean;',
-  // Nothing supplies this yet (TODO(PT-4394)); pinned so the partial-coverage row can be wired
-  // against a known shape rather than a guess.
+  // This menu has no extend option yet (TODO(PT-4394)); pinned so the partial-coverage row can be
+  // wired against a known shape rather than a guess.
   'extendCharacterMarker(marker: string, conflictingMarkers?: readonly string[]): boolean;',
 ];
 

--- a/extensions/src/platform-scripture-editor/src/editor-character-marker-contract.test.ts
+++ b/extensions/src/platform-scripture-editor/src/editor-character-marker-contract.test.ts
@@ -1,0 +1,89 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+/*
+ * Guards the character-marker slice of `EditorRef` against the INSTALLED
+ * `@eten-tech-foundation/platform-editor`. Nothing else in this extension does.
+ *
+ * Every character-marker suite supplies its own `EditorRef` stub (`vi.mock`, plus partial refs cast
+ * through `as unknown as MutableRefObject<EditorRef | null>`), so those tests pass no matter what
+ * the package actually ships. `tsc` covers the members this extension calls on a typed `EditorRef`
+ * — but not `changeCharacterMarker`, which is hand-declared as an adapter in
+ * `character-marker-menu.utils.ts` and `use-character-marker-state.hook.ts` and never tied to the
+ * package, so no compiler check connects the two. That is the hole this fills: a 0.8.15-only
+ * operation sat referenced-but-unreachable behind a 0.8.14 pin without any test noticing.
+ *
+ * Reads the resolved package's type declarations rather than importing it: `EditorRef` is a type,
+ * so there is no runtime object to reflect over without mounting a Lexical editor in jsdom. Reading
+ * whatever is RESOLVED is the point — a fresh clone gets the published tarball and a linked
+ * developer gets the yalc build, and either one drifting from these signatures is a real break.
+ */
+
+const require = createRequire(import.meta.url);
+const SRC_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+/** Members this extension relies on, with the exact signature it relies on them having. */
+const REQUIRED_EDITOR_REF_MEMBERS = [
+  // Called directly by `use-remove-character-marker.hook.ts`. The `boolean` matters: it is the
+  // outcome signal that tells a declined removal from a real one.
+  'removeCharacterMarker(marker?: string): boolean;',
+  // The operation `changeCharacterMarker` adapts. NOTE THE ARGUMENT ORDER — see below.
+  'replaceCharacterMarker(toMarker: string, fromMarker?: string): boolean;',
+  // Nothing supplies this yet (TODO(PT-4394)); pinned so the partial-coverage row can be wired
+  // against a known shape rather than a guess.
+  'extendCharacterMarker(marker: string, conflictingMarkers?: readonly string[]): boolean;',
+];
+
+/** Source files that hand-declare the `changeCharacterMarker` adapter, and the shape they declare. */
+const ADAPTER_DECLARATION_FILES = [
+  'character-marker-menu.utils.ts',
+  'use-character-marker-state.hook.ts',
+];
+const CHANGE_ADAPTER_DECLARATION =
+  'changeCharacterMarker?: (fromMarker: string, toMarker: string) => void;';
+
+/** Whitespace-insensitive haystack, so d.ts reformatting alone can't fail this. */
+function collapseWhitespace(text: string): string {
+  return text.replace(/\s+/g, ' ');
+}
+
+function readInstalledEditorTypes(): string {
+  const packageJsonPath = require.resolve('@eten-tech-foundation/platform-editor/package.json');
+  const packageJson: { types?: string } = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  if (!packageJson.types)
+    throw new Error('@eten-tech-foundation/platform-editor declares no `types` entry');
+  return readFileSync(path.join(path.dirname(packageJsonPath), packageJson.types), 'utf-8');
+}
+
+describe('EditorRef character-marker contract (installed platform-editor)', () => {
+  it('declares every character-marker operation this extension depends on', () => {
+    const types = collapseWhitespace(readInstalledEditorTypes());
+
+    // Asserted as a list of what's missing rather than one expectation per member, so a failure
+    // names every absent signature at once instead of stopping at the first.
+    const missing = REQUIRED_EDITOR_REF_MEMBERS.filter(
+      (member) => !types.includes(collapseWhitespace(member)),
+    );
+
+    expect(missing).toEqual([]);
+  });
+
+  it('keeps the hand-declared change adapter paired with the editor operation it adapts', () => {
+    // `changeCharacterMarker(fromMarker, toMarker)` takes its arguments in the OPPOSITE order from
+    // `replaceCharacterMarker(toMarker, fromMarker)`, and both are `string`, so a wiring that
+    // forwards positionally would compile and silently swap the two markers. Whoever wires this up
+    // under PT-4394 must adapt, not forward — and if either side's parameter names change, this
+    // fails so the pairing is re-checked rather than assumed.
+    const filesMissingAdapter = ADAPTER_DECLARATION_FILES.filter(
+      (file) =>
+        !collapseWhitespace(readFileSync(path.join(SRC_DIR, file), 'utf-8')).includes(
+          CHANGE_ADAPTER_DECLARATION,
+        ),
+    );
+
+    expect(filesMissingAdapter).toEqual([]);
+  });
+});

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -1490,8 +1490,13 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
       return;
     }
     pendingScaffoldInsertRef.current = true;
-    // Undo for this insert relies on `applyUpdate('local')` edits staying undoable, which the
-    // pinned `@eten-tech-foundation/platform-editor` provides.
+    // Undo for this insert depends on the editor keeping its history across the `onUsjChange` round
+    // trip this call sets off: the editor's state-load effect fires Lexical's
+    // `CLEAR_HISTORY_COMMAND` unconditionally, so anything that re-runs it moments after an edit
+    // wipes the undo stack. `@eten-tech-foundation/platform-editor` 0.8.15 is the first published
+    // version that holds that effect's inputs stable BY VALUE rather than by reference; 0.8.14 does
+    // not. The pin is `~0.8.15`, so a patch release could regress it without a bump review, and no
+    // test here or upstream covers undo for this path — re-check it by hand when the pin moves.
     editorRef.current?.applyUpdate(buildChapterScaffoldOps(scrRef.chapterNum, lastVerse), 'local');
   }, [scrRef.book, scrRef.chapterNum, lastVerse, isStructureProtected, notifyStructureProtected]);
 

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -1490,9 +1490,8 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
       return;
     }
     pendingScaffoldInsertRef.current = true;
-    // KNOWN CAVEAT: undo reliability for this insert depends on unreleased fixes in the vendored
-    // `@eten-tech-foundation/platform-editor` package — this extension's package.json still pins an
-    // older version, so don't assume undo works cleanly here until that pin is bumped.
+    // Undo for this insert relies on `applyUpdate('local')` edits staying undoable, which the
+    // pinned `@eten-tech-foundation/platform-editor` provides.
     editorRef.current?.applyUpdate(buildChapterScaffoldOps(scrRef.chapterNum, lastVerse), 'local');
   }, [scrRef.book, scrRef.chapterNum, lastVerse, isStructureProtected, notifyStructureProtected]);
 

--- a/extensions/src/platform-scripture-editor/src/use-character-marker-state.hook.test.ts
+++ b/extensions/src/platform-scripture-editor/src/use-character-marker-state.hook.test.ts
@@ -345,7 +345,7 @@ describe('useCharacterMarkerState — disabled rows', () => {
   // `insertMarker` nests rather than replaces. These assert that the inert rows are also marked
   // unavailable, so a click is refused visibly instead of being silently swallowed.
 
-  it('disables every marker row while a marker is applied and replacement does not exist yet', () => {
+  it('disables every marker row while a marker is applied and no change operation was supplied', () => {
     const { result } = renderHook(() => useCharacterMarkerState(options()));
 
     const markerRows = result.current.markerMenuItems.filter((item) => item.marker);
@@ -353,7 +353,7 @@ describe('useCharacterMarkerState — disabled rows', () => {
     expect(markerRows.every((item) => item.isDisabled)).toBe(true);
   });
 
-  it('disables only the applied marker once replacement exists', () => {
+  it('disables only the applied marker once a change operation is supplied', () => {
     const { result } = renderHook(() =>
       useCharacterMarkerState(options({ changeCharacterMarker: vi.fn() })),
     );

--- a/extensions/src/platform-scripture-editor/src/use-character-marker-state.hook.ts
+++ b/extensions/src/platform-scripture-editor/src/use-character-marker-state.hook.ts
@@ -37,7 +37,12 @@ export type UseCharacterMarkerStateOptions = {
    * remove row.
    */
   removeCharacterMarker?: (marker?: string) => void;
-  /** Supplied once replacement exists upstream; absent means picking a marker adds instead. */
+  /**
+   * Replaces the applied marker with the picked one. Absent means picking a marker while one is
+   * applied does nothing — it never falls back to adding, because adding nests.
+   *
+   * TODO(PT-4394): wire this to `EditorRef.replaceCharacterMarker`.
+   */
   changeCharacterMarker?: (fromMarker: string, toMarker: string) => void;
 };
 

--- a/lib/platform-bible-react/package.json
+++ b/lib/platform-bible-react/package.json
@@ -79,7 +79,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@eten-tech-foundation/platform-editor": "~0.8.14",
+    "@eten-tech-foundation/platform-editor": "~0.8.15",
     "@eten-tech-foundation/scripture-utilities": "~0.1.6",
     "@fontsource-variable/ibm-plex-sans": "^5.2.8",
     "@lexical/headless": "~0.43.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "@dreamsicle.io/stylelint-config-tailwindcss": "^1.2.2",
         "@electron/notarize": "^3.0.1",
         "@electron/rebuild": "^4.0.4",
-        "@eten-tech-foundation/platform-editor": "~0.8.14",
+        "@eten-tech-foundation/platform-editor": "~0.8.15",
         "@eten-tech-foundation/scripture-utilities": "~0.1.6",
         "@lexical/headless": "~0.43.0",
         "@lexical/html": "~0.43.0",
@@ -1010,7 +1010,7 @@
       },
       "devDependencies": {
         "@dreamsicle.io/stylelint-config-tailwindcss": "^1.2.2",
-        "@eten-tech-foundation/platform-editor": "~0.8.14",
+        "@eten-tech-foundation/platform-editor": "~0.8.15",
         "@eten-tech-foundation/scripture-utilities": "~0.1.6",
         "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@stylistic/eslint-plugin-ts": "^2.13.0",
@@ -1184,7 +1184,7 @@
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {
-        "@eten-tech-foundation/platform-editor": "~0.8.14",
+        "@eten-tech-foundation/platform-editor": "~0.8.15",
         "@eten-tech-foundation/scripture-utilities": "~0.1.6",
         "@fontsource-variable/ibm-plex-sans": "^5.2.8",
         "@lexical/headless": "~0.43.0",
@@ -4244,9 +4244,9 @@
       }
     },
     "node_modules/@eten-tech-foundation/platform-editor": {
-      "version": "0.8.14",
-      "resolved": "https://registry.npmjs.org/@eten-tech-foundation/platform-editor/-/platform-editor-0.8.14.tgz",
-      "integrity": "sha512-H6FhN6nwHEh68bSYMi7JiwqCxHLLI8trleY1rghpXCCnofnWBHKnXOI40iQ1HgL0el2y7EU1ihKQR9GliAwe+A==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@eten-tech-foundation/platform-editor/-/platform-editor-0.8.15.tgz",
+      "integrity": "sha512-y9lT2vetWDhyT6uLWmJU6E5Qs41EwZQQTuGlmqWSPKC244frxTY1u9hJri6bNpR7Bp6JyKfgMIFlyz1BD3oFSQ==",
       "license": "MIT",
       "dependencies": {
         "@eten-tech-foundation/scripture-utilities": "~0.1.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4251,6 +4251,7 @@
       "dependencies": {
         "@eten-tech-foundation/scripture-utilities": "~0.1.6",
         "@floating-ui/dom": "^1.7.6",
+        "@lexical/html": "^0.43.0",
         "@lexical/react": "^0.43.0",
         "@lexical/selection": "^0.43.0",
         "@lexical/text": "^0.43.0",

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
     "@dreamsicle.io/stylelint-config-tailwindcss": "^1.2.2",
     "@electron/notarize": "^3.0.1",
     "@electron/rebuild": "^4.0.4",
-    "@eten-tech-foundation/platform-editor": "~0.8.14",
+    "@eten-tech-foundation/platform-editor": "~0.8.15",
     "@eten-tech-foundation/scripture-utilities": "~0.1.6",
     "@lexical/headless": "~0.43.0",
     "@lexical/html": "~0.43.0",


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# PT-3780: Put the insertion point inside a marker added in a footnote

## Summary

Adding an `fk` or `fq` **inside a footnote** left the caret *before* the new marker and its bubble
instead of inside it, so the next keystroke landed outside the marker you just created.

The fix is upstream and already released. This branch just picks it up: it bumps
`@eten-tech-foundation/platform-editor` from `~0.8.14` to `~0.8.15`.

**No behavior code in paranext-core changed.** Four files are version strings, three are
comment-only. That is the whole diff.

| Commit | Files | What it does |
| --- | --- | --- |
| `9cf8220b689` | `package.json`, `lib/platform-bible-react/package.json`, `extensions/src/platform-scripture-editor/package.json`, `package-lock.json` | Bumps the editor dependency in all three places that declare it, plus the lock. **This is the actual fix.** |
| `4ce02fef0c3` | `character-marker-menu.utils.ts`, `use-remove-character-marker.hook.ts`, `platform-scripture-editor.web-view.tsx` | Comments only. Eight comments claimed the editor lacked operations it now has — including one telling readers not to trust undo "until that pin is bumped". No logic touched. |

### Reviewing this quickly

1. **Commit 1** — confirm the version moved in all three manifests and the lock. Mechanical.
2. **Commit 2** — read the comment diffs. Ask yourself only: *is the new wording true?* Nothing else changed.
3. **Decide the one open question below.**

### The one thing worth your attention

**0.8.14 → 0.8.15 looks like one patch step but spans four months and ~80 upstream commits** —
React 19 compat, USJ table rendering, paste structure protection, a `ScriptureReferencePlugin`
rebuild, and several cursor-placement changes.

Two things make this much less alarming than it sounds:

- The upstream API delta is **purely additive** — no removals, no signature narrowings (verified
  against the upstream API report between release tags).
- CI and yalc-linked developers have **already been running this code**. `postinstall` →
  `link-dev-packages` links the `platform-yalc` branch (0.8.15 + a README commit), which is why
  `main` typechecks green against 0.8.15-only APIs on a 0.8.14 lockfile.

**The question for you:** a fresh clone and downstream consumers of the published
`platform-bible-react` take the whole jump at once. Is the smoke testing below enough, or do you
want more before this merges?

---

## More detail

<details>
<summary><b>Why the bug happened</b></summary>

The caret fix is scripture-editors `e480c885` ("PT-3780: Put the insertion point inside a marker
inserted in a footnote", #530, merged 2026-08-11). It lands the caret inside the new marker's
content with `selectEnd()`, entirely inside `usj-marker-action.utils.ts` — no new option or
call-site change is needed here.

| | |
| --- | --- |
| Fix is in `platform_v0.8.15` | ✅ confirmed via `git merge-base --is-ancestor` |
| Fix is in `platform_v0.8.14` | ❌ not an ancestor |
| 0.8.14 published | 2026-04-14 |
| 0.8.15 published | 2026-08-17 |

Containment was proven against the release tags rather than inferred from dates. (Grepping the
published bundles is useless here — comments are stripped during the build, so a ticket-ID search
gives a false negative even when the fix is present.)

**Why it didn't reproduce in the standalone editor app:** that app runs scripture-editors `main`,
which has the fix. The bug shows up wherever the *published* dependency is what resolves — a fresh
clone, CI without the link step, or a checkout whose `link-dev-packages` did not complete.

This bump also closes a real declared-vs-actual gap: core already called 0.8.15-only APIs
(`EditorRef.removeCharacterMarker`, `EditorOptions.structureProtectionMode`,
`UsjNodeOptions.extraValidMarkers`, `ViewOptions.showCharMarkerTitles` / `hasGutterParaMarkers`)
while declaring 0.8.14.

</details>

<details>
<summary><b>Upstream API delta (0.8.14 → 0.8.15) — all additive</b></summary>

Verified against `packages/platform/etc/platform-editor.api.md` between tags.

- `EditorRef`: added `extendCharacterMarker`, `removeCharacterMarker`, `replaceCharacterMarker`.
  Added a callbacks-object `setAnnotation` overload and **deprecated** (did not remove) the
  positional form.
- `EditorOptions`: added optional `structureProtectionMode`.
- `UsjNodeOptions`: added optional `extraValidMarkers`.
- `ViewOptions`: added optional `hasActiveTextFocusBox`, `hasGutterParaMarkers`, `showCharMarkerTitles`.
- New exports: `PARAGRAPH_STRUCTURE_VIEW_MODE`, `StructureProtectionMode`, `TypedMarkOnMouseEnter`,
  `TypedMarkOnMouseLeave`.
- `getDefaultViewMode` return type widened; `viewModeToViewNames` gained `"paragraph-structure"`.
  No core code uses either (verified by grep).

Nothing in paranext-core's public surface changed: no `platform-bible-utils` changes, no
`papi.d.ts` regeneration needed, no exported symbols added or removed. The one contract change is
that `lib/platform-bible-react` is a **published** package, so its dependency floor rises for
downstream consumers — intended, since the fix is required.

</details>

<details>
<summary><b>Why the comments needed changing</b></summary>

All eight were written when `EditorRef` had only `insertMarker`, and asserted the editor exposed no
way to remove, replace, or extend a character marker. It now exposes all three, so the stated
reasons were false. The *behavior* is unchanged — the affected menu rows are still inert, but
because nothing in this extension supplies those operations, not because the editor lacks them.

Two are worth a closer look:

- **`platform-scripture-editor.web-view.tsx:1346`** carried a `KNOWN CAVEAT` saying undo for the
  chapter-scaffold insert could not be trusted "until that pin is bumped" — the pin this PR bumps.
  The underlying fix (`applyUpdate('local')` inserts remain undoable) was confirmed present in
  0.8.15 and absent from 0.8.14 before the caveat was rewritten.
- **`use-remove-character-marker.hook.ts:105`** said the outcome signal it wanted did not exist.
  It does — `removeCharacterMarker` returns a `boolean` — and the call discards it. The comment now
  names that as the gap.

</details>

<details>
<summary><b>Verification</b></summary>

- **Manual**: the footnote caret fix was confirmed by hand in a running app built from this branch.
  No automated test in this repo covers it.
- `npm run typecheck` (core + erb + all workspaces) — exit 0.
- `platform-scripture-editor` suite — 54 files / 781 tests, exit 0.
- Full extensions suite — 94 files / 1426 tests, exit 0.
- `lib/platform-bible-react` unit tests — 38 files / 384 tests, exit 0.
- ESLint and Prettier on every changed file — clean.
- `npm ls` — root, `platform-bible-react`, and `platform-scripture-editor` all dedupe to 0.8.15.

**Not run**: repo-wide `lint` / `format:check`, the core `src/` suite, and `dotnet test`
(unaffected by a JS dependency bump). Scoped equivalents were run against every changed file.

**Lockfile note**: the lock change is limited to the editor entry and its range references. A plain
`npm install` on this machine also rewrites ~65 lines of `@tailwindcss/oxide-wasm32-wasi` entries;
re-resolving an *unmodified* tree produced identical churn, confirming it is npm-version noise
rather than a consequence of this bump, so it was left out. CI is unaffected — `npm ci` installs
from the lock, and the "verify no files changed" step runs after `build`, not install.

</details>

<details>
<summary><b>Deliberately not done here (follow-up candidates)</b></summary>

- **Wire the newly-available operations.** 0.8.15 provides `extendCharacterMarker` and
  `replaceCharacterMarker`. Until something supplies them, `'partial'` selections and the
  change-marker row stay inert. Kept out to keep this branch a dependency bump.
- **Add a contract test** asserting the installed `EditorRef` exposes the members this extension
  calls. The character-marker suites mock `EditorRef`, so they pass regardless of what the installed
  package provides — which is exactly how a 0.8.15-only API sat inert on a 0.8.14 pin without any
  test noticing.
- **Caret-placement regression test** — lives upstream, where PR #530 ships 345 lines of coverage
  across `Editor.test.tsx` and `usj-marker-action-utils.test.ts`. Testing it from here would mean
  driving a third-party package's Lexical internals through jsdom.
- **`extensions/src/platform-scripture-editor/package.json:41-45` `devDependencies` are out of
  alphabetical order** — pre-existing, adjacent to a touched line, left alone to keep the diff clean.

</details>
<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2703)
<!-- Reviewable:end -->
