### PR TITLE
PT-4467: Show reference-panel resources in the Find project picker

### DIFF
--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -3217,3 +3217,45 @@ step, no automation. Just a record.
   `^\d+_web-view-state$` obsolete-key sweep are all untouched: they read numeric-era data no future
   build can add to, and durability changes nothing about them.
 - **Source:** PT-4464.
+## adr-find-searchable-tabs: Find searches what a tab declares it displays, and targets editors and reference panels differently
+
+- **Date:** 2026-09-03
+- **Status:** Accepted
+- **Context:** Find's project picker listed only projects open in a Scripture editor tab, so a
+  resource shown in a read-only reference panel (Model text, Bible texts, Commentaries) could not be
+  selected. Worse, Ctrl+F from such a panel passed that resource's project id to Find, whose
+  reassignment effect then found no matching tab, took its cross-project fallback, and silently
+  re-ran the search against an unrelated project (PT-4467). The panels already declare the resource
+  they display under `NAVIGABLE_PROJECT_IDS_WEB_VIEW_STATE_KEY` (see
+  [adr-navigable-project-ids](#adr-navigable-project-ids)), but nothing on the consuming side read
+  it.
+- **Decision:** `useOpenProjectTabs` gained an opt-in `includeNavigableProjectIds`, under which a
+  web view reports the projects it declares instead of its container project, yielding one tab per
+  declared project. Find opts in and widens its picker filter to
+  `FIND_SEARCHABLE_WEB_VIEW_TYPES`. Because a declaring view can contribute several tabs, tabs are
+  keyed by (web view, project) rather than by web view alone. A declaration of `[]` means "displays
+  nothing" and offers no project; an absent key means the view does not participate, so its
+  container project answers. Result activation then splits by tab kind: an editor is driven through
+  its web view controller (select + highlight), while a reference panel exposes no controller, so
+  activating its tab is the whole navigation. Wherever several tabs of one project qualify, an
+  editor wins.
+- **Alternatives:** **Pin the trigger-supplied project id so the reassignment effect cannot move
+  it** — rejected: it stops the snap-away but leaves the resource absent from the picker, so the
+  user still cannot see or choose what is being searched. **Mirror a Find-specific state key across
+  the two extensions** — implemented first and then removed: `navigableProjectIds` already carries
+  exactly this value from exactly these panels, with a readiness gate, so a second key meant both
+  panels publishing the same value twice under two keys. **Include the Text Collection** — deferred:
+  it declares every resource it hosts and would be nearly free to list, but "go to result" has no
+  defined behavior there, since each cell is its own editor and revealing the grid would not show
+  which cell matched.
+- **Consequences:** Any web view that declares navigable projects becomes searchable by adding its
+  type to `FIND_SEARCHABLE_WEB_VIEW_TYPES`, with no further wiring. The cost is that Find's picker
+  no longer means "projects open in an editor", so callers must not assume a picked row is a valid
+  Replace target — Replace stays gated on editability, which already covers it. Because a panel
+  registers no controller, "go to result" on a panel-only resource can only activate its tab: in
+  Simple mode the Bible texts and Commentaries panels share Find's Column 3 stack, so that
+  necessarily hides the results list, while the Model text panel is already visible in Column 1 and
+  the activation only moves keyboard focus. Find cannot tell those cases apart from inside its own
+  iframe, since PAPI exposes no visibility query for another web view.
+  **Revisit** if per-cell reveal is designed for the Text Collection, which would bring it into the
+  searchable set.

--- a/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
+++ b/extensions/src/platform-scripture-editor/src/_editor-overrides.scss
@@ -314,3 +314,34 @@ button {
     border-bottom: 2px solid var(--foreground);
   }
 }
+
+// Verse-arrival highlight: a brief pulse on the verse a navigation landed on. Applied by adding
+// `.highlighted` to the verse element returned by `scrollToVerse`, and removed on cleanup.
+//
+// Lives here rather than in the Scripture editor's own stylesheet because the read-only reference
+// panels need it too: Find's "go to result" scrolls those panels to the matched verse, and without
+// the pulse the user lands on a verse with nothing indicating which one matched.
+//
+// Highlight keyframes thanks to chazsolo at https://stackoverflow.com/a/55835473
+@keyframes highlight {
+  from {
+    background-color: yellow;
+  }
+}
+
+.editor-container .highlighted {
+  position: relative;
+}
+
+.editor-container .highlighted::before {
+  content: '';
+  position: absolute;
+  width: 25px;
+  height: 25px;
+  border-radius: 50%;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  opacity: 0.8;
+  animation: highlight 2s;
+}

--- a/extensions/src/platform-scripture-editor/src/editor-dom.util.test.ts
+++ b/extensions/src/platform-scripture-editor/src/editor-dom.util.test.ts
@@ -17,6 +17,8 @@ import {
   BASELINE_PROBE_ATTRIBUTE,
   clampTopToVisibleArea,
   findScrollContainer,
+  hasNewScrollTarget,
+  isEchoOfPublishedScrRef,
   measureBaselineOffset,
   scrollToAnnotation,
   scrollToVerse,
@@ -492,5 +494,55 @@ describe('clampTopToVisibleArea', () => {
     // Both clamps are active and pull opposite ways. Order is the behavior being pinned: max-then-min
     // yields the bottom bound, whereas min-then-max would return the visible-area top instead.
     expect(clampTopToVisibleArea({ top: 0, bottom: 50 }, { top: 0 }, { top: 100 })).toBe(49);
+  });
+});
+
+const JHN_3_16 = { book: 'JHN', chapterNum: 3, verseNum: 16 };
+const JHN_3_17 = { book: 'JHN', chapterNum: 3, verseNum: 17 };
+const ROM_3_16 = { book: 'ROM', chapterNum: 3, verseNum: 16 };
+const USJ_A = { type: 'USJ', content: ['a'] };
+const USJ_B = { type: 'USJ', content: ['b'] };
+
+describe('isEchoOfPublishedScrRef', () => {
+  it('recognizes the reference this view just published', () => {
+    expect(isEchoOfPublishedScrRef(JHN_3_16, JHN_3_16)).toBe(true);
+  });
+
+  it('does not treat a different verse as an echo', () => {
+    // A real navigation to a neighbouring verse must still scroll.
+    expect(isEchoOfPublishedScrRef(JHN_3_16, JHN_3_17)).toBe(false);
+  });
+
+  it('compares the book too, not just the numbers', () => {
+    expect(isEchoOfPublishedScrRef(JHN_3_16, ROM_3_16)).toBe(false);
+  });
+
+  it('is not an echo when nothing is outstanding', () => {
+    expect(isEchoOfPublishedScrRef(undefined, JHN_3_16)).toBe(false);
+  });
+});
+
+describe('hasNewScrollTarget', () => {
+  it('scrolls when nothing has been scrolled to yet', () => {
+    expect(hasNewScrollTarget(undefined, JHN_3_16, USJ_A)).toBe(true);
+  });
+
+  it('skips a bare reveal, so a manual scroll survives a tab switch', () => {
+    expect(hasNewScrollTarget({ scrRef: JHN_3_16, usj: USJ_A }, JHN_3_16, USJ_A)).toBe(false);
+  });
+
+  it('scrolls when the reference moved while hidden', () => {
+    expect(hasNewScrollTarget({ scrRef: JHN_3_16, usj: USJ_A }, JHN_3_17, USJ_A)).toBe(true);
+  });
+
+  it('scrolls when the chapter content arrives for the same reference', () => {
+    // A reveal can beat the chapter load; the content landing is the cue to scroll, and the
+    // reference alone would not distinguish it.
+    expect(hasNewScrollTarget({ scrRef: JHN_3_16, usj: USJ_A }, JHN_3_16, USJ_B)).toBe(true);
+  });
+
+  it('compares content by identity, not value', () => {
+    // The panel pushes whatever object the PDP hands it; an equal-but-new object is a real update.
+    expect(hasNewScrollTarget({ scrRef: JHN_3_16, usj: USJ_A }, JHN_3_16, { ...USJ_A })).toBe(true);
   });
 });

--- a/extensions/src/platform-scripture-editor/src/editor-dom.util.ts
+++ b/extensions/src/platform-scripture-editor/src/editor-dom.util.ts
@@ -317,3 +317,63 @@ export function scrollToAnnotation(id: string): HTMLElement | undefined {
 
   return annotationElement;
 }
+
+/**
+ * Whether an incoming reference is this view's own echo — the reference it just published coming
+ * back through its scroll group.
+ *
+ * A read-only reference panel sits on scroll group 0, so a verse click inside it publishes to the
+ * group and returns immediately as a prop update. Scrolling for that echo would drag the user's own
+ * click target to the top of the viewport right after they clicked it.
+ *
+ * @param lastPublishedScrRef The reference this view last published, or `undefined` if none is
+ *   outstanding.
+ * @param scrRef The incoming reference.
+ * @returns `true` when the incoming reference is the outstanding echo and no scroll should happen.
+ */
+export function isEchoOfPublishedScrRef(
+  lastPublishedScrRef: SerializedVerseRef | undefined,
+  scrRef: SerializedVerseRef,
+): boolean {
+  return (
+    !!lastPublishedScrRef &&
+    lastPublishedScrRef.book === scrRef.book &&
+    lastPublishedScrRef.chapterNum === scrRef.chapterNum &&
+    lastPublishedScrRef.verseNum === scrRef.verseNum
+  );
+}
+
+/**
+ * Whether there is anything new to scroll to since the last scroll this view performed.
+ *
+ * Guards the bare reveal: a panel that shares a tab stack with other views is re-shown constantly,
+ * and re-scrolling every time would discard a scroll position the user set by hand before switching
+ * tabs. The chapter content is part of the identity because a reveal can beat the chapter load —
+ * when content arrives for the same reference, that IS new and does need a scroll.
+ *
+ * @param lastScrolledFor What the last performed scroll was for, or `undefined` if none yet.
+ * @param scrRef The reference to scroll to.
+ * @param usj The chapter content currently loaded, compared by identity.
+ * @returns `true` when the reference or the content differs from the last scroll.
+ */
+export function hasNewScrollTarget(
+  lastScrolledFor: { scrRef: SerializedVerseRef; usj: unknown } | undefined,
+  scrRef: SerializedVerseRef,
+  usj: unknown,
+): boolean {
+  if (!lastScrolledFor) return true;
+  return (
+    lastScrolledFor.usj !== usj ||
+    lastScrolledFor.scrRef.book !== scrRef.book ||
+    lastScrolledFor.scrRef.chapterNum !== scrRef.chapterNum ||
+    lastScrolledFor.scrRef.verseNum !== scrRef.verseNum
+  );
+}
+
+/**
+ * Max ms to wait for a verse scroll to become possible before giving up — the rAF retry in the
+ * model text panel and the settle loop in the resource text panel both bound themselves with it.
+ * The usual reason for reaching it is a verse marker genuinely absent from the USJ (a `\v 16-17`
+ * range publishes no marker for 17).
+ */
+export const SCROLL_MAX_WAIT_MS = 2000;

--- a/extensions/src/platform-scripture-editor/src/model-text-panel.component.tsx
+++ b/extensions/src/platform-scripture-editor/src/model-text-panel.component.tsx
@@ -38,7 +38,7 @@ import { RetryableErrorView, LoadingView } from './panel-state-views.component';
 import { getResourcePanelReadiness } from './resource-panel-readiness.utils';
 import { PanelReadinessView } from './panel-readiness-view.component';
 import type { EffectiveResourceReferenceListState } from './use-effective-resource-reference-list.hook';
-import { scrollToVerse } from './editor-dom.util';
+import { SCROLL_MAX_WAIT_MS, scrollToVerse } from './editor-dom.util';
 import { ResourceBookNotAvailable } from './resource-book-not-available.component';
 import { ResourceBlankChapter } from './resource-blank-chapter.component';
 import { ResourceTextUnavailable } from './resource-text-unavailable.component';
@@ -66,9 +66,6 @@ export const MODEL_TEXT_EDITOR_CONTAINER_TEST_ID = 'model-text-editor-container'
 // and the editor reloads (re-serialize + setEditorState) whenever the `view` object's identity
 // changes — so a refetch of identical content would force a pointless full reload.
 const VIEW_OPTIONS = getDefaultViewOptions();
-
-/** Max ms to retry scrolling via rAF before giving up (e.g. verse marker missing from USJ) */
-const SCROLL_MAX_WAIT_MS = 2000;
 
 export {
   MODEL_TEXT_PANEL_STRING_KEYS,

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.scss
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.scss
@@ -16,30 +16,6 @@ mark {
 
 // #region verse number highlight
 
-// Highlight keyframes thanks to chazsolo at https://stackoverflow.com/a/55835473
-@keyframes highlight {
-  from {
-    background-color: yellow;
-  }
-}
-
-.editor-container .highlighted {
-  position: relative;
-}
-
-.editor-container .highlighted::before {
-  content: '';
-  position: absolute;
-  width: 25px;
-  height: 25px;
-  border-radius: 50%;
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
-  opacity: 0.8;
-  animation: highlight 2s;
-}
-
 // #endregion
 
 // Simple-mode-only rules (including .scripture-editor-tab-nav-simple, used by this web view's

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
   useExtraValidMarkers,
   useTabIconSelection,
+  useViewVisibility,
   type TabIconUrls,
   Spinner,
 } from 'platform-bible-react';
@@ -32,10 +33,16 @@ import {
   LocalizeKey,
   ResourceType,
 } from 'platform-bible-utils';
-import { Canon } from '@sillsdev/scripture';
+import { Canon, SerializedVerseRef } from '@sillsdev/scripture';
 import { ChevronDown } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ResourceReferenceList } from 'platform-scripture';
+import {
+  hasNewScrollTarget,
+  isEchoOfPublishedScrRef,
+  SCROLL_MAX_WAIT_MS,
+  scrollToVerse,
+} from './editor-dom.util';
 import { useOpenFindShortcut } from './use-open-find-shortcut.hook';
 import { useEffectiveResourceReferenceList } from './use-effective-resource-reference-list.hook';
 import { useResourcePickerResources } from './use-resource-picker-resources.hook';
@@ -590,6 +597,23 @@ globalThis.webViewComponent = function ResourceTextPanel({
   // EditorRef requires null initial value per React ref convention
   // eslint-disable-next-line no-null/no-null
   const editorRef = useRef<EditorRef | null>(null);
+
+  // What this panel last published to its scroll group, and what it last successfully scrolled to.
+  // Both feed the guards on the reveal-scroll effect below.
+  const lastPublishedScrRefRef = useRef<SerializedVerseRef | undefined>(undefined);
+  const lastScrolledForRef = useRef<{ scrRef: SerializedVerseRef; usj: unknown } | undefined>(
+    undefined,
+  );
+  const isViewVisible = useViewVisibility();
+
+  // Record what we publish before forwarding it, so the bounce-back can be recognised as our own.
+  const handleScrRefChange = useCallback(
+    (newScrRef: SerializedVerseRef) => {
+      lastPublishedScrRefRef.current = newScrRef;
+      setScrRef(newScrRef);
+    },
+    [setScrRef],
+  );
   // Markers this resource's content actually uses. Passed to the editor as extraValidMarkers so it
   // doesn't warn "Unexpected <kind> marker" for handbook/commentary markers (e.g. \pn, \jmp) — scoped
   // per-resource from the USJ being displayed, never a global list. Empty for content that needs
@@ -615,6 +639,105 @@ globalThis.webViewComponent = function ResourceTextPanel({
   useEffect(() => {
     if (usjFromPdp) editorRef.current?.setUsj(usjFromPdp);
   }, [usjFromPdp, contentState, isBlankChapter]);
+
+  // Scroll to the current verse when this tab is shown, and again once a chapter's content lands.
+  //
+  // `Editorial` renders the reference it is given but does not scroll to the verse — every consumer
+  // that scrolls does it by calling `scrollToVerse`, as the Scripture editor and the model text
+  // panel both do.
+  //
+  // Keyed on visibility AND on the reference: visibility covers the reveal (a tab activation carries
+  // no reference change of its own), and the reference covers "go to result" landing on a panel that
+  // is already visible.
+  useEffect(() => {
+    // The echo is consumed FIRST, and whether or not this panel is visible. A verse click inside
+    // `Editorial` publishes to scroll group 0 and bounces straight back as a prop update; scrolling
+    // on that would yank the user's own click target to the top. Leaving the latch armed because
+    // the panel happened to be hidden would be worse: a later, genuine "go to result" onto that
+    // same verse would look like an echo and be swallowed, and a panel registers no web view
+    // controller, so nothing would retry it.
+    if (isEchoOfPublishedScrRef(lastPublishedScrRefRef.current, scrRef)) {
+      lastPublishedScrRefRef.current = undefined;
+      // The clicked verse IS this panel's position now. Recording it keeps a later bare reveal from
+      // treating it as a new target and snapping away from wherever the user has since scrolled.
+      lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
+      return undefined;
+    }
+
+    // `isUsjLoading` is the guard that keeps a scroll off the PREVIOUS chapter: `useProjectData`
+    // holds the old USJ across a selector change, and that content is fully laid out, so the settle
+    // loop below would happily accept it. `scrollToVerse` matches on verse number alone, with no
+    // book or chapter qualifier, so scrolling then lands on — and pulses — the same verse number in
+    // the wrong chapter.
+    if (!isViewVisible || !usjFromPdp || isUsjLoading) return undefined;
+
+    // Nothing new since the last scroll — this is a bare reveal, so leave the user's scroll alone.
+    if (!hasNewScrollTarget(lastScrolledForRef.current, scrRef, usjFromPdp)) return undefined;
+
+    // Wait for the revealed pane's layout to SETTLE, then scroll exactly once.
+    //
+    // Two traps here. First, the verse marker enters the DOM before the chapter has finished laying
+    // out, so an offset computed at that moment is measured against a much shorter content box and
+    // scrolls to a fraction of the real target. Second — and why a naive rAF retry does not rescue
+    // it — `scrollToVerse` scrolls with `behavior: 'smooth'`, so re-calling it every frame restarts
+    // the animation from wherever it had crept to and it never converges.
+    //
+    // Sampling the scroll container's height until it stops changing avoids both: the geometry is
+    // trustworthy by then, and the single call that follows animates uninterrupted.
+    let cancelled = false;
+    const start = Date.now();
+    let lastScrollHeight = -1;
+    // Pulses the verse we land on, so the match is identifiable when several share a verse or a
+    // commentary entry is long. Same treatment the Scripture editor gives an arrived verse.
+    let highlightedVerseElement: HTMLElement | undefined;
+    const scrollWhenSettled = () => {
+      if (cancelled) return;
+
+      // Below verse 1 means the chapter top, which `scrollToVerse` handles without a verse marker
+      // and so without settled geometry. Verse 1 is NOT in this case: it has a real marker and real
+      // geometry to measure, so it goes through the settle loop like any other verse.
+      if (scrRef.verseNum < 1) {
+        scrollToVerse(scrRef);
+        lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
+        return;
+      }
+
+      const timedOut = Date.now() - start > SCROLL_MAX_WAIT_MS;
+      // `.editor-container` is sampled as a CONTENT-GROWTH PROXY, not as the scroll container.
+      // Which element actually scrolls differs by host — `_editor-overrides.scss` warns that this
+      // one is auto-height in the Scripture editor and its wrapper scrolls instead — so the scroll
+      // itself is left to `scrollToVerse`, which discovers the container via `findScrollContainer`.
+      // Only the height is read here, and that tracks the chapter laying out either way.
+      const contentElement = document.querySelector<HTMLElement>('.editor-container');
+      // `querySelector` yields null, not undefined, so compare truthily — treating a missing
+      // element as "settled" would scroll against geometry that does not exist yet.
+      const scrollHeight = contentElement ? contentElement.scrollHeight : -1;
+      const isSettled = !!contentElement && scrollHeight === lastScrollHeight;
+      lastScrollHeight = scrollHeight;
+
+      if (isSettled || timedOut) {
+        highlightedVerseElement = scrollToVerse(scrRef);
+        // Only a scroll that actually landed is recorded. The verse marker can be genuinely absent
+        // — a `\v 16-17` range publishes no `[data-number="17"]` — and the pane may not have
+        // produced overflow yet. Recording regardless would make `hasNewScrollTarget` answer "same
+        // target" forever, so the panel would never catch up on a later reveal.
+        if (highlightedVerseElement) {
+          lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
+          highlightedVerseElement.classList.add('highlighted');
+        }
+        return;
+      }
+      requestAnimationFrame(scrollWhenSettled);
+    };
+    scrollWhenSettled();
+    return () => {
+      cancelled = true;
+      highlightedVerseElement?.classList.remove('highlighted');
+    };
+    // `scrollToVerse` and the two predicates are stable module-level imports; listing them would
+    // cause spurious re-runs.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isViewVisible, usjFromPdp, isUsjLoading, scrRef.book, scrRef.chapterNum, scrRef.verseNum]);
 
   // #endregion
 
@@ -757,7 +880,7 @@ globalThis.webViewComponent = function ResourceTextPanel({
         <Editorial
           ref={editorRef}
           scrRef={scrRef}
-          onScrRefChange={setScrRef}
+          onScrRefChange={handleScrRefChange}
           options={options}
           logger={logger}
         />

--- a/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/resource-text-panel.web-view.tsx
@@ -663,6 +663,11 @@ globalThis.webViewComponent = function ResourceTextPanel({
       lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
       return undefined;
     }
+    // The latch is only ever valid for the very NEXT reference, so any other reference discards it.
+    // Otherwise a publish whose echo never arrives as its own update — a Find result writing to the
+    // group before the round-trip lands — leaves the latch armed forever, and a later genuine "go to
+    // result" onto that verse would match it and be swallowed.
+    lastPublishedScrRefRef.current = undefined;
 
     // `isUsjLoading` is the guard that keeps a scroll off the PREVIOUS chapter: `useProjectData`
     // holds the old USJ across a selector change, and that content is fully laid out, so the settle
@@ -692,17 +697,25 @@ globalThis.webViewComponent = function ResourceTextPanel({
     let highlightedVerseElement: HTMLElement | undefined;
     const scrollWhenSettled = () => {
       if (cancelled) return;
+      const timedOut = Date.now() - start > SCROLL_MAX_WAIT_MS;
 
-      // Below verse 1 means the chapter top, which `scrollToVerse` handles without a verse marker
-      // and so without settled geometry. Verse 1 is NOT in this case: it has a real marker and real
-      // geometry to measure, so it goes through the settle loop like any other verse.
+      // Below verse 1 means the chapter top, which `scrollToVerse` reaches without a verse marker
+      // and so without settled geometry — but it still needs the container in the DOM, and it
+      // cannot report that, since it returns an element only when it matched a marker. So the
+      // container is checked here before recording; otherwise a reveal that beat the container into
+      // the DOM would scroll nothing and still be recorded as done. Verse 1 is NOT in this case: it
+      // has a real marker and real geometry, so it goes through the settle loop like any other.
       if (scrRef.verseNum < 1) {
-        scrollToVerse(scrRef);
-        lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
+        if (document.querySelector('.editor-container')) {
+          scrollToVerse(scrRef);
+          lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
+          return;
+        }
+        if (timedOut) return;
+        requestAnimationFrame(scrollWhenSettled);
         return;
       }
 
-      const timedOut = Date.now() - start > SCROLL_MAX_WAIT_MS;
       // `.editor-container` is sampled as a CONTENT-GROWTH PROXY, not as the scroll container.
       // Which element actually scrolls differs by host — `_editor-overrides.scss` warns that this
       // one is auto-height in the Scripture editor and its wrapper scrolls instead — so the scroll
@@ -715,18 +728,26 @@ globalThis.webViewComponent = function ResourceTextPanel({
       const isSettled = !!contentElement && scrollHeight === lastScrollHeight;
       lastScrollHeight = scrollHeight;
 
-      if (isSettled || timedOut) {
+      if (isSettled) {
         highlightedVerseElement = scrollToVerse(scrRef);
         // Only a scroll that actually landed is recorded. The verse marker can be genuinely absent
-        // — a `\v 16-17` range publishes no `[data-number="17"]` — and the pane may not have
-        // produced overflow yet. Recording regardless would make `hasNewScrollTarget` answer "same
-        // target" forever, so the panel would never catch up on a later reveal.
+        // — a `\v 16-17` range publishes no `[data-number="17"]` — so recording regardless would
+        // make `hasNewScrollTarget` answer "same target" forever and the panel would never catch up
+        // on a later reveal.
         if (highlightedVerseElement) {
           lastScrolledForRef.current = { scrRef, usj: usjFromPdp };
           highlightedVerseElement.classList.add('highlighted');
+          return;
         }
-        return;
+        // Settled but no marker yet. Two consecutive equal heights are cheap to reach — an empty,
+        // flex-sized container reports the same height every frame before Lexical has reconciled
+        // the chapter — so "settled" is not "rendered". Keep waiting rather than treating one
+        // agreeing pair as the answer; `scrollToVerse` does not scroll without a marker, so
+        // re-calling it cannot restart an animation.
       }
+      // Out of time: give up WITHOUT recording, so a later reveal tries again instead of being
+      // told the target is unchanged.
+      if (timedOut) return;
       requestAnimationFrame(scrollWhenSettled);
     };
     scrollWhenSettled();
@@ -734,8 +755,10 @@ globalThis.webViewComponent = function ResourceTextPanel({
       cancelled = true;
       highlightedVerseElement?.classList.remove('highlighted');
     };
-    // `scrollToVerse` and the two predicates are stable module-level imports; listing them would
-    // cause spurious re-runs.
+    // The rule wants `scrRef` itself, but this effect is keyed on the three fields that decide where
+    // to scroll. `useWebViewScrollGroupScrRef` hands back a fresh object whenever the scroll group
+    // publishes, including for a reference that did not change, so depending on the object would
+    // restart the settle loop on updates that cannot move the target.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isViewVisible, usjFromPdp, isUsjLoading, scrRef.book, scrRef.chapterNum, scrRef.verseNum]);
 

--- a/extensions/src/platform-scripture/contributions/localizedStrings.json
+++ b/extensions/src/platform-scripture/contributions/localizedStrings.json
@@ -3,6 +3,12 @@
     "%webView_find_allBooks%": {
       "fallbackKey": "%comment_filter_scope_all_books%"
     },
+    "%webView_find_noOpenProjects_results%": {
+      "fallbackKey": "%webView_find_noOpenProjectsOrResources_results%"
+    },
+    "%webView_find_projectFilter_noOpenProjects%": {
+      "fallbackKey": "%webView_find_projectFilter_noOpenProjectsOrResources%"
+    },
     "%webView_find_projectFilter_noProjectsFound%": {
       "fallbackKey": "%webView_checksSidePanel_projectFilter_noProjectsFound%"
     },
@@ -494,13 +500,13 @@
       "%webView_find_showing%": "Showing",
       "%webView_find_findTab%": "Find",
       "%webView_find_replaceTab%": "Replace",
-      "%webView_find_projectFilter_noOpenProjects%": "No open projects",
+      "%webView_find_projectFilter_noOpenProjectsOrResources%": "No open projects or resources",
       "%webView_find_projectFilter_noProjectsFound%": "No projects found",
       "%webView_find_projectSelector_label%": "Project",
       "%webView_find_projectSelector_searchPlaceholder%": "Search projects & resources",
       "%webView_find_projectSelector_openTabsSectionHeading%": "Opened project & resource tabs",
       "%webView_find_projectSelector_otherProjectsSectionHeading%": "Your projects & resources",
-      "%webView_find_noOpenProjects_results%": "No projects are open. Open a project to search.",
+      "%webView_find_noOpenProjectsOrResources_results%": "No projects or resources are open. Open one to search.",
       "%webView_find_project_unavailableError%": "the selected project is not available to search",
       "%webView_find_replace%": "Replace",
       "%webView_find_replaceAll%": "Replace all",

--- a/extensions/src/platform-scripture/src/find.web-view.tsx
+++ b/extensions/src/platform-scripture/src/find.web-view.tsx
@@ -63,6 +63,8 @@ import {
   prunePresentBookIds,
   resolveScrollGroupForPickedProject,
   resolveSelectedProjectScrollGroup,
+  resolveTargetEditorWebViewId,
+  resolveTargetReferencePanelWebViewId,
   shouldClearResultsForInvalidQuery,
 } from './find/find.utils';
 import { deriveFindBookLists, UNKNOWN_FIND_BOOK_LISTS } from './find/find-book-lists.utils';
@@ -78,6 +80,10 @@ import {
 import { DEFAULT_REPLACE_PREVIEW_OPTIONS, PreviewOptions } from './find/replace-preview-types';
 import { SCRIPTURE_EDITOR_WEBVIEW_TYPE } from './scripture-editor-web-view-type.const';
 import { useOpenProjectTabs } from './hooks/use-open-project-tabs';
+import {
+  FIND_SEARCHABLE_WEB_VIEW_TYPES,
+  REFERENCE_PANEL_WEB_VIEW_TYPES,
+} from './resource-panel-web-view-types.const';
 import { useFindSearchTriggers } from './find/use-find-search-triggers.hook';
 import { useAutoSearchDebounce } from './find/use-auto-search-debounce.hook';
 
@@ -106,15 +112,6 @@ const SEARCH_DEBOUNCE_DELAY_MS = 500;
 const HISTORY_DEBOUNCE_DELAY_MS = 5000;
 /** Stable empty-array reference so the History data subscription's default doesn't change identity. */
 const DEFAULT_RECENT_SEARCHES: string[] = [];
-
-/**
- * Web-view types that should count as "open" project tabs for the project picker's "Open Tabs"
- * grouping. Mirrors `checks-side-panel.web-view.tsx` / `manage-books.web-view.tsx`: only the
- * scripture editor binds a project to a scroll group in a user-meaningful way. Without this filter,
- * every project-bound web view (including this Find panel itself) would falsely mark a project as
- * open.
- */
-const SCRIPTURE_EDITOR_WEB_VIEW_TYPES = new Set<string>(['platformScriptureEditor.react']);
 
 /** Short and full names for every scripture project/resource, keyed by canonical project id. */
 type ProjectNamesById = { [id: string]: Pick<FindProject, 'shortName' | 'fullName'> };
@@ -415,11 +412,16 @@ global.webViewComponent = function FindWebView({
   // Filter to scripture editor tabs only — without this filter, every project-bound web view
   // (e.g. this Find panel itself) would falsely mark a project as "open" in the picker's "Open
   // Tabs" grouping.
-  const editorWebViewFilter = useCallback(
-    (webView: { webViewType: string }) => SCRIPTURE_EDITOR_WEB_VIEW_TYPES.has(webView.webViewType),
+  const searchableWebViewFilter = useCallback(
+    (webView: { webViewType: string }) => FIND_SEARCHABLE_WEB_VIEW_TYPES.has(webView.webViewType),
     [],
   );
-  const allOpenProjectTabs = useOpenProjectTabs(editorWebViewFilter);
+  const allOpenProjectTabs = useOpenProjectTabs(
+    searchableWebViewFilter,
+    // The reference panels declare the resource they display; their container project is the
+    // editable project whose reference list they show, which is not what Find searches.
+    { includeNavigableProjectIds: true },
+  );
   const noOpenProjects = allOpenProjectTabs.length === 0;
 
   // Find's project picker only ever lists projects that are open in an editor tab (a project
@@ -497,18 +499,32 @@ global.webViewComponent = function FindWebView({
   const pendingProjectSwitchRerunRef = useRef(false);
 
   // Which open editor tab a Find result click should scroll: the exact tab the project selector
-  // has selected. Deterministic (not a heuristic) because the reassignment effect below guarantees
-  // `(projectId, selectedScrollGroupId)` always names an open tab whenever one exists anywhere.
-  // `undefined` only when `noOpenProjects` — nothing to scroll.
-  const targetEditorWebViewId = useMemo(() => {
-    if (!projectId || selectedScrollGroupId === undefined) return undefined;
-    const normalizedProjectId = normalizeProjectId(projectId);
-    return allOpenProjectTabs.find(
-      (tab) =>
-        normalizeProjectId(tab.projectId) === normalizedProjectId &&
-        tab.scrollGroupId === selectedScrollGroupId,
-    )?.webViewId;
-  }, [projectId, selectedScrollGroupId, allOpenProjectTabs]);
+  // has selected, when that tab is a real Scripture editor. Also `undefined` when the selected
+  // scripture is only open in a read-only reference panel — those register no web view controller.
+  // See `resolveTargetEditorWebViewId`.
+  const targetEditorWebViewId = useMemo(
+    () =>
+      resolveTargetEditorWebViewId(
+        projectId,
+        selectedScrollGroupId,
+        allOpenProjectTabs,
+        SCRIPTURE_EDITOR_WEBVIEW_TYPE,
+      ),
+    [projectId, selectedScrollGroupId, allOpenProjectTabs],
+  );
+
+  // Which reference panel tab a "go to result" activation should bring to the front, when the
+  // selected scripture is showing in one rather than in an editor. See
+  // `resolveTargetReferencePanelWebViewId`.
+  const targetReferencePanelWebViewId = useMemo(
+    () =>
+      resolveTargetReferencePanelWebViewId(
+        projectId,
+        allOpenProjectTabs,
+        REFERENCE_PANEL_WEB_VIEW_TYPES,
+      ),
+    [projectId, allOpenProjectTabs],
+  );
 
   // #endregion
 
@@ -891,6 +907,7 @@ global.webViewComponent = function FindWebView({
       selectedScrollGroupId,
       allOpenProjectTabs,
       editorWebViewId,
+      SCRIPTURE_EDITOR_WEBVIEW_TYPE,
     );
     if (!resolved) return;
     // `resolved.projectId` may carry `useOpenProjectTabs`'s lowercased casing when it names a
@@ -933,10 +950,11 @@ global.webViewComponent = function FindWebView({
         selectedScrollGroupId,
         allOpenProjectTabs,
         editorWebViewId,
+        SCRIPTURE_EDITOR_WEBVIEW_TYPE,
       );
       if (!resolved) {
         logger.warn(
-          `Find: ignoring project selection for ${newProjectId} — it has no open editor tab.`,
+          `Find: ignoring project selection for ${newProjectId} — it has no open editor or reference panel tab.`,
         );
         return;
       }
@@ -1755,11 +1773,28 @@ global.webViewComponent = function FindWebView({
     [editorWebViewController, targetEditorWebViewId, setVerseRefSetting],
   );
 
-  /** Navigate to a result AND shift focus to the editor (double-click / reference-click). */
+  /**
+   * Navigate to a result AND shift focus to the tab showing it (double-click / reference-click):
+   * the Scripture editor when one is open for the project, otherwise the reference panel displaying
+   * it. Single-click preview (`handleFocusedResultChange`) never changes the active tab.
+   */
   const handleOpenAtResult = useCallback(
     (searchResult: HidableFindResult, index: number) => {
       setFocusedResultIndex(index);
       setVerseRefSetting(searchResult.start.verseRef);
+      if (targetReferencePanelWebViewId && !targetEditorWebViewId) {
+        // The scripture is showing in a read-only reference panel, which registers no web view
+        // controller — so activating its tab IS the navigation. `setVerseRefSetting` above already
+        // moved the panel's scroll group, so it renders the result's reference once shown.
+        //
+        // What the user sees depends on where that panel lives. Bible texts and Commentaries share
+        // Find's Column 3 stack in Simple mode, so activating one necessarily hides Find; that is
+        // the point of this gesture, and single-click preview is the way to keep Find in front.
+        // The Model text panel sits alone in Column 1 and is already visible, so this reveals
+        // nothing and only moves keyboard focus off the result list. Find cannot tell the two cases
+        // apart from inside its own iframe — PAPI exposes no visibility query for another web view.
+        papi.window.setFocus({ focusType: 'webView', id: targetReferencePanelWebViewId });
+      }
       if (targetEditorWebViewId && editorWebViewController) {
         papi.window.setFocus({ focusType: 'webView', id: targetEditorWebViewId });
         // Await selectRange before setAnnotation so the websocket is settled (avoids
@@ -1783,7 +1818,12 @@ global.webViewComponent = function FindWebView({
         );
       }
     },
-    [editorWebViewController, targetEditorWebViewId, setVerseRefSetting],
+    [
+      editorWebViewController,
+      targetEditorWebViewId,
+      targetReferencePanelWebViewId,
+      setVerseRefSetting,
+    ],
   );
 
   const handleHideResult = useCallback((index: number) => {

--- a/extensions/src/platform-scripture/src/find.web-view.tsx
+++ b/extensions/src/platform-scripture/src/find.web-view.tsx
@@ -83,6 +83,7 @@ import { useOpenProjectTabs } from './hooks/use-open-project-tabs';
 import {
   FIND_SEARCHABLE_WEB_VIEW_TYPES,
   REFERENCE_PANEL_WEB_VIEW_TYPES,
+  REVEALABLE_REFERENCE_PANEL_WEB_VIEW_TYPES,
 } from './resource-panel-web-view-types.const';
 import { useFindSearchTriggers } from './find/use-find-search-triggers.hook';
 import { useAutoSearchDebounce } from './find/use-auto-search-debounce.hook';
@@ -409,23 +410,35 @@ global.webViewComponent = function FindWebView({
     useMemo(() => ({}), []),
   );
 
-  // Filter to scripture editor tabs only — without this filter, every project-bound web view
-  // (e.g. this Find panel itself) would falsely mark a project as "open" in the picker's "Open
-  // Tabs" grouping.
+  // Filter to the tab types whose scripture Find can search — without this filter, every
+  // project-bound web view (e.g. this Find panel itself) would falsely mark a project as "open" in
+  // the picker's "Open Tabs" grouping.
   const searchableWebViewFilter = useCallback(
     (webView: { webViewType: string }) => FIND_SEARCHABLE_WEB_VIEW_TYPES.has(webView.webViewType),
     [],
   );
-  const allOpenProjectTabs = useOpenProjectTabs(
-    searchableWebViewFilter,
-    // The reference panels declare the resource they display; their container project is the
-    // editable project whose reference list they show, which is not what Find searches.
-    { includeNavigableProjectIds: true },
+  const openProjectTabs = useOpenProjectTabs(searchableWebViewFilter, {
+    includeNavigableProjectIds: true,
+  });
+  // A reference panel's container project is the editable project whose reference list it shows —
+  // the panel is not displaying that project's text, so Find must not offer it. The hook unions
+  // container and declared projects, per what the shared state key documents; narrowing that to
+  // "what this tab actually displays" is Find's rule, so it is applied here rather than there.
+  const allOpenProjectTabs = useMemo(
+    () =>
+      openProjectTabs.filter(
+        (tab) =>
+          !(
+            REFERENCE_PANEL_WEB_VIEW_TYPES.has(tab.webViewType) && tab.projectSource === 'container'
+          ),
+      ),
+    [openProjectTabs],
   );
   const noOpenProjects = allOpenProjectTabs.length === 0;
 
-  // Find's project picker only ever lists projects that are open in an editor tab (a project
-  // isn't a candidate to search until it's actually open): once a project's last tab closes, the
+  // Find's project picker only ever lists projects open in a searchable tab — an editor, or a
+  // reference panel displaying that project's text (a project isn't a candidate to search until it
+  // is actually open): once a project's last tab closes, the
   // reassignment effect below moves the selection to another open project before this list update
   // even renders. A transient "selected but not listed" gap IS possible while the metadata fetch
   // above is in flight or stale — the refetch effect below and the `isLoadingProjects` gate in the
@@ -521,7 +534,7 @@ global.webViewComponent = function FindWebView({
       resolveTargetReferencePanelWebViewId(
         projectId,
         allOpenProjectTabs,
-        REFERENCE_PANEL_WEB_VIEW_TYPES,
+        REVEALABLE_REFERENCE_PANEL_WEB_VIEW_TYPES,
       ),
     [projectId, allOpenProjectTabs],
   );

--- a/extensions/src/platform-scripture/src/find/find.component.test.tsx
+++ b/extensions/src/platform-scripture/src/find/find.component.test.tsx
@@ -68,7 +68,7 @@ function stubLocalizedStrings(keys: readonly LocalizeKey[]): LanguageStrings {
   return strings;
 }
 
-const NO_OPEN_PROJECTS_KEY = '%webView_find_noOpenProjects_results%';
+const NO_OPEN_PROJECTS_KEY = '%webView_find_noOpenProjectsOrResources_results%';
 const SEARCH_PROMPT_KEY = '%webView_find_searchPrompt%';
 /** The status-bar message for a completed search with 1 result and none hidden. */
 const STATUS_MESSAGE_KEY = '%webView_find_result%';

--- a/extensions/src/platform-scripture/src/find/find.component.tsx
+++ b/extensions/src/platform-scripture/src/find/find.component.tsx
@@ -98,13 +98,13 @@ export const FIND_LOCALIZED_STRING_KEYS = [
   '%webView_find_matchCase%',
   '%webView_find_matchContentIn%',
   '%webView_find_nextResult%',
-  '%webView_find_noOpenProjects_results%',
+  '%webView_find_noOpenProjectsOrResources_results%',
   '%webView_find_noResultsFound%',
   '%webView_find_pattern%',
   '%webView_find_preserveCase%',
   '%webView_find_preserveCase_tooltip%',
   '%webView_find_previousResult%',
-  '%webView_find_projectFilter_noOpenProjects%',
+  '%webView_find_projectFilter_noOpenProjectsOrResources%',
   '%webView_find_projectFilter_noProjectsFound%',
   '%webView_find_projectSelector_label%',
   '%webView_find_projectSelector_openTabsSectionHeading%',
@@ -824,7 +824,7 @@ export function Find({
     localizedStrings: projectSelectorLocalizedStrings,
     isLoading: isLoadingProjects,
     hideFilterMenu: true,
-    buttonPlaceholder: localizedStrings['%webView_find_projectFilter_noOpenProjects%'],
+    buttonPlaceholder: localizedStrings['%webView_find_projectFilter_noOpenProjectsOrResources%'],
     commandEmptyMessage: localizedStrings['%webView_find_projectFilter_noProjectsFound%'],
     ariaLabel: localizedStrings['%webView_find_projectSelector_label%'],
     buttonVariant: 'outline' as const,
@@ -1217,7 +1217,7 @@ export function Find({
         {resultsAreaState === 'noOpenProjectsPrompt' && (
           <ResultsPlaceholder
             id="find-no-open-projects-placeholder"
-            message={localizedStrings['%webView_find_noOpenProjects_results%']}
+            message={localizedStrings['%webView_find_noOpenProjectsOrResources_results%']}
           />
         )}
         {/* Invalid-query placeholder: a term is present but won't run (e.g. `selectedBooks` scope

--- a/extensions/src/platform-scripture/src/find/find.utils.test.ts
+++ b/extensions/src/platform-scripture/src/find/find.utils.test.ts
@@ -611,7 +611,8 @@ describe('resolveSelectedProjectScrollGroup', () => {
     projectId: string,
     scrollGroupId: number,
     webViewId: string,
-  ): OpenScrollGroupTab => ({ projectId, scrollGroupId, webViewId });
+    webViewType = 'platformScriptureEditor.react',
+  ): OpenScrollGroupTab => ({ projectId, scrollGroupId, webViewId, webViewType });
 
   it('keeps the current selection unchanged when its tab is still open', () => {
     const openTabs = [tab('PROJ-A', 0, 'wv-1'), tab('PROJ-B', 1, 'wv-2')];
@@ -634,6 +635,100 @@ describe('resolveSelectedProjectScrollGroup', () => {
     expect(resolveSelectedProjectScrollGroup('PROJ-A', 0, openTabs, undefined)).toEqual({
       projectId: 'PROJ-A',
       scrollGroupId: 1,
+    });
+  });
+
+  // The picker lists resources open only in a reference panel, so a panel tab can now win any of
+  // the three branches below. Adopting its scroll group while an editor of the same project sits in
+  // a different group leaves `resolveTargetEditorWebViewId` with no match, which silently drops the
+  // editor's select + highlight on every result click.
+  describe('editor preference over reference panels', () => {
+    const panel = (projectId: string, scrollGroupId: number, webViewId: string) =>
+      tab(projectId, scrollGroupId, webViewId, 'platformScriptureEditor.bibleTexts');
+
+    it('prefers an editor over a panel in the same-project fallback, whatever the order', () => {
+      const expected = { projectId: 'PROJ-A', scrollGroupId: 1 };
+      const panelTab = panel('PROJ-A', 0, 'wv-panel');
+      const editorTab = tab('PROJ-A', 1, 'wv-editor', 'platformScriptureEditor.react');
+
+      expect(
+        resolveSelectedProjectScrollGroup(
+          'PROJ-A',
+          2,
+          [panelTab, editorTab],
+          undefined,
+          'platformScriptureEditor.react',
+        ),
+      ).toEqual(expected);
+      expect(
+        resolveSelectedProjectScrollGroup(
+          'PROJ-A',
+          2,
+          [editorTab, panelTab],
+          undefined,
+          'platformScriptureEditor.react',
+        ),
+      ).toEqual(expected);
+    });
+
+    it('prefers an editor even when preferredWebViewId names the panel', () => {
+      // The panel may well be the tab that opened Find (Ctrl+F from a reference panel), but
+      // resolving to it would cost the editor's select + highlight on every later result click.
+      const tabs = [
+        panel('PROJ-A', 0, 'wv-panel'),
+        tab('PROJ-A', 1, 'wv-editor', 'platformScriptureEditor.react'),
+      ];
+      expect(
+        resolveSelectedProjectScrollGroup(
+          'PROJ-A',
+          2,
+          tabs,
+          'wv-panel',
+          'platformScriptureEditor.react',
+        ),
+      ).toEqual({ projectId: 'PROJ-A', scrollGroupId: 1 });
+    });
+
+    it('honours preferredWebViewId when the project has no editor open', () => {
+      const tabs = [panel('PROJ-A', 0, 'wv-panel-1'), panel('PROJ-A', 3, 'wv-panel-2')];
+      expect(
+        resolveSelectedProjectScrollGroup(
+          'PROJ-A',
+          2,
+          tabs,
+          'wv-panel-2',
+          'platformScriptureEditor.react',
+        ),
+      ).toEqual({ projectId: 'PROJ-A', scrollGroupId: 3 });
+    });
+
+    it('prefers an editor in the cross-project fallback despite its higher scroll group', () => {
+      // Panels are pinned to group 0, so ordering by scroll group alone always picks the panel.
+      const tabs = [
+        panel('PROJ-B', 0, 'wv-panel'),
+        tab('PROJ-C', 2, 'wv-editor', 'platformScriptureEditor.react'),
+      ];
+      expect(
+        resolveSelectedProjectScrollGroup(
+          'PROJ-A',
+          0,
+          tabs,
+          undefined,
+          'platformScriptureEditor.react',
+        ),
+      ).toEqual({ projectId: 'PROJ-C', scrollGroupId: 2 });
+    });
+
+    it('still resolves to a panel when the project has no editor tab open', () => {
+      expect(
+        resolveSelectedProjectScrollGroup(
+          'PROJ-A',
+          0,
+          [panel('PROJ-A', 3, 'wv-panel')],
+          undefined,
+          'platformScriptureEditor.react',
+        ),
+      ).toEqual({ projectId: 'PROJ-A', scrollGroupId: 3 });
     });
   });
 
@@ -823,7 +918,8 @@ describe('resolveScrollGroupForPickedProject', () => {
     projectId: string,
     scrollGroupId: number,
     webViewId: string,
-  ): OpenScrollGroupTab => ({ projectId, scrollGroupId, webViewId });
+    webViewType = 'platformScriptureEditor.react',
+  ): OpenScrollGroupTab => ({ projectId, scrollGroupId, webViewId, webViewType });
 
   // The regression this pins: the simple-mode picker reports only a project id, so re-picking the
   // project Find is ALREADY on must not move which of its tabs Find targets. Resolving with an

--- a/extensions/src/platform-scripture/src/find/find.utils.test.ts
+++ b/extensions/src/platform-scripture/src/find/find.utils.test.ts
@@ -2,22 +2,24 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { newPlatformError } from 'platform-bible-utils';
 import { FindJobStatusReport } from 'platform-scripture';
 import {
+  CharacterCategorizer,
+  MAX_CONSECUTIVE_POLL_MISSES,
+  OpenScrollGroupTab,
   applyPreserveCase,
   armBoundedWait,
   buildSearchRegex,
   callControllerSafely,
-  CharacterCategorizer,
   classifyPollAttempt,
   gateStartSearch,
   isDifferentProjectSelection,
   isFindQueryValid,
   isSimpleInterfaceMode,
-  MAX_CONSECUTIVE_POLL_MISSES,
   nextPollMissState,
-  OpenScrollGroupTab,
   prunePresentBookIds,
   resolveScrollGroupForPickedProject,
   resolveSelectedProjectScrollGroup,
+  resolveTargetEditorWebViewId,
+  resolveTargetReferencePanelWebViewId,
   shouldClearResultsForInvalidQuery,
 } from './find.utils';
 
@@ -606,17 +608,59 @@ describe('shouldClearResultsForInvalidQuery', () => {
   });
 });
 
+/**
+ * The two scroll-group resolvers under test, with the Scripture editor's web view type defaulted.
+ * That parameter is required in production so the editor preference cannot be silently skipped;
+ * defaulting it here keeps each case below about the behaviour it is pinning. Pass it explicitly to
+ * vary it.
+ */
+const EDITOR_WEB_VIEW_TYPE = 'platformScriptureEditor.react';
+const resolveSelected = (
+  currentProjectId: string,
+  currentScrollGroupId: number | undefined,
+  openTabs: readonly OpenScrollGroupTab[],
+  preferredWebViewId: string | undefined,
+  editorWebViewType: string = EDITOR_WEB_VIEW_TYPE,
+) =>
+  resolveSelectedProjectScrollGroup(
+    currentProjectId,
+    currentScrollGroupId,
+    openTabs,
+    preferredWebViewId,
+    editorWebViewType,
+  );
+const resolveForPicked = (
+  pickedProjectId: string,
+  currentScrollGroupId: number | undefined,
+  openTabs: readonly OpenScrollGroupTab[],
+  preferredWebViewId: string | undefined,
+  editorWebViewType: string = EDITOR_WEB_VIEW_TYPE,
+) =>
+  resolveScrollGroupForPickedProject(
+    pickedProjectId,
+    currentScrollGroupId,
+    openTabs,
+    preferredWebViewId,
+    editorWebViewType,
+  );
+
 describe('resolveSelectedProjectScrollGroup', () => {
   const tab = (
     projectId: string,
     scrollGroupId: number,
     webViewId: string,
     webViewType = 'platformScriptureEditor.react',
-  ): OpenScrollGroupTab => ({ projectId, scrollGroupId, webViewId, webViewType });
+  ): OpenScrollGroupTab => ({
+    projectId,
+    scrollGroupId,
+    webViewId,
+    webViewType,
+    projectSource: 'container',
+  });
 
   it('keeps the current selection unchanged when its tab is still open', () => {
     const openTabs = [tab('PROJ-A', 0, 'wv-1'), tab('PROJ-B', 1, 'wv-2')];
-    expect(resolveSelectedProjectScrollGroup('PROJ-A', 0, openTabs, undefined)).toEqual({
+    expect(resolveSelected('PROJ-A', 0, openTabs, undefined)).toEqual({
       projectId: 'PROJ-A',
       scrollGroupId: 0,
     });
@@ -624,7 +668,7 @@ describe('resolveSelectedProjectScrollGroup', () => {
 
   it('matches the open tab case-insensitively against the current project id', () => {
     const openTabs = [tab('proj-a', 0, 'wv-1')];
-    expect(resolveSelectedProjectScrollGroup('PROJ-A', 0, openTabs, undefined)).toEqual({
+    expect(resolveSelected('PROJ-A', 0, openTabs, undefined)).toEqual({
       projectId: 'PROJ-A',
       scrollGroupId: 0,
     });
@@ -632,7 +676,7 @@ describe('resolveSelectedProjectScrollGroup', () => {
 
   it('falls back to another open tab of the same project when the current pair closed', () => {
     const openTabs = [tab('PROJ-A', 1, 'wv-2')];
-    expect(resolveSelectedProjectScrollGroup('PROJ-A', 0, openTabs, undefined)).toEqual({
+    expect(resolveSelected('PROJ-A', 0, openTabs, undefined)).toEqual({
       projectId: 'PROJ-A',
       scrollGroupId: 1,
     });
@@ -652,7 +696,7 @@ describe('resolveSelectedProjectScrollGroup', () => {
       const editorTab = tab('PROJ-A', 1, 'wv-editor', 'platformScriptureEditor.react');
 
       expect(
-        resolveSelectedProjectScrollGroup(
+        resolveSelected(
           'PROJ-A',
           2,
           [panelTab, editorTab],
@@ -661,7 +705,7 @@ describe('resolveSelectedProjectScrollGroup', () => {
         ),
       ).toEqual(expected);
       expect(
-        resolveSelectedProjectScrollGroup(
+        resolveSelected(
           'PROJ-A',
           2,
           [editorTab, panelTab],
@@ -679,26 +723,14 @@ describe('resolveSelectedProjectScrollGroup', () => {
         tab('PROJ-A', 1, 'wv-editor', 'platformScriptureEditor.react'),
       ];
       expect(
-        resolveSelectedProjectScrollGroup(
-          'PROJ-A',
-          2,
-          tabs,
-          'wv-panel',
-          'platformScriptureEditor.react',
-        ),
+        resolveSelected('PROJ-A', 2, tabs, 'wv-panel', 'platformScriptureEditor.react'),
       ).toEqual({ projectId: 'PROJ-A', scrollGroupId: 1 });
     });
 
     it('honours preferredWebViewId when the project has no editor open', () => {
       const tabs = [panel('PROJ-A', 0, 'wv-panel-1'), panel('PROJ-A', 3, 'wv-panel-2')];
       expect(
-        resolveSelectedProjectScrollGroup(
-          'PROJ-A',
-          2,
-          tabs,
-          'wv-panel-2',
-          'platformScriptureEditor.react',
-        ),
+        resolveSelected('PROJ-A', 2, tabs, 'wv-panel-2', 'platformScriptureEditor.react'),
       ).toEqual({ projectId: 'PROJ-A', scrollGroupId: 3 });
     });
 
@@ -709,19 +741,13 @@ describe('resolveSelectedProjectScrollGroup', () => {
         tab('PROJ-C', 2, 'wv-editor', 'platformScriptureEditor.react'),
       ];
       expect(
-        resolveSelectedProjectScrollGroup(
-          'PROJ-A',
-          0,
-          tabs,
-          undefined,
-          'platformScriptureEditor.react',
-        ),
+        resolveSelected('PROJ-A', 0, tabs, undefined, 'platformScriptureEditor.react'),
       ).toEqual({ projectId: 'PROJ-C', scrollGroupId: 2 });
     });
 
     it('still resolves to a panel when the project has no editor tab open', () => {
       expect(
-        resolveSelectedProjectScrollGroup(
+        resolveSelected(
           'PROJ-A',
           0,
           [panel('PROJ-A', 3, 'wv-panel')],
@@ -734,7 +760,7 @@ describe('resolveSelectedProjectScrollGroup', () => {
 
   it('prefers the tab matching preferredWebViewId over other tabs of the same project', () => {
     const openTabs = [tab('PROJ-A', 1, 'wv-2'), tab('PROJ-A', 2, 'wv-3')];
-    expect(resolveSelectedProjectScrollGroup('PROJ-A', 0, openTabs, 'wv-3')).toEqual({
+    expect(resolveSelected('PROJ-A', 0, openTabs, 'wv-3')).toEqual({
       projectId: 'PROJ-A',
       scrollGroupId: 2,
     });
@@ -742,7 +768,7 @@ describe('resolveSelectedProjectScrollGroup', () => {
 
   it('ignores preferredWebViewId when it belongs to a different project', () => {
     const openTabs = [tab('PROJ-A', 1, 'wv-2'), tab('PROJ-B', 2, 'wv-3')];
-    expect(resolveSelectedProjectScrollGroup('PROJ-A', 0, openTabs, 'wv-3')).toEqual({
+    expect(resolveSelected('PROJ-A', 0, openTabs, 'wv-3')).toEqual({
       projectId: 'PROJ-A',
       scrollGroupId: 1,
     });
@@ -750,7 +776,7 @@ describe('resolveSelectedProjectScrollGroup', () => {
 
   it('resolves an initial (undefined) scroll group by preferring preferredWebViewId', () => {
     const openTabs = [tab('PROJ-A', 0, 'wv-1'), tab('PROJ-A', 1, 'wv-2')];
-    expect(resolveSelectedProjectScrollGroup('PROJ-A', undefined, openTabs, 'wv-2')).toEqual({
+    expect(resolveSelected('PROJ-A', undefined, openTabs, 'wv-2')).toEqual({
       projectId: 'PROJ-A',
       scrollGroupId: 1,
     });
@@ -758,14 +784,14 @@ describe('resolveSelectedProjectScrollGroup', () => {
 
   it('falls back to a different project entirely once the current project has no open tabs', () => {
     const openTabs = [tab('PROJ-B', 3, 'wv-9')];
-    expect(resolveSelectedProjectScrollGroup('PROJ-A', 0, openTabs, undefined)).toEqual({
+    expect(resolveSelected('PROJ-A', 0, openTabs, undefined)).toEqual({
       projectId: 'PROJ-B',
       scrollGroupId: 3,
     });
   });
 
   it('returns undefined when no tabs are open anywhere', () => {
-    expect(resolveSelectedProjectScrollGroup('PROJ-A', 0, [], undefined)).toBeUndefined();
+    expect(resolveSelected('PROJ-A', 0, [], undefined)).toBeUndefined();
   });
 
   // `openTabs` arrives in web-view-event arrival order (`[...tabsMap.values()]`), so picking
@@ -775,13 +801,9 @@ describe('resolveSelectedProjectScrollGroup', () => {
     const tabs = [tab('PROJ-C', 2, 'wv-c'), tab('PROJ-B', 1, 'wv-b'), tab('PROJ-D', 1, 'wv-d')];
     const expected = { projectId: 'PROJ-B', scrollGroupId: 1 };
 
-    expect(resolveSelectedProjectScrollGroup('PROJ-A', 0, tabs, undefined)).toEqual(expected);
-    expect(resolveSelectedProjectScrollGroup('PROJ-A', 0, [...tabs].reverse(), undefined)).toEqual(
-      expected,
-    );
-    expect(
-      resolveSelectedProjectScrollGroup('PROJ-A', 0, [tabs[2], tabs[0], tabs[1]], undefined),
-    ).toEqual(expected);
+    expect(resolveSelected('PROJ-A', 0, tabs, undefined)).toEqual(expected);
+    expect(resolveSelected('PROJ-A', 0, [...tabs].reverse(), undefined)).toEqual(expected);
+    expect(resolveSelected('PROJ-A', 0, [tabs[2], tabs[0], tabs[1]], undefined)).toEqual(expected);
   });
 });
 
@@ -919,7 +941,13 @@ describe('resolveScrollGroupForPickedProject', () => {
     scrollGroupId: number,
     webViewId: string,
     webViewType = 'platformScriptureEditor.react',
-  ): OpenScrollGroupTab => ({ projectId, scrollGroupId, webViewId, webViewType });
+  ): OpenScrollGroupTab => ({
+    projectId,
+    scrollGroupId,
+    webViewId,
+    webViewType,
+    projectSource: 'container',
+  });
 
   // The regression this pins: the simple-mode picker reports only a project id, so re-picking the
   // project Find is ALREADY on must not move which of its tabs Find targets. Resolving with an
@@ -927,7 +955,7 @@ describe('resolveScrollGroupForPickedProject', () => {
   // Find from group 1 to group 0.
   it('keeps the tab Find already targets when the same project is picked again', () => {
     const openTabs = [tab('PROJ-A', 0, 'wv-1'), tab('PROJ-A', 1, 'wv-2')];
-    expect(resolveScrollGroupForPickedProject('PROJ-A', 1, openTabs, undefined)).toEqual({
+    expect(resolveForPicked('PROJ-A', 1, openTabs, undefined)).toEqual({
       projectId: 'PROJ-A',
       scrollGroupId: 1,
     });
@@ -938,17 +966,15 @@ describe('resolveScrollGroupForPickedProject', () => {
   it('resolves identically no matter what order the open tabs arrive in', () => {
     const tabs = [tab('PROJ-A', 0, 'wv-1'), tab('PROJ-A', 1, 'wv-2'), tab('PROJ-B', 2, 'wv-3')];
     const expected = { projectId: 'PROJ-A', scrollGroupId: 1 };
-    expect(resolveScrollGroupForPickedProject('PROJ-A', 1, tabs, undefined)).toEqual(expected);
-    expect(resolveScrollGroupForPickedProject('PROJ-A', 1, [...tabs].reverse(), undefined)).toEqual(
-      expected,
-    );
+    expect(resolveForPicked('PROJ-A', 1, tabs, undefined)).toEqual(expected);
+    expect(resolveForPicked('PROJ-A', 1, [...tabs].reverse(), undefined)).toEqual(expected);
   });
 
   // Matches what `projectScrollGroup` mode does for a not-open-project row: the newly picked
   // project lands in the group the user was already reading in.
   it('inherits the current scroll group when the newly picked project has a tab there', () => {
     const openTabs = [tab('PROJ-A', 2, 'wv-1'), tab('PROJ-B', 2, 'wv-2'), tab('PROJ-B', 5, 'wv-3')];
-    expect(resolveScrollGroupForPickedProject('PROJ-B', 2, openTabs, undefined)).toEqual({
+    expect(resolveForPicked('PROJ-B', 2, openTabs, undefined)).toEqual({
       projectId: 'PROJ-B',
       scrollGroupId: 2,
     });
@@ -956,7 +982,7 @@ describe('resolveScrollGroupForPickedProject', () => {
 
   it('prefers the tab shown in the triggering editor when the current group has none', () => {
     const openTabs = [tab('PROJ-A', 0, 'wv-1'), tab('PROJ-B', 4, 'wv-2'), tab('PROJ-B', 7, 'wv-3')];
-    expect(resolveScrollGroupForPickedProject('PROJ-B', 0, openTabs, 'wv-3')).toEqual({
+    expect(resolveForPicked('PROJ-B', 0, openTabs, 'wv-3')).toEqual({
       projectId: 'PROJ-B',
       scrollGroupId: 7,
     });
@@ -964,7 +990,7 @@ describe('resolveScrollGroupForPickedProject', () => {
 
   it('falls back to the picked project’s own tab when neither the group nor the editor matches', () => {
     const openTabs = [tab('PROJ-A', 0, 'wv-1'), tab('PROJ-B', 4, 'wv-2')];
-    expect(resolveScrollGroupForPickedProject('PROJ-B', 0, openTabs, 'wv-1')).toEqual({
+    expect(resolveForPicked('PROJ-B', 0, openTabs, 'wv-1')).toEqual({
       projectId: 'PROJ-B',
       scrollGroupId: 4,
     });
@@ -972,7 +998,7 @@ describe('resolveScrollGroupForPickedProject', () => {
 
   it('matches the picked project case-insensitively', () => {
     const openTabs = [tab('proj-a', 3, 'wv-1')];
-    expect(resolveScrollGroupForPickedProject('PROJ-A', undefined, openTabs, undefined)).toEqual({
+    expect(resolveForPicked('PROJ-A', undefined, openTabs, undefined)).toEqual({
       projectId: 'PROJ-A',
       scrollGroupId: 3,
     });
@@ -983,10 +1009,141 @@ describe('resolveScrollGroupForPickedProject', () => {
   // project the user did not pick. Rejecting it here leaves the reassignment effect to choose.
   it('returns undefined rather than retargeting a project the user did not pick', () => {
     const openTabs = [tab('PROJ-B', 3, 'wv-9')];
-    expect(resolveScrollGroupForPickedProject('PROJ-A', 0, openTabs, undefined)).toBeUndefined();
+    expect(resolveForPicked('PROJ-A', 0, openTabs, undefined)).toBeUndefined();
   });
 
   it('returns undefined when no tabs are open anywhere', () => {
-    expect(resolveScrollGroupForPickedProject('PROJ-A', 0, [], undefined)).toBeUndefined();
+    expect(resolveForPicked('PROJ-A', 0, [], undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveTargetEditorWebViewId', () => {
+  const EDITOR = 'platformScriptureEditor.react';
+  const PANEL = 'platformScriptureEditor.bibleTexts';
+  const tab = (
+    projectId: string,
+    scrollGroupId: number,
+    webViewId: string,
+    webViewType: string,
+  ): OpenScrollGroupTab => ({
+    projectId,
+    scrollGroupId,
+    webViewId,
+    webViewType,
+    projectSource: 'container',
+  });
+
+  it('returns the editor tab matching the selected project and scroll group', () => {
+    const tabs = [tab('PROJ-A', 0, 'wv-other', EDITOR), tab('PROJ-A', 1, 'wv-target', EDITOR)];
+    expect(resolveTargetEditorWebViewId('PROJ-A', 1, tabs, EDITOR)).toBe('wv-target');
+  });
+
+  it('matches the project id case-insensitively', () => {
+    expect(
+      resolveTargetEditorWebViewId('PROJ-A', 0, [tab('proj-a', 0, 'wv-1', EDITOR)], EDITOR),
+    ).toBe('wv-1');
+  });
+
+  it('never returns a reference panel, which registers no web view controller', () => {
+    // Handing a panel's id to useWebViewController leaves it waiting ~20s for a controller that
+    // never arrives, then rejecting unhandled — the trap this resolver exists to avoid.
+    expect(
+      resolveTargetEditorWebViewId('PROJ-A', 0, [tab('PROJ-A', 0, 'wv-panel', PANEL)], EDITOR),
+    ).toBeUndefined();
+  });
+
+  it('does not match an editor of the same project in another scroll group', () => {
+    expect(
+      resolveTargetEditorWebViewId('PROJ-A', 0, [tab('PROJ-A', 1, 'wv-1', EDITOR)], EDITOR),
+    ).toBeUndefined();
+  });
+
+  it('returns undefined before a project or scroll group is selected', () => {
+    const tabs = [tab('PROJ-A', 0, 'wv-1', EDITOR)];
+    expect(resolveTargetEditorWebViewId(undefined, 0, tabs, EDITOR)).toBeUndefined();
+    expect(resolveTargetEditorWebViewId('PROJ-A', undefined, tabs, EDITOR)).toBeUndefined();
+  });
+});
+
+describe('resolveTargetReferencePanelWebViewId', () => {
+  const EDITOR = 'platformScriptureEditor.react';
+  const BIBLE_TEXTS = 'platformScriptureEditor.bibleTexts';
+  const COMMENTARIES = 'platformScriptureEditor.commentaries';
+  const REVEALABLE = new Set([BIBLE_TEXTS, COMMENTARIES]);
+  const tab = (
+    projectId: string,
+    scrollGroupId: number,
+    webViewId: string,
+    webViewType: string,
+  ): OpenScrollGroupTab => ({
+    projectId,
+    scrollGroupId,
+    webViewId,
+    webViewType,
+    projectSource: 'declared',
+  });
+
+  it('returns the panel displaying the selected scripture', () => {
+    const tabs = [tab('PROJ-A', 0, 'wv-editor', EDITOR), tab('RES-1', 0, 'wv-panel', BIBLE_TEXTS)];
+    expect(resolveTargetReferencePanelWebViewId('RES-1', tabs, REVEALABLE)).toBe('wv-panel');
+  });
+
+  it('matches the project id case-insensitively', () => {
+    expect(
+      resolveTargetReferencePanelWebViewId(
+        'RES-1',
+        [tab('res-1', 0, 'wv-panel', BIBLE_TEXTS)],
+        REVEALABLE,
+      ),
+    ).toBe('wv-panel');
+  });
+
+  it('ignores scroll group, unlike the editor resolver', () => {
+    // The panel follows the reference through its own group membership; the only action here is
+    // activating the tab, so which group it sits in does not decide whether it is the target.
+    expect(
+      resolveTargetReferencePanelWebViewId(
+        'RES-1',
+        [tab('RES-1', 3, 'wv-panel', BIBLE_TEXTS)],
+        REVEALABLE,
+      ),
+    ).toBe('wv-panel');
+  });
+
+  it('returns undefined for a project open only in an editor', () => {
+    expect(
+      resolveTargetReferencePanelWebViewId(
+        'PROJ-A',
+        [tab('PROJ-A', 0, 'wv-editor', EDITOR)],
+        REVEALABLE,
+      ),
+    ).toBeUndefined();
+  });
+
+  it('ignores a panel type that is not revealable', () => {
+    // The Model text panel is searchable but withheld from reveal — see
+    // REVEALABLE_REFERENCE_PANEL_WEB_VIEW_TYPES.
+    const tabs = [tab('RES-1', 0, 'wv-model', 'platformScriptureEditor.modelText')];
+    expect(resolveTargetReferencePanelWebViewId('RES-1', tabs, REVEALABLE)).toBeUndefined();
+  });
+
+  it('takes the first match when two panels show the same resource', () => {
+    // Documented as arbitrary: every candidate shows the same resource at the same reference, so
+    // any of them is a correct destination.
+    const tabs = [
+      tab('RES-1', 0, 'wv-bible', BIBLE_TEXTS),
+      tab('RES-1', 0, 'wv-comm', COMMENTARIES),
+    ];
+    expect(resolveTargetReferencePanelWebViewId('RES-1', tabs, REVEALABLE)).toBe('wv-bible');
+  });
+
+  it('returns undefined when no project is selected', () => {
+    expect(
+      resolveTargetReferencePanelWebViewId(
+        undefined,
+        [tab('RES-1', 0, 'wv-panel', BIBLE_TEXTS)],
+        REVEALABLE,
+      ),
+    ).toBeUndefined();
   });
 });

--- a/extensions/src/platform-scripture/src/find/find.utils.ts
+++ b/extensions/src/platform-scripture/src/find/find.utils.ts
@@ -396,13 +396,12 @@ export function resolveSelectedProjectScrollGroup(
   currentScrollGroupId: ScrollGroupId | undefined,
   openTabs: readonly OpenScrollGroupTab[],
   preferredWebViewId: string | undefined,
-  scriptureEditorWebViewType?: string,
+  scriptureEditorWebViewType: string,
 ): SelectedProjectScrollGroup | undefined {
   const normalizedCurrentProjectId = normalizeProjectId(currentProjectId);
   const matchesCurrentProject = (tab: OpenScrollGroupTab) =>
     normalizeProjectId(tab.projectId) === normalizedCurrentProjectId;
-  const isEditor = (tab: OpenScrollGroupTab) =>
-    scriptureEditorWebViewType !== undefined && tab.webViewType === scriptureEditorWebViewType;
+  const isEditor = (tab: OpenScrollGroupTab) => tab.webViewType === scriptureEditorWebViewType;
   /** Editors first, original order preserved within each group. */
   const editorsFirst = (tabs: readonly OpenScrollGroupTab[]) => [
     ...tabs.filter(isEditor),
@@ -552,7 +551,7 @@ export function resolveScrollGroupForPickedProject(
   currentScrollGroupId: ScrollGroupId | undefined,
   openTabs: readonly OpenScrollGroupTab[],
   preferredWebViewId: string | undefined,
-  scriptureEditorWebViewType?: string,
+  scriptureEditorWebViewType: string,
 ): SelectedProjectScrollGroup | undefined {
   const resolved = resolveSelectedProjectScrollGroup(
     pickedProjectId,

--- a/extensions/src/platform-scripture/src/find/find.utils.ts
+++ b/extensions/src/platform-scripture/src/find/find.utils.ts
@@ -268,7 +268,7 @@ export function isSimpleInterfaceMode(interfaceMode: 'simple' | 'power' | Platfo
  * `@papi/frontend` import `use-open-project-tabs.ts` performs, and remains importable by the
  * presentational component, its story, and this file's unit tests.
  */
-export type OpenScrollGroupTab = Omit<OpenProjectTabWithWebView, 'webViewType'>;
+export type OpenScrollGroupTab = OpenProjectTabWithWebView;
 
 /**
  * Runs a web-view-controller call, containing BOTH ways a controller for a CLOSED editor tab fails.
@@ -377,6 +377,13 @@ export function prunePresentBookIds(
  *   tabs left at all.
  * - Returns `undefined` when no tabs are open anywhere.
  *
+ * Wherever several tabs qualify, an EDITOR wins over a reference panel. Find drives results through
+ * the Scripture editor's web view controller, and `resolveTargetEditorWebViewId` matches on
+ * (project, scroll group) — so landing on a panel's group while the project also has an editor open
+ * in another group leaves that resolver with no match, silently dropping the editor's select and
+ * highlight. Panels became candidates here once the picker started listing resources shown only in
+ * a reference panel, and they sort ahead of editors by default because they sit in group 0.
+ *
  * @param currentProjectId Find's current project id.
  * @param currentScrollGroupId The currently selected scroll group, or `undefined` before an initial
  *   selection has been made.
@@ -389,10 +396,18 @@ export function resolveSelectedProjectScrollGroup(
   currentScrollGroupId: ScrollGroupId | undefined,
   openTabs: readonly OpenScrollGroupTab[],
   preferredWebViewId: string | undefined,
+  scriptureEditorWebViewType?: string,
 ): SelectedProjectScrollGroup | undefined {
   const normalizedCurrentProjectId = normalizeProjectId(currentProjectId);
   const matchesCurrentProject = (tab: OpenScrollGroupTab) =>
     normalizeProjectId(tab.projectId) === normalizedCurrentProjectId;
+  const isEditor = (tab: OpenScrollGroupTab) =>
+    scriptureEditorWebViewType !== undefined && tab.webViewType === scriptureEditorWebViewType;
+  /** Editors first, original order preserved within each group. */
+  const editorsFirst = (tabs: readonly OpenScrollGroupTab[]) => [
+    ...tabs.filter(isEditor),
+    ...tabs.filter((tab) => !isEditor(tab)),
+  ];
 
   if (
     currentScrollGroupId !== undefined &&
@@ -401,15 +416,18 @@ export function resolveSelectedProjectScrollGroup(
     return { projectId: currentProjectId, scrollGroupId: currentScrollGroupId };
   }
 
+  // `preferredWebViewId` names the tab that opened Find, but it does not override the editor
+  // preference: when the same project also has an editor open, resolving to the panel that
+  // triggered Find would cost the editor's select and highlight on every subsequent result click.
+  const sameProjectTabs = editorsFirst(openTabs.filter(matchesCurrentProject));
   const preferredTab =
     preferredWebViewId !== undefined
-      ? openTabs.find((tab) => tab.webViewId === preferredWebViewId && matchesCurrentProject(tab))
+      ? sameProjectTabs.find((tab) => tab.webViewId === preferredWebViewId)
       : undefined;
-  if (preferredTab) {
-    return { projectId: currentProjectId, scrollGroupId: preferredTab.scrollGroupId };
-  }
-
-  const sameProjectTab = openTabs.find(matchesCurrentProject);
+  const sameProjectTab =
+    preferredTab && (isEditor(preferredTab) || !sameProjectTabs.some(isEditor))
+      ? preferredTab
+      : sameProjectTabs[0];
   if (sameProjectTab) {
     return { projectId: currentProjectId, scrollGroupId: sameProjectTab.scrollGroupId };
   }
@@ -420,13 +438,95 @@ export function resolveSelectedProjectScrollGroup(
   // events happened to land, so taking `openTabs[0]` made the landing project depend on event timing
   // and differ between otherwise identical sessions. Order by scroll group, then project id, so the
   // same set of open tabs always resolves to the same fallback.
+  // Editors sort ahead of panels here too: panels are pinned to group 0, so ordering by scroll
+  // group alone would systematically land on a panel over an editor in any higher group.
   const fallbackTab = [...openTabs].sort(
     (a, b) =>
+      Number(isEditor(b)) - Number(isEditor(a)) ||
       a.scrollGroupId - b.scrollGroupId ||
       normalizeProjectId(a.projectId).localeCompare(normalizeProjectId(b.projectId)),
   )[0];
   if (!fallbackTab) return undefined;
   return { projectId: fallbackTab.projectId, scrollGroupId: fallbackTab.scrollGroupId };
+}
+
+/**
+ * Resolve which open tab a Find result click should drive through the Scripture editor's web view
+ * controller — the tab matching the selected `(project, scroll group)` pair, but ONLY when it is a
+ * real Scripture editor.
+ *
+ * The read-only reference panels (model text, Bible texts, commentaries) are searchable and so are
+ * listed in the project picker, but they register no web view controller. Handing one of their ids
+ * to `useWebViewController(SCRIPTURE_EDITOR_WEBVIEW_TYPE, ...)` leaves it waiting on a controller
+ * that never arrives (~20s, then an unhandled rejection) — the same trap `resolveFindInvocation`
+ * avoids for the Ctrl+F path.
+ *
+ * `undefined` is a correct, expected answer whenever the selected scripture is only open in a
+ * reference panel: both result handlers navigate via `setVerseRefSetting` before consulting the
+ * controller, so results still navigate — only the editor-side select/highlight is skipped, which
+ * is right when no editor is showing that scripture.
+ *
+ * @param projectId Find's currently selected project id, or `undefined` when none is selected.
+ * @param selectedScrollGroupId The selected scroll group, or `undefined` before an initial
+ *   selection.
+ * @param openTabs Currently open searchable tabs, editors and reference panels alike.
+ * @param scriptureEditorWebViewType The Scripture editor's web view type.
+ * @returns The editor tab's web view id, or `undefined` when no editor tab matches.
+ */
+export function resolveTargetEditorWebViewId(
+  projectId: string | undefined,
+  selectedScrollGroupId: ScrollGroupId | undefined,
+  openTabs: readonly OpenProjectTabWithWebView[],
+  scriptureEditorWebViewType: string,
+): string | undefined {
+  if (!projectId || selectedScrollGroupId === undefined) return undefined;
+  const normalizedProjectId = normalizeProjectId(projectId);
+  return openTabs.find(
+    (tab) =>
+      tab.webViewType === scriptureEditorWebViewType &&
+      normalizeProjectId(tab.projectId) === normalizedProjectId &&
+      tab.scrollGroupId === selectedScrollGroupId,
+  )?.webViewId;
+}
+
+/**
+ * Resolve which read-only reference panel tab is displaying the selected scripture, so a "go to
+ * result" activation can bring that tab to the front.
+ *
+ * Used only when {@link resolveTargetEditorWebViewId} finds no editor: a project open in a real
+ * editor is driven through the editor's web view controller, which also selects and highlights the
+ * match. A reference panel exposes no controller, so activating its tab is the whole interaction —
+ * the panel is already following the reference through its scroll group, so it renders the right
+ * place on its own once shown.
+ *
+ * Deliberately does NOT match on scroll group, unlike the editor resolver. That resolver's group
+ * match picks _which_ of several editor tabs a result click drives; here the only action is
+ * activating a tab showing this scripture, and the panel's own group membership is what moves its
+ * content.
+ *
+ * When the same resource is open in more than one panel (Bible texts and Commentaries, or two
+ * panels in Power mode), the first match wins. Tab order comes from `useOpenProjectTabs`' `Map`
+ * iteration, so which panel is revealed is arbitrary — accepted deliberately, because every
+ * candidate is showing the same resource at the same reference, so any of them is a correct
+ * destination.
+ *
+ * @param projectId Find's currently selected project id, or `undefined` when none is selected.
+ * @param openTabs Currently open searchable tabs, editors and reference panels alike.
+ * @param referencePanelWebViewTypes The reference panel web view types.
+ * @returns The reference panel tab's web view id, or `undefined` when no panel shows this project.
+ */
+export function resolveTargetReferencePanelWebViewId(
+  projectId: string | undefined,
+  openTabs: readonly OpenProjectTabWithWebView[],
+  referencePanelWebViewTypes: ReadonlySet<string>,
+): string | undefined {
+  if (!projectId) return undefined;
+  const normalizedProjectId = normalizeProjectId(projectId);
+  return openTabs.find(
+    (tab) =>
+      referencePanelWebViewTypes.has(tab.webViewType) &&
+      normalizeProjectId(tab.projectId) === normalizedProjectId,
+  )?.webViewId;
 }
 
 /**
@@ -452,12 +552,14 @@ export function resolveScrollGroupForPickedProject(
   currentScrollGroupId: ScrollGroupId | undefined,
   openTabs: readonly OpenScrollGroupTab[],
   preferredWebViewId: string | undefined,
+  scriptureEditorWebViewType?: string,
 ): SelectedProjectScrollGroup | undefined {
   const resolved = resolveSelectedProjectScrollGroup(
     pickedProjectId,
     currentScrollGroupId,
     openTabs,
     preferredWebViewId,
+    scriptureEditorWebViewType,
   );
   if (!resolved) return undefined;
   if (normalizeProjectId(resolved.projectId) !== normalizeProjectId(pickedProjectId))

--- a/extensions/src/platform-scripture/src/find/find.utils.ts
+++ b/extensions/src/platform-scripture/src/find/find.utils.ts
@@ -495,8 +495,10 @@ export function resolveTargetEditorWebViewId(
  * Used only when {@link resolveTargetEditorWebViewId} finds no editor: a project open in a real
  * editor is driven through the editor's web view controller, which also selects and highlights the
  * match. A reference panel exposes no controller, so activating its tab is the whole interaction —
- * the panel is already following the reference through its scroll group, so it renders the right
- * place on its own once shown.
+ * a panel following Find's scroll group has already been moved by the write that precedes the
+ * activation, so it renders the right place on its own once shown. A panel detached from every
+ * scroll group is the exception: it ignores that write, and `useOpenProjectTabs` reports it as
+ * group 0 regardless, so it can still be picked here and revealed at an unrelated reference.
  *
  * Deliberately does NOT match on scroll group, unlike the editor resolver. That resolver's group
  * match picks _which_ of several editor tabs a result click drives; here the only action is

--- a/extensions/src/platform-scripture/src/hooks/use-open-project-tabs.test.ts
+++ b/extensions/src/platform-scripture/src/hooks/use-open-project-tabs.test.ts
@@ -92,6 +92,7 @@ describe('useOpenProjectTabs', () => {
         projectId: 'p-1',
         scrollGroupId: 0,
         webViewType: 'platformScriptureEditor.react',
+        projectSource: 'container',
       },
     ]);
   });
@@ -149,6 +150,7 @@ describe('useOpenProjectTabs', () => {
         projectId: 'p-1',
         scrollGroupId: 0,
         webViewType: 'platformScriptureEditor.react',
+        projectSource: 'container',
       },
     ]);
   });
@@ -172,6 +174,7 @@ describe('useOpenProjectTabs', () => {
         projectId: 'abcdef',
         scrollGroupId: 0,
         webViewType: 'platformScriptureEditor.react',
+        projectSource: 'container',
       },
     ]);
   });
@@ -223,6 +226,7 @@ describe('useOpenProjectTabs', () => {
       projectId: 'p-editor',
       scrollGroupId: 0,
       webViewType: 'platformScriptureEditor.react',
+      projectSource: 'container',
     });
   });
 
@@ -478,18 +482,21 @@ describe('useOpenProjectTabs', () => {
       expect(result.current[0].projectId).toBe('res-1');
     });
 
-    it('prefers the declared resource over the container project', () => {
+    it('reports the container project and the declared resource, tagged by source', () => {
+      // The key documents the declared ids as projects displayed BEYOND the view's own, so both
+      // belong here. Narrowing to "what this tab displays" is the caller's rule, and `projectSource`
+      // is what lets it apply one — Find drops a reference panel's container project.
       const result = openWith({
         id: 'wv-panel',
         webViewType: BIBLE_TEXTS,
-        // The container is the editable project whose reference list is shown; the resource on
-        // screen is what Find must search.
         projectId: 'CONTAINER-1',
         scrollGroupScrRef: 0,
         state: { navigableProjectIds: ['RES-1'] },
       });
-      expect(result.current).toHaveLength(1);
-      expect(result.current[0].projectId).toBe('res-1');
+      expect(result.current.map((tab) => [tab.projectId, tab.projectSource]).sort()).toEqual([
+        ['container-1', 'container'],
+        ['res-1', 'declared'],
+      ]);
     });
 
     it('yields one tab per declared project for a view hosting several', () => {
@@ -533,9 +540,9 @@ describe('useOpenProjectTabs', () => {
       expect(result.current.map((tab) => tab.projectId)).toEqual(['res-2']);
     });
 
-    it('offers nothing for a view declaring an empty list, even with a container project', () => {
-      // An empty declaration means "I display nothing" — falling back to the container project
-      // would offer a project this tab is not showing.
+    it('adds nothing for a view declaring an empty list', () => {
+      // `[]` says "nothing beyond my own project", so the union is just the container. A caller
+      // that must not offer the container (Find, for a reference panel) filters it out by source.
       const result = openWith({
         id: 'wv-panel',
         webViewType: BIBLE_TEXTS,
@@ -543,7 +550,9 @@ describe('useOpenProjectTabs', () => {
         scrollGroupScrRef: 0,
         state: { navigableProjectIds: [] },
       });
-      expect(result.current).toEqual([]);
+      expect(result.current.map((tab) => [tab.projectId, tab.projectSource])).toEqual([
+        ['container-1', 'container'],
+      ]);
     });
 
     it('falls back to the container project when a view declares nothing at all', () => {

--- a/extensions/src/platform-scripture/src/hooks/use-open-project-tabs.test.ts
+++ b/extensions/src/platform-scripture/src/hooks/use-open-project-tabs.test.ts
@@ -8,6 +8,7 @@ interface WebViewLike {
   webViewType?: string;
   projectId?: string;
   scrollGroupScrRef?: unknown;
+  state?: Record<string, unknown>;
 }
 type WebViewEventHandler = (event: { webView: WebViewLike }) => void;
 
@@ -436,5 +437,160 @@ describe('useOpenProjectTabs', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+  describe('includeNavigableProjectIds', () => {
+    const BIBLE_TEXTS = 'platformScriptureEditor.bibleTexts';
+    const TEXT_COLLECTION = 'platformScriptureEditor.scriptureTextGrid';
+    const openWith = (webView: WebViewLike, includeNavigableProjectIds = true) => {
+      const { result } = renderHook(() =>
+        useOpenProjectTabs(undefined, { includeNavigableProjectIds }),
+      );
+      const handler = mockOnDidOpenWebView.mock.calls[0][0];
+      act(() => handler({ webView }));
+      return result;
+    };
+
+    it('ignores declared projects unless the option is passed', () => {
+      const { result } = renderHook(() => useOpenProjectTabs());
+      const handler = mockOnDidOpenWebView.mock.calls[0][0];
+      act(() =>
+        handler({
+          webView: {
+            id: 'wv-panel',
+            webViewType: BIBLE_TEXTS,
+            // Simple mode's default layout opens this panel with no container project.
+            scrollGroupScrRef: 0,
+            state: { navigableProjectIds: ['RES-1'] },
+          },
+        }),
+      );
+      expect(result.current).toEqual([]);
+    });
+
+    it('surfaces a panel whose only project is the resource it declares', () => {
+      const result = openWith({
+        id: 'wv-panel',
+        webViewType: BIBLE_TEXTS,
+        scrollGroupScrRef: 0,
+        state: { navigableProjectIds: ['RES-1'] },
+      });
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0].projectId).toBe('res-1');
+    });
+
+    it('prefers the declared resource over the container project', () => {
+      const result = openWith({
+        id: 'wv-panel',
+        webViewType: BIBLE_TEXTS,
+        // The container is the editable project whose reference list is shown; the resource on
+        // screen is what Find must search.
+        projectId: 'CONTAINER-1',
+        scrollGroupScrRef: 0,
+        state: { navigableProjectIds: ['RES-1'] },
+      });
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0].projectId).toBe('res-1');
+    });
+
+    it('yields one tab per declared project for a view hosting several', () => {
+      const result = openWith({
+        id: 'wv-grid',
+        webViewType: TEXT_COLLECTION,
+        scrollGroupScrRef: 0,
+        state: { navigableProjectIds: ['RES-1', 'RES-2'] },
+      });
+      expect(result.current.map((tab) => tab.projectId).sort()).toEqual(['res-1', 'res-2']);
+      expect(result.current.every((tab) => tab.webViewId === 'wv-grid')).toBe(true);
+    });
+
+    it('drops the projects a view stops declaring', () => {
+      const { result } = renderHook(() =>
+        useOpenProjectTabs(undefined, { includeNavigableProjectIds: true }),
+      );
+      const openHandler = mockOnDidOpenWebView.mock.calls[0][0];
+      act(() =>
+        openHandler({
+          webView: {
+            id: 'wv-grid',
+            webViewType: TEXT_COLLECTION,
+            scrollGroupScrRef: 0,
+            state: { navigableProjectIds: ['RES-1', 'RES-2'] },
+          },
+        }),
+      );
+      expect(result.current).toHaveLength(2);
+      const updateHandler = mockOnDidUpdateWebView.mock.calls[0][0];
+      act(() =>
+        updateHandler({
+          webView: {
+            id: 'wv-grid',
+            webViewType: TEXT_COLLECTION,
+            scrollGroupScrRef: 0,
+            state: { navigableProjectIds: ['RES-2'] },
+          },
+        }),
+      );
+      expect(result.current.map((tab) => tab.projectId)).toEqual(['res-2']);
+    });
+
+    it('offers nothing for a view declaring an empty list, even with a container project', () => {
+      // An empty declaration means "I display nothing" — falling back to the container project
+      // would offer a project this tab is not showing.
+      const result = openWith({
+        id: 'wv-panel',
+        webViewType: BIBLE_TEXTS,
+        projectId: 'CONTAINER-1',
+        scrollGroupScrRef: 0,
+        state: { navigableProjectIds: [] },
+      });
+      expect(result.current).toEqual([]);
+    });
+
+    it('falls back to the container project when a view declares nothing at all', () => {
+      // An editor never publishes the key; it must still report its own project.
+      const result = openWith({
+        id: 'wv-editor',
+        webViewType: 'platformScriptureEditor.react',
+        projectId: 'PROJ-1',
+        scrollGroupScrRef: 0,
+      });
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0].projectId).toBe('proj-1');
+    });
+
+    it('rejects a malformed declaration rather than treating it as a project id', () => {
+      // Web view state is written by whoever owns the web view, so the value is guarded, not
+      // trusted. A malformed value is no declaration, so the container project answers.
+      const result = openWith({
+        id: 'wv-panel',
+        webViewType: BIBLE_TEXTS,
+        projectId: 'CONTAINER-1',
+        scrollGroupScrRef: 0,
+        state: { navigableProjectIds: 'RES-1' },
+      });
+      expect(result.current).toHaveLength(1);
+      expect(result.current[0].projectId).toBe('container-1');
+    });
+
+    it('removes every tab a closed view contributed', () => {
+      const { result } = renderHook(() =>
+        useOpenProjectTabs(undefined, { includeNavigableProjectIds: true }),
+      );
+      const openHandler = mockOnDidOpenWebView.mock.calls[0][0];
+      act(() =>
+        openHandler({
+          webView: {
+            id: 'wv-grid',
+            webViewType: TEXT_COLLECTION,
+            scrollGroupScrRef: 0,
+            state: { navigableProjectIds: ['RES-1', 'RES-2'] },
+          },
+        }),
+      );
+      expect(result.current).toHaveLength(2);
+      const closeHandler = mockOnDidCloseWebView.mock.calls[0][0];
+      act(() => closeHandler({ webView: { id: 'wv-grid' } }));
+      expect(result.current).toEqual([]);
+    });
   });
 });

--- a/extensions/src/platform-scripture/src/hooks/use-open-project-tabs.ts
+++ b/extensions/src/platform-scripture/src/hooks/use-open-project-tabs.ts
@@ -2,6 +2,10 @@ import papi from '@papi/frontend';
 import { useEffect, useMemo, useState } from 'react';
 import { wait } from 'platform-bible-utils';
 import type { ScrollGroupId } from 'platform-bible-utils';
+import {
+  isNavigableProjectIds,
+  NAVIGABLE_PROJECT_IDS_WEB_VIEW_STATE_KEY,
+} from 'platform-bible-utils/experimental';
 
 export interface OpenProjectTabWithWebView {
   webViewId: string;
@@ -12,11 +16,49 @@ export interface OpenProjectTabWithWebView {
 
 export type WebViewFilter = (webView: { webViewType: string }) => boolean;
 
+export interface UseOpenProjectTabsOptions {
+  /**
+   * Report the projects a web view declares under `NAVIGABLE_PROJECT_IDS_WEB_VIEW_STATE_KEY`
+   * instead of its container `projectId`, yielding one tab per declared project.
+   *
+   * Off by default: the existing consumers (checklist, checks-side-panel) ask "which project does
+   * this tab belong to", and a reference panel's answer to that is still its container project.
+   */
+  includeNavigableProjectIds?: boolean;
+}
+
 interface WebViewEventLike {
   id: string;
   webViewType?: string;
   projectId?: string;
   scrollGroupScrRef?: unknown;
+  state?: Record<string, unknown>;
+}
+
+/**
+ * Projects a web view declares as displayed, or `undefined` when it declares nothing at all.
+ *
+ * The empty array and a missing key mean different things and must not be collapsed. A view that
+ * declares `[]` is saying "I display nothing" — it should offer no project, not fall back to its
+ * container. A view with no key at all (an editor) never participates, so its container project is
+ * the right answer.
+ *
+ * Guarded rather than trusted: web view state is written by whoever owns the web view, so a
+ * malformed value is treated as no declaration rather than reaching consumers as a project id.
+ */
+function getNavigableProjectIds(state: Record<string, unknown> | undefined): string[] | undefined {
+  if (!state || !(NAVIGABLE_PROJECT_IDS_WEB_VIEW_STATE_KEY in state)) return undefined;
+  const navigableProjectIds = state[NAVIGABLE_PROJECT_IDS_WEB_VIEW_STATE_KEY];
+  return isNavigableProjectIds(navigableProjectIds) ? navigableProjectIds : undefined;
+}
+
+/**
+ * Map key for one (web view, project) pair. A web view that declares several navigable projects
+ * yields several tabs, so the web view id alone is no longer unique. NUL-separated because it
+ * cannot occur in either half.
+ */
+function tabKey(webViewId: string, projectId: string): string {
+  return `${webViewId}\u0000${projectId}`;
 }
 
 /**
@@ -43,13 +85,17 @@ interface WebViewEventLike {
  *   because the other consumers (checklist, checks-side-panel) key off this shape; removing it is a
  *   separate cleanup tracked outside this change.
  */
-export function useOpenProjectTabs(filter?: WebViewFilter): OpenProjectTabWithWebView[] {
+export function useOpenProjectTabs(
+  filter?: WebViewFilter,
+  options?: UseOpenProjectTabsOptions,
+): OpenProjectTabWithWebView[] {
   const [tabsMap, setTabsMap] = useState<Map<string, OpenProjectTabWithWebView>>(() => new Map());
+  const includeNavigableProjectIds = options?.includeNavigableProjectIds ?? false;
 
   useEffect(() => {
     let cancelled = false;
     const upsert = (webView: WebViewEventLike) => {
-      const { id, projectId, scrollGroupScrRef, webViewType } = webView;
+      const { id, projectId, scrollGroupScrRef, webViewType, state } = webView;
       const passesFilter = !filter || (webViewType !== undefined && filter({ webViewType }));
       // See JSDoc above: undefined → default group 0; numeric → as-is.
       //
@@ -79,29 +125,42 @@ export function useOpenProjectTabs(filter?: WebViewFilter): OpenProjectTabWithWe
       ) {
         scrollGroup = 0;
       }
-      const passes =
-        typeof projectId === 'string' &&
-        projectId.length > 0 &&
-        scrollGroup !== undefined &&
-        passesFilter;
+      // A view that declares navigable projects reports those instead of its container project —
+      // a reference panel's container is the editable project whose reference list it shows, not
+      // the resource on screen. Falls back to the container project, which is what an editor tab
+      // (and every opted-out caller) reports.
+      const declaredProjectIds = includeNavigableProjectIds
+        ? getNavigableProjectIds(state)
+        : undefined;
+      const tabProjectIds = (
+        declaredProjectIds ?? (typeof projectId === 'string' ? [projectId] : [])
+      ).filter((tabProjectId) => tabProjectId.length > 0);
+      const passes = tabProjectIds.length > 0 && scrollGroup !== undefined && passesFilter;
       setTabsMap((prev) => {
-        if (!passes || scrollGroup === undefined || typeof projectId !== 'string') {
-          if (!prev.has(id)) return prev;
+        const keyPrefix = `${id}\u0000`;
+        const previousKeys = [...prev.keys()].filter((key) => key.startsWith(keyPrefix));
+        if (!passes || scrollGroup === undefined) {
+          if (previousKeys.length === 0) return prev;
           const next = new Map(prev);
-          next.delete(id);
+          previousKeys.forEach((key) => next.delete(key));
           return next;
         }
-        const tab: OpenProjectTabWithWebView = {
-          webViewId: id,
+        const next = new Map(prev);
+        // Drop what this web view contributed before re-adding: its declared set can shrink, and a
+        // stale entry would keep offering a project the view no longer displays.
+        previousKeys.forEach((key) => next.delete(key));
+        tabProjectIds.forEach((tabProjectId) => {
           // Lowercased for backward-compatibility with existing consumers. This casing is NOT
           // authoritative — canonical project ids are UPPERCASE — so consumers must match
           // case-insensitively (see normalizeProjectId / I12).
-          projectId: projectId.toLowerCase(),
-          scrollGroupId: scrollGroup,
-          webViewType: webViewType ?? '',
-        };
-        const next = new Map(prev);
-        next.set(id, tab);
+          const normalizedProjectId = tabProjectId.toLowerCase();
+          next.set(tabKey(id, normalizedProjectId), {
+            webViewId: id,
+            projectId: normalizedProjectId,
+            scrollGroupId: scrollGroup,
+            webViewType: webViewType ?? '',
+          });
+        });
         return next;
       });
     };
@@ -149,9 +208,11 @@ export function useOpenProjectTabs(filter?: WebViewFilter): OpenProjectTabWithWe
     const unsubUpdate = papi.webViews.onDidUpdateWebView(({ webView }) => upsert(webView));
     const unsubClose = papi.webViews.onDidCloseWebView(({ webView }) => {
       setTabsMap((prev) => {
-        if (!prev.has(webView.id)) return prev;
+        const keyPrefix = `${webView.id}\u0000`;
+        const closedKeys = [...prev.keys()].filter((key) => key.startsWith(keyPrefix));
+        if (closedKeys.length === 0) return prev;
         const next = new Map(prev);
-        next.delete(webView.id);
+        closedKeys.forEach((key) => next.delete(key));
         return next;
       });
     });
@@ -161,7 +222,7 @@ export function useOpenProjectTabs(filter?: WebViewFilter): OpenProjectTabWithWe
       unsubUpdate();
       unsubClose();
     };
-  }, [filter]);
+  }, [filter, includeNavigableProjectIds]);
 
   return useMemo(() => [...tabsMap.values()], [tabsMap]);
 }

--- a/extensions/src/platform-scripture/src/hooks/use-open-project-tabs.ts
+++ b/extensions/src/platform-scripture/src/hooks/use-open-project-tabs.ts
@@ -12,17 +12,33 @@ export interface OpenProjectTabWithWebView {
   projectId: string;
   scrollGroupId: ScrollGroupId;
   webViewType: string;
+  /**
+   * Where `projectId` came from: the web view definition's own `projectId` (`'container'`), or the
+   * list the view declares under `NAVIGABLE_PROJECT_IDS_WEB_VIEW_STATE_KEY` (`'declared'`).
+   *
+   * Always `'container'` unless the caller passed `includeNavigableProjectIds`. Callers that must
+   * distinguish "the project this tab belongs to" from "the project this tab is displaying" — a
+   * reference panel's container is the editable project whose reference list it shows, not the
+   * resource on screen — filter on this rather than re-reading web view state.
+   */
+  projectSource: 'container' | 'declared';
 }
 
 export type WebViewFilter = (webView: { webViewType: string }) => boolean;
 
 export interface UseOpenProjectTabsOptions {
   /**
-   * Report the projects a web view declares under `NAVIGABLE_PROJECT_IDS_WEB_VIEW_STATE_KEY`
-   * instead of its container `projectId`, yielding one tab per declared project.
+   * Also report the projects a web view declares under `NAVIGABLE_PROJECT_IDS_WEB_VIEW_STATE_KEY`,
+   * yielding one tab per project.
+   *
+   * The declared list is UNIONED with the container `projectId`, which is what that key documents
+   * ("readers just union the lists") and what the toolbar's `useOpenProjectBookIds` does. Each tab
+   * carries `projectSource` so a caller can tell the two apart and apply its own rule — Find drops
+   * a reference panel's container project, because the panel is not displaying that project's
+   * text.
    *
    * Off by default: the existing consumers (checklist, checks-side-panel) ask "which project does
-   * this tab belong to", and a reference panel's answer to that is still its container project.
+   * this tab belong to", for which the container project is the whole answer.
    */
   includeNavigableProjectIds?: boolean;
 }
@@ -125,17 +141,19 @@ export function useOpenProjectTabs(
       ) {
         scrollGroup = 0;
       }
-      // A view that declares navigable projects reports those instead of its container project —
-      // a reference panel's container is the editable project whose reference list it shows, not
-      // the resource on screen. Falls back to the container project, which is what an editor tab
-      // (and every opted-out caller) reports.
+      // Union, not replace: the declared list names projects displayed BEYOND the view's own
+      // `projectId`, so both belong in the output. `projectSource` lets a caller narrow that —
+      // see `UseOpenProjectTabsOptions.includeNavigableProjectIds`.
       const declaredProjectIds = includeNavigableProjectIds
         ? getNavigableProjectIds(state)
         : undefined;
-      const tabProjectIds = (
-        declaredProjectIds ?? (typeof projectId === 'string' ? [projectId] : [])
-      ).filter((tabProjectId) => tabProjectId.length > 0);
-      const passes = tabProjectIds.length > 0 && scrollGroup !== undefined && passesFilter;
+      const containerProjectIds: [string, 'container'][] =
+        typeof projectId === 'string' && projectId.length > 0 ? [[projectId, 'container']] : [];
+      const declaredEntries: [string, 'declared'][] = (declaredProjectIds ?? [])
+        .filter((declaredProjectId) => declaredProjectId.length > 0)
+        .map((declaredProjectId) => [declaredProjectId, 'declared']);
+      const tabEntries = [...containerProjectIds, ...declaredEntries];
+      const passes = tabEntries.length > 0 && scrollGroup !== undefined && passesFilter;
       setTabsMap((prev) => {
         const keyPrefix = `${id}\u0000`;
         const previousKeys = [...prev.keys()].filter((key) => key.startsWith(keyPrefix));
@@ -149,16 +167,19 @@ export function useOpenProjectTabs(
         // Drop what this web view contributed before re-adding: its declared set can shrink, and a
         // stale entry would keep offering a project the view no longer displays.
         previousKeys.forEach((key) => next.delete(key));
-        tabProjectIds.forEach((tabProjectId) => {
+        tabEntries.forEach(([tabProjectId, projectSource]) => {
           // Lowercased for backward-compatibility with existing consumers. This casing is NOT
           // authoritative — canonical project ids are UPPERCASE — so consumers must match
           // case-insensitively (see normalizeProjectId / I12).
           const normalizedProjectId = tabProjectId.toLowerCase();
+          // A view that declares its own container project would otherwise yield the same key
+          // twice; the declared entry is the meaningful one, so it wins.
           next.set(tabKey(id, normalizedProjectId), {
             webViewId: id,
             projectId: normalizedProjectId,
             scrollGroupId: scrollGroup,
             webViewType: webViewType ?? '',
+            projectSource,
           });
         });
         return next;

--- a/extensions/src/platform-scripture/src/resource-panel-web-view-types.const.test.ts
+++ b/extensions/src/platform-scripture/src/resource-panel-web-view-types.const.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  BIBLE_TEXTS_PANEL_WEBVIEW_TYPE,
+  COMMENTARIES_PANEL_WEBVIEW_TYPE,
+  FIND_SEARCHABLE_WEB_VIEW_TYPES,
+  REFERENCE_PANEL_WEB_VIEW_TYPES,
+  MODEL_TEXT_PANEL_WEBVIEW_TYPE,
+} from './resource-panel-web-view-types.const';
+
+describe('resource panel web view types', () => {
+  it('pins this extension’s mirrored copies to the editor’s web view type literals', () => {
+    // Extensions can't import each other's source, so these are mirrors of the consts in
+    // platform-scripture-editor's main.ts. Pinning the literals catches an accidental edit to
+    // these copies, which would silently drop the panels back out of Find's project picker.
+    expect(MODEL_TEXT_PANEL_WEBVIEW_TYPE).toBe('platformScriptureEditor.modelText');
+    expect(BIBLE_TEXTS_PANEL_WEBVIEW_TYPE).toBe('platformScriptureEditor.bibleTexts');
+    expect(COMMENTARIES_PANEL_WEBVIEW_TYPE).toBe('platformScriptureEditor.commentaries');
+  });
+});
+
+describe('FIND_SEARCHABLE_WEB_VIEW_TYPES', () => {
+  it('includes the editor and all three read-only reference panels', () => {
+    expect([...FIND_SEARCHABLE_WEB_VIEW_TYPES].sort()).toEqual(
+      [
+        'platformScriptureEditor.react',
+        'platformScriptureEditor.modelText',
+        'platformScriptureEditor.bibleTexts',
+        'platformScriptureEditor.commentaries',
+      ].sort(),
+    );
+  });
+
+  it('excludes the Text Collection, whose per-cell reveal is not designed yet', () => {
+    // The grid has no single searchable project to offer the picker, so it is intentionally out.
+    expect(FIND_SEARCHABLE_WEB_VIEW_TYPES.has('platformScriptureEditor.scriptureTextGrid')).toBe(
+      false,
+    );
+  });
+});
+
+describe('REFERENCE_PANEL_WEB_VIEW_TYPES', () => {
+  it('holds exactly the three read-only reference panels', () => {
+    expect([...REFERENCE_PANEL_WEB_VIEW_TYPES].sort()).toEqual(
+      [
+        'platformScriptureEditor.modelText',
+        'platformScriptureEditor.bibleTexts',
+        'platformScriptureEditor.commentaries',
+      ].sort(),
+    );
+  });
+
+  it('excludes the Scripture editor, which is driven by its web view controller instead', () => {
+    expect(REFERENCE_PANEL_WEB_VIEW_TYPES.has('platformScriptureEditor.react')).toBe(false);
+  });
+});

--- a/extensions/src/platform-scripture/src/resource-panel-web-view-types.const.test.ts
+++ b/extensions/src/platform-scripture/src/resource-panel-web-view-types.const.test.ts
@@ -4,6 +4,7 @@ import {
   COMMENTARIES_PANEL_WEBVIEW_TYPE,
   FIND_SEARCHABLE_WEB_VIEW_TYPES,
   REFERENCE_PANEL_WEB_VIEW_TYPES,
+  REVEALABLE_REFERENCE_PANEL_WEB_VIEW_TYPES,
   MODEL_TEXT_PANEL_WEBVIEW_TYPE,
 } from './resource-panel-web-view-types.const';
 
@@ -31,7 +32,9 @@ describe('FIND_SEARCHABLE_WEB_VIEW_TYPES', () => {
   });
 
   it('excludes the Text Collection, whose per-cell reveal is not designed yet', () => {
-    // The grid has no single searchable project to offer the picker, so it is intentionally out.
+    // NOT because it has no project to offer — it declares every resource it hosts and latches a
+    // focused one it already hands to Ctrl+F. It is out because "go to result" has no defined
+    // behaviour when each cell is its own editor. Tracked as PT-4507.
     expect(FIND_SEARCHABLE_WEB_VIEW_TYPES.has('platformScriptureEditor.scriptureTextGrid')).toBe(
       false,
     );
@@ -51,5 +54,25 @@ describe('REFERENCE_PANEL_WEB_VIEW_TYPES', () => {
 
   it('excludes the Scripture editor, which is driven by its web view controller instead', () => {
     expect(REFERENCE_PANEL_WEB_VIEW_TYPES.has('platformScriptureEditor.react')).toBe(false);
+  });
+});
+
+describe('REVEALABLE_REFERENCE_PANEL_WEB_VIEW_TYPES', () => {
+  it('holds the panels a "go to result" activation may bring to the front', () => {
+    expect([...REVEALABLE_REFERENCE_PANEL_WEB_VIEW_TYPES].sort()).toEqual(
+      [BIBLE_TEXTS_PANEL_WEBVIEW_TYPE, COMMENTARIES_PANEL_WEBVIEW_TYPE].sort(),
+    );
+  });
+
+  it('excludes the Model text panel, which cannot catch up after a hidden reveal', () => {
+    // Its scroll effect is keyed on the reference alone. A reference arriving while its tab is
+    // hidden finds no layout in a display:none iframe, so the scroll no-ops and nothing re-runs on
+    // activation — the revealed panel would show a stale position, with no controller to retry
+    // through. It stays searchable; only the reveal is withheld.
+    expect(REVEALABLE_REFERENCE_PANEL_WEB_VIEW_TYPES.has(MODEL_TEXT_PANEL_WEBVIEW_TYPE)).toBe(
+      false,
+    );
+    expect(REFERENCE_PANEL_WEB_VIEW_TYPES.has(MODEL_TEXT_PANEL_WEBVIEW_TYPE)).toBe(true);
+    expect(FIND_SEARCHABLE_WEB_VIEW_TYPES.has(MODEL_TEXT_PANEL_WEBVIEW_TYPE)).toBe(true);
   });
 });

--- a/extensions/src/platform-scripture/src/resource-panel-web-view-types.const.ts
+++ b/extensions/src/platform-scripture/src/resource-panel-web-view-types.const.ts
@@ -1,0 +1,49 @@
+import { SCRIPTURE_EDITOR_WEBVIEW_TYPE } from './scripture-editor-web-view-type.const';
+
+// The three consts below are the web view types of the read-only scripture reference panels, as
+// this extension sees them. `platform-scripture` cannot import `platform-scripture-editor`'s
+// source, so these values are mirrored here. They must equal the corresponding consts in
+// `extensions/src/platform-scripture-editor/src/main.ts`; a pinning test in
+// `resource-panel-web-view-types.const.test.ts` catches an accidental edit to these copies.
+
+/** Web view type of the Model text panel. Mirrored — see the note above. */
+export const MODEL_TEXT_PANEL_WEBVIEW_TYPE = 'platformScriptureEditor.modelText';
+
+/** Web view type of the Bible texts panel. Mirrored — see the note above. */
+export const BIBLE_TEXTS_PANEL_WEBVIEW_TYPE = 'platformScriptureEditor.bibleTexts';
+
+/** Web view type of the Commentaries panel. Mirrored — see the note above. */
+export const COMMENTARIES_PANEL_WEBVIEW_TYPE = 'platformScriptureEditor.commentaries';
+
+/**
+ * The read-only scripture reference panels, as a set.
+ *
+ * These share two properties Find depends on: the resource they display is not their definition
+ * `projectId` (they declare it under `NAVIGABLE_PROJECT_IDS_WEB_VIEW_STATE_KEY` instead), and they
+ * register no web view controller — so Find can activate their tab but cannot drive their content.
+ */
+export const REFERENCE_PANEL_WEB_VIEW_TYPES = new Set<string>([
+  MODEL_TEXT_PANEL_WEBVIEW_TYPE,
+  BIBLE_TEXTS_PANEL_WEBVIEW_TYPE,
+  COMMENTARIES_PANEL_WEBVIEW_TYPE,
+]);
+
+/**
+ * Tab types whose scripture Find can search, and therefore the ones whose projects the Find project
+ * picker lists.
+ *
+ * Each of these tabs displays scripture Find can search, and each already routes Ctrl+F to Find for
+ * it (`useOpenFindShortcut` in `platform-scripture-editor`): the editor passes its own project, the
+ * reference panels pass the resource they display.
+ *
+ * The Text Collection (`platformScriptureEditor.scriptureTextGrid`) is excluded, but NOT because it
+ * has no project to offer — it declares every resource it hosts, and latches one focused resource
+ * (`useFocusedResourceProjectId`) that it already hands to Ctrl+F. It is excluded because "go to
+ * result" has no defined behavior there: each grid cell is its own editor, so revealing the grid
+ * would land the user on a tab with no indication of which cell holds the match. Including it needs
+ * that interaction designed first.
+ */
+export const FIND_SEARCHABLE_WEB_VIEW_TYPES = new Set<string>([
+  SCRIPTURE_EDITOR_WEBVIEW_TYPE,
+  ...REFERENCE_PANEL_WEB_VIEW_TYPES,
+]);

--- a/extensions/src/platform-scripture/src/resource-panel-web-view-types.const.ts
+++ b/extensions/src/platform-scripture/src/resource-panel-web-view-types.const.ts
@@ -29,6 +29,23 @@ export const REFERENCE_PANEL_WEB_VIEW_TYPES = new Set<string>([
 ]);
 
 /**
+ * The reference panels a "go to result" activation may bring to the front.
+ *
+ * The Model text panel is deliberately absent. It has no visibility-keyed scroll: its effect runs
+ * on the reference alone, and a reference arriving while its tab is hidden finds no layout in a
+ * `display: none` iframe, so the scroll silently no-ops and nothing re-runs on activation — the
+ * revealed panel would show a stale position, with no controller to retry through. Simple mode is
+ * unaffected either way, since Model text sits alone in Column 1 and is always visible, which is
+ * also why withholding the reveal costs nothing there: the panel is already on screen and the
+ * scroll group has already moved it. Model text remains fully searchable and listed in the picker;
+ * only the reveal is withheld. Add it here once that panel handles the hidden case.
+ */
+export const REVEALABLE_REFERENCE_PANEL_WEB_VIEW_TYPES = new Set<string>([
+  BIBLE_TEXTS_PANEL_WEBVIEW_TYPE,
+  COMMENTARIES_PANEL_WEBVIEW_TYPE,
+]);
+
+/**
  * Tab types whose scripture Find can search, and therefore the ones whose projects the Find project
  * picker lists.
  *


### PR DESCRIPTION
## Summary

Find's project picker listed only projects open in a Scripture **editor** tab, so a resource shown
in a read-only reference panel (Model text, Bible texts, Commentaries) could not be selected. Ctrl+F
from such a panel was worse than useless: it handed Find that resource's project id, Find's
reassignment effect found no matching tab, took its cross-project fallback, and silently re-ran the
search against an unrelated project (PT-4467).

This PR is **purely the consuming side**. All three panels already declare the resource they display
under `NAVIGABLE_PROJECT_IDS_WEB_VIEW_STATE_KEY` (see `adr-navigable-project-ids`); nothing read it.
`useOpenProjectTabs` now does, and Find lists and targets those tabs.

### Why review this

Not part of the current epic. It fixes a collision between two merged tickets — PT-4341 made Ctrl+F
pass the displayed resource's project, PT-3362 restricted the picker to editor tabs — which leaves
Ctrl+F from any reference panel silently searching the wrong project. Worth reviewer time because
the broken path is the common one in Simple mode, where the reference panels are always on screen.

## Changes

- **`useOpenProjectTabs` reads declared projects**, behind an opt-in `includeNavigableProjectIds`.
  The declared list is **unioned** with the container `projectId`, which is what the shared key
  documents and what the toolbar's `useOpenProjectBookIds` already does. Each tab carries
  `projectSource` (`'container' | 'declared'`) so a caller can narrow that. Because a view can
  declare several projects — the Text Collection hosts many — tabs are keyed by (web view, project),
  and a view's previous entries are dropped before its new ones so a shrinking list cannot leave a
  stale project on offer.
- **Find applies its own rule**: a reference panel's container project is never offered, because the
  panel is not displaying that project's text.
- **Result activation splits by tab kind.** An editor is driven through its web view controller
  (select + highlight). A reference panel registers no controller — handing one of their ids to
  `useWebViewController` waits ~20s for a controller that never arrives — so activating its tab is
  the whole navigation, and the scroll group carries the reference.
- **An editor wins wherever several tabs of one project qualify**, in all three branches that pick
  among them. Panels are pinned to scroll group 0, so ordering by scroll group alone systematically
  preferred a panel over an editor in any higher group, leaving `resolveTargetEditorWebViewId` with
  no match and silently dropping the editor's select and highlight on every result click.
- **The Bible texts and Commentaries panels scroll to the referenced verse** when revealed, and
  highlight it. Keyed on visibility and the reference, with guards for the panel's own scroll-group
  echo, a bare reveal (so a manual scroll survives a tab switch), the previous chapter's USJ still
  being on screen, and a scroll that did not land.
- **Picker copy** now says "projects or resources", via new localized keys with `fallbackKey`
  redirects for the old ones, per the immutability rule in `Localization-Guide.md`.

## Needs UX sign-off

**One gesture, two outcomes, with nothing signalling which you get.** "Go to result" on a project
open in an editor keeps Find visible and focuses the editor. On a resource open only in a Bible
texts or Commentaries panel, it activates that panel — which shares Find's Column 3 stack in Simple
mode, so the results list disappears. It follows that for such a resource you cannot see the results
list and the resource text at the same time in Simple mode. This is inherent to the fixed
three-column layout rather than a defect, and it is documented at the call site, but it is a
user-facing behaviour change on the common path and deserves an explicit decision.

Note this applies to Bible texts and Commentaries only. The Model text panel sits alone in Column 1
and is excluded from the reveal set (see below), so it is never fronted by a result.

## Known gaps, deliberately not fixed here

- **The Model text panel is searchable but not a reveal target.** Its scroll effect is keyed on the
  reference alone, so a reference arriving while its tab is hidden finds no layout in a
  `display: none` iframe and nothing re-runs on activation. Rather than ship a stale-position case,
  `REVEALABLE_REFERENCE_PANEL_WEB_VIEW_TYPES` withholds the reveal. Costs nothing in Simple mode,
  where that panel is always visible and the scroll group has already moved it.
- **The Text Collection is not searchable** — filed as PT-4507. It declares every resource it hosts
  and would be nearly free to list, but "go to result" has no defined behaviour when each cell is
  its own editor.
- **A panel detached from every scroll group** is recorded as group 0 by `useOpenProjectTabs`
  (pre-existing on `main`), so a reveal could front a panel parked at an unrelated reference. This
  PR makes that reachable from Find rather than creating it.
- **The scroll effect has no test of its own.** Its three decision functions are unit-tested
  (`scrollToVerse`, `isEchoOfPublishedScrRef`, `hasNewScrollTarget`); the effect that composes them
  is not. Deliberate call, noted here rather than left implicit.

## Testing

- [x] 1911 tests pass across `platform-scripture` and `platform-scripture-editor` (111 files)
- [x] ESLint and Stylelint clean
- [x] Manual verification in Simple mode — picker lists panel resources, "go to result" reveals and
      scrolls the panel, and a verse click inside a panel no longer jumps

## AI Involvement

AI-assisted. Claude Opus 5 wrote most of the implementation and tests under review, ran a
`/review-paratext` pass over the branch, and worked two rounds of review feedback with the author.
The branch was rebuilt on `main` after review round 1 found that the publishing mechanism this PR
originally added already existed there. The author reviewed all changes and made the judgment calls
on each finding. No session link — the work was done in the Claude Code VS Code extension.

## Risk Level

Medium — it changes what Find's project picker offers and adds scroll behaviour to panels that
previously had none, both on Simple mode's common path. Mitigated by the decision logic being
extracted as unit-tested predicates, and by the editor path being unchanged when an editor is open.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2749)
<!-- Reviewable:end -->
