### PR TITLE
PT-4335: Route extension-raised notifications and prompts to the window they concern

### DIFF
--- a/e2e-tests/tests/isolated/multi-window/per-window-ui.spec.ts
+++ b/e2e-tests/tests/isolated/multi-window/per-window-ui.spec.ts
@@ -4,9 +4,9 @@
  * The multi-window architecture makes formerly app-singleton UI surfaces per-window by
  * construction: each window is a full renderer with its own OverlayHost, Toaster, toolbar, and
  * module state, web view iframes inherit their PARENT window's papi object, and the main process
- * routes dialog/notification/web-view requests to the window they name, or to the focused window
- * when they name none. Nothing pinned any of that behaviour — this spec is the regression guard
- * that does.
+ * routes notification and web-view requests to the window they name, and everything else — dialogs
+ * included, which cannot name one — to the focused window. Nothing pinned any of that behaviour —
+ * this spec is the regression guard that does.
  *
  * One test, one Electron instance (each launch costs 30+ seconds, so the scenarios share two
  * windows), asserting in order:
@@ -255,9 +255,9 @@ function showModalAlertViaWebSocket(prompt: string): Promise<unknown> {
 
 /**
  * Send a notification through the GENERIC notification service — the name the main process serves
- * with a service router that routes `send` to the window they name, or to the focused window when
- * they name none. `duration: 0` means the toast never auto-closes, so assertions cannot race an
- * auto-dismiss; tests dismiss explicitly.
+ * with a service router that routes `send` to the window the notification names, or to the focused
+ * window when it names none. `duration: 0` means the toast never auto-closes, so assertions cannot
+ * race an auto-dismiss; tests dismiss explicitly.
  */
 async function sendNotification(message: string): Promise<string | number> {
   return sendPapiRequestOnce<string | number>(

--- a/e2e-tests/tests/isolated/multi-window/per-window-ui.spec.ts
+++ b/e2e-tests/tests/isolated/multi-window/per-window-ui.spec.ts
@@ -4,8 +4,9 @@
  * The multi-window architecture makes formerly app-singleton UI surfaces per-window by
  * construction: each window is a full renderer with its own OverlayHost, Toaster, toolbar, and
  * module state, web view iframes inherit their PARENT window's papi object, and the main process
- * routes generic dialog/notification/web-view requests to the focused window. Nothing pinned any of
- * that behaviour — this spec is the regression guard that does.
+ * routes dialog/notification/web-view requests to the window they name, or to the focused window
+ * when they name none. Nothing pinned any of that behaviour — this spec is the regression guard
+ * that does.
  *
  * One test, one Electron instance (each launch costs 30+ seconds, so the scenarios share two
  * windows), asserting in order:
@@ -254,8 +255,9 @@ function showModalAlertViaWebSocket(prompt: string): Promise<unknown> {
 
 /**
  * Send a notification through the GENERIC notification service — the name the main process serves
- * with a service router that forwards `send` to the focused window. `duration: 0` means the toast
- * never auto-closes, so assertions cannot race an auto-dismiss; tests dismiss explicitly.
+ * with a service router that routes `send` to the window they name, or to the focused window when
+ * they name none. `duration: 0` means the toast never auto-closes, so assertions cannot race an
+ * auto-dismiss; tests dismiss explicitly.
  */
 async function sendNotification(message: string): Promise<string | number> {
   return sendPapiRequestOnce<string | number>(

--- a/extensions/src/platform-scripture-editor/src/markers-view-notifier.model.ts
+++ b/extensions/src/platform-scripture-editor/src/markers-view-notifier.model.ts
@@ -185,6 +185,9 @@ export class MarkersViewNotifier {
           message,
           clickCommand: 'platformScriptureEditor.dismissMarkerNotificationForProjectToday',
           clickCommandLabel: localizedClickLabel,
+          // This prompt is about this editor's project, and the editor may be in a window the user
+          // is not currently looking at.
+          webViewId: webViewDefinition.id,
         });
         this.projectIdsByNotificationId.set(notificationId, projectId);
 

--- a/extensions/src/platform-scripture-editor/src/shared-layout-receiver.model.test.ts
+++ b/extensions/src/platform-scripture-editor/src/shared-layout-receiver.model.test.ts
@@ -175,6 +175,24 @@ describe('SharedLayoutReceiver', () => {
     );
   });
 
+  it('routes the notification to the editor it is about, in case another window is focused', async () => {
+    // getAllOpenWebViewDefinitions returns editor id 'ed-1' — see makeReceiverHarness. Naming it lets
+    // the notification router send the prompt to the window that owns that editor rather than
+    // whichever window the user happens to be looking at.
+    const h = makeReceiverHarness({ layout: [{ type: 'project', name: 'A', id: '1' }] });
+    await h.receiver.applyForProject('proj-1');
+    h.papi.projectDataProviders.get.mockImplementation(async () => ({
+      getSetting: vi.fn(async (key: string) =>
+        key === 'platformScripture.sharedLayoutDefaultTab'
+          ? 'CommentaryResource'
+          : { dataVersion: '1.0.0', items: [{ type: 'project', name: 'B', id: '2' }] },
+      ),
+    }));
+    h.fireSync();
+    await flush();
+    expect(h.send).toHaveBeenCalledWith(expect.objectContaining({ webViewId: 'ed-1' }));
+  });
+
   it('does not notify when the layout is unchanged', async () => {
     const h = makeReceiverHarness({ layout: [{ type: 'project', name: 'A', id: '1' }] });
     await h.receiver.applyForProject('proj-1');

--- a/extensions/src/platform-scripture-editor/src/shared-layout-receiver.model.ts
+++ b/extensions/src/platform-scripture-editor/src/shared-layout-receiver.model.ts
@@ -161,7 +161,7 @@ export class SharedLayoutReceiver {
   /**
    * The Simple-mode editor a completed sync's "Apply now" prompt should be about — its project, to
    * decide whether the layout changed, and its web view id, so the router can send the prompt to
-   * the window that actually has it open instead of the focused window (PT-4335).
+   * the window that actually has it open instead of the focused window.
    */
   private async getOpenSimpleModeEditor(): Promise<
     { projectId: string; webViewId: string } | undefined
@@ -172,12 +172,14 @@ export class SharedLayoutReceiver {
       (def) => def.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE && !def.state?.isReadOnly,
     );
     if (!editor?.projectId) return undefined;
+
     return { projectId: editor.projectId, webViewId: editor.id };
   }
 
   private async handleSyncCompleted(): Promise<void> {
     const editor = await this.getOpenSimpleModeEditor();
     if (!editor) return;
+
     const { projectId, webViewId } = editor;
 
     // Only manual Send/Receives reach here (`onSyncStateChanged` does not fire for the programmatic
@@ -203,7 +205,7 @@ export class SharedLayoutReceiver {
       clickCommand: 'platformScriptureEditor.applySharedLayout',
       clickCommandLabel: '%platformScriptureEditor_sharedLayout_applyNow%',
       // Routes the prompt to the window that has this editor open, rather than the focused window —
-      // the project it is about may not be the one the user is currently looking at (PT-4335).
+      // the project it is about may not be the one the user is currently looking at.
       webViewId,
     });
     this.projectIdByNotificationId.set(notificationId, projectId);

--- a/extensions/src/platform-scripture-editor/src/shared-layout-receiver.model.ts
+++ b/extensions/src/platform-scripture-editor/src/shared-layout-receiver.model.ts
@@ -158,18 +158,27 @@ export class SharedLayoutReceiver {
     }
   }
 
-  private async getOpenSimpleModeProjectId(): Promise<string | undefined> {
+  /**
+   * The Simple-mode editor a completed sync's "Apply now" prompt should be about — its project, to
+   * decide whether the layout changed, and its web view id, so the router can send the prompt to
+   * the window that actually has it open instead of the focused window (PT-4335).
+   */
+  private async getOpenSimpleModeEditor(): Promise<
+    { projectId: string; webViewId: string } | undefined
+  > {
     if ((await this.papi.settings.get('platform.interfaceMode')) !== 'simple') return undefined;
     const defs = await this.papi.webViews.getAllOpenWebViewDefinitions();
     const editor = defs.find(
       (def) => def.webViewType === SCRIPTURE_EDITOR_WEBVIEW_TYPE && !def.state?.isReadOnly,
     );
-    return editor?.projectId;
+    if (!editor?.projectId) return undefined;
+    return { projectId: editor.projectId, webViewId: editor.id };
   }
 
   private async handleSyncCompleted(): Promise<void> {
-    const projectId = await this.getOpenSimpleModeProjectId();
-    if (!projectId) return;
+    const editor = await this.getOpenSimpleModeEditor();
+    if (!editor) return;
+    const { projectId, webViewId } = editor;
 
     // Only manual Send/Receives reach here (`onSyncStateChanged` does not fire for the programmatic
     // project-switch sync), so always take the notify path when the layout changed. Project-switch
@@ -193,6 +202,9 @@ export class SharedLayoutReceiver {
       message: '%platformScriptureEditor_sharedLayout_newLayoutAvailable%',
       clickCommand: 'platformScriptureEditor.applySharedLayout',
       clickCommandLabel: '%platformScriptureEditor_sharedLayout_applyNow%',
+      // Routes the prompt to the window that has this editor open, rather than the focused window —
+      // the project it is about may not be the one the user is currently looking at (PT-4335).
+      webViewId,
     });
     this.projectIdByNotificationId.set(notificationId, projectId);
     this.notificationIdByProjectId.set(projectId, notificationId);

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -6426,6 +6426,9 @@ declare module 'shared/models/notification.service-model' {
      * Omit for a generic notice, which should keep routing to the focused window — where the user is
      * looking is the right place for something that is not about anything in particular.
      *
+     * The narrowest key available: a notification about a project with no web view currently open has
+     * no `webViewId` to name, and routes to the focused window like a generic notice would.
+     *
      * @experimental
      */
     webViewId?: WebViewId;

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -6411,11 +6411,11 @@ declare module 'shared/models/notification.service-model' {
      */
     duration?: number;
     /**
-     * Optional id of a web view this notification is about. When provided, the notification is
-     * routed to the window that owns that web view instead of the focused window — for a notification
-     * or prompt raised about a specific project or editor that may not be the one the user is
-     * currently looking at. Falls back to the focused window if the web view cannot be found open in
-     * any window.
+     * Optional id of a web view this notification is about. When provided, the notification is routed
+     * to the window that owns that web view instead of the focused window — for a notification or
+     * prompt raised about a specific project or editor that may not be the one the user is currently
+     * looking at. Falls back to the focused window if the web view cannot be found open in any
+     * window.
      *
      * Omit for a generic notice, which should keep routing to the focused window — where the user is
      * looking is the right place for something that is not about anything in particular.

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -6400,6 +6400,11 @@ declare module 'shared/models/notification.service-model' {
      * On an update (a `send` reusing an id that is still showing), any optional field you omit keeps
      * the value it had on the previous `send` for that id - omitting a field never clears it. Pass
      * the field explicitly to change it.
+     *
+     * The one exception is {@link webViewId}: which window a `send` runs in is decided in the main
+     * process before the renderer ever sees the notification to merge it, so omitting `webViewId` on
+     * an update does NOT keep routing to the window the original send resolved to - it always routes
+     * by the rules {@link webViewId} documents, using only what this call passed.
      */
     notificationId?: string | number;
     /**
@@ -6414,8 +6419,9 @@ declare module 'shared/models/notification.service-model' {
      * Optional id of a web view this notification is about. When provided, the notification is routed
      * to the window that owns that web view instead of the focused window — for a notification or
      * prompt raised about a specific project or editor that may not be the one the user is currently
-     * looking at. Falls back to the focused window if the web view cannot be found open in any
-     * window.
+     * looking at. Falls back to the focused window whenever the web view's window cannot be
+     * determined — it is open nowhere, a window that might have it could not be asked, or it is
+     * moving between windows.
      *
      * Omit for a generic notice, which should keep routing to the focused window — where the user is
      * looking is the right place for something that is not about anything in particular.

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -6404,7 +6404,10 @@ declare module 'shared/models/notification.service-model' {
      * The one exception is {@link webViewId}: which window a `send` runs in is decided in the main
      * process before the renderer ever sees the notification to merge it, so omitting `webViewId` on
      * an update does NOT keep routing to the window the original send resolved to - it always routes
-     * by the rules {@link webViewId} documents, using only what this call passed.
+     * by the rules {@link webViewId} documents, using only what this call passed. An update that lands
+     * in a different window updates nothing: that window has never seen the id, so it opens a second
+     * notification with no merge applied, and the original stays up in the window it was routed to.
+     * Pass the same `webViewId` on every `send` that shares an id.
      */
     notificationId?: string | number;
     /**

--- a/lib/papi-dts/papi.d.ts
+++ b/lib/papi-dts/papi.d.ts
@@ -6265,6 +6265,7 @@ declare module 'shared/models/notification.service-model' {
   import { CommandHandlers } from 'papi-shared-types';
   import { LocalizeKey } from 'platform-bible-utils';
   import type { NetworkObjectDocumentation } from 'shared/models/openrpc.model';
+  import type { WebViewId } from 'shared/models/web-view.model';
   export type Severity = 'info' | 'warning' | 'error';
   /**
    * The placements a notification can appear in, as a frozen array so it can be the single source of
@@ -6409,6 +6410,19 @@ declare module 'shared/models/notification.service-model' {
      * seconds).
      */
     duration?: number;
+    /**
+     * Optional id of a web view this notification is about. When provided, the notification is
+     * routed to the window that owns that web view instead of the focused window — for a notification
+     * or prompt raised about a specific project or editor that may not be the one the user is
+     * currently looking at. Falls back to the focused window if the web view cannot be found open in
+     * any window.
+     *
+     * Omit for a generic notice, which should keep routing to the focused window — where the user is
+     * looking is the right place for something that is not about anything in particular.
+     *
+     * @experimental
+     */
+    webViewId?: WebViewId;
   }
   /**
    * Type signature for a command handler that is called when a user clicks on a notification.

--- a/src/main/services/__tests__/notification.service-router.test.ts
+++ b/src/main/services/__tests__/notification.service-router.test.ts
@@ -21,6 +21,7 @@ const mocks = vi.hoisted(() => {
     getReadyWindowIds: vi.fn(),
     getUnreachableWindowIds: vi.fn(),
     getAbandonedWindowIds: vi.fn(),
+    isWindowClosing: vi.fn(),
     networkObjectGet: vi.fn(),
     networkObjectSet: vi.fn(),
     loggerWarn: vi.fn(),
@@ -55,6 +56,7 @@ vi.mock('@main/services/window-state.service', () => ({
   getReadyWindowIds: mocks.getReadyWindowIds,
   getUnreachableWindowIds: mocks.getUnreachableWindowIds,
   getAbandonedWindowIds: mocks.getAbandonedWindowIds,
+  isWindowClosing: mocks.isWindowClosing,
 }));
 vi.mock('@shared/services/network-object.service', () => ({
   networkObjectService: { get: mocks.networkObjectGet, set: mocks.networkObjectSet },
@@ -98,6 +100,7 @@ describe('notification service router', () => {
     mocks.getReadyWindowIds.mockReturnValue([]);
     mocks.getUnreachableWindowIds.mockReturnValue([]);
     mocks.getAbandonedWindowIds.mockReturnValue([]);
+    mocks.isWindowClosing.mockReturnValue(false);
     mocks.findWindowIdOwningWebView.mockResolvedValue({
       windowId: undefined,
       hadUnreachableWindows: false,
@@ -157,8 +160,26 @@ describe('notification service router', () => {
     await router.send({ message: 'hi', severity: 'info', webViewId: 'wv-1' });
 
     expect(mocks.findWindowIdOwningWebView).toHaveBeenCalledWith('wv-1', expect.any(String));
-    expect(owner.send).toHaveBeenCalled();
+    expect(owner.send).toHaveBeenCalledWith({ message: 'hi', severity: 'info', webViewId: 'wv-1' });
     expect(focused.send).not.toHaveBeenCalled();
+  });
+
+  test('falls back to the focused window rather than sending into a closing owner window', async () => {
+    const focused = windowShard([]);
+    const closing = windowShard([]);
+    withWindows({ 1: focused, 2: closing });
+    mocks.findWindowIdOwningWebView.mockResolvedValue({
+      windowId: '2',
+      hadUnreachableWindows: false,
+    });
+    mocks.isWindowClosing.mockImplementation((windowId: string) => windowId === '2');
+    const router = await getRouter();
+
+    await router.send({ message: 'hi', severity: 'info', webViewId: 'wv-1' });
+
+    expect(closing.send).not.toHaveBeenCalled();
+    expect(focused.send).toHaveBeenCalled();
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(expect.stringContaining('is closing'));
   });
 
   test('falls back to the focused window when a notification names a webViewId nobody owns', async () => {
@@ -173,9 +194,48 @@ describe('notification service router', () => {
 
     await router.send({ message: 'hi', severity: 'info', webViewId: 'wv-missing' });
 
-    expect(focused.send).toHaveBeenCalled();
+    expect(focused.send).toHaveBeenCalledWith({
+      message: 'hi',
+      severity: 'info',
+      webViewId: 'wv-missing',
+    });
     expect(other.send).not.toHaveBeenCalled();
     expect(mocks.loggerWarn).toHaveBeenCalledWith(expect.stringContaining('wv-missing'));
+  });
+
+  test('falls back to the focused window when the owner window cannot serve its shard', async () => {
+    const focused = windowShard([]);
+    // Window 2 announced a notification shard, but it no longer resolves
+    withWindows({ 1: focused, 2: undefined });
+    mocks.findWindowIdOwningWebView.mockResolvedValue({
+      windowId: '2',
+      hadUnreachableWindows: false,
+    });
+    const router = await getRouter();
+
+    await router.send({ message: 'hi', severity: 'info', webViewId: 'wv-1' });
+
+    expect(focused.send).toHaveBeenCalled();
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining("that window's notification service could not be resolved"),
+    );
+  });
+
+  test('says in the log when a window could not be asked who owns the web view', async () => {
+    const focused = windowShard([]);
+    withWindows({ 1: focused, 2: windowShard([]) }, { unreachableWindowIds: ['2'] });
+    mocks.findWindowIdOwningWebView.mockResolvedValue({
+      windowId: undefined,
+      hadUnreachableWindows: true,
+    });
+    const router = await getRouter();
+
+    await router.send({ message: 'hi', severity: 'info', webViewId: 'wv-1' });
+
+    expect(focused.send).toHaveBeenCalled();
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(
+      expect.stringContaining('some windows could not be asked'),
+    );
   });
 
   test('dismisses in the window showing the notification, not the focused one', async () => {

--- a/src/main/services/__tests__/notification.service-router.test.ts
+++ b/src/main/services/__tests__/notification.service-router.test.ts
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => {
     networkObjectGet: vi.fn(),
     networkObjectSet: vi.fn(),
     loggerWarn: vi.fn(),
+    findWindowIdOwningWebView: vi.fn(),
     shardAnnouncementListeners,
     onDidCreateNetworkObject: vi.fn((listener: (details: NetworkObjectDetails) => void) => {
       shardAnnouncementListeners.create.push(listener);
@@ -63,6 +64,9 @@ vi.mock('@shared/services/network-object.service', () => ({
 vi.mock('@shared/services/logger.service', () => ({
   logger: { info: vi.fn(), warn: mocks.loggerWarn, error: vi.fn() },
 }));
+vi.mock('@main/services/web-view.service-router', () => ({
+  findWindowIdOwningWebView: mocks.findWindowIdOwningWebView,
+}));
 
 /** Capture the router object registered under the generic name */
 async function getRouter() {
@@ -94,6 +98,10 @@ describe('notification service router', () => {
     mocks.getReadyWindowIds.mockReturnValue([]);
     mocks.getUnreachableWindowIds.mockReturnValue([]);
     mocks.getAbandonedWindowIds.mockReturnValue([]);
+    mocks.findWindowIdOwningWebView.mockResolvedValue({
+      windowId: undefined,
+      hadUnreachableWindows: false,
+    });
   });
 
   test('sends to a window that registered its shard after the router started', async () => {
@@ -134,6 +142,40 @@ describe('notification service router', () => {
 
     expect(focused.send).toHaveBeenCalled();
     expect(other.send).not.toHaveBeenCalled();
+  });
+
+  test('sends a notification naming a webViewId to the window that owns it, not the focused one', async () => {
+    const focused = windowShard([]);
+    const owner = windowShard([]);
+    withWindows({ 1: focused, 2: owner });
+    mocks.findWindowIdOwningWebView.mockResolvedValue({
+      windowId: '2',
+      hadUnreachableWindows: false,
+    });
+    const router = await getRouter();
+
+    await router.send({ message: 'hi', severity: 'info', webViewId: 'wv-1' });
+
+    expect(mocks.findWindowIdOwningWebView).toHaveBeenCalledWith('wv-1', expect.any(String));
+    expect(owner.send).toHaveBeenCalled();
+    expect(focused.send).not.toHaveBeenCalled();
+  });
+
+  test('falls back to the focused window when a notification names a webViewId nobody owns', async () => {
+    const focused = windowShard([]);
+    const other = windowShard([]);
+    withWindows({ 1: focused, 2: other });
+    mocks.findWindowIdOwningWebView.mockResolvedValue({
+      windowId: undefined,
+      hadUnreachableWindows: false,
+    });
+    const router = await getRouter();
+
+    await router.send({ message: 'hi', severity: 'info', webViewId: 'wv-missing' });
+
+    expect(focused.send).toHaveBeenCalled();
+    expect(other.send).not.toHaveBeenCalled();
+    expect(mocks.loggerWarn).toHaveBeenCalledWith(expect.stringContaining('wv-missing'));
   });
 
   test('dismisses in the window showing the notification, not the focused one', async () => {

--- a/src/main/services/__tests__/web-view.service-router.test.ts
+++ b/src/main/services/__tests__/web-view.service-router.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 // `vi.mock` calls are hoisted above these imports, so the service resolves against the stubs below
 import {
+  findWindowIdOwningWebView,
   getAllOpenWebViewDefinitionsWithReachability,
   getOpenWebViewDefinitionsForWindow,
   setWebViewWindowCreator,
@@ -1485,6 +1486,43 @@ describe('web view service router', () => {
     await expect(router.getOpenWebViewDefinition('owned-view')).resolves.toEqual({
       id: 'owned-view',
     });
+  });
+
+  test('findWindowIdOwningWebView resolves the id of the window that owns a web view', async () => {
+    const owner = windowShard(['owned-view']);
+    withWindows({ 1: windowShard([]), 2: owner });
+
+    const { windowId, hadUnreachableWindows } = await findWindowIdOwningWebView(
+      'owned-view',
+      'test operation',
+    );
+
+    expect(windowId).toBe('2');
+    expect(hadUnreachableWindows).toBe(false);
+  });
+
+  test('findWindowIdOwningWebView answers undefined when no window owns the web view', async () => {
+    withWindows({ 1: windowShard([]), 2: windowShard([]) });
+
+    const { windowId, hadUnreachableWindows } = await findWindowIdOwningWebView(
+      'missing-view',
+      'test operation',
+    );
+
+    expect(windowId).toBeUndefined();
+    expect(hadUnreachableWindows).toBe(false);
+  });
+
+  test('findWindowIdOwningWebView reports unreachable windows rather than guessing', async () => {
+    withWindows({ 1: windowShard([]), 2: windowShard([]) }, { unreachableWindowIds: ['2'] });
+
+    const { windowId, hadUnreachableWindows } = await findWindowIdOwningWebView(
+      'some-view',
+      'test operation',
+    );
+
+    expect(windowId).toBeUndefined();
+    expect(hadUnreachableWindows).toBe(true);
   });
 
   test('refuses to answer that nobody owns a web view while a window that stopped serving may hold it', async () => {

--- a/src/main/services/notification.service-router.ts
+++ b/src/main/services/notification.service-router.ts
@@ -3,19 +3,27 @@
  * network object name and routes calls to a window's notification service shard (e.g.
  * "NotificationService-f81d4fae-7dec-11d0-a765-00a0c91e6bf6"). A new notification goes to the
  * focused window, so one raised by a background task appears where the user is looking rather than
- * in whichever renderer happened to start first; dismissing one goes to the window that is actually
- * showing it.
+ * in whichever renderer happened to start first — UNLESS it names
+ * {@link PlatformNotification.webViewId}, in which case it goes to the window that owns that web
+ * view: a notification or prompt about a specific project or editor is about something concrete,
+ * and the window showing it may not be the one the user currently has focused. Dismissing one goes
+ * to the window that is actually showing it.
  *
  * See the router/shard pattern in `.context/standards/Architecture.md` § "Service router and
  * service shard".
  */
 
 import { getReadyWindowIds } from '@main/services/window-state.service';
-import { createTargetShardResolver } from '@main/services/target-shard-resolver.util';
+import {
+  createTargetShardResolver,
+  resolveShardForWindow,
+} from '@main/services/target-shard-resolver.util';
+import { findWindowIdOwningWebView } from '@main/services/web-view.service-router';
 import {
   INotificationService,
   NOTIFICATION_SERVICE_NETWORK_OBJECT_DOCS,
   NotificationServiceNetworkObjectName,
+  PlatformNotification,
 } from '@shared/models/notification.service-model';
 import { logger } from '@shared/services/logger.service';
 import { networkObjectService } from '@shared/services/network-object.service';
@@ -43,6 +51,45 @@ const getTargetNotificationShard = createTargetShardResolver(
   NotificationServiceNetworkObjectName,
   notificationShards,
 );
+
+/**
+ * The notification service shard a `send` should run in: the window that owns
+ * {@link PlatformNotification.webViewId} when the notification names one, otherwise the focused
+ * window, exactly as before that field existed.
+ *
+ * Falls back to the focused window rather than throwing when the named web view cannot be resolved
+ * to a window — a notification is user-facing feedback, and showing it in the wrong window is a
+ * better outcome than not showing it at all. Every fallback path is logged, since a caller that
+ * bothered to name a `webViewId` presumably cared where the notification landed.
+ */
+async function getSendTargetShard(
+  notification: PlatformNotification,
+): Promise<INotificationService> {
+  if (notification.webViewId !== undefined) {
+    const { windowId, hadUnreachableWindows } = await findWindowIdOwningWebView(
+      notification.webViewId,
+      'route notification',
+    );
+    if (windowId !== undefined) {
+      try {
+        return await resolveShardForWindow(
+          NotificationServiceNetworkObjectName,
+          notificationShards,
+          windowId,
+        );
+      } catch (e) {
+        logger.warn(
+          `Notification named webViewId ${notification.webViewId}, owned by window ${windowId}, but that window's notification service could not be resolved (${getErrorMessage(e)}); falling back to the focused window.`,
+        );
+      }
+    } else {
+      logger.warn(
+        `Notification named webViewId ${notification.webViewId}, but no window could be found owning it${hadUnreachableWindows ? ' (some windows could not be asked)' : ''}; falling back to the focused window.`,
+      );
+    }
+  }
+  return getTargetNotificationShard();
+}
 
 /**
  * Dismiss a notification in the window(s) that own it — the ones whose renderers are showing it,
@@ -103,7 +150,7 @@ async function dismissInOwningWindows(notificationId: string | number): Promise<
  * a name the router does not answer for.
  */
 const notificationServiceRouter: INotificationService = {
-  send: async (...args) => (await getTargetNotificationShard()).send(...args),
+  send: async (notification) => (await getSendTargetShard(notification)).send(notification),
   dismiss: async (notificationId) => dismissInOwningWindows(notificationId),
 };
 

--- a/src/main/services/notification.service-router.ts
+++ b/src/main/services/notification.service-router.ts
@@ -13,7 +13,7 @@
  * service shard".
  */
 
-import { getReadyWindowIds } from '@main/services/window-state.service';
+import { getReadyWindowIds, isWindowClosing } from '@main/services/window-state.service';
 import {
   createTargetShardResolver,
   resolveShardForWindow,
@@ -55,7 +55,7 @@ const getTargetNotificationShard = createTargetShardResolver(
 /**
  * The notification service shard a `send` should run in: the window that owns
  * {@link PlatformNotification.webViewId} when the notification names one, otherwise the focused
- * window, exactly as before that field existed.
+ * window.
  *
  * Falls back to the focused window rather than throwing when the named web view cannot be resolved
  * to a window — a notification is user-facing feedback, and showing it in the wrong window is a
@@ -65,12 +65,15 @@ const getTargetNotificationShard = createTargetShardResolver(
 async function getSendTargetShard(
   notification: PlatformNotification,
 ): Promise<INotificationService> {
-  if (notification.webViewId !== undefined) {
+  if (notification.webViewId) {
     const { windowId, hadUnreachableWindows } = await findWindowIdOwningWebView(
       notification.webViewId,
       'route notification',
     );
-    if (windowId !== undefined) {
+    // Read the closing state again here, at the last moment before the window is asked to show the
+    // notification. Finding the owner meant asking every window in the app, which takes as long as
+    // the slowest of them — long enough for this one's close to have been decided since.
+    if (windowId !== undefined && !isWindowClosing(windowId)) {
       try {
         return await resolveShardForWindow(
           NotificationServiceNetworkObjectName,
@@ -82,6 +85,10 @@ async function getSendTargetShard(
           `Notification named webViewId ${notification.webViewId}, owned by window ${windowId}, but that window's notification service could not be resolved (${getErrorMessage(e)}); falling back to the focused window.`,
         );
       }
+    } else if (windowId !== undefined) {
+      logger.warn(
+        `Notification named webViewId ${notification.webViewId}, owned by window ${windowId}, but that window is closing; falling back to the focused window.`,
+      );
     } else {
       logger.warn(
         `Notification named webViewId ${notification.webViewId}, but no window could be found owning it${hadUnreachableWindows ? ' (some windows could not be asked)' : ''}; falling back to the focused window.`,

--- a/src/main/services/web-view.service-router.ts
+++ b/src/main/services/web-view.service-router.ts
@@ -352,6 +352,26 @@ async function findOwner(
 }
 
 /**
+ * The window that owns a given web view, for callers outside this router that only need to know
+ * which window to act in — not the shard or the definition {@link findOwner} also resolves.
+ *
+ * Used by `notification.service-router.ts` to route a notification or prompt that names a
+ * `webViewId` to the window showing it, instead of the focused window.
+ *
+ * See {@link findOwner} for what `hadUnreachableWindows` means and for the reachable-window
+ * tie-break applied when more than one window answers.
+ *
+ * @param operation Named in the warnings {@link findOwner} logs when a window could not be asked
+ */
+export async function findWindowIdOwningWebView(
+  webViewId: WebViewId,
+  operation: string,
+): Promise<{ windowId: string | undefined; hadUnreachableWindows: boolean }> {
+  const { owner, hadUnreachableWindows } = await findOwner({ kind: 'id', webViewId }, operation);
+  return { windowId: owner?.windowId, hadUnreachableWindows };
+}
+
+/**
  * The tab or tab group a layout says to open next to, over or inside, which names the window that
  * tab or tab group is in.
  *

--- a/src/main/services/web-view.service-router.ts
+++ b/src/main/services/web-view.service-router.ts
@@ -358,10 +358,13 @@ async function findOwner(
  * Used by `notification.service-router.ts` to route a notification or prompt that names a
  * `webViewId` to the window showing it, instead of the focused window.
  *
- * See {@link findOwner} for what `hadUnreachableWindows` means and for the reachable-window
- * tie-break applied when more than one window answers.
+ * See {@link findOwner} for what `hadUnreachableWindows` means. In the defensive case where more
+ * than one window claims the id, it prefers the routing-target window and otherwise the oldest.
  *
+ * @param webViewId The web view whose owning window to find
  * @param operation Named in the warnings {@link findOwner} logs when a window could not be asked
+ * @returns The owning window's id, or `undefined` both when no window owns the web view and when a
+ *   window that might own it could not be asked — `hadUnreachableWindows` tells those apart
  */
 export async function findWindowIdOwningWebView(
   webViewId: WebViewId,

--- a/src/renderer/services/notification.service-shard.ts
+++ b/src/renderer/services/notification.service-shard.ts
@@ -220,8 +220,9 @@ const notificationService: INotificationService = {
  *
  * Registered under this window's scoped name (e.g.
  * `NotificationService-f81d4fae-7dec-11d0-a765-00a0c91e6bf6`) so every window can serve its own
- * notification UI. The main process publishes the generic name and forwards to the focused window,
- * so a notification raised by a background task lands where the user is looking.
+ * notification UI. The main process publishes the generic name and forwards to the window that owns
+ * the web view a notification names, or to the focused window when it names none, so a notification
+ * raised by a background task lands where the user is looking.
  */
 export async function startNotificationServiceShard(): Promise<void> {
   if (globalThis.windowId === undefined)

--- a/src/shared/models/notification.service-model.ts
+++ b/src/shared/models/notification.service-model.ts
@@ -140,6 +140,11 @@ export interface PlatformNotification {
    * On an update (a `send` reusing an id that is still showing), any optional field you omit keeps
    * the value it had on the previous `send` for that id - omitting a field never clears it. Pass
    * the field explicitly to change it.
+   *
+   * The one exception is {@link webViewId}: which window a `send` runs in is decided in the main
+   * process before the renderer ever sees the notification to merge it, so omitting `webViewId` on
+   * an update does NOT keep routing to the window the original send resolved to - it always routes
+   * by the rules {@link webViewId} documents, using only what this call passed.
    */
   notificationId?: string | number;
   /**
@@ -154,8 +159,9 @@ export interface PlatformNotification {
    * Optional id of a web view this notification is about. When provided, the notification is routed
    * to the window that owns that web view instead of the focused window — for a notification or
    * prompt raised about a specific project or editor that may not be the one the user is currently
-   * looking at. Falls back to the focused window if the web view cannot be found open in any
-   * window.
+   * looking at. Falls back to the focused window whenever the web view's window cannot be
+   * determined — it is open nowhere, a window that might have it could not be asked, or it is
+   * moving between windows.
    *
    * Omit for a generic notice, which should keep routing to the focused window — where the user is
    * looking is the right place for something that is not about anything in particular.

--- a/src/shared/models/notification.service-model.ts
+++ b/src/shared/models/notification.service-model.ts
@@ -166,6 +166,9 @@ export interface PlatformNotification {
    * Omit for a generic notice, which should keep routing to the focused window — where the user is
    * looking is the right place for something that is not about anything in particular.
    *
+   * The narrowest key available: a notification about a project with no web view currently open has
+   * no `webViewId` to name, and routes to the focused window like a generic notice would.
+   *
    * @experimental
    */
   webViewId?: WebViewId;

--- a/src/shared/models/notification.service-model.ts
+++ b/src/shared/models/notification.service-model.ts
@@ -144,7 +144,10 @@ export interface PlatformNotification {
    * The one exception is {@link webViewId}: which window a `send` runs in is decided in the main
    * process before the renderer ever sees the notification to merge it, so omitting `webViewId` on
    * an update does NOT keep routing to the window the original send resolved to - it always routes
-   * by the rules {@link webViewId} documents, using only what this call passed.
+   * by the rules {@link webViewId} documents, using only what this call passed. An update that lands
+   * in a different window updates nothing: that window has never seen the id, so it opens a second
+   * notification with no merge applied, and the original stays up in the window it was routed to.
+   * Pass the same `webViewId` on every `send` that shares an id.
    */
   notificationId?: string | number;
   /**

--- a/src/shared/models/notification.service-model.ts
+++ b/src/shared/models/notification.service-model.ts
@@ -1,6 +1,7 @@
 import { CommandHandlers } from 'papi-shared-types';
 import { LocalizeKey } from 'platform-bible-utils';
 import type { NetworkObjectDocumentation } from '@shared/models/openrpc.model';
+import type { WebViewId } from '@shared/models/web-view.model';
 
 export type Severity = 'info' | 'warning' | 'error';
 
@@ -149,6 +150,19 @@ export interface PlatformNotification {
    * seconds).
    */
   duration?: number;
+  /**
+   * Optional id of a web view this notification is about. When provided, the notification is routed
+   * to the window that owns that web view instead of the focused window — for a notification or
+   * prompt raised about a specific project or editor that may not be the one the user is currently
+   * looking at. Falls back to the focused window if the web view cannot be found open in any
+   * window.
+   *
+   * Omit for a generic notice, which should keep routing to the focused window — where the user is
+   * looking is the right place for something that is not about anything in particular.
+   *
+   * @experimental
+   */
+  webViewId?: WebViewId;
 }
 
 /**
@@ -222,6 +236,7 @@ export const NOTIFICATION_SERVICE_NETWORK_OBJECT_DOCS: NetworkObjectDocumentatio
               dismissible: { type: 'boolean' },
               notificationId: { type: ['string', 'number'] },
               duration: { type: 'number' },
+              webViewId: { type: 'string' },
             },
             required: ['message', 'severity'],
           },


### PR DESCRIPTION
## Summary

Notifications and prompts raised by the extension host had no way to say which window they were about, so `notification.service-router.ts` always routed them to the *focused* window — correct for generic notices, wrong when the notification concerns a project/editor open in a *different* window.

Confirmed real case (PR #2621 review finding R4-06): the shared-layout "Apply now" prompt can be sent about a project in window 1 while window 2 is focused, asking the user to apply a layout for a project they can't see.

## Changes

- `notification.service-model.ts`: new optional, `@experimental` `webViewId` field on `PlatformNotification`. When set, routes to the window that owns that web view instead of the focused window; falls back to focus (with a logged warning) if it can't be resolved.
- `web-view.service-router.ts`: new exported `findWindowIdOwningWebView`, reusing the existing `findOwner` ownership fan-out rather than duplicating it.
- `notification.service-router.ts`: `send()` uses the above when a notification names a `webViewId`.
- `shared-layout-receiver.model.ts`: passes the relevant editor's `webViewId` on its "Apply shared layout now?" prompt — the confirmed bug fix.
- `lib/papi-dts/papi.d.ts`: regenerated to publish the new field to extension-facing types.

No `webViewId` set → routing is byte-for-byte unchanged (focused window), so generic notices are unaffected.

## Scope note

A second case cited in the ticket ("empty-editor detection") turned out to be a *command*-routing bug in a different service (`web-view.service-router.ts`'s `openScriptureEditor` routing), not a notification — left out of this PR as a separate concern.

## Testing

- 6 new unit tests across `notification.service-router.test.ts`, `web-view.service-router.test.ts`, and `shared-layout-receiver.model.test.ts` (owner-routing, fallback-to-focus, unreachable-windows cases), all via TDD.
- `tsc --noEmit` clean in both `core` and `extensions`.
- `eslint`/`prettier` clean on all touched files.
- Manually verified in a running two-window session: a notification naming a `webViewId` lands in the window that owns it even when a different window is focused; falls back to focus when unset or unresolvable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2780)
<!-- Reviewable:end -->
