### PR TITLE
PT-4403: Show honest book-not-found message in resource panels

### DIFF
--- a/c-sharp-tests/MissingBookExceptionTests.cs
+++ b/c-sharp-tests/MissingBookExceptionTests.cs
@@ -1,0 +1,77 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Text.RegularExpressions;
+using Paranext.DataProvider;
+
+namespace TestParanextDataProvider
+{
+    /// <summary>
+    /// Pins the exact wording of <see cref="MissingBookException"/>'s message.
+    /// </summary>
+    /// <remarks>
+    /// The Scripture editor extension detects "this book is not in this project/resource" by
+    /// pattern-matching the message text of the error the PDP returns — there is no structured
+    /// error code to key off. That check lives in <c>isBookNotFoundError</c> in
+    /// <c>extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts</c>,
+    /// which applies the regex duplicated below.
+    ///
+    /// Without this test the coupling is advisory only: rewording the message here still compiles
+    /// and still passes every other test, but silently turns both Scripture tabs' honest "this book
+    /// does not exist" message back into an empty editor. If this test fails because the message
+    /// changed deliberately, update the regex in the TypeScript helper in the same commit.
+    /// </remarks>
+    [ExcludeFromCodeCoverage]
+    public class MissingBookExceptionTests
+    {
+        /// <summary>
+        /// Must stay character-for-character identical to <c>BOOK_NOT_FOUND_REGEX</c> in
+        /// <c>platform-scripture-editor.utils.ts</c>.
+        /// </summary>
+        private const string ExtensionBookNotFoundRegex = @"Book number \d+ not found in project";
+
+        [Test]
+        public void Message_MatchesRegexTheScriptureEditorExtensionUses()
+        {
+            var exception = new MissingBookException(40, "ProjectName");
+
+            Assert.That(exception.Message, Does.Match(ExtensionBookNotFoundRegex));
+        }
+
+        [Test]
+        public void Message_HasTheExactExpectedWording()
+        {
+            var exception = new MissingBookException(40, "ProjectName");
+
+            Assert.That(
+                exception.Message,
+                Is.EqualTo("Book number 40 not found in project ProjectName.")
+            );
+        }
+
+        [Test]
+        public void Message_MatchesTheExtensionRegexForAnyBookNumber()
+        {
+            foreach (var bookNum in new[] { 1, 40, 66 })
+            {
+                var exception = new MissingBookException(bookNum, "ProjectName");
+
+                Assert.That(
+                    Regex.IsMatch(exception.Message, ExtensionBookNotFoundRegex),
+                    Is.True,
+                    $"Book number {bookNum} should be detected as book-not-found by the extension"
+                );
+            }
+        }
+
+        [Test]
+        public void BookNumAndProjectId_ArePreserved()
+        {
+            var exception = new MissingBookException(40, "ProjectName");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(exception.BookNum, Is.EqualTo(40));
+                Assert.That(exception.ProjectId, Is.EqualTo("ProjectName"));
+            });
+        }
+    }
+}

--- a/c-sharp/MissingBookException.cs
+++ b/c-sharp/MissingBookException.cs
@@ -4,7 +4,9 @@ namespace Paranext.DataProvider;
 /// Exception thrown when a requested book is not found in a Paratext project.
 /// </summary>
 public class MissingBookException(int bookNum, string projectId)
-    // IMPORTANT: The scripture editor WebView depends on the exact text of this message.
+    // IMPORTANT: The scripture editor WebView depends on the exact text of this message; it is
+    // pattern-matched by `isBookNotFoundError` in platform-scripture-editor.utils.ts and pinned by
+    // MissingBookExceptionTests. Reword it only alongside that regex.
     : Exception($"Book number {bookNum} not found in project {projectId}.")
 {
     /// <summary>

--- a/extensions/src/platform-scripture-editor/src/book-not-available-view.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/book-not-available-view.component.tsx
@@ -96,7 +96,14 @@ export function BookNotAvailableView({
         tabIndex={-1}
         className="tw:flex tw:h-full tw:items-center tw:justify-center tw:px-4 tw:outline-none"
       >
-        <span>{localize(localizedStrings, SIMPLE_MESSAGE_KEY)}</span>
+        {/* Same small muted treatment as `EmptyDescription` in the Power branch below and as
+            `EmptyState` in the resource panels, so a missing book reads identically whichever
+            surface the user is on. The message stays a plain `span` rather than `EmptyState`
+            because the `role="status"` live region and the focus repair both live on the wrapper
+            above, which `EmptyState` has no way to accept. */}
+        <span className="tw:text-sm tw:text-muted-foreground tw:text-center">
+          {localize(localizedStrings, SIMPLE_MESSAGE_KEY)}
+        </span>
       </div>
     );
   }

--- a/extensions/src/platform-scripture-editor/src/model-text-panel.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/model-text-panel.component.test.tsx
@@ -36,6 +36,8 @@ const STRINGS = {
     "The model text couldn't be installed. Check your connection and try again.",
   '%webView_modelTextPanel_retry%': 'Try again',
   '%webView_modelTextPanel_emptyState_prompt%': 'No model text selected.',
+  '%webView_platformScriptureEditor_error_bookNotFoundResource%':
+    'This book does not exist in this resource.',
 };
 
 const INSTALLED_RESOURCE: DblResourceData = {
@@ -276,5 +278,92 @@ describe('ModelTextPanel', () => {
         "The model text couldn't be installed. Check your connection and try again.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it('shows the missing-book message instead of the editor when the resource lacks the book', async () => {
+    // A book the resource doesn't have makes getChapterUSJ reject. Without the bookExists branch the
+    // panel just clears `usj` and still renders the read-only editor, which then shows the previous
+    // chapter's text or an "enter some Scripture" prompt — an edit prompt in a read-only resource.
+    const getResourceChapter = vi.fn(async () => {
+      throw new Error(
+        'JSON-RPC Request error (-32000): Book number 1 not found in project project-web.',
+      );
+    });
+    renderPanel({
+      effectiveModelTexts: configuredModelText('uid-web'),
+      dblResources: [INSTALLED_RESOURCE],
+      getResourceChapter,
+    });
+
+    expect(
+      await screen.findByText('This book does not exist in this resource.'),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('editorial')).not.toBeInTheDocument();
+  });
+
+  it('announces the missing-book message in a live region', async () => {
+    // The panel swaps the editor out for this message as the user navigates, so without a status
+    // role a screen reader user gets silence where the model text used to be.
+    const getResourceChapter = vi.fn(async () => {
+      throw new Error('Book number 1 not found in project project-web.');
+    });
+    renderPanel({
+      effectiveModelTexts: configuredModelText('uid-web'),
+      dblResources: [INSTALLED_RESOURCE],
+      getResourceChapter,
+    });
+
+    expect(await screen.findByRole('status')).toHaveTextContent(
+      'This book does not exist in this resource.',
+    );
+  });
+
+  it('keeps rendering the editor when the chapter load fails for an unrelated reason', async () => {
+    // Only a missing book earns the "this book does not exist" claim. Any other failure must fall
+    // back to the editor rather than telling the user something untrue about the resource.
+    const getResourceChapter = vi.fn(async () => {
+      throw new Error('Network request failed');
+    });
+    renderPanel({
+      effectiveModelTexts: configuredModelText('uid-web'),
+      dblResources: [INSTALLED_RESOURCE],
+      getResourceChapter,
+    });
+
+    expect(await screen.findByTestId('editorial')).toBeInTheDocument();
+    expect(
+      screen.queryByText('This book does not exist in this resource.'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('recovers to the editor when navigating from a missing book to one the resource has', async () => {
+    // bookExists must be re-set on a successful load, or the panel stays stuck on the message for
+    // the rest of the session once the user hits one missing book.
+    const getResourceChapter = vi.fn(async () => ({ usj: SAMPLE_USJ, textDirection: 'ltr' }));
+    getResourceChapter.mockRejectedValueOnce(
+      new Error('Book number 1 not found in project project-web.'),
+    );
+    const { rerender } = renderPanel({
+      effectiveModelTexts: configuredModelText('uid-web'),
+      dblResources: [INSTALLED_RESOURCE],
+      getResourceChapter,
+      scrRef: { book: 'GEN', chapterNum: 1, verseNum: 1 },
+    });
+    expect(
+      await screen.findByText('This book does not exist in this resource.'),
+    ).toBeInTheDocument();
+
+    // Navigate to a book the resource does contain; the next load resolves.
+    rerender(
+      <ModelTextPanel
+        {...makeProps({
+          effectiveModelTexts: configuredModelText('uid-web'),
+          dblResources: [INSTALLED_RESOURCE],
+          getResourceChapter,
+          scrRef: { book: 'MAT', chapterNum: 1, verseNum: 1 },
+        })}
+      />,
+    );
+    expect(await screen.findByTestId('editorial')).toBeInTheDocument();
   });
 });

--- a/extensions/src/platform-scripture-editor/src/model-text-panel.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/model-text-panel.component.tsx
@@ -8,6 +8,7 @@ import { Usj } from '@eten-tech-foundation/scripture-utilities';
 import { SerializedVerseRef } from '@sillsdev/scripture';
 import {
   Button,
+  EmptyState,
   Spinner,
   Tooltip,
   TooltipContent,
@@ -16,7 +17,11 @@ import {
   useExtraValidMarkers,
   useTruncationTooltip,
 } from 'platform-bible-react';
-import { type DblResourceData, type LocalizedStringValue } from 'platform-bible-utils';
+import {
+  getErrorMessage,
+  type DblResourceData,
+  type LocalizedStringValue,
+} from 'platform-bible-utils';
 import type {
   DblResourceReference,
   EffectiveResourceReference,
@@ -24,6 +29,7 @@ import type {
   ResourceReferenceList,
 } from 'platform-scripture';
 import { ComponentProps, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { isBookNotFoundError } from './platform-scripture-editor.utils';
 import { selectTextConnection } from './select-dbl-resource';
 import { isDblResourceReference } from './resource-reference.utils';
 import { findCachedDblResource } from './scripture-text-grid/dbl-resource-lookup.utils';
@@ -61,6 +67,9 @@ export const MODEL_TEXT_PANEL_STRING_KEYS = Object.freeze([
   '%webView_modelTextPanel_installFailedOffline%',
   '%webView_modelTextPanel_retry%',
   '%webView_modelTextPanel_emptyState_prompt%',
+  // Shared with both Scripture tabs' missing-book branch so every panel words a book the resource
+  // lacks the same way
+  '%webView_platformScriptureEditor_error_bookNotFoundResource%',
 ] as const);
 
 type ModelTextPanelLocalizedStringKey = (typeof MODEL_TEXT_PANEL_STRING_KEYS)[number];
@@ -184,6 +193,11 @@ export function ModelTextPanel({
   const [textDirection, setTextDirection] = useState<string>(DEFAULT_TEXT_DIRECTION);
   // `undefined` means "not yet fetched" so we can show the loading state, matching the original.
   const [isUsjLoading, setIsUsjLoading] = useState(false);
+  // A book missing from the resource makes `getChapterUSJ` reject rather than return empty USJ.
+  // Without tracking it, the load below just clears `usj` and this panel falls through to the
+  // read-only editor, which then shows either the previous chapter's text or its "enter some
+  // Scripture" placeholder — an edit prompt in a resource the user cannot edit.
+  const [bookExists, setBookExists] = useState(true);
 
   useEffect(() => {
     if (!resourceProjectId) {
@@ -200,11 +214,18 @@ export function ModelTextPanel({
       if (!isActive) return;
       setUsj(nextUsj);
       setTextDirection(nextTextDirection || DEFAULT_TEXT_DIRECTION);
+      setBookExists(true);
       setIsUsjLoading(false);
     };
-    load().catch(() => {
+    load().catch((e) => {
       if (!isActive) return;
       setUsj(undefined);
+      // A book the resource simply doesn't have is ordinary navigation, not a fault, so it is
+      // logged quietly; every other failure is a real error. Matches both Scripture tabs.
+      const bookNotFound = isBookNotFoundError(e);
+      if (bookNotFound) logger?.debug(`Book not found in model text: ${getErrorMessage(e)}`);
+      else logger?.error(`Error getting USJ for the model text panel: ${getErrorMessage(e)}`);
+      setBookExists(!bookNotFound);
       setIsUsjLoading(false);
     });
     return () => {
@@ -446,6 +467,24 @@ export function ModelTextPanel({
     return (
       <div className="tw:flex tw:h-screen tw:items-center tw:justify-center tw:p-8 tw:text-center">
         <Spinner />
+      </div>
+    );
+  }
+
+  // Missing book: the resolved resource has no such book. Say so rather than handing the reader an
+  // empty read-only editor. Uses the same borrowed string and `EmptyState` treatment as both
+  // Scripture tabs, so the identical sentence is worded, styled, and announced to screen readers
+  // the same way in every panel that can hit this state.
+  if (!bookExists) {
+    return (
+      <div className="tw:flex tw:h-screen tw:items-center tw:justify-center tw:p-8">
+        <EmptyState
+          id="model-text-panel-book-not-found"
+          className="tw:text-center"
+          message={
+            localizedStrings['%webView_platformScriptureEditor_error_bookNotFoundResource%'] ?? ''
+          }
+        />
       </div>
     );
   }

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { ScriptureRange } from 'platform-scripture-editor';
 import type PapiBackend from '@papi/backend';
-import { UsjTextContentLocation } from 'platform-bible-utils';
+import { newPlatformError, UsjTextContentLocation } from 'platform-bible-utils';
 import type { SavedWebViewDefinition } from '@papi/core';
 import { MutableRefObject } from 'react';
 import { EditorRef } from '@eten-tech-foundation/platform-editor';
@@ -18,6 +18,7 @@ import {
   selectProjectIdsForOpenMode,
   startDefaultProjectPicker,
   toScriptureEditorInfos,
+  isBookNotFoundError,
   isChapterBlank,
   buildChapterScaffoldOps,
   canAddChapterNumber,
@@ -2589,5 +2590,27 @@ describe('resolveAddChapterNumberClick', () => {
 
   it('returns "insert" when not in flight and lastVerse is positive', () => {
     expect(resolveAddChapterNumberClick(false, 3)).toBe('insert');
+  });
+});
+
+describe('isBookNotFoundError', () => {
+  it('returns true for a PlatformError whose message says the book number was not found', () => {
+    expect(
+      isBookNotFoundError(newPlatformError('Book number 40 not found in project ProjectName')),
+    ).toBe(true);
+  });
+
+  it('returns false for a PlatformError with an unrelated message', () => {
+    expect(isBookNotFoundError(newPlatformError('Permissions exception for projectId abc'))).toBe(
+      false,
+    );
+  });
+
+  it('returns false for a successfully retrieved USJ document', () => {
+    expect(isBookNotFoundError({ type: USJ_TYPE, version: USJ_VERSION, content: [] })).toBe(false);
+  });
+
+  it('returns false for undefined, as when the data has not arrived yet', () => {
+    expect(isBookNotFoundError(undefined)).toBe(false);
   });
 });

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.test.ts
@@ -2613,4 +2613,18 @@ describe('isBookNotFoundError', () => {
   it('returns false for undefined, as when the data has not arrived yet', () => {
     expect(isBookNotFoundError(undefined)).toBe(false);
   });
+
+  it('returns true for a thrown Error, as when awaiting getChapterUSJ rejects', () => {
+    expect(
+      isBookNotFoundError(
+        new Error(
+          'JSON-RPC Request error (-32000): Book number 1 not found in project ProjectName.',
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a thrown Error with an unrelated message', () => {
+    expect(isBookNotFoundError(new Error('Network request failed'))).toBe(false);
+  });
 });

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -1158,3 +1158,26 @@ export function resolveAddChapterNumberClick(
 }
 
 // #endregion Chapter Scaffold Helpers
+
+// #region PDP Error Detection
+
+// This regex is connected directly to the exception message within MissingBookException.cs
+const BOOK_NOT_FOUND_REGEX = /Book number \d+ not found in project/;
+
+/**
+ * Whether a value received from a scripture PDP is the error it returns when the requested book
+ * does not exist in the project or resource. Views use this to show an honest "this book does not
+ * exist" message instead of an empty editor.
+ *
+ * Anything that is not a `PlatformError` — including the USJ itself and `undefined` while the data
+ * is still in flight — is not a book-not-found error.
+ *
+ * @param possibleError Value returned by a scripture PDP (e.g. `ChapterUSJ`), which may be a
+ *   `PlatformError`.
+ */
+export function isBookNotFoundError(possibleError: unknown): boolean {
+  if (!isPlatformError(possibleError)) return false;
+  return BOOK_NOT_FOUND_REGEX.test(getErrorMessage(possibleError));
+}
+
+// #endregion PDP Error Detection

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.utils.ts
@@ -1161,22 +1161,26 @@ export function resolveAddChapterNumberClick(
 
 // #region PDP Error Detection
 
-// This regex is connected directly to the exception message within MissingBookException.cs
+// This regex is connected directly to the exception message within MissingBookException.cs.
+// `c-sharp-tests/MissingBookExceptionTests.cs` duplicates this pattern and fails if that message is
+// reworded, so the two sides cannot drift silently — update both together.
 const BOOK_NOT_FOUND_REGEX = /Book number \d+ not found in project/;
 
 /**
- * Whether a value received from a scripture PDP is the error it returns when the requested book
+ * Whether a value received from a scripture PDP is the error it reports when the requested book
  * does not exist in the project or resource. Views use this to show an honest "this book does not
  * exist" message instead of an empty editor.
  *
- * Anything that is not a `PlatformError` — including the USJ itself and `undefined` while the data
- * is still in flight — is not a book-not-found error.
+ * Handles both shapes the scripture PDPs surface, because the two call styles fail differently:
+ * `useProjectData` hands back a `PlatformError` in place of the data, while awaiting
+ * `getChapterUSJ` directly rejects with a thrown `Error`. Anything that is neither — including the
+ * USJ itself and `undefined` while the data is still in flight — is not a book-not-found error.
  *
- * @param possibleError Value returned by a scripture PDP (e.g. `ChapterUSJ`), which may be a
- *   `PlatformError`.
+ * @param possibleError Value returned by a scripture PDP (e.g. `ChapterUSJ`) or thrown by one of
+ *   its methods, which may be a `PlatformError` or an `Error`.
  */
 export function isBookNotFoundError(possibleError: unknown): boolean {
-  if (!isPlatformError(possibleError)) return false;
+  if (!isPlatformError(possibleError) && !(possibleError instanceof Error)) return false;
   return BOOK_NOT_FOUND_REGEX.test(getErrorMessage(possibleError));
 }
 

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -42,6 +42,7 @@ import {
   CommentEditor,
   DisabledActionTooltip,
   EditorKeyboardShortcuts,
+  EmptyState,
   FOOTNOTE_EDITOR_STRING_KEYS,
   FootnoteEditor,
   MarkdownRenderer,
@@ -1290,8 +1291,13 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
   const [usjFromPdp, bookExists] = useMemo(() => {
     if (!isPlatformError(usjFromPdpPossiblyError)) return [usjFromPdpPossiblyError, true];
 
-    logger.error(`Error getting USJ from PDP: ${getErrorMessage(usjFromPdpPossiblyError)}`);
-    return [defaultUsj, !isBookNotFoundError(usjFromPdpPossiblyError)];
+    // A book missing from the project is ordinary navigation, not a fault, so it is logged
+    // quietly; every other PDP failure is a real error. Both Scripture tabs branch the same way.
+    const bookNotFound = isBookNotFoundError(usjFromPdpPossiblyError);
+    const errorMessage = getErrorMessage(usjFromPdpPossiblyError);
+    if (bookNotFound) logger.debug(`Book not found in project: ${errorMessage}`);
+    else logger.error(`Error getting USJ from PDP: ${errorMessage}`);
+    return [defaultUsj, !bookNotFound];
   }, [usjFromPdpPossiblyError]);
   const usjSentToPdp = useRef<Usj | undefined>(usjFromPdp);
   const currentlyWritingUsjToPdp = useRef(false);
@@ -1969,7 +1975,18 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
         return (
           <div className="tw:flex tw:items-center tw:justify-center tw:h-full tw:px-4">
             {workaround}
-            {localizedStrings['%webView_platformScriptureEditor_error_bookNotFoundResource%']}
+            {/* `EmptyState` rather than bare text: this region swaps content in place as the user
+                navigates, so its `role="status"` is what announces the missing book to a screen
+                reader instead of scripture going silent. It is also the treatment the Bible text,
+                commentary, and model text panels use for the same sentence, so the message reads
+                and announces identically wherever a resource lacks the book. */}
+            <EmptyState
+              id="platform-scripture-editor-book-not-found-resource"
+              className="tw:text-center"
+              message={
+                localizedStrings['%webView_platformScriptureEditor_error_bookNotFoundResource%']
+              }
+            />
           </div>
         );
       }

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -126,6 +126,7 @@ import {
   formatEditorTitle,
   generateInlineMarkerMenuListItems,
   generateParagraphMenuListItems,
+  isBookNotFoundError,
   isChapterBlank,
   openCommentListAndSelectThreadSafe,
   resolveAddChapterNumberClick,
@@ -276,9 +277,6 @@ const getViewOptionsForType = (
   if (viewType === 'markers') return { ...paragraphStructure, noteMode: 'expanded' };
   return paragraphStructure;
 };
-
-// This regex is connected directly to the exception message within MissingBookException.cs
-const bookNotFoundRegex = /Book number \d+ not found in project/;
 
 // This regex is connected directly to the exception message within PermissionsException.cs
 const PERMISSIONS_EXCEPTION_REGEX = /Permissions exception for projectId/;
@@ -1292,9 +1290,8 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
   const [usjFromPdp, bookExists] = useMemo(() => {
     if (!isPlatformError(usjFromPdpPossiblyError)) return [usjFromPdpPossiblyError, true];
 
-    const errorMessage = getErrorMessage(usjFromPdpPossiblyError);
-    logger.error(`Error getting USJ from PDP: ${errorMessage}`);
-    return [defaultUsj, !bookNotFoundRegex.test(errorMessage)];
+    logger.error(`Error getting USJ from PDP: ${getErrorMessage(usjFromPdpPossiblyError)}`);
+    return [defaultUsj, !isBookNotFoundError(usjFromPdpPossiblyError)];
   }, [usjFromPdpPossiblyError]);
   const usjSentToPdp = useRef<Usj | undefined>(usjFromPdp);
   const currentlyWritingUsjToPdp = useRef(false);

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -40,6 +40,7 @@ import type {
   EffectiveResourceReference,
   ResourceReferenceList,
 } from 'platform-scripture';
+import { isBookNotFoundError } from './platform-scripture-editor.utils';
 import { useOpenFindShortcut } from './use-open-find-shortcut.hook';
 import { useEffectiveResourceReferenceList } from './use-effective-resource-reference-list.hook';
 import { useCommentaryMarkerStyles } from './use-commentary-marker-styles.hook';
@@ -58,6 +59,9 @@ import { selectTextConnection } from './select-dbl-resource';
 const DEFAULT_TEXT_DIRECTION = 'ltr';
 
 const RESOURCE_PANEL_STRING_KEYS: LocalizeKey[] = [
+  // Shared with the editable scripture editor's read-only branch so both tabs word a missing book
+  // the same way
+  '%webView_platformScriptureEditor_error_bookNotFoundResource%',
   '%webView_resourcePanel_noProject%',
   '%webView_resourcePanel_installing%',
   '%webView_resourcePanel_selecting%',
@@ -423,6 +427,16 @@ globalThis.webViewComponent = function ResourceTextPanel({
 
   const usjFromPdp = !isPlatformError(usjPossiblyError) ? usjPossiblyError : undefined;
 
+  // A book missing from the resource comes back from the PDP as an error rather than as empty USJ.
+  // Detect it so the panel can say so: without this branch `Editorial` renders with no scripture
+  // set, showing either the previous chapter's content or its "enter some scripture" placeholder —
+  // neither is honest for a read-only resource.
+  const bookExists = useMemo(() => {
+    if (!isPlatformError(usjPossiblyError)) return true;
+    logger.warn(`Error getting USJ for the resource panel: ${getErrorMessage(usjPossiblyError)}`);
+    return !isBookNotFoundError(usjPossiblyError);
+  }, [usjPossiblyError]);
+
   // #endregion
 
   // #region Text direction
@@ -631,16 +645,25 @@ globalThis.webViewComponent = function ResourceTextPanel({
         downloadResourcesLabel={localizedStrings['%webView_resourcePanel_downloadResources%']}
       />
 
-      {/* Scripture content */}
-      <div className="tw:flex-1 tw:overflow-auto" dir={options.textDirection}>
-        <Editorial
-          ref={editorRef}
-          scrRef={scrRef}
-          onScrRefChange={setScrRef}
-          options={options}
-          logger={logger}
-        />
-      </div>
+      {/* Scripture content, or an honest message when the resource has no such book. The
+          resource selector above stays mounted in both cases so the user can switch to a resource
+          that does contain the book. The message sits outside the `dir` wrapper because it is
+          UI-locale text, not resource text. */}
+      {bookExists ? (
+        <div className="tw:flex-1 tw:overflow-auto" dir={options.textDirection}>
+          <Editorial
+            ref={editorRef}
+            scrRef={scrRef}
+            onScrRefChange={setScrRef}
+            options={options}
+            logger={logger}
+          />
+        </div>
+      ) : (
+        <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8 tw:text-center">
+          {localizedStrings['%webView_platformScriptureEditor_error_bookNotFoundResource%']}
+        </div>
+      )}
     </div>
   );
 

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -1,5 +1,5 @@
 import { Editorial, EditorOptions, EditorRef } from '@eten-tech-foundation/platform-editor';
-import { EMPTY_USJ } from '@eten-tech-foundation/scripture-utilities';
+import { EMPTY_USJ, Usj } from '@eten-tech-foundation/scripture-utilities';
 import type { WebViewProps } from '@papi/core';
 import papi, { logger } from '@papi/frontend';
 import {
@@ -19,6 +19,7 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  EmptyState,
   Spinner,
   usePromise,
   useExtraValidMarkers,
@@ -425,16 +426,21 @@ globalThis.webViewComponent = function ResourceTextPanel({
     EMPTY_USJ,
   );
 
-  const usjFromPdp = !isPlatformError(usjPossiblyError) ? usjPossiblyError : undefined;
+  // Handle a PlatformError if one comes in instead of resource text. A book missing from the
+  // resource comes back from the PDP as an error rather than as empty USJ, so detect it and let the
+  // panel say so: otherwise `Editorial` renders with no scripture set, showing either the previous
+  // chapter's content or its "enter some scripture" placeholder — neither is honest for a read-only
+  // resource. Derived in one pass, like the editable Scripture tab.
+  const [usjFromPdp, bookExists] = useMemo<[Usj | undefined, boolean]>(() => {
+    if (!isPlatformError(usjPossiblyError)) return [usjPossiblyError, true];
 
-  // A book missing from the resource comes back from the PDP as an error rather than as empty USJ.
-  // Detect it so the panel can say so: without this branch `Editorial` renders with no scripture
-  // set, showing either the previous chapter's content or its "enter some scripture" placeholder —
-  // neither is honest for a read-only resource.
-  const bookExists = useMemo(() => {
-    if (!isPlatformError(usjPossiblyError)) return true;
-    logger.warn(`Error getting USJ for the resource panel: ${getErrorMessage(usjPossiblyError)}`);
-    return !isBookNotFoundError(usjPossiblyError);
+    // A book missing from the resource is ordinary navigation, not a fault, so it is logged
+    // quietly; every other PDP failure is a real error. Matches the editable Scripture tab.
+    const bookNotFound = isBookNotFoundError(usjPossiblyError);
+    const errorMessage = getErrorMessage(usjPossiblyError);
+    if (bookNotFound) logger.debug(`Book not found in resource: ${errorMessage}`);
+    else logger.error(`Error getting USJ for the resource panel: ${errorMessage}`);
+    return [undefined, !bookNotFound];
   }, [usjPossiblyError]);
 
   // #endregion
@@ -648,7 +654,9 @@ globalThis.webViewComponent = function ResourceTextPanel({
       {/* Scripture content, or an honest message when the resource has no such book. The
           resource selector above stays mounted in both cases so the user can switch to a resource
           that does contain the book. The message sits outside the `dir` wrapper because it is
-          UI-locale text, not resource text. */}
+          UI-locale text, not resource text. `EmptyState` (rather than bare text) because this
+          region swaps content in place as the user navigates, so its `role="status"` is what
+          announces the missing book to a screen reader instead of scripture going silent. */}
       {bookExists ? (
         <div className="tw:flex-1 tw:overflow-auto" dir={options.textDirection}>
           <Editorial
@@ -660,8 +668,14 @@ globalThis.webViewComponent = function ResourceTextPanel({
           />
         </div>
       ) : (
-        <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8 tw:text-center">
-          {localizedStrings['%webView_platformScriptureEditor_error_bookNotFoundResource%']}
+        <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
+          <EmptyState
+            id="resource-text-panel-book-not-found"
+            className="tw:text-center"
+            message={
+              localizedStrings['%webView_platformScriptureEditor_error_bookNotFoundResource%']
+            }
+          />
         </div>
       )}
     </div>


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: `pt-4403-honest-message-when-book-does-not-exist`

**Base**: `origin/main`

**Date**: 2026-08-21

**Review model**: Claude Opus 5

**Files changed**: 8

## Overview

A book missing from the selected resource comes back from the scripture PDP as an *error*, not as
empty USJ. Every panel that displayed resource text collapsed that error to "no data" and then
rendered the read-only editor anyway — so the user saw either the previous chapter's text or an
"Enter some Scripture…" placeholder. Both are dishonest: the first is stale content presented as
current, the second is an edit prompt in a resource the user cannot edit.

This change detects the book-not-found error and renders the existing localized message
(`%webView_platformScriptureEditor_error_bookNotFoundResource%`) instead. The detection — and the
regex coupled to `MissingBookException.cs` — is extracted into `isBookNotFoundError` in
`platform-scripture-editor.utils.ts` so all three Scripture surfaces share one unit-testable source
of truth. The resource selector stays mounted so the user can switch to a resource that has the
book, and the message sits outside the `dir` wrapper because it is UI-locale text, not resource text.

During review the fix was extended from the Bible text tab to the **Model text panel**, which had
the identical bug via a different code path, and the message was converged onto the shared
`EmptyState` component in the resource panels so the same sentence is worded, styled, and announced
to screen readers identically everywhere.

### Rebased onto PT-4111 (#2691)

#2691 landed first and rewrote the editable editor's `!bookExists` branch into a mode-aware
`BookNotAvailableView` (Power zero-state with a **Manage books** action, Simple "ask your project
administrator" copy) behind an `isResource` fork. This PR was rebased on top of it and its own
`EmptyState` wrapper for that branch was **dropped as superseded** — #2691's version is strictly
richer and is what ships.

What survives the rebase is everything #2691 does not cover:

- the three resource surfaces (Bible text tab, Commentaries tab — same component — and Model text
  panel), which #2691 never touches;
- `isBookNotFoundError` in `platform-scripture-editor.utils.ts`, replacing the editor's local
  `bookNotFoundRegex`, so all surfaces share one unit-testable predicate;
- the log-level branch (`debug` for a book the text simply lacks, `error` retained for genuine PDP
  faults);
- `MissingBookExceptionTests`, pinning the C#↔TS contract.

Two small edits close the consistency gap #2691 left, which NN 5A ("consistent across all tabs")
calls for directly:

- **`platform-scripture-editor.web-view.tsx`** — the `isResource` branch rendered bare text in a
  `<div>` with no live region, the only missing-book surface that announced nothing. Now
  `EmptyState`, matching the resource panels.
- **`book-not-available-view.component.tsx`** — Simple mode's `<span>` now carries
  `tw:text-sm tw:text-muted-foreground`, matching `EmptyDescription` in its own Power branch and
  `EmptyState` everywhere else. It stays a `span` rather than becoming an `EmptyState`: the
  `role="status"` live region and the focus repair live on the wrapper `div`, and `EmptyState`
  cannot accept either, so converting it would have been an accessibility regression. Typography
  was the only thing actually diverging.

## API Changes

None. No public API surfaces changed.

- `lib/platform-bible-react/`, `lib/platform-bible-utils/`: unchanged
- `lib/papi-dts/papi.d.ts`: unchanged (no regeneration needed; no hand edits)
- `extensions/src/*/src/types/*.d.ts`: unchanged
- The new export `isBookNotFoundError` is extension-internal (not a declaration file, not
  re-exported through `@papi/`), consumed only within `platform-scripture-editor`.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **The missing-book message rendered as bare text in a `<div>`, skipping the `EmptyState`
      component** (`resource-text-panel.web-view.tsx`). The region swaps content in place as the
      user navigates, so with no live region a screen reader user got silence where scripture used
      to be. Flagged independently by both the UX and style passes; a sibling web view in the same
      extension (`scripture-text-grid.web-view.tsx:545`) already used `EmptyState`.
      _(fixed during review: replaced with `<EmptyState id="resource-text-panel-book-not-found"
      className="tw:text-center" />`, gaining `role="status"`, the standard
      `tw:text-sm tw:text-muted-foreground` treatment, and a `data-testid`. Verified live in the
      running app: the rendered node is
      `<p role="status" data-testid="resource-text-panel-book-not-found">`.)_

[Author response: Author chose to adopt `EmptyState` immediately. The same treatment was then
applied to the editable editor and the Model text panel so all three panels match.]

### Minor — Consider

- [x] **Log level disagreed between the two tabs** — `logger.warn` in the resource panel vs
      `logger.error` in the editable editor for the same class of PDP failure, undercutting the
      "one source of truth" goal. _(fixed during review: both now branch identically. Investigated
      what was actually pre-existing rather than guessing — the editable editor's `logger.error` was
      the only prior pattern; the resource panel previously logged **nothing** at all, so the `warn`
      was new in this PR, not an existing convention.)_
- [x] **Book-not-found was logged as a fault** even though it is ordinary navigation, so every
      navigation to a missing book emitted a warning/error. _(fixed during review: branches on
      `isBookNotFoundError` first — `logger.debug` for the expected missing book, `logger.error`
      retained for genuine PDP failures, so the pre-existing severity for real faults is not
      downgraded. Verified in `~/Library/Logs/Electron/main.log`: the new messages appear at
      `[debug]` and there are **zero** error-level book-not-found entries.)_
- [x] **`isPlatformError` evaluated twice on the same value** in `resource-text-panel.web-view.tsx`
      (once for `usjFromPdp`, again inside the `bookExists` memo), where the editable editor derives
      both in one pass. _(fixed during review: collapsed to a single
      `const [usjFromPdp, bookExists] = useMemo<[Usj | undefined, boolean]>(...)`, matching the
      editable editor's shape. The resource panel's `undefined`-on-error semantics were preserved —
      unlike the editor's `defaultUsj` — because the `if (usjFromPdp)` guard downstream depends on
      it.)_
- [x] **The two tabs styled the identical message differently** — `tw:flex-1 … tw:p-8 tw:text-center`
      vs `tw:h-full tw:px-4` with no centering — so the same sentence sat in a different place
      depending on which tab you were in. _(fixed during review, then **superseded by #2691**, which
      replaced that whole branch. The in-review `EmptyState` wrapper was dropped in the rebase; the
      cross-surface consistency it was after is now delivered by the two edits described under
      "Rebased onto PT-4111" above.)_
- [x] **The C#/TypeScript contract was advisory only** — `BOOK_NOT_FOUND_REGEX` is coupled to
      `MissingBookException.cs`'s message text, comments pointed both ways, but nothing failed if
      someone reworded the C#. _(fixed during review: added
      `c-sharp-tests/MissingBookExceptionTests.cs` (4 tests) pinning the exact wording and the
      regex the extension applies, and cross-referenced the comments on both sides.
      **Falsifiability checked**: temporarily rewording the C# message to
      `"Book {n} is missing from {id}."` failed 3 of the 4 tests; original restored.)_
- [x] **No panel-level test for the render fork** — the predicate was unit-tested, but the
      "render the message instead of the editor" decision was not. _(fixed during review for the
      Model text panel: 4 tests added to the existing `model-text-panel.component.test.tsx`
      covering the message replacing the editor, the `role="status"` live region, the negative
      control (an unrelated failure still renders the editor), and recovery when navigating back to
      a book the resource has. **Falsifiability checked**: disabling the render branch failed 3 of
      the 4, with the negative control correctly still passing. `resource-text-panel.web-view.tsx`
      still has no test file of its own — see Suggested Review Focus.)_
- [ ] ~~`logger` call inside `useMemo` is a render-time side effect (double-fires under StrictMode)~~
      _(Dismissed: consistent with the pre-existing editable editor, both files now do it
      identically, and the common case is now `debug` so the noise is minimal. Moving it to a
      `useEffect` would split the log from the derivation it explains.)_
- [ ] ~~A shared `{ usj, bookExists }` helper would make "one source of truth" cover the whole
      guard → log → branch dance, not just the regex~~ _(Dismissed: the three call sites differ in
      fallback (`defaultUsj` vs `undefined` vs React state) and in log wording, so the helper would
      need enough parameters that it would not clearly pay for itself.)_
- [ ] ~~The message says what is missing but not what to do next~~ _(Dismissed: the change
      deliberately reuses the existing string rather than coining a new one, and rewording would
      affect all three panels. Per the style guide a *meaning* change would need a new key.)_
- [ ] ~~The borrowed localization key is prepended above the alphabetized `%webView_resourcePanel_*`
      block~~ _(Dismissed: the comment above it already marks it as borrowed from another web view's
      namespace, which is the information a reader needs.)_
- [ ] ~~`Editorial` is unmounted while the book is missing, so returning to a book that exists
      remounts a fresh editor whose content depends on the `setUsj` effect refiring~~
      _(Dismissed as a known, pre-existing coupling: it mirrors the editable editor's existing
      `!bookExists` early return, and holds as long as `useProjectData` returns a new object
      identity per chapter. The Model text panel's equivalent recovery path **is** now covered by a
      test.)_

[Author response: Author asked for the log-level disagreement, the double evaluation, the
cross-tab styling divergence, and the unenforceable C# contract to be fixed, and asked that the
pre-existing pattern be checked rather than assumed. The remaining five were dismissed with
reasoning recorded above.]

### Template Propagation

#### Shared Regions Modified

None. The only `#region shared with` marker in this extension is in `src/webpack-env.d.ts`, which
is not in the diff. (The new `#region PDP Error Detection` is a plain region marker, not a shared
one.)

#### Extension Config Changes

None. No `package.json`, `tsconfig.json`, `webpack.config.ts`, `.eslintrc*`, CI, or dependency
changes.

## Positive Observations

- The regex and its `MissingBookException.cs` coupling comment moved together into the utils
  module, so the fragile string stayed documented at its new home — and it was renamed to
  `BOOK_NOT_FOUND_REGEX`, matching the neighboring `PERMISSIONS_EXCEPTION_REGEX` convention that
  the old `bookNotFoundRegex` did not follow.
- `isBookNotFoundError` was placed in the module that already hosts this extension's shared pure
  helpers, respecting that file's documented extension-host import boundary — a real trap given the
  header comment there. `extension-host-import-boundary.test.ts` passes.
- The TSDoc explicitly covers the `undefined`/in-flight and plain-USJ cases, and the tests cover
  exactly those branches including the "unrelated `PlatformError`" negative.
- No new localized strings: the existing key is reused, with both `en` and `es` entries already
  present, and an inline comment explains why a `platformScriptureEditor`-prefixed key appears in
  other panels.
- Placing the message outside the `dir={options.textDirection}` wrapper — with a comment saying why
  — is exactly right for a mixed-direction panel: resource text keeps its own direction while the
  UI sentence follows the interface locale.
- Keeping the resource selector mounted in the missing-book case leaves the user a way out instead
  of stranding them.
- The refactor of the editable editor is behavior-preserving: the deleted local regex and the
  retained log produce the same `bookExists` result as before.
- Comments throughout explain *why* rather than restating the code.

## Interview Notes

**Stated purpose**: make the Bible text tab honest when the selected resource lacks the current
book, instead of showing stale content or an edit prompt in a read-only resource.

**Key decisions the author made during review:**

- On the `EmptyState` finding, the author chose to adopt the shared component rather than defend the
  bare `<div>`.
- On the log-level disagreement, the author explicitly asked *"What was pre-existing? We want to
  follow code patterns"* rather than accepting a proposed level. That check changed the outcome: the
  investigation showed `logger.error` was the only pre-existing pattern and that the `logger.warn`
  was introduced by this PR, so `error` was retained for genuine faults instead of being downgraded
  to `warn` across both files.
- The author endorsed branching on `isBookNotFoundError` so the expected case logs quietly.
- The author approved collapsing the resource panel to the editable editor's single-memo shape
  specifically on consistency-with-existing-patterns grounds.
- When shown screenshot evidence that the **Model text panel** had the same unfixed bug, the author
  chose to fix it in this PR rather than defer it, accepting the scope increase.

**Author understanding**: the author demonstrated clear understanding of the change throughout and
drove several decisions rather than accepting suggestions. The "what was pre-existing?" question in
particular caught an assumption that would otherwise have silently changed existing behavior. No
areas were deferred to AI and no uncertainty was expressed.

**Unresolved items**: none.

## Verification Performed

Beyond the standard checks, three behavioral claims in this PR were verified against the running
app rather than inferred from the diff:

1. **The bug reproduces and the fix resolves it** — captured before/after in Platform.Bible using
   SANIAS (a New Testament–only Sanskrit resource) navigated Matthew 1:1 → Genesis 1:1, the same
   navigation on both `main` and this branch. Before: the panel showed Matthew content while the
   toolbar read Genesis 1:1. After: "This book does not exist in this resource." Screenshots are in
   `.review/screenshots/`.
2. **The accessibility fix is real** — the live DOM in both panels is
   `<p role="status" data-testid="…-book-not-found" class="tw:text-sm tw:text-muted-foreground
   tw:text-center">`, and the editor is confirmed unmounted.
3. **The log-level change is real** — `~/Library/Logs/Electron/main.log` shows the new messages at
   `[debug]` with **zero** error-level book-not-found entries.

Both new test groups were **mutation-checked** (deliberately break the code, confirm the tests fail,
restore) rather than merely observed passing.

## In-Review Quality Check

All checks pass after the in-review changes:

| Check | Result |
| --- | --- |
| `npm run typecheck` | Clean |
| `npm run lint` | **0 errors**; 5 warnings, all pre-existing. Two (`import/no-duplicates`) are in `model-text-panel.component.tsx` — a file this branch edits — but they predate it: their line numbers merely shifted from 28/34 to 34/40 because the new imports pushed them down. They concern a duplicate `resource-reference.utils` import unrelated to this change, so they were left alone rather than folded into this PR. |
| Prettier (changed files only) | Already formatted — no changes |
| `csharpier` | Clean, no stray reformats |
| `npm test` | **840 passed**, 58 files |
| `dotnet test c-sharp-tests/` | **1584 passed**, 0 failed, 6 skipped |

No fixes were needed to satisfy the quality gate; no unfixable failures.

## Suggested Review Focus

- [ ] **Scope increase, deliberately taken**: the PR also fixes `model-text-panel.component.tsx`.
      Confirm you are happy with that breadth in one PR versus splitting the Model text panel into a
      follow-up.
- [ ] **The two consistency edits reach into #2691's just-merged code** (`book-not-available-view`'s
      Simple `<span>` and the editor's `isResource` branch). They are deliberate and small, but they
      touch code reviewed days ago under a different ticket — worth confirming you want them here
      rather than as a separate follow-up.
- [ ] **The broadened `isBookNotFoundError` contract**: it now accepts both a `PlatformError` (what
      `useProjectData` returns) *and* a thrown `Error` (what awaiting `getChapterUSJ` rejects with),
      because the Model text panel fails via the second path. Worth a look at whether widening the
      guard to `possibleError instanceof Error` is the right boundary, versus two separate
      predicates.
- [ ] **`resource-text-panel.web-view.tsx` still has no test file**, so its render fork is covered
      only by the manual verification above. The Model text panel's equivalent fork is now
      unit-tested; consider whether the resource panel warrants the same.
- [ ] **`logger` is not in the Model text panel's load-effect dependency array.** `exhaustive-deps`
      is already suppressed on that effect for an unrelated documented reason, and the PAPI logger is
      a stable module-level object, so this is believed safe — but it is a new use of a prop inside
      that effect and worth a second pair of eyes.
- [ ] **The C#↔TS coupling is now enforced by a test, but by duplication**: the regex literal exists
      in both `platform-scripture-editor.utils.ts` and `MissingBookExceptionTests.cs`. A shared
      constant is not possible across the language boundary; confirm the duplicate-with-a-failing-test
      approach is the tradeoff you want.
- [ ] **Surface sweep**: the Bible text tab, Commentaries tab, Model text panel, and both branches
      of the editable editor are now consistent. One known hole is `scripture-text-grid.web-view.tsx`,
      which has no book-not-found handling at all (its only `EmptyState` is "no resources selected").
      It is Power-only and setting-gated, so it may be out of scope — worth a deliberate decision
      rather than an omission.

## Screenshots

> Reproduced with **SANIAS** (Sanskrit Bible, New Testament only) navigated Matthew 1:1 → Genesis 1:1 — the same navigation on `main` and on this branch.

| | Before (`main`) | After (this branch) |
| --- | --- | --- |
| **Bible text panel** | Shows Matthew content while the toolbar reads Genesis 1:1 | "This book does not exist in this resource." |
| **Model text panel** | Shows Matthew content (same bug, different code path) | "This book does not exist in this resource." |

_Screenshot files are in `.review/screenshots/` (gitignored) — attach `before-full-window.png` and `after-full-window.png` here._

<!-- review-paratext:summary:end -->

AI-assisted — [session](<session URL>)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2706)
<!-- Reviewable:end -->

