### PR TITLE
Derive allowPopups like the other WebView security keys

### DIFF
--- a/.context/standards/Security-Guide.md
+++ b/.context/standards/Security-Guide.md
@@ -108,6 +108,33 @@ Extensions run in isolated contexts:
 
 ---
 
+## WebView Definition Security Keys
+
+Four `WebViewDefinition` properties gate a WebView's execution environment: `allowScripts`,
+`allowSameOrigin`, `allowedFrameSources`, and `allowPopups`. A WebView provider supplies these
+values, and only the provider can — none of the four is in the WebView definition's
+updatable-property list, so a running WebView's own content cannot widen its own sandbox. Even so,
+the platform never treats a value that merely passed through as trustworthy on its own:
+
+- **Stripped on save.** `SAVED_WEBVIEW_DEFINITION_OMITTED_KEYS` (`web-view.model.ts`) excludes all
+  four from what gets persisted into a saved layout, so a WebView never gets reloaded with a stale
+  or tampered value for one of these keys — the provider must re-supply them every time it provides
+  the WebView's content.
+- **Derived on read.** `openOrReloadWebView` (`web-view.service-shard.ts`) recomputes each of the
+  four from the provider's freshly-returned `WebViewDefinition` and assigns them into the resulting
+  `WebViewTabProps` after the initial object spread — never copying them straight through from the
+  provider's raw object. `allowScripts` and `allowSameOrigin` get an explicit default when unset;
+  `allowedFrameSources` is filtered down to `https:`, `papi-extension:`, and `http://localhost:`
+  schemes (HTML and React WebViews) or matched against the WebView's own patterns (URL WebViews);
+  `allowPopups` defaults to `false` when unset. The WebView component reads only these derived
+  values — never the provider's raw object — when building the iframe's `sandbox` attribute and CSP.
+
+Any key added to `SAVED_WEBVIEW_DEFINITION_OMITTED_KEYS` for the same reason (a provider-supplied
+value that must not reach the iframe unmediated) should get the same treatment: an explicit default
+and an assignment after the `{ ...webView }` spread, not a bare pass-through.
+
+---
+
 ## Security Best Practices
 
 When developing extensions:

--- a/.context/standards/Security-Guide.md
+++ b/.context/standards/Security-Guide.md
@@ -123,11 +123,15 @@ the platform never treats a value that merely passed through as trustworthy on i
 - **Derived on read.** `openOrReloadWebView` (`web-view.service-shard.ts`) recomputes each of the
   four from the provider's freshly-returned `WebViewDefinition` and assigns them into the resulting
   `WebViewTabProps` after the initial object spread — never copying them straight through from the
-  provider's raw object. `allowScripts` and `allowSameOrigin` get an explicit default when unset;
-  `allowedFrameSources` is filtered down to `https:`, `papi-extension:`, and `http://localhost:`
-  schemes (HTML and React WebViews) or matched against the WebView's own patterns (URL WebViews);
-  `allowPopups` defaults to `false` when unset. The WebView component reads only these derived
-  values — never the provider's raw object — when building the iframe's `sandbox` attribute and CSP.
+  provider's raw object. `allowSameOrigin` gets an explicit default when unset, as does
+  `allowScripts` for every content type except URL WebViews, where the provider's value is left as
+  it came; `allowedFrameSources` is filtered down to `https:`, `papi-extension:`, and
+  `http://localhost:` schemes (HTML and React WebViews) or matched against the WebView's own
+  patterns (URL WebViews); `allowPopups` defaults to `false` when unset. The derived values are what
+  reach the iframe, never the provider's raw object — `allowScripts`, `allowSameOrigin` and
+  `allowPopups` through the `sandbox` attribute the WebView component builds, and
+  `allowedFrameSources` through the `frame-src` directive of the CSP, which is built into the
+  WebView's content by `openOrReloadWebView` itself before the component ever sees it.
 
 Any key added to `SAVED_WEBVIEW_DEFINITION_OMITTED_KEYS` for the same reason (a provider-supplied
 value that must not reach the iframe unmediated) should get the same treatment: an explicit default

--- a/src/renderer/services/web-view.service-shard.test.ts
+++ b/src/renderer/services/web-view.service-shard.test.ts
@@ -1116,7 +1116,7 @@ describe('handleSwitchToSimpleMode', () => {
   });
 });
 
-describe('getWebView derives security-relevant WebViewDefinition keys instead of passing them through', () => {
+describe('openOrReloadWebView derives security-relevant WebViewDefinition keys instead of passing them through', () => {
   beforeEach(() => {
     vi.resetModules();
   });
@@ -1153,6 +1153,40 @@ describe('getWebView derives security-relevant WebViewDefinition keys instead of
     expect(finalWebView?.allowPopups).toBe(false);
     // Filtered, not the raw array with the disallowed scheme still present.
     expect(finalWebView?.allowedFrameSources).toEqual(['https://good.example.com']);
+  });
+
+  it("keeps a provider's explicit values for allowScripts, allowSameOrigin, and allowPopups rather than forcing the defaults", async () => {
+    // The test above pins the defaults, which on its own cannot tell a derived value from a
+    // hardcoded one: replacing any of these three with the constant it defaults to would still
+    // satisfy it. This pins the other half, so the pair fails for either mistake. It is not
+    // hypothetical for allowPopups - paratext-registration and platform-scripture-editor both open
+    // WebViews with `allowPopups: true` and would silently lose popups if it became a constant.
+    const host = await importHost();
+    const fakeDockLayout = createFakeDockLayout();
+    host.registerDockLayout(fakeDockLayout);
+
+    const WEB_VIEW_ID = 'explicit-security-values-webview';
+    getWebViewProviderMock.mockResolvedValue({
+      getWebView: vi.fn(async () => ({
+        id: WEB_VIEW_ID,
+        webViewType: 'test.explicitSecurityValues',
+        content: '',
+        // Each one is the opposite of what this key defaults to, so a default that overrode the
+        // provider would be visible in every assertion below rather than in none of them.
+        allowScripts: false,
+        allowSameOrigin: false,
+        allowPopups: true,
+      })),
+    });
+
+    await host.openOrReloadWebView({ id: WEB_VIEW_ID, webViewType: 'test.explicitSecurityValues' });
+
+    const { lastCall } = vi.mocked(fakeDockLayout.addWebViewToDock).mock;
+    const [finalWebView] = lastCall ?? [];
+
+    expect(finalWebView?.allowScripts).toBe(false);
+    expect(finalWebView?.allowSameOrigin).toBe(false);
+    expect(finalWebView?.allowPopups).toBe(true);
   });
 });
 

--- a/src/renderer/services/web-view.service-shard.test.ts
+++ b/src/renderer/services/web-view.service-shard.test.ts
@@ -1116,6 +1116,46 @@ describe('handleSwitchToSimpleMode', () => {
   });
 });
 
+describe('getWebView derives security-relevant WebViewDefinition keys instead of passing them through', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('derives allowScripts, allowSameOrigin, allowedFrameSources, and allowPopups from the provider webview rather than passing its raw values through', async () => {
+    const host = await importHost();
+    const fakeDockLayout = createFakeDockLayout();
+    host.registerDockLayout(fakeDockLayout);
+
+    const WEB_VIEW_ID = 'security-normalization-webview';
+    getWebViewProviderMock.mockResolvedValue({
+      // Stands in for a compromised or buggy provider: omits the three keys that are otherwise
+      // only defaulted (allowScripts, allowSameOrigin, allowPopups all left `undefined`) and
+      // supplies a disallowed scheme (plain `http:`, neither `https:` nor `http://localhost:`)
+      // alongside an allowed one in allowedFrameSources - exactly the kind of untrusted values
+      // `SAVED_WEBVIEW_DEFINITION_OMITTED_KEYS` exists to keep a reloaded WebView from inheriting.
+      getWebView: vi.fn(async () => ({
+        id: WEB_VIEW_ID,
+        webViewType: 'test.securityNormalization',
+        content: '',
+        allowedFrameSources: ['http://evil.example.com', 'https://good.example.com'],
+      })),
+    });
+
+    await host.openOrReloadWebView({ id: WEB_VIEW_ID, webViewType: 'test.securityNormalization' });
+
+    expect(fakeDockLayout.addWebViewToDock).toHaveBeenCalled();
+    const { lastCall } = vi.mocked(fakeDockLayout.addWebViewToDock).mock;
+    const [finalWebView] = lastCall ?? [];
+
+    // Defaulted, not left as the provider's raw `undefined`.
+    expect(finalWebView?.allowScripts).toBe(true);
+    expect(finalWebView?.allowSameOrigin).toBe(true);
+    expect(finalWebView?.allowPopups).toBe(false);
+    // Filtered, not the raw array with the disallowed scheme still present.
+    expect(finalWebView?.allowedFrameSources).toEqual(['https://good.example.com']);
+  });
+});
+
 describe('Scripture Editor tab events keep last-opened-project-cache current', () => {
   const FIXED_SIMPLE_EDITOR_TAB_ID = 'simple-editor-tab';
 

--- a/src/renderer/services/web-view.service-shard.ts
+++ b/src/renderer/services/web-view.service-shard.ts
@@ -2377,6 +2377,8 @@ export async function openOrReloadWebView(
   if (contentType !== WEB_VIEW_CONTENT_TYPE.URL) allowScripts = webView.allowScripts ?? true;
   /** Default allowSameOrigin to true */
   const allowSameOrigin = webView.allowSameOrigin ?? true;
+  /** Default allowPopups to false */
+  const allowPopups = webView.allowPopups ?? false;
   /**
    * Only allow connecting to `papi-extension:` and `https:` urls. For HTML and React WebViews, this
    * controls the `frame-src` directive and therefore which urls can be iframe `src`es in the
@@ -2733,6 +2735,7 @@ export async function openOrReloadWebView(
     allowScripts,
     allowSameOrigin,
     allowedFrameSources,
+    allowPopups,
   };
 
   const finalLayout = (await getDockLayout()).addWebViewToDock(


### PR DESCRIPTION
Four `WebViewDefinition` properties gate a WebView's execution environment: `allowScripts`, `allowSameOrigin`, `allowedFrameSources` and `allowPopups`. All four are stripped when a layout is saved, so a provider has to re-supply them every time — and three of them are then normalized on read, after the spread that builds the final definition: `allowScripts` and `allowSameOrigin` get explicit defaults, and `allowedFrameSources` is filtered to permitted schemes.

`allowPopups` was the exception. It rode the provider's value through the spread untouched into the iframe's `sandbox` attribute. This is defence in depth rather than a live hole — `allowPopups` is not an updatable property, so a running WebView's own content cannot set it, and providers are trusted — but the asymmetry meant one of the four keys was trusted for merely having been passed in, while its siblings were not.

It now gets the same treatment as `allowSameOrigin`: an explicit default and a re-assignment into the final definition, so all four keys are derived rather than passed through.

The test drives the real open path with a provider that omits three of the keys and supplies a disallowed frame source alongside an allowed one, then asserts the definition that reaches the dock carries the derived values. It fails if the new normalization is removed.

`Security-Guide.md` gains a section naming the four keys, the strip-on-save/derive-on-read rule and the reason for it, so the next key added to the omitted list gets the same treatment by default.

AI-assisted — [session](https://claude.ai/code/session_01YZM7sFGcszqegR7A1xfE9p)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2735)
<!-- Reviewable:end -->
