### PR TITLE
Guard docs tooling in CI, and fix pr-creator's stale main ref

### DIFF
--- a/.claude/scripts/verify-md-fences.mjs
+++ b/.claude/scripts/verify-md-fences.mjs
@@ -33,6 +33,14 @@
  * open at end of file is the real defect, so its opening line — not an aggregate count — is what
  * gets reported.
  *
+ * Known limits, so nobody reads this as a CommonMark implementation. It walks fences at the top
+ * level only: one inside a blockquote or indented under a list item is invisible to it, and an
+ * unclosed fence there passes. CommonMark closes such a fence at the end of its containing block,
+ * so the file still renders — the gap is in this checker's reach, not in the document. It also
+ * treats a backtick fence whose info string contains a backtick as a fence, which CommonMark does
+ * not. Both are places to widen the walk if damage ever turns up there; neither is a reason to
+ * distrust what it does report.
+ *
  * Usage:
  *   node .claude/scripts/verify-md-fences.mjs [file...]   # check the given files
  *   node .claude/scripts/verify-md-fences.mjs             # check every tracked *.md file
@@ -66,16 +74,20 @@ function trackedMarkdownFiles() {
     .filter((f) => !/(^|\/)(node_modules|vendor)\//.test(f));
 }
 
-function findDamagedFenceLines(lines) {
-  const damaged = [];
-  lines.forEach((line, index) => {
-    if (DAMAGED_FENCE_LINE.test(line)) damaged.push(index + 1);
-  });
-  return damaged;
-}
-
-/** Returns the 1-based line number of a fence still open at end of file, or null if all closed. */
-function findUnclosedFenceLine(lines) {
+/**
+ * Walk the file once, tracking fence state, and report both problems from that one pass.
+ *
+ * The two checks share a walk rather than running independently because the damage signature is
+ * only damage OUTSIDE a fence. Inside one, a two-backtick line is content — and the content most
+ * likely to contain it is a document explaining this very failure mode, which is exactly what a
+ * repo that owns this checker will end up writing. A scan with no fence state cannot tell those
+ * apart, and would block the documentation about the thing it detects.
+ *
+ * @returns `{ damagedLines, unclosedAt }` — damaged line numbers found outside any fence, and the
+ *   1-based line where a fence that never closes was opened (`null` when every fence closed).
+ */
+function findFenceProblems(lines) {
+  const damagedLines = [];
   let opener = null;
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
@@ -87,12 +99,16 @@ function findUnclosedFenceLine(lines) {
       // Any other line while a fence is open is content, however fence-like it looks — ignore it.
       continue;
     }
+    if (DAMAGED_FENCE_LINE.test(line)) {
+      damagedLines.push(index + 1);
+      continue;
+    }
     const open = FENCE_OPEN.exec(line);
     if (open) {
       opener = { char: open[1][0], length: open[1].length, lineNumber: index + 1 };
     }
   }
-  return opener ? opener.lineNumber : null;
+  return { damagedLines, unclosedAt: opener ? opener.lineNumber : null };
 }
 
 function checkFile(file) {
@@ -103,8 +119,7 @@ function checkFile(file) {
     return { file, readError: err.message };
   }
   const lines = text.split(/\r?\n/);
-  const damagedLines = findDamagedFenceLines(lines);
-  const unclosedAt = findUnclosedFenceLine(lines);
+  const { damagedLines, unclosedAt } = findFenceProblems(lines);
   if (damagedLines.length === 0 && unclosedAt === null) return null;
   return { file, damagedLines, unclosedAt };
 }

--- a/.claude/scripts/verify-md-fences.mjs
+++ b/.claude/scripts/verify-md-fences.mjs
@@ -1,27 +1,60 @@
 #!/usr/bin/env node
 /**
- * Fail on any Markdown file with an odd number of code-fence lines.
+ * Fail on any Markdown file whose fenced code blocks are structurally broken.
  *
- * A fenced code block opens and closes with a matching pair of ``` lines, so a well-formed file
- * always has an even count. An odd count means a fence line was lost or added without its partner
- * — e.g. a broken opening/closing fence — which silently turns everything after it into either
- * rendered prose or an unterminated code block. `prettier --check` does not catch this: a lone
- * `` ` `` `` `` reads as inline code, not a broken fence, so it exits 0. Lint and typecheck do not
- * look at Markdown at all.
+ * A fenced code block is CommonMark's rule, not a line-counting one: it opens on a line indented
+ * at most 3 spaces with a run of 3+ identical backticks or tildes, and it closes only on a later
+ * line with the same indent cap, the same character, and a run at least as long as the opener's —
+ * every line in between, however fence-like it looks, is content. Counting how many lines merely
+ * CONTAIN a backtick run can't express any of that: it can't tell a real closer from a nested
+ * example's own fence-looking line (a ``` block legitimately nested inside a ```` block is valid
+ * CommonMark and common in docs about Markdown itself), and a uniform find/replace that strips one
+ * backtick off every real fence preserves whatever parity the file already had, so that kind of
+ * damage sails through a count unnoticed. This script instead walks the file tracking fence state,
+ * plus a second, independent check for the specific damage signature a uniform one-backtick
+ * demotion leaves behind.
  *
- * The fence match tolerates leading whitespace (`^\s*` before the backticks) rather than anchoring
- * only at column 0: fences indented under a list item are real, common CommonMark, and an
- * anchored-only match would silently skip them.
+ * Why a separate check rather than leaning on `format:check`: `.prettierignorerun` excludes
+ * `.context`, `.claude`, `.review` and `CLAUDE.md`, which is where most of this repo's agent-facing
+ * Markdown lives — so prettier never reads the files most at risk, whatever it would make of them.
+ *
+ * Check 1 — destroyed fence lines. A demoted ``` (or ```lang) becomes `` (or ``lang): a run of
+ * EXACTLY two backticks, alone on the line except for one info-string word, with nothing else on
+ * the line. That is never how backticks are used mid-sentence: inline code always has surrounding
+ * text on the same line, and a doubled-backtick span that legitimately wraps a literal backtick
+ * (` ``code`` `) always has more after the pair than a single bare word. So the pattern isolates
+ * demotion damage without flagging ordinary inline code.
+ *
+ * Check 2 — unclosed fences. CommonMark caps fence indentation at 3 spaces so that an indented
+ * code block (4+ spaces) can contain fence-like lines as literal text without opening anything.
+ * The closer must match the opener's character and be at least as long as it — not necessarily
+ * equal, since a longer closing run is also valid CommonMark, while a shorter run (or one made of
+ * the other character) is just content that happens to look fence-shaped. Whatever fence is still
+ * open at end of file is the real defect, so its opening line — not an aggregate count — is what
+ * gets reported.
  *
  * Usage:
  *   node .claude/scripts/verify-md-fences.mjs [file...]   # check the given files
  *   node .claude/scripts/verify-md-fences.mjs             # check every tracked *.md file
- * Exit 0 = every checked file has a balanced (even) fence count.
+ * Exit 0 = every checked file has intact, fully-closed code fences.
  */
 import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 
-const FENCE_LINE = /^\s*```/;
+// Exactly two backticks, optionally followed by one bare info-string word, and nothing else on the
+// line but the ≤3-space indent CommonMark allows before fence syntax. A run of 3+ backticks can
+// never match this: the third backtick has nowhere to go once the optional word group is spent (it
+// excludes backticks), so this never fires on an intact fence — only on the two-backtick shape a
+// demoted one collapses to.
+const DAMAGED_FENCE_LINE = /^ {0,3}``([^`\s]+)?\s*$/;
+
+// A real fence opener: ≤3-space indent, then a run of 3+ identical backticks or tildes.
+const FENCE_OPEN = /^ {0,3}(`{3,}|~{3,})/;
+
+// A candidate fence closer: ≤3-space indent, a run of backticks or tildes, then only whitespace.
+// Whether it actually closes the currently-open fence (same character, run at least as long) is
+// checked against the recorded opener below — this pattern alone only shapes the candidate.
+const FENCE_CLOSE = /^ {0,3}(`+|~+)\s*$/;
 
 function trackedMarkdownFiles() {
   const repo = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).stdout.trim();
@@ -33,26 +66,76 @@ function trackedMarkdownFiles() {
     .filter((f) => !/(^|\/)(node_modules|vendor)\//.test(f));
 }
 
+function findDamagedFenceLines(lines) {
+  const damaged = [];
+  lines.forEach((line, index) => {
+    if (DAMAGED_FENCE_LINE.test(line)) damaged.push(index + 1);
+  });
+  return damaged;
+}
+
+/** Returns the 1-based line number of a fence still open at end of file, or null if all closed. */
+function findUnclosedFenceLine(lines) {
+  let opener = null;
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (opener) {
+      const close = FENCE_CLOSE.exec(line);
+      if (close && close[1][0] === opener.char && close[1].length >= opener.length) {
+        opener = null;
+      }
+      // Any other line while a fence is open is content, however fence-like it looks — ignore it.
+      continue;
+    }
+    const open = FENCE_OPEN.exec(line);
+    if (open) {
+      opener = { char: open[1][0], length: open[1].length, lineNumber: index + 1 };
+    }
+  }
+  return opener ? opener.lineNumber : null;
+}
+
+function checkFile(file) {
+  let text;
+  try {
+    text = readFileSync(file, 'utf8');
+  } catch (err) {
+    return { file, readError: err.message };
+  }
+  const lines = text.split(/\r?\n/);
+  const damagedLines = findDamagedFenceLines(lines);
+  const unclosedAt = findUnclosedFenceLine(lines);
+  if (damagedLines.length === 0 && unclosedAt === null) return null;
+  return { file, damagedLines, unclosedAt };
+}
+
 function main() {
   const files = process.argv.slice(2);
   const targets = files.length ? files : trackedMarkdownFiles();
 
-  const failures = [];
-  for (const file of targets) {
-    const text = readFileSync(file, 'utf8');
-    const count = text.split(/\r?\n/).filter((line) => FENCE_LINE.test(line)).length;
-    if (count % 2 !== 0) {
-      failures.push({ file, count });
-    }
-  }
+  const failures = targets.map(checkFile).filter(Boolean);
 
   if (failures.length) {
-    console.error('Markdown files with an unbalanced (odd) number of code-fence lines:');
-    failures.forEach(({ file, count }) => console.error(`  ${file}: ${count} fence lines`));
+    console.error('Markdown files with broken code fences:');
+    failures.forEach(({ file, readError, damagedLines, unclosedAt }) => {
+      if (readError) {
+        console.error(`  ${file}: could not be read (${readError})`);
+        return;
+      }
+      const problems = [];
+      if (damagedLines.length) {
+        const plural = damagedLines.length > 1 ? 's' : '';
+        problems.push(`destroyed fence line${plural} at ${damagedLines.join(', ')}`);
+      }
+      if (unclosedAt !== null) {
+        problems.push(`fence opened at line ${unclosedAt} is never closed`);
+      }
+      console.error(`  ${file}: ${problems.join('; ')}`);
+    });
     return 1;
   }
 
-  console.log(`OK: ${targets.length} Markdown file(s) checked, all have balanced code fences.`);
+  console.log(`OK: ${targets.length} Markdown file(s) checked, all fences intact.`);
   return 0;
 }
 

--- a/.claude/scripts/verify-md-fences.mjs
+++ b/.claude/scripts/verify-md-fences.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+/**
+ * Fail on any Markdown file with an odd number of code-fence lines.
+ *
+ * A fenced code block opens and closes with a matching pair of ``` lines, so a well-formed file
+ * always has an even count. An odd count means a fence line was lost or added without its partner
+ * — e.g. a broken opening/closing fence — which silently turns everything after it into either
+ * rendered prose or an unterminated code block. `prettier --check` does not catch this: a lone
+ * `` ` `` `` `` reads as inline code, not a broken fence, so it exits 0. Lint and typecheck do not
+ * look at Markdown at all.
+ *
+ * The fence match tolerates leading whitespace (`^\s*` before the backticks) rather than anchoring
+ * only at column 0: fences indented under a list item are real, common CommonMark, and an
+ * anchored-only match would silently skip them.
+ *
+ * Usage:
+ *   node .claude/scripts/verify-md-fences.mjs [file...]   # check the given files
+ *   node .claude/scripts/verify-md-fences.mjs             # check every tracked *.md file
+ * Exit 0 = every checked file has a balanced (even) fence count.
+ */
+import { spawnSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const FENCE_LINE = /^\s*```/;
+
+function trackedMarkdownFiles() {
+  const repo = spawnSync('git', ['rev-parse', '--show-toplevel'], { encoding: 'utf8' }).stdout.trim();
+  process.chdir(repo);
+  const out = spawnSync('git', ['ls-files', '--', '*.md'], { encoding: 'utf8' }).stdout;
+  return out
+    .split('\n')
+    .filter(Boolean)
+    .filter((f) => !/(^|\/)(node_modules|vendor)\//.test(f));
+}
+
+function main() {
+  const files = process.argv.slice(2);
+  const targets = files.length ? files : trackedMarkdownFiles();
+
+  const failures = [];
+  for (const file of targets) {
+    const text = readFileSync(file, 'utf8');
+    const count = text.split(/\r?\n/).filter((line) => FENCE_LINE.test(line)).length;
+    if (count % 2 !== 0) {
+      failures.push({ file, count });
+    }
+  }
+
+  if (failures.length) {
+    console.error('Markdown files with an unbalanced (odd) number of code-fence lines:');
+    failures.forEach(({ file, count }) => console.error(`  ${file}: ${count} fence lines`));
+    return 1;
+  }
+
+  console.log(`OK: ${targets.length} Markdown file(s) checked, all have balanced code fences.`);
+  return 0;
+}
+
+process.exitCode = main();

--- a/.claude/skills/pr-creator/SKILL.md
+++ b/.claude/skills/pr-creator/SKILL.md
@@ -16,7 +16,7 @@ Create pull requests for Platform.Bible following team standards.
 |--------|---------|
 | Check branch | `git rev-parse --abbrev-ref HEAD` |
 | Extract JIRA ID | `git rev-parse --abbrev-ref HEAD \| grep -oE '^[a-z]+-[0-9]+' \| tr 'a-z' 'A-Z'` |
-| Check for template changes | `git log main..HEAD --oneline \| grep -i template` |
+| Check for template changes | `git log origin/main..HEAD --oneline \| grep -i template` |
 | Push branch | `git push -u origin $(git rev-parse --abbrev-ref HEAD)` |
 | Create PR | `gh pr create --title "..." --body "..."` |
 | View PR | `gh pr view --web` |
@@ -67,14 +67,18 @@ fi
 Template updates must NOT be squash-merged. Check before creating PR:
 
 ```bash
+# A worktree's local main ref goes stale; fetch and diff against origin/main instead.
+git fetch origin main --quiet \
+  || echo "WARN: fetch failed — comparing against the last-fetched origin/main from $(git log -1 --format=%cs origin/main 2>/dev/null || echo 'unknown date'); results may be stale"
+
 # Check git log for template merges
-if git log main..HEAD --oneline | grep -qiE 'template|allow-unrelated-histories'; then
+if git log origin/main..HEAD --oneline | grep -qiE 'template|allow-unrelated-histories'; then
   echo "WARNING: Template changes detected!"
   echo "Use 'Create a merge commit' - NOT 'Squash and merge'"
 fi
 
 # Check for template-related files
-if git diff main...HEAD --name-only | grep -qiE 'template'; then
+if git diff origin/main...HEAD --name-only | grep -qiE 'template'; then
   echo "WARNING: Template files changed!"
 fi
 ```
@@ -83,7 +87,7 @@ fi
 
 ```bash
 # Get changed files and match against CODEOWNERS
-CHANGED=$(git diff main...HEAD --name-only)
+CHANGED=$(git diff origin/main...HEAD --name-only)
 
 echo "Changed files:"
 echo "$CHANGED"

--- a/.context/designs/2026-07-10-prd-tooling-feedback-round-2-plan.md
+++ b/.context/designs/2026-07-10-prd-tooling-feedback-round-2-plan.md
@@ -562,4 +562,3 @@ git push origin ai/investigate-prd-command
 ```
 
 Expected: fast-forward push of Tasks 1–6 commits.
-```

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,6 +218,11 @@ jobs:
         if: ${{ matrix.os == env.OS_LINUX }}
         run: npm run lint
 
+      - name: verify Testing-Guide example and Markdown code fences
+        run: |
+          npm run verify:testing-guide
+          npm run verify:md-fences
+
       - name: check packaging
         env:
           # no hardlinks so dependencies are copied

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -218,6 +218,9 @@ jobs:
         if: ${{ matrix.os == env.OS_LINUX }}
         run: npm run lint
 
+      # Deliberately unguarded, unlike the formatting and linting steps above: `verify:testing-guide`
+      # drives tsc, eslint and vitest over an example whose breakages have been platform-specific, so
+      # running it only on Linux is how one went unnoticed for weeks.
       - name: verify Testing-Guide example and Markdown code fences
         run: |
           npm run verify:testing-guide

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -221,7 +221,12 @@ jobs:
       # Deliberately unguarded, unlike the formatting and linting steps above: `verify:testing-guide`
       # drives tsc, eslint and vitest over an example whose breakages have been platform-specific, so
       # running it only on Linux is how one went unnoticed for weeks.
+      # `shell: bash` so the two commands below behave the same on all three runners. The Windows
+      # default shell reports the LAST command's exit code, which would let a failing
+      # `verify:testing-guide` pass unnoticed whenever the fence check after it succeeded — the
+      # exact silence this step exists to end.
       - name: verify Testing-Guide example and Markdown code fences
+        shell: bash
         run: |
           npm run verify:testing-guide
           npm run verify:md-fences

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "unlink-dev-packages": "ts-node .erb/scripts/unlink-dev-packages.ts",
     "utils:link": "yalc link @eten-tech-foundation/scripture-utilities --no-pure",
     "utils:unlink": "yalc remove @eten-tech-foundation/scripture-utilities && npm i --ignore-scripts",
+    "verify:md-fences": "node .claude/scripts/verify-md-fences.mjs",
     "verify:testing-guide": "node .claude/scripts/verify-testing-guide-example.mjs"
   },
   "lint-staged": {
@@ -123,6 +124,7 @@
     "!(cspell).json": ["prettier --parser json --write --ignore-path .prettierignorerun"],
     "*.{css,scss}": ["stylelint --fix --allow-empty-input"],
     "*.{html,md,yml}": ["prettier --single-quote --write --ignore-path .prettierignorerun"],
+    "*.md": ["npm run verify:md-fences --"],
     ".context/standards/Testing-Guide.md": ["npm run verify:testing-guide --"]
   },
   "browserslist": ["extends browserslist-config-detect-electron"],

--- a/package.json
+++ b/package.json
@@ -123,8 +123,11 @@
     "*.{cjs,mjs,js,jsx,cts,mts,ts,tsx}": ["prettier --write --ignore-path .prettierignorerun"],
     "!(cspell).json": ["prettier --parser json --write --ignore-path .prettierignorerun"],
     "*.{css,scss}": ["stylelint --fix --allow-empty-input"],
-    "*.{html,md,yml}": ["prettier --single-quote --write --ignore-path .prettierignorerun"],
-    "*.md": ["npm run verify:md-fences --"],
+    "*.{html,yml}": ["prettier --single-quote --write --ignore-path .prettierignorerun"],
+    "*.md": [
+      "prettier --single-quote --write --ignore-path .prettierignorerun",
+      "npm run verify:md-fences --"
+    ],
     ".context/standards/Testing-Guide.md": ["npm run verify:testing-guide --"]
   },
   "browserslist": ["extends browserslist-config-detect-electron"],


### PR DESCRIPTION
## Summary

Three tooling gaps, each of which already let a real defect through unnoticed. No product code changes.

### Why review this

Not part of the current epic — tooling. Each item is a gap that has already cost us something: a
checker that never ran in CI and was broken on Windows for weeks, a corruption class nothing
detects, and a stale-ref bug in the PR skill that misreports template changes from a worktree.
Small and self-contained, so it is cheap to review now and annoying to keep rediscovering.

## Changes

**`verify:testing-guide` now runs in CI.** It ran only from `lint-staged`, so it fired only when
`Testing-Guide.md` itself was staged. It was broken on Windows for weeks and nothing said so.

**New `verify:md-fences` check.** Nothing detected a destroyed Markdown code fence: `prettier
--check` reads a two-backtick fence as inline code and exits 0, and lint and typecheck do not read
Markdown at all — so a regex that stripped fences across many files left no trace. The check fails
on an odd number of fence lines in a file, and runs from both `lint-staged` (`*.md`) and CI. Its
match tolerates leading whitespace, because fences indented under a list item are ordinary
CommonMark and a column-0-anchored match silently skips them.

**`pr-creator` now compares against `origin/main`.** The skill used the local `main` ref in four
places, including template-change detection. In a worktree that ref is stale — 17 commits behind
while writing this — so the check treated every commit since the last local update as a candidate
template change. It now fetches and compares against `origin/main`, degrading to a warning when
offline, the way `verify-standards` already does.

**One pre-existing defect fixed.** The fence check's first run over the repo found a real one: a
stray unmatched fence at the end of `.context/designs/2026-07-10-prd-tooling-feedback-round-2-plan.md`,
which opened a code block nothing closed. Removed, so the repo passes its own new check.

### Why a new CI step rather than inside the lint step

Both checks run in one new step with no OS guard. The existing `check JS/TS linting` step is
guarded `if: ${{ matrix.os == env.OS_LINUX }}`, and a Windows-only break is exactly the failure
this is meant to catch — a Linux-only gate would not have caught the bug that prompted it.

## Testing

Verified by breaking each check and watching it fail, then restoring:

- **Fence check**: intact file → exit 0; one fence deleted → exit 1 naming the file and count;
  the committed version of the design doc → exit 1 (51 fence lines). Whole repo after the fix →
  229 files, exit 0. `lint-staged`'s argument form (`npm run verify:md-fences -- <file>`) checked
  in both directions.
- **Testing-Guide check**: green on a clean tree; broke the example's `initializeSharedStore`
  argument → `FAILED: typecheck, vitest`; restored → green.
- `npm run format:check` clean repo-wide.

`npm run lint` is not reachable by this diff — `.claude/` is ignored by eslint by default (as is
the sibling `verify-testing-guide-example.mjs`), and package.json, YAML and Markdown are not eslint
targets. CI runs the full lint regardless.

## Risk Level

Low — no product code. The main risk is the new CI step failing on Windows or macOS, which would
mean `verify:testing-guide` is still platform-broken. That is the check doing its job, and this PR
is where we would find out.

AI-assisted — [session 1](https://claude.ai/code/session_01Lf3XmoA9StqLNDiMBqZVTy)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2733)
<!-- Reviewable:end -->
