### PR TITLE
PT-4496: Mount the core22 GNOME platform snap in Linux snap builds

### DIFF
--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -3021,6 +3021,62 @@ step, no automation. Just a record.
 - **What covers this ground instead:** `adr-scroll-group-hosted-in-main` and
   `adr-theme-hosted-in-main`.
 
+## adr-snap-gnome-plug-renamed-by-patch: The snap's GNOME platform plug is renamed by patching electron-builder's template, not overridden in config
+
+- **Date:** 2026-09-02
+- **Status:** Accepted
+- **Context:** electron-builder's snapcraft template hardcodes a `gnome-3-28-1804` content plug
+  (Ubuntu 18.04) at `$SNAP/gnome-platform` and rewrites only `snap.base` when `base` is set, so a
+  `core22` snap mounted a bionic GNOME platform: mismatched Mesa/DRI, libdbus and GTK/Wayland, and
+  no window on launch. The template is wrong at its own default too (`base: core20` paired with the
+  bionic plug), so this is not an artefact of overriding `base`. The first fix overrode the plug's
+  `content`/`default-provider` under the template's original *name*, which config can do. It worked
+  on cold installs and failed on upgrades: snapd matches stored connections by plug **name**, so
+  `reloadConnections` found the old connection, failed the policy re-check against the new
+  `content`, logged `cannot refresh static attributes of the connection`, revived it with the old
+  attributes anyway, and auto-connected the new one alongside. Two content plugs then compete for
+  one mount point and snapd renames one aside to break the tie — arbitrarily. Measured on Ubuntu
+  22.04: 16 in-place upgrades launched 9 times and segfaulted 7, from an identical build.
+- **Decision:** Rename the plug so the old name no longer exists for snapd to match, which lets the
+  stale connection be dropped rather than revived. electron-builder's config **cannot** express
+  this — it merges config plugs into the template's map by key (`snap.plugs[plugName] =
+  plugOptions`), so it can replace a template entry but never rename or remove one, and introducing
+  a second key leaves both plugs declared. The rename therefore lives in a `patch-package` patch on
+  `app-builder-lib`'s template. `base` is the single source of truth for the pairing, enforced
+  against the patched template and the workflow runners by
+  `.erb/scripts/electron-builder-snap-config.test.ts`.
+- **Alternatives:** Override the attributes under the template's name — rejected, empirically: it
+  makes every existing install a coin flip. Declare a second, correctly-named plug in config —
+  rejected: config cannot remove the template's plug, so both ship and collide. Neutralise the
+  template's plug by retargeting it to an unused mount point and adding a correct one — rejected:
+  ships a permanent vestigial plug and relies on snapd tolerating a stale connection to a bogus
+  target. A `post-refresh` hook that disconnects the stale plug — rejected: strict confinement has
+  no `snapd-control`.
+- **Consequences:** paratext-10-studio *creates* `patches/app-builder-lib+26.7.0.patch` in this repo
+  from its own `repo-patches/paranext-core.patch`, to add mercurial snap parts to the same template.
+  A second core-owned patch at that same path would collide — the studio applies repo patches with
+  `git apply --3way`, which turns an add/add case into conflict markers written *into the patch
+  file*, leaving patch-package unable to parse it. **patch-package supports sequenced patches**
+  (`<pkg>+<version>+<NNN>+<description>.patch`), so this patch is named
+  `app-builder-lib+26.7.0+002+rename-gnome-platform-plug.patch` and occupies a different path
+  entirely. Both patches then apply in sequence to the same template — verified with the studio's
+  real patch body: the result carries the mercurial parts *and* `gnome-42-2204`. There is therefore
+  **no collision, no forced merge order and no companion studio change**. The two hunks touch
+  disjoint regions (~line 21 vs ~line 130), so apply order does not matter.
+  Two hazards come with that. Regenerating this patch later with plain
+  `npx patch-package app-builder-lib`, without `--append`, collapses the sequence back into a single
+  unsequenced `app-builder-lib+26.7.0.patch` — reintroducing exactly the collision the sequenced
+  name avoids; regenerate with `--append`, or rename the output back. And a renamed plug is a new
+  content tag from the snap store's perspective, so store-granted auto-connection for it should be
+  confirmed on a published build rather than inferred from sideload testing, which bypasses store
+  assertions.
+- **Source:** PT-4496. PR #2747 review raised the upgrade path, which the original cold-install
+  diagnosis had not considered; its re-review then established the sequenced-patch mechanism above,
+  correcting an earlier belief that patch-package allows only one patch per package+version and that
+  a coordinated studio merge was therefore unavoidable. Verification report, including the 12 renamed
+  cycles against live controls and the `snap disconnect` repair for an already-broken install:
+  https://claude.ai/code/artifact/cc4c4c08-2e75-4dd5-855a-312fc4a6a57e
+
 ## adr-startup-sync-readiness-gate: Core owns startup-sync ordering and gates it on project-data-provider readiness
 
 - **Date:** 2026-08-16
@@ -3769,59 +3825,3 @@ step, no automation. Just a record.
   the cost of the signal being an approximation (one service standing in for all of them) rather than
   a true invariant.
 - **Source:** PT-4275 (multi-window epic); introduced in PR #2621.
-
-## adr-snap-gnome-plug-renamed-by-patch: The snap's GNOME platform plug is renamed by patching electron-builder's template, not overridden in config
-
-- **Date:** 2026-09-02
-- **Status:** Accepted
-- **Context:** electron-builder's snapcraft template hardcodes a `gnome-3-28-1804` content plug
-  (Ubuntu 18.04) at `$SNAP/gnome-platform` and rewrites only `snap.base` when `base` is set, so a
-  `core22` snap mounted a bionic GNOME platform: mismatched Mesa/DRI, libdbus and GTK/Wayland, and
-  no window on launch. The template is wrong at its own default too (`base: core20` paired with the
-  bionic plug), so this is not an artefact of overriding `base`. The first fix overrode the plug's
-  `content`/`default-provider` under the template's original *name*, which config can do. It worked
-  on cold installs and failed on upgrades: snapd matches stored connections by plug **name**, so
-  `reloadConnections` found the old connection, failed the policy re-check against the new
-  `content`, logged `cannot refresh static attributes of the connection`, revived it with the old
-  attributes anyway, and auto-connected the new one alongside. Two content plugs then compete for
-  one mount point and snapd renames one aside to break the tie — arbitrarily. Measured on Ubuntu
-  22.04: 16 in-place upgrades launched 9 times and segfaulted 7, from an identical build.
-- **Decision:** Rename the plug so the old name no longer exists for snapd to match, which lets the
-  stale connection be dropped rather than revived. electron-builder's config **cannot** express
-  this — it merges config plugs into the template's map by key (`snap.plugs[plugName] =
-  plugOptions`), so it can replace a template entry but never rename or remove one, and introducing
-  a second key leaves both plugs declared. The rename therefore lives in a `patch-package` patch on
-  `app-builder-lib`'s template. `base` is the single source of truth for the pairing, enforced
-  against the patched template and the workflow runners by
-  `.erb/scripts/electron-builder-snap-config.test.ts`.
-- **Alternatives:** Override the attributes under the template's name — rejected, empirically: it
-  makes every existing install a coin flip. Declare a second, correctly-named plug in config —
-  rejected: config cannot remove the template's plug, so both ship and collide. Neutralise the
-  template's plug by retargeting it to an unused mount point and adding a correct one — rejected:
-  ships a permanent vestigial plug and relies on snapd tolerating a stale connection to a bogus
-  target. A `post-refresh` hook that disconnects the stale plug — rejected: strict confinement has
-  no `snapd-control`.
-- **Consequences:** paratext-10-studio *creates* `patches/app-builder-lib+26.7.0.patch` in this repo
-  from its own `repo-patches/paranext-core.patch`, to add mercurial snap parts to the same template.
-  A second core-owned patch at that same path would collide — the studio applies repo patches with
-  `git apply --3way`, which turns an add/add case into conflict markers written *into the patch
-  file*, leaving patch-package unable to parse it. **patch-package supports sequenced patches**
-  (`<pkg>+<version>+<NNN>+<description>.patch`), so this patch is named
-  `app-builder-lib+26.7.0+002+rename-gnome-platform-plug.patch` and occupies a different path
-  entirely. Both patches then apply in sequence to the same template — verified with the studio's
-  real patch body: the result carries the mercurial parts *and* `gnome-42-2204`. There is therefore
-  **no collision, no forced merge order and no companion studio change**. The two hunks touch
-  disjoint regions (~line 21 vs ~line 130), so apply order does not matter.
-  Two hazards come with that. Regenerating this patch later with plain
-  `npx patch-package app-builder-lib`, without `--append`, collapses the sequence back into a single
-  unsequenced `app-builder-lib+26.7.0.patch` — reintroducing exactly the collision the sequenced
-  name avoids; regenerate with `--append`, or rename the output back. And a renamed plug is a new
-  content tag from the snap store's perspective, so store-granted auto-connection for it should be
-  confirmed on a published build rather than inferred from sideload testing, which bypasses store
-  assertions.
-- **Source:** PT-4496. PR #2747 review raised the upgrade path, which the original cold-install
-  diagnosis had not considered; its re-review then established the sequenced-patch mechanism above,
-  correcting an earlier belief that patch-package allows only one patch per package+version and that
-  a coordinated studio merge was therefore unavoidable. Verification report, including the 12 renamed
-  cycles against live controls and the `snap disconnect` repair for an already-broken install:
-  https://claude.ai/code/artifact/cc4c4c08-2e75-4dd5-855a-312fc4a6a57e

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -3769,3 +3769,59 @@ step, no automation. Just a record.
   the cost of the signal being an approximation (one service standing in for all of them) rather than
   a true invariant.
 - **Source:** PT-4275 (multi-window epic); introduced in PR #2621.
+
+## adr-snap-gnome-plug-renamed-by-patch: The snap's GNOME platform plug is renamed by patching electron-builder's template, not overridden in config
+
+- **Date:** 2026-09-02
+- **Status:** Accepted
+- **Context:** electron-builder's snapcraft template hardcodes a `gnome-3-28-1804` content plug
+  (Ubuntu 18.04) at `$SNAP/gnome-platform` and rewrites only `snap.base` when `base` is set, so a
+  `core22` snap mounted a bionic GNOME platform: mismatched Mesa/DRI, libdbus and GTK/Wayland, and
+  no window on launch. The template is wrong at its own default too (`base: core20` paired with the
+  bionic plug), so this is not an artefact of overriding `base`. The first fix overrode the plug's
+  `content`/`default-provider` under the template's original *name*, which config can do. It worked
+  on cold installs and failed on upgrades: snapd matches stored connections by plug **name**, so
+  `reloadConnections` found the old connection, failed the policy re-check against the new
+  `content`, logged `cannot refresh static attributes of the connection`, revived it with the old
+  attributes anyway, and auto-connected the new one alongside. Two content plugs then compete for
+  one mount point and snapd renames one aside to break the tie — arbitrarily. Measured on Ubuntu
+  22.04: 16 in-place upgrades launched 9 times and segfaulted 7, from an identical build.
+- **Decision:** Rename the plug so the old name no longer exists for snapd to match, which lets the
+  stale connection be dropped rather than revived. electron-builder's config **cannot** express
+  this — it merges config plugs into the template's map by key (`snap.plugs[plugName] =
+  plugOptions`), so it can replace a template entry but never rename or remove one, and introducing
+  a second key leaves both plugs declared. The rename therefore lives in a `patch-package` patch on
+  `app-builder-lib`'s template. `base` is the single source of truth for the pairing, enforced
+  against the patched template and the workflow runners by
+  `.erb/scripts/electron-builder-snap-config.test.ts`.
+- **Alternatives:** Override the attributes under the template's name — rejected, empirically: it
+  makes every existing install a coin flip. Declare a second, correctly-named plug in config —
+  rejected: config cannot remove the template's plug, so both ship and collide. Neutralise the
+  template's plug by retargeting it to an unused mount point and adding a correct one — rejected:
+  ships a permanent vestigial plug and relies on snapd tolerating a stale connection to a bogus
+  target. A `post-refresh` hook that disconnects the stale plug — rejected: strict confinement has
+  no `snapd-control`.
+- **Consequences:** paratext-10-studio *creates* `patches/app-builder-lib+26.7.0.patch` in this repo
+  from its own `repo-patches/paranext-core.patch`, to add mercurial snap parts to the same template.
+  A second core-owned patch at that same path would collide — the studio applies repo patches with
+  `git apply --3way`, which turns an add/add case into conflict markers written *into the patch
+  file*, leaving patch-package unable to parse it. **patch-package supports sequenced patches**
+  (`<pkg>+<version>+<NNN>+<description>.patch`), so this patch is named
+  `app-builder-lib+26.7.0+002+rename-gnome-platform-plug.patch` and occupies a different path
+  entirely. Both patches then apply in sequence to the same template — verified with the studio's
+  real patch body: the result carries the mercurial parts *and* `gnome-42-2204`. There is therefore
+  **no collision, no forced merge order and no companion studio change**. The two hunks touch
+  disjoint regions (~line 21 vs ~line 130), so apply order does not matter.
+- **Footgun:** regenerating this patch later with plain `npx patch-package app-builder-lib`, without
+  `--append`, collapses the sequence back into a single unsequenced `app-builder-lib+26.7.0.patch`
+  — which reintroduces exactly the collision the sequenced name avoids. Regenerate with `--append`,
+  or rename the output back.
+- **Also:** a renamed plug is a new content tag from the snap store's perspective, so store-granted
+  auto-connection for it should be confirmed on a published build rather than inferred from sideload
+  testing, which bypasses store assertions.
+- **Source:** PT-4496. PR #2747 review raised the upgrade path, which the original cold-install
+  diagnosis had not considered; its re-review then established the sequenced-patch mechanism above,
+  correcting an earlier belief that patch-package allows only one patch per package+version and that
+  a coordinated studio merge was therefore unavoidable. Verification report, including the 12 renamed
+  cycles against live controls and the `snap disconnect` repair for an already-broken install:
+  https://claude.ai/code/artifact/cc4c4c08-2e75-4dd5-855a-312fc4a6a57e

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -3812,13 +3812,13 @@ step, no automation. Just a record.
   real patch body: the result carries the mercurial parts *and* `gnome-42-2204`. There is therefore
   **no collision, no forced merge order and no companion studio change**. The two hunks touch
   disjoint regions (~line 21 vs ~line 130), so apply order does not matter.
-- **Footgun:** regenerating this patch later with plain `npx patch-package app-builder-lib`, without
-  `--append`, collapses the sequence back into a single unsequenced `app-builder-lib+26.7.0.patch`
-  — which reintroduces exactly the collision the sequenced name avoids. Regenerate with `--append`,
-  or rename the output back.
-- **Also:** a renamed plug is a new content tag from the snap store's perspective, so store-granted
-  auto-connection for it should be confirmed on a published build rather than inferred from sideload
-  testing, which bypasses store assertions.
+  Two hazards come with that. Regenerating this patch later with plain
+  `npx patch-package app-builder-lib`, without `--append`, collapses the sequence back into a single
+  unsequenced `app-builder-lib+26.7.0.patch` — reintroducing exactly the collision the sequenced
+  name avoids; regenerate with `--append`, or rename the output back. And a renamed plug is a new
+  content tag from the snap store's perspective, so store-granted auto-connection for it should be
+  confirmed on a published build rather than inferred from sideload testing, which bypasses store
+  assertions.
 - **Source:** PT-4496. PR #2747 review raised the upgrade path, which the original cold-install
   diagnosis had not considered; its re-review then established the sequenced-patch mechanism above,
   correcting an earlier belief that patch-package allows only one patch per package+version and that

--- a/.erb/scripts/electron-builder-snap-config.test.ts
+++ b/.erb/scripts/electron-builder-snap-config.test.ts
@@ -1,0 +1,126 @@
+// This covers `electron-builder.json5` at the repo root, not a sibling module. It lives here
+// because `vitest.config.ts` only collects tests from `src/**`, `tools/pt9-css-converter/src/**`
+// and `.erb/scripts/**`, and build config belongs to the last of those.
+
+import { readFileSync } from 'fs';
+import path from 'path';
+import JSON5 from 'json5';
+
+/**
+ * The GNOME platform content snap that pairs with each snap base.
+ *
+ * These must stay in step: a base and a platform snap from different Ubuntu releases put the app's
+ * staged libraries and the mounted platform libraries out of sync, and the app fails to launch. The
+ * full rationale, and why the plug is declared the way it is, lives beside the plug itself in
+ * `electron-builder.json5`.
+ */
+const GNOME_PLATFORM_BY_BASE: Readonly<Record<string, string>> = {
+  core18: 'gnome-3-28-1804',
+  core20: 'gnome-3-38-2004',
+  core22: 'gnome-42-2204',
+  core24: 'gnome-46-2404',
+};
+
+/** Mount point the snap's launch scripts read the GNOME platform from. */
+const GNOME_PLATFORM_TARGET = '$SNAP/gnome-platform';
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+
+type PlugDescriptor = {
+  interface?: string;
+  content?: string;
+  target?: string;
+  'default-provider'?: string;
+};
+
+/** Entries in `snap.plugs` are either a bare interface name or a keyed plug definition. */
+type SnapPlug = string | Record<string, PlugDescriptor>;
+
+type ElectronBuilderConfig = { snap: { base: string; plugs: SnapPlug[] } };
+
+function readSnapConfig(): ElectronBuilderConfig['snap'] {
+  const contents = readFileSync(path.join(REPO_ROOT, 'electron-builder.json5'), 'utf8');
+  return JSON5.parse<ElectronBuilderConfig>(contents).snap;
+}
+
+/** The key and definition of whichever content plug mounts the GNOME platform snap. */
+function findGnomePlatformPlug(plugs: SnapPlug[]) {
+  return plugs
+    .flatMap((plug) => (typeof plug === 'string' ? [] : Object.entries(plug)))
+    .map(([key, descriptor]) => ({ key, descriptor }))
+    .find(({ descriptor }) => descriptor?.target === GNOME_PLATFORM_TARGET);
+}
+
+/**
+ * Electron-builder's snapcraft template, resolved through the module graph rather than an assumed
+ * `node_modules` layout — `app-builder-lib` is a transitive dependency of `electron-builder`, so
+ * nothing guarantees npm hoists it to the repo root. `templates/` is package-internal, so a bare
+ * read failure is ambiguous; surface it as a prompt to re-check the override instead.
+ */
+function readSnapTemplate(): string {
+  try {
+    const packageRoot = path.dirname(require.resolve('app-builder-lib/package.json'));
+    return readFileSync(path.join(packageRoot, 'templates', 'snap', 'snapcraft.yaml'), 'utf8');
+  } catch (error) {
+    throw new Error(
+      "Could not read app-builder-lib's templates/snap/snapcraft.yaml. The GNOME platform plug in " +
+        'electron-builder.json5 overrides an entry from that template, so if the template has ' +
+        `moved or changed shape, check that the override still applies. Cause: ${error}`,
+    );
+  }
+}
+
+/**
+ * The key electron-builder's template declares its GNOME content plug under.
+ *
+ * Our config can REPLACE a template plug entry but never delete one, so the override has to reuse
+ * this exact key. Declaring it under a different name leaves the template's plug in place and
+ * produces two content plugs competing for the same mount point.
+ */
+function readTemplateGnomePlugKey(): string | undefined {
+  const lines = readSnapTemplate().split('\n');
+  const targetIndex = lines.findIndex((line) => line.trim() === `target: ${GNOME_PLATFORM_TARGET}`);
+  if (targetIndex < 0) return undefined;
+
+  // The plug's key is the nearest two-space-indented mapping key above its `target:` line.
+  const keyLine = lines
+    .slice(0, targetIndex)
+    .reverse()
+    .find((line) => /^ {2}\S+:\s*$/.test(line));
+  return keyLine ? /^ {2}(\S+):\s*$/.exec(keyLine)?.[1] : undefined;
+}
+
+describe('electron-builder snap configuration', () => {
+  it('declares a snap base whose matching GNOME platform snap is known', () => {
+    // Bumping `base` without teaching this map the new pairing should fail loudly rather than
+    // silently leaving the previous release's platform snap mounted.
+    expect(Object.keys(GNOME_PLATFORM_BY_BASE)).toContain(readSnapConfig().base);
+  });
+
+  it('mounts the GNOME platform content snap matching snap.base', () => {
+    const { base, plugs } = readSnapConfig();
+    const plug = findGnomePlatformPlug(plugs);
+    if (!plug)
+      throw new Error(
+        `electron-builder.json5 declares no content plug targeting ${GNOME_PLATFORM_TARGET}, so ` +
+          `the template's Ubuntu 18.04 default is left in place.`,
+      );
+
+    const expected = GNOME_PLATFORM_BY_BASE[base];
+    // snapd matches content plugs on the `content` attribute, which defaults to the plug's key.
+    // Overriding `content` is what actually rebinds the plug; `default-provider` only decides
+    // which snap gets installed to satisfy it.
+    expect(plug.descriptor.content).toBe(expected);
+    expect(plug.descriptor['default-provider']).toBe(expected);
+  });
+
+  it("overrides the template's GNOME plug under the template's own key", () => {
+    // If an electron-builder upgrade renames this plug or fixes the template itself, the override
+    // silently stops applying. Failing here is the signal to revisit it.
+    const templateKey = readTemplateGnomePlugKey();
+    // Both sides can be absent, and `undefined === undefined` would pass while asserting nothing.
+    // Pin the template side down first so the comparison below always has something to be wrong about.
+    expect(templateKey).toBeDefined();
+    expect(findGnomePlatformPlug(readSnapConfig().plugs)?.key).toBe(templateKey);
+  });
+});

--- a/.erb/scripts/electron-builder-snap-config.test.ts
+++ b/.erb/scripts/electron-builder-snap-config.test.ts
@@ -1,18 +1,21 @@
-// This covers `electron-builder.json5` at the repo root, not a sibling module. It lives here
-// because `vitest.config.ts` only collects tests from `src/**`, `tools/pt9-css-converter/src/**`
-// and `.erb/scripts/**`, and build config belongs to the last of those.
+// @vitest-environment node
 
-import { readFileSync } from 'fs';
+// This covers the snap packaging setup rather than a sibling module: `electron-builder.json5` at
+// the repo root plus the snapcraft template that the `app-builder-lib` patch under `patches/`
+// rewrites. It lives here because `vitest.config.ts` only collects tests from `src/**`,
+// `tools/pt9-css-converter/src/**` and `.erb/scripts/**`, and build config belongs to the last.
+
+import { readdirSync, readFileSync } from 'fs';
 import path from 'path';
 import JSON5 from 'json5';
+import { parse as parseYaml } from 'yaml';
 
 /**
  * The GNOME platform content snap that pairs with each snap base.
  *
  * These must stay in step: a base and a platform snap from different Ubuntu releases put the app's
  * staged libraries and the mounted platform libraries out of sync, and the app fails to launch. The
- * full rationale, and why the plug is declared the way it is, lives beside the plug itself in
- * `electron-builder.json5`.
+ * full rationale lives beside `base` in `electron-builder.json5`.
  */
 const GNOME_PLATFORM_BY_BASE: Readonly<Record<string, string>> = {
   core18: 'gnome-3-28-1804',
@@ -21,41 +24,126 @@ const GNOME_PLATFORM_BY_BASE: Readonly<Record<string, string>> = {
   core24: 'gnome-46-2404',
 };
 
+/**
+ * The Ubuntu runner each snap base is built on.
+ *
+ * Parts of the snap are assembled in the host OS and parts in the snap environment, so a base that
+ * disagrees with the runner mixes libraries from two Ubuntu releases into one snap.
+ *
+ * The `core18` and `core20` rows are historical: GitHub Actions has retired both of those runner
+ * images, so those pairings document what was true rather than something reachable today.
+ */
+const UBUNTU_RUNNER_BY_BASE: Readonly<Record<string, string>> = {
+  core18: 'ubuntu-18.04',
+  core20: 'ubuntu-20.04',
+  core22: 'ubuntu-22.04',
+  core24: 'ubuntu-24.04',
+};
+
+/** Workflows that pin the Linux runner the snap is built on, via an `OS_LINUX` env value. */
+const LINUX_RUNNER_WORKFLOWS = ['test.yml', 'package-main.yml', 'publish.yml'];
+
 /** Mount point the snap's launch scripts read the GNOME platform from. */
 const GNOME_PLATFORM_TARGET = '$SNAP/gnome-platform';
 
 const REPO_ROOT = path.join(__dirname, '..', '..');
 
-type PlugDescriptor = {
+/**
+ * The attributes of a single plug.
+ *
+ * Deliberately not called `PlugDescriptor`: electron-builder exports that name for the OUTER map of
+ * plug-name to attributes, so reusing it here for the inner bag would read backwards to anyone who
+ * knows the library.
+ */
+type PlugAttributes = {
   interface?: string;
-  content?: string;
   target?: string;
   'default-provider'?: string;
 };
 
-/** Entries in `snap.plugs` are either a bare interface name or a keyed plug definition. */
-type SnapPlug = string | Record<string, PlugDescriptor>;
+/** A found plug, keyed by the name it is declared under. */
+type NamedPlug = { key: string; descriptor: PlugAttributes };
 
-type ElectronBuilderConfig = { snap: { base: string; plugs: SnapPlug[] } };
-
-function readSnapConfig(): ElectronBuilderConfig['snap'] {
-  const contents = readFileSync(path.join(REPO_ROOT, 'electron-builder.json5'), 'utf8');
-  return JSON5.parse<ElectronBuilderConfig>(contents).snap;
+/** A plain object, for walking into parsed config and YAML without asserting a shape. */
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && !!value && !Array.isArray(value);
 }
 
-/** The key and definition of whichever content plug mounts the GNOME platform snap. */
-function findGnomePlatformPlug(plugs: SnapPlug[]) {
-  return plugs
-    .flatMap((plug) => (typeof plug === 'string' ? [] : Object.entries(plug)))
+/**
+ * A plug map holds one descriptor per plug name. A plug declared as a bare name has no descriptor
+ * at all — electron-builder stores an empty value for it, and YAML yields one for `key:` with
+ * nothing after it — so entries are treated as optional and absent ones are filtered out below.
+ */
+function isPlugMap(value: unknown): value is Record<string, PlugAttributes | undefined> {
+  return isRecord(value);
+}
+
+let cachedConfig: unknown;
+
+/** `electron-builder.json5`, parsed once for every reader below. */
+function readConfig(): unknown {
+  cachedConfig ??= JSON5.parse(
+    readFileSync(path.join(REPO_ROOT, 'electron-builder.json5'), 'utf8'),
+  );
+  return cachedConfig;
+}
+
+/**
+ * `snap.base` from `electron-builder.json5`.
+ *
+ * Validated rather than narrowed: a config restructure should say so, not surface as a bare
+ * TypeError from somewhere downstream.
+ */
+function readSnapBase(): string {
+  const config = readConfig();
+  const base: unknown = isRecord(config) && isRecord(config.snap) ? config.snap.base : undefined;
+  if (typeof base !== 'string')
+    throw new Error(
+      'electron-builder.json5 has no string `snap.base`. If the config was restructured, this ' +
+        'test and the GNOME platform pairing it guards both need revisiting.',
+    );
+  return base;
+}
+
+/**
+ * Every plug that mounts something at `$SNAP/gnome-platform` in the snap electron-builder would
+ * actually emit, gathered from both places one can be declared: electron-builder's snapcraft
+ * template, and this repo's own `snap.plugs`.
+ *
+ * Both are collected because a build-time collision is what breaks the snap: two plugs competing
+ * for this one mount point make snapd rename one aside, arbitrarily, at install time. They are
+ * merged by key last-wins to mirror electron-builder's own merge (`snap.plugs[plugName] =
+ * plugOptions`), so a config entry that legitimately overrides the template's plug under the same
+ * key stays one plug here, exactly as it would in the build.
+ */
+function findGnomePlatformPlugs(): NamedPlug[] {
+  const template: unknown = parseYaml(readSnapTemplate());
+  const templatePlugs = isRecord(template) && isPlugMap(template.plugs) ? template.plugs : {};
+
+  const config = readConfig();
+  // `snap.plugs` accepts a bare plug map as well as an array of names and maps.
+  const rawConfigPlugs: unknown =
+    isRecord(config) && isRecord(config.snap) ? config.snap.plugs : undefined;
+  const configPlugEntries = (Array.isArray(rawConfigPlugs) ? rawConfigPlugs : [rawConfigPlugs])
+    .filter(isPlugMap)
+    .flatMap((plugMap) => Object.entries(plugMap));
+
+  const mergedByKey = new Map(
+    [...Object.entries(templatePlugs), ...configPlugEntries].filter(
+      (entry): entry is [string, PlugAttributes] => Boolean(entry[1]),
+    ),
+  );
+
+  return [...mergedByKey]
     .map(([key, descriptor]) => ({ key, descriptor }))
-    .find(({ descriptor }) => descriptor?.target === GNOME_PLATFORM_TARGET);
+    .filter(({ descriptor }) => descriptor.target === GNOME_PLATFORM_TARGET);
 }
 
 /**
  * Electron-builder's snapcraft template, resolved through the module graph rather than an assumed
  * `node_modules` layout — `app-builder-lib` is a transitive dependency of `electron-builder`, so
  * nothing guarantees npm hoists it to the repo root. `templates/` is package-internal, so a bare
- * read failure is ambiguous; surface it as a prompt to re-check the override instead.
+ * read failure is ambiguous; surface it as a prompt to re-check the patch instead.
  */
 function readSnapTemplate(): string {
   try {
@@ -63,64 +151,93 @@ function readSnapTemplate(): string {
     return readFileSync(path.join(packageRoot, 'templates', 'snap', 'snapcraft.yaml'), 'utf8');
   } catch (error) {
     throw new Error(
-      "Could not read app-builder-lib's templates/snap/snapcraft.yaml. The GNOME platform plug in " +
-        'electron-builder.json5 overrides an entry from that template, so if the template has ' +
-        `moved or changed shape, check that the override still applies. Cause: ${error}`,
+      "Could not read app-builder-lib's templates/snap/snapcraft.yaml. " +
+        'The app-builder-lib patch under patches/ rewrites the GNOME platform plug in that ' +
+        'template, so if it has moved or changed shape, check that the patch still applies. ' +
+        `Cause: ${error}`,
     );
   }
 }
 
 /**
- * The key electron-builder's template declares its GNOME content plug under.
- *
- * Our config can REPLACE a template plug entry but never delete one, so the override has to reuse
- * this exact key. Declaring it under a different name leaves the template's plug in place and
- * produces two content plugs competing for the same mount point.
+ * The `app-builder-lib` patch files, found by glob rather than by name: patch-package stamps the
+ * package version into the filename, so the name changes on every `electron-builder` bump.
  */
-function readTemplateGnomePlugKey(): string | undefined {
-  const lines = readSnapTemplate().split('\n');
-  const targetIndex = lines.findIndex((line) => line.trim() === `target: ${GNOME_PLATFORM_TARGET}`);
-  if (targetIndex < 0) return undefined;
+function readAppBuilderLibPatches(): string[] {
+  const patchesDir = path.join(REPO_ROOT, 'patches');
+  return readdirSync(patchesDir)
+    .filter((name) => /^app-builder-lib\+.*\.patch$/.test(name))
+    .map((name) => readFileSync(path.join(patchesDir, name), 'utf8'));
+}
 
-  // The plug's key is the nearest two-space-indented mapping key above its `target:` line.
-  const keyLine = lines
-    .slice(0, targetIndex)
-    .reverse()
-    .find((line) => /^ {2}\S+:\s*$/.test(line));
-  return keyLine ? /^ {2}(\S+):\s*$/.exec(keyLine)?.[1] : undefined;
+/** The `OS_LINUX` runner each snap-building workflow pins, named so a failure says which one. */
+function readWorkflowLinuxRunners(): { workflow: string; runner: string | undefined }[] {
+  return LINUX_RUNNER_WORKFLOWS.map((workflow) => {
+    const contents = readFileSync(path.join(REPO_ROOT, '.github', 'workflows', workflow), 'utf8');
+    return { workflow, runner: /^\s*OS_LINUX:\s*(\S+)/m.exec(contents)?.[1] };
+  });
 }
 
 describe('electron-builder snap configuration', () => {
-  it('declares a snap base whose matching GNOME platform snap is known', () => {
-    // Bumping `base` without teaching this map the new pairing should fail loudly rather than
-    // silently leaving the previous release's platform snap mounted.
-    expect(Object.keys(GNOME_PLATFORM_BY_BASE)).toContain(readSnapConfig().base);
+  it('declares a snap base whose matching GNOME platform snap and runner are known', () => {
+    // Bumping `base` without teaching these maps the new pairings should fail loudly rather than
+    // silently leaving the previous release's platform snap or runner in place.
+    const base = readSnapBase();
+    expect(Object.keys(GNOME_PLATFORM_BY_BASE)).toContain(base);
+    expect(Object.keys(UBUNTU_RUNNER_BY_BASE)).toContain(base);
   });
 
-  it('mounts the GNOME platform content snap matching snap.base', () => {
-    const { base, plugs } = readSnapConfig();
-    const plug = findGnomePlatformPlug(plugs);
-    if (!plug)
-      throw new Error(
-        `electron-builder.json5 declares no content plug targeting ${GNOME_PLATFORM_TARGET}, so ` +
-          `the template's Ubuntu 18.04 default is left in place.`,
-      );
-
-    const expected = GNOME_PLATFORM_BY_BASE[base];
-    // snapd matches content plugs on the `content` attribute, which defaults to the plug's key.
-    // Overriding `content` is what actually rebinds the plug; `default-provider` only decides
-    // which snap gets installed to satisfy it.
-    expect(plug.descriptor.content).toBe(expected);
-    expect(plug.descriptor['default-provider']).toBe(expected);
+  it('keeps a confinement that ships plugs at all', () => {
+    // Under `confinement: 'classic'` electron-builder deletes the entire plugs map (`delete
+    // snap.plugs`), so the GNOME platform plug would vanish from the snap while every other
+    // assertion in this file still passed — they read the config and the template, not the effect
+    // of confinement on them. Absent is fine; the template's default is strict.
+    const config = readConfig();
+    const confinement: unknown =
+      isRecord(config) && isRecord(config.snap) ? config.snap.confinement : undefined;
+    expect(confinement).not.toBe('classic');
   });
 
-  it("overrides the template's GNOME plug under the template's own key", () => {
-    // If an electron-builder upgrade renames this plug or fixes the template itself, the override
-    // silently stops applying. Failing here is the signal to revisit it.
-    const templateKey = readTemplateGnomePlugKey();
-    // Both sides can be absent, and `undefined === undefined` would pass while asserting nothing.
-    // Pin the template side down first so the comparison below always has something to be wrong about.
-    expect(templateKey).toBeDefined();
-    expect(findGnomePlatformPlug(readSnapConfig().plugs)?.key).toBe(templateKey);
+  it('builds the snap on the Ubuntu runner matching snap.base', () => {
+    // `base` is coupled to three things: the GNOME platform snap (asserted below), and the runner
+    // pinned by every workflow that builds a snap. That second coupling was comment-only until
+    // now, so a `base` bump could leave the runners behind and mix two Ubuntu releases into one
+    // snap -- the same class of mismatch this whole guard exists to prevent.
+    const expected = UBUNTU_RUNNER_BY_BASE[readSnapBase()];
+    expect(readWorkflowLinuxRunners()).toEqual(
+      LINUX_RUNNER_WORKFLOWS.map((workflow) => ({ workflow, runner: expected })),
+    );
+  });
+
+  it('mounts exactly one GNOME platform plug, named for snap.base', () => {
+    const expected = GNOME_PLATFORM_BY_BASE[readSnapBase()];
+    const plugs = findGnomePlatformPlugs();
+
+    // Asserting on the KEY, and on there being exactly one, is what makes this guard meaningful.
+    // snapd matches stored connections by plug name across a refresh, so a plug left under an
+    // older name revives the stale connection on every existing install — and a second plug under
+    // any other name leaves two competing for this mount point, which snapd breaks by renaming one
+    // aside arbitrarily. Both failure modes ship an app that may or may not start.
+    // A failure here means either the patch stopped renaming the template plug, or something in
+    // `snap.plugs` declared a second plug on this mount point. Both ship a snap that may not start.
+    expect(plugs.map((plug) => plug.key)).toEqual([expected]);
+    expect(plugs[0].descriptor.interface).toBe('content');
+    // A name/provider mismatch means snapd installs the wrong platform snap to satisfy the plug.
+    expect(plugs[0].descriptor['default-provider']).toBe(expected);
+  });
+
+  it('keeps the rename in a committed patch, not just in an installed node_modules', () => {
+    // The assertion above reads the INSTALLED template, which is what electron-builder consumes —
+    // but that stays satisfied by a warm `node_modules` even if the patch file were deleted. A
+    // fresh `npm ci` in CI is the real check; this catches the same mistake locally. It confirms
+    // the patch is present and names the right plug, not that it would still apply.
+    const expected = GNOME_PLATFORM_BY_BASE[readSnapBase()];
+    const patches = readAppBuilderLibPatches();
+
+    // Zero patches means a fresh `npm ci` would ship the Ubuntu 18.04 plug. A patch that exists
+    // but does not mention the expected name usually means it was regenerated with plain
+    // `npx patch-package app-builder-lib`, without `--append`, which drops the rename.
+    expect(patches.length).toBeGreaterThan(0);
+    expect(patches.some((patch) => patch.includes(expected))).toBe(true);
   });
 });

--- a/.erb/scripts/electron-builder-snap-config.test.ts
+++ b/.erb/scripts/electron-builder-snap-config.test.ts
@@ -217,9 +217,9 @@ describe('electron-builder snap configuration', () => {
     // snapd matches stored connections by plug name across a refresh, so a plug left under an
     // older name revives the stale connection on every existing install — and a second plug under
     // any other name leaves two competing for this mount point, which snapd breaks by renaming one
-    // aside arbitrarily. Both failure modes ship an app that may or may not start.
-    // A failure here means either the patch stopped renaming the template plug, or something in
-    // `snap.plugs` declared a second plug on this mount point. Both ship a snap that may not start.
+    // aside arbitrarily. Both failure modes ship an app that may or may not start, and the
+    // unexpected key says which: a stale name means the patch stopped renaming the template plug,
+    // an extra one means something in `snap.plugs` declared a second plug on this mount point.
     expect(plugs.map((plug) => plug.key)).toEqual([expected]);
     expect(plugs[0].descriptor.interface).toBe('content');
     // A name/provider mismatch means snapd installs the wrong platform snap to satisfy the plug.

--- a/.erb/scripts/startup-waterfall.util.test.ts
+++ b/.erb/scripts/startup-waterfall.util.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment node
+
 import { parseStartupMarks, formatWaterfall, selectLatestRun } from './startup-waterfall.util';
 
 const SAMPLE = [

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -138,6 +138,23 @@
       'unity7',
       'wayland',
       'x11',
+      // electron-builder's snapcraft template hardcodes a `gnome-3-28-1804` content plug (Ubuntu
+      // 18.04 / GNOME 3.28) and does not revise it when `base` is set, so without this override a
+      // core22 app mounts a bionic GNOME platform: mismatched Mesa/DRI, libdbus and GTK/Wayland
+      // stacks, and no window opens at all. Config can REPLACE a template plug entry but never
+      // remove one, so this has to reuse the template's key rather than introduce a new one --
+      // two plugs would then compete for the same mount point. snapd matches content plugs on the
+      // `content` attribute, which defaults to the key, so overriding `content` is what actually
+      // rebinds the plug. Keep in step with `base` above; enforced by
+      // .erb/scripts/electron-builder-snap-config.test.ts
+      {
+        'gnome-3-28-1804': {
+          interface: 'content',
+          content: 'gnome-42-2204',
+          target: '$SNAP/gnome-platform',
+          'default-provider': 'gnome-42-2204',
+        },
+      },
       {
         'dot-platform-bible': {
           interface: 'personal-files',

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -95,6 +95,14 @@
     // The base version needs to align with the Ubuntu runners in the GitHub Actions workflows.
     // Some things are built in the host OS, and some are built in the snap environment. If they
     // don't match, there will likely be compatibility issues.
+    //
+    // It must also align with the GNOME platform content snap mounted at $SNAP/gnome-platform,
+    // which is NOT configurable here: electron-builder's snapcraft template hardcodes that plug
+    // and config can replace a template plug entry but never rename or remove one. Renaming it is
+    // what matters -- snapd matches stored connections by plug NAME on refresh, so an attribute-only
+    // override leaves existing installs mounting the old platform. The pairing therefore lives in
+    // the `app-builder-lib` patch under `patches/`, and is enforced against this `base` value by
+    // .erb/scripts/electron-builder-snap-config.test.ts
     base: 'core22',
     category: 'Development',
     environment: {
@@ -138,23 +146,6 @@
       'unity7',
       'wayland',
       'x11',
-      // electron-builder's snapcraft template hardcodes a `gnome-3-28-1804` content plug (Ubuntu
-      // 18.04 / GNOME 3.28) and does not revise it when `base` is set, so without this override a
-      // core22 app mounts a bionic GNOME platform: mismatched Mesa/DRI, libdbus and GTK/Wayland
-      // stacks, and no window opens at all. Config can REPLACE a template plug entry but never
-      // remove one, so this has to reuse the template's key rather than introduce a new one --
-      // two plugs would then compete for the same mount point. snapd matches content plugs on the
-      // `content` attribute, which defaults to the key, so overriding `content` is what actually
-      // rebinds the plug. Keep in step with `base` above; enforced by
-      // .erb/scripts/electron-builder-snap-config.test.ts
-      {
-        'gnome-3-28-1804': {
-          interface: 'content',
-          content: 'gnome-42-2204',
-          target: '$SNAP/gnome-platform',
-          'default-provider': 'gnome-42-2204',
-        },
-      },
       {
         'dot-platform-bible': {
           interface: 'personal-files',

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -103,6 +103,12 @@
     // override leaves existing installs mounting the old platform. The pairing therefore lives in
     // the `app-builder-lib` patch under `patches/`, and is enforced against this `base` value by
     // .erb/scripts/electron-builder-snap-config.test.ts
+    //
+    // Upstream knows: electron-builder issue #9452 root-caused the same stale `gnome-3-28-1804`
+    // runtime, and PR #9517 addressed it by migrating snap builds to the `snapcraft` CLI under a
+    // new root `snapcraft` config property, rather than by fixing this `snap` property's template.
+    // Remove the patch (and this note) once we migrate to that property, which needs an
+    // electron-builder upgrade -- 26.7.0 does not expose it.
     base: 'core22',
     category: 'Development',
     environment: {

--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -107,8 +107,19 @@
     // Upstream knows: electron-builder issue #9452 root-caused the same stale `gnome-3-28-1804`
     // runtime, and PR #9517 addressed it by migrating snap builds to the `snapcraft` CLI under a
     // new root `snapcraft` config property, rather than by fixing this `snap` property's template.
-    // Remove the patch (and this note) once we migrate to that property, which needs an
-    // electron-builder upgrade -- 26.7.0 does not expose it.
+    //
+    // Removing the patch takes that new property AND `base: core24` -- the property alone is not
+    // enough, and stopping at it would silently reinstate this bug. Under `snapcraft`, core18,
+    // core20 and core22 all dispatch to `SnapCoreLegacy` (`LinuxTargetHelper.getSnapCore`), which
+    // loads this same template with the same hardcoded `gnome-3-28-1804` plug and merges config
+    // plugs by key exactly as the `snap` property does. Only core24 escapes, via the snapcraft
+    // `gnome` extension, which supplies `gnome-46-2404` itself. So migrating on core22 and deleting
+    // the patch would put every existing install back on the wrong platform snap -- and take the
+    // guard with it, since that test asserts against the patched template.
+    //
+    // core24 is its own project, not a flag flip: it was beta when #9517 merged, its reporter saw
+    // the built snap land in an lxd container path and not launch, and `libtinfo5` in
+    // `stagePackages` below does not exist on noble.
     base: 'core22',
     category: 'Development',
     environment: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,7 +171,8 @@
         "webpack-cli": "^5.1.4",
         "webpack-dev-server": "^5.2.2",
         "webpack-merge": "^6.0.1",
-        "yalc": "^1.0.0-pre.53"
+        "yalc": "^1.0.0-pre.53",
+        "yaml": "^2.8.3"
       },
       "engines": {
         "node": ">=18.12.x",

--- a/package.json
+++ b/package.json
@@ -290,7 +290,8 @@
     "webpack-cli": "^5.1.4",
     "webpack-dev-server": "^5.2.2",
     "webpack-merge": "^6.0.1",
-    "yalc": "^1.0.0-pre.53"
+    "yalc": "^1.0.0-pre.53",
+    "yaml": "^2.8.3"
   },
   "engines": {
     "node": ">=18.12.x",

--- a/patches/app-builder-lib+26.7.0+002+rename-gnome-platform-plug.patch
+++ b/patches/app-builder-lib+26.7.0+002+rename-gnome-platform-plug.patch
@@ -1,0 +1,17 @@
+diff --git a/node_modules/app-builder-lib/templates/snap/snapcraft.yaml b/node_modules/app-builder-lib/templates/snap/snapcraft.yaml
+index f0d706d..0f7c9af 100644
+--- a/node_modules/app-builder-lib/templates/snap/snapcraft.yaml
++++ b/node_modules/app-builder-lib/templates/snap/snapcraft.yaml
+@@ -130,10 +130,10 @@ parts:
+       - "-usr/lib/*/libXrandr*"
+       - "-usr/lib/*/libXrender*"
+ plugs:
+-  gnome-3-28-1804:
++  gnome-42-2204:
+     interface: content
+     target: $SNAP/gnome-platform
+-    default-provider: gnome-3-28-1804
++    default-provider: gnome-42-2204
+   gtk-3-themes:
+     interface: content
+     target: $SNAP/data-dir/themes


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: fix/snap-gnome-platform-plug

**Base**: origin/main

**Date**: 2026-09-02

**Review model**: Claude Opus 5

**Files changed**: 6

## Overview

Linux snap builds declare `base: core22` but mounted `gnome-3-28-1804` — the Ubuntu 18.04 / GNOME
3.28 content snap — at `$SNAP/gnome-platform`. electron-builder's snapcraft template hardcodes that
plug and rewrites only `snap.base`, so the app ran jammy-staged libraries against a bionic platform:
Mesa/DRI, libdbus and the GTK/Wayland stack all mismatched, and the app segfaulted on launch without
ever opening a window.

The first commit on this branch overrode the plug's `content`/`default-provider` under the
template's original *name*. That fixed cold installs — the path the bug was originally diagnosed on
— but code review raised the upgrade path, which had not been considered. snapd matches stored
connections by plug **name** on refresh, so it revived the stale connection *and* auto-connected the
new one; two content plugs then competed for one mount point and snapd broke the tie by renaming one
aside, arbitrarily. The second commit therefore **renames** the plug, via a `patch-package` patch on
the template — the only mechanism that can, since electron-builder config can replace a template
plug entry but never rename or remove one.

## API Changes

None. No public API surfaces changed. The diff touches only snap packaging config, a patch file, a
build-config test, the decisions log, and dependency manifests — nothing in
`lib/platform-bible-react/`, `lib/platform-bible-utils/`, `lib/papi-dts/papi.d.ts`, or any
`extensions/src/*/src/types/*.d.ts`.

## Findings

### Critical — Must address before merge

- [x] **A core-owned patch at `patches/app-builder-lib+26.7.0.patch` would break the
      paratext-10-studio build.** The studio does not carry its own patch:
      `repo-patches/paranext-core.patch` *creates* that same path here to add mercurial snap parts.
      The studio applies repo patches with `git apply --3way` (`lib/git.util.ts:130`), which turns
      the add/add case into `<<<<<<< ours` / `>>>>>>> theirs` markers written **into the patch file
      itself**, leaving patch-package unable to parse it. _(fixed during review: the patch is named
      `app-builder-lib+26.7.0+002+rename-gnome-platform-plug.patch`, using patch-package's sequenced
      patch support, so it occupies a different path from the studio's and the two apply in sequence
      to the same template.)_

[Author response: **Resolved by a sequenced filename — there is no merge-order dependency and no
companion studio change.** This finding originally carried a premise that patch-package allows only
one patch file per package+version, on which a whole core-first merge plan was built. The re-review
established that patch-package 8.0.1 — already used here — supports sequenced patches
(`<pkg>+<version>+<NNN>+<description>.patch`). Naming this PR's file
`app-builder-lib+26.7.0+002+rename-gnome-platform-plug.patch` puts it at a different path from the
one the studio creates, so there is no add/add case at all.

Verified independently rather than taken on trust, in two parts. Core's actual case: the sequenced
patch applies with **no** unsequenced base file present (`app-builder-lib@26.7.0 (2
rename-gnome-platform-plug) ✔`, exit 0, template renamed). The coexistence case, using the studio's
**real** patch body extracted from its `repo-patches/paranext-core.patch`: both apply in sequence,
exit 0, and the resulting template carries the mercurial parts *and* `gnome-42-2204`. The two hunks
touch disjoint regions (~line 21 vs ~line 130), so apply order does not matter.

**Footgun recorded in the decisions log:** regenerating later with plain
`npx patch-package app-builder-lib`, without `--append`, collapses the sequence back into one
unsequenced file and reintroduces the collision.]

### Important — Should address before merge

None.

### Minor — Consider

- [x] **`findGnomePlatformPlugs()` did not dedupe by key**, though electron-builder merges plugs by
      key — so a future legitimate config override of the correctly-named `gnome-42-2204` plug would
      have failed the "exactly one" assertion even though the real build emits one plug. _(fixed
      during review: merged by key last-wins, mirroring `snap.plugs[plugName] = plugOptions`.
      Verified both directions — a same-key override now stays green, a different-key plug on the
      same mount point still reddens.)_
- [x] **The third test was subsumed by the second** and could never fail alone. _(fixed during
      review: dropped, with its snapd-matches-by-name rationale folded into the surviving
      assertion's comment, where it explains why asserting on the KEY is what makes the guard
      meaningful.)_
- [x] **The test read only the installed template**, so deleting the patch file with a warm
      `node_modules` left it green locally. _(fixed during review: added an assertion that a
      committed `app-builder-lib` patch exists and names the expected plug. Verified it reddens when
      the patch file is removed. It confirms presence, not that the patch would still apply — a
      fresh `npm ci` in CI remains the real check.)_
- [x] **The version-pinned patch filename appeared in three prose sites**, all of which rot on an
      `app-builder-lib` bump. _(fixed during review: the new assertion finds patches by glob rather
      than name, and all three references now read "the `app-builder-lib` patch under `patches/`".)_
- [x] **`PlugDescriptor.content` was declared but never read** — it was load-bearing in the
      attribute-override approach and is dead now that the plug is renamed. _(fixed during review:
      dropped.)_
- [x] **`electron-builder.json5` was read and parsed twice**, and `readSnapBase()` ran three times.
      _(fixed during review: parsed once behind a memoised reader; a separate `isRecord` predicate
      now handles config navigation, since the plug-map predicate was the wrong shape for reaching
      `snap.base`.)_
- [x] **The `base` ↔ Ubuntu-runner coupling was comment-only.** The comment beside `base` asserts
      alignment with both the runners and the platform snap; the test guarded only the platform
      half, so a `core24` bump would have passed while the runners stayed on 22.04. _(fixed during
      review: added a `UBUNTU_RUNNER_BY_BASE` pairing and an assertion that all three snap-building
      workflows pin the matching `OS_LINUX`. Verified it reddens on a `base` mutation.)_
- [x] **No decisions-log entry for "patch, not config".** _(fixed during review: added
      `adr-snap-gnome-plug-renamed-by-patch` to `.context/standards/Architecture-Decisions.md`,
      covering the mechanism, the four rejected alternatives, and the cross-repo consequence.)_
- [ ] ~~The patch has no in-place `patch-package notes:` header, unlike three of the four existing
      patches~~ _(The premise is factually wrong: none of the four existing patches has such a
      header — all start directly with `diff --git` — so adding one would make ours the
      inconsistent patch. Whether patch-package supports comments in `.patch` files could not be
      verified (reading `node_modules` is blocked in this environment), so it was not relied on. A
      different option was considered and declined: a YAML comment inside the patched template,
      which needs no patch-package feature since it is ordinary file content. Author chose to keep
      the patch minimal at two changed lines, since the rationale now lives in
      `electron-builder.json5`, the test, and the decisions log.)_

- [x] **`PlugDescriptor` inverted electron-builder's own meaning** — upstream exports that name for
      the OUTER map of plug-name to attributes, so using it for the inner attribute bag read
      backwards to anyone who knows the library. _(fixed during review: renamed to `PlugAttributes`,
      with a doc comment stating why it deliberately avoids the upstream name. Carried over from the
      prior Reviewable round, finding #12.)_
- [x] **`confinement: 'classic'` was a blind spot.** electron-builder deletes the entire plugs map
      under classic confinement (`delete snap.plugs`), so the GNOME platform plug would vanish from
      the snap while every other assertion here still passed — they read the config and the
      template, not the effect of confinement on them. _(fixed during review: added an assertion
      that confinement is not classic, absent being fine since the template default is strict.
      Verified it reddens when classic is set. Carried over from the prior Reviewable round,
      finding #25.)_

[Author response: Ten of eleven fixed during the review. One was dismissed after its factual
premise was checked and found false. The last two came from re-triaging the prior Reviewable round
against the rewritten code rather than from this analysis pass — see Interview Notes.]

### Template Propagation

#### Shared Regions Modified

None. No `#region shared with` markers in any changed file.

#### Extension Config Changes

- [n/a] No changed file is under `extensions/`. `electron-builder.json5`, `package.json`,
  `patches/` and `.erb/scripts/` are top-level build config, outside the extension-template
  propagation mechanism.
- [n/a] The paratext-10-studio patch collision is real cross-repo coordination but falls outside
  this mechanism. Tracked as the Critical finding above.

## Positive Observations

- The mechanism was verified rather than asserted, by every analysis pass independently: the
  template really does hardcode the plug, `snap.base` really is the only field rewritten, and
  `snap.plugs[plugName] = plugOptions` really is assignment-only — so the rename genuinely cannot be
  expressed in config.
- With no explicit `content:` attribute the content interface defaults to the plug name, which
  matches the provider snap's slot; the patch is two lines.
- The regression test is anchored to the artefact that ships. It reads the patched template out of
  `node_modules`, and CI's `npm ci` → `postinstall` → `patch-package` → `npm test` sequence means an
  `app-builder-lib` bump that stops the patch applying turns CI red rather than shipping a snap that
  segfaults on launch.
- `readSnapTemplate()` resolves via `require.resolve('app-builder-lib/package.json')` rather than
  assuming root hoisting, correct for a transitive dependency, and both failure paths throw
  actionable messages naming what to re-check.
- `readSnapBase()` validates rather than casts, and every expected value is derived from `base`, so
  a future bump fails loudly instead of silently mounting the wrong platform.
- The test mirrors electron-builder's own `normalizePlugConfiguration` shapes (bare map *or* array
  of names and maps), so the guard cannot be bypassed by writing `snap.plugs` in the other supported
  form.
- Dependency hygiene: `yaml` was already a hoisted transitive dev dependency at exactly 2.8.3, so
  the lockfile change is 2 lines adding only the root declaration, with no new resolution.
  `patch-package` with a `patches/` directory is an established mechanism here (four pre-existing
  patches), so no new pattern was introduced.
- Comments are forward-facing throughout — constraint and mechanism, no PR narration.

## Interview Notes

**Purpose (author's framing).** Make Linux snap builds mount the GNOME platform snap matching
`base: core22`. The change of direction mid-branch was because the original diagnosis came from a
**cold install** — where the failure was first noticed — so the re-install/upgrade path was simply
not in view until code review raised it.

**Verification.** Since the review, extensive testing in an Ubuntu 22.04 VM proved out the new
direction. Report (shared to the org):
https://claude.ai/code/artifact/cc4c4c08-2e75-4dd5-855a-312fc4a6a57e

The load-bearing results, so this summary stands alone without opening it:

| | Attribute override (first commit) | Plug rename (this commit) |
| --- | --- | --- |
| Content connections after upgrade | 2 | 1 |
| `cannot refresh static attributes` in journal | twice per upgrade, every upgrade | never |
| `gnome-platform-2` mount-clash rename | every upgrade | never |
| App opens with no flags | 9 of 16 | 12 of 12 |

The rename cycles ran with unmodified controls interleaved, which still flipped 4/3 and 1/1 on the
same machine the same day — so the harness was demonstrably live, not quiet. A `state.json` audit of
all 16 `platform-bible` entries found no `gnome-3-28-1804` key and no `undesired`/`hotplug-gone`
residue, so nothing is left for a future build to match against. Both build shapes were tested — the
plug in the app's plug list and not — and behave identically, which is what makes the template's own
shape (top-level `plugs:` only) sufficient; three existing content plugs in this snap have always
been snap-level-only.

**Nobody is affected today.** This is not merged, and the published store build is 0.5.0, whose plug
predates the change. The risk is entirely pre-merge — but real: store 0.5.0 binds exactly the
connection `reloadConnections` revives, so users refreshing from it would have landed in the coin
flip.

**Repair for an already-broken install**, if one ever occurs:
`snap disconnect platform-bible:gnome-3-28-1804 gnome-3-28-1804:gnome-3-28-1804`. It fixes the mount
immediately and holds across refreshes, because snapd records `"undesired": true`. It is a
per-machine repair and cannot be applied centrally, so it complements the rename rather than
replacing it.

**Untested, and it applies to any version of this fix.** A renamed plug is a new content tag from
the snap store's perspective, and store-granted auto-connection for a changed content tag cannot be
inferred from sideload results — every install tested used `--dangerous`, which bypasses store
assertions. This should be confirmed on a published build (`publish.yml` already uploads to edge on
every publish) before the fix is relied on for existing users.

**A reframing worth carrying.** The wrong platform snap has been in the config since snap support
landed in Feb 2025. What made it *fatal* was the Electron bump: the published 0.5.0 build has the
same misconfiguration and still opens a window, because its older Electron falls back to software
rendering rather than dying.

**The prior Reviewable round was audited against the code, not against notes.** All 29 comments
from the review of the first approach were re-checked line by line rather than assumed obsolete
because the code had changed — and that audit found four had been overclaimed as done.

*Genuinely fixed:* #1, #5, #36, #37, plus #2, #3, #7, #14, #16, #20, #21, #22, #23, #24, #25, #29
and #31. (#7 needed a second pass: the directive had been added to the new test but not to
`.erb/scripts/startup-waterfall.util.test.ts`, which the finding explicitly named. Now done —
that file drops from ~300ms of environment setup to 2ms.)

*Partially fixed, and stated as such:* **#12** — the inversion is fixed (`PlugDescriptor` →
`PlugAttributes`) but the types are still hand-written rather than imported from `app-builder-lib`,
which is awkward to do since `electron-builder` does not re-export them. **#10** — a `core24` bump
now fails the runner assertion, but `libtinfo5` in `stagePackages` does not exist on noble and is
unguarded. **#26** — the "downgrade to `core18` passes by construction" leg is now caught, since
core18 expects `ubuntu-18.04` against pinned `ubuntu-22.04`; the "typo in the map" leg stands, as
the map remains its own oracle. **#32** — the suggested `expect(value, message)` form is rejected by
the repo's `vitest/valid-expect` rule, so each load-bearing assertion carries an explanatory comment
instead; real messages would need that rule's `maxArgs` raised repo-wide.

*Moot rather than guarded:* **#17** — with the rename, a bare string in `snap.plugs` leaves the
template's correct plug in place, so the hazard is gone by construction but nothing asserts it.
**#28** — the inaccurate failure message was deleted with the throw it belonged to.

*Dismissed with reasons:* **#11** — importing `dev-package-utils.ts` would `ENOENT` in CI, as the
reviewer's own refuter found; **#13** — pre-existing and documented in `tsconfig.erb.json`;
**#15** — nothing importable in `notarize.js`; **#19** — 6 em dashes remain, established as not a
repo convention.

*Open:* **#30** (the guard watches the template, not `snap.js`, so an upstream plug emitted in code
would be invisible), **#33** (no assertion against what electron-builder actually generates) and
**#38** (upstream issue unfiled). #33 would close #30 too; both are in review focus.

No areas of uncertainty were expressed, and nothing was deferred to AI without explanation.

## In-Review Quality Check

Ten in-review fixes were made across three files.

| Check | Exit code | Result |
| --- | --- | --- |
| `npm run typecheck` | 0 | Clean |
| `npm run lint` | 0 | 0 errors; 1 pre-existing warning in an untouched file |
| Prettier on changed files | 0 | All already formatted |
| New test file, all 5 assertions | 0 | Each mutation-tested to confirm it can fail |
| Full suite in CI | 0 | Green across windows, ubuntu-22.04 and macOS |
| `cspell` on the test file | 0 | Clean |

**The suite passes.** Local runs during this review did produce timeout failures, but those were
this machine under sustained load, not a problem with the branch: CI is green across all three OSes,
and a clean local run on `main` passes too. Every failing test was in a file untouched by this diff
and passed in isolation.

One durable observation worth someone's attention separately, unrelated to this branch:
`src/renderer/services/web-view.service-shard.initial-load.test.ts` reports `tests 5.28s` **in
isolation** against a **5s per-test timeout**, so it has no headroom and is the first thing to tip
over when a machine or runner is busy. Raising that timeout or speeding the test up would remove a
recurring source of confusing red builds.

`cspell` flags four words on the added decisions-log lines (`libdbus`, `segfaulted`, `Neutralise`,
`sideload`). Deliberately not added to `cspell.json` — the author's position is that cspell earns
its keep on identifiers and padding the curated list with prose vocabulary makes it worse at that
job. That document already carries 57 pre-existing unknown words.

## Suggested Review Focus

- [x] **Upstream is already aware, and there is nothing to file** (prior review, #38). Searching
      before writing a report found electron-builder **#9452**, closed COMPLETED, reporting the same
      crash and root-caused identically — through the same `font-antialiasing` schema error, whose
      key postdates the `gnome-3-28-1804` runtime the template pins. It was closed by **PR #9517**,
      which this repo's workflows already cite in their snapcraft-8.x pin comments: upstream did not
      fix the template, it migrated snap builds to the `snapcraft` CLI under a new root `snapcraft`
      config property and left the `snap` property used here on the old template. Verified 26.7.0
      does not expose that property; latest published is 26.15.3. The patch now carries that citation
      and its removal condition.
- [ ] **Two follow-up tickets to file once this lands.** (a) Assert against the snap electron-builder
      actually generates (prior review #33, which closes #30 too) — every mechanism behind the
      sibling findings lives in `snap.js` and is invisible from the JSON5 source, so the endorsed
      shape is an assertion on the generated `snapcraft.yaml` in `release/build/` after
      `npm run package`, no launching. It needs a packaging run, hence a CI step rather than a unit
      test. (b) Upgrade electron-builder and migrate `snap` → `snapcraft`, which retires this patch
      entirely. Both caveated: core24 support was *beta* at merge and reported as not working
      end-to-end, and a `core24` move also needs `stagePackages` reviewed, since `libtinfo5` does not
      exist on noble (prior review #10's other half).
- [ ] **Store auto-connection for the new content tag.** Untested by construction — sideloads carry
      no store assertions. Decide whether an edge release should confirm it before this reaches
      existing users, and whether that gates the merge or follows it.
- [ ] **Whether the runner assertion belongs here.** It was added during review and goes slightly
      beyond the fix. It completes a coupling the config comment already claims, but it does put
      workflow parsing into a snap-config test.
- [ ] **The pairing maps are their own oracle** (prior review, #26). `GNOME_PLATFORM_BY_BASE` and
      `UBUNTU_RUNNER_BY_BASE` detect an *unknown* base but cannot detect a *wrong* pairing — set
      `core22: 'gnome-41-2204'` and everything passes. There is no fix without an external source of
      truth, so the rows are worth a human read: only `core22` is exercised today, and a wrong value
      would send a future bump at the wrong platform snap or runner. Also note `libtinfo5` in
      `stagePackages` does not exist on noble, so a `core24` bump needs more than these two rows
      updated.
- [ ] **`grade: 'devel'` at `electron-builder.json5` is stale** — its comment says to switch to
      `stable` "when it's ready to be published on the snap store", but the snap is already
      published and store revision 19 reports `grade: stable`. Not touched here; worth a follow-up.
<!-- review-paratext:summary:end -->

AI-assisted — Claude Code (Claude Opus 5). No session URL is available from the VS Code extension; attribution is carried by the `Co-authored-by` trailer on the commit.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2747)
<!-- Reviewable:end -->
