### PR TITLE
Revert the Formatted-view marker palette to its pre-Standard-View behavior

### DIFF
--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.tsx
@@ -1918,7 +1918,6 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
         notifyStructureProtected,
         restoreEditorSelection,
         contextMarker,
-        styleInfo,
       ),
     [
       contextMarker,
@@ -1926,7 +1925,6 @@ globalThis.webViewComponent = function PlatformScriptureEditor({
       isStructureProtected,
       notifyStructureProtected,
       restoreEditorSelection,
-      styleInfo,
     ],
   );
 

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.utils.test.ts
@@ -1,14 +1,12 @@
 // @vitest-environment jsdom
-// The module under test pulls in `getMarkerMenuItems`/`defaultStyleInfo` as real (not type-only)
-// imports from `@eten-tech-foundation/platform-editor`, whose bundled entry point touches
-// `document` at module-eval time (it re-exports the whole editor, React components and all). The
-// default `node` environment (see `vitest.config.ts`) has no `document`, so this file needs jsdom
-// — same fix already used by `scripture-pane.test.tsx` and `use-editor-pdp-sync.hook.test.ts` for
-// the same package.
+// The module under test value-imports `platform-bible-react`, whose bundled entry point touches
+// `document` at module-eval time (it re-exports the whole component library). The default `node`
+// environment (see `vitest.config.ts`) has no `document`, so this file needs jsdom — same fix
+// already used by `scripture-pane.test.tsx` and `use-editor-pdp-sync.hook.test.ts`.
 import { describe, it, expect, vi } from 'vitest';
 import { MutableRefObject } from 'react';
-import type { EditorRef, SelectionRange, StyleInfo } from '@eten-tech-foundation/platform-editor';
-import { isLocalizeKey, type LanguageStrings } from 'platform-bible-utils';
+import type { EditorRef, SelectionRange } from '@eten-tech-foundation/platform-editor';
+import { isBlockMarker, isLocalizeKey } from 'platform-bible-utils';
 import {
   generateInlineMarkerMenuListItems,
   getChapterKey,
@@ -34,158 +32,72 @@ function makeMockEditorRef() {
 }
 
 describe('generateInlineMarkerMenuListItems', () => {
+  // The 'p' parent's children include block markers (e.g. 'q' poetry, 's1' section heading) and
+  // inline markers (e.g. 'f' footnote, 'x' cross-reference) against the real usfmMarkers data.
   const PARENT = 'p';
   const noop = () => {};
 
-  // Minimal project-stylesheet fixture (as if merged from usfm.sty + custom.sty and serialized by
-  // the host), carrying one of each styleType the menu has to handle: 'p' the parent paragraph and
-  // 'q1'/'s1' two more block styles, 'v' a verse marker (the library classifies it as styleType
-  // "character", but `isBlockMarker` special-cases 'v' as structural — same as PT9), 'f' a note
-  // marker, and 'nd' a plain inline character marker. `wj` is deliberately absent here and added
-  // back per-test to exercise stylesheet-driven inclusion/exclusion.
-  const BASE_STYLE_INFO: StyleInfo = {
-    markers: {
-      p: { marker: 'p', styleType: 'paragraph' },
-      q1: { marker: 'q1', styleType: 'paragraph', description: 'Poetic line' },
-      s1: { marker: 's1', styleType: 'paragraph', description: 'Section heading' },
-      v: { marker: 'v', styleType: 'character' },
-      f: { marker: 'f', styleType: 'note', endMarker: 'f*', description: 'A Footnote text item' },
-      nd: { marker: 'nd', styleType: 'character', description: 'For name of deity' },
-    },
-  };
-
-  /** Invoke the generator with the fixture stylesheet, overriding only what a test cares about. */
-  function generate({
-    localizedStrings = {},
-    isStructureProtected = false,
-    notifyStructureProtected = vi.fn(),
-    restoreSelection,
-    parentMarker = PARENT,
-    styleInfo = BASE_STYLE_INFO,
-    ref = makeMockEditorRef().ref,
-    closeMarkersMenu = vi.fn(),
-  }: {
-    localizedStrings?: LanguageStrings;
-    isStructureProtected?: boolean;
-    notifyStructureProtected?: () => void;
-    restoreSelection?: () => void;
-    parentMarker?: string;
-    styleInfo?: StyleInfo;
-    ref?: MutableRefObject<EditorRef | null>;
-    closeMarkersMenu?: () => void;
-  } = {}) {
-    return generateInlineMarkerMenuListItems(
+  it('offers both block and inline markers for the parent', () => {
+    const { ref } = makeMockEditorRef();
+    const markers = generateInlineMarkerMenuListItems(
       ref,
-      closeMarkersMenu,
-      localizedStrings,
-      isStructureProtected,
-      notifyStructureProtected,
-      restoreSelection,
-      parentMarker,
-      styleInfo,
-    );
-  }
+      noop,
+      {},
+      false,
+      vi.fn(),
+      undefined,
+      PARENT,
+    ).map((item) => item.marker ?? '');
 
-  it('offers BOTH block and inline markers, so `\\` in the Formatted view reaches the whole stylesheet', () => {
-    const markers = generate().map((item) => item.marker);
-
-    // The two kinds the menu exists to combine. `nd` is a character style, `p`/`q1`/`s1` are block
-    // styles — the library's own `character` and `paragraph` sources are mutually exclusive, so a
-    // list holding both can only have come from merging them.
-    expect(markers).toEqual(expect.arrayContaining(['nd', 'f', 'p', 'q1', 's1']));
+    // The menu is the one place a user can reach either kind from the keyboard, so both have to be
+    // there: 'nd'/'wj' character styles, 'f'/'x' notes, 'p'/'q'/'s1' block styles.
+    expect(markers).toEqual(expect.arrayContaining(['nd', 'wj', 'f', 'x', 'p', 'q', 's1']));
+    expect(markers.filter((marker) => isBlockMarker(marker)).length).toBeGreaterThan(0);
+    expect(markers.filter((marker) => !isBlockMarker(marker)).length).toBeGreaterThan(0);
   });
 
-  it('omits block markers when the caret is in a character span, which cannot start a paragraph', () => {
-    // Positive control: this same stylesheet DOES yield block markers from a block context, so an
-    // absent block half below is the gate doing its job, not the block half having gone missing.
-    expect(generate({ parentMarker: PARENT }).map((item) => item.marker)).toContain('q1');
-
-    const markers = generate({ parentMarker: 'nd' }).map((item) => item.marker);
-
-    // ...and the character half still arrives, so this is not merely an empty menu.
-    expect(markers).toContain('nd');
-    expect(markers).not.toContain('p');
-    expect(markers).not.toContain('q1');
-    expect(markers).not.toContain('s1');
-  });
-
-  it('omits block markers when the caret is in a note, which cannot contain a paragraph', () => {
-    expect(generate({ parentMarker: PARENT }).map((item) => item.marker)).toContain('q1');
-
-    const markers = generate({ parentMarker: 'f' }).map((item) => item.marker);
-
-    expect(markers).toContain('nd');
-    expect(markers).not.toContain('p');
-    expect(markers).not.toContain('q1');
-    expect(markers).not.toContain('s1');
-  });
-
-  it('offers block markers under any block context, not just the caret paragraph itself', () => {
-    // Guards against a merge that only ever echoes `parentMarker` back: asking from inside `\s1`
-    // must still offer `p` and `q1`.
-    const markers = generate({ parentMarker: 's1' }).map((item) => item.marker);
-
-    expect(markers).toEqual(expect.arrayContaining(['p', 'q1', 's1', 'nd']));
-  });
-
-  it('when protected: every block marker is disallowed while inline markers stay insertable', () => {
-    const items = generate({ isStructureProtected: true });
-    const isDisallowed = (marker: string) => items.find((i) => i.marker === marker)?.isDisallowed;
-
-    expect(isDisallowed('p')).toBe(true);
-    expect(isDisallowed('q1')).toBe(true);
-    expect(isDisallowed('s1')).toBe(true);
-    expect(isDisallowed('nd')).toBeFalsy();
-    expect(isDisallowed('f')).toBeFalsy();
-  });
-
-  it('keeps basic markers ahead of non-basic ones across the merged list', () => {
-    // `(basic)` in a stylesheet Description is what PT9's ScrTag.IsBasic reads, and the library
-    // lifts it into its ordering. A naive concatenation would strand a basic block marker behind
-    // every non-basic character marker.
-    const items = generate({
-      styleInfo: {
-        markers: {
-          ...BASE_STYLE_INFO.markers,
-          q1: { marker: 'q1', styleType: 'paragraph', description: 'Poetic line (basic)' },
-          nd: { marker: 'nd', styleType: 'character', description: 'For name of deity' },
-        },
-      },
-    });
-    const markers = items.map((item) => item.marker);
-
-    expect(markers.indexOf('q1')).toBeLessThan(markers.indexOf('nd'));
-  });
-
-  it('when protected: a block-marker item is disallowed and its action notifies without inserting', () => {
-    const { ref, insertMarker } = makeMockEditorRef();
-    const notify = vi.fn();
-    const close = vi.fn();
-    const items = generate({
+  it('offers only the markers the parent declares as children', () => {
+    const { ref } = makeMockEditorRef();
+    const markers = generateInlineMarkerMenuListItems(
       ref,
-      closeMarkersMenu: close,
-      isStructureProtected: true,
-      notifyStructureProtected: notify,
-    });
+      noop,
+      {},
+      false,
+      vi.fn(),
+      undefined,
+      PARENT,
+    ).map((item) => item.marker);
 
-    const blockItem = items.find((i) => i.marker === 'p');
-    expect(blockItem?.isDisallowed).toBe(true);
-
-    blockItem?.action?.();
-    expect(notify).toHaveBeenCalledTimes(1);
-    expect(close).toHaveBeenCalledTimes(1);
-    expect(insertMarker).not.toHaveBeenCalled();
+    // Parent-scoped, not the whole marker table: 'p' declares no introduction markers, and a menu
+    // that offered them would be listing markers that cannot occur here.
+    expect(markers).not.toContain('ip');
+    expect(markers).not.toContain('imt');
   });
 
-  it('when protected: the verse marker is disallowed too, though the sheet types it as a character', () => {
-    const items = generate({ isStructureProtected: true });
+  it('sorts by marker code', () => {
+    const { ref } = makeMockEditorRef();
+    const markers = generateInlineMarkerMenuListItems(
+      ref,
+      noop,
+      {},
+      false,
+      vi.fn(),
+      undefined,
+      PARENT,
+    ).map((item) => item.marker ?? '');
 
-    // `isBlockMarker` special-cases `v` as structural, same as PT9 — so it is blocked while
-    // structure protection is on even though it arrives via the character source.
-    expect(items.find((i) => i.marker === 'v')?.isDisallowed).toBe(true);
+    expect(markers).toEqual([...markers].sort((a, b) => a.localeCompare(b)));
   });
 
-  it('when protected: inline-marker item (f) is allowed and its action inserts', () => {
+  it('returns [] for a parent with no children, so the menu never opens empty', () => {
+    const { ref } = makeMockEditorRef();
+    // 'nd' is a leaf character marker — nothing can be inserted under it.
+    expect(
+      generateInlineMarkerMenuListItems(ref, noop, {}, false, vi.fn(), undefined, 'nd'),
+    ).toEqual([]);
+  });
+
+  it('when protected: block-marker item is disallowed and its action notifies without inserting', () => {
     const { ref, insertMarker } = makeMockEditorRef();
     const notify = vi.fn();
     const close = vi.fn();
@@ -197,7 +109,29 @@ describe('generateInlineMarkerMenuListItems', () => {
       notify,
       undefined,
       PARENT,
-      BASE_STYLE_INFO,
+    );
+
+    const blockItem = items.find((i) => i.marker === 'q');
+    expect(blockItem?.isDisallowed).toBe(true);
+
+    blockItem?.action?.();
+    expect(notify).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(insertMarker).not.toHaveBeenCalled();
+  });
+
+  it('when protected: inline-marker item is allowed and its action inserts', () => {
+    const { ref, insertMarker } = makeMockEditorRef();
+    const notify = vi.fn();
+    const close = vi.fn();
+    const items = generateInlineMarkerMenuListItems(
+      ref,
+      close,
+      {},
+      true,
+      notify,
+      undefined,
+      PARENT,
     );
 
     const inlineItem = items.find((i) => i.marker === 'f');
@@ -221,16 +155,30 @@ describe('generateInlineMarkerMenuListItems', () => {
       notify,
       undefined,
       PARENT,
-      BASE_STYLE_INFO,
     );
 
     expect(items.length).toBeGreaterThan(0);
     expect(items.every((i) => !i.isDisallowed)).toBe(true);
 
-    items.forEach((item) => item.action?.());
-    expect(insertMarker).toHaveBeenCalledTimes(items.length);
-    items.forEach((item) => expect(insertMarker).toHaveBeenCalledWith(item.marker));
+    items[0].action?.();
+    expect(insertMarker).toHaveBeenCalledWith(items[0].marker);
     expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('localizes marker titles, falling back to the raw localize key when not loaded', () => {
+    const { ref } = makeMockEditorRef();
+    const items = generateInlineMarkerMenuListItems(
+      ref,
+      noop,
+      { '%markerMenu_marker_f_description%': 'Fußnote (übersetzt)' },
+      false,
+      vi.fn(),
+      undefined,
+      PARENT,
+    );
+
+    expect(items.find((i) => i.marker === 'f')?.title).toBe('Fußnote (übersetzt)');
+    expect(items.find((i) => i.marker === 'nd')?.title).toBe('%markerMenu_marker_nd_description%');
   });
 
   it('restores the caret before inserting, so a pick made after the menu took focus still lands', () => {
@@ -244,7 +192,6 @@ describe('generateInlineMarkerMenuListItems', () => {
       vi.fn(),
       restoreSelection,
       PARENT,
-      BASE_STYLE_INFO,
     );
 
     items[0].action?.();
@@ -269,7 +216,6 @@ describe('generateInlineMarkerMenuListItems', () => {
       vi.fn(),
       restoreSelection,
       PARENT,
-      BASE_STYLE_INFO,
     );
 
     items.find((item) => item.isDisallowed)?.action?.();
@@ -281,160 +227,6 @@ describe('generateInlineMarkerMenuListItems', () => {
   it('returns [] when there is no parent marker', () => {
     const { ref } = makeMockEditorRef();
     expect(generateInlineMarkerMenuListItems(ref, noop, {}, false, vi.fn())).toEqual([]);
-  });
-
-  it('titles fall back to the raw stylesheet description, or the marker code when no description is given', () => {
-    const { ref } = makeMockEditorRef();
-    const items = generateInlineMarkerMenuListItems(
-      ref,
-      noop,
-      {},
-      false,
-      vi.fn(),
-      undefined,
-      PARENT,
-      BASE_STYLE_INFO,
-    );
-
-    expect(items.find((i) => i.marker === 'f')?.title).toBe('A Footnote text item');
-    expect(items.find((i) => i.marker === 'v')?.title).toBe('v');
-  });
-
-  it('prefers the bundled markerMenu LocalizeKey over the stylesheet description when loaded', () => {
-    const { ref } = makeMockEditorRef();
-    const items = generateInlineMarkerMenuListItems(
-      ref,
-      noop,
-      { '%markerMenu_marker_f_description%': 'Fußnote (übersetzt)' },
-      false,
-      vi.fn(),
-      undefined,
-      PARENT,
-      BASE_STYLE_INFO,
-    );
-
-    // The translated markerMenu_marker_* strings are the PRIMARY title source; the raw
-    // stylesheet Description only fills in for markers with no loaded LocalizeKey — which is
-    // what custom.sty markers rely on.
-    expect(items.find((i) => i.marker === 'f')?.title).toBe('Fußnote (übersetzt)');
-    expect(items.find((i) => i.marker === 'v')?.title).toBe('v');
-  });
-
-  it('localizes a description that is a localize key through localizedStrings', () => {
-    const { ref } = makeMockEditorRef();
-    const withLocalizeKeyDescription: StyleInfo = {
-      markers: {
-        ...BASE_STYLE_INFO.markers,
-        nd: { marker: 'nd', styleType: 'character', description: '%marker_nd_description%' },
-      },
-    };
-    const items = generateInlineMarkerMenuListItems(
-      ref,
-      noop,
-      { '%marker_nd_description%': 'For name of deity (localized)' },
-      false,
-      vi.fn(),
-      undefined,
-      PARENT,
-      withLocalizeKeyDescription,
-    );
-
-    expect(items.find((i) => i.marker === 'nd')?.title).toBe('For name of deity (localized)');
-  });
-
-  it('falls back to the raw localize key when localizedStrings has no entry for it', () => {
-    const { ref } = makeMockEditorRef();
-    const withLocalizeKeyDescription: StyleInfo = {
-      markers: {
-        ...BASE_STYLE_INFO.markers,
-        nd: { marker: 'nd', styleType: 'character', description: '%marker_nd_description%' },
-      },
-    };
-    const items = generateInlineMarkerMenuListItems(
-      ref,
-      noop,
-      {},
-      false,
-      vi.fn(),
-      undefined,
-      PARENT,
-      withLocalizeKeyDescription,
-    );
-
-    expect(items.find((i) => i.marker === 'nd')?.title).toBe('%marker_nd_description%');
-  });
-
-  it('omits a marker the supplied project stylesheet does not define (project-invalid)', () => {
-    const { ref } = makeMockEditorRef();
-    const items = generateInlineMarkerMenuListItems(
-      ref,
-      noop,
-      {},
-      false,
-      vi.fn(),
-      undefined,
-      PARENT,
-      BASE_STYLE_INFO,
-    );
-
-    expect(items.some((i) => i.marker === 'wj')).toBe(false);
-  });
-
-  it('includes a marker once the supplied stylesheet defines it (custom.sty addition)', () => {
-    const { ref } = makeMockEditorRef();
-    const withCustomMarker: StyleInfo = {
-      markers: {
-        ...BASE_STYLE_INFO.markers,
-        wj: { marker: 'wj', styleType: 'character', description: 'For marking the words of Jesus' },
-      },
-    };
-    const items = generateInlineMarkerMenuListItems(
-      ref,
-      noop,
-      {},
-      false,
-      vi.fn(),
-      undefined,
-      PARENT,
-      withCustomMarker,
-    );
-
-    expect(items.some((i) => i.marker === 'wj')).toBe(true);
-  });
-
-  it('falls back to the bundled default stylesheet when no project styleInfo is supplied', () => {
-    const { ref } = makeMockEditorRef();
-    const items = generateInlineMarkerMenuListItems(
-      ref,
-      noop,
-      {},
-      false,
-      vi.fn(),
-      undefined,
-      PARENT,
-    );
-
-    // The bundled usfm.sty defines far more inline/note markers under 'p' than the minimal test
-    // fixture above, so this can only pass if the no-styleInfo path is actually wired up.
-    expect(items.length).toBeGreaterThan(Object.keys(BASE_STYLE_INFO.markers).length);
-    expect(items.some((i) => i.marker === 'wj')).toBe(true);
-  });
-
-  it('offers both kinds against the real bundled stylesheet, not just the test fixture', () => {
-    const { ref } = makeMockEditorRef();
-    const markers = generateInlineMarkerMenuListItems(
-      ref,
-      noop,
-      {},
-      false,
-      vi.fn(),
-      undefined,
-      PARENT,
-    ).map((item) => item.marker);
-
-    // The user-facing shape of this menu, pinned against the stylesheet that actually ships:
-    // inline styles (`nd`, `wj`), note styles (`f`), and block styles (`p`, `q1`, `s1`) together.
-    expect(markers).toEqual(expect.arrayContaining(['nd', 'wj', 'f', 'p', 'q1', 's1']));
   });
 });
 

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.utils.test.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.utils.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import { MutableRefObject } from 'react';
 import type { EditorRef, SelectionRange, StyleInfo } from '@eten-tech-foundation/platform-editor';
-import { isLocalizeKey } from 'platform-bible-utils';
+import { isLocalizeKey, type LanguageStrings } from 'platform-bible-utils';
 import {
   generateInlineMarkerMenuListItems,
   getChapterKey,
@@ -38,41 +38,151 @@ describe('generateInlineMarkerMenuListItems', () => {
   const noop = () => {};
 
   // Minimal project-stylesheet fixture (as if merged from usfm.sty + custom.sty and serialized by
-  // the host): 'p' the parent paragraph, 'v' a verse marker (the library classifies it as
-  // styleType "character", but `isBlockMarker` special-cases 'v' as structural — same as PT9), 'f'
-  // a note marker, and 'nd' a plain inline character marker. `wj` is deliberately absent here and
-  // added back per-test to exercise stylesheet-driven inclusion/exclusion.
+  // the host), carrying one of each styleType the menu has to handle: 'p' the parent paragraph and
+  // 'q1'/'s1' two more block styles, 'v' a verse marker (the library classifies it as styleType
+  // "character", but `isBlockMarker` special-cases 'v' as structural — same as PT9), 'f' a note
+  // marker, and 'nd' a plain inline character marker. `wj` is deliberately absent here and added
+  // back per-test to exercise stylesheet-driven inclusion/exclusion.
   const BASE_STYLE_INFO: StyleInfo = {
     markers: {
       p: { marker: 'p', styleType: 'paragraph' },
+      q1: { marker: 'q1', styleType: 'paragraph', description: 'Poetic line' },
+      s1: { marker: 's1', styleType: 'paragraph', description: 'Section heading' },
       v: { marker: 'v', styleType: 'character' },
       f: { marker: 'f', styleType: 'note', endMarker: 'f*', description: 'A Footnote text item' },
       nd: { marker: 'nd', styleType: 'character', description: 'For name of deity' },
     },
   };
 
-  it('when protected: block-marker item (v) is disallowed and its action notifies without inserting', () => {
+  /** Invoke the generator with the fixture stylesheet, overriding only what a test cares about. */
+  function generate({
+    localizedStrings = {},
+    isStructureProtected = false,
+    notifyStructureProtected = vi.fn(),
+    restoreSelection,
+    parentMarker = PARENT,
+    styleInfo = BASE_STYLE_INFO,
+    ref = makeMockEditorRef().ref,
+    closeMarkersMenu = vi.fn(),
+  }: {
+    localizedStrings?: LanguageStrings;
+    isStructureProtected?: boolean;
+    notifyStructureProtected?: () => void;
+    restoreSelection?: () => void;
+    parentMarker?: string;
+    styleInfo?: StyleInfo;
+    ref?: MutableRefObject<EditorRef | null>;
+    closeMarkersMenu?: () => void;
+  } = {}) {
+    return generateInlineMarkerMenuListItems(
+      ref,
+      closeMarkersMenu,
+      localizedStrings,
+      isStructureProtected,
+      notifyStructureProtected,
+      restoreSelection,
+      parentMarker,
+      styleInfo,
+    );
+  }
+
+  it('offers BOTH block and inline markers, so `\\` in the Formatted view reaches the whole stylesheet', () => {
+    const markers = generate().map((item) => item.marker);
+
+    // The two kinds the menu exists to combine. `nd` is a character style, `p`/`q1`/`s1` are block
+    // styles — the library's own `character` and `paragraph` sources are mutually exclusive, so a
+    // list holding both can only have come from merging them.
+    expect(markers).toEqual(expect.arrayContaining(['nd', 'f', 'p', 'q1', 's1']));
+  });
+
+  it('omits block markers when the caret is in a character span, which cannot start a paragraph', () => {
+    // Positive control: this same stylesheet DOES yield block markers from a block context, so an
+    // absent block half below is the gate doing its job, not the block half having gone missing.
+    expect(generate({ parentMarker: PARENT }).map((item) => item.marker)).toContain('q1');
+
+    const markers = generate({ parentMarker: 'nd' }).map((item) => item.marker);
+
+    // ...and the character half still arrives, so this is not merely an empty menu.
+    expect(markers).toContain('nd');
+    expect(markers).not.toContain('p');
+    expect(markers).not.toContain('q1');
+    expect(markers).not.toContain('s1');
+  });
+
+  it('omits block markers when the caret is in a note, which cannot contain a paragraph', () => {
+    expect(generate({ parentMarker: PARENT }).map((item) => item.marker)).toContain('q1');
+
+    const markers = generate({ parentMarker: 'f' }).map((item) => item.marker);
+
+    expect(markers).toContain('nd');
+    expect(markers).not.toContain('p');
+    expect(markers).not.toContain('q1');
+    expect(markers).not.toContain('s1');
+  });
+
+  it('offers block markers under any block context, not just the caret paragraph itself', () => {
+    // Guards against a merge that only ever echoes `parentMarker` back: asking from inside `\s1`
+    // must still offer `p` and `q1`.
+    const markers = generate({ parentMarker: 's1' }).map((item) => item.marker);
+
+    expect(markers).toEqual(expect.arrayContaining(['p', 'q1', 's1', 'nd']));
+  });
+
+  it('when protected: every block marker is disallowed while inline markers stay insertable', () => {
+    const items = generate({ isStructureProtected: true });
+    const isDisallowed = (marker: string) => items.find((i) => i.marker === marker)?.isDisallowed;
+
+    expect(isDisallowed('p')).toBe(true);
+    expect(isDisallowed('q1')).toBe(true);
+    expect(isDisallowed('s1')).toBe(true);
+    expect(isDisallowed('nd')).toBeFalsy();
+    expect(isDisallowed('f')).toBeFalsy();
+  });
+
+  it('keeps basic markers ahead of non-basic ones across the merged list', () => {
+    // `(basic)` in a stylesheet Description is what PT9's ScrTag.IsBasic reads, and the library
+    // lifts it into its ordering. A naive concatenation would strand a basic block marker behind
+    // every non-basic character marker.
+    const items = generate({
+      styleInfo: {
+        markers: {
+          ...BASE_STYLE_INFO.markers,
+          q1: { marker: 'q1', styleType: 'paragraph', description: 'Poetic line (basic)' },
+          nd: { marker: 'nd', styleType: 'character', description: 'For name of deity' },
+        },
+      },
+    });
+    const markers = items.map((item) => item.marker);
+
+    expect(markers.indexOf('q1')).toBeLessThan(markers.indexOf('nd'));
+  });
+
+  it('when protected: a block-marker item is disallowed and its action notifies without inserting', () => {
     const { ref, insertMarker } = makeMockEditorRef();
     const notify = vi.fn();
     const close = vi.fn();
-    const items = generateInlineMarkerMenuListItems(
+    const items = generate({
       ref,
-      close,
-      {},
-      true,
-      notify,
-      undefined,
-      PARENT,
-      BASE_STYLE_INFO,
-    );
+      closeMarkersMenu: close,
+      isStructureProtected: true,
+      notifyStructureProtected: notify,
+    });
 
-    const blockItem = items.find((i) => i.marker === 'v');
+    const blockItem = items.find((i) => i.marker === 'p');
     expect(blockItem?.isDisallowed).toBe(true);
 
     blockItem?.action?.();
     expect(notify).toHaveBeenCalledTimes(1);
     expect(close).toHaveBeenCalledTimes(1);
     expect(insertMarker).not.toHaveBeenCalled();
+  });
+
+  it('when protected: the verse marker is disallowed too, though the sheet types it as a character', () => {
+    const items = generate({ isStructureProtected: true });
+
+    // `isBlockMarker` special-cases `v` as structural, same as PT9 — so it is blocked while
+    // structure protection is on even though it arrives via the character source.
+    expect(items.find((i) => i.marker === 'v')?.isDisallowed).toBe(true);
   });
 
   it('when protected: inline-marker item (f) is allowed and its action inserts', () => {
@@ -308,6 +418,23 @@ describe('generateInlineMarkerMenuListItems', () => {
     // fixture above, so this can only pass if the no-styleInfo path is actually wired up.
     expect(items.length).toBeGreaterThan(Object.keys(BASE_STYLE_INFO.markers).length);
     expect(items.some((i) => i.marker === 'wj')).toBe(true);
+  });
+
+  it('offers both kinds against the real bundled stylesheet, not just the test fixture', () => {
+    const { ref } = makeMockEditorRef();
+    const markers = generateInlineMarkerMenuListItems(
+      ref,
+      noop,
+      {},
+      false,
+      vi.fn(),
+      undefined,
+      PARENT,
+    ).map((item) => item.marker);
+
+    // The user-facing shape of this menu, pinned against the stylesheet that actually ships:
+    // inline styles (`nd`, `wj`), note styles (`f`), and block styles (`p`, `q1`, `s1`) together.
+    expect(markers).toEqual(expect.arrayContaining(['nd', 'wj', 'f', 'p', 'q1', 's1']));
   });
 });
 

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.utils.ts
@@ -62,12 +62,39 @@ function resolveMarkerMenuItemTitle(
 }
 
 /**
+ * Whether the marker the caret sits in is a block (paragraph-styleType) context, and so a place
+ * where inserting another block marker makes sense.
+ *
+ * `Object.hasOwn`, not a bare index: a document marked `\toString` (or any other `Object.prototype`
+ * member name) would otherwise resolve to the inherited function and be read as a stylesheet entry
+ * the sheet never declared.
+ */
+function isBlockContext(styleInfo: StyleInfo, marker: string): boolean {
+  if (!Object.hasOwn(styleInfo.markers, marker)) return false;
+  return styleInfo.markers[marker]?.styleType === 'paragraph';
+}
+
+/**
  * Function that generates the inline marker menu items that will update as the cursor location
  * changes. Sourced from the project's stylesheet (usfm.sty + custom.sty, merged and serialized by
  * the host) via the shared library's `getMarkerMenuItems` — the same PT9-derived classification
  * used by the standard-view `\`/Enter palettes — so a project's custom.sty markers are offered and
  * markers the project's stylesheet doesn't define are not, instead of walking a static built-in
  * marker list.
+ *
+ * This is the palette the Formatted and Markers views open on `\`, and it offers BOTH kinds of
+ * marker: the character/note styles from the library's `character` source, plus the block styles
+ * from its `paragraph` source. It has to combine them itself because those two sources are mutually
+ * exclusive by design — PT9 picks between them by where the caret sits relative to the paragraph's
+ * marker glyph, which is the rule the standard-view `\` palette follows. These views render no
+ * marker glyphs at all, so no caret position in them can ever reach the paragraph source, and
+ * offering only one of the two would put half the stylesheet permanently out of reach.
+ *
+ * The block half is offered only in a block context ({@link isBlockContext}) — a caret inside a
+ * character span or a note is not a position another paragraph can start at. Item order is the
+ * library's PT9-derived one, with a final stable basic-first pass over the combined list so basic
+ * markers of both kinds lead, matching what the library itself does when it merges close tags into
+ * the character source.
  *
  * @param editorRef The ref for the editor component to be able to insert markers
  * @param closeMarkersMenu Callback to close the markers menu after an action
@@ -98,13 +125,31 @@ export function generateInlineMarkerMenuListItems(
 ): MarkerMenuItem[] {
   if (!parentMarker) return [];
 
-  const items = getMarkerMenuItems(styleInfo ?? defaultStyleInfo, {
-    source: 'character',
+  const effectiveStyleInfo = styleInfo ?? defaultStyleInfo;
+  const context = {
     paraMarker: parentMarker,
     previousParaMarkers: [],
     openCharMarkers: [],
     hasTextSelection: false,
     inMarkerText: false,
+  };
+
+  const characterItems = getMarkerMenuItems(effectiveStyleInfo, {
+    ...context,
+    source: 'character',
+  });
+  // No `previousParaMarkers`, so the library's validity replay starts from an empty stack and every
+  // block marker the sheet declares is offered. This menu deliberately does not narrow by document
+  // position: it is an insert palette the user searches, not PT9's caret-shape-driven `\` popup.
+  const paragraphItems = isBlockContext(effectiveStyleInfo, parentMarker)
+    ? getMarkerMenuItems(effectiveStyleInfo, { ...context, source: 'paragraph' })
+    : [];
+
+  // `Array.prototype.sort` is stable, so each source keeps its own PT9-derived ordering within the
+  // basic and non-basic groups.
+  const items = [...characterItems, ...paragraphItems].sort((a, b) => {
+    if (a.isBasic === b.isBasic) return 0;
+    return a.isBasic ? -1 : 1;
   });
 
   return items.map((item): MarkerMenuItem => {

--- a/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.utils.ts
+++ b/extensions/src/platform-scripture-editor/src/platform-scripture-editor.web-view.utils.ts
@@ -1,19 +1,18 @@
 /**
  * WEB-VIEW-ONLY utility helpers for the platform-scripture-editor extension.
  *
- * IMPORTANT: this module imports RUNTIME VALUES (`getMarkerMenuItems`, `defaultStyleInfo`) from
- * `@eten-tech-foundation/platform-editor`, whose dist is a single, non-splittable library bundle
- * that also contains the React editor components and a top-level `react/jsx-runtime` import.
- * Importing any value from it pulls the whole bundle into the importer's webpack module graph. That
- * is fine in the web view (browser iframe, live React), but FATAL in the extension host: `main.js`
- * runs in a sandboxed Node context with no React runtime and a `require` that rejects anything but
- * `@papi/*`-family modules, so the editor bundle's eager `react/jsx-runtime` import throws during
- * `activate()` and the whole extension fails to activate.
+ * IMPORTANT: this module value-imports `platform-bible-react`, a React component library that calls
+ * `forwardRef`/`createContext` at module-eval time. That is fine in the web view (browser iframe,
+ * live React), but FATAL in the extension host: `main.js` runs in a sandboxed Node context with no
+ * React runtime and a `require` that rejects anything but `@papi/*`-family modules, so the eager
+ * `react` import throws during `activate()` and the whole extension fails to activate. The same
+ * hazard applies to any RUNTIME VALUE from `@eten-tech-foundation/platform-editor`, whose dist is a
+ * single non-splittable bundle carrying the React editor components — import types from it only.
  *
  * Therefore this module must ONLY ever be imported by web-view code (and its tests) — NEVER by
  * `main.ts` or anything `main.ts` reaches. Main-bundle-safe helpers live in
- * `platform-scripture-editor.utils.ts`, which is restricted to `import type` from the editor
- * package.
+ * `platform-scripture-editor.utils.ts`. `extension-host-import-boundary.test.ts` walks the import
+ * graph from `main.ts` and enforces this.
  */
 
 import {
@@ -24,77 +23,19 @@ import {
   type PaletteItem,
 } from 'platform-bible-utils';
 import type { MutableRefObject } from 'react';
-import {
-  defaultStyleInfo,
-  getMarkerMenuItems,
-  type EditorRef,
-  type MarkerMenuItem as EditorMarkerMenuItem,
-  type SelectionRange,
-  type StyleInfo,
+import type {
+  EditorRef,
+  MarkerMenuItem as EditorMarkerMenuItem,
+  SelectionRange,
 } from '@eten-tech-foundation/platform-editor';
 import { markerMenuItemToPaletteItem, type MarkerMenuItem } from 'platform-bible-react';
 import { stripMarkerNestingPrefix } from 'platform-bible-react/experimental';
 import { WRITE_GUARD_RELEASE_AFTER_MS } from './write-in-flight-guard.util';
 
 /**
- * Resolves the display title for a stylesheet-sourced marker-menu item.
- *
- * The bundled markers table's `description` is always a `LocalizeKey`
- * (`%markerMenu_marker_*_description%`) and is the PRIMARY title source — the translated
- * `markerMenu_marker_*` strings must keep working for every marker the table knows. The
- * stylesheet's raw English `Description` is the FALLBACK: it is all a custom.sty marker has (no
- * LocalizeKey exists for it), and it also covers a bundled marker whose translation is not loaded.
- * The marker code itself is the last resort so a row with no description at all still has a title
- * (though the row then shows the code twice).
- */
-function resolveMarkerMenuItemTitle(
-  marker: string,
-  description: string | undefined,
-  localizedStrings: LanguageStrings,
-): string {
-  const localizeKey = usfmMarkers[marker]?.description;
-  if (localizeKey && isLocalizeKey(localizeKey)) {
-    const localized = localizedStrings[localizeKey];
-    if (localized) return localized;
-  }
-  if (!description) return marker;
-  return isLocalizeKey(description) ? (localizedStrings[description] ?? description) : description;
-}
-
-/**
- * Whether the marker the caret sits in is a block (paragraph-styleType) context, and so a place
- * where inserting another block marker makes sense.
- *
- * `Object.hasOwn`, not a bare index: a document marked `\toString` (or any other `Object.prototype`
- * member name) would otherwise resolve to the inherited function and be read as a stylesheet entry
- * the sheet never declared.
- */
-function isBlockContext(styleInfo: StyleInfo, marker: string): boolean {
-  if (!Object.hasOwn(styleInfo.markers, marker)) return false;
-  return styleInfo.markers[marker]?.styleType === 'paragraph';
-}
-
-/**
  * Function that generates the inline marker menu items that will update as the cursor location
- * changes. Sourced from the project's stylesheet (usfm.sty + custom.sty, merged and serialized by
- * the host) via the shared library's `getMarkerMenuItems` — the same PT9-derived classification
- * used by the standard-view `\`/Enter palettes — so a project's custom.sty markers are offered and
- * markers the project's stylesheet doesn't define are not, instead of walking a static built-in
- * marker list.
- *
- * This is the palette the Formatted and Markers views open on `\`, and it offers BOTH kinds of
- * marker: the character/note styles from the library's `character` source, plus the block styles
- * from its `paragraph` source. It has to combine them itself because those two sources are mutually
- * exclusive by design — PT9 picks between them by where the caret sits relative to the paragraph's
- * marker glyph, which is the rule the standard-view `\` palette follows. These views render no
- * marker glyphs at all, so no caret position in them can ever reach the paragraph source, and
- * offering only one of the two would put half the stylesheet permanently out of reach.
- *
- * The block half is offered only in a block context ({@link isBlockContext}) — a caret inside a
- * character span or a note is not a position another paragraph can start at. Item order is the
- * library's PT9-derived one, with a final stable basic-first pass over the combined list so basic
- * markers of both kinds lead, matching what the library itself does when it merges close tags into
- * the character source.
+ * changes. In the future this function will take data from an `.sty` file so that users can define
+ * their own markers.
  *
  * @param editorRef The ref for the editor component to be able to insert markers
  * @param closeMarkersMenu Callback to close the markers menu after an action
@@ -108,10 +49,7 @@ function isBlockContext(styleInfo: StyleInfo, marker: string): boolean {
  *   focus, run just before inserting. The menu focuses its own search input, so without this the
  *   insert can find no selection to act on
  * @param parentMarker The current parent marker which is used to determine which markers to include
- * @param styleInfo The project's stylesheet data; falls back to the bundled default stylesheet when
- *   absent (e.g. no project stylesheet loaded yet)
- * @returns The list of inline marker menu items, in the library's PT9-derived order (basic markers
- *   first)
+ * @returns The list of inline marker menu items
  */
 export function generateInlineMarkerMenuListItems(
   editorRef: MutableRefObject<EditorRef | null>,
@@ -121,61 +59,45 @@ export function generateInlineMarkerMenuListItems(
   notifyStructureProtected: () => void,
   restoreSelection?: () => void,
   parentMarker?: string,
-  styleInfo?: StyleInfo,
 ): MarkerMenuItem[] {
   if (!parentMarker) return [];
 
-  const effectiveStyleInfo = styleInfo ?? defaultStyleInfo;
-  const context = {
-    paraMarker: parentMarker,
-    previousParaMarkers: [],
-    openCharMarkers: [],
-    hasTextSelection: false,
-    inMarkerText: false,
-  };
+  const markerDetails = usfmMarkers[parentMarker];
+  if (!markerDetails?.children) return [];
 
-  const characterItems = getMarkerMenuItems(effectiveStyleInfo, {
-    ...context,
-    source: 'character',
+  const markerMenuItems: MarkerMenuItem[] = [];
+  Object.entries(markerDetails.children).forEach(([, markers]) => {
+    markerMenuItems.push(
+      ...markers.map((marker): MarkerMenuItem => {
+        const isDisallowed = isStructureProtected && isBlockMarker(marker);
+        return {
+          marker,
+          title:
+            localizedStrings[usfmMarkers[marker].description] ?? usfmMarkers[marker].description,
+          isDisallowed,
+          action: () => {
+            // Defense-in-depth: unreachable while the menu renders `isDisallowed` items as
+            // disabled `CommandItem`s (a disabled cmdk item never fires `onSelect`). Kept as a
+            // second layer of protection in case that disabled rendering is ever loosened or the
+            // menu wiring changes.
+            if (isDisallowed) {
+              notifyStructureProtected();
+              closeMarkersMenu();
+              return;
+            }
+            // This menu focuses its own search input on open, which takes focus off
+            // `.editor-input` — and Lexical's blur processing can null the selection `insertMarker`
+            // needs, so the insert would land nowhere. Restore it first, as every other
+            // marker-apply surface does.
+            restoreSelection?.();
+            editorRef.current?.insertMarker(marker);
+            closeMarkersMenu();
+          },
+        };
+      }),
+    );
   });
-  // No `previousParaMarkers`, so the library's validity replay starts from an empty stack and every
-  // block marker the sheet declares is offered. This menu deliberately does not narrow by document
-  // position: it is an insert palette the user searches, not PT9's caret-shape-driven `\` popup.
-  const paragraphItems = isBlockContext(effectiveStyleInfo, parentMarker)
-    ? getMarkerMenuItems(effectiveStyleInfo, { ...context, source: 'paragraph' })
-    : [];
-
-  // `Array.prototype.sort` is stable, so each source keeps its own PT9-derived ordering within the
-  // basic and non-basic groups.
-  const items = [...characterItems, ...paragraphItems].sort((a, b) => {
-    if (a.isBasic === b.isBasic) return 0;
-    return a.isBasic ? -1 : 1;
-  });
-
-  return items.map((item): MarkerMenuItem => {
-    const isDisallowed = isStructureProtected && isBlockMarker(item.marker);
-    return {
-      marker: item.marker,
-      title: resolveMarkerMenuItemTitle(item.marker, item.description, localizedStrings),
-      isDisallowed,
-      action: () => {
-        // Defense-in-depth: unreachable while the menu renders `isDisallowed` items as disabled
-        // `CommandItem`s (a disabled cmdk item never fires `onSelect`). Kept as a second layer of
-        // protection in case that disabled rendering is ever loosened or the menu wiring changes.
-        if (isDisallowed) {
-          notifyStructureProtected();
-          closeMarkersMenu();
-          return;
-        }
-        // This menu focuses its own search input on open, which takes focus off `.editor-input` —
-        // and Lexical's blur processing can null the selection `insertMarker` needs, so the insert
-        // would land nowhere. Restore it first, as every other marker-apply surface does.
-        restoreSelection?.();
-        editorRef.current?.insertMarker(item.marker);
-        closeMarkersMenu();
-      },
-    };
-  });
+  return markerMenuItems.sort((a, b) => (a.marker ?? a.title).localeCompare(b.marker ?? b.title));
 }
 
 /**


### PR DESCRIPTION
## Summary

Pressing `\` in the Formatted view (and Markers view) opens the marker palette with **only inline markers** — `nd` shows up, `p`/`q`/`s1` do not. This reverts that palette to the implementation it had before the Standard View port.

### Why review this

Not part of the current epic. It is a user-visible regression introduced by the Standard View merge (#2565), found in hands-on use in Simple mode; the palette has been missing every block marker since that merged, so it is worth unblocking ahead of other non-epic work.

## What went wrong

`generateInlineMarkerMenuListItems` used to walk the static `usfmMarkers[parentMarker].children` table, which mixes block and inline markers by category (62 entries under `\p`: `p q s1 ...` alongside `nd wj f ...`).

The Standard View port replaced that with the shared library's stylesheet-driven `getMarkerMenuItems`, hardcoded to `source: 'character'`. That source emits only character- and note-styleType entries **by design** — PT9 chooses between its `character` and `paragraph` sources by where the caret sits relative to the paragraph's marker glyph, and the two are mutually exclusive. The Formatted view renders no marker glyphs, so no caret position in it can ever reach the paragraph source, and every block marker fell out.

Measured against the real bundled stylesheet, `\p` context: **36 items, 33 character + 3 note, 0 paragraph.**

Two things corroborate this was an oversight rather than a decision:

- The `isStructureProtected` + `isBlockMarker` guard in the same function became unreachable for every marker except `v` — the whole structure-protection path on this menu was inert.
- Its test was retargeted onto `v` as the "block marker" fixture. `v` is typed `styleType: 'character'` but special-cased as structural by `isBlockMarker`, so it is the one "block" marker that survives a character-source query. The suite stayed green while every real block marker vanished.

## Changes

`generateInlineMarkerMenuListItems` goes back to the pre-Standard-View implementation verbatim. That restores more than the missing markers — the stylesheet-driven version had changed the menu's whole shape, and all of it comes back:

| | Standard View port | Restored |
|---|---|---|
| Source | project stylesheet | static `usfmMarkers` children |
| Items under `\p` | 158 | 62 |
| Scoping | all markers valid in context | parent-scoped |
| Order | basic-first, then natural | alphabetical by marker code |
| `\c` | excluded | offered |
| Under a leaf marker (`\nd`) | 3 items | no menu |

**Kept from the port:** the `restoreSelection` callback that puts the caret back before inserting. That is an unrelated fix for this menu stealing focus with its own search input; dropping it would leave a pick landing nowhere. It is the only difference from the pre-Standard-View original, and it is a one-line removal if it should go too.

Consequences: the `styleInfo` argument is gone from the call site, and with it this module's last runtime import of `@eten-tech-foundation/platform-editor` — so the module doc now names `platform-bible-react` as the extension-host hazard it actually carries.

## Testing

- [x] `npx vitest run src/platform-scripture-editor` — 80 files, 1294 tests pass
- [x] ESLint clean on all three changed files
- [x] `tsc --noEmit` reports no errors in any changed file (the `paratextBibleSendReceive.*` errors in that output are pre-existing on `main`)
- [ ] Hands-on check in the running app — not done; worth a look before merge

The old suite passed while every block marker was missing, so the tests now cover **what the menu offers**, not just how one item behaves: both kinds present, parent scoping, alphabetical order, the empty result under a leaf marker, and title localization — alongside the structure-protection and caret-restore cases already there.

Each was mutation-verified rather than just observed green:

| Mutation | Tests red |
|---|---|
| Filter block markers out (reproduces the regression) | 2 |
| Drop the alphabetical sort | 1 |
| Ignore parent scoping | 6 |

## AI Involvement

Investigation, revert, and tests generated with Claude Code (Opus 5) and reviewed by me. The root cause was traced by bisecting `generateInlineMarkerMenuListItems` across the Standard View merge and confirmed by running the library's sources against the real bundled stylesheet before any code was changed.

AI-assisted — [session 1](https://claude.ai/code/session_0118oyULyPiQgL6YAgi1ftGp)

## Risk Level

Low — one function in one extension, restored to code that shipped for months before the Standard View port. No API surface change; the only call-site change is dropping the now-unused `styleInfo` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0118oyULyPiQgL6YAgi1ftGp

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2761)
<!-- Reviewable:end -->
