### PR TITLE
PT-4368: Guard DBL install verification against null InstalledScrText

### DIFF
--- a/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
+++ b/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
@@ -1,4 +1,4 @@
-using System.Diagnostics;
+﻿using System.Diagnostics;
 using System.Text.Json;
 using Paranext.DataProvider.ParatextUtils;
 using Paranext.DataProvider.Services;
@@ -285,12 +285,23 @@ internal class DblResourcesDataProvider(
                 )
             );
 
-        // Note that we don't get any info telling if the installation succeeded or failed
+        // Install()'s return value is NOT a success flag: InstallableResource.InternalInstall
+        // returns `fontsFound` ("true if any fonts were copied"), so false is the normal return for
+        // a successful install of a resource that ships no fonts. Presence in the collection is the
+        // only usable signal, which is what we check below.
         installableResource.Install();
 
         ScrTextCollection.RefreshScrTexts();
 
-        if (!ScrTextCollection.IsPresent(installableResource.InstalledScrText))
+        // InstalledScrText is assigned only once InternalInstall completes, so it is still null when
+        // the install bailed out early (e.g. the DBL download failed). ScrTextCollection.IsPresent
+        // dereferences its argument, so a null check must come first — otherwise the very failure
+        // this guard exists to report surfaces as a NullReferenceException instead of the localized
+        // message below.
+        if (
+            installableResource.InstalledScrText == null
+            || !ScrTextCollection.IsPresent(installableResource.InstalledScrText)
+        )
             throw new Exception(
                 LocalizationService.GetLocalizedString(
                     PapiClient,

--- a/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
+++ b/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
@@ -1,4 +1,4 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Text.Json;
 using Paranext.DataProvider.ParatextUtils;
 using Paranext.DataProvider.Services;
@@ -293,11 +293,11 @@ internal class DblResourcesDataProvider(
 
         ScrTextCollection.RefreshScrTexts();
 
-        // InstalledScrText is assigned only once InternalInstall completes, so it is still null when
-        // the install bailed out early (e.g. the DBL download failed). ScrTextCollection.IsPresent
-        // dereferences its argument, so a null check must come first — otherwise the very failure
-        // this guard exists to report surfaces as a NullReferenceException instead of the localized
-        // message below.
+        // InstalledScrText is assigned only once InternalInstall completes, so it is still null
+        // when the install bailed out early (e.g. the DBL download failed).
+        // ScrTextCollection.IsPresent dereferences its argument, so a null check must come first —
+        // otherwise the very failure this guard exists to report surfaces as a
+        // NullReferenceException instead of the localized message below.
         if (
             installableResource.InstalledScrText == null
             || !ScrTextCollection.IsPresent(installableResource.InstalledScrText)


### PR DESCRIPTION
## Summary

A failed DBL resource install threw `NullReferenceException` out of the very check that exists to
report it, so **Get Resources** never showed its own "installation failed" message.

`InstallDblResourceCore` verified an install with
`ScrTextCollection.IsPresent(installableResource.InstalledScrText)`. ParatextData assigns
`InstalledScrText` only once `InstallableResource.InternalInstall` completes, so it stays `null`
whenever the install bailed out early (e.g. the DBL download failed) — and
`ScrTextCollection.IsPresentInternal(ScrText)` dereferences `scrText.Guid`. The localized
`%getResources_errorInstallResource_installationFailed%` message was therefore unreachable: the
failure path always faulted with an NRE first.

This null-checks `InstalledScrText` before the presence check, so the failure surfaces with its
intended message.

### Why review this

Not part of the current epic — *please correct this if PT-4368 is being counted as epic work.*

This came out of investigating **PT-4368** ("first-time sync silently skips connected resources").
The bulk of that bug lives in Paratext 10 Studio's `SyncProjectsCore` and is being fixed separately
in the patch repo; this is the one piece that belongs in public core, and it stands on its own. It is
worth reviewer time now because it is the *reporting* path for a resource install failure — while it
is broken, any DBL install failure is misdiagnosed as a program error rather than shown to the user,
which makes the Studio-side work harder to verify.

## Changes

- `c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs` — null-check
  `InstalledScrText` before `ScrTextCollection.IsPresent`.
- Replaced the comment "we don't get any info telling if the installation succeeded or failed",
  which is not accurate, with a note on what `Install()`'s return value actually means (below).

### The one thing worth your judgment

The obvious-looking alternative fix is to test `Install()`'s return value. **That would be a bug**,
and the new comment exists to stop someone doing it later.
`InstallableResource.Install()` → `InternalInstall()` ends with `return fontsFound;`, XML-documented
as *"true if any fonts were copied to the destination folder"*. So `false` is the **normal** return
for a *successful* install of a resource that ships no fonts — i.e. most resources. Presence in the
collection is the only usable success signal, which is what this method already (correctly) chose to
use.

`InstallableDBLResource.Install()` does return `false` early when the download itself fails, which is
what makes the bool look like a success flag at a glance — but it otherwise returns `base.Install()`,
so its `false` is ambiguous between "download failed" and "installed, no fonts".

## AI Involvement

AI-assisted. The change, its comments, and this description were drafted by Claude Code (Claude Opus
5) and reviewed by me. The commit carries a `Co-Authored-By` trailer attributing it as a generator;
I am the author.

Specifically AI-generated: the 13-line diff and its two comments. The claims about ParatextData's
behavior were verified directly against the Paratext 9 source tree
(`ParatextData/Archiving/InstallableResource.cs`, `ParatextData/ScrTextCollection.cs`) rather than
inferred — the `fontsFound` return, the single `InstalledScrText` assignment site, and the
`scrText.Guid` dereference in `IsPresentInternal` are each read from that source. Reviewers who want
to spot-check should look there.

## Testing

- [x] `dotnet build` — succeeded, 0 errors. The 4 warnings are pre-existing `CS8625`s in
      `ParatextProjectDataProviderCommentTests.cs`, untouched here.
- [x] `dotnet test c-sharp-tests/` — 1716 passed, 0 failed, 7 pre-existing skips (re-run after rebasing onto `main`).
- [x] `dotnet csharpier --check` — clean on the changed file.
- [ ] Not manually verified in the app: reaching this branch requires a genuine DBL install failure
      (a download that fails mid-flight, or a resource whose zip fails `CheckResource`), which I
      could not stage reliably. The change is a null guard ahead of an existing check, so the
      success path is unaffected by construction.

No test was added. The method is not currently covered — there is no
`c-sharp-tests/Projects/DigitalBibleLibrary/` — and exercising it needs `InstallableDBLResource` plus
live DBL access, so a unit test here would only be able to assert against a mock of the very
ParatextData behavior at issue. Happy to add one if a reviewer sees a seam I missed.

## Risk Level

Low — one file, +13/-2, C# only. Adds a null check ahead of an existing condition; the
already-installed and success paths are unchanged. Worst case, a failure that used to throw NRE now
throws the localized message instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2709)
<!-- Reviewable:end -->

