### PR TITLE
PT-4285: Skip bounds captures taken while a window changes display

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -120,6 +120,7 @@ import { createWindowEmptinessHandler } from '@main/services/window-emptiness.ut
 import {
   DEFAULT_WINDOW_HEIGHT,
   DEFAULT_WINDOW_WIDTH,
+  areCapturedBoundsTrustworthy,
   ensureBoundsVisibleOnSomeDisplay,
 } from '@main/window-bounds.util';
 import {
@@ -263,6 +264,8 @@ const WINDOW_CLOSE_TIME_OUT_MS = 10000;
 
 /** How long to coalesce a window's resize/move events before capturing its bounds */
 const BOUNDS_CAPTURE_DEBOUNCE_MS = 100;
+// A window that has just crossed to another display is left untrusted for longer than this
+// debounce — see `DISPLAY_SETTLE_MS` in `window-bounds.util.ts`, which says why.
 
 /**
  * How a window being created relates to the persisted window-layouts structure: it restores a saved
@@ -802,14 +805,42 @@ async function main() {
      * normal state, so maximizing/minimizing/full-screening cannot overwrite the last normal
      * placement — only flip the flags.
      */
+    /** Display the last accepted placement was on, so a move between displays can be recognized */
+    let lastAcceptedDisplayId: number | undefined;
+    /** When this window was first seen on the display it is on now */
+    let currentDisplaySince = Date.now();
+    /** Display this window was last seen on, whether or not that placement was accepted */
+    let lastSeenDisplayId: number | undefined;
+
     const captureWindowBoundsState = (): WindowBoundsState => {
       const isMaximized = newWindow.isMaximized();
       const isFullScreen = newWindow.isFullScreen();
       const capturedState: WindowBoundsState = { isMaximized, isFullScreen };
       if (!isMaximized && !isFullScreen && !newWindow.isMinimized()) {
         const { x, y, width, height } = newWindow.getBounds();
-        capturedState.bounds = { x, y, width, height };
-        capturedState.displayBounds = { ...screen.getDisplayMatching(capturedState.bounds).bounds };
+        const bounds = { x, y, width, height };
+        const displays = screen.getAllDisplays();
+        const seenDisplayId = screen.getDisplayMatching(bounds).id;
+        if (seenDisplayId !== lastSeenDisplayId) {
+          lastSeenDisplayId = seenDisplayId;
+          currentDisplaySince = Date.now();
+        }
+        // A placement the platform has not finished agreeing about is left out entirely, the same
+        // way a maximized or minimized window's is: `updateWindowBounds` keeps the last one it was
+        // given when a capture carries none, so the window keeps the placement it last held rather
+        // than gaining a wrong one. See `areCapturedBoundsTrustworthy`.
+        if (
+          areCapturedBoundsTrustworthy(
+            bounds,
+            displays,
+            lastAcceptedDisplayId,
+            Date.now() - currentDisplaySince,
+          )
+        ) {
+          capturedState.bounds = bounds;
+          capturedState.displayBounds = { ...screen.getDisplayMatching(bounds).bounds };
+          lastAcceptedDisplayId = seenDisplayId;
+        }
       }
       return capturedState;
     };

--- a/src/main/window-bounds.util.test.ts
+++ b/src/main/window-bounds.util.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
+  areCapturedBoundsTrustworthy,
   DEFAULT_WINDOW_HEIGHT,
   DEFAULT_WINDOW_WIDTH,
   ensureBoundsVisibleOnSomeDisplay,
@@ -101,5 +102,59 @@ describe('ensureBoundsVisibleOnSomeDisplay', () => {
     ensureBoundsVisibleOnSomeDisplay(savedState, [PRIMARY], PRIMARY);
 
     expect(savedState).toEqual(original);
+  });
+});
+
+/** The displays above, with the ids the trustworthiness check needs to tell them apart */
+const PRIMARY_WITH_ID = { id: 1, bounds: PRIMARY.bounds };
+const SECONDARY_WITH_ID = { id: 2, bounds: SECONDARY.bounds };
+const BOTH_DISPLAYS = [PRIMARY_WITH_ID, SECONDARY_WITH_ID];
+
+describe('areCapturedBoundsTrustworthy', () => {
+  test('bounds straddling two displays are not trustworthy', () => {
+    // While a window spans a boundary between displays of different scale factors, Windows and
+    // Chromium briefly disagree about its DPI and the captured size comes out around 25% too large
+    const straddling = { x: 1800, y: 100, width: 400, height: 600 };
+
+    expect(
+      areCapturedBoundsTrustworthy(straddling, BOTH_DISPLAYS, PRIMARY_WITH_ID.id, 10_000),
+    ).toBe(false);
+  });
+
+  test('bounds on a display the window has only just reached are not trustworthy yet', () => {
+    // The damaging snapshot is the one taken just AFTER the window lands: the geometry is already
+    // on one display, so a containment check alone accepts it, while the two DPI answers have not
+    // yet agreed
+    const onSecondary = { x: 2000, y: 100, width: 800, height: 600 };
+
+    expect(areCapturedBoundsTrustworthy(onSecondary, BOTH_DISPLAYS, PRIMARY_WITH_ID.id, 50)).toBe(
+      false,
+    );
+  });
+
+  test('bounds on a display the window has settled on are trustworthy', () => {
+    const onSecondary = { x: 2000, y: 100, width: 800, height: 600 };
+
+    expect(
+      areCapturedBoundsTrustworthy(onSecondary, BOTH_DISPLAYS, PRIMARY_WITH_ID.id, 10_000),
+    ).toBe(true);
+  });
+
+  test('bounds moved within the same display are trustworthy at once', () => {
+    // The control that keeps the guard from degrading into "never persist": a window moved inside
+    // one display has crossed no boundary, so nothing is owed a settle and its placement must be
+    // saved immediately. Without this, a guard that always refused would pass every test above.
+    const movedWithinPrimary = { x: 300, y: 200, width: 800, height: 600 };
+
+    expect(
+      areCapturedBoundsTrustworthy(movedWithinPrimary, BOTH_DISPLAYS, PRIMARY_WITH_ID.id, 0),
+    ).toBe(true);
+  });
+
+  test('the first capture of a session is trustworthy once it is on a display', () => {
+    // Nothing has been accepted yet, so there is no transition to settle after
+    const onPrimary = { x: 100, y: 50, width: 800, height: 600 };
+
+    expect(areCapturedBoundsTrustworthy(onPrimary, BOTH_DISPLAYS, undefined, 0)).toBe(true);
   });
 });

--- a/src/main/window-bounds.util.ts
+++ b/src/main/window-bounds.util.ts
@@ -61,3 +61,57 @@ export function ensureBoundsVisibleOnSomeDisplay(
     displayBounds: { ...primaryDisplay.bounds },
   };
 }
+
+/**
+ * How long after a window reaches a different display its placement stays untrusted.
+ *
+ * Longer than the capture debounce on purpose. The debounce answers "has the user stopped moving
+ * the window"; this answers "has the platform finished agreeing with itself about the window's
+ * scale", which outlasts the movement. See {@link areCapturedBoundsTrustworthy}.
+ */
+export const DISPLAY_SETTLE_MS = 500;
+
+/** A display the trustworthiness check can tell apart from its neighbours */
+export type IdentifiedDisplayLike = DisplayLike & { id: number };
+
+/**
+ * Whether a window's current placement is safe to persist.
+ *
+ * While a window spans the boundary between two displays with different scale factors, Windows and
+ * Chromium report different answers for its DPI — Win32 keeps the scale the window is crossing FROM
+ * while the window is already resolved onto the display it is crossing TO — so the window is
+ * physically about 25% larger than the layout it holds. The state is harmless to look at and clears
+ * itself, but a placement captured during it and restored later brings the window back at the wrong
+ * size.
+ *
+ * Two moments are refused, and the second is the one that actually corrupts anything:
+ *
+ * - Bounds lying in no single display: the window is straddling. Restoring these would be refused
+ *   anyway by {@link ensureBoundsVisibleOnSomeDisplay}, which requires containment in one display —
+ *   so this half only avoids replacing a good placement with one already known to be unusable.
+ * - Bounds on a display the window has just reached, before {@link DISPLAY_SETTLE_MS} has passed.
+ *   These pass containment and would be restored, and they are the ones that come back wrong: the
+ *   geometry has landed while the two DPI answers have not yet met.
+ *
+ * A window moved within one display crosses nothing and is trusted at once, which is what keeps
+ * this from quietly freezing every saved placement.
+ *
+ * @param bounds Placement captured just now
+ * @param displays Displays connected right now
+ * @param lastAcceptedDisplayId Display the last accepted capture was on, or `undefined` if none has
+ *   been accepted this session
+ * @param msSinceDisplayChange How long the window has been on the display it is on now
+ * @returns Whether the placement can be persisted
+ */
+export function areCapturedBoundsTrustworthy(
+  bounds: WindowRectangle,
+  displays: readonly IdentifiedDisplayLike[],
+  lastAcceptedDisplayId: number | undefined,
+  msSinceDisplayChange: number,
+): boolean {
+  const containingDisplay = displays.find((display) => isContainedIn(bounds, display));
+  if (!containingDisplay) return false;
+  if (lastAcceptedDisplayId === undefined) return true;
+  if (containingDisplay.id === lastAcceptedDisplayId) return true;
+  return msSinceDisplayChange >= DISPLAY_SETTLE_MS;
+}


### PR DESCRIPTION
## Summary

A window's placement is no longer saved while the platform is still making up its mind about the window's scale. Dragging a window between two displays with different scale factors leaves a short window of time in which the size we would persist is wrong by about a quarter — and restoring it later brings the window back at that wrong size.

### Why review this

Part of the current multi-window epic (PT-4275), closing the one hazard PT-4285's own description names as outstanding. Its Definition of Done is otherwise delivered on main. The hazard was found by PT-4276's Windows column on real mixed-DPI hardware, recorded there as "exactly the kind of state a layout-persistence feature could snapshot and later restore wrongly", and this is that snapshot being prevented.

## The mechanism

While a window spans the boundary between two displays of different scale factors, Win32 and Chromium disagree: `GetDpiForWindow` reports the DPI context inherited from the crossing (120) while `MonitorFromWindow` resolves to the 96-DPI display and Chromium renders at `dpr` 1. The window is physically ~25% larger than the layout it contains. It looks fine and it resolves itself once the window is fully on one display — but a bounds capture taken during it is wrong, and persists.

The straddle is not the dangerous part. Bounds captured mid-straddle lie in no single display, and the restore path (`ensureBoundsVisibleOnSomeDisplay`) already requires containment within one display, so it discards them and re-places at default size. Annoying, not corrupting.

**The damaging capture is the one just after the window lands.** The geometry is already on one display — so it passes containment and *will* be restored — while the two DPI answers have not yet met. A containment check alone does not catch it, which is why this needs a settle period rather than a geometry test.

## Changes

- **`areCapturedBoundsTrustworthy(bounds, displays, lastAcceptedDisplayId, msSinceDisplayChange)`** — a pure helper in `window-bounds.util.ts`, alongside the containment rule it reuses. It refuses two moments: bounds lying in no single display (the straddle), and bounds on a display the window has only just reached, before `DISPLAY_SETTLE_MS` has elapsed (the tail). A window moved *within* one display has crossed nothing and is trusted immediately.
- **`DISPLAY_SETTLE_MS = 500`**, deliberately longer than the 100 ms capture debounce: the debounce answers "has the user stopped moving the window", this answers "has the platform finished agreeing with itself", and the second outlasts the first. It sits beside the helper that uses it, with a pointer comment on the debounce so both timings read together.
- **No new plumbing.** The capture already had a mode for "these bounds are not worth trusting" — the branch that omits them for a maximized, full-screen or minimized window — and `updateWindowBounds` already keeps the last placement it was given when a capture carries none (`slot.entry.bounds = boundsState.bounds ?? slot.entry.bounds`). So this is one more condition on that existing branch: every capture call site inherits it unchanged, the maximized and full-screen flags still record, and there is no schema change.
- A new `IdentifiedDisplayLike` type carries the display id the check needs, leaving `DisplayLike` and every existing caller of `ensureBoundsVisibleOnSomeDisplay` untouched.

**Decided product consequence:** a quit taken while the window straddles restores the placement the window last held, rather than the straddle. That is the intended behaviour — the alternative is restoring a size that is knowably wrong.

## Verification

**`papi.d.ts` delta expected: none** — this adds no PAPI surface. Confirmed none after `build:types`.

Five unit tests, written before the helper existed and watched to fail against it. **Both mutation directions were applied and each watched to turn the suite red:**

- *Containment check removed* → "bounds straddling two displays are not trustworthy" and "bounds on a display the window has only just reached" both fail.
- *Always refuse* → "bounds on a display the window has settled on" and "bounds moved within the same display are trustworthy at once" both fail. **This is the control that matters**: without it, a guard that simply never saved anything would pass every straddle test while silently freezing every user's saved placement — a regression no amount of straddle testing would catch.

`build:main`, `typecheck`, `format:check` clean; `npm run lint` reports zero errors, and the three changed files lint clean individually. Full suite: 2951 passing, 1 skipped, across 207 files.

Not covered here: the behaviour needs real mixed-DPI hardware to observe end to end, which is the same constraint PT-4276 recorded (macOS cannot reach the straddle state on a default configuration; WSLg cannot construct a mixed-DPI pair at any monitor count). The logic is therefore pinned at the unit level, where it is deterministic, rather than by an environment that cannot produce the fault.

## AI Involvement

AI-assisted. Design and implementation were produced with Claude Code under review, from a design agreed before any code was written; the mechanism was read against PT-4276's recorded findings and the current capture/restore code rather than inferred, and the mutation testing above was the check on the tests themselves. The human developer is the author and reviewed the result.

## Risk Level

Low — one condition inside an existing guard, on a path that already has a well-defined "no bounds this time" mode. The failure it could introduce (refusing too often) is exactly what the always-refuse mutation control pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2754)
<!-- Reviewable:end -->
