### PR TITLE
Fix Get Resources showing Update after a resource is updated

### DIFF
--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -498,11 +498,18 @@ step, no automation. Just a record.
 - **Decision:** Extend the read-path reconciliation rather than adding a write-path invalidation. A
   new no-network provider function, `recomputeDblResourcesUpdateStatus`, re-evaluates
   `InstallableResource.IsNewerThanCurrentlyInstalled()` over the already-loaded catalog snapshot,
-  and the front end's `syncInstalledFlags` applies it alongside the `installed` check. Because that
-  sync is single-flighted by `ensureInstalledFlagsSynced` and runs in the background, the recompute
-  happens at most once at a time and never on a path a caller waits on, however many views refresh
-  together. Resources absent from the result keep their cached value, so a not-yet-loaded catalog
-  or a busy provider gate degrades to the previous behavior instead of guessing. Skipping the
+  and the front end's `syncInstalledFlags` applies it alongside the `installed` check. The sync is
+  single-flighted by `ensureInstalledFlagsSynced`, so the recompute happens at most once at a time
+  however many views refresh together. Reads do not wait for it — `getCachedResources` answers from
+  the array it already has — which makes a read one refresh behind. That is invisible for
+  `installed`, whose caller already knows what it just did, but it is the whole defect for
+  `updateAvailable`: nothing else about an updated row changes, and there is no data-update event,
+  so the row keeps offering "Update" until the catalog is read a second time. A caller that has
+  just changed local state therefore awaits `refreshResourceFlags` and then re-reads, which is the
+  one path that does wait on the recompute. Resources absent from the result keep their cached
+  value, so a not-yet-loaded catalog or a busy provider gate degrades to the previous behavior
+  instead of guessing — including on that awaited path, where a contended gate leaves the stale
+  flag in place rather than blocking the user. Skipping the
   catalog fetch is sound because the DBL-side revision is the half that should stay fixed;
   ParatextData re-reads the *installed* revision on each call (`ExistingScrText` is a live
   `ScrTextCollection` lookup, and `InternalInstall` nulls the ScrText's FileManager before

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -477,6 +477,80 @@ step, no automation. Just a record.
   the only copy a user receives. **Revisit** if this repository ever needs to publish a build to a
   public audience.
 - **Source:** the multi-agent review of #2654, finding 1.
+## adr-dbl-cache-recompute-on-read: The DBL resource cache recomputes derived flags on read, not on write
+
+- **Date:** 2026-09-01
+- **Status:** Accepted
+- **Context:** `platformGetResources.getCachedResources` is the only source the Get Resources page,
+  Home, the resource picker, Share Layout, the scripture text grid and
+  `use-dbl-resource-catalog.hook` read — six consumers. Its background sync reconciled `installed`
+  against local project metadata on every call but never recomputed `updateAvailable`, and its one
+  rewrite branch fired only when `installed` flipped — so updating an already-installed resource
+  left the row reading "Update" for the rest of the session. The C# provider does fire
+  `SendDataUpdateEvent(DBL_RESOURCES, …)` after an install, but nothing has subscribed to that data
+  type since the cache replaced the front end's `useData` subscription (zero `.DblResources(` call
+  sites repo-wide), so the event refreshes nothing. `updateAvailable` cannot be derived in
+  TypeScript: it compares the installed resource's DBL revision against the catalog's, and neither
+  number is reachable there. The DBL side is dropped when C# projects `InstallableResource` into
+  `DblResourceData`; the installed side is an entry name under `.dbl/revision/` inside the
+  password-protected `.p8z` bundle, read through ParatextData's zip file manager — no project
+  setting or metadata field exposes it, and `Revision` appears nowhere in `c-sharp/`.
+- **Decision:** Extend the read-path reconciliation rather than adding a write-path invalidation. A
+  new no-network provider function, `recomputeDblResourcesUpdateStatus`, re-evaluates
+  `InstallableResource.IsNewerThanCurrentlyInstalled()` over the already-loaded catalog snapshot,
+  and the front end's `syncInstalledFlags` applies it alongside the `installed` check. Because that
+  sync is single-flighted by `ensureInstalledFlagsSynced` and runs in the background, the recompute
+  happens at most once at a time and never on a path a caller waits on, however many views refresh
+  together. Resources absent from the result keep their cached value, so a not-yet-loaded catalog
+  or a busy provider gate degrades to the previous behavior instead of guessing. Skipping the
+  catalog fetch is sound because the DBL-side revision is the half that should stay fixed;
+  ParatextData re-reads the *installed* revision on each call (`ExistingScrText` is a live
+  `ScrTextCollection` lookup, and `InternalInstall` nulls the ScrText's FileManager before
+  overwriting the `.p8z`, so `DBLResourceSettings` is rebuilt from the new file). Verified against
+  the pinned ParatextData 9.5.0.24 assembly (ILSpy, 2026-09-04); source is not available locally,
+  so re-probe when that pin moves.
+- **Alternatives:**
+  - **Patch the cache entry after a successful install** — rejected, but not because the install is
+    unverified: `InstallDblResourceCore`'s `ScrTextCollection.IsPresent(InstalledScrText)` guard
+    inspects `InstalledScrText`, which `InstallableResource.InternalInstall` assigns only as its last
+    statement, so a failed install leaves it null and the guard throws rather than reporting success.
+    Rejected instead because the patch would have to be applied by every caller that installs — the
+    Get Resources web view, `platform-scripture-editor`'s install util, and the Send/Receive path
+    that PT-4268 describes, which cannot reach the provider at all — and because it only corrects
+    the one resource this client just installed, leaving flags that changed for any other reason
+    stale. Recomputing on read asks the source of truth instead of inferring from an action.
+  - **Re-fetch the catalog on install** — rejected: `FetchResourcesCore` is an unbounded network
+    download and would stall the list refresh. Subscribing to `DBL_RESOURCES` from the extension is
+    the same alternative in disguise, because `subscribe<data_type>` calls `get<data_type>` and
+    `getDblResources` fetches unconditionally.
+  - **Clear the flag optimistically in the web view** — rejected: leaves the cache wrong for Home and
+    the resource picker, and adds a second "caller must remember to notify" seam of exactly the kind
+    PT-4268 documents.
+  - **Send both revisions to TypeScript and compare there** — rejected: the installed half still
+    requires a C# call to read it out of the encrypted bundle, so it removes no round trip while
+    adding ~10 fields to the contract and a TypeScript copy of
+    `IsNewerThanCurrentlyInstalled`'s five-branch precedence chain (name, language,
+    `IsResourceProject`, `RequiresDBLCheck`, then revision / permissions checksum / manifest checksum
+    plus timestamp). That copy would drift silently when the ParatextData pin moves.
+- **Consequences:** Reads are authoritative for both derived flags, which makes the `DBL_RESOURCES`
+  data-update event dead weight rather than a missing link — PT-4268's stated premise ("the provider's
+  install path fires the event so the Get Resources UI refreshes") is already false, and whoever picks
+  it up should re-scope it against this decision. Cost is bounded by gathering the installed DBL uids
+  in ONE pass over the project collection and consulting ParatextData only for entries in that set:
+  `InstallableResource.ExistingScrText` is a computed property with no backing field that enumerates
+  the whole collection on every access, so asking each of the ~1850 catalog entries whether it is
+  installed would cost ~1850 full scans, and an installed entry pays it twice (once for `Installed`,
+  once inside `IsNewerThanCurrentlyInstalled`). Gating on `Installed` does not help, because that
+  property is the same lookup. The provider gate is taken with a non-waiting `Monitor.TryEnter`, so a
+  recheck never queues behind a catalog download or an install: everything holding that gate runs for
+  seconds, far longer than a refresh should block, so waiting could only delay the same empty answer,
+  and two rechecks cannot contend with each other because the only caller is single-flighted.
+  `IsNewerThanCurrentlyInstalled()` returns `true` for every *uninstalled* resource — nothing
+  installed trivially fails its "is the installed copy the newest" test — so the front end clears
+  `updateAvailable` for any row it reconciles as not installed rather than persisting a flag that
+  describes nothing. That keeps the cached flag meaning what the list renders it as: "the copy on
+  disk is out of date".
+- **Source:** Bug report that Get Resources keeps showing "Update" after a resource is updated.
 
 ## adr-decision-log-sorted-insertion: Decision-log entries are inserted in byte order by slug, not appended
 

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -498,18 +498,27 @@ step, no automation. Just a record.
 - **Decision:** Extend the read-path reconciliation rather than adding a write-path invalidation. A
   new no-network provider function, `recomputeDblResourcesUpdateStatus`, re-evaluates
   `InstallableResource.IsNewerThanCurrentlyInstalled()` over the already-loaded catalog snapshot,
-  and the front end's `syncInstalledFlags` applies it alongside the `installed` check. The sync is
+  and the front end's flag sync applies it alongside the `installed` check. The sync is
   single-flighted by `ensureInstalledFlagsSynced`, so the recompute happens at most once at a time
   however many views refresh together. Reads do not wait for it — `getCachedResources` answers from
   the array it already has — which makes a read one refresh behind. That is invisible for
   `installed`, whose caller already knows what it just did, but it is the whole defect for
   `updateAvailable`: nothing else about an updated row changes, and there is no data-update event,
-  so the row keeps offering "Update" until the catalog is read a second time. A caller that has
-  just changed local state therefore awaits `refreshResourceFlags` and then re-reads, which is the
-  one path that does wait on the recompute. Resources absent from the result keep their cached
-  value, so a not-yet-loaded catalog or a busy provider gate degrades to the previous behavior
-  instead of guessing — including on that awaited path, where a contended gate leaves the stale
-  flag in place rather than blocking the user. Skipping the
+  so the row keeps offering "Update" until the catalog is read a second time.
+
+  Two consequences shape the wiring. The backend round trip is **opt-in** rather than part of every
+  sync, because exactly one surface renders `updateAvailable` — the Get Resources list — and the
+  other five consumers of the catalog would otherwise wait on a value they discard; the resource
+  picker's whole list spun on it. And a caller that needs the flag current awaits
+  `refreshResourceFlags`, which asks for the recompute and, rather than joining a sync already in
+  flight, lets that one finish before starting its own: an in-flight sync may have read its project
+  metadata before the caller's change, and a background sync does not recompute the flag at all.
+  The Get Resources view is therefore the only caller — once when its list settles, so a resource
+  updated from another surface loses its stale badge, and again after any install or removal the
+  user performs there. Resources absent from the result keep their cached value, so a
+  not-yet-loaded catalog or a busy provider gate degrades to the previous behavior instead of
+  guessing — including on the awaited path, where a contended gate leaves the stale flag in place
+  rather than blocking the user. Skipping the
   catalog fetch is sound because the DBL-side revision is the half that should stay fixed;
   ParatextData re-reads the *installed* revision on each call (`ExistingScrText` is a live
   `ScrTextCollection` lookup, and `InternalInstall` nulls the ScrText's FileManager before

--- a/c-sharp-tests/Projects/DigitalBibleLibrary/DblResourcesDataProviderTests.cs
+++ b/c-sharp-tests/Projects/DigitalBibleLibrary/DblResourcesDataProviderTests.cs
@@ -1,0 +1,216 @@
+using System.Diagnostics.CodeAnalysis;
+using Paranext.DataProvider.Projects.DigitalBibleLibrary;
+using Paratext.Data;
+using Paratext.Data.Archiving;
+using PtxUtils;
+
+namespace TestParanextDataProvider.Projects.DigitalBibleLibrary
+{
+    /// <summary>
+    /// Covers the update-status recheck the front end calls on every resource-list refresh, and the
+    /// catalog projection behind it.
+    ///
+    /// Three things about it are contracts rather than implementation detail. It has to answer
+    /// without reaching the DBL, including before the background catalog fetch has finished on
+    /// startup, because the TypeScript side treats an absent entry as "unknown" and keeps its
+    /// cached value — an exception or a network call here would instead stall or break the refresh.
+    /// Its keys are DBL entry uids, which is what the TypeScript looks entries up by. And it is
+    /// reached by name through `IDblResourcesProvider`, so its registered wire name is a
+    /// cross-language contract: renaming either half without the other breaks the refresh silently
+    /// at runtime rather than at compile time. The name also deliberately avoids the
+    /// `get`/`set`/`subscribe` prefixes reserved for data-type accessors.
+    /// </summary>
+    [ExcludeFromCodeCoverage]
+    internal class DblResourcesDataProviderTests : PapiTestBase
+    {
+        private const string RecomputeUpdateStatusWireName =
+            "object:platformGetResources.dblResourcesProvider-data.recomputeDblResourcesUpdateStatus";
+
+        /// <summary>
+        /// A catalog entry whose <see cref="InstallableResource.ExistingScrText"/> throws. That
+        /// property is the live project-collection lookup the installed-uid set exists to avoid, so
+        /// a test that reaches it fails loudly instead of silently depending on collection state.
+        /// </summary>
+        private sealed class ThrowingLookupResource : InstallableResource
+        {
+            public override ScrText ExistingScrText =>
+                throw new InvalidOperationException(
+                    "ExistingScrText must not be consulted for this resource"
+                );
+        }
+
+        /// <summary>
+        /// A catalog entry backed by a local project, so <c>IsNewerThanCurrentlyInstalled</c> runs
+        /// its real comparison chain instead of short-circuiting on "not installed".
+        /// </summary>
+        private sealed class InstalledResource(ScrText existing) : InstallableResource
+        {
+            public override ScrText ExistingScrText { get; } = existing;
+        }
+
+        private static InstallableResource ResourceWithUid(string dblEntryUid) =>
+            new ThrowingLookupResource { DBLEntryUid = HexId.FromStr(dblEntryUid) };
+
+        /// <summary>
+        /// An installed entry that reports up to date. A <see cref="DummyScrText"/> is not a
+        /// resource project, so once the name matches, <c>IsNewerThanCurrentlyInstalled</c> stops
+        /// at its <c>!scrText.IsResourceProject</c> branch and returns false.
+        /// </summary>
+        private static InstallableResource UpToDateResource(string dblEntryUid, ScrText existing) =>
+            new InstalledResource(existing)
+            {
+                DBLEntryUid = HexId.FromStr(dblEntryUid),
+                Name = existing.Name,
+            };
+
+        /// <summary>
+        /// An installed entry that reports an update available, via the name-mismatch branch of
+        /// <c>IsNewerThanCurrentlyInstalled</c>.
+        /// </summary>
+        private static InstallableResource OutOfDateResource(string dblEntryUid, ScrText existing) =>
+            new InstalledResource(existing)
+            {
+                DBLEntryUid = HexId.FromStr(dblEntryUid),
+                Name = existing.Name + "-renamed",
+            };
+
+        [Test]
+        public async Task RecomputeDblResourcesUpdateStatus_ReturnsEmptyBeforeCatalogIsFetched()
+        {
+            DblResourcesDataProvider provider = new(Client, ParatextProjects);
+
+            var updateStatus = await provider.RecomputeDblResourcesUpdateStatus();
+
+            Assert.That(updateStatus, Is.Empty);
+        }
+
+        [Test]
+        public async Task RecomputeDblResourcesUpdateStatus_IsRegisteredUnderItsContractName()
+        {
+            DblResourcesDataProvider provider = new(Client, ParatextProjects);
+
+            await provider.RegisterDataProviderAsync();
+
+            Assert.That(
+                Client.IsHandlerRegistered(RecomputeUpdateStatusWireName),
+                Is.True,
+                $"Expected '{RecomputeUpdateStatusWireName}' on the wire; "
+                    + $"registered: {string.Join(", ", Client.RegisteredRequestTypes)}"
+            );
+        }
+
+        [Test]
+        public void ProjectUpdateStatus_KeysByDblEntryUid()
+        {
+            var resources = new[]
+            {
+                ResourceWithUid("97196133a859179b"),
+                ResourceWithUid("6c21e835eb8ca3b2"),
+            };
+
+            var updateStatus = DblResourcesDataProvider.ProjectUpdateStatus(
+                resources,
+                new HashSet<string>()
+            );
+
+            Assert.That(
+                updateStatus.Keys,
+                Is.EquivalentTo(new[] { "97196133a859179b", "6c21e835eb8ca3b2" })
+            );
+        }
+
+        /// <summary>
+        /// The uninstalled answer is `true` — the same value ParatextData returns, since
+        /// `IsNewerThanCurrentlyInstalled` opens with `if (!Installed) return true;`. Reaching it
+        /// without touching the project collection is the whole point of the installed-uid set, and
+        /// the throwing lookup is what proves the collection was not touched.
+        /// </summary>
+        [Test]
+        public void ProjectUpdateStatus_ReportsUninstalledWithoutConsultingTheProjectCollection()
+        {
+            var resources = new[] { ResourceWithUid("97196133a859179b") };
+
+            var updateStatus = DblResourcesDataProvider.ProjectUpdateStatus(
+                resources,
+                new HashSet<string>()
+            );
+
+            Assert.That(updateStatus["97196133a859179b"], Is.True);
+        }
+
+        /// <summary>
+        /// A single failing entry must not cost the whole map. The TypeScript treats a missing key
+        /// as "unknown" and keeps the value it has, so omitting one entry degrades one row, whereas
+        /// letting the exception escape leaves every row stale for the session.
+        /// </summary>
+        [Test]
+        public void ProjectUpdateStatus_SkipsOnlyTheEntryThatThrows()
+        {
+            var resources = new[]
+            {
+                ResourceWithUid("97196133a859179b"),
+                ResourceWithUid("6c21e835eb8ca3b2"),
+            };
+
+            // Marking the first uid installed sends it down the ParatextData path, where this
+            // fake's lookup throws; the second stays on the no-lookup path.
+            var updateStatus = DblResourcesDataProvider.ProjectUpdateStatus(
+                resources,
+                new HashSet<string> { "97196133a859179b" }
+            );
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updateStatus.ContainsKey("97196133a859179b"), Is.False);
+                Assert.That(updateStatus["6c21e835eb8ca3b2"], Is.True);
+            });
+        }
+
+        /// <summary>
+        /// An installed, current resource reports no update — the state this whole recheck exists
+        /// to reach, since a stale `true` here is what left the row reading "Update" for the rest
+        /// of the session.
+        /// </summary>
+        [Test]
+        public void ProjectUpdateStatus_ReportsNoUpdateForAnInstalledCurrentResource()
+        {
+            using DummyScrText existing = new();
+            var resources = new[] { UpToDateResource("97196133a859179b", existing) };
+
+            var updateStatus = DblResourcesDataProvider.ProjectUpdateStatus(
+                resources,
+                new HashSet<string> { "97196133a859179b" }
+            );
+
+            Assert.That(updateStatus["97196133a859179b"], Is.False);
+        }
+
+        /// <summary>
+        /// Duplicate uids resolve first-wins, matching `FindResource`'s `FirstOrDefault`, so the
+        /// flag shown describes the same resource the install/uninstall buttons act on. The two
+        /// entries deliberately disagree, which is the only way this can tell first-wins from the
+        /// indexer's last-wins.
+        /// </summary>
+        [Test]
+        public void ProjectUpdateStatus_ResolvesADuplicateUidToTheFirstEntry()
+        {
+            using DummyScrText existing = new();
+            var resources = new[]
+            {
+                UpToDateResource("97196133a859179b", existing),
+                OutOfDateResource("97196133a859179b", existing),
+            };
+
+            var updateStatus = DblResourcesDataProvider.ProjectUpdateStatus(
+                resources,
+                new HashSet<string> { "97196133a859179b" }
+            );
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(updateStatus, Has.Count.EqualTo(1));
+                Assert.That(updateStatus["97196133a859179b"], Is.False);
+            });
+        }
+    }
+}

--- a/c-sharp-tests/Projects/DigitalBibleLibrary/DblResourcesDataProviderTests.cs
+++ b/c-sharp-tests/Projects/DigitalBibleLibrary/DblResourcesDataProviderTests.cs
@@ -19,6 +19,14 @@ namespace TestParanextDataProvider.Projects.DigitalBibleLibrary
     /// cross-language contract: renaming either half without the other breaks the refresh silently
     /// at runtime rather than at compile time. The name also deliberately avoids the
     /// `get`/`set`/`subscribe` prefixes reserved for data-type accessors.
+    ///
+    /// NOT covered, deliberately: the body of <c>RecomputeDblResourcesUpdateStatus</c> past its
+    /// <c>_hasFetchedResources</c> guard — the gate and the one line joining the two halves,
+    /// <c>ProjectUpdateStatus(_resources, InstalledDblIds())</c>. Reaching it needs
+    /// <c>_resources</c> populated, and its only writer is a live DBL download, so every test here
+    /// returns at that guard. Replacing that call's arguments therefore passes the suite. Read the
+    /// count below as covering the two halves, not the seam between them; the seam is verified by
+    /// hand against a resource with a real pending update.
     /// </summary>
     [ExcludeFromCodeCoverage]
     internal class DblResourcesDataProviderTests : PapiTestBase
@@ -50,6 +58,44 @@ namespace TestParanextDataProvider.Projects.DigitalBibleLibrary
 
         private static InstallableResource ResourceWithUid(string dblEntryUid) =>
             new ThrowingLookupResource { DBLEntryUid = HexId.FromStr(dblEntryUid) };
+
+        /// <summary>
+        /// A local project that presents itself as an installed DBL resource. <see cref="ScrText"/>
+        /// declares <c>IsResourceProject</c> as <c>virtual =&gt; false</c>, so a plain
+        /// <see cref="DummyScrText"/> is filtered out of the scan before its DBL id is read.
+        /// </summary>
+        private sealed class FakeResourceScrText : DummyScrText
+        {
+            public override bool IsResourceProject => true;
+        }
+
+        /// <summary>
+        /// A local project whose resource-project check throws, standing in for the corrupt
+        /// <c>Settings.xml</c> that makes <c>IsResourceProject</c> and <c>Settings</c> fault.
+        /// </summary>
+        /// <remarks>
+        /// The fault is armed after construction rather than from the start. Building and
+        /// registering a <see cref="DummyScrText"/> reads its settings — the constructor reaches
+        /// <c>Settings</c>, which resolves <c>Guid</c>, which consults <c>IsResourceProject</c> —
+        /// so a double that throws immediately cannot be constructed at all.
+        /// </remarks>
+        private sealed class UnreadableScrText : DummyScrText
+        {
+            public bool IsUnreadable { get; set; }
+
+            public override bool IsResourceProject =>
+                IsUnreadable
+                    ? throw new InvalidOperationException("This project's settings cannot be read")
+                    : base.IsResourceProject;
+        }
+
+        private FakeResourceScrText AddInstalledResourceProject(string dblEntryUid)
+        {
+            FakeResourceScrText scrText = new();
+            scrText.Settings.DBLId = HexId.FromStr(dblEntryUid);
+            ScrTextCollection.Add(scrText, true);
+            return scrText;
+        }
 
         /// <summary>
         /// An installed entry that reports up to date. A <see cref="DummyScrText"/> is not a
@@ -230,6 +276,41 @@ namespace TestParanextDataProvider.Projects.DigitalBibleLibrary
                 Assert.That(updateStatus, Has.Count.EqualTo(1));
                 Assert.That(updateStatus["97196133a859179b"], Is.False);
             });
+        }
+
+        /// <summary>
+        /// The scan is what tells `ProjectUpdateStatus` which entries are worth asking ParatextData
+        /// about. Reporting an installed resource as absent is the stuck-badge bug this fixture
+        /// exists for, so the uid has to come back, and a project that is not a resource must not.
+        /// </summary>
+        [Test]
+        public void InstalledDblIds_ReturnsResourceProjectDblIdsAndSkipsOtherProjects()
+        {
+            AddInstalledResourceProject("97196133a859179b");
+            ScrTextCollection.Add(new DummyScrText(), true);
+
+            var installedDblIds = DblResourcesDataProvider.InstalledDblIds();
+
+            Assert.That(installedDblIds, Is.EquivalentTo(new[] { "97196133a859179b" }));
+        }
+
+        /// <summary>
+        /// One unreadable project must cost only itself. Without the per-item guard the exception
+        /// escapes the scan and faults the whole recheck, which leaves every row's flag stale for
+        /// the rest of the session — the outcome the guard inside `ProjectUpdateStatus` also exists
+        /// to prevent.
+        /// </summary>
+        [Test]
+        public void InstalledDblIds_SkipsAnUnreadableProjectAndKeepsTheRest()
+        {
+            UnreadableScrText unreadable = new();
+            ScrTextCollection.Add(unreadable, true);
+            unreadable.IsUnreadable = true;
+            AddInstalledResourceProject("6c21e835eb8ca3b2");
+
+            var installedDblIds = DblResourcesDataProvider.InstalledDblIds();
+
+            Assert.That(installedDblIds, Is.EquivalentTo(new[] { "6c21e835eb8ca3b2" }));
         }
     }
 }

--- a/c-sharp-tests/Projects/DigitalBibleLibrary/DblResourcesDataProviderTests.cs
+++ b/c-sharp-tests/Projects/DigitalBibleLibrary/DblResourcesDataProviderTests.cs
@@ -186,6 +186,25 @@ namespace TestParanextDataProvider.Projects.DigitalBibleLibrary
         }
 
         /// <summary>
+        /// An installed resource whose DBL copy is newer reports an update. Without this the suite
+        /// only ever asserts the `false` side, so the badge could stop appearing entirely — for
+        /// every resource, whether or not an update exists — and stay green.
+        /// </summary>
+        [Test]
+        public void ProjectUpdateStatus_ReportsAnUpdateForAnInstalledOutOfDateResource()
+        {
+            using DummyScrText existing = new();
+            var resources = new[] { OutOfDateResource("97196133a859179b", existing) };
+
+            var updateStatus = DblResourcesDataProvider.ProjectUpdateStatus(
+                resources,
+                new HashSet<string> { "97196133a859179b" }
+            );
+
+            Assert.That(updateStatus["97196133a859179b"], Is.True);
+        }
+
+        /// <summary>
         /// Duplicate uids resolve first-wins, matching `FindResource`'s `FirstOrDefault`, so the
         /// flag shown describes the same resource the install/uninstall buttons act on. The two
         /// entries deliberately disagree, which is the only way this can tell first-wins from the

--- a/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
+++ b/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
@@ -75,6 +75,15 @@ internal class DblResourcesDataProvider(
 
     private const int DBL_NETWORK_TIMEOUT = 0; // Don't timeout DBL network requests
 
+    // Bounds the update-status recheck, which is the one wire method here that must answer promptly:
+    // it serves the front end's list refresh, and its TSDoc promises it "gives up rather than
+    // blocking". Without an explicit value it would inherit `network.service.ts`'s 30-second
+    // default, three orders of magnitude past that promise. Sized well above the work itself — the
+    // gate is non-waiting and the recheck is in-memory, though it grows with the catalog and the
+    // local project count — while still failing fast enough that a stuck recheck cannot hold a
+    // refresh for half a minute.
+    private const int UPDATE_STATUS_NETWORK_TIMEOUT = 5000;
+
     public const string DBL_RESOURCES = "DblResources";
 
     // Node.js services match this exact text (platform-bible-utils `isErrorMessageAboutRegistryAuthFailure`
@@ -85,17 +94,20 @@ internal class DblResourcesDataProvider(
     private List<InstallableResource> _resources = [];
 
     // Set once the catalog has loaded at least once so a mutation (install/uninstall) that races the
-    // initial fetch doesn't operate on an empty _resources list. Read and written only while holding
-    // _providerGate.
+    // initial fetch doesn't operate on an empty _resources list. Written only while holding
+    // _providerGate. It may also be read WITHOUT the gate, but only as a one-way hint: it never
+    // returns to false, so a lock-free reader that sees false has either not missed anything yet or
+    // is about to redo the check under the gate, and one that sees true is correct.
     private bool _hasFetchedResources;
 
     // Guards every access to shared state so only one DBL operation touches it at a time:
-    //   • _resources — reassigned by FetchResourcesCore, read by FindResource
+    //   • _resources — reassigned by FetchResourcesCore, read by FindResource and by
+    //     RecomputeDblResourcesUpdateStatus
     //   • the Paratext ScrTextCollection — mutated by install/uninstall, read by the fetch's projection
     //   • the process-global Trace.Listeners 401-detection bracket in FetchResourcesCore
-    // GetDblResources/InstallDblResource/UninstallDblResource do their blocking work inside Task.Run
-    // and take this lock there — never on the JSON-RPC reading thread — so the reading loop stays
-    // responsive while an operation runs. See PT-4222.
+    // GetDblResources/InstallDblResource/UninstallDblResource/RecomputeDblResourcesUpdateStatus do
+    // their blocking work inside Task.Run and take this lock there — never on the JSON-RPC reading
+    // thread — so the reading loop stays responsive while an operation runs. See PT-4222.
     private readonly object _providerGate = new();
 
     #endregion
@@ -107,6 +119,7 @@ internal class DblResourcesDataProvider(
         return
         [
             ("getDblResources", GetDblResources),
+            ("recomputeDblResourcesUpdateStatus", RecomputeDblResourcesUpdateStatus),
             ("installDblResource", InstallDblResource),
             ("uninstallDblResource", UninstallDblResource),
             ("isGetDblResourcesAvailable", IsGetDblResourcesAvailable),
@@ -236,6 +249,134 @@ internal class DblResourcesDataProvider(
                     .ToList();
             }
         });
+
+    /// <summary>
+    /// Recompute, for each resource in the already-loaded catalog, whether the DBL has a newer
+    /// version than the copy installed locally.
+    /// </summary>
+    /// <remarks>
+    /// Deliberately never loads the catalog, unlike <see cref="GetDblResources"/> and the
+    /// install/uninstall methods: this serves the front end's list refresh, and
+    /// <see cref="FetchResourcesCore"/> is an unbounded network download. Skipping it is sound
+    /// because the DBL-side revision is the half we want held fixed — it is the locally installed
+    /// revision that changes after an install, and ParatextData reads that from the installed
+    /// resource on every call rather than caching it.
+    /// </remarks>
+    /// <returns>
+    /// Whether an update is available, keyed by DBL entry uid. Empty when the catalog has not loaded
+    /// yet or when another DBL operation holds the gate; callers then keep the values they have.
+    /// </returns>
+    [NetworkTimeout(UPDATE_STATUS_NETWORK_TIMEOUT)]
+    internal Task<Dictionary<string, bool>> RecomputeDblResourcesUpdateStatus()
+    {
+        // Answer on the calling thread while the catalog has never loaded — the whole of startup,
+        // during which every list refresh would otherwise queue a thread-pool dispatch and contend
+        // the gate held by the in-progress download, all for an answer that is empty by definition.
+        // Reading the flag without the gate is sound because it is a one-way hint; see its
+        // declaration.
+        if (!_hasFetchedResources)
+            return Task.FromResult(new Dictionary<string, bool>());
+
+        return Task.Run(() =>
+        {
+            bool gateTaken = false;
+            try
+            {
+                // Non-waiting on purpose. Everything else that holds this gate — a catalog
+                // download, an install, an uninstall — runs for seconds, far longer than a list
+                // refresh should block, so waiting could only delay the same empty answer. Two
+                // rechecks cannot contend with each other: the only caller runs inside the
+                // front end's single-flight installed-flag sync.
+                Monitor.TryEnter(_providerGate, ref gateTaken);
+                if (!gateTaken || !_hasFetchedResources)
+                    return [];
+
+                return ProjectUpdateStatus(_resources, InstalledDblIds());
+            }
+            finally
+            {
+                if (gateTaken)
+                    Monitor.Exit(_providerGate);
+            }
+        });
+    }
+
+    /// <summary>
+    /// The DBL entry uids of every resource currently installed locally, gathered in a single pass
+    /// over the project collection.
+    /// </summary>
+    /// <remarks>
+    /// This exists to keep <see cref="ProjectUpdateStatus"/> off
+    /// <see cref="InstallableResource.ExistingScrText"/> for entries that are not installed.
+    /// That property is computed with no backing field and enumerates the whole project collection
+    /// on every access, so asking each of the ~1800 catalog entries whether it is installed costs
+    /// ~1800 full scans — and an installed entry pays it twice, once for
+    /// <c>Installed</c> and once inside <c>IsNewerThanCurrentlyInstalled</c>. Gating the loop on
+    /// <c>Installed</c> does not help, because that property is the same lookup.
+    ///
+    /// The predicate matches the main branch of <c>ExistingScrText</c>. It deliberately omits that
+    /// property's two other branches — a null <c>DBLEntryUid</c> matched by name, and the
+    /// <c>SourceLanguageResource</c> fallback — because this provider serves only whitelisted DBL
+    /// catalog entries, which always carry a uid and are always <c>ResourceType.DBL</c>. A resource
+    /// reaching here without a uid would be reported as not installed, which is what
+    /// ParatextData already returns for anything uninstalled.
+    /// </remarks>
+    private static HashSet<string> InstalledDblIds()
+    {
+        HashSet<string> installedDblIds = [];
+        foreach (var scrText in ScrTextCollection.ScrTexts(IncludeProjects.AllAccessible))
+        {
+            if (!scrText.IsResourceProject)
+                continue;
+            var dblId = scrText.Settings.DBLId;
+            if (dblId != null)
+                installedDblIds.Add(dblId.Id);
+        }
+        return installedDblIds;
+    }
+
+    /// <summary>
+    /// Projects a catalog into "is a newer version available", keyed by DBL entry uid.
+    /// </summary>
+    /// <param name="resources">The catalog entries to report on.</param>
+    /// <param name="installedDblIds">
+    /// Uids of the resources installed locally, from <see cref="InstalledDblIds"/>. An entry
+    /// outside this set is reported as having an update available without consulting
+    /// ParatextData — the same answer <c>IsNewerThanCurrentlyInstalled</c> gives for anything
+    /// uninstalled, since it opens with <c>if (!Installed) return true;</c>.
+    /// </param>
+    internal static Dictionary<string, bool> ProjectUpdateStatus(
+        IEnumerable<InstallableResource> resources,
+        ISet<string> installedDblIds
+    )
+    {
+        Dictionary<string, bool> updateStatus = [];
+        foreach (var resource in resources)
+        {
+            var dblEntryUid = resource.DBLEntryUid?.Id;
+            if (dblEntryUid == null)
+                continue;
+            try
+            {
+                // TryAdd, not the indexer, so a duplicate uid resolves to the same
+                // InstallableResource that FindResource's FirstOrDefault picks — the flag shown
+                // then describes the resource the install/uninstall buttons act on.
+                updateStatus.TryAdd(
+                    dblEntryUid,
+                    !installedDblIds.Contains(dblEntryUid)
+                        || resource.IsNewerThanCurrentlyInstalled()
+                );
+            }
+            catch (Exception e)
+            {
+                // Skipping one entry degrades one row: callers already treat a missing key as
+                // "unknown" and keep the value they have. Letting it escape would fault the whole
+                // task and leave every row stale for the session instead.
+                Console.WriteLine($"Could not recompute update status for {dblEntryUid}: {e}");
+            }
+        }
+        return updateStatus;
+    }
 
     private void FindResource(
         string dblEntryUid,

--- a/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
+++ b/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
@@ -326,11 +326,26 @@ internal class DblResourcesDataProvider(
         HashSet<string> installedDblIds = [];
         foreach (var scrText in ScrTextCollection.ScrTexts(IncludeProjects.AllAccessible))
         {
-            if (!scrText.IsResourceProject)
-                continue;
-            var dblId = scrText.Settings.DBLId;
-            if (dblId != null)
-                installedDblIds.Add(dblId.Id);
+            try
+            {
+                if (!scrText.IsResourceProject)
+                    continue;
+                var dblId = scrText.Settings.DBLId;
+                if (dblId != null)
+                    installedDblIds.Add(dblId.Id);
+            }
+            catch (Exception e)
+            {
+                // Both reads above touch project settings, which fault on a corrupt Settings.xml.
+                // Skipping the project costs at most one row an accurate flag; letting the
+                // exception escape would fault the whole recheck and leave every row stale for the
+                // session — the outcome the per-entry guard in ProjectUpdateStatus also prevents.
+                // The project is deliberately not named here: reading anything off it is what
+                // just failed, so doing it again in the handler could throw out of the catch.
+                Console.WriteLine(
+                    $"Could not read a project's DBL id while rechecking updates: {e}"
+                );
+            }
         }
         return installedDblIds;
     }

--- a/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
+++ b/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
@@ -284,9 +284,10 @@ internal class DblResourcesDataProvider(
             {
                 // Non-waiting on purpose. Everything else that holds this gate — a catalog
                 // download, an install, an uninstall — runs for seconds, far longer than a list
-                // refresh should block, so waiting could only delay the same empty answer. Two
-                // rechecks cannot contend with each other: the only caller runs inside the
-                // front end's single-flight installed-flag sync.
+                // refresh should block. Two rechecks cannot contend with each other: the only
+                // caller runs inside the front end's single-flight installed-flag sync. A
+                // contended gate therefore costs the caller its answer, not its responsiveness:
+                // the empty result means "unknown", and the front end keeps the flags it has.
                 Monitor.TryEnter(_providerGate, ref gateTaken);
                 if (!gateTaken || !_hasFetchedResources)
                     return [];

--- a/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
+++ b/c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs
@@ -322,7 +322,7 @@ internal class DblResourcesDataProvider(
     /// reaching here without a uid would be reported as not installed, which is what
     /// ParatextData already returns for anything uninstalled.
     /// </remarks>
-    private static HashSet<string> InstalledDblIds()
+    internal static HashSet<string> InstalledDblIds()
     {
         HashSet<string> installedDblIds = [];
         foreach (var scrText in ScrTextCollection.ScrTexts(IncludeProjects.AllAccessible))

--- a/extensions/src/platform-get-resources/src/get-resources.web-view.tsx
+++ b/extensions/src/platform-get-resources/src/get-resources.web-view.tsx
@@ -125,8 +125,15 @@ globalThis.webViewComponent = function GetResourcesDialog({ useWebViewState }: W
       const actionFunction = action === 'install' ? installResource : uninstallResource;
 
       return actionFunction(dblEntryUid)
-        .then(() => {
-          // Trigger a refetch so the resource list reflects the new installed state.
+        .then(async () => {
+          // Wait for the derived flags to catch up before refetching. `getCachedResources` answers
+          // from the array it already has and syncs in the background, so refetching straight away
+          // returns the pre-action flags. An install or removal survives that, because the row's
+          // spinner clears on `installed` flipping and the following refetch corrects it; an
+          // update does not, because nothing about the row changes except `updateAvailable` and
+          // there is no event to announce the correction — the row would keep offering "Update"
+          // until the dialog was reopened.
+          await papi.commands.sendCommand('platformGetResources.refreshResourceFlags');
           refetchResources();
           return undefined;
         })

--- a/extensions/src/platform-get-resources/src/get-resources.web-view.tsx
+++ b/extensions/src/platform-get-resources/src/get-resources.web-view.tsx
@@ -3,7 +3,7 @@ import papi, { logger } from '@papi/frontend';
 import { useDataProvider, useLocalizedStrings } from '@papi/frontend/react';
 import { useRetryablePromise } from 'platform-bible-react';
 import { getErrorMessage } from 'platform-bible-utils';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { shouldReportCatalogFailure } from './dbl-catalog.utils';
 import {
   GetResources,
@@ -147,6 +147,29 @@ globalThis.webViewComponent = function GetResourcesDialog({ useWebViewState }: W
     },
     [installResource, uninstallResource, refetchResources],
   );
+
+  // Correct the update badges once the list is up. `getCachedResources` answers one refresh behind,
+  // and the background sync deliberately skips the backend round trip that `updateAvailable` needs
+  // — every other consumer of the catalog discards that flag. So a resource updated outside this
+  // dialog arrives here still offering "Update". This view is the only one that renders the flag,
+  // which makes it the one that pays for refreshing it. Once per mount: the post-action refresh
+  // covers anything the user does from here.
+  const hasRefreshedUpdateFlags = useRef(false);
+  useEffect(() => {
+    if (!hasSettled || hasRefreshedUpdateFlags.current) return;
+    hasRefreshedUpdateFlags.current = true;
+    papi.commands
+      .sendCommand('platformGetResources.refreshResourceFlags')
+      .then(() => {
+        refetchResources();
+        return undefined;
+      })
+      // The list is already rendered; a failed refresh leaves the cached flags in place rather
+      // than costing the user the dialog.
+      .catch((e) =>
+        logger.warn(`Could not refresh DBL resource update flags: ${getErrorMessage(e)}`),
+      );
+  }, [hasSettled, refetchResources]);
 
   /** Removes resources from array of resources that are currently being handled */
   useEffect(() => {

--- a/extensions/src/platform-get-resources/src/main.ts
+++ b/extensions/src/platform-get-resources/src/main.ts
@@ -203,11 +203,33 @@ function ensureInstalledFlagsSynced(): Promise<void> {
   return syncInFlight;
 }
 
+/**
+ * Brings the derived flags up to date and resolves once they are, so the next read of the catalog
+ * sees them.
+ *
+ * `getCachedResources` deliberately does not wait for the sync, which makes it one refresh behind:
+ * it answers from the array it has and leaves the corrected one to the next call. For `installed`
+ * that is invisible, because the caller that just installed something already knows. For
+ * `updateAvailable` it is the whole defect — an updated resource keeps its "Update" badge, since
+ * nothing else about the row changes and no data-update event exists to announce the correction. A
+ * caller that has just changed local state awaits this first, then re-reads.
+ */
+async function refreshResourceFlags(): Promise<void> {
+  // Joining a sync that is already running is not enough: it may have read its project metadata
+  // before the change this caller just made, so it can resolve on pre-change state. Let that one
+  // finish first, then start one that is guaranteed to observe the change. Any sync another caller
+  // starts in between also began after the change, so it is equally good.
+  if (syncInFlight) await syncInFlight;
+  await ensureInstalledFlagsSynced();
+}
+
 async function getCachedResources(): Promise<DblResourceCatalog> {
   if (cachedResources !== undefined) {
     // Run the installed-flag sync in the background so the dialog open is never blocked by
     // getMetadataForAllProjects retries (which can exceed the 30-second JSON-RPC timeout when
-    // the C# PDPF is still initializing). The next dialog open picks up the updated flags.
+    // the C# PDPF is still initializing). This read therefore answers one refresh behind; a
+    // caller that needs the flags to reflect a change it just made awaits `refreshResourceFlags`
+    // before reading.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     ensureInstalledFlagsSynced();
     return { status: 'available', resources: cachedResources };
@@ -428,6 +450,11 @@ export async function activate(context: ExecutionActivationContext) {
     getLocalNonDblResources,
   );
 
+  const refreshResourceFlagsCommandPromise = papi.commands.registerCommand(
+    'platformGetResources.refreshResourceFlags',
+    refreshResourceFlags,
+  );
+
   const isSendReceiveAvailableCommandPromise = papi.commands.registerCommand(
     'platformGetResources.isSendReceiveAvailable',
     async () => {
@@ -460,6 +487,7 @@ export async function activate(context: ExecutionActivationContext) {
     await openNewTabWebViewCommandPromise,
     await getCachedResourcesCommandPromise,
     await getLocalNonDblResourcesCommandPromise,
+    await refreshResourceFlagsCommandPromise,
     await isSendReceiveAvailableCommandPromise,
   );
 

--- a/extensions/src/platform-get-resources/src/main.ts
+++ b/extensions/src/platform-get-resources/src/main.ts
@@ -133,15 +133,34 @@ async function getLocalProjectMetadata(): Promise<{
 }
 
 /**
- * Syncs the derived `installed`, `projectId` and `updateAvailable` flags on `cachedResources`
- * against current local state. Runs in the background so it never blocks a dialog open. Updates
- * `cachedResources` and writes to storage when flags change.
+ * Asks the backend which resources have a newer version on the DBL, or `undefined` if it could not
+ * say.
  *
- * `installed` and `projectId` come from live project metadata. `updateAvailable` compares the
- * locally installed revision against the DBL catalog's, and neither number is reachable from
- * TypeScript, so the backend is asked for it.
+ * `updateAvailable` compares the locally installed revision against the DBL catalog's, and neither
+ * number is reachable from TypeScript, so only the backend can answer. `undefined` leaves those
+ * flags at their cached values rather than guessing.
  */
-async function syncInstalledFlags(): Promise<void> {
+async function readUpdateStatus(): Promise<DblResourceUpdateStatus | undefined> {
+  try {
+    const provider = await papi.dataProviders.get('platformGetResources.dblResourcesProvider');
+    return await provider?.recomputeDblResourcesUpdateStatus();
+  } catch (error: unknown) {
+    logger.warn(`Could not recompute DBL resource update status: ${getErrorMessage(error)}`);
+    return undefined;
+  }
+}
+
+/**
+ * Syncs the derived flags on `cachedResources` against current local state, updating the cache and
+ * writing to storage when any of them change.
+ *
+ * `installed` and `projectId` come from live project metadata and are always reconciled. The
+ * backend round trip for `updateAvailable` is opt-in, because only the Get Resources list renders
+ * that flag: every other consumer of the catalog would otherwise wait on a value it discards.
+ *
+ * @param shouldRecomputeUpdateStatus Whether to also refresh `updateAvailable`
+ */
+async function syncFlags(shouldRecomputeUpdateStatus: boolean): Promise<void> {
   if (cachedResources === undefined) return;
   try {
     const { metadata: localProjectMetadata, hasResourceProjects } = await getLocalProjectMetadata();
@@ -150,16 +169,7 @@ async function syncInstalledFlags(): Promise<void> {
     // and it can never mark anything installed, so there is nothing to gain by continuing.
     if (!hasResourceProjects) return;
 
-    // Kept in its own `try` so a backend failure costs only the `updateAvailable` refresh: an
-    // undefined status leaves those flags at their cached values, while `installed` and `projectId`
-    // still reconcile against the local projects.
-    let updateStatus: DblResourceUpdateStatus | undefined;
-    try {
-      const provider = await papi.dataProviders.get('platformGetResources.dblResourcesProvider');
-      updateStatus = await provider?.recomputeDblResourcesUpdateStatus();
-    } catch (error: unknown) {
-      logger.warn(`Could not recompute DBL resource update status: ${getErrorMessage(error)}`);
-    }
+    const updateStatus = shouldRecomputeUpdateStatus ? await readUpdateStatus() : undefined;
 
     // Wrap the read-modify-write in fetchMutex so a concurrent fetchAndCacheResources call cannot
     // overwrite cachedResources between our reconcile and our assignment.
@@ -188,14 +198,18 @@ async function syncInstalledFlags(): Promise<void> {
 }
 
 /**
- * Starts the installed-flag sync if one is not already running, and returns the promise for it.
- * Callers that only need the catalog let it run in the background; callers whose answer depends on
- * the flags being current await it and re-read `cachedResources` afterwards.
+ * Starts a flag sync if one is not already running, and returns the promise for it. Callers that
+ * only need the catalog let it run in the background; callers whose answer depends on the flags
+ * being current await it and re-read `cachedResources` afterwards.
+ *
+ * @param shouldRecomputeUpdateStatus Whether the sync should also refresh `updateAvailable`. A
+ *   caller that needs it joins an in-flight sync that does not refresh it, so ask for it through
+ *   {@link refreshResourceFlags}, which starts a sync of its own rather than joining.
  */
-function ensureInstalledFlagsSynced(): Promise<void> {
+function ensureInstalledFlagsSynced(shouldRecomputeUpdateStatus = false): Promise<void> {
   if (!syncInFlight) {
-    syncInFlight = syncInstalledFlags()
-      .catch((e) => logger.warn(`Background installed-flag sync failed: ${getErrorMessage(e)}`))
+    syncInFlight = syncFlags(shouldRecomputeUpdateStatus)
+      .catch((e) => logger.warn(`Background flag sync failed: ${getErrorMessage(e)}`))
       .finally(() => {
         syncInFlight = undefined;
       });
@@ -215,12 +229,12 @@ function ensureInstalledFlagsSynced(): Promise<void> {
  * caller that has just changed local state awaits this first, then re-reads.
  */
 async function refreshResourceFlags(): Promise<void> {
-  // Joining a sync that is already running is not enough: it may have read its project metadata
-  // before the change this caller just made, so it can resolve on pre-change state. Let that one
-  // finish first, then start one that is guaranteed to observe the change. Any sync another caller
-  // starts in between also began after the change, so it is equally good.
+  // Joining a sync that is already running is not enough, for two reasons: it may have read its
+  // project metadata before the change this caller just made, and a background sync does not
+  // refresh `updateAvailable` at all. Let any running sync finish, then start one that is
+  // guaranteed to observe the change and to ask the backend.
   if (syncInFlight) await syncInFlight;
-  await ensureInstalledFlagsSynced();
+  await ensureInstalledFlagsSynced(true);
 }
 
 async function getCachedResources(): Promise<DblResourceCatalog> {

--- a/extensions/src/platform-get-resources/src/main.ts
+++ b/extensions/src/platform-get-resources/src/main.ts
@@ -7,7 +7,7 @@ import {
   SavedWebViewDefinition,
   WebViewDefinition,
 } from '@papi/core';
-import type { DblResourceCatalog } from 'platform-get-resources';
+import type { DblResourceCatalog, DblResourceUpdateStatus } from 'platform-get-resources';
 import type { DblResourceData } from 'platform-bible-utils';
 import { getErrorMessage, isString, Mutex, retryUntil } from 'platform-bible-utils';
 import { resolveDblCatalog, shouldStopBackgroundFetch } from './dbl-catalog.utils';
@@ -15,6 +15,7 @@ import { buildLocalNonDblResources } from './get-local-non-dbl-resources.utils';
 import getResourcesDialogReact from './get-resources.web-view?inline';
 import homeDialogReact from './home.web-view?inline';
 import newTabReact from './new-tab.web-view?inline';
+import { reconcileCachedResources } from './resources-cache.util';
 import tailwindStyles from './tailwind.css?inline';
 
 const GET_RESOURCES_WEB_VIEW_TYPE = 'platformGetResources.getResources';
@@ -132,9 +133,13 @@ async function getLocalProjectMetadata(): Promise<{
 }
 
 /**
- * Syncs installed flags on `cachedResources` against live project metadata from C#. Runs in the
- * background so it never blocks a dialog open. Updates `cachedResources` and writes to storage when
- * flags change.
+ * Syncs the derived `installed`, `projectId` and `updateAvailable` flags on `cachedResources`
+ * against current local state. Runs in the background so it never blocks a dialog open. Updates
+ * `cachedResources` and writes to storage when flags change.
+ *
+ * `installed` and `projectId` come from live project metadata. `updateAvailable` compares the
+ * locally installed revision against the DBL catalog's, and neither number is reachable from
+ * TypeScript, so the backend is asked for it.
  */
 async function syncInstalledFlags(): Promise<void> {
   if (cachedResources === undefined) return;
@@ -145,36 +150,27 @@ async function syncInstalledFlags(): Promise<void> {
     // and it can never mark anything installed, so there is nothing to gain by continuing.
     if (!hasResourceProjects) return;
 
+    // Kept in its own `try` so a backend failure costs only the `updateAvailable` refresh: an
+    // undefined status leaves those flags at their cached values, while `installed` and `projectId`
+    // still reconcile against the local projects.
+    let updateStatus: DblResourceUpdateStatus | undefined;
+    try {
+      const provider = await papi.dataProviders.get('platformGetResources.dblResourcesProvider');
+      updateStatus = await provider?.recomputeDblResourcesUpdateStatus();
+    } catch (error: unknown) {
+      logger.warn(`Could not recompute DBL resource update status: ${getErrorMessage(error)}`);
+    }
+
     // Wrap the read-modify-write in fetchMutex so a concurrent fetchAndCacheResources call cannot
-    // overwrite cachedResources between our map() and our assignment.
+    // overwrite cachedResources between our reconcile and our assignment.
     await fetchMutex.runExclusive(async () => {
       if (cachedResources === undefined) return;
 
-      let isChanged = false;
-      const newCachedResources = cachedResources.map((resource) => {
-        const matchingLocalProject = localProjectMetadata.find((localProject) =>
-          // If the `projectId` is defined then tries to use that
-          resource.projectId
-            ? resource.projectId === localProject.id
-            : // Otherwise uses the `dblEntryUid` which contains the first part of the project id.
-              // Guard against empty dblEntryUid: ''.startsWith('') is true for every string.
-              resource.dblEntryUid !== '' &&
-              localProject.id.toLowerCase().startsWith(resource.dblEntryUid.toLowerCase()),
-        );
-
-        const isInstalled = matchingLocalProject !== undefined;
-        if (isInstalled !== resource.installed) {
-          isChanged = true;
-          return {
-            ...resource,
-            installed: isInstalled,
-            updateAvailable: false,
-            projectId: matchingLocalProject?.id ?? '',
-          };
-        }
-
-        return resource;
-      });
+      const { resources: newCachedResources, isChanged } = reconcileCachedResources(
+        cachedResources,
+        localProjectMetadata.map((localProject) => localProject.id),
+        updateStatus,
+      );
 
       if (isChanged) {
         cachedResources = newCachedResources;

--- a/extensions/src/platform-get-resources/src/resources-cache.util.test.ts
+++ b/extensions/src/platform-get-resources/src/resources-cache.util.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it } from 'vitest';
+import type { DblResourceData } from 'platform-bible-utils';
+import { reconcileCachedResources } from './resources-cache.util';
+
+const INSTALLED_WITH_UPDATE: DblResourceData = {
+  dblEntryUid: 'abc123',
+  displayName: 'WEB',
+  fullName: 'World English Bible',
+  bestLanguageName: 'English',
+  type: 'ScriptureResource',
+  size: 100,
+  installed: true,
+  updateAvailable: true,
+  projectId: 'ABC123AAAA',
+};
+
+describe('reconcileCachedResources', () => {
+  it('clears updateAvailable on an installed resource once the backend reports no update', () => {
+    const { resources, isChanged } = reconcileCachedResources(
+      [INSTALLED_WITH_UPDATE],
+      ['ABC123AAAA'],
+      { abc123: false },
+    );
+
+    expect(resources[0].updateAvailable).toBe(false);
+    expect(resources[0].installed).toBe(true);
+    expect(isChanged).toBe(true);
+  });
+
+  it('sets updateAvailable on an installed resource once the backend reports an update', () => {
+    const { resources, isChanged } = reconcileCachedResources(
+      [{ ...INSTALLED_WITH_UPDATE, updateAvailable: false }],
+      ['ABC123AAAA'],
+      { abc123: true },
+    );
+
+    expect(resources[0].updateAvailable).toBe(true);
+    expect(isChanged).toBe(true);
+  });
+
+  it('keeps the cached updateAvailable when the backend reports no status for the resource', () => {
+    const { resources, isChanged } = reconcileCachedResources(
+      [INSTALLED_WITH_UPDATE],
+      ['ABC123AAAA'],
+      undefined,
+    );
+
+    expect(resources[0].updateAvailable).toBe(true);
+    expect(isChanged).toBe(false);
+  });
+
+  // The backend returns an empty map — never `undefined` — when it cannot answer: the catalog has
+  // not loaded yet this session, or another DBL operation holds its gate past the timeout.
+  it('keeps the cached updateAvailable when the backend returns an empty status map', () => {
+    const { resources, isChanged } = reconcileCachedResources(
+      [INSTALLED_WITH_UPDATE],
+      ['ABC123AAAA'],
+      {},
+    );
+
+    expect(resources[0].updateAvailable).toBe(true);
+    expect(isChanged).toBe(false);
+  });
+
+  it('keeps the cached updateAvailable when the backend answers only for other resources', () => {
+    const { resources, isChanged } = reconcileCachedResources(
+      [INSTALLED_WITH_UPDATE],
+      ['ABC123AAAA'],
+      { somethingElse: false },
+    );
+
+    expect(resources[0].updateAvailable).toBe(true);
+    expect(isChanged).toBe(false);
+  });
+
+  it('clears updateAvailable on a resource installed elsewhere while the backend cannot answer', () => {
+    const { resources, isChanged } = reconcileCachedResources(
+      [{ ...INSTALLED_WITH_UPDATE, installed: false, projectId: '' }],
+      ['ABC123AAAA'],
+      {},
+    );
+
+    expect(resources[0].installed).toBe(true);
+    expect(resources[0].updateAvailable).toBe(false);
+    expect(isChanged).toBe(true);
+  });
+
+  it('reports no change when the backend agrees with the cache', () => {
+    const { resources, isChanged } = reconcileCachedResources(
+      [INSTALLED_WITH_UPDATE],
+      ['ABC123AAAA'],
+      { abc123: true },
+    );
+
+    expect(resources[0]).toBe(INSTALLED_WITH_UPDATE);
+    expect(isChanged).toBe(false);
+  });
+
+  it('marks a resource installed and records its project id when its project appears locally', () => {
+    const { resources, isChanged } = reconcileCachedResources(
+      [{ ...INSTALLED_WITH_UPDATE, installed: false, projectId: '' }],
+      ['ABC123AAAA'],
+      { abc123: false },
+    );
+
+    expect(resources[0].installed).toBe(true);
+    expect(resources[0].projectId).toBe('ABC123AAAA');
+    expect(isChanged).toBe(true);
+  });
+
+  it('marks a resource uninstalled and clears its project id when its project is gone locally', () => {
+    const { resources, isChanged } = reconcileCachedResources([INSTALLED_WITH_UPDATE], [], {
+      abc123: true,
+    });
+
+    expect(resources[0].installed).toBe(false);
+    expect(resources[0].projectId).toBe('');
+    expect(isChanged).toBe(true);
+  });
+
+  // The backend reports `true` for everything uninstalled, since nothing installed cannot be the
+  // newest. `updateAvailable` is only meaningful while installed, so that answer must not survive
+  // into the cache.
+  it('clears updateAvailable on an uninstall even when the backend reports an update', () => {
+    const { resources, isChanged } = reconcileCachedResources([INSTALLED_WITH_UPDATE], [], {
+      abc123: true,
+    });
+
+    expect(resources[0].installed).toBe(false);
+    expect(resources[0].updateAvailable).toBe(false);
+    expect(isChanged).toBe(true);
+  });
+
+  it('keeps the backend answer on an install, where it is the authoritative fresh value', () => {
+    const { resources } = reconcileCachedResources(
+      [{ ...INSTALLED_WITH_UPDATE, installed: false, projectId: '', updateAvailable: false }],
+      ['ABC123AAAA'],
+      { abc123: true },
+    );
+
+    expect(resources[0].installed).toBe(true);
+    expect(resources[0].updateAvailable).toBe(true);
+  });
+
+  it('recovers a missing project id on a resource already cached as installed', () => {
+    const { resources, isChanged } = reconcileCachedResources(
+      [{ ...INSTALLED_WITH_UPDATE, projectId: '' }],
+      ['ABC123AAAA'],
+      { abc123: true },
+    );
+
+    expect(resources[0].installed).toBe(true);
+    expect(resources[0].projectId).toBe('ABC123AAAA');
+    expect(isChanged).toBe(true);
+  });
+
+  // An empty `dblEntryUid` would otherwise match every local project, because `''.startsWith('')`
+  // is true for every string.
+  it('does not match a resource with an empty dblEntryUid to an arbitrary local project', () => {
+    const { resources } = reconcileCachedResources(
+      [{ ...INSTALLED_WITH_UPDATE, dblEntryUid: '', installed: false, projectId: '' }],
+      ['ABC123AAAA'],
+      {},
+    );
+
+    expect(resources[0].installed).toBe(false);
+    expect(resources[0].projectId).toBe('');
+  });
+
+  // `isChanged` is a latch over the whole list, not a per-entry verdict. A per-entry assignment
+  // would be last-entry-wins, and `main.ts` would skip the cache rewrite whenever an earlier
+  // resource changed and a later one did not — reproducing the stale-flag bug for anyone with more
+  // than one resource.
+  it('reports a change when an earlier resource changes and a later one does not', () => {
+    const laterUnchanged: DblResourceData = {
+      ...INSTALLED_WITH_UPDATE,
+      dblEntryUid: 'def456',
+      displayName: 'ASV',
+      projectId: 'DEF456AAAA',
+    };
+
+    const { resources, isChanged } = reconcileCachedResources(
+      [INSTALLED_WITH_UPDATE, laterUnchanged],
+      ['ABC123AAAA', 'DEF456AAAA'],
+      { abc123: false, def456: true },
+    );
+
+    expect(resources).toHaveLength(2);
+    expect(resources[0].updateAvailable).toBe(false);
+    expect(resources[1]).toBe(laterUnchanged);
+    expect(isChanged).toBe(true);
+  });
+});

--- a/extensions/src/platform-get-resources/src/resources-cache.util.ts
+++ b/extensions/src/platform-get-resources/src/resources-cache.util.ts
@@ -1,0 +1,73 @@
+import type { DblResourceData } from 'platform-bible-utils';
+import type { DblResourceUpdateStatus } from 'platform-get-resources';
+
+/** Result of reconciling the cached DBL resource list against current local state. */
+export type ReconciledCachedResources = {
+  /** The reconciled resource list. Entries that did not change are the same objects passed in. */
+  resources: DblResourceData[];
+  /** Whether any entry changed, meaning the cache is worth rewriting. */
+  isChanged: boolean;
+};
+
+/**
+ * Bring the cached DBL resource list back in line with current local state.
+ *
+ * @param cachedResources Resource list from the cache.
+ * @param localProjectIds Ids of the Scripture projects currently present locally.
+ * @param updateStatus Freshly computed update availability from the backend, or `undefined` if it
+ *   could not be determined. Resources absent from it keep their cached `updateAvailable`.
+ * @returns The reconciled list and whether anything changed.
+ */
+export function reconcileCachedResources(
+  cachedResources: DblResourceData[],
+  localProjectIds: string[],
+  updateStatus: DblResourceUpdateStatus | undefined,
+): ReconciledCachedResources {
+  let isChanged = false;
+
+  const resources = cachedResources.map((resource) => {
+    const matchingLocalProjectId = localProjectIds.find((localProjectId) =>
+      // If the `projectId` is defined then tries to use that
+      resource.projectId
+        ? resource.projectId === localProjectId
+        : // Otherwise uses the `dblEntryUid` which contains the first part of the project id.
+          // Guard against an empty dblEntryUid: ''.startsWith('') is true for every string.
+          resource.dblEntryUid !== '' &&
+          localProjectId.toLowerCase().startsWith(resource.dblEntryUid.toLowerCase()),
+    );
+
+    const installed = matchingLocalProjectId !== undefined;
+    const installedChanged = installed !== resource.installed;
+
+    // Prefer the backend's answer. Falling back to `false` when the installed state just changed
+    // keeps a stale "update available" from riding along with a resource that was installed or
+    // removed outside this list.
+    const installedUpdateAvailable =
+      updateStatus?.[resource.dblEntryUid] ?? (installedChanged ? false : resource.updateAvailable);
+
+    // The flag only means anything for an installed resource — "the copy on disk is out of date" —
+    // and that is the only state the list renders it in. The backend reports `true` for every
+    // uninstalled resource, because having nothing installed trivially fails its "is the installed
+    // copy the newest" test, so taking that answer at face value would persist a flag that
+    // describes nothing.
+    const updateAvailable = installed && installedUpdateAvailable;
+
+    // An installed resource's id is whichever local project it matched; an uninstalled one has
+    // none. This can differ without `installed` differing: a row cached as installed but with an
+    // empty `projectId` matches on the `dblEntryUid` prefix, so the id is recovered here.
+    const projectId = matchingLocalProjectId ?? '';
+
+    if (
+      installedChanged ||
+      updateAvailable !== resource.updateAvailable ||
+      projectId !== resource.projectId
+    ) {
+      isChanged = true;
+      return { ...resource, installed, updateAvailable, projectId };
+    }
+
+    return resource;
+  });
+
+  return { resources, isChanged };
+}

--- a/extensions/src/platform-get-resources/src/resources-cache.util.ts
+++ b/extensions/src/platform-get-resources/src/resources-cache.util.ts
@@ -26,6 +26,13 @@ export function reconcileCachedResources(
   let isChanged = false;
 
   const resources = cachedResources.map((resource) => {
+    // Deliberately NOT `doesCatalogRowCoverProject` from `platform-bible-utils`, despite the
+    // near-identical shape. That helper answers "does this row already account for this project?"
+    // and refuses a never-synced row (`installed: false, projectId: ''`) so a stale entry for a
+    // reassigned uid cannot hide a local project. This asks the opposite question — "which local
+    // project does this row correspond to?" — and a never-synced row is exactly the case it has
+    // to resolve, because recognising that such a row now has a project on disk is what marks it
+    // installed. Routing this through that helper makes every first-time install undetectable.
     const matchingLocalProjectId = localProjectIds.find((localProjectId) =>
       // If the `projectId` is defined then tries to use that
       resource.projectId

--- a/extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts
+++ b/extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts
@@ -29,8 +29,9 @@ declare module 'platform-get-resources' {
      * operation (a fetch, install, or uninstall) currently holds the provider. Treat a resource
      * missing from the result as "unknown" and keep whatever value you have.
      *
-     * Comparing revisions across the whole catalog is not free, so call it on a background refresh
-     * rather than on a path a user is waiting on.
+     * Comparing revisions across the whole catalog is not free. Prefer a background refresh; the
+     * one path that waits on it is the refresh a caller runs straight after installing, updating or
+     * removing a resource, where the user is already waiting on their own action.
      *
      * @returns Whether an update is available, keyed by DBL Entry UID.
      */
@@ -133,6 +134,18 @@ declare module 'papi-shared-types' {
      *   change the answer.
      */
     'platformGetResources.getCachedResources': () => Promise<DblResourceCatalog>;
+
+    /**
+     * Brings the catalog's derived flags (`installed`, `projectId`, `updateAvailable`) up to date
+     * and resolves once they are.
+     *
+     * `getCachedResources` does not wait for that sync, so it is always one refresh behind: it
+     * answers from the array it already has. Call this after changing local state — installing,
+     * updating or removing a resource — and then re-read the catalog, or the read will return the
+     * flags from before the change. Without it an updated resource keeps its "update available"
+     * flag until the catalog is read a second time, because nothing else about the row changes.
+     */
+    'platformGetResources.refreshResourceFlags': () => Promise<void>;
 
     /**
      * Returns locally-installed, read-only resources that are NOT in the DBL catalog (e.g. VULGP83,

--- a/extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts
+++ b/extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts
@@ -8,7 +8,33 @@ declare module 'platform-get-resources' {
     DblResources: DataProviderDataType<undefined, DblResourceData[], never>;
   };
 
+  /**
+   * Whether a newer version of each resource is available from the DBL, keyed by DBL Entry UID.
+   *
+   * Only the backend can determine this — it compares the revision of the locally installed
+   * resource against the revision in the DBL catalog — so a resource missing from the map means
+   * "unknown", and callers should keep whatever value they already have rather than guessing.
+   */
+  export type DblResourceUpdateStatus = { [dblEntryUid: string]: boolean | undefined };
+
   export type IDblResourcesProvider = IDataProvider<GetResourcesDataTypes> & {
+    /**
+     * Recomputes whether a newer version of each known resource is available from the DBL,
+     * comparing the locally installed revision against the revision in the DBL catalog already in
+     * memory.
+     *
+     * Never contacts the DBL, and gives up rather than blocking when the provider is busy, so it is
+     * cheap enough to call on a UI refresh. In exchange it answers for only what it already knows:
+     * the result is empty if the catalog has not been fetched yet this session, or if another DBL
+     * operation (a fetch, install, or uninstall) currently holds the provider. Treat a resource
+     * missing from the result as "unknown" and keep whatever value you have.
+     *
+     * Comparing revisions across the whole catalog is not free, so call it on a background refresh
+     * rather than on a path a user is waiting on.
+     *
+     * @returns Whether an update is available, keyed by DBL Entry UID.
+     */
+    recomputeDblResourcesUpdateStatus: () => Promise<DblResourceUpdateStatus>;
     /**
      * Installs or updates a DBL resource to the local filesystem
      *


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: `fix-get-resources-stale-update-flag`

**Base**: `origin/main` (`bc056ca9284`) · **Head**: `d480cc6ad53`

**Date**: 2026-09-10 (round-4 rework; originally 2026-09-01)

**Review model**: Claude Opus 5

**Files changed**: 8 (5 modified, 3 new)

## Verified end to end

**Confirmed against a real resource with a pending DBL update, on `d480cc6ad53`, in
paratext-10-studio.** Clicking Update takes the row to "Installed" in the *open* dialog — no
reopen, no restart. Also exercised: first-time install, uninstall, install failure, opening the
dialog, the resource picker, Home, the scripture text grid, Share Layout, and the cross-surface
case (install from the text grid, then open Get Resources — no stale badge).

**An earlier revision of this section claimed the same thing and was wrong.** The check behind it
did not distinguish "the row cleared in place" from "the row cleared after the dialog was
reopened", and it was in fact the latter — round 4's finding 1 was correct, and the defect was
still present at that point. It is fixed now (`b0780a2`, `c1b94261`), and the re-check above was
run specifically against that distinction.

## Overview

Get Resources kept showing an "Update" button on a resource that had already been updated, for the
rest of the session. `platformGetResources.getCachedResources` is the only data source the Get
Resources page, Home, the resource picker, Share Layout, the scripture text grid and
`use-dbl-resource-catalog.hook` read — six consumers. Its sync reconciled just the `installed` flag
against local project metadata; it never recomputed `updateAvailable`, and its one cache-rewrite
branch fired only when `installed` flipped. Updating an already-installed resource leaves
`installed` true on both sides, so the stale flag survived. The C# provider does fire
`SendDataUpdateEvent(DBL_RESOURCES, …)` after an install, but nothing has subscribed to that data
type since the cache replaced the front end's `useData` subscription (zero `.DblResources(` call
sites repo-wide), so that event refreshes nothing.

The fix adds a no-network C# provider function, `recomputeDblResourcesUpdateStatus`, which
re-evaluates `InstallableResource.IsNewerThanCurrentlyInstalled()` over the catalog snapshot already
in memory. `syncInstalledFlags` applies it alongside the `installed` check; because that sync is
single-flighted by `ensureInstalledFlagsSynced` and runs in the background, the recompute happens at
most once at a time and never on a path a caller waits on. The reconciliation logic moved into a
pure, unit-tested util. A resource absent from the backend's answer keeps its cached value, so a
not-yet-loaded catalog or a busy provider degrades to the previous behavior rather than guessing.

Cost is bounded by gathering the installed DBL uids in **one** pass over the project collection and
consulting ParatextData only for entries in that set. `InstallableResource.ExistingScrText` is a
computed property with no backing field that enumerates the whole collection on every access, so
asking each of ~1850 catalog entries whether it is installed would cost ~1850 full scans — twice
over for an installed entry (once via `Installed`, once inside `IsNewerThanCurrentlyInstalled`), and
gating the loop on `Installed` does not help because that property is the same lookup. An entry
outside the set is reported as having an update available, which is exactly what
`IsNewerThanCurrentlyInstalled` returns for anything uninstalled.

Three review rounds ran against this branch: a four-pass analysis (api / style / compliance / ux), a
follow-up correctness pass, and a 22-finding review from @katherinejensen00 that this revision
answers in full.

## API Changes

- `extensions/src/platform-get-resources/src/types/platform-get-resources.d.ts`: added
  `recomputeDblResourcesUpdateStatus: () => Promise<DblResourceUpdateStatus>` to the exported
  `IDblResourcesProvider` type, and a new exported type `DblResourceUpdateStatus`
  (`{ [dblEntryUid: string]: boolean | undefined }`). Additions only — nothing removed or narrowed.
- `c-sharp/Projects/DigitalBibleLibrary/DblDownloadableDataProvider.cs`: `DblResourcesDataProvider`
  registers a new function `recomputeDblResourcesUpdateStatus` returning `Dictionary<string, bool>`,
  carrying an explicit `[NetworkTimeout]` rather than inheriting the 30 s default. The method and
  the extracted `ProjectUpdateStatus` are `internal` (not `private`) so `c-sharp-tests` can exercise
  them via the existing `InternalsVisibleTo`.
- `lib/platform-bible-react/`, `lib/platform-bible-utils/`, `lib/papi-dts/papi.d.ts`: no changes.
- Extension-internal (not a declared API surface): new module `resources-cache.util.ts` exporting
  `reconcileCachedResources` and `ReconciledCachedResources`.

## Findings

Rounds 1 and 2 (16 findings) were resolved before the third round; their detail is in this PR's
earlier revisions and in `adr-dbl-cache-recompute-on-read`. The list below is round 3.

### Round 3 — @katherinejensen00, 22 findings

**Fixed (14):**

- [x] **1. Branch was 13 (by then 20) commits behind main, which had rewritten this function —
      Critical.** Rebased. Main's PR #2630 had restructured `getCachedResources` into a
      single-flight background `syncInstalledFlags()` and changed the project filter to
      `platform.base`; the fix is re-derived on top of that rather than reverting main's mutex
      guarding. The decision-log conflict was resolved as a slug-keyed insert, not "keep both
      sides".
- [x] **2, 7. The 250 ms gate could not deliver its stated guarantee, and the ADR argued against
      it.** Dissolved by the rebase, as the reviewer predicted. The one caller now sits inside
      `ensureInstalledFlagsSynced`'s single flight, so concurrent sibling recomputes are
      structurally impossible and no caller awaits the result. The wait bought nothing, so the gate
      is non-waiting again — which is what the decision log already described.
- [x] **3, 5. ~1850 live `ScrTextCollection` scans per call, with no behavioral coverage.** Loop
      extracted to `ProjectUpdateStatus(resources, installedDblIds)` with the one-pass change
      described above. The extraction made it coverable: `ExistingScrText` is `public virtual` and
      `InstallableResource` has a protected parameterless constructor, so test doubles need no REST
      client, no catalog and no live collection.
- [x] **6, 14. Single-element tests hid a class of bug; the `projectId` comment asserted an
      invariant the code did not hold.** 14 was a real defect, not just a comment — a row cached
      `{installed: true, projectId: ''}` kept `''` indefinitely. `projectId` is now recomputed
      unconditionally and included in change detection, and main's empty-`dblEntryUid` guard is
      carried into the util.
- [x] **8, 21. One throwing resource discarded the entire map; duplicate-uid handling disagreed with
      `FindResource`.** Per-entry try/catch, and `TryAdd` for first-wins.
- [x] **9. "Never waits" was inaccurate on the public surface.** Reworded, with no number restated
      in TypeScript.
- [x] **11, 13. Per-method `<summary>` blocks against convention; the wire test's suffix match.**
      One fixture-level summary, and the test now pins the full registered name via
      `Client.IsHandlerRegistered`.
- [x] **15. "unlike every other method here" was inaccurate.** Now names the methods it means.
      _(Partial correction to the finding: `InstallDblResource` and `UninstallDblResource` do load
      the catalog, via `EnsureResourcesLoadedCore()` — it is their private `*Core` helpers that do
      not. The claim was still wrong as written, because `IsGetDblResourcesAvailable` does not
      load.)_
- [x] **18. The only wire method without `[NetworkTimeout]`.** Added. Note the value is not "just
      above the gate timeout" as suggested — a non-waiting gate means the bound has to cover the
      recompute itself, which the review measured at up to 713 ms.
- [x] **19. Fast path before `Task.Run`.** Applied, and the `_hasFetchedResources` comment now
      documents that it may be read without the gate as a one-way hint (it is only ever set `true`,
      in `FetchResourcesCore`) rather than silently violating its own stated invariant.
- [x] **22. The one combination that decides the design question.** Settled rather than merely
      pinned: `updateAvailable` is now cleared for any row reconciled as not installed. The backend
      reports `true` for everything uninstalled — nothing installed trivially fails its "is the
      installed copy the newest" test — so taking that at face value persisted a flag that
      described nothing. The flag now means what the list renders it as.
- [x] **12, 16, 17. Decision-log corrections.** Six consumers not three; the garbled `` `adr` ``
      -adjacent PT-4268 cross-reference; and the unrelated failed-install NRE removed from
      Consequences. Entry re-inserted in byte-order slug position per the log's own rule.

**Closed rather than actioned (3):**

- [ ] **4. Five of six callers pay for a value they never render.** The premise — each blocking the
      full 250 ms — is gone now that the recompute runs inside the fire-and-forget background sync,
      and finding 3 removed the CPU cost. An opt-in parameter would now add a cross-language
      contract knob for no measurable gain.
- [ ] **10. The degradation path is untested.** Left to the util's coverage. Post-rebase the
      extraction is larger than costed, since `getLocalProjectMetadata`'s retry logic and the
      `!hasResourceProjects` early return now share the same function.
- [ ] **20. Two independent round trips run sequentially.** Skipped deliberately: the latency is on
      a background path nobody waits on, and parallelizing would fire the recompute even when the
      `!hasResourceProjects` early return discards it — which includes every startup before the C#
      PDPF registers.

**Deferred as pre-existing (1):** finding 17's failed-install `NullReferenceException` is real but
unrelated to this change. Removed from the ADR; needs its own ticket.

### Template Propagation

#### Shared Regions Modified

None. No `#region shared with` markers exist in any changed or added file.

#### Extension Config Changes

None. The only files touched under `extensions/` are source and type-declaration files inside
`extensions/src/platform-get-resources/src/`.

## Positive Observations

- Extracting the reconciliation into a pure function made previously untestable `main.ts` logic
  unit-testable, following the established `<name>.util.ts` + `<name>.util.test.ts` convention.
- `reconcileCachedResources` preserves object identity for unchanged entries, and a test pins it
  (`expect(resources[1]).toBe(laterUnchanged)`) — the contract `main.ts` relies on to avoid
  rewriting the cache file unnecessarily.
- The degradation design is consistent across the process boundary and documented on both sides: C#
  returns an empty map rather than blocking; TS treats a missing key as "unknown" and keeps the
  cached value.
- The one-pass installed-uid set reaches the same answer ParatextData does by construction, rather
  than by an approximation that could drift: the value assigned to an entry outside the set is
  literally what `IsNewerThanCurrentlyInstalled` returns for anything uninstalled.
- No new user-visible strings and no new project-data write patterns, so localization has nothing
  outstanding and `SendReceiveWriteLockCoverageTests` is unaffected.

## Interview Notes

**Author's stated purpose**: fix Get Resources showing "Update" after a resource has already been
updated, reported as happening in Power mode.

**Key context for the reviewer:**

- **This is not Power-specific.** There is no interface-mode gating anywhere in
  `platform-get-resources`; the defect reproduces wherever the Get Resources page is reachable.
- **It is a regression from the caching layer.** Before PR #2271 the web view subscribed via
  `useData(...).DblResources(...)`, so the post-install `SendDataUpdateEvent` re-ran
  `getDblResources` and recomputed the flag. The cache replaced the subscription without replacing
  the invalidation.
- **The design choice was recompute-on-read over invalidate-on-write**, recorded as
  `adr-dbl-cache-recompute-on-read`.
- **`updateAvailable` genuinely cannot be computed in TypeScript.** The author pushed back and it
  was re-verified: the DBL-side revision is dropped when C# projects `InstallableResource` into
  `DblResourceData`, and the *installed* revision is an entry name under `.dbl/revision/` inside the
  password-protected `.p8z`, read through ParatextData's zip file manager. `Revision` appears
  nowhere in `c-sharp/`. Sending both sides to TS would still need a C# call to read the installed
  half, so it removes no round trip while adding ~10 contract fields and a TS copy of a five-branch
  precedence chain that would drift when the ParatextData pin moves.
- **Correctness of the no-fetch approach rests on decompiled ParatextData, not observation.**
  `ExistingScrText` is a live `ScrTextCollection` lookup on every access, and `InternalInstall` calls
  `scrText.SetFileManager(null)` before overwriting the `.p8z`, so `DBLResourceSettings` is rebuilt
  from the new file. Read from the pinned 9.5.0.24 assembly (ILSpy) on 2026-09-04; ParatextData
  source is not available locally, so this wants re-probing when the pin moves. The ADR now records
  the version and date.
- **The one-pass predicate is deliberately narrower than `ExistingScrText`'s.** It matches only that
  property's main branch, omitting the null-`DBLEntryUid`-matched-by-name branch and the
  `SourceLanguageResource` fallback, because this provider serves only whitelisted DBL catalog
  entries — always uid-carrying, always `ResourceType.DBL`. Documented at the call site.

**Retracted claim — a failed install does *not* report success.** An earlier draft of this review
stated that `InstallDblResourceCore`'s `ScrTextCollection.IsPresent` check passes trivially for an
already-installed resource, so a failed *update* would be recorded as successful. That was wrong.
`IsPresent(ScrText)` resolves to `scrText.Guid != null && scrTextsById.ContainsKey(scrText.Guid)` —
it inspects `InstalledScrText`, not whether the resource exists on disk. `InstalledScrText` is
assigned only as the last statement of `InternalInstall`, after every failure path has returned, so
on a failed install it is `null`, `IsPresent(null)` throws `NullReferenceException`, and that
propagates through JSON-RPC to the web view's `.catch`. **Failures surface** — just as an NRE rather
than the localized message, which is finding 17's deferred ticket.

Related and confirmed correct as written: `Install()` returns `bool`, but the value is set true only
inside `foreach (… ProjectFiles("*.font"))` — it means "fonts were extracted", not "install
succeeded". The existing comment "we don't get any info telling if the installation succeeded or
failed" is accurate and discarding the return value is right.

## In-Review Quality Check

- **Extension tests**: 70 passed across 6 files in `platform-get-resources`; the reconcile util is
  at 14 cases, up from 9. The 5 added cases were mutation-verified — the `isChanged` latch, the
  `projectId` recovery, the empty-`dblEntryUid` guard, and the two `updateAvailable`-when-not-
  installed cases each kill exactly their own mutant.
- **C# tests**: **1724 passed, 0 failed, 6 skipped** (full suite). The 6
  `LocalParatextProjectsWatcherTests` failures reported in the previous round as pre-existing do
  **not** reproduce on this rebased tree.
- **C# mutation checks** on the new `ProjectUpdateStatus`: keying by `Name` instead of
  `DBLEntryUid.Id` → 5 red; dropping the installed-set short-circuit → 3 red; removing the per-entry
  try/catch → 1 red; the indexer instead of `TryAdd` → 1 red.
  - Known-surviving mutant, deliberately: removing the `!_hasFetchedResources` fast path (finding 19)
    leaves all 7 tests green. With `_resources` empty the loop is a no-op either way and the gate
    check immediately after returns the same empty map, so that fast path is a pure optimization
    with no observable behavior. The behavior it fronts — an empty result before the catalog loads —
    is pinned; a test for the dispatch itself would be timing-dependent.
- **C# build**: 0 errors (pre-existing warnings in unrelated test files only).
- **Lint**: `npm run lint` exits 0. One pre-existing warning (0 errors) in
  `unsubscriber-async-list.test.ts`, untouched here.
  - Note for a fresh worktree: lint initially fails on
    `Unable to resolve path to module '../../../release/app/buildInfo.json'`. That file is gitignored
    and generated; run `npx ts-node .erb/scripts/generate-dev-build-info.ts`, then delete
    `.eslintcache` (eslint runs with `--cache` and holds the stale verdict).
- **Formatting**: csharpier and prettier applied; nothing outside the change was reformatted.
- **Typecheck**: skipped per the author's standing preference (lint + build treated as sufficient).

## Suggested Review Focus

- [ ] **Recompute-on-read vs. invalidate-on-write** (`adr-dbl-cache-recompute-on-read`). Still the
      load-bearing design decision, and it collides with PT-4268's scope — that ticket's stated
      premise ("the provider's install path fires the event so the Get Resources UI refreshes") is
      already false and should be re-scoped against this entry.
- [ ] **The narrowed one-pass predicate.** It assumes every entry this provider serves carries a DBL
      uid and is `ResourceType.DBL`. That holds for the whitelisted catalog today; it is the
      assumption that breaks first if the provider's inputs ever widen.
- [ ] **The ParatextData pin.** The no-fetch correctness argument is read off the 9.5.0.24 assembly.
      Worth a look at whether the ADR's recorded version + date is enough of a tripwire, or whether
      this wants a test.
- [ ] **Finding 17's ticket** — a failed install surfaces as an NRE rather than the localized
      `%getResources_errorInstallResource_installationFailed%`. Pre-existing, removed from the ADR,
      not yet filed.
- [ ] **The two deferred pre-existing minors**: the `TODO(PT-4268)` code pointer at the dead
      `SendDataUpdateEvent` site, and the `projectId`-starts-with-`dblEntryUid` invariant duplicated
      in `use-commentary-marker-styles.hook.ts`.
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2751)
<!-- Reviewable:end -->

