### PR TITLE
ci: give react unit tests 15 s and stop the matrix failing fast

### DIFF
--- a/.context/standards/Testing-Guide.md
+++ b/.context/standards/Testing-Guide.md
@@ -395,6 +395,8 @@ export default defineConfig(async () => {
       // Warms the lazy one-time ICU init behind Intl.* so it never lands inside a test's
       // timeout window on a slow CI worker. See vitest.setup.ts for the rationale.
       setupFiles: ['./vitest.setup.ts'],
+      // Must stay comfortably above vitest.setup.ts's asyncUtilTimeout — see note below.
+      testTimeout: 15000,
       include: ['src/**/*.test.ts', 'src/**/*.test.tsx'],
     },
   };
@@ -404,6 +406,16 @@ export default defineConfig(async () => {
 > The workspace configs (`extensions/vitest.config.ts`, `lib/platform-bible-utils/vite.config.ts`,
 > `lib/platform-bible-react/vitest.config.ts`) reference this same repo-root `vitest.setup.ts` via a
 > relative `setupFiles` path, so every vitest worker warms Intl once before any timed test.
+
+> **`testTimeout` vs. `asyncUtilTimeout`.** `vitest.setup.ts` also raises testing-library's own
+> `asyncUtilTimeout` — the deadline a bare `waitFor`/`findBy*` gives up at — independently of
+> vitest's per-test `testTimeout`. `testTimeout`'s clock starts at the beginning of the test body,
+> while a given `waitFor` call only starts its own `asyncUtilTimeout` countdown when that call is
+> reached, so whichever deadline elapses first wins. Every project that loads this shared setup
+> file must keep its own `testTimeout` comfortably above `asyncUtilTimeout` — not just nominally
+> above it, since any work a test does before reaching the `waitFor` call eats into that margin —
+> or a failing `waitFor` is reported as vitest's bare timeout instead of testing-library's richer
+> error (with its DOM dump), silently losing the more useful failure message.
 
 ### Key Dependencies
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,9 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     strategy:
+      # A unit-test flake on one runner must not cancel the others: the blocking E2E suite runs only
+      # on Linux, so cancelling it because Windows was slow leaves the PR with no signal at all.
+      fail-fast: false
       matrix:
         # Make sure these match with the env values above
         os: [windows-latest, macos-15, ubuntu-22.04]

--- a/extensions/vitest.config.ts
+++ b/extensions/vitest.config.ts
@@ -13,6 +13,11 @@ const config = defineConfig({
       path.resolve(__dirname, '../vitest.setup.ts'),
       path.resolve(__dirname, '../vitest.setup.node.ts'),
     ],
+    // The shared vitest.setup.ts raises testing-library's asyncUtilTimeout to 5 s so a `waitFor`
+    // slowed by CI contention gives up on its own before the test's overall budget, rather than
+    // sharing vitest's own testTimeout and losing the race to it. That budget must stay
+    // comfortably below this one for testing-library's richer failure to ever be reachable.
+    testTimeout: 15000,
     include: ['src/**/*.test.ts', 'src/**/*.test.tsx', 'lib/**/*.test.ts', 'lib/**/*.test.tsx'],
   },
   resolve: {

--- a/lib/platform-bible-react/vitest.config.ts
+++ b/lib/platform-bible-react/vitest.config.ts
@@ -24,6 +24,10 @@ const workspace = defineConfig({
           globals: true,
           environment: 'jsdom',
           setupFiles: [intlWarmupSetup],
+          // Timing-sensitive component tests here wait on React state settling, and on a contended
+          // windows-latest runner that wait crosses the 5 s default while the assertion itself is
+          // sound. 15 s absorbs the contention and still bounds a genuine hang.
+          testTimeout: 15000,
         },
       },
       // Node.js tests for build scripts

--- a/lib/platform-bible-react/vitest.config.ts
+++ b/lib/platform-bible-react/vitest.config.ts
@@ -27,6 +27,9 @@ const workspace = defineConfig({
           // Timing-sensitive component tests here wait on React state settling, and on a contended
           // windows-latest runner that wait crosses the 5 s default while the assertion itself is
           // sound. 15 s absorbs the contention and still bounds a genuine hang.
+          // The shared vitest.setup.ts also raises testing-library's asyncUtilTimeout to 5 s; this
+          // budget must stay comfortably above that one for testing-library's richer failure to
+          // ever be reachable.
           testTimeout: 15000,
         },
       },

--- a/lib/platform-bible-react/vitest.config.ts
+++ b/lib/platform-bible-react/vitest.config.ts
@@ -37,6 +37,12 @@ const workspace = defineConfig({
           include: ['scripts/**/*.test.ts'],
           environment: 'node',
           setupFiles: [intlWarmupSetup],
+          // The shared vitest.setup.ts raises testing-library's asyncUtilTimeout to 5 s so a
+          // `waitFor` slowed by CI contention gives up on its own before the test's overall
+          // budget, rather than sharing vitest's own testTimeout and losing the race to it. That
+          // budget must stay comfortably below this one for testing-library's richer failure to
+          // ever be reachable.
+          testTimeout: 15000,
         },
       },
       // Browser tests for Storybook

--- a/lib/platform-bible-utils/vite.config.ts
+++ b/lib/platform-bible-utils/vite.config.ts
@@ -47,6 +47,11 @@ const config = defineConfig({
       path.resolve(__dirname, '../../vitest.setup.ts'),
       path.resolve(__dirname, '../../vitest.setup.node.ts'),
     ],
+    // The shared vitest.setup.ts raises testing-library's asyncUtilTimeout to 5 s so a `waitFor`
+    // slowed by CI contention gives up on its own before the test's overall budget, rather than
+    // sharing vitest's own testTimeout and losing the race to it. That budget must stay
+    // comfortably below this one for testing-library's richer failure to ever be reachable.
+    testTimeout: 15000,
   },
 });
 export default config;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,6 +11,11 @@ const config = defineConfig(async () => {
       // Warms the lazy one-time ICU init behind Intl.* so it never lands inside a test's timeout
       // window on a slow CI worker. See vitest.setup.ts for the full rationale.
       setupFiles: ['./vitest.setup.ts'],
+      // vitest.setup.ts raises testing-library's asyncUtilTimeout to 5 s so a `waitFor` slowed by
+      // CI contention gives up on its own before the test's overall budget, rather than sharing
+      // vitest's own testTimeout and losing the race to it. That budget must stay comfortably
+      // below this one for testing-library's richer failure to ever be reachable.
+      testTimeout: 15000,
       include: [
         'src/**/*.test.ts',
         'src/**/*.test.tsx',

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -53,6 +53,13 @@ new Intl.ListFormat(locale).format(['a', 'b']);
 // that were queued while cb() ran — a bare Promise.resolve() only drains one microtask level
 // and misses multi-await async chains (e.g., two sequential sendCommand() awaits in a hook).
 configure({
+  // Testing-library's own budget, which is separate from vitest's `testTimeout` and is NOT raised by
+  // it: a bare `waitFor` gives up after this long and fails the test while vitest is still content.
+  // Timing-sensitive component tests here spend it waiting for React state to settle, and on a
+  // contended windows-latest runner that wait crosses 1 s while the assertion is sound — the same
+  // class as the per-test budget, one level down. Five seconds absorbs the contention and still
+  // bounds a wait that is never going to succeed.
+  asyncUtilTimeout: 5000,
   asyncWrapper: async (cb) => {
     // Temporarily clear the React act environment flag so that `waitFor` polling intervals don't
     // produce "not wrapped in act" warnings (mirrors the intent of @testing-library/react's original


### PR DESCRIPTION
## Summary

Three branches failed CI today on three different `platform-bible-react` component tests, each a
timing-sensitive assertion that ran out of time on `windows-latest`:

| Run | Test |
|---|---|
| 33624120083 | `select-books-picker.component.test.tsx` — 5122 ms |
| 33622636517 | `comment-thread.component.test.tsx` — `CommentThread assignee state machine` |
| 33620874987 | the footnote caller-dropdown `waitFor` |

None of those branches touches `lib/platform-bible-react`, so the tests are not what changed: the
runner is contended and the budgets are too tight for assertions that wait on React state settling.

**There are two budgets, and they are not the same one.** Measuring the three failures separated
them:

| Failure | Elapsed | Budget crossed |
|---|---|---|
| `select-books-picker` | 5122 ms | vitest `testTimeout`, default 5 s |
| footnote caller-dropdown | 5099 ms | vitest `testTimeout`, default 5 s |
| `comment-thread` | **1263 ms** | testing-library `asyncUtilTimeout`, default **1 s** |

The comment-thread one is the reason this PR needed a second commit. It fails inside a bare
`waitFor`, which gives up after one second while vitest is still waiting patiently — so raising
`testTimeout` does not touch it, and an earlier version of this description wrongly claimed the
class was closed. That test runs in 71 ms on an idle machine.

## Changes

- **`testTimeout` goes to 15 s in the react `unit` project**, then (commit `4e51ab6f`, see the
  Addendum below) **in the four other projects that load the shared `vitest.setup.ts`** — the
  repo-root config, `platform-bible-utils`, `platform-bible-react`'s `scripts` project, and
  `extensions` — so `testTimeout` sits above `asyncUtilTimeout` (next bullet) everywhere the latter
  applies. Only the `storybook` project (browser mode, no shared setup file) keeps the 5 s default,
  so a genuine hang there is still bounded. 15 s absorbs the contention without making a real hang
  cheap.
- **Testing-library's `asyncUtilTimeout` goes to 5 s**, in the shared `vitest.setup.ts`. That setup
  file is loaded by five configs — the repo-root `vitest.config.ts`, `platform-bible-utils`,
  `platform-bible-react` (both its `unit` and `scripts` projects), and `extensions` — so this budget
  rises across all of them. The `extensions` suite leans on testing-library heavily too
  (comment-list, manage-books-dialog, use-bcv-sync-scroll, use-auto-search-debounce, and more), so
  its async budget genuinely rises there as well — it is not inert. Deliberate for the projects that
  wait on the same React state on the same runner; it is the wider of the two changes and should be
  read as one.
- **The build matrix stops failing fast.** This is the half that turns a flake into an outage: the
  blocking E2E suite runs only on Linux, so a Windows unit flake was cancelling the one job that
  produces the signal a PR is gated on. With `fail-fast: false`, a Windows wobble costs a red
  Windows job instead of "no PR can go green".

## Why both

Either alone leaves the problem. Raising the timeout reduces how often Windows trips, but any future
Windows failure still cancels the Linux E2E. Disabling fail-fast keeps the E2E signal, but leaves a
red Windows job on every affected PR. Together, the common case stops happening and the uncommon
case stops being fatal.

## Testing

`comment-thread.component.test.tsx` passes under the new config (8 tests) — the file that motivated
the second budget. The repo-root suite passes with the raised async budget (208 files, 2955 tests),
which is the half with the wider blast radius. The workflow YAML parses with `fail-fast: false` on
the matrix job and the OS list unchanged. No product code is touched.

**What this does not demonstrate.** A green run here is the runner having a good hour, not evidence
the fix works: the value of a raised budget shows up as the absence of future red, which no single
run can show. What is verifiable is the mechanism — the three failures were measured against the two
budgets, and each is now above the one it crossed.

## Risk Level

Low, and self-limiting. Neither budget can mask a failure — a test that genuinely fails still fails,
and a `waitFor` that is never going to succeed still gives up; only the deadline for something merely
slow moves. Disabling fail-fast makes CI slower to
report on a broken commit (all three jobs run to completion) and costs more runner minutes; that is
the deliberate trade for not losing the E2E signal.

## AI Involvement

AI-assisted — [session](https://claude.ai/code/session_01VumBqDNMeTmKXenGEjX5T8). Claude read the
three failing runs, located the react package's own vitest config and its three named projects,
made both changes, verified the previously-failing test file passes and the workflow YAML parses,
and drafted this description. The scope — which project's timeout, and pairing it with `fail-fast`
— was directed rather than chosen by the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VumBqDNMeTmKXenGEjX5T8

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2759)
<!-- Reviewable:end -->




## Addendum — the risk statement now holds across all five projects

Review found that the Risk Level section's claim — "a `waitFor` that is never going to succeed
still gives up [with a real, diagnosable error]" — held only for the platform-bible-react `unit`
project as originally written. The other four projects that load the shared `vitest.setup.ts`
(the repo root, `extensions`, `platform-bible-utils`, and platform-bible-react's `scripts`
project) had no `testTimeout` override, so the new `asyncUtilTimeout: 5000` landed exactly equal
to vitest's own 5000 ms default there. Vitest's per-test clock starts before the test body runs,
ahead of testing-library's own `waitFor` timer, so it always won that race — a failing `waitFor`
in those four projects reported vitest's bare `Test timed out` with no DOM dump instead of
testing-library's richer error.

Fixed in commit `4e51ab6f1e33857a22178599c88de083b4d10c65`: `testTimeout` is now raised to
15000 ms in those four projects too, matching the value the `unit` project already used, so
`asyncUtilTimeout` sits below every consuming project's `testTimeout` everywhere it's loaded. The
Risk Level statement now holds across all five projects, not just one.

