### PR TITLE
e2e: clean up only this checkout's processes, never the machine's

### DIFF
--- a/e2e-tests/global-teardown.ts
+++ b/e2e-tests/global-teardown.ts
@@ -56,6 +56,8 @@ export default async function globalTeardown(_config: FullConfig): Promise<void>
     );
   } else if (swept === 'by-name') {
     console.log(`Cleanup: swept by process name (${process.platform} has no /proc to scope by).`);
+  } else if (swept === 'by-name-failed') {
+    console.log('Cleanup: the process-name sweep reported nothing to stop, or could not complete.');
   } else if (pids.length > 0) {
     console.log(
       `Cleanup: terminated ${pids.length} process(es) under ${rootDir}: ${pids.join(', ')}`,

--- a/e2e-tests/global-teardown.ts
+++ b/e2e-tests/global-teardown.ts
@@ -32,14 +32,13 @@ export default async function globalTeardown(_config: FullConfig): Promise<void>
     }
   }
 
-  // Sweep up anything a crashed fixture left behind — this checkout's processes, and only when the
-  // machine belongs to the run.
+  // Sweep up anything a crashed fixture left behind.
   //
-  // Selection is by working directory rather than process name wherever that is possible: a name
-  // match reaches every electron and dotnet process on the machine, including the developer's own
-  // app, any app a CDP-based suite is attached to, and other checkouts' runs on a shared box. See
-  // e2e-tests/scoped-cleanup.ts, which also explains why non-Linux CI runners still match by name.
-  const { swept, pids } = runCleanup(
+  // Selection is by working directory wherever that is possible: a name match reaches every
+  // electron and dotnet process on the machine, including the developer's own app, any app a
+  // CDP-based suite is attached to, and other checkouts' runs on a shared box. See
+  // e2e-tests/scoped-cleanup.ts for which sweeps each environment gets and why.
+  const { scoped, byName, pids } = runCleanup(
     { ciFlag: process.env.CI, platform: process.platform, root: rootDir },
     {
       killUnderRoot: killProcessesUnderRoot,
@@ -49,20 +48,21 @@ export default async function globalTeardown(_config: FullConfig): Promise<void>
     },
   );
 
-  if (swept === 'none') {
+  if (scoped) {
     console.log(
-      'Skipping cleanup sweep: CI is not set to a value meaning yes. The launch fixtures already ' +
-        'tear down what they started; run `npm run stop` by hand if something leaked.',
+      pids.length > 0
+        ? `Cleanup: terminated ${pids.length} process(es) under ${rootDir}: ${pids.join(', ')}`
+        : `Cleanup: no leftover processes under ${rootDir}.`,
     );
-  } else if (swept === 'by-name') {
-    console.log(`Cleanup: swept by process name (${process.platform} has no /proc to scope by).`);
-  } else if (swept === 'by-name-failed') {
-    console.log('Cleanup: the process-name sweep reported nothing to stop, or could not complete.');
-  } else if (pids.length > 0) {
+  } else if (byName === 'skipped') {
     console.log(
-      `Cleanup: terminated ${pids.length} process(es) under ${rootDir}: ${pids.join(', ')}`,
+      `Skipping cleanup sweep: ${process.platform} has no /proc to scope by, and CI is not set ` +
+        'to a value meaning yes. The launch fixtures already tear down what they started; run ' +
+        '`npm run stop` by hand if something leaked.',
     );
-  } else {
-    console.log(`Cleanup: no leftover processes under ${rootDir}.`);
   }
+
+  if (byName === 'ran') console.log('Cleanup: also swept by process name (the machine is ours).');
+  if (byName === 'failed')
+    console.log('Cleanup: the process-name sweep reported nothing to stop, or could not complete.');
 }

--- a/e2e-tests/global-teardown.ts
+++ b/e2e-tests/global-teardown.ts
@@ -1,7 +1,8 @@
 import type { FullConfig } from '@playwright/test';
 import path from 'path';
 import fs from 'fs';
-import { isSweepEnabled, killProcessesUnderRoot } from './scoped-cleanup';
+import { execSync } from 'child_process';
+import { killProcessesUnderRoot, runCleanup } from './scoped-cleanup';
 
 // Playwright global teardown requires this signature even though config is unused
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -31,24 +32,35 @@ export default async function globalTeardown(_config: FullConfig): Promise<void>
     }
   }
 
-  // Sweep up anything a crashed fixture left behind — but only this checkout's processes, and only
-  // when the machine belongs to the run.
+  // Sweep up anything a crashed fixture left behind — this checkout's processes, and only when the
+  // machine belongs to the run.
   //
-  // Selection is by working directory, never by process name: a name match reaches every electron
-  // and dotnet process on the machine, including the developer's own app, any app a CDP-based
-  // suite is attached to, and other checkouts' runs on a shared box. See
-  // e2e-tests/scoped-cleanup.ts.
-  if (!isSweepEnabled(process.env.CI)) {
+  // Selection is by working directory rather than process name wherever that is possible: a name
+  // match reaches every electron and dotnet process on the machine, including the developer's own
+  // app, any app a CDP-based suite is attached to, and other checkouts' runs on a shared box. See
+  // e2e-tests/scoped-cleanup.ts, which also explains why non-Linux CI runners still match by name.
+  const { swept, pids } = runCleanup(
+    { ciFlag: process.env.CI, platform: process.platform, root: rootDir },
+    {
+      killUnderRoot: killProcessesUnderRoot,
+      sweepByProcessName: () => {
+        execSync('npm run stop', { cwd: rootDir, stdio: 'pipe', timeout: 10_000 });
+      },
+    },
+  );
+
+  if (swept === 'none') {
     console.log(
       'Skipping cleanup sweep: CI is not set to a value meaning yes. The launch fixtures already ' +
         'tear down what they started; run `npm run stop` by hand if something leaked.',
     );
-    return;
+  } else if (swept === 'by-name') {
+    console.log(`Cleanup: swept by process name (${process.platform} has no /proc to scope by).`);
+  } else if (pids.length > 0) {
+    console.log(
+      `Cleanup: terminated ${pids.length} process(es) under ${rootDir}: ${pids.join(', ')}`,
+    );
+  } else {
+    console.log(`Cleanup: no leftover processes under ${rootDir}.`);
   }
-  const killed = killProcessesUnderRoot(rootDir);
-  console.log(
-    killed.length > 0
-      ? `Cleanup: terminated ${killed.length} process(es) under ${rootDir}: ${killed.join(', ')}`
-      : `Cleanup: no leftover processes under ${rootDir}.`,
-  );
 }

--- a/e2e-tests/global-teardown.ts
+++ b/e2e-tests/global-teardown.ts
@@ -1,7 +1,7 @@
 import type { FullConfig } from '@playwright/test';
-import { execSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
+import { isSweepEnabled, killProcessesUnderRoot } from './scoped-cleanup';
 
 // Playwright global teardown requires this signature even though config is unused
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -31,12 +31,24 @@ export default async function globalTeardown(_config: FullConfig): Promise<void>
     }
   }
 
-  // Run the stop script to ensure all Electron processes are terminated
-  console.log('Running cleanup: npm run stop');
-  try {
-    execSync('npm run stop', { cwd: rootDir, stdio: 'pipe', timeout: 10_000 });
-    console.log('Cleanup completed.');
-  } catch {
-    console.log('Cleanup: No processes to stop or already stopped.');
+  // Sweep up anything a crashed fixture left behind — but only this checkout's processes, and only
+  // when the machine belongs to the run.
+  //
+  // Selection is by working directory, never by process name: a name match reaches every electron
+  // and dotnet process on the machine, including the developer's own app, any app a CDP-based
+  // suite is attached to, and other checkouts' runs on a shared box. See
+  // e2e-tests/scoped-cleanup.ts.
+  if (!isSweepEnabled(process.env.CI)) {
+    console.log(
+      'Skipping cleanup sweep: CI is not set to a value meaning yes. The launch fixtures already ' +
+        'tear down what they started; run `npm run stop` by hand if something leaked.',
+    );
+    return;
   }
+  const killed = killProcessesUnderRoot(rootDir);
+  console.log(
+    killed.length > 0
+      ? `Cleanup: terminated ${killed.length} process(es) under ${rootDir}: ${killed.join(', ')}`
+      : `Cleanup: no leftover processes under ${rootDir}.`,
+  );
 }

--- a/e2e-tests/scoped-cleanup.test.ts
+++ b/e2e-tests/scoped-cleanup.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Unit tests for the teardown's process selection.
+ *
+ * Teardown used to finish by killing every process named `electron` or `dotnet` on the machine.
+ * That is correct on a CI runner the run owns and wrong everywhere else: it takes down the
+ * developer's own app, any app a CDP-based suite is attached to, and other people's runs. These
+ * cover the two decisions that keep it from doing so — whether to sweep at all, and which processes
+ * belong to this checkout.
+ */
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+import { isSweepEnabled, selectPidsUnderRoot } from './scoped-cleanup';
+
+const ROOT = '/home/dev/paranext-core';
+
+describe('whether to sweep at all', () => {
+  it('sweeps when CI is set to something meaning yes', () => {
+    expect(isSweepEnabled('true')).toBe(true);
+    expect(isSweepEnabled('1')).toBe(true);
+    expect(isSweepEnabled('yes')).toBe(true);
+  });
+
+  it('does NOT sweep when CI is unset or empty', () => {
+    expect(isSweepEnabled(undefined)).toBe(false);
+    expect(isSweepEnabled('')).toBe(false);
+    expect(isSweepEnabled('   ')).toBe(false);
+  });
+
+  it('does NOT sweep when CI is set to something meaning no', () => {
+    // The whole point: `CI=false` is a non-empty string, so a truthiness test treats it as yes and
+    // sweeps the machine — which is a common wrapper and IDE idiom, not an exotic case.
+    expect(isSweepEnabled('false')).toBe(false);
+    expect(isSweepEnabled('0')).toBe(false);
+    expect(isSweepEnabled('no')).toBe(false);
+    expect(isSweepEnabled('off')).toBe(false);
+    expect(isSweepEnabled('FALSE')).toBe(false);
+  });
+});
+
+describe('which processes belong to this checkout', () => {
+  const candidates = [
+    { pid: 101, comm: 'electron', cwd: ROOT },
+    { pid: 102, comm: 'electron', cwd: path.join(ROOT, 'release/app') },
+    { pid: 103, comm: 'dotnet', cwd: path.join(ROOT, 'c-sharp') },
+  ];
+
+  it('selects processes running inside the root', () => {
+    expect(selectPidsUnderRoot(ROOT, candidates, [])).toEqual([101, 102, 103]);
+  });
+
+  it('leaves a neighbouring checkout alone', () => {
+    // The failure that matters: another worktree's app must survive this run's teardown.
+    const neighbour = { pid: 201, comm: 'electron', cwd: '/home/dev/other-worktree/paranext-core' };
+
+    expect(selectPidsUnderRoot(ROOT, [...candidates, neighbour], [])).not.toContain(201);
+  });
+
+  it('is not fooled by a sibling directory sharing the root as a prefix', () => {
+    const sibling = { pid: 202, comm: 'electron', cwd: `${ROOT}-other/release/app` };
+
+    expect(selectPidsUnderRoot(ROOT, [sibling], [])).toEqual([]);
+  });
+
+  it('never selects this process or its ancestors', () => {
+    // Teardown runs from the repo root, so without this it would select the very process doing the
+    // killing and take the run down with it.
+    const self = { pid: 999, comm: 'node', cwd: ROOT };
+
+    expect(selectPidsUnderRoot(ROOT, [...candidates, self], [999])).not.toContain(999);
+  });
+
+  it('ignores processes whose cwd could not be read', () => {
+    // /proc/<pid>/cwd is unreadable for another user's process. Unknown means "not ours".
+    const unreadable = { pid: 301, comm: 'electron', cwd: undefined };
+
+    expect(selectPidsUnderRoot(ROOT, [unreadable], [])).toEqual([]);
+  });
+
+  it('only targets the process names the old sweep targeted', () => {
+    // Everything under the root is not fair game: npm, node and the shell running the suite all
+    // live here too, and killing them kills the run.
+    const ourOwnTooling = { pid: 401, comm: 'npm', cwd: ROOT };
+
+    expect(selectPidsUnderRoot(ROOT, [ourOwnTooling], [])).toEqual([]);
+  });
+});

--- a/e2e-tests/scoped-cleanup.test.ts
+++ b/e2e-tests/scoped-cleanup.test.ts
@@ -86,9 +86,9 @@ describe('which processes belong to this checkout', () => {
   });
 });
 
-describe('which cleanup a platform gets', () => {
+describe('which cleanup each environment gets', () => {
   /** Records which action ran, so the choice can be asserted without killing anything. */
-  function spyActions() {
+  function spyActions(sweepByProcessName = () => {}) {
     const calls: string[] = [];
     return {
       calls,
@@ -99,45 +99,65 @@ describe('which cleanup a platform gets', () => {
         },
         sweepByProcessName: () => {
           calls.push('by-name');
+          sweepByProcessName();
         },
       },
     };
   }
 
-  it('sweeps nothing when the gate says no, on any platform', () => {
-    const linux = spyActions();
-    expect(
-      runCleanup({ ciFlag: 'false', platform: 'linux', root: ROOT }, linux.actions).swept,
-    ).toBe('none');
-    expect(linux.calls).toEqual([]);
-
-    const mac = spyActions();
-    runCleanup({ ciFlag: undefined, platform: 'darwin', root: ROOT }, mac.actions);
-    expect(mac.calls).toEqual([]);
-  });
-
-  it('uses the scoped kill on Linux, and never the name sweep', () => {
+  function cleanup(ciFlag: string | undefined, platform: NodeJS.Platform) {
     const { calls, actions } = spyActions();
+    const result = runCleanup({ ciFlag, platform, root: ROOT }, actions);
+    return { ...result, calls };
+  }
 
-    const result = runCleanup({ ciFlag: 'true', platform: 'linux', root: ROOT }, actions);
+  it('cleans up this checkout on Linux even when nobody set CI', () => {
+    // The case the whole module exists for. A developer's box is where scoping matters: their run
+    // must clear its own leaked app without touching a peer's checkout or their editor's.
+    const result = cleanup(undefined, 'linux');
 
-    expect(result.swept).toBe('scoped');
+    expect(result.scoped).toBe(true);
     expect(result.pids).toEqual([4242]);
-    expect(calls).toEqual([`scoped:${ROOT}`]);
-    expect(calls).not.toContain('by-name');
+    expect(result.calls).toEqual([`scoped:${ROOT}`]);
+    expect(result.byName).toBe('skipped');
   });
 
-  it('falls back to the name sweep where /proc does not exist', () => {
-    // Selection reads /proc, which only Linux has. Without this branch a macOS or Windows CI runner
-    // would sweep nothing at all — silently losing the cleanup the gate exists to allow. A CI
-    // runner is single-tenant, so matching by name is correct there.
+  it('does the same when CI is explicitly false on Linux', () => {
+    const result = cleanup('false', 'linux');
+
+    expect(result.scoped).toBe(true);
+    expect(result.byName).toBe('skipped');
+  });
+
+  it('also runs the machine-wide sweep on a Linux CI runner', () => {
+    // A CI runner is single-tenant, so the old sweep's wider reach costs nothing there and keeps
+    // its coverage — it matches build watchers by command line, which scoped selection does not.
+    const result = cleanup('true', 'linux');
+
+    expect(result.scoped).toBe(true);
+    expect(result.byName).toBe('ran');
+    expect(result.calls).toEqual([`scoped:${ROOT}`, 'by-name']);
+  });
+
+  it('sweeps by name on a CI runner without /proc', () => {
     (['darwin', 'win32'] as const).forEach((platform) => {
-      const { calls, actions } = spyActions();
+      const result = cleanup('true', platform);
 
-      const result = runCleanup({ ciFlag: 'true', platform, root: ROOT }, actions);
+      expect(result.scoped).toBe(false);
+      expect(result.byName).toBe('ran');
+      expect(result.calls).toEqual(['by-name']);
+    });
+  });
 
-      expect(result.swept).toBe('by-name');
-      expect(calls).toEqual(['by-name']);
+  it('does nothing off CI where it cannot scope', () => {
+    // Nothing can be scoped without /proc, and a machine-wide kill on someone's own Mac or Windows
+    // box is the behaviour this module exists to stop. Doing nothing is the only safe answer.
+    (['darwin', 'win32'] as const).forEach((platform) => {
+      const result = cleanup(undefined, platform);
+
+      expect(result.scoped).toBe(false);
+      expect(result.byName).toBe('skipped');
+      expect(result.calls).toEqual([]);
     });
   });
 });
@@ -202,21 +222,30 @@ describe('process names as the kernel reports them', () => {
 });
 
 describe('a failing name sweep does not fail the run', () => {
+  const throwingActions = {
+    killUnderRoot: () => [4242],
+    sweepByProcessName: () => {
+      throw new Error('npm run stop exited 1');
+    },
+  };
+
   it('reports the failure instead of throwing out of teardown', () => {
     // `npm run stop` shelling out to ps/CIM and fkill can exit non-zero or time out; that was an
     // expected outcome before and must not turn a passing run red.
-    const actions = {
-      killUnderRoot: () => [],
-      sweepByProcessName: () => {
-        throw new Error('npm run stop exited 1');
-      },
-    };
-
     expect(() =>
-      runCleanup({ ciFlag: 'true', platform: 'darwin', root: ROOT }, actions),
+      runCleanup({ ciFlag: 'true', platform: 'darwin', root: ROOT }, throwingActions),
     ).not.toThrow();
-    expect(runCleanup({ ciFlag: 'true', platform: 'darwin', root: ROOT }, actions).swept).toBe(
-      'by-name-failed',
-    );
+    expect(
+      runCleanup({ ciFlag: 'true', platform: 'darwin', root: ROOT }, throwingActions).byName,
+    ).toBe('failed');
+  });
+
+  it('keeps the scoped result when only the name sweep fails', () => {
+    // On a Linux runner both run. A failing name sweep must not discard pids already terminated.
+    const result = runCleanup({ ciFlag: 'true', platform: 'linux', root: ROOT }, throwingActions);
+
+    expect(result.scoped).toBe(true);
+    expect(result.pids).toEqual([4242]);
+    expect(result.byName).toBe('failed');
   });
 });

--- a/e2e-tests/scoped-cleanup.test.ts
+++ b/e2e-tests/scoped-cleanup.test.ts
@@ -140,3 +140,62 @@ describe('which cleanup a platform gets', () => {
     });
   });
 });
+
+describe('processes this checkout must NOT claim', () => {
+  it('leaves a nested worktree alone, even though its path is inside the root', () => {
+    // Worktrees in this repo live at <root>/.claude/worktrees/<name>, so plain prefix containment
+    // claims every one of them. A teardown run from the canonical checkout would then kill every
+    // worktree's app — the exact cross-checkout kill this module exists to prevent, wearing a
+    // different shape.
+    const nested = {
+      pid: 501,
+      comm: 'electron',
+      cwd: path.join(ROOT, '.claude/worktrees/some-branch'),
+    };
+    const deeper = {
+      pid: 502,
+      comm: 'dotnet',
+      cwd: path.join(ROOT, '.claude/worktrees/some-branch/c-sharp'),
+    };
+
+    expect(selectPidsUnderRoot(ROOT, [nested, deeper], [])).toEqual([]);
+  });
+
+  it('still claims its own processes when it IS a nested worktree', () => {
+    // The run happening inside a worktree must clean up after itself.
+    const worktreeRoot = path.join(ROOT, '.claude/worktrees/some-branch');
+    const own = { pid: 503, comm: 'electron', cwd: worktreeRoot };
+
+    expect(selectPidsUnderRoot(worktreeRoot, [own], [])).toEqual([503]);
+  });
+});
+
+describe('process names as the kernel reports them', () => {
+  it('matches the data provider by the name /proc actually shows', () => {
+    // /proc/<pid>/comm is capped at 15 characters, so a 20-character executable name is truncated
+    // and a full-length entry in the list can never match anything.
+    const dataProvider = { pid: 601, comm: 'ParanextDataPro', cwd: ROOT };
+
+    expect(selectPidsUnderRoot(ROOT, [dataProvider], [])).toEqual([601]);
+  });
+});
+
+describe('a failing name sweep does not fail the run', () => {
+  it('reports the failure instead of throwing out of teardown', () => {
+    // `npm run stop` shelling out to ps/CIM and fkill can exit non-zero or time out; that was an
+    // expected outcome before and must not turn a passing run red.
+    const actions = {
+      killUnderRoot: () => [],
+      sweepByProcessName: () => {
+        throw new Error('npm run stop exited 1');
+      },
+    };
+
+    expect(() =>
+      runCleanup({ ciFlag: 'true', platform: 'darwin', root: ROOT }, actions),
+    ).not.toThrow();
+    expect(runCleanup({ ciFlag: 'true', platform: 'darwin', root: ROOT }, actions).swept).toBe(
+      'by-name-failed',
+    );
+  });
+});

--- a/e2e-tests/scoped-cleanup.test.ts
+++ b/e2e-tests/scoped-cleanup.test.ts
@@ -9,9 +9,11 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
-import { afterAll, describe, expect, it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { isSweepEnabled, runCleanup, selectPidsUnderRoot } from './scoped-cleanup';
 
+// Working directories come from /proc, so every synthetic one here is POSIX regardless of the host
+// running the tests. The real directories in the symlink test below are the one exception.
 const ROOT = '/home/dev/paranext-core';
 
 describe('whether to sweep at all', () => {
@@ -41,8 +43,8 @@ describe('whether to sweep at all', () => {
 describe('which processes belong to this checkout', () => {
   const candidates = [
     { pid: 101, comm: 'electron', cwd: ROOT },
-    { pid: 102, comm: 'electron', cwd: path.join(ROOT, 'release/app') },
-    { pid: 103, comm: 'dotnet', cwd: path.join(ROOT, 'c-sharp') },
+    { pid: 102, comm: 'electron', cwd: path.posix.join(ROOT, 'release/app') },
+    { pid: 103, comm: 'dotnet', cwd: path.posix.join(ROOT, 'c-sharp') },
   ];
 
   it('selects processes running inside the root', () => {
@@ -171,12 +173,12 @@ describe('processes this checkout must NOT claim', () => {
     const nested = {
       pid: 501,
       comm: 'electron',
-      cwd: path.join(ROOT, '.claude/worktrees/some-branch'),
+      cwd: path.posix.join(ROOT, '.claude/worktrees/some-branch'),
     };
     const deeper = {
       pid: 502,
       comm: 'dotnet',
-      cwd: path.join(ROOT, '.claude/worktrees/some-branch/c-sharp'),
+      cwd: path.posix.join(ROOT, '.claude/worktrees/some-branch/c-sharp'),
     };
 
     expect(selectPidsUnderRoot(ROOT, [nested, deeper], [])).toEqual([]);
@@ -184,7 +186,7 @@ describe('processes this checkout must NOT claim', () => {
 
   it('still claims its own processes when it IS a nested worktree', () => {
     // The run happening inside a worktree must clean up after itself.
-    const worktreeRoot = path.join(ROOT, '.claude/worktrees/some-branch');
+    const worktreeRoot = path.posix.join(ROOT, '.claude/worktrees/some-branch');
     const own = { pid: 503, comm: 'electron', cwd: worktreeRoot };
 
     expect(selectPidsUnderRoot(worktreeRoot, [own], [])).toEqual([503]);
@@ -192,27 +194,28 @@ describe('processes this checkout must NOT claim', () => {
 });
 
 describe('a root reached through a symlink', () => {
-  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'scoped-cleanup-'));
-  const realRoot = path.join(scratch, 'real-checkout');
-  const linkedRoot = path.join(scratch, 'linked-checkout');
-  fs.mkdirSync(realRoot);
-  fs.symlinkSync(realRoot, linkedRoot);
-
-  afterAll(() => {
-    fs.rmSync(scratch, { recursive: true, force: true });
-  });
-
-  // Skipped off Linux: this is the only test that needs real directories, and a Windows temp path
-  // is not POSIX, so it cannot describe a /proc working directory. Creating a symlink there also
-  // needs privileges the runner may not have.
+  // Linux-only, and every filesystem call lives inside the test rather than the suite body: a
+  // skipped test still has its enclosing describe evaluated during collection, and creating a
+  // symlink on Windows needs privileges a runner may not have. A Windows temp path could not
+  // stand in for a /proc working directory anyway.
   it.skipIf(process.platform !== 'linux')(
     "claims its own processes when the run's root is a symlink",
     () => {
-      // /proc/<pid>/cwd is a resolved path, so a run launched through a symlinked checkout compares
-      // its own processes against a path they can never match, and cleans up nothing at all.
-      const mine = { pid: 301, comm: 'electron', cwd: path.join(realRoot, 'release/app') };
+      const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'scoped-cleanup-'));
+      try {
+        const realRoot = path.join(scratch, 'real-checkout');
+        const linkedRoot = path.join(scratch, 'linked-checkout');
+        fs.mkdirSync(realRoot);
+        fs.symlinkSync(realRoot, linkedRoot);
 
-      expect(selectPidsUnderRoot(linkedRoot, [mine], [])).toEqual([301]);
+        // /proc/<pid>/cwd is a resolved path, so a run launched through a symlinked checkout
+        // compares its own processes against a path they can never match, and cleans up nothing.
+        const mine = { pid: 301, comm: 'electron', cwd: path.join(realRoot, 'release/app') };
+
+        expect(selectPidsUnderRoot(linkedRoot, [mine], [])).toEqual([301]);
+      } finally {
+        fs.rmSync(scratch, { recursive: true, force: true });
+      }
     },
   );
 });

--- a/e2e-tests/scoped-cleanup.test.ts
+++ b/e2e-tests/scoped-cleanup.test.ts
@@ -9,7 +9,7 @@
  */
 import path from 'path';
 import { describe, expect, it } from 'vitest';
-import { isSweepEnabled, selectPidsUnderRoot } from './scoped-cleanup';
+import { isSweepEnabled, runCleanup, selectPidsUnderRoot } from './scoped-cleanup';
 
 const ROOT = '/home/dev/paranext-core';
 
@@ -82,5 +82,61 @@ describe('which processes belong to this checkout', () => {
     const ourOwnTooling = { pid: 401, comm: 'npm', cwd: ROOT };
 
     expect(selectPidsUnderRoot(ROOT, [ourOwnTooling], [])).toEqual([]);
+  });
+});
+
+describe('which cleanup a platform gets', () => {
+  /** Records which action ran, so the choice can be asserted without killing anything. */
+  function spyActions() {
+    const calls: string[] = [];
+    return {
+      calls,
+      actions: {
+        killUnderRoot: (root: string) => {
+          calls.push(`scoped:${root}`);
+          return [4242];
+        },
+        sweepByProcessName: () => {
+          calls.push('by-name');
+        },
+      },
+    };
+  }
+
+  it('sweeps nothing when the gate says no, on any platform', () => {
+    const linux = spyActions();
+    expect(
+      runCleanup({ ciFlag: 'false', platform: 'linux', root: ROOT }, linux.actions).swept,
+    ).toBe('none');
+    expect(linux.calls).toEqual([]);
+
+    const mac = spyActions();
+    runCleanup({ ciFlag: undefined, platform: 'darwin', root: ROOT }, mac.actions);
+    expect(mac.calls).toEqual([]);
+  });
+
+  it('uses the scoped kill on Linux, and never the name sweep', () => {
+    const { calls, actions } = spyActions();
+
+    const result = runCleanup({ ciFlag: 'true', platform: 'linux', root: ROOT }, actions);
+
+    expect(result.swept).toBe('scoped');
+    expect(result.pids).toEqual([4242]);
+    expect(calls).toEqual([`scoped:${ROOT}`]);
+    expect(calls).not.toContain('by-name');
+  });
+
+  it('falls back to the name sweep where /proc does not exist', () => {
+    // Selection reads /proc, which only Linux has. Without this branch a macOS or Windows CI runner
+    // would sweep nothing at all — silently losing the cleanup the gate exists to allow. A CI
+    // runner is single-tenant, so matching by name is correct there.
+    (['darwin', 'win32'] as const).forEach((platform) => {
+      const { calls, actions } = spyActions();
+
+      const result = runCleanup({ ciFlag: 'true', platform, root: ROOT }, actions);
+
+      expect(result.swept).toBe('by-name');
+      expect(calls).toEqual(['by-name']);
+    });
   });
 });

--- a/e2e-tests/scoped-cleanup.test.ts
+++ b/e2e-tests/scoped-cleanup.test.ts
@@ -1,14 +1,15 @@
 /**
  * Unit tests for the teardown's process selection.
  *
- * Teardown used to finish by killing every process named `electron` or `dotnet` on the machine.
- * That is correct on a CI runner the run owns and wrong everywhere else: it takes down the
- * developer's own app, any app a CDP-based suite is attached to, and other people's runs. These
- * cover the two decisions that keep it from doing so — whether to sweep at all, and which processes
- * belong to this checkout.
+ * Killing every process named `electron` or `dotnet` on the machine is correct only on a CI runner
+ * the run owns. Anywhere else it takes down the developer's own app, any app a CDP-based suite is
+ * attached to, and other people's runs. These cover the two decisions that keep teardown from doing
+ * that — whether to sweep at all, and which processes belong to this checkout.
  */
+import fs from 'fs';
+import os from 'os';
 import path from 'path';
-import { describe, expect, it } from 'vitest';
+import { afterAll, describe, expect, it } from 'vitest';
 import { isSweepEnabled, runCleanup, selectPidsUnderRoot } from './scoped-cleanup';
 
 const ROOT = '/home/dev/paranext-core';
@@ -167,6 +168,26 @@ describe('processes this checkout must NOT claim', () => {
     const own = { pid: 503, comm: 'electron', cwd: worktreeRoot };
 
     expect(selectPidsUnderRoot(worktreeRoot, [own], [])).toEqual([503]);
+  });
+});
+
+describe('a root reached through a symlink', () => {
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'scoped-cleanup-'));
+  const realRoot = path.join(scratch, 'real-checkout');
+  const linkedRoot = path.join(scratch, 'linked-checkout');
+  fs.mkdirSync(realRoot);
+  fs.symlinkSync(realRoot, linkedRoot);
+
+  afterAll(() => {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  });
+
+  it("claims its own processes when the run's root is a symlink", () => {
+    // /proc/<pid>/cwd is a resolved path, so a run launched through a symlinked checkout compares
+    // its own processes against a path they can never match, and cleans up nothing at all.
+    const mine = { pid: 301, comm: 'electron', cwd: path.join(realRoot, 'release/app') };
+
+    expect(selectPidsUnderRoot(linkedRoot, [mine], [])).toEqual([301]);
   });
 });
 

--- a/e2e-tests/scoped-cleanup.test.ts
+++ b/e2e-tests/scoped-cleanup.test.ts
@@ -202,13 +202,19 @@ describe('a root reached through a symlink', () => {
     fs.rmSync(scratch, { recursive: true, force: true });
   });
 
-  it("claims its own processes when the run's root is a symlink", () => {
-    // /proc/<pid>/cwd is a resolved path, so a run launched through a symlinked checkout compares
-    // its own processes against a path they can never match, and cleans up nothing at all.
-    const mine = { pid: 301, comm: 'electron', cwd: path.join(realRoot, 'release/app') };
+  // Skipped off Linux: this is the only test that needs real directories, and a Windows temp path
+  // is not POSIX, so it cannot describe a /proc working directory. Creating a symlink there also
+  // needs privileges the runner may not have.
+  it.skipIf(process.platform !== 'linux')(
+    "claims its own processes when the run's root is a symlink",
+    () => {
+      // /proc/<pid>/cwd is a resolved path, so a run launched through a symlinked checkout compares
+      // its own processes against a path they can never match, and cleans up nothing at all.
+      const mine = { pid: 301, comm: 'electron', cwd: path.join(realRoot, 'release/app') };
 
-    expect(selectPidsUnderRoot(linkedRoot, [mine], [])).toEqual([301]);
-  });
+      expect(selectPidsUnderRoot(linkedRoot, [mine], [])).toEqual([301]);
+    },
+  );
 });
 
 describe('process names as the kernel reports them', () => {

--- a/e2e-tests/scoped-cleanup.ts
+++ b/e2e-tests/scoped-cleanup.ts
@@ -54,6 +54,10 @@ export function isSweepEnabled(value: string | undefined): boolean {
 /**
  * The pids of sweepable processes running inside `root`, excluding `excludePids`.
  *
+ * Every path here is POSIX. Working directories come from `/proc`, which exists only on Linux, so
+ * both sides of the comparison are POSIX by construction — resolving them with the host's rules
+ * would rewrite them on a platform this selector never really runs on.
+ *
  * Containment is checked against the resolved path with a separator, so a sibling checkout whose
  * path merely starts with the same characters — `paranext-core-other` beside `paranext-core` — is
  * not treated as inside it. A process whose working directory could not be read is left alone:
@@ -64,13 +68,15 @@ export function isSweepEnabled(value: string | undefined): boolean {
  * `dir` with symlinks resolved, falling back to a plain resolve when the path cannot be read.
  *
  * A working directory read from /proc is always fully resolved, so a root that still contains a
- * symlink compares against a path no process can match.
+ * symlink compares against a path no process can match. The fallback covers a root that does not
+ * exist, and every root on a host without /proc.
  */
 function realPathOrResolved(dir: string): string {
+  const resolved = path.posix.resolve(dir);
   try {
-    return fs.realpathSync(path.resolve(dir));
+    return fs.realpathSync(resolved);
   } catch {
-    return path.resolve(dir);
+    return resolved;
   }
 }
 
@@ -80,13 +86,13 @@ export function selectPidsUnderRoot(
   excludePids: number[],
 ): number[] {
   const resolvedRoot = realPathOrResolved(root);
-  const prefix = `${resolvedRoot}${path.sep}`;
+  const prefix = `${resolvedRoot}${path.posix.sep}`;
   // Worktrees of this repository live at <root>/.claude/worktrees/<name>, so they sit INSIDE the
   // root by path while belonging to a different checkout and, usually, a different run. Plain
   // containment would claim all of them, which is the same cross-checkout kill this module exists
   // to prevent. A run whose own root IS such a directory is unaffected: the container it excludes
   // is relative to its own root, not the canonical one.
-  const nestedWorktrees = `${path.join(resolvedRoot, '.claude', 'worktrees')}${path.sep}`;
+  const nestedWorktrees = `${path.posix.join(resolvedRoot, '.claude', 'worktrees')}${path.posix.sep}`;
   return candidates
     .filter((candidate) => !excludePids.includes(candidate.pid))
     .filter((candidate) => SWEEPABLE_PROCESS_NAMES.includes(candidate.comm))

--- a/e2e-tests/scoped-cleanup.ts
+++ b/e2e-tests/scoped-cleanup.ts
@@ -60,12 +60,26 @@ export function isSweepEnabled(value: string | undefined): boolean {
  * unknown means "not ours", because /proc entries for another user's processes are unreadable and
  * guessing in that direction is how a neighbour's app gets killed.
  */
+/**
+ * `dir` with symlinks resolved, falling back to a plain resolve when the path cannot be read.
+ *
+ * A working directory read from /proc is always fully resolved, so a root that still contains a
+ * symlink compares against a path no process can match.
+ */
+function realPathOrResolved(dir: string): string {
+  try {
+    return fs.realpathSync(path.resolve(dir));
+  } catch {
+    return path.resolve(dir);
+  }
+}
+
 export function selectPidsUnderRoot(
   root: string,
   candidates: ProcessCandidate[],
   excludePids: number[],
 ): number[] {
-  const resolvedRoot = path.resolve(root);
+  const resolvedRoot = realPathOrResolved(root);
   const prefix = `${resolvedRoot}${path.sep}`;
   // Worktrees of this repository live at <root>/.claude/worktrees/<name>, so they sit INSIDE the
   // root by path while belonging to a different checkout and, usually, a different run. Plain

--- a/e2e-tests/scoped-cleanup.ts
+++ b/e2e-tests/scoped-cleanup.ts
@@ -181,14 +181,31 @@ export type CleanupActions = {
   sweepByProcessName: () => void;
 };
 
+/** What a cleanup did. */
+export type CleanupOutcome = {
+  /** Pids terminated because their working directory is inside this checkout. */
+  pids: number[];
+  /** Whether the working-directory-scoped sweep ran. */
+  scoped: boolean;
+  /** What the machine-wide sweep by process name did. */
+  byName: 'skipped' | 'ran' | 'failed';
+};
+
 /**
  * Decide and perform the cleanup this run should do.
  *
- * Scoped selection reads `/proc`, which only Linux has, so on macOS and Windows it can find nothing
- * at all. Those are CI runners in practice, and a CI runner is single-tenant — nothing else on the
- * machine belongs to anyone — so matching by name is both correct and the only option there.
- * Falling through to "do nothing" instead would quietly drop the cleanup on two of the three
- * platforms CI builds on.
+ * The two sweeps answer different questions and are not alternatives. Scoping answers "which
+ * processes are mine", and matters most on a shared developer machine, where a run must clear its
+ * own leaked app without touching a peer's checkout or the app the developer is using. It reads
+ * `/proc`, so only Linux can do it at all.
+ *
+ * The machine-wide sweep answers "is anything left over", and is safe only where the machine
+ * belongs to the run. On a CI runner it is, so it runs there in addition — it matches build
+ * watchers by command line, which selection by process name cannot reach.
+ *
+ * That leaves one combination with nothing to do: off CI, on a platform without `/proc`, where
+ * scoping is impossible and a machine-wide kill would hit the developer's own processes. Doing
+ * nothing is the only safe answer there.
  */
 export function runCleanup(
   {
@@ -197,16 +214,17 @@ export function runCleanup(
     root,
   }: { ciFlag: string | undefined; platform: NodeJS.Platform; root: string },
   actions: CleanupActions,
-): { swept: 'none' | 'scoped' | 'by-name' | 'by-name-failed'; pids: number[] } {
-  if (!isSweepEnabled(ciFlag)) return { swept: 'none', pids: [] };
-  if (platform === 'linux') return { swept: 'scoped', pids: actions.killUnderRoot(root) };
+): CleanupOutcome {
+  const scoped = platform === 'linux';
+  const pids = scoped ? actions.killUnderRoot(root) : [];
+  if (!isSweepEnabled(ciFlag)) return { pids, scoped, byName: 'skipped' };
   try {
     actions.sweepByProcessName();
   } catch {
     // Having nothing to stop is a routine outcome, and the shell-outs behind it (ps, PowerShell's
     // CIM enumeration, fkill) can also exit non-zero or time out. None of that should turn a run
-    // whose tests all passed into a failed one.
-    return { swept: 'by-name-failed', pids: [] };
+    // whose tests all passed into a failed one, nor discard pids already terminated.
+    return { pids, scoped, byName: 'failed' };
   }
-  return { swept: 'by-name', pids: [] };
+  return { pids, scoped, byName: 'ran' };
 }

--- a/e2e-tests/scoped-cleanup.ts
+++ b/e2e-tests/scoped-cleanup.ts
@@ -15,18 +15,24 @@ import path from 'path';
 /** A process considered for cleanup. `cwd` is undefined when it could not be read. */
 export type ProcessCandidate = { pid: number; comm: string; cwd: string | undefined };
 
+/** `/proc/<pid>/comm` is capped at this many characters by the kernel (TASK_COMM_LEN - 1). */
+const COMM_MAX_LENGTH = 15;
+
 /**
- * The only process names cleanup considers.
+ * The only process names cleanup considers, truncated the way `/proc` reports them.
  *
  * Being under the repo root is necessary but NOT sufficient: npm, node and the shell running the
  * suite are rooted there too, and killing them kills the run doing the killing.
  *
  * `dotnet` is the data provider in development (`dotnet watch --project
- * c-sharp/ParanextDataProvider.csproj`), which is how every e2e run launches it. A packaged build
- * runs it as a `ParanextDataProvider` executable instead, named here so a packaged app started by
- * hand in this checkout is not left behind.
+ * c-sharp/ParanextDataProvider.csproj`), which is how every e2e run launches it. `dotnet watch`
+ * then execs the apphost binary, and a packaged build runs that binary directly — so the executable
+ * name is here too. It is longer than the cap, which is exactly why these are truncated rather than
+ * compared whole: spelled in full it would never match anything.
  */
-const SWEEPABLE_PROCESS_NAMES = ['electron', 'dotnet', 'ParanextDataProvider'];
+const SWEEPABLE_PROCESS_NAMES = ['electron', 'dotnet', 'ParanextDataProvider'].map((name) =>
+  name.slice(0, COMM_MAX_LENGTH),
+);
 
 /** Values that mean "no" even though they are non-empty strings. */
 const NEGATIVE_FLAG_VALUES = ['0', 'false', 'no', 'off'];
@@ -61,13 +67,20 @@ export function selectPidsUnderRoot(
 ): number[] {
   const resolvedRoot = path.resolve(root);
   const prefix = `${resolvedRoot}${path.sep}`;
+  // Worktrees of this repository live at <root>/.claude/worktrees/<name>, so they sit INSIDE the
+  // root by path while belonging to a different checkout and, usually, a different run. Plain
+  // containment would claim all of them, which is the same cross-checkout kill this module exists
+  // to prevent. A run whose own root IS such a directory is unaffected: the container it excludes
+  // is relative to its own root, not the canonical one.
+  const nestedWorktrees = `${path.join(resolvedRoot, '.claude', 'worktrees')}${path.sep}`;
   return candidates
     .filter((candidate) => !excludePids.includes(candidate.pid))
     .filter((candidate) => SWEEPABLE_PROCESS_NAMES.includes(candidate.comm))
     .filter(
       (candidate) =>
         candidate.cwd !== undefined &&
-        (candidate.cwd === resolvedRoot || candidate.cwd.startsWith(prefix)),
+        (candidate.cwd === resolvedRoot || candidate.cwd.startsWith(prefix)) &&
+        !candidate.cwd.startsWith(nestedWorktrees),
     )
     .map((candidate) => candidate.pid);
 }
@@ -170,9 +183,16 @@ export function runCleanup(
     root,
   }: { ciFlag: string | undefined; platform: NodeJS.Platform; root: string },
   actions: CleanupActions,
-): { swept: 'none' | 'scoped' | 'by-name'; pids: number[] } {
+): { swept: 'none' | 'scoped' | 'by-name' | 'by-name-failed'; pids: number[] } {
   if (!isSweepEnabled(ciFlag)) return { swept: 'none', pids: [] };
   if (platform === 'linux') return { swept: 'scoped', pids: actions.killUnderRoot(root) };
-  actions.sweepByProcessName();
+  try {
+    actions.sweepByProcessName();
+  } catch {
+    // Having nothing to stop is a routine outcome, and the shell-outs behind it (ps, PowerShell's
+    // CIM enumeration, fkill) can also exit non-zero or time out. None of that should turn a run
+    // whose tests all passed into a failed one.
+    return { swept: 'by-name-failed', pids: [] };
+  }
   return { swept: 'by-name', pids: [] };
 }

--- a/e2e-tests/scoped-cleanup.ts
+++ b/e2e-tests/scoped-cleanup.ts
@@ -1,13 +1,13 @@
 /**
  * Teardown cleanup scoped to the checkout that ran the tests.
  *
- * The suite's teardown used to finish by running `npm run stop`, which kills every process named
- * `electron` or `dotnet` on the machine. That is defensible on a CI runner the run owns, and wrong
- * anywhere else: it takes down the developer's own app, any app a CDP-based suite is attached to,
- * and other checkouts' runs on the same box.
+ * Matching processes by NAME reaches every `electron` and `dotnet` on the machine: the developer's
+ * own app, any app a CDP-based suite is attached to, and other checkouts' runs on a shared box.
+ * Selection here is by working directory instead, so cleanup reaches only what this checkout
+ * started.
  *
- * Two decisions keep it honest, and both live here so they can be tested without killing anything:
- * whether to sweep at all, and which processes belong to this checkout.
+ * Two decisions live here so they can be tested without killing anything: whether to sweep at all,
+ * and which processes belong to this checkout.
  */
 import fs from 'fs';
 import path from 'path';
@@ -16,12 +16,17 @@ import path from 'path';
 export type ProcessCandidate = { pid: number; comm: string; cwd: string | undefined };
 
 /**
- * The process names the machine-wide sweep used to match, and the only ones considered here.
+ * The only process names cleanup considers.
  *
- * Being under the repo root is NOT sufficient on its own: npm, node and the shell running the suite
- * are all rooted there too, and killing them kills the run doing the killing.
+ * Being under the repo root is necessary but NOT sufficient: npm, node and the shell running the
+ * suite are rooted there too, and killing them kills the run doing the killing.
+ *
+ * `dotnet` is the data provider in development (`dotnet watch --project
+ * c-sharp/ParanextDataProvider.csproj`), which is how every e2e run launches it. A packaged build
+ * runs it as a `ParanextDataProvider` executable instead, named here so a packaged app started by
+ * hand in this checkout is not left behind.
  */
-const SWEEPABLE_PROCESS_NAMES = ['electron', 'dotnet'];
+const SWEEPABLE_PROCESS_NAMES = ['electron', 'dotnet', 'ParanextDataProvider'];
 
 /** Values that mean "no" even though they are non-empty strings. */
 const NEGATIVE_FLAG_VALUES = ['0', 'false', 'no', 'off'];
@@ -67,25 +72,32 @@ export function selectPidsUnderRoot(
     .map((candidate) => candidate.pid);
 }
 
+/** The parent of `pid`, or undefined when it cannot be read. */
+function readParentPid(pid: number): number | undefined {
+  try {
+    // /proc/<pid>/stat field 4 is the parent pid. Field 2 is the command name, which can contain
+    // spaces and parentheses, so only the fields after the final ')' can be split safely.
+    const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf-8');
+    const afterComm = stat
+      .slice(stat.lastIndexOf(')') + 1)
+      .trim()
+      .split(/\s+/);
+    const parsed = Number.parseInt(afterComm[1] ?? '', 10);
+    return Number.isNaN(parsed) ? undefined : parsed;
+  } catch {
+    return undefined;
+  }
+}
+
 /** This process and every ancestor of it, so cleanup cannot kill the run performing it. */
 export function selfAndAncestorPids(): number[] {
   const pids: number[] = [];
-  let { pid } = process;
-  while (pid !== undefined && pid > 1 && !pids.includes(pid)) {
-    pids.push(pid);
-    try {
-      // /proc/<pid>/stat field 4 is the parent pid. The command name in field 2 can contain spaces
-      // and parentheses, so the fields after the final ')' are what can be split safely.
-      const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf-8');
-      const afterComm = stat
-        .slice(stat.lastIndexOf(')') + 1)
-        .trim()
-        .split(/\s+/);
-      const parsed = Number.parseInt(afterComm[1] ?? '', 10);
-      pid = Number.isNaN(parsed) ? undefined : parsed;
-    } catch {
-      pid = undefined;
-    }
+  let current = process.pid;
+  while (current > 1 && !pids.includes(current)) {
+    pids.push(current);
+    const parent = readParentPid(current);
+    if (parent === undefined) break;
+    current = parent;
   }
   return pids;
 }
@@ -132,4 +144,35 @@ export function killProcessesUnderRoot(root: string): number[] {
     }
   });
   return pids;
+}
+
+/** What a cleanup pass may do, injected so the choice between them is testable. */
+export type CleanupActions = {
+  /** Terminate this checkout's processes, returning their pids. */
+  killUnderRoot: (root: string) => number[];
+  /** Terminate by process name across the machine. Only ever correct where the machine is ours. */
+  sweepByProcessName: () => void;
+};
+
+/**
+ * Decide and perform the cleanup this run should do.
+ *
+ * Scoped selection reads `/proc`, which only Linux has, so on macOS and Windows it can find nothing
+ * at all. Those are CI runners in practice, and a CI runner is single-tenant — nothing else on the
+ * machine belongs to anyone — so matching by name is both correct and the only option there.
+ * Falling through to "do nothing" instead would quietly drop the cleanup on two of the three
+ * platforms CI builds on.
+ */
+export function runCleanup(
+  {
+    ciFlag,
+    platform,
+    root,
+  }: { ciFlag: string | undefined; platform: NodeJS.Platform; root: string },
+  actions: CleanupActions,
+): { swept: 'none' | 'scoped' | 'by-name'; pids: number[] } {
+  if (!isSweepEnabled(ciFlag)) return { swept: 'none', pids: [] };
+  if (platform === 'linux') return { swept: 'scoped', pids: actions.killUnderRoot(root) };
+  actions.sweepByProcessName();
+  return { swept: 'by-name', pids: [] };
 }

--- a/e2e-tests/scoped-cleanup.ts
+++ b/e2e-tests/scoped-cleanup.ts
@@ -1,0 +1,135 @@
+/**
+ * Teardown cleanup scoped to the checkout that ran the tests.
+ *
+ * The suite's teardown used to finish by running `npm run stop`, which kills every process named
+ * `electron` or `dotnet` on the machine. That is defensible on a CI runner the run owns, and wrong
+ * anywhere else: it takes down the developer's own app, any app a CDP-based suite is attached to,
+ * and other checkouts' runs on the same box.
+ *
+ * Two decisions keep it honest, and both live here so they can be tested without killing anything:
+ * whether to sweep at all, and which processes belong to this checkout.
+ */
+import fs from 'fs';
+import path from 'path';
+
+/** A process considered for cleanup. `cwd` is undefined when it could not be read. */
+export type ProcessCandidate = { pid: number; comm: string; cwd: string | undefined };
+
+/**
+ * The process names the machine-wide sweep used to match, and the only ones considered here.
+ *
+ * Being under the repo root is NOT sufficient on its own: npm, node and the shell running the suite
+ * are all rooted there too, and killing them kills the run doing the killing.
+ */
+const SWEEPABLE_PROCESS_NAMES = ['electron', 'dotnet'];
+
+/** Values that mean "no" even though they are non-empty strings. */
+const NEGATIVE_FLAG_VALUES = ['0', 'false', 'no', 'off'];
+
+/**
+ * Whether an environment flag asks for the sweep.
+ *
+ * A plain truthiness test on `process.env.CI` treats `CI=false` and `CI=0` as yes, because both are
+ * non-empty strings — and those are ordinary wrapper and IDE idioms rather than exotic cases. That
+ * reading is what let a developer's machine be swept by a run that had explicitly said not to.
+ */
+export function isSweepEnabled(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === '') return false;
+  return !NEGATIVE_FLAG_VALUES.includes(normalized);
+}
+
+/**
+ * The pids of sweepable processes running inside `root`, excluding `excludePids`.
+ *
+ * Containment is checked against the resolved path with a separator, so a sibling checkout whose
+ * path merely starts with the same characters — `paranext-core-other` beside `paranext-core` — is
+ * not treated as inside it. A process whose working directory could not be read is left alone:
+ * unknown means "not ours", because /proc entries for another user's processes are unreadable and
+ * guessing in that direction is how a neighbour's app gets killed.
+ */
+export function selectPidsUnderRoot(
+  root: string,
+  candidates: ProcessCandidate[],
+  excludePids: number[],
+): number[] {
+  const resolvedRoot = path.resolve(root);
+  const prefix = `${resolvedRoot}${path.sep}`;
+  return candidates
+    .filter((candidate) => !excludePids.includes(candidate.pid))
+    .filter((candidate) => SWEEPABLE_PROCESS_NAMES.includes(candidate.comm))
+    .filter(
+      (candidate) =>
+        candidate.cwd !== undefined &&
+        (candidate.cwd === resolvedRoot || candidate.cwd.startsWith(prefix)),
+    )
+    .map((candidate) => candidate.pid);
+}
+
+/** This process and every ancestor of it, so cleanup cannot kill the run performing it. */
+export function selfAndAncestorPids(): number[] {
+  const pids: number[] = [];
+  let { pid } = process;
+  while (pid !== undefined && pid > 1 && !pids.includes(pid)) {
+    pids.push(pid);
+    try {
+      // /proc/<pid>/stat field 4 is the parent pid. The command name in field 2 can contain spaces
+      // and parentheses, so the fields after the final ')' are what can be split safely.
+      const stat = fs.readFileSync(`/proc/${pid}/stat`, 'utf-8');
+      const afterComm = stat
+        .slice(stat.lastIndexOf(')') + 1)
+        .trim()
+        .split(/\s+/);
+      const parsed = Number.parseInt(afterComm[1] ?? '', 10);
+      pid = Number.isNaN(parsed) ? undefined : parsed;
+    } catch {
+      pid = undefined;
+    }
+  }
+  return pids;
+}
+
+/** Every process this user can see, with its name and working directory. */
+export function readProcessCandidates(): ProcessCandidate[] {
+  let entries: string[];
+  try {
+    entries = fs.readdirSync('/proc');
+  } catch {
+    return [];
+  }
+  return entries.flatMap((entry) => {
+    const pid = Number.parseInt(entry, 10);
+    if (Number.isNaN(pid)) return [];
+    let comm: string;
+    try {
+      comm = fs.readFileSync(`/proc/${pid}/comm`, 'utf-8').trim();
+    } catch {
+      return [];
+    }
+    let cwd: string | undefined;
+    try {
+      cwd = fs.readlinkSync(`/proc/${pid}/cwd`);
+    } catch {
+      cwd = undefined;
+    }
+    return [{ pid, comm, cwd }];
+  });
+}
+
+/**
+ * Terminate sweepable processes belonging to `root`, and report which.
+ *
+ * @returns The pids signalled, so a caller can say what it did rather than claiming a tidy exit.
+ */
+export function killProcessesUnderRoot(root: string): number[] {
+  const pids = selectPidsUnderRoot(root, readProcessCandidates(), selfAndAncestorPids());
+  pids.forEach((pid) => {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // Already gone between listing and signalling; nothing to do.
+    }
+  });
+  return pids;
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,9 @@ const config = defineConfig(async () => {
         'src/**/*.test.tsx',
         'tools/pt9-css-converter/src/**/*.test.ts',
         '.erb/scripts/**/*.test.ts',
+        // e2e HARNESS logic only — never the Playwright specs, which live under
+        // e2e-tests/tests/ and are run by Playwright, not vitest.
+        'e2e-tests/*.test.ts',
       ],
     },
   };


### PR DESCRIPTION
E2E teardown ended by running `npm run stop`, unconditionally (`e2e-tests/global-teardown.ts`). That script matches by process **name** and kills every `electron` and `dotnet` process on the machine, so a run finishing in one checkout took down the developer's own app, any app a CDP-based suite was attached to, and other checkouts' runs on the same box. On a shared machine this is the difference between cleaning up after yourself and cleaning up after everyone.

Two decisions now govern it, and both are testable without killing anything.

## Which cleanup each environment gets

The old code asked one flag to decide two different things, and got both wrong. It skipped everything outside CI — so the scoped sweep ran only on a CI runner, which is single-tenant and the one place scoping buys nothing, while a developer's machine, the reason to scope at all, cleaned up nothing. And it treated the two sweeps as alternatives, so wherever scoping was possible the name sweep's wider reach was lost.

They answer different questions, so they are no longer exclusive:

| | Linux | macOS / Windows |
|---|---|---|
| **off CI** | scoped sweep | nothing |
| **on CI** | scoped sweep **and** name sweep | name sweep |

Scoping asks which processes are this checkout's. It needs `/proc`, and it now runs on Linux in every environment — that is what lets a developer's box clear its own leaks without touching a peer's checkout. The name sweep asks whether anything is left over anywhere; it is safe only where the machine belongs to the run, so CI gets it in addition, keeping exactly the coverage it had. Off CI without `/proc` there is nothing safe to do, and that is the only cell that does nothing.

Where the flag is still read, it is read as a real boolean. The previous form treated `CI=false` and `CI=0` as yes, because both are non-empty strings — ordinary wrapper and IDE idioms, not exotic cases.

## What gets swept

Selection is by working directory, never by process name. A process is a candidate only if it is running inside this checkout, and:

- a sibling path that merely shares the prefix (`paranext-core-other` beside `paranext-core`) does not count;
- **a worktree of this repository does not count either.** Worktrees live at `<root>/.claude/worktrees/<name>` — inside the root by path, but a different checkout and usually a different run. Containment alone would have claimed every one of them, which is the same cross-checkout kill this change exists to prevent. Selection is relative to whichever root is asking, so a run *inside* a worktree still cleans up after itself;
- a process whose working directory cannot be read is left alone — unreadable means another user's process, and guessing in that direction is exactly how a neighbour's app gets killed;
- this process and its ancestors are excluded, so cleanup cannot kill the run performing it;
- being inside the checkout is necessary but **not sufficient**: npm, node and the shell running the suite are rooted there too, so only the app's own process names are considered;
- the root itself is resolved through symlinks. A working directory read from `/proc` is always fully resolved, so a run launched through a symlinked checkout would otherwise compare its processes against a path none of them can match and clean up nothing at all.

Those names are matched as the kernel reports them. `/proc/<pid>/comm` is capped at fifteen characters, so `ParanextDataProvider` appears there as `ParanextDataPro`; the full spelling is kept in the source and truncated at the comparison.


The dev-server kill by pid file is unchanged — it was already scoped to what the run started.

## Platforms without `/proc`

Scoped selection needs `/proc`, so on macOS and Windows the old name sweep is still what runs. Its failure is caught: having nothing to stop is a routine outcome there, and the shell-outs behind it can exit non-zero or time out — without the catch, a run whose tests all passed would end as a failed one.

## The one consequence to look at

On Linux the scoped sweep now runs off CI, so an e2e run will terminate an `electron` or `dotnet` process inside its own checkout that it did not start — a dev app left running in that same checkout.

In practice neither config can reach that state. The launch-based config's `globalSetup` throws when port 8876 is already bound (`Port 8876 is already in use`), and Playwright does not run `globalTeardown` when `globalSetup` throws, so the run aborts before any test rather than killing anything. The config used when an app *is* deliberately running — `playwright-cdp.config.ts`, for the attached specs — declares no `globalSetup` or `globalTeardown` at all, so it never reaches this code. The residual case is an app started *during* a run in the same checkout, which teardown will kill.

## Verification

Twenty unit tests over the two decisions, including all six cells of the dispatch matrix, the sibling-prefix case, the nested-worktree case (both directions), the symlinked-root case, the unreadable-cwd case, the self-exclusion case, and the comm-truncation case. Each guard was checked by mutation — removed, then confirmed a test goes red.

Proven live as well: two processes named `electron` were started, one running inside the checkout and one outside it, and offered to the selection.

```
WOULD KILL: [1971257, 1973080]
inside(1973080) selected?  true
outside(1973081) selected? false

after: inside  — killed
       outside — survived
```

The unscoped sweep was never run on this machine to test this; the scoped function was called directly.

## Note for reviewers

This branch is off `main`, where `tsc -p e2e-tests/tsconfig.json` already fails with 14 pre-existing errors in `enhanced-resources` and `internet-settings`. None are from this change — my own files typecheck clean — and #2755 fixes them.

#2726 carries an earlier, weaker version of this gate; it will restack onto this branch and drop that hunk, along with the `vitest.config.ts` include line, which both branches touch.

AI-assisted — [session](https://claude.ai/code/session_01QyoVc1Cd9L2RcuDGE3T3FT)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QyoVc1Cd9L2RcuDGE3T3FT

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2757)
<!-- Reviewable:end -->
