### PR TITLE
Document why root package.json has no name, and guard the lockfile

### DIFF
--- a/.claude/rules/root-package-json-no-name.md
+++ b/.claude/rules/root-package-json-no-name.md
@@ -1,0 +1,39 @@
+---
+paths:
+  - 'package.json'
+  - 'package-lock.json'
+  - 'release/app/package.json'
+---
+
+## Never Add `name` or `version` to the Root `package.json`
+
+The root `package.json` deliberately carries no `name` and no `version`. The app's identity lives in
+`release/app/package.json` (`name: "platform-bible"`), and electron-builder resolves it from both
+files in ways that are not obvious from either.
+
+**Do not add these fields.** The full reasoning, the alternatives, and the manual test matrix any
+future attempt must clear are in
+[`adr-root-package-json-no-name`](../../.context/standards/Architecture-Decisions.md) — read that
+before proposing a change, rather than re-deriving it.
+
+### The symptom you are probably reacting to
+
+Because npm falls back to the containing directory name when `name` is absent, running
+`npm install` from a clone or git worktree **not** named `paranext-core` rewrites the root `name` in
+`package-lock.json`:
+
+```diff
+-  "name": "paranext-core",
++  "name": "my-branch-worktree",
+```
+
+**Fix the lockfile, not the manifest.** Restore the line to `paranext-core`. A check in
+`.husky/pre-commit` blocks the commit if you miss it, and the wrong name is otherwise
+self-consistent — CI's "Verify no files changed after build" will not catch it.
+
+### Why this rule exists
+
+Adding the field is a reasonable-looking one-line change, so it keeps getting proposed — repeatedly
+and independently, including by AI agents, each time rediscovering the reasoning from scratch. If
+you are about to suggest it, you are not the first. The ADR weighs the payoff against the exposure
+and records what a future attempt would have to demonstrate.

--- a/.claude/rules/root-package-json-no-name.md
+++ b/.claude/rules/root-package-json-no-name.md
@@ -31,6 +31,12 @@ Because npm falls back to the containing directory name when `name` is absent, r
 `.husky/pre-commit` blocks the commit if you miss it, and the wrong name is otherwise
 self-consistent — CI's "Verify no files changed after build" will not catch it.
 
+That hook guards the symptom, not this rule: it compares the lockfile's root `name` against
+`paranext-core`, so adding `"name": "paranext-core"` to the manifest makes npm write the expected
+value and the check passes while the decision is being violated. What actually stops that is CI —
+naming the root makes `import/no-relative-packages` reject 12 pre-existing imports across 9 files.
+See the ADR for why that is a prerequisite rather than a nuisance.
+
 ### Why this rule exists
 
 Adding the field is a reasonable-looking one-line change, so it keeps getting proposed — repeatedly

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -2545,6 +2545,56 @@ step, no automation. Just a record.
 - **Source:** punctuation-checklist port (markers-consumption verdict); see `08_Checklists.md` in the
   PT9 feature inventory for the per-tool behavior and the verse-range divergence.
 
+## adr-root-package-json-no-name: The root `package.json` carries no `name` or `version`; app identity lives in `release/app/package.json`
+
+- **Date:** 2026-09-08
+- **Status:** Accepted
+- **Context:** The root `package.json` has no `name` and no `version` field. That absence is
+  load-bearing rather than an oversight, but nothing in the repo said so, and it is repeatedly
+  re-proposed — PR #2199, a revision of PR #2257, and again during unrelated dependency work in
+  September 2026 — each time rediscovering the reasoning from scratch.
+  electron-builder resolves app identity from **both** the root manifest and
+  `release/app/package.json` in ways neither file makes obvious: `electron-builder.json5` sets
+  `productName` and `appId` and points `directories.app` at `release/app`, while
+  `release/app/package.json` carries the real identity (`name: "platform-bible"`). Adding
+  `name`/`version` to the root is *recollected* to have broken the macOS build once — raised by
+  tjcouch-sil in review of #2257, who asked jolierabideau to confirm it. Treat that as unverified
+  recollection rather than established fact: it has not been reproduced, and the review carries no
+  corroboration. The visible cost of the absence is that npm falls back to the containing directory
+  name, so `npm install` from a clone or git worktree not named `paranext-core` rewrites the
+  lockfile's root `name`.
+- **Decision:** Leave the root `package.json` without `name` or `version`. Guard the *symptom*
+  instead: `.husky/pre-commit` blocks a commit that stages a `package-lock.json` whose root `name`
+  is not `paranext-core`, alongside the existing yalc-entries check. It reads the staged blob, and
+  only when the lockfile is staged, so an unrelated commit is never blocked and a drifted staged
+  copy is never missed because the working tree was fixed without re-staging.
+- **Alternatives:**
+  - *Add `name` to the root manifest* — deferred, not rejected on merit. PR #2199 proposed
+    `paranext-core` and a revision of PR #2257 proposed `platform-bible`; the two attempts did not
+    agree on the value, which is itself a sign the question is unsettled. The payoff is removing a
+    one-line lockfile annoyance; the exposure is app identity across two products and three
+    operating systems.
+  - *Add it here and in `paratext-10-studio` together* — that coordination would be mandatory, not
+    optional: `lib/build.ts` there rewrites `release/app/package.json` (setting
+    `releaseAppPackage.name` and `.version`) and never touches the root manifest, so a root `name`
+    would survive the Paratext 10 Studio rename unchanged.
+  - *Leave it undocumented* — rejected: the undocumented status quo is what produced the repeated
+    rediscoveries.
+- **Consequences:** Dev runs store data under `%appdata%/Electron` rather than a product-named
+  directory (prod is unaffected); the team treats the resulting dev/prod log separation as a minor
+  benefit. Anyone revisiting this must first clear the bar set in review of #2257 — test dev **and**
+  prod (portable and installed), on Platform.Bible **and** Paratext 10 Studio, on all three
+  operating systems, checking app data paths (`%appdata%/<name>`, `~/<name>`, install dir), deep
+  links and the displayed app name, the output executable name, executable metadata, and signing.
+  Revisit if electron-builder's field resolution becomes documented well enough to retire that
+  matrix, or if someone confirms or refutes the macOS recollection.
+- **Source:** PR #2199 (`fix: add explicit name to package.json`, opened 2026-04-14 by merchako, who
+  later asked to hand it off after the review below), and
+  tjcouch-sil's CHANGES_REQUESTED review of PR #2257 (2026-05-11), which carries the full rationale
+  and the test matrix. #2257 itself is unrelated work ("Update some vestigial Paranext references to
+  Platform.Bible", merged 2026-05-13) that briefly proposed the same root-`name` addition and
+  dropped it.
+
 ## adr-runaway-data-hook-guard: `useData`'s runaway guard counts subscribes and deliveries, degrades rather than throws, and expires
 
 - **Date:** 2026-08-28

--- a/.context/standards/Architecture-Decisions.md
+++ b/.context/standards/Architecture-Decisions.md
@@ -2552,17 +2552,23 @@ step, no automation. Just a record.
 - **Context:** The root `package.json` has no `name` and no `version` field. That absence is
   load-bearing rather than an oversight, but nothing in the repo said so, and it is repeatedly
   re-proposed — PR #2199, a revision of PR #2257, and again during unrelated dependency work in
-  September 2026 — each time rediscovering the reasoning from scratch.
-  electron-builder resolves app identity from **both** the root manifest and
-  `release/app/package.json` in ways neither file makes obvious: `electron-builder.json5` sets
-  `productName` and `appId` and points `directories.app` at `release/app`, while
-  `release/app/package.json` carries the real identity (`name: "platform-bible"`). Adding
-  `name`/`version` to the root is *recollected* to have broken the macOS build once — raised by
-  tjcouch-sil in review of #2257, who asked jolierabideau to confirm it. Treat that as unverified
-  recollection rather than established fact: it has not been reproduced, and the review carries no
-  corroboration. The visible cost of the absence is that npm falls back to the containing directory
-  name, so `npm install` from a clone or git worktree not named `paranext-core` rewrites the
-  lockfile's root `name`.
+  August 2026 (PR #2714, whose own merge landed in September) — each time rediscovering the
+  reasoning from scratch. Naming the root has twice broken CI, for a precise and fully diagnosed
+  reason: it makes eslint-plugin-import treat the root as a package, so `import/no-relative-packages`
+  rejects every pre-existing relative import that crosses out of the root into `release/app`,
+  `.storybook` or the `lib` packages — 12 errors across 9 files, none of them files such a change
+  would touch. That is what failed the Ubuntu build on #2257 revision r3 (2026-05-11) and all three
+  platforms on #2714 (2026-08-28). Separately, electron-builder resolves app identity from **both**
+  the root manifest and `release/app/package.json` in ways neither file makes obvious:
+  `electron-builder.json5` sets `productName` and `appId` and points `directories.app` at
+  `release/app`, while `release/app/package.json` carries the real identity
+  (`name: "platform-bible"`). Adding `name`/`version` to the root is separately *recollected* to have
+  broken the macOS build — raised by tjcouch-sil in review of #2257, who asked jolierabideau to
+  confirm it. That recollection specifically remains unverified: jolierabideau never replied on
+  either PR, and #2257's macOS job was cancelled rather than run, so it neither confirms nor refutes
+  it. The visible cost of the absence is that npm falls back to the containing directory name, so
+  `npm install` from a clone or git worktree not named `paranext-core` rewrites the lockfile's root
+  `name`.
 - **Decision:** Leave the root `package.json` without `name` or `version`. Guard the *symptom*
   instead: `.husky/pre-commit` blocks a commit that stages a `package-lock.json` whose root `name`
   is not `paranext-core`, alongside the existing yalc-entries check. It reads the staged blob, and
@@ -2572,8 +2578,12 @@ step, no automation. Just a record.
   - *Add `name` to the root manifest* — deferred, not rejected on merit. PR #2199 proposed
     `paranext-core` and a revision of PR #2257 proposed `platform-bible`; the two attempts did not
     agree on the value, which is itself a sign the question is unsettled. The payoff is removing a
-    one-line lockfile annoyance; the exposure is app identity across two products and three
-    operating systems.
+    one-line lockfile annoyance. The cost has two parts, and the cheap one is the one that has
+    actually stopped every attempt so far: the `import/no-relative-packages` failure above must be
+    resolved first, by either moving the root into a workspace layout that makes those imports legal
+    or rewriting the 12 offending imports, plus whatever prettier and stylelint fallout follows.
+    Only past that does the second part apply — app identity across two products and three
+    operating systems, which is unverified rather than disproven.
   - *Add it here and in `paratext-10-studio` together* — that coordination would be mandatory, not
     optional: `lib/build.ts` there rewrites `release/app/package.json` (setting
     `releaseAppPackage.name` and `.version`) and never touches the root manifest, so a root `name`
@@ -2586,8 +2596,12 @@ step, no automation. Just a record.
   prod (portable and installed), on Platform.Bible **and** Paratext 10 Studio, on all three
   operating systems, checking app data paths (`%appdata%/<name>`, `~/<name>`, install dir), deep
   links and the displayed app name, the output executable name, executable metadata, and signing.
-  Revisit if electron-builder's field resolution becomes documented well enough to retire that
-  matrix, or if someone confirms or refutes the macOS recollection.
+  Before any of that, though, the `import/no-relative-packages` prerequisite has to be cleared —
+  it is cheap, precise and reproducible, and it is what has actually failed CI both times, so an
+  attempt that works the matrix first will be stopped long before reaching it. Revisit if the
+  import layout changes so that naming the root no longer trips that rule, if electron-builder's
+  field resolution becomes documented well enough to retire the matrix, or if someone confirms or
+  refutes the macOS recollection.
 - **Source:** PR #2199 (`fix: add explicit name to package.json`, opened 2026-04-14 by merchako, who
   later asked to hand it off after the review below), and
   tjcouch-sil's CHANGES_REQUESTED review of PR #2257 (2026-05-11), which carries the full rationale

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -44,6 +44,32 @@ if grep -q '\.yalc' package-lock.json 2>/dev/null; then
   exit 1
 fi
 
+# Block committing a package-lock.json whose root name has drifted (staged only). The root
+# package.json deliberately has no "name" field (see adr-root-package-json-no-name in
+# .context/standards/Architecture-Decisions.md), so npm falls back to the containing directory name:
+# any clone or git worktree not named paranext-core rewrites it on npm install. This inspects the
+# staged blob rather than the working tree, so a commit that does not touch the lockfile is never
+# blocked, and a drifted staged copy is never missed because the working tree was fixed but not
+# re-staged.
+if git diff --cached --name-only --diff-filter=ACMR | grep -qx 'package-lock.json'; then
+  LOCK_ROOT_NAME=$(git show :package-lock.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).name" 2>/dev/null)
+  if [ "$LOCK_ROOT_NAME" != "paranext-core" ]; then
+    echo ""
+    echo "Error: package-lock.json's root \"name\" is \"$LOCK_ROOT_NAME\", expected \"paranext-core\"."
+    echo "npm falls back to the directory name because the root package.json has no \"name\" field."
+    echo "Do NOT add a \"name\" to package.json - that field is deliberately absent."
+    echo "See adr-root-package-json-no-name in .context/standards/Architecture-Decisions.md."
+    echo ""
+    echo "If the lockfile has no other changes you want to keep, discard it:"
+    echo "  git checkout HEAD -- package-lock.json"
+    echo ""
+    echo "Otherwise edit the root \"name\" (the second line of the file) back to"
+    echo "\"paranext-core\" and re-stage:"
+    echo "  git add package-lock.json"
+    exit 1
+  fi
+fi
+
 echo "Format and stylelint fixes..."
 npm run lint:staged
 echo "Format and stylelint fixes finished"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -53,6 +53,16 @@ fi
 # re-staged.
 if git diff --cached --name-only --diff-filter=ACMR | grep -qx 'package-lock.json'; then
   LOCK_ROOT_NAME=$(git show :package-lock.json | node -p "JSON.parse(require('fs').readFileSync(0, 'utf8')).name" 2>/dev/null)
+  # An empty value means node could not parse the staged blob at all (unresolved conflict markers
+  # are the usual cause); "undefined" means it parsed but carried no root name. Neither is drift, so
+  # do not send the developer off to edit a name that is not the problem. stderr stays suppressed
+  # above: without it a V8 stack trace buries the message below.
+  if [ -z "$LOCK_ROOT_NAME" ] || [ "$LOCK_ROOT_NAME" = "undefined" ]; then
+    echo ""
+    echo "Error: could not read the root \"name\" from the staged package-lock.json."
+    echo "Is it valid JSON with a root \"name\"? Unresolved conflict markers will do this."
+    exit 1
+  fi
   if [ "$LOCK_ROOT_NAME" != "paranext-core" ]; then
     echo ""
     echo "Error: package-lock.json's root \"name\" is \"$LOCK_ROOT_NAME\", expected \"paranext-core\"."


### PR DESCRIPTION
<!-- review-paratext:summary:start -->

# Document why root package.json has no name, and guard the lockfile

The root `package.json` deliberately carries no `name` and no `version` — app identity lives in `release/app/package.json`, and electron-builder resolves it from both files in ways neither makes obvious. That absence is load-bearing but was recorded nowhere, so it has been independently re-proposed several times, each attempt rediscovering the reasoning from scratch.

This branch records the decision and guards its most visible symptom. It adds `adr-root-package-json-no-name` to the decision log, a path-scoped `.claude/rules/` entry so agents meet the rule when editing the relevant manifests, and a `.husky/pre-commit` check that blocks committing a `package-lock.json` whose root `name` has drifted. It deliberately does **not** touch the `name` field itself — it guards the symptom and leaves the risky field alone.

**3 files, +145 / −0. Two commits:** the original entry, then the fixes from Katherine's review.

## What a reviewer should look at

- [ ] **Is `import/no-relative-packages` the right thing to lead with?** The entry now names it as the prerequisite, ahead of the electron-builder matrix, on the grounds that it is precise, cheap, reproducible, and what actually failed CI on #2257 r3 and #2714. Reproduced independently here: 12 errors across 9 files. The judgement call is ordering it first — the electron-builder exposure is still real, just unverified.
- [ ] **The staged-only scope of the guard.** It fires only when `package-lock.json` is staged. That fixes a real false negative, but drift sitting in the working tree is invisible until you stage the file. Confirm that is the behaviour you want.
- [ ] **Whether the macOS claim should stay.** Recorded as unverified recollection; jolierabideau was asked on both PRs and never replied, and #2257's macOS job was cancelled rather than run. It is one of two reasons the field stays unchanged, so it may be worth chasing confirmation or letting the entry stand.
- [ ] **PR #2199 is still open and orphaned.** Its author asked to hand it off. This branch documents the decision but does not close that PR.

## Review round 2 — Katherine's findings

All five verified independently before acting on them; all five addressed in `c0dfc15bf8f`.

| # | Finding | Resolution |
| --- | --- | --- |
| 1 | "Not reproduced / no corroboration" overstated the record | Split: macOS report stays unverified, but naming the root has broken CI twice for a diagnosed reason |
| 2 | `import/no-relative-packages` is the real blocker, and was absent | Now the lead prerequisite in `Context`, `Alternatives` and the revisit conditions |
| 3 | The third attempt was August 2026, not September | Corrected; only #2714's merge landed in September |
| 4 | Rule file read as though the hook enforces the rule | Now states it guards the symptom, and names CI as what actually stops a manifest `name` |
| 5 | Malformed staged JSON misdiagnosed as a name problem | Distinct message for unreadable/absent root name; `2>/dev/null` kept so no V8 trace buries it |

Reproduced for finding 2 rather than taken on trust: adding `"name": "paranext-core"` to the root produces the errors; removing it, the same files are clean. Confirmed her count of 12 exactly, under the repo's own lint scope.

Deliberately **not** changed, per her measurement against the file's own house style: entry length (50 lines vs a median of 47), the unbroken `Context` prose (the format of 50/61 entries), the test matrix as prose rather than a checklist (tick-boxes would read as a to-do list rather than a bar to clear), and the six-line `Source:` field (the only place recording #2257 as *unrelated* work).

<details>
<summary>Round 1 — findings from the pre-PR review, all resolved before opening</summary>

### Important

- [x] **The guard read the working-tree lockfile rather than the staged blob**, producing both a false negative (stage a drifted lockfile → fix the working tree → forget to re-stage → the hook reads the fixed file and passes) and a false positive (every commit blocked while the working tree is drifted). With CLAUDE.md forbidding `--no-verify`, there was no escape hatch. _(Fixed: gated on `git diff --cached`, reads `git show :package-lock.json`. Both modes re-tested.)_

### Minor

- [x] **No runnable fix in the error message** _(Fixed: both recovery paths given.)_
- [x] **Format-coupled `sed` extraction** _(Fixed: node reading the staged blob from stdin.)_
- [x] **Empty-string edge case on a missing key** _(Fixed via the node switch; refined again in round 2.)_
- [x] **ADR Decision field described the superseded behaviour** _(Fixed.)_
- [x] **Rule file restated the ADR's rationale** _(Fixed: it defers to the ADR.)_
- [ ] ~~Hook-only, no CI backstop~~ _(Accepted: both documents state CI cannot catch this. Round 2 established that CI **does** catch the more important case — a manifest `name` — via `import/no-relative-packages`.)_
- [ ] ~~No test covers the guard~~ _(Accepted: no test infrastructure exists for `.husky/` hooks. All paths verified by hand.)_
- [ ] ~~ADR link has no `#slug` fragment~~ _(Accepted: matches repo convention — and round 2 confirmed GitHub slugifies the whole heading, so the fragment would not resolve anyway.)_

</details>

<details>
<summary>Verification</summary>

- `sh -n .husky/pre-commit` — exit 0 (husky runs hooks with `sh`).
- `npx prettier --check` on both Markdown files — exit 0.
- Guard behaviour verified end-to-end after every edit: staged drift blocks; unstaged drift is ignored; `git commit -a` still catches drift because it stages first; malformed staged JSON now reports an unreadable name rather than drift; a correct name passes.
- ADR slug ordering re-verified after the rebase: `LC_ALL=C sort -c` over all `^## adr-` headings passes.
- **Paratext 10 Studio compatibility**, re-checked against the final hook rather than the initial version. Its `paranext-core.patch` hunk anchors on lines 1–5, and `git apply --3way --check` exits 0 over this change. Its inserted `exit 1` sits at line 4, so this guard is unreachable inside `temp-build/paranext-core` by construction, and the build never commits inside the clone anyway (`git apply`, `git add`, `git diff`, `git reset --hard` — none fire `pre-commit`). The clone directory is literally `paranext-core`, so npm's fallback could not drift there either.

Not run: `npm run typecheck`, `npm run lint`, `npm test`. The diff is two Markdown files and one extensionless shell file — eslint runs `--ext .cjs,.js,.jsx,.ts,.tsx`, stylelint globs only CSS/SCSS, and there is no TypeScript or test code here. CI runs the full set regardless.

</details>

<!-- review-paratext:summary:end -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2778)
<!-- Reviewable:end -->
