### PR TITLE
Add jira-creation skill for creating PT work items

### DIFF
--- a/.claude/commands/prd-to-jira.md
+++ b/.claude/commands/prd-to-jira.md
@@ -53,13 +53,14 @@ tools); **drafting** doesn't — if Jira isn't connected, say so and follow step
 3. **Dry-run gate (required — never skip).** Show the user the complete drafts and get explicit
    approval before creating anything. These are posted to the team's Jira under the user's name.
 4. **Create, then populate each description in a second pass.** Creating an issue in `PT` replaces
-   your description with the work-item type's default template, so follow
-   [`.claude/rules/jira-issue-creation.md`](../rules/jira-issue-creation.md) (create → read the
-   live template off the created issue → fit your content into its sections → push the edit →
-   verify). Create the parent, then each child with the parent set — one at a time, keeping the
-   created keys. The child sections this command drafts (User Story, Description, Implementation
-   Ideas, Testing Ideas, Definition of Done, Dependencies) are written to line up with a typical
-   task template — map them onto whatever headings each issue actually shows, carrying any extras
+   your description with the work-item type's default template, so use the **`jira-creation`
+   skill** ([`.claude/skills/jira-creation/SKILL.md`](../skills/jira-creation/SKILL.md)) — create
+   → read the live template off the created issue → fit your content into its sections → push the
+   edit → verify. Create the parent, then each child with the parent set — one at a time, filling
+   and verifying each before moving on, and keeping the created keys. The child sections this
+   command drafts (User Story, Description, Implementation Ideas, Testing Ideas, Definition of
+   Done, Dependencies) are written to line up with a typical task template — map them onto
+   whatever headings each issue actually shows, carrying any extras
    (e.g. **Dependencies**) under the closest section. For the parent, place the problem statement /
    PRD link / non-negotiables table under the closest headings rather than dropping the scaffold.
 5. **Back-fill the mapping**: update the parent's description so each non-negotiable row lists

--- a/.claude/rules/jira-issue-creation.md
+++ b/.claude/rules/jira-issue-creation.md
@@ -3,47 +3,14 @@ paths:
   - ".claude/commands/prd-to-jira.md"
 ---
 
-## Creating Jira Issues — Fill the Template, Don't Overwrite It
+## Creating Jira Issues — Use the `jira-creation` Skill
 
-Platform.Bible work is tracked in the **Paratext (`PT`) Jira project** on
-`paratextstudio.atlassian.net`, reached through the Atlassian MCP server (OAuth — no API token, and
-issues are created under the signed-in user's own account and permissions).
+Creating a work item in the Paratext `PT` Jira project is **create → read the live template →
+fit your content into it → edit → verify**: the project replaces any description you pass to the
+create call with the work-item type's default template, so the real description has to be
+delivered by a follow-up edit.
 
-When you create an issue there, the project applies **that work-item type's default description
-template**, and it **replaces whatever description you passed in the create call**. Each work-item
-type (Combined, Dev Task, Sub-task, Bug, …) has its own template and the templates change over
-time, so never assume their shape or hard-code their sections — read the live template off the
-issue you just created.
-
-### Process for the description
-
-1. **Create the issue first** with the summary (and type/parent). Don't rely on the description you
-   pass to the create call — it won't survive.
-2. **Read the created issue's description back.** That is the current, authoritative template for
-   that work-item type.
-3. **Fit your content into the template's sections** — keep its headings and scaffold, and fill
-   each section with the relevant part of what you wrote. Put anything that doesn't map cleanly
-   under the closest section rather than deleting a heading. Populate the template; don't replace it
-   with a different shape.
-4. **Push the filled-in description** with an edit call — a post-create edit overrides the template
-   reliably.
-5. **Re-read and verify** the sections now hold your content instead of the empty placeholders. If
-   they're still empty or unchanged, the edit didn't take — stop and report rather than leaving a
-   blank templated stub.
-
-The template you read back might look something like the following — this is only an illustration of
-the *shape*, not the sections to expect:
-
-```
-### User Story
-...
-### Definition of Done
-...
-```
-
-### Also worth knowing
-
-- Resolve the site's `cloudId` at call time (you can pass the hostname `paratextstudio.atlassian.net`
-  as `cloudId`); don't hard-code it.
-- The Atlassian MCP toolset can create / edit / comment / transition but **cannot delete** issues —
-  test or mistaken issues must be deleted by hand or transitioned to a closed state.
+The full process, the `PT` project reference (types, parenting, custom fields, content format),
+and the failure modes live in one place — the **`jira-creation` skill**
+(`.claude/skills/jira-creation/SKILL.md`). Invoke it before creating or editing any `PT` issue;
+don't restate its steps here.

--- a/.claude/skills/jira-creation/SKILL.md
+++ b/.claude/skills/jira-creation/SKILL.md
@@ -1,0 +1,195 @@
+---
+name: jira-creation
+description: "[Paratext PT Jira ONLY] Use when creating a work item (Combined, Sub-task, Dev Task, UX Task, Bug, Epic) in the Paratext `PT` project on paratextstudio.atlassian.net, or when a newly created issue's description shows empty template headings instead of the text that was written for it. NOT for other Jira sites or projects."
+allowed-tools: mcp__atlassian__createJiraIssue, mcp__atlassian__editJiraIssue, mcp__atlassian__getJiraIssue, mcp__atlassian__getJiraProjectIssueTypesMetadata, mcp__atlassian__getJiraIssueTypeMetaWithFields, mcp__atlassian__searchJiraIssuesUsingJql
+---
+
+# Creating Jira Work Items in the Paratext `PT` Project
+
+Platform.Bible work is tracked in the **Paratext (`PT`)** project on
+`paratextstudio.atlassian.net`, reached through the Atlassian MCP server. OAuth — no API token —
+so **issues are created under the signed-in human's own account**, are visible to the team
+immediately, and **cannot be deleted by any MCP tool**. Create deliberately.
+
+This skill is the single source of truth for the create-then-fill process.
+`.claude/rules/jira-issue-creation.md` and `/prd-to-jira` both point here.
+
+## Core principle
+
+**The description passed to the create call does not survive. Draft it once, deliver it in a
+second call — and re-send it whole every time it changes.**
+
+**Every work-item type in `PT` has a default description template.** The project applies that
+type's template at creation and it replaces whatever description was passed in. What lands on the
+issue is a skeleton: headings with a placeholder `...` under each, and none of the drafted text.
+
+So the drafted body reaches Jira in the **edit**, not the create. Every later change re-sends the
+whole thing: `description` declares `"operations": ["set"]` and nothing else, so it has no append
+or patch at any layer. (Array fields like `labels` do declare `add`/`remove`, but `editJiraIssue`
+exposes only `fields` — set semantics — so through this tool every write is a whole-field
+replacement regardless.)
+
+Read the created issue back regardless — not to learn *whether* the template fired, it did, but
+to get the exact headings this type uses today, which are what you fill.
+
+## Two templated fields, not one
+
+`description` is not the only templated body field, and on some types it isn't the right one:
+
+- **Bug** has no `description` field on its create screen at all. Its body is
+  **`customfield_10116` — "Bug Task Description"** (`## Observed Problem / ## Expected Behavior /
+  ## How to Reproduce / ## Definition of Done / ## Environment / ## Original Report`). Writing a
+  Bug's content into `description` puts it in the wrong place.
+- **`customfield_10116` shows up on other types too**, carrying the same template (confirmed on
+  Sub-task). It is **not** in `getJiraIssue`'s default field set, so it is invisible unless asked
+  for by name — and it is routinely left as an unfilled skeleton (PT-4025 is one).
+
+**Create-time metadata won't tell you which fields are templated**, in either direction: on
+Sub-task, `description` reports `hasDefaultValue: false` though its template always fires, and
+`customfield_10116` is absent from Sub-task's create screen yet appears populated on Sub-task
+issues. Call `getJiraIssueTypeMetaWithFields` for what it *does* answer — which fields you may set
+at create time, and that Bug has no `description` — and not for this.
+
+The only reliable discovery is **reading the created issue back with `fields: ["*all"]`** and
+seeing which fields came back as heading-plus-`...` skeletons. Do that once per type you haven't
+handled before. Then decide, per templated field, whether it is yours to fill or is legitimately
+left alone, and say which you chose — don't fill a second template with duplicated content just
+because it's there.
+
+## Process
+
+1. **Draft the full description locally first**, before any Jira call. Keep the draft in the
+   conversation verbatim — it has to survive intact into the step 8 edit and every later
+   revision, and must never be reconstructed from memory or re-summarized.
+2. **Get approval.** Show the user the summary, issue type, parent, and complete description, and
+   wait for an explicit go-ahead. These post to the team's board under the user's name and MCP
+   cannot delete them.
+3. **Resolve the target and find the templated fields.** Pass
+   `cloudId: "paratextstudio.atlassian.net"` (the hostname is accepted; don't hard-code a UUID).
+   Confirm the issue type name with `getJiraProjectIssueTypesMetadata` for project `PT` — names
+   and the set of types change. Then call `getJiraIssueTypeMetaWithFields` with
+   `requiredFieldsOnly: false` for that type to see which body fields you may set at create time
+   — this is where you learn a type has no `description` at all, as Bug doesn't. It will **not**
+   tell you which fields are templated (see Two templated fields above); step 6 does that.
+4. **Check for an existing issue before creating** whenever this is a resume, a retry, or a
+   batch that may have partly run: `searchJiraIssuesUsingJql` with
+   `project = PT AND summary ~ "<the summary>" ORDER BY created DESC`. A blank templated stub
+   from an interrupted run is an issue to *fill*, not to recreate — nothing can delete the
+   duplicate.
+5. **Create** with `createJiraIssue`: `projectKey: "PT"`, `issueTypeName`, `summary`, `parent`
+   (top-level parameter — used both for a Sub-task's parent and to epic-parent a Combined), and
+   any custom fields under `additional_fields`. Set `contentFormat: "markdown"` and
+   `responseContentFormat: "markdown"` explicitly (see Content format below). **Don't pass the
+   drafted body text here** — the template discards it every time, so it only doubles the tokens.
+   Send it in step 8.
+6. **Read the live templates.** Re-read with `getJiraIssue` and
+   `responseContentFormat: "markdown"`, using `fields: ["*all"]` for a type you haven't handled
+   before (or at minimum `["description", "customfield_10116"]`). Custom fields are absent from
+   the default field set, so a field you don't name is a template you'll never see. Note every
+   field that came back as headings with `...` placeholders. **Never assume the headings** — each
+   type has its own, and they change over time. Read the ones on *this* issue.
+7. **Fit the draft into the live template's sections.** Keep its headings and their order. Put
+   content that doesn't map cleanly under the closest heading. Do not delete a heading; do not
+   substitute a different structure. Populate the template — don't replace it.
+8. **Edit** with `editJiraIssue`, `contentFormat: "markdown"`, setting the field the content
+   actually belongs in — `fields: { description: <complete filled-in text> }` for most types, or
+   `fields: { customfield_10116: <complete filled-in text> }` for a Bug. A post-create edit
+   sticks; the template default only fires on create.
+9. **Verify against a specific string.** Re-read the field you just edited and confirm a
+   distinctive phrase from the draft — pick one before editing, e.g. the first sentence under the
+   second heading — is actually present in the returned text. "It looks right" is not a check. If
+   the sections are still empty, the edit didn't take: stop and report rather than leaving a blank
+   stub on the board.
+
+**Several issues at once.** Every gap between create and fill is a window where a dead session
+leaves a blank templated stub nobody can delete. So run steps 5–9 to completion on one issue
+before starting the next; where a parent's key is needed first, create and fill the parent, then
+each child in turn. Report each key as it is created, so an interrupted run leaves an exact record
+of what exists — and resume through step 4, never by recreating.
+
+## Content format
+
+Both `createJiraIssue` and `editJiraIssue` take `contentFormat` (`"markdown"` or `"adf"`), and
+the read tools take `responseContentFormat`. The tool schemas say the default **varies by tool**
+when omitted, so pin it explicitly on every call and **read and write in the same format**.
+Reading a template as ADF and writing it back as Markdown (or the reverse) is the fastest way to
+turn the team's headings into literal text or an unreadable blob. `"markdown"` is the right
+choice for ordinary descriptions.
+
+## Worked example — filling, not replacing
+
+A Sub-task read back right after create looks something like this. **This is an illustration of
+the shape, not the sections to expect** — read the real ones off the issue:
+
+```markdown
+### User Story
+...
+### Description
+...
+### Definition of Done
+...
+```
+
+Given a draft that says the results dialog needs a conflict link, the *right* edit keeps every
+heading and distributes the draft into them:
+
+```markdown
+### User Story
+As a translator finishing a Send/Receive, I want the results dialog to tell me a merge conflict
+happened and take me to it, so I don't silently ship unresolved conflicts.
+
+### Description
+Add a clickable affordance on the conflict row in `results-view.component.tsx` that opens the
+comment list filtered to unresolved conflicts. The cell is inert today.
+
+### Definition of Done
+- The conflict count is a link; activating it opens the filtered comment list.
+- The count in the dialog matches the count in the list it opens.
+```
+
+The *wrong* edit throws the scaffold away and writes `## Problem / ## Approach` instead, or drops
+`### User Story` because the draft had no persona. If the draft has nothing for a heading, keep
+the heading and write the closest thing you have under it.
+
+## `PT` project reference
+
+| Thing | Value |
+|---|---|
+| Site / `cloudId` | `paratextstudio.atlassian.net` |
+| Project key | `PT` |
+| Work-item types | Initiative, Epic, Combined (shared UX+Dev item), Dev Task, UX Task, Sub-task, Bug, User Snap — re-verify with `getJiraProjectIssueTypesMetadata` |
+| Parenting | Top-level `parent` parameter — a Sub-task's parent, or the epic above a Combined (e.g. `parent: "PT-3846"`) |
+| Body fields | `description` on most types; `customfield_10116` ("Bug Task Description") on Bug, whose create screen has no `description`. Both are templated, and `customfield_10116` also appears on other types |
+| Custom fields | `additional_fields`, e.g. `{ "customfield_10553": { "id": "10505" } }` (Sub Team → Simple) — confirm IDs with `getJiraIssueTypeMetaWithFields` |
+| Deleting | Not possible via MCP — transition to a closed state or ask a human |
+
+**Fields to leave alone:** set only what the user asked for. Don't invent an assignee, a
+priority, or a status transition. For work items generated from a PRD investigation, the team
+convention is stricter — no time estimates, no assignee, no transitions, Jira defaults
+throughout (see `/prd-to-jira`). A human-directed request ("file this bug and assign it to me")
+is a different case: do what was asked.
+
+## Common mistakes
+
+| Mistake | What happens | Instead |
+|---|---|---|
+| Passing the body text on create and assuming it stuck | Issue shows an empty skeleton; the drafted content is gone | Skip it on create; deliver it in the edit |
+| Hard-coding the expected headings | Content lands under headings the template no longer has | Read the live template off the created issue |
+| Writing a Bug's content into `description` | Bug's create screen has no `description` | Use `customfield_10116` |
+| Reading back only `description` | A second templated field stays an empty skeleton nobody sees | Read with `fields: ["*all"]` on a type you haven't handled |
+| Replacing the template with your own structure | Breaks the shape the team scans for | Fill the template's sections |
+| Sending only the changed section in an edit | The rest of the description is wiped | Send the whole description every time |
+| Mixing `markdown` and `adf` between read and write | Headings render as literal text | Pin both formats to `markdown` |
+| Creating first, asking after | Un-deletable clutter on the team board | Approval gate before the first create call |
+| Recreating after a failed run | A second un-deletable stub | Search by summary (step 4) and fill the existing one |
+| Summarizing the draft to avoid re-typing it | Ticket ends up thinner than what was approved | Re-send the approved text verbatim |
+
+## Red flags
+
+- "The create call took the description, no need to check." — It didn't. Check.
+- "I'll just append the new section." — There is no append. Send the whole field.
+- "I'll compose it inline in the create call and skip the local draft." — Then there is nothing
+  left to deliver in the edit.
+- "I'll use the headings from the last ticket I made." — Read this issue's template.
+- "The edit probably worked." — Name a string from the draft and find it in the read-back.
+- Reporting an issue as created without having read its description back.


### PR DESCRIPTION
## Summary

Creating an issue in the `PT` Jira project **discards the description passed to the create call** and stores the work-item type's default skeleton instead, so the real description has to be delivered by a follow-up edit. That behavior was documented only inside `.claude/rules/jira-issue-creation.md`, path-scoped to `/prd-to-jira`, so anything creating a ticket outside that command would silently leave a blank templated stub on the board — and nothing in the MCP toolset can delete one.

This adds `.claude/skills/jira-creation/SKILL.md` as the single source of truth for the **create → read the live template → fill it → edit → verify** process, and reduces the rule and the `/prd-to-jira` step to pointers at it.

### Why review this

Not part of current epic. It is agent tooling: it makes Jira tickets created by Claude land correctly filled rather than as blank skeletons that a human then has to find and fix by hand. Worth reviewer time now mainly to sanity-check the two team conventions it encodes (below), since a wrong convention here gets applied to every future ticket.

## Changes

- **New** `.claude/skills/jira-creation/SKILL.md` — the process, a `PT` project reference table, a worked fill-the-template example, and common-mistakes / red-flags tables.
- `.claude/rules/jira-issue-creation.md` — reduced to a pointer (keeps its `prd-to-jira.md` path scope so it still auto-loads and redirects).
- `.claude/commands/prd-to-jira.md` — step 4 now points at the skill; also fixed a mangled line wrap.

## Facts verified against the live `PT` project

These were checked with read-only Atlassian MCP calls, not assumed:

- **Bug's create screen has no `description` field at all.** Its body is `customfield_10116` ("Bug Task Description"). That field also appears on other types carrying its own template, is absent from `getJiraIssue`'s default field set, and is routinely left unfilled — PT-4025 is a Sub-task carrying an empty one.
- **Create-time metadata does not identify templated fields**, in either direction: `description` reports `hasDefaultValue: false` on Sub-task though its template always fires, and `customfield_10116` is missing from Sub-task's create screen yet populated on Sub-task issues. Reading the created issue back with `fields: ["*all"]` is the only reliable discovery.
- **`description` declares `operations: ["set"]` only** — no append or patch at any layer. Array fields (`labels`, `fixVersions`) do declare `add`/`remove`, but `editJiraIssue` exposes only `fields`, so every write through the MCP tool is a whole-field replacement.
- Issue types are Initiative, Epic, Combined, Dev Task, UX Task, Sub-task, Bug, User Snap.

## Please check these two conventions

Both are inferences, not documented team rules — they are the likeliest thing to be wrong:

1. **Should `customfield_10116` be filled on non-Bug types?** The skill says decide per field and state the choice. That is inferred from PT-4025 leaving it blank, which is one data point.
2. **"Set only what the user asked for"** (no invented assignee, priority, or transition). The stricter no-estimates/no-assignee rule is scoped to PRD-derived items and attributed to `/prd-to-jira`; a human-directed "file this bug and assign it to me" is treated as a different case.

## AI Involvement

Written with Claude Code (Opus 5). Claude drafted the skill, ran an adversarial review pass against its own draft, and made the verification calls to the live Jira project; I directed the scope, corrected the claim that only some work-item types have templates, and reviewed the result. Two of Claude's early mechanism claims were wrong on first pass and were corrected by checking the API rather than reasoning — the commit message records what ended up verified.

AI-assisted — [session 1](https://claude.ai/code/session_01TSy4VriQacG7zY2WSTUoba)

## Testing

- [x] `npx prettier --check` clean on all three files
- [x] Pre-commit hooks (lint-staged / format / stylelint) passed
- [x] Claims re-verified against live Jira via read-only MCP calls
- [ ] **Not** pressure-tested against a baseline run — the common-mistakes and red-flags tables target predicted rather than observed failure modes, so they may aim at the wrong things
- n/a `npm test` / `dotnet test` — documentation-only change, no code paths touched

## Risk Level

Low — Markdown under `.claude/` only. No runtime, build, or test code is affected. The realistic failure mode is a convention being wrong and propagating into future tickets, which is what the two questions above are asking you to check.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2732)
<!-- Reviewable:end -->
