### PR TITLE
Stop the version bump from reformatting theming.mdx

### DIFF
--- a/lib/platform-bible-react/.remarkignore
+++ b/lib/platform-bible-react/.remarkignore
@@ -1,3 +1,4 @@
 # remark's MDX serializer reformats JSX inside attribute values (e.g. preview={...} props),
 # removing intentional indentation. Files listed here are excluded from remark --output.
 src/stories/guidelines/design-principles.mdx
+src/stories/guidelines/theming.mdx


### PR DESCRIPTION
Follow-up to #2782. The `0.6.0-alpha.1` bump (#2783) carried an unrelated whitespace change to `lib/platform-bible-react/src/stories/guidelines/theming.mdx`. That change has been reverted on the bump branch; this PR fixes the cause.

**One line in `.remarkignore`.** This was originally two commits; the second — making `format:mdx:check` actually check anything — is now split out into #2799 so this one can go in quickly during the release. This PR stands entirely on its own.

## Why it changed

`npm run bump-versions` runs `npm run format`, which ends in `format:mdx` (`remark . --ext .mdx --output`). remark's MDX serializer strips the indentation of JSX inside attribute values, so it rewrites this page's `<ExampleBlock>` props:

```diff
   preview={
-  <input
-    value="this has manual colors"
+<input
+value="this has manual colors"
```

For `preview={...}` that is cosmetic. But the same pass also flattens ``code={`...`}``, a template literal Storybook renders verbatim as the code sample readers see, so remark was changing displayed content, not just source layout.

This is a known remark behavior in this repo — `.remarkignore` exists for exactly it, and already lists `design-principles.mdx` (added in #2270). `theming.mdx` uses the same component and needed the same entry. It has been drifting since it was created in #2180, seven days after `.remarkignore` was introduced.

Note this does **not** touch the UX-owned MDX content; it stops remark from rewriting it. `.remarkignore` is a remark-cli concern only, so Storybook rendering is unaffected.

## Verification

- **The bug is gone end to end**: `npm run format` — the exact command the bump runs — now leaves every tracked MDX file untouched. Before this change it rewrote `theming.mdx`.
- **Sweep, not spot-check**: ran remark against all 19 tracked MDX files under both configured roots. Exactly two differ from remark's output — `design-principles.mdx` (already ignored) and `theming.mdx`. A deterministic grep of every `package.json` plus `.erb/` and `.github/` confirms those two `remark` invocations are the whole surface. This would not catch a remark invocation built dynamically at runtime; there are none.
- **This line is load-bearing**: with the follow-up's real checker applied, removing this `.remarkignore` entry makes the check exit 1 and name `theming.mdx`; restoring it goes green. Verified both directions.
- `npm run typecheck:erb`, repo-wide `eslint`, `stylelint`, and `npm run format:check` all pass. C# and unit tests were not run: nothing here touches runtime code.

## Why nobody noticed for ~3.5 months

`format:mdx:check` is `remark . --ext .mdx` — remark with no `--output`. That reports plugin messages; it never compares remark's serialized output to the bytes on disk, so it exits 0 on a file `format:mdx` would rewrite. It has been that way since #1715 (2025-07-18). CI ran it on every PR and could not have caught this.

So the drift sat in the repo until someone ran a full `npm run format` — which, in practice, is the release version bump. **That gap is fixed in #2799, not here.** Without it, the next JSX-heavy MDX page will drift the same way and surface in a future bump.

## Unrelated observation, not fixed here

`format:mdx` also rewrites MDX inside `storybook-static/` when a developer has built Storybook locally. It is gitignored build output so nothing is harmed, but adding `storybook-static` to `.remarkignore` would save the pointless writes. Left out to keep this PR to the reported problem.

AI-assisted — [session 1](https://claude.ai/code/session_019EmD5if9cG2ZwaQCzkhFan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RH1JMqjK2KLBHhe3xLaEPY

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2784)
<!-- Reviewable:end -->
