### PR TITLE
Add pr-attach skill for inline PR evidence without committing binaries

### DIFF
--- a/.claude/skills/pr-attach/SKILL.md
+++ b/.claude/skills/pr-attach/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: pr-attach
+description: "[paranext-core ONLY] Attach local screenshots/recordings to GitHub PR bodies or comments WITHOUT committing them to any repo, by uploading to GitHub's own user-attachments CDN and embedding the returned URL. Use when PR verification evidence (screenshots, repro GIFs, short clips) should render inline on a PR. Fails soft by design — if the undocumented endpoint breaks, skip the images and continue; never block the workflow."
+---
+
+# pr-attach — inline PR images via GitHub's user-attachments CDN
+
+Uploads files to the same CDN the GitHub web UI uses for drag-and-drop
+(`uploads.github.com/user-attachments/assets`), then prints markdown embeds to paste into a
+PR body or comment. Zero bytes land in any git repo, and verification evidence still renders
+inline where the reviewer reads it.
+
+**This rides an UNDOCUMENTED endpoint.** As of 2026-08-11 it works with a plain
+`gh auth token` (HTTP 201, returns `{"url": "https://github.com/user-attachments/assets/<uuid>"}`),
+but GitHub may change or remove it without notice. Treat images as a nice-to-have garnish:
+the calling workflow must produce its deliverable with or without them.
+
+## Usage
+
+```bash
+.claude/skills/pr-attach/scripts/pr-attach.sh [-r owner/repo] shot1.png shot2.png
+# stdout, one line per success:
+#   ![shot1.png](https://github.com/user-attachments/assets/<uuid>)
+.claude/skills/pr-attach/scripts/pr-attach.sh --check   # endpoint canary (uploads a 1x1 png)
+```
+
+Without `-r` the repo is taken from the current directory's git remote. Paste the stdout
+lines into the PR body/comment being drafted. Supported types, in any letter case: png, jpg,
+jpeg, gif, webp, mp4, mov, webm. Videos are emitted as a **bare URL** rather than an
+`![...]()` embed, because that is the form GitHub turns into a player.
+
+## The contract
+
+- On ANY failure (endpoint gone, schema drift, timeout, auth) the script warns on stderr
+  and prints nothing for that file. **Exit 3 is its only failure code**, and it means *no
+  embeds were produced*. A partial batch — some files uploaded, some did not — exits **0**
+  with the usable embeds on stdout and a warning on stderr, because a caller told to treat a
+  nonzero exit as "skip the images" would otherwise discard embeds that are perfectly good.
+  Exit 3 means "no embeds available": the caller SKIPS the images and continues. Never
+  retry-loop, never block, never fail a workflow because of a missing screenshot.
+- Because callers are told to branch on 3 alone, the script keeps that true in the corner
+  cases: SIGPIPE is ignored, so piping into `head` cannot exit 141, and a failed write to
+  stdout is counted as a failure rather than a delivered embed.
+- Only a URL of the exact asset shape is accepted. The URL is interpolated into markdown, so
+  a response with a crafted tail could otherwise inject a second link into a PR comment.
+- Before a batch that matters, optionally run `--check` once; if it fails, skip the batch.
+  `--check` is a canary rather than an upload: on success it exits 0 with **empty stdout**,
+  writing its confirmation to stderr. Empty stdout from `--check` means healthy, not "no
+  embeds". It takes no file arguments and needs `python3` for its 1x1 png.
+- If the endpoint dies permanently, fall back to the `paranext/media` repo pattern
+  (push under `paranext-core/pr-<N>/`, embed `raw.githubusercontent.com` URLs — proposed in
+  paranext-core PR #2506; check that PR for its current state), or post without images.
+
+## Lifecycle facts (measured 2026-08-11)
+
+- A fresh upload serves **only authenticated requests**; an anonymous fetch 404s. It becomes
+  anonymously visible once its URL is referenced in **posted** content — the same
+  activation-on-post lifecycle as drag-and-drop. So a 404 from a plain `curl` on a
+  just-uploaded asset is NOT a failure. To verify a pending asset, fetch it with
+  `Authorization: Bearer $(gh auth token)`.
+- Assets uploaded with a `repository_id` inherit that repo's visibility once posted
+  (paranext-core is public, so posted images render for everyone).
+- The endpoint's real failure shape is an error JSON with no `url` field (e.g.
+  `{"message":"Not Found",...}`), which the script's guard treats as breakage.
+
+## House rules still apply
+
+Uploading is silent and safe — it publishes nothing on its own. But **posting the body or
+comment that embeds the images is still gated exactly as before**: this skill changes
+nothing about posting approvals (see `/process-pr-feedback`'s stop before pushing and
+posting, and the house rule that posting under the user's name needs their explicit
+per-run approval).

--- a/.claude/skills/pr-attach/SKILL.md
+++ b/.claude/skills/pr-attach/SKILL.md
@@ -39,8 +39,9 @@ jpeg, gif, webp, mp4, mov, webm. Videos are emitted as a **bare URL** rather tha
   Exit 3 means "no embeds available": the caller SKIPS the images and continues. Never
   retry-loop, never block, never fail a workflow because of a missing screenshot.
 - Because callers are told to branch on 3 alone, the script keeps that true in the corner
-  cases: SIGPIPE is ignored, so piping into `head` cannot exit 141, and a failed write to
-  stdout is counted as a failure rather than a delivered embed.
+  cases: SIGPIPE is ignored, so piping into `head` cannot exit 141; a failed write to stdout
+  is counted as a failure rather than a delivered embed; and an interrupt cleans up and exits
+  3 instead of resuming the batch one file at a time.
 - Only a URL of the exact asset shape is accepted. The URL is interpolated into markdown, so
   a response with a crafted tail could otherwise inject a second link into a PR comment.
 - Before a batch that matters, optionally run `--check` once; if it fails, skip the batch.

--- a/.claude/skills/pr-attach/scripts/pr-attach.sh
+++ b/.claude/skills/pr-attach/scripts/pr-attach.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# Upload images/videos to GitHub's user-attachments CDN and print markdown embeds.
+#
+# Rides an UNDOCUMENTED endpoint (uploads.github.com/user-attachments/assets) that GitHub
+# could remove or change at any time. Designed to FAIL SOFT: any failure prints a warning
+# to stderr and prints nothing to stdout for that file. It must never block the workflow
+# that calls it.
+#
+# Exit codes for an upload run: 0 = at least one embed reached stdout (a partial batch exits 0
+# and warns, because the embeds it did produce are usable); 3 = no embeds, the skippable
+# condition. Never any other nonzero code - so callers can branch on 3 alone. SIGPIPE is ignored
+# rather than fatal, so a caller piping into `head` gets 0 or 3 like everyone else.
+#
+# `--check` is a canary, not an upload: on success it exits 0 having written only to stderr, so
+# empty stdout there means the endpoint is healthy rather than that nothing was produced. It
+# takes no file arguments and needs python3 to build its 1x1 png.
+#
+# Lifecycle fact (verified 2026-08-11): a fresh upload is served ONLY to authenticated
+# requests; it becomes anonymously visible once the URL is referenced in posted content
+# (PR body/comment) - the same activation-on-post lifecycle as drag-and-drop.
+#
+# Usage:
+#   pr-attach.sh [-r owner/repo] file [file ...]   # print one embed line per file
+#   pr-attach.sh --check [-r owner/repo]           # endpoint canary: upload a 1x1 png
+#
+# Fallback when this breaks: the paranext/media repo pattern proposed in paranext-core PR #2506
+# (check that PR for its current state), or post without images.
+
+set -u
+
+# A closed reader on stdout must not kill the script: the contract callers are told to rely on is
+# "0 or 3, never anything else", and a fatal SIGPIPE exits 141. Ignoring it turns the same event
+# into a failed write, which the write check below reports as exit 3.
+trap '' PIPE
+
+TMPDIR_C=""
+trap 'rm -rf "${TMPDIR_C:-}"' EXIT INT TERM
+
+warn() { echo "pr-attach: $*" >&2; }
+
+fail_hint() {
+  warn "the user-attachments endpoint is undocumented and may have changed or been removed."
+  warn "Fall back to the paranext/media repo (raw URLs; see paranext-core PR #2506) or post without images."
+}
+
+REPO=""
+CHECK=0
+FILES=()
+FILE_COUNT=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -r)
+      # Under `set -u` a bare `-r` dereferences an unset $2 and the shell exits 1, breaking the
+      # "exits 3 - never any other nonzero code" contract callers are told to rely on.
+      if [ $# -lt 2 ]; then warn "-r needs an argument (owner/repo)"; exit 3; fi
+      REPO="$2"; shift 2 ;;
+    --check) CHECK=1; shift ;;
+    --)
+      shift
+      while [ $# -gt 0 ]; do FILES+=("$1"); FILE_COUNT=$((FILE_COUNT + 1)); shift; done ;;
+    -?*)
+      # Swallowing an unknown flag as a filename hides a typo: `--repo x/y` would warn once about
+      # a missing file and then upload to the auto-detected repo instead, exiting 0.
+      warn "unknown option: $1"; exit 3 ;;
+    *) FILES+=("$1"); FILE_COUNT=$((FILE_COUNT + 1)); shift ;;
+  esac
+done
+
+if ! command -v gh >/dev/null || ! command -v jq >/dev/null || ! command -v curl >/dev/null; then
+  warn "missing gh/jq/curl"; exit 3
+fi
+if [ "$CHECK" = 1 ] && [ "$FILE_COUNT" -gt 0 ]; then
+  warn "--check takes no file arguments"; exit 3
+fi
+if [ "$CHECK" = 0 ] && [ "$FILE_COUNT" -eq 0 ]; then
+  warn "no files given"; exit 3
+fi
+if [ "$CHECK" = 1 ] && ! command -v python3 >/dev/null; then
+  warn "--check needs python3 to generate its canary png"; exit 3
+fi
+
+if [ -z "$REPO" ]; then
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner 2>/dev/null) || true
+fi
+if [ -z "$REPO" ]; then
+  warn "no repo given (-r owner/repo) and none detectable from cwd"; exit 3
+fi
+
+# On API errors gh prints the raw error JSON to stdout despite --jq, so require a number.
+REPO_ID=$(gh api "repos/$REPO" --jq .id 2>/dev/null)
+case "$REPO_ID" in
+  ''|*[!0-9]*) warn "could not resolve repository id for $REPO"; exit 3 ;;
+esac
+
+TOKEN=$(gh auth token 2>/dev/null)
+if [ -z "$TOKEN" ]; then
+  warn "gh auth token unavailable"; exit 3
+fi
+
+if [ "$CHECK" = 1 ]; then
+  # `mktemp --suffix=` is GNU-only - BSD mktemp (macOS) rejects it, which would make --check fail
+  # permanently there and report it through fail_hint, blaming GitHub for a local tool gap.
+  TMPDIR_C=$(mktemp -d) || { warn "mktemp failed"; exit 3; }
+  TMPPNG="$TMPDIR_C/canary.png"
+  python3 - "$TMPPNG" <<'PYEOF'
+import struct, sys, zlib
+def chunk(t, d):
+    c = struct.pack('>I', len(d)) + t + d
+    return c + struct.pack('>I', zlib.crc32(t + d) & 0xffffffff)
+ihdr = struct.pack('>IIBBBBB', 1, 1, 8, 2, 0, 0, 0)
+png = (b'\x89PNG\r\n\x1a\n' + chunk(b'IHDR', ihdr)
+       + chunk(b'IDAT', zlib.compress(b'\x00\x80\x80\x80')) + chunk(b'IEND', b''))
+open(sys.argv[1], 'wb').write(png)
+PYEOF
+  FILES=("$TMPPNG")
+  FILE_COUNT=1
+fi
+
+mime_for() {
+  # Screenshots off Windows tooling and phone captures routinely carry .PNG/.JPG.
+  case "$(printf '%s' "${1##*.}" | tr '[:upper:]' '[:lower:]')" in
+    png) echo image/png ;; jpg|jpeg) echo image/jpeg ;; gif) echo image/gif ;;
+    webp) echo image/webp ;; mp4) echo video/mp4 ;; mov) echo video/quicktime ;;
+    webm) echo video/webm ;; *) echo "" ;;
+  esac
+}
+
+RC=0
+OK_COUNT=0
+for f in "${FILES[@]}"; do
+  if [ ! -f "$f" ]; then warn "no such file: $f"; RC=3; continue; fi
+  MIME=$(mime_for "$f")
+  if [ -z "$MIME" ]; then warn "unsupported extension: $f"; RC=3; continue; fi
+  NAME=$(basename -- "$f")
+  # The name reaches the query string @uri-escaped, but the alt text is interpolated into
+  # markdown, where a `]` or a newline in a filename would break out of the embed.
+  ALT=$(printf '%s' "$NAME" | tr -d '\n\r][()')
+  # The Authorization header goes in via a config file on stdin rather than argv: everything on
+  # curl's command line is readable from /proc/<pid>/cmdline by any local process mid-upload.
+  RESP=$(printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" \
+    | curl -sS --max-time 30 -X POST \
+      "https://uploads.github.com/user-attachments/assets?name=$(jq -rn --arg n "$NAME" '$n|@uri')&content_type=$MIME&repository_id=$REPO_ID" \
+      --config - -H "Accept: application/json" \
+      --data-binary "@$f" 2>&1)
+  URL=$(echo "$RESP" | jq -r '.url // empty' 2>/dev/null)
+  # Matching the prefix alone is not enough. The URL is interpolated into `![alt](url)`, so a
+  # response whose tail is `) [text](https://elsewhere` injects a second, fully-formed link into
+  # whatever PR body or comment the caller pastes this into. Accept only the asset-id shape.
+  if [[ "$URL" =~ ^https://github\.com/user-attachments/assets/[0-9a-fA-F-]+$ ]]; then
+    if [ "$CHECK" = 1 ]; then
+      echo "pr-attach: endpoint OK ($URL)" >&2
+    else
+      # GitHub renders a video as a player only from a bare URL on its own line; image markdown
+      # around a video asset renders as a broken image.
+      case "$MIME" in
+        video/*) OUT="$URL" ;;
+        *) OUT="![$ALT]($URL)" ;;
+      esac
+      # Counting an embed the write never delivered would report exit 0 with empty stdout.
+      if echo "$OUT"; then
+        OK_COUNT=$((OK_COUNT + 1))
+      else
+        warn "stdout write failed for $NAME"; RC=3
+      fi
+    fi
+  else
+    warn "upload failed for $NAME: $(echo "$RESP" | head -c 300)"
+    fail_hint
+    RC=3
+  fi
+done
+
+# Exit 3 means "no embeds" - the skippable condition the header promises. A batch in which some
+# files uploaded has embeds on stdout, and exiting 3 there would tell a caller following that
+# contract to discard them.
+if [ "$RC" != 0 ] && [ "$OK_COUNT" -gt 0 ]; then
+  warn "partial batch: $OK_COUNT uploaded, the rest failed - embeds above are usable"
+  exit 0
+fi
+exit $RC

--- a/.claude/skills/pr-attach/scripts/pr-attach.sh
+++ b/.claude/skills/pr-attach/scripts/pr-attach.sh
@@ -34,7 +34,12 @@ set -u
 trap '' PIPE
 
 TMPDIR_C=""
-trap 'rm -rf "${TMPDIR_C:-}"' EXIT INT TERM
+# The signal handlers must terminate as well as clean up. A cleanup-only trap replaces the default
+# terminate-on-signal, and bash resumes the script afterwards - so Ctrl-C during a batch would kill
+# only the in-flight curl and upload every remaining file, once per interrupt. Exiting 3 keeps the
+# "0 or 3, never anything else" contract.
+trap 'rm -rf "${TMPDIR_C:-}"' EXIT
+trap 'rm -rf "${TMPDIR_C:-}"; exit 3' INT TERM
 
 warn() { echo "pr-attach: $*" >&2; }
 
@@ -134,11 +139,14 @@ for f in "${FILES[@]}"; do
   NAME=$(basename -- "$f")
   # The name reaches the query string @uri-escaped, but the alt text is interpolated into
   # markdown, where a `]` or a newline in a filename would break out of the embed.
-  ALT=$(printf '%s' "$NAME" | tr -d '\n\r][()')
+  ALT=$(printf '%s' "$NAME" | tr -d '\n\r][()`\\')
   # The Authorization header goes in via a config file on stdin rather than argv: everything on
   # curl's command line is readable from /proc/<pid>/cmdline by any local process mid-upload.
+  # A single wall-clock cap that suits a screenshot makes a multi-megabyte clip fail on upload
+  # size and report it through fail_hint, blaming GitHub for a slow uplink.
+  case "$MIME" in video/*) MAX_TIME=300 ;; *) MAX_TIME=60 ;; esac
   RESP=$(printf 'header = "Authorization: Bearer %s"\n' "$TOKEN" \
-    | curl -sS --max-time 30 -X POST \
+    | curl -sS --connect-timeout 10 --max-time "$MAX_TIME" -X POST \
       "https://uploads.github.com/user-attachments/assets?name=$(jq -rn --arg n "$NAME" '$n|@uri')&content_type=$MIME&repository_id=$REPO_ID" \
       --config - -H "Accept: application/json" \
       --data-binary "@$f" 2>&1)


### PR DESCRIPTION
Adds a `pr-attach` skill: upload a screenshot or short clip to the same `user-attachments` CDN GitHub's web UI uses for drag-and-drop, and print a markdown embed to paste into a PR body or comment. Verification evidence renders inline where the reviewer reads it, and no binaries land in the repo.

Split out of #2659, where it had been folded in as a rider. It is orthogonal to that PR's subject, and 143 lines of shell riding an undocumented endpoint want a reviewer reading shell semantics rather than procedure prose.

## The contract

The endpoint is undocumented and GitHub can change or remove it without notice, so the script fails soft: any failure warns on stderr, prints nothing for that file, and the caller skips the images instead of failing a workflow over a missing screenshot. **Exit 3 is the only failure code** — that is what callers branch on. A partial batch exits 0, because embeds that did succeed are usable.

## Keeping that contract true

The happy path was the easy part. Each of these was reproduced before being fixed:

- **SIGPIPE.** `pr-attach.sh *.png | head -1` exited **141** from a script promising 0 or 3. SIGPIPE is now ignored, so a closed reader becomes a failed write instead of a fatal signal.
- **Unchecked writes.** `OK_COUNT` incremented without checking the write landed, so a closed stdout produced exit 0 with no output. The write is now checked.
- **Markdown injection.** The URL guard matched only the prefix, and the URL is interpolated into `![alt](url)`. A response ending `...assets/x) [Click here](https://evil.example.com` emitted a second, fully-formed link into text destined for a PR comment — and exited 0. Only the exact asset-id shape is accepted now. Filenames get the same treatment before becoming alt text.
- **Token on the command line.** The `Authorization` header was in `curl`'s argv, readable from `/proc/<pid>/cmdline` by any local process mid-upload. It now goes in via a config file on stdin.

Smaller corrections: extensions match in any letter case (screenshots off Windows tooling arrive as `.PNG`); videos are emitted as a bare URL, the only form GitHub renders as a player; an unknown flag is rejected rather than swallowed as a filename, so a `--repo` typo cannot silently upload to the auto-detected repo; `--check` rejects file arguments instead of discarding them; and the canary's temp directory is cleaned up on signal as well as on exit.

## Notes for review

- Uploading publishes nothing on its own — an asset is only served anonymously once its URL appears in posted content. Posting the comment that embeds it stays gated by the usual approval rule.
- Nothing in the repo is automated over `.claude/skills/**` — no lint, no format check, no CI job — so this file is reviewed by reading it. `shellcheck` reports no warning- or error-severity findings.
- Draft until #2659 settles.

AI-assisted — [session](https://claude.ai/code/session_013Vdu1mi387aTZ4LUT6NiER)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2719)
<!-- Reviewable:end -->
