### PR TITLE
ci: stop a flaky Linux snap install failing the whole build

### DIFF
--- a/.erb/scripts/electron-builder-snap-config.test.ts
+++ b/.erb/scripts/electron-builder-snap-config.test.ts
@@ -43,6 +43,15 @@ const UBUNTU_RUNNER_BY_BASE: Readonly<Record<string, string>> = {
 /** Workflows that pin the Linux runner the snap is built on, via an `OS_LINUX` env value. */
 const LINUX_RUNNER_WORKFLOWS = ['test.yml', 'package-main.yml', 'publish.yml'];
 
+/**
+ * The step each of those workflows installs snapcraft and LXD under.
+ *
+ * The three copies exist because the step runs BEFORE `actions/checkout`, so it cannot be a local
+ * composite action — nothing is on disk to `uses:` yet. Duplication is therefore the only option;
+ * silent divergence is not, which is what the test below is for.
+ */
+const SNAP_TOOLS_STEP_NAME = 'Install snap tools on Linux';
+
 /** Mount point the snap's launch scripts read the GNOME platform from. */
 const GNOME_PLATFORM_TARGET = '$SNAP/gnome-platform';
 
@@ -63,6 +72,9 @@ type PlugAttributes = {
 
 /** A found plug, keyed by the name it is declared under. */
 type NamedPlug = { key: string; descriptor: PlugAttributes };
+
+/** A workflow step, as far as the comparison below needs to see one. */
+type WorkflowStep = Record<string, unknown>;
 
 /** A plain object, for walking into parsed config and YAML without asserting a shape. */
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -178,6 +190,30 @@ function readWorkflowLinuxRunners(): { workflow: string; runner: string | undefi
   });
 }
 
+/**
+ * The snap-toolchain step from each snap-building workflow.
+ *
+ * Parsed rather than text-sliced so that indentation and the YAML comments around the step cannot
+ * register as a difference. The shell script is a single scalar, so the comments _inside_ it are
+ * compared along with the commands — which is wanted: a comment that still describes the old
+ * behavior is its own kind of drift.
+ */
+function readSnapToolsSteps(): { workflow: string; step: WorkflowStep | undefined }[] {
+  return LINUX_RUNNER_WORKFLOWS.map((workflow) => {
+    const parsed: unknown = parseYaml(
+      readFileSync(path.join(REPO_ROOT, '.github', 'workflows', workflow), 'utf8'),
+    );
+    const jobs: unknown[] =
+      isRecord(parsed) && isRecord(parsed.jobs) ? Object.values(parsed.jobs) : [];
+    const step = jobs
+      .filter(isRecord)
+      .flatMap((job) => (Array.isArray(job.steps) ? job.steps : []))
+      .filter(isRecord)
+      .find((candidate) => candidate.name === SNAP_TOOLS_STEP_NAME);
+    return { workflow, step };
+  });
+}
+
 describe('electron-builder snap configuration', () => {
   it('declares a snap base whose matching GNOME platform snap and runner are known', () => {
     // Bumping `base` without teaching these maps the new pairings should fail loudly rather than
@@ -207,6 +243,24 @@ describe('electron-builder snap configuration', () => {
     expect(readWorkflowLinuxRunners()).toEqual(
       LINUX_RUNNER_WORKFLOWS.map((workflow) => ({ workflow, runner: expected })),
     );
+  });
+
+  it('installs the snap toolchain identically in every snap-building workflow', () => {
+    // All three legs build the snap through snapcraft and LXD, so all three meet the same snap
+    // store outages, the same auto-refresh mid-pack, and the same failures whose evidence is only
+    // in snapcraft's log. Hardening one copy and not another is invisible in review -- the diff
+    // looks complete -- and leaves the flake live on whichever leg was missed, including the one
+    // behind branch protection.
+    const steps = readSnapToolsSteps();
+
+    // Checked first and separately: if the step were renamed everywhere, every entry below would
+    // be `undefined` and the equality would pass while comparing nothing.
+    expect(steps.filter(({ step }) => !step).map(({ workflow }) => workflow)).toEqual([]);
+
+    // Compared against the first workflow rather than pairwise so a failure's diff names the file
+    // that drifted.
+    const [reference, ...others] = steps;
+    expect(others).toEqual(others.map(({ workflow }) => ({ workflow, step: reference.step })));
   });
 
   it('mounts exactly one GNOME platform plug, named for snap.base', () => {

--- a/.github/workflows/package-main.yml
+++ b/.github/workflows/package-main.yml
@@ -77,17 +77,37 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y snapd
+          # The snap store CDN intermittently answers a download with a 502 and snapd
+          # gives up on the first try, failing the job before the build even starts.
+          retry() {
+            local attempt
+            for attempt in 1 2 3; do
+              if "$@"; then return 0; fi
+              echo "WARNING: '$*' failed (attempt $attempt of 3); retrying in 30s"
+              sleep 30
+            done
+            echo "ERROR: '$*' failed after 3 attempts"
+            return 1
+          }
+          # Hold snapd's automatic refreshes for the job. snapd refreshes installed snaps
+          # on its own schedule; refreshing `lxd` (or `core*`/`snapd` under it) while
+          # snapcraft is packing inside an LXD instance restarts the daemon out from under
+          # the running build. Explicit `snap install`/`refresh` below still work while
+          # held. Best-effort: a snapd that rejects the option must not fail the build.
+          sudo snap set system refresh.hold="$(date -u -d '+1 day' +%Y-%m-%dT%H:%M:%SZ)" ||
+            echo "WARNING: could not hold snapd auto-refresh; a refresh may disrupt the snap build"
           # Pin snapcraft to the 8.x track. snapcraft 9 (now latest/stable) removed the
           # deprecated `snap` command alias, which electron-builder 26.x still invokes,
           # breaking the snap build. Remove this pin once we move to electron-builder >= 27
           # (which calls `snapcraft pack`). See electron-builder issue #8880 / PR #9517.
-          sudo snap install snapcraft --classic --channel=8.x/stable
-          sudo snap install lxd
-          sudo snap refresh lxd
+          retry sudo snap install snapcraft --classic --channel=8.x/stable
+          retry sudo snap install lxd
+          retry sudo snap refresh lxd
           sudo lxd init --auto
-          # Add the current user to the lxd group
+          # Add the current user to the lxd group. (No `newgrp lxd` here: in a script it
+          # execs a *child* shell that reads EOF from stdin and exits immediately, so it
+          # never changes this shell's groups -- the `chmod` below is what does the work.)
           getent group lxd | grep -qwF "$USER" || sudo usermod -aG lxd "$USER"
-          newgrp lxd
           # Force the socket to be usable by the current user
           sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
           # https://github.com/canonical/action-build/blob/master/src/tools.ts#L54
@@ -151,6 +171,29 @@ jobs:
           USE_HARD_LINKS: false
         run: |
           npx electron-builder build --publish never --linux
+
+      # The Linux failures worth debugging leave their evidence outside the build's own
+      # output: snapcraft's log holds the real mksquashfs error rather than the bare
+      # "mksquashfs call failed:" that reaches the console, and if the kernel ever kills
+      # the build for memory it names the process it chose only in dmesg.
+      - name: Capture Linux failure diagnostics
+        if: ${{ failure() && matrix.os == env.OS_LINUX }}
+        run: |
+          echo "=== kernel OOM activity ==="
+          sudo dmesg --ctime 2>/dev/null | grep -iE "out of memory|oom-kill|killed process" || echo "(no OOM entries in dmesg)"
+          echo "=== kernel log tail ==="
+          sudo dmesg --ctime 2>/dev/null | tail -40 || true
+          echo "=== memory ==="; free -h; swapon --show || true
+          echo "=== disk ==="; df -h /
+
+      - name: Upload snapcraft logs (Linux)
+        if: ${{ failure() && matrix.os == env.OS_LINUX }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapcraft-logs
+          path: |
+            ~/.local/state/snapcraft/log/
+          if-no-files-found: warn
 
       - name: Rename Windows exe to include GitHub Action Run ID
         if: ${{ matrix.os == env.OS_WINDOWS }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -96,17 +96,37 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y snapd
+          # The snap store CDN intermittently answers a download with a 502 and snapd
+          # gives up on the first try, failing the job before the build even starts.
+          retry() {
+            local attempt
+            for attempt in 1 2 3; do
+              if "$@"; then return 0; fi
+              echo "WARNING: '$*' failed (attempt $attempt of 3); retrying in 30s"
+              sleep 30
+            done
+            echo "ERROR: '$*' failed after 3 attempts"
+            return 1
+          }
+          # Hold snapd's automatic refreshes for the job. snapd refreshes installed snaps
+          # on its own schedule; refreshing `lxd` (or `core*`/`snapd` under it) while
+          # snapcraft is packing inside an LXD instance restarts the daemon out from under
+          # the running build. Explicit `snap install`/`refresh` below still work while
+          # held. Best-effort: a snapd that rejects the option must not fail the build.
+          sudo snap set system refresh.hold="$(date -u -d '+1 day' +%Y-%m-%dT%H:%M:%SZ)" ||
+            echo "WARNING: could not hold snapd auto-refresh; a refresh may disrupt the snap build"
           # Pin snapcraft to the 8.x track. snapcraft 9 (now latest/stable) removed the
           # deprecated `snap` command alias, which electron-builder 26.x still invokes,
           # breaking the snap build. Remove this pin once we move to electron-builder >= 27
           # (which calls `snapcraft pack`). See electron-builder issue #8880 / PR #9517.
-          sudo snap install snapcraft --classic --channel=8.x/stable
-          sudo snap install lxd
-          sudo snap refresh lxd
+          retry sudo snap install snapcraft --classic --channel=8.x/stable
+          retry sudo snap install lxd
+          retry sudo snap refresh lxd
           sudo lxd init --auto
-          # Add the current user to the lxd group
+          # Add the current user to the lxd group. (No `newgrp lxd` here: in a script it
+          # execs a *child* shell that reads EOF from stdin and exits immediately, so it
+          # never changes this shell's groups -- the `chmod` below is what does the work.)
           getent group lxd | grep -qwF "$USER" || sudo usermod -aG lxd "$USER"
-          newgrp lxd
           # Force the socket to be usable by the current user
           sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
           # https://github.com/canonical/action-build/blob/master/src/tools.ts#L54
@@ -232,6 +252,29 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npx electron-builder --publish never --linux
+
+      # The Linux failures worth debugging leave their evidence outside the build's own
+      # output: snapcraft's log holds the real mksquashfs error rather than the bare
+      # "mksquashfs call failed:" that reaches the console, and if the kernel ever kills
+      # the build for memory it names the process it chose only in dmesg.
+      - name: Capture Linux failure diagnostics
+        if: ${{ failure() && matrix.os == env.OS_LINUX }}
+        run: |
+          echo "=== kernel OOM activity ==="
+          sudo dmesg --ctime 2>/dev/null | grep -iE "out of memory|oom-kill|killed process" || echo "(no OOM entries in dmesg)"
+          echo "=== kernel log tail ==="
+          sudo dmesg --ctime 2>/dev/null | tail -40 || true
+          echo "=== memory ==="; free -h; swapon --show || true
+          echo "=== disk ==="; df -h /
+
+      - name: Upload snapcraft logs (Linux)
+        if: ${{ failure() && matrix.os == env.OS_LINUX }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapcraft-logs
+          path: |
+            ~/.local/state/snapcraft/log/
+          if-no-files-found: warn
 
       # Creates the tag, the draft and the generated notes, and attaches NO binaries. The release is
       # a fixed point in Git history for the Paratext 10 Studio build to construct its own releases

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -95,17 +95,37 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y snapd
+          # The snap store CDN intermittently answers a download with a 502 and snapd
+          # gives up on the first try, failing the job before the build even starts.
+          retry() {
+            local attempt
+            for attempt in 1 2 3; do
+              if "$@"; then return 0; fi
+              echo "WARNING: '$*' failed (attempt $attempt of 3); retrying in 30s"
+              sleep 30
+            done
+            echo "ERROR: '$*' failed after 3 attempts"
+            return 1
+          }
+          # Hold snapd's automatic refreshes for the job. snapd refreshes installed snaps
+          # on its own schedule; refreshing `lxd` (or `core*`/`snapd` under it) while
+          # snapcraft is packing inside an LXD instance restarts the daemon out from under
+          # the running build. Explicit `snap install`/`refresh` below still work while
+          # held. Best-effort: a snapd that rejects the option must not fail the build.
+          sudo snap set system refresh.hold="$(date -u -d '+1 day' +%Y-%m-%dT%H:%M:%SZ)" ||
+            echo "WARNING: could not hold snapd auto-refresh; a refresh may disrupt the snap build"
           # Pin snapcraft to the 8.x track. snapcraft 9 (now latest/stable) removed the
           # deprecated `snap` command alias, which electron-builder 26.x still invokes,
           # breaking the snap build. Remove this pin once we move to electron-builder >= 27
           # (which calls `snapcraft pack`). See electron-builder issue #8880 / PR #9517.
-          sudo snap install snapcraft --classic --channel=8.x/stable
-          sudo snap install lxd
-          sudo snap refresh lxd
+          retry sudo snap install snapcraft --classic --channel=8.x/stable
+          retry sudo snap install lxd
+          retry sudo snap refresh lxd
           sudo lxd init --auto
-          # Add the current user to the lxd group
+          # Add the current user to the lxd group. (No `newgrp lxd` here: in a script it
+          # execs a *child* shell that reads EOF from stdin and exits immediately, so it
+          # never changes this shell's groups -- the `chmod` below is what does the work.)
           getent group lxd | grep -qwF "$USER" || sudo usermod -aG lxd "$USER"
-          newgrp lxd
           # Force the socket to be usable by the current user
           sudo chmod 666 /var/snap/lxd/common/lxd/unix.socket
           # https://github.com/canonical/action-build/blob/master/src/tools.ts#L54
@@ -388,6 +408,30 @@ jobs:
           retention-days: 14
           path: |
             ./release/build/*.snap
+
+      # Any Linux failure here -- the snap pack, or an E2E run the kernel kills for memory --
+      # leaves its real evidence outside the step's own output: snapcraft's log holds the
+      # mksquashfs error behind the bare "mksquashfs call failed:" that reaches the console,
+      # and an OOM kill names the process the kernel chose only in dmesg. Last in the job so a
+      # failure anywhere above reaches it.
+      - name: Capture Linux failure diagnostics
+        if: ${{ failure() && matrix.os == env.OS_LINUX }}
+        run: |
+          echo "=== kernel OOM activity ==="
+          sudo dmesg --ctime 2>/dev/null | grep -iE "out of memory|oom-kill|killed process" || echo "(no OOM entries in dmesg)"
+          echo "=== kernel log tail ==="
+          sudo dmesg --ctime 2>/dev/null | tail -40 || true
+          echo "=== memory ==="; free -h; swapon --show || true
+          echo "=== disk ==="; df -h /
+
+      - name: Upload snapcraft logs (Linux)
+        if: ${{ failure() && matrix.os == env.OS_LINUX }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: snapcraft-logs
+          path: |
+            ~/.local/state/snapcraft/log/
+          if-no-files-found: warn
 
       # Enable tmate debugging of manually-triggered workflows if the input option was provided
       - name: Setup tmate session


### PR DESCRIPTION
Runs [34488976360](https://github.com/paranext/paranext-core/actions/runs/34488976360) and [34384474185](https://github.com/paranext/paranext-core/actions/runs/34384474185) both died in **Install snap tools on Linux** and took the Windows and macOS jobs down with them. Neither failure was ours — the snap store CDN answered `snap install snapcraft` with a 502 and snapd gave up on the first try, failing the job before the build had started:

```
error: cannot perform the following tasks:
- Download snap "snapcraft" (17614) from channel "8.x/stable" (received an
  unexpected http response code (502) when trying to download ...)
```

All three workflows that build a snap get the same block: `test.yml`, `package-main.yml`, `publish.yml`.

## Changes

- **Retry the three snap store operations**, three attempts 30 s apart. The helper runs the command inside an `if` condition so `bash -e` does not abort on an attempt that is *meant* to fail, and returns non-zero after the last one so a genuinely broken store still fails the step.
- **Hold snapd's auto-refresh** for the job. snapd refreshes installed snaps on its own schedule, and refreshing `lxd` while snapcraft is packing inside an LXD instance restarts the daemon out from under the running build. Best-effort, so a snapd that rejects the option cannot fail a build.
- **Capture diagnostics when the Linux job fails** — snapcraft's own log, which holds the real mksquashfs error rather than the bare `mksquashfs call failed:` that reaches the console, plus kernel OOM activity. On-failure only. In `test.yml` these sit last in the job rather than beside the packaging step, so an E2E run the kernel kills for memory reaches them too.
- **Drop `newgrp lxd`.** In a script it execs a *child* shell that reads EOF from stdin and exits immediately, so it never changed this shell's groups; the `chmod` on the socket is what actually makes LXD usable.
- **Assert the three copies stay identical**, in `.erb/scripts/electron-builder-snap-config.test.ts` — see below.

## Why `test.yml` is in scope

`Build on ubuntu-22.04, .Net 8.0.x` is `test.yml`'s rendered job name, and it is a required status check on `main`. `package-main.yml` and `publish.yml` render as `Main on ...` / `Release on ...` and are not required. That leg does build a snap — `check packaging` has no `if:` guard, `electron-builder.json5:79` sets `linux.target: ['snap']`, and the job renames and uploads `./release/build/*.snap` — so hardening only the two post-merge workflows would have left the flake live on the one leg that can block a pull request.

Blast radius differs per workflow, and the difference is worth stating rather than flattening: `test.yml` sets `fail-fast: false`, so a 502 there costs one re-run of the Linux leg. `package-main.yml` and `publish.yml` fail fast, so a 502 on their Linux leg also cancels the healthy Windows and macOS jobs.

## Why the step is duplicated rather than extracted

In all three workflows `Install snap tools on Linux` runs **before** `actions/checkout` (`test.yml` 93 vs 114, `package-main.yml` 75 vs 96, `publish.yml` 94 vs 115), so it cannot be a local composite action — nothing is on disk to `uses:` yet. Extracting it would mean reordering checkout ahead of it in three workflows, and `publish.yml` is `workflow_dispatch`-only, so its copy could not be proven short of cutting a release.

So the three copies are structural. What is not acceptable is that they diverge silently, which is exactly what happened here — so `electron-builder-snap-config.test.ts` now parses each workflow in `LINUX_RUNNER_WORKFLOWS` and asserts the step is identical across all three. Parsed rather than text-sliced, so indentation and surrounding YAML comments cannot register as a difference, while the comments *inside* the shell script are compared along with the commands.

## What is deliberately *not* here

The downstream packaging repo carries a larger version of this fix that deletes preinstalled toolchains and adds 12 GB of swap, because its build was being OOM-killed on a **2-core private-repo runner with 7.8 GB of RAM and a 73 GB disk arriving 82% full**.

This repo is public, so the same `ubuntu-22.04` label gets a **4-core runner with 15 GB of RAM and 146 GB of disk at 41% used** — measured in run 34490568415 below. Neither limit is close here, so spending a step on headroom this job does not need would just be noise. I ported it first and then removed it once the runner's actual numbers came back.

## Verification

[Run 34490568415](https://github.com/paranext/paranext-core/actions/runs/34490568415) and [run 34494076141](https://github.com/paranext/paranext-core/actions/runs/34494076141) are green on all three platforms, with the retried snap installs and the LXD snap build succeeding on Linux. Both predate the `test.yml` change and both carried `fail-fast: false`, since removed; nothing else about them differs from this tree.

The `test.yml` copy is the one this repo can actually prove, and this PR proves it: `test.yml` runs on `pull_request`, so this PR's own `Build on ubuntu-22.04, .Net 8.0.x` leg runs the retry helper and builds the snap through it. `publish.yml` is `workflow_dispatch`-only and has no equivalent check short of a release.

Locally: prettier, eslint, YAML parse, `bash -n` on every bash `run:` block, direct tests of the retry helper under `bash -e` (succeeds first try, succeeds after retries, fails the step after exhausting all three), and the new drift assertion — confirmed failing when one `retry` prefix is removed from `publish.yml`, and when the step is renamed in `test.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012eKf1SVGjFcRcseWoMNUVA

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/paranext/paranext-core/2797)
<!-- Reviewable:end -->
