### PR TITLE
docs: two verification traps where a clean check proves nothing

### DIFF
--- a/.claude/agents/review-analyzer.md
+++ b/.claude/agents/review-analyzer.md
@@ -19,7 +19,7 @@ You will be given:
 
 ## Accuracy Requirement
 
-**Before reporting any finding, verify it against the actual code.** Read the relevant file (or use `git show $MERGE_BASE:<file>` for the before-state) to confirm the issue exists. Do not flag something based on pattern assumptions or file names alone. If you cannot confirm a finding from the actual code, omit it entirely or note that you could not verify it. A small number of accurate findings is better than a long list with errors.
+**Before reporting any finding, verify it against the actual code.** Read the relevant file (or use `git show $MERGE_BASE:<file>` for the before-state) to confirm the issue exists. Do not flag something based on pattern assumptions or file names alone. If you cannot confirm a finding from the actual code, omit it entirely or note that you could not verify it. A small number of accurate findings is better than a long list with errors. The checks a review completes before it is reported are in [Code-Review-Guide.md](../../.context/standards/Code-Review-Guide.md#before-the-verdict).
 
 ## Severity Rubric
 

--- a/.claude/agents/review-analyzer.md
+++ b/.claude/agents/review-analyzer.md
@@ -19,7 +19,7 @@ You will be given:
 
 ## Accuracy Requirement
 
-**Before reporting any finding, verify it against the actual code.** Read the relevant file (or use `git show $MERGE_BASE:<file>` for the before-state) to confirm the issue exists. Do not flag something based on pattern assumptions or file names alone. If you cannot confirm a finding from the actual code, omit it entirely or note that you could not verify it. A small number of accurate findings is better than a long list with errors. The checks a review completes before it is reported are in [Code-Review-Guide.md](../../.context/standards/Code-Review-Guide.md#before-the-verdict).
+**Before reporting any finding, verify it against the actual code.** Read the relevant file (or use `git show $MERGE_BASE:<file>` for the before-state) to confirm the issue exists. Do not flag something based on pattern assumptions or file names alone. If you cannot confirm a finding from the actual code, omit it entirely or note that you could not verify it. Before reporting something as missing, widen the search or open the defining file first — a narrowed search only proves "not here," not "not anywhere" (see [scoped-sweeps-cannot-prove-absence.md](../rules/scoped-sweeps-cannot-prove-absence.md)). A small number of accurate findings is better than a long list with errors. The checks a review completes before it is reported are in [Code-Review-Guide.md](../../.context/standards/Code-Review-Guide.md#before-the-verdict). Your `focus` is a floor, not a boundary — report a defect you can verify even when it falls outside your assigned slice, because no other analyzer is looking where you are looking.
 
 ## Severity Rubric
 

--- a/.claude/rules/scoped-sweeps-cannot-prove-absence.md
+++ b/.claude/rules/scoped-sweeps-cannot-prove-absence.md
@@ -26,14 +26,11 @@ claims and should not be written the same way.
 
 ## A related trap: a generated artifact cannot show what it is not generated from
 
-`lib/papi-dts/papi.d.ts` is generated from the **type** surface. A regenerated-types diff therefore
-cannot reveal a missing wire marker: a command, network object, data provider or network event
-registered without `'x-experimental': true` produces a byte-identical `papi.d.ts`. Verify the wire
-marker by reading the registration's documentation object, or the live OpenRPC document at
-`rpc.discover` — never by inferring it from the type surface. See
+A generated artifact reflects only the surface it was generated from, so a clean diff of it cannot
+prove the absence of something that surface doesn't encode. See
 [Paranext-Core-Patterns.md § Experimental APIs](../../.context/standards/Paranext-Core-Patterns.md#experimental-apis).
 
 ## Tooling note
 
-`grep` on the team's development machines is **ugrep**, not GNU grep. Do not assume flag semantics
-match GNU's; check when a flag matters to the result.
+As of 2026-08, `grep` on the team's development machines is **ugrep**, not GNU grep. Do not assume
+flag semantics match GNU's; check when a flag matters to the result.

--- a/.claude/rules/scoped-sweeps-cannot-prove-absence.md
+++ b/.claude/rules/scoped-sweeps-cannot-prove-absence.md
@@ -1,0 +1,39 @@
+# A Narrowed Search Cannot Tell "Absent" From "Somewhere Else"
+
+When a search is narrowed — by path, by glob, by `grep -v`, or simply by looking only where you
+expect the answer to live — a clean result means **"not here"**, never **"not anywhere"**. Treat
+those as two different findings. Reporting the first as the second is how a false gap gets filed,
+and how a real one gets missed.
+
+Before concluding that something is missing:
+
+1. **Widen the search** until it covers everywhere the thing could legitimately live, or
+2. **Open the file** where it would be defined and look.
+
+State which you did. "Not found under `src/renderer`" and "not present in the repo" are different
+claims and should not be written the same way.
+
+## Two ways this actually went wrong
+
+- **The exclusion swallowed the evidence.** A sweep for stale anchor links into
+  `Architecture-Decisions.md` filtered that file out with `grep -v 'Architecture-Decisions.md'`. That
+  drops every *line containing that filename* — which is precisely what an anchor link is. The sweep
+  came back clean while the stale anchors sat there. Exclude by **path**, not by substring.
+- **The search looked where the caller was, not where the thing is defined.** A check for a missing
+  `'x-experimental': true` marker searched the shard files, because that is where the method lives.
+  The marker lives on the registration's documentation object, elsewhere. The clean result nearly
+  became a filed API-compliance gap that did not exist.
+
+## A related trap: a generated artifact cannot show what it is not generated from
+
+`lib/papi-dts/papi.d.ts` is generated from the **type** surface. A regenerated-types diff therefore
+cannot reveal a missing wire marker: a command, network object, data provider or network event
+registered without `'x-experimental': true` produces a byte-identical `papi.d.ts`. Verify the wire
+marker by reading the registration's documentation object, or the live OpenRPC document at
+`rpc.discover` — never by inferring it from the type surface. See
+[Paranext-Core-Patterns.md § Experimental APIs](../../.context/standards/Paranext-Core-Patterns.md#experimental-apis).
+
+## Tooling note
+
+`grep` on the team's development machines is **ugrep**, not GNU grep. Do not assume flag semantics
+match GNU's; check when a flag matters to the result.

--- a/.context/standards/Code-Review-Guide.md
+++ b/.context/standards/Code-Review-Guide.md
@@ -1,10 +1,10 @@
 ---
 title: Code Review Guide
 description: Code review process, Reviewable workflow, code stewards, and PR approval best practices.
-version: 1.1.0
+version: 1.2.0
 status: active
 created: 2026-03-04
-last_updated: 2026-06-15
+last_updated: 2026-08-27
 ---
 
 # Code Review Guide
@@ -50,6 +50,37 @@ For current code steward assignments, see the [Code Stewards wiki](https://githu
 
 ---
 
+## Before the verdict
+
+Four checks that come before a review is reported. Each of them exists because a review that
+skipped it passed a defect the next stage caught.
+
+- **A checklist from the requester is a floor, not the review.** Run the full review pass alongside
+  it and hold the verdict until that pass finishes; then ask which branch of every two-way switch
+  the diff's tests never exercise — default versus non-default mode, tracked versus untracked,
+  first-load versus fallback. Rigour inside the places someone listed says nothing about the places
+  nobody listed, and the most-travelled path is often one of the latter.
+
+- **Run the control before attributing.** Before a symptom is blamed on a change, check the same
+  signal on the base and on unrelated branches. Two occurrences inside one population are not a
+  pattern until the population without that change has been looked at, and a wrong attribution
+  sends someone after a defect they did not write.
+
+- **Verify a premise in code, citing the line, before it reaches a rationale, an ADR or a report.**
+  Grep the type definitions before accepting "cannot be done" as the reason for a workaround. A
+  false premise costs far more to remove once it has been repeated across a design note, a decision
+  log and a commit message than it costs to check once.
+
+- **A change to a shutdown, close or persistence path keeps its end-to-end scenarios in the gate.**
+  Unit tests, mutation checks and review have each passed defects on those paths that only an
+  end-to-end run caught: what fails there is ordering and lifetime, which a mocked test reproduces
+  by construction rather than exercises.
+
+When a finding is a rule rather than a single site, state the rule and name every site it governs —
+a reviewer's scope becomes the fixer's scope.
+
+---
+
 ## Author Responsibilities
 
 - Merge pull requests after approval or enable auto-merge through GitHub
@@ -90,3 +121,4 @@ Request code reviews in the `#reviews` channel on the [Platform.Bible Discord se
 | ------- | ---------- | ------------------------------------------------------------------- |
 | 1.0.0   | 2026-03-04 | Initial version                                                     |
 | 1.1.0   | 2026-06-15 | De-ported the AI-Assisted-Review (porting) section for the general profile |
+| 1.2.0   | 2026-08-27 | Added "Before the verdict": checks a review completes before it is reported |

--- a/.context/standards/Code-Review-Guide.md
+++ b/.context/standards/Code-Review-Guide.md
@@ -64,9 +64,11 @@ skipped it passed a defect the next stage caught.
 - **Run the control before attributing.** Before a symptom is blamed on a change, check the same
   signal on the base and on unrelated branches. Two occurrences inside one population are not a
   pattern until the population without that change has been looked at, and a wrong attribution
-  sends someone after a defect they did not write.
+  sends someone after a defect they did not write. A control only controls if it reproduces the
+  conditions of the run it is controlling: state what differs between the control and the failing
+  run, and let a matched pair vary the commit or the invocation, never both at once.
 
-- **Verify a premise in code, citing the line, before it reaches a rationale, an ADR or a report.**
+- **Verify a premise in code, citing the file and symbol, before it reaches a rationale, an ADR or a report.**
   Grep the type definitions before accepting "cannot be done" as the reason for a workaround. A
   false premise costs far more to remove once it has been repeated across a design note, a decision
   log and a commit message than it costs to check once.

--- a/.context/standards/Paranext-Core-Patterns.md
+++ b/.context/standards/Paranext-Core-Patterns.md
@@ -1165,6 +1165,8 @@ Add `/** @experimental */` to the type or member.
 
 Pass `'x-experimental': true` in the registration's documentation object. The marker becomes visible in the live OpenRPC document at the WebSocket `rpc.discover` endpoint.
 
+**Verifying the wire marker needs its own step — the usual check cannot see it.** `lib/papi-dts/papi.d.ts` is generated from the *type* surface, so a regenerated-types diff structurally cannot show whether `'x-experimental': true` is present on a registration: a command, network object, data provider or network event registered without it produces a byte-identical `papi.d.ts`. Confirm the wire marker by reading the registration's documentation object, or the live OpenRPC document at `rpc.discover`. Never infer it from the type surface.
+
 ### Quick reference per surface
 
 | Surface | TSDoc location | Wire field path |


### PR DESCRIPTION
## Summary

Two documentation changes recording verification traps from the PT-4275 multi-window stack — both cases where a check reported success **without having examined the thing it claimed to cover**. One of them says that a verification route people actually use is structurally incapable of catching what they think it catches, which is why this wants real eyes rather than a skim.

### Why review this

Not part of the current epic — process cleanup that came out of the multi-window stack. It is worth reviewer time now because a reader following `Paranext-Core-Patterns.md` today would verify an experimental marker with a diff that cannot show it, and conclude the marker is present when nothing checked.

## Changes

**1. `Paranext-Core-Patterns.md` — corrects an implied verification route.** The Experimental APIs section documents both marker surfaces correctly, but never says that the check people actually run covers only one of them. `lib/papi-dts/papi.d.ts` is generated from the *type* surface, so a command, network object, data provider or network event registered without `'x-experimental': true` produces a **byte-identical** `papi.d.ts`. A regenerated-types diff is therefore incapable of revealing a missing wire marker. Confirm it by reading the registration's documentation object or the live OpenRPC document at `rpc.discover` — never by inferring it from regenerated types.

**2. `.claude/rules/scoped-sweeps-cannot-prove-absence.md` — new rule.** A search narrowed by path, glob, exclusion, or simply by looking only where you expect the answer to live means **"not here"**, never **"not anywhere"**. Reporting the first as the second is how a false gap gets filed and a real one gets missed. Cites both instances that happened, in different shapes, on the same day:

- An exclusion that swallowed its own evidence: a sweep for stale anchor links into `Architecture-Decisions.md` excluded that file with `grep -v 'Architecture-Decisions.md'`, which drops every line *containing that filename* — precisely what an anchor link is. It came back clean while the stale anchors sat there. Exclude by **path**, not by substring.
- A search that looked where the caller was rather than where the thing is declared: a check for a missing `'x-experimental': true` searched the shard files, because that is where the method lives. The marker lives on the registration. The clean result nearly became a filed API-compliance gap that did not exist.

The rule also carries the generated-artifact corollary from change 1, and a note that `grep` on the team's machines is ugrep rather than GNU grep, so flag semantics should be checked when they affect a result.

**3. `Code-Review-Guide.md` — a new "Before the verdict" section, plus a pointer from the review analyzer.** Four checks a review completes before it is reported, each one a review that skipped it and a defect the next stage caught: a requester's checklist is a floor, so run the full review pass alongside it, hold the verdict until that pass finishes, and then ask which branch of every two-way switch the diff's tests never exercise; run the control before attributing a symptom to a change, by checking the same signal on the base and on unrelated branches; verify a premise in code, citing the line, before it reaches a rationale, an ADR or a report, and grep the type definitions before accepting "cannot be done" as the reason for a workaround; and keep the end-to-end scenarios in the gate for any shutdown, close or persistence change, because what fails there is ordering and lifetime, which a mocked test reproduces by construction rather than exercises. `review-analyzer.md` gets a one-line pointer to the section rather than a copy, so the rules have one home.

## Scope narrowed after #2720

This PR originally carried three further changes about ADR **numbering** — a correction to the "numbers are claimed at merge" bullet, guidance on sweeping cross-references after a renumber, and a `Git-Guide.md` note on citing ADRs by title until merge. #2720 replaced numbers with write-time slugs, which removes the renumbering hazard those changes existed to document, so all three have been **dropped** rather than rewritten. The branch is rebased onto that work and no longer touches `Architecture-Decisions.md` or `Git-Guide.md`. The one lesson from that material with life beyond numbering — exclude by path, not substring — survives as the first bullet of the new rule, reworded so it no longer depicts the retired `ADR-NNNN` link format.

## Verification

Ran the `verify-standards` gate against this branch's diff, which the repo requires for any PR adding standards content. **The new content comes out clean — zero findings on the added lines.** Checked by line range, not by filename: `Paranext-Core-Patterns.md` carries 15 pre-existing findings at lines 65–669, all well clear of the addition at line 1168, and most of those are legitimate noise (Windows/Linux/macOS platform API names cited as external, which is correct). They are pre-existing on `main`, out of scope here, and untouched — folding a documentation audit into two small edits would bury the change.

## Risk Level

Low — documentation only. No source, no tests, no build output. Both claims are backed by a real incident named in the text, and the `papi.d.ts` claim is checkable from the generator's inputs.

AI-assisted — [session 1](https://claude.ai/code/session_018FNQ8Ewcs6pPg2i3qB3APM)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2725)
<!-- Reviewable:end -->

