### PR TITLE
Fix version-bump CI: skip core's postinstall, install gitleaks for publish

### DIFF
--- a/.github/workflows/bump-versions.yml
+++ b/.github/workflows/bump-versions.yml
@@ -48,7 +48,10 @@ jobs:
 
       - name: Install packages
         run: |
-          npm ci
+          # Bumping versions only needs core's dev tooling (ts-node, prettier), so skip the
+          # postinstall chain. It links scripture-editors via yalc, which needs Volta-managed pnpm
+          # on PATH, and builds the Electron DLL — none of which a version bump reads or writes.
+          npm ci --ignore-scripts
 
       - name: Bump repo versions
         if: ${{ inputs.newVersion != '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -255,6 +255,20 @@ jobs:
           clean: false
           ref: ${{ inputs.bumpRef }}
 
+      # The bump ends in a `git commit`, which runs this repo's husky pre-commit hook. That hook
+      # requires gitleaks on PATH and blocks the commit without it (see README "Install gitleaks"),
+      # and gitleaks is not part of the runner image.
+      - name: Install gitleaks for the pre-commit hook
+        if: ${{ matrix.os == env.OS_LINUX && inputs.newVersionAfterPublishing != '' }}
+        env:
+          GITLEAKS_VERSION: 8.30.1
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            | tar -xz -C "$HOME/.local/bin" gitleaks
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/gitleaks" version
+
       - name: Bump repo versions
         if: ${{ matrix.os == env.OS_LINUX && inputs.newVersionAfterPublishing != '' }}
         uses: ./.github/actions/bump-versions-action


### PR DESCRIPTION
## Problem

`bump-versions.yml` has not been run since #2006 put the shared editor behind a yalc link in core's `postinstall`. That chain (`link-dev-packages`) shells out to `pnpm`, which is only reachable through Volta, and `bump-versions.yml` never got the `volta-cli/action@v4` step that #2006 added to `test.yml`, `package-main.yml`, `publish.yml`, `publish-docs.yml` and `chromatic.yml`. Its last change was #1781, which predates all of that. So `npm ci` dies with:

```
Running pnpm install in scripture-editors...
/bin/sh: 1: pnpm: not found
...
/bin/sh: 1: volta: not found
Error: Failed to link dev packages via yalc.
```

## Fix 1 — `bump-versions.yml`: `npm ci --ignore-scripts`

Rather than add Volta, this installs with `--ignore-scripts`. Bumping versions runs `.erb/scripts/bump-versions.ts`, which needs only `ts-node`/`tsx`, `prettier` + `remark-cli` (for `npm run format`) and the extensions workspace — all root devDependencies, all plain JS. Nothing it touches comes out of `postinstall`, whose output is `patch-package` (`ast-types`, `electron-log`, `rc-dock`, `watchboy`), the yalc editor link, `electron-builder install-app-deps` and a webpack DLL build. The Volta route would clone scripture-editors, run `pnpm install` and two `nx devpub` builds, and build the DLL, all so it can rewrite some `version` fields.

This is also the pattern the rest of the family already uses when it wants core as a toolbox rather than a runnable app — `npm ci --ignore-scripts` on core in `lint.yml` and `publish.yml` of `paranext-extension-template`, `paranext-multi-extension-template`, `paratext-bible-extensions` and `paratext-bible-internal-extensions`.

The split, stated plainly:

- **Needs a built/runnable core** (`test`, `package-main`, `publish`, `publish-docs`, `chromatic`): Volta + the full yalc chain. Already correct.
- **Needs core's `node_modules` as a toolbox** (`bump-versions`): `--ignore-scripts`.

## Fix 2 — `publish.yml`: install gitleaks before the bump

Adding Volta to `bump-versions.yml` would have failed a second time a few minutes later, and that second failure is real for `publish.yml` today.

`npm ci` runs `prepare` → `husky`, which sets `core.hooksPath`. `extensions/lib/bump-versions.ts` then runs `git commit -a`, and `.husky/pre-commit` opens by exiting 1 when `gitleaks` is not on `PATH` — it is not on the runner image, and nothing in `.github/` installs it or sets `HUSKY=0`. `bump-versions.yml` escapes this for free (with `--ignore-scripts`, `prepare` never runs, `core.hooksPath` stays unset, no hooks fire), but `publish.yml`'s bump step needs the full install to build the release, so husky is active there.

Installing gitleaks (pinned 8.30.1, from the official releases, into `~/.local/bin` per the README's own Linux instructions) is preferred over `HUSKY=0` because `CLAUDE.md` forbids skipping the pre-commit hooks, and this way the release bump commit gets the same secret scan a developer's would. The step is gated on the same condition as the bump step, so it is a no-op on Windows/macOS and on publishes that do not bump.

## Does `git commit -a` risk sweeping in unrelated changes?

No, and no reset is needed. Two things already cover it:

1. `actions/checkout@v4` in the "Checkout bump ref" step uses `git checkout --force`, which discards modifications to tracked files — even with `clean: false`. `clean: false` preserves the untracked/ignored artifacts the bump needs (`node_modules`, `.yalc`, `dev-packages/`, `release/build`), not tracked edits from the build.
2. `.erb/scripts/bump-versions.ts` calls `checkForWorkingChanges()` before doing anything, and that uses `git status --porcelain=v2`, which reports untracked files too. A dirty tree fails the bump loudly rather than being folded into the commit.

So the commit can only contain what the bump itself writes after that check: `npm version` in the root and `release/app/package.json`, `npm run format` output, and the extensions bump. The one residual is `npm run format` reformatting a file that was already not prettier-clean on the bump ref — the same thing that would happen locally, and `test.yml`'s formatting check keeps `main` clean.

## Other workflows / other repos

- **paranext-core**: `bump-versions.yml` was the only gap. Every other workflow that runs `npm ci` already has `volta-cli/action@v4`; `codeql-analysis.yml` never installs npm deps.
- **paratext-10-studio**: `bump-versions.yml` and `test.yml` are safe (neither clones core, and the repo has no `postinstall`). `package-main.yml` and `publish.yml` already have Volta. `test-patched-csharp.yml` does hit `pnpm: not found` when its `patch` step runs the clone's `postinstall`, but that workflow already declares those postinstalls best-effort and non-fatal and applies the C# patch first — log noise and a wasted clone, not a break. Left alone here.
- **Extension repos**: already immune via `--ignore-scripts`.

## Testing

- Both workflows parse as YAML and pass `prettier --check`.
- The gitleaks download/extract one-liner was run locally against `v8.30.1`; it produces a working binary (`gitleaks version` → `8.30.1`).
- The workflows themselves are `workflow_dispatch`-only, so the real verification is a dispatch of `bump-versions.yml` after merge.

AI-assisted — [session 1](https://claude.ai/code/session_019EmD5if9cG2ZwaQCzkhFan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019EmD5if9cG2ZwaQCzkhFan

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2782)
<!-- Reviewable:end -->
