### PR TITLE
PT-4483: Fix syncProjects doc comments to match actual behavior

### DIFF
--- a/.claude/rules/architecture/closed-source-command-docs.md
+++ b/.claude/rules/architecture/closed-source-command-docs.md
@@ -1,0 +1,54 @@
+# Doc Altitude for Closed-Source-Backed Commands
+
+Some PAPI commands are declared in this repo (a C# stub, a `.d.ts` augmentation) but only really
+implemented by a closed-source consumer — today, Paratext 10 Studio's private
+`repo-patches/paranext-core.patch`. The doc comment's `@throws PlatformUnimplementedException if
+not running in an application that implements this command (e.g., Paratext 10 Studio)` phrasing
+already says as much: Studio is named as an example implementer, not as the contract.
+
+## The rule
+
+For a command in this position, the XML doc / TSDoc describes **caller-visible guarantees** — what
+a caller may rely on, and what it must not assume — never the current implementer's specific
+mechanism, tuning constants, or internal heuristics.
+
+- **Write:** "callers must not assume every shared project is present locally once this resolves."
+- **Don't write:** "syncs an initial batch of 5, then tries the rest one at a time until it finds a
+  project with a non-Observer role" — that is Studio's current implementation, not the command's
+  contract.
+
+## Why
+
+- **This repo can't verify it.** The real logic lives in a private patch this repo doesn't contain
+  and can't run tests against (see `adr-closed-source-command-doc-altitude` in
+  `Architecture-Decisions.md`). A doc that asserts specific constants is a claim this repo has no
+  way to keep honest — the next time Studio's patch is regenerated (`save-repo-patches`), the doc
+  here has no signal that it drifted.
+- **It's the wrong altitude even before drift.** A command's public doc should describe the command,
+  not one build of one implementer's current approach to satisfying it. If a second white-label app
+  ever implements this contract differently, implementation-specific prose here becomes flatly wrong
+  for that caller while looking authoritative.
+- **Guarantee-level prose is more durable AND more actionable than a bare pointer elsewhere.**
+  "See the other repo for details" doesn't work for readers of this repo (including a future AI
+  agent) who might not have access to or knowledge of the actual implementation(s), and doesn't
+  survive a swapped implementer either. Stating what a caller may/must-not assume is the one thing
+  that stays true regardless of which conforming implementation is running, and it's exactly the
+  information a caller needs to write correct code against the command.
+
+## How to apply
+
+When documenting (or reviewing a doc change to) a command whose real behavior lives in
+`paratext-bible-send-receive` or any other closed-source/swappable extension:
+
+1. State what always holds for **any** conforming implementation — not what the current one happens
+   to do.
+2. If you're tempted to write a specific number, threshold, or named internal check, ask whether a
+   caller actually needs that number to use the command correctly, or whether a weaker "may/must not
+   assume X" statement covers the same ground without pinning down how it's achieved.
+3. Don't invent requirements the contract doesn't actually have, either — "must" language should
+   reflect a real invariant every implementation is expected to honor (e.g., "must throw
+   `PlatformUnimplementedException` if not implemented"), not a guess dressed up as a guarantee.
+
+See `adr-closed-source-command-doc-altitude` in
+[`Architecture-Decisions.md`](../../../.context/standards/Architecture-Decisions.md) for the
+decision history and the specific case (`paratextBibleSendReceive.syncProjects`) that surfaced this.

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -400,6 +400,60 @@ step, no automation. Just a record.
 - **Source:** PRD "Saroj easily works with character-level markers" (appetite 2 developer weeks);
   character-marker removal work on `remove-character-marker`.
 
+## adr-closed-source-command-doc-altitude: Command docs for closed-source-backed PAPI commands describe caller-visible guarantees, not the current implementer's mechanism
+
+- **Date:** 2026-09-05
+- **Status:** Accepted
+- **Context:** PR #2771 (PT-4483) fixed `paratextBibleSendReceive.syncProjects`'s doc comments (the
+  C# stub's XML doc and `src/@types/paratext-bible-send-receive/index.d.ts`'s TSDoc), which had
+  drifted from the real Paratext 10 Studio implementation — a closed-source patch
+  (`paratext-10-studio` `repo-patches/paranext-core.patch`, `SyncProjectsCore`). A first draft of the
+  fix encoded Studio's specific first-sync mechanism directly (an initial batch of 5 projects, then
+  one at a time, stopping once a non-Observer role is found), verified against the actual patch
+  source. Code review (Reviewable, `katherinejensen00`, with direct access to that patch) found the
+  new text itself over-generalized: for accounts with five or fewer shared projects, or accounts
+  where the user has no editable role on any of them, the described "stops early, rather than
+  syncing the whole account" claim doesn't hold — the whole account downloads regardless, just via a
+  different path through the same mechanism. Fixing that specific overgeneralization in place would
+  still have left the doc asserting Studio's tunable constants (batch size, the role check) as part
+  of the command's contract — constants this repo cannot verify, cannot test against (the stub
+  throws/no-ops; no core test exercises the real logic), and has no way to detect drifting the next
+  time Studio's patch is regenerated (`save-repo-patches`).
+- **Decision:** Doc comments for a command whose real implementation is closed-source or otherwise
+  swappable (today: anything backed by `paratext-bible-send-receive`, i.e. any command whose
+  `@throws` names `PlatformUnimplementedException` "if not running in an application that implements
+  this command (e.g., Paratext 10 Studio)") describe caller-visible **guarantees** only — what a
+  caller may rely on and must not assume — never the current implementer's specific mechanism or
+  tuning constants. Concretely, `syncProjects`'s zero-local-projects case now reads "an
+  implementation is expected to try to make at least one project available for the current user to
+  work in, if the account has one — but may stop short of downloading every shared project in the
+  account, trading completeness for performance. Callers MUST NOT assume every shared project is
+  present locally once this resolves," replacing the batch/role-check description. Promoted to a
+  standing rule: `.claude/rules/architecture/closed-source-command-docs.md`.
+- **Alternatives:**
+  - **Encode the known implementation for convenience** (what the first draft did) — rejected:
+    useful once, but ties this repo's doc to a private repo's tunable constants with no verification
+    path and no drift signal; exactly what produced the overgeneralization this decision responds
+    to.
+  - **Keep it vague, point readers to the other repo** — rejected: readers of this repo (including a
+    future AI agent) might not have access to or knowledge of the actual implementation(s); a bare
+    pointer elsewhere is unactionable for them and doesn't tell a caller what it can safely assume.
+  - **Leave the pre-PR wording**, which understated the behavior — rejected: it was the original bug
+    this PR fixed (claimed the no-ID form only ever syncs already-local projects, when a true first
+    sync can and should also acquire the account's first project).
+- **Consequences:** This doc can no longer be invalidated by a Studio-side regeneration of
+  `repo-patches/paranext-core.patch` that changes a tuning constant, since it no longer asserts one.
+  The tradeoff is genuinely less specific information in-repo for someone who wants to reason
+  precisely about first-sync latency or batching — that detail now only exists in the Studio patch
+  itself, which the rule file points to. If a future need arises to expose implementation-specific
+  timing/behavior to core (e.g. for a startup-performance budget), it should be surfaced through an
+  explicit signal (a return value, an event) rather than encoded into a doc comment describing a
+  different implementation's internals. Also unresolved from the same review round: upstreaming the
+  `syncProjects` doc fix to `paratext-bible-internal-extensions`'s own `.d.ts` (per this file's
+  header policy on re-syncs) so a future PT-4233 re-sync doesn't silently revert it — tracked as
+  follow-up, not done as part of this decision.
+- **Source:** PT-4483, review of #2771.
+
 ## adr-decision-log-sorted-insertion: Decision-log entries are inserted in byte order by slug, not appended
 
 - **Date:** 2026-09-03

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -215,17 +215,29 @@ internal class ParatextProjectSendReceiveService(
     }
 
     /// <summary>
-    /// Syncs projects from the provided IDs: filters for editable projects and S/Rs them,
-    /// then reads each editable project's connected resources and projects (one level deep —
-    /// connections of connections are not included) and S/Rs connected translation projects
-    /// or DBL-updates connected resources. Non-editable and unknown IDs are skipped.
-    /// Deduplication is handled internally.
+    /// Syncs the given projects (S/Rs them), then reads each synced project's connected resources
+    /// and projects (one level deep — connections of connections are not included) and S/Rs
+    /// connected translation projects or DBL-updates connected resources as needed. Unknown IDs are
+    /// skipped. Deduplication is handled internally.
     /// Exception is thrown if this function is not implemented in the current application
     /// or if an error was encountered syncing.
     /// </summary>
     /// <param name="projectIds">
-    /// IDs of the projects to sync. If <see langword="null"/>, all shared projects that are already
-    /// present locally (i.e., not new) are synced. An empty array is a no-op.
+    /// IDs of the projects to sync.
+    /// <list type="bullet">
+    /// <item>If explicit IDs are given, each one is synced regardless of whether it is already
+    /// present locally — a <c>new</c> (not yet downloaded) project among them is downloaded, not
+    /// skipped.</item>
+    /// <item>If <see langword="null"/> and at least one shared project the account knows about is
+    /// already present locally (not new), every locally-present project is synced; new projects
+    /// are left alone.</item>
+    /// <item>If <see langword="null"/> and every shared project the account knows about is
+    /// currently new (a true first sync, or the rarer case where every previously-local project
+    /// has since gone missing from disk), downloading stops as soon as one synced project gives
+    /// the current user a non-Observer role — trying a small initial batch, then the rest one at a
+    /// time — rather than unconditionally syncing the whole account.</item>
+    /// <item>An empty array is a no-op.</item>
+    /// </list>
     /// </param>
     protected void SyncProjects(String[]? projectIds)
     {

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -215,10 +215,10 @@ internal class ParatextProjectSendReceiveService(
     }
 
     /// <summary>
-    /// Syncs the given projects (S/Rs them), then reads each synced project's connected resources
-    /// and projects (one level deep — connections of connections are not included) and S/Rs
-    /// connected translation projects or DBL-updates connected resources as needed. Unknown IDs are
-    /// skipped. Deduplication is handled internally.
+    /// Syncs the given projects (S/Rs them), then reads connected resources and projects (one level
+    /// deep — connections of connections are not included) for the project(s) this call settles on,
+    /// and S/Rs connected translation projects or DBL-updates connected resources for those as
+    /// needed. Unknown IDs are skipped. Deduplication is handled internally.
     /// Exception is thrown if this function is not implemented in the current application
     /// or if an error was encountered syncing.
     /// </summary>
@@ -227,10 +227,12 @@ internal class ParatextProjectSendReceiveService(
     /// <list type="bullet">
     /// <item>If explicit IDs are given, each one is synced regardless of whether it is already
     /// present locally — a <c>new</c> (not yet downloaded) project among them is downloaded, not
-    /// skipped.</item>
+    /// skipped, though an implementation may still exclude a given id for reasons outside the
+    /// caller's control (e.g., an unsupported project version, or the project being otherwise
+    /// ineligible).</item>
     /// <item>If <see langword="null"/> and at least one shared project the account knows about is
-    /// already present locally (not new), every locally-present project is synced; new projects
-    /// are left alone.</item>
+    /// already present locally (not new), every locally-present shared project is synced; new
+    /// projects are left alone.</item>
     /// <item>If <see langword="null"/> and no shared project the account knows about is present
     /// locally yet (whether a genuine first sync, or every previously-local project has since gone
     /// missing from disk), an implementation is expected to try to make at least one project

--- a/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
+++ b/c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs
@@ -231,11 +231,12 @@ internal class ParatextProjectSendReceiveService(
     /// <item>If <see langword="null"/> and at least one shared project the account knows about is
     /// already present locally (not new), every locally-present project is synced; new projects
     /// are left alone.</item>
-    /// <item>If <see langword="null"/> and every shared project the account knows about is
-    /// currently new (a true first sync, or the rarer case where every previously-local project
-    /// has since gone missing from disk), downloading stops as soon as one synced project gives
-    /// the current user a non-Observer role — trying a small initial batch, then the rest one at a
-    /// time — rather than unconditionally syncing the whole account.</item>
+    /// <item>If <see langword="null"/> and no shared project the account knows about is present
+    /// locally yet (whether a genuine first sync, or every previously-local project has since gone
+    /// missing from disk), an implementation is expected to try to make at least one project
+    /// available for the current user to work in, if the account has one — but may stop short of
+    /// downloading every shared project in the account, trading completeness for performance.
+    /// Callers MUST NOT assume every shared project is present locally once this resolves.</item>
     /// <item>An empty array is a no-op.</item>
     /// </list>
     /// </param>

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -538,9 +538,9 @@ declare module 'papi-shared-types' {
      * Unknown project IDs are skipped. Deduplication is handled internally.
      *
      * This signature matches this repository's C# stub (`String[]? projectIds`, no return value),
-     * which core itself calls (e.g. the startup sync passes `undefined` for its zero-state
-     * bootstrap case — see the cases below for what that actually syncs). The Send/Receive
-     * extension's own declaration also returns the S/R results; core does not consume them.
+     * which core itself calls with `undefined` — see the cases below for what that actually syncs.
+     * The Send/Receive extension's own declaration also returns the S/R results; core does not
+     * consume them.
      *
      * @param projectIds IDs of the projects to sync.
      *
@@ -549,11 +549,12 @@ declare module 'papi-shared-types' {
      *       are skipped.
      *   - If omitted and at least one shared project the account knows about is already present locally
      *       (not new), every locally-present project is synced; new projects are left alone.
-     *   - If omitted and every shared project the account knows about is currently new (a true first
-     *       sync, or the rarer case where every previously-local project has since gone missing
-     *       from disk), downloading stops as soon as one synced project gives the current user a
-     *       non-Observer role — trying a small initial batch, then the rest one at a time — rather
-     *       than unconditionally syncing the whole account.
+     *   - If omitted and no shared project the account knows about is present locally yet (whether a
+     *       genuine first sync, or every previously-local project has since gone missing from
+     *       disk), an implementation is expected to try to make at least one project available for
+     *       the current user to work in, if the account has one — but may stop short of downloading
+     *       every shared project in the account, trading completeness for performance. Callers MUST
+     *       NOT assume every shared project is present locally once this resolves.
      *   - An empty array is a no-op.
      *
      * @throws `PlatformUnimplementedException` if not running in an application that implements

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -532,10 +532,11 @@ declare module 'papi-shared-types' {
     'paratextBibleSendReceive.commitDaily': (projectId: string) => Promise<void>;
 
     /**
-     * Syncs projects: sends/receives each project, then reads each synced project's connected
-     * resources and projects (one level deep — connections of connections are not included) and
-     * sends/receives connected translation projects or DBL-updates connected resources as needed.
-     * Unknown project IDs are skipped. Deduplication is handled internally.
+     * Syncs projects: sends/receives each project, then reads connected resources and projects (one
+     * level deep — connections of connections are not included) for the project(s) this call
+     * settles on, and sends/receives connected translation projects or DBL-updates connected
+     * resources for those as needed. Unknown project IDs are skipped. Deduplication is handled
+     * internally.
      *
      * This signature matches this repository's C# stub (`String[]? projectIds`, no return value),
      * which core itself calls with `undefined` — see the cases below for what that actually syncs.
@@ -545,10 +546,12 @@ declare module 'papi-shared-types' {
      * @param projectIds IDs of the projects to sync.
      *
      *   - If provided, each given ID is synced regardless of whether it is already present locally — a
-     *       `new` (not yet downloaded) project among them is downloaded, not skipped. Unknown IDs
-     *       are skipped.
+     *       `new` (not yet downloaded) project among them is downloaded, not skipped, though an
+     *       implementation may still exclude a given id for reasons outside the caller's control
+     *       (e.g., an unsupported project version, or the project being otherwise ineligible).
      *   - If omitted and at least one shared project the account knows about is already present locally
-     *       (not new), every locally-present project is synced; new projects are left alone.
+     *       (not new), every locally-present shared project is synced; new projects are left
+     *       alone.
      *   - If omitted and no shared project the account knows about is present locally yet (whether a
      *       genuine first sync, or every previously-local project has since gone missing from
      *       disk), an implementation is expected to try to make at least one project available for

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -542,9 +542,20 @@ declare module 'papi-shared-types' {
      * Send/Receive extension's own declaration also returns the S/R results; core does not consume
      * them.
      *
-     * @param projectIds IDs of the projects to sync. If omitted, all shared projects that are
-     *   already present locally (i.e., not new) are synced. If provided, only projects already
-     *   present locally are synced; new projects (not yet received) and unknown IDs are skipped.
+     * @param projectIds IDs of the projects to sync.
+     *
+     *   - If provided, each given ID is synced regardless of whether it is already present locally — a
+     *       `new` (not yet downloaded) project among them is downloaded, not skipped. Unknown IDs
+     *       are skipped.
+     *   - If omitted and at least one shared project the account knows about is already present locally
+     *       (not new), every locally-present project is synced; new projects are left alone.
+     *   - If omitted and every shared project the account knows about is currently new (a true first
+     *       sync, or the rarer case where every previously-local project has since gone missing
+     *       from disk), downloading stops as soon as one synced project gives the current user a
+     *       non-Observer role — trying a small initial batch, then the rest one at a time — rather
+     *       than unconditionally syncing the whole account.
+     *   - An empty array is a no-op.
+     *
      * @throws `PlatformUnimplementedException` if not running in an application that implements
      *   this command (e.g., Paratext 10 Studio)
      */

--- a/src/@types/paratext-bible-send-receive/index.d.ts
+++ b/src/@types/paratext-bible-send-receive/index.d.ts
@@ -532,15 +532,15 @@ declare module 'papi-shared-types' {
     'paratextBibleSendReceive.commitDaily': (projectId: string) => Promise<void>;
 
     /**
-     * Syncs projects: sends/receives each project, then reads each project's connected resources
-     * and projects (one level deep — connections of connections are not included) and
+     * Syncs projects: sends/receives each project, then reads each synced project's connected
+     * resources and projects (one level deep — connections of connections are not included) and
      * sends/receives connected translation projects or DBL-updates connected resources as needed.
      * Unknown project IDs are skipped. Deduplication is handled internally.
      *
      * This signature matches this repository's C# stub (`String[]? projectIds`, no return value),
-     * which core itself calls (e.g. the startup sync passes `undefined` to mean "sync all"). The
-     * Send/Receive extension's own declaration also returns the S/R results; core does not consume
-     * them.
+     * which core itself calls (e.g. the startup sync passes `undefined` for its zero-state
+     * bootstrap case — see the cases below for what that actually syncs). The Send/Receive
+     * extension's own declaration also returns the S/R results; core does not consume them.
      *
      * @param projectIds IDs of the projects to sync.
      *

--- a/src/main/startup-readiness.util.ts
+++ b/src/main/startup-readiness.util.ts
@@ -317,10 +317,12 @@ function shouldLogProbeAttempt(attempt: number): boolean {
  * An empty result counts as not-ready, not ready-with-no-projects. A workspace that genuinely has
  * no local scripture projects therefore waits the full budget. Note this probe and the eventual
  * sync measure different things: the probe checks for projects visible via
- * `SCRIPTURE_READINESS_PROJECT_INTERFACE`, while `syncProjects(undefined)` means "all shared
- * projects already present locally" — those sets can differ, so the delayed sync is not always a
- * no-op. When there genuinely are no local scripture projects, though, it typically has nothing to
- * do.
+ * `SCRIPTURE_READINESS_PROJECT_INTERFACE`, while `syncProjects(undefined)`'s scope depends on what
+ * is already local — those sets can differ, so the delayed sync is not always a no-op. When there
+ * are genuinely no local scripture projects — whether a true first sync, or every previously-local
+ * project having since gone missing — the delayed sync can be the MOST expensive case (trying to
+ * establish at least one usable project) rather than the least — so this probe's cost model should
+ * not assume the delayed sync is cheap there.
  *
  * Uses the WITHOUT-RETRIES lookup even though its TSDoc names layering PDP factories as the
  * intended caller and points most callers at `getMetadataForAllProjects`. That default is rejected

--- a/src/main/startup-tasks.test.ts
+++ b/src/main/startup-tasks.test.ts
@@ -133,9 +133,9 @@ describe('performStartupTasks', () => {
   });
 
   it('skips the automatic startup sync and warns when settings service throws (no sync-everything fallback)', async () => {
-    // An unreadable mode must not fall through to Simple's no-ID syncProjects (= S/R every shared
-    // project), which would override a Power user's schedule under the exact slow-boot conditions
-    // the read fails in. Do nothing this session and warn instead.
+    // An unreadable mode must not fall through to Simple's broad no-ID syncProjects, which could
+    // override a Power user's schedule under the exact slow-boot conditions the read fails in. Do
+    // nothing this session and warn instead.
     mockSettingsGet.mockRejectedValue(new Error('settings unavailable'));
     await performStartupTasks();
     expect(mockSendCommand).not.toHaveBeenCalled();

--- a/src/main/startup-tasks.ts
+++ b/src/main/startup-tasks.ts
@@ -149,17 +149,17 @@ type StartupSyncTriggerOutcome = ScheduledSessionSyncResult | 'skipped-stale' | 
  * finishes starting up.
  *
  * In Simple mode: waits (bounded) for this workspace's scripture project data provider factories to
- * be registered and answering — see {@link waitForScriptureWorkspaceReady} — then requests a sync of
- * all locally-known shared projects so the user sees the latest content as soon as they open the
- * app. The wait exists because this sync saturates the .NET data provider and would otherwise
- * starve the very factory registration the project picker waits on, leaving the picker locked while
- * the rest of the UI looks loaded. On an exhausted readiness budget the sync still fires — it is
- * delayed, never suppressed. The two exceptions are shutdown and a windowless app: a quit aborts
- * the wait, and a wait that outlives a macOS last-window close (see
- * {@link StartupTasksSignals.readinessAbortSignal}) is not allowed to fire into a resident app with
- * no windows (see {@link StartupTasksSignals.canFireStartupSync}). All errors are swallowed — the
- * S/R extension may not be installed (e.g. Platform.Bible), the command may not yet be registered,
- * or the sync may fail. Startup must never be blocked or visibly affected by this.
+ * be registered and answering — see {@link waitForScriptureWorkspaceReady} — then requests a sync
+ * via `paratextBibleSendReceive.syncProjects`'s no-ID form, which will typically enable the user to
+ * see content as soon as they open the app. The wait exists because this sync saturates the .NET
+ * data provider and would otherwise starve the very factory registration the project picker waits
+ * on, leaving the picker locked while the rest of the UI looks loaded. On an exhausted readiness
+ * budget the sync still fires — it is delayed, never suppressed. The two exceptions are shutdown
+ * and a windowless app: a quit aborts the wait, and a wait that outlives a macOS last-window close
+ * (see {@link StartupTasksSignals.readinessAbortSignal}) is not allowed to fire into a resident app
+ * with no windows (see {@link StartupTasksSignals.canFireStartupSync}). All errors are swallowed —
+ * the S/R extension may not be installed (e.g. Platform.Bible), the command may not yet be
+ * registered, or the sync may fail. Startup must never be blocked or visibly affected by this.
  *
  * In Power mode: requests a sync of just the projects scheduled "On startup/shutdown" via the S/R
  * extension's `runScheduledSessionSync` command. Same error-swallowing contract as Simple mode — if
@@ -167,10 +167,10 @@ type StartupSyncTriggerOutcome = ScheduledSessionSyncResult | 'skipped-stale' | 
  * is a logged no-op, never a crash or a blocked startup.
  *
  * If the interface-mode setting can't be read: skips the automatic startup sync entirely and warns,
- * rather than falling through to Simple mode's "sync everything". The read can fail under the same
+ * rather than falling through to Simple mode's broad no-ID sync. The read can fail under the same
  * slow-cold-boot conditions the Power retry budget exists for, and Simple's no-ID `syncProjects`
- * would S/R every locally-known shared project — overriding a Power user's schedule. Mirrors the
- * symmetric gating in {@link performShutdownTasks}.
+ * could run account-wide — overriding a Power user's schedule. Mirrors the symmetric gating in
+ * {@link performShutdownTasks}.
  */
 export async function performStartupTasks(signals?: StartupTasksSignals): Promise<void> {
   try {
@@ -183,11 +183,11 @@ export async function performStartupTasks(signals?: StartupTasksSignals): Promis
 async function performStartupTasksInternal(signals?: StartupTasksSignals): Promise<void> {
   logger.debug('performStartupTasks invoked');
 
-  // An unreadable mode must NOT fall through to Simple mode's "sync everything": the read can fail
+  // An unreadable mode must NOT fall through to Simple mode's broad no-ID sync: the read can fail
   // under exactly the slow-cold-boot conditions the Power retry budget exists to tolerate, and
-  // Simple's no-ID `syncProjects` fires an S/R of every locally-known shared project, overriding a
-  // Power user's schedule and syncing projects they deliberately excluded. When we can't tell the
-  // mode, the safe default is to skip the automatic startup sync this session and warn.
+  // Simple's no-ID `syncProjects` could run account-wide, overriding a Power user's schedule and
+  // syncing projects they deliberately excluded. When we can't tell the mode, the safe default is to
+  // skip the automatic startup sync this session and warn.
   let interfaceMode: SettingTypes['platform.interfaceMode'] | undefined;
   try {
     interfaceMode = await settingsService.get('platform.interfaceMode');
@@ -277,11 +277,11 @@ async function performStartupTasksInternal(signals?: StartupTasksSignals): Promi
     return;
   }
 
-  // Simple mode: sync all locally-known shared projects (no project IDs = "sync all" per the
-  // C# `String[]? projectIds` contract). The C# S/R command registers asynchronously during
-  // startup; `sendCommand` will wait (with retry on missing handler) until it's available or
-  // times out. `undefined` as the single arg serializes as `null` in the JSON-RPC params array
-  // — matching the "sync all" sentinel on the C# side.
+  // Simple mode: `undefined` is the C# `String[]? projectIds` contract's "no explicit IDs" sentinel
+  // (serializes as `null` in the JSON-RPC params array). See `syncProjects`'s own TSDoc for exactly
+  // what that syncs — it is not always every locally-known project. The C# S/R command registers
+  // asynchronously during startup; `sendCommand` will wait (with retry on missing handler) until
+  // it's available or times out.
   logger.debug('Startup sync starting');
   try {
     await commandService.sendCommand('paratextBibleSendReceive.syncProjects', undefined);
@@ -310,10 +310,10 @@ type SimpleModeSyncGateResult = { run: true } | { run: false; reason: string };
  *
  * Preserves today's exact per-setting semantics:
  *
- * - An unreadable `platform.interfaceMode` never falls through to "sync everything": the read can
- *   fail under the same slow-cold-boot conditions the Power retry budget exists to tolerate, and
- *   Simple's no-ID `syncProjects` would S/R every locally-known shared project, overriding a Power
- *   user's schedule. Logged as a warning (production-visible even in packaged builds).
+ * - An unreadable `platform.interfaceMode` never falls through to Simple's broad no-ID sync: the read
+ *   can fail under the same slow-cold-boot conditions the Power retry budget exists to tolerate,
+ *   and Simple's no-ID `syncProjects` could run account-wide, overriding a Power user's schedule.
+ *   Logged as a warning (production-visible even in packaged builds).
  * - A mode that has moved away from `'simple'` (e.g. to `'power'`, mid-wait) is also `run: false` —
  *   this function only ever green-lights the Simple-mode sync.
  * - An unreadable or `false` `platform.firstRunComplete` skips (consent-safe: a fresh user must not


### PR DESCRIPTION
<!-- review-paratext:summary:start -->
# Code Review Summary

**Branch**: pt-4483-fix-syncprojects-firsttimesync-docs

**Base**: origin/main

**Date**: 2026-09-04

**Review model**: Claude Sonnet 5

**Files changed**: 2

## Overview

Fixes stale/inaccurate doc comments on `paratextBibleSendReceive.syncProjects` — the C# XML doc on
the paranext-core stub (`ParatextProjectSendReceiveService.cs`) and the TS `.d.ts` declaration
(`src/@types/paratext-bible-send-receive/index.d.ts`) — so they describe the actual Paratext 10
Studio behavior rather than a simplified/incorrect summary. Split out from the now-closed PR #2640
(`scope-sync-to-picker-decision`) as a small, standalone doc fix under PT-4483, since the doc
inaccuracies were discovered while re-evaluating that PR's review feedback and don't need to wait
for the larger rework.

Four things were corrected, verified directly against the closed-source Paratext 10 Studio patch
source (`paratext-10-studio` repo, `repo-patches/paranext-core.patch`, `SyncProjectsCore`):

- Explicit `projectIds` sync regardless of local presence — a `new` (not yet downloaded) project
  among them is downloaded, not skipped, contrary to what the old doc claimed.
- `undefined`/`null` with at least one project already locally present syncs every locally-present
  project and leaves new ones alone (unchanged from the old doc — this part was already correct).
- `undefined`/`null` when every known shared project is currently `new` (a true first sync, or the
  rarer case where every previously-local project has since gone missing) does **not**
  unconditionally sync the whole account — it stops downloading as soon as one synced project gives
  the current user a non-Observer role, trying a small initial batch first, then the rest one at a
  time. An earlier draft of this fix claimed "every one of them is synced," which was wrong; this
  was caught and corrected in review before landing.
- The C# doc's `<summary>` had an entirely fictitious claim — "filters for editable projects and
  S/Rs them" / "Non-editable ... IDs are skipped" — with no such filtering logic anywhere in the
  actual sync selection or connected-resource-scan code. Removed; the TS doc's summary never had
  this claim.

No executable code changed in either file — this is a documentation-only fix.

## API Changes

- `c-sharp/Projects/SendReceive/ParatextProjectSendReceiveService.cs`: No signature change.
  `SyncProjects(String[]? projectIds)` doc comment rewritten — removes the false "filters for
  editable projects" claim, adds explicit-ID/null-with-locals/null-first-sync/empty-array behavior
  detail.
- `src/@types/paratext-bible-send-receive/index.d.ts`: No signature change. `@param projectIds` doc
  for `'paratextBibleSendReceive.syncProjects'` rewritten with the same four cases, plus a summary
  wording tweak ("each synced project's connected resources") and a softened parenthetical about
  what passing `undefined` does, to stay consistent with the new detail below it.

Neither file is part of the public API surface tracked for breaking-change purposes
(`lib/platform-bible-react/`, `lib/platform-bible-utils/`, or `papi.d.ts`) — `index.d.ts` augments
`papi-shared-types` for core's own internal command-handler typing. `papi.d.ts` itself is unchanged.

## Findings

### Critical — Must address before merge

None.

### Important — Should address before merge

None.

### Minor — Consider

- [x] **`index.d.ts:468` (pre-fix) — top-of-doc summary said "reads each project's connected resources," inconsistent with the C# summary's new "reads each synced project's connected resources."** _(fixed during review: reworded to "reads each synced project's connected resources" to match)_
- [x] **`index.d.ts:475` (pre-fix) — the parenthetical "(e.g. the startup sync passes `undefined` to mean 'sync all')" oversimplified/contradicted the new detailed bullets just below it, since `undefined` does not always sync literally "all" projects.** _(fixed during review: reworded to point at the detailed cases below instead of asserting a simplified behavior — "the startup sync passes `undefined` for its zero-state bootstrap case — see the cases below for what that actually syncs")_

Author was aware of finding #1 before this review but hadn't judged it worth a separate fix; asked me to use best judgment for both, and confirmed both fixes as made. No items dismissed.

### Template Propagation

#### Shared Regions Modified

None.

#### Extension Config Changes

None.

## Positive Observations

- Correctly removes the C# doc's inaccurate "filters for editable projects" claim — confirmed absent from both the visible stub and the actual Studio patch's selection/connected-resource-scan logic.
- The C# `<list type="bullet">` XML structure is well-formed and matches the pattern already used elsewhere in `c-sharp/Projects/`; the TS bullet list matches this same file's existing `- key = description` style (e.g. `ResultStatus`).
- Both C# and TS docs were kept in sync with each other in substance across all four cases (explicit IDs, null-with-locals, null-first-sync-bootstrap, empty-array), so a C# maintainer and a TS extension developer get the same picture.
- Confirmed via `git diff --name-only` that only these two files changed — no incidental logic, test, or config changes riding along; genuinely small and focused as described.
- No indecipherable initialisms introduced (`S/R`, `Observer` were already established terms in this codebase).
- No backward-facing PT-4483/#2640 references landed in the code itself — those identifiers appear only in the commit message, which is the correct place for them.
- Both formatters (`dotnet csharpier`, `prettier`/ESLint) pass clean on both files.

## Interview Notes

**Stated purpose**: Fix stale/inaccurate doc comments on `paratextBibleSendReceive.syncProjects` (C#
XML doc + TS `.d.ts`) so they describe the actual Paratext 10 Studio behavior — the `isFirstTimeSync`
bootstrap-download carve-out, explicit-ID handling, empty-array no-op, and removal of a false
"filters for editable projects" claim. Split out from the now-closed PR #2640 as a small, focused
doc fix under PT-4483.

**Provenance**: This fix emerged from a detailed re-evaluation of PR #2640's Matt-authored review
(36+ inline comments), which surfaced that the `syncProjects` contract docs were stale relative to
the actual P10 Studio implementation. During that investigation the author corrected two drafted
claims in real time by checking the actual closed-source patch source directly (not just this
repo's stub or the reviewer's prose): first, that a naive "syncs everything on first sync" claim was
wrong (the real behavior stops early once an editable project is found, via a batch-of-5-then-
one-at-a-time heuristic), and second, that "filters for editable projects" in the old C# summary has
no corresponding code at all. Both corrections are reflected in the committed doc text, not just
caught and discarded.

**Verification note for the reviewer**: the `api` analysis agent flagged (as `DONE_WITH_CONCERNS`)
that it could not verify the new doc text against the real `isFirstTimeSync`/batching implementation,
since that logic lives in the closed-source `paratext-10-studio` patch, not this repository. This is
accurate as a statement about what's checkable from this repo alone — but the author did verify the
new text directly against that patch's actual source (`repo-patches/paranext-core.patch`,
`SyncProjectsCore`) during this session, including catching and correcting the two inaccuracies
above before they landed. Worth noting in the PR description or review meeting so the reviewer knows
this wasn't left unverified, just verified outside this repo's visibility.

**No unresolved items.** No Critical/Important findings were raised. Minor findings were both fixed
per the author's "use your best judgment" instruction. Author had nothing further to flag at wrap-up.

## In-Review Quality Check

- **`npm run typecheck`** — PASSED, all workspaces, no fixes needed.
- **`npm run lint`** — PASSED (exit 0 across all workspaces). One pre-existing, unrelated warning
  surfaced in `lib/platform-bible-utils/src/lifetime-management/unsubscriber-async-list.test.ts`
  (`import/no-named-as-default`) — not touched by this branch, not an error, not fixed.
- **Prettier on changed files** — ran; no additional changes needed, both files already correctly
  formatted.
- **`npm test`** — 3003 passed / 1 failed / 1 skipped, 211/212 test files passed. The one failure
  (`keyboard-shortcuts-catalog.component.test.tsx`, a `Hook timed out in 10000ms` during `afterEach`)
  is unrelated to this branch's two doc-comment files; re-run in isolation, all 7 tests in that file
  passed in ~11s. Consistent with resource contention from running immediately after long
  typecheck/lint passes, not a real regression. Not fixed (unrelated, non-reproducing).

No unfixable failures traceable to the in-review changes.

## Suggested Review Focus

- [ ] Given this doc's behavior can't be checked against implementation from within this repo alone
      (the real logic lives in the private Studio patch), a second pair of eyes with direct access to
      `paratext-10-studio`'s `repo-patches/paranext-core.patch` (`SyncProjectsCore`) confirming the
      four-case description still matches current `main` there would be the most valuable check —
      the author already did this once during this session, so this is a re-confirmation rather than
      a first pass.
- [ ] No other open questions — this is a small, self-contained doc fix with no logic changes.
<!-- review-paratext:summary:end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2771)
<!-- Reviewable:end -->
