### PR TITLE
Wait for the PAPI websocket to bind before reporting connected

### DIFF
--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -1576,6 +1576,65 @@ step, no automation. Just a record.
   the merged conditional in `model-text-panel.component.tsx` — proved to be the symptom site rather
   than the defect.
 
+## adr-papi-websocket-hostname-bind: The PAPI websocket binds by hostname, and readiness is awaited rather than assumed
+
+- **Date:** 2026-08-29
+- **Status:** Accepted
+- **Context:** `adr`-worthy because the two halves pull against each other and the losing half is
+  invisible. #2624 (2026-08-03) scoped the PAPI websocket to loopback, changing
+  `new WebSocketServer({ port })` to `new WebSocketServer({ host: 'localhost', port })` in
+  `rpc-websocket-listener.ts` `connect()` — connections are unauthenticated and every registered
+  method is callable over them, so the server must never accept off-machine traffic. But
+  `net.Server.listen(port, host)` performs an **async DNS lookup** when `host` is not an IP literal,
+  deferring the bind, where the previous hostless `listen(port)` bound the wildcard address on the
+  next tick. Meanwhile `connect()` set `ConnectionStatus.Connected` and returned `true`
+  synchronously, never awaiting the server's `listening` event — so `await
+  networkService.initialize()` in main resolved while the socket could still be unbound, and main
+  went on to spawn the extension host and open windows into that gap. The apparent ordering
+  guarantee in `main.ts` (network service, then extension host) did not hold. First launch of the
+  0.4.0-alpha.0 snap after installing: the extension host's single connect was refused at +549 ms
+  and it died 9.98 s later, so **no** settings, localization, or theme provider was ever registered;
+  the renderer rendered raw `%localizeKey%` text and the .NET provider crashed on a missing settings
+  method. Warm restarts bind long before the extension host boots (~500 ms) and were unaffected,
+  which is why it presented as intermittent while being the norm on a cold install. Not
+  load-dependent: with the port free on an idle machine, a client still cannot connect at the
+  instant the pre-fix `connect()` resolves (`rpc-websocket-listener.real-socket.test.ts`).
+- **Decision:** Keep the hostname bind, and make readiness explicit instead of assumed: `connect()`
+  awaits `listening` before reporting success, and reports failure when the server emits `error`
+  (e.g. `EADDRINUSE`) instead of binding.
+- **Alternatives:** **Bind the `127.0.0.1` literal and point clients at it.** This does satisfy the
+  actual requirement — Matt Lyons confirmed the goal is "unreachable off-machine", which the literal
+  meets — and it would remove the resolver from the startup path entirely, restoring a synchronous
+  bind. Rejected because the hostname is there for an *independent* reason: it avoids IPv4-vs-IPv6
+  mismatches between the server's bind and a client's connect, which Matt has actually observed over
+  the years. Three call sites connect by name across two resolver stacks (`rpc-client.ts` for the
+  renderer and extension host, `PapiClient.cs` for .NET, plus the OpenRPC playground URL in
+  `main.ts`), external debugging tools such as `websocat` resolve on their own, and the hostname
+  leaves room for IPv6-centric network configurations. Note the security requirement and the
+  address-family robustness are separate concerns; only the first is about loopback scoping.
+  **Client-side retry with backoff** (implemented first, then dropped) — absorbs the window instead
+  of removing it, and retrying safely needs its own wall-clock budget: an attempt whose socket is
+  accepted but never upgraded can only end by timing out, so an attempt count bounded against
+  `AsyncVariable`'s 10 s default permitted a ~73 s stall of the extension host's connect, worse
+  than the single 10 s failure it replaced — and it is that stall which left the app unusable. **Gate the extension-host spawn on readiness** in
+  `extension-host.service.ts` — unnecessary once `connect()` is honest, since main already awaits
+  `networkService.initialize()` before spawning.
+- **Consequences:** The race is closed at its source, so a client's connect no longer depends on
+  winning a timing window and `RpcClient` carries no retry. The catch: `main.ts`'s ordering is only
+  real *because* `connect()` awaits binding — any future change that makes the listener report ready
+  optimistically silently reopens this, with the symptom appearing three processes away as missing
+  providers. A bind failure is now reported rather than being indistinguishable from success.
+  `RpcWebSocketListener` gained an optional `port` constructor argument so a test can bind a real
+  socket without colliding with a dev app on 8876. The real-socket tests deliberately do not mock
+  `ws` and run on all three CI OSes, because whether "`connect()` resolved" implies "a client can
+  connect now" depends on platform bind/listen semantics and on how `localhost` resolves. Revisit if
+  the app ever needs to be reachable from another machine — that is a different security decision —
+  or if resolver latency on some platform proves material. The loopback rationale now lives here and
+  in the code comment; `Security-Guide.md` has no entry for it.
+- **Source:** Diagnosed from a packaged 0.4.0-alpha.0 snap first-run failure on WSL2 Ubuntu,
+  2026-08-27. Hostname-vs-literal and the `listening` await confirmed with Matt Lyons (#2624's
+  author) on Discord, 2026-08-28.
+
 ## adr-paratext-data-alerts-via-alert-capture: Surface ParatextData alerts via `AlertCapture` instead of swallowing them
 
 - **Formerly:** ADR-0004

--- a/.context/standards/Architecture.md
+++ b/.context/standards/Architecture.md
@@ -57,6 +57,30 @@ its window and lives in that window's renderer.
 | Events | Broadcast notifications | Data provider updates |
 | Subscriptions | Continuous data streaming | `useData()` hook subscriptions |
 
+### WebSocket Invariants
+
+Two rules govern the PAPI websocket. Both have been broken in practice, and neither failure was
+diagnosable from where it surfaced.
+
+**Bind to loopback only.** Connections to the PAPI websocket are unauthenticated, and every
+registered method is callable over them. The server must never accept traffic arriving on a
+non-loopback interface. Bind by the name `localhost` rather than a literal address: clients connect
+to `localhost` too, so both ends resolve through the same resolver and agree on the IP version,
+whichever the host prefers. IPv4-vs-IPv6 mismatches between the two ends have been hit in practice.
+
+**Never report ready before the endpoint accepts.** `IRpcHandler.connect` must not resolve `true`
+until the socket is actually accepting connections. `new WebSocketServer(...)` starts binding but
+does not finish synchronously — and binding by hostname defers it further, behind a DNS lookup.
+Once `connect()` resolves, nothing further gates the extension-host spawn or window creation on
+socket readiness; those clients get one attempt with no retry, so reporting ready optimistically
+refuses them. The symptom appears
+three processes away as missing settings/localization/theme providers and raw `%localizeKey%` text,
+with nothing in the log tying it back to the socket. Any new `IRpcHandler` implementation inherits
+this requirement.
+
+See `adr-papi-websocket-hostname-bind` in [Architecture-Decisions.md](Architecture-Decisions.md)
+for the incident and the alternatives that were rejected.
+
 ### Key Files
 
 - `src/shared/services/network.service.ts` - Core network communication

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -2070,9 +2070,21 @@ declare module 'shared/models/rpc.interface' {
      * - On clients: connecting to the server
      * - On servers: opening an endpoint for clients to connect
      *
+     * An implementation that opens an endpoint MUST NOT resolve `true` until that endpoint is
+     * actually accepting connections. Callers treat this resolving as permission to start processes
+     * that immediately connect, and those clients may get a single attempt with no retry — so
+     * reporting ready optimistically surfaces as a client that was refused, whose symptoms appear in
+     * a different process entirely. See `adr-papi-websocket-hostname-bind`.
+     *
      * @param localEventHandler Function that handles events from the server by accepting an eventType
      *   and an event and emitting the event locally. Used when receiving an event over the network.
-     * @returns Promise that resolves when finished connecting
+     * @returns `true` once the connection is established and usable — for a server, once its endpoint
+     *   is accepting connections. `false` if the connection could not be established.
+     *
+     *   TODO(PT-4495): implementations disagree on what they return when this handler was already
+     *   connected or connecting, so a caller can neither rely on that case nor tell a benign
+     *   double-connect from a real failure. PT-4495 replaces the boolean with a result type that
+     *   distinguishes the three outcomes; until then, only the two states above are contractual.
      */
     connect: (localEventHandler: EventHandler) => Promise<boolean>;
     /**
@@ -2356,6 +2368,14 @@ declare module 'client/services/rpc-client' {
      * An instance method (bound by `bindClassMethods`) rather than a static one for that reason.
      */
     private onError;
+    /**
+     * Reports a failure to whichever connection attempt is still waiting, if any.
+     *
+     * An `AsyncVariable` is single-use and freezes once settled, so this is a no-op after the attempt
+     * has already succeeded or failed. That is what makes it safe to call from both the `error` and
+     * the `close` handler, since a refused socket fires both.
+     */
+    private failConnectionAttempt;
     private onWebSocketOpen;
     private onWebSocketClose;
     private onMessageReceivedByWebSocket;
@@ -2575,6 +2595,7 @@ declare module 'main/services/rpc-websocket-listener' {
    * Created by the main process on start up when the network service initializes
    */
   export class RpcWebSocketListener implements IRpcMethodRegistrar {
+    private readonly port;
     connectionStatus: ConnectionStatus;
     /**
      * Event that fires when a connected process goes away, carrying the method names its departure
@@ -2605,7 +2626,12 @@ declare module 'main/services/rpc-websocket-listener' {
      */
     private readonly warnedForeignAnnouncements;
     private readonly clientDisconnectEmitter;
-    constructor();
+    /**
+     * @param port Port to listen on. Defaults to `WEBSOCKET_PORT`, which the whole app uses;
+     *   overridden only by tests that need to bind a real socket without colliding with a running
+     *   app.
+     */
+    constructor(port?: number);
     get nextSocketId(): string;
     connect(localEventHandler: EventHandler): Promise<boolean>;
     disconnect(): Promise<void>;

--- a/src/client/services/__tests__/rpc-client.test.ts
+++ b/src/client/services/__tests__/rpc-client.test.ts
@@ -1,0 +1,248 @@
+// @vitest-environment node
+
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { logger } from '@shared/services/logger.service';
+import { RpcClient } from '@client/services/rpc-client';
+
+/**
+ * Regression coverage for how a client reports a failed websocket connection to main.
+ *
+ * A client that cannot connect must fail fast and say why: both the `error` and the `close` handler
+ * have to settle the in-flight attempt, or it waits out the full 10 s `AsyncVariable` timeout
+ * before reporting anything, and the log has to carry the underlying cause rather than `{}`.
+ *
+ * The race itself is fixed on the server side, by having the listener wait for its socket to bind
+ * before main reports the network service up (see rpc-websocket-listener.listening.test.ts). What
+ * is covered here is that a client fails fast and says why.
+ */
+
+const mocks = vi.hoisted(() => {
+  type Listener = (ev: unknown) => void;
+
+  /**
+   * Minimal stand-in for the browser/`ws` socket. Starts in CONNECTING (readyState 0) like a real
+   * socket so `RpcClient.connect` waits on its `open`/`error`/`close` events rather than
+   * short-circuiting.
+   *
+   * Deliberately separate from `createFakeWebSocket` in
+   * `src/main/services/__tests__/fake-web-socket-test.util.ts`: that one models the SERVER end of a
+   * client's socket (what main sent, firing `close`), while this is the client end, which needs a
+   * readyState lifecycle and `accept`/`refuse` the server-end suites have no use for.
+   */
+  class FakeWebSocket {
+    readyState = 0;
+
+    closeCalls = 0;
+
+    url: string;
+
+    private listeners = new Map<string, Set<Listener>>();
+
+    constructor(url: string) {
+      this.url = url;
+    }
+
+    addEventListener(type: string, callback: Listener) {
+      const forType = this.listeners.get(type) ?? new Set<Listener>();
+      forType.add(callback);
+      this.listeners.set(type, forType);
+    }
+
+    removeEventListener(type: string, callback: Listener) {
+      this.listeners.get(type)?.delete(callback);
+    }
+
+    close() {
+      this.closeCalls += 1;
+      this.readyState = 3;
+      this.dispatch('close');
+    }
+
+    /** An error that does not tear the socket down, so it stays live afterwards */
+    reportError(error?: unknown) {
+      this.dispatch('error', error);
+    }
+
+    /** What a real socket does when nothing is listening on the port yet (ECONNREFUSED) */
+    refuse(error?: unknown) {
+      this.readyState = 3;
+      this.dispatch('error', error);
+      this.dispatch('close');
+    }
+
+    accept() {
+      this.readyState = 1;
+      this.dispatch('open');
+    }
+
+    private dispatch(type: string, payload?: unknown) {
+      [...(this.listeners.get(type) ?? [])].forEach((callback) => callback(payload ?? { type }));
+    }
+  }
+
+  const state: {
+    /** Pins that a failed attempt is not silently retried */
+    attempts: number;
+    refuseConnection: boolean;
+    /** ReadyState the factory hands back, for the states connect() has to tell apart */
+    initialReadyState: number;
+    /**
+     * Fire `error` without a following `close`, which is how a socket that reports a problem but
+     * stays live presents. Nothing else settles the attempt, and nothing else closes the socket.
+     */
+    errorWithoutClose: boolean;
+    /** Error to hand the `error` listener, for asserting what gets logged */
+    refuseWith: unknown;
+    /**
+     * Close the socket without an `error` first, which is how a peer that accepts the TCP
+     * connection and then drops it before the websocket upgrade presents. Only the `close` handler
+     * runs, so it alone has to settle the attempt.
+     */
+    closeWithoutError: boolean;
+  } = {
+    attempts: 0,
+    refuseConnection: false,
+    initialReadyState: 0,
+    errorWithoutClose: false,
+    refuseWith: undefined,
+    closeWithoutError: false,
+  };
+  const sockets: InstanceType<typeof FakeWebSocket>[] = [];
+  return { FakeWebSocket, state, sockets };
+});
+
+vi.mock('@client/services/web-socket.factory', () => ({
+  createWebSocket: vi.fn(async (url: string) => {
+    mocks.state.attempts += 1;
+    const socket = new mocks.FakeWebSocket(url);
+    socket.readyState = mocks.state.initialReadyState;
+    mocks.sockets.push(socket);
+    // Events must fire after `connect` attaches its listeners, which happens synchronously once
+    // this promise resolves.
+    setTimeout(() => {
+      if (!mocks.state.refuseConnection) socket.accept();
+      else if (mocks.state.closeWithoutError) socket.close();
+      else if (mocks.state.errorWithoutClose) socket.reportError(mocks.state.refuseWith);
+      else socket.refuse(mocks.state.refuseWith);
+    }, 0);
+    return socket;
+  }),
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+}));
+
+/**
+ * Mirrors `ws`'s own `ErrorEvent` (see node_modules/ws/lib/event-target.js): the underlying error
+ * is held behind a symbol and exposed through a prototype getter, so `JSON.stringify` renders the
+ * whole event as `{}` and carries no cause at all.
+ *
+ * Modelling this faithfully matters. A plain `Error` carrying an enumerable `code` would serialize
+ * its own cause and let a stringify-only implementation pass this test.
+ */
+function makeWebSocketErrorEvent(cause: unknown): unknown {
+  const event = {};
+  // Accessors rather than plain values, because that is what makes a real ErrorEvent opaque to
+  // `JSON.stringify`: `ws` marks its own `enumerable: true`, but they live on the PROTOTYPE, and
+  // the instance has no own properties for stringify to find. Defining them here as
+  // non-enumerable own accessors reproduces that same invisibility on a plain object.
+  Object.defineProperty(event, 'error', { get: () => cause });
+  Object.defineProperty(event, 'message', {
+    get: () => (cause instanceof Error ? cause.message : String(cause)),
+  });
+  return event;
+}
+
+/** A connect failure as Node reports it, with the system fields a real ECONNREFUSED carries */
+function makeConnectionRefusedError(): Error {
+  return Object.assign(new Error('connect ECONNREFUSED 127.0.0.1:8876'), {
+    code: 'ECONNREFUSED',
+    errno: -111,
+    syscall: 'connect',
+    address: '127.0.0.1',
+    port: 8876,
+  });
+}
+
+describe('RpcClient initial connection', () => {
+  beforeEach(() => {
+    vi.mocked(logger.error).mockClear();
+    mocks.state.attempts = 0;
+    mocks.state.refuseConnection = false;
+    mocks.state.initialReadyState = 0;
+    mocks.state.errorWithoutClose = false;
+    mocks.sockets.length = 0;
+    mocks.state.refuseWith = undefined;
+    mocks.state.closeWithoutError = false;
+  });
+
+  it('connects when the server is accepting', async () => {
+    const client = new RpcClient();
+
+    await expect(client.connect(() => {})).resolves.toBe(true);
+    expect(mocks.state.attempts).toBe(1);
+  });
+
+  // The 1 s timeout is the assertion: settling on `error`/`close` rather than waiting out the 10 s
+  // AsyncVariable timeout is the whole behavior under test, and the runner enforces the bound
+  // without a wall-clock comparison in the test body that a loaded CI runner could flake.
+  it('reports a refused connection promptly instead of waiting out the timeout', async () => {
+    mocks.state.refuseConnection = true;
+    const client = new RpcClient();
+
+    await expect(client.connect(() => {})).resolves.toBe(false);
+  }, 1000);
+
+  it('reports a socket that closes before connecting, with no error event to settle it', async () => {
+    // A refusal fires `error` then `close`, so the `error` handler always settles the attempt
+    // first and the `close` handler's own settling never gets a turn. A peer that accepts the
+    // connection and drops it before the websocket upgrade fires `close` alone, which is the only
+    // thing left to settle the attempt.
+    mocks.state.refuseConnection = true;
+    mocks.state.closeWithoutError = true;
+    const client = new RpcClient();
+
+    await expect(client.connect(() => {})).resolves.toBe(false);
+  }, 1000);
+
+  it('logs the underlying error code so a refused connection is diagnosable', async () => {
+    mocks.state.refuseConnection = true;
+    mocks.state.refuseWith = makeWebSocketErrorEvent(makeConnectionRefusedError());
+
+    // Guards the test itself: if this ever serializes its cause, the fake has drifted from ws and
+    // would stop being able to catch a stringify-only implementation.
+    expect(JSON.stringify(mocks.state.refuseWith)).toBe('{}');
+    const client = new RpcClient();
+
+    await client.connect(() => {});
+
+    const logged = vi.mocked(logger.error).mock.calls.map((args: unknown[]) => String(args[0]));
+    // A stringify-only implementation renders the whole event as `{}` and carries no cause at all,
+    // so the reason and its code reaching the log is what reading through the accessors buys. The
+    // rejection carries it too, so the attempt's own failure line says why rather than just that.
+    expect(logged.some((message: string) => message.includes('ECONNREFUSED'))).toBe(true);
+    expect(logged.some((message: string) => message.includes('code=ECONNREFUSED'))).toBe(true);
+  });
+
+  it('fails instead of reporting success on a socket that is already closed', async () => {
+    // 3 is CLOSED. Reporting this as connected would hand the caller a dead socket, and every send
+    // would be dropped until its own request timeout expired.
+    mocks.state.initialReadyState = 3;
+    const client = new RpcClient();
+
+    await expect(client.connect(() => {})).resolves.toBe(false);
+  });
+
+  it('settles on an error that is not followed by a close', async () => {
+    // A socket that reports a problem but stays live fires `error` alone, so the error handler is
+    // the only thing that can settle the attempt — the close handler never gets a turn. Closing
+    // that abandoned socket is deliberately left to PT-4435, which owns what a failed connect does
+    // to a live socket.
+    mocks.state.refuseConnection = true;
+    mocks.state.errorWithoutClose = true;
+    const client = new RpcClient();
+
+    await expect(client.connect(() => {})).resolves.toBe(false);
+  }, 1000);
+});

--- a/src/client/services/__tests__/rpc-client.test.ts
+++ b/src/client/services/__tests__/rpc-client.test.ts
@@ -245,4 +245,32 @@ describe('RpcClient initial connection', () => {
 
     await expect(client.connect(() => {})).resolves.toBe(false);
   }, 1000);
+
+  it('leaves no unhandled rejection when it gives up on an already-closed socket', async () => {
+    // `connectionComplete` is armed from construction, so any path that settles nothing leaves it
+    // to reject on its own 10s timeout with nobody subscribed — which surfaces as an unhandled
+    // rejection rather than a test failure. Fake timers stand in for that wait, so pinning it costs
+    // milliseconds instead of holding the file open. Install them before constructing the client,
+    // since the variable arms itself in a field initializer.
+    const unhandled = vi.fn();
+    process.on('unhandledRejection', unhandled);
+    try {
+      vi.useFakeTimers();
+      mocks.state.initialReadyState = 3;
+
+      await expect(new RpcClient().connect(() => {})).resolves.toBe(false);
+
+      await vi.advanceTimersByTimeAsync(10_001);
+      vi.useRealTimers();
+      // A rejection is only reported on the next macrotask, which needs the real clock back.
+      await new Promise((resolve) => {
+        setImmediate(resolve);
+      });
+
+      expect(unhandled).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+      process.off('unhandledRejection', unhandled);
+    }
+  });
 });

--- a/src/client/services/rpc-client.ts
+++ b/src/client/services/rpc-client.ts
@@ -139,6 +139,8 @@ export class RpcClient implements IRpcMethodRegistrar {
 
   async connect(localEventHandler: EventHandler): Promise<boolean> {
     return this.connectionMutex.runExclusive(async () => {
+      // TODO(PT-4495): `true` here means "already connected", the opposite answer the other two
+      // IRpcHandler implementations give for the same condition.
       if (this.connectionStatus === ConnectionStatus.Connected) return true;
       if (this.ws) {
         logger.warn('Client connect() called when websocket exists but not connected');
@@ -168,8 +170,17 @@ export class RpcClient implements IRpcMethodRegistrar {
         // `this.ws.url` — reported by the catch as a connection error that never happened.
         const { url } = this.ws;
 
-        // Wait for the socket to finish connecting before continuing (0 means connecting)
-        if (this.ws.readyState !== 0) this.connectionComplete.resolveToValue();
+        // Wait for the socket to finish connecting before continuing. 0 is CONNECTING, and the
+        // listeners just attached will settle the attempt. Only 1 (OPEN) is already connected:
+        // CLOSING and CLOSED have no further event left to settle this, so resolving on them
+        // reports Connected on a dead socket, and every later send is dropped until the caller's
+        // own request timeout expires. Throw instead, so the catch below reports the failure and
+        // tears the attempt down the same way every other failure does.
+        if (this.ws.readyState === 1) this.connectionComplete.resolveToValue();
+        else if (this.ws.readyState !== 0)
+          throw new Error(
+            `The websocket was already closing or closed (readyState ${this.ws.readyState})`,
+          );
         await this.connectionComplete.promise;
 
         // The socket can die while this await is parked: onWebSocketClose then runs to completion,
@@ -190,7 +201,9 @@ export class RpcClient implements IRpcMethodRegistrar {
         // properties worth serializing.
         RpcClient.handleError(
           `RPC client connection error for ${this.peerName}`,
-          getErrorMessage(error),
+          // An AsyncVariable rejects with a plain string reason; passing that through
+          // `getErrorMessage` would JSON-quote and escape the diagnostic rather than print it.
+          typeof error === 'string' ? error : getErrorMessage(error),
         );
         // TODO(PT-4435): The socket itself is never closed here, only forgotten — leaving a live,
         // listener-less socket and a server-side RpcServer whose registered methods are never
@@ -355,10 +368,25 @@ export class RpcClient implements IRpcMethodRegistrar {
    * An instance method (bound by `bindClassMethods`) rather than a static one for that reason.
    */
   private onError(ev: Event): void {
-    RpcClient.handleError(
-      `Client websocket error event occurred for ${this.peerName}`,
-      describeWebSocketErrorEvent(ev),
-    );
+    const detail = describeWebSocketErrorEvent(ev);
+    RpcClient.handleError(`Client websocket error event occurred for ${this.peerName}`, detail);
+    // An error before the socket opens is the whole answer for the attempt in flight. Without this
+    // nothing settles it on a refused connection, so `connect()` waits out the AsyncVariable's full
+    // timeout before reporting a failure that was already known — long enough that a client given
+    // one attempt and no retry is dead before it hears back. See
+    // `adr-papi-websocket-hostname-bind`.
+    this.failConnectionAttempt(`Websocket reported an error event: ${detail}`);
+  }
+
+  /**
+   * Reports a failure to whichever connection attempt is still waiting, if any.
+   *
+   * An `AsyncVariable` is single-use and freezes once settled, so this is a no-op after the attempt
+   * has already succeeded or failed. That is what makes it safe to call from both the `error` and
+   * the `close` handler, since a refused socket fires both.
+   */
+  private failConnectionAttempt(reason: string): void {
+    if (!this.connectionComplete.hasSettled) this.connectionComplete.rejectWithReason(reason);
   }
 
   private onWebSocketOpen(): void {
@@ -376,6 +404,10 @@ export class RpcClient implements IRpcMethodRegistrar {
     // disconnect is still reported honestly if the socket actually died.
     if (isCleanCloseEvent(ev)) logger.info(summary);
     else logger.warn(summary);
+    // A close with no preceding error still has to settle the attempt in flight: it is the only
+    // event a peer that accepts the TCP connection and then drops it before the websocket upgrade
+    // ever produces, so nothing else would.
+    this.failConnectionAttempt(`Websocket closed before it opened (${detail})`);
     this.removeEventListenersFromWebSocket();
     this.connectionStatus = ConnectionStatus.Disconnected;
   }

--- a/src/client/services/rpc-client.ts
+++ b/src/client/services/rpc-client.ts
@@ -174,11 +174,12 @@ export class RpcClient implements IRpcMethodRegistrar {
         // listeners just attached will settle the attempt. Only 1 (OPEN) is already connected:
         // CLOSING and CLOSED have no further event left to settle this, so resolving on them
         // reports Connected on a dead socket, and every later send is dropped until the caller's
-        // own request timeout expires. Throw instead, so the catch below reports the failure and
-        // tears the attempt down the same way every other failure does.
+        // own request timeout expires. Fail the attempt rather than throwing past the await below:
+        // `connectionComplete` is armed from construction, so a variable left unsettled with
+        // nothing subscribed rejects on its own timeout as an unhandled rejection.
         if (this.ws.readyState === 1) this.connectionComplete.resolveToValue();
         else if (this.ws.readyState !== 0)
-          throw new Error(
+          this.failConnectionAttempt(
             `The websocket was already closing or closed (readyState ${this.ws.readyState})`,
           );
         await this.connectionComplete.promise;

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -339,7 +339,19 @@ async function main() {
   setAppShutdownSignal(isAppShuttingDown);
 
   // The network service has to start first, and it uses the shared store after initialization
-  await networkService.initialize();
+  try {
+    await networkService.initialize();
+  } catch (error) {
+    // Everything below — including the `app.whenReady()` that creates windows and the quit
+    // handlers — is registered further down in this function, so letting this reject would leave a
+    // live process with no window, no way to quit, and the single-instance lock still held, which
+    // blocks every later launch too. Exit instead, so the failure is visible and relaunch works.
+    logger.error(
+      `Could not start the PAPI network service, so the app cannot run: ${getErrorMessage(error)}`,
+    );
+    app.exit(1);
+    return;
+  }
   markStartup('network-service-up');
   await initializeSharedStoreService(networkService);
 

--- a/src/main/services/__tests__/fake-web-socket-test.util.ts
+++ b/src/main/services/__tests__/fake-web-socket-test.util.ts
@@ -1,9 +1,7 @@
 /**
- * Stand-in for the server end of a client's websocket, shared by the suites that exercise what main
- * does while a client is connected and when one goes away (`rpc-client-disconnect.test.ts` and
- * `rpc-disconnect-announcement-ordering.test.ts`). Both need to fire `close` themselves and to read
- * back, in order, everything main sent to a socket, so the fake lives here rather than being copied
- * into each suite and drifting apart.
+ * Stand-ins for both ends of main's websocket, shared by the suites that exercise what main does
+ * while a client is connected, when one goes away, and while its own server is binding. The fakes
+ * live here rather than being copied into each suite and drifting apart.
  */
 
 import { serialize } from 'platform-bible-utils';
@@ -39,4 +37,103 @@ export function createFakeWebSocket() {
     },
     close: () => listeners.close?.forEach((listener) => listener({ target: fakeWebSocket })),
   };
+}
+
+type Handler = (arg?: unknown) => void;
+
+/**
+ * Stand-in for `ws`'s `WebSocketServer`, which `RpcWebSocketListener.connect` waits on: it must
+ * complete the `listening` handshake or `connect()` never resolves.
+ */
+export class FakeWebSocketServer {
+  isClosed = false;
+
+  private handlers = new Map<string, Set<Handler>>();
+
+  /**
+   * Handlers registered through {@link once}, which {@link emit} drops after firing them. Tracked
+   * alongside `handlers` rather than registering a self-removing wrapper, because production
+   * removes these by their original reference — `removeListener('error', onError)` — and
+   * {@link removeListener} here is a `Set` delete keyed on identity, so a wrapper stored in that set
+   * would make it a no-op. (Node's own `EventEmitter` avoids that by matching on the wrapper's
+   * `.listener`; this fake has no such indirection.)
+   */
+  private onceHandlers = new Set<Handler>();
+
+  /**
+   * @param autoListen Whether to fire `listening` on the next tick, which is what a suite that only
+   *   needs `connect()` to succeed wants. Pass false to drive the events by hand with
+   *   {@link FakeWebSocketServer.emit}.
+   */
+  constructor(private readonly autoListen: boolean) {}
+
+  addListener(type: string, handler: Handler) {
+    this.on(type, handler);
+  }
+
+  on(type: string, handler: Handler) {
+    const forType = this.handlers.get(type) ?? new Set<Handler>();
+    forType.add(handler);
+    this.handlers.set(type, forType);
+  }
+
+  once(type: string, handler: Handler) {
+    this.on(type, handler);
+    this.onceHandlers.add(handler);
+    if (this.autoListen && type === 'listening')
+      setTimeout(() => {
+        this.emit('listening');
+      }, 0);
+  }
+
+  removeListener(type: string, handler: Handler) {
+    this.handlers.get(type)?.delete(handler);
+    this.onceHandlers.delete(handler);
+  }
+
+  /**
+   * The first handler registered for `type`, for suites that drive it directly — handing the
+   * `connection` handler a client the way a real `WebSocketServer` would, say.
+   */
+  getHandler(type: string): Handler | undefined {
+    return [...(this.handlers.get(type) ?? [])][0];
+  }
+
+  close() {
+    this.isClosed = true;
+  }
+
+  /**
+   * Drives the event the production code is waiting on.
+   *
+   * Throws an unhandled `error` the way a real EventEmitter does, so a test can tell the difference
+   * between an error that is handled and one that would take the process down.
+   */
+  emit(type: string, arg?: unknown) {
+    const handlers = [...(this.handlers.get(type) ?? [])];
+    if (type === 'error' && handlers.length === 0) throw arg;
+    handlers.forEach((handler) => {
+      if (this.onceHandlers.has(handler)) {
+        this.onceHandlers.delete(handler);
+        this.handlers.get(type)?.delete(handler);
+      }
+      handler(arg);
+    });
+  }
+}
+
+/**
+ * Creates a {@link FakeWebSocketServer}.
+ *
+ * Deliberately keeps no registry of what it created: a suite that needs the instance should collect
+ * it in `vi.hoisted` state, which survives the `vi.resetModules()` some of these suites call.
+ * Module-level state here would not — the mocked `ws` factory and the test body can end up holding
+ * different copies of this module.
+ *
+ * @param autoListen Whether to complete the `listening` handshake automatically on the next tick,
+ *   which is what a suite that only needs `connect()` to succeed wants. Pass false to drive the
+ *   events by hand with {@link FakeWebSocketServer.emit}.
+ */
+export function createFakeWebSocketServer(autoListen = true): FakeWebSocketServer {
+  return new FakeWebSocketServer(autoListen);
 }

--- a/src/main/services/__tests__/rpc-client-disconnect.test.ts
+++ b/src/main/services/__tests__/rpc-client-disconnect.test.ts
@@ -4,14 +4,24 @@ import { RpcServer } from '@main/services/rpc-server';
 import { RegisteredRpcMethodDetails } from '@shared/models/rpc.interface';
 import { REGISTER_METHOD } from '@shared/data/rpc.model';
 import { RpcEventRegistry } from '@main/services/rpc-event-registry';
-import { WebSocketServer } from 'ws';
 import { createFakeWebSocket } from './fake-web-socket-test.util';
+import type { FakeWebSocketServer } from './fake-web-socket-test.util';
 
 // Mock heavy dependencies so this test can run outside the Electron main process.
 vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
-vi.mock('ws', () => ({
-  WebSocketServer: vi.fn(() => ({ addListener: vi.fn(), removeListener: vi.fn(), close: vi.fn() })),
-}));
+const servers = vi.hoisted<FakeWebSocketServer[]>(() => []);
+// connect() waits for the server's `listening` event before reporting success, so the fake has to
+// finish the handshake or connect() would never resolve.
+vi.mock('ws', async () => {
+  const { createFakeWebSocketServer } = await import('./fake-web-socket-test.util');
+  return {
+    WebSocketServer: vi.fn(() => {
+      const server = createFakeWebSocketServer();
+      servers.push(server);
+      return server;
+    }),
+  };
+});
 vi.mock('@shared/services/logger.service', () => ({
   logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
 }));
@@ -23,6 +33,9 @@ describe('RpcServer announces the methods that died with its client', () => {
   let rpcServer: RpcServer;
 
   beforeEach(async () => {
+    // Reset with the rest of the per-test state: `servers` is hoisted, so a test added ahead of
+    // this one would otherwise leave `servers[0]` pointing at its listener rather than this one's.
+    servers.length = 0;
     rpcMethodDetailsByMethodName = new Map();
     announcedMethodNames = [];
     socket = createFakeWebSocket();
@@ -73,11 +86,8 @@ describe('the websocket listener exposes client disconnects to shared code', () 
     );
 
     // Hand the listener a connecting client the same way the WebSocketServer would
-    const connectionListener = vi
-      .mocked(WebSocketServer)
-      .mock.results[0].value.addListener.mock.calls.find(
-        ([eventName]: [string]) => eventName === 'connection',
-      )?.[1];
+    const connectionListener = servers[0]?.getHandler('connection');
+    if (!connectionListener) throw new Error('Main never started listening for connections');
     const socket = createFakeWebSocket();
     connectionListener(socket.webSocket);
 

--- a/src/main/services/__tests__/rpc-disconnect-announcement-ordering.test.ts
+++ b/src/main/services/__tests__/rpc-disconnect-announcement-ordering.test.ts
@@ -3,12 +3,26 @@ import { REGISTER_METHOD } from '@shared/data/rpc.model';
 import { ProcessType } from '@shared/global-this.model';
 import { deserialize } from 'platform-bible-utils';
 import { createFakeWebSocket } from './fake-web-socket-test.util';
+import type { FakeWebSocketServer } from './fake-web-socket-test.util';
 
 // Mock heavy dependencies so main's network stack can run outside the Electron main process.
 vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
-vi.mock('ws', () => ({
-  WebSocketServer: vi.fn(() => ({ addListener: vi.fn(), removeListener: vi.fn(), close: vi.fn() })),
-}));
+// Collected in hoisted state, which survives the `vi.resetModules()` this suite calls between
+// tests — module-level state in the util would leave the mocked factory and the test body holding
+// different copies.
+const servers = vi.hoisted<FakeWebSocketServer[]>(() => []);
+// connect() waits for the server's `listening` event before reporting success, so the fake has to
+// finish the handshake or connect() would never resolve.
+vi.mock('ws', async () => {
+  const { createFakeWebSocketServer } = await import('./fake-web-socket-test.util');
+  return {
+    WebSocketServer: vi.fn(() => {
+      const server = createFakeWebSocketServer();
+      servers.push(server);
+      return server;
+    }),
+  };
+});
 vi.mock('@shared/services/logger.service', () => ({
   logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
 }));
@@ -82,14 +96,10 @@ async function drainMicrotasks(): Promise<void> {
  * `WebSocketServer` would run when a client connects.
  */
 async function startMainNetworkStack(): Promise<(webSocket: WebSocket) => void> {
-  const { WebSocketServer } = await import('ws');
   const { networkObjectService } = await import('@shared/services/network-object.service');
   await networkObjectService.initialize();
 
-  const webSocketServer = vi.mocked(WebSocketServer).mock.results.at(-1)?.value;
-  const connectClient = webSocketServer?.addListener.mock.calls.find(
-    ([eventName]: [string]) => eventName === 'connection',
-  )?.[1];
+  const connectClient = servers.at(-1)?.getHandler('connection');
   if (!connectClient) throw new Error('Main never started listening for websocket connections');
   return connectClient;
 }
@@ -119,6 +129,7 @@ describe('a disconnect announcement reaches surviving sockets before anything ca
     // copy of them rather than inheriting the previous test's network stack.
     vi.resetModules();
     vi.clearAllMocks();
+    servers.length = 0;
     // Only the process that owns the connections announces these disposals
     globalThis.processType = ProcessType.Main;
 

--- a/src/main/services/__tests__/rpc-websocket-listener.binding.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.binding.test.ts
@@ -7,9 +7,12 @@ import { WebSocketServer } from 'ws';
 // WebSocketServer mock returns a listener-shaped stub because connect() wires handlers onto the
 // instance it constructs.
 vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
-vi.mock('ws', () => ({
-  WebSocketServer: vi.fn(() => ({ addListener: vi.fn(), removeListener: vi.fn(), close: vi.fn() })),
-}));
+// connect() waits for the server's `listening` event before reporting success, so the fake has to
+// finish the handshake or connect() would never resolve.
+vi.mock('ws', async () => {
+  const { createFakeWebSocketServer } = await import('./fake-web-socket-test.util');
+  return { WebSocketServer: vi.fn(() => createFakeWebSocketServer()) };
+});
 vi.mock('@shared/services/logger.service', () => ({
   logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
 }));

--- a/src/main/services/__tests__/rpc-websocket-listener.listening.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.listening.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { wait } from 'platform-bible-utils';
+import { RpcWebSocketListener } from '@main/services/rpc-websocket-listener';
+import { logger } from '@shared/services/logger.service';
+import { WebSocketServer } from 'ws';
+import type { FakeWebSocketServer } from './fake-web-socket-test.util';
+
+/**
+ * `new WebSocketServer({...})` binds asynchronously, so `connect()` must wait for the server's
+ * `listening` event before reporting success. Main resolves `networkService.initialize()` on that
+ * result and immediately spawns the extension host, which gets one connect attempt and no retry —
+ * so reporting connected while the socket is still unbound refuses that attempt, leaving no
+ * settings/localization/theme provider registered and the UI rendering raw localize keys.
+ */
+
+vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+// Collected in hoisted state rather than in the util, so the reference survives module resets.
+const servers = vi.hoisted<FakeWebSocketServer[]>(() => []);
+// Driven by hand rather than auto-completing the handshake: these tests control exactly when
+// binding finishes.
+vi.mock('ws', async () => {
+  const { createFakeWebSocketServer } = await import('./fake-web-socket-test.util');
+  return {
+    WebSocketServer: vi.fn(() => {
+      const server = createFakeWebSocketServer(false);
+      servers.push(server);
+      return server;
+    }),
+  };
+});
+
+/** Lets pending microtasks run so a resolved `connect()` would have settled by now. */
+const flush = () => wait(0);
+
+describe('the PAPI websocket reports connected only once it is accepting', () => {
+  let listener: RpcWebSocketListener;
+
+  beforeEach(() => {
+    vi.mocked(WebSocketServer).mockClear();
+    vi.mocked(logger.error).mockClear();
+    servers.length = 0;
+    listener = new RpcWebSocketListener();
+  });
+
+  it('does not resolve connect() until the server has finished binding', async () => {
+    let settled = false;
+    const connecting = listener.connect(vi.fn()).then((result) => {
+      settled = true;
+      return result;
+    });
+
+    await flush();
+    // Binding has not completed, so main must not believe the websocket is usable yet.
+    expect(settled).toBe(false);
+
+    servers[0].emit('listening');
+
+    await expect(connecting).resolves.toBe(true);
+  });
+
+  it('reports failure when the server errors instead of binding', async () => {
+    const connecting = listener.connect(vi.fn());
+
+    await flush();
+    servers[0].emit('error', new Error('listen EADDRINUSE: address already in use'));
+
+    await expect(connecting).resolves.toBe(false);
+    // A half-open server that is never closed keeps whatever the OS did hand it, so the failure
+    // path has to release it rather than just reporting false.
+    expect(servers[0].isClosed).toBe(true);
+  });
+
+  it('can connect again after a failed bind', async () => {
+    // The whole point of unwinding state on a failed bind is that the next attempt can still
+    // succeed. If the rollback ever misses a field, `connect()` returns false at its
+    // already-connecting guard and never reaches a second server.
+    const firstAttempt = listener.connect(vi.fn());
+    await flush();
+    servers[0].emit('error', new Error('listen EADDRINUSE: address already in use'));
+    await expect(firstAttempt).resolves.toBe(false);
+
+    const secondAttempt = listener.connect(vi.fn());
+    await flush();
+    expect(servers).toHaveLength(2);
+    servers[1].emit('listening');
+
+    await expect(secondAttempt).resolves.toBe(true);
+  });
+
+  it('gives up rather than hanging when the server never binds', async () => {
+    vi.useFakeTimers();
+    try {
+      const connecting = listener.connect(vi.fn());
+      // The server emits neither `listening` nor `error` — a wedged resolver. Without a bound this
+      // never settles, and main waits forever before creating any window. Run the pending timers
+      // out rather than advancing a fixed span, so the bound's length stays the listener's business.
+      await vi.runAllTimersAsync();
+
+      await expect(connecting).resolves.toBe(false);
+      expect(servers[0].isClosed).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('keeps handling server errors once it is bound', async () => {
+    const connecting = listener.connect(vi.fn());
+    await flush();
+    servers[0].emit('listening');
+    await expect(connecting).resolves.toBe(true);
+
+    // `ws` forwards the underlying HTTP server's errors for as long as the server is up, and Node
+    // throws on an `error` event with no listener — which in main escapes to the process-level
+    // handler, leaving the process in a state Node documents as undefined and a log line that
+    // names neither the socket nor the server. The bind-time handler is gone by now, so something
+    // else has to be holding the event.
+    const serverError = new Error('accept EMFILE: too many open files');
+    expect(() => servers[0].emit('error', serverError)).not.toThrow();
+    expect(vi.mocked(logger.error).mock.calls.map((args) => String(args[0]))).toContainEqual(
+      expect.stringContaining('EMFILE'),
+    );
+  });
+});

--- a/src/main/services/__tests__/rpc-websocket-listener.real-socket.test.ts
+++ b/src/main/services/__tests__/rpc-websocket-listener.real-socket.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createServer } from 'net';
+import { WebSocket } from 'ws';
+import { retryUntil } from 'platform-bible-utils';
+import { RpcWebSocketListener } from '@main/services/rpc-websocket-listener';
+
+/**
+ * Companion to `rpc-websocket-listener.listening.test.ts`, which proves the `listening` handshake
+ * with a stubbed `ws`. This one deliberately does NOT mock `ws`: it binds a real socket so the
+ * promise `connect()` awaits is resolved by the host's actual network stack.
+ *
+ * That is the part worth running on every OS in CI. Whether `connect()` resolving implies "a client
+ * can connect right now" depends on the platform's bind/listen semantics and on how `localhost`
+ * resolves (IPv4 vs IPv6) — details that a stubbed server cannot exercise and that differ across
+ * Windows, macOS, and Linux.
+ */
+
+vi.mock('electron', () => ({ app: { getVersion: () => '0.0.0' } }));
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { warn: vi.fn(), info: vi.fn(), debug: vi.fn(), error: vi.fn() },
+}));
+
+/**
+ * Asks the OS for a free port and releases it, since binding the app's real port would collide with
+ * a dev app on a developer machine.
+ *
+ * Hand-rolled rather than using the `detect-port` devDependency because that probes upward from a
+ * starting port, so parallel runs and a dev app converge on the same low ports. Asking the OS for
+ * an ephemeral port instead makes a collision the OS's problem, and scopes the probe to `localhost`
+ * — the interface the listener actually binds.
+ */
+function getFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const probe = createServer();
+    probe.on('error', reject);
+    probe.listen(0, 'localhost', () => {
+      const address = probe.address();
+      if (address && typeof address === 'object') {
+        const { port } = address;
+        probe.close(() => resolve(port));
+      } else {
+        probe.close(() => reject(new Error('Could not determine a free port')));
+      }
+    });
+  });
+}
+
+/**
+ * Resolves whether a client can complete a websocket handshake against `port` right now.
+ *
+ * Bounded, because a peer that accepts the TCP connection but never completes the upgrade emits
+ * neither `open` nor `error` — without the timer that reports as a hung suite rather than a false.
+ */
+function canConnect(port: number, timeoutMs = 2000): Promise<boolean> {
+  return new Promise((resolve) => {
+    const client = new WebSocket(`ws://localhost:${port}`);
+    let timeout: ReturnType<typeof setTimeout>;
+    const settle = (result: boolean) => {
+      clearTimeout(timeout);
+      // Keep an error handler attached through the close handshake: `ws` sockets are bare
+      // EventEmitters, so a late `error` with no listener throws inside the test worker.
+      client.removeAllListeners();
+      client.on('error', () => {});
+      client.close();
+      resolve(result);
+    };
+    timeout = setTimeout(() => settle(false), timeoutMs);
+    client.on('open', () => settle(true));
+    client.on('error', () => settle(false));
+  });
+}
+
+/**
+ * Binds a listener on a free port, retrying if something else claimed the port first.
+ *
+ * `getFreePort` releases the port before the listener rebinds it, so a parallel vitest worker or
+ * anything else on the machine can take it in between. Without the retry that lost race surfaces as
+ * `connect()` resolving false, which reads as though the code under test regressed.
+ */
+async function bindOnAFreePort(): Promise<{ listener: RpcWebSocketListener; port: number }> {
+  const maxAttempts = 5;
+  // `retryUntil` rather than a bespoke loop: the awaits move into the attempt callback, so the
+  // attempts stay serial — each must bind before the next port is picked — without suppressing
+  // `no-await-in-loop`. A give-up attempt releases its listener before returning `undefined`.
+  const bound = await retryUntil(
+    async () => {
+      const port = await getFreePort();
+      const candidate = new RpcWebSocketListener(port);
+      if (await candidate.connect(vi.fn())) return { listener: candidate, port };
+      await candidate.disconnect();
+      return undefined;
+    },
+    (result) => !!result,
+    { maxAttempts },
+  );
+  if (!bound) throw new Error(`Could not bind a free port in ${maxAttempts} attempts`);
+  return bound;
+}
+
+describe('the PAPI websocket against a real socket', () => {
+  let listener: RpcWebSocketListener | undefined;
+
+  afterEach(async () => {
+    await listener?.disconnect();
+    listener = undefined;
+  });
+
+  it('accepts a client immediately after connect() resolves', async () => {
+    const bound = await bindOnAFreePort();
+    listener = bound.listener;
+
+    // No delay and no retry between connect() resolving and this attempt. That is the guarantee
+    // main depends on when it spawns the extension host straight after initializing the network
+    // service.
+    await expect(canConnect(bound.port)).resolves.toBe(true);
+  });
+
+  it('reports failure rather than claiming success when the port is already taken', async () => {
+    // Retries past a lost port race, so reaching the assertion below means the port really is held
+    // by the squatter rather than by an unrelated process.
+    const squatting = await bindOnAFreePort();
+    const squatter = squatting.listener;
+
+    try {
+      listener = new RpcWebSocketListener(squatting.port);
+      await expect(listener.connect(vi.fn())).resolves.toBe(false);
+    } finally {
+      await squatter.disconnect();
+    }
+  });
+});

--- a/src/main/services/rpc-server.ts
+++ b/src/main/services/rpc-server.ts
@@ -150,6 +150,9 @@ export class RpcServer implements IRpcHandler {
   }
 
   async connect(): Promise<boolean> {
+    // TODO(PT-4495): `false` here means "already connected", while `RpcClient` returns `true` for
+    // the same condition. The `true` below carries no readiness meaning either — this connect binds
+    // nothing, it attaches listeners to a socket the listener already accepted.
     if (this.connectionStatus === ConnectionStatus.Connected) return false;
     this.hasCompletedTeardown = false;
     this.addEventListenersToWebSocket();

--- a/src/main/services/rpc-websocket-listener.ts
+++ b/src/main/services/rpc-websocket-listener.ts
@@ -42,6 +42,26 @@ import { RpcEventRegistry } from './rpc-event-registry';
 export { RpcEventRegistry };
 
 /**
+ * How long to wait for the websocket server to bind before treating the attempt as failed. Generous
+ * against a healthy bind (sub-millisecond) — this exists to turn an indefinite hang into a logged
+ * failure, not to police a slow machine.
+ */
+const BIND_TIMEOUT_MS = 10_000;
+
+/**
+ * Handles an error the websocket server reports once it is already bound, so Node does not throw an
+ * uncaught exception for an unhandled `error` event.
+ *
+ * Distinct from the bind-time handler in `connect`, which decides whether binding succeeded; by the
+ * time this runs the server is listening and there is nothing left to report back to. Declared at
+ * module scope so adding and removing it use the same reference, and because it needs nothing from
+ * the instance.
+ */
+function onServerError(error: unknown): void {
+  logger.error(`PAPI websocket server error: ${getErrorMessage(error)}`);
+}
+
+/**
  * Owns the WebSocketServer that listens for clients to connect to the web socket. When a client
  * connects, an RpcServer is created in this same process to service that connection.
  *
@@ -84,7 +104,12 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
   private readonly warnedForeignAnnouncements = new Set<string>();
   private readonly clientDisconnectEmitter = new PlatformEventEmitter<RpcClientDisconnectEvent>();
 
-  constructor() {
+  /**
+   * @param port Port to listen on. Defaults to `WEBSOCKET_PORT`, which the whole app uses;
+   *   overridden only by tests that need to bind a real socket without colliding with a running
+   *   app.
+   */
+  constructor(private readonly port: number = WEBSOCKET_PORT) {
     bindClassMethods.call(this);
     this.onDidDisconnectClient = this.clientDisconnectEmitter.event;
   }
@@ -96,8 +121,13 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
   }
 
   connect(localEventHandler: EventHandler): Promise<boolean> {
-    return this.connectionMutex.runExclusive(() => {
+    return this.connectionMutex.runExclusive(async () => {
+      // TODO(PT-4495): `false` here means "already connected", but the bind-failure path below
+      // returns it too, and the caller cannot tell the benign case from the fatal one.
       if (this.connectionStatus !== ConnectionStatus.Disconnected) return false;
+      // Binding is asynchronous, so there is a real window where an attempt is in flight; report it
+      // rather than staying indistinguishable from "never started" until it finishes.
+      this.connectionStatus = ConnectionStatus.Connecting;
       this.localEventHandler = localEventHandler;
       this.registerMethod(GET_METHODS, this.generateOpenRpcSchema, {
         method: {
@@ -116,10 +146,80 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
       // are unauthenticated and every registered method is callable over them, so the server must
       // never accept traffic arriving on a non-loopback interface. Bind by name rather than a
       // literal address: clients connect to `localhost` too, so both ends resolve through the same
-      // resolver and agree on the IP version, whichever the host prefers.
-      this.webSocketServer = new WebSocketServer({ host: 'localhost', port: WEBSOCKET_PORT });
-      this.webSocketServer.addListener('connection', this.onClientConnect);
-      this.webSocketServer.addListener('close', this.disconnect);
+      // resolver and agree on the IP version, whichever the host prefers. IPv4-vs-IPv6 mismatches
+      // between the two ends have been hit in practice, and external tools (websocat and the like)
+      // resolve on their own, so the hostname stays even though it defers the bind behind a DNS
+      // lookup and forces the `listening` wait below. See `adr-papi-websocket-hostname-bind`.
+      const webSocketServer = new WebSocketServer({ host: 'localhost', port: this.port });
+      this.webSocketServer = webSocketServer;
+      webSocketServer.addListener('connection', this.onClientConnect);
+      webSocketServer.addListener('close', this.disconnect);
+
+      // `new WebSocketServer` starts binding but does not finish synchronously, so the socket is
+      // not accepting yet. Wait for `listening` before reporting success: main spawns the
+      // extension host and opens windows as soon as this resolves, and those clients get refused
+      // by a socket that is not bound yet. On a cold start that window is wide enough to lose.
+      // main.ts's ordering (network service, then extension host) is only a real guarantee because
+      // of this wait, so reporting ready before the socket accepts reopens the bug three processes
+      // away.
+      const isListening = await new Promise<boolean>((resolve) => {
+        // `listen` resolves the hostname before it binds, so a wedged resolver can leave the server
+        // emitting neither `listening` nor `error`. Without a bound, `connect()` would never settle
+        // while holding the mutex, and main would sit forever before creating any window, with
+        // nothing logged. A healthy bind takes well under a millisecond, so this only fires when
+        // something is genuinely broken.
+        let bindTimeout: ReturnType<typeof setTimeout>;
+        const onListening = () => {
+          clearTimeout(bindTimeout);
+          webSocketServer.removeListener('error', onError);
+          // A bound server still needs an `error` listener for the rest of its life. `ws` forwards
+          // the underlying HTTP server's errors — an accept failing with EMFILE, say — and Node
+          // throws an uncaught exception when `error` is emitted with no listener. main's
+          // process-level `uncaughtException` handler catches that and logs it, but Node documents
+          // the process as being in an undefined state afterwards, and the line it produces names
+          // neither the socket nor the server. Handle it here so the failure stays local and says
+          // what it was.
+          webSocketServer.addListener('error', onServerError);
+          resolve(true);
+        };
+        function onError(error: unknown) {
+          // Settle before anything that could throw, and disarm the safety timer only once the
+          // attempt is already settled. Clearing it first inverts the guarantee it exists for: a
+          // throw in between would leave `connect()` unsettled inside the mutex with no timer left
+          // to settle it, and main waiting forever before it creates any window.
+          resolve(false);
+          clearTimeout(bindTimeout);
+          webSocketServer.removeListener('listening', onListening);
+          logger.error(`PAPI websocket server failed to bind: ${getErrorMessage(error)}`);
+        }
+        bindTimeout = setTimeout(() => {
+          webSocketServer.removeListener('listening', onListening);
+          webSocketServer.removeListener('error', onError);
+          logger.error(
+            `PAPI websocket server did not bind within ${BIND_TIMEOUT_MS}ms; giving up so startup can report the failure`,
+          );
+          resolve(false);
+        }, BIND_TIMEOUT_MS);
+        webSocketServer.once('listening', onListening);
+        webSocketServer.once('error', onError);
+      });
+
+      if (!isListening) {
+        // TODO(PT-4495): this rollback does not unwind the `GET_METHODS` registration above.
+        // Whether it should is part of settling what a failed connect is supposed to leave behind.
+        //
+        // Drop the `close` listener before closing. `ws` emits `close` on a later tick, so the
+        // hazard is not re-entrancy but staleness: left attached, the failed server's `close`
+        // arrives after a subsequent attempt has already bound and runs `disconnect` against the
+        // NEW server, closing it and reporting Disconnected while `connect()` returned true.
+        webSocketServer.removeListener('connection', this.onClientConnect);
+        webSocketServer.removeListener('close', this.disconnect);
+        webSocketServer.close();
+        this.webSocketServer = undefined;
+        this.localEventHandler = undefined;
+        this.connectionStatus = ConnectionStatus.Disconnected;
+        return false;
+      }
 
       this.connectionStatus = ConnectionStatus.Connected;
       return true;
@@ -131,6 +231,7 @@ export class RpcWebSocketListener implements IRpcMethodRegistrar {
       if (this.webSocketServer) {
         this.webSocketServer.removeListener('connection', this.onClientConnect);
         this.webSocketServer.removeListener('close', this.disconnect);
+        this.webSocketServer.removeListener('error', onServerError);
         this.webSocketServer.close();
         this.webSocketServer = undefined;
       }

--- a/src/shared/models/rpc.interface.ts
+++ b/src/shared/models/rpc.interface.ts
@@ -48,9 +48,21 @@ export interface IRpcHandler {
    * - On clients: connecting to the server
    * - On servers: opening an endpoint for clients to connect
    *
+   * An implementation that opens an endpoint MUST NOT resolve `true` until that endpoint is
+   * actually accepting connections. Callers treat this resolving as permission to start processes
+   * that immediately connect, and those clients may get a single attempt with no retry — so
+   * reporting ready optimistically surfaces as a client that was refused, whose symptoms appear in
+   * a different process entirely. See `adr-papi-websocket-hostname-bind`.
+   *
    * @param localEventHandler Function that handles events from the server by accepting an eventType
    *   and an event and emitting the event locally. Used when receiving an event over the network.
-   * @returns Promise that resolves when finished connecting
+   * @returns `true` once the connection is established and usable — for a server, once its endpoint
+   *   is accepting connections. `false` if the connection could not be established.
+   *
+   *   TODO(PT-4495): implementations disagree on what they return when this handler was already
+   *   connected or connecting, so a caller can neither rely on that case nor tell a benign
+   *   double-connect from a real failure. PT-4495 replaces the boolean with a result type that
+   *   distinguishes the three outcomes; until then, only the two states above are contractual.
    */
   connect: (localEventHandler: EventHandler) => Promise<boolean>;
   /**


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: fix/extension-host-connect-race

**Base**: origin/main

**Date**: 2026-08-31

**Review model**: Claude Opus 5

**Files changed**: 16

## Overview

Fixes a startup race in which `RpcWebSocketListener.connect()` reported the PAPI websocket connected
before its socket was actually bound. PR #2624 scoped the websocket to loopback by **hostname**,
which defers the bind behind a DNS lookup; `connect()` constructed the `WebSocketServer`, set
`ConnectionStatus.Connected` and returned `true` synchronously, so `await networkService.initialize()`
in main resolved while nothing was accepting. Main then spawned the extension host into that gap. On
a cold install the extension host's single connect attempt was refused at +549ms and the process died
9.98s later, registering no settings, localization or theme provider — which surfaced to the user as
an onboarding wizard rendering raw localize keys. Warm restarts bind long before the extension host
boots, which is why it reads as intermittent while being the norm on first launch after installing.

`connect()` now awaits `listening`, reports failure when the server emits `error` instead of binding
(previously indistinguishable from success), bounds the wait so a wedged resolver cannot hang main
while holding the connection mutex, and keeps a permanent `error` listener on the bound server so a
later transport error cannot take main down as an uncaught exception. Main exits non-zero rather than
leaving a live process with no window and the single-instance lock held. Independently, `RpcClient`
now settles a failed connection attempt immediately instead of waiting out its 10s `AsyncVariable`
timeout, and logs the real cause rather than `{}`. Coverage includes a real-socket test that runs on
all three CI OSes, since whether "connect() resolved" implies "a client can connect now" depends on
platform bind/listen semantics.

## API Changes

Verified against `git diff origin/main -- lib/papi-dts/papi.d.ts` at the current branch head.

- `lib/papi-dts/papi.d.ts` / `src/shared/models/rpc.interface.ts` — `IRpcHandler.connect`: TSDoc only;
  signature `(localEventHandler: EventHandler) => Promise<boolean>` unchanged. Adds the readiness MUST
  ("an implementation that opens an endpoint MUST NOT resolve `true` until that endpoint is actually
  accepting connections") and a `TODO(PT-4495)` recording that implementations disagree on the
  already-connected case.
- `lib/papi-dts/papi.d.ts` — `main/services/rpc-websocket-listener`: `RpcWebSocketListener`
  constructor changed from `constructor()` to `constructor(port?: number)`, and a
  `private readonly port` member added. Non-`@papi/` module.
- `lib/papi-dts/papi.d.ts` — `client/services/rpc-client`: one private member added,
  `private failConnectionAttempt`. Non-`@papi/` module, private member only.
- `lib/platform-bible-react`, `lib/platform-bible-utils`, `@papi/*` modules,
  `extensions/src/*/src/types/*.d.ts`: no changes.

No `@papi/` module surface changed, so nothing here is visible to extension developers.
`papi.d.ts` is regenerated with `npm run build:types`, not hand-edited.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

- [x] **`IRpcHandler.connect`'s tightened `@returns` contradicted one of its three implementations.**
      The doc claimed `false` is returned when already connected; `RpcClient.connect` returns `true`
      there, while `RpcServer` and `RpcWebSocketListener` return `false`. _(fixed during review: the
      `@returns` now states only the two contractual outcomes and carries a `TODO(PT-4495)` recording
      that implementations disagree on the already-connected case; matching `TODO(PT-4495)` comments
      added at all three divergent sites so none is findable only from the ticket. Normalizing the
      three was deliberately **not** done — PT-4495 scopes it out of this branch and replaces the
      boolean with a result type.)_
- [x] **Orphaned JSDoc in `rpc-websocket-listener.ts`.** Two JSDoc blocks sat back to back, so
      `BIND_TIMEOUT_MS` took the second, the `onServerError` block was stranded above it, and
      `onServerError` — which carries the "Node throws an uncaught exception for an unhandled `error`
      event" rationale — had no doc attached. _(fixed during review: the handler's block moved down
      onto `function onServerError`.)_
- [x] **`getFreePort`'s comment stated something untrue about a dependency the repo already has.** It
      said `detect-port` "offers no host argument"; `detect-port@2.1.0`'s `PortConfig` exposes
      `hostname?: string`. _(fixed during review: rewritten to the actual rationale — the test wants an
      OS-assigned ephemeral port, whereas `detect-port` probes upward from a starting port, so parallel
      runs and a dev app converge on the same low ports.)_

Author response: all three accepted and fixed in-review. On the first, the author retrieved PT-4495
and used it to rule out the larger fix: the ticket explicitly scopes reconciling the three
implementations out of this branch, and records that the readiness half is already done and should not
be redone. The doc-only option was chosen on that basis rather than by preference.

### Minor — Consider

- [x] **M1 — the renderer path still logged the noise the change set out to remove.** A browser
      `error` event has no `.error`, so `getErrorMessage` fell through to `JSON.stringify` → `{}`
      (`{"isTrusted":false}` in Chrome). That truthy string survived the `message ? [message] : []`
      guard and the `description ? … : context` branch, so the log read
      `…error event occurred: {} url=… readyState=…` and the same `{}` went into the rejection.
      _(fixed during review: a message is now taken only when the cause carries a string `message`, so
      the stringify fallback cannot fire; the `ws` path is unaffected and the renderer path collapses
      to the context-only branch that already existed.)_
- [x] **M2 — the bind-failure rollback does not unwind the `GET_METHODS` registration** made just
      before the bind, so the block reads as if it restores pre-`connect` state and doesn't.
      _(fixed during review: a `TODO(PT-4495)` records the open question. The registration itself was
      deliberately left — see Interview Notes, this was **not** given an invented justification.)_
- [ ] ~~**M3 — a fatal bind failure is invisible to the user.** `main.ts` logs and calls
      `app.exit(1)`: no window, no message. `dialog.showErrorBox` works before `app.whenReady()`.~~
      _(Author left it here and **added it to PT-4495's scope instead**, on the grounds that the message
      worth showing is exactly what PT-4495 makes available — with today's boolean the only honest text
      is "Unable to connect protocol handler", which tells the user nothing. The ticket has since been
      updated.)_
- [ ] ~~**M4 — the new fatal-startup path has no test**, and there is no `src/main/__tests__` harness
      for `main.ts` at all.~~ _(Author judged an Electron-bootstrap harness not economical for one
      `catch` block.)_
- [x] **M5 — the renderer's bare-`Event` branch was never exercised.** Every test fed a `ws`-shaped
      `ErrorEvent`, so `description` was always non-empty. _(fixed during review: added
      `makeBrowserErrorEvent` — prototype accessors plus Chrome's own enumerable `isTrusted` — and a
      test asserting the log carries `url=`/`readyState=` and not `isTrusted`. Verified falsifiable by
      temporarily reverting the M1 fix, which fails the test with the literal
      `{"isTrusted":false} url=… readyState=3`.)_
- [x] **M6 — the bind-timeout test hardcoded `10_000`, duplicating the un-exported `BIND_TIMEOUT_MS`.**
      Raising the constant would have produced a hang-then-vitest-timeout rather than a clear failure.
      _(fixed during review: `vi.runAllTimersAsync()` instead of a fixed advance, so the bound's length
      stays the listener's business. Exporting the constant was rejected — the file is emitted into
      `papi.d.ts`.)_
- [x] **M7 — the failed-bind cleanup exists to permit a retry, but no test proved a retry works.**
      _(fixed during review: added "can connect again after a failed bind". Verified falsifiable —
      dropping just the `connectionStatus = Disconnected` rollback line fails it with
      "expected […] to have a length of 2 but got 1".)_
- [ ] ~~**M8 — `real-socket.test.ts` binds real sockets on all three CI OSes**, a new CI dependency on
      host network behavior.~~ _(Accepted as a conscious choice; the flake vectors are already
      mitigated — OS-assigned ephemeral port, five-attempt rebind retry, 2s bound on `canConnect`.)_
- [x] **M9 — the `ws` `ErrorEvent` unwrapping is duplicated across `rpc-client.ts` and `rpc-server.ts`,
      with the same rationale paragraph verbatim in both, and the two already diverge** (server reports
      `stack`, client reports `errno`/`address`/`port`). _(fixed during review: `rpc-server.ts` now
      cross-references the rationale instead of repeating it, and the surviving copy states that the
      two report different fields on purpose — so the divergence is not "fixed" by a later reader. The
      implementations stay separate: the only home reachable from both would put a logging helper on a
      published API surface.)_
- [ ] ~~**M10 — the bind wait is a ~35-line inline promise executor** nested in an already-long
      `runExclusive`, mixing an arrow const with a `function` declaration purely so hoisting resolves a
      forward reference; extracting `waitForServerToBind(server, timeoutMs)` would remove the trick.~~
      _(Author declined: a readability refactor inside a bugfix PR.)_
- [x] **M11 — client RPC tests were split across both repo conventions.** _(fixed during review:
      `git mv`'d `rpc-client-disconnect.test.ts` out of `src/client/services/__tests__/` to sit beside
      the source, and removed the now-empty directory. Co-location is the dominant repo pattern —
      387 test files beside their source vs 33 in `__tests__`.)_
- [x] **M12 — `FakeWebSocketServer.once` delegated to `on` and never removed the handler**, so it was
      `addListener` under another name while production depends on real `once` semantics.
      _(fixed during review: genuinely one-shot, tracked via a parallel `onceHandlers` set rather than a
      self-removing wrapper — production removes those handlers by their **original** reference
      (`removeListener('error', onError)`), which a wrapper would have turned into a silent no-op.)_
- [ ] ~~**M13 — raw `readyState` literals `0`/`1`/`3` now appear in three files.**~~ _(Matches the
      existing precedent in `src/shared/data/rpc.model.ts`; a named constant is a wider cleanup than
      this PR.)_
- [x] **M14 — a few comments narrate the incident rather than the code**, and the ADR already holds
      that story. _(fixed during review: dropped "see …listening.test.ts for the failure it caused" and
      "exactly the kind of flake that gets a test deleted". A scan of every comment added in the diff
      for the remaining backward-facing patterns came back clean.)_

Author response: nine fixed in-review, five dismissed with reasons recorded above. The author declined
M10 and M13 as out-of-scope cleanups, and routed M3 into PT-4495 rather than bolting a dialog onto
this PR.

### Template Propagation

#### Shared Regions Modified

None. No changed file contains a `#region shared with` marker (the `#endregion` hits in
`src/main/main.ts` are plain organizational regions).

#### Extension Config Changes

None. No changed file is under `extensions/`.

## Positive Observations

- The fix targets the cause rather than the symptom: the server waits for `listening` instead of the
  client retrying, removing the timing window rather than absorbing it.
- The bind wait is bounded. `BIND_TIMEOUT_MS` covers the failure mode the hostname bind introduces —
  a wedged resolver emitting neither `listening` nor `error` — which would otherwise hang `connect()`
  forever while holding `connectionMutex`, with no window ever created and nothing logged.
- The post-bind `error` listener is a real catch, not defensive padding: `ws` forwards the underlying
  HTTP server's errors, and an `error` with no listener is an uncaught exception that would take main
  and every window with it.
- `rpc-websocket-listener.real-socket.test.ts` deliberately does not mock `ws`, so the "connect()
  resolved implies a client can connect now" guarantee is verified against each CI OS's real
  bind/listen and `localhost` resolution — the one dimension a stub cannot exercise, and the dimension
  this bug lived in. The lost-port race is handled with a bounded retry rather than a sleep.
- `rpc-client.test.ts`'s `makeWebSocketErrorEvent` models `ws`'s non-enumerable prototype accessors and
  self-asserts `JSON.stringify(...) === '{}'`, so the fake cannot drift into letting a stringify-only
  implementation pass.
- The `ws` fakes were consolidated into `fake-web-socket-test.util.ts` and three pre-existing suites
  migrated onto them rather than each growing its own inline stub; `FakeWebSocketServer.emit` throws on
  an unhandled `error` the way a real EventEmitter does, which is what makes the "keeps handling server
  errors once bound" assertion meaningful.
- The deadlock hazard in the failure path — `disconnect` takes the same mutex, and `close` would
  re-enter it — is spotted and defused by dropping the `close` listener before closing.
- The decision was recorded properly: `adr-papi-websocket-hostname-bind` captures the incident and the
  rejected alternatives (127.0.0.1 literal, client retry with its ~73s worst case, gating the spawn),
  and the settled rule was promoted into `Architecture.md` as a WebSocket invariant and onto the
  `IRpcHandler.connect` TSDoc — the three-place pattern `CLAUDE.md` asks for, with a real anchor.
- The one `eslint-disable` added (`no-await-in-loop` in the port-retry loop) is scoped to the loop and
  carries a justification.
- No UI code was touched, so no incidental UI edits are mixed into a transport bugfix.

## Interview Notes

**Stated purpose**: fixing the startup websocket connect, discovered while testing the onboarding
wizard from a cold install on WSL; the symptom was permanent localization errors (raw keys showing).

**Design explanation** (asked because the branch touches 16 files): the author gave a complete,
unprompted causal account — PR #2624's loopback-by-hostname security fix made the bind asynchronous
behind a DNS lookup, where `listen(port)` with no host had bound the wildcard next-tick; `connect()`
never awaited `listening`, so `networkService.initialize()` resolved while the socket was unbound and
main spawned the extension host into the gap; the extension host's one attempt was refused at +549ms
and it died 9.98s later having registered no providers, so the UI rendered raw localize keys; a
restart clears it, which is why it reads as flaky while being the norm on a cold install. The author
also noted the window is not load-dependent — a real-socket test on an idle machine with the port free
still cannot connect at the instant the old `connect()` resolved. **No areas were deferred to AI and no
uncertainty was expressed.**

**Tickets created as part of this PR** (both deliberately out of scope here, both referenced from the
code):

- **PT-4494** — the renderer skips `blockWebSocketsToPapiNetwork()` when its network service fails to
  initialize, leaving extension sandboxing off for that session.
- **PT-4495** — `connect()`'s boolean conflates "already connected" with "failed"; the three
  `IRpcHandler` implementations disagree on it; `network.service` flattens every failure into one
  message and does not roll back `jsonRpc` after a failed connect. The author retrieved the full ticket
  during the interview and used it to bound this PR's scope. PT-4495 was **also extended during this
  review** to cover M3 — a fatal startup failure exits with no user-visible message — since the text
  worth showing only becomes available once `connect()` reports a reason.

**Notable correction during the interview**: for M2 the reviewer proposed a comment asserting *why*
`GET_METHODS` is left registered. The author pushed back — that would attribute a decision to previous
authors that was never made. The diff confirms it: `registerMethod(GET_METHODS, …)` is pre-existing
context, and the entire `if (!isListening)` rollback is new on this branch, so nobody had ever faced
the question. The comment landed as a statement of the open question naming PT-4495, not a manufactured
rationale. **Worth flagging to the reviewer as a good instinct, not a problem.**

**Unresolved items**: none. Every Critical/Important finding was either fixed or dismissed with a
reason the author could articulate.

## In-Review Quality Check

All four checks green, verified by exit code and a failure-marker grep over the complete log rather
than by tailing output (the top-level scripts chain several stages plus per-workspace runs, so a tail
can show a clean final block while an earlier stage failed):

- `npm run typecheck` — **EXIT=0**. All stages ran: `typecheck:core`, `typecheck:erb`, and all 14
  workspaces. Failure-marker grep returned nothing.
- `npm run lint` — **EXIT=0**. All stages ran: `build:types`, `lint:scripts`, `lint:styles`, and every
  workspace. Zero errors. Two warnings: one `prettier/prettier` in `fake-web-socket-test.util.ts`
  caused by an in-review comment edit (cleared by the format step; `npx eslint` on that file now exits
  0), and one pre-existing `import/no-named-as-default` in `lib/platform-bible-utils`, a library this
  review did not touch — **not fixed**.
- **Format** (changed files only, not `npm run format`) — **EXIT=0**. One file rewritten:
  `fake-web-socket-test.util.ts` (comment reflow).
- `npm test` — **EXIT=0**. `test:core` 178 files / 2477 tests plus 10 workspace suites; 0 failures, 1
  pre-existing skip. Grep hits for "failed" were all test *names* (e.g. "retries a failed request…").
  The moved and new test files all ran: `src/client/services/rpc-client-disconnect.test.ts` (1),
  `rpc-websocket-listener.listening.test.ts` (5), `rpc-websocket-listener.real-socket.test.ts` (2).

Two in-review tests were additionally verified **falsifiable** by temporarily reverting the code they
cover, then restoring it — see M5 and M7.

## Suggested Review Focus

Prioritized areas for the author-reviewer meeting:

- [x] **Test the built snap package.** The bug reproduces on a cold install of a packaged build, not
      in dev — warm restarts bind long before the extension host boots. Install the snap fresh and
      confirm the onboarding wizard shows translated strings rather than raw localize keys.
- [ ] **PT-4495 was created as part of this PR** — `connect()`'s boolean conflates "already connected"
      with "failed", the three `IRpcHandler` implementations disagree, and `network.service` neither
      surfaces the cause nor rolls back `jsonRpc` after a failed connect. Confirm the doc-only
      treatment here is the right line to draw, and that the four `TODO(PT-4495)` sites cover every
      divergence. The ticket was extended during this review to also cover the silent `app.exit(1)`.
- [ ] **PT-4494 was created as part of this PR** — the renderer skips
      `blockWebSocketsToPapiNetwork()` when its network service fails to initialize, leaving extension
      sandboxing off for that session. This is a security-relevant consequence of the failure path this
      PR makes reachable; worth agreeing on its priority.
- [ ] **This PR makes the port-conflict path reachable for the first time**, and it currently ends as
      `app.exit(1)` with only a log line — no window, no message. Reproduce with `nc -l 8876` before
      launch and agree whether shipping that silent exit is acceptable pending PT-4495.
- [ ] **`BIND_TIMEOUT_MS = 10_000`** — agree the bound is right. It only fires on a wedged resolver,
      but while it runs main has no window and the user sees nothing.
- [ ] **The new real-socket CI surface** — `rpc-websocket-listener.real-socket.test.ts` binds real
      sockets on `windows-latest`, `macos-15` and `ubuntu-22.04`. Accepted deliberately; worth a second
      opinion on the macOS runner, where the E2E smoke suite is already non-blocking for load-related
      flakiness.
- [ ] **M10, declined** — the bind wait is a ~35-line inline promise executor inside `runExclusive`,
      relying on function-declaration hoisting for a forward reference. Left as a readability refactor
      unsuitable for a bugfix PR; confirm you agree, or take it now while the code is fresh.
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2737)
<!-- Reviewable:end -->

