### PR TITLE
fix(docs): unbreak Publish documentation — unresolvable TypeDoc link

### DIFF
--- a/lib/platform-bible-react/src/components/z-index.ts
+++ b/lib/platform-bible-react/src/components/z-index.ts
@@ -8,7 +8,7 @@
  * At 600 this sits above the overlay, modal, and tooltip layers, which is why content portalled out
  * of a popover needs {@link Z_INDEX_ABOVE_POPOVER} to stay visible. Two consequences are unresolved
  * and deliberately not papered over here: a tooltip triggered from inside a popover
- * ({@link Z_INDEX_TOOLTIP}, 550) renders BEHIND it, and a popover renders OVER a modal dialog
+ * (`Z_INDEX_TOOLTIP`, 550) renders BEHIND it, and a popover renders OVER a modal dialog
  * ({@link Z_INDEX_MODAL}, 500). Both want the scale re-ordered rather than another constant raised.
  */
 export const Z_INDEX_ABOVE_DOCK = 600;


### PR DESCRIPTION
## Summary

The **Publish documentation** workflow has been failing on `main` since [`bc1b47f`](https://github.com/paranext/paranext-core/commit/bc1b47fc7a6) (PT-4187, Standard View first-pass port). The docs site has not been redeployed since.

### Why review this

Not part of the current epic. `main` currently cannot publish docs at all — the workflow dies on its first step, so the GitHub Pages site (typedoc for all three libraries plus both Storybooks) is stale as of that merge. One-line fix, worth unblocking now.

### Root cause

`bc1b47f` expanded the TSDoc on `Z_INDEX_ABOVE_DOCK` and added a `{@link Z_INDEX_TOOLTIP}` reference to it. `lib/platform-bible-react/typedoc.json` has a single entry point, `src/index.ts` — and `Z_INDEX_TOOLTIP` is exported from `src/experimental.ts`, not `src/index.ts`. So the link has no target in the doc set:

```
[warning] Failed to resolve link to "Z_INDEX_TOOLTIP" in comment for Z_INDEX_ABOVE_DOCK
[warning] Found 0 errors and 1 warnings
npm error code 4
```

`typedoc.json` sets both `validation.invalidLink: true` and `treatWarningsAsErrors: true`, so that single warning exits non-zero and takes the whole job with it. The sibling `{@link Z_INDEX_MODAL}` and `{@link Z_INDEX_ABOVE_POPOVER}` references in the same comment resolve fine — those two *are* exported from `index.ts`.

## Changes

- Reference `Z_INDEX_TOOLTIP` as inline code rather than `{@link}` in the `Z_INDEX_ABOVE_DOCK` comment.

The prose is unchanged and still names the constant. The alternative — promoting `Z_INDEX_TOOLTIP` from the experimental surface into `index.ts` — would be a consumer-visible API change, which is well beyond a CI fix; the experimental surface is documented as deliberately separate with no stability guarantee.

## Testing

Ran every step of the workflow that had not yet executed on `main` (it failed at the *first* doc build, so nothing downstream had been exercised on this commit):

- [x] `lib/platform-bible-react` → `npm run build:docs` — **exit 0** (was exit 4)
- [x] `lib/platform-bible-utils` → typedoc — **exit 0**
- [x] `lib/papi-dts` → `npm run build:docs` — **exit 0**
- [x] `lib/platform-bible-react` → `npm run build:storybook` — **exit 0**
- [x] root → `npm run storybook:build` — **exit 0**
- [x] `z-index.test.ts` (3 tests) passes; prettier clean

## Risk Level

Low — a single comment line; no runtime code, no exported values, no API surface change.

## AI Involvement

AI-assisted — diagnosis, fix, and local verification of the full workflow path by Claude Opus 5; reviewed by @tjcouch-sil.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2740)
<!-- Reviewable:end -->
