### PR TITLE
Normalize empty Pt9InterlinearSetup strings to absent

### DIFF
--- a/c-sharp-tests/Projects/ParatextProjectDataProviderPt9InterlinearTests.cs
+++ b/c-sharp-tests/Projects/ParatextProjectDataProviderPt9InterlinearTests.cs
@@ -443,7 +443,7 @@ internal class ParatextProjectDataProviderPt9InterlinearTests : PapiTestBase
     [Description(
         "A setup's model and export fields are served as written; PT9's __EMPTY__ sentinel "
             + "means no model text, so the model name is absent while the id PT9 minted for the "
-            + "setup still serves, and empty strings serve as absent."
+            + "setup still serves, and an empty text name serves as absent."
     )]
     public void GetPt9InterlinearData_ServesSetupModelTextAndTreatsTheEmptySentinelAsNone()
     {
@@ -485,6 +485,58 @@ internal class ParatextProjectDataProviderPt9InterlinearTests : PapiTestBase
             Assert.That(data.Setups[1].ModelScrTextName, Is.Null);
             Assert.That(data.Setups[1].ModelScrTextId, Is.EqualTo("fedcba0987654321"));
             Assert.That(data.Setups[1].ExportScrTextName, Is.Null);
+        });
+    }
+
+    [Test]
+    [Description(
+        "Emptiness is not normalized uniformly: an empty font name or text name serves as "
+            + "absent, while an empty language id, language name, or text id serves as an empty "
+            + "string and only a field the project omits is absent."
+    )]
+    public void GetPt9InterlinearData_ServesEmptySetupStringsAsAbsentOrEmptyPerField()
+    {
+        WriteProjectFile(
+            "InterlinearSetup.xml",
+            """
+            <InterlinearSetupList>
+              <InterlinearSetup type="Glossing" language="">
+                <LanguageName></LanguageName>
+                <FontName></FontName>
+                <MdlScrTextName></MdlScrTextName>
+                <MdlScrTextId></MdlScrTextId>
+                <ExportScrTextName></ExportScrTextName>
+                <ExportScrTextId></ExportScrTextId>
+              </InterlinearSetup>
+              <InterlinearSetup type="Glossing">
+              </InterlinearSetup>
+            </InterlinearSetupList>
+            """
+        );
+
+        var data = _provider.GetPt9InterlinearData();
+
+        Assert.That(data.Setups, Has.Count.EqualTo(2));
+        Assert.Multiple(() =>
+        {
+            // Written empty: the three fields the conversion nulls are absent, the four it passes
+            // through keep the empty string PT9 stored.
+            Assert.That(data.Setups[0].FontName, Is.Null);
+            Assert.That(data.Setups[0].ModelScrTextName, Is.Null);
+            Assert.That(data.Setups[0].ExportScrTextName, Is.Null);
+            Assert.That(data.Setups[0].LanguageId, Is.Empty);
+            Assert.That(data.Setups[0].LanguageName, Is.Empty);
+            Assert.That(data.Setups[0].ModelScrTextId, Is.Empty);
+            Assert.That(data.Setups[0].ExportScrTextId, Is.Empty);
+
+            // Omitted entirely: absent regardless of which side of the split the field is on.
+            Assert.That(data.Setups[1].FontName, Is.Null);
+            Assert.That(data.Setups[1].ModelScrTextName, Is.Null);
+            Assert.That(data.Setups[1].ExportScrTextName, Is.Null);
+            Assert.That(data.Setups[1].LanguageId, Is.Null);
+            Assert.That(data.Setups[1].LanguageName, Is.Null);
+            Assert.That(data.Setups[1].ModelScrTextId, Is.Null);
+            Assert.That(data.Setups[1].ExportScrTextId, Is.Null);
         });
     }
 

--- a/c-sharp/Projects/Pt9InterlinearData.cs
+++ b/c-sharp/Projects/Pt9InterlinearData.cs
@@ -146,7 +146,9 @@ public sealed record Pt9Lexicon(
 /// the model text the interlinearization reads from, and the export half: whether and where
 /// approved verses export. The model name is absent for a setup with no model text; the model id
 /// serves whenever PT9 stored one, since a model-less setup mints an id as its settings key.
-/// String fields that are empty in the project are absent here.
+/// Emptiness is not handled uniformly: an empty <c>FontName</c>, <c>ModelScrTextName</c>, or
+/// <c>ExportScrTextName</c> is absent here, while an empty <c>LanguageId</c> or
+/// <c>LanguageName</c> serves as an empty string.
 /// </summary>
 public sealed record Pt9InterlinearSetup(
     [property: JsonPropertyName("type")] string Type,

--- a/c-sharp/Projects/Pt9InterlinearData.cs
+++ b/c-sharp/Projects/Pt9InterlinearData.cs
@@ -146,9 +146,12 @@ public sealed record Pt9Lexicon(
 /// the model text the interlinearization reads from, and the export half: whether and where
 /// approved verses export. The model name is absent for a setup with no model text; the model id
 /// serves whenever PT9 stored one, since a model-less setup mints an id as its settings key.
-/// Emptiness is not handled uniformly: an empty <c>FontName</c>, <c>ModelScrTextName</c>, or
-/// <c>ExportScrTextName</c> is absent here, while an empty <c>LanguageId</c> or
-/// <c>LanguageName</c> serves as an empty string.
+/// Emptiness is not normalized uniformly. A <c>FontName</c>, <c>ModelScrTextName</c>, or
+/// <c>ExportScrTextName</c> that is empty in the project is absent here; <c>LanguageId</c>,
+/// <c>LanguageName</c>, <c>ModelScrTextId</c>, and <c>ExportScrTextId</c> serve as the project
+/// stored them, so an empty one serves as an empty string and only a field the project omits is
+/// absent. That split is incidental to how each field is read rather than a guarantee of this
+/// payload, so treat an empty string and an absent field alike.
 /// </summary>
 public sealed record Pt9InterlinearSetup(
     [property: JsonPropertyName("type")] string Type,

--- a/c-sharp/Projects/Pt9InterlinearReader.cs
+++ b/c-sharp/Projects/Pt9InterlinearReader.cs
@@ -543,8 +543,9 @@ internal static class Pt9InterlinearReader
     /// <summary>
     /// Maps one setup to its served shape. A model name that is empty or PT9's no-model sentinel
     /// means the setup has no model text, so the name is absent; the model id passes through
-    /// whenever present, since a model-less setup mints one as its settings key. Empty strings
-    /// serve as absent fields.
+    /// whenever present, since a model-less setup mints one as its settings key. An empty font
+    /// name or export text name is likewise absent; every other string passes through, so an
+    /// empty one stays empty.
     /// </summary>
     private static Pt9InterlinearSetup ConvertPt9InterlinearSetup(InterlinearSetup setup)
     {


### PR DESCRIPTION
## Summary

`Pt9InterlinearSetup`'s doc comment promised more than the conversion delivered: "String fields that are empty in the project are absent here." `ConvertPt9InterlinearSetup` normalized only three of the record's seven nullable string fields.

The first attempt was to document the real behavior instead. That turned out not to be statable: emptiness depends not just on the field but on which path built the setup. An empty `<LanguageName />` in the setups file came back as `""`, while the same setup rebuilt from legacy settings came back with no language name at all; an empty export id setting came back absent on the legacy path and as `""` from the setups file. A consumer cannot tell which path produced a setup, so no per-field rule was usable.

So this PR makes the original sentence true rather than replacing it. Every setup string that is empty in the project is now served as absent, on both paths.

## Changes

- **`ConvertPt9InterlinearSetup`**: route `LanguageId`, `LanguageName`, and both id `ToString()` results through a new `NullIfEmpty` helper, alongside the `FontName` and `ExportScrTextName` guards that were already there. `Type` is an enum's `ToString` and never empty; `ModelScrTextName` is already covered by the no-model check.
- **`Pt9InterlinearSetup`**: restate emptiness as one rule true on both paths. Two things the investigation turned up are documented rather than normalized, because they are real and previously unstated: the id fields serve PT9's own re-formatting rather than the stored characters (hex folds to lowercase, a legacy `res` id is re-encoded), and a malformed id fails the whole read from the setups file while the legacy path tolerates it.
- **`platform-scripture.d.ts`**: carry the same rule to the surface extension authors actually read, which said nothing about emptiness before.
- **Tests**: `GetPt9InterlinearData_ServesEmptyAndOmittedSetupStringsAlikeAsAbsent` covers every field written empty against the same setup with every field omitted. Three more pin what the doc now claims and nothing covered before: id re-formatting, the setups-file read failing on a malformed id, and the legacy path's unassigned display fields.

### Why this PR is here

Not part of the current epic. (It surfaced against an Interlinearizer extension doc PR.)

## Behavior change

The four pass-through fields now serve absent instead of `""` when the project stored an empty value. Nothing consumes them yet — the Interlinearizer extension reads only `books`, and `test-data/Pt9InterlinearProjectData.json` carries no empty setup strings — and the type is `@experimental`, so this is the cheapest point at which to fix it.

## AI Involvement

AI-assisted. Claude established the per-field and per-path behavior by exercising `GetPt9InterlinearData` against setups files and legacy settings written for each case, verified `InterlinearSetup`'s deserialization and `HexId`'s re-formatting by running them directly (ParatextData 9.5.0.24), wrote the normalization and the tests, and mutation-checked each new assertion by removing the guard it covers. I reviewed the resulting behavior change and confirmed no current consumer reads these fields.

## Risk Level

Low-medium - a behavior change to a payload no shipped code reads yet, on an `@experimental` type, pinned by tests that fail when any guard is removed.

---

Devin review: https://app.devin.ai/review/paranext/paranext-core/pull/2789

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2789)
<!-- Reviewable:end -->
