### PR TITLE
PT-4481: Test the close-all prompt's abort and localization paths

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -9,7 +9,6 @@
 import {
   app,
   BrowserWindow,
-  dialog,
   ipcMain,
   powerMonitor,
   RenderProcessGoneDetails,
@@ -47,10 +46,7 @@ import { startNetworkObjectStatusService } from '@main/services/network-object-s
 import { registerPowerMonitorListeners } from '@main/services/power-monitor-logging.service';
 import { startProjectLookupService } from '@main/services/project-lookup.service-host';
 import { performShutdownTasks, performWindowCloseTasks } from '@main/shutdown-tasks';
-import type {
-  CloseAllAnswer,
-  WindowCloseDecision,
-} from '@main/services/window-close-decision.service';
+import type { WindowCloseDecision } from '@main/services/window-close-decision.service';
 import { performStartupTasks } from '@main/startup-tasks';
 import { startNotificationServiceRouter } from '@main/services/notification.service-router';
 import {
@@ -79,7 +75,6 @@ import {
   resetShutdownLatchesForNewSession,
   runShutdownTasksOnce,
   shouldWindowCloseAbortReadinessWait,
-  whenQuitRequested,
 } from '@main/services/shutdown-latch.service';
 import { setAppShutdownSignal } from '@main/services/rpc-server';
 import {
@@ -110,6 +105,7 @@ import {
   setFocusedWindowId,
   setWindowPendingContentPredicate,
 } from '@main/services/window-state.service';
+import { confirmCloseAllWindows } from '@main/services/close-all-prompt.service';
 import { decideWindowClose } from '@main/services/window-close-decision.service';
 import {
   assignEntryToWindow,
@@ -165,7 +161,6 @@ import {
 import { GET_METHODS } from '@shared/data/rpc.model';
 import { PROJECT_INTERFACE_PLATFORM_BASE } from '@shared/models/project-data-provider.model';
 import * as commandService from '@shared/services/command.service';
-import { localizationService } from '@shared/services/localization.service';
 import { logger } from '@shared/services/logger.service';
 import { readFile } from 'fs/promises';
 import { networkObjectService } from '@shared/services/network-object.service';
@@ -179,7 +174,6 @@ import { CommandNames, SettingTypes } from 'papi-shared-types';
 import {
   getErrorMessage,
   isPlatformError,
-  LocalizeKey,
   serialize,
   ThemeDefinitionExpanded,
   UnsubscriberAsyncList,
@@ -273,15 +267,6 @@ const PROCESS_CLOSE_TIME_OUT_MS = 2000;
  * screen a moment longer.
  */
 const WINDOW_CLOSE_TIME_OUT_MS = 10000;
-
-/**
- * How long the close-all question waits for its localized text before showing English instead.
- *
- * Short on purpose: the user has already clicked ✕ and the window is held open with nothing on
- * screen until the question appears, so a wait long enough to notice is worse than untranslated
- * text.
- */
-const CLOSE_PROMPT_LOCALIZE_TIME_OUT_MS = 3000;
 
 /** How long to coalesce a window's resize/move events before capturing its bounds */
 const BOUNDS_CAPTURE_DEBOUNCE_MS = 100;
@@ -1645,99 +1630,6 @@ async function main() {
       }
     }
   };
-
-  /**
-   * Ask the user whether closing the primary window should close every window. Shown modal to that
-   * window so it cannot be lost behind another one.
-   *
-   * A string lookup that fails must not decide the close: the dialog shows with its English text
-   * rather than the window refusing to close, which is the worse outcome.
-   *
-   * @param primaryWindow The window whose close is being confirmed
-   */
-  async function confirmCloseAllWindows(primaryWindow: BrowserWindow): Promise<CloseAllAnswer> {
-    // `satisfies` rather than an annotation, so each stays its own literal type. Annotating them
-    // `LocalizeKey` widens them to the template `%${string}%`, which turns the record below into a
-    // pattern index signature — and then a mistyped key reads back `undefined` with no error, and
-    // goes into the dialog as a missing title or a blank button.
-    const messageKey = '%closeApp_confirm_message%' satisfies LocalizeKey;
-    const detailKey = '%closeApp_confirm_detail%' satisfies LocalizeKey;
-    const closeAllKey = '%closeApp_confirm_closeAll%' satisfies LocalizeKey;
-    // The shared cancel string rather than one of this dialog's own: the localization guide forbids
-    // duplicating a generic string that already exists, and this button says exactly what it says
-    const cancelKey = '%general_cancel%' satisfies LocalizeKey;
-    const fallbackStrings: Record<
-      typeof messageKey | typeof detailKey | typeof closeAllKey | typeof cancelKey,
-      string
-    > = {
-      [messageKey]: 'Close the application?',
-      [detailKey]:
-        'All windows will close. They will be restored the next time you open the application.',
-      [closeAllKey]: 'Close all windows',
-      [cancelKey]: 'Cancel',
-    };
-    let strings = fallbackStrings;
-    try {
-      // Bounded, because this is a NETWORK call to the extension host and the ✕ is already
-      // committed by the time it runs: a rejection reaches the English fallback below, but a hang
-      // would leave the window prevented from closing with no question on screen and every further
-      // ✕ a silent no-op — the close button would simply look dead. English on time beats
-      // localized eventually.
-      //
-      // Raced against a throwing timer rather than `waitForDuration`, which is otherwise the shape
-      // for this: that helper is built on `Promise.any`, so it never rejects — a request that fails
-      // FAST would be swallowed and the question held back for the whole bound before falling back
-      // to English, which is the delay this bound exists to prevent.
-      strings = {
-        ...fallbackStrings,
-        ...(await Promise.race([
-          localizationService.getLocalizedStrings({
-            localizeKeys: [messageKey, detailKey, closeAllKey, cancelKey],
-          }),
-          wait(CLOSE_PROMPT_LOCALIZE_TIME_OUT_MS).then<never>(() => {
-            throw new Error(`no answer within ${CLOSE_PROMPT_LOCALIZE_TIME_OUT_MS} ms`);
-          }),
-        ])),
-      };
-    } catch (e) {
-      logger.warn(
-        `Could not localize the close-all prompt; showing English: ${getErrorMessage(e)}`,
-      );
-    }
-    const closeAllIndex = 0;
-    const cancelIndex = 1;
-    // A quit arriving while the question is open takes the box down with it. Electron closes a
-    // signalled message box and answers as if the user had cancelled — so the ANSWER is not what
-    // decides here, the quit latch is; without this the question would sit on screen, inert,
-    // through the whole shutdown, and a click on it would be followed by the app quitting anyway.
-    // Parented to the primary window, which is what makes `signal` work on macOS too.
-    const dismissOnQuit = new AbortController();
-    // Nothing awaits this: it exists to fire once, whenever the quit comes, and the box may well
-    // have been answered and gone by then — aborting a finished box is a no-op
-    const armDismissalOnQuit = async () => {
-      await whenQuitRequested();
-      dismissOnQuit.abort();
-    };
-    armDismissalOnQuit().catch((e: unknown) =>
-      logger.warn(`Could not arm the close-all dismissal: ${getErrorMessage(e)}`),
-    );
-    const { response } = await dialog.showMessageBox(primaryWindow, {
-      signal: dismissOnQuit.signal,
-      type: 'question',
-      // No `title`: macOS hides it, and on Windows and Linux it would print the question twice
-      message: strings[messageKey],
-      detail: strings[detailKey],
-      buttons: [strings[closeAllKey], strings[cancelKey]],
-      // The safe choice is what Enter takes: this question exists to interrupt a click whose reach
-      // is wider than expected, so the wide-reaching button must not also be the one a reflex press
-      // lands on. Button order is set by `buttons` above, not by this.
-      defaultId: cancelIndex,
-      // Esc and the window manager's dismiss both land here, so neither can close every window
-      cancelId: cancelIndex,
-      noLink: true,
-    });
-    return response === closeAllIndex ? 'close-all' : 'cancel';
-  }
 
   app.on('window-all-closed', () => {
     // The macOS convention of keeping the application resident after its last window closes only

--- a/src/main/services/__tests__/close-all-prompt.test.ts
+++ b/src/main/services/__tests__/close-all-prompt.test.ts
@@ -1,0 +1,187 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import type { BrowserWindow, MessageBoxOptions, MessageBoxReturnValue } from 'electron';
+import { confirmCloseAllWindows } from '@main/services/close-all-prompt.service';
+import {
+  markQuitRequested,
+  resetShutdownLatchesForNewSession,
+} from '@main/services/shutdown-latch.service';
+import { localizationService } from '@shared/services/localization.service';
+import { logger } from '@shared/services/logger.service';
+
+/**
+ * Declared through `vi.hoisted` and typed to the two-argument call this prompt actually makes.
+ * Reaching for it through Electron's own `dialog.showMessageBox` type instead would resolve to the
+ * single-argument overload, and the parent window the prompt passes would be invisible to the
+ * types.
+ */
+const { showMessageBox } = vi.hoisted(() => ({
+  showMessageBox:
+    vi.fn<(parent: BrowserWindow, options: MessageBoxOptions) => Promise<MessageBoxReturnValue>>(),
+}));
+
+vi.mock('electron', () => ({ dialog: { showMessageBox } }));
+
+vi.mock('@shared/services/localization.service', () => ({
+  localizationService: { getLocalizedStrings: vi.fn() },
+}));
+
+vi.mock('@shared/services/logger.service', () => ({
+  logger: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), debug: vi.fn() },
+}));
+
+/** The English text the prompt falls back to when localization does not answer */
+const ENGLISH = {
+  message: 'Close the application?',
+  detail: 'All windows will close. They will be restored the next time you open the application.',
+  closeAll: 'Close all windows',
+  cancel: 'Cancel',
+};
+
+/** What a working localization service returns, chosen to be unmistakably not the English above */
+const LOCALIZED = {
+  '%closeApp_confirm_message%': '¿Cerrar la aplicación?',
+  '%closeApp_confirm_detail%': 'Se cerrarán todas las ventanas.',
+  '%closeApp_confirm_closeAll%': 'Cerrar todas las ventanas',
+  '%general_cancel%': 'Cancelar',
+};
+
+const CLOSE_ALL_INDEX = 0;
+const CANCEL_INDEX = 1;
+
+/**
+ * Stand-in for the primary window. The prompt only passes it to `showMessageBox` as the parent, so
+ * nothing on it is read.
+ */
+function fakeWindow(id: number): BrowserWindow {
+  // Constructing a real BrowserWindow needs the Electron runtime, and the prompt never touches it
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  return { id } as BrowserWindow;
+}
+
+/** The options the prompt handed to the most recent `showMessageBox` call */
+function optionsFromLastCall(): MessageBoxOptions {
+  const call = showMessageBox.mock.calls.at(-1);
+  if (!call) throw new Error('showMessageBox was never called');
+  return call[1];
+}
+
+/** Answer the box with the given button, for tests whose subject is the setup rather than the answer */
+function answerWith(response: number) {
+  showMessageBox.mockResolvedValue({ response, checkboxChecked: false });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetShutdownLatchesForNewSession();
+  answerWith(CANCEL_INDEX);
+  vi.mocked(localizationService.getLocalizedStrings).mockResolvedValue(LOCALIZED);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('the close-all confirmation prompt', () => {
+  describe('dismissal when a quit arrives while the question is open', () => {
+    test('gives the box a signal that is not already aborted, and aborts it when the quit comes', async () => {
+      let releaseBox: (value: MessageBoxReturnValue) => void = () => {};
+      showMessageBox.mockImplementation(
+        async () =>
+          new Promise<MessageBoxReturnValue>((resolve) => {
+            releaseBox = resolve;
+          }),
+      );
+
+      const answer = confirmCloseAllWindows(fakeWindow(1));
+      await vi.waitFor(() => expect(showMessageBox).toHaveBeenCalled());
+
+      const { signal } = optionsFromLastCall();
+      // Asserting the signal rather than the answer, because the answer cannot tell a working
+      // abort from a broken one: the caller races this against the quit latch, and the latch
+      // decides either way. A box shown with no signal, or with one nothing ever aborts, would
+      // leave the question on screen through the whole shutdown.
+      expect(signal).toBeInstanceOf(AbortSignal);
+      // The control for the assertion below: a signal that arrived already aborted would satisfy
+      // it for free
+      expect(signal?.aborted).toBe(false);
+
+      markQuitRequested();
+      await vi.waitFor(() => expect(signal?.aborted).toBe(true));
+
+      releaseBox({ response: CANCEL_INDEX, checkboxChecked: false });
+      await answer;
+    });
+  });
+
+  describe('localization', () => {
+    test('shows the localized text when localization answers within the bound', async () => {
+      await confirmCloseAllWindows(fakeWindow(1));
+
+      const options = optionsFromLastCall();
+      expect(options.message).toBe(LOCALIZED['%closeApp_confirm_message%']);
+      expect(options.detail).toBe(LOCALIZED['%closeApp_confirm_detail%']);
+      expect(options.buttons).toEqual([
+        LOCALIZED['%closeApp_confirm_closeAll%'],
+        LOCALIZED['%general_cancel%'],
+      ]);
+      expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    test('falls back to English once the bound passes when localization never answers', async () => {
+      vi.useFakeTimers();
+      // Never settles, so only the bound can end the race
+      vi.mocked(localizationService.getLocalizedStrings).mockReturnValue(new Promise(() => {}));
+
+      const answer = confirmCloseAllWindows(fakeWindow(1));
+
+      // Nothing may reach the screen before the bound passes: a box shown early would mean the
+      // race never waited for localization at all
+      await Promise.resolve();
+      expect(showMessageBox).not.toHaveBeenCalled();
+
+      await vi.advanceTimersByTimeAsync(3000);
+      await answer;
+
+      const options = optionsFromLastCall();
+      expect(options.message).toBe(ENGLISH.message);
+      expect(options.detail).toBe(ENGLISH.detail);
+      expect(options.buttons).toEqual([ENGLISH.closeAll, ENGLISH.cancel]);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    test('falls back at once when localization fails, rather than waiting out the bound', async () => {
+      // Deliberately on real timers, never advanced: a fallback that only arrived when the bound
+      // elapsed would hang here. This is why the prompt races a throwing timer instead of using
+      // `waitForDuration`, whose `Promise.any` would swallow a fast failure and hold the question
+      // back for the whole bound.
+      vi.mocked(localizationService.getLocalizedStrings).mockRejectedValue(
+        new Error('localization is unreachable'),
+      );
+
+      await confirmCloseAllWindows(fakeWindow(1));
+
+      const options = optionsFromLastCall();
+      expect(options.message).toBe(ENGLISH.message);
+      expect(options.buttons).toEqual([ENGLISH.closeAll, ENGLISH.cancel]);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+
+  describe('the answer it reports', () => {
+    test('reports close-all for the first button and cancel for the second', async () => {
+      answerWith(CLOSE_ALL_INDEX);
+      expect(await confirmCloseAllWindows(fakeWindow(1))).toBe('close-all');
+
+      answerWith(CANCEL_INDEX);
+      expect(await confirmCloseAllWindows(fakeWindow(1))).toBe('cancel');
+    });
+
+    test('makes Cancel both the default and the dismiss answer, so neither Enter nor Esc closes everything', async () => {
+      await confirmCloseAllWindows(fakeWindow(1));
+
+      const options = optionsFromLastCall();
+      expect(options.defaultId).toBe(CANCEL_INDEX);
+      expect(options.cancelId).toBe(CANCEL_INDEX);
+    });
+  });
+});

--- a/src/main/services/close-all-prompt.service.ts
+++ b/src/main/services/close-all-prompt.service.ts
@@ -1,0 +1,108 @@
+import { BrowserWindow, dialog } from 'electron';
+import { getErrorMessage, LocalizeKey, wait } from 'platform-bible-utils';
+import { logger } from '@shared/services/logger.service';
+import { localizationService } from '@shared/services/localization.service';
+import { whenQuitRequested } from '@main/services/shutdown-latch.service';
+import type { CloseAllAnswer } from '@main/services/window-close-decision.service';
+
+/**
+ * How long to wait for the close prompt's localized strings before showing it in English.
+ *
+ * Short on purpose: the user has already clicked ✕ and the window is held open with nothing on
+ * screen until the question appears, so a wait long enough to notice is worse than untranslated
+ * text.
+ */
+const CLOSE_PROMPT_LOCALIZE_TIME_OUT_MS = 3000;
+
+/**
+ * Ask the user whether closing the primary window should close every window. Shown modal to that
+ * window so it cannot be lost behind another one.
+ *
+ * A string lookup that fails must not decide the close: the dialog shows with its English text
+ * rather than the window refusing to close, which is the worse outcome.
+ *
+ * @param primaryWindow The window whose close is being confirmed
+ */
+export async function confirmCloseAllWindows(
+  primaryWindow: BrowserWindow,
+): Promise<CloseAllAnswer> {
+  // `satisfies` rather than an annotation, so each stays its own literal type. Annotating them
+  // `LocalizeKey` widens them to the template `%${string}%`, which turns the record below into a
+  // pattern index signature — and then a mistyped key reads back `undefined` with no error, and
+  // goes into the dialog as a missing title or a blank button.
+  const messageKey = '%closeApp_confirm_message%' satisfies LocalizeKey;
+  const detailKey = '%closeApp_confirm_detail%' satisfies LocalizeKey;
+  const closeAllKey = '%closeApp_confirm_closeAll%' satisfies LocalizeKey;
+  // The shared cancel string rather than one of this dialog's own: the localization guide forbids
+  // duplicating a generic string that already exists, and this button says exactly what it says
+  const cancelKey = '%general_cancel%' satisfies LocalizeKey;
+  const fallbackStrings: Record<
+    typeof messageKey | typeof detailKey | typeof closeAllKey | typeof cancelKey,
+    string
+  > = {
+    [messageKey]: 'Close the application?',
+    [detailKey]:
+      'All windows will close. They will be restored the next time you open the application.',
+    [closeAllKey]: 'Close all windows',
+    [cancelKey]: 'Cancel',
+  };
+  let strings = fallbackStrings;
+  try {
+    // Bounded, because this is a NETWORK call to the extension host and the ✕ is already
+    // committed by the time it runs: a rejection reaches the English fallback below, but a hang
+    // would leave the window prevented from closing with no question on screen and every further
+    // ✕ a silent no-op — the close button would simply look dead. English on time beats
+    // localized eventually.
+    //
+    // Raced against a throwing timer rather than `waitForDuration`, which is otherwise the shape
+    // for this: that helper is built on `Promise.any`, so it never rejects — a request that fails
+    // FAST would be swallowed and the question held back for the whole bound before falling back
+    // to English, which is the delay this bound exists to prevent.
+    strings = {
+      ...fallbackStrings,
+      ...(await Promise.race([
+        localizationService.getLocalizedStrings({
+          localizeKeys: [messageKey, detailKey, closeAllKey, cancelKey],
+        }),
+        wait(CLOSE_PROMPT_LOCALIZE_TIME_OUT_MS).then<never>(() => {
+          throw new Error(`no answer within ${CLOSE_PROMPT_LOCALIZE_TIME_OUT_MS} ms`);
+        }),
+      ])),
+    };
+  } catch (e) {
+    logger.warn(`Could not localize the close-all prompt; showing English: ${getErrorMessage(e)}`);
+  }
+  const closeAllIndex = 0;
+  const cancelIndex = 1;
+  // A quit arriving while the question is open takes the box down with it. Electron closes a
+  // signalled message box and answers as if the user had cancelled — so the ANSWER is not what
+  // decides here, the quit latch is; without this the question would sit on screen, inert,
+  // through the whole shutdown, and a click on it would be followed by the app quitting anyway.
+  // Parented to the primary window, which is what makes `signal` work on macOS too.
+  const dismissOnQuit = new AbortController();
+  // Nothing awaits this: it exists to fire once, whenever the quit comes, and the box may well
+  // have been answered and gone by then — aborting a finished box is a no-op
+  const armDismissalOnQuit = async () => {
+    await whenQuitRequested();
+    dismissOnQuit.abort();
+  };
+  armDismissalOnQuit().catch((e: unknown) =>
+    logger.warn(`Could not arm the close-all dismissal: ${getErrorMessage(e)}`),
+  );
+  const { response } = await dialog.showMessageBox(primaryWindow, {
+    signal: dismissOnQuit.signal,
+    type: 'question',
+    // No `title`: macOS hides it, and on Windows and Linux it would print the question twice
+    message: strings[messageKey],
+    detail: strings[detailKey],
+    buttons: [strings[closeAllKey], strings[cancelKey]],
+    // The safe choice is what Enter takes: this question exists to interrupt a click whose reach
+    // is wider than expected, so the wide-reaching button must not also be the one a reflex press
+    // lands on. Button order is set by `buttons` above, not by this.
+    defaultId: cancelIndex,
+    // Esc and the window manager's dismiss both land here, so neither can close every window
+    cancelId: cancelIndex,
+    noLink: true,
+  });
+  return response === closeAllIndex ? 'close-all' : 'cancel';
+}


### PR DESCRIPTION
## Summary

`confirmCloseAllWindows` — the close-all confirmation question — was a closure inside `main()`, so nothing could reach it without a `BrowserWindow` and an Electron runtime. Three of its paths had no coverage at any level, including one that a reasonable reader would think was already covered.

It moves to `src/main/services/close-all-prompt.service.ts` **unchanged** — same strings, same button order, same `defaultId`/`cancelId` — the way `decideWindowClose` moved into `window-close-decision.service.ts` for exactly this reason. This is a test PR: no behaviour changes.

**Why review this:** part of the PT-4275 multi-window epic, as the hardening sub-task PT-4481. It came out of the `/review-paratext` sweep of #2729, where Rolf ruled these were not to be fixed in that PR.

## Changes

- **`src/main/services/close-all-prompt.service.ts`** (new) — `confirmCloseAllWindows(primaryWindow)`, lifted verbatim. `CLOSE_PROMPT_LOCALIZE_TIME_OUT_MS` moves with it, since nothing else read it.
- **`src/main/main.ts`** — −112/+1. The function, the constant, and the five imports the move orphaned (`dialog`, `CloseAllAnswer`, `whenQuitRequested`, `localizationService`, `LocalizeKey`). `wait` stayed: it is still used elsewhere.
- **`src/main/services/__tests__/close-all-prompt.test.ts`** (new) — six tests, below.

No new wire surface, and nothing here is public API, so no experimental markers apply.

## What the six tests pin

**The abort wiring** asserts the **signal** the box is given, not the answer that comes back. This is the point of the ticket: the answer cannot tell a working abort from a broken one, because the caller races this against the quit latch and the latch decides either way. A box shown with no signal — or with one nothing ever aborts — would look identical from outside while leaving the question on screen through the whole shutdown. The test checks the signal arrives un-aborted (the control, since an already-aborted signal would satisfy the next assertion for free), then that a quit flips it.

**The localization bound**, both halves, which fail differently:
- a call that never answers must give up at the bound and show English;
- a call that *fails* must fall back **at once** rather than waiting the bound out. That second case is why the race uses a throwing timer instead of `waitForDuration`, whose `Promise.any` would swallow a fast failure — a claim the code comment makes and nothing checked.

**The rest of the contract**: the localized text is used when localization answers in time; `close-all` and `cancel` map to the right buttons; and Cancel is both `defaultId` and `cancelId`, so neither Enter nor Esc can close every window.

## Mutation-checked, not merely green

Each test was broken deliberately and confirmed to fail *on its own*:

| mutation | result |
| --- | --- |
| drop `signal: dismissOnQuit.signal` from the options | dismissal test red alone (1 failed / 5 passed) |
| keep the signal, never call `.abort()` | dismissal test red alone |
| remove the bound from the race | the never-answers test hangs to timeout, red alone |
| rebuild the race in the `Promise.any` (`waitForDuration`) shape | **both** localization tests red — the fast-failure one at 3002 ms, exactly the bound it exists to avoid waiting out |

The last mutation is why the fast-failure case earns its place: it is the only test that catches that shape, and the third mutation does not touch it. Each mutation was reverted and the file confirmed byte-identical by checksum.

## The ticket's third path is deliberately not here

PT-4481 also lists the `isFirstWindow` gate on the shutdown-latch reset. It is left alone, because **the ticket is stale on that point**: the gate gained a discriminating e2e case in `a76e64e9a0d` — `window-close-rule.spec.ts:507`, "creating a window while the question is open does not strand the quit it might still receive" — which landed *after* the sweep commit the ticket was written from, and the latch primitive underneath is already unit-covered. A `count === 0` seam would only give the rule a second home.

## Testing

Root workspace suite green: 213 files, 3070 passed, 1 skipped — up from 212 / 3064, exactly the one file and six tests added here and nothing else moved. `src/main` alone: 47 files, 854 passed. `typecheck:core`, `typecheck:erb` and the root `tsconfig.json` all report 0 errors; eslint and `format:check` clean.

**`papi.d.ts` is untouched** — the expectation was stated before running, and `build:types` leaves the file byte-identical (same checksum before and after), with no generated-artifact drift.

One limitation, stated rather than hidden: the full `npm run typecheck` does not pass in the nested worktree this was built in, and the cause is the worktree, not this change. It reports 50 duplicate-identifier errors, every one pairing a local `src/types/X.d.ts` against a path six levels up that climbs out of the nested worktree into the parent repo — extensions' `typeRoots` use relative paths that survive one level of nesting, not two. The control: **none of the 50 touch `main.ts` or either new file**, and the parent worktree typechecks clean at 0 errors on the same base commit.

## Risk Level

Low — a pure extraction with no behaviour change, plus new test coverage.

## CI

This PR targets a stack base (`pt-4286-window-close-rule`), and `test.yml` only fires on `pull_request` into `main`/`release-prep`/`hotfix-*`/`ai/main`, so GitHub reports no checks here. CI was run explicitly via `workflow_dispatch`: run [33584643285](https://github.com/paranext/paranext-core/actions/runs/33584643285) on `c7775516e87`. **Every job reports `success`, and that is not the whole story.** Read from the warn steps rather than the job conclusions, because `E2E tests (Windows/macOS)` carries `continue-on-error` and its conclusion is rewritten to `success` whether it passed or not:

- **Linux is genuinely green.** `E2E tests (Linux)` is blocking, and it passed. So did type checking, both unit suites, the formatting and lint gates, packaging, and the generated-artifact staleness gate (`Verify no files changed after build`) on all three platforms.
- **Windows and macOS smoke failed and was swallowed.** `Warn on non-blocking E2E failure` ran on both — its condition is `steps.e2e-win-mac.outcome == 'failure'`, so it firing *is* the failure. Windows reported 1 failed and 1 flaky of 13.

The failures are in `ui-interaction.spec.ts` — opening the About dialog from the Help menu, opening Settings from the menu, and the toolbar book/chapter control — all `locator.click` timeouts, none of which touches the close-all prompt this PR extracts. The workflow makes these non-blocking for exactly this reason, citing chronic macOS smoke flakiness (#2336, #2338, #2357) and occasional Windows flakes.

**These are the suite's known flakes, and two experiments say so rather than one hopeful reading.**

*The same commit, run twice.* Re-dispatching this exact commit (`c7775516e87`, run 33588187265) flipped Windows from failing to clean while macOS failed again. A commit cannot cause a failure that disappears when the same commit is re-run, so at least part of this is nondeterminism by definition.

*An unrelated branch, same failures.* #2758 is a pure refactor of the web-view service router off `main`, touching nothing this PR touches. Its Windows job (run 33588674627) failed the same way, concentrated in the same places: `ui-interaction.spec.ts:55` (About dialog), `:97` (theme toggle) and `:117`. `:97` is the very test `test.yml`'s own comment names as a known Windows flake.

For completeness about what an earlier revision of this section claimed: a single clean run on this PR's base commit was cited as showing this "is not the normal state of the branch". One run is a single sample, not a distribution, and for a suite the workflow itself calls chronically flaky it could not support that. The two experiments above are what the claim now rests on. None of it is being waved through — it is recorded here for a reviewer to weigh rather than discover.

---

AI-assisted — [session 1](https://claude.ai/code/session_01SbvrTvyCp9XVHedo6jdwRj)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SbvrTvyCp9XVHedo6jdwRj

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2753)
<!-- Reviewable:end -->


