### PR TITLE
PT-4412: Install DOM globals in Node processes for scripture-utilities

### DIFF
--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -2233,11 +2233,11 @@ step, no automation. Just a record.
   plus a non-dev 0.9.x nested under scripture-utilities), letting an existing global win so a real
   DOM is never overridden. It is a **side-effect module** imported **first** by `extension-host.ts`
   — see that module's docs for why a callable function would run too late. `vitest.setup.node.ts`
-  installs it too, because the `node`-environment test projects (`extensions`,
-  `lib/platform-bible-utils`) run the same converters and would otherwise fail outright; it is kept
-  out of the shared `vitest.setup.ts` so the jsdom projects, which already have a real DOM, do not
-  pull xmldom into all ~150 of their workers for nothing. The main
-  process is deliberately **not** polyfilled: it has no converter call sites.
+  installs it too, because the `node`-environment test projects that run the converters would
+  otherwise fail outright; each such project wires that file in itself, so the ones that never touch
+  the converters do not load it. It is kept out of the shared `vitest.setup.ts` so the jsdom
+  projects, which already have a real DOM, do not pull xmldom into all ~150 of their workers for
+  nothing. The main process is deliberately **not** polyfilled: it has no converter call sites.
 - **Alternatives:** **Let the package fall back to `@xmldom/xmldom` when no DOM is present** (what
   scripture-editors issue #516 floated) — needs no core change, but it is a cross-repo change we do
   not control and would have to land first. **Install from `global-this.model.ts` alongside

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -2216,3 +2216,52 @@ step, no automation. Just a record.
   for a typed surface rather than a state key.
 - **Source:** PT-4346, global BCV control showing books from open resources.
 
+## adr-node-dom-globals-polyfill: Node processes install `@xmldom/xmldom` DOM globals; the extension host does it in a first-import side-effect module
+
+- **Date:** 2026-08-22
+- **Status:** Accepted
+- **Context:** scripture-editors PR
+  [#541](https://github.com/eten-tech-foundation/scripture-editors/pull/541) drops `@xmldom/xmldom`
+  from `@eten-tech-foundation/scripture-utilities` (~89 KB off browser bundles) and makes the
+  USX⇔USJ converters use the platform's **native** `DOMParser`/`XMLSerializer`. Browsers and web
+  views have those; our extension host is plain Node and does not, so the converters throw. It
+  reaches them through `platform-scripture`'s finder and extender PDPEs — every scripture read and
+  write. There was no runtime DOM shim anywhere in `src/`; every `jsdom` reference was in tests.
+- **Decision:** paranext-core supplies the globals rather than waiting on the package.
+  `src/node/polyfills/dom-globals.polyfill.ts` installs them from `@xmldom/xmldom` (now a declared
+  root dependency; previously it reached us only transitively — a dev-only 0.8.x hoisted via `plist`
+  plus a non-dev 0.9.x nested under scripture-utilities), letting an existing global win so a real
+  DOM is never overridden. It is a **side-effect module** imported **first** by `extension-host.ts`
+  — see that module's docs for why a callable function would run too late. `vitest.setup.node.ts`
+  installs it too, because the `node`-environment test projects (`extensions`,
+  `lib/platform-bible-utils`) run the same converters and would otherwise fail outright; it is kept
+  out of the shared `vitest.setup.ts` so the jsdom projects, which already have a real DOM, do not
+  pull xmldom into all ~150 of their workers for nothing. The main
+  process is deliberately **not** polyfilled: it has no converter call sites.
+- **Alternatives:** **Let the package fall back to `@xmldom/xmldom` when no DOM is present** (what
+  scripture-editors issue #516 floated) — needs no core change, but it is a cross-repo change we do
+  not control and would have to land first. **Install from `global-this.model.ts` alongside
+  `polyfillLocalStorage()`** — matches the existing polyfill pattern, but that module already
+  transitively imports `platform-bible-utils`, so its graph is fully evaluated before the install
+  would run; the ordering guarantee would be accidental rather than structural. **Pin the root dep
+  to `^0.8.10`** to match the dev-only hoisted copy — rejected: scripture-utilities parses and
+  serializes with 0.9.x internally, and this code writes scripture to disk, so the extension host
+  should stay on the 0.9 line rather than drop to an older parser. Note this does not pin an exact
+  engine: declaring `^0.9.8` at the root dedupes the package's own nested 0.9.10 away, so the
+  converters now run on whatever 0.9.x resolves at the root (0.9.12 today).
+- **Consequences:** Two `@xmldom/xmldom` majors now live in the tree on purpose.
+  `platform-enhanced-resources` declares `^0.8.10` because `marble-converter.ts` passes
+  `errorHandler` as an object, which 0.9 rejects with a `TypeError`; that dependency was previously
+  undeclared and resolved to the hoisted copy, so the root declaration would otherwise have silently
+  upgraded it and broken every marble conversion. npm satisfies that range by hoisting 0.8.x to
+  `extensions/node_modules/`, which makes it the default for **every** package under
+  `extensions/src/*`, not just this one — `import/no-extraneous-dependencies` is off, so the next
+  extension to import `@xmldom/xmldom` binds to 0.8.x with no warning. Two follow-ups worth taking
+  together: `convertMarbleChapterXml` runs only in a web view, which already has a native
+  `DOMParser`, so dropping the dependency there would remove the pin, the version split, and this
+  paragraph at once. Separately, `@xmldom/xmldom` emits no `parsererror` element, so PR #541's
+  malformed-XML guard is inert under the shim; fatally malformed USX still throws (as a `ParseError`
+  from inside `parseFromString`, not the renderer's `Invalid USX:` error), but *recoverable* defects
+  are silently repaired rather than rejected — on the extension host that repaired form is what gets
+  written back to disk. Revisit if the package ever ships its own Node fallback.
+- **Source:** PT-4412.

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -2257,11 +2257,14 @@ step, no automation. Just a record.
   `extensions/node_modules/`, which makes it the default for **every** package under
   `extensions/src/*`, not just this one — `import/no-extraneous-dependencies` is off, so the next
   extension to import `@xmldom/xmldom` binds to 0.8.x with no warning. Two follow-ups worth taking
-  together: `convertMarbleChapterXml` runs only in a web view, which already has a native
-  `DOMParser`, so dropping the dependency there would remove the pin, the version split, and this
+  together: PT-4445 migrates `marble-converter` to 0.9's `onError` and drops the pin, and PT-4446
+  supersedes it — `convertMarbleChapterXml` runs only in a web view, which already has a native
+  `DOMParser`, so dropping the dependency there removes the pin, the version split, and this
   paragraph at once. Separately, `@xmldom/xmldom` emits no `parsererror` element, so PR #541's
   malformed-XML guard is inert under the shim; fatally malformed USX still throws (as a `ParseError`
   from inside `parseFromString`, not the renderer's `Invalid USX:` error), but *recoverable* defects
   are silently repaired rather than rejected — on the extension host that repaired form is what gets
-  written back to disk. Revisit if the package ever ships its own Node fallback.
-- **Source:** PT-4412.
+  written back to disk. That write-path asymmetry is **PT-4444**, flagged at the save site in
+  `platform-scripture-extender-pdpe.model.ts`. Revisit if the package ever ships its own Node
+  fallback.
+- **Source:** PT-4412, review of #2714.

--- a/extensions/src/platform-enhanced-resources/package.json
+++ b/extensions/src/platform-enhanced-resources/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@sillsdev/scripture": "^2.0.5",
+    "@xmldom/xmldom": "^0.8.10",
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {

--- a/extensions/src/platform-enhanced-resources/src/lib/marble-converter.ts
+++ b/extensions/src/platform-enhanced-resources/src/lib/marble-converter.ts
@@ -5,6 +5,11 @@
 // __unknownAttributes mechanism. xmldom's child-list APIs may surface either
 // undefined or null for "absent", so we coalesce both at boundaries.
 /* eslint-disable no-type-assertion/no-type-assertion, no-null/no-null */
+// This extension pins @xmldom/xmldom to 0.8.x in its package.json because the `errorHandler` object
+// below is 0.8-only — 0.9 throws "errorHandler object is no longer supported, switch to onError!".
+// The repo root declares 0.9.x for the extension host's DOM globals, so without the pin this file
+// would resolve 0.9 and throw on every conversion.
+// TODO: migrate to 0.9's `onError` and drop the pin (follow-up to PT-4412).
 import { DOMParser } from '@xmldom/xmldom';
 import {
   USJ_TYPE,

--- a/extensions/src/platform-enhanced-resources/src/lib/marble-converter.ts
+++ b/extensions/src/platform-enhanced-resources/src/lib/marble-converter.ts
@@ -9,7 +9,9 @@
 // below is 0.8-only — 0.9 throws "errorHandler object is no longer supported, switch to onError!".
 // The repo root declares 0.9.x for the extension host's DOM globals, so without the pin this file
 // would resolve 0.9 and throw on every conversion.
-// TODO: migrate to 0.9's `onError` and drop the pin (follow-up to PT-4412).
+// TODO(PT-4445): migrate to 0.9's `onError` and drop the pin — or PT-4446, which drops the
+// dependency entirely since this converter only ever runs in a web view, which has a native
+// `DOMParser`.
 import { DOMParser } from '@xmldom/xmldom';
 import {
   USJ_TYPE,

--- a/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-extender-pdpe.model.ts
+++ b/extensions/src/platform-scripture/src/project-data-provider/platform-scripture-extender-pdpe.model.ts
@@ -127,6 +127,13 @@ export class ScriptureExtenderProjectDataProviderEngine
     });
   }
 
+  // A read-modify-write round-trips through `usxStringToUsj` in the getters below and back out
+  // through the two setters here. On the extension host that parse runs on `@xmldom/xmldom` (see
+  // `adr-node-dom-globals-polyfill`), which silently repairs recoverable USX defects rather than
+  // rejecting them — the renderer's native `DOMParser` rejects the same input — so what these
+  // setters persist is the repaired form, not what was on disk.
+  // TODO(PT-4444): make the two processes agree on what USX is valid, then drop this note.
+
   // Do not emit update events when running this method because we are subscribing to data updates
   // and sending out update events in the constructor
   @papi.dataProviders.decorators.doNotNotify

--- a/extensions/vitest.config.ts
+++ b/extensions/vitest.config.ts
@@ -9,7 +9,10 @@ const config = defineConfig({
     environment: 'node',
     // Warm the lazy one-time ICU init behind Intl.* so it never lands inside a test's timeout
     // window on a slow CI worker. Shares the repo-root setup file. See vitest.setup.ts for rationale.
-    setupFiles: [path.resolve(__dirname, '../vitest.setup.ts')],
+    setupFiles: [
+      path.resolve(__dirname, '../vitest.setup.ts'),
+      path.resolve(__dirname, '../vitest.setup.node.ts'),
+    ],
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'lib/**/*.test.ts', 'lib/**/*.test.tsx'],
   },
   resolve: {

--- a/lib/platform-bible-utils/vite.config.ts
+++ b/lib/platform-bible-utils/vite.config.ts
@@ -43,7 +43,10 @@ const config = defineConfig({
     // Warm the lazy one-time ICU init behind Intl.* so it never lands inside a test's timeout window
     // on a slow CI worker. This workspace's intl/* tests construct Intl.NumberFormat/DateTimeFormat/
     // Collator directly. Shares the repo-root setup file. See vitest.setup.ts for rationale.
-    setupFiles: [path.resolve(__dirname, '../../vitest.setup.ts')],
+    setupFiles: [
+      path.resolve(__dirname, '../../vitest.setup.ts'),
+      path.resolve(__dirname, '../../vitest.setup.node.ts'),
+    ],
   },
 });
 export default config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "paranext-core",
+  "name": "pt-4412-dom-globals",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -13,6 +13,7 @@
       ],
       "dependencies": {
         "@sillsdev/scripture": "^2.0.5",
+        "@xmldom/xmldom": "^0.9.8",
         "ajv": "^8.18.0",
         "chalk": "^4.1.2",
         "chokidar": "^3.6.0",
@@ -255,6 +256,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "extensions/node_modules/@xmldom/xmldom": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "extensions/node_modules/arg": {
@@ -647,6 +657,7 @@
       "license": "MIT",
       "dependencies": {
         "@sillsdev/scripture": "^2.0.5",
+        "@xmldom/xmldom": "^0.8.10",
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
@@ -4281,15 +4292,6 @@
       "license": "MIT",
       "dependencies": {
         "@xmldom/xmldom": "^0.9.8"
-      }
-    },
-    "node_modules/@eten-tech-foundation/scripture-utilities/node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.6"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -12296,11 +12298,12 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.13",
-      "dev": true,
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
       "license": "MIT",
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.6"
       }
     },
     "node_modules/@xtuc/ieee754": {
@@ -24971,6 +24974,16 @@
       },
       "engines": {
         "node": ">=10.4.0"
+      }
+    },
+    "node_modules/plist/node_modules/@xmldom/xmldom": {
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.15.tgz",
+      "integrity": "sha512-/5NV/vDALVFDXgLmfsy9TRCBlKwO2LNBFzpzvb9iIj+jR+eSc6DLYYvVOdivT/jm7MtU6TebYuRmzEOI7w40UA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "pt-4412-dom-globals",
+  "name": "paranext-core",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
   "browserslist": ["extends browserslist-config-detect-electron"],
   "dependencies": {
     "@sillsdev/scripture": "^2.0.5",
+    "@xmldom/xmldom": "^0.9.8",
     "ajv": "^8.18.0",
     "chalk": "^4.1.2",
     "chokidar": "^3.6.0",

--- a/src/extension-host/extension-host.ts
+++ b/src/extension-host/extension-host.ts
@@ -1,3 +1,5 @@
+// Keep first: installs DOM globals before any import can convert scripture. See the module's docs.
+import '@node/polyfills/dom-globals.polyfill';
 import '@extension-host/global-this.model';
 import '@node/utils/log-archiver.util';
 import { isClient } from '@shared/utils/internal-util';

--- a/src/node/polyfills/dom-globals.polyfill.test.ts
+++ b/src/node/polyfills/dom-globals.polyfill.test.ts
@@ -60,6 +60,32 @@ function firstEvaluatedSpecifier(source: string): string | undefined {
   return evaluated.sort((a, b) => a.index - b.index)[0]?.specifier;
 }
 
+/**
+ * Whether the installed `@eten-tech-foundation/scripture-utilities` delegates its XML work to the
+ * platform's DOM globals — true from the release that drops the package's own bundled
+ * `@xmldom/xmldom` (scripture-editors PR #541) onward, false before it, where the converters run
+ * fine in bare Node and nothing this polyfill installs is reachable.
+ *
+ * Probing beats reading the version because the behavior, not the range, is what the polyfill
+ * exists for.
+ */
+function convertersNeedDomGlobals(): boolean {
+  const saved = DOM_GLOBAL_NAMES.map((name) => [name, Reflect.get(globalThis, name)] as const);
+  DOM_GLOBAL_NAMES.forEach((name) => Reflect.deleteProperty(globalThis, name));
+  try {
+    usxStringToUsj('<usx version="3.0"><book code="GEN" style="id">Genesis</book></usx>');
+    return false;
+  } catch {
+    return true;
+  } finally {
+    saved.forEach(([name, value]) => {
+      if (value !== undefined) Reflect.set(globalThis, name, value);
+    });
+  }
+}
+
+const CONVERTERS_NEED_DOM_GLOBALS = convertersNeedDomGlobals();
+
 beforeEach(() => {
   savedGlobals = Object.fromEntries(
     DOM_GLOBAL_NAMES.map((name) => [name, Reflect.get(globalThis, name)]),
@@ -96,9 +122,12 @@ describe('dom-globals.polyfill', () => {
     expect(serialized).toContain('Genesis');
   });
 
-  // Asserting the globals exist is not the same as asserting the package accepts them: it gates on
-  // its own `assertDomEnvironment` and could need more of the environment than we install. This
-  // drives the exact two functions the extension host calls on every scripture read and write.
+  // Asserting the globals exist is not the same as asserting the package accepts them: once it
+  // gates on its own `assertDomEnvironment` it could need more of the environment than we install.
+  // This drives the exact two functions the extension host calls on every scripture read and write.
+  //
+  // While `scripture-utilities` still bundles its own `@xmldom/xmldom` this passes with or without
+  // the polyfill — see the skipped test below, which is what makes the difference detectable.
   test('the real USX⇔USJ converters round-trip under the installed globals', async () => {
     await importPolyfillFresh();
     const usx =
@@ -117,6 +146,19 @@ describe('dom-globals.polyfill', () => {
     // would drift a little further on every save.
     expect(usxStringToUsj(reserialized)).toEqual(usj);
   });
+
+  // The falsifying half of the round-trip test above: without it, deleting the polyfill outright
+  // still leaves this file green. It reports as skipped — not passed — for as long as the installed
+  // `scripture-utilities` bundles its own XML implementation, so nobody reads green CI as proof the
+  // polyfill is load-bearing. It starts failing the moment the polyfill stops working.
+  test.skipIf(!CONVERTERS_NEED_DOM_GLOBALS)(
+    'the converters fail without the globals, so the polyfill is what makes them work',
+    () => {
+      expect(() =>
+        usxStringToUsj('<usx version="3.0"><book code="GEN" style="id">Genesis</book></usx>'),
+      ).toThrow(/DOM environment/);
+    },
+  );
 
   test('does not override a real DOM (renderer, jsdom tests)', async () => {
     // Stand-ins for a real DOM's constructors — identity is all this test cares about

--- a/src/node/polyfills/dom-globals.polyfill.test.ts
+++ b/src/node/polyfills/dom-globals.polyfill.test.ts
@@ -20,11 +20,14 @@ async function importPolyfillFresh(): Promise<void> {
 }
 
 /**
- * Whether an `import` clause is erased by the compiler, so it loads nothing at runtime. True for
- * `import type { … }` and for a clause whose every named binding is individually `type`-prefixed.
+ * Whether an `import`/`export` clause is erased by the compiler, so it loads nothing at runtime.
+ * True for `import type { … }` and for a clause whose every named binding is individually
+ * `type`-prefixed.
  *
  * `extensions/src/platform-scripture-editor/src/extension-host-import-boundary.test.ts` needs the
- * same parsing for the same reason; the two cannot share a helper across the workspace boundary.
+ * same parsing for the same reason; the two cannot share a helper across the workspace boundary, so
+ * this function and the specifier patterns below are a deliberate copy of that file's. Fix a
+ * parsing bug in one and fix it in the other.
  */
 function isTypeOnlyClause(clause: string): boolean {
   const trimmed = clause.trim();
@@ -40,21 +43,21 @@ function isTypeOnlyClause(clause: string): boolean {
 
 /**
  * The specifier of the first module `source` evaluates at load time — a side-effect import, a value
- * `import … from`, or a `require`. Type-only clauses are skipped because the compiler erases them,
- * so they cannot run anything.
+ * `import`/`export … from`, or a dynamic `import()`/`require()`. Type-only clauses are skipped
+ * because the compiler erases them, so they cannot run anything.
  */
 function firstEvaluatedSpecifier(source: string): string | undefined {
   const evaluated: { index: number; specifier: string }[] = [];
 
   const sideEffectImport = /(?:^|\n)[ \t]*import[ \t]*['"]([^'"]+)['"]/g;
-  const fromImport = /(?:^|\n)[ \t]*import\b([^;'"]*?)from[ \t]*['"]([^'"]+)['"]/g;
-  const runtimeRequire = /\brequire\([ \t]*['"]([^'"]+)['"]/g;
+  const fromImport = /(?:^|\n)[ \t]*(?:import|export)\b([^;'"]*?)from[ \t]*['"]([^'"]+)['"]/g;
+  const runtimeImport = /\b(?:import|require)\([ \t]*['"]([^'"]+)['"]/g;
 
   for (let match = sideEffectImport.exec(source); match; match = sideEffectImport.exec(source))
     evaluated.push({ index: match.index, specifier: match[1] });
   for (let match = fromImport.exec(source); match; match = fromImport.exec(source))
     if (!isTypeOnlyClause(match[1])) evaluated.push({ index: match.index, specifier: match[2] });
-  for (let match = runtimeRequire.exec(source); match; match = runtimeRequire.exec(source))
+  for (let match = runtimeImport.exec(source); match; match = runtimeImport.exec(source))
     evaluated.push({ index: match.index, specifier: match[1] });
 
   return evaluated.sort((a, b) => a.index - b.index)[0]?.specifier;

--- a/src/node/polyfills/dom-globals.polyfill.test.ts
+++ b/src/node/polyfills/dom-globals.polyfill.test.ts
@@ -1,0 +1,145 @@
+// @vitest-environment node
+// Node, not the repo-default jsdom, on purpose: the extension host is plain Node, and the
+// missing-DOM case this polyfill exists for only reproduces without jsdom's DOM globals.
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { usjToUsxString, usxStringToUsj } from '@eten-tech-foundation/scripture-utilities';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// These tests read and write the DOM globals through `Reflect` because TypeScript declares both as
+// always-present, which rules out `delete` and rejects assigning a stand-in.
+const DOM_GLOBAL_NAMES = ['DOMParser', 'XMLSerializer'] as const;
+
+let savedGlobals: Record<string, unknown> = {};
+
+/** Re-runs the polyfill's module body, which is where it installs the globals */
+async function importPolyfillFresh(): Promise<void> {
+  vi.resetModules();
+  await import('./dom-globals.polyfill');
+}
+
+/**
+ * Whether an `import` clause is erased by the compiler, so it loads nothing at runtime. True for
+ * `import type { … }` and for a clause whose every named binding is individually `type`-prefixed.
+ *
+ * `extensions/src/platform-scripture-editor/src/extension-host-import-boundary.test.ts` needs the
+ * same parsing for the same reason; the two cannot share a helper across the workspace boundary.
+ */
+function isTypeOnlyClause(clause: string): boolean {
+  const trimmed = clause.trim();
+  if (/^type\b/.test(trimmed)) return true;
+  const namedBindings = /^\{([^}]*)\}$/.exec(trimmed);
+  if (!namedBindings) return false;
+  const bindings = namedBindings[1]
+    .split(',')
+    .map((binding) => binding.trim())
+    .filter((binding) => binding.length > 0);
+  return bindings.length > 0 && bindings.every((binding) => /^type\b/.test(binding));
+}
+
+/**
+ * The specifier of the first module `source` evaluates at load time — a side-effect import, a value
+ * `import … from`, or a `require`. Type-only clauses are skipped because the compiler erases them,
+ * so they cannot run anything.
+ */
+function firstEvaluatedSpecifier(source: string): string | undefined {
+  const evaluated: { index: number; specifier: string }[] = [];
+
+  const sideEffectImport = /(?:^|\n)[ \t]*import[ \t]*['"]([^'"]+)['"]/g;
+  const fromImport = /(?:^|\n)[ \t]*import\b([^;'"]*?)from[ \t]*['"]([^'"]+)['"]/g;
+  const runtimeRequire = /\brequire\([ \t]*['"]([^'"]+)['"]/g;
+
+  for (let match = sideEffectImport.exec(source); match; match = sideEffectImport.exec(source))
+    evaluated.push({ index: match.index, specifier: match[1] });
+  for (let match = fromImport.exec(source); match; match = fromImport.exec(source))
+    if (!isTypeOnlyClause(match[1])) evaluated.push({ index: match.index, specifier: match[2] });
+  for (let match = runtimeRequire.exec(source); match; match = runtimeRequire.exec(source))
+    evaluated.push({ index: match.index, specifier: match[1] });
+
+  return evaluated.sort((a, b) => a.index - b.index)[0]?.specifier;
+}
+
+beforeEach(() => {
+  savedGlobals = Object.fromEntries(
+    DOM_GLOBAL_NAMES.map((name) => [name, Reflect.get(globalThis, name)]),
+  );
+  DOM_GLOBAL_NAMES.forEach((name) => Reflect.deleteProperty(globalThis, name));
+});
+
+afterEach(() => {
+  DOM_GLOBAL_NAMES.forEach((name) => {
+    if (savedGlobals[name] === undefined) Reflect.deleteProperty(globalThis, name);
+    else Reflect.set(globalThis, name, savedGlobals[name]);
+  });
+});
+
+describe('dom-globals.polyfill', () => {
+  test('installs DOMParser and XMLSerializer when Node provides neither', async () => {
+    expect(Reflect.get(globalThis, 'DOMParser')).toBeUndefined();
+    expect(Reflect.get(globalThis, 'XMLSerializer')).toBeUndefined();
+
+    await importPolyfillFresh();
+
+    expect(Reflect.get(globalThis, 'DOMParser')).toBeDefined();
+    expect(Reflect.get(globalThis, 'XMLSerializer')).toBeDefined();
+  });
+
+  test('installed globals round-trip USX', async () => {
+    await importPolyfillFresh();
+
+    const usx = '<usx version="3.0"><book code="GEN" style="id">Genesis</book></usx>';
+    const doc = new globalThis.DOMParser().parseFromString(usx, 'text/xml');
+    const serialized = new globalThis.XMLSerializer().serializeToString(doc);
+
+    expect(serialized).toContain('code="GEN"');
+    expect(serialized).toContain('Genesis');
+  });
+
+  // Asserting the globals exist is not the same as asserting the package accepts them: it gates on
+  // its own `assertDomEnvironment` and could need more of the environment than we install. This
+  // drives the exact two functions the extension host calls on every scripture read and write.
+  test('the real USX⇔USJ converters round-trip under the installed globals', async () => {
+    await importPolyfillFresh();
+    const usx =
+      '<?xml version="1.0" encoding="utf-8"?>' +
+      '<usx version="3.0"><book code="GEN" style="id">Genesis</book>' +
+      '<chapter number="1" style="c" sid="GEN 1" />' +
+      '<para style="p"><verse number="1" style="v" sid="GEN 1:1" />In the beginning' +
+      '<note caller="+" style="f"><char style="ft">a footnote</char></note></para></usx>';
+
+    const usj = usxStringToUsj(usx);
+    const reserialized = usjToUsxString(usj);
+
+    expect(reserialized).toContain('code="GEN"');
+    expect(reserialized).toContain('In the beginning');
+    // Re-parsing what we serialized must land on the same USJ, or a read-modify-write of a book
+    // would drift a little further on every save.
+    expect(usxStringToUsj(reserialized)).toEqual(usj);
+  });
+
+  test('does not override a real DOM (renderer, jsdom tests)', async () => {
+    // Stand-ins for a real DOM's constructors — identity is all this test cares about
+    const realDomParser = function RealDomParser() {};
+    const realXmlSerializer = function RealXmlSerializer() {};
+    Reflect.set(globalThis, 'DOMParser', realDomParser);
+    Reflect.set(globalThis, 'XMLSerializer', realXmlSerializer);
+
+    await importPolyfillFresh();
+
+    expect(Reflect.get(globalThis, 'DOMParser')).toBe(realDomParser);
+    expect(Reflect.get(globalThis, 'XMLSerializer')).toBe(realXmlSerializer);
+  });
+
+  // The globals only help if they land before anything that converts at load time, and no tooling
+  // enforces that: there is no import-sorting lint rule or Prettier plugin, so an editor's
+  // "Organize Imports" or a hand edit could reorder it silently. This is the guard.
+  test('is the first module the extension host entry point evaluates', () => {
+    const entryPoint = readFileSync(
+      resolve(__dirname, '../../extension-host/extension-host.ts'),
+      'utf8',
+    );
+
+    expect(firstEvaluatedSpecifier(entryPoint)).toBe('@node/polyfills/dom-globals.polyfill');
+  });
+});

--- a/src/node/polyfills/dom-globals.polyfill.ts
+++ b/src/node/polyfills/dom-globals.polyfill.ts
@@ -1,0 +1,35 @@
+/**
+ * Installs `DOMParser` and `XMLSerializer` as globals for Node processes, which have no DOM.
+ *
+ * `@eten-tech-foundation/scripture-utilities`' USX⇔USJ converters use the platform's native
+ * `DOMParser`/`XMLSerializer` instead of bundling an XML implementation, and throw without them.
+ * Browsers and web views supply them; plain Node does not. The package's README prescribes
+ * `@xmldom/xmldom`, which is what this installs. Existing globals win, so a real DOM (renderer,
+ * jsdom tests) is never overridden.
+ *
+ * **Import this module first** in any Node entry point that needs it, and keep it there. A module's
+ * imports are evaluated in source order before its own body runs — true of both this build's
+ * CommonJS output and ESM — so exporting a function to call, the shape its neighbor
+ * `local-storage.polyfill` uses, would run too late: after every other import had its chance to
+ * convert at load time. `dom-globals.polyfill.test.ts` guards the order.
+ */
+
+import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
+
+/**
+ * Defines `globalThis[name]` unless the environment already provides a usable constructor.
+ *
+ * Tests for `function` rather than `undefined` so a `null` or otherwise non-constructible value
+ * still gets replaced — otherwise callers would see `DOMParser is not a constructor` instead of a
+ * working parser. (`local-storage.polyfill` guards the same shape with an explicit `null` check.)
+ *
+ * Goes through `Reflect` rather than assigning directly because xmldom's DOM types are structurally
+ * looser than lib.dom's, so a direct assignment would need a type assertion to compile.
+ */
+function installGlobalIfMissing(name: 'DOMParser' | 'XMLSerializer', implementation: unknown) {
+  if (typeof Reflect.get(globalThis, name) !== 'function')
+    Reflect.set(globalThis, name, implementation);
+}
+
+installGlobalIfMissing('DOMParser', DOMParser);
+installGlobalIfMissing('XMLSerializer', XMLSerializer);

--- a/vitest.setup.node.ts
+++ b/vitest.setup.node.ts
@@ -1,0 +1,13 @@
+// Additional setup for the `node`-environment vitest projects (`extensions`,
+// `lib/platform-bible-utils`), loaded alongside the shared `vitest.setup.ts`.
+//
+// Those projects run the same scripture converters the extension host does, and the converters need
+// `DOMParser`/`XMLSerializer`, which a `node` environment has none of. Installing them here mirrors
+// what `extension-host.ts` does at startup.
+//
+// Deliberately kept out of the shared setup file: the jsdom projects already have a real DOM, so
+// putting it there would pull xmldom into all ~150 of their workers for nothing — and guarding it
+// with a conditional `await import` would make that file a top-level-await module, which measurably
+// destabilized timing-sensitive renderer tests.
+
+import './src/node/polyfills/dom-globals.polyfill';

--- a/vitest.setup.node.ts
+++ b/vitest.setup.node.ts
@@ -1,7 +1,9 @@
-// Additional setup for the `node`-environment vitest projects (`extensions`,
-// `lib/platform-bible-utils`), loaded alongside the shared `vitest.setup.ts`.
+// Additional setup for the `node`-environment vitest projects that run the scripture converters,
+// loaded alongside the shared `vitest.setup.ts`. Each such project wires this file in itself, so a
+// `node`-environment project that never touches the converters does not load it — check that
+// criterion rather than assuming every `node` project is covered.
 //
-// Those projects run the same scripture converters the extension host does, and the converters need
+// Those projects run the same converters the extension host does, and the converters need
 // `DOMParser`/`XMLSerializer`, which a `node` environment has none of. Installing them here mirrors
 // what `extension-host.ts` does at startup.
 //


### PR DESCRIPTION
> **Note — depends on an unpublished upstream release.** This branch targets the
> [scripture-editors PR #541](https://github.com/eten-tech-foundation/scripture-editors/pull/541)
> build, which is not yet published. `package.json` still declares
> `@eten-tech-foundation/scripture-utilities@~0.1.6`, which does *not* contain that change — so with
> the currently-declared version the polyfill is inert (0.1.6 still bundles xmldom internally) and
> what lands is the dependency-graph half. Landing it now is deliberate: it puts the globals in place
> ahead of the upgrade, so the eventual version bump is a one-line PR rather than a combined risky
> one. End-to-end behavior was verified against a local `yalc` link of the #541 build.

## Summary

scripture-editors PR #541 drops `@xmldom/xmldom` from `@eten-tech-foundation/scripture-utilities`
(~89 KB off browser bundles) and makes the USX⇔USJ converters use the platform's **native**
`DOMParser`/`XMLSerializer`. Browsers and web views supply those; plain Node does not, so the
converters throw `requires a DOM environment`. The package's README prescribes installing
`@xmldom/xmldom` as globals.

Our extension host is plain Node and reaches the converters through `platform-scripture`'s finder
PDPE (`usxStringToUsj`) and extender PDPE (`usjToUsxString` / `usxStringToUsj`) — i.e. **every
scripture read and write**. This PR supplies the globals so that upgrade is safe to take.

### Why review this

Not part of the current epic. It is dependency-unblocking work: without it, taking the next
`scripture-utilities` release breaks every scripture read and write in the extension host. Worth
reviewing now so the approach is settled before the upstream release forces the upgrade.

## Changes

- **`src/node/polyfills/dom-globals.polyfill.ts`** — side-effect module that installs
  `DOMParser`/`XMLSerializer` from `@xmldom/xmldom` **only when absent**, so a real DOM (renderer,
  jsdom tests) always wins.
- **`src/extension-host/extension-host.ts`** — imports it *first*. It has to be an import, not a
  function call: ESM evaluates a module's whole import graph before its own body, so a call at the
  top of the entry point would run too late for anything that converts at load time.
- **`vitest.setup.node.ts`** — loads the polyfill for the two `node`-environment vitest projects
  (`extensions`, `lib/platform-bible-utils`), which exercise the same converters. Kept out of the
  shared setup so the jsdom projects don't pull xmldom into ~150 workers for nothing.
- **`package.json`** — declares `@xmldom/xmldom` (`^0.9.8`) as a real dependency; it previously
  reached us only transitively.
- **`extensions/src/platform-enhanced-resources/package.json`** — pins `@xmldom/xmldom` to
  `^0.8.10`. Its `marble-converter.ts` passes `errorHandler` as an object, which is 0.8-only (0.9
  replaced it with `onError` and throws a `TypeError`). That dependency was previously undeclared
  and resolved to a hoisted copy, so the root declaration would otherwise have silently upgraded it
  and broken every marble conversion.
- **`adr-node-dom-globals-polyfill`** in `.context/standards/Architecture-Decisions.md` — records the decision, the
  rejected alternatives, and why the **main process is deliberately not polyfilled** (no converter
  call sites; nothing in its import graph converts at load time — the only module-load-time
  `usxStringToUsj` calls are in `*.data.ts` fixtures imported solely by tests and stories).

Two `@xmldom/xmldom` majors now live in the tree on purpose. `adr-node-dom-globals-polyfill` spells out the consequence
worth a reviewer's attention: npm hoists 0.8.x to `extensions/node_modules/`, making it the default
for *every* package under `extensions/src/*`, and `import/no-extraneous-dependencies` is off — so the
next extension to import `@xmldom/xmldom` binds to 0.8.x with no warning.

## Testing

- [x] Unit tests for the polyfill (`src/node/polyfills/dom-globals.polyfill.test.ts`) — installs
      when absent, leaves an existing global untouched, round-trips parse/serialize.
- [x] Manual verification in the running app against a local build of PR #541: Find, chapter load,
      and verse edit+save all round-trip with zero `requires a DOM environment` errors — covering
      all six call sites and both conversion directions.
- [ ] Full `npm run typecheck && npm run lint && npm test` — **not green locally**, because the
      local `yalc` link for `@eten-tech-foundation/*` has no `dist/`. Every failure is
      `Cannot find module '@eten-tech-foundation/…'`, none in changed files. Deferred to CI, which
      resolves the published packages.

## AI Involvement

AI-assisted (Claude Opus 5). Claude drafted the polyfill, its tests, the vitest wiring, and the ADR,
and did the dependency-resolution archaeology behind the 0.8/0.9 split. Author reviewed all changes
and performed the in-app verification against the PR #541 build.

## Risk Level

**Low–Medium.** The polyfill is additive and defers to any existing global, so no DOM-bearing process
changes behavior. The medium half is the dependency graph: promoting `@xmldom/xmldom` to a root
declaration changes what resolves under `extensions/src/*`, which is why the
`platform-enhanced-resources` pin is part of this change rather than a follow-up.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2714)
<!-- Reviewable:end -->



