### PR TITLE
Bump @sillsdev/scripture to 2.1.0

### DIFF
--- a/extensions/package.json
+++ b/extensions/package.json
@@ -44,7 +44,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "platform-bible-utils": "file:../lib/platform-bible-utils"
   },
   "devDependencies": {

--- a/extensions/src/hello-rock3/package.json
+++ b/extensions/src/hello-rock3/package.json
@@ -35,7 +35,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {

--- a/extensions/src/hello-someone/package.json
+++ b/extensions/src/hello-someone/package.json
@@ -35,7 +35,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {

--- a/extensions/src/legacy-comment-manager/package.json
+++ b/extensions/src/legacy-comment-manager/package.json
@@ -36,7 +36,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {

--- a/extensions/src/paratext-registration/package.json
+++ b/extensions/src/paratext-registration/package.json
@@ -36,7 +36,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {

--- a/extensions/src/platform-enhanced-resources/package.json
+++ b/extensions/src/platform-enhanced-resources/package.json
@@ -36,7 +36,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "@xmldom/xmldom": "^0.8.10",
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },

--- a/extensions/src/platform-get-resources/package.json
+++ b/extensions/src/platform-get-resources/package.json
@@ -36,7 +36,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {

--- a/extensions/src/platform-lexical-tools/package.json
+++ b/extensions/src/platform-lexical-tools/package.json
@@ -37,7 +37,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {

--- a/extensions/src/platform-scripture-editor/package.json
+++ b/extensions/src/platform-scripture-editor/package.json
@@ -36,7 +36,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {

--- a/extensions/src/platform-scripture/package.json
+++ b/extensions/src/platform-scripture/package.json
@@ -36,7 +36,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {

--- a/extensions/src/quick-verse/package.json
+++ b/extensions/src/quick-verse/package.json
@@ -36,7 +36,7 @@
     "react-dom": ">=19.0.0"
   },
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "platform-bible-utils": "file:../../../lib/platform-bible-utils"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "extensions/src/*"
       ],
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "@xmldom/xmldom": "^0.9.8",
         "ajv": "^8.18.0",
         "chalk": "^4.1.2",
@@ -184,7 +184,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "platform-bible-utils": "file:../lib/platform-bible-utils"
       },
       "devDependencies": {
@@ -379,7 +379,7 @@
       "version": "0.6.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
@@ -448,7 +448,7 @@
       "version": "0.6.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
@@ -517,7 +517,7 @@
       "version": "0.6.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
@@ -587,7 +587,7 @@
       "version": "0.6.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
@@ -656,7 +656,7 @@
       "version": "0.6.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "@xmldom/xmldom": "^0.8.10",
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
@@ -808,7 +808,7 @@
       "version": "0.6.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
@@ -878,7 +878,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
@@ -948,7 +948,7 @@
       "version": "0.6.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
@@ -1017,7 +1017,7 @@
       "version": "0.6.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
@@ -1089,7 +1089,7 @@
       "version": "0.6.0-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@sillsdev/scripture": "^2.0.5",
+        "@sillsdev/scripture": "^2.1.0",
         "platform-bible-utils": "file:../../../lib/platform-bible-utils"
       },
       "devDependencies": {
@@ -8806,7 +8806,9 @@
       "license": "MIT"
     },
     "node_modules/@sillsdev/scripture": {
-      "version": "2.0.5",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@sillsdev/scripture/-/scripture-2.1.0.tgz",
+      "integrity": "sha512-jj5mMMCvhjsFW87H8WkIkG/lM6kp/k/vC6bk+hxwvU08NaffmgyAU+kDasNhIiViYvZ96JPUjwPl+z7doDLx9g==",
       "license": "MIT"
     },
     "node_modules/@sinclair/typebox": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
   },
   "browserslist": ["extends browserslist-config-detect-electron"],
   "dependencies": {
-    "@sillsdev/scripture": "^2.0.5",
+    "@sillsdev/scripture": "^2.1.0",
     "@xmldom/xmldom": "^0.9.8",
     "ajv": "^8.18.0",
     "chalk": "^4.1.2",


### PR DESCRIPTION
Bumps `@sillsdev/scripture` from 2.0.5 to 2.1.0.

## What changes

All 12 manifests that declare it — the root, `extensions`, and the 10 extensions under `extensions/src/*` — plus the lockfile. Verifiable in one line:

```bash
git grep -l '"@sillsdev/scripture": "\^2\.1\.0"' -- '*package.json' | wc -l   # 12
git grep -l '"@sillsdev/scripture": "\^2\.0\.5"' -- '*package.json'           # none
```

Only the **root** manifest changes what actually executes. `@sillsdev/scripture` is a webpack `external` for every extension and the host injects the runtime module (`extension.service.ts`, `global-this-web-view.model.ts`), so the other eleven declarations govern types and Vitest resolution. Keeping them in lockstep is deliberate, not load-bearing at runtime.

## Why now — two present-tense reasons, not a hypothetical

**1. The dev tree is currently inconsistent.** Measured in a clean checkout before this PR:

```
node_modules/@sillsdev/scripture                       2.0.5
node_modules/@eten-tech-foundation/platform-editor ->  .yalc/…  0.8.16, declares ^2.1.0
```

The yalc-linked editor has no nested copy, so it resolves to the hoisted root — **2.0.5, which does not satisfy its own `^2.1.0` range**. Nothing errors, because yalc links are applied after npm resolution and npm never polices them. After this PR the tree has exactly one copy, at 2.1.0, and the range is satisfied.

**2. There is a live contract split with the C# half.** `VerseRefConverter`'s reader resolves `verse ?? verseNum!.Value.ToString()` — a present `verse` string **wins over** `verseNum`. That is exactly the object shape 2.0.5's setter produced:

- C# writes `{chapterNum: 3, verseNum: 4, verse: '4b-5a'}`
- TypeScript sets `verseNum = 9`, leaving the stale string
- C# reads it back as **4b-5a, not 9** — silently, across the PAPI wire

And the C# side already exercises these setters in production: `InputRange` writes `verseRef.VerseNum` and `verseRef.ChapterNum` on real `SIL.Scripture.VerseRef` instances. TypeScript was the odd one out.

## What 2.1.0 actually changes

Skipping 2.0.6 picks up two `VerseRef` setter repairs. `chapterNum` ([#58](https://github.com/sillsdev/scripture/pull/58)) assigned the property to itself behind a `ToDo` placeholder and recursed infinitely, so every input threw `RangeError: Maximum call stack size exceeded` and the property was unusable. `verseNum` ([#60](https://github.com/sillsdev/scripture/pull/60)) is the same mis-port but did work — it set the backing field and nothing else, where the C# it ports also clears the verse string and rejects negatives.

**Neither repair is purely an improvement.** For non-negative invalid input, `chapterNum` moves from unusable-but-loud to usable-but-silently-permissive:

```ts
const v = new VerseRef('LUK 3:4', ScrVers.English);
v.chapterNum = 0;
// 2.0.5 -> RangeError: Maximum call stack size exceeded
// 2.1.0 -> "LUK 0:4", BBBCCCVVV 42000004, valid === true
```

Chapter 0 isn't valid, but `internalValid()` cannot detect it while the versification port is unfinished — the library's own new test has that assertion commented out behind a TODO.

## Dependency resolution

One hoisted copy either way, but for a reason worth stating precisely:

- The **registry** path is what guarantees it. `platform-editor@0.8.15` — the published latest, and what the lockfile records — declares `^2.0.5`, which **2.1.0 satisfies**. So npm hoists a single copy and there is no dual-version tree to avoid.
- The **yalc** path is not a guarantee. `dev-packages.json` names `"revision": "platform-yalc"`, which is a **branch, not a pin**: `dev-package-utils.ts` re-checks-out that branch on every install, and `getDevPackagePath` prefers `dev-packages/<folder>` (used by CI) but falls back to a sibling `../<folder>` for developer checkouts. Two developers can get two answers. `platform-editor@0.8.16` is a local yalc artifact — `npm view` returns 0.8.15 — so it is not evidence of anything on its own.

An earlier revision of this description called that revision "pinned" and leaned on 0.8.16. Both were wrong; the conclusion rests on the `^2.0.5` range instead.

## Why nothing here reaches the new guards

The `VerseRef` constructor writes backing fields directly, so construction cannot trip the guards. Every instance site is read-only: `findScrollTarget` and `toNavigationRecord` (comment-list-scroll.utils.ts), `handleVerseRefClick` (comment-list.web-view.tsx), `setHeresy` (quick-verse main.ts), `scrRefToBBBCCC` / `scrRefToBBBCCCVVV` (scripture-util.ts).

<details>
<summary>Full assignment audit — every chapterNum, verseNum, verse and book write in the repo</summary>

Cited by symbol rather than line: an earlier revision of this table used line numbers gathered before a 32-commit rebase, and five of eight had drifted onto unrelated code by the time it was read.

| Symbol | File | Target |
| --- | --- | --- |
| `determineLocationProperties` | platform-scripture-editor.utils.ts | spread of a `SerializedVerseRef` parameter |
| `convertScriptureRangeToEditorRange` | platform-scripture-editor.utils.ts | `SerializedVerseRef` declared with a `verseNum: -1` initialiser |
| `checkInputRange` | checks-side-panel.web-view.tsx | spread of a `SerializedVerseRef` literal |
| `createInventoryInputRange` | inventory.web-view.tsx | spread of a `SerializedVerseRef` literal |
| `transferFragmentsInfoArrayToMaps` | usj-reader-writer.ts | inline structural param, not a VerseRef |
| `getVerseRefForIndexInUsfm` | usj-reader-writer.ts | `verse` and `book` on a `SerializedVerseRef` |
| `normalizeStoredScrRefs` | scroll-group.service-host.ts | `book`, behind a `bookNum` guard |

All target plain objects or structural types — never a class instance, so no setter runs.

Two things worth noting from this table.

The `verseNum: -1` initialiser in `convertScriptureRangeToEditorRange` would throw under the new negative guard had it been an instance. That sentinel is not confined to hand-written literals either — the library produces it itself: `new VerseRef('LUK','','',ScrVers.Septuagint).toJSON()` yields `verseNum: -1`. So a `SerializedVerseRef` carrying `-1` can arrive straight from the library's own serializer. **2.1.0 therefore creates an asymmetric read/write contract**: both getters' TSDoc still documents `-1` as the not-valid value, while the setter now throws `VerseRefException` on it. Nothing here round-trips one through a setter, but code that reads `-1` legitimately and writes it back would break.

Also, `convertScriptureRangeToEditorRange` does not mutate the literal it declares. By the time the write happens, the variable has been rebound to `determineLocationProperties(...).verseRef`, whose USFM branch discards the defensive spread and returns the caller's object **by reference** from `usj-reader-writer`. So that write reaches a caller-owned object. It is benign today — every production caller crosses the PAPI boundary with JSON-deserialized plain objects — but `VerseRef` is structurally assignable to `SerializedVerseRef`, so TypeScript would accept an instance silently and the setter would then clear `_verse`, degrading `LUK 3:4b-5a` to `LUK 3:4`. Listed under follow-ups below.

</details>

## Verification

`npm run typecheck`, `npm run lint`, `npm test` and `dotnet test c-sharp-tests/` all exit 0 (1724 C# tests, 598 TS test files). Rebased onto current `main`; CI re-runs the full three-OS matrix on this head.

Post-install state confirmed by a full `npm i` — not `npm ci --ignore-scripts`, which skips `postinstall` and therefore skips `link-dev-packages` entirely, leaving a stale or absent dev-packages checkout:

```
node_modules/@sillsdev/scripture   2.1.0     <- the only copy in the tree
platform-editor 0.8.16 declares ^2.1.0       <- now satisfied
```

## Follow-ups (not this PR)

- **No test anywhere constructs a `VerseRef`** — zero hits for `new VerseRef(` / `VerseRef.tryParse` across all test files. A revert or a transitive pin would reinstate 2.0.5's setter and nothing would fail. `scripture-util.test.ts` already imports the real package, so a characterization test needs no new dependency.
- **`determineLocationProperties` writes through to a caller-owned object** — its USFM branch discards the defensive spread, and `usj-reader-writer` returns the caller's object by reference. Benign today, since production callers cross PAPI with JSON-deserialized plain objects, but worth a defensive spread.
- **No `VerseRefException` is caught anywhere** — given the new guards throw on values the library itself produces, any future throw propagates uncaught.
- **The root manifest entry is silently load-bearing for both library bundles** — neither `platform-bible-utils` nor `platform-bible-react` declares `@sillsdev/scripture`; both stay external only because their vite configs merge the root manifest's dependency keys into the rollup externals list. If it left root `dependencies`, both dists would bundle their own copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2723)
<!-- Reviewable:end -->
