### PR TITLE
PT-4278: Stop the public window API describing a single window

### DIFF
--- a/.context/standards/Architecture.md
+++ b/.context/standards/Architecture.md
@@ -37,9 +37,11 @@ Platform.Bible uses **JSON-RPC 2.0 over WebSocket** for inter-process communicat
 ```
 
 One renderer process per window, not one for the application: a window is a full renderer hosting
-its own dock layout and its own window-scoped services, and main is the only process all of them
-have in common. Services that must answer for the whole application therefore live in main, which
-outlives any individual window.
+its own dock layout and its own window-scoped services, and main is the only process every renderer
+connects to directly. Services that must coordinate across every open window therefore live in
+main, which outlives any individual window. Other whole-application services — settings, menus,
+themes, extension lifecycle — live in the extension host, which is likewise a single process shared
+by every window (see the service tables below).
 
 ### Communication Patterns
 

--- a/.context/standards/Architecture.md
+++ b/.context/standards/Architecture.md
@@ -40,8 +40,10 @@ One renderer process per window, not one for the application: a window is a full
 its own dock layout and its own window-scoped services, and main is the only process every renderer
 connects to directly. Services that must coordinate across every open window therefore live in
 main, which outlives any individual window. Other whole-application services — settings, menus,
-themes, extension lifecycle — live in the extension host, which is likewise a single process shared
-by every window (see the service tables below).
+theme definitions, extension lifecycle — live in the extension host, which is likewise a single
+process shared by every window (see the service tables below). Which process hosts a given service
+is worth reading out of the tables rather than inferred from what it is about: the theme
+*definitions* are extension-host data, while the theme *service* is hosted elsewhere.
 
 ### Communication Patterns
 

--- a/.context/standards/Architecture.md
+++ b/.context/standards/Architecture.md
@@ -28,13 +28,18 @@ Platform.Bible uses **JSON-RPC 2.0 over WebSocket** for inter-process communicat
 │  • Routes messages between processes                     │
 └────────────────┬────────────────────────────────────────┘
                  │ JSON-RPC over WebSocket (port 8876)
-    ┌────────────┼────────────┬───────────────────┐
-    │            │            │                   │
-┌───▼────────┐ ┌─▼──────────┐ ┌▼────────────────┐
-│ Renderer   │ │ Extension  │ │ .NET Data       │
-│ (React UI) │ │ Host       │ │ Provider        │
-└────────────┘ └────────────┘ └─────────────────┘
+    ┌────────────┼─────────────┬───────────────────┐
+    │            │             │                   │
+┌───▼────────┐ ┌─▼──────────┐ ┌▼───────────┐ ┌─────▼───────────┐
+│ Renderer   │ │ Renderer   │ │ Extension  │ │ .NET Data       │
+│ (window 1) │ │ (window N) │ │ Host       │ │ Provider        │
+└────────────┘ └────────────┘ └────────────┘ └─────────────────┘
 ```
+
+One renderer process per window, not one for the application: a window is a full renderer hosting
+its own dock layout and its own window-scoped services, and main is the only process all of them
+have in common. Services that must answer for the whole application therefore live in main, which
+outlives any individual window.
 
 ### Communication Patterns
 

--- a/.context/standards/Architecture.md
+++ b/.context/standards/Architecture.md
@@ -22,11 +22,11 @@ This document provides detailed architectural information for Platform.Bible (pa
 Platform.Bible uses **JSON-RPC 2.0 over WebSocket** for inter-process communication. All processes connect to the Main process which acts as the message broker.
 
 ```
-┌─────────────────────────────────────────────────────────┐
-│                    Main Process (Electron)               │
-│  • WebSocket server on port 8876                         │
-│  • Routes messages between processes                     │
-└────────────────┬────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────┐
+│                    Main Process (Electron)                   │
+│  • WebSocket server on port 8876                             │
+│  • Routes messages between processes                         │
+└────────────────┬─────────────────────────────────────────────┘
                  │ JSON-RPC over WebSocket (port 8876)
     ┌────────────┼─────────────┬───────────────────┐
     │            │             │                   │
@@ -37,13 +37,17 @@ Platform.Bible uses **JSON-RPC 2.0 over WebSocket** for inter-process communicat
 ```
 
 One renderer process per window, not one for the application: a window is a full renderer hosting
-its own dock layout and its own window-scoped services, and main is the only process every renderer
-connects to directly. Services that must coordinate across every open window therefore live in
-main, which outlives any individual window. Other whole-application services — settings, menus,
-theme definitions, extension lifecycle — live in the extension host, which is likewise a single
-process shared by every window (see the service tables below). Which process hosts a given service
-is worth reading out of the tables rather than inferred from what it is about: the theme
-*definitions* are extension-host data, while the theme *service* is hosted elsewhere.
+its own dock layout and its own window-scoped services. What decides where a service lives is
+lifetime, not subject matter. State that has to survive any individual window — and that two
+windows must agree on — lives in main, which outlives them all; the theme service is hosted there
+for exactly that reason. Whole-application data that no window owns — settings, menus, theme
+definitions, extension lifecycle — lives in the extension host, a single process shared by every
+window.
+
+Both of those outlive a window, so the distinction between them is not readable from what a service
+is *about*: the theme *definitions* are extension-host data while the theme *service* runs in main.
+The service tables below record where the app-global ones live; a window-scoped service is named for
+its window and lives in that window's renderer.
 
 ### Communication Patterns
 

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4564,26 +4564,32 @@ declare module 'shared/services/window.service-model' {
   import { DirectionFromTab } from 'shared/models/docking-framework.model';
   /**
    *
-   * This name is used to register the window data provider on the papi. You can use this name to
-   * find the data provider when accessing it using the useData hook
+   * This name identifies the window data provider on the papi. Each window registers a provider of
+   * its own under a window-scoped name, and this unscoped name resolves to a proxy that forwards to
+   * whichever window currently has focus. So finding the data provider by this name — with the
+   * useData hook, for instance — answers for the focused window, which is not necessarily the
+   * window you are in. Use `papi.window` to reach the caller's own window.
    */
   export const windowServiceProviderName = 'platform.windowServiceDataProvider';
   export const windowServiceObjectToProxy: Readonly<{
     /**
      *
-     * This name is used to register the window data provider on the papi. You can use this name to
-     * find the data provider when accessing it using the useData hook
+     * This name identifies the window data provider on the papi. Each window registers a provider of
+     * its own under a window-scoped name, and this unscoped name resolves to a proxy that forwards to
+     * whichever window currently has focus. So finding the data provider by this name — with the
+     * useData hook, for instance — answers for the focused window, which is not necessarily the
+     * window you are in. Use `papi.window` to reach the caller's own window.
      */
     dataProviderName: 'platform.windowServiceDataProvider';
   }>;
-  /** Focus of the window is on a WebView iframe with the specified id */
+  /** A window's focus is on a WebView iframe with the specified id */
   export type FocusSubjectWebView = {
     focusType: 'webView';
     /** ID of the WebView in focus (its tab ID is the same) */
     id: string;
   };
   /**
-   * Focus of the window is somewhere in a tab (header, toolbar, menu, content, etc.)
+   * A window's focus is somewhere in a tab (header, toolbar, menu, content, etc.)
    *
    * Note that the focused tab could be a WebView, in which case the tab is focused but it is not
    * focused in the WebView's iframe
@@ -4595,11 +4601,11 @@ declare module 'shared/services/window.service-model' {
     /** ID of the tab in focus (if this is a WebView, its WebView ID is the same) */
     id: string;
   };
-  /** Focus of the window is somewhere not in a tab (app menu, app toolbar, etc.) */
+  /** A window's focus is somewhere not in a tab (app menu, app toolbar, etc.) */
   export type FocusSubjectOther = {
     focusType: 'other';
   };
-  /** Current item that is the subject of top-level focus in the window */
+  /** Current item that is the subject of top-level focus in a window */
   export type FocusSubject = FocusSubjectWebView | FocusSubjectTab | FocusSubjectOther;
   /**
    * Gets the id of the web view a focus subject refers to, if it refers to one: either the web view
@@ -4655,9 +4661,9 @@ declare module 'shared/services/window.service-model' {
    * surveil user input. Do not broaden what is announced here without a security review.
    */
   export const EVENT_NAME_ON_DID_APP_WINDOW_INPUT = 'platform.onDidAppWindowInput';
-  /** Specific item that is intended to be focused in the top-level app window */
+  /** Specific item that is intended to be focused at the top level of a window */
   export type SetFocusSubject = FocusSubjectWebView | Omit<FocusSubjectTab, 'tabType'>;
-  /** Instructions that indicate how to change the focus within the window */
+  /** Instructions that indicate how to change the focus within a window */
   export type SetFocusSpecifier = SetFocusSubject | DirectionFromTab | 'detect' | undefined;
   export type WindowDataTypes = {
     Focus: DataProviderDataType<undefined, FocusSubject | undefined, SetFocusSpecifier>;
@@ -4669,7 +4675,9 @@ declare module 'shared/services/window.service-model' {
   }
   /**
    *
-   * Service that allows to interact with the current application window
+   * Service for interacting with an application window. Every window hosts its own, so a call from a
+   * renderer acts on the window it runs in. The extension host is in no window, so a call made there
+   * acts on whichever window has focus at that moment, which can differ between two calls.
    */
   export type IWindowService = {
     /**
@@ -4692,7 +4700,7 @@ declare module 'shared/services/window.service-model' {
      * Sets the subject of focus in the current window.
      *
      * @param focusSubject What to set the current window's focus to. Provide `'detect'` to instruct
-     *   the window to update the current focus based on what is actually focused in the window (only
+     *   that window to update its current focus based on what is actually focused in it (only
      *   necessary when an action happens that changes the focus but the window service does not
      *   detect already). In most cases, you will not need to set `'detect'` manually.
      * @returns `true` or an array of strings if the focus successfully updated; `false` otherwise
@@ -4706,7 +4714,7 @@ declare module 'shared/services/window.service-model' {
      *
      * @param selector `undefined`. Does not have to be provided
      * @param focusSubject What to set the current window's focus to. Provide `'detect'` to instruct
-     *   the window to update the current focus based on what is actually focused in the window (only
+     *   that window to update its current focus based on what is actually focused in it (only
      *   necessary when an action happens that changes the focus but the window service does not
      *   detect already). In most cases, you will not need to set `'detect'` manually.
      *
@@ -12718,7 +12726,9 @@ declare module '@papi/backend' {
     notifications: INotificationService;
     /**
      *
-     * Service that allows to interact with the current application window
+     * Service for interacting with an application window. Every window hosts its own, so a call from a
+     * renderer acts on the window it runs in. The extension host is in no window, so a call made there
+     * acts on whichever window has focus at that moment, which can differ between two calls.
      */
     window: IWindowService;
   };
@@ -12976,7 +12986,9 @@ declare module '@papi/backend' {
   export const notifications: INotificationService;
   /**
    *
-   * Service that allows to interact with the current application window
+   * Service for interacting with an application window. Every window hosts its own, so a call from a
+   * renderer acts on the window it runs in. The extension host is in no window, so a call made there
+   * acts on whichever window has focus at that moment, which can differ between two calls.
    */
   export const window: IWindowService;
 }
@@ -13579,7 +13591,9 @@ declare module '@papi/frontend' {
     notifications: INotificationService;
     /**
      *
-     * Service that allows to interact with the current application window
+     * Service for interacting with an application window. Every window hosts its own, so a call from a
+     * renderer acts on the window it runs in. The extension host is in no window, so a call made there
+     * acts on whichever window has focus at that moment, which can differ between two calls.
      */
     window: IWindowService;
     /**
@@ -13748,7 +13762,9 @@ declare module '@papi/frontend' {
   export const notifications: INotificationService;
   /**
    *
-   * Service that allows to interact with the current application window
+   * Service for interacting with an application window. Every window hosts its own, so a call from a
+   * renderer acts on the window it runs in. The extension host is in no window, so a call made there
+   * acts on whichever window has focus at that moment, which can differ between two calls.
    */
   export const window: IWindowService;
   /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4564,21 +4564,37 @@ declare module 'shared/services/window.service-model' {
   import { DirectionFromTab } from 'shared/models/docking-framework.model';
   /**
    *
-   * This name identifies the window data provider on the papi. Each window registers a provider of
-   * its own under a window-scoped name, and this unscoped name resolves to a proxy that forwards to
-   * whichever window currently has focus. So finding the data provider by this name — with the
-   * useData hook, for instance — answers for the focused window, which is not necessarily the
-   * window you are in. Use `papi.window` to reach the caller's own window.
+   * This name identifies the window data provider on the papi. Every window registers a provider of
+   * its own under a window-scoped name — this name with the window's id appended — and what you get
+   * from this property depends on where you read it.
+   *
+   * From a renderer or a web view, it is that window's own scoped name, so the provider found by it
+   * — with the useData hook, for instance — both reports and changes the focus of the window you
+   * are in. Read it from `papi.window` and use it as it comes.
+   *
+   * From the extension host, which runs in no window, it is the bare unscoped name. That name
+   * resolves to whichever window the router is currently targeting, so two reads can answer for
+   * different windows. The bare {@link windowServiceProviderName} constant behaves the same way
+   * wherever it is imported. To act on one particular window from there,
+   * `platform.getFocusedWindowId` reports which window has focus.
    */
   export const windowServiceProviderName = 'platform.windowServiceDataProvider';
   export const windowServiceObjectToProxy: Readonly<{
     /**
      *
-     * This name identifies the window data provider on the papi. Each window registers a provider of
-     * its own under a window-scoped name, and this unscoped name resolves to a proxy that forwards to
-     * whichever window currently has focus. So finding the data provider by this name — with the
-     * useData hook, for instance — answers for the focused window, which is not necessarily the
-     * window you are in. Use `papi.window` to reach the caller's own window.
+     * This name identifies the window data provider on the papi. Every window registers a provider of
+     * its own under a window-scoped name — this name with the window's id appended — and what you get
+     * from this property depends on where you read it.
+     *
+     * From a renderer or a web view, it is that window's own scoped name, so the provider found by it
+     * — with the useData hook, for instance — both reports and changes the focus of the window you
+     * are in. Read it from `papi.window` and use it as it comes.
+     *
+     * From the extension host, which runs in no window, it is the bare unscoped name. That name
+     * resolves to whichever window the router is currently targeting, so two reads can answer for
+     * different windows. The bare {@link windowServiceProviderName} constant behaves the same way
+     * wherever it is imported. To act on one particular window from there,
+     * `platform.getFocusedWindowId` reports which window has focus.
      */
     dataProviderName: 'platform.windowServiceDataProvider';
   }>;
@@ -4677,7 +4693,13 @@ declare module 'shared/services/window.service-model' {
    *
    * Service for interacting with an application window. Every window hosts its own, so a call from a
    * renderer acts on the window it runs in. The extension host is in no window, so a call made there
-   * acts on whichever window has focus at that moment, which can differ between two calls.
+   * acts on whichever window the router is targeting at that moment, which can differ between two
+   * calls.
+   *
+   * The routing target is usually the focused window, but not always: a window that has taken OS
+   * focus does not become the target until it is ready and not closing, so a newly opened window can
+   * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
+   * tracks focus itself.
    */
   export type IWindowService = {
     /**
@@ -4732,10 +4754,10 @@ declare module 'shared/services/window.service-model' {
      * Subscribe to run a callback function when the current window's subject of focus is changed
      *
      * @param selector `undefined`. Does not have to be provided
-     * @param callback Function to run with the updated localized menuContent for this selector. If
-     *   there is an error while retrieving the updated data, the function will run with a
-     *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this value
-     *   to check if it is an error.
+     * @param callback Function to run with the window's updated subject of focus. If there is an
+     *   error while retrieving the updated data, the function will run with a {@link PlatformError}
+     *   instead of the data. You can call {@link isPlatformError} on this value to check if it is an
+     *   error.
      * @param options Various options to adjust how the subscriber emits updates
      * @returns Unsubscriber function (run to unsubscribe from listening for updates)
      */
@@ -12728,7 +12750,13 @@ declare module '@papi/backend' {
      *
      * Service for interacting with an application window. Every window hosts its own, so a call from a
      * renderer acts on the window it runs in. The extension host is in no window, so a call made there
-     * acts on whichever window has focus at that moment, which can differ between two calls.
+     * acts on whichever window the router is targeting at that moment, which can differ between two
+     * calls.
+     *
+     * The routing target is usually the focused window, but not always: a window that has taken OS
+     * focus does not become the target until it is ready and not closing, so a newly opened window can
+     * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
+     * tracks focus itself.
      */
     window: IWindowService;
   };
@@ -12988,7 +13016,13 @@ declare module '@papi/backend' {
    *
    * Service for interacting with an application window. Every window hosts its own, so a call from a
    * renderer acts on the window it runs in. The extension host is in no window, so a call made there
-   * acts on whichever window has focus at that moment, which can differ between two calls.
+   * acts on whichever window the router is targeting at that moment, which can differ between two
+   * calls.
+   *
+   * The routing target is usually the focused window, but not always: a window that has taken OS
+   * focus does not become the target until it is ready and not closing, so a newly opened window can
+   * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
+   * tracks focus itself.
    */
   export const window: IWindowService;
 }
@@ -13593,7 +13627,13 @@ declare module '@papi/frontend' {
      *
      * Service for interacting with an application window. Every window hosts its own, so a call from a
      * renderer acts on the window it runs in. The extension host is in no window, so a call made there
-     * acts on whichever window has focus at that moment, which can differ between two calls.
+     * acts on whichever window the router is targeting at that moment, which can differ between two
+     * calls.
+     *
+     * The routing target is usually the focused window, but not always: a window that has taken OS
+     * focus does not become the target until it is ready and not closing, so a newly opened window can
+     * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
+     * tracks focus itself.
      */
     window: IWindowService;
     /**
@@ -13764,7 +13804,13 @@ declare module '@papi/frontend' {
    *
    * Service for interacting with an application window. Every window hosts its own, so a call from a
    * renderer acts on the window it runs in. The extension host is in no window, so a call made there
-   * acts on whichever window has focus at that moment, which can differ between two calls.
+   * acts on whichever window the router is targeting at that moment, which can differ between two
+   * calls.
+   *
+   * The routing target is usually the focused window, but not always: a window that has taken OS
+   * focus does not become the target until it is ready and not closing, so a newly opened window can
+   * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
+   * tracks focus itself.
    */
   export const window: IWindowService;
   /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4701,8 +4701,8 @@ declare module 'shared/services/window.service-model' {
    * or the focused window has not registered its window service — either because it is still starting
    * or because it has just gone away — the call throws rather than falling back to another window.
    *
-   * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
-   * bare unscoped name goes through the router; `papi.window` does not.
+   * This is a different resolver from the one the `windowServiceProviderName` doc describes: the bare
+   * unscoped name goes through the router; `papi.window` does not.
    */
   export type IWindowService = {
     /**
@@ -12761,8 +12761,8 @@ declare module '@papi/backend' {
      * or the focused window has not registered its window service — either because it is still starting
      * or because it has just gone away — the call throws rather than falling back to another window.
      *
-     * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
-     * bare unscoped name goes through the router; `papi.window` does not.
+     * This is a different resolver from the one the `windowServiceProviderName` doc describes: the bare
+     * unscoped name goes through the router; `papi.window` does not.
      */
     window: IWindowService;
   };
@@ -13030,8 +13030,8 @@ declare module '@papi/backend' {
    * or the focused window has not registered its window service — either because it is still starting
    * or because it has just gone away — the call throws rather than falling back to another window.
    *
-   * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
-   * bare unscoped name goes through the router; `papi.window` does not.
+   * This is a different resolver from the one the `windowServiceProviderName` doc describes: the bare
+   * unscoped name goes through the router; `papi.window` does not.
    */
   export const window: IWindowService;
 }
@@ -13644,8 +13644,8 @@ declare module '@papi/frontend' {
      * or the focused window has not registered its window service — either because it is still starting
      * or because it has just gone away — the call throws rather than falling back to another window.
      *
-     * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
-     * bare unscoped name goes through the router; `papi.window` does not.
+     * This is a different resolver from the one the `windowServiceProviderName` doc describes: the bare
+     * unscoped name goes through the router; `papi.window` does not.
      */
     window: IWindowService;
     /**
@@ -13824,8 +13824,8 @@ declare module '@papi/frontend' {
    * or the focused window has not registered its window service — either because it is still starting
    * or because it has just gone away — the call throws rather than falling back to another window.
    *
-   * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
-   * bare unscoped name goes through the router; `papi.window` does not.
+   * This is a different resolver from the one the `windowServiceProviderName` doc describes: the bare
+   * unscoped name goes through the router; `papi.window` does not.
    */
   export const window: IWindowService;
   /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -4692,14 +4692,17 @@ declare module 'shared/services/window.service-model' {
   /**
    *
    * Service for interacting with an application window. Every window hosts its own, so a call from a
-   * renderer acts on the window it runs in. The extension host is in no window, so a call made there
-   * acts on whichever window the router is targeting at that moment, which can differ between two
-   * calls.
+   * renderer acts on the window it runs in.
    *
-   * The routing target is usually the focused window, but not always: a window that has taken OS
-   * focus does not become the target until it is ready and not closing, so a newly opened window can
-   * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
-   * tracks focus itself.
+   * The extension host is in no window, so a call made there acts on the window that most recently
+   * had focus — `platform.getFocusedWindowId`, which stays set while the application is in the
+   * background. Two calls can answer for different windows, and a subscription binds to the window
+   * focused when it was made rather than following focus afterwards. If there is no focused window,
+   * or the focused window has not registered its window service — either because it is still starting
+   * or because it has just gone away — the call throws rather than falling back to another window.
+   *
+   * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
+   * bare unscoped name goes through the router; `papi.window` does not.
    */
   export type IWindowService = {
     /**
@@ -12749,14 +12752,17 @@ declare module '@papi/backend' {
     /**
      *
      * Service for interacting with an application window. Every window hosts its own, so a call from a
-     * renderer acts on the window it runs in. The extension host is in no window, so a call made there
-     * acts on whichever window the router is targeting at that moment, which can differ between two
-     * calls.
+     * renderer acts on the window it runs in.
      *
-     * The routing target is usually the focused window, but not always: a window that has taken OS
-     * focus does not become the target until it is ready and not closing, so a newly opened window can
-     * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
-     * tracks focus itself.
+     * The extension host is in no window, so a call made there acts on the window that most recently
+     * had focus — `platform.getFocusedWindowId`, which stays set while the application is in the
+     * background. Two calls can answer for different windows, and a subscription binds to the window
+     * focused when it was made rather than following focus afterwards. If there is no focused window,
+     * or the focused window has not registered its window service — either because it is still starting
+     * or because it has just gone away — the call throws rather than falling back to another window.
+     *
+     * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
+     * bare unscoped name goes through the router; `papi.window` does not.
      */
     window: IWindowService;
   };
@@ -13015,14 +13021,17 @@ declare module '@papi/backend' {
   /**
    *
    * Service for interacting with an application window. Every window hosts its own, so a call from a
-   * renderer acts on the window it runs in. The extension host is in no window, so a call made there
-   * acts on whichever window the router is targeting at that moment, which can differ between two
-   * calls.
+   * renderer acts on the window it runs in.
    *
-   * The routing target is usually the focused window, but not always: a window that has taken OS
-   * focus does not become the target until it is ready and not closing, so a newly opened window can
-   * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
-   * tracks focus itself.
+   * The extension host is in no window, so a call made there acts on the window that most recently
+   * had focus — `platform.getFocusedWindowId`, which stays set while the application is in the
+   * background. Two calls can answer for different windows, and a subscription binds to the window
+   * focused when it was made rather than following focus afterwards. If there is no focused window,
+   * or the focused window has not registered its window service — either because it is still starting
+   * or because it has just gone away — the call throws rather than falling back to another window.
+   *
+   * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
+   * bare unscoped name goes through the router; `papi.window` does not.
    */
   export const window: IWindowService;
 }
@@ -13626,14 +13635,17 @@ declare module '@papi/frontend' {
     /**
      *
      * Service for interacting with an application window. Every window hosts its own, so a call from a
-     * renderer acts on the window it runs in. The extension host is in no window, so a call made there
-     * acts on whichever window the router is targeting at that moment, which can differ between two
-     * calls.
+     * renderer acts on the window it runs in.
      *
-     * The routing target is usually the focused window, but not always: a window that has taken OS
-     * focus does not become the target until it is ready and not closing, so a newly opened window can
-     * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
-     * tracks focus itself.
+     * The extension host is in no window, so a call made there acts on the window that most recently
+     * had focus — `platform.getFocusedWindowId`, which stays set while the application is in the
+     * background. Two calls can answer for different windows, and a subscription binds to the window
+     * focused when it was made rather than following focus afterwards. If there is no focused window,
+     * or the focused window has not registered its window service — either because it is still starting
+     * or because it has just gone away — the call throws rather than falling back to another window.
+     *
+     * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
+     * bare unscoped name goes through the router; `papi.window` does not.
      */
     window: IWindowService;
     /**
@@ -13803,14 +13815,17 @@ declare module '@papi/frontend' {
   /**
    *
    * Service for interacting with an application window. Every window hosts its own, so a call from a
-   * renderer acts on the window it runs in. The extension host is in no window, so a call made there
-   * acts on whichever window the router is targeting at that moment, which can differ between two
-   * calls.
+   * renderer acts on the window it runs in.
    *
-   * The routing target is usually the focused window, but not always: a window that has taken OS
-   * focus does not become the target until it is ready and not closing, so a newly opened window can
-   * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
-   * tracks focus itself.
+   * The extension host is in no window, so a call made there acts on the window that most recently
+   * had focus — `platform.getFocusedWindowId`, which stays set while the application is in the
+   * background. Two calls can answer for different windows, and a subscription binds to the window
+   * focused when it was made rather than following focus afterwards. If there is no focused window,
+   * or the focused window has not registered its window service — either because it is still starting
+   * or because it has just gone away — the call throws rather than falling back to another window.
+   *
+   * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
+   * bare unscoped name goes through the router; `papi.window` does not.
    */
   export const window: IWindowService;
   /**

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -737,11 +737,9 @@ async function main() {
       // TODO: Remove this temporary enforcement when https://paratextstudio.atlassian.net/browse/PT-2333 is implemented
       minWidth: 900,
       icon: getAssetPath('icon.png'),
-      // TODO: Re-check linux support with Electron 34, see https://discord.com/channels/1064938364597436416/1344329166786527232
-      ...(process.platform !== 'linux' ? { titleBarStyle: 'hidden' } : {}),
+      titleBarStyle: 'hidden',
       // re-add window controls
-      // TODO: Re-check linux support with Electron 34, see https://discord.com/channels/1064938364597436416/1344329166786527232
-      ...(process.platform !== 'darwin' && process.platform !== 'linux'
+      ...(process.platform !== 'darwin'
         ? {
             titleBarOverlay: {
               height: TITLE_BAR_BUTTON_HEIGHT,
@@ -1001,8 +999,7 @@ async function main() {
       }
 
       // Adjust the Window button colors based on the current theme
-      // TODO: Re-check linux support with Electron 34, see https://discord.com/channels/1064938364597436416/1344329166786527232
-      if (process.platform !== 'darwin' && process.platform !== 'linux') {
+      if (process.platform !== 'darwin') {
         const paintTitleBarForTheme = (newTheme: ThemeDefinitionExpanded) => {
           if (!newTheme.cssVariables.primary) {
             logger.warn(

--- a/src/renderer/components/platform-bible-toolbar.test.tsx
+++ b/src/renderer/components/platform-bible-toolbar.test.tsx
@@ -979,6 +979,25 @@ describe('PlatformBibleToolbar — title bar reserved space', () => {
     expect(screen.getByTestId('toolbar-root')).not.toHaveClass('tw:pe-0');
   });
 
+  it('reserves the live-measured overlay width on Linux, the same as Windows', async () => {
+    // Linux takes the frameless path with its own caption buttons, so the toolbar has to leave room
+    // for them. Without the reservation the account icon draws on top of the maximize glyph.
+    vi.mocked(useWindowControlsOverlay).mockReturnValue(
+      new DOMRect(0, 0, window.innerWidth - 150, 32),
+    );
+    mockSendCommandForOS('linux');
+
+    render(<PlatformBibleToolbar />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('toolbar-reserved-space-wrapper')).toHaveStyle({
+        paddingRight: '154px',
+      });
+    });
+    expect(screen.getByTestId('toolbar-root')).toHaveClass('tw:border-0');
+    expect(screen.getByTestId('toolbar-root')).toHaveClass('tw:pe-0');
+  });
+
   it('does not reserve space on macOS regardless of overlay geometry, keeping the static traffic-lights class', async () => {
     vi.mocked(useWindowControlsOverlay).mockReturnValue(new DOMRect(0, 0, 700, 32));
     mockSendCommandForOS('darwin');

--- a/src/renderer/components/platform-bible-toolbar.tsx
+++ b/src/renderer/components/platform-bible-toolbar.tsx
@@ -357,8 +357,6 @@ export function PlatformBibleToolbar() {
 
       // no need to reserve space for macos "traffic lights" when in full screen
       if (osPlatform === 'darwin' && isFullScreen) return undefined;
-      // TODO: Re-check linux support with Electron 34, see https://discord.com/channels/1064938364597436416/1344329166786527232
-      if (osPlatform === 'linux') return undefined;
       return osPlatform;
     }, []),
 

--- a/src/renderer/hooks/use-window-controls-overlay.hook.ts
+++ b/src/renderer/hooks/use-window-controls-overlay.hook.ts
@@ -6,8 +6,10 @@ import { useEffect, useState } from 'react';
  * pixel guess can't track DPI scaling, text-size settings, or OS theme differences that change the
  * buttons' actual width; this reads the real value instead.
  *
- * Returns `undefined` when the API is unavailable (macOS/Linux) or the overlay isn't visible (e.g.
- * full screen).
+ * Returns `undefined` when the API is unavailable — macOS draws its own traffic lights and has no
+ * overlay — or when the overlay isn't visible (e.g. full screen). Linux uses the overlay, but which
+ * desktop environments report geometry for it is unverified; one that does not falls back to the
+ * static reservation, the same as before the overlay was asked for there.
  */
 export function useWindowControlsOverlay(): DOMRect | undefined {
   const { windowControlsOverlay } = navigator;

--- a/src/shared/services/window.service-model.ts
+++ b/src/shared/services/window.service-model.ts
@@ -13,13 +13,14 @@ export const windowServiceObjectToProxy = Object.freeze({
   /**
    * JSDOC SOURCE windowServiceProviderName
    *
-   * This name is used to register the window data provider on the papi. You can use this name to
-   * find the data provider when accessing it using the useData hook
+   * This name identifies the window data provider on the papi. You can use this name to find the
+   * data provider when accessing it using the useData hook, and it resolves to the provider serving
+   * the window you are in — each window has one of its own.
    */
   dataProviderName: windowServiceProviderName,
 });
 
-/** Focus of the window is on a WebView iframe with the specified id */
+/** A window's focus is on a WebView iframe with the specified id */
 export type FocusSubjectWebView = {
   focusType: 'webView';
   /** ID of the WebView in focus (its tab ID is the same) */
@@ -27,7 +28,7 @@ export type FocusSubjectWebView = {
 };
 
 /**
- * Focus of the window is somewhere in a tab (header, toolbar, menu, content, etc.)
+ * A window's focus is somewhere in a tab (header, toolbar, menu, content, etc.)
  *
  * Note that the focused tab could be a WebView, in which case the tab is focused but it is not
  * focused in the WebView's iframe
@@ -40,12 +41,12 @@ export type FocusSubjectTab = {
   id: string;
 };
 
-/** Focus of the window is somewhere not in a tab (app menu, app toolbar, etc.) */
+/** A window's focus is somewhere not in a tab (app menu, app toolbar, etc.) */
 export type FocusSubjectOther = {
   focusType: 'other';
 };
 
-/** Current item that is the subject of top-level focus in the window */
+/** Current item that is the subject of top-level focus in a window */
 export type FocusSubject = FocusSubjectWebView | FocusSubjectTab | FocusSubjectOther;
 
 /**
@@ -111,10 +112,10 @@ export type AppWindowInputEvent = {
  */
 export const EVENT_NAME_ON_DID_APP_WINDOW_INPUT = 'platform.onDidAppWindowInput';
 
-/** Specific item that is intended to be focused in the top-level app window */
+/** Specific item that is intended to be focused at the top level of a window */
 export type SetFocusSubject = FocusSubjectWebView | Omit<FocusSubjectTab, 'tabType'>;
 
-/** Instructions that indicate how to change the focus within the window */
+/** Instructions that indicate how to change the focus within a window */
 export type SetFocusSpecifier = SetFocusSubject | DirectionFromTab | 'detect' | undefined;
 
 // Data Type to initialize data provider engine with
@@ -131,7 +132,8 @@ declare module 'papi-shared-types' {
 /**
  * JSDOC SOURCE windowService
  *
- * Service that allows to interact with the current application window
+ * Service for interacting with the application window it is used in. Every window hosts its own, so
+ * a call acts on the caller's own window rather than on one app-wide window.
  */
 export type IWindowService = {
   /**
@@ -149,7 +151,7 @@ export type IWindowService = {
    * Sets the subject of focus in the current window.
    *
    * @param focusSubject What to set the current window's focus to. Provide `'detect'` to instruct
-   *   the window to update the current focus based on what is actually focused in the window (only
+   *   that window to update its current focus based on what is actually focused in it (only
    *   necessary when an action happens that changes the focus but the window service does not
    *   detect already). In most cases, you will not need to set `'detect'` manually.
    * @returns `true` or an array of strings if the focus successfully updated; `false` otherwise
@@ -163,7 +165,7 @@ export type IWindowService = {
    *
    * @param selector `undefined`. Does not have to be provided
    * @param focusSubject What to set the current window's focus to. Provide `'detect'` to instruct
-   *   the window to update the current focus based on what is actually focused in the window (only
+   *   that window to update its current focus based on what is actually focused in it (only
    *   necessary when an action happens that changes the focus but the window service does not
    *   detect already). In most cases, you will not need to set `'detect'` manually.
    *

--- a/src/shared/services/window.service-model.ts
+++ b/src/shared/services/window.service-model.ts
@@ -13,9 +13,11 @@ export const windowServiceObjectToProxy = Object.freeze({
   /**
    * JSDOC SOURCE windowServiceProviderName
    *
-   * This name identifies the window data provider on the papi. You can use this name to find the
-   * data provider when accessing it using the useData hook, and it resolves to the provider serving
-   * the window you are in — each window has one of its own.
+   * This name identifies the window data provider on the papi. Each window registers a provider of
+   * its own under a window-scoped name, and this unscoped name resolves to a proxy that forwards to
+   * whichever window currently has focus. So finding the data provider by this name — with the
+   * useData hook, for instance — answers for the focused window, which is not necessarily the
+   * window you are in. Use `papi.window` to reach the caller's own window.
    */
   dataProviderName: windowServiceProviderName,
 });
@@ -132,8 +134,9 @@ declare module 'papi-shared-types' {
 /**
  * JSDOC SOURCE windowService
  *
- * Service for interacting with the application window it is used in. Every window hosts its own, so
- * a call acts on the caller's own window rather than on one app-wide window.
+ * Service for interacting with an application window. Every window hosts its own, so a call from a
+ * renderer acts on the window it runs in. The extension host is in no window, so a call made there
+ * acts on whichever window has focus at that moment, which can differ between two calls.
  */
 export type IWindowService = {
   /**

--- a/src/shared/services/window.service-model.ts
+++ b/src/shared/services/window.service-model.ts
@@ -13,11 +13,19 @@ export const windowServiceObjectToProxy = Object.freeze({
   /**
    * JSDOC SOURCE windowServiceProviderName
    *
-   * This name identifies the window data provider on the papi. Each window registers a provider of
-   * its own under a window-scoped name, and this unscoped name resolves to a proxy that forwards to
-   * whichever window currently has focus. So finding the data provider by this name — with the
-   * useData hook, for instance — answers for the focused window, which is not necessarily the
-   * window you are in. Use `papi.window` to reach the caller's own window.
+   * This name identifies the window data provider on the papi. Every window registers a provider of
+   * its own under a window-scoped name — this name with the window's id appended — and what you get
+   * from this property depends on where you read it.
+   *
+   * From a renderer or a web view, it is that window's own scoped name, so the provider found by it
+   * — with the useData hook, for instance — both reports and changes the focus of the window you
+   * are in. Read it from `papi.window` and use it as it comes.
+   *
+   * From the extension host, which runs in no window, it is the bare unscoped name. That name
+   * resolves to whichever window the router is currently targeting, so two reads can answer for
+   * different windows. The bare {@link windowServiceProviderName} constant behaves the same way
+   * wherever it is imported. To act on one particular window from there,
+   * `platform.getFocusedWindowId` reports which window has focus.
    */
   dataProviderName: windowServiceProviderName,
 });
@@ -136,7 +144,13 @@ declare module 'papi-shared-types' {
  *
  * Service for interacting with an application window. Every window hosts its own, so a call from a
  * renderer acts on the window it runs in. The extension host is in no window, so a call made there
- * acts on whichever window has focus at that moment, which can differ between two calls.
+ * acts on whichever window the router is targeting at that moment, which can differ between two
+ * calls.
+ *
+ * The routing target is usually the focused window, but not always: a window that has taken OS
+ * focus does not become the target until it is ready and not closing, so a newly opened window can
+ * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
+ * tracks focus itself.
  */
 export type IWindowService = {
   /**
@@ -186,10 +200,10 @@ export type IWindowService = {
    * Subscribe to run a callback function when the current window's subject of focus is changed
    *
    * @param selector `undefined`. Does not have to be provided
-   * @param callback Function to run with the updated localized menuContent for this selector. If
-   *   there is an error while retrieving the updated data, the function will run with a
-   *   {@link PlatformError} instead of the data. You can call {@link isPlatformError} on this value
-   *   to check if it is an error.
+   * @param callback Function to run with the window's updated subject of focus. If there is an
+   *   error while retrieving the updated data, the function will run with a {@link PlatformError}
+   *   instead of the data. You can call {@link isPlatformError} on this value to check if it is an
+   *   error.
    * @param options Various options to adjust how the subscriber emits updates
    * @returns Unsubscriber function (run to unsubscribe from listening for updates)
    */

--- a/src/shared/services/window.service-model.ts
+++ b/src/shared/services/window.service-model.ts
@@ -143,14 +143,17 @@ declare module 'papi-shared-types' {
  * JSDOC SOURCE windowService
  *
  * Service for interacting with an application window. Every window hosts its own, so a call from a
- * renderer acts on the window it runs in. The extension host is in no window, so a call made there
- * acts on whichever window the router is targeting at that moment, which can differ between two
- * calls.
+ * renderer acts on the window it runs in.
  *
- * The routing target is usually the focused window, but not always: a window that has taken OS
- * focus does not become the target until it is ready and not closing, so a newly opened window can
- * hold focus while calls still act on the previous one. `platform.getFocusedWindowId` is what
- * tracks focus itself.
+ * The extension host is in no window, so a call made there acts on the window that most recently
+ * had focus — `platform.getFocusedWindowId`, which stays set while the application is in the
+ * background. Two calls can answer for different windows, and a subscription binds to the window
+ * focused when it was made rather than following focus afterwards. If there is no focused window,
+ * or the focused window has not registered its window service — either because it is still starting
+ * or because it has just gone away — the call throws rather than falling back to another window.
+ *
+ * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
+ * bare unscoped name goes through the router; `papi.window` does not.
  */
 export type IWindowService = {
   /**

--- a/src/shared/services/window.service-model.ts
+++ b/src/shared/services/window.service-model.ts
@@ -152,8 +152,8 @@ declare module 'papi-shared-types' {
  * or the focused window has not registered its window service — either because it is still starting
  * or because it has just gone away — the call throws rather than falling back to another window.
  *
- * This is a different resolver from the one the {@link windowServiceProviderName} doc describes: the
- * bare unscoped name goes through the router; `papi.window` does not.
+ * This is a different resolver from the one the `windowServiceProviderName` doc describes: the bare
+ * unscoped name goes through the router; `papi.window` does not.
  */
 export type IWindowService = {
   /**

--- a/src/shared/services/window.service.test.ts
+++ b/src/shared/services/window.service.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { windowServiceProviderName } from '@shared/services/window.service-model';
+
+// The proxy's dependency graph is only reached by the async path, which these tests never take —
+// they read `dataProviderName`, which the proxy target answers synchronously. Stubbed so the module
+// imports cleanly rather than because anything here is exercised.
+vi.mock('@shared/services/data-provider.service', () => ({ getByType: vi.fn() }));
+vi.mock('@shared/services/command.service', () => ({ sendCommand: vi.fn() }));
+
+/**
+ * `windowService` reads `globalThis.windowId` through a getter at access time, so each case sets it
+ * before importing a fresh copy of the module.
+ *
+ * Wrapped in an object rather than returned directly: the proxy answers every property it does not
+ * hold with an async function, `then` included, so it satisfies the thenable check. Returning it
+ * from an `async` function would make the runtime call that `then` and drive the real provider
+ * lookup, which is neither what these tests are about nor available here.
+ */
+async function windowServiceWithWindowId(windowId: string | undefined) {
+  vi.resetModules();
+  if (windowId === undefined) delete globalThis.windowId;
+  else globalThis.windowId = windowId;
+  return { windowService: (await import('@shared/services/window.service')).windowService };
+}
+
+afterEach(() => {
+  delete globalThis.windowId;
+});
+
+describe('windowService.dataProviderName', () => {
+  test('answers the window-scoped name wherever a window id is set', async () => {
+    // What the public TSDoc on this property promises a renderer or web view caller. The proxy
+    // target spreads `windowServiceObjectToProxy` — whose `dataProviderName` is the bare, unscoped
+    // constant — and then defines a getter of the same name over it, and
+    // `createSyncProxyForAsyncObject`'s trap returns any property present on its target. So the
+    // getter is what answers, and the spread value is never seen.
+    const { windowService } = await windowServiceWithWindowId('7');
+
+    expect(windowService.dataProviderName).toBe(`${windowServiceProviderName}-7`);
+  });
+
+  test('answers the bare unscoped name where no window id is set, as in the extension host', async () => {
+    // The other half of the same promise, and the reason the doc has to name both audiences: the
+    // extension host runs in no window, so the same property there is the unscoped name that
+    // resolves through whichever window the router is targeting.
+    const { windowService } = await windowServiceWithWindowId(undefined);
+
+    expect(windowService.dataProviderName).toBe(windowServiceProviderName);
+  });
+});


### PR DESCRIPTION
# Summary

The **documentation half of PT-4278**, plus the Linux frameless-guard portion of the chrome half, added after round 1's review. The drag-area requirement is the one piece still on the ticket; it is not touched here. See “Linux window chrome” below for what shipped and why it's unverified.

Public API docs stopped describing an application with one window, and the architecture diagram stopped drawing one renderer.

## What this changes

- **`window.service-model.ts`** — the focus-subject types said "the window" with no antecedent, which only reads correctly if there is exactly one. Both `setFocus` overloads told the reader to instruct "the window" to update the focus "in the window"; that anaphora breaks as soon as windows are plural. Each now names *a* window.
- **The service headline** said it interacts with "the current application window" without saying which, or that others exist. It now says it acts on the window it is used in, that **every window hosts its own**, and that a call from the extension host acts on the **routing target** — which is the focused window only while that window is ready and not closing, so a newly opened window can hold OS focus while calls still act on the previous one.
- **The provider-name doc** now answers per audience, because the answer genuinely differs by where you read it. From a renderer or web view, `papi.window.dataProviderName` is that window's **own scoped name**: the proxy target defines a getter returning it, and `createSyncProxyForAsyncObject`'s trap answers from the target for any property the target holds. From the extension host, and from the bare exported constant, it is the unscoped name that resolves through the routing target.
- **`subscribeFocus`'s `@param callback`** described "the updated localized menuContent for this selector", copied from the menu data service. It describes the focus subject it actually receives. The line ships at two overload sites in the generated declarations.
- **`Architecture.md`'s process diagram** drew a single Renderer box. It now draws one per window. The paragraph beneath it states the criterion that decides where a service lives — **lifetime, not subject matter** — because the previous wording said app-wide coordination lives in main and then named settings, menus and theme definitions as extension-host residents one clause later, which cannot discriminate. The Main Process box was also a column wider on its content rows than at its corners, and the four-box child row overhung it; both are squared up.

## What this adds

- **`src/shared/services/window.service.test.ts`** — pins what the provider-name doc now claims: the window-scoped name where a window id is set, the bare name where none is. There was no test on this before, and the one place that mocks `windowService` supplies the *unscoped* name — the misunderstanding the old doc created. Removing the getter, so the spread's unscoped constant answers instead, fails the first case and leaves the second passing.

## Deliberately not changed

- **`docking-framework.model.ts`** — under a standing coordination rule, that file changed only via PT-4281 until it landed.
- **`web-view.service-model.ts`** — checked and needs nothing. Every window mention in it is already plural-safe ("the window that did not answer", "a window that could not answer", "the window the user is looking at").
- No new public API, so no experimental markers are involved.
- Several pre-existing staleness items raised in review are left for follow-up: single-Renderer diagram copies in `CLAUDE.md`, two `.claude/skills/*/reference.md` files and a `.context/research/` snapshot; an `AppFocus` token in `shared-patterns.md` that never existed in code; and this file's own frontmatter and version-log markers. None is introduced or continued by this PR, and the diagram copies are a four-file duplication that fixing one of would not solve.

## UX-owned wording is on `main`, not here

This branch previously carried glossary and interaction-guideline changes routed from #2646 for UX review. **#2670 merged first and rewrote the same lines on `main`**, so both of those commits replayed to nothing during the rebase and dropped out. This PR no longer touches `lib/platform-bible-react/src/stories/guidelines/**` at all, and the current wording — windows as equal siblings, none of them a main or parent window — is #2670's.

One consequence is open rather than settled: the #2646 intent, that an action you start lands in the window you are working in, is now absent from the documentation entirely. Whether a corrected version returns — one that excludes the `openWebView` `existingId` case, which deliberately raises the *owning* window — is a UX call and sits with Rolf.

## Linux window chrome (PT-4278's chrome half)

Four guards kept Linux off the frameless title bar, each carrying the same note to re-check once
Electron 34 landed. They are lifted together, because each alone is worse than none: caption buttons
with nothing reserving room put the account icon on top of the maximize glyph, and a reserved strip
with no buttons in it is just a gap.

- The window goes frameless, as it already did on Windows and macOS.
- Native caption buttons are drawn over it, as on Windows.
- Those buttons follow the theme.
- The toolbar reserves the live-measured width they occupy.

macOS keeps its own traffic lights and stays excluded from the second and third; nothing about the
Windows or macOS path changes value, since every edit only removes `linux` from a negative
condition.

**Linux is unverified, and this is best-effort by explicit decision.** There is no Linux desktop to
try it on — WSLg is not a GNOME or KDE session — so the change is kept to the guards themselves so
that what moved is legible if it has to be undone. **CI's ubuntu smoke suite cannot validate this**:
it runs headless under Xvfb with no window manager, so a green tick there means "still launches",
not "the chrome renders correctly". The one automated check with real teeth is the new unit test
asserting Linux reserves the live-measured overlay width, mirroring the existing Windows case; it
fails against the guard and passes with it lifted.

**Not delivered here:** the ticket's second chrome item, a grabbable drag area at every zoom level.
Its premise is unverified — `-webkit-app-region` appears nowhere in the codebase — and it is a
PT-3346-class bug rather than part of this sweep.


## Verification

`lint` and `format:check` exit 0. The `src/shared` suites pass (31 files, 376 tests). `papi.d.ts` is **regenerated via `npm run build:types`, never hand-edited** — including through the rebase, where every conflict in it was resolved to the base's copy and the file regenerated afterwards rather than merged by hand, since a hand-merge of generated output produces declarations matching neither side. Its diff is wording only: filtering to non-comment lines returns nothing.

`typecheck` was run in a nested worktree, where it fails with duplicate-identifier errors from extension tsconfigs resolving through a fixed number of `../`. It fails identically on `origin/main` at the same nesting depth — the sorted error lists diff to nothing — so the branch adds no type error, but CI is the authority here rather than that local run.

AI-assisted — [session](https://claude.ai/code/session_0119Q6FZ1vLyEMRBgLikjqj9)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2728)
<!-- Reviewable:end -->




