### PR TITLE
PT-4356: Add posthog-node dependency (PostHog provider groundwork)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "node-localstorage": "^3.0.5",
         "platform-bible-react": "file:./lib/platform-bible-react",
         "platform-bible-utils": "file:./lib/platform-bible-utils",
+        "posthog-node": "^5.51.1",
         "radix-ui": "^1.4.3",
         "rc-dock": "^3.3.2",
         "react": "^19.0.0",
@@ -6863,6 +6864,21 @@
     "node_modules/@polka/url": {
       "version": "1.0.0-next.24",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.48.10",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.48.10.tgz",
+      "integrity": "sha512-Y70zhdQFNMwHHZk9MW44MJUR1DyFm0Cn3DOtd+wQYnGv+kX+qc6CA+pBtEmZe2XD0K9uuOKiz2LJwzaq/wz0FA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "^1.405.2"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.405.2",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.405.2.tgz",
+      "integrity": "sha512-NVsw5pER9YEDFOfvmbpyRtIgv+0411QXHg1IjCFh+EcxtmLUP2FdJyiWYVpNM6WhTTlrPEW+fPZpGz1OBXijvQ==",
       "license": "MIT"
     },
     "node_modules/@preact/signals-core": {
@@ -25677,6 +25693,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/posthog-node": {
+      "version": "5.51.1",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.51.1.tgz",
+      "integrity": "sha512-uEGB5OQvYl9f8Fy2t4FolhcBBlYB8sZM6/4Us517M5dcg/d00yyCusm0HydZFwbPQtPntlpr3gNAmv8TTbWuaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "^1.48.9"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/postject": {
       "version": "1.0.0-alpha.6",
       "dev": true,
@@ -27463,7 +27499,7 @@
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"

--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "node-localstorage": "^3.0.5",
     "platform-bible-react": "file:./lib/platform-bible-react",
     "platform-bible-utils": "file:./lib/platform-bible-utils",
+    "posthog-node": "^5.51.1",
     "radix-ui": "^1.4.3",
     "rc-dock": "^3.3.2",
     "react": "^19.0.0",


### PR DESCRIPTION
## Summary

Adds the server-side PostHog SDK (`posthog-node`) as groundwork for a `PostHogAnalyticsProvider`. The analytics abstraction itself **already merged to main via #2686 (PT-4337)**; this PR adds only the dependency on top of that abstraction. Part of the current epic (PT-4356).

## Why this is now a single commit

This branch originally carried a parallel analytics-abstraction implementation, but **#2686 landed the same abstraction on main first**. Rebasing onto main, those commits were dropped as redundant (main's version supersedes them) — the branch now adds only `posthog-node`, which main doesn't yet have.

## Changes

- Adds `posthog-node@^5.51.1` as a runtime dependency (+ transitive `@posthog/core`, `@posthog/types`).
- **No code consumer yet** — the `PostHogAnalyticsProvider`, implementing main's `AnalyticsProvider` interface (`src/shared/models/analytics.model.ts`), is a follow-up PR.

## Why the server-side SDK

The analytics engine runs in the Node extension host (`src/extension-host/services/analytics.service.ts`), so `posthog-node` is the correct SDK — not the renderer's `posthog-js`. Node 22.22.1 (Volta pin) satisfies the package's `engines` (`^20.20.0 || >=22.22.0`).

## AI Involvement

AI-assisted (Claude Opus 4.8): added the dependency, rebased the branch onto main — dropping the redundant analytics commits after discovering #2686 had superseded them — and drafted this description. Verified the install loads (`require('posthog-node')` exposes the `PostHog` client) and that the diff vs `main` is only the dependency. All changes reviewed by the author. _(Author: add the session URL per the authorship rule in `CLAUDE.md`.)_

## Testing

- [x] `posthog-node` loads and exposes the `PostHog` client; `npm ls posthog-node` resolves cleanly.
- [x] Diff vs `main` is exactly the dependency — `package.json` +1 line; lockfile adds `posthog-node` + 2 transitive deps, nothing else.
- [x] `npm run typecheck:core` passes (exit 0, no errors) — covers `src/main`, `src/extension-host`, `src/shared`.

## Risk Level

**Low** — an unused runtime dependency until its provider lands. No code or behavior change.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2713)
<!-- Reviewable:end -->
