### PR TITLE
PT-4424: Cover the missing-book banner in the reference panels

### DIFF
--- a/extensions/src/platform-scripture-editor/src/downloaded-resources.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/downloaded-resources.utils.ts
@@ -167,7 +167,17 @@ function downloadedToRow(
   };
 }
 
-/** Union referenced items with downloaded-but-unreferenced projects, deduped (referenced wins). */
+/**
+ * Union referenced items with downloaded-but-unreferenced projects, deduped (referenced wins).
+ *
+ * The per-reference-kind typing this applies is mirrored by `splitResourcesByTab` in
+ * `src/renderer/components/dialogs/share-layout.utils.ts`, which sorts the same setting into the
+ * Share Layout dialog's tabs. It cannot import from an extension, so the two are kept in step by
+ * hand: change a typing rule here and change it there. Note they diverge on purpose for a reference
+ * the rules cannot place — a `dblResource` missing from the catalog is dropped here (see
+ * `resolveReferenced`) and preserved there, because that side round-trips the setting instead of
+ * rendering it.
+ */
 export function buildPickerResources(
   effectiveItems: EffectiveResourceReference[],
   downloaded: DownloadedResource[],

--- a/extensions/src/platform-scripture-editor/src/downloaded-resources.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/downloaded-resources.utils.ts
@@ -173,10 +173,14 @@ function downloadedToRow(
  * The per-reference-kind typing this applies is mirrored by `splitResourcesByTab` in
  * `src/renderer/components/dialogs/share-layout.utils.ts`, which sorts the same setting into the
  * Share Layout dialog's tabs. It cannot import from an extension, so the two are kept in step by
- * hand: change a typing rule here and change it there. Note they diverge on purpose for a reference
- * the rules cannot place — a `dblResource` missing from the catalog is dropped here (see
- * `resolveReferenced`) and preserved there, because that side round-trips the setting instead of
- * rendering it.
+ * hand: change a typing rule here and change it there.
+ *
+ * They currently disagree in two ways, documented in full on that function. One is deliberate — a
+ * `dblResource` missing from the catalog is dropped here (see `resolveReferenced`) and preserved
+ * there, because that side round-trips the setting instead of rendering it. The other is not: that
+ * side routes every `project` reference to its Bible Texts tab, while `resolveReferenced` refines
+ * the type from the catalog, so a locally-installed commentary appears under Commentaries here and
+ * under Bible Texts there.
  */
 export function buildPickerResources(
   effectiveItems: EffectiveResourceReference[],

--- a/extensions/src/platform-scripture-editor/src/localized-strings.test.ts
+++ b/extensions/src/platform-scripture-editor/src/localized-strings.test.ts
@@ -9,7 +9,7 @@ import { BOOK_NOT_AVAILABLE_VIEW_STRING_KEYS } from './book-not-available-view.c
 import { EMPTY_CHAPTER_VIEW_STRING_KEYS } from './empty-chapter-view.const';
 import { RESOURCE_CELL_STRING_KEYS } from './scripture-text-grid/resource-cell.const';
 import { MODEL_TEXT_PANEL_STRING_KEYS } from './model-text-panel.const';
-import { RESOURCE_PANEL_TYPED_STRING_KEYS } from './resource-panel-strings.utils';
+import { RESOURCE_PANEL_STRING_KEYS } from './resource-text-panel.const';
 import { VIEW_OPTIONS_NOTICE_STRING_KEYS } from './scripture-text-grid/view-options-notice.utils';
 
 type LocalizedStringsFile = {
@@ -208,10 +208,22 @@ describe('retired book-not-found-in-project string', () => {
   });
 });
 
-// The resource panels' strings come in matched `bibleTexts_` / `commentaries_` pairs and the model
-// text panel's in a single set. Driven off the exported key lists so that an en-only addition, or a
-// dropped `es` value, fails here without anyone remembering to edit this file.
-describe.each([...RESOURCE_PANEL_TYPED_STRING_KEYS])('resource panel label %s', (key) => {
+// The resource panels' strings come in matched `bibleTexts_` / `commentaries_` pairs plus a set
+// shared by both tabs, and the model text panel's in a single set. Driven off the exported key
+// lists — `RESOURCE_PANEL_STRING_KEYS` folds the typed pairs in, so every key either panel renders
+// is covered — so that an en-only addition, or a dropped `es` value, fails here without anyone
+// remembering to edit this file.
+//
+// A couple of keys legitimately appear in both frozen lists, because both panels render them. Each
+// list is right to declare what its own surface uses, so the de-duplication belongs here: without
+// it a failure on a shared key reports twice, under two different owners, and the file's
+// one-block-per-surface structure stops meaning anything. The model text block below owns them.
+const MODEL_TEXT_PANEL_KEY_SET = new Set<string>(MODEL_TEXT_PANEL_STRING_KEYS);
+const RESOURCE_PANEL_ONLY_STRING_KEYS = RESOURCE_PANEL_STRING_KEYS.filter(
+  (key) => !MODEL_TEXT_PANEL_KEY_SET.has(key),
+);
+
+describe.each([...RESOURCE_PANEL_ONLY_STRING_KEYS])('resource panel label %s', (key) => {
   it('has an English label', () => {
     expect(localizedStrings.en[key]).toBeTruthy();
   });

--- a/extensions/src/platform-scripture-editor/src/panel-readiness-view.component.stories.tsx
+++ b/extensions/src/platform-scripture-editor/src/panel-readiness-view.component.stories.tsx
@@ -2,27 +2,19 @@ import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import { getLocalizedStrings } from '../../../../.storybook/localization.utils';
 import { PanelReadinessView } from './panel-readiness-view.component';
 import { ExpandableInfo } from './panel-state-views.component';
+import { RESOURCE_PANEL_STRING_KEYS } from './resource-text-panel.const';
 
 /**
  * Resolved from the extension's real `localizedStrings.json` rather than hardcoded, so this story
- * cannot drift from the copy that ships — it already had, showing "Bible text" where the shipping
- * strings say "Bible texts".
+ * cannot drift from the copy that ships.
  *
- * The keys are listed here rather than imported from `RESOURCE_PANEL_STRING_KEYS`, which lives in
- * the web-view module: importing it would pull the whole web view (and `Editorial`) into Storybook
- * to obtain a string array. These are the Resource panel's Bible Texts strings; the Model Text
- * panel renders the same view with its own equivalents.
+ * Driven off the Resource panel's own key list rather than a copy of the handful this view reads,
+ * so a renamed key surfaces here as an unresolved `%...%` token instead of a stale hardcoded
+ * sentence. The list is a leaf module, so importing it costs nothing beyond the string array. The
+ * args below pick the Bible Texts wording; the Commentaries tab and the Model Text panel render the
+ * same view with their own equivalents.
  */
-const RESOURCE_PANEL_KEYS = [
-  '%webView_resourcePanel_settingsUnavailable%',
-  '%webView_resourcePanel_catalogUnavailable%',
-  '%webView_resourcePanel_loading%',
-  '%webView_resourcePanel_bibleTexts_emptyState_prompt%',
-  '%webView_resourcePanel_bibleTexts_pick%',
-  '%webView_resourcePanel_retry%',
-];
-
-const localizedStrings = getLocalizedStrings(RESOURCE_PANEL_KEYS);
+const localizedStrings = getLocalizedStrings([...RESOURCE_PANEL_STRING_KEYS]);
 
 /** Strings for the optional "More info" disclosure, used only by the EmptyWithMoreInfo story. */
 const moreInfoStrings = getLocalizedStrings([
@@ -33,9 +25,9 @@ const moreInfoStrings = getLocalizedStrings([
 
 /**
  * The front of a resource panel's state machine — everything shown before the panel has content to
- * display. The Resource (Bible Texts / Commentaries) panel lives entirely in a web view, so these
- * stories are the only place its loading, error, and empty copy can be reviewed without running the
- * app; the Model Text panel renders the same states through this view too.
+ * display. Nothing renders the Resource (Bible Texts / Commentaries) panel itself in Storybook, so
+ * these stories are the only place its loading, error, and empty copy can be reviewed without
+ * running the app; the Model Text panel renders the same states through this view too.
  *
  * The two failure states deliberately differ in whether they offer a control. A catalog fetch can
  * genuinely be re-driven, so it gets a working retry. An unreadable configured-resource setting

--- a/extensions/src/platform-scripture-editor/src/panel-readiness-view.component.stories.tsx
+++ b/extensions/src/platform-scripture-editor/src/panel-readiness-view.component.stories.tsx
@@ -8,11 +8,19 @@ import { RESOURCE_PANEL_STRING_KEYS } from './resource-text-panel.const';
  * Resolved from the extension's real `localizedStrings.json` rather than hardcoded, so this story
  * cannot drift from the copy that ships.
  *
- * Driven off the Resource panel's own key list rather than a copy of the handful this view reads,
- * so a renamed key surfaces here as an unresolved `%...%` token instead of a stale hardcoded
- * sentence. The list is a leaf module, so importing it costs nothing beyond the string array. The
- * args below pick the Bible Texts wording; the Commentaries tab and the Model Text panel render the
- * same view with their own equivalents.
+ * Requested via the Resource panel's own key list rather than a copy of the handful this view
+ * reads, which is worth it only for not maintaining that copy — the list is a leaf module, so
+ * importing it costs nothing beyond the string array.
+ *
+ * It does NOT make a renamed key visible here. `getLocalizedStrings` falls back to the key for
+ * anything it is asked for and cannot find, so a rename resolves fine in this map while the `args`
+ * below still ask for it by its old literal — and an absent key reads as `undefined`, not as a
+ * `%...%` token, with no `noUncheckedIndexedAccess` to catch it. Renaming a key means editing those
+ * literals too. Reading them through `resolveResourcePanelStringKeys` would fix that for the two
+ * per-resource-type keys, which are the only ones reachable as named values.
+ *
+ * The args below pick the Bible Texts wording; the Commentaries tab and the Model Text panel render
+ * the same view with their own equivalents.
  */
 const localizedStrings = getLocalizedStrings([...RESOURCE_PANEL_STRING_KEYS]);
 

--- a/extensions/src/platform-scripture-editor/src/panel-readiness-view.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/panel-readiness-view.component.tsx
@@ -16,9 +16,10 @@ import { PanelRetryableErrorView, LoadingView } from './panel-state-views.compon
  * display — from a single `readiness` value.
  *
  * Used by BOTH the Resource (Bible Texts / Commentaries) and Model Text panels, so neither can
- * drift from the other on the question that caused this bug. Keeping the states here also gives the
- * Resource panel its only testable seam for them: it lives entirely in a web view with no extracted
- * component.
+ * drift from the other on the question that caused this bug. Both panels have an extracted
+ * component (`resource-text-panel.component.tsx`, `model-text-panel.component.tsx`), so these
+ * states are reachable from a component test through either of them as well as from this view's own
+ * stories.
  *
  * Deciding these states inline is what went wrong in both panels: an empty prompt was rendered from
  * a value that was only meaningful once the data had arrived. Taking one `readiness` value makes

--- a/extensions/src/platform-scripture-editor/src/resource-panel-strings.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/resource-panel-strings.utils.ts
@@ -14,21 +14,28 @@ export type ResourcePanelStringKeys = {
   pickButtonKey: LocalizeKey;
 };
 
-const BIBLE_TEXTS_KEYS: ResourcePanelStringKeys = {
+// `as const satisfies` rather than a `: ResourcePanelStringKeys` annotation: the annotation widens
+// every value to `LocalizeKey`, which absorbs any `%...%` string, so `RESOURCE_PANEL_STRING_KEYS`
+// and the `ResourcePanelLocalizedStrings` it keys would accept keys the panel never renders. The
+// `satisfies` clause keeps the shape checked against the documented type.
+const BIBLE_TEXTS_KEYS = {
   titleKey: '%webView_resourcePanel_bibleTexts_title%',
   titleWithResourceKey: '%webView_resourcePanel_bibleTexts_title_withResource%',
   emptyStatePromptKey: '%webView_resourcePanel_bibleTexts_emptyState_prompt%',
   bookNotAvailableKey: '%webView_resourcePanel_bibleTexts_bookNotAvailable%',
   pickButtonKey: '%webView_resourcePanel_bibleTexts_pick%',
-};
+} as const satisfies ResourcePanelStringKeys;
 
-const COMMENTARIES_KEYS: ResourcePanelStringKeys = {
+const COMMENTARIES_KEYS = {
   titleKey: '%webView_resourcePanel_commentaries_title%',
   titleWithResourceKey: '%webView_resourcePanel_commentaries_title_withResource%',
   emptyStatePromptKey: '%webView_resourcePanel_commentaries_emptyState_prompt%',
   bookNotAvailableKey: '%webView_resourcePanel_commentaries_bookNotAvailable%',
   pickButtonKey: '%webView_resourcePanel_commentaries_pick%',
-};
+} as const satisfies ResourcePanelStringKeys;
+
+/** The keys for one resource type, each narrowed to the exact key that ships for it. */
+export type ResolvedResourcePanelStringKeys = typeof BIBLE_TEXTS_KEYS | typeof COMMENTARIES_KEYS;
 
 /**
  * Every localized string key the resource panel needs for one resource type.
@@ -48,15 +55,23 @@ const COMMENTARIES_KEYS: ResourcePanelStringKeys = {
  */
 export function resolveResourcePanelStringKeys(
   resourceType: ResourceType,
-): ResourcePanelStringKeys {
+): ResolvedResourcePanelStringKeys {
   return resourceType === 'ScriptureResource' ? BIBLE_TEXTS_KEYS : COMMENTARIES_KEYS;
 }
 
 /**
  * Every key the resource panel can render, both resource types together. Exported so the localized
- * strings parity test can drive off it rather than a hand-maintained literal list.
+ * strings parity test can drive off it rather than a hand-maintained literal list, and so
+ * `RESOURCE_PANEL_STRING_KEYS` can fold these in without restating them.
  */
-export const RESOURCE_PANEL_TYPED_STRING_KEYS: readonly LocalizeKey[] = Object.freeze([
+// Deliberately NOT annotated `: readonly LocalizeKey[]`. That annotation would widen these literals
+// back to `LocalizeKey`, which absorbs any `%...%` string — and because
+// `resource-text-panel.const.ts` spreads this into its own `as const` tuple, the widening
+// propagates: `ResourcePanelLocalizedStringKey` degrades from the exact 22-key union to "any
+// `%...%` string", so it stops constraining `localize()`'s argument and the panel's
+// `localizedStrings` prop. Nothing else checks that, and the loss is invisible at runtime — the
+// parity test iterates the same frozen array either way. Leave the type inferred.
+export const RESOURCE_PANEL_TYPED_STRING_KEYS = Object.freeze([
   ...Object.values(BIBLE_TEXTS_KEYS),
   ...Object.values(COMMENTARIES_KEYS),
 ]);

--- a/extensions/src/platform-scripture-editor/src/resource-panel-strings.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/resource-panel-strings.utils.ts
@@ -60,9 +60,9 @@ export function resolveResourcePanelStringKeys(
 }
 
 /**
- * Every key the resource panel can render, both resource types together. Exported so the localized
- * strings parity test can drive off it rather than a hand-maintained literal list, and so
- * `RESOURCE_PANEL_STRING_KEYS` can fold these in without restating them.
+ * Every key the resource panel can render, both resource types together. Exported so
+ * `RESOURCE_PANEL_STRING_KEYS` can fold these in without restating them — which is what puts them
+ * under the localized-strings parity test, since that test drives off the folded list.
  */
 // Deliberately NOT annotated `: readonly LocalizeKey[]`. That annotation would widen these literals
 // back to `LocalizeKey`, which absorbs any `%...%` string — and because

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
@@ -1,0 +1,363 @@
+// @vitest-environment jsdom
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import * as React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import type { Usj } from '@eten-tech-foundation/scripture-utilities';
+import { Canon } from '@sillsdev/scripture';
+import type { DblResourceData } from 'platform-bible-utils';
+import type { PickerResource } from './downloaded-resources.utils';
+import {
+  RESOURCE_TEXT_EDITOR_CONTAINER_TEST_ID,
+  ResourceTextPanel,
+  ResourceTextPanelProps,
+} from './resource-text-panel.component';
+
+/**
+ * Records every `setUsj` the panel pushes into the editor, across editor instances.
+ *
+ * Shared rather than created per instance because the panel UNMOUNTS `Editorial` to show a message
+ * and remounts it on the way back to content — a fresh editor holds nothing, so what the tests
+ * below need to see is whether the panel re-fed it. A per-instance spy nobody captures makes "the
+ * editor is on screen" the only observable fact, which a permanently blank editor also satisfies.
+ */
+const setUsjSpy = vi.fn();
+
+vi.mock('@eten-tech-foundation/platform-editor', () => ({
+  Editorial: React.forwardRef((_props: Record<string, unknown>, ref: React.Ref<unknown>) => {
+    React.useImperativeHandle(ref, () => ({ setUsj: setUsjSpy }));
+    return <div data-testid="editorial" />;
+  }),
+}));
+
+const BIBLE_TEXT_MISSING_BOOK = 'This book does not exist in this Bible text.';
+const COMMENTARY_MISSING_BOOK = 'This book does not exist in this commentary.';
+const BLANK_CHAPTER = 'This chapter is empty in this resource.';
+const TEXT_UNAVAILABLE = 'This text could not be loaded.';
+const PICK_BIBLE_TEXTS = 'Pick Bible texts…';
+
+const STRINGS = {
+  '%webView_platformScriptureEditor_emptyChapter_messageResource%': BLANK_CHAPTER,
+  '%webView_resourcePanel_noProject%': 'No project.',
+  '%webView_resourcePanel_installing%': 'Installing resource…',
+  '%webView_resourcePanel_selecting%': 'Selecting resource…',
+  '%webView_resourcePanel_installFailed%': "The resource couldn't be installed.",
+  '%webView_resourcePanel_installFailedOffline%':
+    "The resource couldn't be installed. Check your connection and try again.",
+  '%webView_resourcePanel_retry%': 'Try again',
+  '%webView_resourcePanel_settingsUnavailable%': "Couldn't load your resources.",
+  '%webView_resourcePanel_loading%': 'Loading…',
+  '%webView_resourcePanel_catalogUnavailable%': "Couldn't load the list of available resources.",
+  '%webView_resourcePanel_downloadResources%': 'Download resources…',
+  '%webView_resourcePanel_bibleTexts_emptyState_prompt%':
+    'No Bible texts selected. Pick one to display a reference translation alongside your project.',
+  '%webView_resourcePanel_bibleTexts_pick%': PICK_BIBLE_TEXTS,
+  '%webView_resourcePanel_textUnavailable%': TEXT_UNAVAILABLE,
+  '%webView_resourcePanel_bibleTexts_bookNotAvailable%': BIBLE_TEXT_MISSING_BOOK,
+  '%webView_resourcePanel_commentaries_bookNotAvailable%': COMMENTARY_MISSING_BOOK,
+};
+
+const RESOURCE_PROJECT_ID = 'project-web';
+
+const INSTALLED_RESOURCE: DblResourceData = {
+  dblEntryUid: 'uid-web',
+  displayName: 'WEB',
+  fullName: 'World English Bible',
+  bestLanguageName: 'English',
+  type: 'ScriptureResource',
+  size: 1200,
+  installed: true,
+  updateAvailable: false,
+  projectId: RESOURCE_PROJECT_ID,
+};
+
+const INSTALLED_COMMENTARY: DblResourceData = {
+  ...INSTALLED_RESOURCE,
+  dblEntryUid: 'uid-hbk',
+  displayName: 'HBKENG',
+  type: 'CommentaryResource',
+  projectId: 'project-hbk',
+};
+
+/** The row the panel is handed for an installed, referenced DBL resource. */
+function dblRow(resource: DblResourceData): PickerResource {
+  return {
+    reference: { type: 'dblResource', id: resource.dblEntryUid, name: resource.displayName },
+    source: 'admin',
+    isAdminLocked: false,
+    type: resource.type,
+    installed: true,
+    projectId: resource.projectId,
+  };
+}
+
+const WEB_ROW = dblRow(INSTALLED_RESOURCE);
+const COMMENTARY_ROW = dblRow(INSTALLED_COMMENTARY);
+
+/**
+ * A chapter with content. It carries a chapter marker and a verse because the panel distinguishes a
+ * populated chapter from a blank one by those nodes — USJ with an empty `content` array is a
+ * _blank_ chapter, not a generic stand-in.
+ */
+const SAMPLE_USJ: Usj = {
+  type: 'USJ',
+  version: '3.1',
+  content: [
+    { type: 'chapter', marker: 'c', number: '1' },
+    {
+      type: 'para',
+      marker: 'p',
+      content: [{ type: 'verse', marker: 'v', number: '1' }, 'In the beginning'],
+    },
+  ],
+};
+
+/** A chapter the resource has, but with nothing in it — no chapter marker and no verses. */
+const BLANK_USJ: Usj = { type: 'USJ', version: '3.1', content: [] };
+
+/**
+ * The exact message the C# `MissingBookException` produces. `parseMissingBookError` reads the book
+ * number and project id back out of it positionally, so a differently-worded rejection lands on the
+ * generic failure state instead — build the fixture from the real shape, never an approximation.
+ */
+function missingBookError(book: string, projectId = RESOURCE_PROJECT_ID) {
+  return {
+    platformErrorVersion: 1,
+    message: `Book number ${Canon.bookIdToNumber(book)} not found in project ${projectId}.`,
+  };
+}
+
+const MAT_1_1 = { book: 'MAT', chapterNum: 1, verseNum: 1 };
+
+function makeProps(overrides: Partial<ResourceTextPanelProps> = {}): ResourceTextPanelProps {
+  return {
+    localizedStrings: STRINGS,
+    hasProject: true,
+    resourceType: 'ScriptureResource',
+    filteredResources: [WEB_ROW],
+    selectedRef: WEB_ROW,
+    readiness: 'configured',
+    dblResources: [INSTALLED_RESOURCE],
+    onRetryCatalog: vi.fn(),
+    scrRef: MAT_1_1,
+    onScrRefChange: vi.fn(),
+    onSelectResource: vi.fn(),
+    usjPossiblyError: SAMPLE_USJ,
+    isUsjLoading: false,
+    textDirection: 'ltr',
+    isSelecting: false,
+    isInstalling: false,
+    installFailed: false,
+    retryInstall: vi.fn(),
+    isOnline: true,
+    // The panel's whole picker surface: it reports the activation and the web view owns the pick.
+    onShowResourcePicker: vi.fn(),
+    // Supplied by default because `logger` is optional and every diagnostic in the panel is behind
+    // it — a harness that omits it swallows a failed pick and a failed chapter read in the one
+    // suite that could otherwise catch them.
+    logger: { debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() },
+    ...overrides,
+  };
+}
+
+function renderPanel(overrides: Partial<ResourceTextPanelProps> = {}) {
+  const props = makeProps(overrides);
+  const utils = render(<ResourceTextPanel {...props} />);
+  return {
+    ...utils,
+    rerenderWith: (next: Partial<ResourceTextPanelProps> = {}) =>
+      utils.rerender(<ResourceTextPanel {...makeProps({ ...overrides, ...next })} />),
+  };
+}
+
+/** The editor is on screen AND holding scripture — the two halves of "the reader can read". */
+function expectEditorShowing() {
+  expect(screen.getByTestId(RESOURCE_TEXT_EDITOR_CONTAINER_TEST_ID)).toBeInTheDocument();
+  expect(screen.getByTestId('editorial')).toBeInTheDocument();
+}
+
+/**
+ * Everything the content area can put on screen. Asserted as one object so that "the panel is
+ * waiting" is a claim about ALL of them at once — checking only the message the test has in mind
+ * would pass just as happily on a panel showing a different one.
+ */
+function contentOnScreen() {
+  return {
+    editor: !!screen.queryByTestId('editorial'),
+    missingBook: !!screen.queryByText(BIBLE_TEXT_MISSING_BOOK),
+    blankChapter: !!screen.queryByText(BLANK_CHAPTER),
+    unavailable: !!screen.queryByText(TEXT_UNAVAILABLE),
+  };
+}
+
+/** No message and no editor — the panel is waiting. */
+const NOTHING_ON_SCREEN = {
+  editor: false,
+  missingBook: false,
+  blankChapter: false,
+  unavailable: false,
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  setUsjSpy.mockClear();
+});
+
+describe('ResourceTextPanel book not in this resource', () => {
+  it('explains that the Bible text does not contain the book, instead of showing a blank editor', () => {
+    renderPanel({ usjPossiblyError: missingBookError('MAT') });
+
+    expect(screen.getByText(BIBLE_TEXT_MISSING_BOOK)).toBeInTheDocument();
+    expect(screen.queryByTestId('editorial')).not.toBeInTheDocument();
+  });
+
+  it('uses the commentary wording when the panel is showing a commentary', () => {
+    renderPanel({
+      resourceType: 'CommentaryResource',
+      filteredResources: [COMMENTARY_ROW],
+      selectedRef: COMMENTARY_ROW,
+      dblResources: [INSTALLED_COMMENTARY],
+      usjPossiblyError: missingBookError('MAT', INSTALLED_COMMENTARY.projectId),
+    });
+
+    expect(screen.getByText(COMMENTARY_MISSING_BOOK)).toBeInTheDocument();
+    expect(screen.queryByText(BIBLE_TEXT_MISSING_BOOK)).not.toBeInTheDocument();
+  });
+
+  it('keeps the resource selector on screen, because switching texts is the only remedy', () => {
+    renderPanel({ usjPossiblyError: missingBookError('MAT') });
+
+    expect(screen.getByText(BIBLE_TEXT_MISSING_BOOK)).toBeInTheDocument();
+    // The selector renders the resolved resource's label; losing it would strip the one control
+    // that can get the reader to a text containing this book.
+    expect(screen.getByRole('button', { name: /WEB/ })).toBeInTheDocument();
+  });
+
+  it('re-feeds the editor when the user navigates to a book the resource does contain', () => {
+    const { rerenderWith } = renderPanel({ usjPossiblyError: missingBookError('MAT') });
+    expect(screen.getByText(BIBLE_TEXT_MISSING_BOOK)).toBeInTheDocument();
+    // `toHaveBeenLastCalledWith` below matches the whole call history on a spy this file clears only
+    // in `afterEach`, so clear it here to pin the transition rather than any earlier feed.
+    setUsjSpy.mockClear();
+
+    rerenderWith({
+      scrRef: { book: 'GEN', chapterNum: 1, verseNum: 1 },
+      usjPossiblyError: SAMPLE_USJ,
+    });
+
+    expect(screen.queryByText(BIBLE_TEXT_MISSING_BOOK)).not.toBeInTheDocument();
+    expectEditorShowing();
+    // The message arm unmounted the editor, so the remount holds nothing until this effect refills
+    // it. Without the feed the reader gets Lexical's "Enter some Scripture…" placeholder — an edit
+    // invitation in a text they cannot edit.
+    expect(setUsjSpy).toHaveBeenLastCalledWith(SAMPLE_USJ);
+  });
+
+  it('keeps waiting when the failure names the book the user just left', () => {
+    renderPanel({ scrRef: MAT_1_1, usjPossiblyError: missingBookError('GEN') });
+
+    expect(contentOnScreen()).toEqual(NOTHING_ON_SCREEN);
+  });
+
+  it('keeps waiting when the failure names a resource the panel has switched away from', () => {
+    renderPanel({ usjPossiblyError: missingBookError('MAT', 'some-other-project') });
+
+    expect(contentOnScreen()).toEqual(NOTHING_ON_SCREEN);
+  });
+});
+
+describe('ResourceTextPanel blank chapter', () => {
+  it('says the chapter is empty when the resource has the book but nothing in the chapter', () => {
+    renderPanel({ usjPossiblyError: BLANK_USJ });
+
+    expect(screen.getByText(BLANK_CHAPTER)).toBeInTheDocument();
+    expect(screen.queryByTestId('editorial')).not.toBeInTheDocument();
+  });
+
+  it('does not call a chapter empty while it is still arriving', () => {
+    // The data layer keeps serving the previous reference's USJ until the new subscription's first
+    // update lands, and its default is itself blank — so a blank value in hand means nothing until
+    // the read has settled. This is the state every navigation passes through.
+    renderPanel({ usjPossiblyError: BLANK_USJ, isUsjLoading: true });
+
+    expect(screen.queryByText(BLANK_CHAPTER)).not.toBeInTheDocument();
+  });
+
+  it('re-feeds the editor when the message gives way to it with the same chapter in hand', () => {
+    const { rerenderWith } = renderPanel({ usjPossiblyError: BLANK_USJ, isUsjLoading: false });
+    expect(screen.getByText(BLANK_CHAPTER)).toBeInTheDocument();
+    setUsjSpy.mockClear();
+
+    // A new read starts, so the blank USJ in hand is no longer a trustworthy "empty": the message
+    // goes and the editor returns — holding the very same USJ object, which is exactly why the feed
+    // cannot be keyed on the USJ alone.
+    rerenderWith({ usjPossiblyError: BLANK_USJ, isUsjLoading: true });
+
+    expectEditorShowing();
+    expect(setUsjSpy).toHaveBeenCalledWith(BLANK_USJ);
+  });
+
+  it('calls a book the resource lacks missing, not empty', () => {
+    // Both conditions hold at once: the read failed AND the USJ in hand is blank. The missing book
+    // is the more specific claim, so it wins.
+    renderPanel({ usjPossiblyError: missingBookError('MAT') });
+
+    expect(screen.getByText(BIBLE_TEXT_MISSING_BOOK)).toBeInTheDocument();
+    expect(screen.queryByText(BLANK_CHAPTER)).not.toBeInTheDocument();
+  });
+});
+
+describe('ResourceTextPanel content that cannot be shown', () => {
+  it('names an unrelated failure instead of spinning forever', () => {
+    // Terminal: the value in hand is an error rather than USJ, and nothing re-emits until the data
+    // provider does — so a spinner here would claim progress that never arrives.
+    renderPanel({
+      usjPossiblyError: { platformErrorVersion: 1, message: 'The disk caught fire.' },
+    });
+
+    expect(screen.getByText(TEXT_UNAVAILABLE)).toBeInTheDocument();
+    expect(screen.queryByTestId('editorial')).not.toBeInTheDocument();
+  });
+
+  it('waits while the chapter is still on its way, rather than mounting an empty editor', () => {
+    // `Editorial` with nothing set paints its "Enter some Scripture…" placeholder, which invites an
+    // edit in a text the reader cannot edit.
+    renderPanel({ usjPossiblyError: undefined });
+
+    expect(contentOnScreen()).toEqual(NOTHING_ON_SCREEN);
+  });
+});
+
+describe('ResourceTextPanel logging', () => {
+  it('logs a missing book at debug and any other failure at error', () => {
+    // A named, terminal message looks the same whatever went wrong, so the log is the only place
+    // the cause survives. A missing book is ordinary navigation rather than a fault, so it goes to
+    // `debug`, which packaged builds drop.
+    const logger = { debug: vi.fn(), error: vi.fn(), warn: vi.fn(), info: vi.fn() };
+    const { rerenderWith } = renderPanel({ usjPossiblyError: missingBookError('MAT'), logger });
+
+    expect(logger.debug).toHaveBeenCalledTimes(1);
+    expect(logger.error).not.toHaveBeenCalled();
+
+    rerenderWith({
+      usjPossiblyError: { platformErrorVersion: 1, message: 'The disk caught fire.' },
+      logger,
+    });
+
+    expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ResourceTextPanel resource picker', () => {
+  it('opens the picker from the empty-state prompt', () => {
+    // The panel's own state machine hides this button behind `readiness`, so nothing else in this
+    // suite reaches it. Without a case here the picker prop is unverified: stubbing it to a no-op
+    // leaves every other test green, which makes it the one prop a refactor can quietly break.
+    const onShowResourcePicker = vi.fn();
+    renderPanel({ readiness: 'empty', onShowResourcePicker });
+
+    fireEvent.click(screen.getByRole('button', { name: PICK_BIBLE_TEXTS }));
+
+    expect(onShowResourcePicker).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
@@ -177,12 +177,20 @@ function expectEditorShowing() {
 }
 
 /**
- * Everything the content area can put on screen. Asserted as one object so that "the panel is
- * waiting" is a claim about ALL of them at once — checking only the message the test has in mind
- * would pass just as happily on a panel showing a different one.
+ * Everything the content area can put on screen, plus the selector as a positive control. Asserted
+ * as one object so that "the panel is waiting" is a claim about ALL of them at once — checking only
+ * the message the test has in mind would pass just as happily on a panel showing a different one.
+ *
+ * `selector` is what makes the waiting assertions falsifiable. Every one of them is otherwise
+ * purely negative, and a negative assertion passes just as well against a panel that rendered
+ * nothing at all: replacing this component's whole render with `<div />` leaves them green. The
+ * selector stays mounted in every content state by design — losing it would strip the reader's only
+ * route to a text that has the book — so requiring it proves the panel is alive and that the
+ * content area specifically is empty.
  */
 function contentOnScreen() {
   return {
+    selector: !!screen.queryByRole('button', { name: /WEB|HBKENG/ }),
     editor: !!screen.queryByTestId('editorial'),
     missingBook: !!screen.queryByText(BIBLE_TEXT_MISSING_BOOK),
     blankChapter: !!screen.queryByText(BLANK_CHAPTER),
@@ -190,8 +198,9 @@ function contentOnScreen() {
   };
 }
 
-/** No message and no editor — the panel is waiting. */
-const NOTHING_ON_SCREEN = {
+/** The selector and nothing else: the panel is alive and the content area is waiting. */
+const NOTHING_BUT_THE_SELECTOR = {
+  selector: true,
   editor: false,
   missingBook: false,
   blankChapter: false,
@@ -256,13 +265,13 @@ describe('ResourceTextPanel book not in this resource', () => {
   it('keeps waiting when the failure names the book the user just left', () => {
     renderPanel({ scrRef: MAT_1_1, usjPossiblyError: missingBookError('GEN') });
 
-    expect(contentOnScreen()).toEqual(NOTHING_ON_SCREEN);
+    expect(contentOnScreen()).toEqual(NOTHING_BUT_THE_SELECTOR);
   });
 
   it('keeps waiting when the failure names a resource the panel has switched away from', () => {
     renderPanel({ usjPossiblyError: missingBookError('MAT', 'some-other-project') });
 
-    expect(contentOnScreen()).toEqual(NOTHING_ON_SCREEN);
+    expect(contentOnScreen()).toEqual(NOTHING_BUT_THE_SELECTOR);
   });
 });
 
@@ -280,7 +289,16 @@ describe('ResourceTextPanel blank chapter', () => {
     // the read has settled. This is the state every navigation passes through.
     renderPanel({ usjPossiblyError: BLANK_USJ, isUsjLoading: true });
 
-    expect(screen.queryByText(BLANK_CHAPTER)).not.toBeInTheDocument();
+    // Asserted as the whole content area rather than just the absent message: what should be on
+    // screen is the EDITOR, and a bare `not.toBeInTheDocument()` would pass against a panel that
+    // rendered nothing at all.
+    expect(contentOnScreen()).toEqual({
+      selector: true,
+      editor: true,
+      missingBook: false,
+      blankChapter: false,
+      unavailable: false,
+    });
   });
 
   it('re-feeds the editor when the message gives way to it with the same chapter in hand', () => {
@@ -324,7 +342,7 @@ describe('ResourceTextPanel content that cannot be shown', () => {
     // edit in a text the reader cannot edit.
     renderPanel({ usjPossiblyError: undefined });
 
-    expect(contentOnScreen()).toEqual(NOTHING_ON_SCREEN);
+    expect(contentOnScreen()).toEqual(NOTHING_BUT_THE_SELECTOR);
   });
 });
 

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { afterEach, describe, it, expect, vi } from 'vitest';
+import { afterEach, beforeAll, describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -24,6 +24,22 @@ import {
  * editor is on screen" the only observable fact, which a permanently blank editor also satisfies.
  */
 const setUsjSpy = vi.fn();
+
+// jsdom implements no `IntersectionObserver`, and the panel's reveal-scroll effect reaches one
+// through `useViewVisibility`. A no-op stub keeps rendering from throwing; the tests below assert on
+// content states rather than on scroll behaviour, so nothing depends on it reporting visibility.
+// Matches the stub in `platform-scripture`'s `find.component.test.tsx`.
+beforeAll(() => {
+  vi.stubGlobal(
+    'IntersectionObserver',
+    vi.fn(() => ({
+      observe: vi.fn(),
+      unobserve: vi.fn(),
+      disconnect: vi.fn(),
+      takeRecords: vi.fn(() => []),
+    })),
+  );
+});
 
 vi.mock('@eten-tech-foundation/platform-editor', () => ({
   Editorial: React.forwardRef((_props: Record<string, unknown>, ref: React.Ref<unknown>) => {

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
@@ -2,6 +2,7 @@
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import * as React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import type { Usj } from '@eten-tech-foundation/scripture-utilities';
 import { Canon } from '@sillsdev/scripture';
@@ -369,6 +370,31 @@ describe('ResourceTextPanel logging', () => {
     });
 
     expect(logger.error).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ResourceTextPanel resource selection', () => {
+  it('reports the row the user chose from the dropdown', async () => {
+    // The dropdown is the only way a user changes which text the panel displays, so this is its
+    // primary control — and like the picker below, stubbing it to a no-op leaves every other test
+    // in this file green.
+    const onSelectResource = vi.fn();
+    renderPanel({
+      filteredResources: [WEB_ROW, COMMENTARY_ROW],
+      selectedRef: WEB_ROW,
+      dblResources: [INSTALLED_RESOURCE, INSTALLED_COMMENTARY],
+      onSelectResource,
+    });
+
+    // `userEvent` rather than `fireEvent`: the Radix trigger opens on a real pointer sequence, and
+    // this is the pattern the repo's other Radix dropdown tests use.
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('button', { name: /WEB/ }));
+    await user.click(await screen.findByRole('menuitemcheckbox', { name: /HBKENG/ }));
+
+    // The namespaced row id, not the bare DBL entry uid — `resolveResourceSelection` compares row
+    // ids, so reporting the bare id would never match the list.
+    expect(onSelectResource).toHaveBeenCalledWith('dbl:uid-hbk');
   });
 });
 

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
@@ -338,6 +338,24 @@ describe('ResourceTextPanel blank chapter', () => {
     expect(setUsjSpy).toHaveBeenCalledWith(BLANK_USJ);
   });
 
+  it('re-feeds the editor when the resource resolves with the same chapter already in hand', () => {
+    // The row is picked but not yet resolved to a project, so the chapter in hand cannot be
+    // attributed to it: a spinner, not content. The USJ object never changes across this
+    // transition, which is why the feed cannot be keyed on the USJ alone.
+    const unresolvedRow: PickerResource = { ...WEB_ROW, projectId: undefined };
+    const { rerenderWith } = renderPanel({
+      selectedRef: unresolvedRow,
+      usjPossiblyError: SAMPLE_USJ,
+    });
+    expect(screen.getByTestId(RESOURCE_TEXT_WAITING_TEST_ID)).toBeInTheDocument();
+    setUsjSpy.mockClear();
+
+    rerenderWith({ selectedRef: WEB_ROW, usjPossiblyError: SAMPLE_USJ });
+
+    expectEditorShowing();
+    expect(setUsjSpy).toHaveBeenCalledWith(SAMPLE_USJ);
+  });
+
   it('calls a book the resource lacks missing, not empty', () => {
     // Both conditions hold at once: the read failed AND the USJ in hand is blank. The missing book
     // is the more specific claim, so it wins.

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
@@ -9,6 +9,7 @@ import type { DblResourceData } from 'platform-bible-utils';
 import type { PickerResource } from './downloaded-resources.utils';
 import {
   RESOURCE_TEXT_EDITOR_CONTAINER_TEST_ID,
+  RESOURCE_TEXT_WAITING_TEST_ID,
   ResourceTextPanel,
   ResourceTextPanelProps,
 } from './resource-text-panel.component';
@@ -181,16 +182,18 @@ function expectEditorShowing() {
  * as one object so that "the panel is waiting" is a claim about ALL of them at once — checking only
  * the message the test has in mind would pass just as happily on a panel showing a different one.
  *
- * `selector` is what makes the waiting assertions falsifiable. Every one of them is otherwise
- * purely negative, and a negative assertion passes just as well against a panel that rendered
- * nothing at all: replacing this component's whole render with `<div />` leaves them green. The
- * selector stays mounted in every content state by design — losing it would strip the reader's only
- * route to a text that has the book — so requiring it proves the panel is alive and that the
- * content area specifically is empty.
+ * `spinner` is what makes the waiting assertions falsifiable, and it has to be the SPINNER rather
+ * than anything outside the content area. Each waiting assertion is otherwise purely negative, and
+ * a negative assertion passes just as well against a content area that rendered nothing at all —
+ * deleting both spinner branches from `renderContent` leaves such tests green. `selector` cannot
+ * stand in for it: the selector renders OUTSIDE `renderContent`, so it is invariant across every
+ * content branch and cannot tell "spinner" from "nothing". It is kept as a second control, for the
+ * whole-panel early returns, which do replace it.
  */
 function contentOnScreen() {
   return {
     selector: !!screen.queryByRole('button', { name: /WEB|HBKENG/ }),
+    spinner: !!screen.queryByTestId(RESOURCE_TEXT_WAITING_TEST_ID),
     editor: !!screen.queryByTestId('editorial'),
     missingBook: !!screen.queryByText(BIBLE_TEXT_MISSING_BOOK),
     blankChapter: !!screen.queryByText(BLANK_CHAPTER),
@@ -198,9 +201,10 @@ function contentOnScreen() {
   };
 }
 
-/** The selector and nothing else: the panel is alive and the content area is waiting. */
-const NOTHING_BUT_THE_SELECTOR = {
+/** The panel is alive and its content area is showing the spinner rather than any outcome. */
+const WAITING_FOR_CONTENT = {
   selector: true,
+  spinner: true,
   editor: false,
   missingBook: false,
   blankChapter: false,
@@ -265,13 +269,13 @@ describe('ResourceTextPanel book not in this resource', () => {
   it('keeps waiting when the failure names the book the user just left', () => {
     renderPanel({ scrRef: MAT_1_1, usjPossiblyError: missingBookError('GEN') });
 
-    expect(contentOnScreen()).toEqual(NOTHING_BUT_THE_SELECTOR);
+    expect(contentOnScreen()).toEqual(WAITING_FOR_CONTENT);
   });
 
   it('keeps waiting when the failure names a resource the panel has switched away from', () => {
     renderPanel({ usjPossiblyError: missingBookError('MAT', 'some-other-project') });
 
-    expect(contentOnScreen()).toEqual(NOTHING_BUT_THE_SELECTOR);
+    expect(contentOnScreen()).toEqual(WAITING_FOR_CONTENT);
   });
 });
 
@@ -294,6 +298,7 @@ describe('ResourceTextPanel blank chapter', () => {
     // rendered nothing at all.
     expect(contentOnScreen()).toEqual({
       selector: true,
+      spinner: false,
       editor: true,
       missingBook: false,
       blankChapter: false,
@@ -342,7 +347,7 @@ describe('ResourceTextPanel content that cannot be shown', () => {
     // edit in a text the reader cannot edit.
     renderPanel({ usjPossiblyError: undefined });
 
-    expect(contentOnScreen()).toEqual(NOTHING_BUT_THE_SELECTOR);
+    expect(contentOnScreen()).toEqual(WAITING_FOR_CONTENT);
   });
 });
 

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.test.tsx
@@ -36,12 +36,12 @@ const COMMENTARY_MISSING_BOOK = 'This book does not exist in this commentary.';
 const BLANK_CHAPTER = 'This chapter is empty in this resource.';
 const TEXT_UNAVAILABLE = 'This text could not be loaded.';
 const PICK_BIBLE_TEXTS = 'Pick Bible texts…';
+const SELECTING = 'Selecting resource…';
 
 const STRINGS = {
   '%webView_platformScriptureEditor_emptyChapter_messageResource%': BLANK_CHAPTER,
   '%webView_resourcePanel_noProject%': 'No project.',
   '%webView_resourcePanel_installing%': 'Installing resource…',
-  '%webView_resourcePanel_selecting%': 'Selecting resource…',
   '%webView_resourcePanel_installFailed%': "The resource couldn't be installed.",
   '%webView_resourcePanel_installFailedOffline%':
     "The resource couldn't be installed. Check your connection and try again.",
@@ -53,6 +53,7 @@ const STRINGS = {
   '%webView_resourcePanel_bibleTexts_emptyState_prompt%':
     'No Bible texts selected. Pick one to display a reference translation alongside your project.',
   '%webView_resourcePanel_bibleTexts_pick%': PICK_BIBLE_TEXTS,
+  '%webView_resourcePanel_selecting%': SELECTING,
   '%webView_resourcePanel_textUnavailable%': TEXT_UNAVAILABLE,
   '%webView_resourcePanel_bibleTexts_bookNotAvailable%': BIBLE_TEXT_MISSING_BOOK,
   '%webView_resourcePanel_commentaries_bookNotAvailable%': COMMENTARY_MISSING_BOOK,
@@ -382,5 +383,23 @@ describe('ResourceTextPanel resource picker', () => {
     fireEvent.click(screen.getByRole('button', { name: PICK_BIBLE_TEXTS }));
 
     expect(onShowResourcePicker).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ResourceTextPanel pick in flight', () => {
+  it('reports progress during a first pick, when nothing is configured yet', () => {
+    // A first pick cannot show up in the reference list until `selectTextConnection` has installed
+    // the resource and the write has propagated back, so readiness is still `empty` for the whole
+    // download. If the readiness branch were tested first the reader would sit on "no texts
+    // selected" — with an enabled pick button and no progress — until it finished.
+    renderPanel({
+      readiness: 'empty',
+      filteredResources: [],
+      selectedRef: undefined,
+      isSelecting: true,
+    });
+
+    expect(screen.getByText(SELECTING)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: PICK_BIBLE_TEXTS })).not.toBeInTheDocument();
   });
 });

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
@@ -503,6 +503,12 @@ export function ResourceTextPanel({
   // Distinguish the two causes so the label is accurate: a user pick (isSelecting) reads
   // "Selecting…", while an auto-install of an already-configured resource (isInstalling) — where
   // the user picked nothing and it is just downloading — reads "Installing…".
+  //
+  // TODO(PT-4561): Fold this into `getResourcePanelReadiness` so branch order here is not a second
+  // answer to "is this panel ready?", per `adr-panel-readiness-from-sources`. Ordering it here also
+  // makes a pick in flight outrank an unreadable settings list, which that function's own precedence
+  // argues against — PT-4561 decides that deliberately. `model-text-panel.component.tsx` still tests
+  // readiness first and so has this same first-pick defect.
   if (isSelecting || isInstalling) {
     return (
       <LoadingView

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
@@ -345,6 +345,26 @@ export function ResourceTextPanel({
     );
   }
 
+  // Ahead of the readiness branch below, because a pick in flight outranks what the reference list
+  // currently says. On a FIRST pick the list is still empty — the resource is not referenced until
+  // `selectTextConnection` has installed it and the write has propagated back — so readiness is
+  // `empty`, and testing readiness first would leave the reader on "no texts selected", with an
+  // enabled pick button and no progress, for the whole download.
+  //
+  // Distinguish the two causes so the label is accurate: a user pick (isSelecting) reads
+  // "Selecting…", while an auto-install of an already-configured resource (isInstalling) — where
+  // the user picked nothing and it is just downloading — reads "Installing…".
+  if (isSelecting || isInstalling) {
+    return (
+      <LoadingView
+        label={localize(
+          localizedStrings,
+          isSelecting ? '%webView_resourcePanel_selecting%' : '%webView_resourcePanel_installing%',
+        )}
+      />
+    );
+  }
+
   // Front of the state machine: still resolving, unreadable setting, or genuinely nothing
   // configured. Driven by one readiness value so the empty prompt can only appear once emptiness is
   // actually known — the loading branch deliberately outlasts the catalog fetch when something is
@@ -402,21 +422,6 @@ export function ResourceTextPanel({
         )}
         retryLabel={localize(localizedStrings, '%webView_resourcePanel_retry%')}
         onRetry={retryInstall}
-      />
-    );
-  }
-
-  // Installing state: selected DblResource found but not yet installed. Distinguish the two causes
-  // so the label is accurate: a user pick (isSelecting) reads "Selecting…", while an auto-install
-  // of a configured resource (isInstalling) — where the user picked nothing and it's just
-  // downloading — reads "Installing…".
-  if (isSelecting || isInstalling) {
-    return (
-      <LoadingView
-        label={localize(
-          localizedStrings,
-          isSelecting ? '%webView_resourcePanel_selecting%' : '%webView_resourcePanel_installing%',
-        )}
       />
     );
   }

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
@@ -55,6 +55,14 @@ const localize = (strings: ResourcePanelLocalizedStrings, key: ResourcePanelLoca
  */
 export const RESOURCE_TEXT_EDITOR_CONTAINER_TEST_ID = 'resource-text-editor-container';
 
+/**
+ * Identifies the content area's waiting state. `Spinner` is a bare `LoaderCircle` SVG with no role
+ * and no accessible name, so without a handle here a test can only assert that the messages and the
+ * editor are ABSENT — which a content area rendering nothing at all satisfies just as well.
+ * Asserting the spinner is present is what makes "the panel is waiting" a falsifiable claim.
+ */
+export const RESOURCE_TEXT_WAITING_TEST_ID = 'resource-text-waiting';
+
 type ResourceSelectorDropdownProps = {
   filteredResources: PickerResource[];
   selectedRef: PickerResource | undefined;
@@ -431,7 +439,10 @@ export function ResourceTextPanel({
   const renderContent = () => {
     if (contentState === 'loading')
       return (
-        <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
+        <div
+          className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8"
+          data-testid={RESOURCE_TEXT_WAITING_TEST_ID}
+        >
           <Spinner />
         </div>
       );
@@ -478,7 +489,10 @@ export function ResourceTextPanel({
     // cannot edit.
     if (!usjFromPdp)
       return (
-        <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
+        <div
+          className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8"
+          data-testid={RESOURCE_TEXT_WAITING_TEST_ID}
+        >
           <Spinner />
         </div>
       );

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
@@ -11,6 +11,7 @@ import {
   DropdownMenuTrigger,
   Spinner,
   useExtraValidMarkers,
+  useViewVisibility,
 } from 'platform-bible-react';
 import {
   DblResourceData,
@@ -20,12 +21,22 @@ import {
   ResourceType,
 } from 'platform-bible-utils';
 import { ChevronDown } from 'lucide-react';
-import { ComponentProps, useEffect, useMemo, useRef } from 'react';
+import { ComponentProps, useCallback, useEffect, useMemo, useRef } from 'react';
+import {
+  hasNewScrollTarget,
+  isEchoOfPublishedScrRef,
+  SCROLL_MAX_WAIT_MS,
+  scrollToVerse,
+} from './editor-dom.util';
 import { getRefLabel, getResourceReferenceRowId } from './resource-reference.utils';
 import type { PickerResource } from './downloaded-resources.utils';
 import type { ResourcePanelReadiness } from './resource-panel-readiness.utils';
 import { PanelReadinessView } from './panel-readiness-view.component';
-import { ExpandableInfo, LoadingView, RetryableErrorView } from './panel-state-views.component';
+import {
+  ExpandableInfo,
+  LoadingView,
+  PanelRetryableErrorView,
+} from './panel-state-views.component';
 import { ResourceBookNotAvailable } from './resource-book-not-available.component';
 import { ResourceBlankChapter } from './resource-blank-chapter.component';
 import { ResourceTextUnavailable } from './resource-text-unavailable.component';
@@ -291,6 +302,22 @@ export function ResourceTextPanel({
   // EditorRef requires null initial value per React ref convention
   // eslint-disable-next-line no-null/no-null
   const editorRef = useRef<EditorRef | null>(null);
+  // What this panel last published to its scroll group, and what it last successfully scrolled to.
+  // Both feed the guards on the reveal-scroll effect below.
+  const lastPublishedScrRefRef = useRef<SerializedVerseRef | undefined>(undefined);
+  const lastScrolledForRef = useRef<{ scrRef: SerializedVerseRef; usj: unknown } | undefined>(
+    undefined,
+  );
+  const isViewVisible = useViewVisibility();
+
+  // Record what we publish before forwarding it, so the bounce-back can be recognised as our own.
+  const handleScrRefChange = useCallback(
+    (newScrRef: SerializedVerseRef) => {
+      lastPublishedScrRefRef.current = newScrRef;
+      onScrRefChange(newScrRef);
+    },
+    [onScrRefChange],
+  );
   // Markers this resource's content actually uses. Passed to the editor as extraValidMarkers so it
   // doesn't warn "Unexpected <kind> marker" for handbook/commentary markers (e.g. \pn, \jmp) — scoped
   // per-resource from the USJ being displayed, never a global list. Empty for content that needs
@@ -328,6 +355,128 @@ export function ResourceTextPanel({
   useEffect(() => {
     if (usjFromPdp) editorRef.current?.setUsj(usjFromPdp);
   }, [usjFromPdp, contentState, isBlankChapter]);
+
+  // Scroll to the current verse when this tab is shown, and again once a chapter's content lands.
+  //
+  // `Editorial` renders the reference it is given but does not scroll to the verse — every consumer
+  // that scrolls does it by calling `scrollToVerse`, as the Scripture editor and the model text
+  // panel both do.
+  //
+  // Keyed on visibility AND on the reference: visibility covers the reveal (a tab activation carries
+  // no reference change of its own), and the reference covers "go to result" landing on a panel that
+  // is already visible.
+  useEffect(() => {
+    // The echo is consumed FIRST, and whether or not this panel is visible. A verse click inside
+    // `Editorial` publishes to scroll group 0 and bounces straight back as a prop update; scrolling
+    // on that would yank the user's own click target to the top. Leaving the latch armed because
+    // the panel happened to be hidden would be worse: a later, genuine "go to result" onto that
+    // same verse would look like an echo and be swallowed, and a panel registers no web view
+    // controller, so nothing would retry it.
+    if (isEchoOfPublishedScrRef(lastPublishedScrRefRef.current, scrRef)) {
+      lastPublishedScrRefRef.current = undefined;
+      // The clicked verse IS this panel's position now. Recording it keeps a later bare reveal from
+      // treating it as a new target and snapping away from wherever the user has since scrolled.
+      lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
+      return undefined;
+    }
+    // The latch is only ever valid for the very NEXT reference, so any other reference discards it.
+    // Otherwise a publish whose echo never arrives as its own update — a Find result writing to the
+    // group before the round-trip lands — leaves the latch armed forever, and a later genuine "go to
+    // result" onto that verse would match it and be swallowed.
+    lastPublishedScrRefRef.current = undefined;
+
+    // `isUsjLoading` is the guard that keeps a scroll off the PREVIOUS chapter: `useProjectData`
+    // holds the old USJ across a selector change, and that content is fully laid out, so the settle
+    // loop below would happily accept it. `scrollToVerse` matches on verse number alone, with no
+    // book or chapter qualifier, so scrolling then lands on — and pulses — the same verse number in
+    // the wrong chapter.
+    if (!isViewVisible || !usjFromPdp || isUsjLoading) return undefined;
+
+    // Nothing new since the last scroll — this is a bare reveal, so leave the user's scroll alone.
+    if (!hasNewScrollTarget(lastScrolledForRef.current, scrRef, usjFromPdp)) return undefined;
+
+    // Wait for the revealed pane's layout to SETTLE, then scroll exactly once.
+    //
+    // Two traps here. First, the verse marker enters the DOM before the chapter has finished laying
+    // out, so an offset computed at that moment is measured against a much shorter content box and
+    // scrolls to a fraction of the real target. Second — and why a naive rAF retry does not rescue
+    // it — `scrollToVerse` scrolls with `behavior: 'smooth'`, so re-calling it every frame restarts
+    // the animation from wherever it had crept to and it never converges.
+    //
+    // Sampling the scroll container's height until it stops changing avoids both: the geometry is
+    // trustworthy by then, and the single call that follows animates uninterrupted.
+    let cancelled = false;
+    const start = Date.now();
+    let lastScrollHeight = -1;
+    // Pulses the verse we land on, so the match is identifiable when several share a verse or a
+    // commentary entry is long. Same treatment the Scripture editor gives an arrived verse.
+    let highlightedVerseElement: HTMLElement | undefined;
+    const scrollWhenSettled = () => {
+      if (cancelled) return;
+      const timedOut = Date.now() - start > SCROLL_MAX_WAIT_MS;
+
+      // Below verse 1 means the chapter top, which `scrollToVerse` reaches without a verse marker
+      // and so without settled geometry — but it still needs the container in the DOM, and it
+      // cannot report that, since it returns an element only when it matched a marker. So the
+      // container is checked here before recording; otherwise a reveal that beat the container into
+      // the DOM would scroll nothing and still be recorded as done. Verse 1 is NOT in this case: it
+      // has a real marker and real geometry, so it goes through the settle loop like any other.
+      if (scrRef.verseNum < 1) {
+        if (document.querySelector('.editor-container')) {
+          scrollToVerse(scrRef);
+          lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
+          return;
+        }
+        if (timedOut) return;
+        requestAnimationFrame(scrollWhenSettled);
+        return;
+      }
+
+      // `.editor-container` is sampled as a CONTENT-GROWTH PROXY, not as the scroll container.
+      // Which element actually scrolls differs by host — `_editor-overrides.scss` warns that this
+      // one is auto-height in the Scripture editor and its wrapper scrolls instead — so the scroll
+      // itself is left to `scrollToVerse`, which discovers the container via `findScrollContainer`.
+      // Only the height is read here, and that tracks the chapter laying out either way.
+      const contentElement = document.querySelector<HTMLElement>('.editor-container');
+      // `querySelector` yields null, not undefined, so compare truthily — treating a missing
+      // element as "settled" would scroll against geometry that does not exist yet.
+      const scrollHeight = contentElement ? contentElement.scrollHeight : -1;
+      const isSettled = !!contentElement && scrollHeight === lastScrollHeight;
+      lastScrollHeight = scrollHeight;
+
+      if (isSettled) {
+        highlightedVerseElement = scrollToVerse(scrRef);
+        // Only a scroll that actually landed is recorded. The verse marker can be genuinely absent
+        // — a `\v 16-17` range publishes no `[data-number="17"]` — so recording regardless would
+        // make `hasNewScrollTarget` answer "same target" forever and the panel would never catch up
+        // on a later reveal.
+        if (highlightedVerseElement) {
+          lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
+          highlightedVerseElement.classList.add('highlighted');
+          return;
+        }
+        // Settled but no marker yet. Two consecutive equal heights are cheap to reach — an empty,
+        // flex-sized container reports the same height every frame before Lexical has reconciled
+        // the chapter — so "settled" is not "rendered". Keep waiting rather than treating one
+        // agreeing pair as the answer; `scrollToVerse` does not scroll without a marker, so
+        // re-calling it cannot restart an animation.
+      }
+      // Out of time: give up WITHOUT recording, so a later reveal tries again instead of being
+      // told the target is unchanged.
+      if (timedOut) return;
+      requestAnimationFrame(scrollWhenSettled);
+    };
+    scrollWhenSettled();
+    return () => {
+      cancelled = true;
+      highlightedVerseElement?.classList.remove('highlighted');
+    };
+    // The rule wants `scrRef` itself, but this effect is keyed on the three fields that decide where
+    // to scroll. `useWebViewScrollGroupScrRef` hands back a fresh object whenever the scroll group
+    // publishes, including for a reference that did not change, so depending on the object would
+    // restart the settle loop on updates that cannot move the target.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isViewVisible, usjFromPdp, isUsjLoading, scrRef.book, scrRef.chapterNum, scrRef.verseNum]);
 
   // #endregion
 
@@ -413,7 +562,7 @@ export function ResourceTextPanel({
   // (the usual first-run cause), hint at the connection.
   if (installFailed) {
     return (
-      <RetryableErrorView
+      <PanelRetryableErrorView
         message={localize(
           localizedStrings,
           isOnline
@@ -508,25 +657,10 @@ export function ResourceTextPanel({
         dir={options.textDirection}
         data-testid={RESOURCE_TEXT_EDITOR_CONTAINER_TEST_ID}
       >
-        {/*
-          Hidden case: intentionally not handled. In Simple mode the Bible texts and Commentaries
-          tabs share one Column 3 stack, so whichever is inactive stays mounted under
-          `display: none` and keeps receiving scroll-group reference changes. The data half needs
-          nothing — the chapter subscription keeps delivering and the `setUsj` feed above works
-          without layout — but `Editorial` navigating to `scrRef` is geometry, and scrolling inside
-          a display-none iframe no-ops. So a panel that was hidden across several reference changes
-          can show the right chapter scrolled to the wrong verse until the next move, because the
-          feed will not re-run for a chapter whose USJ has not changed.
-
-          Accepted rather than deferred with `useViewVisibility`/`useRunWhenVisible`: this panel is
-          read-only with no scroll state of its own worth catching up, the chapter on screen is
-          always correct, and the next reference change corrects the verse. Revisit if the panel
-          ever gains its own scroll position or a highlight to keep in sync.
-        */}
         <Editorial
           ref={editorRef}
           scrRef={scrRef}
-          onScrRefChange={onScrRefChange}
+          onScrRefChange={handleScrRefChange}
           options={options}
           logger={logger}
         />

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
@@ -508,6 +508,21 @@ export function ResourceTextPanel({
         dir={options.textDirection}
         data-testid={RESOURCE_TEXT_EDITOR_CONTAINER_TEST_ID}
       >
+        {/*
+          Hidden case: intentionally not handled. In Simple mode the Bible texts and Commentaries
+          tabs share one Column 3 stack, so whichever is inactive stays mounted under
+          `display: none` and keeps receiving scroll-group reference changes. The data half needs
+          nothing — the chapter subscription keeps delivering and the `setUsj` feed above works
+          without layout — but `Editorial` navigating to `scrRef` is geometry, and scrolling inside
+          a display-none iframe no-ops. So a panel that was hidden across several reference changes
+          can show the right chapter scrolled to the wrong verse until the next move, because the
+          feed will not re-run for a chapter whose USJ has not changed.
+
+          Accepted rather than deferred with `useViewVisibility`/`useRunWhenVisible`: this panel is
+          read-only with no scroll state of its own worth catching up, the chapter on screen is
+          always correct, and the next reference change corrects the verse. Revisit if the panel
+          ever gains its own scroll position or a highlight to keep in sync.
+        */}
         <Editorial
           ref={editorRef}
           scrRef={scrRef}

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
@@ -223,6 +223,14 @@ export type ResourceTextPanelProps = {
  * down as a prop and this component MUST NOT re-derive it — a second derivation would be a second
  * answer to one question, free to disagree with the subscription that produced the content on
  * screen. Resolve it once, in the caller, and pass it (see `resolveResourceSelection`).
+ *
+ * This callback-out shape is the pattern to follow for a panel component, not merely one of two
+ * in-tree options. `ModelTextPanelProps` takes `showResourcePicker` returning the chosen resource
+ * plus the get/set/install callbacks, and owns the pick, the install and the write inside the
+ * component; this panel takes an argument-free `onShowResourcePicker` and owns none of them.
+ * Keeping that work in the caller is what keeps `@papi` out of this file — which is what makes the
+ * component renderable from a test and a story at all, since neither can serve a PAPI call.
+ * `ModelTextPanel` has not converged yet; see PT-4561, which already touches both panels.
  */
 export function ResourceTextPanel({
   localizedStrings,

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.component.tsx
@@ -1,0 +1,528 @@
+import { Editorial, EditorOptions, EditorRef } from '@eten-tech-foundation/platform-editor';
+import { Usj } from '@eten-tech-foundation/scripture-utilities';
+import { Canon, SerializedVerseRef } from '@sillsdev/scripture';
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+  Spinner,
+  useExtraValidMarkers,
+} from 'platform-bible-react';
+import {
+  DblResourceData,
+  getErrorMessage,
+  isPlatformError,
+  PlatformError,
+  ResourceType,
+} from 'platform-bible-utils';
+import { ChevronDown } from 'lucide-react';
+import { ComponentProps, useEffect, useMemo, useRef } from 'react';
+import { getRefLabel, getResourceReferenceRowId } from './resource-reference.utils';
+import type { PickerResource } from './downloaded-resources.utils';
+import type { ResourcePanelReadiness } from './resource-panel-readiness.utils';
+import { PanelReadinessView } from './panel-readiness-view.component';
+import { ExpandableInfo, LoadingView, RetryableErrorView } from './panel-state-views.component';
+import { ResourceBookNotAvailable } from './resource-book-not-available.component';
+import { ResourceBlankChapter } from './resource-blank-chapter.component';
+import { ResourceTextUnavailable } from './resource-text-unavailable.component';
+import {
+  isBlankChapterOnScreen,
+  isMissingBookError,
+  resolveResourceContentState,
+} from './platform-scripture-editor.utils';
+import { resolveResourcePanelStringKeys } from './resource-panel-strings.utils';
+import type {
+  ResourcePanelLocalizedStringKey,
+  ResourcePanelLocalizedStrings,
+} from './resource-text-panel.const';
+
+/**
+ * Falls back to the key itself, matching the idiom in `model-text-panel.component.tsx`. Falling
+ * back to `''` instead would render an empty message region — a blank panel, which is the exact
+ * failure these messages exist to remove.
+ */
+const localize = (strings: ResourcePanelLocalizedStrings, key: ResourcePanelLocalizedStringKey) =>
+  strings[key] ?? key;
+
+/**
+ * Identifies the wrapper around `Editorial`. The wrapper, not the editor, is what a message or
+ * spinner replaces, so a test asserting that the text on screen was swapped for one of them has to
+ * address this element.
+ */
+export const RESOURCE_TEXT_EDITOR_CONTAINER_TEST_ID = 'resource-text-editor-container';
+
+type ResourceSelectorDropdownProps = {
+  filteredResources: PickerResource[];
+  selectedRef: PickerResource | undefined;
+  dblResources: DblResourceData[];
+  onSelectResource: (id: string) => void;
+  onShowResourcePicker: () => void;
+  downloadResourcesLabel: string;
+};
+
+function ResourceSelectorDropdown({
+  filteredResources,
+  selectedRef,
+  dblResources,
+  onSelectResource,
+  onShowResourcePicker,
+  downloadResourcesLabel,
+}: ResourceSelectorDropdownProps) {
+  return (
+    <div className="tw:px-2 tw:py-1">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="outline"
+            className="tw:h-8 tw:w-full tw:justify-between tw:overflow-hidden tw:text-ellipsis tw:whitespace-nowrap"
+          >
+            <span className="tw:overflow-hidden tw:text-ellipsis tw:whitespace-nowrap">
+              {selectedRef ? getRefLabel(selectedRef.reference, dblResources) : ''}
+            </span>
+            <ChevronDown className="tw:ml-1 tw:h-4 tw:w-4 tw:shrink-0" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent className="tw:w-72">
+          {filteredResources.map((ref) => {
+            const refId = getResourceReferenceRowId(ref.reference);
+            return (
+              <DropdownMenuCheckboxItem
+                key={refId}
+                checked={
+                  refId ===
+                  (selectedRef ? getResourceReferenceRowId(selectedRef.reference) : undefined)
+                }
+                onCheckedChange={() => {
+                  onSelectResource(refId);
+                }}
+              >
+                {getRefLabel(ref.reference, dblResources)}
+              </DropdownMenuCheckboxItem>
+            );
+          })}
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onSelect={() => onShowResourcePicker()}>
+            {downloadResourcesLabel}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+export type ResourceTextPanelProps = {
+  /** Localized strings; import `RESOURCE_PANEL_STRING_KEYS` to resolve them. */
+  localizedStrings: ResourcePanelLocalizedStrings;
+  /** Whether the panel has a project context (opened with a project id). */
+  hasProject: boolean;
+  /**
+   * Which kind of resource this panel shows. `'ScriptureResource'` is the Bible texts tab; every
+   * other type is the commentaries tab. Selects the whole matched set of strings — see
+   * `resolveResourcePanelStringKeys`.
+   */
+  resourceType: ResourceType;
+  /**
+   * The rows this panel offers, already filtered to `resourceType`. Filtering needs the panel's
+   * union of referenced and locally-downloaded rows, which only the caller has.
+   */
+  filteredResources: PickerResource[];
+  /**
+   * The row being displayed, already resolved from the persisted selection — see
+   * `resolveResourceSelection`. Resolved by the caller rather than here because the caller keys its
+   * chapter subscription off this row's project id and feeds the result back in as
+   * `usjPossiblyError`: deriving it on both sides would be two answers to one question.
+   */
+  selectedRef: PickerResource | undefined;
+  /**
+   * Which of the panel's front states to render, or `configured` to continue to the content
+   * branches. Decided by the caller from whether its sources have ARRIVED — see
+   * `getResourcePanelReadiness`, and the caller's promotion of `empty` once the downloaded rows are
+   * in.
+   */
+  readiness: ResourcePanelReadiness;
+  /** All DBL resources — used to label the selector rows. */
+  dblResources: DblResourceData[];
+  /** Re-runs the DBL resource catalog fetch. */
+  onRetryCatalog: () => void;
+  /** The reference the panel is displaying. */
+  scrRef: SerializedVerseRef;
+  /** Called when the editor changes the Scripture reference. */
+  onScrRefChange: (scrRef: SerializedVerseRef) => void;
+  /** Records a new selection by row id (see `getResourceReferenceRowId`). */
+  onSelectResource: (id: string) => void;
+  /**
+   * The chapter read for `selectedRef`'s project, exactly as the data layer returned it — USJ, a
+   * `PlatformError`, or `undefined` before anything has arrived. Which message that implies is
+   * derived here rather than by the caller, so every consumer gets one answer.
+   */
+  usjPossiblyError: Usj | PlatformError | undefined;
+  /**
+   * Whether that chapter read is in flight. Gates the blank-chapter message: the data layer keeps
+   * serving the PREVIOUS reference's USJ until the new subscription's first update lands, and its
+   * default is itself blank.
+   */
+  isUsjLoading: boolean;
+  /** The displayed resource's text direction. Applied to the editor only, never to the messages. */
+  textDirection: EditorOptions['textDirection'];
+  /**
+   * Whether a user-initiated pick is in flight, which this panel renders as "Selecting…". Distinct
+   * from `isInstalling`, where the user picked nothing and a configured resource is just
+   * downloading.
+   */
+  isSelecting: boolean;
+  /** Whether an auto-install of the selected resource is in flight. */
+  isInstalling: boolean;
+  /** Whether the last install attempt for the selected resource failed. */
+  installFailed: boolean;
+  /** Clears the failed-install state and re-attempts the same resource. */
+  retryInstall: () => void;
+  /** Whether the machine is online. Only adds a "check your connection" hint to install failures. */
+  isOnline: boolean;
+  /**
+   * Ask the caller to open the resource picker and act on whatever the user chooses.
+   * Fire-and-forget and argument-free: the whole pick — the ids to pre-select, the install, the
+   * write, and the in-flight and unmount guards `useDialogCallback` already provides — belongs to
+   * the caller, so this panel only reports that the affordance was activated.
+   */
+  onShowResourcePicker: () => void;
+  /** Logger forwarded to the editor (the web view supplies the PAPI logger; tests may omit it). */
+  logger?: ComponentProps<typeof Editorial>['logger'];
+};
+
+/**
+ * Read-only panel that displays one referenced Scripture resource or commentary. It owns the render
+ * and the content-state decisions — what a chapter read in hand means and which of the panel's
+ * states is on screen. Changing which resource is shown is dispatched to the caller.
+ *
+ * Everything upstream of that arrives already resolved, and `selectedRef` is the load-bearing case:
+ * the caller has to resolve it regardless, because that row's project id keys the chapter
+ * subscription whose result comes back down here as `usjPossiblyError`. So the resolved row flows
+ * down as a prop and this component MUST NOT re-derive it — a second derivation would be a second
+ * answer to one question, free to disagree with the subscription that produced the content on
+ * screen. Resolve it once, in the caller, and pass it (see `resolveResourceSelection`).
+ */
+export function ResourceTextPanel({
+  localizedStrings,
+  hasProject,
+  resourceType,
+  filteredResources,
+  selectedRef,
+  readiness,
+  dblResources,
+  onRetryCatalog,
+  scrRef,
+  onScrRefChange,
+  onSelectResource,
+  usjPossiblyError,
+  isUsjLoading,
+  textDirection,
+  isSelecting,
+  isInstalling,
+  installFailed,
+  retryInstall,
+  isOnline,
+  onShowResourcePicker,
+  logger,
+}: ResourceTextPanelProps) {
+  // #region Content state
+
+  const resourceProjectId = selectedRef?.projectId;
+
+  const usjFromPdp = !isPlatformError(usjPossiblyError) ? usjPossiblyError : undefined;
+
+  // A chapter the resource HAS but with nothing in it. Gated on the load having finished because
+  // the data layer doesn't reset to its default when the reference changes — it keeps the previous
+  // chapter's USJ until the new subscription's first update lands, and that default is itself
+  // blank. Without the gate the panel would claim "empty" over a chapter that is still arriving,
+  // and again on first mount.
+  //
+  // Chapter 0 is front matter rather than a chapter; `isBlankChapterOnScreen` has that rationale.
+  const isBlankChapter = useMemo(
+    () => !isUsjLoading && isBlankChapterOnScreen(usjFromPdp, scrRef.chapterNum),
+    [usjFromPdp, isUsjLoading, scrRef.chapterNum],
+  );
+
+  // The book-not-available message is withheld unless the failure names the book AND project on
+  // screen right now, so a result still describing the reference the user just left cannot be
+  // misattributed to this one. See `resolveResourceContentState`. Derived here rather than in the
+  // render body below so the editor-feeding effect can depend on it.
+  const contentState = useMemo(
+    () =>
+      resolveResourceContentState({
+        resourceProjectId,
+        usjPossiblyError,
+        currentBookNum: Canon.bookIdToNumber(scrRef.book),
+      }),
+    [resourceProjectId, usjPossiblyError, scrRef.book],
+  );
+
+  // A chapter read that fails is otherwise invisible outside the UI, and the state it produces — a
+  // named, terminal message — looks the same whatever went wrong, so the log is the only place the
+  // cause survives. Keyed on the error alone so paging through books on a sticky failure does not
+  // re-emit it once per book.
+  //
+  // A missing book is ordinary navigation rather than a fault and is already explained on screen, so
+  // it goes to `debug`, which packaged builds drop. If detection ever broke, the same failure would
+  // fall to `error` below and be loud in production rather than silent.
+  useEffect(() => {
+    if (!isPlatformError(usjPossiblyError)) return;
+    const message = getErrorMessage(usjPossiblyError);
+    if (isMissingBookError(usjPossiblyError))
+      logger?.debug(`Book not found in resource text: ${message}`);
+    else logger?.error(`Error getting resource chapter USJ: ${message}`);
+  }, [usjPossiblyError, logger]);
+
+  // #endregion
+
+  // #region Editor
+
+  // EditorRef requires null initial value per React ref convention
+  // eslint-disable-next-line no-null/no-null
+  const editorRef = useRef<EditorRef | null>(null);
+  // Markers this resource's content actually uses. Passed to the editor as extraValidMarkers so it
+  // doesn't warn "Unexpected <kind> marker" for handbook/commentary markers (e.g. \pn, \jmp) — scoped
+  // per-resource from the USJ being displayed, never a global list. Empty for content that needs
+  // nothing extra, so the option is omitted (opt-in, no behavior change). The returned array keeps a
+  // stable identity while the marker set is unchanged, so `options` doesn't churn on every fetch.
+  const extraValidMarkers = useExtraValidMarkers(usjFromPdp);
+
+  const options: EditorOptions = useMemo(
+    () => ({
+      isReadonly: true,
+      hasSpellCheck: false,
+      textDirection,
+      ...(extraValidMarkers.length > 0 ? { nodes: { extraValidMarkers } } : {}),
+    }),
+    [textDirection, extraValidMarkers],
+  );
+
+  // `contentState` and `isBlankChapter` are deps because the content-area branches below UNMOUNT
+  // `Editorial` rather than hiding it. A remounted editor holds nothing, and this effect is its only
+  // feed — so without re-running when the panel comes back to the editor, the reader gets Lexical's
+  // "Enter some Scripture…" placeholder (an edit invitation in a text they cannot edit) until the
+  // next USJ happens to arrive.
+  //
+  // TODO(PT-4517): These deps cover only the content-area branches. The four whole-panel early
+  // returns below also unmount the editor — `!hasProject`, `readiness !== 'configured'`,
+  // `installFailed`, `isSelecting || isInstalling` — and none of them is a dep here, so returning
+  // from one with the USJ and content state unchanged remounts an editor this effect never re-feeds.
+  // Picking the resource already on screen is the reachable case: `isSelecting` unmounts, the pick
+  // resolves, and nothing in the deps moved.
+  //
+  // `ModelTextPanel`'s `tw:hidden` is NOT the fix to copy here: it covers only that panel's
+  // content-area states — the half this dep list already handles — and it keeps six whole-panel
+  // early returns of its own, fed by an effect keyed on the USJ alone. In those branches the editor
+  // is not rendered in any form, so there is no element to hide.
+  useEffect(() => {
+    if (usjFromPdp) editorRef.current?.setUsj(usjFromPdp);
+  }, [usjFromPdp, contentState, isBlankChapter]);
+
+  // #endregion
+
+  // #region Render
+
+  // One resource type, one matched set of strings. See `resolveResourcePanelStringKeys`.
+  const { emptyStatePromptKey, bookNotAvailableKey, pickButtonKey } =
+    resolveResourcePanelStringKeys(resourceType);
+
+  if (!hasProject) {
+    return (
+      <div className="tw:flex tw:h-screen tw:items-center tw:justify-center tw:p-8 tw:text-center">
+        <p>{localize(localizedStrings, '%webView_resourcePanel_noProject%')}</p>
+      </div>
+    );
+  }
+
+  // Front of the state machine: still resolving, unreadable setting, or genuinely nothing
+  // configured. Driven by one readiness value so the empty prompt can only appear once emptiness is
+  // actually known — the loading branch deliberately outlasts the catalog fetch when something is
+  // configured.
+  if (readiness !== 'configured') {
+    return (
+      <PanelReadinessView
+        readiness={readiness}
+        errorMessage={localize(localizedStrings, '%webView_resourcePanel_settingsUnavailable%')}
+        emptyPrompt={localize(localizedStrings, emptyStatePromptKey)}
+        moreInfo={
+          // Only Bible Texts needs the disclosure; the Commentaries prompt says what it is asking
+          // for, so it renders the shorter empty state.
+          resourceType === 'ScriptureResource' ? (
+            <ExpandableInfo
+              moreLabel={localize(
+                localizedStrings,
+                '%webView_resourcePanel_bibleTexts_emptyState_moreInfo%',
+              )}
+              lessLabel={localize(
+                localizedStrings,
+                '%webView_resourcePanel_bibleTexts_emptyState_lessInfo%',
+              )}
+              body={localize(
+                localizedStrings,
+                '%webView_resourcePanel_bibleTexts_emptyState_moreInfo_body%',
+              )}
+            />
+          ) : undefined
+        }
+        catalogErrorMessage={localize(
+          localizedStrings,
+          '%webView_resourcePanel_catalogUnavailable%',
+        )}
+        loadingLabel={localize(localizedStrings, '%webView_resourcePanel_loading%')}
+        pickLabel={localize(localizedStrings, pickButtonKey)}
+        retryLabel={localize(localizedStrings, '%webView_resourcePanel_retry%')}
+        onPick={() => onShowResourcePicker()}
+        onRetryCatalog={onRetryCatalog}
+      />
+    );
+  }
+
+  // Install failed: the selected resource is in the catalog but couldn't be installed. Offer a
+  // retry rather than spinning forever; a success drops out of this state on its own. When offline
+  // (the usual first-run cause), hint at the connection.
+  if (installFailed) {
+    return (
+      <RetryableErrorView
+        message={localize(
+          localizedStrings,
+          isOnline
+            ? '%webView_resourcePanel_installFailed%'
+            : '%webView_resourcePanel_installFailedOffline%',
+        )}
+        retryLabel={localize(localizedStrings, '%webView_resourcePanel_retry%')}
+        onRetry={retryInstall}
+      />
+    );
+  }
+
+  // Installing state: selected DblResource found but not yet installed. Distinguish the two causes
+  // so the label is accurate: a user pick (isSelecting) reads "Selecting…", while an auto-install
+  // of a configured resource (isInstalling) — where the user picked nothing and it's just
+  // downloading — reads "Installing…".
+  if (isSelecting || isInstalling) {
+    return (
+      <LoadingView
+        label={localize(
+          localizedStrings,
+          isSelecting ? '%webView_resourcePanel_selecting%' : '%webView_resourcePanel_installing%',
+        )}
+      />
+    );
+  }
+
+  // Scripture content, or the reason there is none: nothing has arrived yet, the resource has no
+  // such book, or it has the book but the chapter is blank. A blank chapter arrives as a successful,
+  // empty USJ rather than as an error, so it is invisible to `contentState` and needs its own check;
+  // the missing book is tested first because it is the more specific claim. Every branch beats
+  // letting `Editorial` render with no scripture set, which shows its "enter some Scripture" prompt
+  // — an edit invitation in a text the reader cannot edit.
+  //
+  // These are the panel's CONTENT area only. The selector header stays mounted above all of them,
+  // including the spinner: a resource missing a book has no remedy inside this panel, so the only
+  // thing the user can do about it is switch to a text that has the book, and taking the selector
+  // away while a chapter loads would remove that between every navigation.
+  //
+  // Only the editor gets `dir`. That is the RESOURCE's text direction, and the messages are app
+  // chrome: inheriting it would lay a left-to-right UI string out right-to-left whenever the
+  // resource is RTL.
+  const renderContent = () => {
+    if (contentState === 'loading')
+      return (
+        <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
+          <Spinner />
+        </div>
+      );
+
+    if (contentState === 'bookNotAvailable')
+      return (
+        <div className="tw:flex-1 tw:overflow-auto">
+          <ResourceBookNotAvailable
+            message={localize(localizedStrings, bookNotAvailableKey)}
+            announcementKey={`${resourceProjectId}:${scrRef.book}`}
+          />
+        </div>
+      );
+
+    if (isBlankChapter)
+      return (
+        <div className="tw:flex-1 tw:overflow-auto">
+          <ResourceBlankChapter
+            message={localize(
+              localizedStrings,
+              '%webView_platformScriptureEditor_emptyChapter_messageResource%',
+            )}
+            announcementKey={`${resourceProjectId}:${scrRef.book}:${scrRef.chapterNum}`}
+          />
+        </div>
+      );
+
+    // A failure that is not a missing book in the text on screen. Terminal, because the value in
+    // hand is an error rather than USJ and nothing re-emits until the data provider does — so a
+    // spinner here would claim progress that never arrives.
+    if (contentState === 'failed')
+      return (
+        <div className="tw:flex-1 tw:overflow-auto">
+          <ResourceTextUnavailable
+            message={localize(localizedStrings, '%webView_resourcePanel_textUnavailable%')}
+            announcementKey={`${resourceProjectId}:${scrRef.book}:${scrRef.chapterNum}`}
+          />
+        </div>
+      );
+
+    // No USJ in hand for the reference on screen, and no failure to name: the chapter is still on
+    // its way. Keep waiting rather than mounting `Editorial` with nothing set, which paints
+    // Lexical's "Enter some Scripture…" placeholder — an edit invitation in a text the reader
+    // cannot edit.
+    if (!usjFromPdp)
+      return (
+        <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
+          <Spinner />
+        </div>
+      );
+
+    return (
+      <div
+        className="tw:flex-1 tw:overflow-auto"
+        dir={options.textDirection}
+        data-testid={RESOURCE_TEXT_EDITOR_CONTAINER_TEST_ID}
+      >
+        <Editorial
+          ref={editorRef}
+          scrRef={scrRef}
+          onScrRefChange={onScrRefChange}
+          options={options}
+          logger={logger}
+        />
+      </div>
+    );
+  };
+
+  // Active state: resource is installed and USJ is available
+  // This panel (Bible Texts / Commentaries) is Simple-mode-only, so `editor-container-simple`
+  // (flattens .editor-container's rounded top corners — see _simple-mode.scss) is applied
+  // unconditionally, unlike the Scripture Editor's conditional use of the same class.
+  return (
+    <div className="tw:flex tw:h-screen tw:flex-col editor-container-simple">
+      <ResourceSelectorDropdown
+        filteredResources={filteredResources}
+        selectedRef={selectedRef}
+        dblResources={dblResources}
+        onSelectResource={onSelectResource}
+        onShowResourcePicker={onShowResourcePicker}
+        downloadResourcesLabel={localize(
+          localizedStrings,
+          '%webView_resourcePanel_downloadResources%',
+        )}
+      />
+
+      {renderContent()}
+    </div>
+  );
+
+  // #endregion
+}
+
+export default ResourceTextPanel;

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.const.ts
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.const.ts
@@ -1,0 +1,51 @@
+import type { LocalizedStringValue } from 'platform-bible-utils';
+import { RESOURCE_PANEL_TYPED_STRING_KEYS } from './resource-panel-strings.utils';
+
+/**
+ * Object containing all keys used for localization in the resource text panel. Pass these keys into
+ * the Platform's localization hook (in the app) or `getLocalizedStrings` (in Storybook) and pass
+ * the resulting localized strings into the `localizedStrings` prop.
+ *
+ * The per-resource-type keys come from `RESOURCE_PANEL_TYPED_STRING_KEYS` rather than being listed
+ * again here. `useLocalizedStrings` seeds key-to-key defaults only for the keys in the array it is
+ * given, so a hand-maintained second list is a silent hole: add a field to
+ * `ResourcePanelStringKeys`, forget the array, and the render site reads `undefined` and announces
+ * an empty message.
+ *
+ * Kept in its own module, following `model-text-panel.const.ts`, so a consumer can read the key
+ * list without importing the panel. `resource-text-panel.component.tsx` imports `Editorial` at
+ * module scope, so reaching this list through it drags the whole editor component tree along:
+ * `localized-strings.test.ts` runs in the node environment, where that fails on `document is not
+ * defined`, and the Storybook stories would load an editor just to obtain a string array.
+ */
+export const RESOURCE_PANEL_STRING_KEYS = Object.freeze([
+  // Shared with the model text panel's blank-chapter branch. Distinct from the editable
+  // `..._emptyChapter_message%`, which sits beside an "Add chapter number" action these read-only
+  // panels must not offer. The missing-book wording is per resource type and comes from
+  // `RESOURCE_PANEL_TYPED_STRING_KEYS` below; a blank chapter reads the same either way.
+  '%webView_platformScriptureEditor_emptyChapter_messageResource%',
+  '%webView_resourcePanel_noProject%',
+  '%webView_resourcePanel_installing%',
+  '%webView_resourcePanel_selecting%',
+  '%webView_resourcePanel_installFailed%',
+  '%webView_resourcePanel_installFailedOffline%',
+  '%webView_resourcePanel_retry%',
+  '%webView_resourcePanel_settingsUnavailable%',
+  '%webView_resourcePanel_loading%',
+  '%webView_resourcePanel_catalogUnavailable%',
+  '%webView_resourcePanel_downloadResources%',
+  '%webView_resourcePanel_textUnavailable%',
+  // The Bible-texts empty state's "More info" disclosure. Not part of
+  // RESOURCE_PANEL_TYPED_STRING_KEYS: that set pairs one key per field for BOTH resource types,
+  // and commentaries deliberately has no disclosure — its prompt is self-explanatory.
+  '%webView_resourcePanel_bibleTexts_emptyState_moreInfo%',
+  '%webView_resourcePanel_bibleTexts_emptyState_lessInfo%',
+  '%webView_resourcePanel_bibleTexts_emptyState_moreInfo_body%',
+  ...RESOURCE_PANEL_TYPED_STRING_KEYS,
+] as const);
+
+export type ResourcePanelLocalizedStringKey = (typeof RESOURCE_PANEL_STRING_KEYS)[number];
+
+export type ResourcePanelLocalizedStrings = {
+  [key in ResourcePanelLocalizedStringKey]?: LocalizedStringValue;
+};

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -233,6 +233,12 @@ globalThis.webViewComponent = function ResourceTextPanelWebView({
   // Committing a pick, holding still while one is in flight, migrating a legacy bare id and
   // falling back when the selection leaves the list are one decision, not four effects that can
   // disagree across renders. `resolveResourceSelection` makes it, and is tested directly.
+  //
+  // Resolved HERE and handed to the panel as `selectedRef`, rather than resolved by the panel and
+  // reported back up: `resourceProjectId` below keys the `ChapterUSJ` subscription that produces
+  // the `usjPossiblyError` this passes DOWN to the panel, so a callback would close a cycle. That
+  // constraint is what fixes the direction of the whole boundary, and it is why there is exactly
+  // one answer to "which resource is on screen" rather than two derivations to keep in step.
   const selection = resolveResourceSelection(
     filteredResources,
     selectedResourceId,
@@ -454,7 +460,7 @@ globalThis.webViewComponent = function ResourceTextPanelWebView({
   return (
     <ResourceTextPanel
       localizedStrings={localizedStrings}
-      hasProject={projectId !== undefined}
+      hasProject={!!projectId}
       resourceType={resourceType}
       filteredResources={filteredResources}
       selectedRef={selectedRef}

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -408,8 +408,12 @@ globalThis.webViewComponent = function ResourceTextPanelWebView({
               await installResource(dblEntryUid);
             } catch (e) {
               // Record the failure so that once the pick finishes and the auto-install effect
-              // re-enables, its failed-uid guard suppresses a duplicate install attempt; this also
-              // surfaces the install-failed state immediately instead of after a second attempt.
+              // re-enables, its failed-uid guard suppresses a duplicate install attempt.
+              //
+              // TODO(PT-4508): This does NOT surface the failure on screen. `selectTextConnection`
+              // swallows the rethrow below and returns without persisting, so the selection never
+              // changes, `dblEntryUidToInstall` stays `undefined`, and `installFailed` never becomes
+              // true — a failed pick is silent until the user tries again.
               markInstallFailed(dblEntryUid);
               throw e;
             }

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -228,6 +228,12 @@ globalThis.webViewComponent = function ResourceTextPanelWebView({
   // Holds the row id of a resource just selected from the picker while it propagates through the
   // reactive settings chain and into filteredResources. Written from the reference
   // `selectTextConnection` actually stored, so it is comparable to the row ids of the list.
+  //
+  // TODO(PT-4509): The dropdown is interactive during that window — `isSelecting` goes false in its
+  // `finally`, removing the LoadingView that covered the selector, before the written reference
+  // reaches `filteredResources` — and `resolveResourceSelection`'s pending branch ignores
+  // `selectedResourceId`. So a user who changes their mind in that window watches the panel jump to
+  // the resource they abandoned, with nothing indicating their own earlier pick won.
   const [pendingResourceId, setPendingResourceId] = useState<string | undefined>(undefined);
 
   // Committing a pick, holding still while one is in flight, migrating a legacy bare id and

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -1,4 +1,3 @@
-import { Editorial, EditorOptions, EditorRef } from '@eten-tech-foundation/platform-editor';
 import { EMPTY_USJ } from '@eten-tech-foundation/scripture-utilities';
 import type { WebViewProps } from '@papi/core';
 import papi, { logger } from '@papi/frontend';
@@ -11,20 +10,7 @@ import {
   useProjectSetting,
   useSetting,
 } from '@papi/frontend/react';
-import {
-  Button,
-  DropdownMenu,
-  DropdownMenuCheckboxItem,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-  useExtraValidMarkers,
-  useTabIconSelection,
-  useViewVisibility,
-  type TabIconUrls,
-  Spinner,
-} from 'platform-bible-react';
+import { useTabIconSelection, type TabIconUrls } from 'platform-bible-react';
 import {
   DblResourceData,
   formatReplacementString,
@@ -33,16 +19,8 @@ import {
   LocalizeKey,
   ResourceType,
 } from 'platform-bible-utils';
-import { Canon, SerializedVerseRef } from '@sillsdev/scripture';
-import { ChevronDown } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { ResourceReferenceList } from 'platform-scripture';
-import {
-  hasNewScrollTarget,
-  isEchoOfPublishedScrRef,
-  SCROLL_MAX_WAIT_MS,
-  scrollToVerse,
-} from './editor-dom.util';
 import { useOpenFindShortcut } from './use-open-find-shortcut.hook';
 import { useEffectiveResourceReferenceList } from './use-effective-resource-reference-list.hook';
 import { useResourcePickerResources } from './use-resource-picker-resources.hook';
@@ -53,70 +31,30 @@ import {
   type ResourcePanelReadiness,
 } from './resource-panel-readiness.utils';
 import { useDblResourceCatalog } from './use-dbl-resource-catalog.hook';
-import { PanelReadinessView } from './panel-readiness-view.component';
 import { useCommentaryMarkerStyles } from './use-commentary-marker-styles.hook';
 import { useDblResourceAutoInstall } from './use-dbl-resource-auto-install.hook';
 import { useInstallDblResource } from './use-install-dbl-resource.hook';
 import { useIsOnline } from './use-is-online.hook';
 import {
+  getResourceReferenceRowId,
   isDblResourceReference,
   isProjectReference,
-  getRefLabel,
-  getResourceReferenceRowId,
 } from './resource-reference.utils';
 import { resolveResourceSelection } from './resource-selection.utils';
 import { findCachedDblResource } from './scripture-text-grid/dbl-resource-lookup.utils';
-import { ResourceBookNotAvailable } from './resource-book-not-available.component';
-import { ResourceBlankChapter } from './resource-blank-chapter.component';
-import { ResourceTextUnavailable } from './resource-text-unavailable.component';
-import {
-  isBlankChapterOnScreen,
-  isMissingBookError,
-  resolveResourceContentState,
-} from './platform-scripture-editor.utils';
-import {
-  RESOURCE_PANEL_TYPED_STRING_KEYS,
-  resolveResourcePanelStringKeys,
-} from './resource-panel-strings.utils';
-import {
-  ExpandableInfo,
-  PanelRetryableErrorView,
-  LoadingView,
-} from './panel-state-views.component';
+import { resolveResourcePanelStringKeys } from './resource-panel-strings.utils';
 import { selectTextConnection } from './select-dbl-resource';
+import { ResourceTextPanel } from './resource-text-panel.component';
+import { RESOURCE_PANEL_STRING_KEYS } from './resource-text-panel.const';
 import { usePublishNavigableProjectIds } from './use-publish-navigable-project-ids.hook';
 
 const DEFAULT_TEXT_DIRECTION = 'ltr';
 
-// The per-resource-type keys come from `RESOURCE_PANEL_TYPED_STRING_KEYS` rather than being listed
-// again here. `useLocalizedStrings` seeds key-to-key defaults only for the keys in the array it is
-// given, so a hand-maintained second list is a silent hole: add a field to `ResourcePanelStringKeys`,
-// forget the array, and the render site reads `undefined` and announces an empty message.
-const RESOURCE_PANEL_STRING_KEYS: LocalizeKey[] = [
-  // Shared with the model text panel's blank-chapter branch. Distinct from the editable
-  // `..._emptyChapter_message%`, which sits beside an "Add chapter number" action these read-only
-  // panels must not offer. The missing-book wording is per resource type and comes from
-  // `RESOURCE_PANEL_TYPED_STRING_KEYS` below; a blank chapter reads the same either way.
-  '%webView_platformScriptureEditor_emptyChapter_messageResource%',
-  '%webView_resourcePanel_noProject%',
-  '%webView_resourcePanel_installing%',
-  '%webView_resourcePanel_selecting%',
-  '%webView_resourcePanel_installFailed%',
-  '%webView_resourcePanel_installFailedOffline%',
-  '%webView_resourcePanel_retry%',
-  '%webView_resourcePanel_settingsUnavailable%',
-  '%webView_resourcePanel_loading%',
-  '%webView_resourcePanel_catalogUnavailable%',
-  '%webView_resourcePanel_downloadResources%',
-  '%webView_resourcePanel_textUnavailable%',
-  // The Bible-texts empty state's "More info" disclosure. Not part of
-  // RESOURCE_PANEL_TYPED_STRING_KEYS: that set pairs one key per field for BOTH resource types,
-  // and commentaries deliberately has no disclosure — its prompt is self-explanatory.
-  '%webView_resourcePanel_bibleTexts_emptyState_moreInfo%',
-  '%webView_resourcePanel_bibleTexts_emptyState_lessInfo%',
-  '%webView_resourcePanel_bibleTexts_emptyState_moreInfo_body%',
-  ...RESOURCE_PANEL_TYPED_STRING_KEYS,
-];
+// Built once at module scope, not inline in the `useLocalizedStrings` call. The hook's key array
+// must keep a stable identity across renders — a fresh array every render re-runs its lookup — and
+// `RESOURCE_PANEL_STRING_KEYS` is a frozen readonly tuple, so it is spread into a mutable
+// `LocalizeKey[]` exactly once here.
+const ALL_STRING_KEYS: LocalizeKey[] = [...RESOURCE_PANEL_STRING_KEYS];
 
 const BIBLE_TEXTS_ICON_URLS: TabIconUrls = {
   lightDefault: 'papi-extension://platformScriptureEditor/assets/book-open.svg',
@@ -136,73 +74,23 @@ const COMMENTARIES_ICON_URLS: TabIconUrls = {
 // collection, so its rows are the union of both.
 const RESOURCE_PICKER_OPTIONS = { includeDownloaded: true } as const;
 
-type ResourceSelectorDropdownProps = {
-  filteredResources: PickerResource[];
-  selectedRef: PickerResource | undefined;
-  dblResources: DblResourceData[];
-  onSelectResource: (id: string) => void;
-  onShowResourcePicker: () => void;
-  downloadResourcesLabel: string;
-};
-
-function ResourceSelectorDropdown({
-  filteredResources,
-  selectedRef,
-  dblResources,
-  onSelectResource,
-  onShowResourcePicker,
-  downloadResourcesLabel,
-}: ResourceSelectorDropdownProps) {
-  return (
-    <div className="tw:px-2 tw:py-1">
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="outline"
-            className="tw:h-8 tw:w-full tw:justify-between tw:overflow-hidden tw:text-ellipsis tw:whitespace-nowrap"
-          >
-            <span className="tw:overflow-hidden tw:text-ellipsis tw:whitespace-nowrap">
-              {selectedRef ? getRefLabel(selectedRef.reference, dblResources) : ''}
-            </span>
-            <ChevronDown className="tw:ml-1 tw:h-4 tw:w-4 tw:shrink-0" />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="tw:w-72">
-          {filteredResources.map((ref) => {
-            const refId = getResourceReferenceRowId(ref.reference);
-            return (
-              <DropdownMenuCheckboxItem
-                key={refId}
-                checked={
-                  refId ===
-                  (selectedRef ? getResourceReferenceRowId(selectedRef.reference) : undefined)
-                }
-                onCheckedChange={() => {
-                  onSelectResource(refId);
-                }}
-              >
-                {getRefLabel(ref.reference, dblResources)}
-              </DropdownMenuCheckboxItem>
-            );
-          })}
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={() => onShowResourcePicker()}>
-            {downloadResourcesLabel}
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
-  );
-}
-
-globalThis.webViewComponent = function ResourceTextPanel({
+/**
+ * Thin data-loader for the Bible Texts / Commentaries panel. It wires PAPI to the props of
+ * `ResourceTextPanel`, which owns the render and the content-state decisions.
+ *
+ * The selection is resolved HERE rather than in the component because the resolved row's project id
+ * keys the `ChapterUSJ` subscription below, whose result is then handed back down to the component
+ * as `usjPossiblyError`. The component takes the resolved row as a prop and never re-derives it, so
+ * there is exactly one answer to "which resource is on screen".
+ */
+globalThis.webViewComponent = function ResourceTextPanelWebView({
   id: webViewId,
   projectId,
   updateWebViewDefinition,
   useWebViewState,
   useWebViewScrollGroupScrRef,
 }: WebViewProps) {
-  const [localizedStrings] = useLocalizedStrings(RESOURCE_PANEL_STRING_KEYS);
+  const [localizedStrings] = useLocalizedStrings(ALL_STRING_KEYS);
 
   const [scrRef, setScrRef] = useWebViewScrollGroupScrRef();
 
@@ -415,14 +303,9 @@ globalThis.webViewComponent = function ResourceTextPanel({
     }
   }
 
-  // One resource type, one matched set of strings. See `resolveResourcePanelStringKeys`.
-  const {
-    titleKey,
-    titleWithResourceKey,
-    emptyStatePromptKey,
-    bookNotAvailableKey,
-    pickButtonKey,
-  } = resolveResourcePanelStringKeys(resourceType);
+  // One resource type, one matched set of strings. See `resolveResourcePanelStringKeys`. Only the
+  // title keys are read here; the panel resolves the rest for itself from the same helper.
+  const { titleKey, titleWithResourceKey } = resolveResourcePanelStringKeys(resourceType);
 
   useEffect(() => {
     const baseTitle = localizedStrings[titleKey];
@@ -472,50 +355,6 @@ globalThis.webViewComponent = function ResourceTextPanel({
     EMPTY_USJ,
   );
 
-  const usjFromPdp = !isPlatformError(usjPossiblyError) ? usjPossiblyError : undefined;
-
-  // A chapter the resource HAS but with nothing in it. Gated on the load having finished because
-  // `useProjectData`'s underlying `useData` hook doesn't reset to its default when the selector
-  // (here, `scrRef`) changes — it keeps the previous chapter's USJ until the new subscription's
-  // first update lands, and its default is `EMPTY_USJ`, which is itself blank. Without the gate the
-  // panel would claim "empty" over a chapter that is still arriving, and again on first mount.
-  //
-  // Chapter 0 is front matter rather than a chapter; `isBlankChapterOnScreen` has that rationale.
-  const isBlankChapter = useMemo(
-    () => !isUsjLoading && isBlankChapterOnScreen(usjFromPdp, scrRef.chapterNum),
-    [usjFromPdp, isUsjLoading, scrRef.chapterNum],
-  );
-
-  // The book-not-available message is withheld unless the failure names the book AND project on
-  // screen right now, so a result still describing the reference the user just left cannot be
-  // misattributed to this one. See `resolveResourceContentState`. Derived here rather than in the
-  // render body below so the editor-feeding effect can depend on it.
-  const contentState = useMemo(
-    () =>
-      resolveResourceContentState({
-        resourceProjectId,
-        usjPossiblyError,
-        currentBookNum: Canon.bookIdToNumber(scrRef.book),
-      }),
-    [resourceProjectId, usjPossiblyError, scrRef.book],
-  );
-
-  // A chapter read that fails is otherwise invisible outside the UI, and the state it produces — a
-  // named, terminal message — looks the same whatever went wrong, so the log is the only place the
-  // cause survives. Keyed on the error alone so paging through books on a sticky failure does not
-  // re-emit it once per book.
-  //
-  // A missing book is ordinary navigation rather than a fault and is already explained on screen, so
-  // it goes to `debug`, which packaged builds drop. If detection ever broke, the same failure would
-  // fall to `error` below and be loud in production rather than silent.
-  useEffect(() => {
-    if (!isPlatformError(usjPossiblyError)) return;
-    const message = getErrorMessage(usjPossiblyError);
-    if (isMissingBookError(usjPossiblyError))
-      logger.debug(`Book not found in resource text: ${message}`);
-    else logger.error(`Error getting resource chapter USJ: ${message}`);
-  }, [usjPossiblyError]);
-
   // #endregion
 
   // #region Text direction
@@ -543,7 +382,8 @@ globalThis.webViewComponent = function ResourceTextPanel({
   // installed locally but not in the text collection, so they belong in the picker's INSTALLED
   // section instead. Drawn from every picker row rather than the type-filtered ones so a resource
   // of another type that is in the text collection (a commentary alongside Bible texts) is not
-  // re-offered as INSTALLED.
+  // re-offered as INSTALLED. That is also why the pick belongs here rather than in the panel: the
+  // panel sees only its type-filtered rows.
   const currentFilteredDblIds = useMemo(() => {
     return (pickerResources ?? []).flatMap((r) => {
       if (r.source === 'downloaded') return [];
@@ -583,6 +423,11 @@ globalThis.webViewComponent = function ResourceTextPanel({
     [getUserResourceTexts, setUserResourceTexts, installResource, retryInstall, markInstallFailed],
   );
 
+  // `useDialogCallback` is what keeps a second activation from destroying the picker the user is
+  // working in: the dialog service REPLACES rather than queues, rejecting the open overlay with
+  // ABORTED, and the hook's default `maximumOpenDialogs: 1` drops the second request instead. It
+  // also holds the mounted guard, so a picker resolving after this tab closes cannot write the
+  // user's reference list. Both are the hook's, not this module's — do not hand-roll them.
   const showResourcePicker = useDialogCallback(
     'platform.resourcePicker',
     useMemo(
@@ -602,354 +447,29 @@ globalThis.webViewComponent = function ResourceTextPanel({
 
   // #endregion
 
-  // #region Editor
-
-  // EditorRef requires null initial value per React ref convention
-  // eslint-disable-next-line no-null/no-null
-  const editorRef = useRef<EditorRef | null>(null);
-
-  // What this panel last published to its scroll group, and what it last successfully scrolled to.
-  // Both feed the guards on the reveal-scroll effect below.
-  const lastPublishedScrRefRef = useRef<SerializedVerseRef | undefined>(undefined);
-  const lastScrolledForRef = useRef<{ scrRef: SerializedVerseRef; usj: unknown } | undefined>(
-    undefined,
-  );
-  const isViewVisible = useViewVisibility();
-
-  // Record what we publish before forwarding it, so the bounce-back can be recognised as our own.
-  const handleScrRefChange = useCallback(
-    (newScrRef: SerializedVerseRef) => {
-      lastPublishedScrRefRef.current = newScrRef;
-      setScrRef(newScrRef);
-    },
-    [setScrRef],
-  );
-  // Markers this resource's content actually uses. Passed to the editor as extraValidMarkers so it
-  // doesn't warn "Unexpected <kind> marker" for handbook/commentary markers (e.g. \pn, \jmp) — scoped
-  // per-resource from the USJ being displayed, never a global list. Empty for content that needs
-  // nothing extra, so the option is omitted (opt-in, no behavior change). The returned array keeps a
-  // stable identity while the marker set is unchanged, so `options` doesn't churn on every fetch.
-  const extraValidMarkers = useExtraValidMarkers(usjFromPdp);
-
-  const options: EditorOptions = useMemo(
-    () => ({
-      isReadonly: true,
-      hasSpellCheck: false,
-      textDirection,
-      ...(extraValidMarkers.length > 0 ? { nodes: { extraValidMarkers } } : {}),
-    }),
-    [textDirection, extraValidMarkers],
-  );
-
-  // `contentState` and `isBlankChapter` are deps because the branches below UNMOUNT `Editorial`
-  // rather than hiding it. A remounted editor holds nothing, and this effect is its only feed — so
-  // without re-running when the panel comes back to the editor, the reader gets Lexical's "Enter
-  // some Scripture…" placeholder (an edit invitation in a text they cannot edit) until the next USJ
-  // happens to arrive.
-  useEffect(() => {
-    if (usjFromPdp) editorRef.current?.setUsj(usjFromPdp);
-  }, [usjFromPdp, contentState, isBlankChapter]);
-
-  // Scroll to the current verse when this tab is shown, and again once a chapter's content lands.
-  //
-  // `Editorial` renders the reference it is given but does not scroll to the verse — every consumer
-  // that scrolls does it by calling `scrollToVerse`, as the Scripture editor and the model text
-  // panel both do.
-  //
-  // Keyed on visibility AND on the reference: visibility covers the reveal (a tab activation carries
-  // no reference change of its own), and the reference covers "go to result" landing on a panel that
-  // is already visible.
-  useEffect(() => {
-    // The echo is consumed FIRST, and whether or not this panel is visible. A verse click inside
-    // `Editorial` publishes to scroll group 0 and bounces straight back as a prop update; scrolling
-    // on that would yank the user's own click target to the top. Leaving the latch armed because
-    // the panel happened to be hidden would be worse: a later, genuine "go to result" onto that
-    // same verse would look like an echo and be swallowed, and a panel registers no web view
-    // controller, so nothing would retry it.
-    if (isEchoOfPublishedScrRef(lastPublishedScrRefRef.current, scrRef)) {
-      lastPublishedScrRefRef.current = undefined;
-      // The clicked verse IS this panel's position now. Recording it keeps a later bare reveal from
-      // treating it as a new target and snapping away from wherever the user has since scrolled.
-      lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
-      return undefined;
-    }
-    // The latch is only ever valid for the very NEXT reference, so any other reference discards it.
-    // Otherwise a publish whose echo never arrives as its own update — a Find result writing to the
-    // group before the round-trip lands — leaves the latch armed forever, and a later genuine "go to
-    // result" onto that verse would match it and be swallowed.
-    lastPublishedScrRefRef.current = undefined;
-
-    // `isUsjLoading` is the guard that keeps a scroll off the PREVIOUS chapter: `useProjectData`
-    // holds the old USJ across a selector change, and that content is fully laid out, so the settle
-    // loop below would happily accept it. `scrollToVerse` matches on verse number alone, with no
-    // book or chapter qualifier, so scrolling then lands on — and pulses — the same verse number in
-    // the wrong chapter.
-    if (!isViewVisible || !usjFromPdp || isUsjLoading) return undefined;
-
-    // Nothing new since the last scroll — this is a bare reveal, so leave the user's scroll alone.
-    if (!hasNewScrollTarget(lastScrolledForRef.current, scrRef, usjFromPdp)) return undefined;
-
-    // Wait for the revealed pane's layout to SETTLE, then scroll exactly once.
-    //
-    // Two traps here. First, the verse marker enters the DOM before the chapter has finished laying
-    // out, so an offset computed at that moment is measured against a much shorter content box and
-    // scrolls to a fraction of the real target. Second — and why a naive rAF retry does not rescue
-    // it — `scrollToVerse` scrolls with `behavior: 'smooth'`, so re-calling it every frame restarts
-    // the animation from wherever it had crept to and it never converges.
-    //
-    // Sampling the scroll container's height until it stops changing avoids both: the geometry is
-    // trustworthy by then, and the single call that follows animates uninterrupted.
-    let cancelled = false;
-    const start = Date.now();
-    let lastScrollHeight = -1;
-    // Pulses the verse we land on, so the match is identifiable when several share a verse or a
-    // commentary entry is long. Same treatment the Scripture editor gives an arrived verse.
-    let highlightedVerseElement: HTMLElement | undefined;
-    const scrollWhenSettled = () => {
-      if (cancelled) return;
-      const timedOut = Date.now() - start > SCROLL_MAX_WAIT_MS;
-
-      // Below verse 1 means the chapter top, which `scrollToVerse` reaches without a verse marker
-      // and so without settled geometry — but it still needs the container in the DOM, and it
-      // cannot report that, since it returns an element only when it matched a marker. So the
-      // container is checked here before recording; otherwise a reveal that beat the container into
-      // the DOM would scroll nothing and still be recorded as done. Verse 1 is NOT in this case: it
-      // has a real marker and real geometry, so it goes through the settle loop like any other.
-      if (scrRef.verseNum < 1) {
-        if (document.querySelector('.editor-container')) {
-          scrollToVerse(scrRef);
-          lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
-          return;
-        }
-        if (timedOut) return;
-        requestAnimationFrame(scrollWhenSettled);
-        return;
-      }
-
-      // `.editor-container` is sampled as a CONTENT-GROWTH PROXY, not as the scroll container.
-      // Which element actually scrolls differs by host — `_editor-overrides.scss` warns that this
-      // one is auto-height in the Scripture editor and its wrapper scrolls instead — so the scroll
-      // itself is left to `scrollToVerse`, which discovers the container via `findScrollContainer`.
-      // Only the height is read here, and that tracks the chapter laying out either way.
-      const contentElement = document.querySelector<HTMLElement>('.editor-container');
-      // `querySelector` yields null, not undefined, so compare truthily — treating a missing
-      // element as "settled" would scroll against geometry that does not exist yet.
-      const scrollHeight = contentElement ? contentElement.scrollHeight : -1;
-      const isSettled = !!contentElement && scrollHeight === lastScrollHeight;
-      lastScrollHeight = scrollHeight;
-
-      if (isSettled) {
-        highlightedVerseElement = scrollToVerse(scrRef);
-        // Only a scroll that actually landed is recorded. The verse marker can be genuinely absent
-        // — a `\v 16-17` range publishes no `[data-number="17"]` — so recording regardless would
-        // make `hasNewScrollTarget` answer "same target" forever and the panel would never catch up
-        // on a later reveal.
-        if (highlightedVerseElement) {
-          lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
-          highlightedVerseElement.classList.add('highlighted');
-          return;
-        }
-        // Settled but no marker yet. Two consecutive equal heights are cheap to reach — an empty,
-        // flex-sized container reports the same height every frame before Lexical has reconciled
-        // the chapter — so "settled" is not "rendered". Keep waiting rather than treating one
-        // agreeing pair as the answer; `scrollToVerse` does not scroll without a marker, so
-        // re-calling it cannot restart an animation.
-      }
-      // Out of time: give up WITHOUT recording, so a later reveal tries again instead of being
-      // told the target is unchanged.
-      if (timedOut) return;
-      requestAnimationFrame(scrollWhenSettled);
-    };
-    scrollWhenSettled();
-    return () => {
-      cancelled = true;
-      highlightedVerseElement?.classList.remove('highlighted');
-    };
-    // The rule wants `scrRef` itself, but this effect is keyed on the three fields that decide where
-    // to scroll. `useWebViewScrollGroupScrRef` hands back a fresh object whenever the scroll group
-    // publishes, including for a reference that did not change, so depending on the object would
-    // restart the settle loop on updates that cannot move the target.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isViewVisible, usjFromPdp, isUsjLoading, scrRef.book, scrRef.chapterNum, scrRef.verseNum]);
-
-  // #endregion
-
-  // #region Render
-
-  if (!projectId) {
-    return (
-      <div className="tw:flex tw:h-screen tw:items-center tw:justify-center tw:p-8 tw:text-center">
-        <p>{localizedStrings['%webView_resourcePanel_noProject%']}</p>
-      </div>
-    );
-  }
-
-  // Front of the state machine: still resolving, unreadable setting, or genuinely nothing
-  // configured. Driven by one readiness value so the empty prompt can only appear once emptiness is
-  // actually known — the loading branch deliberately outlasts the catalog fetch when something is
-  // configured, which is the window the old guard let fall through to the empty state.
-  if (readiness !== 'configured') {
-    return (
-      <PanelReadinessView
-        readiness={readiness}
-        errorMessage={localizedStrings['%webView_resourcePanel_settingsUnavailable%']}
-        emptyPrompt={localizedStrings[emptyStatePromptKey]}
-        moreInfo={
-          // Only Bible Texts needs the disclosure; the Commentaries prompt says what it is asking
-          // for, so it renders the shorter empty state.
-          resourceType === 'ScriptureResource' ? (
-            <ExpandableInfo
-              moreLabel={localizedStrings['%webView_resourcePanel_bibleTexts_emptyState_moreInfo%']}
-              lessLabel={localizedStrings['%webView_resourcePanel_bibleTexts_emptyState_lessInfo%']}
-              body={localizedStrings['%webView_resourcePanel_bibleTexts_emptyState_moreInfo_body%']}
-            />
-          ) : undefined
-        }
-        catalogErrorMessage={localizedStrings['%webView_resourcePanel_catalogUnavailable%']}
-        loadingLabel={localizedStrings['%webView_resourcePanel_loading%']}
-        pickLabel={localizedStrings[pickButtonKey]}
-        retryLabel={localizedStrings['%webView_resourcePanel_retry%']}
-        onPick={() => showResourcePicker()}
-        onRetryCatalog={refetchCatalog}
-      />
-    );
-  }
-
-  // Install failed: the selected resource is in the catalog but couldn't be installed. Offer a
-  // retry rather than spinning forever; a success drops out of this state on its own. When offline
-  // (the usual first-run cause), hint at the connection.
-  if (installFailed) {
-    return (
-      <PanelRetryableErrorView
-        message={
-          localizedStrings[
-            isOnline
-              ? '%webView_resourcePanel_installFailed%'
-              : '%webView_resourcePanel_installFailedOffline%'
-          ]
-        }
-        retryLabel={localizedStrings['%webView_resourcePanel_retry%']}
-        onRetry={retryInstall}
-      />
-    );
-  }
-
-  // Installing state: selected DblResource found but not yet installed. Distinguish the two causes
-  // so the label is accurate: a user pick (isSelecting) reads "Selecting…", while an auto-install
-  // of a configured resource (isInstalling) — where the user picked nothing and it's just
-  // downloading — reads "Installing…".
-  if (isSelecting || isInstalling) {
-    return (
-      <LoadingView
-        label={
-          localizedStrings[
-            isSelecting ? '%webView_resourcePanel_selecting%' : '%webView_resourcePanel_installing%'
-          ]
-        }
-      />
-    );
-  }
-
-  // Scripture content, or the reason there is none: nothing has arrived yet, the resource has no
-  // such book, or it has the book but the chapter is blank. A blank chapter arrives as a successful,
-  // empty USJ rather than as an error, so it is invisible to `contentState` and needs its own check;
-  // the missing book is tested first because it is the more specific claim. Every branch beats
-  // letting `Editorial` render with no scripture set, which shows its "enter some Scripture" prompt
-  // — an edit invitation in a text the reader cannot edit.
-  //
-  // These are the panel's CONTENT area only. The selector header stays mounted above all of them,
-  // including the spinner: a resource missing a book has no remedy inside this panel, so the only
-  // thing the user can do about it is switch to a text that has the book, and taking the selector
-  // away while a chapter loads would remove that between every navigation.
-  //
-  // Only the editor gets `dir`. That is the RESOURCE's text direction, and the messages are app
-  // chrome: inheriting it would lay a left-to-right UI string out right-to-left whenever the
-  // resource is RTL.
-  const renderContent = () => {
-    if (contentState === 'loading')
-      return (
-        <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
-          <Spinner />
-        </div>
-      );
-
-    if (contentState === 'bookNotAvailable')
-      return (
-        <div className="tw:flex-1 tw:overflow-auto">
-          <ResourceBookNotAvailable
-            message={localizedStrings[bookNotAvailableKey]}
-            announcementKey={`${resourceProjectId}:${scrRef.book}`}
-          />
-        </div>
-      );
-
-    if (isBlankChapter)
-      return (
-        <div className="tw:flex-1 tw:overflow-auto">
-          <ResourceBlankChapter
-            message={
-              localizedStrings['%webView_platformScriptureEditor_emptyChapter_messageResource%']
-            }
-            announcementKey={`${resourceProjectId}:${scrRef.book}:${scrRef.chapterNum}`}
-          />
-        </div>
-      );
-
-    // A failure that is not a missing book in the text on screen. Terminal, because the value in
-    // hand is an error rather than USJ and nothing re-emits until the data provider does — so a
-    // spinner here would claim progress that never arrives.
-    if (contentState === 'failed')
-      return (
-        <div className="tw:flex-1 tw:overflow-auto">
-          <ResourceTextUnavailable
-            message={localizedStrings['%webView_resourcePanel_textUnavailable%']}
-            announcementKey={`${resourceProjectId}:${scrRef.book}:${scrRef.chapterNum}`}
-          />
-        </div>
-      );
-
-    // No USJ in hand for the reference on screen, and no failure to name: the chapter is still on
-    // its way. Keep waiting rather than mounting `Editorial` with nothing set, which paints
-    // Lexical's "Enter some Scripture…" placeholder — an edit invitation in a text the reader
-    // cannot edit.
-    if (!usjFromPdp)
-      return (
-        <div className="tw:flex tw:flex-1 tw:items-center tw:justify-center tw:p-8">
-          <Spinner />
-        </div>
-      );
-
-    return (
-      <div className="tw:flex-1 tw:overflow-auto" dir={options.textDirection}>
-        <Editorial
-          ref={editorRef}
-          scrRef={scrRef}
-          onScrRefChange={handleScrRefChange}
-          options={options}
-          logger={logger}
-        />
-      </div>
-    );
-  };
-
-  // Active state: resource is installed and USJ is available
-  // This panel (Bible Texts / Commentaries) is Simple-mode-only, so `editor-container-simple`
-  // (flattens .editor-container's rounded top corners — see _simple-mode.scss) is applied
-  // unconditionally, unlike the Scripture Editor's conditional use of the same class.
   return (
-    <div className="tw:flex tw:h-screen tw:flex-col editor-container-simple">
-      <ResourceSelectorDropdown
-        filteredResources={filteredResources}
-        selectedRef={selectedRef}
-        dblResources={dblResources}
-        onSelectResource={setSelectedResourceId}
-        onShowResourcePicker={showResourcePicker}
-        downloadResourcesLabel={localizedStrings['%webView_resourcePanel_downloadResources%']}
-      />
-
-      {renderContent()}
-    </div>
+    <ResourceTextPanel
+      localizedStrings={localizedStrings}
+      hasProject={projectId !== undefined}
+      resourceType={resourceType}
+      filteredResources={filteredResources}
+      selectedRef={selectedRef}
+      readiness={readiness}
+      dblResources={dblResources}
+      onRetryCatalog={refetchCatalog}
+      scrRef={scrRef}
+      onScrRefChange={setScrRef}
+      onSelectResource={setSelectedResourceId}
+      usjPossiblyError={usjPossiblyError}
+      isUsjLoading={isUsjLoading}
+      textDirection={textDirection}
+      isSelecting={isSelecting}
+      isInstalling={isInstalling}
+      installFailed={installFailed}
+      retryInstall={retryInstall}
+      isOnline={isOnline}
+      onShowResourcePicker={showResourcePicker}
+      logger={logger}
+    />
   );
-
-  // #endregion
 };

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { usxStringToUsj } from '@eten-tech-foundation/scripture-utilities';
+import { Canon } from '@sillsdev/scripture';
 import { ResourceCell } from './resource-cell.component';
 
 const {
@@ -42,6 +43,7 @@ vi.mock('@papi/frontend/react', () => ({
       '%webView_scriptureTextGrid_cell_not_installed%': 'Resource not installed',
       '%webView_scriptureTextGrid_cell_status_loading%': 'Resource is loading…',
       '%webView_scriptureTextGrid_cell_status_failed%': 'Download failed',
+      '%webView_scriptureTextGrid_cell_status_bookNotAvailable%': 'Book not in this text',
       '%webView_scriptureTextGrid_cell_verse_empty%': 'No text for this verse',
     },
     false,
@@ -543,5 +545,74 @@ describe('ResourceCell zoom', () => {
     const [lastOptions] = capturedEditorOptions.mock.lastCall ?? [];
     // The editor must not receive a contextMenu — zoom is handled by the view's own right-click menu.
     expect(lastOptions?.contextMenu).toBeUndefined();
+  });
+});
+
+/**
+ * The exact message the C# `MissingBookException` produces. `parseMissingBookError` reads the book
+ * number and project id back out of it positionally, so a differently-worded rejection lands on the
+ * generic failure state instead — build the fixture from the real shape, never an approximation.
+ */
+function missingBookError(book: string, projectId = 'p1') {
+  return {
+    platformErrorVersion: 1,
+    message: `Book number ${Canon.bookIdToNumber(book)} not found in project ${projectId}.`,
+  };
+}
+
+describe('ResourceCell book not in this text', () => {
+  it('names the book as absent rather than blaming the download', () => {
+    setUsjResult(missingBookError('MAT'), false);
+    render(<ResourceCell {...props} />);
+
+    expect(screen.getByText('Book not in this text')).toBeInTheDocument();
+    // Nothing went wrong and no download can help, so neither the fault nor a retry may appear.
+    expect(screen.queryByText('Download failed')).not.toBeInTheDocument();
+    expect(screen.queryByText('Resource is loading…')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('editorial')).not.toBeInTheDocument();
+  });
+
+  it('keeps waiting when the failure names the book the user just left', () => {
+    // The cell shows MAT while the hook still serves GEN's rejection: re-keying the chapter
+    // subscription does not clear the previous selector's result until the first update lands.
+    setUsjResult(missingBookError('GEN'), false);
+    render(<ResourceCell {...props} />);
+
+    expect(screen.queryByText('Book not in this text')).not.toBeInTheDocument();
+    expect(screen.getByText('Resource is loading…')).toBeInTheDocument();
+  });
+
+  it('keeps waiting when the failure names a resource this cell is not showing', () => {
+    setUsjResult(missingBookError('MAT', 'a-different-project'), false);
+    render(<ResourceCell {...props} />);
+
+    expect(screen.queryByText('Book not in this text')).not.toBeInTheDocument();
+    expect(screen.getByText('Resource is loading…')).toBeInTheDocument();
+  });
+
+  it('returns to the text when the user navigates to a book the resource does contain', () => {
+    setUsjResult(missingBookError('MAT'), false);
+    const { rerender } = render(<ResourceCell {...props} />);
+    expect(screen.getByText('Book not in this text')).toBeInTheDocument();
+    setUsjSpy.mockClear();
+
+    // Move the book first, while the hook still serves the MAT rejection. The stale-failure guard
+    // takes over — the error no longer names the book on screen — so the cell drops to waiting.
+    // Stepping the two halves apart is what keeps this from conflating "the message cleared because
+    // the book changed" with "because the value is no longer an error".
+    rerender(<ResourceCell {...props} scrRef={{ ...scrRef, book: 'GEN' }} />);
+    expect(screen.queryByText('Book not in this text')).not.toBeInTheDocument();
+    expect(screen.getByText('Resource is loading…')).toBeInTheDocument();
+
+    setUsjResult(chapter, false);
+    rerender(<ResourceCell {...props} scrRef={{ ...scrRef, book: 'GEN' }} />);
+
+    expect(screen.queryByText('Book not in this text')).not.toBeInTheDocument();
+    expect(screen.getByTestId('editorial')).toBeInTheDocument();
+    // The message branch unmounted the editor, so a remounted editor holds nothing —
+    // "editorial is on screen" is satisfied just as well by a permanently blank editor showing
+    // Lexical's placeholder. Assert the re-feed, matching the twin in
+    // `resource-text-panel.component.test.tsx`.
+    expect(setUsjSpy).toHaveBeenLastCalledWith(chapter);
   });
 });

--- a/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
+++ b/extensions/src/platform-scripture-editor/src/scripture-text-grid/resource-cell.component.test.tsx
@@ -227,6 +227,22 @@ describe('ResourceCell', () => {
     expect(screen.getByTestId('editorial')).toBeInTheDocument();
     expect(setUsjSpy).toHaveBeenCalledWith(chapter); // whole chapter, unspliced
   });
+  it('re-feeds the editor when a read finishes with the same chapter already in hand', () => {
+    // The cell unmounts Editorial to show the loading message, so the editor it remounts on the way
+    // back holds nothing. The USJ object never changes across this transition — only the in-flight
+    // flag does — which is why the feed cannot be keyed on the USJ alone.
+    setUsjResult(chapter, true);
+    const { rerender } = render(<ResourceCell {...props} />);
+    expect(screen.getByText('Resource is loading…')).toBeInTheDocument();
+    expect(screen.queryByTestId('editorial')).not.toBeInTheDocument();
+    setUsjSpy.mockClear();
+
+    setUsjResult(chapter, false);
+    rerender(<ResourceCell {...props} />);
+
+    expect(screen.getByTestId('editorial')).toBeInTheDocument();
+    expect(setUsjSpy).toHaveBeenCalledWith(chapter);
+  });
   it('applies the resource own text direction', () => {
     setUsjResult(chapter, false);
     mockUseProjectSetting.mockReturnValue(['rtl', vi.fn(), vi.fn(), false]);

--- a/src/renderer/components/dialogs/share-layout.utils.ts
+++ b/src/renderer/components/dialogs/share-layout.utils.ts
@@ -16,13 +16,23 @@ function isProjectReference(ref: ResourceReference): boolean {
 }
 
 /**
- * Splits a flat `referencedProjectsAndResources` list into per-tab sub-lists, mirroring the
- * filtering `resource-text-panel.web-view.tsx` already applies for display: `dblResource` items are
- * typed via the cached DBL resource catalog, `project` items always belong to the Scripture tab,
- * and any other reference type — including a `dblResource` item whose id isn't (currently) found in
- * the catalog — is routed into `otherResources` instead of being dropped. The dialog doesn't
- * display or let the admin edit `otherResources`, but callers must round-trip it unchanged when
- * writing the setting back out, or those references are permanently lost.
+ * Splits a flat `referencedProjectsAndResources` list into per-tab sub-lists, mirroring the per-tab
+ * classification the resource panel already applies for display. That classification is two steps
+ * in the platform-scripture-editor extension: `buildPickerResources` (in
+ * `downloaded-resources.utils.ts`) stamps a `type` on each row — `dblResource` items are typed via
+ * the cached DBL resource catalog, `project` items default to the Scripture tab — and
+ * `resource-text-panel.web-view.tsx` then keeps only the rows whose `type` matches the tab it is
+ * showing.
+ *
+ * Where the two deliberately differ: the panel keeps ONE filtered list and discards whatever does
+ * not match, because it shows a single resource type. This function must instead route every
+ * non-matching reference — including a `dblResource` item whose id isn't (currently) found in the
+ * catalog — into `otherResources`. The dialog doesn't display or let the admin edit
+ * `otherResources`, but callers must round-trip it unchanged when writing the setting back out, or
+ * those references are permanently lost.
+ *
+ * `src/renderer` cannot import across the extension boundary, so this comment is the only thing
+ * keeping the classification rules in step: edit them together.
  */
 export function splitResourcesByTab(
   items: ResourceReference[],

--- a/src/renderer/components/dialogs/share-layout.utils.ts
+++ b/src/renderer/components/dialogs/share-layout.utils.ts
@@ -24,12 +24,13 @@ function isProjectReference(ref: ResourceReference): boolean {
  * `resource-text-panel.web-view.tsx` then keeps only the rows whose `type` matches the tab it is
  * showing.
  *
- * Where the two deliberately differ: the panel keeps ONE filtered list and discards whatever does
- * not match, because it shows a single resource type. This function must instead route every
- * non-matching reference — including a `dblResource` item whose id isn't (currently) found in the
- * catalog — into `otherResources`. The dialog doesn't display or let the admin edit
- * `otherResources`, but callers must round-trip it unchanged when writing the setting back out, or
- * those references are permanently lost.
+ * The two agree on the rules and differ on what happens to a reference the rules cannot place. A
+ * `dblResource` with no row in the catalog has no knowable type, so the panel DROPS it — a guessed
+ * type would leak a blank row into a type-filtered view. This function must PRESERVE it instead, in
+ * `otherResources`, because it is round-tripping the setting rather than rendering it: the dialog
+ * doesn't display or let the admin edit `otherResources`, but callers must write it back unchanged
+ * or those references are permanently lost. Same rule, opposite failure mode — do not "fix" one to
+ * match the other.
  *
  * `src/renderer` cannot import across the extension boundary, so this comment is the only thing
  * keeping the classification rules in step: edit them together.

--- a/src/renderer/components/dialogs/share-layout.utils.ts
+++ b/src/renderer/components/dialogs/share-layout.utils.ts
@@ -19,18 +19,27 @@ function isProjectReference(ref: ResourceReference): boolean {
  * Splits a flat `referencedProjectsAndResources` list into per-tab sub-lists, mirroring the per-tab
  * classification the resource panel already applies for display. That classification is two steps
  * in the platform-scripture-editor extension: `buildPickerResources` (in
- * `downloaded-resources.utils.ts`) stamps a `type` on each row — `dblResource` items are typed via
- * the cached DBL resource catalog, `project` items default to the Scripture tab — and
+ * `downloaded-resources.utils.ts`) stamps a `type` on each row, and
  * `resource-text-panel.web-view.tsx` then keeps only the rows whose `type` matches the tab it is
  * showing.
  *
- * The two agree on the rules and differ on what happens to a reference the rules cannot place. A
- * `dblResource` with no row in the catalog has no knowable type, so the panel DROPS it — a guessed
- * type would leak a blank row into a type-filtered view. This function must PRESERVE it instead, in
- * `otherResources`, because it is round-tripping the setting rather than rendering it: the dialog
- * doesn't display or let the admin edit `otherResources`, but callers must write it back unchanged
- * or those references are permanently lost. Same rule, opposite failure mode — do not "fix" one to
- * match the other.
+ * The two do NOT agree, in two ways. Both are live; neither is a bug to "fix" by making one match
+ * the other without deciding which is right.
+ *
+ * 1. **`project` references are typed differently.** This function routes every one of them to
+ *    `scriptureResources`. The panel refines the type first, by looking the project id up in the
+ *    catalog (`resolveReferenced`: `type: dblByProjectId?.type ?? 'ScriptureResource'`). A
+ *    locally-installed commentary is stored as a `ProjectReference` but has a catalog entry typed
+ *    `CommentaryResource`, so the panel files it under Commentaries while this dialog shows the
+ *    same reference under Bible Texts. That divergence is user-visible, and this function is the
+ *    side that is wrong about it — fixing it here needs the catalog lookup, which the dialog
+ *    already has `dblResources` for.
+ * 2. **A reference the rules cannot place is handled oppositely, deliberately.** A `dblResource` with
+ *    no catalog row has no knowable type, so the panel DROPS it rather than leak a blank row into a
+ *    type-filtered view. This function must PRESERVE it, in `otherResources`, because it
+ *    round-trips the setting rather than rendering it: the dialog neither displays nor lets the
+ *    admin edit `otherResources`, but callers must write it back unchanged or those references are
+ *    permanently lost.
  *
  * `src/renderer` cannot import across the extension boundary, so this comment is the only thing
  * keeping the classification rules in step: edit them together.


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# PT-4424 — Cover the reference panels' missing-book banner with tests

**Branch**: `worktree-pt-4424-reference-panel-regression-tests` · **Base**: `origin/main` ·
**Files changed**: 11 · **Review model**: Claude Opus 5

## What this does

PT-4424 asks that the Model text, Bible texts and Commentaries panes show a "book not in this text"
banner and rerender when the user navigates to a book a resource does not contain, with a regression
test pinning it. The banner itself already shipped; this branch supplies the coverage for the two
surfaces that had none. The Model text pane was already covered by
`model-text-panel.component.test.tsx`, so all three panes named in the ticket now have tests.

To make the Bible texts / Commentaries panel testable at all, `ResourceTextPanel` is extracted out of
`resource-text-panel.web-view.tsx` into `resource-text-panel.component.tsx`, mirroring the
`model-text-panel` split already on main.

## The extraction boundary

The web view keeps every PAPI hook and everything derived from one: the filtered rows, the two-stage
`readiness`, `resolveResourceSelection` and its apply effect, `resourceProjectId`, `dblMatch`, the
dynamic-title effect, the auto-install, `useCommentaryMarkerStyles`, `useOpenFindShortcut`,
`usePublishNavigableProjectIds`, the `ChapterUSJ` subscription and the text-direction setting. It also
keeps the entire pick path, **including `useDialogCallback`** — that hook supplies
`maximumOpenDialogs: 1` and an unmount guard, and hand-rolling either in the component would be
strictly worse than keeping it.

The component takes the **already-resolved** row as a prop rather than deriving it again, so there is
only ever one answer to "which resource is on screen". That matters for a reason worth stating: the
web view needs that answer to key the `ChapterUSJ` subscription that produces the `usjPossiblyError`
it passes back *down*, so the dependency is circular and the panel cannot report the resolution
upward instead. An earlier revision of this PR had both sides deriving it independently and needed a
shared helper to keep them honest; that duplication is now gone entirely.

Result: a 21-prop component and a web view that holds only PAPI wiring.

One caveat since the rebase: the component is **not** purely props-driven any more. #2749's
reveal-scroll effect moved into it (see the hidden-tab section), and that effect reads the editor DOM
directly. Its dependencies all live here, so this is where it belongs — but the component does touch
`document`.

**One correction to the "mirrors the model-text split" framing above:** the file layout mirrors it,
but the ownership split is the *opposite*. `ModelTextPanelProps` takes
`showResourcePicker(selectedResourceIds) => Promise<DblResourceData | undefined>` plus the
get/set/install callbacks, and owns the pick, the install and the write inside the component;
`ResourceTextPanelProps` takes a zero-argument `onShowResourcePicker` and owns none of it, leaving
all of that in the web view. This branch's direction is the intended one — it is what keeps `@papi`
out of the component entirely, which is what makes the component renderable from a test and a story
at all, since neither can serve a PAPI call.

Resolved: the `ResourceTextPanel` TSDoc now states the callback-out shape is the pattern to follow
for a panel component, names the divergence, and points at **PT-4561** for the sibling's
convergence — that ticket already touches both panels. Previously this was an open question here
with two in-tree precedents and no tiebreaker for the next extraction.

## Tests

**`resource-text-panel.component.test.tsx`** (new, 16 tests) — a book the resource lacks gets the
banner rather than a blank editor; commentaries get their own wording; the resource selector stays
reachable, because switching texts is the only remedy; a stale failure naming another book or another
resource keeps the panel waiting; navigating to a book the resource does contain re-feeds the editor;
a blank chapter is distinguished from one still arriving; a missing book outranks a blank chapter; an
unrelated failure is named rather than spun on; the dropdown reports the row the user picked; the
empty-state pick affordance reaches the picker; and a pick in flight reports progress rather than
leaving the empty prompt on screen.

**`scripture-text-grid/resource-cell.component.test.tsx`** (+4) — the same book-absent state in the
grid's cells, plus both stale-failure guards.

**Scope note on those four.** `ResourceCell` is rendered only from the `scripture-text-grid` tree —
the Text Collection — not by either reference panel, so they are not part of PT-4424's named panes.
They are here because it is the same banner reached through the same positional-parse contract, and
because they are the only place the two stale-failure guards are pinned at all. Flagging it rather
than letting the diff imply PT-4424 delivered a fourth surface.

Three things these tests do deliberately:

- The `MissingBookException` fixture is built from the **real C# wording**. `parseMissingBookError`
  reads the book number and project id back out of it positionally, so an approximation would route
  silently to the generic-failure branch and the suite would still look green.
- `contentOnScreen()` asserts the whole content area as one object — spinner, editor and all three
  messages — so "the panel is waiting" is a claim about every one of them at once rather than a
  `not.toBeInTheDocument()` that passes by omission.
- `setUsjSpy` is module-scoped so the editor **re-feed** is observable. The panel unmounts
  `Editorial` to show a message, so "the editor is back on screen" is satisfied just as well by a
  permanently blank editor showing Lexical's "Enter some Scripture…" placeholder — an edit invitation
  in a text the reader cannot edit. That is PT-4424's actual failure mode.

**Falsifiability was checked by mutation, not assumed** — and one round of review found the first
attempt at it insufficient, so the current state is worth stating precisely:

- Neutering the `bookNotAvailable` arm turns 5 of the 16 red.
- Dropping `contentState, isBlankChapter` from the editor-feed deps turns the blank-chapter re-feed
  test red — and only *that* one, because the other re-feed test's USJ identity also changes, so the
  blank-chapter case is what pins those deps.
- Deleting **both spinner branches** from `renderContent` turns exactly the three "keeps waiting"
  tests red. It previously turned nothing red: the waiting assertions were purely negative, and the
  first positive control added for them required the resource *selector*, which renders outside
  `renderContent` and is therefore invariant across every content branch. `Spinner` is a bare
  `LoaderCircle` with no role or accessible name, so the content area needed its own handle
  (`RESOURCE_TEXT_WAITING_TEST_ID`) for the claim to be falsifiable at all.
- Stubbing the pick affordance turns the picker test red; reporting a bare DBL uid instead of the
  namespaced row id, or dropping the callback, each turn the selection test red.
- Swapping `isSelecting` back below the readiness branch turns the pick-in-flight test red.

**1433 tests pass** (87 files) · extension typecheck clean · ESLint clean · Prettier clean.

## Also in here, from review

- Split the localized-string keys into `resource-text-panel.const.ts` with a frozen list and a derived
  key union, so the node-environment parity test can reach them without pulling in the editor
  component tree. It now guards every key either panel renders (22, up from 10), and the two keys both
  panels share are attributed to one block so a failure reports once rather than twice under two
  owners.
- Narrow the resource-panel key objects with `as const satisfies`, and record why
  `RESOURCE_PANEL_TYPED_STRING_KEYS` must stay un-annotated: the annotation would widen the union
  through the tuple spread and stop it constraining `localize()` and the `localizedStrings` prop,
  which nothing else checks. (It would *not* affect the parity test, which spreads the same frozen
  array either way — worth being precise about, since a maintainer who tests the wrong claim will
  discard the guidance with it.)
- Drive the readiness-view stories off the real key list, deleting a hand-maintained copy. Its
  comment now also states, plainly, that this does **not** make a renamed key visible in the story —
  `getLocalizedStrings` falls back to the key only for keys it is asked for, so a rename resolves in
  the map while the `args` still ask by the old literal, and an absent key reads as `undefined` with
  no `noUncheckedIndexedAccess` to catch it. That is mildly worse than the hardcoded array it
  replaced, which failed loudly with a visible `%…%` token. Documented rather than fixed: only the
  two per-resource-type keys are reachable as named values, so a full fix needs new named exports for
  a Storybook-only benefit.
- `scrRef` and `onScrRefChange` are required props; both defaults were unreachable and the
  empty-closure default allocated a fresh closure per render into the editor's options.
- Repoint the `share-layout.utils.ts` cross-reference at the classification the panel actually
  performs, and describe **both** ways the two now diverge. One is deliberate: an unplaceable
  `dblResource` is dropped by the panel and preserved by the dialog in `otherResources`, because that
  side round-trips the setting rather than rendering it. The other is not, and #2630 introduced it —
  the dialog routes every `project` reference to Bible Texts while `resolveReferenced` refines the
  type from the catalog, so a locally-installed commentary is filed under Commentaries by the panel
  and Bible Texts by the dialog. The comment says which side is wrong. The misfiling itself is a
  renderer-dialog behavior change and is not fixed here. `buildPickerResources` carries the same
  summary, so the instruction is reachable from the side more likely to change.
- Report progress during a first resource pick. `isSelecting || isInstalling` now precedes the
  readiness return: on a first pick the resource is not in the reference list until the install and
  the write have completed, so readiness stays `empty` and the reader previously sat on "No Bible
  texts selected" with an enabled pick button for the whole download. Reaching the "Selecting
  resource…" state also removes that button, which closes an invitation to a second pick —
  `useDialogCallback` frees its dialog slot before invoking the resolve handler that starts the
  install. Note the reorder also puts `isSelecting` above `installFailed`, so an install failing
  *during* a pick shows "Selecting resource…" for the tick before the `finally` clears it, then the
  retry view.

## Hidden-tab handling — now upstream, and relocated here

Flagged because `.claude/rules/cross-view-sync-hidden-views.md` asks for the hidden case to be
answered in the PR description as well as in the code.

An earlier revision of this branch recorded "do nothing while hidden" as a deliberate decision. That
is no longer the answer: **#2749 implemented the geometry case on main** while this branch was in
review. `resource-text-panel.web-view.tsx` gained a reveal-scroll effect keyed on `useViewVisibility`
*and* the reference — visibility covers a tab activation, which carries no reference change of its
own — with an echo latch so the panel's own scroll-group publishes are not treated as new targets,
and a layout-settle loop because a verse marker enters the DOM before the chapter has finished laying
out.

Both halves are therefore handled now:

- **Data-driven**: the `ChapterUSJ` subscription keeps delivering while hidden and the `setUsj` feed
  works with no layout.
- **Geometry-driven**: the reveal-scroll effect scrolls to the verse when the tab is shown.

**What this branch did with it.** Every dependency of that effect — `editorRef`, `usjFromPdp`,
`isUsjLoading`, the editor DOM — moved into the component in this extraction, so the effect and its
two refs were relocated from the web view into `resource-text-panel.component.tsx` during the rebase.
The code is unchanged from main apart from the latch calling the `onScrRefChange` prop instead of
`setScrRef` directly. The web view retains none of it.

Two consequences worth a reviewer's eye:

- The component now reaches `document.querySelector('.editor-container')`, so it is no longer purely
  props-driven. That is inherent to where the effect's dependencies live, not a choice made here.
- `resource-text-panel.component.test.tsx` needed an `IntersectionObserver` stub, since
  `useViewVisibility` reaches for one and jsdom implements none. It follows the existing stub in
  `platform-scripture`'s `find.component.test.tsx`. The panel tests assert content states, not scroll
  behaviour, so nothing depends on it reporting visibility — **the reveal-scroll effect itself is
  untested here**, exactly as it was on main.

## Deliberately not fixed here

**`TODO(PT-4517)` — a pre-existing blank editor in *both* panels.** The editor-feed effect's deps
cover the content-area branches but not the whole-panel early returns (`!hasProject`,
`readiness !== 'configured'`, `installFailed`, `isSelecting || isInstalling`), which return a
different subtree and so also unmount the editor. Returning from one with the USJ unchanged remounts
an editor nothing re-feeds. Reachable by picking the resource already on screen.

Worth flagging for the reviewer, because the obvious fix does not work: `ModelTextPanel`'s `tw:hidden`
covers only *its* content-area states — the half this panel's dep list already handles — and it keeps
six whole-panel early returns of its own, fed by an effect keyed on the USJ alone. It is therefore
*less* protected on this path, not immune to the class. In those branches the editor is not rendered
in any form, so there is no element to hide; the fix is structural and should be decided once for both
panels.

**PT-4508** — a failed install during a manual pick is silent: `selectTextConnection` swallows the
rethrow, nothing persists, so `installFailed` never becomes true and no message, log or state change
results. The fix touches `select-dbl-resource.ts`, shared with the model text panel.

**`TODO(PT-4509)`** — the dropdown is unguarded while a pick is in flight. `isSelecting` goes false
in its `finally`, uncovering the selector, before the written reference reaches `filteredResources`,
and `resolveResourceSelection`'s pending branch ignores `selectedResourceId` — so a user who changes
their mind in that window watches the panel jump to the resource they abandoned. The ticket has been
rescoped to this half: its original stranding claim is withdrawn (the cold-mount reproduction is
unreachable, since every path exposing the picker already requires `effectiveResourcesState` to be
`ready`), and main's `resolveResourceSelection` gave `pendingResourceId` a real clearing path via
`shouldClearPending` regardless.

**`TODO(PT-4561)`** — the in-flight-pick branch answers "is this panel ready?" outside
`getResourcePanelReadiness`, which `adr-panel-readiness-from-sources` asks panels not to do. Folding
it in would also fix `model-text-panel`'s identical first-pick defect, but it changes a shared util's
contract plus production behavior in a panel this PR does not touch, and it settles whether an
in-flight pick outranks an unreadable settings list — a precedence that is currently an accident of
return order, and that the util's own comment argues the other way on.

**Most of the broader component coverage.** The extraction makes the install-failed, readiness and
selection branches testable, and they were equally untested before this PR. Not a blanket exclusion,
though: the pick-in-flight, picker and logging tests here do pin a readiness branch and the
debug/error split, because each was needed to hold a fix honest. What remains uncovered is
`hasProject === false`, `installFailed`/`isOnline`/`retryInstall`, `textDirection`, and the
`isSelecting` vs `isInstalling` distinction. The sibling suite does not cover `hasProject === false`,
`pendingResourceId` or the auto-correct effect either; the pending-pick test is tracked on PT-4509,
since that is the invariant that can actually strand the panel.

**PT-4424's packaged-build DoD clause.** The banner shipped in PT-4132 (#2704) and its component is
untouched here, so verifying it in a packaged build belongs to that PR. What this branch contributes
is the automated coverage that makes the banner's appearance checkable on every run rather than once
by hand — which is the durable form of the same check. Stating it rather than leaving the clause
silent.

## Rebase note for reviewers

This branch was re-derived onto current main rather than rebased. #2630 (PT-4059) replaced the data
model the first revision was built on — `EffectiveResourceReference[]` became `PickerResource[]` rows
carrying `type`/`installed`/`projectId`, the two selection effects became `resolveResourceSelection`,
and `getRefId` became `getResourceReferenceRowId`. A textual rebase applied cleanly in the files that
did not conflict and then failed to compile, because the component encoded a model that no longer
existed.

So the following, added in earlier review rounds, are **deliberately gone** — main supersedes each:
`resolveResourcePanelSelection`, `ResourcePanelSelection`, `filterResourcesByType`,
`resolveSelectedResource`, `SelectedResource`, `getRefId`. Main's `resolveResourceSelection` is also
more capable than what it replaced: it rewrites a legacy bare id to its namespaced form and falls back
to the first row that actually has a `projectId`, rather than blindly to `[0]`.

## Verification, and what `npm run lint` does locally

Verified for this branch: **1433 tests pass** (87 files) · extension typecheck clean · ESLint clean
on every changed file · Prettier clean. Falsifiability of the new tests was checked by mutation, not
assumed — see the Tests section.

`npm run lint` — the command CI runs — **does not complete in a local git worktree**, for reasons
none of which involve this branch's code. Recording them because the first two look like real
failures and cost time to diagnose:

1. `build:types` failed with `TS2688: Cannot find type definition file for 'jest'` / `'node'`.
   Cause: `lib/papi-dts/tsconfig.json` sets `typeRoots` **explicitly**, hardcoding
   `../../node_modules/@types`. In a worktree that path is the worktree's own (near-empty)
   `node_modules`, and because `typeRoots` is explicit, tsc never falls back to walking up to the
   parent checkout's `@types`. Symlinking them in clears it.
   **Note:** `tsc` emits despite these errors, so a failed run **rewrites `lib/papi-dts/papi.d.ts`**
   with a truncated file (~2,400 lines short). Do not commit it. Once types resolve, the file
   regenerates byte-identical to what is committed.
2. `import/no-unresolved` on `release/app/buildInfo.json` — a gitignored build artifact that a
   worktree has never generated. Copy it in. `eslint --cache` will keep reporting it after the fix
   until `.eslintcache` is deleted.
3. With both cleared, root `lint:scripts` and `lint:styles` **pass**, and the run reaches the
   per-workspace lints, where it stops on `copy-webpack-plugin` being unresolvable. That one is not
   a worktree artifact: the package is declared by ten extension workspaces and is absent from the
   shared `node_modules` altogether, so it needs a real `npm install`.

Two related environment facts, both independent of this PR:

- Main depends on `unicode-segmenter` via `lib/platform-bible-utils` (#2626). Without it, 50 test
  files fail at transform before reaching an assertion.
- `npm install` on this repo currently fails on a peer conflict: `storybook` is pinned to exactly
  `9.1.19` while `@storybook/addon-vitest: ^9.1.19` resolves to `9.1.20`, which requires
  `storybook@^9.1.20`.

CI installs cleanly from the lockfile, so it is unaffected by 1–3 and remains the authoritative lint
signal for this branch.
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2748)
<!-- Reviewable:end -->

